### PR TITLE
Inline variable definitions into let-symbol expressions

### DIFF
--- a/middle_end/flambda2/tests/mlexamples/let_symbol_var_inlining.ml
+++ b/middle_end/flambda2/tests/mlexamples/let_symbol_var_inlining.ml
@@ -1,0 +1,22 @@
+module M = struct
+  let a = List.length
+
+  let b = Sys.os_type
+
+  let c = List.map
+end
+
+include M
+
+module F (X : sig
+  val x : int
+end) =
+struct
+  let f n = n + X.x
+
+  let g m = m * X.x
+end
+
+include F [@inlined never] (struct
+  let x = 42
+end)

--- a/middle_end/flambda2/tests/mlexamples/let_symbol_var_inlining.mli
+++ b/middle_end/flambda2/tests/mlexamples/let_symbol_var_inlining.mli
@@ -1,0 +1,9 @@
+val a : 'a list -> int
+
+val b : string
+
+val c : ('a -> 'b) -> 'a list -> 'b list
+
+val f : int -> int
+
+val g : int -> int

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -853,7 +853,7 @@ and let_cont_rec env res conts body =
      recursive cont (aka a loop), as it would increase the number of times the
      computation is performed (even if there is only one syntactic
      occurrence) *)
-  let wrap, env = Env.flush_delayed_lets env in
+  let wrap, env = Env.flush_delayed_lets ~entering_loop:true env in
   (* Compute the environment for jump ids *)
   let map = Continuation_handlers.to_map conts in
   let env =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -441,7 +441,7 @@ let order_add b acc = M.add b.order b acc
 let order_add_map m acc =
   Variable.Map.fold (fun _ b acc -> order_add b acc) m acc
 
-let flush_delayed_lets env =
+let flush_delayed_lets ?(entering_loop = false) env =
   (* generate a wrapper function to introduce the delayed let-bindings. *)
   let wrap_aux pures stages e =
     let order_map = order_add_map pures M.empty in
@@ -456,14 +456,18 @@ let flush_delayed_lets env =
       (fun _ b acc -> To_cmm_helper.letin b.cmm_var b.cmm_expr acc)
       order_map e
   in
-  (* Only pure bindings that are not to be inlined are flushed now. The
-     remainder are preserved, ensuring that the corresponding expressions are
-     sunk down as far as possible. *)
-  let pures_to_inline, pures_not_to_inline =
-    Variable.Map.partition (fun _ binding -> binding.inline) env.pures
+  (* Unless entering a loop, only pure bindings that are not to be inlined are
+     flushed now. The remainder are preserved, ensuring that the corresponding
+     expressions are sunk down as far as possible. *)
+  (* CR-someday mshinwell: work out a criterion for allowing substitutions into
+     loops. *)
+  let pures_to_keep, pures_to_flush =
+    if entering_loop
+    then Variable.Map.empty, env.pures
+    else Variable.Map.partition (fun _ binding -> binding.inline) env.pures
   in
-  let wrap e = wrap_aux pures_not_to_inline env.stages e in
-  wrap, { env with stages = []; pures = pures_to_inline }
+  let wrap e = wrap_aux pures_to_flush env.stages e in
+  wrap, { env with stages = []; pures = pures_to_keep }
 
 (* Use and Scoping checks *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -120,7 +120,8 @@ val inline_variable :
 
 (** Wrap the given cmm expression with all the delayed let bindings accumulated
     in the environment. *)
-val flush_delayed_lets : t -> (Cmm.expression -> Cmm.expression) * t
+val flush_delayed_lets :
+  ?entering_loop:bool -> t -> (Cmm.expression -> Cmm.expression) * t
 
 (** Fetch the extra info for a flambda variable (if any). *)
 val extra_info : t -> Variable.t -> extra_info option


### PR DESCRIPTION
I think there's been a longstanding problem with Flambda 2 causing excessive numbers of live variables for compilation of let-symbol expressions corresponding to large module blocks.  This causes poor compilation time when using the default register allocator; with the linear scan allocator, register allocation may succeed but the "number of live variables" field in the frame table may overflow (cf. #246).

@lukemaurer is digging out some recent examples but I think the major problem might be when the contents of lots of module fields are copied, when such fields are not known to hold symbols.  There are two such examples (one using `include` and the other using a functor) in the test case here.  (The `.mli` is just to control unwanted bindings in the output.)

This PR attempts to solve this problem by using the existing `Un_cps` code that sinks let-bindings down and substitutes ones that are used exactly once (which I suspect the majority of the variables holding copied values will be).  I looked through the `Un_cps` code to see if I could find anything wrong with using the variable-inlining code at let-symbol bindings, but it did seem ok.

The Cmm code for the test cases here used to be compiled as:
```
(function camlTest__entry ()
 (catch
   (let
     ; In a large example each of the following four bound variables could be
     ; held live for a long time, with significant interference with other variables.
     (b159/275 (load val (+a "camlStdlib__Sys" 24))
      include180/292
        (app{test.ml:14,8-52} "camlTest__anon-fn[test.ml:9,9--87]_0_3_code"
          "camlTest__Pmakeblock87" val)
      Pfield181/293 (load val (+a include180/292 8))
      Pfield182/294 (load val include180/292))
     (store val(root-init) (+a "camlTest" 8) b159/275)
     (store val(root-init) (+a "camlTest" 24) Pfield182/294)
     (store val(root-init) (+a "camlTest" 32) Pfield181/293)
     (exit 1 "camlTest"))
 with(1 *ret*158/274: val) 1))
```
whereas now we get:
```
(function camlTest__entry ()
 (catch
   (let
     include180/292
       (app{test.ml:14,8-52} "camlTest__anon-fn[test.ml:9,9--87]_0_3_code"
         "camlTest__Pmakeblock87" val)
     (store val(root-init) (+a "camlTest" 8)
       (load val (+a "camlStdlib__Sys" 24)))
     (store val(root-init) (+a "camlTest" 24) (load val include180/292))
     (store val(root-init) (+a "camlTest" 32)
       (load val (+a include180/292 8)))
     (exit 1 "camlTest"))
 with(1 *ret*158/274: val) 1))
```
The variable corresponding to the applied functor is still potentially live for a long time, but I think that's unavoidable, at least until we have function return type inference in the simplifier.  (At that point projections from the applied functor may well be able to be simplified to symbols.)