### PR TITLE
Prevent equations on imported variables that may not be canonical

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -75,11 +75,13 @@ let remove_unreachable ~reachable_names t =
       Name_occurrences.mem_code_id reachable_names code_id)
     t
 
-let remove_unused_closure_vars_from_result_types ~used_closure_vars t =
+let remove_unused_closure_vars_from_result_types_and_shortcut_aliases
+    ~used_closure_vars ~canonicalise t =
   Code_id.Map.map
     (fun code_or_metadata ->
       Code_or_metadata.map_result_types code_or_metadata ~f:(fun result_ty ->
-          Flambda2_types.remove_unused_closure_vars result_ty ~used_closure_vars))
+          Flambda2_types.remove_unused_closure_vars_and_shortcut_aliases
+            result_ty ~used_closure_vars ~canonicalise))
     t
 
 let all_ids_for_export t =

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -40,7 +40,10 @@ val find : t -> Code_id.t -> Code_or_metadata.t option
 
 val remove_unreachable : reachable_names:Name_occurrences.t -> t -> t
 
-val remove_unused_closure_vars_from_result_types :
-  used_closure_vars:Var_within_closure.Set.t -> t -> t
+val remove_unused_closure_vars_from_result_types_and_shortcut_aliases :
+  used_closure_vars:Var_within_closure.Set.t ->
+  canonicalise:(Simple.t -> Simple.t) ->
+  t ->
+  t
 
 val iter_code : t -> f:(Code.t -> unit) -> unit

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -130,7 +130,7 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol
   | None -> None
   | Some _ when Flambda_features.opaque () -> None
   | Some final_typing_env ->
-    let final_typing_env =
+    let final_typing_env, canonicalise =
       TE.Pre_serializable.create final_typing_env ~used_closure_vars
     in
     let reachable_names =
@@ -140,7 +140,8 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol
       (* CR mshinwell: do we need to remove unused closure ID bindings from the
          result types too? *)
       all_code
-      |> EC.remove_unused_closure_vars_from_result_types ~used_closure_vars
+      |> EC.remove_unused_closure_vars_from_result_types_and_shortcut_aliases
+           ~used_closure_vars ~canonicalise
       |> EC.remove_unreachable ~reachable_names
     in
     let final_typing_env =

