### PR TITLE
More thorough treatment of closure offsets

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -23,6 +23,12 @@ let print ppf t = Code_id.Map.print Code_or_metadata.print ppf t
 
 let empty = Code_id.Map.empty
 
+let free_names t =
+  Code_id.Map.fold
+    (fun _code_id code acc ->
+      Name_occurrences.union acc (Code_or_metadata.free_names code))
+    t Name_occurrences.empty
+
 let add_code ~keep_code code_map t =
   Code_id.Map.mapi
     (fun code_id code ->

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -23,6 +23,8 @@ val print : Format.formatter -> t -> unit
 
 val empty : t
 
+val free_names : t -> Name_occurrences.t
+
 val add_code : keep_code:(Code_id.t -> bool) -> Code.t Code_id.Map.t -> t -> t
 
 val mark_as_imported : t -> t

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -147,6 +147,16 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol
     let final_typing_env =
       TE.Serializable.create final_typing_env ~reachable_names
     in
+    let closure_elts_used_in_typing_env =
+      TE.Serializable.free_closure_ids_and_closure_vars final_typing_env
+    in
+    let exported_offsets =
+      exported_offsets
+      |> Closure_offsets.collect_used_closure_ids
+           (Name_occurrences.closure_ids closure_elts_used_in_typing_env)
+      |> Closure_offsets.collect_used_closure_vars
+           (Name_occurrences.closure_vars closure_elts_used_in_typing_env)
+    in
     Some
       (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets
          ~used_closure_vars)

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -164,13 +164,13 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol
     in
     let exported_offsets =
       exported_offsets
-      |> Closure_offsets.collect_used_closure_ids
+      |> Closure_offsets.reexport_closure_ids
            (Name_occurrences.closure_ids free_names_of_all_code)
-      |> Closure_offsets.collect_used_closure_vars
+      |> Closure_offsets.reexport_closure_vars
            (Name_occurrences.closure_vars free_names_of_all_code)
-      |> Closure_offsets.collect_used_closure_ids
+      |> Closure_offsets.reexport_closure_ids
            (Name_occurrences.closure_ids closure_elts_used_in_typing_env)
-      |> Closure_offsets.collect_used_closure_vars
+      |> Closure_offsets.reexport_closure_vars
            (Name_occurrences.closure_vars closure_elts_used_in_typing_env)
     in
     Some

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1654,8 +1654,7 @@ let close_program ~symbol_for_global ~big_endian ~module_ident
     Or_unknown.map (Acc.closure_offsets acc) ~f:(fun offsets ->
         (* CR gbury: would it be possible to use the free_names from the acc to
            compute the used closure vars ? *)
-        Closure_offsets.finalize_offsets offsets ~used_closure_vars:Unknown
-          ~used_closure_ids:Unknown)
+        Closure_offsets.finalize_offsets offsets ~used_names:Unknown)
   in
   ( Flambda_unit.create ~return_continuation:return_cont ~exn_continuation ~body
       ~module_symbol ~used_closure_vars:Unknown,

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1654,7 +1654,13 @@ let close_program ~symbol_for_global ~big_endian ~module_ident
     Or_unknown.map (Acc.closure_offsets acc) ~f:(fun offsets ->
         (* CR gbury: would it be possible to use the free_names from the acc to
            compute the used closure vars ? *)
-        Closure_offsets.finalize_offsets offsets ~used_names:Unknown)
+        (* CR gbury: in classic mode, make use of the used_closure_vars returned
+           by Closure offsets (once we give it a non-unknown used_names, as per
+           the above CR). *)
+        let _used_closure_vars, offsets =
+          Closure_offsets.finalize_offsets offsets ~used_names:Unknown
+        in
+        offsets)
   in
   ( Flambda_unit.create ~return_continuation:return_cont ~exn_continuation ~body
       ~module_symbol ~used_closure_vars:Unknown,

--- a/middle_end/flambda2/nominal/name_mode.ml
+++ b/middle_end/flambda2/nominal/name_mode.ml
@@ -64,6 +64,8 @@ let is_normal t = match t with Normal -> true | In_types | Phantom -> false
 
 let is_phantom t = match t with Phantom -> true | In_types | Normal -> false
 
+let is_in_types t = match t with In_types -> true | Normal | Phantom -> false
+
 let min_in_types = In_types
 
 let min_in_terms = Phantom

--- a/middle_end/flambda2/nominal/name_mode.mli
+++ b/middle_end/flambda2/nominal/name_mode.mli
@@ -36,6 +36,8 @@ val is_normal : t -> bool
 
 val is_phantom : t -> bool
 
+val is_in_types : t -> bool
+
 val min_in_types : t
 
 val min_in_terms : t

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -983,16 +983,16 @@ let closure_ids t = For_closure_ids.keys t.closure_ids
 
 let closure_ids_normal t =
   For_closure_ids.fold_with_mode t.closure_ids ~init:Closure_id.Set.empty
-    ~f:(fun acc closure_var name_mode ->
+    ~f:(fun acc closure_id name_mode ->
       if Name_mode.is_normal name_mode
-      then Closure_id.Set.add closure_var acc
+      then Closure_id.Set.add closure_id acc
       else acc)
 
 let closure_ids_in_types t =
   For_closure_ids.fold_with_mode t.closure_ids ~init:Closure_id.Set.empty
-    ~f:(fun acc closure_var name_mode ->
+    ~f:(fun acc closure_id name_mode ->
       if Name_mode.is_in_types name_mode
-      then Closure_id.Set.add closure_var acc
+      then Closure_id.Set.add closure_id acc
       else acc)
 
 let closure_vars t = For_closure_vars.keys t.closure_vars

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -981,19 +981,33 @@ let rec union_list ts =
 
 let closure_ids t = For_closure_ids.keys t.closure_ids
 
-let normal_closure_ids t =
+let closure_ids_normal t =
   For_closure_ids.fold_with_mode t.closure_ids ~init:Closure_id.Set.empty
     ~f:(fun acc closure_var name_mode ->
       if Name_mode.is_normal name_mode
       then Closure_id.Set.add closure_var acc
       else acc)
 
+let closure_ids_in_types t =
+  For_closure_ids.fold_with_mode t.closure_ids ~init:Closure_id.Set.empty
+    ~f:(fun acc closure_var name_mode ->
+      if Name_mode.is_in_types name_mode
+      then Closure_id.Set.add closure_var acc
+      else acc)
+
 let closure_vars t = For_closure_vars.keys t.closure_vars
 
-let normal_closure_vars t =
+let closure_vars_normal t =
   For_closure_vars.fold_with_mode t.closure_vars
     ~init:Var_within_closure.Set.empty ~f:(fun acc closure_var name_mode ->
       if Name_mode.is_normal name_mode
+      then Var_within_closure.Set.add closure_var acc
+      else acc)
+
+let closure_vars_in_types t =
+  For_closure_vars.fold_with_mode t.closure_vars
+    ~init:Var_within_closure.Set.empty ~f:(fun acc closure_var name_mode ->
+      if Name_mode.is_in_types name_mode
       then Var_within_closure.Set.add closure_var acc
       else acc)
 

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -122,11 +122,15 @@ val continuations_including_in_trap_actions : t -> Continuation.Set.t
 
 val closure_ids : t -> Closure_id.Set.t
 
-val normal_closure_ids : t -> Closure_id.Set.t
+val closure_ids_normal : t -> Closure_id.Set.t
+
+val closure_ids_in_types : t -> Closure_id.Set.t
 
 val closure_vars : t -> Var_within_closure.Set.t
 
-val normal_closure_vars : t -> Var_within_closure.Set.t
+val closure_vars_normal : t -> Var_within_closure.Set.t
+
+val closure_vars_in_types : t -> Var_within_closure.Set.t
 
 val symbols : t -> Symbol.Set.t
 

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -123,9 +123,6 @@ let run ~symbol_for_global ~get_global_info ~round unit =
   let closure_vars_in_types =
     Name_occurrences.closure_vars_in_types name_occurrences
   in
-  (* CR gbury/lthls: we should also add the free_names from the typing env
-     (after the preparation for cmx/removal of unused closure vars) to the
-     exported offsets. *)
   let used_closure_vars, exported_offsets =
     match UA.closure_offsets uacc with
     | Unknown ->

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -111,9 +111,15 @@ let run ~symbol_for_global ~get_global_info ~round unit =
       (Exported_code.mark_as_imported !imported_code)
   in
   let name_occurrences = UA.name_occurrences uacc in
-  let used_closure_ids = Name_occurrences.normal_closure_ids name_occurrences in
+  let used_closure_ids = Name_occurrences.closure_ids_normal name_occurrences in
   let used_closure_vars =
-    Name_occurrences.normal_closure_vars name_occurrences
+    Name_occurrences.closure_vars_normal name_occurrences
+  in
+  let closure_ids_in_types =
+    Name_occurrences.closure_ids_in_types name_occurrences
+  in
+  let closure_vars_in_types =
+    Name_occurrences.closure_vars_in_types name_occurrences
   in
   let exported_offsets =
     match UA.closure_offsets uacc with
@@ -121,8 +127,13 @@ let run ~symbol_for_global ~get_global_info ~round unit =
       Misc.fatal_error "Closure offsets must be computed and cannot be unknown"
     | Known closure_offsets ->
       Closure_offsets.finalize_offsets closure_offsets
-        ~used_closure_vars:(Known used_closure_vars)
-        ~used_closure_ids:(Known used_closure_ids)
+        ~used_names:
+          (Known
+             { closure_vars_normal = used_closure_vars;
+               closure_ids_normal = used_closure_ids;
+               closure_vars_in_types;
+               closure_ids_in_types
+             })
   in
   let cmx =
     Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -111,8 +111,10 @@ let run ~symbol_for_global ~get_global_info ~round unit =
       (Exported_code.mark_as_imported !imported_code)
   in
   let name_occurrences = UA.name_occurrences uacc in
-  let used_closure_ids = Name_occurrences.closure_ids_normal name_occurrences in
-  let used_closure_vars =
+  let closure_ids_normal =
+    Name_occurrences.closure_ids_normal name_occurrences
+  in
+  let closure_vars_normal =
     Name_occurrences.closure_vars_normal name_occurrences
   in
   let closure_ids_in_types =
@@ -121,19 +123,29 @@ let run ~symbol_for_global ~get_global_info ~round unit =
   let closure_vars_in_types =
     Name_occurrences.closure_vars_in_types name_occurrences
   in
-  let exported_offsets =
+  (* CR gbury/lthls: we should also add the free_names from the typing env
+     (after the preparation for cmx/removal of unused closure vars) to the
+     exported offsets. *)
+  let used_closure_vars, exported_offsets =
     match UA.closure_offsets uacc with
     | Unknown ->
       Misc.fatal_error "Closure offsets must be computed and cannot be unknown"
-    | Known closure_offsets ->
-      Closure_offsets.finalize_offsets closure_offsets
-        ~used_names:
-          (Known
-             { closure_vars_normal = used_closure_vars;
-               closure_ids_normal = used_closure_ids;
-               closure_vars_in_types;
-               closure_ids_in_types
-             })
+    | Known closure_offsets -> (
+      let used_names : Closure_offsets.used_names Or_unknown.t =
+        Known
+          { closure_vars_normal;
+            closure_ids_normal;
+            closure_vars_in_types;
+            closure_ids_in_types
+          }
+      in
+      match Closure_offsets.finalize_offsets closure_offsets ~used_names with
+      | Known used_closure_vars, offsets -> used_closure_vars, offsets
+      | Unknown, _ ->
+        (* could be an assert false *)
+        Misc.fatal_error
+          "Closure offsets should not have returned Unknown when given a known \
+           used_names.")
   in
   let cmx =
     Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol

--- a/middle_end/flambda2/simplify_shared/closure_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/closure_offsets.ml
@@ -34,6 +34,10 @@ let keep_closure_var ~used_closure_vars v =
   | Unknown -> true
   | Known used_closure_vars -> closure_var_is_used ~used_closure_vars v
 
+(* CR gbury: considering that the goal is to have `offsets` significantly
+   smaller than the `imported_offsets`, it might be better for performance to
+   check whether the closure_id/var is already in the offsets before looking it
+   up in the imported offsets ? *)
 let collect_used_closure_ids closure_id_set offsets =
   let imported_offsets = EO.imported_offsets () in
   Closure_id.Set.fold

--- a/middle_end/flambda2/simplify_shared/closure_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/closure_offsets.mli
@@ -51,7 +51,9 @@ val add_set_of_closures :
     compilation unit, taking into account the constraints introduced by the
     sharing of closure_id/env_var across multiple sets of closures. *)
 val finalize_offsets :
-  used_names:used_names Or_unknown.t -> t -> Exported_offsets.t
+  used_names:used_names Or_unknown.t ->
+  t ->
+  Var_within_closure.Set.t Or_unknown.t * Exported_offsets.t
 
 (** {2 Helper functions} *)
 

--- a/middle_end/flambda2/simplify_shared/closure_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/closure_offsets.mli
@@ -19,6 +19,20 @@
 (** The type of state used to accumulate constraints on offsets. *)
 type t
 
+(** The type of names that are used (and pertinent for offset computing) *)
+type used_names =
+  { closure_ids_normal : Closure_id.Set.t;
+        (** Closure ids that appear in projections with normal name mode *)
+    closure_ids_in_types : Closure_id.Set.t;
+        (** Closure ids that appear in types (and thus can be eventually used in
+            normal name mode later) *)
+    closure_vars_normal : Var_within_closure.Set.t;
+        (** Closure vars that appear in projections with normal name mode *)
+    closure_vars_in_types : Var_within_closure.Set.t
+        (** Closure vars that appear in types (and thus can be eventually used
+            in normal name mode later) *)
+  }
+
 (** Printing function. *)
 val print : Format.formatter -> t -> unit
 
@@ -37,10 +51,7 @@ val add_set_of_closures :
     compilation unit, taking into account the constraints introduced by the
     sharing of closure_id/env_var across multiple sets of closures. *)
 val finalize_offsets :
-  used_closure_vars:Var_within_closure.Set.t Or_unknown.t ->
-  used_closure_ids:Closure_id.Set.t Or_unknown.t ->
-  t ->
-  Exported_offsets.t
+  used_names:used_names Or_unknown.t -> t -> Exported_offsets.t
 
 (** {2 Helper functions} *)
 

--- a/middle_end/flambda2/simplify_shared/closure_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/closure_offsets.mli
@@ -63,15 +63,13 @@ val closure_name : Closure_id.t -> string
 (** Returns the address for a function code from the global name of a closure. *)
 val closure_code : string -> string
 
-(** Returns the assignments of closure variables to [Simple]s from the given set
-    of closures, but ignoring any closure variable that does not occur in
-    [used_closure_vars], so long as [used_closure_vars] is [Known]. If
-    [used_closure_vars] is [Unknown] then assignments for all closure variables
-    are returned. *)
-val filter_closure_vars :
-  Flambda.Set_of_closures.t ->
-  used_closure_vars:Var_within_closure.Set.t Or_unknown.t ->
-  Simple.t Var_within_closure.Map.t
+(** Add (if necessary) the offsets for the given set of closure ids. *)
+val collect_used_closure_ids :
+  Closure_id.Set.t -> Exported_offsets.t -> Exported_offsets.t
+
+(** Add (if necessary) the offsets for the given set of closure ids. *)
+val collect_used_closure_vars :
+  Var_within_closure.Set.t -> Exported_offsets.t -> Exported_offsets.t
 
 (** {2 Offsets & Layouts} *)
 
@@ -88,6 +86,7 @@ type layout_slot =
     increasing order). *)
 type layout =
   { startenv : int;
+    empty_env : bool;
     slots : (int * layout_slot) list
   }
 

