### PR TITLE
Backport of PR#10542 (immediate64 attribute fix) from upstream

### DIFF
--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -137,14 +137,9 @@ let update_type temp_env env id loc =
       with Ctype.Unify trace ->
         raise (Error(loc, Type_clash (env, trace)))
 
-let get_unboxed_type_representation env ty =
-  match Typedecl_unboxed.get_unboxed_type_representation env ty with
-  | Typedecl_unboxed.This x -> Some x
-  | _ -> None
-
 (* Determine if a type's values are represented by floats at run-time. *)
 let is_float env ty =
-  match get_unboxed_type_representation env ty with
+  match Typedecl_unboxed.get_unboxed_type_representation env ty with
     Some {desc = Tconstr(p, _, _); _} -> Path.same p Predef.path_float
   | _ -> false
 

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -56,9 +56,6 @@ val check_coherence:
 (* for fixed types *)
 val is_fixed_type : Parsetree.type_declaration -> bool
 
-(* for typeopt.ml *)
-val get_unboxed_type_representation: Env.t -> type_expr -> type_expr option
-
 type native_repr_kind = Unboxed | Untagged
 
 type error =

--- a/ocaml/typing/typedecl_immediacy.ml
+++ b/ocaml/typing/typedecl_immediacy.ml
@@ -26,12 +26,8 @@ let compute_decl env tdecl =
     | (Type_record ([{ld_type = arg; _}], _), _)
   when tdecl.type_unboxed.unboxed ->
     begin match Typedecl_unboxed.get_unboxed_type_representation env arg with
-    | Typedecl_unboxed.Unavailable -> Type_immediacy.Unknown
-    | Typedecl_unboxed.This argrepr -> Ctype.immediacy env argrepr
-    | Typedecl_unboxed.Only_on_64_bits argrepr ->
-        match Ctype.immediacy env argrepr with
-        | Type_immediacy.Always -> Type_immediacy.Always_on_64bits
-        | Type_immediacy.Always_on_64bits | Type_immediacy.Unknown as x -> x
+    | None -> Type_immediacy.Unknown
+    | Some argrepr -> Ctype.immediacy env argrepr
     end
   | (Type_variant (_ :: _ as cstrs), _) ->
     if not (List.exists (fun c -> c.Types.cd_args <> Types.Cstr_tuple []) cstrs)

--- a/ocaml/typing/typedecl_unboxed.ml
+++ b/ocaml/typing/typedecl_unboxed.ml
@@ -16,25 +16,15 @@
 
 open Types
 
-type t =
-  | Unavailable
-  | This of type_expr
-  | Only_on_64_bits of type_expr
-
 (* We use the Ctype.expand_head_opt version of expand_head to get access
    to the manifest type of private abbreviations. *)
 let rec get_unboxed_type_representation env ty fuel =
-  if fuel < 0 then Unavailable else
+  if fuel < 0 then None else
   let ty = Ctype.repr (Ctype.expand_head_opt env ty) in
   match ty.desc with
   | Tconstr (p, args, _) ->
     begin match Env.find_type p env with
-    | exception Not_found -> This ty
-    | {type_immediate = Always; _} ->
-        This Predef.type_int
-    | {type_immediate = Always_on_64bits; _} ->
-        Only_on_64_bits Predef.type_int
-    | {type_unboxed = {unboxed = false}} -> This ty
+    | exception Not_found -> Some ty
     | {type_params; type_kind =
          Type_record ([{ld_type = ty2; _}], _)
        | Type_variant [{cd_args = Cstr_tuple [ty2]; _}]
@@ -44,12 +34,9 @@ let rec get_unboxed_type_representation env ty fuel =
         let ty2 = match ty2.desc with Tpoly (t, _) -> t | _ -> ty2 in
         get_unboxed_type_representation env
           (Ctype.apply env type_params ty2 args) (fuel - 1)
-    | {type_kind=Type_abstract} -> Unavailable
-          (* This case can occur when checking a recursive unboxed type
-             declaration. *)
-    | _ -> assert false (* only the above can be unboxed *)
+    | _ -> Some ty
     end
-  | _ -> This ty
+  | _ -> Some ty
 
 let get_unboxed_type_representation env ty =
   (* Do not give too much fuel: PR#7424 *)

--- a/ocaml/typing/typedecl_unboxed.mli
+++ b/ocaml/typing/typedecl_unboxed.mli
@@ -16,10 +16,5 @@
 
 open Types
 
-type t =
-  | Unavailable
-  | This of type_expr
-  | Only_on_64_bits of type_expr
-
 (* for typeopt.ml *)
-val get_unboxed_type_representation: Env.t -> type_expr -> t
+val get_unboxed_type_representation: Env.t -> type_expr -> type_expr option

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -27,7 +27,7 @@ let scrape_ty env ty =
   | Tconstr (p, _, _) ->
       begin match Env.find_type p env with
       | {type_unboxed = {unboxed = true; _}; _} ->
-        begin match Typedecl.get_unboxed_type_representation env ty with
+        begin match Typedecl_unboxed.get_unboxed_type_representation env ty with
         | None -> ty
         | Some ty2 -> ty2
         end


### PR DESCRIPTION
As subject.  This is sufficient to fix the example in #119 but does not fix this (which still fails with the assertion at `typeopt.ml:236`):
```
type t = { foo : t } [@@unboxed]
let f { foo } bar = ()
```