### PR TITLE
Disable the comparison of bytecode programs (`ocamltest`)

### DIFF
--- a/ocaml/.gitmodules
+++ b/ocaml/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "flexdll"]
-    path = flexdll
-    url = https://github.com/alainfrisch/flexdll.git

--- a/ocaml/ocamltest/ocaml_actions.ml
+++ b/ocaml/ocamltest/ocaml_actions.ml
@@ -864,19 +864,26 @@ let compare_programs backend comparison_tool log env =
     (Result.pass_with_reason reason, env)
   end else really_compare_programs backend comparison_tool log env
 
-let make_bytecode_programs_comparison_tool =
+(* See CR in compare_bytecode_programs_code below.
+let _make_bytecode_programs_comparison_tool =
   let ocamlrun = Ocaml_files.ocamlrun in
   let cmpbyt = Ocaml_files.cmpbyt in
   let tool_name = ocamlrun ^ " " ^ cmpbyt in
-  Filecompare.make_comparison_tool tool_name ""
+  Filecompare.make_comparison_tool tool_name ""*)
 
 let native_programs_comparison_tool = Filecompare.default_comparison_tool
 
-let compare_bytecode_programs_code log env =
+let compare_bytecode_programs_code _log env : Result.t * Environments.t =
+  (* CR xclerc: consider re-enabling the test if it can be made robust enough.
+     Currently, ocamlc.byte and ocamlc.opt (flambda2) sometimes generate equivalent
+     cmi files whose contents differ because of sharing; the resulting difference
+     is propagated through digests to the bytecode executables.
   let bytecode_programs_comparison_tool =
     make_bytecode_programs_comparison_tool in
   compare_programs
     Ocaml_backends.Bytecode bytecode_programs_comparison_tool log env
+  *)
+  Result.pass_with_reason "comparing of bytecode programs is disabled", env
 
 let compare_bytecode_programs =
   native_action


### PR DESCRIPTION
This pull request disables the comparison of bytecode programs
(`ocamlc.byte` vs `ocamlc.opt`) because the comparison leads
to test failures for equivalent files.

Currently, `ocamlc.byte` and `ocamlc.opt` (flambda2) sometimes
generate equivalent `.cmi` files whose contents differ because of
sharing; the resulting difference is propagated through digests to
the bytecode executables.

This pull request fixes the following tests (section "List of failed tests"):

    tests/basic/'sets.ml' with 2 (bytecode) 
    tests/lib-stdlabels/'test_stdlabels.ml' with 2 (bytecode) 
    tests/lib-hashtbl/'htbl.ml' with 2 (bytecode) 
    tests/gc-roots/'globroots.ml' with 2 (bytecode) 


note: I have manually checked that the failures were caused by
`.cmi` files with the same (as is `=`) signature that happened to
have two different marshaling depending on the compiler.