### PR TITLE
Add Cmm operation Cbswap

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -886,15 +886,13 @@ let emit_instr fallthrough i =
       I.add (int n) (addressing addr QWORD i 0)
   | Lop(Ispecific(Ifloatarithmem(op, addr))) ->
       instr_for_floatarithmem op (addressing addr REAL8 i 1) (res i 0)
-  | Lop(Ispecific(Ibswap 16)) ->
+  | Lop(Ispecific(Ibswap { bitwidth = Sixteen })) ->
       I.xchg ah al;
       I.movzx (res16 i 0) (res i 0)
-  | Lop(Ispecific(Ibswap 32)) ->
+  | Lop(Ispecific(Ibswap { bitwidth = Thirtytwo })) ->
       I.bswap (res32 i 0);
-  | Lop(Ispecific(Ibswap 64)) ->
+  | Lop(Ispecific(Ibswap { bitwidth = Sixtyfour })) ->
       I.bswap (res i 0)
-  | Lop(Ispecific(Ibswap _)) ->
-      assert false
   | Lop(Ispecific Isqrtf) ->
       if arg i 0 <> res i 0 then
         I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -458,6 +458,7 @@ let operation_supported = function
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
+  | Cbswap _
   | Cclz _ | Cctz _
   | Ccmpi _ | Caddv | Cadda | Ccmpa _
   | Cnegf | Cabsf | Caddf | Csubf | Cmulf | Cdivf

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -175,8 +175,7 @@ let one_arg name args =
 (* If you update [inline_ops], you may need to update [is_simple_expr] and/or
    [effects_of], below. *)
 let inline_ops =
-  [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
-    "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+  [ "sqrt"; ]
 
 let is_immediate n = n <= 0x7FFF_FFFF && n >= -0x8000_0000
 
@@ -330,13 +329,8 @@ method! select_operation op args dbg =
       | _ ->
           super#select_operation op args dbg
       end
-  | Cextcall { func = "caml_bswap16_direct"; } ->
-      (Ispecific (Ibswap 16), args)
-  | Cextcall { func = "caml_int32_direct_bswap"; } ->
-      (Ispecific (Ibswap 32), args)
-  | Cextcall { func = "caml_int64_direct_bswap"; }
-  | Cextcall { func = "caml_nativeint_direct_bswap"; } ->
-      (Ispecific (Ibswap 64), args)
+  | Cbswap { bitwidth } ->
+    (Ispecific (Ibswap bitwidth), args)
   (* Recognize sign extension *)
   | Casr ->
       begin match args with

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -532,9 +532,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Ispecific (Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf)) -> 1
     | Lop (Ispecific (Ishiftarith _)) -> 1
     | Lop (Ispecific (Imuladd | Imulsub)) -> 1
-    | Lop (Ispecific (Ibswap 16)) -> 2
-    | Lop (Ispecific (Ibswap (32|64))) -> 1
-    | Lop (Ispecific (Ibswap _)) -> assert false
+    | Lop (Ispecific (Ibswap { bitwidth = Sixteen } )) -> 2
+    | Lop (Ispecific (Ibswap { bitwidth = (Thirtytwo | Sixtyfour) })) -> 1
     | Lop (Ispecific Imove32) -> 1
     | Lop (Iname_for_debugger _) -> 0
     | Lop (Iprobe _ | Iprobe_is_enabled _) ->
@@ -899,16 +898,15 @@ let emit_instr i =
                      | Imulsub -> "msub"
                      | _ -> assert false) in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
-    | Lop(Ispecific(Ibswap size)) ->
-        begin match size with
-        | 16 ->
+    | Lop(Ispecific(Ibswap { bitwidth })) ->
+        begin match bitwidth with
+        | Sixteen ->
             `	rev16	{emit_wreg i.res.(0)}, {emit_wreg i.arg.(0)}\n`;
             `	ubfm	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, #0, #15\n`
-        | 32 ->
+        | Thirtytwo ->
             `	rev	{emit_wreg i.res.(0)}, {emit_wreg i.arg.(0)}\n`
-        | 64 ->
+        | Sixtyfour ->
             `	rev	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
-        | _ -> assert false
         end
     | Lop (Iname_for_debugger _) -> ()
     | Lop (Iprobe _ | Iprobe_is_enabled _) ->

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -533,7 +533,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Ispecific (Ishiftarith _)) -> 1
     | Lop (Ispecific (Imuladd | Imulsub)) -> 1
     | Lop (Ispecific (Ibswap 16)) -> 2
-    | Lop (Ispecific (Ibswap _)) -> 1
+    | Lop (Ispecific (Ibswap (32|64))) -> 1
+    | Lop (Ispecific (Ibswap _)) -> assert false
     | Lop (Ispecific Imove32) -> 1
     | Lop (Iname_for_debugger _) -> 0
     | Lop (Iprobe _ | Iprobe_is_enabled _) ->
@@ -907,8 +908,7 @@ let emit_instr i =
             `	rev	{emit_wreg i.res.(0)}, {emit_wreg i.arg.(0)}\n`
         | 64 ->
             `	rev	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