--- a/middle_end/flambda2/simplify_shared/closure_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/closure_offsets.mli
@@ -63,12 +63,14 @@ val closure_name : Closure_id.t -> string
 (** Returns the address for a function code from the global name of a closure. *)
 val closure_code : string -> string
 
-(** Add (if necessary) the offsets for the given set of closure ids. *)
-val collect_used_closure_ids :
+(** Ensure the offsets for the given closure ids are in the given exported
+    offsets. *)
+val reexport_closure_ids :
   Closure_id.Set.t -> Exported_offsets.t -> Exported_offsets.t
 
-(** Add (if necessary) the offsets for the given set of closure ids. *)
-val collect_used_closure_vars :
+(** Ensure the offsets for the given closure ids are in the given exported
+    offsets. *)
+val reexport_closure_vars :
   Var_within_closure.Set.t -> Exported_offsets.t -> Exported_offsets.t
 
 (** {2 Offsets & Layouts} *)

--- a/middle_end/flambda2/simplify_shared/exported_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.ml
@@ -18,8 +18,8 @@
     They're computed for elements defined in the current compilation unit by
     [Closure_offsets], and read from cmx files for external symbols. Because an
     external cmx can reference elements from another cmx that the current
-    compilation cannot see, all offsets read from external cmx files must be
-    re-exported. *)
+    compilation cannot see, all offsets that occurs in the current compilation
+    unit should be re-exported. *)
 
 type closure_info =
   | Dead_id
