### PR TITLE
Track return types of functors

### DIFF
--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -26,6 +26,9 @@ module type Flambda_backend_options = sig
 
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
+  val flambda2_result_types_functors_only : unit -> unit
+  val flambda2_result_types_all_functions : unit -> unit
+  val no_flambda2_result_types : unit -> unit
   val flambda2_unbox_along_intra_function_control_flow : unit -> unit
   val no_flambda2_unbox_along_intra_function_control_flow : unit -> unit
   val flambda2_backend_cse_at_toplevel : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -26,7 +26,7 @@ module Flambda2 = struct
     let backend_cse_at_toplevel = false
     let cse_depth = 2
     let treat_invalid_code_as_unreachable = false
-    let function_result_types = Functors_only
+    let function_result_types = Never
     let unicode = true
   end
 

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -16,6 +16,8 @@
 let use_ocamlcfg = ref false            (* -ocamlcfg *)
 let dump_cfg = ref false                (* -dcfg *)
 
+type function_result_types = Never | Functors_only | All_functions
+
 module Flambda2 = struct
   module Default = struct
     let classic_mode = false
@@ -24,6 +26,7 @@ module Flambda2 = struct
     let backend_cse_at_toplevel = false
     let cse_depth = 2
     let treat_invalid_code_as_unreachable = false
+    let function_result_types = Functors_only
     let unicode = true
   end
 
@@ -36,6 +39,7 @@ module Flambda2 = struct
   let treat_invalid_code_as_unreachable =
     ref Default.treat_invalid_code_as_unreachable
   let unicode = ref Default.unicode
+  let function_result_types = ref Default.function_result_types
 
   module Dump = struct
     let rawfexpr = ref false
@@ -222,7 +226,8 @@ module Flambda2 = struct
     join_points := true;
     unbox_along_intra_function_control_flow := true;
     Expert.fallback_inlining_heuristic := false;
-    backend_cse_at_toplevel := false
+    backend_cse_at_toplevel := false;
+    function_result_types := Functors_only
 end
 
 let set_oclassic () =

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -17,6 +17,8 @@
 val use_ocamlcfg : bool ref
 val dump_cfg : bool ref
 
+type function_result_types = Never | Functors_only | All_functions
+
 module Flambda2 : sig
   module Default : sig
     val classic_mode : bool
@@ -25,9 +27,12 @@ module Flambda2 : sig
     val backend_cse_at_toplevel : bool
     val cse_depth : int
     val treat_invalid_code_as_unreachable : bool
+    val function_result_types : function_result_types
 
     val unicode : bool
   end
+
+  val function_result_types : function_result_types ref
 
   val classic_mode : bool ref
   val join_points : bool ref

--- a/dune
+++ b/dune
@@ -251,19 +251,34 @@
   ; The driver should be in here too, but is not at present.  This might
   ; be tricky because it has a different name...
   )
- (libraries ocamlcommon stdlib flambda_backend_common flambda2_identifiers flambda2_cmx))
+ (libraries
+  ocamlcommon
+  stdlib
+  flambda_backend_common
+  flambda2_identifiers
+  flambda2_cmx))
 
 (library
  (name flambda_backend_common)
  (wrapped false)
  (modes byte native)
  ; same flags as for ocamlcommon library
- (flags (
-   -nostdlib -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66
-   -warn-error A -bin-annot -safe-string -strict-formats
-   -w -67
+ (flags
+  (-nostdlib
+   -strict-sequence
+   -principal
+   -absname
+   -w
+   +a-4-9-40-41-42-44-45-48-66
+   -warn-error
+   A
+   -bin-annot
+   -safe-string
+   -strict-formats
+   -w
+   -67
    ; remove -w -67 by adding the camlinternalMenhirLib hack like the Makefile
- ))
+   ))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
  (libraries stdlib ocamlcommon)
@@ -337,9 +352,9 @@
    %{dep:middle_end/flambda2/lattices/flambda2_lattices.a}
    %{dep:middle_end/flambda2/bound_identifiers/flambda2_bound_identifiers.a}
    %{dep:middle_end/flambda2/term_basics/flambda2_term_basics.a}
+   %{dep:middle_end/flambda2/types/flambda2_types.a}
    %{dep:middle_end/flambda2/terms/flambda2_terms.a}
    %{dep:middle_end/flambda2/simplify_shared/flambda2_simplify_shared.a}
-   %{dep:middle_end/flambda2/types/flambda2_types.a}
    %{dep:middle_end/flambda2/cmx/flambda2_cmx.a}
    %{dep:middle_end/flambda2/from_lambda/flambda2_from_lambda.a}
    %{dep:middle_end/flambda2/simplify/flambda2_simplify.a}
@@ -364,9 +379,9 @@
    %{dep:middle_end/flambda2/lattices/flambda2_lattices.cma}
    %{dep:middle_end/flambda2/bound_identifiers/flambda2_bound_identifiers.cma}
    %{dep:middle_end/flambda2/term_basics/flambda2_term_basics.cma}
+   %{dep:middle_end/flambda2/types/flambda2_types.cma}
    %{dep:middle_end/flambda2/terms/flambda2_terms.cma}
    %{dep:middle_end/flambda2/simplify_shared/flambda2_simplify_shared.cma}
-   %{dep:middle_end/flambda2/types/flambda2_types.cma}
    %{dep:middle_end/flambda2/cmx/flambda2_cmx.cma}
    %{dep:middle_end/flambda2/from_lambda/flambda2_from_lambda.cma}
    %{dep:middle_end/flambda2/simplify/flambda2_simplify.cma}
@@ -391,9 +406,9 @@
    %{dep:middle_end/flambda2/lattices/flambda2_lattices.cmxa}
    %{dep:middle_end/flambda2/bound_identifiers/flambda2_bound_identifiers.cmxa}
    %{dep:middle_end/flambda2/term_basics/flambda2_term_basics.cmxa}
+   %{dep:middle_end/flambda2/types/flambda2_types.cmxa}
    %{dep:middle_end/flambda2/terms/flambda2_terms.cmxa}
    %{dep:middle_end/flambda2/simplify_shared/flambda2_simplify_shared.cmxa}
-   %{dep:middle_end/flambda2/types/flambda2_types.cmxa}
    %{dep:middle_end/flambda2/cmx/flambda2_cmx.cmxa}
    %{dep:middle_end/flambda2/from_lambda/flambda2_from_lambda.cmxa}
    %{dep:middle_end/flambda2/simplify/flambda2_simplify.cmxa}
@@ -1258,38 +1273,89 @@
   (middle_end/flambda2/to_cmm/.flambda2_to_cmm.objs/byte/flambda2_to_cmm__To_cmm.cmt
    as
    compiler-libs/flambda2_to_cmm__To_cmm.cmt)
-
   (compiler_hooks.mli as compiler-libs/compiler_hooks.mli)
-  (.ocamloptcomp.objs/byte/compiler_hooks.cmi as compiler-libs/compiler_hooks.cmi)
-  (.ocamloptcomp.objs/byte/compiler_hooks.cmo as compiler-libs/compiler_hooks.cmo)
-  (.ocamloptcomp.objs/byte/compiler_hooks.cmt as compiler-libs/compiler_hooks.cmt)
-  (.ocamloptcomp.objs/byte/compiler_hooks.cmti as compiler-libs/compiler_hooks.cmti)
-  (.ocamloptcomp.objs/native/compiler_hooks.cmx as compiler-libs/compiler_hooks.cmx)
+  (.ocamloptcomp.objs/byte/compiler_hooks.cmi
+   as
+   compiler-libs/compiler_hooks.cmi)
+  (.ocamloptcomp.objs/byte/compiler_hooks.cmo
+   as
+   compiler-libs/compiler_hooks.cmo)
+  (.ocamloptcomp.objs/byte/compiler_hooks.cmt
+   as
+   compiler-libs/compiler_hooks.cmt)
+  (.ocamloptcomp.objs/byte/compiler_hooks.cmti
+   as
+   compiler-libs/compiler_hooks.cmti)
+  (.ocamloptcomp.objs/native/compiler_hooks.cmx
+   as
+   compiler-libs/compiler_hooks.cmx)
   (flambda_backend_args.mli as compiler-libs/flambda_backend_args.mli)
-  (.flambda_backend_common.objs/native/flambda_backend_args.cmx as compiler-libs/flambda_backend_args.cmx)
-  (.flambda_backend_common.objs/byte/flambda_backend_args.cmi as compiler-libs/flambda_backend_args.cmi)
-  (.flambda_backend_common.objs/byte/flambda_backend_args.cmo as compiler-libs/flambda_backend_args.cmo)
-  (.flambda_backend_common.objs/byte/flambda_backend_args.cmt as compiler-libs/flambda_backend_args.cmt)
-  (.flambda_backend_common.objs/byte/flambda_backend_args.cmti as compiler-libs/flambda_backend_args.cmti)
+  (.flambda_backend_common.objs/native/flambda_backend_args.cmx
+   as
+   compiler-libs/flambda_backend_args.cmx)
+  (.flambda_backend_common.objs/byte/flambda_backend_args.cmi
+   as
+   compiler-libs/flambda_backend_args.cmi)
+  (.flambda_backend_common.objs/byte/flambda_backend_args.cmo
+   as
+   compiler-libs/flambda_backend_args.cmo)
+  (.flambda_backend_common.objs/byte/flambda_backend_args.cmt
+   as
+   compiler-libs/flambda_backend_args.cmt)
+  (.flambda_backend_common.objs/byte/flambda_backend_args.cmti
+   as
+   compiler-libs/flambda_backend_args.cmti)
   (flambda_backend_flags.mli as compiler-libs/flambda_backend_flags.mli)
-  (.flambda_backend_common.objs/native/flambda_backend_flags.cmx as compiler-libs/flambda_backend_flags.cmx)
-  (.flambda_backend_common.objs/byte/flambda_backend_flags.cmi as compiler-libs/flambda_backend_flags.cmi)
-  (.flambda_backend_common.objs/byte/flambda_backend_flags.cmo as compiler-libs/flambda_backend_flags.cmo)
-  (.flambda_backend_common.objs/byte/flambda_backend_flags.cmt as compiler-libs/flambda_backend_flags.cmt)
-  (.flambda_backend_common.objs/byte/flambda_backend_flags.cmti as compiler-libs/flambda_backend_flags.cmti)
+  (.flambda_backend_common.objs/native/flambda_backend_flags.cmx
+   as
+   compiler-libs/flambda_backend_flags.cmx)
+  (.flambda_backend_common.objs/byte/flambda_backend_flags.cmi
+   as
+   compiler-libs/flambda_backend_flags.cmi)
+  (.flambda_backend_common.objs/byte/flambda_backend_flags.cmo
+   as
+   compiler-libs/flambda_backend_flags.cmo)
+  (.flambda_backend_common.objs/byte/flambda_backend_flags.cmt
+   as
+   compiler-libs/flambda_backend_flags.cmt)
+  (.flambda_backend_common.objs/byte/flambda_backend_flags.cmti
+   as
+   compiler-libs/flambda_backend_flags.cmti)
   (printast_with_mappings.mli as compiler-libs/printast_with_mappings.mli)
-  (.ocamloptcomp.objs/byte/printast_with_mappings.cmi as compiler-libs/printast_with_mappings.cmi)
-  (.ocamloptcomp.objs/byte/printast_with_mappings.cmo as compiler-libs/printast_with_mappings.cmo)
-  (.ocamloptcomp.objs/byte/printast_with_mappings.cmt as compiler-libs/printast_with_mappings.cmt)
-  (.ocamloptcomp.objs/byte/printast_with_mappings.cmti as compiler-libs/printast_with_mappings.cmti)
-  (.ocamloptcomp.objs/native/printast_with_mappings.cmx as compiler-libs/printast_with_mappings.cmx)
-  (location_tracker_formatter.mli as compiler-libs/location_tracker_formatter.mli)
-  (.ocamloptcomp.objs/byte/location_tracker_formatter.cmi as compiler-libs/location_tracker_formatter.cmi)
-  (.ocamloptcomp.objs/byte/location_tracker_formatter.cmo as compiler-libs/location_tracker_formatter.cmo)
-  (.ocamloptcomp.objs/byte/location_tracker_formatter.cmt as compiler-libs/location_tracker_formatter.cmt)
-  (.ocamloptcomp.objs/byte/location_tracker_formatter.cmti as compiler-libs/location_tracker_formatter.cmti)
-  (.ocamloptcomp.objs/native/location_tracker_formatter.cmx as compiler-libs/location_tracker_formatter.cmx)
-  ))
+  (.ocamloptcomp.objs/byte/printast_with_mappings.cmi
+   as
+   compiler-libs/printast_with_mappings.cmi)
+  (.ocamloptcomp.objs/byte/printast_with_mappings.cmo
+   as
+   compiler-libs/printast_with_mappings.cmo)
+  (.ocamloptcomp.objs/byte/printast_with_mappings.cmt
+   as
+   compiler-libs/printast_with_mappings.cmt)
+  (.ocamloptcomp.objs/byte/printast_with_mappings.cmti
+   as
+   compiler-libs/printast_with_mappings.cmti)
+  (.ocamloptcomp.objs/native/printast_with_mappings.cmx
+   as
+   compiler-libs/printast_with_mappings.cmx)
+  (location_tracker_formatter.mli
+   as
+   compiler-libs/location_tracker_formatter.mli)
+  (.ocamloptcomp.objs/byte/location_tracker_formatter.cmi
+   as
+   compiler-libs/location_tracker_formatter.cmi)
+  (.ocamloptcomp.objs/byte/location_tracker_formatter.cmo
+   as
+   compiler-libs/location_tracker_formatter.cmo)
+  (.ocamloptcomp.objs/byte/location_tracker_formatter.cmt
+   as
+   compiler-libs/location_tracker_formatter.cmt)
+  (.ocamloptcomp.objs/byte/location_tracker_formatter.cmti
+   as
+   compiler-libs/location_tracker_formatter.cmti)
+  (.ocamloptcomp.objs/native/location_tracker_formatter.cmx
+   as
+   compiler-libs/location_tracker_formatter.cmx)))
+
 (install
  (section lib)
  (package ocaml)
@@ -2111,9 +2177,15 @@
   (.ocamloptcomp.objs/byte/variable.cmo as compiler-libs/variable.cmo)
   (.ocamloptcomp.objs/byte/variable.cmt as compiler-libs/variable.cmt)
   (.ocamloptcomp.objs/byte/variable.cmti as compiler-libs/variable.cmti)
-  (ocaml/.ocamlcommon.objs/byte/extensions.cmi as compiler-libs/extensions.cmi)
-  (ocaml/.ocamlcommon.objs/byte/extensions.cmo as compiler-libs/extensions.cmo)
-  (ocaml/.ocamlcommon.objs/byte/extensions.cmt as compiler-libs/extensions.cmt)
+  (ocaml/.ocamlcommon.objs/byte/extensions.cmi
+   as
+   compiler-libs/extensions.cmi)
+  (ocaml/.ocamlcommon.objs/byte/extensions.cmo
+   as
+   compiler-libs/extensions.cmo)
+  (ocaml/.ocamlcommon.objs/byte/extensions.cmt
+   as
+   compiler-libs/extensions.cmt)
   (ocaml/.ocamlcommon.objs/byte/extensions.cmti
    as
    compiler-libs/extensions.cmti)

--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -47,11 +47,7 @@ let merge t1 t2 = Code_id.Map.union Code_or_metadata.merge t1 t2
 
 let mem code_id t = Code_id.Map.mem code_id t
 
-let find_exn t code_id =
-  match Code_id.Map.find code_id t with
-  | exception Not_found ->
-    Misc.fatal_errorf "Code ID %a not bound" Code_id.print code_id
-  | code_or_metadata -> code_or_metadata
+let find_exn t code_id = Code_id.Map.find code_id t
 
 let find t code_id =
   match Code_id.Map.find code_id t with
@@ -73,10 +69,17 @@ let find t code_id =
     None
   | code_or_metadata -> Some code_or_metadata
 
-let remove_unreachable t ~reachable_names =
+let remove_unreachable ~reachable_names t =
   Code_id.Map.filter
     (fun code_id _code_or_metadata ->
       Name_occurrences.mem_code_id reachable_names code_id)
+    t
+
+let remove_unused_closure_vars_from_result_types ~used_closure_vars t =
+  Code_id.Map.map
+    (fun code_or_metadata ->
+      Code_or_metadata.map_result_types code_or_metadata ~f:(fun result_ty ->
+          Flambda2_types.remove_unused_closure_vars result_ty ~used_closure_vars))
     t
 
 let all_ids_for_export t =

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -38,6 +38,9 @@ val find_exn : t -> Code_id.t -> Code_or_metadata.t
     be special handling if a code ID is unbound (see comment in the .ml file) *)
 val find : t -> Code_id.t -> Code_or_metadata.t option
 