-        | _ ->
-            assert false
+        | _ -> assert false
         end
     | Lop (Iname_for_debugger _) -> ()
     | Lop (Iprobe _ | Iprobe_is_enabled _) ->

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -315,6 +315,7 @@ let operation_supported = function
   | Cclz _ | Cctz _ | Cpopcnt
   | Cprefetch _
     -> false   (* Not implemented *)
+  | Cbswap _
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr

--- a/backend/arm64/selection.ml
+++ b/backend/arm64/selection.ml
@@ -87,8 +87,7 @@ let is_immediate n =
 (* If you update [inline_ops], you may need to update [is_simple_expr] and/or
    [effects_of], below. *)
 let inline_ops =
-  [ "sqrt"; "caml_bswap16_direct"; "caml_int32_direct_bswap";
-    "caml_int64_direct_bswap"; "caml_nativeint_direct_bswap" ]
+  [ "sqrt"; ]
 
 let use_direct_addressing _symb =
   (not !Clflags.dlcode) && (not Arch.macosx)
@@ -227,13 +226,8 @@ method! select_operation op args dbg =
   | Cextcall { func = "sqrt" } ->
       (Ispecific Isqrtf, args)
   (* Recognize bswap instructions *)
-  | Cextcall { func = "caml_bswap16_direct" } ->
-      (Ispecific(Ibswap 16), args)
-  | Cextcall { func = "caml_int32_direct_bswap"; } ->
-      (Ispecific(Ibswap 32), args)
-  | Cextcall { func = "caml_int64_direct_bswap"; } |
-    Cextcall { func = "caml_nativeint_direct_bswap" } ->
-      (Ispecific (Ibswap 64), args)
+  | Cbswap { bitwidth } ->
+      (Ispecific(Ibswap bitwidth), args)
   (* Other operations are regular *)
   | _ ->
       super#select_operation op args dbg

--- a/backend/arm64/selection.ml
+++ b/backend/arm64/selection.ml
@@ -97,6 +97,12 @@ let is_stack_slot rv =
         | [| { loc = Stack _ } |] -> true
         | _ -> false)
 
+let select_bitwidth : Cmm.bswap_bitwidth -> Arch.bswap_bitwidth =
+  function
+  | Sixteen -> Sixteen
+  | Thirtytwo -> Thirtytwo
+  | Sixtyfour -> Sixtyfour
+
 (* Instruction selection *)
 
 class selector = object(self)
@@ -227,7 +233,8 @@ method! select_operation op args dbg =
       (Ispecific Isqrtf, args)
   (* Recognize bswap instructions *)
   | Cbswap { bitwidth } ->
-      (Ispecific(Ibswap bitwidth), args)
+    let bitwidth = select_bitwidth bitwidth in
+      (Ispecific(Ibswap { bitwidth }), args)
   (* Other operations are regular *)
   | _ ->
       super#select_operation op args dbg

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -183,6 +183,7 @@ and operation =
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool } | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
+  | Cbswap of { bitwidth: int; }
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -154,6 +154,8 @@ type trywith_kind =
   | Regular
   | Delayed of trywith_shared_label
 
+type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
+
 type memory_chunk =
     Byte_unsigned
   | Byte_signed
@@ -183,7 +185,7 @@ and operation =
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool } | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
-  | Cbswap of { bitwidth: int; }
+  | Cbswap of { bitwidth: bswap_bitwidth; }
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -152,6 +152,8 @@ type trywith_kind =
       This allows for sharing a single handler in several places, or having
       multiple entry and exit points to a single trywith block. *)
 
+type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
+
 type memory_chunk =
     Byte_unsigned
   | Byte_signed
@@ -184,7 +186,7 @@ and operation =
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool }  | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
-  | Cbswap of { bitwidth: int }
+  | Cbswap of { bitwidth: bswap_bitwidth; }
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -164,7 +164,6 @@ type memory_chunk =
   | Single
   | Double                             (* word-aligned 64-bit float
                                           see PR#10433 *)
-
 and operation =
     Capply of machtype * Lambda.region_close
   | Cextcall of
@@ -185,6 +184,7 @@ and operation =
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool }  | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
+  | Cbswap of { bitwidth: int }
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2378,11 +2378,11 @@ let bbswap bi arg dbg =
       dbg)
 
 let bbswap bi arg dbg =
-  let bitwidth =
+  let bitwidth : Cmm.bswap_bitwidth =
     match (bi : Primitive.boxed_integer) with
