### PR TITLE
Improve unboxing during cmm for Flambda

### DIFF
--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -57,19 +57,19 @@ let rec with_afl_logging b dbg =
 
 and instrument = function
   (* these cases add logging, as they may be targets of conditional branches *)
-  | Cifthenelse (cond, t_dbg, t, f_dbg, f, dbg) ->
+  | Cifthenelse (cond, t_dbg, t, f_dbg, f, dbg, kind) ->
      Cifthenelse (instrument cond, t_dbg, with_afl_logging t t_dbg,
-       f_dbg, with_afl_logging f f_dbg, dbg)
-  | Ctrywith (e, kind, ex, handler, dbg) ->
-     Ctrywith (instrument e, kind, ex, with_afl_logging handler dbg, dbg)
-  | Cswitch (e, cases, handlers, dbg) ->
+       f_dbg, with_afl_logging f f_dbg, dbg, kind)
+  | Ctrywith (e, kind, ex, handler, dbg, value_kind) ->
+     Ctrywith (instrument e, kind, ex, with_afl_logging handler dbg, dbg, value_kind)
+  | Cswitch (e, cases, handlers, dbg, value_kind) ->
      let handlers =
        Array.map (fun (handler, handler_dbg) ->
            let handler = with_afl_logging handler handler_dbg in
            handler, handler_dbg)
          handlers
      in
-     Cswitch (instrument e, cases, handlers, dbg)
+     Cswitch (instrument e, cases, handlers, dbg, value_kind)
 
   (* these cases add no logging, but instrument subexpressions *)
   | Clet (v, e, body) -> Clet (v, instrument e, instrument body)
@@ -81,12 +81,12 @@ and instrument = function
   | Ctuple es -> Ctuple (List.map instrument es)
   | Cop (op, es, dbg) -> Cop (op, List.map instrument es, dbg)
   | Csequence (e1, e2) -> Csequence (instrument e1, instrument e2)
-  | Ccatch (isrec, cases, body) ->
+  | Ccatch (isrec, cases, body, kind) ->
      let cases =
        List.map (fun (nfail, ids, e, dbg) -> nfail, ids, instrument e, dbg)
          cases
      in
-     Ccatch (isrec, cases, instrument body)
+     Ccatch (isrec, cases, instrument body, kind)
   | Cexit (ex, args, traps) -> Cexit (ex, List.map instrument args, traps)
   | Cregion e -> Cregion (instrument e)
   | Ctail e -> Ctail (instrument e)

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -241,8 +241,8 @@ method! select_store is_assign addr exp =
   | Cconst_natint (_, _) | Cconst_float (_, _) | Cconst_symbol (_, _)
   | Cvar _ | Clet (_, _, _) | Clet_mut (_, _, _, _) | Cphantom_let (_, _, _)
   | Cassign (_, _) | Ctuple _ | Cop (_, _, _) | Csequence (_, _)
-  | Cifthenelse (_, _, _, _, _, _) | Cswitch (_, _, _, _) | Ccatch (_, _, _)
-  | Cexit (_, _, _) | Ctrywith (_, _, _, _, _)
+  | Cifthenelse (_, _, _, _, _, _, _) | Cswitch (_, _, _, _, _) | Ccatch (_, _, _, _)
+  | Cexit (_, _, _) | Ctrywith (_, _, _, _, _, _)
   | Cregion _ | Ctail _
     ->
       super#select_store is_assign addr exp

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -207,9 +207,15 @@ and operation =
   | Copaque (* Sys.opaque_identity *)
   | Cbeginregion | Cendregion
 
+type value_kind =
+  | Vval of Lambda.value_kind (* Valid OCaml values *)
+  | Vint (* Untagged integers and off-heap pointers *)
+  | Vaddr (* Derived pointers *)
+  | Vfloat (* Unboxed floating-point numbers *)
+
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)
-and expression =
+type expression =
     Cconst_int of int * Debuginfo.t
   | Cconst_natint of nativeint * Debuginfo.t
   | Cconst_float of float * Debuginfo.t
@@ -226,17 +232,18 @@ and expression =
   | Cop of operation * expression list * Debuginfo.t
   | Csequence of expression * expression
   | Cifthenelse of expression * Debuginfo.t * expression
-      * Debuginfo.t * expression * Debuginfo.t
+      * Debuginfo.t * expression * Debuginfo.t * value_kind
   | Cswitch of expression * int array * (expression * Debuginfo.t) array
-      * Debuginfo.t
+      * Debuginfo.t * value_kind
   | Ccatch of
       rec_flag
         * (label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
         * expression
+        * value_kind
   | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
-      * expression * Debuginfo.t
+      * expression * Debuginfo.t * value_kind
   | Cregion of expression
   | Ctail of expression
 
@@ -272,7 +279,7 @@ type phrase =
 
 val ccatch :
      label * (Backend_var.With_provenance.t * machtype) list
-       * expression * expression * Debuginfo.t
+       * expression * expression * Debuginfo.t * value_kind
   -> expression
 
 val reset : unit -> unit
@@ -286,12 +293,12 @@ val iter_shallow_tail: (expression -> unit) -> expression -> bool
       considered to be in tail position (because their result become
       the final result for the expression).  *)
 
-val map_shallow_tail: (expression -> expression) -> expression -> expression
+val map_shallow_tail: ?kind:value_kind -> (expression -> expression) -> expression -> expression
   (** Apply the transformation to those immediate sub-expressions of an
       expression that are in tail position, using the same definition of "tail"
       as [iter_shallow_tail] *)
 
-val map_tail: (expression -> expression) -> expression -> expression
+val map_tail: ?kind:value_kind -> (expression -> expression) -> expression -> expression
   (** Apply the transformation to an expression, trying to push it
       to all inner sub-expressions that can produce the final result,
       by recursively applying map_shallow_tail *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -273,12 +273,12 @@ let untag_int i dbg =
       Cop(Clsr, [c; Cconst_int (n+1, dbg)], dbg)
   | c -> asr_int c (Cconst_int (1, dbg)) dbg
 
-let mk_if_then_else dbg cond ifso_dbg ifso ifnot_dbg ifnot =
+let mk_if_then_else dbg value_kind cond ifso_dbg ifso ifnot_dbg ifnot =
   match cond with
   | Cconst_int (0, _) -> ifnot
   | Cconst_int (1, _) -> ifso
   | _ ->
-    Cifthenelse(cond, ifso_dbg, ifso, ifnot_dbg, ifnot, dbg)
+    Cifthenelse(cond, ifso_dbg, ifso, ifnot_dbg, ifnot, dbg, value_kind)
 
 let mk_not dbg cmm =
   match cmm with
@@ -368,7 +368,7 @@ let create_loop body dbg =
   let cont = Lambda.next_raise_count () in
   let call_cont = Cexit (Lbl cont, [], []) in
   let body = Csequence (body, call_cont) in
-  Ccatch (Recursive, [cont, [], body, dbg], call_cont)
+  Ccatch (Recursive, [cont, [], body, dbg], call_cont, Vval Pgenval)
 
 (* Turning integer divisions into multiply-high then shift.
    The [division_parameters] function is used in module Emit for
@@ -518,7 +518,7 @@ let rec div_int c1 c2 is_safe dbg =
                       Cop(Cdivi, [c1; c2], dbg),
                       dbg,
                       raise_symbol dbg "caml_exn_Division_by_zero",
-                      dbg)))
+                      dbg, Vint)))
 
 let mod_int c1 c2 is_safe dbg =
   match (c1, c2) with
@@ -559,7 +559,7 @@ let mod_int c1 c2 is_safe dbg =
                       Cop(Cmodi, [c1; c2], dbg),
                       dbg,
                       raise_symbol dbg "caml_exn_Division_by_zero",
-                      dbg)))
+                      dbg, Vint)))
 
 (* Division or modulo on boxed integers.  The overflow case min_int / -1
    can occur, in which case we force x / -1 = -x and x mod -1 = 0. (PR#5513). *)
@@ -569,7 +569,7 @@ let is_different_from x = function
   | Cconst_natint (n, _) -> n <> Nativeint.of_int x
   | _ -> false
 
-let safe_divmod_bi mkop is_safe mkm1 c1 c2 bi dbg =
+let safe_divmod_bi mkop kind is_safe mkm1 c1 c2 bi dbg =
   bind "divisor" c2 (fun c2 ->
   bind "dividend" c1 (fun c1 ->
     let c = mkop c1 c2 is_safe dbg in
@@ -580,16 +580,16 @@ let safe_divmod_bi mkop is_safe mkm1 c1 c2 bi dbg =
       Cifthenelse(Cop(Ccmpi Cne, [c2; Cconst_int (-1, dbg)], dbg),
         dbg, c,
         dbg, mkm1 c1 dbg,
-        dbg)
+        dbg, kind)
     else
       c))
 
 let safe_div_bi is_safe =
-  safe_divmod_bi div_int is_safe
+  safe_divmod_bi div_int Vint is_safe
     (fun c1 dbg -> Cop(Csubi, [Cconst_int (0, dbg); c1], dbg))
 
 let safe_mod_bi is_safe =
-  safe_divmod_bi mod_int is_safe (fun _ dbg -> Cconst_int (0, dbg))
+  safe_divmod_bi mod_int Vint is_safe (fun _ dbg -> Cconst_int (0, dbg))
 
 (* Bool *)
 
@@ -610,6 +610,7 @@ let box_float dbg m c = Cop(Calloc m, [alloc_float_header m dbg; c], dbg)
 
 let unbox_float dbg =
   map_tail
+    ~kind:Vfloat
     (function
       | Cop(Calloc _, [Cconst_natint (hdr, _); c], _)
         when Nativeint.equal hdr float_header ->
@@ -643,20 +644,20 @@ let rec remove_unit = function
   | Csequence(c, Cconst_int (1, _)) -> c
   | Csequence(c1, c2) ->
       Csequence(c1, remove_unit c2)
-  | Cifthenelse(cond, ifso_dbg, ifso, ifnot_dbg, ifnot, dbg) ->
+  | Cifthenelse(cond, ifso_dbg, ifso, ifnot_dbg, ifnot, dbg, kind) ->
       Cifthenelse(cond,
         ifso_dbg, remove_unit ifso,
         ifnot_dbg,
-        remove_unit ifnot, dbg)
-  | Cswitch(sel, index, cases, dbg) ->
+        remove_unit ifnot, dbg, kind)
+  | Cswitch(sel, index, cases, dbg, kind) ->
       Cswitch(sel, index,
         Array.map (fun (case, dbg) -> remove_unit case, dbg) cases,
-        dbg)
-  | Ccatch(rec_flag, handlers, body) ->
+        dbg, kind)
+  | Ccatch(rec_flag, handlers, body, kind) ->
       let map_h (n, ids, handler, dbg) = (n, ids, remove_unit handler, dbg) in
