### PR TITLE
Ensure that Lifthenelse has a boolean-valued condition

### DIFF
--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -2744,9 +2744,10 @@ let combine_constructor loc arg pat_env cstr partial ctx def
             match
               (cstr.cstr_consts, cstr.cstr_nonconsts, consts, nonconsts)
             with
-            | 1, 1, [ (0, act1) ], [ (0, act2) ] ->
+            | 1, 1, [ (0, act1) ], [ (0, act2) ]
+              when not (Clflags.is_flambda2 ()) ->
                 (* Typically, match on lists, will avoid isint primitive in that
-              case *)
+                   case *)
                 Lifthenelse (arg, act2, act1)
             | n, 0, _, [] ->
                 (* The type defines constant constructors only *)

--- a/ocaml/lambda/switch.ml
+++ b/ocaml/lambda/switch.ml
@@ -187,6 +187,9 @@ let prerr_inter i = Printf.fprintf stderr
   and get_low cases i =
     let r,_,_ = cases.(i) in
     r
+  and get_high cases i =
+    let _,r,_ = cases.(i) in
+    r
 
   type ctests = {
     mutable n : int ;
@@ -660,9 +663,14 @@ let rec pkey chan  = function
           and right = {s with cases=right} in
 
           if i=1 && (lim+ctx.off)=1 && get_low cases 0+ctx.off=0 then
-            Arg.make_if
-              ctx.arg
-              (c_test ctx right) (c_test ctx left)
+            if lcases = 2 && get_high cases 1+ctx.off = 1 then
+              Arg.make_if
+                ctx.arg
+                (c_test ctx right) (c_test ctx left)
+            else
+              make_if_ne
+                ctx.arg 0
+                (c_test ctx right) (c_test ctx left)
           else if less_tests cright cleft then
             make_if_lt
               ctx.arg (lim+ctx.off)


### PR DESCRIPTION
The only form of conditional expression in Flambda 2 takes the form of a switch expression on untagged immediates.  There are no default cases; all values of the scrutinee must be known.

The Lambda `Lifthenelse` expression is translated to one of these switches, with two arms (untagged `0` and `1`), under the presumption that the condition is boolean-valued.  If it were not, I think we would need to generate two comparisons: one to turn a "zero or something else" value into zero or one; and then a second comparison to determine which branch to take.

To my mind it also seems cleaner, from a language design perspective, to insist that `Lifthenelse` is boolean-valued.

The front end currently generates some `Lifthenelse` which are not boolean-valued.  This patch should fix that, although there is one outstanding question in a CR that I don't know the answer to.

@stedolan maybe we could discuss this.