### PR TITLE
Remove Cmm.memory_chunk.Double_u

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -778,7 +778,7 @@ let emit_instr fallthrough i =
           I.movsxd (addressing addr DWORD i 0) dest
       | Single ->
           I.cvtss2sd (addressing addr REAL4 i 0) dest
-      | Double | Double_u ->
+      | Double ->
           I.movsd (addressing addr REAL8 i 0) dest
       end
   | Lop(Istore(chunk, addr, _)) ->
@@ -794,7 +794,7 @@ let emit_instr fallthrough i =
       | Single ->
           I.cvtsd2ss (arg i 0) xmm15;
           I.movss xmm15 (addressing addr REAL4 i 1)
-      | Double | Double_u ->
+      | Double ->
           I.movsd (arg i 0) (addressing addr REAL8 i 1)
       end
   | Lop(Ialloc { bytes = n; label_after_call_gc; spacetime_index; dbginfo }) ->

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -344,7 +344,7 @@ let destroyed_at_oper = function
                    | Icheckbound _),_))
   | Iop(Istore((Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
                | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val
-               | Double | Double_u), _, _))
+               | Double ), _, _))
   | Iop(Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
        | Ifloatofint | Iintoffloat
        | Iconst_int _ | Iconst_float _ | Iconst_symbol _
@@ -399,7 +399,7 @@ let max_register_pressure = function
                 | Iasr | Ipopcnt | Iclz _| Ictz _|Icheckbound _), _)
   | Istore((Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
             | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val
-            | Double | Double_u),
+            | Double ),
             _, _)
   | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat | Iconst_int _ | Iconst_float _ | Iconst_symbol _

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -236,7 +236,7 @@ method! select_operation op args dbg =
       self#select_floatarith false Idivf Ifloatdiv args
   | Cextcall { name = "sqrt"; alloc = false; } ->
      begin match args with
-       [Cop(Cload ((Double|Double_u as chunk), _), [loc], _dbg)] ->
+       [Cop(Cload ((Double as chunk), _), [loc], _dbg)] ->
          let (addr, arg) = self#select_addressing chunk loc in
          (Ispecific(Ifloatsqrtf addr), [arg])
      | [arg] ->
@@ -297,11 +297,11 @@ method! select_operation op args dbg =
 
 method select_floatarith commutative regular_op mem_op args =
   match args with
-    [arg1; Cop(Cload ((Double|Double_u as chunk), _), [loc2], _)] ->
+    [arg1; Cop(Cload ((Double as chunk), _), [loc2], _)] ->
       let (addr, arg2) = self#select_addressing chunk loc2 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),
                  [arg1; arg2])
-  | [Cop(Cload ((Double|Double_u as chunk), _), [loc1], _); arg2]
+  | [Cop(Cload ((Double as chunk), _), [loc1], _); arg2]
         when commutative ->
       let (addr, arg1) = self#select_addressing chunk loc1 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -133,7 +133,7 @@ let pseudoregs_for_operation op arg res =
   | Iintop_imm ((Imulh|Idiv|Imod|Icomp _|Icheckbound _
                 |Ipopcnt|Iclz _|Ictz _), _)
   | Ispecific (Isqrtf|Isextend32|Izextend32|Ilea _|Istore_int (_, _, _)
-              |Ioffset_loc (_, _)|Ifloatsqrtf _)
+              |Ioffset_loc (_, _)|Ifloatsqrtf _ |Irdtsc)
   | Imove|Ispill|Ireload|Ifloatofint|Iintoffloat|Iconst_int _|Iconst_float _
   | Iconst_symbol _|Icall_ind _|Icall_imm _|Itailcall_ind _|Itailcall_imm _
   | Iextcall _|Istackoffset _|Iload (_, _)|Istore (_, _, _)|Ialloc _

--- a/backend/arm/emit.mlp
+++ b/backend/arm/emit.mlp
@@ -586,7 +586,7 @@ let emit_instr i =
     | Lop(Iload(Single, addr)) when !fpu >= VFPv2 ->
         `	flds	s14, {emit_addressing addr i.arg 0}\n`;
         `	fcvtds	{emit_reg i.res.(0)}, s14\n`; 2
-    | Lop(Iload((Double | Double_u), addr)) when !fpu = Soft ->
+    | Lop(Iload(Double, addr)) when !fpu = Soft ->
         (* Use LDM or LDRD if possible *)
         begin match i.res.(0), i.res.(1), addr with
           {loc = Reg rt}, {loc = Reg rt2}, Iindexed 0
@@ -613,14 +613,13 @@ let emit_instr i =
           | Byte_signed -> "ldrsb"
           | Sixteen_unsigned -> "ldrh"
           | Sixteen_signed -> "ldrsh"
