### PR TITLE
Use an option rather than a set for the exceptional successor(s)

### DIFF
--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -41,7 +41,7 @@ type basic_block =
         (** Trap depth of the start of the block. Used for cross checking the
             construction of [exns], and for emitting adjust trap on edges from
             one block to the next. *)
-    mutable exns : Label.Set.t;
+    mutable exn : Label.t option;
         (** All possible handlers of a raise that (1) can be triggered either by
             an explicit raise, or instructions such as calls and allocations,
             that appear(s) in this block; and (2) are within the same function.

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -645,7 +645,7 @@ module Trap_depth_and_exn = struct
       let stack, exceptional_successor =
         ListLabels.fold_left block.body ~init:(stack, None)
           ~f:(fun (stack, exceptional_successor) instr ->
-              process_basic exceptional_successor stack instr)
+            process_basic exceptional_successor stack instr)
       in
       let stack, exceptional_successor =
         process_terminator exceptional_successor stack block.terminator

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -590,11 +590,11 @@ module Trap_depth_and_exn = struct
     if can_raise
     then (
       match stack with
-      | [] -> stack, None
+      | [] -> stack, exceptional_successor
       | handler_label :: handler_stack ->
         assert (Option.is_none exceptional_successor);
         stack, Some (handler_label, handler_stack))
-    else stack, None
+    else stack, exceptional_successor
 
   let process_terminator :
       handler_option ->

--- a/backend/cfg/disconnect_block.ml
+++ b/backend/cfg/disconnect_block.ml
@@ -80,7 +80,10 @@ let disconnect cfg_with_layout label =
     Label.Set.iter
       (fun pred_label ->
         let pred_block = Label.Tbl.find cfg.blocks pred_label in
-        assert (not (Label.Set.mem label pred_block.exns));
+        Option.iter
+          (fun pred_block_exn ->
+            assert (not (Label.equal label pred_block_exn)))
+          pred_block.exn;
         update_predecessor's_terminators cfg ~pred_block
           ~being_disconnected:label ~target_label)
       block.predecessors

--- a/backend/cfg/eliminate_dead_code.ml
+++ b/backend/cfg/eliminate_dead_code.ml
@@ -66,7 +66,7 @@ let run_dead_block : Cfg_with_layout.t -> unit =
               <- Label.Set.remove label succ_block.predecessors)
           (Cfg.successor_labels ~normal:true ~exn:true block);
         block.terminator <- { block.terminator with desc = Cfg_intf.S.Never };
-        block.exns <- Label.Set.empty)
+        block.exn <- None)
       unreachable_labels;
     Label.Set.iter
       (fun label -> Cfg_with_layout.remove_block cfg_with_layout label)

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -315,7 +315,7 @@ let check_and_register_traps t =
      then it has a registered exn successor or interproc exn. *)
   let f _ (block : C.basic_block) =
     let n = match block.exn with None -> 0 | Some _ -> 1 in
-    assert ((not block.can_raise) || n > 0 || Cfg.can_raise_interproc block)
+    assert ((not block.can_raise) || n = 1 || Cfg.can_raise_interproc block)
   in
   C.iter_blocks t.cfg ~f
 

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -51,7 +51,7 @@ type t =
        will be able to store the trap_stacks directly within their nodes, but it
        is a major restructuring of create_blocks, which won't be needed when we
        split blocks to have only one stack each. *)
-    exns : T.t list Label.Tbl.t;
+    exns : T.t Label.Tbl.t;
         (** Maps labels to trap stacks at each raise point in the corresponding
             block. *)
     (* CR-someday gyorsh: this won't be needed after block splitting, as it will
@@ -150,8 +150,9 @@ let resolve_traps_to_pop t ls =
 let record_exn t (block : C.basic_block) traps =
   block.can_raise <- true;
   match Label.Tbl.find_opt t.exns block.start with
-  | None -> Label.Tbl.add t.exns block.start [traps]
-  | Some ls -> Label.Tbl.replace t.exns block.start (traps :: ls)
+  | None -> Label.Tbl.add t.exns block.start traps
+  | Some _ ->
+    Misc.fatal_errorf "Cannot record another exception for %d" block.start
 
 let create_empty_block t start ~trap_depth ~traps =
   let terminator : C.terminator C.instruction =
@@ -204,9 +205,9 @@ let register_block t (block : C.basic_block) traps =
      recorded and resolved at the end of the pass. *)
   (match Label.Tbl.find_opt t.exns block.start with
   | None -> ()
-  | Some ls ->
+  | Some trap_stack ->
     t.unresolved_traps_to_pop
-      <- resolve_traps_to_pop t ls @ t.unresolved_traps_to_pop);
+      <- (resolve_traps_to_pop t [trap_stack]) @ t.unresolved_traps_to_pop);
   Label.Tbl.add t.cfg.blocks block.start block
 
 let check_traps t label (block : C.basic_block) =
@@ -247,38 +248,26 @@ let register_exns t label (block : C.basic_block) =
      Unknown frames or labels. *)
   match Label.Tbl.find_opt t.exns label with
   | None -> ()
-  | Some exns ->
-    let f acc trap_stack =
-      match T.top_exn trap_stack with
-      | None -> Misc.fatal_errorf "register_exns: empty trap stack for %d" label
-      | Some l ->
-        if Label.equal l t.interproc_handler
-        then acc
-        else if Option.is_none acc
-        then Some l
-        else Misc.fatal_errorf "register_exns: multiple handlers for %d" label
-      | exception T.Unresolved ->
-        (* must be dead block or flow from exception handler only *)
-        assert block.dead;
-        if !C.verbose
-        then
-          Printf.printf
-            "unknown trap stack in exns of block %d: the block must be dead, \
-             or there is a bug in trap stacks."
-            label;
-        acc
-    in
-    block.exn <- List.fold_left f None exns;
+  | Some trap_stack ->
+    assert (Option.is_none block.exn);
+    (match T.top_exn trap_stack with
+     | None -> Misc.fatal_errorf "register_exns: empty trap stack for %d" label
+     | Some l ->
+       if not (Label.equal l t.interproc_handler)
+       then block.exn <- Some l
+     | exception T.Unresolved ->
+       (* must be dead block or flow from exception handler only *)
+       assert block.dead;
+       if !C.verbose
+       then
+         Printf.printf
+           "unknown trap stack in exns of block %d: the block must be dead, \
+            or there is a bug in trap stacks."
+           label);
     if !C.verbose
     then (
-      Printf.printf "%s: %d exn stacks at %d: " t.cfg.fun_name
-        (List.length exns) label;
-      List.iter T.print exns;
-      Printf.printf "%s: %d exns at %d: " t.cfg.fun_name
-        (match block.exn with None -> 0 | Some _ -> 1)
-        label;
-      Option.iter (Printf.printf "%d ") block.exn;
-      Printf.printf "\n")
+      Printf.printf "%s: %d exn %s: " t.cfg.fun_name label
+        (match block.exn with None -> "none" | Some l -> Int.to_string l))
 
 let check_and_register_traps t =
   (* check that all blocks referred to in pushtraps are marked as


### PR DESCRIPTION
After https://github.com/ocaml-flambda/flambda-backend/pull/312, a block can have at most one exceptional successor.
This pull request is simply changing the corresponding field from
a set to an option. Precisely, in the `Cfg.basic_block` type,

```
exns : Label.Set.t
```

becomes

```
exn : Label.t option
```

The rest of the diff is just about the consequences.