### PR TITLE
Copy testsuite tools to top-level

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -231,6 +231,11 @@ runtest-upstream:
 	rm -rf _runtest
 	mkdir _runtest
 	cp -a ocaml/testsuite _runtest/testsuite
+	# replace backend-specific testsuite/tools with their new versions
+	rm _runtest/testsuite/tools/*
+	cp -a testsuite/tools/* _runtest/testsuite/tools/
+	(cd _runtest/testsuite/tools && \
+	  	ln -s ../../../ocaml/testsuite/tools/Makefile Makefile)
 	(cd _runtest && ln -s ../ocaml/Makefile.tools Makefile.tools)
 	(cd _runtest && ln -s ../ocaml/Makefile.config Makefile.config)
 	cp _build2/install/default/bin/* _runtest/

--- a/ocaml/testsuite/tools/parsecmm.mly
+++ b/ocaml/testsuite/tools/parsecmm.mly
@@ -220,12 +220,7 @@ expr:
   | LPAREN APPLY location expr exprlist machtype RPAREN
                 { Cop(Capply $6, $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
-               {Cop(Cextcall {name=$3; ret=$5; alloc=false;
-                              builtin=false;
-                              effects=Arbitrary_effects;
-                              coeffects=Has_coeffects;
-                              label_after=None},
-                     List.rev $4, debuginfo ())}
+               {Cop(Cextcall($3, $5, false, None), List.rev $4, debuginfo ())}
   | LPAREN ALLOC exprlist RPAREN { Cop(Calloc, List.rev $3, debuginfo ()) }
   | LPAREN SUBF expr RPAREN { Cop(Cnegf, [$3], debuginfo ()) }
   | LPAREN SUBF expr expr RPAREN { Cop(Csubf, [$3; $4], debuginfo ()) }

--- a/testsuite/tools/asmgen_amd64.S
+++ b/testsuite/tools/asmgen_amd64.S
@@ -1,0 +1,83 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                OCaml                                   */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 2000 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#ifdef SYS_macosx
+#define ALIGN 4
+#else
+#define ALIGN 16
+#endif
+
+#ifdef SYS_macosx
+#define CALL_GEN_CODE _call_gen_code
+#define CAML_C_CALL _caml_c_call
+#define CAML_NEGF_MASK _caml_negf_mask
+#define CAML_ABSF_MASK _caml_absf_mask
+#else
+#define CALL_GEN_CODE call_gen_code
+#define CAML_C_CALL caml_c_call
+#define CAML_NEGF_MASK caml_negf_mask
+#define CAML_ABSF_MASK caml_absf_mask
+#endif
+
+        .globl  CALL_GEN_CODE
+        .align  ALIGN
+CALL_GEN_CODE:
+        pushq   %rbx
+        pushq   %rbp
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+        movq    %rdi, %r10
+        movq    %rsi, %rax
+        movq    %rdx, %rbx
+        movq    %rcx, %rdi
+        movq    %r8, %rsi
+        call    *%r10
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbp
+        popq    %rbx
+        ret
+
+        .globl  CAML_C_CALL
+        .align  ALIGN
+CAML_C_CALL:
+        jmp     *%rax
+
+#ifdef SYS_macosx
+        .literal16
+#elif defined(SYS_mingw64) || defined(SYS_cygwin)
+        .section        .rodata.cst8
+#else
+        .section        .rodata.cst8,"aM",@progbits,8
+#endif
+        .globl  CAML_NEGF_MASK
+        .align  ALIGN
+CAML_NEGF_MASK:
+        .quad   0x8000000000000000, 0
+        .globl  CAML_ABSF_MASK
+        .align  ALIGN
+CAML_ABSF_MASK:
+        .quad   0x7FFFFFFFFFFFFFFF, 0
+
+        .comm   young_limit, 8
+
+#if defined(SYS_linux)
+    /* Mark stack as non-executable */
+        .section .note.GNU-stack,"",%progbits
+#endif

--- a/testsuite/tools/asmgen_arm.S
+++ b/testsuite/tools/asmgen_arm.S
@@ -1,0 +1,42 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                OCaml                                   */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1998 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+        .text
+
+        .global call_gen_code
+        .type   call_gen_code, %function
+        .align  0
+call_gen_code:
+        mov     ip, sp
+        stmfd   sp!, {r4, r5, r6, r7, r8, r9, fp, ip, lr, pc}
+        sub     fp, ip, #4
+    @ r0 is function to call
+    @ r1, r2, r3 are arguments 1, 2, 3
+        mov     r4, r0
+        mov     r0, r1
+        mov     r1, r2
+        mov     r2, r3
+        blx     r4
+        ldmea   fp, {r4, r5, r6, r7, r8, r9, fp, sp, pc}
+
+        .global caml_c_call
+        .type   caml_c_call, %function
+        .align  0
+caml_c_call:
+    @ function to call is in r10
+        bx      r10
+
+/* Mark stack as non-executable */
+        .section .note.GNU-stack,"",%progbits

--- a/testsuite/tools/asmgen_arm64.S
+++ b/testsuite/tools/asmgen_arm64.S
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                OCaml                                   */
+/*                                                                        */
+/*             Xavier Leroy, projet Gallium, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 2013 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+        .globl  call_gen_code
+        .align  2
+call_gen_code:
+    /* Set up stack frame and save callee-save registers */
+        stp     x29, x30, [sp, -160]!
+        add     x29, sp, #0
+        stp     x19, x20, [sp, 16]
+        stp     x21, x22, [sp, 32]
+        stp     x23, x24, [sp, 48]
+        stp     x25, x26, [sp, 64]
+        stp     x27, x28, [sp, 80]
+        stp     d8, d9, [sp, 96]
+        stp     d10, d11, [sp, 112]
+        stp     d12, d13, [sp, 128]
+        stp     d14, d15, [sp, 144]
+    /* Shuffle arguments */
+        mov     x8, x0
+        mov     x0, x1
+        mov     x1, x2
+        mov     x2, x3
+        mov     x3, x4
+    /* Call generated asm */
+        blr     x8
+    /* Reload callee-save registers and return address */
+        ldp     x19, x20, [sp, 16]
+        ldp     x21, x22, [sp, 32]
+        ldp     x23, x24, [sp, 48]
+        ldp     x25, x26, [sp, 64]
+        ldp     x27, x28, [sp, 80]
+        ldp     d8, d9, [sp, 96]
+        ldp     d10, d11, [sp, 112]
+        ldp     d12, d13, [sp, 128]
+        ldp     d14, d15, [sp, 144]
+        ldp     x29, x30, [sp], 160
+        ret
+
+        .globl  caml_c_call
+        .align  2
+caml_c_call:
+        br      x15
+
+/* Mark stack as non-executable */
+        .section .note.GNU-stack,"",%progbits

--- a/testsuite/tools/asmgen_i386.S
+++ b/testsuite/tools/asmgen_i386.S
@@ -1,0 +1,70 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                OCaml                                   */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* Linux with ELF binaries does not prefix identifiers with _.
+   Linux with a.out binaries, FreeBSD, and NextStep do. */
+
+#if defined(SYS_linux_elf) || defined(SYS_bsd_elf) \
+ || defined(SYS_solaris) || defined(SYS_beos) || defined(SYS_gnu)
+#define G(x) x
+#define FUNCTION_ALIGN 16
+#else
+#define G(x) _##x
+#define FUNCTION_ALIGN 4
+#endif
+
+        .globl  G(call_gen_code)
+        .align  FUNCTION_ALIGN
+G(call_gen_code):
+        pushl %ebp
+        movl %esp,%ebp
+        pushl %ebx
+        pushl %esi
+        pushl %edi
+        movl 12(%ebp),%eax
+        movl 16(%ebp),%ebx
+        movl 20(%ebp),%ecx
+        movl 24(%ebp),%edx
+        call *8(%ebp)
+        popl %edi
+        popl %esi
+        popl %ebx
+        popl %ebp
+        ret
+
+        .globl  G(caml_c_call)
+        .align  FUNCTION_ALIGN
+G(caml_c_call):
+        jmp     *%eax
+
+        .comm   G(Caml_state), 4
+
+/* Some tests are designed to cause registers to spill; on
+ * x86 we require the caml_extra_params symbol from the RTS. */
+        .data
+        .globl  G(caml_extra_params)
+G(caml_extra_params):
+#ifndef SYS_solaris
+        .space  64
+#else
+        .zero   64
+#endif
+
+
+
+#if defined(SYS_linux_elf)
+    /* Mark stack as non-executable */
+        .section .note.GNU-stack,"",%progbits
+#endif

