### PR TITLE
Semaphore without probes: dummy notes

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1443,7 +1443,7 @@ let emit_probe_notes0 probes =
       D.qword (const 0)
     end;
     D.qword (ConstLabel semaphore_label);
-    D.bytes "ocaml.1\000";
+    D.bytes "ocaml.2\000";
     D.bytes (p.probe_name ^ "\000");
     D.bytes (args ^ "\000");
     def_label d;

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1483,6 +1483,51 @@ let emit_probe_notes probes =
   | [], true -> ()
   | _ -> emit_probe_notes0 probes
 
+let emit_dummy_probe_sites () =
+  let semaphores_without_probes =
+    List.fold_left (fun acc probe ->
+      String.Map.remove probe.probe_name acc)
+      !probe_semaphores !probes in
+  if (String.Map.is_empty semaphores_without_probes) then []
+  else begin
+    let fun_name = Compilenv.make_symbol (Some "___dummy_probes") in
+
+    (* start the function (as in fundecl) *)
+    emit_named_text_section fun_name;
+    D.align 16;
+    add_def_symbol fun_name;
+    D.global (emit_symbol fun_name);
+    D.label (emit_symbol fun_name);
+    cfi_startproc ();
+
+    (* emit dummy probe sites: labeled NOP only for stapsdt probes to work,
+       but no calls to probe wrapper because there is no ocaml probe handler. *)
+    let dummy_probes =
+      String.Map.fold (fun probe_name _label acc ->
+        let probe_label = new_label () in
+        def_label probe_label;
+        I.nop (); (* for uprobes and usdt probes as well *)
+        let probe = { probe_name;
+                      probe_label;
+                      probe_arg = [||];
+                      probe_live = Reg.Set.empty;
+                      probe_handler_code_sym = None;
+                      (* the following fields are unused for dummy probes,
+                         which have no ocaml handler and do not call
+                         probe wrappers. *)
+                      probe_stack_offset = !stack_offset;
+                      probe_num_stack_slots = num_stack_slots;
+                    }
+        in
+        probe :: acc)
+        semaphores_without_probes []
+    in
+    I.ret ();
+    (* end the function (as in fundecl) *)
+    cfi_endproc ();
+    emit_function_type_and_size fun_name;
+    dummy_probes
+  end
 
 let end_assembly() =
   if !float_constants <> [] then begin
@@ -1498,6 +1543,9 @@ let end_assembly() =
 
   (* Emit probe handler wrappers *)
   List.iter emit_probe_handler_wrapper !probes;
+
+  (* Emit dummy probes for semaphores without probes in this compilation unit. *)
+  let dummy_probes = emit_dummy_probe_sites () in
 
   emit_named_text_section (Compilenv.make_symbol (Some "code_end"));
   if system = S_macosx then I.nop ();
@@ -1548,7 +1596,7 @@ let end_assembly() =
     D.size frametable (ConstSub (ConstThis, ConstLabel frametable))
   end;
 
