### PR TITLE
Classic mode generates .cmx

### DIFF
--- a/middle_end/flambda2/classic_mode_types/dune
+++ b/middle_end/flambda2/classic_mode_types/dune
@@ -1,0 +1,20 @@
+(include_subdirs unqualified)
+
+(library
+ (name flambda2_classic_mode_types)
+ (wrapped false)
+ (flags
+  (:standard
+   -principal
+   -nostdlib
+   -open
+   Flambda2_identifiers
+   -open
+   Flambda2_term_basics))
+ (ocamlopt_flags
+  (:standard -O3))
+ (libraries
+  stdlib
+  ocamlcommon
+  flambda2_identifiers
+  flambda2_term_basics))

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*            Pierre Chambart and Vincent Laviron, OCamlPro               *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Approximations used for cross-module inlining in Closure_conversion *)
+
+type 'code t =
+  | Value_unknown
+  | Closure_approximation of Code_id.t * 'code option
+  | Block_approximation of 'code t array * Alloc_mode.t
+
+let is_unknown = function
+  | Value_unknown -> true
+  | Closure_approximation _ | Block_approximation _ -> false

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -1,0 +1,26 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*            Pierre Chambart and Vincent Laviron, OCamlPro               *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Approximations used for cross-module inlining in Closure_conversion *)
+
+type 'code t =
+  | Value_unknown
+  | Closure_approximation of Code_id.t * 'code option
+  | Block_approximation of 'code t array * Alloc_mode.t
+
+val is_unknown : 'a t -> bool

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -64,7 +64,9 @@ let load_symbol_approx loader symbol : Code.t Value_approximation.t =
   | None -> Value_unknown
   | Some typing_env ->
     let find_code code_id =
-      Exported_code.find_code loader.imported_code code_id
+      match Exported_code.find loader.imported_code code_id with
+      | Some (Code_present code) -> Some code
+      | _ -> None
     in
     T.extract_symbol_approx typing_env symbol find_code
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -247,8 +247,19 @@ let prepare_cmx_from_approx ~approxs ~exported_offsets ~used_closure_vars
   if Flambda_features.opaque ()
   then None
   else
+    (* CR keryan : for now all content of loaded .cmx are reexported. We may
+       want to remove unreachable code as does [prepare_cmx_file_contents] at
+       some point *)
     let final_typing_env =
       TE.Serializable.create_from_closure_conversion_approx approxs
+    in
+    let free_names_of_all_code = EC.free_names all_code in
+    let exported_offsets =
+      exported_offsets
+      |> Closure_offsets.reexport_closure_ids
+           (Name_occurrences.closure_ids free_names_of_all_code)
+      |> Closure_offsets.reexport_closure_vars
+           (Name_occurrences.closure_vars free_names_of_all_code)
     in
     Some
       (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -67,6 +67,8 @@ let load_symbol_approx loader symbol : Code.t Value_approximation.t =
       match Exported_code.find loader.imported_code code_id with
       | Some (Code_present code) -> Some code
       | _ -> None
+      (* CR keryan : we want to use metadata in classic mode at some point in
+         the near futur *)
     in
     T.extract_symbol_approx typing_env symbol find_code
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -239,12 +239,13 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol
          ~used_closure_vars)
 
 let prepare_cmx_from_approx ~approxs ~used_closure_vars all_code =
-  if Flambda_features.opaque () then None
+  if Flambda_features.opaque ()
+  then None
   else
     let final_typing_env =
       TE.Serializable.create_from_closure_conversion_approx approxs
     in
-    let exported_offsets =
-      Exported_offsets.imported_offsets ()
-    in
-    Some (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets ~used_closure_vars)
+    let exported_offsets = Exported_offsets.imported_offsets () in
+    Some
+      (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets
+         ~used_closure_vars)

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -68,7 +68,7 @@ let load_symbol_approx loader symbol : Code.t Value_approximation.t =
       | Some (Code_present code) -> Some code
       | _ -> None
       (* CR keryan : we want to use metadata in classic mode at some point in
-         the near futur *)
+         the near future *)
     in
     T.extract_symbol_approx typing_env symbol find_code
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -20,23 +20,27 @@ module EC = Exported_code
 module T = Flambda2_types
 module TE = Flambda2_types.Typing_env
 
