### PR TITLE
Move compiler flag -dcfg out of ocaml/ subdirectory

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -234,7 +234,7 @@ let compile_fundecl ~ppf_dump fd_cmm =
       ++ Profile.record ~accumulate:true "linear_to_cfg"
            (Linear_to_cfg.run ~preserve_orig_labels:true)
       ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cfg
-      ++ pass_dump_cfg_if ppf_dump dump_cfg "After linear_to_cfg"
+      ++ pass_dump_cfg_if ppf_dump Flambda_backend_flags.dump_cfg "After linear_to_cfg"
       ++ save_cfg
       ++ Profile.record ~accumulate:true "cfg_to_linear" Cfg_to_linear.run
       ++ pass_dump_linear_if ppf_dump dump_linear "After cfg_to_linear"

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -23,6 +23,10 @@ let mk_no_ocamlcfg f =
   "-no-ocamlcfg", Arg.Unit f, " Do not use ocamlcfg"
 ;;
 
+let mk_dcfg f =
+  "-dcfg", Arg.Unit f, " (undocumented)"
+;;
+
 module Flambda2 = Flambda_backend_flags.Flambda2
 
 let mk_flambda2_join_points f =
@@ -348,6 +352,7 @@ let mk_dfreshen f =
 module type Flambda_backend_options = sig
   val ocamlcfg : unit -> unit
   val no_ocamlcfg : unit -> unit
+  val dcfg : unit -> unit
 
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
@@ -406,6 +411,7 @@ struct
   let list2 = [
     mk_ocamlcfg F.ocamlcfg;
     mk_no_ocamlcfg F.no_ocamlcfg;
+    mk_dcfg F.dcfg;
 
     mk_flambda2_join_points F.flambda2_join_points;
     mk_no_flambda2_join_points F.no_flambda2_join_points;
@@ -491,6 +497,7 @@ module Flambda_backend_options_impl = struct
 
   let ocamlcfg = set Flambda_backend_flags.use_ocamlcfg
   let no_ocamlcfg = clear Flambda_backend_flags.use_ocamlcfg
+  let dcfg = set Flambda_backend_flags.dump_cfg
 
   let flambda2_join_points = set Flambda2.join_points
   let no_flambda2_join_points = clear Flambda2.join_points

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -22,6 +22,8 @@
 module type Flambda_backend_options = sig
   val ocamlcfg : unit -> unit
   val no_ocamlcfg : unit -> unit
+  val dcfg : unit -> unit
+
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
   val flambda2_unbox_along_intra_function_control_flow : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -14,6 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 let use_ocamlcfg = ref false            (* -ocamlcfg *)
+let dump_cfg = ref false                (* -dcfg *)
 
 module Flambda2 = struct
   module Default = struct

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -15,6 +15,7 @@
 (**************************************************************************)
 (** Flambda-backend specific command line flags *)
 val use_ocamlcfg : bool ref
+val dump_cfg : bool ref
 
 module Flambda2 : sig
   module Default : sig

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -803,10 +803,6 @@ let mk_dcamlprimc f =
   "-dcamlprimc", Arg.Unit f, " (undocumented)"
 ;;
 
-let mk_dcfg f =
-  "-dcfg", Arg.Unit f, " (undocumented)"
-;;
-
 let mk_dcmm_invariants f =
   "-dcmm-invariants", Arg.Unit f, " Extra sanity checks on Cmm"
 ;;
@@ -1121,7 +1117,6 @@ module type Optcommon_options = sig
   val _dflambda_verbose : unit -> unit
   val _drawclambda : unit -> unit
   val _dclambda : unit -> unit
-  val _dcfg : unit -> unit
   val _dcmm_invariants : unit -> unit
   val _dcmm : unit -> unit
   val _dsel : unit -> unit
@@ -1496,7 +1491,6 @@ struct
     mk_dflambda_let F._dflambda_let;
     mk_dflambda_verbose F._dflambda_verbose;
 
-    mk_dcfg F._dcfg;
     mk_dcmm F._dcmm;
     mk_dsel F._dsel;
     mk_dcombine F._dcombine;
@@ -1606,7 +1600,6 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_dcmm_invariants F._dcmm_invariants;
     mk_drawflambda F._drawflambda;
     mk_dflambda F._dflambda;
-    mk_dcfg F._dcfg;
     mk_dcmm F._dcmm;
     mk_dsel F._dsel;
     mk_dcombine F._dcombine;
@@ -1787,7 +1780,6 @@ module Default = struct
     let _dalloc = set dump_regalloc
     let _davail () = dump_avail := true
     let _dclambda = set dump_clambda
-    let _dcfg = set dump_cfg
     let _dcmm = set dump_cmm
     let _dcmm_invariants = set cmm_invariants
     let _dcombine = set dump_combine

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -205,7 +205,6 @@ module type Optcommon_options = sig
   val _dflambda_verbose : unit -> unit
   val _drawclambda : unit -> unit
   val _dclambda : unit -> unit
-  val _dcfg : unit -> unit
   val _dcmm_invariants : unit -> unit
   val _dcmm : unit -> unit
   val _dsel : unit -> unit

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -116,7 +116,6 @@ let optimize_for_speed = ref true       (* -compact *)
 and opaque = ref false                  (* -opaque *)
 
 and dump_cmm = ref false                (* -dcmm *)
-let dump_cfg = ref false                (* -dcfg *)
 let dump_selection = ref false          (* -dsel *)
 let dump_cse = ref false                (* -dcse *)
 let dump_live = ref false               (* -dlive *)

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -121,7 +121,6 @@ val dump_instr : bool ref
 val keep_camlprimc_file : bool ref
 val keep_asm_file : bool ref
 val optimize_for_speed : bool ref
-val dump_cfg : bool ref
 val dump_cmm : bool ref
 val dump_selection : bool ref
 val dump_cse : bool ref

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -59,7 +59,7 @@ let main() =
      "-S", Arg.Set write_asm_file,
        " Output file to filename.s (default is stdout)";
      "-g", Arg.Set Clflags.debug, "";
-     "-dcfg", Arg.Set dump_cfg, "";
+     "-dcfg", Arg.Set Flambda_backend_flags.dump_cfg, "";
      "-dcmm", Arg.Set dump_cmm, "";
      "-dcse", Arg.Set dump_cse, "";
      "-dsel", Arg.Set dump_selection, "";


### PR DESCRIPTION
Follow-up on #382, in which I forgot to move this flag.