-          | Double
-          | Double_u -> "fldd"
+          | Double -> "fldd"
           | _ (* 32-bit quantities *) -> "ldr" in
         `	{emit_string instr}	{emit_reg r}, {emit_addressing addr i.arg 0}\n`; 1
     | Lop(Istore(Single, addr, _)) when !fpu >= VFPv2 ->
         `	fcvtsd	s14, {emit_reg i.arg.(0)}\n`;
         `	fsts	s14, {emit_addressing addr i.arg 1}\n`; 2
-    | Lop(Istore((Double | Double_u), addr, _)) when !fpu = Soft ->
+    | Lop(Istore(Double, addr, _)) when !fpu = Soft ->
         (* Use STM or STRD if possible *)
         begin match i.arg.(0), i.arg.(1), addr with
           {loc = Reg rt}, {loc = Reg rt2}, Iindexed 0
@@ -642,8 +641,7 @@ let emit_instr i =
           | Byte_signed -> "strb"
           | Sixteen_unsigned
           | Sixteen_signed -> "strh"
-          | Double
-          | Double_u -> "fstd"
+          | Double -> "fstd"
           | _ (* 32-bit quantities *) -> "str" in
         `	{emit_string instr}	{emit_reg r}, {emit_addressing addr i.arg 1}\n`; 1
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->

--- a/backend/arm/selection.ml
+++ b/backend/arm/selection.ml
@@ -24,7 +24,7 @@ open Mach
 let is_offset chunk n =
   match chunk with
   (* VFPv{2,3} load/store have -1020 to 1020.  Offset must be multiple of 4 *)
-  | Single | Double | Double_u
+  | Single | Double
     when !fpu >= VFPv2 ->
       n >= -1020 && n <= 1020 && n mod 4 = 0
   (* ARM load/store byte/word have -4095 to 4095 *)

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -670,7 +670,7 @@ let emit_instr i =
         | Single ->
             `	ldr	s7, {emit_addressing addr base}\n`;
             `	fcvt	{emit_reg dst}, s7\n`
-        | Word_int | Word_val | Double | Double_u ->
+        | Word_int | Word_val | Double ->
             `	ldr	{emit_reg dst}, {emit_addressing addr base}\n`
         end
     | Lop(Istore(size, addr, _)) ->
@@ -692,7 +692,7 @@ let emit_instr i =
         | Single ->
             `	fcvt	s7, {emit_reg src}\n`;
             `	str	s7, {emit_addressing addr base}\n`;
-        | Word_int | Word_val | Double | Double_u ->
+        | Word_int | Word_val | Double ->
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         end
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->

--- a/backend/arm64/selection.ml
+++ b/backend/arm64/selection.ml
@@ -31,7 +31,7 @@ let is_offset chunk n =
         n land 1 = 0 && n lsr 1 < 0x1000
     | Thirtytwo_unsigned | Thirtytwo_signed | Single ->
         n land 3 = 0 && n lsr 2 < 0x1000
