### PR TITLE
Fix build with function sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ configure_opts
 ocaml-stage1-config.status
 ocaml-stage2-config.status
 ocamlopt_flags.sexp
+cflags.sexp

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ configure
 configure_opts
 ocaml-stage1-config.status
 ocaml-stage2-config.status
+ocamlopt_flags.sexp

--- a/Makefile.in
+++ b/Makefile.in
@@ -58,7 +58,8 @@ stage0: _build0/config.status
 # This code should use build contexts instead of --build-dir.
 .PHONY: stage1
 stage1: ocaml-stage1-config.status stage0 \
-          ocaml/otherlibs/dynlink/natdynlinkops2
+          ocaml/otherlibs/dynlink/natdynlinkops2 \
+	  flags.sexp
 	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage0_prefix)/bin:$$PATH \
@@ -66,15 +67,6 @@ stage1: ocaml-stage1-config.status stage0 \
 	(cd _build1/install/default/bin && \
 	  rm -f ocamllex && \
 	  ln -s ocamllex.opt ocamllex)
-
-ifeq "$(FUNCTION_SECTIONS)" "true"
-OCAMLOPT_FLAGS_SEXP="(:standard -function-sections)"
-else
-OCAMLOPT_FLAGS_SEXP="(:standard)"
-endif
-
-ocamlopt_flags.sexp:
-	echo $(OCAMLOPT_FLAGS_SEXP) > ocamlopt_flags.sexp
 
 # CR mshinwell: We should add targets that don't use --profile=release, for
 # speed, and also ensuring that warnings are errors.  We should also consider
@@ -84,7 +76,7 @@ ocamlopt_flags.sexp:
 # itself, including the stdlib, otherlibs, compilerlibs, etc.  The result is
 # equivalent to having done "make world.opt && make ocamlnat" upstream.
 .PHONY: stage2
-stage2: ocaml-stage2-config.status stage1 ocamlopt_flags.sexp
+stage2: ocaml-stage2-config.status stage1
 	cp ocaml-stage2-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage1_prefix)/bin:$$PATH \
@@ -97,7 +89,8 @@ stage2: ocaml-stage2-config.status stage1 ocamlopt_flags.sexp
 # in the middle end and backend.
 .PHONY: hacking
 hacking: ocaml-stage1-config.status stage0 \
-          ocaml/otherlibs/dynlink/natdynlinkops2
+          ocaml/otherlibs/dynlink/natdynlinkops2 \
+	  flags.sexp
 	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage0_prefix)/bin:$$PATH \
@@ -171,6 +164,39 @@ ocaml/otherlibs/dynlink/natdynlinkops2: ocaml-stage1-config.status
 	else \
 	  /bin/echo -n "-bin-annot" > ocaml/otherlibs/dynlink/natdynlinkops1; \
 	fi
+
+
+# Extract compilation flags from Makefile.config of stage1
+# and write them to a file that dune can use in stage1 and stage2.
+# CR gyorsh: do we need a separate rule for stage2?
+# or can the file be reused?
+
+.PHONY: flags.sexp
+flags.sexp: ocamlopt_flags.sexp cflags.sexp
+
+
+ocamlopt_flags.sexp: ocaml-stage1-config.status
+	cp ocaml-stage1-config.status ocaml/config.status
+	(cd ocaml && ./config.status)
+	grep -q '^FUNCTION_SECTIONS=true' ocaml/Makefile.config; \
+	if [ $$? -eq 0 ] ; then \
+	  /bin/echo -n "(:standard -function-sections)" > ocamlopt_flags.sexp; \
+	else \
+	  /bin/echo -n "(:standard)" > ocamlopt_flags.sexp; \
+	fi
+
+# CR gyorsh: how to redirect output of a shell command to a variable
+# and then print its value?
+cflags.sexp: ocaml-stage1-config.status
+	cp ocaml-stage1-config.status ocaml/config.status
+	(cd ocaml && ./config.status)
+	/bin/echo -n "(" > cflags.sexp;
+	/bin/echo -n $$(grep "^OC_CFLAGS=" ocaml/Makefile.config \
+		  	| sed 's/^OC_CFLAGS=//') >> cflags.sexp;
+	/bin/echo -n " " >> cflags.sexp;
+	/bin/echo -n $$(grep "^OC_CPPFLAGS=" ocaml/Makefile.config \
+		  	| sed 's/^OC_CPPFLAGS=//') >> cflags.sexp;
+	/bin/echo -n ")" >> cflags.sexp;
 
 # Most of the installation tree is correctly set up by dune, but we need to
 # copy it to the final destination, and rearrange a few things to match

