### PR TITLE
Add missing array kinds

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_conversions.ml
+++ b/middle_end/flambda2/from_lambda/lambda_conversions.ml
@@ -44,7 +44,8 @@ let rec value_kind (vk : L.value_kind) =
     else KS.block (Tag.create_exn tag) (List.map value_kind fields)
   | Parrayval Pfloatarray -> KS.float_array
   | Parrayval Pintarray -> KS.immediate_array
-  | Parrayval (Paddrarray | Pgenarray) -> KS.any_value
+  | Parrayval Paddrarray -> KS.value_array
+  | Parrayval Pgenarray -> KS.generic_array
 
 let inline_attribute (attr : L.inline_attribute) : Inline_attribute.t =
   match attr with

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -631,6 +631,8 @@ module With_subkind = struct
     | Boxed_int64, Any_value
     | Boxed_nativeint, Any_value
     | Tagged_immediate, Any_value
+    (* All specialised array kinds may be used at kind [Generic_array], and
+       [Immediate_array] may be used at kind [Value_array] *)
     | Float_array, Generic_array
     | Immediate_array, Value_array
     | Immediate_array, Generic_array

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -385,6 +385,8 @@ module With_subkind = struct
       | Float_block of { num_fields : int }
       | Float_array
       | Immediate_array
+      | Value_array
+      | Generic_array
 
     include Container_types.Make (struct
       type nonrec t = t
@@ -429,6 +431,14 @@ module With_subkind = struct
           Format.fprintf ppf "@<0>%s=Immediate_array@<0>%s"
             colour
             (Flambda_colours.normal ())
+        | Value_array ->
+          Format.fprintf ppf "@<0>%s=Value_array@<0>%s"
+            colour
+            (Flambda_colours.normal ())
+        | Generic_array ->
+          Format.fprintf ppf "@<0>%s=Generic_array@<0>%s"
+            colour
+            (Flambda_colours.normal ())
 
       let compare = Stdlib.compare
 
@@ -454,7 +464,7 @@ module With_subkind = struct
         | Anything -> ()
         | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
         | Tagged_immediate | Block _ | Float_block _ | Float_array
-        | Immediate_array ->
+        | Immediate_array | Value_array | Generic_array ->
           Misc.fatal_errorf "Only subkind %a is valid for kind %a" Subkind.print
             subkind print kind)
     end;
@@ -492,6 +502,10 @@ module With_subkind = struct
 
   let immediate_array = create value Immediate_array
 
+  let value_array = create value Value_array
+
+  let generic_array = create value Generic_array
+
   let block tag fields =
     if List.exists (fun t -> not (equal t.kind Value)) fields
     then
@@ -523,7 +537,7 @@ module With_subkind = struct
           Subkind.print subkind
       | (Naked_number _ | Fabricated | Rec_info),
         (Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
-          | Tagged_immediate | Block _ | Float_block _ | Float_array | Immediate_array) ->
+          | Tagged_immediate | Block _ | Float_block _ | Float_array | Immediate_array | Value_array | Generic_array) ->
         assert false
     (* see [create] *)
 
@@ -553,6 +567,8 @@ module With_subkind = struct
     | Float_block of { num_fields : int }
     | Float_array
     | Immediate_array
+    | Value_array
+    | Generic_array
 
   let rec subkind_descr (t : Subkind.t) : descr =
     match t with
@@ -567,6 +583,8 @@ module With_subkind = struct
     | Float_block { num_fields } -> Float_block { num_fields }
     | Float_array -> Float_array
     | Immediate_array -> Immediate_array
+    | Value_array -> Value_array
+    | Generic_array -> Generic_array
 
   let descr t : descr =
     match t.kind with
@@ -587,6 +605,8 @@ module With_subkind = struct
     | Tagged_immediate, Tagged_immediate
     | Float_array, Float_array
     | Immediate_array, Immediate_array
+    | Value_array, Value_array
+    | Generic_array, Generic_array
     | Rec_info, Rec_info ->
       true
     | Block { tag = t1; fields = fields1 }, Block { tag = t2; fields = fields2 }
@@ -604,16 +624,23 @@ module With_subkind = struct
     | (Block _ | Float_block _), Any_value
     | Float_array, Any_value
     | Immediate_array, Any_value
+    | Value_array, Any_value
+    | Generic_array, Any_value
     | Boxed_float, Any_value
     | Boxed_int32, Any_value
     | Boxed_int64, Any_value
     | Boxed_nativeint, Any_value
-    | Tagged_immediate, Any_value ->
+    | Tagged_immediate, Any_value
+    | Float_array, Generic_array
+    | Immediate_array, Value_array
+    | Immediate_array, Generic_array
+    | Value_array, Generic_array ->
       true
     (* All other combinations are incompatible. *)
     | ( ( Any_value | Naked_number _ | Boxed_float | Boxed_int32 | Boxed_int64
         | Boxed_nativeint | Tagged_immediate | Block _ | Float_block _
-        | Float_array | Immediate_array | Rec_info ),
+        | Float_array | Immediate_array | Value_array | Generic_array | Rec_info
+          ),
         _ ) ->
       false
 
