### PR TITLE
Compute free closure ids and closure vars of serialized environments

### DIFF
--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -1263,3 +1263,15 @@ let restrict_to_closure_vars
       newer_version_of_code_ids = _
     } =
   { empty with closure_vars }
+
+let restrict_to_closure_vars_and_closure_ids
+    { names = _;
+      continuations = _;
+      continuations_with_traps = _;
+      continuations_in_trap_actions = _;
+      closure_ids;
+      closure_vars;
+      code_ids = _;
+      newer_version_of_code_ids = _
+    } =
+  { empty with closure_ids; closure_vars }

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -138,6 +138,8 @@ val only_newer_version_of_code_ids : t -> Code_id.Set.t
 
 val restrict_to_closure_vars : t -> t
 
+val restrict_to_closure_vars_and_closure_ids : t -> t
+
 val code_ids_and_newer_version_of_code_ids : t -> Code_id.Set.t
 
 val without_code_ids : t -> t

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -169,3 +169,21 @@ let remove_unused_closure_vars_and_shortcut_aliases
       names_to_types
   in
   { names_to_types; aliases; symbol_projections }
+
+let free_closure_ids_and_closure_vars
+    { names_to_types; aliases = _; symbol_projections } =
+  let from_projections =
+    Variable.Map.fold
+      (fun _var proj free_names ->
+        Name_occurrences.union free_names
+          (Name_occurrences.restrict_to_closure_vars_and_closure_ids
+             (Symbol_projection.free_names proj)))
+      symbol_projections Name_occurrences.empty
+  in
+  Name.Map.fold
+    (fun _name (ty, _binding_time) free_names ->
+      let free_names_of_ty = Type_grammar.free_names ty in
+      Name_occurrences.union free_names
+        (Name_occurrences.restrict_to_closure_vars_and_closure_ids
+           free_names_of_ty))
+    names_to_types from_projections

--- a/middle_end/flambda2/types/env/cached_level.mli
+++ b/middle_end/flambda2/types/env/cached_level.mli
@@ -55,3 +55,5 @@ val remove_unused_closure_vars_and_shortcut_aliases :
   t -> used_closure_vars:Var_within_closure.Set.t -> t
 
 val canonicalise : t -> Simple.t -> Simple.t
+
+val free_closure_ids_and_closure_vars : t -> Name_occurrences.t

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1202,6 +1202,8 @@ module Serializable : sig
 
   val create : Pre_serializable.t -> reachable_names:Name_occurrences.t -> t
 
+  val free_closure_ids_and_closure_vars : t -> Name_occurrences.t
+
   val print : Format.formatter -> t -> unit
 
   val all_ids_for_export : t -> Ids_for_export.t
@@ -1254,6 +1256,9 @@ end = struct
       just_after_level;
       next_binding_time = env.next_binding_time
     }
+
+  let free_closure_ids_and_closure_vars t =
+    Cached_level.free_closure_ids_and_closure_vars t.just_after_level
 
   let [@ocamlformat "disable"] print ppf
       { defined_symbols_without_equations; code_age_relation; just_after_level;

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -190,6 +190,8 @@ module Serializable : sig
 
   val create : Pre_serializable.t -> reachable_names:Name_occurrences.t -> t
 
+  val free_closure_ids_and_closure_vars : t -> Name_occurrences.t
+
   val print : Format.formatter -> t -> unit
 
   val to_typing_env :

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -221,6 +221,8 @@ module Typing_env : sig
 
     val create : Pre_serializable.t -> reachable_names:Name_occurrences.t -> t
 
+    val free_closure_ids_and_closure_vars : t -> Name_occurrences.t
+
     val print : Format.formatter -> t -> unit
 
     val to_typing_env :


### PR DESCRIPTION
This should allow for correctly re-exporting all closure offsets appearing in types.