### PR TITLE
Fix all_ids_for_export and apply_renaming in Aliases

### DIFF
--- a/middle_end/flambda2/basic/coercion.ml
+++ b/middle_end/flambda2/basic/coercion.ml
@@ -48,3 +48,10 @@ let compose_exn t1 ~then_:t2 =
   | Some t -> t
   | None ->
     Misc.fatal_errorf "Invalid composition: %a@ >>@ %a" print t1 print t2
+
+let all_ids_for_export t =
+  match t with
+  | Id -> Ids_for_export.empty
+  | Change_depth { from; to_; } ->
+    Ids_for_export.union (Rec_info_expr.all_ids_for_export from)
+      (Rec_info_expr.all_ids_for_export to_)

--- a/middle_end/flambda2/basic/coercion.mli
+++ b/middle_end/flambda2/basic/coercion.mli
@@ -17,6 +17,7 @@
 include module type of struct include Reg_width_things.Coercion end
 
 include Contains_names.S with type t := t
+include Contains_ids.S with type t := t
 
 val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/cmx/ids_for_export.mli
+++ b/middle_end/flambda2/cmx/ids_for_export.mli
@@ -50,6 +50,8 @@ val add_symbol : t -> Symbol.t -> t
 
 val add_name : t -> Name.t -> t
 
+val add_const : t -> Reg_width_things.Const.t -> t
+
 val add_simple : t -> Simple.t -> t
 
 val add_code_id : t -> Code_id.t -> t


### PR DESCRIPTION
These should now ensure we don't miss any names.  (There may be some redundant additions to the `Ids_for_export` structures, but better safe than sorry.)