--- a/testsuite/tools/asmgen_i386nt.asm
+++ b/testsuite/tools/asmgen_i386nt.asm
@@ -1,0 +1,67 @@
+;*********************************************************************;
+;                                                                     ;
+;                                OCaml                                ;
+;                                                                     ;
+;            Xavier Leroy, projet Cristal, INRIA Rocquencourt         ;
+;                                                                     ;
+;  Copyright 1996 Institut National de Recherche en Informatique et   ;
+;  en Automatique.  All rights reserved.  This file is distributed    ;
+;  under the terms of the Q Public License version 1.0.               ;
+;                                                                     ;
+;*********************************************************************;
+
+        .386
+        .MODEL FLAT
+
+        .CODE
+        PUBLIC  _call_gen_code
+        ALIGN   4
+_call_gen_code:
+        push    ebp
+        mov     ebp, esp
+        push    ebx
+        push    esi
+        push    edi
+        mov     eax, [ebp+12]
+        mov     ebx, [ebp+16]
+        mov     ecx, [ebp+20]
+        mov     edx, [ebp+24]
+        call    DWORD PTR [ebp+8]
+        pop     edi
+        pop     esi
+        pop     ebx
+        pop     ebp
+        ret
+
+        PUBLIC  _caml_c_call
+        ALIGN   4
+_caml_c_call:
+        ffree   st(0)
+        ffree   st(1)
+        ffree   st(2)
+        ffree   st(3)
+        jmp     eax
+
+        PUBLIC  _caml_call_gc
+        PUBLIC  _caml_alloc
+        PUBLIC  _caml_alloc1
+        PUBLIC  _caml_alloc2
+        PUBLIC  _caml_alloc3
+        PUBLIC  _caml_allocN
+        PUBLIC  _caml_extra_params
+        PUBLIC  _caml_raise_exn
+_caml_call_gc:
+_caml_alloc:
+_caml_alloc1:
+_caml_alloc2:
+_caml_alloc3:
+_caml_allocN:
+_caml_extra_params:
+_caml_raise_exn:
+        int     3
+
+        .DATA
+        PUBLIC  _Caml_state
+_Caml_state dword 0
+
+        END

--- a/testsuite/tools/asmgen_power.S
+++ b/testsuite/tools/asmgen_power.S
@@ -1,0 +1,200 @@
+/*********************************************************************/
+/*                                                                   */
+/*                               OCaml                               */
+/*                                                                   */
+/*           Xavier Leroy, projet Cristal, INRIA Rocquencourt        */
+/*                                                                   */
+/* Copyright 1996 Institut National de Recherche en Informatique et  */
+/* en Automatique.  All rights reserved.  This file is distributed   */
+/* under the terms of the Q Public License version 1.0.              */
+/*                                                                   */
+/*********************************************************************/
+
+#if defined(MODEL_ppc64) || defined(MODEL_ppc64le)
+#define EITHER(a,b) b
+#else
+#define EITHER(a,b) a
+#endif
+
+#define WORD EITHER(4,8)
+#define lg EITHER(lwz,ld)
+#define lgu EITHER(lwzu,ldu)
+#define stg EITHER(stw,std)
+#define stgu EITHER(stwu,stdu)
+
+#if defined(MODEL_ppc)
+#define RESERVED_STACK 16
+#define LR_SAVE_AREA 4
+#endif
+#if defined(MODEL_ppc64)
+#define RESERVED_STACK 48
+#define LR_SAVE_AREA 16
+#endif
+#if defined(MODEL_ppc64le)
+#define RESERVED_STACK 32
+#define LR_SAVE_AREA 16
+#endif
+
+/* Function definitions */
+
+#if defined(MODEL_ppc)
+#define FUNCTION(name) \
+  .section ".text"; \
+  .globl name; \
+  .type name, @function; \
+  .align 2; \
+  name:
+#endif
+
+#if defined(MODEL_ppc64)
+#define FUNCTION(name) \
+  .section ".opd","aw"; \
+  .align 3; \
+  .globl name; \
+  .type name, @function; \
+  name: .quad .L.name,.TOC.@tocbase; \
+  .text; \
+  .align 2; \
+  .L.name:
+#endif
+
+#if defined(MODEL_ppc64le)
+#define FUNCTION(name) \
+  .section ".text"; \
+  .globl name; \
+  .type name, @function; \
+  .align 2; \
+  name: ; \
+  0: addis 2, 12, (.TOC. - 0b)@ha; \
+  addi 2, 2, (.TOC. - 0b)@l; \
+  .localentry name, . - 0b
+#endif
+
+FUNCTION(call_gen_code)
+    /* Allocate and link stack frame */
+        stgu    1, -(WORD*18 + 8*18 + RESERVED_STACK)(1)
+    /* 18 saved GPRs, 18 saved FPRs */
+    /* Save return address */
+        mflr    0
+        stg     0, (WORD*18 + 8*18 + RESERVED_STACK + LR_SAVE_AREA)(1)
+    /* Save all callee-save registers, starting at RESERVED_STACK */
+        addi    11, 1, RESERVED_STACK - WORD
+        stgu    14, WORD(11)
+        stgu    15, WORD(11)
+        stgu    16, WORD(11)
+        stgu    17, WORD(11)
+        stgu    18, WORD(11)
+        stgu    19, WORD(11)
+        stgu    20, WORD(11)
+        stgu    21, WORD(11)
+        stgu    22, WORD(11)
+        stgu    23, WORD(11)
+        stgu    24, WORD(11)
+        stgu    25, WORD(11)
+        stgu    26, WORD(11)
+        stgu    27, WORD(11)
+        stgu    28, WORD(11)
+        stgu    29, WORD(11)
+        stgu    30, WORD(11)
+        stgu    31, WORD(11)
+        stfdu   14, 8(11)
+        stfdu   15, 8(11)
+        stfdu   16, 8(11)
+        stfdu   17, 8(11)
+        stfdu   18, 8(11)
+        stfdu   19, 8(11)
+        stfdu   20, 8(11)
+        stfdu   21, 8(11)
+        stfdu   22, 8(11)
+        stfdu   23, 8(11)
+        stfdu   24, 8(11)
+        stfdu   25, 8(11)
+        stfdu   26, 8(11)
+        stfdu   27, 8(11)
+        stfdu   28, 8(11)
+        stfdu   29, 8(11)
+        stfdu   30, 8(11)
+        stfdu   31, 8(11)
+    /* Get function pointer in CTR */
+#if defined(MODEL_ppc)
+        mtctr   3
+#elif defined(MODEL_ppc64)
+        ld      0, 0(3)
+        mtctr   0
+        ld      2, 8(3)
+#elif defined(MODEL_ppc64le)
+        mtctr   3
+        mr      12, 3
+#else
+#error "wrong MODEL"
+#endif
+    /* Shuffle arguments */
+        mr      3, 4
+        mr      4, 5
+        mr      5, 6
+        mr      6, 7
+    /* Call the function */
+        bctrl
+    /* Restore callee-save registers */
+        addi    11, 1, RESERVED_STACK - WORD
+        lgu     14, WORD(11)
+        lgu     15, WORD(11)
+        lgu     16, WORD(11)
+        lgu     17, WORD(11)
+        lgu     18, WORD(11)
+        lgu     19, WORD(11)
+        lgu     20, WORD(11)
+        lgu     21, WORD(11)
+        lgu     22, WORD(11)
+        lgu     23, WORD(11)
+        lgu     24, WORD(11)
+        lgu     25, WORD(11)
+        lgu     26, WORD(11)
+        lgu     27, WORD(11)
+        lgu     28, WORD(11)
+        lgu     29, WORD(11)
+        lgu     30, WORD(11)
+        lgu     31, WORD(11)
+        lfdu    14, 8(11)
+        lfdu    15, 8(11)
+        lfdu    16, 8(11)
+        lfdu    17, 8(11)
+        lfdu    18, 8(11)
+        lfdu    19, 8(11)
+        lfdu    20, 8(11)
+        lfdu    21, 8(11)
+        lfdu    22, 8(11)
+        lfdu    23, 8(11)
+        lfdu    24, 8(11)
+        lfdu    25, 8(11)
+        lfdu    26, 8(11)
+        lfdu    27, 8(11)
+        lfdu    28, 8(11)
+        lfdu    29, 8(11)
+        lfdu    30, 8(11)
+        lfdu    31, 8(11)
+    /* Reload return address */
+        lg      0, (WORD*18 + 8*18 + RESERVED_STACK + LR_SAVE_AREA)(1)
+        mtlr    0
+    /* Return */
+        addi    1, 1, (WORD*18 + 8*18 + RESERVED_STACK)
+        blr
+
+FUNCTION(caml_c_call)
+    /* Jump to C function (address in r28) */
+#if defined(MODEL_ppc)
+        mtctr   28
+#elif defined(MODEL_ppc64)
+        ld      0, 0(28)
+        mtctr   0
+        ld      2, 8(28)
+#elif defined(MODEL_ppc64le)
+        mtctr   28
+        mr      12, 28
+#else
+#error "wrong MODEL"
+#endif
+        bctr
+
+/* Mark stack as non-executable */
+        .section .note.GNU-stack,"",%progbits

