### PR TITLE
Reduce max inlining depths at -O2 and -O3

### DIFF
--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -606,7 +606,7 @@ module Flambda2 = struct
     }
 
     let o2_arguments = {
-      max_depth = Some 10;
+      max_depth = Some 2;
       call_cost = Some (2.0 *. Default.call_cost);
       alloc_cost = Some (2.0 *. Default.alloc_cost);
       prim_cost = Some (2.0 *. Default.prim_cost);
@@ -619,7 +619,7 @@ module Flambda2 = struct
     }
 
     let o3_arguments = {
-      max_depth = Some 20;
+      max_depth = Some 3;
       call_cost = Some (3.0 *. Default.call_cost);
       alloc_cost = Some (3.0 *. Default.alloc_cost);
       prim_cost = Some (3.0 *. Default.prim_cost);


### PR DESCRIPTION
It seems like these should be lower (see #333).

One thing I've noticed on the JS code base is that certain constructions with functors (e.g. applications of `Identifiable.Make`) were being inlined out with flambda1 at `-O3` despite very high max inlining depth (of the order of 12) being required -- at least with the Flambda 2 definition of max inlining depth.  I'm unsure whether this is just because of the toplevel inlining bonus in flambda 1, a bug, or both.