### PR TITLE
Use C++ name mangling convention; fix Debuginfo.t scopes

### DIFF
--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1271,7 +1271,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
     List.map
       (function
           (id, Lfunction{kind; params; return; body; loc}) ->
-            let label = Compilenv.make_symbol (Some (V.unique_name id)) in
+            let label = Compilenv.make_fun_symbol loc (V.unique_name id) in
             let arity = List.length params in
             let fundesc =
               {fun_label = label;

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -115,6 +115,245 @@ let make_symbol ?(unitname = current_unit.ui_symbol) idopt =
   | None -> prefix
   | Some id -> concat_symbol prefix id
 
+let begins_with ?(from = 0) str prefix = 
+  let rec helper idx =
+    if idx < 0 then true
+    else 
+      String.get str (from + idx) = String.get prefix idx && helper (idx-1)
+  in
+  let n = String.length str in
+  let m = String.length prefix in
+  if n >= from + m then helper (m-1) else false
+
+let split_on_string str split = 
+  let n = String.length str in
+  let m = String.length split in
+  let rec helper acc last_idx idx = 
+    if idx = n then
+      let cur = String.sub str last_idx (idx - last_idx) in
+      List.rev (cur :: acc)
+    else if begins_with ~from:idx str split then
+      let cur = String.sub str last_idx (idx - last_idx) in
+      helper (cur :: acc) (idx + m) (idx + m)
+    else
+      helper acc last_idx (idx + 1)
+  in
+  helper [] 0 0
+
+let split_on_chars str chars =
+  let rec helper chars_left s acc = 
+    match chars_left with
+    | [] -> s :: acc
+    | c :: cs -> 
+      List.fold_right (helper cs) (String.split_on_char c s) acc
+  in 
+  helper chars str []
+
+let split_last_exn str c = 
+  let n = String.length str in
+  let ridx = String.rindex str c in
+  (String.sub str 0 ridx, String.sub str (ridx + 1) (n - ridx - 1))
+
+let escape_symbols part = 
+  let buf = Buffer.create 16 in
+  let was_hex_last = ref false in
+  let handle_char = function 
+    | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') as c ->
+      if !was_hex_last then Buffer.add_string buf "__";
+      Buffer.add_char buf c;
+      was_hex_last := false
+    | c ->
+      Printf.bprintf buf "%sX%02x"
+        (if !was_hex_last then "_" else "__")
+        (Char.code c);
+      was_hex_last := true
+  in
+  String.iter handle_char part;
+  Buffer.contents buf
+
+type expression = 
+  | String of string
+  | Dot of expression * string
+
+type cpp_name =
+  | Simple of string
+  | Scoped of cpp_name list
+  | Templated of string * template_arg list
+
+and template_arg =
+  | Cpp_name of cpp_name
+  | Expression of expression
+
+let mangle_cpp name =
+  let with_length s =
+    let s = escape_symbols s in
+    Printf.sprintf "%d%s" (String.length s) s in
+  let rec mangle_expression = function
+    | String s -> with_length s
+    | Dot (e, name) -> Printf.sprintf "dt%s%s" (mangle_expression e) (with_length name)
+  in 
+  let rec mangle_name = function
+    | Simple s -> with_length s
+    | Scoped names ->
+      let s = List.map mangle_name names |> String.concat "" in
+      Printf.sprintf "N%sE" s
+    | Templated (str, parts) ->
+      let s = List.map mangle_arg parts |> String.concat "" in
+      Printf.sprintf "%sI%sE" (with_length str) s
+  and mangle_arg = function
+    | Cpp_name name -> mangle_name name
+    | Expression expression ->
+      Printf.sprintf "X%sE" (mangle_expression expression)
+  in
+  "_Z" ^ mangle_name name
+
+let file_template_arg file =
+  (* Take the file name only *)
+  let filename =
+    if String.contains file '/' then snd (split_last_exn file '/')
+    else file
+  in
+  match String.split_on_char '.' filename with
+  | [] -> Misc.fatal_error "Empty split"
+  | hd :: tl ->
+    let expr = List.fold_left (fun e x -> Dot (e, x)) (String hd) tl in
+    Expression expr
+
+let name_op = function
+  | "+" -> "PLUS"
+  | "++" -> "PLUSPLUS"
+  | "+." -> "PLUSDOT"
+  | "+=" -> "PLUSEQ"
+  | "-" -> "MINUS"
+  | "-." -> "MINUSDOT"
+  | "*" -> "STAR"
+  | "%" -> "PERCENT"
+  | "=" -> "EQUAL"
+  | "<" -> "LESS"
+  | ">" -> "GREATER"
+  | "<>" -> "NOTEQUAL"
+  | "||" -> "BARBAR"
+  | "&" -> "AMPERSAND"
+  | "&&" -> "AMPERAMPER"
+  | ":=" -> "COLONEQUAL"
+  | "^" -> "CARET"
+  | "^^" -> "CARETCARET"
+  | "@" -> "AT"
+  | "<<" -> "LSHIFT"
+  | ">>" -> "RSHIFT"
+  | op -> op
+  
+let build_location_info loc =
+  let loc = Debuginfo.Scoped_location.to_location loc in
+  let (file, line, startchar) = Location.get_pos_info loc.loc_start in
+  let endchar = loc.loc_end.pos_cnum - loc.loc_start.pos_bol in
+  let line_str = Printf.sprintf "ln_%d" line in
+  let info = [ file_template_arg file; Cpp_name (Simple line_str) ] in
+  if startchar >= 0 then
+    let char_str = Printf.sprintf "ch_%d_to_%d" startchar endchar in
+    info @ [ Cpp_name (Simple char_str) ]
+  else info
+
+(* OCaml names can contain single quotes but need to be escaped
+   for C++ identifiers. *)
+let convert_identifier str =
+  match String.split_on_char '\'' str with
+  | [] -> Misc.fatal_error "empty split"
+  | [ s ] -> Simple s
+  | parts -> 
+    let s = String.concat "_Q" parts in
+    Templated (s, [ Cpp_name (Simple "quoted")] )
+
+let convert_closure_id id loc = 
+  if begins_with id "anon_fn[" then
+    (* Keep the unique integer stamp *)
+    let (_init, stamp) = split_last_exn id '_' in
+    (* Put the location inside C++ template args *)
+    Templated ("anon_fn_" ^ stamp, build_location_info loc)
+  else
+    match id.[0] with
+    (* A regular identifier *)
+    | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') -> convert_identifier id
+    (* An operator *)
+    | _op -> 
+      let (op, stamp) = split_last_exn id '_' in
+      Templated ("op_" ^ stamp, [Cpp_name (Simple (name_op op))])
+  
+let convert_scope scope =
+  let n = String.length scope in
+  (* anonymous function *)
+  if String.equal scope "(fun)" then Templated ("anon_fn", [])
+  (* operators *)
+  else if n > 2 && String.get scope 0 = '(' && String.get scope (n - 1) = ')' then
+    let op = String.sub scope 1 (n - 2) in
+    Templated ("op", [ Cpp_name (Simple (name_op op)) ])
+  (* regular identifiers *)
+  else convert_identifier scope
+
+let list_of_scopes scopes = 
+  (* Works for now since the only separators are '.' and '#' *)
+  let scope_str = Debuginfo.Scoped_location.string_of_scopes scopes in
+  split_on_chars scope_str [ '.'; '#' ]
+
+let scope_matches_closure_id scope closure_id = 
+  (* If the `id` is an anonymous function this corresponds to that,
+      and, even if not, then the function has likely been given
+      a name via some aliasing (e.g. `let f = fun x -> ...`) *)
+  String.equal scope "(fun)" ||
+  (* Normal case where closure id and scope match directly *)
+  begins_with closure_id scope ||
+  (* For operators, the scope is wrapped in parens *)
+  ( String.length scope >= 3 &&
+    begins_with closure_id (String.sub scope 1 (String.length scope - 2)))
+
+(* Returns a pair of the top-level module and the list of scopes
+   the strictly contain the closure id *)
+let module_and_scopes ~unitname loc id = 
+  match (loc : Debuginfo.Scoped_location.t) with
+  | Loc_known { loc = _; scopes } ->
+    let scopes = list_of_scopes scopes in
+    (* Remove last scope if it matches closure id *)
+    let scopes = 
+      match List.rev scopes with
+      | [] -> Misc.fatal_errorf "No location - %s %s" unitname id
+      | last_scope :: rest when scope_matches_closure_id last_scope id -> 
+        List.rev rest
+      | _ -> scopes
+    in
+    (* If the scope is now empty, use the unitname as the top-level module *)
+    begin match scopes with
+      | [] -> unitname, []
+      | top_module :: sub_scopes -> top_module, sub_scopes
+    end
+  | Loc_unknown -> unitname, []
+
+let remove_prefix str prefix = 
+  let n = String.length prefix in
+  if begins_with str prefix then
+    String.sub str n (String.length str - n)
+  else
+    str
+
+let make_fun_symbol ?(unitname = current_unit.ui_symbol) loc id =
+  let unitname = remove_prefix "caml" unitname in
+  let top_level_module, sub_scopes = module_and_scopes ~unitname loc id in
+  let namespace_parts name =
+    split_on_string name "__" |> List.map (fun part -> Simple part)
+  in
+  let parts =
+    List.concat [
+      namespace_parts top_level_module;
+      List.map convert_scope sub_scopes;
+      [ convert_closure_id id loc ];
+      if String.equal top_level_module unitname then [] 
+      else [
+        Templated ("inlined_in",
+          [ Cpp_name (Scoped (namespace_parts unitname)) ])
+      ]
+    ]
+  in
+  mangle_cpp (Scoped parts)
+
 let current_unit_linkage_name () =
   Linkage_name.create (make_symbol ~unitname:current_unit.ui_symbol None)
 
@@ -432,23 +671,31 @@ let structured_constants () =
          provenance = Some provenance;
        })
 