--- a/testsuite/tools/asmgen_riscv.S
+++ b/testsuite/tools/asmgen_riscv.S
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                OCaml                                   */
+/*                                                                        */
+/*                Nicolas Ojeda Bar <n.oje.bar@gmail.com>                 */
+/*                                                                        */
+/*   Copyright 2019 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define STORE sd
+#define LOAD ld
+
+        .globl  call_gen_code
+        .align  2
+call_gen_code:
+    /* Set up stack frame and save callee-save registers */
+        ADDI    sp, sp, -208
+        STORE   ra, 192(sp)
+        STORE   s0, 0(sp)
+        STORE   s1, 8(sp)
+        STORE   s2, 16(sp)
+        STORE   s3, 24(sp)
+        STORE   s4, 32(sp)
+        STORE   s5, 40(sp)
+        STORE   s6, 48(sp)
+        STORE   s7, 56(sp)
+        STORE   s8, 64(sp)
+        STORE   s9, 72(sp)
+        STORE   s10, 80(sp)
+        STORE   s11, 88(sp)
+        fsd     fs0, 96(sp)
+        fsd     fs1, 104(sp)
+        fsd     fs2, 112(sp)
+        fsd     fs3, 120(sp)
+        fsd     fs4, 128(sp)
+        fsd     fs5, 136(sp)
+        fsd     fs6, 144(sp)
+        fsd     fs7, 152(sp)
+        fsd     fs8, 160(sp)
+        fsd     fs9, 168(sp)
+        fsd     fs10, 176(sp)
+        fsd     fs11, 184(sp)
+    /* Shuffle arguments */
+        mv      t0, a0
+        mv      a0, a1
+        mv      a1, a2
+        mv      a2, a3
+        mv      a3, a4
+    /* Call generated asm */
+        jalr    t0
+    /* Reload callee-save registers and return address */
+        LOAD    ra, 192(sp)
+        LOAD    s0, 0(sp)
+        LOAD    s1, 8(sp)
+        LOAD    s2, 16(sp)
+        LOAD    s3, 24(sp)
+        LOAD    s4, 32(sp)
+        LOAD    s5, 40(sp)
+        LOAD    s6, 48(sp)
+        LOAD    s7, 56(sp)
+        LOAD    s8, 64(sp)
+        LOAD    s9, 72(sp)
+        LOAD    s10, 80(sp)
+        LOAD    s11, 88(sp)
+        fld     fs0, 96(sp)
+        fld     fs1, 104(sp)
+        fld     fs2, 112(sp)
+        fld     fs3, 120(sp)
+        fld     fs4, 128(sp)
+        fld     fs5, 136(sp)
+        fld     fs6, 144(sp)
+        fld     fs7, 152(sp)
+        fld     fs8, 160(sp)
+        fld     fs9, 168(sp)
+        fld     fs10, 176(sp)
+        fld     fs11, 184(sp)
+        addi    sp, sp, 208
+        ret
+
+        .globl  caml_c_call
+        .align  2
+caml_c_call:
+        jr      t2

