### PR TITLE
Re-enable -flambda2-join-points

### DIFF
--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -175,10 +175,16 @@ let compute_handler_env uses ~env_at_fork_plus_params ~consts_lifted_during_body
       LCS.add_to_denv env_at_fork_plus_params consts_lifted_during_body
     in
     let typing_env = DE.typing_env denv in
+    let should_do_join =
+      Flambda_features.join_points ()
+      || match use_envs_with_ids with [] | [_] -> true | _ :: _ :: _ -> false
+    in
     let handler_env, extra_params_and_args =
-      (* CR mshinwell: remove Flambda_features.join_points *)
-      join denv typing_env params ~env_at_fork_plus_params
-        ~consts_lifted_during_body ~use_envs_with_ids
+      if should_do_join
+      then
+        join denv typing_env params ~env_at_fork_plus_params
+          ~consts_lifted_during_body ~use_envs_with_ids
+      else denv, Continuation_extra_params_and_args.empty
     in
     let handler_env =
       DE.map_typing_env handler_env ~f:(fun handler_env ->

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -934,15 +934,15 @@ module Flambda2 = Clflags.Flambda2
 
 let mk_flambda2_join_points f =
   "-flambda2-join-points", Arg.Unit f,
-  Printf.sprintf "Propagate information from incoming edges at a join\n\
+  Printf.sprintf "Propagate information from all incoming edges to a join\n\
       \     point%s (Flambda 2 only)"
     (format_default Flambda2.Default.join_points)
 ;;
 
 let mk_no_flambda2_join_points f =
   "-no-flambda2-join-points", Arg.Unit f,
-  Printf.sprintf " Propagate information only from the fork point to\n\
-      \     a join point%s (Flambda 2 only)"
+  Printf.sprintf " Propagate information to a join point only if there are\n\
+      \     zero or one incoming edge(s)%s (Flambda 2 only)"
     (format_not_default Flambda2.Default.join_points)
 ;;
 

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -462,7 +462,7 @@ end
 module Flambda2 = struct
   module Default = struct
     let classic_mode = false
-    let join_points = true
+    let join_points = false
     let unbox_along_intra_function_control_flow = true
     let backend_cse_at_toplevel = false
     let cse_depth = 2
@@ -657,7 +657,7 @@ module Flambda2 = struct
 
   let o2_flags () =
     cse_depth := 2;
-    join_points := true;
+    join_points := false;
     unbox_along_intra_function_control_flow := true;
     Expert.fallback_inlining_heuristic := false;
     backend_cse_at_toplevel := false


### PR DESCRIPTION
If enabled, this allows information to be propagated to a join point when there are two or more incoming edges.  This patch also disables this propagation at `-O2`; it is enabled at `-O3`.