### PR TITLE
Build m32 from upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ _build/
 _build0/
 _build1/
 _build2/
+_build_upstream/
 .rsync-output
 .rsync-output-compare
 _compare/

--- a/Makefile.in
+++ b/Makefile.in
@@ -239,8 +239,6 @@ build_upstream: ocaml/configure.ac
 	    --prefix=@prefix@ \
 	    --disable-ocamldoc \
 	    --disable-ocamltest \
-	    --disable-debug-runtime \
-	    --disable-instrumented-runtime \
 	    --disable-debugger && \
 	    $(MAKE) world.opt && \
 	    $(MAKE) ocamlnat)

--- a/Makefile.in
+++ b/Makefile.in
@@ -230,8 +230,7 @@ config_files: ocaml-stage1-config.status
 
 ## Build upstream compiler.
 ## Similar to stage0 except the installation directory
-.PHONY: build_upstream
-build_upstream: ocaml/configure.ac
+_build_upstream/config.status: ocaml/configure.ac
 	rm -rf _build_upstream
 	mkdir _build_upstream
 	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build_upstream
@@ -239,7 +238,12 @@ build_upstream: ocaml/configure.ac
 	  cat ../configure_opts_stage0 | tr -d '\n' | xargs -0 ./configure -C \
 	    --prefix=@prefix@ \
 	    --disable-ocamldoc \
-	    --enable-ocamltest && \
+	    --enable-ocamltest)
+
+.PHONY: build_upstream
+build_upstream: _build_upstream/config.status
+	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build_upstream
+	(cd _build_upstream && \
 	    $(MAKE) world.opt && \
 	    $(MAKE) ocamlnat)
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -238,8 +238,7 @@ build_upstream: ocaml/configure.ac
 	  cat ../configure_opts_stage0 | tr -d '\n' | xargs -0 ./configure -C \
 	    --prefix=@prefix@ \
 	    --disable-ocamldoc \
-	    --disable-ocamltest \
-	    --disable-debugger && \
+	    --enable-ocamltest && \
 	    $(MAKE) world.opt && \
 	    $(MAKE) ocamlnat)
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -228,7 +228,8 @@ config_files: ocaml-stage1-config.status
 	/bin/echo -n "( `grep \"^SHAREDLIB_CFLAGS=\" ocaml/Makefile.config \
 		| sed 's/^SHAREDLIB_CFLAGS=//'` )" > sharedlib_cflags.sexp
 
-## For targets not supported in backend, we can install the result of stage0
+## Build upstream compiler.
+## Similar to stage0 except the installation directory
 .PHONY: build_upstream
 build_upstream: ocaml/configure.ac
 	rm -rf _build_upstream

--- a/Makefile.in
+++ b/Makefile.in
@@ -229,11 +229,25 @@ config_files: ocaml-stage1-config.status
 		| sed 's/^SHAREDLIB_CFLAGS=//'` )" > sharedlib_cflags.sexp
 
 ## For targets not supported in backend, we can install the result of stage0
-.PHONY: install_stage0
-install_stage0: stage0
-	mkdir -p $(prefix)
-	rsync --copy-links --chmod=u+rw,go+r -r $(stage0_prefix)/* $(prefix)
-        # CR gyorsh: when is it supposed to be installed for upstream build?
+.PHONY: build_upstream
+build_upstream: ocaml/configure.ac
+	rm -rf _build_upstream
+	mkdir _build_upstream
+	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build_upstream
+	(cd _build_upstream && \
+	  cat ../configure_opts_stage0 | tr -d '\n' | xargs -0 ./configure -C \
+	    --prefix=@prefix@ \
+	    --disable-ocamldoc \
+	    --disable-ocamltest \
+	    --disable-debug-runtime \
+	    --disable-instrumented-runtime \
+	    --disable-debugger && \
+	    $(MAKE) world.opt && \
+	    $(MAKE) ocamlnat)
+
+.PHONY: install_upstream
+install_upstream: build_upstream
+	(cd _build_upstream && $(MAKE) install)
 	cp ocaml/VERSION $(prefix)/lib/ocaml/
 
 # Most of the installation tree is correctly set up by dune, but we need to

--- a/Makefile.in
+++ b/Makefile.in
@@ -228,6 +228,13 @@ config_files: ocaml-stage1-config.status
 	/bin/echo -n "( `grep \"^SHAREDLIB_CFLAGS=\" ocaml/Makefile.config \
 		| sed 's/^SHAREDLIB_CFLAGS=//'` )" > sharedlib_cflags.sexp
 
+## For targets not supported in backend, we can install the result of stage0
+.PHONY: install_stage0
+install_stage0: stage0
+	rsync --copy-links --chmod=u+rw,go+r -r $(stage0_prefix)/* $(prefix)
+        # CR gyorsh: when is it supposed to be installed for upstream build?
+	cp ocaml/VERSION $(prefix)/lib/ocaml/
+
 # Most of the installation tree is correctly set up by dune, but we need to
 # copy it to the final destination, and rearrange a few things to match
 # upstream.

--- a/Makefile.in
+++ b/Makefile.in
@@ -231,6 +231,7 @@ config_files: ocaml-stage1-config.status
 ## For targets not supported in backend, we can install the result of stage0
 .PHONY: install_stage0
 install_stage0: stage0
+	mkdir -p $(prefix)
 	rsync --copy-links --chmod=u+rw,go+r -r $(stage0_prefix)/* $(prefix)
         # CR gyorsh: when is it supposed to be installed for upstream build?
 	cp ocaml/VERSION $(prefix)/lib/ocaml/

--- a/build_ocaml_compiler.sexp
+++ b/build_ocaml_compiler.sexp
@@ -7,6 +7,7 @@
   supports_flambda2
   uses_autoconf
   is_flambda_backend
+  build_m32_from_upstream
   ))
  (features (
    normal


### PR DESCRIPTION
Follow-up on #387. Provide a way to build and install targets from ocaml/ subdirectory. Can be particularly useful for targets not available in backend subdirectory. Tested for  i386.

This PR adds "make install_stage0" target that installs the result of stage0 build to the configured prefix. 

