### PR TITLE
Change the way the label for tailrec calls is stored

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -566,7 +566,7 @@ let emit_named_text_section func_name =
 (* Name of current function *)
 let function_name = ref ""
 (* Entry point for tail recursive calls *)
-let tailrec_entry_point = ref 0
+let tailrec_entry_point = ref None
 
 (* Emit tracing probes *)
 
@@ -722,7 +722,9 @@ let emit_instr fallthrough i =
   | Lop(Itailcall_imm { func; label_after; }) ->
       begin
         if func = !function_name then
-          I.jmp (label !tailrec_entry_point)
+          match !tailrec_entry_point with
+          | None -> Misc.fatal_error "jump to missing tailrec entry point"
+          | Some tailrec_entry_point -> I.jmp (label tailrec_entry_point)
         else begin
           output_epilogue begin fun () ->
             add_used_symbol func;

--- a/backend/arm/emit.mlp
+++ b/backend/arm/emit.mlp
@@ -281,7 +281,7 @@ let output_epilogue f =
 (* Name of current function *)
 let function_name = ref ""
 (* Entry point for tail recursive calls *)
-let tailrec_entry_point = ref 0
+let tailrec_entry_point = ref None
 (* Pending floating-point literals *)
 let float_literals = ref ([] : (int64 * label) list)
 (* Pending relative references to the global offset table *)
@@ -474,7 +474,9 @@ let emit_instr i =
           0
         end
       in
-      `{emit_label !tailrec_entry_point}:\n`;
+      (match !tailrec_entry_point with
+      | None -> Misc.fatal_error "jump to missing tailrec entry point"
+      | Some tailrec_entry_point -> `{emit_label tailrec_entry_point}:\n`);
       num_instrs
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
@@ -559,7 +561,9 @@ let emit_instr i =
         end
     | Lop(Itailcall_imm { func; label_after = _; }) ->
         if func = !function_name then begin
-          `	b	{emit_label !tailrec_entry_point}\n`; 1
+          (match !tailrec_entry_point with
+          | None -> Misc.fatal_error "jump to missing tailrec entry point"
+          | Some tailrec_entry_point -> `	b	{emit_label tailrec_entry_point}\n`); 1
         end else begin
           output_epilogue begin fun () ->
             if !contains_calls then

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -304,7 +304,7 @@ let output_epilogue f =
 (* Name of current function *)
 let function_name = ref ""
 (* Entry point for tail recursive calls *)
-let tailrec_entry_point = ref 0
+let tailrec_entry_point = ref None
 (* Pending floating-point literals *)
 let float_literals = ref ([] : (int64 * label) list)
 
@@ -630,7 +630,9 @@ let emit_instr i =
         output_epilogue (fun () -> `	br	{emit_reg i.arg.(0)}\n`)
     | Lop(Itailcall_imm { func; label_after = _; }) ->
         if func = !function_name then
-          `	b	{emit_label !tailrec_entry_point}\n`
+          match !tailrec_entry_point with
+          | None -> Misc.fatal_error "jump to missing tailrec entry point"
+          | Some tailrec_entry_point -> `	b	{emit_label tailrec_entry_point}\n`
         else
           output_epilogue (fun () -> `	b	{emit_symbol func}\n`)
     | Lop(Iextcall { func; alloc = false; label_after = _; }) ->

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -137,8 +137,9 @@ let compile_fundecl ~ppf_dump fd_cmm =
   ++ (fun (fd : Linear.fundecl) ->
       if !use_ocamlcfg then begin
         let cfg = Linear_to_cfg.run fd ~preserve_orig_labels:true in
-        let fun_body = Cfg_to_linear.run cfg in
-        { fd with Linear.fun_body; }
+        let fun_body, tailrec_label = Cfg_to_linear.run cfg in
+        let fun_tailrec_entry_point_label = Option.value tailrec_label ~default:(-1) in
+        { fd with Linear.fun_body; fun_tailrec_entry_point_label; }
       end else
         fd)
   ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -137,8 +137,7 @@ let compile_fundecl ~ppf_dump fd_cmm =
   ++ (fun (fd : Linear.fundecl) ->
       if !use_ocamlcfg then begin
         let cfg = Linear_to_cfg.run fd ~preserve_orig_labels:true in
-        let fun_body, tailrec_label = Cfg_to_linear.run cfg in
-        let fun_tailrec_entry_point_label = Option.value tailrec_label ~default:(-1) in
+        let fun_body, fun_tailrec_entry_point_label = Cfg_to_linear.run cfg in
         { fd with Linear.fun_body; fun_tailrec_entry_point_label; }
       end else
         fd)

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -109,11 +109,9 @@ let replace_successor_labels t ~normal ~exn block ~f =
           Float_test { lt = f lt; eq = f eq; gt = f gt; uo = f uo }
       | Switch labels -> Switch (Array.map f labels)
       | Tailcall (Self { destination; label_after; }) ->
