### PR TITLE
Join points with no parameters

### DIFF
--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -671,8 +671,7 @@ and symbol_binding ppf (sb : symbol_binding) =
   match sb with
   | Data ss -> static_data_binding ppf ss
   | Code code -> code_binding ppf code
-  | Deleted_code id ->
-    Format.fprintf ppf "@[<hov 1>deleted_code@ %a@]" code_id id
+  | Deleted_code id -> Format.fprintf ppf "@[<hov 1>deleted@ %a@]" code_id id
   | Closure clo -> static_closure_binding ppf clo
   | Set_of_closures soc ->
     Format.fprintf ppf "@[<hv>@[<hv2>set_of_closures@ ";


### PR DESCRIPTION
I'm not completely certain this is ok, @lthls please let me know what you think.

I suddenly realised this evening that we're maybe doing far too many join calculations for no benefit.  At present, the full `Join_levels` calculation is circumvented in only one case, when the join point continuation has exactly one use and that use is inlinable.  However I think there's another case when we can circumvent it, which happens a lot: the case where the join point continuation has no parameters (no matter how many uses it has).  My reasoning is that since there are no parameters, then there can't be any information flow from the use site(s) to the join point, meaning that the environment at the fork point can be used immediately (modulo addition of lifted constants, as in the inlinable case) for simplification of the join point continuation's handler.

I think it follows that, for continuations with no parameters, we can avoid incrementing the scope level to save time in the typing environment calculations.  The scope level change is there so that the environment can be cut into two parts at that point, but there won't be any cutting if there isn't going to be any joining...