### PR TITLE
Root scanning fixes for Flambda 2

### DIFF
--- a/ocaml/runtime/roots_nat.c
+++ b/ocaml/runtime/roots_nat.c
@@ -252,6 +252,8 @@ void caml_oldify_local_roots (void)
   unsigned short * p;
   value * glob;
   value * root;
+  value glob_block;
+  int start;
   struct caml__roots_block *lr;
   link *lnk;
 
@@ -260,9 +262,15 @@ void caml_oldify_local_roots (void)
        i <= caml_globals_inited && caml_globals[i] != 0;
        i++) {
     for(glob = caml_globals[i]; *glob != 0; glob++) {
-      for (j = 0; j < Wosize_val(*glob); j++){
-        Oldify (&Field (*glob, j));
-      }
+      glob_block = *glob;
+      start = 0;
+      CAMLassert (Is_block (glob_block));
+      if (Tag_val (glob_block) == Infix_tag)
+        glob_block -= Infix_offset_val (glob_block);
+      if (Tag_val (glob_block) == Closure_tag)
+        start = Start_env_closinfo (Closinfo_val (glob_block));
+      for (j = start; j < Wosize_val (glob_block); j++)
+        Oldify (&Field (glob_block, j));
     }
   }
   caml_globals_scanned = caml_globals_inited;
