### PR TITLE
Refactor the check for macosx system when emitting probes

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1384,12 +1384,17 @@ let emit_probe_handler_wrapper p =
   emit_function_type_and_size wrap_label
 
 let emit_probe_notes0 () =
-  begin match system with
-  | S_gnu | S_cygwin | S_solaris | S_win32 | S_linux_elf | S_bsd_elf
-  | S_beos | S_mingw | S_win64 | S_linux | S_mingw64 | S_unknown ->
-    D.section [".note.stapsdt"] (Some "?") [ "\"note\"" ]
-  | S_macosx -> D.section ["__DATA";"__note_stapsdt"] None ["regular"]
-  end;
+  let is_macosx_system =
+    match system with
+    | S_macosx -> (* CR-someday gyorsh: emit dtrace format on mac *) true
+    | S_gnu | S_solaris | S_linux_elf | S_bsd_elf
+    | S_beos | S_linux  -> false
+    | S_cygwin | S_mingw | S_mingw64 | S_win64 | S_win32 | S_unknown ->
+      Misc.fatal_error "emit_probe_notes: unexpected system"
+  in
+  (match is_macosx_system with
+   | false -> D.section [".note.stapsdt"] (Some "?") [ "\"note\"" ]
+   | true -> D.section ["__DATA";"__note_stapsdt"] None ["regular"]);
   let stap_arg arg =
     let arg_name =
       match arg.loc with
@@ -1431,14 +1436,9 @@ let emit_probe_notes0 () =
     D.align 4;
     def_label c;
     D.qword (ConstLabel (emit_label p.probe_label));
-    begin match system with
-    | S_gnu | S_cygwin | S_solaris | S_win32 | S_linux_elf | S_bsd_elf
-    | S_beos | S_mingw | S_win64 | S_linux | S_mingw64 | S_unknown ->
-      D.qword (ConstLabel "_.stapsdt.base")
-    | S_macosx ->
-      (* CR-soon gyorsh: emit dtrace format on mac  *)
-      D.qword (const 0)
-    end;
+    (match is_macosx_system with
+     | false -> D.qword (ConstLabel "_.stapsdt.base")
+     | true -> D.qword (const 0));
     D.qword (ConstLabel semaphore_label);
     D.bytes "ocaml.1\000";
     D.bytes (probe_name ^ "\000");
@@ -1447,24 +1447,18 @@ let emit_probe_notes0 () =
     D.align 4;
   in
   List.iter describe_one_probe !probes;
-  begin match system with
-  | S_gnu | S_cygwin | S_solaris | S_win32 | S_linux_elf | S_bsd_elf
-  | S_beos | S_mingw | S_win64 | S_linux | S_mingw64 | S_unknown ->
-    D.section [".stapsdt.base"] (Some "aG")
-      ["\"progbits\""; ".stapsdt.base"; "comdat"];
-    D.weak "_.stapsdt.base";
-    D.hidden "_.stapsdt.base";
-    D.label "_.stapsdt.base";
-    D.space 1;
-    D.size "_.stapsdt.base" (const 1)
-  | S_macosx -> ()
-  end;
-  begin match system with
-  | S_gnu | S_cygwin | S_solaris | S_win32 | S_linux_elf | S_bsd_elf
-  | S_beos | S_mingw | S_win64 | S_linux | S_mingw64 | S_unknown ->
-    D.section [".probes"] (Some "wa") ["\"progbits\""];
-  | S_macosx -> D.section ["__TEXT";"__probes"] None ["regular"]
-  end;
+  (match is_macosx_system with
+   | false ->
+     D.section [".stapsdt.base"] (Some "aG")
+       ["\"progbits\""; ".stapsdt.base"; "comdat"];
+     D.weak "_.stapsdt.base";
+     D.hidden "_.stapsdt.base";
+     D.label "_.stapsdt.base";
+     D.space 1;
+     D.size "_.stapsdt.base" (const 1);
+     D.section [".probes"] (Some "wa") ["\"progbits\""]
+   | true ->
+     D.section ["__TEXT";"__probes"] None ["regular"]);
   D.align 2;
   String.Map.iter (fun _ label ->
       D.weak label;


### PR DESCRIPTION
Follow-up on https://github.com/ocaml-flambda/flambda-backend/pull/142#discussion_r701792120. 
This PR is on top of #142, only the last commit is new.

This PR refactors the checks for whether the `system` is `S_macosx` or not, making the code simpler and easier to read. 

Probes for Windows and MacOS are not supported (disabled at configure time). The code for Macos is there if in the future we want to add support Dtrace probes, however the syntax for section names and some other assembly directive syntax is slightly from other targets. 

