### PR TITLE
Asmpackager for Flambda 2

### DIFF
--- a/backend/asmpackager.mli
+++ b/backend/asmpackager.mli
@@ -22,6 +22,10 @@ val package_files
   -> string list
   -> string
   -> backend:(module Backend_intf.S)
+  -> flambda2_backend:(module Flambda2__Flambda_backend_intf.S)
+  -> flambda2_to_cmm:(
+        Flambda2__Flambda_middle_end.middle_end_result
+     -> Cmm.phrase list)
   -> unit
 
 type error =

--- a/driver/dune
+++ b/driver/dune
@@ -3,5 +3,6 @@
   (modes byte native)
   (flags (:standard -principal -nostdlib))
   (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
-  (libraries stdlib ocamloptcomp)
+  (libraries stdlib ocamloptcomp flambda2_to_cmm flambda2_backend_impl
+    flambda2)
   (modules optcompile))

--- a/driver/flambda_backend_main.ml
+++ b/driver/flambda_backend_main.ml
@@ -1,5 +1,9 @@
+let flambda2_backend =
+  (module Flambda2_backend_impl : Flambda2__Flambda_backend_intf.S)
+
 let () =
   (match Sys.backend_type with
    | Native -> Memtrace.trace_if_requested ~context:"ocamlopt" ()
    | Bytecode | Other _ -> ());
-  exit (Optmaindriver.main Sys.argv Format.err_formatter)
+  exit (Optmaindriver.main Sys.argv Format.err_formatter
+    ~flambda2_backend ~flambda2_to_cmm:Flambda2_to_cmm.Un_cps.unit)

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -31,12 +31,14 @@ module Backend = struct
     (* The "-1" is to allow for a potential closure environment parameter. *)
     Proc.max_arguments_for_tailcalls - 1
 end
+
 let backend = (module Backend : Backend_intf.S)
 
 let usage = "Usage: ocamlopt <options> <files>\nOptions are:"
 
 module Options = Main_args.Make_optcomp_options (Main_args.Default.Optmain)
-let main argv ppf =
+
+let main argv ppf ~flambda2_backend ~flambda2_to_cmm =
   native_code := true;
   match
     Compenv.readenv ppf Before_args;
@@ -95,7 +97,8 @@ let main argv ppf =
       let target = Compenv.extract_output !output_name in
       Compmisc.with_ppf_dump ~file_prefix:target (fun ppf_dump ->
         Asmpackager.package_files ~ppf_dump (Compmisc.initial_env ())
-          (Compenv.get_objfiles ~with_ocamlparam:false) target ~backend);
+          (Compenv.get_objfiles ~with_ocamlparam:false) target ~backend
+          ~flambda2_backend ~flambda2_to_cmm);
       Warnings.check_fatal ();
     end
     else if !shared then begin

--- a/driver/optmaindriver.mli
+++ b/driver/optmaindriver.mli
@@ -18,4 +18,11 @@
 
    NB: Due to internal state in the compiler, calling [main] twice during
    the same process is unsupported. *)
-val main : string array -> Format.formatter -> int
+val main
+   : string array
+  -> Format.formatter
+  -> flambda2_backend:(module Flambda2__Flambda_backend_intf.S)
+  -> flambda2_to_cmm:(
+        Flambda2__Flambda_middle_end.middle_end_result
+     -> Cmm.phrase list)
+  -> int

--- a/dune
+++ b/dune
@@ -121,7 +121,7 @@
    memtrace
    flambda2
    flambda2_to_cmm
-   flambda2_backend_intf
+   flambda2_backend_impl
    ocamloptcomp
    ocamlcommon
    stdlib)
@@ -140,7 +140,7 @@
    memtrace
    flambda2
    flambda2_to_cmm
-   flambda2_backend_intf
+   flambda2_backend_impl
    ocamloptcomp
    ocamlcommon
    stdlib

--- a/middle_end/flambda2/backend_intf/dune
+++ b/middle_end/flambda2/backend_intf/dune
@@ -1,9 +1,9 @@
 (include_subdirs no)
 
 (library
-  (name flambda2_backend_intf)
+  (name flambda2_backend_impl)
   (wrapped false)
   (flags (:standard -principal -nostdlib -open Flambda2))
   (libraries stdlib ocamlcommon ocamlbytecomp ocamloptcomp
-             flambda2_compilenv_deps flambda2)
+    flambda2_compilenv_deps flambda2)
 )


### PR DESCRIPTION
This makes the necessary changes to `Asmpackager` for Flambda 2.  To avoid circular dependencies, the Flambda 2 middle end and Flambda 2 to Cmm translation aren't referenced until right at the top, in `Flambda_backend_main`.

This PR also fixes the misnaming of the `Flambda_backend_impl` library (although this still doesn't solve the problem of needing to use the mangled names).