### PR TITLE
Deliver asynchronous exceptions to the previous frame

### DIFF
--- a/ocaml/otherlibs/systhreads/st_stubs.c
+++ b/ocaml/otherlibs/systhreads/st_stubs.c
@@ -78,6 +78,8 @@ struct caml_thread_struct {
   uintnat last_retaddr;     /* Saved value of Caml_state->last_return_address */
   value * gc_regs;          /* Saved value of Caml_state->gc_regs */
   char * exception_pointer; /* Saved value of Caml_state->exception_pointer */
+  char * async_exception_pointer;
+                       /* Saved value of Caml_state->async_exception_pointer */
   struct caml__roots_block * local_roots; /* Saved value of local_roots */
   struct caml_local_arenas * local_arenas;
   struct longjmp_buffer * exit_buf; /* For thread exit */
@@ -182,6 +184,7 @@ Caml_inline void caml_thread_save_runtime_state(void)
   curr_thread->last_retaddr = Caml_state->last_return_address;
   curr_thread->gc_regs = Caml_state->gc_regs;
   curr_thread->exception_pointer = Caml_state->exception_pointer;
+  curr_thread->async_exception_pointer = Caml_state->async_exception_pointer;
   curr_thread->local_arenas = caml_get_local_arenas();
 #else
   curr_thread->stack_low = Caml_state->stack_low;
@@ -206,6 +209,7 @@ Caml_inline void caml_thread_restore_runtime_state(void)
   Caml_state->last_return_address = curr_thread->last_retaddr;
   Caml_state->gc_regs = curr_thread->gc_regs;
   Caml_state->exception_pointer = curr_thread->exception_pointer;
+  Caml_state->async_exception_pointer = curr_thread->async_exception_pointer;
   caml_set_local_arenas(curr_thread->local_arenas);
 #else
   Caml_state->stack_low = curr_thread->stack_low;
@@ -334,6 +338,7 @@ static caml_thread_t caml_thread_new_info(void)
   th->top_of_stack = NULL;
   th->last_retaddr = 1;
   th->exception_pointer = NULL;
+  th->async_exception_pointer = NULL;
   th->local_roots = NULL;
   th->local_arenas = NULL;
   th->exit_buf = NULL;

--- a/ocaml/runtime/amd64.S
+++ b/ocaml/runtime/amd64.S
@@ -575,8 +575,10 @@ FUNCTION(G(caml_start_program))
         LEA_VAR(caml_program, %r12)
     /* Common code for caml_start_program and caml_callback* */
 LBL(caml_start_program):
+    /* Save the current async exception pointer */
+        pushq   Caml_state(async_exception_pointer); CFI_ADJUST (8)
+        /* stack now 16-aligned */
     /* Build a callback link */
-        subq    $8, %rsp; CFI_ADJUST (8)        /* stack 16-aligned */
         pushq   Caml_state(gc_regs); CFI_ADJUST(8)
         pushq   Caml_state(last_return_address); CFI_ADJUST(8)
         pushq   Caml_state(bottom_of_stack); CFI_ADJUST(8)
@@ -587,6 +589,8 @@ LBL(caml_start_program):
         pushq   %r13; CFI_ADJUST(8)
         pushq   Caml_state(exception_pointer); CFI_ADJUST(8)
         movq    %rsp, Caml_state(exception_pointer)
+    /* Register the same exception handler for async exceptions */
+        movq    %rsp, Caml_state(async_exception_pointer)
     /* Call the OCaml code */
         call    *%r12
 LBL(107):
@@ -600,7 +604,8 @@ LBL(109):
         popq    Caml_state(bottom_of_stack); CFI_ADJUST(-8)
         popq    Caml_state(last_return_address); CFI_ADJUST(-8)
         popq    Caml_state(gc_regs); CFI_ADJUST(-8)
-        addq    $8, %rsp; CFI_ADJUST (-8);
+    /* Restore the asynchronous exception pointer. */
+        popq    Caml_state(async_exception_pointer); CFI_ADJUST(-8)
     /* Restore callee-save registers. */
         POP_CALLEE_SAVE_REGS
     /* Return to caller. */
@@ -686,6 +691,18 @@ LBL(112):
         ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_raise_exception))
