### PR TITLE
Make Proc.frame_required and Proc.prologue_required independent of Mach

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -423,12 +423,12 @@ let op_is_pure = function
 
 (* Layout of the stack frame *)
 
-let frame_required fd =
-  fp || fd.fun_contains_calls ||
-  fd.fun_num_stack_slots.(0) > 0 || fd.fun_num_stack_slots.(1) > 0
+let frame_required ~fun_contains_calls ~fun_num_stack_slots =
+  fp || fun_contains_calls ||
+  fun_num_stack_slots.(0) > 0 || fun_num_stack_slots.(1) > 0
 
-let prologue_required fd =
-  frame_required fd
+let prologue_required ~fun_contains_calls ~fun_num_stack_slots =
+  frame_required ~fun_contains_calls ~fun_num_stack_slots
 
 (* Calling the assembler *)
 

--- a/backend/arm/proc.ml
+++ b/backend/arm/proc.ml
@@ -342,15 +342,15 @@ let op_is_pure = function
 
 (* Layout of the stack *)
 
-let frame_required fd =
-  let num_stack_slots = fd.fun_num_stack_slots in
-  fd.fun_contains_calls
+let frame_required ~fun_contains_calls ~fun_num_stack_slots =
+  let num_stack_slots = fun_num_stack_slots in
+  fun_contains_calls
     || num_stack_slots.(0) > 0
     || num_stack_slots.(1) > 0
     || num_stack_slots.(2) > 0
 
-let prologue_required fd =
-  frame_required fd
+let prologue_required ~fun_contains_calls ~fun_num_stack_slots =
+  frame_required ~fun_contains_calls ~fun_num_stack_slots
 
 (* Calling the assembler *)
 

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -292,13 +292,13 @@ let op_is_pure = function
   | _ -> true
 
 (* Layout of the stack *)
-let frame_required fd =
-  fd.fun_contains_calls
-    || fd.fun_num_stack_slots.(0) > 0
-    || fd.fun_num_stack_slots.(1) > 0
+let frame_required ~fun_contains_calls ~fun_num_stack_slots =
+  fun_contains_calls
+    || fun_num_stack_slots.(0) > 0
+    || fun_num_stack_slots.(1) > 0
 
-let prologue_required fd =
-  frame_required fd
+let prologue_required ~fun_contains_calls ~fun_num_stack_slots =
+  frame_required ~fun_contains_calls ~fun_num_stack_slots
 
 (* Calling the assembler *)
 

--- a/backend/i386/proc.ml
+++ b/backend/i386/proc.ml
@@ -240,16 +240,16 @@ let op_is_pure = function
 
 (* Layout of the stack frame *)
 
-let frame_required fd =
+let frame_required ~fun_contains_calls ~fun_num_stack_slots =
   let frame_size_at_top_of_function =
     (* cf. [frame_size] in emit.mlp. *)
-    Misc.align (4*fd.fun_num_stack_slots.(0) + 8*fd.fun_num_stack_slots.(1) + 4)
+    Misc.align (4*fun_num_stack_slots.(0) + 8*fun_num_stack_slots.(1) + 4)
       stack_alignment
   in
   frame_size_at_top_of_function > 4
 
-let prologue_required fd =
-  frame_required fd
+let prologue_required ~fun_contains_calls ~fun_num_stack_slots =
+  frame_required ~fun_contains_calls ~fun_num_stack_slots
 
 (* Calling the assembler *)
 

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -370,10 +370,14 @@ let add_prologue first_insn prologue_required =
   skip_naming_ops first_insn
 
 let fundecl f =
-  let fun_prologue_required = Proc.prologue_required f in
-  let contains_calls = f.Mach.fun_contains_calls in
+  let fun_contains_calls = f.Mach.fun_contains_calls in
+  let fun_num_stack_slots = f.Mach.fun_num_stack_slots in
+  let fun_prologue_required =
+    Proc.prologue_required ~fun_contains_calls ~fun_num_stack_slots in
+  let fun_frame_required =
+    Proc.frame_required ~fun_contains_calls ~fun_num_stack_slots in
   let fun_tailrec_entry_point_label, fun_body =
