### PR TITLE
Script comparing built and installed artifacts

### DIFF
--- a/tools/check_installed_tree.sh
+++ b/tools/check_installed_tree.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e -u -o pipefail
+
+prefix="$1"
+shift
+
+built=$(mktemp)
+installed=$(mktemp)
+
+trap "rm -f ${built} ${installed}" EXIT
+
+list_artifacts() {
+    directory="$1"
+    (cd "${directory}";
+     find . -type d \( -path ./compiler-libs -o -path ./dynlink/dynlink_compilerlibs \) -prune -false \
+          -o -name \*.cmi \
+          -o -name \*.cmt \
+          -o -name \*.cmti \
+          -o -name \*.cmx \
+         | xargs basename)
+}
+
+list_artifacts "_build0/stdlib" > "${built}"
+list_artifacts "_build0/otherlibs" >> "${built}"
+list_artifacts "${prefix}/lib/ocaml" > "${installed}"
+
+sort -o "${built}" "${built}"
+sort -o "${installed}" "${installed}"
+
+echo "Differences between built and installed artifacts:"
+diff "${built}" "${installed}" && echo "(none)"
+


### PR DESCRIPTION
This pull requests is in some sense a follow-up to #183.
It adds a shell script comparing the lists of built and installed
artifacts. The idea is to eventually have the following call at
the end of the `ci` target:

    ./tools/check_installed_tree.sh _install $prefix
