### PR TITLE
Use C++ name mangling convention

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -528,12 +528,17 @@ fmt:
 	ocamlformat -i \
 	  $$(find backend/cfg \
 	    \( -name "*.ml" -or -name "*.mli" \))
+	ocamlformat -i middle_end/mangling.ml
+	ocamlformat -i middle_end/mangling.mli
 	ocamlformat -i tools/merge_archives.ml
 
 .PHONY: check-fmt
 check-fmt:
 	if [ "$$(git status --porcelain middle_end/flambda2)" != "" ] || \
-           [ "$$(git status --porcelain backend/cfg)" != "" ]; then \
+           [ "$$(git status --porcelain backend/cfg)" != "" ] || \
+           [ "$$(git status --porcelain middle_end/mangling.ml)" != "" ] || \
+           [ "$$(git status --porcelain middle_end/mangling.mli)" != "" ] || \
+           [ "$$(git status --porcelain tools/merge_archives.ml)" != "" ]; then \
 	  echo; \
 	  echo "Tree must be clean before running 'make check-fmt'"; \
 	  exit 1; \
@@ -541,6 +546,8 @@ check-fmt:
 	$(MAKE) fmt
 	if [ "$$(git diff middle_end/flambda2)" != "" ] || \
            [ "$$(git diff backend/cfg)" != "" ] || \
+           [ "$$(git diff middle_end/mangling.ml)" != "" ] || \
+           [ "$$(git diff middle_end/mangling.mli)" != "" ] || \
            [ "$$(git diff tools/merge_archives.ml)" != "" ]; then \
 	  echo; \
 	  echo "The following code was not formatted correctly:"; \

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -27,6 +27,9 @@ let mk_dcfg f =
   "-dcfg", Arg.Unit f, " (undocumented)"
 ;;
 
+let mk_use_cpp_mangling f =
+  "-use-cpp-mangling", Arg.Unit f, " Use cpp mangling for function symbols."
+
 module Flambda2 = Flambda_backend_flags.Flambda2
 
 let mk_flambda2_result_types_functors_only f =
@@ -392,6 +395,8 @@ module type Flambda_backend_options = sig
   val no_ocamlcfg : unit -> unit
   val dcfg : unit -> unit
 
+  val use_cpp_mangling : unit -> unit
+
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
   val flambda2_result_types_functors_only : unit -> unit
@@ -454,6 +459,8 @@ struct
     mk_ocamlcfg F.ocamlcfg;
     mk_no_ocamlcfg F.no_ocamlcfg;
     mk_dcfg F.dcfg;
+
+    mk_use_cpp_mangling F.use_cpp_mangling;
 
     mk_flambda2_join_points F.flambda2_join_points;
     mk_no_flambda2_join_points F.no_flambda2_join_points;
@@ -547,6 +554,8 @@ module Flambda_backend_options_impl = struct
   let ocamlcfg = set Flambda_backend_flags.use_ocamlcfg
   let no_ocamlcfg = clear Flambda_backend_flags.use_ocamlcfg
   let dcfg = set Flambda_backend_flags.dump_cfg
+
+  let use_cpp_mangling = set Flambda_backend_flags.use_cpp_mangling
 
   let flambda2_join_points = set Flambda2.join_points
   let no_flambda2_join_points = clear Flambda2.join_points
@@ -703,6 +712,7 @@ module Extra_params = struct
         Flambda_backend_flags.set_o3 (); true
     (* define new params *)
     | "ocamlcfg" -> set Flambda_backend_flags.use_ocamlcfg
