### PR TITLE
Revert #293 and simplify the explicit case analysis

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -286,6 +286,9 @@ let equal_specific_operation left right =
     true
   | Icrc32q, Icrc32q ->
     true
+  | Ifloat_iround, Ifloat_iround -> true
+  | Ifloat_min, Ifloat_min -> true
+  | Ifloat_max, Ifloat_max -> true
   | Iprefetch { is_write = left_is_write; locality = left_locality; addr = left_addr; },
     Iprefetch { is_write = right_is_write; locality = right_locality; addr = right_addr; } ->
     Bool.equal left_is_write right_is_write
@@ -293,5 +296,6 @@ let equal_specific_operation left right =
     && equal_addressing_mode left_addr right_addr
   | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
     | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc
+    | Ifloat_iround | Ifloat_min | Ifloat_max
     | Icrc32q | Iprefetch _), _ ->
     false

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -242,11 +242,7 @@ let equal_addressing_mode left right =
     Int.equal left_scale right_scale && Int.equal left_displ right_displ
   | Iindexed2scaled (left_scale, left_displ), Iindexed2scaled (right_scale, right_displ) ->
     Int.equal left_scale right_scale && Int.equal left_displ right_displ
-  | Ibased _,  (Iindexed _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _)
-  | Iindexed _, (Ibased _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _)
-  | Iindexed2 _, (Ibased _  | Iindexed _ | Iscaled _ | Iindexed2scaled _)
-  | Iscaled _, (Ibased _  | Iindexed _ | Iindexed2 _ | Iindexed2scaled _)
-  | Iindexed2scaled _, (Ibased _ | Iindexed _ | Iindexed2 _ | Iscaled _) ->
+  | (Ibased _ | Iindexed _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _), _ ->
     false
 
 let equal_prefetch_temporal_locality_hint left right =
@@ -255,11 +251,7 @@ let equal_prefetch_temporal_locality_hint left right =
   | Low, Low -> true
   | Moderate, Moderate -> true
   | High, High -> true
-  | Nonlocal, (Low | Moderate | High)
-  | Low, (Nonlocal | Moderate | High)
-  | Moderate, (Nonlocal | Low | High)
-  | High, (Nonlocal | Low | Moderate) ->
-    false
+  | (Nonlocal | Low | Moderate | High), _ -> false
 
 let equal_float_operation left right =
   match left, right with
@@ -267,11 +259,7 @@ let equal_float_operation left right =
   | Ifloatsub, Ifloatsub -> true
   | Ifloatmul, Ifloatmul -> true
   | Ifloatdiv, Ifloatdiv -> true
-  | Ifloatadd, (Ifloatsub | Ifloatmul | Ifloatdiv)
-  | Ifloatsub, (Ifloatadd | Ifloatmul | Ifloatdiv)
-  | Ifloatmul, (Ifloatadd | Ifloatsub | Ifloatdiv)
-  | Ifloatdiv, (Ifloatadd | Ifloatsub | Ifloatmul) ->
-    false
+  | (Ifloatadd | Ifloatsub | Ifloatmul | Ifloatdiv), _ -> false
 
 let equal_specific_operation left right =
   match left, right with
@@ -303,43 +291,7 @@ let equal_specific_operation left right =
     Bool.equal left_is_write right_is_write
     && equal_prefetch_temporal_locality_hint left_locality right_locality
     && equal_addressing_mode left_addr right_addr