--- a/middle_end/flambda2/types/env/aliases.mli
+++ b/middle_end/flambda2/types/env/aliases.mli
@@ -76,10 +76,9 @@ type add_result = private
 
 (** Add an alias relationship to the tracker. The two simple expressions must be
     different and not both constants. They must both be canonical (as returned
-    by [get_canonical_ignoring_name_mode]), and in addition it is forbidden to
-    pass an argument that may be discovered not to be canonical by loading a
-    cmx. If [add t s1 mode1 s2 mode2] returns [{ t = t'; canonical_element;
-    alias_of_demoted_element }], then according to [t'],
+    by [get_canonical_ignoring_name_mode]). If [add t s1 mode1 s2 mode2] returns
+    [{ t = t'; canonical_element; alias_of_demoted_element }], then according to
+    [t'],
 
     - [canonical_element] is the canonical element of both [s1] and [s2];
 

--- a/middle_end/flambda2/types/env/aliases.mli
+++ b/middle_end/flambda2/types/env/aliases.mli
@@ -75,24 +75,24 @@ type add_result = private
   }
 
 (** Add an alias relationship to the tracker. The two simple expressions must be
-    different and not both constants. If [add t s1 mode1 s2 mode2] returns [{ t
-    = t'; canonical_element; alias_of_demoted_element }], then according to
-    [t'],
+    different and not both constants. They must both be canonical (as returned
+    by [get_canonical_ignoring_name_mode]), and in addition it is forbidden to
+    pass an argument that may be discovered not to be canonical by loading a
+    cmx. If [add t s1 mode1 s2 mode2] returns [{ t = t'; canonical_element;
+    alias_of_demoted_element }], then according to [t'],
 
     - [canonical_element] is the canonical element of both [s1] and [s2];
 
     - [alias_of_demoted_element] is either [s1] or [s2] (possibly with a new
     coercion; see note on [add_result]); and
 
-    - in the case that [alias_of_demoted_element] was canonical before (meaning
-    that either [s1] or [s2] happened to be canonical), it is no longer
-    canonical. *)
+    - [alias_of_demoted_element] is no longer canonical. *)
 val add :
   binding_time_resolver:(Name.t -> Binding_time.With_name_mode.t) ->
   binding_times_and_modes:(_ * Binding_time.With_name_mode.t) Name.Map.t ->
   t ->
-  element1:Simple.t ->
-  element2:Simple.t ->
+  canonical_element1:Simple.t ->
+  canonical_element2:Simple.t ->
   add_result
 
 (** [get_canonical_element] returns [None] only when the

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -151,9 +151,9 @@ let canonicalise t simple =
   Simple.pattern_match simple
     ~const:(fun _ -> simple)
     ~name:(fun name ~coercion ->
-        Simple.apply_coercion_exn
-          (Aliases.get_canonical_ignoring_name_mode t.aliases name)
-          coercion)
+      Simple.apply_coercion_exn
+        (Aliases.get_canonical_ignoring_name_mode t.aliases name)
+        coercion)
 
 let remove_unused_closure_vars_and_shortcut_aliases
     ({ names_to_types; aliases; symbol_projections } as t) ~used_closure_vars =

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -147,15 +147,24 @@ let merge t1 t2 =
   in
   { names_to_types; aliases; symbol_projections }
 
-let remove_unused_closure_vars { names_to_types; aliases; symbol_projections }
-    ~used_closure_vars =
+let remove_unused_closure_vars_and_shortcut_aliases
+    { names_to_types; aliases; symbol_projections } ~used_closure_vars =
+  let canonicalise simple =
+    Simple.pattern_match simple
+      ~const:(fun _ -> simple)
+      ~name:(fun name ~coercion ->
+        Simple.apply_coercion_exn
+          (Aliases.get_canonical_ignoring_name_mode aliases name)
+          coercion)
+  in
   let names_to_types =
     Name.Map.map_sharing
       (fun ((ty, binding_time_and_mode) as info) ->
         let ty' =
-          Type_grammar.remove_unused_closure_vars ty ~used_closure_vars
+          Type_grammar.remove_unused_closure_vars_and_shortcut_aliases ty
+            ~used_closure_vars ~canonicalise
         in
         if ty == ty' then info else ty', binding_time_and_mode)
       names_to_types
   in
-  { names_to_types; aliases; symbol_projections }
+  { names_to_types; aliases; symbol_projections }, canonicalise

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -147,16 +147,17 @@ let merge t1 t2 =
   in
   { names_to_types; aliases; symbol_projections }
 
-let remove_unused_closure_vars_and_shortcut_aliases
-    { names_to_types; aliases; symbol_projections } ~used_closure_vars =
-  let canonicalise simple =
-    Simple.pattern_match simple
-      ~const:(fun _ -> simple)
-      ~name:(fun name ~coercion ->
+let canonicalise t simple =
+  Simple.pattern_match simple
+    ~const:(fun _ -> simple)
+    ~name:(fun name ~coercion ->
         Simple.apply_coercion_exn
-          (Aliases.get_canonical_ignoring_name_mode aliases name)
+          (Aliases.get_canonical_ignoring_name_mode t.aliases name)
           coercion)
-  in
+
+let remove_unused_closure_vars_and_shortcut_aliases
+    ({ names_to_types; aliases; symbol_projections } as t) ~used_closure_vars =
+  let canonicalise = canonicalise t in
   let names_to_types =
     Name.Map.map_sharing
       (fun ((ty, binding_time_and_mode) as info) ->
@@ -167,4 +168,4 @@ let remove_unused_closure_vars_and_shortcut_aliases
         if ty == ty' then info else ty', binding_time_and_mode)
       names_to_types
   in
-  { names_to_types; aliases; symbol_projections }, canonicalise
+  { names_to_types; aliases; symbol_projections }

--- a/middle_end/flambda2/types/env/cached_level.mli
+++ b/middle_end/flambda2/types/env/cached_level.mli
@@ -52,4 +52,6 @@ val apply_renaming : t -> Renaming.t -> t
 val merge : t -> t -> t
 
 val remove_unused_closure_vars_and_shortcut_aliases :
-  t -> used_closure_vars:Var_within_closure.Set.t -> t * (Simple.t -> Simple.t)
+  t -> used_closure_vars:Var_within_closure.Set.t -> t
+
+val canonicalise : t -> Simple.t -> Simple.t

--- a/middle_end/flambda2/types/env/cached_level.mli
+++ b/middle_end/flambda2/types/env/cached_level.mli
@@ -51,5 +51,5 @@ val apply_renaming : t -> Renaming.t -> t
 
 val merge : t -> t -> t
 
-val remove_unused_closure_vars :
-  t -> used_closure_vars:Var_within_closure.Set.t -> t
+val remove_unused_closure_vars_and_shortcut_aliases :
+  t -> used_closure_vars:Var_within_closure.Set.t -> t * (Simple.t -> Simple.t)

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -74,11 +74,14 @@ module One_level = struct
     }
 
   let remove_unused_closure_vars_and_shortcut_aliases t ~used_closure_vars =
-    let just_after_level, canonicalise =
+    let just_after_level =
       Cached_level.remove_unused_closure_vars_and_shortcut_aliases
         t.just_after_level ~used_closure_vars
     in
-    { t with just_after_level }, canonicalise
+    { t with just_after_level }
+
+  let canonicalise t =
+    Cached_level.canonicalise t.just_after_level
 end
 
 type t =
@@ -1186,11 +1189,11 @@ end = struct
   type t = typing_env
 
   let create (t : typing_env) ~used_closure_vars =
-    let current_level, canonicalise =
+    let current_level =
       One_level.remove_unused_closure_vars_and_shortcut_aliases t.current_level
         ~used_closure_vars
     in
-    { t with current_level }, canonicalise
+    { t with current_level }, One_level.canonicalise current_level
 
   let find_or_missing = find_or_missing
 end

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -80,8 +80,7 @@ module One_level = struct
     in
     { t with just_after_level }
 
-  let canonicalise t =
-    Cached_level.canonicalise t.just_after_level
+  let canonicalise t = Cached_level.canonicalise t.just_after_level
 end
 
 type t =

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -781,9 +781,7 @@ and add_equation1 t name ty ~(meet_type : meet_type) =
         Simple.pattern_match alias_of
           ~const:(fun _ -> alias_of)
           ~name:(fun name ~coercion ->
-            (* TODO: handle correctly *)
-            ignore coercion;
-            find_canonical name)
+            Simple.apply_coercion_exn (find_canonical name) coercion)
       in
       if Simple.equal alias alias_of
       then None
@@ -794,8 +792,8 @@ and add_equation1 t name ty ~(meet_type : meet_type) =
               : Aliases.add_result) =
           (* This may raise [Binding_time_resolver_failure]. *)
           Aliases.add ~binding_time_resolver:t.binding_time_resolver aliases
-            ~binding_times_and_modes:(names_to_types t) ~element1:alias
-            ~element2:alias_of
+            ~binding_times_and_modes:(names_to_types t)
+            ~canonical_element1:alias ~canonical_element2:alias_of
         in
         let t = with_aliases t ~aliases in
         (* We need to change the demoted alias's type to point to the new

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -744,9 +744,10 @@ and add_equation1 t name ty ~(meet_type : meet_type) =
         else
           match (resolver t) comp_unit with
           | None ->
-            (* The corresponding cmx is unavailable, so even if [name] was not
-               canonical in its compilation unit we won't ever discover it.
-               Relying on the current aliases structure is fine. *)
+            (* The corresponding cmx is unavailable. However, we have ensured
+               that all equations exported in cmx files point to canonical
+               aliases, so there is no way for a non-canonical name to appear
+               outside its own compilation unit. *)
             aliases t
           | Some env -> aliases env
           | exception exn ->

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -177,7 +177,10 @@ val free_names_transitive : t -> Type_grammar.t -> Name_occurrences.t
 module Pre_serializable : sig
   type t
 
-  val create : typing_env -> used_closure_vars:Var_within_closure.Set.t -> t
+  val create :
+    typing_env ->
+    used_closure_vars:Var_within_closure.Set.t ->
+    t * (Simple.t -> Simple.t)
 
   val find_or_missing : t -> Name.t -> Type_grammar.t option
 end

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -31,8 +31,11 @@ val apply_renaming : t -> Renaming.t -> t
 
 include Contains_ids.S with type t := t
 
-val remove_unused_closure_vars :
-  t -> used_closure_vars:Var_within_closure.Set.t -> t
+val remove_unused_closure_vars_and_shortcut_aliases :
+  t ->
+  used_closure_vars:Var_within_closure.Set.t ->
+  canonicalise:(Simple.t -> Simple.t) ->
+  t
 
 type typing_env
 
@@ -199,7 +202,10 @@ module Typing_env : sig
   module Pre_serializable : sig
     type t
 
-    val create : typing_env -> used_closure_vars:Var_within_closure.Set.t -> t
+    val create :
+      typing_env ->
+      used_closure_vars:Var_within_closure.Set.t ->
+      t * (Simple.t -> Simple.t)
 
     val find_or_missing : t -> Name.t -> flambda_type option
   end

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -202,6 +202,12 @@ module Typing_env : sig
   module Pre_serializable : sig
     type t
 
+    (* This function ensures that all occurrences of aliases in the returned
+       environment are canonical. But some types, like function return types,
+       live outside the typing environment. To ensure that they can be exported
+       safely, they must go through
+       [remove_unused_closure_vars_and_shortcut_aliases] too, with the
+       [canonicalise] argument set to the function returned here. *)
     val create :
       typing_env ->
       used_closure_vars:Var_within_closure.Set.t ->

--- a/middle_end/flambda2/types/grammar/type_descr.ml
+++ b/middle_end/flambda2/types/grammar/type_descr.ml
@@ -74,12 +74,15 @@ module T : sig
     'head t ->
     Name_occurrences.t
 
-  val remove_unused_closure_vars :
-    free_names_head:('head -> Name_occurrences.t) ->
-    remove_unused_closure_vars_head:
-      ('head -> used_closure_vars:Var_within_closure.Set.t -> 'head) ->
+  val remove_unused_closure_vars_and_shortcut_aliases :
+    remove_unused_closure_vars_and_shortcut_aliases_head:
+      ('head ->
+      used_closure_vars:Var_within_closure.Set.t ->
+      canonicalise:(Simple.t -> Simple.t) ->
+      'head) ->
     'head t ->
     used_closure_vars:Var_within_closure.Set.t ->
+    canonicalise:(Simple.t -> Simple.t) ->
     'head t
 end = struct
   module Descr = struct
@@ -114,13 +117,19 @@ end = struct
         Name_occurrences.downgrade_occurrences_at_strictly_greater_kind
           (Simple.free_names simple) Name_mode.in_types
 
-    let remove_unused_closure_vars ~remove_unused_closure_vars_head t
-        ~used_closure_vars =
+    let remove_unused_closure_vars_and_shortcut_aliases
+        ~remove_unused_closure_vars_and_shortcut_aliases_head t
+        ~used_closure_vars ~canonicalise =
       match t with
       | No_alias head ->
-        let head' = remove_unused_closure_vars_head head ~used_closure_vars in
+        let head' =
+          remove_unused_closure_vars_and_shortcut_aliases_head head
+            ~used_closure_vars ~canonicalise
+        in
         if head == head' then t else No_alias head'
-      | Equals _ -> t
+      | Equals alias ->
+        let canonical = canonicalise alias in
+        if alias == canonical then t else Equals canonical
   end
 
   module WCFN = With_cached_free_names
@@ -176,17 +185,17 @@ end = struct
         ~free_names_head:(WCFN.free_names ~free_names_descr:free_names_head)
         descr
 
-  let remove_unused_closure_vars ~free_names_head
-      ~remove_unused_closure_vars_head (t : _ t) ~used_closure_vars : _ t =
+  let remove_unused_closure_vars_and_shortcut_aliases
+      ~remove_unused_closure_vars_and_shortcut_aliases_head (t : _ t) ~used_closure_vars ~canonicalise : _ t =
     match t with
     | Unknown | Bottom -> t
     | Ok descr ->
       let descr' =
-        Descr.remove_unused_closure_vars
-          ~remove_unused_closure_vars_head:
-            (WCFN.remove_unused_closure_vars ~free_names_descr:free_names_head
-               ~remove_unused_closure_vars_descr:remove_unused_closure_vars_head)
-          descr ~used_closure_vars
+        Descr.remove_unused_closure_vars_and_shortcut_aliases
+          ~remove_unused_closure_vars_and_shortcut_aliases_head:
+            (WCFN.remove_unused_closure_vars_and_shortcut_aliases
+               ~remove_unused_closure_vars_and_shortcut_aliases_descr:remove_unused_closure_vars_and_shortcut_aliases_head)
+          descr ~used_closure_vars ~canonicalise
       in
       if descr == descr' then t else Ok descr'
 end

--- a/middle_end/flambda2/types/grammar/type_descr.ml
+++ b/middle_end/flambda2/types/grammar/type_descr.ml
@@ -186,7 +186,8 @@ end = struct
         descr
 
   let remove_unused_closure_vars_and_shortcut_aliases
-      ~remove_unused_closure_vars_and_shortcut_aliases_head (t : _ t) ~used_closure_vars ~canonicalise : _ t =
+      ~remove_unused_closure_vars_and_shortcut_aliases_head (t : _ t)
+      ~used_closure_vars ~canonicalise : _ t =
     match t with
     | Unknown | Bottom -> t
     | Ok descr ->
@@ -194,7 +195,8 @@ end = struct
         Descr.remove_unused_closure_vars_and_shortcut_aliases
           ~remove_unused_closure_vars_and_shortcut_aliases_head:
             (WCFN.remove_unused_closure_vars_and_shortcut_aliases
-               ~remove_unused_closure_vars_and_shortcut_aliases_descr:remove_unused_closure_vars_and_shortcut_aliases_head)
+               ~remove_unused_closure_vars_and_shortcut_aliases_descr:
+                 remove_unused_closure_vars_and_shortcut_aliases_head)
           descr ~used_closure_vars ~canonicalise
       in
       if descr == descr' then t else Ok descr'

--- a/middle_end/flambda2/types/grammar/type_descr.mli
+++ b/middle_end/flambda2/types/grammar/type_descr.mli
@@ -64,12 +64,15 @@ val apply_renaming :
 val free_names :
   free_names_head:('head -> Name_occurrences.t) -> 'head t -> Name_occurrences.t
 
-val remove_unused_closure_vars :
-  free_names_head:('head -> Name_occurrences.t) ->
-  remove_unused_closure_vars_head:
-    ('head -> used_closure_vars:Var_within_closure.Set.t -> 'head) ->
+val remove_unused_closure_vars_and_shortcut_aliases :
+  remove_unused_closure_vars_and_shortcut_aliases_head:
+    ('head ->
+    used_closure_vars:Var_within_closure.Set.t ->
+    canonicalise:(Simple.t -> Simple.t) ->
+    'head) ->
   'head t ->
   used_closure_vars:Var_within_closure.Set.t ->
+  canonicalise:(Simple.t -> Simple.t) ->
   'head t
 
 val all_ids_for_export :

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -1156,140 +1156,172 @@ let apply_coercion t coercion =
     Misc.fatal_errorf "Cannot apply coercion %a@ to type %a" Coercion.print
       coercion print t
 
-let rec remove_unused_closure_vars t ~used_closure_vars =
+let rec remove_unused_closure_vars_and_shortcut_aliases t ~used_closure_vars
+    ~canonicalise =
   match t with
   | Value ty ->
     let ty' =
-      TD.remove_unused_closure_vars ty ~used_closure_vars
-        ~remove_unused_closure_vars_head:
-          remove_unused_closure_vars_head_of_kind_value
-        ~free_names_head:free_names_head_of_kind_value
+      TD.remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+        ~remove_unused_closure_vars_and_shortcut_aliases_head:
+          remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_value
     in
     if ty == ty' then t else Value ty'
   | Naked_immediate ty ->
     let ty' =
-      TD.remove_unused_closure_vars ty ~used_closure_vars
-        ~remove_unused_closure_vars_head:
-          remove_unused_closure_vars_head_of_kind_naked_immediate
-        ~free_names_head:free_names_head_of_kind_naked_immediate
+      TD.remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+        ~remove_unused_closure_vars_and_shortcut_aliases_head:
+          remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_immediate
     in
     if ty == ty' then t else Naked_immediate ty'
   | Naked_float ty ->
     let ty' =
-      TD.remove_unused_closure_vars ty ~used_closure_vars
-        ~remove_unused_closure_vars_head:
-          remove_unused_closure_vars_head_of_kind_naked_float
-        ~free_names_head:free_names_head_of_kind_naked_float
+      TD.remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+        ~remove_unused_closure_vars_and_shortcut_aliases_head:
+          remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_float
     in
     if ty == ty' then t else Naked_float ty'
   | Naked_int32 ty ->
     let ty' =
-      TD.remove_unused_closure_vars ty ~used_closure_vars
-        ~remove_unused_closure_vars_head:
-          remove_unused_closure_vars_head_of_kind_naked_int32
-        ~free_names_head:free_names_head_of_kind_naked_int32
+      TD.remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+        ~remove_unused_closure_vars_and_shortcut_aliases_head:
+          remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_int32
     in
     if ty == ty' then t else Naked_int32 ty'
   | Naked_int64 ty ->
     let ty' =
-      TD.remove_unused_closure_vars ty ~used_closure_vars
-        ~remove_unused_closure_vars_head:
-          remove_unused_closure_vars_head_of_kind_naked_int64
-        ~free_names_head:free_names_head_of_kind_naked_int64
+      TD.remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+        ~remove_unused_closure_vars_and_shortcut_aliases_head:
+          remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_int64
     in
     if ty == ty' then t else Naked_int64 ty'
   | Naked_nativeint ty ->
     let ty' =
-      TD.remove_unused_closure_vars ty ~used_closure_vars
-        ~remove_unused_closure_vars_head:
-          remove_unused_closure_vars_head_of_kind_naked_nativeint
-        ~free_names_head:free_names_head_of_kind_naked_nativeint
+      TD.remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+        ~remove_unused_closure_vars_and_shortcut_aliases_head:
+          remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_nativeint
     in
     if ty == ty' then t else Naked_nativeint ty'
   | Rec_info ty ->
     let ty' =
-      TD.remove_unused_closure_vars ty ~used_closure_vars
-        ~remove_unused_closure_vars_head:
-          remove_unused_closure_vars_head_of_kind_rec_info
-        ~free_names_head:free_names_head_of_kind_rec_info
+      TD.remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+        ~remove_unused_closure_vars_and_shortcut_aliases_head:
+          remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_rec_info
     in
     if ty == ty' then t else Rec_info ty'
 
-and remove_unused_closure_vars_head_of_kind_value head ~used_closure_vars =
+and remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_value head
+    ~used_closure_vars ~canonicalise =
   match head with
   | Variant { blocks; immediates; is_unique } ->
     let immediates' =
       let>+$ immediates = immediates in
-      remove_unused_closure_vars immediates ~used_closure_vars
+      remove_unused_closure_vars_and_shortcut_aliases immediates
+        ~used_closure_vars ~canonicalise
     in
     let blocks' =
       let>+$ blocks = blocks in
-      remove_unused_closure_vars_row_like_for_blocks blocks ~used_closure_vars
+      remove_unused_closure_vars_and_shortcut_aliases_row_like_for_blocks blocks
+        ~used_closure_vars ~canonicalise
     in
     if immediates == immediates' && blocks == blocks'
     then head
     else Variant { is_unique; blocks = blocks'; immediates = immediates' }
   | Boxed_float ty ->
-    let ty' = remove_unused_closure_vars ty ~used_closure_vars in
+    let ty' =
+      remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+    in
     if ty == ty' then head else Boxed_float ty'
   | Boxed_int32 ty ->
-    let ty' = remove_unused_closure_vars ty ~used_closure_vars in
+    let ty' =
+      remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+    in
     if ty == ty' then head else Boxed_int32 ty'
   | Boxed_int64 ty ->
-    let ty' = remove_unused_closure_vars ty ~used_closure_vars in
+    let ty' =
+      remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+    in
     if ty == ty' then head else Boxed_int64 ty'
   | Boxed_nativeint ty ->
-    let ty' = remove_unused_closure_vars ty ~used_closure_vars in
+    let ty' =
+      remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+    in
     if ty == ty' then head else Boxed_nativeint ty'
   | Closures { by_closure_id } ->
     let by_closure_id' =
-      remove_unused_closure_vars_row_like_for_closures by_closure_id
-        ~used_closure_vars
+      remove_unused_closure_vars_and_shortcut_aliases_row_like_for_closures
+        by_closure_id ~used_closure_vars ~canonicalise
     in
     if by_closure_id == by_closure_id'
     then head
     else Closures { by_closure_id = by_closure_id' }
   | String _ -> head
   | Array { element_kind; length } ->
-    let length' = remove_unused_closure_vars length ~used_closure_vars in
+    let length' =
+      remove_unused_closure_vars_and_shortcut_aliases length ~used_closure_vars
+        ~canonicalise
+    in
     if length == length' then head else Array { element_kind; length = length' }
 
-and remove_unused_closure_vars_head_of_kind_naked_immediate head
-    ~used_closure_vars =
+and remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_immediate
+    head ~used_closure_vars ~canonicalise =
   match head with
   | Naked_immediates _ -> head
   | Is_int ty ->
-    let ty' = remove_unused_closure_vars ty ~used_closure_vars in
+    let ty' =
+      remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+    in
     if ty == ty' then head else Is_int ty'
   | Get_tag ty ->
-    let ty' = remove_unused_closure_vars ty ~used_closure_vars in
+    let ty' =
+      remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+        ~canonicalise
+    in
     if ty == ty' then head else Get_tag ty'
 
-and remove_unused_closure_vars_head_of_kind_naked_float head
-    ~used_closure_vars:_ =
+and remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_float
+    head ~used_closure_vars:_ ~canonicalise:_ =
   head
 
-and remove_unused_closure_vars_head_of_kind_naked_int32 head
-    ~used_closure_vars:_ =
+and remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_int32
+    head ~used_closure_vars:_ ~canonicalise:_ =
   head
 
-and remove_unused_closure_vars_head_of_kind_naked_int64 head
-    ~used_closure_vars:_ =
+and remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_int64
+    head ~used_closure_vars:_ ~canonicalise:_ =
   head
 
-and remove_unused_closure_vars_head_of_kind_naked_nativeint head
-    ~used_closure_vars:_ =
+and remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_naked_nativeint
+    head ~used_closure_vars:_ ~canonicalise:_ =
   head
 
-and remove_unused_closure_vars_head_of_kind_rec_info head ~used_closure_vars:_ =
+and remove_unused_closure_vars_and_shortcut_aliases_head_of_kind_rec_info head
+    ~used_closure_vars:_ ~canonicalise:_ =
   head
 
-and remove_unused_closure_vars_row_like :
+and remove_unused_closure_vars_and_shortcut_aliases_row_like :
       'index 'maps_to 'known.
-      remove_unused_closure_vars_index:
-        ('index -> used_closure_vars:Var_within_closure.Set.t -> 'index) ->
-      remove_unused_closure_vars_maps_to:
-        ('maps_to -> used_closure_vars:Var_within_closure.Set.t -> 'maps_to) ->
+      remove_unused_closure_vars_and_shortcut_aliases_index:
+        ('index ->
+        used_closure_vars:Var_within_closure.Set.t ->
+        canonicalise:(Simple.t -> Simple.t) ->
+        'index) ->
+      remove_unused_closure_vars_and_shortcut_aliases_maps_to:
+        ('maps_to ->
+        used_closure_vars:Var_within_closure.Set.t ->
+        canonicalise:(Simple.t -> Simple.t) ->
+        'maps_to) ->
       known:'known ->
       other:('index, 'maps_to) row_like_case Or_bottom.t ->
       map_known:
@@ -1297,24 +1329,32 @@ and remove_unused_closure_vars_row_like :
         'known ->
         'known) ->
       used_closure_vars:Var_within_closure.Set.t ->
+      canonicalise:(Simple.t -> Simple.t) ->
       ('known * ('index, 'maps_to) row_like_case Or_bottom.t) option =
- fun ~remove_unused_closure_vars_index ~remove_unused_closure_vars_maps_to
-     ~known ~other ~map_known ~used_closure_vars ->
-  let[@inline always] remove_unused_closure_vars_index = function
+ fun ~remove_unused_closure_vars_and_shortcut_aliases_index
+     ~remove_unused_closure_vars_and_shortcut_aliases_maps_to ~known ~other
+     ~map_known ~used_closure_vars ~canonicalise ->
+  let[@inline always] remove_unused_closure_vars_and_shortcut_aliases_index =
+    function
     | Known index ->
-      Known (remove_unused_closure_vars_index index ~used_closure_vars)
+      Known
+        (remove_unused_closure_vars_and_shortcut_aliases_index index
+           ~used_closure_vars ~canonicalise)
     | At_least index ->
-      At_least (remove_unused_closure_vars_index index ~used_closure_vars)
+      At_least
+        (remove_unused_closure_vars_and_shortcut_aliases_index index
+           ~used_closure_vars ~canonicalise)
   in
   let known' =
     map_known
       (fun { index; maps_to; env_extension } ->
-        { index = remove_unused_closure_vars_index index;
+        { index = remove_unused_closure_vars_and_shortcut_aliases_index index;
           env_extension =
-            remove_unused_closure_vars_env_extension env_extension
-              ~used_closure_vars;
+            remove_unused_closure_vars_and_shortcut_aliases_env_extension
+              env_extension ~used_closure_vars ~canonicalise;
           maps_to =
-            remove_unused_closure_vars_maps_to maps_to ~used_closure_vars
+            remove_unused_closure_vars_and_shortcut_aliases_maps_to maps_to
+              ~used_closure_vars ~canonicalise
         })
       known
   in
@@ -1324,72 +1364,81 @@ and remove_unused_closure_vars_row_like :
     | Ok { index; maps_to; env_extension } ->
       (* CR mshinwell: phys-equal tests here and elsewhere are inadequate *)
       Ok
-        { index = remove_unused_closure_vars_index index;
+        { index = remove_unused_closure_vars_and_shortcut_aliases_index index;
           env_extension =
-            remove_unused_closure_vars_env_extension env_extension
-              ~used_closure_vars;
+            remove_unused_closure_vars_and_shortcut_aliases_env_extension
+              env_extension ~used_closure_vars ~canonicalise;
           maps_to =
-            remove_unused_closure_vars_maps_to maps_to ~used_closure_vars
+            remove_unused_closure_vars_and_shortcut_aliases_maps_to maps_to
+              ~used_closure_vars ~canonicalise
         }
   in
   if known == known' && other == other' then None else Some (known', other')
 
-and remove_unused_closure_vars_row_like_for_blocks
-    ({ known_tags; other_tags } as row_like_for_tags) ~used_closure_vars =
+and remove_unused_closure_vars_and_shortcut_aliases_row_like_for_blocks
+    ({ known_tags; other_tags } as row_like_for_tags) ~used_closure_vars
+    ~canonicalise =
   match
-    remove_unused_closure_vars_row_like
-      ~remove_unused_closure_vars_index:(fun block_size ~used_closure_vars:_ ->
-        block_size)
-      ~remove_unused_closure_vars_maps_to:
-        remove_unused_closure_vars_int_indexed_product ~known:known_tags
-      ~other:other_tags ~map_known:Tag.Map.map_sharing ~used_closure_vars
+    remove_unused_closure_vars_and_shortcut_aliases_row_like
+      ~remove_unused_closure_vars_and_shortcut_aliases_index:
+        (fun block_size ~used_closure_vars:_ ~canonicalise:_ -> block_size)
+      ~remove_unused_closure_vars_and_shortcut_aliases_maps_to:
+        remove_unused_closure_vars_and_shortcut_aliases_int_indexed_product
+      ~known:known_tags ~other:other_tags ~map_known:Tag.Map.map_sharing
+      ~used_closure_vars ~canonicalise
   with
   | None -> row_like_for_tags
   | Some (known_tags, other_tags) -> { known_tags; other_tags }
 
-and remove_unused_closure_vars_row_like_for_closures
+and remove_unused_closure_vars_and_shortcut_aliases_row_like_for_closures
     ({ known_closures; other_closures } as row_like_for_closures)
-    ~used_closure_vars =
+    ~used_closure_vars ~canonicalise =
   match
-    remove_unused_closure_vars_row_like
-      ~remove_unused_closure_vars_index:
-        Set_of_closures_contents.remove_unused_closure_vars
-      ~remove_unused_closure_vars_maps_to:
-        remove_unused_closure_vars_closures_entry ~known:known_closures
-      ~other:other_closures ~map_known:Closure_id.Map.map_sharing
-      ~used_closure_vars
+    remove_unused_closure_vars_and_shortcut_aliases_row_like
+      ~remove_unused_closure_vars_and_shortcut_aliases_index:
+        (fun index ~used_closure_vars ~canonicalise:_ ->
+        Set_of_closures_contents.remove_unused_closure_vars index
+          ~used_closure_vars)
+      ~remove_unused_closure_vars_and_shortcut_aliases_maps_to:
+        remove_unused_closure_vars_and_shortcut_aliases_closures_entry
+      ~known:known_closures ~other:other_closures
+      ~map_known:Closure_id.Map.map_sharing ~used_closure_vars ~canonicalise
   with
   | None -> row_like_for_closures
   | Some (known_closures, other_closures) -> { known_closures; other_closures }
 
-and remove_unused_closure_vars_closures_entry
-    { function_types; closure_types; closure_var_types } ~used_closure_vars =
+and remove_unused_closure_vars_and_shortcut_aliases_closures_entry
+    { function_types; closure_types; closure_var_types } ~used_closure_vars
+    ~canonicalise =
   { function_types =
       Closure_id.Map.map_sharing
         (fun function_type ->
           Or_unknown_or_bottom.map function_type ~f:(fun function_type ->
-              remove_unused_closure_vars_function_type function_type
-                ~used_closure_vars))
+              remove_unused_closure_vars_and_shortcut_aliases_function_type
+                function_type ~used_closure_vars ~canonicalise))
         function_types;
     closure_types =
-      remove_unused_closure_vars_closure_id_indexed_product closure_types
-        ~used_closure_vars;
+      remove_unused_closure_vars_and_shortcut_aliases_closure_id_indexed_product
+        closure_types ~used_closure_vars ~canonicalise;
     closure_var_types =
-      remove_unused_closure_vars_var_within_closure_indexed_product
-        closure_var_types ~used_closure_vars
+      remove_unused_closure_vars_and_shortcut_aliases_var_within_closure_indexed_product
+        closure_var_types ~used_closure_vars ~canonicalise
   }
 
-and remove_unused_closure_vars_closure_id_indexed_product
-    { closure_id_components_by_index } ~used_closure_vars =
+and remove_unused_closure_vars_and_shortcut_aliases_closure_id_indexed_product
+    { closure_id_components_by_index } ~used_closure_vars ~canonicalise =
   let closure_id_components_by_index =
     Closure_id.Map.map_sharing
-      (fun ty -> remove_unused_closure_vars ty ~used_closure_vars)
+      (fun ty ->
+        remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+          ~canonicalise)
       closure_id_components_by_index
   in
   { closure_id_components_by_index }
 
-and remove_unused_closure_vars_var_within_closure_indexed_product
-    { var_within_closure_components_by_index } ~used_closure_vars =
+and remove_unused_closure_vars_and_shortcut_aliases_var_within_closure_indexed_product
+    { var_within_closure_components_by_index } ~used_closure_vars ~canonicalise
+    =
   let var_within_closure_components_by_index =
     (* CR-someday mshinwell: some loss of sharing here, potentially *)
     Var_within_closure.Map.filter_map
@@ -1398,33 +1447,43 @@ and remove_unused_closure_vars_var_within_closure_indexed_product
               (Var_within_closure.in_compilation_unit closure_var
                  (Compilation_unit.get_current_exn ())))
            || Var_within_closure.Set.mem closure_var used_closure_vars
-        then Some (remove_unused_closure_vars ty ~used_closure_vars)
+        then
+          Some
+            (remove_unused_closure_vars_and_shortcut_aliases ty
+               ~used_closure_vars ~canonicalise)
         else None)
       var_within_closure_components_by_index
   in
   { var_within_closure_components_by_index }
 
-and remove_unused_closure_vars_int_indexed_product { fields; kind }
-    ~used_closure_vars =
+and remove_unused_closure_vars_and_shortcut_aliases_int_indexed_product
+    { fields; kind } ~used_closure_vars ~canonicalise =
   let fields = Array.copy fields in
   for i = 0 to Array.length fields - 1 do
-    fields.(i) <- remove_unused_closure_vars fields.(i) ~used_closure_vars
+    fields.(i)
+      <- remove_unused_closure_vars_and_shortcut_aliases fields.(i)
+           ~used_closure_vars ~canonicalise
   done;
   { fields; kind }
 
-and remove_unused_closure_vars_function_type
-    ({ code_id; rec_info } as function_type) ~used_closure_vars =
-  let rec_info' = remove_unused_closure_vars rec_info ~used_closure_vars in
+and remove_unused_closure_vars_and_shortcut_aliases_function_type
+    ({ code_id; rec_info } as function_type) ~used_closure_vars ~canonicalise =
+  let rec_info' =
+    remove_unused_closure_vars_and_shortcut_aliases rec_info ~used_closure_vars
+      ~canonicalise
+  in
   if rec_info == rec_info'
   then function_type
   else { code_id; rec_info = rec_info' }
 
-and remove_unused_closure_vars_env_extension ({ equations } as env_extension)
-    ~used_closure_vars =
+and remove_unused_closure_vars_and_shortcut_aliases_env_extension
+    ({ equations } as env_extension) ~used_closure_vars ~canonicalise =
   let changed = ref false in
   let equations' =
     Name.Map.map_sharing
-      (fun ty -> remove_unused_closure_vars ty ~used_closure_vars)
+      (fun ty ->
+        remove_unused_closure_vars_and_shortcut_aliases ty ~used_closure_vars
+          ~canonicalise)
       equations
   in
   if !changed then { equations = equations' } else env_extension

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -129,8 +129,11 @@ include Contains_names.S with type t := t
 
 include Contains_ids.S with type t := t
 
-val remove_unused_closure_vars :
-  t -> used_closure_vars:Var_within_closure.Set.t -> t
+val remove_unused_closure_vars_and_shortcut_aliases :
+  t ->
+  used_closure_vars:Var_within_closure.Set.t ->
+  canonicalise:(Simple.t -> Simple.t) ->
+  t
 
 val kind : t -> Flambda_kind.t
 

--- a/middle_end/flambda2/types/grammar/with_cached_free_names.ml
+++ b/middle_end/flambda2/types/grammar/with_cached_free_names.ml
@@ -50,26 +50,13 @@ let apply_renaming ~apply_renaming_descr ~free_names_descr t renaming =
     in
     { descr; free_names }
 
-let remove_unused_closure_vars ~free_names_descr
-    ~remove_unused_closure_vars_descr t ~used_closure_vars =
-  let descr_known_to_contain_no_unused_closure_vars =
-    (* If the free names are already computed (modulo application of a
-       renaming), we can use them as a shortcut, to potentially avoid traversing
-       the [descr]. *)
-    if Option.is_some t.free_names
-    then
-      let free_names = free_names t ~free_names_descr in
-      let closure_vars = Name_occurrences.closure_vars free_names in
-      let unused_closure_vars =
-        Var_within_closure.Set.diff closure_vars used_closure_vars
-      in
-      Var_within_closure.Set.is_empty unused_closure_vars
-    else false
+let remove_unused_closure_vars_and_shortcut_aliases
+    ~remove_unused_closure_vars_and_shortcut_aliases_descr t
+    ~used_closure_vars ~canonicalise =
+  let descr =
+    remove_unused_closure_vars_and_shortcut_aliases_descr (descr t)
+      ~used_closure_vars ~canonicalise
   in
-  if descr_known_to_contain_no_unused_closure_vars
-  then t
-  else
-    let descr = remove_unused_closure_vars_descr (descr t) ~used_closure_vars in
-    { descr; free_names = None }
+  if descr == t.descr then t else { descr; free_names = None; }
 
 let print ~print_descr ppf t = print_descr ppf (descr t)

--- a/middle_end/flambda2/types/grammar/with_cached_free_names.ml
+++ b/middle_end/flambda2/types/grammar/with_cached_free_names.ml
@@ -51,12 +51,12 @@ let apply_renaming ~apply_renaming_descr ~free_names_descr t renaming =
     { descr; free_names }
 
 let remove_unused_closure_vars_and_shortcut_aliases
-    ~remove_unused_closure_vars_and_shortcut_aliases_descr t
-    ~used_closure_vars ~canonicalise =
+    ~remove_unused_closure_vars_and_shortcut_aliases_descr t ~used_closure_vars
+    ~canonicalise =
   let descr =
     remove_unused_closure_vars_and_shortcut_aliases_descr (descr t)
       ~used_closure_vars ~canonicalise
   in
-  if descr == t.descr then t else { descr; free_names = None; }
+  if descr == t.descr then t else { descr; free_names = None }
 
 let print ~print_descr ppf t = print_descr ppf (descr t)

--- a/middle_end/flambda2/types/grammar/with_cached_free_names.mli
+++ b/middle_end/flambda2/types/grammar/with_cached_free_names.mli
@@ -45,10 +45,13 @@ val free_names :
   'descr t ->
   Name_occurrences.t
 
-val remove_unused_closure_vars :
-  free_names_descr:('descr -> Name_occurrences.t) ->
-  remove_unused_closure_vars_descr:
-    ('descr -> used_closure_vars:Var_within_closure.Set.t -> 'descr) ->
+val remove_unused_closure_vars_and_shortcut_aliases :
+  remove_unused_closure_vars_and_shortcut_aliases_descr:
+    ('descr ->
+    used_closure_vars:Var_within_closure.Set.t ->
+    canonicalise:(Simple.t -> Simple.t) ->
+    'descr) ->
   'descr t ->
   used_closure_vars:Var_within_closure.Set.t ->
+  canonicalise:(Simple.t -> Simple.t) ->
   'descr t


### PR DESCRIPTION
Following the discussion on Slack, here is a patch that should ensure that equations are never added to variables that could be found later to be not canonical.