### PR TITLE
Use hooks for type tree and parse tree

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -154,11 +154,14 @@ let rec regalloc ~ppf_dump round fd =
   in
   dump_if ppf_dump dump_regalloc "After register allocation" fd;
   let (newfd, redo_regalloc) = Reload.fundecl fd num_stack_slots in
-  Compiler_hooks.execute Compiler_hooks.Mach_reload newfd;
   dump_if ppf_dump dump_reload "After insertion of reloading code" newfd;
   if redo_regalloc then begin
     Reg.reinit(); Liveness.fundecl newfd; regalloc ~ppf_dump (round + 1) newfd
-  end else newfd
+  end else begin
+    (* Ensure the hooks are called only once. *)
+    Compiler_hooks.execute Compiler_hooks.Mach_reload newfd;
+    newfd
+  end
 
 let (++) x f = f x
 

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -154,7 +154,7 @@ let rec regalloc ~ppf_dump round fd =
   in
   dump_if ppf_dump dump_regalloc "After register allocation" fd;
   let (newfd, redo_regalloc) = Reload.fundecl fd num_stack_slots in
-  Compiler_hooks.execute Compiler_hooks.Mach_split newfd;
+  Compiler_hooks.execute Compiler_hooks.Mach_reload newfd;
   dump_if ppf_dump dump_reload "After insertion of reloading code" newfd;
   if redo_regalloc then begin
     Reg.reinit(); Liveness.fundecl newfd; regalloc ~ppf_dump (round + 1) newfd

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -16,8 +16,8 @@ open Compile_common
 type _ pass =
   | Parse_tree_intf : Parsetree.signature pass
   | Parse_tree_impl : Parsetree.structure pass
-  | Typecheck_intf : Typedtree.signature pass
-  | Typecheck_impl : (Typedtree.structure * Typedtree.module_coercion) pass
+  | Type_tree_intf : Typedtree.signature pass
+  | Type_tree_impl : (Typedtree.structure * Typedtree.module_coercion) pass
   | Raw_lambda : Lambda.program pass
   | Lambda : Lambda.program pass
   | Raw_flambda2 : Flambda2_terms.Flambda_unit.t pass
@@ -95,8 +95,8 @@ let register : type a. a pass -> (a -> unit) -> unit =
   match representation with
   | Parse_tree_intf -> hooks.parse_tree_intf <- f :: hooks.parse_tree_intf
   | Parse_tree_impl -> hooks.parse_tree_impl <- f :: hooks.parse_tree_impl
-  | Typecheck_intf -> hooks.typecheck_intf <- f :: hooks.typecheck_intf
-  | Typecheck_impl -> hooks.typecheck_impl <- f :: hooks.typecheck_impl
+  | Type_tree_intf -> hooks.typecheck_intf <- f :: hooks.typecheck_intf
+  | Type_tree_impl -> hooks.typecheck_impl <- f :: hooks.typecheck_impl
   | Raw_lambda -> hooks.raw_lambda <- f :: hooks.raw_lambda
   | Lambda -> hooks.lambda <- f :: hooks.lambda
   | Raw_flambda2 -> hooks.raw_flambda2 <- f :: hooks.raw_flambda2
@@ -122,8 +122,8 @@ let execute : type a. a pass -> a -> unit =
   match representation with
   | Parse_tree_intf -> execute_hooks hooks.parse_tree_intf arg
   | Parse_tree_impl -> execute_hooks hooks.parse_tree_impl arg
-  | Typecheck_intf -> execute_hooks hooks.typecheck_intf arg
-  | Typecheck_impl -> execute_hooks hooks.typecheck_impl arg
+  | Type_tree_intf -> execute_hooks hooks.typecheck_intf arg
+  | Type_tree_impl -> execute_hooks hooks.typecheck_impl arg
   | Raw_lambda -> execute_hooks hooks.raw_lambda arg
   | Lambda -> execute_hooks hooks.lambda arg
   | Raw_flambda2 -> execute_hooks hooks.raw_flambda2 arg
@@ -149,8 +149,8 @@ let clear : type a. a pass -> unit =
   function
   | Parse_tree_intf -> hooks.parse_tree_intf <- []
   | Parse_tree_impl -> hooks.parse_tree_impl <- []
