### PR TITLE
Four small inliner fixes

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -281,14 +281,14 @@ let might_inline dacc ~apply ~function_type ~simplify_expr ~return_arity : t =
   in
   if not (Code_or_metadata.code_present code_or_metadata)
   then Missing_code
-  else if not (argument_types_useful dacc apply)
-  then Argument_types_not_useful
   else if Function_decl_inlining_decision_type.must_be_inlined decision
   then Definition_says_inline
   else if Function_decl_inlining_decision_type.cannot_be_inlined decision
   then Definition_says_not_to_inline
   else if env_prohibits_inlining
   then Environment_says_never_inline
+  else if not (argument_types_useful dacc apply)
+  then Argument_types_not_useful
   else
     let cost_metrics =
       speculative_inlining ~apply dacc ~simplify_expr ~return_arity
@@ -361,7 +361,7 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity : t =
         | Default_inlined ->
           let max_rec_depth =
             Flambda_features.Inlining.max_rec_depth
-              ~round:(DE.round (DA.denv dacc))
+              (Round (DE.round (DA.denv dacc)))
           in
           if Simplify_rec_info_expr.depth_may_be_at_least dacc rec_info
                max_rec_depth

--- a/middle_end/flambda2/terms/inlining_arguments.ml
+++ b/middle_end/flambda2/terms/inlining_arguments.ml
@@ -18,6 +18,7 @@
 module Args = struct
   type t =
     { max_inlining_depth : int;
+      max_rec_depth : int;
       call_cost : float;
       alloc_cost : float;
       prim_cost : float;
@@ -30,7 +31,8 @@ module Args = struct
     }
 
   let[@ocamlformat "disable"] print ppf t =