-let rec load_cmx_file_contents ~get_global_info comp_unit ~imported_units
-    ~imported_names ~imported_code =
-  match Compilation_unit.Map.find comp_unit !imported_units with
+type loader =
+  { get_global_info : Compilation_unit.t -> Flambda_cmx_format.t option;
+    mutable imported_names : Name.Set.t;
+    mutable imported_code : Exported_code.t;
+    mutable imported_units : TE.t option Compilation_unit.Map.t
+  }
+
+let rec load_cmx_file_contents loader comp_unit =
+  match Compilation_unit.Map.find comp_unit loader.imported_units with
   | typing_env_or_none -> typing_env_or_none
   | exception Not_found -> (
-    match get_global_info comp_unit with
+    match loader.get_global_info comp_unit with
     | None ->
       (* To make things easier to think about, we never retry after a .cmx load
          fails. *)
-      imported_units := Compilation_unit.Map.add comp_unit None !imported_units;
+      loader.imported_units
+        <- Compilation_unit.Map.add comp_unit None loader.imported_units;
       None
     | Some cmx ->
-      let resolver comp_unit =
-        load_cmx_file_contents ~get_global_info comp_unit ~imported_names
-          ~imported_code ~imported_units
-      in
-      let get_imported_names () = !imported_names in
+      let resolver comp_unit = load_cmx_file_contents loader comp_unit in
+      let get_imported_names () = loader.imported_names in
       let typing_env, all_code =
         Flambda_cmx_format.import_typing_env_and_code cmx
       in
@@ -44,13 +48,60 @@ let rec load_cmx_file_contents ~get_global_info comp_unit ~imported_units
         TE.Serializable.to_typing_env ~resolver ~get_imported_names typing_env
       in
       let newly_imported_names = TE.name_domain typing_env in
-      imported_names := Name.Set.union newly_imported_names !imported_names;
-      imported_code := EC.merge all_code !imported_code;
+      loader.imported_names
+        <- Name.Set.union newly_imported_names loader.imported_names;
+      loader.imported_code <- EC.merge all_code loader.imported_code;
       let offsets = Flambda_cmx_format.exported_offsets cmx in
       Exported_offsets.import_offsets offsets;
-      imported_units
-        := Compilation_unit.Map.add comp_unit (Some typing_env) !imported_units;
+      loader.imported_units
+        <- Compilation_unit.Map.add comp_unit (Some typing_env)
+             loader.imported_units;
       Some typing_env)
+
+let all_predefined_exception_symbols ~symbol_for_global =
+  Predef.all_predef_exns
+  |> List.map (fun ident ->
+         symbol_for_global
+           ?comp_unit:(Some (Compilation_unit.predefined_exception ()))
+           ident)
+  |> Symbol.Set.of_list
+
+let predefined_exception_typing_env ~symbol_for_global loader =
+  let comp_unit = Compilation_unit.get_current_exn () in
+  Compilation_unit.set_current (Compilation_unit.predefined_exception ());
+  let resolver comp_unit = load_cmx_file_contents loader comp_unit in
+  let get_imported_names () = loader.imported_names in
+  let typing_env =
+    Symbol.Set.fold
+      (fun sym typing_env ->
+        TE.add_definition typing_env (Bound_name.symbol sym) Flambda_kind.value)
+      (all_predefined_exception_symbols ~symbol_for_global)
+      (TE.create ~resolver ~get_imported_names)
+  in
+  Compilation_unit.set_current comp_unit;
+  typing_env
+
+let create_loader ~get_global_info ~symbol_for_global =
+  let loader =
+    { get_global_info;
+      imported_names = Name.Set.empty;
+      imported_code = Exported_code.empty;
+      imported_units = Compilation_unit.Map.empty
+    }
+  in
+  let predefined_exception_typing_env =
+    predefined_exception_typing_env ~symbol_for_global loader
+  in
+  loader.imported_units
+    <- Compilation_unit.Map.singleton
+         (Compilation_unit.predefined_exception ())
+         (Some predefined_exception_typing_env);
+  loader.imported_names <- TE.name_domain predefined_exception_typing_env;
+  loader
+
+let get_imported_names loader () = loader.imported_names
+
+let get_imported_code loader () = loader.imported_code
 
 let compute_reachable_names_and_code ~module_symbol typing_env code =
   let rec fixpoint names_to_add names_already_added =

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -242,14 +242,14 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol
       (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets
          ~used_closure_vars)
 
-let prepare_cmx_from_approx ~approxs ~used_closure_vars all_code =
+let prepare_cmx_from_approx ~approxs ~exported_offsets ~used_closure_vars
+    all_code =
   if Flambda_features.opaque ()
   then None
   else
     let final_typing_env =
       TE.Serializable.create_from_closure_conversion_approx approxs
     in
-    let exported_offsets = Exported_offsets.imported_offsets () in
     Some
       (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets
          ~used_closure_vars)

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -46,6 +46,7 @@ val prepare_cmx_file_contents :
 
 val prepare_cmx_from_approx :
   approxs:Code.t Value_approximation.t Symbol.Map.t ->
+  exported_offsets:Exported_offsets.t ->
   used_closure_vars:Var_within_closure.Set.t ->
   Exported_code.t ->
   Flambda_cmx_format.t option

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -34,10 +34,19 @@ val get_imported_code : loader -> unit -> Exported_code.t
 val load_cmx_file_contents :
   loader -> Compilation_unit.t -> Flambda2_types.Typing_env.t option
 
