### PR TITLE
Fix joins for row likes with incompatible kinds

### DIFF
--- a/middle_end/flambda2/tests/mlexamples/product_join_with_mixed_kinds.ml
+++ b/middle_end/flambda2/tests/mlexamples/product_join_with_mixed_kinds.ml
@@ -1,0 +1,22 @@
+
+type float_rec = { a : float; b : float; }
+type (_, _) c =
+  | F : (float_rec, unit) c
+  | B : (int * int, int * int) c
+
+let f (type x) (type y) (b : (x, y) c) w x (y:y) : x * unit =
+  let x : x =
+    match b with
+    | F ->
+      { a = w; b = x }
+    | B ->
+      let (u, v) = y in
+      (* This creates a row_like of type Other ( value, value ) *)
+      let _ = Sys.opaque_identity (u + v) in
+      y
+  in
+  (* Here happens the join of
+     Tag_254 ( float, float ) with Other ( value, value )
+     If nothing was done to prevent it, there would be a join between
+     products with different kinds, which is prohibited *)
+  x, ()

--- a/middle_end/flambda2/types/structures/closures_entry.rec.ml
+++ b/middle_end/flambda2/types/structures/closures_entry.rec.ml
@@ -214,3 +214,5 @@ let map_closure_types
         closure_types;
         closure_var_types;
       })
+
+let fields_kind _ = Flambda_kind.value

--- a/middle_end/flambda2/types/structures/closures_entry.rec.mli
+++ b/middle_end/flambda2/types/structures/closures_entry.rec.mli
@@ -46,6 +46,8 @@ val function_decl_types : t -> Function_declaration_type.t Closure_id.Map.t
 
 val closure_var_types : t -> Type_grammar.t Var_within_closure.Map.t
 
+val fields_kind : t -> Flambda_kind.t
+
 include Type_structure_intf.S
   with type t := t
   with type flambda_type := Type_grammar.t

--- a/middle_end/flambda2/types/structures/product.rec.ml
+++ b/middle_end/flambda2/types/structures/product.rec.ml
@@ -247,11 +247,9 @@ module Int_indexed = struct
 
   let join env t1 t2 =
     if not (Flambda_kind.equal t1.kind t2.kind) then begin
-      failwith "mismatching kinds" (* XXX temporary *)
-        (*
       Misc.fatal_errorf "Product.Int_indexed.join between mismatching \
                          kinds %a and %a@."
-        Flambda_kind.print t1.kind Flambda_kind.print t2.kind *)
+        Flambda_kind.print t1.kind Flambda_kind.print t2.kind
     end;
     let fields1 = t1.fields in
     let fields2 = t2.fields in

--- a/middle_end/flambda2/types/structures/product.rec.ml
+++ b/middle_end/flambda2/types/structures/product.rec.ml
@@ -41,6 +41,8 @@ module Make (Index : Product_intf.Index) = struct
 
   let print_with_cache ~cache:_ ppf t = print ppf t
 
+  let fields_kind t = t.kind
+
   let create kind components_by_index =
     (* CR mshinwell: Check that the types are all of the same kind *)
     { components_by_index;
@@ -185,6 +187,8 @@ module Int_indexed = struct
       (Array.to_list t.fields)
 
   let print_with_cache ~cache:_ ppf t = print ppf t
+
+  let fields_kind t = t.kind
 
   let create_from_list kind tys = {
     kind;

--- a/middle_end/flambda2/types/structures/product_intf.ml
+++ b/middle_end/flambda2/types/structures/product_intf.ml
@@ -37,6 +37,8 @@ module type S_base = sig
 
   val project : t -> Index.t -> flambda_type Or_unknown.t
 
+  val fields_kind : t -> Flambda_kind.t
+
   include Type_structure_intf.S
     with type t := t
     with type flambda_type := flambda_type

--- a/middle_end/flambda2/types/structures/row_like_maps_to_intf.ml
+++ b/middle_end/flambda2/types/structures/row_like_maps_to_intf.ml
@@ -28,6 +28,8 @@ module type S = sig
 
   type t
 
+  val fields_kind : t -> Flambda_kind.t
+
   include Type_structure_intf.S
     with type t := t
     with type flambda_type := flambda_type

--- a/middle_end/flambda2/types/type_of_kind/type_of_kind_value0.rec.ml
+++ b/middle_end/flambda2/types/type_of_kind/type_of_kind_value0.rec.ml
@@ -340,9 +340,7 @@ let join_variant env
     Known (Blocks.join env b1 b2)
   in
   let blocks =
-    try (* XXX temporary *)
-      join_unknown blocks_join env blocks1 blocks2
-    with (Failure _) -> Or_unknown.Unknown
+    join_unknown blocks_join env blocks1 blocks2
   in
   let imms =
     join_unknown (T.join ?bound_name:None) env imms1 imms2


### PR DESCRIPTION
Row_likes used to be only contain fields of kind value. This changed with https://github.com/ocaml-flambda/ocaml/pull/396

Now a join can be performed between a float record and a block that contains fields of incompatible type (with some help from GADTs). This is ok most of the time since they come with different tags, but it is possible to build a row like of unknown tag with unannotated fields accesses. Those can only occur on standard blocks. Float records accesses always comes with annotated accesses.

So we can consider a new invariant for row likes:
If they contains fields of kinds other than value, the tag must be known. And no tag can be used for both value and non value contents.
If this ever end up being too restrictive (with changes to the language allowing new kinds of blocks), we could change row like tags to carry fields kinds