-      Ccatch(rec_flag, List.map map_h handlers, remove_unit body)
-  | Ctrywith(body, kind, exn, handler, dbg) ->
-    Ctrywith(remove_unit body, kind, exn, remove_unit handler, dbg)
+      Ccatch(rec_flag, List.map map_h handlers, remove_unit body, kind)
+  | Ctrywith(body, kind, exn, handler, dbg, value_kind) ->
+    Ctrywith(remove_unit body, kind, exn, remove_unit handler, dbg, value_kind)
   | Clet(id, c1, c2) ->
       Clet(id, c1, remove_unit c2)
   | Cop(Capply(_mty, pos), args, dbg) ->
@@ -1195,6 +1196,7 @@ let unbox_int dbg bi =
         [Cop(Cadda, [arg; Cconst_int (size_addr, dbg)], dbg)], dbg)
   in
   map_tail
+    ~kind:Vint
     (function
       | Cop(Calloc _,
             [hdr; ops;
@@ -1586,7 +1588,7 @@ let transl_isout h arg dbg = tag_int (Cop(Ccmpa Clt, [h ; arg], dbg)) dbg
 
 (* Build an actual switch (ie jump table) *)
 
-let make_switch arg cases actions dbg =
+let make_switch arg cases actions dbg kind =
   let extract_uconstant =
     function
     (* Constant integers loaded from a table should end in 1,
@@ -1637,7 +1639,7 @@ let make_switch arg cases actions dbg =
   in
   match Misc.Stdlib.Array.all_somes (Array.map extract_uconstant actions) with
   | None ->
-      Cswitch (arg,cases,actions,dbg)
+      Cswitch (arg,cases,actions,dbg, kind)
   | Some const_actions ->
       match extract_affine ~cases ~const_actions with
       | Some (offset, slope) ->
@@ -1657,6 +1659,7 @@ struct
 
   type act = expression
   type loc = Debuginfo.t
+  type nonrec value_kind = value_kind
 
   (* CR mshinwell: GPR#2294 will fix the Debuginfo here *)
 
@@ -1665,15 +1668,15 @@ struct
   let make_offset arg n = add_const arg n Debuginfo.none
   let make_isout h arg = Cop (Ccmpa Clt, [h ; arg], Debuginfo.none)
   let make_isin h arg = Cop (Ccmpa Cge, [h ; arg], Debuginfo.none)
-  let make_if cond ifso ifnot =
+  let make_if value_kind cond ifso ifnot =
     Cifthenelse (cond, Debuginfo.none, ifso, Debuginfo.none, ifnot,
-      Debuginfo.none)
-  let make_switch dbg arg cases actions =
+      Debuginfo.none, value_kind)
+  let make_switch dbg value_kind arg cases actions =
     let actions = Array.map (fun expr -> expr, dbg) actions in
-    make_switch arg cases actions dbg
+    make_switch arg cases actions dbg value_kind
   let bind arg body = bind "switcher" arg body
 
-  let make_catch handler = match handler with
+  let make_catch kind handler = match handler with
   | Cexit (Lbl i,[],[]) -> i,fun e -> e
   | _ ->
       let dbg = Debuginfo.none in
@@ -1688,7 +1691,7 @@ struct
       | Cexit (j,_,_) ->
           if Lbl i = j then handler
           else body
-      | _ ->  ccatch (i,[],body,handler, dbg))
+      | _ ->  ccatch (i,[],body,handler, dbg, kind))
 
   let make_exit i = Cexit (Lbl i,[],[])
 
@@ -1736,7 +1739,7 @@ module SwitcherBlocks = Switch.Make(SArgBlocks)
 (* Int switcher, arg in [low..high],
    cases is list of individual cases, and is sorted by first component *)
 
-let transl_int_switch dbg arg low high cases default = match cases with
+let transl_int_switch dbg value_kind arg low high cases default = match cases with
 | [] -> assert false
 | _::_ ->
     let store = StoreExp.mk_store () in
@@ -1776,13 +1779,13 @@ let transl_int_switch dbg arg low high cases default = match cases with
     bind "switcher" arg
       (fun a ->
         SwitcherBlocks.zyva
-          dbg
+          dbg value_kind
           (low,high)
           a
           (Array.of_list inters) store)
 
 
-let transl_switch_clambda loc arg index cases =
+let transl_switch_clambda loc value_kind arg index cases =
   let store = StoreExpForSwitch.mk_store () in
   let index =
     Array.map
@@ -1811,7 +1814,7 @@ let transl_switch_clambda loc arg index cases =
       bind "switcher" arg
         (fun a ->
            SwitcherBlocks.zyva
-             loc
+             loc value_kind
              (0,n_index-1)
              a
              (Array.of_list inters) store)
@@ -1908,15 +1911,15 @@ let cache_public_method meths tag cache dbg =
                      dbg)], dbg),
            dbg, Cassign(hi, Cop(Csubi, [Cvar mi; cconst_int 2], dbg)),
            dbg, Cassign(li, Cvar mi),
-           dbg),
+           dbg, Vint (* unit *)),
         Cifthenelse
           (Cop(Ccmpi Cge, [Cvar li; Cvar hi], dbg),
            dbg, Cexit (Lbl raise_num, [], []),
            dbg, Ctuple [],
-           dbg))))
+           dbg, Vint (* unit *)))))
        dbg,
      Ctuple [],
-     dbg),
+     dbg, Vint (* unit *)),
   Clet (
     VP.create tagged,
       Cop(Caddi, [lsl_const (Cvar li) log2_size_addr dbg;
@@ -2021,7 +2024,8 @@ let apply_function_body (arity, (mode : Lambda.alloc_mode)) =
            (let res = V.create_local "result" in
             Clet(VP.create res, app,
                  Csequence(Cop(Cendregion, [Cvar region], dbg ()), Cvar res))),
-           dbg ())
+           dbg (),
+           Vval Pgenval)
     end else begin
       let newclos = V.create_local "clos" in
       Clet(VP.create newclos,
@@ -2053,7 +2057,8 @@ let apply_function_body (arity, (mode : Lambda.alloc_mode)) =
        dbg ()),
    dbg (),
    code,
-   dbg ()))
+   dbg (),
+   Vval Pgenval))
 
 let send_function (arity, mode) =
   let dbg = placeholder_dbg in
@@ -2084,7 +2089,7 @@ let send_function (arity, mode) =
                 cache_public_method (Cvar meths) tag cache (dbg ()),
                 dbg (),
                 cached_pos,
-                dbg ()),
+                dbg (), Vval Pgenval),
     Cop(Cload (Word_val, Mutable),
       [Cop(Cadda, [Cop (Cadda, [Cvar real; Cvar meths], dbg ());
        cconst_int(2*size_addr-1)], dbg ())], dbg ()))))
@@ -2379,7 +2384,7 @@ let arraylength kind arg dbg =
                           dbg,
                           Cop(Clsr,
                             [hdr; Cconst_int (numfloat_shift, dbg)], dbg),
-                          dbg))
+                          dbg, Vint))
       in
       Cop(Cor, [len; Cconst_int (1, dbg)], dbg)
   | Paddrarray | Pintarray ->
@@ -2618,7 +2623,7 @@ let arrayref_unsafe kind arg1 arg2 dbg =
                       addr_array_ref arr idx dbg,
                       dbg,
                       float_array_ref arr idx dbg,
-                      dbg)))
+                      dbg, Vval Pgenval)))
   | Paddrarray ->
       addr_array_ref arg1 arg2 dbg
   | Pintarray ->
@@ -2641,7 +2646,7 @@ let arrayref_safe kind arg1 arg2 dbg =
                         addr_array_ref arr idx dbg,
                         dbg,
                         float_array_ref arr idx dbg,
-                        dbg))
+                        dbg, Vval Pgenval))
         else
           Cifthenelse(is_addr_array_hdr hdr dbg,
             dbg,
@@ -2652,7 +2657,7 @@ let arrayref_safe kind arg1 arg2 dbg =
             Csequence(
               make_checkbound dbg [float_array_length_shifted hdr dbg; idx],
               float_array_ref arr idx dbg),
-            dbg))))
+            dbg, Vval Pgenval))))
       | Paddrarray ->
           bind "index" arg2 (fun idx ->
           bind "arr" arg1 (fun arr ->
@@ -2721,7 +2726,7 @@ let arrayset_unsafe kind arg1 arg2 arg3 dbg =
                         dbg,
                         float_array_set arr index (unbox_float dbg newval)
                           dbg,
-                        dbg))))
+                        dbg, Vint (* unit *)))))
   | Paddrarray ->
       addr_array_set arg1 arg2 arg3 dbg
   | Pintarray ->
@@ -2747,7 +2752,7 @@ let arrayset_safe kind arg1 arg2 arg3 dbg =
                         float_array_set arr idx
                           (unbox_float dbg newval)
                           dbg,
-                        dbg))
+                        dbg, Vint (* unit *)))
         else
           Cifthenelse(
             is_addr_array_hdr hdr dbg,
@@ -2760,7 +2765,7 @@ let arrayset_safe kind arg1 arg2 arg3 dbg =
               make_checkbound dbg [float_array_length_shifted hdr dbg; idx],
               float_array_set arr idx
                 (unbox_float dbg newval) dbg),