+val load_symbol_approx :
+  loader -> Symbol.t -> Code.t Value_approximation.t
+
 val prepare_cmx_file_contents :
   final_typing_env:Flambda2_types.Typing_env.t option ->
   module_symbol:Symbol.t ->
   used_closure_vars:Var_within_closure.Set.t ->
   exported_offsets:Exported_offsets.t ->
+  Exported_code.t ->
+  Flambda_cmx_format.t option
+
+val prepare_cmx_from_approx :
+  approxs:Code.t Value_approximation.t Symbol.Map.t ->
+  used_closure_vars:Var_within_closure.Set.t ->
   Exported_code.t ->
   Flambda_cmx_format.t option

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -34,8 +34,7 @@ val get_imported_code : loader -> unit -> Exported_code.t
 val load_cmx_file_contents :
   loader -> Compilation_unit.t -> Flambda2_types.Typing_env.t option
 
-val load_symbol_approx :
-  loader -> Symbol.t -> Code.t Value_approximation.t
+val load_symbol_approx : loader -> Symbol.t -> Code.t Value_approximation.t
 
 val prepare_cmx_file_contents :
   final_typing_env:Flambda2_types.Typing_env.t option ->

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -19,14 +19,20 @@
 (** Dumping and restoring of simplification environment information to and from
     .cmx files. *)
 
-val load_cmx_file_contents :
+type loader
+
+val create_loader :
   get_global_info:
     (Flambda2_identifiers.Compilation_unit.t -> Flambda_cmx_format.t option) ->
-  Compilation_unit.t ->
-  imported_units:Flambda2_types.Typing_env.t option Compilation_unit.Map.t ref ->
-  imported_names:Name.Set.t ref ->
-  imported_code:Exported_code.t ref ->
-  Flambda2_types.Typing_env.t option
+  symbol_for_global:(?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
+  loader
+
+val get_imported_names : loader -> unit -> Name.Set.t
+
+val get_imported_code : loader -> unit -> Exported_code.t
+
+val load_cmx_file_contents :
+  loader -> Compilation_unit.t -> Flambda2_types.Typing_env.t option
 
 val prepare_cmx_file_contents :
   final_typing_env:Flambda2_types.Typing_env.t option ->

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -180,15 +180,7 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
         then
           let output_prefix = prefixname ^ ".cps_conv" in
           Inlining_report.output_then_forget_decisions ~output_prefix);
-        let exported_offsets =
-          match (offsets : _ Or_unknown.t) with
-          | Unknown ->
-            Misc.fatal_errorf
-              "Classic mode requires lambda_to_flambda to compute\n\
-              \               the offsets for closure elements"
-          | Known closure_offsets -> closure_offsets
-        in
-        raw_flambda, exported_offsets, cmx, code
+        raw_flambda, offsets, cmx, code
       end
       else
         let raw_flambda =

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -175,7 +175,11 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
     print_rawflambda ppf raw_flambda;
     let flambda, offsets, cmx, all_code =
       if Flambda_features.classic_mode ()
-      then
+      then begin
+        (if Flambda_features.inlining_report ()
+        then
+          let output_prefix = prefixname ^ ".cps_conv" in
+          Inlining_report.output_then_forget_decisions ~output_prefix);
         let exported_offsets =
           match (offsets : _ Or_unknown.t) with
           | Unknown ->
@@ -185,6 +189,7 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
           | Known closure_offsets -> closure_offsets
         in
         raw_flambda, exported_offsets, cmx, code
+      end
       else
         let raw_flambda =
           if Flambda_features.Debug.permute_every_name ()

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -189,10 +189,12 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
           else raw_flambda
         in
         let round = 0 in
+        let cmx_loader =
+          Flambda_cmx.create_loader ~get_global_info ~symbol_for_global
+        in
         let { Simplify.unit = flambda; exported_offsets; cmx; all_code } =
           Profile.record_call ~accumulate:true "simplify" (fun () ->
-              Simplify.run ~symbol_for_global ~get_global_info ~round
-                raw_flambda)
+              Simplify.run ~cmx_loader ~round raw_flambda)
         in
         (if Flambda_features.inlining_report ()
         then

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -844,7 +844,7 @@ let close_let acc env id user_visible defining_expr
                 Named.print defining_expr
             else None
           | Block_approximation (approx, _alloc_mode) ->
-            let approx : Env.value_approximation =
+            let approx =
               Simple.pattern_match field
                 ~const:(fun const ->
                   match Reg_width_things.Const.descr const with
@@ -857,8 +857,8 @@ let close_let acc env id user_visible defining_expr
                          approximation of length %d."
                         i (Array.length approx);
                     approx.(i)
-                  | _ -> Env.Value_unknown)
-                ~name:(fun _ ~coercion:_ -> Env.Value_unknown)
+                  | _ -> Value_approximation.Value_unknown)
+                ~name:(fun _ ~coercion:_ -> Value_approximation.Value_unknown)
             in
             Some (Env.add_value_approximation body_env (Name.var var) approx)
         end

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1672,7 +1672,7 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
   let module_block_approximation =
     match Acc.continuation_known_arguments ~cont:prog_return_cont acc with
     | Some [approx] -> approx
