### PR TITLE
Add Debuginfo.t to Variable.t in Flambda 1

### DIFF
--- a/middle_end/flambda/augment_specialised_args.ml
+++ b/middle_end/flambda/augment_specialised_args.ml
@@ -533,7 +533,6 @@ module Make (T : S) = struct
         ~params:wrapper_params
         ~body:wrapper_body
         ~stub:true
-        ~dbg:Debuginfo.none
         ~inline:Default_inline
         ~specialise:Default_specialise
         ~is_a_functor:false
@@ -621,7 +620,6 @@ module Make (T : S) = struct
           ~params:all_params
           ~body:function_decl.body
           ~stub:function_decl.stub
-          ~dbg:function_decl.dbg
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
           ~is_a_functor:function_decl.is_a_functor

--- a/middle_end/flambda/base_types/closure_element.mli
+++ b/middle_end/flambda/base_types/closure_element.mli
@@ -27,6 +27,8 @@ val unwrap_set : Set.t -> Variable.Set.t
 val in_compilation_unit : t -> Compilation_unit.t -> bool
 val get_compilation_unit : t -> Compilation_unit.t
 
+val debug_info : t -> Debuginfo.t option
+
 val unique_name : t -> string
 
 val output_full : out_channel -> t -> unit

--- a/middle_end/flambda/base_types/closure_id.ml
+++ b/middle_end/flambda/base_types/closure_id.ml
@@ -18,3 +18,5 @@
 open! Int_replace_polymorphic_compare
 
 include Closure_element
+
+let debug_info t = Option.get (debug_info t)

--- a/middle_end/flambda/base_types/closure_id.mli
+++ b/middle_end/flambda/base_types/closure_id.mli
@@ -25,3 +25,5 @@
     (viz. [Project_closure]). *)
 
 include module type of Closure_element
+
+val debug_info : t -> Debuginfo.t

--- a/middle_end/flambda/base_types/closure_origin.ml
+++ b/middle_end/flambda/base_types/closure_origin.ml
@@ -20,3 +20,4 @@ open! Int_replace_polymorphic_compare
 include Closure_id
 
 let create t = t
+

--- a/middle_end/flambda/base_types/closure_origin.mli
+++ b/middle_end/flambda/base_types/closure_origin.mli
@@ -20,4 +20,4 @@ val create : Closure_id.t -> t
 
 val get_compilation_unit : t -> Compilation_unit.t
 
-val debug_info : t -> Debuginfo.t option
+val debug_info : t -> Debuginfo.t

--- a/middle_end/flambda/base_types/closure_origin.mli
+++ b/middle_end/flambda/base_types/closure_origin.mli
@@ -19,3 +19,5 @@ include Identifiable.S
 val create : Closure_id.t -> t
 
 val get_compilation_unit : t -> Compilation_unit.t
+
+val debug_info : t -> Debuginfo.t option

--- a/middle_end/flambda/base_types/mutable_variable.ml
+++ b/middle_end/flambda/base_types/mutable_variable.ml
@@ -19,4 +19,10 @@ open! Int_replace_polymorphic_compare
 
 include Variable
 
+let create ?current_compilation_unit names = create ?current_compilation_unit names
+
+let create_with_same_name_as_ident ident = create_with_same_name_as_ident ident
+
+let rename ?current_compilation_unit t = rename ?current_compilation_unit t
+
 let create_from_variable = rename

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -605,9 +605,6 @@ and close_functions t external_env function_declarations : Flambda.named =
     let param_vars = List.map (Env.find_var closure_env) params in
     let params = List.map Parameter.wrap param_vars in
     let closure_bound_var = Function_decl.closure_bound_var decl in
-    (* The closure_bound_var for a declared function should
-       always have the debug info *)
-    assert (Option.is_some (Variable.debug_info closure_bound_var));
     let unboxed_version = Variable.rename closure_bound_var in
     let body = close t closure_env body in
     let closure_origin =

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -100,7 +100,7 @@ let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
   in
   let tuple_param = Parameter.wrap tuple_param_var in
   Flambda.create_function_declaration ~params:[tuple_param]
-    ~body ~stub:true ~dbg:Debuginfo.none ~inline:Default_inline
+    ~body ~stub:true ~inline:Default_inline
     ~specialise:Default_specialise ~is_a_functor:false
     ~closure_origin:(Closure_origin.create (Closure_id.wrap closure_bound_var))
 
