### PR TITLE
Local allocations support for Flambda 2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
         "ocaml.sandbox": {
                 "kind": "opam",
-                "switch": "4.12-built-with-flambda2"
+                "switch": "4.12.0+closure+local"
         }
 }

--- a/middle_end/flambda2/from_lambda/lambda_conversions.ml
+++ b/middle_end/flambda2/from_lambda/lambda_conversions.ml
@@ -28,11 +28,8 @@ let check_float_array_optimisation_enabled () =
       "[Pgenarray] is not expected when the float array optimisation is \
        disabled"
 
-let local_unsupported () =
-  Misc.fatal_errorf "Local allocations are not yet supported in Flambda2"
-
-let alloc_mode (mode : L.alloc_mode) =
-  match mode with Alloc_heap -> () | Alloc_local -> local_unsupported ()
+let alloc_mode (mode : L.alloc_mode) : Alloc_mode.t =
+  match mode with Alloc_heap -> Heap | Alloc_local -> Local
 
 let rec value_kind (vk : L.value_kind) =
   match vk with
@@ -195,7 +192,7 @@ let convert_init_or_assign (i_or_a : L.initialization_or_assignment) :
   | Heap_initialization -> Initialization
   | Root_initialization ->
     Misc.fatal_error "[Root_initialization] should not appear in Flambda input"
-  | Local_assignment -> local_unsupported ()
+  | Local_assignment -> Local_assignment
 
 type converted_array_kind =
   | Array_kind of P.Array_kind.t

--- a/middle_end/flambda2/from_lambda/lambda_conversions.mli
+++ b/middle_end/flambda2/from_lambda/lambda_conversions.mli
@@ -87,6 +87,4 @@ val convert_field_read_semantics : Lambda.field_read_semantics -> Mutability.t
 
 val convert_lambda_block_size : int -> Targetint_31_63.Imm.t Or_unknown.t
 
-val local_unsupported : unit -> 'a
-
-val alloc_mode : Lambda.alloc_mode -> unit
+val alloc_mode : Lambda.alloc_mode -> Alloc_mode.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -76,6 +76,15 @@ module Env : sig
     t -> Continuation.t -> (Ident.t * Lambda.value_kind) list
 
   val get_mutable_variable : t -> Ident.t -> Ident.t
+
+  val entering_region : t -> Ident.t -> t
+
+  val innermost_region : t -> Ident.t
+
+  (** The innermost (newest) region is first in the list. *)
+  val region_stack : t -> Ident.t list
+
+  val region_stack_at_handler : t -> Continuation.t -> Ident.t list
 end = struct
   type t =
     { current_unit_id : Ident.t;
@@ -85,7 +94,9 @@ end = struct
       try_stack : Continuation.t list;
       try_stack_at_handler : Continuation.t list Continuation.Map.t;
       static_exn_continuation : Continuation.t Numeric_types.Int.Map.t;
-      recursive_static_catches : Numeric_types.Int.Set.t
+      recursive_static_catches : Numeric_types.Int.Set.t;
+      region_stack : Ident.t list;
+      region_stack_at_handler : Ident.t list Continuation.Map.t
     }
 
   let create ~current_unit_id ~return_continuation ~exn_continuation =
@@ -99,7 +110,9 @@ end = struct
       try_stack = [];
       try_stack_at_handler = Continuation.Map.empty;
       static_exn_continuation = Numeric_types.Int.Map.empty;
-      recursive_static_catches = Numeric_types.Int.Set.empty
+      recursive_static_catches = Numeric_types.Int.Set.empty;
+      region_stack = [];
+      region_stack_at_handler = Continuation.Map.empty
     }
 
   let current_unit_id t = t.current_unit_id
@@ -138,6 +151,9 @@ end = struct
 
   let add_continuation t cont ~push_to_try_stack (recursive : Asttypes.rec_flag)
       =
+    let new_region_stack_at_handler =
+      Continuation.Map.add cont t.region_stack t.region_stack_at_handler
+    in
     let body_env =
       let mutables_needed_by_continuations =
         Continuation.Map.add cont (mutables_in_scope t)
@@ -146,7 +162,16 @@ end = struct
       let try_stack =
         if push_to_try_stack then cont :: t.try_stack else t.try_stack
       in
-      { t with mutables_needed_by_continuations; try_stack }
+      let region_stack_at_handler =
+        match recursive with
+        | Nonrecursive -> t.region_stack_at_handler
+        | Recursive -> new_region_stack_at_handler
+      in
+      { t with
+        mutables_needed_by_continuations;
+        try_stack;
+        region_stack_at_handler
+      }
     in
     let current_values_of_mutables_in_scope =
       Ident.Map.mapi
@@ -162,7 +187,10 @@ end = struct
           then Misc.fatal_error "Try continuations should not be recursive";
           body_env
       in
-      { handler_env with current_values_of_mutables_in_scope }
+      { handler_env with
+        current_values_of_mutables_in_scope;
+        region_stack_at_handler = new_region_stack_at_handler
+      }
     in
     let extra_params =
       Ident.Map.data handler_env.current_values_of_mutables_in_scope
@@ -175,7 +203,9 @@ end = struct
         try_stack_at_handler =
           Continuation.Map.add cont t.try_stack t.try_stack_at_handler;
         static_exn_continuation =
-          Numeric_types.Int.Map.add static_exn cont t.static_exn_continuation
+          Numeric_types.Int.Map.add static_exn cont t.static_exn_continuation;
+        region_stack_at_handler =
+          Continuation.Map.add cont t.region_stack t.region_stack_at_handler
       }
     in
     let recursive : Asttypes.rec_flag =
@@ -237,6 +267,23 @@ end = struct
     | exception Not_found ->
       Misc.fatal_errorf "Mutable variable %a not bound in env" Ident.print id
     | id, _kind -> id
+
+  let entering_region t id = { t with region_stack = id :: t.region_stack }
+
+  let innermost_region t =
+    match t.region_stack with
+    | region :: _ -> region
+    | [] ->
+      Misc.fatal_error "Cannot get innermost region as no regions are open"
+
+  let region_stack t = t.region_stack
+
+  let region_stack_at_handler t continuation =
+    match Continuation.Map.find continuation t.region_stack_at_handler with
+    | exception Not_found ->
+      Misc.fatal_errorf "No region stack recorded for handler %a"
+        Continuation.print continuation
+    | stack -> stack
 end
 
 module CCenv = Closure_conversion_aux.Env
@@ -276,7 +323,8 @@ let _print_stack ppf stack =
     stack
 
 (* Uses of [Lstaticfail] that jump out of try-with handlers need special care:
-   the correct number of pop trap operations must be inserted. *)
+   the correct number of pop trap operations must be inserted. A similar thing
+   is also necessary for closing local allocation regions. *)
 let compile_staticfail acc env ccenv ~(continuation : Continuation.t) ~args :
     Acc.t * Expr_with_acc.t =
   let try_stack_at_handler = Env.get_try_stack_at_handler env continuation in
@@ -315,11 +363,46 @@ let compile_staticfail acc env ccenv ~(continuation : Continuation.t) ~args :
     | [], _ :: _ -> assert false
     (* see above *)
   in
-  let after_pop acc ccenv =
-    CC.close_apply_cont acc ccenv continuation None args
+  let region_stack_at_handler = Env.region_stack_at_handler env continuation in
+  let region_stack_now = Env.region_stack env in
+  if List.length region_stack_at_handler > List.length region_stack_now
+  then
+    Misc.fatal_errorf
+      "Cannot jump to continuation %a: it would involve jumping into a local \
+       allocation region"
+      Continuation.print continuation;
+  assert (
+    Ident.Set.subset
+      (Ident.Set.of_list region_stack_at_handler)
+      (Ident.Set.of_list region_stack_now));
+  let rec add_end_regions acc ~region_stack_now =
+    let add_end_region region ~region_stack_now after_everything =
+      let add_remaining_end_regions acc =
+        add_end_regions acc ~region_stack_now
+      in
+      let body = add_remaining_end_regions acc after_everything in
+      fun acc ccenv ->
+        CC.close_let acc ccenv
+          (Ident.create_local "unit")
+          Not_user_visible (End_region region) ~body
+    in
+    let no_end_region after_everything = after_everything in
+    match region_stack_now, region_stack_at_handler with
+    | [], [] -> no_end_region
+    | region1 :: region_stack_now, region2 :: _ ->
+      if Ident.same region1 region2
+      then no_end_region
+      else add_end_region region1 ~region_stack_now
+    | region :: region_stack_now, [] -> add_end_region region ~region_stack_now
+    | [], _ :: _ -> assert false
+    (* see above *)
   in
-  let mk_poptraps = add_pop_traps acc ~try_stack_now after_pop in
-  mk_poptraps acc ccenv
+  add_pop_traps acc ~try_stack_now
+    (fun acc ccenv ->
+      add_end_regions acc ~region_stack_now
+        (fun acc ccenv -> CC.close_apply_cont acc ccenv continuation None args)
+        acc ccenv)
+    acc ccenv
 
 let switch_for_if_then_else ~cond ~ifso ~ifnot =
   (* CR mshinwell: We need to make sure that [cond] is {0, 1}-valued. The
@@ -633,6 +716,9 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pprobe_is_enabled _ ->
     false
 
+(* CR mshinwell: Make sure that [Apply] terms in tail position jump directly to
+   the return continuation rather than relying on a wrapper to be removed. *)
+
 let rec cps_non_tail acc env ccenv (lam : L.lambda)
     (k : Acc.t -> Env.t -> CCenv.t -> Ident.t -> Acc.t * Expr_with_acc.t)
     (k_exn : Continuation.t) : Acc.t * Expr_with_acc.t =
@@ -650,7 +736,7 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
   | Lapply
       { ap_func;
         ap_args;
-        ap_region_close = _;
+        ap_region_close;
         ap_mode;
         ap_loc;
         ap_tailcall;
@@ -658,7 +744,13 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
         ap_specialised;
         ap_probe
       } ->
-    LC.alloc_mode ap_mode;
+    (* It is important that any necessary [End_region] marker (from a
+       surrounding [Lregion]) is inserted before the tail call! *)
+    let need_end_region =
+      match ap_region_close with
+      | Rc_normal -> false
+      | Rc_close_at_apply -> true
+    in
     cps_non_tail_list acc env ccenv ap_args
       (fun acc env ccenv args ->
         cps_non_tail acc env ccenv ap_func
@@ -683,10 +775,20 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
                     tailcall = ap_tailcall;
                     inlined = ap_inlined;
                     specialised = ap_specialised;
-                    probe = ap_probe
+                    probe = ap_probe;
+                    mode = ap_mode
                   }
                 in
-                wrap_return_continuation acc env ccenv apply)
+                if not need_end_region
+                then wrap_return_continuation acc env ccenv apply
+                else
+                  (* CR vlaviron: Need to close all regions, or equivalently the
+                     outermost one *)
+                  let region = Env.innermost_region env in
+                  CC.close_let acc ccenv (Ident.create_local "unit")
+                    Not_user_visible (End_region region) ~body:(fun acc ccenv ->
+                      let acc = Acc.add_region_closed_early acc region in
+                      wrap_return_continuation acc env ccenv apply))
               ~handler:(fun acc env ccenv -> k acc env ccenv result_var))
           k_exn)
       k_exn
@@ -837,8 +939,11 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
         CC.close_let_cont acc ccenv ~name:continuation ~is_exn_handler:false
           ~params ~recursive ~body ~handler)
       ~handler:(fun acc env ccenv -> k acc env ccenv result_var)
-  | Lsend (meth_kind, meth, obj, args, _pos, mode, loc) ->
-    LC.alloc_mode mode;
+  | Lsend (meth_kind, meth, obj, args, pos, mode, loc) ->
+    (* See comments in the [Lapply] case above. *)
+    let need_end_region =
+      match pos with Rc_normal -> false | Rc_close_at_apply -> true
+    in
     cps_non_tail_simple acc env ccenv obj
       (fun acc env ccenv obj ->
         cps_non_tail acc env ccenv meth
@@ -865,10 +970,21 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
                         tailcall = Default_tailcall;
                         inlined = Default_inlined;
                         specialised = Default_specialise;
-                        probe = None
+                        probe = None;
+                        mode
                       }
                     in
-                    wrap_return_continuation acc env ccenv apply)
+                    if not need_end_region
+                    then wrap_return_continuation acc env ccenv apply
+                    else
+                      (* CR vlaviron: Need to close all regions, or equivalently
+                         the outermost one *)
+                      let region = Env.innermost_region env in
+                      CC.close_let acc ccenv (Ident.create_local "unit")
+                        Not_user_visible (End_region region)
+                        ~body:(fun acc ccenv ->
+                          let acc = Acc.add_region_closed_early acc region in
+                          wrap_return_continuation acc env ccenv apply))
                   ~handler:(fun acc env ccenv -> k acc env ccenv result_var))
               k_exn)
           k_exn)
@@ -876,33 +992,47 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
   | Ltrywith (body, id, handler) ->
     let body_result = Ident.create_local "body_result" in
     let result_var = Ident.create_local "try_with_result" in
-    let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler:false
-      ~params:[result_var, Not_user_visible, Pgenval]
-      ~body:(fun acc env ccenv after_continuation ->
+    let region = Ident.create_local "try_region" in
+    (* As for all other constructs, the OCaml type checker and the Lambda
+       generation pass ensures that there will be an enclosing region around the
+       whole [Ltrywith] (possibly not immediately enclosing, but maybe further
+       out). The only reason we need a [Begin_region] here is to be able to
+       unwind the local allocation stack if the exception handler is invoked.
+       (This also explains why there is no [End_region] at the end of the "try"
+       body.) *)
+    CC.close_let acc ccenv region Not_user_visible Begin_region
+      ~body:(fun acc ccenv ->
         let_cont_nonrecursive_with_extra_params acc env ccenv
-          ~is_exn_handler:true
-          ~params:[id, User_visible, Pgenval]
-          ~body:(fun acc env ccenv handler_continuation ->
+          ~is_exn_handler:false
+          ~params:[result_var, Not_user_visible, Pgenval]
+          ~body:(fun acc env ccenv after_continuation ->
             let_cont_nonrecursive_with_extra_params acc env ccenv
-              ~is_exn_handler:false
-              ~params:[body_result, Not_user_visible, Pgenval]
-              ~body:(fun acc env ccenv poptrap_continuation ->
+              ~is_exn_handler:true
+              ~params:[id, User_visible, Pgenval]
+              ~body:(fun acc env ccenv handler_continuation ->
                 let_cont_nonrecursive_with_extra_params acc env ccenv
-                  ~is_exn_handler:false ~params:[]
-                  ~body:(fun acc env ccenv body_continuation ->
-                    apply_cont_with_extra_args acc env ccenv body_continuation
-                      (Some (IR.Push { exn_handler = handler_continuation }))
-                      [])
+                  ~is_exn_handler:false
+                  ~params:[body_result, Not_user_visible, Pgenval]
+                  ~body:(fun acc env ccenv poptrap_continuation ->
+                    let_cont_nonrecursive_with_extra_params acc env ccenv
+                      ~is_exn_handler:false ~params:[]
+                      ~body:(fun acc env ccenv body_continuation ->
+                        apply_cont_with_extra_args acc env ccenv
+                          body_continuation
+                          (Some (IR.Push { exn_handler = handler_continuation }))
+                          [])
+                      ~handler:(fun acc env ccenv ->
+                        cps_tail acc env ccenv body poptrap_continuation
+                          handler_continuation))
                   ~handler:(fun acc env ccenv ->
-                    cps_tail acc env ccenv body poptrap_continuation
-                      handler_continuation))
+                    apply_cont_with_extra_args acc env ccenv after_continuation
+                      (Some (IR.Pop { exn_handler = handler_continuation }))
+                      [IR.Var body_result]))
               ~handler:(fun acc env ccenv ->
-                apply_cont_with_extra_args acc env ccenv after_continuation
-                  (Some (IR.Pop { exn_handler = handler_continuation }))
-                  [IR.Var body_result]))
-          ~handler:(fun acc env ccenv ->
-            cps_tail acc env ccenv handler after_continuation k_exn))
-      ~handler:(fun acc env ccenv -> k acc env ccenv result_var)
+                CC.close_let acc ccenv (Ident.create_local "unit")
+                  Not_user_visible (End_region region) ~body:(fun acc ccenv ->
+                    cps_tail acc env ccenv handler after_continuation k_exn)))
+          ~handler:(fun acc env ccenv -> k acc env ccenv result_var))
   | Lifthenelse (cond, ifso, ifnot) ->
     let lam = switch_for_if_then_else ~cond ~ifso ~ifnot in
     cps_non_tail acc env ccenv lam k k_exn
