### PR TITLE
Allow --enable-middle-end=flambda2 etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,12 +28,13 @@ AC_MSG_NOTICE([Using dune executable: $dune])
 
 AC_ARG_ENABLE([middle-end],
   [AS_HELP_STRING([--enable-middle-end],
-    [Select which middle end to use: closure or flambda])],
+    [Select which middle end to use: closure, flambda or flambda2])],
   [AS_CASE([$enable_middle_end],
     [closure], [middle_end=closure middle_end_arg=--disable-flambda],
     [flambda], [middle_end=flambda middle_end_arg=--enable-flambda],
-    [*],       [AC_MSG_ERROR([Bad middle end (not closure or flambda)])])],
-  [AC_MSG_ERROR([--enable-middle-end=closure|flambda must be provided])])
+    [flambda2], [middle_end=flambda middle_end_arg=--enable-flambda2],
+    [*], [AC_MSG_ERROR([Bad middle end (not closure, flambda or flambda2)])])],
+  [AC_MSG_ERROR([--enable-middle-end=closure|flambda|flambda2 must be provided])])
 
 stage0_prefix=$ac_abs_confdir/_build0/_install
 stage1_prefix=$ac_abs_confdir/_build1/install/default

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -95,6 +95,8 @@ let implementation ~backend ~start_from ~source_file ~output_prefix =
     Compilenv.reset ?packname:!Clflags.for_package info.module_name;
     if Config.flambda
     then flambda info backend typed
+    else if Config.flambda2
+    then Misc.fatal_error "Flambda 2 coming soon!"
     else clambda info backend typed
   in
   with_info ~source_file ~output_prefix ~dump_ext:"cmx" @@ fun info ->

--- a/ocaml/Makefile.config.in
+++ b/ocaml/Makefile.config.in
@@ -231,6 +231,7 @@ WITH_FPIC=@fpic@
 TARGET=@target@
 HOST=@host@
 FLAMBDA=@flambda@
+FLAMBDA2=@flambda2@
 WITH_FLAMBDA_INVARIANTS=@flambda_invariants@
 FORCE_SAFE_STRING=@force_safe_string@
 DEFAULT_SAFE_STRING=@default_safe_string@

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -16897,29 +16897,22 @@ if test x"$enable_flambda" = "xyes"; then :
    flambda2=false
    if test x"$enable_flambda2" = "xyes"; then :
   as_fn_error $? "please enable only one of Flambda 1 and Flambda 2" "$LINENO" 5
-else
-  if test x"$enable_flambda_invariants" = "xyes"; then :
-  flambda_invariants=true
-else
-  flambda_invariants=false
-fi
 fi
 else
   flambda=false
-   flambda_invariants=false
 fi
 
 if test x"$enable_flambda2" = "xyes"; then :
   flambda2=true
    flambda=false
-   if test x"$enable_flambda_invariants" = "xyes"; then :
+else
+  flambda2=false
+fi
+
+if test x"$enable_flambda_invariants" = "xyes"; then :
   flambda_invariants=true
 else
   flambda_invariants=false
-fi
-else
-  flambda2=false
-   flambda_invariants=false
 fi
 
 if test x"$enable_flat_float_array" = "xno"; then :

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -706,6 +706,7 @@ function_sections
 flat_float_array
 windows_unicode
 flambda_invariants
+flambda2
 flambda
 frame_pointers
 profinfo_width
@@ -801,7 +802,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -846,6 +846,7 @@ enable_installing_bytecode_programs
 enable_native_compiler
 enable_flambda
 enable_flambda_invariants
+enable_flambda2
 with_target_bindir
 enable_reserved_header_bits
 enable_stdlib_manpages
@@ -917,7 +918,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1170,15 +1170,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1316,7 +1307,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1469,7 +1460,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1529,9 +1519,10 @@ Optional Features:
                           also install the bytecode versions of programs
   --disable-native-compiler
                           do not build the native compiler
-  --enable-flambda        enable flambda optimizations
+  --enable-flambda        enable the Flambda 1 middle end
   --enable-flambda-invariants
                           enable invariants checks in flambda
+  --enable-flambda2       enable the Flambda 2 middle end
   --enable-reserved-header-bits=BITS
                           reserve BITS (between 0 and 31) bits in block
                           headers for profiling info
@@ -2886,6 +2877,7 @@ VERSION=4.12.1+dev0-2021-02-24
 
 
 
+
 ## Generated files
 
 ac_config_files="$ac_config_files Makefile.build_config"
@@ -3181,6 +3173,12 @@ fi
 # Check whether --enable-flambda-invariants was given.
 if test "${enable_flambda_invariants+set}" = set; then :
   enableval=$enable_flambda_invariants;
+fi
+
+
+# Check whether --enable-flambda2 was given.
+if test "${enable_flambda2+set}" = set; then :
+  enableval=$enable_flambda2;
 fi
 
 
@@ -16896,14 +16894,32 @@ esac
 
 if test x"$enable_flambda" = "xyes"; then :
   flambda=true
+   flambda2=false
+   if test x"$enable_flambda2" = "xyes"; then :
+  as_fn_error $? "please enable only one of Flambda 1 and Flambda 2" "$LINENO" 5
+else
   if test x"$enable_flambda_invariants" = "xyes"; then :
   flambda_invariants=true
 else
   flambda_invariants=false
 fi