@@ -208,7 +208,10 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
            contents_kind = block_kind })
   | Lfunction { kind; params; body; attr; loc; } ->
     let name = Names.anon_fn_with_loc loc in
-    let closure_bound_var = Variable.create name in
+    let closure_bound_var =
+      let debug_info = Debuginfo.from_location loc in
+      Variable.create ~debug_info name
+    in
     (* CR-soon mshinwell: some of this is now very similar to the let rec case
        below *)
     let set_of_closures_var = Variable.create Names.set_of_closures in
@@ -258,7 +261,8 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
           | (let_rec_ident,
              Lambda.Lfunction { kind; params; body; attr; loc }) ->
             let closure_bound_var =
-              Variable.create_with_same_name_as_ident let_rec_ident
+              let debug_info = Debuginfo.from_location loc in
+              Variable.create_with_same_name_as_ident ~debug_info let_rec_ident
             in
             let function_declaration =
               Function_decl.create ~let_rec_ident:(Some let_rec_ident)
@@ -524,7 +528,9 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let st_exn = Static_exception.create () in
     let env = Env.add_static_exception env i st_exn in
     let ids = List.map fst ids in
-    let vars = List.map Variable.create_with_same_name_as_ident ids in
+    let vars =
+      List.map (fun ident -> Variable.create_with_same_name_as_ident ident) ids
+    in
     Static_catch (st_exn, vars, close t env body,
       close t (Env.add_vars env ids vars) handler)
   | Ltrywith (body, id, handler) ->
@@ -581,8 +587,6 @@ and close_functions t external_env function_declarations : Flambda.named =
   let all_free_idents = Function_decls.all_free_idents function_declarations in
   let close_one_function map decl =
     let body = Function_decl.body decl in
-    let loc = Function_decl.loc decl in
-    let dbg = Debuginfo.from_location loc in
     let params = Function_decl.params decl in
     (* Create fresh variables for the elements of the closure (cf.
        the comment on [Function_decl.closure_env_without_parameters], above).
@@ -601,13 +605,16 @@ and close_functions t external_env function_declarations : Flambda.named =
     let param_vars = List.map (Env.find_var closure_env) params in
     let params = List.map Parameter.wrap param_vars in
     let closure_bound_var = Function_decl.closure_bound_var decl in
+    (* The closure_bound_var for a declared function should
+       always have the debug info *)
+    assert (Option.is_some (Variable.debug_info closure_bound_var));
     let unboxed_version = Variable.rename closure_bound_var in
     let body = close t closure_env body in
     let closure_origin =
       Closure_origin.create (Closure_id.wrap unboxed_version)
     in
     let fun_decl =
-      Flambda.create_function_declaration ~params ~body ~stub ~dbg
+      Flambda.create_function_declaration ~params ~body ~stub
         ~inline:(Function_decl.inline decl)
         ~specialise:(Function_decl.specialise decl)
         ~is_a_functor:(Function_decl.is_a_functor decl)
@@ -662,7 +669,10 @@ and close_let_bound_expression t ?let_rec_ident let_bound_var env
   | Lfunction { kind; params; body; attr; loc; } ->
     (* Ensure that [let] and [let rec]-bound functions have appropriate
        names. *)
-    let closure_bound_var = Variable.rename let_bound_var in
+    let closure_bound_var =
+      let debug_info = Debuginfo.from_location loc in
+      Variable.rename ~debug_info let_bound_var
+    in
     let decl =
       Function_decl.create ~let_rec_ident ~closure_bound_var ~kind
         ~params:(List.map fst params) ~body ~attr ~loc

--- a/middle_end/flambda/export_info.ml
+++ b/middle_end/flambda/export_info.ml
@@ -258,6 +258,17 @@ let t_of_transient transient
     constant_closures;
   }
 
