### PR TITLE
Improve speed of reification etc.

### DIFF
--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -301,6 +301,7 @@ let make_new_let_bindings uacc
           }
       | Reachable_try_reify
           { named = defining_expr;
+            ty = _;
             free_names = free_names_of_defining_expr;
             cost_metrics = cost_metrics_of_defining_expr
           } ->

--- a/middle_end/flambda2/simplify/lifting/reification.mli
+++ b/middle_end/flambda2/simplify/lifting/reification.mli
@@ -22,6 +22,6 @@ val try_to_reify :
   Downwards_acc.t ->
   Simplified_named.t ->
   bound_to:Bound_var.t ->
-  kind_of_bound_to:Flambda_kind.t ->
   allow_lifting:bool ->
+  Flambda2_types.t ->
   Simplified_named.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplified_named.ml
+++ b/middle_end/flambda2/simplify/simplified_named.ml
@@ -38,6 +38,7 @@ type t =
       }
   | Reachable_try_reify of
       { named : simplified_named;
+        ty : Flambda2_types.t;
         cost_metrics : Cost_metrics.t;
         free_names : Name_occurrences.t
       }
@@ -62,14 +63,15 @@ let reachable (named : Named.t) ~try_reify =
         Named.print named
     | Rec_info rec_info_expr -> Rec_info rec_info_expr, Cost_metrics.zero
   in
-  if try_reify
-  then
+  match try_reify with
+  | Some ty ->
     Reachable_try_reify
       { named = simplified_named;
+        ty;
         cost_metrics;
         free_names = Named.free_names named
       }
-  else
+  | None ->
     Reachable
       { named = simplified_named;
         cost_metrics;
@@ -94,10 +96,11 @@ let reachable_with_known_free_names ~find_code_characteristics (named : Named.t)
         Named.print named
     | Rec_info rec_info_expr -> Rec_info rec_info_expr, Cost_metrics.zero
   in
-  if try_reify
-  then
-    Reachable_try_reify { named = simplified_named; cost_metrics; free_names }
-  else Reachable { named = simplified_named; cost_metrics; free_names }
+  match try_reify with
+  | Some ty ->
+    Reachable_try_reify
+      { named = simplified_named; ty; cost_metrics; free_names }
+  | None -> Reachable { named = simplified_named; cost_metrics; free_names }
 
 let invalid () =
   if Flambda_features.treat_invalid_code_as_unreachable ()

--- a/middle_end/flambda2/simplify/simplified_named.mli
+++ b/middle_end/flambda2/simplify/simplified_named.mli
@@ -36,6 +36,7 @@ type t = private
       }
   | Reachable_try_reify of
       { named : simplified_named;
+        ty : Flambda2_types.t;
         cost_metrics : Cost_metrics.t;
         free_names : Name_occurrences.t
       }
@@ -44,14 +45,14 @@ type t = private
 (** It is an error to pass [Set_of_closures] or [Static_consts] to this
     function. (Sets of closures are disallowed because computation of their free
     names might be expensive; use [reachable_with_known_free_names] instead.) *)
-val reachable : Named.t -> try_reify:bool -> t
+val reachable : Named.t -> try_reify:Flambda2_types.t option -> t
 
 (** It is an error to pass [Static_consts] to this function. *)
 val reachable_with_known_free_names :
   find_code_characteristics:(Code_id.t -> Cost_metrics.code_characteristics) ->
   Named.t ->
   free_names:Name_occurrences.t ->
-  try_reify:bool ->
+  try_reify:Flambda2_types.t option ->
   t
 
 val invalid : unit -> t

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -49,7 +49,7 @@ let inline_linearly_used_continuation uacc ~create_apply_cont ~params ~handler
           let named = Named.create_simple arg in
           { Simplify_named_result.let_bound;
             simplified_defining_expr =
-              Simplified_named.reachable named ~try_reify:false;
+              Simplified_named.reachable named ~try_reify:None;
             original_defining_expr = Some named
           })
     in

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -133,7 +133,7 @@ end = struct
     let kind = N.result_kind in
     let[@inline always] result_unknown () =
       let dacc = DA.add_variable dacc result_var (N.unknown op) in
