### PR TITLE
First set of command-line flags for Flambda 2

### DIFF
--- a/middle_end/flambda2/compilenv_deps/flambda_features.ml
+++ b/middle_end/flambda2/compilenv_deps/flambda_features.ml
@@ -18,12 +18,12 @@ let flambda2_is_enabled () = Config.flambda
 
 (* CR mshinwell: wire this in *)
 
-let join_points () = true (* !Clflags.Flambda.join_points *)
-let unbox_along_intra_function_control_flow () = true
-  (* !Clflags.Flambda.unbox_along_intra_function_control_flow *)
-let backend_cse_at_toplevel () = false
-  (* !Clflags.Flambda.backend_cse_at_toplevel *)
-let cse_depth () = 0 (* !Clflags.Flambda.cse_depth *)
+let join_points () = !Clflags.Flambda2.join_points
+let unbox_along_intra_function_control_flow () =
+  !Clflags.Flambda2.unbox_along_intra_function_control_flow
+let backend_cse_at_toplevel () =
+  !Clflags.Flambda2.backend_cse_at_toplevel
+let cse_depth () = !Clflags.Flambda2.cse_depth
 
 let safe_string () = Config.safe_string
 let flat_float_array () = Config.flat_float_array
@@ -89,24 +89,23 @@ module Inlining = struct
 end
 
 module Debug = struct
-  let permute_every_name () = false
-    (* !Clflags.Flambda.Debug.permute_every_name *)
+  let permute_every_name () = !Clflags.Flambda2.Debug.permute_every_name
 
-  let concrete_types_only_on_canonicals () = false
-    (* !Clflags.Flambda.Debug.concrete_types_only_on_canonicals *)
+  let concrete_types_only_on_canonicals () =
+    !Clflags.Flambda2.Debug.concrete_types_only_on_canonicals
 end
 
 module Expert = struct
-  let code_id_and_symbol_scoping_checks () = false
-    (* !Clflags.Flambda.Expert.code_id_and_symbol_scoping_checks *)
-  let fallback_inlining_heuristic () = false
-    (* !Clflags.Flambda.Expert.fallback_inlining_heuristic *)
-  let inline_effects_in_cmm () = false
-    (* !Clflags.Flambda.Expert.inline_effects_in_cmm *)
-  let max_block_size_for_projections () = None
-    (* !Clflags.Flambda.Expert.max_block_size_for_projections *)
-  let phantom_lets () = true
-    (* !Clflags.Flambda.Expert.phantom_lets *)
-  let max_unboxing_depth () = 1
-    (* !Clflags.Flambda.Expert.max_unboxing_depth *)
+  let code_id_and_symbol_scoping_checks () =
+    !Clflags.Flambda2.Expert.code_id_and_symbol_scoping_checks
+  let fallback_inlining_heuristic () =
+    !Clflags.Flambda2.Expert.fallback_inlining_heuristic
+  let inline_effects_in_cmm () =
+    !Clflags.Flambda2.Expert.inline_effects_in_cmm
+  let max_block_size_for_projections () =
+    !Clflags.Flambda2.Expert.max_block_size_for_projections
+  let phantom_lets () =
+    !Clflags.Flambda2.Expert.phantom_lets
+  let max_unboxing_depth () =
+    !Clflags.Flambda2.Expert.max_unboxing_depth
 end

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -919,120 +919,161 @@ let mk__ f =
   "<file>  Treat <file> as a file name (even if it starts with `-')"
 ;;
 
+let format_default flag = if flag then " (default)" else ""
+let format_not_default flag = if flag then "" else " (default)"
+
+module Flambda2 = Clflags.Flambda2
+
 let mk_flambda2_join_points f =
-  "-flambda2-join-points", Arg.Unit f, " Propagate information from incoming \
-    edges at a join point (Flambda 2 only)"
+  "-flambda2-join-points", Arg.Unit f,
+  Printf.sprintf " Propagate information from incoming \
+      edges at a join point%s (Flambda 2 only)"
+    (format_default Flambda2.Default.join_points)
 ;;
 
 let mk_no_flambda2_join_points f =
-  "-no-flambda2-join-points", Arg.Unit f, " Propagate information only from \
-    the fork point to a join point (Flambda 2 only)"
+  "-no-flambda2-join-points", Arg.Unit f,
+  Printf.sprintf " Propagate information only from \
+      the fork point to a join point%s (Flambda 2 only)"
+    (format_not_default Flambda2.Default.join_points)
 ;;
 
 let mk_flambda2_unbox_along_intra_function_control_flow f =
   "-flambda2-unbox-along-intra-function-control-flow", Arg.Unit f,
