### PR TITLE
Fix permission of installed files (all installed files were read-only)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -232,8 +232,8 @@ config_files: ocaml-stage1-config.status
 .PHONY: install
 install: stage2
 	mkdir -p $(prefix)
-	rsync --copy-links -r $(stage2_prefix)/bin $(prefix)
-	rsync --copy-links -r $(stage2_prefix)/lib $(prefix)
+	rsync --copy-links --chmod=u+rw,go+r -r $(stage2_prefix)/bin $(prefix)
+	rsync --copy-links --chmod=u+rw,go+r -r $(stage2_prefix)/lib $(prefix)
 	rm -f $(prefix)/bin/ocamllex
 	ln -s $(prefix)/bin/ocamllex.opt $(prefix)/bin/ocamllex
 	rm -f $(prefix)/bin/flambda_backend.main*


### PR DESCRIPTION
Files in dune's build directory are read-only to help the dune cache to work properly.
Thus copying from this directory should not be done and `dune install` should be used instead (or explicitly chmoded as opam does).

~The dune invocation was taken from the `stage2` step.~

*Side note: copying + chmod (e.g. `rsync --chmod=u+rw,go+r`) would work too. Feel free to take whichever solution you prefer.*

EDIT: actually nevermind, rsync is better as it does not require the custom dune binary during installation.