### PR TITLE
Use -linscan for -Oclassic

### DIFF
--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -206,11 +206,9 @@ module Flambda2 = struct
 
   let oclassic_flags () =
     classic_mode := true;
-    cse_depth := 2;
-    join_points := false;
-    unbox_along_intra_function_control_flow := true;
     Expert.fallback_inlining_heuristic := true;
-    backend_cse_at_toplevel := false
+    backend_cse_at_toplevel := false;
+    Clflags.use_linscan := true
 
   let o2_flags () =
     cse_depth := 2;


### PR DESCRIPTION
Hopefully this will avoid the problem that the "transl_store" functions in `Translmod` were designed to solve many years ago.  It should also be slightly faster in the normal case.

This PR also removes a couple of redundant assignments to flags that are not checked in classic mode.