### PR TITLE
CMM traps

### DIFF
--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -60,8 +60,8 @@ and instrument = function
   | Cifthenelse (cond, t_dbg, t, f_dbg, f, dbg) ->
      Cifthenelse (instrument cond, t_dbg, with_afl_logging t t_dbg,
        f_dbg, with_afl_logging f f_dbg, dbg)
-  | Ctrywith (e, ex, handler, dbg) ->
-     Ctrywith (instrument e, ex, with_afl_logging handler dbg, dbg)
+  | Ctrywith (e, kind, ex, handler, dbg) ->
+     Ctrywith (instrument e, kind, ex, with_afl_logging handler dbg, dbg)
   | Cswitch (e, cases, handlers, dbg) ->
      let handlers =
        Array.map (fun (handler, handler_dbg) ->
@@ -87,7 +87,7 @@ and instrument = function
          cases
      in
      Ccatch (isrec, cases, instrument body)
-  | Cexit (ex, args) -> Cexit (ex, List.map instrument args)
+  | Cexit (ex, args, traps) -> Cexit (ex, List.map instrument args, traps)
 
   (* these are base cases and have no logging *)
   | Cconst_int _ | Cconst_natint _ | Cconst_float _

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -330,7 +330,7 @@ let destroyed_at_oper = function
        | Iconst_int _ | Iconst_float _ | Iconst_symbol _
        | Itailcall_ind | Itailcall_imm _ | Istackoffset _ | Iload (_, _)
        | Iname_for_debugger _ | Iprobe _| Iprobe_is_enabled _)
-  | Iend | Ireturn | Iifthenelse (_, _, _) | Icatch (_, _, _)
+  | Iend | Ireturn _ | Iifthenelse (_, _, _) | Icatch (_, _, _, _)
   | Iexit _ | Iraise _
     ->
     if fp then

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -210,7 +210,7 @@ method! select_store is_assign addr exp =
   | Cvar _ | Clet (_, _, _) | Clet_mut (_, _, _, _) | Cphantom_let (_, _, _)
   | Cassign (_, _) | Ctuple _ | Cop (_, _, _) | Csequence (_, _)
   | Cifthenelse (_, _, _, _, _, _) | Cswitch (_, _, _, _) | Ccatch (_, _, _)
-  | Cexit (_, _) | Ctrywith (_, _, _, _)
+  | Cexit (_, _, _) | Ctrywith (_, _, _, _, _)
     ->
       super#select_store is_assign addr exp
 

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -109,6 +109,10 @@ let negate_float_comparison = Lambda.negate_float_comparison
 let swap_float_comparison = Lambda.swap_float_comparison
 type label = int
 
+type exit_label =
+  | Return_lbl
+  | Lbl of label
+
 let init_label = 99
 
 let label_counter = ref init_label
@@ -137,6 +141,16 @@ type phantom_defining_expr =
   | Cphantom_read_field of { var : Backend_var.t; field : int; }
   | Cphantom_read_symbol_field of { sym : string; field : int; }
   | Cphantom_block of { tag : int; fields : Backend_var.t list; }
+
+type trywith_shared_label = int
+
+type trap_action =
+  | Push of trywith_shared_label
+  | Pop
+
+type trywith_kind =
+  | Regular
+  | Delayed of trywith_shared_label
 
 type memory_chunk =
     Byte_unsigned
@@ -202,12 +216,12 @@ type expression =
       * Debuginfo.t
   | Ccatch of
       rec_flag
