### PR TITLE
Use `movq` for a move between quadwords

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -836,7 +836,7 @@ let emit_instr fallthrough i =
       let cond, need_swap = float_cond_and_need_swap cmp in
       let a0, a1 = if need_swap then arg i 1, arg i 0 else arg i 0, arg i 1 in
       I.cmpsd cond a1 a0;
-      I.movd a0 (res i 0);
+      I.movq a0 (res i 0);
       I.neg (res i 0)
   | Lop(Inegf) ->
       I.xorpd (mem64_rip OWORD (emit_symbol "caml_negf_mask")) (res i 0)


### PR DESCRIPTION
(This is joint work with @gretay-js and @mshinwell.)

The `amd64` emitter used to generate a `movd`
instruction between an xmm and a regular 64-bit
register. This is wrong since the only operand
combinations accepted by `movd` are with 32-bit
registers.

This does not cause any problem with the compiler
itself since the assembler helpfully (?!) rewrote the
`movd` instruction into a `movq` one. However, the
`X86_binary_emitter` module does not perform the
rewrite and fails.