-    | _ -> assert false
+    | _ -> Value_approximation.Value_unknown
   in
   let acc, body = bind_code (Acc.code acc) acc body in
   (* We must make sure there is always an outer [Let_symbol] binding so that
@@ -1694,7 +1694,7 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
     List.fold_left
       (fun sa (symbol, _) ->
         (* CR Keryan: for now only constants are lifted. It will need refinement
-           with thelifting of closed functions *)
+           with the lifting of closed functions *)
         Symbol.Map.add symbol Value_approximation.Value_unknown sa)
       (Symbol.Map.singleton module_symbol module_block_approximation)
       (Acc.declared_symbols acc)
@@ -1744,7 +1744,9 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
         offsets)
   in
   ( Flambda_unit.create ~return_continuation:return_cont ~exn_continuation ~body
-      ~module_symbol ~used_closure_vars:(Known used_closure_vars),
+      ~module_symbol ~used_closure_vars:Unknown,
+    (* CR keryan: this should use [used_closure_vars] as well but it doesn't
+       work well with cmx from simplify yet (issue #331) *)
     all_code,
     cmx,
     exported_offsets )

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1672,14 +1672,7 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
   let module_block_approximation =
     match Acc.continuation_known_arguments ~cont:prog_return_cont acc with
     | Some [approx] -> approx
-    | Some l ->
-      Format.eprintf "%a, approx len: %d\n" Continuation.print prog_return_cont
-        (List.length l);
-      assert false
-    | _ ->
-      Format.eprintf "%a, approx len: none\n" Continuation.print
-        prog_return_cont;
-      Value_approximation.Value_unknown
+    | _ -> assert false
   in
   let acc, body = bind_code (Acc.code acc) acc body in
   (* We must make sure there is always an outer [Let_symbol] binding so that
@@ -1726,16 +1719,12 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
   let get_code_metadata code_id =
     Code_id.Map.find code_id (Acc.code acc) |> Code.code_metadata
   in
-  let used_closure_vars =
-    (* let vs = *)
-    Name_occurrences.closure_vars (Acc.free_names acc)
-    (*in Format.eprintf "%a\n" Var_within_closure.Set.print vs;
-     * vs *)
-  in
+  let used_closure_vars = Name_occurrences.closure_vars (Acc.free_names acc) in
   let all_code =
-    Exported_code.add_code
+    Exported_code.add_code (Acc.code acc)
       ~keep_code:(fun _ -> true)
-      (Acc.code acc) Exported_code.empty
+      (Exported_code.mark_as_imported
+         (Flambda_cmx.get_imported_code cmx_loader ()))
   in
   let cmx =
     Flambda_cmx.prepare_cmx_from_approx ~approxs:symbols_approximations

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -67,9 +67,13 @@ val close_switch :
 val close_program :
   symbol_for_global:(?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
   big_endian:bool ->
+  cmx_loader:Flambda_cmx.loader ->
   module_ident:Ident.t ->
   module_block_size_in_words:int ->
   program:(Acc.t -> Env.t -> Acc.t * Expr_with_acc.t) ->
   prog_return_cont:Continuation.t ->
   exn_continuation:Continuation.t ->
-  Flambda_unit.t * Exported_code.t * Exported_offsets.t Or_unknown.t
+  Flambda_unit.t
+  * Exported_code.t
+  * Flambda_cmx_format.t option
+  * Exported_offsets.t Or_unknown.t

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -76,4 +76,4 @@ val close_program :
   Flambda_unit.t
   * Exported_code.t
   * Flambda_cmx_format.t option
-  * Exported_offsets.t Or_unknown.t
+  * Exported_offsets.t

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -183,7 +183,10 @@ module Env = struct
       current_unit_id = Compilation_unit.get_persistent_ident compilation_unit;
       current_depth = None;
       value_approximations = Name.Map.empty;
-      approximation_for_external_symbol = approximation_loader cmx_loader;
+      approximation_for_external_symbol =
+        (if Flambda_features.classic_mode ()
+        then approximation_loader cmx_loader
+        else fun _symbol -> Value_approximation.Value_unknown);
       symbol_for_global;
       big_endian;
       path_to_root = Debuginfo.Scoped_location.Loc_unknown;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -459,8 +459,9 @@ module Acc = struct
     { t with
       free_names =
         Name_occurrences.remove_continuation t.free_names cont
-        (* continuation_applications =
-         *   Continuation.Map.remove cont t.continuation_applications *)
+        (* We don't remove the continuation from [t.continuation_applications]
+           here because we need this information of the module block to escape
+           its scope to build the .cmx in [Closure_conversion.close_program]. *)
     }
 
   let remove_code_id_from_free_names code_id t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -363,7 +363,7 @@ module Acc = struct
       cost_metrics : Cost_metrics.t;
       seen_a_function : bool;
       symbol_for_global : Ident.t -> Symbol.t;
-      closure_offsets : Closure_offsets.t Or_unknown.t;
+      closure_offsets : Closure_offsets.t;
       regions_closed_early : Ident.Set.t
     }
 
@@ -491,14 +491,11 @@ module Acc = struct
   let symbol_for_global t = t.symbol_for_global
 
   let add_set_of_closures_offsets ~is_phantom t set_of_closures =
-    match t.closure_offsets with
-    | Unknown -> t
-    | Known closure_offsets ->
-      let closure_offsets =
-        Closure_offsets.add_set_of_closures closure_offsets ~is_phantom
-          set_of_closures
-      in
-      { t with closure_offsets = Known closure_offsets }
+    let closure_offsets =
+      Closure_offsets.add_set_of_closures t.closure_offsets ~is_phantom
+        set_of_closures
+    in
+    { t with closure_offsets }
 
   let add_region_closed_early t region =
     { t with

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -95,11 +95,6 @@ module IR = struct
 end
 
 module Env = struct
-  type value_approximation =
-    | Value_unknown
-    | Closure_approximation of Code_id.t * Code.t option
-    | Block_approximation of value_approximation array * Alloc_mode.t
-
   type t =
     { variables : Variable.t Ident.Map.t;
       globals : Symbol.t Numeric_types.Int.Map.t;
@@ -107,7 +102,7 @@ module Env = struct
       current_unit_id : Ident.t;
       current_depth : Variable.t option;
       symbol_for_global : Ident.t -> Symbol.t;
-      value_approximations : value_approximation Name.Map.t;
+      value_approximations : Code.t Value_approximation.t Name.Map.t;
       big_endian : bool;
       path_to_root : Debuginfo.Scoped_location.t;
       inlining_history_tracker : Inlining_history.Tracker.t
@@ -241,7 +236,7 @@ module Env = struct
     Ident.Map.find id t.simples_to_substitute
 
   let add_value_approximation t name approx =
-    if approx = Value_unknown
+    if Value_approximation.is_unknown approx
     then t
     else
       { t with
@@ -252,17 +247,17 @@ module Env = struct
     add_value_approximation t name (Closure_approximation (code_id, approx))
 
   let add_block_approximation t name approxs alloc_mode =
-    if Array.for_all (( = ) Value_unknown) approxs
+    if Array.for_all Value_approximation.is_unknown approxs
     then t
     else
       add_value_approximation t name (Block_approximation (approxs, alloc_mode))
 
   let find_value_approximation t simple =
     Simple.pattern_match simple
-      ~const:(fun _ -> Value_unknown)
+      ~const:(fun _ -> Value_approximation.Value_unknown)
       ~name:(fun name ~coercion:_ ->
         try Name.Map.find name t.value_approximations
-        with Not_found -> Value_unknown)
+        with Not_found -> Value_approximation.Value_unknown)
 
   let add_approximation_alias t name alias =
     match find_value_approximation t (Simple.name name) with
@@ -288,7 +283,7 @@ end
 
 module Acc = struct
   type continuation_application =
-    | Trackable_arguments of Env.value_approximation list
+    | Trackable_arguments of Code.t Value_approximation.t list
     | Untrackable
 
   type t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -177,7 +177,7 @@ module Acc : sig
 
   val create :
     symbol_for_global:(Ident.t -> Symbol.t) ->
-    closure_offsets:Closure_offsets.t Or_unknown.t ->
+    closure_offsets:Closure_offsets.t ->
     t
 
   val declared_symbols : t -> (Symbol.t * Static_const.t) list
@@ -230,7 +230,7 @@ module Acc : sig
 
   val symbol_for_global : t -> Ident.t -> Symbol.t
 
-  val closure_offsets : t -> Closure_offsets.t Or_unknown.t
+  val closure_offsets : t -> Closure_offsets.t
 
   val add_set_of_closures_offsets :
     is_phantom:bool -> t -> Set_of_closures.t -> t

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -81,6 +81,19 @@ module IR : sig
   val print_named : Format.formatter -> named -> unit
 end
 
+module Inlining : sig
+  type inlinable_result =
+    | Not_inlinable
+    | Inlinable of Code.t
+
+  val threshold : unit -> int
+
+  val definition_inlining_decision :
+    Inline_attribute.t ->
+    Cost_metrics.t ->
+    Function_decl_inlining_decision_type.t
+end
+
 (** Used to remember which [Variable.t] values correspond to which [Ident.t]
     values during closure conversion, and similarly for static exception
     identifiers. *)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -85,11 +85,6 @@ end
     values during closure conversion, and similarly for static exception
     identifiers. *)
 module Env : sig
-  type value_approximation =
-    | Value_unknown
-    | Closure_approximation of Code_id.t * Code.t option
-    | Block_approximation of value_approximation array * Alloc_mode.t
-
   type t
 
   val create : symbol_for_global:(Ident.t -> Symbol.t) -> big_endian:bool -> t
@@ -127,16 +122,16 @@ module Env : sig
 
   val find_simple_to_substitute_exn : t -> Ident.t -> Simple.t
 
-  val add_value_approximation : t -> Name.t -> value_approximation -> t
+  val add_value_approximation : t -> Name.t -> Code.t Value_approximation.t -> t
 
   val add_closure_approximation : t -> Name.t -> Code_id.t * Code.t option -> t
 
   val add_block_approximation :
-    t -> Name.t -> value_approximation array -> Alloc_mode.t -> t
+    t -> Name.t -> Code.t Value_approximation.t array -> Alloc_mode.t -> t
 
   val add_approximation_alias : t -> Name.t -> Name.t -> t
 
-  val find_value_approximation : t -> Simple.t -> value_approximation
+  val find_value_approximation : t -> Simple.t -> Code.t Value_approximation.t
 
   val current_depth : t -> Variable.t option
 
@@ -194,7 +189,7 @@ module Acc : sig
   val remove_continuation_from_free_names : Continuation.t -> t -> t
 
   val continuation_known_arguments :
-    cont:Continuation.t -> t -> Env.value_approximation list option
+    cont:Continuation.t -> t -> Code.t Value_approximation.t list option
 
   val with_free_names : Name_occurrences.t -> t -> t
 
@@ -325,7 +320,7 @@ module Apply_cont_with_acc : sig
   val create :
     Acc.t ->
     ?trap_action:Trap_action.t ->
-    ?args_approx:Env.value_approximation list ->
+    ?args_approx:Code.t Value_approximation.t list ->
     Continuation.t ->
     args:Simple.t list ->
     dbg:Debuginfo.t ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -87,7 +87,11 @@ end
 module Env : sig
   type t
 
-  val create : symbol_for_global:(Ident.t -> Symbol.t) -> big_endian:bool -> t
+  val create :
+    symbol_for_global:(Ident.t -> Symbol.t) ->
+    big_endian:bool ->
+    cmx_loader:Flambda_cmx.loader ->
+    t
 
   val clear_local_bindings : t -> t
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1765,9 +1765,12 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~scrutinee
       switch_expr acc ccenv)
     k_exn
 
-let lambda_to_flambda ~symbol_for_global ~big_endian ~module_ident
+let lambda_to_flambda ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
     ~module_block_size_in_words (lam : Lambda.lambda) :
-    Flambda_unit.t * Exported_code.t * Exported_offsets.t Or_unknown.t =
+    Flambda_unit.t
+    * Exported_code.t
+    * Flambda_cmx_format.t option
+    * Exported_offsets.t Or_unknown.t =
   let current_unit_id =
     Compilation_unit.get_persistent_ident (Compilation_unit.get_current_exn ())
   in
@@ -1779,6 +1782,6 @@ let lambda_to_flambda ~symbol_for_global ~big_endian ~module_ident
   let toplevel acc ccenv =
     cps_tail acc env ccenv lam return_continuation exn_continuation
   in
-  CC.close_program ~symbol_for_global ~big_endian ~module_ident
+  CC.close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
     ~module_block_size_in_words ~program:toplevel
     ~prog_return_cont:return_continuation ~exn_continuation

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1770,7 +1770,7 @@ let lambda_to_flambda ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
     Flambda_unit.t
     * Exported_code.t
     * Flambda_cmx_format.t option
-    * Exported_offsets.t Or_unknown.t =
+    * Exported_offsets.t =
   let current_unit_id =
     Compilation_unit.get_persistent_ident (Compilation_unit.get_current_exn ())
   in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
@@ -28,4 +28,4 @@ val lambda_to_flambda :
   Flambda_unit.t
   * Exported_code.t
   * Flambda_cmx_format.t option
-  * Exported_offsets.t Or_unknown.t
+  * Exported_offsets.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
@@ -21,7 +21,11 @@
 val lambda_to_flambda :
   symbol_for_global:(?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
   big_endian:bool ->
+  cmx_loader:Flambda_cmx.loader ->
   module_ident:Ident.t ->
   module_block_size_in_words:int ->
   Lambda.lambda ->
-  Flambda_unit.t * Exported_code.t * Exported_offsets.t Or_unknown.t
+  Flambda_unit.t
+  * Exported_code.t
+  * Flambda_cmx_format.t option
+  * Exported_offsets.t Or_unknown.t

--- a/middle_end/flambda2/simplify/simplify.mli
+++ b/middle_end/flambda2/simplify/simplify.mli
@@ -30,8 +30,7 @@ type simplify_result = private
   }
 
 val run :
-  symbol_for_global:(?comp_unit:Compilation_unit.t -> Ident.t -> Symbol.t) ->
-  get_global_info:(Compilation_unit.t -> Flambda_cmx_format.t option) ->
+  cmx_loader:Flambda_cmx.loader ->
   round:int ->
   Flambda_unit.t ->
   simplify_result

--- a/middle_end/flambda2/tests/tools/dune
+++ b/middle_end/flambda2/tests/tools/dune
@@ -4,4 +4,4 @@
   (flags (:standard -principal -nostdlib))
   (libraries
    stdlib runtime_native ocamlcommon ocamloptcomp
-   flambda2 flambda2_compare flambda2_parser flambda2_terms))
+   flambda2 flambda2_compare flambda2_parser flambda2_terms flambda2_cmx))

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -51,7 +51,9 @@ let run_expect_test ~symbol_for_global ~get_global_info ~extension ~filename
     Fexpr_to_flambda.conv ~symbol_for_global ~module_ident before
   in
   check_invariants before_fl;
