### PR TITLE
Disable ocamlformat on printing functions

### DIFF
--- a/middle_end/flambda2/basic/closure_id.ml
+++ b/middle_end/flambda2/basic/closure_id.ml
@@ -37,7 +37,7 @@ module Self = Container_types.Make (struct
 
   let hash t = t.name_stamp lxor (Compilation_unit.hash t.compilation_unit)
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "@<0>%s" (Flambda_colours.closure_element ());
     if Compilation_unit.equal t.compilation_unit
         (Compilation_unit.get_current_exn ())

--- a/middle_end/flambda2/basic/code_id.ml
+++ b/middle_end/flambda2/basic/code_id.ml
@@ -30,7 +30,7 @@ module Code_id_data = struct
 
   let flags = 0
 
-  let print ppf { compilation_unit; name; linkage_name; } =
+  let [@ocamlformat "disable"] print ppf { compilation_unit; name; linkage_name; } =
     Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(compilation_unit@ %a)@]@ \
         @[<hov 1>(name@ %s)@]@ \
@@ -108,7 +108,7 @@ module T0 = struct
   let equal = Id.equal
   let hash = Id.hash
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "@<0>%s%a@<0>%s"
       (Flambda_colours.code_id ())
       Linkage_name.print (linkage_name t)
@@ -123,8 +123,8 @@ module T = struct
   include T0
 end
 
-module Set = Patricia_tree.Make_set (struct let print = print end)
-module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
+module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
+module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
 module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 module Lmap = Lmap.Make(T)
 

--- a/middle_end/flambda2/basic/code_id.ml
+++ b/middle_end/flambda2/basic/code_id.ml
@@ -123,8 +123,8 @@ module T = struct
   include T0
 end
 
-module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
-module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
+module Set = Patricia_tree.Make_set (struct let print = print end)
+module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
 module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 module Lmap = Lmap.Make(T)
 