-let closure_symbol fv =
-  let compilation_unit = Closure_id.get_compilation_unit fv in
+let function_label closure_id =
   let unitname =
-    Linkage_name.to_string (Compilation_unit.get_linkage_name compilation_unit)
+    Closure_id.get_compilation_unit closure_id
+    |> Compilation_unit.get_linkage_name
+    |> Linkage_name.to_string
   in
-  let linkage_name =
-    concat_symbol unitname ((Closure_id.unique_name fv) ^ "_closure")
-  in
-  Symbol.of_global_linkage compilation_unit (Linkage_name.create linkage_name)
+  let name = Closure_id.unique_name closure_id in
+  match Closure_id.debug_info closure_id with
+  | None | Some [] ->
+    (* concat_symbol unitname name *)
+    let scoped_loc = Debuginfo.Scoped_location.Loc_unknown in
+    make_fun_symbol ~unitname scoped_loc name
+  | Some ((item :: _items) as debug_info) ->
+    let scoped_loc =
+      Debuginfo.Scoped_location.Loc_known
+        { loc = Debuginfo.to_location debug_info
+        ; scopes = item.dinfo_scopes
+        }
+    in
+    make_fun_symbol ~unitname scoped_loc name
 
-let function_label fv =
-  let compilation_unit = Closure_id.get_compilation_unit fv in
-  let unitname =
-    Linkage_name.to_string
-      (Compilation_unit.get_linkage_name compilation_unit)
-  in
-  (concat_symbol unitname (Closure_id.unique_name fv))
+let closure_symbol closure_id =
+  let compilation_unit = Closure_id.get_compilation_unit closure_id in
+  let linkage_name = (function_label closure_id) ^ "_closure" in
+  Symbol.of_global_linkage compilation_unit (Linkage_name.create linkage_name)
 
 let require_global global_ident =
   if not (Ident.is_predef global_ident) then

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -59,6 +59,7 @@ val make_symbol: ?unitname:string -> string option -> string
            [make_symbol ~unitname:u (Some id)] returns the asm symbol that
            corresponds to symbol [id] in the compilation unit [u]
            (or the current unit). *)
