### PR TITLE
Fix Flambda_features.flambda2_is_enabled

### DIFF
--- a/middle_end/flambda2/compilenv_deps/flambda_features.ml
+++ b/middle_end/flambda2/compilenv_deps/flambda_features.ml
@@ -14,7 +14,7 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-let flambda2_is_enabled () = Config.flambda
+let flambda2_is_enabled () = Clflags.is_flambda2 ()
 
 (* CR mshinwell: wire this in *)
 


### PR DESCRIPTION
This was testing the wrong variable.  (In the Flambda 2 dev branch, `Config.flambda` meant Flambda 2.)