### PR TITLE
Fix removal of closure variables in types

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -122,10 +122,10 @@ let import_typing_env_and_code0 t =
       t.table_data.continuations
   in
   let used_closure_vars = t.used_closure_vars in
+  let original_compilation_unit = t.original_compilation_unit in
   let renaming =
     Renaming.create_import_map ~symbols ~variables ~simples ~consts ~code_ids
-      ~continuations ~used_closure_vars
-      ~compilation_unit:t.original_compilation_unit
+      ~continuations ~used_closure_vars ~original_compilation_unit
   in
   let typing_env =
     Flambda2_types.Typing_env.Serializable.apply_renaming t.final_typing_env

--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -125,6 +125,7 @@ let import_typing_env_and_code0 t =
   let renaming =
     Renaming.create_import_map ~symbols ~variables ~simples ~consts ~code_ids
       ~continuations ~used_closure_vars
+      ~compilation_unit:t.original_compilation_unit
   in
   let typing_env =
     Flambda2_types.Typing_env.Serializable.apply_renaming t.final_typing_env

--- a/middle_end/flambda2/nominal/renaming.ml
+++ b/middle_end/flambda2/nominal/renaming.ml
@@ -146,7 +146,7 @@ end = struct
   let closure_var_is_used t var =
     if Var_within_closure.in_compilation_unit var t.original_compilation_unit
     then Var_within_closure.Set.mem var t.used_closure_vars
-    else (* This closure variable may be used in other units *)
+    else (* This closure variable might be used in other units *)
       true
 end
 

--- a/middle_end/flambda2/nominal/renaming.ml
+++ b/middle_end/flambda2/nominal/renaming.ml
@@ -38,7 +38,7 @@ module Import_map : sig
     code_ids:Code_id.t Code_id.Map.t ->
     continuations:Continuation.t Continuation.Map.t ->
     used_closure_vars:Var_within_closure.Set.t ->
-    compilation_unit:Compilation_unit.t ->
+    original_compilation_unit:Compilation_unit.t ->
     t
 
   val is_empty : t -> bool
@@ -75,7 +75,7 @@ end = struct
          [Flambda_cmx.compute_reachable_names_and_code] we have to assume that
          code IDs can be missing (and so we cannot detect code IDs that are
          really missing at this point). *)
-      compilation_unit : Compilation_unit.t
+      original_compilation_unit : Compilation_unit.t
           (* This complements [used_closure_vars]. Removal of closure variables
              is only allowed for variables that are not used in the compilation
              unit they are defined in. *)
@@ -89,7 +89,7 @@ end = struct
         code_ids;
         continuations;
         used_closure_vars;
-        compilation_unit = _
+        original_compilation_unit = _
       } =
     Symbol.Map.is_empty symbols
     && Variable.Map.is_empty variables
@@ -100,7 +100,7 @@ end = struct
     && Var_within_closure.Set.is_empty used_closure_vars
 
   let create ~symbols ~variables ~simples ~consts ~code_ids ~continuations
-      ~used_closure_vars ~compilation_unit =
+      ~used_closure_vars ~original_compilation_unit =
     { symbols;
       variables;
       simples;
@@ -108,7 +108,7 @@ end = struct
       code_ids;
       continuations;
       used_closure_vars;
-      compilation_unit
+      original_compilation_unit
     }
 
   let symbol t orig =
@@ -144,7 +144,7 @@ end = struct
     | exception Not_found -> simple
 
   let closure_var_is_used t var =
-    if Var_within_closure.in_compilation_unit var t.compilation_unit
+    if Var_within_closure.in_compilation_unit var t.original_compilation_unit
     then Var_within_closure.Set.mem var t.used_closure_vars
     else (* This closure variable may be used in other units *)
       true
@@ -167,10 +167,10 @@ let empty =
   }
 
 let create_import_map ~symbols ~variables ~simples ~consts ~code_ids
