### PR TITLE
Clobber-free build

### DIFF
--- a/.github/workflows/check_all_arches.yml
+++ b/.github/workflows/check_all_arches.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Checkout dune github repo
       uses: actions/checkout@master
       with:
-        repository: 'ocaml-flambda/dune'
-        ref: 'special_dune'
+        repository: 'lukemaurer/dune'
+        ref: 'special-dune-2.9'
         path: 'dune'
 
     - name: Build dune

--- a/.github/workflows/closure.yml
+++ b/.github/workflows/closure.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Checkout dune github repo
       uses: actions/checkout@master
       with:
-        repository: 'ocaml-flambda/dune'
-        ref: 'special_dune'
+        repository: 'lukemaurer/dune'
+        ref: 'special-dune-2.9'
         path: 'dune'
 
     - name: Build dune

--- a/.github/workflows/closure_cfg.yml
+++ b/.github/workflows/closure_cfg.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Checkout dune github repo
       uses: actions/checkout@master
       with:
-        repository: 'ocaml-flambda/dune'
-        ref: 'special_dune'
+        repository: 'lukemaurer/dune'
+        ref: 'special-dune-2.9'
         path: 'dune'
 
     - name: Build dune

--- a/.github/workflows/flambda1.yml
+++ b/.github/workflows/flambda1.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Checkout dune github repo
       uses: actions/checkout@master
       with:
-        repository: 'ocaml-flambda/dune'
-        ref: 'special_dune'
+        repository: 'lukemaurer/dune'
+        ref: 'special-dune-2.9'
         path: 'dune'
 
     - name: Build dune

--- a/.github/workflows/flambda1_cfg.yml
+++ b/.github/workflows/flambda1_cfg.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Checkout dune github repo
       uses: actions/checkout@master
       with:
-        repository: 'ocaml-flambda/dune'
-        ref: 'special_dune'
+        repository: 'lukemaurer/dune'
+        ref: 'special-dune-2.9'
         path: 'dune'
 
     - name: Build dune

--- a/.github/workflows/flambda2.yml
+++ b/.github/workflows/flambda2.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Checkout dune github repo
       uses: actions/checkout@master
       with:
-        repository: 'ocaml-flambda/dune'
-        ref: 'special_dune'
+        repository: 'lukemaurer/dune'
+        ref: 'special-dune-2.9'
         path: 'dune'
 
     - name: Build dune

--- a/.github/workflows/flambda2_cfg.yml
+++ b/.github/workflows/flambda2_cfg.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Checkout dune github repo
       uses: actions/checkout@master
       with:
-        repository: 'ocaml-flambda/dune'
-        ref: 'special_dune'
+        repository: 'lukemaurer/dune'
+        ref: 'special-dune-2.9'
         path: 'dune'
 
     - name: Build dune

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ _compare/
 _runtest/
 _stage0_configure/
 _stage2_configure/
+_upstream_configure/
 autom4te.cache
 _install/
 
@@ -56,6 +57,7 @@ _install/
 /ocaml-stage0-config.status
 /ocaml-stage1-config.status
 /ocaml-stage2-config.status
+/ocaml-upstream-config.status
 /ocaml-stage1-Makefile.config
 /ocamlopt_flags.sexp
 /oc_cflags.sexp

--- a/.gitignore
+++ b/.gitignore
@@ -37,13 +37,12 @@ _ocamltestd
 
 _build/
 _build0/
-_build1/
-_build2/
 _build_upstream/
 .rsync-output
 .rsync-output-compare
 _compare/
 _runtest/
+_stage0_configure/
 _stage2_configure/
 autom4te.cache
 _install/
@@ -54,9 +53,12 @@ _install/
 /configure
 /configure_opts
 /configure_opts_stage0
+/ocaml-stage0-config.status
 /ocaml-stage1-config.status
 /ocaml-stage2-config.status
+/ocaml-stage1-Makefile.config
 /ocamlopt_flags.sexp
 /oc_cflags.sexp
 /oc_cppflags.sexp
 /sharedlib_cflags.sexp
+/dune-workspace

--- a/HACKING.md
+++ b/HACKING.md
@@ -121,6 +121,13 @@ and test run.
 Some of our tests are expect tests run using a custom tool called `flexpect`.
 Corrected outputs can be promoted using `make promote`.
 
+Note that currently the Flambda backend tests run entirely on the stage1
+compiler. This is because the stage1 compiler is treated essentially as a
+cross-compiler in `dune-workspace.stage2`, so Dune thinks that the stage2
+executables aren't runnable on this machine. Thus if you try to build
+`@_build/stage2/runtest`, explicitly saying to run the tests using stage2,
+it still falls back to stage1.
+
 ## Running only part of the upstream testsuite
 
 This can be done from the `_runtest` directory after it has been initialised by a previous `make runtest-upstream`.

