### PR TITLE
Add version to .ocamlformat

### DIFF
--- a/backend/cfg/.ocamlformat
+++ b/backend/cfg/.ocamlformat
@@ -11,3 +11,4 @@ space-around-lists=false
 space-around-variants=false
 type-decl=sparse
 wrap-comments=true
+version=0.19.0

--- a/middle_end/flambda2/.ocamlformat
+++ b/middle_end/flambda2/.ocamlformat
@@ -11,3 +11,4 @@ space-around-lists=false
 space-around-variants=false
 type-decl=sparse
 wrap-comments=true
+version=0.19.0


### PR DESCRIPTION
See https://github.com/ocaml-flambda/flambda-backend/pull/237#issuecomment-915952014.

The version in `.ocamlformat` config file must match the version of `ocamlformat` used in the CI.