### PR TITLE
Add precomputed cfg fields

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -132,15 +132,11 @@ let test_cfgize (f : Mach.fundecl) (res : Linear.fundecl) : unit =
   if ocamlcfg_verbose then begin
     Format.eprintf "processing function %s...\n%!" f.Mach.fun_name;
   end;
-  let prologue_required = res.fun_prologue_required in
   let result =
     Cfgize.fundecl
       f
       ~preserve_orig_labels:false
       ~simplify_terminators:true
-      ~prologue_required
-      ~dbg:(if prologue_required then res.fun_body.dbg else Debuginfo.none)
-      ~fdo:(if prologue_required then res.fun_body.fdo else Fdo_info.none)
   in
   let expected = Linear_to_cfg.run res ~preserve_orig_labels:false in
   Eliminate_fallthrough_blocks.run expected;

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -188,9 +188,7 @@ let compile_fundecl ~ppf_dump fd_cmm =
       ++ Profile.record ~accumulate:true "linear_to_cfg"
            (Linear_to_cfg.run ~preserve_orig_labels:true)
       ++ pass_dump_cfg_if ppf_dump dump_cfg "After linear_to_cfg"
-      ++ Profile.record ~accumulate:true "cfg_to_linear" (fun cfg ->
-        let fun_body, fun_tailrec_entry_point_label = Cfg_to_linear.run cfg in
-        { fd with Linear.fun_body; fun_tailrec_entry_point_label; })
+      ++ Profile.record ~accumulate:true "cfg_to_linear" Cfg_to_linear.run
       ++ pass_dump_linear_if ppf_dump dump_linear "After cfg_to_linear"
     end else
       fd)

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -45,11 +45,23 @@ type t =
   { blocks : basic_block Label.Tbl.t;
     fun_name : string;
     fun_dbg : Debuginfo.t;
-    entry_label : Label.t
+    entry_label : Label.t;
+    fun_fast : bool;
+    fun_contains_calls : bool;
+    (* CR-someday gyorsh: compute locally. *)
+    fun_num_stack_slots : int array
   }
 
-let create ~fun_name ~fun_dbg =
-  { fun_name; fun_dbg; entry_label = 1; blocks = Label.Tbl.create 31 }
+let create ~fun_name ~fun_dbg ~fun_fast ~fun_contains_calls ~fun_num_stack_slots
+    =
+  { fun_name;
+    fun_dbg;
+    entry_label = 1;
+    blocks = Label.Tbl.create 31;
+    fun_fast;
+    fun_contains_calls;
+    fun_num_stack_slots
+  }
 
 let mem_block t label = Label.Tbl.mem t.blocks label
 

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -73,11 +73,21 @@ type t = private
   { blocks : basic_block Label.Tbl.t;  (** Map from labels to blocks *)
     fun_name : string;  (** Function name, used for printing messages *)
     fun_dbg : Debuginfo.t;  (** Dwarf debug info for function entry. *)
-    entry_label : Label.t
+    entry_label : Label.t;
         (** This label must be the first in all layouts of this cfg. *)
+    fun_fast : bool;  (** Precomputed based on cmmgen information. *)
+    fun_contains_calls : bool;  (** Precomputed at selection time. *)
+    fun_num_stack_slots : int array
+        (** Precomputed at register allocation time *)
   }
 
-val create : fun_name:string -> fun_dbg:Debuginfo.t -> t
+val create :
+  fun_name:string ->
+  fun_dbg:Debuginfo.t ->
+  fun_fast:bool ->
+  fun_contains_calls:bool ->
+  fun_num_stack_slots:int array ->
+  t
 
 val fun_name : t -> string
 

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -375,8 +375,12 @@ let check_basic_instruction :
     unit =
  fun state location idx expected result ->
   check_basic state location expected.desc result.desc;
-  check_instruction ~check_live:true ~check_dbg:true ~check_arg:true idx
-    location expected result
+  let check_dbg =
+    match expected.desc with Prologue -> false | _ -> true
+    [@@ocaml.warning "-4"]
+  in
+  check_instruction ~check_live:true ~check_dbg ~check_arg:true idx location
+    expected result
 
 let rec check_basic_instruction_list :
     State.t ->

--- a/backend/cfg/cfg_equivalence.mli
+++ b/backend/cfg/cfg_equivalence.mli
@@ -19,4 +19,5 @@ val check_cfg_with_layout :
  *  and terminators.)
  *
  *  Caveat: the check currently ignores the live sets and debug information
- *  on all terminators, and the input registers on `Always _` terminators. *)
+ *  on all terminators, the debug information on function prologue,
+ *  and the input registers on `Always _` terminators. *)

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -375,14 +375,34 @@ let run cfg_with_layout =
     in
     next := { Linear_utils.label; insn }
   done;
-  !next.insn, !tailrec_label
+  let fun_contains_calls = cfg.fun_contains_calls in
+  let fun_num_stack_slots = cfg.fun_num_stack_slots in
+  let fun_frame_required =
+    Proc.frame_required ~fun_contains_calls ~fun_num_stack_slots
+  in
+  let fun_prologue_required =
+    Proc.prologue_required ~fun_contains_calls ~fun_num_stack_slots
+  in
+  { Linear.fun_name = cfg.fun_name;
+    fun_body = !next.insn;
+    fun_tailrec_entry_point_label = !tailrec_label;
+    fun_fast = cfg.fun_fast;
+    fun_dbg = cfg.fun_dbg;
+    fun_contains_calls;
+    fun_num_stack_slots;
+    fun_frame_required;
+    fun_prologue_required
+  }
 
 (** debug print block as assembly *)
 let print_assembly (blocks : Cfg.basic_block list) =
   (* create a fake cfg just for printing these blocks *)
   let layout = List.map (fun (b : Cfg.basic_block) -> b.start) blocks in
   let fun_name = "_fun_start_" in