-            dbg)))))
+            dbg, Vint (* unit*))))))
   | Paddrarray ->
       bind "newval" arg3 (fun newval ->
       bind "index" arg2 (fun idx ->

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -138,11 +138,12 @@ val safe_mod_bi :
   expression
 
 (** If-Then-Else expression
-    [mk_if_then_else dbg cond ifso_dbg ifso ifnot_dbg ifnot] associates
+    [mk_if_then_else dbg kind cond ifso_dbg ifso ifnot_dbg ifnot] associates
     [dbg] to the global if-then-else expression, [ifso_dbg] to the
     then branch [ifso], and [ifnot_dbg] to the else branch [ifnot] *)
 val mk_if_then_else :
   Debuginfo.t ->
+  Cmm.value_kind ->
   expression ->
   Debuginfo.t -> expression ->
   Debuginfo.t -> expression ->
@@ -551,24 +552,24 @@ val bigstring_set :
 (** [transl_isout h arg dbg] *)
 val transl_isout : expression -> expression -> Debuginfo.t -> expression
 
-(** [make_switch arg cases actions dbg] : Generate a Cswitch construct,
+(** [make_switch arg cases actions dbg kind] : Generate a Cswitch construct,
     or optimize as a static table lookup when possible. *)
 val make_switch :
   expression -> int array -> (expression * Debuginfo.t) array -> Debuginfo.t ->
-  expression
+  Cmm.value_kind -> expression
 
-(** [transl_int_switch loc arg low high cases default] *)
+(** [transl_int_switch loc kind arg low high cases default] *)
 val transl_int_switch :
-  Debuginfo.t -> expression -> int -> int ->
+  Debuginfo.t -> Cmm.value_kind -> expression -> int -> int ->
   (int * expression) list -> expression -> expression
 
-(** [transl_switch_clambda loc arg index cases] *)
+(** [transl_switch_clambda loc kind arg index cases] *)
 val transl_switch_clambda :
-  Debuginfo.t -> expression -> int array -> expression array -> expression
+  Debuginfo.t -> Cmm.value_kind -> expression -> int array -> expression array -> expression
 
 (** [strmatch_compile dbg arg default cases] *)
 val strmatch_compile :
-  Debuginfo.t -> expression -> expression option ->
+  Debuginfo.t -> Cmm.value_kind -> expression -> expression option ->
   (string * expression) list -> expression
 
 (** Closures and function applications *)

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -145,14 +145,14 @@ let rec check env (expr : Cmm.expression) =
   | Csequence (expr1, expr2) ->
     check env expr1;
     check env expr2
-  | Cifthenelse (test, _, ifso, _, ifnot, _) ->
+  | Cifthenelse (test, _, ifso, _, ifnot, _, _) ->
     check env test;
     check env ifso;
     check env ifnot
-  | Cswitch (body, _, branches, _) ->
+  | Cswitch (body, _, branches, _, _) ->
     check env body;
     Array.iter (fun (expr, _) -> check env expr) branches
-  | Ccatch (rec_flag, handlers, body) ->
+  | Ccatch (rec_flag, handlers, body, _) ->
     let env_extended =
       List.fold_left
         (fun env (cont, args, _, _) ->
@@ -169,7 +169,7 @@ let rec check env (expr : Cmm.expression) =
     List.iter (fun (_, _, handler, _) -> check env_handler handler) handlers
   | Cexit (exit_label, args, _trap_actions) ->
     Env.jump env ~exit_label ~arg_num:(List.length args)
-  | Ctrywith (body, _trywith_kind, _, handler, _) ->
+  | Ctrywith (body, _trywith_kind, _, handler, _, _) ->
     (* Jumping from inside a trywith body to outside isn't very nice,
        but it's handled correctly by Linearize, as it happens
        when compiling match ... with exception ..., for instance, so it is

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -278,7 +278,7 @@ let rec expr ppf = function
       fprintf ppf ")@]")
   | Csequence(e1, e2) ->
       fprintf ppf "@[<2>(seq@ %a@ %a)@]" sequence e1 sequence e2
-  | Cifthenelse(e1, e2_dbg, e2, e3_dbg, e3, dbg) ->
+  | Cifthenelse(e1, e2_dbg, e2, e3_dbg, e3, dbg, _kind) ->
       with_location_mapping ~label:"Cifthenelse-e1" ~dbg ppf (fun () ->
       fprintf ppf "@[<2>(if@ %a@ " expr e1;
       with_location_mapping ~label:"Cifthenelse-e2" ~dbg:e2_dbg ppf (fun () ->
@@ -286,7 +286,7 @@ let rec expr ppf = function
       with_location_mapping ~label:"Cifthenelse-e3" ~dbg:e3_dbg ppf (fun () ->
       fprintf ppf "%a" expr e3);
       fprintf ppf ")@]")
-  | Cswitch(e1, index, cases, dbg) ->
+  | Cswitch(e1, index, cases, dbg, _kind) ->
       with_location_mapping ~label:"Cswitch" ~dbg ppf (fun () ->
       let print_case i ppf =
         for j = 0 to Array.length index - 1 do
@@ -297,7 +297,7 @@ let rec expr ppf = function
         fprintf ppf "@ @[<2>%t@ %a@]" (print_case i) sequence (fst cases.(i))
        done in
       fprintf ppf "@[<v 0>@[<2>(switch@ %a@ @]%t)@]" expr e1 print_cases)
-  | Ccatch(flag, handlers, e1) ->
+  | Ccatch(flag, handlers, e1, _kind) ->
       let print_handler ppf (i, ids, e2, dbg) =
         with_location_mapping ~label:"Ccatch-handler" ~dbg ppf (fun () ->
         fprintf ppf "(%d%a)@ %a"
@@ -322,7 +322,7 @@ let rec expr ppf = function
       fprintf ppf "@[<2>(exit%a %a" trap_action_list traps exit_label i;
       List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
       fprintf ppf ")@]"
-  | Ctrywith(e1, kind, id, e2, dbg) ->
+  | Ctrywith(e1, kind, id, e2, dbg, _value_kind) ->
       fprintf ppf "@[<2>(try%a@ %a@;<1 -2>with@ %a@ "
             trywith_kind kind sequence e1 VP.print id;
       with_location_mapping ~label:"Ctrywith" ~dbg ppf (fun () ->

--- a/backend/strmatch.ml
+++ b/backend/strmatch.ml
@@ -24,7 +24,7 @@ module VP = Backend_var.With_provenance
 module type I = sig
   val string_block_length : Cmm.expression -> Cmm.expression
   val transl_switch :
-      Debuginfo.t -> Cmm.expression -> int -> int ->
+      Debuginfo.t -> Cmm.value_kind -> Cmm.expression -> int -> int ->
         (int * Cmm.expression) list -> Cmm.expression ->
           Cmm.expression
 end
@@ -85,12 +85,12 @@ module Make(I:I) = struct
     let size = I.string_block_length str in
     Clet(id, size, body)
 
-  let mk_cmp_gen cmp_op id nat ifso ifnot =
+  let mk_cmp_gen cmp_op value_kind id nat ifso ifnot =
     let dbg = Debuginfo.none in
     let test =
       Cop (Ccmpi cmp_op, [ Cvar id; Cconst_natint (nat, dbg) ], dbg)
     in
-    Cifthenelse (test, dbg, ifso, dbg, ifnot, dbg)
+    Cifthenelse (test, dbg, ifso, dbg, ifnot, dbg, value_kind)
 
   let mk_lt = mk_cmp_gen Clt
   let mk_eq = mk_cmp_gen Ceq
@@ -282,20 +282,20 @@ module Make(I:I) = struct
   as match_on_cell can be called in two different contexts :
   from do_compile_pats and top_compile below.
  *)
-    let match_oncell compile_rec str default idx env =
+    let match_oncell value_kind compile_rec str default idx env =
       let id = gen_cell_id () in
       let rec comp_rec env =
         let len = List.length env in
         if len <= 3 then
           List.fold_right
             (fun (key,cases) ifnot ->
-              mk_eq id key
+              mk_eq value_kind id key
                 (compile_rec str default cases)
               ifnot)
             env default
         else
           let lt,midkey,ge = split_env len env in
-          mk_lt id midkey (comp_rec lt) (comp_rec ge) in
+          mk_lt value_kind id midkey (comp_rec lt) (comp_rec ge) in
       mk_let_cell (VP.create id) str idx (comp_rec env)
 
 (*
@@ -304,7 +304,7 @@ module Make(I:I) = struct
   - notice: patterns (and idx) all have the same length
  *)
 
-    let rec do_compile_pats idxs str default cases =
+    let rec do_compile_pats value_kind idxs str default cases =
       if dbg then begin
         pp_match stderr "COMPILE" idxs cases
       end ;
@@ -319,8 +319,8 @@ module Make(I:I) = struct
           begin match idxs with
           | [] -> assert false
           | idx::idxs ->
-              match_oncell
-                (do_compile_pats idxs) str default idx (by_cell cases)
+              match_oncell value_kind
+                (do_compile_pats value_kind idxs) str default idx (by_cell cases)
           end
 
 
@@ -341,19 +341,19 @@ module Make(I:I) = struct
   In that latter case pattern len is string length-1 and is corrected.
  *)
 
-    let compile_by_size dbg from_ind str default cases =
+    let compile_by_size dbg value_kind from_ind str default cases =
       let size_cases =
         List.map
           (fun (len,cases) ->
             let len = len+from_ind in
             let act =
-              do_compile_pats
+              do_compile_pats value_kind
                 (interval from_ind len)
                 str default  cases in
             (len,act))
           (by_size cases) in
       let id = gen_size_id () in
-      let switch = I.transl_switch dbg (Cvar id) 1 max_int size_cases default in
+      let switch = I.transl_switch dbg value_kind (Cvar id) 1 max_int size_cases default in
       mk_let_size (VP.create id) str switch
 
 (*
@@ -361,17 +361,17 @@ module Make(I:I) = struct
   either on size or on first cell, using the
   'least discriminant' heuristics.
  *)
-    let top_compile debuginfo str default cases =
+    let top_compile debuginfo value_kind str default cases =
       let a_len = count_arities_length cases
       and a_fst = count_arities_first cases in
       if a_len <= a_fst then begin
         if dbg then pp_cases stderr "SIZE" cases ;
-        compile_by_size debuginfo 0 str default cases
+        compile_by_size debuginfo value_kind 0 str default cases
       end else begin
         if dbg then pp_cases stderr "FIRST COL" cases ;
         let compile_size_rest str default cases =
-          compile_by_size debuginfo 1 str default cases in
-        match_oncell compile_size_rest str default 0 (by_cell cases)
+          compile_by_size debuginfo value_kind 1 str default cases in
+        match_oncell value_kind compile_size_rest str default 0 (by_cell cases)
       end
 
 (* Module entry point *)
@@ -380,9 +380,9 @@ module Make(I:I) = struct
     | Cexit (_e,[],_traps) ->  k arg
     | _ ->
         let e = next_raise_count () in
-        ccatch (e,[],k (Cexit (Lbl e,[],[])),arg,dbg)
+        ccatch (e,[],k (Cexit (Lbl e,[],[])),arg,dbg, Vval Pgenval)
 
-    let compile dbg str default cases =
+    let compile dbg value_kind str default cases =
 (* We do not attempt to really optimise default=None *)
       let cases,default = match cases,default with
       | (_,e)::cases,None
@@ -392,6 +392,6 @@ module Make(I:I) = struct
         List.rev_map
           (fun (s,act) -> pat_of_string s,act)
           cases in
-      catch dbg default (fun default -> top_compile dbg str default cases)
+      catch dbg default (fun default -> top_compile dbg value_kind str default cases)
 
   end

--- a/backend/strmatch.mli
+++ b/backend/strmatch.mli
@@ -18,7 +18,7 @@
 module type I = sig
   val string_block_length : Cmm.expression -> Cmm.expression
   val transl_switch :
-      Debuginfo.t -> Cmm.expression -> int -> int ->
+      Debuginfo.t -> Cmm.value_kind -> Cmm.expression -> int -> int ->
         (int * Cmm.expression) list -> Cmm.expression ->
           Cmm.expression
 end
@@ -26,7 +26,8 @@ end
 module Make(_:I) : sig
   (* Compile stringswitch (arg,cases,d)
      Note: cases should not contain string duplicates *)
-  val compile : Debuginfo.t -> Cmm.expression (* arg *)
+  val compile : Debuginfo.t -> Cmm.value_kind
+    -> Cmm.expression (* arg *)
     -> Cmm.expression option (* d *) ->
     (string * Cmm.expression) list (* cases *)-> Cmm.expression
 end

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -60,16 +60,25 @@ and ulambda =
       * uphantom_defining_expr option * ulambda
   | Uletrec of (Backend_var.With_provenance.t * ulambda) list * ulambda
   | Uprim of Clambda_primitives.primitive * ulambda list * Debuginfo.t
-  | Uswitch of ulambda * ulambda_switch * Debuginfo.t
-  | Ustringswitch of ulambda * (string * ulambda) list * ulambda option
+  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * Lambda.value_kind
+  | Ustringswitch of
+      ulambda *
+      (string * ulambda) list *
+      ulambda option *
+      Lambda.value_kind
   | Ustaticfail of int * ulambda list
   | Ucatch of
       int *
       (Backend_var.With_provenance.t * value_kind) list *
       ulambda *
-      ulambda
-  | Utrywith of ulambda * Backend_var.With_provenance.t * ulambda
-  | Uifthenelse of ulambda * ulambda * ulambda
+      ulambda *
+      Lambda.value_kind
+  | Utrywith of
+      ulambda *
+      Backend_var.With_provenance.t *
+      ulambda *
+      Lambda.value_kind
+  | Uifthenelse of ulambda * ulambda * ulambda * Lambda.value_kind
   | Usequence of ulambda * ulambda
   | Uwhile of ulambda * ulambda
   | Ufor of Backend_var.With_provenance.t * ulambda * ulambda

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -71,16 +71,25 @@ and ulambda =
       * uphantom_defining_expr option * ulambda
   | Uletrec of (Backend_var.With_provenance.t * ulambda) list * ulambda
   | Uprim of Clambda_primitives.primitive * ulambda list * Debuginfo.t
-  | Uswitch of ulambda * ulambda_switch * Debuginfo.t
-  | Ustringswitch of ulambda * (string * ulambda) list * ulambda option
+  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * Lambda.value_kind
+  | Ustringswitch of
+      ulambda *
+      (string * ulambda) list *
+      ulambda option *
+      Lambda.value_kind
   | Ustaticfail of int * ulambda list
   | Ucatch of
       int *
       (Backend_var.With_provenance.t * value_kind) list *
       ulambda *
-      ulambda
-  | Utrywith of ulambda * Backend_var.With_provenance.t * ulambda
-  | Uifthenelse of ulambda * ulambda * ulambda
+      ulambda *
+      Lambda.value_kind
+  | Utrywith of
+      ulambda *
+      Backend_var.With_provenance.t *
+      ulambda *
+      Lambda.value_kind
+  | Uifthenelse of ulambda * ulambda * ulambda * Lambda.value_kind
   | Usequence of ulambda * ulambda
   | Uwhile of ulambda * ulambda
   | Ufor of Backend_var.With_provenance.t * ulambda * ulambda

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -396,7 +396,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
                      case in the array data types work.
                      mshinwell: deferred CR *)
                   name_expr ~name:Names.result
-                    (Prim (prim, [numerator; denominator], dbg))))))))
+                    (Prim (prim, [numerator; denominator], dbg)), Pintval))))))
   | Lprim ((Pdivint Safe | Pmodint Safe
            | Pdivbint { is_safe = Safe } | Pmodbint { is_safe = Safe }), _, _)
       when not !Clflags.unsafe ->
