### PR TITLE
Include deleted code in Flambda_unit.iter

### DIFF
--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -195,6 +195,7 @@ let simplify_static_consts dacc (bound_symbols : Bound_symbols.t) static_consts
               (DE.define_symbol (DA.denv dacc) closure_symbol K.value))
           closure_symbols dacc)
       ~code:(fun dacc _ _ -> dacc)
+      ~deleted_code:(fun dacc _ -> dacc)
       ~block_like:(fun dacc _ _ -> dacc)
   in
   (* Next we simplify all the constants that are not closures. The ordering of
@@ -212,6 +213,7 @@ let simplify_static_consts dacc (bound_symbols : Bound_symbols.t) static_consts
         ( Bound_symbols.Pattern.code code_id :: bound_symbols,
           static_const :: static_consts,
           dacc ))
+      ~deleted_code:(fun acc _code_id -> acc)
       ~set_of_closures:(fun acc ~closure_symbols:_ _ -> acc)
       ~block_like:
         (fun (bound_symbols, static_consts, dacc) symbol static_const ->
@@ -231,6 +233,7 @@ let simplify_static_consts dacc (bound_symbols : Bound_symbols.t) static_consts
     Static_const_group.match_against_bound_symbols static_consts bound_symbols
       ~init:([], [])
       ~code:(fun acc _ _ -> acc)
+      ~deleted_code:(fun acc _ -> acc)
       ~block_like:(fun acc _ _ -> acc)
       ~set_of_closures:
         (fun (closure_bound_names_all_sets, sets_of_closures) ~closure_symbols

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -530,6 +530,7 @@ and match_against_bound_symbols_static_const_group :
       Bound_symbols.t ->
       init:'a ->
       code:('a -> Code_id.t -> function_params_and_body Code0.t -> 'a) ->
+      deleted_code:('a -> Code_id.t -> 'a) ->
       set_of_closures:
         ('a ->
         closure_symbols:Symbol.t Closure_id.Lmap.t ->
@@ -538,6 +539,7 @@ and match_against_bound_symbols_static_const_group :
       block_like:('a -> Symbol.t -> Static_const.t -> 'a) ->
       'a =
  fun t bound_symbols ~init ~code:code_callback
+     ~deleted_code:deleted_code_callback
      ~set_of_closures:set_of_closures_callback ~block_like:block_like_callback ->
   let bound_symbol_pats = Bound_symbols.to_list bound_symbols in
   if List.compare_lengths t bound_symbol_pats <> 0
@@ -551,7 +553,7 @@ and match_against_bound_symbols_static_const_group :
       match_against_bound_symbols_pattern_static_const_or_code static_const
         bound_symbols_pat
         ~code:(fun code_id code -> code_callback acc code_id code)
-        ~deleted_code:(fun _code_id -> acc)
+        ~deleted_code:(fun code_id -> deleted_code_callback acc code_id)
         ~set_of_closures:(fun ~closure_symbols set_of_closures ->
           set_of_closures_callback acc ~closure_symbols set_of_closures)
         ~block_like:(fun symbol static_const ->
@@ -755,6 +757,9 @@ and flatten_for_printing0 bound_symbols defining_exprs =
         }
       in
       flattened_acc @ [flattened], true)
+    ~deleted_code:(fun acc _code_id ->
+      (* CR lmaurer: We should probably be printing deleted code *)
+      acc)
     ~set_of_closures:
       (fun (flattened_acc, second_or_later_rec_binding) ~closure_symbols
            set_of_closures ->

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -529,6 +529,7 @@ module Static_const_group : sig
     Bound_symbols.t ->
     init:'a ->
     code:('a -> Code_id.t -> Function_params_and_body.t Code0.t -> 'a) ->
+    deleted_code:('a -> Code_id.t -> 'a) ->
     set_of_closures:
       ('a ->
       closure_symbols:Symbol.t Closure_id.Lmap.t ->

--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -194,7 +194,7 @@ module Iter = struct
     Static_const_group.match_against_bound_symbols static_consts bound_symbols
       ~init:()
       ~code:(fun () code_id (code : Code.t) ->
-        f_c ~id:code_id code;
+        f_c ~id:code_id (Some code);
         let params_and_body = Code.params_and_body code in
         Function_params_and_body.pattern_match params_and_body
           ~f:(fun
@@ -207,6 +207,7 @@ module Iter = struct
                ~my_depth:_
                ~free_names_of_body:_
              -> expr f_c f_s body))
+      ~deleted_code:(fun () code_id -> f_c ~id:code_id None)
       ~set_of_closures:(fun () ~closure_symbols set_of_closures ->
         f_s ~closure_symbols:(Some closure_symbols) ~is_phantom:false
           set_of_closures)

--- a/middle_end/flambda2/terms/flambda_unit.mli
+++ b/middle_end/flambda2/terms/flambda_unit.mli
@@ -46,7 +46,7 @@ val body : t -> Flambda.Expr.t
 val permute_everything : t -> t
 
 val iter :
-  ?code:(id:Code_id.t -> Code.t -> unit) ->
+  ?code:(id:Code_id.t -> Code.t option -> unit) ->
   ?set_of_closures:
     (closure_symbols:Symbol.t Closure_id.Lmap.t option ->
     is_phantom:bool ->


### PR DESCRIPTION
Fixes -dflexpect, which was choking anytime it saw a `newer_version_of` with a deleted argument (which is usually) since it hadn't seen a binding for the code id.