### PR TITLE
Fix computation of extra_args during CPS conversion of Lstaticraise

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -894,12 +894,12 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
       k k_exn
   | Lstaticraise (static_exn, args) ->
     let continuation = Env.get_static_exn_continuation env static_exn in
-    let extra_args =
-      List.map (fun var : IR.simple -> Var var)
-        (Env.extra_args_for_continuation env continuation)
-    in
     cps_non_tail_list acc env ccenv args
       (fun acc env ccenv args ->
+         let extra_args =
+           List.map (fun var : IR.simple -> Var var)
+             (Env.extra_args_for_continuation env continuation)
+         in
          compile_staticfail acc env ccenv
            ~continuation ~args:(args @ extra_args)
       ) k_exn
@@ -1251,12 +1251,12 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
       k k_exn
   | Lstaticraise (static_exn, args) ->
     let continuation = Env.get_static_exn_continuation env static_exn in
-    let extra_args =
-      List.map (fun var : IR.simple -> Var var)
-        (Env.extra_args_for_continuation env continuation)
-    in
     cps_non_tail_list acc env ccenv args
       (fun acc env ccenv args ->
+         let extra_args =
+           List.map (fun var : IR.simple -> Var var)
+             (Env.extra_args_for_continuation env continuation)
+         in
          compile_staticfail acc env ccenv
            ~continuation ~args:(args @ extra_args)
       ) k_exn

--- a/middle_end/flambda2/tests/mlexamples/extra_args_and_staticraise.ml
+++ b/middle_end/flambda2/tests/mlexamples/extra_args_and_staticraise.ml
@@ -1,0 +1,30 @@
+(* After [Base.Hashtbl.fold].
+   This example produces the following lambda code:
+
+    (let
+      (f/9 =
+         (function x/11[int] init/12[int] : int
+           (let (m/13 =v[int] init/12)
+             (catch
+               (try (exit 1 (for i/14 0 to x/11 (assign m/13 (+ m/13 i/14))))
+                with exn/23 0)
+              with (1 val/22[int]) m/13))))
+      (makeblock 0 f/9))
+
+   which is interesting because of the for-loop as an argument to
+   [exit], in conjunction with the mutable variable [m]. *)
+
+type 'a ref = { mutable contents : 'a }
+external ref : 'a -> 'a ref = "%makemutable"
+external ( ! ) : 'a ref -> 'a = "%field0"
+external ( := ) : 'a ref -> 'a -> unit = "%setfield0"
+external ( + ) : int -> int -> int = "%addint"
+let f x init =
+  let m = ref init in
+  match
+    for i = 0 to x do
+      m := !m + i
+    done
+  with
+  | () -> !m
+  | exception _ -> 0


### PR DESCRIPTION
This fixes a subtle bug in CPS conversion, which took many hours to find, that can be triggered by the example in the diff.  Prior to this PR, the raw Flambda terms were wrong: they would return `init` instead of `!m` from the function `f`.

The example produces an unusual Lambda code sequence (in the comment in the diff) which involves having a `for`-loop as the argument to `Lstaticraise` (printed as "`exit`") in conjunction with a mutable variable that is required at the corresponding `Lstaticcatch` handler.  It is necessary to get the correct "instance" of the mutable variable, converted during CPS conversion to multiple immutable ones, at the exits of the `for`-loop.  This means that the environment in the meta-level continuation passed to `cps_non_tail_list` (originally on line 901/902) must be used for computing `extra_args`, not the environment e.g. on line 896 as was happening before.  Using the environment on line 896 causes the `Lstaticcatch` handler to receive the snapshot of the mutable variable as it was before the `for`-loop, not after the requisite number of iterations.