--- a/middle_end/flambda2/basic/code_id_or_symbol.ml
+++ b/middle_end/flambda2/basic/code_id_or_symbol.ml
@@ -21,7 +21,7 @@ type t =
 include Container_types.Make (struct
   type nonrec t = t
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Code_id code_id ->
       Format.fprintf ppf "@[<hov 1>(code_id@ %a)@]" Code_id.print code_id

--- a/middle_end/flambda2/basic/coeffects.ml
+++ b/middle_end/flambda2/basic/coeffects.ml
@@ -18,7 +18,7 @@
 
 type t = No_coeffects | Has_coeffects
 
-let print ppf co =
+let [@ocamlformat "disable"] print ppf co =
   match co with
   | No_coeffects -> Format.fprintf ppf "no coeffects"
   | Has_coeffects -> Format.fprintf ppf "has coeffects"

--- a/middle_end/flambda2/basic/coercion.ml
+++ b/middle_end/flambda2/basic/coercion.ml
@@ -16,7 +16,7 @@
 
 include Reg_width_things.Coercion
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let free_names t =
   match t with

--- a/middle_end/flambda2/basic/continuation.ml
+++ b/middle_end/flambda2/basic/continuation.ml
@@ -178,8 +178,8 @@ include Container_types.Make (struct
     print (Format.formatter_of_out_channel chan) t
 end)
 
-module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
-module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
+module Set = Patricia_tree.Make_set (struct let print = print end)
+module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
 (* CR mshinwell: The [Tbl]s will still print integers! *)
 module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 

--- a/middle_end/flambda2/basic/continuation.ml
+++ b/middle_end/flambda2/basic/continuation.ml
@@ -47,7 +47,7 @@ module Sort = struct
     | Define_root_symbol -> "Define_root_symbol"
     | Toplevel_return -> "Toplevel_return"
 
-  let print ppf t = Format.pp_print_string ppf (to_string t)
+  let [@ocamlformat "disable"] print ppf t = Format.pp_print_string ppf (to_string t)
 
   let equal t1 t2 =
     match t1, t2 with
@@ -72,7 +72,7 @@ module Data = struct
 
   let flags = continuation_flags
 
-  let print ppf { compilation_unit; name; name_stamp; sort;
+  let [@ocamlformat "disable"] print ppf { compilation_unit; name; name_stamp; sort;
                   previous_compilation_units = _; } =
     Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(compilation_unit@ %a)@]@ \
@@ -167,7 +167,7 @@ include Container_types.Make (struct
   let hash t =
     Hashtbl.hash t
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "@<0>%s" (Flambda_colours.continuation ());
     if String.equal (name t) "k"
     then Format.fprintf ppf "k%d" (name_stamp t)
@@ -178,12 +178,12 @@ include Container_types.Make (struct
     print (Format.formatter_of_out_channel chan) t
 end)
 
-module Set = Patricia_tree.Make_set (struct let print = print end)
-module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
+module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
+module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
 (* CR mshinwell: The [Tbl]s will still print integers! *)
 module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let export t = find_data t
 
@@ -216,7 +216,7 @@ module With_args = struct
       Hashtbl.hash (hash (fst t),
         List.map Variable.hash (snd t))
 
-    let print ppf (cont, vars) =
+    let [@ocamlformat "disable"] print ppf (cont, vars) =
       Format.fprintf ppf "@[(%a, %a)@]"
         print cont
         Variable.print_list vars

--- a/middle_end/flambda2/basic/continuation_extra_params_and_args.ml
+++ b/middle_end/flambda2/basic/continuation_extra_params_and_args.ml
@@ -23,7 +23,7 @@ module Extra_arg = struct
     | New_let_binding_with_named_args of
         Variable.t * (Simple.t list -> Flambda_primitive.t)
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Already_in_scope simple ->
       Format.fprintf ppf "@[<hov 1>(Already_in_scope@ %a)@]"
@@ -39,7 +39,7 @@ module Extra_arg = struct
   module List = struct
     type nonrec t = t list
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       Format.fprintf ppf "(%a)"
         (Format.pp_print_list ~pp_sep:Format.pp_print_space print) t
   end
@@ -50,7 +50,7 @@ type t = {
   extra_args : Extra_arg.t list Apply_cont_rewrite_id.Map.t;
 }
 
-let print ppf { extra_params; extra_args; } =
+let [@ocamlformat "disable"] print ppf { extra_params; extra_args; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(extra_params@ %a)@]@ \
       @[<hov 1>(extra_args@ %a)@]\

--- a/middle_end/flambda2/basic/effects.ml
+++ b/middle_end/flambda2/basic/effects.ml
@@ -23,7 +23,7 @@ type t =
   | Only_generative_effects of Mutability.t
   | Arbitrary_effects
 
-let print ppf eff =
+let [@ocamlformat "disable"] print ppf eff =
   match eff with
   | No_effects ->
       Format.fprintf ppf "no effects"

--- a/middle_end/flambda2/basic/effects_and_coeffects.ml
+++ b/middle_end/flambda2/basic/effects_and_coeffects.ml
@@ -15,7 +15,7 @@
 
 type t = Effects.t * Coeffects.t
 
-let print fmt (eff, coeff) =
+let [@ocamlformat "disable"] print fmt (eff, coeff) =
   Format.fprintf fmt "%a * %a" Effects.print eff Coeffects.print coeff
 
 let compare (e1, c1) (e2, c2) =

--- a/middle_end/flambda2/basic/exn_continuation.ml
+++ b/middle_end/flambda2/basic/exn_continuation.ml
@@ -29,7 +29,7 @@ include Container_types.Make (struct
       Simple.print simple
       Flambda_kind.With_subkind.print kind
 
-  let print ppf { exn_handler; extra_args; } =
+  let [@ocamlformat "disable"] print ppf { exn_handler; extra_args; } =
     match extra_args with
     | [] -> Continuation.print ppf exn_handler
     | _ ->
@@ -72,7 +72,7 @@ include Container_types.Make (struct
   let hash _ = Misc.fatal_error "Exn_continuation.hash not yet implemented"
 end)
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let create ~exn_handler ~extra_args =
   begin match Continuation.sort exn_handler with

--- a/middle_end/flambda2/basic/id_types.ml
+++ b/middle_end/flambda2/basic/id_types.ml
@@ -60,7 +60,7 @@ module Id(_:sig end) : Id = struct
     then Int.to_string t
     else Printf.sprintf "%s_%i" name t
   let output fd t = output_string fd (to_string t)
-  let print ppf v = Format.pp_print_string ppf (to_string v)
+  let [@ocamlformat "disable"] print ppf v = Format.pp_print_string ppf (to_string v)
 end
 
 module UnitId(Innerid:Id)(Compilation_unit:Container_types.Thing) :
@@ -78,7 +78,7 @@ module UnitId(Innerid:Id)(Compilation_unit:Container_types.Thing) :
     Printf.fprintf oc "%a.%a"
       Compilation_unit.output x.unit
       Innerid.output x.id
-  let print ppf x =
+  let [@ocamlformat "disable"] print ppf x =
     Format.fprintf ppf "%a.%a"
       Compilation_unit.print x.unit
       Innerid.print x.id

--- a/middle_end/flambda2/basic/inline_attribute.ml
+++ b/middle_end/flambda2/basic/inline_attribute.ml
@@ -23,7 +23,7 @@ type t =
   | Unroll of int
   | Default_inline
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   let fprintf = Format.fprintf in
   match t with
   | Always_inline -> fprintf ppf "Always_inline"

--- a/middle_end/flambda2/basic/invalid_term_semantics.ml
+++ b/middle_end/flambda2/basic/invalid_term_semantics.ml
@@ -20,7 +20,7 @@ type t =
   | Treat_as_unreachable
   | Halt_and_catch_fire
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Treat_as_unreachable -> Format.pp_print_string ppf "Treat_as_unreachable"
   | Halt_and_catch_fire -> Format.pp_print_string ppf "Halt_and_catch_fire"

--- a/middle_end/flambda2/basic/kinded_parameter.ml
+++ b/middle_end/flambda2/basic/kinded_parameter.ml
@@ -38,7 +38,7 @@ include Container_types.Make (struct
   let hash { param; kind; } =
     Hashtbl.hash (Variable.hash param, Flambda_kind.With_subkind.hash kind)
 
-  let print ppf { param; kind; } =
+  let [@ocamlformat "disable"] print ppf { param; kind; } =
     Format.fprintf ppf "@[(@<0>%s%a@<0>%s @<1>\u{2237} %a)@]"
       (Flambda_colours.parameter ())
       Variable.print param
@@ -49,7 +49,7 @@ include Container_types.Make (struct
     print (Format.formatter_of_out_channel chan) t
 end)
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let create param kind =
   { param;
@@ -123,7 +123,7 @@ module List = struct
     List.compare_lengths t1 t2 = 0
       && List.for_all2 equal t1 t2
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "@[<hov 0>%a@]"
       (Format.pp_print_list ~pp_sep:Format.pp_print_space print) t
 

--- a/middle_end/flambda2/basic/mutability.ml
+++ b/middle_end/flambda2/basic/mutability.ml
@@ -18,7 +18,7 @@
 
 type t = Mutable | Immutable | Immutable_unique
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Mutable -> Format.pp_print_string ppf "Mutable"
   | Immutable -> Format.pp_print_string ppf "Immutable"

--- a/middle_end/flambda2/basic/or_deleted.ml
+++ b/middle_end/flambda2/basic/or_deleted.ml
@@ -20,7 +20,7 @@ type 'a t =
   | Present of 'a
   | Deleted
 
-let print print_contents ppf t =
+let [@ocamlformat "disable"] print print_contents ppf t =
   match t with
   | Present contents -> print_contents ppf contents
   | Deleted -> Format.pp_print_string ppf "Deleted"

--- a/middle_end/flambda2/basic/or_variable.ml
+++ b/middle_end/flambda2/basic/or_variable.ml
@@ -20,7 +20,7 @@ type 'a t =
   | Const of 'a
   | Var of Variable.t
 
-let print print_const ppf t =
+let [@ocamlformat "disable"] print print_const ppf t =
   match t with
   | Const cst -> print_const ppf cst
   | Var var -> Variable.print ppf var

--- a/middle_end/flambda2/basic/recursive.ml
+++ b/middle_end/flambda2/basic/recursive.ml
@@ -18,7 +18,7 @@
 
 type t = Non_recursive | Recursive
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Non_recursive -> Format.pp_print_string ppf "Non_recursive"
   | Recursive -> Format.pp_print_string ppf "Recursive"

--- a/middle_end/flambda2/basic/scope.ml
+++ b/middle_end/flambda2/basic/scope.ml
@@ -37,6 +37,6 @@ let to_int t = t
 
 let max t1 t2 = max t1 t2
 
-module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
-module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
+module Set = Patricia_tree.Make_set (struct let print = print end)
+module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
 module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)

--- a/middle_end/flambda2/basic/scope.ml
+++ b/middle_end/flambda2/basic/scope.ml
@@ -37,6 +37,6 @@ let to_int t = t
 
 let max t1 t2 = max t1 t2
 
-module Set = Patricia_tree.Make_set (struct let print = print end)
-module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
+module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
+module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
 module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)

--- a/middle_end/flambda2/basic/simple.ml
+++ b/middle_end/flambda2/basic/simple.ml
@@ -130,7 +130,7 @@ module List = struct
     let hash t =
       Hashtbl.hash (List.map hash t)
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       (Format.pp_print_list print ~pp_sep:Format.pp_print_space) ppf t
 
     let output chan t =
@@ -174,7 +174,7 @@ module With_kind = struct
     let hash (s, k) =
       Hashtbl.hash (hash s, Flambda_kind.hash k)
 
-    let print ppf (s, k) =
+    let [@ocamlformat "disable"] print ppf (s, k) =
       Format.fprintf ppf "@[(%a@ @<1>\u{2237}@ %a)@]"
         print s
         Flambda_kind.print k

--- a/middle_end/flambda2/basic/symbol_scoping_rule.ml
+++ b/middle_end/flambda2/basic/symbol_scoping_rule.ml
@@ -20,7 +20,7 @@ type t =
 
 let compare = Stdlib.compare
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Syntactic -> Format.pp_print_string ppf "Syntactic"
   | Dominator -> Format.pp_print_string ppf "Dominator"

--- a/middle_end/flambda2/basic/trap_action.ml
+++ b/middle_end/flambda2/basic/trap_action.ml
@@ -55,7 +55,7 @@ let raise_kind_option_to_string = function
   | Some Reraise -> " (reraise)"
   | Some No_trace -> " (notrace)"
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   let fprintf = Format.fprintf in
   match t with
   | Push { exn_handler; } ->
@@ -74,7 +74,7 @@ let print ppf t =
       (Flambda_colours.expr_keyword ())
       (Flambda_colours.normal ())
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let invariant _env _t = ()
 
@@ -108,7 +108,7 @@ let all_ids_for_export t =
 module Option = struct
   type nonrec t = t option
 
-  let print ppf = function
+  let [@ocamlformat "disable"] print ppf = function
     | None -> ()
     | Some t -> print ppf t
 

--- a/middle_end/flambda2/basic/var_within_closure.ml
+++ b/middle_end/flambda2/basic/var_within_closure.ml
@@ -37,7 +37,7 @@ module Self = Container_types.Make (struct
 
   let hash t = t.name_stamp lxor (Compilation_unit.hash t.compilation_unit)
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "@<0>%s" (Flambda_colours.closure_var ());
     if Compilation_unit.equal t.compilation_unit
         (Compilation_unit.get_current_exn ())

--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -28,7 +28,7 @@ module Calling_convention = struct
   let params_arity t = t.params_arity
   let is_tupled t = t.is_tupled
 
-  let print ppf { needs_closure_arg; params_arity; is_tupled } =
+  let [@ocamlformat "disable"] print ppf { needs_closure_arg; params_arity; is_tupled } =
     Format.fprintf ppf
       "@[<hov 1>(needs_closure_arg@ %b)@] \
        @[<hov 1>(is_tupled@ %b)@] \
@@ -88,7 +88,7 @@ let print0 ppf t0 =
       "@[<hov 1>(Imported@ (calling_convention@ %a))@]"
       Calling_convention.print calling_convention
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Code_id.Map.print print0 ppf t
 
 let empty = Code_id.Map.empty

--- a/middle_end/flambda2/cmx/exported_offsets.ml
+++ b/middle_end/flambda2/cmx/exported_offsets.ml
@@ -46,7 +46,7 @@ let print_closure_info fmt (info: closure_info) =
 let print_env_var_info fmt (info: env_var_info) =
   Format.fprintf fmt "@[<h>(o:%d)@]" info.offset
 
-let print fmt env =
+let [@ocamlformat "disable"] print fmt env =
   Format.fprintf fmt "{@[<v>closures: @[<v>%a@]@,env_vars: @[<v>%a@]@]}"
     (Closure_id.Map.print print_closure_info) env.closure_offsets
     (Var_within_closure.Map.print print_env_var_info) env.env_var_offsets

--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -251,7 +251,7 @@ let print0 ppf t =
   Format.fprintf ppf "@[<hov>Offsets:@ %a@]@;"
     Exported_offsets.print t.exported_offsets
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   let rec print_rest ppf = function
     | [] -> ()
     | t0 :: t ->

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -101,7 +101,7 @@ module Comparison = struct
     if cond then t else Different { approximant = approximant () }
   ;;
 
-  let print f ppf t =
+  let [@ocamlformat "disable"] print f ppf t =
     match t with
     | Equivalent -> Format.fprintf ppf "Equivalent"
     | Different { approximant } ->

--- a/middle_end/flambda2/compilenv_deps/coercion0.ml
+++ b/middle_end/flambda2/compilenv_deps/coercion0.ml
@@ -91,7 +91,7 @@ module Make(Rec_info_expr : Rec_info_expr0.S)
       ignore (to_1, from2);
       Some (change_depth ~from:from1 ~to_:to_2)
 
-  let print ppf = function
+  let [@ocamlformat "disable"] print ppf = function
     | Id ->
       Format.fprintf ppf "@<0>%sid@<0>%s"
         (Flambda_colours.elide ())

--- a/middle_end/flambda2/compilenv_deps/compilation_unit.ml
+++ b/middle_end/flambda2/compilenv_deps/compilation_unit.ml
@@ -51,7 +51,7 @@ include Container_types.Make (struct
 
   let equal = equal0
 
-  let print ppf t = Format.pp_print_string ppf (string_for_printing t)
+  let [@ocamlformat "disable"] print ppf t = Format.pp_print_string ppf (string_for_printing t)
 
   let output chan t =
     print (Format.formatter_of_out_channel chan) t

--- a/middle_end/flambda2/compilenv_deps/container_types.ml
+++ b/middle_end/flambda2/compilenv_deps/container_types.ml
@@ -118,7 +118,7 @@ module Pair (A : Thing) (B : Thing) : Thing with type t = A.t * B.t = struct
   let output oc (a, b) = Printf.fprintf oc " (%a, %a)" A.output a B.output b
   let hash (a, b) = Hashtbl.hash (A.hash a, B.hash b)
   let equal (a1, b1) (a2, b2) = A.equal a1 a2 && B.equal b1 b2
-  let print ppf (a, b) = Format.fprintf ppf " (%a, @ %a)" A.print a B.print b
+  let [@ocamlformat "disable"] print ppf (a, b) = Format.fprintf ppf " (%a, @ %a)" A.print a B.print b
 end
 
 module Make_map (T : Thing) (Set : Set with module T := T) = struct
@@ -176,7 +176,7 @@ module Make_map (T : Thing) (Set : Set with module T := T) = struct
   let map_keys f m =
     of_list (List.map (fun (k, v) -> f k, v) (bindings m))
 
-  let print print_datum ppf t =
+  let [@ocamlformat "disable"] print print_datum ppf t =
     let module Lmap = Lmap.Make (T) in
     Lmap.print print_datum ppf (Lmap.of_list (bindings t))
 
@@ -269,7 +269,7 @@ module Make_set (T : Thing) = struct
       iter (fun v -> Printf.fprintf oc "%a " T.output v) s;
       Printf.fprintf oc ")"
 
-    let print ppf s =
+    let [@ocamlformat "disable"] print ppf s =
       let elts ppf s = iter (fun e -> Format.fprintf ppf "@ %a" T.print e) s in
       Format.fprintf ppf "@[<1>{@[%a@ @]}@]" elts s
 

--- a/middle_end/flambda2/compilenv_deps/linkage_name.ml
+++ b/middle_end/flambda2/compilenv_deps/linkage_name.ml
@@ -21,7 +21,7 @@ type t = string
 include Container_types.Make (struct
   include String
   let hash = Hashtbl.hash
-  let print ppf t = Format.pp_print_string ppf t
+  let [@ocamlformat "disable"] print ppf t = Format.pp_print_string ppf t
   let output chan t =
     print (Format.formatter_of_out_channel chan) t
 end)

--- a/middle_end/flambda2/compilenv_deps/lmap.ml
+++ b/middle_end/flambda2/compilenv_deps/lmap.ml
@@ -114,7 +114,7 @@ module Make (T : Thing) : S with type key = T.t = struct
               print_key key print_datum datum))
         l
 
-  let print f fmt m = print_assoc T.print f fmt m
+  let [@ocamlformat "disable"] print f fmt m = print_assoc T.print f fmt m
 
   let rec invariant m = match m with
     | [] -> ()

--- a/middle_end/flambda2/compilenv_deps/numeric_types.ml
+++ b/middle_end/flambda2/compilenv_deps/numeric_types.ml
@@ -21,7 +21,7 @@ module Int_base = Container_types.Make (struct
   let output oc x = Printf.fprintf oc "%i" x
   let hash i = i
   let equal (i : int) j = i = j
-  let print = Format.pp_print_int
+  let [@ocamlformat "disable"] print = Format.pp_print_int
 end)
 
 module Int = struct
@@ -83,7 +83,7 @@ module Float = struct
     let output oc x = Printf.fprintf oc "%f" x
     let hash f = Hashtbl.hash f
     let equal (i : float) j = i = j
-    let print = Format.pp_print_float
+    let [@ocamlformat "disable"] print = Format.pp_print_float
   end)
 end
 
@@ -106,7 +106,7 @@ module Float_by_bit_pattern = struct
     let equal = Int64.equal
     let hash f = Hashtbl.hash f
 
-    let print ppf t = Format.pp_print_float ppf (Int64.float_of_bits t)
+    let [@ocamlformat "disable"] print ppf t = Format.pp_print_float ppf (Int64.float_of_bits t)
     let output chan t = Printf.fprintf chan "%g" (Int64.float_of_bits t)
   end
 
@@ -165,7 +165,7 @@ module Int32 = struct
     let compare x y = Int32.compare x y
     let equal t1 t2 = (compare t1 t2 = 0)
     let hash f = Hashtbl.hash f
-    let print ppf t = Format.fprintf ppf "%ld" t
+    let [@ocamlformat "disable"] print ppf t = Format.fprintf ppf "%ld" t
     let output chan t = Printf.fprintf chan "%ld" t
   end
 
@@ -194,7 +194,7 @@ module Int64 = struct
     let compare x y = Int64.compare x y
     let equal t1 t2 = (compare t1 t2 = 0)
     let hash f = Hashtbl.hash f
-    let print ppf t = Format.fprintf ppf "%Ld" t
+    let [@ocamlformat "disable"] print ppf t = Format.fprintf ppf "%Ld" t
     let output chan t = Printf.fprintf chan "%Ld" t
   end
 

--- a/middle_end/flambda2/compilenv_deps/one_bit_fewer.ml
+++ b/middle_end/flambda2/compilenv_deps/one_bit_fewer.ml
@@ -89,7 +89,7 @@ module Make(I : S) : S with type t = I.t = struct
   let equal = I.equal
   let hash = I.hash
   let output = I.output
-  let print = I.print
+  let [@ocamlformat "disable"] print = I.print
 
   (* sign extension can "correct" an {n} bits value that has
      overflowed over the range of {n-1} bits integer, back into

--- a/middle_end/flambda2/compilenv_deps/or_infinity.ml
+++ b/middle_end/flambda2/compilenv_deps/or_infinity.ml
@@ -35,6 +35,6 @@ let hash ~f = function
   | Finite a -> Hashtbl.hash (0, f a)
   | Infinity -> Hashtbl.hash 1
 
-let print ~f ppf = function
+let [@ocamlformat "disable"] print ~f ppf = function
   | Finite a -> f ppf a
   | Infinity -> Format.pp_print_string ppf "\u{221e}"

--- a/middle_end/flambda2/compilenv_deps/patricia_tree.ml
+++ b/middle_end/flambda2/compilenv_deps/patricia_tree.ml
@@ -448,7 +448,7 @@ end) = struct
 
   let output _ _ = Misc.fatal_error "output not yet implemented"
 
-  let print ppf s =
+  let [@ocamlformat "disable"] print ppf s =
     let elts ppf s = iter (fun e -> Format.fprintf ppf "@ %a" Elt.print e) s in
     Format.fprintf ppf "@[<1>{@[%a@ @]}@]" elts s
 
@@ -1151,7 +1151,7 @@ struct
 
   let map_keys _ _ = Misc.fatal_error "map_keys not yet implemented"
 
-  let print print_datum ppf t =
+  let [@ocamlformat "disable"] print print_datum ppf t =
     if is_empty t then
       Format.fprintf ppf "{}"
     else

--- a/middle_end/flambda2/compilenv_deps/rec_info_expr0.ml
+++ b/middle_end/flambda2/compilenv_deps/rec_info_expr0.ml
@@ -78,7 +78,7 @@ module Make(Variable : Container_types.S)
     let unrolling ~remaining_depth = Unrolling { remaining_depth; }
     let do_not_unroll = Do_not_unroll
 
-    let print ppf = function
+    let [@ocamlformat "disable"] print ppf = function
       | Not_unrolling ->
         Format.pp_print_string ppf "Not_unrolling"
       | Unrolling { remaining_depth } ->
@@ -127,7 +127,7 @@ module Make(Variable : Container_types.S)
               unrolling = (Not_unrolling | Unrolling _ | Do_not_unroll) }
     | Var _ | Succ _ | Unroll_to _ -> false
 
-  let rec print ppf = function
+  let [@ocamlformat "disable"] rec print ppf = function
     | Const { depth; unrolling } ->
       begin match unrolling with
       | Not_unrolling ->

--- a/middle_end/flambda2/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda2/compilenv_deps/reg_width_things.ml
@@ -292,8 +292,8 @@ module Const = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
-  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let print = print end)
+  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
   (* CR mshinwell: The [Tbl]s will still print integers! *)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