-  | Ilea _, (Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ | Isqrtf
-            | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
-            | Iprefetch _)
-  | Istore_int _, (Ilea _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ | Isqrtf
-                  | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
-                  | Iprefetch _)
-  | Ioffset_loc _, (Ilea _ | Istore_int _ | Ifloatarithmem _ | Ibswap _ | Isqrtf
-                   | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
-                   | Iprefetch _)
-  | Ifloatarithmem _, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ibswap _ | Isqrtf
-                      | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
-                      | Iprefetch _)
-  | Ibswap _, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Isqrtf
-              | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
-              | Iprefetch _)
-  | Isqrtf, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
-            | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
-            | Iprefetch _)
-  | Ifloatsqrtf _, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ |
-                    Ibswap _ | Isqrtf | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
-                   | Iprefetch _)
-  | Isextend32, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
-                | Isqrtf | Ifloatsqrtf _ | Izextend32 | Irdtsc | Irdpmc | Icrc32q
-                | Iprefetch _)
-  | Izextend32, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
-                | Isqrtf | Ifloatsqrtf _ | Isextend32 | Irdtsc | Irdpmc | Icrc32q
-                | Iprefetch _)
-  | Irdtsc, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
-            | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdpmc | Icrc32q
-            | Iprefetch _)
-  | Irdpmc, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
-            | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Icrc32q
-            | Iprefetch _)
-  | Icrc32q, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
-             | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc
-             | Iprefetch _)
-  | Iprefetch _, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
-                 | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc
-                 | Icrc32q) ->
+  | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+    | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc
+    | Icrc32q | Iprefetch _), _ ->
     false

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -229,5 +229,117 @@ let float_cond_and_need_swap cond =
   | CFge  -> LEf,  true
   | CFnge -> NLEf, true
 
-let equal_addressing_mode left right = left = right
-let equal_specific_operation left right = left = right
+
+let equal_addressing_mode left right =
+  match left, right with
+  | Ibased (left_sym, left_displ), Ibased (right_sym, right_displ) ->
+    String.equal left_sym right_sym && Int.equal left_displ right_displ
+  | Iindexed left_displ, Iindexed right_displ ->
+    Int.equal left_displ right_displ
+  | Iindexed2 left_displ, Iindexed2 right_displ ->
+    Int.equal left_displ right_displ
+  | Iscaled (left_scale, left_displ), Iscaled (right_scale, right_displ) ->
+    Int.equal left_scale right_scale && Int.equal left_displ right_displ
+  | Iindexed2scaled (left_scale, left_displ), Iindexed2scaled (right_scale, right_displ) ->
+    Int.equal left_scale right_scale && Int.equal left_displ right_displ
+  | Ibased _,  (Iindexed _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _)
+  | Iindexed _, (Ibased _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _)
+  | Iindexed2 _, (Ibased _  | Iindexed _ | Iscaled _ | Iindexed2scaled _)
+  | Iscaled _, (Ibased _  | Iindexed _ | Iindexed2 _ | Iindexed2scaled _)
+  | Iindexed2scaled _, (Ibased _ | Iindexed _ | Iindexed2 _ | Iscaled _) ->
+    false
+
+let equal_prefetch_temporal_locality_hint left right =
+  match left, right with
+  | Nonlocal, Nonlocal -> true
+  | Low, Low -> true
+  | Moderate, Moderate -> true
+  | High, High -> true
+  | Nonlocal, (Low | Moderate | High)
+  | Low, (Nonlocal | Moderate | High)
+  | Moderate, (Nonlocal | Low | High)
+  | High, (Nonlocal | Low | Moderate) ->
+    false
+
+let equal_float_operation left right =
+  match left, right with
+  | Ifloatadd, Ifloatadd -> true
+  | Ifloatsub, Ifloatsub -> true
+  | Ifloatmul, Ifloatmul -> true
+  | Ifloatdiv, Ifloatdiv -> true
+  | Ifloatadd, (Ifloatsub | Ifloatmul | Ifloatdiv)
+  | Ifloatsub, (Ifloatadd | Ifloatmul | Ifloatdiv)
+  | Ifloatmul, (Ifloatadd | Ifloatsub | Ifloatdiv)
+  | Ifloatdiv, (Ifloatadd | Ifloatsub | Ifloatmul) ->
+    false
+
+let equal_specific_operation left right =
+  match left, right with
+  | Ilea x, Ilea y -> equal_addressing_mode x y
+  | Istore_int (x, x', x''), Istore_int (y, y', y'') ->
+    Nativeint.equal x y && equal_addressing_mode x' y' && Bool.equal x'' y''
+  | Ioffset_loc (x, x'), Ioffset_loc (y, y') ->
+    Int.equal x y && equal_addressing_mode x' y'
+  | Ifloatarithmem (x, x'), Ifloatarithmem (y, y') ->
+    equal_float_operation x y && equal_addressing_mode x' y'
+  | Ibswap left, Ibswap right ->
+    Int.equal left right
+  | Isqrtf, Isqrtf ->
+    true
+  | Ifloatsqrtf left, Ifloatsqrtf right ->
+    equal_addressing_mode left right
+  | Isextend32, Isextend32 ->
+    true
+  | Izextend32, Izextend32 ->
+    true
+  | Irdtsc, Irdtsc ->
+    true
+  | Irdpmc, Irdpmc ->
+    true
+  | Icrc32q, Icrc32q ->
+    true
+  | Iprefetch { is_write = left_is_write; locality = left_locality; addr = left_addr; },
+    Iprefetch { is_write = right_is_write; locality = right_locality; addr = right_addr; } ->
+    Bool.equal left_is_write right_is_write
+    && equal_prefetch_temporal_locality_hint left_locality right_locality
+    && equal_addressing_mode left_addr right_addr
+  | Ilea _, (Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ | Isqrtf
+            | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
+            | Iprefetch _)
+  | Istore_int _, (Ilea _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ | Isqrtf
+                  | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
+                  | Iprefetch _)
+  | Ioffset_loc _, (Ilea _ | Istore_int _ | Ifloatarithmem _ | Ibswap _ | Isqrtf
+                   | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
+                   | Iprefetch _)
+  | Ifloatarithmem _, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ibswap _ | Isqrtf
+                      | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
+                      | Iprefetch _)
+  | Ibswap _, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Isqrtf
+              | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
+              | Iprefetch _)
+  | Isqrtf, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+            | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
+            | Iprefetch _)
+  | Ifloatsqrtf _, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ |
+                    Ibswap _ | Isqrtf | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Icrc32q
+                   | Iprefetch _)
+  | Isextend32, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+                | Isqrtf | Ifloatsqrtf _ | Izextend32 | Irdtsc | Irdpmc | Icrc32q
+                | Iprefetch _)
+  | Izextend32, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+                | Isqrtf | Ifloatsqrtf _ | Isextend32 | Irdtsc | Irdpmc | Icrc32q
+                | Iprefetch _)
+  | Irdtsc, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+            | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdpmc | Icrc32q
+            | Iprefetch _)
+  | Irdpmc, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+            | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Icrc32q
+            | Iprefetch _)
+  | Icrc32q, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+             | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc
+             | Iprefetch _)
+  | Iprefetch _, (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
+                 | Isqrtf | Ifloatsqrtf _ | Isextend32 | Izextend32 | Irdtsc | Irdpmc
+                 | Icrc32q) ->
+    false