--- a/Makefile.in
+++ b/Makefile.in
@@ -16,10 +16,33 @@ stage2_prefix=@stage2_prefix@
 middle_end=@middle_end@
 dune=@dune@
 
-stage1_build=_build1/default
-stage2_build=_build2/default
+stage1_build=_build/stage1
+stage2_build=_build/stage2
 
-arch := $(shell grep '^ARCH=' ocaml/Makefile.config | cut -d'=' -f2)
+# Note that this is assigned with = so it will be expanded lazily. Won't work
+# unless ocaml-stage1-Makefile.config has been generated already (see the
+# find_arch target below).
+arch=$(shell grep '^ARCH=' ocaml-stage1-Makefile.config | cut -d'=' -f2)
+
+# A target to use to make sure that $(arch) will work. It doesn't actually
+# find the architecture itself, but it makes sure that it can be found.
+.PHONY: find_arch
+find_arch: ocaml-stage1-Makefile.config
+
+# Annoyingly, Dune checks all build contexts to make sure they have ocamlc in
+# their PATHs, even when only building in a subset of build contexts. So when we
+# haven't yet built stage1, the stage2 build context is invalid, and this
+# prevents building stage1. So we have to build stage1 in a separate workspace
+# that doesn't define stage2 at all. (Sadly, the workspace for stage2 has to
+# include *both* contexts so that stage1 can be stage2's host context, so we
+# have to be redundant.)
+#
+# Also, I would love to just define $(dune_stage1) and $(dune_stage2) to have
+# both the Dune executable and these flags, but Dune does not allow any flags
+# before the name of the command (so "dune build --root=." works but "dune
+# --root=. build" does not).
+dune_flags_stage1=--workspace=dune-workspace.stage1 --root=.
+dune_flags_stage2=--workspace=dune-workspace.stage2 --root=.
 
 # The Flambda backend compiler build proceeds, from cold, in three stages.
 # We call these (in order) stage0, stage1 and stage2.  They are documented
@@ -37,40 +60,40 @@ arch := $(shell grep '^ARCH=' ocaml/Makefile.config | cut -d'=' -f2)
 #
 # CR-someday mshinwell: We should replace this with a coldstart using dune.
 .PHONY: stage0
-stage0: _build0/config.status
+stage0: ocaml-stage0-config.status
 	rm -f .rsync-output
 	rsync -i -a --filter=':- $$(pwd)/ocaml/.gitignore' \
 	  $$(pwd)/ocaml/ $$(pwd)/_build0 \
 	  | grep -v '/$$' \
 	  | tee .rsync-output
 	if [ -s .rsync-output ] || ! [ -d $(stage0_prefix) ]; then \
-	  (cd _build0 && \
-	    $(MAKE) world.opt && \
-	    $(MAKE) ocamlnat && \
-	    $(MAKE) install); \
+	  $(MAKE) force-stage0; \
 	fi
+
+.PHONY: force-stage0
+force-stage0: ocaml-stage0-config.status
+	cp ocaml-stage0-config.status _build0/config.status
+	(cd _build0 && \
+	  ./config.status && \
+	  $(MAKE) world.opt && \
+	  $(MAKE) ocamlnat)
+	(cd _build0 && $(MAKE) install)
 
 # stage1 builds the Flambda backend compiler using the stage0 compiler.
 #
 # At the end, we have a working Flambda backend compiler, equivalent to having
 # done "make ocamlopt" upstream.  For testing with a broken middle or backend,
 # e.g. if the stdlib doesn't compile, you can stop here and run
-# _build1/default/flambda_backend_main.exe.
+# _build/stage1/flambda_backend_main.exe.
 #
 # At this point we don't yet have a standard library and a set of otherlibs
 # whose .cmx files are compatible with this new compiler.  Neither are the
 # Flambda backend compiler, or the compilerlibs that form it, built with the
 # Flambda backend compiler itself.  These steps comprise stage2.
-#
-# This code should use build contexts instead of --build-dir.
 .PHONY: stage1
-stage1: ocaml-stage1-config.status stage0 \
-	  config_files
-	cp ocaml-stage1-config.status ocaml/config.status
-	(cd ocaml && ./config.status)
-	PATH=$(stage0_prefix)/bin:$$PATH \
-	  ARCH=$(arch) \
-	  $(dune) build --root=. --profile=release --build-dir=_build1 @install
+stage1: ocaml-stage1-config.status stage0 config_files find_arch
+	ARCH=$(arch) $(dune) build @$(stage1_build)/install $(dune_flags_stage1) \
+	  --profile=release
 	(cd $(stage1_prefix)/bin && \
 	  rm -f ocamllex && \
 	  ln -s ocamllex.opt ocamllex)
