### PR TITLE
Drop equations involving only imported variables

### DIFF
--- a/middle_end/flambda2/basic/name.ml
+++ b/middle_end/flambda2/basic/name.ml
@@ -85,7 +85,7 @@ let compilation_unit t =
   ~var:(fun var -> Variable.compilation_unit var)
   ~symbol:(fun sym -> Symbol.compilation_unit sym)
 
-let is_foreign t =
+let is_imported t =
   let current = Compilation_unit.get_current_exn () in
   not (Compilation_unit.equal current (compilation_unit t))
 

--- a/middle_end/flambda2/basic/name.ml
+++ b/middle_end/flambda2/basic/name.ml
@@ -85,6 +85,10 @@ let compilation_unit t =
   ~var:(fun var -> Variable.compilation_unit var)
   ~symbol:(fun sym -> Symbol.compilation_unit sym)
 
+let is_foreign t =
+  let current = Compilation_unit.get_current_exn () in
+  not (Compilation_unit.equal current (compilation_unit t))
+
 let rename t =
   pattern_match t
     ~var:(fun v -> var (Variable.rename v))

--- a/middle_end/flambda2/basic/name.mli
+++ b/middle_end/flambda2/basic/name.mli
@@ -50,6 +50,8 @@ val must_be_symbol : t -> Symbol.t
 
 val compilation_unit : t -> Compilation_unit.t
 
+val is_foreign : t -> bool
+
 val must_be_var_opt : t -> Variable.t option
 
 val must_be_symbol_opt : t -> Symbol.t option

--- a/middle_end/flambda2/basic/name.mli
+++ b/middle_end/flambda2/basic/name.mli
@@ -50,7 +50,7 @@ val must_be_symbol : t -> Symbol.t
 
 val compilation_unit : t -> Compilation_unit.t
 
-val is_foreign : t -> bool
+val is_imported : t -> bool
 
 val must_be_var_opt : t -> Variable.t option
 

--- a/middle_end/flambda2/basic/simple.ml
+++ b/middle_end/flambda2/basic/simple.ml
@@ -51,6 +51,11 @@ let [@inline always] is_symbol t =
 let [@inline always] is_const t =
   pattern_match t ~name:(fun _ ~coercion:_ -> false) ~const:(fun _ -> true)
 
+let is_foreign_or_constant t =
+  pattern_match t
+    ~const:(fun _ -> true)
+    ~name:(fun name ~coercion:_ -> Name.is_foreign name)
+
 let pattern_match' t ~var ~symbol ~const =
   pattern_match t ~const
     ~name:(fun name -> Name.pattern_match name ~var ~symbol)

--- a/middle_end/flambda2/basic/simple.ml
+++ b/middle_end/flambda2/basic/simple.ml
@@ -51,10 +51,10 @@ let [@inline always] is_symbol t =
 let [@inline always] is_const t =
   pattern_match t ~name:(fun _ ~coercion:_ -> false) ~const:(fun _ -> true)
 
-let is_foreign_or_constant t =
+let is_imported_or_constant t =
   pattern_match t
     ~const:(fun _ -> true)
-    ~name:(fun name ~coercion:_ -> Name.is_foreign name)
+    ~name:(fun name ~coercion:_ -> Name.is_imported name)
 
 let pattern_match' t ~var ~symbol ~const =
   pattern_match t ~const

--- a/middle_end/flambda2/basic/simple.mli
+++ b/middle_end/flambda2/basic/simple.mli
@@ -72,7 +72,7 @@ val is_symbol : t -> bool
 
 val is_var : t -> bool
 
-val is_foreign_or_constant : t -> bool
+val is_imported_or_constant : t -> bool
 
 val free_names_in_types : t -> Name_occurrences.t
 

--- a/middle_end/flambda2/basic/simple.mli
+++ b/middle_end/flambda2/basic/simple.mli
@@ -72,6 +72,8 @@ val is_symbol : t -> bool
 
 val is_var : t -> bool
 
+val is_foreign_or_constant : t -> bool
+
 val free_names_in_types : t -> Name_occurrences.t
 
 val pattern_match'

--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -243,7 +243,15 @@ end = struct
     in
     let all = Map_to_canonical.union t1.all t2.all in
     let t = { aliases; all; } in
