### PR TITLE
Keep Sys.opaque_identity in Cmm and Mach (port upstream PR 9412)

### DIFF
--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -234,7 +234,7 @@ method class_of_operation op =
   | Imove | Ispill | Ireload -> assert false   (* treated specially *)
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _ -> Op_pure
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ | Iprobe _ -> assert false                 (* treated specially *)
+  | Iextcall _ | Iprobe _ | Iopaque -> assert false  (* treated specially *)
   | Istackoffset _ -> Op_other
   | Iload(_,_) -> Op_load
   | Istore(_,_,asg) -> Op_store asg
@@ -289,6 +289,9 @@ method private cse n i k =
          could be kept, but won't be usable for CSE as one of their
          arguments is always a memory load.  For simplicity, we
          just forget everything. *)
+      self#cse empty_numbering i.next (fun next -> k { i with next; })
+  | Iop Iopaque ->
+      (* Assume arbitrary side effects from Iopaque *)
       self#cse empty_numbering i.next (fun next -> k { i with next; })
   | Iop (Ialloc _) ->
       (* For allocations, we must avoid extending the live range of a

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -44,7 +44,7 @@ method! class_of_operation op =
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _ | Iextcall _
   | Istackoffset _ | Iload _ | Istore _ | Ialloc _
   | Iintop _ | Iintop_imm _
-  | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _
+  | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _ | Iopaque
     -> super#class_of_operation op
 
 end

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -831,6 +831,8 @@ let emit_instr fallthrough i =
       I.cvtsi2sd  (arg i 0)  (res i 0)
   | Lop(Iintoffloat) ->
       I.cvttsd2si (arg i 0) (res i 0)
+  | Lop(Iopaque) ->
+      assert (i.arg.(0).loc = i.res.(0).loc)
   | Lop(Ispecific(Ilea addr)) ->
       I.lea (addressing addr NONE i 0) (res i 0)
   | Lop(Ispecific(Istore_int(n, addr, _))) ->

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -331,7 +331,7 @@ let destroyed_at_oper = function
        | Ifloatofint | Iintoffloat
        | Iconst_int _ | Iconst_float _ | Iconst_symbol _
        | Itailcall_ind | Itailcall_imm _ | Istackoffset _ | Iload (_, _)
-       | Iname_for_debugger _ | Iprobe _| Iprobe_is_enabled _)
+       | Iname_for_debugger _ | Iprobe _| Iprobe_is_enabled _ | Iopaque)
   | Iend | Ireturn _ | Iifthenelse (_, _, _) | Icatch (_, _, _, _)
   | Iexit _ | Iraise _
     ->
@@ -358,7 +358,7 @@ let safe_register_pressure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Istackoffset _ | Iload (_, _) | Istore (_, _, _)
   | Iintop _ | Iintop_imm (_, _) | Ispecific _ | Iname_for_debugger _
-  | Iprobe _ | Iprobe_is_enabled _
+  | Iprobe _ | Iprobe_is_enabled _ | Iopaque
     -> if fp then 10 else 11
 
 let max_register_pressure =
@@ -395,7 +395,7 @@ let max_register_pressure =
              | Irdtsc | Irdpmc | Icrc32q | Istore_int (_, _, _)
              | Ioffset_loc (_, _) | Ifloatarithmem (_, _)
              | Ibswap _ | Ifloatsqrtf _ | Isqrtf)