-    " Pass values within a function as unboxed where possible (Flambda 2 only)"
+  Printf.sprintf " Pass values within a function as unboxed where possible%s \
+      (Flambda 2 only)"
+    (format_default Flambda2.Default.unbox_along_intra_function_control_flow)
 ;;
 
 let mk_no_flambda2_unbox_along_intra_function_control_flow f =
   "-no-flambda2-unbox-along-intra-function-control-flow", Arg.Unit f,
-    " Pass values within a function in their normal representation \
-      (Flambda 2 only)"
-;;
-
-let mk_flambda2_cse_depth f =
-  "-flambda2-cse-depth", Arg.Int f,
-    " Depth threshold for eager tracking of CSE equations (default 2) \
-      (Flambda 2 only)"
-;;
-
-let mk_flambda2_expert_code_id_and_symbol_scoping_checks f =
-  "-flambda2-expert-code-id-and-symbol-scoping-checks", Arg.Unit f,
-    " Perform checks on static scopes of code IDs and symbols during Un_cps \
-      (Flambda 2 only)"
-;;
-
-let mk_no_flambda2_expert_code_id_and_symbol_scoping_checks f =
-  "-no-flambda2-expert-code-id-and-symbol-scoping-checks", Arg.Unit f,
-    " Perform checks on static scopes of code IDs and symbols during Un_cps \
-      (Flambda 2 only)"
-;;
-
-let mk_flambda2_expert_fallback_inlining_heuristic f =
-  "-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
-    " Prevent inlining of functions whose bodies contain closures \
-      (Flambda 2 only)"
-;;
-
-let mk_no_flambda2_expert_fallback_inlining_heuristic f =
-  "-no-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
-    " Allow inlining of functions whose bodies contain closures (default) \
-      (Flambda 2 only)"
-;;
-
-let mk_flambda2_expert_inline_effects_in_cmm f =
-  "-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
-  " Allow inlining of effectful expressions in the produced cmm \
-    (Flambda 2 only)"
-;;
-
-let mk_no_flambda2_expert_inline_effects_in_cmm f =
-  "-no-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
-  " Prevent inlining of effectful expressions in the produced cmm (default) \
-    (Flambda 2 only)"
-;;
-
-let mk_flambda2_expert_phantom_lets f =
-  "-flambda2-expert-phantom-lets", Arg.Unit f,
-  " Generate phantom lets when -g is specified (Flambda 2 only)"
-;;
-
-let mk_no_flambda2_expert_phantom_lets f =
-  "-no-flambda2-expert-phantom-lets", Arg.Unit f,
-  " Do not generate phantom lets even when -g is specified (Flambda 2 only)"
-;;
-
-let mk_flambda2_expert_max_block_size_for_projections f =
-  "-flambda2-expert-max-block-size-for-projections", Arg.Int f,
-  " Do not simplify projections from blocks if the block size exceeds \
-    this value (Flambda 2 only)"
-;;
-
-let mk_flambda2_expert_max_unboxing_depth f =
-  "-flambda2-expert-max-unboxing-depth", Arg.Int f,
-  " Do not unbox types deeper that this value (Flambda 2 only)"
-;;
-
-let mk_flambda2_debug_permute_every_name f =
-  "-flambda2-debug-permute-every-name", Arg.Unit f,
-    " Permute every name to check permutation works (Flambda 2 only)"
-;;
-
-let mk_no_flambda2_debug_permute_every_name f =
-  "-no-flambda2-debug-permute-every-name", Arg.Unit f,
-    " Do not permute every name to check permutation works (Flambda 2 only)"
-;;
-
-let mk_flambda2_debug_concrete_types_only_on_canonicals f =
-  "-flambda2-debug-concrete-types-only-on-canonicals", Arg.Unit f,
-    " Check that concrete types are only assigned to canonical names \
-      (Flambda 2 only)"
-;;
-
-let mk_no_flambda2_debug_concrete_types_only_on_canonicals f =
-  "-no-flambda2-debug-concrete-types-only-on-canonicals", Arg.Unit f,
-    " Do not check that concrete types are only assigned to canonical names \
-      (Flambda 2 only)"
+  Printf.sprintf " Pass values within a function in their normal \
+      representation%s (Flambda 2 only)"
+    (format_not_default
+      Flambda2.Default.unbox_along_intra_function_control_flow)
 ;;
 
 let mk_flambda2_backend_cse_at_toplevel f =
   "-flambda2-backend-cse-at-toplevel", Arg.Unit f,
-    " Apply the backend CSE pass to module initializers (Flambda 2 only)"
+  Printf.sprintf " Apply the backend CSE pass to module initializers%s \
+      (Flambda 2 only)"
+    (format_default Flambda2.Default.backend_cse_at_toplevel)
 ;;
 
 let mk_no_flambda2_backend_cse_at_toplevel f =
   "-no-flambda2-backend-cse-at-toplevel", Arg.Unit f,
