### PR TITLE
Sign extend the result of bswap32 in cmm

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -142,6 +142,9 @@ let unary_int_arith_primitive _env dbg kind op arg =
   | Naked_immediate, Swap_byte_endianness -> C.bswap16 arg dbg
   (* Special case for manipulating int64 on 32-bit hosts *)
   | Naked_int64, Neg when C.arch32 -> C.unsupported_32_bits ()
+  | Naked_int32, Swap_byte_endianness when C.arch64 ->
+    let primitive_kind = primitive_boxed_int_of_standard_int kind in
+    C.sign_extend_32 dbg (C.bbswap primitive_kind arg dbg)
   (* General case (including byte swap for 64-bit on 32-bit archi) *)
   | _, Neg -> C.sub_int (C.int 0) arg dbg
   | _, Swap_byte_endianness ->


### PR DESCRIPTION
Address the problem reveal by the test case in https://github.com/ocaml-flambda/flambda-backend/pull/501

`cmmgen.ml`  sign extends the result of `Cmm_helpers.bbswap` for 32-bit on 64-bit target, so `to_cmm.ml` should do the same. 
It was working fine because `Ibswap 32` sign-extended the result of `bswap` instruction in `Emit.mlp` (amd64) prior to https://github.com/ocaml-flambda/flambda-backend/pull/482.  

