### PR TITLE
More precise tracking of symbol projections in data_flow

### DIFF
--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -191,11 +191,8 @@ let record_var_binding var name_occurrences ~generate_phantom_lets t =
     { elt with bindings; used_in_handler; }
   )
 
-let record_symbol_projection var symbol t =
+let record_symbol_projection var name_occurrences t =
   update_top_of_stack ~t ~f:(fun elt ->
-    let name_occurrences =
-      Name_occurrences.singleton_symbol symbol Name_mode.normal
-    in
     let bindings =
       Name.Map.update (Name.var var) (function
         | None -> Some name_occurrences
@@ -204,8 +201,11 @@ let record_symbol_projection var symbol t =
             original
           else
             Misc.fatal_errorf
-              "The following projection has been bound to different symbols: %a"
+              "@[<v>The following projection has been bound to different symbols:\
+               %a@ previously bound to:@ %a@ and now to@ %a@]"
               Variable.print var
+              Name_occurrences.print prior_occurences
+              Name_occurrences.print name_occurrences
       ) elt.bindings
     in
     { elt with bindings; }

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -58,7 +58,7 @@ val record_var_binding
 
 val record_symbol_projection
    : Variable.t
-  -> Symbol.t
+  -> Name_occurrences.t
   -> t
   -> t
 (** Add a variable binding to the symbol.

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -156,7 +156,7 @@ let simplify_let ~simplify_expr ~simplify_toplevel dacc let_expr ~down_to_up =
                   (* Record all projections as potential dependencies. *)
                   Variable.Map.fold (fun var proj data_flow ->
                       Data_flow.record_symbol_projection var
-                        (Symbol_projection.symbol proj)
+                        (Symbol_projection.free_names proj)
                         data_flow)
                     (LC.symbol_projections lifted_constant)
                     data_flow

--- a/middle_end/flambda2/terms/symbol_projection.ml
+++ b/middle_end/flambda2/terms/symbol_projection.ml
@@ -97,8 +97,14 @@ let apply_renaming ({ symbol; projection = _; } as t) renaming =
   if symbol == symbol' then t
   else { t with symbol = symbol'; }
 
-let free_names { symbol; projection = _; } =
-  Name_occurrences.singleton_symbol symbol Name_mode.normal
+let free_names { symbol; projection; } =
+  let free_names =
+    Name_occurrences.singleton_symbol symbol Name_mode.normal
+  in
+  match projection with
+  | Block_load _ -> free_names
+  | Project_var { project_from = _; var; } ->
+    Name_occurrences.add_closure_var free_names var Name_mode.normal
 
 let all_ids_for_export { symbol; projection = _; } =
   Ids_for_export.singleton_symbol symbol


### PR DESCRIPTION
See commit message for more information.
This PR also fixes the free_names computation of symbol projections to be in line with what the free names of the projection primitive return (i.e. include the closure var in the free_names).

This should make it so that `ppx_tools` can now build.