### PR TITLE
Avoid clearing caches in native toplevel

### DIFF
--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -78,5 +78,6 @@ val compile_unit
    -> asm_filename:string
    -> keep_asm:bool
    -> obj_filename:string
+   -> may_reduce_heap:bool
    -> (unit -> unit)
    -> unit

--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -322,6 +322,7 @@ let link_shared ~ppf_dump objfiles output_name =
     Asmgen.compile_unit ~output_prefix:output_name
       ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
       ~obj_filename:startup_obj
+      ~may_reduce_heap:true
       (fun () ->
          make_shared_startup_file ~ppf_dump
            (List.map (fun (ui,_,crc) -> (ui,crc)) units_tolink)
@@ -395,6 +396,7 @@ let link ~ppf_dump objfiles output_name =
     Asmgen.compile_unit ~output_prefix:output_name
       ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
       ~obj_filename:startup_obj
+      ~may_reduce_heap:true
       (fun () -> make_startup_file ~ppf_dump units_tolink);
     Emitaux.reduce_heap_size ~reset:(fun () -> reset ());
     Misc.try_finally


### PR DESCRIPTION
Since #429, `Emitaux` clears various caches before calling the assembler, including the typechecker's cache of loaded `cmi` files.

When using `ocamlopt` to compile a single file, this saves memory. However, when using the native toplevel, this breaks short-paths (which relies on the cmi cache), and probably slows things down (because there are usually multiple phrases and the cache is useful). So, this patch turns off this mechanism when run from the toplevel.

(Future work: it may also be worth disabling this mechanism when `ocamlopt` is being used to compile multiple files)