### PR TITLE
Temporarily comment out an `[@inlined]` annotation (test suite)

### DIFF
--- a/ocaml/testsuite/tests/basic-float/tfloat_record.ml
+++ b/ocaml/testsuite/tests/basic-float/tfloat_record.ml
@@ -35,7 +35,8 @@ print_newline ();;
 
 
 let b = Float_array.small_float_array 12
-let c = (Float_array.longer_float_array [@inlined]) 34
+(* CR xclerc for lmaurer: uncomment the `[@inlined]` annotation below. *)
+let c = (Float_array.longer_float_array (*[@inlined]*)) 34
 
 let print_array a =
   Array.iter (fun f ->


### PR DESCRIPTION
This pull request temporarily comment out an inlining annotation,
in an attempt to please the CI.