### PR TITLE
Refactor -extension and -standard flags

### DIFF
--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -471,7 +471,7 @@ let read_one_param ppf position name v =
 
   | "extension" -> Clflags.Extension.enable v
   | "no-extensions" ->
-    if check_bool ppf "standard" v then Clflags.Extension.disable_all ()
+    if check_bool ppf "no-extensions" v then Clflags.Extension.disable_all ()
 
   | _ ->
     if !warnings_for_discarded_params &&

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -469,6 +469,10 @@ let read_one_param ppf position name v =
       | Some pass -> set_save_ir_after pass true
     end
 
+  | "extension" -> Clflags.Extension.enable v
+  | "standard" ->
+    if check_bool ppf "standard" v then Clflags.Extension.set_standard ()
+
   | _ ->
     if !warnings_for_discarded_params &&
        not (List.mem name !can_discard) then begin

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -470,7 +470,7 @@ let read_one_param ppf position name v =
     end
 
   | "extension" -> Clflags.Extension.enable v
-  | "standard" ->
+  | "no-extensions" ->
     if check_bool ppf "standard" v then Clflags.Extension.disable_all ()
 
   | _ ->

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -471,7 +471,7 @@ let read_one_param ppf position name v =
 
   | "extension" -> Clflags.Extension.enable v
   | "standard" ->
-    if check_bool ppf "standard" v then Clflags.Extension.set_standard ()
+    if check_bool ppf "standard" v then Clflags.Extension.disable_all ()
 
   | _ ->
     if !warnings_for_discarded_params &&

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -724,7 +724,8 @@ let mk_extension f =
 ;;
 
 let mk_standard f =
-  "-standard", Arg.Unit f, " Disable all default extensions"
+  "-standard", Arg.Unit f, " Disable all extensions specified using -extension flag \
+                            (before or after -standard flag), or in OCAMLPARAM."
 ;;
 
 let mk_dparsetree f =

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -726,8 +726,8 @@ let mk_extension f =
 let mk_no_extensions f =
   "-no-extensions", Arg.Unit f,
   " Disable all extensions, including extensions that are enabled by default,\n\
-   or specified in command line using -extension flags\n\
-   (before or after -no-extensions), or in OCAMLPARAM."
+  \    or specified in command line using -extension flags\n\
+  \    (before or after -no-extensions), or in OCAMLPARAM."
 ;;
 
 let mk_dparsetree f =

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -723,9 +723,11 @@ let mk_extension f =
   "<extension> Enable the extension (may be specified more than once)"
 ;;
 
-let mk_standard f =
-  "-standard", Arg.Unit f, " Disable all extensions specified using -extension flag \
-                            (before or after -standard flag), or in OCAMLPARAM."
+let mk_no_extensions f =
+  "-no-extensions", Arg.Unit f,
+  " Disable all extensions, including extensions that are enabled by default,\n\
+   or specified in command line using -extension flags\n\
+   (before or after -no-extensions), or in OCAMLPARAM."
 ;;
 
 let mk_dparsetree f =
@@ -1040,7 +1042,7 @@ module type Compiler_options = sig
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
   val _dprofile : unit -> unit
-  val _standard : unit -> unit
+  val _no_extensions : unit -> unit
   val _dump_into_file : unit -> unit
 
   val _args: string -> string array
@@ -1293,7 +1295,7 @@ struct
     mk_dcamlprimc F._dcamlprimc;
     mk_dtimings F._dtimings;
     mk_dprofile F._dprofile;
-    mk_standard F._standard;
+    mk_no_extensions F._no_extensions;
     mk_dump_into_file F._dump_into_file;
     mk_extension F._extension;
 
@@ -1521,7 +1523,7 @@ struct
     mk_dstartup F._dstartup;
     mk_dtimings F._dtimings;
     mk_dprofile F._dprofile;
-    mk_standard F._standard;
+    mk_no_extensions F._no_extensions;
     mk_dump_into_file F._dump_into_file;
     mk_dump_pass F._dump_pass;
     mk_extension F._extension;
@@ -1897,7 +1899,7 @@ module Default = struct
     let _config_var = Misc.show_config_variable_and_exit
     let _dprofile () = profile_columns := Profile.all_columns
     let _dtimings () = profile_columns := [`Time]
-    let _standard = Extension.set_standard
+    let _no_extensions = Extension.disable_all
     let _dump_into_file = set dump_into_file
     let _for_pack s = for_package := (Some s)
     let _g = set debug

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -720,7 +720,7 @@ let mk_extension f =
     Clflags.Extension.(List.map to_string all)
   in
   "-extension", Arg.Symbol (available_extensions, f),
-  "<extension> Enable the extension (may be specified more than once)"
+  "<extension>  Enable the extension (may be specified more than once)"
 ;;
 
 let mk_no_extensions f =

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -1776,7 +1776,7 @@ module Default = struct
     let _unsafe = set unsafe
     let _warn_error s = Warnings.parse_options true s
     let _warn_help = Warnings.help_warnings
-    let _extension s = add_extension s
+    let _extension s = Extension.enable s
   end
 
   module Native = struct
@@ -1892,7 +1892,7 @@ module Default = struct
     let _config_var = Misc.show_config_variable_and_exit
     let _dprofile () = profile_columns := Profile.all_columns
     let _dtimings () = profile_columns := [`Time]