-  emit_probe_notes ();
+  emit_probe_notes (dummy_probes @ !probes);
 
   if system = S_linux then
     (* Mark stack as non-executable, PR#4564 *)

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -531,15 +531,22 @@ let tailrec_entry_point = ref None
 
 type probe =
   {
-    stack_offset: int;
-    num_stack_slots: int array;
+    probe_stack_offset: int;
+    probe_num_stack_slots: int array;
     (* Record frame info held in the corresponding mutable variables. *)
     probe_label: label;
     (* Probe site, recorded in .note.stapsdt section
        for enabling and disabling the probes  *)
-    probe_insn: Linear.instruction;
-    (* Iprobe instruction, recorded at probe site and used for emitting
-       the notes and the wrapper code at the end of the compilation unit. *)
+    probe_name: string;
+    (* Use-defined name of the probe. *)
+    probe_handler_code_sym: string option;
+    (* Probe handler function symbol. *)
+
+    probe_arg: Reg.t array;
+    probe_live: Reg.Set.t;
+    (* Information about Iprobe instruction,
+       recorded at probe site and used for emitting the notes and
+       the wrapper code at the end of the compilation unit. *)
   }
 
 let probe_handler_wrapper_name probe_label =
@@ -935,13 +942,16 @@ let emit_instr fallthrough i =
     in
     I.prefetch is_write locality (addressing addr QWORD i 0)
   | Lop (Iname_for_debugger _) -> ()
-  | Lop (Iprobe _) ->
+  | Lop (Iprobe { name; handler_code_sym }) ->
     let probe_label = new_label () in
     let probe =
       { probe_label;
-        probe_insn = i;
-        stack_offset = !stack_offset;
-        num_stack_slots = Array.copy num_stack_slots;
+        probe_name = name;
+        probe_handler_code_sym = Some handler_code_sym;
+        probe_arg = Array.copy i.arg;
+        probe_live = i.live;
+        probe_stack_offset = !stack_offset;
+        probe_num_stack_slots = Array.copy num_stack_slots;
       }
     in
     probes := probe :: !probes;
@@ -1283,23 +1293,20 @@ let make_stack_loc ~offset i (r : Reg.t) =
 
 let emit_probe_handler_wrapper p =
   let wrap_label = probe_handler_wrapper_name p.probe_label in
-  let probe_name, handler_code_sym =
-    match p.probe_insn.desc with
-    | Lop (Iprobe { name; handler_code_sym; }) -> name, handler_code_sym
-    | _ -> assert false
-  in
+  let handler_code_sym = Option.get p.probe_handler_code_sym in
   (* Restore stack frame info as it was at the probe site, so we can easily
      refer to slots in the corresponding frame.  (As per the comment above,
      recall that the wrapper does however have its own frame.) *)
   frame_required := true;
-  stack_offset := p.stack_offset;
+  stack_offset := p.probe_stack_offset;
   for i = 0 to Proc.num_register_classes - 1 do
-    num_stack_slots.(i) <- p.num_stack_slots.(i);
+    num_stack_slots.(i) <- p.probe_num_stack_slots.(i);
   done;
   (* Account for the return address that is now pushed on the stack. *)
   stack_offset := !stack_offset + 8;
   (* Emit function entry code *)
-  D.comment (Printf.sprintf "probe %s %s" probe_name handler_code_sym);
+  D.comment (Printf.sprintf "probe %s %s" p.probe_name
+               handler_code_sym);
   emit_named_text_section wrap_label;
   D.align 16;
   _label wrap_label;
@@ -1313,15 +1320,15 @@ let emit_probe_handler_wrapper p =
   assert (size_addr = 8 && size_int = 8 && size_float = 8);
   (* Compute the size of stack slots for all live hard registers. *)
   let live =
-    Reg.Set.elements p.probe_insn.live
+    Reg.Set.elements p.probe_live
     |> List.filter Reg.is_reg
     |> Array.of_list
   in
   let live_offset = 8 * (Array.length live) in
   (* Compute the size of stack slots for spilling all arguments of the probe. *)
   let aux_offset = 8 (* for saving r15 *) in
-  let tmp_offset = 8 * (Array.length p.probe_insn.arg) in
-  let loc_args, loc_offset = Proc.loc_arguments (Reg.typv p.probe_insn.arg) in
+  let tmp_offset = 8 * (Array.length p.probe_arg) in
+  let loc_args, loc_offset = Proc.loc_arguments (Reg.typv p.probe_arg) in
   (* Ensure the stack is aligned.
      Assuming that the stack at the probe site is 16-byte aligned,
      [loc_arguments] ensures that [loc_offset] is 16-byte aligned.
@@ -1345,16 +1352,17 @@ let emit_probe_handler_wrapper p =
   I.mov r15 (reg saved_r15);
   (* Spill all arguments of the probe.  Some of these may already be on the
      stack, in which case a temporary is used for the move. *)
-  let tmp = Array.mapi (make_stack_loc ~offset:loc_offset) p.probe_insn.arg in
+  let tmp = Array.mapi (make_stack_loc ~offset:loc_offset) p.probe_arg in
   Array.iteri (fun i reg -> move_allowing_stack_to_stack reg (tmp.(i)))
-    p.probe_insn.arg;
+    p.probe_arg;
   (* Load probe arguments to correct locations for the handler *)
   Array.iteri (fun i reg -> move_allowing_stack_to_stack tmp.(i) reg) loc_args;
   (* Reload spilled registers used as temporaries *)
   I.mov (reg saved_r15) r15;
   (* Emit call to handler *)
-  add_used_symbol handler_code_sym;
-  emit_call handler_code_sym;
+  let h = Option.get p.probe_handler_code_sym in
+  add_used_symbol h;
+  emit_call h;
   (* Record a frame description for the wrapper *)
   let label = new_label () in
   let live_offset =
@@ -1383,7 +1391,7 @@ let emit_probe_handler_wrapper p =
   cfi_endproc ();
   emit_function_type_and_size wrap_label
 
-let emit_probe_notes0 () =
+let emit_probe_notes0 probes =
   begin match system with
   | S_gnu | S_cygwin | S_solaris | S_win32 | S_linux_elf | S_bsd_elf
   | S_beos | S_mingw | S_win64 | S_linux | S_mingw64 | S_unknown ->
@@ -1403,18 +1411,13 @@ let emit_probe_notes0 () =
     Printf.sprintf "%d@%s" (Reg.size_of_contents_in_bytes arg) arg_name
   in
   let describe_one_probe p =
-    let probe_name =
-      match p.probe_insn.desc with
-      | Lop (Iprobe { name; _; }) -> name
-      | _ -> assert false
-    in
     let args =
       Array.fold_right (fun arg acc -> (stap_arg arg)::acc)
-        p.probe_insn.arg
+        p.probe_arg
         []
       |> String.concat " "
     in
-    let semaphore_label = emit_symbol (find_or_add_semaphore probe_name) in
+    let semaphore_label = emit_symbol (find_or_add_semaphore p.probe_name) in
     D.align 4;
     let a = new_label() in
     let b = new_label() in
@@ -1441,12 +1444,12 @@ let emit_probe_notes0 () =
     end;
     D.qword (ConstLabel semaphore_label);
     D.bytes "ocaml.1\000";
-    D.bytes (probe_name ^ "\000");
+    D.bytes (p.probe_name ^ "\000");
     D.bytes (args ^ "\000");
     def_label d;
     D.align 4;
   in
-  List.iter describe_one_probe !probes;
+  List.iter describe_one_probe probes;
   begin match system with
   | S_gnu | S_cygwin | S_solaris | S_win32 | S_linux_elf | S_bsd_elf
   | S_beos | S_mingw | S_win64 | S_linux | S_mingw64 | S_unknown ->
@@ -1475,10 +1478,11 @@ let emit_probe_notes0 () =
       add_def_symbol label)
     !probe_semaphores
 
-let emit_probe_notes () =
-  match !probes with
-  | [] -> ()
-  | _ -> emit_probe_notes0 ()
+let emit_probe_notes probes =
+  match probes, String.Map.is_empty !probe_semaphores with
+  | [], true -> ()
+  | _ -> emit_probe_notes0 probes
+
 
 let end_assembly() =
   if !float_constants <> [] then begin

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1305,8 +1305,7 @@ let emit_probe_handler_wrapper p =
   (* Account for the return address that is now pushed on the stack. *)
   stack_offset := !stack_offset + 8;
   (* Emit function entry code *)
-  D.comment (Printf.sprintf "probe %s %s" p.probe_name
-               handler_code_sym);
+  D.comment (Printf.sprintf "probe %s %s" p.probe_name handler_code_sym);
   emit_named_text_section wrap_label;
   D.align 16;
   _label wrap_label;
@@ -1360,9 +1359,8 @@ let emit_probe_handler_wrapper p =
   (* Reload spilled registers used as temporaries *)
   I.mov (reg saved_r15) r15;
   (* Emit call to handler *)
-  let h = Option.get p.probe_handler_code_sym in
-  add_used_symbol h;
-  emit_call h;
+  add_used_symbol handler_code_sym;
+  emit_call handler_code_sym;
   (* Record a frame description for the wrapper *)
   let label = new_label () in
   let live_offset =

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -528,25 +528,29 @@ let function_name = ref ""
 let tailrec_entry_point = ref None
 
 (* Emit tracing probes *)
-
-type probe =
+type probe_handler =
   {
     probe_stack_offset: int;
     probe_num_stack_slots: int array;
     (* Record frame info held in the corresponding mutable variables. *)
-    probe_label: label;
-    (* Probe site, recorded in .note.stapsdt section
-       for enabling and disabling the probes  *)
-    probe_name: string;
-    (* Use-defined name of the probe. *)
-    probe_handler_code_sym: string option;
+    probe_handler_code_sym: string;
     (* Probe handler function symbol. *)
-
     probe_arg: Reg.t array;
     probe_live: Reg.Set.t;
     (* Information about Iprobe instruction,
        recorded at probe site and used for emitting the notes and
        the wrapper code at the end of the compilation unit. *)
+  }
+
+type probe =
+  {
+    probe_label: label;
+    (* Probe site, recorded in .note.stapsdt section
+       for enabling and disabling the probes  *)
+    probe_name: string;
+    (* User-defined name of the probe. *)
+    probe_handler: probe_handler option;
+    (* User-defined handler or None for dummy probes. *)
   }
 
 let probe_handler_wrapper_name probe_label =
@@ -944,14 +948,18 @@ let emit_instr fallthrough i =
   | Lop (Iname_for_debugger _) -> ()
   | Lop (Iprobe { name; handler_code_sym }) ->
     let probe_label = new_label () in
-    let probe =
-      { probe_label;
-        probe_name = name;
-        probe_handler_code_sym = Some handler_code_sym;
+    let h =
+      { probe_handler_code_sym = handler_code_sym;
         probe_arg = Array.copy i.arg;
         probe_live = i.live;
         probe_stack_offset = !stack_offset;
         probe_num_stack_slots = Array.copy num_stack_slots;
+      }
+    in
+    let probe =
+      { probe_label;
+        probe_name = name;
+        probe_handler = Some h;
       }
     in
     probes := probe :: !probes;
@@ -1293,19 +1301,20 @@ let make_stack_loc ~offset i (r : Reg.t) =
 
 let emit_probe_handler_wrapper p =
   let wrap_label = probe_handler_wrapper_name p.probe_label in
-  let handler_code_sym = Option.get p.probe_handler_code_sym in
+  let h = Option.get p.probe_handler in
   (* Restore stack frame info as it was at the probe site, so we can easily
      refer to slots in the corresponding frame.  (As per the comment above,
      recall that the wrapper does however have its own frame.) *)
   frame_required := true;
-  stack_offset := p.probe_stack_offset;
+  stack_offset := h.probe_stack_offset;
   for i = 0 to Proc.num_register_classes - 1 do
-    num_stack_slots.(i) <- p.probe_num_stack_slots.(i);
+    num_stack_slots.(i) <- h.probe_num_stack_slots.(i);
   done;
   (* Account for the return address that is now pushed on the stack. *)
   stack_offset := !stack_offset + 8;
   (* Emit function entry code *)
-  D.comment (Printf.sprintf "probe %s %s" p.probe_name handler_code_sym);
+  D.comment (Printf.sprintf "probe %s %s" p.probe_name
+               h.probe_handler_code_sym);
   emit_named_text_section wrap_label;
   D.align 16;
   _label wrap_label;
@@ -1319,15 +1328,15 @@ let emit_probe_handler_wrapper p =
   assert (size_addr = 8 && size_int = 8 && size_float = 8);
   (* Compute the size of stack slots for all live hard registers. *)
   let live =
-    Reg.Set.elements p.probe_live
+    Reg.Set.elements h.probe_live
     |> List.filter Reg.is_reg
     |> Array.of_list
   in
   let live_offset = 8 * (Array.length live) in
   (* Compute the size of stack slots for spilling all arguments of the probe. *)
   let aux_offset = 8 (* for saving r15 *) in
-  let tmp_offset = 8 * (Array.length p.probe_arg) in
-  let loc_args, loc_offset = Proc.loc_arguments (Reg.typv p.probe_arg) in
+  let tmp_offset = 8 * (Array.length h.probe_arg) in
+  let loc_args, loc_offset = Proc.loc_arguments (Reg.typv h.probe_arg) in
   (* Ensure the stack is aligned.
      Assuming that the stack at the probe site is 16-byte aligned,
      [loc_arguments] ensures that [loc_offset] is 16-byte aligned.
@@ -1351,16 +1360,16 @@ let emit_probe_handler_wrapper p =
   I.mov r15 (reg saved_r15);
   (* Spill all arguments of the probe.  Some of these may already be on the
      stack, in which case a temporary is used for the move. *)
-  let tmp = Array.mapi (make_stack_loc ~offset:loc_offset) p.probe_arg in
+  let tmp = Array.mapi (make_stack_loc ~offset:loc_offset) h.probe_arg in
   Array.iteri (fun i reg -> move_allowing_stack_to_stack reg (tmp.(i)))
-    p.probe_arg;
+    h.probe_arg;
   (* Load probe arguments to correct locations for the handler *)
   Array.iteri (fun i reg -> move_allowing_stack_to_stack tmp.(i) reg) loc_args;
   (* Reload spilled registers used as temporaries *)
   I.mov (reg saved_r15) r15;
   (* Emit call to handler *)
-  add_used_symbol handler_code_sym;
-  emit_call handler_code_sym;
+  add_used_symbol h.probe_handler_code_sym;
+  emit_call h.probe_handler_code_sym;
   (* Record a frame description for the wrapper *)
   let label = new_label () in
   let live_offset =
@@ -1410,10 +1419,13 @@ let emit_probe_notes0 probes =
   in
   let describe_one_probe p =
     let args =
-      Array.fold_right (fun arg acc -> (stap_arg arg)::acc)
-        p.probe_arg
-        []
-      |> String.concat " "
+      match p.probe_handler with
+      | None -> ""
+      | Some h ->
+        Array.fold_right (fun arg acc -> (stap_arg arg)::acc)
+          h.probe_arg
+          []
+        |> String.concat " "
     in
     let semaphore_label = emit_symbol (find_or_add_semaphore p.probe_name) in
     D.align 4;
@@ -1507,14 +1519,7 @@ let emit_dummy_probe_sites () =
         I.nop (); (* for uprobes and usdt probes as well *)
         let probe = { probe_name;
                       probe_label;
-                      probe_arg = [||];
-                      probe_live = Reg.Set.empty;
-                      probe_handler_code_sym = None;
-                      (* the following fields are unused for dummy probes,
-                         which have no ocaml handler and do not call
-                         probe wrappers. *)
-                      probe_stack_offset = !stack_offset;
-                      probe_num_stack_slots = num_stack_slots;
+                      probe_handler = None;
                     }
         in
         probe :: acc)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -124,7 +124,6 @@ type error =
   | Probe_format
   | Probe_name_too_long of string
   | Probe_name_format of string
-  | Probe_name_undefined of string
   | Probe_is_enabled_format
   | Literal_overflow of string
   | Unknown_literal of string * char
@@ -3753,10 +3752,6 @@ and type_expect_
                        _ } ,
                       _)}]) ->
         check_probe_name name name_loc env;
