### PR TITLE
Fix parallel make issue

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -57,16 +57,20 @@ stage0: _build0/config.status
 #
 # This code should use build contexts instead of --build-dir.
 .PHONY: stage1
-stage1: ocaml-stage1-config.status stage0 \
+stage1: mount-ocaml-stage1-config.status stage0 \
           ocaml/otherlibs/dynlink/natdynlinkops2 \
 	  flags.sexp
-	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage0_prefix)/bin:$$PATH \
 	  $(dune) build --profile=release --build-dir=_build1 @install
 	(cd _build1/install/default/bin && \
 	  rm -f ocamllex && \
 	  ln -s ocamllex.opt ocamllex)
+
+# Ensures parallel processes don't attempt to copy /stage0
+.PHONY: mount-ocaml-stage1-config.status
+mount-ocaml-stage1-config.status:
+	cp ocaml-stage1-config.status ocaml/config.status
 
 # CR mshinwell: We should add targets that don't use --profile=release, for
 # speed, and also ensuring that warnings are errors.  We should also consider
@@ -88,10 +92,9 @@ stage2: ocaml-stage2-config.status stage1
 # features, especially large ones that take a long time to get to compile,
 # in the middle end and backend.
 .PHONY: hacking
-hacking: ocaml-stage1-config.status stage0 \
+hacking: mount-ocaml-stage1-config.status stage0 \
           ocaml/otherlibs/dynlink/natdynlinkops2 \
 	  flags.sexp
-	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage0_prefix)/bin:$$PATH \
 	  $(dune) build -w --profile=release --build-dir=_build1 @install
@@ -144,8 +147,7 @@ ocaml-stage2-config.status: ocaml/configure.ac
 # will provide '' on the command line to ocamlopt which causes an
 # error.
 # CR mshinwell: This should be moved into the upstream dune build system.
-ocaml/otherlibs/dynlink/natdynlinkops2: ocaml-stage1-config.status
-	cp ocaml-stage1-config.status ocaml/config.status
+ocaml/otherlibs/dynlink/natdynlinkops2: mount-ocaml-stage1-config.status
 	(cd ocaml && ./config.status)
 	cat ocaml/Makefile.config \
 	  | sed 's/^NATDYNLINKOPTS=$$/NATDYNLINKOPTS=-g/' \
@@ -169,8 +171,7 @@ ocaml/otherlibs/dynlink/natdynlinkops2: ocaml-stage1-config.status
 # Extract compilation flags from Makefile.config of stage1
 # and write them to a file that dune can use in stage1 and stage2.
 .PHONY: flags.sexp
-flags.sexp: ocaml-stage1-config.status
-	cp ocaml-stage1-config.status ocaml/config.status
+flags.sexp: mount-ocaml-stage1-config.status
 	(cd ocaml && ./config.status)
 	grep -q '^FUNCTION_SECTIONS=true' ocaml/Makefile.config; \
 	if [ $$? -eq 0 ] ; then \


### PR DESCRIPTION
Both the `flags.sexp` and `ocaml/otherlibs/dynlink/natdynlinkops2` begin by running `cp ocaml-stage1-config.status ocaml/config.status`. This isn't a problem on GitHub Actions with `-j3`, but on our higher performance machines, these two operations end up exactly in parallel and fail:

```
cp ocaml-stage1-config.status ocaml/config.status
cp ocaml-stage1-config.status ocaml/config.status
mkdir _build0
rsync -a --filter=':- $(pwd)/ocaml/.gitignore' \
  $(pwd)/ocaml/ $(pwd)/_stage2_configure
(cd ocaml && ./config.status)
rsync -a $(pwd)/ocaml/ $(pwd)/_build0
/bin/sh: 1: ./config.status: Text file busy
make[1]: *** [Makefile:149: ocaml/otherlibs/dynlink/natdynlinkops2] Error 2
make[1]: *** Waiting for unfinished jobs....
```

The fix here is to introduce a phony target to synchronise the copy operation. stage0 doesn't clobber `ocaml/config.status`, so `stage1` can be sure that `ocaml/config.status` is `ocaml-stage1-config.status` at the start of the recipe.