### PR TITLE
Disable bytecode compilers in ocamltest

### DIFF
--- a/ocaml/ocamltest/ocaml_compilers.ml
+++ b/ocaml/ocamltest/ocaml_compilers.ml
@@ -40,14 +40,10 @@ class compiler
   method target = target
 
   method program_variable =
-    if Ocaml_backends.is_native host
-    then Builtin_variables.program2
-    else Builtin_variables.program
+    Builtin_variables.program
 
   method program_output_variable =
-    if Ocaml_backends.is_native host
-    then None
-    else Some Builtin_variables.output
+    Some Builtin_variables.output
 
   method ! reference_file env prefix =
     let default = tool#reference_file env prefix in

--- a/ocaml/ocamltest/ocaml_tests.ml
+++ b/ocaml/ocamltest/ocaml_tests.ml
@@ -20,43 +20,46 @@ open Builtin_actions
 open Ocaml_actions
 
 let bytecode =
-  let opt_actions =
-  [
-    setup_ocamlc_opt_build_env;
-    ocamlc_opt;
-    check_ocamlc_opt_output;
-    compare_bytecode_programs
-  ] in
-{
-  test_name = "bytecode";
-  test_run_by_default = true;
-  test_actions =
-  [
-    setup_ocamlc_byte_build_env;
-    ocamlc_byte;
-    check_ocamlc_byte_output;
-    run;
-    check_program_output;
-  ] @ (if Ocamltest_config.arch<>"none" then opt_actions else [])
-}
+  let test_actions =
+    if Ocamltest_config.arch="none" then
+      [
+        setup_ocamlc_byte_build_env;
+        ocamlc_byte;
+        check_ocamlc_byte_output;
+        run;
+        check_program_output;
+      ]
+    else
+      [
+        setup_ocamlc_opt_build_env;
+        ocamlc_opt;
+        check_ocamlc_opt_output;
+        run;
+        check_program_output
+      ]
+  in
+  {
+    test_name = "bytecode";
+    test_run_by_default = true;
+    test_actions;
+  }
 
 let native =
-  let opt_actions =
-  [
-    setup_ocamlopt_byte_build_env;
-    ocamlopt_byte;
-    check_ocamlopt_byte_output;
-    run;
-    check_program_output;
-    setup_ocamlopt_opt_build_env;
-    ocamlopt_opt;
-    check_ocamlopt_opt_output;
-  ] in
+  let test_actions =
+    if not Ocamltest_config.native_compiler then [skip]
+    else
+      [
+        setup_ocamlopt_opt_build_env;
+        ocamlopt_opt;
+        check_ocamlopt_opt_output;
+        run;
+        check_program_output
+      ]
+  in
   {
     test_name = "native";
     test_run_by_default = true;
-    test_actions =
-      (if Ocamltest_config.native_compiler then opt_actions else [skip])
+    test_actions;
   }
 
 let toplevel = {


### PR DESCRIPTION
Current, `ocamltest` compiles every test case four times, using all of `ocamlc`, `ocamlc.opt`, `ocamlopt` and `ocamlopt.opt`. The only reason to compile with both `ocamlc` and `ocamlc.opt` is to compare their output, and likewise for ocamlopt.

However, since #128 , we don't actually compare the output of `ocamlc` and `ocamlc.opt`, and I'm not sure there much need to compare `ocamlopt` and `ocamlopt.opt` either. So, this PR stops `ocamltest` from using `ocamlc` and `ocamlopt` at all, greatly speeding the upstream testsuite. We still compile every case in bytecode and native modes, but only once.