### PR TITLE
Update HACKING.md and README.md for required OPAM switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ and ocamlformat. If you're working on developing the Flambda backend, it's
 recommended that you set up a purpose-built OPAM switch. See
 [HACKING.md][switch] for details.
 
-[switch]: HACKING.md#requirements-and-opam-switch
+[switch]: HACKING.md#requirements-and-opam-coldstart

--- a/README.md
+++ b/README.md
@@ -53,3 +53,13 @@ layout is compatible with upstream, run:
 ```
 $ make install
 ```
+
+## OPAM switch for development work
+
+In addition to the special version of Dune, currently the Flambda backend
+requires a customised version of Merlin, as well as specific versions of Menhir
+and ocamlformat. If you're working on developing the Flambda backend, it's
+recommended that you set up a purpose-built OPAM switch. See
+[HACKING.md][switch] for details.
+
+[switch]: HACKING.md#requirements-and-opam-switch


### PR DESCRIPTION
Combined instructions dealing with new requirements for Dune and Merlin.

Should not be merged until:

- [ ] #361 and #362 are both merged
- [ ] In Dune, [lukemaurer:special-dune-2.9][1] is pushed to [ocaml-flambda:special_dune][2]

[1]: /lukemaurer/dune/tree/special-dune-2.9
[2]: /ocaml-flambda/dune/tree/special_dune

Alternatively, we can point to my Dune fork in the instructions, or someone with permissions can create the special-dune-2.9 branch there.