-        * (int * (Backend_var.With_provenance.t * machtype) list
+        * (label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
         * expression
-  | Cexit of int * expression list
-  | Ctrywith of expression * Backend_var.With_provenance.t * expression
-      * Debuginfo.t
+  | Cexit of exit_label * expression list * trap_action list
+  | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
+      * expression * Debuginfo.t
 
 type codegen_option =
   | Reduce_code_size
@@ -263,7 +277,7 @@ let iter_shallow_tail f = function
       List.iter (fun (_, _, h, _dbg) -> f h) handlers;
       f body;
       true
-  | Ctrywith(e1, _id, e2, _dbg) ->
+  | Ctrywith(e1, _kind, _id, e2, _dbg) ->
       f e1;
       f e2;
       true
@@ -301,8 +315,8 @@ let rec map_tail f = function
   | Ccatch(rec_flag, handlers, body) ->
       let map_h (n, ids, handler, dbg) = (n, ids, map_tail f handler, dbg) in
       Ccatch(rec_flag, List.map map_h handlers, map_tail f body)
-  | Ctrywith(e1, id, e2, dbg) ->
-      Ctrywith(map_tail f e1, id, map_tail f e2, dbg)
+  | Ctrywith(e1, kind, id, e2, dbg) ->
+      Ctrywith(map_tail f e1, kind, id, map_tail f e2, dbg)
   | Cexit _ | Cop (Craise _, _, _) as cmm ->
       cmm
   | Cconst_int _
@@ -337,10 +351,10 @@ let map_shallow f = function
   | Ccatch (rf, hl, body) ->
       let map_h (n, ids, handler, dbg) = (n, ids, f handler, dbg) in
       Ccatch (rf, List.map map_h hl, f body)
-  | Cexit (n, el) ->
-      Cexit (n, List.map f el)
-  | Ctrywith (e1, id, e2, dbg) ->
-      Ctrywith (f e1, id, f e2, dbg)
+  | Cexit (n, el, traps) ->
+      Cexit (n, List.map f el, traps)
+  | Ctrywith (e1, kind, id, e2, dbg) ->
+      Ctrywith (f e1, kind, id, f e2, dbg)
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float _

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -146,7 +146,7 @@ type trywith_kind =
       handled by this handler. *)
   | Delayed of trywith_shared_label
   (** The body starts with the previous exception handler, and only after going
-      throguh an explicit Push-annotated Cexit will this handler become active.
+      through an explicit Push-annotated Cexit will this handler become active.
       This allows for sharing a single handler in several places, or having
       multiple entry and exit points to a single trywith block. *)
 

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -96,6 +96,10 @@ val new_label: unit -> label
 val set_label: label -> unit
 val cur_label: unit -> label
 
+type exit_label =
+  | Return_lbl
+  | Lbl of label
+
 type rec_flag = Nonrecursive | Recursive
 
 type effects = No_effects | Arbitrary_effects
@@ -127,6 +131,24 @@ type phantom_defining_expr =
   | Cphantom_block of { tag : int; fields : Backend_var.t list; }
   (** The phantom-let-bound variable points at a block with the given
       structure. *)
+
+type trywith_shared_label = int (* Same as Ccatch handlers *)
+
+type trap_action =
+  | Push of trywith_shared_label
+  (** Add the corresponding handler to the trap stack. *)
+  | Pop
+  (** Remove the last handler from the trap stack. *)
+
+type trywith_kind =
+  | Regular
+  (** Regular trywith: an uncaught exception from the body will always be
+      handled by this handler. *)
+  | Delayed of trywith_shared_label
+  (** The body starts with the previous exception handler, and only after going
+      throguh an explicit Push-annotated Cexit will this handler become active.
+      This allows for sharing a single handler in several places, or having
+      multiple entry and exit points to a single trywith block. *)
 
 type memory_chunk =
     Byte_unsigned
@@ -203,12 +225,12 @@ and expression =
       * Debuginfo.t
   | Ccatch of
       rec_flag
-        * (int * (Backend_var.With_provenance.t * machtype) list
+        * (label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
         * expression
-  | Cexit of int * expression list
-  | Ctrywith of expression * Backend_var.With_provenance.t * expression
-      * Debuginfo.t
+  | Cexit of exit_label * expression list * trap_action list
+  | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
+      * expression * Debuginfo.t
 
 type codegen_option =
   | Reduce_code_size
@@ -241,7 +263,7 @@ type phrase =
   | Cdata of data_item list
 
 val ccatch :
-     int * (Backend_var.With_provenance.t * machtype) list
+     label * (Backend_var.With_provenance.t * machtype) list
        * expression * expression * Debuginfo.t
   -> expression
 

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -113,11 +113,7 @@ let mk_traps env nfail =
   if handler_depth = env.trywith_depth then []
   else begin
     assert (handler_depth <= env.trywith_depth);
-    let rec build_pops n =
-      if n = 0 then []
-      else Pop :: (build_pops (n - 1))
-    in
-    build_pops (env.trywith_depth - handler_depth)
+    List.init (env.trywith_depth - handler_depth) (fun _ -> Pop)
   end
 
 (* Description of the "then" and "else" continuations in [transl_if]. If

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -43,6 +43,8 @@ type env = {
   unboxed_ids : (V.t * boxed_number) V.tbl;
   notify_catch : (Cmm.expression list -> unit) IntMap.t;
   environment_param : V.t option;
+  trywith_depth : int;
+  catch_trywith_depths : int IntMap.t;
 }
 
 (* notify_catch associates to each catch handler a callback
@@ -65,6 +67,8 @@ let empty_env =
     unboxed_ids = V.empty;
     notify_catch = IntMap.empty;
     environment_param = None;
+    trywith_depth = 0;
+    catch_trywith_depths = IntMap.empty;
   }
 
 let create_env ~environment_param =
@@ -83,13 +87,38 @@ let add_unboxed_id id unboxed_id bn env =
 
 let add_notify_catch n f env =
   { env with
-    notify_catch = IntMap.add n f env.notify_catch
+    notify_catch = IntMap.add n f env.notify_catch;
   }
 
 let notify_catch i env l =
   match IntMap.find_opt i env.notify_catch with
   | Some f -> f l
   | None -> ()
+
+let incr_depth env =
+  { env with trywith_depth = succ env.trywith_depth; }
+
+let enter_catch_body env nfail =
+  { env with
+    catch_trywith_depths =
+      IntMap.add nfail env.trywith_depth env.catch_trywith_depths;
+  }
+
+let mk_traps env nfail =
+  let handler_depth =
+    match IntMap.find_opt nfail env.catch_trywith_depths with
+    | None -> Misc.fatal_errorf "Cmmgen.mk_traps: Unknown handler %d" nfail
+    | Some d -> d
+  in
+  if handler_depth = env.trywith_depth then []
+  else begin
+    assert (handler_depth <= env.trywith_depth);
+    let rec build_pops n =
+      if n = 0 then []
+      else Pop :: (build_pops (n - 1))
+    in
+    build_pops (env.trywith_depth - handler_depth)
+  end
 
 (* Description of the "then" and "else" continuations in [transl_if]. If
    the "then" continuation is true and the "else" continuation is false then
@@ -602,16 +631,19 @@ let rec transl env e =
   | Ustaticfail (nfail, args) ->
       let cargs = List.map (transl env) args in
       notify_catch nfail env cargs;
-      Cexit (nfail, cargs)
+      let traps = mk_traps env nfail in
+      Cexit (Lbl nfail, cargs, traps)
   | Ucatch(nfail, [], body, handler) ->
       let dbg = Debuginfo.none in
-      make_catch nfail (transl env body) (transl env handler) dbg
+      let env_body = enter_catch_body env nfail in
+      make_catch nfail (transl env_body body) (transl env handler) dbg
   | Ucatch(nfail, ids, body, handler) ->
       let dbg = Debuginfo.none in
       transl_catch env nfail ids body handler dbg
   | Utrywith(body, exn, handler) ->
       let dbg = Debuginfo.none in
-      Ctrywith(transl env body, exn, transl env handler, dbg)
+      let new_body = transl (incr_depth env) body in
+      Ctrywith(new_body, Regular, exn, transl env handler, dbg)
   | Uifthenelse(cond, ifso, ifnot) ->
       let ifso_dbg = Debuginfo.none in
       let ifnot_dbg = Debuginfo.none in
@@ -628,7 +660,7 @@ let rec transl env e =
            (raise_num, [],
             create_loop(transl_if env Unknown dbg cond
                     dbg (remove_unit(transl env body))
-                    dbg (Cexit (raise_num,[])))
+                    dbg (Cexit (Lbl raise_num,[],[])))
               dbg,
             Ctuple [],
             dbg))
@@ -647,7 +679,7 @@ let rec transl env e =
                  Cifthenelse
                    (Cop(Ccmpi tst, [Cvar (VP.var id); high], dbg),
                     dbg,
-                    Cexit (raise_num, []),
+                    Cexit (Lbl raise_num, [], []),
                     dbg,
                     create_loop
                       (Csequence
@@ -660,7 +692,7 @@ let rec transl env e =
                              Cifthenelse
                                (Cop(Ccmpi Ceq, [Cvar (VP.var id_prev); high],
                                   dbg),
-                                dbg, Cexit (raise_num,[]),
+                                dbg, Cexit (Lbl raise_num,[],[]),
                                 dbg, Ctuple [],
                                 dbg)))))
                       dbg,
@@ -697,7 +729,7 @@ and transl_catch env nfail ids body handler dbg =
       )
       ids args
   in
-  let env_body = add_notify_catch nfail report env in
+  let env_body = enter_catch_body (add_notify_catch nfail report env) nfail in
   let body = transl env_body body in
   let new_env, rewrite, ids =
     List.fold_right
@@ -725,8 +757,8 @@ and transl_catch env nfail ids body handler dbg =
       (* Rewrite the body to unbox the call sites *)
       let rec aux e =
         match Cmm.map_shallow aux e with
-        | Cexit (n, el) when n = nfail ->
-            Cexit (new_nfail, List.map2 (fun f e -> f e) rewrite el)
+        | Cexit (Lbl n, el, traps) when n = nfail ->
+            Cexit (Lbl new_nfail, List.map2 (fun f e -> f e) rewrite el, traps)
         | c -> c
       in
       aux body
@@ -1185,12 +1217,12 @@ and transl_let env str kind id exp body =
       end
 
 and make_catch ncatch body handler dbg = match body with
-| Cexit (nexit,[]) when nexit=ncatch -> handler
+| Cexit (Lbl nexit,[],[]) when nexit=ncatch -> handler
 | _ ->  ccatch (ncatch, [], body, handler, dbg)
 
 and is_shareable_cont exp =
   match exp with
-  | Cexit (_,[]) -> true
+  | Cexit (_,[],[]) -> true
   | _ -> false
 
 and make_shareable_cont dbg mk exp =
@@ -1199,7 +1231,7 @@ and make_shareable_cont dbg mk exp =
     let nfail = next_raise_count () in
     make_catch
       nfail
-      (mk (Cexit (nfail,[])))
+      (mk (Cexit (Lbl nfail,[],[])))
       exp
       dbg
   end

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -26,9 +26,39 @@ module V = Backend_var
    handlers collected in [avail_at_exit].) *)
 let avail_at_exit = Hashtbl.create 42
 let avail_at_raise = ref RAS.Unreachable
+let current_trap_stack = ref M.Uncaught
+
+let augment_availability_at_exit nfail avail_before =
+  let avail_at_top_of_handler =
+    match Hashtbl.find avail_at_exit nfail with
+    | exception Not_found ->
+      Misc.fatal_errorf "Iexit %d not in scope of Icatch" nfail
+    | avail_at_top_of_handler -> avail_at_top_of_handler
+  in
+  let avail_at_top_of_handler =
+    RAS.inter avail_at_top_of_handler avail_before
+  in
+  Hashtbl.replace avail_at_exit nfail avail_at_top_of_handler
 
 let augment_availability_at_raise avail =
