### PR TITLE
Refined call conventions in Closure_conversion

### DIFF
--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -20,7 +20,7 @@
 
 type 'code t =
   | Value_unknown
-  | Closure_approximation of Code_id.t * 'code option
+  | Closure_approximation of Code_id.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 
 let is_unknown = function

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -20,7 +20,7 @@
 
 type 'code t =
   | Value_unknown
-  | Closure_approximation of Code_id.t * 'code
+  | Closure_approximation of Code_id.t * Closure_id.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 
 let is_unknown = function

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -20,7 +20,7 @@
 
 type 'code t =
   | Value_unknown
-  | Closure_approximation of Code_id.t * 'code option
+  | Closure_approximation of Code_id.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 
 val is_unknown : 'a t -> bool

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -20,7 +20,7 @@
 
 type 'code t =
   | Value_unknown
-  | Closure_approximation of Code_id.t * 'code
+  | Closure_approximation of Code_id.t * Closure_id.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 
 val is_unknown : 'a t -> bool

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -58,17 +58,17 @@ let rec load_cmx_file_contents loader comp_unit =
              loader.imported_units;
       Some typing_env)
 
-let load_symbol_approx loader symbol : Code.t Value_approximation.t =
+let load_symbol_approx loader symbol : Code_or_metadata.t Value_approximation.t
+    =
   let comp_unit = Symbol.compilation_unit symbol in
   match load_cmx_file_contents loader comp_unit with
   | None -> Value_unknown
   | Some typing_env ->
     let find_code code_id =
       match Exported_code.find loader.imported_code code_id with
-      | Some (Code_present code) -> Some code
-      | _ -> None
-      (* CR keryan : we want to use metadata in classic mode at some point in
-         the near future *)
+      | Some code_or_meta -> code_or_meta
+      | _ -> assert false
+      (* CR now : is there a case where this could happen ? *)
     in
     T.extract_symbol_approx typing_env symbol find_code
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -67,8 +67,10 @@ let load_symbol_approx loader symbol : Code_or_metadata.t Value_approximation.t
     let find_code code_id =
       match Exported_code.find loader.imported_code code_id with
       | Some code_or_meta -> code_or_meta
-      | _ -> assert false
-      (* CR now : is there a case where this could happen ? *)
+      | _ ->
+        Misc.fatal_errorf
+          "Failed to load informations for %a. Code id not found." Code_id.print
+          code_id
     in
     T.extract_symbol_approx typing_env symbol find_code
 

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -34,7 +34,8 @@ val get_imported_code : loader -> unit -> Exported_code.t
 val load_cmx_file_contents :
   loader -> Compilation_unit.t -> Flambda2_types.Typing_env.t option
 
-val load_symbol_approx : loader -> Symbol.t -> Code.t Value_approximation.t
+val load_symbol_approx :
+  loader -> Symbol.t -> Code_or_metadata.t Value_approximation.t
 
 val prepare_cmx_file_contents :
   final_typing_env:Flambda2_types.Typing_env.t option ->
@@ -45,7 +46,7 @@ val prepare_cmx_file_contents :
   Flambda_cmx_format.t option
 
 val prepare_cmx_from_approx :
-  approxs:Code.t Value_approximation.t Symbol.Map.t ->
+  approxs:Code_or_metadata.t Value_approximation.t Symbol.Map.t ->
   exported_offsets:Exported_offsets.t ->
   used_closure_vars:Var_within_closure.Set.t ->
   Exported_code.t ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1509,10 +1509,13 @@ let close_apply acc env (apply : IR.apply) : Acc.t * Expr_with_acc.t =
           Code_metadata.result_arity metadata )
     | Value_unknown -> None
     | _ ->
