### PR TITLE
Add dummy ocamlcp

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -236,6 +236,7 @@ install: stage2
 	mkdir -p $(prefix)
 	rsync --copy-links --chmod=u+rw,go+r -r $(stage2_prefix)/bin $(prefix)
 	cp scripts/dummy-ocamlprof.sh $(prefix)/bin/ocamlprof
+	cp scripts/dummy-ocamlcp.sh $(prefix)/bin/ocamlcp
 	rsync --copy-links --chmod=u+rw,go+r -r $(stage2_prefix)/lib $(prefix)
 	rm -f $(prefix)/bin/ocamllex
 	ln -s $(prefix)/bin/ocamllex.opt $(prefix)/bin/ocamllex

--- a/scripts/dummy-ocamlcp.sh
+++ b/scripts/dummy-ocamlcp.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "The Flambda backend does not support the ocamlcp tool."
+exit 1


### PR DESCRIPTION
Essentially the same as #184 but for `ocamlcp`, which it seems is required for the configure script of `rml` to work (cf http://check.ocamllabs.io:8081/log/1629759966-3a6c6fae13d55acd1b3d775e32f6b15f039aea87/4.12+flambda2/bad/rml.1.09.07 ).