-    | Word_int | Word_val | Double | Double_u ->
+    | Word_int | Word_val | Double ->
         n land 7 = 0 && n lsr 3 < 0x1000)
 
 (* An automaton to recognize ( 0+1+0* | 1+0+1* )

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -134,7 +134,6 @@ type memory_chunk =
   | Word_val
   | Single
   | Double
-  | Double_u
 
 and operation =
     Capply of machtype

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -127,7 +127,8 @@ type memory_chunk =
   | Word_int                           (* integer or pointer outside heap *)
   | Word_val                           (* pointer inside heap or encoded int *)
   | Single
-  | Double                             (* 64-bit-aligned 64-bit float *)
+  | Double                             (* word-aligned 64-bit float
+                                          see PR#10433 *)
 
 and operation =
     Capply of machtype

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -128,7 +128,6 @@ type memory_chunk =
   | Word_val                           (* pointer inside heap or encoded int *)
   | Single
   | Double                             (* 64-bit-aligned 64-bit float *)
-  | Double_u                           (* word-aligned 64-bit float *)
 
 and operation =
     Capply of machtype

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -562,9 +562,9 @@ let unbox_float dbg =
           | Some (Uconst_float x) ->
               Cconst_float (x, dbg) (* or keep _dbg? *)
           | _ ->
-              Cop(Cload (Double_u, Immutable), [cmm], dbg)
+              Cop(Cload (Double, Immutable), [cmm], dbg)
           end
-      | cmm -> Cop(Cload (Double_u, Immutable), [cmm], dbg)
+      | cmm -> Cop(Cload (Double, Immutable), [cmm], dbg)
     )
 
 (* Complex *)
@@ -572,8 +572,8 @@ let unbox_float dbg =
 let box_complex dbg c_re c_im =
   Cop(Calloc, [alloc_floatarray_header 2 dbg; c_re; c_im], dbg)
 
-let complex_re c dbg = Cop(Cload (Double_u, Immutable), [c], dbg)
-let complex_im c dbg = Cop(Cload (Double_u, Immutable),
+let complex_re c dbg = Cop(Cload (Double, Immutable), [c], dbg)
+let complex_im c dbg = Cop(Cload (Double, Immutable),
                         [Cop(Cadda, [c; Cconst_int (size_float, dbg)], dbg)],
                         dbg)
 
@@ -721,7 +721,7 @@ let int_array_ref arr ofs dbg =
   Cop(Cload (Word_int, Mutable),
     [array_indexing log2_size_addr arr ofs dbg], dbg)
 let unboxed_float_array_ref arr ofs dbg =
-  Cop(Cload (Double_u, Mutable),
+  Cop(Cload (Double, Mutable),
     [array_indexing log2_size_float arr ofs dbg], dbg)
 let float_array_ref arr ofs dbg =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
@@ -744,7 +744,7 @@ let int_array_set arr ofs newval dbg =
   Cop(Cstore (Word_int, Lambda.Assignment),
     [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let float_array_set arr ofs newval dbg =
-  Cop(Cstore (Double_u, Lambda.Assignment),
+  Cop(Cstore (Double, Lambda.Assignment),
     [array_indexing log2_size_float arr ofs dbg; newval], dbg)
 
 (* String length *)
@@ -2103,7 +2103,7 @@ let generic_functions shared units =
 type unary_primitive = expression -> Debuginfo.t -> expression
 
 let floatfield n ptr dbg =
-  Cop(Cload (Double_u, Mutable),
+  Cop(Cload (Double, Mutable),
       [if n = 0 then ptr
        else Cop(Cadda, [ptr; Cconst_int(n * size_float, dbg)], dbg)],
       dbg)
@@ -2264,7 +2264,7 @@ let setfield n ptr init arg1 arg2 dbg =
 
 let setfloatfield n init arg1 arg2 dbg =
   return_unit dbg (
-    Cop(Cstore (Double_u, init),
+    Cop(Cstore (Double, init),
         [if n = 0 then arg1
          else Cop(Cadda, [arg1; Cconst_int(n * size_float, dbg)], dbg);
          arg2], dbg))

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2687,9 +2687,9 @@ let transl_builtin name args dbg =
   | "caml_native_pointer_store_unboxed_int32" ->
     Some(Cop(Cstore (Thirtytwo_signed, Assignment), args, dbg))
   | "caml_native_pointer_load_unboxed_float" ->
-    Some(Cop(Cload (Double_u, Mutable), args, dbg))
+    Some(Cop(Cload (Double, Mutable), args, dbg))
   | "caml_native_pointer_store_unboxed_float" ->
-    Some(Cop(Cstore (Double_u, Assignment), args, dbg))
+    Some(Cop(Cstore (Double, Assignment), args, dbg))
   (* Ext_pointer: handled as tagged int *)
   | "caml_ext_pointer_load_immediate"
   | "caml_ext_pointer_load_unboxed_nativeint" ->
@@ -2706,9 +2706,9 @@ let transl_builtin name args dbg =
   | "caml_ext_pointer_store_unboxed_int32" ->
     ext_pointer_store Thirtytwo_signed name args dbg
   | "caml_ext_pointer_load_unboxed_float" ->
-    ext_pointer_load Double_u name args dbg
+    ext_pointer_load Double name args dbg
   | "caml_ext_pointer_store_unboxed_float" ->
-    ext_pointer_store Double_u name args dbg
+    ext_pointer_store Double name args dbg
   | _ -> None
 
 (* [cextcall] is called from [Cmmgen.transl_ccall] *)

--- a/backend/i386/CSE.ml
+++ b/backend/i386/CSE.ml
@@ -29,7 +29,7 @@ method! class_of_operation op =
   (* Operations that affect the floating-point stack cannot be factored *)
   | Iconst_float _ | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Iintoffloat | Ifloatofint
-  | Iload((Single | Double | Double_u), _) -> Op_other
+  | Iload((Single | Double), _) -> Op_other
   (* Specific ops *)
   | Ispecific(Ilea _) -> Op_pure
   | Ispecific(Istore_int(_, _, is_asg)) -> Op_store is_asg

--- a/backend/i386/emit.mlp
+++ b/backend/i386/emit.mlp
@@ -590,7 +590,7 @@ let emit_instr fallthrough i =
           I.movsx (addressing addr WORD i 0) (reg dest)
       | Single ->
           I.fld (addressing addr REAL4 i 0)
-      | Double | Double_u ->
+      | Double ->
           I.fld (addressing addr REAL8 i 0)
       end
   | Lop(Istore(chunk, addr, _)) ->
@@ -608,7 +608,7 @@ let emit_instr fallthrough i =
             I.fld (reg i.arg.(0));
             I.fstp (addressing addr REAL4 i 1)
           end
-      | Double | Double_u ->
+      | Double ->
           if is_tos i.arg.(0) then
             I.fstp (addressing addr REAL8 i 1)
           else begin

--- a/backend/i386/selection.ml
+++ b/backend/i386/selection.ml
@@ -133,7 +133,7 @@ let pseudoregs_for_operation op arg res =
   (* For floating-point operations and floating-point loads,
      the result is always left at the top of the floating-point stack *)
   | Iconst_float _ | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
-  | Ifloatofint | Iload((Single | Double | Double_u), _)
+  | Ifloatofint | Iload((Single | Double ), _)
   | Ispecific(Isubfrev | Idivfrev | Ifloatarithmem _ | Ifloatspecial _) ->
       (arg, [| tos |], false)           (* don't move it immediately *)
   (* For storing a byte, the argument must be in eax...edx.
@@ -149,7 +149,6 @@ let pseudoregs_for_operation op arg res =
 let chunk_double = function
     Single -> false
   | Double -> true
-  | Double_u -> true
   | _ -> assert false
 
 (* The selector class *)
@@ -296,8 +295,8 @@ method select_push exp =
   | Cop(Cload ((Word_int | Word_val as chunk), _), [loc], _) ->
       let (addr, arg) = self#select_addressing chunk loc in
       (Ispecific(Ipush_load addr), arg)
-  | Cop(Cload (Double_u, _), [loc], _) ->
-      let (addr, arg) = self#select_addressing Double_u loc in
+  | Cop(Cload (Double, _), [loc], _) ->
+      let (addr, arg) = self#select_addressing Double loc in
       (Ispecific(Ipush_load_float addr), arg)
   | _ -> (Ispecific(Ipush), exp)
 

--- a/backend/power/emit.mlp
+++ b/backend/power/emit.mlp
@@ -744,7 +744,7 @@ let emit_instr i =
           | Thirtytwo_signed -> if ppc64 then "lwa" else "lwz"
 	  | Word_int | Word_val -> lg
           | Single -> "lfs"
-          | Double | Double_u -> "lfd" in
+          | Double -> "lfd" in
         emit_load_store loadinstr addr i.arg 0 i.res.(0);
         if chunk = Byte_signed then
           `	extsb	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
@@ -756,7 +756,7 @@ let emit_instr i =
 	  | Thirtytwo_unsigned | Thirtytwo_signed -> "stw"
 	  | Word_int | Word_val -> stg
           | Single -> "stfs"
-          | Double | Double_u -> "stfd" in
+          | Double -> "stfd" in
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->
         if !call_gc_label = 0 then begin

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -70,7 +70,6 @@ let chunk = function
   | Word_val -> "val"
   | Single -> "float32"
   | Double -> "float64"
-  | Double_u -> "float64u"
 
 let phantom_defining_expr ppf defining_expr =
   match defining_expr with

--- a/backend/riscv/emit.mlp
+++ b/backend/riscv/emit.mlp
@@ -357,7 +357,7 @@ let emit_instr i =
         | Thirtytwo_signed -> "lw"
         | Word_int | Word_val -> "ld"
         | Single -> assert false
-        | Double | Double_u -> "fld"
+        | Double -> "fld"
       in
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_int ofs}({emit_reg i.arg.(0)})\n`
   | Lop(Istore(Single, Iindexed ofs, _)) ->
@@ -372,7 +372,7 @@ let emit_instr i =
         | Thirtytwo_unsigned | Thirtytwo_signed -> "sw"
         | Word_int | Word_val -> "sd"
         | Single -> assert false
-        | Double | Double_u -> "fsd"
+        | Double -> "fsd"
       in
       `	{emit_string instr}	{emit_reg i.arg.(0)}, {emit_int ofs}({emit_reg i.arg.(1)})\n`
   | Lop(Ialloc {bytes; label_after_call_gc = label; dbginfo}) ->

--- a/backend/s390x/emit.mlp
+++ b/backend/s390x/emit.mlp
@@ -407,7 +407,7 @@ let emit_instr i =
           | Thirtytwo_signed -> "lgf"
           | Word_int | Word_val -> "lg"
           | Single -> "ley"
-          | Double | Double_u -> "ldy" in
+          | Double -> "ldy" in
         emit_load_store loadinstr addr i.arg 0 i.res.(0);
         if chunk = Single then
           `	ldebr	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
@@ -423,7 +423,7 @@ let emit_instr i =
           | Thirtytwo_unsigned | Thirtytwo_signed -> "sty"
           | Word_int | Word_val -> "stg"
           | Single -> assert false
-          | Double | Double_u -> "stdy" in
+          | Double -> "stdy" in
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
 
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -70,7 +70,7 @@ let oper_result_type = function
   | Cload (c, _) ->
       begin match c with
       | Word_val -> typ_val
-      | Single | Double | Double_u -> typ_float
+      | Single | Double -> typ_float
       | _ -> typ_int
       end
   | Calloc -> typ_val
@@ -1064,7 +1064,7 @@ method emit_stores env data regs_addr =
             Istore(_, _, _) ->
               for i = 0 to Array.length regs - 1 do
                 let r = regs.(i) in
-                let kind = if r.typ = Float then Double_u else Word_val in
+                let kind = if r.typ = Float then Double else Word_val in
                 self#insert env
                             (Iop(Istore(kind, !a, false)))
                             (Array.append [|r|] regs_addr) [||];

--- a/ocaml/asmcomp/amd64/emit.mlp
+++ b/ocaml/asmcomp/amd64/emit.mlp
@@ -770,7 +770,7 @@ let emit_instr fallthrough i =
           I.movsxd (addressing addr DWORD i 0) dest
       | Single ->
           I.cvtss2sd (addressing addr REAL4 i 0) dest
-      | Double | Double_u ->
+      | Double ->
           I.movsd (addressing addr REAL8 i 0) dest
       end
   | Lop(Istore(chunk, addr, _)) ->
@@ -786,7 +786,7 @@ let emit_instr fallthrough i =
       | Single ->
           I.cvtsd2ss (arg i 0) xmm15;
           I.movss xmm15 (addressing addr REAL4 i 1)
-      | Double | Double_u ->
+      | Double ->
           I.movsd (arg i 0) (addressing addr REAL8 i 1)
       end
   | Lop(Ialloc { bytes = n; label_after_call_gc; spacetime_index; dbginfo }) ->

--- a/ocaml/asmcomp/amd64/selection.ml
+++ b/ocaml/asmcomp/amd64/selection.ml
@@ -203,7 +203,7 @@ method! select_operation op args dbg =
       self#select_floatarith false Idivf Ifloatdiv args
   | Cextcall("sqrt", _, false, _) ->
      begin match args with
-       [Cop(Cload ((Double|Double_u as chunk), _), [loc], _dbg)] ->
+       [Cop(Cload ((Double as chunk), _), [loc], _dbg)] ->
          let (addr, arg) = self#select_addressing chunk loc in
          (Ispecific(Ifloatsqrtf addr), [arg])
      | [arg] ->
@@ -254,11 +254,11 @@ method! select_operation op args dbg =
 
 method select_floatarith commutative regular_op mem_op args =
   match args with
-    [arg1; Cop(Cload ((Double|Double_u as chunk), _), [loc2], _)] ->
+    [arg1; Cop(Cload ((Double as chunk), _), [loc2], _)] ->
       let (addr, arg2) = self#select_addressing chunk loc2 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),
                  [arg1; arg2])
-  | [Cop(Cload ((Double|Double_u as chunk), _), [loc1], _); arg2]
+  | [Cop(Cload ((Double as chunk), _), [loc1], _); arg2]
         when commutative ->
       let (addr, arg1) = self#select_addressing chunk loc1 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),

--- a/ocaml/asmcomp/arm/emit.mlp
+++ b/ocaml/asmcomp/arm/emit.mlp
@@ -582,7 +582,7 @@ let emit_instr i =
     | Lop(Iload(Single, addr)) when !fpu >= VFPv2 ->
         `	flds	s14, {emit_addressing addr i.arg 0}\n`;
         `	fcvtds	{emit_reg i.res.(0)}, s14\n`; 2
-    | Lop(Iload((Double | Double_u), addr)) when !fpu = Soft ->
+    | Lop(Iload(Double, addr)) when !fpu = Soft ->
         (* Use LDM or LDRD if possible *)
         begin match i.res.(0), i.res.(1), addr with
           {loc = Reg rt}, {loc = Reg rt2}, Iindexed 0
@@ -609,14 +609,13 @@ let emit_instr i =
           | Byte_signed -> "ldrsb"
           | Sixteen_unsigned -> "ldrh"
           | Sixteen_signed -> "ldrsh"
-          | Double
-          | Double_u -> "fldd"
+          | Double -> "fldd"
           | _ (* 32-bit quantities *) -> "ldr" in
         `	{emit_string instr}	{emit_reg r}, {emit_addressing addr i.arg 0}\n`; 1
     | Lop(Istore(Single, addr, _)) when !fpu >= VFPv2 ->
         `	fcvtsd	s14, {emit_reg i.arg.(0)}\n`;
         `	fsts	s14, {emit_addressing addr i.arg 1}\n`; 2
-    | Lop(Istore((Double | Double_u), addr, _)) when !fpu = Soft ->
+    | Lop(Istore(Double, addr, _)) when !fpu = Soft ->
         (* Use STM or STRD if possible *)
         begin match i.arg.(0), i.arg.(1), addr with
           {loc = Reg rt}, {loc = Reg rt2}, Iindexed 0
@@ -638,8 +637,7 @@ let emit_instr i =
           | Byte_signed -> "strb"
           | Sixteen_unsigned
           | Sixteen_signed -> "strh"
-          | Double
-          | Double_u -> "fstd"
+          | Double -> "fstd"
           | _ (* 32-bit quantities *) -> "str" in
         `	{emit_string instr}	{emit_reg r}, {emit_addressing addr i.arg 1}\n`; 1
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->

--- a/ocaml/asmcomp/arm/selection.ml
+++ b/ocaml/asmcomp/arm/selection.ml
@@ -24,7 +24,7 @@ open Mach
 let is_offset chunk n =
   match chunk with
   (* VFPv{2,3} load/store have -1020 to 1020.  Offset must be multiple of 4 *)
-  | Single | Double | Double_u
+  | Single | Double
     when !fpu >= VFPv2 ->
       n >= -1020 && n <= 1020 && n mod 4 = 0
   (* ARM load/store byte/word have -4095 to 4095 *)

--- a/ocaml/asmcomp/arm64/emit.mlp
+++ b/ocaml/asmcomp/arm64/emit.mlp
@@ -668,7 +668,7 @@ let emit_instr i =
         | Single ->
             `	ldr	s7, {emit_addressing addr base}\n`;
             `	fcvt	{emit_reg dst}, s7\n`
-        | Word_int | Word_val | Double | Double_u ->
+        | Word_int | Word_val | Double ->
             `	ldr	{emit_reg dst}, {emit_addressing addr base}\n`
         end
     | Lop(Istore(size, addr, _)) ->
@@ -690,7 +690,7 @@ let emit_instr i =
         | Single ->
             `	fcvt	s7, {emit_reg src}\n`;
             `	str	s7, {emit_addressing addr base}\n`;
-        | Word_int | Word_val | Double | Double_u ->
+        | Word_int | Word_val | Double ->
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         end
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->

--- a/ocaml/asmcomp/arm64/selection.ml
+++ b/ocaml/asmcomp/arm64/selection.ml
@@ -31,7 +31,7 @@ let is_offset chunk n =
         n land 1 = 0 && n lsr 1 < 0x1000
     | Thirtytwo_unsigned | Thirtytwo_signed | Single ->
         n land 3 = 0 && n lsr 2 < 0x1000
-    | Word_int | Word_val | Double | Double_u ->
+    | Word_int | Word_val | Double ->
         n land 7 = 0 && n lsr 3 < 0x1000)
 
 (* An automaton to recognize ( 0+1+0* | 1+0+1* )

--- a/ocaml/asmcomp/cmm.ml
+++ b/ocaml/asmcomp/cmm.ml
@@ -131,7 +131,6 @@ type memory_chunk =
   | Word_val
   | Single
   | Double
-  | Double_u
 
 and operation =
     Capply of machtype

--- a/ocaml/asmcomp/cmm.mli
+++ b/ocaml/asmcomp/cmm.mli
@@ -124,7 +124,8 @@ type memory_chunk =
   | Word_int                           (* integer or pointer outside heap *)
   | Word_val                           (* pointer inside heap or encoded int *)
   | Single
-  | Double                             (* 64-bit-aligned 64-bit float *)
+  | Double                             (* word-aligned 64-bit float
+                                          see PR#10433 *)
 
 and operation =
     Capply of machtype

--- a/ocaml/asmcomp/cmm.mli
+++ b/ocaml/asmcomp/cmm.mli
@@ -125,7 +125,6 @@ type memory_chunk =
   | Word_val                           (* pointer inside heap or encoded int *)
   | Single
   | Double                             (* 64-bit-aligned 64-bit float *)
-  | Double_u                           (* word-aligned 64-bit float *)
 
 and operation =
     Capply of machtype

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -562,9 +562,9 @@ let unbox_float dbg =
           | Some (Uconst_float x) ->
               Cconst_float (x, dbg) (* or keep _dbg? *)
           | _ ->
-              Cop(Cload (Double_u, Immutable), [cmm], dbg)
+              Cop(Cload (Double, Immutable), [cmm], dbg)
           end
-      | cmm -> Cop(Cload (Double_u, Immutable), [cmm], dbg)
+      | cmm -> Cop(Cload (Double, Immutable), [cmm], dbg)
     )
 
 (* Complex *)
@@ -572,8 +572,8 @@ let unbox_float dbg =
 let box_complex dbg c_re c_im =
   Cop(Calloc, [alloc_floatarray_header 2 dbg; c_re; c_im], dbg)
 
-let complex_re c dbg = Cop(Cload (Double_u, Immutable), [c], dbg)
-let complex_im c dbg = Cop(Cload (Double_u, Immutable),
+let complex_re c dbg = Cop(Cload (Double, Immutable), [c], dbg)
+let complex_im c dbg = Cop(Cload (Double, Immutable),
                         [Cop(Cadda, [c; Cconst_int (size_float, dbg)], dbg)],
                         dbg)
 
@@ -721,7 +721,7 @@ let int_array_ref arr ofs dbg =
   Cop(Cload (Word_int, Mutable),
     [array_indexing log2_size_addr arr ofs dbg], dbg)
 let unboxed_float_array_ref arr ofs dbg =
-  Cop(Cload (Double_u, Mutable),
+  Cop(Cload (Double, Mutable),
     [array_indexing log2_size_float arr ofs dbg], dbg)
 let float_array_ref arr ofs dbg =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
@@ -736,7 +736,7 @@ let int_array_set arr ofs newval dbg =
   Cop(Cstore (Word_int, Lambda.Assignment),
     [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let float_array_set arr ofs newval dbg =
-  Cop(Cstore (Double_u, Lambda.Assignment),
+  Cop(Cstore (Double, Lambda.Assignment),
     [array_indexing log2_size_float arr ofs dbg; newval], dbg)
 
 (* String length *)
@@ -2083,7 +2083,7 @@ let generic_functions shared units =
 type unary_primitive = expression -> Debuginfo.t -> expression
 
 let floatfield n ptr dbg =
-  Cop(Cload (Double_u, Mutable),
+  Cop(Cload (Double, Mutable),
       [if n = 0 then ptr
        else Cop(Cadda, [ptr; Cconst_int(n * size_float, dbg)], dbg)],
       dbg)
@@ -2187,7 +2187,7 @@ let setfield n ptr init arg1 arg2 dbg =
 
 let setfloatfield n init arg1 arg2 dbg =
   return_unit dbg (
-    Cop(Cstore (Double_u, init),
+    Cop(Cstore (Double, init),
         [if n = 0 then arg1
          else Cop(Cadda, [arg1; Cconst_int(n * size_float, dbg)], dbg);
          arg2], dbg))

--- a/ocaml/asmcomp/i386/CSE.ml
+++ b/ocaml/asmcomp/i386/CSE.ml
@@ -29,7 +29,7 @@ method! class_of_operation op =
   (* Operations that affect the floating-point stack cannot be factored *)
   | Iconst_float _ | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Iintoffloat | Ifloatofint
-  | Iload((Single | Double | Double_u), _) -> Op_other
+  | Iload((Single | Double), _) -> Op_other
   (* Specific ops *)
   | Ispecific(Ilea _) -> Op_pure
   | Ispecific(Istore_int(_, _, is_asg)) -> Op_store is_asg

--- a/ocaml/asmcomp/i386/emit.mlp
+++ b/ocaml/asmcomp/i386/emit.mlp
@@ -588,7 +588,7 @@ let emit_instr fallthrough i =
           I.movsx (addressing addr WORD i 0) (reg dest)
       | Single ->
           I.fld (addressing addr REAL4 i 0)
-      | Double | Double_u ->
+      | Double ->
           I.fld (addressing addr REAL8 i 0)
       end
   | Lop(Istore(chunk, addr, _)) ->
@@ -606,7 +606,7 @@ let emit_instr fallthrough i =
             I.fld (reg i.arg.(0));
             I.fstp (addressing addr REAL4 i 1)
           end
-      | Double | Double_u ->
+      | Double ->
           if is_tos i.arg.(0) then
             I.fstp (addressing addr REAL8 i 1)
           else begin

--- a/ocaml/asmcomp/i386/selection.ml
+++ b/ocaml/asmcomp/i386/selection.ml
@@ -133,7 +133,7 @@ let pseudoregs_for_operation op arg res =
   (* For floating-point operations and floating-point loads,
      the result is always left at the top of the floating-point stack *)
   | Iconst_float _ | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
-  | Ifloatofint | Iload((Single | Double | Double_u), _)
+  | Ifloatofint | Iload((Single | Double ), _)
   | Ispecific(Isubfrev | Idivfrev | Ifloatarithmem _ | Ifloatspecial _) ->
       (arg, [| tos |], false)           (* don't move it immediately *)
   (* For storing a byte, the argument must be in eax...edx.
@@ -149,7 +149,6 @@ let pseudoregs_for_operation op arg res =
 let chunk_double = function
     Single -> false
   | Double -> true
-  | Double_u -> true
   | _ -> assert false
 
 (* The selector class *)
@@ -296,8 +295,8 @@ method select_push exp =
   | Cop(Cload ((Word_int | Word_val as chunk), _), [loc], _) ->
       let (addr, arg) = self#select_addressing chunk loc in
       (Ispecific(Ipush_load addr), arg)
-  | Cop(Cload (Double_u, _), [loc], _) ->
-      let (addr, arg) = self#select_addressing Double_u loc in
+  | Cop(Cload (Double, _), [loc], _) ->
+      let (addr, arg) = self#select_addressing Double loc in
       (Ispecific(Ipush_load_float addr), arg)
   | _ -> (Ispecific(Ipush), exp)
 

--- a/ocaml/asmcomp/power/emit.mlp
+++ b/ocaml/asmcomp/power/emit.mlp
@@ -742,7 +742,7 @@ let emit_instr i =
           | Thirtytwo_signed -> if ppc64 then "lwa" else "lwz"
 	  | Word_int | Word_val -> lg
           | Single -> "lfs"
-          | Double | Double_u -> "lfd" in
+          | Double -> "lfd" in
         emit_load_store loadinstr addr i.arg 0 i.res.(0);
         if chunk = Byte_signed then
           `	extsb	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
@@ -754,7 +754,7 @@ let emit_instr i =
 	  | Thirtytwo_unsigned | Thirtytwo_signed -> "stw"
 	  | Word_int | Word_val -> stg
           | Single -> "stfs"
-          | Double | Double_u -> "stfd" in
+          | Double -> "stfd" in
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->
         if !call_gc_label = 0 then begin

--- a/ocaml/asmcomp/printcmm.ml
+++ b/ocaml/asmcomp/printcmm.ml
@@ -70,7 +70,6 @@ let chunk = function
   | Word_val -> "val"
   | Single -> "float32"
   | Double -> "float64"
-  | Double_u -> "float64u"
 
 let phantom_defining_expr ppf defining_expr =
   match defining_expr with

--- a/ocaml/asmcomp/riscv/emit.mlp
+++ b/ocaml/asmcomp/riscv/emit.mlp
@@ -355,7 +355,7 @@ let emit_instr i =
         | Thirtytwo_signed -> "lw"
         | Word_int | Word_val -> "ld"
         | Single -> assert false
-        | Double | Double_u -> "fld"
+        | Double -> "fld"
       in
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_int ofs}({emit_reg i.arg.(0)})\n`
   | Lop(Istore(Single, Iindexed ofs, _)) ->
@@ -370,7 +370,7 @@ let emit_instr i =
         | Thirtytwo_unsigned | Thirtytwo_signed -> "sw"
         | Word_int | Word_val -> "sd"
         | Single -> assert false
-        | Double | Double_u -> "fsd"
+        | Double -> "fsd"
       in
       `	{emit_string instr}	{emit_reg i.arg.(0)}, {emit_int ofs}({emit_reg i.arg.(1)})\n`
   | Lop(Ialloc {bytes; label_after_call_gc = label; dbginfo}) ->

--- a/ocaml/asmcomp/s390x/emit.mlp
+++ b/ocaml/asmcomp/s390x/emit.mlp
@@ -405,7 +405,7 @@ let emit_instr i =
           | Thirtytwo_signed -> "lgf"
           | Word_int | Word_val -> "lg"
           | Single -> "ley"
-          | Double | Double_u -> "ldy" in
+          | Double -> "ldy" in
         emit_load_store loadinstr addr i.arg 0 i.res.(0);
         if chunk = Single then
           `	ldebr	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
@@ -421,7 +421,7 @@ let emit_instr i =
           | Thirtytwo_unsigned | Thirtytwo_signed -> "sty"
           | Word_int | Word_val -> "stg"
           | Single -> assert false
-          | Double | Double_u -> "stdy" in
+          | Double -> "stdy" in
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
 
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->

--- a/ocaml/asmcomp/selectgen.ml
+++ b/ocaml/asmcomp/selectgen.ml
@@ -70,7 +70,7 @@ let oper_result_type = function
   | Cload (c, _) ->
       begin match c with
       | Word_val -> typ_val
-      | Single | Double | Double_u -> typ_float
+      | Single | Double -> typ_float
       | _ -> typ_int
       end
   | Calloc -> typ_val
@@ -1058,7 +1058,7 @@ method emit_stores env data regs_addr =
             Istore(_, _, _) ->
               for i = 0 to Array.length regs - 1 do
                 let r = regs.(i) in
-                let kind = if r.typ = Float then Double_u else Word_val in
+                let kind = if r.typ = Float then Double else Word_val in
                 self#insert env
                             (Iop(Istore(kind, !a, false)))
                             (Array.append [|r|] regs_addr) [||];

--- a/ocaml/testsuite/tools/parsecmm.mly
+++ b/ocaml/testsuite/tools/parsecmm.mly
@@ -273,7 +273,7 @@ expr:
           Debuginfo.none) }
   | LPAREN FLOATAREF expr expr RPAREN
       { let open Asttypes in
-        Cop(Cload (Double_u, Mutable), [access_array $3 $4 Arch.size_float],
+        Cop(Cload (Double, Mutable), [access_array $3 $4 Arch.size_float],
           Debuginfo.none) }
   | LPAREN ADDRASET expr expr expr RPAREN
       { let open Lambda in
@@ -285,7 +285,7 @@ expr:
             [access_array $3 $4 Arch.size_int; $5], Debuginfo.none) }
   | LPAREN FLOATASET expr expr expr RPAREN
       { let open Lambda in
-        Cop(Cstore (Double_u, Assignment),
+        Cop(Cstore (Double, Assignment),
             [access_array $3 $4 Arch.size_float; $5], Debuginfo.none) }
 ;
 exprlist:
@@ -325,7 +325,7 @@ chunk:
   | ADDR                        { Word_val }
   | FLOAT32                     { Single }
   | FLOAT64                     { Double }
-  | FLOAT                       { Double_u }
+  | FLOAT                       { Double }
   | VAL                         { Word_val }
 ;
 unaryop:


### PR DESCRIPTION
All current targets treat Double_u the same as Double. 
Double_u was [introduced](https://github.com/ocaml/ocaml/commit/c02c1359461e27ba91ccd8751f5855c50f9929f7) for sparc and mips, which treated it differently from Double.

This PR only makes changes in `ocaml` directory for now.