-    let _standard = set_standard
+    let _standard = Extension.set_standard
     let _dump_into_file = set dump_into_file
     let _for_pack s = for_package := (Some s)
     let _g = set debug

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -716,7 +716,11 @@ let mk_dump_into_file f =
 ;;
 
 let mk_extension f =
-  "-extension", Arg.String f, "<extension> Enable the extension"
+  let available_extensions =
+    Clflags.Extension.(List.map to_string all)
+  in
+  "-extension", Arg.Symbol (available_extensions, f),
+  "<extension> Enable the extension (may be specified more than once)"
 ;;
 
 let mk_standard f =

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -725,9 +725,10 @@ let mk_extension f =
 
 let mk_no_extensions f =
   "-no-extensions", Arg.Unit f,
-  " Disable all extensions, including extensions that are enabled by default,\n\
-  \    or specified in command line using -extension flags\n\
-  \    (before or after -no-extensions), or in OCAMLPARAM."
+  " Disable all extensions, wherever they are specified; this flag\n\
+  \    overrides the -extension flag (whether specified before or after this\n\
+  \    flag), disables any extensions that are enabled by default, and\n\
+  \    ignores any extensions requested in OCAMLPARAM."
 ;;
 
 let mk_dparsetree f =

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -119,7 +119,7 @@ module type Compiler_options = sig
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
   val _dprofile : unit -> unit
-  val _standard : unit -> unit
+  val _no_extensions : unit -> unit
   val _dump_into_file : unit -> unit
 
   val _args: string -> string array

--- a/ocaml/testsuite/tests/comprehensions/comprehensions.ml
+++ b/ocaml/testsuite/tests/comprehensions/comprehensions.ml
@@ -1,5 +1,5 @@
 (* TEST
-  flags = "-extension Comprehensions"
+  flags = "-extension comprehensions"
    * expect
 *)
 (*Type checking tests.*)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -5739,7 +5739,7 @@ let report_error ~loc env = function
       Location.errorf ~loc
         "%%probe_is_enabled points must specify a single probe name as a \
          string literal"
-  | Extension_not_enabled(ext) ->
+  | Extension_not_enabled ext ->
     let name = Clflags.Extension.to_string ext in
     Location.errorf ~loc
         "Extension %s must be enabled to use this feature." name

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -127,7 +127,7 @@ type error =
   | Probe_name_format of string
   | Probe_name_undefined of string
   | Probe_is_enabled_format
-  | Extension_not_enabled of Clflags.extension
+  | Extension_not_enabled of Clflags.Extension.t
   | Literal_overflow of string
   | Unknown_literal of string * char
   | Illegal_letrec_pat
@@ -3776,12 +3776,12 @@ and type_expect_
   | Pexp_extension (({ txt = ("extension.list_comprehension"
                             | "extension.arr_comprehension"); _ },
                     _ ) as extension)  ->
-    if Clflags.is_extension_enabled Clflags.Comprehensions then
+    if Clflags.Extension.(is_enabled Comprehensions) then
       let ext_expr = Extensions.extension_expr_of_payload ~loc extension in
       type_extension ~loc ~env ~ty_expected ~sexp ext_expr
     else
       raise
-        (Error (loc, env, Extension_not_enabled(Clflags.Comprehensions)))
+        (Error (loc, env, Extension_not_enabled(Clflags.Extension.Comprehensions)))
   | Pexp_extension ext ->
     raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
@@ -5740,7 +5740,7 @@ let report_error ~loc env = function
         "%%probe_is_enabled points must specify a single probe name as a \
          string literal"
   | Extension_not_enabled(ext) ->
-    let name = Clflags.string_of_extension ext in
+    let name = Clflags.Extension.to_string ext in
     Location.errorf ~loc
         "Extension %s must be enabled to use this feature." name
   | Literal_overflow ty ->

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -185,7 +185,7 @@ type error =
   | Probe_name_undefined of string
   (* CR-soon mshinwell: Use an inlined record *)
   | Probe_is_enabled_format
-  | Extension_not_enabled of Clflags.extension
+  | Extension_not_enabled of Clflags.Extension.t
   | Literal_overflow of string
   | Unknown_literal of string * char
   | Illegal_letrec_pat

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -384,8 +384,8 @@ module Extension = struct
   let extensions = ref ([] : t list)   (* -extension *)
   let equal _t1 _t2 = true
 
-  let standard = ref false             (* -standard *)
-  let set_standard () = standard := true
+  let disable_all_extensions = ref false             (* -no-extensions *)
+  let disable_all () = disable_all_extensions := true
 
   let to_string = function
     | Comprehensions -> "comprehensions"
@@ -399,7 +399,7 @@ module Extension = struct
     if not (List.exists (equal t) !extensions) then
       extensions := t::!extensions
 
