### PR TITLE
Workaround for a GNU make 3.81 bug

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -178,12 +178,16 @@ flags.sexp: ocaml-stage1-config.status
 	else \
 	  /bin/echo -n "(:standard)" > ocamlopt_flags.sexp; \
 	fi
-	/bin/echo -n "( $$(grep "^OC_CFLAGS=" ocaml/Makefile.config \
-		  	| sed 's/^OC_CFLAGS=//') )" > oc_cflags.sexp
-	/bin/echo -n "( $$(grep "^OC_CPPFLAGS=" ocaml/Makefile.config \
-		| sed 's/^OC_CPPFLAGS=//') )" > oc_cppflags.sexp
-	/bin/echo -n "( $$(grep "^SHAREDLIB_CFLAGS=" ocaml/Makefile.config \
-		| sed 's/^SHAREDLIB_CFLAGS=//') )" > sharedlib_cflags.sexp
+	# note: it looks like the use of "$(...)" with a command spanning over
+	# two lines triggers a bug in GNU make 3.81, that will as a consequence
+	# change the file name. It also looks like the bug is not triggered by
+	# "`...`".
+	/bin/echo -n "( `grep \"^OC_CFLAGS=\" ocaml/Makefile.config \
+		  	| sed 's/^OC_CFLAGS=//'` )" > oc_cflags.sexp
+	/bin/echo -n "( `grep \"^OC_CPPFLAGS=\" ocaml/Makefile.config \
+		| sed 's/^OC_CPPFLAGS=//'` )" > oc_cppflags.sexp
+	/bin/echo -n "( `grep \"^SHAREDLIB_CFLAGS=\" ocaml/Makefile.config \
+		| sed 's/^SHAREDLIB_CFLAGS=//'` )" > sharedlib_cflags.sexp
 
 # Most of the installation tree is correctly set up by dune, but we need to
 # copy it to the final destination, and rearrange a few things to match


### PR DESCRIPTION
It looks like GNU make 3.81 (which is for instance the default
on macOS 10.15.x) is misbehaving when a `$(...)` command
spans over two lines.

As a small reproduction case, the following Makefile:

```
default:
	echo '$$(true \
)' > some-extremely-long-file-name

.PHONY: default
```

will output:

```
echo '$(true )' > some-extremelyong-file-n-name
```

While (at least) versions 3.82 and 4.3 are not affected, this
pull request changes `$(...)` to ` `` `(which, as far as I can
tell, does not trigger the bug) to avoid puzzling build failures
on platforms using 3.81.