### PR TITLE
Revert bswap PRs (480 and 482)

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -73,8 +73,6 @@ type prefetch_info = {
   addr: addressing_mode;
 }
 
-type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
-
 type rounding_mode = Half_to_even | Down | Up | Towards_zero | Current
 
 type specific_operation =
@@ -84,7 +82,7 @@ type specific_operation =
   | Ioffset_loc of int * addressing_mode (* Add a constant to a location *)
   | Ifloatarithmem of float_operation * addressing_mode
                                        (* Float arith operation with memory *)
-  | Ibswap of { bitwidth: bswap_bitwidth; } (* endianness conversion *)
+  | Ibswap of int                      (* endianness conversion *)
   | Isqrtf                             (* Float square root *)
   | Ifloatsqrtf of addressing_mode     (* Float square root from memory *)
   | Ifloat_iround                      (* Rounds a [float] to an [int64]
@@ -158,11 +156,6 @@ let string_of_rounding_mode = function
   | Towards_zero -> "truncate"
   | Current -> "current"
 
-let int_of_bswap_bitwidth = function
-  | Sixteen -> 16
-  | Thirtytwo -> 32
-  | Sixtyfour -> 64
-
 let print_addressing printreg addr ppf arg =
   match addr with
   | Ibased(s, 0) ->
@@ -211,8 +204,8 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "%a %s float64[%a]" printreg arg.(0) (op_name op)
                    (print_addressing printreg addr)
                    (Array.sub arg 1 (Array.length arg - 1))
-  | Ibswap { bitwidth } ->
-    fprintf ppf "bswap_%i %a" (int_of_bswap_bitwidth bitwidth) printreg arg.(0)
+  | Ibswap i ->
+      fprintf ppf "bswap_%i %a" i printreg arg.(0)
   | Isextend32 ->
       fprintf ppf "sextend32 %a" printreg arg.(0)
   | Izextend32 ->
@@ -303,8 +296,8 @@ let equal_specific_operation left right =
     Int.equal x y && equal_addressing_mode x' y'
   | Ifloatarithmem (x, x'), Ifloatarithmem (y, y') ->
     equal_float_operation x y && equal_addressing_mode x' y'
-  | Ibswap { bitwidth = left }, Ibswap { bitwidth = right } ->
-    Int.equal (int_of_bswap_bitwidth left) (int_of_bswap_bitwidth right)
+  | Ibswap left, Ibswap right ->
+    Int.equal left right
   | Isqrtf, Isqrtf ->
     true
   | Ifloatsqrtf left, Ifloatsqrtf right ->

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -891,6 +891,7 @@ let emit_instr fallthrough i =
       I.movzx (res16 i 0) (res i 0)
   | Lop(Ispecific(Ibswap 32)) ->
       I.bswap (res32 i 0);
+      I.movsxd (res32 i 0) (res i 0)
   | Lop(Ispecific(Ibswap 64)) ->
       I.bswap (res i 0)
   | Lop(Ispecific(Ibswap _)) ->

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -886,13 +886,15 @@ let emit_instr fallthrough i =
       I.add (int n) (addressing addr QWORD i 0)
   | Lop(Ispecific(Ifloatarithmem(op, addr))) ->
       instr_for_floatarithmem op (addressing addr REAL8 i 1) (res i 0)
-  | Lop(Ispecific(Ibswap { bitwidth = Sixteen })) ->
+  | Lop(Ispecific(Ibswap 16)) ->
       I.xchg ah al;
       I.movzx (res16 i 0) (res i 0)
-  | Lop(Ispecific(Ibswap { bitwidth = Thirtytwo })) ->
+  | Lop(Ispecific(Ibswap 32)) ->
       I.bswap (res32 i 0);
-  | Lop(Ispecific(Ibswap { bitwidth = Sixtyfour })) ->
+  | Lop(Ispecific(Ibswap 64)) ->
       I.bswap (res i 0)
+  | Lop(Ispecific(Ibswap _)) ->
+      assert false
   | Lop(Ispecific Isqrtf) ->
       if arg i 0 <> res i 0 then
         I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -458,7 +458,6 @@ let operation_supported = function
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
-  | Cbswap _
   | Cclz _ | Cctz _
   | Ccmpi _ | Caddv | Cadda | Ccmpa _
   | Cnegf | Cabsf | Caddf | Csubf | Cmulf | Cdivf

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -41,8 +41,6 @@ type addressing_mode =
 type cmm_label = int
   (* Do not introduce a dependency to Cmm *)
 
-type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
-
 type specific_operation =
   | Ifar_alloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo }
   | Ifar_intop_checkbound