-  let cmx_loader = Flambda_cmx.create_loader ~symbol_for_global ~get_global_info in
+  let cmx_loader =
+    Flambda_cmx.create_loader ~symbol_for_global ~get_global_info
+  in
   let { Simplify.unit = actual_fl; _ } =
     Simplify.run ~cmx_loader ~round:0 before_fl
   in

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -51,8 +51,9 @@ let run_expect_test ~symbol_for_global ~get_global_info ~extension ~filename
     Fexpr_to_flambda.conv ~symbol_for_global ~module_ident before
   in
   check_invariants before_fl;
+  let cmx_loader = Flambda_cmx.create_loader ~symbol_for_global ~get_global_info in
   let { Simplify.unit = actual_fl; _ } =
-    Simplify.run ~symbol_for_global ~get_global_info ~round:0 before_fl
+    Simplify.run ~cmx_loader ~round:0 before_fl
   in
   let expected_fl =
     Fexpr_to_flambda.conv ~symbol_for_global ~module_ident expected

--- a/middle_end/flambda2/tests/tools/import.ml
+++ b/middle_end/flambda2/tests/tools/import.ml
@@ -3,3 +3,4 @@ include Flambda2_identifiers
 include Flambda2_terms
 include Flambda2_parser
 include Flambda2_simplify