-    " Do not apply the backend CSE pass to module initializers (Flambda 2 only)"
+  Printf.sprintf " Do not apply the backend CSE pass to module initializers%s \
+      (Flambda 2 only)"
+    (format_not_default Flambda2.Default.backend_cse_at_toplevel)
+;;
+
+let mk_flambda2_cse_depth f =
+  "-flambda2-cse-depth", Arg.Int f,
+  Printf.sprintf " Depth threshold for eager tracking of CSE equations \
+      (default %d) (Flambda 2 only)"
+    Flambda2.Default.cse_depth
+;;
+
+let mk_flambda2_expert_code_id_and_symbol_scoping_checks f =
+  "-flambda2-expert-code-id-and-symbol-scoping-checks", Arg.Unit f,
+  Printf.sprintf " Perform checks on static scopes of code IDs and symbols \
+      during Un_cps%s (Flambda 2 only)"
+    (format_default Flambda2.Expert.Default.code_id_and_symbol_scoping_checks)
+;;
+
+let mk_no_flambda2_expert_code_id_and_symbol_scoping_checks f =
+  "-no-flambda2-expert-code-id-and-symbol-scoping-checks", Arg.Unit f,
+  Printf.sprintf " Do not perform checks on static scopes of code IDs and \
+      symbols during Un_cps%s (Flambda 2 only)"
+    (format_not_default
+      Flambda2.Expert.Default.code_id_and_symbol_scoping_checks)
+;;
+
+let mk_flambda2_expert_fallback_inlining_heuristic f =
+  "-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
+  Printf.sprintf " Prevent inlining of functions whose bodies contain \
+      closures%s (Flambda 2 only)"
+    (format_default Flambda2.Expert.Default.fallback_inlining_heuristic)
+;;
+
+let mk_no_flambda2_expert_fallback_inlining_heuristic f =
+  "-no-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
+  Printf.sprintf " Allow inlining of functions whose bodies contain \
+      closures%s (Flambda 2 only)"
+    (format_not_default Flambda2.Expert.Default.fallback_inlining_heuristic)
+;;
+
+let mk_flambda2_expert_inline_effects_in_cmm f =
+  "-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
+  Printf.sprintf " Allow inlining of effectful expressions in the produced \
+      Cmm code%s (Flambda 2 only)"
+    (format_default Flambda2.Expert.Default.inline_effects_in_cmm)
+;;
+
+let mk_no_flambda2_expert_inline_effects_in_cmm f =
+  "-no-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
+  Printf.sprintf " Prevent inlining of effectful expressions in the produced \
+      Cmm code%s (Flambda 2 only)"
+    (format_not_default Flambda2.Expert.Default.inline_effects_in_cmm)
+;;
+
+let mk_flambda2_expert_phantom_lets f =
+  "-flambda2-expert-phantom-lets", Arg.Unit f,
+  Printf.sprintf " Generate phantom lets when -g is specified%s \
+      (Flambda 2 only)"
+    (format_default Flambda2.Expert.Default.phantom_lets)
+;;
+
+let mk_no_flambda2_expert_phantom_lets f =
+  "-no-flambda2-expert-phantom-lets", Arg.Unit f,
+  Printf.sprintf " Do not generate phantom lets even when -g is specified%s \
+      (Flambda 2 only)"
+    (format_not_default Flambda2.Expert.Default.phantom_lets)
+;;
+
+let mk_flambda2_expert_max_block_size_for_projections f =
+  "-flambda2-expert-max-block-size-for-projections", Arg.Int f,
+  Printf.sprintf " Do not simplify projections from blocks if the block size \
+      exceeds this value (default %s) (Flambda 2 only)"
+    (match Flambda2.Expert.Default.max_block_size_for_projections with
+     | None -> "not set"
+     | Some max -> string_of_int max)
+;;
+
+let mk_flambda2_expert_max_unboxing_depth f =
+  "-flambda2-expert-max-unboxing-depth", Arg.Int f,
+  Printf.sprintf " Do not unbox (nested) values deeper than this many levels \
+      (default %d) (Flambda 2 only)"
+    Flambda2.Expert.Default.max_unboxing_depth
+;;
+
+let mk_flambda2_debug_permute_every_name f =
+  "-flambda2-debug-permute-every-name", Arg.Unit f,
+  Printf.sprintf " Permute every name to test name permutation code%s \
+      (Flambda 2 only)"
+    (format_default Flambda2.Debug.Default.permute_every_name)
+;;
+
+let mk_no_flambda2_debug_permute_every_name f =
+  "-no-flambda2-debug-permute-every-name", Arg.Unit f,
+  Printf.sprintf " Do not permute every name to test name permutation code%s \
+      (Flambda 2 only)"
+    (format_not_default Flambda2.Debug.Default.permute_every_name)
+;;
+
+let mk_flambda2_debug_concrete_types_only_on_canonicals f =
+  "-flambda2-debug-concrete-types-only-on-canonicals", Arg.Unit f,
+  Printf.sprintf " Check that concrete types are only assigned to canonical \
+      names%s (Flambda 2 only)"
+    (format_default Flambda2.Debug.Default.concrete_types_only_on_canonicals)
+;;
+
+let mk_no_flambda2_debug_concrete_types_only_on_canonicals f =
+  "-no-flambda2-debug-concrete-types-only-on-canonicals", Arg.Unit f,
+  Printf.sprintf " Do not check that concrete types are only assigned to \
+      canonical names%s (Flambda 2 only)"
+    (format_not_default
+      Flambda2.Debug.Default.concrete_types_only_on_canonicals)
 ;;
 
 module type Common_options = sig

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -919,6 +919,122 @@ let mk__ f =
   "<file>  Treat <file> as a file name (even if it starts with `-')"
 ;;
 