@@ -367,8 +367,8 @@ module Variable = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
-  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let print = print end)
+  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t
@@ -439,8 +439,8 @@ module Symbol = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
-  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let print = print end)
+  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t
@@ -486,8 +486,8 @@ module Name = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
-  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let print = print end)
+  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 end
 
@@ -618,8 +618,8 @@ module Simple = struct
             has non-identity [Coercion]"
           print t
 
-  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
-  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let print = print end)
+  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t

--- a/middle_end/flambda2/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda2/compilenv_deps/reg_width_things.ml
@@ -51,7 +51,7 @@ module Const_data = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf (t : t) =
+    let [@ocamlformat "disable"] print ppf (t : t) =
       match t with
       | Naked_immediate i ->
         Format.fprintf ppf "@<0>%s#%a@<0>%s"
@@ -152,7 +152,7 @@ module Variable_data = struct
 
   let flags = var_flags
 
-  let print ppf { compilation_unit; previous_compilation_units = _;
+  let [@ocamlformat "disable"] print ppf { compilation_unit; previous_compilation_units = _;
                   name; name_stamp; user_visible; } =
     Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(compilation_unit@ %a)@]@ \
@@ -211,7 +211,7 @@ module Symbol_data = struct
 
   let flags = symbol_flags
 
-  let print ppf { compilation_unit; linkage_name; } =
+  let [@ocamlformat "disable"] print ppf { compilation_unit; linkage_name; } =
     Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(compilation_unit@ %a)@]@ \
         @[<hov 1>(linkage_name@ %a)@]\
@@ -281,7 +281,7 @@ module Const = struct
     let equal = Id.equal
     let hash = Id.hash
 
-    let print ppf t = Const_data.print ppf (descr t)
+    let [@ocamlformat "disable"] print ppf t = Const_data.print ppf (descr t)
 
     let output chan t = print (Format.formatter_of_out_channel chan) t
   end
@@ -292,8 +292,8 @@ module Const = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct let print = print end)
-  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
+  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
   (* CR mshinwell: The [Tbl]s will still print integers! *)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
@@ -348,7 +348,7 @@ module Variable = struct
     let hash = Id.hash
 
     (* CR mshinwell: colour? *)
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       let cu = compilation_unit t in
       if Compilation_unit.equal cu (Compilation_unit.get_current_exn ())
       then Format.fprintf ppf "%s/%d" (name t) (name_stamp t)
@@ -367,8 +367,8 @@ module Variable = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct let print = print end)
-  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
+  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t
@@ -422,7 +422,7 @@ module Symbol = struct
     let equal = Id.equal
     let hash = Id.hash
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       Format.fprintf ppf "@<0>%s" (Flambda_colours.symbol ());
       Compilation_unit.print ppf (compilation_unit t);
       Format.pp_print_string ppf ".";
@@ -439,8 +439,8 @@ module Symbol = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct let print = print end)
-  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
+  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t
@@ -469,7 +469,7 @@ module Name = struct
     let equal = Id.equal
     let hash = Id.hash
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       Format.fprintf ppf "@<0>%s" (Flambda_colours.name ());
       pattern_match t
         ~var:(fun var -> Variable.print ppf var)
@@ -486,8 +486,8 @@ module Name = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct let print = print end)
-  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
+  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 end
 
@@ -503,7 +503,7 @@ module Simple_data = struct
 
   let flags = simple_flags
 
-  let print ppf { simple = _; coercion; } =
+  let [@ocamlformat "disable"] print ppf { simple = _; coercion; } =
     Format.fprintf ppf "@[<hov 1>\
         @[<hov 1>(coercion@ %a)@]\
         @]"
@@ -583,8 +583,8 @@ module Simple = struct
     let equal = Id.equal
     let hash = Id.hash
 
-    let print ppf t =
-      let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
+      let [@ocamlformat "disable"] print ppf t =
         pattern_match t
           ~name:(fun name ~coercion:_ -> Name.print ppf name)
           ~const:(fun cst -> Const.print ppf cst)
@@ -618,8 +618,8 @@ module Simple = struct
             has non-identity [Coercion]"
           print t
 
-  module Set = Patricia_tree.Make_set (struct let print = print end)
-  module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
+  module Set = Patricia_tree.Make_set (struct let [@ocamlformat "disable"] print = print end)
+  module Map = Patricia_tree.Make_map (struct let [@ocamlformat "disable"] print = print end) (Set)
   module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t

--- a/middle_end/flambda2/compilenv_deps/tag.ml
+++ b/middle_end/flambda2/compilenv_deps/tag.ml
@@ -26,7 +26,7 @@ include Container_types.Make (struct
   let equal = Numeric_types.Int.equal
   let hash = Numeric_types.Int.hash
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "@[tag_%d@]" t
 
   let output chan t =

--- a/middle_end/flambda2/compilenv_deps/targetint_31_63.ml
+++ b/middle_end/flambda2/compilenv_deps/targetint_31_63.ml
@@ -44,7 +44,7 @@ module Imm = struct
 
     let output = output
 
-    let print = print
+    let [@ocamlformat "disable"] print = print
 
     let minus_one = -1L
 
@@ -169,7 +169,7 @@ module T0 = struct
 
   let hash t = Imm.hash t.value
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     let print_as_char =
       t.print_as_char
       && Imm.compare t.value Imm.zero >= 0

--- a/middle_end/flambda2/compilenv_deps/targetint_31_63.ml
+++ b/middle_end/flambda2/compilenv_deps/targetint_31_63.ml
@@ -44,7 +44,7 @@ module Imm = struct
 
     let output = output
 
-    let [@ocamlformat "disable"] print = print
+    let print = print
 
     let minus_one = -1L
 

--- a/middle_end/flambda2/compilenv_deps/targetint_32_64.ml
+++ b/middle_end/flambda2/compilenv_deps/targetint_32_64.ml
@@ -128,7 +128,7 @@ module Int32 = struct
     let compare = Int32.compare
     let equal = Int32.equal
     let hash = Hashtbl.hash
-    let print ppf t = Format.fprintf ppf "%ld" t
+    let [@ocamlformat "disable"] print ppf t = Format.fprintf ppf "%ld" t
     let output chan t =
       print (Format.formatter_of_out_channel chan) t
   end)
@@ -191,7 +191,7 @@ module Int64 = struct
     let compare = Int64.compare
     let equal t1 t2 = (compare t1 t2 = 0)
     let hash = Hashtbl.hash
-    let print ppf t = Format.fprintf ppf "%Ld" t
+    let [@ocamlformat "disable"] print ppf t = Format.fprintf ppf "%Ld" t
     let output chan t =
       print (Format.formatter_of_out_channel chan) t
   end)

--- a/middle_end/flambda2/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/inlining/call_site_inlining_decision.ml
@@ -54,7 +54,7 @@ type t =
       threshold: float;
     }
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Environment_says_never_inline ->
     Format.fprintf ppf "Environment_says_never_inline"

--- a/middle_end/flambda2/inlining/function_decl_inlining_decision.ml
+++ b/middle_end/flambda2/inlining/function_decl_inlining_decision.ml
@@ -49,7 +49,7 @@ let behaviour t =
   | Functor _
   | Speculatively_inlinable _-> Could_possibly_be_inlined
 
-let print fmt = function
+let [@ocamlformat "disable"] print fmt = function
   | Never_inline_attribute ->
     Format.fprintf fmt "Never_inline_attribute"
   | Function_body_too_large large_function_size ->

