### PR TITLE
Implement Patricia_tree.map_sharing properly

### DIFF
--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -963,11 +963,19 @@ struct
   let mapi f t =
     fold (fun key datum result -> add key (f key datum) result) t empty
 
-  (* CR lmaurer: Implement this one properly even if [map] isn't efficient yet,
-     since not sharing makes _other things_ (including row-like types) less
-     efficient. *)
-
-  let map_sharing = map
+  let map_sharing f t =
+    let changed = ref false in
+    let f a =
+      let a' = f a in
+      if a == a'
+      then a
+      else begin
+        changed := true;
+        a'
+      end
+    in
+    let t' = map f t in
+    if !changed then t' else t
 
   let to_seq t =
     let rec aux acc () =


### PR DESCRIPTION
This is a naive implementation in terms of `map`. The hope is that preserving sharing should save some amount of churn in type calculations, which are eating a lot of CPU.