### PR TITLE
Add builtin, effects and coeffects fields to Cextcall

### DIFF
--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -104,6 +104,9 @@ let instrument_initialiser c dbg =
   with_afl_logging
     (Csequence
        (Cop (Cextcall { name = "caml_setup_afl";
+                        builtin = false;
+                        effects = Arbitrary_effects;
+                        coeffects = Has_coeffects;
                         ret = typ_int; alloc = false; label_after = None; },
              [Cconst_int (0, dbg ())],
              dbg ()),

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -111,6 +111,9 @@ let new_label() = incr label_counter; !label_counter
 
 type rec_flag = Nonrecursive | Recursive
 
+type effects = No_effects | Arbitrary_effects
+type coeffects = No_coeffects | Has_coeffects
+
 type phantom_defining_expr =
   | Cphantom_const_int of Targetint.t
   | Cphantom_const_symbol of string
@@ -139,6 +142,9 @@ and operation =
       { name: string;
         ret: machtype;
         alloc: bool;
+        builtin: bool;
+        effects: effects;
+        coeffects: coeffects;
         label_after: label option;
         (** If specified, the given label will be placed immediately after the
             call (at the same place as any frame descriptor would reference). *)

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -87,6 +87,9 @@ val cur_label: unit -> label
 
 type rec_flag = Nonrecursive | Recursive
 
+type effects = No_effects | Arbitrary_effects
+type coeffects = No_coeffects | Has_coeffects
+
 type phantom_defining_expr =
   (* CR-soon mshinwell: Convert this to [Targetint.OCaml.t] (or whatever the
      representation of "target-width OCaml integers of type [int]"
@@ -133,6 +136,9 @@ and operation =
       { name: string;
         ret: machtype;
         alloc: bool;
+        builtin: bool;
+        effects: effects;
+        coeffects: coeffects;
         label_after: label option;
         (** If specified, the given label will be placed immediately after the
             call (at the same place as any frame descriptor would reference). *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2155,6 +2155,10 @@ let arraylength kind arg dbg =
   | Pfloatarray ->
       Cop(Cor, [float_array_length_shifted hdr dbg; Cconst_int (1, dbg)], dbg)
 
+(* CR-soon gyorsh: effects and coeffects for primitives are set conservatively
+   to Arbitrary_effects and Has_coeffects, resp.
+   Check if this can be improved (e.g., bswap). *)
+
 let bbswap bi arg dbg =
   let prim = match (bi : Primitive.boxed_integer) with
     | Pnativeint -> "nativeint"

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -728,10 +728,16 @@ let float_array_ref arr ofs dbg =
 
 let addr_array_set arr ofs newval dbg =
   Cop(Cextcall { name = "caml_modify"; ret = typ_void; alloc = false;
+                 builtin = false;
+                 effects = Arbitrary_effects;
+                 coeffects = Has_coeffects;
                  label_after = None},
       [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let addr_array_initialize arr ofs newval dbg =
   Cop(Cextcall { name = "caml_initialize";
+                 builtin = false;
+                 effects = Arbitrary_effects;
+                 coeffects = Has_coeffects;
                  ret = typ_void; alloc = false; label_after = None},
       [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let int_array_set arr ofs newval dbg =
@@ -769,6 +775,9 @@ let bigstring_length ba dbg =
 let lookup_tag obj tag dbg =
   bind "tag" tag (fun tag ->
     Cop(Cextcall { name = "caml_get_public_method"; ret = typ_val;
+                   builtin = false;
+                   effects = Arbitrary_effects;
+                   coeffects = Has_coeffects;
                    alloc = false; label_after = None },
         [obj; tag],
         dbg))
@@ -800,6 +809,9 @@ let make_alloc_generic set_fn dbg tag wordsize args =
                           fill_fields (idx + 2) el) in
     Clet(VP.create id,
          Cop(Cextcall { name = "caml_alloc"; ret = typ_val; alloc = true;
+                        builtin = false;
+                        effects = Arbitrary_effects;
+                        coeffects = Has_coeffects;
                         label_after = None },
                  [Cconst_int (wordsize, dbg); Cconst_int (tag, dbg)], dbg),
          fill_fields 1 args)
@@ -808,6 +820,9 @@ let make_alloc_generic set_fn dbg tag wordsize args =
 let make_alloc dbg tag args =
   let addr_array_init arr ofs newval dbg =
     Cop(Cextcall { name = "caml_initialize"; ret = typ_void; alloc = false;
+                   builtin = false;
+                   effects = Arbitrary_effects;
+                   coeffects = Has_coeffects;
                    label_after = None },
         [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
   in
@@ -2147,12 +2162,18 @@ let bbswap bi arg dbg =
     | Pint64 -> "int64"
   in
   Cop(Cextcall { name = Printf.sprintf "caml_%s_direct_bswap" prim;
+                 builtin = false;
+                 effects = Arbitrary_effects;
+                 coeffects = Has_coeffects;
                  ret = typ_int; alloc = false; label_after = None; },
       [arg],
       dbg)
 
 let bswap16 arg dbg =
   (Cop(Cextcall { name = "caml_bswap16_direct";
+                  builtin = false;
+                  effects = Arbitrary_effects;
+                  coeffects = Has_coeffects;
                   ret = typ_int; alloc = false; label_after = None; },
        [arg],
        dbg))
@@ -2180,6 +2201,9 @@ let setfield n ptr init arg1 arg2 dbg =
   | Caml_modify ->
       return_unit dbg (Cop(Cextcall { name = "caml_modify";
                                       ret = typ_void; alloc = false;
+                                      builtin = false;
+                                      effects = Arbitrary_effects;
+                                      coeffects = Has_coeffects;
                                       label_after = None },
                       [field_address arg1 n dbg;
                        arg2],
@@ -2187,6 +2211,9 @@ let setfield n ptr init arg1 arg2 dbg =
   | Caml_initialize ->
       return_unit dbg (Cop(Cextcall { name = "caml_initialize";
                                       ret = typ_void; alloc = false;
+                                      builtin = false;
+                                      effects = Arbitrary_effects;
+                                      coeffects = Has_coeffects;
                                       label_after = None },
                       [field_address arg1 n dbg;
                        arg2],

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -736,6 +736,9 @@ and transl_make_array dbg env kind args =
   match kind with
   | Pgenarray ->
       Cop(Cextcall { name = "caml_make_array";
+                     builtin = false;
+                     effects = Arbitrary_effects;
+                     coeffects = Has_coeffects;
                      ret = typ_val; alloc = true; label_after = None},
           [make_alloc dbg 0 (List.map (transl env) args)], dbg)
   | Paddrarray | Pintarray ->
@@ -774,6 +777,9 @@ and transl_ccall env prim args dbg =
   let args = transl_args prim.prim_native_repr_args args in
   wrap_result
     (Cop(Cextcall { name = Primitive.native_name prim;
+                    builtin = false;
+                    effects = Arbitrary_effects;
+                    coeffects = Has_coeffects;
                     ret = typ_res; alloc = prim.prim_alloc;
                     label_after = None },
      args, dbg))
@@ -1319,6 +1325,9 @@ and transl_letrec env bindings cont =
   in
   let op_alloc prim args =
     Cop(Cextcall { name = prim; ret = typ_val; alloc = true;
+                   builtin = false;
+                   effects = Arbitrary_effects;
+                   coeffects = Has_coeffects;
                    label_after = None },
         args, dbg) in
   let rec init_blocks = function
@@ -1347,6 +1356,11 @@ and transl_letrec env bindings cont =
     | (id, exp, (RHS_block _ | RHS_infix _ | RHS_floatblock _)) :: rem ->
         let op =
           Cop(Cextcall { name = "caml_update_dummy"; ret = typ_void;
+                         builtin = false;
+                         effects = Arbitrary_effects;
+                         coeffects = Has_coeffects;
+                         (* CR gyorsh: should this be no_(co)effects?
+                            why was it [alloc=false]? *)
                          alloc = false; label_after = None },
               [Cvar (VP.var id); transl env exp], dbg) in
         Csequence(op, fill_blocks rem)

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1359,8 +1359,6 @@ and transl_letrec env bindings cont =
                          builtin = false;
                          effects = Arbitrary_effects;
                          coeffects = Has_coeffects;
-                         (* CR gyorsh: should this be no_(co)effects?
-                            why was it [alloc=false]? *)
                          alloc = false; label_after = None },
               [Cvar (VP.var id); transl env exp], dbg) in
         Csequence(op, fill_blocks rem)

--- a/backend/spacetime_profiling.ml
+++ b/backend/spacetime_profiling.ml
@@ -113,6 +113,9 @@ let code_for_function_prologue ~function_name ~fun_dbg:dbg ~node_hole =
                   Cop (Cextcall { name = "caml_spacetime_allocate_node";
                                   ret = [| Int |];
                                   alloc = false;
+                                  builtin = false;
+                                  effects = Arbitrary_effects;
+                                  coeffects = Has_coeffects;
                                   label_after = None},
                 [cconst_int (1 (* header *) + !index_within_node);
                 Cvar pc;
@@ -155,6 +158,9 @@ let code_for_blockheader ~value's_header ~node ~dbg =
     *)
     Cop (Cextcall { name = "caml_spacetime_generate_profinfo";
                     ret = [| Int |];
+                    builtin = false;
+                    effects = Arbitrary_effects;
+                    coeffects = Has_coeffects;
                     alloc = false; label_after = Some label },
       [Cvar address_of_profinfo;
        cconst_int (index_within_node + 1)],
@@ -275,6 +281,9 @@ let code_for_call ~node ~callee ~is_tail ~label dbg =
         else cconst_int 1  (* [Val_unit] *)
       in
       Cop (Cextcall { name = "caml_spacetime_indirect_node_hole_ptr";
+                      builtin = false;
+                      effects = Arbitrary_effects;
+                      coeffects = Has_coeffects;
                       ret = [| Int |]; alloc = false; label_after = None },
         [callee; Cvar place_within_node; caller_node],
         dbg))

--- a/ocaml/testsuite/tools/parsecmm.mly
+++ b/ocaml/testsuite/tools/parsecmm.mly
@@ -221,6 +221,9 @@ expr:
                 { Cop(Capply $6, $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
                {Cop(Cextcall {name=$3; ret=$5; alloc=false;
+                              builtin=false;
+                              effects=Arbitrary_effects;
+                              coeffects=Has_coeffects;
                               label_after=None},
                      List.rev $4, debuginfo ())}
   | LPAREN ALLOC exprlist RPAREN { Cop(Calloc, List.rev $3, debuginfo ()) }


### PR DESCRIPTION
Add `builtin`, `effects`, and `coeffects` fields, which will be used by subsequent PRs.
This PR is on top of #10.