### PR TITLE
Minor CI speedup

### DIFF
--- a/.github/workflows/check_all_arches.yml
+++ b/.github/workflows/check_all_arches.yml
@@ -38,7 +38,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: dune_build_compiler
       run: |
-        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install --disable-debug-runtime --disable-debugger --disable-ocamldoc --disable-ocamltest --disable-installing-source-artifacts --disable-stdlib-manpages
         make -j $J world.opt
         make install
 

--- a/.github/workflows/closure.yml
+++ b/.github/workflows/closure.yml
@@ -38,7 +38,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: dune_build_compiler
       run: |
-        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install --disable-debug-runtime --disable-debugger --disable-ocamldoc --disable-ocamltest --disable-installing-source-artifacts --disable-stdlib-manpages
         make -j $J world.opt
         make install
 

--- a/.github/workflows/closure_cfg_local.yml
+++ b/.github/workflows/closure_cfg_local.yml
@@ -38,7 +38,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: dune_build_compiler
       run: |
-        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install --disable-debug-runtime --disable-debugger --disable-ocamldoc --disable-ocamltest --disable-installing-source-artifacts --disable-stdlib-manpages
         make -j $J world.opt
         make install
 

--- a/.github/workflows/flambda1.yml
+++ b/.github/workflows/flambda1.yml
@@ -38,7 +38,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: dune_build_compiler
       run: |
-        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install --disable-debug-runtime --disable-debugger --disable-ocamldoc --disable-ocamltest --disable-installing-source-artifacts --disable-stdlib-manpages
         make -j $J world.opt
         make install
 

--- a/.github/workflows/flambda1_cfg_local.yml
+++ b/.github/workflows/flambda1_cfg_local.yml
@@ -38,7 +38,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: dune_build_compiler
       run: |
-        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install --disable-debug-runtime --disable-debugger --disable-ocamldoc --disable-ocamltest --disable-installing-source-artifacts --disable-stdlib-manpages
         make -j $J world.opt
         make install
 

--- a/.github/workflows/flambda2.yml
+++ b/.github/workflows/flambda2.yml
@@ -38,7 +38,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: dune_build_compiler
       run: |
-        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install --disable-debug-runtime --disable-debugger --disable-ocamldoc --disable-ocamltest --disable-installing-source-artifacts --disable-stdlib-manpages
         make -j $J world.opt
         make install
 

--- a/.github/workflows/flambda2_cfg.yml
+++ b/.github/workflows/flambda2_cfg.yml
@@ -38,7 +38,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: dune_build_compiler
       run: |
-        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install --disable-debug-runtime --disable-debugger --disable-ocamldoc --disable-ocamltest --disable-installing-source-artifacts --disable-stdlib-manpages
         make -j $J world.opt
         make install
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,7 +44,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: dune_build_compiler
       run: |
-        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install --disable-debug-runtime --disable-debugger --disable-ocamldoc --disable-ocamltest --disable-installing-source-artifacts --disable-stdlib-manpages
         make -j $J world.opt
         make install
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -48,7 +48,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: dune_build_compiler
       run: |
-        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install
+        ./configure --prefix=$GITHUB_WORKSPACE/dune_build_compiler/_install --disable-debug-runtime --disable-debugger --disable-ocamldoc --disable-ocamltest --disable-installing-source-artifacts --disable-stdlib-manpages
         make -j $J world.opt
         make install
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,9 +1,13 @@
-name: macos
+name: merge
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [closed]
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
+
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -72,6 +76,6 @@ jobs:
           --enable-middle-end=flambda2 \
           --with-dune=$GITHUB_WORKSPACE/dune/dune.exe
 
-    - name: Build (Flambda 2 mode)
+    - name: Build, install and test Flambda backend (Flambda 2 mode)
       working-directory: flambda_backend
-      run: make -j $J stage2
+      run: make -j $J ci


### PR DESCRIPTION
This pull request (hopefully) speeds up most existing CI
jobs by tweaking the the build of the upstream compiler
used to build dune in order to avoid building things that
will not be used afterwards.

(Includes https://github.com/ocaml-flambda/flambda-backend/pull/507, which is orthogonal.)