--- a/backend/arm/arch.ml
+++ b/backend/arm/arch.ml
@@ -268,12 +268,6 @@ let equal_addressing_mode left right =
   match left, right with
   | Iindexed left, Iindexed right -> Int.equal left right
 
-let equal_prefetch_temporal_locality_hint _ _ : bool =
-  assert false
-
-let equal_float_operation _ _ : bool =
-  assert false
-
 let equal_arith_operation left right =
   match left, right with
   | Ishiftadd, Ishiftadd -> true
@@ -282,12 +276,8 @@ let equal_arith_operation left right =
   | Ishiftand, Ishiftand -> true
   | Ishiftor, Ishiftor -> true
   | Ishiftxor, Ishiftxor -> true
-  | Ishiftadd, (Ishiftsub | Ishiftsubrev | Ishiftand | Ishiftor | Ishiftxor)
-  | Ishiftsub, (Ishiftadd | Ishiftsubrev | Ishiftand | Ishiftor | Ishiftxor)
-  | Ishiftsubrev, (Ishiftadd | Ishiftsub | Ishiftand | Ishiftor | Ishiftxor)
-  | Ishiftand, (Ishiftadd | Ishiftsub | Ishiftsubrev | Ishiftor | Ishiftxor)
-  | Ishiftor, (Ishiftadd | Ishiftsub | Ishiftsubrev | Ishiftand | Ishiftxor)
-  | Ishiftxor, (Ishiftadd | Ishiftsub | Ishiftsubrev | Ishiftand | Ishiftor) ->
+  | (Ishiftadd | Ishiftsub | Ishiftsubrev
+    | Ishiftand | Ishiftor | Ishiftxor), _ ->
     false
 
 let equal_shift_operation left right =
