### PR TITLE
Drop recursive equation in Typing_env_extension.join

### DIFF
--- a/middle_end/flambda2/types/type_grammar.rec.ml
+++ b/middle_end/flambda2/types/type_grammar.rec.ml
@@ -1007,7 +1007,7 @@ let join ?bound_name env t1 t2 =
       print t1
       print t2
 
-let equation_is_directly_recursive name ty =
+let is_alias_of_name ty name =
   match get_alias_exn ty with
   | exception Not_found -> false
   | simple ->
@@ -1017,7 +1017,7 @@ let equation_is_directly_recursive name ty =
 
 let check_equation name ty =
   if Flambda_features.check_invariants () then begin
-    if equation_is_directly_recursive name ty then begin
+    if is_alias_of_name ty name then begin
       Misc.fatal_errorf "Directly recursive equation@ %a = %a@ \
           disallowed"
         Name.print name

--- a/middle_end/flambda2/types/type_grammar.rec.mli
+++ b/middle_end/flambda2/types/type_grammar.rec.mli
@@ -45,6 +45,7 @@ val apply_coercion : t -> Coercion.t -> t Or_bottom.t
 val eviscerate : t -> Typing_env.t -> t
 
 val get_alias_exn : t -> Simple.t
+val is_alias_of_name : t -> Name.t -> bool
 
 val is_obviously_bottom : t -> bool
 val is_obviously_unknown : t -> bool


### PR DESCRIPTION
Fixes a corner case where we're joining `x : ty1` and `x : ty2` and it
turns out `ty1` and `ty2` are both aliases that canonicalize to `x`.
We were producing `x = x` in that case, which is invalid. The correct
behavior is to drop `x` since it's effectively unknown.