### PR TITLE
Use correct C compiler flags from Makefile.config for foreign_stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ configure_opts
 ocaml-stage1-config.status
 ocaml-stage2-config.status
 ocamlopt_flags.sexp
+oc_cflags.sexp
+oc_cppflags.sexp
+sharedlib_cflags.sexp

--- a/Makefile.in
+++ b/Makefile.in
@@ -168,11 +168,9 @@ ocaml/otherlibs/dynlink/natdynlinkops2: ocaml-stage1-config.status
 
 # Extract compilation flags from Makefile.config of stage1
 # and write them to a file that dune can use in stage1 and stage2.
-# CR gyorsh: do we need a separate rule for stage2?
-# or can the file be reused?
-
 .PHONY: flags.sexp
-flags.sexp: ocamlopt_flags.sexp
+flags.sexp: ocamlopt_flags.sexp oc_cflags.sexp oc_cppflags.sexp \
+            sharedlib_cflags.sexp
 
 ocamlopt_flags.sexp: ocaml-stage1-config.status
 	cp ocaml-stage1-config.status ocaml/config.status
@@ -183,6 +181,24 @@ ocamlopt_flags.sexp: ocaml-stage1-config.status
 	else \
 	  /bin/echo -n "(:standard)" > ocamlopt_flags.sexp; \
 	fi
+
+oc_cflags.sexp: ocaml-stage1-config.status
+	cp ocaml-stage1-config.status ocaml/config.status
+	(cd ocaml && ./config.status)
+	/bin/echo -n "( $$(grep "^OC_CFLAGS=" ocaml/Makefile.config \
+		  	| sed 's/^OC_CFLAGS=//') )" > oc_cflags.sexp
+
+oc_cppflags.sexp: ocaml-stage1-config.status
+	cp ocaml-stage1-config.status ocaml/config.status
+	(cd ocaml && ./config.status)
+	/bin/echo -n "( $$(grep "^OC_CPPFLAGS=" ocaml/Makefile.config \
+		| sed 's/^OC_CPPFLAGS=//') )" > oc_cppflags.sexp
+
+sharedlib_cflags.sexp: ocaml-stage1-config.status
+	cp ocaml-stage1-config.status ocaml/config.status
+	(cd ocaml && ./config.status)
+	/bin/echo -n "( $$(grep "^SHAREDLIB_CFLAGS=" ocaml/Makefile.config \
+		| sed 's/^SHAREDLIB_CFLAGS=//') )" > sharedlib_cflags.sexp
 
 # Most of the installation tree is correctly set up by dune, but we need to
 # copy it to the final destination, and rearrange a few things to match

--- a/dune-project
+++ b/dune-project
@@ -2,6 +2,8 @@
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 
+;; CR-soon gyorsh: uncomment the following line when we upgrade to dune 2.8
+;; (use_standard_c_and_cxx_flags true)
 (cram enable)
 
 (package

--- a/ocaml/ocamltest/dune
+++ b/ocaml/ocamltest/dune
@@ -37,7 +37,10 @@
  (libraries ocamlcommon stdlib)
  (modules (:standard \ options main))
  (foreign_stubs (language c) (names run_unix run_stubs ocamltest_stdlib_stubs)
-   (flags -DCAML_INTERNALS -I%{project_root}/ocaml/runtime)))
+   (flags ((-DCAML_INTERNALS)
+           (:include %{project_root}/oc_cflags.sexp)
+           (:include %{project_root}/oc_cppflags.sexp)))
+   (include_dirs %{project_root}/ocaml/runtime)))
 
 (rule
  (targets empty.ml)

--- a/ocaml/otherlibs/str/dune
+++ b/ocaml/otherlibs/str/dune
@@ -23,7 +23,11 @@
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall))
  (libraries stdlib)
- (foreign_stubs (language c) (names strstubs)))
+ (foreign_stubs (language c) (names strstubs)
+  (flags ((:include %{project_root}/oc_cflags.sexp)
+          (:include %{project_root}/sharedlib_cflags.sexp)
+          (:include %{project_root}/oc_cppflags.sexp)))
+  (include_dirs %{project_root}/ocaml/runtime)))
 
 (install
   (files

--- a/ocaml/otherlibs/systhreads/dune
+++ b/ocaml/otherlibs/systhreads/dune
@@ -30,13 +30,18 @@
     (language c)
     (names st_stubs_byte)
     (mode byte)
-    (flags -DCAML_NAME_SPACE)
+    (flags ((:include %{project_root}/oc_cflags.sexp)
+            (:include %{project_root}/sharedlib_cflags.sexp)
+            (:include %{project_root}/oc_cppflags.sexp)))
     (include_dirs %{project_root}/ocaml/runtime))
   (foreign_stubs
     (language c)
     (names st_stubs_native)
     (mode native)
-    (flags -DNATIVE_CODE -DCAML_NAME_SPACE)
+    (flags ((-DNATIVE_CODE)
+            (:include %{project_root}/oc_cflags.sexp)
+            (:include %{project_root}/sharedlib_cflags.sexp)
+            (:include %{project_root}/oc_cppflags.sexp)))
     (include_dirs %{project_root}/ocaml/runtime)))
 
 (rule

--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -35,7 +35,10 @@
    shutdown signals sleep socket socketaddr socketpair sockopt stat strofaddr
    symlink termios time times truncate umask unixsupport unlink utimes wait
    write)
-   (flags -I %{project_root}/ocaml/runtime)
+   (flags ((:include %{project_root}/oc_cflags.sexp)
+           (:include %{project_root}/sharedlib_cflags.sexp)
+           (:include %{project_root}/oc_cppflags.sexp)))
+   (include_dirs %{project_root}/ocaml/runtime)
  ))
 
 (install


### PR DESCRIPTION
Addresses the second issue from #28.

Use OC_CFLAGS, OC_CPPFLAGS, and SHAREDLIB_CFLAGS for foreign_stubs.

In the standard upstream build that uses Makefiles, C compiler flags include OC_CFLAGS, OC_CPPFLAGS, and SHAREDLIB_CFLAGS.  In dune build, flags for building C stubs are automatically supplied by dune from `ocamlc -config`, which is determined by OCAMLC_CFLAGS and  OCAMLC_CPPFLAGS.

The two sets of flags are not the same, for example:

```
OC_CFLAGS=-std=gnu99 -O2 -fno-strict-aliasing -fwrapv -fno-builtin-memcmp -Wall -Wdeclaration-after-statement -Werror -fexcess-precision=standard -fno-tree-vrp -ffunction-sections
OC_CPPFLAGS= -D_FILE_OFFSET_BITS=64 -D_REENTRANT -DCAML_NAME_SPACE
SHAREDLIB_CFLAGS=-fPIC

OCAMLC_CFLAGS=-std=gnu99 -O2 -fno-strict-aliasing -fwrapv -fno-builtin-memcmp -fPIC
OCAMLC_CPPFLAGS= -D_FILE_OFFSET_BITS=64 -D_REENTRANT

```
I tried `make compare` but it fails on my machine even without the PR with something related to Build_path_prefix_map.