### PR TITLE
Use setup-ocaml in formatting CI job

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -9,6 +9,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        ocaml-compiler:
+          - "4.12.0"
 
     steps:
     - name: Checkout the Flambda backend repo
@@ -16,14 +18,10 @@ jobs:
       with:
         path: 'flambda_backend'
 
-    - name: Install OPAM
-      run: sudo apt-get install opam
-
-    - name: Initialise OPAM
-      run: opam init -y
-
-    - name: Install OCaml 4.12 OPAM switch
-      run: opam switch create -y 4.12.0
+    - name: Setup OCaml ${{ matrix.ocaml-compiler }}
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
     - name: Install ocamlformat 0.19.0
       run: opam pin -y ocamlformat 0.19.0
@@ -42,4 +40,4 @@ jobs:
 
     - name: Check formatting of Flambda 2 and Cfg code
       working-directory: flambda_backend
-      run: opam exec --switch=4.12.0 make check-fmt
+      run: opam exec -- make check-fmt


### PR DESCRIPTION
Using the `ocaml/setup-ocaml` plugin allows the compiler build to be cached so the formatting job will run faster. You can see a second [run of the job here](https://github.com/patricoferris/flambda-backend/runs/4406399641) after the caches are primed reducing the job to between 3-4 mins (at the moment it looks like it takes about 9).