-    add_prologue (linear f.Mach.fun_body end_instr contains_calls)
+    add_prologue (linear f.Mach.fun_body end_instr fun_contains_calls)
       fun_prologue_required
   in
   { fun_name = f.Mach.fun_name;
@@ -381,8 +385,8 @@ let fundecl f =
     fun_fast = not (List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options);
     fun_dbg  = f.Mach.fun_dbg;
     fun_tailrec_entry_point_label = Some fun_tailrec_entry_point_label;
-    fun_contains_calls = contains_calls;
-    fun_num_stack_slots = f.Mach.fun_num_stack_slots;
-    fun_frame_required = Proc.frame_required f;
+    fun_contains_calls;
+    fun_num_stack_slots;
+    fun_frame_required;
     fun_prologue_required;
   }

--- a/backend/power/proc.ml
+++ b/backend/power/proc.ml
@@ -340,19 +340,19 @@ let reserved_stack_space_required () =
   | ELF32 -> false
   | ELF64v1 | ELF64v2 -> true
 
-let frame_required fd =
+let frame_required ~fun_contains_calls ~fun_num_stack_slots =
   let is_elf32 =
     match abi with
     | ELF32 -> true
     | ELF64v1 | ELF64v2 -> false
   in
   reserved_stack_space_required ()
-    || fd.fun_num_stack_slots.(0) > 0
-    || fd.fun_num_stack_slots.(1) > 0
-    || (fd.fun_contains_calls && is_elf32)
+    || fun_num_stack_slots.(0) > 0
+    || fun_num_stack_slots.(1) > 0
+    || (fun_contains_calls && is_elf32)
 
-let prologue_required fd =
-  frame_required fd
+let prologue_required ~fun_contains_calls ~fun_num_stack_slots =
+  frame_required ~fun_contains_calls ~fun_num_stack_slots
 
 (* Calling the assembler *)
 

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -62,10 +62,16 @@ val regs_are_volatile: Reg.t array -> bool
 val op_is_pure: Mach.operation -> bool
 
 (* Info for laying out the stack frame *)
-val frame_required : Mach.fundecl -> bool
+val frame_required :
+  fun_contains_calls:bool ->
+  fun_num_stack_slots: int array ->
+  bool
 
 (* Function prologues *)
-val prologue_required : Mach.fundecl -> bool
+val prologue_required :
+  fun_contains_calls : bool ->
+  fun_num_stack_slots : int array ->
+  bool
 
 (** For a given register class, the DWARF register numbering for that class.
     Given an allocated register with location [Reg n] and class [reg_class], the

--- a/backend/riscv/proc.ml
+++ b/backend/riscv/proc.ml
@@ -278,13 +278,13 @@ let op_is_pure = function
 
 (* Layout of the stack *)
 
-let frame_required fd =
-  fd.fun_contains_calls
-  || fd.fun_num_stack_slots.(0) > 0
-  || fd.fun_num_stack_slots.(1) > 0
+let frame_required ~fun_contains_calls ~fun_num_stack_slots =
+  fun_contains_calls
+  || fun_num_stack_slots.(0) > 0
+  || fun_num_stack_slots.(1) > 0
 
-let prologue_required fd =
-  frame_required fd
+let prologue_required ~fun_contains_calls ~fun_num_stack_slots =
+  frame_required ~fun_contains_calls ~fun_num_stack_slots
 
 (* See
    https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md *)

--- a/backend/s390x/proc.ml
+++ b/backend/s390x/proc.ml
@@ -222,13 +222,13 @@ let op_is_pure = function
 
 (* Layout of the stack *)
 
-let frame_required fd =
-  fd.fun_contains_calls
-    || fd.fun_num_stack_slots.(0) > 0
-    || fd.fun_num_stack_slots.(1) > 0
+let frame_required ~fun_contains_calls ~fun_num_stack_slots =
+  fun_contains_calls
+    || fun_num_stack_slots.(0) > 0
+    || fun_num_stack_slots.(1) > 0
 
-let prologue_required fd =
-  frame_required fd
+let prologue_required ~fun_contains_calls ~fun_num_stack_slots =
+  frame_required ~fun_contains_calls ~fun_num_stack_slots
 
 (* Calling the assembler *)
 


### PR DESCRIPTION
These functions will be called without Mach.fundecl, e.g., to go directly from Cfg to Linear IR, or when Cfg is used for FDO.