-val remove_unreachable : t -> reachable_names:Name_occurrences.t -> t
+val remove_unreachable : reachable_names:Name_occurrences.t -> t -> t
+
+val remove_unused_closure_vars_from_result_types :
+  used_closure_vars:Var_within_closure.Set.t -> t -> t
 
 val iter_code : t -> f:(Code.t -> unit) -> unit

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1207,7 +1207,10 @@ let close_one_function acc ~external_env ~by_closure_id decl
   let code =
     Code.create code_id ~params_and_body
       ~free_names_of_params_and_body:(Acc.free_names acc) ~params_arity
-      ~result_arity:[LC.value_kind return] ~stub ~inline
+      ~result_arity:[LC.value_kind return]
+      ~result_types:
+        (Result_types.create_default ~params ~result_arity:[LC.value_kind return])
+      ~stub ~inline
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1209,7 +1209,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
       ~free_names_of_params_and_body:(Acc.free_names acc) ~params_arity
       ~result_arity:[LC.value_kind return]
       ~result_types:
-        (Result_types.create_default ~params ~result_arity:[LC.value_kind return])
+        (Result_types.create_unknown ~params ~result_arity:[LC.value_kind return])
       ~stub ~inline
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~recursive ~newer_version_of:None ~cost_metrics

--- a/middle_end/flambda2/identifiers/rec_info_expr0.ml
+++ b/middle_end/flambda2/identifiers/rec_info_expr0.ml
@@ -72,6 +72,8 @@ module type S = sig
   val hash : t -> int
 
   val map_depth_variables : t -> f:(variable -> variable) -> t
+
+  val erase_variables : t -> t
 end
 
 module Make (Variable : Container_types.S) : S with type variable = Variable.t =
@@ -209,5 +211,16 @@ struct
       if new_t0 == t0 then t else Succ new_t0
     | Unroll_to (depth, t0) ->
       let new_t0 = map_depth_variables t0 ~f in
+      if new_t0 == t0 then t else Unroll_to (depth, new_t0)
+
+  let rec erase_variables t =
+    match t with
+    | Const _ -> t
+    | Var _ -> unknown
+    | Succ t0 ->
+      let new_t0 = erase_variables t0 in
+      if new_t0 == t0 then t else Succ new_t0
+    | Unroll_to (depth, t0) ->
+      let new_t0 = erase_variables t0 in
       if new_t0 == t0 then t else Unroll_to (depth, new_t0)
 end

--- a/middle_end/flambda2/identifiers/rec_info_expr0.mli
+++ b/middle_end/flambda2/identifiers/rec_info_expr0.mli
@@ -82,6 +82,8 @@ module type S = sig
   val hash : t -> int
 
   val map_depth_variables : t -> f:(variable -> variable) -> t
+
+  val erase_variables : t -> t
 end
 
 module Make (Variable : Container_types.S) : S with type variable = Variable.t

--- a/middle_end/flambda2/nominal/name_abstraction.ml
+++ b/middle_end/flambda2/nominal/name_abstraction.ml
@@ -86,6 +86,20 @@ module Make (Bindable : Bindable.S) (Term : Term) = struct
 end
 [@@inline always]
 
