### PR TITLE
Improvements to code paths for simplifying primitives (and CSE bug fix)

### DIFF
--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -331,6 +331,20 @@ let mark_parameters_as_toplevel t params =
   in
   { t with variables_defined_at_toplevel }
 
+let define_variable_and_extend_typing_environment t var kind env_extension =
+  (* This is a combined operation to reduce allocation. *)
+  let typing_env =
+    let var' = Bound_name.var var in
+    TE.add_definition t.typing_env var' kind
+  in
+  let variables_defined_at_toplevel =
+    if t.at_unit_toplevel
+    then Variable.Set.add (Bound_var.var var) t.variables_defined_at_toplevel
+    else t.variables_defined_at_toplevel
+  in
+  let typing_env = TE.add_env_extension typing_env env_extension in
+  { t with typing_env; variables_defined_at_toplevel }
+
 let add_variable_and_extend_typing_environment t var ty env_extension =
   (* This is a combined operation to reduce allocation. *)
   let typing_env =

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -119,6 +119,13 @@ val add_parameters_with_unknown_types' :
 
 val mark_parameters_as_toplevel : t -> Bound_parameter.t list -> t
 
+val define_variable_and_extend_typing_environment :
+  t ->
+  Bound_var.t ->
+  Flambda_kind.t ->
+  Flambda2_types.Typing_env_extension.t ->
+  t
+
 val add_variable_and_extend_typing_environment :
   t ->
   Bound_var.t ->

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -259,6 +259,11 @@ let make_new_let_bindings uacc
           { named = defining_expr;
             free_names = free_names_of_defining_expr;
             cost_metrics = cost_metrics_of_defining_expr
+          }
+      | Reachable_try_reify
+          { named = defining_expr;
+            free_names = free_names_of_defining_expr;
+            cost_metrics = cost_metrics_of_defining_expr
           } ->
         let defining_expr = Simplified_named.to_named defining_expr in
         let expr, uacc, creation_result =

--- a/middle_end/flambda2/simplify/lifting/reification.mli
+++ b/middle_end/flambda2/simplify/lifting/reification.mli
@@ -24,4 +24,4 @@ val try_to_reify :
   bound_to:Bound_var.t ->
   kind_of_bound_to:Flambda_kind.t ->
   allow_lifting:bool ->
-  Simplified_named.t * Downwards_acc.t * Flambda2_types.t
+  Simplified_named.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplified_named.mli
+++ b/middle_end/flambda2/simplify/simplified_named.mli
@@ -34,18 +34,24 @@ type t = private
         cost_metrics : Cost_metrics.t;
         free_names : Name_occurrences.t
       }
+  | Reachable_try_reify of
+      { named : simplified_named;
+        cost_metrics : Cost_metrics.t;
+        free_names : Name_occurrences.t
+      }
   | Invalid of Invalid_term_semantics.t
 
 (** It is an error to pass [Set_of_closures] or [Static_consts] to this
     function. (Sets of closures are disallowed because computation of their free
     names might be expensive; use [reachable_with_known_free_names] instead.) *)
-val reachable : Named.t -> t
+val reachable : Named.t -> try_reify:bool -> t
 
 (** It is an error to pass [Static_consts] to this function. *)
 val reachable_with_known_free_names :
   find_code_characteristics:(Code_id.t -> Cost_metrics.code_characteristics) ->
   Named.t ->
   free_names:Name_occurrences.t ->
