### PR TITLE
-Oclassic, -O2 and -O3 handling for Flambda 2

### DIFF
--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -32,12 +32,6 @@ let (|>>) (x, y) f = (x, f y)
 (** Native compilation backend for .ml files. *)
 
 let flambda i backend typed =
-  if !Clflags.classic_inlining then begin
-    Clflags.default_simplify_rounds := 1;
-    Clflags.use_inlining_arguments_set Clflags.classic_arguments;
-    Clflags.unbox_free_vars_of_closures := false;
-    Clflags.unbox_specialised_args := false
-  end;
   typed
   |> Profile.(record transl)
       (Translmod.transl_implementation_flambda i.module_name)
@@ -67,7 +61,7 @@ let flambda i backend typed =
     Compilenv.save_unit_info (cmx i))
 
 let clambda i backend typed =
-  Clflags.use_inlining_arguments_set Clflags.classic_arguments;
+  Clflags.set_oclassic ();
   typed
   |> Profile.(record transl)
     (Translmod.transl_store_implementation i.module_name)

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -337,23 +337,9 @@ let read_one_param ppf position name v =
     Int_arg_helper.parse v
       "Bad syntax in OCAMLPARAM for 'inline-max-depth'"
       inline_max_depth
-
-  | "Oclassic" ->
-      set "Oclassic" [ classic_inlining ] v
-  | "O2" ->
-    if check_bool ppf "O2" v then begin
-      default_simplify_rounds := 2;
-      use_inlining_arguments_set o2_arguments;
-      use_inlining_arguments_set ~round:0 o1_arguments
-    end
-
-  | "O3" ->
-    if check_bool ppf "O3" v then begin
-      default_simplify_rounds := 3;
-      use_inlining_arguments_set o3_arguments;
-      use_inlining_arguments_set ~round:1 o2_arguments;
-      use_inlining_arguments_set ~round:0 o1_arguments
-    end
+  | "Oclassic" -> if check_bool ppf "Oclassic" v then Clflags.set_oclassic ()
+  | "O2" -> if check_bool ppf "O2" v then Clflags.set_o2 ()
+  | "O3" -> if check_bool ppf "O3" v then Clflags.set_o3 ()
   | "unbox-closures" ->
       set "unbox-closures" [ unbox_closures ] v
   | "unbox-closures-factor" ->

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -2214,7 +2214,7 @@ module Default = struct
   module Native = struct
     let _S = set keep_asm_file
     let _clambda_checks () = clambda_checks := true
-    let _classic_inlining () = classic_inlining := true
+    let _classic_inlining () = set_oclassic ()
     let _compact = clear optimize_for_speed
     let _dalloc = set dump_regalloc
     let _davail () = dump_avail := true
@@ -2300,15 +2300,8 @@ module Default = struct
        collected, then checked all at once for illegal combinations, and then
        transformed into the settings of the individual parameters.
     *)
-    let _o2 () =
-      default_simplify_rounds := 2;
-      use_inlining_arguments_set o2_arguments;
-      use_inlining_arguments_set ~round:0 o1_arguments
-    let _o3 () =
-      default_simplify_rounds := 3;
-      use_inlining_arguments_set o3_arguments;
-      use_inlining_arguments_set ~round:1 o2_arguments;
-      use_inlining_arguments_set ~round:0 o1_arguments
+    let _o2 () = Clflags.set_o2 ()
+    let _o3 () = Clflags.set_o3 ()
     let _remove_unused_arguments = set remove_unused_arguments
     let _rounds n = simplify_rounds := (Some n)
     let _unbox_closures = set unbox_closures

--- a/ocaml/driver/optcompile.ml
+++ b/ocaml/driver/optcompile.ml
@@ -32,12 +32,6 @@ let (|>>) (x, y) f = (x, f y)
 (** Native compilation backend for .ml files. *)
 
 let flambda i backend typed =
-  if !Clflags.classic_inlining then begin
-    Clflags.default_simplify_rounds := 1;
-    Clflags.use_inlining_arguments_set Clflags.classic_arguments;
-    Clflags.unbox_free_vars_of_closures := false;
-    Clflags.unbox_specialised_args := false
-  end;
   typed
   |> Profile.(record transl)
       (Translmod.transl_implementation_flambda i.module_name)
@@ -67,7 +61,7 @@ let flambda i backend typed =
     Compilenv.save_unit_info (cmx i))
 
 let clambda i backend typed =
-  Clflags.use_inlining_arguments_set Clflags.classic_arguments;
+  Clflags.set_oclassic ();
   typed
   |> Profile.(record transl)
     (Translmod.transl_store_implementation i.module_name)

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -337,7 +337,7 @@ let clflags_attribute_with_int_payload attr ~name clflags_ref =
     | Some i -> clflags_ref := i
     | None -> ()
   end
-  
+
 let nolabels_attribute attr =
   clflags_attribute_without_payload attr
     ~name:"nolabels" Clflags.classic
@@ -345,10 +345,7 @@ let nolabels_attribute attr =
 let flambda_o3_attribute attr =
   clflags_attribute_without_payload' attr
     ~name:"flambda_o3"
-    ~f:(fun () ->
-      if Config.flambda then begin
-        Clflags.use_inlining_arguments_set Clflags.o3_arguments
-      end)
+    ~f:(fun () -> if Config.flambda then Clflags.set_o3 ())
 
 let inline_attribute attr =
   if String.equal attr.attr_name.txt "inline"
@@ -367,7 +364,7 @@ let inline_attribute attr =
         Clflags.Float_arg_helper.parse s err_msg Clflags.inline_threshold
       | None -> warn_payload attr.attr_loc attr.attr_name.txt err_msg
   end
-  
+
 let afl_inst_ratio_attribute attr =
   clflags_attribute_with_int_payload attr
     ~name:"afl_inst_ratio" Clflags.afl_inst_ratio

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -43,29 +43,6 @@ module Float_arg_helper : sig
   val get : key:int -> parsed -> float
 end
 
-type inlining_arguments = {
-  inline_call_cost : int option;
-  inline_alloc_cost : int option;
-  inline_prim_cost : int option;
-  inline_branch_cost : int option;
-  inline_indirect_cost : int option;
-  inline_lifting_benefit : int option;
-  inline_branch_factor : float option;
-  inline_max_depth : int option;
-  inline_max_unroll : int option;
-  inline_threshold : float option;
-  inline_toplevel_threshold : int option;
-}
-
-val classic_arguments : inlining_arguments
-val o1_arguments : inlining_arguments
-val o2_arguments : inlining_arguments
-val o3_arguments : inlining_arguments
-
-(** Set all the inlining arguments for a round.
-    The default is set if no round is provided. *)
-val use_inlining_arguments_set : ?round:int -> inlining_arguments -> unit
-
 val objfiles : string list ref
 val ccobjs : string list ref
 val dllibs : string list ref
@@ -324,12 +301,11 @@ module Flambda2 : sig
 
     val report_bin : bool ref
   end
-
-  val oclassic_flags : unit -> unit
-  val o1_flags : unit -> unit
-  val o2_flags : unit -> unit
-  val o3_flags : unit -> unit
 end
+
+val set_oclassic : unit -> unit
+val set_o2 : unit -> unit
+val set_o3 : unit -> unit
 
 module Compiler_pass : sig
   type t = Parsing | Typing | Scheduling | Emit


### PR DESCRIPTION
This should hopefully cause `-Oclassic`, `-O2` and `-O3` to operate correctly in all three modes (Closure, Flambda 1, Flambda 2).  There is no `-O1` currently exposed to the user at the command line, just like before.