+    | "use-cpp-mangling" -> set Flambda_backend_flags.use_cpp_mangling
     | "flambda2-join-points" -> set Flambda2.join_points
     | "flambda2-result-types" ->
       (match String.lowercase_ascii v with

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -28,7 +28,7 @@ let mk_dcfg f =
 ;;
 
 let mk_use_cpp_mangling f =
-  "-use-cpp-mangling", Arg.Unit f, " Use cpp mangling for function symbols."
+  "-gcpp-mangling", Arg.Unit f, " Use C++ mangling for function symbols"
 
 module Flambda2 = Flambda_backend_flags.Flambda2
 

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -24,6 +24,8 @@ module type Flambda_backend_options = sig
   val no_ocamlcfg : unit -> unit
   val dcfg : unit -> unit
 
+  val use_cpp_mangling : unit -> unit
+
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
   val flambda2_result_types_functors_only : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -16,6 +16,8 @@
 let use_ocamlcfg = ref false            (* -ocamlcfg *)
 let dump_cfg = ref false                (* -dcfg *)
 
+let use_cpp_mangling = ref false        (* -use-cpp-mangling *)
+
 type function_result_types = Never | Functors_only | All_functions
 
 module Flambda2 = struct

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -17,6 +17,8 @@
 val use_ocamlcfg : bool ref
 val dump_cfg : bool ref
 
+val use_cpp_mangling : bool ref
+
 type function_result_types = Never | Functors_only | All_functions
 
 module Flambda2 : sig

--- a/dune
+++ b/dune
@@ -86,6 +86,7 @@
   clambda_primitives
   compilation_unit
   compilenv
+  mangling
   convert_primitives
   internal_variable_names
   linkage_name
@@ -445,6 +446,7 @@
   (clambda_primitives.mli as compiler-libs/clambda_primitives.mli)
   (compilation_unit.mli as compiler-libs/compilation_unit.mli)
   (compilenv.mli as compiler-libs/compilenv.mli)
+  (mangling.mli as compiler-libs/mangling.mli)
   (convert_primitives.mli as compiler-libs/convert_primitives.mli)
   (internal_variable_names.mli as compiler-libs/internal_variable_names.mli)
   (linkage_name.mli as compiler-libs/linkage_name.mli)
@@ -1539,6 +1541,10 @@
   (.ocamloptcomp.objs/byte/compilenv.cmo as compiler-libs/compilenv.cmo)
   (.ocamloptcomp.objs/byte/compilenv.cmt as compiler-libs/compilenv.cmt)
   (.ocamloptcomp.objs/byte/compilenv.cmti as compiler-libs/compilenv.cmti)
+  (.ocamloptcomp.objs/byte/mangling.cmi as compiler-libs/mangling.cmi)
+  (.ocamloptcomp.objs/byte/mangling.cmo as compiler-libs/mangling.cmo)
+  (.ocamloptcomp.objs/byte/mangling.cmt as compiler-libs/mangling.cmt)
+  (.ocamloptcomp.objs/byte/mangling.cmti as compiler-libs/mangling.cmti)
   (.ocamloptcomp.objs/byte/convert_primitives.cmi
    as
    compiler-libs/convert_primitives.cmi)
@@ -2244,6 +2250,7 @@
    as
    compiler-libs/compilation_unit.cmx)
   (.ocamloptcomp.objs/native/compilenv.cmx as compiler-libs/compilenv.cmx)
+  (.ocamloptcomp.objs/native/mangling.cmx as compiler-libs/mangling.cmx)
   (.ocamloptcomp.objs/native/convert_primitives.cmx
    as
    compiler-libs/convert_primitives.cmx)

--- a/middle_end/.ocamlformat
+++ b/middle_end/.ocamlformat
@@ -1,0 +1,14 @@
+# Please make a pull request to change this file.
+# Keep this file in sync with other .ocamlformat files in this repo.
+assignment-operator=begin-line
+cases-exp-indent=2
+doc-comments=before
+dock-collection-brackets=false
+exp-grouping=preserve
+if-then-else=keyword-first
+parens-tuple=multi-line-only
+space-around-lists=false
+space-around-variants=false
+type-decl=sparse
+wrap-comments=true
+version=0.19.0

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1391,7 +1391,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
           (id, Lfunction({kind; params; return; body; loc; mode; region}
                          as funct)) ->
             Lambda.check_lfunction funct;