+include Flambda2_cmx

--- a/middle_end/flambda2/types/dune
+++ b/middle_end/flambda2/types/dune
@@ -34,6 +34,7 @@
   ocamlcommon
   flambda2_algorithms
   flambda2_bound_identifiers
+  flambda2_classic_mode_types
   flambda2_identifiers
   flambda2_kinds
   flambda2_lattices

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1262,9 +1262,9 @@ end = struct
 
   let create_from_closure_conversion_approx
       (symbols : _ Value_approximation.t Symbol.Map.t) =
-    let defined_symbols_without_equations =
-      Symbol.Map.keys symbols |> Symbol.Set.elements
-    in
+    (* By using Cached_level.add_or_replace_binding below, we ensure that all
+       symbols have an equation (that may be Unknown). *)
+    let defined_symbols_without_equations = [] in
     let code_age_relation = Code_age_relation.empty in
     let next_binding_time = Binding_time.earliest_var in
     let rec type_from_approx approx =

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1202,6 +1202,9 @@ module Serializable : sig
 
   val create : Pre_serializable.t -> reachable_names:Name_occurrences.t -> t
 
+  val create_from_closure_conversion_approx :
+    'a Value_approximation.t Symbol.Map.t -> t
+
   val free_closure_ids_and_closure_vars : t -> Name_occurrences.t
 
   val print : Format.formatter -> t -> unit
