### PR TITLE
Remove `can_raise_interproc` from `Cfg.basic_block`

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -37,7 +37,6 @@ type basic_block =
     trap_depth : int;
     mutable exns : Label.Set.t;
     mutable can_raise : bool;
-    mutable can_raise_interproc : bool;
     mutable is_trap_handler : bool;
     mutable dead : bool
   }
@@ -130,6 +129,9 @@ let get_block_exn t label =
   | exception Not_found ->
       Misc.fatal_errorf "Cfg.get_block_exn: block %d not found" label
   | block -> block
+
+let can_raise_interproc block =
+  block.can_raise && (block.trap_depth = 1)
 
 let fun_name t = t.fun_name
 

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -100,6 +100,9 @@ val replace_successor_labels :
   unit
 
 val can_raise_interproc : basic_block -> bool
+(** Returns [true] iff the passed block raises an exn that is not handled in
+    this function, [can_raise_interproc] implies [can_raise] but not necessarily
+    vice versa. *)
 
 val mem_block : t -> Label.t -> bool
 

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -50,10 +50,6 @@ type basic_block =
     mutable can_raise : bool;
         (** Does this block contain any instruction that can raise, such as a
             call, bounds check, allocation, or an explicit [raise]? *)
-    mutable can_raise_interproc : bool;
-        (** This block raises an exn that is not handled in this function,
-            [can_raise_interproc] implies [can_raise] but not necessarily
-            vice versa. *)
     mutable is_trap_handler : bool;
         (** Is this block a trap handler (i.e. is it an exn successor of
             another block) or not? *)
@@ -102,6 +98,8 @@ val replace_successor_labels :
   basic_block ->
   f:(Label.t -> Label.t) ->
   unit
+
+val can_raise_interproc : basic_block -> bool
 
 val mem_block : t -> Label.t -> bool
 

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -134,7 +134,7 @@ let print_dot t ?(show_instr = true) ?(show_exn = true) ?annotate_block
           Printf.fprintf oc "%s->%s [style=dashed %s]\n" (name label)
             (name l) (annotate_succ label l))
         (Cfg.successor_labels ~normal:false ~exn:true block);
-      if block.can_raise_interproc then
+      if Cfg.can_raise_interproc block then
         Printf.fprintf oc "%s->%s [style=dashed]\n" (name label)
           "placeholder" )
   in

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -315,7 +315,6 @@ let check_and_register_traps t =
      then it has a registered exn successor or interproc exn. *)
   let f _ (block : C.basic_block) =
     let n = Label.Set.cardinal block.exns in
-    assert ((not (Cfg.can_raise_interproc block)) || block.can_raise);
     assert ((not block.can_raise) || n > 0 || (Cfg.can_raise_interproc block))
   in
   C.iter_blocks t.cfg ~f


### PR DESCRIPTION
This pull request deletes the `can_raise_interproc` field
from the `Cfg.basic_block`, and replaces it with a function.
Indeed, it looks like the  following invariant holds:

    block.can_raise && (block.trap_depth = 1)

so there is no need to store the value.