### PR TITLE
make_suitable_for_environment: Expand unavailable variables occurring only once

### DIFF
--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -362,22 +362,24 @@ type to_erase =
 
 exception Missing_cmx_file
 
-let free_variables_transitive env already_seen ty =
-  let rec free_variables_transitive0 ty ~result =
+let free_variables_transitive ~free_names_of_type env free_vars_acc ty =
+  let rec free_variables_transitive0 ty ~free_vars_acc =
     (* We don't need to look at symbols because the assumption (see the .mli) is
        that all symbols have valid types in the target environment. *)
-    let free_vars = TG.free_names ty |> Name_occurrences.with_only_variables in
+    let free_vars =
+      free_names_of_type ty |> Name_occurrences.with_only_variables
+    in
     if missing_kind env free_vars
     then raise Missing_cmx_file
     else
-      let to_traverse = Name_occurrences.diff free_vars result in
-      let result = Name_occurrences.union result to_traverse in
-      Name_occurrences.fold_names to_traverse ~init:result
-        ~f:(fun result name ->
+      let to_traverse = Name_occurrences.diff free_vars free_vars_acc in
+      let free_vars_acc = Name_occurrences.union free_vars_acc free_vars in
+      Name_occurrences.fold_names to_traverse ~init:free_vars_acc
+        ~f:(fun free_vars_acc name ->
           let ty = TE.find env name None in
-          free_variables_transitive0 ty ~result)
+          free_variables_transitive0 ty ~free_vars_acc)
   in
-  free_variables_transitive0 ty ~result:already_seen
+  free_variables_transitive0 ty ~free_vars_acc
 
 let make_suitable_for_environment env (to_erase : to_erase) bind_to_and_types =
   (match to_erase with
@@ -409,9 +411,15 @@ let make_suitable_for_environment env (to_erase : to_erase) bind_to_and_types =
   else
     (* Now collect all of the free variables, transitively (see comment on
        function above). *)
+    let root_types = List.map snd bind_to_and_types in
     match
-      bind_to_and_types |> List.map snd
-      |> List.fold_left (free_variables_transitive env) Name_occurrences.empty
+      ( List.fold_left
+          (free_variables_transitive ~free_names_of_type:TG.free_names env)
+          Name_occurrences.empty root_types,
+        List.fold_left
+          (free_variables_transitive
+             ~free_names_of_type:TG.free_names_except_through_closure_vars env)
+          Name_occurrences.empty root_types )
     with
     | exception Missing_cmx_file ->
       (* Just forget everything if there is a .cmx file missing. *)
@@ -419,46 +427,98 @@ let make_suitable_for_environment env (to_erase : to_erase) bind_to_and_types =
         (fun result (bind_to, ty) ->
           TEEV.add_or_replace_equation result bind_to (MTC.unknown_like ty))
         TEEV.empty bind_to_and_types
-    | free_vars ->
+    | free_vars, free_vars_except_through_closure_vars ->
       (* Determine which variables will be unavailable and thus need fresh ones
          assigning to them. *)
-      let unavailable_vars =
-        match to_erase with
-        | Everything_not_in suitable_for ->
-          Name_occurrences.fold_variables free_vars ~init:[]
-            ~f:(fun unavailable_vars var ->
-              if not (TE.mem suitable_for (Name.var var))
-              then var :: unavailable_vars
-              else unavailable_vars)
-        | All_variables_except to_keep ->
-          Name_occurrences.fold_variables free_vars ~init:[]
-            ~f:(fun unavailable_vars var ->
-              if not (Variable.Set.mem var to_keep)
-              then var :: unavailable_vars
-              else unavailable_vars)
+      let ( unavailable_vars_renamed,
+            unavailable_vars_expanded,
+            unavailable_vars_removed ) =
+        let erase var =
+          match to_erase with
+          | Everything_not_in suitable_for ->
+            not (TE.mem suitable_for (Name.var var))
+          | All_variables_except to_keep -> not (Variable.Set.mem var to_keep)
+        in
+        Name_occurrences.fold_variables free_vars ~init:([], [], [])
+          ~f:(fun
+               (( unavailable_vars_renamed,
+                  unavailable_vars_expanded,
+                  unavailable_vars_removed ) as unavailable_vars)
+               var
+             ->
+            if erase var
+            then
+              if Name_occurrences.mem_var free_vars_except_through_closure_vars
+                   var
+              then
+                match Name_occurrences.count_variable free_vars var with
+                | Zero ->
+                  Misc.fatal_errorf
+                    "Inconsistent occurrences of %a in free names"
+                    Variable.print var
+                | One ->
+                  ( unavailable_vars_renamed,
+                    var :: unavailable_vars_expanded,
+                    unavailable_vars_removed )
+                | More_than_one ->
+                  ( var :: unavailable_vars_renamed,
+                    unavailable_vars_expanded,
+                    unavailable_vars_removed )
+              else
+                ( unavailable_vars_renamed,
+                  unavailable_vars_expanded,
+                  var :: unavailable_vars_removed )
+            else unavailable_vars)
       in
       (* Fetch the type equation for each free variable. Also add in the
          equations about the "bind-to" names provided to this function. If any
          of the "bind-to" names are already defined in [env], the type given in
-         [bind_to_and_types] takes precedence over such definition. *)
+         [bind_to_and_types] takes precedence over such definition. All
+         occurrences of variables that only occur once are expanded directly.
+         All occurrences of variables that are only reachable through closure
+         variables are replaced with an Unknown type. *)
+      let to_expand = Variable.Set.of_list unavailable_vars_expanded in
+      let to_remove = Variable.Set.of_list unavailable_vars_removed in
+      let to_project = Variable.Set.union to_expand to_remove in
+      let expand_type ty =
+        let rec expand var =
+          let ty = TE.find env (Name.var var) None in
+          if Variable.Set.mem var to_remove
+          then MTC.unknown_like ty
+          else
+            match TG.get_alias_exn ty with
+            | exception Not_found ->
+              TG.project_variables_out ~to_project ~expand ty
+            | simple ->
+              Simple.pattern_match' simple
+                ~const:(fun _ -> ty)
+                ~symbol:(fun _ ~coercion:_ -> ty)
+                ~var:(fun var ~coercion ->
+                  if Variable.Set.mem var to_expand
+                  then TG.apply_coercion (expand var) coercion
+                  else ty)
+        in
+        TG.project_variables_out ~to_project ~expand ty
+      in
       let equations =
