### PR TITLE
Semaphores for ocaml probes

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -944,7 +944,11 @@ let emit_instr fallthrough i =
        semaphores are of type unsigned short.
        [1] https://sourceware.org/systemtap/wiki/UserSpaceProbeImplementation
     *)
-    I.mov (addressing (Ibased(semaphore_sym, 0)) WORD i 0) (res16 i 0);
+    (* OCaml has it's own semaphore, in addition to system tap,
+       to control ocaml probe handlers independently from stap probe handlers.
+       It is placed immediately after stap semaphore, and is the same
+       size - hence offset 2. *)
+    I.mov (addressing (Ibased(semaphore_sym, 2)) WORD i 0) (res16 i 0);
     (* If the semaphore is 0, then the result is 0, otherwise 1. *)
     I.cmp (int 0) (res16 i 0);
     I.set (cond (Iunsigned Cne)) (res8 i 0);
@@ -1450,7 +1454,8 @@ let emit_probe_notes0 () =
   String.Map.iter (fun _ label ->
       D.global label;
       _label label;
-      D.word (const 0);
+      D.word (const 0); (* for systemtap probes *)
+      D.word (const 0); (* for ocaml probes *)
       add_def_symbol label)
     !probe_semaphores
 

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1425,7 +1425,7 @@ let emit_probe_notes0 () =
       D.qword (const 0)
     end;
     D.qword (ConstLabel semaphore_label);
-    D.bytes "ocaml\000";
+    D.bytes "ocaml.1\000";
     D.bytes (probe_name ^ "\000");
     D.bytes (args ^ "\000");
     def_label d;

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -559,7 +559,7 @@ let find_or_add_semaphore name =
   match String.Map.find_opt name !probe_semaphores with
   | Some label -> label
   | None ->
-    let sym = Compilenv.make_symbol (Some ("semaphore_"^name)) in
+    let sym = "caml_probes_semaphore_"^name in
     probe_semaphores := String.Map.add name sym !probe_semaphores;
     sym
 
@@ -1452,7 +1452,8 @@ let emit_probe_notes0 () =
   end;
   D.align 2;
   String.Map.iter (fun _ label ->
-      D.global label;
+      D.weak label;
+      D.hidden label;
       _label label;
       D.word (const 0); (* for systemtap probes *)
       D.word (const 0); (* for ocaml probes *)


### PR DESCRIPTION
Add separate space for a separate semaphore for ocaml-probes.  Ocaml probes should not use systemtap semaphores because they control different handlers.

The PR also tidies semaphores symbols that need not be global.