-    invariant t;
+    (* CR vlaviron: Here we're merging structures that can come from different
+       compilation units. In particular, if one variable has mode Normal in one
+       of the units, then in all the other ones it will have mode In_types.
+       The proper way to handle that might be to move all variables to mode
+       In_types on export or import (there's code in Typing_env.find that
+       takes care of returning the correct mode to the outside already, so it's
+       mostly an internal issue).
+       For now, as a quick fix the invariant checks are disabled here. *)
+    (* invariant t; *)
     t
 
   let compose { aliases; all; } ~then_ =

--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -1298,8 +1298,29 @@ let clean_for_export
         aliases_of_canonical_names;
         aliases_of_consts;
         binding_times_and_modes; } =
-  (* CR vlaviron: This function is kept as a reminder that we'd like
-     to remove unreachable entries at some point. *)
+  (* CR vlaviron: We'd like to remove unreachable entries at some point. *)
+  let canonical_elements =
+    (* At this point, we know that we're never going to add new aliases to
+       this structure, so it's fine if we break the invariant that all
+       non-canonical elements are in the [canonical_elements] map.
+       Note that this is only needed because the [merge] function uses
+       [Map.disjoint_union], to avoid an expensive reconstruction of the
+       whole structure. We ensure this by making sure that all keys in the
+       map are bound in the compilation unit the structure was created for.
+       Either a better handling of packs (removing the need for merging units)
+       or a more comprehensive merge function would remove the need for this
+       filter.
+
+       Aliases between imported names can be brought in the current scope
+       when an extension stored in a Row_like or Variant type is opened.
+       In addition, it would be possible to add aliases when simplifying
+       the physical equality primitive, although at the time of writing
+       this is not implemented yet.
+    *)
+    Name.Map.filter (fun name _canonical ->
+        not (Name.is_imported name))
+      canonical_elements
+  in
   { canonical_elements;
     aliases_of_canonical_names;
     aliases_of_consts;

--- a/middle_end/flambda2/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env.rec.ml
@@ -940,8 +940,6 @@ let invariant_for_new_equation (t:t) name ty =
     end
   end
 
-exception Drop_equation
-
 let rec add_equation0 (t:t) name ty =
   if Flambda_features.Debug.concrete_types_only_on_canonicals () then begin
     let is_concrete =
@@ -999,7 +997,7 @@ let rec add_equation0 (t:t) name ty =
   (* invariant_for_aliases res; *)
   res
 
-and add_equation_exn t name ty =
+and add_equation t name ty =
   if Flambda_features.check_invariants () then begin
     let existing_ty = find t name None in
     if not (K.equal (Type_grammar.kind existing_ty) (Type_grammar.kind ty))
@@ -1052,22 +1050,6 @@ and add_equation_exn t name ty =
          any name modes). *)
       let canonical = Aliases.get_canonical_ignoring_name_mode aliases name in
       canonical, t, ty
-    | alias_of when Simple.is_foreign_or_constant alias_of
-                 && Name.is_foreign name ->
-      (* At the point of writing we do not properly merge alias structures in
-         packs, and rely on the domains of their [canonical_elements] maps
-         being disjoint. In practice, this means that this map must only have
-         elements from the current compilation unit as keys.
-         It's already impossible for constants to end up as keys, as they're
-         always canonical. The same also holds for symbols.
-         A foreign variable can't alias to a non-foreign symbol either, but
-         the implementation doesn't know it; fortunately until we start
-         supporting arbitrary aliases (for example, as created by the physical
-         equality primitive), it's impossible to reach this case in practice.
-         So all that remains are aliases between a foreign variable and
-         either a constant or a foreign name.
-         In these cases we drop the equation. *)
-      raise Drop_equation
     | alias_of ->
       (* Forget where [name] and [alias_of] came from---our job is now to
          record that they're equal. In general, they have canonical expressions
@@ -1144,10 +1126,6 @@ and add_equation_exn t name ty =
     add_equation0 t name ty
   in
   Simple.pattern_match bare_lhs ~name ~const:(fun _ -> t)
-
-and add_equation t name ty =
-  try add_equation_exn t name ty with
-  | Drop_equation -> t
 
 and add_env_extension t (env_extension : Typing_env_extension.t) =
   Typing_env_extension.fold


### PR DESCRIPTION
See the comment added to `Typing_env.add_equation` for details.

Note that the use of an exception is a hack to avoid re-indenting significant amounts of code. I can switch it to a less hackish patch after reviews.

Preliminary tests on the `nocrypto` package show that it fixes the `disjoint_map` error when loading packs.