### PR TITLE
Sort_lifted_constants: fix duplication of definitions

### DIFF
--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -207,6 +207,16 @@ let create_code code_id defining_expr =
     symbol_projections = Definition.symbol_projections definition
   }
 
+let create_definition definition =
+  let definitions = [definition] in
+  { definitions;
+    bound_symbols = compute_bound_symbols definitions;
+    defining_exprs = compute_defining_exprs definitions;
+    is_fully_static =
+      Rebuilt_static_const.is_fully_static (Definition.defining_expr definition);
+    symbol_projections = Definition.symbol_projections definition
+  }
+
 let concat ts =
   let definitions =
     List.fold_left (fun definitions t -> t.definitions @ definitions) [] ts

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.mli
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.mli
@@ -92,6 +92,8 @@ val create_set_of_closures :
 
 val create_code : Code_id.t -> Rebuilt_static_const.t -> t
 
+val create_definition : Definition.t -> t
+
 val definitions : t -> Definition.t list
 
 val bound_symbols : t -> Bound_symbols.t

--- a/middle_end/flambda2/simplify/lifting/sort_lifted_constants.ml
+++ b/middle_end/flambda2/simplify/lifting/sort_lifted_constants.ml
@@ -59,7 +59,8 @@ let build_dep_graph lifted_constants =
             (fun being_defined (dep_graph, code_id_or_symbol_to_const) ->
               let dep_graph = CIS.Map.add being_defined deps dep_graph in
               let code_id_or_symbol_to_const =
-                CIS.Map.add being_defined lifted_constant
+                CIS.Map.add being_defined
+                  (Lifted_constant.create_definition definition)
                   code_id_or_symbol_to_const
               in
               dep_graph, code_id_or_symbol_to_const)


### PR DESCRIPTION
A small fix, that will become necessary if we want to run Simplify with constant closure lifting activated (#164).
