### PR TITLE
Use Closure for stage 0 coldstart build in Flambda 2 mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ autom4te.cache
 /config.status
 /configure
 /configure_opts
+/configure_opts_stage0
 /ocaml-stage1-config.status
 /ocaml-stage2-config.status
 /ocamlopt_flags.sexp

--- a/Makefile.in
+++ b/Makefile.in
@@ -49,7 +49,7 @@ stage0: _build0/config.status
 # done "make ocamlopt" upstream.  For testing with a broken middle or backend,
 # e.g. if the stdlib doesn't compile, you can stop here and run
 # _build1/default/flambda_backend_main.exe.
-# 
+#
 # At this point we don't yet have a standard library and a set of otherlibs
 # whose .cmx files are compatible with this new compiler.  Neither are the
 # Flambda backend compiler, or the compilerlibs that form it, built with the
@@ -97,13 +97,14 @@ hacking: ocaml-stage1-config.status stage0 \
 # The stage0 configure step configures the tree to build pretty much the
 # bare minimum that we need for building stage1.
 # Currently the middle end for stage0 will match the selected middle end
-# for the Flambda backend compiler.
+# for the Flambda backend compiler, except when using Flambda 2, when it
+# will be Closure (see configure.ac).
 _build0/config.status: ocaml/configure.ac
 	rm -rf _build0
 	mkdir _build0
 	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build0
 	(cd _build0 && \
-	  cat ../configure_opts | xargs -0 ./configure -C \
+	  cat ../configure_opts_stage0 | xargs -0 ./configure -C \
 	    --prefix=@stage0_prefix@ \
 	    --disable-ocamldoc \
 	    --disable-ocamltest \

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,11 @@ eval 'for option in '$ac_configure_args'; do echo $option; done' \
 # example).
 cat $temp | tr '\n' '\0' > configure_opts
 
+# For stage0 when Flambda 2 is enabled, the stage0 compiler is
+# configured in Closure mode.
+# We use "." instead of "\x00" since the latter may not work on non-GNU sed.
+cat configure_opts | sed 's/^--enable-flambda2.//g' > configure_opts_stage0
+
 rm -f $temp
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
Normally, the middle end used for stage 0 (the coldstart using `make` from the upstream subtree) is the same as the middle end in the final Flambda backend compilers.

However, with Flambda 2, this can't be the case since Flambda 2 doesn't exist in the upstream subtree.  Instead we use Closure.