### PR TITLE
Compiler error when -disable-all-extensions and -extension are used

### DIFF
--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -399,16 +399,16 @@ module Extension = struct
     match !extensions with
     | [] -> ()
     | ls ->
-      Misc.fatal_errorf
+      raise (Arg.Bad(Printf.sprintf
         "Extensions %s are incompatible with compiler flag -disable-all-extensions"
-        (String.concat "," (List.map to_string ls))
+        (String.concat "," (List.map to_string ls))))
 
   let enable extn =
     if !disable_all_extensions then
-      Misc.fatal_errorf
+      raise (Arg.Bad(Printf.sprintf
         "Cannot enable extension %s: \
          incompatible with compiler flag -disable-all-extensions"
-        extn;
+        extn));
     let t = of_string (String.lowercase_ascii extn) in
     if not (List.exists (equal t) !extensions) then
       extensions := t :: !extensions

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -400,7 +400,8 @@ module Extension = struct
     | [] -> ()
     | ls ->
       raise (Arg.Bad(Printf.sprintf
-        "Extensions %s are incompatible with compiler flag -disable-all-extensions"
+        "Compiler flag -disable-all-extensions is incompatible with \
+         the enabled extensions: %s"
         (String.concat "," (List.map to_string ls))))
 
   let enable extn =


### PR DESCRIPTION
Compiler flags `-extension <ext>`  and `-disable-all-extensions` should be compilation error, not just silently disabling the extensions.

It was an error when tested with `-extension comprehensions` but with `-extension local`, any use of keyword `local_` is then treated as an identifier (possibly leading to miscompilation) when then extension is disabled. 

~~This is a draft, a proper fix will have user error instead of fatal_error.~~