+val make_fun_symbol: ?unitname:string -> Debuginfo.Scoped_location.t -> string -> string
 
 val symbol_in_current_unit: string -> bool
         (* Return true if the given asm symbol belongs to the

--- a/middle_end/flambda/augment_specialised_args.ml
+++ b/middle_end/flambda/augment_specialised_args.ml
@@ -533,11 +533,11 @@ module Make (T : S) = struct
         ~params:wrapper_params
         ~body:wrapper_body
         ~stub:true
-        ~dbg:Debuginfo.none
         ~inline:Default_inline
         ~specialise:Default_specialise
         ~is_a_functor:false
         ~closure_origin:function_decl.closure_origin
+        ()
     in
     new_fun_var, new_function_decl, rewritten_existing_specialised_args,
       benefit
@@ -626,6 +626,7 @@ module Make (T : S) = struct
           ~specialise:function_decl.specialise
           ~is_a_functor:function_decl.is_a_functor
           ~closure_origin
+          ()
       in
       let funs, direct_call_surrogates =
         if for_one_function.make_direct_call_surrogates then

--- a/middle_end/flambda/base_types/closure_element.mli
+++ b/middle_end/flambda/base_types/closure_element.mli
@@ -27,6 +27,8 @@ val unwrap_set : Set.t -> Variable.Set.t
 val in_compilation_unit : t -> Compilation_unit.t -> bool
 val get_compilation_unit : t -> Compilation_unit.t
 
+val debug_info : t -> Debuginfo.t option
+
 val unique_name : t -> string
 
 val output_full : out_channel -> t -> unit

--- a/middle_end/flambda/base_types/closure_origin.mli
+++ b/middle_end/flambda/base_types/closure_origin.mli
@@ -19,3 +19,5 @@ include Identifiable.S
 val create : Closure_id.t -> t
 
 val get_compilation_unit : t -> Compilation_unit.t
+
+val debug_info : t -> Debuginfo.t option

--- a/middle_end/flambda/base_types/mutable_variable.ml
+++ b/middle_end/flambda/base_types/mutable_variable.ml
@@ -19,4 +19,10 @@ open! Int_replace_polymorphic_compare
 
 include Variable
 
+let create ?current_compilation_unit names = create ?current_compilation_unit names
+
+let create_with_same_name_as_ident ident = create_with_same_name_as_ident ident
+
+let rename ?current_compilation_unit t = rename ?current_compilation_unit t
+
 let create_from_variable = rename

--- a/middle_end/flambda/export_info_for_pack.ml
+++ b/middle_end/flambda/export_info_for_pack.ml
@@ -145,7 +145,8 @@ and import_function_declarations_for_pack_aux units pack
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
           ~is_a_functor:function_decl.is_a_functor
-          ~closure_origin:function_decl.closure_origin)
+          ~closure_origin:function_decl.closure_origin
+          ())
       function_decls.funs
   in
   Flambda.import_function_declarations_for_pack

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -1021,11 +1021,10 @@ let update_function_decl's_params_and_body
     is_a_functor = func_decl.is_a_functor;
   }
 
