### PR TITLE
Add config variables flambda_backend, flambda2 and probes

### DIFF
--- a/ocaml/utils/config.mli
+++ b/ocaml/utils/config.mli
@@ -200,6 +200,10 @@ val flambda : bool
 val flambda2 : bool
 (** Whether the compiler was configured for Flambda 2 *)
 
+val flambda_backend : bool
+(** [true] if the compiler was built in a Flambda backend repo, [false] if
+    the compiler was built as per upstream. *)
+
 val with_flambda_invariants : bool
 (** Whether the invariants checks for flambda are enabled *)
 

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -215,7 +215,7 @@ let configuration_variables =
   p "linear_magic_number" linear_magic_number;
 
   p_bool "flambda_backend" true;
-  p_bool "probes" true;
+  p_bool "probes" probes;
 ]
 
 let print_config_value oc = function

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -193,6 +193,7 @@ let configuration_variables =
   p "host" host;
   p "target" target;
   p_bool "flambda" flambda;
+  p_bool "flambda2" flambda2;
   p_bool "safe_string" safe_string;
   p_bool "default_safe_string" default_safe_string;
   p_bool "flat_float_array" flat_float_array;
@@ -214,6 +215,7 @@ let configuration_variables =
   p "linear_magic_number" linear_magic_number;
 
   p_bool "flambda_backend" true;
+  p_bool "probes" true;
 ]
 
 let print_config_value oc = function

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -76,6 +76,9 @@ let mkdll, mkexe, mkmaindll =
 let flambda = %%FLAMBDA%%
 let flambda2 = %%FLAMBDA2%%
 let with_flambda_invariants = %%WITH_FLAMBDA_INVARIANTS%%
+
+let flambda_backend = true
+
 let safe_string = %%FORCE_SAFE_STRING%%
 let default_safe_string = %%DEFAULT_SAFE_STRING%%
 let windows_unicode = %%WINDOWS_UNICODE%% != 0

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -217,7 +217,7 @@ let configuration_variables =
   p "cmt_magic_number" cmt_magic_number;
   p "linear_magic_number" linear_magic_number;
 
-  p_bool "flambda_backend" true;
+  p_bool "flambda_backend" flambda_backend;
   p_bool "probes" probes;
 ]
 

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -212,6 +212,8 @@ let configuration_variables =
   p "cmxs_magic_number" cmxs_magic_number;
   p "cmt_magic_number" cmt_magic_number;
   p "linear_magic_number" linear_magic_number;
+
+  p_bool "flambda_backend" true;
 ]
 
 let print_config_value oc = function


### PR DESCRIPTION
One of the Flambda 2 patches redefines `fst` and `snd` to use "immutable field reading" primitives rather than the mutable versions.  Unfortunately these primitives are named directly in the `Stdlib` interfaces and replicated in `Core`.  This means that the change breaks `Core`.  The current plan is to conditionalise `Core` as to whether we are compiling against the flambda-backend.  @xclerc Does this look right to you?  (The variable is deliberately not exposed in `config.mli`.)