-      Simplified_named.reachable original_term ~try_reify:false, dacc
+      Simplified_named.reachable original_term ~try_reify:None, dacc
     in
     let[@inline always] result_invalid () =
       let dacc = DA.add_variable dacc result_var (T.bottom kind) in
@@ -169,10 +169,10 @@ end = struct
         let dacc = DA.add_variable dacc result_var ty in
         match T.get_alias_exn ty with
         | exception Not_found ->
-          Simplified_named.reachable named ~try_reify:false, dacc
+          Simplified_named.reachable named ~try_reify:None, dacc
         | simple ->
           let named = Named.create_simple simple in
-          Simplified_named.reachable named ~try_reify:false, dacc
+          Simplified_named.reachable named ~try_reify:None, dacc
     in
     let only_one_side_known op nums ~folder ~other_side =
       let possible_results =
@@ -984,7 +984,7 @@ let[@inline always] simplify_immutable_block_load0
   let[@inline always] unchanged () =
     let ty = T.unknown result_kind in
     let dacc = DA.add_variable dacc result_var ty in
-    Simplified_named.reachable original_term ~try_reify:false, dacc
+    Simplified_named.reachable original_term ~try_reify:None, dacc
   in
   let[@inline always] invalid () =
     let ty = T.bottom result_kind in
@@ -996,7 +996,7 @@ let[@inline always] simplify_immutable_block_load0
       DA.add_variable dacc result_var (T.alias_type_of result_kind simple)
     in
     let named = Named.create_simple simple in
-    Simplified_named.reachable named ~try_reify:false, dacc
+    Simplified_named.reachable named ~try_reify:None, dacc
   in
   let typing_env = DA.typing_env dacc in
   match T.prove_equals_single_tagged_immediate typing_env index_ty with
@@ -1074,7 +1074,7 @@ let simplify_phys_equal (op : P.equality_comparison) (kind : K.t) dacc
     in
     ( Simplified_named.reachable
         (Named.create_simple (Simple.const_bool bool))
-        ~try_reify:false,
+        ~try_reify:None,
       dacc )
   in
   if Simple.equal arg1 arg2
@@ -1110,7 +1110,7 @@ let simplify_phys_equal (op : P.equality_comparison) (kind : K.t) dacc
             DA.add_variable dacc result_var
               (T.these_naked_immediates Targetint_31_63.all_bools)
           in
-          Simplified_named.reachable original_term ~try_reify:false, dacc))
+          Simplified_named.reachable original_term ~try_reify:None, dacc))
     | Naked_number Naked_immediate -> (
       let typing_env = DA.typing_env dacc in
       let proof1 = T.prove_naked_immediates typing_env arg1_ty in
@@ -1124,7 +1124,7 @@ let simplify_phys_equal (op : P.equality_comparison) (kind : K.t) dacc
           DA.add_variable dacc result_var
             (T.these_naked_immediates Targetint_31_63.all_bools)
         in
-        Simplified_named.reachable original_term ~try_reify:false, dacc)
+        Simplified_named.reachable original_term ~try_reify:None, dacc)
     | Naked_number Naked_float ->
       (* CR mshinwell: Should this case be statically disallowed in the type, to
          force people to use [Float_comp]? *)
