### PR TITLE
Don't create extensions for row_like meet with no known indices

### DIFF
--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -466,7 +466,10 @@ and meet_row_like :
         get_singleton_map_known known2 )
     with
     | Bottom, Some _, _, _ | _, _, Bottom, Some _ -> false
-    | (Ok _ | Bottom), _, (Ok _ | Bottom), _ -> true
+    | (Ok _ | Bottom), _, (Ok _ | Bottom), _ ->
+      if is_empty_map_known known1 && is_empty_map_known known2
+      then false
+      else true
   in
   let env = Meet_env.env meet_env in
   let join_env = Join_env.create env ~left_env:env ~right_env:env in


### PR DESCRIPTION
The case where both inputs have no known indices can create results with only one case (in `other`) but with an extension associated.
This should not be a bug in itself, but this triggers another bug in the handling of extensions that creates recursive equations.
This PR should be a good idea on its own, and happens to get us temporarily out of the recursive equation issues, for which the solution is likely to bring https://github.com/ocaml-flambda/ocaml/pull/316 back.