-  | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _
+  | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _ | Iopaque
     -> consumes ~int:0 ~float:0
 
 (* Pure operations (without any side effect besides updating their result
@@ -404,7 +404,7 @@ let max_register_pressure =
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Iprefetch _) -> false
   | Ispecific(Ilea _ | Isextend32 | Izextend32) -> true
   | Ispecific(Irdtsc | Irdpmc | Icrc32q | Istore_int (_, _, _)
@@ -453,5 +453,5 @@ let operation_supported = function
   | Cfloatofint | Cintoffloat | Ccmpf _
   | Craise _
   | Ccheckbound
-  | Cprobe _ | Cprobe_is_enabled _
+  | Cprobe _ | Cprobe_is_enabled _ | Copaque
     -> true

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -141,6 +141,7 @@ method! reload_operation op arg res =
   | Icompf _
   | Itailcall_ind|Itailcall_imm _|Iextcall _|Istackoffset _|Iload (_, _)
   | Istore (_, _, _)|Ialloc _|Iname_for_debugger _|Iprobe _|Iprobe_is_enabled _
+  | Iopaque
     -> (* Other operations: all args and results in registers *)
       super#reload_operation op arg res
 

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -151,7 +151,7 @@ let pseudoregs_for_operation op arg res =
   | Imove|Ispill|Ireload|Ifloatofint|Iintoffloat|Iconst_int _|Iconst_float _
   | Iconst_symbol _|Icall_ind|Icall_imm _|Itailcall_ind|Itailcall_imm _
   | Iextcall _|Istackoffset _|Iload (_, _)|Istore (_, _, _)|Ialloc _
-  | Iname_for_debugger _|Iprobe _|Iprobe_is_enabled _
+  | Iname_for_debugger _|Iprobe _|Iprobe_is_enabled _ | Iopaque
     -> raise Use_default
 
 let select_locality (l : Cmm.prefetch_temporal_locality_hint)

--- a/backend/arm/emit.mlp
+++ b/backend/arm/emit.mlp
@@ -747,6 +747,8 @@ let emit_instr i =
     | Lop(Iintoffloat) ->
         `	ftosizd	s14, {emit_reg i.arg.(0)}\n`;
         `	fmrs	{emit_reg i.res.(0)}, s14\n`; 2
+    | Lop(Iopaque) ->
+        assert (i.arg.(0).loc = i.res.(0).loc); 0
     | Lop(Iaddf | Isubf | Imulf | Idivf | Ispecific Inegmulf as op) ->
         let instr = (match op with
                        Iaddf              -> "faddd"

--- a/backend/arm/proc.ml
+++ b/backend/arm/proc.ml
@@ -336,7 +336,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _)
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque
   | Ispecific(Ishiftcheckbound _) -> false
   | _ -> true
 
@@ -374,5 +374,5 @@ let operation_supported = function
   | Cfloatofint | Cintoffloat | Ccmpf _
   | Craise _
   | Ccheckbound
-  | Cprobe _ | Cprobe_is_enabled _
+  | Cprobe _ | Cprobe_is_enabled _ | Copaque
     -> true

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -529,6 +529,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Iintop_imm _) -> 1
     | Lop (Ifloatofint | Iintoffloat | Iabsf | Inegf | Ispecific Isqrtf) -> 1
     | Lop (Iaddf | Isubf | Imulf | Idivf | Ispecific Inegmulf) -> 1
+    | Lop (Iopaque) -> 0
     | Lop (Ispecific (Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf)) -> 1
     | Lop (Ispecific (Ishiftarith _)) -> 1
     | Lop (Ispecific (Imuladd | Imulsub)) -> 1
@@ -876,6 +877,8 @@ let emit_instr i =
                      | Inegmulsubf -> "fnmsub"
                      | _ -> assert false) in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, {emit_reg i.arg.(0)}\n`
+    | Lop(Iopaque) ->
+        assert (i.arg.(0).loc = i.res.(0).loc)
     | Lop(Ispecific(Ishiftarith(op, shift))) ->
         let instr = (match op with
                        Ishiftadd    -> "add"

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -287,7 +287,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _)
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque
   | Ispecific(Ishiftcheckbound _) -> false
   | _ -> true
 
@@ -322,5 +322,5 @@ let operation_supported = function
   | Cfloatofint | Cintoffloat | Ccmpf _
   | Craise _
   | Ccheckbound
-  | Cprobe _ | Cprobe_is_enabled _
+  | Cprobe _ | Cprobe_is_enabled _ | Copaque
     -> true

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -208,6 +208,7 @@ let dump_op ppf = function
   | Probe { name; handler_code_sym } ->
     Format.fprintf ppf "probe %s %s" name handler_code_sym
   | Probe_is_enabled { name } -> Format.fprintf ppf "probe_is_enabled %s" name
+  | Opaque -> Format.fprintf ppf "opaque"
   | Name_for_debugger _ -> Format.fprintf ppf "name_for_debugger"
 
 let dump_call ppf = function

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -247,6 +247,7 @@ let check_operation : location -> Cfg.operation -> Cfg.operation -> unit =
   | Specific expected_spec, Specific result_spec
     when Arch.equal_specific_operation expected_spec result_spec ->
     ()
+  | Opaque, Opaque -> ()
   | ( Name_for_debugger
         { ident = left_ident;
           which_parameter = left_which_parameter;

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -79,6 +79,7 @@ module S = struct
           handler_code_sym : string
         }
     | Probe_is_enabled of { name : string }
+    | Opaque
     | Specific of Arch.specific_operation
     | Name_for_debugger of
         { ident : Ident.t;

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -77,6 +77,7 @@ let from_basic (basic : Cfg.basic) : L.instruction_desc =
       | Intoffloat -> Iintoffloat
       | Probe { name; handler_code_sym } -> Iprobe { name; handler_code_sym }
       | Probe_is_enabled { name } -> Iprobe_is_enabled { name }
+      | Opaque -> Iopaque
       | Specific op -> Ispecific op
       | Name_for_debugger { ident; which_parameter; provenance; is_assignment }
         ->

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -414,6 +414,7 @@ let to_basic (mop : Mach.operation) : C.basic =
   | Icompf c -> Op (Compf c)
   | Ifloatofint -> Op Floatofint
   | Iintoffloat -> Op Intoffloat
+  | Iopaque -> Op Opaque
   | Ispecific op -> Op (Specific op)
   | Iname_for_debugger { ident; which_parameter; provenance; is_assignment } ->
     Op (Name_for_debugger { ident; which_parameter; provenance; is_assignment })
@@ -610,7 +611,8 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     | Istore (_, _, _)
     | Ialloc _ | Iintop _
     | Iintop_imm (_, _)
-    | Iprobe _ | Iprobe_is_enabled _ | Ispecific _ | Iname_for_debugger _ ->
+    | Iopaque | Iprobe _ | Iprobe_is_enabled _ | Ispecific _
+    | Iname_for_debugger _ ->
       let desc = to_basic mop in
       block.body <- create_instruction t desc i ~trap_depth :: block.body;
       if Mach.operation_can_raise mop then record_exn t block traps;

--- a/backend/cfgize.ml
+++ b/backend/cfgize.ml
@@ -202,6 +202,8 @@ let basic_or_terminator_of_operation
       Basic (Op Intoffloat)
     | Ispecific op ->
       Basic (Op (Specific op))
+    | Iopaque ->
+      Basic (Op Opaque)
     | Iname_for_debugger _ ->
       Misc.fatal_error "Cfgize.basic_or_terminator_of_operation: \
                         \"the Iname_for_debugger\" instruction is currently not supported "
@@ -332,6 +334,7 @@ let can_raise_operation
     | Probe _ -> true
     | Probe_is_enabled _ -> false (* CR xclerc for xclerc: double check *)
     | Specific _ -> false (* CR xclerc for xclerc: double check *)
+    | Opaque -> false
     | Name_for_debugger _ -> false
 
 let can_raise_instr
@@ -358,6 +361,7 @@ let is_noop_move (instr : Cfg.basic Cfg.instruction) : bool =
   | Op (Const_int _ | Const_float _ | Const_symbol _ | Stackoffset _
        | Load _ | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf
        | Subf | Mulf | Divf | Compf _ | Floatofint | Intoffloat | Probe _
+       | Opaque
        | Probe_is_enabled _ | Specific _ | Name_for_debugger _)
   | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
     false

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -198,6 +198,7 @@ and operation =
   | Ccheckbound
   | Cprobe of { name: string; handler_code_sym: string; }
   | Cprobe_is_enabled of { name: string }
+  | Copaque
 
 type expression =
     Cconst_int of int * Debuginfo.t

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -204,6 +204,7 @@ and operation =
                    or equal to the bound. *)
   | Cprobe of { name: string; handler_code_sym: string; }
   | Cprobe_is_enabled of { name: string }
+  | Copaque (* Sys.opaque_identity *)
 
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1387,6 +1387,9 @@ let check_bound safety access_size dbg length a2 k =
       in
       Csequence(make_checkbound dbg [max_or_zero a1 dbg; a2], k)
 
+let opaque e dbg =
+  Cop(Copaque, [e], dbg)
+
 let unaligned_set size ptr idx newval dbg =
   match (size : Clambda_primitives.memory_access_size) with
   | Sixteen -> unaligned_set_16 ptr idx newval dbg

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -334,6 +334,9 @@ val check_bound :
   expression -> expression -> expression ->
   expression
 
+(** Sys.opaque_identity *)
+val opaque : expression -> Debuginfo.t -> expression
+
 (** Generic application functions *)
 
 (** Get the symbol for the generic application with [n] arguments, and

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -824,7 +824,7 @@ and transl_prim_1 env p arg dbg =
   match p with
   (* Generic operations *)
     Popaque ->
-      transl env arg
+      opaque (transl env arg) dbg
   (* Heap operations *)
   | Pfield n ->
       get_field env (transl env arg) n dbg

--- a/backend/i386/emit.mlp
+++ b/backend/i386/emit.mlp
@@ -741,6 +741,8 @@ let emit_instr fallthrough i =
       I.add (int 8) esp;
       cfi_adjust_cfa_offset (-8);
       stack_offset := !stack_offset + 8
+  | Lop(Iopaque) ->
+      assert (i.arg.(0).loc = i.res.(0).loc)
   | Lop(Ispecific(Ilea addr)) ->
       I.lea (addressing addr DWORD i 0) (reg i.res.(0))
   | Lop(Ispecific(Istore_int(n, addr, _))) ->

--- a/backend/i386/proc.ml
+++ b/backend/i386/proc.ml
@@ -233,7 +233,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Ilea _) -> true
   | Ispecific _ -> false
   | _ -> true
@@ -270,5 +270,5 @@ let operation_supported = function
   | Cfloatofint | Cintoffloat | Ccmpf _
   | Craise _
   | Ccheckbound
-  | Cprobe _ | Cprobe_is_enabled _
+  | Cprobe _ | Cprobe_is_enabled _ | Copaque
     -> true

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -67,6 +67,7 @@ type operation =
   | Icompf of float_comparison
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat
+  | Iopaque
   | Ispecific of Arch.specific_operation
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
       provenance : unit option; is_assignment : bool; }
@@ -171,7 +172,8 @@ let rec instr_iter f i =
             | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
             | Icompf _
             | Ifloatofint | Iintoffloat
-            | Ispecific _ | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _) ->
+            | Ispecific _ | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _
+            | Iopaque) ->
         instr_iter f i.next
 
 let operation_can_raise op =

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -71,6 +71,7 @@ type operation =
   | Icompf of float_comparison
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat
+  | Iopaque
   | Ispecific of Arch.specific_operation
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
       provenance : unit option; is_assignment : bool; }

--- a/backend/power/emit.mlp
+++ b/backend/power/emit.mlp
@@ -518,6 +518,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf) -> 1
     | Lop(Ifloatofint) -> 9
     | Lop(Iintoffloat) -> 4
+    | Lop(Iopaque) -> 0
     | Lop(Ispecific _) -> 1
     | Lop (Iname_for_debugger _) -> 0
     | Lop (Iprobe _ |Iprobe_is_enabled _) ->
@@ -880,6 +881,8 @@ let emit_instr i =
           `	lwz	{emit_reg i.res.(0)}, 4(1)\n`;
           `	addi	1, 1, 16\n`
         end
+    | Lop(Iopaque) ->
+        assert (i.arg.(0).loc = i.res.(0).loc)
     | Lop(Ispecific sop) ->
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`

