### PR TITLE
Do not inline function deemed un-inlinable at definition

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -864,7 +864,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)
-      ~dbg ~is_tupled
+      ~dbg ~is_tupled ~inlining_decision:Not_yet_decided
   in
   let acc = Acc.add_code ~code_id ~code acc in
   let acc = Acc.with_seen_a_function acc true in

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -789,12 +789,14 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           Flambda.Cost_metrics.from_size (Code_size.of_int code_size)
         in
         let code =
+          (* CR mshinwell: [inlining_decision] should maybe be set properly *)
           Flambda.Code.create code_id ~params_and_body ~newer_version_of
             ~params_arity ~result_arity ~stub:false ~inline ~is_a_functor:false
             ~recursive
             ~cost_metrics (* CR poechsel: grab inlining arguments from fexpr. *)
             ~inlining_arguments:(Inlining_arguments.create ~round:0)
             ~dbg:Debuginfo.none ~is_tupled
+            ~inlining_decision:Never_inline_attribute
         in
         Code code
     in

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
@@ -23,6 +23,7 @@ open! Flambda.Import
    inlined. *)
 type t = private
   | Missing_code
+  | Definition_says_not_to_inline
   | Environment_says_never_inline
   | Unrolling_depth_exceeded
   | Max_inlining_depth_exceeded
@@ -47,7 +48,10 @@ val print : Format.formatter -> t -> unit
 val report : Format.formatter -> t -> unit
 
 type can_inline = private
-  | Do_not_inline of { warn_if_attribute_ignored : bool }
+  | Do_not_inline of
+      { warn_if_attribute_ignored : bool;
+        because_of_definition : bool
+      }
   | Inline of { unroll_to : int option }
 
 val can_inline : t -> can_inline

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
@@ -22,6 +22,7 @@ open! Flambda.Import
    something can be inlined, and one giving the reasons why something cannot be
    inlined. *)
 type t = private
+  | Missing_code
   | Environment_says_never_inline
   | Unrolling_depth_exceeded
   | Max_inlining_depth_exceeded
@@ -54,7 +55,7 @@ val can_inline : t -> can_inline
 val make_decision :
   Downwards_acc.t ->
   simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  function_decl:Flambda_type.Function_declaration_type.Inlinable.t ->
+  function_decl:Flambda_type.Function_declaration_type.T0.t ->
   apply:Apply.t ->
   return_arity:Flambda_arity.With_subkinds.t ->
   t

--- a/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.ml
@@ -18,123 +18,17 @@
 
 open! Flambda.Import
 
-type t =
-  | Never_inline_attribute
-  | Function_body_too_large of Code_size.t
-  | Stub
-  | Attribute_inline
-  | Small_function of
-      { size : Code_size.t;
-        small_function_size : Code_size.t
-      }
-  | Speculatively_inlinable of
-      { size : Code_size.t;
-        small_function_size : Code_size.t;
-        large_function_size : Code_size.t
-      }
-  | Functor of { size : Code_size.t }
-
-type inlining_behaviour =
-  | Cannot_be_inlined
-  | Must_be_inlined
-  | Could_possibly_be_inlined
-
-let behaviour t =
-  match t with
-  | Never_inline_attribute | Function_body_too_large _ -> Cannot_be_inlined
-  | Stub | Attribute_inline | Small_function _ -> Must_be_inlined
-  | Functor _ | Speculatively_inlinable _ -> Could_possibly_be_inlined
-
-let [@ocamlformat "disable"] print fmt = function
-  | Never_inline_attribute ->
-    Format.fprintf fmt "Never_inline_attribute"
-  | Function_body_too_large large_function_size ->
-    Format.fprintf fmt
-      "@[<hov 1>(Function_body_too_large@ %a)@]"
-      Code_size.print large_function_size
-  | Stub ->
-    Format.fprintf fmt "Stub"
-  | Attribute_inline ->
-    Format.fprintf fmt "Attribute_inline"
-  | Small_function {size; small_function_size} ->
-    Format.fprintf fmt
-      "@[<hov 1>(Small_function@ \
-        @[<hov 1>(size@ %a)@]@ \
-        @[<hov 1>(small_function_size@ %a)@]\
-        )@]"
-      Code_size.print size
-      Code_size.print small_function_size
-  | Speculatively_inlinable {size;
-                              small_function_size;
-                              large_function_size} ->
-    Format.fprintf fmt
-      "@[<hov 1>(Speculatively_inlinable@ \
-        @[<hov 1>(size@ %a)@]@ \
-        @[<hov 1>(small_function_size@ %a)@]@ \
-        @[<hov 1>(large_function_size@ %a)@]\
-        )@]"
-      Code_size.print size
-      Code_size.print small_function_size
-      Code_size.print large_function_size
-  | Functor { size } ->
-    Format.fprintf fmt
-      "@[<hov 1>(Functor@ \
-        @[<hov 1>(size@ %a)@]\
-        )@]"
-      Code_size.print size
-
-let report_reason fmt = function
-  | Never_inline_attribute ->
-    Format.fprintf fmt "%a" Format.pp_print_text
-      "the function has an attribute preventing its inlining"
-  | Function_body_too_large large_function_size ->
-    Format.fprintf fmt
-      "the@ function's@ body@ is@ too@ large,@ more@ specifically,@ it@ is@ \
-       larger@ than@ the@ large@ function@ size:@ %a"
-      Code_size.print large_function_size
-  | Stub -> Format.fprintf fmt "the@ function@ is@ a@ stub"
-  | Attribute_inline ->
-    Format.fprintf fmt
-      "the@ function@ has@ an@ attribute@ forcing@ its@ inlining"
-  | Small_function { size; small_function_size } ->
-    Format.fprintf fmt
-      "the@ function's@ body@ is@ smaller@ than@ the@ threshold@ size@ for@ \
-       small@ functions: size=%a <= large@ function@ size=%a"
-      Code_size.print size Code_size.print small_function_size
-  | Speculatively_inlinable { size; small_function_size; large_function_size }
-    ->
-    Format.fprintf fmt
-      "the@ function's@ body@ is@ between@ the@ threshold@ size@ for@ small@ \
-       functions and the@ threshold@ size@ for@ large@ functions: small@ \
-       function@ size=%a < size=%a < large@ function@ size=%a"
-      Code_size.print small_function_size Code_size.print size Code_size.print
-      large_function_size
-  | Functor _ ->
-    Format.fprintf fmt
-      "this@ function@ is@ a@ functor@ (so@ the@ large@ function@ threshold@ \
-       was@ not@ applied)."
-
-let report fmt t =
-  Format.fprintf fmt
-    "@[<v>The function %s be inlined at its use-sites@ because @[<hov>%a@]@]"
-    (match behaviour t with
-    | Cannot_be_inlined -> "cannot"
-    | Could_possibly_be_inlined -> "could"
-    | Must_be_inlined -> "must")
-    report_reason t
-
-let make_decision code : t =
+let make_decision ~inlining_arguments:args ~inline ~stub ~cost_metrics:metrics
+    ~is_a_functor : Function_decl_inlining_decision_type.t =
   (* At present, we follow Closure, taking inlining decisions without first
      examining call sites. *)