@@ -83,12 +106,9 @@ stage1: ocaml-stage1-config.status stage0 \
 # itself, including the stdlib, otherlibs, compilerlibs, etc.  The result is
 # equivalent to having done "make world.opt && make ocamlnat" upstream.
 .PHONY: stage2
-stage2: ocaml-stage2-config.status stage1
-	cp ocaml-stage2-config.status ocaml/config.status
-	(cd ocaml && ./config.status)
-	PATH=$(stage1_prefix)/bin:$$PATH \
-	  ARCH=$(arch) \
-	  $(dune) build --root=. --profile=release --build-dir=_build2 @install
+stage2: ocaml-stage2-config.status find_arch stage1
+	ARCH=$(arch) $(dune) build $(dune_flags_stage2) --profile=release \
+		@$(stage2_build)/install
 
 # This target is like a polling version of upstream "make ocamlopt" (based
 # on the stage1 target, above).
@@ -96,13 +116,9 @@ stage2: ocaml-stage2-config.status stage1
 # features, especially large ones that take a long time to get to compile,
 # in the middle end and backend.
 .PHONY: hacking
-hacking: ocaml-stage1-config.status stage0 \
-	  config_files
-	cp ocaml-stage1-config.status ocaml/config.status
-	(cd ocaml && ./config.status)
-	PATH=$(stage0_prefix)/bin:$$PATH \
-	  ARCH=$(arch) \
-	  $(dune) build --root=. -w --profile=release --build-dir=_build1 @install
+hacking: ocaml-stage1-config.status stage0 config_files find_arch
+	ARCH=$(arch) $(dune) build $(dune_flags_stage2) -w --profile=release \
+	  @$(stage1_build)/install
 
 
 ## Test compilation of backend-specific parts
@@ -117,20 +133,16 @@ ARCH_SPECIFIC =\
 .PHONY: check_arch
 check_arch: ocaml-stage1-config.status stage0 \
 	config_files
-	cp ocaml-stage1-config.status ocaml/config.status
-	(cd ocaml && ./config.status)
 	@echo "========= CHECKING backend/$(ARCH) =============="
 	rm -f $(ARCH_SPECIFIC)
-	PATH=$(stage0_prefix)/bin:$$PATH \
-	  $(dune) build --root=. --profile=release --build-dir=_build1 ocamloptcomp.cma
+	$(dune) build $(dune_flags_stage1) --profile=release \
+	  $(stage1_build)/ocamloptcomp.cma
 	rm -f $(ARCH_SPECIFIC)
 
 .PHONY: check_all_arches
 check_all_arches: ocaml-stage1-config.status stage0 \
 	config_files
-	cp ocaml-stage1-config.status ocaml/config.status
-	(cd ocaml && ./config.status)
-	if $$(grep '^ARCH64=true' ocaml/Makefile.config > /dev/null) ; \
+	if $$(grep '^ARCH64=true' ocaml-stage1-Makefile.config > /dev/null) ; \
 	then \
 		for i in $(ARCHES); do \
 		   $(MAKE) --no-print-directory check_arch ARCH=$$i || exit 1; \
@@ -144,18 +156,33 @@ check_all_arches: ocaml-stage1-config.status stage0 \
 # Currently the middle end for stage0 will match the selected middle end
 # for the Flambda backend compiler, except when using Flambda 2, when it
 # will be Closure (see configure.ac).
