### PR TITLE
Fix flambda_o3 and flambda_oclassic attributes

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -44,7 +44,7 @@ let mk_flambda2_result_types_functors_only f =
   Printf.sprintf " Infer result types for functors (but no other\n\
       \     functions)%s (Flambda 2 only)"
     (format_default (
-      match Flambda2.default.function_result_types with
+      match Flambda2.Default.function_result_types with
       | Functors_only -> true
       | Never | All_functions -> false))
 ;;
@@ -54,7 +54,7 @@ let mk_flambda2_result_types_all_functions f =
   Printf.sprintf " Infer result types for all functions\n\
       \     (including functors)%s (Flambda 2 only)"
     (format_default (
-      match Flambda2.default.function_result_types with
+      match Flambda2.Default.function_result_types with
       | All_functions -> true
       | Never | Functors_only -> false))
 ;;
@@ -64,7 +64,7 @@ let mk_no_flambda2_result_types f =
   Printf.sprintf " Do not infer result types for functions (or\n\
       \     functors)%s (Flambda 2 only)"
     (format_default (
-      match Flambda2.default.function_result_types with
+      match Flambda2.Default.function_result_types with
       | Never -> true
       | Functors_only | All_functions -> false))
 ;;
@@ -74,21 +74,21 @@ let mk_flambda2_join_points f =
   "-flambda2-join-points", Arg.Unit f,
   Printf.sprintf " Propagate information from all incoming edges to a join\n\
       \     point%s (Flambda 2 only)"
-    (format_default Flambda2.default.join_points)
+    (format_default Flambda2.Default.join_points)
 ;;
 
 let mk_no_flambda2_join_points f =
   "-no-flambda2-join-points", Arg.Unit f,
   Printf.sprintf " Propagate information to a join point only if there are\n\
       \     zero or one incoming edge(s)%s (Flambda 2 only)"
-    (format_not_default Flambda2.default.join_points)
+    (format_not_default Flambda2.Default.join_points)
 ;;
 
 let mk_flambda2_unbox_along_intra_function_control_flow f =
   "-flambda2-unbox-along-intra-function-control-flow", Arg.Unit f,
   Printf.sprintf " Pass values within\n\
       \     a function as unboxed where possible%s (Flambda 2 only)"
-    (format_default Flambda2.default.unbox_along_intra_function_control_flow)
+    (format_default Flambda2.Default.unbox_along_intra_function_control_flow)
 ;;
 
 let mk_no_flambda2_unbox_along_intra_function_control_flow f =
@@ -96,35 +96,35 @@ let mk_no_flambda2_unbox_along_intra_function_control_flow f =
   Printf.sprintf " Pass values within\n\
       \     a function in their normal representation%s (Flambda 2 only)"
     (format_not_default
-      Flambda2.default.unbox_along_intra_function_control_flow)
+      Flambda2.Default.unbox_along_intra_function_control_flow)
 ;;
 
 let mk_flambda2_backend_cse_at_toplevel f =
   "-flambda2-backend-cse-at-toplevel", Arg.Unit f,
   Printf.sprintf " Apply the backend CSE pass to module\n\
       \     initializers%s (Flambda 2 only)"
-    (format_default Flambda2.default.backend_cse_at_toplevel)
+    (format_default Flambda2.Default.backend_cse_at_toplevel)
 ;;
 
 let mk_no_flambda2_backend_cse_at_toplevel f =
   "-no-flambda2-backend-cse-at-toplevel", Arg.Unit f,
   Printf.sprintf " Do not apply the backend CSE pass to\n\
       \     module initializers%s (Flambda 2 only)"
-    (format_not_default Flambda2.default.backend_cse_at_toplevel)
+    (format_not_default Flambda2.Default.backend_cse_at_toplevel)
 ;;
 
 let mk_flambda2_cse_depth f =
   "-flambda2-cse-depth", Arg.Int f,
   Printf.sprintf " Depth threshold for eager tracking of CSE equations\n\
       \     (default %d) (Flambda 2 only)"
-    Flambda2.default.cse_depth
+    Flambda2.Default.cse_depth
 ;;
 
 let mk_flambda2_join_depth f =
   "-flambda2-join-depth", Arg.Int f,
   Printf.sprintf " Depth threshold for alias expansion in join\n\
       \     (default %d) (Flambda 2 only)"
-    Flambda2.default.join_depth
+    Flambda2.Default.join_depth
 ;;
 
 let mk_flambda2_expert_code_id_and_symbol_scoping_checks f =
@@ -132,7 +132,7 @@ let mk_flambda2_expert_code_id_and_symbol_scoping_checks f =
   Printf.sprintf " Perform checks on static\n\
       \     scopes of code IDs and symbols during To_cmm%s\n\
       \     (Flambda 2 only)"
-    (format_default Flambda2.Expert.default.code_id_and_symbol_scoping_checks)
+    (format_default Flambda2.Expert.Default.code_id_and_symbol_scoping_checks)
 ;;
 
 let mk_no_flambda2_expert_code_id_and_symbol_scoping_checks f =
@@ -141,49 +141,49 @@ let mk_no_flambda2_expert_code_id_and_symbol_scoping_checks f =
       \     on static scopes of code IDs and symbols during To_cmm%s\n\
       \     (Flambda 2 only)"
     (format_not_default
-      Flambda2.Expert.default.code_id_and_symbol_scoping_checks)
+      Flambda2.Expert.Default.code_id_and_symbol_scoping_checks)
 ;;
 
 let mk_flambda2_expert_fallback_inlining_heuristic f =
   "-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
   Printf.sprintf " Prevent inlining of functions\n\
       \     whose bodies contain closures%s (Flambda 2 only)"
-    (format_default Flambda2.Expert.default.fallback_inlining_heuristic)
+    (format_default Flambda2.Expert.Default.fallback_inlining_heuristic)
 ;;
 
 let mk_no_flambda2_expert_fallback_inlining_heuristic f =
   "-no-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
   Printf.sprintf " Allow inlining of functions\n\
       \     whose bodies contain closures%s (Flambda 2 only)"
-    (format_not_default Flambda2.Expert.default.fallback_inlining_heuristic)
+    (format_not_default Flambda2.Expert.Default.fallback_inlining_heuristic)
 ;;
 
 let mk_flambda2_expert_inline_effects_in_cmm f =
   "-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
   Printf.sprintf " Allow inlining of effectful\n\
       \     expressions in the produced Cmm code%s (Flambda 2 only)"
-    (format_default Flambda2.Expert.default.inline_effects_in_cmm)
+    (format_default Flambda2.Expert.Default.inline_effects_in_cmm)
 ;;
 
 let mk_no_flambda2_expert_inline_effects_in_cmm f =
   "-no-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
   Printf.sprintf " Prevent inlining of effectful\n\
       \     expressions in the produced Cmm code%s (Flambda 2 only)"
-    (format_not_default Flambda2.Expert.default.inline_effects_in_cmm)
+    (format_not_default Flambda2.Expert.Default.inline_effects_in_cmm)
 ;;
 
 let mk_flambda2_expert_phantom_lets f =
   "-flambda2-expert-phantom-lets", Arg.Unit f,
   Printf.sprintf " Generate phantom lets when -g\n\
       \     is specified%s (Flambda 2 only)"
