### PR TITLE
Remove hack for .depend from runtime/dune 

### DIFF
--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -42,12 +42,10 @@
           obj.c lexing.c callback.c debugger.c weak.c compact.c finalise.c
           custom.c dynlink.c afl.c unix.c win32.c bigarray.c main.c memprof.c 
           domain.c caml/domain_state.tbl eventlog.c skiplist.c codefrag.c
-          instrtrace.c caml/opnames.h prims.c) 
+          instrtrace.c caml/opnames.h prims.c .depend) 
  (action
    (progn
-     (bash "touch .depend") ; hack.
-     (run make -j8 %{targets} COMPUTE_DEPS=false)
-     (bash "rm -f .depend"))))
+     (run make %{targets}))))
 
 (rule
   (targets prims.c)
@@ -68,14 +66,10 @@
   parsing.c gc_ctrl.c md5.c obj.c lexing.c unix.c printexc.c callback.c weak.c
   compact.c finalise.c custom.c globroots.c backtrace_nat.c backtrace.c
   dynlink_nat.c debugger.c meta.c dynlink.c clambda_checks.c afl.c bigarray.c memprof.c domain.c
-  caml/domain_state.tbl eventlog.c prims.c)
+  caml/domain_state.tbl eventlog.c prims.c .depend)
  (action
   (progn
-   (bash "touch .depend") ; hack.
-   (run make -j8 %{targets})
-   (bash "rm -f .depend"))))
-
-; Why isn't .depend present under _build?
+   (run make %{targets}))))
 
 (rule
   (targets ld.conf)
@@ -91,34 +85,29 @@
 ;      (run make -j8 %{targets})
 ;      (bash "chmod o+w %{targets}"))))
 ;
+
 (rule
   (targets ocamlrun)
-  (deps libcamlrun.a prims.o)
+  (deps libcamlrun.a prims.o .depend)
   (action
     (progn
-      (bash "touch .depend") ; hack.
-      (run make -j8 %{targets})
-      (bash "rm -f .depend"))))
+    (run make %{targets}))))
 
 (rule
   (targets ocamlrund)
   ; the ocamlrun dep is a hack to serialise production of ocamlrun* so there
   ; isn't a race on prims.o
-  (deps libcamlrund.a prims.o ocamlrun)
+  (deps libcamlrund.a prims.o ocamlrun .depend)
   (action
     (progn
-      (bash "touch .depend") ; hack.
-      (run make -j8 %{targets})
-      (bash "rm -f .depend"))))
+      (run make %{targets}))))
 
 (rule
   (targets ocamlruni)
-  (deps libcamlruni.a prims.o ocamlrund)
+  (deps libcamlruni.a prims.o ocamlrund .depend)
   (action
     (progn
-      (bash "touch .depend") ; hack.
-      (run make -j8 %{targets})
-      (bash "rm -f .depend"))))
+      (run make %{targets}))))
 
 (library
   (name runtime_byte)

--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -42,7 +42,7 @@
           obj.c lexing.c callback.c debugger.c weak.c compact.c finalise.c
           custom.c dynlink.c afl.c unix.c win32.c bigarray.c main.c memprof.c 
           domain.c caml/domain_state.tbl eventlog.c skiplist.c codefrag.c
-          instrtrace.c caml/opnames.h prims.c .depend) 
+          instrtrace.c caml/opnames.h prims.c) 
  (action
    (progn
      (run make %{targets}))))
@@ -66,7 +66,7 @@
   parsing.c gc_ctrl.c md5.c obj.c lexing.c unix.c printexc.c callback.c weak.c
   compact.c finalise.c custom.c globroots.c backtrace_nat.c backtrace.c
   dynlink_nat.c debugger.c meta.c dynlink.c clambda_checks.c afl.c bigarray.c memprof.c domain.c
-  caml/domain_state.tbl eventlog.c prims.c .depend)
+  caml/domain_state.tbl eventlog.c prims.c)
  (action
   (progn
    (run make %{targets}))))
@@ -88,7 +88,7 @@
 
 (rule
   (targets ocamlrun)
-  (deps libcamlrun.a prims.o .depend)
+  (deps libcamlrun.a prims.o)
   (action
     (progn
     (run make %{targets}))))
@@ -97,14 +97,14 @@
   (targets ocamlrund)
   ; the ocamlrun dep is a hack to serialise production of ocamlrun* so there
   ; isn't a race on prims.o
-  (deps libcamlrund.a prims.o ocamlrun .depend)
+  (deps libcamlrund.a prims.o ocamlrun)
   (action
     (progn
       (run make %{targets}))))
 
 (rule
   (targets ocamlruni)
-  (deps libcamlruni.a prims.o ocamlrund .depend)
+  (deps libcamlruni.a prims.o ocamlrund)
   (action
     (progn
       (run make %{targets}))))


### PR DESCRIPTION
Upstream, `.depend` file was removed from `runtime` directory in https://github.com/ocaml/ocaml/pull/9332.
At the same time, the hack for `.depend` in `runtime/dune` was removed by https://github.com/ocaml-flambda/ocaml/pull/460.
This PR combines the two changes. I haven't tested it propertly yet, not sure how to do it, other than adding dummy files and seeing that they show  up in dependencies.

After this change, `make depend` works in `ocaml` directory, but `make alldepend` still does not work because of `otherlibs/dynlink/dynlink_compilerlibs` but I haven't figured out the issue yet.

