### PR TITLE
Do not allocate slots for closure_ids in phantom set_of_closures

### DIFF
--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -138,7 +138,11 @@ module Iter = struct
   and named let_expr (bindable_let_bound : Bindable_let_bound.t) f_c f_s n =
     match (n : Named.t) with
     | Simple _ | Prim _ | Rec_info _ -> ()
-    | Set_of_closures s -> f_s ~closure_symbols:None s
+    | Set_of_closures s ->
+      let is_phantom =
+        Name_mode.is_phantom (Bindable_let_bound.name_mode bindable_let_bound)
+      in
+      f_s ~closure_symbols:None ~is_phantom s
     | Static_consts consts -> (
       match bindable_let_bound with
       | Symbols { bound_symbols; _ } ->
@@ -206,13 +210,14 @@ module Iter = struct
                  ~my_depth:_
                -> expr f_c f_s body))
       ~set_of_closures:(fun () ~closure_symbols set_of_closures ->
-        f_s ~closure_symbols:(Some closure_symbols) set_of_closures)
+        f_s ~closure_symbols:(Some closure_symbols) ~is_phantom:false
+          set_of_closures)
       ~block_like:(fun () _ _ -> ())
 end
 
 let ignore_code ~id:_ _ = ()
 
-let ignore_set_of_closures ~closure_symbols:_ _ = ()
+let ignore_set_of_closures ~closure_symbols:_ ~is_phantom:_ _ = ()
 
 let iter ?(code = ignore_code) ?(set_of_closures = ignore_set_of_closures) t =
   Iter.expr code set_of_closures t.body

--- a/middle_end/flambda2/terms/flambda_unit.mli
+++ b/middle_end/flambda2/terms/flambda_unit.mli
@@ -52,6 +52,7 @@ val iter :
   ?code:(id:Code_id.t -> Flambda.Code.t -> unit) ->
   ?set_of_closures:
     (closure_symbols:Symbol.t Closure_id.Lmap.t option ->
+    is_phantom:bool ->
     Flambda.Set_of_closures.t ->
     unit) ->
   t ->

--- a/middle_end/flambda2/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda2/to_cmm/un_cps_closure.ml
@@ -626,8 +626,11 @@ end
 let compute_offsets env code unit =
   let state = ref (Greedy.create_initial_state env) in
   let used_closure_vars = Flambda_unit.used_closure_vars unit in
-  let aux ~closure_symbols:_ s =
-    state := Greedy.create_slots_for_set !state code used_closure_vars s
+  let aux ~closure_symbols:_ ~is_phantom s =
+    if not is_phantom then
+      (* if the definition is a phantom one, there is no need to attribute
+          a slot. Also a phantom declaration can refer to a dead code_id. *)
+      state := Greedy.create_slots_for_set !state code used_closure_vars s
   in
   Flambda_unit.iter unit ~set_of_closures:aux;
   Misc.try_finally

--- a/middle_end/flambda2/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda2/to_cmm/un_cps_closure.ml
@@ -627,9 +627,10 @@ let compute_offsets env code unit =
   let state = ref (Greedy.create_initial_state env) in
   let used_closure_vars = Flambda_unit.used_closure_vars unit in
   let aux ~closure_symbols:_ ~is_phantom s =
-    if not is_phantom then
-      (* if the definition is a phantom one, there is no need to attribute
-          a slot. Also a phantom declaration can refer to a dead code_id. *)
+    if not is_phantom
+    then
+      (* if the definition is a phantom one, there is no need to attribute a
+         slot. Also a phantom declaration can refer to a dead code_id. *)
       state := Greedy.create_slots_for_set !state code used_closure_vars s
   in
   Flambda_unit.iter unit ~set_of_closures:aux;


### PR DESCRIPTION
When a phantom set of closure is the only reference to code_id, data_flow removes the code_id.

Apparently, right now phantom expression can reference dead symbols. There are no assertion preventing that. The only one that are really checked are code_id referenced from phantom set_of_closures. To handle that correctly Data_flow would have to track separately the live and the phantom values.

If we don't care about keeping the references to dead symbols, or as a stopgap solution this resolve the problem of unbound code_id as seen for instance in kyotocabinet.

Note that even if we were to track the references to phantom symbols in data_flow, we would still want this change because this prevents code_id referenced in dead set_of_closures to worsening the shape of other closures referencing the same code_id. (But I don't think that this can happen right now) 