-  let args = Code.inlining_arguments code in
-  match Code.inline code with
+  match (inline : Inline_attribute.t) with
   | Never_inline -> Never_inline_attribute
   | Hint_inline | Always_inline -> Attribute_inline
   | Default_inline | Unroll _ ->
-    if Code.stub code
+    if stub
     then Stub
     else
-      let metrics = Code.cost_metrics code in
       let large_function_size =
         Inlining_arguments.large_function_size args |> Code_size.of_int
       in
@@ -144,7 +38,7 @@ let make_decision code : t =
       let size = Cost_metrics.size metrics in
       let is_small = Code_size.( <= ) size small_function_size in
       let is_large = Code_size.( <= ) large_function_size size in
-      if Code.is_a_functor code
+      if is_a_functor
       then Functor { size }
       else if is_large
       then Function_body_too_large large_function_size

--- a/middle_end/flambda2/simplify/inlining/inlining_report.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_report.ml
@@ -32,7 +32,7 @@ type fundecl_pass =
 type at_function_declaration =
   { pass : fundecl_pass;
     code_id : Code_id.exported;
-    decision : Function_decl_inlining_decision.t
+    decision : Function_decl_inlining_decision_type.t
   }
 
 type decision =
@@ -92,7 +92,7 @@ let [@ocamlformat "disable"] rec print ~depth fmt = function
       stars depth Code_id.(name (import code_id)) print_debuginfo dbg;
     Format.fprintf fmt "%a @[<v>Before simplification:@ @ %a@]@\n@\n"
       stars (depth + 1)
-      Function_decl_inlining_decision.report decision;
+      Function_decl_inlining_decision_type.report decision;
     print ~depth:(depth + 1) fmt r
 
   (* Exiting a function_declaration (possibly nested) *)
@@ -100,7 +100,7 @@ let [@ocamlformat "disable"] rec print ~depth fmt = function
       pass = After_simplify; code_id; decision; } } :: r ->
     Format.fprintf fmt "%a @[<v>After simplification of %s{%a}:@ @ %a@]@\n@\n@\n"
       stars depth Code_id.(name (import code_id)) print_debuginfo dbg
-      Function_decl_inlining_decision.report decision;
+      Function_decl_inlining_decision_type.report decision;
     print ~depth:(depth - 1) fmt r
 
   (* Function call *)

--- a/middle_end/flambda2/simplify/inlining/inlining_report.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_report.ml
@@ -18,12 +18,11 @@
    method, c-calls, or function with no precise enough type to inline). *)
 
 type at_call_site =
-  | Unknown_function
-  | Non_inlinable_function of { code_id : Code_id.exported }
-  | Inlinable_function of
+  | Known_function of
       { code_id : Code_id.exported;
         decision : Call_site_inlining_decision.t
       }
+  | Unknown_function
 
 type fundecl_pass =
   | Before_simplify
@@ -112,16 +111,7 @@ let [@ocamlformat "disable"] rec print ~depth fmt = function
       "The function call has not been inlined"
       "because the optimizer had not enough information about the function";
     print ~depth fmt r
