### PR TITLE
Cfg instruction that can raise end a block

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -293,6 +293,52 @@ let can_raise_terminator (i : terminator) =
   | Tailcall (Self _) ->
     false
 
+let can_raise_operation : operation -> bool = function
+  | Move -> false
+  | Spill -> false
+  | Reload -> false
+  | Const_int _ -> false
+  | Const_float _ -> false
+  | Const_symbol _ -> false
+  | Stackoffset _ -> false
+  | Load _ -> false
+  | Store _ -> false
+  | Intop _ -> false
+  | Intop_imm _ -> false
+  | Negf -> false
+  | Absf -> false
+  | Addf -> false
+  | Subf -> false
+  | Mulf -> false
+  | Divf -> false
+  | Compf _ -> false
+  | Floatofint -> false
+  | Intoffloat -> false
+  | Probe _ -> true
+  | Probe_is_enabled _ -> false (* CR xclerc for xclerc: double check *)
+  | Specific _ -> false (* CR xclerc for xclerc: double check *)
+  | Opaque -> false
+  | Name_for_debugger _ -> false
+
+let can_raise_basic : basic -> bool = function
+  | Op op -> can_raise_operation op
+  | Call _ -> true
+  | Reloadretaddr -> false
+  | Pushtrap _ -> false
+  | Poptrap -> false
+  | Prologue -> false
+
+(* CR gyorsh: [is_pure_terminator] is not the same as [can_raise_terminator]
+   because of [Tailcal Self] which is not pure but marked as cannot raise at the
+   moment, which we might want to reconsider later. *)
+let is_pure_terminator desc =
+  match (desc : terminator) with
+  | Raise _ | Call_no_return _ | Tailcall _ -> false
+  | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+  | Switch _ | Return ->
+    (* CR gyorsh: fix for memory operands *)
+    true
+
 let print_basic oc i =
   Format.kasprintf (Printf.fprintf oc "%s") "%a" dump_basic i
 

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -148,3 +148,9 @@ val print_basic : out_channel -> basic instruction -> unit
    reordering. *)
 
 val can_raise_terminator : terminator -> bool
+
+val can_raise_basic : basic -> bool
+
+val can_raise_operation : operation -> bool
+
+val is_pure_terminator : terminator -> bool

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -565,8 +565,8 @@ module Trap_depth_and_exns = struct
 
   type handler_table = handler_stack Label.Tbl.t
 
-  let record_handler :
-      handler_stack -> handler_table -> can_raise:bool -> unit =
+  let record_handler : handler_stack -> handler_table -> can_raise:bool -> unit
+      =
    fun stack table ~can_raise ->
     if can_raise
     then

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -422,11 +422,8 @@ let rec add_blocks :
       let terminator_is_goto =
         match (terminator.Cfg.desc : Cfg.terminator) with
         | Always _ -> true
-        | Raise _
-        | Tailcall (Func _)
-        | Call_no_return _ | Never | Parity_test _ | Truth_test _ | Float_test _
-        | Int_test _ | Switch _ | Return
-        | Tailcall (Self _) ->
+        | Raise _ | Tailcall _ | Call_no_return _ | Never | Parity_test _
+        | Truth_test _ | Float_test _ | Int_test _ | Switch _ | Return ->
           false
       in
       let rec check = function
@@ -481,7 +478,7 @@ let rec add_blocks :
           "Cfgize.extract_block_info: unexpected Iop with no terminator";
       let next, add_next_block = prepare_next_block () in
       terminate_block ~trap_actions:[]
-        (copy_instruction state last ~desc:(Cfg.Always next));
+        (copy_instruction_no_reg state last ~desc:(Cfg.Always next));
       add_next_block ()
     | Iend ->
       if Label.equal next fallthrough_label

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -416,10 +416,10 @@ let rec add_blocks :
         body
     in
     let can_raise =
