### PR TITLE
Add /testsuite/tools/Makefile and allow to use Flambda 2 libs (and fix .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,14 +46,14 @@ _runtest/
 _stage2_configure/
 autom4te.cache
 
-Makefile
-config.log
-config.status
-configure
-configure_opts
-ocaml-stage1-config.status
-ocaml-stage2-config.status
-ocamlopt_flags.sexp
-oc_cflags.sexp
-oc_cppflags.sexp
-sharedlib_cflags.sexp
+/Makefile
+/config.log
+/config.status
+/configure
+/configure_opts
+/ocaml-stage1-config.status
+/ocaml-stage2-config.status
+/ocamlopt_flags.sexp
+/oc_cflags.sexp
+/oc_cppflags.sexp
+/sharedlib_cflags.sexp

--- a/Makefile.in
+++ b/Makefile.in
@@ -232,8 +232,6 @@ runtest-upstream:
 	# replace backend-specific testsuite/tools with their new versions
 	rm _runtest/testsuite/tools/*
 	cp -a testsuite/tools/* _runtest/testsuite/tools/
-	(cd _runtest/testsuite/tools && \
-	  	ln -s ../../../ocaml/testsuite/tools/Makefile Makefile)
 	(cd _runtest && ln -s ../ocaml/Makefile.tools Makefile.tools)
 	(cd _runtest && ln -s ../ocaml/Makefile.build_config Makefile.build_config)
 	(cd _runtest && ln -s ../ocaml/Makefile.config_if_required Makefile.config_if_required)

--- a/Makefile.in
+++ b/Makefile.in
@@ -255,6 +255,12 @@ runtest-upstream:
 	  _runtest/compilerlibs
 	cp _build2/install/default/lib/ocaml/compiler-libs/*.cmxa \
 	  _runtest/compilerlibs
+	cp _build2/default/middle_end/flambda2/compilenv_deps/flambda2_compilenv_deps.cma \
+	  _runtest/compilerlibs
+	cp _build2/default/middle_end/flambda2/flambda2.cma \
+	  _runtest/compilerlibs
+	cp _build2/default/middle_end/flambda2/backend_intf/flambda2_backend_intf.cma \
+	  _runtest/compilerlibs
 	mkdir _runtest/toplevel
 	cp _build2/default/ocaml/toplevel/.ocamltoplevel.objs/byte/*.cm* \
 	  _runtest/toplevel/

--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -35,7 +35,7 @@ codegen_DIRS = parsing utils typing middle_end bytecomp lambda asmcomp
 codegen_OCAMLFLAGS = $(addprefix -I $(TOPDIR)/, $(codegen_DIRS)) -w +40 -g
 
 codegen_LIBS = $(addprefix $(COMPILERLIBSDIR)/,\
-  ocamlcommon ocamloptcomp)
+  ocamlcommon flambda2_compilenv_deps flambda2_backend_intf flambda2 ocamloptcomp)
 
 codegen_OBJECTS = $(addsuffix .cmo,\
   parsecmmaux parsecmm lexcmm codegen_main)

--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -1,0 +1,100 @@
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                 Jeremie Dimino, Jane Street Europe                     *
+#*                                                                        *
+#*   Copyright 2016 Jane Street Group LLC                                 *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+.NOTPARALLEL:
+
+TOPDIR = ../..
+
+COMPILERLIBSDIR = $(TOPDIR)/compilerlibs
+
+RUNTIME_VARIANT ?=
+ASPPFLAGS ?=
+
+include $(TOPDIR)/Makefile.tools
+
+expect_MAIN=expect_test
+expect_PROG=$(expect_MAIN)$(EXE)
+expect_DIRS = parsing utils driver typing toplevel
+expect_OCAMLFLAGS = $(addprefix -I $(TOPDIR)/,$(expect_DIRS))
+expect_LIBS := $(addprefix $(COMPILERLIBSDIR)/,\
+  ocamlcommon ocamlbytecomp ocamltoplevel)
+
+codegen_PROG = codegen$(EXE)
+codegen_DIRS = parsing utils typing middle_end bytecomp lambda asmcomp
+codegen_OCAMLFLAGS = $(addprefix -I $(TOPDIR)/, $(codegen_DIRS)) -w +40 -g
+
+codegen_LIBS = $(addprefix $(COMPILERLIBSDIR)/,\
+  ocamlcommon ocamloptcomp)
+
+codegen_OBJECTS = $(addsuffix .cmo,\
+  parsecmmaux parsecmm lexcmm codegen_main)
+
+tools := $(expect_PROG)
+
+ifeq "$(NATIVE_COMPILER)" "true"
+tools += $(codegen_PROG)
+ifneq "$(CCOMPTYPE)-$(ARCH)" "msvc-amd64"
+# The asmgen tests are not ported to MSVC64 yet
+# so do not compile any arch-specific module
+tools += asmgen_$(ARCH).$(O)
+endif
+endif
+
+all: $(tools)
+
+$(expect_PROG): $(expect_LIBS:=.cma) $(expect_MAIN).cmo
+	$(OCAMLC) -linkall -o $@ $^
+
+$(expect_PROG): COMPFLAGS = $(expect_OCAMLFLAGS)
+
+$(codegen_PROG): COMPFLAGS = $(codegen_OCAMLFLAGS)
+
+codegen_main.cmo: parsecmm.cmo
+
+$(codegen_PROG): $(codegen_OBJECTS)
+	$(OCAMLC) -o $@ $(codegen_LIBS:=.cma) $^
+
+parsecmm.mli parsecmm.ml: parsecmm.mly
+	$(OCAMLYACC) -q parsecmm.mly
+
+lexcmm.ml: lexcmm.mll
+	$(OCAMLLEX) -q lexcmm.mll
+
+parsecmmaux.cmo: parsecmmaux.cmi
+
+lexcmm.cmo: lexcmm.cmi
+
+parsecmm.cmo: parsecmm.cmi
+
+asmgen_i386.obj: asmgen_i386nt.asm
+	@set -o pipefail ; \
+	$(ASM) $@ $^ | tail -n +2
+
+%.cmi: %.mli
+	$(OCAMLC) -c $<
+
+%.cmo: %.ml
+	$(OCAMLC) -c $<
+
+%.cmx: %.ml
+	$(OCAMLOPT) -c $<
+
+%.$(O): %.S
+	$(ASPP) $(ASPPFLAGS) -DSYS_$(SYSTEM) -DMODEL_$(MODEL) -o $@ $<
+
+.PHONY: clean
+clean:
+	rm -f *.cm* *.o *.obj
+	rm -f expect_test expect_test.exe codegen codegen.exe
+	rm -f parsecmm.ml parsecmm.mli lexcmm.ml


### PR DESCRIPTION
This adds a local copy of the `Makefile` for the upstream testsuite's `tools` directory, which we currently have a partial copy of at the root.  Then the Flambda 2 libraries are added to the linker invocations for these tools.  Without this, `Compilenv` will fail to link, after PR#108.

During development of this patch it was noticed that `.gitignore` is incorrectly matching files in subdirectories for certain patterns, which is fixed here, enabling the new `Makefile` to be added to git.