-  | { decision = At_call_site (Non_inlinable_function { code_id; });
-      dbg; } :: r ->
-    Format.fprintf fmt "%a @[<v>%s of %s{%a}@ @ %s@ %s@]@\n@\n"
-      stars depth
-      (if depth = 0 then "Toplevel application" else "Application")
-      Code_id.(name (import code_id)) print_debuginfo dbg
-      "The function call has not been inlined"
-      "because its definition was deemed not inlinable";
-    print ~depth fmt r
-  | { decision = At_call_site (Inlinable_function { code_id; decision; });
+  | { decision = At_call_site (Known_function { code_id; decision; });
       dbg; } :: r ->
     Format.fprintf fmt "%a @[<v>%s of %s{%a}@ @ %a@]@\n@\n"
       stars depth

--- a/middle_end/flambda2/simplify/inlining/inlining_report.mli
+++ b/middle_end/flambda2/simplify/inlining/inlining_report.mli
@@ -15,17 +15,11 @@
 (** Report inlining decisions *)
 
 type at_call_site =
-  | Unknown_function  (** Function call where the function's type is unknown. *)
-  | Non_inlinable_function of
-      { code_id : Code_id.exported  (** code id of the callee *) }
-      (** Function call where the function's type is known, but was marked as
-          non-inlinable. *)
-  | Inlinable_function of
+  | Known_function of
       { code_id : Code_id.exported;  (** code id of the callee *)
         decision : Call_site_inlining_decision.t
-      }
-      (** Function call where the function's type is known, and was marked as
-          inlinable. *)
+      }  (** Function call where the function's type is known *)
+  | Unknown_function  (** Function call where the function's type is unknown. *)
 
 (** There are two decisions made for each function declaration: one before
     simplifying the body, and one after (this is useful for e.g. recursive

--- a/middle_end/flambda2/simplify/inlining/inlining_report.mli
+++ b/middle_end/flambda2/simplify/inlining/inlining_report.mli
@@ -38,7 +38,7 @@ type fundecl_pass =
 type at_function_declaration =
   { pass : fundecl_pass;
     code_id : Code_id.exported;  (** code id of the function being declared *)
-    decision : Function_decl_inlining_decision.t
+    decision : Function_decl_inlining_decision_type.t
   }
 
 (** This defines the various kinds of decisions related to inlining that will be

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -19,7 +19,7 @@
 open! Simplify_import
 module DA = Downwards_acc
 module DE = Downwards_env
-module I = Flambda_type.Function_declaration_type.Inlinable
+module I = Flambda_type.Function_declaration_type.T0
 module VB = Bound_var
 
 let make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~my_depth

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.mli
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.mli
@@ -22,5 +22,5 @@ val inline :
   Downwards_acc.t ->
   apply:Apply.t ->
   unroll_to:int option ->
-  Flambda_type.Function_declaration_type.Inlinable.t ->
+  Flambda_type.Function_declaration_type.T0.t ->
   Downwards_acc.t * Expr.t

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -34,7 +34,8 @@ let create_normal_non_code const =
 
 let create_code are_rebuilding code_id ~(params_and_body : _ Or_deleted.t)
     ~newer_version_of ~params_arity ~result_arity ~stub ~inline ~is_a_functor
-    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled =
+    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
+    ~inlining_decision =
   if ART.do_not_rebuild_terms are_rebuilding
   then
     let params_and_body =
@@ -46,7 +47,7 @@ let create_code are_rebuilding code_id ~(params_and_body : _ Or_deleted.t)
     let non_constructed_code =
       Non_constructed_code.create code_id ~params_and_body ~newer_version_of
         ~params_arity ~result_arity ~stub ~inline ~is_a_functor ~recursive
-        ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
+        ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~inlining_decision
     in
     Code_not_rebuilt non_constructed_code
   else
@@ -62,7 +63,7 @@ let create_code are_rebuilding code_id ~(params_and_body : _ Or_deleted.t)
     let code =
       Code.create code_id ~params_and_body ~newer_version_of ~params_arity
         ~result_arity ~stub ~inline ~is_a_functor ~recursive ~cost_metrics
-        ~inlining_arguments ~dbg ~is_tupled
+        ~inlining_arguments ~dbg ~is_tupled ~inlining_decision
     in
     Normal { const = Code code; free_names = Code.free_names code }
 
@@ -297,7 +298,8 @@ module Group = struct
                  ~recursive:(NCC.recursive code)
                  ~cost_metrics:(NCC.cost_metrics code)
                  ~inlining_arguments:(NCC.inlining_arguments code)
-                 ~dbg:(NCC.dbg code) ~is_tupled:(NCC.is_tupled code)))
+                 ~dbg:(NCC.dbg code) ~is_tupled:(NCC.is_tupled code)
+                 ~inlining_decision:(NCC.inlining_decision code)))
     in
     consts
     |> List.filter_map (fun code ->

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -44,6 +44,7 @@ val create_code :
   inlining_arguments:Inlining_arguments.t ->
   dbg:Debuginfo.t ->
   is_tupled:bool ->
+  inlining_decision:Function_decl_inlining_decision_type.t ->
   t
 
 (* This function should be used when a [Code.t] is already in hand, e.g. from

--- a/middle_end/flambda2/terms/code0.ml
+++ b/middle_end/flambda2/terms/code0.ml
@@ -49,7 +49,8 @@ struct
       cost_metrics : Cost_metrics.t;
       inlining_arguments : Inlining_arguments.t;
       dbg : Debuginfo.t;
-      is_tupled : bool
+      is_tupled : bool;
+      inlining_decision : Function_decl_inlining_decision_type.t
     }
 
   let code_id { code_id; _ } = code_id
@@ -89,6 +90,8 @@ struct
 
   let is_tupled { is_tupled; _ } = is_tupled
 
+  let inlining_decision { inlining_decision; _ } = inlining_decision
+
   let check_params_and_body code_id (params_and_body : _ Or_deleted.t) =
     let free_names_of_params_and_body =
       match params_and_body with
@@ -114,7 +117,7 @@ struct
   let create code_id ~(params_and_body : _ Or_deleted.t) ~newer_version_of
       ~params_arity ~result_arity ~stub ~(inline : Inline_attribute.t)
       ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
-      =
+      ~inlining_decision =
     begin
       match stub, inline with
       | true, (Hint_inline | Never_inline | Default_inline)
@@ -142,7 +145,8 @@ struct
       cost_metrics;
       inlining_arguments;
       dbg;
-      is_tupled
+      is_tupled;
+      inlining_decision
     }
 
   let with_code_id code_id t = { t with code_id }
@@ -174,7 +178,7 @@ struct
         { code_id = _; params_and_body; newer_version_of; stub; inline;
           is_a_functor; params_arity; result_arity; recursive;
           free_names_of_params_and_body = _; cost_metrics; inlining_arguments;
-          dbg; is_tupled; } =
+          dbg; is_tupled; inlining_decision; } =
     let module C = Flambda_colours in
     match params_and_body with
     | Present _ ->
@@ -189,7 +193,8 @@ struct
           @[<hov 1>(cost_metrics@ %a)@]@ \
           @[<hov 1>(inlining_arguments@ %a)@]@ \
           @[<hov 1>@<0>%s(dbg@ %a)@<0>%s@]@ \
-          @[<hov 1>@<0>%s(is_tupled @ %b)@<0>%s@]@ \
+          @[<hov 1>@<0>%s(is_tupled@ %b)@<0>%s@]@ \
+          @[<hov 1>(inlining_decision@ %a)@]@ \
           %a\
           )@]"
         (if Option.is_none newer_version_of then Flambda_colours.elide ()
@@ -240,6 +245,7 @@ struct
         else Flambda_colours.elide ())
         is_tupled
         (Flambda_colours.normal ())