@@ -1255,6 +1258,53 @@ end = struct
       code_age_relation;
       just_after_level;
       next_binding_time = env.next_binding_time
+    }
+
+  let create_from_closure_conversion_approx
+      (symbols : _ Value_approximation.t Symbol.Map.t) =
+    let defined_symbols_without_equations =
+      Symbol.Map.keys symbols |> Symbol.Set.elements
+    in
+    let code_age_relation = Code_age_relation.empty in
+    let next_binding_time = Binding_time.earliest_var in
+    let rec type_from_approx approx =
+      match (approx : _ Value_approximation.t) with
+      | Value_unknown -> MTC.unknown Flambda_kind.value
+      | Block_approximation (fields, alloc_mode) ->
+        let fields = List.map type_from_approx (Array.to_list fields) in
+        MTC.immutable_block ~is_unique:false Tag.zero
+          ~field_kind:Flambda_kind.value ~fields (Or_unknown.Known alloc_mode)
+      | Closure_approximation (code_id, _code_opt) ->
+        let closure_id =
+          Closure_id.wrap
+            (Compilation_unit.get_current_exn ())
+            (Variable.create (Code_id.name code_id))
+        in
+        let fun_decl =
+          TG.Function_type.create code_id
+            ~rec_info:(MTC.unknown Flambda_kind.rec_info)
+        in
+        let all_function_decls_in_set =
+          Closure_id.Map.singleton closure_id (Or_unknown_or_bottom.Ok fun_decl)
+        in
+        let all_closures_in_set =
+          Closure_id.Map.singleton closure_id (MTC.unknown Flambda_kind.value)
+        in
+        let all_closure_vars_in_set = Var_within_closure.Map.empty in
+        MTC.exactly_this_closure closure_id ~all_function_decls_in_set
+          ~all_closures_in_set ~all_closure_vars_in_set Or_unknown.Unknown
+    in
+    let just_after_level =
+      Symbol.Map.fold
+        (fun sym approx cached ->
+          Cached_level.add_or_replace_binding cached (Name.symbol sym)
+            (type_from_approx approx) Binding_time.symbols Name_mode.normal)
+        symbols Cached_level.empty
+    in
+    { defined_symbols_without_equations;
+      code_age_relation;
+      just_after_level;
+      next_binding_time
     }
 
   let free_closure_ids_and_closure_vars t =

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -192,6 +192,9 @@ module Serializable : sig
 
   val free_closure_ids_and_closure_vars : t -> Name_occurrences.t
 
