### PR TITLE
Check all arches in backend 

### DIFF
--- a/.github/workflows/check_all_arches.yml
+++ b/.github/workflows/check_all_arches.yml
@@ -1,0 +1,71 @@
+name: check_all_arches
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    env:
+      J: "3"
+
+    steps:
+    - name: Checkout the Flambda backend repo
+      uses: actions/checkout@master
+      with:
+        path: 'flambda_backend'
+
+    - name: Cache dune build compiler install directory
+      uses: actions/cache@v1
+      id: cache
+      with:
+        path: ${{ github.workspace }}/dune_build_compiler/_install
+        key: ${{ matrix.os }}-cache-dune-build-compiler
+
+    - name: Checkout OCaml 4.12 (dune build compiler)
+      uses: actions/checkout@master
+      if: steps.cache.outputs.cache-hit != 'true'
+      with:
+        repository: 'ocaml/ocaml'
+        path: 'dune_build_compiler'
+        ref: '4.12'
+
+    - name: Build and install dune build compiler
+      if: steps.cache.outputs.cache-hit != 'true'
+      working-directory: dune_build_compiler
+      run: |
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        make -j $J world.opt
+        make install
+
+    - name: Checkout dune github repo
+      uses: actions/checkout@master
+      with:
+        repository: 'ocaml-flambda/dune'
+        ref: 'special_dune'
+        path: 'dune'
+
+    - name: Build dune
+      working-directory: dune
+      run: |
+        PATH=$GITHUB_WORKSPACE/dune_build_compiler/_install/bin:$PATH make release
+
+    - name: Run autoconf for Flambda backend
+      working-directory: flambda_backend
+      run: autoconf
+
+    - name: Configure Flambda backend (Closure mode)
+      working-directory: flambda_backend
+      run: |
+        ./configure \
+          --prefix=$GITHUB_WORKSPACE/_install \
+          --enable-middle-end=closure \
+          --with-dune=$GITHUB_WORKSPACE/dune/dune.exe
+
+    - name: Build all targets (Closure mode)
+      working-directory: flambda_backend
+      run: make -j $J check_all_arches

--- a/.github/workflows/check_all_arches.yml
+++ b/.github/workflows/check_all_arches.yml
@@ -66,6 +66,6 @@ jobs:
           --enable-middle-end=closure \
           --with-dune=$GITHUB_WORKSPACE/dune/dune.exe
 
-    - name: Build all targets (Closure mode)
+    - name: Build check_all_arches (Closure mode)
       working-directory: flambda_backend
       run: make -j $J check_all_arches

--- a/Makefile.in
+++ b/Makefile.in
@@ -62,6 +62,7 @@ stage1: ocaml-stage1-config.status stage0 \
 	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage0_prefix)/bin:$$PATH \
+	  ARCH=`grep '^ARCH=' ocaml/Makefile.config | cut -d'=' -f2` \
 	  $(dune) build --profile=release --build-dir=_build1 @install
 	(cd _build1/install/default/bin && \
 	  rm -f ocamllex && \
@@ -79,6 +80,7 @@ stage2: ocaml-stage2-config.status stage1
 	cp ocaml-stage2-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage1_prefix)/bin:$$PATH \
+	  ARCH=`grep '^ARCH=' ocaml/Makefile.config | cut -d'=' -f2` \
 	  $(dune) build --profile=release --build-dir=_build2 @install
 
 # This target is like a polling version of upstream "make ocamlopt" (based
@@ -92,7 +94,45 @@ hacking: ocaml-stage1-config.status stage0 \
 	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	PATH=$(stage0_prefix)/bin:$$PATH \
+	  ARCH=`grep '^ARCH=' ocaml/Makefile.config | cut -d'=' -f2` \
 	  $(dune) build -w --profile=release --build-dir=_build1 @install
