### PR TITLE
Fix ocamlcfg builds

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -63,7 +63,7 @@ let successor_labels_normal ti =
   | Tailcall (Self { destination; }) -> Label.Set.singleton destination
   | Switch labels -> Array.to_seq labels |> Label.Set.of_seq
   | Return | Raise _ | Tailcall (Func _) -> Label.Set.empty
-  | Throw _ -> Label.Set.empty
+  | Call_no_return _ -> Label.Set.empty
   | Never -> Label.Set.empty
   | Always l -> Label.Set.singleton l
   | Parity_test { ifso; ifnot } | Truth_test { ifso; ifnot } ->
@@ -113,7 +113,7 @@ let replace_successor_labels t ~normal ~exn block ~f =
         Tailcall (Self { destination = f destination; })
       | Tailcall (Func Indirect)
       | Tailcall (Func (Direct _))
-      | Return | Raise _ | Throw _ -> block.terminator.desc
+      | Return | Raise _ | Call_no_return _ -> block.terminator.desc
     in
     block.terminator <- { block.terminator with desc }
 
@@ -256,8 +256,8 @@ let print_terminator oc ?(sep = "\n") ti =
       for i = 0 to Array.length labels - 1 do
         Printf.fprintf oc "case %d: goto %d%s" i labels.(i) sep
       done
-  | Throw { func_symbol : string; _ }  ->
-    Printf.fprintf oc "Throw %s%s" func_symbol sep
+  | Call_no_return { func_symbol : string; _ }  ->
+    Printf.fprintf oc "Call_no_return %s%s" func_symbol sep
   | Return -> Printf.fprintf oc "Return%s" sep
   | Raise _ -> Printf.fprintf oc "Raise%s" sep
   | Tailcall (Self _) -> Printf.fprintf oc "Tailcall self%s" sep

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -165,7 +165,7 @@ module S = struct
     | Return
     | Raise of Lambda.raise_kind
     | Tailcall of tail_call_operation
-    | Throw of external_call_operation
+    | Call_no_return of external_call_operation
 end
 
 (* CR-someday gyorsh: Switch can be translated to Branch. *)

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -39,14 +39,15 @@ module S = struct
     | Self of { destination : Label.t; }
     | Func of func_call_operation
 
+  type external_call_operation =
+    { func_symbol : string;
+      alloc : bool;
+      ty_res : Cmm.machtype;
+      ty_args : Cmm.exttype list
+    }
+
   type prim_call_operation =
-    | External of
-        { func_symbol : string;
-          alloc : bool;
-          returns : bool;
-          ty_res : Cmm.machtype;
-          ty_args : Cmm.exttype list
-        }
+    | External of external_call_operation
     | Alloc of
         { bytes : int;
           dbginfo : Debuginfo.alloc_dbginfo;
@@ -164,6 +165,7 @@ module S = struct
     | Return
     | Raise of Lambda.raise_kind
     | Tailcall of tail_call_operation
+    | Throw of external_call_operation
 end
 
 (* CR-someday gyorsh: Switch can be translated to Branch. *)

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -46,8 +46,8 @@ let from_basic (basic : Cfg.basic) : L.instruction_desc =
   | Call (F (Indirect)) -> Lop (Icall_ind)
   | Call (F (Direct { func_symbol; })) ->
       Lop (Icall_imm { func = func_symbol; })
-  | Call (P (External { func_symbol; alloc; ty_args; ty_res; returns; })) ->
-      Lop (Iextcall { func = func_symbol; alloc; ty_args; ty_res; returns; })
+  | Call (P (External { func_symbol; alloc; ty_args; ty_res; })) ->
+      Lop (Iextcall { func = func_symbol; alloc; ty_args; ty_res; returns = true; })
   | Call
       (P
         (Checkbound { immediate = None; }))
@@ -181,7 +181,10 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
     | Tailcall (Func (Direct { func_symbol })) ->
       [L.Lop (Itailcall_imm { func = func_symbol })], None
     | Tailcall (Self { destination }) ->
-        [L.Lop (Itailcall_imm { func = Cfg.fun_name cfg })], Some destination
+      [L.Lop (Itailcall_imm { func = Cfg.fun_name cfg })], Some destination
+    | Throw { func_symbol; alloc; ty_args; ty_res; } ->
+      [L.Lop (Iextcall { func = func_symbol; alloc; ty_args; ty_res;
+                         returns = false; })], None
     | Switch labels -> [L.Lswitch labels], None
     | Never -> Misc.fatal_error "Cannot linearize terminator: Never"
     | Always label -> branch_or_fallthrough label, None
@@ -328,7 +331,7 @@ let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
             let new_labels = CL.new_labels cfg_with_layout in
             CL.preserve_orig_labels cfg_with_layout
             && not (Label.Set.mem block.start new_labels)
-        | Return | Raise _ | Tailcall _ -> assert false )
+        | Return | Raise _ | Tailcall _ | Throw _ -> assert false )
 
 let adjust_trap_depth body (block : Cfg.basic_block)
     ~(prev_block : Cfg.basic_block) =

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -182,7 +182,7 @@ let linearize_terminator cfg (terminator : Cfg.terminator Cfg.instruction)
       [L.Lop (Itailcall_imm { func = func_symbol })], None
     | Tailcall (Self { destination }) ->
       [L.Lop (Itailcall_imm { func = Cfg.fun_name cfg })], Some destination