@@ -939,10 +1069,20 @@ let rec cps_non_tail acc env ccenv (lam : L.lambda)
        by completely removing it (replacing by unit). *)
     Misc.fatal_error
       "[Lifused] should have been removed by [Simplif.simplify_lets]"
-  | Lregion lam ->
-    (* CR sdolan: Ignoring Lregion is only correct because Flambda2 does not yet
-       generate local allocations *)
-    cps_non_tail acc env ccenv lam k k_exn
+  | Lregion body ->
+    let region = Ident.create_local "region" in
+    CC.close_let acc ccenv region Not_user_visible Begin_region
+      ~body:(fun acc ccenv ->
+        let env = Env.entering_region env region in
+        cps_non_tail acc env ccenv body
+          (fun acc env ccenv result ->
+            if Acc.region_closed_early acc region
+            then k acc env ccenv result
+            else
+              CC.close_let acc ccenv (Ident.create_local "unit")
+                Not_user_visible (End_region region) ~body:(fun acc ccenv ->
+                  k acc env ccenv result))
+          k_exn)
 
 and cps_non_tail_simple acc env ccenv (lam : L.lambda)
     (k : Acc.t -> Env.t -> CCenv.t -> IR.simple -> Acc.t * Expr_with_acc.t)
@@ -971,10 +1111,25 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
     else apply_cont_with_extra_args acc env ccenv k None [IR.Var id]
   | Lconst const ->
     name_then_cps_tail acc env ccenv "const" (IR.Simple (Const const)) k k_exn
-  | Lapply apply ->
-    cps_non_tail_list acc env ccenv apply.ap_args
+  | Lapply
+      { ap_func;
+        ap_args;
+        ap_region_close;
+        ap_mode;
+        ap_loc;
+        ap_tailcall;
+        ap_inlined;
+        ap_specialised;
+        ap_probe
+      } ->
+    let need_end_region =
+      match ap_region_close with
+      | Rc_normal -> false
+      | Rc_close_at_apply -> true
+    in
+    cps_non_tail_list acc env ccenv ap_args
       (fun acc env ccenv args ->
-        cps_non_tail acc env ccenv apply.ap_func
+        cps_non_tail acc env ccenv ap_func
           (fun acc env ccenv func ->
             let exn_continuation : IR.exn_continuation =
               { exn_handler = k_exn;
@@ -987,14 +1142,24 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
                 continuation = k;
                 exn_continuation;
                 args;
-                loc = apply.ap_loc;
-                tailcall = apply.ap_tailcall;
-                inlined = apply.ap_inlined;
-                specialised = apply.ap_specialised;
-                probe = apply.ap_probe
+                loc = ap_loc;
+                tailcall = ap_tailcall;
+                inlined = ap_inlined;
+                specialised = ap_specialised;
+                probe = ap_probe;
+                mode = ap_mode
               }
             in
-            wrap_return_continuation acc env ccenv apply)
+            if not need_end_region
+            then wrap_return_continuation acc env ccenv apply
+            else
+              (* CR vlaviron: Need to close all regions, or equivalently the
+                 outermost one *)
+              let region = Env.innermost_region env in
+              CC.close_let acc ccenv (Ident.create_local "unit")
+                Not_user_visible (End_region region) ~body:(fun acc ccenv ->
+                  let acc = Acc.add_region_closed_early acc region in
+                  wrap_return_continuation acc env ccenv apply))
           k_exn)
       k_exn
   | Lfunction func ->
@@ -1153,8 +1318,10 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
     in
     CC.close_let_cont acc ccenv ~name:continuation ~is_exn_handler:false ~params
       ~recursive ~body ~handler
-  | Lsend (meth_kind, meth, obj, args, _pos, mode, loc) ->
-    LC.alloc_mode mode;
+  | Lsend (meth_kind, meth, obj, args, pos, mode, loc) ->
+    let need_end_region =
+      match pos with Rc_normal -> false | Rc_close_at_apply -> true
+    in
     cps_non_tail_simple acc env ccenv obj
       (fun acc env ccenv obj ->
         cps_non_tail acc env ccenv meth
@@ -1176,10 +1343,20 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
                     tailcall = Default_tailcall;
                     inlined = Default_inlined;
                     specialised = Default_specialise;
-                    probe = None
+                    probe = None;
+                    mode
                   }
                 in
-                wrap_return_continuation acc env ccenv apply)
+                if not need_end_region
+                then wrap_return_continuation acc env ccenv apply
+                else
+                  (* CR vlaviron: Need to close all regions, or equivalently the
+                     outermost one *)
+                  let region = Env.innermost_region env in
+                  CC.close_let acc ccenv (Ident.create_local "unit")
+                    Not_user_visible (End_region region) ~body:(fun acc ccenv ->
+                      let acc = Acc.add_region_closed_early acc region in
+                      wrap_return_continuation acc env ccenv apply))
               k_exn)
           k_exn)
       k_exn
@@ -1199,27 +1376,34 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
       k_exn
   | Ltrywith (body, id, handler) ->
     let body_result = Ident.create_local "body_result" in
-    let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler:true
-      ~params:[id, User_visible, Pgenval]
-      ~body:(fun acc env ccenv handler_continuation ->
+    let region = Ident.create_local "try_region" in
+    CC.close_let acc ccenv region Not_user_visible Begin_region
+      ~body:(fun acc ccenv ->
         let_cont_nonrecursive_with_extra_params acc env ccenv
-          ~is_exn_handler:false
-          ~params:[body_result, Not_user_visible, Pgenval]
-          ~body:(fun acc env ccenv poptrap_continuation ->
+          ~is_exn_handler:true
+          ~params:[id, User_visible, Pgenval]
+          ~body:(fun acc env ccenv handler_continuation ->
             let_cont_nonrecursive_with_extra_params acc env ccenv
-              ~is_exn_handler:false ~params:[]
-              ~body:(fun acc env ccenv body_continuation ->
-                apply_cont_with_extra_args acc env ccenv body_continuation
-                  (Some (IR.Push { exn_handler = handler_continuation }))
-                  [])
+              ~is_exn_handler:false
+              ~params:[body_result, Not_user_visible, Pgenval]
+              ~body:(fun acc env ccenv poptrap_continuation ->
+                let_cont_nonrecursive_with_extra_params acc env ccenv
+                  ~is_exn_handler:false ~params:[]
+                  ~body:(fun acc env ccenv body_continuation ->
+                    apply_cont_with_extra_args acc env ccenv body_continuation
+                      (Some (IR.Push { exn_handler = handler_continuation }))
+                      [])
+                  ~handler:(fun acc env ccenv ->
+                    cps_tail acc env ccenv body poptrap_continuation
+                      handler_continuation))
               ~handler:(fun acc env ccenv ->
-                cps_tail acc env ccenv body poptrap_continuation
-                  handler_continuation))
+                apply_cont_with_extra_args acc env ccenv k
+                  (Some (IR.Pop { exn_handler = handler_continuation }))
+                  [IR.Var body_result]))
           ~handler:(fun acc env ccenv ->
-            apply_cont_with_extra_args acc env ccenv k
-              (Some (IR.Pop { exn_handler = handler_continuation }))
-              [IR.Var body_result]))
-      ~handler:(fun acc env ccenv -> cps_tail acc env ccenv handler k k_exn)
+            CC.close_let acc ccenv (Ident.create_local "unit")
+              Not_user_visible (End_region region) ~body:(fun acc ccenv ->
+                cps_tail acc env ccenv handler k k_exn)))
   | Lifthenelse (cond, ifso, ifnot) ->
     let lam = switch_for_if_then_else ~cond ~ifso ~ifnot in
     cps_tail acc env ccenv lam k k_exn
@@ -1240,10 +1424,20 @@ and cps_tail acc env ccenv (lam : L.lambda) (k : Continuation.t)
        by completely removing it (replacing by unit). *)
     Misc.fatal_error
       "[Lifused] should have been removed by [Simplif.simplify_lets]"
-  | Lregion lam ->
-    (* CR sdolan: Ignoring Lregion is only correct because Flambda2 does not yet
-       generate local allocations *)
-    cps_tail acc env ccenv lam k k_exn
+  | Lregion body ->
+    let region = Ident.create_local "region" in
+    CC.close_let acc ccenv region Not_user_visible Begin_region
+      ~body:(fun acc ccenv ->
+        let env = Env.entering_region env region in
+        cps_non_tail acc env ccenv body
+          (fun acc env ccenv result ->
+            if Acc.region_closed_early acc region
+            then cps_tail acc env ccenv (L.Lvar result) k k_exn
+            else
+              CC.close_let acc ccenv (Ident.create_local "unit")
+                Not_user_visible (End_region region) ~body:(fun acc ccenv ->
+                  cps_tail acc env ccenv (L.Lvar result) k k_exn))
+          k_exn)
 
 and name_then_cps_non_tail acc env ccenv name defining_expr k _k_exn :
     Acc.t * Expr_with_acc.t =
@@ -1374,9 +1568,11 @@ and cps_function_bindings env (bindings : (Ident.t * L.lambda) list) =
     [] bindings_with_wrappers
 
 and cps_function env ~fid ~stub ~(recursive : Recursive.t) ?free_idents
-    ({ kind; params; return; body; attr; loc; mode; region = _ } : L.lfunction)
-    : Function_decl.t =
-  LC.alloc_mode mode;
+    ({ kind; params; return; body; attr; loc; mode; region } : L.lfunction) :
+    Function_decl.t =
+  let num_trailing_local_params =
+    match kind with Curried { nlocal } -> nlocal | Tupled -> 0
+  in
   let body_cont = Continuation.create ~sort:Return () in
   let body_exn_cont = Continuation.create () in
   let free_idents_of_body =
@@ -1401,7 +1597,8 @@ and cps_function env ~fid ~stub ~(recursive : Recursive.t) ?free_idents
   in
   Function_decl.create ~let_rec_ident:(Some fid) ~closure_id ~kind ~params
     ~return ~return_continuation:body_cont ~exn_continuation ~body ~attr ~loc
-    ~free_idents_of_body ~stub recursive
+    ~free_idents_of_body ~stub recursive ~closure_alloc_mode:mode
+    ~num_trailing_local_params ~contains_no_escaping_local_allocs:region
 
 and cps_switch acc env ccenv (switch : L.lambda_switch) ~scrutinee
     (k : Continuation.t) (k_exn : Continuation.t) : Acc.t * Expr_with_acc.t =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -179,7 +179,9 @@ let expression_for_failure acc exn_cont ~register_const_string primitive dbg
         Named.create_prim
           (Variadic
              ( Make_block
-                 (Values (Tag.Scannable.zero, [Any_value; Any_value]), Immutable),
+                 ( Values (Tag.Scannable.zero, [Any_value; Any_value]),
+                   Immutable,
+                   Heap ),
                contents_of_exn_bucket ))
           dbg
       in

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -28,7 +28,7 @@ type empty_naked_int64 = private Naked_int64
 
 type empty_naked_nativeint = private Naked_nativeint
 
-type fabricated = private Fabricated
+type region = private Region
 
 type rec_info = private Rec_info
 
@@ -74,7 +74,7 @@ end
 type t =
   | Value
   | Naked_number of Naked_number_kind.t
-  | Fabricated
+  | Region
   | Rec_info
 
 type kind = t
@@ -91,7 +91,7 @@ let naked_int64 = Naked_number Naked_int64
 
 let naked_nativeint = Naked_number Naked_nativeint
 
-let fabricated = Fabricated
+let region = Region
 
 let rec_info = Rec_info
 
