### PR TITLE
Typos

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -23,10 +23,6 @@ want to modify the Flambda backend.  Jump to:
 
 Pull requests should be submitted to the `main` branch, which is the default.
 
-Simple edits to documents can be committed directly via the Github "edit file"
-functionality for people with write access to the repo.  Changes requiring review
-and all code changes must go through PRs.
-
 PRs should not be merged unless all CI checks have passed unless there is a good
 reason.  It is not necessary to wait for CI checks to pass after genuinely trivial
 changes to a PR that was previously passing CI.

--- a/ocaml/parsing/extensions.ml
+++ b/ocaml/parsing/extensions.ml
@@ -104,7 +104,7 @@ let unwrap_structure ~loc = function
 let unmap_comprehension ~loc payload =
   let str = unwrap_structure ~loc payload in
   let get_hd_and_tl = function
-    | [] -> Misc.fatal_error "Unexpected sturcture in comprehension extension."
+    | [] -> Misc.fatal_error "Unexpected structure in comprehension extension."
     | hd::tl -> hd, tl
   in
   let str_hd, str_tl = get_hd_and_tl str in
@@ -161,7 +161,7 @@ let extension_expr_of_payload ~loc ((name, payload) : extension) =
 
 let report_error ~loc = function
   | Extension_not_existent extension_name ->
-    Location.errorf ~loc "Extension %s does not exsist." extension_name
+    Location.errorf ~loc "Extension %s does not exist." extension_name
   | Illegal_comprehension_extension_construct ->
     Location.errorf ~loc "Wrong extension syntax for comprehensions."
 


### PR DESCRIPTION
1e3ad7f2a76add6505dff35bba8e958e9ffc6d1e fixes two minor typos in error messages.

612ecbc83155410858d3c7779740e0f83a5d0832 deletes a paragraph from `HACKING.md` which was
suggesting the "edit file" feature of the GitHub interface could
be used to commit such small changes.