@@ -62,10 +62,23 @@ let empty =
     env_var_offsets = Var_within_closure.Map.empty
   }
 
+let equal_closure_info (info1 : closure_info) (info2 : closure_info) =
+  match info1, info2 with
+  | Dead_id, Dead_id -> true
+  | Id_slot { offset = o1; size = s1 }, Id_slot { offset = o2; size = s2 } ->
+    o1 = o2 && s1 = s2
+  | Dead_id, Id_slot _ | Id_slot _, Dead_id -> false
+
+let equal_env_var_info (info1 : env_var_info) (info2 : env_var_info) =
+  match info1, info2 with
+  | Dead_var, Dead_var -> true
+  | Var_slot { offset = o1 }, Var_slot { offset = o2 } -> o1 = o2
+  | Dead_var, Var_slot _ | Var_slot _, Dead_var -> false
+
 let add_closure_offset env closure offset =
   match Closure_id.Map.find closure env.closure_offsets with
   | o ->
-    assert (o = offset);
+    assert (equal_closure_info o offset);
     env
   | exception Not_found ->
     let closure_offsets =
@@ -76,7 +89,7 @@ let add_closure_offset env closure offset =
 let add_env_var_offset env env_var offset =
   match Var_within_closure.Map.find env_var env.env_var_offsets with
   | o ->