@@ -625,6 +652,6 @@ module With_subkind = struct
     | Anything -> false
     | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
     | Tagged_immediate | Block _ | Float_block _ | Float_array | Immediate_array
-      ->
+    | Value_array | Generic_array ->
       true
 end

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -191,6 +191,8 @@ module With_subkind : sig
       | Float_block of { num_fields : int }
       | Float_array
       | Immediate_array
+      | Value_array
+      | Generic_array
 
     include Container_types.S with type t := t
   end
@@ -235,6 +237,10 @@ module With_subkind : sig
 
   val immediate_array : t
 
+  val value_array : t
+
+  val generic_array : t
+
   val block : Tag.t -> t list -> t
 
   val float_block : num_fields:int -> t
@@ -257,6 +263,8 @@ module With_subkind : sig
     | Float_block of { num_fields : int }
     | Float_array
     | Immediate_array
+    | Value_array
+    | Generic_array
 
   val descr : t -> descr
 

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -124,6 +124,8 @@ type kind_with_subkind =
   | Rec_info
   | Float_array
   | Immediate_array
+  | Value_array
+  | Generic_array
 
 type static_data_binding =
   { symbol : symbol;

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -263,6 +263,8 @@ let rec value_kind_with_subkind (k : Fexpr.kind_with_subkind) :
   | Rec_info -> KWS.rec_info
   | Float_array -> KWS.float_array
   | Immediate_array -> KWS.immediate_array
+  | Value_array -> KWS.value_array
+  | Generic_array -> KWS.generic_array
 
 let value_kind : Fexpr.kind -> Flambda_kind.t = function
   | Value -> Flambda_kind.value

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -419,6 +419,8 @@ let kind_with_subkind (k : Flambda_kind.With_subkind.t) =
     | Rec_info -> Rec_info
     | Float_array -> Float_array
     | Immediate_array -> Immediate_array
+    | Value_array -> Value_array
+    | Generic_array -> Generic_array
   in
   convert (Flambda_kind.With_subkind.descr k)
 

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -150,6 +150,8 @@ let kind_with_subkind ppf (k : kind_with_subkind) =
   | Rec_info -> str "rec_info"
   | Float_array -> str "float_array"
   | Immediate_array -> str "immediate_array"
+  | Value_array -> str "value_array"
+  | Generic_array -> str "generic_array"
 
 let arity ppf (a : arity) =
   match a with

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -124,6 +124,14 @@ let simplify_make_array dacc dbg (array_kind : P.Array_kind.t)
         (T.array_of_length
            ~element_kind:(Known Flambda_kind.With_subkind.tagged_immediate)
            ~length:T.any_tagged_immediate)
+    | Value_array ->
+      Known
+        (T.array_of_length
+           ~element_kind:(Known Flambda_kind.With_subkind.any_value)
+           ~length:T.any_tagged_immediate)
+    | Generic_array ->
+      Known
+        (T.array_of_length ~element_kind:Unknown ~length:T.any_tagged_immediate)
     | Rec_info -> Misc.fatal_error "Array elements cannot have kind [Rec_info]"
   in
   let typing_env = DA.typing_env dacc in

--- a/middle_end/flambda2/tests/mlexamples/array_kind.ml
+++ b/middle_end/flambda2/tests/mlexamples/array_kind.ml
@@ -1,0 +1,20 @@
+(* Lambda output:
+ * (let (f/261 = (function a/263[addrarray] (array.get[gen] a/263 0)))
+ *   (makeblock 0 f/261))
+ *)
+(* The [gen] annotation on array.get is expected: the [get] function is typed as
+   'a array -> 'a, and it's only during simplification of local functions that
+   its body is brought back into the body of [f], without changing the
+   annotations. Regular inlining would have caused the same situation. *)
+
+(* Expected Cmm output:
+ * (function{tmp/array_kind.ml:1,6-61} camlArray_kind__f_0_1_code (a49/315: val)
+ *  (if (<a 1 (>>u (load_mut int (+a a49/315 -8)) 9)) (load_mut val a49/315)
+ *    (extcall "caml_ml_array_bound_error"{tmp/array_kind.ml:2,14-19} ->.)))
+ *)
+(* The check for the length is of course there, but the check for the float
+   array tag has been removed thanks to the kind info on the argument. *)
+
+let f (a : _ option array) =
+  let get a = a.(0) in
+  get a

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -317,6 +317,11 @@ let rec unknown_with_descr (descr : Flambda_kind.With_subkind.descr) =
     TG.array_of_length
       ~element_kind:(Known Flambda_kind.With_subkind.tagged_immediate)
       ~length:any_tagged_immediate
+  | Value_array ->
+    TG.array_of_length ~element_kind:(Known Flambda_kind.With_subkind.any_value)
+      ~length:any_tagged_immediate
+  | Generic_array ->
+    TG.array_of_length ~element_kind:Unknown ~length:any_tagged_immediate
 
 let unknown_with_subkind kind =
   unknown_with_descr (Flambda_kind.With_subkind.descr kind)


### PR DESCRIPTION
The Lambda kinds `Parrayval Paddrarray` and `Parrayval Pgenarray` didn't have a matching Flambda 2 kind; this PR adds the corresponding kinds.