-    (format_default Flambda2.Expert.default.phantom_lets)
+    (format_default Flambda2.Expert.Default.phantom_lets)
 ;;
 
 let mk_no_flambda2_expert_phantom_lets f =
   "-no-flambda2-expert-phantom-lets", Arg.Unit f,
   Printf.sprintf " Do not generate phantom lets even when -g\n\
       \     is specified%s (Flambda 2 only)"
-    (format_not_default Flambda2.Expert.default.phantom_lets)
+    (format_not_default Flambda2.Expert.Default.phantom_lets)
 ;;
 
 let mk_flambda2_expert_max_block_size_for_projections f =
@@ -191,7 +191,7 @@ let mk_flambda2_expert_max_block_size_for_projections f =
   Printf.sprintf " Do not simplify projections\n\
       \     from blocks if the block size exceeds this value (default %s)\n\
       \     (Flambda 2 only)"
-    (match Flambda2.Expert.default.max_block_size_for_projections with
+    (match Flambda2.Expert.Default.max_block_size_for_projections with
      | None -> "not set"
      | Some max -> string_of_int max)
 ;;
@@ -200,14 +200,14 @@ let mk_flambda2_expert_max_unboxing_depth f =
   "-flambda2-expert-max-unboxing-depth", Arg.Int f,
   Printf.sprintf " Do not unbox (nested) values deeper\n\
       \     than this many levels (default %d) (Flambda 2 only)"
-    Flambda2.Expert.default.max_unboxing_depth
+    Flambda2.Expert.Default.max_unboxing_depth
 ;;
 
 let mk_flambda2_expert_can_inline_recursive_functions f =
   "-flambda2-expert-can-inline-recursive-functions", Arg.Unit f,
   Printf.sprintf " Consider inlining\n\
      \      recursive functions (default %s) (Flambda 2 only)"
-    (format_default Flambda2.Expert.default.can_inline_recursive_functions)
+    (format_default Flambda2.Expert.Default.can_inline_recursive_functions)
 ;;
 
 let mk_no_flambda2_expert_can_inline_recursive_functions f =
@@ -215,7 +215,7 @@ let mk_no_flambda2_expert_can_inline_recursive_functions f =
   Printf.sprintf " Only inline recursive\n\
       \     functions if forced to so do by an attribute\n\
       \     (default %s) (Flambda 2 only)"
-    (format_not_default Flambda2.Expert.default.can_inline_recursive_functions)
+    (format_not_default Flambda2.Expert.Default.can_inline_recursive_functions)
 ;;
 
 let mk_flambda2_debug_permute_every_name f =

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -683,17 +683,6 @@ module Extra_params = struct
       Compenv.int_setter ppf name option v; true
     in
     match name with
-    (* override existing params *)
-    | "Oclassic" ->
-      if Compenv.check_bool ppf "Oclassic" v then
-        Flambda_backend_flags.set_oclassic (); true
-    | "O2" ->
-      if Compenv.check_bool ppf "O2" v then
-        Flambda_backend_flags.set_o2 (); true
-    | "O3" ->
-      if Compenv.check_bool ppf "O3" v then
-        Flambda_backend_flags.set_o3 (); true
-    (* define new params *)
     | "ocamlcfg" -> set Flambda_backend_flags.use_ocamlcfg
     | "use-cpp-mangling" -> set Flambda_backend_flags.use_cpp_mangling
     | "heap-reduction-threshold" -> set_int Flambda_backend_flags.heap_reduction_threshold
@@ -806,8 +795,7 @@ struct
      If the same string input can be recognized by two options,
      the flambda-backend implementation will take precedence,
      but this should be avoided. To override an option from Main_args,
-     redefine it in the implementation of this functor's argument.
-     See the approach below for _o3 in Default. *)
+     redefine it in the implementation of this functor's argument. *)
   let list = list2 @ list
 end
 
@@ -821,15 +809,9 @@ module Default = struct
   module Optmain = struct
     include Main_args.Default.Optmain
     include Flambda_backend_options_impl
-    let _o2 () = Flambda_backend_flags.set_o2 ()
-    let _o3 () = Flambda_backend_flags.set_o3 ()
-    let _classic_inlining () = Flambda_backend_flags.set_oclassic ()
   end
   module Opttopmain = struct
     include Main_args.Default.Opttopmain
     include Flambda_backend_options_impl
-    let _o2 () = Flambda_backend_flags.set_o2 ()
-    let _o3 () = Flambda_backend_flags.set_o3 ()
-    let _classic_inlining () = Flambda_backend_flags.set_oclassic ()
   end
 end

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -44,7 +44,7 @@ let mk_flambda2_result_types_functors_only f =
   Printf.sprintf " Infer result types for functors (but no other\n\
       \     functions)%s (Flambda 2 only)"
     (format_default (
-      match Flambda2.Default.function_result_types with
+      match Flambda2.default.function_result_types with
       | Functors_only -> true
       | Never | All_functions -> false))
 ;;
@@ -54,7 +54,7 @@ let mk_flambda2_result_types_all_functions f =
   Printf.sprintf " Infer result types for all functions\n\
       \     (including functors)%s (Flambda 2 only)"
     (format_default (
-      match Flambda2.Default.function_result_types with
+      match Flambda2.default.function_result_types with
       | All_functions -> true
       | Never | Functors_only -> false))
 ;;
@@ -64,7 +64,7 @@ let mk_no_flambda2_result_types f =
   Printf.sprintf " Do not infer result types for functions (or\n\
       \     functors)%s (Flambda 2 only)"
     (format_default (
-      match Flambda2.Default.function_result_types with
+      match Flambda2.default.function_result_types with
       | Never -> true
       | Functors_only | All_functions -> false))
 ;;
@@ -74,21 +74,21 @@ let mk_flambda2_join_points f =
   "-flambda2-join-points", Arg.Unit f,
   Printf.sprintf " Propagate information from all incoming edges to a join\n\
       \     point%s (Flambda 2 only)"
-    (format_default Flambda2.Default.join_points)
+    (format_default Flambda2.default.join_points)
 ;;
 
 let mk_no_flambda2_join_points f =
   "-no-flambda2-join-points", Arg.Unit f,
   Printf.sprintf " Propagate information to a join point only if there are\n\
       \     zero or one incoming edge(s)%s (Flambda 2 only)"
-    (format_not_default Flambda2.Default.join_points)
+    (format_not_default Flambda2.default.join_points)
 ;;
 
 let mk_flambda2_unbox_along_intra_function_control_flow f =
   "-flambda2-unbox-along-intra-function-control-flow", Arg.Unit f,
   Printf.sprintf " Pass values within\n\
       \     a function as unboxed where possible%s (Flambda 2 only)"
-    (format_default Flambda2.Default.unbox_along_intra_function_control_flow)
+    (format_default Flambda2.default.unbox_along_intra_function_control_flow)
 ;;
 
 let mk_no_flambda2_unbox_along_intra_function_control_flow f =
@@ -96,35 +96,35 @@ let mk_no_flambda2_unbox_along_intra_function_control_flow f =
   Printf.sprintf " Pass values within\n\
       \     a function in their normal representation%s (Flambda 2 only)"
     (format_not_default
-      Flambda2.Default.unbox_along_intra_function_control_flow)
+      Flambda2.default.unbox_along_intra_function_control_flow)
 ;;
 
 let mk_flambda2_backend_cse_at_toplevel f =
   "-flambda2-backend-cse-at-toplevel", Arg.Unit f,
   Printf.sprintf " Apply the backend CSE pass to module\n\
       \     initializers%s (Flambda 2 only)"
