### PR TITLE
Disconnect blocks with exceptional successors

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -178,12 +178,16 @@ flags.sexp: ocaml-stage1-config.status
 	else \
 	  /bin/echo -n "(:standard)" > ocamlopt_flags.sexp; \
 	fi
-	/bin/echo -n "( $$(grep "^OC_CFLAGS=" ocaml/Makefile.config \
-		  	| sed 's/^OC_CFLAGS=//') )" > oc_cflags.sexp
-	/bin/echo -n "( $$(grep "^OC_CPPFLAGS=" ocaml/Makefile.config \
-		| sed 's/^OC_CPPFLAGS=//') )" > oc_cppflags.sexp
-	/bin/echo -n "( $$(grep "^SHAREDLIB_CFLAGS=" ocaml/Makefile.config \
-		| sed 's/^SHAREDLIB_CFLAGS=//') )" > sharedlib_cflags.sexp
+	# note: it looks like the use of "$(...)" with a command spanning over
+	# two lines triggers a bug in GNU make 3.81, that will as a consequence
+	# change the file name. It also looks like the bug is not triggered by
+	# "`...`".
+	/bin/echo -n "( `grep \"^OC_CFLAGS=\" ocaml/Makefile.config \
+		  	| sed 's/^OC_CFLAGS=//'` )" > oc_cflags.sexp
+	/bin/echo -n "( `grep \"^OC_CPPFLAGS=\" ocaml/Makefile.config \
+		| sed 's/^OC_CPPFLAGS=//'` )" > oc_cppflags.sexp
+	/bin/echo -n "( `grep \"^SHAREDLIB_CFLAGS=\" ocaml/Makefile.config \
+		| sed 's/^SHAREDLIB_CFLAGS=//'` )" > sharedlib_cflags.sexp
 
 # Most of the installation tree is correctly set up by dune, but we need to
 # copy it to the final destination, and rearrange a few things to match

--- a/backend/cfg/disconnect_block.ml
+++ b/backend/cfg/disconnect_block.ml
@@ -43,9 +43,8 @@ let disconnect cfg_with_layout label =
     (* CR-someday gyorsh: if trap handlers can be eliminated, remove this
        label from block.exn of other blocks. *)
     Misc.fatal_error "Removing trap handler blocks is not supported";
-  let successors = C.successor_labels ~normal:true ~exn:true cfg block in
   let has_predecessors = not (Label.Set.is_empty block.predecessors) in
-  let n = Label.Set.cardinal successors in
+  let n = Label.Set.cardinal (C.successor_labels ~normal:true ~exn:false cfg block) in
   let has_more_than_one_successor = n > 1 in
   if !C.verbose then Printf.printf "Disconnect %d in %s\n" label cfg.fun_name;
   if has_more_than_one_successor && has_predecessors then
@@ -56,6 +55,7 @@ let disconnect cfg_with_layout label =
        least one predecessor"
       Label.print label;
   (* Update successor blocks. *)
+  let successors = C.successor_labels ~normal:true ~exn:true cfg block in
   Label.Set.iter
     (fun succ ->
       let succ_block = C.get_block_exn cfg succ in

--- a/backend/cfg/disconnect_block.ml
+++ b/backend/cfg/disconnect_block.ml
@@ -43,8 +43,9 @@ let disconnect cfg_with_layout label =
     (* CR-someday gyorsh: if trap handlers can be eliminated, remove this
        label from block.exn of other blocks. *)
     Misc.fatal_error "Removing trap handler blocks is not supported";
+  let successors = C.successor_labels ~normal:true ~exn:false cfg block in
   let has_predecessors = not (Label.Set.is_empty block.predecessors) in
-  let n = Label.Set.cardinal (C.successor_labels ~normal:true ~exn:false cfg block) in
+  let n = Label.Set.cardinal successors in
   let has_more_than_one_successor = n > 1 in
   if !C.verbose then Printf.printf "Disconnect %d in %s\n" label cfg.fun_name;
   if has_more_than_one_successor && has_predecessors then
@@ -55,7 +56,6 @@ let disconnect cfg_with_layout label =
        least one predecessor"
       Label.print label;
   (* Update successor blocks. *)
-  let successors = C.successor_labels ~normal:true ~exn:true cfg block in
   Label.Set.iter
     (fun succ ->
       let succ_block = C.get_block_exn cfg succ in
@@ -65,6 +65,12 @@ let disconnect cfg_with_layout label =
           (Label.Set.remove label succ_block.predecessors)
           block.predecessors)
     successors;
+  Label.Set.iter
+    (fun succ ->
+       let succ_block = C.get_block_exn cfg succ in
+       assert (Label.Set.mem label succ_block.predecessors);
+       succ_block.predecessors <- Label.Set.remove label succ_block.predecessors)
+    (C.successor_labels ~normal:false ~exn:true cfg block);
   (* Update predecessor blocks. *)
   if n = 1 then
     let target_label = Label.Set.min_elt successors in


### PR DESCRIPTION
We currently only allow the disconnection of empty blocks with
no more than one successor. It seems safe, however, to *not* take
into account exceptional successors when we perform the check.

This pull request does exactly that, but ensures that the set of
predecessors of any exceptional successor is properly updated.