--- a/Makefile.in
+++ b/Makefile.in
@@ -67,6 +67,15 @@ stage1: ocaml-stage1-config.status stage0 \
 	  rm -f ocamllex && \
 	  ln -s ocamllex.opt ocamllex)
 
+ifeq "$(FUNCTION_SECTIONS)" "true"
+OCAMLOPT_FLAGS_SEXP="(:standard -function-sections)"
+else
+OCAMLOPT_FLAGS_SEXP="(:standard)"
+endif
+
+ocamlopt_flags.sexp:
+	echo $(OCAMLOPT_FLAGS_SEXP) > ocamlopt_flags.sexp
+
 # CR mshinwell: We should add targets that don't use --profile=release, for
 # speed, and also ensuring that warnings are errors.  We should also consider
 # adding a new Dune profile that is like "release" but has warnings as errors.
@@ -75,7 +84,7 @@ stage1: ocaml-stage1-config.status stage0 \
 # itself, including the stdlib, otherlibs, compilerlibs, etc.  The result is
 # equivalent to having done "make world.opt && make ocamlnat" upstream.
 .PHONY: stage2
-stage2: ocaml-stage2-config.status stage1
+stage2: ocaml-stage2-config.status stage1 ocamlopt_flags.sexp
 	cp ocaml-stage2-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage1_prefix)/bin:$$PATH \

--- a/driver/dune
+++ b/driver/dune
@@ -2,6 +2,6 @@
   (name flambda_backend_driver)
   (modes byte native)
   (flags (:standard -principal -nostdlib))
-  (ocamlopt_flags (:standard -function-sections))
+  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
   (libraries stdlib ocamloptcomp)
   (modules optcompile))

--- a/dune
+++ b/dune
@@ -35,7 +35,7 @@
   ; We should change the code so this "-open" can be removed.
   ; Likewise fix occurrences of warning 9.
   (flags (:standard -principal -nostdlib -w -9))
-  (ocamlopt_flags (:standard -function-sections))
+  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
   (modules_without_implementation
     backend_intf
     cmx_format

--- a/native_toplevel/dune
+++ b/native_toplevel/dune
@@ -19,7 +19,7 @@
  (modes native)
  (wrapped false)
  (flags (:standard -principal -nostdlib -w -9))
- (ocamlopt_flags (:standard -function-sections))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (libraries stdlib ocamlcommon ocamlbytecomp ocamloptcomp
    dynlink_internal)
  (modules genprintval_native opttoploop opttopdirs opttopmain))

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -39,7 +39,7 @@
    -w -67
    ; remove -w -67 by adding the camlinternalMenhirLib hack like the Makefile
  ))
- (ocamlopt_flags (:standard -function-sections))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags -linkall)
  (libraries stdlib)
  (modules_without_implementation
@@ -88,7 +88,7 @@
    -nostdlib -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
- (ocamlopt_flags (:standard -function-sections))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (libraries stdlib ocamlcommon)
  (modules
     ;; bytecomp/

--- a/ocaml/lex/dune
+++ b/ocaml/lex/dune
@@ -16,7 +16,7 @@
   (wrapped false)
   (modes byte native)
   (flags (:standard -principal -nostdlib))
-  (ocamlopt_flags (:standard -function-sections))
+  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
   (libraries stdlib)
   (modules
     common

--- a/ocaml/ocamltest/dune
+++ b/ocaml/ocamltest/dune
@@ -37,7 +37,8 @@
  (libraries ocamlcommon stdlib)
  (modules (:standard \ options main))
  (foreign_stubs (language c) (names run_unix run_stubs ocamltest_stdlib_stubs)
-   (flags -DCAML_INTERNALS -I%{project_root}/ocaml/runtime)))
+   (flags ((-DCAML_INTERNALS -I%{project_root}/ocaml/runtime)
+         (:include %{project_root}/cflags.sexp)))))
 
 (rule
  (targets empty.ml)

--- a/ocaml/otherlibs/bigarray/dune
+++ b/ocaml/otherlibs/bigarray/dune
@@ -20,7 +20,7 @@
    -nostdlib -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
- (ocamlopt_flags (:standard -function-sections))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall))
  (libraries stdlib))
 

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -20,7 +20,7 @@
     -nostdlib -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48
     -warn-error A -bin-annot -safe-string -strict-formats
   ))