+module Make_free_names
+    (Bindable : Bindable.S) (Term : sig
+      include Term
+
+      val free_names : t -> Name_occurrences.t
+    end) =
+struct
+  type nonrec t = (Bindable.t, Term.t) t
+
+  let free_names (bindable, term) =
+    Name_occurrences.diff (Term.free_names term) (Bindable.free_names bindable)
+end
+[@@inline always]
+
 module Make_matching_and_renaming
     (Bindable : Bindable.S) (Term : sig
       type t

--- a/middle_end/flambda2/nominal/name_abstraction.mli
+++ b/middle_end/flambda2/nominal/name_abstraction.mli
@@ -48,6 +48,17 @@ module Make (Bindable : Bindable.S) (Term : Term) : sig
   val apply_renaming : t -> Renaming.t -> t
 end
 
+module Make_free_names
+    (Bindable : Bindable.S) (Term : sig
+      include Term
+
+      val free_names : t -> Name_occurrences.t
+    end) : sig
+  type nonrec t = (Bindable.t, Term.t) t
+
+  val free_names : t -> Name_occurrences.t
+end
+
 module Make_matching_and_renaming
     (Bindable : Bindable.S) (Term : sig
       type t

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -750,7 +750,10 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           | None -> [Flambda_kind.With_subkind.any_value]
           | Some ar -> arity ar
         in
-        let params_and_body, free_names_of_params_and_body, is_my_closure_used =
+        let ( params,
+              params_and_body,
+              free_names_of_params_and_body,
+              is_my_closure_used ) =
           let { Fexpr.params; closure_var; depth_var; ret_cont; exn_cont; body }
               =
             params_and_body
@@ -797,7 +800,8 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
             (* Flambda.Function_params_and_body.free_names params_and_body |>
                names_and_closure_vars *)
           in
-          ( params_and_body,
+          ( params,
+            params_and_body,
             free_names,
             Flambda.Function_params_and_body.is_my_closure_used params_and_body
           )
@@ -812,8 +816,9 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         let code =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
-            ~newer_version_of ~params_arity ~result_arity ~stub:false ~inline
-            ~is_a_functor:false ~recursive
+            ~newer_version_of ~params_arity ~result_arity
+            ~result_types:(Result_types.create_default ~params ~result_arity)
+            ~stub:false ~inline ~is_a_functor:false ~recursive
             ~cost_metrics (* CR poechsel: grab inlining arguments from fexpr. *)
             ~inlining_arguments:(Inlining_arguments.create ~round:0)
             ~dbg:Debuginfo.none ~is_tupled ~is_my_closure_used

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -817,7 +817,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
             ~newer_version_of ~params_arity ~result_arity
-            ~result_types:(Result_types.create_default ~params ~result_arity)
+            ~result_types:(Result_types.create_unknown ~params ~result_arity)
             ~stub:false ~inline ~is_a_functor:false ~recursive
             ~cost_metrics (* CR poechsel: grab inlining arguments from fexpr. *)
             ~inlining_arguments:(Inlining_arguments.create ~round:0)

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -77,7 +77,11 @@ end = struct
   let find_exn t id =
     match find t id with
     | Some fexpr_id -> fexpr_id
-    | None -> Misc.fatal_errorf "missing %s %a" I.desc I.print id
+    | None ->
+      Misc.fatal_errorf "missing %s %a (known names: %a)" I.desc I.print id
+        (Format.pp_print_list ~pp_sep:Format.pp_print_space
+           Format.pp_print_string)
+        (String_map.bindings t.names |> List.map fst)
 end
 
 module Global_name_map (I : Convertible_id) : sig

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -134,13 +134,15 @@ val define_variable_and_extend_typing_environment :
   Flambda2_types.Typing_env_extension.t ->
   t
 
-type extension_kind =
-  | Normal of Flambda2_types.Typing_env_extension.t
-  | With_extra_variables of
-      Flambda2_types.Typing_env_extension.With_extra_variables.t
-
 val add_variable_and_extend_typing_environment :
-  t -> Bound_var.t -> Flambda2_types.t -> extension_kind -> t
+  t ->
+  Bound_var.t ->
+  Flambda2_types.t ->
+  Flambda2_types.Typing_env_extension.t ->
+  t
+
+val extend_typing_environment :
+  t -> Flambda2_types.Typing_env_extension.With_extra_variables.t -> t
 
 val with_typing_env : t -> Flambda2_types.Typing_env.t -> t
 

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -104,6 +104,7 @@ val add_equation_on_name : t -> Name.t -> Flambda2_types.t -> t
 val define_parameters : t -> params:Bound_parameter.t list -> t
 
 val add_parameters :
+  ?name_mode:Name_mode.t ->
   ?at_unit_toplevel:bool ->
   t ->
   Bound_parameter.t list ->
@@ -111,9 +112,14 @@ val add_parameters :
   t
 
 val add_parameters_with_unknown_types :
-  ?at_unit_toplevel:bool -> t -> Bound_parameter.t list -> t
+  ?name_mode:Name_mode.t ->
+  ?at_unit_toplevel:bool ->
+  t ->
+  Bound_parameter.t list ->
+  t
 
 val add_parameters_with_unknown_types' :
+  ?name_mode:Name_mode.t ->
   ?at_unit_toplevel:bool ->
   t ->
   Bound_parameter.t list ->
@@ -128,12 +134,13 @@ val define_variable_and_extend_typing_environment :
   Flambda2_types.Typing_env_extension.t ->
   t
 
+type extension_kind =
+  | Normal of Flambda2_types.Typing_env_extension.t
+  | With_extra_variables of
+      Flambda2_types.Typing_env_extension.With_extra_variables.t
+
 val add_variable_and_extend_typing_environment :
-  t ->
-  Bound_var.t ->
-  Flambda2_types.t ->
-  Flambda2_types.Typing_env_extension.t ->
-  t
+  t -> Bound_var.t -> Flambda2_types.t -> extension_kind -> t
 
 val with_typing_env : t -> Flambda2_types.Typing_env.t -> t
 

--- a/middle_end/flambda2/simplify/join_points.mli
+++ b/middle_end/flambda2/simplify/join_points.mli
@@ -21,6 +21,7 @@
 [@@@ocaml.warning "+a-30-40-41-42"]
 
 val compute_handler_env :
+  ?unknown_if_defined_at_or_later_than:Scope.t ->
   Continuation_uses.t ->
   env_at_fork_plus_params:Downwards_env.t ->
   consts_lifted_during_body:Lifted_constant_state.t ->

--- a/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
@@ -140,7 +140,7 @@ let add_to_denv ?maybe_already_defined denv lifted =
                    enclosing scope. *)
                 T.make_suitable_for_environment
                   (DE.typing_env denv_at_definition)
-                  typ (Everything_not_in typing_env) ~bind_to:sym
+                  (Everything_not_in typing_env) [sym, typ]
               in
               TE.add_env_extension_with_extra_variables typing_env env_extension)
           types_of_symbols typing_env)

--- a/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
@@ -140,7 +140,7 @@ let add_to_denv ?maybe_already_defined denv lifted =
                    enclosing scope. *)
                 T.make_suitable_for_environment
                   (DE.typing_env denv_at_definition)
-                  typ ~suitable_for:typing_env ~bind_to:sym
+                  typ (Everything_not_in typing_env) ~bind_to:sym
               in
               TE.add_env_extension_with_extra_variables typing_env env_extension)
           types_of_symbols typing_env)

--- a/middle_end/flambda2/simplify/non_constructed_code.ml
+++ b/middle_end/flambda2/simplify/non_constructed_code.ml
@@ -26,6 +26,8 @@ let params_arity = Code0.params_arity
 
 let result_arity = Code0.result_arity
 
+let result_types = Code0.result_types
+
 let stub = Code0.stub
 
 let inline = Code0.inline
@@ -47,14 +49,14 @@ let is_my_closure_used = Code0.is_my_closure_used
 let inlining_decision = Code0.inlining_decision
 
 let create code_id ~free_names_of_params_and_body ~newer_version_of
-    ~params_arity ~result_arity ~stub ~inline ~is_a_functor ~recursive
-    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
-    ~inlining_decision =
+    ~params_arity ~result_arity ~result_types ~stub ~inline ~is_a_functor
+    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
+    ~is_my_closure_used ~inlining_decision =
   Code0.create ~print_function_params_and_body:Unit.print code_id
     ~params_and_body:() ~free_names_of_params_and_body ~newer_version_of
-    ~params_arity ~result_arity ~stub ~inline ~is_a_functor ~recursive
-    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
-    ~inlining_decision
+    ~params_arity ~result_arity ~result_types ~stub ~inline ~is_a_functor
+    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
+    ~is_my_closure_used ~inlining_decision
 
 let print = Code0.print ~print_function_params_and_body:Unit.print
 

--- a/middle_end/flambda2/simplify/non_constructed_code.mli
+++ b/middle_end/flambda2/simplify/non_constructed_code.mli
@@ -29,6 +29,8 @@ val params_arity : t -> Flambda_arity.With_subkinds.t
 
 val result_arity : t -> Flambda_arity.With_subkinds.t
 
+val result_types : t -> Result_types.t
+
 val stub : t -> bool
 
 val inline : t -> Inline_attribute.t
@@ -55,6 +57,7 @@ val create :
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
   result_arity:Flambda_arity.With_subkinds.t ->
+  result_types:Result_types.t ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -56,14 +56,14 @@ let create_normal_non_code const =
 
 let create_code are_rebuilding code_id ~params_and_body
     ~free_names_of_params_and_body ~newer_version_of ~params_arity ~result_arity
-    ~stub ~inline ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments
-    ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision =
+    ~result_types ~stub ~inline ~is_a_functor ~recursive ~cost_metrics
+    ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision =
   if ART.do_not_rebuild_terms are_rebuilding
   then
     let non_constructed_code =
       Non_constructed_code.create code_id ~free_names_of_params_and_body
-        ~newer_version_of ~params_arity ~result_arity ~stub ~inline
-        ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg
+        ~newer_version_of ~params_arity ~result_arity ~result_types ~stub
+        ~inline ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg
         ~is_tupled ~is_my_closure_used ~inlining_decision
     in
     Code_not_rebuilt non_constructed_code
@@ -74,8 +74,8 @@ let create_code are_rebuilding code_id ~params_and_body
     in
     let code =
       Code.create code_id ~params_and_body ~free_names_of_params_and_body
-        ~newer_version_of ~params_arity ~result_arity ~stub ~inline
-        ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg
+        ~newer_version_of ~params_arity ~result_arity ~result_types ~stub
+        ~inline ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg
         ~is_tupled ~is_my_closure_used ~inlining_decision
     in
     Normal
@@ -325,7 +325,8 @@ module Group = struct
                ~free_names_of_params_and_body:Name_occurrences.empty
                ~newer_version_of:(NCC.newer_version_of code)
                ~params_arity:(NCC.params_arity code)
-               ~result_arity:(NCC.result_arity code) ~stub:(NCC.stub code)
+               ~result_arity:(NCC.result_arity code)
+               ~result_types:(NCC.result_types code) ~stub:(NCC.stub code)
                ~inline:(NCC.inline code) ~is_a_functor:(NCC.is_a_functor code)
                ~recursive:(NCC.recursive code)
                ~cost_metrics:(NCC.cost_metrics code)

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -36,6 +36,7 @@ val create_code :
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
   result_arity:Flambda_arity.With_subkinds.t ->
+  result_types:Result_types.t ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -121,7 +121,8 @@ let rebuild_non_inlined_direct_full_application apply ~use_id ~exn_cont_use_id
   after_rebuild expr uacc
 
 let simplify_direct_full_application ~simplify_expr dacc apply function_type
-    ~callee's_code_id ~result_arity ~down_to_up ~coming_from_indirect =
+    ~callee's_code_id ~params_arity ~result_arity ~result_types ~down_to_up
+    ~coming_from_indirect =
   let inlined =
     (* CR mshinwell for poechsel: Make sure no other warnings or inlining report
        decisions get emitted when not rebuilding terms. *)
@@ -168,13 +169,58 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
       match Apply.continuation apply with
       | Never_returns -> dacc, None
       | Return apply_return_continuation ->
-        let dacc, use_id =
-          DA.record_continuation_use dacc apply_return_continuation
-            (Non_inlinable { escaping = true })
-            ~env_at_use:(DA.denv dacc)
-            ~arg_types:(T.unknown_types_from_arity_with_subkinds result_arity)
-        in
-        dacc, Some use_id
+        Result_types.pattern_match result_types ~f:(fun ~params ~results ->
+            if List.compare_lengths params_arity params <> 0
+            then
+              Misc.fatal_errorf
+                "Params arity %a does not match up with params in the result \
+                 types structure:@ %a@ for application:@ %a"
+                Flambda_arity.With_subkinds.print params_arity
+                Result_types.print result_types Apply.print apply;
+            if List.compare_lengths result_arity results <> 0
+            then
+              Misc.fatal_errorf
+                "Result arity %a does not match up with the result types \
+                 structure:@ %a@ for application:@ %a"
+                Flambda_arity.With_subkinds.print params_arity
+                Result_types.print result_types Apply.print apply;
+            let denv = DA.denv dacc in
+            let denv =
+              DE.add_parameters_with_unknown_types ~name_mode:Name_mode.in_types
+                denv params
+            in
+            let denv =
+              let args = Apply.args apply in
+              assert (List.compare_lengths params args = 0);
+              List.fold_left2
+                (fun denv param arg ->
+                  DE.add_equation_on_variable denv (BP.var param)
+                    (T.alias_type_of (K.With_subkind.kind (BP.kind param)) arg))
+                denv params args
+            in
+            let denv =
+              List.fold_left2
+                (fun denv kind (result, env_extension) ->
+                  DE.add_variable_and_extend_typing_environment denv
+                    (VB.create (BP.var result) NM.in_types)
+                    (T.unknown_with_subkind kind)
+                    (With_extra_variables env_extension))
+                denv result_arity results
+            in
+            let arg_types =
+              List.map2
+                (fun kind (result_var, _env_extension) ->
+                  T.alias_type_of (K.With_subkind.kind kind)
+                    (BP.simple result_var))
+                result_arity results
+            in
+            let dacc = DA.with_denv dacc denv in
+            let dacc, use_id =
+              DA.record_continuation_use dacc apply_return_continuation
+                (Non_inlinable { escaping = true })
+                ~env_at_use:(DA.denv dacc) ~arg_types
+            in
+            dacc, Some use_id)
     in
     let dacc, exn_cont_use_id =
       DA.record_continuation_use dacc
@@ -191,8 +237,8 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
            ~exn_cont_use_id ~result_arity ~coming_from_indirect)
 
 let simplify_direct_partial_application ~simplify_expr dacc apply