+        Function_decl_inlining_decision_type.print inlining_decision
         print_params_and_body params_and_body
     | Deleted ->
       Format.fprintf ppf "@[<hov 1>(\
@@ -287,7 +293,8 @@ struct
          free_names_of_params_and_body;
          inlining_arguments = _;
          dbg = _;
-         is_tupled = _
+         is_tupled = _;
+         inlining_decision = _
        } as t) perm =
     (* inlined and modified version of Option.map to preserve sharing *)
     let newer_version_of' =
@@ -338,7 +345,8 @@ struct
         free_names_of_params_and_body = _;
         inlining_arguments = _;
         dbg = _;
-        is_tupled = _
+        is_tupled = _;
+        inlining_decision = _
       } =
     let newer_version_of_ids =
       match newer_version_of with

--- a/middle_end/flambda2/terms/code_intf.ml
+++ b/middle_end/flambda2/terms/code_intf.ml
@@ -58,6 +58,8 @@ module type S = sig
 
   val is_tupled : t -> bool
 
+  val inlining_decision : t -> Function_decl_inlining_decision_type.t
+
   val create :
     Code_id.t (** needed for [compare], although useful otherwise too *) ->
     params_and_body:(function_params_and_body * Name_occurrences.t) Or_deleted.t ->
@@ -72,6 +74,7 @@ module type S = sig
     inlining_arguments:Inlining_arguments.t ->
     dbg:Debuginfo.t ->
     is_tupled:bool ->
+    inlining_decision:Function_decl_inlining_decision_type.t ->
     t
 
   val with_code_id : Code_id.t -> t -> t

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -608,6 +608,8 @@ and Code : sig
 
   val is_tupled : t -> bool
 
+  val inlining_decision : t -> Function_decl_inlining_decision_type.t
+
   val create :
     Code_id.t ->
     params_and_body:
@@ -623,6 +625,7 @@ and Code : sig
     inlining_arguments:Inlining_arguments.t ->
     dbg:Debuginfo.t ->
     is_tupled:bool ->
+    inlining_decision:Function_decl_inlining_decision_type.t ->
     t
 
   val with_code_id : Code_id.t -> t -> t

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
@@ -126,3 +126,13 @@ let report fmt t =
     | Could_possibly_be_inlined -> "could"
     | Must_be_inlined -> "must")
     report_decision t
