### PR TITLE
Prepare the simplifier for ocamlformat

### DIFF
--- a/middle_end/flambda2/simplify/simplify_import.ml
+++ b/middle_end/flambda2/simplify/simplify_import.ml
@@ -41,6 +41,7 @@ module CIS = Code_id_or_symbol
 module CUE = Continuation_uses_env
 module DA = Downwards_acc
 module DE = Downwards_env
+module DF = Data_flow
 module EA = Continuation_extra_params_and_args.Extra_arg
 module EB = Expr_builder
 module EPA = Continuation_extra_params_and_args

--- a/middle_end/flambda2/simplify/simplify_import.mli
+++ b/middle_end/flambda2/simplify/simplify_import.mli
@@ -41,6 +41,7 @@ module CIS = Code_id_or_symbol
 module CUE = Continuation_uses_env
 module DA = Downwards_acc
 module DE = Downwards_env
+module DF = Data_flow
 module EA = Continuation_extra_params_and_args.Extra_arg
 module EB = Expr_builder
 module EPA = Continuation_extra_params_and_args

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -18,6 +18,24 @@
 
 open! Simplify_import
 
+let keep_lifted_constant_only_if_used uacc acc lifted_constant =
+  let bound = LC.bound_symbols lifted_constant in
+  let code_ids_live =
+    match UA.reachable_code_ids uacc with
+    | Unknown -> Bound_symbols.binds_code bound
+    | Known { live_code_ids = _; ancestors_of_live_code_ids; } ->
+      not (Code_id.Set.intersection_is_empty
+            (Bound_symbols.code_being_defined bound)
+            ancestors_of_live_code_ids)
+  in
+  let symbols_live =
+    not (Name.Set.intersection_is_empty
+          (Name.set_of_symbol_set (Bound_symbols.being_defined bound))
+          (UA.required_names uacc))
+  in
+  if symbols_live || code_ids_live then LCS.add acc lifted_constant
+  else acc
+
 let rebuild_let simplify_named_result
       removed_operations ~lifted_constants_from_defining_expr
       ~at_unit_toplevel ~(closure_info:Closure_info.t)
@@ -30,23 +48,7 @@ let rebuild_let simplify_named_result
     | Not_in_a_closure ->
       (* CR gbury: do only if we are actually rebuilding terms *)
       LCS.fold lifted_constants_from_defining_expr ~init:LCS.empty
-        ~f:(fun acc lifted_constant ->
-          let bound = LC.bound_symbols lifted_constant in
-          let code_ids_live =
-            match UA.reachable_code_ids uacc with
-            | Unknown -> Bound_symbols.binds_code bound
-            | Known { live_code_ids = _; ancestors_of_live_code_ids; } ->
-              not (Code_id.Set.intersection_is_empty
-                    (Bound_symbols.code_being_defined bound)
-                    ancestors_of_live_code_ids)
-          in
-          let symbols_live =
-            not (Name.Set.intersection_is_empty
-                  (Name.set_of_symbol_set (Bound_symbols.being_defined bound))
-                  (UA.required_names uacc))
-          in
-          if symbols_live || code_ids_live then LCS.add acc lifted_constant
-          else acc)
+        ~f:(keep_lifted_constant_only_if_used uacc)
   in
   let lifted_constants_from_defining_expr =
     Sort_lifted_constants.sort lifted_constants_from_defining_expr
@@ -99,156 +101,183 @@ let rebuild_let simplify_named_result
     in
     after_rebuild body uacc
 
