### PR TITLE
Change the result register for rdtsc and rdpmc intrinsics

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -963,22 +963,24 @@ let emit_instr fallthrough i =
       assert (!popcnt_support);
       I.popcnt (arg i 0) (res i 0)
   | Lop(Ispecific Irdtsc) ->
-    assert (reg64 i.res.(0) = RDX);
+    assert (reg64 i.res.(0) = RAX);
     I.rdtsc ();
+    let rdx = Reg64 RDX in
     (* The instruction fills in the low 32 bits of the result registers. *)
     (* Combine edx and eax into a single 64-bit result in rdx. *)
-    I.sal (int 32) (res i 0); (* shift edx to the high part of rdx *)
+    I.sal (int 32) rdx; (* shift edx to the high part of rdx *)
     (* On processors that support the Intel 64 architecture,
        the high-order 32 bits of each of RAX and RDX are cleared. *)
-    I.or_ rax (res i 0) (* combine high and low into rdx *)
+    I.or_ rdx (res i 0) (* combine high and low into rax *)
   | Lop(Ispecific Irdpmc) ->
-    assert ((arg64 i 0 = RCX) && (reg64 i.res.(0) = RDX));
+    assert ((arg64 i 0 = RCX) && (reg64 i.res.(0) = RAX));
     I.rdpmc ();
+    let rdx = Reg64 RDX in
     (* The instruction fills in the low 32 bits of the result registers. *)
     (* Combine edx and eax into a single 64-bit result in rdx. *)
-    I.sal (int 32) (res i 0); (* shift edx to the high part of rdx *)
+    I.sal (int 32) rdx; (* shift edx to the high part of rdx *)
     I.mov eax eax; (* zero-extend eax *)
-    I.or_ rax (res i 0) (* combine high and low into rdx *)
+    I.or_ rdx (res i 0) (* combine high and low into rax *)
   | Lop (Ispecific Icrc32q) ->
     assert (arg i 0 = res i 0);
     I.crc32 (arg i 1) (res i 0)

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -963,7 +963,6 @@ let emit_instr fallthrough i =
       assert (!popcnt_support);
       I.popcnt (arg i 0) (res i 0)
   | Lop(Ispecific Irdtsc) ->
-    assert (reg64 i.res.(0) = RAX);
     I.rdtsc ();
     let rdx = Reg64 RDX in
     (* The instruction fills in the low 32 bits of the result registers. *)
@@ -971,15 +970,21 @@ let emit_instr fallthrough i =
     I.sal (int 32) rdx; (* shift edx to the high part of rdx *)
     (* On processors that support the Intel 64 architecture,
        the high-order 32 bits of each of RAX and RDX are cleared. *)
-    I.or_ rdx (res i 0) (* combine high and low into rax *)
+    (match reg64 i.res.(0) with
+     | RAX -> I.or_ rdx (res i 0) (* combine high and low into rax *)
+     | RDX -> I.or_ rax (res i 0) (* combine high and low into rdx *)
+     | _ ->
+       (* combine high and low into res *)
+       I.mov rax (res i 0);
+       I.or_ rdx (res i 0))
   | Lop(Ispecific Irdpmc) ->
-    assert ((arg64 i 0 = RCX) && (reg64 i.res.(0) = RAX));
+    assert (arg64 i 0 = RCX);
     I.rdpmc ();
     let rdx = Reg64 RDX in
     (* The instruction fills in the low 32 bits of the result registers. *)
     (* Combine edx and eax into a single 64-bit result in rdx. *)
     I.sal (int 32) rdx; (* shift edx to the high part of rdx *)
-    I.mov eax eax; (* zero-extend eax *)
+    I.mov eax (res i 0); (* zero-extend eax *)
     I.or_ rdx (res i 0) (* combine high and low into rax *)
   | Lop (Ispecific Icrc32q) ->
     assert (arg i 0 = res i 0);

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -333,7 +333,7 @@ let destroyed_at_oper = function
       [| loc_spacetime_node_hole |]
   | Iswitch(_, _) -> [| rax; rdx |]
   | Itrywith _ -> [| r11 |]
-  | Iop(Ispecific(Irdtsc | Irdpmc)) -> [| rax |]
+  | Iop(Ispecific (Irdtsc | Irdpmc)) -> [| rdx |]
   | Iop(Ispecific(Isqrtf | Isextend32 | Izextend32 | Icrc32q | Ilea _
                  | Istore_int (_, _, _) | Ioffset_loc (_, _)
                  | Ifloatarithmem (_, _) | Ibswap _ | Ifloatsqrtf _))

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -333,7 +333,7 @@ let destroyed_at_oper = function
       [| loc_spacetime_node_hole |]
   | Iswitch(_, _) -> [| rax; rdx |]
   | Itrywith _ -> [| r11 |]
