### PR TITLE
Fix parallel make

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -58,8 +58,7 @@ stage0: _build0/config.status
 # This code should use build contexts instead of --build-dir.
 .PHONY: stage1
 stage1: ocaml-stage1-config.status stage0 \
-          ocaml/otherlibs/dynlink/natdynlinkops2 \
-	  flags.sexp
+	  config_files
 	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage0_prefix)/bin:$$PATH \
@@ -89,8 +88,7 @@ stage2: ocaml-stage2-config.status stage1
 # in the middle end and backend.
 .PHONY: hacking
 hacking: ocaml-stage1-config.status stage0 \
-          ocaml/otherlibs/dynlink/natdynlinkops2 \
-	  flags.sexp
+	  config_files
 	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage0_prefix)/bin:$$PATH \
@@ -137,6 +135,7 @@ ocaml-stage2-config.status: ocaml/configure.ac
 	    --disable-ocamldoc && \
 	  cp config.status ../ocaml-stage2-config.status)
 
+# natdynlinkops2:
 # We need to augment dune's substitutions so this part isn't so
 # difficult.  We use /bin/echo to avoid builtin variants of "echo"
 # which don't accept "-n".  Unfortunately if there are no
@@ -144,9 +143,15 @@ ocaml-stage2-config.status: ocaml/configure.ac
 # will provide '' on the command line to ocamlopt which causes an
 # error.
 # CR mshinwell: This should be moved into the upstream dune build system.
-ocaml/otherlibs/dynlink/natdynlinkops2: ocaml-stage1-config.status
+#
+# flags.sexp:
+# Extract compilation flags from Makefile.config of stage1
+# and write them to a file that dune can use in stage1 and stage2.
+.PHONY: config_files
+config_files: ocaml-stage1-config.status
 	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
+# natdynlinkops2
 	cat ocaml/Makefile.config \
 	  | sed 's/^NATDYNLINKOPTS=$$/NATDYNLINKOPTS=-g/' \
 	  | grep '^NATDYNLINKOPTS=' \
@@ -164,14 +169,7 @@ ocaml/otherlibs/dynlink/natdynlinkops2: ocaml-stage1-config.status
 	else \
 	  /bin/echo -n "-bin-annot" > ocaml/otherlibs/dynlink/natdynlinkops1; \
 	fi
-
-
-# Extract compilation flags from Makefile.config of stage1
-# and write them to a file that dune can use in stage1 and stage2.
-.PHONY: flags.sexp
-flags.sexp: ocaml-stage1-config.status
-	cp ocaml-stage1-config.status ocaml/config.status
-	(cd ocaml && ./config.status)
+# flags.sexp
 	grep -q '^FUNCTION_SECTIONS=true' ocaml/Makefile.config; \
 	if [ $$? -eq 0 ] ; then \
 	  /bin/echo -n "(:standard -function-sections)" > ocamlopt_flags.sexp; \


### PR DESCRIPTION
The two rules `ocaml/otherlibs/dynlink/natdynlinkops2` and `flags.sexp` could cause errors if run in parallel, so I've merged them into a single `config_files` rule.