### PR TITLE
More robust handling of missing imported code

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -157,10 +157,8 @@ let find_code t code_id =
   match Code_id.Map.find code_id t with
   | exception Not_found ->
     Misc.fatal_errorf "Code ID %a not bound" Code_id.print code_id
-  | Present { code; calling_convention = _; } -> code
-  | Imported _ ->
-    Misc.fatal_errorf "Actual code for Code ID %a is missing"
-      Code_id.print code_id
+  | Present { code; calling_convention = _; } -> Some code
+  | Imported _ -> None
 
 let find_code_if_not_imported t code_id =
   match Code_id.Map.find code_id t with

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -45,7 +45,7 @@ val merge : t -> t -> t
 
 val mem : Code_id.t -> t -> bool
 
-val find_code : t -> Code_id.t -> Flambda.Code.t
+val find_code : t -> Code_id.t -> Flambda.Code.t option
 
 val find_code_if_not_imported : t -> Code_id.t -> Flambda.Code.t option
 

--- a/middle_end/flambda2/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/inlining/inlining_transforms.ml
@@ -194,7 +194,14 @@ let inline dacc ~apply ~unroll_to function_decl =
   let apply_exn_continuation = Apply.exn_continuation apply in
   (* CR mshinwell: Add meet constraint to the return continuation *)
   let denv = DA.denv dacc in
-  let code = DE.find_code denv (I.code_id function_decl) in
+  let code =
+    match DE.find_code denv (I.code_id function_decl) with
+    | Some code -> code
+    | None ->
+      Misc.fatal_errorf "Cannot inline without the [Code.t] being available \
+          (this should have been caught earlier):@ %a"
+        Apply.print apply
+  in
   let rec_info =
     match T.prove_rec_info (DE.typing_env denv) (I.rec_info function_decl) with
     | Proved rec_info -> rec_info

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -172,7 +172,7 @@ val define_code : t -> code_id:Code_id.t -> code:Code.t -> t
 
 val mem_code : t -> Code_id.t -> bool
 
-val find_code : t -> Code_id.t -> Code.t
+val find_code : t -> Code_id.t -> Code.t option
 
 (** Appends the locations of inlined call-sites to the given debuginfo
     and sets the resulting debuginfo as the current one in the

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -46,10 +46,9 @@ let record_free_names_of_apply_as_used dacc apply =
     | Return k -> Data_flow.add_apply_result_cont k data_flow
   )
 
-let simplify_direct_tuple_application ~simplify_expr dacc apply code_id
-      ~down_to_up =
+let simplify_direct_tuple_application ~simplify_expr dacc apply
+      ~callee's_code ~down_to_up =
   let dbg = Apply.dbg apply in
-  let callee's_code = DE.find_code (DA.denv dacc) code_id in
   let param_arity = Code.params_arity callee's_code in
   let n = List.length param_arity in
   (* Split the tuple argument from other potential over application arguments *)
@@ -482,7 +481,7 @@ let simplify_direct_over_application ~simplify_expr dacc apply ~param_arity ~res
 let simplify_direct_function_call ~simplify_expr dacc apply
       ~callee's_code_id_from_type ~callee's_code_id_from_call_kind
       ~callee's_closure_id ~result_arity ~recursive ~arg_types:_
-      ~must_be_detupled function_decl_opt ~down_to_up =
+      ~must_be_detupled function_decl_opt ~down_to_up ~type_unavailable =
   begin match Apply.probe_name apply, Apply.inline apply with
   | None, _
   | Some _, Never_inline -> ()
@@ -527,40 +526,42 @@ let simplify_direct_function_call ~simplify_expr dacc apply
         ~return_arity:result_arity
     in
     let apply = Apply.with_call_kind apply call_kind in