-      Misc.fatal_errorf
-        "Unexpected approximation for callee %a in [Closure_conversion], \
-         expected a closure approximation."
-        Simple.print callee
+      if Flambda_features.check_invariants ()
+      then
+        Misc.fatal_errorf
+          "Unexpected approximation for callee %a in [Closure_conversion], \
+           expected a closure approximation."
+          Simple.print callee
+      else None
   in
   match code_info with
   | None -> close_exact_or_unknown_apply acc env apply None

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1692,7 +1692,7 @@ let close_apply acc env (apply : IR.apply) : Acc.t * Expr_with_acc.t =
         num_trailing_local_params,
         contains_no_escaping_local_allocs,
         result_arity ) -> (
-    let splited_args =
+    let split_args =
       let split args arity =
         let rec cut n l =
           if n <= 0
@@ -1725,7 +1725,7 @@ let close_apply acc env (apply : IR.apply) : Acc.t * Expr_with_acc.t =
       in
       split apply.args arity
     in
-    match splited_args with
+    match split_args with
     | Exact args ->
       close_exact_or_unknown_apply acc env
         { apply with args; continuation = apply.continuation }

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -201,13 +201,13 @@ module Inlining = struct
         ~apply ~pass:After_closure_conversion ();
       Not_inlinable
     | Block_approximation _ -> assert false
-    | Closure_approximation (_code_id, Metadata_only _) ->
+    | Closure_approximation (_code_id, _, Metadata_only _) ->
       Inlining_report.record_decision_at_call_site_for_known_function ~tracker
         ~apply ~pass:After_closure_conversion ~unrolling_depth:None
         ~callee:(Inlining_history.Absolute.empty compilation_unit)
         ~are_rebuilding_terms Definition_says_not_to_inline;
       Not_inlinable
-    | Closure_approximation (_code_id, Code_present code) ->
+    | Closure_approximation (_code_id, _, Code_present code) ->
       let fun_params_length =
         Code.params_arity code |> Flambda_arity.With_subkinds.to_arity
         |> Flambda_arity.length
@@ -1329,9 +1329,9 @@ let close_functions acc external_env function_declarations =
     Closure_id.Lmap.of_list (List.rev funs)
   in
   let approximations =
-    Closure_id.Map.map
-      (fun (code_id, code) ->
-        Value_approximation.Closure_approximation (code_id, code))
+    Closure_id.Map.mapi
+      (fun closure_id (code_id, code) ->
+        Value_approximation.Closure_approximation (code_id, closure_id, code))
       approximations
   in
   let function_decls = Function_declarations.create funs in
@@ -1471,14 +1471,14 @@ let close_apply acc env (apply : IR.apply) : Acc.t * Expr_with_acc.t =
   let approx = Env.find_value_approximation env callee in
   let code_info =
     match approx with
-    | Closure_approximation (_, Code_present code) ->
+    | Closure_approximation (_, _, Code_present code) ->
       Some
         ( Code.params_arity code,
           Code.is_tupled code,
           Code.num_trailing_local_params code,
           Code.contains_no_escaping_local_allocs code,
           Code.result_arity code )
-    | Closure_approximation (_, Metadata_only metadata) ->
+    | Closure_approximation (_, _, Metadata_only metadata) ->
       Some
         ( Code_metadata.params_arity metadata,
           Code_metadata.is_tupled metadata,

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1522,7 +1522,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
         specialise = Default_specialise;
         local = Default_local;
         is_a_functor = false;
-        stub = true
+        stub = false
       }
   in
   let free_idents_of_body =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1516,11 +1516,9 @@ let close_apply acc env (apply : IR.apply) : Acc.t * Expr_with_acc.t =
   in
   match code_info with
   | None -> close_exact_or_unknown_apply acc env apply None
-  | Some (_arity, true, _, _, _) ->
-    close_exact_or_unknown_apply acc env apply (Some approx)
   | Some
       ( arity,
-        false,
+        is_tupled,
         num_trailing_local_params,
         contains_no_escaping_local_allocs,
         result_arity ) -> (
@@ -1532,6 +1530,13 @@ let close_apply acc env (apply : IR.apply) : Acc.t * Expr_with_acc.t =
         | e1 :: l1, _ :: l2 ->
           let args, missing, remains = split l1 l2 in
           e1 :: args, missing, remains
+      in
+      let arity =
+        if is_tupled
+        then
+          Flambda_arity.With_subkinds.create
+            [Flambda_kind.With_subkind.block Tag.zero arity]
+        else arity
       in
       split apply.args arity
     in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -837,22 +837,16 @@ let close_exact_or_unknown_apply acc env
       ( acc,
         match (callee_approx : Env.value_approximation option) with
         | Some (Closure_approximation (code_id, closure_id, code_or_meta)) ->
-          let param_arity, return_arity, is_tupled, _closure_used =
+          let return_arity, is_tupled =
             let meta = Code_or_metadata.code_metadata code_or_meta in
-            Code_metadata.(
-              ( params_arity meta,
-                result_arity meta,
-                is_tupled meta,
-                is_my_closure_used meta ))
+            Code_metadata.(result_arity meta, is_tupled meta)
           in
           if is_tupled
           then
-            let param_arity =
-              Flambda_arity.With_subkinds.create
-                [Flambda_kind.With_subkind.block Tag.zero param_arity]
-            in
-            Call_kind.indirect_function_call_known_arity ~param_arity
-              ~return_arity mode
+            (* CR keryan : We could do better here since we know the arity, but
+               we would have to untuple the arguments and we lack information
+               for now *)
+            Call_kind.indirect_function_call_unknown_arity mode
           else
             Call_kind.direct_function_call code_id closure_id ~return_arity mode
         | None -> Call_kind.indirect_function_call_unknown_arity mode

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -158,11 +158,12 @@ module Env = struct
         let approx = Flambda_cmx.load_symbol_approx loader symbol in
         let rec filter_inlinable approx =
           match (approx : value_approximation) with
-          | Value_unknown | Closure_approximation (_, Metadata_only _) -> approx
+          | Value_unknown | Closure_approximation (_, _, Metadata_only _) ->
+            approx
           | Block_approximation (approxs, alloc_mode) ->
             let approxs = Array.map filter_inlinable approxs in
             Value_approximation.Block_approximation (approxs, alloc_mode)
-          | Closure_approximation (code_id, Code_present code) -> (
+          | Closure_approximation (code_id, closure_id, Code_present code) -> (
             match
               Inlining.definition_inlining_decision (Code.inline code)
                 (Code.cost_metrics code)
@@ -171,6 +172,7 @@ module Env = struct
             | _ ->
               Value_approximation.Closure_approximation
                 ( code_id,
+                  closure_id,
                   Code_or_metadata.(remember_only_metadata (create code)) ))
         in
         let approx = filter_inlinable approx in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -60,10 +60,8 @@ module IR = struct
       continuation : Continuation.t;
       exn_continuation : exn_continuation;
       loc : Lambda.scoped_location;
-      tailcall : Lambda.tailcall_attribute;
       region_close : Lambda.region_close;
       inlined : Lambda.inlined_attribute;
-      specialised : Lambda.specialise_attribute;
       probe : Lambda.probe;
       mode : Lambda.alloc_mode
     }

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -127,6 +127,8 @@ module Inlining = struct
 end
 
 module Env = struct
+  type value_approximation = Code_or_metadata.t Value_approximation.t
+
   type t =
     { variables : Variable.t Ident.Map.t;
       globals : Symbol.t Numeric_types.Int.Map.t;
@@ -134,9 +136,8 @@ module Env = struct
       current_unit_id : Ident.t;
       current_depth : Variable.t option;
       symbol_for_global : Ident.t -> Symbol.t;
-      value_approximations : Code.t Value_approximation.t Name.Map.t;
-      approximation_for_external_symbol :
-        Symbol.t -> Code.t Value_approximation.t;
+      value_approximations : value_approximation Name.Map.t;
+      approximation_for_external_symbol : Symbol.t -> value_approximation;
       big_endian : bool;
       path_to_root : Debuginfo.Scoped_location.t;
       inlining_history_tracker : Inlining_history.Tracker.t
@@ -158,18 +159,21 @@ module Env = struct
       | exception Not_found ->
         let approx = Flambda_cmx.load_symbol_approx loader symbol in
         let rec filter_inlinable approx =
-          match (approx : Code.t Value_approximation.t) with
-          | Value_unknown | Closure_approximation (_, None) -> approx
+          match (approx : value_approximation) with
+          | Value_unknown | Closure_approximation (_, Metadata_only _) -> approx
           | Block_approximation (approxs, alloc_mode) ->
             let approxs = Array.map filter_inlinable approxs in
             Value_approximation.Block_approximation (approxs, alloc_mode)
-          | Closure_approximation (code_id, Some code) -> (
+          | Closure_approximation (code_id, Code_present code) -> (
             match
               Inlining.definition_inlining_decision (Code.inline code)
                 (Code.cost_metrics code)
             with
             | Attribute_inline | Small_function _ -> approx
-            | _ -> Value_approximation.Closure_approximation (code_id, None))
+            | _ ->
+              Value_approximation.Closure_approximation
+                ( code_id,
+                  Code_or_metadata.(remember_only_metadata (create code)) ))
         in
         let approx = filter_inlinable approx in
         externals := Symbol.Map.add symbol approx !externals;
@@ -348,13 +352,13 @@ end
 
 module Acc = struct
   type continuation_application =
-    | Trackable_arguments of Code.t Value_approximation.t list
+    | Trackable_arguments of Env.value_approximation list
     | Untrackable
 
   type t =
     { declared_symbols : (Symbol.t * Static_const.t) list;
       lifted_sets_of_closures :
-        ((Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t
+        ((Symbol.t * Env.value_approximation) Closure_id.Lmap.t
         * Flambda.Set_of_closures.t)
         list;
       shareable_constants : Symbol.t Static_const.Map.t;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -64,10 +64,8 @@ module IR : sig
       continuation : Continuation.t;
       exn_continuation : exn_continuation;
       loc : Lambda.scoped_location;
-      tailcall : Lambda.tailcall_attribute;
       region_close : Lambda.region_close;
       inlined : Lambda.inlined_attribute;
-      specialised : Lambda.specialise_attribute;
       probe : Lambda.probe;
       mode : Lambda.alloc_mode
     }

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -98,6 +98,8 @@ end
     values during closure conversion, and similarly for static exception
     identifiers. *)
 module Env : sig
+  type value_approximation = Code_or_metadata.t Value_approximation.t
+
   type t
 
   val create :
@@ -139,14 +141,14 @@ module Env : sig
 
   val find_simple_to_substitute_exn : t -> Ident.t -> Simple.t
 
-  val add_value_approximation : t -> Name.t -> Code.t Value_approximation.t -> t
+  val add_value_approximation : t -> Name.t -> value_approximation -> t
 
   val add_block_approximation :
-    t -> Name.t -> Code.t Value_approximation.t array -> Alloc_mode.t -> t
+    t -> Name.t -> value_approximation array -> Alloc_mode.t -> t
 
   val add_approximation_alias : t -> Name.t -> Name.t -> t
 
-  val find_value_approximation : t -> Simple.t -> Code.t Value_approximation.t
+  val find_value_approximation : t -> Simple.t -> value_approximation
 
   val current_depth : t -> Variable.t option
 
@@ -182,7 +184,7 @@ module Acc : sig
 
   val lifted_sets_of_closures :
     t ->
-    ((Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t
+    ((Symbol.t * Env.value_approximation) Closure_id.Lmap.t
     * Flambda.Set_of_closures.t)
     list
 
@@ -199,7 +201,7 @@ module Acc : sig
   val add_declared_symbol : symbol:Symbol.t -> constant:Static_const.t -> t -> t
 
   val add_lifted_set_of_closures :
-    symbols:(Symbol.t * Code.t Value_approximation.t) Closure_id.Lmap.t ->
+    symbols:(Symbol.t * Env.value_approximation) Closure_id.Lmap.t ->
     set_of_closures:Flambda.Set_of_closures.t ->
     t ->
     t
@@ -216,7 +218,7 @@ module Acc : sig
   val remove_continuation_from_free_names : Continuation.t -> t -> t
 
   val continuation_known_arguments :
-    cont:Continuation.t -> t -> Code.t Value_approximation.t list option
+    cont:Continuation.t -> t -> Env.value_approximation list option
 
   val with_free_names : Name_occurrences.t -> t -> t
 
@@ -347,7 +349,7 @@ module Apply_cont_with_acc : sig
   val create :
     Acc.t ->
     ?trap_action:Trap_action.t ->
-    ?args_approx:Code.t Value_approximation.t list ->
+    ?args_approx:Env.value_approximation list ->
     Continuation.t ->
     args:Simple.t list ->
     dbg:Debuginfo.t ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -791,9 +791,9 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
         ap_region_close;
         ap_mode;
         ap_loc;
-        ap_tailcall;
+        ap_tailcall = _;
         ap_inlined;
-        ap_specialised;
+        ap_specialised = _;
         ap_probe
       } ->
     cps_non_tail_list acc env ccenv ap_args
@@ -817,10 +817,8 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
                     exn_continuation;
                     args;
                     loc = ap_loc;
-                    tailcall = ap_tailcall;
                     region_close = ap_region_close;
                     inlined = ap_inlined;
-                    specialised = ap_specialised;
                     probe = ap_probe;
                     mode = ap_mode
                   }
@@ -1001,10 +999,8 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
                         exn_continuation;
                         args;
                         loc;
-                        tailcall = Default_tailcall;
                         region_close = pos;
                         inlined = Default_inlined;
-                        specialised = Default_specialise;
                         probe = None;
                         mode
                       }
@@ -1152,9 +1148,9 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
         ap_region_close;
         ap_mode;
         ap_loc;
-        ap_tailcall;
+        ap_tailcall = _;
         ap_inlined;
-        ap_specialised;
+        ap_specialised = _;
         ap_probe
       } ->
     cps_non_tail_list acc env ccenv ap_args
@@ -1173,10 +1169,8 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
                 exn_continuation;
                 args;
                 loc = ap_loc;
-                tailcall = ap_tailcall;
                 region_close = ap_region_close;
                 inlined = ap_inlined;
-                specialised = ap_specialised;
                 probe = ap_probe;
                 mode = ap_mode
               }
@@ -1361,10 +1355,8 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
                     exn_continuation;
                     args;
                     loc;
-                    tailcall = Default_tailcall;
                     region_close = pos;
                     inlined = Default_inlined;
-                    specialised = Default_specialise;
                     probe = None;
                     mode
                   }

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1274,12 +1274,7 @@ end = struct
         let fields = List.map type_from_approx (Array.to_list fields) in
         MTC.immutable_block ~is_unique:false Tag.zero
           ~field_kind:Flambda_kind.value ~fields (Or_unknown.Known alloc_mode)
-      | Closure_approximation (code_id, _code_opt) ->
-        let closure_id =
-          Closure_id.wrap
-            (Compilation_unit.get_current_exn ())
-            (Variable.create (Code_id.name code_id))
-        in
+      | Closure_approximation (code_id, closure_id, _code_opt) ->
         let fun_decl =
           TG.Function_type.create code_id
             ~rec_info:(MTC.unknown Flambda_kind.rec_info)

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -88,8 +88,8 @@ let extract_symbol_approx env symbol find_code =
           | Bottom | Unknown -> Value_unknown
           | Ok function_type ->
             let code_id = Function_type.code_id function_type in
-            let code = find_code code_id in
-            Closure_approximation (code_id, code)
+            let code_or_meta = find_code code_id in
+            Closure_approximation (code_id, code_or_meta)
         end)
       | Variant
           { immediates = Unknown; blocks = _; is_unique = _; alloc_mode = _ }

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -89,7 +89,7 @@ let extract_symbol_approx env symbol find_code =
           | Ok function_type ->
             let code_id = Function_type.code_id function_type in
             let code_or_meta = find_code code_id in
-            Closure_approximation (code_id, code_or_meta)
+            Closure_approximation (code_id, closure_id, code_or_meta)
         end)
       | Variant
           { immediates = Unknown; blocks = _; is_unique = _; alloc_mode = _ }

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -760,5 +760,5 @@ val never_holds_locally_allocated_values :
 val extract_symbol_approx :
   Typing_env.t ->
   Symbol.t ->
-  (Code_id.t -> 'code option) ->
+  (Code_id.t -> 'code) ->
   'code Value_approximation.t


### PR DESCRIPTION
(From #164, [relevant diff](https://github.com/ocaml-flambda/flambda-backend/pull/424/files/8d91aba7390c8c51bf3b8646671850d52ed37d9f..6048793cd64901d075772633a9fb85e2092487ee))

This handles functions applications more closely to what is done in Closure, i.e. extract a full function call from under/over-applications. And applies direct calls when possible.