### PR TITLE
Force argument and result in register for imul with a constant

### DIFF
--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -93,6 +93,12 @@ method! reload_operation op arg res =
       (* This add will be turned into a lea; args and results must be
          in registers *)
       super#reload_operation op arg res
+  | Iintop_imm (Imul, _) ->
+      (* First argument (= result) must be in register *)
+      if stackp arg.(0) then
+        let r = self#makereg arg.(0) in
+        ([|r|],[|r|])
+      else (arg, res)
   | Ispecific Ifloat_iround
   | Ispecific (Ifloat_round _)
   | Iintop_imm (Icomp _, _) ->


### PR DESCRIPTION
In reload, add a missing case for `Iintop_imm Imul` .
Without it, the compiler emits `imulq $12, 72(%rsp)`  which is illegal because  it has a load from stack as destination instead of a register.

For example:
```
let foo v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16 v17 v18 =
     ( (8 * v1))
    +  ( (4 * v2))
    + ( (6 * v3))
    + ( (6 * v4))
    + (  (3 * v5))
    + ( (6 * v6))
    + (  (6 * v7))
    +  ( (6 * v8))
    +  ( (8 * v9))
    + (8 * v10)
    + (4 * v11)
    + (6 * v12)
    + (6 * v13)
    + (3 * v14)
    + (6 * v15)
    + (6 * v16)
    + (12 * v17)
    + (8 * v18)

let boo () =
  let v1 = Sys.opaque_identity 0 in
  let v2 = Sys.opaque_identity 0 in
  let v3 = Sys.opaque_identity 0 in
  let v4 = Sys.opaque_identity 0 in
  let v5 = Sys.opaque_identity 0 in
  let v6 = Sys.opaque_identity 0 in
  let v7 = Sys.opaque_identity 0 in
  let v8 = Sys.opaque_identity 0 in
  let v9 = Sys.opaque_identity 0 in
  let v10 = Sys.opaque_identity 0 in
  let v11 = Sys.opaque_identity 0 in
  let v12 = Sys.opaque_identity 0 in
  let v13 = Sys.opaque_identity 0 in
  let v14 = Sys.opaque_identity 0 in
  let v15 = Sys.opaque_identity 0 in
  let v16 = Sys.opaque_identity 0 in
  let v17 = Sys.opaque_identity 0 in
  let v18 = Sys.opaque_identity 0 in
  foo v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16 v17 v18

let () =
  ignore (Sys.opaque_identity (boo ()) : int)
```
causes assembler error
```
boo.s: Assembler messages:
boo.s:71: Error: operand size mismatch for `imul'
File "boo.ml", line 1:
Error: Assembler error, input left in file boo.s
```