-    if must_be_detupled then
-      simplify_direct_tuple_application ~simplify_expr dacc apply
-        callee's_code_id ~down_to_up
-    else begin
-      let args = Apply.args apply in
-      let provided_num_args = List.length args in
-      let callee's_code = DE.find_code (DA.denv dacc) callee's_code_id in
-      (* A function declaration with [is_tupled = true] must be treated
-         specially:
-         - Direct calls adopt the normal calling convention of the code's body,
-           i.e. that given by [Code.params_arity].
-         - Indirect calls adopt the calling convention consisting of a
-           single tuple argument, irrespective of what [Code.params_arity]
-           says. *)
-      let param_arity = Code.params_arity callee's_code in
-      let num_params = List.length param_arity in
-      if provided_num_args = num_params then
-        simplify_direct_full_application ~simplify_expr dacc apply
-          function_decl_opt ~callee's_code_id ~result_arity ~down_to_up
-          ~coming_from_indirect
-      else if provided_num_args > num_params then
-        simplify_direct_over_application ~simplify_expr dacc apply ~param_arity
-          ~result_arity ~down_to_up ~coming_from_indirect
-      else if provided_num_args > 0 && provided_num_args < num_params then
-        simplify_direct_partial_application ~simplify_expr dacc apply
-          ~callee's_code_id ~callee's_closure_id ~param_arity ~result_arity
-          ~recursive ~down_to_up ~coming_from_indirect
-      else
-        Misc.fatal_errorf "Function with %d params when simplifying \
-                           direct OCaml function call with %d arguments: %a"
-          num_params
-          provided_num_args
-          Apply.print apply
-    end
+    match DE.find_code (DA.denv dacc) callee's_code_id with
+    | None -> type_unavailable ()
+    | Some callee's_code ->
+      if must_be_detupled then
+        simplify_direct_tuple_application ~simplify_expr dacc apply
+          ~callee's_code ~down_to_up
+      else begin
+        let args = Apply.args apply in
+        let provided_num_args = List.length args in
+        (* A function declaration with [is_tupled = true] must be treated
+           specially:
+           - Direct calls adopt the normal calling convention of the code's
+             body, i.e. that given by [Code.params_arity].
+           - Indirect calls adopt the calling convention consisting of a
+             single tuple argument, irrespective of what [Code.params_arity]
+             says. *)
+        let param_arity = Code.params_arity callee's_code in
+        let num_params = List.length param_arity in
+        if provided_num_args = num_params then
+          simplify_direct_full_application ~simplify_expr dacc apply
+            function_decl_opt ~callee's_code_id ~result_arity ~down_to_up
+            ~coming_from_indirect
+        else if provided_num_args > num_params then
+          simplify_direct_over_application ~simplify_expr dacc apply
+            ~param_arity ~result_arity ~down_to_up ~coming_from_indirect
+        else if provided_num_args > 0 && provided_num_args < num_params then
+          simplify_direct_partial_application ~simplify_expr dacc apply
+            ~callee's_code_id ~callee's_closure_id ~param_arity ~result_arity
+            ~recursive ~down_to_up ~coming_from_indirect
+        else
+          Misc.fatal_errorf "Function with %d params when simplifying \
+                            direct OCaml function call with %d arguments: %a"
+            num_params
+            provided_num_args
+            Apply.print apply
+      end
 
 let rebuild_function_call_where_callee's_type_unavailable apply call_kind
       ~use_id ~exn_cont_use_id uacc ~after_rebuild =
@@ -733,18 +734,22 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
         | Indirect_known_arity _ -> None
       in
       let callee's_code_id_from_type = I.code_id inlinable in