-    assert (o = offset);
+    assert (equal_env_var_info o offset);
     env
   | exception Not_found ->
     let env_var_offsets =
@@ -104,19 +117,6 @@ let map_env_var_offsets env f =
   Var_within_closure.Map.mapi f env.env_var_offsets
 
 let current_offsets = ref empty
-
-let equal_closure_info (info1 : closure_info) (info2 : closure_info) =
-  match info1, info2 with
-  | Dead_id, Dead_id -> true
-  | Id_slot { offset = o1; size = s1 }, Id_slot { offset = o2; size = s2 } ->
-    o1 = o2 && s1 = s2
-  | Dead_id, Id_slot _ | Id_slot _, Dead_id -> false
-
-let equal_env_var_info (info1 : env_var_info) (info2 : env_var_info) =
-  match info1, info2 with
-  | Dead_var, Dead_var -> true
-  | Var_slot { offset = o1 }, Var_slot { offset = o2 } -> o1 = o2
-  | Dead_var, Var_slot _ | Var_slot _, Dead_var -> false
 
 let imported_offsets () = !current_offsets
 

--- a/middle_end/flambda2/simplify_shared/exported_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.ml
@@ -18,7 +18,7 @@
     They're computed for elements defined in the current compilation unit by
     [Closure_offsets], and read from cmx files for external symbols. Because an
     external cmx can reference elements from another cmx that the current