+let record_one_closure_element_binding_for_data_flow symbol closure_var simple
+      data_flow =
+  DF.record_closure_element_binding
+    (Name.symbol symbol) closure_var
+    (Simple.free_names simple) data_flow
+
+let record_one_closure_binding_for_data_flow ~free_names ~closure_elements
+      _ (symbol, _) data_flow =
+  let data_flow =
+    DF.record_symbol_binding symbol free_names
+      data_flow
+  in
+  Var_within_closure.Map.fold
+    (record_one_closure_element_binding_for_data_flow symbol)
+    closure_elements data_flow
+
+let record_lifted_constant_definition_for_data_flow data_flow definition =
+  let module D = LC.Definition in
+  match D.descr definition with
+  | Code code_id ->
+    DF.record_code_id_binding code_id
+      (D.free_names definition) data_flow
+  | Block_like { symbol; _ } ->
+    DF.record_symbol_binding symbol
+      (D.free_names definition) data_flow
+  | Set_of_closures { closure_symbols_with_types; _ } ->
+    let expr = D.defining_expr definition in
+    match Rebuilt_static_const.to_const expr with
+    | Some const ->
+      let set_of_closures =
+        Static_const.must_be_set_of_closures const
+      in
+      let free_names =
+        Function_declarations.free_names
+          (Set_of_closures.function_decls set_of_closures)
+      in
+      let closure_elements =
+        Set_of_closures.closure_elements set_of_closures
+      in
+      Closure_id.Lmap.fold
+        (record_one_closure_binding_for_data_flow ~free_names ~closure_elements)
+        closure_symbols_with_types data_flow
+    | None ->
+      let free_names = D.free_names definition in
+      Closure_id.Lmap.fold (fun _ (symbol, _) data_flow ->
+          DF.record_symbol_binding symbol free_names
+          data_flow)
+        closure_symbols_with_types data_flow
+
+let record_lifted_constant_for_data_flow data_flow lifted_constant =
+  let data_flow =
+    (* Record all projections as potential dependencies. *)
+    Variable.Map.fold (fun var proj data_flow ->
+        DF.record_symbol_projection var
+          (Symbol_projection.free_names proj)
+          data_flow)
+      (LC.symbol_projections lifted_constant)
+      data_flow
+  in
+  ListLabels.fold_left (LC.definitions lifted_constant)
+    ~init:data_flow ~f:record_lifted_constant_definition_for_data_flow
+
+let record_new_defining_expression_binding_for_data_flow dacc data_flow
+      (binding : Simplify_named_result.binding_to_place) =
+  match binding.simplified_defining_expr with
+  | Invalid _ -> data_flow
+  | Reachable { free_names; named; cost_metrics = _; } ->
+    let can_be_removed =
+      match named with
+      | Simple _ | Set_of_closures _ | Rec_info _ -> true
+      | Prim (prim, _) -> P.at_most_generative_effects prim
+    in
+    if not can_be_removed then
+      DF.add_used_in_current_handler free_names data_flow
+    else
+      let generate_phantom_lets =
+        DE.generate_phantom_lets (DA.denv dacc)
+      in
+      (* CR gbury: use Bindable_let_bound.fold_all_bound_vars instead
+         of a match here. *)
+      match binding.let_bound with
+      | Singleton v ->
+        DF.record_var_binding (VB.var v) free_names
+          ~generate_phantom_lets data_flow
+      | Set_of_closures { closure_vars; name_mode = _; } ->
+        ListLabels.fold_left closure_vars ~init:data_flow
+          ~f:(fun data_flow v ->
+            DF.record_var_binding (VB.var v) free_names
+              ~generate_phantom_lets data_flow)
+      | Symbols _ ->
+        (* This cannot be reached.  Simplify_named does not return any
+           symbol bindings, they all go via the lifted constants
+           accumulator in [DA]. *)
+        Misc.fatal_error "[Symbols] not expected here"
+
+let update_data_flow dacc closure_info ~lifted_constants_from_defining_expr
+      simplify_named_result data_flow =
+  let data_flow =
+    match Closure_info.in_or_out_of_closure closure_info with
+    | In_a_closure ->
+      (* The dependency information for lifted constants (stored in
+         [Data_flow]) is only required at the point when the constants
+         are placed.  That always happens at toplevel, never inside
+         closures -- so we don't need to do anything here. *)
+      data_flow
+    | Not_in_a_closure ->
+      LCS.fold lifted_constants_from_defining_expr
+        ~init:data_flow ~f:record_lifted_constant_for_data_flow
+  in
+  ListLabels.fold_left
+    (Simplify_named_result.bindings_to_place_in_any_order
+      simplify_named_result)
+    ~init:data_flow
+    ~f:(record_new_defining_expression_binding_for_data_flow dacc)
+
+let simplify_let0 ~simplify_expr ~simplify_toplevel dacc let_expr ~down_to_up
+      bindable_let_bound ~body =
+  let module L = Flambda.Let in
+  (* Remember then clear the lifted constants memory in [DA] so we can
+     easily find out which constants are generated during simplification
+     of the defining expression and the [body]. *)
+  let dacc, prior_lifted_constants = DA.get_and_clear_lifted_constants dacc in
+  (* Simplify the defining expression. *)
+  let simplify_named_result, removed_operations =
+    Simplify_named.simplify_named dacc bindable_let_bound
+      (L.defining_expr let_expr)
+      ~simplify_toplevel
+  in
+  let dacc = Simplify_named_result.dacc simplify_named_result in
+  (* First accumulate variable, symbol and code ID usage information. *)
+  (* CR gbury/pchambart : in the case of an invalid, we currently
+     over-approximate the uses. In case of an invalid, we might want to
+     instead flush the uses of the current control flow branch (but this
+     would require a more precise stack). *)
+  (* We currently over-approximate the use of variables in symbols: both in
+     the lifted constants, and in the bound constants, which we consider to be
+     always used, leading to the free_names in their defining expressions to
+     be considered as used unconditionally. *)
+  let closure_info = DE.closure_info (DA.denv dacc) in
+  (* Next remember any lifted constants that were generated during the
+     simplification of the defining expression and sort them, since they
+     may be mutually recursive.  Then add back in to [dacc]
+     the [prior_lifted_constants] remembered above.  This results in the
+     definitions and types for all these constants being available at a
+     subsequent [Let_cont].  At such a point, [dacc] will be queried to
+     retrieve all of the constants, which are then manually transferred
+     into the computed [dacc] at the join point for subsequent
+     simplification of the continuation handler(s).
+     Note that no lifted constants are ever placed during the simplification
+     of the defining expression.  (Not even in the case of a
+     [Set_of_closures] binding, since "let symbol" is disallowed under a
+     lambda.) *)
+  let lifted_constants_from_defining_expr = DA.get_lifted_constants dacc in
+  let dacc = DA.add_lifted_constants dacc prior_lifted_constants in
+  let dacc =
+    DA.map_data_flow dacc ~f:(update_data_flow dacc closure_info
+      ~lifted_constants_from_defining_expr simplify_named_result)
+  in
+  let at_unit_toplevel = DE.at_unit_toplevel (DA.denv dacc) in
+  (* Simplify the body of the let-expression and make the new [Let] bindings
+     around the simplified body.  [Simplify_named] will already have
+     prepared [dacc] with the necessary bindings for the simplification of
+     the body. *)
+  let down_to_up dacc ~rebuild:rebuild_body =
+    let rebuild uacc ~after_rebuild =
+      let after_rebuild body uacc =
+        rebuild_let simplify_named_result
+          removed_operations ~lifted_constants_from_defining_expr
+          ~at_unit_toplevel ~closure_info ~body uacc ~after_rebuild
+      in
+      rebuild_body uacc ~after_rebuild
+    in
+    down_to_up dacc ~rebuild
+  in
+  simplify_expr dacc body ~down_to_up
+
 let simplify_let ~simplify_expr ~simplify_toplevel dacc let_expr ~down_to_up =
   let module L = Flambda.Let in
-  L.pattern_match let_expr ~f:(fun bindable_let_bound ~body ->
-    (* Remember then clear the lifted constants memory in [DA] so we can
-       easily find out which constants are generated during simplification
-       of the defining expression and the [body]. *)
-    let dacc, prior_lifted_constants = DA.get_and_clear_lifted_constants dacc in
-    (* Simplify the defining expression. *)
-    let simplify_named_result, removed_operations =
-      Simplify_named.simplify_named dacc bindable_let_bound
-        (L.defining_expr let_expr)
-        ~simplify_toplevel
-    in
-    let dacc = Simplify_named_result.dacc simplify_named_result in
-    (* First accumulate variable, symbol and code ID usage information. *)
-    (* CR gbury/pchambart : in the case of an invalid, we currently
-       over-approximate the uses. In case of an invalid, we might want to
-       instead flush the uses of the current control flow branch (but this
-       would require a more precise stack). *)
-    (* We currently over-approximate the use of variables in symbols: both in
-       the lifted constants, and in the bound constants, which we consider to be
-       always used, leading to the free_names in their defining expressions to
-       be considered as used unconditionally. *)
-    let closure_info = DE.closure_info (DA.denv dacc) in
-    (* Next remember any lifted constants that were generated during the
-       simplification of the defining expression and sort them, since they
-       may be mutually recursive.  Then add back in to [dacc]
-       the [prior_lifted_constants] remembered above.  This results in the
-       definitions and types for all these constants being available at a
-       subsequent [Let_cont].  At such a point, [dacc] will be queried to
-       retrieve all of the constants, which are then manually transferred
-       into the computed [dacc] at the join point for subsequent
-       simplification of the continuation handler(s).
-       Note that no lifted constants are ever placed during the simplification
-       of the defining expression.  (Not even in the case of a
-       [Set_of_closures] binding, since "let symbol" is disallowed under a
-       lambda.) *)
-    let lifted_constants_from_defining_expr = DA.get_lifted_constants dacc in
-    let dacc = DA.add_lifted_constants dacc prior_lifted_constants in
-    let dacc =
-      DA.map_data_flow dacc ~f:(fun data_flow ->
-        let data_flow =
-          match Closure_info.in_or_out_of_closure closure_info with
-          | In_a_closure ->
-            (* The dependency information for lifted constants (stored in
-               [Data_flow]) is only required at the point when the constants
-               are placed.  That always happens at toplevel, never inside
-               closures -- so we don't need to do anything here. *)
-            data_flow
-          | Not_in_a_closure ->
-            let module D = LC.Definition in
-            LCS.fold lifted_constants_from_defining_expr
-              ~init:data_flow ~f:(fun data_flow lifted_constant ->
-                let data_flow =
-                  (* Record all projections as potential dependencies. *)
-                  Variable.Map.fold (fun var proj data_flow ->
-                      Data_flow.record_symbol_projection var
-                        (Symbol_projection.free_names proj)
-                        data_flow)
-                    (LC.symbol_projections lifted_constant)
-                    data_flow
-                in
-                ListLabels.fold_left (LC.definitions lifted_constant)
-                  ~init:data_flow ~f:(fun data_flow definition ->
-                    match D.descr definition with
-                    | Code code_id ->
-                      Data_flow.record_code_id_binding code_id
-                        (D.free_names definition) data_flow
-                    | Block_like { symbol; _ } ->
-                      Data_flow.record_symbol_binding symbol
-                        (D.free_names definition) data_flow
-                    | Set_of_closures { closure_symbols_with_types; _ } ->
-                      let expr = D.defining_expr definition in
-                      match Rebuilt_static_const.to_const expr with
-                      | Some const ->
-                        let set_of_closures =
-                          Static_const.must_be_set_of_closures const
-                        in
-                        let free_names =
-                          Function_declarations.free_names
-                            (Set_of_closures.function_decls set_of_closures)
-                        in
-                        let closure_elements =
-                          Set_of_closures.closure_elements set_of_closures
-                        in
-                        Closure_id.Lmap.fold (fun _ (symbol, _) data_flow ->
-                            let data_flow =
-                              Data_flow.record_symbol_binding symbol free_names
-                                data_flow
-                            in
-                            Var_within_closure.Map.fold
-                              (fun closure_var simple data_flow ->
-                                Data_flow.record_closure_element_binding
-                                  (Name.symbol symbol) closure_var
-                                  (Simple.free_names simple) data_flow)
-                              closure_elements data_flow)
-                          closure_symbols_with_types data_flow
-                      | None ->
-                        let free_names = D.free_names definition in
-                        Closure_id.Lmap.fold (fun _ (symbol, _) data_flow ->
-                            Data_flow.record_symbol_binding symbol free_names
-                            data_flow)
-                          closure_symbols_with_types data_flow))
-        in
-        ListLabels.fold_left
-          (Simplify_named_result.bindings_to_place_in_any_order
-            simplify_named_result)
-          ~init:data_flow
-          ~f:(fun data_flow
-                  (binding : Simplify_named_result.binding_to_place) ->
-            match binding.simplified_defining_expr with
-            | Invalid _ -> data_flow
-            | Reachable { free_names; named; cost_metrics = _; } ->
-              let can_be_removed =
-                match named with
-                | Simple _ | Set_of_closures _ | Rec_info _ -> true
-                | Prim (prim, _) -> P.at_most_generative_effects prim
-              in
-              if not can_be_removed then
-                Data_flow.add_used_in_current_handler free_names data_flow
-              else
-                let generate_phantom_lets =
-                  DE.generate_phantom_lets (DA.denv dacc)
-                in
-                (* CR gbury: use Bindable_let_bound.fold_all_bound_vars instead
-                   of a match here. *)
-                match binding.let_bound with
-                | Singleton v ->
-                  Data_flow.record_var_binding (VB.var v) free_names
-                    ~generate_phantom_lets data_flow
-                | Set_of_closures { closure_vars; name_mode = _; } ->
-                  ListLabels.fold_left closure_vars ~init:data_flow
-                    ~f:(fun data_flow v ->
-                      Data_flow.record_var_binding (VB.var v) free_names
-                        ~generate_phantom_lets data_flow)
-                | Symbols _ ->
-                  (* This cannot be reached.  Simplify_named does not return any
-                     symbol bindings, they all go via the lifted constants
-                     accumulator in [DA]. *)
-                  Misc.fatal_error "[Symbols] not expected here"))
-    in
-    let at_unit_toplevel = DE.at_unit_toplevel (DA.denv dacc) in
-    (* Simplify the body of the let-expression and make the new [Let] bindings
-       around the simplified body.  [Simplify_named] will already have
-       prepared [dacc] with the necessary bindings for the simplification of
-       the body. *)
-    simplify_expr dacc body
-      ~down_to_up:(fun dacc ~rebuild:rebuild_body ->
-        down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
-          rebuild_body uacc ~after_rebuild:(fun body uacc ->
-            rebuild_let simplify_named_result
-              removed_operations ~lifted_constants_from_defining_expr
-              ~at_unit_toplevel ~closure_info ~body uacc ~after_rebuild))))
+  L.pattern_match let_expr ~f:(simplify_let0 ~simplify_expr
+    ~simplify_toplevel dacc let_expr ~down_to_up)

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -18,107 +18,109 @@
 
 open! Simplify_import
 
+let rebuild_arm uacc arm (action, use_id, arity)
+      (new_let_conts, arms, identity_arms, not_arms) =
+  match
+    EB.add_wrapper_for_switch_arm uacc action
+      ~use_id (Flambda_arity.With_subkinds.of_arity arity)
+  with
+  | Apply_cont action ->
+    let action =
+      Simplify_common.clear_demoted_trap_action uacc action
+    in
+    let action =
+      (* First try to absorb any [Apply_cont] expression that forms the
+         entirety of the arm's action (via an intermediate zero-arity
+         continuation without trap action) into the [Switch] expression
+         itself. *)
+      if not (Apply_cont.is_goto action) then Some action
+      else
+        let cont = Apply_cont.continuation action in
+        let check_handler ~handler ~action =
+          match RE.to_apply_cont handler with
+          | Some action -> Some action
+          | None -> Some action
+        in
+        match UE.find_continuation (UA.uenv uacc) cont with
+        | Linearly_used_and_inlinable { handler;
+            free_names_of_handler = _; params;
+            cost_metrics_of_handler = _ } ->
+          assert (List.length params = 0);
+          check_handler ~handler ~action
+        | Non_inlinable_zero_arity { handler = Known handler; } ->
+          check_handler ~handler ~action
+        | Non_inlinable_zero_arity { handler = Unknown; } -> Some action
+        | Unreachable _ -> None
+        | Non_inlinable_non_zero_arity _
+        | Toplevel_or_function_return_or_exn_continuation _ ->
+          Misc.fatal_errorf "Inconsistency for %a between \
+              [Apply_cont.is_goto] and continuation environment \
+              in [UA]:@ %a"
+            Continuation.print cont
+            UA.print uacc
+    in
+    begin match action with
+    | None ->
+      (* The destination is unreachable; delete the [Switch] arm. *)
+      new_let_conts, arms, identity_arms, not_arms
+    | Some action ->
+      let normal_case ~identity_arms ~not_arms =
+        let arms = Targetint_31_63.Map.add arm action arms in
+        new_let_conts, arms, identity_arms, not_arms
+      in
+      (* Now check to see if the arm is of a form that might mean the
+         whole [Switch] is either the identity or a boolean NOT. *)
+      match Apply_cont.to_one_arg_without_trap_action action with
+      | None -> normal_case ~identity_arms ~not_arms
+      | Some arg ->
+        (* CR-someday mshinwell: Maybe this check should be generalised
+           e.g. to detect
+             | 0 -> apply_cont k x y 1
+             | 1 -> apply_cont k x y 0
+        *)
+        let [@inline always] const arg =
+          match Reg_width_const.descr arg with
+          | Tagged_immediate arg ->
+            if Targetint_31_63.equal arm arg then
+              let identity_arms =
+                Targetint_31_63.Map.add arm action identity_arms
+              in
+              normal_case ~identity_arms ~not_arms
+            else if
+              (Targetint_31_63.equal arm Targetint_31_63.bool_true
+                && Targetint_31_63.equal arg Targetint_31_63.bool_false)
+              ||
+                (Targetint_31_63.equal arm Targetint_31_63.bool_false
+                  && Targetint_31_63.equal arg Targetint_31_63.bool_true)
+            then
+              let not_arms = Targetint_31_63.Map.add arm action not_arms in
+              normal_case ~identity_arms ~not_arms
+            else
+              normal_case ~identity_arms ~not_arms
+          | Naked_immediate _ | Naked_float _ | Naked_int32 _
+          | Naked_int64 _ | Naked_nativeint _ ->
+            normal_case ~identity_arms ~not_arms
+        in
+        Simple.pattern_match arg ~const
+          ~name:(fun _ ~coercion:_ -> normal_case ~identity_arms ~not_arms)
+    end
+  | New_wrapper (new_cont, new_handler, free_names_of_handler,
+      cost_metrics_handler) ->
+    let new_let_cont =
+      new_cont, new_handler, free_names_of_handler, cost_metrics_handler
+    in
+    let new_let_conts = new_let_cont :: new_let_conts in
+    let action = Apply_cont.goto new_cont in
+    let arms = Targetint_31_63.Map.add arm action arms in
+    new_let_conts, arms, identity_arms, not_arms
+
 let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
       ~after_rebuild =
   let new_let_conts, arms, identity_arms, not_arms =