+let mk_flambda2_join_points f =
+  "-flambda2-join-points", Arg.Unit f, " Propagate information from incoming \
+    edges at a join point (Flambda 2 only)"
+;;
+
+let mk_no_flambda2_join_points f =
+  "-no-flambda2-join-points", Arg.Unit f, " Propagate information only from \
+    the fork point to a join point (Flambda 2 only)"
+;;
+
+let mk_flambda2_unbox_along_intra_function_control_flow f =
+  "-flambda2-unbox-along-intra-function-control-flow", Arg.Unit f,
+    " Pass values within a function as unboxed where possible (Flambda 2 only)"
+;;
+
+let mk_no_flambda2_unbox_along_intra_function_control_flow f =
+  "-no-flambda2-unbox-along-intra-function-control-flow", Arg.Unit f,
+    " Pass values within a function in their normal representation \
+      (Flambda 2 only)"
+;;
+
+let mk_flambda2_cse_depth f =
+  "-flambda2-cse-depth", Arg.Int f,
+    " Depth threshold for eager tracking of CSE equations (default 2) \
+      (Flambda 2 only)"
+;;
+
+let mk_flambda2_expert_code_id_and_symbol_scoping_checks f =
+  "-flambda2-expert-code-id-and-symbol-scoping-checks", Arg.Unit f,
+    " Perform checks on static scopes of code IDs and symbols during Un_cps \
+      (Flambda 2 only)"
+;;
+
+let mk_no_flambda2_expert_code_id_and_symbol_scoping_checks f =
+  "-no-flambda2-expert-code-id-and-symbol-scoping-checks", Arg.Unit f,
+    " Perform checks on static scopes of code IDs and symbols during Un_cps \
+      (Flambda 2 only)"
+;;
+
+let mk_flambda2_expert_fallback_inlining_heuristic f =
+  "-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
+    " Prevent inlining of functions whose bodies contain closures \
+      (Flambda 2 only)"
+;;
+
+let mk_no_flambda2_expert_fallback_inlining_heuristic f =
+  "-no-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
+    " Allow inlining of functions whose bodies contain closures (default) \
+      (Flambda 2 only)"
+;;
+
+let mk_flambda2_expert_inline_effects_in_cmm f =
+  "-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
+  " Allow inlining of effectful expressions in the produced cmm \
+    (Flambda 2 only)"
+;;
+
+let mk_no_flambda2_expert_inline_effects_in_cmm f =
+  "-no-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
+  " Prevent inlining of effectful expressions in the produced cmm (default) \
+    (Flambda 2 only)"
+;;
+
+let mk_flambda2_expert_phantom_lets f =
+  "-flambda2-expert-phantom-lets", Arg.Unit f,
+  " Generate phantom lets when -g is specified (Flambda 2 only)"
+;;
+
+let mk_no_flambda2_expert_phantom_lets f =
+  "-no-flambda2-expert-phantom-lets", Arg.Unit f,
+  " Do not generate phantom lets even when -g is specified (Flambda 2 only)"
+;;
+
+let mk_flambda2_expert_max_block_size_for_projections f =
+  "-flambda2-expert-max-block-size-for-projections", Arg.Int f,
+  " Do not simplify projections from blocks if the block size exceeds \
+    this value (Flambda 2 only)"
+;;
+
+let mk_flambda2_expert_max_unboxing_depth f =
+  "-flambda2-expert-max-unboxing-depth", Arg.Int f,
+  " Do not unbox types deeper that this value (Flambda 2 only)"
+;;
+
+let mk_flambda2_debug_permute_every_name f =
+  "-flambda2-debug-permute-every-name", Arg.Unit f,
+    " Permute every name to check permutation works (Flambda 2 only)"
+;;
+
+let mk_no_flambda2_debug_permute_every_name f =
+  "-no-flambda2-debug-permute-every-name", Arg.Unit f,
+    " Do not permute every name to check permutation works (Flambda 2 only)"
+;;
+
+let mk_flambda2_debug_concrete_types_only_on_canonicals f =
+  "-flambda2-debug-concrete-types-only-on-canonicals", Arg.Unit f,
+    " Check that concrete types are only assigned to canonical names \
+      (Flambda 2 only)"
+;;
+
+let mk_no_flambda2_debug_concrete_types_only_on_canonicals f =
+  "-no-flambda2-debug-concrete-types-only-on-canonicals", Arg.Unit f,
+    " Do not check that concrete types are only assigned to canonical names \
+      (Flambda 2 only)"
+;;
+
+let mk_flambda2_backend_cse_at_toplevel f =
+  "-flambda2-backend-cse-at-toplevel", Arg.Unit f,
+    " Apply the backend CSE pass to module initializers (Flambda 2 only)"
+;;
+
+let mk_no_flambda2_backend_cse_at_toplevel f =
+  "-no-flambda2-backend-cse-at-toplevel", Arg.Unit f,
+    " Do not apply the backend CSE pass to module initializers (Flambda 2 only)"
+;;
+
 module type Common_options = sig
   val _absname : unit -> unit
   val _alert : string -> unit
