### PR TITLE
Import flambda2 changes (`Asmpackager`)

### DIFF
--- a/ocaml/.gitmodules
+++ b/ocaml/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "flexdll"]
-    path = flexdll
-    url = https://github.com/alainfrisch/flexdll.git


### PR DESCRIPTION
This pull request imports changes from the flambda2 repository
(module `Asmpackager`). It is expected to fix the following tests
(from the "List of failed tests" category on [#125 checks](https://github.com/ocaml-flambda/flambda-backend/pull/125/checks)):

```
    tests/lib-dynlink-native/'main.ml' with 1.1.1.1.1.1.1.1...1.1.1.1.1.1.1 (ocamlopt.byte) 
    tests/lib-dynlink-packed/'loader.ml' with 1.2.1.3 (ocamlopt.byte) 
    tests/lib-dynlink-packed/'loader.ml' with 1.2.1.4 (ocamlopt.byte) 
    tests/lib-dynlink-packed/'loader.ml' with 1.2.1.5.1.1 (check-program-output) 
    tests/lib-dynlink-pr4839/'test.ml' with 1.2.1.10 (ocamlopt.byte) 
    tests/lib-dynlink-pr4839/'test.ml' with 1.2.1.16 (ocamlopt.byte) 
    tests/link-test/'test.ml' with 2.1.1.1.1.1.1.1.1.1.1 (ocamlopt.byte) 
    tests/regression/pr8769/'pr8769.ml' with 2.4 (ocamlopt.byte) 
```

If/when this pull request is approved and subsequently merged,
I am planning on rebasing #125, which I intent to use as the
"current state of the test suite".