### PR TITLE
Always emit column field of .loc directive

### DIFF
--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -291,7 +291,7 @@ let print_line b = function
   | Loc { file_num; line; col; discriminator } ->
       (* PR#7726: Location.none uses column -1, breaks LLVM assembler *)
       (* If we don't set the optional column field, debug_line program
-         gets the column value from the previous .loc direcitve. *)
+         gets the column value from the previous .loc directive. *)
       if col >= 0 then bprintf b "\t.loc\t%d\t%d\t%d" file_num line col
       else bprintf b "\t.loc\t%d\t%d\t0" file_num line;
       begin match discriminator with

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -290,8 +290,10 @@ let print_line b = function
   | Indirect_symbol s -> bprintf b "\t.indirect_symbol %s" s
   | Loc { file_num; line; col; discriminator } ->
       (* PR#7726: Location.none uses column -1, breaks LLVM assembler *)
+      (* If we don't set the optional column field, debug_line program
+         gets the column value from the previous .loc direcitve. *)
       if col >= 0 then bprintf b "\t.loc\t%d\t%d\t%d" file_num line col
-      else bprintf b "\t.loc\t%d\t%d" file_num line;
+      else bprintf b "\t.loc\t%d\t%d\t0" file_num line;
       begin match discriminator with
       | None -> ()
       | Some k -> bprintf b "\tdiscriminator %d" k


### PR DESCRIPTION
When source location's column is not available from debug info (e.g., for a dummy location), we should emit the default value 0 for it, not leave it out.  If the optional `column` field of `.loc` is not emitted, `debug_line` program keeps column value of a previous `.loc` directive that explicitly set the `column` field (even for an unrelated file and line). 

Manually tested on small examples. Column value can be seen with llvm-symbolizer (addr2line does not show them).