### PR TITLE
Print deleted code

### DIFF
--- a/middle_end/flambda2/tests/mlexamples/deleted_code_printing.ml
+++ b/middle_end/flambda2/tests/mlexamples/deleted_code_printing.ml
@@ -1,0 +1,14 @@
+(* This example shows a case where the generated program starts with a sequence
+   of deleted code bindings, then a variable, then the rest of the program. This
+   caused a bug when printing the result if deleted bindings are not printed, as
+   the printer expects all sequences of symbol/code bindings to include at least
+   one printable element. *)
+type t = { mutable foo : int }
+
+let env = { foo = 42 }
+
+external id : 'a -> 'a = "%opaque"
+
+let foobar () =
+  let rec aux () = if id false then env.foo else aux () in
+  aux ()


### PR DESCRIPTION
In addition of addressing a CR, this fixes a bug that @Gbury stumbled upon: if a `Let_symbol` binding only binds deleted code, then an assertion would be triggered when printing the code (`flatten_for_printing` would return an empty list)