### PR TITLE
Add Float_block subkind and fix bug in Lambda_conversions.value_kind

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_conversions.ml
+++ b/middle_end/flambda2/from_lambda/lambda_conversions.ml
@@ -36,7 +36,12 @@ let rec value_kind (vk : L.value_kind) =
   | Pboxedintval Pnativeint -> KS.boxed_nativeint
   | Pintval -> KS.tagged_immediate
   | Pblock { tag; fields } ->
-    KS.block (Tag.create_exn tag) (List.map value_kind fields)
+    (* If we have [Obj.double_array_tag] here, this is always an
+       all-float block, not an array. *)
+    if tag = Obj.double_array_tag then
+      KS.float_block ~num_fields:(List.length fields)
+    else
+      KS.block (Tag.create_exn tag) (List.map value_kind fields)
 
 let inline_attribute (attr : L.inline_attribute) : Inline_attribute.t =
   match attr with

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -99,6 +99,7 @@ type kind = (* can't alias because Flambda_kind.t is private *)
 type kind_with_subkind = (* can't alias for same reason as [kind] *)
   | Any_value
   | Block of { tag : Tag.t; fields : kind_with_subkind list }
+  | Float_block of { num_fields : int; }
   | Naked_number of naked_number_kind
   | Boxed_float
   | Boxed_int32

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -237,6 +237,7 @@ let rec value_kind_with_subkind (k : Fexpr.kind_with_subkind)
   | Any_value -> KWS.any_value
   | Block { tag; fields; } ->
     KWS.block tag (List.map value_kind_with_subkind fields)
+  | Float_block { num_fields; } -> KWS.float_block ~num_fields
   | Naked_number naked_number_kind ->
     begin
       match naked_number_kind with

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -377,6 +377,7 @@ let kind_with_subkind (k : Flambda_kind.With_subkind.t) =
     | Block { tag; fields; } ->
       let fields = List.map convert fields in
       Block { tag; fields; }
+    | Float_block { num_fields; } -> Float_block { num_fields; }
     | Naked_number nnk -> Naked_number nnk
     | Boxed_float -> Boxed_float
     | Boxed_int32 -> Boxed_int32

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -144,6 +144,7 @@ let kind_with_subkind ppf (k : kind_with_subkind) =
   match k with
   | Any_value -> str "val"
   | Block _ -> str "block" (* CR mshinwell: improve this *)
+  | Float_block _ -> str "float_block"
   | Naked_number nnk -> naked_number_kind ppf nnk
   | Boxed_float -> str "float boxed"
   | Boxed_int32 -> str "int32 boxed"

--- a/middle_end/flambda2/types/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/types/kinds/flambda_kind.mli
@@ -167,6 +167,7 @@ module With_subkind : sig
       | Boxed_nativeint
       | Tagged_immediate
       | Block of { tag : Tag.t; fields : t list }
+      | Float_block of { num_fields : int; }
 
     include Container_types.S with type t := t
   end
@@ -194,6 +195,7 @@ module With_subkind : sig
   val tagged_immediate : t
   val rec_info : t
   val block : Tag.t -> t list -> t
+  val float_block : num_fields:int -> t
 
   val of_naked_number_kind : Naked_number_kind.t -> t
 
@@ -207,6 +209,7 @@ module With_subkind : sig
     | Tagged_immediate
     | Rec_info
     | Block of { tag : Tag.t; fields : descr list }
+    | Float_block of { num_fields : int; }
 
   val descr : t -> descr
 

--- a/middle_end/flambda2/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda2/types/template/flambda_type.templ.ml
@@ -80,15 +80,14 @@ let rec unknown_with_descr (descr : Flambda_kind.With_subkind.descr) =
   | Tagged_immediate -> any_tagged_immediate ()
   | Rec_info -> any_rec_info ()
   | Block { tag; fields } ->
-    let field_kind, fields =
-      if Tag.equal Tag.double_array_tag tag then
-        Flambda_kind.naked_float,
-        List.map (fun _ -> any_naked_float ()) fields
-      else
-        Flambda_kind.value,
-        List.map unknown_with_descr fields
-    in
-    immutable_block ~is_unique:false tag ~field_kind ~fields
+    assert (not (Tag.equal tag Tag.double_array_tag));
+    immutable_block ~is_unique:false tag
+      ~field_kind:Flambda_kind.value
+      ~fields:(List.map unknown_with_descr fields)
+  | Float_block { num_fields; } ->
+    immutable_block ~is_unique:false Tag.double_array_tag
+      ~field_kind:Flambda_kind.naked_float
+      ~fields:(List.init num_fields (fun _ -> any_naked_float ()))
 
 let unknown_with_subkind kind =
   unknown_with_descr (Flambda_kind.With_subkind.descr kind)


### PR DESCRIPTION
`Lambda_conversions.value_kind` had a bug where it was failing to recognise all-float records.  This PR fixes that and also tightens up the subkind type definition by adding a `Float_block` case.

cc @chambart 