-    | Throw { func_symbol; alloc; ty_args; ty_res; } ->
+    | Call_no_return { func_symbol; alloc; ty_args; ty_res; } ->
       [L.Lop (Iextcall { func = func_symbol; alloc; ty_args; ty_res;
                          returns = false; })], None
     | Switch labels -> [L.Lswitch labels], None
@@ -331,7 +331,7 @@ let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
             let new_labels = CL.new_labels cfg_with_layout in
             CL.preserve_orig_labels cfg_with_layout
             && not (Label.Set.mem block.start new_labels)
-        | Return | Raise _ | Tailcall _ | Throw _ -> assert false )
+        | Return | Raise _ | Tailcall _ | Call_no_return _ -> assert false )
 
 let adjust_trap_depth body (block : Cfg.basic_block)
     ~(prev_block : Cfg.basic_block) =

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -212,7 +212,7 @@ let register_block t (block : C.basic_block) traps =
 
 let can_raise_terminator (i : C.terminator) =
   match i with
-  | Raise _ | Tailcall (Func _) | Throw _ -> true
+  | Raise _ | Tailcall (Func _) | Call_no_return _ -> true
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
   | Int_test _ | Switch _ | Return
   | Tailcall (Self _) ->
@@ -386,7 +386,7 @@ let add_terminator t (block : C.basic_block) (i : L.instruction)
   ( match desc with
   | Never -> Misc.fatal_error "Cannot add terminator: Never"
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _ -> ()
-  | Switch _ | Return | Raise _ | Tailcall _ | Throw _ ->
+  | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _ ->
       if not (Linear_utils.defines_label i.next) then
         Misc.fatal_errorf "Linear instruction not followed by label:@ %a"
           Printlinear.instr
@@ -614,7 +614,7 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
           create_blocks t i.next block ~trap_depth ~traps
       | Iextcall { func; alloc; ty_args; ty_res; returns = false; } ->
         let desc =
-          C.Throw ({ func_symbol = func; alloc; ty_args; ty_res; })
+          C.Call_no_return ({ func_symbol = func; alloc; ty_args; ty_res; })
         in
         add_terminator t block i desc ~trap_depth ~traps;
         create_blocks t i.next block ~trap_depth ~traps

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -212,7 +212,7 @@ let register_block t (block : C.basic_block) traps =
 
 let can_raise_terminator (i : C.terminator) =
   match i with
-  | Raise _ | Tailcall (Func _) -> true
+  | Raise _ | Tailcall (Func _) | Throw _ -> true
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
   | Int_test _ | Switch _ | Return
   | Tailcall (Self _) ->
@@ -386,7 +386,7 @@ let add_terminator t (block : C.basic_block) (i : L.instruction)
   ( match desc with
   | Never -> Misc.fatal_error "Cannot add terminator: Never"
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _ -> ()
-  | Switch _ | Return | Raise _ | Tailcall _ ->
+  | Switch _ | Return | Raise _ | Tailcall _ | Throw _ ->
       if not (Linear_utils.defines_label i.next) then
         Misc.fatal_errorf "Linear instruction not followed by label:@ %a"
           Printlinear.instr
@@ -400,8 +400,8 @@ let to_basic (mop : Mach.operation) : C.basic =
   | Icall_ind -> Call (F Indirect)
   | Icall_imm { func; } ->
       Call (F (Direct { func_symbol = func; }))
-  | Iextcall { func; alloc; ty_args; ty_res; returns; } ->
-      Call (P (External { func_symbol = func; alloc; ty_args; ty_res; returns }))
+  | Iextcall { func; alloc; ty_args; ty_res; returns = true; } ->
+      Call (P (External { func_symbol = func; alloc; ty_args; ty_res; }))
   | Iintop Icheckbound ->
       Call
         (P
@@ -453,7 +453,8 @@ let to_basic (mop : Mach.operation) : C.basic =
       Op
         (Name_for_debugger
            { ident; which_parameter; provenance; is_assignment })
-  | Itailcall_ind | Itailcall_imm _ -> assert false
+  | Itailcall_ind | Itailcall_imm _ | Iextcall { returns = false; _ }
+    -> assert false
 
 (** [traps] represents the trap stack, with head being the top. [trap_depths]
     is the depth of the trap stack. *)
@@ -611,6 +612,12 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
           in
           add_terminator t block i desc ~trap_depth ~traps;
           create_blocks t i.next block ~trap_depth ~traps
+      | Iextcall { func; alloc; ty_args; ty_res; returns = false; } ->
+        let desc =
+          C.Throw ({ func_symbol = func; alloc; ty_args; ty_res; })
+        in
+        add_terminator t block i desc ~trap_depth ~traps;
+        create_blocks t i.next block ~trap_depth ~traps
       | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf
       | Idivf | Ifloatofint | Iintoffloat | Iconst_int _ | Iconst_float _
       | Icompf _

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -99,6 +99,7 @@ let block (block : C.basic_block) =
         let l = Label.Set.min_elt labels in
         block.terminator <- { block.terminator with desc = Always l }
   | Switch labels -> simplify_switch block labels
+  | Throw _
   | Tailcall (Self _ | Func _) | Raise _ | Return -> ()
 
 let run cfg = C.iter_blocks cfg ~f:(fun _ b -> block b)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -99,7 +99,7 @@ let block (block : C.basic_block) =
         let l = Label.Set.min_elt labels in
         block.terminator <- { block.terminator with desc = Always l }
   | Switch labels -> simplify_switch block labels
-  | Throw _
+  | Call_no_return _
   | Tailcall (Self _ | Func _) | Raise _ | Return -> ()
 
 let run cfg = C.iter_blocks cfg ~f:(fun _ b -> block b)

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -60,9 +60,6 @@ let rec adjust_trap_depth delta_traps next =
   match next.desc with
   | Ladjust_trap_depth { delta_traps = k } ->
     adjust_trap_depth (delta_traps + k) next.next
-  | Llabel lbl ->
-    let next = adjust_trap_depth delta_traps next.next in
-    cons_instr (Llabel lbl) next
   | Lbranch lbl ->
     let next = adjust_trap_depth delta_traps next.next in
     cons_instr (Lbranch lbl) next

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -170,8 +170,7 @@ let linear i n contains_calls =
       Iend -> n
     | Iop(Itailcall_ind | Itailcall_imm _ as op)
     | Iop((Iextcall { returns = false; _ }) as op) ->
-        (* note: there cannot be deadcode in n *)
-        copy_instr (Lop op) i (linear env i.Mach.next n)
+        copy_instr (Lop op) i (discard_dead_code (linear env i.Mach.next n))
     | Iop(Imove | Ireload | Ispill)
       when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
         linear env i.Mach.next n

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -60,9 +60,6 @@ let rec adjust_trap_depth delta_traps next =
   match next.desc with
   | Ladjust_trap_depth { delta_traps = k } ->
     adjust_trap_depth (delta_traps + k) next.next
-  | Lbranch lbl ->
-    let next = adjust_trap_depth delta_traps next.next in
-    cons_instr (Lbranch lbl) next
   | _ ->
     if delta_traps = 0 then next
     else cons_instr (Ladjust_trap_depth { delta_traps }) next

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -164,7 +164,7 @@ let linear i n contains_calls =
       Iend -> n
     | Iop(Itailcall_ind | Itailcall_imm _ as op)
     | Iop((Iextcall { returns = false; _ }) as op) ->
-        copy_instr (Lop op) i (discard_dead_code (linear env i.Mach.next n))
+        copy_instr (Lop op) i (discard_dead_code n)
     | Iop(Imove | Ireload | Ispill)
       when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
         linear env i.Mach.next n


### PR DESCRIPTION
Compilation with `-ocamlcfg` flag with an assertion violation in Linear_to_cfg. For example:
```
let rec compare_list a b =
  match a, b with
  | [], [] -> 0
  | [], _ -> -1
  | _, [] -> 1
  | x :: xs, y :: ys ->
    let res = compare x y in
    if res <> 0 then res else compare_list xs ys
```
This PR fixes the failure.

This PR is currently on top of https://github.com/ocaml-flambda/flambda-backend/pull/159, to check ocamlcfg in the new CI workflow (but should probaby be merged before the changes in #159).

A change in https://github.com/ocaml-flambda/flambda-backend/pull/72  in [linearize.ml:L141](https://github.com/ocaml-flambda/flambda-backend/pull/72/files#diff-2810a8b768126ab64516b7674307910bc3feac1f61c5e892637d5e3c03c021b6L141)  breaks a nice invariant that was previously maintained by `Linearize` and checked by an assertion in `Linear_to_cfg` translation. The invariant is "no dead code after a tail call". After #72, we get code fragment like this for the for the tail call  above example (`jmp .L104` followed by dead `jmp .L101`):
```
.L103:
        movq    (%rsp), %rax
        movq    8(%rax), %rbx
        movq    8(%rsp), %rax
        movq    8(%rax), %rax
        jmp     .L104
        jmp     .L101
        .align  4
.L102:
        movl    $3, %eax
        addq    $24, %rsp
        ret
        .align  4
```

To restore the invariant, I added back a call to `discard_deadcode`. I am not sure it is the right fix.  Note that it doesn't revert  to the way Itailcalls were handled before #72. I do not understand why in #72 `n` was replaced with `linear env i.Mach.next n` in that line. Other cases in `linear` for an instruction `i` that does not return still discard the rest of `i.next` (for example, `Ireturn`). @lthls @mshinwell do you remember why the change was made?


