### PR TITLE
Fix caml_globals_map duplicate entries

### DIFF
--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -51,7 +51,7 @@ let check_consistency file_name unit crc =
   begin try
     List.iter
       (fun (name, crco) ->
-        String.Tbl.add interfaces name ();
+        String.Tbl.replace interfaces name ();
         match crco with
           None -> ()
         | Some crc ->
@@ -91,7 +91,7 @@ let check_consistency file_name unit crc =
   end;
   implementations := unit.ui_name :: !implementations;
   Cmx_consistbl.set crc_implementations unit.ui_name crc file_name;
-  String.Tbl.add implementations_defined unit.ui_name file_name;
+  String.Tbl.replace implementations_defined unit.ui_name file_name;
   if unit.ui_symbol <> unit.ui_name then
     cmx_required := unit.ui_name :: !cmx_required
 


### PR DESCRIPTION
Used `replace` instead of `add` on the interfaces Hash table (which is being used as a set), to avoid duplicate entries. The duplicate entries lead to enormous `caml_globals_map` values.

Also use `replace` instead of `add` on another hash table usage, not because it was causing any problems but because it seems like `add` should be avoided outside unusual situations.

I tested a build with this and linking times are normal again.