--- a/testsuite/tools/asmgen_s390x.S
+++ b/testsuite/tools/asmgen_s390x.S
@@ -1,0 +1,67 @@
+#define ALIGN 8
+
+#define CALL_GEN_CODE call_gen_code
+#define CAML_C_CALL caml_c_call
+#define CAML_NEGF_MASK caml_negf_mask
+#define CAML_ABSF_MASK caml_absf_mask
+
+        .section ".text"
+
+        .globl  CALL_GEN_CODE
+        .type   CALL_GEN_CODE, @function
+        .align  ALIGN
+CALL_GEN_CODE:
+        /* Stack space */
+        lay     %r15, -144(%r15)
+        /* Save registers */
+        stmg    %r6,%r14, 0(%r15)
+        std     %f8, 72(%r15)
+        std     %f9, 80(%r15)
+        std     %f10, 88(%r15)
+        std     %f11, 96(%r15)
+        std     %f12, 104(%r15)
+        std     %f13, 112(%r15)
+        std     %f14, 120(%r15)
+        std     %f15, 128(%r15)
+        /* Shuffle args */
+        lgr     %r1, %r2
+        lgr     %r2, %r3
+        lgr     %r3, %r4
+        lgr     %r4, %r5
+        /* Function call */
+        basr    %r14, %r1
+        /* Restore registers */
+        lmg    %r6,%r14, 0(%r15)
+        ld     %f8, 72(%r15)
+        ld     %f9, 80(%r15)
+        ld     %f10, 88(%r15)
+        ld     %f11, 96(%r15)
+        ld     %f12, 104(%r15)
+        ld     %f13, 112(%r15)
+        ld     %f14, 120(%r15)
+        ld     %f15, 128(%r15)
+        /* Return */
+        lay     %r15, 144(%r15)
+        br      %r14
+
+        .globl  CAML_C_CALL
+        .type   CAML_C_CALL, @function
+        .align  ALIGN
+CAML_C_CALL:
+        br      %r7
+
+        .section ".rodata"
+
+        .global CAML_NEGF_MASK
+        .align  ALIGN
+CAML_NEGF_MASK:
+        .quad   0x8000000000000000, 0
+        .global  CAML_ABSF_MASK
+        .align  ALIGN
+CAML_ABSF_MASK:
+        .quad   0x7FFFFFFFFFFFFFFF, 0
+
+        .comm   young_limit, 8
+
+/* Mark stack as non-executable */
+        .section .note.GNU-stack,"",%progbits

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -1,0 +1,80 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Clflags
+let write_asm_file = ref false
+
+let compile_file filename =
+  if !write_asm_file then begin
+    let out_name = Filename.chop_extension filename ^ ".s" in
+    Emitaux.output_channel := open_out out_name
+  end; (* otherwise, stdout *)
+  Compilenv.reset "test";
+  Emit.begin_assembly();
+  let ic = open_in filename in
+  let lb = Lexing.from_channel ic in
+  lb.Lexing.lex_curr_p <- Lexing.{ lb.lex_curr_p with pos_fname = filename };
+  try
+    while true do
+      Asmgen.compile_phrase ~ppf_dump:Format.std_formatter
+        (Parsecmm.phrase Lexcmm.token lb)
+    done
+  with
+      End_of_file ->
+        close_in ic; Emit.end_assembly();
+        if !write_asm_file then close_out !Emitaux.output_channel
+    | Lexcmm.Error msg ->
+        close_in ic; Lexcmm.report_error lb msg
+    | Parsing.Parse_error ->
+        close_in ic;
+        let start_p = Lexing.lexeme_start_p lb in
+        let end_p = Lexing.lexeme_end_p lb in
+        Printf.eprintf "File \"%s\", line %i, characters %i-%i:\n\
+                        Syntax error.\n%!"
+          filename
+          start_p.Lexing.pos_lnum
+          (start_p.Lexing.pos_cnum - start_p.Lexing.pos_bol)
+          (end_p.Lexing.pos_cnum - start_p.Lexing.pos_bol)
+    | Parsecmmaux.Error msg ->
+        close_in ic; Parsecmmaux.report_error msg
+    | x ->
+        close_in ic; raise x
+
+let usage = "Usage: codegen <options> <files>\noptions are:"
+
+let main() =
+  Arg.parse [
+     "-S", Arg.Set write_asm_file,
+       " Output file to filename.s (default is stdout)";
+     "-g", Arg.Set Clflags.debug, "";
+     "-dcmm", Arg.Set dump_cmm, "";
+     "-dcse", Arg.Set dump_cse, "";
+     "-dsel", Arg.Set dump_selection, "";
+     "-dlive", Arg.Unit(fun () -> dump_live := true ), "";
+     "-dspill", Arg.Set dump_spill, "";
+     "-dsplit", Arg.Set dump_split, "";
+     "-dinterf", Arg.Set dump_interf, "";
+     "-dprefer", Arg.Set dump_prefer, "";
+     "-dalloc", Arg.Set dump_regalloc, "";
+     "-dreload", Arg.Set dump_reload, "";
+     "-dscheduling", Arg.Set dump_scheduling, "";
+     "-dlinear", Arg.Set dump_linear, "";
+     "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
+    ] compile_file usage
+
+let () =
+  main ();
+  Profile.print Format.std_formatter !Clflags.profile_columns;
+  exit 0

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -1,0 +1,372 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Jeremie Dimino, Jane Street Europe                   *)
+(*                                                                        *)
+(*   Copyright 2016 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Execute a list of phrases from a .ml file and compare the result to the
+   expected output, written inside [%%expect ...] nodes. At the end, create
+   a .corrected file containing the corrected expectations. The test is
+   successful if there is no differences between the two files.
+
+   An [%%expect] node always contains both the expected outcome with and
+   without -principal. When the two differ the expectation is written as
+   follows:
+
+   {[
+     [%%expect {|
+     output without -principal
+     |}, Principal{|
+     output with -principal
+     |}]
+   ]}
+*)
+
+[@@@ocaml.warning "-40"]
+
+open StdLabels
+
+(* representation of: {tag|str|tag} *)
+type string_constant =
+  { str : string
+  ; tag : string
+  }
+
+type expectation =
+  { extid_loc   : Location.t (* Location of "expect" in "[%%expect ...]" *)
+  ; payload_loc : Location.t (* Location of the whole payload *)
+  ; normal      : string_constant (* expectation without -principal *)
+  ; principal   : string_constant (* expectation with -principal *)
+  }
+
+(* A list of phrases with the expected toplevel output *)
+type chunk =
+  { phrases     : Parsetree.toplevel_phrase list
+  ; expectation : expectation
+  }
+
+type correction =
+  { corrected_expectations : expectation list
+  ; trailing_output        : string
+  }
+
+let match_expect_extension (ext : Parsetree.extension) =
+  match ext with
+  | ({Asttypes.txt="expect"|"ocaml.expect"; loc = extid_loc}, payload) ->
+    let invalid_payload () =
+      Location.raise_errorf ~loc:extid_loc "invalid [%%%%expect payload]"
+    in
+    let string_constant (e : Parsetree.expression) =
+      match e.pexp_desc with
+      | Pexp_constant (Pconst_string (str, _, Some tag)) ->
+        { str; tag }
+      | _ -> invalid_payload ()
+    in
+    let expectation =
+      match payload with
+      | PStr [{ pstr_desc = Pstr_eval (e, []) }] ->
+        let normal, principal =
+          match e.pexp_desc with
+          | Pexp_tuple
+              [ a
+              ; { pexp_desc = Pexp_construct
+                                ({ txt = Lident "Principal"; _ }, Some b) }
+              ] ->
+            (string_constant a, string_constant b)
+          | _ -> let s = string_constant e in (s, s)
+        in
+        { extid_loc
+        ; payload_loc = e.pexp_loc
+        ; normal
+        ; principal
+        }
+      | PStr [] ->
+        let s = { tag = ""; str = "" } in
+        { extid_loc
+        ; payload_loc  = { extid_loc with loc_start = extid_loc.loc_end }
+        ; normal    = s
+        ; principal = s
+        }
+      | _ -> invalid_payload ()
+    in
+    Some expectation
+  | _ ->
+    None
+
+(* Split a list of phrases from a .ml file *)
+let split_chunks phrases =
+  let rec loop (phrases : Parsetree.toplevel_phrase list) code_acc acc =
+    match phrases with
+    | [] ->
+      if code_acc = [] then
+        (List.rev acc, None)
+      else
+        (List.rev acc, Some (List.rev code_acc))
+    | phrase :: phrases ->
+      match phrase with
+      | Ptop_def [] -> loop phrases code_acc acc
+      | Ptop_def [{pstr_desc = Pstr_extension(ext, [])}] -> begin
+          match match_expect_extension ext with
+          | None -> loop phrases (phrase :: code_acc) acc
+          | Some expectation ->
+            let chunk =
+              { phrases     = List.rev code_acc
+              ; expectation
+              }
+            in
+            loop phrases [] (chunk :: acc)
+        end
+      | _ -> loop phrases (phrase :: code_acc) acc
+  in
+  loop phrases [] []
+
+module Compiler_messages = struct
+  let capture ppf ~f =
+    Misc.protect_refs
+      [ R (Location.formatter_for_warnings, ppf) ]
+      f
+end
+
+let collect_formatters buf pps ~f =
+  let ppb = Format.formatter_of_buffer buf in
+  let out_functions = Format.pp_get_formatter_out_functions ppb () in
+
+  List.iter (fun pp -> Format.pp_print_flush pp ()) pps;
+  let save =
+    List.map (fun pp -> Format.pp_get_formatter_out_functions pp ()) pps
+  in
+  let restore () =
+    List.iter2
+      (fun pp out_functions ->
+         Format.pp_print_flush pp ();
+         Format.pp_set_formatter_out_functions pp out_functions)
+      pps save
+  in
+  List.iter
+    (fun pp -> Format.pp_set_formatter_out_functions pp out_functions)
+    pps;
+  match f () with
+  | x             -> restore (); x
+  | exception exn -> restore (); raise exn
+
+(* Invariant: ppf = Format.formatter_of_buffer buf *)
+let capture_everything buf ppf ~f =
+  collect_formatters buf [Format.std_formatter; Format.err_formatter]
+                     ~f:(fun () -> Compiler_messages.capture ppf ~f)
+
+let exec_phrase ppf phrase =
+  if !Clflags.dump_parsetree then Printast. top_phrase ppf phrase;
+  if !Clflags.dump_source    then Pprintast.top_phrase ppf phrase;
+  Toploop.execute_phrase true ppf phrase
+
+let parse_contents ~fname contents =
+  let lexbuf = Lexing.from_string contents in
+  Location.init lexbuf fname;
+  Location.input_name := fname;
+  Location.input_lexbuf := Some lexbuf;
+  Parse.use_file lexbuf
+
+let eval_expectation expectation ~output =
+  let s =
+    if !Clflags.principal then
+      expectation.principal
+    else
+      expectation.normal
+  in
+  if s.str = output then
+    None
+  else
+    let s = { s with str = output } in
+    Some (
+      if !Clflags.principal then
+        { expectation with principal = s }
+      else
+        { expectation with normal = s }
+    )
+
+let shift_lines delta phrases =
+  let position (pos : Lexing.position) =
+    { pos with pos_lnum = pos.pos_lnum + delta }
+  in
+  let location _this (loc : Location.t) =
+    { loc with
+      loc_start = position loc.loc_start
+    ; loc_end   = position loc.loc_end
+    }
+  in
+  let mapper = { Ast_mapper.default_mapper with location } in
+  List.map phrases ~f:(function
+    | Parsetree.Ptop_dir _ as p -> p
+    | Parsetree.Ptop_def st ->
+      Parsetree.Ptop_def (mapper.structure mapper st))
+
+let rec min_line_number : Parsetree.toplevel_phrase list -> int option =
+function
+  | [] -> None
+  | (Ptop_dir _  | Ptop_def []) :: l -> min_line_number l
+  | Ptop_def (st :: _) :: _ -> Some st.pstr_loc.loc_start.pos_lnum
+
+let eval_expect_file _fname ~file_contents =
+  Warnings.reset_fatal ();
+  let chunks, trailing_code =
+    parse_contents ~fname:"" file_contents |> split_chunks
+  in
+  let buf = Buffer.create 1024 in
+  let ppf = Format.formatter_of_buffer buf in
+  let exec_phrases phrases =
+    let phrases =
+      match min_line_number phrases with
+      | None -> phrases
+      | Some lnum -> shift_lines (1 - lnum) phrases
+    in
+    (* For formatting purposes *)
+    Buffer.add_char buf '\n';
+    let _ : bool =
+      List.fold_left phrases ~init:true ~f:(fun acc phrase ->
+        acc &&
+        let snap = Btype.snapshot () in
+        try
+          exec_phrase ppf phrase
+        with exn ->
+          let bt = Printexc.get_raw_backtrace () in
+          begin try Location.report_exception ppf exn
+          with _ ->
+            Format.fprintf ppf "Uncaught exception: %s\n%s\n"
+              (Printexc.to_string exn)
+              (Printexc.raw_backtrace_to_string bt)
+          end;
+          Btype.backtrack snap;
+          false
+      )
+    in
+    Format.pp_print_flush ppf ();
+    let len = Buffer.length buf in
+    if len > 0 && Buffer.nth buf (len - 1) <> '\n' then
+      (* For formatting purposes *)
+      Buffer.add_char buf '\n';
+    let s = Buffer.contents buf in
+    Buffer.clear buf;
+    Misc.delete_eol_spaces s
+  in
+  let corrected_expectations =
+    capture_everything buf ppf ~f:(fun () ->
+      List.fold_left chunks ~init:[] ~f:(fun acc chunk ->
+        let output = exec_phrases chunk.phrases in
+        match eval_expectation chunk.expectation ~output with
+        | None -> acc
+        | Some correction -> correction :: acc)
+      |> List.rev)
+  in
+  let trailing_output =
+    match trailing_code with
+    | None -> ""
+    | Some phrases ->
+      capture_everything buf ppf ~f:(fun () -> exec_phrases phrases)
+  in
+  { corrected_expectations; trailing_output }
+
+let output_slice oc s a b =
+  output_string oc (String.sub s ~pos:a ~len:(b - a))
+
+let output_corrected oc ~file_contents correction =
+  let output_body oc { str; tag } =
+    Printf.fprintf oc "{%s|%s|%s}" tag str tag
+  in
+  let ofs =
+    List.fold_left correction.corrected_expectations ~init:0
+      ~f:(fun ofs c ->
+        output_slice oc file_contents ofs c.payload_loc.loc_start.pos_cnum;
+        output_body oc c.normal;
+        if c.normal.str <> c.principal.str then begin
+          output_string oc ", Principal";
+          output_body oc c.principal
+        end;
+        c.payload_loc.loc_end.pos_cnum)
+  in
+  output_slice oc file_contents ofs (String.length file_contents);
+  match correction.trailing_output with
+  | "" -> ()
+  | s  -> Printf.fprintf oc "\n[%%%%expect{|%s|}]\n" s
+
+let write_corrected ~file ~file_contents correction =
+  let oc = open_out file in
+  output_corrected oc ~file_contents correction;
+  close_out oc
+
+let process_expect_file fname =
+  let corrected_fname = fname ^ ".corrected" in
+  let file_contents =
+    let ic = open_in_bin fname in
+    match really_input_string ic (in_channel_length ic) with
+    | s           -> close_in ic; Misc.normalise_eol s
+    | exception e -> close_in ic; raise e
+  in
+  let correction = eval_expect_file fname ~file_contents in
+  write_corrected ~file:corrected_fname ~file_contents correction
+
+let repo_root = ref None
+let keep_original_error_size = ref false
+
+let main fname =
+  if not !keep_original_error_size then
+    Clflags.error_size := 0;
+  Toploop.override_sys_argv
+    (Array.sub Sys.argv ~pos:!Arg.current
+       ~len:(Array.length Sys.argv - !Arg.current));
+  (* Ignore OCAMLRUNPARAM=b to be reproducible *)
+  Printexc.record_backtrace false;
+  if not !Clflags.no_std_include then begin
+    match !repo_root with
+    | None -> ()
+    | Some dir ->
+        (* If we pass [-repo-root], use the stdlib from inside the
+           compiler, not the installed one. We use
+           [Compenv.last_include_dirs] to make sure that the stdlib
+           directory is the last one. *)
+        Clflags.no_std_include := true;
+        Compenv.last_include_dirs := [Filename.concat dir "stdlib"]
+  end;
+  Compmisc.init_path ();
+  Toploop.initialize_toplevel_env ();
+  Sys.interactive := false;
+  process_expect_file fname;
+  exit 0
+
+module Options = Main_args.Make_bytetop_options (struct
+  include Main_args.Default.Topmain
+  let _stdin () = (* disabled *) ()
+  let _args = Arg.read_arg
+  let _args0 = Arg.read_arg0
+  let anonymous s = main s
+end);;
+
+let args =
+  Arg.align
+    ( [ "-repo-root", Arg.String (fun s -> repo_root := Some s),
+        "<dir> root of the OCaml repository. This causes the tool to use \
+         the stdlib from the current source tree rather than the installed one."
+      ; "-keep-original-error-size", Arg.Set keep_original_error_size,
+        " truncate long error messages as the compiler would"
+      ] @ Options.list
+    )
+
+let usage = "Usage: expect_test <options> [script-file [arguments]]\n\
+             options are:"
+
+let () =
+  Clflags.color := Some Misc.Color.Never;
+  try
+    Arg.parse args main usage;
+    Printf.eprintf "expect_test: no input file\n";
+    exit 2
+  with exn ->
+    Location.report_exception Format.err_formatter exn;
+    exit 2