@@ -1125,6 +1241,28 @@ module type Optcommon_options = sig
   val _dlinear :  unit -> unit
   val _dinterval : unit -> unit
   val _dstartup :  unit -> unit
+
+  val _flambda2_join_points : unit -> unit
+  val _no_flambda2_join_points : unit -> unit
+  val _flambda2_unbox_along_intra_function_control_flow : unit -> unit
+  val _no_flambda2_unbox_along_intra_function_control_flow : unit -> unit
+  val _flambda2_backend_cse_at_toplevel : unit -> unit
+  val _no_flambda2_backend_cse_at_toplevel : unit -> unit
+  val _flambda2_cse_depth : int -> unit
+  val _flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
+  val _no_flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
+  val _flambda2_expert_fallback_inlining_heuristic : unit -> unit
+  val _no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
+  val _flambda2_expert_inline_effects_in_cmm : unit -> unit
+  val _no_flambda2_expert_inline_effects_in_cmm : unit -> unit
+  val _flambda2_expert_phantom_lets : unit -> unit
+  val _no_flambda2_expert_phantom_lets : unit -> unit
+  val _flambda2_expert_max_block_size_for_projections : int -> unit
+  val _flambda2_expert_max_unboxing_depth : int -> unit
+  val _flambda2_debug_permute_every_name : unit -> unit
+  val _no_flambda2_debug_permute_every_name : unit -> unit
+  val _flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
+  val _no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
 end;;
 
 module type Optcomp_options = sig
@@ -1459,6 +1597,45 @@ struct
     mk_where F._where;
     mk__ F.anonymous;
 
+    mk_flambda2_join_points F._flambda2_join_points;
+    mk_no_flambda2_join_points F._no_flambda2_join_points;
+    mk_flambda2_unbox_along_intra_function_control_flow
+      F._flambda2_unbox_along_intra_function_control_flow;
+    mk_no_flambda2_unbox_along_intra_function_control_flow
+      F._no_flambda2_unbox_along_intra_function_control_flow;
+    mk_flambda2_backend_cse_at_toplevel F._flambda2_backend_cse_at_toplevel;
+    mk_no_flambda2_backend_cse_at_toplevel
+      F._no_flambda2_backend_cse_at_toplevel;
+    mk_flambda2_cse_depth F._flambda2_cse_depth;
+    mk_flambda2_expert_code_id_and_symbol_scoping_checks
+      F._flambda2_expert_code_id_and_symbol_scoping_checks;
+    mk_no_flambda2_expert_code_id_and_symbol_scoping_checks
+      F._no_flambda2_expert_code_id_and_symbol_scoping_checks;
+    mk_flambda2_expert_fallback_inlining_heuristic
+      F._flambda2_expert_fallback_inlining_heuristic;
+    mk_no_flambda2_expert_fallback_inlining_heuristic
+      F._no_flambda2_expert_fallback_inlining_heuristic;
+    mk_flambda2_expert_inline_effects_in_cmm
+      F._flambda2_expert_inline_effects_in_cmm;
+    mk_no_flambda2_expert_inline_effects_in_cmm
+      F._no_flambda2_expert_inline_effects_in_cmm;
+    mk_flambda2_expert_phantom_lets
+      F._flambda2_expert_phantom_lets;
+    mk_no_flambda2_expert_phantom_lets
+      F._no_flambda2_expert_phantom_lets;
+    mk_flambda2_expert_max_block_size_for_projections
+      F._flambda2_expert_max_block_size_for_projections;
+    mk_flambda2_expert_max_unboxing_depth
+      F._flambda2_expert_max_unboxing_depth;
+    mk_flambda2_debug_permute_every_name
+      F._flambda2_debug_permute_every_name;
+    mk_no_flambda2_debug_permute_every_name
+      F._no_flambda2_debug_permute_every_name;
+    mk_flambda2_debug_concrete_types_only_on_canonicals
+      F._flambda2_debug_concrete_types_only_on_canonicals;
+    mk_no_flambda2_debug_concrete_types_only_on_canonicals
+      F._no_flambda2_debug_concrete_types_only_on_canonicals;
+
     mk_match_context_rows F._match_context_rows;
     mk_dno_unique_ids F._dno_unique_ids;
     mk_dunique_ids F._dunique_ids;