@@ -58,7 +56,7 @@ type specific_operation =
   | Imulsubf      (* floating-point multiply and subtract *)
   | Inegmulsubf   (* floating-point negate, multiply and subtract *)
   | Isqrtf        (* floating-point square root *)
-  | Ibswap of { bitwidth: bswap_bitwidth; } (* endianness conversion *)
+  | Ibswap of int (* endianness conversion *)
   | Imove32       (* 32-bit integer move *)
 
 and arith_operation =
@@ -103,11 +101,6 @@ let print_addressing printreg addr ppf arg =
       fprintf ppf "\"%s\"" s
   | Ibased(s, n) ->
       fprintf ppf "\"%s\" + %i" s n
-
-let int_of_bswap_bitwidth = function
-  | Sixteen -> 16
-  | Thirtytwo -> 32
-  | Sixtyfour -> 64
 
 let print_specific_operation printreg op ppf arg =
   match op with
@@ -170,8 +163,7 @@ let print_specific_operation printreg op ppf arg =
   | Isqrtf ->
       fprintf ppf "sqrtf %a"
         printreg arg.(0)
-  | Ibswap { bitwidth } ->
-      let n = int_of_bswap_bitwidth bitwidth in
+  | Ibswap n ->
       fprintf ppf "bswap%i %a" n
         printreg arg.(0)
   | Imove32 ->
@@ -220,8 +212,7 @@ let equal_specific_operation left right =
   | Imulsubf, Imulsubf -> true
   | Inegmulsubf, Inegmulsubf -> true
   | Isqrtf, Isqrtf -> true
-  | Ibswap { bitwidth = left }, Ibswap { bitwidth = right } ->
-    Int.equal (int_of_bswap_bitwidth left) (int_of_bswap_bitwidth right)
+  | Ibswap left_int, Ibswap right_int -> Int.equal left_int right_int
   | Imove32, Imove32 -> true
   | (Ifar_alloc _  | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
     | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -532,8 +532,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Ispecific (Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf)) -> 1
     | Lop (Ispecific (Ishiftarith _)) -> 1
     | Lop (Ispecific (Imuladd | Imulsub)) -> 1
-    | Lop (Ispecific (Ibswap { bitwidth = Sixteen } )) -> 2
-    | Lop (Ispecific (Ibswap { bitwidth = (Thirtytwo | Sixtyfour) })) -> 1
+    | Lop (Ispecific (Ibswap 16)) -> 2
+    | Lop (Ispecific (Ibswap _)) -> 1
     | Lop (Ispecific Imove32) -> 1
     | Lop (Iname_for_debugger _) -> 0
     | Lop (Iprobe _ | Iprobe_is_enabled _) ->
@@ -898,15 +898,17 @@ let emit_instr i =
                      | Imulsub -> "msub"
                      | _ -> assert false) in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
-    | Lop(Ispecific(Ibswap { bitwidth })) ->
-        begin match bitwidth with
-        | Sixteen ->
+    | Lop(Ispecific(Ibswap size)) ->
+        begin match size with
+        | 16 ->
             `	rev16	{emit_wreg i.res.(0)}, {emit_wreg i.arg.(0)}\n`;
             `	ubfm	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, #0, #15\n`
-        | Thirtytwo ->
+        | 32 ->
             `	rev	{emit_wreg i.res.(0)}, {emit_wreg i.arg.(0)}\n`