--- a/testsuite/tools/lexcmm.mli
+++ b/testsuite/tools/lexcmm.mli
@@ -1,0 +1,25 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val token: Lexing.lexbuf -> Parsecmm.token
+
+type error =
+    Illegal_character
+  | Unterminated_comment
+  | Unterminated_string
+
+exception Error of error
+
+val report_error: Lexing.lexbuf -> error -> unit

--- a/testsuite/tools/lexcmm.mll
+++ b/testsuite/tools/lexcmm.mll
@@ -1,0 +1,261 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+{
+open Parsecmm
+
+type error =
+    Illegal_character
+  | Unterminated_comment
+  | Unterminated_string
+
+exception Error of error
+
+(* For nested comments *)
+
+let comment_depth = ref 0
+
+(* The table of keywords *)
+
+let keyword_table =
+  Misc.create_hashtable 149 [
+    "absf", ABSF;
+    "addr", ADDR;
+    "align", ALIGN;
+    "alloc", ALLOC;
+    "and", AND;
+    "app", APPLY;
+    "assign", ASSIGN;
+    "byte", BYTE;
+    "case", CASE;
+    "catch", CATCH;
+    "checkbound", CHECKBOUND;
+    "data", DATA;
+    "exit", EXIT;
+    "extcall", EXTCALL;
+    "float", FLOAT;
+    "float32", FLOAT32;
+    "float64", FLOAT64;
+    "floatofint", FLOATOFINT;
+    "function", FUNCTION;
+    "global", GLOBAL;
+    "half", HALF;
+    "if", IF;
+    "int", INT;
+    "int32", INT32;
+    "intoffloat", INTOFFLOAT;
+    "string", KSTRING;
+    "let", LET;
+    "letmut", LETMUT;
+    "load", LOAD;
+    "mod", MODI;
+    "mulh", MULH;
+    "or", OR;
+    "proj", PROJ;
+    "raise", RAISE Lambda.Raise_regular;
+    "reraise", RAISE Lambda.Raise_reraise;
+    "raise_notrace", RAISE Lambda.Raise_notrace;
+    "seq", SEQ;
+    "signed", SIGNED;
+    "skip", SKIP;
+    "store", STORE;
+    "switch", SWITCH;
+    "try", TRY;
+    "unit", UNIT;
+    "unsigned", UNSIGNED;
+    "val", VAL;
+    "while", WHILE;
+    "with", WITH;
+    "xor", XOR;
+    "addraref", ADDRAREF;
+    "intaref", INTAREF;
+    "floataref", FLOATAREF;
+    "addraset", ADDRASET;
+    "intaset", INTASET;
+    "floataset", FLOATASET
+]
+
+(* To buffer string literals *)
+
+let initial_string_buffer = Bytes.create 256
+let string_buff = ref initial_string_buffer
+let string_index = ref 0
+
+let reset_string_buffer () =
+  string_buff := initial_string_buffer;
+  string_index := 0
+
+let store_string_char c =
+  if !string_index >= Bytes.length (!string_buff) then begin
+    let new_buff = Bytes.create (Bytes.length (!string_buff) * 2) in
+    Bytes.blit (!string_buff) 0 new_buff 0 (Bytes.length (!string_buff));
+    string_buff := new_buff
+  end;
+  Bytes.unsafe_set (!string_buff) (!string_index) c;
+  incr string_index
+
+let get_stored_string () =
+  let s = Bytes.sub_string (!string_buff) 0 (!string_index) in
+  string_buff := initial_string_buffer;
+  s
+
+(* To translate escape sequences *)
+
+let char_for_backslash = function
+    'n' -> '\010'
+  | 'r' -> '\013'
+  | 'b' -> '\008'
+  | 't' -> '\009'
+  | c   -> c
+
+let char_for_decimal_code lexbuf i =
+  Char.chr(100 * (Char.code(Lexing.lexeme_char lexbuf i) - 48) +
+               10 * (Char.code(Lexing.lexeme_char lexbuf (i+1)) - 48) +
+                    (Char.code(Lexing.lexeme_char lexbuf (i+2)) - 48))
+
+(* Error report *)
+
+let report_error lexbuf msg =
+  prerr_string "Lexical error around character ";
+  prerr_int (Lexing.lexeme_start lexbuf);
+  match msg with
+    Illegal_character ->
+      prerr_string ": illegal character"
+  | Unterminated_comment ->
+      prerr_string ": unterminated comment"
+  | Unterminated_string ->
+      prerr_string ": unterminated string"
+
+}
+
+let newline = ('\013'* '\010')
+
+rule token = parse
+    newline
+      { Lexing.new_line lexbuf; token lexbuf }
+  | [' ' '\009' '\012'] +
+      { token lexbuf }
+  | "+a" { ADDA }
+  | "+v" { ADDV }
+  | "+f" { ADDF }
+  | "+" { ADDI }
+  | ">>s" { ASR }
+  | ":" { COLON }
+  | "/f" { DIVF }
+  | "/" { DIVI }
+  | eof { EOF }
+  | "==a" { EQA }
+  | "==f" { EQF }
+  | "==" { EQI }
+  | ">=a" { GEA }
+  | ">=f" { GEF }
+  | ">=" { GEI }
+  | ">a" { GTA }
+  | ">f" { GTF }
+  | ">" { GTI }
+  | "[" { LBRACKET }
+  | "<=a" { LEA }
+  | "<=f" { LEF }
+  | "<=" { LEI }
+  | "(" { LPAREN }
+  | "<<" { LSL }
+  | ">>u" { LSR }
+  | "<a" { LTA }
+  | "<f" { LTF }
+  | "<" { LTI }
+  | "*f" { MULF }
+  | "*" { STAR }
+  | "!=a" { NEA }
+  | "!=f" { NEF }
+  | "!=" { NEI }
+  | "!>=f" { NGEF }
+  | "!>f" { NGTF }
+  | "!<=f" { NLEF }
+  | "!<f" { NLTF }
+  | "]" { RBRACKET }
+  | ")" { RPAREN }
+  | "-f" { SUBF }
+  | "-" { SUBI }
+  | '-'? (['0'-'9']+ | "0x" ['0'-'9' 'a'-'f' 'A'-'F']+
+                     | "0o" ['0'-'7']+ | "0b" ['0'-'1']+)
+      { INTCONST(int_of_string(Lexing.lexeme lexbuf)) }
+  | '-'? ['0'-'9']+ 'a'
+      { let s = Lexing.lexeme lexbuf in
+        POINTER(int_of_string(String.sub s 0 (String.length s - 1))) }
+  | '-'? ['0'-'9']+ ('.' ['0'-'9']*)? (['e' 'E'] ['+' '-']? ['0'-'9']+)?
+      { FLOATCONST(Lexing.lexeme lexbuf) }
+  | ['A'-'Z' 'a'-'z' '\223'-'\246' '\248'-'\255' ]
+    (['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255'
+      '\'' '0'-'9' ]) * '/'? (['0'-'9'] *)
+      { let s = Lexing.lexeme lexbuf in
+        try
+          Hashtbl.find keyword_table s
+        with Not_found ->
+          IDENT s }
+  | "\""
+      { reset_string_buffer();
+        string lexbuf;
+        STRING (get_stored_string()) }
+  | "(*"
+      { comment_depth := 1;
+        comment lexbuf;
+        token lexbuf }
+  | '{' ['A' - 'Z' 'a'-'z' '/' ',' '.' '-' '_' ' ''0'-'9']+
+        ':' [ '0'-'9' ]+ ',' ['0'-'9' ]+ '-' ['0'-'9' ]+ '}'
+      {
+        let loc_s = Lexing.lexeme lexbuf in
+        let pos_fname, pos_lnum, start, end_ =
+          Scanf.sscanf loc_s "{%s@:%i,%i-%i}" (fun file line start end_ ->
+              (file, line, start, end_))
+        in
+        let loc_start =
+          Lexing.{ pos_fname; pos_lnum; pos_bol = 0; pos_cnum = start }
+        in
+        let loc_end =
+          Lexing.{ pos_fname; pos_lnum; pos_bol = 0; pos_cnum = end_ }
+        in
+        let location = Location.{ loc_start; loc_end; loc_ghost = false } in
+        LOCATION location }
+  | _ { raise(Error(Illegal_character)) }
+
+and comment = parse
+    "(*"
+      { comment_depth := succ !comment_depth; comment lexbuf }
+  | "*)"
+      { comment_depth := pred !comment_depth;
+        if !comment_depth > 0 then comment lexbuf }
+  | eof
+      { raise (Error(Unterminated_comment)) }
+  | newline
+      { Lexing.new_line lexbuf; comment lexbuf }
+  | _
+      { comment lexbuf }
+
+and string = parse
+    '"'
+      { () }
+  | '\\' [' ' '\010' '\013' '\009' '\026' '\012'] +
+      { string lexbuf }
+  | '\\' ['\\' '"' 'n' 't' 'b' 'r']
+      { store_string_char(char_for_backslash(Lexing.lexeme_char lexbuf 1));
+        string lexbuf }
+  | '\\' ['0'-'9'] ['0'-'9'] ['0'-'9']
+      { store_string_char(char_for_decimal_code lexbuf 1);
+         string lexbuf }
+  | eof
+      { raise (Error(Unterminated_string)) }
+  | _
+      { store_string_char(Lexing.lexeme_char lexbuf 0);
+        string lexbuf }

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -1,0 +1,431 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* A simple parser for C-- */
+
+%{
+open Cmm
+open Parsecmmaux
+
+let rec make_letdef def body =
+  match def with
+    [] -> body
+  | (id, def) :: rem ->
+      unbind_ident id;
+      Clet(id, def, make_letdef rem body)
+
+let rec make_letmutdef def body =
+  match def with
+    [] -> body
+  | (id, ty, def) :: rem ->
+      unbind_ident id;
+      Clet_mut(id, ty, def, make_letmutdef rem body)
+
+let make_switch n selector caselist =
+  let index = Array.make n 0 in
+  let casev = Array.of_list caselist in
+  let dbg = Debuginfo.none in
+  let actv = Array.make (Array.length casev) (Cexit(0,[]), dbg) in
+  for i = 0 to Array.length casev - 1 do
+    let (posl, e) = casev.(i) in
+    List.iter (fun pos -> index.(pos) <- i) posl;
+    actv.(i) <- (e, dbg)
+  done;
+  Cswitch(selector, index, actv, dbg)
+
+let access_array base numelt size =
+  match numelt with
+    Cconst_int (0, _) -> base
+  | Cconst_int (n, _) ->
+      let dbg = Debuginfo.none in
+      Cop(Cadda, [base; Cconst_int(n * size, dbg)], dbg)
+  | _ ->
+      let dbg = Debuginfo.none in
+      Cop(Cadda, [base;
+                  Cop(Clsl, [numelt; Cconst_int(Misc.log2 size, dbg)],
+                  dbg)],
+          dbg)
+
+%}
+
+%token ABSF
+%token ADDA
+%token ADDF
+%token ADDI
+%token ADDV
+%token ADDR
+%token ALIGN
+%token ALLOC
+%token AND
+%token APPLY
+%token ASR
+%token ASSIGN
+%token BYTE
+%token CASE
+%token CATCH
+%token CHECKBOUND
+%token COLON
+%token DATA
+%token DIVF
+%token DIVI
+%token EOF
+%token EQA
+%token EQF
+%token EQI
+%token EXIT
+%token EXTCALL
+%token FLOAT
+%token FLOAT32
+%token FLOAT64
+%token <string> FLOATCONST
+%token FLOATOFINT
+%token FUNCTION
+%token GEA
+%token GEF
+%token GEI
+%token GLOBAL
+%token GTA
+%token GTF
+%token GTI
+%token HALF
+%token <string> IDENT
+%token IF
+%token INT
+%token INT32
+%token <int> INTCONST
+%token INTOFFLOAT
+%token KSTRING
+%token LBRACKET
+%token LEA
+%token LEF
+%token LEI
+%token LET
+%token LETMUT
+%token LOAD
+%token <Location.t> LOCATION
+%token LPAREN
+%token LSL
+%token LSR
+%token LTA
+%token LTF
+%token LTI
+%token MODI
+%token MULF
+%token MULH
+%token MULI
+%token NEA
+%token NEF
+%token NEI
+%token NGEF
+%token NGTF
+%token NLEF
+%token NLTF
+%token OR
+%token <int> POINTER
+%token PROJ
+%token <Lambda.raise_kind> RAISE
+%token RBRACKET
+%token RPAREN
+%token SEQ
+%token SIGNED
+%token SKIP
+%token STAR
+%token STORE
+%token <string> STRING
+%token SUBF
+%token SUBI
+%token SWITCH
+%token TRY
+%token UNIT
+%token UNSIGNED
+%token VAL
+%token WHILE
+%token WITH
+%token XOR
+%token ADDRAREF
+%token INTAREF
+%token FLOATAREF
+%token ADDRASET
+%token INTASET
+%token FLOATASET
+
+%start phrase
+%type <Cmm.phrase> phrase
+
+%%
+
+phrase:
+    fundecl     { Cfunction $1 }
+  | datadecl    { Cdata $1 }
+  | EOF         { raise End_of_file }
+;
+fundecl:
+    LPAREN FUNCTION fun_name LPAREN params RPAREN sequence RPAREN
+      { List.iter (fun (id, ty) -> unbind_ident id) $5;
+        {fun_name = $3; fun_args = $5; fun_body = $7;
+         fun_codegen_options =
+           if Config.flambda then [
+             Reduce_code_size;
+             No_CSE;
+           ]
+           else [ Reduce_code_size ];
+         fun_dbg = debuginfo ()} }
+;
+fun_name:
+    STRING              { $1 }
+  | IDENT               { $1 }
+params:
+    oneparam params     { $1 :: $2 }
+  | /**/                { [] }
+;
+oneparam:
+    IDENT COLON machtype { (bind_ident $1, $3) }
+;
+machtype:
+    UNIT                        { [||] }
+  | componentlist               { Array.of_list(List.rev $1) }
+;
+component:
+    VAL                         { Val }
+  | ADDR                        { Addr }
+  | INT                         { Int }
+  | FLOAT                       { Float }
+;
+componentlist:
+    component                    { [$1] }
+  | componentlist STAR component { $3 :: $1 }
+;
+expr:
+    INTCONST    { Cconst_int ($1, debuginfo ()) }
+  | FLOATCONST  { Cconst_float (float_of_string $1, debuginfo ()) }
+  | STRING      { Cconst_symbol ($1, debuginfo ()) }
+  | POINTER     { Cconst_pointer ($1, debuginfo ()) }
+  | IDENT       { Cvar(find_ident $1) }
+  | LBRACKET RBRACKET { Ctuple [] }
+  | LPAREN LET letdef sequence RPAREN { make_letdef $3 $4 }
+  | LPAREN LETMUT letmutdef sequence RPAREN { make_letmutdef $3 $4 }
+  | LPAREN ASSIGN IDENT expr RPAREN { Cassign(find_ident $3, $4) }
+  | LPAREN APPLY location expr exprlist machtype RPAREN
+                { Cop(Capply $6, $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
+  | LPAREN EXTCALL STRING exprlist machtype RPAREN
+               {Cop(Cextcall {name=$3; ret=$5; alloc=false;
+                              builtin=false;
+                              effects=Arbitrary_effects;
+                              coeffects=Has_coeffects;
+                              label_after=None},
+                     List.rev $4, debuginfo ())}
+  | LPAREN ALLOC exprlist RPAREN { Cop(Calloc, List.rev $3, debuginfo ()) }
+  | LPAREN SUBF expr RPAREN { Cop(Cnegf, [$3], debuginfo ()) }
+  | LPAREN SUBF expr expr RPAREN { Cop(Csubf, [$3; $4], debuginfo ()) }
+  | LPAREN unaryop expr RPAREN { Cop($2, [$3], debuginfo ()) }
+  | LPAREN binaryop expr expr RPAREN { Cop($2, [$3; $4], debuginfo ()) }
+  | LPAREN SEQ sequence RPAREN { $3 }
+  | LPAREN IF expr expr expr RPAREN
+      { Cifthenelse($3, debuginfo (), $4, debuginfo (), $5, debuginfo ()) }
+  | LPAREN SWITCH INTCONST expr caselist RPAREN { make_switch $3 $4 $5 }
+  | LPAREN WHILE expr sequence RPAREN
+      {
+        let lbl0 = Lambda.next_raise_count () in
+        let lbl1 = Lambda.next_raise_count () in
+        let body =
+          match $3 with
+            Cconst_int (x, _) when x <> 0 -> $4
+          | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
+                             (Cexit(lbl0,[])),
+                             debuginfo ()) in
+        Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
+          Ccatch(Recursive,
+            [lbl1, [], Csequence(body, Cexit(lbl1, [])), debuginfo ()],
+            Cexit(lbl1, []))) }
+  | LPAREN EXIT IDENT exprlist RPAREN
+    { Cexit(find_label $3, List.rev $4) }
+  | LPAREN CATCH sequence WITH catch_handlers RPAREN
+    { let handlers = $5 in
+      List.iter (fun (_, l, _, _) ->
+        List.iter (fun (x, _) -> unbind_ident x) l) handlers;
+      Ccatch(Recursive, handlers, $3) }
+  | EXIT        { Cexit(0,[]) }
+  | LPAREN TRY sequence WITH bind_ident sequence RPAREN
+                { unbind_ident $5; Ctrywith($3, $5, $6, debuginfo ()) }
+  | LPAREN VAL expr expr RPAREN
+      { let open Asttypes in
+        Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
+          debuginfo ()) }
+  | LPAREN ADDRAREF expr expr RPAREN
+      { let open Asttypes in
+        Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
+          Debuginfo.none) }
+  | LPAREN INTAREF expr expr RPAREN
+      { let open Asttypes in
+        Cop(Cload (Word_int, Mutable), [access_array $3 $4 Arch.size_int],
+          Debuginfo.none) }
+  | LPAREN FLOATAREF expr expr RPAREN
+      { let open Asttypes in
+        Cop(Cload (Double, Mutable), [access_array $3 $4 Arch.size_float],
+          Debuginfo.none) }
+  | LPAREN ADDRASET expr expr expr RPAREN
+      { let open Lambda in
+        Cop(Cstore (Word_val, Assignment),
+            [access_array $3 $4 Arch.size_addr; $5], Debuginfo.none) }
+  | LPAREN INTASET expr expr expr RPAREN
+      { let open Lambda in
+        Cop(Cstore (Word_int, Assignment),
+            [access_array $3 $4 Arch.size_int; $5], Debuginfo.none) }
+  | LPAREN FLOATASET expr expr expr RPAREN
+      { let open Lambda in
+        Cop(Cstore (Double, Assignment),
+            [access_array $3 $4 Arch.size_float; $5], Debuginfo.none) }
+;
+exprlist:
+    exprlist expr               { $2 :: $1 }
+  | /**/                        { [] }
+;
+letdef:
+    oneletdef                   { [$1] }
+  | LPAREN letdefmult RPAREN    { $2 }
+;
+letdefmult:
+    /**/                        { [] }
+  | oneletdef letdefmult        { $1 :: $2 }
+;
+oneletdef:
+    IDENT expr                  { (bind_ident $1, $2) }
+;
+letmutdef:
+    oneletmutdef                { [$1] }
+  | LPAREN letmutdefmult RPAREN { $2 }
+;
+letmutdefmult:
+    /**/                        { [] }
+  | oneletmutdef letmutdefmult  { $1 :: $2 }
+;
+oneletmutdef:
+    IDENT machtype expr         { (bind_ident $1, $2, $3) }
+;
+chunk:
+    UNSIGNED BYTE               { Byte_unsigned }
+  | SIGNED BYTE                 { Byte_signed }
+  | UNSIGNED HALF               { Sixteen_unsigned }
+  | SIGNED HALF                 { Sixteen_signed }
+  | UNSIGNED INT32              { Thirtytwo_unsigned }
+  | SIGNED INT32                { Thirtytwo_signed }
+  | INT                         { Word_int }
+  | ADDR                        { Word_val }
+  | FLOAT32                     { Single }
+  | FLOAT64                     { Double }
+  | FLOAT                       { Double }
+  | VAL                         { Word_val }
+;
+unaryop:
+    LOAD chunk                  { Cload ($2, Asttypes.Mutable) }
+  | FLOATOFINT                  { Cfloatofint }
+  | INTOFFLOAT                  { Cintoffloat }
+  | RAISE                       { Craise $1 }
+  | ABSF                        { Cabsf }
+;
+binaryop:
+    STORE chunk                 { Cstore ($2, Lambda.Assignment) }
+  | ADDI                        { Caddi }
+  | SUBI                        { Csubi }
+  | STAR                        { Cmuli }
+  | DIVI                        { Cdivi }
+  | MODI                        { Cmodi }
+  | AND                         { Cand }
+  | OR                          { Cor }
+  | XOR                         { Cxor }
+  | LSL                         { Clsl }
+  | LSR                         { Clsr }
+  | ASR                         { Casr }
+  | EQI                         { Ccmpi Ceq }
+  | NEI                         { Ccmpi Cne }
+  | LTI                         { Ccmpi Clt }
+  | LEI                         { Ccmpi Cle }
+  | GTI                         { Ccmpi Cgt }
+  | GEI                         { Ccmpi Cge }
+  | ADDA                        { Cadda }
+  | ADDV                        { Caddv }
+  | EQA                         { Ccmpa Ceq }
+  | NEA                         { Ccmpa Cne }
+  | LTA                         { Ccmpa Clt }
+  | LEA                         { Ccmpa Cle }
+  | GTA                         { Ccmpa Cgt }
+  | GEA                         { Ccmpa Cge }
+  | ADDF                        { Caddf }
+  | MULF                        { Cmulf }
+  | DIVF                        { Cdivf }
+  | EQF                         { Ccmpf CFeq }
+  | NEF                         { Ccmpf CFneq }
+  | LTF                         { Ccmpf CFlt }
+  | NLTF                        { Ccmpf CFnlt }
+  | LEF                         { Ccmpf CFle }
+  | NLEF                        { Ccmpf CFnle }
+  | GTF                         { Ccmpf CFgt }
+  | NGTF                        { Ccmpf CFngt }
+  | GEF                         { Ccmpf CFge }
+  | NGEF                        { Ccmpf CFnge }
+  | CHECKBOUND                  { Ccheckbound }
+  | MULH                        { Cmulhi }
+;
+sequence:
+    expr sequence               { Csequence($1, $2) }
+  | expr                        { $1 }
+;
+caselist:
+    onecase sequence caselist   { ($1, $2) :: $3 }
+  | /**/                        { [] }
+;
+onecase:
+    CASE INTCONST COLON onecase { $2 :: $4 }
+  | CASE INTCONST COLON         { [$2] }
+;
+bind_ident:
+    IDENT                       { bind_ident $1 }
+;
+datadecl:
+    LPAREN datalist RPAREN      { List.rev $2 }
+  | LPAREN DATA datalist RPAREN { List.rev $3 }
+;
+datalist:
+    datalist dataitem           { $2 :: $1 }
+  | /**/                        { [] }
+;
+dataitem:
+    STRING COLON                { Cdefine_symbol $1 }
+  | BYTE INTCONST               { Cint8 $2 }
+  | HALF INTCONST               { Cint16 $2 }
+  | INT INTCONST                { Cint(Nativeint.of_int $2) }
+  | FLOAT FLOATCONST            { Cdouble (float_of_string $2) }
+  | ADDR STRING                 { Csymbol_address $2 }
+  | VAL STRING                 { Csymbol_address $2 }
+  | KSTRING STRING              { Cstring $2 }
+  | SKIP INTCONST               { Cskip $2 }
+  | ALIGN INTCONST              { Calign $2 }
+  | GLOBAL STRING               { Cglobal_symbol $2 }
+;
+catch_handlers:
+  | catch_handler
+    { [$1] }
+  | catch_handler AND catch_handlers
+    { $1 :: $3 }
+
+catch_handler:
+  | sequence
+    { 0, [], $1, debuginfo () }
+  | LPAREN IDENT params RPAREN sequence
+    { find_label $2, $3, $5, debuginfo () }
+
+location:
+    /**/                        { None }
+  | LOCATION                    { Some $1 }

