### PR TITLE
CI: avoid unnecessary work when testing flambda2

### DIFF
--- a/ocaml/testsuite/Makefile
+++ b/ocaml/testsuite/Makefile
@@ -238,7 +238,7 @@ one: lib tools
 	@$(MAKE) check-failstamp
 	@if [ -n '$(LIST)' ] ; then \
      while IFS='' read -r LINE; do \
-       $(MAKE) --no-print-directory exec-one DIR=$$LINE ; \
+       $(MAKE) --no-print-directory exec-one DIR="`echo $$LINE | sed 's/^ *//g'`" ; \
      done < $$LIST 2>&1 | tee $(TESTLOG) ; \
      $(MAKE) report ; fi
 


### PR DESCRIPTION
When `runtest-upstream` is run for the flambda2 compiler,
and `parallel` is not present the following [command](https://github.com/ocaml-flambda/flambda-backend/blame/main/ocaml/testsuite/Makefile#L241):
```
$(MAKE) --no-print-directory exec-one DIR=$$LINE
```
results in:
```
$(MAKE) --no-print-directory exec-one DIR= some/path
```
because the file read to set `LINE` has leading spaces on
all lines.

As a consequence, the following [lines](https://github.com/ocaml-flambda/flambda-backend/blame/main/ocaml/testsuite/Makefile#L252):
```
	  for dir in $(DIR)/*; do
	    if [ -d $$dir ]; then
	      $(MAKE) exec-one DIR=$$dir;
	    fi;
	  done;
```
are evaluated with `DIR` set to the empty string, hence
iterating over the whole file system from the root.

As far as I can tell, it does not happen when `parallel`
is present because `parallel` itself appears to be
trimming the strings.