-      let callee's_code = DE.find_code denv callee's_code_id_from_type in
-      let must_be_detupled =
-        call_must_be_detupled (Code.is_tupled callee's_code)
-      in
-      simplify_direct_function_call ~simplify_expr dacc apply
-        ~callee's_code_id_from_type
-        ~callee's_code_id_from_call_kind ~callee's_closure_id ~arg_types
-        ~result_arity:(Code.result_arity callee's_code)
-        ~recursive:(Code.recursive callee's_code)
-        ~must_be_detupled
-        (Some inlinable)
-        ~down_to_up
+      begin match DE.find_code denv callee's_code_id_from_type with
+      | None -> type_unavailable ()
+      | Some callee's_code ->
+        let must_be_detupled =
+          call_must_be_detupled (Code.is_tupled callee's_code)
+        in
+        simplify_direct_function_call ~simplify_expr dacc apply
+          ~callee's_code_id_from_type
+          ~callee's_code_id_from_call_kind ~callee's_closure_id ~arg_types
+          ~result_arity:(Code.result_arity callee's_code)
+          ~recursive:(Code.recursive callee's_code)
+          ~must_be_detupled
+          (Some inlinable)
+          ~down_to_up
+          ~type_unavailable
+      end
     | Ok (Non_inlinable non_inlinable) ->
       let module N = T.Function_declaration_type.Non_inlinable in
       let callee's_code_id_from_type = N.code_id non_inlinable in
@@ -754,21 +759,23 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
         | Indirect_unknown_arity
         | Indirect_known_arity _ -> None
       in
-      let callee's_code_from_type =
-        DE.find_code denv callee's_code_id_from_type
-      in
-      let must_be_detupled =
-        call_must_be_detupled (Code.is_tupled callee's_code_from_type)
-      in
-      simplify_direct_function_call ~simplify_expr dacc apply
-        ~callee's_code_id_from_type
-        ~callee's_code_id_from_call_kind
-        ~callee's_closure_id ~arg_types
-        ~result_arity:(Code.result_arity callee's_code_from_type)
-        ~recursive:(Code.recursive callee's_code_from_type)
-        ~must_be_detupled
-        None
-        ~down_to_up
+      begin match DE.find_code denv callee's_code_id_from_type with
+      | None -> type_unavailable ()
+      | Some callee's_code_from_type ->
+        let must_be_detupled =
+          call_must_be_detupled (Code.is_tupled callee's_code_from_type)
+        in
+        simplify_direct_function_call ~simplify_expr dacc apply
+          ~callee's_code_id_from_type
+          ~callee's_code_id_from_call_kind
+          ~callee's_closure_id ~arg_types
+          ~result_arity:(Code.result_arity callee's_code_from_type)
+          ~recursive:(Code.recursive callee's_code_from_type)
+          ~must_be_detupled
+          None
+          ~down_to_up
+          ~type_unavailable
+      end
     | Bottom ->
       down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
         let uacc =

--- a/middle_end/flambda2/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda2/to_cmm/un_cps_closure.ml
@@ -444,9 +444,12 @@ module Greedy = struct
           match find_closure_slot state c with
           | Some s -> s, state
           | None ->
-              let code = Exported_code.find_code exported_code code_id in
-              let is_tupled = Code.is_tupled code in
-              let params_arity = Code.params_arity code in
+              let calling_convention =
+                Exported_code.find_calling_convention exported_code code_id
+              in
+              let module CC = Exported_code.Calling_convention in
+              let is_tupled = CC.is_tupled calling_convention in
+              let params_arity = CC.params_arity calling_convention in
               let arity = List.length params_arity in
               let size = if arity = 1 && not is_tupled then 2 else 3 in
               let s = create_slot size (Closure c) in

--- a/middle_end/flambda2/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env.rec.ml
@@ -1235,7 +1235,7 @@ let mem_code t id =
 let find_code t id =
   match Code_id.Map.find id t.all_code with
   | exception Not_found -> Exported_code.find_code (t.get_imported_code ()) id
-  | code -> code
+  | code -> Some code
 
 let code_age_relation t = t.code_age_relation
 

--- a/middle_end/flambda2/types/env/typing_env.rec.mli
+++ b/middle_end/flambda2/types/env/typing_env.rec.mli
@@ -140,7 +140,7 @@ val define_code
 
 val mem_code : t -> Code_id.t -> bool
 
-val find_code : t -> Code_id.t -> Flambda.Code.t
+val find_code : t -> Code_id.t -> Flambda.Code.t option
 
 val code_age_relation : t -> Code_age_relation.t
 

--- a/middle_end/flambda2/types/flambda_type.mli
+++ b/middle_end/flambda2/types/flambda_type.mli
@@ -177,7 +177,7 @@ module Typing_env : sig
 
   val mem_code : t -> Code_id.t -> bool
 
-  val find_code : t -> Code_id.t -> Flambda.Code.t
+  val find_code : t -> Code_id.t -> Flambda.Code.t option
 
   val code_age_relation : t -> Code_age_relation.t
 

--- a/middle_end/flambda2/types/structures/function_declaration_type.rec.ml
+++ b/middle_end/flambda2/types/structures/function_declaration_type.rec.ml
@@ -192,11 +192,13 @@ let meet (env : Meet_env.t) (t1 : t) (t2 : t)
     let resolver = TE.code_age_relation_resolver typing_env in
     let check_other_things_and_return code_id rec_info extension
       : (t * TEE.t) Or_bottom.t =
-      let code = TE.find_code typing_env code_id in
-      let t, _inlining_decision =
-        create ~code ~rec_info
-      in
-      Ok (t, extension)
+      match TE.find_code typing_env code_id with
+      | None -> Ok (Ok (Non_inlinable { code_id; }), extension)
+      | Some code ->
+        let t, _inlining_decision =
+          create ~code ~rec_info
+        in
+        Ok (t, extension)
     in
     begin match
       Code_age_relation.meet target_code_age_rel ~resolver code_id1 code_id2
@@ -263,11 +265,13 @@ let join (env : Join_env.t) (t1 : t) (t2 : t) : t =
     let target_code_age_rel = TE.code_age_relation typing_env in
     let resolver = TE.code_age_relation_resolver typing_env in
     let check_other_things_and_return code_id rec_info : t =
-      let code = TE.find_code typing_env code_id in
-      let t, _inlining_decision =
-        create ~code ~rec_info
-      in
-      t
+      match TE.find_code typing_env code_id with
+      | None -> Ok (Non_inlinable { code_id; })
+      | Some code ->
+        let t, _inlining_decision =
+          create ~code ~rec_info
+        in
+        t
     in
     let code_age_rel1 =
       TE.code_age_relation (Join_env.left_join_env env)


### PR DESCRIPTION
This changes the interface for finding code in the environment so that certain callers can provide fallback behaviour in the event that a `.cmx` file is discovered to be missing.

This only touches Flambda 2 and will be reviewed later.