### PR TITLE
Obj changes for Flambda 2

### DIFF
--- a/ocaml/stdlib/obj.ml
+++ b/ocaml/stdlib/obj.ml
@@ -30,10 +30,18 @@ external magic : 'a -> 'b = "%identity"
 external is_int : t -> bool = "%obj_is_int"
 let [@inline always] is_block a = not (is_int a)
 external tag : t -> int = "caml_obj_tag" [@@noalloc]
+(* For Flambda 2 there is a strict distinction between arrays and other
+   blocks.  %obj_size and %obj_field may only be used on blocks.  As such
+   they are protected here using [Sys.opaque_identity], since this
+   restriction is likely not respected by callees of this module. *)
 external size : t -> int = "%obj_size"
+let [@inline always] size t = size (Sys.opaque_identity t)
 external reachable_words : t -> int = "caml_obj_reachable_words"
 external field : t -> int -> t = "%obj_field"
+let [@inline always] field t = field (Sys.opaque_identity t)
 external set_field : t -> int -> t -> unit = "%obj_set_field"
+let [@inline always] set_field t index new_value =
+  set_field (Sys.opaque_identity t) index new_value
 external floatarray_get : floatarray -> int -> float = "caml_floatarray_get"
 external floatarray_set :
     floatarray -> int -> float -> unit = "caml_floatarray_set"

--- a/ocaml/stdlib/obj.mli
+++ b/ocaml/stdlib/obj.mli
@@ -31,7 +31,7 @@ external magic : 'a -> 'b = "%identity"
 val [@inline always] is_block : t -> bool
 external is_int : t -> bool = "%obj_is_int"
 external tag : t -> int = "caml_obj_tag" [@@noalloc]
-external size : t -> int = "%obj_size"
+val size : t -> int
 external reachable_words : t -> int = "caml_obj_reachable_words"
   (**
      Computes the total size (in words, including the headers) of all
@@ -42,7 +42,7 @@ external reachable_words : t -> int = "caml_obj_reachable_words"
      @Since 4.04
   *)
 
-external field : t -> int -> t = "%obj_field"
+val field : t -> int -> t
 
 (** When using flambda:
 
@@ -55,7 +55,7 @@ external field : t -> int -> t = "%obj_field"
     {!Sys.opaque_identity}, so any information about its contents will not
     be propagated.
 *)
-external set_field : t -> int -> t -> unit = "%obj_set_field"
+val set_field : t -> int -> t -> unit
 
 val [@inline always] double_field : t -> int -> float  (* @since 3.11.2 *)
 val [@inline always] set_double_field : t -> int -> float -> unit

--- a/ocaml/testsuite/tests/warnings/w59.flambda.reference
+++ b/ocaml/testsuite/tests/warnings/w59.flambda.reference
@@ -1,23 +1,23 @@
 File "w59.ml", line 51, characters 2-43:
-51 |   set_field (repr o) 0 (repr 3);
+51 |   set_field (Obj.repr o) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 52, characters 2-43:
-52 |   set_field (repr p) 0 (repr 3);
+52 |   set_field (Obj.repr p) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 53, characters 2-43:
-53 |   set_field (repr q) 0 (repr 3);
+53 |   set_field (Obj.repr q) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 54, characters 2-43:
-54 |   set_field (repr r) 0 (repr 3)
+54 |   set_field (Obj.repr r) 0 (Obj.repr 3)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 

--- a/ocaml/testsuite/tests/warnings/w59.flambda.reference
+++ b/ocaml/testsuite/tests/warnings/w59.flambda.reference
@@ -1,22 +1,22 @@
-File "w59.ml", line 51, characters 2-43:
+File "w59.ml", line 51, characters 2-39:
 51 |   set_field (Obj.repr o) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
-File "w59.ml", line 52, characters 2-43:
+File "w59.ml", line 52, characters 2-39:
 52 |   set_field (Obj.repr p) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
-File "w59.ml", line 53, characters 2-43:
+File "w59.ml", line 53, characters 2-39:
 53 |   set_field (Obj.repr q) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
-File "w59.ml", line 54, characters 2-43:
+File "w59.ml", line 54, characters 2-39:
 54 |   set_field (Obj.repr r) 0 (Obj.repr 3)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 

--- a/ocaml/testsuite/tests/warnings/w59.flambda.reference
+++ b/ocaml/testsuite/tests/warnings/w59.flambda.reference
@@ -1,23 +1,23 @@
 File "w59.ml", line 51, characters 2-43:
-51 |   Obj.set_field (Obj.repr o) 0 (Obj.repr 3);
+51 |   set_field (repr o) 0 (repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 52, characters 2-43:
-52 |   Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
+52 |   set_field (repr p) 0 (repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 53, characters 2-43:
-53 |   Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
+53 |   set_field (repr q) 0 (repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 54, characters 2-43:
-54 |   Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
+54 |   set_field (repr r) 0 (repr 3)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 

--- a/ocaml/testsuite/tests/warnings/w59.flambda.reference
+++ b/ocaml/testsuite/tests/warnings/w59.flambda.reference
@@ -1,18 +1,18 @@
 File "w59.ml", line 51, characters 2-39:
 51 |   set_field (Obj.repr o) 0 (Obj.repr 3);
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 52, characters 2-39:
 52 |   set_field (Obj.repr p) 0 (Obj.repr 3);
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 53, characters 2-39:
 53 |   set_field (Obj.repr q) 0 (Obj.repr 3);
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.

--- a/ocaml/testsuite/tests/warnings/w59.flambda.reference
+++ b/ocaml/testsuite/tests/warnings/w59.flambda.reference
@@ -1,29 +1,29 @@
 File "w59.ml", line 46, characters 2-43:
-46 |   Obj.set_field (Obj.repr o) 0 (Obj.repr 3);
+51 |   Obj.set_field (Obj.repr o) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 47, characters 2-43:
-47 |   Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
+52 |   Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 48, characters 2-43:
-48 |   Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
+53 |   Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 49, characters 2-43:
-49 |   Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
+54 |   Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 56, characters 2-7:
-56 |   set o
+61 |   set o
        ^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 

--- a/ocaml/testsuite/tests/warnings/w59.flambda.reference
+++ b/ocaml/testsuite/tests/warnings/w59.flambda.reference
@@ -1,24 +1,24 @@
 File "w59.ml", line 51, characters 2-39:
 51 |   set_field (Obj.repr o) 0 (Obj.repr 3);
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 52, characters 2-39:
 52 |   set_field (Obj.repr p) 0 (Obj.repr 3);
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 53, characters 2-39:
 53 |   set_field (Obj.repr q) 0 (Obj.repr 3);
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
 File "w59.ml", line 54, characters 2-39:
 54 |   set_field (Obj.repr r) 0 (Obj.repr 3)
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.

--- a/ocaml/testsuite/tests/warnings/w59.flambda.reference
+++ b/ocaml/testsuite/tests/warnings/w59.flambda.reference
@@ -1,28 +1,28 @@
-File "w59.ml", line 46, characters 2-43:
+File "w59.ml", line 51, characters 2-43:
 51 |   Obj.set_field (Obj.repr o) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
-File "w59.ml", line 47, characters 2-43:
+File "w59.ml", line 52, characters 2-43:
 52 |   Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
-File "w59.ml", line 48, characters 2-43:
+File "w59.ml", line 53, characters 2-43:
 53 |   Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
-File "w59.ml", line 49, characters 2-43:
+File "w59.ml", line 54, characters 2-43:
 54 |   Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 
 in this source file.  Such assignments may generate incorrect code 
 when using Flambda.
-File "w59.ml", line 56, characters 2-7:
+File "w59.ml", line 61, characters 2-7:
 61 |   set o
        ^^^^^
 Warning 59 [flambda-assignment-to-non-mutable-value]: A potential assignment to a non-mutable value was detected 

--- a/ocaml/testsuite/tests/warnings/w59.ml
+++ b/ocaml/testsuite/tests/warnings/w59.ml
@@ -42,14 +42,19 @@ let p = fun x -> x
 let q = 3.14
 let r = 1
 
+(* %obj_set_field is OK here for Flambda 2 because we never use
+   it on an array.  We can't use Obj.field since that function
+   contains a [Sys.opaque_identity]. *)
+external set_field : Obj.t -> int -> Obj.t -> unit = "%obj_set_field"
+
 let () =
-  Obj.set_field (Obj.repr o) 0 (Obj.repr 3);
-  Obj.set_field (Obj.repr p) 0 (Obj.repr 3);
-  Obj.set_field (Obj.repr q) 0 (Obj.repr 3);
-  Obj.set_field (Obj.repr r) 0 (Obj.repr 3)
+  set_field (Obj.repr o) 0 (Obj.repr 3);
+  set_field (Obj.repr p) 0 (Obj.repr 3);
+  set_field (Obj.repr q) 0 (Obj.repr 3);
+  set_field (Obj.repr r) 0 (Obj.repr 3)
 
 let set v =
-  Obj.set_field (Obj.repr v) 0 (Obj.repr 3)
+  set_field (Obj.repr v) 0 (Obj.repr 3)
   [@@inline]
 
 let () =
@@ -59,7 +64,7 @@ let () =
 
 let opaque = Sys.opaque_identity (1,2)
 let set_opaque =
-  Obj.set_field
+  set_field
     (Obj.repr opaque)
     0
     (Obj.repr 3)


### PR DESCRIPTION
The type system in Flambda 2 has a strict distinction between arrays and blocks (and in case you are wondering, we did try unifying them, which turned out not to be a good idea).  Unfortunately the historical interface to `Obj` is such that some of its functions (in particular `size`, `field` and `set_field`) are likely called on both arrays and blocks.  To avoid this causing the generation of `Invalid` traps we add `Sys.opaque_identity` in various places.  This should not affect runtime performance per se.  However it does mean that any information about the relevant array or block known by Flambda 2 will not be used when compiling the `Obj` call.