@@ -1575,6 +1752,45 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk__ F.anonymous;
     mk_color F._color;
     mk_error_style F._error_style;
+
+    mk_flambda2_join_points F._flambda2_join_points;
+    mk_no_flambda2_join_points F._no_flambda2_join_points;
+    mk_flambda2_unbox_along_intra_function_control_flow
+      F._flambda2_unbox_along_intra_function_control_flow;
+    mk_no_flambda2_unbox_along_intra_function_control_flow
+      F._no_flambda2_unbox_along_intra_function_control_flow;
+    mk_flambda2_backend_cse_at_toplevel F._flambda2_backend_cse_at_toplevel;
+    mk_no_flambda2_backend_cse_at_toplevel
+      F._no_flambda2_backend_cse_at_toplevel;
+    mk_flambda2_cse_depth F._flambda2_cse_depth;
+    mk_flambda2_expert_code_id_and_symbol_scoping_checks
+      F._flambda2_expert_code_id_and_symbol_scoping_checks;
+    mk_no_flambda2_expert_code_id_and_symbol_scoping_checks
+      F._no_flambda2_expert_code_id_and_symbol_scoping_checks;
+    mk_flambda2_expert_fallback_inlining_heuristic
+      F._flambda2_expert_fallback_inlining_heuristic;
+    mk_no_flambda2_expert_fallback_inlining_heuristic
+      F._no_flambda2_expert_fallback_inlining_heuristic;
+    mk_flambda2_expert_inline_effects_in_cmm
+      F._flambda2_expert_inline_effects_in_cmm;
+    mk_no_flambda2_expert_inline_effects_in_cmm
+      F._no_flambda2_expert_inline_effects_in_cmm;
+    mk_flambda2_expert_phantom_lets
+      F._flambda2_expert_phantom_lets;
+    mk_no_flambda2_expert_phantom_lets
+      F._no_flambda2_expert_phantom_lets;
+    mk_flambda2_expert_max_block_size_for_projections
+      F._flambda2_expert_max_block_size_for_projections;
+    mk_flambda2_expert_max_unboxing_depth
+      F._flambda2_expert_max_unboxing_depth;
+    mk_flambda2_debug_permute_every_name
+      F._flambda2_debug_permute_every_name;
+    mk_no_flambda2_debug_permute_every_name
+      F._no_flambda2_debug_permute_every_name;
+    mk_flambda2_debug_concrete_types_only_on_canonicals
+      F._flambda2_debug_concrete_types_only_on_canonicals;
+    mk_no_flambda2_debug_concrete_types_only_on_canonicals
+      F._no_flambda2_debug_concrete_types_only_on_canonicals;
 
     mk_dsource F._dsource;
     mk_dparsetree F._dparsetree;
@@ -1858,6 +2074,46 @@ module Default = struct
     let _unbox_closures = set unbox_closures
     let _unbox_closures_factor f = unbox_closures_factor := f
     let _verbose = set verbose
