### PR TITLE
Extend conditions to include flambda2

### DIFF
--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -23,7 +23,7 @@ let is_inline_attribute = function
 
 let is_inlined_attribute = function
   | {txt=("inlined"|"ocaml.inlined")} -> true
-  | {txt=("unrolled"|"ocaml.unrolled")} when Config.flambda -> true
+  | {txt=("unrolled"|"ocaml.unrolled")} when Config.flambda || Config.flambda2 -> true
   | _ -> false
 
 let is_specialise_attribute = function

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -667,7 +667,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           ap_probe = Some {name};
         }
       in
-      begin match Config.flambda with
+      begin match Config.flambda || Config.flambda2 with
       | true ->
           Llet(Strict, Pgenval, funcid, Lfunction handler, Lapply app)
       | false ->

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -345,7 +345,7 @@ let nolabels_attribute attr =
 let flambda_o3_attribute attr =
   clflags_attribute_without_payload' attr
     ~name:"flambda_o3"
-    ~f:(fun () -> if Config.flambda then Clflags.set_o3 ())
+    ~f:(fun () -> if Config.flambda || Config.flambda2 then Clflags.set_o3 ())
 
 let inline_attribute attr =
   if String.equal attr.attr_name.txt "inline"

--- a/ocaml/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
+++ b/ocaml/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
@@ -176,6 +176,7 @@ let () =
   check_noalloc "unbox only if useful" unbox_only_if_useful;
   check_noalloc "ignore useless args" ignore_useless_args;
 
+  (* CR xclerc for lukemaurer: enable these test for both flambda 1 and 2. *)
   if Config.flambda then begin
     check_noalloc "float and int32 record" unbox_record;
     check_noalloc "eliminate intermediate immutable float record"


### PR DESCRIPTION
Follow-up to https://github.com/ocaml-flambda/flambda-backend/pull/112, extending some conditions to include flambda2.

Other occurrences to consider:
- `ocaml/lambda/translattribute.ml`: [`@unrolled`](https://github.com/ocaml-flambda/flambda-backend/blob/main/ocaml/lambda/translattribute.ml#L26), [`@specialise`](https://github.com/ocaml-flambda/flambda-backend/blob/main/ocaml/lambda/translattribute.ml#L30), [`@specialised`](https://github.com/ocaml-flambda/flambda-backend/blob/main/ocaml/lambda/translattribute.ml#L34);
- `ocaml/testsuite/tests/float-unboxing/float_subst_boxed_number.ml`: [enable unboxing test](https://github.com/ocaml-flambda/flambda-backend/blob/main/ocaml/testsuite/tests/float-unboxing/float_subst_boxed_number.ml#L179).