### PR TITLE
Stop clobbering of autoconf-generated files for build_upstream

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -247,7 +247,9 @@ _build_upstream/config.status: ocaml/configure.ac
 
 .PHONY: build_upstream
 build_upstream: _build_upstream/config.status
-	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build_upstream
+	rsync -a \
+	  --filter=':- $$(pwd)/ocaml/.gitignore' \
+		$$(pwd)/ocaml/ $$(pwd)/_build_upstream
 	(cd _build_upstream && \
 	    $(MAKE) world.opt && \
 	    $(MAKE) ocamlnat)


### PR DESCRIPTION
The rule for `build_upstream` was clobbering files with versions from the `ocaml/` subdirectory which were configured for the stage 1 build dir, not the upstream build dir.  This meant that `install_upstream` was installing into the stage 1 install dir, then failing when it tried to copy the `VERSION` file into the correct install dir.

This applies only for m32 builds and I've just tested such, so will merge straight away.