-      (* Recompute [can_raise] and check that instruction in the middle of the
+      (* Recompute [can_raise] and check that instructions in the middle of the
          block do not raise, i.e., only the terminator, or the last instruction
          (when the terminator is just a goto) can raise. *)
-      let last_can_raise =
+      let terminator_is_goto =
         match (terminator.Cfg.desc : Cfg.terminator) with
         | Always _ -> true
         | Raise _
@@ -433,13 +433,14 @@ let rec add_blocks :
         | [] -> false
         | [last] ->
           let res = Cfg.can_raise_basic last.Cfg.desc in
-          assert ((not res) || last_can_raise);
+          assert ((not res) || terminator_is_goto);
           res
         | hd :: tail ->
           assert (not (Cfg.can_raise_basic hd.Cfg.desc));
           check tail
       in
-      Cfg.can_raise_terminator terminator.Cfg.desc || check body
+      let body_can_raise = check body in
+      Cfg.can_raise_terminator terminator.Cfg.desc || body_can_raise
     in
     State.add_block state ~label:start
       ~block:

--- a/backend/cfg/eliminate_fallthrough_blocks.ml
+++ b/backend/cfg/eliminate_fallthrough_blocks.ml
@@ -33,14 +33,7 @@ let is_fallthrough_block cfg_with_layout (block : C.basic_block) =
   if Label.equal cfg.entry_label block.start
      || block.is_trap_handler
      || List.length block.body > 0
-     ||
-     match block.terminator.desc with
-     | Tailcall (Self _) -> true
-     | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
-     | Int_test _ | Switch _ | Return | Raise _
-     | Tailcall (Func _)
-     | Call_no_return _ ->
-       false
+     || not (C.is_pure_terminator block.terminator.desc)
   then None
   else
     let successors = C.successor_labels ~normal:true ~exn:false block in

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -615,8 +615,16 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     | Iname_for_debugger _ ->
       let desc = to_basic mop in
       block.body <- create_instruction t desc i ~trap_depth :: block.body;
-      if Mach.operation_can_raise mop then record_exn t block traps;
-      create_blocks t i.next block ~trap_depth ~traps)
+      if Mach.operation_can_raise mop
+      then begin
+        (* Instruction that can raise is always at the end of a block. *)
+        record_exn t block traps;
+        let fallthrough = get_or_make_label t i.next in
+        let desc : Cfg.terminator = Always fallthrough.label in
+        add_terminator t block i desc ~trap_depth ~traps;
+        create_blocks t fallthrough.insn block ~trap_depth ~traps
+      end
+      else create_blocks t i.next block ~trap_depth ~traps)
 
 let run (f : Linear.fundecl) ~preserve_orig_labels =
   let t =

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -621,7 +621,8 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
         record_exn t block traps;
         let fallthrough = get_or_make_label t i.next in
         let desc : Cfg.terminator = Always fallthrough.label in
-        add_terminator t block i desc ~trap_depth ~traps;
+        let i_no_reg = { i with arg = [||]; res = [||]; fdo = Fdo_info.none } in
+        add_terminator t block i_no_reg desc ~trap_depth ~traps;
         create_blocks t fallthrough.insn block ~trap_depth ~traps
       end
       else create_blocks t i.next block ~trap_depth ~traps)

--- a/backend/cfg/merge_straightline_blocks.ml
+++ b/backend/cfg/merge_straightline_blocks.ml
@@ -37,7 +37,7 @@
  *  - its body is set to the concatenation of `b1.body` and `b2.body`;
  *  - its terminator becomes the terminator of `b2`;
  *  - its `can_raise` is set to that of `b2`;
- *  - its `exns`, and `can_raise_interproc` fields  are set to the "union"
+ *  - its `exns`, and `can_raise_interproc` fields are set to the "union"
  *    of the respective fields in `b1` and `b2`;
  *  - (its other fields are left unchanged);
  *  and `b2` is modified as follows:
@@ -54,7 +54,7 @@
  *  (as opposed to the information encoded in the graph). *)
 
 (* CR gyorsh: with the new requirement on b1 (that it cannot raise) this pass is
-   even closer to eliminate_fallthrough_blocks. the only different I think is
+   even closer to eliminate_fallthrough_blocks. The only difference I think is
    that b1's body need not be empty here. *)
 let rec merge_blocks (modified : bool) (cfg_with_layout : Cfg_with_layout.t) :
     bool =

--- a/backend/cfg/merge_straightline_blocks.ml
+++ b/backend/cfg/merge_straightline_blocks.ml
@@ -28,7 +28,7 @@
 (* Two blocks `b1` and `b2` can be merged if:
  * - `b1` is not the entry block;
  * - `b1` has only one non-exceptional successor, `b2`;
- * - `b1` cannot raise
+ * - `b1` cannot raise;
  * - `b2` has only one predecessor, `b1`;
  * - `b1` and `b2` are distinct blocks;
  * - the terminator of `b1` is not a tailcall to self.


### PR DESCRIPTION
This is an alternative to #308, not sure what's better. 

The difference is that this PR does not make Call into a terminator. Instead, any operation that can raise (including calls, probes, and `Ispecific` ones that can raise) must be the last instruction in the block and if it is not a terminator, then a terminator `Always` is added. We don't need special case terminators for calls and probes, and in particular no need to have both `basic` and `terminator` variations of Ispecific, depending on whether the Ispecific can raise or not. This version does not change `cfgize` very much. 

The difficulty with this representation is to ensure that all the places where a block needs to be split are handled correctly (which is enforced much better with types of #303), but it can be checked using `cfg_invariants` pass (in preparation).

This representation guarantees that a block can have at most one exceptional successor. 