-        Tailcall (Self { destination = f destination; label_after = f label_after; })
-      | Tailcall (Func (Indirect { label_after; })) ->
-        Tailcall (Func (Indirect { label_after = f label_after; }))
-      | Tailcall (Func (Direct { func_symbol; label_after; })) ->
-        Tailcall (Func (Direct { func_symbol; label_after = f label_after; }))
+        Tailcall (Self { destination = f destination; label_after; })
+      | Tailcall (Func (Indirect _))
+      | Tailcall (Func (Direct _))
       | Return | Raise _  -> block.terminator.desc
     in
     block.terminator <- { block.terminator with desc }

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -80,24 +80,18 @@ type t = private
     fun_dbg : Debuginfo.t;  (** Dwarf debug info for function entry. *)
     entry_label : Label.t;
         (** This label must be the first in all layouts of this cfg. *)
-    mutable fun_tailrec_entry_point_label : Label.t
-        (** When a [Prologue] is absent, this is the same as [entry_label].
-            Otherwise, the [Prologue] falls through to this label. *)
   }
 
-val create : fun_name:string -> fun_tailrec_entry_point_label:Label.t ->
-  fun_dbg:Debuginfo.t -> t
+val create : fun_name:string -> fun_dbg:Debuginfo.t -> t
 
 val fun_name : t -> string
 
 val entry_label : t -> Label.t
 
-val fun_tailrec_entry_point_label : t -> Label.t
-
 val predecessor_labels : basic_block -> Label.t list
 
 val successor_labels :
-  t -> normal:bool -> exn:bool -> basic_block -> Label.Set.t
+  normal:bool -> exn:bool -> basic_block -> Label.Set.t
 (** [exn] does not account for exceptional flow from the block that goes
     outside of the function. *)
 
@@ -116,8 +110,6 @@ val remove_block_exn : t -> Label.t -> unit
 val get_block : t -> Label.t -> basic_block option
 
 val get_block_exn : t -> Label.t -> basic_block
-
-val set_fun_tailrec_entry_point_label : t -> Label.t -> unit
 
 val iter_blocks : t -> f:(Label.t -> basic_block -> unit) -> unit
 

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -38,7 +38,7 @@ module S = struct
         }
 
   type tail_call_operation =
-    | Self of { label_after : Label.t }
+    | Self of { destination : Label.t; label_after : Label.t }
     | Func of func_call_operation
 
   type prim_call_operation =

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -179,7 +179,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
         [L.Lop (Itailcall_ind { label_after })]
     | Tailcall (Func (Direct { func_symbol; label_after })) ->
         [L.Lop (Itailcall_imm { func = func_symbol; label_after })]
-    | Tailcall (Self { label_after }) ->
+    | Tailcall (Self { destination = _; label_after }) ->
         [L.Lop (Itailcall_imm { func = Cfg.fun_name cfg; label_after })]
     | Switch labels -> [L.Lswitch labels]
     | Never -> Misc.fatal_error "Cannot linearize terminator: Never"
@@ -385,8 +385,7 @@ let print_assembly (blocks : Cfg.basic_block list) =
   let layout = List.map (fun (b : Cfg.basic_block) -> b.start) blocks in
   let fun_name = "_fun_start_" in
   let fun_tailrec_entry_point_label = 0 in
-  let cfg = Cfg.create ~fun_name ~fun_tailrec_entry_point_label
-              ~fun_dbg:Debuginfo.none in
+  let cfg = Cfg.create ~fun_name ~fun_dbg:Debuginfo.none in
   List.iter
     (fun (block : Cfg.basic_block) ->
        Label.Tbl.add cfg.blocks block.start block)

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -149,7 +149,7 @@ let mk_float_cond ~lt ~eq ~gt ~uo =
   | true, false, false, true -> Must_be_last
 
 let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