@@ -109,14 +109,14 @@ include Container_types.Make (struct
       match t1, t2 with
       | Value, Value -> 0
       | Naked_number n1, Naked_number n2 -> Naked_number_kind.compare n1 n2
-      | Fabricated, Fabricated -> 0
+      | Region, Region -> 0
       | Rec_info, Rec_info -> 0
       | Value, _ -> -1
       | _, Value -> 1
       | Naked_number _, _ -> -1
       | _, Naked_number _ -> 1
-      | Fabricated, _ -> -1
-      | _, Fabricated -> 1
+      | Region, _ -> -1
+      | _, Region -> 1
 
   let equal t1 t2 = compare t1 t2 = 0
 
@@ -153,12 +153,12 @@ include Container_types.Make (struct
         Format.fprintf ppf "(Naked_number %a)"
           Naked_number_kind.print naked_number_kind
       end
-    | Fabricated ->
+    | Region ->
       if unicode then
-        Format.fprintf ppf "@<0>%s@<1>\u{1d53d}@<0>%s"
+        Format.fprintf ppf "@<0>%s@<1>\u{1d53d}@<1>\u{1d558}@<0>%s"
           colour (Flambda_colours.normal ())
       else
-        Format.fprintf ppf "Fab"
+        Format.fprintf ppf "Region"
     | Rec_info ->
       if unicode then
         Format.fprintf ppf "@<0>%s@<1>\u{211d}@<0>%s"
@@ -168,14 +168,14 @@ include Container_types.Make (struct
 end)
 
 let is_value t =
-  match t with Value -> true | Naked_number _ | Fabricated | Rec_info -> false
+  match t with Value -> true | Naked_number _ | Region | Rec_info -> false
 
 let is_naked_float t =
   match t with
   | Naked_number Naked_float -> true
   | Value
   | Naked_number (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint)
-  | Fabricated | Rec_info ->
+  | Region | Rec_info ->
     false
 
 module Standard_int = struct
@@ -459,7 +459,7 @@ module With_subkind = struct
     begin
       match kind with
       | Value -> ()
-      | Naked_number _ | Fabricated | Rec_info -> (
+      | Naked_number _ | Region | Rec_info -> (
         match subkind with
         | Anything -> ()
         | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
@@ -535,7 +535,7 @@ module With_subkind = struct
         Format.fprintf ppf "@[%a%a@]"
           print kind
           Subkind.print subkind
-      | (Naked_number _ | Fabricated | Rec_info),
+      | (Naked_number _ | Region | Rec_info),
         (Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
           | Tagged_immediate | Block _ | Float_block _ | Float_array | Immediate_array | Value_array | Generic_array) ->
         assert false
@@ -591,7 +591,7 @@ module With_subkind = struct
     | Value -> subkind_descr t.subkind
     | Naked_number naked_number_kind -> Naked_number naked_number_kind
     | Rec_info -> Rec_info
-    | Fabricated -> Misc.fatal_error "Not implemented"
+    | Region -> Misc.fatal_error "Not implemented"
 
   let rec compatible_descr descr ~when_used_at =
     match descr, when_used_at with

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -42,7 +42,7 @@ type naked_int64 = empty_naked_int64 * Numeric_types.Int64.Set.t
 
 type naked_nativeint = empty_naked_nativeint * Targetint_32_64.Set.t
 
-type fabricated = private Fabricated
+type region = private Region
 
 type rec_info = private Rec_info
 
@@ -62,11 +62,11 @@ type t = private
   | Value  (** OCaml values that may exist at source level. *)
   | Naked_number of Naked_number_kind.t
       (** The kind of unboxed numbers and untagged immediates. *)
-  | Fabricated
+  | Region
       (** Values which have been introduced by Flambda and are never accessible
           at the source language level (for example sets of closures). *)
   | Rec_info
-      (** Recursion depths of identifiers. Like [Fabricated], not accessible at
+      (** Recursion depths of identifiers. Like [Region], not accessible at
           the source level, but also not accessible at run time. *)
 
 type kind = t
@@ -84,9 +84,9 @@ val naked_int64 : t
 
 val naked_nativeint : t
 
-(* CR mshinwell: Fabricated kinds are only used in Flambda_static now. Make a
+(* CR mshinwell: Region kinds are only used in Flambda_static now. Make a
    separate type. *)
-val fabricated : t
+val region : t
 
 val rec_info : t
 

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -66,8 +66,8 @@ type t = private
       (** Values which have been introduced by Flambda and are never accessible
           at the source language level (for example sets of closures). *)
   | Rec_info
-      (** Recursion depths of identifiers. Like [Region], not accessible at
-          the source level, but also not accessible at run time. *)
+      (** Recursion depths of identifiers. Like [Region], not accessible at the
+          source level, but also not accessible at run time. *)
 
 type kind = t
 

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -104,7 +104,7 @@ type kind =
   (* can't alias because Flambda_kind.t is private *)
   | Value
   | Naked_number of naked_number_kind
-  | Fabricated
+  | Region
   | Rec_info
 
 type kind_with_subkind =
@@ -230,6 +230,7 @@ type string_or_bytes = Flambda_primitive.string_or_bytes =
 type init_or_assign = Flambda_primitive.Init_or_assign.t =
   | Initialization
   | Assignment
+  | Local_assignment
 
 type comparison = Flambda_primitive.comparison =
   | Eq

--- a/middle_end/flambda2/parser/flambda_lex.ml
+++ b/middle_end/flambda2/parser/flambda_lex.ml
@@ -51,7 +51,7 @@ let keyword_table =
     "end", KWD_END;
     "error", KWD_ERROR;
     "exn", KWD_EXN;
-    "fabricated", KWD_FABRICATED;
+    "region", KWD_FABRICATED;
     "float", KWD_FLOAT;
     "halt_and_catch_fire", KWD_HCF;
     "hint", KWD_HINT;

--- a/middle_end/flambda2/parser/flambda_parser.ml
+++ b/middle_end/flambda2/parser/flambda_parser.ml
@@ -5194,7 +5194,7 @@ module Tables = struct
 # 5195 "flambda_parser_in.ml"
         ) = 
 # 528 "flambda_parser.mly"
-                   ( Fabricated )
+                   ( Region )
 # 5199 "flambda_parser_in.ml"
          in
         {

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -132,7 +132,7 @@ let kind ppf (k : kind) =
   match k with
   | Value -> Format.pp_print_string ppf "val"
   | Naked_number nnk -> naked_number_kind ppf nnk
-  | Fabricated -> Format.pp_print_string ppf "fabricated"
+  | Region -> Format.pp_print_string ppf "region"
   | Rec_info -> Format.pp_print_string ppf "rec_info"
 
 let kind_with_subkind ppf (k : kind_with_subkind) =
@@ -267,7 +267,12 @@ let array_kind ~space ppf (ak : array_kind) =
   pp_option ~space Format.pp_print_string ppf str
 
 let init_or_assign ppf ia =
-  let str = match ia with Initialization -> "=" | Assignment -> "<-" in
+  let str =
+    match ia with
+    | Initialization -> "="
+    | Assignment -> "<-"
+    | Local_assignment -> "<-local"
+  in
   Format.fprintf ppf "%s" str
 
 let boxed_variable ppf var ~kind =

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -436,9 +436,9 @@ let remove_unused_closure_vars uacc static_const =
               closure_var)
           closure_vars
       in
-      Set_of_closures.create
-        (Set_of_closures.function_decls set_of_closures)
-        ~closure_elements)
+      Set_of_closures.create ~closure_elements
+        (Set_of_closures.alloc_mode set_of_closures)
+        (Set_of_closures.function_decls set_of_closures))
 
 let create_let_symbols uacc lifted_constant ~body =
   let bound_symbols = LC.bound_symbols lifted_constant in

--- a/middle_end/flambda2/simplify/non_constructed_code.ml
+++ b/middle_end/flambda2/simplify/non_constructed_code.ml
@@ -24,6 +24,10 @@ let newer_version_of = Code0.newer_version_of
 
 let params_arity = Code0.params_arity
 
+let num_leading_heap_params = Code0.num_leading_heap_params
+
+let num_trailing_local_params = Code0.num_trailing_local_params
+
 let result_arity = Code0.result_arity
 
 let result_types = Code0.result_types
@@ -48,15 +52,19 @@ let is_my_closure_used = Code0.is_my_closure_used
 
 let inlining_decision = Code0.inlining_decision
 
+let contains_no_escaping_local_allocs = Code0.contains_no_escaping_local_allocs
+
 let create code_id ~free_names_of_params_and_body ~newer_version_of
-    ~params_arity ~result_arity ~result_types ~stub ~inline ~is_a_functor
-    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
-    ~is_my_closure_used ~inlining_decision =
+    ~params_arity ~num_trailing_local_params ~result_arity ~result_types
+    ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor ~recursive
+    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
+    ~inlining_decision =
   Code0.create ~print_function_params_and_body:Unit.print code_id
     ~params_and_body:() ~free_names_of_params_and_body ~newer_version_of
-    ~params_arity ~result_arity ~result_types ~stub ~inline ~is_a_functor
-    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
-    ~is_my_closure_used ~inlining_decision
+    ~params_arity ~num_trailing_local_params ~result_arity ~result_types
+    ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor ~recursive
+    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
+    ~inlining_decision
 
 let print = Code0.print ~print_function_params_and_body:Unit.print
 

--- a/middle_end/flambda2/simplify/non_constructed_code.mli
+++ b/middle_end/flambda2/simplify/non_constructed_code.mli
@@ -27,6 +27,10 @@ val newer_version_of : t -> Code_id.t option
 
 val params_arity : t -> Flambda_arity.With_subkinds.t
 
+val num_leading_heap_params : t -> int
+
+val num_trailing_local_params : t -> int
+
 val result_arity : t -> Flambda_arity.With_subkinds.t
 
 val result_types : t -> Result_types.t
@@ -51,13 +55,17 @@ val is_my_closure_used : t -> bool
 
 val inlining_decision : t -> Function_decl_inlining_decision_type.t
 
+val contains_no_escaping_local_allocs : t -> bool
+
 val create :
   Code_id.t ->
   free_names_of_params_and_body:Name_occurrences.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
+  num_trailing_local_params:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
   result_types:Result_types.t ->
+  contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->

--- a/middle_end/flambda2/simplify/number_adjuncts.ml
+++ b/middle_end/flambda2/simplify/number_adjuncts.ml
@@ -124,11 +124,11 @@ module type Boxable = sig
     Flambda2_types.t ->
     Num.Set.t Flambda2_types.proof
 
-  val this_boxed : Num.t -> Flambda2_types.t
+  val this_boxed : Num.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
-  val these_boxed : Num.Set.t -> Flambda2_types.t
+  val these_boxed : Num.Set.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
-  val box : Flambda2_types.t -> Flambda2_types.t
+  val box : Flambda2_types.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
   type naked_number_kind
 end

--- a/middle_end/flambda2/simplify/number_adjuncts.mli
+++ b/middle_end/flambda2/simplify/number_adjuncts.mli
@@ -123,11 +123,11 @@ module type Boxable = sig
     Flambda2_types.t ->
     Num.Set.t Flambda2_types.proof
 
-  val this_boxed : Num.t -> Flambda2_types.t
+  val this_boxed : Num.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
-  val these_boxed : Num.Set.t -> Flambda2_types.t
+  val these_boxed : Num.Set.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
-  val box : Flambda2_types.t -> Flambda2_types.t
+  val box : Flambda2_types.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
   type naked_number_kind
 end

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -55,15 +55,18 @@ let create_normal_non_code const =
     }
 
 let create_code are_rebuilding code_id ~params_and_body
-    ~free_names_of_params_and_body ~newer_version_of ~params_arity ~result_arity
-    ~result_types ~stub ~inline ~is_a_functor ~recursive ~cost_metrics
-    ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision =
+    ~free_names_of_params_and_body ~newer_version_of ~params_arity
+    ~num_trailing_local_params ~result_arity ~result_types
+    ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor ~recursive
+    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
+    ~inlining_decision =
   if ART.do_not_rebuild_terms are_rebuilding
   then
     let non_constructed_code =
       Non_constructed_code.create code_id ~free_names_of_params_and_body
-        ~newer_version_of ~params_arity ~result_arity ~result_types ~stub
-        ~inline ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg
+        ~newer_version_of ~params_arity ~num_trailing_local_params ~result_arity
+        ~result_types ~contains_no_escaping_local_allocs ~stub ~inline
+        ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg
         ~is_tupled ~is_my_closure_used ~inlining_decision
     in
     Code_not_rebuilt non_constructed_code
@@ -74,8 +77,9 @@ let create_code are_rebuilding code_id ~params_and_body
     in
     let code =
       Code.create code_id ~params_and_body ~free_names_of_params_and_body
-        ~newer_version_of ~params_arity ~result_arity ~result_types ~stub
-        ~inline ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg
+        ~newer_version_of ~params_arity ~num_trailing_local_params ~result_arity
+        ~result_types ~contains_no_escaping_local_allocs ~stub ~inline
+        ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg
         ~is_tupled ~is_my_closure_used ~inlining_decision
     in
     Normal
@@ -325,9 +329,13 @@ module Group = struct
                ~free_names_of_params_and_body:Name_occurrences.empty
                ~newer_version_of:(NCC.newer_version_of code)
                ~params_arity:(NCC.params_arity code)
+               ~num_trailing_local_params:(NCC.num_trailing_local_params code)
                ~result_arity:(NCC.result_arity code)
-               ~result_types:(NCC.result_types code) ~stub:(NCC.stub code)
-               ~inline:(NCC.inline code) ~is_a_functor:(NCC.is_a_functor code)
+               ~result_types:(NCC.result_types code)
+               ~contains_no_escaping_local_allocs:
+                 (NCC.contains_no_escaping_local_allocs code)
+               ~stub:(NCC.stub code) ~inline:(NCC.inline code)
+               ~is_a_functor:(NCC.is_a_functor code)
                ~recursive:(NCC.recursive code)
                ~cost_metrics:(NCC.cost_metrics code)
                ~inlining_arguments:(NCC.inlining_arguments code)

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -35,8 +35,10 @@ val create_code :
   free_names_of_params_and_body:Name_occurrences.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
+  num_trailing_local_params:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
   result_types:Result_types.t ->
+  contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1140,7 +1140,7 @@ let simplify_phys_equal (op : P.equality_comparison) (kind : K.t) dacc
     | Naked_number Naked_nativeint ->
       Binary_int_eq_comp_nativeint.simplify op dacc ~original_term dbg ~arg1
         ~arg1_ty ~arg2 ~arg2_ty ~result_var
-    | Fabricated -> Misc.fatal_error "Fabricated kind not expected here"
+    | Region -> Misc.fatal_error "Region kind not expected here"
     | Rec_info -> Misc.fatal_error "Rec_info kind not expected here"
 
 let simplify_array_load (array_kind : P.Array_kind.t) mutability dacc

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -68,7 +68,12 @@ val project_tuple :
 (** Split a direct over-application into a full application followed by the
     application of the leftover arguments. *)
 val split_direct_over_application :
-  Apply_expr.t -> param_arity:Flambda_arity.With_subkinds.t -> Expr.t
+  Apply_expr.t ->
+  param_arity:Flambda_arity.With_subkinds.t ->
+  result_arity:Flambda_arity.With_subkinds.t ->
+  apply_alloc_mode:Alloc_mode.t ->
+  contains_no_escaping_local_allocs:bool ->
+  Expr.t
 
 type apply_cont_context =
   | Apply_cont_expr

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -63,7 +63,7 @@ let simplify_comparison_of_tagged_immediates ~dbg dacc ~cmp_prim cont a b =
   let _free_names, res =
     let_prim ~dbg v_comp (P.Binary (cmp_prim, a, b))
     @@ let_prim ~dbg tagged
-         (P.Unary (Box_number Untagged_immediate, Simple.var v_comp))
+         (P.Unary (Box_number (Untagged_immediate, Heap), Simple.var v_comp))
     @@ apply_cont ~dbg cont tagged
   in
   Poly_compare_specialized (dacc, res)
@@ -79,7 +79,7 @@ let simplify_comparison_of_boxed_numbers ~dbg dacc ~kind ~cmp_prim cont a b =
     @@ let_prim ~dbg v_comp
          (P.Binary (cmp_prim, Simple.var a_naked, Simple.var b_naked))
     @@ let_prim ~dbg tagged
-         (P.Unary (Box_number Untagged_immediate, Simple.var v_comp))
+         (P.Unary (Box_number (Untagged_immediate, Heap), Simple.var v_comp))
     @@ apply_cont ~dbg cont tagged
   in
   Poly_compare_specialized (dacc, res)

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -38,3 +38,8 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     let ty = T.any_naked_bool in
     let dacc = DA.add_variable dacc result_var ty in
     Simplified_named.reachable named ~try_reify:false, dacc
+  | Begin_region ->
+    let named = Named.create_prim original_prim dbg in
+    let ty = T.any_region in
+    let dacc = DA.add_variable dacc result_var ty in
+    Simplified_named.reachable named ~try_reify:false, dacc

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -76,9 +76,12 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
       let fields = field_tys in
       match is_mutable with
       | Immutable ->
+        (* XXX Should we have [Alloc_mode.Static]? *)
         T.immutable_block ~is_unique:false tag ~field_kind:K.value ~fields
+          (Known Heap)
       | Immutable_unique ->
         T.immutable_block ~is_unique:true tag ~field_kind:K.value ~fields
+          (Known Heap)
       | Mutable -> T.any_value
     in
     let dacc = bind_result_sym ty in
@@ -89,7 +92,9 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
   (* CR mshinwell: Need to reify to change Equals types into new terms *)
   | Boxed_float or_var ->
     let or_var, ty =
-      simplify_or_variable dacc (fun f -> T.this_boxed_float f) or_var K.value
+      simplify_or_variable dacc
+        (fun f -> T.this_boxed_float f (Known Heap))
+        or_var K.value
     in
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_float
@@ -98,7 +103,9 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
       dacc )
   | Boxed_int32 or_var ->
     let or_var, ty =
-      simplify_or_variable dacc (fun f -> T.this_boxed_int32 f) or_var K.value
+      simplify_or_variable dacc
+        (fun f -> T.this_boxed_int32 f (Known Heap))
+        or_var K.value
     in
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_int32
@@ -107,7 +114,9 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
       dacc )
   | Boxed_int64 or_var ->
     let or_var, ty =
-      simplify_or_variable dacc (fun f -> T.this_boxed_int64 f) or_var K.value
+      simplify_or_variable dacc
+        (fun f -> T.this_boxed_int64 f (Known Heap))
+        or_var K.value
     in
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_boxed_int64
@@ -117,7 +126,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
   | Boxed_nativeint or_var ->
     let or_var, ty =
       simplify_or_variable dacc
-        (fun f -> T.this_boxed_nativeint f)
+        (fun f -> T.this_boxed_nativeint f (Known Heap))
         or_var K.value
     in
     let dacc = bind_result_sym ty in

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -166,7 +166,7 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
     let bound_to = Bound_var.create bound_to NM.normal in
     let defining_expr =
       Named.create_prim
-        (Unary (Box_number Untagged_immediate, scrutinee))
+        (Unary (Box_number (Untagged_immediate, Heap), scrutinee))
         Debuginfo.none
     in
     let let_expr =
@@ -327,7 +327,8 @@ let check_cse_environment dacc ~scrutinee =
      the CSE environment and registering it as a required variable like the
      scrutinee. If it is not available, no problem can occur. *)
   match