@@ -295,9 +285,7 @@ let equal_shift_operation left right =
   | Ishiftlogicalleft, Ishiftlogicalleft -> true
   | Ishiftlogicalright, Ishiftlogicalright -> true
   | Ishiftarithmeticright, Ishiftarithmeticright -> true
-  | Ishiftlogicalleft, (Ishiftlogicalright | Ishiftarithmeticright)
-  | Ishiftlogicalright, (Ishiftlogicalleft | Ishiftarithmeticright)
-  | Ishiftarithmeticright, (Ishiftlogicalleft | Ishiftlogicalright) ->
+  | (Ishiftlogicalleft | Ishiftlogicalright | Ishiftarithmeticright), _ ->
     false
 
 let equal_specific_operation left right =
@@ -322,17 +310,6 @@ let equal_specific_operation left right =
   | Inegmulsubf, Inegmulsubf -> true
   | Isqrtf, Isqrtf -> true
   | Ibswap left, Ibswap right -> Int.equal left right
-  | Ishiftarith _, (Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Ishiftcheckbound _, (Ishiftarith _ | Irevsubimm _ | Imulhadd | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Irevsubimm _, (Ishiftarith _ | Ishiftcheckbound _ | Imulhadd | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Imulhadd, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Imuladd, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Imulsub, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Inegmulf, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd | Imulsub | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Imuladdf, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd | Imulsub | Inegmulf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Inegmuladdf, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd | Imulsub | Inegmulf | Imuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Imulsubf, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Inegmulsubf | Isqrtf | Ibswap _)
-  | Inegmulsubf, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Isqrtf | Ibswap _)
-  | Isqrtf, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Ibswap _)
-  | Ibswap _, (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf) ->
-    false
+  | (Ishiftarith _ | Ishiftcheckbound _ | Irevsubimm _ | Imulhadd | Imuladd
+    | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf
+    | Isqrtf | Ibswap _), _ -> false

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -170,5 +170,116 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "move32 %a"
         printreg arg.(0)
 
