### PR TITLE
Correct free names information for Function_params_and_body

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -54,7 +54,8 @@ module Calling_convention = struct
 
   let compute ~params_and_body ~is_tupled =
     let f ~return_continuation:_ _exn_continuation params ~body:_ ~my_closure:_
-        ~(is_my_closure_used : _ Or_unknown.t) ~my_depth:_ =
+        ~(is_my_closure_used : _ Or_unknown.t) ~my_depth:_ ~free_names_of_body:_
+        =
       let is_my_closure_used =
         match is_my_closure_used with
         | Unknown -> true

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -395,11 +395,12 @@ and subst_params_and_body env params_and_body =
          ~my_closure
          ~is_my_closure_used:_
          ~my_depth
+         ~free_names_of_body
        ->
       let body = subst_expr env body in
       let dbg = Function_params_and_body.debuginfo params_and_body in
       Function_params_and_body.create ~return_continuation exn_continuation
-        params ~dbg ~body ~my_closure ~free_names_of_body:Unknown ~my_depth)
+        params ~dbg ~body ~my_closure ~free_names_of_body ~my_depth)
 
 and subst_let_cont env (let_cont_expr : Let_cont_expr.t) =
   match let_cont_expr with

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -731,6 +731,7 @@ and static_let_expr env bound_symbols defining_expr body : Fexpr.expr =
                    ~my_closure
                    ~is_my_closure_used:_
                    ~my_depth
+                   ~free_names_of_body:_
                    :
                    Fexpr.params_and_body
                  ->

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -214,6 +214,7 @@ let inline dacc ~apply ~unroll_to function_decl =
          ~my_closure
          ~is_my_closure_used:_
          ~my_depth
+         ~free_names_of_body:_
        ->
       let make_inlined_body =
         make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~my_depth

--- a/middle_end/flambda2/simplify/non_constructed_code.ml
+++ b/middle_end/flambda2/simplify/non_constructed_code.ml
@@ -21,8 +21,6 @@ include
     (struct
       include Unit
 
-      let free_names_of_body _ = Or_unknown.Unknown
-
       let all_ids_for_export _ = Ids_for_export.empty
     end)
     (Flambda.Cost_metrics)

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -459,6 +459,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants closure_id
            ~my_closure
            ~is_my_closure_used:_
            ~my_depth
+           ~free_names_of_body:_
          ->
         let dacc =
           dacc_inside_function context ~used_closure_vars ~shareable_constants

--- a/middle_end/flambda2/terms/code0.ml
+++ b/middle_end/flambda2/terms/code0.ml
@@ -26,8 +26,6 @@ module Make (Function_params_and_body : sig
 
   val apply_renaming : t -> Renaming.t -> t
 
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
-
   val print : Format.formatter -> t -> unit
 end) (Cost_metrics : sig
   type t
@@ -265,13 +263,6 @@ struct
           older Name_mode.normal
     in
     Name_occurrences.union from_newer_version_of t.free_names_of_params_and_body
-
-  let free_names_of_body t =
-    let params_and_body =
-      params_and_body_must_be_present
-        ~error_context:"Accessing free_names_of_body" t
-    in
-    Function_params_and_body.free_names_of_body params_and_body
 
   let apply_renaming
       ({ code_id;

--- a/middle_end/flambda2/terms/code0.mli
+++ b/middle_end/flambda2/terms/code0.mli
@@ -23,8 +23,6 @@ module Make (Function_params_and_body : sig
 
   val apply_renaming : t -> Renaming.t -> t
 
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
-
   val print : Format.formatter -> t -> unit
 end) (Cost_metrics : sig
   type t

--- a/middle_end/flambda2/terms/code_intf.ml
+++ b/middle_end/flambda2/terms/code_intf.ml
@@ -90,8 +90,6 @@ module type S = sig
 
   include Contains_names.S with type t := t
 
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
-
   val print : Format.formatter -> t -> unit
 
   val all_ids_for_export : t -> Ids_for_export.t

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -434,6 +434,7 @@ and Function_params_and_body : sig
       my_closure:Variable.t ->
       is_my_closure_used:bool Or_unknown.t ->
       my_depth:Variable.t ->
+      free_names_of_body:Name_occurrences.t Or_unknown.t ->
       'a) ->
     'a
 
@@ -459,8 +460,6 @@ and Function_params_and_body : sig
       my_depth:Variable.t ->
       'a) ->
     'a
-
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
 
   (** Return the debuginfo associated *)
   val debuginfo : t -> Debuginfo.t
@@ -638,8 +637,6 @@ and Code : sig
   val print : Format.formatter -> t -> unit
 
   include Contains_names.S with type t := t
-
-  val free_names_of_body : t -> Name_occurrences.t Or_unknown.t
 
   val all_ids_for_export : t -> Ids_for_export.t
 

--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -206,6 +206,7 @@ module Iter = struct
                  ~my_closure:_
                  ~is_my_closure_used:_
                  ~my_depth:_
+                 ~free_names_of_body:_
                -> expr f_c f_s body))
       ~set_of_closures:(fun () ~closure_symbols set_of_closures ->
         f_s ~closure_symbols:(Some closure_symbols) ~is_phantom:false

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -1459,6 +1459,7 @@ and params_and_body env res fun_name p =
          ~my_closure
          ~is_my_closure_used
          ~my_depth:_
+         ~free_names_of_body:_
        ->
       try
         let args = function_args vars my_closure ~is_my_closure_used in


### PR DESCRIPTION
The `free_names_of_body` field of the `Function_params_and_body.t` structure was including names bound by the abstractions, outside of these abstractions. I've pushed the field inside the abstraction and tweaked the interfaces accordingly.

@Keryan-dev this should help quite a it with the inlining work.