-    ~callee's_code_id ~callee's_closure_id ~param_arity ~result_arity ~recursive
-    ~down_to_up ~coming_from_indirect =
+    ~callee's_code_id ~callee's_closure_id ~param_arity ~result_arity
+    ~result_types ~recursive ~down_to_up ~coming_from_indirect =
   (* For simplicity, we disallow [@inline] attributes on partial applications.
      The user may always write an explicit wrapper instead with such an
      attribute. *)
@@ -235,11 +281,6 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         arg)
       args param_arity
   in
-  if not (Flambda_arity.With_subkinds.is_singleton_value result_arity)
-  then
-    Misc.fatal_errorf
-      "Partially-applied function with non-[value] return kind: %a" Apply.print
-      apply;
   let wrapper_var = Variable.create "partial_app" in
   let compilation_unit = Compilation_unit.get_current_exn () in
   let wrapper_closure_id =
@@ -376,8 +417,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         Code.create code_id ~params_and_body
           ~free_names_of_params_and_body:free_names ~newer_version_of:None
           ~params_arity:(BP.List.arity_with_subkinds remaining_params)
-          ~result_arity ~stub:true ~inline:Default_inline ~is_a_functor:false
-          ~recursive ~cost_metrics:cost_metrics_of_body
+          ~result_arity ~result_types ~stub:true ~inline:Default_inline
+          ~is_a_functor:false ~recursive ~cost_metrics:cost_metrics_of_body
           ~inlining_arguments:(DE.inlining_arguments (DA.denv dacc))
           ~dbg ~is_tupled:false
           ~is_my_closure_used:
@@ -474,8 +515,8 @@ let simplify_direct_over_application ~simplify_expr dacc apply ~param_arity
 
 let simplify_direct_function_call ~simplify_expr dacc apply
     ~callee's_code_id_from_type ~callee's_code_id_from_call_kind
-    ~callee's_closure_id ~result_arity ~recursive ~arg_types:_ ~must_be_detupled
-    function_decl ~down_to_up =
+    ~callee's_closure_id ~result_arity ~result_types ~recursive ~arg_types:_
+    ~must_be_detupled function_decl ~down_to_up =
   begin
     match Apply.probe_name apply, Apply.inlined apply with
     | None, _ | Some _, Never_inlined -> ()
@@ -545,7 +586,8 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       if provided_num_args = num_params
       then
         simplify_direct_full_application ~simplify_expr dacc apply function_decl
-          ~callee's_code_id ~result_arity ~down_to_up ~coming_from_indirect
+          ~callee's_code_id ~params_arity ~result_arity ~result_types
+          ~down_to_up ~coming_from_indirect
       else if provided_num_args > num_params
       then
         simplify_direct_over_application ~simplify_expr dacc apply
@@ -555,7 +597,8 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       then
         simplify_direct_partial_application ~simplify_expr dacc apply
           ~callee's_code_id ~callee's_closure_id ~param_arity:params_arity
-          ~result_arity ~recursive ~down_to_up ~coming_from_indirect
+          ~result_arity ~result_types ~recursive ~down_to_up
+          ~coming_from_indirect
       else
         Misc.fatal_errorf
           "Function with %d params when simplifying direct OCaml function call \
@@ -735,6 +778,7 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
       ~callee's_code_id_from_type ~callee's_code_id_from_call_kind
       ~callee's_closure_id ~arg_types
       ~result_arity:(Code_metadata.result_arity callee's_code_metadata)
+      ~result_types:(Code_metadata.result_types callee's_code_metadata)
       ~recursive:(Code_metadata.recursive callee's_code_metadata)
       ~must_be_detupled func_decl_type ~down_to_up
   | Unknown -> type_unavailable ()

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -132,11 +132,12 @@ end = struct
       ~closure_element_types_inside_functions_all_sets
       ~old_to_new_code_ids_all_sets =
     let closure_bound_names_all_sets_inside =
-      (* When not lifting (i.e. the bound names are variables), we need to
+      (* When not lifting (i.e. the bound names are variables), we used to
          create a fresh set of irrelevant variables, since the let-bound names
-         are not in scope for the closure definition(s). *)
-      (* List.map (fun closure_bound_names -> Closure_id.Map.map_sharing
-         Bound_name.rename closure_bound_names) *)
+         are not in scope for the closure definition(s). However instead we now
+         actually use the same names, which will be bound at [In_types] mode,
+         and suitably captured by a name abstraction if they escape via function
+         result types. *)
       closure_bound_names_all_sets
     in
     let closure_types_via_aliases_all_sets =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -617,7 +617,7 @@ let simplify_function0 context ~used_closure_vars ~shareable_constants
   in
   let is_a_functor = Code.is_a_functor code in
   let result_types =
-    if not is_a_functor
+    if not (Flambda_features.function_result_types ~is_a_functor)
     then default_result_types
     else
       match return_cont_uses with

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -881,18 +881,7 @@ let simplify_set_of_closures0 context set_of_closures ~closure_bound_names
              (fun bound_name closure_type denv ->
                let bound_name = Bound_name.to_name bound_name in
                DE.add_equation_on_name denv bound_name closure_type)
-             closure_types_by_bound_name
-        (* |> Closure_id.Map.fold (fun closure_id inside_name denv -> let
-           inside_name = Bound_name.name inside_name in match
-           Closure_id.Map.find closure_id closure_bound_names with | exception
-           Not_found -> Misc.fatal_errorf "Closure ID %a not found in
-           outside-function map:@ %a" Closure_id.print closure_id
-           (Closure_id.Map.print Bound_name.print) closure_bound_names_inside |
-           outside_name -> let outside_name = Bound_name.name outside_name in (*
-           In the case of lifted sets of closures, the inside and outside names
-           are the same symbols. *) if Name.equal inside_name outside_name then
-           denv else DE.add_equation_on_name denv inside_name (T.alias_type_of
-           K.value (Simple.name outside_name))) closure_bound_names_inside*))
+             closure_types_by_bound_name)
   in
   let set_of_closures =
     Function_declarations.create all_function_decls_in_set

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -111,7 +111,7 @@ end = struct
         in
         let env_extension =
           T.make_suitable_for_environment env_prior_to_sets type_prior_to_sets
-            ~suitable_for:env_inside_function ~bind_to:(Name.var var)
+            (Everything_not_in env_inside_function) ~bind_to:(Name.var var)
         in
         let env_inside_function =
           TE.add_env_extension_with_extra_variables env_inside_function
@@ -426,7 +426,8 @@ type simplify_function_result =
   { new_code_id : Code_id.t;
     code : Rebuilt_static_const.t option;
     dacc_after_body : DA.t option;
-    uacc_after_upwards_traversal : UA.t option
+    uacc_after_upwards_traversal : UA.t option;
+    lifted_consts_this_function : LCS.t
   }
 
 let simplify_function0 context ~used_closure_vars ~shareable_constants
@@ -447,9 +448,20 @@ let simplify_function0 context ~used_closure_vars ~shareable_constants
       (Code.inlining_arguments code)
       inlining_arguments_from_denv
   in
-  let ( params_and_body,
+  let result_arity = Code.result_arity code in
+  let return_cont_params =
+    List.mapi
+      (fun i kind_with_subkind ->
+        BP.create
+          (Variable.create ("result" ^ string_of_int i))
+          kind_with_subkind)
+      result_arity
+  in
+  let ( params,
+        params_and_body,
         dacc_after_body,
         free_names_of_code,
+        return_cont_uses,
         uacc_after_upwards_traversal ) =
     Function_params_and_body.pattern_match (Code.params_and_body code)
       ~f:(fun
@@ -483,6 +495,8 @@ let simplify_function0 context ~used_closure_vars ~shareable_constants
                      in
                      TE.with_code_age_relation typing_env code_age_relation)
               |> fun denv ->
+              DE.add_parameters_with_unknown_types denv return_cont_params
+              |> fun denv ->
               (* Lifted constants from previous functions in the set get put
                  into the environment for subsequent functions. *)
               LCS.add_to_denv denv lifted_consts_prev_functions)
@@ -496,7 +510,11 @@ let simplify_function0 context ~used_closure_vars ~shareable_constants
         with
         | body, uacc ->
           let dacc_after_body = UA.creation_dacc uacc in
-          (* CR mshinwell: Should probably look at [cont_uses]? *)
+          let return_cont_uses =
+            CUE.get_continuation_uses
+              (DA.continuation_uses_env dacc_after_body)
+              return_continuation
+          in
           let free_names_of_body = UA.name_occurrences uacc in
           let params_and_body =
             RE.Function_params_and_body.create ~free_names_of_body
@@ -542,7 +560,12 @@ let simplify_function0 context ~used_closure_vars ~shareable_constants
               Variable.print my_depth
               (RE.print (UA.are_rebuilding_terms uacc))
               body;
-          params_and_body, dacc_after_body, free_names_of_code, uacc
+          ( params,
+            params_and_body,
+            dacc_after_body,
+            free_names_of_code,
+            return_cont_uses,
+            uacc )
         | exception Misc.Fatal_error ->
           let bt = Printexc.get_raw_backtrace () in
           Format.eprintf
@@ -578,24 +601,95 @@ let simplify_function0 context ~used_closure_vars ~shareable_constants
       ~dbg;
     decision
   in
+  let lifted_consts_this_function =
+    (* Subtle point: [uacc_after_upwards_traversal] must be used to retrieve all
+       of the lifted constants generated during the simplification of the
+       function, not [dacc_after_body]. The reason for this is that sometimes
+       the constants in [DA] are cleared (but remembered) and reinstated
+       afterwards, for example at a [Let_cont]. It follows that if the turning
+       point where the downwards traversal turns into an upwards traversal is in
+       such a context, not all of the constants may currently be present in
+       [DA]. *)
+    UA.lifted_constants uacc_after_upwards_traversal
+  in
+  let default_result_types =
+    Result_types.create_default ~params ~result_arity
+  in
+  let is_a_functor = Code.is_a_functor code in
+  let result_types =
+    if not is_a_functor
+    then default_result_types
+    else
+      match return_cont_uses with
+      | None -> default_result_types
+      | Some uses -> (
+        (* CR mshinwell: Should we meet the result types with the arity? Also at
+           applications? *)
+        let code_age_relation_after_function =
+          TE.code_age_relation (DA.typing_env dacc_after_body)
+        in
+        let env_at_fork_plus_params =
+          (* We use [C.dacc_inside_functions] not [C.dacc_prior_to_sets] to
+             ensure that the environment contains bindings for any symbols being
+             defined by the set of closures. *)
+          DE.add_parameters_with_unknown_types
+            (DA.denv (C.dacc_inside_functions context))
+            return_cont_params
+        in
+        let join =
+          let consts_lifted_during_body =
+            LCS.union lifted_consts_prev_functions lifted_consts_this_function
+          in
+          Join_points.compute_handler_env
+            ~unknown_if_defined_at_or_later_than:
+              (DE.get_continuation_scope env_at_fork_plus_params)
+            uses ~params:return_cont_params ~env_at_fork_plus_params
+            ~consts_lifted_during_body
+            ~code_age_relation_after_body:code_age_relation_after_function
+        in
+        match join with
+        | No_uses -> default_result_types
+        | Uses { handler_env; _ } ->
+          let params_and_results =
+            BP.List.var_set (params @ return_cont_params)
+          in
+          let results =
+            List.map
+              (fun result ->
+                let typing_env = DE.typing_env handler_env in
+                let ty =
+                  TE.find typing_env (BP.name result)
+                    (Some (K.With_subkind.kind (BP.kind result)))
+                in
+                let env_extension =
+                  T.make_suitable_for_environment typing_env ty
+                    (All_variables_except params_and_results)
+                    ~bind_to:(BP.name result)
+                in
+                result, env_extension)
+              return_cont_params
+          in
+          Result_types.create ~params ~results)
+  in
   let code =
     Rebuilt_static_const.create_code
       (DA.are_rebuilding_terms dacc_after_body)
       new_code_id ~params_and_body
       ~free_names_of_params_and_body:free_names_of_code
       ~newer_version_of:(Some old_code_id)
-      ~params_arity:(Code.params_arity code)
-      ~result_arity:(Code.result_arity code) ~stub:(Code.stub code)
-      ~inline:(Code.inline code) ~is_a_functor:(Code.is_a_functor code)
-      ~recursive:(Code.recursive code) ~cost_metrics ~inlining_arguments
-      ~dbg:(Code.dbg code) ~is_tupled:(Code.is_tupled code)
+      ~params_arity:(Code.params_arity code) ~result_arity ~result_types
+      ~stub:(Code.stub code) ~inline:(Code.inline code)
+      ~is_a_functor:(Code.is_a_functor code) ~recursive:(Code.recursive code)
+      ~cost_metrics ~inlining_arguments ~dbg:(Code.dbg code)
+      ~is_tupled:(Code.is_tupled code)
       ~is_my_closure_used:(Code.is_my_closure_used code)
       ~inlining_decision
   in
   { new_code_id;
     code = Some code;
     dacc_after_body = Some dacc_after_body;
-    uacc_after_upwards_traversal = Some uacc_after_upwards_traversal
+    uacc_after_upwards_traversal = Some uacc_after_upwards_traversal;
+    lifted_consts_this_function
   }
 
 let simplify_function context ~used_closure_vars ~shareable_constants
@@ -613,7 +707,8 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     { new_code_id = code_id;
       code = None;
       dacc_after_body = None;
-      uacc_after_upwards_traversal = None
+      uacc_after_upwards_traversal = None;
+      lifted_consts_this_function = LCS.empty
     }
 
 type simplify_set_of_closures0_result =
@@ -656,7 +751,8 @@ let simplify_set_of_closures0 context set_of_closures ~closure_bound_names
         let { new_code_id;
               code = new_code;
               dacc_after_body;
-              uacc_after_upwards_traversal
+              uacc_after_upwards_traversal;
+              lifted_consts_this_function
             } =
           simplify_function context ~used_closure_vars ~shareable_constants
             ~closure_offsets closure_id old_code_id
@@ -670,20 +766,6 @@ let simplify_set_of_closures0 context set_of_closures ~closure_bound_names
             T.this_rec_info Rec_info_expr.initial
           in
           function_decl_type new_code_id rec_info
-        in
-        let lifted_consts_this_function =
-          (* Subtle point: [uacc_after_upwards_traversal] must be used to
-             retrieve all of the lifted constants generated during the
-             simplification of the function, not [dacc_after_body]. The reason
-             for this is that sometimes the constants in [DA] are cleared (but
-             remembered) and reinstated afterwards, for example at a [Let_cont].
-             It follows that if the turning point where the downwards traversal
-             turns into an upwards traversal is in such a context, not all of
-             the constants may currently be present in [DA]. *)
-          match uacc_after_upwards_traversal with
-          | None -> LCS.empty
-          | Some uacc_after_upwards_traversal ->
-            UA.lifted_constants uacc_after_upwards_traversal
         in
         let result_function_decls_in_set =
           (closure_id, new_code_id) :: result_function_decls_in_set
@@ -792,7 +874,9 @@ let simplify_set_of_closures0 context set_of_closures ~closure_bound_names
      [T.make_suitable_for_environment] would be needed here, as the return types
      could name the irrelevant variables bound to the closures. (We could
      further add equalities between those irrelevant variables and the bound
-     closure variables themselves.) *)
+     closure variables themselves.)
+
+     mshinwell: first half fixed, see above where [Code] is created. *)
   let dacc =
     DA.map_denv dacc ~f:(fun denv ->
         denv

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -612,16 +612,13 @@ let simplify_function0 context ~used_closure_vars ~shareable_constants
        [DA]. *)
     UA.lifted_constants uacc_after_upwards_traversal
   in
