### PR TITLE
Speedups in Asmlink

### DIFF
--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -37,21 +37,21 @@ exception Error of error
 
 (* Consistency check between interfaces and implementations *)
 
-module Cmi_consistbl = Consistbl.Make (Misc.Stdlib.String)
+module Cmi_consistbl = Consistbl.Make (String)
 let crc_interfaces = Cmi_consistbl.create ()
-let interfaces = ref ([] : string list)
+let interfaces = ref String.Set.empty
 
-module Cmx_consistbl = Consistbl.Make (Misc.Stdlib.String)
+module Cmx_consistbl = Consistbl.Make (String)
 let crc_implementations = Cmx_consistbl.create ()
 let implementations = ref ([] : string list)
-let implementations_defined = ref ([] : (string * string) list)
+let implementations_defined = String.Tbl.create 100
 let cmx_required = ref ([] : string list)
 
 let check_consistency file_name unit crc =
   begin try
     List.iter
       (fun (name, crco) ->
-        interfaces := name :: !interfaces;
+        interfaces := String.Set.add name !interfaces;
         match crco with
           None -> ()
         | Some crc ->
@@ -85,19 +85,18 @@ let check_consistency file_name unit crc =
     raise(Error(Inconsistent_implementation(name, user, auth)))
   end;
   begin try
-    let source = List.assoc unit.ui_name !implementations_defined in
+    let source = String.Tbl.find implementations_defined unit.ui_name in
     raise (Error(Multiple_definition(unit.ui_name, file_name, source)))
   with Not_found -> ()
   end;
   implementations := unit.ui_name :: !implementations;
   Cmx_consistbl.set crc_implementations unit.ui_name crc file_name;
-  implementations_defined :=
-    (unit.ui_name, file_name) :: !implementations_defined;
+  String.Tbl.add implementations_defined unit.ui_name file_name;
   if unit.ui_symbol <> unit.ui_name then
     cmx_required := unit.ui_name :: !cmx_required
 
 let extract_crc_interfaces () =
-  Cmi_consistbl.extract !interfaces crc_interfaces
+  Cmi_consistbl.extract (String.Set.elements !interfaces) crc_interfaces
 let extract_crc_implementations () =
   Cmx_consistbl.extract !implementations crc_implementations
 
@@ -230,20 +229,26 @@ let force_linking_of_startup ~ppf_dump =
   Asmgen.compile_phrase ~ppf_dump
     (Cmm.Cdata ([Cmm.Csymbol_address "caml_startup"]))
 
-let make_globals_map units_list ~crc_interfaces =
-  let crc_interfaces = String.Tbl.of_seq (List.to_seq crc_interfaces) in
+let make_globals_map units_list =
+  (* The order in which entries appear in the globals map does not matter
+     (see the natdynlink code).
+     Note that [!interfaces] can contain duplicates.
+     We can corrupt [!interfaces] since it won't be used again until the next
+     compilation. *)
   let defined =
     List.map (fun (unit, _, impl_crc) ->
-        let intf_crc = String.Tbl.find crc_interfaces unit.ui_name in
-        String.Tbl.remove crc_interfaces unit.ui_name;
+        let intf_crc = Cmi_consistbl.find crc_interfaces unit.ui_name in
+        interfaces := String.Set.remove unit.ui_name !interfaces;
         (unit.ui_name, intf_crc, Some impl_crc, unit.ui_defines))
       units_list
   in
-  String.Tbl.fold (fun name intf acc ->
-      (name, intf, None, []) :: acc)
-    crc_interfaces defined
+  String.Set.fold (fun name globals_map ->
+      let intf_crc = Cmi_consistbl.find crc_interfaces name in
+      (name, intf_crc, None, []) :: globals_map)
+    !interfaces
+    defined
 
-let make_startup_file ~ppf_dump units_list ~crc_interfaces =
+let make_startup_file ~ppf_dump units_list =
   let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in
   Location.input_name := "caml_startup"; (* set name of "current" input *)
   Compilenv.reset "_startup";
@@ -258,7 +263,7 @@ let make_startup_file ~ppf_dump units_list ~crc_interfaces =
     (fun i name -> compile_phrase (Cmm_helpers.predef_exception i name))
     Runtimedef.builtin_exceptions;
   compile_phrase (Cmm_helpers.global_table name_list);
-  let globals_map = make_globals_map units_list ~crc_interfaces in
+  let globals_map = make_globals_map units_list in
   compile_phrase (Cmm_helpers.globals_map globals_map);
   compile_phrase(Cmm_helpers.data_segment_table ("_startup" :: name_list));
   if !Clflags.function_sections then
@@ -375,7 +380,6 @@ let link ~ppf_dump objfiles output_name =
     List.iter
       (fun (info, file_name, crc) -> check_consistency file_name info crc)
       units_tolink;
-    let crc_interfaces = extract_crc_interfaces () in
     Clflags.ccobjs := !Clflags.ccobjs @ !lib_ccobjs;
     Clflags.all_ccopts := !lib_ccopts @ !Clflags.all_ccopts;
                                                  (* put user's opts first *)
@@ -387,7 +391,7 @@ let link ~ppf_dump objfiles output_name =
     Asmgen.compile_unit ~output_prefix:output_name
       ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
       ~obj_filename:startup_obj
-      (fun () -> make_startup_file ~ppf_dump units_tolink ~crc_interfaces);
+      (fun () -> make_startup_file ~ppf_dump units_tolink);
     Misc.try_finally
       (fun () ->
          call_linker (List.map object_file_name objfiles)
@@ -464,9 +468,9 @@ let () =
 let reset () =
   Cmi_consistbl.clear crc_interfaces;
   Cmx_consistbl.clear crc_implementations;
-  implementations_defined := [];
+  String.Tbl.reset implementations_defined;
   cmx_required := [];
-  interfaces := [];
+  interfaces := String.Set.empty;
   implementations := [];
   lib_ccobjs := [];
   lib_ccopts := []

--- a/ocaml/utils/consistbl.ml
+++ b/ocaml/utils/consistbl.ml
@@ -67,23 +67,11 @@ end) = struct
 
   let extract l tbl =
     let l = List.sort_uniq Module_name.compare l in
-    List.fold_left
-      (fun assc name ->
-         try
-           let (crc, _) = Module_name.Tbl.find tbl name in
-             (name, Some crc) :: assc
-         with Not_found ->
-           (name, None) :: assc)
-      [] l
+    List.fold_left (fun assc name -> (name, find tbl name) :: assc) [] l
 
   let extract_map mod_names tbl =
     Module_name.Set.fold
-      (fun name result ->
-         try
-           let (crc, _) = Module_name.Tbl.find tbl name in
-           Module_name.Map.add name (Some crc) result
-         with Not_found ->
-           Module_name.Map.add name None result)
+      (fun name result -> Module_name.Map.add name (find tbl name) result)
       mod_names
       Module_name.Map.empty
 

--- a/ocaml/utils/consistbl.ml
+++ b/ocaml/utils/consistbl.ml
@@ -60,6 +60,11 @@ end) = struct
 
   let source tbl name = snd (Module_name.Tbl.find tbl name)
 
+  let find t name =
+    match Module_name.Tbl.find t name with
+    | exception Not_found -> None
+    | (crc, _) -> Some crc
+
   let extract l tbl =
     let l = List.sort_uniq Module_name.compare l in
     List.fold_left

--- a/ocaml/utils/consistbl.mli
+++ b/ocaml/utils/consistbl.mli
@@ -57,6 +57,8 @@ end) : sig
            if the latter has an associated CRC in [tbl].
            Raise [Not_found] otherwise. *)
 
+  val find: t -> Module_name.t -> Digest.t option
+
   val extract: Module_name.t list -> t -> (Module_name.t * Digest.t option) list
         (* [extract tbl names] returns an associative list mapping each string
            in [names] to the CRC associated with it in [tbl]. If no CRC is


### PR DESCRIPTION
This patch removes a lot of unnecessary list manipulation in `Asmlink`, making linking faster on large programs.