### PR TITLE
use upstream version of Cextcall in Parsecmm under ocaml directory 

### DIFF
--- a/ocaml/testsuite/tools/parsecmm.mly
+++ b/ocaml/testsuite/tools/parsecmm.mly
@@ -221,13 +221,7 @@ expr:
   | LPAREN APPLY location expr exprlist machtype RPAREN
                 { Cop(Capply $6, $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
-               {Cop(Cextcall {name=$3; ret=$5; alloc=false;
-                              builtin=false;
-                              returns=true;
-                              effects=Arbitrary_effects;
-                              coeffects=Has_coeffects;
-                              ty_args=[];},
-                     List.rev $4, debuginfo ())}
+               {Cop(Cextcall($3, $5, false, None), List.rev $4, debuginfo ())}
   | LPAREN ALLOC exprlist RPAREN { Cop(Calloc, List.rev $3, debuginfo ()) }
   | LPAREN SUBF expr RPAREN { Cop(Cnegf, [$3], debuginfo ()) }
   | LPAREN SUBF expr expr RPAREN { Cop(Csubf, [$3; $4], debuginfo ()) }


### PR DESCRIPTION
Cherry-pick 9432cfdadb043a191b414a2caece3e4f9bbc68b7

This commit, which was part of PR #55, was lost when PR #55 was ported to 4.12.