-_build0/config.status: ocaml/configure.ac
-	rm -rf _build0
-	mkdir _build0
-	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build0
-	(cd _build0 && \
-	  cat ../configure_opts_stage0 | tr -d '\n' | xargs -0 ./configure -C \
+#
+# IMPORTANT: We *never* run a configure or config.status script within
+# the ocaml subtree. We're going to have three different builds using
+# that same subtree, and in particular the stage1 and stage2 builds
+# share a single Dune state database (_build/.db), so if anything
+# clobbers anything in ocaml/, it could trip something up.
+#
+# Fortunately, it's never actually necessary: configure scripts can
+# trivially be run from anywhere and will generate output wherever you
+# run them, and config.status scripts can also be run from anywhere
+# (given the right command-line options). So here, for instance, since
+# all we want for the moment is the config.status file from the stage0
+# configuration, we make a _stage0_configure directory just to run
+# configure. We'll run this config.status inside the _build0 copy of
+# the ocaml subtree later.
+ocaml-stage0-config.status: ocaml/configure.ac
+	rm -rf _stage0_configure
+	mkdir _stage0_configure
+	(cd _stage0_configure && \
+	  cat ../configure_opts_stage0 | tr -d '\n' | xargs -0 ../ocaml/configure -C \
 	    --prefix=$(stage0_prefix) \
 	    --disable-ocamldoc \
 	    --disable-ocamltest \
 	    --disable-debug-runtime \
 	    --disable-instrumented-runtime \
 	    --disable-debugger)
+	cp _stage0_configure/config.status ocaml-stage0-config.status
 
 # stage1 has already been configured by running the configure script.
 # It is configured according to any options requested by the user, including
@@ -164,22 +191,34 @@ _build0/config.status: ocaml/configure.ac
 
 # This configures stage2 to have the same configure options as stage1
 # except that the prefix is set to the ultimate installation directory.
-# We save the config.status file (which is executable) for fast reconfiguration
-# of the ocaml/ subdirectory during the dune builds for stage1 and stage2.
-# The stage2 configure can be run by make in parallel with that for stage0.
-# We add --enable-ocamltest so that the config.status generated here can be
-# immediately reused for the "compare" target (see below).
+# Rather than change ocaml/ in place (see comments on
+# ocaml-stage0-config.status), we save the config.status file (which is
+# executable) and run it from Dune - thus putting the output in just
+# stage2's build directory. This is a bit of a pain since by default
+# our config.status generates output in subdirectories, which Dune
+# doesn't support. So we have to run the config.status once for each
+# subdirectory it outputs to. (See the rule for m.h and s.h in
+# ocaml/runtime/caml/dune.)
+
+# The stage2 configure can be run by make in parallel with that for
+# stage0.
+
+# We add --enable-ocamltest so that the config.status generated here
+# can be immediately reused for the "compare" target (see below).
 ocaml-stage2-config.status: ocaml/configure.ac
 	rm -rf _stage2_configure
 	mkdir _stage2_configure
-	rsync -a --filter=':- $$(pwd)/ocaml/.gitignore' \
-	  $$(pwd)/ocaml/ $$(pwd)/_stage2_configure
 	(cd _stage2_configure && \
-	  cat ../configure_opts | xargs -0 ./configure -C \
+	  cat ../configure_opts | xargs -0 ../ocaml/configure -C \
 	    --prefix=$(prefix) \
 	    --enable-ocamltest \
-	    --disable-ocamldoc && \
-	  cp config.status ../ocaml-stage2-config.status)
+	    --disable-ocamldoc)
+	cp _stage2_configure/config.status ocaml-stage2-config.status
+
+# A copy of the stage1 Makefile.config out of the way of other things
+ocaml-stage1-Makefile.config: ocaml-stage1-config.status
+	./ocaml-stage1-config.status \
+	  --file=ocaml-stage1-Makefile.config:ocaml/Makefile.config.in
 
 # natdynlinkops2:
 # We need to augment dune's substitutions so this part isn't so
@@ -194,16 +233,14 @@ ocaml-stage2-config.status: ocaml/configure.ac
 # Extract compilation flags from Makefile.config of stage1
 # and write them to a file that dune can use in stage1 and stage2.
 .PHONY: config_files
-config_files: ocaml-stage1-config.status
-	cp ocaml-stage1-config.status ocaml/config.status
-	(cd ocaml && ./config.status)
+config_files: ocaml-stage1-Makefile.config
 # natdynlinkops2
-	cat ocaml/Makefile.config \
+	cat ocaml-stage1-Makefile.config \
 	  | sed 's/^NATDYNLINKOPTS=$$/NATDYNLINKOPTS=-g/' \
 	  | grep '^NATDYNLINKOPTS=' \
 	  | sed 's/^[^=]*=\(.*\)/-ccopt\n"\1"/' \
 	  > ocaml/otherlibs/dynlink/natdynlinkops