-        ListLabels.fold_left unavailable_vars ~init:[] ~f:(fun equations var ->
+        ListLabels.fold_left unavailable_vars_renamed ~init:[]
+          ~f:(fun equations var ->
             let name = Name.var var in
             let ty = TE.find env name None in
-            (name, ty) :: equations)
+            (name, expand_type ty) :: equations)
       in
       let equations =
         List.fold_left
           (fun equations (bind_to, ty) ->
             (* The [bind_to] variables are not expected to be unavailable, so
                this shouldn't cause duplicates. *)
-            (bind_to, ty) :: equations)
+            (bind_to, expand_type ty) :: equations)
           equations bind_to_and_types
       in
       (* Make fresh variables for the unavailable variables and form a
          renaming. *)
       let unavailable_to_fresh_vars =
-        List.map (fun var -> var, Variable.rename var) unavailable_vars
+        List.map (fun var -> var, Variable.rename var) unavailable_vars_renamed
         |> Variable.Map.of_list
       in
       let renaming =

--- a/middle_end/flambda2/types/grammar/type_descr.ml
+++ b/middle_end/flambda2/types/grammar/type_descr.ml
@@ -221,7 +221,8 @@ end = struct
     | Unknown | Bottom -> Name_occurrences.empty
     | Ok descr ->
       Descr.free_names
-        ~free_names_head:(WCFN.free_names_no_cache ~free_names_descr:free_names_head)
+        ~free_names_head:
+          (WCFN.free_names_no_cache ~free_names_descr:free_names_head)
         descr
 
   let remove_unused_closure_vars_and_shortcut_aliases
@@ -240,14 +241,13 @@ end = struct
       in
       if descr == descr' then t else Ok descr'
 
