### PR TITLE
Ensure the symbol for the module block is defined

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -1569,7 +1569,8 @@ let unit ~make_symbol unit cmx ~all_code =
           (List.map snd return_cont_params)
           (Flambda_unit.return_continuation unit)
       in
-      let body, res = expr env R.empty (Flambda_unit.body unit) in
+      let r = R.empty ~module_symbol:(Flambda_unit.module_symbol unit) in
+      let body, res = expr env r (Flambda_unit.body unit) in
       let body =
         let unit_value = C.targetint Targetint_32_64.one in
         C.ccatch ~rec_flag:false ~body

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -25,20 +25,25 @@ type t =
     functions : Cmm.fundecl list;
     current_data : Cmm.data_item list;
     module_symbol : Symbol.t;
-    module_symbol_defined : bool;
+    module_symbol_defined : bool
   }
 
 let empty ~module_symbol =
-  { gc_roots = []; data_list = []; functions = []; current_data = [];
-    module_symbol; module_symbol_defined = false; }
-
+  { gc_roots = [];
+    data_list = [];
+    functions = [];
+    current_data = [];
+    module_symbol;
+    module_symbol_defined = false
+  }
 
 let check_for_module_symbol t symbol =
-  if Symbol.equal symbol t.module_symbol then begin
+  if Symbol.equal symbol t.module_symbol
+  then begin
     assert (not t.module_symbol_defined);
-    { t with module_symbol_defined = true; }
-  end else t
-
+    { t with module_symbol_defined = true }
+  end
+  else t
 
 let defines_a_symbol data =
   match (data : Cmm.data_item) with
@@ -73,14 +78,12 @@ let set_data r l =
         "about to lose some translated static data items")
 
 let define_module_symbol_if_missing r =
-  if r.module_symbol_defined then r
+  if r.module_symbol_defined
+  then r
   else
     let s' = Linkage_name.to_string (Symbol.linkage_name r.module_symbol) in
     let l =
-      C.emit_block
-        (s', Cmmgen_state.Global)
-        (C.black_block_header 0 0)
-        []
+      C.emit_block (s', Cmmgen_state.Global) (C.black_block_header 0 0) []
     in
     set_data r l
 

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -23,10 +23,22 @@ type t =
   { gc_roots : Symbol.t list;
     data_list : Cmm.phrase list;
     functions : Cmm.fundecl list;
-    current_data : Cmm.data_item list
+    current_data : Cmm.data_item list;
+    module_symbol : Symbol.t;
+    module_symbol_defined : bool;
   }
 
-let empty = { gc_roots = []; data_list = []; functions = []; current_data = [] }
+let empty ~module_symbol =
+  { gc_roots = []; data_list = []; functions = []; current_data = [];
+    module_symbol; module_symbol_defined = false; }
+
+
+let check_for_module_symbol t symbol =
+  if Symbol.equal symbol t.module_symbol then begin
+    assert (not t.module_symbol_defined);
+    { t with module_symbol_defined = true; }
+  end else t
+
 
 let defines_a_symbol data =
   match (data : Cmm.data_item) with
@@ -60,11 +72,25 @@ let set_data r l =
       Misc.fatal_errorf "To_cmm_result.set_data: %s"
         "about to lose some translated static data items")
 
+let define_module_symbol_if_missing r =
+  if r.module_symbol_defined then r
+  else
+    let s' = Linkage_name.to_string (Symbol.linkage_name r.module_symbol) in
+    let l =
+      C.emit_block
+        (s', Cmmgen_state.Global)
+        (C.black_block_header 0 0)
+        []
+    in
+    set_data r l
+
 let add_gc_roots r l = { r with gc_roots = l @ r.gc_roots }
 
 let add_function r f = { r with functions = f :: r.functions }
 
 let to_cmm r =
+  (* make sure the module symbol is defined *)
+  let r = define_module_symbol_if_missing r in
   (* Make sure we do not forget any current data *)
   let r = archive_data r in
   (* Sort functions according to debuginfo *)

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -25,7 +25,7 @@
 type t
 
 (** The empty result. *)
-val empty : t
+val empty : module_symbol:Symbol.t -> t
 
 (** Archive the current data into the list of already translated data. *)
 val archive_data : t -> t
@@ -42,6 +42,11 @@ val add_gc_roots : t -> Symbol.t list -> t
 
 (** Add a function translation. *)
 val add_function : t -> Cmm.fundecl -> t
+
+(** Record the symbol as having been defined. This is used to keep track of whether
+    the symbol for the current unit has been defined. *)
+val check_for_module_symbol : t -> Symbol.t -> t
+
 
 (* CR mshinwell: Use a "private" record for the return type of this. *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -43,10 +43,9 @@ val add_gc_roots : t -> Symbol.t list -> t
 (** Add a function translation. *)
 val add_function : t -> Cmm.fundecl -> t
 
-(** Record the symbol as having been defined. This is used to keep track of whether
-    the symbol for the current unit has been defined. *)
+(** Record the symbol as having been defined. This is used to keep track of
+    whether the symbol for the current unit has been defined. *)
 val check_for_module_symbol : t -> Symbol.t -> t
-
 
 (* CR mshinwell: Use a "private" record for the return type of this. *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -262,6 +262,7 @@ let static_const0 env r ~updates ~params_and_body
     (bound_symbols : Bound_symbols.Pattern.t) (static_const : Static_const.t) =
   match bound_symbols, static_const with
   | Block_like s, Block (tag, _mut, fields) ->
+    let r = R.check_for_module_symbol r s in
     let name = symbol s in
     let tag = Tag.Scannable.to_int tag in
     let block_name = name, Cmmgen_state.Global in


### PR DESCRIPTION
In case when the flambda code creating the module block symbol becomes unreachable (and is simplified away by the simplifier), the compiler must still emit a symbol for the module block, to avoid linker errors later in the compilation pipeline.

Should solve #413 