### PR TITLE
Resurrect Missing_code in Call_site_inlining_decision

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
@@ -22,6 +22,7 @@ open! Flambda.Import
    something can be inlined, and one giving the reasons why something cannot be
    inlined. *)
 type t = private
+  | Missing_code
   | Definition_says_not_to_inline
   | Environment_says_never_inline
   | Argument_types_not_useful

--- a/middle_end/flambda2/terms/code_or_metadata.ml
+++ b/middle_end/flambda2/terms/code_or_metadata.ml
@@ -86,3 +86,6 @@ let code_metadata t =
 
 let iter_code t ~f =
   match t with Code_present code -> f code | Metadata_only _ -> ()
+
+let code_present t =
+  match t with Code_present _ -> true | Metadata_only _ -> false

--- a/middle_end/flambda2/terms/code_or_metadata.mli
+++ b/middle_end/flambda2/terms/code_or_metadata.mli
@@ -31,6 +31,8 @@ val iter_code : t -> f:(Code.t -> unit) -> unit
 
 val code_metadata : t -> Code_metadata.t
 
+val code_present : t -> bool
+
 (** As for [Code_metadata], the free names of a value of type [t] do not include
     the code ID, which is only kept for convenience. *)
 include Contains_names.S with type t := t


### PR DESCRIPTION
I thought this wasn't needed whilst doing #358, but I think that was wrong.  @lukemaurer hit a case on the JS tree which I'm fairly certain is due to the `Missing_code` case having been removed.