### PR TITLE
Add HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,15 @@
+# Hacking on Flambda backend project for OCaml
+
+This page is intended to keep track of useful information for people who
+want to modify Flambda backend.
+
+## Bootstrapping
+
+- Bootstrapping: use the same process as the upstream compiler. In
+  `ocaml` subdirectory, follow the instructions in
+  [ocaml/BOOTSTRAP.adoc](ocaml/BOOSTRAP.adoc).
+
+- Changes in `ocaml/asmcomp` and `ocaml/middle_end` directories should
+  also be applied to the corresponding directories `backend` and
+  `middle_end`.
+

--- a/HACKING.md
+++ b/HACKING.md
@@ -3,13 +3,26 @@
 This page is intended to keep track of useful information for people who
 want to modify Flambda backend.
 
-## Bootstrapping
 
-- Bootstrapping: use the same process as the upstream compiler. In
-  `ocaml` subdirectory, follow the instructions in
-  [ocaml/BOOTSTRAP.adoc](ocaml/BOOSTRAP.adoc).
+## Rebuilding during dev work
 
-- Changes in `ocaml/asmcomp` and `ocaml/middle_end` directories should
-  also be applied to the corresponding directories `backend` and
-  `middle_end`.
+To rebuild after making changes, you can just type `make` (or `make -j16`, etc).
 
+There is a special target `make hacking` which starts Dune in polling mode.  The rebuild
+performed here is equivalent to `make ocamlopt` in the upstream distribution: it rebuilds the
+compiler itself, but doesn't rebuild the stdlib or anything else with the new compiler.
+This target is likely what you want for development of large features in the middle end or
+backend.  Rebuild times for this target should be very fast.
+
+The aim is to minimise patches against the upstream compiler (the
+contents of the ocaml/ subdirectory), but you can configure and build
+in that directory as you would for upstream.  If a bootstrap is
+required, the normal bootstrapping commands should also work: from
+within the ocaml/ subdirectory, follow the instructions in
+[ocaml/BOOTSTRAP.adoc](ocaml/BOOSTRAP.adoc); the newly-bootstrapped
+compiler will be picked up the next time that the Flambda backend is
+built from the toplevel directory of the checkout.
+
+Any changes in `ocaml/asmcomp` and `ocaml/middle_end` directories
+should also be applied to the corresponding directories `backend` and
+`middle_end`.

--- a/README.md
+++ b/README.md
@@ -60,21 +60,3 @@ before running `make compare`.
 There is also a `make ci` target (best run as e.g. `make -j16 ci`) which does a full build
 and test run.  It does not currently run `make compare` as some spurious failures have
 been observed on the Github systems.
-
-## Rebuilding during dev work
-
-To rebuild after making changes, you can just type `make` (or `make -j16`, etc).
-
-There is a special target `make hacking` which starts Dune in polling mode.  The rebuild
-performed here is equivalent to `make ocamlopt` in the upstream distribution: it rebuilds the
-compiler itself, but doesn't rebuild the stdlib or anything else with the new compiler.
-This target is likely what you want for development of large features in the middle end or
-backend.  Rebuild times for this target should be very fast.
-
-The aim is to minimise patches against the upstream compiler (the contents of
-the ocaml/ subdirectory), but you can configure and build in that directory as
-you would for upstream.  If a bootstrap is required, the normal bootstrapping
-commands should also work (all from within the ocaml/ subdirectory); the
-newly-bootstrapped compiler will be picked up the next time that the Flambda
-backend is built from the toplevel directory of the checkout.
-


### PR DESCRIPTION
Starting a document to keep track of information for developers working with this repo.

Should we move section "Rebuilding during dev work" from README to HACKING?