@@ -408,7 +408,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let cond = Variable.create Names.cond_sequor in
     Flambda.create_let const_true (Const (Int 1))
       (Flambda.create_let cond (Expr arg1)
-        (If_then_else (cond, Var const_true, arg2)))
+        (If_then_else (cond, Var const_true, arg2, Pintval)))
   | Lprim (Psequand, [arg1; arg2], _) ->
     let arg1 = close t env arg1 in
     let arg2 = close t env arg2 in
@@ -416,7 +416,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let cond = Variable.create Names.const_sequand in
     Flambda.create_let const_false (Const (Int 0))
       (Flambda.create_let cond (Expr arg1)
-        (If_then_else (cond, arg2, Var const_false)))
+        (If_then_else (cond, arg2, Var const_false, Pintval)))
   | Lprim ((Psequand | Psequor), _, _) ->
     Misc.fatal_error "Psequand / Psequor must have exactly two arguments"
   | Lprim ((Pidentity | Pbytes_to_string | Pbytes_of_string), [arg], _) ->
@@ -503,7 +503,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       ~create_body:(fun args ->
         name_expr (Prim (p, args, dbg))
           ~name:(Names.of_primitive lambda_p))
-  | Lswitch (arg, sw, _loc) ->
+  | Lswitch (arg, sw, _loc, kind) ->
     let scrutinee = Variable.create Names.switch in
     let aux (i, lam) = i, close t env lam in
     let nums sw_num cases default =
@@ -521,13 +521,14 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
           numblocks = nums sw.sw_numblocks sw.sw_blocks sw.sw_failaction;
           blocks = List.map aux sw.sw_blocks;
           failaction = Option.map (close t env) sw.sw_failaction;
+          kind;
         }))