-  | Typecheck_intf -> hooks.typecheck_intf <- []
-  | Typecheck_impl -> hooks.typecheck_impl <- []
+  | Type_tree_intf -> hooks.typecheck_intf <- []
+  | Type_tree_impl -> hooks.typecheck_impl <- []
   | Raw_lambda -> hooks.raw_lambda <- []
   | Lambda -> hooks.lambda <- []
   | Raw_flambda2 -> hooks.raw_flambda2 <- []

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -41,8 +41,8 @@ type _ pass =
 type t = {
   mutable parse_tree_intf : (Parsetree.signature -> unit) list;
   mutable parse_tree_impl : (Parsetree.structure -> unit) list;
-  mutable typecheck_intf : (Typedtree.signature -> unit) list;
-  mutable typecheck_impl : ((Typedtree.structure * Typedtree.module_coercion) -> unit) list;
+  mutable typed_tree_intf : (Typedtree.signature -> unit) list;
+  mutable typed_tree_impl : ((Typedtree.structure * Typedtree.module_coercion) -> unit) list;
   mutable raw_lambda : (Lambda.program -> unit) list;
   mutable lambda : (Lambda.program -> unit) list;
   mutable raw_flambda2 : (Flambda2_terms.Flambda_unit.t -> unit) list;
@@ -65,8 +65,8 @@ type t = {
 let hooks : t = {
   parse_tree_intf = [];
   parse_tree_impl = [];
-  typecheck_intf = [];
-  typecheck_impl = [];
+  typed_tree_intf = [];
+  typed_tree_impl = [];
   raw_lambda = [];
   lambda = [];
   raw_flambda2 = [];
@@ -95,8 +95,8 @@ let register : type a. a pass -> (a -> unit) -> unit =
   match representation with
   | Parse_tree_intf -> hooks.parse_tree_intf <- f :: hooks.parse_tree_intf
   | Parse_tree_impl -> hooks.parse_tree_impl <- f :: hooks.parse_tree_impl
-  | Type_tree_intf -> hooks.typecheck_intf <- f :: hooks.typecheck_intf
-  | Type_tree_impl -> hooks.typecheck_impl <- f :: hooks.typecheck_impl
+  | Type_tree_intf -> hooks.typed_tree_intf <- f :: hooks.typed_tree_intf
+  | Type_tree_impl -> hooks.typed_tree_impl <- f :: hooks.typed_tree_impl
   | Raw_lambda -> hooks.raw_lambda <- f :: hooks.raw_lambda
   | Lambda -> hooks.lambda <- f :: hooks.lambda
   | Raw_flambda2 -> hooks.raw_flambda2 <- f :: hooks.raw_flambda2
@@ -122,8 +122,8 @@ let execute : type a. a pass -> a -> unit =
   match representation with
   | Parse_tree_intf -> execute_hooks hooks.parse_tree_intf arg
   | Parse_tree_impl -> execute_hooks hooks.parse_tree_impl arg
-  | Type_tree_intf -> execute_hooks hooks.typecheck_intf arg
-  | Type_tree_impl -> execute_hooks hooks.typecheck_impl arg
+  | Type_tree_intf -> execute_hooks hooks.typed_tree_intf arg
+  | Type_tree_impl -> execute_hooks hooks.typed_tree_impl arg
   | Raw_lambda -> execute_hooks hooks.raw_lambda arg
   | Lambda -> execute_hooks hooks.lambda arg
   | Raw_flambda2 -> execute_hooks hooks.raw_flambda2 arg
@@ -149,8 +149,8 @@ let clear : type a. a pass -> unit =
   function
   | Parse_tree_intf -> hooks.parse_tree_intf <- []
   | Parse_tree_impl -> hooks.parse_tree_impl <- []
-  | Type_tree_intf -> hooks.typecheck_intf <- []
-  | Type_tree_impl -> hooks.typecheck_impl <- []
+  | Type_tree_intf -> hooks.typed_tree_intf <- []
+  | Type_tree_impl -> hooks.typed_tree_impl <- []
   | Raw_lambda -> hooks.raw_lambda <- []
   | Lambda -> hooks.lambda <- []
   | Raw_flambda2 -> hooks.raw_flambda2 <- []

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -16,8 +16,8 @@ open Compile_common
 type _ pass =
   | Parse_tree_intf : Parsetree.signature pass
   | Parse_tree_impl : Parsetree.structure pass
-  | Type_tree_intf : Typedtree.signature pass
-  | Type_tree_impl : (Typedtree.structure * Typedtree.module_coercion) pass
+  | Typed_tree_intf : Typedtree.signature pass
+  | Typed_tree_impl : (Typedtree.structure * Typedtree.module_coercion) pass
   | Raw_lambda : Lambda.program pass
   | Lambda : Lambda.program pass
   | Raw_flambda2 : Flambda2_terms.Flambda_unit.t pass
@@ -95,8 +95,8 @@ let register : type a. a pass -> (a -> unit) -> unit =
   match representation with
   | Parse_tree_intf -> hooks.parse_tree_intf <- f :: hooks.parse_tree_intf
   | Parse_tree_impl -> hooks.parse_tree_impl <- f :: hooks.parse_tree_impl
-  | Type_tree_intf -> hooks.typed_tree_intf <- f :: hooks.typed_tree_intf
-  | Type_tree_impl -> hooks.typed_tree_impl <- f :: hooks.typed_tree_impl
+  | Typed_tree_intf -> hooks.typed_tree_intf <- f :: hooks.typed_tree_intf
+  | Typed_tree_impl -> hooks.typed_tree_impl <- f :: hooks.typed_tree_impl
   | Raw_lambda -> hooks.raw_lambda <- f :: hooks.raw_lambda
   | Lambda -> hooks.lambda <- f :: hooks.lambda
   | Raw_flambda2 -> hooks.raw_flambda2 <- f :: hooks.raw_flambda2
@@ -122,8 +122,8 @@ let execute : type a. a pass -> a -> unit =
   match representation with
   | Parse_tree_intf -> execute_hooks hooks.parse_tree_intf arg
   | Parse_tree_impl -> execute_hooks hooks.parse_tree_impl arg
-  | Type_tree_intf -> execute_hooks hooks.typed_tree_intf arg
-  | Type_tree_impl -> execute_hooks hooks.typed_tree_impl arg
+  | Typed_tree_intf -> execute_hooks hooks.typed_tree_intf arg
+  | Typed_tree_impl -> execute_hooks hooks.typed_tree_impl arg
   | Raw_lambda -> execute_hooks hooks.raw_lambda arg
   | Lambda -> execute_hooks hooks.lambda arg
   | Raw_flambda2 -> execute_hooks hooks.raw_flambda2 arg
@@ -149,8 +149,8 @@ let clear : type a. a pass -> unit =
   function
   | Parse_tree_intf -> hooks.parse_tree_intf <- []
   | Parse_tree_impl -> hooks.parse_tree_impl <- []
-  | Type_tree_intf -> hooks.typed_tree_intf <- []
-  | Type_tree_impl -> hooks.typed_tree_impl <- []
+  | Typed_tree_intf -> hooks.typed_tree_intf <- []
+  | Typed_tree_impl -> hooks.typed_tree_impl <- []
   | Raw_lambda -> hooks.raw_lambda <- []
   | Lambda -> hooks.lambda <- []
   | Raw_flambda2 -> hooks.raw_flambda2 <- []

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -21,6 +21,9 @@ open Compile_common
    of how the compiler would behave.
    Several hooks can be registered for the same pass. There's no guarantees
    on the order of execution of hooks.
+   When one IR is the output of several passes, the hooks are usually called
+   on the latest version of the IR (the exception being passes marked as "raw",
+   where corresponding hooks are called on the earliest version of the IR).
 *)
 
 type _ pass =

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -26,8 +26,8 @@ open Compile_common
 type _ pass =
   | Parse_tree_intf : Parsetree.signature pass
   | Parse_tree_impl : Parsetree.structure pass
-  | Type_tree_intf : Typedtree.signature pass
-  | Type_tree_impl : (Typedtree.structure * Typedtree.module_coercion) pass
+  | Typed_tree_intf : Typedtree.signature pass
+  | Typed_tree_impl : (Typedtree.structure * Typedtree.module_coercion) pass
   | Raw_lambda : Lambda.program pass
   | Lambda : Lambda.program pass
   | Raw_flambda2 : Flambda2_terms.Flambda_unit.t pass

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -26,8 +26,8 @@ open Compile_common
 type _ pass =
   | Parse_tree_intf : Parsetree.signature pass
   | Parse_tree_impl : Parsetree.structure pass
-  | Typecheck_intf : Typedtree.signature pass
-  | Typecheck_impl : (Typedtree.structure * Typedtree.module_coercion) pass
+  | Type_tree_intf : Typedtree.signature pass
+  | Type_tree_impl : (Typedtree.structure * Typedtree.module_coercion) pass
   | Raw_lambda : Lambda.program pass
   | Lambda : Lambda.program pass
   | Raw_flambda2 : Flambda2_terms.Flambda_unit.t pass

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -26,7 +26,7 @@ let interface ~source_file ~output_prefix =
   with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
   Compile_common.interface
   ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_intf)
-  ~hook_type_tree:(Compiler_hooks.execute Compiler_hooks.Type_tree_intf)
+  ~hook_typed_tree:(Compiler_hooks.execute Compiler_hooks.Type_tree_intf)
     info
 
 let (|>>) (x, y) f = (x, f y)
@@ -123,11 +123,11 @@ let implementation ~backend ~flambda2 ~start_from ~source_file ~output_prefix =
   in
   with_info ~source_file ~output_prefix ~dump_ext:"cmx" @@ fun info ->
   match (start_from:Clflags.Compiler_pass.t) with
-  | Parsing -> Compile_common.implementation
-
-  ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_impl)
-  ~hook_type_tree:(Compiler_hooks.execute Compiler_hooks.Type_tree_impl)
-                 info ~backend
+  | Parsing ->
+    Compile_common.implementation
+      ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_impl)
+      ~hook_typed_tree:(Compiler_hooks.execute Compiler_hooks.Type_tree_impl)
+      info ~backend
   | Emit -> emit info
   | _ -> Misc.fatal_errorf "Cannot start from %s"
            (Clflags.Compiler_pass.to_string start_from)

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -26,7 +26,7 @@ let interface ~source_file ~output_prefix =
   with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
   Compile_common.interface
   ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_intf)