-  (ocamlopt_flags (:standard -function-sections))
+  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
   (modules
     config
     build_path_prefix_map

--- a/ocaml/otherlibs/str/dune
+++ b/ocaml/otherlibs/str/dune
@@ -23,7 +23,8 @@
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall))
  (libraries stdlib)
- (foreign_stubs (language c) (names strstubs)))
+ (foreign_stubs (language c) (names strstubs)
+  (flags (:include %{project_root}/cflags.sexp))))
 
 (install
   (files

--- a/ocaml/otherlibs/str/dune
+++ b/ocaml/otherlibs/str/dune
@@ -20,7 +20,7 @@
    -nostdlib -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
- (ocamlopt_flags (:standard -function-sections))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall))
  (libraries stdlib)
  (foreign_stubs (language c) (names strstubs)))

--- a/ocaml/otherlibs/systhreads/dune
+++ b/ocaml/otherlibs/systhreads/dune
@@ -22,7 +22,7 @@
     mutex
     thread)
   (flags -w +33..39 -warn-error A -g -bin-annot -safe-string)
-  (ocamlopt_flags (:standard -function-sections))
+  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
   (libraries stdlib unix)
   (library_flags -linkall)
   (c_library_flags -lpthread)

--- a/ocaml/otherlibs/systhreads/dune
+++ b/ocaml/otherlibs/systhreads/dune
@@ -30,13 +30,14 @@
     (language c)
     (names st_stubs_byte)
     (mode byte)
-    (flags -DCAML_NAME_SPACE)
+    (flags ((-DCAML_NAME_SPACE) (:include %{project_root}/cflags.sexp)))
     (include_dirs %{project_root}/ocaml/runtime))
   (foreign_stubs
     (language c)
     (names st_stubs_native)
     (mode native)
-    (flags -DNATIVE_CODE -DCAML_NAME_SPACE)
+    (flags ((-DNATIVE_CODE -DCAML_NAME_SPACE)
+           (:include %{project_root}/cflags.sexp)))
     (include_dirs %{project_root}/ocaml/runtime)))
 
 (rule

--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -35,7 +35,8 @@
    shutdown signals sleep socket socketaddr socketpair sockopt stat strofaddr
    symlink termios time times truncate umask unixsupport unlink utimes wait
    write)
-   (flags -I %{project_root}/ocaml/runtime)
+   (flags ((-I %{project_root}/ocaml/runtime)
+           (:include %{project_root}/cflags.sexp)))
  ))
 
 (install

--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -20,7 +20,7 @@
    -nostdlib -absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot
    -g -safe-string -strict-sequence -strict-formats
  ))
- (ocamlopt_flags (:standard -function-sections))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall))
  (libraries stdlib)
  (foreign_stubs (language c) (names

--- a/ocaml/stdlib/dune
+++ b/ocaml/stdlib/dune
@@ -24,7 +24,7 @@
      -g -warn-error A -bin-annot -nostdlib
      -safe-string -strict-formats
  ))
- (ocamlopt_flags (:standard -function-sections))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (preprocess
    (per_module
      ((action


### PR DESCRIPTION
Fix the following build problems related to function sections:
1) on macOs, the build fails because -function-sections compilation flag is not support by ocaml, but passed unconditionally in dune files. 
2) on linux, -ffunction-sections compilation flag is not passed to C compiler when compiling C stubs from otherlibs.

This PR is based on a patch prepared by @xclerc  to address the first problem. 

It creates two .sexp files based on ocaml/Makefile.config during stage1 compiler and uses them in dune files.
- `ocamlopt_flags.sexp`  contains OCAMLOPT_FLAGS
- `cflags.sexp` contains OC_CPPFLAGS and OC_CFLAGS
There is already a similar hack to handle flags for `natdynlink`.   
I don't know if there is a better way.

Flags for building C stubs are automatically supplied by dune from compiler config. These flags seem to be a subset of the ones used in Makefiles for otherlibs (and copied to `cflags.sexp` in this PR to be used by dune). Recent dune release provides a way to [disable the defaults](https://dune.readthedocs.io/en/stable/dune-files.html#always-add-cflags), but the special dune we currently use to build flambda-backend is not there yet. We should consider using it to avoid duplication of flags.