--- a/middle_end/flambda2/inlining/inlining_arguments.ml
+++ b/middle_end/flambda2/inlining/inlining_arguments.ml
@@ -29,7 +29,7 @@ module Args = struct
     threshold : float;
   }
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     let { max_inlining_depth; call_cost; alloc_cost; prim_cost; branch_cost;
           indirect_call_cost; poly_compare_cost;
           small_function_size; large_function_size;
@@ -201,7 +201,7 @@ end
 
 type t = Args.t
 
-let print ppf = Args.print ppf
+let [@ocamlformat "disable"] print ppf = Args.print ppf
 
 let max_inlining_depth t = t.Args.max_inlining_depth
 let call_cost t = t.Args.call_cost

--- a/middle_end/flambda2/inlining/inlining_report.ml
+++ b/middle_end/flambda2/inlining/inlining_report.ml
@@ -86,7 +86,7 @@ let print_debuginfo ppf dbg =
   if Debuginfo.is_none dbg then Format.pp_print_string ppf "None"
   else Debuginfo.print_compact ppf dbg
 
-let rec print ~depth fmt = function
+let [@ocamlformat "disable"] rec print ~depth fmt = function
   (* end of report log *)
   | [] ->
     if depth <> 0 then

--- a/middle_end/flambda2/inlining/inlining_state.ml
+++ b/middle_end/flambda2/inlining/inlining_state.ml
@@ -30,7 +30,7 @@ let default ~round = {
 
 let create ~arguments ~depth = { arguments; depth }
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Format.fprintf ppf "@[<hov 1>(depth@ %d, arguments@ %a)@]"
     t.depth
     Inlining_arguments.print t.arguments

--- a/middle_end/flambda2/inlining/metrics/code_size.ml
+++ b/middle_end/flambda2/inlining/metrics/code_size.ml
@@ -411,7 +411,7 @@ let invalid = 0
 
 let switch switch = 0 + (5 * Switch_expr.num_arms switch)
 
-let print ppf t = Format.fprintf ppf "%d" t
+let [@ocamlformat "disable"] print ppf t = Format.fprintf ppf "%d" t
 
 let of_int t = t
 let to_int t = t

--- a/middle_end/flambda2/inlining/metrics/removed_operations.ml
+++ b/middle_end/flambda2/inlining/metrics/removed_operations.ml
@@ -75,7 +75,7 @@ let direct_call_of_indirect =
 let specialized_poly_compare =
   { zero with specialized_poly_compare = 1; }
 
-let print ppf b =
+let [@ocamlformat "disable"] print ppf b =
   Format.fprintf ppf "@[call: %i@ alloc: %i@ \
                       prim: %i@ branch: %i@ \
                       direct: %i@ poly_cmp: %i@ \

--- a/middle_end/flambda2/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/lifting/lifted_constant.ml
@@ -75,7 +75,7 @@ module Definition = struct
         symbols
     | Block_like { symbol; _ } -> Symbol.print ppf symbol
 
-  let print ppf { descr; defining_expr; } =
+  let [@ocamlformat "disable"] print ppf { descr; defining_expr; } =
     Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(descr@ %a)@]@ \
         @[<hov 1>(defining_expr@ %a)@]\
@@ -161,7 +161,7 @@ let free_names_of_defining_exprs t =
 
 let is_fully_static t = t.is_fully_static
 
-let print ppf
+let [@ocamlformat "disable"] print ppf
       { definitions; bound_symbols = _; defining_exprs = _;
         is_fully_static = _; symbol_projections = _; } =
   Format.fprintf ppf "@[<hov 1>(%a)@]"

--- a/middle_end/flambda2/lifting/lifted_constant_state.ml
+++ b/middle_end/flambda2/lifting/lifted_constant_state.ml
@@ -40,7 +40,7 @@ let to_list_outermost_first t =
   in
   to_list t []
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Format.fprintf ppf "@[<hov 1>(outermost_first@ %a)@]"
     (Format.pp_print_list ~pp_sep:Format.pp_print_space LC.print)
     (to_list_outermost_first t)

--- a/middle_end/flambda2/naming/bindable_let_bound.ml
+++ b/middle_end/flambda2/naming/bindable_let_bound.ml
@@ -31,7 +31,7 @@ type t =
 include Container_types.Make (struct
   type nonrec t = t
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Singleton var -> Var_in_binding_pos.print ppf var
     | Set_of_closures { name_mode = _; closure_vars; } ->
@@ -61,7 +61,7 @@ include Container_types.Make (struct
     Misc.fatal_error "Bindable_let_bound.output not yet implemented"
 end)
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let free_names t =
   match t with

--- a/middle_end/flambda2/naming/bindable_variable_in_terms.ml
+++ b/middle_end/flambda2/naming/bindable_variable_in_terms.ml
@@ -18,7 +18,7 @@
 
 include Variable
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let free_names t =
   Name_occurrences.singleton_variable t Name_mode.normal

--- a/middle_end/flambda2/naming/bindable_variable_in_types.ml
+++ b/middle_end/flambda2/naming/bindable_variable_in_types.ml
@@ -18,7 +18,7 @@
 
 include Variable
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let free_names t =
   Name_occurrences.singleton_variable t Name_mode.in_types

--- a/middle_end/flambda2/naming/name_abstraction.ml
+++ b/middle_end/flambda2/naming/name_abstraction.ml
@@ -197,7 +197,7 @@ module Make_list (Bindable : Bindable.S) (Term : Term) = struct
   let [@inline always] pattern_match_pair
         ((names0, term0) as t1) ((names1, term1) as t2) ~f =
     if List.compare_lengths names0 names1 <> 0 then begin
-      let [@ocamlformat "disable"] print ppf t : unit = print ppf t in
+      let print ppf t : unit = print ppf t in
       Misc.fatal_errorf "Cannot concrete a pair of generalised abstractions \
           unless they have the same number of names in binding position:@ \
           %a@ and@ %a"

--- a/middle_end/flambda2/naming/name_abstraction.ml
+++ b/middle_end/flambda2/naming/name_abstraction.ml
@@ -68,7 +68,7 @@ module Make (Bindable : Bindable.S) (Term : Term) = struct
     let fresh_term = Term.apply_renaming term perm in
     f fresh_name fresh_term
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     let style = !printing_style in
     pattern_match t ~f:(fun name term ->
       Format.fprintf ppf "@[<hov 1>%s@<1>%s%s%a%s@<1>%s%s@ %a@]"
@@ -81,7 +81,7 @@ module Make (Bindable : Bindable.S) (Term : Term) = struct
         (Flambda_colours.normal ())
         Term.print term)
 
-  let print_with_cache ~cache ppf t =
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
     let style = !printing_style in
     pattern_match t ~f:(fun name term ->
       Format.fprintf ppf "@[<hov 1>%s@<1>%s%s%a%s@<1>%s%s@ %a@]"
@@ -174,13 +174,13 @@ module Make_list (Bindable : Bindable.S) (Term : Term) = struct
         (after_binding_position style)
         (Flambda_colours.normal ())
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     pattern_match t ~f:(fun names term ->
       Format.fprintf ppf "@[<hov 1>%a@ %a@]"
         print_bindable_name_list names
         Term.print term)
 
-  let print_with_cache ~cache ppf t =
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
     pattern_match t ~f:(fun names term ->
       Format.fprintf ppf "@[<hov 1>%a@ %a@]"
         print_bindable_name_list names
@@ -197,7 +197,7 @@ module Make_list (Bindable : Bindable.S) (Term : Term) = struct
   let [@inline always] pattern_match_pair
         ((names0, term0) as t1) ((names1, term1) as t2) ~f =
     if List.compare_lengths names0 names1 <> 0 then begin
-      let print ppf t : unit = print ppf t in
+      let [@ocamlformat "disable"] print ppf t : unit = print ppf t in
       Misc.fatal_errorf "Cannot concrete a pair of generalised abstractions \
           unless they have the same number of names in binding position:@ \
           %a@ and@ %a"
@@ -304,13 +304,13 @@ module Make_map (Bindable : Bindable.S) (Term : Term) = struct
         (after_binding_position style)
         (Flambda_colours.normal ())
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     pattern_match' t ~f:(fun names term ->
       Format.fprintf ppf "@[<hov 1>%a@ %a@]"
         print_bindable_name_list names
         Term.print term)
 
-  let print_with_cache ~cache ppf t =
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
     pattern_match' t ~f:(fun names term ->
       Format.fprintf ppf "@[<hov 1>%a@ %a@]"
         print_bindable_name_list names

--- a/middle_end/flambda2/naming/name_in_binding_pos.ml
+++ b/middle_end/flambda2/naming/name_in_binding_pos.ml
@@ -51,7 +51,7 @@ let to_simple t = Simple.name t.name
 include Container_types.Make (struct
   type nonrec t = t
 
-  let print ppf { name; name_mode; } =
+  let [@ocamlformat "disable"] print ppf { name; name_mode; } =
     Format.fprintf ppf "@[<hov 1>)\
         @[<hov 1>(name@ %a)@]@ \
         @[<hov 1>(name_mode@ %a)@]\

--- a/middle_end/flambda2/naming/name_mode.ml
+++ b/middle_end/flambda2/naming/name_mode.ml
@@ -95,7 +95,7 @@ let compare_partial_order t1 t2 =
 include Container_types.Make (struct
   type nonrec t = t
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Normal -> Format.pp_print_string ppf "Normal"
     | In_types -> Format.pp_print_string ppf "In_types"
@@ -146,7 +146,7 @@ module Or_absent = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       match t with
       | Absent -> Format.pp_print_string ppf "Absent"
       | Present kind ->

--- a/middle_end/flambda2/naming/name_occurrences.ml
+++ b/middle_end/flambda2/naming/name_occurrences.ml
@@ -142,7 +142,7 @@ end = struct
       |> Kind.Map.add Kind.in_types (num_occurrences_in_types t)
       |> Kind.Map.add Kind.phantom (num_occurrences_phantom t)
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       Format.fprintf ppf "@[<hov 1>(\
           @[<hov 1>(by_kind %a)@]\
           )@]"
@@ -268,7 +268,7 @@ end = struct
       N.Map.singleton name for_one_name
     | Potentially_many map -> map
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     N.Map.print For_one_name.print ppf (map t)
 
   let invariant t =
@@ -626,7 +626,7 @@ let empty = {
   newer_version_of_code_ids = For_code_ids.empty;
 }
 
-let print ppf ({ names; continuations; continuations_with_traps;
+let [@ocamlformat "disable"] print ppf ({ names; continuations; continuations_with_traps;
                  continuations_in_trap_actions;
                  closure_vars; code_ids; newer_version_of_code_ids; } as t) =
   if t = empty then

--- a/middle_end/flambda2/naming/num_occurrences.ml
+++ b/middle_end/flambda2/naming/num_occurrences.ml
@@ -21,7 +21,7 @@ type t =
   | One
   | More_than_one
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Zero -> Format.fprintf ppf "Zero"
   | One -> Format.fprintf ppf "One"

--- a/middle_end/flambda2/naming/permutation.ml
+++ b/middle_end/flambda2/naming/permutation.ml
@@ -29,7 +29,7 @@ module Make (N : Container_types.S) = struct
       backwards = N.Map.empty;
     }
 
-  let print ppf { forwards; backwards; } =
+  let [@ocamlformat "disable"] print ppf { forwards; backwards; } =
     Format.fprintf ppf "@[((forwards %a)@ (backwards %a))@]"
       (N.Map.print N.print) forwards
       (N.Map.print N.print) backwards

--- a/middle_end/flambda2/naming/renaming.ml
+++ b/middle_end/flambda2/naming/renaming.ml
@@ -161,7 +161,7 @@ let create_import_map ~symbols ~variables ~simples ~consts ~code_ids
   if Import_map.is_empty import_map then empty
   else { empty with import_map = Some import_map; }
 
-let print ppf
+let [@ocamlformat "disable"] print ppf
       { continuations; variables; code_ids; symbols; import_map = _; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(continuations@ %a)@]@ \

--- a/middle_end/flambda2/naming/var_in_binding_pos.ml
+++ b/middle_end/flambda2/naming/var_in_binding_pos.ml
@@ -45,7 +45,7 @@ include Container_types.Make (struct
   type nonrec t = t
 
 (*
-  let print ppf { var; name_mode; } =
+  let [@ocamlformat "disable"] print ppf { var; name_mode; } =
     Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(var@ %a)@]@ \
         @[<hov 1>(name_mode@ %a)@]\
@@ -54,7 +54,7 @@ include Container_types.Make (struct
       Name_mode.print name_mode
 *)
 
-  let print ppf { var; name_mode; } =
+  let [@ocamlformat "disable"] print ppf { var; name_mode; } =
     match Name_mode.descr name_mode with
     | Normal -> Variable.print ppf var
     | In_types -> Format.fprintf ppf "@[%a\u{1d749}@]" Variable.print var

--- a/middle_end/flambda2/naming/with_delayed_permutation.ml
+++ b/middle_end/flambda2/naming/with_delayed_permutation.ml
@@ -78,8 +78,8 @@ end) = struct
       t.free_names <- Some free_names;
       free_names
 
-  let print_with_cache ~cache ppf t =
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
     Descr.print_with_cache ~cache ppf (descr t)
 
-  let print ppf t = Descr.print ppf (descr t)
+  let [@ocamlformat "disable"] print ppf t = Descr.print ppf (descr t)
 end

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -457,7 +457,7 @@ let binop ppf binop a b =
 let unop ppf u =
   let str s = Format.pp_print_string ppf s in
   let box_or_unbox verb_not_imm verb_imm (bk : box_kind) =
-    let [@ocamlformat "disable"] print verb obj =
+    let print verb obj =
       Format.fprintf ppf "%%%s_%s" verb obj
     in
     match bk with

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -457,7 +457,7 @@ let binop ppf binop a b =
 let unop ppf u =
   let str s = Format.pp_print_string ppf s in
   let box_or_unbox verb_not_imm verb_imm (bk : box_kind) =
-    let print verb obj =
+    let [@ocamlformat "disable"] print verb obj =
       Format.fprintf ppf "%%%s_%s" verb obj
     in
     match bk with

--- a/middle_end/flambda2/simplify/basic/apply_cont_rewrite.ml
+++ b/middle_end/flambda2/simplify/basic/apply_cont_rewrite.ml
@@ -40,7 +40,7 @@ let print_ea_used ppf t =
           Format.fprintf ppf "%a%a" EA.print ea print_used used))
     t
 
-let print ppf { original_params; used_params; used_extra_params;
+let [@ocamlformat "disable"] print ppf { original_params; used_params; used_extra_params;
                 extra_args;
               } =
   Format.fprintf ppf "@[<hov 1>(\

--- a/middle_end/flambda2/simplify/basic/continuation_in_env.ml
+++ b/middle_end/flambda2/simplify/basic/continuation_in_env.ml
@@ -35,7 +35,7 @@ type t =
   | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
 
 (* CR mshinwell: Write a proper printer *)
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Linearly_used_and_inlinable { params = _; handler = _;
       free_names_of_handler = _; cost_metrics_of_handler = _ } ->

--- a/middle_end/flambda2/simplify/basic/simplified_named.ml
+++ b/middle_end/flambda2/simplify/basic/simplified_named.ml
@@ -99,7 +99,7 @@ let invalid () =
   else
     Invalid Halt_and_catch_fire
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Reachable { named; _ } ->
     Named.print ppf (to_named named)

--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -35,7 +35,7 @@ type t = {
   combined : Simple.t EP.Map.t;
 }
 
-let print ppf { by_scope; combined; } =
+let [@ocamlformat "disable"] print ppf { by_scope; combined; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(by_scope@ %a)@]@ \
       @[<hov 1>(combined@ %a)@]\
@@ -89,7 +89,7 @@ end = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       match t with
       | Needs_extra_binding { bound_to; } ->
         Format.fprintf ppf "@[<hov 1>(Needs_extra_binding@ %a)@]"

--- a/middle_end/flambda2/simplify/env/are_rebuilding_terms.ml
+++ b/middle_end/flambda2/simplify/env/are_rebuilding_terms.ml
@@ -22,5 +22,5 @@ type t = DE.are_rebuilding_terms
 
 let do_not_rebuild_terms t = not (DE.are_rebuilding_terms_to_bool t)
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Format.fprintf ppf "%b" (DE.are_rebuilding_terms_to_bool t)

--- a/middle_end/flambda2/simplify/env/closure_info.ml
+++ b/middle_end/flambda2/simplify/env/closure_info.ml
@@ -24,7 +24,7 @@ type t =
       exn_continuation : Exn_continuation.t;
     }
 
-let print ppf = function
+let [@ocamlformat "disable"] print ppf = function
   | Not_in_a_closure ->
     Format.fprintf ppf "not_in_a_closure"
   | In_a_set_of_closures_but_not_yet_in_a_specific_closure ->

--- a/middle_end/flambda2/simplify/env/continuation_uses_env.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses_env.ml
@@ -22,7 +22,7 @@ type t = {
   continuation_uses : Continuation_uses.t Continuation.Map.t;
 }
 
-let print ppf { continuation_uses; } =
+let [@ocamlformat "disable"] print ppf { continuation_uses; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(continuation_uses@ %a)@]\
       )@]"

--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -24,7 +24,7 @@ module Reachable_code_ids = struct
     ancestors_of_live_code_ids : Code_id.Set.t;
   }
 
-  let print ppf { live_code_ids; ancestors_of_live_code_ids; } =
+  let [@ocamlformat "disable"] print ppf { live_code_ids; ancestors_of_live_code_ids; } =
     Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(live_code_ids@ %a)@]@ \
         @[<hov 1>(ancestors_of_live_code_ids@ %a)@]\
@@ -100,7 +100,7 @@ let print_map ppf map =
 let print_extra ppf extra =
   Continuation.Map.print Continuation_extra_params_and_args.print ppf extra
 
-let print ppf { stack; map; extra } =
+let [@ocamlformat "disable"] print ppf { stack; map; extra } =
   Format.fprintf ppf
     "@[<hov 1>(\
       @[<hov 1>(stack %a)@]@ \

