### PR TITLE
Add -mbranches-within-32B to major GC compilation (where available)

### DIFF
--- a/ocaml/Makefile.config.in
+++ b/ocaml/Makefile.config.in
@@ -243,6 +243,7 @@ PROBES=@probes@
 AWK=@AWK@
 STDLIB_MANPAGES=@stdlib_manpages@
 NAKED_POINTERS=@naked_pointers@
+INTEL_JCC_BUG_CFLAGS=@intel_jcc_bug_cflags@
 
 ### Native command to build ocamlrun.exe
 

--- a/ocaml/aclocal.m4
+++ b/ocaml/aclocal.m4
@@ -30,6 +30,7 @@ m4_include([build-aux/lt~obsolete.m4])
 # Macros from the autoconf macro archive
 m4_include([build-aux/ax_func_which_gethostbyname_r.m4])
 m4_include([build-aux/ax_pthread.m4])
+m4_include([build-aux/ax_check_compile_flag.m4])
 
 # The following macro figures out which C compiler is used.
 # It does so by checking for compiler-specific predefined macros.

--- a/ocaml/build-aux/ax_check_compile_flag.m4
+++ b/ocaml/build-aux/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -691,6 +691,7 @@ build_os
 build_vendor
 build_cpu
 build
+intel_jcc_bug_cflags
 naked_pointers_checker
 naked_pointers
 compute_deps
@@ -802,6 +803,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -918,6 +920,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1170,6 +1173,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1307,7 +1319,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1460,6 +1472,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -2840,6 +2853,7 @@ VERSION=4.12.0
 
 
  # TODO: rename this variable
+
 
 
 
@@ -14075,6 +14089,53 @@ case $arch in #(
      ;;
 esac ;;
 esac
+
+# The major GC performs better with this flag on Intel processors
+# This is a workaround for an Intel CPU bug:
+# https://www.intel.co.uk/content/www/uk/en/support/articles/000055650/processors.html
+
+intel_jcc_bug_cflags=''
+case $arch in #(
+  amd64) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Wa,-mbranches-within-32B-boundaries" >&5
+$as_echo_n "checking whether C compiler accepts -Wa,-mbranches-within-32B-boundaries... " >&6; }
+if ${ax_cv_check_cflags___Wa__mbranches_within_32B_boundaries+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -Wa,-mbranches-within-32B-boundaries"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ax_cv_check_cflags___Wa__mbranches_within_32B_boundaries=yes
+else
+  ax_cv_check_cflags___Wa__mbranches_within_32B_boundaries=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___Wa__mbranches_within_32B_boundaries" >&5
+$as_echo "$ax_cv_check_cflags___Wa__mbranches_within_32B_boundaries" >&6; }
+if test "x$ax_cv_check_cflags___Wa__mbranches_within_32B_boundaries" = xyes; then :
+  intel_jcc_bug_cflags=-Wa,-mbranches-within-32B-boundaries
+else
+  :
+fi
+ ;; #(
+  *) :
+     ;;
+esac
+
 
 # Assembler
 

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -169,6 +169,7 @@ AC_SUBST([stdlib_manpages])
 AC_SUBST([compute_deps])
 AC_SUBST([naked_pointers])
 AC_SUBST([naked_pointers_checker])
+AC_SUBST([intel_jcc_bug_cflags])
 
 ## Generated files
 
@@ -1075,6 +1076,16 @@ AS_CASE([$arch],
        # Alpine and other musl-based Linux distributions
        [common_cflags="-no-pie $common_cflags"],
     [])])
+
+# The major GC performs better with this flag on Intel processors
+# This is a workaround for an Intel CPU bug:
+# https://www.intel.co.uk/content/www/uk/en/support/articles/000055650/processors.html
+
+intel_jcc_bug_cflags=''
+AS_CASE([$arch],
+  [amd64],
+    [AX_CHECK_COMPILE_FLAG([-Wa,-mbranches-within-32B-boundaries],
+     [intel_jcc_bug_cflags=-Wa,-mbranches-within-32B-boundaries])])
 
 # Assembler
 

--- a/ocaml/runtime/Makefile
+++ b/ocaml/runtime/Makefile
@@ -333,6 +333,11 @@ libasmrun_shared.$(SO): $(libasmrunpic_OBJECTS)
 %.npic.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
 %.npic.$(D): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
 
+# The major GC performs better with this flag on Intel processors
+# This is a workaround for an Intel CPU bug:
+# https://www.intel.co.uk/content/www/uk/en/support/articles/000055650/processors.html
+major_gc.%: OC_CFLAGS += $(INTEL_JCC_BUG_CFLAGS)
+
 # Compilation of C files
 
 # The COMPILE_C_FILE macro below receives as argument the pattern


### PR DESCRIPTION
The major GC performs better with this flag on Intel processors

This is a workaround for an Intel CPU bug: <https://www.intel.co.uk/content/www/uk/en/support/articles/000055650/processors.html>