-  let project_variables_out ~free_names_head ~to_project
-      ~expand ~project_head (t : _ t) : _ t =
+  let project_variables_out ~free_names_head ~to_project ~expand ~project_head
+      (t : _ t) : _ t =
     match t with
     | Unknown | Bottom -> t
     | Ok descr -> (
       let project_head wdr =
-        WCFN.project_variables_out
-          ~free_names_descr:free_names_head ~to_project
+        WCFN.project_variables_out ~free_names_descr:free_names_head ~to_project
           ~project_descr:project_head wdr
       in
       match

--- a/middle_end/flambda2/types/grammar/type_descr.mli
+++ b/middle_end/flambda2/types/grammar/type_descr.mli
@@ -64,6 +64,9 @@ val apply_renaming :
 val free_names :
   free_names_head:('head -> Name_occurrences.t) -> 'head t -> Name_occurrences.t
 
+val free_names_no_cache :
+  free_names_head:('head -> Name_occurrences.t) -> 'head t -> Name_occurrences.t
+
 val remove_unused_closure_vars_and_shortcut_aliases :
   remove_unused_closure_vars_and_shortcut_aliases_head:
     ('head ->
@@ -73,6 +76,14 @@ val remove_unused_closure_vars_and_shortcut_aliases :
   'head t ->
   used_closure_vars:Var_within_closure.Set.t ->
   canonicalise:(Simple.t -> Simple.t) ->
+  'head t
+
+val project_variables_out :
+  free_names_head:('head -> Name_occurrences.t) ->
+  to_project:Variable.Set.t ->
+  expand:(Variable.t -> coercion:Coercion.t -> 'head t) ->
+  project_head:('head -> 'head) ->
+  'head t ->
   'head t
 
 val all_ids_for_export :

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -174,23 +174,21 @@ let rec free_names0 ~follow_closure_vars t =
         (free_names_head_of_kind_naked_immediate0 ~follow_closure_vars)
       ty
   | Naked_float ty ->
-    type_descr_free_names
-      ~free_names_head:free_names_head_of_kind_naked_float ty
+    type_descr_free_names ~free_names_head:free_names_head_of_kind_naked_float
+      ty
   | Naked_int32 ty ->
-    type_descr_free_names
-      ~free_names_head:free_names_head_of_kind_naked_int32 ty
+    type_descr_free_names ~free_names_head:free_names_head_of_kind_naked_int32
+      ty
   | Naked_int64 ty ->
-    type_descr_free_names
-      ~free_names_head:free_names_head_of_kind_naked_int64 ty
+    type_descr_free_names ~free_names_head:free_names_head_of_kind_naked_int64
+      ty
   | Naked_nativeint ty ->
     type_descr_free_names
       ~free_names_head:free_names_head_of_kind_naked_nativeint ty
   | Rec_info ty ->
-    type_descr_free_names
-      ~free_names_head:free_names_head_of_kind_rec_info ty
+    type_descr_free_names ~free_names_head:free_names_head_of_kind_rec_info ty
   | Region ty ->
-    type_descr_free_names
-      ~free_names_head:free_names_head_of_kind_region ty
+    type_descr_free_names ~free_names_head:free_names_head_of_kind_region ty
 
 and free_names_head_of_kind_value0 ~follow_closure_vars head =
   match head with
@@ -1640,9 +1638,8 @@ let rec project_variables_out ~to_project ~expand t =
           Variable.print var print ty
     in
     let ty' =
-      TD.project_variables_out
-        ~free_names_head:free_names_head_of_kind_value ~to_project
-        ~expand:expand_with_coercion
+      TD.project_variables_out ~free_names_head:free_names_head_of_kind_value
+        ~to_project ~expand:expand_with_coercion
         ~project_head:(project_head_of_kind_value ~to_project ~expand)
         ty
     in
@@ -1671,7 +1668,7 @@ let rec project_variables_out ~to_project ~expand t =
       match apply_coercion (expand var) coercion with
       | Naked_float ty -> ty
       | ( Value _ | Naked_immediate _ | Naked_int32 _ | Naked_int64 _
-        | Naked_nativeint _ | Rec_info _ | Region _) as ty ->
+        | Naked_nativeint _ | Rec_info _ | Region _ ) as ty ->
         Misc.fatal_errorf
           "Wrong kind while expanding %a: expecting [Naked_float], got type %a"
           Variable.print var print ty
@@ -1689,7 +1686,7 @@ let rec project_variables_out ~to_project ~expand t =
       match apply_coercion (expand var) coercion with
       | Naked_int32 ty -> ty
       | ( Value _ | Naked_immediate _ | Naked_float _ | Naked_int64 _
-        | Naked_nativeint _ | Rec_info _ | Region _) as ty ->
+        | Naked_nativeint _ | Rec_info _ | Region _ ) as ty ->
         Misc.fatal_errorf
           "Wrong kind while expanding %a: expecting [Naked_int32], got type %a"
           Variable.print var print ty
@@ -1707,7 +1704,7 @@ let rec project_variables_out ~to_project ~expand t =
       match apply_coercion (expand var) coercion with
       | Naked_int64 ty -> ty
       | ( Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _
-        | Naked_nativeint _ | Rec_info _ | Region _) as ty ->
+        | Naked_nativeint _ | Rec_info _ | Region _ ) as ty ->
         Misc.fatal_errorf
           "Wrong kind while expanding %a: expecting [Naked_int64], got type %a"
           Variable.print var print ty
@@ -1725,7 +1722,7 @@ let rec project_variables_out ~to_project ~expand t =
       match apply_coercion (expand var) coercion with
       | Naked_nativeint ty -> ty
       | ( Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _
-        | Naked_int64 _ | Rec_info _ | Region _) as ty ->
+        | Naked_int64 _ | Rec_info _ | Region _ ) as ty ->
         Misc.fatal_errorf
           "Wrong kind while expanding %a: expecting [Naked_nativeint], got \
            type %a"
@@ -1744,15 +1741,14 @@ let rec project_variables_out ~to_project ~expand t =
       match apply_coercion (expand var) coercion with
       | Rec_info ty -> ty
       | ( Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _
-        | Naked_int64 _ | Naked_nativeint _ | Region _) as ty ->
+        | Naked_int64 _ | Naked_nativeint _ | Region _ ) as ty ->
         Misc.fatal_errorf
           "Wrong kind while expanding %a: expecting [Rec_info], got type %a"
           Variable.print var print ty
     in
     let ty' =
-      TD.project_variables_out
-        ~free_names_head:free_names_head_of_kind_rec_info ~to_project
-        ~expand:expand_with_coercion
+      TD.project_variables_out ~free_names_head:free_names_head_of_kind_rec_info
+        ~to_project ~expand:expand_with_coercion
         ~project_head:(project_head_of_kind_rec_info ~to_project ~expand)
         ty
     in
@@ -1762,15 +1758,14 @@ let rec project_variables_out ~to_project ~expand t =
       match apply_coercion (expand var) coercion with
       | Region ty -> ty
       | ( Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _
-        | Naked_int64 _ | Naked_nativeint _ | Rec_info _) as ty ->
+        | Naked_int64 _ | Naked_nativeint _ | Rec_info _ ) as ty ->
         Misc.fatal_errorf
           "Wrong kind while expanding %a: expecting [Region], got type %a"
           Variable.print var print ty
     in
     let ty' =
