### PR TITLE
Improvements to canonical simples / expand_head during meet etc

### DIFF
--- a/middle_end/flambda2/types/expand_head.mli
+++ b/middle_end/flambda2/types/expand_head.mli
@@ -80,12 +80,11 @@ end
 
 val expand_head : Typing_env.t -> Type_grammar.t -> Expanded_type.t
 
-val get_canonical_simples_and_expand_heads :
-  left_env:Typing_env.t ->
-  left_ty:Type_grammar.t ->
-  right_env:Typing_env.t ->
-  right_ty:Type_grammar.t ->
-  Simple.t option * Expanded_type.t * Simple.t option * Expanded_type.t
+val expand_head0 :
+  Typing_env.t ->
+  Type_grammar.t ->
+  known_canonical_simple_at_in_types_mode:Simple.t option ->
+  Expanded_type.t
 
 val is_bottom : Typing_env.t -> Type_grammar.t -> bool
 


### PR DESCRIPTION
This stops canonical simples being looked up twice during meet.  It used to be happening both in `Expand_head.get_canonical_simples_and_expand_heads` and `Expand_head.expand_head0`.

This also stops heads being expanded at all in the (presumably quite common?) case where both sides of a meet are an alias type naming the same canonical simple.