### PR TITLE
Don't drop deleted code ids

### DIFF
--- a/middle_end/flambda2/basic/or_deleted.ml
+++ b/middle_end/flambda2/basic/or_deleted.ml
@@ -24,3 +24,9 @@ let print print_contents ppf t =
   match t with
   | Present contents -> print_contents ppf contents
   | Deleted -> Format.pp_print_string ppf "Deleted"
+
+let equal equal_contents t1 t2 =
+  match t1, t2 with
+  | Present contents1, Present contents2 -> equal_contents contents1 contents2
+  | Deleted, Deleted -> true
+  | Present _, Deleted | Deleted, Present _ -> false

--- a/middle_end/flambda2/basic/or_deleted.mli
+++ b/middle_end/flambda2/basic/or_deleted.mli
@@ -21,3 +21,5 @@ type 'a t =
   | Deleted
 
 val print : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -49,7 +49,10 @@ val find_code : t -> Code_id.t -> Flambda.Code.t option
 
 val find_code_if_not_imported : t -> Code_id.t -> Flambda.Code.t option
 
-val find_calling_convention : t -> Code_id.t -> Calling_convention.t
+val find_calling_convention
+   : t
+  -> Code_id.t
+  -> Calling_convention.t Or_deleted.t
 
 val remove_unreachable : t -> reachable_names:Name_occurrences.t -> t
 

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -294,9 +294,7 @@ module Group = struct
         | Non_code_not_rebuilt _ | Code_not_rebuilt _ -> None)
     in
     consts
-    |> List.filter_map (fun code ->
-      if Code.is_deleted code then None
-      else Some (Code.code_id code, code))
+    |> List.map (fun code -> (Code.code_id code, code))
     |> Code_id.Map.of_list
 
   let function_params_and_body_for_code_not_rebuilt =

--- a/middle_end/flambda2/to_cmm/un_cps.ml
+++ b/middle_end/flambda2/to_cmm/un_cps.ml
@@ -1377,7 +1377,8 @@ and let_dynamic_set_of_closures env res body closure_vars
   let l, env, effs =
     fill_layout decl_map layout.startenv elts env effs [] 0 layout.slots
   in
-  let csoc = C.make_closure_block l in
+  let has_zero_closures = Closure_id.Lmap.is_empty decls in
+  let csoc = C.make_closure_block l ~has_zero_closures in
   (* Create a variable to hold the set of closure *)
   let soc_var = Variable.create "*set_of_closures*" in
   let env = Env.bind_variable env soc_var effs false csoc in

--- a/middle_end/flambda2/to_cmm/un_cps_env.ml
+++ b/middle_end/flambda2/to_cmm/un_cps_env.ml
@@ -188,7 +188,11 @@ let exn_cont env = env.k_exn
 (* Function info *)
 
 let get_function_info env code_id =
-  Exported_code.find_calling_convention env.functions_info code_id
+  match Exported_code.find_calling_convention env.functions_info code_id with
+  | Present calling_convention -> calling_convention
+  | Deleted ->
+    Misc.fatal_errorf "No calling convention available for deleted code %a"
+      Code_id.print code_id
 
 let get_func_decl_params_arity t code_id =
   let info = get_function_info t code_id in

--- a/middle_end/flambda2/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2/to_cmm/un_cps_helper.ml
@@ -294,10 +294,14 @@ let make_block ?(dbg=Debuginfo.none) kind args =
     end;
     make_array ~dbg Naked_floats args
 
-let make_closure_block ?(dbg=Debuginfo.none) l =
+let make_closure_block ?(dbg=Debuginfo.none) l ~has_zero_closures =
   assert (List.compare_length_with l 0 > 0);
-  let tag = Tag.(to_int closure_tag) in
-  make_alloc dbg tag l
+  (* Blocks consisting of only an environment must not have tag Closure_tag *)
+  if has_zero_closures then
+    make_alloc dbg 0 l
+  else
+    let tag = Tag.(to_int closure_tag) in
+    make_alloc dbg tag l
 
 (* Block access *)
 

--- a/middle_end/flambda2/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda2/to_cmm/un_cps_helper.mli
@@ -93,7 +93,8 @@ val make_block :
 (** Create a block using the given fields. *)
 
 val make_closure_block :
-  ?dbg:Debuginfo.t -> Cmm.expression list -> Cmm.expression
+  ?dbg:Debuginfo.t -> Cmm.expression list ->
+  has_zero_closures:bool -> Cmm.expression
 (** Create a closure block. *)
 
 (** {2 Boxed numbers} *)

--- a/middle_end/flambda2/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda2/to_cmm/un_cps_static.ml
@@ -171,12 +171,17 @@ let rec static_set_of_closures env symbs set prev_update =
     | [] -> []
     (* Regular case. *)
     | _ ->
-      let header = C.cint (C.black_closure_header length) in
+      let header =
+        (* Blocks consisting of only an environment must not have tag
+           Closure_tag. *)
+        if Closure_id.Map.is_empty decls then C.black_block_header 0 length
+        else C.black_closure_header length
+      in
       let sdef = match !clos_symb with
         | None -> []
         | Some s -> C.define_symbol ~global:false (symbol s)
       in
-      header :: sdef @ l
+      (C.cint header) :: sdef @ l
   in
   env, block, updates
 


### PR DESCRIPTION
A deleted code id can still appear in a set of closures. In this case,
we know that the closure won't actually be invoked, but in general we
can't remove it from the set because it might be the only closure and
we can't have a set of zero closures. (A set of closures surviving
despite pointing entirely to deleted code would be surprising, but in
principle it's possible if something manages to use the environment.)

Since it's going to appear in the set of closures, we need the code id
to end up in the exported code. We put in a dummy calling convention,
since it's never going to be called anyway.