+
+let must_be_inlined t =
+  match behaviour t with
+  | Must_be_inlined -> true
+  | Cannot_be_inlined | Could_possibly_be_inlined -> false
+
+let cannot_be_inlined t =
+  match behaviour t with
+  | Cannot_be_inlined -> true
+  | Must_be_inlined | Could_possibly_be_inlined -> false

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
@@ -1,0 +1,128 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2021 OCamlPro SAS                                    *)
+(*   Copyright 2014--2021 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+type t =
+  | Not_yet_decided
+  | Never_inline_attribute
+  | Function_body_too_large of Code_size.t
+  | Stub
+  | Attribute_inline
+  | Small_function of
+      { size : Code_size.t;
+        small_function_size : Code_size.t
+      }
+  | Speculatively_inlinable of
+      { size : Code_size.t;
+        small_function_size : Code_size.t;
+        large_function_size : Code_size.t
+      }
+  | Functor of { size : Code_size.t }
+
+let [@ocamlformat "disable"] print ppf t =
+  match t with
+  | Not_yet_decided -> Format.fprintf ppf "Not_yet_decided"
+  | Never_inline_attribute ->
+    Format.fprintf ppf "Never_inline_attribute"
+  | Function_body_too_large large_function_size ->
+    Format.fprintf ppf
+      "@[<hov 1>(Function_body_too_large@ %a)@]"
+      Code_size.print large_function_size
+  | Stub ->
+    Format.fprintf ppf "Stub"
+  | Attribute_inline ->
+    Format.fprintf ppf "Attribute_inline"
+  | Small_function {size; small_function_size} ->
+    Format.fprintf ppf
+      "@[<hov 1>(Small_function@ \
+        @[<hov 1>(size@ %a)@]@ \
+        @[<hov 1>(small_function_size@ %a)@]\
+        )@]"
+      Code_size.print size
+      Code_size.print small_function_size
+  | Speculatively_inlinable {size;
+                              small_function_size;
+                              large_function_size} ->
+    Format.fprintf ppf
+      "@[<hov 1>(Speculatively_inlinable@ \
+        @[<hov 1>(size@ %a)@]@ \
+        @[<hov 1>(small_function_size@ %a)@]@ \
+        @[<hov 1>(large_function_size@ %a)@]\
+        )@]"
+      Code_size.print size
+      Code_size.print small_function_size
+      Code_size.print large_function_size
+  | Functor { size } ->
+    Format.fprintf ppf
+      "@[<hov 1>(Functor@ \
+        @[<hov 1>(size@ %a)@]\
+        )@]"
+      Code_size.print size
+
+let report_decision ppf t =
+  match t with
+  | Not_yet_decided -> Format.fprintf ppf "no decision has yet been made"
+  | Never_inline_attribute ->
+    Format.fprintf ppf "%a" Format.pp_print_text
+      "the function has an attribute preventing its inlining"
+  | Function_body_too_large large_function_size ->
+    Format.fprintf ppf
+      "the@ function's@ body@ is@ too@ large,@ more@ specifically,@ it@ is@ \
+       larger@ than@ the@ large@ function@ size:@ %a"
+      Code_size.print large_function_size
+  | Stub -> Format.fprintf ppf "the@ function@ is@ a@ stub"
+  | Attribute_inline ->
+    Format.fprintf ppf
+      "the@ function@ has@ an@ attribute@ forcing@ its@ inlining"
+  | Small_function { size; small_function_size } ->
+    Format.fprintf ppf
+      "the@ function's@ body@ is@ smaller@ than@ the@ threshold@ size@ for@ \
+       small@ functions: size=%a <= large@ function@ size=%a"
+      Code_size.print size Code_size.print small_function_size
+  | Speculatively_inlinable { size; small_function_size; large_function_size }
+    ->
+    Format.fprintf ppf
+      "the@ function's@ body@ is@ between@ the@ threshold@ size@ for@ small@ \
+       functions and the@ threshold@ size@ for@ large@ functions: small@ \
+       function@ size=%a < size=%a < large@ function@ size=%a"
+      Code_size.print small_function_size Code_size.print size Code_size.print
+      large_function_size
+  | Functor _ ->
+    Format.fprintf ppf
+      "this@ function@ is@ a@ functor@ (so@ the@ large@ function@ threshold@ \
+       was@ not@ applied)."
+
+type inlining_behaviour =
+  | Cannot_be_inlined
+  | Must_be_inlined
+  | Could_possibly_be_inlined
+
+let behaviour t =
+  match t with
+  | Not_yet_decided | Never_inline_attribute | Function_body_too_large _ ->
+    Cannot_be_inlined
+  | Stub | Attribute_inline | Small_function _ -> Must_be_inlined
+  | Functor _ | Speculatively_inlinable _ -> Could_possibly_be_inlined
+
+let report fmt t =
+  Format.fprintf fmt
+    "@[<v>The function %s be inlined at its use-sites@ because @[<hov>%a@]@]"
+    (match behaviour t with
+    | Cannot_be_inlined -> "cannot"
+    | Could_possibly_be_inlined -> "could"
+    | Must_be_inlined -> "must")
+    report_decision t

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
@@ -37,9 +37,6 @@ val print : Format.formatter -> t -> unit
 
 val report : Format.formatter -> t -> unit
 
-type inlining_behaviour = private
-  | Cannot_be_inlined
-  | Must_be_inlined
-  | Could_possibly_be_inlined
+val must_be_inlined : t -> bool
 
-val behaviour : t -> inlining_behaviour
+val cannot_be_inlined : t -> bool

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
@@ -5,8 +5,8 @@
 (*                       Pierre Chambart, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2013--2021 OCamlPro SAS                                    *)
+(*   Copyright 2014--2021 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,14 +14,32 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
-open! Flambda.Import
+type t =
+  | Not_yet_decided
+  | Never_inline_attribute
+  | Function_body_too_large of Code_size.t
+  | Stub
+  | Attribute_inline
+  | Small_function of
+      { size : Code_size.t;
+        small_function_size : Code_size.t
+      }
+  | Speculatively_inlinable of
+      { size : Code_size.t;
+        small_function_size : Code_size.t;
+        large_function_size : Code_size.t
+      }
+  | Functor of { size : Code_size.t }
 
-val make_decision :
-  inlining_arguments:Inlining_arguments.t ->
-  inline:Inline_attribute.t ->
-  stub:bool ->
-  cost_metrics:Cost_metrics.t ->
-  is_a_functor:bool ->
-  Function_decl_inlining_decision_type.t
+val print : Format.formatter -> t -> unit
+
+val report : Format.formatter -> t -> unit
+
+type inlining_behaviour = private
+  | Cannot_be_inlined
+  | Must_be_inlined
+  | Could_possibly_be_inlined
+
+val behaviour : t -> inlining_behaviour

--- a/middle_end/flambda2/types/flambda_type.mli
+++ b/middle_end/flambda2/types/flambda_type.mli
@@ -227,27 +227,15 @@ val join :
 type 'a type_accessor = Typing_env.t -> 'a
 
 module Function_declaration_type : sig
-  module Inlinable : sig
+  module T0 : sig
     type t
 
     val code_id : t -> Code_id.t
 
     val rec_info : t -> flambda_type
-
-    val must_be_inlined : t -> bool
   end
 
-  module Non_inlinable : sig
-    type t
-
-    val code_id : t -> Code_id.t
-  end
-
-  type t0 = private
-    | Inlinable of Inlinable.t
-    | Non_inlinable of Non_inlinable.t
-
-  type t = t0 Or_unknown_or_bottom.t
+  type t = T0.t Or_unknown_or_bottom.t
 end
 
 module Closures_entry : sig
@@ -429,21 +417,8 @@ val this_immutable_string : string -> t
 
 val mutable_string : size:int -> t
 
-(* CR lmaurer: Returning a pair here seems clumsy. Could also keep the inlining
-   decision in the [Function_declaration_type.t] at the cost of a bit more
-   storage that hangs around long after its only use. *)
-
-(** Create a description of a function declaration whose code is known. It may
-    be considered inlinable. *)
 val create_function_declaration :
-  code:Flambda.Code.t ->
-  rec_info:t ->
-  Function_declaration_type.t * Function_decl_inlining_decision.t
-
-(** Create a description of a function declaration whose code is unknown. Such
-    declarations cannot be inlined, but can be direct called. *)
-val create_non_inlinable_function_declaration :
-  code_id:Code_id.t -> Function_declaration_type.t
+  Code_id.t -> rec_info:t -> Function_declaration_type.t
 
 val exactly_this_closure :
   Closure_id.t ->
@@ -671,7 +646,7 @@ type reification_result = private
   | Lift of to_lift (* CR mshinwell: rename? *)
   | Lift_set_of_closures of
       { closure_id : Closure_id.t;
-        function_decls : Function_declaration_type.Inlinable.t Closure_id.Map.t;
+        function_decls : Function_declaration_type.T0.t Closure_id.Map.t;
         closure_vars : Simple.t Var_within_closure.Map.t
       }
   | Simple of Simple.t

--- a/middle_end/flambda2/types/structures/function_declaration_type.rec.ml
+++ b/middle_end/flambda2/types/structures/function_declaration_type.rec.ml
@@ -5,8 +5,8 @@
 (*                       Pierre Chambart, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2013--2021 OCamlPro SAS                                    *)
+(*   Copyright 2014--2021 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -19,244 +19,121 @@
 module TE = Typing_env
 module TEE = Typing_env_extension
 
-module Inlinable = struct
+module T0 = struct
   type t =
     { code_id : Code_id.t;
-      rec_info : Type_grammar.t;
-      must_be_inlined : bool
+      rec_info : Type_grammar.t
     }
 
-  let [@ocamlformat "disable"] print ppf { code_id; rec_info; must_be_inlined } =
+  let [@ocamlformat "disable"] print ppf { code_id; rec_info } =
     Format.fprintf ppf
-      "@[<hov 1>(Inlinable@ \
+      "@[<hov 1>(function_decl@ \
         @[<hov 1>(code_id@ %a)@]@ \
-        @[<hov 1>(rec_info@ %a)@]@ \
-        @[<hov 1><must_be_inlined@ %b)@]\
+        @[<hov 1>(rec_info@ %a)@]\
         )@]"
       Code_id.print code_id
       Type_grammar.print rec_info
-      must_be_inlined
 
   let code_id t = t.code_id
 
   let rec_info t = t.rec_info
 
-  let must_be_inlined t = t.must_be_inlined
-
-  let free_names { code_id; rec_info; must_be_inlined = _ } =
+  let free_names { code_id; rec_info } =
     Name_occurrences.add_code_id
       (Type_grammar.free_names rec_info)
       code_id Name_mode.normal
 
-  let all_ids_for_export { code_id; rec_info; must_be_inlined = _ } =
+  let all_ids_for_export { code_id; rec_info } =
     Ids_for_export.add_code_id
       (Type_grammar.all_ids_for_export rec_info)
       code_id
 
-  let apply_renaming ({ code_id; rec_info; must_be_inlined = _ } as t) renaming
-      =
+  let apply_renaming ({ code_id; rec_info } as t) renaming =
     let code_id' = Renaming.apply_code_id renaming code_id in
     let rec_info' = Type_grammar.apply_renaming rec_info renaming in
     if code_id == code_id' && rec_info == rec_info'
     then t
-    else { t with code_id = code_id'; rec_info = rec_info' }
+    else { code_id = code_id'; rec_info = rec_info' }
 end
 
-module Non_inlinable = struct
-  type t = { code_id : Code_id.t }
+type t = T0.t Or_unknown_or_bottom.t
 
-  let [@ocamlformat "disable"] print ppf { code_id; } =
-    Format.fprintf ppf
-      "@[<hov 1>(Non_inlinable@ \
-        @[<hov 1>(code_id@ %a)@]\
-        )@]"
-      Code_id.print code_id
+let create code_id ~rec_info : t = Ok { code_id; rec_info }
 
-  let code_id t = t.code_id
-
-  let free_names { code_id } =
-    Name_occurrences.singleton_code_id code_id Name_mode.normal
-
-  let all_ids_for_export { code_id } = Ids_for_export.singleton_code_id code_id
-
-  let apply_renaming ({ code_id } as t) renaming =
-    let code_id' = Renaming.apply_code_id renaming code_id in
-    if code_id == code_id' then t else { code_id = code_id' }
-end
-
-type t0 =
-  | Inlinable of Inlinable.t
-  | Non_inlinable of Non_inlinable.t
-
-type t = t0 Or_unknown_or_bottom.t
-
-let create ~code ~rec_info =
-  let code_id = Flambda.Code.code_id code in
-  let inlining_decision = Function_decl_inlining_decision.make_decision code in
-  let t : t =
-    match Function_decl_inlining_decision.behaviour inlining_decision with
-    | Cannot_be_inlined -> Ok (Non_inlinable { code_id })
-    | Must_be_inlined ->
-      Ok (Inlinable { code_id; rec_info; must_be_inlined = true })
-    | Could_possibly_be_inlined ->
-      Ok (Inlinable { code_id; rec_info; must_be_inlined = false })
-  in
-  t, inlining_decision
-
-let create_non_inlinable ~code_id : t = Ok (Non_inlinable { code_id })
-
-let print_t0 ppf t0 =
-  match t0 with
-  | Inlinable inlinable -> Inlinable.print ppf inlinable
-  | Non_inlinable non_inlinable -> Non_inlinable.print ppf non_inlinable
-
-let print ppf t = Or_unknown_or_bottom.print print_t0 ppf t
+let print ppf t = Or_unknown_or_bottom.print T0.print ppf t
 
 let free_names (t : t) =
   match t with
   | Bottom | Unknown -> Name_occurrences.empty
-  | Ok (Inlinable i) -> Inlinable.free_names i
-  | Ok (Non_inlinable ni) -> Non_inlinable.free_names ni
+  | Ok t0 -> T0.free_names t0
 
 let all_ids_for_export (t : t) =
   match t with
   | Bottom | Unknown -> Ids_for_export.empty
-  | Ok (Inlinable i) -> Inlinable.all_ids_for_export i
-  | Ok (Non_inlinable ni) -> Non_inlinable.all_ids_for_export ni
+  | Ok t0 -> T0.all_ids_for_export t0
 
 let apply_renaming (t : t) renaming : t =
   match t with
   | Bottom | Unknown -> t
-  | Ok (Inlinable inlinable) ->
-    Ok (Inlinable (Inlinable.apply_renaming inlinable renaming))
-  | Ok (Non_inlinable non_inlinable) ->
-    Ok (Non_inlinable (Non_inlinable.apply_renaming non_inlinable renaming))
+  | Ok t0 -> Ok (T0.apply_renaming t0 renaming)
 
 let meet (env : Meet_env.t) (t1 : t) (t2 : t) : (t * TEE.t) Or_bottom.t =
   match t1, t2 with
-  (* CR mshinwell: Try to factor out "Or_unknown_or_bottom" handling from here
-     and elsewhere *)
   | Bottom, _ | _, Bottom -> Ok (Bottom, TEE.empty ())
   | Unknown, t | t, Unknown -> Ok (t, TEE.empty ())
-  | ( Ok (Non_inlinable { code_id = code_id1 }),
-      Ok (Non_inlinable { code_id = code_id2 }) ) -> (
+  | ( Ok { code_id = code_id1; rec_info = rec_info1 },
+      Ok { code_id = code_id2; rec_info = rec_info2 } ) -> (
     let typing_env = Meet_env.env env in
-    let target_code_age_rel = TE.code_age_relation typing_env in
-    let resolver = TE.code_age_relation_resolver typing_env in
-    let check_other_things_and_return code_id : (t * TEE.t) Or_bottom.t =
-      Ok (Ok (Non_inlinable { code_id }), TEE.empty ())
-    in
     match
-      Code_age_relation.meet target_code_age_rel ~resolver code_id1 code_id2
+      Code_age_relation.meet
+        (TE.code_age_relation typing_env)
+        ~resolver:(TE.code_age_relation_resolver typing_env)
+        code_id1 code_id2
     with
-    | Ok code_id -> check_other_things_and_return code_id
-    | Bottom -> Bottom)
-  | Ok (Non_inlinable _), Ok (Inlinable _)
-  | Ok (Inlinable _), Ok (Non_inlinable _) ->
-    (* CR mshinwell: This should presumably return [Non_inlinable] if the
-       arities match. *)
-    (* CR vlaviron: The above comment was from before meet and join were split.
-       Now that we know we're in meet, we can actually keep either of them (the
-       inlinable one seems better) *)
-    Ok (Unknown, TEE.empty ())
-  | ( Ok
-        (Inlinable
-          { code_id = code_id1; rec_info = rec_info1; must_be_inlined = _ }),
-      Ok
-        (Inlinable
-          { code_id = code_id2; rec_info = rec_info2; must_be_inlined = _ }) )
-    -> (
-    let typing_env = Meet_env.env env in
-    let target_code_age_rel = TE.code_age_relation typing_env in
-    let resolver = TE.code_age_relation_resolver typing_env in
-    let check_other_things_and_return code_id rec_info extension :
-        (t * TEE.t) Or_bottom.t =
-      match TE.find_code typing_env code_id with
-      | None -> Ok (Ok (Non_inlinable { code_id }), extension)
-      | Some code ->
-        let t, _inlining_decision = create ~code ~rec_info in
-        Ok (t, extension)
-    in
-    match
-      Code_age_relation.meet target_code_age_rel ~resolver code_id1 code_id2
-    with
-    | Ok code_id -> begin
+    | Bottom -> Bottom
+    | Ok code_id -> (
+      (* It's possible that [code_id] corresponds to [Deleted] code. In that
+         case, any attempt to inline will fail, as the code will not be found in
+         the simplifier's environment -- see
+         [Simplify_apply_expr.simplify_direct_function_call]. *)
       match Type_grammar.meet env rec_info1 rec_info2 with
       | Ok (rec_info, extension) ->
-        check_other_things_and_return code_id rec_info extension
-      | Bottom -> Bottom
-    end
-    | Bottom -> Bottom)
+        let t = create code_id ~rec_info in
+        Ok (t, extension)
+      | Bottom -> Bottom))
 
 let join (env : Join_env.t) (t1 : t) (t2 : t) : t =
   match t1, t2 with
