### PR TITLE
Resurrect [@inline never] annotations in camlinternalMod

### DIFF
--- a/ocaml/stdlib/camlinternalMod.ml
+++ b/ocaml/stdlib/camlinternalMod.ml
@@ -61,7 +61,7 @@ and init_mod_block loc comps =
   done;
   modu
 
-let init_mod loc shape =
+let [@inline never] init_mod loc shape =
   match shape with
   | Module comps ->
      Obj.repr (init_mod_block loc comps)
@@ -88,7 +88,7 @@ and update_mod_block comps o n =
     update_mod_field o i comps.(i) (Obj.field n i)
   done
 
-let update_mod shape o n =
+let [@inline never] update_mod shape o n =
   match shape with
   | Module comps ->
      update_mod_block comps o n


### PR DESCRIPTION
We had `[@inline never]` annotations on `camlinternalMod` in the `flambda2.0-stable` dev branch, but they weren't ported to the Flambda backend, in favour of @stedolan 's rework of that file.  Unfortunately that appears not to be sufficient and the Flambda 2 type system takes exception to it, causing `Invalid` to be generated.  We can maybe investigate exactly why later, but for the moment this should be fine.