### PR TITLE
Ensure sound closure of local alloc regions in Lambda_to_flambda

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -927,6 +927,7 @@ let close_apply acc env
        exn_continuation;
        loc;
        tailcall = _;
+       region_close = _;
        inlined;
        specialised = _;
        probe;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -61,6 +61,7 @@ module IR = struct
       exn_continuation : exn_continuation;
       loc : Lambda.scoped_location;
       tailcall : Lambda.tailcall_attribute;
+      region_close : Lambda.region_close;
       inlined : Lambda.inlined_attribute;
       specialised : Lambda.specialise_attribute;
       probe : Lambda.probe;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -65,6 +65,7 @@ module IR : sig
       exn_continuation : exn_continuation;
       loc : Lambda.scoped_location;
       tailcall : Lambda.tailcall_attribute;
+      region_close : Lambda.region_close;
       inlined : Lambda.inlined_attribute;
       specialised : Lambda.specialise_attribute;
       probe : Lambda.probe;


### PR DESCRIPTION
This uses continuations created through `Lambda_to_flambda` to track the expected state of local stack and close regions only when it's necessary, i.e. when jumping a continuation (through a function or not) outside the scope of relevant regions.

Wrapper continuations are used to avoid the duplications of `End_region`, which produces noisy additional `Let_cont`s at some places that could be flatten out, but unused wrappers are cleared out by `Closure_conversion` so I don't expect a lot more code to be generated. 