### PR TITLE
Optimize bits_of_float / float_of_bit with memory operands

### DIFF
--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -276,7 +276,7 @@ method! select_operation op args dbg =
   | Cextcall { func = "caml_int64_bits_of_float_unboxed"; alloc = false;
                ty = [|Int|]; ty_args = [XFloat] } ->
       (match args with
-      | [Cop(Cload ((Word_int | Word_val | Double), _), [loc], _dbg)] ->
+      | [Cop(Cload (Double, _), [loc], _dbg)] ->
         let c = Word_int in
         let (addr, arg) = self#select_addressing c loc in
         Iload(c, addr), [arg]
@@ -284,7 +284,7 @@ method! select_operation op args dbg =
   | Cextcall { func = "caml_int64_float_of_bits_unboxed"; alloc = false;
                ty = [|Float|]; ty_args = [XInt64] } ->
       (match args with
-      | [Cop(Cload ((Word_int | Word_val | Double), _), [loc], _dbg)] ->
+      | [Cop(Cload (Word_int, _), [loc], _dbg)] ->
         let c = Double in
         let (addr, arg) = self#select_addressing c loc in
         Iload(c, addr), [arg]

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -277,7 +277,7 @@ method! select_operation op args dbg =
                ty = [|Int|]; ty_args = [XFloat] } ->
       (match args with
       | [Cop(Cload ((Word_int | Word_val | Double), _), [loc], _dbg)] ->
-        let c = Word_val in
+        let c = Word_int in
         let (addr, arg) = self#select_addressing c loc in
         Iload(c, addr), [arg]
       | _ -> Imove, args)

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -274,10 +274,21 @@ method! select_operation op args dbg =
          assert false
     end
   | Cextcall { func = "caml_int64_bits_of_float_unboxed"; alloc = false;
-               ty = [|Int|]; ty_args = [XFloat] }
+               ty = [|Int|]; ty_args = [XFloat] } ->
+      (match args with
+      | [Cop(Cload ((Word_int | Word_val | Double), _), [loc], _dbg)] ->
+        let c = Word_val in
+        let (addr, arg) = self#select_addressing c loc in
+        Iload(c, addr), [arg]
+      | _ -> Imove, args)
   | Cextcall { func = "caml_int64_float_of_bits_unboxed"; alloc = false;
                ty = [|Float|]; ty_args = [XInt64] } ->
-     Imove, args
+      (match args with
+      | [Cop(Cload ((Word_int | Word_val | Double), _), [loc], _dbg)] ->
+        let c = Double in
+        let (addr, arg) = self#select_addressing c loc in
+        Iload(c, addr), [arg]
+      | _ -> Imove, args)
   | Cextcall { func; builtin = true; ty = ret; ty_args = _; } ->
       begin match func, ret with
       | "caml_rdtsc_unboxed", [|Int|] -> Ispecific Irdtsc, args


### PR DESCRIPTION
This PR optimizes `float_of_bits` and `bits_of_float` with a memory operand into a single instruction.

With PR #296 we get a move between two registers of type float and int after a separate load instruction, because the compiler does not know how to assign two virtual registers of different types to the same physical register. I don't know how to solve this in general for these two "reinterpreting" instruction. This PR handles a special case which seems like an improvement worth having on its own. Other `Ispecific` instructions can have memory operands, but they will be handled in (or
as a followup of) #313, because they don't reinterpret their arguments.

Here is an example for `bits_of_float`:
```
type t = { f : float; }
let[@cold] incr_float_in_field x =
  Int64.add (Int64.bits_of_float x.f) 1L |> Int64.to_int
```

```
camlTt__incr_float_in_field_5:
-	movsd	(%rax), %xmm0
-	movq	%xmm0, %rax
+	movq	(%rax), %rax
 	salq	$1, %rax
 	addq	$3, %rax
 	ret
```

With flambda2, we also emit better code for `float_of_bits` in this example:
```
external unsafe_get_int64 : Bytes.t -> int -> int64 = "%caml_bytes_get64u"
external unsafe_set_int64 : Bytes.t -> int -> int64 -> unit = "%caml_bytes_set64u"

let[@cold] incr_float_in_str str pos =
  let f = unsafe_get_int64 str pos |> Int64.float_of_bits in
  let f = f +. 1.0 in
  Int64.bits_of_float f |> unsafe_set_int64 str pos
```

```
camlT__incr_float_in_str_0_1_code:
 	sarq	$1, %rbx
-	movq	(%rax,%rbx), %rdi
-	movq	%rdi, %xmm0
+	movsd	(%rax,%rbx), %xmm0
 	movsd	.L101(%rip), %xmm1
 	addsd	%xmm1, %xmm0
 	movq	%xmm0, %rdi
 	movq	%rdi, (%rax,%rbx)
 	movl	$1, %eax
 	ret
```


[1] with memory operands PR