+let t_of_opaque_transient transient =
+  { sets_of_closures = transient.sets_of_closures;
+    values = transient.values;
+    symbol_id = transient.symbol_id;
+    invariant_params = transient.invariant_params;
+    recursive = transient.recursive;
+    offset_fun = empty.offset_fun;
+    offset_fv = empty.offset_fv;
+    constant_closures = empty.constant_closures;
+  }
+
 let merge (t1 : t) (t2 : t) : t =
   let eidmap_disjoint_union ?eq map1 map2 =
     Compilation_unit.Map.merge (fun _id map1 map2 ->

--- a/middle_end/flambda/export_info.mli
+++ b/middle_end/flambda/export_info.mli
@@ -160,6 +160,8 @@ val t_of_transient
   -> constant_closures:Closure_id.Set.t
   -> t
 
+val t_of_opaque_transient : transient -> t
+
 (** Union of export information.  Verifies that there are no identifier
     clashes. *)
 val merge : t -> t -> t

--- a/middle_end/flambda/export_info_for_pack.ml
+++ b/middle_end/flambda/export_info_for_pack.ml
@@ -141,7 +141,7 @@ and import_function_declarations_for_pack_aux units pack
       (fun (function_decl : Flambda.function_declaration) ->
         Flambda.create_function_declaration ~params:function_decl.params
           ~body:(import_code_for_pack units pack function_decl.body)
-          ~stub:function_decl.stub ~dbg:function_decl.dbg
+          ~stub:function_decl.stub
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
           ~is_a_functor:function_decl.is_a_functor

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -1021,8 +1021,7 @@ let update_function_decl's_params_and_body
     is_a_functor = func_decl.is_a_functor;
   }
 
-
-let create_function_declaration ~params ~body ~stub ~dbg
+let create_function_declaration ~params ~body ~stub
       ~(inline : Lambda.inline_attribute)
       ~(specialise : Lambda.specialise_attribute) ~is_a_functor
       ~closure_origin
@@ -1045,13 +1044,20 @@ let create_function_declaration ~params ~body ~stub ~dbg
       "Stubs may not be annotated as [Always_specialise]: %a"
       print body
   end;
+  let dbg_origin =
+    match Closure_origin.debug_info closure_origin with
+    | None ->
+      Misc.fatal_errorf "Debug info missing on closure origin %a"
+        Closure_origin.print closure_origin
+    | Some dbg_origin -> dbg_origin
+  in
   { closure_origin;
     params;
     body;
     free_variables = free_variables body;
     free_symbols = free_symbols body;
     stub;
-    dbg;
+    dbg = dbg_origin;
     inline;
     specialise;
     is_a_functor;

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -1044,13 +1044,7 @@ let create_function_declaration ~params ~body ~stub
       "Stubs may not be annotated as [Always_specialise]: %a"
       print body
   end;
-  let dbg_origin =
-    match Closure_origin.debug_info closure_origin with
-    | None ->
-      Misc.fatal_errorf "Debug info missing on closure origin %a"
-        Closure_origin.print closure_origin
-    | Some dbg_origin -> dbg_origin
-  in
+  let dbg_origin = Closure_origin.debug_info closure_origin in
   { closure_origin;
     params;
     body;

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -551,7 +551,6 @@ val create_function_declaration
    : params:Parameter.t list
   -> body:t
   -> stub:bool
-  -> dbg:Debuginfo.t
   -> inline:Lambda.inline_attribute
   -> specialise:Lambda.specialise_attribute
   -> is_a_functor:bool

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -588,6 +588,9 @@ and to_clambda_closed_set_of_closures t env symbol
       Un_anf.apply ~ppf_dump:t.ppf_dump ~what:symbol
         (to_clambda t env_body function_decl.body)
     in
+    assert (
+      Option.equal (fun dbg1 dbg2 -> Debuginfo.compare dbg1 dbg2 = 0)
+        (Variable.debug_info id) (Some function_decl.dbg));
     { label = Compilenv.function_label (Closure_id.wrap id);
       arity = Flambda_utils.function_arity function_decl;
       params = List.map (fun var -> VP.create var, Lambda.Pgenval) params;

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -769,12 +769,15 @@ let convert ~ppf_dump (program, exported_transient) : result =
       t.constants_for_instrumentation
   in
   let exported =
-    Export_info.t_of_transient exported_transient
-      ~program
-      ~local_offset_fun:current_unit.fun_offset_table
-      ~local_offset_fv:current_unit.fv_offset_table
-      ~imported_offset_fun:imported_units.fun_offset_table
-      ~imported_offset_fv:imported_units.fv_offset_table
-      ~constant_closures:current_unit.constant_closures
+    if !Clflags.opaque then
+      Export_info.t_of_opaque_transient exported_transient
+    else
+      Export_info.t_of_transient exported_transient
+        ~program
+        ~local_offset_fun:current_unit.fun_offset_table
+        ~local_offset_fv:current_unit.fv_offset_table
+        ~imported_offset_fun:imported_units.fun_offset_table
+        ~imported_offset_fv:imported_units.fv_offset_table
+        ~constant_closures:current_unit.constant_closures
   in
   { expr; preallocated_blocks; structured_constants; exported; }

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -347,7 +347,7 @@ let make_closure_declaration
   let subst_param param = Parameter.map_var subst param in
   let function_declaration =
     Flambda.create_function_declaration ~params:(List.map subst_param params)
-      ~body ~stub ~dbg:Debuginfo.none ~inline:Default_inline
+      ~body ~stub ~inline:Default_inline
       ~specialise:Default_specialise ~is_a_functor:false
       ~closure_origin:(Closure_origin.create (Closure_id.wrap id))
   in

--- a/middle_end/flambda/freshening.ml
+++ b/middle_end/flambda/freshening.ml
@@ -322,7 +322,7 @@ module Project_var = struct
         in
         let function_decl =
           Flambda.create_function_declaration ~params ~body
-            ~stub:func_decl.stub ~dbg:func_decl.dbg
+            ~stub:func_decl.stub
             ~inline:func_decl.inline ~specialise:func_decl.specialise
             ~is_a_functor:func_decl.is_a_functor
             ~closure_origin:func_decl.closure_origin

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -843,7 +843,7 @@ and simplify_partial_application env r ~lhs_of_application
       }
     in
     let closure_variable =
-      Variable.rename ~debug_info:dbg
+      Variable.rename ~debug_info:(Closure_id.debug_info closure_id_being_applied)
         (Closure_id.unwrap closure_id_being_applied)
     in
     Flambda_utils.make_closure_declaration ~id:closure_variable

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -611,7 +611,7 @@ and simplify_set_of_closures original_env r
     in
     let function_decl =
       Flambda.create_function_declaration ~params:function_decl.params
-        ~body ~stub:function_decl.stub ~dbg:function_decl.dbg
+        ~body ~stub:function_decl.stub
         ~inline:function_decl.inline ~specialise:function_decl.specialise
         ~is_a_functor:function_decl.is_a_functor
         ~closure_origin:function_decl.closure_origin
@@ -843,7 +843,7 @@ and simplify_partial_application env r ~lhs_of_application
       }
     in
     let closure_variable =
-      Variable.rename
+      Variable.rename ~debug_info:dbg
         (Closure_id.unwrap closure_id_being_applied)
     in
     Flambda_utils.make_closure_declaration ~id:closure_variable
@@ -1442,7 +1442,7 @@ and duplicate_function ~env ~(set_of_closures : Flambda.set_of_closures)
   in
   let function_decl =
     Flambda.create_function_declaration ~params:function_decl.params
-      ~body ~stub:function_decl.stub ~dbg:function_decl.dbg
+      ~body ~stub:function_decl.stub
       ~inline:function_decl.inline ~specialise:function_decl.specialise
       ~is_a_functor:function_decl.is_a_functor
       ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -673,6 +673,5 @@ let inline_by_copying_function_declaration
       in
       let expr = Flambda_utils.bind ~body ~bindings:state.let_bindings in
       let env = E.activate_freshening (E.set_never_inline env) in
-      let env = E.set_inline_debuginfo ~dbg env in
       Some (simplify env r expr)
     end

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -534,7 +534,6 @@ let rewrite_function ~lhs_of_application ~closure_id_being_applied
     Flambda.create_function_declaration
       ~params ~body
       ~stub:function_body.stub
-      ~dbg:function_body.dbg
       ~inline:function_body.inline
       ~specialise:function_body.specialise
       ~is_a_functor:function_body.is_a_functor
@@ -674,5 +673,6 @@ let inline_by_copying_function_declaration
       in
       let expr = Flambda_utils.bind ~body ~bindings:state.let_bindings in
       let env = E.activate_freshening (E.set_never_inline env) in
+      let env = E.set_inline_debuginfo ~dbg env in
       Some (simplify env r expr)
     end

--- a/middle_end/flambda/remove_unused_arguments.ml
+++ b/middle_end/flambda/remove_unused_arguments.ml
@@ -40,7 +40,7 @@ let remove_params unused (fun_decl: Flambda.function_declaration)
       unused_params
   in
   Flambda.create_function_declaration ~params:used_params ~body
-    ~stub:fun_decl.stub ~dbg:fun_decl.dbg ~inline:fun_decl.inline
+    ~stub:fun_decl.stub ~inline:fun_decl.inline
     ~specialise:fun_decl.specialise ~is_a_functor:fun_decl.is_a_functor
     ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
 
@@ -99,7 +99,7 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
   in
   let function_decl =
     Flambda.create_function_declaration ~params:(List.map snd args') ~body
-      ~stub:true ~dbg:fun_decl.dbg ~inline:Default_inline
+      ~stub:true ~inline:Default_inline
       ~specialise:Default_specialise ~is_a_functor:fun_decl.is_a_functor
       ~closure_origin:fun_decl.closure_origin
   in

--- a/middle_end/variable.ml
+++ b/middle_end/variable.ml
@@ -89,7 +89,7 @@ let create_with_same_name_as_ident ?debug_info ident =
 let rename ?current_compilation_unit ?debug_info t =
   let debug_info =
     match debug_info with
-    | Some debug_info -> Some debug_info
+    | Some _ -> debug_info
     | None -> t.debug_info
   in
   create_with_name_string ?current_compilation_unit ?debug_info t.name

--- a/middle_end/variable.ml
+++ b/middle_end/variable.ml
@@ -22,6 +22,7 @@ type t = {
   name : string;
   name_stamp : int;
   (** [name_stamp]s are unique within any given compilation unit. *)
+  debug_info : Debuginfo.t option;
 }
 
 include Identifiable.Make (struct
@@ -62,7 +63,7 @@ end)
 
 let previous_name_stamp = ref (-1)
 
-let create_with_name_string ?current_compilation_unit name =
+let create_with_name_string ?current_compilation_unit ?debug_info name =
   let compilation_unit =
     match current_compilation_unit with
     | Some compilation_unit -> compilation_unit
@@ -75,22 +76,30 @@ let create_with_name_string ?current_compilation_unit name =
   { compilation_unit;
     name;
     name_stamp;
+    debug_info;
   }
 
-let create ?current_compilation_unit name =
+let create ?current_compilation_unit ?debug_info name =
   let name = (name : Internal_variable_names.t :> string) in
-  create_with_name_string ?current_compilation_unit name
+  create_with_name_string ?current_compilation_unit ?debug_info name
 
-let create_with_same_name_as_ident ident =
-  create_with_name_string (Ident.name ident)
+let create_with_same_name_as_ident ?debug_info ident =
+  create_with_name_string ?debug_info (Ident.name ident)
 
-let rename ?current_compilation_unit t =
-  create_with_name_string ?current_compilation_unit t.name
+let rename ?current_compilation_unit ?debug_info t =
+  let debug_info =
+    match debug_info with
+    | Some debug_info -> Some debug_info
+    | None -> t.debug_info
+  in
+  create_with_name_string ?current_compilation_unit ?debug_info t.name
 
 let in_compilation_unit t cu =
   Compilation_unit.equal cu t.compilation_unit
 
 let get_compilation_unit t = t.compilation_unit
+
+let debug_info t = t.debug_info
 
 let name t = t.name
 

--- a/middle_end/variable.mli
+++ b/middle_end/variable.mli
@@ -28,14 +28,17 @@
 
 include Identifiable.S
 
+(** [debug_info] should be set for variables representing functions *)
 val create
    : ?current_compilation_unit:Compilation_unit.t
+  -> ?debug_info:Debuginfo.t
   -> Internal_variable_names.t
   -> t
-val create_with_same_name_as_ident : Ident.t -> t
+val create_with_same_name_as_ident : ?debug_info:Debuginfo.t -> Ident.t -> t
 
 val rename
    : ?current_compilation_unit:Compilation_unit.t
+  -> ?debug_info:Debuginfo.t
   -> t
   -> t
 
@@ -46,6 +49,8 @@ val name : t -> string
 val unique_name : t -> string
 
 val get_compilation_unit : t -> Compilation_unit.t
+
+val debug_info : t -> Debuginfo.t option
 
 val print_list : Format.formatter -> t list -> unit
 val print_opt : Format.formatter -> t option -> unit


### PR DESCRIPTION
This patch adds `Debuginfo.t` to `Variable.t` and hence `Closure_id.t` in Flambda 1.  In turn this allows the debugging information to be available when constructing the mangled names of functions.  A subsequent patch will use this to emit mangled names that follow the C++ conventions (see draft patch in #244).  Such names will be correctly demangled in `perf`, complete with submodule and anonymous function location information.  (`perf` does not read DWARF information to demangle names.)  In due course we can define a proper OCaml mangling convention and add support to that in `perf`, but that will take a fair amount of time.  Patches such as this one will be needed nonetheless.

Original work by @basimkhajwal

@chambart could you please review this?