### PR TITLE
Native toplevel enhancements to match bytecode toplevel

### DIFF
--- a/native_toplevel/opttopdirs.ml
+++ b/native_toplevel/opttopdirs.ml
@@ -73,6 +73,38 @@ let _ = Hashtbl.add directive_table "cd" (Directive_string dir_cd)
 
 (* Load in-core a .cmxs file *)
 
+let load_file_exn ppf name0 =
+  let name =
+    try Some (Load_path.find name0)
+    with Not_found -> None
+  in
+  match name with
+  | None ->
+    let msg = Format.asprintf "File not found: %s@." name0 in
+    failwith msg
+  | Some name ->
+    let fn,tmp =
+      if Filename.check_suffix name ".cmx" || Filename.check_suffix name ".cmxa"
+      then
+        let cmxs = Filename.temp_file "caml" ".cmxs" in
+        Asmlink.link_shared ~ppf_dump:ppf [name] cmxs;
+        cmxs,true
+      else
+        name,false
+    in
+    let res =
+      try
+        Dynlink.loadfile fn;
+        Result.Ok ()
+      with
+      | Dynlink.Error (Module_already_loaded _) -> Result.Ok ()
+      | exn -> Result.Error exn
+    in
+    if tmp then (try Sys.remove fn with Sys_error _ -> ());
+    match res with
+    | Ok () -> ()
+    | Error exn -> raise exn
+
 let load_file ppf name0 =
   let name =
     try Some (Load_path.find name0)
@@ -107,8 +139,9 @@ let load_file ppf name0 =
     if tmp then (try Sys.remove fn with Sys_error _ -> ());
     success
 
-
 let dir_load ppf name = ignore (load_file ppf name)
+
+let dir_load_exn name = load_file_exn name
 
 let _ = Hashtbl.add directive_table "load" (Directive_string (dir_load std_out))
 
@@ -216,3 +249,13 @@ let _ =
 
   Hashtbl.add directive_table "warn_error"
              (Directive_string (parse_warnings std_out true))
+
+let section_options = "Compiler options"
+
+let _ = add_directive "ppx"
+    (Directive_string(fun s -> Clflags.all_ppx := s :: !Clflags.all_ppx))
+    {
+      section = section_options;
+      doc = "After parsing, pipe the abstract \
+          syntax tree through the preprocessor command.";
+    }

--- a/native_toplevel/opttopdirs.ml
+++ b/native_toplevel/opttopdirs.ml
@@ -73,38 +73,6 @@ let _ = Hashtbl.add directive_table "cd" (Directive_string dir_cd)
 
 (* Load in-core a .cmxs file *)
 
-let load_file_exn ppf name0 =
-  let name =
-    try Some (Load_path.find name0)
-    with Not_found -> None
-  in
-  match name with
-  | None ->
-    let msg = Format.asprintf "File not found: %s@." name0 in
-    failwith msg
-  | Some name ->
-    let fn,tmp =
-      if Filename.check_suffix name ".cmx" || Filename.check_suffix name ".cmxa"
-      then
-        let cmxs = Filename.temp_file "caml" ".cmxs" in
-        Asmlink.link_shared ~ppf_dump:ppf [name] cmxs;
-        cmxs,true
-      else
-        name,false
-    in
-    let res =
-      try
-        Dynlink.loadfile fn;
-        Result.Ok ()
-      with
-      | Dynlink.Error (Module_already_loaded _) -> Result.Ok ()
-      | exn -> Result.Error exn
-    in
-    if tmp then (try Sys.remove fn with Sys_error _ -> ());
-    match res with
-    | Ok () -> ()
-    | Error exn -> raise exn
-
 let load_file ppf name0 =
   let name =
     try Some (Load_path.find name0)
@@ -140,8 +108,6 @@ let load_file ppf name0 =
     success
 
 let dir_load ppf name = ignore (load_file ppf name)
-
-let dir_load_exn name = load_file_exn name
 
 let _ = Hashtbl.add directive_table "load" (Directive_string (dir_load std_out))
 

--- a/native_toplevel/opttopdirs.mli
+++ b/native_toplevel/opttopdirs.mli
@@ -22,7 +22,6 @@ val dir_directory : string -> unit
 val dir_remove_directory : string -> unit
 val dir_cd : string -> unit
 val dir_load : formatter -> string -> unit
-val dir_load_exn : formatter -> string -> unit
 val dir_use : formatter -> string -> unit
 val dir_use_output : formatter -> string -> unit
 val dir_install_printer : formatter -> Longident.t -> unit