-    ~(next : Linear_utils.labelled_insn) =
+    ~(next : Linear_utils.labelled_insn) : L.instruction * Label.t option =
   (* CR-someday gyorsh: refactor, a lot of redundant code for different cases *)
   (* CR-someday gyorsh: for successor labels that are not fallthrough, order
      of branch instructions should depend on perf data and possibly the
@@ -171,23 +171,23 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
         if Label.equal l1 l2 then [L.Lbranch l1]
         else [L.Lcondbranch (c1, l1); L.Lbranch l2]
   in
-  let desc_list =
+  let desc_list, tailrec_label =
     match terminator.desc with
-    | Return -> [L.Lreturn]
-    | Raise kind -> [L.Lraise kind]
+    | Return -> [L.Lreturn], None
+    | Raise kind -> [L.Lraise kind], None
     | Tailcall (Func (Indirect { label_after })) ->
-        [L.Lop (Itailcall_ind { label_after })]
+      [L.Lop (Itailcall_ind { label_after })], None
     | Tailcall (Func (Direct { func_symbol; label_after })) ->
-        [L.Lop (Itailcall_imm { func = func_symbol; label_after })]
-    | Tailcall (Self { destination = _; label_after }) ->
-        [L.Lop (Itailcall_imm { func = Cfg.fun_name cfg; label_after })]
-    | Switch labels -> [L.Lswitch labels]
+      [L.Lop (Itailcall_imm { func = func_symbol; label_after })], None
+    | Tailcall (Self { destination; label_after }) ->
+        [L.Lop (Itailcall_imm { func = Cfg.fun_name cfg; label_after })], Some destination
+    | Switch labels -> [L.Lswitch labels], None
     | Never -> Misc.fatal_error "Cannot linearize terminator: Never"
-    | Always label -> branch_or_fallthrough label
+    | Always label -> branch_or_fallthrough label, None
     | Parity_test { ifso; ifnot } ->
-        emit_bool (Ieventest, ifso) (Ioddtest, ifnot)
+      emit_bool (Ieventest, ifso) (Ioddtest, ifnot), None
     | Truth_test { ifso; ifnot } ->
-        emit_bool (Itruetest, ifso) (Ifalsetest, ifnot)
+      emit_bool (Itruetest, ifso) (Ifalsetest, ifnot), None
     | Float_test { lt; eq; gt; uo } -> (
         let successor_labels =
           Label.Set.singleton lt |> Label.Set.add gt |> Label.Set.add eq
@@ -195,7 +195,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
         in
         match Label.Set.cardinal successor_labels with
         | 0 -> assert false
-        | 1 -> branch_or_fallthrough (Label.Set.min_elt successor_labels)
+        | 1 -> branch_or_fallthrough (Label.Set.min_elt successor_labels), None
         | 2 | 3 | 4 ->
             let must_be_last, any =
               Label.Set.fold
@@ -240,7 +240,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
                   else Some (L.Lcondbranch (Ifloattest c, lbl)))
                 any
             in
-            branches @ branch_or_fallthrough last
+            branches @ branch_or_fallthrough last, None
         | _ -> assert false )
     | Int_test { lt; eq; gt; imm; is_signed } -> (
         let successor_labels =
@@ -248,7 +248,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
         in
         match Label.Set.cardinal successor_labels with
         | 0 -> assert false
-        | 1 -> branch_or_fallthrough (Label.Set.min_elt successor_labels)
+        | 1 -> branch_or_fallthrough (Label.Set.min_elt successor_labels), None
         | 2 | 3 ->
             (* If fallthrough label is a successor, do not emit a jump for
                it. Otherwise, the last jump could be unconditional. *)
@@ -276,7 +276,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
               let find l =
                 if Label.equal next.label l then None else Some l
               in
-              [L.Lcondbranch3 (find lt, find eq, find gt)]
+              [L.Lcondbranch3 (find lt, find eq, find gt)], None
             else
               let init = branch_or_fallthrough last in
               Label.Set.fold
@@ -296,12 +296,12 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
                     | Some n -> Mach.Iinttest_imm (comp, n)
                   in
                   L.Lcondbranch (test, lbl) :: acc)
-                cond_successor_labels init
+                cond_successor_labels init, None
         | _ -> assert false )
   in
   List.fold_left
     (fun next desc -> to_linear_instr ~like:terminator desc ~next)
-    next.insn (List.rev desc_list)
+    next.insn (List.rev desc_list), tailrec_label
 
 let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
     ~(prev_block : Cfg.basic_block) =
@@ -345,6 +345,7 @@ let run cfg_with_layout =
   let layout = Array.of_list (CL.layout cfg_with_layout) in
   let len = Array.length layout in
   let next = ref Linear_utils.labelled_insn_end in
+  let tailrec_label = ref None in
   for i = len - 1 downto 0 do
     let label = layout.(i) in
     if not (Label.Tbl.mem cfg.blocks label) then