-        add_delayed_check
-          (fun () ->
-             if not (Env.has_probe name) then
-               raise(Error(name_loc, env, (Probe_name_undefined name))));
         rue {
           exp_desc = Texp_probe_is_enabled {name};
           exp_loc = loc; exp_extra = [];
@@ -5606,11 +5601,6 @@ let report_error ~loc env = function
          Probe names may only contain alphanumeric characters or \
          underscores."
         name
-  | Probe_name_undefined name ->
-      Location.errorf ~loc
-        "Undefined probe name `%s' used in %%probe_is_enabled. \
-         Not found [%%probe \"%s\" ...] in the same compilation unit."
-        name name
   | Probe_format ->
       Location.errorf ~loc
         "Probe points must consist of a name, as a string \

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -181,7 +181,6 @@ type error =
   | Probe_format
   | Probe_name_too_long of string
   | Probe_name_format of string
-  | Probe_name_undefined of string
   (* CR-soon mshinwell: Use an inlined record *)
   | Probe_is_enabled_format
   | Literal_overflow of string


### PR DESCRIPTION
In the original version of probes (before PR #60), inlining of `[%probe_is_enabled" <name>]` into a another compilation unit can result in link error if there is no mention of the `[%probe  <name>]` with the same `<name>` in the target-of-inlining compilation unit. For example:
```
$ cat t1.ml
let () = Printf.printf "%%probe_is_enabled = %b\n" (T2.probe_is_enabled ());

$ cat t2.ml
let [@inline always] probe_is_enabled () = [%probe_is_enabled "test2"]

$ ocamlopt.opt t2.ml t1.ml -o t.exe
t1.o: In function `camlT1__entry':
:(.text+0x7): undefined reference to `camlT1__semaphore_test2'
collect2: error: ld returned 1 exit status
File "caml_startup", line 1:
Error: Error during linking (exit code 1)
EXIT STATUS 2
```
This PR fixes it by emitting "dummy" probe sites.  (PR#60 fixes this problem as well by creating a unique semaphore label per name.)

Additionally, this PR removes the source-level requirement on compilation unit that has `[%probe_is_enabled <name>]` to contain also `[%probe <name>]`.  

There is a small downside to removing this check, which can catch some spelling mistakes in probe names that would otherwise go unnoticed. This is not catching all such issues, and anyway most `[%probe ]` commands are expected to be generated automatically by a ppx and so won't have these issues.

The main motivation for supporting `[%probe_is_enabled <name>]` without any `[%probe <name>]` in the source of the program is to toggle tracing/logging code that is not inside a `[%probe]` at runtime from another process with low overhead, compared to RPC.  A corresponding change in probes library will ensure that dummy probe sites are not updated. As a result, semaphore-only "probes" will be toggled without pausing the tracee. Systemtap will continue to work as before in the presence of dummy probes.

Dummy probes are implemented by adding special (unused) function with name ending in `___dummy_probes` per compilation unit if needed, with a `NOP` instruction for each dummy probe site and without a cmp/call instruction to the probe wrapper. 

It is a small change after refactoring of probe type (that is by itself an improvement).  Therefore, this RP is best reviewed commit by commit. 

It is necessary to advance the version of probe notes, because old tracer tool must not attempt to update dummy probe sites, which do not have an ocaml probe handler.

I'm not sure if this change needs bootstrap.