### PR TITLE
Add dwarf-related flags

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -531,6 +531,9 @@ fmt:
 	ocamlformat -i middle_end/mangling.ml
 	ocamlformat -i middle_end/mangling.mli
 	ocamlformat -i tools/merge_archives.ml
+	ocamlformat -i \
+	  $$(find backend/debug/dwarf \
+	    \( -name "*.ml" -or -name "*.mli" \))
 
 .PHONY: check-fmt
 check-fmt:

--- a/Makefile.in
+++ b/Makefile.in
@@ -347,6 +347,8 @@ runtest-upstream:
 	cp $(stage2_prefix)/lib/ocaml/compiler-libs/*.cma _runtest/compilerlibs
 	cp $(stage2_prefix)/lib/ocaml/compiler-libs/*.a _runtest/compilerlibs
 	cp $(stage2_prefix)/lib/ocaml/compiler-libs/*.cmxa _runtest/compilerlibs
+	cp _build2/default/backend/debug/dwarf/dwarf_flags/dwarf_flags.cma \
+	  _runtest/compilerlibs
 	mkdir _runtest/toplevel
 	cp $(stage2_build)/ocaml/toplevel/.ocamltoplevel.objs/byte/*.cm* \
 	  _runtest/toplevel/

--- a/Makefile.in
+++ b/Makefile.in
@@ -347,8 +347,6 @@ runtest-upstream:
 	cp $(stage2_prefix)/lib/ocaml/compiler-libs/*.cma _runtest/compilerlibs
 	cp $(stage2_prefix)/lib/ocaml/compiler-libs/*.a _runtest/compilerlibs
 	cp $(stage2_prefix)/lib/ocaml/compiler-libs/*.cmxa _runtest/compilerlibs
-	cp _build2/default/backend/debug/dwarf/dwarf_flags/dwarf_flags.cma \
-	  _runtest/compilerlibs
 	mkdir _runtest/toplevel
 	cp $(stage2_build)/ocaml/toplevel/.ocamltoplevel.objs/byte/*.cm* \
 	  _runtest/toplevel/

--- a/backend/debug/dwarf/.ocamlformat
+++ b/backend/debug/dwarf/.ocamlformat
@@ -1,0 +1,14 @@
+# Please make a pull request to change this file.
+# Keep this file in sync with other .ocamlformat files in this repo.
+assignment-operator=begin-line
+cases-exp-indent=2
+doc-comments=before
+dock-collection-brackets=false
+exp-grouping=preserve
+if-then-else=keyword-first
+parens-tuple=multi-line-only
+space-around-lists=false
+space-around-variants=false
+type-decl=sparse
+wrap-comments=true
+version=0.19.0

--- a/backend/debug/dwarf/dwarf_flags/dune
+++ b/backend/debug/dwarf/dwarf_flags/dune
@@ -1,0 +1,9 @@
+(include_subdirs unqualified)
+
+(library
+  (name dwarf_flags)
+  (wrapped true)
+  (flags (:standard -principal -nostdlib))
+  (ocamlopt_flags (:standard -O3))
+  (libraries stdlib ocamlcommon)
+)

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -1,0 +1,134 @@
+type debug_thing =
+  | Debug_ocamldebug
+  | Debug_js_of_ocaml
+  | Debug_subprocs
+  | Debug_backtraces
+  | Debug_bounds_checking
+  | Debug_disable_bytecode_opt
+  | Debug_dwarf_cfi
+  | Debug_dwarf_loc
+  | Debug_dwarf_functions
+  | Debug_dwarf_scopes
+  | Debug_dwarf_vars
+  | Debug_dwarf_call_sites
+  | Debug_dwarf_cmm
+
+let bytecode_g =
+  [ Debug_ocamldebug;
+    Debug_js_of_ocaml;
+    Debug_subprocs;
+    Debug_backtraces;
+    Debug_disable_bytecode_opt ]
+
+let g0 = []
+
+let g1 =
+  [ Debug_subprocs;
+    Debug_backtraces;
+    Debug_bounds_checking;
+    Debug_disable_bytecode_opt;
+    Debug_dwarf_cfi;
+    Debug_dwarf_loc ]
+
+let g2 =
+  [ Debug_subprocs;
+    Debug_backtraces;
+    Debug_bounds_checking;
+    Debug_disable_bytecode_opt;
+    Debug_dwarf_cfi;
+    Debug_dwarf_loc;
+    Debug_dwarf_functions ]
+
+let g3 =
+  [ Debug_subprocs;
+    Debug_backtraces;
+    Debug_bounds_checking;
+    Debug_disable_bytecode_opt;
+    Debug_dwarf_cfi;
+    Debug_dwarf_loc;
+    Debug_dwarf_functions;
+    Debug_dwarf_scopes;
+    Debug_dwarf_vars;
+    Debug_dwarf_call_sites;
+    Debug_dwarf_cmm ]
+
+let all_g_levels = ["g0", g0; "g1", g1; "g2", g2; "g3", g3]
+
+let current_debug_settings = ref g0
+
+let use_g0 () = current_debug_settings := g0
+
+let use_g1 () = current_debug_settings := g1
+
+let use_g2 () = current_debug_settings := g2
+
+let use_g3 () =
+  Clflags.binary_annotations := true;
+  (* since [Debug_dwarf_vars] is present *)
+  current_debug_settings := g3
+
+let use_g () =
+  if !Clflags.native_code
+  then use_g1 ()
+  else current_debug_settings := bytecode_g
+
+let debug_thing thing = List.mem thing !current_debug_settings
+
+let set_debug_thing thing =
+  let new_settings =
+    List.filter (fun thing' -> thing <> thing') !current_debug_settings
+  in
+  current_debug_settings := thing :: new_settings
+
+let clear_debug_thing thing =
+  let new_settings =
+    List.filter (fun thing' -> thing <> thing') !current_debug_settings
+  in
+  current_debug_settings := new_settings
+
+let describe_debug_default_internal ~negate thing =
+  let defaults =
+    List.filter_map
+      (fun (level, things_enabled_at_level) ->
+        let enabled_at_level = List.mem thing things_enabled_at_level in
+        let state = if negate then not enabled_at_level else enabled_at_level in
+        if state then Some ("-" ^ level) else None)
+      all_g_levels
+  in
+  match defaults with
+  | [] -> ""
+  | defaults -> " (default with " ^ String.concat ", " defaults ^ ")"
+
+let describe_debug_default thing =
+  describe_debug_default_internal ~negate:false thing
+
+let describe_debug_default_negated thing =
+  describe_debug_default_internal ~negate:true thing
+
+type dwarf_version =
+  | Four
+  | Five
+
+let default_gdwarf_version = Four
+
+let gdwarf_version = ref default_gdwarf_version
+
+let default_gdwarf_offsets = false
+
+let gdwarf_offsets = ref default_gdwarf_offsets
+
+let default_ddebug_invariants = false
+
+let ddebug_invariants = ref default_ddebug_invariants
+
+type dwarf_format =
+  | Thirty_two
+  | Sixty_four
+
+let default_gdwarf_format = Thirty_two
+
+let gdwarf_format = ref default_gdwarf_format
+
+let default_gdwarf_self_tail_calls = true
+
+let gdwarf_self_tail_calls = ref default_gdwarf_self_tail_calls

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
@@ -1,0 +1,62 @@
+type debug_thing =
+  | Debug_ocamldebug
+  | Debug_js_of_ocaml
+  | Debug_subprocs
+  | Debug_backtraces
+  | Debug_bounds_checking
+  | Debug_disable_bytecode_opt
+  | Debug_dwarf_cfi
+  | Debug_dwarf_loc
+  | Debug_dwarf_functions
+  | Debug_dwarf_scopes
+  | Debug_dwarf_vars
+  | Debug_dwarf_call_sites
+  | Debug_dwarf_cmm
+
+val debug_thing : debug_thing -> bool
+
+val set_debug_thing : debug_thing -> unit
+
+val clear_debug_thing : debug_thing -> unit
+
+val describe_debug_default : debug_thing -> string
+
+val describe_debug_default_negated : debug_thing -> string
+
+val use_g : unit -> unit
+
+val use_g0 : unit -> unit
+
+val use_g1 : unit -> unit
+
+val use_g2 : unit -> unit
+
+val use_g3 : unit -> unit
+
+type dwarf_version =
+  | Four
+  | Five
+
+val gdwarf_version : dwarf_version ref
+
+val default_gdwarf_version : dwarf_version
+
+val gdwarf_offsets : bool ref
+
+val default_gdwarf_offsets : bool
+
+val gdwarf_self_tail_calls : bool ref
+
+val default_gdwarf_self_tail_calls : bool
+
+type dwarf_format =
+  | Thirty_two
+  | Sixty_four
+
+val gdwarf_format : dwarf_format ref
+
+val default_gdwarf_format : dwarf_format
+
+val default_ddebug_invariants : bool
+
+val ddebug_invariants : bool ref

--- a/dune
+++ b/dune
@@ -282,7 +282,7 @@
    ))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
- (libraries stdlib ocamlcommon)
+ (libraries stdlib ocamlcommon dwarf_flags)
  (modules flambda_backend_args flambda_backend_flags))
 
 (executable

--- a/dune
+++ b/dune
@@ -343,6 +343,7 @@
   (run
    %{dep:tools/merge_dot_a_files.sh}
    %{targets}
+   %{dep:backend/debug/dwarf/dwarf_flags/dwarf_flags.a}
    %{dep:flambda_backend_common.a}
    %{dep:middle_end/flambda2/ui/flambda2_ui.a}
    %{dep:middle_end/flambda2/algorithms/flambda2_algorithms.a}
@@ -370,6 +371,7 @@
   (run
    %{dep:tools/merge_archives.exe}
    %{targets}
+   %{dep:backend/debug/dwarf/dwarf_flags/dwarf_flags.cma}
    %{dep:flambda_backend_common.cma}
    %{dep:middle_end/flambda2/ui/flambda2_ui.cma}
    %{dep:middle_end/flambda2/algorithms/flambda2_algorithms.cma}
@@ -397,6 +399,7 @@
   (run
    %{dep:tools/merge_archives.exe}
    %{targets}
+   %{dep:backend/debug/dwarf/dwarf_flags/dwarf_flags.cmxa}
    %{dep:flambda_backend_common.cmxa}
    %{dep:middle_end/flambda2/ui/flambda2_ui.cmxa}
    %{dep:middle_end/flambda2/algorithms/flambda2_algorithms.cmxa}
@@ -428,6 +431,7 @@
 
 (install
  (files
+  (backend/debug/dwarf/dwarf_flags/dwarf_flags.cma as compiler-libs/dwarf_flags.cma)
   (ocamloptcomp_with_flambda2.cma as compiler-libs/ocamloptcomp.cma)
   (ocamloptcomp_with_flambda2.cmxa as compiler-libs/ocamloptcomp.cmxa)
   (ocamloptcomp_with_flambda2.a as compiler-libs/ocamloptcomp.a))
@@ -1356,7 +1360,19 @@
    compiler-libs/location_tracker_formatter.cmti)
   (.ocamloptcomp.objs/native/location_tracker_formatter.cmx
    as
-   compiler-libs/location_tracker_formatter.cmx)))
+   compiler-libs/location_tracker_formatter.cmx)
+  (backend/debug/dwarf/dwarf_flags/dwarf_flags.mli 
+   as compiler-libs/dwarf_flags.mli)
+  (backend/debug/dwarf/dwarf_flags/.dwarf_flags.objs/native/dwarf_flags.cmx
+   as compiler-libs/dwarf_flags.cmx)
+  (backend/debug/dwarf/dwarf_flags/.dwarf_flags.objs/byte/dwarf_flags.cmi
+   as compiler-libs/dwarf_flags.cmi)
+  (backend/debug/dwarf/dwarf_flags/.dwarf_flags.objs/byte/dwarf_flags.cmo
+   as compiler-libs/dwarf_flags.cmo)
+  (backend/debug/dwarf/dwarf_flags/.dwarf_flags.objs/byte/dwarf_flags.cmt
+   as compiler-libs/dwarf_flags.cmt)
+  (backend/debug/dwarf/dwarf_flags/.dwarf_flags.objs/byte/dwarf_flags.cmti
+   as compiler-libs/dwarf_flags.cmti)))
 
 (install
  (section lib)

--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -36,6 +36,7 @@ codegen_OCAMLFLAGS = $(addprefix -I $(TOPDIR)/, $(codegen_DIRS)) -w +40 -g
 
 codegen_LIBS = $(addprefix $(COMPILERLIBSDIR)/,\
   ocamlcommon \
+  dwarf_flags \
   flambda2_cmx \
   flambda2_ui \
   flambda2_algorithms \


### PR DESCRIPTION
Prerequisite for gdb support.

All flags related to dwarf are put inside a library in backend/debug/dwarf.
Later on they will be connected to flambda_backend_main and reused by the code paths emitting dwarf information.