-  (* CR mshinwell: Try to factor out "Or_unknown_or_bottom" handling from here
-     and elsewhere *)
   | Bottom, t | t, Bottom -> t
   | Unknown, _ | _, Unknown -> Unknown
-  | ( Ok (Non_inlinable { code_id = code_id1 }),
-      Ok (Non_inlinable { code_id = code_id2 }) ) -> (
-    let typing_env = Join_env.target_join_env env in
-    let target_code_age_rel = TE.code_age_relation typing_env in
-    let resolver = TE.code_age_relation_resolver typing_env in
-    let check_other_things_and_return code_id : t =
-      Ok (Non_inlinable { code_id })
-    in
-    let code_age_rel1 = TE.code_age_relation (Join_env.left_join_env env) in
-    let code_age_rel2 = TE.code_age_relation (Join_env.right_join_env env) in
+  | ( Ok { code_id = code_id1; rec_info = rec_info1 },
+      Ok { code_id = code_id2; rec_info = rec_info2 } ) -> (
+    let target_typing_env = Join_env.target_join_env env in
     match
-      Code_age_relation.join ~target_t:target_code_age_rel ~resolver
-        code_age_rel1 code_age_rel2 code_id1 code_id2
+      Code_age_relation.join
+        ~target_t:(TE.code_age_relation target_typing_env)
+        ~resolver:(TE.code_age_relation_resolver target_typing_env)
+        (TE.code_age_relation (Join_env.left_join_env env))
+        (TE.code_age_relation (Join_env.right_join_env env))
+        code_id1 code_id2
     with
-    | Known code_id -> check_other_things_and_return code_id
-    | Unknown -> Unknown)
-  | Ok (Non_inlinable _), Ok (Inlinable _)
-  | Ok (Inlinable _), Ok (Non_inlinable _) ->
-    (* CR mshinwell: This should presumably return [Non_inlinable] if the
-       arities match. *)
-    Unknown
-  | ( Ok
-        (Inlinable
-          { code_id = code_id1; rec_info = rec_info1; must_be_inlined = _ }),
-      Ok
-        (Inlinable
-          { code_id = code_id2; rec_info = rec_info2; must_be_inlined = _ }) )
-    -> (
-    let typing_env = Join_env.target_join_env env in
-    let target_code_age_rel = TE.code_age_relation typing_env in
-    let resolver = TE.code_age_relation_resolver typing_env in
-    let check_other_things_and_return code_id rec_info : t =
-      match TE.find_code typing_env code_id with
-      | None -> Ok (Non_inlinable { code_id })
-      | Some code ->
-        let t, _inlining_decision = create ~code ~rec_info in
-        t
-    in
-    let code_age_rel1 = TE.code_age_relation (Join_env.left_join_env env) in
-    let code_age_rel2 = TE.code_age_relation (Join_env.right_join_env env) in
-    match
-      Code_age_relation.join ~target_t:target_code_age_rel ~resolver
-        code_age_rel1 code_age_rel2 code_id1 code_id2
-    with
-    | Known code_id -> begin
+    | Unknown -> Unknown
+    | Known code_id -> (
       match Type_grammar.join env rec_info1 rec_info2 with
-      | Known rec_info -> check_other_things_and_return code_id rec_info
-      | Unknown -> Unknown
-    end
-    | Unknown -> Unknown)
+      | Known rec_info -> create code_id ~rec_info
+      | Unknown -> Unknown))
 
 let apply_coercion (t : t) (coercion : Coercion.t) : t Or_bottom.t =
   match coercion with
   | Id -> Ok t