+
+/* Raise an async exception from C */
+
+FUNCTION(G(caml_raise_async_exception))
+CFI_STARTPROC
+        movq    C_ARG_1, %r14   /* Caml_state */
+        /* %rax is about to be clobbered anyway */
+        movq    Caml_state(async_exception_pointer), %rax
+        movq    %rax, Caml_state(exception_pointer)
+        jmp     G(caml_raise_exception)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_raise_async_exception))
 
 /* Raise a Stack_overflow exception on return from segv_handler()
    (in runtime/signals_nat.c).  On entry, the stack is full, so we

--- a/ocaml/runtime/caml/domain_state.tbl
+++ b/ocaml/runtime/caml/domain_state.tbl
@@ -20,6 +20,8 @@ DOMAIN_STATE(value*, young_limit)
 
 DOMAIN_STATE(char*, exception_pointer)
 /* Exception pointer that points into the current stack */
+DOMAIN_STATE(char*, async_exception_pointer)
+/* Async exception pointer that points into the current stack */
 
 DOMAIN_STATE(void*, young_base)
 DOMAIN_STATE(value*, young_start)

--- a/ocaml/runtime/caml/fail.h
+++ b/ocaml/runtime/caml/fail.h
@@ -39,6 +39,7 @@
 #define SYS_BLOCKED_IO 9        /* "Sys_blocked_io" */
 #define ASSERT_FAILURE_EXN 10   /* "Assert_failure" */
 #define UNDEFINED_RECURSIVE_MODULE_EXN 11 /* "Undefined_recursive_module" */
+#define ASYNC_EXN 12            /* "Async_exn" */
 
 #ifdef POSIX_SIGNALS
 struct longjmp_buffer {
@@ -66,6 +67,7 @@ struct longjmp_buffer {
 int caml_is_special_exception(value exn);
 
 CAMLextern value caml_raise_if_exception(value res);
+CAMLextern void caml_raise_async(value res);
 
 #endif /* CAML_INTERNALS */
 
@@ -111,6 +113,10 @@ CAMLnoreturn_end;
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_out_of_memory (void)
+CAMLnoreturn_end;
+
+CAMLnoreturn_start
+CAMLextern void caml_raise_out_of_memory_fatal (void)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start

--- a/ocaml/runtime/caml/stack.h
+++ b/ocaml/runtime/caml/stack.h
@@ -141,6 +141,7 @@ extern intnat * caml_frametable[];
 #define caml_last_return_address (Caml_state_field(last_return_address))
 #define caml_gc_regs (Caml_state_field(gc_regs))
 #define caml_exception_pointer (Caml_state_field(exception_pointer))
+#define caml_async_exception_pointer (Caml_state_field(async_exception_pointer))
 
 CAMLextern frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp);
 

--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -23,7 +23,7 @@
      callback.c weak.c
    finalise.c stacks.c dynlink.c backtrace_byt.c backtrace.c
      afl.c
-   bigarray.c eventlog.c)
+   bigarray.c eventlog.c fail_nat.c)
  (action  (with-stdout-to %{targets} (run %{dep:gen_primitives.sh}))))
 
 ; Shouldn't this use foreign build sandboxing?

--- a/ocaml/runtime/fail_byt.c
+++ b/ocaml/runtime/fail_byt.c
@@ -161,6 +161,11 @@ CAMLexport void caml_raise_out_of_memory(void)
   caml_raise_constant(Field(caml_global_data, OUT_OF_MEMORY_EXN));
 }
 
+CAMLexport void caml_raise_out_of_memory_fatal(void)
+{
+  caml_raise_out_of_memory();
+}
+
 CAMLexport void caml_raise_stack_overflow(void)
 {
   check_global_data("Stack_overflow");
@@ -203,6 +208,11 @@ CAMLexport value caml_raise_if_exception(value res)
   return res;
 }
 