-            let label = Compilenv.make_symbol (Some (V.unique_name id)) in
+            let label = Compilenv.make_fun_symbol loc (V.unique_name id) in
             let arity = List.length params in
             let fundesc =
               {fun_label = label;

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -120,7 +120,10 @@ let make_symbol ?(unitname = current_unit.ui_symbol) idopt =
   | Some id -> concat_symbol prefix id
 
 let make_fun_symbol ?(unitname = current_unit.ui_symbol) loc id =
-  Mangling.fun_symbol ~unitname ~loc ~id
+  if !Flambda_backend_flags.use_cpp_mangling then
+    Mangling.fun_symbol ~unitname ~loc ~id
+  else
+    make_symbol ~unitname (Some id)
 
 let current_unit_linkage_name () =
   Linkage_name.create (make_symbol ~unitname:current_unit.ui_symbol None)
@@ -437,9 +440,27 @@ let structured_constants () =
          exported = Hashtbl.mem exported_constants symbol;
          definition;
          provenance = Some provenance;
-       })
+        })
 
-let function_label closure_id =
+let legacy_closure_symbol fv =
+  let compilation_unit = Closure_id.get_compilation_unit fv in
+  let unitname =
+    Linkage_name.to_string (Compilation_unit.get_linkage_name compilation_unit)
+  in
+  let linkage_name =
+    concat_symbol unitname ((Closure_id.unique_name fv) ^ "_closure")
+  in
+  Symbol.of_global_linkage compilation_unit (Linkage_name.create linkage_name)
+
+let legacy_function_label fv =
+  let compilation_unit = Closure_id.get_compilation_unit fv in
+  let unitname =
+    Linkage_name.to_string
+      (Compilation_unit.get_linkage_name compilation_unit)
+  in
+  (concat_symbol unitname (Closure_id.unique_name fv))
+
+let cpp_function_label closure_id =
   let unitname =
     Closure_id.get_compilation_unit closure_id
     |> Compilation_unit.get_linkage_name
@@ -457,10 +478,22 @@ let function_label closure_id =
   in
   make_fun_symbol ~unitname scoped_loc name
 
-let closure_symbol closure_id =
+let cpp_closure_symbol closure_id =
   let compilation_unit = Closure_id.get_compilation_unit closure_id in
-  let linkage_name = (function_label closure_id) ^ "_closure" in
+  let linkage_name = (cpp_function_label closure_id) ^ "_closure" in
   Symbol.of_global_linkage compilation_unit (Linkage_name.create linkage_name)
+
+let function_label closure_id =
+  if !Flambda_backend_flags.use_cpp_mangling then
+    cpp_function_label closure_id
+  else
+    legacy_function_label closure_id
+
+let closure_symbol closure_id =
+  if !Flambda_backend_flags.use_cpp_mangling then
+    cpp_closure_symbol closure_id
+  else
+    legacy_closure_symbol closure_id
 
 let require_global global_ident =
   if not (Ident.is_predef global_ident) then

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -61,6 +61,7 @@ val make_symbol: ?unitname:string -> string option -> string
            [make_symbol ~unitname:u (Some id)] returns the asm symbol that
            corresponds to symbol [id] in the compilation unit [u]
            (or the current unit). *)
+val make_fun_symbol: ?unitname:string -> Debuginfo.Scoped_location.t -> string -> string
 
 val symbol_in_current_unit: string -> bool
         (* Return true if the given asm symbol belongs to the

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -61,7 +61,8 @@ val make_symbol: ?unitname:string -> string option -> string
            [make_symbol ~unitname:u (Some id)] returns the asm symbol that
            corresponds to symbol [id] in the compilation unit [u]
            (or the current unit). *)
