### PR TITLE
Make tailrec label optional

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -178,12 +178,16 @@ flags.sexp: ocaml-stage1-config.status
 	else \
 	  /bin/echo -n "(:standard)" > ocamlopt_flags.sexp; \
 	fi
-	/bin/echo -n "( $$(grep "^OC_CFLAGS=" ocaml/Makefile.config \
-		  	| sed 's/^OC_CFLAGS=//') )" > oc_cflags.sexp
-	/bin/echo -n "( $$(grep "^OC_CPPFLAGS=" ocaml/Makefile.config \
-		| sed 's/^OC_CPPFLAGS=//') )" > oc_cppflags.sexp
-	/bin/echo -n "( $$(grep "^SHAREDLIB_CFLAGS=" ocaml/Makefile.config \
-		| sed 's/^SHAREDLIB_CFLAGS=//') )" > sharedlib_cflags.sexp
+	# note: it looks like the use of "$(...)" with a command spanning over
+	# two lines triggers a bug in GNU make 3.81, that will as a consequence
+	# change the file name. It also looks like the bug is not triggered by
+	# "`...`".
+	/bin/echo -n "( `grep \"^OC_CFLAGS=\" ocaml/Makefile.config \
+		  	| sed 's/^OC_CFLAGS=//'` )" > oc_cflags.sexp
+	/bin/echo -n "( `grep \"^OC_CPPFLAGS=\" ocaml/Makefile.config \
+		| sed 's/^OC_CPPFLAGS=//'` )" > oc_cppflags.sexp
+	/bin/echo -n "( `grep \"^SHAREDLIB_CFLAGS=\" ocaml/Makefile.config \
+		| sed 's/^SHAREDLIB_CFLAGS=//'` )" > sharedlib_cflags.sexp
 
 # Most of the installation tree is correctly set up by dune, but we need to
 # copy it to the final destination, and rearrange a few things to match

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -566,7 +566,7 @@ let emit_named_text_section func_name =
 (* Name of current function *)
 let function_name = ref ""
 (* Entry point for tail recursive calls *)
-let tailrec_entry_point = ref 0
+let tailrec_entry_point = ref None
 
 (* Emit tracing probes *)
 
@@ -722,7 +722,9 @@ let emit_instr fallthrough i =
   | Lop(Itailcall_imm { func; label_after; }) ->
       begin
         if func = !function_name then
-          I.jmp (label !tailrec_entry_point)
+          match !tailrec_entry_point with
+          | None -> Misc.fatal_error "jump to missing tailrec entry point"
+          | Some tailrec_entry_point -> I.jmp (label tailrec_entry_point)
         else begin
           output_epilogue begin fun () ->
             add_used_symbol func;

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -138,7 +138,9 @@ let compile_fundecl ~ppf_dump fd_cmm =
       if !use_ocamlcfg then begin
         let cfg = Ocamlcfg.Cfg_with_layout.of_linear fd ~preserve_orig_labels:true in
         let fun_body = Ocamlcfg.Cfg_with_layout.to_linear cfg in
-        { fd with Linear.fun_body; }
+        let fun_tailrec_entry_point_label =
+          Ocamlcfg.Cfg.fun_tailrec_entry_point_label (Ocamlcfg.Cfg_with_layout.cfg cfg) in
+        { fd with Linear.fun_body; fun_tailrec_entry_point_label }
       end else
         fd)
   ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -55,7 +55,7 @@ let create ~fun_name ~fun_tailrec_entry_point_label ~fun_dbg =
     fun_dbg;
     entry_label = 1;
     blocks = Label.Tbl.create 31;
-    fun_tailrec_entry_point_label = Some fun_tailrec_entry_point_label
+    fun_tailrec_entry_point_label
   }
 
 let mem_block t label = Label.Tbl.mem t.blocks label

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -85,7 +85,7 @@ type t = private
             Otherwise, the [Prologue] falls through to this label. *)
   }
 
-val create : fun_name:string -> fun_tailrec_entry_point_label:Label.t ->
+val create : fun_name:string -> fun_tailrec_entry_point_label:Label.t option ->
   fun_dbg:Debuginfo.t -> t
 
 val fun_name : t -> string

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -80,7 +80,7 @@ type t = private
     fun_dbg : Debuginfo.t;  (** Dwarf debug info for function entry. *)
     entry_label : Label.t;
         (** This label must be the first in all layouts of this cfg. *)
-    mutable fun_tailrec_entry_point_label : Label.t
+    mutable fun_tailrec_entry_point_label : Label.t option
         (** When a [Prologue] is absent, this is the same as [entry_label].
             Otherwise, the [Prologue] falls through to this label. *)
   }
@@ -92,7 +92,7 @@ val fun_name : t -> string
 
 val entry_label : t -> Label.t
 