--- a/testsuite/tools/parsecmmaux.ml
+++ b/testsuite/tools/parsecmmaux.ml
@@ -1,0 +1,58 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Auxiliary functions for parsing *)
+
+type error =
+    Unbound of string
+
+exception Error of error
+
+let tbl_ident = (Hashtbl.create 57 : (string, Backend_var.t) Hashtbl.t)
+let tbl_label = (Hashtbl.create 57 : (string, int) Hashtbl.t)
+
+let ident_name s =
+  match String.index s '/' with
+  | exception Not_found -> s
+  | n -> String.sub s 0 n
+
+let bind_ident s =
+  let id = Backend_var.create_local (ident_name s) in
+  Hashtbl.add tbl_ident s id;
+  Backend_var.With_provenance.create id
+
+let find_ident s =
+  try
+    Hashtbl.find tbl_ident s
+  with Not_found ->
+    raise(Error(Unbound s))
+
+let unbind_ident id =
+  Hashtbl.remove tbl_ident (Backend_var.With_provenance.name id)
+
+let find_label s =
+  try
+    Hashtbl.find tbl_label s
+  with Not_found ->
+    let lbl = Lambda.next_raise_count () in
+    Hashtbl.add tbl_label s lbl;
+    lbl
+
+let report_error = function
+    Unbound s ->
+      prerr_string "Unbound identifier "; prerr_string s; prerr_endline "."
+
+let debuginfo ?(loc=Location.symbol_rloc ()) () =
+  Debuginfo.(from_location (Scoped_location.of_location ~scopes:[] loc))

--- a/testsuite/tools/parsecmmaux.mli
+++ b/testsuite/tools/parsecmmaux.mli
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Auxiliary functions for parsing *)
+
+val bind_ident: string -> Backend_var.With_provenance.t
+val find_ident: string -> Backend_var.t
+val unbind_ident: Backend_var.With_provenance.t -> unit
+
+val find_label: string -> int
+
+val debuginfo: ?loc:Location.t -> unit -> Debuginfo.t
+
+type error =
+    Unbound of string
+
+exception Error of error
+
+val report_error: error -> unit


### PR DESCRIPTION
Tools for `asmgen` tests depend on the compiler backend, in particular `Parsecmm` depends on `Cmm`. 

This PR creates a copy of `ocaml/testsuite` at the top-level of this repo. Changes to `backend` and `middle_end` subdirectories should only affect the top-level `testsuite` subdirectory and not `ocaml/testsuite`.

For now, `testsuite` only contains `tools`. We can add backend-specific `tests` later in a  similar way to `tools`. 

This PR also fixes "make runtest-upstream" to use the top-level `testsuite/tools`, and reverts backend-related changes in `ocaml/testsuite/tools`. It re-enabled upstream tests with upstream compiler from within `ocaml` subdirectory as usual.
