### PR TITLE
Emit MOVQ for stack accesses of type Float (amd64)

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -493,8 +493,8 @@ let move (src : Reg.t) (dst : Reg.t) =
     begin match src.typ, src.loc, dst.typ, dst.loc with
     | Float, Reg.Reg _, Float, Reg.Reg _ -> I.movapd (reg src) (reg dst)
     | Float, _, Float, _ -> I.movsd (reg src) (reg dst)
-    | Float, Reg.Reg _, Int, _
-    | Int, _, Float, Reg.Reg _ -> I.movq (reg src) (reg dst)
+    | Float, _, Int, _
+    | Int, _, Float, _ -> I.movq (reg src) (reg dst)
     | _ -> I.mov (reg src) (reg dst)
     end
 

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -95,8 +95,8 @@ let suf arg =
   match typeof arg with
   | BYTE -> "b"
   | WORD -> "w"
-  | DWORD -> "l"
-  | QWORD | REAL8 -> "q"
+  | DWORD | REAL8 -> "l"
+  | QWORD -> "q"
   | REAL4 -> "s"
   | NONE -> ""
   | OWORD | NEAR | PROC -> assert false

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -95,8 +95,8 @@ let suf arg =
   match typeof arg with
   | BYTE -> "b"
   | WORD -> "w"
-  | DWORD | REAL8 -> "l"
-  | QWORD -> "q"
+  | DWORD -> "l"
+  | QWORD | REAL8 -> "q"
   | REAL4 -> "s"
   | NONE -> ""
   | OWORD | NEAR | PROC -> assert false


### PR DESCRIPTION
PR #296 introduced moves between "registers" of type Float and Int. When the destination is a Reg.t of type Float with location on the stack, the move is emitted as `movl` instruction [1] with a 64-bit register operand, which is not a legal assembly instruction.
For example, flambda2 can be induced to emit `movl    %rdi, 32(%rsp)` which causes the following error:
```
/tmp/camlasm16fdfc.s: Assembler messages:
/tmp/camlasm16fdfc.s:20463: Error: incorrect register `%rdi' used with `l' suffix
```
This PR fixes the bug by emitting `movq` explicitly for this case.

[1] X86_gas.suf returns `l` for `REAL8`, I don't know why not `q`.