### PR TITLE
Float operations with constants on amd64

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -33,6 +33,7 @@ method! class_of_operation op =
     | Istore_int(_, _, is_asg) -> Op_store is_asg
     | Ioffset_loc(_, _) -> Op_store true
     | Ifloatarithmem _ | Ifloatsqrtf _ -> Op_load
+    | Ifloatarithconst _ -> Op_pure
     | Ibswap _ | Isqrtf -> super#class_of_operation op
     | Irdtsc | Irdpmc -> Op_other
     | Ifloat_iround | Ifloat_min | Ifloat_max | Ifloat_round _

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -364,7 +364,7 @@ let instr_for_floatop = function
   | Idivf -> I.divsd
   | _ -> assert false
 
-let instr_for_floatarithmem = function
+let instr_for_floatarith = function
   | Ifloatadd -> I.addsd
   | Ifloatsub -> I.subsd
   | Ifloatmul -> I.mulsd
@@ -855,7 +855,10 @@ let emit_instr fallthrough i =
   | Lop(Ispecific(Ioffset_loc(n, addr))) ->
       I.add (int n) (addressing addr QWORD i 0)
   | Lop(Ispecific(Ifloatarithmem(op, addr))) ->
-      instr_for_floatarithmem op (addressing addr REAL8 i 1) (res i 0)
+      instr_for_floatarith op (addressing addr REAL8 i 1) (res i 0)
+  | Lop(Ispecific(Ifloatarithconst(op, f))) ->
+      let lbl = add_float_constant f in
+      instr_for_floatarith op (mem64_rip NONE (emit_label lbl)) (res i 0)
   | Lop(Ispecific(Ibswap 16)) ->
       I.xchg ah al;
       I.movzx (res16 i 0) (res i 0)

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -319,7 +319,8 @@ let destroyed_at_oper = function
                  | Iprefetch _
                  | Ifloat_round _
                  | Ifloat_iround | Ifloat_min | Ifloat_max
-                 | Ifloatarithmem (_, _) | Ibswap _ | Ifloatsqrtf _))
+                 | Ifloatarithmem (_, _) | Ibswap _ | Ifloatsqrtf _
+                 | Ifloatarithconst _))
   | Iop(Iintop(Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr
               | Ipopcnt | Iclz _ | Ictz _ | Icheckbound))
   | Iop(Iintop_imm((Iadd | Isub | Imul | Imulh | Iand | Ior | Ixor | Ilsl
@@ -398,7 +399,7 @@ let max_register_pressure =
              | Ifloat_round _
              | Ifloat_iround | Ifloat_min | Ifloat_max
              | Ioffset_loc (_, _) | Ifloatarithmem (_, _)
-             | Ibswap _ | Ifloatsqrtf _ | Isqrtf)
+             | Ibswap _ | Ifloatsqrtf _ | Isqrtf | Ifloatarithconst _)
   | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _ | Iopaque
     -> consumes ~int:0 ~float:0
 
@@ -411,7 +412,7 @@ let op_is_pure = function
   | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Iprefetch _) -> false
   | Ispecific(Ilea _ | Isextend32 | Izextend32 | Ifloat_iround | Ifloat_round _
-             | Ifloat_min | Ifloat_max) -> true
+             | Ifloat_min | Ifloat_max | Ifloatarithconst _) -> true
   | Ispecific(Irdtsc | Irdpmc | Icrc32q | Istore_int (_, _, _)
              | Ioffset_loc (_, _) | Ifloatarithmem (_, _)
              | Ibswap _ | Ifloatsqrtf _ | Isqrtf)-> false

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -143,7 +143,7 @@ method! reload_operation op arg res =
                | Istore_int (_, _, _)
                | Ioffset_loc (_, _) | Ifloatarithmem (_, _)
                | Iprefetch _
-               | Ibswap _| Ifloatsqrtf _)
+               | Ibswap _| Ifloatsqrtf _ | Ifloatarithconst _)
   | Imove|Ispill|Ireload|Inegf|Iabsf|Iconst_float _|Icall_ind|Icall_imm _
   | Icompf _
   | Itailcall_ind|Itailcall_imm _|Iextcall _|Istackoffset _|Iload (_, _)


### PR DESCRIPTION
Since float constants are just memory locations, we don't need to load them into registers if we immediately operate on them -- so we mirror the Floatarithmem operation.

(Note: because I'm terrible with the github interface, this was originally not marked as a draft, so it has requested review)