### PR TITLE
Lift symbol uses from block loads using approximations

### DIFF
--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -20,16 +20,18 @@
 
 type 'code t =
   | Value_unknown
+  | Value_symbol of Symbol.t
   | Closure_approximation of Code_id.t * Closure_id.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 
 let is_unknown = function
   | Value_unknown -> true
-  | Closure_approximation _ | Block_approximation _ -> false
+  | Value_symbol _ | Closure_approximation _ | Block_approximation _ -> false
 
 let rec free_names ~code_free_names approx =
   match approx with
   | Value_unknown -> Name_occurrences.empty
+  | Value_symbol sym -> Name_occurrences.singleton_symbol sym Name_mode.normal
   | Block_approximation (approxs, _) ->
     Array.fold_left
       (fun names approx ->

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -20,6 +20,7 @@
 
 type 'code t =
   | Value_unknown
+  | Value_symbol of Symbol.t
   | Closure_approximation of Code_id.t * Closure_id.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -299,6 +299,7 @@ module Inlining = struct
     let apply_return_continuation = Apply.continuation apply in
     let apply_exn_continuation = Apply.exn_continuation apply in
     let params_and_body = Code.params_and_body code in
+    let cost_metrics = Code.cost_metrics code in
     Function_params_and_body.pattern_match params_and_body
       ~f:(fun
            ~return_continuation
@@ -323,6 +324,7 @@ module Inlining = struct
             ~apply_depth
         in
         let acc = Acc.with_free_names Name_occurrences.empty acc in
+        let acc = Acc.increment_metrics cost_metrics acc in
         match Exn_continuation.extra_args apply_exn_continuation with
         | [] ->
           make_inlined_body acc

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -329,25 +329,12 @@ module Env = struct
     else
       add_value_approximation t name (Block_approximation (approxs, alloc_mode))
 
-  let value_approximation t simple =
-    Simple.pattern_match' simple
-      ~const:(fun _ -> Value_approximation.Value_unknown)
-      ~var:(fun var ~coercion:_ ->
-        try Name.Map.find (Name.var var) t.value_approximations
-        with Not_found -> Value_approximation.Value_unknown)
-      ~symbol:(fun symbol ~coercion:_ ->
-        Value_approximation.Value_symbol symbol)
-
   let find_value_approximation t simple =
     Simple.pattern_match simple
       ~const:(fun _ -> Value_approximation.Value_unknown)
       ~name:(fun name ~coercion:_ ->
-        match Name.Map.find name t.value_approximations with
-        | Value_symbol symbol -> t.approximation_for_external_symbol symbol
-        | (Value_unknown | Block_approximation _ | Closure_approximation _) as
-          approx ->
-          approx
-        | exception Not_found ->
+        try Name.Map.find name t.value_approximations
+        with Not_found ->
           Name.pattern_match name
             ~var:(fun _ -> Value_approximation.Value_unknown)
             ~symbol:t.approximation_for_external_symbol)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -694,13 +694,6 @@ module Expr_with_acc = struct
     let acc = Acc.add_free_names (Apply_expr.free_names apply) acc in
     acc, Expr.create_apply apply
 
-  let create_let (acc, let_expr) =
-    (* The signature for create_let is a bit different. It is mainly used to
-       materialize expressions coming from Let_cont_with_acc where the cost
-       metrics were already computed. The signature is such that results from
-       Let_cont_with_acc can be directly piped through [create_let].*)
-    acc, Expr.create_let let_expr
-
   let create_switch acc switch =
     let acc =
       Acc.increment_metrics
@@ -730,39 +723,53 @@ end
 
 module Let_with_acc = struct
   let create acc let_bound named ~body =
-    let cost_metrics_of_defining_expr =
+    let is_unused_singleton =
+      match Bound_pattern.must_be_singleton_opt let_bound with
+      | Some var ->
+        not (Name_occurrences.mem_var (Acc.free_names acc) (Bound_var.var var))
+      | None -> false
+    in
+    let has_no_effects =
       match (named : Named.t) with
-      | Prim (prim, _) -> Code_size.prim prim |> Cost_metrics.from_size
-      | Simple simple -> Code_size.simple simple |> Cost_metrics.from_size
-      | Static_consts _consts -> Cost_metrics.zero
-      | Set_of_closures set_of_closures ->
-        let code_mapping = Acc.code acc in
-        Cost_metrics.set_of_closures
-          ~find_code_characteristics:(fun code_id ->
-            let code = Code_id.Map.find code_id code_mapping in
-            { cost_metrics = Code.cost_metrics code;
-              params_arity = List.length (Code.params_arity code)
-            })
-          set_of_closures
-      | Rec_info _ -> Cost_metrics.zero
+      | Prim (prim, _) -> Flambda_primitive.no_effects_or_coeffects prim
+      | Simple _ | Static_consts _ | Set_of_closures _ | Rec_info _ -> true
     in
-    let acc =
-      Acc.increment_metrics
-        (Cost_metrics.increase_due_to_let_expr ~is_phantom:false
-           ~cost_metrics_of_defining_expr)
-        acc
-    in
-    let free_names_of_body = Or_unknown.Known (Acc.free_names acc) in
-    let acc =
-      Bound_pattern.fold_all_bound_names let_bound ~init:acc
-        ~var:(fun acc var ->
-          Acc.remove_var_from_free_names (Bound_var.var var) acc)
-        ~symbol:(fun acc s -> Acc.remove_symbol_from_free_names s acc)
-        ~code_id:(fun acc cid -> Acc.remove_code_id_from_free_names cid acc)
-    in
-    let expr = Let.create let_bound named ~body ~free_names_of_body in
-    let acc = Acc.add_free_names (Named.free_names named) acc in
-    acc, expr
+    if is_unused_singleton && has_no_effects
+    then acc, body
+    else
+      let cost_metrics_of_defining_expr =
+        match (named : Named.t) with
+        | Prim (prim, _) -> Code_size.prim prim |> Cost_metrics.from_size
+        | Simple simple -> Code_size.simple simple |> Cost_metrics.from_size
+        | Static_consts _consts -> Cost_metrics.zero
+        | Set_of_closures set_of_closures ->
+          let code_mapping = Acc.code acc in
+          Cost_metrics.set_of_closures
+            ~find_code_characteristics:(fun code_id ->
+              let code = Code_id.Map.find code_id code_mapping in
+              { cost_metrics = Code.cost_metrics code;
+                params_arity = List.length (Code.params_arity code)
+              })
+            set_of_closures
+        | Rec_info _ -> Cost_metrics.zero
+      in
+      let acc =
+        Acc.increment_metrics
+          (Cost_metrics.increase_due_to_let_expr ~is_phantom:false
+             ~cost_metrics_of_defining_expr)
+          acc
+      in
+      let free_names_of_body = Or_unknown.Known (Acc.free_names acc) in
+      let acc =
+        Bound_pattern.fold_all_bound_names let_bound ~init:acc
+          ~var:(fun acc var ->
+            Acc.remove_var_from_free_names (Bound_var.var var) acc)
+          ~symbol:(fun acc s -> Acc.remove_symbol_from_free_names s acc)
+          ~code_id:(fun acc cid -> Acc.remove_code_id_from_free_names cid acc)
+      in
+      let let_expr = Let.create let_bound named ~body ~free_names_of_body in
+      let acc = Acc.add_free_names (Named.free_names named) acc in
+      acc, Expr.create_let let_expr
 end
 
 module Continuation_handler_with_acc = struct

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -731,7 +731,7 @@ module Let_with_acc = struct
     in
     let has_no_effects =
       match (named : Named.t) with
-      | Prim (prim, _) -> Flambda_primitive.no_effects_or_coeffects prim
+      | Prim (prim, _) -> Flambda_primitive.at_most_generative_effects prim
       | Simple _ | Static_consts _ | Set_of_closures _ | Rec_info _ -> true
     in
     if is_unused_singleton && has_no_effects

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -146,6 +146,8 @@ module Env : sig
 
   val add_approximation_alias : t -> Name.t -> Name.t -> t
 
+  val value_approximation : t -> Simple.t -> value_approximation
+
   val find_value_approximation : t -> Simple.t -> value_approximation
 
   val current_depth : t -> Variable.t option

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -146,8 +146,6 @@ module Env : sig
 
   val add_approximation_alias : t -> Name.t -> Name.t -> t
 
-  val value_approximation : t -> Simple.t -> value_approximation
-
   val find_value_approximation : t -> Simple.t -> value_approximation
 
   val current_depth : t -> Variable.t option

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -336,8 +336,6 @@ module Expr_with_acc : sig
 
   val create_apply : Acc.t -> Apply.t -> Acc.t * t
 
-  val create_let : Acc.t * Let.t -> Acc.t * t
-
   val create_switch : Acc.t -> Switch.t -> Acc.t * t
 
   val create_invalid : Acc.t -> Flambda.Invalid.t -> Acc.t * t
@@ -358,7 +356,11 @@ end
 
 module Let_with_acc : sig
   val create :
-    Acc.t -> Bound_pattern.t -> Named.t -> body:Expr_with_acc.t -> Acc.t * Let.t
+    Acc.t ->
+    Bound_pattern.t ->
+    Named.t ->
+    body:Expr_with_acc.t ->
+    Acc.t * Expr_with_acc.t
 end
 
 module Let_cont_with_acc : sig

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -114,7 +114,6 @@ let raise_exn_for_failure acc ~dbg exn_cont exn_bucket extra_let_binding =
     Let_with_acc.create acc
       (Bound_pattern.singleton bound_var)
       defining_expr ~body:apply_cont
-    |> Expr_with_acc.create_let
 
 let expression_for_failure acc env exn_cont ~register_const_string primitive dbg
     (failure : failure) =
@@ -319,7 +318,6 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
       Let_with_acc.create acc
         (Bound_pattern.singleton cond_result_pat)
         cond ~body:switch
-      |> Expr_with_acc.create_let
     in
     let join_handler_expr acc =
       cont acc (Named.create_simple (Simple.var result_var))
@@ -335,7 +333,6 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
       Let_with_acc.create acc
         (Bound_pattern.singleton ifso_result_pat)
         ifso ~body
-      |> Expr_with_acc.create_let
     in
     let ifnot_handler_expr acc =
       bind_rec acc env exn_cont ~register_const_string ifnot dbg
@@ -348,7 +345,6 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
       Let_with_acc.create acc
         (Bound_pattern.singleton ifnot_result_pat)
         ifnot ~body
-      |> Expr_with_acc.create_let
     in
     let body acc =
       Let_cont_with_acc.build_non_recursive acc ifnot_cont ~handler_params:[]
@@ -375,6 +371,5 @@ and bind_rec_primitive acc env exn_cont ~register_const_string
     let cont acc (named : Named.t) =
       let acc, body = cont acc (Simple.var var) in
       Let_with_acc.create acc (Bound_pattern.singleton var') named ~body
-      |> Expr_with_acc.create_let
     in
     bind_rec acc env exn_cont ~register_const_string p dbg cont

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1270,6 +1270,8 @@ end = struct
     let rec type_from_approx approx =
       match (approx : _ Value_approximation.t) with
       | Value_unknown -> MTC.unknown Flambda_kind.value
+      | Value_symbol symbol ->
+        TG.alias_type_of Flambda_kind.value (Simple.symbol symbol)
       | Block_approximation (fields, alloc_mode) ->
         let fields = List.map type_from_approx (Array.to_list fields) in
         MTC.immutable_block ~is_unique:false Tag.zero


### PR DESCRIPTION
(From #424, [relevant diff](https://github.com/ocaml-flambda/flambda-backend/pull/439/files/57c64d377e92c367add1488d1d65df00ec873c1f..890fa0b8b5bb4c050be3de493bf7f2441ff8f6a4).)