-      TD.project_variables_out
-        ~free_names_head:free_names_head_of_kind_region ~to_project
-        ~expand:expand_with_coercion
+      TD.project_variables_out ~free_names_head:free_names_head_of_kind_region
+        ~to_project ~expand:expand_with_coercion
         ~project_head:(project_head_of_kind_region ~to_project ~expand)
         ty
     in
@@ -1789,7 +1784,9 @@ and project_head_of_kind_value ~to_project ~expand head =
     in
     if immediates == immediates' && blocks == blocks'
     then head
-    else Variant { is_unique; blocks = blocks'; immediates = immediates'; alloc_mode }
+    else
+      Variant
+        { is_unique; blocks = blocks'; immediates = immediates'; alloc_mode }
   | Mutable_block _ -> head
   | Boxed_float (ty, alloc_mode) ->
     let ty' = project_variables_out ~to_project ~expand ty in
@@ -1809,7 +1806,7 @@ and project_head_of_kind_value ~to_project ~expand head =
     in
     if by_closure_id == by_closure_id'
     then head
-    else Closures { by_closure_id = by_closure_id' ; alloc_mode }
+    else Closures { by_closure_id = by_closure_id'; alloc_mode }
   | String _ -> head
   | Array { element_kind; length } ->
     let length' = project_variables_out ~to_project ~expand length in

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -135,6 +135,8 @@ val print : Format.formatter -> t -> unit
     regardless of where in the type such variables occur. *)
 include Contains_names.S with type t := t
 
+val free_names_except_through_closure_vars : t -> Name_occurrences.t
+
 include Contains_ids.S with type t := t
 
 val remove_unused_closure_vars_and_shortcut_aliases :
@@ -142,6 +144,9 @@ val remove_unused_closure_vars_and_shortcut_aliases :
   used_closure_vars:Var_within_closure.Set.t ->
   canonicalise:(Simple.t -> Simple.t) ->
   t
+
+val project_variables_out :
+  to_project:Variable.Set.t -> expand:(Variable.t -> t) -> t -> t
 
 val kind : t -> Flambda_kind.t
 

--- a/middle_end/flambda2/types/grammar/with_cached_free_names.ml
+++ b/middle_end/flambda2/types/grammar/with_cached_free_names.ml
@@ -34,6 +34,11 @@ let[@inline always] free_names ~free_names_descr t =
     t.free_names <- Some free_names;
     free_names
 
+let[@inline always] free_names_no_cache ~free_names_descr
+    t =
+  let descr = descr t in
+  free_names_descr descr
+
 let apply_renaming ~apply_renaming_descr ~free_names_descr t renaming =
   let free_names = free_names ~free_names_descr t in
   if (not (Renaming.has_import_map renaming))
@@ -58,5 +63,20 @@ let remove_unused_closure_vars_and_shortcut_aliases
       ~used_closure_vars ~canonicalise
   in
   if descr == t.descr then t else { descr; free_names = None }
+
+let project_variables_out ~free_names_descr ~to_project
+    ~project_descr t =
+  let free_names = free_names t ~free_names_descr in
+  let has_variable_to_project =
+    Variable.Set.fold
+      (fun var has_variable_to_project ->
+        has_variable_to_project || Name_occurrences.mem_var free_names var)
+      to_project false
+  in
+  if has_variable_to_project
+  then
+    let descr' = project_descr t.descr in
+    if descr' == t.descr then t else create descr'
+  else t
 
 let print ~print_descr ppf t = print_descr ppf (descr t)

--- a/middle_end/flambda2/types/grammar/with_cached_free_names.ml
+++ b/middle_end/flambda2/types/grammar/with_cached_free_names.ml
@@ -34,8 +34,7 @@ let[@inline always] free_names ~free_names_descr t =
     t.free_names <- Some free_names;
     free_names
 
-let[@inline always] free_names_no_cache ~free_names_descr
-    t =
+let[@inline always] free_names_no_cache ~free_names_descr t =
   let descr = descr t in
   free_names_descr descr
 
@@ -64,8 +63,7 @@ let remove_unused_closure_vars_and_shortcut_aliases
   in
   if descr == t.descr then t else { descr; free_names = None }
 
-let project_variables_out ~free_names_descr ~to_project
-    ~project_descr t =
+let project_variables_out ~free_names_descr ~to_project ~project_descr t =
   let free_names = free_names t ~free_names_descr in
   let has_variable_to_project =
     Variable.Set.fold

--- a/middle_end/flambda2/types/grammar/with_cached_free_names.mli
+++ b/middle_end/flambda2/types/grammar/with_cached_free_names.mli
@@ -45,6 +45,11 @@ val free_names :
   'descr t ->
   Name_occurrences.t
 
+val free_names_no_cache :
+  free_names_descr:('descr -> Name_occurrences.t) ->
+  'descr t ->
+  Name_occurrences.t
+
 val remove_unused_closure_vars_and_shortcut_aliases :
   remove_unused_closure_vars_and_shortcut_aliases_descr:
     ('descr ->
@@ -54,4 +59,11 @@ val remove_unused_closure_vars_and_shortcut_aliases :
   'descr t ->
   used_closure_vars:Var_within_closure.Set.t ->
   canonicalise:(Simple.t -> Simple.t) ->
+  'descr t
+
+val project_variables_out :
+  free_names_descr:('descr -> Name_occurrences.t) ->
+  to_project:Variable.Set.t ->
+  project_descr:('descr -> 'descr) ->
+  'descr t ->
   'descr t


### PR DESCRIPTION
This PR is aimed at reducing the number of variables that get quantified existentially when making a type suitable for another environment.

This works by finding the variables that only occur once (transitively) in the input types, and replacing them by a valid expansion (if they're canonical, their head expansion, otherwise either a valid alias or the expansion of it).
Since this has to explore types in depth, it requires a new set of functions, that I've called `project_*` because they correspond to the concept projection on a lower-dimensional plane in the context of multi-dimensional environments.