### PR TITLE
Fix "make check_all_arches" in ocaml/ subdirectory

### DIFF
--- a/ocaml/asmcomp/arm/emit.mlp
+++ b/ocaml/asmcomp/arm/emit.mlp
@@ -769,6 +769,8 @@ let emit_instr i =
             assert false
         end
     | Lop (Iname_for_debugger _) -> 0
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+      Misc.fatal_error ("Probes not supported.")
     | Lreloadretaddr ->
         let n = frame_size() in
         `	ldr	lr, [sp, #{emit_int(n-4)}]\n`; 1

--- a/ocaml/asmcomp/arm64/emit.mlp
+++ b/ocaml/asmcomp/arm64/emit.mlp
@@ -532,6 +532,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Ispecific (Ibswap _)) -> 1
     | Lop (Ispecific Imove32) -> 1
     | Lop (Iname_for_debugger _) -> 0
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+      Misc.fatal_error ("Probes not supported.")
     | Lreloadretaddr -> 0
     | Lreturn -> epilogue_size ()
     | Llabel _ -> 0
@@ -880,6 +882,8 @@ let emit_instr i =
             assert false
         end
     | Lop (Iname_for_debugger _) -> ()
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+      Misc.fatal_error ("Probes not supported.")
     | Lreloadretaddr ->
         ()
     | Lreturn ->

--- a/ocaml/asmcomp/power/emit.mlp
+++ b/ocaml/asmcomp/power/emit.mlp
@@ -498,6 +498,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Iintoffloat) -> 4
     | Lop(Ispecific _) -> 1
     | Lop (Iname_for_debugger _) -> 0
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+      Misc.fatal_error ("Probes not supported.")
     | Lreloadretaddr -> 2
     | Lreturn -> 2
     | Llabel _ -> 0
@@ -859,6 +861,8 @@ let emit_instr i =
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
     | Lop (Iname_for_debugger _) -> ()
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+      Misc.fatal_error ("Probes not supported.")
     | Lreloadretaddr ->
         `	{emit_string lg}	11, {emit_int(retaddr_offset())}(1)\n`;
         `	mtlr	11\n`

--- a/ocaml/asmcomp/riscv/emit.mlp
+++ b/ocaml/asmcomp/riscv/emit.mlp
@@ -443,6 +443,8 @@ let emit_instr i =
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
   | Lop (Iname_for_debugger _) ->
       ()
+  | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+      Misc.fatal_error ("Probes not supported.")
   | Lreloadretaddr ->
       let n = frame_size () in
       reload_ra n

--- a/ocaml/asmcomp/s390x/emit.mlp
+++ b/ocaml/asmcomp/s390x/emit.mlp
@@ -544,6 +544,8 @@ let emit_instr i =
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop (Iname_for_debugger _) -> ()
+    | Lop (Iprobe _ |Iprobe_is_enabled _) ->
+      Misc.fatal_error ("Probes not supported.")
     | Lreloadretaddr ->
         let n = frame_size() in
         `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`


### PR DESCRIPTION
It was missing `Iprobe` and `Iprobe_is_enabled` cases. 

The CI didn't catch it, because it only checks the versions from the `backend` directory. (The jst repo will probably be the right place to check it).