-    (format_default Flambda2.Default.backend_cse_at_toplevel)
+    (format_default Flambda2.default.backend_cse_at_toplevel)
 ;;
 
 let mk_no_flambda2_backend_cse_at_toplevel f =
   "-no-flambda2-backend-cse-at-toplevel", Arg.Unit f,
   Printf.sprintf " Do not apply the backend CSE pass to\n\
       \     module initializers%s (Flambda 2 only)"
-    (format_not_default Flambda2.Default.backend_cse_at_toplevel)
+    (format_not_default Flambda2.default.backend_cse_at_toplevel)
 ;;
 
 let mk_flambda2_cse_depth f =
   "-flambda2-cse-depth", Arg.Int f,
   Printf.sprintf " Depth threshold for eager tracking of CSE equations\n\
       \     (default %d) (Flambda 2 only)"
-    Flambda2.Default.cse_depth
+    Flambda2.default.cse_depth
 ;;
 
 let mk_flambda2_join_depth f =
   "-flambda2-join-depth", Arg.Int f,
   Printf.sprintf " Depth threshold for alias expansion in join\n\
       \     (default %d) (Flambda 2 only)"
-    Flambda2.Default.join_depth
+    Flambda2.default.join_depth
 ;;
 
 let mk_flambda2_expert_code_id_and_symbol_scoping_checks f =
@@ -132,7 +132,7 @@ let mk_flambda2_expert_code_id_and_symbol_scoping_checks f =
   Printf.sprintf " Perform checks on static\n\
       \     scopes of code IDs and symbols during To_cmm%s\n\
       \     (Flambda 2 only)"
-    (format_default Flambda2.Expert.Default.code_id_and_symbol_scoping_checks)
+    (format_default Flambda2.Expert.default.code_id_and_symbol_scoping_checks)
 ;;
 
 let mk_no_flambda2_expert_code_id_and_symbol_scoping_checks f =
@@ -141,49 +141,49 @@ let mk_no_flambda2_expert_code_id_and_symbol_scoping_checks f =
       \     on static scopes of code IDs and symbols during To_cmm%s\n\
       \     (Flambda 2 only)"
     (format_not_default
-      Flambda2.Expert.Default.code_id_and_symbol_scoping_checks)
+      Flambda2.Expert.default.code_id_and_symbol_scoping_checks)
 ;;
 
 let mk_flambda2_expert_fallback_inlining_heuristic f =
   "-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
   Printf.sprintf " Prevent inlining of functions\n\
       \     whose bodies contain closures%s (Flambda 2 only)"
-    (format_default Flambda2.Expert.Default.fallback_inlining_heuristic)
+    (format_default Flambda2.Expert.default.fallback_inlining_heuristic)
 ;;
 
 let mk_no_flambda2_expert_fallback_inlining_heuristic f =
   "-no-flambda2-expert-fallback-inlining-heuristic", Arg.Unit f,
   Printf.sprintf " Allow inlining of functions\n\
       \     whose bodies contain closures%s (Flambda 2 only)"
-    (format_not_default Flambda2.Expert.Default.fallback_inlining_heuristic)
+    (format_not_default Flambda2.Expert.default.fallback_inlining_heuristic)
 ;;
 
 let mk_flambda2_expert_inline_effects_in_cmm f =
   "-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
   Printf.sprintf " Allow inlining of effectful\n\
       \     expressions in the produced Cmm code%s (Flambda 2 only)"
-    (format_default Flambda2.Expert.Default.inline_effects_in_cmm)
+    (format_default Flambda2.Expert.default.inline_effects_in_cmm)
 ;;
 
 let mk_no_flambda2_expert_inline_effects_in_cmm f =
   "-no-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
   Printf.sprintf " Prevent inlining of effectful\n\
       \     expressions in the produced Cmm code%s (Flambda 2 only)"
-    (format_not_default Flambda2.Expert.Default.inline_effects_in_cmm)
+    (format_not_default Flambda2.Expert.default.inline_effects_in_cmm)
 ;;
 
 let mk_flambda2_expert_phantom_lets f =
   "-flambda2-expert-phantom-lets", Arg.Unit f,
   Printf.sprintf " Generate phantom lets when -g\n\
       \     is specified%s (Flambda 2 only)"
-    (format_default Flambda2.Expert.Default.phantom_lets)
+    (format_default Flambda2.Expert.default.phantom_lets)
 ;;
 
 let mk_no_flambda2_expert_phantom_lets f =
   "-no-flambda2-expert-phantom-lets", Arg.Unit f,
   Printf.sprintf " Do not generate phantom lets even when -g\n\
       \     is specified%s (Flambda 2 only)"
-    (format_not_default Flambda2.Expert.Default.phantom_lets)
+    (format_not_default Flambda2.Expert.default.phantom_lets)
 ;;
 
 let mk_flambda2_expert_max_block_size_for_projections f =
@@ -191,7 +191,7 @@ let mk_flambda2_expert_max_block_size_for_projections f =
   Printf.sprintf " Do not simplify projections\n\
       \     from blocks if the block size exceeds this value (default %s)\n\
       \     (Flambda 2 only)"