-    | Pnativeint -> size_int * 8
-    | Pint32 -> 32
-    | Pint64 -> 64
+    | Pnativeint -> if size_int = 4 then Thirtytwo else Sixtyfour
+    | Pint32 -> Thirtytwo
+    | Pint64 -> Sixtyfour
   in
   let op = Cbswap { bitwidth } in
   if (bi = Primitive.Pint64 && size_int = 4) ||
@@ -2402,7 +2402,7 @@ let bswap16 arg dbg =
        dbg))
 
 let bswap16 arg dbg =
-  let op = Cbswap { bitwidth = 16 } in
+  let op = Cbswap { bitwidth = Cmm.Sixteen } in
   if Proc.operation_supported op then
     Cop (op,[arg],dbg)
   else

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2353,15 +2353,6 @@ let arraylength kind arg dbg =
    to Arbitrary_effects and Has_coeffects, resp.
    Check if this can be improved (e.g., bswap). *)
 
-let if_operation_supported op ~f =
-  match Proc.operation_supported op with
-  | true -> Some (f ())
-  | false -> None
-
-let if_operation_supported_bi bi op ~f =
-  if bi = Primitive.Pint64 && size_int = 4 then None
-  else if_operation_supported op ~f
-
 let bbswap bi arg dbg =
   let bitwidth : Cmm.bswap_bitwidth =
     match (bi : Primitive.boxed_integer) with
@@ -2401,6 +2392,15 @@ let bswap16 arg dbg =
                   ty = typ_int; alloc = false; ty_args = []; },
        [arg],
        dbg))
+
+let if_operation_supported op ~f =
+  match Proc.operation_supported op with
+  | true -> Some (f ())
+  | false -> None
+
+let if_operation_supported_bi bi op ~f =
+  if bi = Primitive.Pint64 && size_int = 4 then None
+  else if_operation_supported op ~f
 
 let clz ~arg_is_non_zero bi arg dbg =
   let op = Cclz { arg_is_non_zero; } in

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1169,7 +1169,7 @@ and transl_unbox_int_low dbg env bi e =
   if bi = Pint32 then low_32 dbg e else e
 
 and transl_unbox_sized size dbg env exp =
-  match size with
+  match (size : Clambda_primitives.memory_access_size) with
   | Sixteen ->
      ignore_high_bit_int (untag_int (transl env exp) dbg)
   | Thirty_two -> transl_unbox_int dbg env Pint32 exp

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -179,6 +179,7 @@ let operation d = function
   | Clsl -> "<<"
   | Clsr -> ">>u"
   | Casr -> ">>s"
+  | Cbswap { bitwidth } -> Printf.sprintf "bswap_%i" bitwidth
   | Cclz { arg_is_non_zero; } -> Printf.sprintf "clz %B" arg_is_non_zero
   | Cctz { arg_is_non_zero; } -> Printf.sprintf "ctz %B" arg_is_non_zero
   | Cpopcnt -> "popcnt"

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -179,7 +179,9 @@ let operation d = function
   | Clsl -> "<<"
   | Clsr -> ">>u"
   | Casr -> ">>s"
-  | Cbswap { bitwidth } -> Printf.sprintf "bswap_%i" bitwidth
+  | Cbswap { bitwidth = Sixteen } -> "bswap_16"
+  | Cbswap { bitwidth = Thirtytwo } -> "bswap_32"
+  | Cbswap { bitwidth = Sixtyfour } -> "bswap_64"
   | Cclz { arg_is_non_zero; } -> Printf.sprintf "clz %B" arg_is_non_zero
   | Cctz { arg_is_non_zero; } -> Printf.sprintf "ctz %B" arg_is_non_zero
   | Cpopcnt -> "popcnt"

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -173,6 +173,7 @@ let oper_result_type = function
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi |
     Cand | Cor | Cxor | Clsl | Clsr | Casr |
     Cclz _ | Cctz _ | Cpopcnt |
+    Cbswap _ |
     Ccmpi _ | Ccmpa _ | Ccmpf _ -> typ_int
   | Caddv -> typ_val
   | Cadda -> typ_addr
@@ -445,6 +446,7 @@ method is_simple_expr = function
       | Cload _ | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor
       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf
       | Cclz _ | Cctz _ | Cpopcnt
+      | Cbswap _
       | Cabsf | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
       | Ccmpf _ -> List.for_all self#is_simple_expr args
       end
@@ -492,6 +494,7 @@ method effects_of exp =
       | Cload (_, Asttypes.Mutable) -> EC.coeffect_only Coeffect.Read_mutable
       | Cprobe_is_enabled _ -> EC.coeffect_only Coeffect.Arbitrary
       | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor
+      | Cbswap _
       | Cclz _ | Cctz _ | Cpopcnt
       | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf | Cabsf
       | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat | Ccmpf _ ->


### PR DESCRIPTION
This PR refactors the handling of bswap. Adding Cmm operation for byte swap simplifies cmmgen and selection.  
No changes in generated code. Another PR will follow with code generation improvements. 