--- a/middle_end/flambda2/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/downwards_acc.ml
@@ -33,7 +33,7 @@ type t = {
   demoted_exn_handlers : Continuation.Set.t;
 }
 
-let print ppf
+let [@ocamlformat "disable"] print ppf
       { denv; continuation_uses_env; shareable_constants; used_closure_vars;
         lifted_constants; data_flow; demoted_exn_handlers; } =
   Format.fprintf ppf "@[<hov 1>(\

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -51,7 +51,7 @@ let print_debuginfo ppf dbg =
   if Debuginfo.is_none dbg then Format.pp_print_string ppf "None"
   else Debuginfo.print_compact ppf dbg
 
-let print ppf { backend = _; round; typing_env;
+let [@ocamlformat "disable"] print ppf { backend = _; round; typing_env;
                 inlined_debuginfo; can_inline;
                 inlining_state; float_const_prop;
                 at_unit_toplevel; unit_toplevel_exn_continuation;

--- a/middle_end/flambda2/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/upwards_acc.ml
@@ -42,7 +42,7 @@ type t = {
   demoted_exn_handlers : Continuation.Set.t;
 }
 
-let print ppf
+let [@ocamlformat "disable"] print ppf
       { uenv; creation_dacc = _; code_age_relation; lifted_constants;
         name_occurrences; used_closure_vars; all_code = _;
         shareable_constants; cost_metrics; are_rebuilding_terms;

--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -40,7 +40,7 @@ let print_scope_level_and_continuation_in_env ppf (scope_level, cont_in_env) =
     Scope.print scope_level
     Continuation_in_env.print cont_in_env
 
-let print ppf { continuations; exn_continuations; continuation_aliases;
+let [@ocamlformat "disable"] print ppf { continuations; exn_continuations; continuation_aliases;
                 apply_cont_rewrites;
               } =
   Format.fprintf ppf "@[<hov 1>(\

--- a/middle_end/flambda2/simplify/non_constructed_code.ml
+++ b/middle_end/flambda2/simplify/non_constructed_code.ml
@@ -19,6 +19,6 @@
 include Code0.Make (struct
     include Unit
     let all_ids_for_export _ = Ids_for_export.empty
-    let print_with_cache ~cache:_ ppf t = print ppf t
+    let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
   end)
   (Flambda.Cost_metrics)

--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -46,7 +46,7 @@ let is_unreachable t are_rebuilding =
     | Let _ | Let_cont _ | Apply _ | Apply_cont _ | Switch _
     | Invalid Halt_and_catch_fire -> false
 
-let print are_rebuilding ppf t =
+let [@ocamlformat "disable"] print are_rebuilding ppf t =
   if ART.do_not_rebuild_terms are_rebuilding then
     Format.fprintf ppf "<unavailable, terms not being rebuilt>"
   else

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -196,7 +196,7 @@ let to_const t =
   | Non_code_not_rebuilt _ | Code_not_rebuilt _ -> None
   | Normal { const; _ } -> Some const
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Normal { const; _ } -> Static_const.print ppf const
   | Non_code_not_rebuilt { free_names = _; } ->
@@ -260,7 +260,7 @@ module Group = struct
       free_names = Unknown;
     }
 
-  let print ppf { consts; free_names = _; } =
+  let [@ocamlformat "disable"] print ppf { consts; free_names = _; } =
     Format.fprintf ppf "@[<hov 1>(%a)@]"
       (Format.pp_print_list ~pp_sep:Format.pp_print_space print) consts
 

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -102,7 +102,7 @@ end = struct
         compare t1 t2 = 0
 
       let hash _ = Misc.fatal_error "Not yet implemented"
-      let print _ppf _t = Misc.fatal_error "Not yet implemented"
+      let [@ocamlformat "disable"] print _ppf _t = Misc.fatal_error "Not yet implemented"
       let output _ _ = Misc.fatal_error "Not yet implemented"
     end)
   end

--- a/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
@@ -107,7 +107,7 @@ module Evaluated_rec_info_expr = struct
     unrolling : Rec_info_expr.Unrolling_state.t;
   }
 
-  let print ppf { depth; unrolling } =
+  let [@ocamlformat "disable"] print ppf { depth; unrolling } =
     Rec_info_expr.print ppf (Rec_info_expr.const ~depth ~unrolling)
 end
 

--- a/middle_end/flambda2/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda2/simplify/typing_helpers/continuation_uses.ml
@@ -34,7 +34,7 @@ let create continuation arity =
     uses = [];
   }
 
-let print ppf { continuation; arity; uses; } =
+let [@ocamlformat "disable"] print ppf { continuation; arity; uses; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(continuation@ %a)@]@ \
       @[<hov 1>(arity@ %a)@]@ \

--- a/middle_end/flambda2/simplify/typing_helpers/one_continuation_use.ml
+++ b/middle_end/flambda2/simplify/typing_helpers/one_continuation_use.ml
@@ -33,7 +33,7 @@ let create kind ~env_at_use:env id ~arg_types =
     env;
   }
 
-let print ppf { env = _; id = _; kind = _; arg_types; } =
+let [@ocamlformat "disable"] print ppf { env = _; id = _; kind = _; arg_types; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(arg_types@ %a)@]@ \
       )@]"

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -33,7 +33,7 @@ let print_or_elide_debuginfo ppf dbg =
 include Container_types.Make (struct
   type nonrec t = t
 
-  let print ppf { k; args; trap_action; dbg; } =
+  let [@ocamlformat "disable"] print ppf { k; args; trap_action; dbg; } =
     let name, trap_action =
       match Continuation.sort k, trap_action, args with
       | Normal_or_exn, None, [] -> "goto", None
@@ -109,7 +109,7 @@ include Container_types.Make (struct
   let equal t1 t2 = (compare t1 t2 = 0)
 end)
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let invariant _env _ = ()
 (*

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -39,7 +39,7 @@ module Result_continuation = struct
         | Return k -> Continuation.hash k
         | Never_returns as h -> Hashtbl.hash h
 
-      let print fmt = function
+      let [@ocamlformat "disable"] print fmt = function
         | Return k -> Continuation.print fmt k
         | Never_returns -> Format.fprintf fmt "∅"
 
@@ -74,7 +74,7 @@ type t = {
   probe_name : string option;
 }
 
-let print ppf { callee; continuation; exn_continuation; args; call_kind;
+let [@ocamlformat "disable"] print ppf { callee; continuation; exn_continuation; args; call_kind;
       dbg; inline; inlining_state; probe_name; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(%a\u{3008}%a\u{3009}\u{300a}%a\u{300b}@ (%a))@]@ \
@@ -100,7 +100,7 @@ let print ppf { callee; continuation; exn_continuation; args; call_kind;
       | Some probe_name -> Format.pp_print_string ppf probe_name)
     probe_name
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let invariant env
       ({ callee;

--- a/middle_end/flambda2/terms/bound_symbols.ml
+++ b/middle_end/flambda2/terms/bound_symbols.ml
@@ -26,7 +26,7 @@ module Pattern = struct
   let set_of_closures closure_symbols = Set_of_closures closure_symbols
   let block_like symbol = Block_like symbol
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Code code_id ->
       Format.fprintf ppf "@[<hov 1>(Code@ %a)@]" Code_id.print code_id
@@ -139,11 +139,11 @@ let singleton pattern = [pattern]
 
 let to_list t = t
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Format.fprintf ppf "@[<hov 1>(%a)@]"
     (Format.pp_print_list ~pp_sep:Format.pp_print_space Pattern.print) t
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 (* CR mshinwell: This should have an [invariant] function.  One thing to
    check is that the [closure_symbols] are all distinct. *)

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -40,7 +40,7 @@ module Function_call = struct
         return_arity : Flambda_arity.With_subkinds.t;
       }
 
-  let print ppf call =
+  let [@ocamlformat "disable"] print ppf call =
     match call with
     | Direct { code_id; closure_id; return_arity; } ->
       fprintf ppf "@[<hov 1>(Direct@ \
@@ -92,7 +92,7 @@ type t =
       is_c_builtin : bool;
     }
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   match t with
   | Function call -> Function_call.print ppf call
   | Method { kind; obj; } ->
@@ -109,7 +109,7 @@ let print ppf t =
       Flambda_arity.print param_arity
       Flambda_arity.print return_arity
 
-let print_with_cache ~cache:_ ppf t =
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t =
   print ppf t
 
 let invariant0 t =

--- a/middle_end/flambda2/terms/code0.ml
+++ b/middle_end/flambda2/terms/code0.ml
@@ -182,7 +182,7 @@ end) = struct
         Format.fprintf ppf "%a" print_contents contents
   end
 
-  let print_with_cache ~cache ppf
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf
         { code_id = _; params_and_body; newer_version_of; stub; inline;
           is_a_functor; params_arity; result_arity; recursive;
           free_names_of_params_and_body = _; cost_metrics; inlining_arguments;
@@ -263,7 +263,7 @@ end) = struct
         (Option.print_compact Code_id.print) newer_version_of
         (Flambda_colours.normal ())
 
-  let print ppf code =
+  let [@ocamlformat "disable"] print ppf code =
     print_with_cache ~cache:(Printing_cache.create ()) ppf code
 
   let compare { code_id = code_id1; _ } { code_id = code_id2; _ } =

--- a/middle_end/flambda2/terms/continuation_handler.rec.ml
+++ b/middle_end/flambda2/terms/continuation_handler.rec.ml
@@ -22,14 +22,14 @@ module T0 = struct
     handler : Expr.t;
   }
 
-  let print_with_cache ~cache ppf
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf
         { handler; num_normal_occurrences_of_params = _; } =
     fprintf ppf "@[<hov 1>(\
         @[<hov 1>(handler@ %a)@]\
         )@]"
       (Expr.print_with_cache ~cache) handler
 
-  let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+  let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
   let free_names { handler; num_normal_occurrences_of_params = _; } =
     Expr.free_names handler
@@ -139,7 +139,7 @@ let print_using_where_with_cache (recursive : Recursive.t) ~cache ppf k
       (Expr.print_with_cache ~cache) handler;
     fprintf ppf "@]")
 
-let print_with_cache ~cache ppf { abst; is_exn_handler; } =
+let [@ocamlformat "disable"] print_with_cache ~cache ppf { abst; is_exn_handler; } =
   Format.fprintf ppf "@[<hov 1>\
       @[<hov 1>(params_and_handler@ %a)@]@ \
       @[<hov 1>(is_exn_handler@ %b)@]\
@@ -147,7 +147,7 @@ let print_with_cache ~cache ppf { abst; is_exn_handler; } =
     (A.print_with_cache ~cache) abst
     is_exn_handler
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let is_exn_handler t = t.is_exn_handler

--- a/middle_end/flambda2/terms/continuation_handlers.rec.ml
+++ b/middle_end/flambda2/terms/continuation_handlers.rec.ml
@@ -20,10 +20,10 @@ type t = Continuation_handler.t Continuation.Map.t
 
 let invariant _env _t = ()
 
-let print_with_cache ~cache:_ _ppf _t =
+let [@ocamlformat "disable"] print_with_cache ~cache:_ _ppf _t =
   Misc.fatal_error "Continuation_handlers.print_with_cache not yet implemented"
 
-let print _ppf _t =
+let [@ocamlformat "disable"] print _ppf _t =
   Misc.fatal_error "Continuation_handlers.print not yet implemented"
 
 let to_map t = t

--- a/middle_end/flambda2/terms/cost_metrics.rec.ml
+++ b/middle_end/flambda2/terms/cost_metrics.rec.ml
@@ -114,7 +114,7 @@ type code_characteristics = {
 let zero = { size = Code_size.zero; removed = Removed_operations.zero }
 let size t = t.size
 
-let print ppf t = Format.fprintf ppf "@[size: %a removed: {%a}]"
+let [@ocamlformat "disable"] print ppf t = Format.fprintf ppf "@[size: %a removed: {%a}]"
                     Code_size.print t.size
                     Removed_operations.print t.removed
 

--- a/middle_end/flambda2/terms/expr.rec.ml
+++ b/middle_end/flambda2/terms/expr.rec.ml
@@ -124,7 +124,7 @@ let invariant env t =
 (* CR mshinwell: We might want printing functions that show the delayed
    permutation, etc. *)
 
-let print_with_cache ~cache ppf (t : t) =
+let [@ocamlformat "disable"] print_with_cache ~cache ppf (t : t) =
   match descr t with
   | Let let_expr -> Let_expr.print_with_cache ~cache ppf let_expr
   | Let_cont let_cont -> Let_cont_expr.print_with_cache ~cache ppf let_cont
@@ -141,7 +141,7 @@ let print_with_cache ~cache ppf (t : t) =
       Invalid_term_semantics.print semantics
       (Flambda_colours.normal ())
 
-let print ppf (t : t) =
+let [@ocamlformat "disable"] print ppf (t : t) =
   print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let create_let let_expr = create (Let let_expr)

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -36,7 +36,7 @@ module Block_of_values_field = struct
     | Boxed_int64
     | Boxed_nativeint
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Any_value -> Format.fprintf ppf "Any_value"
     | Immediate -> Format.fprintf ppf "Immediate"
@@ -56,7 +56,7 @@ module Block_kind = struct
        (c.f. [Array_kind.Float_array_opt_dynamic], below) for blocks;
        it is known at compile time whether they are all-float. *)
 