-  let default_result_types =
-    Result_types.create_default ~params ~result_arity
-  in
   let is_a_functor = Code.is_a_functor code in
   let result_types =
     if not (Flambda_features.function_result_types ~is_a_functor)
-    then default_result_types
+    then Result_types.create_unknown ~params ~result_arity
     else
       match return_cont_uses with
-      | None -> default_result_types
+      | None -> Result_types.create_bottom ~params ~result_arity
       | Some uses -> (
         (* CR mshinwell: Should we meet the result types with the arity? Also at
            applications? *)
@@ -648,7 +645,7 @@ let simplify_function0 context ~used_closure_vars ~shareable_constants
             ~code_age_relation_after_body:code_age_relation_after_function
         in
         match join with
-        | No_uses -> default_result_types
+        | No_uses -> assert false (* should have been caught above *)
         | Uses { handler_env; _ } ->
           let params_and_results =
             BP.List.var_set (params @ return_cont_params)

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -166,7 +166,7 @@ let simplify_make_array dacc dbg (array_kind : P.Array_kind.t)
     let dacc =
       DA.map_denv dacc ~f:(fun denv ->
           DE.add_variable_and_extend_typing_environment denv result_var ty
-            (Normal env_extension))
+            env_extension)
     in
     Simplified_named.reachable named ~try_reify:true, dacc
 

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -166,7 +166,7 @@ let simplify_make_array dacc dbg (array_kind : P.Array_kind.t)
     let dacc =
       DA.map_denv dacc ~f:(fun denv ->
           DE.add_variable_and_extend_typing_environment denv result_var ty
-            env_extension)
+            (Normal env_extension))
     in
     Simplified_named.reachable named ~try_reify:true, dacc
 

--- a/middle_end/flambda2/terms/code.ml
+++ b/middle_end/flambda2/terms/code.ml
@@ -30,6 +30,8 @@ let params_arity = Code0.params_arity
 
 let result_arity = Code0.result_arity
 
+let result_types = Code0.result_types
+
 let stub = Code0.stub
 
 let inline = Code0.inline
@@ -51,15 +53,15 @@ let is_my_closure_used = Code0.is_my_closure_used
 let inlining_decision = Code0.inlining_decision
 
 let create code_id ~params_and_body ~free_names_of_params_and_body
-    ~newer_version_of ~params_arity ~result_arity ~stub ~inline ~is_a_functor
-    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
+    ~newer_version_of ~params_arity ~result_arity ~result_types ~stub ~inline
+    ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
     ~is_my_closure_used ~inlining_decision =
   Code0.create
     ~print_function_params_and_body:Flambda.Function_params_and_body.print
     code_id ~params_and_body ~free_names_of_params_and_body ~newer_version_of
-    ~params_arity ~result_arity ~stub ~inline ~is_a_functor ~recursive
-    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
-    ~inlining_decision
+    ~params_arity ~result_arity ~result_types ~stub ~inline ~is_a_functor
+    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
+    ~is_my_closure_used ~inlining_decision
 
 let with_code_id = Code0.with_code_id
 
@@ -84,3 +86,5 @@ let all_ids_for_export =
   Code0.all_ids_for_export
     ~all_ids_for_export_function_params_and_body:
       Flambda.Function_params_and_body.all_ids_for_export
+
+let map_result_types = Code0.map_result_types

--- a/middle_end/flambda2/terms/code.mli
+++ b/middle_end/flambda2/terms/code.mli
@@ -34,6 +34,8 @@ val params_arity : t -> Flambda_arity.With_subkinds.t
 
 val result_arity : t -> Flambda_arity.With_subkinds.t
 
+val result_types : t -> Result_types.t
+
 val stub : t -> bool
 
 val inline : t -> Inline_attribute.t
@@ -61,6 +63,7 @@ val create :
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
   result_arity:Flambda_arity.With_subkinds.t ->
+  result_types:Result_types.t ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->
@@ -89,3 +92,5 @@ val print : Format.formatter -> t -> unit
 include Contains_names.S with type t := t
 
 val all_ids_for_export : t -> Ids_for_export.t
+
+val map_result_types : t -> f:(Flambda2_types.t -> Flambda2_types.t) -> t

--- a/middle_end/flambda2/terms/code0.ml
+++ b/middle_end/flambda2/terms/code0.ml
@@ -34,6 +34,8 @@ let params_arity t = Code_metadata.params_arity t.code_metadata
 
 let result_arity t = Code_metadata.result_arity t.code_metadata
 
+let result_types t = Code_metadata.result_types t.code_metadata
+
 let stub t = Code_metadata.stub t.code_metadata
 
 let inline t = Code_metadata.inline t.code_metadata
@@ -67,8 +69,9 @@ let check_free_names_of_params_and_body ~print_function_params_and_body code_id
 
 let create ~print_function_params_and_body code_id ~params_and_body
     ~free_names_of_params_and_body ~newer_version_of ~params_arity ~result_arity
-    ~stub ~(inline : Inline_attribute.t) ~is_a_functor ~recursive ~cost_metrics
-    ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision =
+    ~result_types ~stub ~(inline : Inline_attribute.t) ~is_a_functor ~recursive
+    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
+    ~inlining_decision =
   begin
     match stub, inline with
     | true, (Available_inline | Never_inline | Default_inline)
@@ -84,8 +87,8 @@ let create ~print_function_params_and_body code_id ~params_and_body
     ~params_and_body ~free_names_of_params_and_body;
   let code_metadata =
     Code_metadata.create code_id ~newer_version_of ~params_arity ~result_arity
-      ~stub ~inline ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments
-      ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision
+      ~result_types ~stub ~inline ~is_a_functor ~recursive ~cost_metrics
+      ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision
   in
   { params_and_body; free_names_of_params_and_body; code_metadata }
 
@@ -147,3 +150,6 @@ let all_ids_for_export ~all_ids_for_export_function_params_and_body
   Ids_for_export.union
     (Code_metadata.all_ids_for_export code_metadata)
     params_and_body_ids
+
+let map_result_types ({ code_metadata; _ } as t) ~f =
+  { t with code_metadata = Code_metadata.map_result_types code_metadata ~f }

--- a/middle_end/flambda2/terms/code0.mli
+++ b/middle_end/flambda2/terms/code0.mli
@@ -30,6 +30,8 @@ val params_arity : 'function_params_and_body t -> Flambda_arity.With_subkinds.t
 
 val result_arity : 'function_params_and_body t -> Flambda_arity.With_subkinds.t
 
+val result_types : 'function_params_and_body t -> Result_types.t
+
 val stub : 'function_params_and_body t -> bool
 
 val inline : 'function_params_and_body t -> Inline_attribute.t
@@ -60,6 +62,7 @@ val create :
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
   result_arity:Flambda_arity.With_subkinds.t ->
+  result_types:Result_types.t ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->
@@ -110,3 +113,8 @@ val all_ids_for_export :
   Ids_for_export.t
 
 val compare : 'function_params_and_body t -> 'function_params_and_body t -> int
+
+val map_result_types :
+  'function_params_and_body t ->
+  f:(Flambda2_types.t -> Flambda2_types.t) ->
+  'function_params_and_body t

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -26,6 +26,8 @@ val params_arity : t -> Flambda_arity.With_subkinds.t
 
 val result_arity : t -> Flambda_arity.With_subkinds.t
 
+val result_types : t -> Result_types.t
+
 val stub : t -> bool
 
 val inline : t -> Inline_attribute.t
