### PR TITLE
Merge Flambda 2 .cmxa/.a files into new ocamloptcomp.cmxa/.a

### DIFF
--- a/dune
+++ b/dune
@@ -147,6 +147,30 @@
    runtime_native)
  (modules flambda_backend_main_native))
 
+(rule
+  (targets ocamloptcomp_with_flambda2.a)
+  (action (run %{dep:tools/merge_dot_a_files.sh}
+    %{targets}
+    %{dep:middle_end/flambda2/compilenv_deps/flambda2_compilenv_deps.a}
+    %{dep:middle_end/flambda2/flambda2.a}
+    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.a}
+    %{dep:middle_end/flambda2/backend_intf/flambda2_backend_impl.a}
+    %{dep:ocamloptcomp.a}
+  ))
+)
+
+(rule
+  (targets ocamloptcomp_with_flambda2.cmxa)
+  (action (run %{dep:tools/merge_archives.exe}
+    %{targets}
+    %{dep:middle_end/flambda2/compilenv_deps/flambda2_compilenv_deps.cmxa}
+    %{dep:middle_end/flambda2/flambda2.cmxa}
+    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.cmxa}
+    %{dep:middle_end/flambda2/backend_intf/flambda2_backend_impl.cmxa}
+    %{dep:ocamloptcomp.cmxa}
+  ))
+)
+
 (install
   (files
     (flambda_backend_main.bc as ocamlopt.byte)
@@ -158,9 +182,11 @@
 
 (install
   (files
-    (ocamloptcomp.a as compiler-libs/ocamloptcomp.a)
-    (ocamloptcomp.cmxa as compiler-libs/ocamloptcomp.cmxa)
     (ocamloptcomp.cma as compiler-libs/ocamloptcomp.cma)
+    ; CR mshinwell: There is currently no ocamloptcomp+Flambda2 merged
+    ; archive for bytecode.
+    (ocamloptcomp_with_flambda2.cmxa as compiler-libs/ocamloptcomp.cmxa)
+    (ocamloptcomp_with_flambda2.a as compiler-libs/ocamloptcomp.a)
   )
   (section lib)
   (package ocaml))

--- a/dune
+++ b/dune
@@ -153,9 +153,9 @@
     %{targets}
     %{dep:middle_end/flambda2/compilenv_deps/flambda2_compilenv_deps.a}
     %{dep:middle_end/flambda2/flambda2.a}
+    %{dep:ocamloptcomp.a}
     %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.a}
     %{dep:middle_end/flambda2/backend_intf/flambda2_backend_impl.a}
-    %{dep:ocamloptcomp.a}
   ))
 )
 
@@ -165,9 +165,9 @@
     %{targets}
     %{dep:middle_end/flambda2/compilenv_deps/flambda2_compilenv_deps.cmxa}
     %{dep:middle_end/flambda2/flambda2.cmxa}
+    %{dep:ocamloptcomp.cmxa}
     %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.cmxa}
     %{dep:middle_end/flambda2/backend_intf/flambda2_backend_impl.cmxa}
-    %{dep:ocamloptcomp.cmxa}
   ))
 )
 

--- a/tools/dune
+++ b/tools/dune
@@ -52,6 +52,5 @@
 (executable
   (name merge_archives)
   (modes native)
-  (flags -nostdlib)
   (modules merge_archives)
   (libraries ocamlcommon ocamlbytecomp ocamloptcomp runtime_native))

--- a/tools/dune
+++ b/tools/dune
@@ -48,3 +48,10 @@
   )
   (section bin)
   (package ocaml))
+
+(executable
+  (name merge_archives)
+  (modes native)
+  (flags -nostdlib)
+  (modules merge_archives)
+  (libraries ocamlcommon ocamlbytecomp ocamloptcomp runtime_native))

--- a/tools/merge_archives.ml
+++ b/tools/merge_archives.ml
@@ -75,11 +75,7 @@ let merge_cmxa ~target ~archives =
   close_out chan
 
 let has_extension archive ~ext =
-  let ext = "." ^ ext in
-  let ext_len = String.length ext in
-  let archive_len = String.length archive in
-  archive_len > ext_len
-   && String.equal (String.sub archive (archive_len - ext_len) ext_len) ext
+  Filename.check_suffix archive ("." ^ ext)
 
 let syntax () =
   Printf.eprintf "syntax: %s TARGET-CMX-OR-CMXA-FILE CMA-OR-CMXA-FILES\n"