-    (match Flambda2.Expert.Default.max_block_size_for_projections with
+    (match Flambda2.Expert.default.max_block_size_for_projections with
      | None -> "not set"
      | Some max -> string_of_int max)
 ;;
@@ -200,14 +200,14 @@ let mk_flambda2_expert_max_unboxing_depth f =
   "-flambda2-expert-max-unboxing-depth", Arg.Int f,
   Printf.sprintf " Do not unbox (nested) values deeper\n\
       \     than this many levels (default %d) (Flambda 2 only)"
-    Flambda2.Expert.Default.max_unboxing_depth
+    Flambda2.Expert.default.max_unboxing_depth
 ;;
 
 let mk_flambda2_expert_can_inline_recursive_functions f =
   "-flambda2-expert-can-inline-recursive-functions", Arg.Unit f,
   Printf.sprintf " Consider inlining\n\
      \      recursive functions (default %s) (Flambda 2 only)"
-    (format_default Flambda2.Expert.Default.can_inline_recursive_functions)
+    (format_default Flambda2.Expert.default.can_inline_recursive_functions)
 ;;
 
 let mk_no_flambda2_expert_can_inline_recursive_functions f =
@@ -215,7 +215,7 @@ let mk_no_flambda2_expert_can_inline_recursive_functions f =
   Printf.sprintf " Only inline recursive\n\
       \     functions if forced to so do by an attribute\n\
       \     (default %s) (Flambda 2 only)"
-    (format_not_default Flambda2.Expert.Default.can_inline_recursive_functions)
+    (format_not_default Flambda2.Expert.default.can_inline_recursive_functions)
 ;;
 
 let mk_flambda2_debug_permute_every_name f =
@@ -533,14 +533,17 @@ struct
 end
 
 module Flambda_backend_options_impl = struct
-  let set r () = r := true
-  let clear r () = r := false
+  let set r () = r := Flambda_backend_flags.Set true
+  let clear r () = r := Flambda_backend_flags.Set false
 
-  let ocamlcfg = set Flambda_backend_flags.use_ocamlcfg
-  let no_ocamlcfg = clear Flambda_backend_flags.use_ocamlcfg
-  let dcfg = set Flambda_backend_flags.dump_cfg
+  let set' r () = r := true
+  let clear' r () = r := false
 
-  let use_cpp_mangling = set Flambda_backend_flags.use_cpp_mangling
+  let ocamlcfg = set' Flambda_backend_flags.use_ocamlcfg
+  let no_ocamlcfg = clear' Flambda_backend_flags.use_ocamlcfg
+  let dcfg = set' Flambda_backend_flags.dump_cfg
+
+  let use_cpp_mangling = set' Flambda_backend_flags.use_cpp_mangling
 
   let heap_reduction_threshold x =
     Flambda_backend_flags.heap_reduction_threshold := x
@@ -548,11 +551,11 @@ module Flambda_backend_options_impl = struct
   let flambda2_join_points = set Flambda2.join_points
   let no_flambda2_join_points = clear Flambda2.join_points
   let flambda2_result_types_functors_only () =
-    Flambda2.function_result_types := Flambda_backend_flags.Functors_only
+    Flambda2.function_result_types := Flambda_backend_flags.Set Flambda_backend_flags.Functors_only
   let flambda2_result_types_all_functions () =
-    Flambda2.function_result_types := Flambda_backend_flags.All_functions
+    Flambda2.function_result_types := Flambda_backend_flags.Set Flambda_backend_flags.All_functions
   let no_flambda2_result_types () =
-    Flambda2.function_result_types := Flambda_backend_flags.Never
+    Flambda2.function_result_types := Flambda_backend_flags.Set Flambda_backend_flags.Never
   let flambda2_unbox_along_intra_function_control_flow =
     set Flambda2.unbox_along_intra_function_control_flow
   let no_flambda2_unbox_along_intra_function_control_flow =
@@ -561,8 +564,8 @@ module Flambda_backend_options_impl = struct
     set Flambda2.backend_cse_at_toplevel
   let no_flambda2_backend_cse_at_toplevel =
     clear Flambda2.backend_cse_at_toplevel
-  let flambda2_cse_depth n = Flambda2.cse_depth := n
-  let flambda2_join_depth n = Flambda2.join_depth := n
+  let flambda2_cse_depth n = Flambda2.cse_depth := Flambda_backend_flags.Set n
+  let flambda2_join_depth n = Flambda2.join_depth := Flambda_backend_flags.Set n
   let flambda2_expert_code_id_and_symbol_scoping_checks =
     set Flambda2.Expert.code_id_and_symbol_scoping_checks
   let no_flambda2_expert_code_id_and_symbol_scoping_checks =
@@ -580,21 +583,21 @@ module Flambda_backend_options_impl = struct
   let no_flambda2_expert_phantom_lets =
     clear Flambda2.Expert.phantom_lets
   let flambda2_expert_max_block_size_for_projections size =
-    Flambda2.Expert.max_block_size_for_projections := Some size
+    Flambda2.Expert.max_block_size_for_projections := Flambda_backend_flags.Set (Some size)
   let flambda2_expert_max_unboxing_depth depth =
-    Flambda2.Expert.max_unboxing_depth := depth
+    Flambda2.Expert.max_unboxing_depth := Flambda_backend_flags.Set depth
   let flambda2_expert_can_inline_recursive_functions () =
-    Flambda2.Expert.can_inline_recursive_functions := true
+    Flambda2.Expert.can_inline_recursive_functions := Flambda_backend_flags.Set true
   let no_flambda2_expert_can_inline_recursive_functions () =
-    Flambda2.Expert.can_inline_recursive_functions := false
+    Flambda2.Expert.can_inline_recursive_functions := Flambda_backend_flags.Set false
   let flambda2_debug_permute_every_name =
-    set Flambda2.Debug.permute_every_name
+    set' Flambda2.Debug.permute_every_name
   let no_flambda2_debug_permute_every_name =
-    clear Flambda2.Debug.permute_every_name
+    clear' Flambda2.Debug.permute_every_name
   let flambda2_debug_concrete_types_only_on_canonicals =
-    set Flambda2.Debug.concrete_types_only_on_canonicals
+    set' Flambda2.Debug.concrete_types_only_on_canonicals
   let no_flambda2_debug_concrete_types_only_on_canonicals =
-    clear Flambda2.Debug.concrete_types_only_on_canonicals
+    clear' Flambda2.Debug.concrete_types_only_on_canonicals
 
   let flambda2_inline_max_depth spec =
     Clflags.Int_arg_helper.parse spec
@@ -655,52 +658,66 @@ module Flambda_backend_options_impl = struct
       Flambda2.Inlining.threshold
 
   let flambda2_speculative_inlining_only_if_arguments_useful =
-    set Flambda2.Inlining.speculative_inlining_only_if_arguments_useful
+    set' Flambda2.Inlining.speculative_inlining_only_if_arguments_useful
 
   let no_flambda2_speculative_inlining_only_if_arguments_useful =
-    clear Flambda2.Inlining.speculative_inlining_only_if_arguments_useful
+    clear' Flambda2.Inlining.speculative_inlining_only_if_arguments_useful
 
-  let flambda2_inlining_report_bin = set Flambda2.Inlining.report_bin
+  let flambda2_inlining_report_bin = set' Flambda2.Inlining.report_bin
 
   let flambda2_unicode = set Flambda2.unicode
 
-  let drawfexpr = set Flambda2.Dump.rawfexpr
-  let dfexpr = set Flambda2.Dump.fexpr
-  let dflexpect = set Flambda2.Dump.flexpect
-  let dclosure_offsets = set Flambda2.Dump.closure_offsets
-  let dfreshen = set Flambda2.Dump.freshen
+  let drawfexpr = set' Flambda2.Dump.rawfexpr
+  let dfexpr = set' Flambda2.Dump.fexpr
+  let dflexpect = set' Flambda2.Dump.flexpect
+  let dclosure_offsets = set' Flambda2.Dump.closure_offsets
+  let dfreshen = set' Flambda2.Dump.freshen
 end
 
 module Extra_params = struct
   let read_param ppf _position name v =
     let set option =
-      Compenv.setter ppf (fun b -> b) name [ option ] v; true
+      let b = Compenv.check_bool ppf name v in
+      option := Flambda_backend_flags.Set b;
+      true
     in
     let _clear option =
-      Compenv.setter ppf (fun b -> not b) name [ option ] v; true
+      let b = Compenv.check_bool ppf name v in
+      option := Flambda_backend_flags.Set (not b);
+      false
     in
     let set_int option =
+      begin match Compenv.check_int ppf name v with
+      | Some i -> option := Flambda_backend_flags.Set i
+      | None -> ()
+      end;
+      true
+    in
+    let set' option =
+      Compenv.setter ppf (fun b -> b) name [ option ] v; true
+    in
+    let set_int' option =
       Compenv.int_setter ppf name option v; true
     in
     match name with
-    | "ocamlcfg" -> set Flambda_backend_flags.use_ocamlcfg
-    | "use-cpp-mangling" -> set Flambda_backend_flags.use_cpp_mangling
-    | "heap-reduction-threshold" -> set_int Flambda_backend_flags.heap_reduction_threshold
+    | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
+    | "use-cpp-mangling" -> set' Flambda_backend_flags.use_cpp_mangling
+    | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
     | "flambda2-join-points" -> set Flambda2.join_points
     | "flambda2-result-types" ->
       (match String.lowercase_ascii v with
       | "never" ->
-        Flambda2.function_result_types := Flambda_backend_flags.Never
+        Flambda2.function_result_types := Flambda_backend_flags.(Set Never)
       | "functors-only" ->
-        Flambda2.function_result_types := Flambda_backend_flags.Functors_only
+        Flambda2.function_result_types := Flambda_backend_flags.(Set Functors_only)
       | "all-functions" ->
-        Flambda2.function_result_types := Flambda_backend_flags.All_functions
+        Flambda2.function_result_types := Flambda_backend_flags.(Set All_functions)
       | _ ->
         Misc.fatal_error "Syntax: flambda2-result-types=\
           never|functors-only|all-functions");
       true
     | "flambda2-result-types-all-functions" ->
-      Flambda2.function_result_types := Flambda_backend_flags.All_functions;
+      Flambda2.function_result_types := Flambda_backend_flags.(Set All_functions);
       true
     | "flambda2-unbox-along-intra-function-control-flow" ->
        set Flambda2.unbox_along_intra_function_control_flow
@@ -763,17 +780,17 @@ module Extra_params = struct
          "Bad syntax in OCAMLPARAM for 'flambda2-inline-threshold'"
          Flambda2.Inlining.threshold; true
     | "flambda2-speculative-inlining-only-if-arguments-useful" ->
-       set Flambda2.Inlining.speculative_inlining_only_if_arguments_useful
+       set' Flambda2.Inlining.speculative_inlining_only_if_arguments_useful
     | "flambda2-inlining-report-bin" ->
-       set Flambda2.Inlining.report_bin
+       set' Flambda2.Inlining.report_bin
     | "flambda2-expert-code-id-and-symbol-scoping-checks" ->
        set Flambda2.Expert.code_id_and_symbol_scoping_checks
     | "flambda2-expert-fallback-inlining-heuristic" ->
        set Flambda2.Expert.fallback_inlining_heuristic
     | "flambda2-debug-permute-every-name" ->
-       set Flambda2.Debug.permute_every_name
+       set' Flambda2.Debug.permute_every_name
     | "flambda2-debug-concrete-types-only-on-canonicals" ->
-       set Flambda2.Debug.concrete_types_only_on_canonicals
+       set' Flambda2.Debug.concrete_types_only_on_canonicals
     | _ -> false
 end
 

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -80,6 +80,7 @@ module Flambda2 = struct
     cse_depth = 2;
     join_points = true;
     unbox_along_intra_function_control_flow = true;
+    backend_cse_at_toplevel = false;
   }
 
   let o3 = {
@@ -142,7 +143,11 @@ module Flambda2 = struct
       fallback_inlining_heuristic = true;
     }
 