-  | Change_depth { from; to_ } -> begin
+  | Change_depth { from; to_ } -> (
     match t with
-    | Unknown | Bottom | Ok (Non_inlinable _) -> Ok t
-    | Ok (Inlinable ({ rec_info; _ } as inlinable)) ->
+    | Unknown | Bottom -> Ok t
+    | Ok ({ rec_info; _ } as t0) ->
       (* CR lmaurer: We should really be checking that [from] matches the
          current [rec_info], but that requires either passing in a typing
          environment or making absolutely sure that rec_infos get
          canonicalized. *)
       ignore (from, rec_info);
       let rec_info = Type_grammar.this_rec_info to_ in
-      Ok (Ok (Inlinable { inlinable with rec_info }))
-  end
+      Ok (Ok { t0 with rec_info }))

--- a/middle_end/flambda2/types/structures/function_declaration_type.rec.mli
+++ b/middle_end/flambda2/types/structures/function_declaration_type.rec.mli
@@ -5,8 +5,8 @@
 (*                       Pierre Chambart, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2013--2021 OCamlPro SAS                                    *)
+(*   Copyright 2014--2021 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -16,34 +16,17 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-module Inlinable : sig
+module T0 : sig
   type t
 
   val code_id : t -> Code_id.t
 
   val rec_info : t -> Type_grammar.t
-
-  val must_be_inlined : t -> bool
 end
 
-module Non_inlinable : sig
-  type t
+type t = T0.t Or_unknown_or_bottom.t
 
-  val code_id : t -> Code_id.t
-end
-
-type t0 = private
-  | Inlinable of Inlinable.t
-  | Non_inlinable of Non_inlinable.t
-
-type t = t0 Or_unknown_or_bottom.t
-
-val create :
-  code:Flambda.Code.t ->
-  rec_info:Type_grammar.t ->
-  t * Function_decl_inlining_decision.t
-
-val create_non_inlinable : code_id:Code_id.t -> t
+val create : Code_id.t -> rec_info:Type_grammar.t -> t
 
 include
   Type_structure_intf.S

--- a/middle_end/flambda2/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda2/types/template/flambda_type.templ.ml
@@ -953,7 +953,7 @@ type reification_result =
   | Lift of to_lift
   | Lift_set_of_closures of
       { closure_id : Closure_id.t;
-        function_decls : Function_declaration_type.Inlinable.t Closure_id.Map.t;
+        function_decls : Function_declaration_type.T0.t Closure_id.Map.t;
         closure_vars : Simple.t Var_within_closure.Map.t
       }
   | Simple of Simple.t
@@ -1107,9 +1107,8 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
               | Bottom -> function_decls_with_closure_vars
               | Ok function_decl -> (
                 match function_decl with
-                | Bottom | Unknown | Ok (Non_inlinable _) ->
-                  function_decls_with_closure_vars
-                | Ok (Inlinable inlinable_decl) ->
+                | Bottom | Unknown -> function_decls_with_closure_vars
+                | Ok t0 ->
                   (* CR mshinwell: We're ignoring [coercion] *)
                   let closure_var_types =
                     Closures_entry.closure_var_types closures_entry
@@ -1143,8 +1142,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
                      <> Var_within_closure.Map.cardinal closure_var_simples
                   then function_decls_with_closure_vars
                   else
-                    Closure_id.Map.add closure_id
-                      (inlinable_decl, closure_var_simples)
+                    Closure_id.Map.add closure_id (t0, closure_var_simples)
                       function_decls_with_closure_vars))
             closure_ids Closure_id.Map.empty
         in

--- a/middle_end/flambda2/types/type_grammar.rec.ml
+++ b/middle_end/flambda2/types/type_grammar.rec.ml
@@ -673,11 +673,8 @@ let any_boxed_int64 () = box_int64 (any_naked_int64 ())
 
 let any_boxed_nativeint () = box_nativeint (any_naked_nativeint ())
 
-let create_function_declaration ~code ~rec_info =
-  Function_declaration_type.create ~code ~rec_info
-
-let create_non_inlinable_function_declaration ~code_id =
-  Function_declaration_type.create_non_inlinable ~code_id
+let create_function_declaration code_id ~rec_info =
+  Function_declaration_type.create code_id ~rec_info
 
 let exactly_this_closure closure_id ~all_function_decls_in_set:function_decls
     ~all_closures_in_set:closure_types

--- a/middle_end/flambda2/types/type_grammar.rec.mli
+++ b/middle_end/flambda2/types/type_grammar.rec.mli
@@ -201,12 +201,7 @@ val type_for_const : Reg_width_const.t -> t
 val kind_for_const : Reg_width_const.t -> Flambda_kind.t
 
 val create_function_declaration :
-  code:Flambda.Code.t ->
-  rec_info:t ->
-  Function_declaration_type.t * Function_decl_inlining_decision.t
-
-val create_non_inlinable_function_declaration :
-  code_id:Code_id.t -> Function_declaration_type.t
+  Code_id.t -> rec_info:t -> Function_declaration_type.t
 
 val exactly_this_closure :
   Closure_id.t ->


### PR DESCRIPTION
Patch for #285.

After #285 function deemed not to be inlined on their definitions could still be inlined as the inliner was making the hidden assumption that it would only be called on inlinable functions.
Now the inliner will check if the function was indeed marked as being inlinable.