--- a/tools/merge_archives.ml
+++ b/tools/merge_archives.ml
@@ -1,0 +1,106 @@
+(**************************************************************************
+ *                                                                        *
+ *                                 OCaml                                  *
+ *                                                                        *
+ *                    Mark Shinwell, Jane Street Europe                   *
+ *                                                                        *
+ *   Copyright 2021 Jane Street Group LLC                                 *
+ *                                                                        *
+ *   All rights reserved.  This file is distributed under the terms of    *
+ *   the GNU Lesser General Public License version 2.1, with the          *
+ *   special exception on linking described in the file LICENSE.          *
+ *                                                                        *
+ **************************************************************************)
+
+module String_set = Set.Make (String)
+
+let merge_cma ~target:_ ~archives:_ =
+  failwith "not yet implemented"
+
+let read_cmxa filename =
+  let chan = open_in_bin filename in
+  let magic =
+    really_input_string chan (String.length Config.cmxa_magic_number)
+  in
+  let (cmxa : Cmx_format.library_infos) = input_value chan in
+  close_in chan;
+  magic, cmxa
+
+let merge_cmxa0 ~archives =
+  let magic_and_cmxa_list = List.map read_cmxa archives in
+  let magics = List.map fst magic_and_cmxa_list in
+  let cmxa_list = List.map snd magic_and_cmxa_list in
+  let magic =
+    match String_set.elements (String_set.of_list magics) with
+    | [magic] -> magic
+    | _::_ -> failwith "Archives do not agree on the .cmxa magic number"
+    | [] -> assert false
+  in
+  let _, lib_units, lib_ccobjs, lib_ccopts =
+    List.fold_left
+      (fun (lib_names, lib_units, lib_ccobjs, lib_ccopts)
+           (cmxa : Cmx_format.library_infos) ->
+        let new_lib_names =
+          List.map (fun ((cmx : Cmx_format.unit_infos), _) -> cmx.ui_name)
+            cmxa.lib_units
+          |>
+          String_set.of_list
+        in
+        let already_defined = String_set.inter new_lib_names lib_names in
+        if not (String_set.is_empty already_defined) then begin
+          failwith "Archives contain multiply-defined units"
+        end;
+        let lib_names = String_set.union new_lib_names lib_names in
+        let lib_units = lib_units @ cmxa.lib_units in
+        let cmxa_lib_ccobjs = String_set.of_list cmxa.lib_ccobjs in
+        let lib_ccobjs = String_set.union cmxa_lib_ccobjs lib_ccobjs in
+        let lib_ccopts = lib_ccopts @ cmxa.lib_ccopts in
+        lib_names, lib_units, lib_ccobjs, lib_ccopts)
+      (String_set.empty, [], String_set.empty, [])
+      cmxa_list
+  in
+  let cmxa : Cmx_format.library_infos =
+    { lib_units;
+      lib_ccobjs = String_set.elements lib_ccobjs;
+      lib_ccopts;
+    }
+  in
+  magic, cmxa
+
+let merge_cmxa ~target ~archives =
+  let magic, cmxa = merge_cmxa0 ~archives in
+  let chan = open_out_bin target in
+  output_string chan magic;
+  output_value chan cmxa;
+  close_out chan
+
+let has_extension archive ~ext =
+  let ext = "." ^ ext in
+  let ext_len = String.length ext in
+  let archive_len = String.length archive in
+  archive_len > ext_len
+   && String.equal (String.sub archive (archive_len - ext_len) ext_len) ext
+
+let syntax () =
+  Printf.eprintf "syntax: %s TARGET-CMX-OR-CMXA-FILE CMA-OR-CMXA-FILES\n"
+    Sys.argv.(0);
+  Printf.eprintf "Please provide only .cma files or only .cmxa files.";
+  exit 1
+
+let () =
+  if Array.length Sys.argv < 3 then syntax ();
+  let target = Sys.argv.(1) in
+  let archives =
+    Array.sub Sys.argv 2 (Array.length Sys.argv - 2)
+    |> Array.to_list
+  in
+  let all_cma =
+    List.for_all (fun archive -> has_extension archive ~ext:"cma") archives
+  in
+  let all_cmxa =
+    List.for_all (fun archive -> has_extension archive ~ext:"cmxa") archives
+  in
+  match all_cma, all_cmxa with
+  | true, false -> merge_cma ~target ~archives
+  | false, true -> merge_cmxa ~target ~archives
+  | true, true | false, false -> syntax ()

--- a/tools/merge_dot_a_files.sh
+++ b/tools/merge_dot_a_files.sh
@@ -29,6 +29,8 @@ fi
 files=$(mktemp)
 tempdir=$(mktemp -d)
 
+trap "rm -rf $tempdir $files" EXIT
+
 for archive in $archives; do
   archive=$(absolute_path $archive)
   ar t $archive | grep '\.o$' >> $files
@@ -38,7 +40,4 @@ done
 cd $tempdir
 rm -f $target
 
-ar r $target $(cat $files)
-
-rm -rf $tempdir
-rm -f $files
+ar rD $target $(cat $files)

--- a/tools/merge_dot_a_files.sh
+++ b/tools/merge_dot_a_files.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Merge static library (.a) files into one.
+
+set -eu
+
+if [ "$#" -lt 2 ]; then
+  echo "syntax: $0 TARGET-DOT-A-FILE INPUT-DOT-A-FILE [...]"
+  exit 1
+fi
+
+absolute_path () {
+  path=$1
+  dir=$(dirname $path)
+  dir_abs=$(cd $dir && pwd)
+  file=$(basename $path)
+  echo $dir_abs/$file
+}
+
+target=$1
+shift
+archives=$*
+
+target=$(absolute_path $target)
+
+if [ "$(uname)" = "Darwin" ]; then
+  exec libtool -static -o $target $archives
+fi
+
+files=$(mktemp)
+tempdir=$(mktemp -d)
+
+for archive in $archives; do
+  archive=$(absolute_path $archive)
+  ar t $archive | grep '\.o$' >> $files
+  (cd $tempdir && ar x $archive)
+done
+
+cd $tempdir
+rm -f $target
+
+ar r $target $(cat $files)
+
+rm -rf $tempdir
+rm -f $files


### PR DESCRIPTION
This will avoid clients of compilerlibs having to explicitly link against the Flambda 2 archives.  There is currently no tool for merging `.cmxa` files as far as I know, so I wrote one.  This may need to be extended in the future to handle `.cma` files too.