### PR TITLE
Add missing case for Ispecific rdtsc in an exhaustive match

### DIFF
--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -133,7 +133,7 @@ let pseudoregs_for_operation op arg res =
   | Iintop_imm ((Imulh|Idiv|Imod|Icomp _|Icheckbound _
                 |Ipopcnt|Iclz _|Ictz _), _)
   | Ispecific (Isqrtf|Isextend32|Izextend32|Ilea _|Istore_int (_, _, _)
-              |Ioffset_loc (_, _)|Ifloatsqrtf _)
+              |Ioffset_loc (_, _)|Ifloatsqrtf _ |Irdtsc)
   | Imove|Ispill|Ireload|Ifloatofint|Iintoffloat|Iconst_int _|Iconst_float _
   | Iconst_symbol _|Icall_ind _|Icall_imm _|Itailcall_ind _|Itailcall_imm _
   | Iextcall _|Istackoffset _|Iload (_, _)|Istore (_, _, _)|Ialloc _


### PR DESCRIPTION
This fixes warning 8 caused by 13b02262c commit, which was merged after f07447a6a165b0ce038cc9de46844fef9dd3361a commit that made the match exhaustive. I think it didn't trigger the warning in the CI because there was no rebase.