-  ~hook_typed_tree:(Compiler_hooks.execute Compiler_hooks.Type_tree_intf)
+  ~hook_typed_tree:(Compiler_hooks.execute Compiler_hooks.Typed_tree_intf)
     info
 
 let (|>>) (x, y) f = (x, f y)
@@ -126,7 +126,7 @@ let implementation ~backend ~flambda2 ~start_from ~source_file ~output_prefix =
   | Parsing ->
     Compile_common.implementation
       ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_impl)
-      ~hook_typed_tree:(Compiler_hooks.execute Compiler_hooks.Type_tree_impl)
+      ~hook_typed_tree:(Compiler_hooks.execute Compiler_hooks.Typed_tree_impl)
       info ~backend
   | Emit -> emit info
   | _ -> Misc.fatal_errorf "Cannot start from %s"

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -24,7 +24,10 @@ let with_info = Compile_common.with_info ~native:true ~tool_name
 
 let interface ~source_file ~output_prefix =
   with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
-  Compile_common.interface info
+  Compile_common.interface
+  ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_intf)
+  ~hook_type_tree:(Compiler_hooks.execute Compiler_hooks.Type_tree_intf)
+    info
 
 let (|>>) (x, y) f = (x, f y)
 
@@ -120,7 +123,11 @@ let implementation ~backend ~flambda2 ~start_from ~source_file ~output_prefix =
   in
   with_info ~source_file ~output_prefix ~dump_ext:"cmx" @@ fun info ->
   match (start_from:Clflags.Compiler_pass.t) with