-let equal_addressing_mode left right = left = right
-let equal_specific_operation left right = left = right
+let equal_addressing_mode left right =
+  match left, right with
+  | Iindexed left_int, Iindexed right_int ->
+    Int.equal left_int right_int
+  | Ibased (left_string, left_int), Ibased (right_string, right_int) ->
+    String.equal left_string right_string
+    && Int.equal left_int right_int
+  | Iindexed _, Ibased _
+  | Ibased _, Iindexed _ ->
+    false
+
+let equal_prefetch_temporal_locality_hint _ _ : bool =
+  assert false
+
+let equal_float_operation _ _ : bool =
+  assert false
+
+let equal_arith_operation left right =
+  match left, right with
+  | Ishiftadd, Ishiftadd -> true
+  | Ishiftsub, Ishiftsub -> true
+  | Ishiftadd, Ishiftsub
+  | Ishiftsub, Ishiftadd ->
+    false
+
+let equal_specific_operation left right =
+  match left, right with
+  | Ifar_alloc { bytes = left_bytes; dbginfo = _; },
+    Ifar_alloc { bytes = right_bytes; dbginfo = _; } ->
+    Int.equal left_bytes right_bytes
+  | Ifar_intop_checkbound, Ifar_intop_checkbound -> true
+  | Ifar_intop_imm_checkbound { bound = left_bound; },
+    Ifar_intop_imm_checkbound { bound = right_bound; } ->
+    Int.equal left_bound right_bound
+  | Ishiftarith (left_arith_operation, left_int),
+    Ishiftarith (right_arith_operation, right_int) ->
+    equal_arith_operation left_arith_operation right_arith_operation
+    && Int.equal left_int right_int
+  | Ishiftcheckbound { shift = left_shift; },
+    Ishiftcheckbound { shift = right_shift; } ->
+    Int.equal left_shift right_shift
+  | Ifar_shiftcheckbound { shift = left_shift; },
+    Ifar_shiftcheckbound { shift = right_shift; } ->
+    Int.equal left_shift right_shift
+  | Imuladd, Imuladd -> true
+  | Imulsub, Imulsub -> true
+  | Inegmulf, Inegmulf -> true
+  | Imuladdf, Imuladdf -> true
+  | Inegmuladdf, Inegmuladdf -> true
+  | Imulsubf, Imulsubf -> true
+  | Inegmulsubf, Inegmulsubf -> true
+  | Isqrtf, Isqrtf -> true
+  | Ibswap left_int, Ibswap right_int -> Int.equal left_int right_int
+  | Imove32, Imove32 -> true
+  | Ifar_alloc _, (Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
+                  | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub
+                  | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf
+                  | Ibswap _ | Imove32)
+  | Ifar_intop_checkbound, (Ifar_alloc _ | Ifar_intop_imm_checkbound _ | Ishiftarith _
+                           | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
+                           | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
+                           | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
+  | Ifar_intop_imm_checkbound _, (Ifar_alloc _ | Ifar_intop_checkbound | Ishiftarith _
+                                 | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
+                                 | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
+                                 | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
+  | Ishiftarith _, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
+                   | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub
+                   | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf
+                   | Ibswap _ | Imove32)
+  | Ishiftcheckbound _, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
+                        | Ishiftarith _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub
+                        | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf
+                        | Isqrtf | Ibswap _ | Imove32)
+  | Ifar_shiftcheckbound _, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
+                            | Ishiftarith _ | Ishiftcheckbound _ | Imuladd | Imulsub
+                            | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf
+                            | Isqrtf | Ibswap _ | Imove32)
+  | Imuladd, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
+             | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imulsub | Inegmulf | Imuladdf
+             | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
+  | Imulsub, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
+             | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Inegmulf | Imuladdf
+             | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
+  | Inegmulf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
+              | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub | Imuladdf
+              | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
+  | Imuladdf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ |
+               Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
+              | Imulsub | Inegmulf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf
+              | Ibswap _ | Imove32)
+  | Inegmuladdf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
+                 | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
+                 | Imulsub | Inegmulf | Imuladdf | Imulsubf | Inegmulsubf | Isqrtf
+                 | Ibswap _ | Imove32)
+  | Imulsubf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
+              | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
+              | Imulsub | Inegmulf | Imuladdf | Inegmuladdf  | Inegmulsubf | Isqrtf
+              | Ibswap _ | Imove32)
+  | Inegmulsubf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
+                 | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
+                 | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Isqrtf | Ibswap _
+                 | Imove32)
+  | Isqrtf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
+            | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub | Inegmulf
+            | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Ibswap _ | Imove32)
+  | Ibswap _, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
+              | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub | Inegmulf
+              | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Imove32)
+  | Imove32, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
+             | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub | Inegmulf
+             | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _) ->
+    false

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -177,23 +177,13 @@ let equal_addressing_mode left right =
   | Ibased (left_string, left_int), Ibased (right_string, right_int) ->
     String.equal left_string right_string
     && Int.equal left_int right_int
-  | Iindexed _, Ibased _
-  | Ibased _, Iindexed _ ->
-    false
-
-let equal_prefetch_temporal_locality_hint _ _ : bool =
-  assert false
-
-let equal_float_operation _ _ : bool =
-  assert false
+  | (Iindexed _ | Ibased _), _ -> false
 
 let equal_arith_operation left right =
   match left, right with
   | Ishiftadd, Ishiftadd -> true
   | Ishiftsub, Ishiftsub -> true
-  | Ishiftadd, Ishiftsub
-  | Ishiftsub, Ishiftadd ->
-    false
+  | (Ishiftadd | Ishiftsub), _ -> false
 
 let equal_specific_operation left right =
   match left, right with
@@ -224,62 +214,8 @@ let equal_specific_operation left right =
   | Isqrtf, Isqrtf -> true
   | Ibswap left_int, Ibswap right_int -> Int.equal left_int right_int
   | Imove32, Imove32 -> true
