### PR TITLE
Emit roundsd instruction (amd64)

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -35,7 +35,7 @@ method! class_of_operation op =
     | Ifloatarithmem _ | Ifloatsqrtf _ -> Op_load
     | Ibswap _ | Isqrtf -> super#class_of_operation op
     | Irdtsc | Irdpmc -> Op_other
-    | Ifloat_iround | Ifloat_min | Ifloat_max
+    | Ifloat_iround | Ifloat_min | Ifloat_max | Ifloat_round _
     | Icrc32q -> Op_pure
     | Iprefetch _ -> Op_other
     end

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -73,6 +73,8 @@ type prefetch_info = {
   addr: addressing_mode;
 }
 
+type rounding_mode = Half_to_even | Down | Up | Towards_zero
+
 type specific_operation =
     Ilea of addressing_mode             (* "lea" gives scaled adds *)
   | Istore_int of nativeint * addressing_mode * bool
@@ -85,6 +87,8 @@ type specific_operation =
   | Ifloatsqrtf of addressing_mode     (* Float square root from memory *)
   | Ifloat_iround                      (* Rounds a [float] to an [int64]
                                           using the current rounding mode *)
+  | Ifloat_round of rounding_mode      (* Round [float] to an integer [float]
+                                          using the specified mode *)
   | Ifloat_min                         (* Return min of two floats *)
   | Ifloat_max                         (* Return max of two floats *)
   | Isextend32                         (* 32 to 64 bit conversion with sign
@@ -144,6 +148,12 @@ let string_of_prefetch_temporal_locality_hint = function
   | Moderate -> "moderate"
   | High -> "high"
 
+let string_of_rounding_mode = function
+  | Half_to_even -> "half_to_even"
+  | Down -> "down"
+  | Up -> "up"
+  | Towards_zero -> "truncate"
+
 let print_addressing printreg addr ppf arg =
   match addr with
   | Ibased(s, 0) ->
@@ -175,6 +185,9 @@ let print_specific_operation printreg op ppf arg =
   | Isqrtf ->
       fprintf ppf "sqrtf %a" printreg arg.(0)
   | Ifloat_iround -> fprintf ppf "float_iround %a" printreg arg.(0)
+  | Ifloat_round mode ->
+     fprintf ppf "float_round %s %a" (string_of_rounding_mode mode)
+       printreg arg.(0)
   | Ifloat_min -> fprintf ppf "float_min %a %a" printreg arg.(0) printreg arg.(1)
   | Ifloat_max -> fprintf ppf "float_max %a %a" printreg arg.(0) printreg arg.(1)
   | Ifloatsqrtf addr ->

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -73,7 +73,7 @@ type prefetch_info = {
   addr: addressing_mode;
 }
 
-type rounding_mode = Half_to_even | Down | Up | Towards_zero
+type rounding_mode = Half_to_even | Down | Up | Towards_zero | Current
 
 type specific_operation =
     Ilea of addressing_mode             (* "lea" gives scaled adds *)
@@ -153,6 +153,7 @@ let string_of_rounding_mode = function
   | Down -> "down"
   | Up -> "up"
   | Towards_zero -> "truncate"
+  | Current -> "current"
 
 let print_addressing printreg addr ppf arg =
   match addr with

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -378,6 +378,12 @@ let cond = function
   | Iunsigned Cle -> BE  | Iunsigned Cgt -> A
   | Iunsigned Clt -> B   | Iunsigned Cge -> AE
 
+let rounding_mode = function
+  | Half_to_even -> RoundNearest
+  | Down -> RoundDown
+  | Up -> RoundUp
+  | Towards_zero -> RoundTruncate
+
 (* Output an = 0 or <> 0 test. *)
 
 let output_test_zero arg =
@@ -862,6 +868,8 @@ let emit_instr fallthrough i =
       I.sqrtsd (addressing addr REAL8 i 0) (res i 0)
   | Lop(Ispecific Ifloat_iround) ->
      I.cvtsd2si (arg i 0) (res i 0)
+  | Lop(Ispecific(Ifloat_round mode)) ->
+     I.roundsd (rounding_mode mode) (arg i 0) (res i 0)
   | Lop(Ispecific Ifloat_min) ->
      I.minsd (arg i 1) (res i 0)
   | Lop(Ispecific Ifloat_max) ->

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -383,6 +383,7 @@ let rounding_mode = function
   | Down -> RoundDown
   | Up -> RoundUp
   | Towards_zero -> RoundTruncate
+  | Current -> RoundCurrent
 
 (* Output an = 0 or <> 0 test. *)
 

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -317,6 +317,7 @@ let destroyed_at_oper = function
   | Iop(Ispecific(Isqrtf | Isextend32 | Izextend32 | Icrc32q | Ilea _
                  | Istore_int (_, _, _) | Ioffset_loc (_, _)
                  | Iprefetch _
+                 | Ifloat_round _
                  | Ifloat_iround | Ifloat_min | Ifloat_max
                  | Ifloatarithmem (_, _) | Ibswap _ | Ifloatsqrtf _))
   | Iop(Iintop(Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr
@@ -394,6 +395,7 @@ let max_register_pressure =
   | Istackoffset _ | Iload (_, _)
   | Ispecific(Ilea _ | Isextend32 | Izextend32 | Iprefetch _
              | Irdtsc | Irdpmc | Icrc32q | Istore_int (_, _, _)
+             | Ifloat_round _
              | Ifloat_iround | Ifloat_min | Ifloat_max
              | Ioffset_loc (_, _) | Ifloatarithmem (_, _)
              | Ibswap _ | Ifloatsqrtf _ | Isqrtf)
@@ -408,7 +410,7 @@ let op_is_pure = function
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
   | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Iprefetch _) -> false
-  | Ispecific(Ilea _ | Isextend32 | Izextend32 | Ifloat_iround
+  | Ispecific(Ilea _ | Isextend32 | Izextend32 | Ifloat_iround | Ifloat_round _
              | Ifloat_min | Ifloat_max) -> true
   | Ispecific(Irdtsc | Irdpmc | Icrc32q | Istore_int (_, _, _)
              | Ioffset_loc (_, _) | Ifloatarithmem (_, _)

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -53,6 +53,7 @@ open Mach
      Ispecific(Irdtsc)          R
      Ispecific(Irdpmc)          R       R           (Arg1 = rcx)
      Ispecific(Ifloat_iround)   R       S
+     Ispecific(Ifloat_round _)  R       S
      Ispecific(Ifloat_min)      R       R       S   (and Res = Arg1)
      Ispecific(Ifloat_max)      R       R       S   (and Res = Arg1)
 
@@ -93,6 +94,7 @@ method! reload_operation op arg res =
          in registers *)
       super#reload_operation op arg res
   | Ispecific Ifloat_iround
+  | Ispecific (Ifloat_round _)
   | Iintop_imm (Icomp _, _) ->
       (* The argument(s) can be either in register or on stack.
          The result must be in a register. *)
@@ -140,7 +142,7 @@ method! reload_operation op arg res =
   | Ispecific  (Isqrtf | Isextend32 | Izextend32 | Ilea _
                | Istore_int (_, _, _)
                | Ioffset_loc (_, _) | Ifloatarithmem (_, _)
-               | Iprefetch _ 
+               | Iprefetch _
                | Ibswap _| Ifloatsqrtf _)
   | Imove|Ispill|Ireload|Inegf|Iabsf|Iconst_float _|Icall_ind|Icall_imm _
   | Icompf _

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -295,6 +295,8 @@ method! select_operation op args dbg =
          Ispecific (Ifloat_round Down), args
       | "caml_float_round_towards_zero_unboxed", [|Float|] ->
          Ispecific (Ifloat_round Towards_zero), args
+      | "caml_float_round_current_unboxed", [|Float|] ->
+         Ispecific (Ifloat_round Current), args
       | "caml_float_min_unboxed", [|Float|] ->
          Ispecific Ifloat_min, args
       | "caml_float_max_unboxed", [|Float|] ->

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -148,7 +148,7 @@ let pseudoregs_for_operation op arg res =
   | Iintop_imm ((Imulh|Idiv|Imod|Icomp _|Icheckbound
                 |Ipopcnt|Iclz _|Ictz _), _)
   | Ispecific (Isqrtf|Isextend32|Izextend32|Ilea _|Istore_int (_, _, _)
-              |Ifloat_iround
+              |Ifloat_iround|Ifloat_round _
               |Ioffset_loc (_, _)|Ifloatsqrtf _|Irdtsc|Iprefetch _)
   | Imove|Ispill|Ireload|Ifloatofint|Iintoffloat|Iconst_int _|Iconst_float _
   | Iconst_symbol _|Icall_ind|Icall_imm _|Itailcall_ind|Itailcall_imm _
@@ -287,6 +287,14 @@ method! select_operation op args dbg =
           Ispecific Icrc32q, args
       | "caml_float_iround_half_to_even_unboxed", [|Int|] ->
          Ispecific Ifloat_iround, args
+      | "caml_float_round_half_to_even_unboxed", [|Float|] ->
+         Ispecific (Ifloat_round Half_to_even), args
+      | "caml_float_round_up_unboxed", [|Float|] ->
+         Ispecific (Ifloat_round Up), args
+      | "caml_float_round_down_unboxed", [|Float|] ->
+         Ispecific (Ifloat_round Down), args
+      | "caml_float_round_towards_zero_unboxed", [|Float|] ->
+         Ispecific (Ifloat_round Towards_zero), args
       | "caml_float_min_unboxed", [|Float|] ->
          Ispecific Ifloat_min, args
       | "caml_float_max_unboxed", [|Float|] ->

--- a/backend/x86_ast.mli
+++ b/backend/x86_ast.mli
@@ -40,6 +40,7 @@ type rounding =
   | RoundDown
   | RoundNearest
   | RoundTruncate
+  | RoundCurrent
 
 type constant =
   | Const of int64

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -202,6 +202,7 @@ module I = struct
   let rdtsc () = emit (RDTSC)
   let rdpmc () = emit (RDPMC)
   let ret () = emit RET
+  let roundsd r x y = emit (ROUNDSD (r, x, y))
   let sal x y = emit (SAL (x, y))
   let sar x y = emit (SAR (x, y))
   let set cond x = emit (SET (cond, x))

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -195,6 +195,7 @@ module I : sig
   val rdtsc: unit -> unit
   val rdpmc: unit -> unit
   val ret: unit -> unit
+  val roundsd : rounding -> arg -> arg -> unit
   val sal: arg -> arg -> unit
   val sar: arg -> arg -> unit
   val set: condition -> arg -> unit

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -107,6 +107,7 @@ let i1_s b s x = bprintf b "\t%s%s\t%a" s (suf x) arg x
 let i2 b s x y = bprintf b "\t%s\t%a, %a" s arg x arg y
 let i2_s b s x y = bprintf b "\t%s%s\t%a, %a" s (suf y) arg x arg y
 let i2_ss b s x y = bprintf b "\t%s%s%s\t%a, %a" s (suf x) (suf y) arg x arg y
+let i3 b s x y z = bprintf b "\t%s\t%a, %a, %a" s arg x arg y arg z
 
 let i1_call_jmp b s = function
   (* this is the encoding of jump labels: don't use * *)
@@ -223,7 +224,7 @@ let print_instr b = function
   | RDTSC -> i0 b "rdtsc"
   | RDPMC -> i0 b "rdpmc"
   | RET ->  i0 b "ret"
-  | ROUNDSD (r, arg1, arg2) -> i2 b (string_of_rounding r) arg1 arg2
+  | ROUNDSD (r, arg1, arg2) -> i3 b "roundsd" (imm_of_rounding r) arg1 arg2
   | SAL (arg1, arg2) -> i2_s b "sal" arg1 arg2
   | SAR (arg1, arg2) -> i2_s b "sar" arg1 arg2
   | SET (c, arg) -> i1 b ("set" ^ string_of_condition c) arg

--- a/backend/x86_masm.ml
+++ b/backend/x86_masm.ml
@@ -109,6 +109,7 @@ and scst b = function
 let i0 b s = bprintf b "\t%s" s
 let i1 b s x = bprintf b "\t%s\t%a" s arg x
 let i2 b s x y = bprintf b "\t%s\t%a, %a" s arg y arg x
+let i3 b s x y z = bprintf b "\t%s\t%a, %a, %a" s arg x arg y arg z
 
 let i1_call_jmp b s = function
   | Sym x -> bprintf b "\t%s\t%s" s x
@@ -215,7 +216,7 @@ let print_instr b = function
   | RDTSC  -> i0 b "rdtsc"
   | RDPMC -> i0 b "rdpmc"
   | RET -> i0 b "ret"
-  | ROUNDSD (r, arg1, arg2) -> i2 b (string_of_rounding r) arg1 arg2
+  | ROUNDSD (r, arg1, arg2) -> i3 b "roundsd" (imm_of_rounding r) arg1 arg2
   | SAL (arg1, arg2) -> i2 b "sal" arg1 arg2
   | SAR (arg1, arg2) -> i2 b "sar" arg1 arg2
   | SET (c, arg) -> i1 b ("set" ^ string_of_condition c) arg

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -235,6 +235,12 @@ let string_of_rounding = function
   | RoundTruncate -> "roundsd.trunc"
   | RoundNearest -> "roundsd.near"
 
+let imm_of_rounding = function
+  | RoundNearest -> Imm 8L
+  | RoundDown -> Imm 9L
+  | RoundUp -> Imm 10L
+  | RoundTruncate -> Imm 11L
+
 let internal_assembler = ref None
 let register_internal_assembler f = internal_assembler := Some f
 

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -234,6 +234,7 @@ let string_of_rounding = function
   | RoundUp -> "roundsd.up"
   | RoundTruncate -> "roundsd.trunc"
   | RoundNearest -> "roundsd.near"
+  | RoundCurrent -> "roundsd"
 
 (* Control fields for [roundsd] operation is specified as a 4-bit immediate:
    bit 3: whether to signal Precision Floating-Point Exception.
@@ -245,6 +246,7 @@ let imm_of_rounding = function
   | RoundDown -> Imm 9L
   | RoundUp -> Imm 10L
   | RoundTruncate -> Imm 11L
+  | RoundCurrent -> Imm 12L
 
 let internal_assembler = ref None
 let register_internal_assembler f = internal_assembler := Some f

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -235,6 +235,11 @@ let string_of_rounding = function
   | RoundTruncate -> "roundsd.trunc"
   | RoundNearest -> "roundsd.near"
 
+(* Control fields for [roundsd] operation is specified as a 4-bit immediate:
+   bit 3: whether to signal Precision Floating-Point Exception.
+   bit 2: if set, select rounding mode from MXCSR.RC, else use bits 0 and 1.
+   bits 0 and 1: rounding mode, according to  Table 4-17 of
+   Intel® 64 and IA-32 Architectures Software Developer’s Manual Volume 2. *)
 let imm_of_rounding = function
   | RoundNearest -> Imm 8L
   | RoundDown -> Imm 9L

--- a/backend/x86_proc.mli
+++ b/backend/x86_proc.mli
@@ -31,6 +31,7 @@ val string_of_condition: condition -> string
 val string_of_float_condition: float_condition -> string
 val string_of_symbol: (*prefix*) string -> string -> string
 val string_of_rounding: rounding -> string
+val imm_of_rounding: rounding -> arg
 val string_of_prefetch_temporal_locality_hint:
   prefetch_temporal_locality_hint -> string
 val buf_bytes_directive:


### PR DESCRIPTION
Can be used to implement `Base.Float.round` and `Stdlib.Float.{floor,ceil,trunc}` . 
It requires sse4.1, do we need a flag to disable it at compiler/configure time?

By the way, there was already some support for this instruction in `x86_gas.ml` but it appears to be unused and I couldn't convince `gas` to accept its syntax, so I had to change it.