### PR TITLE
Fix build for i386

### DIFF
--- a/backend/i386/selection.ml
+++ b/backend/i386/selection.ml
@@ -89,7 +89,7 @@ let rec float_needs = function
       let n1 = float_needs arg1 in
       let n2 = float_needs arg2 in
       if n1 = n2 then 1 + n1 else if n1 > n2 then n1 else n2
-  | Cop(Cextcall { name = fn }, args, _dbg)
+  | Cop(Cextcall { func = fn }, args, _dbg)
     when !fast_math && List.mem fn inline_float_ops ->
       begin match args with
         [arg] -> float_needs arg
@@ -168,7 +168,7 @@ method is_immediate_test _cmp _n = true
 
 method! is_simple_expr e =
   match e with
-  | Cop(Cextcall { name = fn; }, args, _)
+  | Cop(Cextcall { func = fn; }, args, _)
     when !fast_math && List.mem fn inline_float_ops ->
       (* inlined float ops are simple if their arguments are *)
       List.for_all self#is_simple_expr args
@@ -177,7 +177,7 @@ method! is_simple_expr e =
 
 method! effects_of e =
   match e with
-  | Cop(Cextcall { name = fn; }, args, _)
+  | Cop(Cextcall { func = fn; }, args, _)
     when !fast_math && List.mem fn inline_float_ops ->
       Selectgen.Effect_and_coeffect.join_list_map args self#effects_of
   | _ ->
@@ -239,7 +239,7 @@ method! select_operation op args dbg =
           super#select_operation op args dbg
       end
   (* Recognize inlined floating point operations *)
-  | Cextcall { name = fn; alloc = false; _ }
+  | Cextcall { func = fn; alloc = false; _ }
     when !fast_math && List.mem fn inline_float_ops ->
       (Ispecific(Ifloatspecial fn), args)
   (* Default *)

--- a/middle_end/flambda2/naming/name_occurrences.ml
+++ b/middle_end/flambda2/naming/name_occurrences.ml
@@ -108,10 +108,12 @@ end = struct
       t land 0xfffff
 
     let num_occurrences_in_types t =
-      (t land 0xfffff_00000) lsr 20
+      (* The constant is computed to avoid problems when the host system
+         is 32 bit. *)
+      (t land (0xfffff lsl 20)) lsr 20
 
     let num_occurrences_phantom t =
-      (t land 0xfffff_00000_00000) lsr 40
+      (t land (0xfffff lsl 40)) lsr 40
 
     let encode_normal_occurrences num =
       assert (num >= 0 && num <= 0xfffff);  (* CR mshinwell: proper error *)
@@ -129,10 +131,10 @@ end = struct
       num land (lnot 0xfffff)
 
     let without_in_types_occurrences num =
-      num land (lnot 0xfffff_00000)
+      num land (lnot (0xfffff lsl 20))
 
     let without_phantom_occurrences num =
-      num land (lnot 0xfffff_00000_00000)
+      num land (lnot (0xfffff lsl 40))
 
     let to_map t =
       Kind.Map.empty


### PR DESCRIPTION
Two problems:
- the i386 backend was out-of-date with respect to `Cextcall`;
- the Flambda 2 code contained some constants that are unrepresentable on 32 bit hosts.