### PR TITLE
Add inlined debuginfo when simplifying cont apps

### DIFF
--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -153,4 +153,7 @@ let simplify_apply_cont dacc apply_cont ~down_to_up =
     DA.record_continuation_use dacc (AC.continuation apply_cont)
       use_kind ~env_at_use:(DA.denv dacc) ~arg_types
   in
+  let dbg = AC.debuginfo apply_cont in
+  let dbg = DE.add_inlined_debuginfo' (DA.denv dacc) dbg in
+  let apply_cont = AC.with_debuginfo apply_cont ~dbg in
   down_to_up dacc ~rebuild:(rebuild_apply_cont apply_cont ~args ~rewrite_id)

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -268,6 +268,10 @@ let update_args t ~args =
   if args == t.args then t
   else { t with args; }
 
+let with_debuginfo t ~dbg =
+  if dbg == t.dbg then t
+  else { t with dbg; }
+
 let no_args t =
   match args t with
   | [] -> true

--- a/middle_end/flambda2/terms/apply_cont_expr.mli
+++ b/middle_end/flambda2/terms/apply_cont_expr.mli
@@ -54,6 +54,8 @@ val update_continuation_and_args
 
 val update_args : t -> args:Simple.t list -> t
 
+val with_debuginfo : t -> dbg:Debuginfo.t -> t
+
 val is_goto : t -> bool
 
 val is_goto_to : t -> Continuation.t -> bool


### PR DESCRIPTION
Failing to add inlined debuginfo meant that inlining a function that
raises an exception would leave the debuginfo in the inlined code
alone, thus leaving out the calling function from the stack trace.

So, the source

    let my_raise exn = raise exn
    let f () = my_raise Not_found

gets CPS'd to

    let my_raise exn k e = raise e exn [dbg my_raise]
    let f () k e = my_raise exn k e [dbg f]

and then inlining _should_ produce

    let f () k e = raise e exn [dbg f;my_raise]

but if we forget to adjust the debuginfo for a continuation
application (including a `raise`), we get instead

    let f () k e = raise e exn [dbg my_raise]

and `f` now doesn't appear in the stack trace.

(Worth noting that "inlined debuginfo" is actually about the
_caller(s)_, not the inlined function.)