--- a/backend/power/proc.ml
+++ b/backend/power/proc.ml
@@ -327,7 +327,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Imultaddf | Imultsubf) -> true
   | Ispecific _ -> false
   | _ -> true
@@ -375,5 +375,5 @@ let operation_supported = function
   | Cfloatofint | Cintoffloat | Ccmpf _
   | Craise _
   | Ccheckbound
-  | Cprobe _ | Cprobe_is_enabled _
+  | Cprobe _ | Cprobe_is_enabled _ | Copaque
     -> true

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -197,6 +197,7 @@ let operation d = function
   | Cprefetch { is_write; locality; } ->
     Printf.sprintf "prefetch is_write=%b prefetch_temporal_locality_hint=%s"
       is_write (temporal_locality locality)
+  | Copaque -> "opaque"
 
 let rec expr ppf = function
   | Cconst_int (n, _dbg) -> fprintf ppf "%i" n

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -165,6 +165,7 @@ let operation op arg ppf res =
   | Idivf -> fprintf ppf "%a /f %a" reg arg.(0) reg arg.(1)
   | Ifloatofint -> fprintf ppf "floatofint %a" reg arg.(0)
   | Iintoffloat -> fprintf ppf "intoffloat %a" reg arg.(0)
+  | Iopaque -> fprintf ppf "opaque %a" reg arg.(0)
   | Iname_for_debugger { ident; which_parameter; } ->
     fprintf ppf "name_for_debugger %a%s=%a"
       V.print ident

