### PR TITLE
Amd64 emit tweaks

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -861,11 +861,8 @@ let emit_instr fallthrough i =
       let lbl = bound_error_label ?label:label_after_error i.dbg ~spacetime in
       I.cmp (int n) (arg i 0);
       I.jbe (label lbl)
-  | Lop(Iintop_imm (Iand, n)) when n >= 0 && n <= 0xFFFF_FFFF ->
-      begin match i.res.(0).loc with
-      | Reg _ -> I.and_ (int n) (res32 i 0)
-      | _     -> I.and_ (int n) (res i 0)
-      end
+  | Lop(Iintop_imm (Iand, n)) when n >= 0 && n <= 0xFFFF_FFFF && Reg.is_reg i.res.(0) ->
+      I.and_ (int n) (res32 i 0)
   | Lop(Iintop Ixor) when i.arg.(1).loc = i.res.(0).loc ->
       begin match i.res.(0).loc with
       | Reg _ -> I.xor (res32 i 0) (res32 i 0)

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -863,11 +863,8 @@ let emit_instr fallthrough i =
       I.jbe (label lbl)
   | Lop(Iintop_imm (Iand, n)) when n >= 0 && n <= 0xFFFF_FFFF && Reg.is_reg i.res.(0) ->
       I.and_ (int n) (res32 i 0)
-  | Lop(Iintop Ixor) when i.arg.(1).loc = i.res.(0).loc ->
-      begin match i.res.(0).loc with
-      | Reg _ -> I.xor (res32 i 0) (res32 i 0)
-      | _     -> I.xor (arg i 1) (res i 0)
-      end
+  | Lop(Iintop Ixor) when i.arg.(1).loc = i.res.(0).loc && Reg.is_reg i.res.(0) ->
+      I.xor (res32 i 0) (res32 i 0)
   | Lop(Iintop(Idiv | Imod)) ->
       I.cqo ();
       I.idiv (arg i 1)

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -861,6 +861,16 @@ let emit_instr fallthrough i =
       let lbl = bound_error_label ?label:label_after_error i.dbg ~spacetime in
       I.cmp (int n) (arg i 0);
       I.jbe (label lbl)
+  | Lop(Iintop_imm (Iand, n)) when n >= 0 && n <= 0xFFFF_FFFF ->
+      begin match i.res.(0).loc with
+      | Reg _ -> I.and_ (int n) (res32 i 0)
+      | _     -> I.and_ (int n) (res i 0)
+      end
+  | Lop(Iintop Ixor) when i.arg.(1).loc = i.res.(0).loc ->
+      begin match i.res.(0).loc with
+      | Reg _ -> I.xor (res32 i 0) (res32 i 0)
+      | _     -> I.xor (arg i 1) (res i 0)
+      end
   | Lop(Iintop(Idiv | Imod)) ->
       I.cqo ();
       I.idiv (arg i 1)
@@ -874,9 +884,9 @@ let emit_instr fallthrough i =
       instr_for_intop op (arg i 1) (res i 0)
   | Lop(Iintop_imm(Iadd, n)) when i.arg.(0).loc <> i.res.(0).loc ->
       I.lea (mem64 NONE n (arg64 i 0)) (res i 0)
-  | Lop(Iintop_imm(Iadd, 1) | Iintop_imm(Isub, -1)) ->
+  | Lop(Iintop_imm(Iadd, 1) | Iintop_imm(Isub, -1)) when not !fastcode_flag ->
       I.inc (res i 0)
-  | Lop(Iintop_imm(Iadd, -1) | Iintop_imm(Isub, 1)) ->
+  | Lop(Iintop_imm(Iadd, -1) | Iintop_imm(Isub, 1)) when not !fastcode_flag ->
       I.dec (res i 0)
   | Lop(Iintop_imm(op, n)) ->
       (* We have i.arg.(0) = i.res.(0) *)


### PR DESCRIPTION
I was instructed to transfer/revive https://github.com/ocaml/ocaml/pull/1490 here.
It is noteworthy, though, that the most interesting tweak was
merged through https://github.com/ocaml/ocaml/pull/8990. The remaining tweaks are:

- a slightly shorter code when `and`-ing a register and a
  known (32-bit) constant; 
- a slightly shorter code when `xor`-ing a register with itself;
- a (conditional) use of `add`/`sub` instead of `inc`/`dec` because
  the latter may introduce unnecessary data dependencies.