-    compilation cannot see, all offsets that occurs in the current compilation
+    compilation cannot see, all offsets that occur in the current compilation
     unit should be re-exported. *)
 
 type closure_info =

--- a/middle_end/flambda2/simplify_shared/exported_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.mli
@@ -25,7 +25,9 @@ type closure_info =
            3 fields (caml_curry + arity + code pointer) otherwise *)
   }
 
-type env_var_info = { offset : int }
+type env_var_info =
+  | Removed
+  | Alive of { offset : int }
 
 (** The empty environment *)
 val empty : t

--- a/middle_end/flambda2/simplify_shared/exported_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.mli
@@ -16,18 +16,20 @@
 type t
 
 type closure_info =
-  { offset : int;
-    size : int
-        (* Number of fields taken for the function:
+  | Dead_id
+  | Id_slot of
+      { offset : int;
+        size : int
+            (* Number of fields taken for the function:
 
-           2 fields (code pointer + arity) for function of arity one
+               2 fields (code pointer + arity) for function of arity one
 
-           3 fields (caml_curry + arity + code pointer) otherwise *)
-  }
+               3 fields (caml_curry + arity + code pointer) otherwise *)
+      }
 
 type env_var_info =
-  | Removed
-  | Alive of { offset : int }
+  | Dead_var
+  | Var_slot of { offset : int }
 
 (** The empty environment *)
 val empty : t

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -241,8 +241,9 @@ let free_names
         Name_mode.normal
   in
   Name_occurrences.union free_names