-    find_cse_simple dacc (Unary (Box_number Untagged_immediate, scrutinee))
+    find_cse_simple dacc
+      (Unary (Box_number (Untagged_immediate, Heap), scrutinee))
   with
   | None -> dacc
   | Some tagged_scrutinee -> (

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -53,6 +53,7 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     let field_types = List.map type_of_var fields in
     let shape =
       T.immutable_block ~is_unique:false tag ~field_kind ~fields:field_types
+        Unknown
     in
     let denv = add_equation_on_var denv param_var shape in
     List.fold_left
@@ -155,7 +156,7 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
             block_fields)
         fields_by_tag
     in
-    let shape = T.variant ~const_ctors ~non_const_ctors in
+    let shape = T.variant ~const_ctors ~non_const_ctors Unknown in
     let denv = add_equation_on_var denv param_var shape in
     (* Recurse on the fields *)
     Tag.Scannable.Map.fold
@@ -170,15 +171,15 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     denv_of_number_decision K.naked_immediate shape param_var naked_immediate
       denv
   | Unbox (Number (Naked_float, { param = naked_float; args = _ })) ->
-    let shape = T.boxed_float_alias_to ~naked_float in
+    let shape = T.boxed_float_alias_to ~naked_float Unknown in
     denv_of_number_decision K.naked_float shape param_var naked_float denv
   | Unbox (Number (Naked_int32, { param = naked_int32; args = _ })) ->
-    let shape = T.boxed_int32_alias_to ~naked_int32 in
+    let shape = T.boxed_int32_alias_to ~naked_int32 Unknown in
     denv_of_number_decision K.naked_int32 shape param_var naked_int32 denv
   | Unbox (Number (Naked_int64, { param = naked_int64; args = _ })) ->
-    let shape = T.boxed_int64_alias_to ~naked_int64 in
+    let shape = T.boxed_int64_alias_to ~naked_int64 Unknown in
     denv_of_number_decision K.naked_int64 shape param_var naked_int64 denv
   | Unbox (Number (Naked_nativeint, { param = naked_nativeint; args = _ })) ->
-    let shape = T.boxed_nativeint_alias_to ~naked_nativeint in
+    let shape = T.boxed_nativeint_alias_to ~naked_nativeint Unknown in
     denv_of_number_decision K.naked_nativeint shape param_var naked_nativeint
       denv

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -107,8 +107,8 @@ let rec make_optimistic_decision ~depth tenv ~param_type : U.decision =
             Unbox (Variant { tag; const_ctors; fields_by_tag })
           | Proved _ | Wrong_kind | Invalid | Unknown -> begin
             match T.prove_single_closures_entry' tenv param_type with
-            | Proved (closure_id, closures_entry, _fun_decl) when unbox_closures
-              ->
+            | Proved (closure_id, _, closures_entry, _fun_decl)
+              when unbox_closures ->
               let vars_within_closure =
                 make_optimistic_vars_within_closure ~depth tenv closures_entry
               in
@@ -144,6 +144,7 @@ and make_optimistic_fields ~add_tag_to_name ~depth tenv param_type (tag : Tag.t)
   in
   let shape =
     T.immutable_block ~is_unique:false tag ~field_kind ~fields:field_types
+      Unknown
   in
   let env_extension =
     match T.meet tenv param_type shape with

--- a/middle_end/flambda2/term_basics/alloc_mode.ml
+++ b/middle_end/flambda2/term_basics/alloc_mode.ml
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2022 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type t =
+  | Heap
+  | Local
+
+let print ppf t =
+  match t with
+  | Heap -> Format.pp_print_string ppf "Heap"
+  | Local -> Format.pp_print_string ppf "Local"
+
+let compare t1 t2 =
+  match t1, t2 with
+  | Heap, Heap | Local, Local -> 0
+  | Heap, Local -> -1
+  | Local, Heap -> 1

