### PR TITLE
Do not hardcode the threshold for heap reduction

### DIFF
--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -380,7 +380,7 @@ let reduce_heap_size ~reset =
   let _minor, _promoted, major_words = Gc.counters () in
   (* Uses [major_words] because it doesn't require a heap traversal to compute and 
      for this workload a majority of major words are live at this point. *)
-  if major_words > 500_000_000.0 /. 8.0 then begin
+  if major_words > float !Flambda_backend_flags.heap_reduction_threshold then begin
     Profile.record_call "compact" (fun () ->
       reset ();
       Gc.compact ())

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -380,7 +380,13 @@ let reduce_heap_size ~reset =
   let _minor, _promoted, major_words = Gc.counters () in
   (* Uses [major_words] because it doesn't require a heap traversal to compute and 
      for this workload a majority of major words are live at this point. *)
-  if major_words > float !Flambda_backend_flags.heap_reduction_threshold then begin
+  let heap_reduction_threshold =
+    if !Flambda_backend_flags.heap_reduction_threshold >= 0 then
+      float !Flambda_backend_flags.heap_reduction_threshold
+    else
+      Float.infinity
+  in
+  if major_words > heap_reduction_threshold then begin
     Profile.record_call "compact" (fun () ->
       reset ();
       Gc.compact ())

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -30,6 +30,10 @@ let mk_dcfg f =
 let mk_use_cpp_mangling f =
   "-gcpp-mangling", Arg.Unit f, " Use C++ mangling for function symbols"
 
+let mk_heap_reduction_threshold f =
+  "-heap-reduction-threshold", Arg.Int f, " Threshold (in major words) to trigger a heap reduction before code emission"
+;;
+
 module Flambda2 = Flambda_backend_flags.Flambda2
 
 let mk_flambda2_result_types_functors_only f =
@@ -379,6 +383,8 @@ module type Flambda_backend_options = sig
 
   val use_cpp_mangling : unit -> unit
 
+  val heap_reduction_threshold : int -> unit
+
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
   val flambda2_result_types_functors_only : unit -> unit
@@ -440,6 +446,8 @@ struct
     mk_dcfg F.dcfg;
 
     mk_use_cpp_mangling F.use_cpp_mangling;
+
+    mk_heap_reduction_threshold F.heap_reduction_threshold;
 
     mk_flambda2_join_points F.flambda2_join_points;
     mk_no_flambda2_join_points F.no_flambda2_join_points;
@@ -530,6 +538,9 @@ module Flambda_backend_options_impl = struct
   let dcfg = set Flambda_backend_flags.dump_cfg
 
   let use_cpp_mangling = set Flambda_backend_flags.use_cpp_mangling
+
+  let heap_reduction_threshold x =
+    Flambda_backend_flags.heap_reduction_threshold := x
 
   let flambda2_join_points = set Flambda2.join_points
   let no_flambda2_join_points = clear Flambda2.join_points
@@ -682,6 +693,7 @@ module Extra_params = struct
     (* define new params *)
     | "ocamlcfg" -> set Flambda_backend_flags.use_ocamlcfg
     | "use-cpp-mangling" -> set Flambda_backend_flags.use_cpp_mangling
+    | "heap-reduction-threshold" -> set_int Flambda_backend_flags.heap_reduction_threshold
     | "flambda2-join-points" -> set Flambda2.join_points
     | "flambda2-result-types" ->
       (match String.lowercase_ascii v with

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -31,7 +31,10 @@ let mk_use_cpp_mangling f =
   "-gcpp-mangling", Arg.Unit f, " Use C++ mangling for function symbols"
 
 let mk_heap_reduction_threshold f =
-  "-heap-reduction-threshold", Arg.Int f, " Threshold (in major words) to trigger a heap reduction before code emission"
+  "-heap-reduction-threshold",
+  Arg.Int f,
+  Printf.sprintf " Threshold (in major words, defaulting to %d) to trigger a heap reduction before code emission"
+    Flambda_backend_flags.default_heap_reduction_threshold
 ;;
 
 module Flambda2 = Flambda_backend_flags.Flambda2

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -26,6 +26,8 @@ module type Flambda_backend_options = sig
 
   val use_cpp_mangling : unit -> unit
 
+  val heap_reduction_threshold : int -> unit
+
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
   val flambda2_result_types_functors_only : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -18,7 +18,8 @@ let dump_cfg = ref false                (* -dcfg *)
 
 let use_cpp_mangling = ref false        (* -use-cpp-mangling *)
 
-let heap_reduction_threshold = ref (500_000_000 / 8) (* -heap-reduction-threshold *)
+let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
+let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)
 
 type function_result_types = Never | Functors_only | All_functions
 

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -18,6 +18,8 @@ let dump_cfg = ref false                (* -dcfg *)
 
 let use_cpp_mangling = ref false        (* -use-cpp-mangling *)
 
+let heap_reduction_threshold = ref (500_000_000 / 8) (* -heap-reduction-threshold *)
+
 type function_result_types = Never | Functors_only | All_functions
 
 module Flambda2 = struct

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -19,6 +19,8 @@ val dump_cfg : bool ref
 
 val use_cpp_mangling : bool ref
 
+val heap_reduction_threshold : int ref
+
 type function_result_types = Never | Functors_only | All_functions
 
 module Flambda2 : sig

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -19,6 +19,7 @@ val dump_cfg : bool ref
 
 val use_cpp_mangling : bool ref
 
+val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
 
 type function_result_types = Never | Functors_only | All_functions


### PR DESCRIPTION
As the title suggests, this pull request simply
makes the threshold for a heap reduction before
code emission a variable that can be controlled
from the command-line or the environment.

The rationale is that one may want to change it
without rebuilding the compiler, and there is a
chance the build system may be in a position
to give some insight since it controls the level
of parallelism.