-    (Result_types.free_names result_types
-    |> Name_occurrences.without_closure_vars)
+    (Name_occurrences.downgrade_occurrences_at_strictly_greater_kind
+       (Result_types.free_names result_types)
+       Name_mode.in_types)
 
 let apply_renaming
     ({ code_id;

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -449,7 +449,14 @@ let unary_primitive env dbg f arg =
     | Some { offset = c1_offset; _ }, Some { offset = c2_offset; _ } ->
       let diff = c2_offset - c1_offset in
       None, C.infix_field_address ~dbg arg diff
-    | Some _, None | None, Some _ | None, None -> None, C.unreachable
+    (* missing offset: this is an error *)
+    | Some _, None ->
+      Misc.fatal_errorf "missing offset for closure %a" Closure_id.print c1
+    | None, Some _ ->
+      Misc.fatal_errorf "missing offset for closure %a" Closure_id.print c2
+    | None, None ->
+      Misc.fatal_errorf "missing offset for closures %a and %a" Closure_id.print
+        c1 Closure_id.print c2
   end
   | Project_var { project_from; var } -> (
     match Env.env_var_offset env var, Env.closure_offset env project_from with
@@ -464,7 +471,7 @@ let unary_primitive env dbg f arg =
       None, C.unreachable
     (* missing offset: this is an error *)
     | (Some _ | None), None ->
-      Misc.fatal_errorf "missing offset for closure" Closure_id.print
+      Misc.fatal_errorf "missing offset for closure %a" Closure_id.print
         project_from
     | None, Some _ ->
       Misc.fatal_errorf "missing offset for env_var %a" Var_within_closure.print

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -446,36 +446,46 @@ let unary_primitive env dbg f arg =
   | Box_number (kind, alloc_mode) -> None, C.box_number ~dbg kind alloc_mode arg
   | Select_closure { move_from = c1; move_to = c2 } -> begin
     match Env.closure_offset env c1, Env.closure_offset env c2 with
-    | Some { offset = c1_offset; _ }, Some { offset = c2_offset; _ } ->
+    | ( Some (Id_slot { offset = c1_offset; _ }),
+        Some (Id_slot { offset = c2_offset; _ }) ) ->
       let diff = c2_offset - c1_offset in
       None, C.infix_field_address ~dbg arg diff
+    (* one of the ids has been marked as dead, the code should be
+       unreachable. *)
+    | Some Dead_id, Some (Id_slot _)
+    | Some (Id_slot _), Some Dead_id
+    | Some Dead_id, Some Dead_id ->
+      None, C.unreachable
     (* missing offset: this is an error *)
     | Some _, None ->
       Misc.fatal_errorf "missing offset for closure %a" Closure_id.print c1
     | None, Some _ ->
       Misc.fatal_errorf "missing offset for closure %a" Closure_id.print c2
     | None, None ->
-      Misc.fatal_errorf "missing offset for closures %a and %a" Closure_id.print
-        c1 Closure_id.print c2
+      Misc.fatal_errorf "missing offsets for closures %a and %a"
+        Closure_id.print c1 Closure_id.print c2
   end
   | Project_var { project_from; var } -> (
     match Env.env_var_offset env var, Env.closure_offset env project_from with
     (* Normal case: we have offsets for everything *)
-    | Some (Alive { offset }), Some { offset = base; _ } ->
+    | Some (Var_slot { offset }), Some (Id_slot { offset = base; _ }) ->
       None, C.get_field_gen Asttypes.Immutable arg (offset - base) dbg
-    (* the closure var has been explicitly removed, the code is unreachable *)
-    | Some Removed, Some _ ->
-      (* Note that if a closure var is missing from a set of closures
-         environment, then [Env.closure_offset] might return [None], even though
-         the set of closures has been seen by [Closure_offsets]. *)
+    (* the closure var and/or id has been explicitly removed, the code is
+       unreachable *)
+    | Some Dead_var, Some (Id_slot _)
+    | Some (Var_slot _), Some Dead_id
+    | Some Dead_var, Some Dead_id ->
       None, C.unreachable
     (* missing offset: this is an error *)
-    | (Some _ | None), None ->
+    | Some _, None ->
       Misc.fatal_errorf "missing offset for closure %a" Closure_id.print
         project_from
     | None, Some _ ->
       Misc.fatal_errorf "missing offset for env_var %a" Var_within_closure.print
-        var)
+        var
+    | None, None ->
+      Misc.fatal_errorf "missing offsets for closure id %a and var %a"
+        Closure_id.print project_from Var_within_closure.print var)
   | Is_boxed_float ->
     (* As a note, this omits the [Is_in_value_area] check that exists in
        [caml_make_array], which is used by non-Flambda 2 compilers. This seems
@@ -1449,9 +1459,11 @@ and let_dynamic_set_of_closures env res body closure_vars s
   let env =
     List.fold_left2
       (fun acc cid v ->
-        let v = Bound_var.var v in
-        let e, effs = get_closure_by_offset env soc_cmm_var cid in
-        let_expr_bind acc v ~num_normal_occurrences_of_bound_vars e effs)
+        match get_closure_by_offset env soc_cmm_var cid with
+        | None -> acc
+        | Some (e, effs) ->
+          let v = Bound_var.var v in
+          let_expr_bind acc v ~num_normal_occurrences_of_bound_vars e effs)
       env
       (Closure_id.Lmap.keys decls)
       closure_vars
@@ -1462,8 +1474,9 @@ and let_dynamic_set_of_closures env res body closure_vars s
 
 and get_closure_by_offset env set_cmm cid =
   match Env.closure_offset env cid with
-  | Some { offset; _ } ->
-    C.infix_field_address ~dbg:Debuginfo.none set_cmm offset, Ece.pure
+  | Some (Id_slot { offset; _ }) ->
+    Some (C.infix_field_address ~dbg:Debuginfo.none set_cmm offset, Ece.pure)
+  | Some Dead_id -> None
   | None -> Misc.fatal_errorf "No closure offset for %a" Closure_id.print cid
 
 and fill_layout decls startenv elts env effs acc i = function

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -305,10 +305,18 @@ let get_exn_extra_args env k =
 (* Offsets *)
 
 let closure_offset env closure =
-  Exported_offsets.closure_offset env.offsets closure
+  match Exported_offsets.closure_offset env.offsets closure with
+  | Some res -> res
+  | None ->
+    Misc.fatal_errorf "Missing offset for closure id %a" Closure_id.print
+      closure
 
 let env_var_offset env env_var =
-  Exported_offsets.env_var_offset env.offsets env_var
+  match Exported_offsets.env_var_offset env.offsets env_var with
+  | Some res -> res
+  | None ->
+    Misc.fatal_errorf "Missing offset for closure var %a"
+      Var_within_closure.print env_var
 
 let layout env set_of_closures =
   let fun_decls = Set_of_closures.function_decls set_of_closures in

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -43,15 +43,14 @@ val classify : Effects_and_coeffects.t -> kind
 (** Environment for flambda to cmm translation *)
 type t
 
-(** [mk offsets k k_exn ~used_closure_vars] creates a local environment for
-    translating a flambda expression, with return continuation [k], exception
-    continuation [k_exn], and which uses the given closures variables. *)
+(** [mk offsets k k_exn] creates a local environment for translating a flambda
+    expression, with return continuation [k], exception continuation [k_exn],
+    and which uses the given closures variables. *)
 val mk :
   Exported_offsets.t ->
   Exported_code.t ->
   Continuation.t ->
   exn_continuation:Continuation.t ->
-  used_closure_vars:Var_within_closure.Set.t Or_unknown.t ->
   t
 
 (** [enter_function_def env k k_exn] creates a local environment for translating
@@ -202,11 +201,7 @@ val env_var_offset :
   t -> Var_within_closure.t -> Exported_offsets.env_var_info option
 
 (** Wrapper around {!Closure_offsets.layout}. *)
-val layout :
-  t -> Closure_id.t list -> Var_within_closure.t list -> Closure_offsets.layout
-
-(** All closure variables used in the whole program. *)
-val used_closure_vars : t -> Var_within_closure.Set.t Or_unknown.t
+val layout : t -> Set_of_closures.t -> Closure_offsets.layout
 
 (** Add the given names to the current scope *)
 val add_to_scope : t -> Code_id_or_symbol.Set.t -> t

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -194,11 +194,10 @@ val get_jump_id : t -> Continuation.t -> int
 (** {2 Sets of closures and offsets} *)
 
 (** Wrapper around {!Closure_offsets.closure_offset}. *)
-val closure_offset : t -> Closure_id.t -> Exported_offsets.closure_info option
+val closure_offset : t -> Closure_id.t -> Exported_offsets.closure_info
 
 (** Wrapper around {!Closure_offsets.env_var_offset}. *)
-val env_var_offset :
-  t -> Var_within_closure.t -> Exported_offsets.env_var_info option
+val env_var_offset : t -> Var_within_closure.t -> Exported_offsets.env_var_info
 
 (** Wrapper around {!Closure_offsets.layout}. *)
 val layout : t -> Set_of_closures.t -> Closure_offsets.layout

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -143,19 +143,12 @@ let get_whole_closure_symbol =
       r := Some s;
       s
 
-let rec static_set_of_closures env symbs set prev_update =
+let rec static_set_of_closures env symbs set (layout : Closure_offsets.layout)
+    prev_update =
   let clos_symb = ref None in
   let fun_decls = Set_of_closures.function_decls set in
   let decls = Function_declarations.funs fun_decls in
-  let elts =
-    Closure_offsets.filter_closure_vars set
-      ~used_closure_vars:(Env.used_closure_vars env)
-  in
-  let layout =
-    Env.layout env
-      (List.map fst (Closure_id.Map.bindings decls))
-      (List.map fst (Var_within_closure.Map.bindings elts))
-  in
+  let elts = Set_of_closures.closure_elements set in
   let env, l, updates, length =
     fill_static_layout clos_symb symbs decls layout.startenv elts env []
       prev_update 0 layout.slots
@@ -258,7 +251,8 @@ let preallocate_set_of_closures (r, updates, env) ~closure_symbols
     let closure_symbols =
       closure_symbols |> Closure_id.Lmap.bindings |> Closure_id.Map.of_list
     in
-    static_set_of_closures env closure_symbols set_of_closures updates
+    let layout = Env.layout env set_of_closures in
+    static_set_of_closures env closure_symbols set_of_closures layout updates
   in
   let r = R.set_data r data in
   r, updates, env

--- a/middle_end/flambda2/to_cmm/to_cmm_static.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.mli
@@ -22,6 +22,7 @@ val static_set_of_closures :
   To_cmm_env.t ->
   Symbol.t Closure_id.Map.t ->
   Set_of_closures.t ->
+  Closure_offsets.layout ->
   Cmm.expression option ->
   To_cmm_env.t * Cmm.data_item list * Cmm.expression option
 


### PR DESCRIPTION
It can happen that a closure_id/closure_var from another compilation unit only occur in types in the current compilation unit (mainly due to functions/functor's result types), and in that case, we need to export the offsets for these ids/vars, so that later units have access to these offsets without the original compilation unit's cmx.