+  val create_from_closure_conversion_approx :
+    'a Value_approximation.t Symbol.Map.t -> t
+
   val print : Format.formatter -> t -> unit
 
   val to_typing_env :

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -65,7 +65,7 @@ let join ?bound_name central_env ~left_env ~left_ty ~right_env ~right_ty =
   | Unknown -> unknown_like left_ty
   | Known ty -> ty
 
-let extract_symbol_approx env symbol all_code =
+let extract_symbol_approx env symbol find_code =
   let rec type_to_approx (ty : t) : _ Value_approximation.t =
     let expanded = Expand_head.expand_head env ty in
     match Expand_head.Expanded_type.descr expanded with
@@ -88,7 +88,7 @@ let extract_symbol_approx env symbol all_code =
           | Bottom | Unknown -> Value_unknown
           | Ok function_type ->
             let code_id = Function_type.code_id function_type in
-            let code = Code_id.Map.find_opt code_id all_code in
+            let code = find_code code_id in
             (* CR vlaviron: Should we fail if [code] is [None] ? *)
             Closure_approximation (code_id, code)
         end)

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -89,7 +89,6 @@ let extract_symbol_approx env symbol find_code =
           | Ok function_type ->
             let code_id = Function_type.code_id function_type in
             let code = find_code code_id in
-            (* CR vlaviron: Should we fail if [code] is [None] ? *)
             Closure_approximation (code_id, code)
         end)
       | Variant

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -758,4 +758,7 @@ val never_holds_locally_allocated_values :
   Typing_env.t -> Variable.t -> Flambda_kind.t -> bool
 
 val extract_symbol_approx :
-  Typing_env.t -> Symbol.t -> 'code Code_id.Map.t -> 'code Value_approximation.t
+  Typing_env.t ->
+  Symbol.t ->
+  (Code_id.t -> 'code option) ->
+  'code Value_approximation.t

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -223,6 +223,9 @@ module Typing_env : sig
 
     val free_closure_ids_and_closure_vars : t -> Name_occurrences.t
 
+    val create_from_closure_conversion_approx :
+      'a Value_approximation.t Symbol.Map.t -> t
+
     val print : Format.formatter -> t -> unit
 
     val to_typing_env :
@@ -753,3 +756,6 @@ val reify :
 
 val never_holds_locally_allocated_values :
   Typing_env.t -> Variable.t -> Flambda_kind.t -> bool
+
+val extract_symbol_approx :
+  Typing_env.t -> Symbol.t -> 'code Code_id.Map.t -> 'code Value_approximation.t


### PR DESCRIPTION
From #203, [relevant diff](https://github.com/ocaml-flambda/flambda-backend/pull/336/files/596d716850cd2e020ecd7079b587eaf0cfbf4d5e..6ae749cc3f43856317708e825956c2a9f9e6c46c).

This improves #203 by generating .cmx for units compiled in classic mode, allowing the inlining to be done beyond the local unit.

Thanks to the work of @lthls, the cmx of both classic mode and simplify are compatible.  