--- a/backend/reloadgen.ml
+++ b/backend/reloadgen.ml
@@ -75,6 +75,10 @@ method reload_operation op arg res =
        so that the presence of a probe does not affect
        register allocation of the rest of the code. *)
     (arg, res)
+  | Iopaque ->
+      (* arg = result, can be on stack or register *)
+      assert (arg.(0).stamp = res.(0).stamp);
+      (arg, res)
   | _ ->
       (self#makeregs arg, self#makeregs res)
 

--- a/backend/riscv/emit.mlp
+++ b/backend/riscv/emit.mlp
@@ -457,6 +457,8 @@ let emit_instr i =
       `	fcvt.d.l	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
   | Lop(Iintoffloat) ->
       `	fcvt.l.d	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, rtz\n`
+  | Lop(Iopaque) ->
+      assert (i.arg.(0).loc = i.res.(0).loc)
   | Lop(Ispecific sop) ->
       let instr = name_for_specific sop in
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`

--- a/backend/riscv/proc.ml
+++ b/backend/riscv/proc.ml
@@ -334,5 +334,5 @@ let operation_supported = function
   | Cfloatofint | Cintoffloat | Ccmpf _
   | Craise _
   | Ccheckbound
-  | Cprobe _ | Cprobe_is_enabled _
+  | Cprobe _ | Cprobe_is_enabled _ | Copaque
     -> true

--- a/backend/s390x/emit.mlp
+++ b/backend/s390x/emit.mlp
@@ -551,6 +551,8 @@ let emit_instr i =
     | Lop(Iintoffloat) ->
         (* rounding method #5 = round toward 0 *)
         `	cgdbr	{emit_reg i.res.(0)}, 5, {emit_reg i.arg.(0)}\n`
+    | Lop(Iopaque) ->
+        assert (i.arg.(0).loc = i.res.(0).loc)
     | Lop(Ispecific sop) ->
         assert (i.arg.(2).loc = i.res.(0).loc);
         let instr = name_for_specific sop in

--- a/backend/s390x/proc.ml
+++ b/backend/s390x/proc.ml
@@ -216,7 +216,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Imultaddf | Imultsubf) -> true
   | _ -> true
 
@@ -251,5 +251,5 @@ let operation_supported = function
   | Cfloatofint | Cintoffloat | Ccmpf _
   | Craise _
   | Ccheckbound
-  | Cprobe _ | Cprobe_is_enabled _
+  | Cprobe _ | Cprobe_is_enabled _ | Copaque
     -> true

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -419,7 +419,7 @@ let unary_primitive env dbg f arg =
         (C.field_address arg (4 + dimension) dbg) )
   | String_length _ -> None, C.string_length arg dbg
   | Int_as_pointer -> None, C.int_as_pointer arg dbg