-  | Ifar_alloc _, (Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
-                  | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub
-                  | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf
-                  | Ibswap _ | Imove32)
-  | Ifar_intop_checkbound, (Ifar_alloc _ | Ifar_intop_imm_checkbound _ | Ishiftarith _
-                           | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
-                           | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
-                           | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
-  | Ifar_intop_imm_checkbound _, (Ifar_alloc _ | Ifar_intop_checkbound | Ishiftarith _
-                                 | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
-                                 | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
-                                 | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
-  | Ishiftarith _, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
-                   | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub
-                   | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf
-                   | Ibswap _ | Imove32)
-  | Ishiftcheckbound _, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
-                        | Ishiftarith _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub
-                        | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf
-                        | Isqrtf | Ibswap _ | Imove32)
-  | Ifar_shiftcheckbound _, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
-                            | Ishiftarith _ | Ishiftcheckbound _ | Imuladd | Imulsub
-                            | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf
-                            | Isqrtf | Ibswap _ | Imove32)
-  | Imuladd, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
-             | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imulsub | Inegmulf | Imuladdf
-             | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
-  | Imulsub, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
-             | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Inegmulf | Imuladdf
-             | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
-  | Inegmulf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
-              | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub | Imuladdf
-              | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _ | Imove32)
-  | Imuladdf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ |
-               Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
-              | Imulsub | Inegmulf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf
-              | Ibswap _ | Imove32)
-  | Inegmuladdf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
-                 | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
-                 | Imulsub | Inegmulf | Imuladdf | Imulsubf | Inegmulsubf | Isqrtf
-                 | Ibswap _ | Imove32)
-  | Imulsubf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
-              | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
-              | Imulsub | Inegmulf | Imuladdf | Inegmuladdf  | Inegmulsubf | Isqrtf
-              | Ibswap _ | Imove32)
-  | Inegmulsubf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
-                 | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd
-                 | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf | Isqrtf | Ibswap _
-                 | Imove32)
-  | Isqrtf, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
-            | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub | Inegmulf
-            | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Ibswap _ | Imove32)
-  | Ibswap _, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
-              | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub | Inegmulf
-              | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Imove32)
-  | Imove32, (Ifar_alloc _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _ | Ishiftarith _
-             | Ishiftcheckbound _ | Ifar_shiftcheckbound _ | Imuladd | Imulsub | Inegmulf
-             | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _) ->
-    false
+  | (Ifar_alloc _  | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
+    | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _
+    | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
+    | Inegmulsubf | Isqrtf | Ibswap _ | Imove32), _ -> false
+