-   let print ppf t =
+   let [@ocamlformat "disable"] print ppf t =
     match t with
     | Values (tag, shape) ->
       Format.fprintf ppf
@@ -92,7 +92,7 @@ module Array_kind = struct
     | Naked_floats
     | Float_array_opt_dynamic
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Immediates -> Format.pp_print_string ppf "Immediates"
     | Naked_floats -> Format.pp_print_string ppf "Naked_floats"
@@ -123,7 +123,7 @@ module Duplicate_block_kind = struct
     | Values of { tag : Tag.Scannable.t; length : Targetint_31_63.Imm.t; }
     | Naked_floats of { length : Targetint_31_63.Imm.t; }
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Values { tag; length; } ->
       Format.fprintf ppf
@@ -160,7 +160,7 @@ module Duplicate_array_kind = struct
     | Naked_floats of { length : Targetint_31_63.Imm.t option; }
     | Float_array_opt_dynamic
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Immediates -> Format.pp_print_string ppf "Immediates"
     | Values -> Format.pp_print_string ppf "Values"
@@ -193,7 +193,7 @@ module Block_access_field_kind = struct
     | Any_value
     | Immediate
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Any_value -> Format.pp_print_string ppf "Any_value"
     | Immediate -> Format.pp_print_string ppf "Immediate"
@@ -210,7 +210,7 @@ module Block_access_kind = struct
       }
     | Naked_floats of { size : Targetint_31_63.Imm.t Or_unknown.t; }
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Values { tag; size; field_kind; } ->
       Format.fprintf ppf
@@ -257,7 +257,7 @@ type string_or_bytes = String | Bytes
 module Init_or_assign = struct
   type t = Initialization | Assignment
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     let fprintf = Format.fprintf in
     match t with
     | Initialization -> fprintf ppf "Init"
@@ -1537,7 +1537,7 @@ include Container_types.Make (struct
 
   let hash _t = Misc.fatal_error "Not implemented"
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     let colour =
       match classify_for_printing t with
       | Constructive -> Flambda_colours.prim_constructive ()
@@ -1855,7 +1855,7 @@ module Eligible_for_cse = struct
     let compare = compare
     let equal = equal
     let hash = hash
-    let print = print
+    let [@ocamlformat "disable"] print = print
     let output = output
   end)
 
@@ -1879,7 +1879,7 @@ module Without_args = struct
     | Ternary of ternary_primitive
     | Variadic of variadic_primitive
 
-  let print ppf (t : t) =
+  let [@ocamlformat "disable"] print ppf (t : t) =
     match t with
     | Nullary prim -> print_nullary_primitive ppf prim
     | Unary prim -> print_unary_primitive ppf prim

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1855,7 +1855,7 @@ module Eligible_for_cse = struct
     let compare = compare
     let equal = equal
     let hash = hash
-    let [@ocamlformat "disable"] print = print
+    let print = print
     let output = output
   end)
 

--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -41,7 +41,7 @@ let body t = t.body
 let module_symbol t = t.module_symbol
 let used_closure_vars t = t.used_closure_vars
 
-let print ppf
+let [@ocamlformat "disable"] print ppf
       { return_continuation; exn_continuation; body; module_symbol;
         used_closure_vars;
       } =

--- a/middle_end/flambda2/terms/function_declarations.ml
+++ b/middle_end/flambda2/terms/function_declarations.ml
@@ -43,12 +43,12 @@ let funs_in_order t = t.in_order
 let find ({ funs; _ } : t) closure_id =
   Closure_id.Map.find closure_id funs
 
-let print_with_cache ~cache:_ ppf { in_order; _ } =
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf { in_order; _ } =
   Format.fprintf ppf "@[<hov 1>(%a)@]"
     (Closure_id.Lmap.print Code_id.print)
     in_order
 
-let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let free_names { funs; _ } =
   Closure_id.Map.fold

--- a/middle_end/flambda2/terms/function_params_and_body.rec.ml
+++ b/middle_end/flambda2/terms/function_params_and_body.rec.ml
@@ -78,7 +78,7 @@ let pattern_match_pair t1 t2 ~f =
           f ~return_continuation exn_continuation params ~body1 ~body2 ~my_closure
             ~my_depth))))
 
-let print_with_cache ~cache ppf t =
+let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
   pattern_match t
     ~f:(fun ~return_continuation exn_continuation params ~body ~my_closure
             ~is_my_closure_used:_ ~my_depth ->
@@ -102,7 +102,7 @@ let print_with_cache ~cache ppf t =
         (Flambda_colours.normal ())
         (Expr.print_with_cache ~cache) body)
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let params_arity t = t.params_arity

--- a/middle_end/flambda2/terms/let_cont_expr.rec.ml
+++ b/middle_end/flambda2/terms/let_cont_expr.rec.ml
@@ -27,7 +27,7 @@ type t =
 (* CR mshinwell: A sketch of code for the invariant check is on cps_types. *)
 let invariant _env _t = ()
 
-let print_with_cache ~cache ppf t =
+let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
   let rec gather_let_conts let_conts let_cont =
     match let_cont with
     | Non_recursive { handler; num_free_occurrences = _;
@@ -66,7 +66,7 @@ let print_with_cache ~cache ppf t =
     (List.rev let_conts);
   fprintf ppf ")@]"
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let create_non_recursive' ~cont handler ~body

--- a/middle_end/flambda2/terms/let_expr.rec.ml
+++ b/middle_end/flambda2/terms/let_expr.rec.ml
@@ -24,14 +24,14 @@ module T0 = struct
     body : Expr.t;
   }
 
-  let print_with_cache ~cache ppf
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf
         { body; num_normal_occurrences_of_bound_vars = _; } =
     fprintf ppf "@[<hov 1>(\
         @[<hov 1>(body@ %a)@]\
         )@]"
       (Expr.print_with_cache ~cache) body
 
-  let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+  let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
   let free_names { body; num_normal_occurrences_of_bound_vars = _; } =
     Expr.free_names body
@@ -290,7 +290,7 @@ let print_let_symbol_with_cache ~cache ppf t =
 
 (* For printing all kinds of let-expressions: *)
 
-let print_with_cache ~cache ppf
+let [@ocamlformat "disable"] print_with_cache ~cache ppf
       ({ name_abstraction = _; defining_expr; } as t) =
   let let_bound_var_colour bindable_let_bound defining_expr =
     let name_mode = Bindable_let_bound.name_mode bindable_let_bound in
@@ -336,7 +336,7 @@ let print_with_cache ~cache ppf
       fprintf ppf "@])@ %a)@]"
         (Expr.print_with_cache ~cache) expr)
 
-let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let create bindable_let_bound defining_expr ~body
       ~(free_names_of_body : _ Or_unknown.t) =

--- a/middle_end/flambda2/terms/named.rec.ml
+++ b/middle_end/flambda2/terms/named.rec.ml
@@ -36,7 +36,7 @@ let print_or_elide_debuginfo ppf dbg =
     Debuginfo.print_compact ppf dbg
   end
 
-let print_with_cache ~cache ppf (t : t) =
+let [@ocamlformat "disable"] print_with_cache ~cache ppf (t : t) =
   match t with
   | Simple simple -> Simple.print ppf simple
   | Prim (prim, dbg) ->
@@ -52,7 +52,7 @@ let print_with_cache ~cache ppf (t : t) =
   | Rec_info rec_info_expr ->
     Rec_info_expr.print_with_cache ~cache ppf rec_info_expr
 