+fi
 else
   flambda=false
+   flambda_invariants=false
+fi
+
+if test x"$enable_flambda2" = "xyes"; then :
+  flambda2=true
+   flambda=false
+   if test x"$enable_flambda_invariants" = "xyes"; then :
+  flambda_invariants=true
+else
   flambda_invariants=false
+fi
+else
+  flambda2=false
+   flambda_invariants=false
 fi
 
 if test x"$enable_flat_float_array" = "xno"; then :

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -153,6 +153,7 @@ AC_SUBST([profinfo])
 AC_SUBST([profinfo_width])
 AC_SUBST([frame_pointers])
 AC_SUBST([flambda])
+AC_SUBST([flambda2])
 AC_SUBST([flambda_invariants])
 AC_SUBST([windows_unicode])
 AC_SUBST([flat_float_array])
@@ -304,11 +305,15 @@ AC_ARG_ENABLE([native-compiler],
 
 AC_ARG_ENABLE([flambda],
   [AS_HELP_STRING([--enable-flambda],
-    [enable flambda optimizations])])
+    [enable the Flambda 1 middle end])])
 
 AC_ARG_ENABLE([flambda-invariants],
   [AS_HELP_STRING([--enable-flambda-invariants],
     [enable invariants checks in flambda])])
+
+AC_ARG_ENABLE([flambda2],
+  [AS_HELP_STRING([--enable-flambda2],
+    [enable the Flambda 2 middle end])])
 
 AC_ARG_WITH([target-bindir],
   [AS_HELP_STRING([--with-target-bindir],
@@ -1764,11 +1769,23 @@ AS_CASE([$enable_ocamltest,AC_PACKAGE_VERSION],
 
 AS_IF([test x"$enable_flambda" = "xyes"],
   [flambda=true
-  AS_IF([test x"$enable_flambda_invariants" = "xyes"],
-    [flambda_invariants=true],
-    [flambda_invariants=false])],
+   flambda2=false
+   AS_IF([test x"$enable_flambda2" = "xyes"],
+     [AC_MSG_ERROR([please enable only one of Flambda 1 and Flambda 2])],
+     [AS_IF([test x"$enable_flambda_invariants" = "xyes"],
+       [flambda_invariants=true],
+       [flambda_invariants=false])])],
   [flambda=false
-  flambda_invariants=false])
+   flambda_invariants=false])
+
+AS_IF([test x"$enable_flambda2" = "xyes"],
+  [flambda2=true
+   flambda=false
+   AS_IF([test x"$enable_flambda_invariants" = "xyes"],
+     [flambda_invariants=true],
+     [flambda_invariants=false])],
+  [flambda2=false
+   flambda_invariants=false])
 
 AS_IF([test x"$enable_flat_float_array" = "xno"],
   [flat_float_array=false],

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -1772,20 +1772,17 @@ AS_IF([test x"$enable_flambda" = "xyes"],
    flambda2=false
    AS_IF([test x"$enable_flambda2" = "xyes"],
      [AC_MSG_ERROR([please enable only one of Flambda 1 and Flambda 2])],
-     [AS_IF([test x"$enable_flambda_invariants" = "xyes"],
-       [flambda_invariants=true],
-       [flambda_invariants=false])])],
-  [flambda=false
-   flambda_invariants=false])
+     [])],
+  [flambda=false])
 
 AS_IF([test x"$enable_flambda2" = "xyes"],
   [flambda2=true
-   flambda=false
-   AS_IF([test x"$enable_flambda_invariants" = "xyes"],
-     [flambda_invariants=true],
-     [flambda_invariants=false])],
-  [flambda2=false
-   flambda_invariants=false])
+   flambda=false],
+  [flambda2=false])
+
+AS_IF([test x"$enable_flambda_invariants" = "xyes"],
+  [flambda_invariants=true],
+  [flambda_invariants=false])
 
 AS_IF([test x"$enable_flat_float_array" = "xno"],
   [flat_float_array=false],

--- a/ocaml/utils/Makefile
+++ b/ocaml/utils/Makefile
@@ -57,6 +57,7 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST_STRING,EXT_LIB) \
 	    $(call SUBST_STRING,EXT_OBJ) \
 	    $(call SUBST,FLAMBDA) \
+	    $(call SUBST,FLAMBDA2) \
 	    $(call SUBST,WITH_FLAMBDA_INVARIANTS) \
 	    $(call SUBST_STRING,FLEXLINK_FLAGS) \
 	    $(call SUBST_QUOTE,FLEXDLL_DIR) \

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -74,7 +74,7 @@ let mkdll, mkexe, mkmaindll =
     "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
 
 let flambda = %%FLAMBDA%%
-let flambda2 = false
+let flambda2 = %%FLAMBDA2%%
 let with_flambda_invariants = %%WITH_FLAMBDA_INVARIANTS%%
 let safe_string = %%FORCE_SAFE_STRING%%
 let default_safe_string = %%DEFAULT_SAFE_STRING%%


### PR DESCRIPTION
This does two things:
- allows `--enable-middle-end=flambda2` as an option to the Flambda backend `configure` script;
- adds support in the `ocaml` subtree for an `--enable-flambda2` to the `configure` script.  This is wired to `Config.flambda2`.  A fatal error is currently generated when attempting to run the compiler if configured with Flambda 2.