### PR TITLE
Avoid passing a "\n" argument to `configure`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -104,7 +104,7 @@ _build0/config.status: ocaml/configure.ac
 	mkdir _build0
 	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build0
 	(cd _build0 && \
-	  cat ../configure_opts_stage0 | xargs -0 ./configure -C \
+	  cat ../configure_opts_stage0 | tr -d '\n' | xargs -0 ./configure -C \
 	    --prefix=@stage0_prefix@ \
 	    --disable-ocamldoc \
 	    --disable-ocamltest \


### PR DESCRIPTION
(This is mainly to get feedback from the CI, I am not claiming this is a proper fix.)

When configuring at toplevel with `--enable-middle-end=flambda2`, the file with
the options for stage 0 (namely `configure_opts_stage0`) contains a "\n" string
which is then passed to `configure`. This leads (at least on macOS) to a failure
of the configure call. If there are leftovers from a previous successful build, stage 0
will "inherit" the configuration, leading to an inconsistent state (e.g. the `Config`
module will report it is an flambda2 build, even though the subtree does not even
contain the sources for flambda2).