@@ -352,9 +353,15 @@ let run cfg_with_layout =
     let block = Label.Tbl.find cfg.blocks label in
     assert (Label.equal label block.start);
     let body =
-      let terminator =
+      let terminator, terminator_tailrec_label =
         linearize_terminator cfg block.terminator ~next:!next
       in
+      (match !tailrec_label, terminator_tailrec_label with
+       | (Some _ | None), None -> ()
+       | None, Some _ -> tailrec_label := terminator_tailrec_label
+       | Some old_trl, Some new_trl ->
+         assert (Label.equal old_trl new_trl);
+         tailrec_label := terminator_tailrec_label);
       List.fold_left
         (fun next i -> basic_to_linear i ~next)
         terminator (List.rev block.body)
@@ -377,14 +384,14 @@ let run cfg_with_layout =
     in
     next := { Linear_utils.label; insn }
   done;
-  !next.insn
+  !next.insn, !tailrec_label
 
 (** debug print block as assembly *)
 let print_assembly (blocks : Cfg.basic_block list) =
   (* create a fake cfg just for printing these blocks *)
   let layout = List.map (fun (b : Cfg.basic_block) -> b.start) blocks in
   let fun_name = "_fun_start_" in
-  let fun_tailrec_entry_point_label = 0 in
+  
   let cfg = Cfg.create ~fun_name ~fun_dbg:Debuginfo.none in
   List.iter
     (fun (block : Cfg.basic_block) ->
@@ -394,7 +401,8 @@ let print_assembly (blocks : Cfg.basic_block list) =
     Cfg_with_layout.create cfg ~layout ~new_labels:Label.Set.empty
       ~preserve_orig_labels:true
   in
-  let fun_body = run cl in
+  let fun_body, tailrec_label = run cl in
+  let fun_tailrec_entry_point_label = Option.value tailrec_label ~default:0 in
   let fundecl =
     { Linear.fun_name;
       fun_body;

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -359,9 +359,7 @@ let run cfg_with_layout =
       (match !tailrec_label, terminator_tailrec_label with
        | (Some _ | None), None -> ()
        | None, Some _ -> tailrec_label := terminator_tailrec_label
-       | Some old_trl, Some new_trl ->
-         assert (Label.equal old_trl new_trl);
-         tailrec_label := terminator_tailrec_label);
+       | Some old_trl, Some new_trl -> assert (Label.equal old_trl new_trl));
       List.fold_left
         (fun next i -> basic_to_linear i ~next)
         terminator (List.rev block.body)
@@ -391,7 +389,6 @@ let print_assembly (blocks : Cfg.basic_block list) =
   (* create a fake cfg just for printing these blocks *)
   let layout = List.map (fun (b : Cfg.basic_block) -> b.start) blocks in
   let fun_name = "_fun_start_" in
-  
   let cfg = Cfg.create ~fun_name ~fun_dbg:Debuginfo.none in
   List.iter
     (fun (block : Cfg.basic_block) ->
@@ -401,8 +398,7 @@ let print_assembly (blocks : Cfg.basic_block list) =
     Cfg_with_layout.create cfg ~layout ~new_labels:Label.Set.empty
       ~preserve_orig_labels:true
   in
-  let fun_body, tailrec_label = run cl in
-  let fun_tailrec_entry_point_label = Option.value tailrec_label ~default:0 in
+  let fun_body, fun_tailrec_entry_point_label = run cl in
   let fundecl =
     { Linear.fun_name;
       fun_body;

--- a/backend/cfg/cfg_to_linear.mli
+++ b/backend/cfg/cfg_to_linear.mli
@@ -27,6 +27,6 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-val run : Cfg_with_layout.t -> Linear.instruction
+val run : Cfg_with_layout.t -> Linear.instruction * Label.t option
 
 val print_assembly : Cfg.basic_block list -> unit

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -81,10 +81,10 @@ let print t oc msg =
     Label.Set.iter (Printf.fprintf oc " %d") block.predecessors;
     Printf.fprintf oc "\nsuccessors:";
     Label.Set.iter (Printf.fprintf oc " %d")
-      (Cfg.successor_labels ~normal:true ~exn:false t.cfg block);
+      (Cfg.successor_labels ~normal:true ~exn:false block);
     Printf.fprintf oc "\nexn-successors:";
     Label.Set.iter (Printf.fprintf oc " %d")
-      (Cfg.successor_labels ~normal:false ~exn:true t.cfg block)
+      (Cfg.successor_labels ~normal:false ~exn:true block)
   in
   List.iter print_block t.layout
 
@@ -127,13 +127,13 @@ let print_dot t ?(show_instr = true) ?(show_exn = true) ?annotate_block
       (fun l ->
         Printf.fprintf oc "%s->%s[%s]\n" (name label) (name l)
           (annotate_succ label l))
-      (Cfg.successor_labels ~normal:true ~exn:false t.cfg block);
+      (Cfg.successor_labels ~normal:true ~exn:false block);
     if show_exn then (
       Label.Set.iter
         (fun l ->
           Printf.fprintf oc "%s->%s [style=dashed %s]\n" (name label)
             (name l) (annotate_succ label l))
-        (Cfg.successor_labels ~normal:false ~exn:true t.cfg block);
+        (Cfg.successor_labels ~normal:false ~exn:true block);
       if block.can_raise_interproc then
         Printf.fprintf oc "%s->%s [style=dashed]\n" (name label)
           "placeholder" )

--- a/backend/cfg/disconnect_block.ml
+++ b/backend/cfg/disconnect_block.ml
@@ -70,7 +70,7 @@ let disconnect cfg_with_layout label =
        let succ_block = C.get_block_exn cfg succ in
        assert (Label.Set.mem label succ_block.predecessors);
        succ_block.predecessors <- Label.Set.remove label succ_block.predecessors)
-    (C.successor_labels ~normal:false ~exn:true cfg block);
+    (C.successor_labels ~normal:false ~exn:true block);
   (* Update predecessor blocks. *)
   if n = 1 then
     let target_label = Label.Set.min_elt successors in

--- a/backend/cfg/disconnect_block.ml
+++ b/backend/cfg/disconnect_block.ml
@@ -43,7 +43,7 @@ let disconnect cfg_with_layout label =
     (* CR-someday gyorsh: if trap handlers can be eliminated, remove this
        label from block.exn of other blocks. *)
     Misc.fatal_error "Removing trap handler blocks is not supported";
-  let successors = C.successor_labels ~normal:true ~exn:true cfg block in
+  let successors = C.successor_labels ~normal:true ~exn:true block in
   let has_predecessors = not (Label.Set.is_empty block.predecessors) in
   let n = Label.Set.cardinal successors in
   let has_more_than_one_successor = n > 1 in

--- a/backend/cfg/eliminate_fallthrough_blocks.ml
+++ b/backend/cfg/eliminate_fallthrough_blocks.ml
@@ -39,7 +39,7 @@ let is_fallthrough_block cfg_with_layout (block : C.basic_block) =
        can raise and has a single successor. *)
   then None
   else
-    let successors = C.successor_labels ~normal:true ~exn:false cfg block in
+    let successors = C.successor_labels ~normal:true ~exn:false block in
     if Label.Set.cardinal successors = 1 then
       let target_label = Label.Set.min_elt successors in
       if Label.equal target_label block.start then None (* self-loop *)

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -195,7 +195,7 @@ let register_block t (block : C.basic_block) traps =
   (* Update trap stacks of normal successor blocks. *)
   Label.Set.iter
     (fun label -> record_traps t label traps)
-    (C.successor_labels t.cfg ~normal:true ~exn:false block);
+    (C.successor_labels ~normal:true ~exn:false block);
   (* Update trap stacks of exns successors. For each trap stack [s] in
      [t.exns]: The handler is the block identified by the label on the top of
      [s]. The trap stack of the handler must be the same as (pop [s]). The
@@ -324,7 +324,7 @@ let check_and_register_traps t =
 let register_predecessors_for_all_blocks t =
   Label.Tbl.iter
     (fun label block ->
-      let targets = C.successor_labels ~normal:true ~exn:true t.cfg block in
+      let targets = C.successor_labels ~normal:true ~exn:true block in
       Label.Set.iter
         (fun target ->
           let target_block = Label.Tbl.find t.cfg.blocks target in
@@ -454,8 +454,8 @@ let to_basic (mop : Mach.operation) : C.basic =
 
 (** [traps] represents the trap stack, with head being the top. [trap_depths]
     is the depth of the trap stack. *)
-let rec create_blocks t (i : L.instruction) (block : C.basic_block)
-    ~trap_depth ~traps =
+let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
+    ~tailrec_label ~trap_depth ~traps =
   (* [traps] is constructed incrementally, because Ladjust_trap does not give
      enough information to compute it upfront, but trap_depth is directly
      computed. *)
@@ -483,13 +483,13 @@ let rec create_blocks t (i : L.instruction) (block : C.basic_block)
         register_block t block traps );
       (* CR-someday gyorsh: check for multiple consecutive labels *)
       let new_block = create_empty_block t start ~trap_depth ~traps in
-      create_blocks t i.next new_block ~trap_depth ~traps
+      create_blocks t i.next new_block ~tailrec_label ~trap_depth ~traps
   | Lreturn ->
       if trap_depth <> 1 then
         Misc.fatal_errorf "Trap depth is %d, but it must be 1 at Lreturn"
           trap_depth;
       add_terminator t block i Return ~trap_depth ~traps;
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Lraise kind ->
       (* CR-someday gyorsh: Why does the compiler not generate adjust after
          raise? raise pops the trap handler stack and then the next block may
@@ -503,11 +503,11 @@ let rec create_blocks t (i : L.instruction) (block : C.basic_block)
          gyorsh: it is now handled in register_block called from
          add_terminator. *)
       add_terminator t block i (Raise kind) ~trap_depth ~traps;
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Lbranch lbl ->
       if !C.verbose then Printf.printf "Lbranch %d\n" lbl;
       add_terminator t block i (Always lbl) ~trap_depth ~traps;
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Lcondbranch (cond, lbl) ->
       (* This representation does not preserve the order of successors. *)
       let fallthrough = get_or_make_label t i.next in
@@ -524,7 +524,7 @@ let rec create_blocks t (i : L.instruction) (block : C.basic_block)
             Int_test (mk_int_test cmp ~lbl ~inv ~imm:(Some n))
       in
       add_terminator t block i desc ~trap_depth ~traps;
-      create_blocks t fallthrough.insn block ~trap_depth ~traps
+      create_blocks t fallthrough.insn block ~tailrec_label ~trap_depth ~traps
   | Lcondbranch3 (lbl0, lbl1, lbl2) ->
       let fallthrough = get_or_make_label t i.next in
       let get_dest lbl = Option.value lbl ~default:fallthrough.label in
@@ -537,12 +537,12 @@ let rec create_blocks t (i : L.instruction) (block : C.basic_block)
         }
       in
       add_terminator t block i (Int_test it) ~trap_depth ~traps;
-      create_blocks t fallthrough.insn block ~trap_depth ~traps
+      create_blocks t fallthrough.insn block ~tailrec_label ~trap_depth ~traps
   | Lswitch labels ->
       (* CR-someday gyorsh: get rid of switches entirely and re-generate them
          based on optimization and perf data? *)
       add_terminator t block i (Switch labels) ~trap_depth ~traps;
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Ladjust_trap_depth { delta_traps } ->
       (* We do not emit any executable code for this insn; it only moves the
          virtual stack pointer in the emitter. We do not have a corresponding
@@ -556,7 +556,7 @@ let rec create_blocks t (i : L.instruction) (block : C.basic_block)
           "Ladjust_trap_depth %d moves the trap depth below zero: %d"
           delta_traps trap_depth;
       let traps = T.unknown () in
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Lpushtrap { lbl_handler } ->
       t.trap_handlers <- Label.Set.add lbl_handler t.trap_handlers;
       record_traps t lbl_handler traps;
@@ -564,7 +564,7 @@ let rec create_blocks t (i : L.instruction) (block : C.basic_block)
       block.body <- create_instruction t desc ~trap_depth i :: block.body;
       let trap_depth = trap_depth + 1 in
       let traps = T.push traps lbl_handler in
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Lpoptrap ->
       let desc = C.Poptrap in
       block.body <- create_instruction t desc ~trap_depth i :: block.body;
@@ -578,34 +578,34 @@ let rec create_blocks t (i : L.instruction) (block : C.basic_block)
       if !C.verbose then (
         Printf.printf "after pop: ";
         T.print traps );
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Lentertrap ->
       (* Must be the first instruction in the block. *)
       assert (List.compare_length_with block.body 0 = 0);
       block.is_trap_handler <- true;
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Lprologue ->
       let desc = C.Prologue in
       block.body <- create_instruction t desc i ~trap_depth :: block.body;
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Lreloadretaddr ->
       let desc = C.Reloadretaddr in
       block.body <- create_instruction t desc i ~trap_depth :: block.body;
-      create_blocks t i.next block ~trap_depth ~traps
+      create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
   | Lop mop -> (
       match mop with
       | Itailcall_ind { label_after } ->
           let desc = C.Tailcall (Func (Indirect { label_after })) in
           add_terminator t block i desc ~trap_depth ~traps;
-          create_blocks t i.next block ~trap_depth ~traps
+          create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
       | Itailcall_imm { func = func_symbol; label_after } ->
           let desc =
             if String.equal func_symbol (C.fun_name t.cfg) then
-              C.Tailcall (Self { label_after })
+              C.Tailcall (Self { destination = tailrec_label; label_after })
             else C.Tailcall (Func (Direct { func_symbol; label_after }))
           in
           add_terminator t block i desc ~trap_depth ~traps;
-          create_blocks t i.next block ~trap_depth ~traps
+          create_blocks t i.next block ~tailrec_label ~trap_depth ~traps
       | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf
       | Idivf | Ifloatofint | Iintoffloat | Iconst_int _ | Iconst_float _
       | Iconst_symbol _ | Icall_ind _ | Icall_imm _ | Iextcall _
@@ -619,13 +619,12 @@ let rec create_blocks t (i : L.instruction) (block : C.basic_block)
           let desc = to_basic mop in
           block.body <- create_instruction t desc i ~trap_depth :: block.body;
           if Mach.operation_can_raise mop then record_exn t block traps;
-          create_blocks t i.next block ~trap_depth ~traps )
+          create_blocks t i.next block ~tailrec_label ~trap_depth ~traps )
 
 let run (f : Linear.fundecl) ~preserve_orig_labels =
   let t =
     let cfg =
       Cfg.create ~fun_name:f.fun_name ~fun_dbg:f.fun_dbg
-        ~fun_tailrec_entry_point_label:f.fun_tailrec_entry_point_label
     in
     create cfg
   in
@@ -641,7 +640,8 @@ let run (f : Linear.fundecl) ~preserve_orig_labels =
   let entry_block =
     create_empty_block t t.cfg.entry_label ~trap_depth ~traps
   in
-  create_blocks t f.fun_body entry_block ~trap_depth ~traps;
+  create_blocks t f.fun_body entry_block
+    ~tailrec_label:f.fun_tailrec_entry_point_label ~trap_depth ~traps;
   (* Register predecessors now rather than during cfg construction, because
      of forward jumps: the blocks do not exist when the jump that reference
      them is processed. *)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -87,18 +87,18 @@ let simplify_switch (block : C.basic_block) labels =
    order. Also, for linear to cfg and back will be harder to generate exactly
    the same layout. Also, how do we map execution counts about branches onto
    this terminator? *)
-let block cfg (block : C.basic_block) =
+let block (block : C.basic_block) =
   match block.terminator.desc with
   | Always _ -> ()
   | Never ->
       Misc.fatal_errorf "Cannot simplify terminator: Never (in block %d)"
         block.start
   | Parity_test _ | Truth_test _ | Int_test _ | Float_test _ ->
-      let labels = C.successor_labels cfg ~normal:true ~exn:false block in
+      let labels = C.successor_labels ~normal:true ~exn:false block in
       if Label.Set.cardinal labels = 1 then
         let l = Label.Set.min_elt labels in
         block.terminator <- { block.terminator with desc = Always l }
   | Switch labels -> simplify_switch block labels
   | Tailcall (Self _ | Func _) | Raise _ | Return -> ()
 
-let run cfg = C.iter_blocks cfg ~f:(fun _ b -> block cfg b)
+let run cfg = C.iter_blocks cfg ~f:(fun _ b -> block b)

--- a/backend/cfg/simplify_terminator.mli
+++ b/backend/cfg/simplify_terminator.mli
@@ -28,6 +28,6 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-val block : Cfg.t -> Cfg.basic_block -> unit
+val block : Cfg.basic_block -> unit
 
 val run : Cfg.t -> unit

--- a/backend/i386/emit.mlp
+++ b/backend/i386/emit.mlp
@@ -486,7 +486,7 @@ let emit_named_text_section func_name =
 (* Name of current function *)
 let function_name = ref ""
 (* Entry point for tail recursive calls *)
-let tailrec_entry_point = ref 0
+let tailrec_entry_point = ref None
 
 let emit_instr fallthrough i =
   emit_debug_info i.dbg;
@@ -551,7 +551,9 @@ let emit_instr fallthrough i =
       end
   | Lop(Itailcall_imm { func; label_after = _; }) ->
       if func = !function_name then
-        I.jmp (label !tailrec_entry_point)
+        match !tailrec_entry_point with
+        | None -> Misc.fatal_error "jump to missing tailrec entry point"
+        | Some tailrec_entry_point -> I.jmp (label tailrec_entry_point)
       else begin
         output_epilogue begin fun () ->
           add_used_symbol func;

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -54,7 +54,7 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
-    fun_tailrec_entry_point_label : label;
+    fun_tailrec_entry_point_label : label option;
     fun_contains_calls: bool;
     fun_num_stack_slots: int array;
     fun_frame_required: bool;

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -55,7 +55,7 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
-    fun_tailrec_entry_point_label : label;
+    fun_tailrec_entry_point_label : label option;
     fun_contains_calls: bool;
     fun_num_stack_slots: int array;
     fun_frame_required: bool;

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -334,7 +334,7 @@ let fundecl f =
     fun_fast = not (List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options);
     fun_dbg  = f.Mach.fun_dbg;
     fun_spacetime_shape = f.Mach.fun_spacetime_shape;
-    fun_tailrec_entry_point_label;
+    fun_tailrec_entry_point_label = Some fun_tailrec_entry_point_label;
     fun_contains_calls = contains_calls;
     fun_num_stack_slots = f.Mach.fun_num_stack_slots;
     fun_frame_required = Proc.frame_required f;

--- a/backend/power/emit.mlp
+++ b/backend/power/emit.mlp
@@ -397,7 +397,7 @@ let name_for_specific = function
 (* Name of current function *)
 let function_name = ref ""
 (* Entry point for tail recursive calls *)
-let tailrec_entry_point = ref 0
+let tailrec_entry_point = ref None
 (* Label of glue code for calling the GC *)
 let call_gc_label = ref 0
 
@@ -685,7 +685,9 @@ let emit_instr i =
         `	bctr\n`
     | Lop(Itailcall_imm { func; label_after = _; }) ->
         if func = !function_name then
-          `	b	{emit_label !tailrec_entry_point}\n`
+          match !tailrec_entry_point with
+          | None -> Misc.fatal_error "jump to missing tailrec entry point"
+          | Some tailrec_entry_point -> `	b	{emit_label tailrec_entry_point}\n`
         else begin
           begin match abi with
           | ELF32 ->

--- a/backend/riscv/emit.mlp
+++ b/backend/riscv/emit.mlp
@@ -264,7 +264,7 @@ let name_for_specific = function
 let function_name = ref ""
 
 (* Entry point for tail recursive calls *)
-let tailrec_entry_point = ref 0
+let tailrec_entry_point = ref None
 
 (* Output the assembly code for an instruction *)
 
@@ -324,7 +324,9 @@ let emit_instr i =
       `	jr	{emit_reg i.arg.(0)}\n`
   | Lop(Itailcall_imm {func; label_after = _}) ->
       if func = !function_name then begin
-        `	j	{emit_label !tailrec_entry_point}\n`
+        match !tailrec_entry_point with
+        | None -> Misc.fatal_error "jump to missing tailrec entry point"
+        | Some tailrec_entry_point -> `	j	{emit_label tailrec_entry_point}\n`
       end else begin
         let n = frame_size() in
         if !contains_calls then reload_ra n;

--- a/backend/s390x/emit.mlp
+++ b/backend/s390x/emit.mlp
@@ -305,7 +305,7 @@ let name_for_specific = function
 (* Name of current function *)
 let function_name = ref ""
 (* Entry point for tail recursive calls *)
-let tailrec_entry_point = ref 0
+let tailrec_entry_point = ref None
 
 (* Output the assembly code for an instruction *)
 
@@ -370,7 +370,9 @@ let emit_instr i =
         `	br	{emit_reg i.arg.(0)}\n`
     | Lop(Itailcall_imm { func; label_after = _; }) ->
         if func = !function_name then
-          `	brcl	15, {emit_label !tailrec_entry_point}\n`
+          match !tailrec_entry_point with
+          | None -> Misc.fatal_error "jump to missing tailrec entry point"
+          | Some tailrec_entry_point -> `	brcl	15, {emit_label tailrec_entry_point}\n`
         else begin
           let n = frame_size() in
           if !contains_calls then


### PR DESCRIPTION
This (draft) pull request is in some sense an alternative to https://github.com/ocaml-flambda/flambda-backend/pull/48.

It removes the `fun_tailrec_entry_point_label` field from `Cfg.t`,
and explicitly stores the destination label in the `Self` constructor of
`Cfg_intf.tail_call_operation`. By doing so, we avoid the pitfalls
of bookkeeping.

A complementary (larger-scale) change would be to also try and
remove the same field from `Linear.fundecl`, but it is unclear to
me whether it is worthwhile at this stage.