+  try_reify:bool ->
   t
 
 val invalid : unit -> t

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -48,7 +48,8 @@ let inline_linearly_used_continuation uacc ~create_apply_cont ~params ~handler
           in
           let named = Named.create_simple arg in
           { Simplify_named_result.let_bound;
-            simplified_defining_expr = Simplified_named.reachable named;
+            simplified_defining_expr =
+              Simplified_named.reachable named ~try_reify:false;
             original_defining_expr = Some named
           })
     in

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1221,10 +1221,6 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
         let named = Named.create_prim prim dbg in
         let ty = T.unknown (P.result_kind' prim) in
         let dacc = DA.add_variable dacc result_var ty in
-        let dacc =
-          record_any_symbol_projection_for_block_load dacc ~result_var
-            ~block:arg1 ~index:arg2
-        in
         Simplified_named.reachable named ~try_reify:false, dacc
     | String_or_bigstring_load _ | Bigarray_load _ ->
       fun dacc ~original_term:_ dbg ~arg1 ~arg1_ty:_ ~arg2 ~arg2_ty:_

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.mli
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.mli
@@ -20,6 +20,7 @@
 
 val simplify_binary_primitive :
   Downwards_acc.t ->
+  Flambda_primitive.t ->
   Flambda_primitive.binary_primitive ->
   arg1:Simple.t ->
   arg1_ty:Flambda2_types.t ->
@@ -27,7 +28,4 @@ val simplify_binary_primitive :
   arg2_ty:Flambda2_types.t ->
   Debuginfo.t ->
   result_var:Bound_var.t ->
-  Simplified_named.t
-  * Flambda2_types.Typing_env_extension.t
-  * Simple.t list
-  * Downwards_acc.t
+  Simplified_named.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -87,7 +87,9 @@ let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var
     ~result_kind =
   let env = DA.typing_env dacc in
   match T.meet_shape env deconstructing ~shape ~result_var ~result_kind with
-  | Bottom -> Simplified_named.invalid (), dacc
+  | Bottom ->
+    let dacc = DA.add_variable dacc result_var (T.unknown result_kind) in
+    Simplified_named.invalid (), dacc
   | Ok env_extension ->
     let dacc =
       DA.map_denv dacc ~f:(fun denv ->

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -88,7 +88,7 @@ let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var
   let env = DA.typing_env dacc in
   match T.meet_shape env deconstructing ~shape ~result_var ~result_kind with
   | Bottom ->
-    let dacc = DA.add_variable dacc result_var (T.unknown result_kind) in
+    let dacc = DA.add_variable dacc result_var (T.bottom result_kind) in
     Simplified_named.invalid (), dacc
   | Ok env_extension ->
     let dacc =

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -23,7 +23,6 @@ module K = Flambda_kind
 module BP = Bound_parameter
 module P = Flambda_primitive
 module T = Flambda2_types
-module TEE = T.Typing_env_extension
 module UA = Upwards_acc
 module UE = Upwards_env
 module AC = Apply_cont_expr
@@ -88,9 +87,14 @@ let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var
     ~result_kind =
   let env = DA.typing_env dacc in
   match T.meet_shape env deconstructing ~shape ~result_var ~result_kind with
-  | Bottom -> Simplified_named.invalid (), TEE.empty, dacc
+  | Bottom -> Simplified_named.invalid (), dacc
   | Ok env_extension ->
-    Simplified_named.reachable original_term, env_extension, dacc
+    let dacc =
+      DA.map_denv dacc ~f:(fun denv ->
+          DE.define_variable_and_extend_typing_environment denv result_var
+            result_kind env_extension)
+    in
+    Simplified_named.reachable original_term ~try_reify:true, dacc
 
 let update_exn_continuation_extra_args uacc ~exn_cont_use_id apply =
   let exn_cont_rewrite =

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -52,7 +52,7 @@ val simplify_projection :
   shape:Flambda2_types.t ->
   result_var:Bound_var.t ->
   result_kind:Flambda_kind.t ->
-  Simplified_named.t * Flambda2_types.Typing_env_extension.t * Downwards_acc.t
+  Simplified_named.t * Downwards_acc.t
 
 val update_exn_continuation_extra_args :
   Upwards_acc.t ->

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -211,7 +211,9 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
           let let_bound = Bound_pattern.singleton var in
           let prim = Flambda_primitive.(Nullary (Optimised_out k)) in
           let named = Named.create_prim prim Debuginfo.none in
-          let simplified_defining_expr = Simplified_named.reachable named in
+          let simplified_defining_expr =
+            Simplified_named.reachable named ~try_reify:false
+          in
           { Simplify_named_result.let_bound;
             simplified_defining_expr;
             original_defining_expr = Some named

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -227,6 +227,8 @@ let simplify_let0 ~simplify_expr ~simplify_toplevel dacc let_expr ~down_to_up
      defining expression and the [body]. *)
   let dacc, prior_lifted_constants = DA.get_and_clear_lifted_constants dacc in
   (* Simplify the defining expression. *)
+  (* CR mshinwell/vlaviron: We shouldn't need to continue simplifying the body
+     if [Simplify_named] returns [Invalid]. *)
   let simplify_named_result, removed_operations =
     Simplify_named.simplify_named dacc bound_pattern (L.defining_expr let_expr)
       ~simplify_toplevel

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -184,7 +184,8 @@ let record_new_defining_expression_binding_for_data_flow dacc data_flow
     (binding : Simplify_named_result.binding_to_place) =
   match binding.simplified_defining_expr with
   | Invalid _ -> data_flow
-  | Reachable { free_names; named; cost_metrics = _ } ->
+  | Reachable { free_names; named; cost_metrics = _ }
+  | Reachable_try_reify { free_names; named; cost_metrics = _ } ->
     let can_be_removed =
       match named with
       | Simple _ | Set_of_closures _ | Rec_info _ -> true

--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -90,6 +90,11 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
     let simplified_named, dacc =
       Simplify_primitive.simplify_primitive dacc prim dbg ~result_var:bound_var
     in
+    if Flambda_features.check_invariants ()
+       && not (TE.mem (DA.typing_env dacc) (Name.var (Bound_var.var bound_var)))
+    then
+      Misc.fatal_errorf "Primitive %a = %a did not yield a result var"
+        Bound_var.print bound_var P.print prim;
     match simplified_named with
     | Reachable_try_reify _ ->
       let kind = P.result_kind' prim in

--- a/middle_end/flambda2/simplify/simplify_named_result.ml
+++ b/middle_end/flambda2/simplify/simplify_named_result.ml
@@ -74,7 +74,7 @@ let bindings_to_place_in_any_order t =
         let let_bound = Bound_pattern.singleton bound_var in
         let simplified_defining_expr =
           Simple.symbol symbol |> Flambda.Named.create_simple
-          |> Simplified_named.reachable
+          |> Simplified_named.reachable ~try_reify:false
         in
         { let_bound; simplified_defining_expr; original_defining_expr = None }
         :: bindings)

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -17,8 +17,8 @@
 
 open! Simplify_import
 
-let simplify_nullary_primitive dacc (prim : P.nullary_primitive) dbg ~result_var
-    =
+let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
+    dbg ~result_var =
   match prim with
   | Optimised_out result_kind ->
     begin
@@ -29,14 +29,12 @@ let simplify_nullary_primitive dacc (prim : P.nullary_primitive) dbg ~result_var
           "The 'optimised_out' primitive should only be used in bindings of \
            phantom variables"
     end;
-    let named = Named.create_prim (Nullary prim) dbg in
+    let named = Named.create_prim original_prim dbg in
     let ty = T.unknown result_kind in
-    let var = Name.var (Bound_var.var result_var) in
-    let env_extension = TEE.one_equation var ty in
-    Simplified_named.reachable named, env_extension, [], dacc
+    let dacc = DA.add_variable dacc result_var ty in
+    Simplified_named.reachable named ~try_reify:false, dacc
   | Probe_is_enabled { name = _ } ->
-    let named = Named.create_prim (Nullary prim) dbg in
+    let named = Named.create_prim original_prim dbg in
     let ty = T.any_naked_bool in
-    let var = Name.var (Bound_var.var result_var) in
-    let env_extension = TEE.one_equation var ty in
-    Simplified_named.reachable named, env_extension, [], dacc
+    let dacc = DA.add_variable dacc result_var ty in
+    Simplified_named.reachable named ~try_reify:false, dacc

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.mli
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.mli
@@ -19,10 +19,8 @@
 
 val simplify_nullary_primitive :
   Downwards_acc.t ->
+  Flambda_primitive.t ->
   Flambda_primitive.nullary_primitive ->
   Debuginfo.t ->
   result_var:Bound_var.t ->
-  Simplified_named.t
-  * Flambda2_types.Typing_env_extension.t
-  * Simple.t list
-  * Downwards_acc.t
+  Simplified_named.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplify_primitive.mli
+++ b/middle_end/flambda2/simplify/simplify_primitive.mli
@@ -23,7 +23,4 @@ val simplify_primitive :
   Flambda_primitive.t ->
   Debuginfo.t ->
   result_var:Bound_var.t ->
-  Simplified_named.t
-  * Flambda2_types.Typing_env_extension.t
-  * Simple.t list
-  * Downwards_acc.t
+  Simplified_named.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -946,7 +946,7 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
     in
     Simplified_named.reachable_with_known_free_names ~find_code_characteristics
       (Named.create_set_of_closures set_of_closures)
-      ~free_names:(Named.free_names named)
+      ~free_names:(Named.free_names named) ~try_reify:false
   in
   Simplify_named_result.have_simplified_to_single_term dacc bound_vars
     defining_expr

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -18,8 +18,8 @@
 
 open! Simplify_import
 
-let simplify_array_set (array_kind : P.Array_kind.t) init_or_assign dacc dbg
-    ~arg1 ~arg1_ty:array_ty ~arg2 ~arg2_ty:_ ~arg3 ~arg3_ty:_ ~result_var =
+let simplify_array_set original_prim (array_kind : P.Array_kind.t) dacc dbg
+    ~array_ty ~result_var =
   let elt_kind = P.Array_kind.element_kind array_kind |> K.With_subkind.kind in
   let array_kind =
     Simplify_common.specialise_array_kind dacc array_kind ~array_ty
@@ -35,20 +35,17 @@ let simplify_array_set (array_kind : P.Array_kind.t) init_or_assign dacc dbg
       P.Array_kind.element_kind array_kind |> K.With_subkind.kind
     in
     assert (K.equal elt_kind elt_kind');
-    let prim : P.t =
-      Ternary (Array_set (array_kind, init_or_assign), arg1, arg2, arg3)
-    in
-    let named = Named.create_prim prim dbg in
-    let ty = T.unknown (P.result_kind' prim) in
+    let named = Named.create_prim original_prim dbg in
+    let ty = T.unknown (P.result_kind' original_prim) in
     let dacc = DA.add_variable dacc result_var ty in
     Simplified_named.reachable named ~try_reify:false, dacc
 
-let simplify_ternary_primitive dacc _original_prim (prim : P.ternary_primitive)
-    ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty dbg ~result_var =
+let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
+    ~arg1 ~arg1_ty ~arg2 ~arg2_ty:_ ~arg3 ~arg3_ty:_ dbg ~result_var =
   match prim with
-  | Array_set (array_kind, init_or_assign) ->
-    simplify_array_set array_kind init_or_assign dacc dbg ~arg1 ~arg1_ty ~arg2
-      ~arg2_ty ~arg3 ~arg3_ty ~result_var
+  | Array_set (array_kind, _init_or_assign) ->
+    simplify_array_set original_prim array_kind dacc dbg ~array_ty:arg1_ty
+      ~result_var
   | Block_set _ | Bytes_or_bigstring_set _ | Bigarray_set _ ->
     let prim : P.t = Ternary (prim, arg1, arg2, arg3) in
     let named = Named.create_prim prim dbg in

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.mli
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.mli
@@ -20,6 +20,7 @@
 
 val simplify_ternary_primitive :
   Downwards_acc.t ->
+  Flambda_primitive.t ->
   Flambda_primitive.ternary_primitive ->
   arg1:Simple.t ->
   arg1_ty:Flambda2_types.t ->
@@ -29,7 +30,4 @@ val simplify_ternary_primitive :
   arg3_ty:Flambda2_types.t ->
   Debuginfo.t ->
   result_var:Bound_var.t ->
-  Simplified_named.t
-  * Flambda2_types.Typing_env_extension.t
-  * Simple.t list
-  * Downwards_acc.t
+  Simplified_named.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.mli
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.mli
@@ -20,12 +20,10 @@
 
 val simplify_unary_primitive :
   Downwards_acc.t ->
+  Flambda_primitive.t ->
   Flambda_primitive.unary_primitive ->
   arg:Simple.t ->
   arg_ty:Flambda2_types.t ->
   Debuginfo.t ->
   result_var:Bound_var.t ->
-  Simplified_named.t
-  * Flambda2_types.Typing_env_extension.t
-  * Simple.t list
-  * Downwards_acc.t
+  Simplified_named.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.mli
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.mli
@@ -20,11 +20,9 @@
 
 val simplify_variadic_primitive :
   Downwards_acc.t ->
+  Flambda_primitive.t ->
   Flambda_primitive.variadic_primitive ->
   args_with_tys:(Simple.t * Flambda2_types.t) list ->
   Debuginfo.t ->
   result_var:Bound_var.t ->
-  Simplified_named.t
-  * Flambda2_types.Typing_env_extension.t
-  * Simple.t list
-  * Downwards_acc.t
+  Simplified_named.t * Downwards_acc.t

--- a/middle_end/flambda2/tests/mlexamples/cse_needing_canonicalisation.ml
+++ b/middle_end/flambda2/tests/mlexamples/cse_needing_canonicalisation.ml
@@ -1,0 +1,6 @@
+let f x y =
+  let a = x + y in
+  let p = x, y in
+  let x' = fst p in
+  let b = x' + y in
+  a, b


### PR DESCRIPTION
This patch aims to reduce allocation and unnecessary work on the code paths for simplifying primitives:
- excess lists in `Simplify_primitive` are no longer constructed
- construction of many env-extensions is avoided, in favour of adding directly to `dacc`
- the code dealing with symbol projections is now invoked explicitly in the two places where it applies rather than everywhere
- reification is only undertaken where it might be of value.

There is also a bug fix: prior to this patch, the arguments of primitives were not being canonicalised before the CSE equation map was checked.  The test case added in this PR provides an example of when this is needed.

Rebasing this patch across the array specialisation patch was tricky, so there may be some minor things to fix up.