### PR TITLE
Fix typo in Cpopcnt constructor use in Proc.operation_supported

### DIFF
--- a/backend/arm/proc.ml
+++ b/backend/arm/proc.ml
@@ -363,7 +363,7 @@ let assemble_file infile outfile =
 let init () = ()
 
 let operation_supported = function
-  | Cclz _ | Cctz _ | Popcnt
+  | Cclz _ | Cctz _ | Cpopcnt
     -> false   (* Not implemented *)
   | Capply _ | Cextcall _ | Cload _ | Calloc | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -270,7 +270,7 @@ let assemble_file infile outfile =
 let init () = ()
 
 let operation_supported = function
-  | Cclz _ | Cctz _ | Popcnt
+  | Cclz _ | Cctz _ | Cpopcnt
     -> false   (* Not implemented *)
   | Capply _ | Cextcall _ | Cload _ | Calloc | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/backend/i386/proc.ml
+++ b/backend/i386/proc.ml
@@ -260,7 +260,7 @@ let assemble_file infile outfile =
 let init () = ()
 
 let operation_supported = function
-  | Cclz _ | Cctz _ | Popcnt
+  | Cclz _ | Cctz _ | Cpopcnt
     -> false   (* Not implemented *)
   | Capply _ | Cextcall _ | Cload _ | Calloc | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/backend/power/proc.ml
+++ b/backend/power/proc.ml
@@ -369,7 +369,7 @@ let assemble_file infile outfile =
 let init () = ()
 
 let operation_supported = function
-  | Cclz _ | Cctz _ | Popcnt
+  | Cclz _ | Cctz _ | Cpopcnt
     -> false   (* Not implemented *)
   | Capply _ | Cextcall _ | Cload _ | Calloc | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/backend/riscv/proc.ml
+++ b/backend/riscv/proc.ml
@@ -337,7 +337,7 @@ let assemble_file infile outfile =
 let init () = ()
 
 let operation_supported = function
-  | Cclz _ | Cctz _ | Popcnt
+  | Cclz _ | Cctz _ | Cpopcnt
     -> false   (* Not implemented *)
   | Capply _ | Cextcall _ | Cload _ | Calloc | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/backend/s390x/proc.ml
+++ b/backend/s390x/proc.ml
@@ -243,7 +243,7 @@ let assemble_file infile outfile =
 let init () = ()
 
 let operation_supported = function
-  | Cclz _ | Cctz _ | Popcnt
+  | Cclz _ | Cctz _ | Cpopcnt
     -> false   (* Not implemented *)
   | Capply _ | Cextcall _ | Cload _ | Calloc | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi


### PR DESCRIPTION
Introduced by #17 and missed because we don't build targets other than amd64 in CI. 
