### PR TITLE
Bump exec magic number

### DIFF
--- a/ocaml/runtime/caml/exec.h
+++ b/ocaml/runtime/caml/exec.h
@@ -60,7 +60,7 @@ struct exec_trailer {
 
 /* Magic number for this release */
 
-#define EXEC_MAGIC "Caml1999X029"
+#define EXEC_MAGIC "Caml1999X500"
 
 #endif /* CAML_INTERNALS */
 

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -94,7 +94,7 @@ let afl_instrument = %%AFL_INSTRUMENT%%
 (* When artifacts are incompatible with upstream OCaml, ocaml-jst uses
    magic numbers ending in 5xx. (The AST and bytecode executables remain
    compatible, so use upstream numbers) *)
-let exec_magic_number = "Caml1999X029"
+let exec_magic_number = "Caml1999X500"
     (* exec_magic_number is duplicated in runtime/caml/exec.h *)
 and cmi_magic_number = "Caml1999I500"
 and cmo_magic_number = "Caml1999O500"


### PR DESCRIPTION
The bytecode executable magic number should have been updated when the others were, because bytecode executables containing debug info contain types, and the format of types changed.

(cc @xclerc who pointed this out)