-    let o2 = default
+    let o2 = {
+      default with
+      fallback_inlining_heuristic = false;
+    }
+
     let o3 = default
 
     let default_for_opt_level opt_level =

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -218,27 +218,34 @@ module Flambda2 = struct
     function_result_types := Functors_only
 end
 
-let set_oclassic () =
-  if Clflags.is_flambda2 () then begin
-    Flambda2.Inlining.use_inlining_arguments_set
-      Flambda2.Inlining.oclassic_arguments;
-    Flambda2.oclassic_flags ()
-  end else begin
-    Clflags.set_oclassic ();
-  end
+let opt_flag_handler : Clflags.Opt_flag_handler.t =
+  let default = Clflags.Opt_flag_handler.default in
 
-let set_o2 () =
-  if Clflags.is_flambda2 () then begin
-    Flambda2.Inlining.use_inlining_arguments_set Flambda2.Inlining.o2_arguments;
-    Flambda2.o2_flags ()
-  end else begin
-    Clflags.set_o2 ();
-  end
+  let set_oclassic () =
+    if Clflags.is_flambda2 () then begin
+      Flambda2.Inlining.use_inlining_arguments_set
+        Flambda2.Inlining.oclassic_arguments;
+      Flambda2.oclassic_flags ()
+    end else begin
+      default.set_oclassic ();
+    end
+  in
 
-let set_o3 () =
-  if Clflags.is_flambda2 () then begin
-    Flambda2.Inlining.use_inlining_arguments_set Flambda2.Inlining.o3_arguments;
-    Flambda2.o3_flags ()
-  end else begin
-    Clflags.set_o3 ();
-  end
+  let set_o2 () =
+    if Clflags.is_flambda2 () then begin
+      Flambda2.Inlining.use_inlining_arguments_set Flambda2.Inlining.o2_arguments;
+      Flambda2.o2_flags ()
+    end else begin
+      default.set_o2 ();
+    end
+  in
+
+  let set_o3 () =
+    if Clflags.is_flambda2 () then begin
+      Flambda2.Inlining.use_inlining_arguments_set Flambda2.Inlining.o3_arguments;
+      Flambda2.o3_flags ()
+    end else begin
+      default.set_o3 ();
+    end
+  in
+  { set_oclassic; set_o2; set_o3 }

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -35,6 +35,17 @@ let flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3 =
   | Set O3 -> o3
 
 module Flambda2 = struct