--- a/native_toplevel/opttopdirs.mli
+++ b/native_toplevel/opttopdirs.mli
@@ -22,6 +22,7 @@ val dir_directory : string -> unit
 val dir_remove_directory : string -> unit
 val dir_cd : string -> unit
 val dir_load : formatter -> string -> unit
+val dir_load_exn : formatter -> string -> unit
 val dir_use : formatter -> string -> unit
 val dir_use_output : formatter -> string -> unit
 val dir_install_printer : formatter -> Longident.t -> unit

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -62,6 +62,10 @@ type directive_fun =
    | Directive_ident of (Longident.t -> unit)
    | Directive_bool of (bool -> unit)
 
+type directive_info = {
+  section: string;
+  doc: string;
+}
 
 let remembered = ref Ident.empty
 
@@ -285,7 +289,7 @@ let load_lambda ppf ~module_ident ~required_globals lam size =
 let pr_item =
   Printtyp.print_items
     (fun env -> function
-      | Sig_value(id, {val_kind = Val_reg; val_type}, _) ->
+       | Sig_value(id, {val_kind = Val_reg; val_type; _}, _) ->
           Some (outval_of_value env (toplevel_value id) val_type)
       | _ -> None
     )
@@ -307,7 +311,14 @@ let print_exception_outcome ppf exn =
 (* The table of toplevel directives.
    Filled by functions from module topdirs. *)
 
-let directive_table = (Hashtbl.create 13 : (string, directive_fun) Hashtbl.t)
+let directive_table = (Hashtbl.create 23 : (string, directive_fun) Hashtbl.t)
+
+let directive_info_table =
+  (Hashtbl.create 23 : (string, directive_info) Hashtbl.t)
+
+let add_directive name dir_fun dir_info =
+  Hashtbl.add directive_table name dir_fun;
+  Hashtbl.add directive_info_table name dir_info
 
 (* Execute a toplevel phrase *)
 
@@ -398,7 +409,7 @@ let execute_phrase print_outcome ppf phr =
       with x ->
         toplevel_env := oldenv; raise x
       end
-  | Ptop_dir {pdir_name = {Location.txt = dir_name}; pdir_arg } ->
+  | Ptop_dir {pdir_name = {Location.txt = dir_name; _}; pdir_arg; _ } ->
       let d =
         try Some (Hashtbl.find directive_table dir_name)
         with Not_found -> None
@@ -410,8 +421,8 @@ let execute_phrase print_outcome ppf phr =
       | Some d ->
           match d, pdir_arg with
           | Directive_none f, None -> f (); true
-          | Directive_string f, Some {pdira_desc = Pdir_string s} -> f s; true
-          | Directive_int f, Some {pdira_desc = Pdir_int (n,None)} ->
+          | Directive_string f, Some {pdira_desc = Pdir_string s; _} -> f s; true
+          | Directive_int f, Some {pdira_desc = Pdir_int (n,None); _} ->
              begin match Int_literal_converter.int n with
              | n -> f n; true
              | exception _ ->
@@ -420,12 +431,12 @@ let execute_phrase print_outcome ppf phr =
                        dir_name;
                false
              end
-          | Directive_int _, Some {pdira_desc = Pdir_int (_, Some _)} ->
+          | Directive_int _, Some {pdira_desc = Pdir_int (_, Some _); _} ->
               fprintf ppf "Wrong integer literal for directive `%s'.@."
                 dir_name;
               false
-          | Directive_ident f, Some {pdira_desc = Pdir_ident lid} -> f lid; true
-          | Directive_bool f, Some {pdira_desc = Pdir_bool b} -> f b; true
+          | Directive_ident f, Some {pdira_desc = Pdir_ident lid; _} -> f lid; true
+          | Directive_bool f, Some {pdira_desc = Pdir_bool b; _} -> f b; true
           | _ ->
               fprintf ppf "Wrong type of argument for directive `%s'.@."
                 dir_name;

--- a/native_toplevel/opttoploop.mli
+++ b/native_toplevel/opttoploop.mli
@@ -37,8 +37,18 @@ type directive_fun =
    | Directive_ident of (Longident.t -> unit)
    | Directive_bool of (bool -> unit)
 
+type directive_info = {
+  section: string;
+  doc: string;
+}
+
+val add_directive : string -> directive_fun -> directive_info -> unit
+
 val directive_table : (string, directive_fun) Hashtbl.t
         (* Table of known directives, with their execution function *)
+
+val directive_info_table : (string, directive_info) Hashtbl.t
+
 val toplevel_env : Env.t ref
         (* Typing environment for the toplevel *)
 val initialize_toplevel_env : unit -> unit


### PR DESCRIPTION
These various enhancements are needed until the upstream bytecode+native toplevel unification patch has been merged into the Flambda backend.  This is work by @nathanreb for the mdx+JIT project.