@@ -51,6 +53,7 @@ val create :
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
   result_arity:Flambda_arity.With_subkinds.t ->
+  result_types:Result_types.t ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->
@@ -71,8 +74,12 @@ val with_cost_metrics : Cost_metrics.t -> t -> t
 
 val print : Format.formatter -> t -> unit
 
+(** [free_names] does not return occurrences of closure vars inside the
+    [result_types]. *)
 include Contains_names.S with type t := t
 
 val all_ids_for_export : t -> Ids_for_export.t
 
-val equal : t -> t -> bool
+val approx_equal : t -> t -> bool
+
+val map_result_types : t -> f:(Flambda2_types.t -> Flambda2_types.t) -> t

--- a/middle_end/flambda2/terms/code_or_metadata.ml
+++ b/middle_end/flambda2/terms/code_or_metadata.ml
@@ -33,7 +33,7 @@ let create code = Code_present code
 let merge code_id t1 t2 =
   match t1, t2 with
   | Metadata_only cm1, Metadata_only cm2 ->
-    if Code_metadata.equal cm1 cm2
+    if Code_metadata.approx_equal cm1 cm2
     then Some t1
     else
       Misc.fatal_errorf
@@ -45,7 +45,7 @@ let merge code_id t1 t2 =
   | Metadata_only cm_imported, (Code_present code_present as t)
   | (Code_present code_present as t), Metadata_only cm_imported ->
     let cm_present = Code.code_metadata code_present in
-    if Code_metadata.equal cm_present cm_imported
+    if Code_metadata.approx_equal cm_present cm_imported
     then Some t
     else
       Misc.fatal_errorf
@@ -86,6 +86,12 @@ let code_metadata t =
 
 let iter_code t ~f =
   match t with Code_present code -> f code | Metadata_only _ -> ()
+
+let map_result_types t ~f =
+  match t with
+  | Code_present code -> Code_present (Code.map_result_types code ~f)
+  | Metadata_only code_metadata ->
+    Metadata_only (Code_metadata.map_result_types code_metadata ~f)
 
 let code_present t =
   match t with Code_present _ -> true | Metadata_only _ -> false

--- a/middle_end/flambda2/terms/dune
+++ b/middle_end/flambda2/terms/dune
@@ -24,6 +24,8 @@
    -open
    Flambda2_term_basics
    -open
+   Flambda2_types
+   -open
    Flambda2_ui))
  (ocamlopt_flags
   (:standard -O3))
@@ -38,4 +40,5 @@
   flambda2_nominal
   flambda2_numbers
   flambda2_term_basics
+  flambda2_types
   flambda2_ui))

--- a/middle_end/flambda2/terms/result_types.ml
+++ b/middle_end/flambda2/terms/result_types.ml
@@ -157,7 +157,7 @@ let create ~params ~results =
   let bound = { Bound.params; results; other_vars } in
   A.create bound env_extensions
 
-let create_default ~params ~result_arity =
+let create_trivial ~params ~result_arity create_type =
   let results =
     List.mapi
       (fun i kind_with_subkind ->
@@ -170,12 +170,19 @@ let create_default ~params ~result_arity =
           T.Typing_env_extension.With_extra_variables.add_or_replace_equation
             T.Typing_env_extension.With_extra_variables.empty
             (Bound_parameter.name bound_parameter)
-            (T.unknown_with_subkind kind_with_subkind)
+            (create_type kind_with_subkind)
         in
         bound_parameter, env_extension)
       result_arity
   in
   create ~params ~results
+
+let create_unknown ~params ~result_arity =
+  create_trivial ~params ~result_arity T.unknown_with_subkind
+
+let create_bottom ~params ~result_arity =
+  create_trivial ~params ~result_arity (fun kind_with_subkind ->
+      T.bottom (Flambda_kind.With_subkind.kind kind_with_subkind))
 
 let pattern_match t ~f =
   A.pattern_match t

--- a/middle_end/flambda2/terms/result_types.ml
+++ b/middle_end/flambda2/terms/result_types.ml
@@ -1,0 +1,200 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2022 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+module T = Flambda2_types
+
+module Bound = struct
+  type t =
+    { params : Bound_parameter.List.t;
+      results : Bound_parameter.List.t;
+      other_vars : Variable.t list
+    }
+
+  let free_names { params; results; other_vars } =
+    let free_names =
+      Name_occurrences.union
+        (Bound_parameter.List.free_names params)
+        (Bound_parameter.List.free_names results)
+    in
+    List.fold_left
+      (fun free_names var ->
+        Name_occurrences.add_variable free_names var Name_mode.in_types)
+      free_names other_vars
+
+  let apply_renaming { params; results; other_vars } renaming =
+    let params = Bound_parameter.List.apply_renaming params renaming in
+    let results = Bound_parameter.List.apply_renaming results renaming in
+    let other_vars =
+      List.map (fun var -> Renaming.apply_variable renaming var) other_vars
+    in
+    { params; results; other_vars }
+
+  let all_ids_for_export { params; results; other_vars } =
+    let ids =
+      Ids_for_export.union
+        (Bound_parameter.List.all_ids_for_export params)
+        (Bound_parameter.List.all_ids_for_export results)
+    in
+    List.fold_left
+      (fun ids var -> Ids_for_export.add_variable ids var)
+      ids other_vars
+
+  let rename { params; results; other_vars } =
+    let params = Bound_parameter.List.rename params in
+    let results = Bound_parameter.List.rename results in
+    let other_vars = List.map (fun var -> Variable.rename var) other_vars in
+    { params; results; other_vars }
+
+  let print ppf { params; results; other_vars } =
+    Format.fprintf ppf
+      "@[<hov 1>(@[<hov 1>(params@ (%a))@]@ @[<hov 1>(results@ (%a))@]@ @[<hov \
+       1>(other_vars@ (%a))@])@]"
+      Bound_parameter.List.print params Bound_parameter.List.print results
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space Variable.print)
+      other_vars
+
+  let name_permutation { params; results; other_vars }
+      ~guaranteed_fresh:
+        { params = fresh_params;
+          results = fresh_results;
+          other_vars = fresh_other_vars
+        } =
+    if List.compare_lengths params fresh_params <> 0
+       || List.compare_lengths results fresh_results <> 0
+       || List.compare_lengths other_vars fresh_other_vars <> 0
+    then Misc.fatal_error "Mismatching params/results/other-vars list lengths";
+    let renaming =
+      List.fold_left2
+        (fun renaming param fresh_param ->
+          Renaming.add_fresh_variable renaming
+            (Bound_parameter.var param)
+            ~guaranteed_fresh:(Bound_parameter.var fresh_param))
+        Renaming.empty params fresh_params
+    in
+    let renaming =
+      List.fold_left2
+        (fun renaming result fresh_result ->
+          Renaming.add_fresh_variable renaming
+            (Bound_parameter.var result)
+            ~guaranteed_fresh:(Bound_parameter.var fresh_result))
+        renaming results fresh_results
+    in
+    List.fold_left2
+      (fun renaming other_var fresh_other_var ->
+        Renaming.add_fresh_variable renaming other_var
+          ~guaranteed_fresh:fresh_other_var)
+      renaming other_vars fresh_other_vars
+end
+
+module Result_env_extensions = struct
+  type t = T.Typing_env_extension.With_extra_variables.t list
+
+  let apply_renaming t renaming =
+    List.map
+      (fun env_extension ->
+        T.Typing_env_extension.With_extra_variables.apply_renaming env_extension
+          renaming)
+      t
+
+  let free_names t =
+    List.map T.Typing_env_extension.With_extra_variables.free_names t
+    |> Name_occurrences.union_list
+
+  let all_ids_for_export t =
+    List.map T.Typing_env_extension.With_extra_variables.all_ids_for_export t
+    |> Ids_for_export.union_list
+end
+
+module A = Name_abstraction.Make (Bound) (Result_env_extensions)
+module FN = Name_abstraction.Make_free_names (Bound) (Result_env_extensions)
+
+type t = A.t
+
+let print ppf t =
+  let { Bound.params; results; other_vars }, env_extensions =
+    Name_abstraction.peek_for_printing t
+  in
+  let results = List.combine results env_extensions in
+  Format.fprintf ppf
+    "@[<hov 1>(@[<hov 1>(params@ (%a))@]@ @[<hov 1>(other_vars@ (%a))@]@ \
+     @[<hov 1>(results@ (%a))@])@]"
+    Bound_parameter.List.print params
+    (Format.pp_print_list ~pp_sep:Format.pp_print_space Variable.print)
+    other_vars
+    (Format.pp_print_list ~pp_sep:Format.pp_print_space
+       (fun ppf (result, env_extension) ->
+         Format.fprintf ppf
+           "@[<hov 1>(@[<hov 1>(result@ %a)@]@ @[<hov 1>(env_extension@ \
+            %a)@])@]"
+           Bound_parameter.print result
+           T.Typing_env_extension.With_extra_variables.print env_extension))
+    results
+
+let create ~params ~results =
+  let results, env_extensions = List.split results in
+  let other_vars =
+    List.fold_left
+      (fun other_vars env_extension ->
+        (T.Typing_env_extension.With_extra_variables.existential_vars
+           env_extension
+        |> Variable.Set.elements)
+        @ other_vars)
+      [] env_extensions
+  in
+  let bound = { Bound.params; results; other_vars } in
+  A.create bound env_extensions
+
+let create_default ~params ~result_arity =
+  let results =
+    List.mapi
+      (fun i kind_with_subkind ->
+        let bound_parameter =
+          Bound_parameter.create
+            (Variable.create ("result" ^ string_of_int i))
+            kind_with_subkind
+        in
+        let env_extension =
+          T.Typing_env_extension.With_extra_variables.add_or_replace_equation
+            T.Typing_env_extension.With_extra_variables.empty
+            (Bound_parameter.name bound_parameter)
+            (T.unknown_with_subkind kind_with_subkind)
+        in
+        bound_parameter, env_extension)
+      result_arity
+  in
+  create ~params ~results
+
+let pattern_match t ~f =
+  A.pattern_match t
+    ~f:(fun { Bound.params; results; other_vars = _ } env_extensions ->
+      let results = List.combine results env_extensions in
+      f ~params ~results)
+
+let free_names = FN.free_names
+
+let apply_renaming = A.apply_renaming
+
+let all_ids_for_export = A.all_ids_for_export
+
+let map_result_types t ~f =
+  A.pattern_match t
+    ~f:(fun { Bound.params; results; other_vars = _ } env_extensions ->
+      let env_extensions =
+        List.map
+          (T.Typing_env_extension.With_extra_variables.map_types ~f)
+          env_extensions
+      in
+      create ~params ~results:(List.combine results env_extensions))

--- a/middle_end/flambda2/terms/result_types.mli
+++ b/middle_end/flambda2/terms/result_types.mli
@@ -18,10 +18,8 @@ type t
 
 val create :
   params:Bound_parameter.t list ->
-  results:
-    (Bound_parameter.t
-    * Flambda2_types.Typing_env_extension.With_extra_variables.t)
-    list ->
+  results:Bound_parameter.t list ->
+  Flambda2_types.Typing_env_extension.With_extra_variables.t ->
   t
 
 val create_unknown :
