### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,19 +33,23 @@ file_formats/                   @mshinwell
 middle_end/                     @mshinwell
 
 middle_end/flambda2/                    @mshinwell @lthls
+middle_end/flambda2/algorithms          @mshinwell @gbury
 middle_end/flambda2/backend_intf        @mshinwell @lthls
 middle_end/flambda2/basic               @mshinwell @lthls
+middle_end/flambda2/bound_identifiers   @mshinwell @lthls
 middle_end/flambda2/cmx                 @lthls @mshinwell
-middle_end/flambda2/compilenv_deps      @mshinwell @gbury
+middle_end/flambda2/compare             @poechsel @lukemaurer
 middle_end/flambda2/from_lambda         @lthls @mshinwell
-middle_end/flambda2/inlining            @poechsel @lukemaurer
-middle_end/flambda2/lifting             @mshinwell @chambart
+middle_end/flambda2/identifiers         @lthls @mshinwell
 middle_end/flambda2/nominal             @mshinwell @lthls
 middle_end/flambda2/simplify            @mshinwell @gbury
+middle_end/flambda2/simplify/inlining   @poechsel @lukemaurer
+middle_end/flambda2/simplify/lifting    @mshinwell @chambart
+middle_end/flambda2/simplify/unboxing   @chambart @gbury
 middle_end/flambda2/terms               @mshinwell @lthls
 middle_end/flambda2/to_cmm              @gbury @lthls
 middle_end/flambda2/types               @lthls @chambart
-middle_end/flambda2/unboxing            @chambart @gbury
+
 
 middle_end/flambda2/compare             @lukemaurer
 middle_end/flambda2/parser              @lukemaurer


### PR DESCRIPTION
Some recent PR moving files around forgot to update the codeowners file.

There are still some folders in flambda2 with no specific codeowners
(and whose review should thus default to @lthls and @mshinwell ):
kinds, numbers, parsers, scripts, tests.