--- a/backend/i386/arch.ml
+++ b/backend/i386/arch.ml
@@ -164,5 +164,8 @@ let stack_alignment =
   | _ -> 16
   (* PR#6038: GCC and Clang seem to require 16-byte alignment nowadays *)
 
-let equal_addressing_mode left right = left = right
-let equal_specific_operation left right = left = right
+(* CR xclerc for xclerc: TODO *)
+let equal_addressing_mode _ _ : bool = assert false
+let equal_prefetch_temporal_locality_hint _ _ : bool = assert false
+let equal_float_operation _ _ : bool = assert false
+let equal_specific_operation _ _ : bool = assert false

--- a/backend/i386/arch.ml
+++ b/backend/i386/arch.ml
@@ -164,8 +164,54 @@ let stack_alignment =
   | _ -> 16
   (* PR#6038: GCC and Clang seem to require 16-byte alignment nowadays *)
 
-(* CR xclerc for xclerc: TODO *)
-let equal_addressing_mode _ _ : bool = assert false
-let equal_prefetch_temporal_locality_hint _ _ : bool = assert false
-let equal_float_operation _ _ : bool = assert false
-let equal_specific_operation _ _ : bool = assert false
+let equal_addressing_mode left right =
+  match left, right with
+  | Ibased (left_sym, left_displ), Ibased (right_sym, right_displ) ->
+    String.equal left_sym right_sym && Int.equal left_displ right_displ
+  | Iindexed left_displ, Iindexed right_displ ->
+    Int.equal left_displ right_displ
+  | Iindexed2 left_displ, Iindexed2 right_displ ->
+    Int.equal left_displ right_displ
+  | Iscaled (left_scale, left_displ), Iscaled (right_scale, right_displ) ->
+    Int.equal left_scale right_scale && Int.equal left_displ right_displ
+  | Iindexed2scaled (left_scale, left_displ), Iindexed2scaled (right_scale, right_displ) ->
+    Int.equal left_scale right_scale && Int.equal left_displ right_displ
+  | (Ibased _ | Iindexed _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _), _ ->
+    false
+
+let equal_float_operation left right =
+  match left, right with
+  | Ifloatadd, Ifloatadd -> true
+  | Ifloatsub, Ifloatsub -> true
+  | Ifloatsubrev, Ifloatsubrev -> true
+  | Ifloatmul, Ifloatmul -> true
+  | Ifloatdiv, Ifloatdiv -> true
+  | Ifloatdivrev, Ifloatdivrev -> true
+  | (Ifloatadd | Ifloatsub | Ifloatsubrev
+    | Ifloatmul | Ifloatdiv | Ifloatdivrev), _ ->
+    false
+
+let equal_specific_operation left right =
+  match left, right with
+  | Ilea x, Ilea y -> equal_addressing_mode x y
+  | Istore_int (x, x', x''), Istore_int (y, y', y'') ->
+    Nativeint.equal x y && equal_addressing_mode x' y' && Bool.equal x'' y''
+  | Istore_symbol (x, x', x''), Istore_symbol (y, y', y'') ->
+    String.equal x y && equal_addressing_mode x' y' && Bool.equal x'' y''
+  | Ioffset_loc (x, x'), Ioffset_loc (y, y') ->
+    Int.equal x y && equal_addressing_mode x' y'
+  | Ipush, Ipush -> true
+  | Ipush_int x, Ipush_int y -> Nativeint.equal x y
+  | Ipush_symbol x, Ipush_symbol y -> String.equal x y
+  | Ipush_load x, Ipush_load y -> equal_addressing_mode x y
+  | Ipush_load_float x, Ipush_load_float y -> equal_addressing_mode x y
+  | Isubfrev, Isubfrev -> true
+  | Idivfrev, Idivfrev -> true
+  | Ifloatarithmem (x, x', x''), Ifloatarithmem (y, y', y'') ->
+    Bool.equal x y &&
+    equal_float_operation x' y' && equal_addressing_mode x'' y''
+  | Ifloatspecial x, Ifloatspecial y -> String.equal x y
+  | (Ilea _ | Istore_int _ | Istore_symbol _ | Ioffset_loc _
+    | Ipush | Ipush_int _ | Ipush_symbol _ | Ipush_load _ | Ipush_load_float _
+    | Isubfrev | Idivfrev |   Ifloatarithmem _ | Ifloatspecial _), _ ->
+    false

--- a/backend/power/arch.ml
+++ b/backend/power/arch.ml
@@ -117,5 +117,8 @@ let print_specific_operation printreg op ppf arg =
   | Ialloc_far { bytes; _ } ->
       fprintf ppf "alloc_far %d" bytes
 
-let equal_addressing_mode left right = left = right
-let equal_specific_operation left right = left = right
+(* CR xclerc for xclerc: TODO *)
+let equal_addressing_mode _ _ : bool = assert false
+let equal_prefetch_temporal_locality_hint _ _ : bool = assert false
+let equal_float_operation _ _ : bool = assert false
+let equal_specific_operation _ _ : bool = assert false

--- a/backend/power/arch.ml
+++ b/backend/power/arch.ml
@@ -117,8 +117,22 @@ let print_specific_operation printreg op ppf arg =
   | Ialloc_far { bytes; _ } ->
       fprintf ppf "alloc_far %d" bytes
 
-(* CR xclerc for xclerc: TODO *)
-let equal_addressing_mode _ _ : bool = assert false
-let equal_prefetch_temporal_locality_hint _ _ : bool = assert false
-let equal_float_operation _ _ : bool = assert false
-let equal_specific_operation _ _ : bool = assert false
+let equal_addressing_mode left right =
+  match left, right with
+  | Ibased (x,x'), Ibased (y,y') ->
+    String.equal x y && Int.equal x' y'
+  | Iindexed x, Iindexed y -> Int.equal x y
+  | Iindexed2,  Iindexed2 -> true
+  | (Ibased _ | Iindexed _ | Iindexed2), _ -> false
+
+
+let equal_specific_operation left right =
+    match left, right with
+  | Imultaddf, Imultaddf -> true
+  | Imultsubf, Imultsubf -> true
+  | Ialloc_far { bytes = x; dbginfo = x' },
+    Ialloc_far { bytes = y; dbginfo = y' } ->
+    (* CR-someday gyorsh: implement equal_alloc_debuginfo *)
+    Int.equal x y && x' = y'
+  | (Imultaddf | Imultsubf |Ialloc_far _), _ -> false
+

--- a/backend/riscv/arch.ml
+++ b/backend/riscv/arch.ml
@@ -84,8 +84,12 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "-f (%a *f %a -f %a)"
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
 
-(* CR xclerc for xclerc: TODO *)
-let equal_addressing_mode _ _ : bool = assert false
-let equal_prefetch_temporal_locality_hint _ _ : bool = assert false
-let equal_float_operation _ _ : bool = assert false
-let equal_specific_operation _ _ : bool = assert false
+let equal_addressing_mode left right =
+    match left, right with
+  | Iindexed x, Iindexed y -> Int.equal x y
+
+let equal_specific_operation left right =
+  match left, right with
+  | Imultaddf x, Imultaddf y -> Bool.equal x y
+  | Imultsubf x, Imultsubf y -> Bool.equal x y
+  | (Imultaddf _ | Imultsubf _), _ -> false

--- a/backend/riscv/arch.ml
+++ b/backend/riscv/arch.ml
@@ -84,5 +84,8 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "-f (%a *f %a -f %a)"
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
 
-let equal_addressing_mode left right = left = right
-let equal_specific_operation left right = left = right
+(* CR xclerc for xclerc: TODO *)
+let equal_addressing_mode _ _ : bool = assert false
+let equal_prefetch_temporal_locality_hint _ _ : bool = assert false
+let equal_float_operation _ _ : bool = assert false
+let equal_specific_operation _ _ : bool = assert false

--- a/backend/s390x/arch.ml
+++ b/backend/s390x/arch.ml
@@ -89,8 +89,14 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "%a *f %a -f %a"
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
 
-(* CR xclerc for xclerc: TODO *)
-let equal_addressing_mode _ _ : bool = assert false
-let equal_prefetch_temporal_locality_hint _ _ : bool = assert false
-let equal_float_operation _ _ : bool = assert false
-let equal_specific_operation _ _ : bool = assert false
+let equal_addressing_mode left right =
+  match left, right with
+  | Iindexed x, Iindexed y -> Int.equal x y
+  | Iindexed2 x, Iindexed2 y -> Int.equal x y
+  | (Iindexed _ | Iindexed2 _), _ -> false
+
+let equal_specific_operation left right =
+  match left, right with
+  | Imultaddf, Imultaddf -> true
+  | Imultsubf, Imultsubf -> true
+  | (Imultaddf | Imultsubf), _ -> false

--- a/backend/s390x/arch.ml
+++ b/backend/s390x/arch.ml
@@ -89,5 +89,8 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "%a *f %a -f %a"
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
 
-let equal_addressing_mode left right = left = right
-let equal_specific_operation left right = left = right
+(* CR xclerc for xclerc: TODO *)
+let equal_addressing_mode _ _ : bool = assert false
+let equal_prefetch_temporal_locality_hint _ _ : bool = assert false
+let equal_float_operation _ _ : bool = assert false
+let equal_specific_operation _ _ : bool = assert false


### PR DESCRIPTION
Revert #293, simplify the case analysis when the arguments of `Arch.equal_specific_operation` are equal, and still have warning 4 on, and fix in all targets.