-  | Iop(Ispecific (Irdtsc | Irdpmc)) -> [| rdx |]
+  | Iop(Ispecific (Irdtsc | Irdpmc)) -> [| rax; rdx |]
   | Iop(Ispecific(Isqrtf | Isextend32 | Izextend32 | Icrc32q | Ilea _
                  | Istore_int (_, _, _) | Ioffset_loc (_, _)
                  | Ifloatarithmem (_, _) | Ibswap _ | Ifloatsqrtf _))

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -48,8 +48,8 @@ open Mach
      Ispecific(Ilea)            R       R       R
      Ispecific(Ifloatarithmem)  R       R       R
      Ispecific(Icrc32q)         R       R       S   (and Res = Arg1)
-     Ispecific(Irdtsc)          R                   (and Res = rdx)
-     Ispecific(Irdpmc)          R       R           (and Res = rdx, Arg1 = rcx)
+     Ispecific(Irdtsc)          R
+     Ispecific(Irdpmc)          R       R           (Arg1 = rcx)
 
    Conditional branches:
      Iinttest                           S       R
@@ -91,9 +91,11 @@ method! reload_operation op arg res =
       then (let r = self#makereg arg.(0) in ([|r; arg.(1)|], [|r|]))
       else (arg, res)
   | Ispecific (Irdtsc | Irdpmc) ->
-    (* Irdtsc: res(0) already forced in reg.
-       Irdpmc: res(0) and arg(0) already forced in regs. *)
-      (arg, res)
+      (* Irdtsc: result must be in register.
+         Irdpmc: result must be in register, arg.(0) already forced in reg. *)
+      if stackp res.(0)
+      then (let r = self#makereg res.(0) in (arg, [|r|]))
+      else (arg, res)
   | Ispecific Icrc32q ->
     (* First argument and result must be in the same register.
        Second argument can be either in a register or on stack. *)

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -122,14 +122,14 @@ let pseudoregs_for_operation op arg res =
       ([| rax; rcx |], [| rdx |])
   | Ispecific Irdtsc ->
   (* For rdtsc instruction, the result is in edx (high) and eax (low).
-     Make it simple and force the result in rdx and rax clobbered. *)
-    ([| |], [| rdx |])
+     Make it simple and force the result in rax and rdx clobbered. *)
+    ([| |], [| rax |])
   | Ispecific Irdpmc ->
   (* For rdpmc instruction, the argument must be in ecx
      and the result is in edx (high) and eax (low).
-     Make it simple and force the argument in rcx, the result in rdx,
-     and rax clobbered *)
-    ([| rcx |], [| rdx |])
+     Make it simple and force the argument in rcx, the result in rax,
+     and rdx clobbered *)
+    ([| rcx |], [| rax |])
   | Ispecific Icrc32q ->
     (* arg.(0) and res.(0) must be the same *)
     ([|res.(0); arg.(1)|], res)

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -120,16 +120,11 @@ let pseudoregs_for_operation op arg res =
       ([| rax; rcx |], [| rax |])
   | Iintop(Imod) ->
       ([| rax; rcx |], [| rdx |])
-  | Ispecific Irdtsc ->
-  (* For rdtsc instruction, the result is in edx (high) and eax (low).
-     Make it simple and force the result in rax and rdx clobbered. *)
-    ([| |], [| rax |])
   | Ispecific Irdpmc ->
   (* For rdpmc instruction, the argument must be in ecx
      and the result is in edx (high) and eax (low).
-     Make it simple and force the argument in rcx, the result in rax,
-     and rdx clobbered *)
-    ([| rcx |], [| rax |])
+     Make it simple and force the argument in rcx, and rax and rdx clobbered *)
+    ([| rcx |], res)
   | Ispecific Icrc32q ->
     (* arg.(0) and res.(0) must be the same *)
     ([|res.(0); arg.(1)|], res)


### PR DESCRIPTION
The first commit puts the result in rax instead of rdx. 
The second commit does not constrain the result register.

Result in rax is an improvement worth making, because rax is more commonly used in subsequent operations than rdx. It means the code is shorter (by 3 bytes for a mov instruction). Also may be better in term of instruction parallelism because rdx needs to be shifted left first.

The only saving from the second commit is when the result is in rdx to avoid a move. I am not sure if it is worth it.

I haven't observed any difference in performance in microbenchmarks between the base version and each of the two commits.