### PR TITLE
Intrinsic for Int32 unsigned to int conversion

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2811,6 +2811,8 @@ let transl_builtin name args dbg =
     mulhi ~signed:true Pint64 args dbg
   | "caml_unsigned_int64_mulh_unboxed" ->
     mulhi ~signed:false Pint64 args dbg
+  | "caml_int32_unsigned_to_int_trunc_unboxed_to_untagged" ->
+    Some (zero_extend_32 dbg (one_arg name args))
   (* Native_pointer: handled as unboxed nativeint *)
   | "caml_ext_pointer_as_native_pointer" ->
     Some(int_as_pointer (one_arg name args) dbg)


### PR DESCRIPTION
Existing `Int32.unsigned_to_int` function returns an option and does not have a compiler primitive.  This  PR adds an intrinsics defined  as follows:
```
external unsigned_to_int_trunc :  (int32[@unboxed]) -> (int[@untagged])  = 
  "caml_int32_unsigned_to_int_trunc" "caml_int32_unsigned_to_int_trunc_unboxed_to_untagged"
[@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
```

On 64-bit targets, the new intrinsic zero-extends the input. 
On 32-bit targets, the new intrinsic truncates the results, similarly to `Int32.to_int` (instead of returning an option).

For comparison, consider
```
let test_intrinsics_unsigned x = unsigned_to_int_trunc x
let test_signed x =  Stdlib.Int32.to_int x
let test_stdlib_unsigned x  = Stdlib.Int32.unsigned_to_int x |> Option.get
```
Here is the generated  assembly:
```
camlT__test_intrinsics_unsigned_65:
	movl	8(%rax), %eax
	leaq	1(%rax,%rax), %rax
	ret

camlT__test_signed_72:
	movslq	8(%rax), %rax
	leaq	1(%rax,%rax), %rax
	ret

camlT__test_stdlib_unsigned_50:
	movslq	8(%rax), %rax
	leaq	1(%rax,%rax), %rax
	cmpq	$1, %rax
	jge	.L109
	movq	camlStdlib__Int32__Pccall_404@GOTPCREL(%rip), %rbx
	movq	(%rbx), %rbx
	leaq	-1(%rax,%rbx), %rax
	ret
	.align	4
.L109:
	ret
```