### PR TITLE
Insert missing page table check in roots_nat.c

### DIFF
--- a/ocaml/runtime/roots_nat.c
+++ b/ocaml/runtime/roots_nat.c
@@ -439,6 +439,16 @@ static int visit(scanning_action maj, scanning_action min,
   if (!Is_block(v))
     return 0;
 
+  if (Is_young(v)) {
+    if (min != NULL) min(v, p);
+    return 0;
+  }
+
+  if (!Is_in_value_area(v))
+    return 0;
+
+  /* Either major or local, distinguish by header color */
+
   hd = Hd_val(vblock);
   /* Compaction can create things that look like Infix_tag,
      but have color Caml_gray (cf. eptr in compact.c).
@@ -450,11 +460,6 @@ static int visit(scanning_action maj, scanning_action min,
 
   if (Color_hd(hd) == Caml_black)
     return 0;
-
-  if (Is_young(vblock)) {
-    if (min != NULL) min(v, p);
-    return 0;
-  }
 
   if (Color_hd(hd) == Local_unmarked) {
     Hd_val(vblock) = With_color_hd(hd, Local_marked);


### PR DESCRIPTION
The new `visit` function, introduced for local allocs, examines the header of a value without first doing a page table check. When naked pointers are present, this is invalid as an OCaml value may be an arbitrary bitstring.

This patch inserts an `Is_in_value_area` check before the header is examined. For performance, the `Is_young` check is moved earlier, before the page table lookup, as `Is_young` does not dereference the value and is faster than the page table check.