-        | Sixtyfour ->
+        | 64 ->
             `	rev	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
+        | _ ->
+            assert false
         end
     | Lop (Iname_for_debugger _) -> ()
     | Lop (Iprobe _ | Iprobe_is_enabled _) ->

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -315,7 +315,6 @@ let operation_supported = function
   | Cclz _ | Cctz _ | Cpopcnt
   | Cprefetch _
     -> false   (* Not implemented *)
-  | Cbswap _
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -154,8 +154,6 @@ type trywith_kind =
   | Regular
   | Delayed of trywith_shared_label
 
-type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
-
 type memory_chunk =
     Byte_unsigned
   | Byte_signed
@@ -185,7 +183,6 @@ and operation =
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool } | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
-  | Cbswap of { bitwidth: bswap_bitwidth; }
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -152,8 +152,6 @@ type trywith_kind =
       This allows for sharing a single handler in several places, or having
       multiple entry and exit points to a single trywith block. *)
 
-type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
-
 type memory_chunk =
     Byte_unsigned
   | Byte_signed
@@ -166,6 +164,7 @@ type memory_chunk =
   | Single
   | Double                             (* word-aligned 64-bit float
                                           see PR#10433 *)
+
 and operation =
     Capply of machtype * Lambda.region_close
   | Cextcall of
@@ -186,7 +185,6 @@ and operation =
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool }  | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
-  | Cbswap of { bitwidth: bswap_bitwidth; }
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2392,37 +2392,22 @@ let arraylength kind arg dbg =
    Check if this can be improved (e.g., bswap). *)
 
 let bbswap bi arg dbg =
-  let bitwidth : Cmm.bswap_bitwidth =
-    match (bi : Primitive.boxed_integer) with
-    | Pnativeint -> if size_int = 4 then Thirtytwo else Sixtyfour
-    | Pint32 -> Thirtytwo
-    | Pint64 -> Sixtyfour
+  let prim, tyarg = match (bi : Primitive.boxed_integer) with
+    | Pnativeint -> "nativeint", XInt
+    | Pint32 -> "int32", XInt32
+    | Pint64 -> "int64", XInt64
   in
-  let op = Cbswap { bitwidth } in
-  if (bi = Primitive.Pint64 && size_int = 4) ||
-     not (Proc.operation_supported op) then
-    let prim, tyarg = match (bi : Primitive.boxed_integer) with
-      | Pnativeint -> "nativeint", XInt
-      | Pint32 -> "int32", XInt32
-      | Pint64 -> "int64", XInt64
-    in
-    Cop(Cextcall { func = Printf.sprintf "caml_%s_direct_bswap" prim;
-                   builtin = false;
-                   returns = true;
-                   effects = Arbitrary_effects;
-                   coeffects = Has_coeffects;
-                   ty = typ_int; alloc = false; ty_args = [tyarg]; },
-        [arg],
-        dbg)
-  else
-    Cop (op,[arg],dbg)
+  Cop(Cextcall { func = Printf.sprintf "caml_%s_direct_bswap" prim;
+                 builtin = false;
+                 returns = true;
+                 effects = Arbitrary_effects;
+                 coeffects = Has_coeffects;
+                 ty = typ_int; alloc = false; ty_args = [tyarg]; },
+      [arg],
+      dbg)
 
 let bswap16 arg dbg =
-  let op = Cbswap { bitwidth = Cmm.Sixteen } in
-  if Proc.operation_supported op then
-    Cop (op,[arg],dbg)
-  else
-    (Cop(Cextcall { func = "caml_bswap16_direct";
+  (Cop(Cextcall { func = "caml_bswap16_direct";
                   builtin = false;
                   returns = true;
                   effects = Arbitrary_effects;

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1181,7 +1181,7 @@ and transl_unbox_int_low dbg env bi e =
   if bi = Pint32 then low_32 dbg e else e
 
 and transl_unbox_sized size dbg env exp =
-  match (size : Clambda_primitives.memory_access_size) with
+  match size with
   | Sixteen ->
      ignore_high_bit_int (untag_int (transl env exp) dbg)
   | Thirty_two -> transl_unbox_int dbg env Pint32 exp

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -179,9 +179,6 @@ let operation d = function
   | Clsl -> "<<"
   | Clsr -> ">>u"
   | Casr -> ">>s"
-  | Cbswap { bitwidth = Sixteen } -> "bswap_16"
-  | Cbswap { bitwidth = Thirtytwo } -> "bswap_32"
-  | Cbswap { bitwidth = Sixtyfour } -> "bswap_64"
   | Cclz { arg_is_non_zero; } -> Printf.sprintf "clz %B" arg_is_non_zero
   | Cctz { arg_is_non_zero; } -> Printf.sprintf "ctz %B" arg_is_non_zero
   | Cpopcnt -> "popcnt"

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -173,7 +173,6 @@ let oper_result_type = function
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi |
     Cand | Cor | Cxor | Clsl | Clsr | Casr |
     Cclz _ | Cctz _ | Cpopcnt |
-    Cbswap _ |
     Ccmpi _ | Ccmpa _ | Ccmpf _ -> typ_int
   | Caddv -> typ_val
   | Cadda -> typ_addr
@@ -451,7 +450,6 @@ method is_simple_expr = function
       | Cload _ | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor
       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf
       | Cclz _ | Cctz _ | Cpopcnt
-      | Cbswap _
       | Cabsf | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
       | Ccmpf _ -> List.for_all self#is_simple_expr args
       end
@@ -500,7 +498,6 @@ method effects_of exp =
       | Cload (_, Asttypes.Mutable) -> EC.coeffect_only Coeffect.Read_mutable
       | Cprobe_is_enabled _ -> EC.coeffect_only Coeffect.Arbitrary
       | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor
-      | Cbswap _
       | Cclz _ | Cctz _ | Cpopcnt
       | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf | Cabsf
       | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat | Ccmpf _ ->


### PR DESCRIPTION
These are producing the wrong answer (testcase to be provided shortly), possibly only with Flambda 2 -- being looked into now.  There must be some disagreement about the semantics of these, so let's revert for the moment.