### PR TITLE
Simplify code stubs at definition and do not specialise them

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -431,7 +431,7 @@ module Acc = struct
     | Known closure_offsets ->
       let closure_offsets =
         Closure_offsets.add_set_of_closures closure_offsets ~is_phantom
-          ~all_code:t.code set_of_closures
+          set_of_closures
       in
       { t with closure_offsets = Known closure_offsets }
 

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -459,6 +459,8 @@ let with_cse t cse = { t with cse }
 let set_do_not_rebuild_terms_and_disable_inlining t =
   { t with do_not_rebuild_terms = true; can_inline = false }
 
+let disable_inlining t = { t with can_inline = false }
+
 let set_rebuild_terms t = { t with do_not_rebuild_terms = false }
 
 let are_rebuilding_terms t =

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -183,6 +183,8 @@ val with_cse : t -> Common_subexpression_elimination.t -> t
 
 val set_do_not_rebuild_terms_and_disable_inlining : t -> t
 
+val disable_inlining : t -> t
+
 val set_rebuild_terms : t -> t
 
 val are_rebuilding_terms : t -> Are_rebuilding_terms.t

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -26,7 +26,6 @@ module RE = Rebuilt_expr
 module UA = Upwards_acc
 module UE = Upwards_env
 module DA = Downwards_acc
-module DE = Downwards_env
 module VB = Bound_var
 
 type let_creation_result =
@@ -50,11 +49,9 @@ let add_set_of_closures_offsets ~is_phantom named uacc =
     match UA.closure_offsets uacc with
     | Unknown -> uacc
     | Known closure_offsets ->
-      let dacc = UA.creation_dacc uacc in
-      let all_code = DE.all_code (DA.denv dacc) in
       let closure_offsets =
         Closure_offsets.add_set_of_closures closure_offsets ~is_phantom
-          ~all_code set_of_closures
+          set_of_closures
       in
       UA.with_closure_offsets uacc (Known closure_offsets)
   in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.mli
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.mli
@@ -38,3 +38,10 @@ val simplify_lifted_sets_of_closures :
   closure_bound_names_all_sets:Bound_name.t Closure_id.Map.t list ->
   simplify_toplevel:Simplify_common.simplify_toplevel ->
   Bound_symbols.t * Rebuilt_static_const.Group.t * Downwards_acc.t
+
+val simplify_stub_function :
+  Downwards_acc.t ->
+  Code.t ->
+  all_code:Code.t Code_id.Map.t ->
+  simplify_toplevel:Simplify_common.simplify_toplevel ->
+  Rebuilt_static_const.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify_shared/closure_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/closure_offsets.ml
@@ -819,7 +819,7 @@ let print fmt l =
 
 let create () = []
 
-let add_set_of_closures l ~is_phantom ~all_code:_ set_of_closures =
+let add_set_of_closures l ~is_phantom set_of_closures =
   if is_phantom then l else set_of_closures :: l
 
 let add_offsets_from_function l1 ~from_function:l2 =

--- a/middle_end/flambda2/simplify_shared/closure_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/closure_offsets.mli
@@ -40,12 +40,10 @@ val print : Format.formatter -> t -> unit
 val create : unit -> t
 
 (** Add a set of closure to the set of constraints. *)
-val add_set_of_closures :
-  t ->
-  is_phantom:bool ->
-  all_code:Code.t Code_id.Map.t ->
-  Set_of_closures.t ->
-  t
+val add_set_of_closures : t -> is_phantom:bool -> Set_of_closures.t -> t
+
+(** Aggregate sets of closures from two contexts *)
+val add_offsets_from_function : t -> from_function:t -> t
 
 (** Aggregate sets of closures from two contexts *)
 val add_offsets_from_function : t -> from_function:t -> t


### PR DESCRIPTION
The main change is only one commit ([Simplify code stubs at definition only](https://github.com/ocaml-flambda/flambda-backend/commit/11ce8846e04f87b5bdd835feae4ad721ab3aaee8)), but there are a number of other commits that fix various bugs that would trigger otherwise, and one commit ([Allow metadata-only code in environments](https://github.com/ocaml-flambda/flambda-backend/commit/ed18bcace5a10d37e949ced5630990a29e3c3a6e)) that does not fix a bug but could be cleanly split from the main commit and should be mostly a no-op, making it easier to review independently.