### PR TITLE
Erase unused closure variables from types prior to .cmx reachability calculation

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -60,34 +60,53 @@ let compute_reachable_names_and_code ~module_symbol typing_env code =
         Name_occurrences.union names_to_add names_already_added
       in
       let fold_code_id names_to_add code_id =
-        match Exported_code.find code code_id with
-        | None -> names_to_add
-        | Some code_or_metadata ->
-          let free_names = Code_or_metadata.free_names code_or_metadata in
-          let names_to_consider =
-            Name_occurrences
-            .with_only_names_and_code_ids_promoting_newer_version_of free_names
-          in
-          let new_names =
-            Name_occurrences.diff names_to_consider names_already_added
-          in
-          Name_occurrences.union new_names names_to_add
+        if not
+             (Code_id.in_compilation_unit code_id
+                (Compilation_unit.get_current_exn ()))
+        then
+          (* Code in units upon which the current unit depends cannot reference
+             this unit. *)
+          names_to_add
+        else
+          match Exported_code.find code code_id with
+          | None -> names_to_add
+          | Some code_or_metadata ->
+            let free_names = Code_or_metadata.free_names code_or_metadata in
+            let names_to_consider =
+              Name_occurrences
+              .with_only_names_and_code_ids_promoting_newer_version_of
+                free_names
+            in
+            let new_names =
+              Name_occurrences.diff names_to_consider names_already_added
+            in
+            Name_occurrences.union new_names names_to_add
       in
       let fold_name names_to_add name =
-        match TE.find_or_missing typing_env name with
-        | Some ty ->
-          let ty_names = T.free_names ty in
-          let names_to_consider =
-            Name_occurrences
-            .with_only_names_and_code_ids_promoting_newer_version_of ty_names
-          in
-          let new_names =
-            Name_occurrences.diff names_to_consider names_already_added
-          in
-          Name_occurrences.union new_names names_to_add
-        | None ->
-          (* A missing type cannot refer to names defined in the current unit *)
+        if not
+             (Compilation_unit.equal
+                (Name.compilation_unit name)
+                (Compilation_unit.get_current_exn ()))
+        then
+          (* Names in units upon which the current unit depends cannot reference
+             this unit. *)
           names_to_add
+        else
+          match TE.find_or_missing typing_env name with
+          | Some ty ->
+            let ty_names = T.free_names ty in
+            let names_to_consider =
+              Name_occurrences
+              .with_only_names_and_code_ids_promoting_newer_version_of ty_names
+            in
+            let new_names =
+              Name_occurrences.diff names_to_consider names_already_added
+            in
+            Name_occurrences.union new_names names_to_add
+          | None ->
+            (* A missing type cannot refer to names defined in the current
+               unit *)
+            names_to_add
       in
       let from_code_ids =
         Name_occurrences.fold_code_ids names_to_add ~init:Name_occurrences.empty

--- a/middle_end/flambda2/lattices/or_unknown.ml
+++ b/middle_end/flambda2/lattices/or_unknown.ml
@@ -95,4 +95,6 @@ module Let_syntax = struct
   let ( let>* ) x f = bind x ~f
 
   let ( let>+ ) x f = map x ~f
+
+  let ( let>+$ ) x f = map_sharing x ~f
 end

--- a/middle_end/flambda2/lattices/or_unknown.mli
+++ b/middle_end/flambda2/lattices/or_unknown.mli
@@ -48,4 +48,8 @@ module Let_syntax : sig
   val ( let>* ) : 'a t -> ('a -> 'b t) -> 'b t
 
   val ( let>+ ) : 'a t -> ('a -> 'b) -> 'b t
