### PR TITLE
Update instructions in HACKING to use flambda-backend in opam

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -203,7 +203,7 @@ The exact version doesn't matter that much, but the version number should
 match the one in the Flambda backend tree.  (The name of the package given
 here is independent of the name of the switch.)
 
-To finish the installation, `opam install ocaml` will install the remaining
+To finish the installation, `opam install ocaml.4.12.0` will install the remaining
 auxiliary packages necessary for a regular switch. After that, normal opam
 packages can be installed the usual way.
 


### PR DESCRIPTION
Since the release of 4.13, the instructions were out of date. `opam install ocaml` would select `ocaml.4.13.0` and therefore install a base compiler resulting in a broken switch, half `4.13.0`, half `4.12.0+flambda2`.

It's probably best practice to always explicitly specify the version so that we're shielded from such problems in the future.