-    ~continuations ~used_closure_vars ~compilation_unit =
+    ~continuations ~used_closure_vars ~original_compilation_unit =
   let import_map =
     Import_map.create ~symbols ~variables ~simples ~consts ~code_ids
-      ~continuations ~used_closure_vars ~compilation_unit
+      ~continuations ~used_closure_vars ~original_compilation_unit
   in
   if Import_map.is_empty import_map
   then empty

--- a/middle_end/flambda2/nominal/renaming.mli
+++ b/middle_end/flambda2/nominal/renaming.mli
@@ -38,6 +38,7 @@ val create_import_map :
   code_ids:Code_id.t Code_id.Map.t ->
   continuations:Continuation.t Continuation.Map.t ->
   used_closure_vars:Var_within_closure.Set.t ->
+  compilation_unit:Compilation_unit.t ->
   t
 
 (** Note that [compose] is not commutative on the permutation component. The

--- a/middle_end/flambda2/nominal/renaming.mli
+++ b/middle_end/flambda2/nominal/renaming.mli
@@ -38,7 +38,7 @@ val create_import_map :
   code_ids:Code_id.t Code_id.Map.t ->
   continuations:Continuation.t Continuation.Map.t ->
   used_closure_vars:Var_within_closure.Set.t ->
-  compilation_unit:Compilation_unit.t ->
+  original_compilation_unit:Compilation_unit.t ->
   t
 
 (** Note that [compose] is not commutative on the permutation component. The

--- a/middle_end/flambda2/tests/mlexamples/closure_var_a.ml
+++ b/middle_end/flambda2/tests/mlexamples/closure_var_a.ml
@@ -1,0 +1,16 @@
+(* Comes with closure_var_b.ml and closure_var_c.ml.
+
+   In this example, closures created in Closure_var_b need to retain their
+   closure variable [x] even though their bodies do not use it, because they
+   might be passed to the parent code in Closure_var_a which does need the
+   variable.
+
+   By adding a third file that inlines the parent code ID, we check that the
+   types for the closures also correctly include the variable (if they don't,
+   the simplification of the Project_var primitive will return invalid and cause
+   segfaults at runtime). *)
+
+let f x =
+  let () = () in
+  let g y = x, y in
+  g

--- a/middle_end/flambda2/tests/mlexamples/closure_var_b.ml
+++ b/middle_end/flambda2/tests/mlexamples/closure_var_b.ml
@@ -1,0 +1,15 @@
+(* Comes with closure_var_a.ml and closure_var_c.ml.
+
+   In this example, closures created in Closure_var_b need to retain their
+   closure variable [x] even though their bodies do not use it, because they
+   might be passed to the parent code in Closure_var_a which does need the
+   variable.
+
+   By adding a third file that inlines the parent code ID, we check that the
+   types for the closures also correctly include the variable (if they don't,
+   the simplification of the Project_var primitive will return invalid and cause
+   segfaults at runtime). *)
+
+let g0 = (Closure_var_a.f [@inlined]) 0
+
+let g1 = (Closure_var_a.f [@inlined]) 1

--- a/middle_end/flambda2/tests/mlexamples/closure_var_c.ml
+++ b/middle_end/flambda2/tests/mlexamples/closure_var_c.ml
@@ -1,0 +1,18 @@
+(* Comes with closure_var_a.ml and closure_var_b.ml.
+
+   In this example, closures created in Closure_var_b need to retain their
+   closure variable [x] even though their bodies do not use it, because they
+   might be passed to the parent code in Closure_var_a which does need the
+   variable.
+
+   By adding a third file that inlines the parent code ID, we check that the
+   types for the closures also correctly include the variable (if they don't,
+   the simplification of the Project_var primitive will return invalid and cause
+   segfaults at runtime). *)
+
+let f b =
+  let g = if b then Closure_var_b.g0 else Closure_var_b.g1 in
+  let x, y = (g [@inlined]) 3 in
+  assert (x = 0 || x = 1);
+  assert (y = 3);
+  ()


### PR DESCRIPTION
I plan to add examples that would fail without this patch; please don't merge before I've done that.