+  module Default = struct
+    let classic_mode = false
+    let join_points = false
+    let unbox_along_intra_function_control_flow = true
+    let backend_cse_at_toplevel = false
+    let cse_depth = 2
+    let join_depth = 5
+    let function_result_types = Never
+    let unicode = true
+  end
+
   type flags = {
     classic_mode : bool;
     join_points : bool;
@@ -48,14 +59,14 @@ module Flambda2 = struct
   }
 
   let default = {
-    classic_mode = false;
-    join_points = false;
-    unbox_along_intra_function_control_flow = true;
-    backend_cse_at_toplevel = false;
-    cse_depth = 2;
-    join_depth = 5;
-    function_result_types = Never;
-    unicode = true;
+    classic_mode = Default.classic_mode;
+    join_points = Default.join_points;
+    unbox_along_intra_function_control_flow = Default.unbox_along_intra_function_control_flow;
+    backend_cse_at_toplevel = Default.backend_cse_at_toplevel;
+    cse_depth = Default.cse_depth;
+    join_depth = Default.join_depth;
+    function_result_types = Default.function_result_types;
+    unicode = Default.unicode;
   }
 
   let oclassic = {
@@ -96,6 +107,16 @@ module Flambda2 = struct
   end
 
   module Expert = struct
+    module Default = struct
+      let code_id_and_symbol_scoping_checks = false
+      let fallback_inlining_heuristic = false
+      let inline_effects_in_cmm = false
+      let phantom_lets = false
+      let max_block_size_for_projections = None
+      let max_unboxing_depth = 3
+      let can_inline_recursive_functions = false
+    end
+
     type flags = {
       code_id_and_symbol_scoping_checks : bool;
       fallback_inlining_heuristic : bool;
@@ -107,13 +128,13 @@ module Flambda2 = struct
     }
 
     let default = {
-      code_id_and_symbol_scoping_checks = false;
-      fallback_inlining_heuristic = false;
-      inline_effects_in_cmm = false;
-      phantom_lets = false;
-      max_block_size_for_projections = None;
-      max_unboxing_depth = 3;
-      can_inline_recursive_functions = false;
+      code_id_and_symbol_scoping_checks = Default.code_id_and_symbol_scoping_checks;
+      fallback_inlining_heuristic = Default.fallback_inlining_heuristic;
+      inline_effects_in_cmm = Default.inline_effects_in_cmm;
+      phantom_lets = Default.phantom_lets;
+      max_block_size_for_projections = Default.max_block_size_for_projections;
+      max_unboxing_depth = Default.max_unboxing_depth;
+      can_inline_recursive_functions = Default.can_inline_recursive_functions;
     }
 
     let oclassic = {
@@ -261,34 +282,30 @@ module Flambda2 = struct
   end
 end
 
+let set_oclassic () =
+  if Clflags.is_flambda2 () then begin
+    Flambda2.Inlining.use_inlining_arguments_set
+      Flambda2.Inlining.oclassic_arguments;
+    opt_level := Set Oclassic
+  end else begin
+    Clflags.Opt_flag_handler.default.set_oclassic ();
+  end
+
+let set_o2 () =
+  if Clflags.is_flambda2 () then begin
+    Flambda2.Inlining.use_inlining_arguments_set Flambda2.Inlining.o2_arguments;
+    opt_level := Set O2
+  end else begin
+    Clflags.Opt_flag_handler.default.set_o2 ();
+  end
+
+let set_o3 () =
+  if Clflags.is_flambda2 () then begin
+    Flambda2.Inlining.use_inlining_arguments_set Flambda2.Inlining.o3_arguments;
+    opt_level := Set O3
+  end else begin
+    Clflags.Opt_flag_handler.default.set_o3 ();
+  end
+
 let opt_flag_handler : Clflags.Opt_flag_handler.t =
-  let default = Clflags.Opt_flag_handler.default in
-
-  let set_oclassic () =
-    if Clflags.is_flambda2 () then begin
-      Flambda2.Inlining.use_inlining_arguments_set
-        Flambda2.Inlining.oclassic_arguments;
-      opt_level := Set Oclassic
-    end else begin
-      default.set_oclassic ();
-    end
-  in
-
-  let set_o2 () =
-    if Clflags.is_flambda2 () then begin
-      Flambda2.Inlining.use_inlining_arguments_set Flambda2.Inlining.o2_arguments;
-      opt_level := Set O2
-    end else begin
-      default.set_o2 ();
-    end
-  in
-
-  let set_o3 () =
-    if Clflags.is_flambda2 () then begin
-      Flambda2.Inlining.use_inlining_arguments_set Flambda2.Inlining.o3_arguments;
-      opt_level := Set O3
-    end else begin
-      default.set_o3 ();
-    end
-  in
   { set_oclassic; set_o2; set_o3 }

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -200,13 +200,30 @@ module Flambda2 = struct
     let o3_arguments = o2_arguments
   end
 
+  let clear_o_flags () =
+    (* Reset anything set by -O2, -O3, or -Oclassic to the default
+       values so that later -O options (or OCAMLPARAM or attributes)
+       cleanly override earlier ones *)
+    classic_mode := Default.classic_mode;
+    cse_depth := Default.cse_depth;
+    join_points := Default.join_points;
+    unbox_along_intra_function_control_flow :=
+      Default.unbox_along_intra_function_control_flow;
+    Expert.fallback_inlining_heuristic :=
+      Expert.Default.fallback_inlining_heuristic;
+    (* This default is copied from [Clflags]: *)
+    Clflags.use_linscan := false;
+    function_result_types := Default.function_result_types
+
   let oclassic_flags () =
+    clear_o_flags ();
     classic_mode := true;
     Expert.fallback_inlining_heuristic := true;
     backend_cse_at_toplevel := false;
     Clflags.use_linscan := true
 
   let o2_flags () =
+    clear_o_flags ();
     cse_depth := 2;
     join_points := true;
     unbox_along_intra_function_control_flow := true;

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -29,8 +29,21 @@ type 'a or_default = Set of 'a | Default
 val opt_level : opt_level or_default ref
 
 module Flambda2 : sig
+  module Default : sig
+    val classic_mode : bool
+    val join_points : bool
+    val unbox_along_intra_function_control_flow : bool
+    val backend_cse_at_toplevel : bool
+    val cse_depth : int
+    val join_depth : int
+    val function_result_types : function_result_types
+
+    val unicode : bool
+  end
+
   (* CR-someday lmaurer: We could eliminate most of the per-flag boilerplate using GADTs
      and heterogeneous maps. Whether that's an improvement is a fair question. *)
+
   type flags = {
     classic_mode : bool;
     join_points : bool;
@@ -43,7 +56,6 @@ module Flambda2 : sig
     unicode : bool;
   }
 
-  val default : flags
   val default_for_opt_level : opt_level or_default -> flags
 
   val function_result_types : function_result_types or_default ref
@@ -66,6 +78,16 @@ module Flambda2 : sig
   end
 
   module Expert : sig
+    module Default : sig
+      val code_id_and_symbol_scoping_checks : bool
+      val fallback_inlining_heuristic : bool
+      val inline_effects_in_cmm : bool
+      val phantom_lets : bool
+      val max_block_size_for_projections : int option
+      val max_unboxing_depth : int
+      val can_inline_recursive_functions : bool
+    end
+
     type flags = {
       code_id_and_symbol_scoping_checks : bool;
       fallback_inlining_heuristic : bool;
@@ -76,7 +98,6 @@ module Flambda2 : sig
       can_inline_recursive_functions : bool;
     }
 
-    val default : flags
     val default_for_opt_level : opt_level or_default -> flags
 
     val code_id_and_symbol_scoping_checks : bool or_default ref

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -23,30 +23,39 @@ val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
 
 type function_result_types = Never | Functors_only | All_functions
+type opt_level = Oclassic | O2 | O3
+type 'a or_default = Set of 'a | Default
+
+val opt_level : opt_level or_default ref
 
 module Flambda2 : sig
-  module Default : sig
-    val classic_mode : bool
-    val join_points : bool
-    val unbox_along_intra_function_control_flow : bool
-    val backend_cse_at_toplevel : bool
-    val cse_depth : int
-    val join_depth : int
-    val function_result_types : function_result_types
+  (* CR-someday lmaurer: We could eliminate most of the per-flag boilerplate using GADTs
+     and heterogeneous maps. Whether that's an improvement is a fair question. *)
+  type flags = {
+    classic_mode : bool;
+    join_points : bool;
+    unbox_along_intra_function_control_flow : bool;
+    backend_cse_at_toplevel : bool;
+    cse_depth : int;
+    join_depth : int;
+    function_result_types : function_result_types;
 
-    val unicode : bool
-  end
+    unicode : bool;
+  }
 
-  val function_result_types : function_result_types ref
+  val default : flags
+  val default_for_opt_level : opt_level or_default -> flags
 
-  val classic_mode : bool ref
-  val join_points : bool ref
-  val unbox_along_intra_function_control_flow : bool ref
-  val backend_cse_at_toplevel : bool ref
-  val cse_depth : int ref
-  val join_depth : int ref
+  val function_result_types : function_result_types or_default ref
 
-  val unicode : bool ref
+  val classic_mode : bool or_default ref
+  val join_points : bool or_default ref
+  val unbox_along_intra_function_control_flow : bool or_default ref
+  val backend_cse_at_toplevel : bool or_default ref
+  val cse_depth : int or_default ref
+  val join_depth : int or_default ref
+
+  val unicode : bool or_default ref
 
   module Dump : sig
     val rawfexpr : bool ref
@@ -57,23 +66,26 @@ module Flambda2 : sig
   end
 
   module Expert : sig
-    module Default : sig
-      val code_id_and_symbol_scoping_checks : bool
-      val fallback_inlining_heuristic : bool
-      val inline_effects_in_cmm : bool
-      val phantom_lets : bool
-      val max_block_size_for_projections : int option
-      val max_unboxing_depth : int
-      val can_inline_recursive_functions : bool
-    end
+    type flags = {
+      code_id_and_symbol_scoping_checks : bool;
+      fallback_inlining_heuristic : bool;
+      inline_effects_in_cmm : bool;
+      phantom_lets : bool;
+      max_block_size_for_projections : int option;
+      max_unboxing_depth : int;
+      can_inline_recursive_functions : bool;
+    }
 
-    val code_id_and_symbol_scoping_checks : bool ref
-    val fallback_inlining_heuristic : bool ref
-    val inline_effects_in_cmm : bool ref
-    val phantom_lets : bool ref
-    val max_block_size_for_projections : int option ref
-    val max_unboxing_depth : int ref
-    val can_inline_recursive_functions : bool ref
+    val default : flags
+    val default_for_opt_level : opt_level or_default -> flags
+
+    val code_id_and_symbol_scoping_checks : bool or_default ref
+    val fallback_inlining_heuristic : bool or_default ref
+    val inline_effects_in_cmm : bool or_default ref
+    val phantom_lets : bool or_default ref
+    val max_block_size_for_projections : int option or_default ref
+    val max_unboxing_depth : int or_default ref
+    val can_inline_recursive_functions : bool or_default ref
   end
 
   module Debug : sig

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -127,7 +127,4 @@ module Flambda2 : sig
   end
 end
 
-
-val set_oclassic : unit -> unit
-val set_o2 : unit -> unit
-val set_o3 : unit -> unit
+val opt_flag_handler : Clflags.Opt_flag_handler.t

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -66,6 +66,7 @@ let main argv ppf ~flambda2 =
       ["-depend", Arg.Unit Makedepend.main_from_option,
        "<options> Compute dependencies \
         (use 'ocamlopt -depend -help' for details)"];
+    Clflags.Opt_flag_handler.set Flambda_backend_flags.opt_flag_handler;
     Clflags.parse_arguments argv Compenv.anonymous usage;
     Compmisc.read_clflags_from_env ();
     if !Clflags.plugin then

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -146,11 +146,10 @@ let output_flexpect ~ml_filename ~raw_flambda:old_unit new_unit =
 let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
     ~module_block_size_in_words ~module_initializer ~keep_symbol_tables =
   (* Make sure -linscan is enabled in classic mode. Doing this here to be sure
-     it happens exactly when -Oclassic is in effect, which we don't know at
-     CLI processing time because there may be an [@@@flambda_oclassic] or
+     it happens exactly when -Oclassic is in effect, which we don't know at CLI
+     processing time because there may be an [@@@flambda_oclassic] or
      [@@@flambda_o3] attribute. *)
-  if Flambda_features.classic_mode () then
-    Clflags.use_linscan := true;
+  if Flambda_features.classic_mode () then Clflags.use_linscan := true;
   Misc.Color.setup (Flambda_features.colour ());
   (* When the float array optimisation is enabled, the length of an array needs
      to be computed differently according to the array kind, in the case where

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -145,6 +145,12 @@ let output_flexpect ~ml_filename ~raw_flambda:old_unit new_unit =
 
 let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
     ~module_block_size_in_words ~module_initializer ~keep_symbol_tables =
+  (* Make sure -linscan is enabled in classic mode. Doing this here to be sure
+     it happens exactly when -Oclassic is in effect, which we don't know at
+     CLI processing time because there may be an [@@@flambda_oclassic] or
+     [@@@flambda_o3] attribute. *)
+  if Flambda_features.classic_mode () then
+    Clflags.use_linscan := true;
   Misc.Color.setup (Flambda_features.colour ());
   (* When the float array optimisation is enabled, the length of an array needs
      to be computed differently according to the array kind, in the case where

--- a/middle_end/flambda2/tests/mlexamples/opt_flags.ml
+++ b/middle_end/flambda2/tests/mlexamples/opt_flags.ml
@@ -1,3 +1,5 @@
+[@@@flambda_o3]
+
 (* Differentiates between optimisation levels. Requires inspecting -dcmm to
    verify.
 
@@ -8,6 +10,15 @@
 (* - With no flags at all, x is constant. *)
 (* - With -O2, x and y are constant. *)
 (* - With -O3, all three are constant. *)
+
+(* Except in -Oclassic, which doesn't statically allocate [M] at all, the -dcmm
+   output should have a block with just a few integers near the top; they'll
+   either be the computed constant in tagged form or 1 if the value isn't
+   constant at that level. In particular, they should be: *)
+
+(* - (no flags): 85 1 1
+ * - -O2: 85 199 1
+ * - -O3: 85 199 3403 *)
 
 module M : sig
   val x : int

--- a/middle_end/flambda2/tests/mlexamples/opt_flags.ml
+++ b/middle_end/flambda2/tests/mlexamples/opt_flags.ml
@@ -1,0 +1,54 @@
+(* Differentiates between optimisation levels. Requires inspecting -dcmm to
+   verify.
+
+   Three values are exported by the module. Whether they are compile-time
+   constants depends on the flags in effect: *)
+
+(* - With -Oclassic, none are constant. *)
+(* - With no flags at all, x is constant. *)
+(* - With -O2, x and y are constant. *)
+(* - With -O3, all three are constant. *)
+
+module M : sig
+  val x : int
+
+  val y : int
+
+  val z : int
+end = struct
+  let f () =
+    let g () = 42 in
+    g, g
+
+  (* requires -Oclassic off *)
+  let x =
+    (* if f appears only once, -Oclassic inlines it *)
+    let _ = f in
+    let f, _ = f () in
+    f ()
+
+  external getenv : string -> string = "caml_sys_getenv"
+
+  (* requires -O2 or -O3 (or -flambda2-join-points) *)
+  let y =
+    match match getenv "foo" with _ -> Some 1 | exception _ -> Some 2 with
+    | Some _ -> 99
+    | None -> -1
+
+  module F (X : sig
+    val g : unit -> int
+  end) =
+  struct
+    let h () = X.g ()
+  end
+  [@@inline never]
+
+  module X = struct
+    let g () = 1701
+  end
+
+  module FX = F (X)
+
+  (* requires -O3 (or any -flambda2-result-types-X) *)
+  let z = FX.h ()
+end

--- a/middle_end/flambda2/tests/mlexamples/opt_flags.ml
+++ b/middle_end/flambda2/tests/mlexamples/opt_flags.ml
@@ -1,5 +1,3 @@
-[@@@flambda_o3]
-
 (* Differentiates between optimisation levels. Requires inspecting -dcmm to
    verify.
 

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -16,26 +16,49 @@
 
 let flambda2_is_enabled () = Clflags.is_flambda2 ()
 
-let classic_mode () = !Flambda_backend_flags.Flambda2.classic_mode
+let with_default (r : 'a Flambda_backend_flags.or_default)
+    ~(f : Flambda_backend_flags.Flambda2.flags -> 'a) =
+  match r with
+  | Set a -> a
+  | Default ->
+    f
+      (Flambda_backend_flags.Flambda2.default_for_opt_level
+         !Flambda_backend_flags.opt_level)
 
-let join_points () = !Flambda_backend_flags.Flambda2.join_points
+let classic_mode () =
+  !Flambda_backend_flags.Flambda2.classic_mode
+  |> with_default ~f:(fun d -> d.classic_mode)
+
+let join_points () =
+  !Flambda_backend_flags.Flambda2.join_points
+  |> with_default ~f:(fun d -> d.join_points)
 
 let unbox_along_intra_function_control_flow () =
   !Flambda_backend_flags.Flambda2.unbox_along_intra_function_control_flow
+  |> with_default ~f:(fun d -> d.unbox_along_intra_function_control_flow)
 
 let backend_cse_at_toplevel () =
   !Flambda_backend_flags.Flambda2.backend_cse_at_toplevel
+  |> with_default ~f:(fun d -> d.backend_cse_at_toplevel)
 
-let cse_depth () = !Flambda_backend_flags.Flambda2.cse_depth
+let cse_depth () =
+  !Flambda_backend_flags.Flambda2.cse_depth
+  |> with_default ~f:(fun d -> d.cse_depth)
 
-let join_depth () = !Flambda_backend_flags.Flambda2.join_depth
+let join_depth () =
+  !Flambda_backend_flags.Flambda2.join_depth
+  |> with_default ~f:(fun d -> d.join_depth)
 
 let safe_string () = Config.safe_string
 
 let flat_float_array () = Config.flat_float_array
 
 let function_result_types ~is_a_functor =
-  match !Flambda_backend_flags.Flambda2.function_result_types with
+  let when_ =
+    !Flambda_backend_flags.Flambda2.function_result_types
+    |> with_default ~f:(fun d -> d.function_result_types)
+  in
+  match when_ with
   | Never -> false
   | Functors_only -> is_a_functor
   | All_functions -> true
@@ -54,7 +77,9 @@ let inlining_report_bin () = !Flambda_backend_flags.Flambda2.Inlining.report_bin
 
 let colour () = !Clflags.color
 
-let unicode () = !Flambda_backend_flags.Flambda2.unicode
+let unicode () =
+  !Flambda_backend_flags.Flambda2.unicode
+  |> with_default ~f:(fun d -> d.unicode)
 
 let check_invariants () = !Clflags.flambda_invariant_checks
 
@@ -152,23 +177,40 @@ module Debug = struct
 end
 
 module Expert = struct
+  let with_default (r : 'a Flambda_backend_flags.or_default)
+      ~(f : Flambda_backend_flags.Flambda2.Expert.flags -> 'a) =
+    match r with
+    | Set a -> a
+    | Default ->
+      f
+        (Flambda_backend_flags.Flambda2.Expert.default_for_opt_level
+           !Flambda_backend_flags.opt_level)
+
   let code_id_and_symbol_scoping_checks () =
     !Flambda_backend_flags.Flambda2.Expert.code_id_and_symbol_scoping_checks
+    |> with_default ~f:(fun d -> d.code_id_and_symbol_scoping_checks)
 
   let fallback_inlining_heuristic () =
     !Flambda_backend_flags.Flambda2.Expert.fallback_inlining_heuristic
+    |> with_default ~f:(fun d -> d.fallback_inlining_heuristic)
 
   let inline_effects_in_cmm () =
     !Flambda_backend_flags.Flambda2.Expert.inline_effects_in_cmm
+    |> with_default ~f:(fun d -> d.inline_effects_in_cmm)
 
   let max_block_size_for_projections () =
     !Flambda_backend_flags.Flambda2.Expert.max_block_size_for_projections
+    |> with_default ~f:(fun d -> d.max_block_size_for_projections)
 
-  let phantom_lets () = !Flambda_backend_flags.Flambda2.Expert.phantom_lets
+  let phantom_lets () =
+    !Flambda_backend_flags.Flambda2.Expert.phantom_lets
+    |> with_default ~f:(fun d -> d.phantom_lets)
 
   let max_unboxing_depth () =
     !Flambda_backend_flags.Flambda2.Expert.max_unboxing_depth
+    |> with_default ~f:(fun d -> d.max_unboxing_depth)
 
   let can_inline_recursive_functions () =
     !Flambda_backend_flags.Flambda2.Expert.can_inline_recursive_functions
+    |> with_default ~f:(fun d -> d.can_inline_recursive_functions)
 end

--- a/native_toplevel/opttopmain.ml
+++ b/native_toplevel/opttopmain.ml
@@ -102,6 +102,7 @@ let () =
 
 let main () =
   Clflags.native_code := true;
+  Clflags.Opt_flag_handler.set Flambda_backend_flags.opt_flag_handler;
   let list = ref Options.list in
   begin
     try

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -193,6 +193,14 @@ let check_bool ppf name s =
       "bad value %s for %s" s name;
     false
 
+let check_int ppf name s =
+  match int_of_string s with
+  | i -> Some i
+  | exception _ ->
+      Printf.ksprintf (print_error ppf)
+        "bad value %s for %s" s name;
+      None
+
 let decode_compiler_pass ppf v ~name ~filter =
   let module P = Clflags.Compiler_pass in
   let passes = P.available_pass_names ~filter ~native:!native_code in

--- a/ocaml/driver/compenv.mli
+++ b/ocaml/driver/compenv.mli
@@ -54,6 +54,7 @@ val setter :
     Format.formatter -> (bool -> 'a) -> string -> 'a ref list -> string -> unit
 val int_setter : Format.formatter -> string -> int ref -> string -> unit
 val check_bool : Format.formatter -> string -> string -> bool
+val check_int : Format.formatter -> string -> string -> int option
 
 (* [is_unit_name name] returns true only if [name] can be used as a
    correct module name *)

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -219,7 +219,7 @@ let mk_inline_max_unroll f =
 let mk_classic_inlining f =
   "-Oclassic", Arg.Unit f, " Make inlining decisions at function definition \
      time rather than at the call site (replicates previous behaviour of the \
-     compiler)"
+     compiler).  Implies -linscan (and causes -nolinscan to be ignored)."
 ;;
 
 let mk_inline_cost arg descr default f =

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -229,6 +229,18 @@ val unboxed_types : bool ref
 val insn_sched : bool ref
 val insn_sched_default : bool
 
+module Opt_flag_handler : sig
+  type t = {
+    set_oclassic : unit -> unit;
+    set_o2 : unit -> unit;
+    set_o3 : unit -> unit;
+  }
+
+  val default : t
+
+  val set : t -> unit
+end
+
 val set_oclassic : unit -> unit
 val set_o2 : unit -> unit
 val set_o3 : unit -> unit


### PR DESCRIPTION
The implementations of the `flambda_o3` and `flambda_oclassic` attributes were calling into `Clflags`, but the flambda backend implements optimization flags by circumventing `Clflags` entirely. The only obvious solution is to add a hook to `Clflags` so we can simply override what `Clflags.set_o3 ()` does. Fortunately, doing it this way means that the other two ways of setting the flags - the command line and `OCAMLPARAM` - no longer need to do anything special.

Tested manually using the included .ml source file.