### PR TITLE
Replace unused raise argument with a dummy value

### DIFF
--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -83,21 +83,22 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
       let apply_cont =
         if AC.is_raise apply_cont then
           match AC.args apply_cont with
-          | [] | _ :: _ :: _ -> assert false
-          | [ arg ] ->
-            let arg_is_used =
+          | [] -> assert false
+          | first_arg :: other_args ->
+            let first_arg_is_used =
               Simple.pattern_match
                 ~const:(fun _ -> true)
                 ~name:(fun name ~coercion:_ ->
                     Name.Set.mem name (UA.required_names uacc))
-                arg
+                first_arg
             in
-            if arg_is_used then
+            if first_arg_is_used then
               apply_cont
             else
               (* The raise argument must be present, if it is unused, we replace
                  it by a dummy value to avoid keeping a useless value alive  *)
-              AC.update_args ~args:[Simple.const_zero] apply_cont
+              let dummy_value = Simple.const_zero in
+              AC.update_args ~args:(dummy_value :: other_args) apply_cont
         else
           apply_cont
       in

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -80,6 +80,27 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
       let apply_cont =
         Simplify_common.clear_demoted_trap_action uacc apply_cont
       in
+      let apply_cont =
+        if AC.is_raise apply_cont then
+          match AC.args apply_cont with
+          | [] | _ :: _ :: _ -> assert false
+          | [ arg ] ->
+            let arg_is_used =
+              Simple.pattern_match
+                ~const:(fun _ -> true)
+                ~name:(fun name ~coercion:_ ->
+                    Name.Set.mem name (UA.required_names uacc))
+                arg
+            in
+            if arg_is_used then
+              apply_cont
+            else
+              (* The raise argument must be present, if it is unused, we replace
+                 it by a dummy value to avoid keeping a useless value alive  *)
+              AC.update_args ~args:[Simple.const_zero] apply_cont
+        else
+          apply_cont
+      in
       match rewrite with
       | None -> EB.no_rewrite apply_cont
       | Some rewrite ->

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -84,15 +84,15 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
         if AC.is_raise apply_cont then
           match AC.args apply_cont with
           | [] -> assert false
-          | first_arg :: other_args ->
-            let first_arg_is_used =
+          | exn_bucket :: other_args ->
+            let exn_bucket_is_used =
               Simple.pattern_match
                 ~const:(fun _ -> true)
                 ~name:(fun name ~coercion:_ ->
                     Name.Set.mem name (UA.required_names uacc))
-                first_arg
+                exn_bucket
             in
-            if first_arg_is_used then
+            if exn_bucket_is_used then
               apply_cont
             else
               (* The raise argument must be present, if it is unused, we replace

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -81,7 +81,8 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
         Simplify_common.clear_demoted_trap_action uacc apply_cont
       in
       let apply_cont =
-        if AC.is_raise apply_cont then
+        if AC.is_raise apply_cont
+        then
           match AC.args apply_cont with
           | [] -> assert false
           | exn_bucket :: other_args ->
@@ -89,18 +90,17 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
               Simple.pattern_match
                 ~const:(fun _ -> true)
                 ~name:(fun name ~coercion:_ ->
-                    Name.Set.mem name (UA.required_names uacc))
+                  Name.Set.mem name (UA.required_names uacc))
                 exn_bucket
             in
-            if exn_bucket_is_used then
-              apply_cont
+            if exn_bucket_is_used
+            then apply_cont
             else
               (* The raise argument must be present, if it is unused, we replace
-                 it by a dummy value to avoid keeping a useless value alive  *)
+                 it by a dummy value to avoid keeping a useless value alive *)
               let dummy_value = Simple.const_zero in
               AC.update_args ~args:(dummy_value :: other_args) apply_cont
-        else
-          apply_cont
+        else apply_cont
       in
       match rewrite with
       | None -> EB.no_rewrite apply_cont

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -85,6 +85,9 @@ let compute_used_params uacc params ~is_exn_handler ~is_single_inlinable_use
          parameter is the exception bucket. Then this hack can be removed. *)
       if !first && is_exn_handler
       then begin
+        (* If this argument is actually unused, the apply_conts is updated
+           accordingly in simplify_apply_cont. Apply_cont_rewrite can't at the
+           moment represent this transformation, so it has to be done manualy *)
         first := false;
         true
       end

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -212,6 +212,11 @@ let to_goto t =
   then Some (continuation t)
   else None
 
+let is_raise t =
+  match t.trap_action with
+  | Some (Pop { exn_handler; _ }) -> Continuation.equal t.k exn_handler
+  | Some (Push _) | None -> false
+
 let clear_trap_action t = { t with trap_action = None }
 
 let to_one_arg_without_trap_action t =

--- a/middle_end/flambda2/terms/apply_cont_expr.mli
+++ b/middle_end/flambda2/terms/apply_cont_expr.mli
@@ -53,6 +53,8 @@ val update_args : t -> args:Simple.t list -> t
 
 val with_debuginfo : t -> dbg:Debuginfo.t -> t
 
+val is_raise : t -> bool
+
 val is_goto : t -> bool
 
 val is_goto_to : t -> Continuation.t -> bool


### PR DESCRIPTION
When compiling with `-g`
```OCaml
   try assert (0 = 40 + 2) with _ -> ()
```
the exception handler is kept, but the exception symbol is marked as unused by `Data_flow` because the exception value is actually unused. But we can't remove the argument because exceptions arguments can't be removed.