-  let is_enabled ext = not !standard && List.mem ext !extensions
+  let is_enabled ext = not !disable_all_extensions && List.mem ext !extensions
 end
 
 let dump_into_file = ref false (* -dump-into-file *)

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -376,23 +376,30 @@ let set_dumped_pass s enabled =
     dumped_passes_list := dumped_passes
   end
 
-type extension = Comprehensions
+module Extension = struct
+  type t = Comprehensions
 
-let extensions = ref ([] : extension list) (* -extensions *)
-let set_standard () = extensions := []
+  let all = [ Comprehensions ]
 
-let string_of_extension = function
-| Comprehensions -> "comprehensions"
+  let extensions = ref ([] : t list)   (* -extension *)
+  let equal _t1 _t2 = true
 
-let extension_of_string = function
-| "comprehensions" -> Comprehensions
-| extn ->  raise (Arg.Bad(Printf.sprintf "Extension %s is not known" extn))
+  let set_standard () = extensions := []  (* -standard *)
 
-let add_extension extn =
-  let extension = extension_of_string (String.lowercase_ascii extn) in
-  extensions := extension::!extensions
+  let to_string = function
+    | Comprehensions -> "comprehensions"
 
-let is_extension_enabled ext = List.mem ext !extensions
+  let of_string = function
+    | "comprehensions" -> Comprehensions
+    | extn ->  raise (Arg.Bad(Printf.sprintf "Extension %s is not known" extn))
+
+  let enable extn =
+    let t = of_string (String.lowercase_ascii extn) in
+    if not (List.exists (equal t) !extensions) then
+      extensions := t::!extensions
+
+  let is_enabled ext = not !standard && List.mem ext !extensions
+end
 
 let dump_into_file = ref false (* -dump-into-file *)
 

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -382,7 +382,7 @@ module Extension = struct
   let all = [ Comprehensions ]
 
   let extensions = ref ([] : t list)   (* -extension *)
-  let equal _t1 _t2 = true
+  let equal Comprehensions Comprehensions = true
 
   let disable_all_extensions = ref false             (* -no-extensions *)
   let disable_all () = disable_all_extensions := true

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -397,7 +397,7 @@ module Extension = struct
   let enable extn =
     let t = of_string (String.lowercase_ascii extn) in
     if not (List.exists (equal t) !extensions) then
-      extensions := t::!extensions
+      extensions := t :: !extensions
 
   let is_enabled ext = not !disable_all_extensions && List.mem ext !extensions
 end

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -392,7 +392,7 @@ module Extension = struct
 
   let of_string = function
     | "comprehensions" -> Comprehensions
-    | extn ->  raise (Arg.Bad(Printf.sprintf "Extension %s is not known" extn))
+    | extn -> raise (Arg.Bad(Printf.sprintf "Extension %s is not known" extn))
 
   let enable extn =
     let t = of_string (String.lowercase_ascii extn) in

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -384,7 +384,8 @@ module Extension = struct
   let extensions = ref ([] : t list)   (* -extension *)
   let equal _t1 _t2 = true
 
-  let set_standard () = extensions := []  (* -standard *)
+  let standard = ref false             (* -standard *)
+  let set_standard () = standard := true
 
   let to_string = function
     | Comprehensions -> "comprehensions"

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -202,12 +202,14 @@ val set_dumped_pass : string -> bool -> unit
 
 val dump_into_file : bool ref
 
-type extension = Comprehensions
-val extensions : extension list ref
-val set_standard : unit -> unit
-val add_extension: string -> unit
-val is_extension_enabled: extension -> bool
-val string_of_extension: extension -> string
+module Extension : sig
+  type t = Comprehensions
+  val enable: string -> unit
+  val is_enabled : t -> bool
+  val to_string : t -> string
+  val all : t list
+  val set_standard : unit -> unit
+end
 
 (* Support for flags that can also be set from an environment variable *)
 type 'a env_reader = {

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -208,8 +208,7 @@ module Extension : sig
   val is_enabled : t -> bool
   val to_string : t -> string
   val all : t list
-  (* [set_standard ()] disables all extensions (enabled before or after it) *)
-  val set_standard : unit -> unit
+  val disable_all : unit -> unit
 end
 
 (* Support for flags that can also be set from an environment variable *)

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -208,6 +208,7 @@ module Extension : sig
   val is_enabled : t -> bool
   val to_string : t -> string
   val all : t list
+  (* [set_standard ()] disables all extensions (enabled before or after it) *)
   val set_standard : unit -> unit
 end
 

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -204,7 +204,7 @@ val dump_into_file : bool ref
 
 module Extension : sig
   type t = Comprehensions
-  val enable: string -> unit
+  val enable : string -> unit
   val is_enabled : t -> bool
   val to_string : t -> string
   val all : t list


### PR DESCRIPTION
The only functionality change in this PR is to the interpretation of -standard flag to disable all extensions globally, whether specified before and after it in command line.

Other changes:
- Refactor Clflags functions for handling of -extension and -standard command-line flags into a separate module
- Print the list of available extensions in -help message for -extension
- Fix testsuite
- Add extension  and standard flags to OCAMLPARAM
