### PR TITLE
Cherry-pick upstream PR#10184 (dynlink invariant removal)

### DIFF
--- a/ocaml/otherlibs/dynlink/dynlink_common.ml
+++ b/ocaml/otherlibs/dynlink/dynlink_common.ml
@@ -62,15 +62,6 @@ module Make (P : Dynlink_platform_intf.S) = struct
          were privately loaded. *)
     }
 
-    let invariant t =
-      let ifaces = String.Map.keys t.ifaces in
-      let implems = String.Map.keys t.implems in
-      assert (String.Set.subset implems ifaces);
-      assert (String.Set.subset t.main_program_units ifaces);
-      assert (String.Set.subset t.main_program_units implems);
-      assert (String.Set.subset t.public_dynamically_loaded_units ifaces);
-      assert (String.Set.subset t.public_dynamically_loaded_units implems)
-
     let empty = {
       ifaces = String.Map.empty;
       implems = String.Map.empty;
@@ -275,7 +266,6 @@ module Make (P : Dynlink_platform_intf.S) = struct
           public_dynamically_loaded_units;
         }
       in
-      State.invariant state;
       state
     end
 

--- a/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -5,8 +5,8 @@ Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 137, characters 16-25
 Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 139, characters 6-137
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 344, characters 13-44
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 334, characters 13-44
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 342, characters 8-240
-Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 352, characters 8-17
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 332, characters 8-240
+Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 342, characters 8-17
 Called from Test10_main in file "test10_main.ml", line 51, characters 13-69

--- a/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -6,8 +6,8 @@ Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/dynlink.ml", lin
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/dynlink.ml", line 250, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/dynlink.ml", line 252, characters 10-149
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 344, characters 13-44
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 334, characters 13-44
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 342, characters 8-240
-Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 352, characters 8-17
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 332, characters 8-240
+Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 342, characters 8-17
 Called from Test10_main in file "test10_main.ml", line 49, characters 30-87


### PR DESCRIPTION
This needed the testsuite output regenerating for `lib-dynlink-initializers`.  The actual code is the same as upstream.