### PR TITLE
Fix Selectgen and Spill for probes

### DIFF
--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -813,6 +813,12 @@ method emit_expr (env:environment) exp =
               self#emit_stores env new_args rd;
               set_traps_for_raise env;
               Some rd
+          | Iprobe _ ->
+              let r1 = self#emit_tuple env new_args in
+              let rd = self#regs_for ty in
+              let rd = self#insert_op_debug env new_op dbg r1 rd in
+              set_traps_for_raise env;
+              Some rd
           | op ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -500,7 +500,8 @@ let rec spill :
       let before =
         match i.desc with
           Iop Icall_ind | Iop(Icall_imm _) | Iop(Iextcall _) | Iop(Ialloc _)
-        | Iop(Iintop Icheckbound) | Iop(Iintop_imm(Icheckbound, _)) ->
+        | Iop(Iintop Icheckbound) | Iop(Iintop_imm(Icheckbound, _))
+        | Iop (Iprobe _) ->
             Reg.Set.union before1 env.at_raise
         | _ ->
             before1 in


### PR DESCRIPTION
Two minor fixes:
- one missing case for probes in `Selectgen`, needed for the new Cmm traps representation;
- one match case accidentally removed during merging of a previous PR in `Spill`.

Joint work with @xclerc 