### PR TITLE
Handle coercions in make_suitable_for_environment

### DIFF
--- a/middle_end/flambda2/types/grammar/type_descr.mli
+++ b/middle_end/flambda2/types/grammar/type_descr.mli
@@ -83,7 +83,7 @@ val project_variables_out :
   to_project:Variable.Set.t ->
   expand:(Variable.t -> coercion:Coercion.t -> 'head t) ->
   project_head:('head -> 'head) ->
-  project_coercion:(Coercion.t -> Coercion.t) ->
+  project_coercion:(Coercion.t -> Coercion.t Or_unknown.t) ->
   'head t ->
   'head t
 

--- a/middle_end/flambda2/types/grammar/type_descr.mli
+++ b/middle_end/flambda2/types/grammar/type_descr.mli
@@ -83,6 +83,7 @@ val project_variables_out :
   to_project:Variable.Set.t ->
   expand:(Variable.t -> coercion:Coercion.t -> 'head t) ->
   project_head:('head -> 'head) ->
+  project_coercion:(Coercion.t -> Coercion.t) ->
   'head t ->
   'head t
 


### PR DESCRIPTION
This fixes an oversight in PR #492, that would leave depth variables in coercions free.
The solution is not optimal, but it's constrained by the fact that coercions cannot represent `Unknown` (or `Bottom`, but that's less of an issue) currently.