### PR TITLE
Switch: rewrite unused exception bucket

### DIFF
--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -78,29 +78,8 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
     let rewrite_use_result =
       let apply_cont = AC.update_continuation_and_args apply_cont cont ~args in
       let apply_cont =
-        Simplify_common.clear_demoted_trap_action uacc apply_cont
-      in
-      let apply_cont =
-        if AC.is_raise apply_cont
-        then
-          match AC.args apply_cont with
-          | [] -> assert false
-          | exn_bucket :: other_args ->
-            let exn_bucket_is_used =
-              Simple.pattern_match
-                ~const:(fun _ -> true)
-                ~name:(fun name ~coercion:_ ->
-                  Name.Set.mem name (UA.required_names uacc))
-                exn_bucket
-            in
-            if exn_bucket_is_used
-            then apply_cont
-            else
-              (* The raise argument must be present, if it is unused, we replace
-                 it by a dummy value to avoid keeping a useless value alive *)
-              let dummy_value = Simple.const_zero in
-              AC.update_args ~args:(dummy_value :: other_args) apply_cont
-        else apply_cont
+        Simplify_common.clear_demoted_trap_action_and_patch_unused_exn_bucket
+          uacc apply_cont
       in
       match rewrite with
       | None -> EB.no_rewrite apply_cont

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -77,4 +77,5 @@ type apply_cont_context =
 val apply_cont_use_kind :
   context:apply_cont_context -> Apply_cont.t -> Continuation_use_kind.t
 
-val clear_demoted_trap_action : Upwards_acc.t -> Apply_cont.t -> Apply_cont.t
+val clear_demoted_trap_action_and_patch_unused_exn_bucket :
+  Upwards_acc.t -> Apply_cont.t -> Apply_cont.t

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -20,15 +20,15 @@ open! Simplify_import
 
 let rebuild_arm uacc arm (action, use_id, arity)
     (new_let_conts, arms, identity_arms, not_arms) =
+  let action =
+    Simplify_common.clear_demoted_trap_action_and_patch_unused_exn_bucket uacc
+      action
+  in
   match
     EB.add_wrapper_for_switch_arm uacc action ~use_id
       (Flambda_arity.With_subkinds.of_arity arity)
   with
   | Apply_cont action -> (
-    let action =
-      Simplify_common.clear_demoted_trap_action_and_patch_unused_exn_bucket uacc
-        action
-    in
     let action =
       (* First try to absorb any [Apply_cont] expression that forms the entirety
          of the arm's action (via an intermediate zero-arity continuation

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -25,7 +25,10 @@ let rebuild_arm uacc arm (action, use_id, arity)
       (Flambda_arity.With_subkinds.of_arity arity)
   with
   | Apply_cont action -> (
-    let action = Simplify_common.clear_demoted_trap_action uacc action in
+    let action =
+      Simplify_common.clear_demoted_trap_action_and_patch_unused_exn_bucket uacc
+        action
+    in
     let action =
       (* First try to absorb any [Apply_cont] expression that forms the entirety
          of the arm's action (via an intermediate zero-arity continuation

--- a/middle_end/flambda2/tests/mlexamples/unused_bucket_switch.ml
+++ b/middle_end/flambda2/tests/mlexamples/unused_bucket_switch.ml
@@ -1,0 +1,12 @@
+(* The Failure exception raised by failwith is never used, so its symbol should
+   disappear; however the Apply_cont corresponding to the raise must be
+   rewritten to use a summy argument instead. This test creates a case where the
+   rewriting needs to apply in a switch arm instead of a regular Apply_cont. *)
+
+let[@inline never] opaque x = x
+
+let n =
+  try
+    let[@local never] f () = if opaque true then 42 else failwith "urk" in
+    f ()
+  with _ -> 1


### PR DESCRIPTION
This moves the existing logic in `Simplify_apply_cont_expr` to `Simplify_common` and also calls it in `Simplify_switch`.