+
+  (** [let>+$] returns the input ['a t] if the mapping function returns a value
+      that is physically-equal to its input. *)
+  val ( let>+$ ) : 'a t -> ('a -> 'a) -> 'a t
 end

--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -1219,8 +1219,7 @@ let clean_for_export
     { canonical_elements;
       aliases_of_canonical_names = _;
       aliases_of_consts = _
-    } =
-  (* CR vlaviron: We'd like to remove unreachable entries at some point. *)
+    } ~reachable_names =
   (* From this point, the structure will only be used for looking up names that
      are defined in this compilation unit. No new aliases will be added, name
      modes have become irrelevant (Typing_env takes care of setting the mode to
@@ -1229,7 +1228,9 @@ let clean_for_export
      not imported. *)
   let canonical_elements =
     Name.Map.filter
-      (fun name _canonical -> not (Name.is_imported name))
+      (fun name _canonical_and_coercion_to_canonical ->
+        (not (Name.is_imported name))
+        && Name_occurrences.mem_name reachable_names name)
       canonical_elements
   in
   { canonical_elements;

--- a/middle_end/flambda2/types/env/aliases.mli
+++ b/middle_end/flambda2/types/env/aliases.mli
@@ -144,6 +144,6 @@ val get_canonical_ignoring_name_mode : t -> Name.t -> Simple.t
     the same name mode (if not, something is very wrong anyway). *)
 val merge : t -> t -> t
 
-val clean_for_export : t -> t
+val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
 val apply_renaming : t -> Renaming.t -> t

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -146,3 +146,16 @@ let merge t1 t2 =
       t1.symbol_projections t2.symbol_projections
   in
   { names_to_types; aliases; symbol_projections }
+
+let remove_unused_closure_vars { names_to_types; aliases; symbol_projections }
+    ~used_closure_vars =
+  let names_to_types =
+    Name.Map.map_sharing
+      (fun ((ty, binding_time_and_mode) as info) ->
+        let ty' =
+          Type_grammar.remove_unused_closure_vars ty ~used_closure_vars
+        in
+        if ty == ty' then info else ty', binding_time_and_mode)
+      names_to_types
+  in
+  { names_to_types; aliases; symbol_projections }

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -103,7 +103,7 @@ let clean_for_export t ~reachable_names =
              current_compilation_unit)
       t.names_to_types
   in
-  let aliases = Aliases.clean_for_export t.aliases in
+  let aliases = Aliases.clean_for_export t.aliases ~reachable_names in
   { t with names_to_types; aliases }
 
 let apply_renaming { names_to_types; aliases; symbol_projections } renaming =

--- a/middle_end/flambda2/types/env/cached_level.mli
+++ b/middle_end/flambda2/types/env/cached_level.mli
@@ -50,3 +50,6 @@ val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 val apply_renaming : t -> Renaming.t -> t
 
 val merge : t -> t -> t
+
+val remove_unused_closure_vars :
+  t -> used_closure_vars:Var_within_closure.Set.t -> t

--- a/middle_end/flambda2/types/env/code_age_relation.ml
+++ b/middle_end/flambda2/types/env/code_age_relation.ml
@@ -113,3 +113,9 @@ let apply_renaming t renaming =
     (fun key v acc ->
       Code_id.Map.add (rename_code_id key) (rename_code_id v) acc)
     t Code_id.Map.empty
+
+let clean_for_export t ~reachable_names =
+  Code_id.Map.filter
+    (fun newer_code_id _older_code_id ->
+      Name_occurrences.mem_code_id reachable_names newer_code_id)
+    t

--- a/middle_end/flambda2/types/env/code_age_relation.mli
+++ b/middle_end/flambda2/types/env/code_age_relation.mli
@@ -56,3 +56,5 @@ val union : t -> t -> t
 val all_code_ids_for_export : t -> Code_id.Set.t
 
 val apply_renaming : t -> Renaming.t -> t
+
+val clean_for_export : t -> reachable_names:Name_occurrences.t -> t

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1166,13 +1166,16 @@ end = struct
     let current_level =
       One_level.clean_for_export env.current_level ~reachable_names
     in
+    let code_age_relation =
+      Code_age_relation.clean_for_export env.code_age_relation ~reachable_names
+    in
     let defined_symbols =
       Symbol.Set.filter
         (fun symbol -> Name_occurrences.mem_symbol reachable_names symbol)
         env.defined_symbols
     in
     { defined_symbols;
-      code_age_relation = env.code_age_relation;
+      code_age_relation;
       just_after_level = One_level.just_after_level current_level;
       next_binding_time = env.next_binding_time
     }

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -170,12 +170,18 @@ val cut : t -> unknown_if_defined_at_or_later_than:Scope.t -> Typing_env_level.t
 
 val free_names_transitive : t -> Type_grammar.t -> Name_occurrences.t
 
-val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
+module Pre_serializable : sig
+  type t
+
+  val create : typing_env -> used_closure_vars:Var_within_closure.Set.t -> t
+
+  val find_or_missing : t -> Name.t -> Type_grammar.t option
+end
 
 module Serializable : sig
   type t
 
-  val create : typing_env -> t
+  val create : Pre_serializable.t -> reachable_names:Name_occurrences.t -> t
 
   val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -181,12 +181,18 @@ module Typing_env : sig
   val aliases_of_simple :
     t -> min_name_mode:Name_mode.t -> Simple.t -> Alias_set.t
 
-  val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
+  module Pre_serializable : sig
+    type t
+
+    val create : typing_env -> used_closure_vars:Var_within_closure.Set.t -> t
+
+    val find_or_missing : t -> Name.t -> flambda_type option
+  end
 
   module Serializable : sig
     type t
 
-    val create : typing_env -> t
+    val create : Pre_serializable.t -> reachable_names:Name_occurrences.t -> t
 
     val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/types/grammar/set_of_closures_contents.ml
+++ b/middle_end/flambda2/types/grammar/set_of_closures_contents.ml
@@ -75,6 +75,25 @@ let apply_renaming { closures; closure_vars } renaming =
   in
   { closures; closure_vars }
 
+let free_names { closures = _; closure_vars } =
+  Var_within_closure.Set.fold
+    (fun closure_var free_names ->
+      Name_occurrences.add_closure_var free_names closure_var Name_mode.normal)
+    closure_vars Name_occurrences.empty
+
+let remove_unused_closure_vars { closures; closure_vars } ~used_closure_vars =
+  (* CR mshinwell: Consider adding [Used_closure_vars.t] *)
+  let closure_vars =
+    Var_within_closure.Set.filter
+      (fun var ->
+        (not
+           (Var_within_closure.in_compilation_unit var
+              (Compilation_unit.get_current_exn ())))
+        || Var_within_closure.Set.mem var used_closure_vars)
+      closure_vars
+  in
+  { closures; closure_vars }
+
 module With_closure_id = struct
   type nonrec t = Closure_id.t * t
 

--- a/middle_end/flambda2/types/grammar/set_of_closures_contents.mli
+++ b/middle_end/flambda2/types/grammar/set_of_closures_contents.mli
@@ -36,7 +36,10 @@ val closures : t -> Closure_id.Set.t
 
 val closure_vars : t -> Var_within_closure.Set.t
 
-val apply_renaming : t -> Renaming.t -> t
+include Contains_names.S with type t := t
+
+val remove_unused_closure_vars :
+  t -> used_closure_vars:Var_within_closure.Set.t -> t
 
 module With_closure_id : sig
   type nonrec t = Closure_id.t * t

--- a/middle_end/flambda2/types/grammar/type_descr.mli
+++ b/middle_end/flambda2/types/grammar/type_descr.mli
@@ -70,6 +70,15 @@ val free_names :
   'head t ->
   Name_occurrences.t
 
+val remove_unused_closure_vars :
+  apply_renaming_head:('head -> Renaming.t -> 'head) ->
+  free_names_head:('head -> Name_occurrences.t) ->
+  remove_unused_closure_vars_head:
+    ('head -> used_closure_vars:Var_within_closure.Set.t -> 'head) ->
+  'head t ->
+  used_closure_vars:Var_within_closure.Set.t ->
+  'head t
+
 val all_ids_for_export :
   apply_renaming_head:('head -> Renaming.t -> 'head) ->
   free_names_head:('head -> Name_occurrences.t) ->

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -178,11 +178,11 @@ let rec apply_renaming_head_of_kind_value head renaming =
   match head with
   | Variant { blocks; immediates; is_unique } ->
     let immediates' =
-      let>+ immediates = immediates in
+      let>+$ immediates = immediates in
       apply_renaming immediates renaming
     in
     let blocks' =
-      let>+ blocks = blocks in
+      let>+$ blocks = blocks in
       apply_renaming_row_like_for_blocks blocks renaming
     in
     if immediates == immediates' && blocks == blocks'
@@ -1241,11 +1241,11 @@ and remove_unused_closure_vars_head_of_kind_value head ~used_closure_vars =
   match head with
   | Variant { blocks; immediates; is_unique } ->
     let immediates' =
-      let>+ immediates = immediates in
+      let>+$ immediates = immediates in
       remove_unused_closure_vars immediates ~used_closure_vars
     in
     let blocks' =
-      let>+ blocks = blocks in
+      let>+$ blocks = blocks in
       remove_unused_closure_vars_row_like_for_blocks blocks ~used_closure_vars
     in
     if immediates == immediates' && blocks == blocks'

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -123,6 +123,8 @@ type flambda_type = t
 
 val print : Format.formatter -> t -> unit
 
+(** [free_names] returns *all* closure variables occurring in the given type
+    regardless of where in the type such variables occur. *)
 include Contains_names.S with type t := t
 
 include Contains_ids.S with type t := t

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -127,6 +127,9 @@ include Contains_names.S with type t := t
 
 include Contains_ids.S with type t := t
 
+val remove_unused_closure_vars :
+  t -> used_closure_vars:Var_within_closure.Set.t -> t
+
 val kind : t -> Flambda_kind.t
 
 val alias_type_of : Flambda_kind.t -> Simple.t -> t

--- a/middle_end/flambda2/types/grammar/with_delayed_renaming.ml
+++ b/middle_end/flambda2/types/grammar/with_delayed_renaming.ml
@@ -60,7 +60,7 @@ let[@inline always] free_names ~apply_renaming_descr ~free_names_descr t =
 
 let remove_unused_closure_vars ~apply_renaming_descr ~free_names_descr
     ~remove_unused_closure_vars_descr t ~used_closure_vars =
-  let descr_known_to_contain_no_closure_vars =
+  let descr_known_to_contain_no_unused_closure_vars =
     (* If the free names are already computed (modulo application of a
        renaming), we can use them as a shortcut, to potentially avoid traversing
        the [descr]. *)
@@ -68,10 +68,13 @@ let remove_unused_closure_vars ~apply_renaming_descr ~free_names_descr
     then
       let free_names = free_names t ~apply_renaming_descr ~free_names_descr in
       let closure_vars = Name_occurrences.closure_vars free_names in
-      Var_within_closure.Set.is_empty closure_vars
+      let unused_closure_vars =
+        Var_within_closure.Set.diff closure_vars used_closure_vars
+      in
+      Var_within_closure.Set.is_empty unused_closure_vars
     else false
   in
-  if descr_known_to_contain_no_closure_vars
+  if descr_known_to_contain_no_unused_closure_vars
   then t
   else
     let descr =

--- a/middle_end/flambda2/types/grammar/with_delayed_renaming.mli
+++ b/middle_end/flambda2/types/grammar/with_delayed_renaming.mli
@@ -54,3 +54,12 @@ val free_names :
   free_names_descr:('descr -> Name_occurrences.t) ->
   'descr t ->
   Name_occurrences.t
+
+val remove_unused_closure_vars :
+  apply_renaming_descr:('descr -> Renaming.t -> 'descr) ->
+  free_names_descr:('descr -> Name_occurrences.t) ->
+  remove_unused_closure_vars_descr:
+    ('descr -> used_closure_vars:Var_within_closure.Set.t -> 'descr) ->
+  'descr t ->
+  used_closure_vars:Var_within_closure.Set.t ->
+  'descr t


### PR DESCRIPTION
Unused closure variables are causing large amounts of symbols, otherwise unreferenced, to be saved in `.cmx` files.  This happens because at present the unused closure variables are only erased from the types of exported typing environments upon import (via `Renaming`).  As such the reachability calculation still traverses through them.

This patch adds a new operation on types for removing unused closure variables.  It tries not to do this by examining any pre-computed free names set first (empirically these sets seem to be frequently available).  I think after this change we can probably remove the used closure variables infrastructure from `Renaming`, but that can be done in a follow-up PR.

The reduction in `.cmx` file size for a reasonably-sized but "normal" example in the JS tree is substantial (around 30%).

This PR is best reviewed commit by commit.  (The commit that moves `Typing_env.Serializable` does not make any actual changes to the code.)