-  | Lstringswitch (arg, sw, def, _) ->
+  | Lstringswitch (arg, sw, def, _, kind) ->
     let scrutinee = Variable.create Names.string_switch in
     Flambda.create_let scrutinee (Expr (close t env arg))
       (String_switch (scrutinee,
         List.map (fun (s, e) -> s, close t env e) sw,
-        Option.map (close t env) def))
+        Option.map (close t env) def, kind))
   | Lstaticraise (i, args) ->
     Lift_code.lifting_helper (close_list t env args)
       ~evaluation_order:`Right_to_left
@@ -535,7 +536,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       ~create_body:(fun args ->
         let static_exn = Env.find_static_exception env i in
         Static_raise (static_exn, args))
-  | Lstaticcatch (body, (i, ids), handler) ->
+  | Lstaticcatch (body, (i, ids), handler, kind) ->
     let st_exn = Static_exception.create () in
     let env = Env.add_static_exception env i st_exn in
     let ids = List.map fst ids in
@@ -543,15 +544,16 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       List.map (fun ident -> Variable.create_with_same_name_as_ident ident) ids
     in
     Static_catch (st_exn, vars, close t env body,
-      close t (Env.add_vars env ids vars) handler)
-  | Ltrywith (body, id, handler) ->
+      close t (Env.add_vars env ids vars) handler, kind)
+  | Ltrywith (body, id, handler, kind) ->
     let var = Variable.create_with_same_name_as_ident id in
-    Try_with (close t env body, var, close t (Env.add_var env id var) handler)
-  | Lifthenelse (cond, ifso, ifnot) ->
+    Try_with (close t env body, var, close t (Env.add_var env id var) handler,
+              kind)
+  | Lifthenelse (cond, ifso, ifnot, kind) ->
     let cond = close t env cond in
     let cond_var = Variable.create Names.cond in
     Flambda.create_let cond_var (Expr cond)
-      (If_then_else (cond_var, close t env ifso, close t env ifnot))
+      (If_then_else (cond_var, close t env ifso, close t env ifnot, kind))
   | Lsequence (lam1, lam2) ->
     let var = Variable.create Names.sequence in
     let lam1 = Flambda.Expr (close t env lam1) in

--- a/middle_end/flambda/effect_analysis.ml
+++ b/middle_end/flambda/effect_analysis.ml
@@ -32,16 +32,16 @@ let rec no_effects (flam : Flambda.t) =
   | Let_rec (defs, body) ->
     no_effects body
       && List.for_all (fun (_, def) -> no_effects_named def) defs
-  | If_then_else (_, ifso, ifnot) -> no_effects ifso && no_effects ifnot
+  | If_then_else (_, ifso, ifnot, _) -> no_effects ifso && no_effects ifnot
   | Switch (_, sw) ->
     let aux (_, flam) = no_effects flam in
     List.for_all aux sw.blocks
       && List.for_all aux sw.consts
       && Option.fold ~some:no_effects ~none:true sw.failaction
-  | String_switch (_, sw, def) ->
+  | String_switch (_, sw, def, _) ->
     List.for_all (fun (_, lam) -> no_effects lam) sw
       && Option.fold ~some:no_effects ~none:true def
-  | Static_catch (_, _, body, _) | Try_with (body, _, _) ->
+  | Static_catch (_, _, body, _, _) | Try_with (body, _, _, _) ->
     (* If there is a [raise] in [body], the whole [Try_with] may have an
        effect, so there is no need to test the handler. *)
     no_effects body

--- a/middle_end/flambda/extract_projections.ml
+++ b/middle_end/flambda/extract_projections.ml
@@ -97,9 +97,9 @@ let rec analyse_expr ~which_variables expr =
       List.iter check_free_variable args
     | Assign { new_value; _ } ->
       check_free_variable new_value
-    | If_then_else (var, _, _)
+    | If_then_else (var, _, _, _)
     | Switch (var, _)
-    | String_switch (var, _, _) ->
+    | String_switch (var, _, _, _) ->
       check_free_variable var
     | Static_raise (_, args) ->
       List.iter check_free_variable args

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -104,13 +104,14 @@ type t =
   | Apply of apply
   | Send of send
   | Assign of assign
-  | If_then_else of Variable.t * t * t
+  | If_then_else of Variable.t * t * t * Lambda.value_kind
   | Switch of Variable.t * switch
   | String_switch of Variable.t * (string * t) list * t option
+                     * Lambda.value_kind
   (** Restrictions on [Lambda.Lstringswitch] also apply to [String_switch]. *)
   | Static_raise of Static_exception.t * Variable.t list
-  | Static_catch of Static_exception.t * Variable.t list * t * t
-  | Try_with of t * Variable.t * t
+  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.value_kind
+  | Try_with of t * Variable.t * t * Lambda.value_kind
   | While of t * t
   | For of for_loop
   | Region of t
@@ -346,6 +347,7 @@ and switch = {
   numblocks : Numbers.Int.Set.t; (** Number of tag block cases *)
   blocks : (int * t) list; (** Tag block cases *)
   failaction : t option; (** Action to take if none matched *)
+  kind : Lambda.value_kind
 }
 
 (** Equivalent to the similar type in [Lambda]. *)

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -177,12 +177,14 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       check_variable_is_bound env from_value;
       check_variable_is_bound env to_value;
       loop (add_binding_occurrence env bound_var) body
-    | Static_catch (static_exn, vars, body, handler) ->
+    | Static_catch (static_exn, vars, body, handler, kind) ->
       ignore_static_exception static_exn;
+      ignore_value_kind kind;
       loop env body;
       loop (add_binding_occurrences env vars) handler
-    | Try_with (body, var, handler) ->
+    | Try_with (body, var, handler, kind) ->
       loop env body;
+      ignore_value_kind kind;
       loop (add_binding_occurrence env var) handler
     (* Everything else: *)
     | Var var -> check_variable_is_bound env var
@@ -207,25 +209,28 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       check_variable_is_bound env obj;
       check_variables_are_bound env args;
       ignore_debuginfo dbg
-    | If_then_else (cond, ifso, ifnot) ->
+    | If_then_else (cond, ifso, ifnot, kind) ->
       check_variable_is_bound env cond;
+      ignore_value_kind kind;
       loop env ifso;
       loop env ifnot
-    | Switch (arg, { numconsts; consts; numblocks; blocks; failaction; }) ->
+    | Switch (arg, { numconsts; consts; numblocks; blocks; failaction; kind }) ->
       check_variable_is_bound env arg;
       ignore_int_set numconsts;
       ignore_int_set numblocks;
+      ignore_value_kind kind;
       List.iter (fun (n, e) ->
           ignore_int n;
           loop env e)
         (consts @ blocks);
       Option.iter (loop env) failaction
-    | String_switch (arg, cases, e_opt) ->
+    | String_switch (arg, cases, e_opt, kind) ->
       check_variable_is_bound env arg;
       List.iter (fun (label, case) ->
           ignore_string label;
           loop env case)
         cases;
+      ignore_value_kind kind;
       Option.iter (loop env) e_opt
     | Static_raise (static_exn, es) ->
       ignore_static_exception static_exn;
@@ -622,7 +627,7 @@ let every_static_exception_is_caught flam =
   in
   let rec loop env (flam : Flambda.t) =
     match flam with
-    | Static_catch (i, _, body, handler) ->
+    | Static_catch (i, _, body, handler, _kind) ->
       let env = Static_exception.Set.add i env in
       loop env handler;
       loop env body
@@ -637,7 +642,7 @@ let every_static_exception_is_caught_at_a_single_position flam =
   let caught = ref Static_exception.Set.empty in
   let f (flam : Flambda.t) =
     match flam with
-    | Static_catch (i, _, _body, _handler) ->
+    | Static_catch (i, _, _body, _handler, _kind) ->
       if Static_exception.Set.mem i !caught then
         raise (Static_exception_caught_in_multiple_places i);
       caught := Static_exception.Set.add i !caught

--- a/middle_end/flambda/flambda_iterators.ml
+++ b/middle_end/flambda/flambda_iterators.ml
@@ -33,14 +33,14 @@ let apply_on_subexpressions f f_named (flam : Flambda.t) =
     List.iter (fun (_,l) -> f l) sw.consts;
     List.iter (fun (_,l) -> f l) sw.blocks;
     Option.iter f sw.failaction
-  | String_switch (_, sw, def) ->
+  | String_switch (_, sw, def, _kind) ->
     List.iter (fun (_,l) -> f l) sw;
     Option.iter f def
-  | Static_catch (_,_,f1,f2) ->
+  | Static_catch (_,_,f1,f2, _) ->
     f f1; f f2;
-  | Try_with (f1,_,f2) ->
+  | Try_with (f1,_,f2, _kind) ->
     f f1; f f2
-  | If_then_else (_,f1, f2) ->
+  | If_then_else (_,f1, f2, _kind) ->
     f f1;f f2
   | While (f1,f2) ->
     f f1; f f2
@@ -120,34 +120,34 @@ let map_subexpressions f f_named (tree:Flambda.t) : Flambda.t =
         }
       in
       Switch (arg, sw)
-  | String_switch (arg, sw, def) ->
+  | String_switch (arg, sw, def, kind) ->
     let new_sw = list_map_sharing (map_snd_sharing (fun _ v -> f v)) sw in
     let new_def = may_map_sharing f def in
     if sw == new_sw && def == new_def then
       tree
     else
-      String_switch(arg, new_sw, new_def)
-  | Static_catch (i, vars, body, handler) ->
+      String_switch(arg, new_sw, new_def, kind)
+  | Static_catch (i, vars, body, handler, kind) ->
     let new_body = f body in
     let new_handler = f handler in
     if new_body == body && new_handler == handler then
       tree
     else
-      Static_catch (i, vars, new_body, new_handler)
-  | Try_with(body, id, handler) ->
+      Static_catch (i, vars, new_body, new_handler, kind)
+  | Try_with(body, id, handler, kind) ->
     let new_body = f body in
     let new_handler = f handler in
     if body == new_body && handler == new_handler then
       tree
     else
-      Try_with(new_body, id, new_handler)
-  | If_then_else(arg, ifso, ifnot) ->
+      Try_with(new_body, id, new_handler, kind)
+  | If_then_else(arg, ifso, ifnot, kind) ->
     let new_ifso = f ifso in
     let new_ifnot = f ifnot in
     if new_ifso == ifso && new_ifnot == ifnot then
       tree
     else
-      If_then_else(arg, new_ifso, new_ifnot)
+      If_then_else(arg, new_ifso, new_ifnot, kind)
   | While(cond, body) ->
     let new_cond = f cond in
     let new_body = f body in
@@ -349,7 +349,7 @@ let map_general ~toplevel f f_named tree =
             tree
           else
             Switch (arg, sw)
-        | String_switch (arg, sw, def) ->
+        | String_switch (arg, sw, def, kind) ->
           let done_something = ref false in
           let sw =
             List.map (fun (i, v) -> i, aux_done_something v done_something) sw
@@ -362,28 +362,28 @@ let map_general ~toplevel f f_named tree =
           if not !done_something then
             tree
           else
-            String_switch(arg, sw, def)
-        | Static_catch (i, vars, body, handler) ->
+            String_switch(arg, sw, def, kind)
+        | Static_catch (i, vars, body, handler, kind) ->
           let new_body = aux body in
           let new_handler = aux handler in
           if new_body == body && new_handler == handler then
             tree
           else
-            Static_catch (i, vars, new_body, new_handler)
-        | Try_with(body, id, handler) ->
+            Static_catch (i, vars, new_body, new_handler, kind)
+        | Try_with(body, id, handler, kind) ->
           let new_body = aux body in
           let new_handler = aux handler in
           if new_body == body && new_handler == handler then
             tree
           else
-            Try_with (new_body, id, new_handler)
-        | If_then_else (arg, ifso, ifnot) ->
+            Try_with (new_body, id, new_handler, kind)
+        | If_then_else (arg, ifso, ifnot, kind) ->
           let new_ifso = aux ifso in
           let new_ifnot = aux ifnot in
           if new_ifso == ifso && new_ifnot == ifnot then
             tree
           else
-            If_then_else (arg, new_ifso, new_ifnot)
+            If_then_else (arg, new_ifso, new_ifnot, kind)
         | While (cond, body) ->
           let new_cond = aux cond in
           let new_body = aux body in

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -247,12 +247,12 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
        bound variables as in NC also *)
     | Assign _ ->
       mark_curr curr
-    | Try_with (f1,id,f2) ->
+    | Try_with (f1,id,f2, _kind) ->
       mark_curr [Var id];
       mark_curr curr;
       mark_loop ~toplevel [] f1;
       mark_loop ~toplevel [] f2
-    | Static_catch (_,ids,f1,f2) ->
+    | Static_catch (_,ids,f1,f2, _) ->
       List.iter (fun id -> mark_curr [Var id]) ids;
       mark_curr curr;
       mark_loop ~toplevel [] f1;
@@ -269,7 +269,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_curr curr;
       mark_loop ~toplevel [] f1;
       mark_loop ~toplevel:false [] body
-    | If_then_else (f1,f2,f3) ->
+    | If_then_else (f1,f2,f3, _kind) ->
       mark_curr curr;
       mark_curr [Var f1];
       mark_loop ~toplevel [] f2;
@@ -287,7 +287,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       List.iter (fun (_,l) -> mark_loop ~toplevel [] l) sw.consts;
       List.iter (fun (_,l) -> mark_loop ~toplevel [] l) sw.blocks;
       Option.iter (fun l -> mark_loop ~toplevel [] l) sw.failaction
-    | String_switch (arg,sw,def) ->
+    | String_switch (arg,sw,def, _kind) ->
       mark_curr curr;
       mark_var arg curr;
       List.iter (fun (_,l) -> mark_loop ~toplevel [] l) sw;

--- a/middle_end/flambda/inlining_cost.ml
+++ b/middle_end/flambda/inlining_cost.ml
@@ -98,18 +98,18 @@ let lambda_smaller' lam ~than:threshold =
       List.iter (fun (_, lam) -> lambda_size lam) sw.consts;
       List.iter (fun (_, lam) -> lambda_size lam) sw.blocks;
       Option.iter lambda_size sw.failaction
-    | String_switch (_, sw, def) ->
+    | String_switch (_, sw, def, _) ->
       List.iter (fun (_, lam) ->
           size := !size + 2;
           lambda_size lam)
         sw;
       Option.iter lambda_size def
     | Static_raise _ -> ()
-    | Static_catch (_, _, body, handler) ->
+    | Static_catch (_, _, body, handler, _) ->
       incr size; lambda_size body; lambda_size handler
-    | Try_with (body, _, handler) ->
+    | Try_with (body, _, handler, _) ->
       size := !size + 8; lambda_size body; lambda_size handler
-    | If_then_else (_, ifso, ifnot) ->
+    | If_then_else (_, ifso, ifnot, _) ->
       size := !size + 2;
       lambda_size ifso; lambda_size ifnot
     | While (cond, body) ->

--- a/middle_end/flambda/ref_to_variables.ml
+++ b/middle_end/flambda/ref_to_variables.ml
@@ -52,23 +52,23 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
     | Let_mutable { initial_value = v; body } ->
       set := Variable.Set.add v !set;
       loop body
-    | If_then_else (cond, ifso, ifnot) ->
+    | If_then_else (cond, ifso, ifnot, _kind) ->
       set := Variable.Set.add cond !set;
       loop ifso;
       loop ifnot
-    | Switch (cond, { consts; blocks; failaction }) ->
+    | Switch (cond, { consts; blocks; failaction; kind = _ }) ->
       set := Variable.Set.add cond !set;
       List.iter (fun (_, branch) -> loop branch) consts;
       List.iter (fun (_, branch) -> loop branch) blocks;
       Option.iter loop failaction
-    | String_switch (cond, branches, default) ->
+    | String_switch (cond, branches, default, _kind) ->
       set := Variable.Set.add cond !set;
       List.iter (fun (_, branch) -> loop branch) branches;
       Option.iter loop default
-    | Static_catch (_, _, body, handler) ->
+    | Static_catch (_, _, body, handler, _) ->
       loop body;
       loop handler
-    | Try_with (body, _, handler) ->
+    | Try_with (body, _, handler, _kind) ->
       loop body;
       loop handler
     | While (cond, body) ->

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -603,7 +603,8 @@ let dissect_letrec ~bindings ~body =
     Lstaticcatch
       ( Lregion (Lambda.rename bound_ids_freshening substituted),
         (cont, List.map (fun (bound_id, _) -> bound_id, Pgenval) bindings),
-        real_body, Pgenval )
+        real_body,
+        Pgenval )
 
 type dissected =
   | Dissected of Lambda.lambda

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -481,12 +481,12 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
     in
     { letrec with effects = Lsequence (lam, letrec.effects); consts }
   | Lapply _
-  | Lswitch (_, _, _)
-  | Lstringswitch (_, _, _, _)
+  | Lswitch (_, _, _, _)
+  | Lstringswitch (_, _, _, _, _)
   | Lstaticraise (_, _)
-  | Lstaticcatch (_, _, _)
-  | Ltrywith (_, _, _)
-  | Lifthenelse (_, _, _)
+  | Lstaticcatch (_, _, _, _)
+  | Ltrywith (_, _, _, _)
+  | Lifthenelse (_, _, _, _)
   | Lsend _ | Lvar _
   | Lprim (_, _, _) ->
     (* This cannot be recursive, otherwise it should have been caught by the
@@ -496,10 +496,10 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
        inspected (appearances in guarded positions in other cases are OK) *)
     let no_recurse =
       match lam with
-      | Lstaticcatch (_, _, _) | Ltrywith (_, _, _) -> None
-      | Lswitch (lam1, _, _)
-      | Lstringswitch (lam1, _, _, _)
-      | Lifthenelse (lam1, _, _) ->
+      | Lstaticcatch (_, _, _, _) | Ltrywith (_, _, _, _) -> None
+      | Lswitch (lam1, _, _, _)
+      | Lstringswitch (lam1, _, _, _, _)
+      | Lifthenelse (lam1, _, _, _) ->
         Some lam1
       | Lapply _ | Lstaticraise _ | Lsend _ | Lvar _ | Lprim _ -> Some lam
       | _ -> assert false
@@ -603,7 +603,7 @@ let dissect_letrec ~bindings ~body =
     Lstaticcatch
       ( Lregion (Lambda.rename bound_ids_freshening substituted),
         (cont, List.map (fun (bound_id, _) -> bound_id, Pgenval) bindings),
-        real_body )
+        real_body, Pgenval )
 
 type dissected =
   | Dissected of Lambda.lambda

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1028,15 +1028,14 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
       ~body:(fun acc ccenv ->
         let_cont_nonrecursive_with_extra_params acc env ccenv
           ~is_exn_handler:false
-          ~params:[result_var, Not_user_visible, Pgenval]
+          ~params:[result_var, Not_user_visible, kind]
           ~body:(fun acc env ccenv after_continuation ->
             let_cont_nonrecursive_with_extra_params acc env ccenv
-              ~is_exn_handler:true
-              ~params:[id, User_visible, kind]
+              ~is_exn_handler:true ~params:[id, User_visible, Pgenval]
               ~body:(fun acc env ccenv handler_continuation ->
                 let_cont_nonrecursive_with_extra_params acc env ccenv
                   ~is_exn_handler:false
-                  ~params:[body_result, Not_user_visible, Pgenval]
+                  ~params:[body_result, Not_user_visible, kind]
                   ~body:(fun acc env ccenv poptrap_continuation ->
                     let_cont_nonrecursive_with_extra_params acc env ccenv
                       ~is_exn_handler:false ~params:[]
@@ -1384,7 +1383,7 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
         in
         CC.close_let acc ccenv new_id User_visible (Simple new_value) ~body)
       k_exn
-  | Ltrywith (body, id, handler, _kind) ->
+  | Ltrywith (body, id, handler, kind) ->
     let body_result = Ident.create_local "body_result" in
     let region = Ident.create_local "try_region" in
     CC.close_let acc ccenv region Not_user_visible Begin_region
@@ -1395,7 +1394,7 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
           ~body:(fun acc env ccenv handler_continuation ->
             let_cont_nonrecursive_with_extra_params acc env ccenv
               ~is_exn_handler:false
-              ~params:[body_result, Not_user_visible, Pgenval]
+              ~params:[body_result, Not_user_visible, kind]
               ~body:(fun acc env ccenv poptrap_continuation ->
                 let_cont_nonrecursive_with_extra_params acc env ccenv
                   ~is_exn_handler:false ~params:[]

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1032,7 +1032,8 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
           ~params:[result_var, Not_user_visible, kind]
           ~body:(fun acc env ccenv after_continuation ->
             let_cont_nonrecursive_with_extra_params acc env ccenv
-              ~is_exn_handler:true ~params:[id, User_visible, Pgenval]
+              ~is_exn_handler:true
+              ~params:[id, User_visible, Pgenval]
               ~body:(fun acc env ccenv handler_continuation ->
                 let_cont_nonrecursive_with_extra_params acc env ccenv
                   ~is_exn_handler:false

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -949,6 +949,7 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
         compile_staticfail acc env ccenv ~continuation ~args:(args @ extra_args))
       k_exn
   | Lstaticcatch (body, (static_exn, args), handler, _kind) ->
+    (* CR-someday poechsel: Use [kind] *)
     let result_var = Ident.create_local "staticcatch_result" in
     let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler:false
       ~params:[result_var, IR.Not_user_visible, Pgenval]
@@ -1303,6 +1304,7 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
     | Transformed lam -> cps_tail acc env ccenv lam k k_exn
   end
   | Lswitch (scrutinee, switch, _loc, _kind) ->
+    (* CR-someday poechsel: Use [kind] *)
     cps_switch acc env ccenv switch ~scrutinee k k_exn
   | Lstringswitch (scrutinee, cases, default, loc, kind) ->
     cps_tail acc env ccenv
@@ -1320,6 +1322,7 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
         compile_staticfail acc env ccenv ~continuation ~args:(args @ extra_args))
       k_exn
   | Lstaticcatch (body, (static_exn, args), handler, _kind) ->
+    (* CR-someday poechsel: Use [kind] *)
     let continuation = Continuation.create () in
     let { Env.body_env; handler_env; extra_params } =
       Env.add_static_exn_continuation env static_exn continuation

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -1352,7 +1352,14 @@ and make_switch ~tag_discriminant env res e arms =
           i + 1, res)
         arms (0, res)
     in
-    wrap (C.transl_switch_clambda Debuginfo.none e index cases), res
+    (* CR-someday poechsel: Put a more precise value kind here *)
+    (* The cases of the switch must have a value kind (i.e. they cannot be
+       unboxed). This is because each case will either end in a `Cexit` or end
+       by "calling" the return continuation, in which case it will just return
+       the argument to that continuation. Currently functions cannot return
+       unboxed values, so that argument must have a value kind. *)
+    ( wrap (C.transl_switch_clambda Debuginfo.none (Vval Pgenval) e index cases),
+      res )
 
 and invalid _env res _e = C.unreachable, res
 

--- a/middle_end/flambda2/to_cmm/to_cmm_helper.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_helper.ml
@@ -271,7 +271,15 @@ let letin_mut v ty e body = Cmm.Clet_mut (v, ty, e, body)
 
 let ite ?(dbg = Debuginfo.none) ?(then_dbg = Debuginfo.none) ~then_
     ?(else_dbg = Debuginfo.none) ~else_ cond =
-  Cmm.Cifthenelse (cond, then_dbg, then_, else_dbg, else_, dbg)
+  Cmm.Cifthenelse
+    ( cond,
+      then_dbg,
+      then_,
+      else_dbg,
+      else_,
+      dbg,
+      (* CR-someday poechsel: Put a correct value kind here *)
+      Vval Pgenval )
 
 let load ?(dbg = Debuginfo.none) kind mut addr =
   Cmm.Cop (Cmm.Cload (kind, mut), [addr], dbg)
@@ -533,7 +541,8 @@ let bigarray_store ?(dbg = Debuginfo.none) _dims kind _layout ba offset v =
 (* try-with blocks *)
 
 let trywith ?(dbg = Debuginfo.none) ~kind ~body ~exn_var ~handler () =
-  Cmm.Ctrywith (body, kind, exn_var, handler, dbg)
+  (* CR-someday poechsel: Put a correct value kind here *)
+  Cmm.Ctrywith (body, kind, exn_var, handler, dbg, Vval Pgenval)
 
 let raise_kind (kind : Trap_action.raise_kind option) : Lambda.raise_kind =
   match kind with
@@ -560,7 +569,7 @@ let trap_return arg trap_actions =
 
 let ccatch ~rec_flag ~handlers ~body =
   let rec_flag = if rec_flag then Cmm.Recursive else Cmm.Nonrecursive in
-  Cmm.Ccatch (rec_flag, handlers, body)
+  Cmm.Ccatch (rec_flag, handlers, body, Vval Pgenval)
 
 (* Function calls *)
 

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -176,7 +176,7 @@ and lam ppf = function
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       fprintf ppf "@[<2>(%a%a)@]"
         Printclambda_primitives.primitive prim lams largs
-  | Uswitch(larg, sw, _dbg) ->
+  | Uswitch(larg, sw, _dbg, _kind) ->
       let print_case tag index i ppf =
         for j = 0 to Array.length index - 1 do
           if index.(j) = i then fprintf ppf "case %s %i:" tag j
@@ -192,7 +192,7 @@ and lam ppf = function
       fprintf ppf
        "@[<v 0>@[<2>(switch@ %a@ @]%a)@]"
         lam larg switch sw
-  | Ustringswitch(larg,sw,d) ->
+  | Ustringswitch(larg,sw,d, _kind) ->
       let switch ppf sw =
         let spc = ref false in
         List.iter
@@ -208,12 +208,13 @@ and lam ppf = function
         | None -> ()
         end in
       fprintf ppf
-        "@[<1>(switch %a@ @[<v 0>%a@])@]" lam larg switch sw
+        "@[<1>(switch %a@ @[<v 0>%a@])@]"
+        lam larg switch sw
   | Ustaticfail (i, ls)  ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       fprintf ppf "@[<2>(exit@ %d%a)@]" i lams ls;
-  | Ucatch(i, vars, lbody, lhandler) ->
+  | Ucatch(i, vars, lbody, lhandler, _kind) ->
       fprintf ppf "@[<2>(catch@ %a@;<1 -1>with (%d%a)@ %a)@]"
         lam lbody i
         (fun ppf vars ->
@@ -227,10 +228,10 @@ and lam ppf = function
         )
         vars
         lam lhandler
-  | Utrywith(lbody, param, lhandler) ->
+  | Utrywith(lbody, param, lhandler, _kind) ->
       fprintf ppf "@[<2>(try@ %a@;<1 -1>with %a@ %a)@]"
         lam lbody VP.print param lam lhandler
-  | Uifthenelse(lcond, lif, lelse) ->
+  | Uifthenelse(lcond, lif, lelse, _kind) ->
       fprintf ppf "@[<2>(if@ %a@ %a@ %a)@]" lam lcond lam lif lam lelse
   | Usequence(l1, l2) ->
       fprintf ppf "@[<2>(seq@ %a@ %a)@]" lam l1 sequence l2

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -1559,6 +1559,7 @@ struct
 
   type act = expression
   type loc = Debuginfo.t
+  type value_kind = unit
 
   (* CR mshinwell: GPR#2294 will fix the Debuginfo here *)
 
@@ -1567,15 +1568,15 @@ struct
   let make_offset arg n = add_const arg n Debuginfo.none
   let make_isout h arg = Cop (Ccmpa Clt, [h ; arg], Debuginfo.none)
   let make_isin h arg = Cop (Ccmpa Cge, [h ; arg], Debuginfo.none)
-  let make_if cond ifso ifnot =
+  let make_if () cond ifso ifnot =
     Cifthenelse (cond, Debuginfo.none, ifso, Debuginfo.none, ifnot,
       Debuginfo.none)
-  let make_switch dbg arg cases actions =
+  let make_switch dbg () arg cases actions =
     let actions = Array.map (fun expr -> expr, dbg) actions in
     make_switch arg cases actions dbg
   let bind arg body = bind "switcher" arg body
 
-  let make_catch handler = match handler with
+  let make_catch () handler = match handler with
   | Cexit (i,[]) -> i,fun e -> e
   | _ ->
       let dbg = Debuginfo.none in
@@ -1678,7 +1679,7 @@ let transl_int_switch dbg arg low high cases default = match cases with
     bind "switcher" arg
       (fun a ->
         SwitcherBlocks.zyva
-          dbg
+          dbg ()
           (low,high)
           a
           (Array.of_list inters) store)
@@ -1713,7 +1714,7 @@ let transl_switch_clambda loc arg index cases =
       bind "switcher" arg
         (fun a ->
            SwitcherBlocks.zyva
-             loc
+             loc ()
              (0,n_index-1)
              a
              (Array.of_list inters) store)

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -311,17 +311,17 @@ type lambda =
   | Llet of let_kind * value_kind * Ident.t * lambda * lambda
   | Lletrec of (Ident.t * lambda) list * lambda
   | Lprim of primitive * lambda list * scoped_location
-  | Lswitch of lambda * lambda_switch * scoped_location
+  | Lswitch of lambda * lambda_switch * scoped_location * value_kind
 (* switch on strings, clauses are sorted by string order,
    strings are pairwise distinct *)
   | Lstringswitch of
-      lambda * (string * lambda) list * lambda option * scoped_location
+      lambda * (string * lambda) list * lambda option * scoped_location * value_kind
   | Lstaticraise of int * lambda list
-  | Lstaticcatch of lambda * (int * (Ident.t * value_kind) list) * lambda
-  | Ltrywith of lambda * Ident.t * lambda
+  | Lstaticcatch of lambda * (int * (Ident.t * value_kind) list) * lambda * value_kind
+  | Ltrywith of lambda * Ident.t * lambda * value_kind
 (* Lifthenelse (e, t, f) evaluates t if e evaluates to 0, and
    evaluates f if e evaluates to any other value *)
-  | Lifthenelse of lambda * lambda * lambda
+  | Lifthenelse of lambda * lambda * lambda * value_kind
   | Lsequence of lambda * lambda
   | Lwhile of lambda * lambda
   | Lfor of Ident.t * lambda * lambda * direction_flag * lambda

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -21,24 +21,24 @@ open Debuginfo.Scoped_location
 
 (* Entry points to match compiler *)
 val for_function:
-        scopes:scopes -> Location.t ->
+        scopes:scopes -> value_kind -> Location.t ->
         int ref option -> lambda -> (pattern * lambda) list -> partial ->
         lambda
 val for_trywith:
-        scopes:scopes -> Location.t ->
+        scopes:scopes -> value_kind -> Location.t ->
         lambda -> (pattern * lambda) list ->
         lambda
 val for_let:
         scopes:scopes -> Location.t ->
-        lambda -> pattern -> lambda ->
+        lambda -> pattern -> value_kind -> lambda ->
         lambda
 val for_multiple_match:
-        scopes:scopes -> Location.t ->
+        scopes:scopes -> value_kind -> Location.t ->
         lambda list -> alloc_mode -> (pattern * lambda) list -> partial ->
         lambda
 
 val for_tupled_function:
-        scopes:scopes -> Location.t ->
+        scopes:scopes -> Location.t -> value_kind ->
         Ident.t list -> (pattern list * lambda) list -> partial ->
         lambda
 
@@ -48,7 +48,7 @@ val flatten_pattern: int -> pattern -> pattern list
 
 (* Expand stringswitch to  string test tree *)
 val expand_stringswitch:
-    scoped_location -> lambda -> (string * lambda) list ->
+    scoped_location -> value_kind -> lambda -> (string * lambda) list ->
     lambda option -> lambda
 
 val inline_lazy_force : lambda -> region_close -> scoped_location -> lambda

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -651,7 +651,7 @@ let rec lam ppf = function
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       fprintf ppf "@[<2>(%a%a)@]" primitive prim lams largs
-  | Lswitch(larg, sw, _loc) ->
+  | Lswitch(larg, sw, _loc, _kind) ->
       let switch ppf sw =
         let spc = ref false in
         List.iter
@@ -674,7 +674,7 @@ let rec lam ppf = function
        "@[<1>(%s %a@ @[<v 0>%a@])@]"
        (match sw.sw_failaction with None -> "switch*" | _ -> "switch")
        lam larg switch sw
-  | Lstringswitch(arg, cases, default, _) ->
+  | Lstringswitch(arg, cases, default, _, _kind) ->
       let switch ppf cases =
         let spc = ref false in
         List.iter
@@ -694,7 +694,7 @@ let rec lam ppf = function
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       fprintf ppf "@[<2>(exit@ %d%a)@]" i lams ls;
-  | Lstaticcatch(lbody, (i, vars), lhandler) ->
+  | Lstaticcatch(lbody, (i, vars), lhandler, _kind) ->
       fprintf ppf "@[<2>(catch@ %a@;<1 -1>with (%d%a)@ %a)@]"
         lam lbody i
         (fun ppf vars ->
@@ -704,10 +704,10 @@ let rec lam ppf = function
         )
         vars
         lam lhandler
-  | Ltrywith(lbody, param, lhandler) ->
+  | Ltrywith(lbody, param, lhandler, _kind) ->
       fprintf ppf "@[<2>(try@ %a@;<1 -1>with %a@ %a)@]"
         lam lbody Ident.print param lam lhandler
-  | Lifthenelse(lcond, lif, lelse) ->
+  | Lifthenelse(lcond, lif, lelse, _kind) ->
       fprintf ppf "@[<2>(if@ %a@ %a@ %a)@]" lam lcond lam lif lam lelse
   | Lsequence(l1, l2) ->
       fprintf ppf "@[<2>(seq@ %a@ %a)@]" lam l1 sequence l2

--- a/ocaml/lambda/switch.mli
+++ b/ocaml/lambda/switch.mli
@@ -78,6 +78,8 @@ module type S =
     type act
     (* type of source locations *)
     type loc
+    (* type of value kind *)
+    type value_kind
 
     (* Various constructors, for making a binder,
         adding one integer, etc. *)
@@ -87,13 +89,13 @@ module type S =
     val make_prim : primitive -> act list -> act
     val make_isout : act -> act -> act
     val make_isin : act -> act -> act
-    val make_if : act -> act -> act -> act
+    val make_if : value_kind -> act -> act -> act -> act
    (* construct an actual switch :
       make_switch arg cases acts
       NB:  cases is in the value form *)
-    val make_switch : loc -> act -> int array -> act array -> act
+    val make_switch : loc -> value_kind -> act -> int array -> act array -> act
    (* Build last minute sharing of action stuff *)
-   val make_catch : act -> int * (act -> act)
+   val make_catch : value_kind -> act -> int * (act -> act)
    val make_exit : int -> act
 
   end
@@ -115,6 +117,7 @@ module Make :
 (* Standard entry point, sharing is tracked *)
       val zyva :
           Arg.loc ->
+          Arg.value_kind ->
           (int * int) ->
            Arg.act ->
            (int * int * int) array ->
@@ -123,6 +126,7 @@ module Make :
 
 (* Output test sequence, sharing tracked *)
      val test_sequence :
+           Arg.value_kind ->
            Arg.act ->
            (int * int * int) array ->
            (Arg.act, _) t_store ->

--- a/ocaml/lambda/translcore.mli
+++ b/ocaml/lambda/translcore.mli
@@ -35,7 +35,7 @@ val transl_apply: scopes:scopes
                   -> (arg_label * apply_arg) list
                   -> scoped_location -> lambda
 val transl_let: scopes:scopes -> ?in_structure:bool
-                  -> rec_flag -> value_binding list -> lambda -> lambda
+                  -> rec_flag -> value_binding list -> value_kind -> lambda -> lambda
 
 val transl_extension_constructor: scopes:scopes ->
   Env.t -> Path.t option ->

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -649,7 +649,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
       | Tstr_value(rec_flag, pat_expr_list) ->
           (* Translate bindings first *)
           let mk_lam_let =
-            transl_let ~scopes ~in_structure:true rec_flag pat_expr_list in
+            transl_let ~scopes ~in_structure:true rec_flag pat_expr_list Pgenval in
           let ext_fields =
             List.rev_append (let_bound_idents pat_expr_list) fields in
           (* Then, translate remainder of struct *)
@@ -1060,6 +1060,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             let ids = let_bound_idents pat_expr_list in
             let lam =
               transl_let ~scopes ~in_structure:true rec_flag pat_expr_list
+                 Pintval (* unit *)
                 (store_idents Loc_unknown ids)
             in
             Lsequence(Lambda.subst no_env_update subst lam,
@@ -1550,6 +1551,7 @@ let transl_toplevel_item ~scopes item =
   | Tstr_value(rec_flag, pat_expr_list) ->
       let idents = let_bound_idents pat_expr_list in
       transl_let ~scopes ~in_structure:true rec_flag pat_expr_list
+        Pintval (* unit *)
         (make_sequence toploop_setvalue_id idents)
   | Tstr_typext(tyext) ->
       let idents =

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -1248,7 +1248,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let dbg = Debuginfo.from_location loc in
       simplif_prim ~backend !Clflags.float_const_prop
                    p (close_list_approx env args) dbg
-  | Lswitch(arg, sw, dbg) ->
+  | Lswitch(arg, sw, dbg, _kind) ->
       let fn fail =
         let (uarg, _) = close env arg in
         let const_index, const_actions, fconst =
@@ -1280,7 +1280,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
             Ucatch (i,[],ubody,uhandler),Value_unknown
           else fn fail
       end
-  | Lstringswitch(arg,sw,d,_) ->
+  | Lstringswitch(arg,sw,d,_,_kind) ->
       let uarg,_ = close env arg in
       let usw =
         List.map
@@ -1296,16 +1296,16 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       Ustringswitch (uarg,usw,ud),Value_unknown
   | Lstaticraise (i, args) ->
       (Ustaticfail (i, close_list env args), Value_unknown)
-  | Lstaticcatch(body, (i, vars), handler) ->
+  | Lstaticcatch(body, (i, vars), handler, _) ->
       let (ubody, _) = close env body in
       let (uhandler, _) = close env handler in
       let vars = List.map (fun (var, k) -> VP.create var, k) vars in
       (Ucatch(i, vars, ubody, uhandler), Value_unknown)
-  | Ltrywith(body, id, handler) ->
+  | Ltrywith(body, id, handler, _kind) ->
       let (ubody, _) = close env body in
       let (uhandler, _) = close env handler in
       (Utrywith(ubody, VP.create id, uhandler), Value_unknown)
-  | Lifthenelse(arg, ifso, ifnot) ->
+  | Lifthenelse(arg, ifso, ifnot, _kind) ->
       begin match close env arg with
         (uarg, Value_const (Uconst_int n)) ->
           sequence_constant_expr uarg

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -499,7 +499,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       ~create_body:(fun args ->
         name_expr (Prim (p, args, dbg))
           ~name:(Names.of_primitive lambda_p))
-  | Lswitch (arg, sw, _loc) ->
+  | Lswitch (arg, sw, _loc, _kind) ->
     let scrutinee = Variable.create Names.switch in
     let aux (i, lam) = i, close t env lam in
     let nums sw_num cases default =
@@ -518,7 +518,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
           blocks = List.map aux sw.sw_blocks;
           failaction = Option.map (close t env) sw.sw_failaction;
         }))
-  | Lstringswitch (arg, sw, def, _) ->
+  | Lstringswitch (arg, sw, def, _, _kind) ->
     let scrutinee = Variable.create Names.string_switch in
     Flambda.create_let scrutinee (Expr (close t env arg))
       (String_switch (scrutinee,
@@ -531,17 +531,17 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       ~create_body:(fun args ->
         let static_exn = Env.find_static_exception env i in
         Static_raise (static_exn, args))
-  | Lstaticcatch (body, (i, ids), handler) ->
+  | Lstaticcatch (body, (i, ids), handler, _) ->
     let st_exn = Static_exception.create () in
     let env = Env.add_static_exception env i st_exn in
     let ids = List.map fst ids in
     let vars = List.map Variable.create_with_same_name_as_ident ids in
     Static_catch (st_exn, vars, close t env body,
       close t (Env.add_vars env ids vars) handler)
-  | Ltrywith (body, id, handler) ->
+  | Ltrywith (body, id, handler, _kind) ->
     let var = Variable.create_with_same_name_as_ident id in
     Try_with (close t env body, var, close t (Env.add_var env id var) handler)
-  | Lifthenelse (cond, ifso, ifnot) ->
+  | Lifthenelse (cond, ifso, ifnot, _kind) ->
     let cond = close t env cond in
     let cond_var = Variable.create Names.cond in
     Flambda.create_let cond_var (Expr cond)

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -43,7 +43,7 @@ let make_switch n selector caselist =
     List.iter (fun pos -> index.(pos) <- i) posl;
     actv.(i) <- (e, dbg)
   done;
-  Cswitch(selector, index, actv, dbg)
+  Cswitch(selector, index, actv, dbg, value_kind ())
 
 let access_array base numelt size =
   match numelt with
@@ -236,7 +236,8 @@ expr:
   | LPAREN binaryop expr expr RPAREN { Cop($2, [$3; $4], debuginfo ()) }
   | LPAREN SEQ sequence RPAREN { $3 }
   | LPAREN IF expr expr expr RPAREN
-      { Cifthenelse($3, debuginfo (), $4, debuginfo (), $5, debuginfo ()) }
+      { Cifthenelse($3, debuginfo (), $4, debuginfo (), $5, debuginfo (),
+                    value_kind ()) }
   | LPAREN SWITCH INTCONST expr caselist RPAREN { make_switch $3 $4 $5 }
   | LPAREN WHILE expr sequence RPAREN
       {
@@ -247,21 +248,22 @@ expr:
             Cconst_int (x, _) when x <> 0 -> $4
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
                              (Cexit(Cmm.Lbl lbl0,[],[])),
-                             debuginfo ()) in
+                             debuginfo (), value_kind ()) in
         Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
           Ccatch(Recursive,
             [lbl1, [], Csequence(body, Cexit(Cmm.Lbl lbl1, [], [])), debuginfo ()],
-            Cexit(Cmm.Lbl lbl1, [], []))) }
+            Cexit(Cmm.Lbl lbl1, [], []), value_kind ()), value_kind ()) }
   | LPAREN EXIT traps IDENT exprlist RPAREN
     { Cexit(Cmm.Lbl (find_label $4), List.rev $5, $3) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
       List.iter (fun (_, l, _, _) ->
         List.iter (fun (x, _) -> unbind_ident x) l) handlers;
-      Ccatch(Recursive, handlers, $3) }
+      Ccatch(Recursive, handlers, $3, value_kind ()) }
   | EXIT        { Cexit(Cmm.Lbl 0,[],[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
-                { unbind_ident $5; Ctrywith($3, Regular, $5, $6, debuginfo ()) }
+      { unbind_ident $5; Ctrywith($3, Regular, $5, $6, debuginfo (),
+                                  value_kind ()) }
   | LPAREN VAL expr expr RPAREN
       { let open Asttypes in
         Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],

--- a/testsuite/tools/parsecmmaux.ml
+++ b/testsuite/tools/parsecmmaux.ml
@@ -60,3 +60,11 @@ let debuginfo ?(loc=Location.symbol_rloc ()) () =
                   ~scopes:Scoped_location.empty_scopes loc
                )
             )
+
+let value_kind () =
+  (* CR-someday poechsel: As the value_kind is only used when building cmm
+     for the first time, its precise value is not important afterward.
+     For now we can say that the cmm code read by parsecmm will only contain
+     Pgenval and it should make no difference, but this should probably be
+     fixed. *)
+  Cmm.Vval Lambda.Pgenval

--- a/testsuite/tools/parsecmmaux.mli
+++ b/testsuite/tools/parsecmmaux.mli
@@ -23,6 +23,8 @@ val find_label: string -> int
 
 val debuginfo: ?loc:Location.t -> unit -> Debuginfo.t
 
+val value_kind : unit -> Cmm.value_kind
+
 type error =
     Unbound of string
 


### PR DESCRIPTION
Cmm was able to unbox some values thanks to the `value_kind` put on `let`. However, only putting the `value_kind` on `let` is not enough and on some simple example the heuristic would fail.
For example, the following example:
```
let foo a =
  let b = if a >= 0.0 then a +. 1.0 else Float.nan in
  b *. b
```
Was compiling into:
```
 (let
   b/166
     (if (>=f (load float64 a/163) 0.)
       (alloc{../flambda-boxing/test.ml:2,27-35} 1277
         (+f (load float64 a/163) 1.))
       (load_mut val (+a "camlStdlib__Float" 56)))
   (alloc{../flambda-boxing/test.ml:3,2-8} 1277
     (*f (load float64 b/166) (load float64 b/166)))))
```

Instead of
```
 (let
   b/245
     (if (>=f (load float64 a/237) 0.) (+f (load float64 a/237) 1.)
       (load float64 (load_mut val (+a "camlStdlib__Float" 56))))
   (alloc{test.ml:3,2-8} 1277 (*f b/245 b/245))))
```

This PR adds a `value_kind` on all join points that is then used to decide if a value should be unboxed on some let statements.