-    Targetint_31_63.Map.fold
-      (fun arm (action, use_id, arity)
-           (new_let_conts, arms, identity_arms, not_arms) ->
-        match
-          EB.add_wrapper_for_switch_arm uacc action
-            ~use_id (Flambda_arity.With_subkinds.of_arity arity)
-        with
-        | Apply_cont action ->
-          let action =
-            Simplify_common.clear_demoted_trap_action uacc action
-          in
-          let action =
-            (* First try to absorb any [Apply_cont] expression that forms the
-               entirety of the arm's action (via an intermediate zero-arity
-               continuation without trap action) into the [Switch] expression
-               itself. *)
-            if not (Apply_cont.is_goto action) then Some action
-            else
-              let cont = Apply_cont.continuation action in
-              let check_handler ~handler ~action =
-                match RE.to_apply_cont handler with
-                | Some action -> Some action
-                | None -> Some action
-              in
-              match UE.find_continuation (UA.uenv uacc) cont with
-              | Linearly_used_and_inlinable { handler;
-                  free_names_of_handler = _; params;
-                  cost_metrics_of_handler = _ } ->
-                assert (List.length params = 0);
-                check_handler ~handler ~action
-              | Non_inlinable_zero_arity { handler = Known handler; } ->
-                check_handler ~handler ~action
-              | Non_inlinable_zero_arity { handler = Unknown; } -> Some action
-              | Unreachable _ -> None
-              | Non_inlinable_non_zero_arity _
-              | Toplevel_or_function_return_or_exn_continuation _ ->
-                Misc.fatal_errorf "Inconsistency for %a between \
-                    [Apply_cont.is_goto] and continuation environment \
-                    in [UA]:@ %a"
-                  Continuation.print cont
-                  UA.print uacc
-          in
-          begin match action with
-          | None ->
-            (* The destination is unreachable; delete the [Switch] arm. *)
-            new_let_conts, arms, identity_arms, not_arms
-          | Some action ->
-            let normal_case ~identity_arms ~not_arms =
-              let arms = Targetint_31_63.Map.add arm action arms in
-              new_let_conts, arms, identity_arms, not_arms
-            in
-            (* Now check to see if the arm is of a form that might mean the
-               whole [Switch] is either the identity or a boolean NOT. *)
-            match Apply_cont.to_one_arg_without_trap_action action with
-            | None -> normal_case ~identity_arms ~not_arms
-            | Some arg ->
-              (* CR-someday mshinwell: Maybe this check should be generalised
-                 e.g. to detect
-                   | 0 -> apply_cont k x y 1
-                   | 1 -> apply_cont k x y 0
-              *)
-              let [@inline always] const arg =
-                match Reg_width_const.descr arg with
-                | Tagged_immediate arg ->
-                  if Targetint_31_63.equal arm arg then
-                    let identity_arms =
-                      Targetint_31_63.Map.add arm action identity_arms
-                    in
-                    normal_case ~identity_arms ~not_arms
-                  else if
-                    (Targetint_31_63.equal arm Targetint_31_63.bool_true
-                      && Targetint_31_63.equal arg Targetint_31_63.bool_false)
-                    ||
-                      (Targetint_31_63.equal arm Targetint_31_63.bool_false
-                        && Targetint_31_63.equal arg Targetint_31_63.bool_true)
-                  then
-                    let not_arms = Targetint_31_63.Map.add arm action not_arms in
-                    normal_case ~identity_arms ~not_arms
-                  else
-                    normal_case ~identity_arms ~not_arms
-                | Naked_immediate _ | Naked_float _ | Naked_int32 _
-                | Naked_int64 _ | Naked_nativeint _ ->
-                  normal_case ~identity_arms ~not_arms
-              in
-              Simple.pattern_match arg ~const
-                ~name:(fun _ ~coercion:_ -> normal_case ~identity_arms ~not_arms)
-          end
-        | New_wrapper (new_cont, new_handler, free_names_of_handler,
-            cost_metrics_handler) ->
-          let new_let_cont =
-            new_cont, new_handler, free_names_of_handler, cost_metrics_handler
-          in
-          let new_let_conts = new_let_cont :: new_let_conts in
-          let action = Apply_cont.goto new_cont in
-          let arms = Targetint_31_63.Map.add arm action arms in
-          new_let_conts, arms, identity_arms, not_arms)
+    Targetint_31_63.Map.fold (rebuild_arm uacc)
       arms
