### PR TITLE
Fix bad assertion when removing an unboxed argument used as phantom

### DIFF
--- a/middle_end/flambda2/naming/name_mode.ml
+++ b/middle_end/flambda2/naming/name_mode.ml
@@ -138,6 +138,11 @@ module Or_absent = struct
     | Absent -> false
     | Present _ -> true
 
+  let is_present_as_normal = function
+    | Absent -> false
+    | Present Normal -> true
+    | Present (Phantom | In_types) -> false
+
   include Container_types.Make (struct
     type nonrec t = t
 

--- a/middle_end/flambda2/naming/name_mode.mli
+++ b/middle_end/flambda2/naming/name_mode.mli
@@ -72,6 +72,7 @@ module Or_absent : sig
   val present : kind -> t
 
   val is_present : t -> bool
+  val is_present_as_normal : t -> bool
 
   include Container_types.S with type t := t
 

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -77,7 +77,9 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
           ListLabels.filter extra_params_and_args.extra_params
             ~f:(fun extra_param ->
               let used =
-                Name_occurrences.mem_var free_names (KP.var extra_param)
+                Name_mode.Or_absent.is_present_as_normal @@
+                Name_occurrences.greatest_name_mode_var
+                  free_names (KP.var extra_param)
               in
               (* The free_names computation is the reference here, because it
                  records precisely what is actually used in the term being

--- a/middle_end/flambda2/tests/mlexamples/data_flow_opam_bug.ml
+++ b/middle_end/flambda2/tests/mlexamples/data_flow_opam_bug.ml
@@ -1,0 +1,12 @@
+(* build with -g *)
+
+let to_string context t =
+  let paren ?(cond=false) f =
+    f
+  in
+  let cond = Some (context = `Plop) in
+  match t with
+  | None ->
+    paren ?cond "plop"
+  | Some _ ->
+    paren ?cond "plip"


### PR DESCRIPTION
This triggered when building
* opam-format: http://check.ocamllabs.io:8081/log/1628941397-5eab245578ee8aab2b80c440c82aa91b9bbfba75/4.12+flambda2/bad/opam-format.2.1.0
* Probably kind2 also http://check.ocamllabs.io:8081/log/1628941397-5eab245578ee8aab2b80c440c82aa91b9bbfba75/4.12+flambda2/bad/kind2.1.4.0
* opam-monorepo http://check.ocamllabs.io:8081/log/1628941397-5eab245578ee8aab2b80c440c82aa91b9bbfba75/4.12+flambda2/bad/opam-monorepo.0.2.3