### PR TITLE
shorter NaN comparisons

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -398,12 +398,18 @@ let emit_float_test cmp i lbl =
      comisd traps on QNaN and SNaN but ucomisd traps on SNaN only.
   *)
   match cmp with
+  | CFeq when arg i 1 = arg i 0 ->
+      I.ucomisd (arg i 1) (arg i 0);
+      I.j NP lbl
   | CFeq ->
       let next = new_label() in
       I.ucomisd (arg i 1) (arg i 0);
       I.jp (label next);          (* skip if unordered *)
       I.je lbl;                   (* branch taken if x=y *)
       def_label next
+  | CFneq when arg i 1 = arg i 0 ->
+      I.ucomisd (arg i 1) (arg i 0);
+      I.jp lbl
   | CFneq ->
       I.ucomisd (arg i 1) (arg i 0);
       I.jp lbl;                   (* branch taken if unordered *)


### PR DESCRIPTION
When we compare floats for equality, we only need to check if they are unordered if both arguments to the comparison are the same -- so we save one branch on amd64