### PR TITLE
Do not simplify Let bodies whose defining expression simplifies to Invalid

### DIFF
--- a/middle_end/flambda2/simplify/simplify_named_result.ml
+++ b/middle_end/flambda2/simplify/simplify_named_result.ml
@@ -79,3 +79,9 @@ let bindings_to_place_in_any_order t =
         { let_bound; simplified_defining_expr; original_defining_expr = None }
         :: bindings)
       bound_vars_to_symbols []
+
+let is_invalid t =
+  match t.descr with
+  | Zero_terms | Multiple_bindings_to_symbols _ -> false
+  | Single_term { simplified_defining_expr; _ } ->
+    Simplified_named.is_invalid simplified_defining_expr

--- a/middle_end/flambda2/simplify/simplify_named_result.mli
+++ b/middle_end/flambda2/simplify/simplify_named_result.mli
@@ -52,3 +52,5 @@ type binding_to_place =
 val bindings_to_place_in_any_order : t -> binding_to_place list
 
 val with_dacc : dacc:Downwards_acc.t -> t -> t
+
+val is_invalid : t -> bool


### PR DESCRIPTION
As per suggestion by @lthls .  The diff looks bad in Github but is very simple really.