### PR TITLE
Fix to allow stage 2 builds in classic mode

### DIFF
--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -143,7 +143,7 @@
 
 (rule
   (targets runtime_native.ml)
-  (action (write-file %{targets} "let linkme = ()")))
+  (action (write-file %{targets} "")))
 
 (install
   (files


### PR DESCRIPTION
This avoids dynamic allocations in `runtime_native.cmxs` that upset the linker. 