### PR TITLE
Fix error with Record_unboxed (bug in block kind patch)

### DIFF
--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -233,7 +233,12 @@ let value_kind env ty =
             | Record_inlined tag ->
               Pblock { tag; fields }
             | Record_unboxed _ ->
-              assert false
+              begin match fields with
+              | [field] -> field
+              | [] | _::_ ->
+                Misc.fatal_error "Records that are [Record_unboxed] should \
+                  have exactly one field"
+              end
             | Record_extension _ ->
               Pgenval
           end


### PR DESCRIPTION
#86 contains a bug; the `assert false` on line 236 of `typeopt.ml` is hit with the following example:
```
module I63 : sig type t [@@immediate64] end = struct type t = int end
type t = { foo : I63.t } [@@unboxed]
let f { foo } bar = ()
```
I'm not certain but I think `[@@immediate64]` may be needed to trigger this.  Two questions:
- Is the patch in this PR correct?
- Does this indicate a bug elsewhere in the typechecker that needs fixing?

When the failure happens the backtrace is from `transl_function` and then `transl_curried_function` in `Translcore`.

cc @chambart 