+
+    let _flambda2_join_points = set Flambda2.join_points
+    let _no_flambda2_join_points = clear Flambda2.join_points
+    let _flambda2_unbox_along_intra_function_control_flow =
+      set Flambda2.unbox_along_intra_function_control_flow
+    let _no_flambda2_unbox_along_intra_function_control_flow =
+      clear Flambda2.unbox_along_intra_function_control_flow
+    let _flambda2_backend_cse_at_toplevel =
+      set Flambda2.backend_cse_at_toplevel
+    let _no_flambda2_backend_cse_at_toplevel =
+      clear Flambda2.backend_cse_at_toplevel
+    let _flambda2_cse_depth n = Flambda2.cse_depth := n
+    let _flambda2_expert_code_id_and_symbol_scoping_checks =
+      set Flambda2.Expert.code_id_and_symbol_scoping_checks
+    let _no_flambda2_expert_code_id_and_symbol_scoping_checks =
+      clear Flambda2.Expert.code_id_and_symbol_scoping_checks
+    let _flambda2_expert_fallback_inlining_heuristic =
+      set Flambda2.Expert.fallback_inlining_heuristic
+    let _no_flambda2_expert_fallback_inlining_heuristic =
+      clear Flambda2.Expert.fallback_inlining_heuristic
+    let _flambda2_expert_inline_effects_in_cmm =
+      set Flambda2.Expert.inline_effects_in_cmm
+    let _no_flambda2_expert_inline_effects_in_cmm =
+      clear Flambda2.Expert.inline_effects_in_cmm
+    let _flambda2_expert_phantom_lets =
+      set Flambda2.Expert.phantom_lets
+    let _no_flambda2_expert_phantom_lets =
+      clear Flambda2.Expert.phantom_lets
+    let _flambda2_expert_max_block_size_for_projections size =
+      Flambda2.Expert.max_block_size_for_projections := Some size
+    let _flambda2_expert_max_unboxing_depth depth =
+      Flambda2.Expert.max_unboxing_depth := depth
+    let _flambda2_debug_permute_every_name =
+      set Flambda2.Debug.permute_every_name
+    let _no_flambda2_debug_permute_every_name =
+      clear Flambda2.Debug.permute_every_name
+    let _flambda2_debug_concrete_types_only_on_canonicals =
+      set Flambda2.Debug.concrete_types_only_on_canonicals
+    let _no_flambda2_debug_concrete_types_only_on_canonicals =
+      clear Flambda2.Debug.concrete_types_only_on_canonicals
   end
 
   module Compiler = struct

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -221,6 +221,28 @@ module type Optcommon_options = sig
   val _dlinear :  unit -> unit
   val _dinterval : unit -> unit
   val _dstartup :  unit -> unit
+
+  val _flambda2_join_points : unit -> unit
+  val _no_flambda2_join_points : unit -> unit
+  val _flambda2_unbox_along_intra_function_control_flow : unit -> unit
+  val _no_flambda2_unbox_along_intra_function_control_flow : unit -> unit
+  val _flambda2_backend_cse_at_toplevel : unit -> unit
+  val _no_flambda2_backend_cse_at_toplevel : unit -> unit
+  val _flambda2_cse_depth : int -> unit
+  val _flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
+  val _no_flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
+  val _flambda2_expert_fallback_inlining_heuristic : unit -> unit
+  val _no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
+  val _flambda2_expert_inline_effects_in_cmm : unit -> unit
+  val _no_flambda2_expert_inline_effects_in_cmm : unit -> unit
+  val _flambda2_expert_phantom_lets : unit -> unit
+  val _no_flambda2_expert_phantom_lets : unit -> unit
+  val _flambda2_expert_max_block_size_for_projections : int -> unit
+  val _flambda2_expert_max_unboxing_depth : int -> unit
+  val _flambda2_debug_permute_every_name : unit -> unit
+  val _no_flambda2_debug_permute_every_name : unit -> unit
+  val _flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
+  val _no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
 end;;
 
 module type Optcomp_options = sig

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -457,6 +457,55 @@ module Compiler_ir = struct
     end
 end
 
