### PR TITLE
Fix an assertion in Closure that breaks probes

### DIFF
--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -992,7 +992,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
            ap_probe = probe; ap_loc = loc;
            ap_inlined = attribute} ->
       let nargs = List.length args in
-      if nargs = 0 then
+      if nargs = 0 && probe = None then
         Misc.fatal_errorf "Closure: 0-ary application at %a"
           Location.print_loc (Debuginfo.Scoped_location.to_location loc);
       assert (nargs > 0);

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -993,7 +993,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
            ap_probe = probe; ap_loc = loc;
            ap_inlined = attribute} ->
       let nargs = List.length args in
-      if nargs = 0 then
+      if nargs = 0 && probe = None then
         Misc.fatal_errorf "Closure: 0-ary application at %a"
           Location.print_loc (Debuginfo.Scoped_location.to_location loc);
       assert (nargs > 0);


### PR DESCRIPTION
`[%probe ...]` is broken since #491, due to an overzealous assertion.