### PR TITLE
Replace "reraise" by a proper "raise_with_backtrace"

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -712,8 +712,6 @@ let close_switch acc env scrutinee (sw : IR.switch)
         untag ~body ~free_names_of_body:Unknown
       |> Expr_with_acc.create_let
 
-external reraise : exn -> 'a = "%reraise"
-
 let close_one_function acc ~external_env ~by_closure_id decl
       ~var_within_closures_from_idents ~closure_ids_from_idents
       function_declarations =
@@ -817,6 +815,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
   let acc, body =
     try body acc closure_env
     with Misc.Fatal_error -> begin
+      let bt = Printexc.get_raw_backtrace () in
       Format.eprintf "\n%sContext is:%s closure converting \
         function@ with [our_let_rec_ident] %a (closure ID %a)"(* @ \ *)
         (* and body:@ %a *)
@@ -825,7 +824,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
         Ident.print our_let_rec_ident
         Closure_id.print closure_id;
         (* print body *)
-      reraise Misc.Fatal_error
+      Printexc.raise_with_backtrace Misc.Fatal_error bt
     end
   in
   let contains_subfunctions = Acc.seen_a_function acc in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -420,8 +420,6 @@ let dacc_inside_function context ~used_closure_vars ~shareable_constants
   |> DA.with_shareable_constants ~shareable_constants
   |> DA.with_used_closure_vars ~used_closure_vars
 
-external reraise : exn -> 'a = "%reraise"
-
 type simplify_function_result = {
   new_code_id : Code_id.t;
   code : Rebuilt_static_const.t;
@@ -547,6 +545,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
           end;
           params_and_body, dacc_after_body, free_names_of_code, uacc
         | exception Misc.Fatal_error ->
+          let bt = Printexc.get_raw_backtrace () in
           Format.eprintf "\n%sContext is:%s simplifying function \
               with closure ID %a,@ params %a,@ return continuation %a,@ \
               exn continuation %a,@ my_closure %a,@ body:@ %a@ \
@@ -560,7 +559,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
             Variable.print my_closure
             Expr.print body
             DA.print dacc;
-          reraise Misc.Fatal_error)
+          Printexc.raise_with_backtrace Misc.Fatal_error bt)
   in
   let cost_metrics = UA.cost_metrics uacc_after_upwards_traversal in
   let old_code_id = code_id in

--- a/middle_end/flambda2/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda2/simplify/typing_helpers/continuation_uses.ml
@@ -44,8 +44,6 @@ let print ppf { continuation; arity; uses; } =
     Flambda_arity.print arity
     (Format.pp_print_list ~pp_sep:Format.pp_print_space U.print) uses
 
-external reraise : exn -> 'a = "%reraise"
-
 let add_use t kind ~env_at_use id ~arg_types =
   try
     let arity = T.arity_of_list arg_types in
@@ -60,6 +58,7 @@ let add_use t kind ~env_at_use id ~arg_types =
       uses = use :: t.uses;
     }
   with Misc.Fatal_error -> begin
+    let bt = Printexc.get_raw_backtrace () in
     Format.eprintf "\n%sContext is:%s adding use of %a with \
           arg types@ (%a);@ existing uses:@ %a; environment:@ %a"
       (Flambda_colours.error ())
@@ -68,7 +67,7 @@ let add_use t kind ~env_at_use id ~arg_types =
       (Format.pp_print_list ~pp_sep:Format.pp_print_space T.print) arg_types
       print t
       DE.print env_at_use;
-    reraise Misc.Fatal_error
+    Printexc.raise_with_backtrace Misc.Fatal_error bt
   end
 
 let union t1 t2 =

--- a/middle_end/flambda2/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env.rec.ml
@@ -1282,8 +1282,6 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params
   in
   add_env_extension_from_level definition_typing_env level
 
-external reraise : exn -> 'a = "%reraise"
-
 let type_simple_in_term_exn t ?min_name_mode simple =
   (* If [simple] is a variable then it should not come from a missing .cmx
      file, since this function is only used for typing variables in terms,
@@ -1347,11 +1345,12 @@ let type_simple_in_term_exn t ?min_name_mode simple =
       ~min_name_mode ~min_binding_time
   with
   | exception Misc.Fatal_error ->
+    let bt = Printexc.get_raw_backtrace () in
     Format.eprintf "\n%sContext is:%s typing environment@ %a\n"
       (Flambda_colours.error ())
       (Flambda_colours.normal ())
       print t;
-    reraise Misc.Fatal_error
+    Printexc.raise_with_backtrace Misc.Fatal_error bt
   | alias -> Type_grammar.alias_type_of kind alias
 
 let get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
@@ -1427,11 +1426,12 @@ let get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
       ~min_name_mode ~min_binding_time
   with
   | exception Misc.Fatal_error ->
+    let bt = Printexc.get_raw_backtrace () in
     Format.eprintf "\n%sContext is:%s typing environment@ %a\n"
       (Flambda_colours.error ())
       (Flambda_colours.normal ())
       print t;
-    reraise Misc.Fatal_error
+    Printexc.raise_with_backtrace Misc.Fatal_error bt
   | alias -> alias
 
 let get_alias_then_canonical_simple_exn t ?min_name_mode


### PR DESCRIPTION
In practice, the calls to Format were often enough to clobber the backtrace and lose the original backtrace. With this patch, the backtrace handling is now explicit and should guarantee that the correct backtrace if kept and printed.