### PR TITLE
Add code coverage using bisect_ppx

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,80 @@
+name: coverage-linux
+on: [push, pull_request]
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: flambda2_coverage
+            config: --enable-middle-end=flambda2 --enable-coverage
+            ocamlparam: ''
+
+    env:
+      J: "3"
+
+    steps:
+    - name: Checkout the Flambda backend repo
+      uses: actions/checkout@master
+      with:
+        path: 'flambda_backend'
+
+    # This adds a switch at $GITHUB_WORKSPACE/_opam
+    - name: Set up OCaml 4.12
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: 4.12
+        opam-pin: false
+        opam-depext: false
+
+    - name: Get host build environment from cache
+      uses: actions/cache@v1
+      id: cache
+      with:
+        path: ${{ github.workspace }}/_opam
+        key: ${{ matrix.os }}-cache-ocaml-412-dune-2.9.1-g7606d586
+
+    - name: Build Dune
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        opam pin dune --yes \
+          git+https://github.com/ocaml-flambda/dune#special_dune
+
+    - name: Build bisect_ppx
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        # bisect_ppx fails to build with current ppxlib
+        opam pin ppxlib 0.23.0 --yes
+        opam pin bisect_ppx --yes \
+          git+https://github.com/lukemaurer/bisect_ppx#html-report-collate-fix
+
+    - name: Trim cached files
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        # Remove unneeded parts to shrink cache file
+        rm -rf _opam/{lib/ocaml/expunge,bin/*.byte}
+
+    - name: Configure Flambda backend
+      working-directory: flambda_backend
+      run: |
+        autoconf
+        ./configure \
+          --prefix=$GITHUB_WORKSPACE/_install \
+          --with-dune=$GITHUB_WORKSPACE/_opam/bin/dune \
+          ${{ matrix.config }}
+
+
+    - name: Build, install and test Flambda backend
+      working-directory: flambda_backend
+      run: opam exec -- make ci
+      env:
+        BUILD_OCAMLPARAM: ${{ matrix.ocamlparam }}
+
+    - name: Publish coverage report
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage
+        path: flambda_backend/_coverage/**

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ _compare/
 _runtest/
 autom4te.cache
 _install/
+_coverage/
 
 /Makefile.config
 /config.log

--- a/HACKING.md
+++ b/HACKING.md
@@ -9,6 +9,7 @@ want to modify the Flambda backend.  Jump to:
   - [Rebuilding during dev work](#rebuilding-during-dev-work)
   - [Running tests](#running-tests)
   - [Running only part of the upstream testsuite](#running-only-part-of-the-upstream-testsuite)
+  - [Running tests with coverage analysis](#running-tests-with-coverage-analysis)
   - [Running the compiler produced by "make hacking" on an example without the stdlib](#running-the-compiler-produced-by-make-hacking-on-an-example-without-the-stdlib)
   - [Getting the compilation command for a stdlib file](#getting-the-compilation-command-for-a-stdlib-file)
   - [Bootstrapping the ocaml subtree](#bootstrapping-the-ocaml-subtree)
@@ -133,6 +134,27 @@ OCAMLSRCDIR=<FLAMBDA_BACKEND>/_runtest make one DIR=tests/runtime-errors
 where `<FLAMBDA_BACKEND>` is the path to your clone.
 You may also need the `CAML_LD_LIBRARY_PATH` setting depending on what you are testing (see `Makefile.in` at the
 root).
+
+## Running tests with coverage analysis
+
+Coverage analysis is available for the Flambda backend tests (that is, just the
+ones run by `make runtest`), which are intended to provide good coverage on
+their own. We use `bisect_ppx` to perform the analysis. Since binaries
+instrumented with `bisect_ppx` have coverage enabled unconditionally, coverage
+support is disabled by default at compile time.
+
+Coverage requires the `bisect_ppx` package to be installed in your OPAM switch.
+Since no OPAM environment is available when building the final compiler, we
+instead enable coverage on the boot compiler and run the tests directly on the
+boot compiler.
+
+To enable coverage, pass the `--enable-coverage` flag to `./configure`.
+(Remember to clean, as by `git clean -dfX`, whenever re-running
+`./configure`). When coverage is enabled, `make boot-runtest` will
+run the tests on the boot compiler and produce coverage data, and
+`make coverage` will produce an HTML report in `_coverage/`. Alternatively,
+with coverage enabled, `make ci` will build the boot compiler, run the
+tests, and produce the report.
 
 ## Running the compiler produced by "make hacking" on an example without the stdlib
 

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ ws_main   = --root=. --workspace=duneconf/main.ws
 
 ifeq ($(coverage),yes)
   coverage_dune_flags=--instrument-with bisect_ppx
-	ocaml_subdirs_to_ignore=otherlibs
+  ocaml_subdirs_to_ignore=otherlibs
 else
   coverage_dune_flags=
-	ocaml_subdirs_to_ignore=
+  ocaml_subdirs_to_ignore=
 endif
 
 define dune_boot_context

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -1,3 +1,4 @@
 install_prefix = @prefix@
 dune = @dune@
 middle_end = @middle_end@
+coverage = @coverage@

--- a/configure.ac
+++ b/configure.ac
@@ -36,9 +36,18 @@ AC_ARG_ENABLE([middle-end],
     [*], [AC_MSG_ERROR([Bad middle end (not closure, flambda or flambda2)])])],
   [AC_MSG_ERROR([--enable-middle-end=closure|flambda|flambda2 must be provided])])
 
+AC_ARG_ENABLE([coverage],
+  [AS_HELP_STRING([--enable-coverage],
+    [Run compiler tests instrumented to output coverage data using bisect_ppx
+     (WARNING: Cannot build an installable compiler with this flag enabled.
+     Mainly intended for use in CI.)])],
+  [coverage=yes],
+  [coverage=no])
+
 AC_SUBST([prefix])
 AC_SUBST([middle_end])
 AC_SUBST([dune])
+AC_SUBST([coverage])
 
 # Don't error on options that this configure script doesn't understand but
 # the ocaml/ one does.

--- a/dune
+++ b/dune
@@ -66,6 +66,7 @@
   (:standard -principal -w -9))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
+ (instrumentation (backend bisect_ppx))
  (modules_without_implementation
   backend_intf
   cmx_format
@@ -282,12 +283,14 @@
    ))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
+ (instrumentation (backend bisect_ppx))
  (libraries ocamlcommon dwarf_flags asm_targets)
  (modules flambda_backend_args flambda_backend_flags))
 
 (executable
  (name flambda_backend_main)
  (modes byte)
+ (instrumentation (backend bisect_ppx))
  (flags (:standard -principal))
  (libraries
   flambda_backend_driver
@@ -307,6 +310,7 @@
 (executable
  (name flambda_backend_main_native)
  (modes native)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard -principal))
  (libraries
@@ -328,6 +332,7 @@
 (executable
  (name boot_ocamlopt)
  (modes native)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard -principal))
  (libraries

--- a/middle_end/flambda2/algorithms/dune
+++ b/middle_end/flambda2/algorithms/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_algorithms)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard -principal))
  (ocamlopt_flags

--- a/middle_end/flambda2/bound_identifiers/dune
+++ b/middle_end/flambda2/bound_identifiers/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_bound_identifiers)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/cmx/dune
+++ b/middle_end/flambda2/cmx/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_cmx)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/compare/dune
+++ b/middle_end/flambda2/compare/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_compare)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/dune
+++ b/middle_end/flambda2/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2)
  (wrapped false)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/from_lambda/dune
+++ b/middle_end/flambda2/from_lambda/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_from_lambda)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/identifiers/dune
+++ b/middle_end/flambda2/identifiers/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_identifiers)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/kinds/dune
+++ b/middle_end/flambda2/kinds/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_kinds)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/lattices/dune
+++ b/middle_end/flambda2/lattices/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_lattices)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/nominal/dune
+++ b/middle_end/flambda2/nominal/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_nominal)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/numbers/dune
+++ b/middle_end/flambda2/numbers/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_numbers)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/parser/dune
+++ b/middle_end/flambda2/parser/dune
@@ -100,6 +100,7 @@
 (library
  (name flambda2_parser)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/simplify/dune
+++ b/middle_end/flambda2/simplify/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_simplify)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/term_basics/dune
+++ b/middle_end/flambda2/term_basics/dune
@@ -5,6 +5,7 @@
 (library
  (name flambda2_term_basics)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/terms/dune
+++ b/middle_end/flambda2/terms/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_terms)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/tests/dune
+++ b/middle_end/flambda2/tests/dune
@@ -1,6 +1,7 @@
 (tests
  (names meet_test)
  (modes native)
+ (instrumentation (backend bisect_ppx))
  (flags (:standard -principal))
  (libraries
   ocamloptcomp ocamlcommon

--- a/middle_end/flambda2/to_cmm/dune
+++ b/middle_end/flambda2/to_cmm/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_to_cmm)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/types/dune
+++ b/middle_end/flambda2/types/dune
@@ -5,6 +5,7 @@
 (library
  (name flambda2_types)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard
    -principal

--- a/middle_end/flambda2/ui/dune
+++ b/middle_end/flambda2/ui/dune
@@ -3,6 +3,7 @@
 (library
  (name flambda2_ui)
  (wrapped true)
+ (instrumentation (backend bisect_ppx))
  (flags
   (:standard -principal))
  (ocamlopt_flags

--- a/ocaml/.gitignore
+++ b/ocaml/.gitignore
@@ -55,6 +55,7 @@ _build
 /ocamlopt
 /ocamlopt.opt
 /ocamlnat
+/dirs-to-ignore.inc
 
 # specific files and patterns in sub-directories
 

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -121,7 +121,9 @@
  (libraries ocamlbytecomp ocamlcommon)
  (modules main_native))
 
-(data_only_dirs yacc)
+; Disabled since there can be only one (data_only_dirs) declaration
+;(data_only_dirs yacc)
+(include dirs-to-ignore.inc)
 
 (rule
  (deps (source_tree yacc))


### PR DESCRIPTION
Coverage is enabled by passing `--enable-coverage` to `./configure`. It's intended that mostly only CI builds will use it, since only the boot compiler can be built (which suffices for running tests).