### PR TITLE
Keep import tables for packs

### DIFF
--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -114,7 +114,7 @@ let make_package_object ~ppf_dump members targetobj targetname coercion
         ~flambda2
         ~ppf_dump
         ~required_globals:required_globals
-        ~keep_symbol_tables:false
+        ~keep_symbol_tables:true
         ()
     end else begin
       let program, middle_end =

--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -204,6 +204,12 @@ let build_package_cmx members cmxfile =
       (fun m accu ->
         match m.pm_kind with PM_intf -> accu | PM_impl info -> info :: accu)
       members [] in
+  (* CR vlaviron: The code for [pack_units1] and [pack_units2] relies on
+     [Compilenv.unit_for_global] to find the correct compilation unit for the
+     packed modules. This is fragile, and means that we must keep
+     [Compilenv.global_infos_table] alive longer than we would otherwise need.
+     We should consider computing the sets earlier, to remove the dependency
+     on the table. *)
   let pack_units1 : Compilation_unit.Set.t lazy_t =
     lazy (List.fold_left
             (fun set info ->


### PR DESCRIPTION
This fixes the errors when building ocamlbuild.
Due to the slightly weird commands used by ocamlbuild, the pack is created from objects that are not in the load path, so we actually rely on the calls to `Compilenv.cache_unit_info` to be able to find the cmx files later.

The problematic part is not during `Simplify` (the tables were only cleared after that anyway), but in `Asmpackager.build_package_cmx`, which merges all the cmx files into one. If the cmx files are not found (which wasn't supposed to happen, as they were cached earlier) then a symbol for them is created from their names, giving them the wrong linkage name.

While the fix works, it seems weird that in `build_package_cmx` we have access to the unit infos but we have to go back through `Compilenv` to recover the Flambda2 compilation unit... Maybe we will need to fix that later.