-  | Parsing -> Compile_common.implementation info ~backend
+  | Parsing -> Compile_common.implementation
+
+  ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_impl)
+  ~hook_type_tree:(Compiler_hooks.execute Compiler_hooks.Type_tree_impl)
+                 info ~backend
   | Emit -> emit info
   | _ -> Misc.fatal_errorf "Cannot start from %s"
            (Clflags.Compiler_pass.to_string start_from)

--- a/ocaml/driver/compile.ml
+++ b/ocaml/driver/compile.ml
@@ -25,7 +25,7 @@ let interface ~source_file ~output_prefix =
   with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
   Compile_common.interface
     ~hook_parse_tree:(fun _ -> ())
-    ~hook_type_tree:(fun _ -> ())
+    ~hook_typed_tree:(fun _ -> ())
     info
 
 (** Bytecode compilation backend for .ml files. *)
@@ -67,7 +67,7 @@ let implementation ~start_from ~source_file ~output_prefix =
   | Parsing ->
     Compile_common.implementation
       ~hook_parse_tree:(fun _ -> ())
-      ~hook_type_tree:(fun _ -> ())
+      ~hook_typed_tree:(fun _ -> ())
       info ~backend
   | _ -> Misc.fatal_errorf "Cannot start from %s"
            (Clflags.Compiler_pass.to_string start_from)

