### PR TITLE
Gc.set incorrectly handles the three `custom_*` fields (backport upstream PR#10125)

### DIFF
--- a/ocaml/Changes
+++ b/ocaml/Changes
@@ -1449,6 +1449,16 @@ OCaml 4.09.0 (19 September 2019)
 - #8944: Fix "open struct .. end" on clambda backend
   (Thomas Refis, review by Leo White, report by Damon Wang and Mark Shinwell)
 
+OCaml 4.08 maintenance branch
+-----------------------------
+
+### Bug fixes:
+
+- #9326, #10125: Gc.set incorrectly handles the three `custom_*` fields,
+  causing a performance regression
+  (report by Emilio Jesús Gallego Arias, analysis and fix by Stephen Dolan,
+   code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)
+
 OCaml 4.08.1 (5 August 2019)
 ----------------------------
 

--- a/ocaml/runtime/gc_ctrl.c
+++ b/ocaml/runtime/gc_ctrl.c
@@ -471,21 +471,21 @@ CAMLprim value caml_gc_set(value v)
 
   /* These fields were added in 4.08.0. */
   if (Wosize_val (v) >= 11){
-    new_custom_maj = norm_custom_maj (Field (v, 8));
+    new_custom_maj = norm_custom_maj (Long_val (Field (v, 8)));
     if (new_custom_maj != caml_custom_major_ratio){
       caml_custom_major_ratio = new_custom_maj;
       caml_gc_message (0x20, "New custom major ratio: %"
                        ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
                        caml_custom_major_ratio);
     }
-    new_custom_min = norm_custom_min (Field (v, 9));
+    new_custom_min = norm_custom_min (Long_val (Field (v, 9)));
     if (new_custom_min != caml_custom_minor_ratio){
       caml_custom_minor_ratio = new_custom_min;
       caml_gc_message (0x20, "New custom minor ratio: %"
                        ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
                        caml_custom_minor_ratio);
     }
-    new_custom_sz = Field (v, 10);
+    new_custom_sz = Long_val (Field (v, 10));
     if (new_custom_sz != caml_custom_minor_max_bsz){
       caml_custom_minor_max_bsz = new_custom_sz;
       caml_gc_message (0x20, "New custom minor size limit: %"

--- a/ocaml/testsuite/tests/regression/pr9326/gc_set.ml
+++ b/ocaml/testsuite/tests/regression/pr9326/gc_set.ml
@@ -1,0 +1,35 @@
+(* TEST
+*)
+
+open Gc
+
+let min_heap_sz = 524288 (* 512k *)
+let maj_heap_inc = 4194304 (* 4M *)
+
+let _ =
+  let g1 = Gc.get() in
+  (* Do not use { g1 with ... }, so that the code will break if more fields
+     are added to the Gc.control record type *)
+  Gc.set { minor_heap_size = min_heap_sz;
+           major_heap_increment = maj_heap_inc;
+           space_overhead = g1.space_overhead;
+           verbose = g1.verbose;
+           max_overhead = g1.max_overhead;
+           stack_limit = g1.stack_limit;
+           allocation_policy = g1.allocation_policy;
+           window_size = g1.window_size;
+           custom_major_ratio = g1.custom_major_ratio;
+           custom_minor_ratio = g1.custom_minor_ratio;
+           custom_minor_max_size = g1.custom_minor_max_size };
+  let g2 = Gc.get() in
+  assert (g2.minor_heap_size = min_heap_sz);
+  assert (g2.major_heap_increment = maj_heap_inc);
+  assert (g2.space_overhead = g1.space_overhead);
+  assert (g2.verbose = g1.verbose);
+  assert (g2.max_overhead = g1.max_overhead);
+  assert (g2.stack_limit = g1.stack_limit);
+  assert (g2.allocation_policy = g1.allocation_policy);
+  assert (g2.window_size = g1.window_size);
+  assert (g2.custom_major_ratio = g1.custom_major_ratio);
+  assert (g2.custom_minor_ratio = g1.custom_minor_ratio);
+  assert (g2.custom_minor_max_size = g1.custom_minor_max_size)


### PR DESCRIPTION
Some `Long_val` conversions were missing.

This was setting the wrong values for the `custom_` parameters,
causing the major GC to work too much, slowing down some programs.

Add regression test.

Fixes: #9326