-      ([], Targetint_31_63.Map.empty, Targetint_31_63.Map.empty, Targetint_31_63.Map.empty)
+      ([], Targetint_31_63.Map.empty, Targetint_31_63.Map.empty,
+       Targetint_31_63.Map.empty)
   in
   let switch_is_identity =
     let arm_discrs = Targetint_31_63.Map.keys arms in
@@ -202,18 +204,20 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
         let uacc =
           UA.notify_removed ~operation:Removed_operations.branch uacc
         in
-        create_tagged_scrutinee uacc dest ~make_body:(fun ~tagged_scrutinee ->
+        let make_body ~tagged_scrutinee =
           (* No need to increment the cost_metrics inside [create_tagged_scrutinee] as it
              will call simplify over the result of [make_body]. *)
           Apply_cont.create dest ~args:[tagged_scrutinee] ~dbg
-          |> Expr.create_apply_cont)
+          |> Expr.create_apply_cont
+        in
+        create_tagged_scrutinee uacc dest ~make_body
       | None ->
         match switch_is_boolean_not with
         | Some dest ->
           let uacc =
             UA.notify_removed ~operation:Removed_operations.branch uacc
           in
-          create_tagged_scrutinee uacc dest ~make_body:(fun ~tagged_scrutinee ->
+          let make_body ~tagged_scrutinee =
             let not_scrutinee = Variable.create "not_scrutinee" in
             let not_scrutinee' = Simple.var not_scrutinee in
             let do_tagging =
@@ -229,7 +233,9 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
               |> Expr.create_apply_cont
             in
             Let.create bound do_tagging ~body ~free_names_of_body:Unknown
-            |> Expr.create_let)
+            |> Expr.create_let
+          in
+          create_tagged_scrutinee uacc dest ~make_body
         | None ->
           (* In that case, even though some branches were removed by simplify we
              should not count them in the number of removed operations: these
@@ -247,172 +253,174 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
           end;
           expr, uacc
   in
+  let bind_let_cont (uacc, body)
+      (new_cont, new_handler, free_names_of_handler, cost_metrics_of_handler) =
+    let free_names_of_body = UA.name_occurrences uacc in
+    let expr =
+      RE.create_non_recursive_let_cont (UA.are_rebuilding_terms uacc)
+        new_cont new_handler ~body ~free_names_of_body
+    in
+    let name_occurrences =
+      Name_occurrences.remove_continuation
+        (Name_occurrences.union free_names_of_body free_names_of_handler)
+        new_cont
+    in
+    let uacc =
+      UA.with_name_occurrences uacc ~name_occurrences
+      |> UA.add_cost_metrics
+        (Cost_metrics.increase_due_to_let_cont_non_recursive
+            ~cost_metrics_of_handler)
+    in
+    uacc, expr
+  in
   let uacc, expr =
-    ListLabels.fold_left new_let_conts ~init:(uacc, body)
-      ~f:(fun (uacc, body)
-              (new_cont, new_handler, free_names_of_handler,
-               cost_metrics_of_handler) ->
-        let free_names_of_body = UA.name_occurrences uacc in
-        let expr =
-          RE.create_non_recursive_let_cont (UA.are_rebuilding_terms uacc)
-            new_cont new_handler ~body ~free_names_of_body
-        in
-        let name_occurrences =
-          Name_occurrences.remove_continuation
-            (Name_occurrences.union free_names_of_body free_names_of_handler)
-            new_cont
-        in
-        let uacc =
-          UA.with_name_occurrences uacc ~name_occurrences
-          |> UA.add_cost_metrics
-            (Cost_metrics.increase_due_to_let_cont_non_recursive
-               ~cost_metrics_of_handler)
-        in
-        uacc, expr)
+    ListLabels.fold_left new_let_conts ~init:(uacc, body) ~f:bind_let_cont
   in
   after_rebuild expr uacc
 
+let find_cse_simple dacc prim =
+  match P.Eligible_for_cse.create prim with
+  | None -> None (* Constant *)
+  | Some with_fixed_value ->
+    match DE.find_cse (DA.denv dacc) with_fixed_value with
+    | None -> None
+    | Some simple ->
+      match
+        TE.get_canonical_simple_exn (DA.typing_env dacc) simple
+          ~min_name_mode:NM.normal
+          ~name_mode_of_existing_simple:NM.normal
+      with
+      | exception Not_found -> None
+      | simple -> Some simple
+
+let check_cse_environment dacc ~scrutinee =
+  (* When the switch is an identity or a NOT, the expression is rewritten
+     to remove the switch during the upwards pass. The switch is replaced by
+     either a tagging or a boolean NOT and a tagging. The result of the
+     tagging can be a variable for which dependencies are not tracked by
+     data_flow the usual way during simplification of lets. This could be
+     benign, if a new expression to compute it was always introduced here,
+     because there is already a dependency registered on the scrutinee. But
+     if CSE replaces it by a variable that is only used here, we can
+     create a real new dependency that didn't exist before.  For example:
+
+       let untagged = untag x
+       apply_cont k untagged (cse_arg tag(untagged) = x)
+       where k x cse_param =
+         switch x
+         | 0 -> apply_cont k2 0
+         | 1 -> apply_cont k2 1
+
+     would be rewritten to:
+
+       let untagged = untag x
+       apply_cont k untagged (cse_arg tag(untagged) = x)
+       where k x cse_param =
+         let tagged = tag x
+         apply_cont k2 tagged
+
+     And with CSE:
+
+       let untagged = untag x
+       apply_cont k untagged (cse_arg tag(untagged) = x)
+       where k x cse_param =
+         apply_cont k2 cse_param
+
+     If the tracking were not done properly, cse_param could be considered
+     dead and removed from the parameters of continuation k.
+
+     We solve this by always looking for a tagged version of the
+     scrutinee in the CSE environment and registering it as a required
+     variable like the scrutinee. If it is not available, no problem can
+     occur.
+  *)
+  match
+    find_cse_simple dacc (Unary (Box_number Untagged_immediate, scrutinee))
+  with
+  | None -> dacc
+  | Some tagged_scrutinee ->
+    let dacc =
+      DA.map_data_flow dacc ~f:(
+        Data_flow.add_used_in_current_handler
+          (Simple.free_names tagged_scrutinee))
+    in
+    match find_cse_simple dacc (Unary (Boolean_not, tagged_scrutinee)) with
+    | None -> dacc
+    | Some not_scrutinee ->
+      DA.map_data_flow dacc ~f:(
+        Data_flow.add_used_in_current_handler
+          (Simple.free_names not_scrutinee))
+
+let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
+  let shape =
+    let imm = Targetint_31_63.int (Targetint_31_63.to_targetint arm) in
+    T.this_naked_immediate imm
+  in
+  match T.meet typing_env_at_use scrutinee_ty shape with
+  | Bottom -> arms, dacc
+  | Ok (_meet_ty, env_extension) ->
+    let env_at_use =
+      TE.add_env_extension typing_env_at_use env_extension
+      |> DE.with_typing_env (DA.denv dacc)
+    in
+    let args = AC.args action in
+    let use_kind =
+      Simplify_common.apply_cont_use_kind ~context:Switch_branch action
+    in
+    match args with
+    | [] ->
+      let dacc, rewrite_id =
+        DA.record_continuation_use dacc (AC.continuation action)
+          use_kind ~env_at_use ~arg_types:[]
+      in
+      let dacc =
+        DA.map_data_flow dacc ~f:(
+          Data_flow.add_apply_cont_args
+            (Apply_cont.continuation action)
+            (List.map Simple.free_names args))
+      in
+      let arms = Targetint_31_63.Map.add arm (action, rewrite_id, []) arms in
+      arms, dacc
+    | _::_ ->
+      let { S. simples = args; simple_tys = arg_types; } =
+        S.simplify_simples dacc args
+      in
+      let dacc, rewrite_id =
+        DA.record_continuation_use dacc (AC.continuation action)
+          use_kind ~env_at_use ~arg_types
+      in
+      let arity = List.map T.kind arg_types in
+      let action = Apply_cont.update_args action ~args in
+      let dacc =
+        DA.map_data_flow dacc ~f:(
+          Data_flow.add_apply_cont_args
+            (Apply_cont.continuation action)
+            (List.map Simple.free_names args))
+      in
+      let arms =
+        Targetint_31_63.Map.add arm (action, rewrite_id, arity) arms
+      in
+      arms, dacc
+
 let simplify_switch ~simplify_let dacc switch ~down_to_up =
-  let module AC = Apply_cont in
   let scrutinee = Switch.scrutinee switch in
   let scrutinee_ty =
     S.simplify_simple dacc scrutinee ~min_name_mode:NM.normal
   in
   let scrutinee = T.get_alias_exn scrutinee_ty in
+  let typing_env_at_use = DA.typing_env dacc in
   let arms, dacc =
-    let typing_env_at_use = DA.typing_env dacc in
-    Targetint_31_63.Map.fold (fun arm action (arms, dacc) ->
-        let shape =
-          let imm = Targetint_31_63.int (Targetint_31_63.to_targetint arm) in
-          T.this_naked_immediate imm
-        in
-        match T.meet typing_env_at_use scrutinee_ty shape with
-        | Bottom -> arms, dacc
-        | Ok (_meet_ty, env_extension) ->
-          let env_at_use =
-            TE.add_env_extension typing_env_at_use env_extension
-            |> DE.with_typing_env (DA.denv dacc)
-          in
-          let args = AC.args action in
-          let use_kind =
-            Simplify_common.apply_cont_use_kind ~context:Switch_branch action
-          in
-          match args with
-          | [] ->
-            let dacc, rewrite_id =
-              DA.record_continuation_use dacc (AC.continuation action)
-                use_kind ~env_at_use ~arg_types:[]
-            in
-            let dacc =
-              DA.map_data_flow dacc ~f:(
-                Data_flow.add_apply_cont_args
-                  (Apply_cont.continuation action)
-                  (List.map Simple.free_names args))
-            in
-            let arms = Targetint_31_63.Map.add arm (action, rewrite_id, []) arms in
-            arms, dacc
-          | _::_ ->
-            let { S. simples = args; simple_tys = arg_types; } =
-              S.simplify_simples dacc args
-            in
-            let dacc, rewrite_id =
-              DA.record_continuation_use dacc (AC.continuation action)
-                use_kind ~env_at_use ~arg_types
-            in
-            let arity = List.map T.kind arg_types in
-            let action = Apply_cont.update_args action ~args in
-            let dacc =
-              DA.map_data_flow dacc ~f:(
-                Data_flow.add_apply_cont_args
-                  (Apply_cont.continuation action)
-                  (List.map Simple.free_names args))
-            in
-            let arms =
-              Targetint_31_63.Map.add arm (action, rewrite_id, arity) arms
-            in
-            arms, dacc)
+    Targetint_31_63.Map.fold (simplify_arm ~typing_env_at_use ~scrutinee_ty)
       (Switch.arms switch)
       (Targetint_31_63.Map.empty, dacc)
-    in
-    let find_cse_simple prim =
-      match P.Eligible_for_cse.create prim with
-      | None -> None (* Constant *)
-      | Some with_fixed_value ->
-        match DE.find_cse (DA.denv dacc) with_fixed_value with
-        | None -> None
-        | Some simple ->
-          match
-            TE.get_canonical_simple_exn (DA.typing_env dacc) simple
-              ~min_name_mode:NM.normal
-              ~name_mode_of_existing_simple:NM.normal
-          with
-          | exception Not_found -> None
-          | simple -> Some simple
-    in
-    let dacc =
-      (* When the switch is an identity or a NOT, the expression is rewritten
-         to remove the switch during the upwards pass. The switch is replaced by
-         either a tagging or a boolean NOT and a tagging. The result of the
-         tagging can be a variable for which dependencies are not tracked by
-         data_flow the usual way during simplification of lets. This could be
-         benign, if a new expression to compute it was always introduced here,
-         because there is already a dependency registered on the scrutinee. But
-         if CSE replaces it by a variable that is only used here, we can
-         create a real new dependency that didn't exist before.  For example:
-
-           let untagged = untag x
-           apply_cont k untagged (cse_arg tag(untagged) = x)
-           where k x cse_param =
-             switch x
-             | 0 -> apply_cont k2 0
-             | 1 -> apply_cont k2 1
-
-         would be rewritten to:
-
-           let untagged = untag x
-           apply_cont k untagged (cse_arg tag(untagged) = x)
-           where k x cse_param =
-             let tagged = tag x
-             apply_cont k2 tagged
-
-         And with CSE:
-
-           let untagged = untag x
-           apply_cont k untagged (cse_arg tag(untagged) = x)
-           where k x cse_param =
-             apply_cont k2 cse_param
-
-         If the tracking were not done properly, cse_param could be considered
-         dead and removed from the parameters of continuation k.
-
-         We solve this by always looking for a tagged version of the
-         scrutinee in the CSE environment and registering it as a required
-         variable like the scrutinee. If it is not available, no problem can
-         occur.
-      *)
-      match
-        find_cse_simple (Unary (Box_number Untagged_immediate, scrutinee))
-      with
-      | None -> dacc
-      | Some tagged_scrutinee ->
-        let dacc =
-          DA.map_data_flow dacc ~f:(
-            Data_flow.add_used_in_current_handler
-              (Simple.free_names tagged_scrutinee))
-        in
-        match find_cse_simple (Unary (Boolean_not, tagged_scrutinee)) with
-        | None -> dacc
-        | Some not_scrutinee ->
-          DA.map_data_flow dacc ~f:(
-            Data_flow.add_used_in_current_handler
-              (Simple.free_names not_scrutinee))
-    in
-    let dacc =
-      if Targetint_31_63.Map.cardinal arms <= 1 then dacc
-      else
-        DA.map_data_flow dacc ~f:(
-          Data_flow.add_used_in_current_handler (Simple.free_names scrutinee))
-    in
-    down_to_up dacc
-      ~rebuild:(rebuild_switch ~simplify_let dacc ~arms ~scrutinee
-        ~scrutinee_ty)
+  in
+  let dacc = check_cse_environment dacc ~scrutinee in
+  let dacc =
+    if Targetint_31_63.Map.cardinal arms <= 1 then dacc
+    else
+      DA.map_data_flow dacc ~f:(
+        Data_flow.add_used_in_current_handler (Simple.free_names scrutinee))
+  in
+  down_to_up dacc
+    ~rebuild:(rebuild_switch ~simplify_let dacc ~arms ~scrutinee
+      ~scrutinee_ty)


### PR DESCRIPTION
As discussed there is a problem in `ocamlformat` (which I am discussing with upstream) whereby anonymous functions are often indented by 4 spaces instead of 2.  This particularly affects readability of the simplifier code.  In this patch I've split most of the anonymous functions involved in the basic control flow of the simplifier, so they are lifted out and named.  In fact I think this is a significant readability improvement in places (a good example is the dataflow-related parts of `Simplify_let`).  I also reckon this is probably a good step along the way to defunctionalising the simplifier -- the various things that would need to be captured in the "reversed expressions" are now enumerated in the parameter lists of lifted functions (e.g. the new ones in `Simplify_let_cont`).

You'll have to trust me that there are no semantic changes in this patch, but I believe there to be none.