### PR TITLE
Add Dwarf_low + Dwarf_high libs and basic DWARF emission for functions

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1169,6 +1169,8 @@ let fundecl fundecl =
       cfi_adjust_cfa_offset (-n);
     end;
   end;
+  let end_symbol = Dwarf_ocaml.Dwarf_concrete_instances.end_symbol_name fundecl.fun_name in
+  D.label (emit_symbol end_symbol);
   cfi_endproc ();
   emit_function_type_and_size fundecl.fun_name
 
@@ -1195,13 +1197,16 @@ let data l =
 
 (* Beginning / end of an assembly file *)
 
-let begin_assembly() =
+let begin_assembly ~init_dwarf =
   X86_proc.reset_asm_code ();
   reset_debug_info();                   (* PR#5603 *)
   reset_imp_table();
   reset_probes ();
   float_constants := [];
   all_functions := [];
+
+  init_dwarf ();
+
   if system = S_win64 then begin
     D.extrn "caml_call_gc" NEAR;
     D.extrn "caml_c_call" NEAR;
@@ -1212,7 +1217,6 @@ let begin_assembly() =
     D.extrn "caml_ml_array_bound_error" NEAR;
     D.extrn "caml_raise_exn" NEAR;
   end;
-
 
   if !Clflags.dlcode || Arch.win64 then begin
     (* from amd64.S; could emit these constants on demand *)
@@ -1532,7 +1536,7 @@ let emit_dummy_probe_sites () =
     dummy_probes
   end
 
-let end_assembly() =
+let end_assembly dwarf =
   if !float_constants <> [] then begin
     begin match system with
     | S_macosx -> D.section ["__TEXT";"__literal8"] None ["8byte_literals"]
@@ -1626,4 +1630,8 @@ let end_assembly() =
     else
       None
   in
+  begin match dwarf with
+    | Some dwarf -> Dwarf_ocaml.Dwarf.emit dwarf
+    | None -> ()
+  end;
   X86_proc.generate_code asm

--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -69,8 +69,11 @@ val compile_implementation_flambda2
 val compile_implementation_linear :
     string -> progname:string -> unit
 
-val compile_phrase :
-    ppf_dump:Format.formatter -> Cmm.phrase -> unit
+val compile_phrase
+  : ?dwarf:Dwarf_ocaml.Dwarf.t 
+  -> ppf_dump:Format.formatter
+  -> Cmm.phrase
+  -> unit
 
 type error =
   | Assembler_error of string
@@ -86,3 +89,12 @@ val compile_unit
    -> obj_filename:string
    -> (unit -> unit)
    -> unit
+
+(* First-class module building for DWARF *)
+
+val build_dwarf
+   : asm_directives:(module Asm_directives_intf.S)
+  -> string
+  -> Dwarf_ocaml.Dwarf.t
+
+val build_asm_directives : unit -> (module Asm_directives_intf.S)

--- a/backend/debug/dwarf/dwarf_deps/asm_directives.ml
+++ b/backend/debug/dwarf/dwarf_deps/asm_directives.ml
@@ -1,0 +1,300 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module type S = Asm_directives_intf.S
+module type Arg = Asm_directives_intf.Arg
+
+module Cached_string = struct
+  type t = {
+    section : Asm_section.t;
+    str : string;
+    comment : string option;
+  }
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let compare { section = section1; str = str1; comment = comment1; }
+          { section = section2; str = str2; comment = comment2; } =
+      let c = Asm_section.compare section1 section2 in
+      if c <> 0 then c
+      else
+        let c = String.compare str1 str2 in
+        if c <> 0 then c
+        else
+          Option.compare String.compare comment1 comment2
+
+    let equal t1 t2 =
+      compare t1 t2 = 0
+
+    let hash t = Hashtbl.hash t
+
+    let print _ _ = Misc.fatal_error "Not yet implemented"
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+  end)
+end
+
+module Make ( A : Asm_directives_intf.Arg ) : Asm_directives_intf.S = struct
+
+  module Int8 = Numbers_extra.Int8
+  module Int16 = Numbers_extra.Int16
+
+  module Uint8 = Numbers_extra.Uint8
+  module Uint16 = Numbers_extra.Uint16
+  module Uint32 = Numbers_extra.Uint32
+  module Uint64 = Numbers_extra.Uint64
+
+  module D = A.D
+
+  let sections_seen = ref []
+
+  let current_section_ref = ref None
+
+  let cached_strings = ref Cached_string.Map.empty
+
+  let temp_var_counter = ref 0
+
+  let is_macos () = 
+    match Config_typed.assembler () with
+    | MASM | GAS_like -> false
+    | MacOS -> true
+
+  let if_not_masm f =
+    match Config_typed.assembler () with
+    | MASM -> ()
+    | GAS_like 
+    | MacOS -> f ()
+  
+  let loc ~file_num ~line ~col =
+    if_not_masm (fun () -> D.loc ~file_num ~line ~col ())
+
+  let new_line () = D.new_line ()
+
+  let not_initialized () =
+    Misc.fatal_error "[Asm_directives.initialize] has not been called"
+
+  let define_label label =
+    let lbl_section = Asm_label.section label in
+    let this_section =
+      match !current_section_ref with
+      | None -> not_initialized ()
+      | Some this_section -> this_section
+    in
+    if not (Asm_section.equal lbl_section this_section) then begin
+      Misc.fatal_errorf "Cannot define label %a intended for section %a \
+          in section %a"
+        Asm_label.print label
+        Asm_section.print lbl_section
+        Asm_section.print this_section
+    end;
+    (* CR-someday bkhajwal: Be aware of MASM label type annotation *)
+    D.label (Asm_label.encode label)
+
+  let switch_to_section section =
+    let first_occurrence =
+      if List.mem section !sections_seen then false
+      else begin
+        sections_seen := section::!sections_seen;
+        true
+      end
+    in
+    match !current_section_ref with
+    | Some section' when Asm_section.equal section section' ->
+      assert (not first_occurrence);
+      ()
+    | _ ->
+      current_section_ref := Some section;
+      let ({ names; flags; args; } : Asm_section.flags_for_section) =
+        Asm_section.flags section ~first_occurrence
+      in
+      if not first_occurrence then begin
+        new_line ()
+      end;
+      D.section names flags args;
+      if first_occurrence then begin
+        define_label (Asm_label.for_section section)
+      end
+
+  let initialize () =
+    cached_strings := Cached_string.Map.empty;
+    sections_seen := [];
+    temp_var_counter := 0;
+    (* Forward label references are illegal in GAS *)
+    begin match Config_typed.assembler () with
+    | MASM | MacOS -> ()
+    | GAS_like -> List.iter switch_to_section (Asm_section.dwarf_sections_in_order ())
+    end;
+    (* Stop dsymutil complaining about empty __debug_line sections (produces
+      bogus error "line table parameters mismatch") by making sure such sections
+      are never empty. *)
+    let file_num = A.get_file_num "none" in
+    loc ~file_num ~line:1 ~col:1;
+    D.text ()
+
+  let with_comment f ?comment x =
+    Option.iter D.comment comment;
+    f x
+
+  let (>>) f g x = g (f x)
+  
+  let int8 = with_comment (Int8.to_int >> Int64.of_int >> D.const_int64 >> D.byte)
+  let int16 = with_comment (Int16.to_int >> Int64.of_int >> D.const_int64 >> D.word)
+  let int32 = with_comment (Int64.of_int32 >> D.const_int64 >> D.long)
+  let int64 = with_comment (D.const_int64 >> D.qword)
+
+  let uint8 = with_comment (Uint8.to_int >> Int64.of_int >> D.const_int64 >> D.byte)
+  let uint16 = with_comment (Uint16.to_int >> Int64.of_int >> D.const_int64 >> D.word)
+  let uint32 = with_comment (Uint32.to_int64 >> D.const_int64 >> D.long)
+  let uint64 = with_comment (Uint64.to_int64 >> D.const_int64 >> D.qword)
+
+  let targetint ?comment num = 
+    match Targetint_extra.repr num with
+    | Int32 n -> int32 ?comment n
+    | Int64 n -> int64 ?comment n
+
+  let uleb128 = with_comment (Uint64.to_int64 >> D.const_int64 >> D.uleb128)
+  let sleb128 = with_comment (D.const_int64 >> D.sleb128)
+
+  let string = with_comment (fun str -> D.bytes str)
+
+  let cache_string ?comment section str =
+    let cached : Cached_string.t = { section; str; comment; } in
+    match Cached_string.Map.find cached !cached_strings with
+    | label -> label
+    | exception Not_found ->
+      let label = Asm_label.create section in
+      cached_strings := Cached_string.Map.add cached label !cached_strings;
+      label
+
+  let emit_cached_strings () =
+    Cached_string.Map.iter (fun { section; str; comment; } label_name ->
+        switch_to_section section;
+        define_label label_name;
+        string ?comment str;
+        int8 Int8.zero)
+      !cached_strings;
+    cached_strings := Cached_string.Map.empty
+
+  let comment str = D.comment str
+
+  let define_data_symbol symbol =
+    (* 
+      CR-someday bkhajwal: Asm_symbol currently is just a string, if section-related
+      information is added, should be worth doing this check.
+
+      check_symbol_for_definition_in_current_section symbol;
+    *)
+    let symbol = Asm_symbol.encode symbol in
+    let data_type = 
+      match Machine_width.of_int_exn Sys.word_size with
+      | Thirty_two -> D.DWORD
+      | Sixty_four -> D.QWORD
+    in
+    D.label ~data_type symbol;
+    begin match Config_typed.assembler (), Config_typed.is_windows () with
+    | GAS_like, false -> D.type_ symbol "STT_OBJECT"
+    | GAS_like, true
+    | MacOS, _
+    | MASM, _ -> ()
+    end
+
+  let global sym = D.global (Asm_symbol.encode sym)
+
+  let const_machine_width const =
+    match Machine_width.of_int_exn Sys.word_size with
+    | Thirty_two -> D.long const
+    | Sixty_four -> D.qword const
+
+  let symbol = with_comment (fun sym ->
+    let lab = D.const_label (Asm_symbol.encode sym) in
+    const_machine_width lab
+  )
+
+  let label ?comment:_ _lab = A.emit_line "label"
+
+  let symbol_plus_offset _sym ~offset_in_bytes:_ = A.emit_line "symbol_plus_offset"
+  
+  let between_symbols_in_current_unit ~upper ~lower =
+    (* CR-someday bkhajwal: Add checks below from gdb-names-gpr
+      check_symbol_in_current_unit upper;
+      check_symbol_in_current_unit lower;
+      check_symbols_in_same_section upper lower;
+    *)
+    let upper = D.const_label (Asm_symbol.encode upper) in
+    let lower = D.const_label (Asm_symbol.encode lower) in
+    (* CR-someday bkhajwal: Add `force_assembly_time_constant` *)
+    const_machine_width (D.const_sub upper lower)
+  
+  let between_labels_16_bit ?comment:_ ~upper:_ ~lower:_ () = A.emit_line "between_labels_16_bit"
+  let between_labels_32_bit ?comment:_ ~upper:_ ~lower:_ () = A.emit_line "between_labels_32_bit"
+  let between_labels_64_bit ?comment:_ ~upper:_ ~lower:_ () = A.emit_line "between_labels_64_bit"
+
+  let between_symbol_in_current_unit_and_label_offset 
+  ?comment:_ ~upper:_ ~lower:_ ~offset_upper:_ () = A.emit_line "between_symbol_in_current_unit_and_label_offset"
+
+  let new_temp_var () =
+    let id = !temp_var_counter in
+    incr temp_var_counter;
+    Printf.sprintf "Ltemp%d" id
+
+  let force_assembly_time_constant _section expr =
+    if not (is_macos ()) then
+      expr
+    else begin
+      (* This ensures the correct result is obtained on macOS.  (Apparently
+        just writing expressions such as "L100 - L101" inline can cause
+        unexpected results when one of the labels is on a section boundary,
+        for example.) *)
+      let temp = new_temp_var () in
+      D.direct_assignment temp expr;
+      (* TODO: Insert logic
+      let compilation_unit = Compilation_unit.get_current_exn ()  in
+      let sym =
+        Asm_symbol.of_external_name_no_prefix section compilation_unit temp
+      in
+      Symbol sym  (* not really a symbol, but OK. *)
+      *)
+      Misc.fatal_error "not implemented"
+    end
+
+  let offset_into_dwarf_section_label ?comment section upper ~width = 
+    let upper_section = Asm_label.section upper in
+    let expected_section : Asm_section.t = DWARF section in
+    if not (Asm_section.equal upper_section expected_section) then begin
+      Misc.fatal_errorf "Label %a (in section %a) is not in section %a"
+        Asm_label.print upper
+        Asm_section.print upper_section
+        Asm_section.print expected_section
+    end;
+    if !Clflags.keep_asm_file then begin
+      let expected_section = Asm_section.to_string expected_section in
+      match comment with
+      | None ->
+        D.comment (Format.asprintf "offset into %s" expected_section)
+      | Some comment ->
+        D.comment (Format.asprintf "%s (offset into %s)" comment expected_section)
+    end;
+    (* macOS does not use relocations in DWARF sections in places, such as
+      here, where they might be expected.  Instead dsymutil and other tools
+      parse DWARF sections properly and adjust offsets manually. *)
+    let expr =
+      if is_macos () then
+        let lower = Asm_label.for_dwarf_section section in
+        force_assembly_time_constant
+          expected_section
+          (D.const_sub
+            (D.const_label (Asm_label.encode upper))
+            (D.const_label (Asm_label.encode lower)))
+      else
+        D.const_label (Asm_label.encode upper)
+    in
+    match (width : Machine_width.t) with
+    | Thirty_two -> D.long expr
+    | Sixty_four -> D.qword expr
+  
+  let offset_into_dwarf_section_symbol
+    ?comment:_
+    _section
+    _symbol
+    ~width:_
+    = A.emit_line "offset_into_dwarf_section_symbol"
+end

--- a/backend/debug/dwarf/dwarf_deps/asm_directives.mli
+++ b/backend/debug/dwarf/dwarf_deps/asm_directives.mli
@@ -1,0 +1,4 @@
+module type S = Asm_directives_intf.S
+module type Arg = Asm_directives_intf.Arg
+
+module Make (_ : Arg) : S

--- a/backend/debug/dwarf/dwarf_deps/asm_directives_intf.ml
+++ b/backend/debug/dwarf/dwarf_deps/asm_directives_intf.ml
@@ -1,0 +1,217 @@
+module type Arg = sig
+    val emit_line : string -> unit
+
+    (* Should be Emitaux.get_file_num *)
+    val get_file_num : string -> int
+
+    module D : sig
+
+      type constant
+      val const_int64 : int64 -> constant
+      val const_label : string -> constant
+      val const_add : constant -> constant -> constant
+      val const_sub : constant -> constant -> constant
+
+      type data_type =
+        | NONE | DWORD | QWORD
+
+      val file: file_num:int -> file_name:string -> unit
+      val loc: file_num:int -> line:int -> col:int -> ?discriminator:int -> unit -> unit
+      val comment: string -> unit
+
+      val label: ?data_type:data_type -> string -> unit
+      val section: string list -> string option -> string list -> unit
+      val text : unit -> unit
+      val new_line : unit -> unit
+      val global: string -> unit
+      val type_: string -> string -> unit
+
+      val byte: constant -> unit
+      val word: constant -> unit
+      val long: constant -> unit
+      val qword: constant -> unit
+      val bytes : string -> unit
+      val uleb128 : constant -> unit
+      val sleb128 : constant -> unit
+
+      val direct_assignment : string -> constant -> unit
+    end
+end
+
+module type S = sig
+
+  (** Emit subsequent directives to the given section.  If this function
+      has not been called before on the particular section, a label
+      declaration will be emitted after declaring the section.
+      Such labels may seem strange, but they are necessary so that
+      references (e.g. DW_FORM_ref_addr / DW_FORM_sec_offset when emitting
+      DWARF) to places that are currently at the start of these sections
+      get relocated correctly when those places become not at the start
+      (e.g. during linking). *)
+  val switch_to_section : Asm_section.t -> unit
+
+  (** Called at the beginning of the assembly generation and only if the dwarf
+      flag has been set. *)
+  val initialize : unit -> unit
+
+  (** Emit an 8-bit signed integer.  There is no padding or sign extension.
+      If the [comment] is specified it will be put on the same line as the
+      integer. *)
+  val int8 : ?comment:string -> Numbers_extra.Int8.t -> unit
+
+  (** Emit a 16-bit signed integer.  There is no padding or sign extension. *)
+  val int16 : ?comment:string -> Numbers_extra.Int16.t -> unit
+
+  (** Emit a 32-bit signed integer.  There is no padding or sign extension. *)
+  val int32 : ?comment:string -> Int32.t -> unit
+
+  (** Emit a 64-bit signed integer. *)
+  val int64 : ?comment:string -> Int64.t -> unit
+
+  (** Emit an 8-bit unsigned integer.  There is no padding. *)
+  val uint8 : ?comment:string -> Numbers_extra.Uint8.t -> unit
+
+  (** Emit an 16-bit unsigned integer.  There is no padding. *)
+  val uint16 : ?comment:string -> Numbers_extra.Uint16.t -> unit
+
+  (** Emit an 32-bit unsigned integer.  There is no padding. *)
+  val uint32 : ?comment:string -> Numbers_extra.Uint32.t -> unit
+
+  (** Emit an 64-bit unsigned integer.  There is no padding. *)
+  val uint64 : ?comment:string -> Numbers_extra.Uint64.t -> unit
+
+  (** Emit a signed integer whose width is that of an address on the target
+      machine.  There is no padding or sign extension. *)
+  (* CR-soon mshinwell: Target addresses should not be signed *)
+  val targetint : ?comment:string -> Targetint_extra.t -> unit
+
+  (** Emit a 64-bit integer in unsigned LEB128 variable-length encoding
+      (cf. DWARF debugging information standard). *)
+  val uleb128 : ?comment:string -> Numbers_extra.Uint64.t -> unit
+
+  (** Emit a 64-bit integer in signed LEB128 variable-length encoding. *)
+  val sleb128 : ?comment:string -> Int64.t -> unit
+
+  (** Emit a string (directly into the current section).  This function
+      does not write a terminating null. *)
+  val string : ?comment:string -> string -> unit
+
+  (** Cache a string for later emission.  The returned label may be used to
+      obtain the address of the string in the section.  This function does
+      not emit anything.  (See [emit_cached_strings], below.)
+      If a string is supplied to this function that is already in the cache
+      then the previously-assigned label is returned, not a new one. *)
+  val cache_string : ?comment:string -> Asm_section.t -> string -> Asm_label.t
+
+  (** Emit the sequence of:
+        label definition:
+          <string><null terminator>
+      pairs as per previous calls to [cache_string] with appropriate directives
+      to switch section interspersed.  This function clears the cache. *)
+  val emit_cached_strings : unit -> unit
+
+  (** Emit a comment. *)
+  val comment : string -> unit
+
+  (** Emit a blank line. *)
+  val new_line : unit -> unit
+
+  (** Define a data ("object") symbol at the current output position.  When
+      emitting for MASM this will cause loads and stores to/from the symbol to
+      be treated as if they are loading machine-width words (unless the
+      instruction has an explicit width suffix). *)
+  val define_data_symbol : Asm_symbol.t -> unit
+
+  (** Mark a symbol as global. *)
+  val global : Asm_symbol.t -> unit
+
+  (** Emit a machine-width reference to the given symbol. *)
+  val symbol : ?comment:string -> Asm_symbol.t -> unit
+
+  (** Define a label at the current position in the current section.
+      The treatment for MASM when emitting into non-text sections is as for
+      [define_symbol], above. *)
+  val define_label : Asm_label.t -> unit
+
+  (** Emit a machine-width reference to the given label. *)
+  val label : ?comment:string -> Asm_label.t -> unit
+
+  (** Emit a machine-width reference to the address formed by adding the
+      given byte offset to the address of the given symbol.  The symbol may be
+      in a compilation unit and/or section different from the current one. *)
+  val symbol_plus_offset
+    : Asm_symbol.t
+    -> offset_in_bytes:Targetint_extra.t
+    -> unit
+
+  (** Emit a machine-width reference giving the displacement between two given
+      symbols.  To obtain a positive result the symbol at the [lower] address
+      should be the second argument, as for normal subtraction.  The symbols
+      must be in the current compilation unit and in the same section. *)
+  val between_symbols_in_current_unit
+    : upper:Asm_symbol.t
+    -> lower:Asm_symbol.t
+    -> unit
+
+  (** Like [between_symbols], but for two labels, emitting a 16-bit-wide
+      reference.  The behaviour upon overflow is unspecified.  The labels must
+      be in the same section. *)
+  val between_labels_16_bit
+    : ?comment:string
+    -> upper:Asm_label.t
+    -> lower:Asm_label.t
+    -> unit
+    -> unit
+
+  (** Like [between_symbols], but for two labels, emitting a 32-bit-wide
+      reference.  The behaviour upon overflow is unspecified.  The labels must
+      be in the same section. *)
+  val between_labels_32_bit
+    : ?comment:string
+    -> upper:Asm_label.t
+    -> lower:Asm_label.t
+    -> unit
+    -> unit
+
+  (** Like [between_symbols], but for two labels, emitting a 64-bit-wide
+      reference.  The labels must be in the same section. *)
+  val between_labels_64_bit
+    : ?comment:string
+    -> upper:Asm_label.t
+    -> lower:Asm_label.t
+    -> unit
+    -> unit
+
+  (** Emit a machine-width reference giving the displacement between the
+      [lower] symbol and the sum of the address of the [upper] label plus
+      [offset_upper].  The [lower] symbol must be in the current compilation
+      unit.  The [upper] label must be in the same section as the [lower]
+      symbol. *)
+  val between_symbol_in_current_unit_and_label_offset
+    : ?comment:string
+    -> upper:Asm_label.t
+    -> lower:Asm_symbol.t
+    -> offset_upper:Targetint_extra.t
+    -> unit
+    -> unit
+
+  (** Emit an offset into a DWARF section given a label identifying the place
+      within such section. *)
+  val offset_into_dwarf_section_label
+    : ?comment:string
+    -> Asm_section.dwarf_section
+    -> Asm_label.t
+    -> width:Machine_width.t
+    -> unit
+
+  (** Emit an offset into a DWARF section given a symbol identifying the place
+      within such section.  The symbol may only be in a compilation unit different
+      from the current one if the supplied section is [Debug_info].  The symbol
+      must always be in the given section. *)
+  val offset_into_dwarf_section_symbol
+    : ?comment:string
+    -> Asm_section.dwarf_section
+    -> Asm_symbol.t
+    -> width:Machine_width.t
+    -> unit
+end

--- a/backend/debug/dwarf/dwarf_deps/asm_label.ml
+++ b/backend/debug/dwarf/dwarf_deps/asm_label.ml
@@ -1,0 +1,125 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type label =
+  | Int of int
+  | String of string
+
+type t = {
+  section : Asm_section.t;
+  label : label;
+}
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare t1 t2 = Stdlib.compare t1.label t2.label
+
+  let equal t1 t2 = (compare t1 t2 = 0)
+
+  let hash t = Hashtbl.hash t.label
+
+  let print ppf t =
+    match t.label with
+    | Int i -> Format.fprintf ppf "L%d" i
+    | String s -> Format.fprintf ppf "L%s" s
+
+  let output _ _ = Misc.fatal_error "Not yet implemented"
+end)
+
+let create_int section label =
+  { section;
+    label = Int label;
+  }
+
+let create_string section label =
+  { section;
+    label = String label;
+  }
+
+let label_prefix =
+  match Config_typed.architecture () with
+  | IA32 | X86_64 ->
+    begin match Config_typed.derived_system () with
+    | Linux
+    | MinGW_32
+    | MinGW_64
+    | Cygwin
+    | FreeBSD
+    | NetBSD
+    | OpenBSD
+    | Generic_BSD
+    | Solaris
+    | Dragonfly
+    | GNU
+    | BeOS
+    | Unknown -> ".L"
+    | MacOS_like
+    | Win32
+    | Win64 -> "L"
+    end
+  | ARM
+  | AArch64
+  | POWER
+  | Z -> ".L"
+
+let encode (t : t) =
+  match t.label with
+  | Int label -> label_prefix ^ (string_of_int label)
+  | String label -> label_prefix ^ label
+
+let section t = t.section
+
+let new_label_ref = ref None
+
+let not_initialized () =
+  Misc.fatal_error "[Asm_label.initialize] has not been called"
+
+let initialize ~new_label =
+  new_label_ref := Some new_label
+
+let create section =
+  match !new_label_ref with
+  | None -> not_initialized ()
+  | Some new_label -> create_int section (new_label ())
+
+let debug_info_label = lazy (create (DWARF Debug_info))
+let debug_abbrev_label = lazy (create (DWARF Debug_abbrev))
+let debug_aranges_label = lazy (create (DWARF Debug_aranges))
+let debug_addr_label = lazy (create (DWARF Debug_addr))
+let debug_loc_label = lazy (create (DWARF Debug_loc))
+let debug_ranges_label = lazy (create (DWARF Debug_ranges))
+let debug_loclists_label = lazy (create (DWARF Debug_loclists))
+let debug_rnglists_label = lazy (create (DWARF Debug_rnglists))
+let debug_str_label = lazy (create (DWARF Debug_str))
+let debug_line_label = lazy (create (DWARF Debug_line))
+
+let for_dwarf_section (dwarf_section : Asm_section.dwarf_section) =
+  match dwarf_section with
+  | Debug_info -> Lazy.force debug_info_label
+  | Debug_abbrev -> Lazy.force debug_abbrev_label
+  | Debug_aranges -> Lazy.force debug_aranges_label
+  | Debug_addr -> Lazy.force debug_addr_label
+  | Debug_loc -> Lazy.force debug_loc_label
+  | Debug_ranges -> Lazy.force debug_ranges_label
+  | Debug_loclists -> Lazy.force debug_loclists_label
+  | Debug_rnglists -> Lazy.force debug_rnglists_label
+  | Debug_str -> Lazy.force debug_str_label
+  | Debug_line -> Lazy.force debug_line_label
+
+let for_section (section : Asm_section.t) =
+  match section with
+  | DWARF dwarf_section -> for_dwarf_section dwarf_section

--- a/backend/debug/dwarf/dwarf_deps/asm_label.mli
+++ b/backend/debug/dwarf/dwarf_deps/asm_label.mli
@@ -1,0 +1,64 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** A label in a specific section within the assembly stream. They may be either
+    numeric or textual. (Numeric ones are converted to textual ones by this
+    module.) The argument to [String] should not include any platform-specific
+    prefix (such as "L", ".L", etc).
+
+    Label's numeric or textual names are unique within the assembly stream
+    for a single compilation unit, even across sections.
+
+    Note: Labels are not symbols in the usual sense---they are a construct
+    in the assembler's metalanguage and not accessible in the object
+    file---although on macOS the terminology for labels appears to be
+    "assembler local symbols".
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+(** Create a fresh integer-valued label (using the [new_label] function passed
+    to [initialize], below). *)
+val create : Asm_section.t -> t
+
+(** Create an integer-valued label. *)
+val create_int : Asm_section.t -> int -> t
+
+(** Create a textual label.  The supplied name must not require escaping. *)
+val create_string : Asm_section.t -> string -> t
+
+(** Convert a label to the corresponding textual form, suitable for direct
+    emission into an assembly file.  This may be useful e.g. when emitting
+    an instruction referencing a label. *)
+val encode : t -> string
+
+(** To be called by the emitter at the very start of code generation.
+    [new_label] should always be [Cmm.new_label]. *)
+val initialize
+   : new_label:(unit -> int)
+  -> unit
+
+(** Which section a label is in. *)
+val section : t -> Asm_section.t
+
+include Identifiable.S with type t := t
+
+(** Retrieve a distinguished label that is suitable for identifying the start
+    of the given section within a given compilation unit's assembly file. *)
+val for_section : Asm_section.t -> t
+
+(** Like [label], but for DWARF sections only. *)
+val for_dwarf_section : Asm_section.dwarf_section -> t

--- a/backend/debug/dwarf/dwarf_deps/asm_section.ml
+++ b/backend/debug/dwarf/dwarf_deps/asm_section.ml
@@ -1,0 +1,131 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type dwarf_section =
+  | Debug_info
+  | Debug_abbrev
+  | Debug_aranges
+  | Debug_addr
+  | Debug_loc
+  | Debug_ranges
+  | Debug_loclists
+  | Debug_rnglists
+  | Debug_str
+  | Debug_line
+
+type t = DWARF of dwarf_section
+
+type flags_for_section = {
+  names : string list;
+  flags : string option;
+  args : string list;
+}
+
+let dwarf_sections_in_order () =
+  let sections = [
+    DWARF Debug_info;
+    DWARF Debug_abbrev;
+    DWARF Debug_aranges;
+    DWARF Debug_str;
+    DWARF Debug_line;
+  ] in
+  let dwarf_version_dependent_sections =
+    match !Clflags.gdwarf_version with
+    | Four ->
+      [ DWARF Debug_loc;
+        DWARF Debug_ranges;
+      ]
+    | Five ->
+      [ DWARF Debug_addr;
+        DWARF Debug_loclists;
+        DWARF Debug_rnglists;
+      ]
+  in
+  sections @ dwarf_version_dependent_sections
+
+let flags t ~first_occurrence =
+  let names, flags, args =
+    match t, Config_typed.derived_system () with
+    | DWARF dwarf, MacOS_like ->
+      let name =
+        match dwarf with
+        | Debug_info -> "__debug_info"
+        | Debug_abbrev -> "__debug_abbrev"
+        | Debug_aranges -> "__debug_aranges"
+        | Debug_addr -> "__debug_addr"
+        | Debug_loc -> "__debug_loc"
+        | Debug_ranges -> "__debug_ranges"
+        | Debug_loclists -> "__debug_loclists"
+        | Debug_rnglists -> "__debug_rnglists"
+        | Debug_str -> "__debug_str"
+        | Debug_line -> "__debug_line"
+      in
+      ["__DWARF"; name], None, ["regular"; "debug"]
+    | DWARF dwarf, _ ->
+      let name =
+        match dwarf with
+        | Debug_info -> ".debug_info"
+        | Debug_abbrev -> ".debug_abbrev"
+        | Debug_aranges -> ".debug_aranges"
+        | Debug_addr -> ".debug_addr"
+        | Debug_loc -> ".debug_loc"
+        | Debug_ranges -> ".debug_ranges"
+        | Debug_loclists -> ".debug_loclists"
+        | Debug_rnglists -> ".debug_rnglists"
+        | Debug_str -> ".debug_str"
+        | Debug_line -> ".debug_line"
+      in
+      let flags =
+        if first_occurrence then
+          Some ""
+        else
+          None
+      in
+      let args =
+        if first_occurrence then
+          ["%progbits"]
+        else
+          []
+      in
+      [name], flags, args
+  in
+  { names; flags; args; }
+
+let to_string t =
+  let { names; flags = _; args = _; } = flags t ~first_occurrence:true in
+  String.concat " " names
+
+let print ppf t =
+  let str =
+    match t with
+    | DWARF Debug_info -> "(DWARF Debug_info)"
+    | DWARF Debug_abbrev -> "(DWARF Debug_abbrev)"
+    | DWARF Debug_aranges -> "(DWARF Debug_aranges)"
+    | DWARF Debug_addr -> "(DWARF Debug_addr)"
+    | DWARF Debug_loc -> "(DWARF Debug_loc)"
+    | DWARF Debug_ranges -> "(DWARF Debug_ranges)"
+    | DWARF Debug_loclists -> "(DWARF Debug_loclists)"
+    | DWARF Debug_rnglists -> "(DWARF Debug_rnglists)"
+    | DWARF Debug_str -> "(DWARF Debug_str)"
+    | DWARF Debug_line -> "(DWARF Debug_line)"
+  in
+  Format.pp_print_string ppf str
+
+let compare t1 t2 =
+  Stdlib.compare t1 t2
+
+let equal t1 t2 =
+  Stdlib.compare t1 t2 = 0

--- a/backend/debug/dwarf/dwarf_deps/asm_section.mli
+++ b/backend/debug/dwarf/dwarf_deps/asm_section.mli
@@ -1,0 +1,53 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Representation of object file sections. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Sections that hold DWARF debugging information. *)
+type dwarf_section =
+  | Debug_info
+  | Debug_abbrev
+  | Debug_aranges
+  | Debug_addr
+  | Debug_loc
+  | Debug_ranges
+  | Debug_loclists
+  | Debug_rnglists
+  | Debug_str
+  | Debug_line
+
+type t = DWARF of dwarf_section
+
+val to_string : t -> string
+
+type flags_for_section = private {
+  names : string list;
+  flags : string option;
+  args : string list;
+}
+
+val dwarf_sections_in_order : unit -> t list
+
+(** The necessary information for a section directive.  [first_occurrence]
+    should be [true] iff the corresponding directive will be the first such
+    in the relevant assembly file for the given section. *)
+val flags : t -> first_occurrence:bool -> flags_for_section
+
+val print : Format.formatter -> t -> unit
+
+val compare : t -> t -> int
+
+val equal : t -> t -> bool

--- a/backend/debug/dwarf/dwarf_deps/asm_symbol.ml
+++ b/backend/debug/dwarf/dwarf_deps/asm_symbol.ml
@@ -1,0 +1,75 @@
+module Thing = struct
+  type t = string
+  let compare = String.compare
+  let equal = String.equal
+  let hash = Hashtbl.hash
+  let output chan t = Printf.fprintf chan "%s" t
+  let print = Format.pp_print_string
+end
+
+include Thing
+include Identifiable.Make(Thing)
+
+let create name = name
+
+let escape name =
+  let spec = ref false in
+  for i = 0 to String.length name - 1 do
+    match String.unsafe_get name i with
+    | 'A'..'Z' | 'a'..'z' | '0'..'9' | '_' -> ()
+    | _ -> spec := true;
+  done;
+  if not !spec then begin
+    name
+  end else begin
+    let b = Buffer.create (String.length name + 10) in
+    String.iter
+      (function
+        | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') as c -> Buffer.add_char b c
+        | c -> Printf.bprintf b "$%02x" (Char.code c)
+      )
+      name;
+    Buffer.contents b
+  end
+
+let symbol_prefix () = (* CR mshinwell: needs checking *)
+  match Config_typed.architecture () with
+  | IA32 | X86_64 ->
+    begin match Config_typed.derived_system () with
+    | Linux
+    | Win32
+    | Win64
+    | MinGW_32
+    | MinGW_64
+    | Cygwin
+    | FreeBSD
+    | NetBSD
+    | OpenBSD
+    | Generic_BSD
+    | Solaris
+    | BeOS
+    | GNU
+    | Dragonfly
+    | Unknown -> "" (* checked ok. *)
+    | MacOS_like -> "_" (* checked ok. *)
+    end
+  | ARM
+  | AArch64
+  | POWER
+  | Z -> ""
+
+let to_escaped_string ?suffix ~symbol_prefix t =
+  let suffix =
+    match suffix with
+    | None -> ""
+    | Some suffix -> suffix
+  in
+  symbol_prefix ^ (escape t) ^ suffix
+
+let encode ?without_prefix t =
+  let symbol_prefix =
+    match without_prefix with
+    | None -> symbol_prefix ()
+    | Some () -> ""
+  in
+  to_escaped_string ~symbol_prefix t

--- a/backend/debug/dwarf/dwarf_deps/asm_symbol.mli
+++ b/backend/debug/dwarf/dwarf_deps/asm_symbol.mli
@@ -1,0 +1,5 @@
+include Identifiable.S
+
+val create : string -> t
+
+val encode : ?without_prefix:unit -> t -> string

--- a/backend/debug/dwarf/dwarf_deps/config_typed.ml
+++ b/backend/debug/dwarf/dwarf_deps/config_typed.ml
@@ -1,0 +1,118 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type architecture =
+  | IA32
+  | X86_64
+  | ARM
+  | AArch64
+  | POWER
+  | Z
+
+let architecture () : architecture =
+  match Config.architecture with
+  | "i386" -> IA32
+  | "amd64" -> X86_64
+  | "arm" -> ARM
+  | "arm64" -> AArch64
+  | "power" -> POWER
+  | "s390x" -> Z
+  | arch -> Misc.fatal_errorf "Unknown architecture `%s'" arch
+
+type derived_system =
+  | Linux
+  | MinGW_32
+  | MinGW_64
+  | Win32
+  | Win64
+  | Cygwin
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+let derived_system () : derived_system =
+  match architecture (), Config.model, Config.system with
+  | IA32, _, "linux_aout" -> Linux
+  | IA32, _, "linux_elf" -> Linux
+  | IA32, _, "bsd_aout" -> Generic_BSD
+  | IA32, _, "bsd_elf" -> Generic_BSD
+  | IA32, _, "beos" -> BeOS
+  | IA32, _, "cygwin" -> Cygwin
+  | (X86_64 | IA32), _, "macosx" -> MacOS_like
+  | IA32, _, "gnu" -> GNU
+  | IA32, _, "mingw" -> MinGW_32
+  | IA32, _, "win32" -> Win32
+  | POWER, "ppc64le", "elf" -> Linux
+  | POWER, "ppc64", "elf" -> Linux
+  | POWER, "ppc", "elf" -> Linux
+  | POWER, "ppc", "netbsd" -> NetBSD
+  | POWER, "ppc", "bsd_elf" -> OpenBSD
+  | Z, _, "elf" -> Linux
+  | ARM, _, "linux_eabihf" -> Linux
+  | ARM, _, "linux_eabi" -> Linux
+  | ARM, _, "bsd" -> OpenBSD
+  | X86_64, _, "linux" -> Linux
+  | X86_64, _, "gnu" -> GNU
+  | X86_64, _, "dragonfly" -> Dragonfly
+  | X86_64, _, "freebsd" -> FreeBSD
+  | X86_64, _, "netbsd" -> NetBSD
+  | X86_64, _, "openbsd" -> OpenBSD
+  | X86_64, _, "darwin" -> MacOS_like
+  | X86_64, _, "mingw" -> MinGW_64
+  | AArch64, _, "linux" -> Linux
+  | X86_64, _, "cygwin" -> Cygwin
+  | X86_64, _, "win64" -> Win64
+  | _, _, "unknown" -> Unknown
+  | _, _, _ ->
+    Misc.fatal_errorf "Cannot determine system type (model %s, system %s): \
+        ensure `target_system.ml' matches `configure'"
+      Config.model Config.system
+
+let is_windows () =
+  match derived_system () with
+  | Linux
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown -> false
+  | MinGW_32
+  | MinGW_64
+  | Win32
+  | Win64
+  | Cygwin -> true
+
+type assembler =
+  | GAS_like
+  | MacOS
+  | MASM
+
+let assembler () =
+  match derived_system () with
+  | Win32
+  | Win64 -> MASM
+  | MacOS_like -> MacOS
+  | MinGW_32
+  | MinGW_64
+  | Cygwin
+  | Linux
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | GNU
+  | Dragonfly
+  | BeOS
+  | Unknown -> GAS_like

--- a/backend/debug/dwarf/dwarf_deps/config_typed.mli
+++ b/backend/debug/dwarf/dwarf_deps/config_typed.mli
@@ -1,0 +1,38 @@
+type architecture =
+  | IA32
+  | X86_64
+  | ARM
+  | AArch64
+  | POWER
+  | Z
+
+val architecture : unit -> architecture
+
+type derived_system =
+  | Linux
+  | MinGW_32
+  | MinGW_64
+  | Win32
+  | Win64
+  | Cygwin
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+val derived_system : unit -> derived_system
+
+val is_windows : unit -> bool
+
+type assembler =
+  | GAS_like
+  | MacOS
+  | MASM
+
+val assembler : unit -> assembler

--- a/backend/debug/dwarf/dwarf_deps/dune
+++ b/backend/debug/dwarf/dwarf_deps/dune
@@ -1,0 +1,9 @@
+(include_subdirs unqualified)
+
+(library
+  (name dwarf_deps)
+  (wrapped false)
+  (flags (:standard -principal -nostdlib))
+  (ocamlopt_flags (:standard -O3))
+  (libraries stdlib ocamlcommon ocamlbytecomp)
+)

--- a/backend/debug/dwarf/dwarf_deps/dwarf_arch_sizes.ml
+++ b/backend/debug/dwarf/dwarf_deps/dwarf_arch_sizes.ml
@@ -1,0 +1,2 @@
+let size_addr = 8
+let size_int = 4

--- a/backend/debug/dwarf/dwarf_deps/dwarf_arch_sizes.mli
+++ b/backend/debug/dwarf/dwarf_deps/dwarf_arch_sizes.mli
@@ -1,0 +1,2 @@
+val size_addr : int
+val size_int : int

--- a/backend/debug/dwarf/dwarf_deps/dwarf_params.ml
+++ b/backend/debug/dwarf/dwarf_deps/dwarf_params.ml
@@ -1,0 +1,5 @@
+module type S = sig
+  module Asm_directives : Asm_directives.S
+
+  val get_file_num : string -> int
+end

--- a/backend/debug/dwarf/dwarf_deps/machine_width.ml
+++ b/backend/debug/dwarf/dwarf_deps/machine_width.ml
@@ -1,0 +1,8 @@
+type t =
+  | Thirty_two
+  | Sixty_four
+
+let of_int_exn  = function
+  | 32 -> Thirty_two
+  | 64 -> Sixty_four
+  | bits -> Misc.fatal_errorf "Unknown machine width: %d" bits

--- a/backend/debug/dwarf/dwarf_deps/machine_width.mli
+++ b/backend/debug/dwarf/dwarf_deps/machine_width.mli
@@ -1,0 +1,5 @@
+type t =
+  | Thirty_two
+  | Sixty_four
+
+val of_int_exn : int -> t

--- a/backend/debug/dwarf/dwarf_deps/numbers_extra.ml
+++ b/backend/debug/dwarf/dwarf_deps/numbers_extra.ml
@@ -1,0 +1,168 @@
+
+module Int = Numbers.Int
+
+module Float = Numbers.Float
+
+module Int8 = struct
+  type t = int
+
+  let zero = 0
+  let one = 1
+
+  let of_int_exn i =
+    if i < -(1 lsl 7) || i > ((1 lsl 7) - 1) then
+      Misc.fatal_errorf "Int8.of_int_exn: %d is out of range" i
+    else
+      i
+
+  let to_int i = i
+
+  let print ppf t = Format.pp_print_int ppf t
+end
+
+module Int16 = struct
+  type t = int
+
+  let zero = 0
+
+  let one = 1
+
+  let of_int_exn i =
+    if i < -(1 lsl 15) || i > ((1 lsl 15) - 1) then
+      Misc.fatal_errorf "Int16.of_int_exn: %d is out of range" i
+    else
+      i
+
+  let lower_int64 = Int64.neg (Int64.shift_left Int64.one 15)
+  let upper_int64 = Int64.sub (Int64.shift_left Int64.one 15) Int64.one
+
+  let of_int64_exn i =
+    if Int64.compare i lower_int64 < 0
+        || Int64.compare i upper_int64 > 0
+    then
+      Misc.fatal_errorf "Int16.of_int64_exn: %Ld is out of range" i
+    else
+      Int64.to_int i
+
+  let to_int t = t
+
+  let print ppf t = Format.pp_print_int ppf t
+end
+
+module Uint8 = struct
+  type t = int
+
+  let print ppf t = Format.pp_print_int ppf t
+
+  let zero = 0
+  let one = 1
+
+  let of_nonnegative_int_exn i =
+    if i < 0 || i > ((1 lsl 8) - 1) then
+      Misc.fatal_errorf "Uint8.of_nonnegative_int_exn: %d is out of range" i
+    else
+      i
+
+  let to_int i = i
+end
+
+module Uint16 = struct
+  type t = int
+
+  let print ppf t = Format.pp_print_int ppf t
+
+  let of_nonnegative_int_exn i =
+    if i < 0 || i > ((1 lsl 16) - 1) then
+      Misc.fatal_errorf "Uint16.of_nonnegative_int_exn: %d is out of range" i
+    else
+      i
+
+  let upper_int64 = Int64.sub (Int64.shift_left Int64.one 16) Int64.one
+
+  let of_nonnegative_int64_exn i =
+    if Int64.compare i 0L < 0
+        || Int64.compare i upper_int64 > 0
+    then
+      Misc.fatal_errorf "Uint16.of_nonnegative_int64_exn: %Ld is out of range" i
+    else
+      Int64.to_int i
+
+  let to_int t = t
+end
+
+module Uint32 = struct
+  type t = Int64.t
+
+  let zero = 0L
+
+  let print ppf t = Format.fprintf ppf "0x%Lx" t
+
+  let upper_int64 = Int64.sub (Int64.shift_left Int64.one 32) Int64.one
+
+  let of_nonnegative_int_exn i =
+    if i < 0 then
+      Misc.fatal_errorf "Uint32.of_nonnegative_int_exn: %d is out of range" i
+    else
+      let i64 = Int64.of_int i in
+      if Int64.compare i64 upper_int64 > 0 then
+        Misc.fatal_errorf "Uint32.of_nonnegative_int_exn: %d is out of range" i
+      else
+        i64
+
+  let of_nonnegative_int64_exn i =
+    if Int64.compare i 0L < 0
+        || Int64.compare i upper_int64 > 0
+    then
+      Misc.fatal_errorf "Uint32.of_nonnegative_int64_exn: %Ld is out of range" i
+    else
+      i
+
+  let of_nonnegative_int32_exn i =
+    if Int32.compare i 0l < 0 then
+      Misc.fatal_errorf "Uint32.of_nonnegative_int64_exn: %ld is out of range" i
+    else
+      Int64.of_int32 i
+
+  let to_int64 t = t
+end
+
+module Uint64 = struct
+  type t = Int64.t
+
+  let zero = 0L
+
+  let succ t = Int64.add 1L t
+
+  let of_nonnegative_int_exn i =
+    if i < 0 then
+      Misc.fatal_errorf "Uint64.of_nonnegative_int_exn: %d is out of range" i
+    else
+      Int64.of_int i
+
+  let of_uint8 i = Int64.of_int i
+  let of_uint16 i = Int64.of_int i
+  let of_uint32 i = i
+
+  let of_nonnegative_int32_exn i =
+    if Int32.compare i 0l < 0 then
+      Misc.fatal_errorf "Uint64.of_nonnegative_int64_exn: %ld is out of range" i
+    else
+      Int64.of_int32 i
+
+  let of_nonnegative_int64_exn i =
+    if Int64.compare i 0L < 0 then
+      Misc.fatal_errorf "Uint64.of_nonnegative_int64_exn: %Ld is out of range" i
+    else
+      i
+
+  let to_int64 t = t
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+    let compare t1 t2 = Stdlib.compare t1 t2
+    let equal t1 t2 = (compare t1 t2 = 0)
+    let hash t = Hashtbl.hash t
+    let print ppf t = Format.fprintf ppf "0x%Lx" t
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+  end)
+end

--- a/backend/debug/dwarf/dwarf_deps/numbers_extra.mli
+++ b/backend/debug/dwarf/dwarf_deps/numbers_extra.mli
@@ -1,0 +1,80 @@
+(** Modules about numbers, some of which satisfy {!Identifiable.S}.
+
+  {b Warning:} this module is unstable and part of
+  {{!Compiler_libs}compiler-libs}.
+*)
+
+module Int = Numbers.Int
+
+module Float = Numbers.Float
+
+module Int8 : sig 
+  include module type of Numbers.Int8 
+  val print : Format.formatter -> t -> unit
+end
+
+module Int16 : sig 
+  include module type of Numbers.Int16 
+  val zero : t
+  val one : t
+  val print : Format.formatter -> t -> unit
+end
+
+(** Do not use polymorphic comparison on the unsigned integer types. *)
+
+module Uint8 : sig
+  type t
+
+  val print : Format.formatter -> t -> unit
+
+  val zero : t
+  val one : t
+
+  val of_nonnegative_int_exn : int -> t
+  val to_int : t -> int
+end
+
+module Uint16 : sig
+  type t
+
+  val print : Format.formatter -> t -> unit
+
+  val of_nonnegative_int_exn : int -> t
+  val of_nonnegative_int64_exn : Int64.t -> t
+
+  val to_int : t -> int
+end
+
+module Uint32 : sig
+  type t
+
+  val print : Format.formatter -> t -> unit
+
+  val zero : t
+
+  val of_nonnegative_int_exn : int -> t
+  val of_nonnegative_int32_exn : Int32.t -> t
+  val of_nonnegative_int64_exn : Int64.t -> t
+
+  val to_int64 : t -> Int64.t
+end
+
+module Uint64 : sig
+  type t
+
+  val zero : t
+
+  val succ : t -> t
+
+  val of_uint8 : Uint8.t -> t
+  val of_uint16 : Uint16.t -> t
+  val of_uint32 : Uint32.t -> t
+
+  val of_nonnegative_int_exn : int -> t
+  val of_nonnegative_int32_exn : Int32.t -> t
+  val of_nonnegative_int64_exn : Int64.t -> t
+
+  val to_int64 : t -> Int64.t
+
+  include Identifiable.S with type t := t
+end

--- a/backend/debug/dwarf/dwarf_deps/targetint_extra.ml
+++ b/backend/debug/dwarf/dwarf_deps/targetint_extra.ml
@@ -1,0 +1,12 @@
+include Targetint
+
+let size_in_bytes_as_targetint = 
+  match size with
+  | 32 -> of_int32 4l
+  | 64 -> of_int64 8L
+  | _  -> assert false
+
+let to_uint64_exn t = 
+  match repr t with
+  | Int32 t -> Numbers_extra.Uint64.of_nonnegative_int32_exn t
+  | Int64 t -> Numbers_extra.Uint64.of_nonnegative_int64_exn t

--- a/backend/debug/dwarf/dwarf_deps/targetint_extra.mli
+++ b/backend/debug/dwarf/dwarf_deps/targetint_extra.mli
@@ -1,0 +1,7 @@
+include module type of Targetint
+
+val size_in_bytes_as_targetint : t
+(** The width of a target integer in bytes, expressed as a value of type [t]. *)
+
+val to_uint64_exn : t -> Numbers_extra.Uint64.t
+(** Convert the given target integer to an unsigned 64-bit integer. *)

--- a/backend/debug/dwarf/dwarf_high/assign_abbrevs.ml
+++ b/backend/debug/dwarf/dwarf_high/assign_abbrevs.ml
@@ -1,0 +1,98 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Dwarf_low
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module ASS = Dwarf_attributes.Attribute_specification.Sealed
+module DIE = Debugging_information_entry
+
+type result = {
+  abbrev_table : Abbreviations_table.t;
+  dies : Debugging_information_entry.t list;
+  compilation_unit_die : Debugging_information_entry.t option;
+  dwarf_4_location_lists : Dwarf_4_location_list.t list;
+}
+
+(* For each pattern of attributes found in the tree of proto-DIEs (of which
+   there should be few compared to the number of DIEs), assign an abbreviation
+   code, generating an abbreviations table in the process.  At the same time,
+   generate a list of DIEs in flattened format, ready for emission.  (These
+   DIEs reference the particular patterns of attributes they use via the
+   abbreviation codes.) *)
+let run ~proto_die_root =
+  let abbrev_table, dies_rev, compilation_unit_die, location_lists_rev =
+    let next_abbreviation_code = ref 1 in
+    Proto_die.depth_first_fold proto_die_root
+      ~init:(Abbreviations_table.create (), [], None, [])
+      ~f:(fun (abbrev_table, dies, compilation_unit_die, location_lists_rev)
+              (action : Proto_die.fold_arg) ->
+        let abbrev_table, die, compilation_unit_die, location_lists_rev =
+          match action with
+          | End_of_siblings ->
+            abbrev_table, DIE.create_null (), compilation_unit_die,
+              location_lists_rev
+          | DIE (tag, has_children, attribute_values, label, name,
+              location_list_in_debug_loc_table) ->
+            let attribute_specs = ASS.Map.keys attribute_values in
+            let abbrev_table, abbreviation_code =
+              match
+                Abbreviations_table.find abbrev_table ~tag ~has_children
+                  ~attribute_specs
+              with
+              | Some abbrev_code -> abbrev_table, abbrev_code
+              | None -> 
+                let abbreviation_code =
+                  Abbreviation_code.of_int !next_abbreviation_code tag
+                in
+                incr next_abbreviation_code;
+                let abbrev_table_entry =
+                  Abbreviations_table_entry.create ~abbreviation_code ~tag
+                    ~has_children ~attribute_specs
+                in
+                Abbreviations_table.add abbrev_table abbrev_table_entry,
+                  abbreviation_code
+            in
+            let die =
+              DIE.create ~label ~abbreviation_code ~attribute_values ~name
+            in
+            let compilation_unit_die =
+              let is_compilation_unit =
+                match tag with
+                | Compile_unit -> true
+                | _ -> false
+              in
+              if not is_compilation_unit then
+                compilation_unit_die
+              else
+                match compilation_unit_die with
+                | None -> Some die
+                | Some _ ->
+                  Misc.fatal_error "More than one `Compile_unit' DIE is present"
+            in
+            let location_lists_rev =
+              match location_list_in_debug_loc_table with
+              | None -> location_lists_rev
+              | Some location_list -> location_list :: location_lists_rev
+            in
+            abbrev_table, die, compilation_unit_die, location_lists_rev
+        in
+        abbrev_table, die::dies, compilation_unit_die, location_lists_rev)
+  in
+  { abbrev_table;
+    dies = List.rev dies_rev;
+    compilation_unit_die;
+    dwarf_4_location_lists = List.rev location_lists_rev;
+  }

--- a/backend/debug/dwarf/dwarf_high/assign_abbrevs.mli
+++ b/backend/debug/dwarf/dwarf_high/assign_abbrevs.mli
@@ -1,0 +1,27 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Dwarf_low
+
+(** Construction of abbreviation tables from proto-DIEs together with
+    flattening of the proto-DIE tree to a list of DIEs. *)
+
+type result = {
+  abbrev_table : Abbreviations_table.t;
+  dies : Debugging_information_entry.t list;
+  compilation_unit_die : Debugging_information_entry.t option;
+  dwarf_4_location_lists : Dwarf_4_location_list.t list;
+}
+
+val run : proto_die_root:Proto_die.t -> result

--- a/backend/debug/dwarf/dwarf_high/dune
+++ b/backend/debug/dwarf/dwarf_high/dune
@@ -1,0 +1,9 @@
+(include_subdirs unqualified)
+
+(library
+  (name dwarf_high)
+  (wrapped true)
+  (flags (:standard -principal -nostdlib))
+  (ocamlopt_flags (:standard -O3))
+  (libraries stdlib ocamlcommon ocamlbytecomp dwarf_low dwarf_deps)
+)

--- a/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.ml
@@ -1,0 +1,349 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Dwarf_low
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module AS = Dwarf_attributes.Attribute_specification
+module AV = Dwarf_attribute_values.Attribute_value
+module V = Dwarf_attribute_values.Value
+
+module Uint64 = Numbers_extra.Uint64
+
+let needs_dwarf_five () =
+  match !Clflags.gdwarf_version with
+  | Four -> Misc.fatal_error "Attribute not supported for DWARF-4"
+  | Five -> ()
+
+let create_entry_pc address_label =
+  let spec = AS.create Entry_pc Addr in
+  AV.create spec (V.code_address_from_label
+    ~comment:"entry PC value" address_label)
+
+let create_low_pc address_label =
+  let spec = AS.create Low_pc Addr in
+  AV.create spec (V.code_address_from_label
+    ~comment:"low PC value" address_label)
+
+let create_high_pc_offset offset =
+  match Targetint_extra.repr offset with
+  | Int32 offset ->
+    let spec = AS.create High_pc Data4 in
+    AV.create spec (V.int32 ~comment:"high PC value as offset" offset)
+  | Int64 offset ->
+    let spec = AS.create High_pc Data8 in
+    AV.create spec (V.int64 ~comment:"high PC value as offset" offset)
+
+let create_high_pc ~low_pc high_pc =
+  match Dwarf_arch_sizes.size_addr with
+  | 4 ->
+    (* CR mshinwell: Shouldn't these be of form [Addr]? *)
+    let spec = AS.create High_pc Data4 in
+    AV.create spec (V.distance_between_label_and_symbol_32_bit
+      ~comment:"high PC value" ~upper:high_pc ~lower:low_pc ())
+  | 8 ->
+    let spec = AS.create High_pc Data8 in
+    AV.create spec (V.distance_between_label_and_symbol_64_bit
+      ~comment:"high PC value" ~upper:high_pc ~lower:low_pc ())
+  | _ -> Misc.fatal_errorf "Unknown [Dwarf_arch_sizes.size_addr] = %d" Dwarf_arch_sizes.size_addr
+
+let create_entry_pc_from_symbol symbol =
+  let spec = AS.create Entry_pc Addr in
+  AV.create spec (V.code_address_from_symbol
+    ~comment:"entry PC value" symbol)
+
+let create_low_pc_from_symbol symbol =
+  let spec = AS.create Low_pc Addr in
+  AV.create spec (V.code_address_from_symbol
+    ~comment:"low PC value" symbol)
+
+let create_high_pc_from_symbol ~low_pc high_pc =
+  match Dwarf_arch_sizes.size_addr with
+  | 4 ->
+    let spec = AS.create High_pc Data4 in
+    AV.create spec (V.distance_between_symbols_32_bit
+      ~comment:"high PC value" ~upper:high_pc ~lower:low_pc ())
+  | 8 ->
+    let spec = AS.create High_pc Data8 in
+    AV.create spec (V.distance_between_symbols_64_bit
+      ~comment:"high PC value" ~upper:high_pc ~lower:low_pc ())
+  | _ -> Misc.fatal_errorf "Unknown [Dwarf_arch_sizes.size_addr] = %d" Dwarf_arch_sizes.size_addr
+
+let create_producer producer_name =
+  let spec = AS.create Producer Strp in
+  AV.create spec (V.indirect_string ~comment:"producer name" producer_name)
+
+let create_name name =
+  let spec = AS.create Name Strp in
+  AV.create spec (V.indirect_string ~comment:"name" name)
+
+let create_comp_dir directory =
+  let spec = AS.create Comp_dir Strp in
+  AV.create spec (V.indirect_string ~comment:"compilation directory" directory)
+
+let create_stmt_list ~debug_line_label =
+  let spec = AS.create Stmt_list Sec_offset_lineptr in
+  (* DWARF-4 standard section 3.1.1.4. *)
+  AV.create spec (V.offset_into_debug_line debug_line_label)
+
+let create_external ~is_visible_externally =
+  if is_visible_externally then
+    let spec = AS.create External Flag_present in
+    AV.create spec (V.flag_true ~comment:"visible externally" ())
+  else
+    let spec = AS.create External Flag in
+    AV.create spec (V.bool ~comment:"not visible externally" false)
+
+let create_decl_file file =
+  let spec = AS.create Decl_file Udata in
+  let file = Uint64.of_nonnegative_int_exn file in
+  AV.create spec (V.uleb128 ~comment:"file number" file)
+
+let create_decl_line line =
+  let spec = AS.create Decl_line Udata in
+  let line = Uint64.of_nonnegative_int_exn line in
+  AV.create spec (V.uleb128 ~comment:"line number" line)
+
+let create_decl_column column =
+  let spec = AS.create Decl_column Udata in
+  let column = Uint64.of_nonnegative_int_exn column in
+  AV.create spec (V.uleb128 ~comment:"column number" column)
+
+let create_call_pc label =
+  let spec = AS.create Call_pc Addr in
+  needs_dwarf_five ();
+  AV.create spec (V.code_address_from_label ~comment:"PC of call site" label)
+
+let create_call_return_pc label =
+  needs_dwarf_five ();
+  let spec = AS.create Call_return_pc Addr in
+  AV.create spec (V.code_address_from_label
+    ~comment:"PC immediately after call site" label)
+
+let create_call_tail_call ~is_tail =
+  if is_tail then
+    let spec =
+      match !Clflags.gdwarf_version with
+      | Four -> AS.create (Dwarf_4 GNU_tail_call) Flag_present
+      | Five -> AS.create Call_tail_call Flag_present
+    in
+    AV.create spec (V.flag_true ~comment:"is a tail call" ())
+  else
+    let spec =
+      match !Clflags.gdwarf_version with
+      | Four -> AS.create (Dwarf_4 GNU_tail_call) Flag
+      | Five -> AS.create Call_tail_call Flag
+    in
+    AV.create spec (V.bool ~comment:"is a non-tail call" false)
+
+let create_call_all_calls () =
+  let spec =
+    match !Clflags.gdwarf_version with
+    | Four -> AS.create (Dwarf_4 GNU_all_call_sites) Flag_present
+    | Five -> AS.create Call_all_calls Flag_present
+  in
+  AV.create spec (V.flag_true ~comment:"DW_AT_call_all_calls is set" ())
+
+let create_call_target loc_desc =
+  let spec =
+    match !Clflags.gdwarf_version with
+    | Four -> AS.create (Dwarf_4 GNU_call_site_target) Exprloc
+    | Five -> AS.create Call_target Exprloc
+  in
+  AV.create spec (V.single_location_description loc_desc)
+
+let create_call_target_clobbered loc_desc =
+  let spec =
+    match !Clflags.gdwarf_version with
+    | Four -> AS.create (Dwarf_4 GNU_call_site_target_clobbered) Exprloc
+    | Five -> AS.create Call_target_clobbered Exprloc
+  in
+  AV.create spec (V.single_location_description loc_desc)
+
+let create_location index =
+  needs_dwarf_five ();
+  let location_list_label = Location_list_table.Index.to_label index in
+  let location_list_index = Location_list_table.Index.to_uint64 index in
+  if not !Clflags.gdwarf_offsets then
+    let spec = AS.create Location Sec_offset_loclist in
+    AV.create spec (V.offset_into_debug_loclists location_list_label)
+  else
+    let spec = AS.create Location Loclistx in
+    AV.create spec (V.loclistx ~index:location_list_index)
+
+let create_ranges index =
+  needs_dwarf_five ();
+  let range_list_label = Range_list_table.Index.to_label index in
+  let range_list_index = Range_list_table.Index.to_uint64 index in
+  if not !Clflags.gdwarf_offsets then
+    let spec = AS.create Ranges Sec_offset_rnglist in
+    AV.create spec (V.offset_into_debug_rnglists range_list_label)
+  else
+    let spec = AS.create Ranges Rnglistx in
+    AV.create spec (V.rnglistx ~index:range_list_index)
+
+let create_single_location_description loc_desc =
+  let spec = AS.create Location Exprloc in
+  AV.create spec (V.single_location_description loc_desc)
+
+let create_composite_location_description loc_desc =
+  let spec = AS.create Location Exprloc in
+  AV.create spec (V.composite_location_description loc_desc)
+
+let create_single_call_value_location_description loc_desc =
+  let spec =
+    match !Clflags.gdwarf_version with
+    | Four -> AS.create (Dwarf_4 GNU_call_site_value) Exprloc
+    | Five -> AS.create Call_value Exprloc
+  in
+  AV.create spec (V.single_location_description loc_desc)
+
+let create_composite_call_value_location_description loc_desc =
+  let spec =
+    match !Clflags.gdwarf_version with
+    | Four -> AS.create (Dwarf_4 GNU_call_site_value) Exprloc
+    | Five -> AS.create Call_value Exprloc
+  in
+  AV.create spec (V.composite_location_description loc_desc)
+
+let create_single_call_data_location_description loc_desc =
+  needs_dwarf_five ();
+  let spec = AS.create Call_data_location Exprloc in
+  AV.create spec (V.single_location_description loc_desc)
+
+let create_single_call_data_value_location_description loc_desc =
+  let spec =
+    match !Clflags.gdwarf_version with
+    | Four -> AS.create (Dwarf_4 GNU_call_site_data_value) Exprloc
+    | Five -> AS.create Call_data_value Exprloc
+  in
+  AV.create spec (V.single_location_description loc_desc)
+
+let create_encoding ~encoding =
+  let spec = AS.create Encoding Data1 in
+  AV.create spec (V.encoding_attribute encoding)
+
+let reference_proto_die attribute proto_die =
+  let spec = AS.create attribute Ref_addr in
+  let label = Proto_die.reference proto_die in
+  AV.create spec (V.offset_into_debug_info ~comment:"ref. to DIE" label)
+
+let create_type ~proto_die = reference_proto_die Type proto_die
+let create_sibling ~proto_die = reference_proto_die Sibling proto_die
+let create_import ~proto_die = reference_proto_die Import proto_die
+
+let create_type_from_reference ~proto_die_reference:label =
+  let spec = AS.create Type Ref_addr in
+  AV.create spec (V.offset_into_debug_info
+    ~comment:"reference to type DIE" label)
+
+(* CR-soon mshinwell: remove "_exn" prefix. *)
+let create_byte_size_exn ~byte_size =
+  let spec = AS.create Byte_size Data8 in
+  AV.create spec (V.int64 ~comment:"byte size" (Int64.of_int byte_size))
+
+let create_bit_size bit_size =
+  let spec = AS.create Bit_size Data8 in
+  AV.create spec (V.int64 ~comment:"bit size" bit_size)
+
+let create_data_member_location ~byte_offset =
+  let spec = AS.create Data_member_location Data8 in
+  AV.create spec (V.int64 ~comment:"data member location" byte_offset)
+
+let create_linkage_name ~linkage_name =
+  let spec = AS.create Linkage_name Strp in
+  AV.create spec (V.indirect_string ~comment:"linkage name" linkage_name)
+
+let create_const_value_from_symbol ~symbol =
+  match Targetint_extra.size with
+  | 32 ->
+    let spec = AS.create Const_value Data4 in
+    AV.create spec (V.symbol_32 symbol)
+  | 64 ->
+    let spec = AS.create Const_value Data8 in
+    AV.create spec (V.symbol_64 symbol)
+  | size -> Misc.fatal_errorf "Unknown Targetint_extra.size %d" size
+
+let create_addr_base label =
+  let spec = AS.create Addr_base Sec_offset_addrptr in
+  AV.create spec (V.offset_into_debug_addr label)
+
+let create_loclists_base label =
+  let spec = AS.create Loclists_base Sec_offset_loclistsptr in
+  AV.create spec (V.offset_into_debug_loclists label)
+
+let create_rnglists_base label =
+  let spec = AS.create Rnglists_base Sec_offset_rnglistsptr in
+  AV.create spec (V.offset_into_debug_rnglists label)
+
+let create_inline inline_code =
+  let spec = AS.create Inline Data1 in
+  AV.create spec (V.inline_code inline_code)
+
+let create_call_origin ~die_symbol =
+  let comment = "reference to call origin DIE" in
+  let spec =
+    match !Clflags.gdwarf_version with
+    | Four ->
+      (* The GDB code says that [DW_AT_abstract_origin] is a GNU extension
+         alias, pre-DWARF 5, for [DW_AT_call_origin]. *)
+      AS.create Abstract_origin Ref_addr
+    | Five ->
+      AS.create Call_origin Ref_addr
+  in
+  AV.create spec (V.offset_into_debug_info_from_symbol ~comment die_symbol)
+
+let create_abstract_origin ~die_symbol =
+  let spec = AS.create Abstract_origin Ref_addr in
+  AV.create spec (V.offset_into_debug_info_from_symbol
+    ~comment:"reference to abstract origin DIE" die_symbol)
+
+let create_language lang =
+  let spec = AS.create Language Data1 in
+  AV.create spec (V.language lang)
+
+let create_declaration () =
+  let spec = AS.create Declaration Flag_present in
+  AV.create spec (
+    V.flag_true ~comment:"incomplete / non-defining declaration" ())
+
+let create_ocaml_compiler_version version =
+  let spec = AS.create (Ocaml_specific Compiler_version) Strp in
+  AV.create spec (V.indirect_string ~comment:"OCaml compiler version" version)
+
+let create_ocaml_unit_name unit_name =
+  let spec = AS.create (Ocaml_specific Unit_name) Strp in
+  AV.create spec (V.indirect_string ~comment:"unit name" (Ident.name unit_name))
+
+let create_ocaml_config_digest digest =
+  let hex = Digest.to_hex digest in
+  let spec = AS.create (Ocaml_specific Config_digest) Strp in
+  AV.create spec (V.indirect_string ~comment:"static config value digest" hex)
+
+let create_ocaml_prefix_name name =
+  let spec = AS.create (Ocaml_specific Prefix_name) Strp in
+  AV.create spec (V.indirect_string ~comment:"prefix name" name)
+
+let create_ocaml_linker_dirs dirs =
+  let dirs =
+    Dwarf_name_laundry.mangle_linker_dirs (Misc.Stdlib.String.Set.elements dirs)
+  in
+  let spec = AS.create (Ocaml_specific Linker_dirs) Strp in
+  AV.create spec (V.indirect_string ~comment:"linker dirs" dirs)
+
+let create_ocaml_cmt_file_digest digest =
+  let hex = Digest.to_hex digest in
+  let spec = AS.create (Ocaml_specific Cmt_file_digest) Strp in
+  AV.create spec (V.indirect_string ~comment:".cmt file digest" hex)

--- a/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.mli
@@ -1,0 +1,238 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Dwarf_low
+
+(** Helper functions for constructing attribute values that do not
+    require a knowledge of DWARF forms. *)
+
+val create_entry_pc
+   : Asm_label.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_low_pc
+   : Asm_label.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+(** Creates a [DW_AT_high_pc] attribute value by taking the offset in
+    bytes from the [DW_AT_low_pc] attribute value. *)
+val create_high_pc_offset
+   : Targetint_extra.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_high_pc
+   : low_pc:Asm_symbol.t
+  -> Asm_label.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+(* CR mshinwell: Make labels consistent / remove unnecessary ones. *)
+
+val create_entry_pc_from_symbol
+   : Asm_symbol.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_low_pc_from_symbol
+   : Asm_symbol.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_high_pc_from_symbol
+   : low_pc:Asm_symbol.t
+  -> Asm_symbol.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_producer
+   : string
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_name
+   : string
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_comp_dir
+   : string
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_stmt_list
+   : debug_line_label:Asm_label.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_external
+   : is_visible_externally:bool
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_decl_file
+   : int
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_decl_line
+   : int
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_decl_column
+   : int
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_call_pc
+   : Asm_label.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_call_return_pc
+   : Asm_label.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_call_tail_call
+   : is_tail:bool
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_call_all_calls
+   : unit
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_call_target
+   : Single_location_description.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_call_target_clobbered
+   : Single_location_description.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_location
+   : Location_list_table.Index.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_ranges
+   : Range_list_table.Index.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_type
+   : proto_die:Proto_die.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_type_from_reference
+   : proto_die_reference:Proto_die.reference
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_import
+   : proto_die:Proto_die.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_encoding
+   : encoding:Encoding_attribute.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_byte_size_exn
+   : byte_size:int
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_bit_size
+   : Int64.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_data_member_location
+   : byte_offset:Int64.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_linkage_name
+   : linkage_name:string
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_sibling
+   : proto_die:Proto_die.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_single_location_description
+   : Single_location_description.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_composite_location_description
+   : Composite_location_description.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_single_call_value_location_description
+   : Single_location_description.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_composite_call_value_location_description
+   : Composite_location_description.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_single_call_data_location_description
+   : Single_location_description.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_single_call_data_value_location_description
+   : Single_location_description.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_const_value_from_symbol
+   : symbol:Asm_symbol.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_addr_base
+   : Asm_label.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_loclists_base
+   : Asm_label.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_rnglists_base
+   : Asm_label.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_inline
+   : Inline_code.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_call_origin
+   : die_symbol:Asm_symbol.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_abstract_origin
+   : die_symbol:Asm_symbol.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_language
+   : Dwarf_language.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_declaration
+   : unit
+  -> Dwarf_attribute_values.Attribute_value.t
+
+(** OCaml-specific DWARF attributes. *)
+
+val create_ocaml_compiler_version
+   : string
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_ocaml_unit_name
+   : Ident.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_ocaml_config_digest
+   : Digest.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_ocaml_prefix_name
+   : string
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_ocaml_linker_dirs
+   : Misc.Stdlib.String.Set.t
+  -> Dwarf_attribute_values.Attribute_value.t
+
+val create_ocaml_cmt_file_digest
+   : Digest.t
+  -> Dwarf_attribute_values.Attribute_value.t

--- a/backend/debug/dwarf/dwarf_high/dwarf_name_laundry.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_name_laundry.ml
@@ -1,0 +1,7 @@
+let linker_dir_sep = '\001'
+
+let mangle_linker_dirs dirs =
+  String.concat (Printf.sprintf "%c" linker_dir_sep) dirs
+
+let demangle_linker_dirs mangled_dirs =
+  String.split_on_char linker_dir_sep mangled_dirs

--- a/backend/debug/dwarf/dwarf_high/dwarf_name_laundry.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_name_laundry.mli
@@ -1,0 +1,7 @@
+(** The name laundry: where names get (de)mangled.
+    (This functionality is used by the debugger support library as well as
+    the compiler.) *)
+
+val mangle_linker_dirs : string list -> string
+
+val demangle_linker_dirs : string -> string list

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.ml
@@ -1,0 +1,46 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Dwarf_low
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+let emit ~params ~compilation_unit_proto_die ~compilation_unit_header_label =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  (* CR-soon mshinwell: the [compilation_unit_die] member of the record
+     returned from [Assign_abbrevs.run] is now unused *)
+  let assigned_abbrevs =
+    Profile.record "assign_abbrevs" (fun () ->
+        Assign_abbrevs.run ~proto_die_root:compilation_unit_proto_die)
+      ()
+  in
+  let debug_abbrev_label = Asm_label.for_section (DWARF Debug_abbrev) in
+  let debug_info =
+    Profile.record "debug_info_section" (fun () ->
+        Debug_info_section.create ~dies:assigned_abbrevs.dies
+          ~debug_abbrev_label
+          ~compilation_unit_header_label)
+      ()
+  in
+  Profile.record "dwarf_world_emit" (fun () ->
+      A.switch_to_section (DWARF Debug_info);
+      Profile.record "debug_info_section"
+        (Debug_info_section.emit ~params) debug_info;
+      A.switch_to_section (DWARF Debug_abbrev);
+      Profile.record "abbreviations_table"
+        (Abbreviations_table.emit ~params) assigned_abbrevs.abbrev_table;
+      A.switch_to_section (DWARF Debug_str);
+      A.emit_cached_strings ())
+    ()

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.mli
@@ -1,0 +1,26 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Helper for emitting the various DWARF sections required for full
+    debugging information. *)
+
+open Dwarf_low
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val emit
+   : params:(module Dwarf_params.S)
+  -> compilation_unit_proto_die:Proto_die.t
+  -> compilation_unit_header_label:Asm_label.t
+  -> unit

--- a/backend/debug/dwarf/dwarf_high/operator_builder.ml
+++ b/backend/debug/dwarf/dwarf_high/operator_builder.ml
@@ -1,0 +1,175 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open Dwarf_low
+
+module O = Dwarf_operator
+
+let dw_op_regx ~dwarf_reg_number : O.t =
+  match dwarf_reg_number with
+  | 0 -> DW_op_reg0
+  | 1 -> DW_op_reg1
+  | 2 -> DW_op_reg2
+  | 3 -> DW_op_reg3
+  | 4 -> DW_op_reg4
+  | 5 -> DW_op_reg5
+  | 6 -> DW_op_reg6
+  | 7 -> DW_op_reg7
+  | 8 -> DW_op_reg8
+  | 9 -> DW_op_reg9
+  | 10 -> DW_op_reg10
+  | 11 -> DW_op_reg11
+  | 12 -> DW_op_reg12
+  | 13 -> DW_op_reg13
+  | 14 -> DW_op_reg14
+  | 15 -> DW_op_reg15
+  | 16 -> DW_op_reg16
+  | 17 -> DW_op_reg17
+  | 18 -> DW_op_reg18
+  | 19 -> DW_op_reg19
+  | 20 -> DW_op_reg20
+  | 21 -> DW_op_reg21
+  | 22 -> DW_op_reg22
+  | 23 -> DW_op_reg23
+  | 24 -> DW_op_reg24
+  | 25 -> DW_op_reg25
+  | 26 -> DW_op_reg26
+  | 27 -> DW_op_reg27
+  | 28 -> DW_op_reg28
+  | 29 -> DW_op_reg29
+  | 30 -> DW_op_reg30
+  | 31 -> DW_op_reg31
+  | _ -> DW_op_regx { reg_number = dwarf_reg_number; }
+
+let dw_op_bregx ~dwarf_reg_number ~offset_in_bytes : O.t =
+  match dwarf_reg_number with
+  | 0 -> DW_op_breg0 { offset_in_bytes; }
+  | 1 -> DW_op_breg1 { offset_in_bytes; }
+  | 2 -> DW_op_breg2 { offset_in_bytes; }
+  | 3 -> DW_op_breg3 { offset_in_bytes; }
+  | 4 -> DW_op_breg4 { offset_in_bytes; }
+  | 5 -> DW_op_breg5 { offset_in_bytes; }
+  | 6 -> DW_op_breg6 { offset_in_bytes; }
+  | 7 -> DW_op_breg7 { offset_in_bytes; }
+  | 8 -> DW_op_breg8 { offset_in_bytes; }
+  | 9 -> DW_op_breg9 { offset_in_bytes; }
+  | 10 -> DW_op_breg10 { offset_in_bytes; }
+  | 11 -> DW_op_breg11 { offset_in_bytes; }
+  | 12 -> DW_op_breg12 { offset_in_bytes; }
+  | 13 -> DW_op_breg13 { offset_in_bytes; }
+  | 14 -> DW_op_breg14 { offset_in_bytes; }
+  | 15 -> DW_op_breg15 { offset_in_bytes; }
+  | 16 -> DW_op_breg16 { offset_in_bytes; }
+  | 17 -> DW_op_breg17 { offset_in_bytes; }
+  | 18 -> DW_op_breg18 { offset_in_bytes; }
+  | 19 -> DW_op_breg19 { offset_in_bytes; }
+  | 20 -> DW_op_breg20 { offset_in_bytes; }
+  | 21 -> DW_op_breg21 { offset_in_bytes; }
+  | 22 -> DW_op_breg22 { offset_in_bytes; }
+  | 23 -> DW_op_breg23 { offset_in_bytes; }
+  | 24 -> DW_op_breg24 { offset_in_bytes; }
+  | 25 -> DW_op_breg25 { offset_in_bytes; }
+  | 26 -> DW_op_breg26 { offset_in_bytes; }
+  | 27 -> DW_op_breg27 { offset_in_bytes; }
+  | 28 -> DW_op_breg28 { offset_in_bytes; }
+  | 29 -> DW_op_breg29 { offset_in_bytes; }
+  | 30 -> DW_op_breg30 { offset_in_bytes; }
+  | 31 -> DW_op_breg31 { offset_in_bytes; }
+  | _ -> DW_op_bregx { reg_number = dwarf_reg_number; offset_in_bytes; }
+
+let register_as_lvalue ~dwarf_reg_number =
+  dw_op_regx ~dwarf_reg_number
+
+let contents_of_register ~dwarf_reg_number =
+  dw_op_bregx ~dwarf_reg_number ~offset_in_bytes:Targetint_extra.zero
+
+let address_of_stack_slot ~offset_in_bytes =
+  (* Note that this isn't target-dependent.  The target dependent part
+     is the calculation of the [offset_in_bytes]. *)
+  [ O.DW_op_call_frame_cfa;
+    O.DW_op_consts (Targetint_extra.to_int64 offset_in_bytes);
+    O.DW_op_minus;
+  ]
+
+let contents_of_stack_slot ~offset_in_bytes =
+  (* Same comment as per [address_of_stack_slot]. *)
+  [ O.DW_op_call_frame_cfa;
+    O.DW_op_consts (Targetint_extra.to_int64 offset_in_bytes);
+    O.DW_op_minus;
+    O.DW_op_deref;
+  ]
+
+let value_of_symbol ~symbol : O.t = DW_op_addr (Symbol symbol)
+
+let signed_int_const i : O.t = DW_op_consts (Targetint_extra.to_int64 i)
+
+let add_unsigned_const i : O.t list =
+  if Targetint_extra.compare i Targetint_extra.zero < 0 then begin
+    Misc.fatal_error "[Operator_builder.add_unsigned_const] only takes \
+      integers >= 0"
+  end;
+  if Targetint_extra.compare i Targetint_extra.zero = 0 then []
+  else [DW_op_plus_uconst (Targetint_extra.to_uint64_exn i)]
+
+let float_const f : O.t =
+  DW_op_const8s f
+
+let implicit_pointer ~offset_in_bytes ~die_label dwarf_version : O.t =
+  if Dwarf_version.compare dwarf_version Dwarf_version.four < 0 then
+    Misc.fatal_error "DWARF implicit pointers not supported at this version"
+  else if Dwarf_version.compare dwarf_version Dwarf_version.four = 0 then
+    DW_op_GNU_implicit_pointer { offset_in_bytes; label = die_label; }
+  else
+    DW_op_implicit_pointer { offset_in_bytes; label = die_label; }
+
+let call ~die_label ~compilation_unit_header_label : O.t =
+  DW_op_call4 { label = die_label; compilation_unit_header_label; }
+
+(* Beware: if sequences of operators generated by this module are ever
+   optimised, care must be taken with the [DW_op_skip] constructions used
+   by the following function---their distance arguments may need updating! *)
+
+let conditional ?(at_join = [O.DW_op_nop]) ~if_zero ~if_nonzero () =
+  let nonzero_branch_size =
+    List.fold_left (fun nonzero_branch_size op ->
+        Dwarf_int.add (O.size op) nonzero_branch_size)
+      (Dwarf_int.zero ())
+      if_nonzero
+  in
+  let nonzero_branch_size = Dwarf_int.to_int64 nonzero_branch_size in
+  let max_branch_size = Int64.of_int ((1 lsl 16) - 1) in
+  let (>) a b = Int64.compare a b > 0 in
+  if nonzero_branch_size > max_branch_size then begin
+    Misc.fatal_error "Dwarf_operator.conditional: nonzero branch too long"
+  end;
+  let nonzero_branch_size = Numbers_extra.Int16.of_int64_exn nonzero_branch_size in
+  let if_zero =
+    if_zero @
+      [O.DW_op_skip { num_bytes_forward = nonzero_branch_size; }]
+  in
+  let zero_branch_size =
+    List.fold_left (fun zero_branch_size op ->
+        Dwarf_int.add (O.size op) zero_branch_size)
+      (Dwarf_int.zero ())
+      if_zero
+  in
+  let zero_branch_size = Dwarf_int.to_int64 zero_branch_size in
+  if zero_branch_size > max_branch_size then begin
+    Misc.fatal_error "Dwarf_operator.conditional: zero branch too long"
+  end;
+  let zero_branch_size = Numbers_extra.Int16.of_int64_exn zero_branch_size in
+  O.DW_op_bra { num_bytes_forward = zero_branch_size; }
+    :: if_zero @ if_nonzero @ at_join

--- a/backend/debug/dwarf/dwarf_high/operator_builder.mli
+++ b/backend/debug/dwarf/dwarf_high/operator_builder.mli
@@ -1,0 +1,58 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Functions for constructing DWARF operators including some simple
+    optimisations thereon. *)
+
+open Dwarf_low
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val register_as_lvalue : dwarf_reg_number:int -> Dwarf_operator.t
+
+val contents_of_register : dwarf_reg_number:int -> Dwarf_operator.t
+
+val address_of_stack_slot
+   : offset_in_bytes:Targetint_extra.t
+  -> Dwarf_operator.t list
+
+val contents_of_stack_slot
+   : offset_in_bytes:Targetint_extra.t
+  -> Dwarf_operator.t list
+
+val value_of_symbol : symbol:Asm_symbol.t -> Dwarf_operator.t
+
+val signed_int_const : Targetint_extra.t -> Dwarf_operator.t
+
+val add_unsigned_const : Targetint_extra.t -> Dwarf_operator.t list
+
+val float_const : Int64.t -> Dwarf_operator.t
+
+val implicit_pointer
+   : offset_in_bytes:Targetint_extra.t
+  -> die_label:Asm_label.t
+  -> Dwarf_version.t
+  -> Dwarf_operator.t
+
+val call
+   : die_label:Asm_label.t
+  -> compilation_unit_header_label:Asm_label.t
+  -> Dwarf_operator.t
+
+val conditional
+   : ?at_join:Dwarf_operator.t list
+  -> if_zero:Dwarf_operator.t list
+  -> if_nonzero:Dwarf_operator.t list
+  -> unit
+  -> Dwarf_operator.t list

--- a/backend/debug/dwarf/dwarf_high/proto_die.ml
+++ b/backend/debug/dwarf/dwarf_high/proto_die.ml
@@ -1,0 +1,137 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Dwarf_low
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module ASS = Dwarf_attributes.Attribute_specification.Sealed
+module AV = Dwarf_attribute_values.Attribute_value
+module Int = Numbers_extra.Int
+
+type reference = Asm_label.t
+let create_reference () = Asm_label.create (DWARF Debug_info)
+
+type t = {
+  parent : t option;
+  mutable children_by_sort_priority : t list Int.Map.t;
+  tag : Dwarf_tag.t;
+  mutable attribute_values : AV.t ASS.Map.t;
+  label : Asm_label.t;
+  (* For references between DIEs within a single unit *)
+  (* CR-someday mshinwell: consider combining [label] and [name] into one
+     "how to reference this DIE" value. *)
+  mutable name : Asm_symbol.t option;
+  (* For references between DIEs across units *)
+  location_list_in_debug_loc_table : Dwarf_4_location_list.t option;
+}
+
+let attribute_values_map attribute_values =
+  List.fold_left (fun map attribute_value ->
+      ASS.Map.add (AV.attribute_spec attribute_value) attribute_value map)
+    ASS.Map.empty
+    attribute_values
+
+(* CR-someday mshinwell: Resurrect support for sibling links. *)
+
+let create ?reference ?(sort_priority = -1) ?location_list_in_debug_loc_table
+      ~parent ~tag ~attribute_values () =
+  begin match parent with
+  | None ->
+    if tag <> Dwarf_tag.Compile_unit then begin
+      failwith "only compilation unit proto-DIEs may be without parents"
+    end
+  | Some _parent -> ()
+  end;
+  let reference =
+    match reference with
+    | None -> Asm_label.create (DWARF Debug_info)
+    | Some reference -> reference
+  in
+  let attribute_values = attribute_values_map attribute_values in
+  let t =
+    { parent;
+      children_by_sort_priority = Int.Map.empty;
+      tag;
+      attribute_values;
+      label = reference;
+      name = None;
+      location_list_in_debug_loc_table;
+    }
+  in
+  begin match parent with
+  | None -> ()
+  | Some parent ->
+    let with_same_sort_priority =
+      match Int.Map.find sort_priority parent.children_by_sort_priority with
+      | exception Not_found -> []
+      | children -> children
+    in
+    let with_same_sort_priority = t :: with_same_sort_priority in
+    parent.children_by_sort_priority
+      <- Int.Map.add sort_priority with_same_sort_priority
+           parent.children_by_sort_priority
+  end;
+  t
+
+let create_ignore ?reference ?sort_priority ?location_list_in_debug_loc_table
+      ~parent ~tag ~attribute_values () =
+  let (_ : t) =
+    create ?reference ?sort_priority ?location_list_in_debug_loc_table
+      ~parent ~tag ~attribute_values ()
+  in
+  ()
+
+let add_or_replace_attribute_value t attribute_value =
+  let attribute_values =
+    ASS.Map.add (AV.attribute_spec attribute_value) attribute_value
+      t.attribute_values
+  in
+  t.attribute_values <- attribute_values
+
+let set_name t name = t.name <- Some name
+
+type fold_arg =
+  | DIE of Dwarf_tag.t * Child_determination.t
+      * AV.t ASS.Map.t
+      * Asm_label.t * Asm_symbol.t option (* optional name *)
+      * Dwarf_4_location_list.t option
+  | End_of_siblings
+
+let rec depth_first_fold t ~init ~f =
+  let has_children : Child_determination.t =
+    if Int.Map.is_empty t.children_by_sort_priority then No
+    else Yes
+  in
+  let acc =
+    f init (DIE (t.tag, has_children, t.attribute_values, t.label, t.name,
+      t.location_list_in_debug_loc_table))
+  in
+  if Int.Map.is_empty t.children_by_sort_priority then
+    acc
+  else
+    let acc =
+      Int.Map.fold (fun _sort_priority children_rev acc ->
+          List.fold_left (fun acc child ->
+              depth_first_fold child ~init:acc ~f)
+            acc
+            (List.rev children_rev))
+        t.children_by_sort_priority
+        acc
+    in
+    f acc End_of_siblings
+
+let reference t = t.label
+
+let location_list_in_debug_loc_table t = t.location_list_in_debug_loc_table

--- a/backend/debug/dwarf/dwarf_high/proto_die.mli
+++ b/backend/debug/dwarf/dwarf_high/proto_die.mli
@@ -1,0 +1,102 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Dwarf_low
+
+(** A "proto-DIE" contains similar information to a DWARF debugging
+    information entry (DIE), but contains the actual attributes whose values
+    are being specified, rather than linking to them via an abbrevation
+    code.  The abbreviation codes are assigned later, when the proto-DIEs
+    are turned into DIEs.
+
+    Proto-DIEs may be formed into the required tree structures using a
+    simple parenting relationship.  The complexities of flattening the
+    structure to the DWARF representation (Section 2.3, DWARF-4 spec) are
+    hidden. *)
+
+type t
+
+(** For creation of proto-DIEs in a group, with references between them. *)
+(* CR-someday mshinwell: remove type equality *)
+type reference = Asm_label.t
+val create_reference : unit -> reference
+
+(* It is an error for [parent] to be [None] unless the [tag] is that for
+   a compilation unit (which is a top-level entity). *)
+val create
+   : ?reference:reference
+  -> ?sort_priority:int
+  -> ?location_list_in_debug_loc_table:Dwarf_4_location_list.t
+  -> parent:t option
+  -> tag:Dwarf_tag.t
+  -> attribute_values:Dwarf_attribute_values.Attribute_value.t list
+  -> unit
+  -> t
+
+val create_ignore
+   : ?reference:reference
+  -> ?sort_priority:int
+  -> ?location_list_in_debug_loc_table:Dwarf_4_location_list.t
+  -> parent:t option
+  -> tag:Dwarf_tag.t
+  -> attribute_values:Dwarf_attribute_values.Attribute_value.t list
+  -> unit
+  -> unit
+
+val add_or_replace_attribute_value
+   : t
+  -> Dwarf_attribute_values.Attribute_value.t
+  -> unit
+
+(* CR-someday mshinwell: add a [name] argument to the creation functions *)
+val set_name : t -> Asm_symbol.t -> unit
+
+(* [reference t] returns a label that may be used when constructing other
+    attribute values. *)
+(* CR-someday mshinwell: ideally, attribute values could accept proto-DIE
+   values directly, but there is a circularity. *)
+val reference : t -> Asm_label.t
+
+type fold_arg = private
+  | DIE of Dwarf_tag.t * Child_determination.t
+      * (Dwarf_attribute_values.Attribute_value.t
+          Dwarf_attributes.Attribute_specification.Sealed.Map.t)
+      * Asm_label.t * Asm_symbol.t option (* optional name *)
+      * Dwarf_4_location_list.t option
+  | End_of_siblings
+
+(* [depth_first_fold] traverses a proto-DIE tree in a depth-first order
+   convenient for DWARF information emission.  (Section 2.3, DWARF-4 spec.)
+   [`End_of_siblings] indicates that a chain of siblings---that is to say,
+   proto-DIEs with the same parent and at the same tree depth as each other---
+   has finished.  This should correspond exactly to the points at which a
+   "chain of sibling entries [must be] terminated by a null entry" specified
+   in the DWARF-4 spec.
+*)
+val depth_first_fold
+   : t
+  -> init:'a
+  -> f:('a -> fold_arg -> 'a)
+  -> 'a
+
+(** If this proto-DIE has been marked as referencing a DWARF-4 location list,
+    return which list it is.  We do not currently need to reference more than
+    one list in the [attribute_values] of any given proto-DIE.  This
+    information (which could theoretically be deduced directly from
+    [attribute_values] rather than relying on the caller---though relying
+    on the caller is easier) enables us to emit the .debug_loc location lists
+    in the same order as they are encountered during a top-down traversal
+    as per [depth_first_fold].  This suppresses a complaint from objdump
+    "Location lists in .debug_loc start at ...". *)
+val location_list_in_debug_loc_table : t -> Dwarf_4_location_list.t option

--- a/backend/debug/dwarf/dwarf_high/simple_location_description_lang.ml
+++ b/backend/debug/dwarf/dwarf_high/simple_location_description_lang.ml
@@ -1,0 +1,168 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open Dwarf_low
+
+module O = Dwarf_operator
+module OB = Operator_builder
+
+type t = Simple_location_description.t
+
+type lvalue = t
+type lvalue_without_address = t
+type normal
+type implicit
+type _ rvalue = t
+
+let empty = []
+
+module Lvalue = struct
+  type t = lvalue
+
+  let in_register ~dwarf_reg_number =
+    [OB.register_as_lvalue ~dwarf_reg_number]
+
+  let in_stack_slot ~offset_in_words =
+    let offset_in_bytes =
+      Targetint_extra.mul offset_in_words Targetint_extra.size_in_bytes_as_targetint
+    in
+    OB.address_of_stack_slot ~offset_in_bytes
+
+  let in_symbol_field symbol ~field =
+    let offset_in_bytes =
+      Targetint_extra.mul field Targetint_extra.size_in_bytes_as_targetint
+    in
+    (OB.value_of_symbol ~symbol) :: OB.add_unsigned_const offset_in_bytes
+
+  let read_field ~block ~field =
+    let offset_in_bytes =
+      Targetint_extra.mul field Targetint_extra.size_in_bytes_as_targetint
+    in
+    (* We emit special code to catch the case where evaluation of [block]
+       fails (for example due to unavailability).  In the event of an
+       unavailability failure, the [DW_OP_call*] evaluation of [block] does
+       nothing to the stack. *)
+    (OB.signed_int_const Targetint_extra.zero) ::
+      block @ [
+        O.DW_op_dup;
+      ] @
+      OB.conditional ~if_zero:[
+        ]
+        ~if_nonzero:([
+          O.DW_op_swap;
+          O.DW_op_drop;
+        ] @ OB.add_unsigned_const offset_in_bytes)
+        ~at_join:[
+        ]
+        ()
+
+  let offset_pointer t ~offset_in_words =
+    let offset_in_bytes =
+      Targetint_extra.mul offset_in_words Targetint_extra.size_in_bytes_as_targetint
+    in
+    (* Similar to [read_field], above. *)
+    (OB.signed_int_const Targetint_extra.zero) ::
+      t @ [
+        O.DW_op_dup;
+      ] @
+      OB.conditional ~if_zero:[
+        ]
+        ~if_nonzero:([
+          O.DW_op_swap;
+          O.DW_op_drop
+        ] @ OB.add_unsigned_const offset_in_bytes)
+        ~at_join:[
+        ]
+        ()
+
+  let location_from_another_die ~die_label ~compilation_unit_header_label =
+    [OB.call ~die_label ~compilation_unit_header_label]
+end
+
+module Lvalue_without_address = struct
+  type t = lvalue_without_address
+
+  (* Note that due to the phantom parameter in the .mli on type [_ Rvalue.t],
+     this function can never be called with an implicit pointer construction.
+     This is important since it would be wrong to put [DW_OP_stack_value]
+     after such a construction. *)
+  let of_rvalue t =
+    t @ [O.DW_op_stack_value]
+
+  let implicit_pointer ~offset_in_bytes ~die_label dwarf_version =
+    [OB.implicit_pointer ~offset_in_bytes ~die_label dwarf_version]
+end
+
+module Rvalue = struct
+  type 'a t = 'a rvalue
+
+  let signed_int_const i = [
+    OB.signed_int_const i;
+  ]
+
+  let float_const i = [
+    OB.float_const i;
+  ]
+
+  let const_symbol symbol = [
+    OB.value_of_symbol ~symbol;
+  ]
+
+  let in_register ~dwarf_reg_number = [
+    OB.contents_of_register ~dwarf_reg_number;
+  ]
+
+  let in_stack_slot ~offset_in_words = 
+    let offset_in_bytes =
+      Targetint_extra.mul offset_in_words Targetint_extra.size_in_bytes_as_targetint
+    in
+    OB.contents_of_stack_slot ~offset_in_bytes
+
+  let read_field ~block ~field =
+    let offset_in_bytes =
+      Targetint_extra.mul field Targetint_extra.size_in_bytes_as_targetint
+    in
+    (OB.signed_int_const Targetint_extra.zero) ::
+      block @ [
+        O.DW_op_dup;
+      ] @
+      OB.conditional ~if_zero:[
+        ]
+        ~if_nonzero:([
+          O.DW_op_swap;
+          O.DW_op_drop;
+        ] @ OB.add_unsigned_const offset_in_bytes @ [
+          O.DW_op_deref
+        ])
+        ~at_join:[
+        ]
+        ()
+
+  let read_symbol_field symbol ~field =
+    read_field ~block:(const_symbol symbol) ~field
+
+  let location_from_another_die ~die_label ~compilation_unit_header_label =
+    [OB.call ~die_label ~compilation_unit_header_label]
+
+  let implicit_pointer ~offset_in_bytes ~die_label dwarf_version =
+    [OB.implicit_pointer ~offset_in_bytes ~die_label dwarf_version]
+end
+
+let of_lvalue t = t
+let of_lvalue_without_address t = t
+let of_rvalue t = t
+
+let compile t = t

--- a/backend/debug/dwarf/dwarf_high/simple_location_description_lang.mli
+++ b/backend/debug/dwarf/dwarf_high/simple_location_description_lang.mli
@@ -1,0 +1,172 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Higher-level representation of simple location descriptions than that
+    provided by the DWARF standard.  This representation is compiled down
+    to [Simple_location_description.t] values.
+
+    Functions in this interface are used to build descriptions that enable the
+    debugger to know what value a particular variable has at runtime.  These
+    descriptions are categorised according to their surrounding context:
+
+    - [Lvalue] descriptions are used when the context needs to know the _place_
+    where a particular variable is stored.  Typically such a description is
+    some address in the target's memory or the name of some register in the
+    target's CPU.
+
+    - [Rvalue] descriptions are used when the context requires the _value_ of
+    a particular variable rather than a description of the place where it lives.
+    This is usually the case when the description is being used as some
+    sub-expression of a larger DWARF expression.
+
+    Sometimes the context requires that the address of a value has to be given,
+    but such address cannot be computed, for example because the value has been
+    entirely optimised out.  However we may well know what the value itself is
+    (or was).  In these cases we use [Lvalue_without_address] semantics
+    (corresponding to DWARF "implicit location descriptions").  These enable
+    rvalues to be converted into descriptions that may be used in lvalue
+    context; and to describe pointers that have been entirely optimised out.
+
+    The descriptions of the functions are written in terms of some fictional
+    value V and time T. The time is when the simple location description is
+    being evaluated in the debugger to inspect V.
+*)
+
+open Dwarf_low
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+type lvalue
+type lvalue_without_address
+type normal
+type implicit
+type 'a rvalue
+
+(** "A piece or all of an object that is present in the source but not in
+    the object code" (DWARF-4 standard 2.6.1.1.4). *)
+val empty : t
+
+module Lvalue : sig
+  type t = lvalue
+
+  (** V will be in the given register at time T. *)
+  val in_register : dwarf_reg_number:int -> t
+
+  (** The address of V will be that of the given stack slot at time T. *)
+  val in_stack_slot : offset_in_words:Targetint_extra.t -> t
+
+  (** The address of V will be the address of the given field of the block
+      whose address (expressed as an rvalue) is given by the provided simple
+      location description at time T. *)
+  val read_field : block:normal rvalue -> field:Targetint_extra.t -> t
+
+  (** The address of V will be the address of the given field of the given
+      symbol at time T. *)
+  val in_symbol_field : Asm_symbol.t -> field:Targetint_extra.t -> t
+
+  (** The address of V will be the supplied address at time T plus the
+      [offset_in_words]. *)
+  val offset_pointer : t -> offset_in_words:Targetint_extra.t -> t
+
+  (** The address (or register location) of V is found in the location given
+      by evaluating the location description (which must yield an lvalue) in
+      the DIE at the given [die_label].  (This is like a function call.) *)
+  val location_from_another_die
+     : die_label:Asm_label.t
+    -> compilation_unit_header_label:Asm_label.t
+    -> t
+end
+
+module Lvalue_without_address : sig
+  type t = lvalue_without_address
+
+  (** The address of V cannot be described, but the value of V is known;
+      the supplied [rvalue] describes such value. *)
+  val of_rvalue : normal rvalue -> t
+
+  (** V is an optimized-out pointer to a value whose contents are given by
+      evaluating the location description (which must yield an rvalue) in the
+      DIE at the given [die_label]. *)
+  val implicit_pointer
+     : offset_in_bytes:Targetint_extra.t
+    -> die_label:Asm_label.t
+    -> Dwarf_version.t
+    -> t
+end
+
+module Rvalue : sig
+  type 'a t = 'a rvalue
+
+  (** V is the given constant integer.  (This is a raw bit pattern, nothing
+      to do with OCaml tagging.) *)
+  val signed_int_const : Targetint_extra.t -> normal t
+
+  (** V is the floating-point number whose bits are specified by the given
+      64-bit integer. *)
+  val float_const : Int64.t -> normal t
+
+  (** V is the address of the given symbol (not the contents of memory
+      pointed to by the given symbol). *)
+  val const_symbol : Asm_symbol.t -> normal t
+
+  (** V will be the contents of the given register at time T. *)
+  val in_register : dwarf_reg_number:int -> normal t
+
+  (** V will be the contents of the given stack slot at time T. *)
+  val in_stack_slot : offset_in_words:Targetint_extra.t -> normal t
+
+  (** V will be the contents of the given field of the block whose location is
+      given by the provided simple location description at time T. *)
+  val read_field : block:normal t -> field:Targetint_extra.t -> normal t
+
+  (** V will be the contents of the given field of the given symbol at
+      time T. *)
+  val read_symbol_field : Asm_symbol.t -> field:Targetint_extra.t -> normal t
+
+  (** V will be found in the location given by evaluating the location
+      description (which must yield an rvalue) in the DIE at the given
+      [die_label].  (This is like a function call.) *)
+  val location_from_another_die
+     : die_label:Asm_label.t
+    -> compilation_unit_header_label:Asm_label.t
+    -> normal t
+
+  (** V is an optimized-out pointer to a value whose contents are given by
+      evaluating the location description (which must yield an rvalue) in the
+      DIE at the given [die_label].
+
+      The resulting description cannot take part in any further location
+      computations.  The type parameter statically ensures this. *)
+  val implicit_pointer
+     : offset_in_bytes:Targetint_extra.t
+    -> die_label:Asm_label.t
+    -> Dwarf_version.t
+    -> implicit t
+end
+
+(** Create a high-level location description from an lvalue description. *)
+val of_lvalue : Lvalue.t -> t
+
+(** Create a high-level location description from an lvalue-without-address
+    description. *)
+val of_lvalue_without_address : Lvalue_without_address.t -> t
+
+(** Create a high-level location description from an rvalue description. *)
+val of_rvalue : _ Rvalue.t -> t
+
+(** Transform a high-level location description into a stream of DWARF
+    operators forming a DWARF simple location description. *)
+val compile : t -> Simple_location_description.t

--- a/backend/debug/dwarf/dwarf_low/abbreviation_code.ml
+++ b/backend/debug/dwarf/dwarf_low/abbreviation_code.ml
@@ -1,0 +1,52 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Uint64 = Numbers_extra.Uint64
+
+type t = {
+  code : int;
+  comment : string;
+}
+
+exception Bad_abbreviation_code of int
+
+let of_int code tag =
+  if code < 1 then raise (Bad_abbreviation_code code);
+  let comment =
+    Printf.sprintf "abbrev. code (abbrev. has tag %s)" (Dwarf_tag.tag_name tag)
+  in
+  { code;
+    comment;
+  }
+
+let null =
+  { code = 0;
+    comment = "null abbreviation code";
+  }
+
+let is_null t =
+  t == null
+
+let encode t =
+  Dwarf_value.uleb128 ~comment:t.comment (Uint64.of_nonnegative_int_exn t.code)
+
+let emit ~params t = Dwarf_value.emit ~params (encode t)
+
+let size t = Dwarf_value.size (encode t)
+
+let compare t1 t2 = Stdlib.compare t1.code t2.code
+
+let hash t = Hashtbl.hash t.code

--- a/backend/debug/dwarf/dwarf_low/abbreviation_code.mli
+++ b/backend/debug/dwarf/dwarf_low/abbreviation_code.mli
@@ -1,0 +1,33 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF abbreviation codes. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+(** The tag is only used for generation of comments and is ignored for
+    [compare] and [hash]. *)
+val of_int : int -> Dwarf_tag.t -> t
+
+val null : t
+
+val is_null : t -> bool
+
+val compare : t -> t -> int
+
+val hash : t -> int

--- a/backend/debug/dwarf/dwarf_low/abbreviations_table.ml
+++ b/backend/debug/dwarf/dwarf_low/abbreviations_table.ml
@@ -1,0 +1,106 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Uint64 = Numbers_extra.Uint64
+
+module Key = struct
+  type t = {
+    tag : Dwarf_tag.t;
+    has_children : Child_determination.t;
+    attribute_specs : Dwarf_attributes.Attribute_specification.Sealed.Set.t;
+  }
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let compare
+          { tag = tag1;
+            has_children = has_children1;
+            attribute_specs = attribute_specs1;
+          }
+          { tag = tag2;
+            has_children = has_children2;
+            attribute_specs = attribute_specs2;
+          } =
+      let c = Dwarf_tag.compare tag1 tag2 in
+      if c <> 0 then c
+      else
+        let c = Child_determination.compare has_children1 has_children2 in
+        if c <> 0 then c
+        else
+          Dwarf_attributes.Attribute_specification.Sealed.Set.compare
+            attribute_specs1 attribute_specs2
+
+    let equal t1 t2 =
+      compare t1 t2 = 0
+
+    let hash _ = Misc.fatal_error "Not yet implemented"
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+    let print _ _ = Misc.fatal_error "Not yet implemented"
+  end)
+end
+
+type t = Abbreviations_table_entry.t Key.Map.t
+
+let create () = Key.Map.empty
+
+let add t entry =
+  let tag = Abbreviations_table_entry.tag entry in
+  let has_children = Abbreviations_table_entry.has_children entry in
+  let attribute_specs = Abbreviations_table_entry.attribute_specs entry in
+  let key : Key.t =
+    { tag;
+      has_children;
+      attribute_specs;
+    }
+  in
+  Key.Map.add key entry t
+
+let find t ~tag ~has_children ~attribute_specs =
+  let key : Key.t =
+    { tag;
+      has_children;
+      attribute_specs;
+    }
+  in
+  match Key.Map.find key t with
+  | exception Not_found -> None
+  | entry -> Some (Abbreviations_table_entry.abbreviation_code entry)
+
+let size t =
+  let (+) = Dwarf_int.add in
+  (* See below re. the zero word. *)
+  Dwarf_value.size (Dwarf_value.uleb128 Uint64.zero)
+    + Key.Map.fold
+        (fun _key entry size -> size + Abbreviations_table_entry.size entry)
+        t
+        (Dwarf_int.zero ())
+
+let emit ~params t =
+  let module Params = (val params : Dwarf_params.S) in
+  (* There appears to be no statement in the DWARF-4 spec (section 7.5.3)
+     saying that the abbrevation table entries have to be in abbrevation
+     code order.  (Ours might not be.) *)
+  Key.Map.iter (fun _key entry ->
+      Params.Asm_directives.new_line ();
+      Abbreviations_table_entry.emit ~params entry)
+    t;
+  (* DWARF-4 spec section 7.5.3: "The abbreviations for a given compilation
+     unit end with an entry consisting of a 0 byte for the abbreviation
+     code." *)
+  Dwarf_value.emit ~params (
+    Dwarf_value.uleb128 ~comment:"End of abbrevs for compilation unit"
+      Uint64.zero)

--- a/backend/debug/dwarf/dwarf_low/abbreviations_table.mli
+++ b/backend/debug/dwarf/dwarf_low/abbreviations_table.mli
@@ -1,0 +1,30 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val create : unit -> t
+
+val add : t -> Abbreviations_table_entry.t -> t
+
+val find
+   : t
+  -> tag:Dwarf_tag.t
+  -> has_children:Child_determination.t
+  -> attribute_specs:Dwarf_attributes.Attribute_specification.Sealed.Set.t
+  -> Abbreviation_code.t option

--- a/backend/debug/dwarf/dwarf_low/abbreviations_table_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/abbreviations_table_entry.ml
@@ -1,0 +1,62 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module AS = Dwarf_attributes.Attribute_specification.Sealed
+module Uint64 = Numbers_extra.Uint64
+
+type t = {
+  abbreviation_code : Abbreviation_code.t;
+  tag : Dwarf_tag.t;
+  has_children : Child_determination.t;
+  attribute_specs : Dwarf_attributes.Attribute_specification.Sealed.Set.t;
+}
+
+let create ~abbreviation_code ~tag ~has_children ~attribute_specs =
+  { abbreviation_code;
+    tag;
+    has_children;
+    attribute_specs;
+  }
+
+let size t =
+  let (+) = Dwarf_int.add in
+  Abbreviation_code.size t.abbreviation_code
+    + Dwarf_tag.size t.tag
+    + Child_determination.size t.has_children
+    + AS.Set.fold (fun attr_spec size ->
+          Dwarf_int.add size (AS.size attr_spec))
+        t.attribute_specs
+        (Dwarf_int.zero ())
+    (* See below regarding the two zero words. *)
+    + Dwarf_value.size (Dwarf_value.uleb128 Uint64.zero)
+    + Dwarf_value.size (Dwarf_value.uleb128 Uint64.zero)
+
+let emit ~params t =
+  Abbreviation_code.emit ~params t.abbreviation_code;
+  Dwarf_tag.emit ~params t.tag;
+  Child_determination.emit ~params t.has_children;
+  AS.Set.iter (fun spec -> AS.emit ~params spec) t.attribute_specs;
+  (* DWARF-4 spec section 7.5.3: "The series of attribute specifications ends
+     with an entry containing 0 for the name and 0 for the form." *)
+  Dwarf_value.emit ~params (
+    Dwarf_value.uleb128 ~comment:"terminator word 1" Uint64.zero);
+  Dwarf_value.emit ~params (
+    Dwarf_value.uleb128 ~comment:"terminator word 2" Uint64.zero)
+
+let tag t = t.tag
+let has_children t = t.has_children
+let attribute_specs t = t.attribute_specs
+let abbreviation_code t = t.abbreviation_code

--- a/backend/debug/dwarf/dwarf_low/abbreviations_table_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/abbreviations_table_entry.mli
@@ -1,0 +1,35 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** One entry in an abbreviations table. *)
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val create
+   : abbreviation_code:Abbreviation_code.t
+  -> tag:Dwarf_tag.t
+  -> has_children:Child_determination.t
+  -> attribute_specs:Dwarf_attributes.Attribute_specification.Sealed.Set.t
+  -> t
+
+val abbreviation_code : t -> Abbreviation_code.t
+val tag : t -> Dwarf_tag.t
+val has_children : t -> Child_determination.t
+val attribute_specs
+   : t
+  -> Dwarf_attributes.Attribute_specification.Sealed.Set.t

--- a/backend/debug/dwarf/dwarf_low/address_index.ml
+++ b/backend/debug/dwarf/dwarf_low/address_index.ml
@@ -1,0 +1,51 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Uint64 = Numbers_extra.Uint64
+
+(* CR-someday mshinwell: Change this to [Uint64] once there is a comparison
+   function on values of that type. *)
+include Int64
+
+let size t = Dwarf_value.size (Dwarf_value.uleb128 (Uint64.of_nonnegative_int64_exn t))
+let emit ~params ?comment t =
+  Dwarf_value.emit ~params (Dwarf_value.uleb128 ?comment (Uint64.of_nonnegative_int64_exn t))
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare = Stdlib.compare
+  let hash = Hashtbl.hash
+  let equal t1 t2 = (compare t1 t2 = 0)
+
+  let print ppf t = Format.fprintf ppf "%Ld" t
+  let output _ _ = Misc.fatal_error "Not yet implemented"
+end)
+
+module Pair = struct
+  type nonrec t = t * t
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let compare = Stdlib.compare
+    let hash = Hashtbl.hash
+    let equal t1 t2 = (compare t1 t2 = 0)
+
+    let print ppf (x, y) = Format.fprintf ppf "(%Ld, %Ld)" x y
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+  end)
+end

--- a/backend/debug/dwarf/dwarf_low/address_index.mli
+++ b/backend/debug/dwarf/dwarf_low/address_index.mli
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Indexes into the .debug_addr table. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+val zero : t
+
+val succ : t -> t
+
+include Identifiable.S with type t := t
+
+val size : t -> Dwarf_int.t
+
+val emit : params:(module Dwarf_params.S) -> ?comment:string -> t -> unit
+
+module Pair : Identifiable.S with type t = t * t

--- a/backend/debug/dwarf/dwarf_low/address_table.ml
+++ b/backend/debug/dwarf/dwarf_low/address_table.ml
@@ -1,0 +1,116 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Uint8 = Numbers_extra.Uint8
+
+module Entry = struct
+  type t = {
+    addr : Asm_label.t;
+    adjustment : int;
+  }
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let compare
+          { addr = addr1; adjustment = adjustment1; }
+          { addr = addr2; adjustment = adjustment2; } =
+      let c = Asm_label.compare addr1 addr2 in
+      if c <> 0 then c
+      else Stdlib.compare adjustment1 adjustment2
+
+    let equal t1 t2 =
+      compare t1 t2 = 0
+
+    let hash { addr; adjustment; } =
+      Hashtbl.hash (Asm_label.hash addr, adjustment)
+
+    let print _ _ = Misc.fatal_error "Not yet implemented"
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+  end)
+end
+
+type entry_and_soc_symbol = {
+  entry : Entry.t;
+  start_of_code_symbol : Asm_symbol.t;
+}
+
+type t = {
+  base_addr : Asm_label.t;
+  mutable next_index : Address_index.t;
+  mutable table : entry_and_soc_symbol Address_index.Map.t;
+  mutable rev_table : Address_index.t Entry.Map.t;
+}
+
+let create () =
+  { base_addr = Asm_label.create (DWARF Debug_addr);
+    next_index = Address_index.zero;
+    table = Address_index.Map.empty;
+    rev_table = Entry.Map.empty;
+  }
+
+let add ?(adjustment = 0) t ~start_of_code_symbol addr =
+  let entry : Entry.t =
+    { addr;
+      adjustment;
+    }
+  in
+  match Entry.Map.find entry t.rev_table with
+  | exception Not_found ->
+    let index = t.next_index in
+    t.next_index <- Address_index.succ index;
+    t.rev_table <- Entry.Map.add entry index t.rev_table;
+    let entry : entry_and_soc_symbol =
+      { entry;
+        start_of_code_symbol;
+      }
+    in
+    t.table <- Address_index.Map.add index entry t.table;
+    index
+  | index -> index
+
+let base_addr t = t.base_addr
+
+let initial_length t =
+  let num_entries = Int64.of_int (Address_index.Map.cardinal t.table) in
+  let size_entries = Int64.mul num_entries (Int64.of_int Dwarf_arch_sizes.size_addr) in
+  Initial_length.create (Dwarf_int.of_int64_exn (Int64.add 4L size_entries))
+
+let size t =
+  let initial_length = initial_length t in
+  Dwarf_int.add (Initial_length.size initial_length)
+    (Initial_length.to_dwarf_int initial_length)
+
+let entry_to_dwarf_value (entry : entry_and_soc_symbol) =
+  let adjustment = Targetint_extra.of_int_exn entry.entry.adjustment in
+  Dwarf_value.code_address_from_label_symbol_diff
+    ~comment:"ending address"
+    ~upper:entry.entry.addr
+    ~lower:entry.start_of_code_symbol
+    ~offset_upper:adjustment
+    ()
+
+let emit ~params t =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  Initial_length.emit ~params (initial_length t);
+  Dwarf_version.emit ~params Dwarf_version.five;
+  A.uint8 (Uint8.of_nonnegative_int_exn Dwarf_arch_sizes.size_addr);
+  A.uint8 Uint8.zero;
+  A.define_label t.base_addr;
+  Address_index.Map.iter (fun _index entry ->
+      Dwarf_value.emit ~params (entry_to_dwarf_value entry))
+    t.table

--- a/backend/debug/dwarf/dwarf_low/address_table.mli
+++ b/backend/debug/dwarf/dwarf_low/address_table.mli
@@ -1,0 +1,43 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Management of the .debug_addr table (DWARF-5 spec section 7.2.7,
+    page 241). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+val create : unit -> t
+
+(** [add ~adjustment t addr] adds to the table the address of the label [addr]
+    (which in the assembly file is referenced from the [start_of_code_symbol])
+    plus the [adjustment].  If the [adjustment] is omitted then it is taken
+    to be zero.
+
+    The returned address index may be used for referencing the address e.g. in
+    a location list entry.
+*)
+val add
+   : ?adjustment:int
+  -> t
+  -> start_of_code_symbol:Asm_symbol.t
+  -> Asm_label.t
+  -> Address_index.t
+
+(** The label to be used as the value of the [DW_AT_base] attribute
+    (DWARF-5 spec page 66 line 14). *)
+val base_addr : t -> Asm_label.t
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/aranges_table.ml
+++ b/backend/debug/dwarf/dwarf_low/aranges_table.ml
@@ -1,0 +1,64 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Int8 = Numbers_extra.Int8
+module Int16 = Numbers_extra.Int16
+
+type t = {
+  size : Dwarf_int.t;
+  values : Dwarf_value.t list;
+}
+
+let create ~start_of_code_symbol ~end_of_code_symbol
+      ~debug_info_label =
+  let module V = Dwarf_value in
+  let values = [
+    (* The initial length is inserted here by the code below. *)
+    V.int16 ~comment:"section version number" (Int16.of_int_exn 2);
+    (* N.B. The following offset is to the compilation unit *header*, not
+       the compilation unit DIE. *)
+    V.offset_into_debug_info ~comment:"offset to compilation unit header"
+      debug_info_label;
+    V.int8 ~comment:"Dwarf_arch_sizes.size_addr" (Int8.of_int_exn Dwarf_arch_sizes.size_addr);
+    V.int8 ~comment:"flat address space" Int8.zero;
+    (* end of header *)
+    (* The mystery values match up with what gcc emits and stop bfd from
+       mangling the aranges tables.  They do not appear to be referenced in
+       the DWARF specification. *)
+    V.int16 ~comment:"mystery value 1" Int16.zero;
+    V.int16 ~comment:"mystery value 2" Int16.zero;
+    (* segment selector omitted (since we selected "flat address space") *)
+    V.code_address_from_symbol start_of_code_symbol;
+    V.code_address_from_symbol_diff ~comment:"length of code"
+      ~upper:end_of_code_symbol ~lower:start_of_code_symbol ();
+    (* The terminating entry is only two words since the segment selector
+       word is again absent. *)
+    V.absolute_address ~comment:"terminator word 1" Targetint_extra.zero;
+    V.absolute_address ~comment:"terminator word 2" Targetint_extra.zero;
+  ]
+  in
+  let size =
+    List.fold_left (fun size value -> Dwarf_int.add size (V.size value))
+      (Dwarf_int.zero ())
+      values
+  in
+  { size; values; }
+
+let size t = t.size
+
+let emit ~params t =
+  Initial_length.emit ~params (Initial_length.create t.size);
+  List.iter (fun v -> Dwarf_value.emit ~params v) t.values

--- a/backend/debug/dwarf/dwarf_low/aranges_table.mli
+++ b/backend/debug/dwarf/dwarf_low/aranges_table.mli
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Tables for faster lookup of program entities by address
+    (.debug_aranges, DWARF-4 standard section 6.1.2).
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val create : start_of_code_symbol:Asm_symbol.t
+  -> end_of_code_symbol:Asm_symbol.t
+  -> debug_info_label:Asm_label.t
+  -> t

--- a/backend/debug/dwarf/dwarf_low/child_determination.ml
+++ b/backend/debug/dwarf/dwarf_low/child_determination.ml
@@ -1,0 +1,36 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Yes
+  | No
+
+let encode = function
+  | Yes -> 0x01
+  | No -> 0x00
+
+let size _t = Dwarf_int.one ()
+
+let emit ~params t =
+  let comment =
+    match t with
+    | Yes -> "Has children"
+    | No -> "No children"
+  in
+  Dwarf_value.emit ~params (Dwarf_value.int8 ~comment
+    (Numbers_extra.Int8.of_int_exn (encode t)))
+
+let compare t1 t2 = Stdlib.compare t1 t2

--- a/backend/debug/dwarf/dwarf_low/child_determination.mli
+++ b/backend/debug/dwarf/dwarf_low/child_determination.mli
@@ -1,0 +1,21 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = Yes | No
+
+include Dwarf_emittable.S with type t := t
+
+val compare : t -> t -> int

--- a/backend/debug/dwarf/dwarf_low/composite_location_description.ml
+++ b/backend/debug/dwarf/dwarf_low/composite_location_description.ml
@@ -1,0 +1,40 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Pieces of (Simple_location_description.t * Targetint_extra.t) list
+
+let pieces_of_simple_location_descriptions slds = Pieces slds
+
+let size t =
+  match t with
+  | Pieces slds ->
+    List.fold_left (fun size (sld, size_in_bytes) ->
+        let pieces = Dwarf_operator.DW_op_piece { size_in_bytes; } in
+        Dwarf_int.add size
+          (Dwarf_int.add (Simple_location_description.size sld)
+            (Dwarf_operator.size pieces)))
+      (Dwarf_int.zero ())
+      slds
+
+let emit ~params t =
+  match t with
+  | Pieces slds ->
+    List.iter (fun (sld, size_in_bytes) ->
+        Simple_location_description.emit ~params sld;
+        let pieces = Dwarf_operator.DW_op_piece { size_in_bytes; } in
+        Dwarf_operator.emit ~params pieces)
+      slds

--- a/backend/debug/dwarf/dwarf_low/composite_location_description.mli
+++ b/backend/debug/dwarf/dwarf_low/composite_location_description.mli
@@ -1,0 +1,26 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+(** Create a composite DW_OP_piece location description from a list of
+    simple location descriptions along with the sizes of the described
+    objects measured in bytes. *)
+val pieces_of_simple_location_descriptions
+   : (Simple_location_description.t * Targetint_extra.t) list
+  -> t

--- a/backend/debug/dwarf/dwarf_low/counted_location_description.ml
+++ b/backend/debug/dwarf/dwarf_low/counted_location_description.ml
@@ -1,0 +1,36 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = {
+  loc_desc : Single_location_description.t;
+  loc_desc_size : Dwarf_int.t;
+}
+
+let create loc_desc =
+  { loc_desc;
+    loc_desc_size = Single_location_description.size loc_desc;
+  }
+
+let size t =
+  Dwarf_int.add
+    (Dwarf_value.size (Dwarf_value.uleb128 (
+      Dwarf_int.to_uint64_exn t.loc_desc_size)))
+    t.loc_desc_size
+
+let emit ~params t =
+  Dwarf_value.emit ~params (Dwarf_value.uleb128 ~comment:"loc_desc_size" (
+    Dwarf_int.to_uint64_exn t.loc_desc_size));
+  Single_location_description.emit ~params t.loc_desc

--- a/backend/debug/dwarf/dwarf_low/counted_location_description.mli
+++ b/backend/debug/dwarf/dwarf_low/counted_location_description.mli
@@ -1,0 +1,23 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Counted location descriptions (DWARF-5 spec page 44 line 17). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+val create : Single_location_description.t -> t
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/debug_info_section.ml
+++ b/backend/debug/dwarf/dwarf_low/debug_info_section.ml
@@ -1,0 +1,97 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module DIE = Debugging_information_entry
+
+type t = {
+  dies : DIE.t list;
+  debug_abbrev_label : Asm_label.t;
+  compilation_unit_header_label : Asm_label.t;
+}
+
+let create ~dies ~debug_abbrev_label ~compilation_unit_header_label =
+  { dies;
+    debug_abbrev_label;
+    compilation_unit_header_label;
+  }
+
+let dwarf_version () =
+  match !Clflags.gdwarf_version with
+  | Four -> Dwarf_version.four
+  | Five -> Dwarf_version.five
+
+(* CR-someday mshinwell: this used to have "label - section", but maybe zero
+   will do. *)
+let debug_abbrev_offset t =
+  Dwarf_value.offset_into_debug_abbrev
+    ~comment:"abbrevs. for this comp. unit"
+    t.debug_abbrev_label
+
+(* CR-someday mshinwell: fix for cross compilation *)
+let address_width_in_bytes_on_target =
+  Dwarf_value.int8 ~comment:"Dwarf_arch_sizes.size_addr"
+    (Numbers_extra.Int8.of_int_exn Dwarf_arch_sizes.size_addr)
+
+let unit_type = Unit_type.Compile
+
+let size_without_first_word t =
+  let (+) = Dwarf_int.add in
+  let total_die_size =
+    List.fold_left (fun size die -> size + DIE.size die)
+      (Dwarf_int.zero ())
+      t.dies
+  in
+  match !Clflags.gdwarf_version with
+  | Four ->
+    Dwarf_version.size (dwarf_version ())
+      + Dwarf_value.size (debug_abbrev_offset t)
+      + Dwarf_value.size address_width_in_bytes_on_target
+      + total_die_size
+  | Five ->
+    Dwarf_version.size (dwarf_version ())
+      + Unit_type.size unit_type
+      + Dwarf_value.size address_width_in_bytes_on_target
+      + Dwarf_value.size (debug_abbrev_offset t)
+      + total_die_size
+
+let size t =
+  let size_without_first_word = size_without_first_word t in
+  let initial_length = Initial_length.create size_without_first_word in
+  Dwarf_int.add (Initial_length.size initial_length) size_without_first_word
+
+let emit ~params t =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  let size_without_first_word = size_without_first_word t in
+  let initial_length = Initial_length.create size_without_first_word in
+  A.define_label t.compilation_unit_header_label;
+  Initial_length.emit ~params initial_length;
+  Dwarf_version.emit ~params (dwarf_version ());
+  begin match dwarf_version () with
+  | Four ->
+    Dwarf_value.emit ~params (debug_abbrev_offset t);
+    Dwarf_value.emit ~params address_width_in_bytes_on_target
+  | Five ->
+    Unit_type.emit ~params unit_type;
+    Dwarf_value.emit ~params address_width_in_bytes_on_target;
+    Dwarf_value.emit ~params (debug_abbrev_offset t)
+  end;
+  A.new_line ();
+  A.comment "Debugging information entries:";
+  A.new_line ();
+  Profile.record "die_emission" (fun dies ->
+      List.iter (fun die -> DIE.emit ~params die) dies)
+    t.dies

--- a/backend/debug/dwarf/dwarf_low/debug_info_section.mli
+++ b/backend/debug/dwarf/dwarf_low/debug_info_section.mli
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Representation of the DWARF .debug_info section. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+(** It is recommended that the [Dwarf_high] library be used to form
+    [dies] (along with the abbreviation table). *)
+val create
+   : dies:Debugging_information_entry.t list
+  -> debug_abbrev_label:Asm_label.t
+  -> compilation_unit_header_label:Asm_label.t
+  -> t
+
+val dwarf_version : unit -> Dwarf_version.t
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/debugging_information_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/debugging_information_entry.ml
@@ -1,0 +1,73 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module ASS = Dwarf_attributes.Attribute_specification.Sealed
+module AV = Dwarf_attribute_values.Attribute_value
+
+type t = {
+  label : Asm_label.t;
+  name : Asm_symbol.t option;
+  abbreviation_code : Abbreviation_code.t;
+  attribute_values : AV.t ASS.Map.t;
+}
+
+let create ~label ~name ~abbreviation_code ~attribute_values =
+  { label;
+    name;
+    abbreviation_code;
+    attribute_values;
+  }
+
+let null =
+  lazy (
+    { label = Asm_label.create (DWARF Debug_info);
+      name = None;
+      abbreviation_code = Abbreviation_code.null;
+      attribute_values = ASS.Map.empty;
+    })
+
+let create_null () = Lazy.force null
+
+let emit ~params t =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  (* The null DIE is likely to be emitted multiple times; we must not
+     emit its label multiple times, or the assembler would complain.
+     We don't actually need to point at the null DIE from anywhere else, so
+     we elide emission of the label altogether. *)
+  if not (Abbreviation_code.is_null t.abbreviation_code) then begin
+    begin match t.name with
+    | None -> ()
+    | Some symbol ->
+      A.define_data_symbol symbol;
+      A.global symbol
+    end;
+    A.define_label t.label
+  end;
+  Abbreviation_code.emit ~params t.abbreviation_code;
+  ASS.Map.iter (fun _spec av -> AV.emit ~params av) t.attribute_values
+
+let size t =
+  ASS.Map.fold (fun _attribute_spec attribute_value size ->
+      Dwarf_int.add size (AV.size attribute_value))
+    t.attribute_values
+    (Abbreviation_code.size t.abbreviation_code)
+
+let label t = t.label
+let abbreviation_code t = t.abbreviation_code
+let attribute_values t = t.attribute_values
+let is_null t = (t == (Lazy.force null))
+let symbol t = t.name

--- a/backend/debug/dwarf/dwarf_low/debugging_information_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/debugging_information_entry.mli
@@ -1,0 +1,44 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Representation of DWARF DIEs (debugging information entries). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+(** If [name] is provided, then a global symbol will be created at the
+    same place as [label]. *)
+val create
+   : label:Asm_label.t
+  -> name:Asm_symbol.t option
+  -> abbreviation_code:Abbreviation_code.t
+  -> attribute_values:
+       Dwarf_attribute_values.Attribute_value.t
+         Dwarf_attributes.Attribute_specification.Sealed.Map.t
+  -> t
+
+val create_null : unit -> t
+val is_null : t -> bool
+
+val abbreviation_code : t -> Abbreviation_code.t
+val attribute_values
+   : t
+  -> Dwarf_attribute_values.Attribute_value.t
+       Dwarf_attributes.Attribute_specification.Sealed.Map.t
+
+val label : t -> Asm_label.t
+val symbol : t -> Asm_symbol.t option

--- a/backend/debug/dwarf/dwarf_low/dune
+++ b/backend/debug/dwarf/dwarf_low/dune
@@ -1,0 +1,9 @@
+(include_subdirs unqualified)
+
+(library
+  (name dwarf_low)
+  (wrapped true)
+  (flags (:standard -principal -nostdlib))
+  (ocamlopt_flags (:standard -O3))
+  (libraries stdlib ocamlcommon ocamlbytecomp dwarf_deps)
+)

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/debug_loc_table.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/debug_loc_table.ml
@@ -1,0 +1,42 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = Dwarf_4_location_list.t list ref
+
+let create () = ((ref []) : t)
+
+let insert t location_list =
+  t := location_list :: !t
+
+let attribute_to_reference_location_list location_list =
+  let spec =
+    Dwarf_attributes.Attribute_specification.create
+      (Dwarf_attributes.Attribute.Dwarf_4 Location)
+      (Dwarf_attributes.Form.Dwarf_4 Sec_offset_loclistptr)
+  in
+  Dwarf_attribute_values.Attribute_value.create spec
+    (Dwarf_attribute_values.Value.offset_into_debug_loc
+      (Dwarf_4_location_list.label location_list))
+
+let size t =
+  List.fold_left (fun size loc_list ->
+      Dwarf_int.add size (Dwarf_4_location_list.size loc_list))
+    (Dwarf_int.zero ())
+    !t
+
+let emit ~params t =
+  List.iter (fun loc_list -> Dwarf_4_location_list.emit ~params loc_list)
+    (List.rev !t)

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/debug_loc_table.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/debug_loc_table.mli
@@ -1,0 +1,29 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Representation of the DWARF-4 .debug_loc table. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val create : unit -> t
+
+val insert : t -> Dwarf_4_location_list.t -> unit
+
+val attribute_to_reference_location_list
+   : Dwarf_4_location_list.t
+  -> Dwarf_attribute_values.Attribute_value.t

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/debug_ranges_table.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/debug_ranges_table.ml
@@ -1,0 +1,42 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = Dwarf_4_range_list.t list ref
+
+let create () = ((ref []) : t)
+
+let insert t ~range_list =
+  let attribute_referencing_the_new_list =
+    let spec =
+      Dwarf_attributes.Attribute_specification.create
+        (Dwarf_attributes.Attribute.Dwarf_4 Ranges)
+        (Dwarf_attributes.Form.Dwarf_4 Sec_offset_rangelistptr)
+    in
+    Dwarf_attribute_values.Attribute_value.create spec
+      (Dwarf_attribute_values.Value.offset_into_debug_ranges
+        (Dwarf_4_range_list.label range_list))
+  in
+  t := range_list :: !t;
+  attribute_referencing_the_new_list
+
+let size t =
+  List.fold_left (fun size range_list ->
+      Dwarf_int.add size (Dwarf_4_range_list.size range_list))
+    (Dwarf_int.zero ())
+    !t
+
+let emit ~params t =
+  List.iter (fun range_list -> Dwarf_4_range_list.emit ~params range_list) !t

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/debug_ranges_table.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/debug_ranges_table.mli
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Representation of the DWARF-4 .debug_ranges table. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val create : unit -> t
+
+val insert
+   : t
+  -> range_list:Dwarf_4_range_list.t
+  -> Dwarf_attribute_values.Attribute_value.t

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list.ml
@@ -1,0 +1,66 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+
+type t = {
+  name : Asm_label.t;
+  entries : Dwarf_4_location_list_entry.t list;
+}
+
+(* It isn't exactly clear what the sorting requirement is, but we sort
+   within a location list by increasing virtual memory address on the
+   start addresses of the entries. *)
+let sort entries =
+  List.sort Dwarf_4_location_list_entry.compare_ascending_vma entries
+
+let create ~location_list_entries =
+  { name = Asm_label.create (DWARF Debug_loc);
+    entries = sort location_list_entries;
+  }
+
+let label t = t.name
+
+let end_marker () =
+  Dwarf_value.absolute_address ~comment:"end marker" Targetint_extra.zero
+
+let size t =
+  let (+) = Dwarf_int.add in
+  let body_size =
+    List.fold_left (fun size entry ->
+        size + (Dwarf_4_location_list_entry.size entry))
+      (Dwarf_int.zero ())
+      t.entries
+  in
+  let end_marker = end_marker () in
+  body_size + Dwarf_value.size end_marker + Dwarf_value.size end_marker
+
+let compare_increasing_vma t1 t2 =
+  match t1.entries, t2.entries with
+  | t1_entry::_, t2_entry::_ ->
+    Dwarf_4_location_list_entry.compare_ascending_vma t1_entry t2_entry
+  | _ -> failwith "Location_list.compare on empty location list(s)"
+
+let emit ~params t =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  A.new_line ();
+  A.comment "Location list:";
+  A.define_label t.name;
+  List.iter (fun entry -> Dwarf_4_location_list_entry.emit ~params entry) t.entries;
+  (* DWARF-4 spec, section 2.6.2. *)
+  let end_marker = end_marker () in
+  Dwarf_value.emit ~params end_marker;
+  Dwarf_value.emit ~params end_marker

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list.mli
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF-4 location lists. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val create
+   : location_list_entries:Dwarf_4_location_list_entry.t list
+  -> t
+
+val label : t -> Asm_label.t
+val compare_increasing_vma : t -> t -> int

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list_entry.ml
@@ -1,0 +1,166 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Location_list_entry = struct
+  type t = {
+    start_of_code_symbol : Asm_symbol.t;
+    beginning_address_label : Asm_label.t;
+    beginning_address_offset : int option;
+    ending_address_label : Asm_label.t;
+    ending_address_offset : int option;
+    expr : Single_location_description.t;
+  }
+
+  let create ~start_of_code_symbol
+             ~first_address_when_in_scope
+             ~first_address_when_in_scope_offset
+             ~first_address_when_not_in_scope
+             ~first_address_when_not_in_scope_offset
+             ~single_location_description =
+    { start_of_code_symbol;
+      beginning_address_label = first_address_when_in_scope;
+      beginning_address_offset = first_address_when_in_scope_offset;
+      ending_address_label = first_address_when_not_in_scope;
+      ending_address_offset = first_address_when_not_in_scope_offset;
+      expr = single_location_description;
+    }
+
+  let expr_size t =
+    let size = Single_location_description.size t.expr in
+    let size = Dwarf_int.to_int64 size in
+    (* CR-someday mshinwell: maybe this size should be unsigned? *)
+    assert (Int64.compare size 0xffffL < 0);
+    Numbers_extra.Int16.of_int64_exn size
+
+  let beginning_value t =
+    let offset_upper =
+      match t.beginning_address_offset with
+      | None -> Targetint_extra.zero
+      | Some offset -> Targetint_extra.of_int_exn offset
+    in
+    Dwarf_value.code_address_from_label_symbol_diff
+      ~comment:"beginning address"
+      ~upper:t.beginning_address_label
+      ~lower:t.start_of_code_symbol
+      ~offset_upper
+      ()
+
+  let ending_value t =
+    let offset_upper =
+      match t.ending_address_offset with
+      | None ->
+        (* It might seem as if this should be "-1", but actually not.
+           DWARF-4 spec p.30 (point 2):
+           "...the first address past the end of the address range over
+            which the location is valid." *)
+        Targetint_extra.zero
+      | Some offset -> Targetint_extra.of_int_exn offset
+    in
+    Dwarf_value.code_address_from_label_symbol_diff
+      ~comment:"ending address"
+      ~upper:t.ending_address_label
+      ~lower:t.start_of_code_symbol
+      ~offset_upper
+      ()
+
+  let size t =
+    let v1 = beginning_value t in
+    let v2 = ending_value t in
+    let v3 = Dwarf_value.int16 (expr_size t) in
+    let (+) = Dwarf_int.add in
+    Dwarf_value.size v1 + Dwarf_value.size v2 + Dwarf_value.size v3
+      + Single_location_description.size t.expr
+
+  let emit ~params t =
+    let module Params = (val params : Dwarf_params.S) in
+    let module A = Params.Asm_directives in
+    Dwarf_value.emit ~params (beginning_value t);
+    Dwarf_value.emit ~params (ending_value t);
+    A.int16 ~comment:"expression size" (expr_size t);
+    A.comment "Single location description (DWARF expression):";
+    Single_location_description.emit ~params t.expr
+end
+
+module Base_address_selection_entry = struct
+  type t = Asm_symbol.t
+
+  let create ~base_address_symbol = base_address_symbol
+
+  let to_dwarf_values t =
+    [Dwarf_value.absolute_address
+       ~comment:"largest representable addr. offset"
+       Targetint_extra.minus_one;  (* all "1"s *)
+     Dwarf_value.code_address_from_symbol ~comment:"base address" t;
+    ]
+
+  let size t =
+    List.fold_left (fun acc v -> Dwarf_int.add acc (Dwarf_value.size v))
+      (Dwarf_int.zero ())
+      (to_dwarf_values t)
+
+  let emit ~params t =
+    List.iter (fun v -> Dwarf_value.emit ~params v) (to_dwarf_values t)
+end
+
+type t =
+  | Location_list_entry of Location_list_entry.t
+  | Base_address_selection_entry of Base_address_selection_entry.t
+
+let create_location_list_entry ~start_of_code_symbol
+      ~first_address_when_in_scope
+      ~first_address_when_in_scope_offset
+      ~first_address_when_not_in_scope
+      ~first_address_when_not_in_scope_offset
+      ~single_location_description =
+  Location_list_entry (
+    Location_list_entry.create ~start_of_code_symbol
+      ~first_address_when_in_scope
+      ~first_address_when_in_scope_offset
+      ~first_address_when_not_in_scope
+      ~first_address_when_not_in_scope_offset
+      ~single_location_description)
+
+let create_base_address_selection_entry ~base_address_symbol =
+  Base_address_selection_entry (
+    Base_address_selection_entry.create ~base_address_symbol)
+
+let size = function
+  | Location_list_entry entry ->
+    Location_list_entry.size entry
+  | Base_address_selection_entry entry ->
+    Base_address_selection_entry.size entry
+
+let emit ~params t =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  match t with
+  | Location_list_entry entry ->
+    A.new_line ();
+    A.comment "Location list entry:";
+    Location_list_entry.emit ~params entry
+  | Base_address_selection_entry entry ->
+    A.comment "Base address selection entry:";
+    Base_address_selection_entry.emit ~params entry
+
+let compare_ascending_vma t1 t2 =
+  (* This relies on a certain ordering on labels.  See [Compute_ranges]. *)
+  match t1, t2 with
+  | Base_address_selection_entry _, Base_address_selection_entry _ ->
+    failwith "Location_list_entry.compare_ascending_vma: unsupported"
+  | Base_address_selection_entry _, Location_list_entry _ -> -1
+  | Location_list_entry _, Base_address_selection_entry _ -> 1
+  | Location_list_entry entry1, Location_list_entry entry2 ->
+    compare entry1.beginning_address_label entry2.beginning_address_label

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list_entry.mli
@@ -1,0 +1,33 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF location list entries. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val create_location_list_entry : start_of_code_symbol:Asm_symbol.t
+  -> first_address_when_in_scope:Asm_label.t
+  -> first_address_when_in_scope_offset:int option
+  -> first_address_when_not_in_scope:Asm_label.t
+  -> first_address_when_not_in_scope_offset:int option
+  -> single_location_description:Single_location_description.t
+  -> t
+
+val create_base_address_selection_entry : base_address_symbol:Asm_symbol.t -> t
+
+val compare_ascending_vma : t -> t -> int

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list.ml
@@ -1,0 +1,64 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+
+type t = {
+  name : Asm_label.t;
+  entries : Dwarf_4_range_list_entry.t list;
+}
+
+(* Same note as in location_list.ml. *)
+let sort entries =
+  List.sort Dwarf_4_range_list_entry.compare_ascending_vma entries
+
+let create ~range_list_entries =
+  { name = Asm_label.create (DWARF Debug_ranges);
+    entries = sort range_list_entries;
+  }
+
+let label t = t.name
+
+let end_marker () =
+  Dwarf_value.absolute_address ~comment:"end marker" Targetint_extra.zero
+
+let size t =
+  let (+) = Dwarf_int.add in
+  let body_size =
+    List.fold_left (fun size entry ->
+        size + (Dwarf_4_range_list_entry.size entry))
+      (Dwarf_int.zero ())
+      t.entries
+  in
+  let end_marker = end_marker () in
+  body_size + Dwarf_value.size end_marker + Dwarf_value.size end_marker
+
+let compare_increasing_vma t1 t2 =
+  match t1.entries, t2.entries with
+  | t1_entry::_, t2_entry::_ ->
+    Dwarf_4_range_list_entry.compare_ascending_vma t1_entry t2_entry
+  | _ -> failwith "Range_list.compare on empty range list(s)"
+
+let emit ~params t =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  A.new_line ();
+  A.comment "Range list:";
+  A.define_label t.name;
+  List.iter (fun entry -> Dwarf_4_range_list_entry.emit ~params entry) t.entries;
+  (* DWARF-4 spec, section 2.17.3 (p.39). *)
+  let end_marker = end_marker () in
+  Dwarf_value.emit ~params end_marker;
+  Dwarf_value.emit ~params end_marker

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list.mli
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF-4 range lists (DWARF-4 spec section 2.17.3). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val create
+   : range_list_entries:Dwarf_4_range_list_entry.t list
+  -> t
+
+val label : t -> Asm_label.t
+val compare_increasing_vma : t -> t -> int

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list_entry.ml
@@ -1,0 +1,135 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+
+module Range_list_entry = struct
+  type t = {
+    start_of_code_symbol : Asm_symbol.t;
+    beginning_address_label : Asm_label.t;
+    ending_address_label : Asm_label.t;
+    ending_address_offset : int option;
+  }
+
+  let create ~start_of_code_symbol
+             ~first_address_when_in_scope
+             ~first_address_when_not_in_scope
+             ~first_address_when_not_in_scope_offset =
+    { start_of_code_symbol;
+      beginning_address_label = first_address_when_in_scope;
+      ending_address_label = first_address_when_not_in_scope;
+      ending_address_offset = first_address_when_not_in_scope_offset;
+    }
+
+  let beginning_value t =
+    Dwarf_value.code_address_from_label_symbol_diff
+      ~comment:"beginning address"
+      ~upper:t.beginning_address_label
+      ~lower:t.start_of_code_symbol
+      ~offset_upper:Targetint_extra.zero
+      ()
+
+  let ending_value t =
+    let offset_upper =
+      match t.ending_address_offset with
+      | None ->
+        (* See note in location_list_entry.ml. *)
+        Targetint_extra.zero
+      | Some offset -> Targetint_extra.of_int_exn offset
+    in
+    Dwarf_value.code_address_from_label_symbol_diff
+      ~comment:"ending address"
+      ~upper:t.ending_address_label
+      ~lower:t.start_of_code_symbol
+      ~offset_upper
+      ()
+
+  let size t =
+    let v1 = beginning_value t in
+    let v2 = ending_value t in
+    let (+) = Dwarf_int.add in
+    Dwarf_value.size v1 + Dwarf_value.size v2
+
+  let emit ~params t =
+    Dwarf_value.emit ~params (beginning_value t);
+    Dwarf_value.emit ~params (ending_value t)
+end
+
+module Base_address_selection_entry = struct
+  type t = Asm_symbol.t
+
+  let create ~base_address_symbol = base_address_symbol
+
+  let to_dwarf_values t =
+    [Dwarf_value.absolute_address
+       ~comment:"largest representable addr. offset"
+       Targetint_extra.minus_one;  (* all "1"s *)
+     Dwarf_value.code_address_from_symbol ~comment:"base address" t;
+    ]
+
+  let size t =
+    List.fold_left (fun acc v -> Dwarf_int.add acc (Dwarf_value.size v))
+      (Dwarf_int.zero ())
+      (to_dwarf_values t)
+
+  let emit ~params t =
+    List.iter (fun v -> Dwarf_value.emit ~params v) (to_dwarf_values t)
+end
+
+type t =
+  | Range_list_entry of Range_list_entry.t
+  | Base_address_selection_entry of Base_address_selection_entry.t
+
+let create_range_list_entry ~start_of_code_symbol
+      ~first_address_when_in_scope
+      ~first_address_when_not_in_scope
+      ~first_address_when_not_in_scope_offset =
+  Range_list_entry (
+    Range_list_entry.create ~start_of_code_symbol
+      ~first_address_when_in_scope
+      ~first_address_when_not_in_scope
+      ~first_address_when_not_in_scope_offset)
+
+let create_base_address_selection_entry ~base_address_symbol =
+  Base_address_selection_entry (
+    Base_address_selection_entry.create ~base_address_symbol)
+
+let size = function
+  | Range_list_entry entry ->
+    Range_list_entry.size entry
+  | Base_address_selection_entry entry ->
+    Base_address_selection_entry.size entry
+
+let emit ~params t =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  match t with
+  | Range_list_entry entry ->
+    A.new_line ();
+    A.comment "Range list entry:";
+    Range_list_entry.emit ~params entry
+  | Base_address_selection_entry entry ->
+    A.comment "Base address selection entry:";
+    Base_address_selection_entry.emit ~params entry
+
+let compare_ascending_vma t1 t2 =
+  (* This relies on a certain ordering on labels.  See [Compute_ranges]. *)
+  match t1, t2 with
+  | Base_address_selection_entry _, Base_address_selection_entry _ ->
+    failwith "Range_list_entry.compare_ascending_vma: unsupported"
+  | Base_address_selection_entry _, Range_list_entry _ -> -1
+  | Range_list_entry _, Base_address_selection_entry _ -> 1
+  | Range_list_entry entry1, Range_list_entry entry2 ->
+    compare entry1.beginning_address_label entry2.beginning_address_label

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list_entry.mli
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF range list entries. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val create_range_list_entry : start_of_code_symbol:Asm_symbol.t
+  -> first_address_when_in_scope:Asm_label.t
+  -> first_address_when_not_in_scope:Asm_label.t
+  -> first_address_when_not_in_scope_offset:int option
+  -> t
+
+val create_base_address_selection_entry : base_address_symbol:Asm_symbol.t -> t
+
+val compare_ascending_vma : t -> t -> int

--- a/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.ml
@@ -1,0 +1,162 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+
+module Value = struct
+  type internal_t =
+    | Dwarf_value of Dwarf_value.t
+    (* Hack to break circular dependency. *)
+    | Single_location_description of Single_location_description.t
+    | Composite_location_description of Composite_location_description.t
+
+  type _ t = internal_t
+
+  module V = Dwarf_value
+
+  let flag_true ?comment () = Dwarf_value (V.flag_true ?comment ())
+  let bool ?comment b = Dwarf_value (V.bool ?comment b)
+  let int8 ?comment i = Dwarf_value (V.int8 ?comment i)
+  let int16 ?comment i = Dwarf_value (V.int16 ?comment i)
+  let int32 ?comment i = Dwarf_value (V.int32 ?comment i)
+  let int64 ?comment i = Dwarf_value (V.int64 ?comment i)
+  let uleb128 ?comment i = Dwarf_value (V.uleb128 ?comment i)
+  let string ?comment s = Dwarf_value (V.string ?comment s)
+  let indirect_string ?comment ptr =
+    Dwarf_value (V.indirect_string ?comment ptr)
+
+  let distance_between_symbols_32_bit ?comment ~upper ~lower () =
+    assert (Dwarf_arch_sizes.size_addr = 4);
+    Dwarf_value (V.code_address_from_symbol_diff ?comment ~upper ~lower ())
+
+  let distance_between_symbols_64_bit ?comment ~upper ~lower () =
+    assert (Dwarf_arch_sizes.size_addr = 8);
+    Dwarf_value (V.code_address_from_symbol_diff ?comment ~upper ~lower ())
+
+  let distance_between_labels_32_bit ?comment ~upper ~lower () =
+    Dwarf_value (V.distance_between_labels_32_bit ?comment ~upper ~lower ())
+
+  let distance_between_labels_64_bit ?comment ~upper ~lower () =
+    Dwarf_value (V.distance_between_labels_64_bit ?comment ~upper ~lower ())
+
+  let distance_between_label_and_symbol_32_bit ?comment ~upper ~lower () =
+    assert (Dwarf_arch_sizes.size_addr = 4);
+    Dwarf_value (V.code_address_from_label_symbol_diff ?comment
+      ~upper ~lower ~offset_upper:Targetint_extra.zero ())
+
+  let distance_between_label_and_symbol_64_bit ?comment ~upper ~lower () =
+    assert (Dwarf_arch_sizes.size_addr = 8);
+    Dwarf_value (V.code_address_from_label_symbol_diff ?comment
+      ~upper ~lower ~offset_upper:Targetint_extra.zero ())
+
+  let code_address_from_label ?comment lbl =
+    Dwarf_value (V.code_address_from_label ?comment lbl)
+  let code_address_from_symbol ?comment sym =
+    Dwarf_value (V.code_address_from_symbol ?comment sym)
+  let offset_into_debug_line lbl = Dwarf_value (V.offset_into_debug_line lbl)
+  let offset_into_debug_line_from_symbol sym =
+    Dwarf_value (V.offset_into_debug_line_from_symbol sym)
+  let offset_into_debug_info ?comment lbl =
+    Dwarf_value (V.offset_into_debug_info ?comment lbl)
+  let offset_into_debug_info_from_symbol ?comment sym =
+    Dwarf_value (V.offset_into_debug_info_from_symbol ?comment sym)
+  let offset_into_debug_loc lbl =
+    Dwarf_value (V.offset_into_debug_loc lbl)
+  let offset_into_debug_ranges lbl =
+    Dwarf_value (V.offset_into_debug_ranges lbl)
+  let offset_into_debug_addr lbl =
+    Dwarf_value (V.offset_into_debug_addr lbl)
+  let offset_into_debug_loclists lbl =
+    Dwarf_value (V.offset_into_debug_loclists lbl)
+  let offset_into_debug_rnglists lbl =
+    Dwarf_value (V.offset_into_debug_rnglists lbl)
+  let single_location_description sld = Single_location_description sld
+  let composite_location_description sld = Composite_location_description sld
+  let encoding_attribute attr =
+    Dwarf_value (Encoding_attribute.as_dwarf_value attr)
+
+  let symbol_32 sym =
+    Dwarf_value (V.code_address_from_symbol sym)
+
+  let symbol_64 sym =
+    Dwarf_value (V.code_address_from_symbol sym)
+
+  let loclistx ~index =
+    Dwarf_value (V.uleb128 index)
+
+  let rnglistx ~index =
+    Dwarf_value (V.uleb128 index)
+
+  let inline_code inline_code =
+    Dwarf_value (Inline_code.as_dwarf_value inline_code)
+
+  let language lang =
+    Dwarf_value (Dwarf_language.as_dwarf_value lang)
+end
+
+module Attribute_value = struct
+  (* CR mshinwell: Try to remove the attribute spec *)
+  type t =
+    Dwarf_attributes.Attribute_specification.Sealed.t * Value.internal_t
+
+  let create attr_spec value =
+    let attr_spec = Dwarf_attributes.Attribute_specification.seal attr_spec in
+    attr_spec, value
+
+  (* CR-someday mshinwell: as per CR above.  This shouldn't be here *)
+  let rec uleb128_size i =
+    assert (Int64.compare i 0L >= 0);
+    if Int64.compare i 128L < 0 then Dwarf_int.one ()
+    else Dwarf_int.succ (uleb128_size (Int64.shift_right_logical i 7))
+
+  let size ((_spec, value) : t) =
+    match value with
+    | Dwarf_value value -> Dwarf_value.size value
+    | Single_location_description loc_desc ->
+      let loc_desc_size = Single_location_description.size loc_desc in
+      Dwarf_int.add (uleb128_size (Dwarf_int.to_int64 loc_desc_size))
+        loc_desc_size
+    | Composite_location_description loc_desc ->
+      let loc_desc_size = Composite_location_description.size loc_desc in
+      Dwarf_int.add (uleb128_size (Dwarf_int.to_int64 loc_desc_size))
+        loc_desc_size
+
+  let emit ~params ((spec, value) : t) =
+    let module Params = (val params : Dwarf_params.S) in
+    let module A = Params.Asm_directives in
+    match value with
+    | Dwarf_value value ->
+      let value =
+        if not !Clflags.keep_asm_file then value
+        else
+          let comment =
+            Format.asprintf "(%a)"
+              Dwarf_attributes.Attribute_specification.Sealed.print spec
+          in
+          Dwarf_value.append_to_comment value comment
+      in
+      Dwarf_value.emit ~params value
+    | Single_location_description loc_desc ->
+      A.uleb128 ~comment:"size of single location desc."
+        (Dwarf_int.to_uint64_exn (Single_location_description.size loc_desc));
+      Single_location_description.emit ~params loc_desc
+    | Composite_location_description loc_desc ->
+      A.uleb128 ~comment:"size of composite location desc."
+        (Dwarf_int.to_uint64_exn
+          (Composite_location_description.size loc_desc));
+      Composite_location_description.emit ~params loc_desc
+
+  let attribute_spec (spec, _value) = spec
+end

--- a/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attribute_values.mli
@@ -1,0 +1,192 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** The values assigned to DWARF attributes. *)
+
+module Value : sig
+  type 'form t
+
+  val flag_true
+     : ?comment:string
+    -> unit
+    -> Dwarf_attributes.Form.flag_present t
+
+  val bool : ?comment:string -> bool -> Dwarf_attributes.Form.data1 t
+
+  val int8
+     : ?comment:string
+    -> Numbers_extra.Int8.t
+    -> Dwarf_attributes.Form.data1 t
+
+  val int16
+     : ?comment:string
+    -> Numbers_extra.Int16.t
+    -> Dwarf_attributes.Form.data2 t
+
+  val int32
+     : ?comment:string
+    -> Int32.t
+    -> Dwarf_attributes.Form.data4 t
+
+  val int64
+     : ?comment:string
+    -> Int64.t
+    -> Dwarf_attributes.Form.data8 t
+
+  val uleb128
+     : ?comment:string
+    -> Numbers_extra.Uint64.t
+    -> Dwarf_attributes.Form.udata t
+
+  val string : ?comment:string -> string -> Dwarf_attributes.Form.string t
+
+  val indirect_string
+     : ?comment:string
+    -> string
+    -> Dwarf_attributes.Form.strp t
+
+  val distance_between_symbols_32_bit
+     : ?comment:string
+    -> upper:Asm_symbol.t
+    -> lower:Asm_symbol.t
+    -> unit
+    -> Dwarf_attributes.Form.data4 t
+
+  val distance_between_symbols_64_bit
+     : ?comment:string
+    -> upper:Asm_symbol.t
+    -> lower:Asm_symbol.t
+    -> unit
+    -> Dwarf_attributes.Form.data8 t
+
+  val distance_between_labels_32_bit
+     : ?comment:string
+    -> upper:Asm_label.t
+    -> lower:Asm_label.t
+    -> unit
+    -> Dwarf_attributes.Form.data4 t
+
+  val distance_between_labels_64_bit
+     : ?comment:string
+    -> upper:Asm_label.t
+    -> lower:Asm_label.t
+    -> unit
+    -> Dwarf_attributes.Form.data8 t
+
+  val distance_between_label_and_symbol_32_bit
+     : ?comment:string
+    -> upper:Asm_label.t
+    -> lower:Asm_symbol.t
+    -> unit
+    -> Dwarf_attributes.Form.data4 t
+
+  val distance_between_label_and_symbol_64_bit
+     : ?comment:string
+    -> upper:Asm_label.t
+    -> lower:Asm_symbol.t
+    -> unit
+    -> Dwarf_attributes.Form.data8 t
+
+  val code_address_from_label
+     : ?comment:string
+    -> Asm_label.t
+    -> Dwarf_attributes.Form.addr t
+
+  val code_address_from_symbol
+     : ?comment:string
+    -> Asm_symbol.t
+    -> Dwarf_attributes.Form.addr t
+
+  val symbol_32 : Asm_symbol.t -> Dwarf_attributes.Form.data4 t
+  val symbol_64 : Asm_symbol.t -> Dwarf_attributes.Form.data8 t
+
+  val offset_into_debug_line
+     : Asm_label.t
+    -> Dwarf_attributes.Form.sec_offset t
+
+  val offset_into_debug_line_from_symbol
+     : Asm_symbol.t
+    -> Dwarf_attributes.Form.sec_offset t
+
+  val offset_into_debug_info
+     : ?comment:string
+    -> Asm_label.t
+    -> Dwarf_attributes.Form.ref_addr t
+
+  val offset_into_debug_info_from_symbol
+     : ?comment:string
+    -> Asm_symbol.t
+    -> Dwarf_attributes.Form.ref_addr t
+
+  (** Not for use for DWARF >= version 5. *)
+  val offset_into_debug_loc
+     : Asm_label.t
+    -> Dwarf_attributes.Form.sec_offset t
+ 
+  (** Not for use for DWARF >= version 5. *)
+  val offset_into_debug_ranges
+     : Asm_label.t
+    -> Dwarf_attributes.Form.sec_offset t
+
+  (** Not for use for DWARF < version 5. *)
+  val offset_into_debug_addr
+     : Asm_label.t
+    -> Dwarf_attributes.Form.sec_offset t
+
+  (** Not for use for DWARF < version 5. *)
+  val offset_into_debug_loclists
+     : Asm_label.t
+    -> Dwarf_attributes.Form.sec_offset t
+
+  (** Not for use for DWARF < version 5. *)
+  val offset_into_debug_rnglists
+     : Asm_label.t
+    -> Dwarf_attributes.Form.sec_offset t
+
+  val single_location_description
+     : Single_location_description.t
+    -> Dwarf_attributes.Form.exprloc t
+
+  val composite_location_description
+     : Composite_location_description.t
+    -> Dwarf_attributes.Form.exprloc t
+
+  val encoding_attribute
+     : Encoding_attribute.t
+    -> Dwarf_attributes.Form.data1 t
+
+  (** Not for use for DWARF < version 5. *)
+  val loclistx : index:Numbers_extra.Uint64.t -> Dwarf_attributes.Form.loclistx t
+
+  (** Not for use for DWARF < version 5. *)
+  val rnglistx : index:Numbers_extra.Uint64.t -> Dwarf_attributes.Form.rnglistx t
+
+  val inline_code : Inline_code.t -> Dwarf_attributes.Form.data1 t
+
+  val language : Dwarf_language.t -> Dwarf_attributes.Form.data1 t
+end
+
+module Attribute_value : sig
+  type t
+
+  val create : 'form Dwarf_attributes.Attribute_specification.t
+    -> 'form Value.t
+    -> t
+
+  val attribute_spec : t -> Dwarf_attributes.Attribute_specification.Sealed.t
+
+  include Dwarf_emittable.S with type t := t
+end

--- a/backend/debug/dwarf/dwarf_low/dwarf_attributes.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attributes.ml
@@ -1,0 +1,816 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Uint64 = Numbers_extra.Uint64
+
+module Class = struct
+  type address = [ `address ]
+  type addrptr = [ `addrptr ]
+  type block = [ `block ]
+  type constant = [ `constant ]
+  type exprloc = [ `exprloc ]
+  type flag = [ `flag ]
+  type lineptr = [ `lineptr ]
+  type loclist = [ `loclist ]
+  type loclistsptr = [ `loclistsptr ]
+  type macptr = [ `macptr ]
+  type rnglist = [ `rnglist ]
+  type rnglistsptr = [ `rnglistsptr ]
+  type reference = [ `reference ]
+  type string = [ `string ]
+  type stroffsetsptr = [ `stroffsetsptr ]
+
+  module Dwarf_4 = struct
+    type loclistptr = [ `loclistptr ]
+    type rangelistptr = [ `rangelistptr ]
+  end
+end
+
+module Form = struct
+  type addr = [ `addr ]
+  type block = [ `block ]
+  type block1 = [ `block1 ]
+  type block2 = [ `block2 ]
+  type block4 = [ `block4 ]
+  type data1 = [ `data1 ]
+  type data2 = [ `data2 ]
+  type data4 = [ `data4 ]
+  type data8 = [ `data8 ]
+  type string = [ `string ]
+  type flag = [ `flag ]
+  type sdata = [ `sdata ]
+  type strp = [ `strp ]
+  type udata = [ `udata ]
+  type ref_addr = [ `ref_addr ]
+  type ref1 = [ `ref1 ]
+  type ref2 = [ `ref2 ]
+  type ref4 = [ `ref4 ]
+  type ref8 = [ `ref8 ]
+  type ref_udata = [ `ref_udata ]
+  type indirect = [ `indirect ]
+  type sec_offset = [ `sec_offset ]
+  type exprloc = [ `exprloc ]
+  type flag_present = [ `flag_present ]
+  type strx = [ `strx ]
+  type addrx = [ `addrx ]
+  type ref_sup4 = [ `ref_sup4 ]
+  type strp_sup = [ `strp_sup ]
+  type data16 = [ `data16 ]
+  type line_strp = [ `line_strp ]
+  type ref_sig8 = [ `ref_sig8 ]
+  type implicit_const = [ `implicit_const ]
+  type loclistx = [ `loclistx ]
+  type rnglistx = [ `rnglistx ]
+  type ref_sup8 = [ `ref_sup8 ]
+  type strx1 = [ `strx1 ]
+  type strx2 = [ `strx2 ]
+  type strx3 = [ `strx3 ]
+  type strx4 = [ `strx4 ]
+  type addrx1 = [ `addrx1 ]
+  type addrx2 = [ `addrx2 ]
+  type addrx3 = [ `addrx3 ]
+  type addrx4 = [ `addrx4 ]
+
+  module Dwarf_4 = struct
+    type ('dwarf_classes, 'form) t =
+      | Sec_offset_loclistptr : (Class.Dwarf_4.loclistptr, sec_offset) t
+      | Sec_offset_rangelistptr : (Class.Dwarf_4.rangelistptr, sec_offset) t
+  end
+
+  type ('dwarf_classes, 'form) t =
+    | Addr : (Class.address, addr) t
+    | Block : (Class.block, block) t
+    | Block1 : (Class.block, block1) t
+    | Block2 : (Class.block, [< block1 | block2 ]) t
+    | Block4 : (Class.block, [< block1 | block2 | block4 ]) t
+    | Data1 : (Class.constant, data1) t
+    | Data2 : (Class.constant, [< data1 | data2 ]) t
+    | Data4 : (Class.constant, [< data1 | data2 | data4 ]) t
+    | Data8 : (Class.constant, [< data1 | data2 | data4 | data8 ]) t
+    | String : (Class.string, string) t
+    | Flag : (Class.flag, data1) t
+    | Sdata : (Class.constant, sdata) t
+    | Strp : (Class.string, strp) t
+    | Udata : (Class.constant, udata) t
+    | Ref_addr : (Class.reference, ref_addr) t
+    | Ref1 : (Class.reference, ref1) t
+    | Ref2 : (Class.reference, [< ref1 | ref2 ]) t
+    | Ref4 : (Class.reference, [< ref1 | ref2 | ref4 ]) t
+    | Ref8 : (Class.reference, [< ref1 | ref2 | ref4 | ref8 ]) t
+    | Ref_udata : (Class.reference, ref_udata) t
+    (* [DW_FORM_indirect] is not currently supported because it cannot be
+       statically-typed in the manner we use here. *)
+    | Sec_offset_addrptr : (Class.addrptr, sec_offset) t
+    | Sec_offset_lineptr : (Class.lineptr, sec_offset) t
+    | Sec_offset_loclist : (Class.loclist, sec_offset) t
+    | Sec_offset_loclistsptr : (Class.loclistsptr, sec_offset) t
+    | Sec_offset_macptr : (Class.macptr, sec_offset) t
+    | Sec_offset_rnglist : (Class.rnglist, sec_offset) t
+    | Sec_offset_rnglistsptr : (Class.rnglistsptr, sec_offset) t
+    | Sec_offset_stroffsetsptr : (Class.stroffsetsptr, sec_offset) t
+    | Exprloc : (Class.exprloc, exprloc) t
+    | Flag_present : (Class.flag, flag_present) t
+    | Strx : (Class.string, strx) t
+    | Addrx : (Class.address, addrx) t
+    | Ref_sup4 : (Class.reference, ref_sup4) t
+    | Strp_sup : (Class.string, strp_sup) t
+    | Data16 : (Class.constant, data16) t
+    | Line_strp : (Class.string, line_strp) t
+    | Ref_sig8 : (Class.reference, ref_sig8) t
+    | Implicit_const : (Class.constant, implicit_const) t
+    | Loclistx : (Class.loclist, loclistx) t
+    | Rnglistx : (Class.rnglist, rnglistx) t
+    | Ref_sup8 : (Class.reference, ref_sup8) t
+    | Strx1 : (Class.string, strx1) t
+    | Strx2 : (Class.string, strx2) t
+    | Strx3 : (Class.string, strx3) t
+    | Strx4 : (Class.string, strx4) t
+    | Addrx1 : (Class.string, addrx1) t
+    | Addrx2 : (Class.string, addrx2) t
+    | Addrx3 : (Class.string, addrx3) t
+    | Addrx4 : (Class.string, addrx4) t
+    | Dwarf_4 : ('dwarf_classes, 'form) Dwarf_4.t -> ('dwarf_classes, 'form) t
+
+  let name (type dwarf_class) (type form) (t : (dwarf_class, form) t) =
+    let name =
+      match t with
+      | Addr -> "addr"
+      | Block -> "block"
+      | Block1 -> "block1"
+      | Block2 -> "block2"
+      | Block4 -> "block4"
+      | Data1 -> "data1"
+      | Data2 -> "data2"
+      | Data4 -> "data4"
+      | Data8 -> "data8"
+      | String -> "string"
+      | Flag -> "flag"
+      | Sdata -> "sdata"
+      | Strp -> "strp"
+      | Udata -> "udata"
+      | Ref_addr -> "ref_addr"
+      | Ref1 -> "ref1"
+      | Ref2 -> "ref2"
+      | Ref4 -> "ref4"
+      | Ref8 -> "ref8"
+      | Ref_udata -> "ref_udata"
+      | Sec_offset_addrptr -> "sec_offset_addrptr"
+      | Sec_offset_lineptr -> "sec_offset_lineptr"
+      | Sec_offset_loclist -> "sec_offset_loclist"
+      | Sec_offset_loclistsptr -> "sec_offset_loclistsptr"
+      | Sec_offset_macptr -> "sec_offset_macptr"
+      | Sec_offset_rnglist -> "sec_offset_rnglist"
+      | Sec_offset_rnglistsptr -> "sec_offset_rnglistsptr"
+      | Sec_offset_stroffsetsptr -> "sec_offset_stroffsetsptr"
+      | Exprloc -> "exprloc"
+      | Flag_present -> "flag_present"
+      | Strx -> "strx"
+      | Addrx -> "addrx"
+      | Ref_sup4 -> "ref_sup4"
+      | Strp_sup -> "strp_sup"
+      | Data16 -> "data16"
+      | Line_strp -> "line_strp"
+      | Ref_sig8 -> "ref_sig8"
+      | Implicit_const -> "implicit_const"
+      | Loclistx -> "loclistx"
+      | Rnglistx -> "rnglistx"
+      | Ref_sup8 -> "ref_sup8"
+      | Strx1 -> "strx1"
+      | Strx2 -> "strx2"
+      | Strx3 -> "strx3"
+      | Strx4 -> "strx4"
+      | Addrx1 -> "addrx1"
+      | Addrx2 -> "addrx2"
+      | Addrx3 -> "addrx3"
+      | Addrx4 -> "addrx4"
+      | Dwarf_4 Sec_offset_loclistptr -> "sec_offset_loclistptr"
+      | Dwarf_4 Sec_offset_rangelistptr -> "sec_offset_rangelistptr"
+    in
+    "DW_FORM_" ^ name
+
+  let encode (type dwarf_class) (type form) (t : (dwarf_class, form) t) =
+    let code =
+      (* DWARF-4 standard page 160 onwards. *)
+      match t with
+      | Addr -> 0x01
+      | Block -> 0x09
+      | Block1 -> 0x0a
+      | Block2 -> 0x03
+      | Block4 -> 0x04
+      | Data1 -> 0x0b
+      | Data2 -> 0x05
+      | Data4 -> 0x06
+      | Data8 -> 0x07
+      | String -> 0x08
+      | Flag -> 0x0c
+      | Sdata -> 0x0d
+      | Strp -> 0x0e
+      | Udata -> 0x0f
+      | Ref_addr -> 0x10
+      | Ref1 -> 0x11
+      | Ref2 -> 0x12
+      | Ref4 -> 0x13
+      | Ref8 -> 0x14
+      | Ref_udata -> 0x15
+      | Sec_offset_addrptr -> 0x17
+      | Sec_offset_lineptr -> 0x17
+      | Sec_offset_loclist -> 0x17
+      | Sec_offset_loclistsptr -> 0x17
+      | Sec_offset_macptr -> 0x17
+      | Sec_offset_rnglist -> 0x17
+      | Sec_offset_rnglistsptr -> 0x17
+      | Sec_offset_stroffsetsptr -> 0x17
+      | Exprloc -> 0x18
+      | Flag_present -> 0x19
+      | Strx -> 0x1a
+      | Addrx -> 0x1b
+      | Ref_sup4 -> 0x1c
+      | Strp_sup -> 0x1d
+      | Data16 -> 0x1e
+      | Line_strp -> 0x1f
+      | Ref_sig8 -> 0x20
+      | Implicit_const -> 0x21
+      | Loclistx -> 0x22
+      | Rnglistx -> 0x23
+      | Ref_sup8 -> 0x24
+      | Strx1 -> 0x25
+      | Strx2 -> 0x26
+      | Strx3 -> 0x27
+      | Strx4 -> 0x28
+      | Addrx1 -> 0x29
+      | Addrx2 -> 0x2a
+      | Addrx3 -> 0x2b
+      | Addrx4 -> 0x2c
+      | Dwarf_4 Sec_offset_loclistptr -> 0x17
+      | Dwarf_4 Sec_offset_rangelistptr -> 0x17
+    in
+    Dwarf_value.uleb128 ~comment:(name t) (Uint64.of_nonnegative_int_exn code)
+
+  let size t =
+    Dwarf_value.size (encode t)
+
+  let emit ~params t =
+    Dwarf_value.emit ~params (encode t)
+end
+
+module Attribute = struct
+  module Dwarf_4 = struct
+    type 'dwarf_classes t =
+      | Location : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | String_length : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Return_addr : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Start_scope : [< Class.constant | Class.Dwarf_4.rangelistptr ] t
+      | Data_member_location :
+          [< Class.constant | Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Frame_base : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Segment : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Static_link : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Use_location : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Vtable_elem_location : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Ranges : Class.Dwarf_4.rangelistptr t
+      | GNU_call_site_value : Class.exprloc t
+      | GNU_call_site_data_value : Class.exprloc t
+      | GNU_call_site_target : Class.exprloc t
+      | GNU_call_site_target_clobbered : Class.exprloc t
+      | GNU_tail_call : Class.flag t
+      | GNU_all_tail_call_sites : Class.flag t
+      | GNU_all_call_sites : Class.flag t
+      | GNU_all_source_call_sites : Class.flag t
+  end
+
+  module Ocaml_specific = struct
+    type 'dwarf_classes t =
+      | Compiler_version : Class.string t
+      | Unit_name : Class.string t
+      | Config_digest : Class.string t
+      | Prefix_name : Class.string t
+      | Linker_dirs : Class.string t
+      | Cmt_file_digest : Class.string t
+  end
+
+  type 'dwarf_classes t =
+    | Sibling : Class.reference t
+    | Location : [< Class.exprloc | Class.loclist ] t
+    | Name : Class.string t
+    | Ordering : Class.constant t
+    | Byte_size : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Bit_offset : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Bit_size : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Stmt_list : Class.lineptr t
+    | Low_pc : Class.address t
+    | High_pc : [< Class.address | Class.constant ] t
+    | Language : Class.constant t
+    | Discr : Class.reference t
+    | Discr_value : Class.constant t
+    | Visibility : Class.constant t
+    | Import : Class.reference t
+    | String_length : [< Class.exprloc | Class.loclistsptr ] t
+    | Common_reference : Class.reference t
+    | Comp_dir : Class.string t
+    | Const_value : [< Class.block | Class.constant | Class.string ] t
+    | Containing_type : Class.reference t
+    | Default_value : Class.reference t
+    | Inline : Class.constant t
+    | Is_optional : Class.flag t
+    | Lower_bound : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Producer : Class.string t
+    | Prototyped : Class.flag t
+    | Return_addr : [< Class.exprloc | Class.loclistsptr ] t
+    | Start_scope : [< Class.constant | Class.rnglistsptr ] t
+    | Bit_stride : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Upper_bound : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Abstract_origin : Class.reference t
+    | Accessibility : Class.constant t
+    | Address_class : Class.constant t
+    | Artificial : Class.flag t
+    | Base_types : Class.reference t
+    | Calling_convention : Class.constant t
+    | Count : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Data_member_location :
+        [< Class.constant | Class.exprloc | Class.loclistsptr ] t
+    | Decl_column : Class.constant t
+    | Decl_file : Class.constant t
+    | Decl_line : Class.constant t
+    | Declaration : Class.flag t
+    | Discr_list : Class.block t
+    | Encoding : Class.constant t
+    | External : Class.flag t
+    | Frame_base : [< Class.exprloc | Class.loclistsptr ] t
+    | Friend : Class.reference t
+    | Identifier_case : Class.constant t
+    | Macro_info : Class.macptr t
+    | Namelist_item : Class.reference t
+    | Priority : Class.reference t
+    | Segment : [< Class.exprloc | Class.loclistsptr ] t
+    | Specification : Class.reference t
+    | Static_link : [< Class.exprloc | Class.loclistsptr ] t
+    | Type : Class.reference t
+    | Use_location : [< Class.exprloc | Class.loclistsptr ] t
+    | Variable_parameter : Class.flag t
+    | Virtuality : Class.constant t
+    | Vtable_elem_location : [< Class.exprloc | Class.loclistsptr ] t
+    | Allocated : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Associated : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Data_location : Class.exprloc t
+    | Byte_stride : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Entry_pc : Class.address t
+    | Use_UTF8 : Class.flag t
+    | Extension : Class.reference t
+    | Ranges : Class.rnglist t
+    | Trampoline :
+        [< Class.address | Class.flag | Class.reference | Class.string ] t
+    | Call_column : Class.constant t
+    | Call_file : Class.constant t
+    | Call_line : Class.constant t
+    | Description : Class.string t
+    | Binary_scale : Class.constant t
+    | Decimal_scale : Class.constant t
+    | Small : Class.reference t
+    | Decimal_sign : Class.constant t
+    | Digit_count : Class.constant t
+    | Picture_string : Class.string t
+    | Mutable : Class.flag t
+    | Threads_scaled : Class.flag t
+    | Explicit : Class.flag t
+    | Object_pointer : Class.reference t
+    | Endianity : Class.constant t
+    | Elemental : Class.flag t
+    | Pure : Class.flag t
+    | Recursive : Class.flag t
+    | Signature : Class.reference t
+    | Main_subprogram : Class.flag t
+    | Data_bit_offset : Class.constant t
+    | Const_expr : Class.flag t
+    | Enum_class : Class.flag t
+    | Linkage_name : Class.string t
+    | String_length_bit_size : Class.constant t
+    | String_length_byte_size : Class.constant t
+    | Rank : Class.exprloc t
+    | Str_offsets_base : Class.stroffsetsptr t
+    | Addr_base : Class.addrptr t
+    | Rnglists_base : Class.rnglistsptr t
+    | Dwo_name : Class.string t
+    | Reference : Class.flag t
+    | Rvalue_reference : Class.flag t
+    | Macros : Class.macptr t
+    | Call_all_calls : Class.flag t
+    | Call_all_source_calls : Class.flag t
+    | Call_all_tail_calls : Class.flag t
+    | Call_return_pc : Class.address t
+    | Call_value : Class.exprloc t
+    | Call_origin : Class.reference t
+    | Call_parameter : Class.reference t
+    | Call_pc : Class.address t
+    | Call_tail_call : Class.flag t
+    | Call_target : Class.exprloc t
+    | Call_target_clobbered : Class.exprloc t
+    | Call_data_location : Class.exprloc t
+    | Call_data_value : Class.exprloc t
+    | Noreturn : Class.flag t
+    | Alignment : Class.constant t
+    | Export_symbols : Class.flag t
+    | Deleted : Class.flag t
+    | Defaulted : Class.constant t
+    | Loclists_base : Class.loclistsptr t
+    | Dwarf_4 : 'dwarf_classes Dwarf_4.t -> 'dwarf_classes t
+    | Ocaml_specific : 'dwarf_classes Ocaml_specific.t -> 'dwarf_classes t
+
+  let name (type dwarf_class) (t : dwarf_class t) =
+    let name =
+      match t with
+      | Sibling -> "sibling"
+      | Location -> "location"
+      | Name -> "name"
+      | Ordering -> "ordering"
+      | Byte_size -> "byte_size"
+      | Bit_offset -> "bit_offset"
+      | Bit_size -> "bit_size"
+      | Stmt_list -> "stmt_list"
+      | Low_pc -> "low_pc"
+      | High_pc -> "high_pc"
+      | Language -> "language"
+      | Discr -> "discr"
+      | Discr_value -> "discr_value"
+      | Visibility -> "visibility"
+      | Import -> "import"
+      | String_length -> "string_length"
+      | Common_reference -> "common_reference"
+      | Comp_dir -> "comp_dir"
+      | Const_value -> "const_value"
+      | Containing_type -> "containing_type"
+      | Default_value -> "default_value"
+      | Inline -> "inline"
+      | Is_optional -> "is_optional"
+      | Lower_bound -> "lower_bound"
+      | Producer -> "producer"
+      | Prototyped -> "prototyped"
+      | Return_addr -> "return_addr"
+      | Start_scope -> "start_scope"
+      | Bit_stride -> "bit_stride"
+      | Upper_bound -> "upper_bound"
+      | Abstract_origin -> "abstract_origin"
+      | Accessibility -> "accessibility"
+      | Address_class -> "address_class"
+      | Artificial -> "artificial"
+      | Base_types -> "base_types"
+      | Calling_convention -> "calling_convention"
+      | Count -> "count"
+      | Data_member_location -> "data_member_location"
+      | Decl_column -> "decl_column"
+      | Decl_file -> "decl_file"
+      | Decl_line -> "decl_line"
+      | Declaration -> "declaration"
+      | Discr_list -> "discr_list"
+      | Encoding -> "encoding"
+      | External -> "external"
+      | Frame_base -> "frame_base"
+      | Friend -> "friend"
+      | Identifier_case -> "identifier_case"
+      | Macro_info -> "macro_info"
+      | Namelist_item -> "namelist_item"
+      | Priority -> "priority"
+      | Segment -> "segment"
+      | Specification -> "specification"
+      | Static_link -> "static_link"
+      | Type -> "type"
+      | Use_location -> "use_location"
+      | Variable_parameter -> "variable_parameter"
+      | Virtuality -> "virtuality"
+      | Vtable_elem_location -> "vtable_elem_location"
+      | Allocated -> "allocated"
+      | Associated -> "associated"
+      | Data_location -> "data_location"
+      | Byte_stride -> "byte_stride"
+      | Entry_pc -> "entry_pc"
+      | Use_UTF8 -> "use_utf8"
+      | Extension -> "extension"
+      | Ranges -> "ranges"
+      | Trampoline -> "trampoline"
+      | Call_column -> "call_column"
+      | Call_file -> "call_file"
+      | Call_line -> "call_line"
+      | Description -> "description"
+      | Binary_scale -> "binary_scale"
+      | Decimal_scale -> "decimal_scale"
+      | Small -> "small"
+      | Decimal_sign -> "decimal_sign"
+      | Digit_count -> "digit_count"
+      | Picture_string -> "picture_string"
+      | Mutable -> "mutable"
+      | Threads_scaled -> "threads_scaled"
+      | Explicit -> "explicit"
+      | Object_pointer -> "object_pointer"
+      | Endianity -> "endianity"
+      | Elemental -> "elemental"
+      | Pure -> "pure"
+      | Recursive -> "recursive"
+      | Signature -> "signature"
+      | Main_subprogram -> "main_subprogram"
+      | Data_bit_offset -> "data_bit_offset"
+      | Const_expr -> "const_expr"
+      | Enum_class -> "enum_class"
+      | Linkage_name -> "linkage_name"
+      | String_length_bit_size -> "string_length_bit_size"
+      | String_length_byte_size -> "string_length_byte_size"
+      | Rank -> "rank"
+      | Str_offsets_base -> "str_offsets_base"
+      | Addr_base -> "addr_base"
+      | Rnglists_base -> "rnglists_base"
+      | Dwo_name -> "dwo_name"
+      | Reference -> "reference"
+      | Rvalue_reference -> "rvalue_reference"
+      | Macros -> "macros"
+      | Call_all_calls -> "call_all_calls"
+      | Call_all_source_calls -> "call_all_source_calls"
+      | Call_all_tail_calls -> "call_all_tail_calls"
+      | Call_return_pc -> "call_return_pc"
+      | Call_value -> "call_value"
+      | Call_origin -> "call_origin"
+      | Call_parameter -> "call_parameter"
+      | Call_pc -> "call_pc"
+      | Call_tail_call -> "call_tail_call"
+      | Call_target -> "call_target"
+      | Call_target_clobbered -> "call_target_clobbered"
+      | Call_data_location -> "call_data_location"
+      | Call_data_value -> "call_data_value"
+      | Noreturn -> "noreturn"
+      | Alignment -> "alignment"
+      | Export_symbols -> "export_symbols"
+      | Deleted -> "deleted"
+      | Defaulted -> "defaulted"
+      | Loclists_base -> "loclists_base"
+      | Dwarf_4 Location -> "location"
+      | Dwarf_4 String_length -> "string_length"
+      | Dwarf_4 Return_addr -> "return_addr"
+      | Dwarf_4 Start_scope -> "start_scope"
+      | Dwarf_4 Data_member_location -> "data_member_location"
+      | Dwarf_4 Frame_base -> "frame_base"
+      | Dwarf_4 Segment -> "segment"
+      | Dwarf_4 Static_link -> "static_link"
+      | Dwarf_4 Use_location -> "use_location"
+      | Dwarf_4 Vtable_elem_location -> "vtable_elem_location"
+      | Dwarf_4 Ranges -> "ranges"
+      | Dwarf_4 GNU_call_site_value -> "GNU_call_site_value"
+      | Dwarf_4 GNU_call_site_data_value -> "GNU_call_site_data_value"
+      | Dwarf_4 GNU_call_site_target -> "GNU_call_site_target"
+      | Dwarf_4 GNU_call_site_target_clobbered ->
+        "GNU_call_site_target_clobbered"
+      | Dwarf_4 GNU_tail_call -> "GNU_tail_call"
+      | Dwarf_4 GNU_all_tail_call_sites -> "GNU_all_tail_call_sites"
+      | Dwarf_4 GNU_all_call_sites -> "GNU_all_call_sites"
+      | Dwarf_4 GNU_all_source_call_sites -> "GNU_all_source_call_sites"
+      | Ocaml_specific Compiler_version -> "Ocaml_compiler_version"
+      | Ocaml_specific Unit_name -> "Ocaml_unit_name"
+      | Ocaml_specific Config_digest -> "Ocaml_config_digest"
+      | Ocaml_specific Prefix_name -> "Ocaml_prefix_name"
+      | Ocaml_specific Linker_dirs -> "Ocaml_linker_dirs"
+      | Ocaml_specific Cmt_file_digest -> "Ocaml_cmt_file_digest"
+    in
+    "DW_AT_" ^ name
+
+  let code (type dwarf_class) (t : dwarf_class t) =
+    match t with
+    | Sibling -> 0x01
+    | Location -> 0x02
+    | Name -> 0x03
+    | Ordering -> 0x09
+    | Byte_size -> 0x0b
+    | Bit_offset -> 0x0c
+    | Bit_size -> 0x0d
+    | Stmt_list -> 0x10
+    | Low_pc -> 0x11
+    | High_pc -> 0x12
+    | Language -> 0x13
+    | Discr -> 0x15
+    | Discr_value -> 0x16
+    | Visibility -> 0x17
+    | Import -> 0x18
+    | String_length -> 0x19
+    | Common_reference -> 0x1a
+    | Comp_dir -> 0x1b
+    | Const_value -> 0x1c
+    | Containing_type -> 0x1d
+    | Default_value -> 0x1e
+    | Inline -> 0x20
+    | Is_optional -> 0x21
+    | Lower_bound -> 0x22
+    | Producer -> 0x25
+    | Prototyped -> 0x27
+    | Return_addr -> 0x2a
+    | Start_scope -> 0x2c
+    | Bit_stride -> 0x2e
+    | Upper_bound -> 0x2f
+    | Abstract_origin -> 0x31
+    | Accessibility -> 0x32
+    | Address_class -> 0x33
+    | Artificial -> 0x34
+    | Base_types -> 0x35
+    | Calling_convention -> 0x36
+    | Count -> 0x37
+    | Data_member_location -> 0x38
+    | Decl_column -> 0x39
+    | Decl_file -> 0x3a
+    | Decl_line -> 0x3b
+    | Declaration -> 0x3c
+    | Discr_list -> 0x3d
+    | Encoding -> 0x3e
+    | External -> 0x3f
+    | Frame_base -> 0x40
+    | Friend -> 0x41
+    | Identifier_case -> 0x42
+    | Macro_info -> 0x43
+    | Namelist_item -> 0x44
+    | Priority -> 0x45
+    | Segment -> 0x46
+    | Specification -> 0x47
+    | Static_link -> 0x48
+    | Type -> 0x49
+    | Use_location -> 0x4a
+    | Variable_parameter -> 0x4b
+    | Virtuality -> 0x4c
+    | Vtable_elem_location -> 0x4d
+    | Allocated -> 0x4e
+    | Associated -> 0x4f
+    | Data_location -> 0x50
+    | Byte_stride -> 0x51
+    | Entry_pc -> 0x52
+    | Use_UTF8 -> 0x53
+    | Extension -> 0x54
+    | Ranges -> 0x55
+    | Trampoline -> 0x56
+    | Call_column -> 0x57
+    | Call_file -> 0x58
+    | Call_line -> 0x59
+    | Description -> 0x5a
+    | Binary_scale -> 0x5b
+    | Decimal_scale -> 0x5c
+    | Small -> 0x5d
+    | Decimal_sign -> 0x5e
+    | Digit_count -> 0x5f
+    | Picture_string -> 0x60
+    | Mutable -> 0x61
+    | Threads_scaled -> 0x62
+    | Explicit -> 0x63
+    | Object_pointer -> 0x64
+    | Endianity -> 0x65
+    | Elemental -> 0x66
+    | Pure -> 0x67
+    | Recursive -> 0x68
+    | Signature -> 0x69
+    | Main_subprogram -> 0x6a
+    | Data_bit_offset -> 0x6b
+    | Const_expr -> 0x6c
+    | Enum_class -> 0x6d
+    | Linkage_name -> 0x6e
+    | String_length_bit_size -> 0x6f
+    | String_length_byte_size -> 0x70
+    | Rank -> 0x71
+    | Str_offsets_base -> 0x72
+    | Addr_base -> 0x73
+    | Rnglists_base -> 0x74
+    | Dwo_name -> 0x76
+    | Reference -> 0x77
+    | Rvalue_reference -> 0x78
+    | Macros -> 0x79
+    | Call_all_calls -> 0x7a
+    | Call_all_source_calls -> 0x7b
+    | Call_all_tail_calls -> 0x7c
+    | Call_return_pc -> 0x7d
+    | Call_value -> 0x7e
+    | Call_origin -> 0x7f
+    | Call_parameter -> 0x80
+    | Call_pc -> 0x81
+    | Call_tail_call -> 0x82
+    | Call_target -> 0x83
+    | Call_target_clobbered -> 0x84
+    | Call_data_location -> 0x85
+    | Call_data_value -> 0x86
+    | Noreturn -> 0x87
+    | Alignment -> 0x88
+    | Export_symbols -> 0x89
+    | Deleted -> 0x8a
+    | Defaulted -> 0x8b
+    | Loclists_base -> 0x8c
+    | Dwarf_4 Location -> 0x02
+    | Dwarf_4 String_length -> 0x19
+    | Dwarf_4 Return_addr -> 0x2a
+    | Dwarf_4 Start_scope -> 0x2c
+    | Dwarf_4 Data_member_location -> 0x38
+    | Dwarf_4 Frame_base -> 0x40
+    | Dwarf_4 Segment -> 0x46
+    | Dwarf_4 Static_link -> 0x48
+    | Dwarf_4 Use_location -> 0x4a
+    | Dwarf_4 Vtable_elem_location -> 0x4d
+    | Dwarf_4 Ranges -> 0x55
+    | Dwarf_4 GNU_call_site_value -> 0x2111
+    | Dwarf_4 GNU_call_site_data_value -> 0x2112
+    | Dwarf_4 GNU_call_site_target -> 0x2113
+    | Dwarf_4 GNU_call_site_target_clobbered -> 0x2114
+    | Dwarf_4 GNU_tail_call -> 0x2115
+    | Dwarf_4 GNU_all_tail_call_sites -> 0x2116
+    | Dwarf_4 GNU_all_call_sites -> 0x2117
+    | Dwarf_4 GNU_all_source_call_sites -> 0x2118
+    | Ocaml_specific Compiler_version -> 0x3100
+    | Ocaml_specific Unit_name -> 0x3101
+    | Ocaml_specific Config_digest -> 0x3102
+    | Ocaml_specific Prefix_name -> 0x3103
+    | Ocaml_specific Linker_dirs -> 0x3104
+    | Ocaml_specific Cmt_file_digest -> 0x3105
+
+  let encode t =
+    Dwarf_value.uleb128 ~comment:(name t) (Uint64.of_nonnegative_int_exn (code t))
+
+  let size t =
+    Dwarf_value.size (encode t)
+
+  let emit ~params t =
+    Dwarf_value.emit ~params (encode t)
+
+  module Sealed = struct
+    type t = {
+      code : int;
+      name : string;
+    }
+
+    include Identifiable.Make (struct
+      type nonrec t = t
+      let compare = Stdlib.compare
+      let equal (t1 : t) t2 = (t1 = t2)
+      let hash _ = failwith "Sealed.hash unsupported"
+      let print ppf { code = _; name; } = Format.pp_print_string ppf name
+      let output _ = failwith "Sealed.output unsupported"
+    end)
+  end
+
+  let seal (t : _ t) : Sealed.t =
+    { code = code t;
+      name = name t;
+    }
+end
+
+module Attribute_specification = struct
+  type 'form t =
+    | T : 'dwarf_classes Attribute.t * ('dwarf_classes, 'form) Form.t
+      -> 'form t
+
+  type 'form spec = 'form t
+
+  let create attribute form = T (attribute, form)
+
+  module Sealed = struct
+    type t = T1 : 'form spec -> t
+
+    include Identifiable.Make (struct
+      type nonrec t = t
+
+      let compare t1 t2 =
+        match t1, t2 with
+        | T1 (T (attr1, form1)), T1 (T (attr2, form2)) ->
+          let c =
+            Stdlib.compare (Attribute.encode attr1)
+              (Attribute.encode attr2)
+          in
+          if c <> 0 then c
+          else
+            Stdlib.compare (Form.encode form1) (Form.encode form2)
+
+      let equal t1 t2 =
+        compare t1 t2 = 0
+
+      let hash _ = failwith "Sealed.hash unsupported"
+
+      let print ppf (T1 (T (attr, form))) =
+        Format.fprintf ppf "%s : %s"
+          (Attribute.name attr)
+          (Form.name form)
+
+      let output _ = failwith "Sealed.output unsupported"
+    end)
+
+    let emit ~params t =
+      match t with
+      | T1 (T (attribute, form)) ->
+        Attribute.emit ~params attribute;
+        Form.emit ~params form
+
+    let size t =
+      match t with
+      | T1 (T (attribute, form)) ->
+        Dwarf_int.add (Attribute.size attribute) (Form.size form)
+  end
+
+  let seal (t : _ t) : Sealed.t = Sealed.T1 t
+end

--- a/backend/debug/dwarf/dwarf_low/dwarf_attributes.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_attributes.mli
@@ -1,0 +1,349 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Everything relating to DWARF forms, classes, attributes and attribute
+    specifications.  That is to say, everything about attributes with the
+    exception of the actual values assigned to them. *)
+
+module Class : sig
+  (* DWARF-4 specification section 7.5.4, page 147.
+     "Each class is a set of forms which have related representations and
+      which are given a common interpretation according to the attribute
+      in which the form is used."
+  *)
+
+  type address = [ `address ]
+  type addrptr = [ `addrptr ]
+  type block = [ `block ]
+  type constant = [ `constant ]
+  type exprloc = [ `exprloc ]
+  type flag = [ `flag ]
+  type lineptr = [ `lineptr ]
+  type loclist = [ `loclist ]
+  type loclistsptr = [ `loclistsptr ]
+  type macptr = [ `macptr ]
+  type rnglist = [ `rnglist ]
+  type rnglistsptr = [ `rnglistsptr ]
+  type reference = [ `reference ]
+  type string = [ `string ]
+  type stroffsetsptr = [ `stroffsetsptr ]
+
+  module Dwarf_4 : sig
+    type loclistptr = [ `loclistptr ]
+    type rangelistptr = [ `rangelistptr ]
+  end
+end
+
+module Form : sig
+  type addr = [ `addr ]
+  type block = [ `block ]
+  type block1 = [ `block1 ]
+  type block2 = [ `block2 ]
+  type block4 = [ `block4 ]
+  type data1 = [ `data1 ]
+  type data2 = [ `data2 ]
+  type data4 = [ `data4 ]
+  type data8 = [ `data8 ]
+  type string = [ `string ]
+  type flag = [ `flag ]
+  type sdata = [ `sdata ]
+  type strp = [ `strp ]
+  type udata = [ `udata ]
+  type ref_addr = [ `ref_addr ]
+  type ref1 = [ `ref1 ]
+  type ref2 = [ `ref2 ]
+  type ref4 = [ `ref4 ]
+  type ref8 = [ `ref8 ]
+  type ref_udata = [ `ref_udata ]
+  type indirect = [ `indirect ]
+  type sec_offset = [ `sec_offset ]
+  type exprloc = [ `exprloc ]
+  type flag_present = [ `flag_present ]
+  type strx = [ `strx ]
+  type addrx = [ `addrx ]
+  type ref_sup4 = [ `ref_sup4 ]
+  type strp_sup = [ `strp_sup ]
+  type data16 = [ `data16 ]
+  type line_strp = [ `line_strp ]
+  type ref_sig8 = [ `ref_sig8 ]
+  type implicit_const = [ `implicit_const ]
+  type loclistx = [ `loclistx ]
+  type rnglistx = [ `rnglistx ]
+  type ref_sup8 = [ `ref_sup8 ]
+  type strx1 = [ `strx1 ]
+  type strx2 = [ `strx2 ]
+  type strx3 = [ `strx3 ]
+  type strx4 = [ `strx4 ]
+  type addrx1 = [ `addrx1 ]
+  type addrx2 = [ `addrx2 ]
+  type addrx3 = [ `addrx3 ]
+  type addrx4 = [ `addrx4 ]
+
+  (** We omit the "DW_FORM_" prefix.
+      "Indirect" is not currently supported.
+  *)
+
+  module Dwarf_4 : sig
+    type ('dwarf_classes, 'form) t =
+      | Sec_offset_loclistptr : (Class.Dwarf_4.loclistptr, sec_offset) t
+      | Sec_offset_rangelistptr : (Class.Dwarf_4.rangelistptr, sec_offset) t
+  end
+
+  type ('dwarf_classes, 'form) t =
+    | Addr : (Class.address, addr) t
+    | Block : (Class.block, block) t
+    | Block1 : (Class.block, block1) t
+    | Block2 : (Class.block, [< block1 | block2 ]) t
+    | Block4 : (Class.block, [< block1 | block2 | block4 ]) t
+    | Data1 : (Class.constant, data1) t
+    | Data2 : (Class.constant, [< data1 | data2 ]) t
+    | Data4 : (Class.constant, [< data1 | data2 | data4 ]) t
+    | Data8 : (Class.constant, [< data1 | data2 | data4 | data8 ]) t
+    | String : (Class.string, string) t
+    | Flag : (Class.flag, data1) t
+    | Sdata : (Class.constant, sdata) t
+    | Strp : (Class.string, strp) t
+    | Udata : (Class.constant, udata) t
+    | Ref_addr : (Class.reference, ref_addr) t
+    | Ref1 : (Class.reference, ref1) t
+    | Ref2 : (Class.reference, [< ref1 | ref2 ]) t
+    | Ref4 : (Class.reference, [< ref1 | ref2 | ref4 ]) t
+    | Ref8 : (Class.reference, [< ref1 | ref2 | ref4 | ref8 ]) t
+    | Ref_udata : (Class.reference, ref_udata) t
+    | Sec_offset_addrptr : (Class.addrptr, sec_offset) t
+    | Sec_offset_lineptr : (Class.lineptr, sec_offset) t
+    | Sec_offset_loclist : (Class.loclist, sec_offset) t
+    | Sec_offset_loclistsptr : (Class.loclistsptr, sec_offset) t
+    | Sec_offset_macptr : (Class.macptr, sec_offset) t
+    | Sec_offset_rnglist : (Class.rnglist, sec_offset) t
+    | Sec_offset_rnglistsptr : (Class.rnglistsptr, sec_offset) t
+    | Sec_offset_stroffsetsptr : (Class.stroffsetsptr, sec_offset) t
+    | Exprloc : (Class.exprloc, exprloc) t
+    | Flag_present : (Class.flag, flag_present) t
+    | Strx : (Class.string, strx) t
+    | Addrx : (Class.address, addrx) t
+    | Ref_sup4 : (Class.reference, ref_sup4) t
+    | Strp_sup : (Class.string, strp_sup) t
+    | Data16 : (Class.constant, data16) t
+    | Line_strp : (Class.string, line_strp) t
+    | Ref_sig8 : (Class.reference, ref_sig8) t
+    | Implicit_const : (Class.constant, implicit_const) t
+    | Loclistx : (Class.loclist, loclistx) t
+    | Rnglistx : (Class.rnglist, rnglistx) t
+    | Ref_sup8 : (Class.reference, ref_sup8) t
+    | Strx1 : (Class.string, strx1) t
+    | Strx2 : (Class.string, strx2) t
+    | Strx3 : (Class.string, strx3) t
+    | Strx4 : (Class.string, strx4) t
+    | Addrx1 : (Class.string, addrx1) t
+    | Addrx2 : (Class.string, addrx2) t
+    | Addrx3 : (Class.string, addrx3) t
+    | Addrx4 : (Class.string, addrx4) t
+    | Dwarf_4 : ('dwarf_classes, 'form) Dwarf_4.t -> ('dwarf_classes, 'form) t
+end
+
+module Attribute : sig
+  (** We omit the "DW_AT_" prefix. *)
+
+  module Dwarf_4 : sig
+    type 'dwarf_classes t =
+      | Location : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | String_length : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Return_addr : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Start_scope : [< Class.constant | Class.Dwarf_4.rangelistptr ] t
+      | Data_member_location :
+          [< Class.constant | Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Frame_base : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Segment : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Static_link : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Use_location : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Vtable_elem_location : [< Class.exprloc | Class.Dwarf_4.loclistptr ] t
+      | Ranges : Class.Dwarf_4.rangelistptr t
+      | GNU_call_site_value : Class.exprloc t
+      | GNU_call_site_data_value : Class.exprloc t
+      | GNU_call_site_target : Class.exprloc t
+      | GNU_call_site_target_clobbered : Class.exprloc t
+      | GNU_tail_call : Class.flag t
+      | GNU_all_tail_call_sites : Class.flag t
+      | GNU_all_call_sites : Class.flag t
+      | GNU_all_source_call_sites : Class.flag t
+  end
+
+  module Ocaml_specific : sig
+    type 'dwarf_classes t =
+      | Compiler_version : Class.string t
+      | Unit_name : Class.string t
+      | Config_digest : Class.string t
+      | Prefix_name : Class.string t
+      | Linker_dirs : Class.string t
+      | Cmt_file_digest : Class.string t
+  end
+
+  type 'dwarf_classes t =
+    | Sibling : Class.reference t
+    | Location : [< Class.exprloc | Class.loclist ] t
+    | Name : Class.string t
+    | Ordering : Class.constant t
+    | Byte_size : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Bit_offset : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Bit_size : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Stmt_list : Class.lineptr t
+    | Low_pc : Class.address t
+    | High_pc : [< Class.address | Class.constant ] t
+    | Language : Class.constant t
+    | Discr : Class.reference t
+    | Discr_value : Class.constant t
+    | Visibility : Class.constant t
+    | Import : Class.reference t
+    | String_length : [< Class.exprloc | Class.loclistsptr ] t
+    | Common_reference : Class.reference t
+    | Comp_dir : Class.string t
+    | Const_value : [< Class.block | Class.constant | Class.string ] t
+    | Containing_type : Class.reference t
+    | Default_value : Class.reference t
+    | Inline : Class.constant t
+    | Is_optional : Class.flag t
+    | Lower_bound : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Producer : Class.string t
+    | Prototyped : Class.flag t
+    | Return_addr : [< Class.exprloc | Class.loclistsptr ] t
+    | Start_scope : [< Class.constant | Class.rnglistsptr ] t
+    | Bit_stride : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Upper_bound : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Abstract_origin : Class.reference t
+    | Accessibility : Class.constant t
+    | Address_class : Class.constant t
+    | Artificial : Class.flag t
+    | Base_types : Class.reference t
+    | Calling_convention : Class.constant t
+    | Count : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Data_member_location :
+        [< Class.constant | Class.exprloc | Class.loclistsptr ] t
+    | Decl_column : Class.constant t
+    | Decl_file : Class.constant t
+    | Decl_line : Class.constant t
+    | Declaration : Class.flag t
+    | Discr_list : Class.block t
+    | Encoding : Class.constant t
+    | External : Class.flag t
+    | Frame_base : [< Class.exprloc | Class.loclistsptr ] t
+    | Friend : Class.reference t
+    | Identifier_case : Class.constant t
+    | Macro_info : Class.macptr t
+    | Namelist_item : Class.reference t
+    | Priority : Class.reference t
+    | Segment : [< Class.exprloc | Class.loclistsptr ] t
+    | Specification : Class.reference t
+    | Static_link : [< Class.exprloc | Class.loclistsptr ] t
+    | Type : Class.reference t
+    | Use_location : [< Class.exprloc | Class.loclistsptr ] t
+    | Variable_parameter : Class.flag t
+    | Virtuality : Class.constant t
+    | Vtable_elem_location : [< Class.exprloc | Class.loclistsptr ] t
+    | Allocated : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Associated : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Data_location : Class.exprloc t
+    | Byte_stride : [< Class.constant | Class.exprloc | Class.reference ] t
+    | Entry_pc : Class.address t
+    | Use_UTF8 : Class.flag t
+    | Extension : Class.reference t
+    | Ranges : Class.rnglist t
+    | Trampoline :
+        [< Class.address | Class.flag | Class.reference | Class.string ] t
+    | Call_column : Class.constant t
+    | Call_file : Class.constant t
+    | Call_line : Class.constant t
+    | Description : Class.string t
+    | Binary_scale : Class.constant t
+    | Decimal_scale : Class.constant t
+    | Small : Class.reference t
+    | Decimal_sign : Class.constant t
+    | Digit_count : Class.constant t
+    | Picture_string : Class.string t
+    | Mutable : Class.flag t
+    | Threads_scaled : Class.flag t
+    | Explicit : Class.flag t
+    | Object_pointer : Class.reference t
+    | Endianity : Class.constant t
+    | Elemental : Class.flag t
+    | Pure : Class.flag t
+    | Recursive : Class.flag t
+    | Signature : Class.reference t
+    | Main_subprogram : Class.flag t
+    | Data_bit_offset : Class.constant t
+    | Const_expr : Class.flag t
+    | Enum_class : Class.flag t
+    | Linkage_name : Class.string t
+    | String_length_bit_size : Class.constant t
+    | String_length_byte_size : Class.constant t
+    | Rank : Class.exprloc t
+    | Str_offsets_base : Class.stroffsetsptr t
+    | Addr_base : Class.addrptr t
+    | Rnglists_base : Class.rnglistsptr t
+    | Dwo_name : Class.string t
+    | Reference : Class.flag t
+    | Rvalue_reference : Class.flag t
+    | Macros : Class.macptr t
+    | Call_all_calls : Class.flag t
+    | Call_all_source_calls : Class.flag t
+    | Call_all_tail_calls : Class.flag t
+    | Call_return_pc : Class.address t
+    | Call_value : Class.exprloc t
+    | Call_origin : Class.reference t
+    | Call_parameter : Class.reference t
+    | Call_pc : Class.address t
+    | Call_tail_call : Class.flag t
+    | Call_target : Class.exprloc t
+    | Call_target_clobbered : Class.exprloc t
+    | Call_data_location : Class.exprloc t
+    | Call_data_value : Class.exprloc t
+    | Noreturn : Class.flag t
+    | Alignment : Class.constant t
+    | Export_symbols : Class.flag t
+    | Deleted : Class.flag t
+    | Defaulted : Class.constant t
+    | Loclists_base : Class.loclistsptr t
+    | Dwarf_4 : 'dwarf_classes Dwarf_4.t -> 'dwarf_classes t
+    | Ocaml_specific : 'dwarf_classes Ocaml_specific.t -> 'dwarf_classes t
+
+  module Sealed : sig
+    type t
+
+    include Identifiable.S with type t := t
+  end
+
+  val seal : _ t -> Sealed.t
+end
+
+module Attribute_specification : sig
+  (* Attribute specifications: pairs of attributes and forms
+     (DWARF-4 specification section 7.5.3, page 146). *)
+
+  type 'form t
+
+  val create : 'dwarf_classes Attribute.t
+    -> ('dwarf_classes, 'form) Form.t
+    -> 'form t
+
+  module Sealed : sig
+    type t
+
+    include Identifiable.S with type t := t
+    include Dwarf_emittable.S with type t := t
+  end
+
+  val seal : _ t -> Sealed.t
+end

--- a/backend/debug/dwarf/dwarf_low/dwarf_emittable.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_emittable.ml
@@ -1,0 +1,35 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module type S = sig
+  type t
+
+  (** Measure the size in bytes of the given entity. *)
+  val size : t -> Dwarf_int.t
+
+  (** Emit assembler directives to describe the given entity. *)
+  val emit : params:(module Dwarf_params.S) -> t -> unit
+end
+
+module type S1_ignore = sig
+  type 'a t
+
+  (** Measure the size in bytes of the given entity. *)
+  val size : _ t -> Dwarf_int.t
+
+  (** Emit assembler directives to describe the given entity. *)
+  val emit : params:(module Dwarf_params.S) -> _ t -> unit
+end

--- a/backend/debug/dwarf/dwarf_low/dwarf_format.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_format.ml
@@ -1,0 +1,30 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Thirty_two
+  | Sixty_four
+
+let current = ref None
+
+let set t = current := Some t
+
+let get () =
+  match !current with
+  | None -> failwith "Dwarf_format.get: [set] has not been called"
+  | Some t -> t
+
+exception Too_large_for_thirty_two_bit_dwarf

--- a/backend/debug/dwarf/dwarf_low/dwarf_format.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_format.mli
@@ -1,0 +1,33 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Whether we are emitting 32-bit or 64-bit DWARF.
+    Note that this width does not necessarily coincide with the width of a
+    native integer on the target processor.  (DWARF-4 standard section 7.4,
+    page 142). *)
+
+type t =
+  | Thirty_two
+  | Sixty_four
+
+val set : t -> unit
+
+(** [get] raises if [set] has not been called beforehand. *)
+val get : unit -> t
+
+(** Exception raised when construction of 32-bit DWARF fails due to
+    outsize sections. *)
+exception Too_large_for_thirty_two_bit_dwarf

--- a/backend/debug/dwarf/dwarf_low/dwarf_int.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_int.ml
@@ -1,0 +1,112 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Uint64 = Numbers_extra.Uint64
+
+type t =
+  | Thirty_two of Int32.t
+  | Sixty_four of Int64.t
+
+let print ppf t =
+  match t with
+  | Thirty_two i -> Format.fprintf ppf "%ld" i
+  | Sixty_four i -> Format.fprintf ppf "%Ld" i
+
+let num i32 =
+  match Dwarf_format.get () with
+  | Thirty_two -> Thirty_two i32
+  | Sixty_four -> Sixty_four (Int64.of_int32 i32)
+
+let zero () = num 0l
+let one () = num 1l
+let two () = num 2l
+let four () = num 4l
+let eight () = num 8l
+
+(* CR mshinwell: Note: for cross compilation, [Sys.int_size] here should be
+   replaced by the size of [int] on the *host*. *)
+let of_host_int_exn i =
+  match Sys.int_size, Dwarf_format.get () with
+  | 31, Thirty_two -> Thirty_two (Int32.of_int i)
+  | 63, Sixty_four -> Sixty_four (Int64.of_int i)
+  | 31, Sixty_four -> Sixty_four (Int64.of_int i)
+  | 63, Thirty_two ->
+    if i >= -0x8000_0000 && i <= 0x7fff_ffff then
+      Thirty_two (Int32.of_int i)
+    else
+      raise Dwarf_format.Too_large_for_thirty_two_bit_dwarf
+  | size, _ -> Misc.fatal_errorf "Unknown [int] size %d" size
+
+let of_int64_exn i64 =
+  match Dwarf_format.get () with
+  | Sixty_four -> Sixty_four i64
+  | Thirty_two ->
+    if i64 >= -0x8000_0000L && i64 <= 0x7fff_ffffL then
+      Thirty_two (Int64.to_int32 i64)
+    else
+      raise Dwarf_format.Too_large_for_thirty_two_bit_dwarf
+
+let of_targetint_exn i =
+  match Targetint_extra.repr i, Dwarf_format.get () with
+  | Int32 i32, Thirty_two -> Thirty_two i32
+  | Int64 i64, Sixty_four -> Sixty_four i64
+  | Int32 i32, Sixty_four -> Sixty_four (Int64.of_int32 i32)
+  | Int64 i64, Thirty_two ->
+    if i64 >= -0x8000_0000L && i64 <= 0x7fff_ffffL then
+      Thirty_two (Int64.to_int32 i64)
+    else
+      raise Dwarf_format.Too_large_for_thirty_two_bit_dwarf
+
+let to_int64 t =
+  match t with
+  | Thirty_two t -> Int64.of_int32 t
+  | Sixty_four t -> t
+
+let to_uint64_exn t =
+  match t with
+  | Thirty_two t -> Uint64.of_nonnegative_int32_exn t
+  | Sixty_four t -> Uint64.of_nonnegative_int64_exn t
+
+let add t1 t2 =
+  begin match t1, t2 with
+  | Thirty_two _, Thirty_two _
+  | Sixty_four _, Sixty_four _ -> ()
+  | Thirty_two _, Sixty_four _
+  | Sixty_four _, Thirty_two _ ->
+    Misc.fatal_error "Cannot intermix sizes of [Dwarf_int]s"
+  end;
+  let t1 = to_int64 t1 in
+  let t2 = to_int64 t2 in
+  of_int64_exn (Int64.add t1 t2)
+
+let succ t = add t (one ())
+
+let width_as_int64 () =
+  match zero () with
+  | Thirty_two _ -> 4L
+  | Sixty_four _ -> 8L
+
+let size t =
+  match t with
+  | Thirty_two _ -> Thirty_two 4l
+  | Sixty_four _ -> Sixty_four 8L
+
+let emit ~params ?comment t =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  match t with
+  | Thirty_two i -> A.int32 ?comment i
+  | Sixty_four i -> A.int64 ?comment i

--- a/backend/debug/dwarf/dwarf_low/dwarf_int.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_int.mli
@@ -1,0 +1,61 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** An integer that has the same width as the current DWARF format.
+
+    Such integers (DWARF-4 specification section 7.4) are required to describe
+    offsets within DWARF sections; they may be wider than the machine's native
+    integers.
+
+    All of the [size] functions for measuring the size of encoded DWARF
+    constructs in this library return values of type [t], even if the encoding
+    of such sizes may sometimes be done via a variable-length encoding.  The
+    reason that it is correct to use values of type [t] is because the
+    width of the integers giving the size of any such constructs cannot
+    exceed the width of the DWARF format.  If they were to exceed such width
+    then it would not be possible to encode every offset into the section
+    containing such constructs using a DWARF-width integer, as mandated by the
+    standard.
+
+    Note that [Dwarf_format.set] must be called before using this module,
+    otherwise exceptions may be raised.
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+val print : Format.formatter -> t -> unit
+
+val zero : unit -> t
+val one : unit -> t
+val two : unit -> t
+val four : unit -> t
+val eight : unit -> t
+
+val of_host_int_exn : int -> t
+val of_int64_exn : Int64.t -> t
+val of_targetint_exn : Targetint_extra.t -> t
+
+val to_int64 : t -> Int64.t
+val to_uint64_exn : t -> Numbers_extra.Uint64.t
+
+val width_as_int64 : unit -> Int64.t
+
+(** [add] and [succ] both check for overflow. *)
+val add : t -> t -> t
+val succ : t -> t
+
+val size : t -> t
+val emit : params:(module Dwarf_params.S) -> ?comment:string -> t -> unit

--- a/backend/debug/dwarf/dwarf_low/dwarf_language.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_language.ml
@@ -1,0 +1,136 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | C89
+  | C
+  | Ada83
+  | C_plus_plus
+  | Cobol74
+  | Cobol85
+  | Fortran77
+  | Fortran90
+  | Pascal83
+  | Modula2
+  | Java
+  | C99
+  | Ada95
+  | Fortran95
+  | PLI
+  | ObjC
+  | ObjC_plus_plus
+  | UPC
+  | D
+  | Python
+  | OpenCL
+  | Go
+  | Modula3
+  | Haskell
+  | C_plus_plus_03
+  | C_plus_plus_11
+  | OCaml
+  | Rust
+  | C11
+  | Swift
+  | Julia
+  | Dylan
+  | C_plus_plus_14
+  | Fortran03
+  | Fortran08
+  | RenderScript
+  | BLISS
+
+let name t =
+  match t with
+  | C89 -> "C89"
+  | C -> "C"
+  | Ada83 -> "Ada83"
+  | C_plus_plus -> "C_plus_plus"
+  | Cobol74 -> "Cobol74"
+  | Cobol85 -> "Cobol85"
+  | Fortran77 -> "Fortran77"
+  | Fortran90 -> "Fortran90"
+  | Pascal83 -> "Pascal83"
+  | Modula2 -> "Modula2"
+  | Java -> "Java"
+  | C99 -> "C99"
+  | Ada95 -> "Ada95"
+  | Fortran95 -> "Fortran95"
+  | PLI -> "PLI"
+  | ObjC -> "ObjC"
+  | ObjC_plus_plus -> "ObjC_plus_plus"
+  | UPC -> "UPC"
+  | D -> "D"
+  | Python -> "Python"
+  | OpenCL -> "OpenCL"
+  | Go -> "Go"
+  | Modula3 -> "Modula3"
+  | Haskell -> "Haskell"
+  | C_plus_plus_03 -> "C_plus_plus_03"
+  | C_plus_plus_11 -> "C_plus_plus_11"
+  | OCaml -> "OCaml"
+  | Rust -> "Rust"
+  | C11 -> "C11"
+  | Swift -> "Swift"
+  | Julia -> "Julia"
+  | Dylan -> "Dylan"
+  | C_plus_plus_14 -> "C_plus_plus_14"
+  | Fortran03 -> "Fortran03"
+  | Fortran08 -> "Fortran08"
+  | RenderScript -> "RenderScript"
+  | BLISS -> "BLISS"
+
+let encode = function
+  | C89 -> 0x01
+  | C -> 0x02
+  | Ada83 -> 0x03
+  | C_plus_plus -> 0x04
+  | Cobol74 -> 0x05
+  | Cobol85 -> 0x06
+  | Fortran77 -> 0x07
+  | Fortran90 -> 0x08
+  | Pascal83 -> 0x09
+  | Modula2 -> 0x0a
+  | Java -> 0x0b
+  | C99 -> 0x0c
+  | Ada95 -> 0x0d
+  | Fortran95 -> 0x0e
+  | PLI -> 0x0f
+  | ObjC -> 0x10
+  | ObjC_plus_plus -> 0x11
+  | UPC -> 0x12
+  | D -> 0x13
+  | Python -> 0x14
+  | OpenCL -> 0x15
+  | Go -> 0x16
+  | Modula3 -> 0x17
+  | Haskell -> 0x18
+  | C_plus_plus_03 -> 0x19
+  | C_plus_plus_11 -> 0x1a
+  | OCaml -> 0x1b
+  | Rust -> 0x1c
+  | C11 -> 0x1d
+  | Swift -> 0x1e
+  | Julia -> 0x1f
+  | Dylan -> 0x20
+  | C_plus_plus_14 -> 0x21
+  | Fortran03 -> 0x22
+  | Fortran08 -> 0x23
+  | RenderScript -> 0x24
+  | BLISS -> 0x25
+
+let as_dwarf_value t =
+  Dwarf_value.int8 ~comment:(name t) (Numbers_extra.Int8.of_int_exn (encode t))

--- a/backend/debug/dwarf/dwarf_low/dwarf_language.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_language.mli
@@ -1,0 +1,58 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF languages (DWARF-5 specification page 62, table 3.1). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | C89
+  | C
+  | Ada83
+  | C_plus_plus
+  | Cobol74
+  | Cobol85
+  | Fortran77
+  | Fortran90
+  | Pascal83
+  | Modula2
+  | Java
+  | C99
+  | Ada95
+  | Fortran95
+  | PLI
+  | ObjC
+  | ObjC_plus_plus
+  | UPC
+  | D
+  | Python
+  | OpenCL
+  | Go
+  | Modula3
+  | Haskell
+  | C_plus_plus_03
+  | C_plus_plus_11
+  | OCaml
+  | Rust
+  | C11
+  | Swift
+  | Julia
+  | Dylan
+  | C_plus_plus_14
+  | Fortran03
+  | Fortran08
+  | RenderScript
+  | BLISS
+
+val as_dwarf_value : t -> Dwarf_value.t

--- a/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
@@ -1,0 +1,806 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Int8 = Numbers_extra.Int8
+module Int16 = Numbers_extra.Int16
+
+module Uint8 = Numbers_extra.Uint8
+module Uint16 = Numbers_extra.Uint16
+module Uint32 = Numbers_extra.Uint32
+module Uint64 = Numbers_extra.Uint64
+
+module I = Dwarf_int
+module V = Dwarf_value
+
+type implicit_value =
+  | Int of Targetint_extra.t
+  | Symbol of Asm_symbol.t
+
+type t =
+  | DW_op_lit0
+  | DW_op_lit1
+  | DW_op_lit2
+  | DW_op_lit3
+  | DW_op_lit4
+  | DW_op_lit5
+  | DW_op_lit6
+  | DW_op_lit7
+  | DW_op_lit8
+  | DW_op_lit9
+  | DW_op_lit10
+  | DW_op_lit11
+  | DW_op_lit12
+  | DW_op_lit13
+  | DW_op_lit14
+  | DW_op_lit15
+  | DW_op_lit16
+  | DW_op_lit17
+  | DW_op_lit18
+  | DW_op_lit19
+  | DW_op_lit20
+  | DW_op_lit21
+  | DW_op_lit22
+  | DW_op_lit23
+  | DW_op_lit24
+  | DW_op_lit25
+  | DW_op_lit26
+  | DW_op_lit27
+  | DW_op_lit28
+  | DW_op_lit29
+  | DW_op_lit30
+  | DW_op_lit31
+  | DW_op_addr of implicit_value
+  | DW_op_const1u of Uint8.t
+  | DW_op_const2u of Uint16.t
+  | DW_op_const4u of Uint32.t
+  | DW_op_const8u of Uint64.t
+  | DW_op_const1s of Int8.t
+  | DW_op_const2s of Int16.t
+  | DW_op_const4s of Int32.t
+  | DW_op_const8s of Int64.t
+  | DW_op_constu of Uint64.t
+  | DW_op_consts of Int64.t
+  | DW_op_fbreg of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg0 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg1 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg2 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg3 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg4 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg5 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg6 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg7 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg8 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg9 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg10 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg11 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg12 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg13 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg14 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg15 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg16 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg17 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg18 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg19 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg20 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg21 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg22 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg23 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg24 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg25 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg26 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg27 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg28 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg29 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg30 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg31 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_bregx of { reg_number : int; offset_in_bytes : Targetint_extra.t; }
+  | DW_op_dup
+  | DW_op_drop
+  | DW_op_pick
+  | DW_op_over
+  | DW_op_swap
+  | DW_op_rot
+  | DW_op_deref
+  | DW_op_deref_size of Uint8.t
+  | DW_op_xderef
+  | DW_op_xderef_size of Uint8.t
+  | DW_op_push_object_address
+  | DW_op_form_tls_address
+  | DW_op_call_frame_cfa
+  | DW_op_abs
+  | DW_op_and
+  | DW_op_div
+  | DW_op_minus
+  | DW_op_mod
+  | DW_op_mul
+  | DW_op_neg
+  | DW_op_not
+  | DW_op_or
+  | DW_op_plus
+  | DW_op_plus_uconst of Uint64.t
+  | DW_op_shl
+  | DW_op_shr
+  | DW_op_shra
+  | DW_op_xor
+  | DW_op_le
+  | DW_op_ge
+  | DW_op_eq
+  | DW_op_lt
+  | DW_op_gt
+  | DW_op_ne
+  | DW_op_skip of { num_bytes_forward : Int16.t; }
+  | DW_op_bra of { num_bytes_forward : Int16.t; }
+  | DW_op_call2 of {
+      label : Asm_label.t;
+      compilation_unit_header_label : Asm_label.t;
+    }
+  | DW_op_call4 of {
+      label : Asm_label.t;
+      compilation_unit_header_label : Asm_label.t;
+    }
+  | DW_op_call_ref of {
+      label : Asm_label.t;
+      compilation_unit_header_label : Asm_label.t;
+    }
+  | DW_op_nop
+  | DW_op_reg0
+  | DW_op_reg1
+  | DW_op_reg2
+  | DW_op_reg3
+  | DW_op_reg4
+  | DW_op_reg5
+  | DW_op_reg6
+  | DW_op_reg7
+  | DW_op_reg8
+  | DW_op_reg9
+  | DW_op_reg10
+  | DW_op_reg11
+  | DW_op_reg12
+  | DW_op_reg13
+  | DW_op_reg14
+  | DW_op_reg15
+  | DW_op_reg16
+  | DW_op_reg17
+  | DW_op_reg18
+  | DW_op_reg19
+  | DW_op_reg20
+  | DW_op_reg21
+  | DW_op_reg22
+  | DW_op_reg23
+  | DW_op_reg24
+  | DW_op_reg25
+  | DW_op_reg26
+  | DW_op_reg27
+  | DW_op_reg28
+  | DW_op_reg29
+  | DW_op_reg30
+  | DW_op_reg31
+  | DW_op_regx of { reg_number : int; }
+  | DW_op_implicit_value of implicit_value
+  | DW_op_stack_value
+  | DW_op_piece of { size_in_bytes : Targetint_extra.t; }
+  | DW_op_bit_piece of {
+      size_in_bits : Targetint_extra.t;
+      offset_in_bits : Targetint_extra.t;
+    }
+  | DW_op_implicit_pointer of {
+      label : Asm_label.t;
+      offset_in_bytes : Targetint_extra.t;
+    }
+  | DW_op_GNU_implicit_pointer of {
+      label : Asm_label.t;
+      offset_in_bytes : Targetint_extra.t;
+    }
+
+let opcode_name t =
+  match t with
+  | DW_op_lit0 -> "DW_op_lit0"
+  | DW_op_lit1 -> "DW_op_lit1"
+  | DW_op_lit2 -> "DW_op_lit2"
+  | DW_op_lit3 -> "DW_op_lit3"
+  | DW_op_lit4 -> "DW_op_lit4"
+  | DW_op_lit5 -> "DW_op_lit5"
+  | DW_op_lit6 -> "DW_op_lit6"
+  | DW_op_lit7 -> "DW_op_lit7"
+  | DW_op_lit8 -> "DW_op_lit8"
+  | DW_op_lit9 -> "DW_op_lit9"
+  | DW_op_lit10 -> "DW_op_lit10"
+  | DW_op_lit11 -> "DW_op_lit11"
+  | DW_op_lit12 -> "DW_op_lit12"
+  | DW_op_lit13 -> "DW_op_lit13"
+  | DW_op_lit14 -> "DW_op_lit14"
+  | DW_op_lit15 -> "DW_op_lit15"
+  | DW_op_lit16 -> "DW_op_lit16"
+  | DW_op_lit17 -> "DW_op_lit17"
+  | DW_op_lit18 -> "DW_op_lit18"
+  | DW_op_lit19 -> "DW_op_lit19"
+  | DW_op_lit20 -> "DW_op_lit20"
+  | DW_op_lit21 -> "DW_op_lit21"
+  | DW_op_lit22 -> "DW_op_lit22"
+  | DW_op_lit23 -> "DW_op_lit23"
+  | DW_op_lit24 -> "DW_op_lit24"
+  | DW_op_lit25 -> "DW_op_lit25"
+  | DW_op_lit26 -> "DW_op_lit26"
+  | DW_op_lit27 -> "DW_op_lit27"
+  | DW_op_lit28 -> "DW_op_lit28"
+  | DW_op_lit29 -> "DW_op_lit29"
+  | DW_op_lit30 -> "DW_op_lit30"
+  | DW_op_lit31 -> "DW_op_lit31"
+  | DW_op_addr _ -> "DW_op_addr"
+  | DW_op_const1u _ -> "DW_op_const1u"
+  | DW_op_const2u _ -> "DW_op_const2u"
+  | DW_op_const4u _ -> "DW_op_const4u"
+  | DW_op_const8u _ -> "DW_op_const8u"
+  | DW_op_const1s _ -> "DW_op_const1s"
+  | DW_op_const2s _ -> "DW_op_const2s"
+  | DW_op_const4s _ -> "DW_op_const4s"
+  | DW_op_const8s _ -> "DW_op_const8s"
+  | DW_op_constu _ -> "DW_op_constu"
+  | DW_op_consts _ -> "DW_op_consts"
+  | DW_op_fbreg _ -> "DW_op_fbreg"
+  | DW_op_breg0 _ -> "DW_op_breg0"
+  | DW_op_breg1 _ -> "DW_op_breg1"
+  | DW_op_breg2 _ -> "DW_op_breg2"
+  | DW_op_breg3 _ -> "DW_op_breg3"
+  | DW_op_breg4 _ -> "DW_op_breg4"
+  | DW_op_breg5 _ -> "DW_op_breg5"
+  | DW_op_breg6 _ -> "DW_op_breg6"
+  | DW_op_breg7 _ -> "DW_op_breg7"
+  | DW_op_breg8 _ -> "DW_op_breg8"
+  | DW_op_breg9 _ -> "DW_op_breg9"
+  | DW_op_breg10 _ -> "DW_op_breg10"
+  | DW_op_breg11 _ -> "DW_op_breg11"
+  | DW_op_breg12 _ -> "DW_op_breg12"
+  | DW_op_breg13 _ -> "DW_op_breg13"
+  | DW_op_breg14 _ -> "DW_op_breg14"
+  | DW_op_breg15 _ -> "DW_op_breg15"
+  | DW_op_breg16 _ -> "DW_op_breg16"
+  | DW_op_breg17 _ -> "DW_op_breg17"
+  | DW_op_breg18 _ -> "DW_op_breg18"
+  | DW_op_breg19 _ -> "DW_op_breg19"
+  | DW_op_breg20 _ -> "DW_op_breg20"
+  | DW_op_breg21 _ -> "DW_op_breg21"
+  | DW_op_breg22 _ -> "DW_op_breg22"
+  | DW_op_breg23 _ -> "DW_op_breg23"
+  | DW_op_breg24 _ -> "DW_op_breg24"
+  | DW_op_breg25 _ -> "DW_op_breg25"
+  | DW_op_breg26 _ -> "DW_op_breg26"
+  | DW_op_breg27 _ -> "DW_op_breg27"
+  | DW_op_breg28 _ -> "DW_op_breg28"
+  | DW_op_breg29 _ -> "DW_op_breg29"
+  | DW_op_breg30 _ -> "DW_op_breg30"
+  | DW_op_breg31 _ -> "DW_op_breg31"
+  | DW_op_bregx _ -> "DW_op_bregx"
+  | DW_op_dup -> "DW_op_dup"
+  | DW_op_drop -> "DW_op_drop"
+  | DW_op_pick -> "DW_op_pick"
+  | DW_op_over -> "DW_op_over"
+  | DW_op_swap -> "DW_op_swap"
+  | DW_op_rot -> "DW_op_rot"
+  | DW_op_deref -> "DW_op_deref"
+  | DW_op_deref_size _-> "DW_op_deref_size"
+  | DW_op_xderef -> "DW_op_xderef"
+  | DW_op_xderef_size _ -> "DW_op_xderef_size"
+  | DW_op_push_object_address -> "DW_op_push_object_address"
+  | DW_op_form_tls_address -> "DW_op_form_tls_address"
+  | DW_op_call_frame_cfa -> "DW_op_call_frame_cfa"
+  | DW_op_abs -> "DW_op_abs"
+  | DW_op_and -> "DW_op_and"
+  | DW_op_div -> "DW_op_div"
+  | DW_op_minus -> "DW_op_minus"
+  | DW_op_mod -> "DW_op_mod"
+  | DW_op_mul -> "DW_op_mul"
+  | DW_op_neg -> "DW_op_neg"
+  | DW_op_not -> "DW_op_not"
+  | DW_op_or -> "DW_op_or"
+  | DW_op_plus -> "DW_op_plus"
+  | DW_op_plus_uconst _ -> "DW_op_plus_uconst"
+  | DW_op_shl -> "DW_op_shl"
+  | DW_op_shr -> "DW_op_shr"
+  | DW_op_shra -> "DW_op_shra"
+  | DW_op_xor -> "DW_op_xor"
+  | DW_op_le -> "DW_op_le"
+  | DW_op_ge -> "DW_op_ge"
+  | DW_op_eq -> "DW_op_eq"
+  | DW_op_lt -> "DW_op_lt"
+  | DW_op_gt -> "DW_op_gt"
+  | DW_op_ne -> "DW_op_ne"
+  | DW_op_skip _ -> "DW_op_skip"
+  | DW_op_bra _ -> "DW_op_bra"
+  | DW_op_call2 _ -> "DW_op_call2"
+  | DW_op_call4 _ -> "DW_op_call4"
+  | DW_op_call_ref _ -> "DW_op_call_ref"
+  | DW_op_nop -> "DW_op_nop"
+  | DW_op_reg0 -> "DW_op_reg0"
+  | DW_op_reg1 -> "DW_op_reg1"
+  | DW_op_reg2 -> "DW_op_reg2"
+  | DW_op_reg3 -> "DW_op_reg3"
+  | DW_op_reg4 -> "DW_op_reg4"
+  | DW_op_reg5 -> "DW_op_reg5"
+  | DW_op_reg6 -> "DW_op_reg6"
+  | DW_op_reg7 -> "DW_op_reg7"
+  | DW_op_reg8 -> "DW_op_reg8"
+  | DW_op_reg9 -> "DW_op_reg9"
+  | DW_op_reg10 -> "DW_op_reg10"
+  | DW_op_reg11 -> "DW_op_reg11"
+  | DW_op_reg12 -> "DW_op_reg12"
+  | DW_op_reg13 -> "DW_op_reg13"
+  | DW_op_reg14 -> "DW_op_reg14"
+  | DW_op_reg15 -> "DW_op_reg15"
+  | DW_op_reg16 -> "DW_op_reg16"
+  | DW_op_reg17 -> "DW_op_reg17"
+  | DW_op_reg18 -> "DW_op_reg18"
+  | DW_op_reg19 -> "DW_op_reg19"
+  | DW_op_reg20 -> "DW_op_reg20"
+  | DW_op_reg21 -> "DW_op_reg21"
+  | DW_op_reg22 -> "DW_op_reg22"
+  | DW_op_reg23 -> "DW_op_reg23"
+  | DW_op_reg24 -> "DW_op_reg24"
+  | DW_op_reg25 -> "DW_op_reg25"
+  | DW_op_reg26 -> "DW_op_reg26"
+  | DW_op_reg27 -> "DW_op_reg27"
+  | DW_op_reg28 -> "DW_op_reg28"
+  | DW_op_reg29 -> "DW_op_reg29"
+  | DW_op_reg30 -> "DW_op_reg30"
+  | DW_op_reg31 -> "DW_op_reg31"
+  | DW_op_regx _ -> "DW_op_regx"
+  | DW_op_implicit_value _ -> "DW_op_implicit_value"
+  | DW_op_stack_value -> "DW_op_stack_value"
+  | DW_op_piece _ -> "DW_op_piece"
+  | DW_op_bit_piece _ -> "DW_op_bit_piece"
+  | DW_op_implicit_pointer _ -> "DW_op_implicit_pointer"
+  | DW_op_GNU_implicit_pointer _ -> "DW_op_GNU_implicit_pointer"
+
+(* DWARF-4 spec section 7.7.1. *)
+let opcode = function
+  | DW_op_lit0 -> 0x30
+  | DW_op_lit1 -> 0x31
+  | DW_op_lit2 -> 0x32
+  | DW_op_lit3 -> 0x33
+  | DW_op_lit4 -> 0x34
+  | DW_op_lit5 -> 0x35
+  | DW_op_lit6 -> 0x36
+  | DW_op_lit7 -> 0x37
+  | DW_op_lit8 -> 0x38
+  | DW_op_lit9 -> 0x39
+  | DW_op_lit10 -> 0x3a
+  | DW_op_lit11 -> 0x3b
+  | DW_op_lit12 -> 0x3c
+  | DW_op_lit13 -> 0x3d
+  | DW_op_lit14 -> 0x3e
+  | DW_op_lit15 -> 0x3f
+  | DW_op_lit16 -> 0x40
+  | DW_op_lit17 -> 0x41
+  | DW_op_lit18 -> 0x42
+  | DW_op_lit19 -> 0x43
+  | DW_op_lit20 -> 0x44
+  | DW_op_lit21 -> 0x45
+  | DW_op_lit22 -> 0x46
+  | DW_op_lit23 -> 0x47
+  | DW_op_lit24 -> 0x48
+  | DW_op_lit25 -> 0x49
+  | DW_op_lit26 -> 0x4a
+  | DW_op_lit27 -> 0x4b
+  | DW_op_lit28 -> 0x4c
+  | DW_op_lit29 -> 0x4d
+  | DW_op_lit30 -> 0x4e
+  | DW_op_lit31 -> 0x4f
+  | DW_op_addr _ -> 0x03
+  | DW_op_const1u _ -> 0x08
+  | DW_op_const2u _ -> 0x0a
+  | DW_op_const4u _ -> 0x0c
+  | DW_op_const8u _ -> 0x0e
+  | DW_op_const1s _ -> 0x09
+  | DW_op_const2s _ -> 0x0b
+  | DW_op_const4s _ -> 0x0d
+  | DW_op_const8s _ -> 0x0f
+  | DW_op_constu _ -> 0x10
+  | DW_op_consts _ -> 0x11
+  | DW_op_fbreg _ -> 0x91
+  | DW_op_breg0 _ -> 0x70
+  | DW_op_breg1 _ -> 0x71
+  | DW_op_breg2 _ -> 0x72
+  | DW_op_breg3 _ -> 0x73
+  | DW_op_breg4 _ -> 0x74
+  | DW_op_breg5 _ -> 0x75
+  | DW_op_breg6 _ -> 0x76
+  | DW_op_breg7 _ -> 0x77
+  | DW_op_breg8 _ -> 0x78
+  | DW_op_breg9 _ -> 0x79
+  | DW_op_breg10 _ -> 0x7a
+  | DW_op_breg11 _ -> 0x7b
+  | DW_op_breg12 _ -> 0x7c
+  | DW_op_breg13 _ -> 0x7d
+  | DW_op_breg14 _ -> 0x7e
+  | DW_op_breg15 _ -> 0x7f
+  | DW_op_breg16 _ -> 0x80
+  | DW_op_breg17 _ -> 0x81
+  | DW_op_breg18 _ -> 0x82
+  | DW_op_breg19 _ -> 0x83
+  | DW_op_breg20 _ -> 0x84
+  | DW_op_breg21 _ -> 0x85
+  | DW_op_breg22 _ -> 0x86
+  | DW_op_breg23 _ -> 0x87
+  | DW_op_breg24 _ -> 0x88
+  | DW_op_breg25 _ -> 0x89
+  | DW_op_breg26 _ -> 0x8a
+  | DW_op_breg27 _ -> 0x8b
+  | DW_op_breg28 _ -> 0x8c
+  | DW_op_breg29 _ -> 0x8d
+  | DW_op_breg30 _ -> 0x8e
+  | DW_op_breg31 _ -> 0x8f
+  | DW_op_bregx _ -> 0x92
+  | DW_op_dup -> 0x12
+  | DW_op_drop -> 0x13
+  | DW_op_pick -> 0x15
+  | DW_op_over -> 0x14
+  | DW_op_swap -> 0x16
+  | DW_op_rot -> 0x17
+  | DW_op_deref -> 0x06
+  | DW_op_deref_size _ -> 0x94
+  | DW_op_xderef -> 0x18
+  | DW_op_xderef_size _ -> 0x95
+  | DW_op_push_object_address -> 0x97
+  | DW_op_form_tls_address -> 0x9b
+  | DW_op_call_frame_cfa -> 0x9c
+  | DW_op_abs -> 0x19
+  | DW_op_and -> 0x1a
+  | DW_op_div -> 0x1b
+  | DW_op_minus -> 0x1c
+  | DW_op_mod -> 0x1d
+  | DW_op_mul -> 0x1e
+  | DW_op_neg -> 0x1f
+  | DW_op_not -> 0x20
+  | DW_op_or -> 0x21
+  | DW_op_plus -> 0x22
+  | DW_op_plus_uconst _ -> 0x23
+  | DW_op_shl -> 0x24
+  | DW_op_shr -> 0x25
+  | DW_op_shra -> 0x26
+  | DW_op_xor -> 0x27
+  | DW_op_le -> 0x2c
+  | DW_op_ge -> 0x2a
+  | DW_op_eq -> 0x29
+  | DW_op_lt -> 0x2d
+  | DW_op_gt -> 0x2b
+  | DW_op_ne -> 0x2e
+  | DW_op_skip _ -> 0x2f
+  | DW_op_bra _ -> 0x28
+  | DW_op_call2 _ -> 0x98
+  | DW_op_call4 _ -> 0x99
+  | DW_op_call_ref _ -> 0x9a
+  | DW_op_nop -> 0x96
+  | DW_op_reg0 -> 0x50
+  | DW_op_reg1 -> 0x51
+  | DW_op_reg2 -> 0x52
+  | DW_op_reg3 -> 0x53
+  | DW_op_reg4 -> 0x54
+  | DW_op_reg5 -> 0x55
+  | DW_op_reg6 -> 0x56
+  | DW_op_reg7 -> 0x57
+  | DW_op_reg8 -> 0x58
+  | DW_op_reg9 -> 0x59
+  | DW_op_reg10 -> 0x5a
+  | DW_op_reg11 -> 0x5b
+  | DW_op_reg12 -> 0x5c
+  | DW_op_reg13 -> 0x5d
+  | DW_op_reg14 -> 0x5e
+  | DW_op_reg15 -> 0x5f
+  | DW_op_reg16 -> 0x60
+  | DW_op_reg17 -> 0x61
+  | DW_op_reg18 -> 0x62
+  | DW_op_reg19 -> 0x63
+  | DW_op_reg20 -> 0x64
+  | DW_op_reg21 -> 0x65
+  | DW_op_reg22 -> 0x66
+  | DW_op_reg23 -> 0x67
+  | DW_op_reg24 -> 0x68
+  | DW_op_reg25 -> 0x69
+  | DW_op_reg26 -> 0x6a
+  | DW_op_reg27 -> 0x6b
+  | DW_op_reg28 -> 0x6c
+  | DW_op_reg29 -> 0x6d
+  | DW_op_reg30 -> 0x6e
+  | DW_op_reg31 -> 0x6f
+  | DW_op_regx _ -> 0x90
+  | DW_op_implicit_value _ -> 0x9e
+  | DW_op_stack_value -> 0x9f
+  | DW_op_piece _ -> 0x93
+  | DW_op_bit_piece _ -> 0x9d
+  | DW_op_implicit_pointer _ -> 0xa0
+  | DW_op_GNU_implicit_pointer _ -> 0xf2
+
+external caml_string_set32 : bytes -> index:int -> Int32.t -> unit
+  = "%caml_string_set32"
+
+external caml_string_set64 : bytes -> index:int -> Int64.t -> unit
+  = "%caml_string_set64"
+
+module Make (M : sig
+  type param
+  type result
+  val unit_result : unit -> result
+  val opcode : param -> t -> result
+  val value : param -> V.t -> result
+  val (>>>) : param -> result -> (unit -> result) -> result
+end) = struct
+  let run param t =
+    let unit_result = M.unit_result () in
+    let opcode = M.opcode param in
+    let value = M.value param in
+    let (>>>) = M.(>>>) param in
+    opcode t
+    >>> fun () ->
+    match t with
+    | DW_op_lit0
+    | DW_op_lit1
+    | DW_op_lit2
+    | DW_op_lit3
+    | DW_op_lit4
+    | DW_op_lit5
+    | DW_op_lit6
+    | DW_op_lit7
+    | DW_op_lit8
+    | DW_op_lit9
+    | DW_op_lit10
+    | DW_op_lit11
+    | DW_op_lit12
+    | DW_op_lit13
+    | DW_op_lit14
+    | DW_op_lit15
+    | DW_op_lit16
+    | DW_op_lit17
+    | DW_op_lit18
+    | DW_op_lit19
+    | DW_op_lit20
+    | DW_op_lit21
+    | DW_op_lit22
+    | DW_op_lit23
+    | DW_op_lit24
+    | DW_op_lit25
+    | DW_op_lit26
+    | DW_op_lit27
+    | DW_op_lit28
+    | DW_op_lit29
+    | DW_op_lit30
+    | DW_op_lit31 -> unit_result
+    | DW_op_addr (Int addr) -> value (V.absolute_address addr)
+    | DW_op_addr (Symbol sym) -> value (V.code_address_from_symbol sym)
+    | DW_op_const1u n -> value (V.uint8 ~comment:"  arg of DW_OP_const1u" n)
+    | DW_op_const2u n -> value (V.uint16 ~comment:"  arg of DW_OP_const2u" n)
+    | DW_op_const4u n -> value (V.uint32 ~comment:"  arg of DW_OP_const4u" n)
+    | DW_op_const8u n -> value (V.uint64 ~comment:"  arg of DW_OP_const8u" n)
+    | DW_op_const1s n -> value (V.int8 ~comment:"  arg of DW_OP_const1s" n)
+    | DW_op_const2s n -> value (V.int16 ~comment:"  arg of DW_OP_const2s" n)
+    | DW_op_const4s n -> value (V.int32 ~comment:"  arg of DW_OP_const4s" n)
+    | DW_op_const8s n -> value (V.int64 ~comment:"  arg of DW_OP_const8s" n)
+    | DW_op_constu n -> value (V.uleb128 ~comment:"  arg of DW_OP_constu" n)
+    | DW_op_consts n -> value (V.sleb128 ~comment:"  arg of DW_OP_consts" n)
+    | DW_op_fbreg { offset_in_bytes; } ->
+      let offset_in_bytes = Targetint_extra.to_int64 offset_in_bytes in
+      value (V.sleb128 ~comment:"offset in bytes" offset_in_bytes)
+    | DW_op_breg0 { offset_in_bytes; }
+    | DW_op_breg1 { offset_in_bytes; }
+    | DW_op_breg2 { offset_in_bytes; }
+    | DW_op_breg3 { offset_in_bytes; }
+    | DW_op_breg4 { offset_in_bytes; }
+    | DW_op_breg5 { offset_in_bytes; }
+    | DW_op_breg6 { offset_in_bytes; }
+    | DW_op_breg7 { offset_in_bytes; }
+    | DW_op_breg8 { offset_in_bytes; }
+    | DW_op_breg9 { offset_in_bytes; }
+    | DW_op_breg10 { offset_in_bytes; }
+    | DW_op_breg11 { offset_in_bytes; }
+    | DW_op_breg12 { offset_in_bytes; }
+    | DW_op_breg13 { offset_in_bytes; }
+    | DW_op_breg14 { offset_in_bytes; }
+    | DW_op_breg15 { offset_in_bytes; }
+    | DW_op_breg16 { offset_in_bytes; }
+    | DW_op_breg17 { offset_in_bytes; }
+    | DW_op_breg18 { offset_in_bytes; }
+    | DW_op_breg19 { offset_in_bytes; }
+    | DW_op_breg20 { offset_in_bytes; }
+    | DW_op_breg21 { offset_in_bytes; }
+    | DW_op_breg22 { offset_in_bytes; }
+    | DW_op_breg23 { offset_in_bytes; }
+    | DW_op_breg24 { offset_in_bytes; }
+    | DW_op_breg25 { offset_in_bytes; }
+    | DW_op_breg26 { offset_in_bytes; }
+    | DW_op_breg27 { offset_in_bytes; }
+    | DW_op_breg28 { offset_in_bytes; }
+    | DW_op_breg29 { offset_in_bytes; }
+    | DW_op_breg30 { offset_in_bytes; }
+    | DW_op_breg31 { offset_in_bytes; } ->
+      let offset_in_bytes = Targetint_extra.to_int64 offset_in_bytes in
+      value (V.sleb128 ~comment:"offset in bytes" offset_in_bytes)
+    | DW_op_bregx { reg_number; offset_in_bytes; } ->
+      let offset_in_bytes = Targetint_extra.to_int64 offset_in_bytes in
+      value (V.uleb128 ~comment:"DWARF reg number"
+        (Uint64.of_nonnegative_int_exn reg_number))
+      >>> fun () ->
+      value (V.sleb128 ~comment:"offset in bytes" offset_in_bytes)
+    | DW_op_dup
+    | DW_op_drop
+    | DW_op_pick
+    | DW_op_over
+    | DW_op_swap
+    | DW_op_rot
+    | DW_op_deref
+    | DW_op_deref_size _
+    | DW_op_xderef -> unit_result
+    | DW_op_xderef_size n -> value (V.uint8 ~comment:"size" n)
+    | DW_op_push_object_address
+    | DW_op_form_tls_address
+    | DW_op_call_frame_cfa
+    | DW_op_abs
+    | DW_op_and
+    | DW_op_div
+    | DW_op_minus
+    | DW_op_mod
+    | DW_op_mul
+    | DW_op_neg
+    | DW_op_not
+    | DW_op_or
+    | DW_op_plus -> unit_result
+    | DW_op_plus_uconst const -> value (V.uleb128 const)
+    | DW_op_shl
+    | DW_op_shr
+    | DW_op_shra
+    | DW_op_xor
+    | DW_op_le
+    | DW_op_ge
+    | DW_op_eq
+    | DW_op_lt
+    | DW_op_gt
+    | DW_op_ne -> unit_result
+    | DW_op_skip { num_bytes_forward; } ->
+      value (V.int16 ~comment:"num bytes to jump forward/backward"
+        num_bytes_forward)
+    | DW_op_bra { num_bytes_forward; } ->
+      value (V.int16 ~comment:"num bytes forward/backward, if TOS non-zero"
+        num_bytes_forward)
+    | DW_op_call2 { label; compilation_unit_header_label; } ->
+      value (V.distance_between_labels_16_bit ~comment:"call2 target"
+        ~upper:label ~lower:compilation_unit_header_label ())
+    | DW_op_call4 { label; compilation_unit_header_label; } ->
+      value (V.distance_between_labels_32_bit ~comment:"call4 target"
+        ~upper:label ~lower:compilation_unit_header_label ())
+    | DW_op_call_ref { label; compilation_unit_header_label; } ->
+      begin match Dwarf_format.get () with
+      | Thirty_two ->
+        value (V.distance_between_labels_32_bit ~comment:"call_ref target"
+          ~upper:label ~lower:compilation_unit_header_label ())
+      | Sixty_four ->
+        value (V.distance_between_labels_64_bit ~comment:"call_ref target"
+          ~upper:label ~lower:compilation_unit_header_label ())
+      end
+    | DW_op_nop
+    | DW_op_reg0
+    | DW_op_reg1
+    | DW_op_reg2
+    | DW_op_reg3
+    | DW_op_reg4
+    | DW_op_reg5
+    | DW_op_reg6
+    | DW_op_reg7
+    | DW_op_reg8
+    | DW_op_reg9
+    | DW_op_reg10
+    | DW_op_reg11
+    | DW_op_reg12
+    | DW_op_reg13
+    | DW_op_reg14
+    | DW_op_reg15
+    | DW_op_reg16
+    | DW_op_reg17
+    | DW_op_reg18
+    | DW_op_reg19
+    | DW_op_reg20
+    | DW_op_reg21
+    | DW_op_reg22
+    | DW_op_reg23
+    | DW_op_reg24
+    | DW_op_reg25
+    | DW_op_reg26
+    | DW_op_reg27
+    | DW_op_reg28
+    | DW_op_reg29
+    | DW_op_reg30
+    | DW_op_reg31 -> unit_result
+    | DW_op_regx { reg_number; } ->
+      value (V.uleb128 ~comment:"DWARF reg number"
+        (Uint64.of_nonnegative_int_exn reg_number))
+    | DW_op_implicit_value (Int i) ->
+      let buf =
+        match Dwarf_arch_sizes.size_int with
+        | 4 ->
+          let buf = Bytes.create 4 in
+          caml_string_set32 buf ~index:0 (Targetint_extra.to_int32 i);
+          buf
+        | 8 ->
+          let buf = Bytes.create 8 in
+          caml_string_set64 buf ~index:0 (Targetint_extra.to_int64 i);
+          buf
+        | n ->
+          Misc.fatal_errorf "Dwarf_operator: bad Dwarf_arch_sizes.size_int = %d" n
+      in
+      let comment =
+        if !Clflags.keep_asm_file then
+          Some (Format.asprintf "implicit value %a" Targetint_extra.print i)
+        else
+          None
+      in
+      value (V.uleb128 ?comment (Uint64.of_nonnegative_int_exn (Bytes.length buf)))
+      >>> fun () ->
+      value (V.string (Bytes.to_string buf))
+    | DW_op_implicit_value (Symbol symbol) ->
+      value (V.uleb128 ~comment:"Dwarf_arch_sizes.size_addr"
+        (Uint64.of_nonnegative_int_exn Dwarf_arch_sizes.size_addr))
+      >>> fun () ->
+      value (V.code_address_from_symbol symbol)
+    | DW_op_stack_value -> unit_result
+    | DW_op_piece { size_in_bytes; } ->
+      let size_in_bytes = Targetint_extra.to_uint64_exn size_in_bytes in
+      value (V.uleb128 ~comment:"size in bytes" size_in_bytes)
+    | DW_op_bit_piece { size_in_bits; offset_in_bits; } ->
+      let size_in_bits = Targetint_extra.to_uint64_exn size_in_bits in
+      let offset_in_bits = Targetint_extra.to_uint64_exn offset_in_bits in
+      value (V.uleb128 ~comment:"size in bits" size_in_bits)
+      >>> fun () ->
+      value (V.uleb128 ~comment:"offset in bits" offset_in_bits)
+    | DW_op_implicit_pointer { offset_in_bytes; label; }
+    | DW_op_GNU_implicit_pointer { offset_in_bytes; label; } ->
+      let offset_in_bytes = Targetint_extra.to_int64 offset_in_bytes in
+      value (V.offset_into_debug_info label)
+      >>> fun () ->
+      value (V.sleb128 ~comment:"offset in bytes" offset_in_bytes)
+end
+
+module Print = Make (struct
+  type param = Format.formatter
+  type result = unit
+  let unit_result () = ()
+
+  let opcode ppf t = Format.pp_print_string ppf (opcode_name t)
+  let value ppf v = V.print ppf v
+  let (>>>) ppf () f = Format.pp_print_string ppf " "; f ()
+end)
+
+module Size = Make (struct
+  type param = unit
+  type result = I.t
+  let unit_result () = I.zero ()
+
+  let opcode () _ = I.one ()
+  let value () v = V.size v
+  let (>>>) () size f = I.add size (f ())
+end)
+
+module Emit = Make (struct
+  type param = (module Dwarf_params.S)
+  type result = unit
+  let unit_result () = ()
+
+  let opcode params t =
+    let comment = opcode_name t in
+    V.emit ~params (V.uint8 ~comment (Uint8.of_nonnegative_int_exn (opcode t)))
+  let value params v = V.emit ~params v
+  let (>>>) _params () f = f ()
+end)
+
+let print ppf t = Print.run ppf t
+let size t = Size.run () t
+let emit ~params t = Emit.run params t

--- a/backend/debug/dwarf/dwarf_low/dwarf_operator.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_operator.mli
@@ -1,0 +1,204 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type implicit_value =
+  | Int of Targetint_extra.t
+  | Symbol of Asm_symbol.t
+
+(* CR mshinwell: Remove "DW_op" prefix to be consistent *)
+type t =
+  | DW_op_lit0
+  | DW_op_lit1
+  | DW_op_lit2
+  | DW_op_lit3
+  | DW_op_lit4
+  | DW_op_lit5
+  | DW_op_lit6
+  | DW_op_lit7
+  | DW_op_lit8
+  | DW_op_lit9
+  | DW_op_lit10
+  | DW_op_lit11
+  | DW_op_lit12
+  | DW_op_lit13
+  | DW_op_lit14
+  | DW_op_lit15
+  | DW_op_lit16
+  | DW_op_lit17
+  | DW_op_lit18
+  | DW_op_lit19
+  | DW_op_lit20
+  | DW_op_lit21
+  | DW_op_lit22
+  | DW_op_lit23
+  | DW_op_lit24
+  | DW_op_lit25
+  | DW_op_lit26
+  | DW_op_lit27
+  | DW_op_lit28
+  | DW_op_lit29
+  | DW_op_lit30
+  | DW_op_lit31
+  | DW_op_addr of implicit_value
+  | DW_op_const1u of Numbers_extra.Uint8.t
+  | DW_op_const2u of Numbers_extra.Uint16.t
+  | DW_op_const4u of Numbers_extra.Uint32.t
+  | DW_op_const8u of Numbers_extra.Uint64.t
+  | DW_op_const1s of Numbers_extra.Int8.t
+  | DW_op_const2s of Numbers_extra.Int16.t
+  | DW_op_const4s of Int32.t
+  | DW_op_const8s of Int64.t
+  | DW_op_constu of Numbers_extra.Uint64.t
+  | DW_op_consts of Int64.t
+  | DW_op_fbreg of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg0 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg1 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg2 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg3 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg4 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg5 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg6 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg7 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg8 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg9 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg10 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg11 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg12 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg13 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg14 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg15 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg16 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg17 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg18 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg19 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg20 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg21 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg22 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg23 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg24 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg25 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg26 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg27 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg28 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg29 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg30 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_breg31 of { offset_in_bytes : Targetint_extra.t; }
+  | DW_op_bregx of { reg_number : int; offset_in_bytes : Targetint_extra.t; }
+    (** The [reg_number] is variable-length, but we will assume that [int]
+        is sufficient. *)
+  | DW_op_dup
+  | DW_op_drop
+  | DW_op_pick
+  | DW_op_over
+  | DW_op_swap
+  | DW_op_rot
+  | DW_op_deref
+  | DW_op_deref_size of Numbers_extra.Uint8.t
+  | DW_op_xderef
+  | DW_op_xderef_size of Numbers_extra.Uint8.t
+  | DW_op_push_object_address
+  | DW_op_form_tls_address
+  | DW_op_call_frame_cfa
+  | DW_op_abs
+  | DW_op_and
+  | DW_op_div
+  | DW_op_minus
+  | DW_op_mod
+  | DW_op_mul
+  | DW_op_neg
+  | DW_op_not
+  | DW_op_or
+  | DW_op_plus
+  | DW_op_plus_uconst of Numbers_extra.Uint64.t
+  | DW_op_shl
+  | DW_op_shr
+  | DW_op_shra
+  | DW_op_xor
+  | DW_op_le
+  | DW_op_ge
+  | DW_op_eq
+  | DW_op_lt
+  | DW_op_gt
+  | DW_op_ne
+  | DW_op_skip of { num_bytes_forward : Numbers_extra.Int16.t; }
+  | DW_op_bra of { num_bytes_forward : Numbers_extra.Int16.t; }
+  | DW_op_call2 of {
+      label : Asm_label.t;
+      compilation_unit_header_label : Asm_label.t;
+    }
+  | DW_op_call4 of {
+      label : Asm_label.t;
+      compilation_unit_header_label : Asm_label.t;
+    }
+  | DW_op_call_ref of {
+      label : Asm_label.t;
+      compilation_unit_header_label : Asm_label.t;
+    }
+  | DW_op_nop
+  | DW_op_reg0
+  | DW_op_reg1
+  | DW_op_reg2
+  | DW_op_reg3
+  | DW_op_reg4
+  | DW_op_reg5
+  | DW_op_reg6
+  | DW_op_reg7
+  | DW_op_reg8
+  | DW_op_reg9
+  | DW_op_reg10
+  | DW_op_reg11
+  | DW_op_reg12
+  | DW_op_reg13
+  | DW_op_reg14
+  | DW_op_reg15
+  | DW_op_reg16
+  | DW_op_reg17
+  | DW_op_reg18
+  | DW_op_reg19
+  | DW_op_reg20
+  | DW_op_reg21
+  | DW_op_reg22
+  | DW_op_reg23
+  | DW_op_reg24
+  | DW_op_reg25
+  | DW_op_reg26
+  | DW_op_reg27
+  | DW_op_reg28
+  | DW_op_reg29
+  | DW_op_reg30
+  | DW_op_reg31
+  | DW_op_regx of { reg_number : int; }
+    (** The [reg_number] is variable-length, but we will assume that [int]
+        is sufficient. *)
+  | DW_op_implicit_value of implicit_value
+  | DW_op_stack_value
+  | DW_op_piece of { size_in_bytes : Targetint_extra.t; }
+  | DW_op_bit_piece of {
+      size_in_bits : Targetint_extra.t;
+      offset_in_bits : Targetint_extra.t;
+    }
+  | DW_op_implicit_pointer of {
+      label : Asm_label.t;
+      offset_in_bytes : Targetint_extra.t;
+    }
+  | DW_op_GNU_implicit_pointer of {
+      label : Asm_label.t;
+      offset_in_bytes : Targetint_extra.t;
+    }
+
+val print : Format.formatter -> t -> unit
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/dwarf_tag.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_tag.ml
@@ -1,0 +1,265 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Int16 = Numbers_extra.Int16
+module Uint64 = Numbers_extra.Uint64
+
+type user = Int16.t
+
+type dwarf_4 =
+  | GNU_call_site
+  | GNU_call_site_parameter
+
+type t =
+  | Array_type
+  | Class_type
+  | Entry_point
+  | Enumeration_type
+  | Formal_parameter
+  | Imported_declaration
+  | Label
+  | Lexical_block
+  | Member
+  | Pointer_type
+  | Reference_type
+  | Compile_unit
+  | String_type
+  | Structure_type
+  | Subroutine_type
+  | Typedef
+  | Union_type
+  | Unspecified_parameters
+  | Variant
+  | Common_block
+  | Common_inclusion
+  | Inheritance
+  | Inlined_subroutine
+  | Module
+  | Ptr_to_member_type
+  | Set_type
+  | Subrange_type
+  | With_stmt
+  | Access_declaration
+  | Base_type
+  | Catch_block
+  | Const_type
+  | Constant
+  | Enumerator
+  | File_type
+  | Friend
+  | Namelist
+  | Namelist_item
+  | Packed_type
+  | Subprogram
+  | Template_type_parameter
+  | Template_value_parameter
+  | Thrown_type
+  | Try_block
+  | Variant_part
+  | Variable
+  | Volatile_type
+  | Dwarf_procedure
+  | Restrict_type
+  | Interface_type
+  | Namespace
+  | Imported_module
+  | Unspecified_type
+  | Partial_unit
+  | Imported_unit
+  | Condition
+  | Shared_type
+  | Type_unit
+  | Rvalue_reference_type
+  | Template_alias
+  | Coarray_type
+  | Generic_subrange
+  | Dynamic_type
+  | Atomic_type
+  | Call_site
+  | Call_site_parameter
+  | Skeleton_unit
+  | Immutable_type
+  | Dwarf_4 of dwarf_4
+  | User of user
+
+let tag_name t =
+  let name =
+    match t with
+    | Array_type -> "array_type"
+    | Class_type -> "class_type"
+    | Entry_point -> "entry_point"
+    | Enumeration_type -> "enumeration_type"
+    | Formal_parameter -> "formal_parameter"
+    | Imported_declaration -> "imported_declaration"
+    | Label -> "label"
+    | Lexical_block -> "lexical_block"
+    | Member -> "member"
+    | Pointer_type -> "pointer_type"
+    | Reference_type -> "reference_type"
+    | Compile_unit -> "compile_unit"
+    | String_type -> "string_type"
+    | Structure_type -> "structure_type"
+    | Subroutine_type -> "subroutine_type"
+    | Typedef -> "typedef"
+    | Union_type -> "union_type"
+    | Unspecified_parameters -> "unspecified_parameters"
+    | Variant -> "variant"
+    | Common_block -> "common_block"
+    | Common_inclusion -> "common_inclusion"
+    | Inheritance -> "inheritance"
+    | Inlined_subroutine -> "inlined_subroutine"
+    | Module -> "module"
+    | Ptr_to_member_type -> "ptr_to_member_type"
+    | Set_type -> "set_type"
+    | Subrange_type -> "subrange_type"
+    | With_stmt -> "with_stmt"
+    | Access_declaration -> "access_declaration"
+    | Base_type -> "base_type"
+    | Catch_block -> "catch_block"
+    | Const_type -> "const_type"
+    | Constant -> "constant"
+    | Enumerator -> "enumerator"
+    | File_type -> "file_type"
+    | Friend -> "friend"
+    | Namelist -> "namelist"
+    | Namelist_item -> "namelist_item"
+    | Packed_type -> "packed_type"
+    | Subprogram -> "subprogram"
+    | Template_type_parameter -> "template_type_parameter"
+    | Template_value_parameter -> "template_value_parameter"
+    | Thrown_type -> "thrown_type"
+    | Try_block -> "try_block"
+    | Variant_part -> "variant_part"
+    | Variable -> "variable"
+    | Volatile_type -> "volatile_type"
+    | Dwarf_procedure -> "dwarf_procedure"
+    | Restrict_type -> "restrict_type"
+    | Interface_type -> "interface_type"
+    | Namespace -> "namespace"
+    | Imported_module -> "imported_module"
+    | Unspecified_type -> "unspecified_type"
+    | Partial_unit -> "partial_unit"
+    | Imported_unit -> "imported_unit"
+    | Condition -> "condition"
+    | Shared_type -> "shared_type"
+    | Type_unit -> "type_unit"
+    | Rvalue_reference_type -> "rvalue_reference_type"
+    | Template_alias -> "template_alias"
+    | Coarray_type -> "coarray_type"
+    | Generic_subrange -> "generic_subrange"
+    | Dynamic_type -> "dynamic_type"
+    | Atomic_type -> "atomic_type"
+    | Call_site -> "call_site"
+    | Call_site_parameter -> "call_site_parameter"
+    | Skeleton_unit -> "skeleton_unit"
+    | Immutable_type -> "immutable_type"
+    | Dwarf_4 GNU_call_site -> "GNU_call_site"
+    | Dwarf_4 GNU_call_site_parameter -> "GNU_call_site_parameter"
+    | User i -> Format.asprintf "user_%a" Int16.print i
+  in
+  "DW_TAG_" ^ name
+
+let dw_tag_lo_user = Int16.of_int_exn 0x4080
+(* The high limit should be [0xffff], but we can't currently encode this since
+   [Int16.t] is signed. *)
+let dw_tag_hi_user = Int16.of_int_exn 0x7fff
+
+let encode t =
+  let code =
+    match t with
+    | Array_type -> 0x01
+    | Class_type -> 0x02
+    | Entry_point -> 0x03
+    | Enumeration_type -> 0x04
+    | Formal_parameter -> 0x05
+    | Imported_declaration -> 0x08
+    | Label -> 0x0a
+    | Lexical_block -> 0x0b
+    | Member -> 0x0d
+    | Pointer_type -> 0x0f
+    | Reference_type -> 0x10
+    | Compile_unit -> 0x11
+    | String_type -> 0x12
+    | Structure_type -> 0x13
+    | Subroutine_type -> 0x15
+    | Typedef -> 0x16
+    | Union_type -> 0x17
+    | Unspecified_parameters -> 0x18
+    | Variant -> 0x19
+    | Common_block -> 0x1a
+    | Common_inclusion -> 0x1b
+    | Inheritance -> 0x1c
+    | Inlined_subroutine -> 0x1d
+    | Module -> 0x1e
+    | Ptr_to_member_type -> 0x1f
+    | Set_type -> 0x20
+    | Subrange_type -> 0x21
+    | With_stmt -> 0x22
+    | Access_declaration -> 0x23
+    | Base_type -> 0x24
+    | Catch_block -> 0x25
+    | Const_type -> 0x26
+    | Constant -> 0x27
+    | Enumerator -> 0x28
+    | File_type -> 0x29
+    | Friend -> 0x2a
+    | Namelist -> 0x2b
+    | Namelist_item -> 0x2c
+    | Packed_type -> 0x2d
+    | Subprogram -> 0x2e
+    | Template_type_parameter -> 0x2f
+    | Template_value_parameter -> 0x30
+    | Thrown_type -> 0x31
+    | Try_block -> 0x32
+    | Variant_part -> 0x33
+    | Variable -> 0x34
+    | Volatile_type -> 0x35
+    | Dwarf_procedure -> 0x36
+    | Restrict_type -> 0x37
+    | Interface_type -> 0x38
+    | Namespace -> 0x39
+    | Imported_module -> 0x3a
+    | Unspecified_type -> 0x3b
+    | Partial_unit -> 0x3c
+    | Imported_unit -> 0x3d
+    | Condition -> 0x3f
+    | Shared_type -> 0x40
+    | Type_unit -> 0x41
+    | Rvalue_reference_type -> 0x42
+    | Template_alias -> 0x43
+    | Coarray_type -> 0x44
+    | Generic_subrange -> 0x45
+    | Dynamic_type -> 0x46
+    | Atomic_type -> 0x47
+    | Call_site -> 0x48
+    | Call_site_parameter -> 0x49
+    | Skeleton_unit -> 0x4a
+    | Immutable_type -> 0x4b
+    | Dwarf_4 GNU_call_site -> 0x4109
+    | Dwarf_4 GNU_call_site_parameter -> 0x410a
+    | User code ->
+      assert (code >= dw_tag_lo_user && code <= dw_tag_hi_user);
+      Int16.to_int code
+  in
+  Dwarf_value.uleb128 ~comment:(tag_name t) (Uint64.of_nonnegative_int_exn code)
+
+let size t =
+  Dwarf_value.size (encode t)
+
+let emit ~params t =
+  Dwarf_value.emit ~params (encode t)
+
+let compare t1 t2 = Stdlib.compare t1 t2

--- a/backend/debug/dwarf/dwarf_low/dwarf_tag.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_tag.mli
@@ -1,0 +1,105 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Varieties of debugging information entries (DIEs), known as "tags".
+    These are held within abbreviation table entries rather than within
+    the DIE structures themselves.
+*)
+
+type user = private Numbers_extra.Int16.t
+
+type dwarf_4 =
+  | GNU_call_site
+  | GNU_call_site_parameter
+
+(** We omit the "DW_TAG_" prefix. *)
+type t =
+  | Array_type
+  | Class_type
+  | Entry_point
+  | Enumeration_type
+  | Formal_parameter
+  | Imported_declaration
+  | Label
+  | Lexical_block
+  | Member
+  | Pointer_type
+  | Reference_type
+  | Compile_unit
+  | String_type
+  | Structure_type
+  | Subroutine_type
+  | Typedef
+  | Union_type
+  | Unspecified_parameters
+  | Variant
+  | Common_block
+  | Common_inclusion
+  | Inheritance
+  | Inlined_subroutine
+  | Module
+  | Ptr_to_member_type
+  | Set_type
+  | Subrange_type
+  | With_stmt
+  | Access_declaration
+  | Base_type
+  | Catch_block
+  | Const_type
+  | Constant
+  | Enumerator
+  | File_type
+  | Friend
+  | Namelist
+  | Namelist_item
+  | Packed_type
+  | Subprogram
+  | Template_type_parameter
+  | Template_value_parameter
+  | Thrown_type
+  | Try_block
+  | Variant_part
+  | Variable
+  | Volatile_type
+  | Dwarf_procedure
+  | Restrict_type
+  | Interface_type
+  | Namespace
+  | Imported_module
+  | Unspecified_type
+  | Partial_unit
+  | Imported_unit
+  | Condition
+  | Shared_type
+  | Type_unit
+  | Rvalue_reference_type
+  | Template_alias
+  | Coarray_type
+  | Generic_subrange
+  | Dynamic_type
+  | Atomic_type
+  | Call_site
+  | Call_site_parameter
+  | Skeleton_unit
+  | Immutable_type
+  | Dwarf_4 of dwarf_4
+  | User of user
+
+include Dwarf_emittable.S with type t := t
+
+val tag_name : t -> string
+
+val compare : t -> t -> int

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.ml
@@ -1,0 +1,436 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* CR mshinwell: Review again, especially the distance-measuring parts. *)
+
+(** Values written into DWARF sections.
+    (For attribute values, see [Dwarf_attribute_values].)
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+
+module Int8 = Numbers_extra.Int8
+module Int16 = Numbers_extra.Int16
+
+module Uint8 = Numbers_extra.Uint8
+module Uint16 = Numbers_extra.Uint16
+module Uint32 = Numbers_extra.Uint32
+module Uint64 = Numbers_extra.Uint64
+
+type value =
+  | Flag_true
+  | Bool of bool
+  | Int8 of Int8.t
+  | Int16 of Int16.t
+  | Int32 of Int32.t
+  | Int64 of Int64.t
+  | Uint8 of Uint8.t
+  | Uint16 of Uint16.t
+  | Uint32 of Uint32.t
+  | Uint64 of Uint64.t
+  | Uleb128 of Uint64.t
+  | Sleb128 of Int64.t
+  | String of string
+  | Indirect_string of string
+  | Absolute_address of Targetint_extra.t
+  | Code_address_from_label of Asm_label.t
+  | Code_address_from_symbol of Asm_symbol.t
+  | Code_address_from_label_symbol_diff of {
+      upper : Asm_label.t;
+      lower : Asm_symbol.t;
+      offset_upper : Targetint_extra.t;
+    }
+  | Code_address_from_symbol_diff of {
+      upper : Asm_symbol.t;
+      lower : Asm_symbol.t;
+    }
+  | Code_address_from_symbol_plus_bytes of {
+      sym : Asm_symbol.t;
+      offset_in_bytes : Targetint_extra.t;
+    }
+  | Offset_into_debug_info of Asm_label.t
+  | Offset_into_debug_info_from_symbol of Asm_symbol.t
+  | Offset_into_debug_line of Asm_label.t
+  | Offset_into_debug_line_from_symbol of Asm_symbol.t
+  | Offset_into_debug_addr of Asm_label.t
+  | Offset_into_debug_loc of Asm_label.t
+  | Offset_into_debug_ranges of Asm_label.t
+  | Offset_into_debug_loclists of Asm_label.t
+  | Offset_into_debug_rnglists of Asm_label.t
+  | Offset_into_debug_abbrev of Asm_label.t
+  | Distance_between_labels_16_bit of {
+      upper : Asm_label.t;
+      lower : Asm_label.t;
+    }
+  | Distance_between_labels_32_bit of {
+      upper : Asm_label.t;
+      lower : Asm_label.t;
+    }
+  | Distance_between_labels_64_bit of {
+      upper : Asm_label.t;
+      lower : Asm_label.t;
+    }
+
+type t = {
+  value : value;
+  comment : string option;
+}
+
+let print ppf { value; comment = _; } =
+  match value with
+  | Flag_true -> Format.pp_print_string ppf "true"
+  | Bool b -> Format.fprintf ppf "%b" b
+  | Int8 i -> Int8.print ppf i
+  | Int16 i -> Int16.print ppf i
+  | Int32 i -> Format.fprintf ppf "%ld" i
+  | Int64 i -> Format.fprintf ppf "%Ld" i
+  | Uint8 i -> Uint8.print ppf i
+  | Uint16 i -> Uint16.print ppf i
+  | Uint32 i -> Uint32.print ppf i
+  | Uint64 i -> Uint64.print ppf i
+  | Uleb128 i -> Format.fprintf ppf "(uleb128 %a)" Uint64.print i
+  | Sleb128 i -> Format.fprintf ppf "(sleb128 %Ld)" i
+  | String str -> Format.fprintf ppf "\"%S\"" str
+  | Indirect_string str ->
+    Format.fprintf ppf "\"%S\" [indirect]" str
+  | Absolute_address addr ->
+    Format.fprintf ppf "0x%Lx" (Targetint_extra.to_int64 addr)
+  | Code_address_from_label lbl -> Asm_label.print ppf lbl
+  | Code_address_from_symbol sym -> Asm_symbol.print ppf sym
+  | Code_address_from_label_symbol_diff { upper; lower; offset_upper; } ->
+    Format.fprintf ppf "(%a + %a) - %a"
+      Asm_label.print upper
+      Targetint_extra.print offset_upper
+      Asm_symbol.print lower
+  | Code_address_from_symbol_diff { upper; lower; } ->
+    Format.fprintf ppf "%a - %a"
+      Asm_symbol.print upper
+      Asm_symbol.print lower
+  | Code_address_from_symbol_plus_bytes { sym; offset_in_bytes; } ->
+    Format.fprintf ppf "%a + %a"
+      Asm_symbol.print sym
+      Targetint_extra.print offset_in_bytes
+  | Offset_into_debug_info lbl ->
+    Format.fprintf ppf "%a - .debug_info" Asm_label.print lbl
+  | Offset_into_debug_info_from_symbol sym ->
+    Format.fprintf ppf "%a - .debug_info" Asm_symbol.print sym
+  | Offset_into_debug_line lbl ->
+    Format.fprintf ppf "%a - .debug_line" Asm_label.print lbl
+  | Offset_into_debug_line_from_symbol sym ->
+    Format.fprintf ppf "%a - .debug_line" Asm_symbol.print sym
+  | Offset_into_debug_addr lbl ->
+    Format.fprintf ppf "%a - .debug_addr" Asm_label.print lbl
+  | Offset_into_debug_loc lbl ->
+    Format.fprintf ppf "%a - .debug_loc" Asm_label.print lbl
+  | Offset_into_debug_ranges lbl ->
+    Format.fprintf ppf "%a - .debug_ranges" Asm_label.print lbl
+  | Offset_into_debug_loclists lbl ->
+    Format.fprintf ppf "%a - .debug_loclists" Asm_label.print lbl
+  | Offset_into_debug_rnglists lbl ->
+    Format.fprintf ppf "%a - .debug_rnglists" Asm_label.print lbl
+  | Offset_into_debug_abbrev lbl ->
+    Format.fprintf ppf "%a - .debug_abbrev" Asm_label.print lbl
+  | Distance_between_labels_16_bit { upper; lower; } ->
+    Format.fprintf ppf "%a - %a (16)"
+      Asm_label.print upper
+      Asm_label.print lower
+  | Distance_between_labels_32_bit { upper; lower; } ->
+    Format.fprintf ppf "%a - %a (32)"
+      Asm_label.print upper
+      Asm_label.print lower
+  | Distance_between_labels_64_bit { upper; lower; } ->
+    Format.fprintf ppf "%a - %a (64)"
+      Asm_label.print upper
+      Asm_label.print lower
+
+let flag_true ?comment () = { value = Flag_true; comment; }
+
+let bool ?comment b = { value = Bool b; comment; }
+
+let int8 ?comment i = { value = Int8 i; comment; }
+
+let int16 ?comment i = { value = Int16 i; comment; }
+
+let int32 ?comment i = { value = Int32 i; comment; }
+
+let int64 ?comment i = { value = Int64 i; comment; }
+
+let uint8 ?comment i = { value = Uint8 i; comment; }
+
+let uint16 ?comment i = { value = Uint16 i; comment; }
+
+let uint32 ?comment i = { value = Uint32 i; comment; }
+
+let uint64 ?comment i = { value = Uint64 i; comment; }
+
+let uleb128 ?comment i = { value = Uleb128 i; comment; }
+
+let sleb128 ?comment i = { value = Sleb128 i; comment; }
+
+let string ?comment str = { value = String str; comment; }
+
+let indirect_string ?comment str = { value = Indirect_string str; comment; }
+
+let absolute_address ?comment addr = { value = Absolute_address addr; comment; }
+
+let code_address_from_label ?comment lbl =
+  { value = Code_address_from_label lbl;
+    comment;
+  }
+
+let code_address_from_symbol ?comment sym =
+  { value = Code_address_from_symbol sym;
+    comment;
+  }
+
+let code_address_from_label_symbol_diff ?comment ~upper ~lower
+      ~offset_upper () =
+  { value = Code_address_from_label_symbol_diff { upper; lower; offset_upper; };
+    comment;
+  }
+
+let code_address_from_symbol_diff ?comment ~upper ~lower () =
+  { value = Code_address_from_symbol_diff { upper; lower; };
+    comment;
+  }
+
+let code_address_from_symbol_plus_bytes sym offset_in_bytes =
+  { value = Code_address_from_symbol_plus_bytes { sym; offset_in_bytes; };
+    comment = None;
+  }
+
+let offset_into_debug_info ?comment lbl =
+  { value = Offset_into_debug_info lbl;
+    comment;
+  }
+
+let offset_into_debug_info_from_symbol ?comment sym =
+  { value = Offset_into_debug_info_from_symbol sym;
+    comment;
+  }
+
+let offset_into_debug_line ?comment lbl =
+  { value = Offset_into_debug_line lbl;
+    comment;
+  }
+
+let offset_into_debug_line_from_symbol ?comment sym =
+  { value = Offset_into_debug_line_from_symbol sym;
+    comment;
+  }
+
+let offset_into_debug_addr ?comment lbl =
+  { value = Offset_into_debug_addr lbl;
+    comment;
+  }
+
+let offset_into_debug_loc ?comment lbl =
+  { value = Offset_into_debug_loc lbl;
+    comment;
+  }
+ 
+let offset_into_debug_ranges ?comment lbl =
+  { value = Offset_into_debug_ranges lbl;
+    comment;
+  }
+
+let offset_into_debug_loclists ?comment lbl =
+  { value = Offset_into_debug_loclists lbl;
+    comment;
+  }
+
+let offset_into_debug_rnglists ?comment lbl =
+  { value = Offset_into_debug_rnglists lbl;
+    comment;
+  }
+
+let offset_into_debug_abbrev ?comment lbl =
+  { value = Offset_into_debug_abbrev lbl;
+    comment;
+  }
+
+let distance_between_labels_16_bit ?comment ~upper ~lower () =
+  { value = Distance_between_labels_16_bit { upper; lower; };
+    comment;
+  }
+
+let distance_between_labels_32_bit ?comment ~upper ~lower () =
+  { value = Distance_between_labels_32_bit { upper; lower; };
+    comment;
+  }
+
+let distance_between_labels_64_bit ?comment ~upper ~lower () =
+  { value = Distance_between_labels_64_bit { upper; lower; };
+    comment;
+  }
+
+let append_to_comment { value; comment; } to_append =
+  let comment =
+    match comment with
+    | None -> Some to_append
+    | Some comment -> Some (comment ^ " " ^ to_append)
+  in
+  { value; comment; }
+
+(* DWARF-4 standard section 7.6. *)
+let uleb128_size i =
+  let rec uleb128_size i =
+    if Int64.compare i 128L < 0 then Dwarf_int.one ()
+    else Dwarf_int.succ (uleb128_size (Int64.shift_right_logical i 7))
+  in
+  let i = Uint64.to_int64 i in
+  if Int64.compare i 0L < 0 then begin
+    Misc.fatal_errorf "Cannot compute ULEB128 encodings on unsigned numbers \
+      that don't fit in [Int64].t"
+  end;
+  uleb128_size i
+
+let rec sleb128_size i =
+  if Int64.compare i (-64L) >= 0 && Int64.compare i 64L < 0 then
+    Dwarf_int.one ()
+  else
+    Dwarf_int.succ (sleb128_size (Int64.shift_right i 7))
+
+let size { value; comment = _; } =
+  match value with
+  | Flag_true -> Dwarf_int.zero ()  (* see comment below *)
+  | Bool _ -> Dwarf_int.one ()
+  | Int8 _ | Uint8 _ -> Dwarf_int.one ()
+  | Int16 _ | Uint16 _ -> Dwarf_int.two ()
+  | Int32 _ | Uint32 _ -> Dwarf_int.four ()
+  | Int64 _ | Uint64 _ -> Dwarf_int.eight ()
+  | Uleb128 i -> uleb128_size i
+  | Sleb128 i -> sleb128_size i
+  | Absolute_address _
+  | Code_address_from_label _
+  | Code_address_from_symbol _
+  | Code_address_from_label_symbol_diff _
+  | Code_address_from_symbol_diff _
+  | Code_address_from_symbol_plus_bytes _ ->
+    begin match Targetint_extra.size with
+    | 32 -> Dwarf_int.four ()
+    | 64 -> Dwarf_int.eight ()
+    | bits -> Misc.fatal_errorf "Unsupported Targetint_extra.size %d" bits
+    end
+  | String str ->
+    Dwarf_int.of_targetint_exn (Targetint_extra.of_int (String.length str + 1))
+  | Indirect_string _
+  | Offset_into_debug_line _
+  | Offset_into_debug_line_from_symbol _
+  | Offset_into_debug_info _
+  | Offset_into_debug_info_from_symbol _
+  | Offset_into_debug_addr _
+  | Offset_into_debug_loc _
+  | Offset_into_debug_ranges _
+  | Offset_into_debug_loclists _
+  | Offset_into_debug_rnglists _
+  | Offset_into_debug_abbrev _ -> Dwarf_int.size (Dwarf_int.zero ())
+  | Distance_between_labels_16_bit _ -> Dwarf_int.two ()
+  | Distance_between_labels_32_bit _ -> Dwarf_int.four ()
+  | Distance_between_labels_64_bit _ -> Dwarf_int.eight ()
+
+let emit ~params { value; comment; } =
+  let module Params = (val params : Dwarf_params.S) in
+  let module A = Params.Asm_directives in
+  let width_for_ref_addr_or_sec_offset () : Machine_width.t =
+    (* DWARF-4 specification p.142. *)
+    match Dwarf_format.get () with
+    | Thirty_two -> Thirty_two
+    | Sixty_four -> Sixty_four
+  in
+  match value with
+  | Flag_true ->
+    (* See DWARF-4 specification p.148 *)
+    begin match comment with
+    | None -> ()
+    | Some comment -> A.comment (comment ^ " (Flag_true elided)")
+    end
+  | Bool b -> A.int8 ?comment (if b then Int8.one else Int8.zero)
+  | Int8 i -> A.int8 ?comment i
+  | Int16 i -> A.int16 ?comment i
+  | Int32 i -> A.int32 ?comment i
+  | Int64 i -> A.int64 ?comment i
+  | Uint8 i -> A.uint8 ?comment i
+  | Uint16 i -> A.uint16 ?comment i
+  | Uint32 i -> A.uint32 ?comment i
+  | Uint64 i -> A.uint64 ?comment i
+  | Uleb128 i -> A.uleb128 ?comment i
+  | Sleb128 i -> A.sleb128 ?comment i
+  | String str -> A.string ?comment str
+  | Indirect_string str ->
+    (* "Indirect" strings are collected together into ".debug_str". *)
+    let label = A.cache_string ?comment (DWARF Debug_str) str in
+    A.offset_into_dwarf_section_label ?comment Debug_str label
+      ~width:(width_for_ref_addr_or_sec_offset ());
+    if !Clflags.keep_asm_file then begin
+      let str_len = String.length str in
+      let max_str_len = 30 in
+      let abbrev =
+        if str_len <= max_str_len then
+          Printf.sprintf "  (.debug_str entry is %S)" str
+        else
+          let abbrev = (String.sub str 0 max_str_len) in
+          Printf.sprintf "  (.debug_str entry starts %S [...])" abbrev
+      in
+      A.comment abbrev
+    end
+  | Absolute_address addr -> A.targetint ?comment addr
+  | Code_address_from_label lbl -> A.label ?comment lbl
+  | Code_address_from_symbol sym -> A.symbol ?comment sym
+  | Code_address_from_label_symbol_diff { upper; lower; offset_upper; } ->
+    A.between_symbol_in_current_unit_and_label_offset ?comment
+      ~upper ~lower ~offset_upper ()
+  | Code_address_from_symbol_diff { upper; lower; } ->
+    A.between_symbols_in_current_unit ~upper ~lower
+  | Code_address_from_symbol_plus_bytes { sym; offset_in_bytes; } ->
+    A.symbol_plus_offset sym ~offset_in_bytes
+  | Offset_into_debug_line label ->
+    A.offset_into_dwarf_section_label ?comment Debug_line label
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Offset_into_debug_line_from_symbol symbol ->
+    A.offset_into_dwarf_section_symbol ?comment Debug_line symbol
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Offset_into_debug_info lbl ->
+    A.offset_into_dwarf_section_label ?comment Debug_info lbl
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Offset_into_debug_info_from_symbol sym ->
+    A.offset_into_dwarf_section_symbol ?comment Debug_info sym
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Offset_into_debug_addr label ->
+    A.offset_into_dwarf_section_label ?comment Debug_addr label
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Offset_into_debug_loc label ->
+    A.offset_into_dwarf_section_label ?comment Debug_loc label
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Offset_into_debug_ranges label ->
+    A.offset_into_dwarf_section_label ?comment Debug_ranges label
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Offset_into_debug_loclists label ->
+    A.offset_into_dwarf_section_label ?comment Debug_loclists label
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Offset_into_debug_rnglists label ->
+    A.offset_into_dwarf_section_label ?comment Debug_rnglists label
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Offset_into_debug_abbrev label ->
+    A.offset_into_dwarf_section_label ?comment Debug_abbrev label
+      ~width:(width_for_ref_addr_or_sec_offset ())
+  | Distance_between_labels_16_bit { upper; lower; } ->
+    (* We rely on the assembler for overflow checking here and in the
+       32-bit case below. *)
+    A.between_labels_16_bit ?comment ~upper ~lower ()
+  | Distance_between_labels_32_bit { upper; lower; } ->
+    A.between_labels_32_bit ?comment ~upper ~lower ()
+  | Distance_between_labels_64_bit { upper; lower; } ->
+    A.between_labels_64_bit ?comment ~upper ~lower ()

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.mli
@@ -1,0 +1,126 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Values written into DWARF sections.
+    (For attribute values, see [Dwarf_attribute_values].)
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+val flag_true : ?comment:string -> unit -> t
+
+val bool : ?comment:string -> bool -> t
+
+val int8 : ?comment:string -> Numbers_extra.Int8.t -> t
+
+val int16 : ?comment:string -> Numbers_extra.Int16.t -> t
+
+val int32 : ?comment:string -> Int32.t -> t
+
+val int64 : ?comment:string -> Int64.t -> t
+
+val uint8 : ?comment:string -> Numbers_extra.Uint8.t -> t
+
+val uint16 : ?comment:string -> Numbers_extra.Uint16.t -> t
+
+val uint32 : ?comment:string -> Numbers_extra.Uint32.t -> t
+
+val uint64 : ?comment:string -> Numbers_extra.Uint64.t -> t
+
+val uleb128 : ?comment:string -> Numbers_extra.Uint64.t -> t
+
+val sleb128 : ?comment:string -> Int64.t -> t
+
+val string : ?comment:string -> string -> t
+
+val indirect_string : ?comment:string -> string -> t
+
+val absolute_address : ?comment:string -> Targetint_extra.t -> t
+
+val code_address_from_label : ?comment:string -> Asm_label.t -> t
+
+val code_address_from_symbol : ?comment:string -> Asm_symbol.t -> t
+
+(** The calculation is: (upper + offset_upper) - lower. *)
+(* CR mshinwell: This doesn't form a code address. *)
+val code_address_from_label_symbol_diff
+   : ?comment:string
+  -> upper:Asm_label.t
+  -> lower:Asm_symbol.t
+  -> offset_upper:Targetint_extra.t
+  -> unit
+  -> t
+
+val code_address_from_symbol_diff
+   : ?comment:string
+  -> upper:Asm_symbol.t
+  -> lower:Asm_symbol.t
+  -> unit
+  -> t
+
+val code_address_from_symbol_plus_bytes : Asm_symbol.t -> Targetint_extra.t -> t
+
+val offset_into_debug_info : ?comment:string -> Asm_label.t -> t
+
+val offset_into_debug_info_from_symbol : ?comment:string -> Asm_symbol.t -> t
+
+val offset_into_debug_line : ?comment:string -> Asm_label.t -> t
+
+val offset_into_debug_line_from_symbol : ?comment:string -> Asm_symbol.t -> t
+
+(** Not for use for DWARF >= version 5. *)
+val offset_into_debug_loc : ?comment:string -> Asm_label.t -> t
+
+(** Not for use for DWARF >= version 5. *)
+val offset_into_debug_ranges : ?comment:string -> Asm_label.t -> t
+
+(** Not for use for DWARF < version 5. *)
+val offset_into_debug_addr : ?comment:string -> Asm_label.t -> t
+
+(** Not for use for DWARF < version 5. *)
+val offset_into_debug_loclists : ?comment:string -> Asm_label.t -> t
+
+(** Not for use for DWARF < version 5. *)
+val offset_into_debug_rnglists : ?comment:string -> Asm_label.t -> t
+
+val offset_into_debug_abbrev : ?comment:string -> Asm_label.t -> t
+
+val distance_between_labels_16_bit
+   : ?comment:string
+  -> upper:Asm_label.t
+  -> lower:Asm_label.t
+  -> unit
+  -> t
+
+val distance_between_labels_32_bit
+   : ?comment:string
+  -> upper:Asm_label.t
+  -> lower:Asm_label.t
+  -> unit
+  -> t
+
+val distance_between_labels_64_bit
+   : ?comment:string
+  -> upper:Asm_label.t
+  -> lower:Asm_label.t
+  -> unit
+  -> t
+
+val append_to_comment : t -> string -> t
+
+val print : Format.formatter -> t -> unit
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/dwarf_version.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_version.ml
@@ -1,0 +1,38 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Four
+  | Five
+
+let four = Four
+let five = Five
+
+let code t =
+  match t with
+  | Four -> 4
+  | Five -> 5
+
+let encode t =
+  Dwarf_value.int16 ~comment:"DWARF version" (Numbers_extra.Int16.of_int_exn (code t))
+
+let size t =
+  Dwarf_value.size (encode t)
+
+let emit ~params t =
+  Dwarf_value.emit ~params (encode t)
+
+let compare t1 t2 = Stdlib.compare (code t1) (code t2)

--- a/backend/debug/dwarf/dwarf_low/dwarf_version.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_version.mli
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Versions of the DWARF standard. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = private
+  | Four
+  | Five
+
+include Dwarf_emittable.S with type t := t
+
+val four : t
+val five : t
+
+val compare : t -> t -> int

--- a/backend/debug/dwarf/dwarf_low/encoding_attribute.ml
+++ b/backend/debug/dwarf/dwarf_low/encoding_attribute.ml
@@ -1,0 +1,36 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | DW_ATE_signed
+  | DW_ATE_float
+
+let signed = DW_ATE_signed
+let float = DW_ATE_float
+
+let name t =
+  match t with
+  | DW_ATE_signed -> "DW_ATE_signed"
+  | DW_ATE_float -> "DW_ATE_float"
+
+let encode = function
+  | DW_ATE_float -> 0x04
+  | DW_ATE_signed -> 0x05
+
+let size _t = 1
+
+let as_dwarf_value t =
+  Dwarf_value.int8 ~comment:(name t) (Numbers_extra.Int8.of_int_exn (encode t))

--- a/backend/debug/dwarf/dwarf_low/encoding_attribute.mli
+++ b/backend/debug/dwarf/dwarf_low/encoding_attribute.mli
@@ -1,0 +1,23 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+val signed : t
+val float : t
+
+val size : t -> int
+val as_dwarf_value : t -> Dwarf_value.t

--- a/backend/debug/dwarf/dwarf_low/initial_length.ml
+++ b/backend/debug/dwarf/dwarf_low/initial_length.ml
@@ -1,0 +1,38 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* DWARF-4 standard section 7.4. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(* Even on a 32-bit platform, a DWARF section may be larger than the
+   maximum representable positive signed 32-bit integer... *)
+type t = Dwarf_int.t
+
+let create initial_length = initial_length
+
+let to_dwarf_int t = t
+
+let size t = Dwarf_int.size t
+
+let sixty_four_bit_indicator = 0xffffffffl
+
+let emit ~params t =
+  match Dwarf_format.get () with
+  | Thirty_two ->
+    Dwarf_int.emit ~params ~comment:"32-bit initial length" t
+  | Sixty_four ->
+    Dwarf_value.emit ~params (
+      Dwarf_value.int32 ~comment:"64-bit indicator" sixty_four_bit_indicator);
+    Dwarf_int.emit ~params ~comment:"64-bit initial length" t

--- a/backend/debug/dwarf/dwarf_low/initial_length.mli
+++ b/backend/debug/dwarf/dwarf_low/initial_length.mli
@@ -1,0 +1,25 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** A value of type [t] represents an "initial length"
+    (DWARF-4 standard section 7.4). *)
+type t
+
+val create : Dwarf_int.t -> t
+
+val to_dwarf_int : t -> Dwarf_int.t
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/inline_code.ml
+++ b/backend/debug/dwarf/dwarf_low/inline_code.ml
@@ -1,0 +1,42 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Not_inlined
+  | Inlined
+  | Declared_not_inlined
+  | Declared_inlined
+
+(* DWARF-5 spec. page 233, table 7.20. *)
+let code t =
+  let code =
+    match t with
+    | Not_inlined -> 0x00
+    | Inlined -> 0x01
+    | Declared_not_inlined -> 0x02
+    | Declared_inlined -> 0x03
+  in
+  Numbers_extra.Uint8.of_nonnegative_int_exn code
+
+let as_dwarf_value t = 
+  let comment =
+    match t with
+    | Not_inlined -> "not inlined"
+    | Inlined -> "inlined"
+    | Declared_not_inlined -> "declared `not inlined'"
+    | Declared_inlined -> "declared `inlined'"
+  in
+  Dwarf_value.uint8 ~comment (code t)

--- a/backend/debug/dwarf/dwarf_low/inline_code.mli
+++ b/backend/debug/dwarf/dwarf_low/inline_code.mli
@@ -1,0 +1,25 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** DWARF "inline codes" (Table 3.4, DWARF-4 spec page 81). *)
+
+type t =
+  | Not_inlined
+  | Inlined
+  | Declared_not_inlined
+  | Declared_inlined
+
+val as_dwarf_value : t -> Dwarf_value.t

--- a/backend/debug/dwarf/dwarf_low/location_list.ml
+++ b/backend/debug/dwarf/dwarf_low/location_list.ml
@@ -1,0 +1,17 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include Location_or_range_list.Make (Location_list_entry)

--- a/backend/debug/dwarf/dwarf_low/location_list.mli
+++ b/backend/debug/dwarf/dwarf_low/location_list.mli
@@ -1,0 +1,21 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF location lists. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include module type of struct
+  include Location_or_range_list.Make (Location_list_entry)
+end

--- a/backend/debug/dwarf/dwarf_low/location_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/location_list_entry.ml
@@ -1,0 +1,33 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include Location_or_range_list_entry.Make (struct
+  module Payload = Counted_location_description
+
+  let code_for_entry_kind (entry : _ Location_or_range_list_entry.entry) =
+    match entry with
+    (* DWARF-5 spec page 227. *)
+    | End_of_list -> 0x00
+    | Base_addressx _ -> 0x01
+    | Startx_endx _ -> 0x02
+    | Startx_length _ -> 0x03
+    | Offset_pair _ -> 0x04
+    | Base_address _ -> 0x06
+    | Start_end _ -> 0x07
+    | Start_length _ -> 0x08
+
+  let section : Asm_section.dwarf_section = Debug_loclists
+end)

--- a/backend/debug/dwarf/dwarf_low/location_list_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/location_list_entry.mli
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF location list entries (DWARF-5 spec section 2.6.2, pages 43--45). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include Location_or_range_list_entry.S
+  with type payload = Counted_location_description.t

--- a/backend/debug/dwarf/dwarf_low/location_list_table.ml
+++ b/backend/debug/dwarf/dwarf_low/location_list_table.ml
@@ -1,0 +1,17 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include Location_or_range_list_table.Make (Location_list)

--- a/backend/debug/dwarf/dwarf_low/location_list_table.mli
+++ b/backend/debug/dwarf/dwarf_low/location_list_table.mli
@@ -1,0 +1,21 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF location list tables (DWARF-5 spec section 7.29, page 243). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include module type of struct
+  include Location_or_range_list_table.Make (Location_list)
+end

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list.ml
@@ -1,0 +1,41 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+
+module Make (Entry : Location_or_range_list_entry.S) = struct
+  type t = Entry.t list
+
+  let create () = []
+
+  let add t entry = entry :: t
+
+  let section = Entry.section
+
+  let size t =
+    List.fold_left (fun size entry ->
+        Dwarf_int.add size (Entry.size entry))
+      (Dwarf_int.zero ())
+      t
+
+  let emit ~params t =
+    let module Params = (val params : Dwarf_params.S) in
+    let module A = Params.Asm_directives in
+    A.comment "Start of list:";
+    A.new_line ();
+    List.iter (fun entry ->
+        Entry.emit ~params entry)
+      (List.rev t)
+end

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list.mli
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list.mli
@@ -1,0 +1,29 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Functor for the production of DWARF location or range list modules. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Make (Entry : Location_or_range_list_entry.S) : sig
+  type t
+
+  val create : unit -> t
+
+  val add : t -> Entry.t -> t
+
+  val section : Asm_section.dwarf_section
+
+  include Dwarf_emittable.S with type t := t
+end

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
@@ -1,0 +1,235 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Int8 = Numbers_extra.Int8
+
+type 'payload entry =
+  | End_of_list
+  | Base_addressx of Address_index.t
+  | Startx_endx of {
+      start_inclusive : Address_index.t;
+      end_exclusive : Address_index.t;
+      payload : 'payload;
+    }
+  | Startx_length of {
+      start_inclusive : Address_index.t;
+      length : Targetint_extra.t;
+      payload : 'payload;
+    }
+  | Offset_pair of {
+      start_offset_inclusive : Targetint_extra.t;
+      end_offset_exclusive : Targetint_extra.t;
+      payload : 'payload;
+    }
+  | Base_address of Asm_symbol.t
+  | Start_end of {
+      start_inclusive : Asm_label.t;
+      end_exclusive : Asm_label.t;
+      end_adjustment : int;
+      payload : 'payload;
+    }
+  | Start_length of {
+      start_inclusive : Asm_label.t;
+      length : Targetint_extra.t;
+      payload : 'payload;
+    }
+
+module type S = sig
+  type payload
+  type nonrec entry = payload entry
+  type t
+
+  val create : entry -> start_of_code_symbol:Asm_symbol.t -> t
+
+  val section : Asm_section.dwarf_section
+
+  include Dwarf_emittable.S with type t := t
+end
+
+module Make (P : sig
+  module Payload : Dwarf_emittable.S
+  val code_for_entry_kind : _ entry -> int
+  val section : Asm_section.dwarf_section
+end) = struct
+  module Payload = P.Payload
+
+  type payload = Payload.t
+  type nonrec entry = Payload.t entry
+
+  type t = {
+    entry : entry;
+    start_of_code_symbol : Asm_symbol.t;
+  }
+
+  let create entry ~start_of_code_symbol =
+    { entry;
+      start_of_code_symbol;
+    }
+
+  let label_address ~comment t label ~adjustment =
+    let adjustment = Targetint_extra.of_int_exn adjustment in
+    Dwarf_value.code_address_from_label_symbol_diff
+      ~comment
+      ~upper:label
+      ~lower:t.start_of_code_symbol
+      ~offset_upper:adjustment
+      ()
+
+  let section = P.section
+
+  let size0 t =
+    match t.entry with
+    | End_of_list -> Dwarf_int.zero ()
+    | Base_addressx addr_index -> Address_index.size addr_index
+    | Startx_endx {
+        start_inclusive;
+        end_exclusive;
+        payload;
+      } ->
+      Dwarf_int.add (Address_index.size start_inclusive)
+        (Dwarf_int.add (Address_index.size end_exclusive)
+          (Payload.size payload))
+    | Startx_length {
+        start_inclusive;
+        length = _;
+        payload;
+      } ->
+      Dwarf_int.add (Address_index.size start_inclusive)
+        (Dwarf_int.add
+          (Dwarf_int.of_targetint_exn (Targetint_extra.size_in_bytes_as_targetint))
+          (Payload.size payload))
+    | Offset_pair {
+        start_offset_inclusive;
+        end_offset_exclusive;
+        payload;
+      } ->
+      let start_offset_inclusive =
+        Dwarf_value.uleb128 (Targetint_extra.to_uint64_exn start_offset_inclusive)
+      in
+      let end_offset_exclusive =
+        Dwarf_value.uleb128 (Targetint_extra.to_uint64_exn end_offset_exclusive)
+      in
+      Dwarf_int.add (Dwarf_value.size start_offset_inclusive)
+        (Dwarf_int.add (Dwarf_value.size end_offset_exclusive)
+          (Payload.size payload))
+    | Base_address _sym ->
+      Dwarf_int.of_host_int_exn Dwarf_arch_sizes.size_addr
+    | Start_end {
+        start_inclusive = _;
+        end_exclusive = _;
+        end_adjustment = _;
+        payload;
+      } ->
+      Dwarf_int.add (Dwarf_int.of_host_int_exn Dwarf_arch_sizes.size_addr)
+        (Dwarf_int.add (Dwarf_int.of_host_int_exn Dwarf_arch_sizes.size_addr)
+          (Payload.size payload))
+    | Start_length {
+        start_inclusive = _;
+        length;
+        payload;
+      } ->
+      let length = Dwarf_value.uleb128 (Targetint_extra.to_uint64_exn length) in
+      Dwarf_int.add (Dwarf_int.of_host_int_exn Dwarf_arch_sizes.size_addr)
+        (Dwarf_int.add (Dwarf_value.size length)
+          (Payload.size payload))
+
+  let size t =
+    Dwarf_int.succ (size0 t)
+
+  let emit ~params t =
+    let module Params = (val params : Dwarf_params.S) in
+    let module A = Params.Asm_directives in
+    (* DWARF-5 spec page 44 lines 14--15. *)
+    A.comment "List entry:";
+    let comment =
+      if !Clflags.keep_asm_file then
+        let comment =
+          match t.entry with
+          | End_of_list -> "End_of_list"
+          | Base_addressx _ -> "Base_addressx"
+          | Startx_endx _ -> "Startx_endx"
+          | Startx_length _ -> "Startx_length"
+          | Offset_pair _ -> "Offset_pair"
+          | Base_address _ -> "Base_address"
+          | Start_end _ -> "Start_end"
+          | Start_length _ -> "Start_length"
+        in
+        Some comment
+      else
+        None
+    in
+    A.int8 ?comment (Int8.of_int_exn (P.code_for_entry_kind t.entry));
+    begin match t.entry with
+    | End_of_list -> ()
+    | Base_addressx addr_index ->
+      Address_index.emit ~params ~comment:"base address" addr_index
+    | Startx_endx {
+        start_inclusive;
+        end_exclusive;
+        payload;
+      } ->
+      Address_index.emit ~params ~comment:"start_inclusive" start_inclusive;
+      Address_index.emit ~params ~comment:"end_exclusive" end_exclusive;
+      Payload.emit ~params payload
+    | Startx_length {
+        start_inclusive;
+        length;
+        payload;
+      } ->
+      Address_index.emit ~params ~comment:"start_inclusive" start_inclusive;
+      A.targetint ~comment:"length" length;
+      Payload.emit ~params payload
+    | Offset_pair {
+        start_offset_inclusive;
+        end_offset_exclusive;
+        payload;
+      } ->
+      Dwarf_value.emit ~params (Dwarf_value.sleb128 ~comment:"start_offset_inclusive" (
+        Targetint_extra.to_int64 start_offset_inclusive));
+      Dwarf_value.emit ~params (Dwarf_value.sleb128 ~comment:"end_offset_exclusive" (
+        Targetint_extra.to_int64 end_offset_exclusive));
+      Payload.emit ~params payload
+    | Base_address sym ->
+      A.symbol sym
+    | Start_end {
+        start_inclusive;
+        end_exclusive;
+        end_adjustment;
+        payload;
+      } ->
+      Dwarf_value.emit ~params (
+        label_address ~comment:"start_inclusive" t start_inclusive
+          ~adjustment:0);
+      Dwarf_value.emit ~params (
+        label_address ~comment:"end_exclusive" t end_exclusive
+          ~adjustment:end_adjustment);
+      Payload.emit ~params payload
+    | Start_length {
+        start_inclusive;
+        length;
+        payload;
+      } ->
+      Dwarf_value.emit ~params (
+        label_address ~comment:"start_inclusive" t start_inclusive
+          ~adjustment:0);
+      Dwarf_value.emit ~params (
+        Dwarf_value.uleb128 ~comment:"length" (Targetint_extra.to_uint64_exn length));
+      Payload.emit ~params payload
+    end;
+    if !Clflags.keep_asm_file then begin
+      A.new_line ()
+    end
+end

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.mli
@@ -1,0 +1,73 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Functor for the production of DWARF location and range list entries. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** The "DW_LLE_" and "DW_RLE_" prefixes are omitted. *)
+type 'payload entry =
+  | End_of_list
+  | Base_addressx of Address_index.t
+  | Startx_endx of {
+      start_inclusive : Address_index.t;
+      end_exclusive : Address_index.t;
+      payload : 'payload;
+    }
+  | Startx_length of {
+      start_inclusive : Address_index.t;
+      length : Targetint_extra.t;
+      payload : 'payload;
+    }
+  | Offset_pair of {
+      start_offset_inclusive : Targetint_extra.t;
+      end_offset_exclusive : Targetint_extra.t;
+      payload : 'payload;
+    }
+  (** We emit [Default_location] since it is only applicable for location
+      lists and we have no use for it at present. *)
+  | Base_address of Asm_symbol.t
+  | Start_end of {
+      start_inclusive : Asm_label.t;
+      end_exclusive : Asm_label.t;
+      end_adjustment : int;
+      (** [end_adjustment] is not present in the DWARF specification.
+          It is used for one-byte adjustments to labels' addresses to ensure
+          correct delimiting of ranges. *)
+      payload : 'payload;
+    }
+  | Start_length of {
+      start_inclusive : Asm_label.t;
+      length : Targetint_extra.t;
+      payload : 'payload;
+    }
+
+module type S = sig
+  type payload
+  type nonrec entry = payload entry
+  type t
+
+  val create : entry -> start_of_code_symbol:Asm_symbol.t -> t
+
+  val section : Asm_section.dwarf_section
+
+  include Dwarf_emittable.S with type t := t
+end
+
+module Make (P : sig
+  module Payload : Dwarf_emittable.S
+  val code_for_entry_kind : _ entry -> int
+  val section : Asm_section.dwarf_section
+end)
+  : S with type payload = P.Payload.t

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
@@ -1,0 +1,133 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Uint8 = Numbers_extra.Uint8
+module Uint32 = Numbers_extra.Uint32
+module Uint64 = Numbers_extra.Uint64
+
+module Make (Location_or_range_list : sig
+  include Dwarf_emittable.S
+  val section : Asm_section.dwarf_section
+end) = struct
+  type one_list = {
+    list : Location_or_range_list.t;
+    offset_from_first_list : Dwarf_int.t;
+    label : Asm_label.t;
+  }
+
+  type t = {
+    base_addr : Asm_label.t;
+    mutable num_lists : int;
+    mutable current_offset_from_first_list : Dwarf_int.t;
+    mutable lists : one_list list;
+  }
+
+  module Index = struct
+    type t = Asm_label.t * Uint64.t
+
+    let create label index = label, Uint64.of_nonnegative_int_exn index
+
+    let to_label (label, _) = label
+    let to_uint64 (_, index) = index
+  end
+
+  let create () =
+    { base_addr = Asm_label.create (DWARF Location_or_range_list.section);
+      num_lists = 0;
+      current_offset_from_first_list = Dwarf_int.zero ();
+      lists = [];
+    }
+
+  let add t list =
+    let which_index = t.num_lists in
+    let one_list =
+      { list;
+        offset_from_first_list = t.current_offset_from_first_list;
+        label = Asm_label.create (DWARF Location_or_range_list.section);
+      }
+    in
+    t.lists <- one_list :: t.lists;
+    let next_offset_from_first_list =
+      let list_size = Location_or_range_list.size list in
+      Dwarf_int.add list_size t.current_offset_from_first_list
+    in
+    t.current_offset_from_first_list <- next_offset_from_first_list;
+    t.num_lists <- t.num_lists + 1;
+    Index.create one_list.label which_index
+
+  let base_addr t = t.base_addr
+
+  let offset_array_supported () =
+    !Clflags.gdwarf_offsets
+
+  let offset_entry_count t =
+    if offset_array_supported () then Uint32.of_nonnegative_int_exn (List.length t.lists)
+    else Uint32.zero
+
+  let offset_array_size t =
+    if offset_array_supported () then
+      Dwarf_int.of_int64_exn (
+        Int64.mul (Dwarf_int.width_as_int64 ())
+          (Uint32.to_int64 (offset_entry_count t)))
+    else
+      Dwarf_int.zero ()
+
+  let initial_length t =
+    let lists_size =
+      List.fold_left (fun lists_size { list; _ } ->
+          Dwarf_int.add lists_size (Location_or_range_list.size list))
+        (Dwarf_int.eight ())  (* DWARF-5 spec page 242 lines 12--20. *)
+        t.lists
+    in
+    Initial_length.create (Dwarf_int.add (offset_array_size t) lists_size)
+
+  let size t =
+    let initial_length = initial_length t in
+    Dwarf_int.add (Initial_length.size initial_length)
+      (Initial_length.to_dwarf_int initial_length)
+
+  let emit ~params t =
+    let module Params = (val params : Dwarf_params.S) in
+    let module A = Params.Asm_directives in
+    Initial_length.emit ~params (initial_length t);
+    Dwarf_version.emit ~params Dwarf_version.five;
+    A.uint8 ~comment:"Dwarf_arch_sizes.size_addr" (Uint8.of_nonnegative_int_exn Dwarf_arch_sizes.size_addr);
+    A.uint8 ~comment:"Segment selector size" Uint8.zero;
+    A.uint32 ~comment:"Offset entry count" (offset_entry_count t);
+    A.comment "Base label:";
+    A.define_label t.base_addr;
+    if offset_array_supported () then begin
+      A.comment "Offset array:";
+      let offset_array_size = offset_array_size t in
+      List.iteri (fun index { offset_from_first_list; _ } ->
+          let offset =
+            Dwarf_int.add offset_array_size offset_from_first_list
+          in
+          let comment =
+            if !Clflags.keep_asm_file then
+              Some (Printf.sprintf "offset to list number %d" index)
+            else
+              None
+          in
+          Dwarf_int.emit ~params ?comment offset)
+        t.lists
+    end;
+    A.comment "Range or location list(s):";
+    List.iter (fun { list; label; _ } ->
+        A.define_label label;
+        Location_or_range_list.emit ~params list)
+      t.lists
+end

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_table.mli
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_table.mli
@@ -1,0 +1,46 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Functor generating modules that handle DWARF location or range
+    list tables. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Make (Location_or_range_list : sig
+  include Dwarf_emittable.S
+  val section : Asm_section.dwarf_section
+end) : sig
+  type t
+
+  val create : unit -> t
+
+  module Index : sig
+    type t
+
+    (** [to_uint64] is used in conjunction with DWARF attributes of
+        forms [DW_FORM_loclistx] and [DW_FORM_rnglistx]. *)
+    val to_uint64 : t -> Numbers_extra.Uint64.t
+
+    (** [to_uint64] is used in conjunction with DWARF attributes of
+        form [DW_FORM_sec_offset].  Such attributes have to be used if offset
+        arrays are not supported on the host system. *)
+    val to_label : t -> Asm_label.t
+  end
+
+  val add : t -> Location_or_range_list.t -> Index.t
+
+  val base_addr : t -> Asm_label.t
+
+  include Dwarf_emittable.S with type t := t
+end

--- a/backend/debug/dwarf/dwarf_low/range_list.ml
+++ b/backend/debug/dwarf/dwarf_low/range_list.ml
@@ -1,0 +1,17 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include Location_or_range_list.Make (Range_list_entry)

--- a/backend/debug/dwarf/dwarf_low/range_list.mli
+++ b/backend/debug/dwarf/dwarf_low/range_list.mli
@@ -1,0 +1,21 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF range lists. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include module type of struct
+  include Location_or_range_list.Make (Range_list_entry)
+end

--- a/backend/debug/dwarf/dwarf_low/range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/range_list_entry.ml
@@ -1,0 +1,37 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include Location_or_range_list_entry.Make (struct
+  module Payload = struct
+    type t = unit
+    let size () = Dwarf_int.zero ()
+    let emit ~params:_ () = ()
+  end
+
+  let code_for_entry_kind (entry : _ Location_or_range_list_entry.entry) =
+    match entry with
+    (* DWARF-5 spec page 240. *)
+    | End_of_list -> 0x00
+    | Base_addressx _ -> 0x01
+    | Startx_endx _ -> 0x02
+    | Startx_length _ -> 0x03
+    | Offset_pair _ -> 0x04
+    | Base_address _ -> 0x05
+    | Start_end _ -> 0x06
+    | Start_length _ -> 0x07
+
+  let section : Asm_section.dwarf_section = Debug_rnglists
+end)

--- a/backend/debug/dwarf/dwarf_low/range_list_entry.mli
+++ b/backend/debug/dwarf/dwarf_low/range_list_entry.mli
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF range list entries (DWARF-5 spec section 2.17.3, pages 52--54). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include Location_or_range_list_entry.S
+  with type payload = unit

--- a/backend/debug/dwarf/dwarf_low/range_list_table.ml
+++ b/backend/debug/dwarf/dwarf_low/range_list_table.ml
@@ -1,0 +1,17 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include Location_or_range_list_table.Make (Range_list)

--- a/backend/debug/dwarf/dwarf_low/range_list_table.mli
+++ b/backend/debug/dwarf/dwarf_low/range_list_table.mli
@@ -1,0 +1,21 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** DWARF range list tables (DWARF-5 spec section 7.28, page 242). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include module type of struct
+  include Location_or_range_list_table.Make (Range_list)
+end

--- a/backend/debug/dwarf/dwarf_low/simple_location_description.ml
+++ b/backend/debug/dwarf/dwarf_low/simple_location_description.ml
@@ -1,0 +1,27 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Operator = Dwarf_operator
+
+type t = Dwarf_operator.t list
+
+let size t =
+  List.fold_left (fun size op -> Dwarf_int.add size (Operator.size op))
+    (Dwarf_int.zero ())
+    t
+
+let emit ~params t =
+  List.iter (fun op -> Operator.emit ~params op) t

--- a/backend/debug/dwarf/dwarf_low/simple_location_description.mli
+++ b/backend/debug/dwarf/dwarf_low/simple_location_description.mli
@@ -1,0 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = Dwarf_operator.t list
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/single_location_description.ml
+++ b/backend/debug/dwarf/dwarf_low/single_location_description.ml
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Simple of Simple_location_description.t
+  | Composite of Composite_location_description.t
+
+let of_simple_location_description sle = Simple sle
+
+let of_composite_location_description cle = Composite cle
+
+let size = function
+  | Simple sle -> Simple_location_description.size sle
+  | Composite cle -> Composite_location_description.size cle
+
+let emit ~params = function
+  | Simple sle -> Simple_location_description.emit ~params sle
+  | Composite cle -> Composite_location_description.emit ~params cle

--- a/backend/debug/dwarf/dwarf_low/single_location_description.mli
+++ b/backend/debug/dwarf/dwarf_low/single_location_description.mli
@@ -1,0 +1,23 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(* DWARF-4 spec section 2.6 (top of page 26). *)
+type t
+
+include Dwarf_emittable.S with type t := t
+
+val of_simple_location_description : Simple_location_description.t -> t
+val of_composite_location_description : Composite_location_description.t -> t

--- a/backend/debug/dwarf/dwarf_low/unit_type.ml
+++ b/backend/debug/dwarf/dwarf_low/unit_type.ml
@@ -1,0 +1,42 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Compile
+  | Type
+  | Partial
+  | Skeleton
+  | Split_compile
+  | Split_type
+
+let code t =
+  match t with
+  | Compile -> 0x01
+  | Type -> 0x02
+  | Partial -> 0x03
+  | Skeleton -> 0x04
+  | Split_compile -> 0x05
+  | Split_type -> 0x06
+
+let encode t =
+  Dwarf_value.uint8 ~comment:"Unit header unit type"
+    (Numbers_extra.Uint8.of_nonnegative_int_exn (code t))
+
+let size t =
+  Dwarf_value.size (encode t)
+
+let emit ~params t =
+  Dwarf_value.emit ~params (encode t)

--- a/backend/debug/dwarf/dwarf_low/unit_type.mli
+++ b/backend/debug/dwarf/dwarf_low/unit_type.mli
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Compilation unit header unit types (DWARF-5 spec section 7.5.1,
+    page 199). *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Compile
+  | Type
+  | Partial
+  | Skeleton
+  | Split_compile
+  | Split_type
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_ocaml/dune
+++ b/backend/debug/dwarf/dwarf_ocaml/dune
@@ -1,0 +1,9 @@
+(include_subdirs unqualified)
+
+(library
+  (name dwarf_ocaml)
+  (wrapped true)
+  (flags (:standard -principal -nostdlib))
+  (ocamlopt_flags (:standard -O3))
+  (libraries stdlib ocamlcommon ocamlbytecomp dwarf_high dwarf_low dwarf_deps)
+)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -1,0 +1,62 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open Dwarf_high
+open Dwarf_low
+
+module DS = Dwarf_state
+
+type t = {
+  state : DS.t;
+  params: (module Dwarf_params.S);
+  mutable emitted : bool;
+}
+
+(* CR mshinwell: On OS X 10.11 (El Capitan), dwarfdump doesn't seem to be able
+   to read our 64-bit DWARF output. *)
+
+let create ~sourcefile ~unit_name ~params =
+  begin match !Clflags.gdwarf_format with
+  | Thirty_two -> Dwarf_format.set Thirty_two
+  | Sixty_four -> Dwarf_format.set Sixty_four
+  end;
+  let compilation_unit_proto_die =
+    Dwarf_compilation_unit.compile_unit_proto_die ~sourcefile ~unit_name 
+  in
+  let compilation_unit_header_label = Asm_label.create (DWARF Debug_info) in
+  let state =
+    DS.create ~compilation_unit_header_label ~compilation_unit_proto_die
+  in
+  { state
+  ; params
+  ; emitted = false
+  }
+
+let dwarf_for_fundecl t fundecl =
+  Dwarf_concrete_instances.for_fundecl ~params:t.params t.state fundecl
+
+let emit t =
+  if t.emitted then begin
+    Misc.fatal_error "Cannot call [Dwarf.emit] more than once on a given \
+      value of type [Dwarf.t]"
+  end;
+  t.emitted <- true;
+  Dwarf_world.emit
+    ~params:t.params
+    ~compilation_unit_proto_die:(DS.compilation_unit_proto_die t.state)
+    ~compilation_unit_header_label:(DS.compilation_unit_header_label t.state)
+
+let emit t = Profile.record "emit_dwarf" emit t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
@@ -1,0 +1,36 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Generation and emission of DWARF debugging information for OCaml
+    compilation units. *)
+
+type t
+
+(** Create a value of type [t], which holds all state necessary to emit
+    DWARF debugging information for a single compilation unit.
+    The names of certain parameters line up with the code in [Asmgen].
+    The current [Compilation_unit] must have been set before calling this
+    function. *)
+val create
+   : sourcefile:string
+  -> unit_name:Ident.t
+  -> params:(module Dwarf_params.S)
+  -> t
+
+val dwarf_for_fundecl : t -> Dwarf_concrete_instances.fundecl -> unit
+
+(** Write the DWARF information to the assembly file.  This should only be
+    called once all (in)constants and function declarations have been passed
+    to the above functions. *)
+val emit : t -> unit

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
@@ -1,0 +1,46 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open Dwarf_high
+
+module DAH = Dwarf_attribute_helpers
+
+let compile_unit_proto_die ~sourcefile ~unit_name =
+  let cwd = Sys.getcwd () in
+  let source_directory_path, source_filename =
+    if Filename.is_relative sourcefile then cwd, sourcefile
+    else Filename.dirname sourcefile, Filename.basename sourcefile
+  in
+  let source_directory_path =
+    Location.rewrite_absolute_path source_directory_path
+  in
+  let attribute_values =
+    [ DAH.create_name source_filename
+    ; DAH.create_comp_dir source_directory_path
+      (* The [OCaml] attribute value here is only defined in DWARF-5, but
+         it doesn't mean anything else in DWARF-4, so we always emit it.
+         This saves special-case logic in gdb based on the producer name. *)
+    ; DAH.create_language OCaml
+    ; DAH.create_producer "ocamlopt"
+    ; DAH.create_ocaml_unit_name unit_name
+    ; DAH.create_ocaml_compiler_version Sys.ocaml_version
+    ; DAH.create_stmt_list ~debug_line_label:(Asm_label.for_dwarf_section Asm_section.Debug_line)
+    ] 
+  in
+  Proto_die.create ~parent:None
+    ~tag:Compile_unit
+    ~attribute_values
+    ()

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.mli
@@ -1,0 +1,24 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Construction of DWARF "compile_unit" DIEs and associated entities. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open Dwarf_high
+
+val compile_unit_proto_die
+   : sourcefile:string
+  -> unit_name:Ident.t
+  -> Proto_die.t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -1,0 +1,51 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open Dwarf_high
+
+type fundecl =
+  { fun_name : string
+  ; fun_dbg : Debuginfo.t
+  }
+
+module DAH = Dwarf_attribute_helpers
+
+let end_symbol_name start_symbol = start_symbol ^ "__end"
+
+let for_fundecl ~params:(module Params : Dwarf_params.S) state fundecl =
+  let parent = Dwarf_state.compilation_unit_proto_die state in
+  let fun_name = fundecl.fun_name in
+  let linkage_name =
+    match fundecl.fun_dbg with 
+    | [ item ] -> Debuginfo.Scoped_location.string_of_scopes item.dinfo_scopes
+    (* Not sure what to do in the cases below *)
+    | [] -> fun_name 
+    | _ -> Misc.fatal_errorf "multiple debug entries"
+  in
+  let start_sym = Asm_symbol.create fun_name in
+  let end_sym = Asm_symbol.create (end_symbol_name fun_name) in
+  let (file_num, line, startchar) =
+    let loc = Debuginfo.to_location fundecl.fun_dbg in
+    if Location.is_none loc then
+      (0, 0, 0)
+    else
+      let (file, line, startchar) = Location.get_pos_info loc.loc_start in
+      (Params.get_file_num file, line, startchar)
+  in
+  let concrete_instance_proto_die =
+    Proto_die.create ~parent:(Some parent)
+      ~tag:Subprogram
+      ~attribute_values:
+        [ DAH.create_name fun_name
+        ; DAH.create_linkage_name ~linkage_name
+        ; DAH.create_low_pc_from_symbol start_sym
+        ; DAH.create_high_pc_from_symbol ~low_pc:start_sym end_sym
+        ; DAH.create_entry_pc_from_symbol start_sym
+        ; DAH.create_decl_file file_num
+        ; DAH.create_decl_line line
+        ; DAH.create_decl_column startchar
+        ; DAH.create_stmt_list ~debug_line_label:(Asm_label.for_dwarf_section Asm_section.Debug_line)
+        ]
+      ()
+  in
+  let name = Printf.sprintf "__concrete_instance_%s" fun_name in
+  Proto_die.set_name concrete_instance_proto_die (Asm_symbol.create name)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.mli
@@ -1,0 +1,13 @@
+type fundecl =
+  { fun_name : string
+  ; fun_dbg : Debuginfo.t
+  }
+
+val for_fundecl
+   : params:(module Dwarf_params.S)
+  -> Dwarf_state.t
+  -> fundecl
+  -> unit
+
+(** End symbol name given start symbol name for a function block *)
+val end_symbol_name : string -> string

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
@@ -1,0 +1,30 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open Dwarf_high
+
+type t = {
+  compilation_unit_header_label : Asm_label.t;
+  compilation_unit_proto_die : Proto_die.t;
+}
+
+let create ~compilation_unit_header_label ~compilation_unit_proto_die =
+  { compilation_unit_header_label;
+    compilation_unit_proto_die;
+  }
+
+let compilation_unit_header_label t = t.compilation_unit_header_label
+let compilation_unit_proto_die t = t.compilation_unit_proto_die

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
@@ -1,0 +1,30 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** State that is shared amongst the various dwarf_* modules. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open Dwarf_high
+
+type t
+
+val create
+   : compilation_unit_header_label:Asm_label.t
+  -> compilation_unit_proto_die:Proto_die.t
+  -> t
+
+val compilation_unit_header_label : t -> Asm_label.t
+
+val compilation_unit_proto_die : t -> Proto_die.t

--- a/backend/emit.mli
+++ b/backend/emit.mli
@@ -17,5 +17,5 @@
 
 val fundecl: Linear.fundecl -> unit
 val data: Cmm.data_item list -> unit
-val begin_assembly: unit -> unit
-val end_assembly: unit -> unit
+val begin_assembly: init_dwarf:(unit -> unit) -> unit
+val end_assembly: Dwarf_ocaml.Dwarf.t option -> unit

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -40,6 +40,12 @@ val emit_debug_info_gen :
   (file_num:int -> line:int -> col:int -> ?discriminator:int -> unit -> unit) ->
   unit
 
+(** Get the file number associated with the filename (or allocate one) *)
+val get_file_num
+   : file_emitter:(file_num:int -> file_name:string -> unit)
+  -> string
+  -> int
+
 type frame_debuginfo =
   | Dbg_alloc of Debuginfo.alloc_dbginfo
   | Dbg_raise of Debuginfo.t

--- a/backend/x86_ast.mli
+++ b/backend/x86_ast.mli
@@ -226,10 +226,13 @@ type asm_line =
   | Hidden of string
   | Weak of string
   | Long of constant
-  | NewLabel of string * data_type
+  | New_label of string * data_type
+  | New_line
   | Quad of constant
   | Section of string list * string option * string list
+  | Sleb128 of constant
   | Space of int
+  | Uleb128 of constant
   | Word of constant
 
   (* masm only (the gas emitter will fail on them) *)
@@ -249,5 +252,8 @@ type asm_line =
   | Size of string * constant
   | Type of string * string
   | Reloc of reloc
+
+  (* MacOS only *)
+  | Direct_assignment of string * constant
 
 type asm_program = asm_line list

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -86,26 +86,30 @@ module D = struct
   let cfi_startproc () = directive Cfi_startproc
   let comment s = directive (Comment s)
   let data () = section [ ".data" ] None []
+  let direct_assignment var const = directive (Direct_assignment (var, const))
   let extrn s ptr = directive (External (s, ptr))
   let file ~file_num ~file_name = directive (File (file_num, file_name))
   let global s = directive (Global s)
   let hidden s = directive (Hidden s)
   let weak s = directive (Weak s)
   let indirect_symbol s = directive (Indirect_symbol s)
-  let label ?(typ = NONE) s = directive (NewLabel (s, typ))
+  let label ?(typ = NONE) s = directive (New_label (s, typ))
   let loc ~file_num ~line ~col ?discriminator () =
     directive (Loc { file_num; line; col; discriminator })
   let long cst = directive (Long cst)
   let mode386 () = directive Mode386
   let model name = directive (Model name)
+  let new_line () = directive New_line
   let private_extern s = directive (Private_extern s)
   let qword cst = directive (Quad cst)
   let reloc ~offset ~name ~expr = directive (Reloc { offset; name; expr })
   let setvar (x, y) = directive (Set (x, y))
   let size name cst = directive (Size (name, cst))
+  let sleb128 n = directive (Sleb128 n)
   let space n = directive (Space n)
   let text () = section [ ".text" ] None []
   let type_ name typ = directive (Type (name, typ))
+  let uleb128 n = directive (Uleb128 n)
   let word cst = directive (Word cst)
 end
 

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -76,11 +76,11 @@ module D : sig
   val cfi_startproc: unit -> unit
   val comment: string -> unit
   val data: unit -> unit
+  val direct_assignment : string -> constant -> unit
   val extrn: string -> data_type -> unit
   val file: file_num:int -> file_name:string -> unit
   val global: string -> unit
   val hidden: string -> unit
-  val weak: string -> unit
   val indirect_symbol: string -> unit
   val label: ?typ:data_type -> string -> unit
   val loc: file_num:int -> line:int -> col:int -> ?discriminator:int -> unit
@@ -88,15 +88,19 @@ module D : sig
   val long: constant -> unit
   val mode386: unit -> unit
   val model: string -> unit
+  val new_line : unit -> unit
   val private_extern: string -> unit
   val qword: constant -> unit
   val reloc: offset:constant -> name:reloc_type -> expr:constant -> unit
   val section: string list -> string option -> string list -> unit
   val setvar: string * constant -> unit
   val size: string -> constant -> unit
+  val sleb128 : constant -> unit
   val space: int -> unit
   val text: unit -> unit
   val type_: string -> string -> unit
+  val uleb128 : constant -> unit
+  val weak: string -> unit
   val word: constant -> unit
 end
 

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -274,7 +274,8 @@ let print_line b = function
   | Hidden s -> bprintf b "\t.hidden\t%s" s;
   | Weak s -> bprintf b "\t.weak\t%s" s;
   | Long n -> bprintf b "\t.long\t%a" cst n
-  | NewLabel (s, _) -> bprintf b "%s:" s
+  | New_label (s, _) -> bprintf b "%s:" s
+  | New_line -> ()
   | Quad n -> bprintf b "\t.quad\t%a" cst n
   | Section ([".data" ], _, _) -> bprintf b "\t.data"
   | Section ([".text" ], _, _) -> bprintf b "\t.text"
@@ -294,6 +295,9 @@ let print_line b = function
   | Word n ->
       if system = S_solaris then bprintf b "\t.value\t%a" cst n
       else bprintf b "\t.word\t%a" cst n
+
+  | Uleb128 n -> bprintf b "\t.uleb128\t%a" cst n
+  | Sleb128 n -> bprintf b "\t.sleb128\t%a" cst n
 
   (* gas only *)
   | Cfi_adjust_cfa_offset n -> bprintf b "\t.cfi_adjust_cfa_offset %d" n
@@ -328,6 +332,11 @@ let print_line b = function
   | Mode386
   | Model _
     -> assert false
+  
+  (* MacOS only *)
+  | Direct_assignment (var, c) -> 
+    assert (List.mem Config.system [ "macosx"; "darwin" ]);
+    bprintf b "\t%s = %a" var cst c
 
 let generate_asm oc lines =
   let b = Buffer.create 10000 in

--- a/backend/x86_masm.ml
+++ b/backend/x86_masm.ml
@@ -236,21 +236,24 @@ let print_line b = function
   | Comment s -> bprintf b " ; %s " s
   | Global s -> bprintf b "\tPUBLIC\t%s" s
   | Long n -> bprintf b "\tDWORD\t%a" cst n
-  | NewLabel (s, NONE) -> bprintf b "%s:" s
-  | NewLabel (s, ptr) -> bprintf b "%s LABEL %s" s (string_of_datatype ptr)
+  | New_label (s, NONE) -> bprintf b "%s:" s
+  | New_label (s, ptr) -> bprintf b "%s LABEL %s" s (string_of_datatype ptr)
+  | New_line -> ()
   | Quad n -> bprintf b "\tQWORD\t%a" cst n
   | Section ([".data"], None, []) -> bprintf b "\t.DATA"
   | Section ([".text"], None, []) -> bprintf b "\t.CODE"
   | Section _ -> assert false
   | Space n -> bprintf b "\tBYTE\t%d DUP (?)" n
   | Word n -> bprintf b "\tWORD\t%a" cst n
-
+  | Sleb128 _ | Uleb128 _ ->
+    Misc.fatal_error "Sleb128 and Uleb128 unsupported for MASM"
+    
   (* windows only *)
   | External (s, ptr) -> bprintf b "\tEXTRN\t%s: %s" s (string_of_datatype ptr)
   | Mode386 -> bprintf b "\t.386"
   | Model name -> bprintf b "\t.MODEL %s" name (* name = FLAT *)
 
-  (* gas only *)
+  (* gas / MacOS only *)
   | Cfi_adjust_cfa_offset _
   | Cfi_endproc
   | Cfi_startproc
@@ -264,6 +267,7 @@ let print_line b = function
   | Hidden _
   | Weak _
   | Reloc _
+  | Direct_assignment _
     -> assert false
 
 let generate_asm oc lines =

--- a/dune
+++ b/dune
@@ -113,7 +113,7 @@
     ; The driver should be in here too, but is not at present.  This might
     ; be tricky because it has a different name...
   )
-  (libraries ocamlcommon stdlib flambda2))
+  (libraries ocamlcommon stdlib flambda2 dwarf_ocaml dwarf_deps))
 
 (executable
  (name flambda_backend_main)
@@ -141,6 +141,8 @@
  (modes native)
  (flags (:standard -principal -nostdlib))
  (libraries
+   dwarf_ocaml
+   dwarf_high
    flambda_backend_driver
    memtrace
    flambda2

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -141,12 +141,330 @@ let mk_for_pack_opt f =
   \     ocamlopt -pack -o <ident>.cmx"
 ;;
 
+let mk_g0 f =
+  let help = " Do not generate debugging information (default)" in
+  "-g0", Arg.Unit f, help
+;;
+
+let mk_g1 f =
+  let help = " Generate basic debugging information" in
+  "-g1", Arg.Unit f, help
+;;
+
+let mk_g2 f =
+  let help =
+    " As for `-g1', but generate simple DWARF information for module and\
+      \n     function names, etc."
+  in
+  "-g2", Arg.Unit f, help
+;;
+
+let mk_g3 f =
+  let help =
+    " Generate DWARF information suitable for extensive use of a\n     \
+      platform debugger"
+  in
+  "-g3", Arg.Unit f, help
+;;
+
 let mk_g_byt f =
   "-g", Arg.Unit f, " Save debugging information"
 ;;
 
 let mk_g_opt f =
-  "-g", Arg.Unit f, " Record debugging information for exception backtrace"
+  "-g", Arg.Unit f, " Equivalent to `-g1'"
+;;
+
+let mk_gdwarf_format f =
+  let default =
+    match Clflags.default_gdwarf_format with
+    | Clflags.Thirty_two -> 32
+    | Clflags.Sixty_four -> 64
+  in
+  "-gdwarf-format", Arg.Int f,
+    Printf.sprintf "32|64  Set DWARF debug info format (default %d-bit)"
+      default
+;;
+
+let mk_gdwarf_version f =
+  let default =
+    match Clflags.default_gdwarf_version with
+    | Clflags.Four -> "4+gnu"
+    | Clflags.Five -> "5"
+  in
+  "-gdwarf-version", Arg.String f,
+    Printf.sprintf "5  Set DWARF debug info version (default %s; does not\
+      \n     affect CFI or line number tables)" default
+;;
+
+let mk_gocamldebug f =
+  let help =
+    " Generate debugging information for use with `ocamldebug'\n     \
+      (bytecode only)"
+      ^ Clflags.describe_debug_default Clflags.Debug_ocamldebug
+  in
+  "-gocamldebug", Arg.Unit f, help
+;;
+
+let mk_gno_ocamldebug f =
+  let help =
+    " Do not generate debugging information for use with\n     \
+      `ocamldebug' (bytecode only)"
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_subprocs
+  in
+  "-gno-ocamldebug", Arg.Unit f, help
+;;
+
+let mk_gjs_of_ocaml f =
+  let help =
+    " Generate debugging information for use with `js_of_ocaml'\n     \
+      (bytecode only)"
+      ^ Clflags.describe_debug_default Clflags.Debug_js_of_ocaml
+  in
+  "-gjs-of-ocaml", Arg.Unit f, help
+;;
+
+let mk_gno_js_of_ocaml f =
+  let help =
+    " Do not generate debugging information for use with\n     \
+      `js_of_ocaml' (bytecode only)"
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_js_of_ocaml
+  in
+  "-gno-js-of-ocaml", Arg.Unit f, help
+;;
+
+let mk_gsubprocs f =
+  let help =
+    " Pass the `-g' option to subprocesses (C compiler, ppx,\
+      \n     etc.)"
+      ^ Clflags.describe_debug_default Clflags.Debug_subprocs
+  in
+  "-gsubprocs", Arg.Unit f, help
+;;
+
+let mk_gno_subprocs f =
+  let help =
+    " Do not pass the `-g' option to subprocesses (C compiler,\
+      \n     linker, ppx, etc.)"
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_subprocs
+  in
+  "-gno-subprocs", Arg.Unit f, help
+;;
+
+let mk_gbacktraces f =
+  let help =
+    " Record backtraces and generate information to show source\
+      \n     locations within them"
+      ^ Clflags.describe_debug_default Clflags.Debug_backtraces
+  in
+  "-gbacktraces", Arg.Unit f, help
+;;
+
+let mk_gno_backtraces f =
+  let help =
+    " Do not record backtraces and generate information to show\
+      \n     source locations within them"
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_backtraces
+  in
+  "-gno-backtraces", Arg.Unit f, help
+;;
+
+let mk_gbounds_checking f =
+  let help =
+    " Increase the accuracy of bounds-check-failure\
+      \n     handlers for debugging (implies -gbacktraces)"
+      ^ Clflags.describe_debug_default Clflags.Debug_bounds_checking
+  in
+  "-gbounds-checking-precision", Arg.Unit f, help
+;;
+
+let mk_gno_bounds_checking f =
+  let help =
+    " Do not increase the accuracy of\
+      \n     bounds-check-failure handlers for debugging"
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_bounds_checking
+  in
+  "-gno-bounds-checking-precision", Arg.Unit f, help
+;;
+
+let mk_gdisable_bytecode_opt f =
+  let help =
+    " Disable certain optimisations to assist debugging\
+      \n     (bytecode only)"
+      ^ Clflags.describe_debug_default Clflags.Debug_disable_bytecode_opt
+  in
+  "-gdisable-bytecode-opt", Arg.Unit f, help
+;;
+
+let mk_gno_disable_bytecode_opt f =
+  let help =
+    " Do not disable certain optimisations to assist\
+      \n     debugging (bytecode only)"
+      ^ Clflags.describe_debug_default_negated
+          Clflags.Debug_disable_bytecode_opt
+  in
+  "-gno-disable-bytecode-opt", Arg.Unit f, help
+;;
+
+let mk_gdwarf_cfi f =
+  let help =
+    " Describe call frame information in DWARF, enabling stack\
+      \n     unwinding and backtraces in platform debuggers (implies \
+      -gsubprocs)\n    "
+      ^ Clflags.describe_debug_default Clflags.Debug_dwarf_cfi
+  in
+  "-gdwarf-cfi", Arg.Unit f, help
+;;
+
+let mk_gno_dwarf_cfi f =
+  let help =
+    " Do not describe call frame information in DWARF\n    "
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_dwarf_cfi
+  in
+  "-gno-dwarf-cfi", Arg.Unit f, help
+;;
+
+let mk_gdwarf_loc f =
+  let help =
+    " Describe source location information in DWARF (implies\
+      \n     -gdwarf-cfi)"
+      ^ Clflags.describe_debug_default Clflags.Debug_dwarf_loc
+  in
+  "-gdwarf-loc", Arg.Unit f, help
+;;
+
+let mk_gno_dwarf_loc f =
+  let help =
+    " Do not describe source location information in DWARF\n    "
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_dwarf_loc
+  in
+  "-gno-dwarf-loc", Arg.Unit f, help
+;;
+
+let mk_gdwarf_scopes f =
+  let help =
+    " Describe variable and inlined frame scoping in DWARF\
+      \n     (implies -gdwarf-loc)"
+      ^ Clflags.describe_debug_default Clflags.Debug_dwarf_scopes
+  in
+  "-gdwarf-scopes", Arg.Unit f, help
+;;
+
+let mk_gno_dwarf_scopes f =
+  let help =
+    " Do not describe variable and inlined frame scoping in DWARF\
+      \n    "
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_dwarf_scopes
+  in
+  "-gno-dwarf-scopes", Arg.Unit f, help
+;;
+
+let mk_gdwarf_vars f =
+  let help =
+    " Describe variables and function parameters in DWARF\n     \
+      (implies -gdwarf-scopes and -bin-annot)"
+      ^ Clflags.describe_debug_default Clflags.Debug_dwarf_vars
+  in
+  "-gdwarf-vars", Arg.Unit f, help
+;;
+
+let mk_gno_dwarf_vars f =
+  let help =
+    " Do not describe variables and function parameters in DWARF\
+      \n    "
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_dwarf_vars
+  in
+  "-gno-dwarf-vars", Arg.Unit f, help
+;;
+
+let mk_gdwarf_call_sites f =
+  let help =
+    " Describe call sites (and the arguments at such) in\n     DWARF \
+      (implies -gdwarf-vars)"
+      ^ Clflags.describe_debug_default Clflags.Debug_dwarf_call_sites
+  in
+  "-gdwarf-call-sites", Arg.Unit f, help
+;;
+
+let mk_gno_dwarf_call_sites f =
+  let help =
+    " Do not describe call sites (and the arguments at such)\n     in DWARF"
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_dwarf_call_sites
+  in
+  "-gno-dwarf-call-sites", Arg.Unit f, help
+;;
+
+let mk_gdwarf_cmm f =
+  let help =
+    " Generate debugging information for functions fabricated by the\n     \
+      compiler in the Cmm language and the corresponding .cmm source file\
+      \n     (implies -gdwarf-vars)"
+      ^ Clflags.describe_debug_default Clflags.Debug_dwarf_cmm
+  in
+  "-gdwarf-cmm", Arg.Unit f, help
+;;
+
+let mk_gno_dwarf_cmm f =
+  let help =
+    " Neither generate debugging information for functions \n     \
+      fabricated by the compiler in the Cmm language nor the corresponding\
+      \n     .cmm source file"
+      ^ Clflags.describe_debug_default_negated Clflags.Debug_dwarf_cmm
+  in
+  "-gno-dwarf-cmm", Arg.Unit f, help
+;;
+
+let mk_gdwarf_offsets f =
+  let help =
+    " Generate offset arrays in DWARF-5 location and range list\n     tables"
+      ^ (if Clflags.default_gdwarf_offsets then " (default)" else "")
+  in
+  "-gdwarf-offsets", Arg.Unit f, help
+;;
+
+let mk_gno_dwarf_offsets f =
+  let help =
+    " Do not generate offset arrays in DWARF-5 location and\n     \
+      range list tables"
+      ^ (if not Clflags.default_gdwarf_offsets then " (default)" else "")
+  in
+  "-gno-dwarf-offsets", Arg.Unit f, help
+;;
+
+let mk_gdwarf_self_tail_calls f =
+  let help =
+    " Generate DW_TAG_call_site for self tail calls\n     (DWARF-5 only, but \
+        not strictly DWARF-5 compliant)"
+      ^ (if Clflags.default_gdwarf_self_tail_calls then " (default)" else "")
+  in
+  "-gdwarf-self-tail-calls", Arg.Unit f, help
+;;
+
+let mk_gno_dwarf_self_tail_calls f =
+  let help =
+    " Do not generate DW_TAG_call_site for self tail\n     calls \
+        (DWARF-5 only, but not strictly DWARF-5 compliant)"
+      ^ (if not Clflags.default_gdwarf_self_tail_calls
+         then " (default)" else "")
+  in
+  "-gno-dwarf-self-tail-calls", Arg.Unit f, help
+;;
+
+let mk_ddebug_invariants f =
+  let help =
+    " Check invariants during debugging information generation\n     passes"
+      ^ (if Clflags.default_ddebug_invariants then " (default)" else "")
+  in
+  "-ddebug-invariants", Arg.Unit f, help
+;;
+
+let mk_dno_debug_invariants f =
+  let help =
+    " Do not check invariants during debugging information\n     generation \
+      passes"
+      ^ (if not Clflags.default_ddebug_invariants then " (default)" else "")
+  in
+  "-dno-debug-invariants", Arg.Unit f, help
 ;;
 
 let mk_i f =
@@ -1467,6 +1785,48 @@ module type Optcomp_options = sig
   val _save_ir_after : string -> unit
   val _probes : unit -> unit
   val _no_probes : unit -> unit
+
+  val _g0 : unit -> unit
+  val _g1 : unit -> unit
+  val _g2 : unit -> unit
+  val _g3 : unit -> unit
+
+  val _gjs_of_ocaml : unit -> unit
+  val _gno_js_of_ocaml : unit -> unit
+  val _gocamldebug : unit -> unit
+  val _gno_ocamldebug : unit -> unit
+  val _gsubprocs : unit -> unit
+  val _gno_subprocs : unit -> unit
+  val _gbacktraces : unit -> unit
+  val _gno_backtraces : unit -> unit
+  val _gbounds_checking : unit -> unit
+  val _gno_bounds_checking : unit -> unit
+  val _gdisable_bytecode_opt : unit -> unit
+  val _gno_disable_bytecode_opt : unit -> unit
+
+  val _gdwarf_format : int -> unit
+  val _gdwarf_version : string -> unit
+
+  val _gdwarf_cfi : unit -> unit
+  val _gno_dwarf_cfi : unit -> unit
+  val _gdwarf_loc : unit -> unit
+  val _gno_dwarf_loc : unit -> unit
+  val _gdwarf_scopes : unit -> unit
+  val _gno_dwarf_scopes : unit -> unit
+  val _gdwarf_vars : unit -> unit
+  val _gno_dwarf_vars : unit -> unit
+  val _gdwarf_call_sites : unit -> unit
+  val _gno_dwarf_call_sites : unit -> unit
+  val _gdwarf_cmm : unit -> unit
+  val _gno_dwarf_cmm : unit -> unit
+
+  val _gdwarf_offsets : unit -> unit
+  val _gno_dwarf_offsets : unit -> unit
+  val _gdwarf_self_tail_calls : unit -> unit
+  val _gno_dwarf_self_tail_calls : unit -> unit
+
+  val _ddebug_invariants : unit -> unit
+  val _dno_debug_invariants : unit -> unit
 end;;
 
 module type Opttop_options = sig
@@ -1891,6 +2251,47 @@ struct
 
     mk_args F._args;
     mk_args0 F._args0;
+
+    mk_g0 F._g0;
+    mk_g1 F._g1;
+    mk_g2 F._g2;
+    mk_g3 F._g3;
+    mk_gdwarf_format F._gdwarf_format;
+    mk_gdwarf_version F._gdwarf_version;
+
+    mk_gjs_of_ocaml F._gjs_of_ocaml;
+    mk_gno_js_of_ocaml F._gno_js_of_ocaml;
+    mk_gocamldebug F._gocamldebug;
+    mk_gno_ocamldebug F._gno_ocamldebug;
+    mk_gsubprocs F._gsubprocs;
+    mk_gno_subprocs F._gno_subprocs;
+    mk_gbacktraces F._gbacktraces;
+    mk_gno_backtraces F._gno_backtraces;
+    mk_gbounds_checking F._gbounds_checking;
+    mk_gno_bounds_checking F._gno_bounds_checking;
+    mk_gdisable_bytecode_opt F._gdisable_bytecode_opt;
+    mk_gno_disable_bytecode_opt F._gno_disable_bytecode_opt;
+
+    mk_gdwarf_cfi F._gdwarf_cfi;
+    mk_gno_dwarf_cfi F._gno_dwarf_cfi;
+    mk_gdwarf_loc F._gdwarf_loc;
+    mk_gno_dwarf_loc F._gno_dwarf_loc;
+    mk_gdwarf_scopes F._gdwarf_scopes;
+    mk_gno_dwarf_scopes F._gno_dwarf_scopes;
+    mk_gdwarf_vars F._gdwarf_vars;
+    mk_gno_dwarf_vars F._gno_dwarf_vars;
+    mk_gdwarf_call_sites F._gdwarf_call_sites;
+    mk_gno_dwarf_call_sites F._gno_dwarf_call_sites;
+    mk_gdwarf_cmm F._gdwarf_cmm;
+    mk_gno_dwarf_cmm F._gno_dwarf_cmm;
+
+    mk_gdwarf_offsets F._gdwarf_offsets;
+    mk_gno_dwarf_offsets F._gno_dwarf_offsets;
+    mk_gdwarf_self_tail_calls F._gdwarf_self_tail_calls;
+    mk_gno_dwarf_self_tail_calls F._gno_dwarf_self_tail_calls;
+
+    mk_ddebug_invariants F._ddebug_invariants;
+    mk_dno_debug_invariants F._dno_debug_invariants;
   ]
 end;;
 
@@ -2534,6 +2935,90 @@ module Default = struct
     let _v () = Compenv.print_version_and_library "native-code compiler"
     let _no_probes = clear probes
     let _probes = set probes
+
+    let _g0 () = use_g0 ()
+    let _g1 () = use_g1 ()
+    let _g2 () = use_g2 ()
+    let _g3 () = use_g3 ()
+
+    let _gocamldebug () = set_debug_thing Debug_ocamldebug
+    let _gno_ocamldebug () = clear_debug_thing Debug_ocamldebug
+    let _gjs_of_ocaml () = set_debug_thing Debug_js_of_ocaml
+    let _gno_js_of_ocaml () = clear_debug_thing Debug_js_of_ocaml
+    let _gsubprocs () = set_debug_thing Debug_subprocs
+    let _gno_subprocs () = clear_debug_thing Debug_subprocs
+    let _gbacktraces () = set_debug_thing Debug_backtraces
+    let _gno_backtraces () = clear_debug_thing Debug_backtraces
+    let _gbounds_checking () =
+      set_debug_thing Debug_bounds_checking;
+      _gbacktraces ()
+    let _gno_bounds_checking () = clear_debug_thing Debug_bounds_checking
+    let _gdisable_bytecode_opt () = set_debug_thing Debug_disable_bytecode_opt
+    let _gno_disable_bytecode_opt () = 
+      clear_debug_thing Debug_disable_bytecode_opt
+
+    let _gdwarf_format format =
+      match format with
+      | 32 -> gdwarf_format := Thirty_two
+      | 64 -> gdwarf_format := Sixty_four
+      | _ -> Compenv.fatal "Please specify `32' or `64' for -gdwarf-format"
+
+    let _gdwarf_version version =
+      match version with
+      | "4+gnu" -> gdwarf_version := Four
+      | "5" -> gdwarf_version := Five
+      | _ -> Compenv.fatal "Please specify `4+gnu' or `5' for -gdwarf-version"
+
+    let _gdwarf_cfi () =
+      set_debug_thing Debug_dwarf_cfi;
+      _gsubprocs ()
+
+    let _gno_dwarf_cfi () =
+      clear_debug_thing Debug_dwarf_cfi
+
+    let _gdwarf_loc () =
+      set_debug_thing Debug_dwarf_loc;
+      _gdwarf_cfi ()
+
+    let _gno_dwarf_loc () =
+      clear_debug_thing Debug_dwarf_loc
+
+    let _gdwarf_scopes () =
+      set_debug_thing Debug_dwarf_scopes;
+      _gdwarf_loc ()
+
+    let _gno_dwarf_scopes () =
+      clear_debug_thing Debug_dwarf_scopes
+
+    let _gdwarf_vars () =
+      set_debug_thing Debug_dwarf_vars;
+      _gdwarf_scopes ();
+      set binary_annotations ()
+
+    let _gno_dwarf_vars () =
+      clear_debug_thing Debug_dwarf_vars
+
+    let _gdwarf_call_sites () =
+      set_debug_thing Debug_dwarf_call_sites;
+      _gdwarf_vars ()
+
+    let _gno_dwarf_call_sites () =
+      clear_debug_thing Debug_dwarf_call_sites
+
+    let _gdwarf_cmm () =
+      set_debug_thing Debug_dwarf_cmm;
+      _gdwarf_vars ()
+
+    let _gno_dwarf_cmm () =
+      clear_debug_thing Debug_dwarf_cmm
+
+    let _gdwarf_offsets = set gdwarf_offsets
+    let _gno_dwarf_offsets = clear gdwarf_offsets
+    let _gdwarf_self_tail_calls = set gdwarf_self_tail_calls
+    let _gno_dwarf_self_tail_calls = clear gdwarf_self_tail_calls
+
+    let _ddebug_invariants = set ddebug_invariants
+    let _dno_debug_invariants = clear ddebug_invariants
   end
 
   module Odoc_args = struct

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -283,6 +283,48 @@ module type Optcomp_options = sig
   val _save_ir_after : string -> unit
   val _probes : unit -> unit
   val _no_probes : unit -> unit
+
+  val _g0 : unit -> unit
+  val _g1 : unit -> unit
+  val _g2 : unit -> unit
+  val _g3 : unit -> unit
+
+  val _gjs_of_ocaml : unit -> unit
+  val _gno_js_of_ocaml : unit -> unit
+  val _gocamldebug : unit -> unit
+  val _gno_ocamldebug : unit -> unit
+  val _gsubprocs : unit -> unit
+  val _gno_subprocs : unit -> unit
+  val _gbacktraces : unit -> unit
+  val _gno_backtraces : unit -> unit
+  val _gbounds_checking : unit -> unit
+  val _gno_bounds_checking : unit -> unit
+  val _gdisable_bytecode_opt : unit -> unit
+  val _gno_disable_bytecode_opt : unit -> unit
+
+  val _gdwarf_format : int -> unit
+  val _gdwarf_version : string -> unit
+
+  val _gdwarf_cfi : unit -> unit
+  val _gno_dwarf_cfi : unit -> unit
+  val _gdwarf_loc : unit -> unit
+  val _gno_dwarf_loc : unit -> unit
+  val _gdwarf_scopes : unit -> unit
+  val _gno_dwarf_scopes : unit -> unit
+  val _gdwarf_vars : unit -> unit
+  val _gno_dwarf_vars : unit -> unit
+  val _gdwarf_call_sites : unit -> unit
+  val _gno_dwarf_call_sites : unit -> unit
+  val _gdwarf_cmm : unit -> unit
+  val _gno_dwarf_cmm : unit -> unit
+
+  val _gdwarf_offsets : unit -> unit
+  val _gno_dwarf_offsets : unit -> unit
+  val _gdwarf_self_tail_calls : unit -> unit
+  val _gno_dwarf_self_tail_calls : unit -> unit
+
+  val _ddebug_invariants : unit -> unit
+  val _dno_debug_invariants : unit -> unit
 end;;
 
 module type Opttop_options = sig

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -686,6 +686,153 @@ let set_o3 () =
     use_inlining_arguments_set ~round:0 o1_arguments
   end
 
+type debug_thing =
+  | Debug_ocamldebug
+  | Debug_js_of_ocaml
+  | Debug_subprocs
+  | Debug_backtraces
+  | Debug_bounds_checking
+  | Debug_disable_bytecode_opt
+  | Debug_dwarf_cfi
+  | Debug_dwarf_loc
+  | Debug_dwarf_functions
+  | Debug_dwarf_scopes
+  | Debug_dwarf_vars
+  | Debug_dwarf_call_sites
+  | Debug_dwarf_cmm
+
+let bytecode_g = [
+  Debug_ocamldebug;
+  Debug_js_of_ocaml;
+  Debug_subprocs;
+  Debug_backtraces;
+  Debug_disable_bytecode_opt;
+]
+
+let g0 = [
+]
+
+let g1 = [
+  Debug_subprocs;
+  Debug_backtraces;
+  Debug_bounds_checking;
+  Debug_disable_bytecode_opt;
+  Debug_dwarf_cfi;
+  Debug_dwarf_loc;
+]
+
+let g2 = [
+  Debug_subprocs;
+  Debug_backtraces;
+  Debug_bounds_checking;
+  Debug_disable_bytecode_opt;
+  Debug_dwarf_cfi;
+  Debug_dwarf_loc;
+  Debug_dwarf_functions;
+]
+
+let g3 = [
+  Debug_subprocs;
+  Debug_backtraces;
+  Debug_bounds_checking;
+  Debug_disable_bytecode_opt;
+  Debug_dwarf_cfi;
+  Debug_dwarf_loc;
+  Debug_dwarf_functions;
+  Debug_dwarf_scopes;
+  Debug_dwarf_vars;
+  Debug_dwarf_call_sites;
+  Debug_dwarf_cmm;
+]
+
+let all_g_levels = [
+  "g0", g0;
+  "g1", g1;
+  "g2", g2;
+  "g3", g3;
+]
+
+let current_debug_settings = ref g0
+
+let use_g0 () =
+  current_debug_settings := g0
+
+let use_g1 () =
+  current_debug_settings := g1
+
+let use_g2 () =
+  current_debug_settings := g2
+
+let use_g3 () =
+  binary_annotations := true;  (* since [Debug_dwarf_vars] is present *)
+  current_debug_settings := g3
+
+let use_g () =
+  if !native_code then use_g1 ()
+  else current_debug_settings := bytecode_g
+
+let debug_thing thing =
+  List.mem thing !current_debug_settings
+
+let set_debug_thing thing =
+  let new_settings =
+    List.filter (fun thing' -> thing <> thing') !current_debug_settings
+  in
+  current_debug_settings := thing :: new_settings
+
+let clear_debug_thing thing =
+  let new_settings =
+    List.filter (fun thing' -> thing <> thing') !current_debug_settings
+  in
+  current_debug_settings := new_settings
+
+let describe_debug_default_internal ~negate thing =
+  let defaults =
+    List.filter_map (fun (level, things_enabled_at_level) ->
+        let enabled_at_level =
+          List.mem thing things_enabled_at_level
+        in
+        let state =
+          if negate then not enabled_at_level
+          else enabled_at_level
+        in
+        if state then Some ("-" ^ level)
+        else None)
+      all_g_levels
+  in
+  match defaults with
+  | [] -> ""
+  | defaults -> " (default with " ^ (String.concat ", " defaults) ^ ")"
+
+let describe_debug_default thing =
+  describe_debug_default_internal ~negate:false thing
+
+let describe_debug_default_negated thing =
+  describe_debug_default_internal ~negate:true thing
+
+type dwarf_version =
+  | Four
+  | Five
+
+let default_gdwarf_version = Four
+let gdwarf_version = ref default_gdwarf_version
+
+let default_gdwarf_offsets = false
+let gdwarf_offsets = ref default_gdwarf_offsets
+
+let default_ddebug_invariants = false
+let ddebug_invariants = ref default_ddebug_invariants
+
+type dwarf_format =
+  | Thirty_two
+  | Sixty_four
+
+let default_gdwarf_format = Thirty_two
+let gdwarf_format = ref default_gdwarf_format
+
+let default_gdwarf_self_tail_calls = true
+let gdwarf_self_tail_calls = ref default_gdwarf_self_tail_calls
+
 (* This is used by the -stop-after option. *)
 module Compiler_pass = struct
   (* If you add a new pass, the following must be updated:

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -307,6 +307,58 @@ val set_oclassic : unit -> unit
 val set_o2 : unit -> unit
 val set_o3 : unit -> unit
 
+type debug_thing =
+  | Debug_ocamldebug
+  | Debug_js_of_ocaml
+  | Debug_subprocs
+  | Debug_backtraces
+  | Debug_bounds_checking
+  | Debug_disable_bytecode_opt
+  | Debug_dwarf_cfi
+  | Debug_dwarf_loc
+  | Debug_dwarf_functions
+  | Debug_dwarf_scopes
+  | Debug_dwarf_vars
+  | Debug_dwarf_call_sites
+  | Debug_dwarf_cmm
+
+val debug_thing : debug_thing -> bool
+
+val set_debug_thing : debug_thing -> unit
+val clear_debug_thing : debug_thing -> unit
+
+val describe_debug_default : debug_thing -> string
+val describe_debug_default_negated : debug_thing -> string
+
+val use_g : unit -> unit
+val use_g0 : unit -> unit
+val use_g1 : unit -> unit
+val use_g2 : unit -> unit
+val use_g3 : unit -> unit
+
+type dwarf_version =
+  | Four
+  | Five
+
+val gdwarf_version : dwarf_version ref
+val default_gdwarf_version : dwarf_version
+
+val gdwarf_offsets : bool ref
+val default_gdwarf_offsets : bool
+
+val gdwarf_self_tail_calls : bool ref
+val default_gdwarf_self_tail_calls : bool
+
+type dwarf_format =
+  | Thirty_two
+  | Sixty_four
+
+val gdwarf_format : dwarf_format ref
+val default_gdwarf_format : dwarf_format
+
+val default_ddebug_invariants : bool
+val ddebug_invariants : bool ref
+
 module Compiler_pass : sig
   type t = Parsing | Typing | Scheduling | Emit
   val of_string : string -> t option


### PR DESCRIPTION
Add the DWARF libraries from work done by Mark [previously](https://github.com/mshinwell/ocaml/tree/gdb-names-gpr) with some simplifications and minor changes to how it interacts with emitting modules.

The entry points for the DWARF generation are in `backend/asmlink.ml` and `backend/asmgen.ml` where we emit the DWARF at the end of the assembly (and also build a first-class module of dependencies that the Dwarf libraries now need). 

The DWARF currently being emitted is simply one per function, containing attributes that include the function name and start/end symbols as specified in `backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml`.

There are additional flags for the full range of DWARF features (copied from Mark's branch) but currently the DWARF is generated whenever `-g` flag is specified, this shouldn't add too much overhead for now since we only emit debug info for the functions.