### PR TITLE
Fix parsecmm.mly in ocaml subdirectory

### DIFF
--- a/ocaml/testsuite/tests/asmgen/catch-try-float.cmm
+++ b/ocaml/testsuite/tests/asmgen/catch-try-float.cmm
@@ -7,6 +7,6 @@ arguments = "-DFLOAT_CATCH -DFUN=catch_try_float main.c"
 (function "catch_try_float" (b:float)
   (+f 10.0
   (catch
-    (try (exit(1) lbl 100.0)
+    (try (exit lbl 100.0)
      with var 456.0)
    with (lbl x:float) (+f x 1000.0))))

--- a/ocaml/testsuite/tests/asmgen/catch-try.cmm
+++ b/ocaml/testsuite/tests/asmgen/catch-try.cmm
@@ -7,6 +7,6 @@ arguments = "-DINT_INT -DFUN=catch_exit main.c"
 (function "catch_exit" (b:int)
   (+ 33
   (catch
-    (try (exit(1) lbl 12)
+    (try (exit lbl 12)
      with var 456)
    with (lbl x:val) (+ x 789))))

--- a/ocaml/testsuite/tools/parsecmm.mly
+++ b/ocaml/testsuite/tools/parsecmm.mly
@@ -37,7 +37,7 @@ let make_switch n selector caselist =
   let index = Array.make n 0 in
   let casev = Array.of_list caselist in
   let dbg = Debuginfo.none in
-  let actv = Array.make (Array.length casev) (Cexit(Cmm.Lbl 0,[],[]), dbg) in
+  let actv = Array.make (Array.length casev) (Cexit(0,[]), dbg) in
   for i = 0 to Array.length casev - 1 do
     let (posl, e) = casev.(i) in
     List.iter (fun pos -> index.(pos) <- i) posl;
@@ -206,9 +206,6 @@ componentlist:
     component                    { [$1] }
   | componentlist STAR component { $3 :: $1 }
 ;
-traps:
-    LPAREN INTCONST RPAREN       { List.init $2 (fun _ -> Pop) }
-  | /**/                         { [] }
 expr:
     INTCONST    { Cconst_int ($1, debuginfo ()) }
   | FLOATCONST  { Cconst_float (float_of_string $1, debuginfo ()) }
@@ -239,22 +236,22 @@ expr:
           match $3 with
             Cconst_int (x, _) when x <> 0 -> $4
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
-                             (Cexit(Cmm.Lbl lbl0,[],[])),
+                             (Cexit(lbl0,[])),
                              debuginfo ()) in
         Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
           Ccatch(Recursive,
-            [lbl1, [], Csequence(body, Cexit(Cmm.Lbl lbl1, [], [])), debuginfo ()],
-            Cexit(Cmm.Lbl lbl1, [], []))) }
-  | LPAREN EXIT traps IDENT exprlist RPAREN
-    { Cexit(Cmm.Lbl (find_label $4), List.rev $5, $3) }
+            [lbl1, [], Csequence(body, Cexit(lbl1, [])), debuginfo ()],
+            Cexit(lbl1, []))) }
+  | LPAREN EXIT IDENT exprlist RPAREN
+    { Cexit(find_label $3, List.rev $4) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
       List.iter (fun (_, l, _, _) ->
         List.iter (fun (x, _) -> unbind_ident x) l) handlers;
       Ccatch(Recursive, handlers, $3) }
-  | EXIT        { Cexit(Cmm.Lbl 0,[],[]) }
+  | EXIT        { Cexit(0,[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
-                { unbind_ident $5; Ctrywith($3, Regular, $5, $6, debuginfo ()) }
+                { unbind_ident $5; Ctrywith($3, $5, $6, debuginfo ()) }
   | LPAREN VAL expr expr RPAREN
       { let open Asttypes in
         Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],

--- a/ocaml/testsuite/tools/parsecmm.mly
+++ b/ocaml/testsuite/tools/parsecmm.mly
@@ -218,7 +218,7 @@ expr:
   | LPAREN APPLY location expr exprlist machtype RPAREN
                 { Cop(Capply $6, $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
-               {Cop(Cextcall($3, $5, false, None), List.rev $4, debuginfo ())}
+               {Cop(Cextcall($3, $5, [], false, None), List.rev $4, debuginfo ())}
   | LPAREN ALLOC exprlist RPAREN { Cop(Calloc, List.rev $3, debuginfo ()) }
   | LPAREN SUBF expr RPAREN { Cop(Cnegf, [$3], debuginfo ()) }
   | LPAREN SUBF expr expr RPAREN { Cop(Csubf, [$3; $4], debuginfo ()) }

--- a/ocaml/testsuite/tools/parsecmm.mly
+++ b/ocaml/testsuite/tools/parsecmm.mly
@@ -218,7 +218,7 @@ expr:
   | LPAREN APPLY location expr exprlist machtype RPAREN
                 { Cop(Capply $6, $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
-               {Cop(Cextcall($3, $5, [], false, None), List.rev $4, debuginfo ())}
+               {Cop(Cextcall($3, $5, [], false), List.rev $4, debuginfo ())}
   | LPAREN ALLOC exprlist RPAREN { Cop(Calloc, List.rev $3, debuginfo ()) }
   | LPAREN SUBF expr RPAREN { Cop(Cnegf, [$3], debuginfo ()) }
   | LPAREN SUBF expr expr RPAREN { Cop(Csubf, [$3; $4], debuginfo ()) }


### PR DESCRIPTION
Running `make tests` under `ocaml` directory is useful when making changes there.  It has been broken since 4.12 because we didn't have a separate copy of parsecmm.mly and asmgen tests to work with the changes in `backend` directory and our top-level `make runtests-upstream` target. 

This PR fixes parsecmm.mly so `make tests -C ocaml` can run, but there are still two tests failing:
```
List of failed tests:
    tests/lib-sys/'opaque.ml' with 1 (native) 
    tests/typing-objects/'Exemples.ml' with 1 (expect) 
```
The first will be fixed when we move to 4.13 (or whichever upstream release has `Iopaque` PR 9412). I don't know what's ailing the second one.