-  let cfg = Cfg.create ~fun_name ~fun_dbg:Debuginfo.none in
+  let cfg =
+    Cfg.create ~fun_name ~fun_dbg:Debuginfo.none ~fun_fast:false
+      ~fun_contains_calls:true ~fun_num_stack_slots:[||]
+  in
   List.iter
     (fun (block : Cfg.basic_block) ->
       Label.Tbl.add cfg.blocks block.start block)
@@ -391,19 +411,7 @@ let print_assembly (blocks : Cfg.basic_block list) =
     Cfg_with_layout.create cfg ~layout ~new_labels:Label.Set.empty
       ~preserve_orig_labels:true
   in
-  let fun_body, fun_tailrec_entry_point_label = run cl in
-  let fundecl =
-    { Linear.fun_name;
-      fun_body;
-      fun_fast = false;
-      fun_dbg = Debuginfo.none;
-      fun_num_stack_slots = Array.make Proc.num_register_classes 0;
-      fun_frame_required = false;
-      fun_prologue_required = false;
-      fun_contains_calls = false;
-      fun_tailrec_entry_point_label
-    }
-  in
+  let fundecl = run cl in
   X86_proc.reset_asm_code ();
   Emit.fundecl fundecl;
   X86_proc.generate_code (Some (X86_gas.generate_asm !Emitaux.output_channel))

--- a/backend/cfg/cfg_to_linear.mli
+++ b/backend/cfg/cfg_to_linear.mli
@@ -27,6 +27,6 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-val run : Cfg_with_layout.t -> Linear.instruction * Label.t option
+val run : Cfg_with_layout.t -> Linear.fundecl
 
 val print_assembly : Cfg.basic_block list -> unit

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -605,7 +605,11 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
 
 let run (f : Linear.fundecl) ~preserve_orig_labels =
   let t =
-    let cfg = Cfg.create ~fun_name:f.fun_name ~fun_dbg:f.fun_dbg in
+    let cfg =
+      Cfg.create ~fun_name:f.fun_name ~fun_dbg:f.fun_dbg ~fun_fast:f.fun_fast
+        ~fun_contains_calls:f.fun_contains_calls
+        ~fun_num_stack_slots:f.fun_num_stack_slots
+    in
     create cfg ~tailrec_label:f.fun_tailrec_entry_point_label
   in
   (* CR-someday gyorsh: label of the function entry must not conflict with

--- a/backend/cfgize.ml
+++ b/backend/cfgize.ml
@@ -675,30 +675,34 @@ let fundecl
   : Mach.fundecl
     -> preserve_orig_labels:bool
     -> simplify_terminators:bool
-    -> prologue_required:bool
-    -> dbg:Debuginfo.t
-    -> fdo:Fdo_info.t
     -> Cfg_with_layout.t
-  = fun fundecl ~preserve_orig_labels ~simplify_terminators ~prologue_required ~dbg ~fdo ->
+  = fun fundecl ~preserve_orig_labels ~simplify_terminators ->
     let { Mach.
           fun_name;
           fun_args = _;
           fun_body;
-          fun_codegen_options = _;
+          fun_codegen_options;
           fun_dbg;
-          fun_num_stack_slots = _;
-          fun_contains_calls = contains_calls; } = fundecl
+          fun_num_stack_slots;
+          fun_contains_calls } = fundecl
     in
     let initial_trap_depth = 1 in
     let start_label = Cmm.new_label () in
     let tailrec_label = Cmm.new_label () in
-    let cfg = Cfg.create ~fun_name ~fun_dbg in
-    let state = State.make ~fun_name ~tailrec_label ~contains_calls cfg.blocks in
+    let fun_fast = not (List.mem Cmm.Reduce_code_size fun_codegen_options) in
+    let prologue_required =
+        Proc.prologue_required ~fun_contains_calls ~fun_num_stack_slots in
+    let cfg = Cfg.create ~fun_name ~fun_dbg ~fun_fast
+                ~fun_contains_calls ~fun_num_stack_slots in
+    let state = State.make ~fun_name ~tailrec_label ~contains_calls:fun_contains_calls
+        cfg.blocks in
     State.add_block state ~label:(Cfg.entry_label cfg) ~block:{
       start = (Cfg.entry_label cfg);
       body = begin match prologue_required with
         | false -> []
         | true ->
+          let dbg = fun_body.dbg in
+          let fdo = Fdo_info.none in
           (* Note: the prologue must come after all `Iname_for_debugger1 instructions
              (this is currently not a concern because we do not support such instructions). *)
           [{ (make_instruction state ~desc:Cfg.Prologue ~trap_depth:initial_trap_depth)

--- a/backend/cfgize.mli
+++ b/backend/cfgize.mli
@@ -2,7 +2,4 @@ val fundecl
   : Mach.fundecl
   -> preserve_orig_labels:bool
   -> simplify_terminators:bool
-  -> prologue_required:bool
-  -> dbg:Debuginfo.t
-  -> fdo:Fdo_info.t
   -> Cfg_with_layout.t


### PR DESCRIPTION
All function-specific information that is required to emit assembly should be available from `Cfg_with_layout.t`.

This PRs adds a few missing fields: `fun_fast`, `fun_contains_calls`, and `fun_num_stack_slots` and uses Proc to compute the other fields: `fun_prologue_required` and `fun_frame_required`. 
Until now we have had these values in available `Linear.fundecl`  alongside the `Cfg`, but going forward it won't always be the case (e.g.,  #197).

On top of #249.