@@ -1166,7 +1166,7 @@ let simplify_array_load (array_kind : P.Array_kind.t) mutability dacc
     let named = Named.create_prim prim dbg in
     let ty = T.unknown (P.result_kind' prim) in
     let dacc = DA.add_variable dacc result_var ty in
-    Simplified_named.reachable named ~try_reify:false, dacc
+    Simplified_named.reachable named ~try_reify:None, dacc
 
 let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var =
@@ -1221,7 +1221,7 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
         let named = Named.create_prim prim dbg in
         let ty = T.unknown (P.result_kind' prim) in
         let dacc = DA.add_variable dacc result_var ty in
-        Simplified_named.reachable named ~try_reify:false, dacc
+        Simplified_named.reachable named ~try_reify:None, dacc
     | String_or_bigstring_load _ | Bigarray_load _ ->
       fun dacc ~original_term:_ dbg ~arg1 ~arg1_ty:_ ~arg2 ~arg2_ty:_
           ~result_var ->
@@ -1229,7 +1229,7 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
         let named = Named.create_prim prim dbg in
         let ty = T.unknown (P.result_kind' prim) in
         let dacc = DA.add_variable dacc result_var ty in
-        Simplified_named.reachable named ~try_reify:false, dacc
+        Simplified_named.reachable named ~try_reify:None, dacc
   in
   let reachable, dacc =
     simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -96,7 +96,12 @@ let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var
           DE.define_variable_and_extend_typing_environment denv result_var
             result_kind env_extension)
     in
-    Simplified_named.reachable original_term ~try_reify:true, dacc
+    let ty =
+      T.Typing_env.find (DA.typing_env dacc)
+        (Name.var (Bound_var.var result_var))
+        (Some result_kind)
+    in
+    Simplified_named.reachable original_term ~try_reify:(Some ty), dacc
 
 let update_exn_continuation_extra_args uacc ~exn_cont_use_id apply =
   let exn_cont_rewrite =

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -212,7 +212,7 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
           let prim = Flambda_primitive.(Nullary (Optimised_out k)) in
           let named = Named.create_prim prim Debuginfo.none in
           let simplified_defining_expr =
-            Simplified_named.reachable named ~try_reify:false
+            Simplified_named.reachable named ~try_reify:None
           in
           { Simplify_named_result.let_bound;
             simplified_defining_expr;

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -185,7 +185,7 @@ let record_new_defining_expression_binding_for_data_flow dacc data_flow
   match binding.simplified_defining_expr with
   | Invalid _ -> data_flow
   | Reachable { free_names; named; cost_metrics = _ }
-  | Reachable_try_reify { free_names; named; cost_metrics = _ } ->
+  | Reachable_try_reify { free_names; named; ty = _; cost_metrics = _ } ->
     let can_be_removed =
       match named with
       | Simple _ | Set_of_closures _ | Rec_info _ -> true

--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -79,9 +79,9 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
     let dacc = DA.add_variable dacc bound_var ty in
     let defining_expr =
       if simple == new_simple
-      then Simplified_named.reachable named ~try_reify:false
+      then Simplified_named.reachable named ~try_reify:None
       else
-        Simplified_named.reachable (Named.create_simple simple) ~try_reify:false
+        Simplified_named.reachable (Named.create_simple simple) ~try_reify:None
     in
     Simplify_named_result.have_simplified_to_single_term dacc bound_pattern
       defining_expr ~original_defining_expr:named
@@ -96,8 +96,7 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
       Misc.fatal_errorf "Primitive %a = %a did not yield a result var"
         Bound_var.print bound_var P.print prim;
     match simplified_named with
-    | Reachable_try_reify _ ->
-      let kind = P.result_kind' prim in
+    | Reachable_try_reify { ty; _ } ->
       (* CR mshinwell: Add check along the lines of: types are unknown whenever
          [not (P.With_fixed_value.eligible prim)] holds. *)
       (* Primitives with generative effects correspond to allocations. Without
@@ -115,7 +114,7 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
       in
       let defining_expr, dacc =
         Reification.try_to_reify dacc simplified_named ~bound_to:bound_var
-          ~kind_of_bound_to:kind ~allow_lifting
+          ~allow_lifting ty
       in
       Simplify_named_result.have_simplified_to_single_term dacc bound_pattern
         defining_expr ~original_defining_expr:named
@@ -176,11 +175,11 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
     let dacc = DA.add_variable dacc bound_var ty in
     let defining_expr =
       if rec_info_expr == new_rec_info_expr
-      then Simplified_named.reachable named ~try_reify:false
+      then Simplified_named.reachable named ~try_reify:None
       else
         Simplified_named.reachable
           (Named.create_rec_info new_rec_info_expr)
-          ~try_reify:false
+          ~try_reify:None
     in
     Simplify_named_result.have_simplified_to_single_term dacc bound_pattern
       defining_expr ~original_defining_expr:named

--- a/middle_end/flambda2/simplify/simplify_named_result.ml
+++ b/middle_end/flambda2/simplify/simplify_named_result.ml
@@ -74,7 +74,7 @@ let bindings_to_place_in_any_order t =
         let let_bound = Bound_pattern.singleton bound_var in
         let simplified_defining_expr =
           Simple.symbol symbol |> Flambda.Named.create_simple
-          |> Simplified_named.reachable ~try_reify:false
+          |> Simplified_named.reachable ~try_reify:None
         in
         { let_bound; simplified_defining_expr; original_defining_expr = None }
         :: bindings)

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -32,9 +32,9 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     let named = Named.create_prim original_prim dbg in
     let ty = T.unknown result_kind in
     let dacc = DA.add_variable dacc result_var ty in
-    Simplified_named.reachable named ~try_reify:false, dacc
+    Simplified_named.reachable named ~try_reify:None, dacc
   | Probe_is_enabled { name = _ } ->
     let named = Named.create_prim original_prim dbg in
     let ty = T.any_naked_bool in
     let dacc = DA.add_variable dacc result_var ty in
-    Simplified_named.reachable named ~try_reify:false, dacc
+    Simplified_named.reachable named ~try_reify:None, dacc

--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -55,7 +55,7 @@ let try_cse dacc ~original_prim ~min_name_mode ~result_var : cse_result =
             ~operation:(Removed_operations.prim original_prim)
             Cost_metrics.zero
         in
-        Simplified_named.reachable named ~try_reify:true
+        Simplified_named.reachable named ~try_reify:(Some ty)
         |> Simplified_named.update_cost_metrics cost_metrics
       in
       Applied (simplified_named, dacc)

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -960,7 +960,7 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
     in
     Simplified_named.reachable_with_known_free_names ~find_code_characteristics
       (Named.create_set_of_closures set_of_closures)
-      ~free_names:(Named.free_names named) ~try_reify:false
+      ~free_names:(Named.free_names named) ~try_reify:None
   in
   Simplify_named_result.have_simplified_to_single_term dacc bound_vars
     defining_expr

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -38,7 +38,7 @@ let simplify_array_set original_prim (array_kind : P.Array_kind.t) dacc dbg
     let named = Named.create_prim original_prim dbg in
     let ty = T.unknown (P.result_kind' original_prim) in
     let dacc = DA.add_variable dacc result_var ty in
-    Simplified_named.reachable named ~try_reify:false, dacc
+    Simplified_named.reachable named ~try_reify:None, dacc
 
 let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty:_ ~arg3 ~arg3_ty:_ dbg ~result_var =
@@ -51,4 +51,4 @@ let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
     let named = Named.create_prim prim dbg in
     let ty = T.unknown (P.result_kind' prim) in
     let dacc = DA.add_variable dacc result_var ty in
-    Simplified_named.reachable named ~try_reify:false, dacc
+    Simplified_named.reachable named ~try_reify:None, dacc

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -65,12 +65,13 @@ let simplify_select_closure ~move_from ~move_to ~min_name_mode dacc
     let dacc = DA.add_variable dacc result_var ty in
     Simplified_named.invalid (), dacc
   | Proved simple ->
+    let ty = T.alias_type_of K.value simple in
     let reachable =
-      Simplified_named.reachable (Named.create_simple simple) ~try_reify:true
+      Simplified_named.reachable
+        (Named.create_simple simple)
+        ~try_reify:(Some ty)
     in
-    let dacc =
-      DA.add_variable dacc result_var (T.alias_type_of K.value simple)
-    in
+    let dacc = DA.add_variable dacc result_var ty in
     reachable, dacc
   | Unknown ->
     let result = Simple.var (Bound_var.var result_var) in
@@ -193,7 +194,7 @@ let simplify_is_int_or_get_tag dacc ~original_term ~scrutinee ~scrutinee_ty:_
     ~result_var ~make_shape =
   (* CR mshinwell: Check [scrutinee_ty] (e.g. its kind)? *)
   let ty = make_shape scrutinee in
-  let dacc = DA.add_variable dacc result_var (make_shape scrutinee) in
+  let dacc = DA.add_variable dacc result_var ty in
   Simplified_named.reachable original_term ~try_reify:(Some ty), dacc
 
 let simplify_is_int dacc ~original_term ~arg:scrutinee ~arg_ty:scrutinee_ty

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -54,7 +54,7 @@ let simplify_make_block_of_values dacc prim dbg tag ~shape
     | Mutable -> T.any_value
   in
   let dacc = DA.add_variable dacc result_var ty in
-  Simplified_named.reachable term ~try_reify:true, dacc
+  Simplified_named.reachable term ~try_reify:(Some ty), dacc
 
 let simplify_make_block_of_floats dacc _prim dbg
     ~(mutable_or_immutable : Mutability.t) args_with_tys ~result_var =
@@ -82,7 +82,7 @@ let simplify_make_block_of_floats dacc _prim dbg
     | Mutable -> T.any_value
   in
   let dacc = DA.add_variable dacc result_var ty in
-  Simplified_named.reachable term ~try_reify:true, dacc
+  Simplified_named.reachable term ~try_reify:(Some ty), dacc
 
 let simplify_make_array dacc dbg (array_kind : P.Array_kind.t)
     ~mutable_or_immutable args_with_tys ~result_var =
@@ -168,7 +168,7 @@ let simplify_make_array dacc dbg (array_kind : P.Array_kind.t)
           DE.add_variable_and_extend_typing_environment denv result_var ty
             env_extension)
     in
-    Simplified_named.reachable named ~try_reify:true, dacc
+    Simplified_named.reachable named ~try_reify:(Some ty), dacc
 
 let simplify_variadic_primitive dacc _original_prim
     (prim : P.variadic_primitive) ~args_with_tys dbg ~result_var =

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -112,6 +112,12 @@ val add_equations_on_params :
     [variable_is_from_missing_cmx_file]. *)
 val find : t -> Name.t -> Flambda_kind.t option -> Type_grammar.t
 
+val find_with_binding_time_and_mode :
+  t ->
+  Name.t ->
+  Flambda_kind.t option ->
+  Type_grammar.t * Binding_time.With_name_mode.t
+
 val find_or_missing : t -> Name.t -> Type_grammar.t option
 
 val find_params : t -> Bound_parameter.t list -> Type_grammar.t list

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -130,6 +130,12 @@ module Typing_env : sig
 
   val find : t -> Name.t -> Flambda_kind.t option -> flambda_type
 
+  val find_with_binding_time_and_mode :
+    t ->
+    Name.t ->
+    Flambda_kind.t option ->
+    Type_grammar.t * Binding_time.With_name_mode.t
+
   val find_or_missing : t -> Name.t -> flambda_type option
 
   val find_params : t -> Bound_parameter.t list -> flambda_type list
@@ -680,6 +686,5 @@ val reify :
   ?disallowed_free_vars:Variable.Set.t ->
   ?allow_unique:bool ->
   Typing_env.t ->
-  min_name_mode:Name_mode.t ->
   t ->
   reification_result

--- a/middle_end/flambda2/types/reify.mli
+++ b/middle_end/flambda2/types/reify.mli
@@ -49,12 +49,14 @@ type reification_result = private
   | Cannot_reify
   | Invalid
 
+(** If this function is provided with an alias type it may assume that the
+    [Simple] forming such alias is canonical. If this isn't the case, nothing
+    will go wrong per se, but the best answer might not be returned. *)
 val reify :
   ?allowed_if_free_vars_defined_in:Typing_env.t ->
   ?additional_free_var_criterion:(Variable.t -> bool) ->
   ?disallowed_free_vars:Variable.Set.t ->
   ?allow_unique:bool ->
   Typing_env.t ->
-  min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   reification_result


### PR DESCRIPTION
This fixes one erroneous setting of `try_reify` from a previous patch.  It also removes an out-of-date comment in the reification code.  The `min_name_mode` parameter passed to the reification code has been removed as it was always set to normal mode.

This patch then changes the type of `try_reify` such that if simplification of a primitive produces something whose type may be worth reifying, then such type is communicated directly to the reification code.  This avoids another environment lookup.  The place where the out-of-date comment was removed also had dubious behaviour, which has been fixed: if the type of the thing being reified is just `=symbol`, we now return `Simple` instead of `Cannot_reify`.  The reification code also delays finding of the canonical simple via the usual methods in `TE` until it is really necessary.  I did try to avoid this entirely but unfortunately we have to check that the name mode of any returned `Simple` is acceptable.

On `typecore.ml` at `-O3` this gives about a 0.4% improvement in cycles.