### PR TITLE
Makefile add .NOTPARALLEL:

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,6 +6,8 @@
 #*                                                                        *
 #**************************************************************************
 
+.NOTPARALLEL:
+
 # CR mshinwell: Find out how to get something like "set -eu" in effect.
 prefix=@prefix@
 stage0_prefix=@stage0_prefix@


### PR DESCRIPTION
Disables parallelism in top-level Makefile, even if `-j` option is provided. Calls to `make` targets in other Makefiles will run in parallel as before. 

This seems to fix random build failures that I get when building on a large box. I haven't found the cause yet, but it would be nice to have this in the meantime.