+CAMLexport void caml_raise_async(value exn)
+{
+  caml_raise(exn);
+}
+
 int caml_is_special_exception(value exn) {
   /* this function is only used in caml_format_exception to produce
      a more readable textual representation of some exceptions. It is
@@ -212,4 +222,9 @@ int caml_is_special_exception(value exn) {
   return exn == Field(caml_global_data, MATCH_FAILURE_EXN)
     || exn == Field(caml_global_data, ASSERT_FAILURE_EXN)
     || exn == Field(caml_global_data, UNDEFINED_RECURSIVE_MODULE_EXN);
+}
+
+CAMLprim value caml_with_async_exns(value body_callback)
+{
+  return caml_callback_exn(body_callback, Val_unit);
 }

--- a/ocaml/runtime/fail_nat.c
+++ b/ocaml/runtime/fail_nat.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include "caml/alloc.h"
+#include "caml/callback.h"
 #include "caml/domain.h"
 #include "caml/fail.h"
 #include "caml/io.h"
@@ -37,29 +38,30 @@
 typedef value caml_generated_constant[1];
 
 extern caml_generated_constant
-  caml_exn_Out_of_memory,
-  caml_exn_Sys_error,
-  caml_exn_Failure,
-  caml_exn_Invalid_argument,
-  caml_exn_End_of_file,
-  caml_exn_Division_by_zero,
-  caml_exn_Not_found,
-  caml_exn_Match_failure,
-  caml_exn_Sys_blocked_io,
-  caml_exn_Stack_overflow,
-  caml_exn_Assert_failure,
-  caml_exn_Undefined_recursive_module;
+    caml_exn_Out_of_memory,
+    caml_exn_Sys_error,
+    caml_exn_Failure,
+    caml_exn_Invalid_argument,
+    caml_exn_End_of_file,
+    caml_exn_Division_by_zero,
+    caml_exn_Not_found,
+    caml_exn_Match_failure,
+    caml_exn_Sys_blocked_io,
+    caml_exn_Stack_overflow,
+    caml_exn_Assert_failure,
+    caml_exn_Undefined_recursive_module,
+    caml_exn_Async_exn;
 
 /* Exception raising */
 
-CAMLnoreturn_start
-  extern void caml_raise_exception (caml_domain_state* state, value bucket)
-CAMLnoreturn_end;
+CAMLnoreturn_start extern void caml_raise_exception(caml_domain_state *state, value bucket)
+    CAMLnoreturn_end;
 
-/* Used by the stack overflow handler -> deactivate ASAN (see
-   segv_handler in signals_nat.c). */
-CAMLno_asan
-void caml_raise(value v)
+CAMLnoreturn_start extern void caml_raise_async_exception(
+  caml_domain_state *state, value bucket)
+    CAMLnoreturn_end;
+
+CAMLno_asan static value prepare_for_raise(value v, char *exception_pointer)
 {
   Unlock_exn();
 
@@ -70,30 +72,72 @@ void caml_raise(value v)
   if (Is_exception_result(v))
     v = Extract_exception(v);
 
-  if (Caml_state->exception_pointer == NULL) caml_fatal_uncaught_exception(v);
+  if (exception_pointer == NULL)
+    caml_fatal_uncaught_exception(v);
 
+  return v;
+}
+
+CAMLno_asan static void unwind_local_roots(char *exception_pointer)
+{
   while (Caml_state->local_roots != NULL &&
-         (char *) Caml_state->local_roots < Caml_state->exception_pointer) {
+         (char *)Caml_state->local_roots < exception_pointer)
+  {
     Caml_state->local_roots = Caml_state->local_roots->next;
   }
-
-  caml_raise_exception(Caml_state, v);
 }
 
 /* Used by the stack overflow handler -> deactivate ASAN (see
    segv_handler in signals_nat.c). */
-CAMLno_asan
-void caml_raise_constant(value tag)
+CAMLno_asan void caml_raise(value v)
+{
+  v = prepare_for_raise(v, Caml_state->exception_pointer);
+  unwind_local_roots(Caml_state->exception_pointer);
+  caml_raise_exception(Caml_state, v);
+}
+
+CAMLnoreturn_start void caml_raise_async(value v) CAMLnoreturn_end;
+
+static value wrap_async_exception(value exn)
+{
+  value wrapped;
+
+  /* [Stack_overflow] can be raised from a signal handler, so we cannot
+     rely on being able to allocate. */
+  if (exn == (value) caml_exn_Stack_overflow) return exn;
+
+  wrapped = caml_alloc_small(2, 0);
+  Field(wrapped, 0) = (value) caml_exn_Async_exn;
+  Field(wrapped, 1) = exn;
+
+  return wrapped;
+}
+
+CAMLno_asan CAMLexport void caml_raise_async(value exn_unwrapped)
+{
+  value exn = wrap_async_exception(exn_unwrapped);
+
+  exn = prepare_for_raise(wrap_async_exception(exn_unwrapped),
+          Caml_state->async_exception_pointer);
+
+  unwind_local_roots(Caml_state->async_exception_pointer);
+
+  caml_raise_async_exception(Caml_state, exn);
+}
+
+/* Used by the stack overflow handler -> deactivate ASAN (see
+   segv_handler in signals_nat.c). */
+CAMLno_asan void caml_raise_constant(value tag)
 {
   caml_raise(tag);
 }
 
 void caml_raise_with_arg(value tag, value arg)
 {
-  CAMLparam2 (tag, arg);
-  CAMLlocal1 (bucket);
+  CAMLparam2(tag, arg);
+  CAMLlocal1(bucket);
 
-  bucket = caml_alloc_small (2, 0);
+  bucket = caml_alloc_small(2, 0);
   Field(bucket, 0) = tag;
   Field(bucket, 1) = arg;
   caml_raise(bucket);
@@ -102,15 +146,16 @@ void caml_raise_with_arg(value tag, value arg)
 
 void caml_raise_with_args(value tag, int nargs, value args[])
 {
-  CAMLparam1 (tag);
-  CAMLxparamN (args, nargs);
+  CAMLparam1(tag);
+  CAMLxparamN(args, nargs);
   value bucket;
   int i;
 
   CAMLassert(1 + nargs <= Max_young_wosize);
-  bucket = caml_alloc_small (1 + nargs, 0);
+  bucket = caml_alloc_small(1 + nargs, 0);
   Field(bucket, 0) = tag;
-  for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
+  for (i = 0; i < nargs; i++)
+    Field(bucket, 1 + i) = args[i];
   caml_raise(bucket);
   CAMLnoreturn;
 }
@@ -123,67 +168,73 @@ void caml_raise_with_string(value tag, char const *msg)
   CAMLnoreturn;
 }
 
-void caml_failwith (char const *msg)
+void caml_failwith(char const *msg)
 {
-  caml_raise_with_string((value) caml_exn_Failure, msg);
+  caml_raise_with_string((value)caml_exn_Failure, msg);
 }
 
-void caml_failwith_value (value msg)
+void caml_failwith_value(value msg)
 {
-  caml_raise_with_arg((value) caml_exn_Failure, msg);
+  caml_raise_with_arg((value)caml_exn_Failure, msg);
 }
 
-void caml_invalid_argument (char const *msg)
+void caml_invalid_argument(char const *msg)
 {
-  caml_raise_with_string((value) caml_exn_Invalid_argument, msg);
+  caml_raise_with_string((value)caml_exn_Invalid_argument, msg);
 }
 
-void caml_invalid_argument_value (value msg)
+void caml_invalid_argument_value(value msg)
 {
-  caml_raise_with_arg((value) caml_exn_Invalid_argument, msg);
+  caml_raise_with_arg((value)caml_exn_Invalid_argument, msg);
 }
 
 void caml_raise_out_of_memory(void)
 {
-  caml_raise_constant((value) caml_exn_Out_of_memory);
+  caml_raise_async((value)caml_exn_Out_of_memory);
+}
+
+void caml_raise_out_of_memory_fatal(void)
+{
+  fprintf(stderr, "[ocaml] Out of memory\n");
+  abort();
 }
 
 /* Used by the stack overflow handler -> deactivate ASAN (see
    segv_handler in signals_nat.c). */
-CAMLno_asan
-void caml_raise_stack_overflow(void)
+CAMLno_asan void caml_raise_stack_overflow(void)
 {
-  caml_raise_constant((value) caml_exn_Stack_overflow);
+  caml_raise_async((value)caml_exn_Stack_overflow);
 }
 
 void caml_raise_sys_error(value msg)
 {
-  caml_raise_with_arg((value) caml_exn_Sys_error, msg);
+  caml_raise_with_arg((value)caml_exn_Sys_error, msg);
 }
 
 void caml_raise_end_of_file(void)
 {
-  caml_raise_constant((value) caml_exn_End_of_file);
+  caml_raise_constant((value)caml_exn_End_of_file);
 }
 
 void caml_raise_zero_divide(void)
 {
-  caml_raise_constant((value) caml_exn_Division_by_zero);
+  caml_raise_constant((value)caml_exn_Division_by_zero);
 }
 
 void caml_raise_not_found(void)
 {
-  caml_raise_constant((value) caml_exn_Not_found);
+  caml_raise_constant((value)caml_exn_Not_found);
 }
 
 void caml_raise_sys_blocked_io(void)
 {
-  caml_raise_constant((value) caml_exn_Sys_blocked_io);
+  caml_raise_constant((value)caml_exn_Sys_blocked_io);
 }
 
 CAMLexport value caml_raise_if_exception(value res)
 {
-  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
+  if (Is_exception_result(res))
+    caml_raise(Extract_exception(res));
   return res;
 }
 
@@ -191,14 +242,16 @@ CAMLexport value caml_raise_if_exception(value res)
    do a GC before the exception is raised (lack of stack descriptors
    for the ccall to [caml_array_bound_error]).  */
 
-static const value * caml_array_bound_error_exn = NULL;
+static const value *caml_array_bound_error_exn = NULL;
 
 void caml_array_bound_error(void)
 {
-  if (caml_array_bound_error_exn == NULL) {
+  if (caml_array_bound_error_exn == NULL)
+  {
     caml_array_bound_error_exn =
-      caml_named_value("Pervasives.array_bound_error");
-    if (caml_array_bound_error_exn == NULL) {
+        caml_named_value("Pervasives.array_bound_error");
+    if (caml_array_bound_error_exn == NULL)
+    {
       fprintf(stderr, "Fatal error: exception "
                       "Invalid_argument(\"index out of bounds\")\n");
       exit(2);
@@ -210,8 +263,29 @@ void caml_array_bound_error(void)
   caml_raise_exception(Caml_state, *caml_array_bound_error_exn);
 }
 
-int caml_is_special_exception(value exn) {
-  return exn == (value) caml_exn_Match_failure
-    || exn == (value) caml_exn_Assert_failure
-    || exn == (value) caml_exn_Undefined_recursive_module;
+int caml_is_special_exception(value exn)
+{
+  return exn == (value)caml_exn_Match_failure || exn == (value)caml_exn_Assert_failure || exn == (value)caml_exn_Undefined_recursive_module;
+}
+
+CAMLprim value caml_with_async_exns(value body_callback)
+{
+  value exn, result;
+
+  result = caml_callback_exn(body_callback, Val_unit);
+
+  if (!Is_exception_result(result))
+    return result;
+
+  exn = Extract_exception(result);
+
+  /* This shouldn't clobber a backtrace (leading back to a finaliser,
+     signal handler, etc) because of the equality check in
+     [caml_stash_backtrace]. */
+  if (exn == (value) caml_exn_Stack_overflow
+      || (Is_block(exn)
+          && Field(exn, 0) == (value) caml_exn_Async_exn))
+    caml_raise(exn);
+
+  return result;
 }

--- a/ocaml/runtime/gen_primitives.sh
+++ b/ocaml/runtime/gen_primitives.sh
@@ -25,7 +25,7 @@ export LC_ALL=C
       alloc array compare extern floats gc_ctrl hash intern interp ints io \
       lexing md5 meta memprof obj parsing signals str sys callback weak \
       finalise stacks dynlink backtrace_byt backtrace afl \
-      bigarray eventlog
+      bigarray eventlog fail_nat
   do
       sed -n -e 's/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p' "$prim.c"
   done

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -469,7 +469,7 @@ Caml_inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
 
   if (wosize > Max_wosize) {
     if (raise_oom)
-      caml_raise_out_of_memory ();
+      caml_raise_out_of_memory_fatal ();
     else
       return 0;
   }
@@ -483,7 +483,7 @@ Caml_inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
       else if (Caml_state->in_minor_collection)
         caml_fatal_error ("out of memory");
       else
-        caml_raise_out_of_memory ();
+        caml_raise_out_of_memory_fatal ();
     }
     caml_fl_add_blocks ((value) new_block);
     hp = caml_fl_allocate (wosize);
@@ -933,7 +933,7 @@ CAMLexport void* caml_stat_alloc_aligned(asize_t sz, int modulo,
   void *result = caml_stat_alloc_aligned_noexc(sz, modulo, b);
   /* malloc() may return NULL if size is 0 */
   if ((result == NULL) && (sz != 0))
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   return result;
 }
 
@@ -967,7 +967,7 @@ CAMLexport caml_stat_block caml_stat_alloc(asize_t sz)
   void *result = caml_stat_alloc_noexc(sz);
   /* malloc() may return NULL if size is 0 */
   if ((result == NULL) && (sz != 0))
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   return result;
 }
 
@@ -1014,7 +1014,7 @@ CAMLexport caml_stat_block caml_stat_resize(caml_stat_block b, asize_t sz)
 {
   void *result = caml_stat_resize_noexc(b, sz);
   if (result == NULL)
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   return result;
 }
 
@@ -1046,7 +1046,7 @@ CAMLexport caml_stat_string caml_stat_strdup(const char *s)
 {
   caml_stat_string result = caml_stat_strdup_noexc(s);
   if (result == NULL)
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   return result;
 }
 
@@ -1057,7 +1057,7 @@ CAMLexport wchar_t * caml_stat_wcsdup(const wchar_t *s)
   int slen = wcslen(s);
   wchar_t* result = caml_stat_alloc((slen + 1)*sizeof(wchar_t));
   if (result == NULL)
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   memcpy(result, s, (slen + 1)*sizeof(wchar_t));
   return result;
 }

--- a/ocaml/runtime/memprof.c
+++ b/ocaml/runtime/memprof.c
@@ -963,8 +963,14 @@ void caml_memprof_track_young(uintnat wosize, int from_caml,
      [local->entries] to make sure the floag is not set back to 1. */
   caml_memprof_set_suspended(0);
 
-  if (Is_exception_result(res))
-    caml_raise(Extract_exception(res));
+  if (Is_exception_result(res)) {
+    value exn = Extract_exception(res);
+    if (from_caml) {
+      caml_raise_async(exn);
+    } else {
+      caml_raise(exn);
+    }
+  }
 
   /* /!\ Since the heap is in an invalid state before initialization,
      very little heap operations are allowed until then. */

--- a/ocaml/runtime/minor_gc.c
+++ b/ocaml/runtime/minor_gc.c
@@ -154,9 +154,9 @@ void caml_set_minor_heap_size (asize_t bsz)
   }
   CAMLassert (Caml_state->young_ptr == Caml_state->young_alloc_end);
   new_heap = caml_stat_alloc_aligned_noexc(bsz, 0, &new_heap_base);
-  if (new_heap == NULL) caml_raise_out_of_memory();
+  if (new_heap == NULL) caml_raise_out_of_memory_fatal();
   if (caml_page_table_add(In_young, new_heap, new_heap + bsz) != 0)
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
 
   if (Caml_state->young_start != NULL){
     caml_page_table_remove(In_young, Caml_state->young_start,
@@ -554,6 +554,7 @@ void caml_alloc_small_dispatch (intnat wosize, int flags,
                                 int nallocs, unsigned char* encoded_alloc_lens)
 {
   intnat whsize = Whsize_wosize (wosize);
+  value res;
 
   /* First, we un-do the allocation performed in [Alloc_small] */
   Caml_state->young_ptr += whsize;
@@ -561,10 +562,14 @@ void caml_alloc_small_dispatch (intnat wosize, int flags,
   while(1) {
     /* We might be here because of an async callback / urgent GC
        request. Take the opportunity to do what has been requested. */
-    if (flags & CAML_FROM_CAML)
+    if (flags & CAML_FROM_CAML) {
       /* In the case of allocations performed from OCaml, execute
          asynchronous callbacks. */
-      caml_raise_if_exception(caml_do_pending_actions_exn ());
+      res = caml_do_pending_actions_exn ();
+      if (Is_exception_result(res)) {
+        caml_raise_async(Extract_exception(res));
+      }
+    }
     else {
       caml_check_urgent_gc (Val_unit);
       /* In the case of long-running C code that regularly polls with

--- a/ocaml/stdlib/printexc.ml
+++ b/ocaml/stdlib/printexc.ml
@@ -57,7 +57,7 @@ let use_printers x =
     | [] -> None in
   conv (Atomic.get printers)
 
-let to_string_default = function
+let (* XXX rec *) to_string_default = function
   | Out_of_memory -> "Out of memory"
   | Stack_overflow -> "Stack overflow"
   | Match_failure(file, line, char) ->
@@ -66,6 +66,7 @@ let to_string_default = function
       sprintf locfmt file line char (char+6) "Assertion failed"
   | Undefined_recursive_module(file, line, char) ->
       sprintf locfmt file line char (char+6) "Undefined recursive module"
+(* XXX  | Async_exn exn -> to_string_default exn *)
   | x ->
       let x = Obj.repr x in
       if Obj.tag x <> 0 then

--- a/ocaml/stdlib/stdlib.ml
+++ b/ocaml/stdlib/stdlib.ml
@@ -46,6 +46,7 @@ exception End_of_file = End_of_file
 exception Division_by_zero = Division_by_zero
 exception Sys_blocked_io = Sys_blocked_io
 exception Undefined_recursive_module = Undefined_recursive_module
+exception Async_exn = Async_exn
 
 (* Composition operators *)
 

--- a/ocaml/stdlib/stdlib.mli
+++ b/ocaml/stdlib/stdlib.mli
@@ -81,9 +81,10 @@ exception Not_found
    not be found. *)
 
 exception Out_of_memory
-(** Exception raised by the garbage collector when there is
-   insufficient memory to complete the computation. (Not reliable for
-   allocations on the minor heap.) *)
+(** Exception raised by functions such as those for array and bigarray
+    creation when there is insufficient memory.  Failure to allocate
+    memory during garbage collection causes a fatal error, unlike in
+    previous versions. *)
 
 exception Stack_overflow
 (** Exception raised by the bytecode interpreter when the evaluation
@@ -118,6 +119,11 @@ exception Undefined_recursive_module of (string * int * int)
 (** Exception raised when an ill-founded recursive module definition
    is evaluated. The arguments are the location of the definition in
    the source code (file name, line number, column number). *)
+
+exception Async_exn of exn
+(** Wrapper for exceptions arising asynchronously (during the execution
+    of finalisers and signal handlers for example).  Only used for
+    native code compilation. *)
 
 (** {1 Comparisons} *)
 

--- a/ocaml/stdlib/sys.mli
+++ b/ocaml/stdlib/sys.mli
@@ -333,6 +333,15 @@ val catch_break : bool -> unit
    and [catch_break false] to let the system
    terminate the program on user interrupt. *)
 
+val with_async_exns : (unit -> 'a) -> 'a
+(** [with_async_exns f] runs [f], ensuring that any asynchronous exceptions
+    (e.g. from finalisers, signal handlers or the GC) occurring during the
+    execution of [f] are reraised as normal exceptions to the call site of
+    [with_async_exns].
+
+    This is useful in particular for catching [Break] in a controlled
+    manner. *)
+
 
 val ocaml_version : string
 (** [ocaml_version] is the version of OCaml.

--- a/ocaml/stdlib/sys.mlp
+++ b/ocaml/stdlib/sys.mlp
@@ -122,6 +122,7 @@ let catch_break on =
   else
     set_signal sigint Signal_default
 
+external with_async_exns : (unit -> 'a) -> 'a = "caml_with_async_exns"
 
 external enable_runtime_warnings: bool -> unit =
   "caml_ml_enable_runtime_warnings"

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -96,6 +96,7 @@ and ident_sys_blocked_io = ident_create "Sys_blocked_io"
 and ident_assert_failure = ident_create "Assert_failure"
 and ident_undefined_recursive_module =
         ident_create "Undefined_recursive_module"
+and ident_async_exn = ident_create "Async_exn"
 
 let all_predef_exns = [
   ident_match_failure;
@@ -110,6 +111,7 @@ let all_predef_exns = [
   ident_sys_blocked_io;
   ident_assert_failure;
   ident_undefined_recursive_module;
+  ident_async_exn
 ]
 
 let path_match_failure = Pident ident_match_failure
@@ -208,6 +210,7 @@ let common_initial_env add_type add_extension empty_env =
                          [newgenty (Ttuple[type_string; type_int; type_int])] (
   add_extension ident_undefined_recursive_module
                          [newgenty (Ttuple[type_string; type_int; type_int])] (
+  add_extension ident_async_exn [type_exn] (
   add_type ident_int64 (
   add_type ident_int32 (
   add_type ident_nativeint (
@@ -235,7 +238,7 @@ let common_initial_env add_type add_extension empty_env =
   add_type ident_int ~immediate:Always (
   add_type ident_extension_constructor (
   add_type ident_floatarray (
-    empty_env))))))))))))))))))))))))))))
+    empty_env)))))))))))))))))))))))))))))
 
 let build_initial_env add_type add_exception empty_env =
   let common = common_initial_env add_type add_exception empty_env in


### PR DESCRIPTION
Flambda 2 expects all [primitive operations](https://github.com/ocaml-flambda/flambda-backend/blob/main/middle_end/flambda2/terms/flambda_primitive.mli) to neither allocate nor perform control flow effects.  The list of primitives includes several that allocate.

We have always known that allocation can raise "asynchronous" exceptions in circumstances such as when a GC finaliser or signal handler, invoked during such allocation, raises.  Owing to the existing semantics of these exceptions being vague, we weren't concerned about one of them being delivered to a different handler than usual, for example.

Unfortunately there is a bug here: the current exception handler during an allocation might be one with extra arguments arising from the conversion of `Lambda` mutable variables to immutable Flambda 2 variables.  Any operation that might raise to such a handler requires special `Cmm` code to be emitted first.  (The current implementation actually uses `Cmm` mutable variables for these extra exception handler parameters, so the special code simply updates the value of those).  Since this special code isn't inserted prior to allocation primitives, the raising of an asynchronous exception from such an operation could cause incorrect results.

This PR uses a trick due to @lthls which causes the runtime to deliver asynchronous exceptions to the frame prior to the most recent frame, unless it is certain that the current exception handler has no extra parameters (this is explained in a comment in the patch).

Incidentally this PR also shows how easy it is to add a new test to be run by dune.