-val make_fun_symbol: ?unitname:string -> Debuginfo.Scoped_location.t -> string -> string
+val make_fun_symbol: ?unitname:string -> Debuginfo.Scoped_location.t
+  -> string -> string
 
 val symbol_in_current_unit: string -> bool
         (* Return true if the given asm symbol belongs to the

--- a/middle_end/mangling.ml
+++ b/middle_end/mangling.ml
@@ -1,0 +1,254 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2010 Institut National de Recherche en Informatique et     *)
+(*     en Automatique                                                     *)
+(*   Copyright 2021--2022 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+let begins_with ?(from = 0) str prefix =
+  let rec helper idx =
+    if idx < 0 then true
+    else
+      String.get str (from + idx) = String.get prefix idx && helper (idx-1)
+  in
+  let n = String.length str in
+  let m = String.length prefix in
+  if n >= from + m then helper (m-1) else false
+
+let split_on_string str split =
+  let n = String.length str in
+  let m = String.length split in
+  let rec helper acc last_idx idx =
+    if idx = n then
+      let cur = String.sub str last_idx (idx - last_idx) in
+      List.rev (cur :: acc)
+    else if begins_with ~from:idx str split then
+      let cur = String.sub str last_idx (idx - last_idx) in
+      helper (cur :: acc) (idx + m) (idx + m)
+    else
+      helper acc last_idx (idx + 1)
+  in
+  helper [] 0 0
+
+let split_on_chars str chars =
+  let rec helper chars_left s acc =
+    match chars_left with
+    | [] -> s :: acc
+    | c :: cs ->
+      List.fold_right (helper cs) (String.split_on_char c s) acc
+  in
+  helper chars str []
+
+let split_last_exn str c =
+  let n = String.length str in
+  let ridx = String.rindex str c in
+  (String.sub str 0 ridx, String.sub str (ridx + 1) (n - ridx - 1))
+
+let escape_symbols part =
+  let buf = Buffer.create 16 in
+  let was_hex_last = ref false in
+  let handle_char = function
+    | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') as c ->
+      if !was_hex_last then Buffer.add_string buf "__";
+      Buffer.add_char buf c;
+      was_hex_last := false
+    | c ->
+      Printf.bprintf buf "%sX%02x"
+        (if !was_hex_last then "_" else "__")
+        (Char.code c);
+      was_hex_last := true
+  in
+  String.iter handle_char part;
+  Buffer.contents buf
+
+type expression =
+  | String of string
+  | Dot of expression * string
+
+type cpp_name =
+  | Simple of string
+  | Scoped of cpp_name list
+  | Templated of string * template_arg list
+
+and template_arg =
+  | Cpp_name of cpp_name
+  | Expression of expression
+
+let mangle_cpp name =
+  let with_length s =
+    let s = escape_symbols s in
+    Printf.sprintf "%d%s" (String.length s) s in
+  let rec mangle_expression = function
+    | String s -> with_length s
+    | Dot (e, name) -> Printf.sprintf "dt%s%s" (mangle_expression e) (with_length name)
+  in
+  let rec mangle_name = function
+    | Simple s -> with_length s
+    | Scoped names ->
+      let s = List.map mangle_name names |> String.concat "" in
+      Printf.sprintf "N%sE" s
+    | Templated (str, parts) ->
+      let s = List.map mangle_arg parts |> String.concat "" in
+      Printf.sprintf "%sI%sE" (with_length str) s
+  and mangle_arg = function
+    | Cpp_name name -> mangle_name name
+    | Expression expression ->
+      Printf.sprintf "X%sE" (mangle_expression expression)
+  in
+  "_Z" ^ mangle_name name
+
+let file_template_arg file =
+  (* Take the file name only *)
+  let filename =
+    if String.contains file '/' then snd (split_last_exn file '/')
+    else file
+  in
+  match String.split_on_char '.' filename with
+  | [] -> Misc.fatal_error "Empty split"
+  | hd :: tl ->
+    let expr = List.fold_left (fun e x -> Dot (e, x)) (String hd) tl in
+    Expression expr
+
+let name_op = function
+  | "+" -> "PLUS"
+  | "++" -> "PLUSPLUS"
+  | "+." -> "PLUSDOT"
+  | "+=" -> "PLUSEQ"
+  | "-" -> "MINUS"
+  | "-." -> "MINUSDOT"
+  | "*" -> "STAR"
+  | "%" -> "PERCENT"
+  | "=" -> "EQUAL"
+  | "<" -> "LESS"
+  | ">" -> "GREATER"
+  | "<>" -> "NOTEQUAL"
+  | "||" -> "BARBAR"
+  | "&" -> "AMPERSAND"
+  | "&&" -> "AMPERAMPER"
+  | ":=" -> "COLONEQUAL"
+  | "^" -> "CARET"
+  | "^^" -> "CARETCARET"
+  | "@" -> "AT"
+  | "<<" -> "LSHIFT"
+  | ">>" -> "RSHIFT"
+  | op -> op
+
+let build_location_info loc =
+  let loc = Debuginfo.Scoped_location.to_location loc in
+  let (file, line, startchar) = Location.get_pos_info loc.loc_start in
+  let endchar = loc.loc_end.pos_cnum - loc.loc_start.pos_bol in
+  let line_str = Printf.sprintf "ln_%d" line in
+  let info = [ file_template_arg file; Cpp_name (Simple line_str) ] in
+  if startchar >= 0 then
+    let char_str = Printf.sprintf "ch_%d_to_%d" startchar endchar in
+    info @ [ Cpp_name (Simple char_str) ]
+  else info
+
+(* OCaml names can contain single quotes but need to be escaped
+   for C++ identifiers. *)
+let convert_identifier str =
+  match String.split_on_char '\'' str with
+  | [] -> Misc.fatal_error "empty split"
+  | [ s ] -> Simple s
+  | parts ->
+    let s = String.concat "_Q" parts in
+    Templated (s, [ Cpp_name (Simple "quoted")] )
+
+let convert_closure_id id loc =
+  if begins_with id "anon_fn[" then
+    (* Keep the unique integer stamp *)
+    let (_init, stamp) = split_last_exn id '_' in
+    (* Put the location inside C++ template args *)
+    Templated ("anon_fn_" ^ stamp, build_location_info loc)
+  else
+    match id.[0] with
+    (* A regular identifier *)
+    | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') -> convert_identifier id
+    (* An operator *)
+    | _op ->
+      let (op, stamp) = split_last_exn id '_' in
+      Templated ("op_" ^ stamp, [Cpp_name (Simple (name_op op))])
+ 
+let convert_scope scope =
+  let n = String.length scope in
+  (* anonymous function *)
+  if String.equal scope "(fun)" then Templated ("anon_fn", [])
+  (* operators *)
+  else if n > 2 && String.get scope 0 = '(' && String.get scope (n - 1) = ')' then
+    let op = String.sub scope 1 (n - 2) in
+    Templated ("op", [ Cpp_name (Simple (name_op op)) ])
+  (* regular identifiers *)
+  else convert_identifier scope
+
+let list_of_scopes scopes =
+  (* Works for now since the only separators are '.' and '#' *)
+  let scope_str = Debuginfo.Scoped_location.string_of_scopes scopes in
+  split_on_chars scope_str [ '.'; '#' ]
+
+let scope_matches_closure_id scope closure_id =
+  (* If the `id` is an anonymous function this corresponds to that,
+      and, even if not, then the function has likely been given
+      a name via some aliasing (e.g. `let f = fun x -> ...`) *)
+  String.equal scope "(fun)" ||
+  (* Normal case where closure id and scope match directly *)
+  begins_with closure_id scope ||
+  (* For operators, the scope is wrapped in parens *)
+  ( String.length scope >= 3 &&
+    begins_with closure_id (String.sub scope 1 (String.length scope - 2)))
+
+(* Returns a pair of the top-level module and the list of scopes
+   the strictly contain the closure id *)
+let module_and_scopes ~unitname loc id =
+  match (loc : Debuginfo.Scoped_location.t) with
+  | Loc_known { loc = _; scopes } ->
+    let scopes = list_of_scopes scopes in
+    (* Remove last scope if it matches closure id *)
+    let scopes =
+      match List.rev scopes with
+      | [] -> Misc.fatal_errorf "No location - %s %s" unitname id
+      | last_scope :: rest when scope_matches_closure_id last_scope id ->
+        List.rev rest
+      | _ -> scopes
+    in
+    (* If the scope is now empty, use the unitname as the top-level module *)
+    begin match scopes with
+      | [] -> unitname, []
+      | top_module :: sub_scopes -> top_module, sub_scopes
+    end
+  | Loc_unknown -> unitname, []
+
+let remove_prefix ~prefix str =
+  let n = String.length prefix in
+  if begins_with str prefix then
+    String.sub str n (String.length str - n)
+  else
+    str
+
+let fun_symbol ~unitname ~loc ~id =
+  let unitname = remove_prefix ~prefix:"caml" unitname  in
+  let top_level_module, sub_scopes = module_and_scopes ~unitname loc id in
+  let namespace_parts name =
+    split_on_string name "__" |> List.map (fun part -> Simple part)
+  in
+  let parts =
+    List.concat [
+      namespace_parts top_level_module;
+      List.map convert_scope sub_scopes;
+      [ convert_closure_id id loc ];
+      if String.equal top_level_module unitname then []
+      else [
+        Templated ("inlined_in",
+          [ Cpp_name (Scoped (namespace_parts unitname)) ])
+      ]
+    ]
+  in
+  mangle_cpp (Scoped parts)

--- a/middle_end/mangling.ml
+++ b/middle_end/mangling.ml
@@ -79,12 +79,8 @@ let mangle_cpp name =
   "_Z" ^ mangle_name name
 
 let file_template_arg file =
-  (* Take the file name only *)
-  let filename =
-    if String.contains file '/'
-    then snd (String.split_last_exn file '/')
-    else file
-  in
+  (* Take the base name only *)
+  let filename = Filename.basename file in
   match String.split_on_char '.' filename with
   | [] -> Misc.fatal_error "Empty split"
   | hd :: tl ->

--- a/middle_end/mangling.ml
+++ b/middle_end/mangling.ml
@@ -178,7 +178,7 @@ let scope_matches_closure_id scope closure_id =
   && String.begins_with closure_id
        (String.sub scope 1 (String.length scope - 2))
 
-(* Returns a pair of the top-level module and the list of scopes the strictly
+(* Returns a pair of the top-level module and the list of scopes that strictly
    contain the closure id *)
 let module_and_scopes ~unitname loc id =
   match (loc : Debuginfo.Scoped_location.t) with

--- a/middle_end/mangling.ml
+++ b/middle_end/mangling.ml
@@ -1,18 +1,25 @@
-(**************************************************************************)
-(*                                                                        *)
-(*                                 OCaml                                  *)
-(*                                                                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
-(*                                                                        *)
-(*   Copyright 2010 Institut National de Recherche en Informatique et     *)
-(*     en Automatique                                                     *)
-(*   Copyright 2021--2022 Jane Street Group LLC                           *)
-(*                                                                        *)
-(*   All rights reserved.  This file is distributed under the terms of    *)
-(*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.          *)
-(*                                                                        *)
-(**************************************************************************)
+(* The MIT License
+ *
+ * Copyright (c) 2021--2022 Jane Street Group, LLC opensource@janestreet.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *)
 
 let begins_with ?(from = 0) str prefix =
   let rec helper idx =
@@ -177,7 +184,7 @@ let convert_closure_id id loc =
     | _op ->
       let (op, stamp) = split_last_exn id '_' in
       Templated ("op_" ^ stamp, [Cpp_name (Simple (name_op op))])
- 
+
 let convert_scope scope =
   let n = String.length scope in
   (* anonymous function *)

--- a/middle_end/mangling.mli
+++ b/middle_end/mangling.mli
@@ -1,17 +1,24 @@
-(**************************************************************************)
-(*                                                                        *)
-(*                                 OCaml                                  *)
-(*                                                                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
-(*                                                                        *)
-(*   Copyright 2010 Institut National de Recherche en Informatique et     *)
-(*     en Automatique                                                     *)
-(*   Copyright 2021--2022 Jane Street Group LLC                           *)
-(*                                                                        *)
-(*   All rights reserved.  This file is distributed under the terms of    *)
-(*   the GNU Lesser General Public License version 2.1, with the          *)
-(*   special exception on linking described in the file LICENSE.          *)
-(*                                                                        *)
-(**************************************************************************)
+(* The MIT License
+ *
+ * Copyright (c) 2021--2022 Jane Street Group, LLC opensource@janestreet.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *)
 
 val fun_symbol : unitname:string -> loc:Debuginfo.Scoped_location.t -> id:string -> string

--- a/middle_end/mangling.mli
+++ b/middle_end/mangling.mli
@@ -21,4 +21,5 @@
  * SOFTWARE.
  *)
 
-val fun_symbol : unitname:string -> loc:Debuginfo.Scoped_location.t -> id:string -> string
+val fun_symbol :
+  unitname:string -> loc:Debuginfo.Scoped_location.t -> id:string -> string

--- a/middle_end/mangling.mli
+++ b/middle_end/mangling.mli
@@ -1,0 +1,17 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2010 Institut National de Recherche en Informatique et     *)
+(*     en Automatique                                                     *)
+(*   Copyright 2021--2022 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val fun_symbol : unitname:string -> loc:Debuginfo.Scoped_location.t -> id:string -> string

--- a/ocaml/testsuite/tests/asmcomp/func_sections.run
+++ b/ocaml/testsuite/tests/asmcomp/func_sections.run
@@ -7,4 +7,4 @@ ${program}
 
 # now check the assembly file produced during compilation
 asm=${test_build_directory}/func_sections.s
-grep ".section .text.caml.camlFunc_sections__" "$asm" | wc -l | tr -d ' ' | sed '/^$/d'
+grep -E ".section .text.caml.(camlFunc_sections__|_ZN13Func_sections)" "$asm" | wc -l | tr -d ' ' | sed '/^$/d'

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -97,6 +97,8 @@ let rec split_last = function
 
 module Stdlib = struct
   module List = struct
+    include List
+
     type 'a t = 'a list
 
     let rec compare cmp l1 l2 =
@@ -227,6 +229,45 @@ module Stdlib = struct
 
     let print ppf t =
       Format.pp_print_string ppf t
+
+    let begins_with ?(from = 0) str ~prefix =
+      let rec helper idx =
+        if idx < 0 then true
+        else
+          String.get str (from + idx) = String.get prefix idx && helper (idx-1)
+      in
+      let n = String.length str in
+      let m = String.length prefix in
+      if n >= from + m then helper (m-1) else false
+
+    let split_on_string str ~split_on =
+      let n = String.length str in
+      let m = String.length split_on in
+      let rec helper acc last_idx idx =
+        if idx = n then
+          let cur = String.sub str last_idx (idx - last_idx) in
+          List.rev (cur :: acc)
+        else if begins_with ~from:idx str ~prefix:split_on then
+          let cur = String.sub str last_idx (idx - last_idx) in
+          helper (cur :: acc) (idx + m) (idx + m)
+        else
+          helper acc last_idx (idx + 1)
+      in
+      helper [] 0 0
+
+    let split_on_chars str ~split_on:chars =
+      let rec helper chars_left s acc =
+        match chars_left with
+        | [] -> s :: acc
+        | c :: cs ->
+          List.fold_right (helper cs) (String.split_on_char c s) acc
+      in
+      helper chars str []
+
+    let split_last_exn str ~split_on =
+      let n = String.length str in
+      let ridx = String.rindex str split_on in
+      String.sub str 0 ridx, String.sub str (ridx + 1) (n - ridx - 1)
   end
 
   external compare : 'a -> 'a -> int = "%compare"

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -173,6 +173,15 @@ module Stdlib : sig
     val print : Format.formatter -> t -> unit
 
     val for_all : (char -> bool) -> t -> bool
+
+    val begins_with : ?from:int -> string -> prefix:string -> bool
+
+    val split_on_string : string -> split_on:string -> string list
+
+    val split_on_chars : string -> split_on:char list -> string list
+
+    (** Splits on the last occurrence of the given character. *)
+    val split_last_exn : string -> split_on:char -> string * string
   end
 
   external compare : 'a -> 'a -> int = "%compare"


### PR DESCRIPTION
Change the symbols to include the scope and use the C++ name mangling convention.
Newer version of #244 