### PR TITLE
Closure conversion: Lift empty arrays as arrays, not blocks

### DIFF
--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -156,6 +156,11 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
         fields,
       dacc )
   | Empty_array ->
+    let dacc =
+      bind_result_sym
+        (T.array_of_length ~element_kind:Unknown
+           ~length:(T.this_tagged_immediate Targetint_31_63.zero))
+    in
     Rebuilt_static_const.create_empty_array (DA.are_rebuilding_terms dacc), dacc
   | Mutable_string { initial_value } ->
     let str_ty = T.mutable_string ~size:(String.length initial_value) in

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -156,6 +156,15 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
         fields,
       dacc )
   | Empty_array ->
+    (* CR-someday lmaurer: Comment from lthls:
+
+       "Given that no element can be read from it (or stored in it), any kind
+       would work, but if we introduce a specific Invalid kind for these empty
+       arrays we might even be able to delete all the code that tries to read
+       from or write to a known empty array (although one would hope that the
+       bounds check would already be proved to always fail). [...] That might be
+       also useful for preserving the array kind during a join between a
+       specialised non-empty array and the empty array." *)
     let dacc =
       bind_result_sym
         (T.array_of_length ~element_kind:Unknown


### PR DESCRIPTION
Also fixes handling empty arrays as input in `Simplify_static_const`.