--- a/middle_end/flambda2/term_basics/alloc_mode.mli
+++ b/middle_end/flambda2/term_basics/alloc_mode.mli
@@ -1,0 +1,21 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2022 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type t =
+  | Heap  (** Normal allocation on the OCaml heap. *)
+  | Local  (** Allocation on the local allocation stack. *)
+
+val print : Format.formatter -> t -> unit
+
+val compare : t -> t -> int

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -39,8 +39,10 @@ include Container_types.Make (struct
       match Continuation.sort k, trap_action, args with
       | Normal_or_exn, None, [] -> "goto", None
       | Normal_or_exn, None, _::_ -> "apply_cont", None
-      | Normal_or_exn, Some (Push _), [] -> "goto", trap_action
-      | Normal_or_exn, Some (Push _), _::_ -> "apply_cont", trap_action
+      | Normal_or_exn, Some (Push _ ), [] ->
+        "goto", trap_action
+      | Normal_or_exn, Some (Push _ ), _::_ ->
+        "apply_cont", trap_action
       | Normal_or_exn, Some (Pop { exn_handler; _ }), _ ->
         if Continuation.equal k exn_handler then "raise", trap_action
         else

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -47,10 +47,14 @@ type method_kind =
 (** Whether an application expression corresponds to an OCaml function
     invocation, an OCaml method invocation, or an external call. *)
 type t = private
-  | Function of Function_call.t
+  | Function of
+      { function_call : Function_call.t;
+        alloc_mode : Alloc_mode.t
+      }
   | Method of
       { kind : method_kind;
-        obj : Simple.t
+        obj : Simple.t;
+        alloc_mode : Alloc_mode.t
       }
   | C_call of
       { alloc : bool;
@@ -64,16 +68,21 @@ include Expr_std.S with type t := t
 include Contains_ids.S with type t := t
 
 val direct_function_call :
-  Code_id.t -> Closure_id.t -> return_arity:Flambda_arity.With_subkinds.t -> t
+  Code_id.t ->
+  Closure_id.t ->
+  return_arity:Flambda_arity.With_subkinds.t ->
+  Alloc_mode.t ->
+  t
 
-val indirect_function_call_unknown_arity : unit -> t
+val indirect_function_call_unknown_arity : Alloc_mode.t -> t
 
 val indirect_function_call_known_arity :
   param_arity:Flambda_arity.With_subkinds.t ->
   return_arity:Flambda_arity.With_subkinds.t ->
+  Alloc_mode.t ->
   t
 
-val method_call : method_kind -> obj:Simple.t -> t
+val method_call : method_kind -> obj:Simple.t -> Alloc_mode.t -> t
 
 val c_call :
   alloc:bool ->

--- a/middle_end/flambda2/terms/code.ml
+++ b/middle_end/flambda2/terms/code.ml
@@ -28,6 +28,10 @@ let newer_version_of = Code0.newer_version_of
 
 let params_arity = Code0.params_arity
 
+let num_leading_heap_params = Code0.num_leading_heap_params
+
+let num_trailing_local_params = Code0.num_trailing_local_params
+
 let result_arity = Code0.result_arity
 
 let result_types = Code0.result_types
@@ -52,16 +56,20 @@ let is_my_closure_used = Code0.is_my_closure_used
 
 let inlining_decision = Code0.inlining_decision
 
+let contains_no_escaping_local_allocs = Code0.contains_no_escaping_local_allocs
+
 let create code_id ~params_and_body ~free_names_of_params_and_body
-    ~newer_version_of ~params_arity ~result_arity ~result_types ~stub ~inline
-    ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
+    ~newer_version_of ~params_arity ~num_trailing_local_params ~result_arity
+    ~result_types ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor
+    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
     ~is_my_closure_used ~inlining_decision =
   Code0.create
     ~print_function_params_and_body:Flambda.Function_params_and_body.print
     code_id ~params_and_body ~free_names_of_params_and_body ~newer_version_of
-    ~params_arity ~result_arity ~result_types ~stub ~inline ~is_a_functor
-    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
-    ~is_my_closure_used ~inlining_decision
+    ~params_arity ~num_trailing_local_params ~result_arity ~result_types
+    ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor ~recursive
+    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
+    ~inlining_decision
 
 let with_code_id = Code0.with_code_id
 

--- a/middle_end/flambda2/terms/code.mli
+++ b/middle_end/flambda2/terms/code.mli
@@ -32,6 +32,10 @@ val newer_version_of : t -> Code_id.t option
 
 val params_arity : t -> Flambda_arity.With_subkinds.t
 
+val num_leading_heap_params : t -> int
+
+val num_trailing_local_params : t -> int
+
 val result_arity : t -> Flambda_arity.With_subkinds.t
 
 val result_types : t -> Result_types.t
@@ -56,14 +60,18 @@ val is_my_closure_used : t -> bool
 
 val inlining_decision : t -> Function_decl_inlining_decision_type.t
 
+val contains_no_escaping_local_allocs : t -> bool
+
 val create :
   Code_id.t ->
   params_and_body:Flambda.Function_params_and_body.t ->
   free_names_of_params_and_body:Name_occurrences.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
+  num_trailing_local_params:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
   result_types:Result_types.t ->
+  contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->

--- a/middle_end/flambda2/terms/code0.ml
+++ b/middle_end/flambda2/terms/code0.ml
@@ -32,6 +32,12 @@ let newer_version_of t = Code_metadata.newer_version_of t.code_metadata
 
 let params_arity t = Code_metadata.params_arity t.code_metadata
 
+let num_leading_heap_params t =
+  Code_metadata.num_leading_heap_params t.code_metadata
+
+let num_trailing_local_params t =
+  Code_metadata.num_trailing_local_params t.code_metadata
+
 let result_arity t = Code_metadata.result_arity t.code_metadata
 
 let result_types t = Code_metadata.result_types t.code_metadata
@@ -56,6 +62,9 @@ let is_my_closure_used t = Code_metadata.is_my_closure_used t.code_metadata
 
 let inlining_decision t = Code_metadata.inlining_decision t.code_metadata
 
+let contains_no_escaping_local_allocs t =
+  Code_metadata.contains_no_escaping_local_allocs t.code_metadata
+
 let check_free_names_of_params_and_body ~print_function_params_and_body code_id
     ~params_and_body ~free_names_of_params_and_body =
   if not
@@ -68,10 +77,11 @@ let check_free_names_of_params_and_body ~print_function_params_and_body code_id
       print_function_params_and_body params_and_body
 
 let create ~print_function_params_and_body code_id ~params_and_body
-    ~free_names_of_params_and_body ~newer_version_of ~params_arity ~result_arity
-    ~result_types ~stub ~(inline : Inline_attribute.t) ~is_a_functor ~recursive
-    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
-    ~inlining_decision =
+    ~free_names_of_params_and_body ~newer_version_of ~params_arity
+    ~num_trailing_local_params ~result_arity ~result_types
+    ~contains_no_escaping_local_allocs ~stub ~(inline : Inline_attribute.t)
+    ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
+    ~is_my_closure_used ~inlining_decision =
   begin
     match stub, inline with
     | true, (Available_inline | Never_inline | Default_inline)
@@ -86,9 +96,11 @@ let create ~print_function_params_and_body code_id ~params_and_body
   check_free_names_of_params_and_body ~print_function_params_and_body code_id
     ~params_and_body ~free_names_of_params_and_body;
   let code_metadata =
-    Code_metadata.create code_id ~newer_version_of ~params_arity ~result_arity
-      ~result_types ~stub ~inline ~is_a_functor ~recursive ~cost_metrics
-      ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision
+    Code_metadata.create code_id ~newer_version_of ~params_arity
+      ~num_trailing_local_params ~result_arity ~result_types
+      ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor ~recursive
+      ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
+      ~inlining_decision
   in
   { params_and_body; free_names_of_params_and_body; code_metadata }
 

--- a/middle_end/flambda2/terms/code0.mli
+++ b/middle_end/flambda2/terms/code0.mli
@@ -28,6 +28,10 @@ val newer_version_of : 'function_params_and_body t -> Code_id.t option
 
 val params_arity : 'function_params_and_body t -> Flambda_arity.With_subkinds.t
 
+val num_leading_heap_params : _ t -> int
+
+val num_trailing_local_params : _ t -> int
+
 val result_arity : 'function_params_and_body t -> Flambda_arity.With_subkinds.t
 
 val result_types : 'function_params_and_body t -> Result_types.t
@@ -53,6 +57,8 @@ val is_my_closure_used : 'function_params_and_body t -> bool
 val inlining_decision :
   'function_params_and_body t -> Function_decl_inlining_decision_type.t
 
+val contains_no_escaping_local_allocs : _ t -> bool
+
 val create :
   print_function_params_and_body:
     (Format.formatter -> 'function_params_and_body -> unit) ->
@@ -61,8 +67,10 @@ val create :
   free_names_of_params_and_body:Name_occurrences.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
+  num_trailing_local_params:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
   result_types:Result_types.t ->
+  contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -24,6 +24,10 @@ val newer_version_of : t -> Code_id.t option
 
 val params_arity : t -> Flambda_arity.With_subkinds.t
 
+val num_leading_heap_params : t -> int
+
+val num_trailing_local_params : t -> int
+
 val result_arity : t -> Flambda_arity.With_subkinds.t
 
 val result_types : t -> Result_types.t
@@ -48,12 +52,16 @@ val is_my_closure_used : t -> bool
 
 val inlining_decision : t -> Function_decl_inlining_decision_type.t
 
+val contains_no_escaping_local_allocs : t -> bool
+
 val create :
   Code_id.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
+  num_trailing_local_params:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
   result_types:Result_types.t ->
+  contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
   is_a_functor:bool ->

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -1495,20 +1495,22 @@ module Named = struct
 
   let apply_renaming = apply_renaming_named
 
-  let box_value name (kind : Flambda_kind.t) dbg : t * Flambda_kind.t =
+  let box_value name (kind : Flambda_kind.t) dbg alloc_mode : t * Flambda_kind.t
+      =
     let simple = Simple.name name in
     match kind with
     | Value -> Simple simple, kind
     | Naked_number Naked_immediate -> Misc.fatal_error "Not yet supported"
     | Naked_number Naked_float ->
-      Prim (Unary (Box_number Naked_float, simple), dbg), K.value
+      Prim (Unary (Box_number (Naked_float, alloc_mode), simple), dbg), K.value
     | Naked_number Naked_int32 ->
-      Prim (Unary (Box_number Naked_int32, simple), dbg), K.value
+      Prim (Unary (Box_number (Naked_int32, alloc_mode), simple), dbg), K.value
     | Naked_number Naked_int64 ->
-      Prim (Unary (Box_number Naked_int64, simple), dbg), K.value
+      Prim (Unary (Box_number (Naked_int64, alloc_mode), simple), dbg), K.value
     | Naked_number Naked_nativeint ->
-      Prim (Unary (Box_number Naked_nativeint, simple), dbg), K.value
-    | Fabricated -> Misc.fatal_error "Cannot box values of [Fabricated] kind"
+      ( Prim (Unary (Box_number (Naked_nativeint, alloc_mode), simple), dbg),
+        K.value )
+    | Region -> Misc.fatal_error "Cannot box values of [Region] kind"
     | Rec_info -> Misc.fatal_error "Cannot box values of [Rec_info] kind"
 
   let unbox_value name (kind : Flambda_kind.t) dbg : t * Flambda_kind.t =
@@ -1525,7 +1527,7 @@ module Named = struct
     | Naked_number Naked_nativeint ->
       ( Prim (Unary (Unbox_number Naked_nativeint, simple), dbg),
         K.naked_nativeint )
-    | Fabricated -> Misc.fatal_error "Cannot unbox values of [Fabricated] kind"
+    | Region -> Misc.fatal_error "Cannot unbox values of [Region] kind"
     | Rec_info -> Misc.fatal_error "Cannot unbox values of [Rec_info] kind"
 
   let at_most_generative_effects (t : t) =
@@ -1551,7 +1553,7 @@ module Named = struct
         Simple.const (Reg_width_const.naked_int64 Int64.zero)
       | Naked_number Naked_nativeint ->
         Simple.const (Reg_width_const.naked_nativeint Targetint_32_64.zero)
-      | Fabricated -> Misc.fatal_error "[Fabricated] kind not expected here"
+      | Region -> Misc.fatal_error "[Region] kind not expected here"
       | Rec_info -> Misc.fatal_error "[Rec_info] kind not expected here"
     in
     Simple simple

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -157,7 +157,11 @@ module Named : sig
   (** Build an expression boxing the name. The returned kind is the one of the
       unboxed version. *)
   val box_value :
-    Name.t -> Flambda_kind.t -> Debuginfo.t -> named * Flambda_kind.t
+    Name.t ->
+    Flambda_kind.t ->
+    Debuginfo.t ->
+    Alloc_mode.t ->
+    named * Flambda_kind.t
 
   (** Build an expression unboxing the name. The returned kind is the one of the
       unboxed version. *)

--- a/middle_end/flambda2/terms/set_of_closures.ml
+++ b/middle_end/flambda2/terms/set_of_closures.ml
@@ -18,21 +18,24 @@
 
 type t =
   { function_decls : Function_declarations.t;
-    closure_elements : Simple.t Var_within_closure.Map.t
+    closure_elements : Simple.t Var_within_closure.Map.t;
+    alloc_mode : Alloc_mode.t
   }
 
 let [@ocamlformat "disable"] print ppf
       { function_decls;
-        closure_elements;
+        closure_elements;alloc_mode;
       } =
   Format.fprintf ppf "@[<hov 1>(%sset_of_closures%s@ \
       @[<hov 1>(function_decls@ %a)@]@ \
-      @[<hov 1>(closure_elements@ %a)@]\
+      @[<hov 1>(closure_elements@ %a)@]@ \
+      @[<hov 1>(alloc_mode@ %a)@]\
       )@]"
     (Flambda_colours.prim_constructive ())
     (Flambda_colours.normal ())
     (Function_declarations.print) function_decls
     (Var_within_closure.Map.print Simple.print) closure_elements
+    Alloc_mode.print alloc_mode
 
 include Container_types.Make (struct
   type nonrec t = t
@@ -42,36 +45,41 @@ include Container_types.Make (struct
   let hash _ = Misc.fatal_error "Not yet implemented"
 
   let compare
-      { function_decls = function_decls1; closure_elements = closure_elements1 }
-      { function_decls = function_decls2; closure_elements = closure_elements2 }
-      =
+      { function_decls = function_decls1;
+        closure_elements = closure_elements1;
+        alloc_mode = alloc_mode1
+      }
+      { function_decls = function_decls2;
+        closure_elements = closure_elements2;
+        alloc_mode = alloc_mode2
+      } =
     let c = Function_declarations.compare function_decls1 function_decls2 in
     if c <> 0
     then c
     else
-      Var_within_closure.Map.compare Simple.compare closure_elements1
-        closure_elements2
+      let c =
+        Var_within_closure.Map.compare Simple.compare closure_elements1
+          closure_elements2
+      in
+      if c <> 0 then c else Alloc_mode.compare alloc_mode1 alloc_mode2
 
   let equal t1 t2 = compare t1 t2 = 0
 end)
 
-let empty =
-  { function_decls = Function_declarations.empty;
-    closure_elements = Var_within_closure.Map.empty
-  }
-
-let is_empty { function_decls; closure_elements } =
+let is_empty { function_decls; closure_elements; alloc_mode = _ } =
   Function_declarations.is_empty function_decls
   && Var_within_closure.Map.is_empty closure_elements
 
-let create function_decls ~closure_elements =
+let create ~closure_elements alloc_mode function_decls =
   (* CR mshinwell: Make sure invariant checks are applied here, e.g. that the
      set of closures is indeed closed. *)
-  { function_decls; closure_elements }
+  { function_decls; closure_elements; alloc_mode }
 
 let function_decls t = t.function_decls
 
 let closure_elements t = t.closure_elements
+
+let alloc_mode t = t.alloc_mode
 
 let has_empty_environment t = Var_within_closure.Map.is_empty t.closure_elements
 
@@ -83,25 +91,28 @@ let environment_doesn't_mention_variables t =
 let [@ocamlformat "disable"] print ppf
       { function_decls;
         closure_elements;
+        alloc_mode;
       } =
   if Var_within_closure.Map.is_empty closure_elements then
-    Format.fprintf ppf "@[<hov 1>(%sset_of_closures%s@ \
+    Format.fprintf ppf "@[<hov 1>(%sset_of_closures%s@ %a@ \
         @[<hov 1>%a@]\
         )@]"
       (Flambda_colours.prim_constructive ())
       (Flambda_colours.normal ())
+      Alloc_mode.print alloc_mode
       (Function_declarations.print) function_decls
   else
-    Format.fprintf ppf "@[<hov 1>(%sset_of_closures%s@ \
+    Format.fprintf ppf "@[<hov 1>(%sset_of_closures%s@ %a@ \
         @[<hov 1>%a@]@ \
         @[<hov 1>(env@ %a)@]\
         )@]"
       (Flambda_colours.prim_constructive ())
       (Flambda_colours.normal ())
+      Alloc_mode.print alloc_mode
       (Function_declarations.print) function_decls
       (Var_within_closure.Map.print Simple.print) closure_elements
 
-let free_names { function_decls; closure_elements } =
+let free_names { function_decls; closure_elements; alloc_mode = _ } =
   (* We are here interested in the the uses of closure_id and
      var_within_closure, so we do not count the closure_ids and
      var_within_closures that are bound by a set of closures. Indeed, the
@@ -112,7 +123,8 @@ let free_names { function_decls; closure_elements } =
     [ Function_declarations.free_names function_decls;
       Simple.List.free_names (Var_within_closure.Map.data closure_elements) ]
 
-let apply_renaming ({ function_decls; closure_elements } as t) renaming =
+let apply_renaming ({ function_decls; closure_elements; alloc_mode } as t)
+    renaming =
   let function_decls' =
     Function_declarations.apply_renaming function_decls renaming
   in
@@ -127,9 +139,12 @@ let apply_renaming ({ function_decls; closure_elements } as t) renaming =
   if function_decls == function_decls' && closure_elements == closure_elements'
   then t
   else
-    { function_decls = function_decls'; closure_elements = closure_elements' }
+    { function_decls = function_decls';
+      closure_elements = closure_elements';
+      alloc_mode
+    }
 
-let all_ids_for_export { function_decls; closure_elements } =
+let all_ids_for_export { function_decls; closure_elements; alloc_mode = _ } =
   let function_decls_ids =
     Function_declarations.all_ids_for_export function_decls
   in

--- a/middle_end/flambda2/terms/set_of_closures.mli
+++ b/middle_end/flambda2/terms/set_of_closures.mli
@@ -22,15 +22,14 @@ include Expr_std.S with type t := t
 
 include Contains_ids.S with type t := t
 
-val empty : t
-
 val is_empty : t -> bool
 
 (** Create a set of closures given the code for its functions and the closure
     variables. *)
 val create :
-  Function_declarations.t ->
   closure_elements:Simple.t Var_within_closure.Map.t ->
+  Alloc_mode.t ->
+  Function_declarations.t ->
   t
 
 (** The function declarations associated with the set of closures. *)
@@ -41,6 +40,8 @@ val closure_elements : t -> Simple.t Var_within_closure.Map.t
 
 (** Returns true iff the given set of closures has an empty environment. *)
 val has_empty_environment : t -> bool
+
+val alloc_mode : t -> Alloc_mode.t
 
 (** Returns true iff the given set of closures does not contain any variables in
     its environment. (If this condition is satisfied, a set of closures may be

--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -24,7 +24,7 @@ let test_meet_chains_two_vars () =
   let env =
     TE.add_equation env (Name.var var1)
       (T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
-         ~fields:[T.any_tagged_immediate])
+         (Known Heap) ~fields:[T.any_tagged_immediate])
   in
   let var2 = Variable.create "var2" in
   let var2' = Bound_var.create var2 Name_mode.normal in
@@ -57,7 +57,7 @@ let test_meet_chains_three_vars () =
   let env =
     TE.add_equation env (Name.var var1)
       (T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
-         ~fields:[T.any_tagged_immediate])
+         (Known Heap) ~fields:[T.any_tagged_immediate])
   in
   let var2 = Variable.create "var2" in
   let var2' = Bound_var.create var2 Name_mode.normal in
@@ -109,7 +109,7 @@ let meet_variants_don't_lose_aliases () =
           Tag.Scannable.create_exn 1, [T.alias_type_of K.value (Simple.var vy)]
         ]
     in
-    T.variant ~const_ctors ~non_const_ctors
+    T.variant ~const_ctors ~non_const_ctors (Known Heap)
   in
   let ty2 =
     let non_const_ctors =
@@ -118,7 +118,7 @@ let meet_variants_don't_lose_aliases () =
           Tag.Scannable.create_exn 1, [T.alias_type_of K.value (Simple.var vb)]
         ]
     in
-    T.variant ~const_ctors ~non_const_ctors
+    T.variant ~const_ctors ~non_const_ctors (Known Heap)
   in
   match T.meet env ty1 ty2 with
   | Bottom -> assert false
@@ -153,11 +153,13 @@ let test_meet_two_blocks () =
   let env =
     TE.add_equation env (Name.var block1)
       (T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
+         (Known Heap)
          ~fields:[T.alias_type_of K.value (Simple.var field1)])
   in
   let env =
     TE.add_equation env (Name.var block2)
       (T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
+         (Known Heap)
          ~fields:[T.alias_type_of K.value (Simple.var field2)])
   in
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -194,15 +194,25 @@ let get_function_info env code_id =
     Misc.fatal_errorf "To_cmm_env.get_function_info: code ID %a not bound"
       Code_id.print code_id
 
+type closure_code_pointers =
+  | Full_application_only
+  | Full_and_partial_application
+
 let get_func_decl_params_arity t code_id =
   let info = get_function_info t code_id in
-  let l = List.length (Code_metadata.params_arity info) in
-  let k =
+  let num_params = List.length (Code_metadata.params_arity info) in
+  let kind : Lambda.function_kind =
     if Code_metadata.is_tupled info
     then Lambda.Tupled
-    else Lambda.Curried { nlocal = 0 }
+    else
+      Lambda.Curried { nlocal = Code_metadata.num_trailing_local_params info }
   in
-  k, l
+  let closure_code_pointers =
+    match kind, num_params with
+    | Curried _, (0 | 1) -> Full_application_only
+    | (Curried _ | Tupled), _ -> Full_and_partial_application
+  in
+  (kind, num_params), closure_code_pointers
 
 (* Variables *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -72,9 +72,15 @@ val exn_cont : t -> Continuation.t
 (** Retrieve known information on the given function *)
 val get_function_info : t -> Code_id.t -> Code_metadata.t
 
+type closure_code_pointers =
+  | Full_application_only
+  | Full_and_partial_application
+
 (** Retrieve the parameter arity of the function declaration (taking into
-    account both the function's own arity and the [is_tupled] flag) *)
-val get_func_decl_params_arity : t -> Code_id.t -> Clambda.arity
+    account both the function's own arity and the [is_tupled] flag) together
+    with the code pointer layout for the closure. *)
+val get_func_decl_params_arity :
+  t -> Code_id.t -> Clambda.arity * closure_code_pointers
 
 (** {2 Variable bindings} *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_helper.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_helper.mli
@@ -84,6 +84,7 @@ val nativeint : ?dbg:Debuginfo.t -> Nativeint.t -> Cmm.expression
 val make_array :
   ?dbg:Debuginfo.t ->
   Flambda_primitive.Array_kind.t ->
+  Alloc_mode.t ->
   Cmm.expression list ->
   Cmm.expression
 
@@ -91,12 +92,13 @@ val make_array :
 val make_block :
   ?dbg:Debuginfo.t ->
   Flambda_primitive.Block_kind.t ->
+  Alloc_mode.t ->
   Cmm.expression list ->
   Cmm.expression
 
 (** Create a closure block. *)
 val make_closure_block :
-  ?dbg:Debuginfo.t -> Cmm.expression list -> Cmm.expression
+  ?dbg:Debuginfo.t -> Alloc_mode.t -> Cmm.expression list -> Cmm.expression
 
 (** {2 Boxed numbers} *)
 
@@ -104,11 +106,13 @@ val make_closure_block :
 val box_number :
   ?dbg:Debuginfo.t ->
   Flambda_kind.Boxable_number.t ->
+  Alloc_mode.t ->
   Cmm.expression ->
   Cmm.expression
 
 (** Shortcut for [box_number Flambda_kind.Boxable_number.Naked_int64] *)
-val box_int64 : ?dbg:Debuginfo.t -> Cmm.expression -> Cmm.expression
+val box_int64 :
+  ?dbg:Debuginfo.t -> Alloc_mode.t -> Cmm.expression -> Cmm.expression
 
 (** Unbox a boxed number. *)
 val unbox_number :
@@ -118,6 +122,8 @@ val unbox_number :
   Cmm.expression
 
 (** {2 Block access} *)
+
+val convert_alloc_mode : Alloc_mode.t -> Lambda.alloc_mode
 
 (** [infix_field_address ptr n dbg] returns an expression for the address of the
     [n]-th field of the set of closures block pointed to by [ptr]. This function
@@ -440,6 +446,7 @@ val direct_call :
 val indirect_call :
   ?dbg:Debuginfo.t ->
   Cmm.machtype ->
+  Alloc_mode.t ->
   Cmm.expression ->
   Cmm.expression list ->
   Cmm.expression
@@ -449,6 +456,7 @@ val indirect_call :
 val indirect_full_call :
   ?dbg:Debuginfo.t ->
   Cmm.machtype ->
+  Alloc_mode.t ->
   Cmm.expression ->
   Cmm.expression list ->
   Cmm.expression

--- a/middle_end/flambda2/types/expand_head.mli
+++ b/middle_end/flambda2/types/expand_head.mli
@@ -36,6 +36,8 @@ module Expanded_type : sig
 
   val create_rec_info : Type_grammar.head_of_kind_rec_info -> t
 
+  val create_region : Type_grammar.head_of_kind_region -> t
+
   val create_bottom : Flambda_kind.t -> t
 
   val create_unknown : Flambda_kind.t -> t
@@ -58,6 +60,7 @@ module Expanded_type : sig
     | Naked_int64 of Type_grammar.head_of_kind_naked_int64
     | Naked_nativeint of Type_grammar.head_of_kind_naked_nativeint
     | Rec_info of Type_grammar.head_of_kind_rec_info
+    | Region of Type_grammar.head_of_kind_region
 
   val descr : t -> descr Or_unknown_or_bottom.t
 
@@ -74,6 +77,7 @@ module Expanded_type : sig
     | Naked_nativeint of
         Type_grammar.head_of_kind_naked_nativeint Or_unknown_or_bottom.t
     | Rec_info of Type_grammar.head_of_kind_rec_info Or_unknown_or_bottom.t
+    | Region of Type_grammar.head_of_kind_region Or_unknown_or_bottom.t
 
   val descr_oub : t -> descr_oub
 end

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -346,29 +346,36 @@ val any_naked_int64 : t
 
 val any_naked_nativeint : t
 
+val any_region : t
+
 val any_rec_info : t
 
 (** Building of types representing tagged / boxed values from specified
     constants. *)
 val this_tagged_immediate : Targetint_31_63.t -> t
 
-val this_boxed_float : Numeric_types.Float_by_bit_pattern.t -> t
+val this_boxed_float :
+  Numeric_types.Float_by_bit_pattern.t -> Alloc_mode.t Or_unknown.t -> t
 
-val this_boxed_int32 : Numeric_types.Int32.t -> t
+val this_boxed_int32 : Numeric_types.Int32.t -> Alloc_mode.t Or_unknown.t -> t
 
-val this_boxed_int64 : Numeric_types.Int64.t -> t
+val this_boxed_int64 : Numeric_types.Int64.t -> Alloc_mode.t Or_unknown.t -> t
 
-val this_boxed_nativeint : Targetint_32_64.t -> t
+val this_boxed_nativeint : Targetint_32_64.t -> Alloc_mode.t Or_unknown.t -> t
 
 val these_tagged_immediates : Targetint_31_63.Set.t -> t
 
-val these_boxed_floats : Numeric_types.Float_by_bit_pattern.Set.t -> t
+val these_boxed_floats :
+  Numeric_types.Float_by_bit_pattern.Set.t -> Alloc_mode.t Or_unknown.t -> t
 
-val these_boxed_int32s : Numeric_types.Int32.Set.t -> t
+val these_boxed_int32s :
+  Numeric_types.Int32.Set.t -> Alloc_mode.t Or_unknown.t -> t
 
-val these_boxed_int64s : Numeric_types.Int64.Set.t -> t
+val these_boxed_int64s :
+  Numeric_types.Int64.Set.t -> Alloc_mode.t Or_unknown.t -> t
 
-val these_boxed_nativeints : Targetint_32_64.Set.t -> t
+val these_boxed_nativeints :
+  Targetint_32_64.Set.t -> Alloc_mode.t Or_unknown.t -> t
 
 (** Building of types representing untagged / unboxed values from specified
     constants. *)
@@ -394,21 +401,25 @@ val these_naked_int64s : Numeric_types.Int64.Set.t -> t
 
 val these_naked_nativeints : Targetint_32_64.Set.t -> t
 
-val boxed_float_alias_to : naked_float:Variable.t -> t
+val boxed_float_alias_to :
+  naked_float:Variable.t -> Alloc_mode.t Or_unknown.t -> t
 
-val boxed_int32_alias_to : naked_int32:Variable.t -> t
+val boxed_int32_alias_to :
+  naked_int32:Variable.t -> Alloc_mode.t Or_unknown.t -> t
 
-val boxed_int64_alias_to : naked_int64:Variable.t -> t
+val boxed_int64_alias_to :
+  naked_int64:Variable.t -> Alloc_mode.t Or_unknown.t -> t
 
-val boxed_nativeint_alias_to : naked_nativeint:Variable.t -> t
+val boxed_nativeint_alias_to :
+  naked_nativeint:Variable.t -> Alloc_mode.t Or_unknown.t -> t
 
-val box_float : t -> t
+val box_float : t -> Alloc_mode.t Or_unknown.t -> t
 
-val box_int32 : t -> t
+val box_int32 : t -> Alloc_mode.t Or_unknown.t -> t
 
-val box_int64 : t -> t
+val box_int64 : t -> Alloc_mode.t Or_unknown.t -> t
 
-val box_nativeint : t -> t
+val box_nativeint : t -> Alloc_mode.t Or_unknown.t -> t
 
 val tagged_immediate_alias_to : naked_immediate:Variable.t -> t
 
@@ -422,7 +433,12 @@ val any_block : t
 
 (** The type of an immutable block with a known tag, size and field types. *)
 val immutable_block :
-  is_unique:bool -> Tag.t -> field_kind:Flambda_kind.t -> fields:t list -> t
+  is_unique:bool ->
+  Tag.t ->
+  field_kind:Flambda_kind.t ->
+  Alloc_mode.t Or_unknown.t ->
+  fields:t list ->
+  t
 
 (** The type of an immutable block with at least [n] fields and an unknown tag.
     The type of the [n - 1]th field is taken to be an [Equals] to the given
@@ -434,7 +450,13 @@ val immutable_block_with_size_at_least :
   field_n_minus_one:Variable.t ->
   t
 
-val variant : const_ctors:t -> non_const_ctors:t list Tag.Scannable.Map.t -> t
+val mutable_block : Alloc_mode.t Or_unknown.t -> t
+
+val variant :
+  const_ctors:t ->
+  non_const_ctors:t list Tag.Scannable.Map.t ->
+  Alloc_mode.t Or_unknown.t ->
+  t
 
 val open_variant_from_const_ctors_type : const_ctors:t -> t
 
@@ -451,6 +473,7 @@ val exactly_this_closure :
     Function_type.t Or_unknown_or_bottom.t Closure_id.Map.t ->
   all_closures_in_set:t Closure_id.Map.t ->
   all_closure_vars_in_set:flambda_type Var_within_closure.Map.t ->
+  Alloc_mode.t Or_unknown.t ->
   flambda_type
 
 val at_least_the_closures_with_ids :
@@ -605,12 +628,21 @@ val prove_is_array_with_element_kind :
     exactly one set of closures. The function declaration type corresponding to
     such closure is returned together with its closure ID, if it is known. *)
 val prove_single_closures_entry :
-  Typing_env.t -> t -> (Closure_id.t * Closures_entry.t * Function_type.t) proof
+  Typing_env.t ->
+  t ->
+  (Closure_id.t
+  * Alloc_mode.t Or_unknown.t
+  * Closures_entry.t
+  * Function_type.t)
+  proof
 
 val prove_single_closures_entry' :
   Typing_env.t ->
   t ->
-  (Closure_id.t * Closures_entry.t * Function_type.t)
+  (Closure_id.t
+  * Alloc_mode.t Or_unknown.t
+  * Closures_entry.t
+  * Function_type.t)
   proof_allowing_kind_mismatch
 
 val prove_strings : Typing_env.t -> t -> String_info.Set.t proof
@@ -674,6 +706,9 @@ val prove_select_closure_simple :
 
 val prove_rec_info : Typing_env.t -> t -> Rec_info_expr.t proof
 
+val prove_alloc_mode_of_boxed_number :
+  Typing_env.t -> t -> Alloc_mode.t Or_unknown.t
+
 type var_or_symbol_or_tagged_immediate = private
   | Var of Variable.t
   | Symbol of Symbol.t
@@ -713,3 +748,6 @@ val reify :
   min_name_mode:Name_mode.t ->
   t ->
   reification_result
+
+val never_holds_locally_allocated_values :
+  Typing_env.t -> Variable.t -> Flambda_kind.t -> bool

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -49,22 +49,37 @@ val any_tagged_bool : Type_grammar.t
 
 val any_naked_bool : Type_grammar.t
 
-val this_boxed_float : Numeric_types.Float_by_bit_pattern.t -> Type_grammar.t
+val this_boxed_float :
+  Numeric_types.Float_by_bit_pattern.t ->
+  Alloc_mode.t Or_unknown.t ->
+  Type_grammar.t
 
-val this_boxed_int32 : int32 -> Type_grammar.t
+val this_boxed_int32 : int32 -> Alloc_mode.t Or_unknown.t -> Type_grammar.t
 
-val this_boxed_int64 : int64 -> Type_grammar.t
+val this_boxed_int64 : int64 -> Alloc_mode.t Or_unknown.t -> Type_grammar.t
 
-val this_boxed_nativeint : Targetint_32_64.t -> Type_grammar.t
+val this_boxed_nativeint :
+  Targetint_32_64.t -> Alloc_mode.t Or_unknown.t -> Type_grammar.t
 
-val these_boxed_floats : Type_grammar.head_of_kind_naked_float -> Type_grammar.t
+val these_boxed_floats :
+  Type_grammar.head_of_kind_naked_float ->
+  Alloc_mode.t Or_unknown.t ->
+  Type_grammar.t
 
-val these_boxed_int32s : Type_grammar.head_of_kind_naked_int32 -> Type_grammar.t
+val these_boxed_int32s :
+  Type_grammar.head_of_kind_naked_int32 ->
+  Alloc_mode.t Or_unknown.t ->
+  Type_grammar.t
 
-val these_boxed_int64s : Type_grammar.head_of_kind_naked_int64 -> Type_grammar.t
+val these_boxed_int64s :
+  Type_grammar.head_of_kind_naked_int64 ->
+  Alloc_mode.t Or_unknown.t ->
+  Type_grammar.t
 
 val these_boxed_nativeints :
-  Type_grammar.head_of_kind_naked_nativeint -> Type_grammar.t
+  Type_grammar.head_of_kind_naked_nativeint ->
+  Alloc_mode.t Or_unknown.t ->
+  Type_grammar.t
 
 val any_boxed_float : Type_grammar.t
 
@@ -82,6 +97,7 @@ val immutable_block :
   is_unique:bool ->
   Tag.t ->
   field_kind:Flambda_kind.t ->
+  Alloc_mode.t Or_unknown.t ->
   fields:Type_grammar.t list ->
   Type_grammar.t
 
@@ -95,6 +111,7 @@ val immutable_block_with_size_at_least :
 val variant :
   const_ctors:Type_grammar.t ->
   non_const_ctors:Type_grammar.t list Tag.Scannable.Map.t ->
+  Alloc_mode.t Or_unknown.t ->
   Type_grammar.t
 
 val open_variant_from_const_ctors_type :
@@ -111,6 +128,7 @@ val exactly_this_closure :
     Type_grammar.function_type Or_unknown_or_bottom.t Closure_id.Map.t ->
   all_closures_in_set:Type_grammar.t Closure_id.Map.t ->
   all_closure_vars_in_set:Type_grammar.t Var_within_closure.Map.t ->
+  Alloc_mode.t Or_unknown.t ->
   Type_grammar.t
 
 val at_least_the_closures_with_ids :

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -39,18 +39,24 @@ type t = private
   | Naked_int64 of head_of_kind_naked_int64 Type_descr.t
   | Naked_nativeint of head_of_kind_naked_nativeint Type_descr.t
   | Rec_info of head_of_kind_rec_info Type_descr.t
+  | Region of head_of_kind_region Type_descr.t
 
 and head_of_kind_value = private
   | Variant of
       { immediates : t Or_unknown.t;
         blocks : row_like_for_blocks Or_unknown.t;
-        is_unique : bool
+        is_unique : bool;
+        alloc_mode : Alloc_mode.t Or_unknown.t
       }
-  | Boxed_float of t
-  | Boxed_int32 of t
-  | Boxed_int64 of t
-  | Boxed_nativeint of t
-  | Closures of { by_closure_id : row_like_for_closures }
+  | Mutable_block of { alloc_mode : Alloc_mode.t Or_unknown.t }
+  | Boxed_float of t * Alloc_mode.t Or_unknown.t
+  | Boxed_int32 of t * Alloc_mode.t Or_unknown.t
+  | Boxed_int64 of t * Alloc_mode.t Or_unknown.t
+  | Boxed_nativeint of t * Alloc_mode.t Or_unknown.t
+  | Closures of
+      { by_closure_id : row_like_for_closures;
+        alloc_mode : Alloc_mode.t Or_unknown.t
+      }
   | String of String_info.Set.t
   | Array of
       { element_kind : Flambda_kind.With_subkind.t Or_unknown.t;
@@ -71,6 +77,8 @@ and head_of_kind_naked_int64 = Numeric_types.Int64.Set.t
 and head_of_kind_naked_nativeint = Targetint_32_64.Set.t
 
 and head_of_kind_rec_info = Rec_info_expr.t
+
+and head_of_kind_region = unit
 
 and 'index row_like_index = private
   | Known of 'index
@@ -161,6 +169,8 @@ val bottom_naked_nativeint : t
 
 val bottom_rec_info : t
 
+val bottom_region : t
+
 val any_value : t
 
 val any_naked_immediate : t
@@ -172,6 +182,8 @@ val any_naked_int32 : t
 val any_naked_int64 : t
 
 val any_naked_nativeint : t
+
+val any_region : t
 
 val any_rec_info : t
 
@@ -200,21 +212,25 @@ val these_naked_int64s : no_alias:bool -> Numeric_types.Int64.Set.t -> t
 
 val these_naked_nativeints : no_alias:bool -> Targetint_32_64.Set.t -> t
 
-val boxed_float_alias_to : naked_float:Variable.t -> t
+val boxed_float_alias_to :
+  naked_float:Variable.t -> Alloc_mode.t Or_unknown.t -> t
 
-val boxed_int32_alias_to : naked_int32:Variable.t -> t
+val boxed_int32_alias_to :
+  naked_int32:Variable.t -> Alloc_mode.t Or_unknown.t -> t
 
-val boxed_int64_alias_to : naked_int64:Variable.t -> t
+val boxed_int64_alias_to :
+  naked_int64:Variable.t -> Alloc_mode.t Or_unknown.t -> t
 
-val boxed_nativeint_alias_to : naked_nativeint:Variable.t -> t
+val boxed_nativeint_alias_to :
+  naked_nativeint:Variable.t -> Alloc_mode.t Or_unknown.t -> t
 
-val box_float : t -> t
+val box_float : t -> Alloc_mode.t Or_unknown.t -> t
 
-val box_int32 : t -> t
+val box_int32 : t -> Alloc_mode.t Or_unknown.t -> t
 
-val box_int64 : t -> t
+val box_int64 : t -> Alloc_mode.t Or_unknown.t -> t
 
-val box_nativeint : t -> t
+val box_nativeint : t -> Alloc_mode.t Or_unknown.t -> t
 
 val tagged_immediate_alias_to : naked_immediate:Variable.t -> t
 
@@ -228,9 +244,12 @@ val create_variant :
   is_unique:bool ->
   immediates:t Or_unknown.t ->
   blocks:row_like_for_blocks Or_unknown.t ->
+  Alloc_mode.t Or_unknown.t ->
   t
 
-val create_closures : row_like_for_closures -> t
+val mutable_block : Alloc_mode.t Or_unknown.t -> t
+
+val create_closures : Alloc_mode.t Or_unknown.t -> row_like_for_closures -> t
 
 val this_immutable_string : string -> t
 
@@ -458,6 +477,7 @@ module Descr : sig
         head_of_kind_naked_nativeint Type_descr.Descr.t Or_unknown_or_bottom.t
     | Rec_info of
         head_of_kind_rec_info Type_descr.Descr.t Or_unknown_or_bottom.t
+    | Region of head_of_kind_region Type_descr.Descr.t Or_unknown_or_bottom.t
 end
 
 val descr : t -> Descr.t
@@ -475,6 +495,8 @@ val create_from_head_naked_int64 : head_of_kind_naked_int64 -> t
 val create_from_head_naked_nativeint : head_of_kind_naked_nativeint -> t
 
 val create_from_head_rec_info : head_of_kind_rec_info -> t
+
+val create_from_head_region : head_of_kind_region -> t
 
 val apply_coercion_head_of_kind_value :
   head_of_kind_value -> Coercion.t -> head_of_kind_value Or_bottom.t
@@ -501,6 +523,9 @@ val apply_coercion_head_of_kind_naked_nativeint :
 val apply_coercion_head_of_kind_rec_info :
   head_of_kind_rec_info -> Coercion.t -> head_of_kind_rec_info Or_bottom.t
 
+val apply_coercion_head_of_kind_region :
+  head_of_kind_region -> Coercion.t -> head_of_kind_region Or_bottom.t
+
 module Head_of_kind_value : sig
   type t = head_of_kind_value
 
@@ -508,19 +533,24 @@ module Head_of_kind_value : sig
     is_unique:bool ->
     blocks:Row_like_for_blocks.t Or_unknown.t ->
     immediates:flambda_type Or_unknown.t ->
+    Alloc_mode.t Or_unknown.t ->
     t
 
-  val create_boxed_float : flambda_type -> t
+  val create_mutable_block : Alloc_mode.t Or_unknown.t -> t
 
-  val create_boxed_int32 : flambda_type -> t
+  (* XXX these alloc mode params should probably be labelled *)
+  val create_boxed_float : flambda_type -> Alloc_mode.t Or_unknown.t -> t
 
-  val create_boxed_int64 : flambda_type -> t
+  val create_boxed_int32 : flambda_type -> Alloc_mode.t Or_unknown.t -> t
 
-  val create_boxed_nativeint : flambda_type -> t
+  val create_boxed_int64 : flambda_type -> Alloc_mode.t Or_unknown.t -> t
+
+  val create_boxed_nativeint : flambda_type -> Alloc_mode.t Or_unknown.t -> t
 
   val create_tagged_immediate : Targetint_31_63.t -> t
 
-  val create_closures : Row_like_for_closures.t -> t
+  val create_closures :
+    Row_like_for_closures.t -> Alloc_mode.t Or_unknown.t -> t
 
   val create_string : String_info.Set.t -> t
 

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -323,6 +323,13 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
       Mutable_block { alloc_mode = alloc_mode2 } ) ->
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
     TG.Head_of_kind_value.create_mutable_block alloc_mode, TEE.empty
+  | ( Variant { alloc_mode = alloc_mode1; _ },
+      Mutable_block { alloc_mode = alloc_mode2 } )
+  | ( Mutable_block { alloc_mode = alloc_mode1 },
+      Variant { alloc_mode = alloc_mode2; _ } ) ->
+    (* CR mshinwell: It would be better to track per-field mutability. *)
+    let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_mutable_block alloc_mode, TEE.empty
   | Boxed_float (n1, alloc_mode1), Boxed_float (n2, alloc_mode2) ->
     let<* n, env_extension = meet env n1 n2 in
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -58,6 +58,29 @@ type meet_expanded_head_result =
 
 exception Bottom_meet
 
+let meet_alloc_mode (alloc_mode1 : Alloc_mode.t Or_unknown.t)
+    (alloc_mode2 : Alloc_mode.t Or_unknown.t) :
+    Alloc_mode.t Or_unknown.t Or_bottom.t =
+  match alloc_mode1, alloc_mode2 with
+  | Unknown, Unknown -> Ok Unknown
+  | Unknown, Known _ -> Ok alloc_mode2
+  | Known _, Unknown -> Ok alloc_mode1
+  | Known Heap, Known Heap -> Ok (Known Heap)
+  | Known Local, Known Local -> Ok (Known Local)
+  | Known Heap, Known Local | Known Local, Known Heap ->
+    (* It is not safe to pick either [Heap] or [Local] and moreover we should
+       never be in this situation by virtue of the OCaml type checker; it is
+       bottom. *)
+    Bottom
+
+let join_alloc_mode (alloc_mode1 : Alloc_mode.t Or_unknown.t)
+    (alloc_mode2 : Alloc_mode.t Or_unknown.t) : Alloc_mode.t Or_unknown.t =
+  match alloc_mode1, alloc_mode2 with
+  | Unknown, _ | _, Unknown -> Unknown
+  | Known Heap, Known Heap -> Known Heap
+  | Known Local, Known Local -> Known Local
+  | Known Heap, Known Local | Known Local, Known Heap -> Unknown
+
 let[@inline always] meet_unknown meet_contents ~contents_is_bottom env
     (or_unknown1 : _ Or_unknown.t) (or_unknown2 : _ Or_unknown.t) :
     (_ Or_unknown.t * TEE.t) Or_bottom.t =
@@ -263,43 +286,67 @@ and meet_expanded_head0 env (descr1 : ET.descr) (descr2 : ET.descr) :
   | Rec_info head1, Rec_info head2 ->
     let<+ head, env_extension = meet_head_of_kind_rec_info env head1 head2 in
     ET.create_rec_info head, env_extension
+  | Region head1, Region head2 ->
+    let<+ head, env_extension = meet_head_of_kind_region env head1 head2 in
+    ET.create_region head, env_extension
   | ( ( Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _
-      | Naked_int64 _ | Naked_nativeint _ | Rec_info _ ),
+      | Naked_int64 _ | Naked_nativeint _ | Rec_info _ | Region _ ),
       _ ) ->
     assert false
 
 and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
     (head2 : TG.head_of_kind_value) : _ Or_bottom.t =
   match head1, head2 with
-  | ( Variant { blocks = blocks1; immediates = imms1; is_unique = is_unique1 },
-      Variant { blocks = blocks2; immediates = imms2; is_unique = is_unique2 } )
-    ->
-    let<+ blocks, immediates, env_extension =
+  | ( Variant
+        { blocks = blocks1;
+          immediates = imms1;
+          is_unique = is_unique1;
+          alloc_mode = alloc_mode1
+        },
+      Variant
+        { blocks = blocks2;
+          immediates = imms2;
+          is_unique = is_unique2;
+          alloc_mode = alloc_mode2
+        } ) ->
+    let<* blocks, immediates, env_extension =
       meet_variant env ~blocks1 ~imms1 ~blocks2 ~imms2
     in
     (* Uniqueness tracks whether duplication/lifting is allowed. It must always
        be propagated, both for meet and join. *)
     let is_unique = is_unique1 || is_unique2 in
-    ( TG.Head_of_kind_value.create_variant ~is_unique ~blocks ~immediates,
+    let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
+    ( TG.Head_of_kind_value.create_variant ~is_unique alloc_mode ~blocks
+        ~immediates,
       env_extension )
-  | Boxed_float n1, Boxed_float n2 ->
-    let<+ n, env_extension = meet env n1 n2 in
-    TG.Head_of_kind_value.create_boxed_float n, env_extension
-  | Boxed_int32 n1, Boxed_int32 n2 ->
-    let<+ n, env_extension = meet env n1 n2 in
-    TG.Head_of_kind_value.create_boxed_int32 n, env_extension
-  | Boxed_int64 n1, Boxed_int64 n2 ->
-    let<+ n, env_extension = meet env n1 n2 in
-    TG.Head_of_kind_value.create_boxed_int64 n, env_extension
-  | Boxed_nativeint n1, Boxed_nativeint n2 ->
-    let<+ n, env_extension = meet env n1 n2 in
-    TG.Head_of_kind_value.create_boxed_nativeint n, env_extension
-  | ( Closures { by_closure_id = by_closure_id1 },
-      Closures { by_closure_id = by_closure_id2 } ) ->
+  | ( Mutable_block { alloc_mode = alloc_mode1 },
+      Mutable_block { alloc_mode = alloc_mode2 } ) ->
+    let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_mutable_block alloc_mode, TEE.empty
+  | Boxed_float (n1, alloc_mode1), Boxed_float (n2, alloc_mode2) ->
+    let<* n, env_extension = meet env n1 n2 in
+    let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_boxed_float n alloc_mode, env_extension
+  | Boxed_int32 (n1, alloc_mode1), Boxed_int32 (n2, alloc_mode2) ->
+    let<* n, env_extension = meet env n1 n2 in
+    let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_boxed_int32 n alloc_mode, env_extension
+  | Boxed_int64 (n1, alloc_mode1), Boxed_int64 (n2, alloc_mode2) ->
+    let<* n, env_extension = meet env n1 n2 in
+    let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_boxed_int64 n alloc_mode, env_extension
+  | Boxed_nativeint (n1, alloc_mode1), Boxed_nativeint (n2, alloc_mode2) ->
+    let<* n, env_extension = meet env n1 n2 in
+    let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_boxed_nativeint n alloc_mode, env_extension
+  | ( Closures { by_closure_id = by_closure_id1; alloc_mode = alloc_mode1 },
+      Closures { by_closure_id = by_closure_id2; alloc_mode = alloc_mode2 } ) ->
+    let<* alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
     let<+ by_closure_id, env_extension =
       meet_row_like_for_closures env by_closure_id1 by_closure_id2
     in
-    TG.Head_of_kind_value.create_closures by_closure_id, env_extension
+    ( TG.Head_of_kind_value.create_closures by_closure_id alloc_mode,
+      env_extension )
   | String strs1, String strs2 ->
     let strs = String_info.Set.inter strs1 strs2 in
     if String_info.Set.is_empty strs
@@ -322,8 +369,8 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
     in
     let<+ length, env_extension = meet env length1 length2 in
     TG.Head_of_kind_value.create_array ~element_kind ~length, env_extension
-  | ( ( Variant _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
-      | Boxed_nativeint _ | Closures _ | String _ | Array _ ),
+  | ( ( Variant _ | Mutable_block _ | Boxed_float _ | Boxed_int32 _
+      | Boxed_int64 _ | Boxed_nativeint _ | Closures _ | String _ | Array _ ),
       _ ) ->
     (* This assumes that all the different constructors are incompatible. This
        could break very hard for dubious uses of Obj. *)
@@ -460,6 +507,8 @@ and meet_head_of_kind_rec_info _env t1 _t2 : _ Or_bottom.t =
      variables are equal *)
   (* Arbitrary choice: *)
   Ok (t1, TEE.empty)
+
+and meet_head_of_kind_region _env () () : _ Or_bottom.t = Ok ((), TEE.empty)
 
 and meet_row_like :
       'index 'maps_to 'row_tag 'known.
@@ -982,8 +1031,11 @@ and join_expanded_head env kind (expanded1 : ET.t) (expanded2 : ET.t) : ET.t =
       | Rec_info head1, Rec_info head2 ->
         let>+ head = join_head_of_kind_rec_info env head1 head2 in
         ET.create_rec_info head
+      | Region head1, Region head2 ->
+        let>+ head = join_head_of_kind_region env head1 head2 in
+        ET.create_region head
       | ( ( Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _
-          | Naked_int64 _ | Naked_nativeint _ | Rec_info _ ),
+          | Naked_int64 _ | Naked_nativeint _ | Rec_info _ | Region _ ),
           _ ) ->
         assert false
     in
@@ -994,34 +1046,54 @@ and join_expanded_head env kind (expanded1 : ET.t) (expanded2 : ET.t) : ET.t =
 and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
     (head2 : TG.head_of_kind_value) : TG.head_of_kind_value Or_unknown.t =
   match head1, head2 with
-  | ( Variant { blocks = blocks1; immediates = imms1; is_unique = is_unique1 },
-      Variant { blocks = blocks2; immediates = imms2; is_unique = is_unique2 } )
-    ->
+  | ( Variant
+        { blocks = blocks1;
+          immediates = imms1;
+          is_unique = is_unique1;
+          alloc_mode = alloc_mode1
+        },
+      Variant
+        { blocks = blocks2;
+          immediates = imms2;
+          is_unique = is_unique2;
+          alloc_mode = alloc_mode2
+        } ) ->
     let>+ blocks, immediates =
       join_variant env ~blocks1 ~imms1 ~blocks2 ~imms2
     in
     (* Uniqueness tracks whether duplication/lifting is allowed. It must always
        be propagated, both for meet and join. *)
     let is_unique = is_unique1 || is_unique2 in
-    TG.Head_of_kind_value.create_variant ~is_unique ~blocks ~immediates
-  | Boxed_float n1, Boxed_float n2 ->
+    let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_variant ~is_unique alloc_mode ~blocks
+      ~immediates
+  | ( Mutable_block { alloc_mode = alloc_mode1 },
+      Mutable_block { alloc_mode = alloc_mode2 } ) ->
+    let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
+    Known (TG.Head_of_kind_value.create_mutable_block alloc_mode)
+  | Boxed_float (n1, alloc_mode1), Boxed_float (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
-    TG.Head_of_kind_value.create_boxed_float n
-  | Boxed_int32 n1, Boxed_int32 n2 ->
+    let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_boxed_float n alloc_mode
+  | Boxed_int32 (n1, alloc_mode1), Boxed_int32 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
-    TG.Head_of_kind_value.create_boxed_int32 n
-  | Boxed_int64 n1, Boxed_int64 n2 ->
+    let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_boxed_int32 n alloc_mode
+  | Boxed_int64 (n1, alloc_mode1), Boxed_int64 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
-    TG.Head_of_kind_value.create_boxed_int64 n
-  | Boxed_nativeint n1, Boxed_nativeint n2 ->
+    let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_boxed_int64 n alloc_mode
+  | Boxed_nativeint (n1, alloc_mode1), Boxed_nativeint (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
-    TG.Head_of_kind_value.create_boxed_nativeint n
-  | ( Closures { by_closure_id = by_closure_id1 },
-      Closures { by_closure_id = by_closure_id2 } ) ->
+    let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
+    TG.Head_of_kind_value.create_boxed_nativeint n alloc_mode
+  | ( Closures { by_closure_id = by_closure_id1; alloc_mode = alloc_mode1 },
+      Closures { by_closure_id = by_closure_id2; alloc_mode = alloc_mode2 } ) ->
     let by_closure_id =
       join_row_like_for_closures env by_closure_id1 by_closure_id2
     in
-    Known (TG.Head_of_kind_value.create_closures by_closure_id)
+    let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
+    Known (TG.Head_of_kind_value.create_closures by_closure_id alloc_mode)
   | String strs1, String strs2 ->
     let strs = String_info.Set.union strs1 strs2 in
     Known (TG.Head_of_kind_value.create_string strs)
@@ -1041,8 +1113,8 @@ and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
     in
     let>+ length = join env length1 length2 in
     TG.Head_of_kind_value.create_array ~element_kind ~length
-  | ( ( Variant _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
-      | Boxed_nativeint _ | Closures _ | String _ | Array _ ),
+  | ( ( Variant _ | Mutable_block _ | Boxed_float _ | Boxed_int32 _
+      | Boxed_int64 _ | Boxed_nativeint _ | Closures _ | String _ | Array _ ),
       _ ) ->
     Unknown
 
@@ -1109,6 +1181,8 @@ and join_head_of_kind_naked_nativeint _env t1 t2 : _ Or_unknown.t =
 
 and join_head_of_kind_rec_info _env t1 t2 : _ Or_unknown.t =
   if Rec_info_expr.equal t1 t2 then Known t1 else Unknown
+
+and join_head_of_kind_region _env () () : _ Or_unknown.t = Known ()
 
 (* Note that unlike the [join] function on types, for structures (closures
    entry, row-like, etc.) the return type is [t] (and not [t Or_unknown.t]).

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -343,6 +343,7 @@ let prove_equals_tagged_immediates env t : Targetint_31_63.Set.t proof =
       then Unknown
       else prove_naked_immediates env imms
   end
+  | Value (Ok (Mutable_block _)) -> Unknown
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
@@ -385,6 +386,7 @@ let prove_tags_and_sizes env t : Targetint_31_63.Imm.t Tag.Map.t proof =
           | Known tags_and_sizes -> Proved tags_and_sizes)
       else Unknown
   end
+  | Value (Ok (Mutable_block _)) -> Unknown
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
@@ -452,6 +454,7 @@ let prove_variant_like env t : variant_like_proof proof_allowing_kind_mismatch =
           in
           Proved { const_ctors; non_const_ctors_with_sizes }))
   end
+  | Value (Ok (Mutable_block _)) -> Unknown
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
@@ -813,6 +816,7 @@ let[@inline] prove_block_field_simple_aux env ~min_name_mode t get_field :
           end)
     end
   end
+  | Value (Ok (Mutable_block _)) -> Unknown
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -149,13 +149,19 @@ val prove_is_array_with_element_kind :
 val prove_single_closures_entry :
   Typing_env.t ->
   Type_grammar.t ->
-  (Closure_id.t * Type_grammar.Closures_entry.t * Type_grammar.Function_type.t)
+  (Closure_id.t
+  * Alloc_mode.t Or_unknown.t
+  * Type_grammar.Closures_entry.t
+  * Type_grammar.Function_type.t)
   proof
 
 val prove_single_closures_entry' :
   Typing_env.t ->
   Type_grammar.t ->
-  (Closure_id.t * Type_grammar.Closures_entry.t * Type_grammar.Function_type.t)
+  (Closure_id.t
+  * Alloc_mode.t Or_unknown.t
+  * Type_grammar.Closures_entry.t
+  * Type_grammar.Function_type.t)
   proof_allowing_kind_mismatch
 
 val prove_strings : Typing_env.t -> Type_grammar.t -> String_info.Set.t proof
@@ -218,3 +224,9 @@ val prove_select_closure_simple :
   Simple.t proof
 
 val prove_rec_info : Typing_env.t -> Type_grammar.t -> Rec_info_expr.t proof
+
+val prove_alloc_mode_of_boxed_number :
+  Typing_env.t -> Type_grammar.t -> Alloc_mode.t Or_unknown.t
+
+val never_holds_locally_allocated_values :
+  Typing_env.t -> Variable.t -> Flambda_kind.t -> bool

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -55,21 +55,40 @@ type reification_result =
 let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
     ?disallowed_free_vars ?(allow_unique = false) env ~min_name_mode t :
     reification_result =
-  let var_allowed var =
-    match allowed_if_free_vars_defined_in with
-    | None -> false
-    | Some allowed_if_free_vars_defined_in -> (
-      TE.mem ~min_name_mode allowed_if_free_vars_defined_in (Name.var var)
-      && begin
-           match additional_free_var_criterion with
-           | None -> true
-           | Some criterion -> criterion var
-         end
-      &&
-      match disallowed_free_vars with
-      | None -> true
-      | Some disallowed_free_vars ->
-        not (Variable.Set.mem var disallowed_free_vars))
+  let var_allowed (alloc_mode : Alloc_mode.t Or_unknown.t) var =
+    (* It is only safe to lift a [Local] allocation if it can be guaranteed that
+       no locally-allocated value is reachable from it: therefore, any variables
+       involved in the definition of an (inconstant) value to be lifted have
+       their types checked to ensure they cannot hold locally-allocated values.
+       Conversely, [Heap] allocations can be lifted even if inconstant, because
+       the OCaml type system will have validated the correctness of the original
+       non-lifted terms; any places in the compiler where new [Local] blocks are
+       created (e.g. during partial application wrapper expansion) will have
+       been checked to ensure they do not break the invariants; and finally
+       because the Flambda 2 type system accurately propagates the allocation
+       modes (and if it loses information there, we won't lift). *)
+    let allowed =
+      match allowed_if_free_vars_defined_in with
+      | None -> false
+      | Some allowed_if_free_vars_defined_in -> (
+        TE.mem ~min_name_mode allowed_if_free_vars_defined_in (Name.var var)
+        && begin
+             match additional_free_var_criterion with
+             | None -> true
+             | Some criterion -> criterion var
+           end
+        &&
+        match disallowed_free_vars with
+        | None -> true
+        | Some disallowed_free_vars ->
+          not (Variable.Set.mem var disallowed_free_vars))
+    in
+    allowed
+    &&
+    match alloc_mode with
+    | Known Heap -> true
+    | Unknown | Known Local ->
+      Provers.never_holds_locally_allocated_values env var Flambda_kind.value
   in
   let canonical_simple =
     match TE.get_alias_then_canonical_simple_exn env ~min_name_mode t with
@@ -91,11 +110,11 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
     match
       Expand_head.expand_head env t |> Expand_head.Expanded_type.descr_oub
     with
-    | Value (Ok (Variant blocks_imms)) -> (
-      if blocks_imms.is_unique && not allow_unique
+    | Value (Ok (Variant { is_unique; blocks; immediates; alloc_mode })) -> (
+      if is_unique && not allow_unique
       then try_canonical_simple ()
       else
-        match blocks_imms.blocks, blocks_imms.immediates with
+        match blocks, immediates with
         | Known blocks, Known imms ->
           if Expand_head.is_bottom env imms
           then
@@ -129,7 +148,9 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
                            fields have coercions. *)
                         None
                       | Proved (Var var, _) ->
-                        if var_allowed var then Some (Var var) else None
+                        if var_allowed alloc_mode var
+                        then Some (Var var)
+                        else None
                       | Proved (Symbol sym, _) -> Some (Symbol sym)
                       | Proved (Tagged_immediate imm, _) ->
                         Some (Tagged_immediate imm)
@@ -144,7 +165,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
                   Lift
                     (Immutable_block
                        { tag;
-                         is_unique = blocks_imms.is_unique;
+                         is_unique;
                          fields = vars_or_symbols_or_tagged_immediates
                        })
                 else try_canonical_simple ())
@@ -162,9 +183,10 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
           else try_canonical_simple ()
         | Known _, Unknown | Unknown, Known _ | Unknown, Unknown ->
           try_canonical_simple ())
-    | Value (Ok (Closures closures)) -> begin
+    | Value (Ok (Mutable_block _)) -> try_canonical_simple ()
+    | Value (Ok (Closures { by_closure_id; alloc_mode })) -> begin
       (* CR mshinwell: Here and above, move to separate function. *)
-      match TG.Row_like_for_closures.get_singleton closures.by_closure_id with
+      match TG.Row_like_for_closures.get_singleton by_closure_id with
       | None -> try_canonical_simple ()
       | Some ((closure_id, contents), closures_entry) ->
         (* CR mshinwell: What about if there were multiple entries in the
@@ -201,7 +223,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
                           closure_var_type
                       with
                       | Proved (Var var, coercion) ->
-                        if var_allowed var
+                        if var_allowed alloc_mode var
                         then
                           Some (Simple.with_coercion (Simple.var var) coercion)
                         else None
@@ -307,7 +329,9 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
       | None -> try_canonical_simple ()
       | Some n -> Simple (Simple.const (Reg_width_const.naked_nativeint n))
     end
-    | Value (Ok (Boxed_float ty_naked_float)) -> begin
+    (* CR-someday mshinwell: These could lift at toplevel when [ty_naked_float]
+       is an alias type. That would require checking the alloc mode. *)
+    | Value (Ok (Boxed_float (ty_naked_float, _alloc_mode))) -> begin
       match Provers.prove_naked_floats env ty_naked_float with
       | Unknown -> try_canonical_simple ()
       | Invalid -> Invalid
@@ -316,7 +340,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
         | None -> try_canonical_simple ()
         | Some f -> Lift (Boxed_float f))
     end
-    | Value (Ok (Boxed_int32 ty_naked_int32)) -> begin
+    | Value (Ok (Boxed_int32 (ty_naked_int32, _alloc_mode))) -> begin
       match Provers.prove_naked_int32s env ty_naked_int32 with
       | Unknown -> try_canonical_simple ()
       | Invalid -> Invalid
@@ -325,7 +349,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
         | None -> try_canonical_simple ()
         | Some n -> Lift (Boxed_int32 n))
     end
-    | Value (Ok (Boxed_int64 ty_naked_int64)) -> begin
+    | Value (Ok (Boxed_int64 (ty_naked_int64, _alloc_mode))) -> begin
       match Provers.prove_naked_int64s env ty_naked_int64 with
       | Unknown -> try_canonical_simple ()
       | Invalid -> Invalid
@@ -334,7 +358,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
         | None -> try_canonical_simple ()
         | Some n -> Lift (Boxed_int64 n))
     end
-    | Value (Ok (Boxed_nativeint ty_naked_nativeint)) -> begin
+    | Value (Ok (Boxed_nativeint (ty_naked_nativeint, _alloc_mode))) -> begin
       match Provers.prove_naked_nativeints env ty_naked_nativeint with
       | Unknown -> try_canonical_simple ()
       | Invalid -> Invalid
@@ -357,7 +381,8 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
     | Naked_int32 Bottom
     | Naked_int64 Bottom
     | Naked_nativeint Bottom
-    | Rec_info Bottom ->
+    | Rec_info Bottom
+    | Region Bottom ->
       Invalid
     | Value Unknown
     | Value (Ok (String _))
@@ -367,5 +392,6 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
     | Naked_int64 Unknown
     | Naked_nativeint Unknown
     | Rec_info Unknown
+    | Region (Unknown | Ok _)
     | Rec_info (Ok _) ->
       try_canonical_simple ())

--- a/testsuite/flambda2-test-list
+++ b/testsuite/flambda2-test-list
@@ -9,12 +9,11 @@
   tests/gc-roots                   FAIL (FIXME)  test_stdlabels.ml has different bytecodes (ocamlc.byte vs ocamlc.byte) - the digest of the main module differ
   tests/int64-unboxing             FAIL (FIXME)  'test.ml' (unboxing of recursive continuation parameter)
   tests/lib-dynlink-init-info      FAIL (FIXME)  fails on macOS
-  tests/lib-dynlink-initializers   FAIL (FIXME)  temporarily disabled (flambda2) 
-  tests/lib-dynlink-pr4839         FAIL (FIXME)  temporarily disabled (flambda2) 
+  tests/lib-dynlink-initializers   FAIL (FIXME)  temporarily disabled (flambda2)
+  tests/lib-dynlink-pr4839         FAIL (FIXME)  temporarily disabled (flambda2)
   tests/lib-hashtbl                FAIL (FIXME)  htbl.ml has different bytecodes (ocamlc.byte vs ocamlc.byte) - the digest of the main module differ
   tests/lib-stdlabels              FAIL (FIXME)  test_stdlabels.ml has different bytecodes (ocamlc.byte vs ocamlc.byte) - the digest of the main module differ
   tests/lib-threads                FAIL (FIXME)  beat.ml seems to fail under heavy load (macOS box on GitHub CI)
   tests/opaque                     FAIL          'test.ml' (cmx file loading)
   tests/statmemprof                FAIL          Stack traces differ
   tests/warnings                   FAIL          'w55.ml' (@inline attribute), 'w59.ml' (missing warnings when using Obj functions)
-  tests/typing-local               FAIL          Local allocations not yet supported in Flambda2


### PR DESCRIPTION
This PR provides support for local allocations in Flambda 2.

First there is a new type `Alloc_mode` which either says whether an allocation is on the `Heap` or the `Local` allocation stack.

As for exception handling in Flambda 2, deconstruction of block-structured region constructs is performed on the way into Flambda 2, rather than during Selectgen.

The following new primitives are added and are generated on the way into Flambda 2:
- `Begin_region`, which starts a new region in which local allocations may be performed.  This primitive returns what is effectively a name for the region, which at runtime will actually be the value of the local allocation stack pointer when the region was opened.  These region names have a new kind, `Region`, as they must be kept apart from everything else (especially since in the backend they have to be given register type `typ_int`).  The `Region` kind was appropriated from the redundant `Fabricated` kind, so as a convenient side-effect that has now gone.
- `End_region`, which takes a variable of kind `Region` and closes the region.

I did consider adding these as trap actions but in the end primitives seem better (@stedolan suggested maybe we could actually do the same for push and pop trap one day).  I also considered whether locally-allocating primitives and sets of closures declarations should name the corresponding region variable, to make things more robust in the face of future code motion transformations.  However there would be a tricky nuance here: only the most recent (innermost) region can be allocated in, and that constraint would have to be encoded.  For the moment the region primitives are marked as effectful and coeffectful, so they cannot be removed or moved; and any locally-allocating primitive or local set of closures declaration is marked as coeffectful to act as a barrier.

There are two new Cmm operations corresponding to the above which directly translate to the pre-existing Mach equivalents.  Note that it is critical that the result of the begin-region operation is `typ_int` not `typ_val`.

The interaction between allocation modes and currying is tricky, as will be seen in the partial application and over application wrapper expansion code (incidentally during this work I noted there doesn’t seem to be any partial application wrapper expansion in classic mode yet).  The local allocations logic here follows that of Closure.

The following properties are now tracked on `Code` to implement all of this:
- the number of _trailing local parameters_ (closure construction as we move along parameter lists starts as `Heap` and then switches, possibly immediately, to `Local` but never the other way around);
- whether a local allocation done inside the function (by that function itself or a callee) might escape out of the function.

The translation into Flambda 2 takes care of ensuring that `End_region` primitives are inserted immediately prior to an application in tail position (as judged by the type checker), after evaluation of any arguments, in the case where such application in the `Lambda` code is surrounded by an `Lregion` that is closing.  (A simple translation would erroneously put the `End_region` after the application.)

This branch is currently based on one of @stedolan’s development branches, I will rebase it once the remainder of the local allocations support has been merged.  See the most recent changeset for the Flambda 2 changes.