+module Flambda2 = struct
+  let join_points = ref true
+  let unbox_along_intra_function_control_flow = ref true
+  let backend_cse_at_toplevel = ref false
+  let cse_depth = ref 2
+
+  module Expert = struct
+    let code_id_and_symbol_scoping_checks = ref false
+    let fallback_inlining_heuristic = ref false
+    let inline_effects_in_cmm = ref false
+    let phantom_lets = ref true
+    let max_block_size_for_projections = ref None
+    let max_unboxing_depth = ref 3
+  end
+
+  module Debug = struct
+    let permute_every_name = ref false
+    let concrete_types_only_on_canonicals = ref false
+  end
+
+  let oclassic_flags () =
+    cse_depth := 2;
+    join_points := false;
+    unbox_along_intra_function_control_flow := true;
+    Expert.fallback_inlining_heuristic := true;
+    backend_cse_at_toplevel := false
+
+  let o1_flags () =
+    cse_depth := 2;
+    join_points := true;
+    unbox_along_intra_function_control_flow := true;
+    Expert.fallback_inlining_heuristic := false;
+    backend_cse_at_toplevel := false
+
+  let o2_flags () =
+    cse_depth := 2;
+    join_points := true;
+    unbox_along_intra_function_control_flow := true;
+    Expert.fallback_inlining_heuristic := false;
+    backend_cse_at_toplevel := false
+
+  let o3_flags () =
+    cse_depth := 2;
+    join_points := true;
+    unbox_along_intra_function_control_flow := true;
+    Expert.fallback_inlining_heuristic := false;
+    backend_cse_at_toplevel := false
+end
+
 (* This is used by the -stop-after option. *)
 module Compiler_pass = struct
   (* If you add a new pass, the following must be updated:

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -458,23 +458,48 @@ module Compiler_ir = struct
 end
 
 module Flambda2 = struct
-  let join_points = ref true
-  let unbox_along_intra_function_control_flow = ref true
-  let backend_cse_at_toplevel = ref false
-  let cse_depth = ref 2
+  module Default = struct
+    let join_points = true
+    let unbox_along_intra_function_control_flow = true
+    let backend_cse_at_toplevel = false
+    let cse_depth = 2
+  end
+
+  let join_points = ref Default.join_points
+  let unbox_along_intra_function_control_flow =
+    ref Default.unbox_along_intra_function_control_flow
+  let backend_cse_at_toplevel = ref Default.backend_cse_at_toplevel
+  let cse_depth = ref Default.cse_depth
 
   module Expert = struct
-    let code_id_and_symbol_scoping_checks = ref false
-    let fallback_inlining_heuristic = ref false
-    let inline_effects_in_cmm = ref false
-    let phantom_lets = ref true
-    let max_block_size_for_projections = ref None
-    let max_unboxing_depth = ref 3
+    module Default = struct
+      let code_id_and_symbol_scoping_checks = false
+      let fallback_inlining_heuristic = false
+      let inline_effects_in_cmm = false
+      let phantom_lets = true
+      let max_block_size_for_projections = None
+      let max_unboxing_depth = 3
+    end
+
+    let code_id_and_symbol_scoping_checks =
+      ref Default.code_id_and_symbol_scoping_checks
+    let fallback_inlining_heuristic = ref Default.fallback_inlining_heuristic
+    let inline_effects_in_cmm = ref Default.inline_effects_in_cmm
+    let phantom_lets = ref Default.phantom_lets
+    let max_block_size_for_projections =
+      ref Default.max_block_size_for_projections
+    let max_unboxing_depth = ref Default.max_unboxing_depth
   end
 
   module Debug = struct
-    let permute_every_name = ref false
-    let concrete_types_only_on_canonicals = ref false
+    module Default = struct
+      let permute_every_name = false
+      let concrete_types_only_on_canonicals = false
+    end
+
+    let permute_every_name = ref Default.permute_every_name
+    let concrete_types_only_on_canonicals =
+      ref Default.concrete_types_only_on_canonicals
   end
 
   let oclassic_flags () =

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -238,12 +238,28 @@ val insn_sched : bool ref
 val insn_sched_default : bool
 
 module Flambda2 : sig
+  module Default : sig
+    val join_points : bool
+    val unbox_along_intra_function_control_flow : bool
+    val backend_cse_at_toplevel : bool
+    val cse_depth : int
+  end
+
   val join_points : bool ref
   val unbox_along_intra_function_control_flow : bool ref
   val backend_cse_at_toplevel : bool ref
   val cse_depth : int ref
 
   module Expert : sig
+    module Default : sig
+      val code_id_and_symbol_scoping_checks : bool
+      val fallback_inlining_heuristic : bool
+      val inline_effects_in_cmm : bool
+      val phantom_lets : bool
+      val max_block_size_for_projections : int option
+      val max_unboxing_depth : int
+    end
+
     val code_id_and_symbol_scoping_checks : bool ref
     val fallback_inlining_heuristic : bool ref
     val inline_effects_in_cmm : bool ref
@@ -253,6 +269,11 @@ module Flambda2 : sig
   end
 
   module Debug : sig
+    module Default : sig
+      val permute_every_name : bool
+      val concrete_types_only_on_canonicals : bool
+    end
+
     val permute_every_name : bool ref
     val concrete_types_only_on_canonicals : bool ref
   end

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -237,6 +237,32 @@ val unboxed_types : bool ref
 val insn_sched : bool ref
 val insn_sched_default : bool
 
+module Flambda2 : sig
+  val join_points : bool ref
+  val unbox_along_intra_function_control_flow : bool ref
+  val backend_cse_at_toplevel : bool ref
+  val cse_depth : int ref
+
+  module Expert : sig
+    val code_id_and_symbol_scoping_checks : bool ref
+    val fallback_inlining_heuristic : bool ref
+    val inline_effects_in_cmm : bool ref
+    val phantom_lets : bool ref
+    val max_block_size_for_projections : int option ref
+    val max_unboxing_depth : int ref
+  end
+
+  module Debug : sig
+    val permute_every_name : bool ref
+    val concrete_types_only_on_canonicals : bool ref
+  end
+
+  val oclassic_flags : unit -> unit
+  val o1_flags : unit -> unit
+  val o2_flags : unit -> unit
+  val o3_flags : unit -> unit
+end
+
 module Compiler_pass : sig
   type t = Parsing | Typing | Scheduling | Emit
   val of_string : string -> t option


### PR DESCRIPTION
This wires through some of the command-line flags for Flambda 2.  It only deals with the ones that, in the old Flambda 2 dev branch, were in the `Clflags.Flambda` submodule (now called `Clflags.Flambda2`).

In due course we should try to refactor the driver so that the middle ends can add their own command-line flags, rather than having to touch the upstream subtree as here.