### PR TITLE
Flambda 2 patches to the Lambda types

### DIFF
--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -108,14 +108,14 @@ let invert_then_else = function
 
 let mut_from_env env ptr =
   match env.environment_param with
-  | None -> Mutable
+  | None -> Asttypes.Mutable
   | Some environment_param ->
     match ptr with
     | Cvar ptr ->
       (* Loads from the current function's closure are immutable. *)
-      if V.same environment_param ptr then Immutable
-      else Mutable
-    | _ -> Mutable
+      if V.same environment_param ptr then Asttypes.Immutable
+      else Asttypes.Mutable
+    | _ -> Asttypes.Mutable
 
 let get_field env ptr n dbg =
   let mut = mut_from_env env ptr in
@@ -1169,7 +1169,7 @@ and transl_let env str kind id exp body =
       (* N.B. [body] must still be traversed even if [exp] will never return:
          there may be constant closures inside that need lifting out. *)
       begin match str, kind with
-      | Immutable, _ -> Clet(id, cexp, transl env body)
+      | (Immutable | Immutable_unique), _ -> Clet(id, cexp, transl env body)
       | Mutable, Pintval -> Clet_mut(id, typ_int, cexp, transl env body)
       | Mutable, _ -> Clet_mut(id, typ_val, cexp, transl env body)
       end
@@ -1180,7 +1180,7 @@ and transl_let env str kind id exp body =
       let body =
         transl (add_unboxed_id (VP.var id) unboxed_id boxed_number env) body in
       begin match str, boxed_number with
-      | Immutable, _ -> Clet (v, cexp, body)
+      | (Immutable | Immutable_unique), _ -> Clet (v, cexp, body)
       | Mutable, bn -> Clet_mut (v, typ_of_boxed_number bn, cexp, body)
       end
 

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type mutable_flag = Asttypes.mutable_flag
+type mutable_flag = Lambda.mutable_flag
 
 type immediate_or_pointer = Lambda.immediate_or_pointer
 

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type mutable_flag = Asttypes.mutable_flag
+type mutable_flag = Lambda.mutable_flag
 
 type immediate_or_pointer = Lambda.immediate_or_pointer
 

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1106,12 +1106,13 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let dbg = Debuginfo.from_location loc in
       check_constant_result (getglobal dbg id)
                             (Compilenv.global_approx id)
-  | Lprim(Pfield n, [lam], loc) ->
+  | Lprim(Pfield ({ index = n; _ }, _), [lam], loc) ->
       let (ulam, approx) = close env lam in
       let dbg = Debuginfo.from_location loc in
       check_constant_result (Uprim(P.Pfield n, [ulam], dbg))
                             (field_approx n approx)
-  | Lprim(Psetfield(n, is_ptr, init), [Lprim(Pgetglobal id, [], _); lam], loc)->
+  | Lprim(Psetfield({ index = n; _ }, is_ptr, init),
+          [Lprim(Pgetglobal id, [], _); lam], loc)->
       let (ulam, approx) = close env lam in
       if approx <> Value_unknown then
         (!global_approx).(n) <- approx;
@@ -1132,10 +1133,14 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
   | Lswitch(arg, sw, dbg) ->
       let fn fail =
         let (uarg, _) = close env arg in
+        let sw_blocks =
+          List.map (fun ({ Lambda. sw_tag; sw_size = _; }, arm) -> sw_tag, arm)
+            sw.sw_blocks
+        in
         let const_index, const_actions, fconst =
           close_switch env sw.sw_consts sw.sw_numconsts fail
         and block_index, block_actions, fblock =
-          close_switch env sw.sw_blocks sw.sw_numblocks fail in
+          close_switch env sw_blocks sw.sw_numblocks fail in
         let ulam =
           Uswitch
             (uarg,

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -26,13 +26,13 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
   | Pmakeblock (tag, mutability, shape) ->
       Pmakeblock (tag, mutability, shape)
-  | Pfield field -> Pfield field
-  | Pfield_computed -> Pfield_computed
-  | Psetfield (field, imm_or_pointer, init_or_assign) ->
+  | Pfield ({ index = field; _ }, _) -> Pfield field
+  | Pfield_computed _sem -> Pfield_computed
+  | Psetfield ({ index = field; _ }, imm_or_pointer, init_or_assign) ->
       Psetfield (field, imm_or_pointer, init_or_assign)
   | Psetfield_computed (imm_or_pointer, init_or_assign) ->
       Psetfield_computed (imm_or_pointer, init_or_assign)
-  | Pfloatfield field -> Pfloatfield field
+  | Pfloatfield (field, _sem) -> Pfloatfield field
   | Psetfloatfield (field, init_or_assign) ->
       Psetfloatfield (field, init_or_assign)
   | Pduprecord (repr, size) -> Pduprecord (repr, size)

--- a/middle_end/flambda/alias_analysis.ml
+++ b/middle_end/flambda/alias_analysis.ml
@@ -23,8 +23,8 @@ type allocation_point =
 
 type allocated_const =
   | Normal of Allocated_const.t
-  | Array of Lambda.array_kind * Asttypes.mutable_flag * Variable.t list
-  | Duplicate_array of Lambda.array_kind * Asttypes.mutable_flag * Variable.t
+  | Array of Lambda.array_kind * Lambda.mutable_flag * Variable.t list
+  | Duplicate_array of Lambda.array_kind * Lambda.mutable_flag * Variable.t
 
 type constant_defining_value =
   | Allocated_const of allocated_const

--- a/middle_end/flambda/alias_analysis.mli
+++ b/middle_end/flambda/alias_analysis.mli
@@ -22,8 +22,8 @@ type allocation_point =
 
 type allocated_const =
   | Normal of Allocated_const.t
-  | Array of Lambda.array_kind * Asttypes.mutable_flag * Variable.t list
-  | Duplicate_array of Lambda.array_kind * Asttypes.mutable_flag * Variable.t
+  | Array of Lambda.array_kind * Lambda.mutable_flag * Variable.t list
+  | Duplicate_array of Lambda.array_kind * Lambda.mutable_flag * Variable.t
 
 type constant_defining_value =
   | Allocated_const of allocated_const

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -499,12 +499,16 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       | None ->
           List.fold_left (fun set (i, _) -> I.Set.add i set) I.Set.empty cases
     in
+    let sw_blocks =
+      List.map (fun ({ Lambda. sw_tag; sw_size = _; }, arm) -> sw_tag, arm)
+        sw.sw_blocks
+    in
     Flambda.create_let scrutinee (Expr (close t env arg))
       (Switch (scrutinee,
         { numconsts = nums sw.sw_numconsts sw.sw_consts sw.sw_failaction;
           consts = List.map aux sw.sw_consts;
-          numblocks = nums sw.sw_numblocks sw.sw_blocks sw.sw_failaction;
-          blocks = List.map aux sw.sw_blocks;
+          numblocks = nums sw.sw_numblocks sw_blocks sw.sw_failaction;
+          blocks = List.map aux sw_blocks;
           failaction = Option.map (close t env) sw.sw_failaction;
         }))
   | Lstringswitch (arg, sw, def, _) ->

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -335,15 +335,16 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
        makeblock(Mutable) can be a 'constant' if it is allocated at
        toplevel: if this expression is evaluated only once.
     *)
-    | Prim (Pmakeblock (_tag, Asttypes.Immutable, _value_kind), args,
-            _dbg) ->
+    | Prim (Pmakeblock (_tag, (Immutable | Immutable_unique), _value_kind),
+            args, _dbg) ->
       mark_vars args curr
 (*  (* CR-someday pchambart: If global mutables are allowed: *)
     | Prim(Lambda.Pmakeblock(_tag, Asttypes.Mutable), args, _dbg, _)
       when toplevel ->
       List.iter (mark_loop ~toplevel curr) args
 *)
-    | Prim (Pmakearray (Pfloatarray, Immutable), args, _) ->
+    | Prim (Pmakearray (Pfloatarray, (Immutable | Immutable_unique)),
+            args, _) ->
       mark_vars args curr
     | Prim (Pmakearray (Pfloatarray, Mutable), args, _) ->
       (* CR-someday pchambart: Toplevel float arrays could always be
@@ -356,7 +357,8 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       *)
       if toplevel then mark_vars args curr
       else mark_curr curr
-    | Prim (Pduparray (Pfloatarray, Immutable), [arg], _) ->
+    | Prim (Pduparray (Pfloatarray, (Immutable | Immutable_unique)),
+            [arg], _) ->
       mark_var arg curr
     | Prim (Pduparray (Pfloatarray, Mutable), [arg], _) ->
       if toplevel then mark_var arg curr

--- a/middle_end/flambda/lift_constants.ml
+++ b/middle_end/flambda/lift_constants.ml
@@ -293,7 +293,7 @@ let translate_definition_and_resolve_alias inconstants
     ~(backend : (module Backend_intf.S))
     : Flambda.constant_defining_value option =
   let resolve_float_array_involving_variables
-        ~(mutability : Asttypes.mutable_flag) ~vars =
+        ~(mutability : Lambda.mutable_flag) ~vars =
     (* Resolve an [Allocated_const] of the form:
         [Array (Pfloatarray, _, _)]
        (which references its contents via variables; it does not contain
@@ -326,7 +326,7 @@ let translate_definition_and_resolve_alias inconstants
     in
     let const : Allocated_const.t =
       match mutability with
-      | Immutable -> Immutable_float_array floats
+      | Immutable | Immutable_unique -> Immutable_float_array floats
       | Mutable -> Float_array floats
     in
     Some (Flambda.Allocated_const const)
@@ -432,7 +432,7 @@ let translate_definition_and_resolve_alias inconstants
     | Allocated_const (Normal (Immutable_float_array floats)) ->
       let const : Allocated_const.t =
         match mutability with
-        | Immutable -> Immutable_float_array floats
+        | Immutable | Immutable_unique -> Immutable_float_array floats
         | Mutable -> Float_array floats
       in
       Some (Flambda.Allocated_const const)

--- a/middle_end/flambda/lift_let_to_initialize_symbol.ml
+++ b/middle_end/flambda/lift_let_to_initialize_symbol.ml
@@ -81,7 +81,8 @@ let rec accumulate ~substitution ~copied_lets ~extracted_lets
     let extracted =
       let renamed = Variable.rename var in
       match named with
-      | Prim (Pmakeblock (tag, Asttypes.Immutable, _value_kind), args, _dbg) ->
+      | Prim (Pmakeblock (tag, (Immutable | Immutable_unique), _value_kind),
+              args, _dbg) ->
         let tag = Tag.create_exn tag in
         let args =
           List.map (fun v ->

--- a/middle_end/flambda/ref_to_variables.ml
+++ b/middle_end/flambda/ref_to_variables.ml
@@ -91,7 +91,7 @@ let variables_containing_ref (flam:Flambda.t) =
   let aux (flam : Flambda.t) =
     match flam with
     | Let { var;
-            defining_expr = Prim(Pmakeblock(0, Asttypes.Mutable, _), l, _);
+            defining_expr = Prim(Pmakeblock(0, Mutable, _), l, _);
           } ->
       map := Variable.Map.add var (List.length l) !map
     | _ -> ()
@@ -127,7 +127,7 @@ let eliminate_ref_of_expr flam =
     let aux (flam : Flambda.t) : Flambda.t =
       match flam with
       | Let { var;
-              defining_expr = Prim(Pmakeblock(0, Asttypes.Mutable, shape), l,_);
+              defining_expr = Prim(Pmakeblock(0, Mutable, shape), l,_);
               body }
         when convertible_variable var ->
         let shape = match shape with

--- a/middle_end/flambda/simplify_primitives.ml
+++ b/middle_end/flambda/simplify_primitives.ml
@@ -108,7 +108,7 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
     : Flambda.named * A.t * Inlining_cost.Benefit.t =
   let fpc = !Clflags.float_const_prop in
   match p with
-  | Pmakeblock(tag_int, Asttypes.Immutable, shape) ->
+  | Pmakeblock(tag_int, (Immutable | Immutable_unique), shape) ->
     let tag = Tag.create_exn tag_int in
     let shape = match shape with
       | None -> List.map (fun _ -> Lambda.Pgenval) args
@@ -116,19 +116,19 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
     in
     let approxs = List.map2 A.augment_with_kind approxs shape in
     let shape = List.map2 A.augment_kind_with_approx approxs shape in
-    Prim (Pmakeblock(tag_int, Asttypes.Immutable, Some shape), args, dbg),
+    Prim (Pmakeblock(tag_int, Lambda.Immutable, Some shape), args, dbg),
     A.value_block tag (Array.of_list approxs), C.Benefit.zero
   | Praise _ ->
     expr, A.value_bottom, C.Benefit.zero
   | Pmakearray(_, _) when is_empty approxs ->
-    Prim (Pmakeblock(0, Asttypes.Immutable, Some []), [], dbg),
+    Prim (Pmakeblock(0, Lambda.Immutable, Some []), [], dbg),
     A.value_block (Tag.create_exn 0) [||], C.Benefit.zero
   | Pmakearray (Pfloatarray, Mutable) ->
       let approx =
         A.value_mutable_float_array ~size:(List.length args)
       in
       expr, approx, C.Benefit.zero
-  | Pmakearray (Pfloatarray, Immutable) ->
+  | Pmakearray (Pfloatarray, (Immutable | Immutable_unique)) ->
       let approx =
         A.value_immutable_float_array (Array.of_list approxs)
       in

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -323,7 +323,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Psetglobal _ -> psetglobal
   | Pmakeblock _ -> pmakeblock
   | Pfield _ -> pfield
-  | Pfield_computed -> pfield_computed
+  | Pfield_computed _ -> pfield_computed
   | Psetfield _ -> psetfield
   | Psetfield_computed _ -> psetfield_computed
   | Pfloatfield _ -> pfloatfield
@@ -430,7 +430,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Psetglobal _ -> psetglobal_arg
   | Pmakeblock _ -> pmakeblock_arg
   | Pfield _ -> pfield_arg
-  | Pfield_computed -> pfield_computed_arg
+  | Pfield_computed _ -> pfield_computed_arg
   | Psetfield _ -> psetfield_arg
   | Psetfield_computed _ -> psetfield_computed_arg
   | Pfloatfield _ -> pfloatfield_arg

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -15,15 +15,14 @@
 
 
 open Format
-open Asttypes
 open Clambda
 
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
 let mutable_flag = function
-  | Mutable-> "[mut]"
-  | Immutable -> ""
+  | Lambda.Mutable-> "[mut]"
+  | Lambda.Immutable | Lambda.Immutable_unique -> ""
 
 let value_kind =
   let open Lambda in

--- a/middle_end/printclambda_primitives.ml
+++ b/middle_end/printclambda_primitives.ml
@@ -15,7 +15,6 @@
 
 
 open Format
-open Asttypes
 
 let boxed_integer_name = function
   | Lambda.Pnativeint -> "nativeint"
@@ -59,6 +58,8 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
       fprintf ppf "read_symbol %s" sym
   | Pmakeblock(tag, Immutable, shape) ->
       fprintf ppf "makeblock %i%a" tag Printlambda.block_shape shape
+  | Pmakeblock(tag, Immutable_unique, shape) ->
+      fprintf ppf "makeblock_unique %i%a" tag Printlambda.block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag Printlambda.block_shape shape
   | Pfield n -> fprintf ppf "field %i" n
@@ -146,8 +147,12 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
   | Parraylength k -> fprintf ppf "array.length[%s]" (array_kind k)
   | Pmakearray (k, Mutable) -> fprintf ppf "makearray[%s]" (array_kind k)
   | Pmakearray (k, Immutable) -> fprintf ppf "makearray_imm[%s]" (array_kind k)
+  | Pmakearray (k, Immutable_unique) ->
+    fprintf ppf "makearray_unique[%s]" (array_kind k)
   | Pduparray (k, Mutable) -> fprintf ppf "duparray[%s]" (array_kind k)
   | Pduparray (k, Immutable) -> fprintf ppf "duparray_imm[%s]" (array_kind k)
+  | Pduparray (k, Immutable_unique) ->
+    fprintf ppf "duparray_unique[%s]" (array_kind k)
   | Parrayrefu k -> fprintf ppf "array.unsafe_get[%s]" (array_kind k)
   | Parraysetu k -> fprintf ppf "array.unsafe_set[%s]" (array_kind k)
   | Parrayrefs k -> fprintf ppf "array.get[%s]" (array_kind k)

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -23,8 +23,8 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   match prim with
   | Pmakeblock _
   | Pmakearray (_, Mutable) -> Only_generative_effects, No_coeffects
-  | Pmakearray (_, Immutable) -> No_effects, No_coeffects
-  | Pduparray (_, Immutable) ->
+  | Pmakearray (_, (Immutable | Immutable_unique)) -> No_effects, No_coeffects
+  | Pduparray (_, (Immutable | Immutable_unique)) ->
       No_effects, No_coeffects  (* Pduparray (_, Immutable) is allowed only on
                                    immutable arrays. *)
   | Pduparray (_, Mutable) | Pduprecord _ ->

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -84,7 +84,7 @@ let close_phrase lam =
   Ident.Set.fold (fun id l ->
     let glb, pos = toplevel_value id in
     let glob =
-      Lprim (Pfield pos,
+      Lprim (mod_field pos,
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -108,14 +108,14 @@ let invert_then_else = function
 
 let mut_from_env env ptr =
   match env.environment_param with
-  | None -> Mutable
+  | None -> Asttypes.Mutable
   | Some environment_param ->
     match ptr with
     | Cvar ptr ->
       (* Loads from the current function's closure are immutable. *)
-      if V.same environment_param ptr then Immutable
-      else Mutable
-    | _ -> Mutable
+      if V.same environment_param ptr then Asttypes.Immutable
+      else Asttypes.Mutable
+    | _ -> Asttypes.Mutable
 
 let get_field env ptr n dbg =
   let mut = mut_from_env env ptr in
@@ -1160,7 +1160,7 @@ and transl_let env str kind id exp body =
       (* N.B. [body] must still be traversed even if [exp] will never return:
          there may be constant closures inside that need lifting out. *)
       begin match str, kind with
-      | Immutable, _ -> Clet(id, cexp, transl env body)
+      | (Immutable | Immutable_unique), _ -> Clet(id, cexp, transl env body)
       | Mutable, Pintval -> Clet_mut(id, typ_int, cexp, transl env body)
       | Mutable, _ -> Clet_mut(id, typ_val, cexp, transl env body)
       end
@@ -1171,7 +1171,7 @@ and transl_let env str kind id exp body =
       let body =
         transl (add_unboxed_id (VP.var id) unboxed_id boxed_number env) body in
       begin match str, boxed_number with
-      | Immutable, _ -> Clet (v, cexp, body)
+      | (Immutable | Immutable_unique), _ -> Clet (v, cexp, body)
       | Mutable, bn -> Clet_mut (v, typ_of_boxed_number bn, cexp, body)
       end
 

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -112,7 +112,7 @@ let preserve_tailcall_for_prim = function
     Pidentity | Popaque | Pdirapply | Prevapply | Psequor | Psequand ->
       true
   | Pbytes_to_string | Pbytes_of_string | Pignore | Pgetglobal _ | Psetglobal _
-  | Pmakeblock _ | Pfield _ | Pfield_computed | Psetfield _
+  | Pmakeblock _ | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
   | Pccall _ | Praise _ | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
@@ -392,10 +392,11 @@ let comp_primitive p args =
   | Pcompare_ints -> Kccall("caml_int_compare", 2)
   | Pcompare_floats -> Kccall("caml_float_compare", 2)
   | Pcompare_bints bi -> comp_bint_primitive bi "compare" args
-  | Pfield n -> Kgetfield n
-  | Pfield_computed -> Kgetvectitem
-  | Psetfield(n, _ptr, _init) -> Ksetfield n
+  | Pfield ({ index = n; _ }, _sem) -> Kgetfield n
+  | Pfield_computed _sem -> Kgetvectitem
+  | Psetfield({ index = n; _ }, _ptr, _init) -> Ksetfield n
   | Psetfield_computed(_ptr, _init) -> Ksetvectitem
+  | Pfloatfield (n, _sem) -> Kgetfloatfield n
   | Psetfloatfield (n, _init) -> Ksetfloatfield n
   | Pduprecord _ -> Kccall("caml_obj_dup", 1)
   | Pccall p -> Kccall(p.prim_name, p.prim_arity)
@@ -784,7 +785,7 @@ let rec comp_expr env exp sz cont =
   | Lprim(Pmakeblock(tag, _mut, _), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
       comp_args env args sz (Kmakeblock(List.length args, tag) :: cont)
-  | Lprim(Pfloatfield n, args, loc) ->
+  | Lprim(Pfloatfield (n, _sem), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
       comp_args env args sz (Kgetfloatfield n :: cont)
   | Lprim(p, args, _) ->
@@ -883,7 +884,8 @@ let rec comp_expr env exp sz cont =
       List.iter
         (fun (n, act) -> act_consts.(n) <- store.act_store () act) sw.sw_consts;
       List.iter
-        (fun (n, act) -> act_blocks.(n) <- store.act_store () act) sw.sw_blocks;
+        (fun ({ sw_tag = tag; sw_size = _; }, act) ->
+          act_blocks.(tag) <- store.act_store () act) sw.sw_blocks;
 (* Compile and label actions *)
       let acts = store.act_get () in
 (*

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -16,6 +16,8 @@
 open Misc
 open Asttypes
 
+type mutable_flag = Immutable | Immutable_unique | Mutable
+
 type compile_time_constant =
   | Big_endian
   | Word_size

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -39,6 +39,24 @@ type is_safe =
   | Safe
   | Unsafe
 
+type field_read_semantics =
+  | Reads_agree
+  | Reads_vary
+
+type block_size =
+  | Known of int
+  | Unknown
+
+type block_info =
+  { tag : int;
+    size : block_size;
+  }
+
+type field_info =
+  { index : int;
+    block_info : block_info;
+  }
+
 type primitive =
   | Pidentity
   | Pbytes_to_string
@@ -51,11 +69,11 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
-  | Pfield_computed
-  | Psetfield of int * immediate_or_pointer * initialization_or_assignment
+  | Pfield of field_info * field_read_semantics
+  | Pfield_computed of field_read_semantics
+  | Psetfield of field_info * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
-  | Pfloatfield of int
+  | Pfloatfield of int * field_read_semantics
   | Psetfloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* Force lazy values *)
@@ -206,7 +224,6 @@ let equal_value_kind x y =
   | Pintval, Pintval -> true
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval), _ -> false
 
-
 type structured_constant =
     Const_base of constant
   | Const_block of int * structured_constant list
@@ -332,8 +349,13 @@ and lambda_switch =
   { sw_numconsts: int;
     sw_consts: (int * lambda) list;
     sw_numblocks: int;
-    sw_blocks: (int * lambda) list;
+    sw_blocks: (lambda_switch_block_key * lambda) list;
     sw_failaction : lambda option}
+
+and lambda_switch_block_key =
+  { sw_tag : int;
+    sw_size : int;
+  }
 
 and lambda_event =
   { lev_loc: scoped_location;
@@ -650,7 +672,13 @@ let rec transl_address loc = function
       then Lprim(Pgetglobal id, [], loc)
       else Lvar id
   | Env.Adot(addr, pos) ->
-      Lprim(Pfield pos, [transl_address loc addr], loc)
+      let field_info = {
+        index = pos;
+        block_info = { tag = 0; size = Unknown; };
+      }
+      in
+      Lprim(Pfield (field_info, Reads_agree),
+            [transl_address loc addr], loc)
 
 let transl_path find loc env path =
   match find path env with
@@ -739,7 +767,7 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
     | Lswitch(arg, sw, loc) ->
         Lswitch(subst s l arg,
                 {sw with sw_consts = List.map (subst_case s l) sw.sw_consts;
-                        sw_blocks = List.map (subst_case s l) sw.sw_blocks;
+                        sw_blocks = List.map (subst_block_case s l) sw.sw_blocks;
                         sw_failaction = subst_opt s l sw.sw_failaction; },
                 loc)
     | Lstringswitch (arg,cases,default,loc) ->
@@ -802,6 +830,7 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
   and subst_decl s l (id, exp) = (id, subst s l exp)
   and subst_case s l (key, case) = (key, subst s l case)
   and subst_strcase s l (key, case) = (key, subst s l case)
+  and subst_block_case s l (key, case) = (key, subst s l case)
   and subst_opt s l = function
     | None -> None
     | Some e -> Some (subst s l e)
@@ -962,3 +991,21 @@ let max_arity () =
 
 let reset () =
   raise_count := 0
+
+let module_block_info : block_info = { tag = 0; size = Unknown; }
+
+let mod_field ?(read_semantics=Reads_agree) pos =
+  (* Note: In some occasions, size is actually available, but in general
+     coercions can reuse blocks if the indices are compatible, so the size is
+     only a minimal guaranteed size and may not reflect the actual block size.
+  *)
+  Pfield (
+    { index = pos;
+      block_info = module_block_info;
+    }, read_semantics)
+
+let mod_setfield pos =
+  Psetfield (
+    { index = pos;
+      block_info = module_block_info;
+    }, Pointer, Root_initialization)

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -17,6 +17,9 @@
 
 open Asttypes
 
+(* Overriding Asttypes.mutable_flag *)
+type mutable_flag = Immutable | Immutable_unique | Mutable
+
 type compile_time_constant =
   | Big_endian
   | Word_size

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -45,6 +45,24 @@ type is_safe =
   | Safe
   | Unsafe
 
+type field_read_semantics =
+  | Reads_agree
+  | Reads_vary
+
+type block_size =
+  | Known of int
+  | Unknown
+
+type block_info =
+  { tag : int;
+    size : block_size;
+  }
+
+type field_info =
+  { index : int;
+    block_info : block_info;
+  }
+
 type primitive =
   | Pidentity
   | Pbytes_to_string
@@ -57,11 +75,11 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
-  | Pfield_computed
-  | Psetfield of int * immediate_or_pointer * initialization_or_assignment
+  | Pfield of field_info * field_read_semantics
+  | Pfield_computed of field_read_semantics
+  | Psetfield of field_info * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
-  | Pfloatfield of int
+  | Pfloatfield of int * field_read_semantics
   | Psetfloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* External call *)
@@ -316,8 +334,14 @@ and lambda_switch =
   { sw_numconsts: int;                  (* Number of integer cases *)
     sw_consts: (int * lambda) list;     (* Integer cases *)
     sw_numblocks: int;                  (* Number of tag block cases *)
-    sw_blocks: (int * lambda) list;     (* Tag block cases *)
+    sw_blocks: (lambda_switch_block_key * lambda) list;  (* Tag block cases *)
     sw_failaction : lambda option}      (* Action to take if failure *)
+
+and lambda_switch_block_key =
+  { sw_tag : int;
+    sw_size : int;
+  }
+
 and lambda_event =
   { lev_loc: scoped_location;
     lev_kind: lambda_event_kind;
@@ -461,3 +485,14 @@ val merge_inline_attributes
   -> inline_attribute option
 
 val reset: unit -> unit
+
+(** Helpers for module block accesses.
+   Size is considered to be unknown in all cases,
+   because coercions can reuse longer but compatible module blocks,
+   so the actual size of a module block may be greater than what its
+   type would suggest.
+   Module accesses are always immutable, except in translobj where the
+   method cache is stored in a mutable module field.
+*)
+val mod_field: ?read_semantics: field_read_semantics -> int -> primitive
+val mod_setfield: int -> primitive

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -100,6 +100,10 @@ module Scoped_location = Debuginfo.Scoped_location
 
 let dbg = false
 
+type simple_constructor_tag =
+  | Constant of int
+  | Block of int
+
 (*
    Compatibility predicate that considers potential rebindings of constructors
    of an extension type.
@@ -1674,12 +1678,18 @@ let get_expr_args_constr ~scopes head (arg, _mut) rem =
     | _ -> fatal_error "Matching.get_expr_args_constr"
   in
   let loc = head_loc ~scopes head in
-  let make_field_accesses binding_kind first_pos last_pos argl =
+  let make_field_accesses binding_kind first_pos last_pos block_info argl =
     let rec make_args pos =
       if pos > last_pos then
         argl
       else
-        (Lprim (Pfield pos, [ arg ], loc), binding_kind) :: make_args (pos + 1)
+        let field_info = {
+          index = pos;
+          block_info;
+        }
+        in
+        (Lprim (Pfield (field_info, Reads_agree), [ arg ], loc), binding_kind)
+          :: make_args (pos + 1)
     in
     make_args first_pos
   in
@@ -1687,11 +1697,19 @@ let get_expr_args_constr ~scopes head (arg, _mut) rem =
     (arg, Alias) :: rem
   else
     match cstr.cstr_tag with
-    | Cstr_constant _
-    | Cstr_block _ ->
-        make_field_accesses Alias 0 (cstr.cstr_arity - 1) rem
+    | Cstr_constant _ -> rem
+    | Cstr_block {tag; size} ->
+        let block_info = { tag; size = Known size; } in
+        make_field_accesses Alias 0 (cstr.cstr_arity - 1) block_info rem
     | Cstr_unboxed -> (arg, Alias) :: rem
-    | Cstr_extension _ -> make_field_accesses Alias 1 cstr.cstr_arity rem
+    | Cstr_extension (_, true) -> rem
+    | Cstr_extension (_, false) -> 
+        let block_info = {
+            tag = 0;
+            size = Known (cstr.cstr_arity + 1);
+          }
+        in
+        make_field_accesses Alias 1 cstr.cstr_arity block_info rem
 
 let divide_constructor ~scopes ctx pm =
   divide
@@ -1705,9 +1723,22 @@ let divide_constructor ~scopes ctx pm =
 
 let get_expr_args_variant_constant = drop_expr_arg
 
+let nonconstant_variant_field index =
+  Lambda.Pfield(
+    {
+      index;
+      (* Non-constant polymorphic variants are blocks of size 2:
+         First field is the hash label, second field is the argument.
+      *)
+      block_info = { tag = 0; size = Known 2; };
+    },
+    (* CR mshinwell: Is this correct? *)
+    Reads_agree)
+    
 let get_expr_args_variant_nonconst ~scopes head (arg, _mut) rem =
   let loc = head_loc ~scopes head in
-  (Lprim (Pfield 1, [ arg ], loc), Alias) :: rem
+   let field_prim = nonconstant_variant_field 1 in
+  (Lprim (field_prim, [ arg ], loc), Alias) :: rem
 
 let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
   let row = Btype.row_repr row in
@@ -1732,13 +1763,13 @@ let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
           | None ->
               add_in_div
                 (make_matching get_expr_args_variant_constant head def ctx)
-                ( = ) (Cstr_constant tag) (patl, action) variants
+                ( = ) (Constant tag) (patl, action) variants
           | Some pat ->
               add_in_div
                 (make_matching
                    (get_expr_args_variant_nonconst ~scopes)
                    head def ctx)
-                ( = ) (Cstr_block tag)
+                ( = ) (Block tag)
                 (pat :: patl, action)
                 variants
       )
@@ -1805,6 +1836,15 @@ let code_force_lazy = get_mod_field "CamlinternalLazy" "force"
    Forward(val_out_of_heap).
 *)
 
+let lazy_forward_field =
+  Lambda.Pfield (
+    {
+      index = 0;
+      block_info = { tag = Obj.forward_tag; size = Known 1; };
+    },
+    Reads_vary)
+
+
 let inline_lazy_force_cond arg loc =
   let idarg = Ident.create_local "lzarg" in
   let varg = Lvar idarg in
@@ -1827,7 +1867,7 @@ let inline_lazy_force_cond arg loc =
                 ( Pintcomp Ceq,
                   [ tag_var; Lconst (Const_base (Const_int Obj.forward_tag)) ],
                   loc ),
-              Lprim (Pfield 0, [ varg ], loc),
+              Lprim (lazy_forward_field, [ varg ], loc),
               Lifthenelse
                 (* if (tag == Obj.lazy_tag) then Lazy.force varg else ... *)
                 ( Lprim
@@ -1865,9 +1905,12 @@ let inline_lazy_force_switch arg loc =
                 sw_numblocks = 256;
                 (* PR#6033 - tag ranges from 0 to 255 *)
                 sw_blocks =
-                  [ (Obj.forward_tag, Lprim (Pfield 0, [ varg ], loc));
-                    ( Obj.lazy_tag,
-                      Lapply
+                  [ ({ sw_tag = Obj.forward_tag;
+                       sw_size = 1;
+                      }, Lprim (lazy_forward_field, [ varg ], loc));
+                    ({ sw_tag = Obj.lazy_tag;
+                       sw_size = 1;
+                     }, Lapply
                         { ap_tailcall = Default_tailcall;
                           ap_loc = loc;
                           ap_func = force_fun;
@@ -1929,7 +1972,13 @@ let get_expr_args_tuple ~scopes head (arg, _mut) rem =
     if pos >= arity then
       rem
     else
-      (Lprim (Pfield pos, [ arg ], loc), Alias) :: make_args (pos + 1)
+      let field_info = {
+        index = pos;
+        block_info = { tag = 0; size = Known arity; };
+      }
+      in
+      (Lprim (Pfield (field_info, Reads_agree), [ arg ], loc), Alias)
+        :: make_args (pos + 1)
   in
   make_args 0
 
@@ -1965,18 +2014,36 @@ let get_expr_args_record ~scopes head (arg, _mut) rem =
         assert false
   in
   let rec make_args pos =
-    if pos >= Array.length all_labels then
+    let len = Array.length all_labels in
+    if pos >= len then
       rem
     else
       let lbl = all_labels.(pos) in
+      let sem =
+        match lbl.lbl_mut with
+        | Immutable -> Reads_agree
+        | Mutable -> Reads_vary
+      in
       let access =
+        let field_info_reg tag = {
+          index = lbl.lbl_pos;
+          block_info = { tag; size = Known len; };
+        }
+        in
         match lbl.lbl_repres with
-        | Record_regular
-        | Record_inlined _ ->
-            Lprim (Pfield lbl.lbl_pos, [ arg ], loc)
+        | Record_regular ->
+            Lprim (Pfield (field_info_reg 0, sem), [ arg ], loc)
+        | Record_inlined tag ->
+            Lprim (Pfield (field_info_reg tag, sem), [ arg ], loc)
         | Record_unboxed _ -> arg
-        | Record_float -> Lprim (Pfloatfield lbl.lbl_pos, [ arg ], loc)
-        | Record_extension _ -> Lprim (Pfield (lbl.lbl_pos + 1), [ arg ], loc)
+        | Record_float -> Lprim (Pfloatfield (lbl.lbl_pos, sem), [ arg ], loc)
+        | Record_extension _ -> 
+            let field_info = {
+              index = lbl.lbl_pos + 1;
+              block_info = { tag = 0; size = Known (len + 1); };
+            }
+            in
+            Lprim (Pfield (field_info, sem), [ arg ], loc)
       in
       let str =
         match lbl.lbl_mut with
@@ -2355,11 +2422,12 @@ let reintroduce_fail sw =
         t;
       if !max >= 3 then
         let default = !i_max in
-        let remove =
+        let remove cases =
           List.filter (fun (_, lam) ->
               match as_simple_exit lam with
               | Some j -> j <> default
               | None -> true)
+            cases
         in
         { sw with
           sw_consts = remove sw.sw_consts;
@@ -2370,7 +2438,8 @@ let reintroduce_fail sw =
         sw
   | Some _ -> sw
 
-module Switcher = Switch.Make (SArg)
+
+module Switcher = Switch.Make(SArg)
 open Switch
 
 let rec last def = function
@@ -2657,13 +2726,31 @@ let split_cases tag_lambda_list =
         let consts, nonconsts = split_rec rem in
         match cstr_tag with
         | Cstr_constant n -> ((n, act) :: consts, nonconsts)
-        | Cstr_block n -> (consts, (n, act) :: nonconsts)
-        | Cstr_unboxed -> (consts, (0, act) :: nonconsts)
+        | Cstr_block { tag; size; } ->
+          let desc = { sw_tag = tag; sw_size = size; } in
+          (consts, (desc, act) :: nonconsts)
+        | Cstr_unboxed ->
+          (* The [sw_size] will never make it through to a [Lswitch]. *)
+          let desc = { sw_tag = 0; sw_size = 0; } in
+          (consts, (desc, act) :: nonconsts)
         | Cstr_extension _ -> assert false
       )
   in
   let const, nonconst = split_rec tag_lambda_list in
   (sort_int_lambda_list const, sort_int_lambda_list nonconst)
+
+let split_cases_simple tag_lambda_list =
+  let rec split_rec = function
+      [] -> ([], [])
+    | (cstr, act) :: rem ->
+        let (consts, nonconsts) = split_rec rem in
+        match cstr with
+        | Constant n -> ((n, act) :: consts, nonconsts)
+        | Block n    -> (consts, (n, act) :: nonconsts)
+  in
+  let const, nonconst = split_rec tag_lambda_list in
+  sort_int_lambda_list const,
+  sort_int_lambda_list nonconst
 
 let split_extension_cases tag_lambda_list =
   let rec split_rec = function
@@ -2711,7 +2798,14 @@ let combine_constructor loc arg pat_env cstr partial ctx def
                       (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem))
                   nonconsts default
               in
-              Llet (Alias, Pgenval, tag, Lprim (Pfield 0, [ arg ], loc), tests)
+              (* We're matching on an extensible type that might correspond
+                 to the given constructor. So the size is Unknown, as not all
+                 constructors have the same size. *)
+              let block_info = { tag = 0; size = Unknown; } in
+              let field_info = { index = 0; block_info; } in
+              Llet (Alias, Pgenval, tag,
+                    Lprim (Pfield (field_info, Reads_agree), [ arg ], loc),
+                    tests)
         in
         List.fold_right
           (fun (path, act) rem ->
@@ -2744,7 +2838,7 @@ let combine_constructor loc arg pat_env cstr partial ctx def
             match
               (cstr.cstr_consts, cstr.cstr_nonconsts, consts, nonconsts)
             with
-            | 1, 1, [ (0, act1) ], [ (0, act2) ] ->
+          | 1, 1, [(0, act1)], [{ sw_tag = 0; sw_size = _; }, act2] ->
                 (* Typically, match on lists, will avoid isint primitive in that
               case *)
                 Lifthenelse (arg, act2, act1)
@@ -2801,7 +2895,7 @@ let call_switcher_variant_constr loc fail arg int_lambda_list =
     ( Alias,
       Pgenval,
       v,
-      Lprim (Pfield 0, [ arg ], loc),
+      Lprim (nonconstant_variant_field 0, [ arg ], loc),
       call_switcher loc fail (Lvar v) min_int max_int int_lambda_list )
 
 let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)
@@ -2836,7 +2930,7 @@ let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)
     else
       mk_failaction_neg partial ctx def
   in
-  let consts, nonconsts = split_cases tag_lambda_list in
+  let consts, nonconsts = split_cases_simple tag_lambda_list in
   let lambda1 =
     match (fail, one_action) with
     | None, Some act -> act

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -146,6 +146,11 @@ let float_comparison ppf = function
   | CFge -> fprintf ppf ">=."
   | CFnge -> fprintf ppf "!>=."
 
+let field_read_semantics ppf sem =
+  match sem with
+  | Reads_agree -> ()
+  | Reads_vary -> fprintf ppf "_mut"
+
 let primitive ppf = function
   | Pidentity -> fprintf ppf "id"
   | Pbytes_to_string -> fprintf ppf "bytes_to_string"
@@ -159,9 +164,11 @@ let primitive ppf = function
       fprintf ppf "makeblock %i%a" tag block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag block_shape shape
-  | Pfield n -> fprintf ppf "field %i" n
-  | Pfield_computed -> fprintf ppf "field_computed"
-  | Psetfield(n, ptr, init) ->
+  | Pfield ({index = n; block_info = _;}, sem) ->
+      fprintf ppf "field%a %i" field_read_semantics sem n
+  | Pfield_computed sem ->
+      fprintf ppf "field_computed%a" field_read_semantics sem
+  | Psetfield({index = n; block_info = _;}, ptr, init) ->
       let instr =
         match ptr with
         | Pointer -> "ptr"
@@ -187,7 +194,8 @@ let primitive ppf = function
         | Assignment -> ""
       in
       fprintf ppf "setfield_%s%s_computed" instr init
-  | Pfloatfield n -> fprintf ppf "floatfield %i" n
+  | Pfloatfield (n, sem) ->
+      fprintf ppf "floatfield%a %i" field_read_semantics sem n
   | Psetfloatfield (n, init) ->
       let init =
         match init with
@@ -356,7 +364,7 @@ let name_of_primitive = function
   | Psetglobal _ -> "Psetglobal"
   | Pmakeblock _ -> "Pmakeblock"
   | Pfield _ -> "Pfield"
-  | Pfield_computed -> "Pfield_computed"
+  | Pfield_computed _ -> "Pfield_computed"
   | Psetfield _ -> "Psetfield"
   | Psetfield_computed _ -> "Psetfield_computed"
   | Pfloatfield _ -> "Pfloatfield"
@@ -566,9 +574,9 @@ let rec lam ppf = function
            fprintf ppf "@[<hv 1>case int %i:@ %a@]" n lam l)
          sw.sw_consts;
         List.iter
-          (fun (n, l) ->
+          (fun ({ sw_tag = tag; sw_size = _; }, l) ->
             if !spc then fprintf ppf "@ " else spc := true;
-            fprintf ppf "@[<hv 1>case tag %i:@ %a@]" n lam l)
+            fprintf ppf "@[<hv 1>case tag %i:@ %a@]" tag lam l)
           sw.sw_blocks ;
         begin match sw.sw_failaction with
         | None  -> ()

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -162,6 +162,8 @@ let primitive ppf = function
   | Psetglobal id -> fprintf ppf "setglobal %a" Ident.print id
   | Pmakeblock(tag, Immutable, shape) ->
       fprintf ppf "makeblock %i%a" tag block_shape shape
+  | Pmakeblock(tag, Immutable_unique, shape) ->
+      fprintf ppf "makeblock_unique %i%a" tag block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag block_shape shape
   | Pfield ({index = n; block_info = _;}, sem) ->
@@ -251,8 +253,12 @@ let primitive ppf = function
   | Parraylength k -> fprintf ppf "array.length[%s]" (array_kind k)
   | Pmakearray (k, Mutable) -> fprintf ppf "makearray[%s]" (array_kind k)
   | Pmakearray (k, Immutable) -> fprintf ppf "makearray_imm[%s]" (array_kind k)
+  | Pmakearray (k, Immutable_unique) ->
+      fprintf ppf "makearray_unique[%s]" (array_kind k)
   | Pduparray (k, Mutable) -> fprintf ppf "duparray[%s]" (array_kind k)
   | Pduparray (k, Immutable) -> fprintf ppf "duparray_imm[%s]" (array_kind k)
+  | Pduparray (k, Immutable_unique) ->
+      fprintf ppf "duparray_unique[%s]" (array_kind k)
   | Parrayrefu k -> fprintf ppf "array.unsafe_get[%s]" (array_kind k)
   | Parraysetu k -> fprintf ppf "array.unsafe_set[%s]" (array_kind k)
   | Parrayrefs k -> fprintf ppf "array.get[%s]" (array_kind k)

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -40,9 +40,10 @@ let rec eliminate_ref id = function
   | Lletrec(idel, e2) ->
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
-  | Lprim(Pfield 0, [Lvar v], _) when Ident.same v id ->
+  | Lprim(Pfield ({ index = 0; _ }, _), [Lvar v], _) when Ident.same v id ->
       Lvar id
-  | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
+  | Lprim(Psetfield({index = 0; _ }, _, _), [Lvar v; e], _)
+    when Ident.same v id ->
       Lassign(id, eliminate_ref id e)
   | Lprim(Poffsetref delta, [Lvar v], loc) when Ident.same v id ->
       Lassign(id, Lprim(Poffsetint delta, [Lvar id], loc))
@@ -649,8 +650,8 @@ let rec emit_tail_infos is_tail lambda =
       list_emit_tail_infos false l
   | Lswitch (lam, sw, _loc) ->
       emit_tail_infos false lam;
-      list_emit_tail_infos_fun snd is_tail sw.sw_consts;
-      list_emit_tail_infos_fun snd is_tail sw.sw_blocks;
+      list_emit_tail_infos_fun0 snd is_tail sw.sw_consts;
+      list_emit_tail_infos_fun1 snd is_tail sw.sw_blocks;
       Option.iter  (emit_tail_infos is_tail) sw.sw_failaction
   | Lstringswitch (lam, sw, d, _) ->
       emit_tail_infos false lam;
@@ -690,7 +691,10 @@ let rec emit_tail_infos is_tail lambda =
       emit_tail_infos is_tail lam
   | Lifused (_, lam) ->
       emit_tail_infos is_tail lam
-and list_emit_tail_infos_fun f is_tail =
+(* CR mshinwell: Why doesn't this generalise when eta expanded? *)
+and list_emit_tail_infos_fun0 f is_tail =
+  List.iter (fun x -> emit_tail_infos is_tail (f x))
+and list_emit_tail_infos_fun1 f is_tail =
   List.iter (fun x -> emit_tail_infos is_tail (f x))
 and list_emit_tail_infos is_tail =
   List.iter (emit_tail_infos is_tail)

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -63,7 +63,13 @@ let mkappl (func, args) =
 let lsequence l1 l2 =
   if l2 = lambda_unit then l1 else Lsequence(l1, l2)
 
-let lfield v i = Lprim(Pfield i, [Lvar v], Loc_unknown)
+let lfield v i bi =
+  let field_info = {
+    index = i;
+    block_info = bi;
+  }
+  in
+  Lprim(Pfield (field_info, Reads_vary), [Lvar v], Loc_unknown)
 
 let transl_label l = share (Const_immstring l)
 
@@ -134,7 +140,12 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
       let env =
         match envs with None -> []
         | Some envs ->
-            [Lprim(Pfield (List.length inh_init + 1),
+            let field_info = {
+              index = List.length inh_init + 1;
+              block_info = { tag = 0; size = Unknown; };
+            }
+            in
+            [Lprim(Pfield (field_info, Reads_vary),
                    [Lvar envs],
                    Loc_unknown)]
       in
@@ -240,12 +251,14 @@ let bind_methods tbl meths vals cl_init =
     if nvals = 0 then "get_method_labels", [] else
     "new_methods_variables", [transl_meth_list (List.map fst vals)]
   in
+  (* size is exactly len + nvals, but we choose not to track it. *)
+  let bi = { tag = 0; size = Unknown; } in
   Llet(Strict, Pgenval, ids,
        mkappl (oo_prim getter,
                [Lvar tbl; transl_meth_list (List.map fst methl)] @ names),
        List.fold_right
          (fun (_lab,id) lam -> decr i; Llet(StrictOpt, Pgenval, id,
-                                           lfield ids !i, lam))
+                                           lfield ids !i bi, lam))
          (methl @ vals) cl_init)
 
 let output_methods tbl methods lam =
@@ -272,6 +285,14 @@ let rec index a = function
 
 let bind_id_as_val (id, _) = ("", id)
 
+let class_field i =
+  let field_info = {
+    index = i;
+    block_info = { tag = 0; size = Known 4; };
+  }
+  in
+  Pfield (field_info, Reads_vary)
+
 let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
   match cl.cl_desc with
   | Tcl_ident _ ->
@@ -279,8 +300,8 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
       | (_, path_lam, obj_init)::inh_init ->
           (inh_init,
            Llet (Strict, Pgenval, obj_init,
-                 mkappl(Lprim(Pfield 1, [path_lam], Loc_unknown), Lvar cla ::
-                        if top then [Lprim(Pfield 3, [path_lam], Loc_unknown)]
+                 mkappl(Lprim(class_field 1, [path_lam], Loc_unknown), Lvar cla ::
+                        if top then [Lprim(class_field 3, [path_lam], Loc_unknown)]
                         else []),
                  bind_super cla super cl_init))
       | _ ->
@@ -366,25 +387,26 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
           let inh = Ident.create_local "inh"
           and ofs = List.length vals + 1
           and valids, methids = super in
+          let bi = { tag = 0; size = Unknown; } in
           let cl_init =
             List.fold_left
               (fun init (nm, id, _) ->
                 Llet(StrictOpt, Pgenval, id,
-                     lfield inh (index nm concr_meths + ofs),
+                     lfield inh (index nm concr_meths + ofs) bi,
                      init))
               cl_init methids in
           let cl_init =
             List.fold_left
               (fun init (nm, id) ->
                 Llet(StrictOpt, Pgenval, id,
-                     lfield inh (index nm vals + 1), init))
+                     lfield inh (index nm vals + 1) bi, init))
               cl_init valids in
           (inh_init,
            Llet (Strict, Pgenval, inh,
                  mkappl(oo_prim "inherits", narrow_args @
                         [path_lam;
                          Lconst(const_int (if top then 1 else 0))]),
-                 Llet(StrictOpt, Pgenval, obj_init, lfield inh 0, cl_init)))
+                 Llet(StrictOpt, Pgenval, obj_init, lfield inh 0 bi, cl_init)))
       | _ ->
           let core cl_init =
             build_class_init
@@ -511,20 +533,21 @@ let transl_class_rebind ~scopes cl vf =
     and env_init = Ident.create_local "env_init"
     and table = Ident.create_local "table"
     and envs = Ident.create_local "envs" in
+    let bi = { tag = 0; size = Known 4; } in
     Llet(
     Strict, Pgenval, new_init, lfunction [obj_init, Pgenval] obj_init',
     Llet(
     Alias, Pgenval, cla, path_lam,
     Lprim(Pmakeblock(0, Immutable, None),
-          [mkappl(Lvar new_init, [lfield cla 0]);
+          [mkappl(Lvar new_init, [lfield cla 0 bi]);
            lfunction [table, Pgenval]
              (Llet(Strict, Pgenval, env_init,
-                   mkappl(lfield cla 1, [Lvar table]),
+                   mkappl(lfield cla 1 bi, [Lvar table]),
                    lfunction [envs, Pgenval]
                      (mkappl(Lvar new_init,
                              [mkappl(Lvar env_init, [Lvar envs])]))));
-           lfield cla 2;
-           lfield cla 3],
+           lfield cla 2 bi;
+           lfield cla 3 bi],
           Loc_unknown)))
   with Exit ->
     lambda_unit
@@ -553,7 +576,7 @@ let rec builtin_meths self env env2 body =
     | p when const_path p -> "const", [p]
     | Lprim(Parrayrefu _, [Lvar s; Lvar n], _) when List.mem s self ->
         "var", [Lvar n]
-    | Lprim(Pfield n, [Lvar e], _) when Ident.same e env ->
+    | Lprim(Pfield ({index = n; _ }, _), [Lvar e], _) when Ident.same e env ->
         "env", [Lvar env2; Lconst(const_int n)]
     | Lsend(Self, met, Lvar s, [], _) when List.mem s self ->
         "meth", [met]
@@ -713,9 +736,10 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
     new_ids' := !new_ids' @ Ident.Set.elements fv;
     (* prerr_ids "new_ids' =" !new_ids'; *)
     let i = ref (i0-1) in
+    let bi = { tag = 0; size = Unknown; } in
     List.fold_left
       (fun subst id ->
-        incr i; Ident.Map.add id (lfield env !i)  subst)
+        incr i; Ident.Map.add id (lfield env !i bi)  subst)
       Ident.Map.empty !new_ids'
   in
   let new_ids_meths = ref [] in
@@ -735,7 +759,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
           [lfunction ((self, Pgenval) :: args)
              (if not (Ident.Set.mem env (free_variables body')) then body' else
               Llet(Alias, Pgenval, env,
-                   Lprim(Pfield_computed,
+                   Lprim(Pfield_computed Reads_vary,
                          [Lvar self; Lvar env2],
                          Loc_unknown),
                    body'))]
@@ -753,9 +777,12 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
     if top then lam else
     (* must be called only once! *)
     let lam = Lambda.subst no_env_update (subst env1 lam 1 new_ids_init) lam in
-    Llet(Alias, Pgenval, env1, (if l = [] then Lvar envs else lfield envs 0),
+    Llet(Alias, Pgenval, env1,
+         (if l = [] then Lvar envs
+          else lfield envs 0 { tag = 0; size = Unknown; }),
     Llet(Alias, Pgenval, env1',
-         (if !new_ids_init = [] then Lvar env1 else lfield env1 0),
+         (if !new_ids_init = [] then Lvar env1
+          else lfield env1 0 { tag = 0; size = Unknown; }),
          lam))
   in
 
@@ -849,7 +876,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
           Loc_unknown)
   and linh_envs =
     List.map
-      (fun (_, path_lam, _) -> Lprim(Pfield 3, [path_lam], Loc_unknown))
+      (fun (_, path_lam, _) ->
+        Lprim(class_field 3, [path_lam], Loc_unknown))
       (List.rev inh_init)
   in
   let make_envs lam =
@@ -869,7 +897,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   in
   let inh_keys =
     List.map
-      (fun (_, path_lam, _) -> Lprim(Pfield 1, [path_lam], Loc_unknown))
+      (fun (_, path_lam, _) ->
+        Lprim(class_field 1, [path_lam], Loc_unknown))
       inh_paths
   in
   let lclass lam =
@@ -887,7 +916,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                                     inh_keys, Loc_unknown)]),
          lam)
   and lset cached i lam =
-    Lprim(Psetfield(i, Pointer, Assignment),
+    let field_info = { index = i; block_info = { tag = 0; size  = Unknown; }; } in
+    Lprim(Psetfield(field_info, Pointer, Assignment),
           [Lvar cached; lam], Loc_unknown)
   in
   let ldirect () =
@@ -915,25 +945,27 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
             mkappl (oo_prim "make_class_store",
                     [transl_meth_list pub_meths;
                      Lvar class_init; Lvar cached])) in
+  (* CR vlaviron size might be known (3?) *)
+  let cached_bi = { tag = 0; size = Unknown; } in
   let lcheck_cache =
     if !Clflags.native_code && !Clflags.afl_instrument then
       (* When afl-fuzz instrumentation is enabled, ignore the cache
          so that the program's behaviour does not change between runs *)
       lupdate_cache
     else
-      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache) in
+      Lifthenelse(lfield cached 0 cached_bi, lambda_unit, lupdate_cache) in
   llets (
   lcache (
   Lsequence(lcheck_cache,
   make_envs (
-  if ids = [] then mkappl (lfield cached 0, [lenvs]) else
+  if ids = [] then mkappl (lfield cached 0 cached_bi, [lenvs]) else
   Lprim(Pmakeblock(0, Immutable, None),
         (if concrete then
-          [mkappl (lfield cached 0, [lenvs]);
-           lfield cached 1;
-           lfield cached 0;
+          [mkappl (lfield cached 0 cached_bi, [lenvs]);
+           lfield cached 1 cached_bi;
+           lfield cached 0 cached_bi;
            lenvs]
-        else [lambda_unit; lfield cached 0; lambda_unit; lenvs]),
+        else [lambda_unit; lfield cached 0 cached_bi; lambda_unit; lenvs]),
         Loc_unknown
        )))))
 

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -87,7 +87,7 @@ let transl_extension_constructor ~scopes env path ext =
   let loc = of_location ~scopes ext.ext_loc in
   match ext.ext_kind with
     Text_decl _ ->
-      Lprim (Pmakeblock (Obj.object_tag, Immutable, None),
+      Lprim (Pmakeblock (Obj.object_tag, Immutable_unique, None),
         [Lconst (Const_base (Const_string (name, ext.ext_loc, None)));
          Lprim (prim_fresh_oo_id, [Lconst (const_int 0)], loc)],
         loc)
@@ -1060,8 +1060,8 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
         fields
     in
     let ll, shape = List.split (Array.to_list lv) in
-    let mut =
-      if Array.exists (fun (lbl, _) -> lbl.lbl_mut = Mutable) fields
+    let mut : Lambda.mutable_flag =
+      if Array.exists (fun (lbl, _) -> lbl.lbl_mut = Asttypes.Mutable) fields
       then Mutable
       else Immutable in
     let lam =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -58,6 +58,21 @@ let declare_probe_handlers lam =
 let prim_fresh_oo_id =
   Pccall (Primitive.simple ~name:"caml_fresh_oo_id" ~arity:1 ~alloc:false)
 
+let record_field_info lbl =
+  let size = Array.length lbl.lbl_all in
+  let is_ext, tag =
+    match lbl.lbl_repres with
+    | Record_extension _ -> true, 0
+    | Record_regular -> false, 0
+    | Record_inlined tag -> false, tag
+    | Record_float | Record_unboxed _ ->
+      assert false
+  in
+  { index = lbl.lbl_pos + (if is_ext then 1 else 0);
+    block_info =
+      { tag; size = Known (size + (if is_ext then 1 else 0)); };
+  }
+
 let transl_extension_constructor ~scopes env path ext =
   let path =
     Printtyp.wrap_printing_env env ~error:true (fun () ->
@@ -333,11 +348,12 @@ and transl_exp0 ~in_new_scope ~scopes e =
           Lconst(const_int n)
       | Cstr_unboxed ->
           (match ll with [v] -> v | _ -> assert false)
-      | Cstr_block n ->
+      | Cstr_block { tag; size; } ->
+          assert (size = List.length ll);
           begin try
-            Lconst(Const_block(n, List.map extract_constant ll))
+            Lconst(Const_block(tag, List.map extract_constant ll))
           with Not_constant ->
-            Lprim(Pmakeblock(n, Immutable, Some shape), ll,
+            Lprim(Pmakeblock(tag, Immutable, Some shape), ll,
                   of_location ~scopes e.exp_loc)
           end
       | Cstr_extension(path, is_const) ->
@@ -369,16 +385,21 @@ and transl_exp0 ~in_new_scope ~scopes e =
         fields representation extended_expression
   | Texp_field(arg, _, lbl) ->
       let targ = transl_exp ~scopes arg in
+      let sem =
+        match lbl.lbl_mut with
+        | Immutable -> Reads_agree
+        | Mutable -> Reads_vary
+      in
       begin match lbl.lbl_repres with
           Record_regular | Record_inlined _ ->
-          Lprim (Pfield lbl.lbl_pos, [targ],
+          Lprim (Pfield (record_field_info lbl, sem), [targ],
                  of_location ~scopes e.exp_loc)
         | Record_unboxed _ -> targ
         | Record_float ->
-          Lprim (Pfloatfield lbl.lbl_pos, [targ],
+          Lprim (Pfloatfield (lbl.lbl_pos, sem), [targ],
                  of_location ~scopes e.exp_loc)
         | Record_extension _ ->
-          Lprim (Pfield (lbl.lbl_pos + 1), [targ],
+          Lprim (Pfield (record_field_info lbl, sem), [targ],
                  of_location ~scopes e.exp_loc)
       end
   | Texp_setfield(arg, _, lbl, newval) ->
@@ -386,11 +407,11 @@ and transl_exp0 ~in_new_scope ~scopes e =
         match lbl.lbl_repres with
           Record_regular
         | Record_inlined _ ->
-          Psetfield(lbl.lbl_pos, maybe_pointer newval, Assignment)
+          Psetfield(record_field_info lbl, maybe_pointer newval, Assignment)
         | Record_unboxed _ -> assert false
         | Record_float -> Psetfloatfield (lbl.lbl_pos, Assignment)
         | Record_extension _ ->
-          Psetfield (lbl.lbl_pos + 1, maybe_pointer newval, Assignment)
+          Psetfield (record_field_info lbl, maybe_pointer newval, Assignment)
       in
       Lprim(access, [transl_exp ~scopes arg; transl_exp ~scopes newval],
             of_location ~scopes e.exp_loc)
@@ -475,10 +496,18 @@ and transl_exp0 ~in_new_scope ~scopes e =
       event_after ~scopes e lam
   | Texp_new (cl, {Location.loc=loc}, _) ->
       let loc = of_location ~scopes loc in
+      let field_info = {
+        index = 0;
+        (* CR vlaviron: Maybe size should be Unknown
+           (but this is coherent with translclass) *)
+        block_info = { tag = 0; size = Known 4; };
+      }
+      in
       Lapply{
         ap_loc=loc;
         ap_func=
-          Lprim(Pfield 0, [transl_class_path loc e.exp_env cl], loc);
+          Lprim(Pfield (field_info, Reads_vary),
+              [transl_class_path loc e.exp_env cl], loc);
         ap_args=[lambda_unit];
         ap_tailcall=Default_tailcall;
         ap_inlined=Default_inline;
@@ -489,7 +518,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
       let loc = of_location ~scopes e.exp_loc in
       let self = transl_value_path loc e.exp_env path_self in
       let var = transl_value_path loc e.exp_env path in
-      Lprim(Pfield_computed, [self; var], loc)
+      Lprim(Pfield_computed Reads_vary, [self; var], loc)
   | Texp_setinstvar(path_self, path, _, expr) ->
       let loc = of_location ~scopes e.exp_loc in
       let self = transl_value_path loc e.exp_env path_self in
@@ -614,7 +643,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           let body, _ =
             List.fold_left (fun (body, pos) id ->
               Llet(Alias, Pgenval, id,
-                   Lprim(Pfield pos, [Lvar oid],
+                   Lprim(mod_field pos, [Lvar oid],
                          of_location ~scopes od.open_loc), body),
               pos + 1
             ) (transl_exp ~scopes e, 0)
@@ -1000,16 +1029,28 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
     let init_id = Ident.create_local "init" in
     let lv =
       Array.mapi
-        (fun i (_, definition) ->
+        (fun i (lbl, definition) ->
            match definition with
            | Kept typ ->
                let field_kind = value_kind env typ in
+               let sem =
+                 match lbl.lbl_mut with
+                 | Immutable -> Reads_agree
+                 | Mutable -> Reads_vary
+               in
+               let field_info is_ext tag i =
+                 let offset = if is_ext then 1 else 0 in
+                 { index = i + offset;
+                   block_info = { tag; size = Known (size + offset); };
+                 }
+               in
                let access =
                  match repres with
-                   Record_regular | Record_inlined _ -> Pfield i
+                   Record_regular -> Pfield (field_info false 0 i, sem)
+                 | Record_inlined tag -> Pfield (field_info false tag i, sem)
                  | Record_unboxed _ -> assert false
-                 | Record_extension _ -> Pfield (i + 1)
-                 | Record_float -> Pfloatfield i in
+                 | Record_extension _ -> Pfield (field_info true 0 i, sem)
+                 | Record_float -> Pfloatfield (i, sem) in
                Lprim(access, [Lvar init_id],
                      of_location ~scopes loc),
                field_kind
@@ -1066,11 +1107,11 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
             match repres with
               Record_regular
             | Record_inlined _ ->
-                Psetfield(lbl.lbl_pos, maybe_pointer expr, Assignment)
+                Psetfield(record_field_info lbl, maybe_pointer expr, Assignment)
             | Record_unboxed _ -> assert false
             | Record_float -> Psetfloatfield (lbl.lbl_pos, Assignment)
             | Record_extension _ ->
-                Psetfield(lbl.lbl_pos + 1, maybe_pointer expr, Assignment)
+                Psetfield(record_field_info lbl, maybe_pointer expr, Assignment)
           in
           Lsequence(Lprim(upd, [Lvar copy_id; transl_exp ~scopes expr],
                           of_location ~scopes loc),

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -83,7 +83,8 @@ let rec apply_coercion loc strict restr arg =
       name_lambda strict arg (fun id ->
         let get_field pos =
           if pos < 0 then lambda_unit
-          else Lprim(Pfield pos,[Lvar id], loc)
+          else
+            Lprim(mod_field pos,[Lvar id], loc)
         in
         let lam =
           Lprim(Pmakeblock(0, Immutable, None),
@@ -758,7 +759,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                   rebind_idents (pos + 1) (id :: newfields) ids
                 in
                 Llet(Alias, Pgenval, id,
-                     Lprim(Pfield pos, [Lvar mid],
+                     Lprim(mod_field pos, [Lvar mid],
                            of_location ~scopes incl.incl_loc), body),
                 size
           in
@@ -787,7 +788,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                     rebind_idents (pos + 1) (id :: newfields) ids
                   in
                   Llet(Alias, Pgenval, id,
-                      Lprim(Pfield pos, [Lvar mid],
+                      Lprim(mod_field pos, [Lvar mid],
                             of_location ~scopes od.open_loc), body),
                   size
               in
@@ -1009,7 +1010,8 @@ let transl_store_subst = ref Ident.Map.empty
 
 let nat_toplevel_name id =
   try match Ident.Map.find id !transl_store_subst with
-    | Lprim(Pfield pos, [Lprim(Pgetglobal glob, [], _)], _) -> (glob,pos)
+    | Lprim(Pfield ({ index = pos; _}, _),
+            [Lprim(Pgetglobal glob, [], _)], _) -> (glob,pos)
     | _ -> raise Not_found
   with Not_found ->
     fatal_error("Translmod.nat_toplevel_name: " ^ Ident.unique_name id)
@@ -1254,7 +1256,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               | [] -> transl_store
                         ~scopes rootpath (add_idents true ids subst) cont rem
               | id :: idl ->
-                  Llet(Alias, Pgenval, id, Lprim(Pfield pos, [Lvar mid],
+                  Llet(Alias, Pgenval, id, Lprim(mod_field pos, [Lvar mid],
                                                  of_location ~scopes loc),
                        Lsequence(store_ident (of_location ~scopes loc) id,
                                  store_idents (pos + 1) idl))
@@ -1300,8 +1302,9 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         [] -> transl_store ~scopes rootpath
                                 (add_idents true ids subst) cont rem
                       | id :: idl ->
-                          Llet(Alias, Pgenval, id, Lprim(Pfield pos, [Lvar mid],
-                                                         loc),
+                          Llet(Alias, Pgenval, id,
+                               Lprim(mod_field pos,
+                                     [Lvar mid], loc),
                                Lsequence(store_ident loc id,
                                          store_idents (pos + 1) idl))
                     in
@@ -1320,7 +1323,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
     try
       let (pos, cc) = Ident.find_same id map in
       let init_val = apply_coercion loc Alias cc (Lvar id) in
-      Lprim(Psetfield(pos, Pointer, Root_initialization),
+      Lprim(mod_setfield pos,
             [Lprim(Pgetglobal glob, [], loc); init_val],
             loc)
     with Not_found ->
@@ -1335,7 +1338,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
       match cc with
         Tcoerce_none ->
           Ident.Map.add id
-            (Lprim(Pfield pos,
+            (Lprim(mod_field pos,
                    [Lprim(Pgetglobal glob, [], Loc_unknown)],
                    Loc_unknown))
             subst
@@ -1348,7 +1351,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
     List.fold_right (add_ident may_coerce) idlist subst
 
   and store_primitive (pos, prim) cont =
-    Lsequence(Lprim(Psetfield(pos, Pointer, Root_initialization),
+    Lsequence(Lprim(mod_setfield pos,
                     [Lprim(Pgetglobal glob, [], Loc_unknown);
                      Translprim.transl_primitive Loc_unknown
                        prim.pc_desc prim.pc_env prim.pc_type None],
@@ -1358,7 +1361,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
   and store_alias (pos, env, path, cc) =
     let path_lam = transl_module_path Loc_unknown env path in
     let init_val = apply_coercion Loc_unknown Strict cc path_lam in
-    Lprim(Psetfield(pos, Pointer, Root_initialization),
+    Lprim(mod_setfield pos,
           [Lprim(Pgetglobal glob, [], Loc_unknown);
            init_val],
           Loc_unknown)
@@ -1479,7 +1482,7 @@ let toplevel_name id =
 let toploop_getvalue id =
   Lapply{
     ap_loc=Loc_unknown;
-    ap_func=Lprim(Pfield toploop_getvalue_pos,
+    ap_func=Lprim(mod_field toploop_getvalue_pos,
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=[Lconst(Const_base(
@@ -1493,7 +1496,7 @@ let toploop_getvalue id =
 let toploop_setvalue id lam =
   Lapply{
     ap_loc=Loc_unknown;
-    ap_func=Lprim(Pfield toploop_setvalue_pos,
+    ap_func=Lprim(mod_field toploop_setvalue_pos,
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=
@@ -1586,7 +1589,7 @@ let transl_toplevel_item ~scopes item =
           lambda_unit
       | id :: ids ->
           Lsequence(toploop_setvalue id
-                      (Lprim(Pfield pos, [Lvar mid], Loc_unknown)),
+                      (Lprim(mod_field pos, [Lvar mid], Loc_unknown)),
                     set_idents (pos + 1) ids) in
       Llet(Strict, Pgenval, mid,
            transl_module ~scopes Tcoerce_none None modl, set_idents 0 ids)
@@ -1609,7 +1612,7 @@ let transl_toplevel_item ~scopes item =
                 lambda_unit
             | id :: ids ->
                 Lsequence(toploop_setvalue id
-                            (Lprim(Pfield pos, [Lvar mid], Loc_unknown)),
+                            (Lprim(mod_field pos, [Lvar mid], Loc_unknown)),
                           set_idents (pos + 1) ids)
           in
           Llet(pure, Pgenval, mid,
@@ -1697,7 +1700,7 @@ let transl_store_package component_names target_name coercion =
       (List.length component_names,
        make_sequence
          (fun pos id ->
-           Lprim(Psetfield(pos, Pointer, Root_initialization),
+           Lprim(mod_setfield pos,
                  [Lprim(Pgetglobal target_name, [], Loc_unknown);
                   get_component id],
                  Loc_unknown))
@@ -1714,9 +1717,9 @@ let transl_store_package component_names target_name coercion =
              apply_coercion Loc_unknown Strict coercion components,
              make_sequence
                (fun pos _id ->
-                 Lprim(Psetfield(pos, Pointer, Root_initialization),
+                 Lprim(mod_setfield pos,
                        [Lprim(Pgetglobal target_name, [], Loc_unknown);
-                        Lprim(Pfield pos, [Lvar blk], Loc_unknown)],
+                        Lprim(mod_field pos, [Lvar blk], Loc_unknown)],
                        Loc_unknown))
                0 pos_cc_list))
   (*

--- a/ocaml/lambda/translobj.ml
+++ b/ocaml/lambda/translobj.ml
@@ -125,7 +125,7 @@ let transl_label_init_flambda f =
 let transl_store_label_init glob size f arg =
   assert(not Config.flambda);
   assert(!Clflags.native_code);
-  method_cache := Lprim(Pfield size,
+  method_cache := Lprim(mod_field ~read_semantics:Reads_vary size,
                         [Lprim(Pgetglobal glob, [], Loc_unknown)],
                         Loc_unknown);
   let expr = f arg in
@@ -133,7 +133,7 @@ let transl_store_label_init glob size f arg =
     if !method_count = 0 then (size, expr) else
     (size+1,
      Lsequence(
-     Lprim(Psetfield(size, Pointer, Root_initialization),
+     Lprim(mod_setfield size,
            [Lprim(Pgetglobal glob, [], Loc_unknown);
             Lprim (Pccall prim_makearray,
                    [int !method_count; int 0],

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -109,6 +109,21 @@ let gen_array_kind =
 let prim_sys_argv =
   Primitive.simple ~name:"caml_sys_argv" ~arity:1 ~alloc:true
 
+let field_unknown i =
+  { index = i;
+    block_info = { tag = 0; size = Unknown; };
+  }
+
+let field_ref =
+  { index = 0;
+    block_info = { tag = 0; size = Known 1; };
+  }
+
+let field_pair i =
+  { index = i;
+    block_info = { tag = 0; size = Known 2; };
+  }
+
 let primitives_table =
   create_hashtable 57 [
     "%identity", Primitive (Pidentity, 1);
@@ -123,9 +138,12 @@ let primitives_table =
     "%loc_POS", Loc Loc_POS;
     "%loc_MODULE", Loc Loc_MODULE;
     "%loc_FUNCTION", Loc Loc_FUNCTION;
-    "%field0", Primitive ((Pfield 0), 1);
-    "%field1", Primitive ((Pfield 1), 1);
-    "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
+    "%field0", Primitive ((Pfield (field_unknown 0, Reads_vary)), 1);
+    "%field1", Primitive ((Pfield (field_unknown 1, Reads_vary)), 1);
+    "%ref_field0", Primitive ((Pfield (field_ref, Reads_vary)), 1);
+    "%pair_field0", Primitive ((Pfield (field_pair 0, Reads_agree)), 1);
+    "%pair_field1", Primitive ((Pfield (field_pair 1, Reads_agree)), 1);
+    "%setfield0", Primitive ((Psetfield(field_unknown 0, Pointer, Assignment)), 2);
     "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
     "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);
     "%raise", Raise Raise_regular;
@@ -760,7 +778,7 @@ let lambda_primitive_needs_event_after = function
   | Pbbswap _ -> true
 
   | Pidentity | Pbytes_to_string | Pbytes_of_string | Pignore | Psetglobal _
-  | Pgetglobal _ | Pmakeblock _ | Pfield _ | Pfield_computed | Psetfield _
+  | Pgetglobal _ | Pmakeblock _ | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Praise _
   | Psequor | Psequand | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint

--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type mutable_flag = Asttypes.mutable_flag
+type mutable_flag = Lambda.mutable_flag
 
 type immediate_or_pointer = Lambda.immediate_or_pointer
 

--- a/ocaml/middle_end/clambda_primitives.mli
+++ b/ocaml/middle_end/clambda_primitives.mli
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type mutable_flag = Asttypes.mutable_flag
+type mutable_flag = Lambda.mutable_flag
 
 type immediate_or_pointer = Lambda.immediate_or_pointer
 

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -1106,12 +1106,13 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let dbg = Debuginfo.from_location loc in
       check_constant_result (getglobal dbg id)
                             (Compilenv.global_approx id)
-  | Lprim(Pfield n, [lam], loc) ->
+  | Lprim(Pfield ({ index = n; _ }, _), [lam], loc) ->
       let (ulam, approx) = close env lam in
       let dbg = Debuginfo.from_location loc in
       check_constant_result (Uprim(P.Pfield n, [ulam], dbg))
                             (field_approx n approx)
-  | Lprim(Psetfield(n, is_ptr, init), [Lprim(Pgetglobal id, [], _); lam], loc)->
+  | Lprim(Psetfield({ index = n; _ }, is_ptr, init),
+          [Lprim(Pgetglobal id, [], _); lam], loc) ->
       let (ulam, approx) = close env lam in
       if approx <> Value_unknown then
         (!global_approx).(n) <- approx;
@@ -1132,10 +1133,14 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
   | Lswitch(arg, sw, dbg) ->
       let fn fail =
         let (uarg, _) = close env arg in
+        let sw_blocks =
+          List.map (fun ({ Lambda. sw_tag; sw_size = _; }, arm) -> sw_tag, arm)
+            sw.sw_blocks
+        in
         let const_index, const_actions, fconst =
           close_switch env sw.sw_consts sw.sw_numconsts fail
         and block_index, block_actions, fblock =
-          close_switch env sw.sw_blocks sw.sw_numblocks fail in
+          close_switch env sw_blocks sw.sw_numblocks fail in
         let ulam =
           Uswitch
             (uarg,

--- a/ocaml/middle_end/convert_primitives.ml
+++ b/ocaml/middle_end/convert_primitives.ml
@@ -26,13 +26,13 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
   | Pmakeblock (tag, mutability, shape) ->
       Pmakeblock (tag, mutability, shape)
-  | Pfield field -> Pfield field
-  | Pfield_computed -> Pfield_computed
-  | Psetfield (field, imm_or_pointer, init_or_assign) ->
+  | Pfield ({ index = field; _ }, _) -> Pfield field
+  | Pfield_computed _sem -> Pfield_computed
+  | Psetfield ({ index = field; _ }, imm_or_pointer, init_or_assign) ->
       Psetfield (field, imm_or_pointer, init_or_assign)
   | Psetfield_computed (imm_or_pointer, init_or_assign) ->
       Psetfield_computed (imm_or_pointer, init_or_assign)
-  | Pfloatfield field -> Pfloatfield field
+  | Pfloatfield (field, _sem) -> Pfloatfield field
   | Psetfloatfield (field, init_or_assign) ->
       Psetfloatfield (field, init_or_assign)
   | Pduprecord (repr, size) -> Pduprecord (repr, size)

--- a/ocaml/middle_end/flambda/alias_analysis.ml
+++ b/ocaml/middle_end/flambda/alias_analysis.ml
@@ -23,8 +23,8 @@ type allocation_point =
 
 type allocated_const =
   | Normal of Allocated_const.t
-  | Array of Lambda.array_kind * Asttypes.mutable_flag * Variable.t list
-  | Duplicate_array of Lambda.array_kind * Asttypes.mutable_flag * Variable.t
+  | Array of Lambda.array_kind * Lambda.mutable_flag * Variable.t list
+  | Duplicate_array of Lambda.array_kind * Lambda.mutable_flag * Variable.t
 
 type constant_defining_value =
   | Allocated_const of allocated_const

--- a/ocaml/middle_end/flambda/alias_analysis.mli
+++ b/ocaml/middle_end/flambda/alias_analysis.mli
@@ -22,8 +22,8 @@ type allocation_point =
 
 type allocated_const =
   | Normal of Allocated_const.t
-  | Array of Lambda.array_kind * Asttypes.mutable_flag * Variable.t list
-  | Duplicate_array of Lambda.array_kind * Asttypes.mutable_flag * Variable.t
+  | Array of Lambda.array_kind * Lambda.mutable_flag * Variable.t list
+  | Duplicate_array of Lambda.array_kind * Lambda.mutable_flag * Variable.t
 
 type constant_defining_value =
   | Allocated_const of allocated_const

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -499,12 +499,16 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       | None ->
           List.fold_left (fun set (i, _) -> I.Set.add i set) I.Set.empty cases
     in
+    let sw_blocks =
+      List.map (fun ({ Lambda. sw_tag; sw_size = _; }, arm) -> sw_tag, arm)
+        sw.sw_blocks
+    in
     Flambda.create_let scrutinee (Expr (close t env arg))
       (Switch (scrutinee,
         { numconsts = nums sw.sw_numconsts sw.sw_consts sw.sw_failaction;
           consts = List.map aux sw.sw_consts;
-          numblocks = nums sw.sw_numblocks sw.sw_blocks sw.sw_failaction;
-          blocks = List.map aux sw.sw_blocks;
+          numblocks = nums sw.sw_numblocks sw_blocks sw.sw_failaction;
+          blocks = List.map aux sw_blocks;
           failaction = Option.map (close t env) sw.sw_failaction;
         }))
   | Lstringswitch (arg, sw, def, _) ->

--- a/ocaml/middle_end/flambda/inconstant_idents.ml
+++ b/ocaml/middle_end/flambda/inconstant_idents.ml
@@ -335,15 +335,16 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
        makeblock(Mutable) can be a 'constant' if it is allocated at
        toplevel: if this expression is evaluated only once.
     *)
-    | Prim (Pmakeblock (_tag, Asttypes.Immutable, _value_kind), args,
-            _dbg) ->
+    | Prim (Pmakeblock (_tag, (Immutable | Immutable_unique), _value_kind),
+            args, _dbg) ->
       mark_vars args curr
 (*  (* CR-someday pchambart: If global mutables are allowed: *)
     | Prim(Lambda.Pmakeblock(_tag, Asttypes.Mutable), args, _dbg, _)
       when toplevel ->
       List.iter (mark_loop ~toplevel curr) args
 *)
-    | Prim (Pmakearray (Pfloatarray, Immutable), args, _) ->
+    | Prim (Pmakearray (Pfloatarray, (Immutable | Immutable_unique)),
+            args, _) ->
       mark_vars args curr
     | Prim (Pmakearray (Pfloatarray, Mutable), args, _) ->
       (* CR-someday pchambart: Toplevel float arrays could always be
@@ -356,7 +357,8 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       *)
       if toplevel then mark_vars args curr
       else mark_curr curr
-    | Prim (Pduparray (Pfloatarray, Immutable), [arg], _) ->
+    | Prim (Pduparray (Pfloatarray, (Immutable | Immutable_unique)),
+            [arg], _) ->
       mark_var arg curr
     | Prim (Pduparray (Pfloatarray, Mutable), [arg], _) ->
       if toplevel then mark_var arg curr

--- a/ocaml/middle_end/flambda/lift_constants.ml
+++ b/ocaml/middle_end/flambda/lift_constants.ml
@@ -293,7 +293,7 @@ let translate_definition_and_resolve_alias inconstants
     ~(backend : (module Backend_intf.S))
     : Flambda.constant_defining_value option =
   let resolve_float_array_involving_variables
-        ~(mutability : Asttypes.mutable_flag) ~vars =
+        ~(mutability : Lambda.mutable_flag) ~vars =
     (* Resolve an [Allocated_const] of the form:
         [Array (Pfloatarray, _, _)]
        (which references its contents via variables; it does not contain
@@ -326,7 +326,7 @@ let translate_definition_and_resolve_alias inconstants
     in
     let const : Allocated_const.t =
       match mutability with
-      | Immutable -> Immutable_float_array floats
+      | Immutable | Immutable_unique -> Immutable_float_array floats
       | Mutable -> Float_array floats
     in
     Some (Flambda.Allocated_const const)
@@ -432,7 +432,7 @@ let translate_definition_and_resolve_alias inconstants
     | Allocated_const (Normal (Immutable_float_array floats)) ->
       let const : Allocated_const.t =
         match mutability with
-        | Immutable -> Immutable_float_array floats
+        | Immutable | Immutable_unique -> Immutable_float_array floats
         | Mutable -> Float_array floats
       in
       Some (Flambda.Allocated_const const)

--- a/ocaml/middle_end/flambda/lift_let_to_initialize_symbol.ml
+++ b/ocaml/middle_end/flambda/lift_let_to_initialize_symbol.ml
@@ -81,7 +81,8 @@ let rec accumulate ~substitution ~copied_lets ~extracted_lets
     let extracted =
       let renamed = Variable.rename var in
       match named with
-      | Prim (Pmakeblock (tag, Asttypes.Immutable, _value_kind), args, _dbg) ->
+      | Prim (Pmakeblock (tag, (Immutable | Immutable_unique), _value_kind),
+              args, _dbg) ->
         let tag = Tag.create_exn tag in
         let args =
           List.map (fun v ->

--- a/ocaml/middle_end/flambda/ref_to_variables.ml
+++ b/ocaml/middle_end/flambda/ref_to_variables.ml
@@ -91,7 +91,7 @@ let variables_containing_ref (flam:Flambda.t) =
   let aux (flam : Flambda.t) =
     match flam with
     | Let { var;
-            defining_expr = Prim(Pmakeblock(0, Asttypes.Mutable, _), l, _);
+            defining_expr = Prim(Pmakeblock(0, Mutable, _), l, _);
           } ->
       map := Variable.Map.add var (List.length l) !map
     | _ -> ()
@@ -127,7 +127,7 @@ let eliminate_ref_of_expr flam =
     let aux (flam : Flambda.t) : Flambda.t =
       match flam with
       | Let { var;
-              defining_expr = Prim(Pmakeblock(0, Asttypes.Mutable, shape), l,_);
+              defining_expr = Prim(Pmakeblock(0, Mutable, shape), l,_);
               body }
         when convertible_variable var ->
         let shape = match shape with

--- a/ocaml/middle_end/flambda/simplify_primitives.ml
+++ b/ocaml/middle_end/flambda/simplify_primitives.ml
@@ -108,7 +108,7 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
     : Flambda.named * A.t * Inlining_cost.Benefit.t =
   let fpc = !Clflags.float_const_prop in
   match p with
-  | Pmakeblock(tag_int, Asttypes.Immutable, shape) ->
+  | Pmakeblock(tag_int, (Immutable | Immutable_unique), shape) ->
     let tag = Tag.create_exn tag_int in
     let shape = match shape with
       | None -> List.map (fun _ -> Lambda.Pgenval) args
@@ -116,19 +116,19 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
     in
     let approxs = List.map2 A.augment_with_kind approxs shape in
     let shape = List.map2 A.augment_kind_with_approx approxs shape in
-    Prim (Pmakeblock(tag_int, Asttypes.Immutable, Some shape), args, dbg),
+    Prim (Pmakeblock(tag_int, Lambda.Immutable, Some shape), args, dbg),
     A.value_block tag (Array.of_list approxs), C.Benefit.zero
   | Praise _ ->
     expr, A.value_bottom, C.Benefit.zero
   | Pmakearray(_, _) when is_empty approxs ->
-    Prim (Pmakeblock(0, Asttypes.Immutable, Some []), [], dbg),
+    Prim (Pmakeblock(0, Lambda.Immutable, Some []), [], dbg),
     A.value_block (Tag.create_exn 0) [||], C.Benefit.zero
   | Pmakearray (Pfloatarray, Mutable) ->
       let approx =
         A.value_mutable_float_array ~size:(List.length args)
       in
       expr, approx, C.Benefit.zero
-  | Pmakearray (Pfloatarray, Immutable) ->
+  | Pmakearray (Pfloatarray, (Immutable | Immutable_unique)) ->
       let approx =
         A.value_immutable_float_array (Array.of_list approxs)
       in

--- a/ocaml/middle_end/internal_variable_names.ml
+++ b/ocaml/middle_end/internal_variable_names.ml
@@ -323,7 +323,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Psetglobal _ -> psetglobal
   | Pmakeblock _ -> pmakeblock
   | Pfield _ -> pfield
-  | Pfield_computed -> pfield_computed
+  | Pfield_computed _ -> pfield_computed
   | Psetfield _ -> psetfield
   | Psetfield_computed _ -> psetfield_computed
   | Pfloatfield _ -> pfloatfield
@@ -430,7 +430,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Psetglobal _ -> psetglobal_arg
   | Pmakeblock _ -> pmakeblock_arg
   | Pfield _ -> pfield_arg
-  | Pfield_computed -> pfield_computed_arg
+  | Pfield_computed _ -> pfield_computed_arg
   | Psetfield _ -> psetfield_arg
   | Psetfield_computed _ -> psetfield_computed_arg
   | Pfloatfield _ -> pfloatfield_arg

--- a/ocaml/middle_end/printclambda.ml
+++ b/ocaml/middle_end/printclambda.ml
@@ -15,15 +15,14 @@
 
 
 open Format
-open Asttypes
 open Clambda
 
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
 let mutable_flag = function
-  | Mutable-> "[mut]"
-  | Immutable -> ""
+  | Lambda.Mutable-> "[mut]"
+  | Lambda.Immutable | Lambda.Immutable_unique -> ""
 
 let value_kind =
   let open Lambda in

--- a/ocaml/middle_end/printclambda_primitives.ml
+++ b/ocaml/middle_end/printclambda_primitives.ml
@@ -15,7 +15,6 @@
 
 
 open Format
-open Asttypes
 
 let boxed_integer_name = function
   | Lambda.Pnativeint -> "nativeint"
@@ -59,6 +58,8 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
       fprintf ppf "read_symbol %s" sym
   | Pmakeblock(tag, Immutable, shape) ->
       fprintf ppf "makeblock %i%a" tag Printlambda.block_shape shape
+  | Pmakeblock(tag, Immutable_unique, shape) ->
+      fprintf ppf "makeblock_unique %i%a" tag Printlambda.block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag Printlambda.block_shape shape
   | Pfield n -> fprintf ppf "field %i" n
@@ -146,8 +147,12 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
   | Parraylength k -> fprintf ppf "array.length[%s]" (array_kind k)
   | Pmakearray (k, Mutable) -> fprintf ppf "makearray[%s]" (array_kind k)
   | Pmakearray (k, Immutable) -> fprintf ppf "makearray_imm[%s]" (array_kind k)
+  | Pmakearray (k, Immutable_unique) ->
+    fprintf ppf "makearray_unique[%s]" (array_kind k)
   | Pduparray (k, Mutable) -> fprintf ppf "duparray[%s]" (array_kind k)
   | Pduparray (k, Immutable) -> fprintf ppf "duparray_imm[%s]" (array_kind k)
+  | Pduparray (k, Immutable_unique) ->
+    fprintf ppf "duparray_unique[%s]" (array_kind k)
   | Parrayrefu k -> fprintf ppf "array.unsafe_get[%s]" (array_kind k)
   | Parraysetu k -> fprintf ppf "array.unsafe_set[%s]" (array_kind k)
   | Parrayrefs k -> fprintf ppf "array.get[%s]" (array_kind k)

--- a/ocaml/middle_end/semantics_of_primitives.ml
+++ b/ocaml/middle_end/semantics_of_primitives.ml
@@ -23,8 +23,8 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   match prim with
   | Pmakeblock _
   | Pmakearray (_, Mutable) -> Only_generative_effects, No_coeffects
-  | Pmakearray (_, Immutable) -> No_effects, No_coeffects
-  | Pduparray (_, Immutable) ->
+  | Pmakearray (_, (Immutable | Immutable_unique)) -> No_effects, No_coeffects
+  | Pduparray (_, (Immutable | Immutable_unique)) ->
       No_effects, No_coeffects  (* Pduparray (_, Immutable) is allowed only on
                                    immutable arrays. *)
   | Pduparray (_, Mutable) | Pduprecord _ ->

--- a/ocaml/testsuite/tests/basic-modules/anonymous.ocamlc.reference
+++ b/ocaml/testsuite/tests/basic-modules/anonymous.ocamlc.reference
@@ -19,5 +19,6 @@
               (let (*match* = (setfield_ptr 0 s "Hello World!"))
                 (makeblock 0)))
             (let
-              (drop = (function param 0) *match* = (apply drop (field 0 s)))
+              (drop = (function param 0)
+               *match* = (apply drop (field_mut 0 s)))
               (makeblock 0 A B f s drop))))))))

--- a/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
+++ b/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
@@ -16,5 +16,7 @@
         (seq
           (ignore
             (let (*match* = (setfield_ptr 0 s "Hello World!")) (makeblock 0)))
-          (let (drop = (function param 0) *match* = (apply drop (field 0 s)))
+          (let
+            (drop = (function param 0)
+             *match* = (apply drop (field_mut 0 s)))
             (makeblock 0 A B f s drop)))))))

--- a/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
+++ b/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
@@ -26,6 +26,6 @@
       (let
         (*match* =
            (apply (field 4 (global Anonymous!))
-             (field 0 (field 3 (global Anonymous!)))))
+             (field_mut 0 (field 3 (global Anonymous!)))))
         0)
       0)))

--- a/ocaml/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/ocaml/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -52,9 +52,9 @@ type t += A | B of unit | C of bool * int;;
 0
 type t = ..
 (let
-  (A/25 = (makeblock 248 "A" (caml_fresh_oo_id 0))
-   B/26 = (makeblock 248 "B" (caml_fresh_oo_id 0))
-   C/27 = (makeblock 248 "C" (caml_fresh_oo_id 0)))
+  (A/25 = (makeblock_unique 248 "A" (caml_fresh_oo_id 0))
+   B/26 = (makeblock_unique 248 "B" (caml_fresh_oo_id 0))
+   C/27 = (makeblock_unique 248 "C" (caml_fresh_oo_id 0)))
   (seq (apply (field 1 (global Toploop!)) "A/25" A/25)
     (apply (field 1 (global Toploop!)) "B/26" B/26)
     (apply (field 1 (global Toploop!)) "C/27" C/27)))

--- a/ocaml/toplevel/genprintval.ml
+++ b/ocaml/toplevel/genprintval.ml
@@ -388,10 +388,10 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 | {type_kind = Type_variant constr_list; type_unboxed} ->
                     let unbx = type_unboxed.unboxed in
                     let tag =
-                      if unbx then Cstr_unboxed
+                      if unbx then Datarepr.Unboxed
                       else if O.is_block obj
-                      then Cstr_block(O.tag obj)
-                      else Cstr_constant(O.obj obj) in
+                      then Datarepr.Block(O.tag obj)
+                      else Datarepr.Constant(O.obj obj) in
                     let {cd_id;cd_args;cd_res} =
                       Datarepr.find_constr_by_tag tag constr_list in
                     let type_params =

--- a/ocaml/toplevel/opttoploop.ml
+++ b/ocaml/toplevel/opttoploop.ml
@@ -82,7 +82,7 @@ let close_phrase lam =
   Ident.Set.fold (fun id l ->
     let glb, pos = toplevel_value id in
     let glob =
-      Lprim (Pfield pos,
+      Lprim (mod_field pos,
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in

--- a/ocaml/typing/datarepr.ml
+++ b/ocaml/typing/datarepr.ml
@@ -117,14 +117,24 @@ let constructor_descrs ~current_unit ty_path decl cstrs =
           | None -> ty_res
         in
         let (tag, descr_rem) =
+          let cstr_block ~size =
+            let tag =
+              Cstr_block {
+                tag = idx_nonconst;
+                size;
+              }
+            in
+            tag, describe_constructors idx_const (idx_nonconst+1) rem
+          in
           match cd_args with
           | _ when decl.type_unboxed.unboxed ->
             assert (rem = []);
             (Cstr_unboxed, [])
           | Cstr_tuple [] -> (Cstr_constant idx_const,
                    describe_constructors (idx_const+1) idx_nonconst rem)
-          | _  -> (Cstr_block idx_nonconst,
-                   describe_constructors idx_const (idx_nonconst+1) rem) in
+          | Cstr_tuple args -> cstr_block ~size:(List.length args)
+          | Cstr_record args -> cstr_block ~size:(List.length args)
+        in
         let cstr_name = Ident.name cd_id in
         let existentials, cstr_args, cstr_inlined =
           let representation =
@@ -217,17 +227,24 @@ let label_descrs ty_res lbls repres priv =
 
 exception Constr_not_found
 
+type constructor_tag_to_find =
+  | Constant of int
+  | Block of int
+  | Unboxed
+
 let rec find_constr tag num_const num_nonconst = function
     [] ->
       raise Constr_not_found
   | {cd_args = Cstr_tuple []; _} as c  :: rem ->
-      if tag = Cstr_constant num_const
+      if tag = Constant num_const
       then c
       else find_constr tag (num_const + 1) num_nonconst rem
   | c :: rem ->
-      if tag = Cstr_block num_nonconst || tag = Cstr_unboxed
-      then c
-      else find_constr tag num_const (num_nonconst + 1) rem
+      match tag with
+      | Block tag when tag = num_nonconst -> c
+      | Unboxed -> c
+      | Block _
+      | Constant _ -> find_constr tag num_const (num_nonconst + 1) rem
 
 let find_constr_by_tag tag cstrlist =
   find_constr tag 0 0 cstrlist

--- a/ocaml/typing/datarepr.mli
+++ b/ocaml/typing/datarepr.mli
@@ -32,8 +32,13 @@ val constructors_of_type:
 
 exception Constr_not_found
 
+type constructor_tag_to_find =
+  | Constant of int
+  | Block of int
+  | Unboxed
+
 val find_constr_by_tag:
-  constructor_tag -> constructor_declaration list ->
+  constructor_tag_to_find -> constructor_declaration list ->
     constructor_declaration
 
 val constructor_existentials :

--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -801,11 +801,15 @@ let should_extend ext env = match ext with
       end
 end
 
+type simple_constructor_tag =
+  | Constant of int
+  | Block of int
+
 module ConstructorTagHashtbl = Hashtbl.Make(
   struct
-    type t = Types.constructor_tag
+    type t = simple_constructor_tag
     let hash = Hashtbl.hash
-    let equal = Types.equal_tag
+    let equal = (=)
   end
 )
 
@@ -816,17 +820,17 @@ let complete_tags nconsts nconstrs tags =
   List.iter
     (function
       | Cstr_constant i -> seen_const.(i) <- true
-      | Cstr_block i -> seen_constr.(i) <- true
+      | Cstr_block { tag; size = _; } -> seen_constr.(tag) <- true
       | _  -> assert false)
     tags ;
   let r = ConstructorTagHashtbl.create (nconsts+nconstrs) in
   for i = 0 to nconsts-1 do
     if not seen_const.(i) then
-      ConstructorTagHashtbl.add r (Cstr_constant i) ()
+      ConstructorTagHashtbl.add r (Constant i) ()
   done ;
   for i = 0 to nconstrs-1 do
     if not seen_constr.(i) then
-      ConstructorTagHashtbl.add r (Cstr_block i) ()
+      ConstructorTagHashtbl.add r (Block i) ()
   done ;
   r
 
@@ -896,7 +900,14 @@ let complete_constrs constr all_tags =
   let constrs = get_variant_constructors constr.pat_env c.cstr_res in
   let others =
     List.filter
-      (fun cnstr -> ConstructorTagHashtbl.mem not_tags cnstr.cstr_tag)
+      (fun cnstr ->
+        match cnstr.cstr_tag with
+        | Cstr_constant i ->
+          ConstructorTagHashtbl.mem not_tags (Constant i)
+        | Cstr_block { tag; size = _; } ->
+          ConstructorTagHashtbl.mem not_tags (Block tag)
+        | Cstr_unboxed
+        | Cstr_extension _ -> false)
       constrs in
   let const, nonconst =
     List.partition (fun cnstr -> cnstr.cstr_arity = 0) others in

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -420,7 +420,10 @@ type constructor_description =
 
 and constructor_tag =
     Cstr_constant of int                (* Constant constructor (an int) *)
-  | Cstr_block of int                   (* Regular constructor (a block) *)
+  | Cstr_block of {                     (* Regular constructor (a block) *)
+      tag : int;
+      size : int;
+    }
   | Cstr_unboxed                        (* Constructor of an unboxed type *)
   | Cstr_extension of Path.t * bool     (* Extension constructor
                                            true if a constant false if a block*)
@@ -428,7 +431,9 @@ and constructor_tag =
 let equal_tag t1 t2 =
   match (t1, t2) with
   | Cstr_constant i1, Cstr_constant i2 -> i2 = i1
-  | Cstr_block i1, Cstr_block i2 -> i2 = i1
+  | Cstr_block { tag = tag1; size = size1; },
+      Cstr_block { tag = tag2; size = size2; } ->
+    tag1 = tag2 && size1 = size2
   | Cstr_unboxed, Cstr_unboxed -> true
   | Cstr_extension (path1, b1), Cstr_extension (path2, b2) ->
       Path.same path1 path2 && b1 = b2

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -551,7 +551,10 @@ type constructor_description =
 
 and constructor_tag =
     Cstr_constant of int                (* Constant constructor (an int) *)
-  | Cstr_block of int                   (* Regular constructor (a block) *)
+  | Cstr_block of {                     (* Regular constructor (a block) *)
+      tag : int;
+      size : int;
+    }
   | Cstr_unboxed                        (* Constructor of an unboxed type *)
   | Cstr_extension of Path.t * bool     (* Extension constructor
                                            true if a constant false if a block*)


### PR DESCRIPTION
The first commit combines several modifications to the `Pfield` primitive, plus a change to `Lswitch` structures (that I could split if needed).
The second commit handles the addition of `Immutable_unique` to `Lambda.mutable_flag`, used for extension constructors.
(Rebased version of #69)