@@ -270,8 +278,15 @@ void caml_oldify_local_roots (void)
   /* Dynamic global roots */
   iter_list(caml_dyn_globals, lnk) {
     for(glob = (value *) lnk->data; *glob != 0; glob++) {
-      for (j = 0; j < Wosize_val(*glob); j++){
-        Oldify (&Field (*glob, j));
+      glob_block = *glob;
+      start = 0;
+      CAMLassert (Is_block (glob_block));
+      if (Tag_val (glob_block) == Infix_tag)
+        glob_block -= Infix_offset_val (glob_block);
+      if (Tag_val (glob_block) == Closure_tag)
+        start = Start_env_closinfo (Closinfo_val (glob_block));
+      for (j = start; j < Wosize_val (glob_block); j++) {
+        Oldify (&Field (glob_block, j));
       }
     }
   }
@@ -360,6 +375,8 @@ intnat caml_darken_all_roots_slice (intnat work)
   static int i, j;
   static value *glob;
   static int do_resume = 0;
+  static value glob_block;
+  static int start;
   static mlsize_t roots_count = 0;
   intnat remaining_work = work;
   CAML_EV_BEGIN(EV_MAJOR_MARK_GLOBAL_ROOTS_SLICE);
@@ -371,8 +388,15 @@ intnat caml_darken_all_roots_slice (intnat work)
      suspend itself when [work] reaches 0. */
   for (i = 0; caml_globals[i] != 0; i++) {
     for(glob = caml_globals[i]; *glob != 0; glob++) {
-      for (j = 0; j < Wosize_val(*glob); j++){
-        caml_darken (Field (*glob, j), &Field (*glob, j));
+      glob_block = *glob;
+      start = 0;
+      CAMLassert (Is_block (glob_block));
+      if (Tag_val (glob_block) == Infix_tag)
+        glob_block -= Infix_offset_val (glob_block);
+      if (Tag_val (glob_block) == Closure_tag)
+        start = Start_env_closinfo (Closinfo_val (glob_block));
+      for (j = start; j < Wosize_val (glob_block); j++) {
+        caml_darken (Field (glob_block, j), &Field (glob_block, j));
         -- remaining_work;
         if (remaining_work == 0){
           roots_count += work;
@@ -401,22 +425,38 @@ void caml_do_roots (scanning_action f, int do_globals)
   int i, j;
   value * glob;
   link *lnk;
+  value glob_block;
+  int start;
 
   CAML_EV_BEGIN(EV_MAJOR_ROOTS_DYNAMIC_GLOBAL);
   if (do_globals){
     /* The global roots */
     for (i = 0; caml_globals[i] != 0; i++) {
       for(glob = caml_globals[i]; *glob != 0; glob++) {
-        for (j = 0; j < Wosize_val(*glob); j++)
-          f (Field (*glob, j), &Field (*glob, j));
+         glob_block = *glob;
+         start = 0;
+         CAMLassert (Is_block (glob_block));
+         if (Tag_val (glob_block) == Infix_tag)
+           glob_block -= Infix_offset_val (glob_block);
+         if (Tag_val (glob_block) == Closure_tag)
+           start = Start_env_closinfo (Closinfo_val (glob_block));
+         for (j = start; j < Wosize_val (glob_block); j++)
+           f (Field (glob_block, j), &Field (glob_block, j));
       }
     }
   }
   /* Dynamic global roots */
   iter_list(caml_dyn_globals, lnk) {
     for(glob = (value *) lnk->data; *glob != 0; glob++) {
-      for (j = 0; j < Wosize_val(*glob); j++){
-        f (Field (*glob, j), &Field (*glob, j));
+      glob_block = *glob;
+      start = 0;
+      CAMLassert (Is_block (glob_block));
+      if (Tag_val (glob_block) == Infix_tag)
+        glob_block -= Infix_offset_val (glob_block);
+      if (Tag_val (glob_block) == Closure_tag)
+        start = Start_env_closinfo (Closinfo_val (glob_block));
+      for (j = start; j < Wosize_val (glob_block); j++) {
+        f (Field (glob_block, j), &Field (glob_block, j));
       }
     }
   }

--- a/ocaml/runtime/roots_nat.c
+++ b/ocaml/runtime/roots_nat.c
@@ -265,12 +265,14 @@ void caml_oldify_local_roots (void)
       glob_block = *glob;
       start = 0;
       CAMLassert (Is_block (glob_block));
-      if (Tag_val (glob_block) == Infix_tag)
-        glob_block -= Infix_offset_val (glob_block);
-      if (Tag_val (glob_block) == Closure_tag)
-        start = Start_env_closinfo (Closinfo_val (glob_block));
-      for (j = start; j < Wosize_val (glob_block); j++)
-        Oldify (&Field (glob_block, j));
+      if (Tag_val (glob_block) < No_scan_tag) {
+        if (Tag_val (glob_block) == Infix_tag)
+          glob_block -= Infix_offset_val (glob_block);
+        if (Tag_val (glob_block) == Closure_tag)
+          start = Start_env_closinfo (Closinfo_val (glob_block));
+        for (j = start; j < Wosize_val (glob_block); j++)
+          Oldify (&Field (glob_block, j));
+      }
     }
   }
   caml_globals_scanned = caml_globals_inited;
@@ -281,12 +283,14 @@ void caml_oldify_local_roots (void)
       glob_block = *glob;
       start = 0;
       CAMLassert (Is_block (glob_block));
-      if (Tag_val (glob_block) == Infix_tag)
-        glob_block -= Infix_offset_val (glob_block);
-      if (Tag_val (glob_block) == Closure_tag)
-        start = Start_env_closinfo (Closinfo_val (glob_block));
-      for (j = start; j < Wosize_val (glob_block); j++) {
-        Oldify (&Field (glob_block, j));
+      if (Tag_val (glob_block) < No_scan_tag) {
+        if (Tag_val (glob_block) == Infix_tag)
+          glob_block -= Infix_offset_val (glob_block);
+        if (Tag_val (glob_block) == Closure_tag)
+          start = Start_env_closinfo (Closinfo_val (glob_block));
+        for (j = start; j < Wosize_val (glob_block); j++) {
+          Oldify (&Field (glob_block, j));
+        }
       }
     }
   }
@@ -391,19 +395,21 @@ intnat caml_darken_all_roots_slice (intnat work)
       glob_block = *glob;
       start = 0;
       CAMLassert (Is_block (glob_block));
-      if (Tag_val (glob_block) == Infix_tag)
-        glob_block -= Infix_offset_val (glob_block);
-      if (Tag_val (glob_block) == Closure_tag)
-        start = Start_env_closinfo (Closinfo_val (glob_block));
-      for (j = start; j < Wosize_val (glob_block); j++) {
-        caml_darken (Field (glob_block, j), &Field (glob_block, j));
-        -- remaining_work;
-        if (remaining_work == 0){
-          roots_count += work;
-          do_resume = 1;
-          goto suspend;
+      if (Tag_val (glob_block) < No_scan_tag) {
+        if (Tag_val (glob_block) == Infix_tag)
+          glob_block -= Infix_offset_val (glob_block);
+        if (Tag_val (glob_block) == Closure_tag)
+          start = Start_env_closinfo (Closinfo_val (glob_block));
+        for (j = start; j < Wosize_val (glob_block); j++) {
+          caml_darken (Field (glob_block, j), &Field (glob_block, j));
+          -- remaining_work;
+          if (remaining_work == 0){
+            roots_count += work;
+            do_resume = 1;
+            goto suspend;
+          }
+        resume: ;
         }
-      resume: ;
       }
     }
   }
@@ -436,12 +442,14 @@ void caml_do_roots (scanning_action f, int do_globals)
          glob_block = *glob;
          start = 0;
          CAMLassert (Is_block (glob_block));
-         if (Tag_val (glob_block) == Infix_tag)
-           glob_block -= Infix_offset_val (glob_block);
-         if (Tag_val (glob_block) == Closure_tag)
-           start = Start_env_closinfo (Closinfo_val (glob_block));
-         for (j = start; j < Wosize_val (glob_block); j++)
-           f (Field (glob_block, j), &Field (glob_block, j));
+         if (Tag_val (glob_block) < No_scan_tag) {
+           if (Tag_val (glob_block) == Infix_tag)
+             glob_block -= Infix_offset_val (glob_block);
+           if (Tag_val (glob_block) == Closure_tag)
+             start = Start_env_closinfo (Closinfo_val (glob_block));
+           for (j = start; j < Wosize_val (glob_block); j++)
+             f (Field (glob_block, j), &Field (glob_block, j));
+         }
       }
     }
   }
@@ -451,12 +459,14 @@ void caml_do_roots (scanning_action f, int do_globals)
       glob_block = *glob;
       start = 0;
       CAMLassert (Is_block (glob_block));
-      if (Tag_val (glob_block) == Infix_tag)
-        glob_block -= Infix_offset_val (glob_block);
-      if (Tag_val (glob_block) == Closure_tag)
-        start = Start_env_closinfo (Closinfo_val (glob_block));
-      for (j = start; j < Wosize_val (glob_block); j++) {
-        f (Field (glob_block, j), &Field (glob_block, j));
+      if (Tag_val (glob_block) < No_scan_tag) {
+        if (Tag_val (glob_block) == Infix_tag)
+          glob_block -= Infix_offset_val (glob_block);
+        if (Tag_val (glob_block) == Closure_tag)
+          start = Start_env_closinfo (Closinfo_val (glob_block));
+        for (j = start; j < Wosize_val (glob_block); j++) {
+          f (Field (glob_block, j), &Field (glob_block, j));
+        }
       }
     }
   }


### PR DESCRIPTION
Originally written by @poechsel in conjunction with @mshinwell

We may want to tidy this up a bit, but it is believed to be correct. It supports two things which Flambda 2 needs:

- registration of closures as static GC roots
- the ability for such closures to be not the first in the corresponding OCaml value (only one closure per set may be registered because of limitations in the compactor; this allows Flambda 2 to choose a closure that might be one of the Infix_tag ones, which makes things easier).