### PR TITLE
Allow meet_int_indexed_product on cases with different field kinds

### DIFF
--- a/middle_end/flambda2/tests/mlexamples/meet_with_incompatible_kinds.ml
+++ b/middle_end/flambda2/tests/mlexamples/meet_with_incompatible_kinds.ml
@@ -13,8 +13,8 @@ let aux (type x) (x : x t) =
   match x with
   | Foo _ -> 3.
   | Bar bar ->
-    (* This block load meets bar (aliased to foo (from f, after inlining) here), with a block
-       with fields of kind float which should result on Bottom *)
+    (* This block load meets bar (aliased to foo (from f, after inlining) here),
+       with a block with fields of kind float which should result on Bottom *)
     bar.f
   [@@inline]
 

--- a/middle_end/flambda2/tests/mlexamples/meet_with_incompatible_kinds.ml
+++ b/middle_end/flambda2/tests/mlexamples/meet_with_incompatible_kinds.ml
@@ -1,0 +1,27 @@
+type foo =
+  { a : int;
+    b : string
+  }
+
+type bar = { f : float }
+
+type _ t =
+  | Foo : foo -> foo t
+  | Bar : bar -> bar t
+
+let aux (type x) (x : x t) =
+  match x with
+  | Foo _ -> 3.
+  | Bar bar ->
+    (* This block load meets bar (aliased to foo (from f, after inlining) here), with a block
+       with fields of kind float which should result on Bottom *)
+    bar.f
+  [@@inline]
+
+let f (x : foo t) =
+  let (Foo foo) = x in
+  (* This is a block load without any annotation on the block foo: the variable
+     foo is a row like of tag 'others' *)
+  let n = foo.a in
+  (* This ensures that foo is known to have fields of kind value *)
+  aux x, n


### PR DESCRIPTION
A meet on a blocks containing wrong field kind (but with unknown tag) is possible on block loads.
The provided example craft such a situation. In that case the result should obviously be bottom.