### PR TITLE
Set all warnings as errors in release profile in dune

### DIFF
--- a/dune
+++ b/dune
@@ -8,6 +8,11 @@
 ;*                                                                        *
 ;**************************************************************************
 
+; set warning as error in release profile
+(env
+  (release
+    (flags (:standard -warn-error +A))))
+
 ; Since upstream has the middle end code inside ocamloptcomp, we do the
 ; same for the moment.
 


### PR DESCRIPTION
By default, dune release profile turns off -warn-error.  It would be useful to turn it on in CI and I don't see any need to turn it off in release.