-  avail_at_raise := RAS.inter avail !avail_at_raise
+  match !current_trap_stack with
+  | Uncaught | Generic_trap _ ->
+    avail_at_raise := RAS.inter avail !avail_at_raise
+  | Specific_trap (label, _) ->
+    augment_availability_at_exit label avail
+
+let setup_avail_at_raise kind =
+  match (kind : Cmm.trywith_kind) with
+  | Regular ->
+    let res = !avail_at_raise in
+    avail_at_raise := RAS.Unreachable;
+    res
+  | Delayed _ -> !avail_at_raise (* This result will not be used *)
+
+let restore_avail_at_raise kind saved_avail_at_raise =
+  match (kind : Cmm.trywith_kind) with
+  | Regular -> avail_at_raise := saved_avail_at_raise
+  | Delayed _ -> ()
 
 let check_invariants (instr : M.instruction) ~(avail_before : RAS.t) =
   match avail_before with
@@ -225,7 +255,7 @@ let rec available_regs (instr : M.instruction)
         Some (ok avail_across), ok avail_after
       | Iifthenelse (_, ifso, ifnot) -> join [ifso; ifnot] ~avail_before
       | Iswitch (_, cases) -> join (Array.to_list cases) ~avail_before
-      | Icatch (recursive, _ts, handlers, body) ->
+      | Icatch (recursive, ts, handlers, body) ->
         List.iter (fun (nfail, _ts, _handler) ->
             (* In case there are nested [Icatch] expressions with the same
                handler numbers, we rely on the [Hashtbl] shadowing
@@ -237,13 +267,14 @@ let rec available_regs (instr : M.instruction)
         in
         (* CR-someday mshinwell: Consider potential efficiency speedups
            (see suggestions from @chambart on GPR#856). *)
-        let aux (nfail, _ts, handler) (nfail', avail_at_top_of_handler) =
+        let aux (nfail, ts, handler) (nfail', avail_at_top_of_handler) =
           assert (nfail = nfail');
           available_regs handler ~avail_before:avail_at_top_of_handler
         in
         let aux_equal (nfail, avail_before_handler)
               (nfail', avail_before_handler') =
           assert (nfail = nfail');
+          current_trap_stack := ts;
           RAS.equal avail_before_handler avail_before_handler'
         in
         let rec fixpoint avail_at_top_of_handlers =
@@ -276,6 +307,7 @@ let rec available_regs (instr : M.instruction)
         List.iter (fun (nfail, _ts, _handler) ->
             Hashtbl.remove avail_at_exit nfail)
           handlers;
+        current_trap_stack := ts;
         let avail_after =
           List.fold_left (fun avail_at_join avail_after_handler ->
               RAS.inter avail_at_join avail_after_handler)
@@ -285,24 +317,19 @@ let rec available_regs (instr : M.instruction)
         None, avail_after
       | Iexit (nfail, _traps) ->
         let avail_before = ok avail_before in
-        let avail_at_top_of_handler =
-          match Hashtbl.find avail_at_exit nfail with
-          | exception Not_found ->  (* also see top of [Icatch] clause above *)
-            Misc.fatal_errorf "Iexit %d not in scope of Icatch" nfail
-          | avail_at_top_of_handler -> avail_at_top_of_handler
-        in
-        let avail_at_top_of_handler =
-          RAS.inter avail_at_top_of_handler avail_before
-        in
-        Hashtbl.replace avail_at_exit nfail avail_at_top_of_handler;
+        augment_availability_at_exit nfail avail_before;
         None, unreachable
-      | Itrywith (body, Regular, (_ts, handler)) ->
-        let saved_avail_at_raise = !avail_at_raise in
-        avail_at_raise := unreachable;
+      | Itrywith (body, kind, (ts, handler)) ->
+        let saved_avail_at_raise = setup_avail_at_raise kind in
         let avail_before = ok avail_before in
         let after_body = available_regs body ~avail_before in
         let avail_before_handler =
-          match !avail_at_raise with
+          let with_exn_bucket =
+            match kind with
+            | Regular -> !avail_at_raise
+            | Delayed nfail -> Hashtbl.find avail_at_exit nfail
+          in
+          match (with_exn_bucket : RAS.t) with
           | Unreachable -> unreachable
           | Ok avail_at_raise ->
             let without_exn_bucket =
@@ -314,15 +341,15 @@ let rec available_regs (instr : M.instruction)
             in
             ok with_anonymous_exn_bucket
         in
-        avail_at_raise := saved_avail_at_raise;
+        restore_avail_at_raise kind saved_avail_at_raise;
+        let saved_trap_stack = !current_trap_stack in
+        current_trap_stack := ts;
         let avail_after =
           RAS.inter after_body
             (available_regs handler ~avail_before:avail_before_handler)
         in
+        current_trap_stack := saved_trap_stack;
         None, avail_after
-      | Itrywith (_body, Delayed _nfail, _handler) ->
-          (* TODO: handle correctly *)
-          assert false
       | Iraise _ ->
         let avail_before = ok avail_before in
         augment_availability_at_raise avail_before;
@@ -347,6 +374,7 @@ let fundecl (f : M.fundecl) =
   if !Clflags.debug && !Clflags.debug_runavail then begin
     assert (Hashtbl.length avail_at_exit = 0);
     avail_at_raise := RAS.Unreachable;
+    current_trap_stack := M.Uncaught;
     let fun_args = R.set_of_array f.fun_args in
     let avail_before = RAS.Ok (RD.Set.without_debug_info fun_args) in
     ignore ((available_regs f.fun_body ~avail_before) : RAS.t);

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -269,6 +269,7 @@ let rec available_regs (instr : M.instruction)
            (see suggestions from @chambart on GPR#856). *)
         let aux (nfail, ts, handler) (nfail', avail_at_top_of_handler) =
           assert (nfail = nfail');
+          current_trap_stack := ts;
           available_regs handler ~avail_before:avail_at_top_of_handler
         in
         let aux_equal (nfail, avail_before_handler)

--- a/backend/interval.ml
+++ b/backend/interval.ml
@@ -136,7 +136,7 @@ let build_intervals fd =
     | Iop _ ->
         insert_destroyed_at_oper intervals i !pos;
         walk_instruction i.next
-    | Ireturn ->
+    | Ireturn _ ->
         insert_destroyed_at_oper intervals i !pos;
         walk_instruction i.next
     | Iifthenelse(_, ifso, ifnot) ->
@@ -148,15 +148,15 @@ let build_intervals fd =
         insert_destroyed_at_oper intervals i !pos;
         Array.iter walk_instruction cases;
         walk_instruction i.next
-    | Icatch(_, handlers, body) ->
+    | Icatch(_, _ts, handlers, body) ->
         insert_destroyed_at_oper intervals i !pos;
-        List.iter (fun (_, i) -> walk_instruction i) handlers;
+        List.iter (fun (_, _, i) -> walk_instruction i) handlers;
         walk_instruction body;
         walk_instruction i.next
     | Iexit _ ->
         insert_destroyed_at_oper intervals i !pos;
         walk_instruction i.next
-    | Itrywith(body, handler) ->
+    | Itrywith(body, _kind, (_ts, handler)) ->
         insert_destroyed_at_oper intervals i !pos;
         walk_instruction body;
         insert_destroyed_at_raise intervals !pos;

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -153,12 +153,23 @@ let rec add_traps env i traps =
     let lbl_handler = find_exit_label env handler in
     add_traps env (cons_instr (Lpushtrap { lbl_handler; }) i) traps
 
+let delta_traps_diff traps =
+  let delta =
+    List.fold_left
+      (fun delta trap ->
+         match trap with
+         | Cmm.Pop -> delta - 1
+         | Cmm.Push _ -> delta + 1)
+      0 traps in
+  -delta
+
 (* Linearize an instruction [i]: add it in front of the continuation [n] *)
 let linear i n contains_calls =
   let rec linear env i n =
     match i.Mach.desc with
       Iend -> n
     | Iop(Itailcall_ind | Itailcall_imm _ as op) ->
+        (* note: there cannot be deadcode in n *)
         copy_instr (Lop op) i (linear env i.Mach.next n)
     | Iop(Imove | Ireload | Ispill)
       when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
@@ -166,15 +177,7 @@ let linear i n contains_calls =
     | Iop op ->
         copy_instr (Lop op) i (linear env i.Mach.next n)
     | Ireturn traps ->
-        let delta_traps =
-          List.fold_left
-            (fun delta trap ->
-               match trap with
-               | Cmm.Pop -> delta - 1
-               | Cmm.Push _ -> delta + 1)
-            0 traps
-        in
-        let n = adjust_trap_depth (-delta_traps) n in
+        let n = adjust_trap_depth (delta_traps_diff traps) n in
         let n1 = copy_instr Lreturn i (discard_dead_code n) in
         let n2 =
           if contains_calls
@@ -275,19 +278,11 @@ let linear i n contains_calls =
     | Iexit (nfail, traps) ->
         let lbl = find_exit_label env nfail in
         assert (i.Mach.next.desc = Mach.Iend);
-        let delta_traps =
-          List.fold_left
-            (fun delta trap ->
-               match trap with
-               | Cmm.Pop -> delta - 1
-               | Cmm.Push _ -> delta + 1)
-            0 traps
-        in
-        let n1 = adjust_trap_depth (-delta_traps) n in
+        let n1 = adjust_trap_depth (delta_traps_diff traps) n in
         add_traps env (add_branch lbl n1) traps
     | Itrywith(body, Regular, (ts, handler)) ->
         let (lbl_join, n1) = get_label (linear env i.Mach.next n) in
-        assert (ts = env.trap_stack);
+        assert (Mach.equal_trap_stack ts env.trap_stack);
         let (lbl_handler, n2) =
           get_label (cons_instr Lentertrap (linear env handler n1))
         in

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -60,9 +60,23 @@ let rec adjust_trap_depth delta_traps next =
   match next.desc with
   | Ladjust_trap_depth { delta_traps = k } ->
     adjust_trap_depth (delta_traps + k) next.next
+  | Llabel lbl ->
+    let next = adjust_trap_depth delta_traps next.next in
+    cons_instr (Llabel lbl) next
+  | Lbranch lbl ->
+    let next = adjust_trap_depth delta_traps next.next in
+    cons_instr (Lbranch lbl) next
   | _ ->
     if delta_traps = 0 then next
     else cons_instr (Ladjust_trap_depth { delta_traps }) next
+
+let delta_traps stack_before stack_after =
+  let rec stack_depth acc stack =
+    match (stack : Mach.trap_stack) with
+    | Uncaught -> acc
+    | Generic_trap t | Specific_trap (_, t) -> stack_depth (succ acc) t
+  in
+  (stack_depth 0 stack_after) - (stack_depth 0 stack_before)
 
 (* Discard all instructions up to the next label.
    This function is to be called before adding a non-terminating
@@ -108,88 +122,108 @@ let add_branch lbl n =
   else
     discard_dead_code n
 
-let try_depth = ref 0
+type linear_env =
+  { trap_stack : Mach.trap_stack;
+    (** The current trap stack *)
+    exit_label : (int * label) list;
+    (** Association list: exit handler -> handler label *)
+  }
 
-(* Association list: exit handler -> (handler label, try-nesting factor) *)
+let initial_env =
+  { trap_stack = Uncaught;
+    exit_label = [];
+  }
 
-let exit_label = ref []
-
-let find_exit_label_try_depth k =
+let find_exit_label env k =
   try
-    List.assoc k !exit_label
+    List.assoc k env.exit_label
   with
   | Not_found -> Misc.fatal_error "Linearize.find_exit_label"
 
-let find_exit_label k =
-  let (label, t) = find_exit_label_try_depth k in
-  assert(t = !try_depth);
-  label
-
-let is_next_catch n = match !exit_label with
-| (n0,(_,t))::_  when n0=n && t = !try_depth -> true
+let is_next_catch env n = match env.exit_label with
+  | (n0,_)::_  when n0=n -> true
 | _ -> false
 
-let local_exit k =
-  snd (find_exit_label_try_depth k) = !try_depth
+let rec add_traps env i traps =
+  match traps with
+  | [] -> i
+  | Cmm.Pop :: traps ->
+    add_traps env (cons_instr Lpoptrap i) traps
+  | Cmm.Push handler :: traps ->
+    let lbl_handler = find_exit_label env handler in
+    add_traps env (cons_instr (Lpushtrap { lbl_handler; }) i) traps
 
 (* Linearize an instruction [i]: add it in front of the continuation [n] *)
 let linear i n contains_calls =
-  let rec linear i n =
+  let rec linear env i n =
     match i.Mach.desc with
       Iend -> n
     | Iop(Itailcall_ind | Itailcall_imm _ as op) ->
-        copy_instr (Lop op) i (discard_dead_code n)
+        copy_instr (Lop op) i (linear env i.Mach.next n)
     | Iop(Imove | Ireload | Ispill)
       when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
-        linear i.Mach.next n
+        linear env i.Mach.next n
     | Iop op ->
-        copy_instr (Lop op) i (linear i.Mach.next n)
-    | Ireturn ->
+        copy_instr (Lop op) i (linear env i.Mach.next n)
+    | Ireturn traps ->
+        let delta_traps =
+          List.fold_left
+            (fun delta trap ->
+               match trap with
+               | Cmm.Pop -> delta - 1
+               | Cmm.Push _ -> delta + 1)
+            0 traps
+        in
+        let n = adjust_trap_depth (-delta_traps) n in
         let n1 = copy_instr Lreturn i (discard_dead_code n) in
-        if contains_calls
-        then cons_instr Lreloadretaddr n1
-        else n1
+        let n2 =
+          if contains_calls
+          then cons_instr Lreloadretaddr n1
+          else n1
+        in
+        add_traps env n2 traps
     | Iifthenelse(test, ifso, ifnot) ->
-        let n1 = linear i.Mach.next n in
+      let n1 = linear env i.Mach.next n in
         begin match (ifso.Mach.desc, ifnot.Mach.desc, n1.desc) with
           Iend, _, Lbranch lbl ->
-            copy_instr (Lcondbranch(test, lbl)) i (linear ifnot n1)
+          copy_instr (Lcondbranch(test, lbl)) i (linear env ifnot n1)
         | _, Iend, Lbranch lbl ->
-            copy_instr (Lcondbranch(invert_test test, lbl)) i (linear ifso n1)
-        | Iexit nfail1, Iexit nfail2, _
-              when is_next_catch nfail1 && local_exit nfail2 ->
-            let lbl2 = find_exit_label nfail2 in
+            copy_instr (Lcondbranch(invert_test test, lbl)) i
+              (linear env ifso n1)
+        | Iexit (nfail1, []), Iexit (nfail2, []), _
+            when is_next_catch env nfail1 ->
+            let lbl2 = find_exit_label env nfail2 in
             copy_instr
-              (Lcondbranch (invert_test test, lbl2)) i (linear ifso n1)
-        | Iexit nfail, _, _ when local_exit nfail ->
-            let n2 = linear ifnot n1
-            and lbl = find_exit_label nfail in
+              (Lcondbranch (invert_test test, lbl2)) i (linear env ifso n1)
+        | Iexit (nfail, []), _, _ ->
+            let n2 = linear env ifnot n1
+            and lbl = find_exit_label env nfail in
             copy_instr (Lcondbranch(test, lbl)) i n2
-        | _,  Iexit nfail, _ when local_exit nfail ->
-            let n2 = linear ifso n1 in
-            let lbl = find_exit_label nfail in
+        | _,  Iexit (nfail, []), _ ->
+            let n2 = linear env ifso n1 in
+            let lbl = find_exit_label env nfail in
             copy_instr (Lcondbranch(invert_test test, lbl)) i n2
         | Iend, _, _ ->
             let (lbl_end, n2) = get_label n1 in
-            copy_instr (Lcondbranch(test, lbl_end)) i (linear ifnot n2)
+            copy_instr (Lcondbranch(test, lbl_end)) i (linear env ifnot n2)
         | _,  Iend, _ ->
             let (lbl_end, n2) = get_label n1 in
             copy_instr (Lcondbranch(invert_test test, lbl_end)) i
-                       (linear ifso n2)
+                       (linear env ifso n2)
         | _, _, _ ->
           (* Should attempt branch prediction here *)
             let (lbl_end, n2) = get_label n1 in
-            let (lbl_else, nelse) = get_label (linear ifnot n2) in
+            let (lbl_else, nelse) = get_label (linear env ifnot n2) in
             copy_instr (Lcondbranch(invert_test test, lbl_else)) i
-              (linear ifso (add_branch lbl_end nelse))
+              (linear env ifso (add_branch lbl_end nelse))
         end
     | Iswitch(index, cases) ->
         let lbl_cases = Array.make (Array.length cases) 0 in
-        let (lbl_end, n1) = get_label(linear i.Mach.next n) in
+        let (lbl_end, n1) = get_label(linear env i.Mach.next n) in
         let n2 = ref (discard_dead_code n1) in
         for i = Array.length cases - 1 downto 0 do
           let (lbl_case, ncase) =
-                  get_label(linear cases.(i) (add_branch lbl_end !n2)) in
+                  get_label(linear env cases.(i) (add_branch lbl_end !n2)) in
           lbl_cases.(i) <- lbl_case;
           n2 := discard_dead_code ncase
         done;
@@ -204,59 +238,86 @@ let linear i n contains_calls =
                      i !n2
         end else
           copy_instr (Lswitch(Array.map (fun n -> lbl_cases.(n)) index)) i !n2
-    | Icatch(_rec_flag, handlers, body) ->
-        let (lbl_end, n1) = get_label(linear i.Mach.next n) in
+    | Icatch(_rec_flag, ts_next, handlers, body) ->
+        let n0 = adjust_trap_depth (delta_traps ts_next env.trap_stack) n in
+        let env_next = { env with trap_stack = ts_next; } in
+        let (lbl_end, n1) = get_label(linear env_next i.Mach.next n0) in
         (* CR mshinwell for pchambart:
            1. rename "io"
            2. Make sure the test cases cover the "Iend" cases too *)
-        let labels_at_entry_to_handlers = List.map (fun (_nfail, handler) ->
+        let labels_at_entry_to_handlers = List.map (fun (_n, _ts, handler) ->
             match handler.Mach.desc with
             | Iend -> lbl_end
             | _ -> Cmm.new_label ())
             handlers in
         let exit_label_add = List.map2
-            (fun (nfail, _) lbl -> (nfail, (lbl, !try_depth)))
+            (fun (nfail, _ts, _) lbl -> (nfail, lbl))
             handlers labels_at_entry_to_handlers in
-        let previous_exit_label = !exit_label in
-        exit_label := exit_label_add @ !exit_label;
-        let n2 = List.fold_left2 (fun n (_nfail, handler) lbl_handler ->
+        let env = { env with exit_label = exit_label_add @ env.exit_label; } in
+        let (n2, ts_n2) =
+          List.fold_left2 (fun (n, ts_next) (_nfail, ts, handler) lbl_handler ->
             match handler.Mach.desc with
-            | Iend -> n
-            | _ -> cons_instr (Llabel lbl_handler)
-                     (linear handler (add_branch lbl_end n)))
-            n1 handlers labels_at_entry_to_handlers
+            | Iend -> n, ts_next
+            | _ ->
+                let delta = delta_traps ts ts_next in
+                let n = adjust_trap_depth delta n in
+                let env = { env with trap_stack = ts; } in
+                let n =
+                  cons_instr (Llabel lbl_handler)
+                    (linear env handler (add_branch lbl_end n))
+                in
+                n, ts)
+            (n1, ts_next) handlers labels_at_entry_to_handlers
         in
-        let n3 = linear body (add_branch lbl_end n2) in
-        exit_label := previous_exit_label;
+        let n2 = adjust_trap_depth (delta_traps env.trap_stack ts_n2) n2 in
+        let n3 = linear env body (add_branch lbl_end n2) in
         n3
-    | Iexit nfail ->
-        let lbl, t = find_exit_label_try_depth nfail in
+    | Iexit (nfail, traps) ->
+        let lbl = find_exit_label env nfail in
         assert (i.Mach.next.desc = Mach.Iend);
-        let delta_traps = !try_depth - t in
-        let n1 = adjust_trap_depth delta_traps n in
-        let rec loop i tt =
-          if t = tt then i
-          else loop (cons_instr Lpoptrap i) (tt - 1)
+        let delta_traps =
+          List.fold_left
+            (fun delta trap ->
+               match trap with
+               | Cmm.Pop -> delta - 1
+               | Cmm.Push _ -> delta + 1)
+            0 traps
         in
-        loop (add_branch lbl n1) !try_depth
-    | Itrywith(body, handler) ->
-        let (lbl_join, n1) = get_label (linear i.Mach.next n) in
+        let n1 = adjust_trap_depth (-delta_traps) n in
+        add_traps env (add_branch lbl n1) traps
+    | Itrywith(body, Regular, (ts, handler)) ->
+        let (lbl_join, n1) = get_label (linear env i.Mach.next n) in
+        assert (ts = env.trap_stack);
         let (lbl_handler, n2) =
-          get_label (cons_instr Lentertrap (linear handler n1))
+          get_label (cons_instr Lentertrap (linear env handler n1))
         in
-        incr try_depth;
+        let env_body =
+          { env with trap_stack = Mach.Generic_trap env.trap_stack; }
+        in
         assert (i.Mach.arg = [| |]);
         let n3 = cons_instr (Lpushtrap { lbl_handler; })
-                   (linear body
+                   (linear env_body body
                       (cons_instr
                          Lpoptrap
                          (add_branch lbl_join n2))) in
-        decr try_depth;
         n3
-
+    | Itrywith(body, Delayed nfail, (ts, handler)) ->
+        let (lbl_join, n1) = get_label (linear env i.Mach.next n) in
+        let delta = delta_traps ts env.trap_stack in
+        let n1' = adjust_trap_depth delta n1 in
+        let env_handler = { env with trap_stack = ts; } in
+        let (lbl_handler, n2) =
+          get_label (cons_instr Lentertrap (linear env_handler handler n1'))
+        in
+        let n2' = adjust_trap_depth (-delta) n2 in
+        let env_body =
+          {env with exit_label = (nfail, lbl_handler) :: env.exit_label; }
+        in
+        let n3 = linear env_body body (add_branch lbl_join n2') in
+        n3
     | Iraise k ->
         copy_instr (Lraise k) i (discard_dead_code n)
-  in linear i n
+  in linear initial_env i n
 
 let add_prologue first_insn prologue_required =
   (* The prologue needs to come after any [Iname_for_debugger] operations that

--- a/backend/liveness.ml
+++ b/backend/liveness.ml
@@ -18,17 +18,34 @@
 
 open Mach
 
-let live_at_exit = ref []
+type liveness_env =
+  { at_exit : (int * Reg.Set.t) list;
+    at_raise : Reg.Set.t;
+    last_regular_trywith_handler : Reg.Set.t;
+  }
 
-let find_live_at_exit k =
+let initial_env =
+  { at_exit = [];
+    at_raise = Reg.Set.empty;
+    last_regular_trywith_handler = Reg.Set.empty;
+  }
+
+let find_live_at_exit env k =
   try
-    List.assoc k !live_at_exit
+    List.assoc k env.at_exit
   with
   | Not_found -> Misc.fatal_error "Liveness.find_live_at_exit"
 
-let live_at_raise = ref Reg.Set.empty
+let env_from_trap_stack env ts =
+  let at_raise =
+    match ts with
+    | Uncaught -> Reg.Set.empty
+    | Generic_trap _ -> env.last_regular_trywith_handler
+    | Specific_trap (nfail, _) -> find_live_at_exit env nfail
+  in
+  { env with at_raise; }
 
-let rec live i finally =
+let rec live env i finally =
   (* finally is the set of registers live after execution of the
      instruction sequence.
      The result of the function is the set of registers live just
@@ -39,11 +56,11 @@ let rec live i finally =
     Iend ->
       i.live <- finally;
       finally
-  | Ireturn | Iop(Itailcall_ind) | Iop(Itailcall_imm _) ->
+  | Ireturn _ | Iop(Itailcall_ind) | Iop(Itailcall_imm _) ->
       i.live <- Reg.Set.empty; (* no regs are live across *)
       Reg.set_of_array i.arg
   | Iop op ->
-      let after = live i.next finally in
+      let after = live env i.next finally in
       if Proc.op_is_pure op                    (* no side effects *)
       && Reg.disjoint_set_array after i.res    (* results are not used after *)
       && not (Proc.regs_are_volatile i.arg)    (* no stack-like hard reg *)
@@ -65,41 +82,42 @@ let rec live i finally =
                  exceptions, as may signal handlers).
                  Hence, everything that must be live at the beginning of
                  the exception handler must also be live across this instr. *)
-               Reg.Set.union across_after !live_at_raise
+               Reg.Set.union across_after env.at_raise
            | _ ->
                across_after in
         i.live <- across;
         Reg.add_set_array across i.arg
       end
   | Iifthenelse(_test, ifso, ifnot) ->
-      let at_join = live i.next finally in
-      let at_fork = Reg.Set.union (live ifso at_join) (live ifnot at_join) in
+      let at_join = live env i.next finally in
+      let at_fork =
+        Reg.Set.union (live env ifso at_join) (live env ifnot at_join)
+      in
       i.live <- at_fork;
       Reg.add_set_array at_fork i.arg
   | Iswitch(_index, cases) ->
-      let at_join = live i.next finally in
+      let at_join = live env i.next finally in
       let at_fork = ref Reg.Set.empty in
       for i = 0 to Array.length cases - 1 do
-        at_fork := Reg.Set.union !at_fork (live cases.(i) at_join)
+        at_fork := Reg.Set.union !at_fork (live env cases.(i) at_join)
       done;
       i.live <- !at_fork;
       Reg.add_set_array !at_fork i.arg
-  | Icatch(rec_flag, handlers, body) ->
-      let at_join = live i.next finally in
-      let aux (nfail,handler) (nfail', before_handler) =
+  | Icatch(rec_flag, ts, handlers, body) ->
+      let at_join = live (env_from_trap_stack env ts) i.next finally in
+      let aux env (nfail, ts, handler) (nfail', before_handler) =
         assert(nfail = nfail');
-        let before_handler' = live handler at_join in
+        let env = env_from_trap_stack env ts in
+        let before_handler' = live env handler at_join in
         nfail, Reg.Set.union before_handler before_handler'
       in
       let aux_equal (nfail, before_handler) (nfail', before_handler') =
         assert(nfail = nfail');
         Reg.Set.equal before_handler before_handler'
       in
-      let live_at_exit_before = !live_at_exit in
       let rec fixpoint before_handlers =
-        live_at_exit := before_handlers @ !live_at_exit;
-        let before_handlers' = List.map2 aux handlers before_handlers in
-        live_at_exit := live_at_exit_before;
+        let env = { env with at_exit = before_handlers @ env.at_exit; } in
+        let before_handlers' = List.map2 (aux env) handlers before_handlers in
         match rec_flag with
         | Cmm.Nonrecursive ->
             before_handlers'
@@ -109,40 +127,43 @@ let rec live i finally =
             else fixpoint before_handlers'
       in
       let init_state =
-        List.map (fun (nfail, _handler) -> nfail, Reg.Set.empty) handlers
+        List.map (fun (nfail, _ts, _handler) -> nfail, Reg.Set.empty) handlers
       in
       let before_handler = fixpoint init_state in
       (* We could use handler.live instead of Reg.Set.empty as the initial
          value but we would need to clean the live field before doing the
          analysis (to remove remnants of previous passes). *)
-      live_at_exit := before_handler @ !live_at_exit;
-      let before_body = live body at_join in
-      live_at_exit := live_at_exit_before;
+      let env = { env with at_exit = before_handler @ env.at_exit; } in
+      let before_body = live env body at_join in
       i.live <- before_body;
       before_body
-  | Iexit nfail ->
-      let this_live = find_live_at_exit nfail in
+  | Iexit (nfail, _traps) ->
+      let this_live = find_live_at_exit env nfail in
       i.live <- this_live ;
       this_live
-  | Itrywith(body, handler) ->
-      let at_join = live i.next finally in
-      let before_handler = live handler at_join in
-      let saved_live_at_raise = !live_at_raise in
-      live_at_raise := Reg.Set.remove Proc.loc_exn_bucket before_handler;
-      let before_body = live body at_join in
-      live_at_raise := saved_live_at_raise;
+  | Itrywith(body, kind, (ts, handler)) ->
+      let at_join = live env i.next finally in
+      let env_handler = env_from_trap_stack env ts in
+      let before_handler = live env_handler handler at_join in
+      let live_at_raise = Reg.Set.remove Proc.loc_exn_bucket before_handler in
+      let env =
+        match kind with
+        | Regular ->
+          { env with at_raise = live_at_raise;
+                     last_regular_trywith_handler = live_at_raise;
+          }
+        | Delayed nfail ->
+          { env with at_exit = (nfail, live_at_raise) :: env.at_exit; }
+      in
+      let before_body = live env body at_join in
       i.live <- before_body;
       before_body
   | Iraise _ ->
-      i.live <- !live_at_raise;
-      Reg.add_set_array !live_at_raise i.arg
-
-let reset () =
-  live_at_raise := Reg.Set.empty;
-  live_at_exit := []
+      i.live <- env.at_raise;
+      Reg.add_set_array env.at_raise i.arg
 
 let fundecl f =
-  let initially_live = live f.fun_body Reg.Set.empty in
+  let initially_live = live initial_env f.fun_body Reg.Set.empty in
   (* Sanity check: only function parameters can be live at entrypoint *)
   let wrong_live = Reg.Set.diff initially_live (Reg.set_of_array f.fun_args) in
   if not (Reg.Set.is_empty wrong_live) then begin

--- a/backend/liveness.mli
+++ b/backend/liveness.mli
@@ -16,5 +16,4 @@
 (* Liveness analysis.
    Annotate mach code with the set of regs live at each point. *)
 
-val reset : unit -> unit
 val fundecl: Mach.fundecl -> unit

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -179,3 +179,13 @@ let operation_can_raise op =
   | Iprobe _
   | Ialloc _ -> true
   | _ -> false
+
+let rec equal_trap_stack ts1 ts2 =
+  match ts1, ts2 with
+  | Uncaught, Uncaught -> true
+  | Generic_trap ts1, Generic_trap ts2 -> equal_trap_stack ts1 ts2
+  | Specific_trap (lbl1, ts1), Specific_trap (lbl2, ts2) ->
+    Int.equal lbl1 lbl2 && equal_trap_stack ts1 ts2
+  | Uncaught, (Generic_trap _ | Specific_trap _)
+  | Generic_trap _, (Uncaught | Specific_trap _)
+  | Specific_trap _, (Uncaught | Generic_trap _) -> false

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -15,6 +15,11 @@
 
 (* Representation of machine code by sequences of pseudoinstructions *)
 
+type trap_stack =
+  | Uncaught
+  | Generic_trap of trap_stack
+  | Specific_trap of Cmm.trywith_shared_label * trap_stack
+
 type integer_comparison =
     Isigned of Cmm.integer_comparison
   | Iunsigned of Cmm.integer_comparison
@@ -81,12 +86,12 @@ type instruction =
 and instruction_desc =
     Iend
   | Iop of operation
-  | Ireturn
+  | Ireturn of Cmm.trap_action list
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
-  | Icatch of Cmm.rec_flag * (int * instruction) list * instruction
-  | Iexit of int
-  | Itrywith of instruction * instruction
+  | Icatch of Cmm.rec_flag * trap_stack * (int * trap_stack * instruction) list * instruction
+  | Iexit of int * Cmm.trap_action list
+  | Itrywith of instruction * Cmm.trywith_kind * (trap_stack * instruction)
   | Iraise of Lambda.raise_kind
 
 type fundecl =
@@ -141,7 +146,7 @@ let rec instr_iter f i =
       f i;
       match i.desc with
         Iend -> ()
-      | Ireturn | Iop Itailcall_ind | Iop(Itailcall_imm _) -> ()
+      | Ireturn _ | Iop Itailcall_ind | Iop(Itailcall_imm _) -> ()
       | Iifthenelse(_tst, ifso, ifnot) ->
           instr_iter f ifso; instr_iter f ifnot; instr_iter f i.next
       | Iswitch(_index, cases) ->
@@ -149,16 +154,23 @@ let rec instr_iter f i =
             instr_iter f cases.(i)
           done;
           instr_iter f i.next
-      | Icatch(_, handlers, body) ->
+      | Icatch(_, _ts, handlers, body) ->
           instr_iter f body;
-          List.iter (fun (_n, handler) -> instr_iter f handler) handlers;
+          List.iter (fun (_n, _ts, handler) -> instr_iter f handler) handlers;
           instr_iter f i.next
       | Iexit _ -> ()
-      | Itrywith(body, handler) ->
+      | Itrywith(body, _kind, (_ts, handler)) ->
           instr_iter f body; instr_iter f handler; instr_iter f i.next
       | Iraise _ -> ()
-      | _ ->
-          instr_iter f i.next
+      | Iop (Imove | Ispill | Ireload
+            | Iconst_int _ | Iconst_float _ | Iconst_symbol _
+            | Icall_ind | Icall_imm _ | Iextcall _ | Istackoffset _
+            | Iload _ | Istore _ | Ialloc _
+            | Iintop _ | Iintop_imm _
+            | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
+            | Ifloatofint | Iintoffloat
+            | Ispecific _ | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _) ->
+        instr_iter f i.next
 
 let operation_can_raise op =
   match op with

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -125,3 +125,5 @@ val instr_cons_debug:
 val instr_iter: (instruction -> unit) -> instruction -> unit
 
 val operation_can_raise : operation -> bool
+
+val equal_trap_stack : trap_stack -> trap_stack -> bool

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -15,6 +15,14 @@
 
 (* Representation of machine code by sequences of pseudoinstructions *)
 
+type trap_stack =
+  | Uncaught
+  (** Exceptions escape the current function *)
+  | Generic_trap of trap_stack
+  (** Current handler is a regular Trywith *)
+  | Specific_trap of Cmm.trywith_shared_label * trap_stack
+  (** Current handler is a delayed/shared Trywith *)
+
 type integer_comparison =
     Isigned of Cmm.integer_comparison
   | Iunsigned of Cmm.integer_comparison
@@ -88,12 +96,12 @@ type instruction =
 and instruction_desc =
     Iend
   | Iop of operation
-  | Ireturn
+  | Ireturn of Cmm.trap_action list
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
-  | Icatch of Cmm.rec_flag * (int * instruction) list * instruction
-  | Iexit of int
-  | Itrywith of instruction * instruction
+  | Icatch of Cmm.rec_flag * trap_stack * (int * trap_stack * instruction) list * instruction
+  | Iexit of int * Cmm.trap_action list
+  | Itrywith of instruction * Cmm.trywith_kind * (trap_stack * instruction)
   | Iraise of Lambda.raise_kind
 
 type fundecl =

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -113,6 +113,28 @@ let location d =
   if not !Clflags.locations then ""
   else Debuginfo.to_string d
 
+let exit_label ppf = function
+  | Return_lbl -> fprintf ppf "*return*"
+  | Lbl lbl -> fprintf ppf "%d" lbl
+
+let trap_action ppf ta =
+  match ta with
+  | Push i -> fprintf ppf "push(%d)" i
+  | Pop -> fprintf ppf "pop"
+
+let trap_action_list ppf traps =
+  match traps with
+  | [] -> ()
+  | t :: rest ->
+      fprintf ppf "<%a" trap_action t;
+      List.iter (fun t -> fprintf ppf " %a" trap_action t) rest;
+      fprintf ppf ">"
+
+let trywith_kind ppf kind =
+  match kind with
+  | Regular -> ()
+  | Delayed i -> fprintf ppf "<delayed %d>" i
+
 let operation d = function
   | Capply _ty -> "app" ^ location d
   | Cextcall { name = lbl; _ } ->
@@ -263,13 +285,13 @@ let rec expr ppf = function
         rec_flag flag
         sequence e1
         print_handlers handlers
-  | Cexit (i, el) ->
-      fprintf ppf "@[<2>(exit %d" i;
+  | Cexit (i, el, traps) ->
+      fprintf ppf "@[<2>(exit%a %a" trap_action_list traps exit_label i;
       List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
       fprintf ppf ")@]"
-  | Ctrywith(e1, id, e2, _dbg) ->
-      fprintf ppf "@[<2>(try@ %a@;<1 -2>with@ %a@ %a)@]"
-             sequence e1 VP.print id sequence e2
+  | Ctrywith(e1, kind, id, e2, _dbg) ->
+      fprintf ppf "@[<2>(try%a@ %a@;<1 -2>with@ %a@ %a)@]"
+             trywith_kind kind sequence e1 VP.print id sequence e2
 
 and sequence ppf = function
   | Csequence(e1, e2) -> fprintf ppf "%a@ %a" sequence e1 sequence e2

--- a/backend/printcmm.mli
+++ b/backend/printcmm.mli
@@ -24,6 +24,8 @@ val exttype : formatter -> Cmm.exttype -> unit
 val extcall_signature : formatter -> Cmm.machtype * Cmm.exttype list -> unit
 val integer_comparison : Cmm.integer_comparison -> string
 val float_comparison : Cmm.float_comparison -> string
+val trap_action_list : formatter -> Cmm.trap_action list -> unit
+val trywith_kind : formatter -> Cmm.trywith_kind -> unit
 val chunk : Cmm.memory_chunk -> string
 val operation : Debuginfo.t -> Cmm.operation -> string
 val expression : formatter -> Cmm.expression -> unit

--- a/backend/strmatch.ml
+++ b/backend/strmatch.ml
@@ -377,10 +377,10 @@ module Make(I:I) = struct
 (* Module entry point *)
 
     let catch dbg arg k = match arg with
-    | Cexit (_e,[]) ->  k arg
+    | Cexit (_e,[],_traps) ->  k arg
     | _ ->
-        let e =  next_raise_count () in
-        ccatch (e,[],k (Cexit (e,[])),arg,dbg)
+        let e = next_raise_count () in
+        ccatch (e,[],k (Cexit (Lbl e,[],[])),arg,dbg)
 
     let compile dbg str default cases =
 (* We do not attempt to really optimise default=None *)

--- a/ocaml/testsuite/tests/asmgen/catch-try-float.cmm
+++ b/ocaml/testsuite/tests/asmgen/catch-try-float.cmm
@@ -7,6 +7,6 @@ arguments = "-DFLOAT_CATCH -DFUN=catch_try_float main.c"
 (function "catch_try_float" (b:float)
   (+f 10.0
   (catch
-    (try (exit lbl 100.0)
+    (try (exit(1) lbl 100.0)
      with var 456.0)
    with (lbl x:float) (+f x 1000.0))))

--- a/ocaml/testsuite/tests/asmgen/catch-try.cmm
+++ b/ocaml/testsuite/tests/asmgen/catch-try.cmm
@@ -7,6 +7,6 @@ arguments = "-DINT_INT -DFUN=catch_exit main.c"
 (function "catch_exit" (b:int)
   (+ 33
   (catch
-    (try (exit lbl 12)
+    (try (exit(1) lbl 12)
      with var 456)
    with (lbl x:val) (+ x 789))))

--- a/ocaml/testsuite/tools/parsecmm.mly
+++ b/ocaml/testsuite/tools/parsecmm.mly
@@ -37,7 +37,7 @@ let make_switch n selector caselist =
   let index = Array.make n 0 in
   let casev = Array.of_list caselist in
   let dbg = Debuginfo.none in
-  let actv = Array.make (Array.length casev) (Cexit(0,[]), dbg) in
+  let actv = Array.make (Array.length casev) (Cexit(Cmm.Lbl 0,[],[]), dbg) in
   for i = 0 to Array.length casev - 1 do
     let (posl, e) = casev.(i) in
     List.iter (fun pos -> index.(pos) <- i) posl;
@@ -206,6 +206,9 @@ componentlist:
     component                    { [$1] }
   | componentlist STAR component { $3 :: $1 }
 ;
+traps:
+    LPAREN INTCONST RPAREN       { List.init $2 (fun _ -> Pop) }
+  | /**/                         { [] }
 expr:
     INTCONST    { Cconst_int ($1, debuginfo ()) }
   | FLOATCONST  { Cconst_float (float_of_string $1, debuginfo ()) }
@@ -241,22 +244,22 @@ expr:
           match $3 with
             Cconst_int (x, _) when x <> 0 -> $4
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
-                             (Cexit(lbl0,[])),
+                             (Cexit(Cmm.Lbl lbl0,[],[])),
                              debuginfo ()) in
         Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
           Ccatch(Recursive,
-            [lbl1, [], Csequence(body, Cexit(lbl1, [])), debuginfo ()],
-            Cexit(lbl1, []))) }
-  | LPAREN EXIT IDENT exprlist RPAREN
-    { Cexit(find_label $3, List.rev $4) }
+            [lbl1, [], Csequence(body, Cexit(Cmm.Lbl lbl1, [], [])), debuginfo ()],
+            Cexit(Cmm.Lbl lbl1, [], []))) }
+  | LPAREN EXIT traps IDENT exprlist RPAREN
+    { Cexit(Cmm.Lbl (find_label $4), List.rev $5, $3) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
       List.iter (fun (_, l, _, _) ->
         List.iter (fun (x, _) -> unbind_ident x) l) handlers;
       Ccatch(Recursive, handlers, $3) }
-  | EXIT        { Cexit(0,[]) }
+  | EXIT        { Cexit(Cmm.Lbl 0,[],[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
-                { unbind_ident $5; Ctrywith($3, $5, $6, debuginfo ()) }
+                { unbind_ident $5; Ctrywith($3, Regular, $5, $6, debuginfo ()) }
   | LPAREN VAL expr expr RPAREN
       { let open Asttypes in
         Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -37,7 +37,7 @@ let make_switch n selector caselist =
   let index = Array.make n 0 in
   let casev = Array.of_list caselist in
   let dbg = Debuginfo.none in
-  let actv = Array.make (Array.length casev) (Cexit(0,[]), dbg) in
+  let actv = Array.make (Array.length casev) (Cexit(Cmm.Lbl 0,[],[]), dbg) in
   for i = 0 to Array.length casev - 1 do
     let (posl, e) = casev.(i) in
     List.iter (fun pos -> index.(pos) <- i) posl;
@@ -206,6 +206,9 @@ componentlist:
     component                    { [$1] }
   | componentlist STAR component { $3 :: $1 }
 ;
+traps:
+    LPAREN INTCONST RPAREN       { List.init $2 (fun _ -> Pop) }
+  | /**/                         { [] }
 expr:
     INTCONST    { Cconst_int ($1, debuginfo ()) }
   | FLOATCONST  { Cconst_float (float_of_string $1, debuginfo ()) }
@@ -241,22 +244,22 @@ expr:
           match $3 with
             Cconst_int (x, _) when x <> 0 -> $4
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
-                             (Cexit(lbl0,[])),
+                             (Cexit(Cmm.Lbl lbl0,[],[])),
                              debuginfo ()) in
         Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
           Ccatch(Recursive,
-            [lbl1, [], Csequence(body, Cexit(lbl1, [])), debuginfo ()],
-            Cexit(lbl1, []))) }
-  | LPAREN EXIT IDENT exprlist RPAREN
-    { Cexit(find_label $3, List.rev $4) }
+            [lbl1, [], Csequence(body, Cexit(Cmm.Lbl lbl1, [], [])), debuginfo ()],
+            Cexit(Cmm.Lbl lbl1, [], []))) }
+  | LPAREN EXIT traps IDENT exprlist RPAREN
+    { Cexit(Cmm.Lbl (find_label $4), List.rev $5, $3) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
       List.iter (fun (_, l, _, _) ->
         List.iter (fun (x, _) -> unbind_ident x) l) handlers;
       Ccatch(Recursive, handlers, $3) }
-  | EXIT        { Cexit(0,[]) }
+  | EXIT        { Cexit(Cmm.Lbl 0,[],[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
-                { unbind_ident $5; Ctrywith($3, $5, $6, debuginfo ()) }
+                { unbind_ident $5; Ctrywith($3, Regular, $5, $6, debuginfo ()) }
   | LPAREN VAL expr expr RPAREN
       { let open Asttypes in
         Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],


### PR DESCRIPTION
This pull request imports / rebases https://github.com/lthls/ocaml/tree/cmm_traps,
which is part of the tip of https://github.com/ocaml-flambda/ocaml.

(This pull request is expected to be equivalent to https://github.com/ocaml-flambda/flambda-backend/pull/66.)