-val fun_tailrec_entry_point_label : t -> Label.t
+val fun_tailrec_entry_point_label : t -> Label.t option
 
 val predecessor_labels : basic_block -> Label.t list
 
@@ -117,7 +117,7 @@ val get_block : t -> Label.t -> basic_block option
 
 val get_block_exn : t -> Label.t -> basic_block
 
-val set_fun_tailrec_entry_point_label : t -> Label.t -> unit
+val set_fun_tailrec_entry_point_label : t -> Label.t option -> unit
 
 val iter_blocks : t -> f:(Label.t -> basic_block -> unit) -> unit
 

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -384,7 +384,7 @@ let print_assembly (blocks : Cfg.basic_block list) =
   (* create a fake cfg just for printing these blocks *)
   let layout = List.map (fun (b : Cfg.basic_block) -> b.start) blocks in
   let fun_name = "_fun_start_" in
-  let fun_tailrec_entry_point_label = 0 in
+  let fun_tailrec_entry_point_label = Some 0 in
   let cfg = Cfg.create ~fun_name ~fun_tailrec_entry_point_label
               ~fun_dbg:Debuginfo.none in
   List.iter

--- a/backend/cfg/eliminate_dead_blocks.ml
+++ b/backend/cfg/eliminate_dead_blocks.ml
@@ -64,7 +64,13 @@ let rec eliminate_dead_blocks cfg_with_layout =
       Printf.printf "\n" );
     (* Termination: the number of remaining blocks is strictly smaller in
        each recursive call. *)
-    eliminate_dead_blocks cfg_with_layout )
+    eliminate_dead_blocks cfg_with_layout;
+    begin match cfg.fun_tailrec_entry_point_label with
+    | None -> ()
+    | Some label ->
+      if List.exists (Label.equal label) found_dead then
+        Cfg.set_fun_tailrec_entry_point_label cfg None
+    end)
   else
     (* check that no blocks are left that are marked as dead *)
     C.iter_blocks cfg ~f:(fun label block ->

--- a/backend/cfg/eliminate_fallthrough_blocks.ml
+++ b/backend/cfg/eliminate_fallthrough_blocks.ml
@@ -71,7 +71,13 @@ let rec disconnect_fallthrough_blocks cfg_with_layout =
     if !C.verbose then
       Printf.printf "%s: disconnected fallthrough blocks: %d\n" cfg.fun_name
         len;
-    disconnect_fallthrough_blocks cfg_with_layout )
+    disconnect_fallthrough_blocks cfg_with_layout;
+    begin match cfg.fun_tailrec_entry_point_label with
+    | None -> ()
+    | Some label ->
+      if List.exists (Label.equal label) found then
+        Cfg.set_fun_tailrec_entry_point_label cfg None
+    end)
 
 let run cfg_with_layout =
   let cfg = CL.cfg cfg_with_layout in

--- a/backend/cfg/ocamlcfg.mli
+++ b/backend/cfg/ocamlcfg.mli
@@ -65,7 +65,7 @@ module Cfg : sig
 
   val entry_label : t -> Label.t
 
-  val fun_tailrec_entry_point_label : t -> Label.t
+  val fun_tailrec_entry_point_label : t -> Label.t option
 end
 
 module Cfg_with_layout : sig

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -54,7 +54,7 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
-    fun_tailrec_entry_point_label : label;
+    fun_tailrec_entry_point_label : label option;
     fun_contains_calls: bool;
     fun_num_stack_slots: int array;
     fun_frame_required: bool;

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -55,7 +55,7 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
-    fun_tailrec_entry_point_label : label;
+    fun_tailrec_entry_point_label : label option;
     fun_contains_calls: bool;
     fun_num_stack_slots: int array;
     fun_frame_required: bool;

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -334,7 +334,7 @@ let fundecl f =
     fun_fast = not (List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options);
     fun_dbg  = f.Mach.fun_dbg;
     fun_spacetime_shape = f.Mach.fun_spacetime_shape;
-    fun_tailrec_entry_point_label;
+    fun_tailrec_entry_point_label = Some fun_tailrec_entry_point_label;
     fun_contains_calls = contains_calls;
     fun_num_stack_slots = f.Mach.fun_num_stack_slots;
     fun_frame_required = Proc.frame_required f;


### PR DESCRIPTION
This pull request changes the type of the `fun_tailrec_entry_point_label`
field from `Label.t` to `Label.t option`. The rationale is that the block
acting as the "tailrec" entry point can be deleted by the fallthrough/dead
code optimization, leaving the field to point to a block not present in
the `blocks` field. While this did not trigger any issue in the current code,
it appears safer to keep the `fun_tailrec_entry_point_label` and `blocks`
fields consistent with each other.