### PR TITLE
Remove Obj.set_tag and Obj.truncate

### DIFF
--- a/ocaml/stdlib/obj.ml
+++ b/ocaml/stdlib/obj.ml
@@ -30,7 +30,6 @@ external magic : 'a -> 'b = "%identity"
 external is_int : t -> bool = "%obj_is_int"
 let [@inline always] is_block a = not (is_int a)
 external tag : t -> int = "caml_obj_tag" [@@noalloc]
-external set_tag : t -> int -> unit = "caml_obj_set_tag"
 external size : t -> int = "%obj_size"
 external reachable_words : t -> int = "caml_obj_reachable_words"
 external field : t -> int -> t = "%obj_field"
@@ -47,7 +46,6 @@ external set_raw_field : t -> int -> raw_data -> unit
 
 external new_block : int -> int -> t = "caml_obj_block"
 external dup : t -> t = "caml_obj_dup"
-external truncate : t -> int -> unit = "caml_obj_truncate"
 external add_offset : t -> Int32.t -> t = "caml_obj_add_offset"
 external with_tag : int -> t -> t = "caml_obj_with_tag"
 

--- a/ocaml/stdlib/obj.mli
+++ b/ocaml/stdlib/obj.mli
@@ -46,13 +46,9 @@ external field : t -> int -> t = "%obj_field"
 
 (** When using flambda:
 
-    [set_field] MUST NOT be called on immutable blocks.  (Blocks allocated
-    in C stubs, or with [new_block] below, are always considered mutable.)
-
-    The same goes for [set_double_field] and [set_tag].  However, for
-    [set_tag], in the case of immutable blocks where the middle-end optimizers
-    never see code that discriminates on their tag (for example records), the
-    operation should be safe.  Such uses are nonetheless discouraged.
+    [set_field] and [set_double_field] MUST NOT be called on immutable
+    blocks.  (Blocks allocated in C stubs, or with [new_block] below,
+    are always considered mutable.)
 
     For experts only:
     [set_field] et al can be made safe by first wrapping the block in
@@ -60,8 +56,6 @@ external field : t -> int -> t = "%obj_field"
     be propagated.
 *)
 external set_field : t -> int -> t -> unit = "%obj_set_field"
-external set_tag : t -> int -> unit = "caml_obj_set_tag"
-  [@@ocaml.deprecated "Use with_tag instead."]
 
 val [@inline always] double_field : t -> int -> float  (* @since 3.11.2 *)
 val [@inline always] set_double_field : t -> int -> float -> unit
@@ -75,8 +69,6 @@ external set_raw_field : t -> int -> raw_data -> unit
 
 external new_block : int -> int -> t = "caml_obj_block"
 external dup : t -> t = "caml_obj_dup"
-external truncate : t -> int -> unit = "caml_obj_truncate"
-  [@@ocaml.deprecated]
 external add_offset : t -> Int32.t -> t = "caml_obj_add_offset"
          (* @since 3.12.0 *)
 external with_tag : int -> t -> t = "caml_obj_with_tag"


### PR DESCRIPTION
As per discussion inside JS just now.  These were already deprecated.