-    let { max_inlining_depth; call_cost; alloc_cost; prim_cost; branch_cost;
+    let { max_inlining_depth; max_rec_depth;
+          call_cost; alloc_cost; prim_cost; branch_cost;
           indirect_call_cost; poly_compare_cost;
           small_function_size; large_function_size;
           threshold;
@@ -38,6 +40,7 @@ module Args = struct
     in
     let module I = Flambda_features.Inlining in
     if Int.equal max_inlining_depth (I.max_depth Default)
+       && Int.equal max_rec_depth (I.max_rec_depth Default)
        && Float.equal call_cost (I.call_cost Default)
        && Float.equal alloc_cost (I.alloc_cost Default)
        && Float.equal prim_cost (I.prim_cost Default)
@@ -78,6 +81,7 @@ module Args = struct
 
   let equal t1 t2 =
     let { max_inlining_depth = t1_max_inlining_depth;
+          max_rec_depth = t1_max_rec_depth;
           call_cost = t1_call_cost;
           alloc_cost = t1_alloc_cost;
           prim_cost = t1_prim_cost;
@@ -91,6 +95,7 @@ module Args = struct
       t1
     in
     let { max_inlining_depth = t2_max_inlining_depth;
+          max_rec_depth = t2_max_rec_depth;
           call_cost = t2_call_cost;
           alloc_cost = t2_alloc_cost;
           prim_cost = t2_prim_cost;
@@ -104,6 +109,7 @@ module Args = struct
       t2
     in
     t1_max_inlining_depth = t2_max_inlining_depth
+    && t1_max_rec_depth = t2_max_rec_depth
     && Float.compare t1_call_cost t2_call_cost = 0
     && Float.compare t1_alloc_cost t2_alloc_cost = 0
     && Float.compare t1_prim_cost t2_prim_cost = 0
@@ -124,6 +130,7 @@ module Args = struct
      * [(<=) t2 t1 = false] as [t2.call_cost > t1.call_cost]
      *)
     let { max_inlining_depth = t1_max_inlining_depth;
+          max_rec_depth = t1_max_rec_depth;
           call_cost = t1_call_cost;
           alloc_cost = t1_alloc_cost;
           prim_cost = t1_prim_cost;
@@ -137,6 +144,7 @@ module Args = struct
       t1
     in
     let { max_inlining_depth = t2_max_inlining_depth;
+          max_rec_depth = t2_max_rec_depth;
           call_cost = t2_call_cost;
           alloc_cost = t2_alloc_cost;
           prim_cost = t2_prim_cost;
@@ -150,6 +158,7 @@ module Args = struct
       t2
     in
     t1_max_inlining_depth <= t2_max_inlining_depth
+    && t1_max_rec_depth <= t2_max_rec_depth
     && Float.compare t1_call_cost t2_call_cost <= 0
     && Float.compare t1_alloc_cost t2_alloc_cost <= 0
     && Float.compare t1_prim_cost t2_prim_cost <= 0
@@ -162,6 +171,7 @@ module Args = struct
 
   let meet t1 t2 =
     let { max_inlining_depth = t1_max_inlining_depth;
+          max_rec_depth = t1_max_rec_depth;
           call_cost = t1_call_cost;
           alloc_cost = t1_alloc_cost;
           prim_cost = t1_prim_cost;
@@ -175,6 +185,7 @@ module Args = struct
       t1
     in
     let { max_inlining_depth = t2_max_inlining_depth;
+          max_rec_depth = t2_max_rec_depth;
           call_cost = t2_call_cost;
           alloc_cost = t2_alloc_cost;
           prim_cost = t2_prim_cost;
@@ -188,6 +199,7 @@ module Args = struct
       t2
     in
     { max_inlining_depth = min t1_max_inlining_depth t2_max_inlining_depth;
+      max_rec_depth = min t1_max_rec_depth t2_max_rec_depth;
       call_cost = Float.min t1_call_cost t2_call_cost;
       alloc_cost = Float.min t1_alloc_cost t2_alloc_cost;
       prim_cost = Float.min t1_prim_cost t2_prim_cost;
@@ -202,6 +214,7 @@ module Args = struct
   let create ~round =
     let module I = Flambda_features.Inlining in
     { max_inlining_depth = I.max_depth (Round round);
+      max_rec_depth = I.max_rec_depth (Round round);
       call_cost = I.call_cost (Round round);
       alloc_cost = I.alloc_cost (Round round);
       prim_cost = I.prim_cost (Round round);

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -81,8 +81,10 @@ module Inlining = struct
     | Round round -> IH.get ~key:round !I.max_depth
     | Default -> D.max_depth
 
-  let max_rec_depth ~round =
-    IH.get ~key:round !Clflags.Flambda2.Inlining.max_rec_depth
+  let max_rec_depth round_or_default =
+    match round_or_default with
+    | Round round -> IH.get ~key:round !Clflags.Flambda2.Inlining.max_rec_depth
+    | Default -> D.max_rec_depth
 
   let call_cost round_or_default =
     match round_or_default with

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -71,7 +71,7 @@ module Inlining : sig
 
   val max_depth : round_or_default -> int
 
-  val max_rec_depth : round:int -> int
+  val max_rec_depth : round_or_default -> int
 
   val call_cost : round_or_default -> float
 

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -642,7 +642,7 @@ module Flambda2 = struct
       indirect_call_cost = Some (3.0 *. Default.indirect_call_cost);
       poly_compare_cost = Some (3.0 *. Default.poly_compare_cost);
       small_function_size = Some (10 * Default.small_function_size);
-      large_function_size = Some (100 * Default.large_function_size);
+      large_function_size = Some (50 * Default.large_function_size);
       threshold = Some 100.;
     }
   end


### PR DESCRIPTION
1. (Important!) The "are the arguments useful?" test should not override decisions on the function declaration such as "this is a small function", "must always be inlined", etc.
2. Large function threshold has gone down to 500 at `-O3`, from 1000.  I think this is probably more reasonable.
3. We forgot to add `max_rec_depth` to `Inlining_arguments` when it was added as a configurable parameter.
4. There was a rebase mistake relating to the `max_rec_depth` accessor in `Flambda_features`, which should have used the new `round_or_default` mechanism.

@lukemaurer Could you please review this, as others are out.