--- a/ocaml/driver/compile.ml
+++ b/ocaml/driver/compile.ml
@@ -23,7 +23,10 @@ let with_info =
 
 let interface ~source_file ~output_prefix =
   with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
-  Compile_common.interface info
+  Compile_common.interface
+    ~hook_parse_tree:(fun _ -> ())
+    ~hook_type_tree:(fun _ -> ())
+    info
 
 (** Bytecode compilation backend for .ml files. *)
 
@@ -61,6 +64,10 @@ let implementation ~start_from ~source_file ~output_prefix =
   in
   with_info ~source_file ~output_prefix ~dump_ext:"cmo" @@ fun info ->
   match (start_from : Clflags.Compiler_pass.t) with
-  | Parsing -> Compile_common.implementation info ~backend
+  | Parsing ->
+    Compile_common.implementation
+      ~hook_parse_tree:(fun _ -> ())
+      ~hook_type_tree:(fun _ -> ())
+      info ~backend
   | _ -> Misc.fatal_errorf "Cannot start from %s"
            (Clflags.Compiler_pass.to_string start_from)

--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -81,13 +81,13 @@ let emit_signature info ast tsg =
   Typemod.save_signature info.module_name tsg
     info.output_prefix info.source_file info.env sg
 
-let interface ~hook_parse_tree ~hook_type_tree info =
+let interface ~hook_parse_tree ~hook_typed_tree info =
   Profile.record_call info.source_file @@ fun () ->
   let ast = parse_intf info in
   hook_parse_tree ast;
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
     let tsg = typecheck_intf info ast in
-    hook_type_tree tsg;
+    hook_typed_tree tsg;
     if not !Clflags.print_types then begin
       emit_signature info ast tsg
     end
@@ -109,7 +109,7 @@ let typecheck_impl i parsetree =
   |> print_if i.ppf_dump Clflags.dump_typedtree
     Printtyped.implementation_with_coercion
 
-let implementation ~hook_parse_tree ~hook_type_tree info ~backend =
+let implementation ~hook_parse_tree ~hook_typed_tree info ~backend =
   Profile.record_call info.source_file @@ fun () ->
   let exceptionally () =
     let sufs = if info.native then [ cmx; obj ] else [ cmo ] in
@@ -120,7 +120,7 @@ let implementation ~hook_parse_tree ~hook_type_tree info ~backend =
     hook_parse_tree parsed;
     if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
       let typed = typecheck_impl info parsed in
-      hook_type_tree typed;
+      hook_typed_tree typed;
       if Clflags.(should_stop_after Compiler_pass.Typing) then () else begin
         backend info typed
       end;

--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -81,11 +81,13 @@ let emit_signature info ast tsg =
   Typemod.save_signature info.module_name tsg
     info.output_prefix info.source_file info.env sg
 
-let interface info =
+let interface ~hook_parse_tree ~hook_type_tree info =
   Profile.record_call info.source_file @@ fun () ->
   let ast = parse_intf info in
+  hook_parse_tree ast;
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
     let tsg = typecheck_intf info ast in
+    hook_type_tree tsg;
     if not !Clflags.print_types then begin
       emit_signature info ast tsg
     end
@@ -107,7 +109,7 @@ let typecheck_impl i parsetree =
   |> print_if i.ppf_dump Clflags.dump_typedtree
     Printtyped.implementation_with_coercion
 
-let implementation info ~backend =
+let implementation ~hook_parse_tree ~hook_type_tree info ~backend =
   Profile.record_call info.source_file @@ fun () ->
   let exceptionally () =
     let sufs = if info.native then [ cmx; obj ] else [ cmo ] in