-let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 (* CR mshinwell: It seems that the type [Flambda_primitive.result_kind]
    should move into [K], now it's used here. *)

--- a/middle_end/flambda2/terms/non_recursive_let_cont_handler.rec.ml
+++ b/middle_end/flambda2/terms/non_recursive_let_cont_handler.rec.ml
@@ -26,9 +26,9 @@ type t = {
 
 let invariant _env _t = ()
 
-let print _ppf _t = Misc.fatal_error "Not yet implemented"
+let [@ocamlformat "disable"] print _ppf _t = Misc.fatal_error "Not yet implemented"
 
-let print_with_cache ~cache:_ _ppf _t = Misc.fatal_error "Not yet implemented"
+let [@ocamlformat "disable"] print_with_cache ~cache:_ _ppf _t = Misc.fatal_error "Not yet implemented"
 
 let create continuation ~body handler =
   let continuation_and_body =

--- a/middle_end/flambda2/terms/rec_info_expr.ml
+++ b/middle_end/flambda2/terms/rec_info_expr.ml
@@ -18,7 +18,7 @@
 
 include Reg_width_things.Rec_info_expr
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let rec apply_renaming orig perm =
   match orig with

--- a/middle_end/flambda2/terms/recursive_let_cont_handlers.rec.ml
+++ b/middle_end/flambda2/terms/recursive_let_cont_handlers.rec.ml
@@ -24,8 +24,8 @@ module T0 = struct
 
   let invariant _env _t = ()
 
-  let print _ppf _t = Misc.fatal_error "Not yet implemented"
-  let print_with_cache ~cache:_ _ppf _t = Misc.fatal_error "Not yet implemented"
+  let [@ocamlformat "disable"] print _ppf _t = Misc.fatal_error "Not yet implemented"
+  let [@ocamlformat "disable"] print_with_cache ~cache:_ _ppf _t = Misc.fatal_error "Not yet implemented"
 
   let create ~body handlers =
     { handlers;

--- a/middle_end/flambda2/terms/set_of_closures.ml
+++ b/middle_end/flambda2/terms/set_of_closures.ml
@@ -21,7 +21,7 @@ type t = {
   closure_elements : Simple.t Var_within_closure.Map.t;
 }
 
-let print_with_cache ~cache ppf
+let [@ocamlformat "disable"] print_with_cache ~cache ppf
       { function_decls;
         closure_elements;
       } =
@@ -37,7 +37,7 @@ let print_with_cache ~cache ppf
 include Container_types.Make (struct
   type nonrec t = t
 
-  let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+  let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
   let output _ _ = Misc.fatal_error "Not yet implemented"
 
@@ -88,7 +88,7 @@ let environment_doesn't_mention_variables t =
   Var_within_closure.Map.for_all (fun _vwc simple -> Simple.is_symbol simple)
     t.closure_elements
 
-let print_with_cache ~cache ppf
+let [@ocamlformat "disable"] print_with_cache ~cache ppf
       { function_decls;
         closure_elements;
       } =
@@ -109,7 +109,7 @@ let print_with_cache ~cache ppf
       (Function_declarations.print_with_cache ~cache) function_decls
       (Var_within_closure.Map.print Simple.print) closure_elements
 
-let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let free_names
       { function_decls;

--- a/middle_end/flambda2/terms/static_const.rec.ml
+++ b/middle_end/flambda2/terms/static_const.rec.ml
@@ -53,7 +53,7 @@ module Field_of_block = struct
         Hashtbl.hash (1, Targetint_31_63.hash immediate)
       | Dynamically_computed var -> Hashtbl.hash (2, Variable.hash var)
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       match t with
       | Symbol symbol -> Symbol.print ppf symbol
       | Tagged_immediate immediate -> Targetint_31_63.print ppf immediate
@@ -107,7 +107,7 @@ type t =
 
 type static_const = t
 
-let print_with_cache ~cache ppf t =
+let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
   match t with
   | Code code ->
     fprintf ppf "@[<hov 1>(@<0>%sCode@<0>%s@ %a)@]"
@@ -180,7 +180,7 @@ let print_with_cache ~cache ppf t =
 include Container_types.Make (struct
   type nonrec t = t
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
   let compare t1 t2 =
@@ -482,13 +482,13 @@ module Group = struct
 
   let empty = []
 
-  let print_with_cache ~cache ppf t =
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
     Format.fprintf ppf "@[<hov 1>(%a)@]"
       (Format.pp_print_list ~pp_sep:Format.pp_print_space
         (print_with_cache ~cache))
       t
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "@[<hov 1>(%a)@]"
       (Format.pp_print_list ~pp_sep:Format.pp_print_space print) t
 

--- a/middle_end/flambda2/terms/switch_expr.ml
+++ b/middle_end/flambda2/terms/switch_expr.ml
@@ -61,7 +61,7 @@ let print_arms ppf arms =
         Apply_cont_expr.print action)
     arms
 
-let print ppf { scrutinee; arms; } =
+let [@ocamlformat "disable"] print ppf { scrutinee; arms; } =
   fprintf ppf
     "@[<v 0>(@<0>%sswitch@<0>%s %a@ @[<v 0>%a@])@]"
     (Flambda_colours.expr_keyword ())
@@ -69,7 +69,7 @@ let print ppf { scrutinee; arms; } =
     Simple.print scrutinee
     print_arms arms
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let invariant _ _ = ()
 

--- a/middle_end/flambda2/terms/symbol_projection.ml
+++ b/middle_end/flambda2/terms/symbol_projection.ml
@@ -31,7 +31,7 @@ module Projection = struct
     | Project_var { project_from; var; } ->
       Hashtbl.hash (Closure_id.hash project_from, Var_within_closure.hash var)
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Block_load { index; } ->
       Format.fprintf ppf "@[<hov 1>(Block_load@ \
@@ -64,7 +64,7 @@ type t = {
   projection : Projection.t;
 }
 
-let print ppf { symbol; projection; } =
+let [@ocamlformat "disable"] print ppf { symbol; projection; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(symbol@ %a)@]@ \
       @[<hov 1>(projection@ %a)@]\

--- a/middle_end/flambda2/tests/mlexamples/printexc.ml
+++ b/middle_end/flambda2/tests/mlexamples/printexc.ml
@@ -621,7 +621,7 @@ let to_string e =
   | Some s -> s
   | None -> to_string_default e
 
-let print fct arg =
+let [@ocamlformat "disable"] print fct arg =
   try
     fct arg
   with x ->

--- a/middle_end/flambda2/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda2/to_cmm/un_cps_closure.ml
@@ -350,7 +350,7 @@ module Greedy = struct
         Format.fprintf fmt "%a@ " print_set s
       ) l
 
-  let print fmt state =
+  let [@ocamlformat "disable"] print fmt state =
     Format.fprintf fmt
       "@[<v 2>Sets of closures:@ %a@]"
       print_sets state.sets_of_closures

--- a/middle_end/flambda2/types/basic/or_bottom.ml
+++ b/middle_end/flambda2/types/basic/or_bottom.ml
@@ -20,7 +20,7 @@ type 'a t =
   | Ok of 'a
   | Bottom
 
-let print f ppf t =
+let [@ocamlformat "disable"] print f ppf t =
   match t with
   | Ok contents -> Format.fprintf ppf "@[(Ok %a)@]" f contents
   | Bottom -> Format.pp_print_string ppf "Bottom"

--- a/middle_end/flambda2/types/basic/or_unknown.ml
+++ b/middle_end/flambda2/types/basic/or_unknown.ml
@@ -20,7 +20,7 @@ type 'a t =
   | Known of 'a
   | Unknown
 
-let print f ppf t =
+let [@ocamlformat "disable"] print f ppf t =
   let colour = Flambda_colours.top_or_bottom_type () in
   match t with
   | Known contents -> Format.fprintf ppf "@[<hov 1>%a@]" f contents
@@ -80,7 +80,7 @@ module Lift (I : Container_types.S) = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf t = print I.print ppf t
+    let [@ocamlformat "disable"] print ppf t = print I.print ppf t
 
     let compare t1 t2 = compare I.compare t1 t2
 

--- a/middle_end/flambda2/types/basic/or_unknown_or_bottom.ml
+++ b/middle_end/flambda2/types/basic/or_unknown_or_bottom.ml
@@ -21,7 +21,7 @@ type 'a t =
   | Ok of 'a
   | Bottom
 
-let print f ppf t =
+let [@ocamlformat "disable"] print f ppf t =
   match t with
   | Unknown -> Format.pp_print_string ppf "Unknown"
   | Ok contents -> Format.fprintf ppf "@[(Ok %a)@]" f contents

--- a/middle_end/flambda2/types/basic/string_info.ml
+++ b/middle_end/flambda2/types/basic/string_info.ml
@@ -52,7 +52,7 @@ include Container_types.Make (struct
 
   let hash t = Hashtbl.hash t
 
-  let print ppf { contents; size; } =
+  let [@ocamlformat "disable"] print ppf { contents; size; } =
     match contents with
     | Unknown_or_mutable ->
       Format.fprintf ppf "(size %a)" Targetint_31_63.Imm.print size

--- a/middle_end/flambda2/types/basic/unit.ml
+++ b/middle_end/flambda2/types/basic/unit.ml
@@ -23,7 +23,7 @@ include Container_types.Make (struct
   let compare () () = 0
   let equal () () = true
   let hash () = 0
-  let print ppf () = Format.pp_print_string ppf "()"
+  let [@ocamlformat "disable"] print ppf () = Format.pp_print_string ppf "()"
   let output chan () = output_string chan "()"
 end)
 

--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -140,7 +140,7 @@ end = struct
       Misc.fatal_errorf "[Aliases_of_canonical_element.invariant]: \
                          [aliases] and [all] are not consistent"
 
-  let print ppf { aliases; all = _; } =
+  let [@ocamlformat "disable"] print ppf { aliases; all = _; } =
     Name_mode.Map.print (Name.Map.print Coercion.print) ppf aliases
 
   let empty = {
@@ -303,7 +303,7 @@ module Alias_set = struct
       |> Option.map (fun (name, coercion) ->
            Simple.with_coercion (Simple.name name) coercion)
 
-  let print ppf { const; names; } =
+  let [@ocamlformat "disable"] print ppf { const; names; } =
     let none ppf () =
       Format.fprintf ppf "@<0>%s()" (Flambda_colours.elide ())
     in
@@ -400,7 +400,7 @@ type t = {
  * canonical_elements[elem_j_n] = (canon_j, coercion_j_n)
  *)
 
-let print ppf { canonical_elements; aliases_of_canonical_names;
+let [@ocamlformat "disable"] print ppf { canonical_elements; aliases_of_canonical_names;
                 aliases_of_consts; binding_times_and_modes; } =
   let print_element_and_coercion ppf (elt, coercion) =
     Format.fprintf ppf "@[<hov 1>(\

--- a/middle_end/flambda2/types/env/binding_time.ml
+++ b/middle_end/flambda2/types/env/binding_time.ml
@@ -17,7 +17,7 @@
 module T = struct
   include Int
 
-  let print = Numeric_types.Int.print
+  let [@ocamlformat "disable"] print = Numeric_types.Int.print
   let output = Numeric_types.Int.output
   let hash = Hashtbl.hash
 end
@@ -78,7 +78,7 @@ module With_name_mode = struct
     else (* Variable out of the allowed scope *)
       Name_mode.in_types
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "(bound at time %d %a)" (binding_time t)
       Name_mode.print (name_mode t)
 

--- a/middle_end/flambda2/types/env/meet_env.rec.ml
+++ b/middle_end/flambda2/types/env/meet_env.rec.ml
@@ -21,7 +21,7 @@ type t = {
   already_meeting : Name.Pair.Set.t;
 }
 
-let print ppf { env; already_meeting; } =
+let [@ocamlformat "disable"] print ppf { env; already_meeting; } =
   Format.fprintf ppf
     "@[<hov 1>(\
       @[<hov 1>(env@ %a)@]@ \

--- a/middle_end/flambda2/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env.rec.ml
@@ -231,7 +231,7 @@ module One_level = struct
     just_after_level : Cached.t;
   }
 
-  let print_with_cache ~min_binding_time ~cache:_ ppf
+  let [@ocamlformat "disable"] print_with_cache ~min_binding_time ~cache:_ ppf
         { scope = _; level; just_after_level; } =
     let restrict_to = Typing_env_level.defined_names level in
     if Name.Set.is_empty restrict_to then
@@ -342,7 +342,7 @@ end = struct
       next_binding_time;
     }
 
-  let print ppf { defined_symbols;
+  let [@ocamlformat "disable"] print ppf { defined_symbols;
                   code_age_relation;
                   just_after_level;
                   next_binding_time = _;
@@ -466,7 +466,7 @@ let aliases t =
 
 (* CR mshinwell: Should print name occurrence kinds *)
 (* CR mshinwell: Add option to print [aliases] *)
-let print_with_cache ~cache ppf
+let [@ocamlformat "disable"] print_with_cache ~cache ppf
       ({ resolver = _; get_imported_names = _; get_imported_code = _;
          prev_levels; current_level; next_binding_time = _;
          defined_symbols; code_age_relation; all_code = _; min_binding_time;
@@ -495,7 +495,7 @@ let print_with_cache ~cache ppf
         levels
         Aliases.print (aliases t))
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let invariant0 ?force _t =

--- a/middle_end/flambda2/types/env/typing_env_extension.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env_extension.rec.ml
@@ -35,7 +35,7 @@ let print_equations ppf equations =
       ppf equations;
     Format.pp_print_string ppf ")"
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Format.fprintf ppf
     "@[<hov 1>(equations@ @[<v 1>%a@])@]"
     print_equations t.equations
@@ -177,7 +177,7 @@ module With_extra_variables = struct
     equations : Type_grammar.t Name.Map.t;
   }
 
-  let print ppf { existential_vars; equations; } =
+  let [@ocamlformat "disable"] print ppf { existential_vars; equations; } =
     Format.fprintf ppf
       "@[<hov 1>(\
        @[<hov 1>(variables@ @[<hov 1>%a@])@]\

--- a/middle_end/flambda2/types/env/typing_env_level.rec.ml
+++ b/middle_end/flambda2/types/env/typing_env_level.rec.ml
@@ -37,7 +37,7 @@ let defines_name_but_no_equations t name =
       && not (Name.Map.mem name t.equations)
 *)
 
-let print_with_cache ~cache ppf
+let [@ocamlformat "disable"] print_with_cache ~cache ppf
       { defined_vars; binding_times = _; equations;
         symbol_projections = _; } =
   (* CR mshinwell: print symbol projections along with tidying up this
@@ -74,7 +74,7 @@ let print_with_cache ~cache ppf
       Variable.Set.print (Variable.Map.keys defined_vars) (* XXX *)
       print_equations equations
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let fold_on_defined_vars f t init =

--- a/middle_end/flambda2/types/kinds/flambda_arity.ml
+++ b/middle_end/flambda2/types/kinds/flambda_arity.ml
@@ -33,7 +33,7 @@ include Container_types.Make (struct
 
   let hash = Hashtbl.hash
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | [] -> Format.pp_print_string ppf "Nullary"
     | _ ->
@@ -74,7 +74,7 @@ module With_subkinds = struct
 
     let hash = Hashtbl.hash
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       match t with
       | [] -> Format.pp_print_string ppf "Nullary"
       | _ ->

--- a/middle_end/flambda2/types/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/types/kinds/flambda_kind.ml
@@ -39,7 +39,7 @@ module Naked_number_kind = struct
     | Naked_int64
     | Naked_nativeint
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     match t with
     | Naked_immediate -> Format.pp_print_string ppf "Naked_immediate"
     | Naked_float -> Format.pp_print_string ppf "Naked_float"
@@ -105,7 +105,7 @@ include Container_types.Make (struct
 
   let hash = Hashtbl.hash
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     let colour = Flambda_colours.kind () in
     match t with
     | Value ->
@@ -195,7 +195,7 @@ module Standard_int = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       match t with
       | Tagged_immediate -> Format.pp_print_string ppf "Tagged_immediate"
       | Naked_immediate -> Format.pp_print_string ppf "Naked_immediate"
@@ -252,7 +252,7 @@ module Standard_int_or_float = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       match t with
       | Tagged_immediate -> Format.pp_print_string ppf "Tagged_immediate"
       | Naked_immediate -> Format.pp_print_string ppf "Naked_immediate"
@@ -314,7 +314,7 @@ module Boxable_number = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       match t with
       | Naked_float -> Format.pp_print_string ppf "Naked_float"
       | Naked_int32 -> Format.pp_print_string ppf "Naked_int32"
@@ -357,7 +357,7 @@ module Naked_number = struct
     | Naked_int64 : naked_int64 t
     | Naked_nativeint : naked_nativeint t
 
-  let print (type a) ppf (t : a t) =
+  let [@ocamlformat "disable"] print (type a) ppf (t : a t) =
     match t with
     | Naked_immediate -> Format.pp_print_string ppf "Naked_immediate"
     | Naked_float -> Format.pp_print_string ppf "Naked_float"
@@ -381,7 +381,7 @@ module With_subkind = struct
     include Container_types.Make (struct
       type nonrec t = t
 
-      let rec print ppf t =
+      let [@ocamlformat "disable"] rec print ppf t =
         let colour = Flambda_colours.subkind () in
         match t with
         | Anything -> ()
@@ -487,7 +487,7 @@ module With_subkind = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf { kind; subkind; } =
+    let [@ocamlformat "disable"] print ppf { kind; subkind; } =
       match kind, subkind with
       | _, Anything -> print ppf kind
       | Value, subkind ->

--- a/middle_end/flambda2/types/structures/closures_entry.rec.ml
+++ b/middle_end/flambda2/types/structures/closures_entry.rec.ml
@@ -39,7 +39,7 @@ let create ~function_decls ~closure_types ~closure_var_types =
     closure_var_types;
   }
 
-let print_with_cache ~cache ppf
+let [@ocamlformat "disable"] print_with_cache ~cache ppf
       { function_decls; closure_types; closure_var_types; } =
   Format.fprintf ppf
     "@[<hov 1>(\
@@ -51,7 +51,7 @@ let print_with_cache ~cache ppf
     (PC.print_with_cache ~cache) closure_types
     (PV.print_with_cache ~cache) closure_var_types
 
-let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let meet env
       { function_decls = function_decls1;

--- a/middle_end/flambda2/types/structures/code_age_relation.ml
+++ b/middle_end/flambda2/types/structures/code_age_relation.ml
@@ -19,7 +19,7 @@
    These relations are expected to be small in the majority of cases. *)
 type t = Code_id.t Code_id.Map.t
 
-let print ppf t = Code_id.Map.print Code_id.print ppf t
+let [@ocamlformat "disable"] print ppf t = Code_id.Map.print Code_id.print ppf t
 
 let empty = Code_id.Map.empty
 

--- a/middle_end/flambda2/types/structures/function_declaration_type.rec.ml
+++ b/middle_end/flambda2/types/structures/function_declaration_type.rec.ml
@@ -26,7 +26,7 @@ module Inlinable = struct
     must_be_inlined : bool;
   }
 
-  let print ppf { code_id; rec_info; must_be_inlined } =
+  let [@ocamlformat "disable"] print ppf { code_id; rec_info; must_be_inlined } =
     Format.fprintf ppf
       "@[<hov 1>(Inlinable@ \
         @[<hov 1>(code_id@ %a)@]@ \
@@ -65,7 +65,7 @@ module Non_inlinable = struct
     code_id : Code_id.t;
   }
 
-  let print ppf { code_id; } =
+  let [@ocamlformat "disable"] print ppf { code_id; } =
     Format.fprintf ppf
       "@[<hov 1>(Non_inlinable@ \
         @[<hov 1>(code_id@ %a)@]\
@@ -116,10 +116,10 @@ let print_t0 ppf t0 =
   | Inlinable inlinable -> Inlinable.print ppf inlinable
   | Non_inlinable non_inlinable -> Non_inlinable.print ppf non_inlinable
 
-let print_with_cache ~cache:_ ppf t =
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t =
   Or_unknown_or_bottom.print print_t0 ppf t
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Or_unknown_or_bottom.print print_t0 ppf t
 
 let free_names (t : t) =

--- a/middle_end/flambda2/types/structures/product.rec.ml
+++ b/middle_end/flambda2/types/structures/product.rec.ml
@@ -32,14 +32,14 @@ module Make (Index : Product_intf.Index) = struct
     kind : Flambda_kind.t;
   }
 
-  let print ppf { components_by_index; kind = _ } =
+  let [@ocamlformat "disable"] print ppf { components_by_index; kind = _ } =
     Format.fprintf ppf
       "@[<hov 1>(\
         @[<hov 1>(components_by_index@ %a)@]\
         )@]"
       (Index.Map.print Type_grammar.print) components_by_index
 
-  let print_with_cache ~cache:_ ppf t = print ppf t
+  let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
   let fields_kind t = t.kind
 
@@ -181,12 +181,12 @@ module Int_indexed = struct
     kind : Flambda_kind.t;
   }
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "@[<hov 1>(%a)@]"
       (Format.pp_print_list ~pp_sep:Format.pp_print_space T.print)
       (Array.to_list t.fields)
 
-  let print_with_cache ~cache:_ ppf t = print ppf t
+  let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
   let fields_kind t = t.kind
 

--- a/middle_end/flambda2/types/structures/row_like.rec.ml
+++ b/middle_end/flambda2/types/structures/row_like.rec.ml
@@ -74,7 +74,7 @@ struct
       Format.fprintf ppf "(At_least @[<2>%a@])"
         Index.print min_index
 
-  let print_with_cache ~cache ppf (({ known_tags; other_tags } as t) : t) =
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf (({ known_tags; other_tags } as t) : t) =
     if is_bottom t then
       (* CR mshinwell: factor out (also in [Type_descr]) *)
       let colour = Flambda_colours.top_or_bottom_type () in
@@ -88,7 +88,7 @@ struct
         if not (TEE.is_empty env_extension) then
           Format.fprintf ppf "@ %a" TEE.print env_extension
       in
-      let print ppf { maps_to; index; env_extension } =
+      let [@ocamlformat "disable"] print ppf { maps_to; index; env_extension } =
         Format.fprintf ppf "=> %a,@ %a%a"
           print_index index
           (Maps_to.print_with_cache ~cache) maps_to
@@ -102,7 +102,7 @@ struct
         (Tag.Map.print print) known_tags
         (Or_bottom.print print) other_tags
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
   let _invariant _t = ()

--- a/middle_end/flambda2/types/structures/set_of_closures_contents.ml
+++ b/middle_end/flambda2/types/structures/set_of_closures_contents.ml
@@ -24,7 +24,7 @@ type t = {
 include Container_types.Make (struct
   type nonrec t = t
 
-  let print ppf { closures; closure_vars; } =
+  let [@ocamlformat "disable"] print ppf { closures; closure_vars; } =
     Format.fprintf ppf "@[<hov 1>(\
           @[<hov 1>(closures@ %a)@]@ \
           @[<hov 1>(closure_vars@ %a)@]\
@@ -89,7 +89,7 @@ module With_closure_id = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf (closure_id, contents) =
+    let [@ocamlformat "disable"] print ppf (closure_id, contents) =
       Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
         Closure_id.print closure_id
         print contents
@@ -114,7 +114,7 @@ module With_closure_id_or_unknown = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf (closure_id_or_unknown, contents) =
+    let [@ocamlformat "disable"] print ppf (closure_id_or_unknown, contents) =
       Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
         (Or_unknown.print Closure_id.print) closure_id_or_unknown
         print contents

--- a/middle_end/flambda2/types/type_descr.rec.ml
+++ b/middle_end/flambda2/types/type_descr.rec.ml
@@ -33,7 +33,7 @@ module Make (Head : Type_head_intf.S
       | No_alias of Head.t Or_unknown_or_bottom.t
       | Equals of Simple.t
 
-    let print_with_cache ~cache ppf t =
+    let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
       let colour = Flambda_colours.top_or_bottom_type () in
       match t with
       | No_alias Unknown ->
@@ -55,7 +55,7 @@ module Make (Head : Type_head_intf.S
           (Flambda_colours.normal ())
           Simple.print simple
 
-    let print ppf t =
+    let [@ocamlformat "disable"] print ppf t =
       print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
     let apply_renaming t renaming =
@@ -92,10 +92,10 @@ module Make (Head : Type_head_intf.S
     | No_alias (Ok head) -> Head.all_ids_for_export head
     | Equals simple -> Ids_for_export.from_simple simple
 
-  let print_with_cache ~cache ppf t =
+  let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
     Descr.print_with_cache ~cache ppf (descr t)
 
-  let print ppf t =
+  let [@ocamlformat "disable"] print ppf t =
     print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
   let create_no_alias head = create (No_alias head)

--- a/middle_end/flambda2/types/type_grammar.rec.ml
+++ b/middle_end/flambda2/types/type_grammar.rec.ml
@@ -38,7 +38,7 @@ type t =
   | Naked_nativeint of T_NN.t
   | Rec_info of T_RI.t
 
-let print_with_cache ~cache ppf (t : Type_grammar.t) =
+let [@ocamlformat "disable"] print_with_cache ~cache ppf (t : Type_grammar.t) =
   match t with
   | Value ty ->
     Format.fprintf ppf "@[<hov 1>(Val@ %a)@]"
@@ -62,7 +62,7 @@ let print_with_cache ~cache ppf (t : Type_grammar.t) =
     Format.fprintf ppf "@[<hov 1>(Rec_info@ %a)@]"
       (T_RI.print_with_cache ~cache) ty
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   let cache : Printing_cache.t = Printing_cache.create () in
   print_with_cache ~cache ppf t
 

--- a/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_float0.rec.ml
+++ b/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_float0.rec.ml
@@ -21,10 +21,10 @@ module TEE = Typing_env_extension
 
 type t = Float.Set.t
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Format.fprintf ppf "@[(Naked_floats@ (%a))@]" Float.Set.print t
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let apply_renaming t _perm = t
 

--- a/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_immediate0.rec.ml
+++ b/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_immediate0.rec.ml
@@ -26,7 +26,7 @@ type t =
   | Is_int of T.t
   | Get_tag of T.t
 
-let print_with_cache ~cache ppf t =
+let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
   match t with
   | Naked_immediates is ->
     Format.fprintf ppf "@[<hov 1>(%a)@]" I.Set.print is
@@ -37,7 +37,7 @@ let print_with_cache ~cache ppf t =
     Format.fprintf ppf "@[<hov 1>(Get_tag@ %a)@]"
       (T.print_with_cache ~cache) ty
 
-let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let apply_renaming t renaming =
   match t with

--- a/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
+++ b/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
@@ -21,10 +21,10 @@ module TEE = Typing_env_extension
 
 type t = Int32.Set.t
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Format.fprintf ppf "@[(Naked_int32s@ (%a))@]" Int32.Set.print t
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let apply_renaming t _renaming = t
 

--- a/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
+++ b/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
@@ -21,10 +21,10 @@ module TEE = Typing_env_extension
 
 type t = Int64.Set.t
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Format.fprintf ppf "@[(Naked_int64s@ (%a))@]" Int64.Set.print t
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let apply_renaming t _renaming = t
 

--- a/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
+++ b/middle_end/flambda2/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
@@ -20,10 +20,10 @@ module TEE = Typing_env_extension
 
 type t = Targetint_32_64.Set.t
 
-let print ppf t =
+let [@ocamlformat "disable"] print ppf t =
   Format.fprintf ppf "@[(Naked_nativeints@ (%a))@]" Targetint_32_64.Set.print t
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let apply_renaming t _renaming = t
 

--- a/middle_end/flambda2/types/type_of_kind/type_of_kind_rec_info0.rec.ml
+++ b/middle_end/flambda2/types/type_of_kind/type_of_kind_rec_info0.rec.ml
@@ -18,9 +18,9 @@
 
 type t = Rec_info_expr.t
 
-let print ppf t = Rec_info_expr.print ppf t
+let [@ocamlformat "disable"] print ppf t = Rec_info_expr.print ppf t
 
-let print_with_cache ~cache:_ ppf t = print ppf t
+let [@ocamlformat "disable"] print_with_cache ~cache:_ ppf t = print ppf t
 
 let apply_renaming t renaming = Rec_info_expr.apply_renaming t renaming
 

--- a/middle_end/flambda2/types/type_of_kind/type_of_kind_value0.rec.ml
+++ b/middle_end/flambda2/types/type_of_kind/type_of_kind_value0.rec.ml
@@ -35,7 +35,7 @@ type t =
   | String of String_info.Set.t
   | Array of { length : T.t; }
 
-let print_with_cache ~cache ppf t =
+let [@ocamlformat "disable"] print_with_cache ~cache ppf t =
   match t with
   | Variant { blocks; immediates; is_unique } ->
     (* CR mshinwell: Improve so that we elide blocks and/or immediates when
@@ -70,7 +70,7 @@ let print_with_cache ~cache ppf t =
     Format.fprintf ppf "@[<hov 1>(Array@ (length@ %a))@]"
       (T.print_with_cache ~cache) length
 
-let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
+let [@ocamlformat "disable"] print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let apply_renaming_variant blocks immediates perm =
   let immediates' =

--- a/middle_end/flambda2/unboxing/unboxing_types.ml
+++ b/middle_end/flambda2/unboxing/unboxing_types.ml
@@ -40,7 +40,7 @@ module Extra_param_and_args = struct
     let args = Apply_cont_rewrite_id.Map.add rewrite_id extra_arg t.args in
     { t with args; }
 
-  let print fmt { param; args = _; } =
+  let [@ocamlformat "disable"] print fmt { param; args = _; } =
     Format.fprintf fmt "@[<hv 1>(\
       @[<hov>(param %a)@]@ \
       @[<v 2>(args@ <...>)@]\
@@ -161,7 +161,7 @@ and print_const_ctor_num ppf = function
       Extra_param_and_args.print is_int
       print_decision ctor
 
-let print ppf { decisions; rewrite_ids_seen; } =
+let [@ocamlformat "disable"] print ppf { decisions; rewrite_ids_seen; } =
   let pp_sep = Format.pp_print_space in
   let aux ppf (param, decision) =
     Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
@@ -180,5 +180,5 @@ module Decisions = struct
     rewrite_ids_seen : Apply_cont_rewrite_id.Set.t;
   }
 
-  let print = print
+  let [@ocamlformat "disable"] print = print
 end

--- a/middle_end/flambda2/unboxing/unboxing_types.ml
+++ b/middle_end/flambda2/unboxing/unboxing_types.ml
@@ -180,5 +180,5 @@ module Decisions = struct
     rewrite_ids_seen : Apply_cont_rewrite_id.Set.t;
   }
 
-  let [@ocamlformat "disable"] print = print
+  let print = print
 end


### PR DESCRIPTION
Some of these annotations may be a bit over-zealous, but they can be trimmed down during review.  In the medium term I'd like to replace the printing code with something to build a proper type.  In addition to being more flexible and easier to write, the code to construct such a type would be able to be formatted correctly by ocamlformat.