### PR TITLE
Turn calls into terminators

### DIFF
--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -148,3 +148,5 @@ val print_basic : out_channel -> basic instruction -> unit
    reordering. *)
 
 val can_raise_terminator : terminator -> bool
+
+val is_pure_terminator : terminator -> bool

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -328,7 +328,6 @@ let check_basic : State.t -> location -> Cfg.basic -> Cfg.basic -> unit =
  fun state location expected result ->
   match expected, result with
   | Op expected, Op result -> check_operation location expected result
-  | Call expected, Call result -> check_call_operation location expected result
   | Reloadretaddr, Reloadretaddr -> ()
   | ( Pushtrap { lbl_handler = expected_lbl_handler },
       Pushtrap { lbl_handler = result_lbl_handler } ) ->
@@ -465,6 +464,10 @@ let check_terminator_instruction :
       check_tail_call_operation state location tc1 tc2
     | Call_no_return cn1, Call_no_return cn2 ->
       check_external_call_operation location cn1 cn2
+    | Call { call = c1; return = r1 }, Call { call = c2; return = r2 } ->
+      State.add_to_explore state r1 r2;
+      let location = location ^ " (terminator)" in
+      check_call_operation location c1 c2
     | _ -> different location "terminator"
   end;
   (* CR xclerc for xclerc: temporary, for testing *)
@@ -472,7 +475,7 @@ let check_terminator_instruction :
     match expected.desc with
     | Always _ -> false
     | Never | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-    | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _ ->
+    | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _ | Call _ ->
       true
   in
   check_instruction ~check_live:false ~check_dbg:false ~check_arg (-1) location

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -134,7 +134,6 @@ module S = struct
 
   type basic =
     | Op of operation
-    | Call of call_operation
     | Reloadretaddr
     | Pushtrap of { lbl_handler : Label.t }
     | Poptrap
@@ -164,6 +163,10 @@ module S = struct
     | Raise of Lambda.raise_kind
     | Tailcall of tail_call_operation
     | Call_no_return of external_call_operation
+    | Call of
+        { call : call_operation;
+          return : Label.t
+        }
 end
 
 (* CR-someday gyorsh: Switch can be translated to Branch. *)

--- a/backend/cfg/eliminate_fallthrough_blocks.ml
+++ b/backend/cfg/eliminate_fallthrough_blocks.ml
@@ -33,14 +33,7 @@ let is_fallthrough_block cfg_with_layout (block : C.basic_block) =
   if Label.equal cfg.entry_label block.start
      || block.is_trap_handler
      || List.length block.body > 0
-     ||
-     match block.terminator.desc with
-     | Tailcall (Self _) -> true
-     | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
-     | Int_test _ | Switch _ | Return | Raise _
-     | Tailcall (Func _)
-     | Call_no_return _ ->
-       false
+     || not (C.is_pure_terminator block.terminator.desc)
   then None
   else
     let successors = C.successor_labels ~normal:true ~exn:false block in

--- a/backend/cfg/merge_straightline_blocks.ml
+++ b/backend/cfg/merge_straightline_blocks.ml
@@ -30,11 +30,11 @@
  * - `b1` has only one non-exceptional successor, `b2`;
  * - `b2` has only one predecessor, `b1`;
  * - `b1` and `b2` are distinct blocks;
- * - the terminator of `b1` is not a tailcall to self.
+ * - the terminator of `b1` is pure
  *
  *  When the condition is met, `b1` is modified as follows:
  *  - its body is set to the concatenation of `b1.body` and `b2.body`;
- *  - its terminator becomes the terminator of `b2`;
+ *  - its terminator is replaced by the terminator of `b2`;
  *  - its `exns`, `can_raise`, and `can_raise_interproc` fields  are set to the "union"
  *    of the respective fields in `b1` and `b2`;
  *  - (its other fields are left unchanged);
@@ -68,14 +68,7 @@ let rec merge_blocks (modified : bool) (cfg_with_layout : Cfg_with_layout.t) :
           if (not (Label.equal b1_label cfg.entry_label))
              && (not (Label.equal b1_label b2_label))
              && List.compare_length_with b2_predecessors 1 = 0
-             &&
-             match b1_block.terminator.desc with
-             | Tailcall (Self _) -> false
-             | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
-             | Int_test _ | Switch _ | Return | Raise _
-             | Tailcall (Func _)
-             | Call_no_return _ ->
-               true
+             && Cfg.is_pure_terminator b1_block.terminator.desc
           then begin
             assert (Label.equal b1_label (List.hd b2_predecessors));
             (* modify b1 *)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -98,6 +98,7 @@ let block (block : C.basic_block) =
       let l = Label.Set.min_elt labels in
       block.terminator <- { block.terminator with desc = Always l }
   | Switch labels -> simplify_switch block labels
-  | Call_no_return _ | Tailcall (Self _ | Func _) | Raise _ | Return -> ()
+  | Call _ | Call_no_return _ | Tailcall (Self _ | Func _) | Raise _ | Return ->
+    ()
 
 let run cfg = C.iter_blocks cfg ~f:(fun _ b -> block b)


### PR DESCRIPTION
The new representation makes it easier to implement dataflow analyses and gives more accurate results.

This refactoring of the CFG was originally proposed by Nandor Licker (see https://github.com/nandor/ocamlcfg/commit/0f36fca0f4fb7f00de11535de8e8b24e88e9823a). 

Not sure about the names for the new inline record fields are `Call { call; return }`.. maybe    `Call { callee; return_label }` would be better.

As a terminator, Call needs a new label to be created for its successor instruction, a label that is not necessarily present in the input, and so the Cfgize pass needed a bit of refactoring to arrange for the label in the right time. Perhaps there is a simpler way to do it. 

I am planning to make a separate PR to turn Probe into a terminator, because Probe can also raise, and then all instruction that can raise terminate a block.