### PR TITLE
Install dummy ocamlprof

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -235,6 +235,7 @@ config_files: ocaml-stage1-config.status
 install: stage2
 	mkdir -p $(prefix)
 	rsync --copy-links --chmod=u+rw,go+r -r $(stage2_prefix)/bin $(prefix)
+	cp scripts/dummy-ocamlprof.sh $(prefix)/bin/ocamlprof
 	rsync --copy-links --chmod=u+rw,go+r -r $(stage2_prefix)/lib $(prefix)
 	rm -f $(prefix)/bin/ocamllex
 	ln -s $(prefix)/bin/ocamllex.opt $(prefix)/bin/ocamllex

--- a/scripts/dummy-ocamlprof.sh
+++ b/scripts/dummy-ocamlprof.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "The Flambda backend does not support the ocamlprof tool."
+exit 1


### PR DESCRIPTION
This should hopefully allow a number of OPAM packages to build, that I suspect don't actually need `ocamlprof`, but are using an old configuration script that looks for it.