@@ -38,10 +36,8 @@ val pattern_match :
   t ->
   f:
     (params:Bound_parameter.t list ->
-    results:
-      (Bound_parameter.t
-      * Flambda2_types.Typing_env_extension.With_extra_variables.t)
-      list ->
+    results:Bound_parameter.t list ->
+    Flambda2_types.Typing_env_extension.With_extra_variables.t ->
     'a) ->
   'a
 

--- a/middle_end/flambda2/terms/result_types.mli
+++ b/middle_end/flambda2/terms/result_types.mli
@@ -2,10 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Vincent Laviron, OCamlPro                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
 (*                                                                        *)
-(*   Copyright 2020 OCamlPro SAS                                          *)
-(*   Copyright 2014--2021 Jane Street Group LLC                           *)
+(*   Copyright 2022 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -15,28 +14,36 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-type t = private
-  | Code_present of Code.t
-  | Metadata_only of Code_metadata.t
+type t
 
-val print : Format.formatter -> t -> unit
+val create :
+  params:Bound_parameter.t list ->
+  results:
+    (Bound_parameter.t
+    * Flambda2_types.Typing_env_extension.With_extra_variables.t)
+    list ->
+  t
 
-val merge : Code_id.t -> t -> t -> t option
+val create_default :
+  params:Bound_parameter.t list ->
+  result_arity:Flambda_arity.With_subkinds.t ->
+  t
 
-val create : Code.t -> t
+val pattern_match :
+  t ->
+  f:
+    (params:Bound_parameter.t list ->
+    results:
+      (Bound_parameter.t
+      * Flambda2_types.Typing_env_extension.With_extra_variables.t)
+      list ->
+    'a) ->
+  'a
 
-val remember_only_metadata : t -> t
-
-val iter_code : t -> f:(Code.t -> unit) -> unit
-
-val map_result_types : t -> f:(Flambda2_types.t -> Flambda2_types.t) -> t
-
-val code_metadata : t -> Code_metadata.t
-
-val code_present : t -> bool
-
-(** As for [Code_metadata], the free names of a value of type [t] do not include
-    the code ID, which is only kept for convenience. *)
 include Contains_names.S with type t := t
 
 include Contains_ids.S with type t := t
+
+val print : Format.formatter -> t -> unit
+
+val map_result_types : t -> f:(Flambda2_types.t -> Flambda2_types.t) -> t

--- a/middle_end/flambda2/terms/result_types.mli
+++ b/middle_end/flambda2/terms/result_types.mli
@@ -24,7 +24,12 @@ val create :
     list ->
   t
 
-val create_default :
+val create_unknown :
+  params:Bound_parameter.t list ->
+  result_arity:Flambda_arity.With_subkinds.t ->
+  t
+
+val create_bottom :
   params:Bound_parameter.t list ->
   result_arity:Flambda_arity.With_subkinds.t ->
   t

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -188,8 +188,11 @@ let exn_cont env = env.k_exn
 (* Function info *)
 
 let get_function_info env code_id =
-  Exported_code.find_exn env.functions_info code_id
-  |> Code_or_metadata.code_metadata
+  match Exported_code.find_exn env.functions_info code_id with
+  | code_or_metadata -> Code_or_metadata.code_metadata code_or_metadata
+  | exception Not_found ->
+    Misc.fatal_errorf "To_cmm_env.get_function_info: code ID %a not bound"
+      Code_id.print code_id
 
 let get_func_decl_params_arity t code_id =
   let info = get_function_info t code_id in

--- a/middle_end/flambda2/types/env/typing_env_extension.ml
+++ b/middle_end/flambda2/types/env/typing_env_extension.ml
@@ -86,10 +86,9 @@ module With_extra_variables = struct
   let empty =
     { existential_vars = Variable.Map.empty; equations = Name.Map.empty }
 
-  let add_definition t var kind ty =
+  let add_definition t var kind =
     let existential_vars = Variable.Map.add var kind t.existential_vars in
-    let equations = Name.Map.add (Name.var var) ty t.equations in
-    { existential_vars; equations }
+    { existential_vars; equations = t.equations }
 
   let add_or_replace_equation t name ty =
     More_type_creators.check_equation name ty;

--- a/middle_end/flambda2/types/env/typing_env_extension.mli
+++ b/middle_end/flambda2/types/env/typing_env_extension.mli
@@ -62,4 +62,13 @@ module With_extra_variables : sig
   val add_definition : t -> Variable.t -> Flambda_kind.t -> Type_grammar.t -> t
 
   val add_or_replace_equation : t -> Name.t -> Type_grammar.t -> t
+
+  val existential_vars : t -> Variable.Set.t
+
+  val map_types : t -> f:(Type_grammar.t -> Type_grammar.t) -> t
+
+  (** At present [existential_vars] is not treated as a binding site. *)
+  include Contains_ids.S with type t := t
+
+  include Contains_names.S with type t := t
 end

--- a/middle_end/flambda2/types/env/typing_env_extension.mli
+++ b/middle_end/flambda2/types/env/typing_env_extension.mli
@@ -59,7 +59,7 @@ module With_extra_variables : sig
 
   val empty : t
 
-  val add_definition : t -> Variable.t -> Flambda_kind.t -> Type_grammar.t -> t
+  val add_definition : t -> Variable.t -> Flambda_kind.t -> t
 
   val add_or_replace_equation : t -> Name.t -> Type_grammar.t -> t
 

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -347,90 +347,181 @@ type to_erase =
   | Everything_not_in of Typing_env.t
   | All_variables_except of Variable.Set.t
 
-(* CR mshinwell: There is a subtlety here: the presence of a name in
-   [suitable_for] doesn't mean that we should blindly return "=name". The type
-   of the name in [suitable_for] might be (much) worse than the one in the
-   environment [t]. *)
-let rec make_suitable_for_environment0_core env t ~depth (to_erase : to_erase)
-    level =
-  let[@inline always] should_erase simple =
-    match to_erase with
-    | Everything_not_in suitable_for -> not (TE.mem_simple suitable_for simple)
-    | All_variables_except to_keep ->
-      Simple.pattern_match' simple
-        ~var:(fun var ~coercion:_ -> not (Variable.Set.mem var to_keep))
-        ~const:(fun _ -> false)
-        ~symbol:(fun _ ~coercion:_ -> false)
-  in
-  let free_names = TG.free_names t in
-  if Name_occurrences.no_variables free_names
-  then level, t
-  else if missing_kind env free_names
-  then level, MTC.unknown (TG.kind t)
-  else
-    let to_erase_names =
-      let var free_var = should_erase (Simple.var free_var) in
-      Name_occurrences.filter_names free_names ~f:(fun free_name ->
-          Name.pattern_match free_name ~var ~symbol:(fun _ -> true))
-    in
-    if Name_occurrences.is_empty to_erase_names
-    then level, t
-    else if depth > 1
-    then level, MTC.unknown (TG.kind t)
+exception Missing_cmx_file
+
+let free_variables_transitive env ty =
+  let rec free_variables_transitive0 ty ~result =
+    (* We don't need to look at symbols because the assumption (see the .mli) is
+       that the type of any symbol is already valid (including any variables it
+       may contain, transitively) in the target environment). *)
+    let free_vars = TG.free_names ty |> Name_occurrences.with_only_variables in
+    if missing_kind env free_vars
+    then raise Missing_cmx_file
     else
-      let level, renaming =
-        (* To avoid writing an erasure operation, we define irrelevant fresh
-           variables in the returned [TEL], and swap them with the variables
-           that we wish to erase throughout the type. *)
-        Name_occurrences.fold_names to_erase_names ~init:(level, Renaming.empty)
-          ~f:(fun ((level, renaming) as acc) to_erase_name ->
-            Name.pattern_match to_erase_name
-              ~symbol:(fun _ -> acc)
-              ~var:(fun to_erase_var ->
-                let original_type = TE.find env to_erase_name None in
-                let kind = TG.kind original_type in
-                let fresh_var = Variable.rename to_erase_var in
-                let level =
-                  let level, ty =
-                    match
-                      TE.get_canonical_simple_exn env
-                        ~min_name_mode:Name_mode.in_types
-                        (Simple.var to_erase_var)
-                    with
-                    | exception Not_found -> level, MTC.unknown kind
-                    | canonical_simple ->
-                      if not (should_erase canonical_simple)
-                      then level, TG.alias_type_of kind canonical_simple
-                      else
-                        let t =
-                          TE.find env (Name.var to_erase_var) (Some kind)
-                        in
-                        let t = expand_head env t |> ET.to_type in
-                        make_suitable_for_environment0_core env t
-                          ~depth:(depth + 1) to_erase level
-                  in
-                  TEEV.add_definition level fresh_var kind ty
-                in
-                let renaming =
-                  Renaming.add_variable renaming to_erase_var fresh_var
-                in
-                level, renaming))
-      in
-      level, TG.apply_renaming t renaming
+      let to_traverse = Name_occurrences.diff free_vars result in
+      Name_occurrences.fold_names to_traverse ~init:result
+        ~f:(fun result name ->
+          let result =
+            Name_occurrences.add_name result name Name_mode.in_types
+          in
+          let ty = TE.find env name None in
+          free_variables_transitive0 ty ~result)
+  in
+  free_variables_transitive0 ty ~result:Name_occurrences.empty
 
-let make_suitable_for_environment0 env t to_erase level =
-  make_suitable_for_environment0_core env t ~depth:0 to_erase level
-
-let make_suitable_for_environment env t (to_erase : to_erase) ~bind_to =
+let make_suitable_for_environment env (to_erase : to_erase) bind_to_and_types =
   (match to_erase with
   | Everything_not_in suitable_for ->
-    if not (TE.mem suitable_for bind_to)
-    then
-      Misc.fatal_errorf
-        "[bind_to] %a is expected to be\n\
-        \   bound in the [suitable_for] environment:@ %a" Name.print bind_to
-        TE.print suitable_for
+    List.iter
+      (fun (bind_to, _ty) ->
+        if not (TE.mem suitable_for bind_to)
+        then
+          Misc.fatal_errorf
+            "Variable to be bound %a is expected to already be\n\
+            \   bound in the [suitable_for] environment:@ %a" Name.print bind_to
+            TE.print suitable_for)
+      bind_to_and_types
   | All_variables_except _ -> ());
-  let level, t = make_suitable_for_environment0 env t to_erase TEEV.empty in
-  let level = TEEV.add_or_replace_equation level bind_to t in
-  level
+  (* Do a quick free variables check first to try to catch easy cases. *)
+  let free_vars =
+    List.fold_left
+      (fun free_vars (_bind_to, ty) ->
+        Name_occurrences.union free_vars
+          (Name_occurrences.with_only_variables (TG.free_names ty)))
+      Name_occurrences.empty bind_to_and_types
+  in
+  if Name_occurrences.is_empty free_vars
+  then
+    List.fold_left
+      (fun result (bind_to, ty) ->
+        TEEV.add_or_replace_equation result bind_to ty)
+      TEEV.empty bind_to_and_types
+  else
+    (* Now collect all of the free variables, transitively (see comment on
+       function above). *)
+    match
+      bind_to_and_types |> List.map snd
+      |> List.map (free_variables_transitive env)
+      |> Name_occurrences.union_list
+    with
+    | exception Missing_cmx_file ->
+      (* Just forget everything if there is a .cmx file missing. *)
+      List.fold_left
+        (fun result (bind_to, ty) ->
+          TEEV.add_or_replace_equation result bind_to (MTC.unknown_like ty))
+        TEEV.empty bind_to_and_types
+    | free_vars ->
+      (* Fetch the type equation for each free variable. Also add in the
+         equations about the "bind-to" names provided to this function. If any
+         of the "bind-to" names are already defined in [env], the type given in
+         [bind_to_and_types] takes precedence over such definition. *)
+      let equations =
+        let free_vars =
+          List.fold_left
+            (fun free_vars (bind_to, _) ->
+              Name.pattern_match bind_to
+                ~var:(fun var -> Name_occurrences.remove_var free_vars var)
+                ~symbol:(fun _ -> free_vars))
+            free_vars bind_to_and_types
+        in
+        Name_occurrences.fold_variables free_vars ~init:[]
+          ~f:(fun equations var ->
+            let name = Name.var var in
+            let ty = TE.find env name None in
+            (name, ty) :: equations)
+      in
+      let equations =
+        List.fold_left
+          (fun equations (bind_to, ty) ->
+            (* This cannot cause a duplicate key in the association list by
+               virtue of the [remove_var] calls above. *)
+            (bind_to, ty) :: equations)
+          equations bind_to_and_types
+      in
+      (* Determine which variables will be unavailable and thus need fresh ones
+         assigning to them. *)
+      let unavailable_vars =
+        match to_erase with
+        | Everything_not_in suitable_for ->
+          Name_occurrences.fold_variables free_vars ~init:[]
+            ~f:(fun unavailable_vars var ->
+              if not (TE.mem suitable_for (Name.var var))
+              then var :: unavailable_vars
+              else unavailable_vars)
+        | All_variables_except to_keep ->
+          Name_occurrences.fold_variables free_vars ~init:[]
+            ~f:(fun unavailable_vars var ->
+              if not (Variable.Set.mem var to_keep)
+              then var :: unavailable_vars
+              else unavailable_vars)
+      in
+      (* Make fresh variables for the unavailable variables and form a
+         renaming. *)
+      let unavailable_to_fresh_vars =
+        List.map (fun var -> var, Variable.rename var) unavailable_vars
+        |> Variable.Map.of_list
+      in
+      let renaming =
+        Variable.Map.fold
+          (fun unavailable_var fresh_var renaming ->
+            Renaming.add_fresh_variable renaming unavailable_var
+              ~guaranteed_fresh:fresh_var)
+          unavailable_to_fresh_vars Renaming.empty
+      in
+      (* For any type equation specifying an alias type, if that alias will be
+         unavailable, then expand the head of the type. Note that this cannot
+         yield any more variables that we haven't seen already, by virtue of the
+         semantics of [free_variables_transitive], above. *)
+      let equations =
+        List.map
+          (fun ((bind_to, ty) as equation) ->
+            let ty' =
+              match TG.get_alias_exn ty with
+              | exception Not_found -> ty
+              | alias ->
+                (* Care: the alias may contain a coercion, which could contain a
+                   variable. *)
+                let contains_unavailable_var =
+                  Name_occurrences.fold_variables (Simple.free_names alias)
+                    ~init:false ~f:(fun contains_unavailable_var var ->
+                      contains_unavailable_var
+                      || Variable.Map.mem var unavailable_to_fresh_vars)
+                in
+                if contains_unavailable_var
+                then expand_head env ty |> ET.to_type
+                else ty
+            in
+            if ty == ty' then equation else bind_to, ty')
+          equations
+      in
+      (* Now replace any unavailable variables with their fresh counterparts, on
+         both sides of the equations map. At the same time identify which
+         equations now have fresh variables on their left-hand sides. *)
+      let equations =
+        List.map
+          (fun (bind_to, ty) ->
+            let bind_to' = Renaming.apply_name renaming bind_to in
+            let ty = TG.apply_renaming ty renaming in
+            let fresh_var =
+              Name.pattern_match bind_to'
+                ~var:(fun var ->
+                  if not (Name.equal bind_to bind_to') then Some var else None)
+                ~symbol:(fun _ -> None)
+            in
+            bind_to', fresh_var, ty)
+          equations
+      in
+      (* Finally form an environment extension with extra variables: the
+         existentials are the fresh variables. *)
+      List.fold_left
+        (fun env_extension (bind_to, fresh_var, ty) ->
+          let env_extension =
+            match fresh_var with
+            | Some bind_to ->
+              TEEV.add_definition env_extension bind_to (TG.kind ty)
+            | None -> env_extension
+          in
+          if TG.is_obviously_unknown ty
+          then env_extension
+          else TEEV.add_or_replace_equation env_extension bind_to ty)
+        TEEV.empty equations

--- a/middle_end/flambda2/types/expand_head.mli
+++ b/middle_end/flambda2/types/expand_head.mli
@@ -95,9 +95,17 @@ type to_erase =
   | Everything_not_in of Typing_env.t
   | All_variables_except of Variable.Set.t
 
+(** This function doesn't descend past an alias type specifying a symbol: the
+    assumption is that such types are already valid in the target environment.
+    (This applies no matter what the setting of [to_erase]).
+
+    If any of the [Name.t]s provided as the "bind-to" names occur already in the
+    supplied environment then the types provided as input to this function will
+    be used instead of the types in such environment. (This situation does not
+    usually occur but does arise when this function is called during function
+    result type computation.) *)
 val make_suitable_for_environment :
   Typing_env.t ->
-  Type_grammar.t ->
   to_erase ->
-  bind_to:Name.t ->
+  (Name.t * Type_grammar.t) list ->
   Typing_env_extension.With_extra_variables.t

--- a/middle_end/flambda2/types/expand_head.mli
+++ b/middle_end/flambda2/types/expand_head.mli
@@ -91,9 +91,13 @@ val is_bottom : Typing_env.t -> Type_grammar.t -> bool
 
 val is_unknown : Typing_env.t -> Type_grammar.t -> bool
 
+type to_erase =
+  | Everything_not_in of Typing_env.t
+  | All_variables_except of Variable.Set.t
+
 val make_suitable_for_environment :
   Typing_env.t ->
   Type_grammar.t ->
-  suitable_for:Typing_env.t ->
+  to_erase ->
   bind_to:Name.t ->
   Typing_env_extension.With_extra_variables.t

--- a/middle_end/flambda2/types/expand_head.mli
+++ b/middle_end/flambda2/types/expand_head.mli
@@ -99,6 +99,11 @@ type to_erase =
     assumption is that such types are already valid in the target environment.
     (This applies no matter what the setting of [to_erase]).
 
+    The returned extension doesn't include equations involving the "bind-to"
+    names but associated to other names. As an example, if one of the "bind-to"
+    names is the result of a projection from a symbol, and the type of the
+    corresonding symbol field is not an alias, then the relation will be lost.
+
     If any of the [Name.t]s provided as the "bind-to" names occur already in the
     supplied environment then the types provided as input to this function will
     be used instead of the types in such environment. (This situation does not

--- a/middle_end/flambda2/types/expand_head.mli
+++ b/middle_end/flambda2/types/expand_head.mli
@@ -102,7 +102,7 @@ type to_erase =
     The returned extension doesn't include equations involving the "bind-to"
     names but associated to other names. As an example, if one of the "bind-to"
     names is the result of a projection from a symbol, and the type of the
-    corresonding symbol field is not an alias, then the relation will be lost.
+    corresponding symbol field is not an alias, then the relation will be lost.
 
     If any of the [Name.t]s provided as the "bind-to" names occur already in the
     supplied environment then the types provided as input to this function will
@@ -113,4 +113,5 @@ val make_suitable_for_environment :
   Typing_env.t ->
   to_erase ->
   (Name.t * Type_grammar.t) list ->
+  (* these [Name.t] values are called the "bind-to" names *)
   Typing_env_extension.With_extra_variables.t

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -83,7 +83,7 @@ module Typing_env_extension : sig
 
     val empty : t
 
-    val add_definition : t -> Variable.t -> Flambda_kind.t -> flambda_type -> t
+    val add_definition : t -> Variable.t -> Flambda_kind.t -> t
 
     val add_or_replace_equation : t -> Name.t -> flambda_type -> t
 
@@ -288,9 +288,8 @@ type to_erase =
     effort basis. *)
 val make_suitable_for_environment :
   Typing_env.t ->
-  flambda_type ->
   to_erase ->
-  bind_to:Name.t ->
+  (Name.t * flambda_type) list ->
   Typing_env_extension.With_extra_variables.t
 
 val apply_coercion : flambda_type -> Coercion.t -> flambda_type

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -27,6 +27,13 @@ val print : Format.formatter -> t -> unit
 
 val arity_of_list : t list -> Flambda_arity.t
 
+val apply_renaming : t -> Renaming.t -> t
+
+include Contains_ids.S with type t := t
+
+val remove_unused_closure_vars :
+  t -> used_closure_vars:Var_within_closure.Set.t -> t
+
 type typing_env
 
 type typing_env_extension
@@ -79,6 +86,14 @@ module Typing_env_extension : sig
     val add_definition : t -> Variable.t -> Flambda_kind.t -> flambda_type -> t
 
     val add_or_replace_equation : t -> Name.t -> flambda_type -> t
+
+    val map_types : t -> f:(flambda_type -> flambda_type) -> t
+
+    val existential_vars : t -> Variable.Set.t
+
+    include Contains_ids.S with type t := t
+
+    include Contains_names.S with type t := t
   end
 end
 
@@ -256,6 +271,10 @@ end
 
 val free_names : t -> Name_occurrences.t
 
+type to_erase =
+  | Everything_not_in of Typing_env.t
+  | All_variables_except of Variable.Set.t
+
 (* CR mshinwell: update comment *)
 
 (** This function takes a type [t] and an environment [env] that assigns types
@@ -269,8 +288,8 @@ val free_names : t -> Name_occurrences.t
     effort basis. *)
 val make_suitable_for_environment :
   Typing_env.t ->
-  t ->
-  suitable_for:Typing_env.t ->
+  flambda_type ->
+  to_erase ->
   bind_to:Name.t ->
   Typing_env_extension.With_extra_variables.t
 

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -32,6 +32,12 @@ let safe_string () = Config.safe_string
 
 let flat_float_array () = Config.flat_float_array
 
+let function_result_types ~is_a_functor =
+  match !Flambda_backend_flags.Flambda2.function_result_types with
+  | Never -> false
+  | Functors_only -> is_a_functor
+  | All_functions -> true
+
 let debug () = !Clflags.debug
 
 let opaque () = !Clflags.opaque

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -30,6 +30,8 @@ val safe_string : unit -> bool
 
 val flat_float_array : unit -> bool
 
+val function_result_types : is_a_functor:bool -> bool
+
 val debug : unit -> bool
 
 val opaque : unit -> bool


### PR DESCRIPTION
I am finding an increasing number of cases in the JS tree where the significantly less aggressive inlining of functors in Flambda 2, compared to Flambda 1, is causing performance degradation by virtue of large numbers of indirect calls.  I think this can be solved by tracking the return types of functors, so that we can see through non-inlined functor applications, and generate direct calls.

I spent a few hours experimenting to see how difficult it would be to track return types and have come up with this patch, which can build the compiler.  It is instructive to run the following before and after this patch which shows the effect on `map.ml` from the standard library:
```
$ cd _build2/default
$ <path to clone>/_build1/install/default/bin/ocamlopt.opt -strict-sequence -absname -w +a-4-9-41-42-44-45-48-66 -g -warn-error A -bin-annot -nostdlib -safe-string -strict-formats -g -I ocaml/stdlib/.stdlib.objs/byte -I ocaml/stdlib/.stdlib.objs/native -intf-suffix .ml -no-alias-deps -open Stdlib -nopervasives -nostdlib -o ocaml/stdlib/.stdlib.objs/native/stdlib__Map.cmx -c -dflambda -impl ocaml/stdlib/map.ml
```
The final two pieces of code in the output are functors (the latter is actually a coercion).  Not only are the return types recorded for these but the coercion functor is much simplified.

I think we could probably tidy this up a bit, cc @lthls and I will try to test this on the JS tree.

The tracking of return types is only enabled for functors because I'm unsure of the compilation time and `.cmx` size impact of turning this on everywhere.  We could perhaps add a command-line flag though which is off by default until we understand this better.