@@ -115,8 +117,10 @@ let implementation info ~backend =
   in
   Misc.try_finally ?always:None ~exceptionally (fun () ->
     let parsed = parse_impl info in
+    hook_parse_tree parsed;
     if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
       let typed = typecheck_impl info parsed in
+      hook_type_tree typed;
       if Clflags.(should_stop_after Compiler_pass.Typing) then () else begin
         backend info typed
       end;

--- a/ocaml/driver/compile_common.mli
+++ b/ocaml/driver/compile_common.mli
@@ -62,7 +62,7 @@ val emit_signature : info -> Parsetree.signature -> Typedtree.signature -> unit
 
 val interface :
   hook_parse_tree:(Parsetree.signature -> unit)
-  -> hook_type_tree:(Typedtree.signature -> unit)
+  -> hook_typed_tree:(Typedtree.signature -> unit)
   -> info -> unit
 (** The complete compilation pipeline for interfaces. *)
 
@@ -80,7 +80,7 @@ val typecheck_impl :
 
 val implementation :
   hook_parse_tree:(Parsetree.structure -> unit)
-  -> hook_type_tree:(Typedtree.structure * Typedtree.module_coercion -> unit)
+  -> hook_typed_tree:(Typedtree.structure * Typedtree.module_coercion -> unit)
   -> info ->
   backend:(info -> Typedtree.structure * Typedtree.module_coercion -> unit) ->
   unit

--- a/ocaml/driver/compile_common.mli
+++ b/ocaml/driver/compile_common.mli
@@ -60,7 +60,10 @@ val emit_signature : info -> Parsetree.signature -> Typedtree.signature -> unit
     containing the given signature.
 *)
 
-val interface : info -> unit
+val interface :
+  hook_parse_tree:(Parsetree.signature -> unit)
+  -> hook_type_tree:(Typedtree.signature -> unit)
+  -> info -> unit
 (** The complete compilation pipeline for interfaces. *)
 
 (** {2 Implementations} *)
@@ -76,7 +79,9 @@ val typecheck_impl :
 *)
 
 val implementation :
-  info ->
+  hook_parse_tree:(Parsetree.structure -> unit)
+  -> hook_type_tree:(Typedtree.structure * Typedtree.module_coercion -> unit)
+  -> info ->
   backend:(info -> Typedtree.structure * Typedtree.module_coercion -> unit) ->
   unit
 (** The complete compilation pipeline for implementations. *)

--- a/ocaml/driver/optcompile.ml
+++ b/ocaml/driver/optcompile.ml
@@ -27,7 +27,7 @@ let interface ~source_file ~output_prefix =
   with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
   Compile_common.interface
     ~hook_parse_tree:(fun _ -> ())
-    ~hook_type_tree:(fun _ -> ())
+    ~hook_typed_tree:(fun _ -> ())
     info
 
 let (|>>) (x, y) f = (x, f y)
@@ -99,7 +99,7 @@ let implementation ~backend ~start_from ~source_file ~output_prefix =
   | Parsing ->
     Compile_common.implementation
       ~hook_parse_tree:(fun _ -> ())
-      ~hook_type_tree:(fun _ -> ())
+      ~hook_typed_tree:(fun _ -> ())
       info ~backend
   | Emit -> emit info
   | _ -> Misc.fatal_errorf "Cannot start from %s"

--- a/ocaml/driver/optcompile.ml
+++ b/ocaml/driver/optcompile.ml
@@ -25,7 +25,10 @@ let with_info =
 
 let interface ~source_file ~output_prefix =
   with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
-  Compile_common.interface info
+  Compile_common.interface
+    ~hook_parse_tree:(fun _ -> ())
+    ~hook_type_tree:(fun _ -> ())
+    info
 
 let (|>>) (x, y) f = (x, f y)
 
@@ -93,7 +96,11 @@ let implementation ~backend ~start_from ~source_file ~output_prefix =
   in
   with_info ~source_file ~output_prefix ~dump_ext:"cmx" @@ fun info ->
   match (start_from:Clflags.Compiler_pass.t) with
-  | Parsing -> Compile_common.implementation info ~backend
+  | Parsing ->
+    Compile_common.implementation
+      ~hook_parse_tree:(fun _ -> ())
+      ~hook_type_tree:(fun _ -> ())
+      info ~backend
   | Emit -> emit info
   | _ -> Misc.fatal_errorf "Cannot start from %s"
            (Clflags.Compiler_pass.to_string start_from)


### PR DESCRIPTION
Even though the hooks for Type_tree and Parse_tree are defined in `Compiler_hooks` they were actually never called.
To avoid having copying `driver/compile_common.ml` this PR adds two new arguments to `Compile_common.interface` and `Compile_common.implementation`.

Also fixes a place where `Compiler_hooks.Mach_split` was used instead of `Compiler_hooks.Mach_reload`.