-	/bin/echo -n $$(cat ocaml/Makefile.config \
+	/bin/echo -n $$(cat ocaml-stage1-Makefile.config \
 	  | sed 's/^NATDYNLINKOPTS=$$/NATDYNLINKOPTS=-bin-annot/' \
 	  | grep '^NATDYNLINKOPTS=' \
 	  | sed 's/^[^=]*=\(.*\)/\1/') \
@@ -216,7 +253,7 @@ config_files: ocaml-stage1-config.status
 	  /bin/echo -n "-bin-annot" > ocaml/otherlibs/dynlink/natdynlinkops1; \
 	fi
 # flags.sexp
-	grep -q '^FUNCTION_SECTIONS=true' ocaml/Makefile.config; \
+	grep -q '^FUNCTION_SECTIONS=true' ocaml-stage1-Makefile.config; \
 	if [ $$? -eq 0 ] ; then \
 	  /bin/echo -n "(:standard -function-sections)" > ocamlopt_flags.sexp; \
 	else \
@@ -226,11 +263,11 @@ config_files: ocaml-stage1-config.status
 	# two lines triggers a bug in GNU make 3.81, that will as a consequence
 	# change the file name. It also looks like the bug is not triggered by
 	# "`...`".
-	/bin/echo -n "( `grep \"^OC_CFLAGS=\" ocaml/Makefile.config \
+	/bin/echo -n "( `grep \"^OC_CFLAGS=\" ocaml-stage1-Makefile.config \
 		  	| sed 's/^OC_CFLAGS=//'` )" > oc_cflags.sexp
-	/bin/echo -n "( `grep \"^OC_CPPFLAGS=\" ocaml/Makefile.config \
+	/bin/echo -n "( `grep \"^OC_CPPFLAGS=\" ocaml-stage1-Makefile.config \
 		| sed 's/^OC_CPPFLAGS=//'` )" > oc_cppflags.sexp
-	/bin/echo -n "( `grep \"^SHAREDLIB_CFLAGS=\" ocaml/Makefile.config \
+	/bin/echo -n "( `grep \"^SHAREDLIB_CFLAGS=\" ocaml-stage1-Makefile.config \
 		| sed 's/^SHAREDLIB_CFLAGS=//'` )" > sharedlib_cflags.sexp
 
 ## Build upstream compiler.
@@ -292,24 +329,19 @@ runtest:
 	# It's a shame that dune needs the stage1 compiler on the path here.
 	# Ideally that would be inaccessible within tests (to prevent mistakes
 	# such as running "ocamlopt" rather than one of the stage2 binaries).
-	PATH=$(stage1_prefix)/bin:$$PATH \
-	  ARCH=$(arch) \
-	  $(dune) runtest --root=. --profile=release --build-dir=_build2
+	ARCH=$(arch) $(dune) build $(dune_flags_stage2) @$(stage2_build)/runtest \
+	  --profile=release
 
 # Only needed for running the test tools by hand; runtest will take care of
 # building them using Dune
 .PHONY: test-tools
-test-tools: stage1
-	PATH=$(stage1_prefix)/bin:$$PATH \
-	  ARCH=$(arch) \
-	  $(dune) build @middle_end/flambda2/tests/tools/all \
-	    --root=. --profile=release --build-dir=_build2
+test-tools: stage1 find_arch
+	ARCH=$(arch) $(dune) build $(dune_flags_stage2) --profile=release \
+	  @$(stage2_build)/middle_end/flambda2/tests/tools/all
 
 .PHONY: promote
-promote:
-	PATH=$(stage1_prefix)/bin:$$PATH \
-	  ARCH=$(arch) \
-	  $(dune) promote --root=. --build-dir=_build2
+promote: find_arch
+	ARCH=$(arch) $(dune) promote $(dune_flags_stage2)
 
 # The following horror will be removed when work to allow the testsuite to
 # run on an installed tree (led by David Allsopp) is completed.
@@ -326,9 +358,12 @@ runtest-upstream:
 	rm _runtest/testsuite/tests/asmgen/*
 	cp -a testsuite/tests/asmgen/* _runtest/testsuite/tests/asmgen/
 	(cd _runtest && ln -s ../ocaml/Makefile.tools Makefile.tools)
-	(cd _runtest && ln -s ../ocaml/Makefile.build_config Makefile.build_config)
-	(cd _runtest && ln -s ../ocaml/Makefile.config_if_required Makefile.config_if_required)
-	(cd _runtest && ln -s ../ocaml/Makefile.config Makefile.config)
+	(cd _runtest && \
+	  ln -s ../$(stage2_build)/ocaml/Makefile.build_config Makefile.build_config)
+	(cd _runtest && \
+	  ln -s ../ocaml/Makefile.config_if_required Makefile.config_if_required)
+	(cd _runtest && \
+	  ln -s ../$(stage2_build)/ocaml/Makefile.config Makefile.config)
 	cp $(stage2_prefix)/bin/* _runtest/
 	# There seems to be an assumption that ocamlc/ocamlopt/ocamllex are
 	# bytecode...
@@ -338,8 +373,10 @@ runtest-upstream:
 	mv _runtest/ocamllex.byte _runtest/lex/ocamllex
 	mkdir _runtest/yacc
 	mv _runtest/ocamlyacc _runtest/yacc/
-	(cd _runtest && ln -s ../_build2/default/ocaml/runtime runtime)
-	(cd _runtest && ln -s ../_build2/install/default/lib/ocaml stdlib)
+	# Note that stage2_build is relative but stage2_prefix is absolute.
+	# CR lmaurer: We should probably decide on one.
+	(cd _runtest && ln -s ../$(stage2_build)/ocaml/runtime runtime)
+	(cd _runtest && ln -s $(stage2_prefix)/lib/ocaml stdlib)
 	# compilerlibs
 	mkdir _runtest/compilerlibs
 	cp $(stage2_prefix)/lib/ocaml/compiler-libs/*.cma _runtest/compilerlibs
@@ -438,14 +475,10 @@ runtest-upstream:
 	# one is broken.  As such, we use the stage1 build dir, not that from
 	# stage2.
 	# This might be causing a spurious rebuild of the runtime
-	PATH=$(stage0_prefix)/bin:$$PATH \
-	  ARCH=$(arch) \
-	  $(dune) build --root=. --profile=release --build-dir=_build1 \
-	  ocaml/tools/cmpbyt.bc
-	PATH=$(stage0_prefix)/bin:$$PATH \
-	  ARCH=$(arch) \
-	  $(dune) build --root=. --profile=release --build-dir=_build1 \
-	  ocaml/ocamltest/ocamltest.byte
+	ARCH=$(arch) $(dune) build $(dune_flags_stage1) --profile=release \
+	  $(stage1_build)/ocaml/tools/cmpbyt.bc
+	ARCH=$(arch) $(dune) build $(dune_flags_stage1) --profile=release \
+	  $(stage1_build)/ocaml/ocamltest/ocamltest.byte
 	cp $(stage1_build)/ocaml/tools/cmpbyt.bc _runtest/tools/cmpbyt
 	# We should build the native ocamltest too.
 	cp $(stage1_build)/ocaml/ocamltest/ocamltest.byte _runtest/ocamltest/ocamltest
@@ -496,10 +529,8 @@ compare: _compare/config.status
 _compare/config.status: ocaml/configure.ac
 	rm -rf _compare
 	mkdir _compare
-	rsync -a --filter=':- $$(pwd)/ocaml/.gitignore' \
-	  $$(pwd)/ocaml/ $$(pwd)/_compare
 	(cd _compare && \
-	  cat ../configure_opts | xargs -0 ./configure -C \
+	  cat ../configure_opts | xargs -0 ../ocaml/configure -C \
 	    --prefix=$$(pwd)/_install \
 	    --disable-stdlib-manpages \
 	    --disable-ocamltest \

--- a/Makefile.in
+++ b/Makefile.in
@@ -332,11 +332,14 @@ install: stage2
 
 # This target only runs the dune-based tests, not the upstream testsuite.
 # stage2 needs to have been built first.
+#
+# This actually runs the tests on the stage1 compiler, or specifically the
+# stage1 compiler libraries. This is because the tests build executables
+# (linking them with the compiler libraries) and then run the executables,
+# but stage2 has stage1 as its host context (see dune-workspace.stage2), so
+# *all* executables that Dune runs for stage2 come from stage1.
 .PHONY: runtest
 runtest:
-	# It's a shame that dune needs the stage1 compiler on the path here.
-	# Ideally that would be inaccessible within tests (to prevent mistakes
-	# such as running "ocamlopt" rather than one of the stage2 binaries).
 	ARCH=$(arch) $(dune) build $(dune_flags_stage2) @$(stage2_build)/runtest \
 	  --profile=release
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -125,7 +125,7 @@ stage2: ocaml-stage2-config.status find_arch stage1
 # in the middle end and backend.
 .PHONY: hacking
 hacking: ocaml-stage1-config.status stage0 config_files find_arch
-	ARCH=$(arch) $(dune) build $(dune_flags_stage2) -w --profile=release \
+	ARCH=$(arch) $(dune) build $(dune_flags_stage1) -w --profile=release \
 	  @$(stage1_build)/install
 
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -90,6 +90,14 @@ force-stage0: ocaml-stage0-config.status
 # whose .cmx files are compatible with this new compiler.  Neither are the
 # Flambda backend compiler, or the compilerlibs that form it, built with the
 # Flambda backend compiler itself.  These steps comprise stage2.
+#
+# CR-someday lmaurer: In principle, since Dune is building both stage1 and
+# stage2 and the stage2 Dune workspace is a superset of the stage1 one, it
+# shouldn't be necessary to build stage1 and stage2 in separate invocations of
+# Dune. As of this writing, however, Dune doesn't recognize that the ocamlc
+# in stage2's PATH is itself a build target (I suspect because it resolves
+# ocamlc before building anything), so it tries to build stage2 with whatever
+# compiler is in the user's PATH.
 .PHONY: stage1
 stage1: ocaml-stage1-config.status stage0 config_files find_arch
 	ARCH=$(arch) $(dune) build @$(stage1_build)/install $(dune_flags_stage1) \

--- a/Makefile.in
+++ b/Makefile.in
@@ -180,6 +180,8 @@ check_all_arches: ocaml-stage1-config.status stage0 \
 # configure. We'll run this config.status inside the _build0 copy of
 # the ocaml subtree later.
 ocaml-stage0-config.status: ocaml/configure.ac
+# Make a separate space to run ocaml/configure and harvest the resulting
+# config.status script
 	rm -rf _stage0_configure
 	mkdir _stage0_configure
 	(cd _stage0_configure && \
@@ -280,20 +282,22 @@ config_files: ocaml-stage1-Makefile.config
 
 ## Build upstream compiler.
 ## Similar to stage0 except the installation directory
-_build_upstream/config.status: ocaml/configure.ac
-	rm -rf _build_upstream
-	mkdir _build_upstream
-	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build_upstream
-	(cd _build_upstream && \
-	  cat ../configure_opts_stage0 | tr -d '\n' | xargs -0 ./configure -C \
-	    --prefix=@prefix@ \
+ocaml-upstream-config.status: ocaml/configure.ac
+	rm -rf _upstream_configure
+	mkdir _upstream_configure
+	(cd _upstream_configure && \
+	  cat ../configure_opts_stage0 | tr -d '\n' | xargs -0 ../ocaml/configure -C \
+	    --prefix=$(prefix) \
 	    --disable-ocamldoc \
 	    --enable-ocamltest)
+	cp _upstream_configure/config.status ocaml-upstream-config.status
 
 .PHONY: build_upstream
-build_upstream: _build_upstream/config.status
+build_upstream: ocaml-upstream-config.status
 	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build_upstream
+	cp ocaml-stage0-config.status _build_upstream/config.status
 	(cd _build_upstream && \
+	    ./config.status && \
 	    $(MAKE) world.opt && \
 	    $(MAKE) ocamlnat)
 

--- a/configure.ac
+++ b/configure.ac
@@ -37,8 +37,8 @@ AC_ARG_ENABLE([middle-end],
   [AC_MSG_ERROR([--enable-middle-end=closure|flambda|flambda2 must be provided])])
 
 stage0_prefix=$ac_abs_confdir/_build0/_install
-stage1_prefix=$ac_abs_confdir/_build1/install/default
-stage2_prefix=$ac_abs_confdir/_build2/install/default
+stage1_prefix=$ac_abs_confdir/_build/install/stage1
+stage2_prefix=$ac_abs_confdir/_build/install/stage2
 
 AC_SUBST([prefix])
 AC_SUBST([middle_end])
@@ -54,8 +54,10 @@ AC_DISABLE_OPTION_CHECKING
 # The "real" --prefix will still be on the command line, but our new one here
 # will take priority.
 # This should match configure_args_for_ocaml, below.
+# Use --no-create to keep the tree clean so that each stage gets a pristine copy
+# (on which it can run its own config.status).
 AX_SUBDIRS_CONFIGURE([ocaml],
-  [$middle_end_arg,-C,--disable-ocamldoc],
+  [$middle_end_arg,-C,--disable-ocamldoc,--no-create],
   [],
   [--prefix=$stage1_prefix],
   [])
@@ -85,7 +87,7 @@ cat configure_opts | sed 's/^--enable-flambda2.//g' > configure_opts_stage0
 
 rm -f $temp
 
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile dune-workspace])
 AC_OUTPUT
 
 # We need a copy of config.status that is, for certain, the correct one

--- a/dune-project
+++ b/dune-project
@@ -2,8 +2,7 @@
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 
-;; CR-soon gyorsh: uncomment the following line when we upgrade to dune 2.8
-;; (use_standard_c_and_cxx_flags true)
+(use_standard_c_and_cxx_flags true)
 (cram enable)
 
 (package

--- a/dune-workspace.in
+++ b/dune-workspace.in
@@ -1,0 +1,16 @@
+; DO NOT EDIT. Generated from dune-workspace.in; edit that instead.
+;
+; This file is for Merlin's benefit only. It is not otherwise used by Dune at
+; any point.
+
+(lang dune 2.8)
+
+; NOTE: If you change this, also change the stage1 stanzas in other
+; dune-workspace* files
+(context
+ (default
+  (name stage1)
+  (merlin)
+  (paths
+   (PATH ("@stage0_prefix@/bin" :standard)))
+  (env (_ (env-vars (STAGE 1))))))

--- a/dune-workspace.stage1
+++ b/dune-workspace.stage1
@@ -1,0 +1,10 @@
+(lang dune 2.8)
+
+; NOTE: If you change this, also change the matching stanzas in
+; other dune-workspace* files
+(context
+ (default
+  (name stage1)
+  (paths
+   (PATH ("_build0/_install/bin" :standard)))
+  (env (_ (env-vars (STAGE 1))))))

--- a/dune-workspace.stage2
+++ b/dune-workspace.stage2
@@ -1,0 +1,18 @@
+(lang dune 2.8)
+
+; NOTE: If you change this, also change the stage1 stanzas in other
+; dune-workspace* files
+(context
+ (default
+  (name stage1)
+  (paths
+   (PATH ("_build0/_install/bin" :standard)))
+  (env (_ (env-vars (STAGE 1))))))
+
+(context
+ (default
+  (name stage2)
+  (host stage1)
+  (paths
+   (PATH ("_build/install/stage1/bin" :standard)))
+  (env (_ (env-vars (STAGE 2))))))

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -30,6 +30,14 @@
 ;(copy_files# middle_end/flambda/*.ml{,i})
 ;(copy_files# middle_end/flambda/base_types/*.ml{,i})
 
+(rule
+ (targets Makefile.build_config Makefile.config)
+ (deps
+  (:config %{project_root}/ocaml-stage%{env:STAGE=missing-value}-config.status)
+  Makefile.build_config.in
+  Makefile.config.in)
+ (action (run %{config} --file=Makefile.build_config --file=Makefile.config)))
+
 (library
  (name ocamlcommon)
  (wrapped false)
@@ -132,7 +140,7 @@
 (data_only_dirs yacc)
 
 (rule
- (deps (source_tree yacc))
+ (deps (source_tree yacc) Makefile.build_config)
  (targets ocamlyacc)
  (action
  (no-infer

--- a/ocaml/ocamltest/dune
+++ b/ocaml/ocamltest/dune
@@ -61,7 +61,10 @@
  (name main)
  (modes byte)
  (flags (:standard -principal -nostdlib
-   -cclib "-I%{project_root}/ocaml/runtime"))
+   ; This is relative to the root of the build directory. Note that we can't
+   ; use %{project_root}/ocaml/runtime because that lacks autoconf-generated
+   ; files.
+   -cclib "-Iocaml/runtime"))
  (modules options main)
  (libraries ocamltest_core_and_plugin runtime_byte stdlib))
 

--- a/ocaml/runtime/caml/dune
+++ b/ocaml/runtime/caml/dune
@@ -23,7 +23,7 @@
 
 (rule
   (targets opnames.h)
-  (deps instruct.h)
+  (deps instruct.h ../../Makefile.config ../../Makefile.build_config)
   (action (run make -C .. caml/opnames.h)))
 
 (rule
@@ -32,6 +32,14 @@
  (action
    (with-stdout-to %{targets}
      (run %{dep:../../tools/make-version-header.sh} %{dep:../../VERSION}))))
+
+(rule
+ (targets m.h s.h)
+ (deps
+   (:config %{project_root}/ocaml-stage%{env:STAGE=missing-value}-config.status)
+   m.h.in
+   s.h.in)
+ (action (run %{config} --header=m.h:m.h.in --header=s.h:s.h.in)))
 
 (install
   (files

--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -50,7 +50,7 @@
 (rule
   (targets prims.c)
   (mode fallback)
-  (deps primitives Makefile)
+  (deps primitives Makefile ../Makefile.config ../Makefile.build_config)
   (action (run make %{targets})))
 
 (rule

--- a/ocaml/stdlib/dune
+++ b/ocaml/stdlib/dune
@@ -44,7 +44,7 @@
 
 (rule
   (targets camlheader camlheaderd camlheaderi camlheader_ur)
-  (deps Makefile StdlibModules .depend)
+  (deps Makefile StdlibModules .depend ../Makefile.config ../Makefile.build_config)
   (action (run make %{targets})))
 
 (install

--- a/ocaml/tools/dune
+++ b/ocaml/tools/dune
@@ -12,6 +12,13 @@
 ;*                                                                        *
 ;**************************************************************************
 
+(rule
+ (target eventlog_metadata)
+ (deps
+  (:config %{project_root}/ocaml-stage%{env:STAGE=missing-value}-config.status)
+  (:in eventlog_metadata.in))
+ (action (run %{config} --file=%{target}:%{in})))
+
 (executables
  (names   make_opcodes cvt_emit)
  (modules make_opcodes cvt_emit)


### PR DESCRIPTION
**NOTE:** Requires updating your special Dune to the [lukemaurer:special-dune-2.9][] branch.

[lukemaurer:special-dune-2.9]: /lukemaurer/dune/tree/special-dune-2.9

The current system relies on modifying the `ocaml/` subtree in place. This is fragile, and is particularly a problem now that we have stage1 and stage2 as build contexts sharing a `_build` directory (and hence sharing saved build state): stage1 and stage2 can clobber each other's inputs, triggering unnecessary rebuilds.

We can avoid ever modifying a file in `ocaml/` by exploiting two
non-obvious properties of Autoconf:

- a `configure` script can be run from any directory and will only create files where it's run

- the `config.status` script that `configure` generates can generate individual files on demand, also from any directory

For stage1 and stage2, then, we can just use `configure` to generate a `config.status`, and then Dune can take care of running `config.status` for itself - which naturally happens in the stage's own `_build` subdirectory. There's some faff required to use a `config.status` as a Dune action, since it normally creates files in subdirectories, which Dune doesn't support. Also, Dune wants to know exactly what files `config.status` will create, so we end up tied more closely to the upstream `configure.ac` than we might like. Finally, we have several Dune actions that run Make and thus depend on `Makefile.config`, which has to be declared explicitly now because `Makefile.config` is not in the source tree. But in return, the build should be considerably more robust, and we continue moving work from Make to Dune (`make stage1` and `make stage2` barely do anything more than call Dune).