-  | Opaque_identity -> None, arg
+  | Opaque_identity -> None, C.opaque arg dbg
   | Int_arith (kind, op) -> None, unary_int_arith_primitive env dbg kind op arg
   | Float_arith op -> None, unary_float_arith_primitive env dbg op arg
   | Num_conv { src; dst } -> arithmetic_conversion dbg src dst arg

--- a/ocaml/testsuite/tests/lib-sys/opaque.ml
+++ b/ocaml/testsuite/tests/lib-sys/opaque.ml
@@ -1,0 +1,38 @@
+(* TEST *)
+
+let[@inline never] float_unboxing s f =
+  let x = Sys.opaque_identity (s +. 1.) in
+  let mw1 = Gc.minor_words () in
+  let mw2 = Gc.minor_words () in
+  f x;
+  let mw3 = Gc.minor_words () in
+  Printf.printf "unbox: %.0f\n" ((mw3 -. mw2) -. (mw2 -. mw1))
+
+let[@inline never] lifetimes () =
+  let final = ref false in
+  let go () =
+    let r = ref 42 in
+    Gc.finalise (fun _ -> final := true) r;
+    let f1 = !final in
+    Gc.full_major ();
+    let f2 = !final in
+    ignore (Sys.opaque_identity r);
+    (f1, f2) in
+  let (f1, f2) = go () in
+  Gc.full_major ();
+  let f3 = !final in
+  Printf.printf "lifetime: %b %b %b\n" f1 f2 f3
+
+let[@inline never] dead_alloc a =
+  let mw1 = Gc.minor_words () in
+  let mw2 = Gc.minor_words () in
+  ignore (Sys.opaque_identity (a, a));
+  let mw3 = Gc.minor_words () in
+  Printf.printf "dead: %.0f\n" ((mw3 -. mw2) -. (mw2 -. mw1))
+  
+
+let () =
+  float_unboxing 50. (fun _ -> ());
+  lifetimes ();
+  dead_alloc 10
+          

--- a/ocaml/testsuite/tests/lib-sys/opaque.reference
+++ b/ocaml/testsuite/tests/lib-sys/opaque.reference
@@ -1,0 +1,3 @@
+unbox: 0
+lifetime: false false true
+dead: 3


### PR DESCRIPTION
See [upstream](https://github.com/ocaml/ocaml/pull/9412).