### PR TITLE
Magic numbers for cmx and cmxa files

### DIFF
--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -96,15 +96,15 @@ and cmi_magic_number = "Caml1999I029"
 and cmo_magic_number = "Caml1999O029"
 and cma_magic_number = "Caml1999A029"
 and cmx_magic_number =
-  if flambda then
-    "Caml1999y029"
+  if flambda || flambda2 then
+    "Caml2021y029"
   else
-    "Caml1999Y029"
+    "Caml2021Y029"
 and cmxa_magic_number =
-  if flambda then
-    "Caml1999z029"
+  if flambda || flambda2 then
+    "Caml2021z029"
   else
-    "Caml1999Z029"
+    "Caml2021Z029"
 and ast_impl_magic_number = "Caml1999M029"
 and ast_intf_magic_number = "Caml1999N029"
 and cmxs_magic_number = "Caml1999D029"

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -981,10 +981,10 @@ module Magic_number = struct
     | "Caml1999I" -> Some Cmi
     | "Caml1999O" -> Some Cmo
     | "Caml1999A" -> Some Cma
-    | "Caml1999y" -> Some (Cmx {flambda = true})
-    | "Caml1999Y" -> Some (Cmx {flambda = false})
-    | "Caml1999z" -> Some (Cmxa {flambda = true})
-    | "Caml1999Z" -> Some (Cmxa {flambda = false})
+    | "Caml2021y" -> Some (Cmx {flambda = true})
+    | "Caml2021Y" -> Some (Cmx {flambda = false})
+    | "Caml2021z" -> Some (Cmxa {flambda = true})
+    | "Caml2021Z" -> Some (Cmxa {flambda = false})
 
     (* Caml2007D and Caml2012T were used instead of the common Caml1999 prefix
        between the introduction of those magic numbers and October 2017

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -1009,12 +1009,12 @@ module Magic_number = struct
     | Cma -> "Caml1999A"
     | Cmx config ->
        if config.flambda
-       then "Caml1999y"
-       else "Caml1999Y"
+       then "Caml2021y"
+       else "Caml2021Y"
     | Cmxa config ->
        if config.flambda
-       then "Caml1999z"
-       else "Caml1999Z"
+       then "Caml2021z"
+       else "Caml2021Z"
     | Cmxs -> "Caml1999D"
     | Cmt -> "Caml1999T"
     | Ast_impl -> "Caml1999M"


### PR DESCRIPTION
The format of `cmx` file has been updated to support flambda2,
and it is hence not safe to share magic numbers for `cmx` and
`cmxa` files with upstream. I think it is not necessary to change
the magic number for `cmxs` files, since they do not embed
`cmx` contents (contrary to `cmxa` files).