### PR TITLE
Update HACKING

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -101,3 +101,8 @@ library, and then the compiler.
 - There are currently no compiler tests for different intrinics. It
   relies on the library tests to avoid duplication. Library tests use
   `Core`, but the library itself does not.
+
+## Dependencies
+
+- `opam install ppx_compare` for flambda2 tests
+


### PR DESCRIPTION
I'm not sure about this one. We seems to have acquired ppx_compare as a dependency, which should probably be documented somewhere, although dune gives pretty good error messages when they are missing. 