### PR TITLE
Cut down Typing_env_level interface

### DIFF
--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -31,7 +31,11 @@ module One_level = struct
 
   let [@ocamlformat "disable"] print ~min_binding_time ppf
         { scope = _; level; just_after_level; } =
-    let restrict_to = TEL.defined_names level in
+    let restrict_to =
+      TEL.fold_on_defined_vars (fun var _bt _kind restrict_to ->
+          Name.Set.add (Name.var var) restrict_to)
+        level Name.Set.empty
+    in
     if Name.Set.is_empty restrict_to then
       Format.fprintf ppf "@[<hov 0>\
           %a\
@@ -983,7 +987,8 @@ let add_env_extension_with_extra_variables t env_extension =
 let add_env_extension_from_level t level ~meet_type : t =
   let t =
     TEL.fold_on_defined_vars
-      (fun var kind t -> add_variable_definition t var kind Name_mode.in_types)
+      (fun var _bt kind t ->
+        add_variable_definition t var kind Name_mode.in_types)
       level t
   in
   let t =

--- a/middle_end/flambda2/types/env/typing_env_level.mli
+++ b/middle_end/flambda2/types/env/typing_env_level.mli
@@ -33,12 +33,6 @@ val create :
   symbol_projections:Symbol_projection.t Variable.Map.t ->
   t
 
-val defined_variables : t -> Variable.Set.t
-
-val defined_variables_with_kinds : t -> Flambda_kind.t Variable.Map.t
-
-val defined_names : t -> Name.Set.t
-
 val equations : t -> Type_grammar.t Name.Map.t
 
 val symbol_projections : t -> Symbol_projection.t Variable.Map.t
@@ -55,9 +49,5 @@ val all_ids_for_export : t -> Ids_for_export.t
 
 val find_kind : t -> Variable.t -> Flambda_kind.t
 
-val variables_by_binding_time : t -> Variable.Set.t Binding_time.Map.t
-
-val variable_is_defined : t -> Variable.t -> bool
-
 val fold_on_defined_vars :
-  (Variable.t -> Flambda_kind.t -> 'a -> 'a) -> t -> 'a -> 'a
+  (Variable.t -> Binding_time.t -> Flambda_kind.t -> 'a -> 'a) -> t -> 'a -> 'a

--- a/middle_end/flambda2/types/join_levels.ml
+++ b/middle_end/flambda2/types/join_levels.ml
@@ -38,20 +38,16 @@ let join_types ~env_at_fork envs_with_levels =
     List.fold_left
       (fun base_env (env_at_use, _, _, level) ->
         let base_env =
-          Binding_time.Map.fold
-            (fun _ vars base_env ->
-              Variable.Set.fold
-                (fun var base_env ->
-                  if TE.mem base_env (Name.var var)
-                  then base_env
-                  else
-                    let kind = TEL.find_kind level var in
-                    TE.add_definition base_env
-                      (Bound_name.var (Bound_var.create var Name_mode.in_types))
-                      kind)
-                vars base_env)
-            (TEL.variables_by_binding_time level)
-            base_env
+          TEL.fold_on_defined_vars
+            (fun var _bt _kind base_env ->
+              if TE.mem base_env (Name.var var)
+              then base_env
+              else
+                let kind = TEL.find_kind level var in
+                TE.add_definition base_env
+                  (Bound_name.var (Bound_var.create var Name_mode.in_types))
+                  kind)
+            level base_env
         in
         let code_age_relation =
           Code_age_relation.union
@@ -160,9 +156,12 @@ let construct_joined_level envs_with_levels ~env_at_fork ~allowed ~joined_types
     List.fold_left
       (fun (defined_vars, binding_times) (_env_at_use, _id, _use_kind, t) ->
         let defined_vars_this_level =
-          Variable.Map.filter
-            (fun var _ -> Name_occurrences.mem_var allowed var)
-            (TEL.defined_variables_with_kinds t)
+          TEL.fold_on_defined_vars
+            (fun var _bt kind defined_vars_this_level ->
+              if Name_occurrences.mem_var allowed var
+              then Variable.Map.add var kind defined_vars_this_level
+              else defined_vars_this_level)
+            t Variable.Map.empty
         in
         let defined_vars =
           Variable.Map.union
@@ -177,15 +176,23 @@ let construct_joined_level envs_with_levels ~env_at_fork ~allowed ~joined_types
             defined_vars defined_vars_this_level
         in
         let binding_times_this_level =
-          Binding_time.Map.filter_map
-            (fun _ vars ->
-              let vars =
-                Variable.Set.filter
-                  (fun var -> Name_occurrences.mem_var allowed var)
-                  vars
-              in
-              if Variable.Set.is_empty vars then None else Some vars)
-            (TEL.variables_by_binding_time t)
+          TEL.fold_on_defined_vars
+            (fun var binding_time _kind binding_times_this_level ->
+              if not (Name_occurrences.mem_var allowed var)
+              then binding_times_this_level
+              else
+                match
+                  Binding_time.Map.find binding_time binding_times_this_level
+                with
+                | exception Not_found ->
+                  Binding_time.Map.add binding_time
+                    (Variable.Set.singleton var)
+                    binding_times_this_level
+                | vars ->
+                  Binding_time.Map.add (* replace *) binding_time
+                    (Variable.Set.add var vars)
+                    binding_times_this_level)
+            t Binding_time.Map.empty
         in
         let binding_times =
           Binding_time.Map.union


### PR DESCRIPTION
What I was originally trying to do here is to use a different data structure for `Typing_env_level` but didn't succeed in doing so.  However I think cutting down the interface is still a good idea, as it makes it easier to experiment with the implementation.