### PR TITLE
Intrinsics for float_of_bits and bits_of_float (amd64)

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -477,9 +477,11 @@ let emit_global_label s =
 
 let move (src : Reg.t) (dst : Reg.t) =
   if src.loc <> dst.loc then
-    begin match src.typ, src.loc, dst.loc with
-    | Float, Reg.Reg _, Reg.Reg _ -> I.movapd (reg src) (reg dst)
-    | Float, _, _ -> I.movsd (reg src) (reg dst)
+    begin match src.typ, src.loc, dst.typ, dst.loc with
+    | Float, Reg.Reg _, Float, Reg.Reg _ -> I.movapd (reg src) (reg dst)
+    | Float, _, Float, _ -> I.movsd (reg src) (reg dst)
+    | Float, Reg.Reg _, Int, _
+    | Int, _, Float, Reg.Reg _ -> I.movq (reg src) (reg dst)
     | _ -> I.mov (reg src) (reg dst)
     end
 

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -271,6 +271,11 @@ method! select_operation op args dbg =
      | _ ->
          assert false
     end
+  | Cextcall { func = "caml_int64_bits_of_float_unboxed"; alloc = false;
+               ty = [|Int|]; ty_args = [XFloat] }
+  | Cextcall { func = "caml_int64_float_of_bits_unboxed"; alloc = false;
+               ty = [|Float|]; ty_args = [XInt64] } ->
+     Imove, args
   | Cextcall { func; builtin = true; ty = ret; ty_args = _; } ->
       begin match func, ret with
       | "caml_rdtsc_unboxed", [|Int|] -> Ispecific Irdtsc, args

--- a/backend/x86_ast.mli
+++ b/backend/x86_ast.mli
@@ -174,6 +174,7 @@ type instruction =
   | MOV of arg * arg
   | MOVAPD of arg * arg
   | MOVD of arg * arg
+  | MOVQ of arg * arg
   | MOVLPD of arg * arg
   | MOVSD of arg * arg
   | MOVSS of arg * arg

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -182,6 +182,7 @@ module I = struct
   let mov x y = emit (MOV (x, y))
   let movapd x y = emit (MOVAPD (x, y))
   let movd x y = emit (MOVD (x, y))
+  let movq x y = emit (MOVQ (x, y))
   let movsd x y = emit (MOVSD (x, y))
   let movss x y = emit (MOVSS (x, y))
   let movsx x y = emit (MOVSX (x, y))

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -175,6 +175,7 @@ module I : sig
   val mov: arg -> arg -> unit
   val movapd: arg -> arg -> unit
   val movd: arg -> arg -> unit
+  val movq: arg -> arg -> unit
   val movsd: arg -> arg -> unit
   val movss: arg -> arg -> unit
   val movsx: arg -> arg -> unit

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -198,6 +198,7 @@ let print_instr b = function
   | MOV (arg1, arg2) -> i2_s b "mov" arg1 arg2
   | MOVAPD (arg1, arg2) -> i2 b "movapd" arg1 arg2
   | MOVD (arg1, arg2) -> i2 b "movd" arg1 arg2
+  | MOVQ (arg1, arg2) -> i2 b "movq" arg1 arg2
   | MOVLPD (arg1, arg2) -> i2 b "movlpd" arg1 arg2
   | MOVSD (arg1, arg2) -> i2 b "movsd" arg1 arg2
   | MOVSS (arg1, arg2) -> i2 b "movss" arg1 arg2

--- a/backend/x86_masm.ml
+++ b/backend/x86_masm.ml
@@ -190,6 +190,7 @@ let print_instr b = function
   | MOV (arg1, arg2) -> i2 b "mov" arg1 arg2
   | MOVAPD (arg1, arg2) -> i2 b "movapd" arg1 arg2
   | MOVD (arg1, arg2) -> i2 b "movd" arg1 arg2
+  | MOVQ (arg1, arg2) -> i2 b "movq" arg1 arg2
   | MOVLPD (arg1, arg2) -> i2 b "movlpd" arg1 arg2
   | MOVSD (arg1, arg2) -> i2 b "movsd" arg1 arg2
   | MOVSS (arg1, arg2) -> i2 b "movss" arg1 arg2


### PR DESCRIPTION
Emit `movq` instruction for Int64.float_of_bits` and `Int64.bits_of_float`.