+
+
+## Test compilation of backend-specific parts
+ARCHES=amd64 i386 arm arm64 power s390x riscv
+ARCH_SPECIFIC =\
+  backend/arch.ml backend/proc.ml backend/CSE.ml backend/selection.ml \
+  backend/scheduling.ml backend/reload.ml backend/emit.ml
+
+# This rule provides a quick way to check that machine-dependent
+# files compiles fine for a foreign architecture (passed as ARCH=xxx).
+# Based on stage1 target above.
+.PHONY: check_arch
+check_arch: ocaml-stage1-config.status stage0 \
+	config_files
+	cp ocaml-stage1-config.status ocaml/config.status
+	(cd ocaml && ./config.status)
+	@echo "========= CHECKING backend/$(ARCH) =============="
+	@rm -f $(ARCH_SPECIFIC)
+	@rm -f backend/*.cm* backend/cfg/*.cm* backend/debug/*.cm*
+	PATH=$(stage0_prefix)/bin:$$PATH \
+	  $(dune) build --profile=release --build-dir=_build1 ocamloptcomp.cma
+	@rm -f $(ARCH_SPECIFIC)
+	@rm -f backend/*.cm* backend/cfg/*.cm* backend/debug/*.cm*
+
+.PHONY: check_all_arches
+check_all_arches: ocaml-stage1-config.status stage0 \
+	config_files
+	cp ocaml-stage1-config.status ocaml/config.status
+	(cd ocaml && ./config.status)
+	@if $$(grep '^ARCH64=true' ocaml/Makefile.config > /dev/null) ; \
+	then \
+		for i in $(ARCHES); do \
+		   $(MAKE) --no-print-directory check_arch ARCH=$$i || exit 1; \
+		done; \
+	else \
+		echo "Architecture tests are disabled on 32-bit platforms." ;\
+	fi
 
 # The stage0 configure step configures the tree to build pretty much the
 # bare minimum that we need for building stage1.
@@ -220,6 +260,7 @@ runtest:
 	# Ideally that would be inaccessible within tests (to prevent mistakes
 	# such as running "ocamlopt" rather than one of the stage2 binaries).
 	PATH=$(stage1_prefix)/bin:$$PATH \
+	  ARCH=`grep '^ARCH=' ocaml/Makefile.config | cut -d'=' -f2` \
 	  $(dune) runtest --profile=release --build-dir=_build2
 
 # The following horror will be removed when work to allow the testsuite to
@@ -358,9 +399,11 @@ runtest-upstream:
 	# stage2.
 	# This might be causing a spurious rebuild of the runtime
 	PATH=$(stage0_prefix)/bin:$$PATH \
+	  ARCH=`grep '^ARCH=' ocaml/Makefile.config | cut -d'=' -f2` \
 	  $(dune) build --profile=release --build-dir=_build1 \
 	  ocaml/tools/cmpbyt.bc
 	PATH=$(stage0_prefix)/bin:$$PATH \
+	  ARCH=`grep '^ARCH=' ocaml/Makefile.config | cut -d'=' -f2` \
 	  $(dune) build --profile=release --build-dir=_build1 \
 	  ocaml/ocamltest/ocamltest.byte
 	cp _build1/default/ocaml/tools/cmpbyt.bc _runtest/tools/cmpbyt

--- a/Makefile.in
+++ b/Makefile.in
@@ -113,19 +113,17 @@ check_arch: ocaml-stage1-config.status stage0 \
 	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
 	@echo "========= CHECKING backend/$(ARCH) =============="
-	@rm -f $(ARCH_SPECIFIC)
-	@rm -f backend/*.cm* backend/cfg/*.cm* backend/debug/*.cm*
+	rm -f $(ARCH_SPECIFIC)
 	PATH=$(stage0_prefix)/bin:$$PATH \
 	  $(dune) build --profile=release --build-dir=_build1 ocamloptcomp.cma
-	@rm -f $(ARCH_SPECIFIC)
-	@rm -f backend/*.cm* backend/cfg/*.cm* backend/debug/*.cm*
+	rm -f $(ARCH_SPECIFIC)
 
 .PHONY: check_all_arches
 check_all_arches: ocaml-stage1-config.status stage0 \
 	config_files
 	cp ocaml-stage1-config.status ocaml/config.status
 	(cd ocaml && ./config.status)
-	@if $$(grep '^ARCH64=true' ocaml/Makefile.config > /dev/null) ; \
+	if $$(grep '^ARCH64=true' ocaml/Makefile.config > /dev/null) ; \
 	then \
 		for i in $(ARCHES); do \
 		   $(MAKE) --no-print-directory check_arch ARCH=$$i || exit 1; \

--- a/backend/arm/emit.mlp
+++ b/backend/arm/emit.mlp
@@ -773,6 +773,7 @@ let emit_instr i =
             assert false
         end
     | Lop (Iname_for_debugger _) -> 0
+    | Lop (Iprobe _ |Iprobe_is_enabled _) -> assert false
     | Lreloadretaddr ->
         let n = frame_size() in
         `	ldr	lr, [sp, #{emit_int(n-4)}]\n`; 1

--- a/backend/arm/emit.mlp
+++ b/backend/arm/emit.mlp
@@ -773,7 +773,8 @@ let emit_instr i =
             assert false
         end
     | Lop (Iname_for_debugger _) -> 0
-    | Lop (Iprobe _ |Iprobe_is_enabled _) -> assert false
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+      fatal_error ("Probes not supported.")
     | Lreloadretaddr ->
         let n = frame_size() in
         `	ldr	lr, [sp, #{emit_int(n-4)}]\n`; 1

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -535,6 +535,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Ispecific (Ibswap _)) -> 1
     | Lop (Ispecific Imove32) -> 1
     | Lop (Iname_for_debugger _) -> 0
+    | Lop (Iprobe _ | Iprobe_is_enabled _) -> assert false
     | Lreloadretaddr -> 0
     | Lreturn -> epilogue_size ()
     | Llabel _ -> 0
@@ -883,6 +884,7 @@ let emit_instr i =
             assert false
         end
     | Lop (Iname_for_debugger _) -> ()
+    | Lop (Iprobe _ | Iprobe_is_enabled _) -> assert false
     | Lreloadretaddr ->
         ()
     | Lreturn ->

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -535,7 +535,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Ispecific (Ibswap _)) -> 1
     | Lop (Ispecific Imove32) -> 1
     | Lop (Iname_for_debugger _) -> 0
-    | Lop (Iprobe _ | Iprobe_is_enabled _) -> assert false
+    | Lop (Iprobe _ | Iprobe_is_enabled _) ->
+      fatal_error ("Probes not supported.")
     | Lreloadretaddr -> 0
     | Lreturn -> epilogue_size ()
     | Llabel _ -> 0
@@ -884,7 +885,8 @@ let emit_instr i =
             assert false
         end
     | Lop (Iname_for_debugger _) -> ()
-    | Lop (Iprobe _ | Iprobe_is_enabled _) -> assert false
+    | Lop (Iprobe _ | Iprobe_is_enabled _) ->
+        fatal_error ("Probes not supported.")
     | Lreloadretaddr ->
         ()
     | Lreturn ->

--- a/backend/arm64/selection.ml
+++ b/backend/arm64/selection.ml
@@ -116,13 +116,13 @@ method! is_immediate op n =
 
 method! is_simple_expr = function
   (* inlined floating-point ops are simple if their arguments are *)
-  | Cop(Cextcall { name = fn; }, args, _) when List.mem fn inline_ops ->
+  | Cop(Cextcall { func; }, args, _) when List.mem func inline_ops ->
       List.for_all self#is_simple_expr args
   | e -> super#is_simple_expr e
 
 method! effects_of e =
   match e with
-  | Cop(Cextcall { name = fn; }, args, _) when List.mem fn inline_ops ->
+  | Cop(Cextcall { func; }, args, _) when List.mem func inline_ops ->
       Selectgen.Effect_and_coeffect.join_list_map args self#effects_of
   | e -> super#effects_of e
 
@@ -224,15 +224,15 @@ method! select_operation op args dbg =
           super#select_operation op args dbg
       end
   (* Recognize floating-point square root *)
-  | Cextcall { name = "sqrt" } ->
+  | Cextcall { func = "sqrt" } ->
       (Ispecific Isqrtf, args)
   (* Recognize bswap instructions *)
-  | Cextcall { name = "caml_bswap16_direct" } ->
+  | Cextcall { func = "caml_bswap16_direct" } ->
       (Ispecific(Ibswap 16), args)
-  | Cextcall { name = "caml_int32_direct_bswap"; } ->
+  | Cextcall { func = "caml_int32_direct_bswap"; } ->
       (Ispecific(Ibswap 32), args)
-  | Cextcall { name = "caml_int64_direct_bswap"; } |
-    Cextcall { name = "caml_nativeint_direct_bswap" } ->
+  | Cextcall { func = "caml_int64_direct_bswap"; } |
+    Cextcall { func = "caml_nativeint_direct_bswap" } ->
       (Ispecific (Ibswap 64), args)
   (* Other operations are regular *)
   | _ ->

--- a/backend/dune
+++ b/backend/dune
@@ -20,6 +20,7 @@
           (glob_files arm64/*.ml)
           (glob_files i386/*.ml)
           (glob_files power/*.ml)
+          (glob_files riscv/*.ml)
           (glob_files s390x/*.ml))
  (action  (bash "cp %{env:ARCH=amd64}/*.ml .")))
 
@@ -31,6 +32,7 @@
           arm64/emit.mlp
           i386/emit.mlp
           power/emit.mlp
+          riscv/emit.mlp
           s390x/emit.mlp)
  (action
    (progn

--- a/backend/dune
+++ b/backend/dune
@@ -15,20 +15,18 @@
 (rule
  (targets arch.ml CSE.ml proc.ml reload.ml scheduling.ml selection.ml)
  (mode    fallback)
- (deps    (:conf ../ocaml/Makefile.config)
-          (glob_files amd64/*.ml)
+ (deps    (glob_files amd64/*.ml)
           (glob_files arm/*.ml)
           (glob_files arm64/*.ml)
           (glob_files i386/*.ml)
           (glob_files power/*.ml)
           (glob_files s390x/*.ml))
- (action  (bash "cp `grep '^ARCH=' %{conf} | cut -d'=' -f2`/*.ml .")))
+ (action  (bash "cp %{env:ARCH=amd64}/*.ml .")))
 
 (rule
  (targets emit.ml)
  (mode    fallback)
- (deps    (:conf ../ocaml/Makefile.config)
-          amd64/emit.mlp
+ (deps    amd64/emit.mlp
           arm/emit.mlp
           arm64/emit.mlp
           i386/emit.mlp
@@ -37,7 +35,7 @@
  (action
    (progn
      (with-stdout-to contains-input-name
-       (bash "echo `grep '^ARCH=' %{conf} | cut -d'=' -f2`/emit.mlp"))
+       (bash "echo %{env:ARCH=amd64}/emit.mlp"))
      (with-stdout-to %{targets}
        (progn
          (bash "echo \\# 1 \\\"`cat contains-input-name`\\\"")

--- a/backend/power/emit.mlp
+++ b/backend/power/emit.mlp
@@ -498,6 +498,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Iintoffloat) -> 4
     | Lop(Ispecific _) -> 1
     | Lop (Iname_for_debugger _) -> 0
+    | Lop (Iprobe _ |Iprobe_is_enabled _) -> assert false
     | Lreloadretaddr -> 2
     | Lreturn -> 2
     | Llabel _ -> 0
@@ -853,6 +854,7 @@ let emit_instr i =
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
     | Lop (Iname_for_debugger _) -> ()
+    | Lop (Iprobe _ |Iprobe_is_enabled _) -> assert false
     | Lreloadretaddr ->
         `	{emit_string lg}	11, {emit_int(retaddr_offset())}(1)\n`;
         `	mtlr	11\n`

--- a/backend/power/emit.mlp
+++ b/backend/power/emit.mlp
@@ -498,7 +498,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Iintoffloat) -> 4
     | Lop(Ispecific _) -> 1
     | Lop (Iname_for_debugger _) -> 0
-    | Lop (Iprobe _ |Iprobe_is_enabled _) -> assert false
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+      Misc.fatal_error ("Probes not supported.")
     | Lreloadretaddr -> 2
     | Lreturn -> 2
     | Llabel _ -> 0
@@ -854,7 +855,8 @@ let emit_instr i =
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
     | Lop (Iname_for_debugger _) -> ()
-    | Lop (Iprobe _ |Iprobe_is_enabled _) -> assert false
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+        Misc.fatal_error ("Probes not supported.")
     | Lreloadretaddr ->
         `	{emit_string lg}	11, {emit_int(retaddr_offset())}(1)\n`;
         `	mtlr	11\n`

--- a/backend/riscv/emit.mlp
+++ b/backend/riscv/emit.mlp
@@ -444,6 +444,7 @@ let emit_instr i =
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
   | Lop (Iname_for_debugger _) ->
       ()
+  | Lop (Iprobe _|Iprobe_is_enabled _) -> assert false
   | Lreloadretaddr ->
       let n = frame_size () in
       reload_ra n

--- a/backend/riscv/emit.mlp
+++ b/backend/riscv/emit.mlp
@@ -444,7 +444,8 @@ let emit_instr i =
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
   | Lop (Iname_for_debugger _) ->
       ()
-  | Lop (Iprobe _|Iprobe_is_enabled _) -> assert false
+  | Lop (Iprobe _|Iprobe_is_enabled _) ->
+      Misc.fatal_error ("Probes not supported.")
   | Lreloadretaddr ->
       let n = frame_size () in
       reload_ra n

--- a/backend/s390x/emit.mlp
+++ b/backend/s390x/emit.mlp
@@ -529,6 +529,8 @@ let emit_instr i =
           `	msgfi	{emit_reg i.res.(0)}, {emit_int n}\n`
     | Lop(Iintop_imm((Imulh | Idiv | Imod), _)) ->
         assert false
+    | Lop(Iintop_imm((Ipopcnt | Iclz _ | Ictz _), _)) ->
+        assert false
     | Lop(Inegf | Iabsf as op) ->
         let instr = name_for_floatop1 op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
@@ -546,6 +548,7 @@ let emit_instr i =
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop (Iname_for_debugger _) -> ()
+    | Lop (Iprobe _ |Iprobe_is_enabled _) -> assert false
     | Lreloadretaddr ->
         let n = frame_size() in
         `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`

--- a/backend/s390x/emit.mlp
+++ b/backend/s390x/emit.mlp
@@ -530,7 +530,7 @@ let emit_instr i =
     | Lop(Iintop_imm((Imulh | Idiv | Imod), _)) ->
         assert false
     | Lop(Iintop_imm((Ipopcnt | Iclz _ | Ictz _), _)) ->
-        assert false
+        fatal_error ("Operation not supported.")
     | Lop(Inegf | Iabsf as op) ->
         let instr = name_for_floatop1 op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
@@ -548,7 +548,8 @@ let emit_instr i =
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop (Iname_for_debugger _) -> ()
-    | Lop (Iprobe _ |Iprobe_is_enabled _) -> assert false
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+        fatal_error ("Probes not supported.")
     | Lreloadretaddr ->
         let n = frame_size() in
         `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`


### PR DESCRIPTION
The first commit in this PR adds Makefile build targets `make check_arch ARCH=<..>` and `make check_all_arches` for `backend` directory, with the same meaning as upstream, except that `check_all_arches` stops on first error (the behavior I've wanted whenever I used it before).  ARCH env variable is then used in dune rules in `backend` instead of the value of ARCH in the current configuration.
The last commit adds `check_all_arches` to CI as a separate workflow. It will be particularly useful with some form of #149 for catching Partial Match (warning 8).
The other commits fix various build errors.
