### PR TITLE
Cause a C warning when CAMLreturn is missing in C stubs.

### DIFF
--- a/ocaml/runtime/caml/memory.h
+++ b/ocaml/runtime/caml/memory.h
@@ -292,6 +292,7 @@ struct caml__roots_block {
 */
 
 #define CAMLparam0() \
+  int caml__missing_CAMLreturn = 0; \
   struct caml__roots_block *caml__frame = Caml_state_field(local_roots)
 
 #define CAMLparam1(x) \
@@ -451,7 +452,10 @@ struct caml__roots_block {
   CAMLxparamN (x, (size))
 
 
-#define CAMLdrop Caml_state_field(local_roots) = caml__frame
+#define CAMLdrop do { \
+  (void)caml__missing_CAMLreturn; \
+  Caml_state_field(local_roots) = caml__frame; \
+} while (0)
 
 #define CAMLreturn0 do{ \
   CAMLdrop; \
@@ -466,7 +470,7 @@ struct caml__roots_block {
 
 #define CAMLreturn(result) CAMLreturnT(value, result)
 
-#define CAMLnoreturn ((void) caml__frame)
+#define CAMLnoreturn ((void) caml__missing_CAMLreturn, (void) caml__frame)
 
 
 /* convenience macro */


### PR DESCRIPTION
Not for the first time, a missing CAMLreturn in a C stub recently caused several people to spend a long time debugging. This patch tries to make that situation a bit easier to debug, by triggering an unused variable warning when it occurs. GCC error output looks like this (when I broke something in otherlibs/str):
```
In file included from strstubs.c:20:
strstubs.c: In function ‘re_replacement_text’:
../../runtime/caml/memory.h:300:7: error: unused variable ‘caml__missing_CAMLreturn’ [-Werror=unused-variable]
  300 |   int caml__missing_CAMLreturn = 0; \
      |       ^~~~~~~~~~~~~~~~~~~~~~~~
../../runtime/caml/memory.h:312:3: note: in expansion of macro ‘CAMLparam0’
  312 |   CAMLparam0 (); \
      |   ^~~~~~~~~~
strstubs.c:483:3: note: in expansion of macro ‘CAMLparam3’
  483 |   CAMLparam3(repl, groups, orig);
      |   ^~~~~~~~~~
cc1: all warnings being treated as errors
```
That's not great but beats debugging mysterious nontermination with gdb. (cc @mshinwell)