### PR TITLE
Don't sign-extend bswap32 in Emit (amd64)

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -863,7 +863,6 @@ let emit_instr fallthrough i =
       I.movzx (res16 i 0) (res i 0)
   | Lop(Ispecific(Ibswap 32)) ->
       I.bswap (res32 i 0);
-      I.movsxd (res32 i 0) (res i 0)
   | Lop(Ispecific(Ibswap 64)) ->
       I.bswap (res i 0)
   | Lop(Ispecific(Ibswap _)) ->


### PR DESCRIPTION
`Ibswap` operation should treat its input as unsigned, but there is some inconsistently currently. For `Ibswap 16`, amd64 emits  zero-extension, but `Ibswap 32` gets sign-extended and we get code that looks like this:

```
camlT__test_swap32_11:
	subq	$8, %rsp
.L100:
	subq	$24, %r15
	cmpq	8(%r14), %r15
	jb	.L101
.L103:
	leaq	8(%r15), %rbx
	movq	$2303, -8(%rbx)
	movq	caml_int32_ops@GOTPCREL(%rip), %rdi
	movq	%rdi, (%rbx)
	movslq	8(%rax), %rax
	bswap	%eax
	movslq	%eax, %rax                
	movslq	%eax, %rax                ;; and one more time, just to be sure
	movq	%rax, 8(%rbx)
	movq	%rbx, %rax
	addq	$8, %rsp
	ret
```
because the result of `Ibswap 32` is also sign-extended when it's boxed (see `Cmm_helpers.box_int_gen`), and it's the only way `Ibswap 32` is used.

@stedolan  I think the sign-extension in `Emit` became unnecessary after https://github.com/ocaml/ocaml/pull/9006