-
-let create_function_declaration ~params ~body ~stub ~dbg
+let create_function_declaration ~params ~body ~stub ?dbg
       ~(inline : Lambda.inline_attribute)
       ~(specialise : Lambda.specialise_attribute) ~is_a_functor
-      ~closure_origin
+      ~closure_origin ()
       : function_declaration =
   begin match stub, inline with
   | true, (Never_inline | Default_inline)
@@ -1045,13 +1044,23 @@ let create_function_declaration ~params ~body ~stub ~dbg
       "Stubs may not be annotated as [Always_specialise]: %a"
       print body
   end;
+  let dbg_origin = 
+    match Closure_origin.debug_info closure_origin with
+    | None -> Misc.fatal_error "Closure debug info missing"
+    | Some dbg_origin -> dbg_origin
+  in
+  (* The debug argument if given should be the same *)
+  begin match dbg with
+  | None -> ()
+  | Some dbg -> assert (Debuginfo.compare dbg dbg_origin = 0) 
+  end;
   { closure_origin;
     params;
     body;
     free_variables = free_variables body;
     free_symbols = free_symbols body;
     stub;
-    dbg;
+    dbg = dbg_origin;
     inline;
     specialise;
     is_a_functor;

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -551,11 +551,12 @@ val create_function_declaration
    : params:Parameter.t list
   -> body:t
   -> stub:bool
-  -> dbg:Debuginfo.t
+  -> ?dbg:Debuginfo.t
   -> inline:Lambda.inline_attribute
   -> specialise:Lambda.specialise_attribute
   -> is_a_functor:bool
   -> closure_origin:Closure_origin.t
+  -> unit
   -> function_declaration
 
 (** Create a function declaration based on another function declaration *)

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -588,6 +588,7 @@ and to_clambda_closed_set_of_closures t env symbol
       Un_anf.apply ~ppf_dump:t.ppf_dump ~what:symbol
         (to_clambda t env_body function_decl.body)
     in
+    assert (Variable.debug_info id = Some function_decl.dbg);
     { label = Compilenv.function_label (Closure_id.wrap id);
       arity = Flambda_utils.function_arity function_decl;
       params = List.map (fun var -> VP.create var, Lambda.Pgenval) params;

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -347,9 +347,10 @@ let make_closure_declaration
   let subst_param param = Parameter.map_var subst param in
   let function_declaration =
     Flambda.create_function_declaration ~params:(List.map subst_param params)
-      ~body ~stub ~dbg:Debuginfo.none ~inline:Default_inline
+      ~body ~stub ~inline:Default_inline
       ~specialise:Default_specialise ~is_a_functor:false
       ~closure_origin:(Closure_origin.create (Closure_id.wrap id))
+      ()
   in
   assert (Variable.Set.equal (Variable.Set.map subst free_variables)
     function_declaration.free_variables);

--- a/middle_end/flambda/freshening.ml
+++ b/middle_end/flambda/freshening.ml
@@ -326,6 +326,7 @@ module Project_var = struct
             ~inline:func_decl.inline ~specialise:func_decl.specialise
             ~is_a_functor:func_decl.is_a_functor
             ~closure_origin:func_decl.closure_origin
+            ()
         in
         function_decl, subst
       in

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -615,6 +615,7 @@ and simplify_set_of_closures original_env r
         ~inline:function_decl.inline ~specialise:function_decl.specialise
         ~is_a_functor:function_decl.is_a_functor
         ~closure_origin:function_decl.closure_origin
+        ()
     in
     let used_params' = Flambda.used_params function_decl in
     Variable.Map.add fun_var function_decl funs,
@@ -843,7 +844,13 @@ and simplify_partial_application env r ~lhs_of_application
       }
     in
     let closure_variable =
-      Variable.rename
+      (* Set the debug location inside an anonymous function at the call site *)
+      let debug_info = 
+        Debuginfo.update_scopes
+          ~f:Debuginfo.Scoped_location.enter_anonymous_function
+          dbg
+      in
+      Variable.rename ~debug_info
         (Closure_id.unwrap closure_id_being_applied)
     in
     Flambda_utils.make_closure_declaration ~id:closure_variable
@@ -1446,6 +1453,7 @@ and duplicate_function ~env ~(set_of_closures : Flambda.set_of_closures)
       ~inline:function_decl.inline ~specialise:function_decl.specialise
       ~is_a_functor:function_decl.is_a_functor
       ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
+      ()
   in
   function_decl, specialised_args
 

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -539,6 +539,7 @@ let rewrite_function ~lhs_of_application ~closure_id_being_applied
       ~specialise:function_body.specialise
       ~is_a_functor:function_body.is_a_functor
       ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
+      ()
   in
   let new_funs =
     Variable.Map.add new_fun_var new_function_decl state.new_funs
@@ -674,5 +675,6 @@ let inline_by_copying_function_declaration
       in
       let expr = Flambda_utils.bind ~body ~bindings:state.let_bindings in
       let env = E.activate_freshening (E.set_never_inline env) in
+      let env = E.set_inline_debuginfo ~dbg env in
       Some (simplify env r expr)
     end

--- a/middle_end/flambda/remove_unused_arguments.ml
+++ b/middle_end/flambda/remove_unused_arguments.ml
@@ -43,6 +43,7 @@ let remove_params unused (fun_decl: Flambda.function_declaration)
     ~stub:fun_decl.stub ~dbg:fun_decl.dbg ~inline:fun_decl.inline
     ~specialise:fun_decl.specialise ~is_a_functor:fun_decl.is_a_functor
     ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
+    ()
 
 let make_stub unused var (fun_decl : Flambda.function_declaration)
     ~specialised_args ~additional_specialised_args =
@@ -102,6 +103,7 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
       ~stub:true ~dbg:fun_decl.dbg ~inline:Default_inline
       ~specialise:Default_specialise ~is_a_functor:fun_decl.is_a_functor
       ~closure_origin:fun_decl.closure_origin
+      ()
   in
   function_decl, renamed, additional_specialised_args
 

--- a/middle_end/variable.ml
+++ b/middle_end/variable.ml
@@ -22,6 +22,8 @@ type t = {
   name : string;
   name_stamp : int;
   (** [name_stamp]s are unique within any given compilation unit. *)
+  debug_info : Debuginfo.t option;
+  (** [debug_info] should be set for variables repreesnting functions *)
 }
 
 include Identifiable.Make (struct
@@ -62,7 +64,7 @@ end)
 
 let previous_name_stamp = ref (-1)
 
-let create_with_name_string ?current_compilation_unit name =
+let create_with_name_string ?current_compilation_unit ?debug_info name =
   let compilation_unit =
     match current_compilation_unit with
     | Some compilation_unit -> compilation_unit
@@ -75,22 +77,30 @@ let create_with_name_string ?current_compilation_unit name =
   { compilation_unit;
     name;
     name_stamp;
+    debug_info;
   }
 
-let create ?current_compilation_unit name =
+let create ?current_compilation_unit ?debug_info name =
   let name = (name : Internal_variable_names.t :> string) in
-  create_with_name_string ?current_compilation_unit name
+  create_with_name_string ?current_compilation_unit ?debug_info name
 
-let create_with_same_name_as_ident ident =
-  create_with_name_string (Ident.name ident)
+let create_with_same_name_as_ident ?debug_info ident =
+  create_with_name_string ?debug_info (Ident.name ident)
 
-let rename ?current_compilation_unit t =
-  create_with_name_string ?current_compilation_unit t.name
+let rename ?current_compilation_unit ?debug_info t =
+  let debug_info = 
+    match debug_info with
+    | Some debug_info -> Some debug_info
+    | None -> t.debug_info 
+  in
+  create_with_name_string ?current_compilation_unit ?debug_info t.name
 
 let in_compilation_unit t cu =
   Compilation_unit.equal cu t.compilation_unit
 
 let get_compilation_unit t = t.compilation_unit
+
+let debug_info t = t.debug_info
 
 let name t = t.name
 

--- a/middle_end/variable.mli
+++ b/middle_end/variable.mli
@@ -30,12 +30,14 @@ include Identifiable.S
 
 val create
    : ?current_compilation_unit:Compilation_unit.t
+  -> ?debug_info:Debuginfo.t
   -> Internal_variable_names.t
   -> t
-val create_with_same_name_as_ident : Ident.t -> t
+val create_with_same_name_as_ident : ?debug_info:Debuginfo.t -> Ident.t -> t
 
 val rename
    : ?current_compilation_unit:Compilation_unit.t
+  -> ?debug_info:Debuginfo.t
   -> t
   -> t
 
@@ -46,6 +48,8 @@ val name : t -> string
 val unique_name : t -> string
 
 val get_compilation_unit : t -> Compilation_unit.t
+
+val debug_info : t -> Debuginfo.t option
 
 val print_list : Format.formatter -> t list -> unit
 val print_opt : Format.formatter -> t option -> unit

--- a/ocaml/lambda/debuginfo.ml
+++ b/ocaml/lambda/debuginfo.ml
@@ -106,6 +106,10 @@ module Scoped_location = struct
   let string_of_scoped_location = function
     | Loc_unknown -> "??"
     | Loc_known { loc = _; scopes } -> string_of_scopes scopes
+  
+  let update_scopes ~f = function 
+    | Loc_unknown -> Loc_unknown
+    | Loc_known { loc; scopes } -> Loc_known { loc; scopes = f ~scopes }
 end
 
 type item = {
@@ -190,6 +194,15 @@ let to_location = function
 
 let inline dbg1 dbg2 =
   dbg1 @ dbg2
+
+let update_scopes t ~f =
+  match t with
+  | [] ->
+    (* Misc.fatal_error "Debug info expected" *)
+    []
+  | item :: items ->
+    let item = { item with dinfo_scopes = f ~scopes:item.dinfo_scopes } in
+    item :: items
 
 (* CR-someday afrisch: FWIW, the current compare function does not seem very
    good, since it reverses the two lists. I don't know how long the lists are,

--- a/ocaml/lambda/debuginfo.mli
+++ b/ocaml/lambda/debuginfo.mli
@@ -33,6 +33,8 @@ module Scoped_location : sig
   val of_location : scopes:scopes -> Location.t -> t
   val to_location : t -> Location.t
   val string_of_scoped_location : t -> string
+
+  val update_scopes : f:(scopes:scopes -> scopes) -> t -> t
 end
 
 type item = private {
@@ -70,6 +72,12 @@ val from_location : Scoped_location.t -> t
 val to_location : t -> Location.t
 
 val inline : t -> t -> t
+
+(** Update the scopes on the most recently inlined debug entry *)
+val update_scopes
+  : t
+  -> f:(scopes:Scoped_location.scopes -> Scoped_location.scopes)
+  -> t
 
 val compare : t -> t -> int
 

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -583,6 +583,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
          transl_exp ~scopes e
       | `Other ->
          (* other cases compile to a lazy block holding a function *)
+         let scopes = enter_anonymous_function ~scopes in
          let fn = Lfunction {kind = Curried;
                              params= [Ident.create_local "param", Pgenval];
                              return = Pgenval;
@@ -803,6 +804,7 @@ and transl_apply ~scopes
                         body = lam; attr;
                         loc}
           | lam ->
+              let loc = update_scopes ~f:enter_anonymous_function loc in
               Lfunction{kind = Curried; params = [id_arg, Pgenval];
                         return = Pgenval; body = lam;
                         attr = default_stub_attribute; loc = loc}

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -736,12 +736,23 @@ let transl_primitive loc p env ty path =
   match params with
   | [] -> body
   | _ ->
-      Lfunction{ kind = Curried;
-                 params;
-                 return = Pgenval;
-                 attr = default_stub_attribute;
-                 loc;
-                 body; }
+    let loc =
+      Debuginfo.Scoped_location.update_scopes
+        ~f:(fun ~scopes ->
+          let scopes =
+            Debuginfo.Scoped_location.enter_value_definition ~scopes
+              (Ident.create_local p.prim_name)
+          in
+          Debuginfo.Scoped_location.enter_anonymous_function ~scopes
+        )
+        loc
+    in
+    Lfunction{ kind = Curried;
+                params;
+                return = Pgenval;
+                attr = default_stub_attribute;
+                loc;
+                body; }
 
 let lambda_primitive_needs_event_after = function
   | Prevapply | Pdirapply (* PR#6920 *)


### PR DESCRIPTION
Change the symbols to include the scope and use the C++ name mangling convention.

A few changes have also been made to the scopes being passed around:
- `translcore.ml` - add an anon scope for lazy blocks
- `translprim.ml` - add a scope for extern functions

