### PR TITLE
Liveness analysis using dataflow (bis)

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -340,8 +340,8 @@ let is_pure_specific : specific_operation -> bool = function
   | Istore_int _ -> false
   | Ioffset_loc _ -> false
   | Ifloatarithmem _ -> false
-  | Ibswap _ -> false
-  | Isqrtf -> false
+  | Ibswap _ -> true
+  | Isqrtf -> true
   | Ifloatsqrtf _ -> false
   | Ifloat_iround -> true
   | Ifloat_round _ -> true
@@ -351,6 +351,6 @@ let is_pure_specific : specific_operation -> bool = function
   | Izextend32 -> true
   | Irdtsc -> false
   | Irdpmc -> false
-  | Icrc32q -> false
+  | Icrc32q -> true
   | Ipause -> false
   | Iprefetch _ -> false

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -334,3 +334,23 @@ let equal_specific_operation left right =
     | Ifloat_iround | Ifloat_round _ | Ifloat_min | Ifloat_max | Ipause
     | Icrc32q | Iprefetch _), _ ->
     false
+
+let is_pure_specific : specific_operation -> bool = function
+  | Ilea _ -> true
+  | Istore_int _ -> false
+  | Ioffset_loc _ -> false
+  | Ifloatarithmem _ -> false
+  | Ibswap _ -> false
+  | Isqrtf -> false
+  | Ifloatsqrtf _ -> false
+  | Ifloat_iround -> true
+  | Ifloat_round _ -> true
+  | Ifloat_min -> true
+  | Ifloat_max -> true
+  | Isextend32 -> true
+  | Izextend32 -> true
+  | Irdtsc -> false
+  | Irdpmc -> false
+  | Icrc32q -> false
+  | Ipause -> false
+  | Iprefetch _ -> false

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -242,6 +242,6 @@ let is_pure_specific : specific_operation -> bool = function
   | Inegmuladdf -> true
   | Imulsubf -> true
   | Inegmulsubf -> true
-  | Isqrtf -> false
-  | Ibswap _ -> false
+  | Isqrtf -> true
+  | Ibswap _ -> true
   | Imove32 -> true

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -228,3 +228,20 @@ let equal_specific_operation left right =
     | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
     | Inegmulsubf | Isqrtf | Ibswap _ | Imove32), _ -> false
 
+let is_pure_specific : specific_operation -> bool = function
+  | Ifar_alloc _ -> false
+  | Ifar_intop_checkbound -> false
+  | Ifar_intop_imm_checkbound _ -> false
+  | Ishiftarith _ -> true
+  | Ishiftcheckbound _ -> false
+  | Ifar_shiftcheckbound _ -> false
+  | Imuladd -> true
+  | Imulsub -> true
+  | Inegmulf -> true
+  | Imuladdf -> true
+  | Inegmuladdf -> true
+  | Imulsubf -> true
+  | Inegmulsubf -> true
+  | Isqrtf -> false
+  | Ibswap _ -> false
+  | Imove32 -> true

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -170,21 +170,65 @@ let ocamlcfg_verbose =
   | Some "1" -> true
   | Some _ | None -> false
 
+let recompute_liveness_on_cfg (cfg_with_layout : Cfg_with_layout.t) : Cfg_with_layout.t =
+  let cfg = Cfg_with_layout.cfg cfg_with_layout in
+  Cfg.iter_blocks cfg ~f:(fun _label block ->
+      (* We use `canary` to ensure the liveness is appropriately set by
+         `Cfg_liveness.Liveness.run`. *)
+      let canary = Reg.create Cmm.Val in
+      canary.Reg.raw_name <- Reg.Raw_name.create_from_var (Ident.create_local "canary");
+      let canary_singleton = Reg.Set.singleton canary in
+      ListLabels.iter block.body ~f:(fun instr -> instr.Cfg.live <- canary_singleton);
+      block.terminator.Cfg.live <- canary_singleton);
+  begin match Cfg_liveness.Liveness.run cfg ~init:Reg.Set.empty () with
+    | Result.Ok (_ : Cfg_liveness.Liveness.map) -> ()
+    | Result.Error (_ : Cfg_liveness.Liveness.map) ->
+      Misc.fatal_errorf "Unable to compute liveness from CFG for function %s@."
+        cfg.Cfg.fun_name;
+  end;
+  Cfg.iter_blocks cfg ~f:(fun _label block ->
+      block.body <- ListLabels.filter block.body ~f:(fun instr ->
+          not (Cfg.is_noop_move instr)));
+  let layout : Label.t list =
+    ListLabels.filter (Cfg_with_layout.layout cfg_with_layout) ~f:(fun label ->
+        Cfg.mem_block (Cfg_with_layout.cfg cfg_with_layout) label)
+  in
+  let result =
+    Cfg_with_layout.create
+      cfg
+      ~layout
+      ~preserve_orig_labels:false
+      ~new_labels:Label.Set.empty
+  in
+  Eliminate_fallthrough_blocks.run result;
+  Merge_straightline_blocks.run result;
+  Eliminate_dead_code.run_dead_block result;
+  Simplify_terminator.run cfg;
+  result
+
 let test_cfgize (f : Mach.fundecl) (res : Linear.fundecl) : unit =
   if ocamlcfg_verbose then begin
     Format.eprintf "processing function %s...\n%!" f.Mach.fun_name;
   end;
+  (* We do not simplify terminators here because it interferes with liveness
+     when we have a terminator with:
+     (i) all its edges leading to the same block;
+     (ii) a condition making a pseudo-register live.
+    In such a case, the terminator would be simplified to a mere jump, the
+    condition would disappear, and the pseudo-register would no longer be
+    live. Is it fine in itself, but would break the equivalence check. *)
   let result =
     Cfgize.fundecl
       f
       ~preserve_orig_labels:false
-      ~simplify_terminators:true
+      ~simplify_terminators:false
   in
   let expected = Linear_to_cfg.run res ~preserve_orig_labels:false in
   Eliminate_fallthrough_blocks.run expected;
   Merge_straightline_blocks.run expected;
   Eliminate_dead_code.run_dead_block expected;
   Simplify_terminator.run (Cfg_with_layout.cfg expected);
+  let result = recompute_liveness_on_cfg result in
   Cfg_equivalence.check_cfg_with_layout f expected result;
   if ocamlcfg_verbose then begin
     Format.eprintf "the CFG on both code paths are equivalent for function %s.\n%!"

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -178,8 +178,8 @@ let recompute_liveness_on_cfg (cfg_with_layout : Cfg_with_layout.t) : Cfg_with_l
       let canary = Reg.create Cmm.Val in
       canary.Reg.raw_name <- Reg.Raw_name.create_from_var (Ident.create_local "canary");
       let canary_singleton = Reg.Set.singleton canary in
-      ListLabels.iter block.body ~f:(fun instr -> instr.Cfg.live <- canary_singleton);
-      block.terminator.Cfg.live <- canary_singleton);
+      block.body <- ListLabels.map block.body ~f:(fun instr -> Cfg.set_live instr canary_singleton);
+      block.terminator <- Cfg.set_live block.terminator canary_singleton);
   begin match Cfg_liveness.Liveness.run cfg ~init:Reg.Set.empty () with
     | Result.Ok (_ : Cfg_liveness.Liveness.map) -> ()
     | Result.Error (_ : Cfg_liveness.Liveness.map) ->

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -394,7 +394,10 @@ let print_terminator oc ?sep ti =
 
 let is_noop_move instr =
   match instr.desc with
-  | Op (Move | Spill | Reload) -> Reg.same_loc instr.arg.(0) instr.res.(0)
+  | Op (Move | Spill | Reload) -> (
+    match instr.arg.(0).loc with
+    | Unknown -> false
+    | Reg _ | Stack _ -> Reg.same_loc instr.arg.(0) instr.res.(0))
   | Op
       ( Const_int _ | Const_float _ | Const_symbol _ | Stackoffset _ | Load _
       | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf | Subf | Mulf

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -349,8 +349,77 @@ let is_pure_terminator desc =
     (* CR gyorsh: fix for memory operands *)
     true
 
+let is_pure_specific : Arch.specific_operation -> bool = function
+  | Ilea _ -> true
+  | Istore_int _ -> false
+  | Ioffset_loc _ -> false
+  | Ifloatarithmem _ -> false
+  | Ibswap _ -> false
+  | Isqrtf -> false
+  | Ifloatsqrtf _ -> false
+  | Ifloat_iround -> true
+  | Ifloat_round _ -> true
+  | Ifloat_min -> true
+  | Ifloat_max -> true
+  | Isextend32 -> true
+  | Izextend32 -> true
+  | Irdtsc -> false
+  | Irdpmc -> false
+  | Icrc32q -> false
+  | Ipause -> false
+  | Iprefetch _ -> false
+
+let is_pure_operation : operation -> bool = function
+  | Move -> true
+  | Spill -> true
+  | Reload -> true
+  | Const_int _ -> true
+  | Const_float _ -> true
+  | Const_symbol _ -> true
+  | Stackoffset _ -> false
+  | Load _ -> true
+  | Store _ -> false
+  | Intop _ -> true
+  | Intop_imm _ -> true
+  | Negf -> true
+  | Absf -> true
+  | Addf -> true
+  | Subf -> true
+  | Mulf -> true
+  | Divf -> true
+  | Compf _ -> true
+  | Floatofint -> true
+  | Intoffloat -> true
+  | Probe _ -> false
+  | Probe_is_enabled _ -> true
+  | Opaque -> false
+  | Begin_region -> false
+  | End_region -> false
+  | Specific s -> is_pure_specific s
+  | Name_for_debugger _ -> true
+
+let is_pure_basic : basic -> bool = function
+  | Op op -> is_pure_operation op
+  | Call _ -> false
+  | Reloadretaddr -> true
+  | Pushtrap _ -> true
+  | Poptrap -> true
+  | Prologue -> true
+
 let print_basic oc i =
   Format.kasprintf (Printf.fprintf oc "%s") "%a" dump_basic i
 
 let print_terminator oc ?sep ti =
   Format.kasprintf (Printf.fprintf oc "%s") "%a" (dump_terminator ?sep) ti
+
+let is_noop_move instr =
+  match instr.desc with
+  | Op (Move | Spill | Reload) -> Reg.same_loc instr.arg.(0) instr.res.(0)
+  | Op
+      ( Const_int _ | Const_float _ | Const_symbol _ | Stackoffset _ | Load _
+      | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf | Subf | Mulf
+      | Divf | Compf _ | Floatofint | Intoffloat | Probe _ | Opaque
+      | Probe_is_enabled _ | Specific _ | Name_for_debugger _ | Begin_region
+      | End_region )
+  | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
+    false

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -351,7 +351,7 @@ let is_pure_terminator desc =
 
 let is_pure_operation : operation -> bool = function
   | Move -> true
-  | Spill -> true
+  | Spill -> false
   | Reload -> true
   | Const_int _ -> true
   | Const_float _ -> true

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -403,3 +403,15 @@ let is_noop_move instr =
       | End_region )
   | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
     false
+
+let set_trap_depth (instr : _ instruction) trap_depth =
+  if instr.trap_depth = trap_depth then
+    instr
+  else
+    { instr with trap_depth; }
+
+let set_live (instr : _ instruction) live =
+  if Reg.Set.equal instr.live live then
+    instr
+  else
+    { instr with live; }

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -351,7 +351,7 @@ let is_pure_terminator desc =
 
 let is_pure_operation : operation -> bool = function
   | Move -> true
-  | Spill -> false
+  | Spill -> true
   | Reload -> true
   | Const_int _ -> true
   | Const_float _ -> true

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -405,13 +405,7 @@ let is_noop_move instr =
     false
 
 let set_trap_depth (instr : _ instruction) trap_depth =
-  if instr.trap_depth = trap_depth then
-    instr
-  else
-    { instr with trap_depth; }
+  if instr.trap_depth = trap_depth then instr else { instr with trap_depth }
 
 let set_live (instr : _ instruction) live =
-  if Reg.Set.equal instr.live live then
-    instr
-  else
-    { instr with live; }
+  if Reg.Set.equal instr.live live then instr else { instr with live }

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -349,26 +349,6 @@ let is_pure_terminator desc =
     (* CR gyorsh: fix for memory operands *)
     true
 
-let is_pure_specific : Arch.specific_operation -> bool = function
-  | Ilea _ -> true
-  | Istore_int _ -> false
-  | Ioffset_loc _ -> false
-  | Ifloatarithmem _ -> false
-  | Ibswap _ -> false
-  | Isqrtf -> false
-  | Ifloatsqrtf _ -> false
-  | Ifloat_iround -> true
-  | Ifloat_round _ -> true
-  | Ifloat_min -> true
-  | Ifloat_max -> true
-  | Isextend32 -> true
-  | Izextend32 -> true
-  | Irdtsc -> false
-  | Irdpmc -> false
-  | Icrc32q -> false
-  | Ipause -> false
-  | Iprefetch _ -> false
-
 let is_pure_operation : operation -> bool = function
   | Move -> true
   | Spill -> true
@@ -395,7 +375,7 @@ let is_pure_operation : operation -> bool = function
   | Opaque -> false
   | Begin_region -> false
   | End_region -> false
-  | Specific s -> is_pure_specific s
+  | Specific s -> Arch.is_pure_specific s
   | Name_for_debugger _ -> true
 
 let is_pure_basic : basic -> bool = function

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -154,3 +154,7 @@ val can_raise_basic : basic -> bool
 val can_raise_operation : operation -> bool
 
 val is_pure_terminator : terminator -> bool
+
+val is_pure_basic : basic -> bool
+
+val is_noop_move : basic instruction -> bool

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -158,3 +158,7 @@ val is_pure_terminator : terminator -> bool
 val is_pure_basic : basic -> bool
 
 val is_noop_move : basic instruction -> bool
+
+val set_trap_depth : 'a instruction -> int -> 'a instruction
+
+val set_live : 'a instruction -> Reg.Set.t -> 'a instruction

--- a/backend/cfg/cfg_dataflow.ml
+++ b/backend/cfg/cfg_dataflow.ml
@@ -152,10 +152,17 @@ end
 module type Backward_transfer = sig
   type domain
 
-  val basic : domain -> exn:domain -> Cfg.basic Cfg.instruction -> domain * Cfg.basic Cfg.instruction
+  val basic :
+    domain ->
+    exn:domain ->
+    Cfg.basic Cfg.instruction ->
+    domain * Cfg.basic Cfg.instruction
 
   val terminator :
-    domain -> exn:domain -> Cfg.terminator Cfg.instruction -> domain * Cfg.terminator Cfg.instruction
+    domain ->
+    exn:domain ->
+    Cfg.terminator Cfg.instruction ->
+    domain * Cfg.terminator Cfg.instruction
 
   val exception_ : domain -> domain
 end
@@ -195,11 +202,12 @@ module Backward
   module WorkSet = Set.Make (WorkSetElement)
 
   let transfer_block : domain -> exn:domain -> Cfg.basic_block -> domain =
-    fun value ~exn block ->
+   fun value ~exn block ->
     let value, terminator = T.terminator value ~exn block.terminator in
     block.terminator <- terminator;
     let value, body =
-      ListLabels.fold_right block.body ~init:(value, []) ~f:(fun instr (value, body) ->
+      ListLabels.fold_right block.body ~init:(value, [])
+        ~f:(fun instr (value, body) ->
           let value, instr = T.basic value ~exn instr in
           value, instr :: body)
     in

--- a/backend/cfg/cfg_dataflow.ml
+++ b/backend/cfg/cfg_dataflow.ml
@@ -2,7 +2,7 @@
 
 open! Int_replace_polymorphic_compare
 
-module type Domain = sig
+module type Forward_domain = sig
   type t
 
   val top : t
@@ -16,7 +16,7 @@ module type Domain = sig
   val to_string : t -> string
 end
 
-module type Transfer = sig
+module type Forward_transfer = sig
   type domain
 
   type t =
@@ -29,7 +29,7 @@ module type Transfer = sig
   val terminator : domain -> Cfg.terminator Cfg.instruction -> t
 end
 
-module type S = sig
+module type Forward_S = sig
   type domain
 
   type map = domain Label.Tbl.t
@@ -38,8 +38,10 @@ module type S = sig
     Cfg.t -> ?max_iteration:int -> ?init:domain -> unit -> (map, map) Result.t
 end
 
-module Forward (D : Domain) (T : Transfer with type domain = D.t) :
-  S with type domain = D.t = struct
+module Forward
+    (D : Forward_domain)
+    (T : Forward_transfer with type domain = D.t) :
+  Forward_S with type domain = D.t = struct
   type domain = D.t
 
   type transfer = T.t
@@ -130,5 +132,174 @@ module Forward (D : Domain) (T : Transfer with type domain = D.t) :
       update ~normal:true ~exn:false normal;
       update ~normal:false ~exn:true exceptional
     done;
-    if !iteration < max_iteration then Result.Ok res else Result.Error res
+    if WorkSet.is_empty !work_set then Result.Ok res else Result.Error res
+end
+
+module type Backward_domain = sig
+  type t
+
+  val bot : t
+
+  val compare : t -> t -> int
+
+  val join : t -> t -> t
+
+  val less_equal : t -> t -> bool
+
+  val to_string : t -> string
+end
+
+module type Backward_transfer = sig
+  type domain
+
+  val basic : domain -> exn:domain -> Cfg.basic Cfg.instruction -> domain
+
+  val terminator :
+    domain -> exn:domain -> Cfg.terminator Cfg.instruction -> domain
+
+  val exception_ : domain -> domain
+end
+
+module type Backward_S = sig
+  type domain
+
+  type map = domain Label.Tbl.t
+
+  val run :
+    Cfg.t -> ?max_iteration:int -> init:domain -> unit -> (map, map) Result.t
+end
+
+module Backward
+    (D : Backward_domain)
+    (T : Backward_transfer with type domain = D.t) :
+  Backward_S with type domain = D.t = struct
+  (* CR xclerc for xclerc: see what can be shared with `Forward`. *)
+
+  type domain = D.t
+
+  type map = domain Label.Tbl.t
+
+  module WorkSetElement = struct
+    type t =
+      { label : Label.t;
+        value : domain
+      }
+
+    let compare { label = left_label; value = left_value }
+        { label = right_label; value = right_value } =
+      match Label.compare left_label right_label with
+      | 0 -> D.compare left_value right_value
+      | res -> res
+  end
+
+  module WorkSet = Set.Make (WorkSetElement)
+
+  let transfer_block : domain -> exn:domain -> Cfg.basic_block -> domain =
+   fun value ~exn block ->
+    ListLabels.fold_right block.body
+      ~init:(T.terminator value ~exn block.terminator) ~f:(fun instr value ->
+        T.basic value ~exn instr)
+
+  let create : Cfg.t -> init:domain -> map * WorkSet.t ref =
+   fun cfg ~init ->
+    let map = Label.Tbl.create (Label.Tbl.length cfg.Cfg.blocks) in
+    let set = ref WorkSet.empty in
+    let value = init in
+    Cfg.iter_blocks cfg ~f:(fun label _block ->
+        Label.Tbl.replace map label value;
+        set := WorkSet.add { WorkSetElement.label; value } !set);
+    map, set
+
+  let remove_and_return :
+      Cfg.t -> WorkSet.t ref -> WorkSetElement.t * Cfg.basic_block =
+   fun cfg set ->
+    let element = WorkSet.choose !set in
+    set := WorkSet.remove element !set;
+    element, Cfg.get_block_exn cfg element.label
+
+  let run :
+      Cfg.t -> ?max_iteration:int -> init:domain -> unit -> (map, map) Result.t
+      =
+   fun cfg ?(max_iteration = max_int) ~init () ->
+    let res, work_set = create cfg ~init in
+    let iteration = ref 0 in
+    (* note: `handler_map` contains the value at the *start* of the block. *)
+    let handler_map : D.t Label.Tbl.t =
+      Label.Tbl.create (Label.Tbl.length cfg.Cfg.blocks)
+    in
+    while (not (WorkSet.is_empty !work_set)) && !iteration < max_iteration do
+      incr iteration;
+      let element, block = remove_and_return cfg work_set in
+      let exn : domain =
+        Option.map
+          (fun exceptional_successor ->
+            Label.Tbl.find_opt handler_map exceptional_successor)
+          block.exn
+        |> Option.join
+        |> Option.value ~default:D.bot
+      in
+      let value = transfer_block element.value ~exn block in
+      if block.is_trap_handler
+      then begin
+        let old_value =
+          Option.value
+            (Label.Tbl.find_opt handler_map block.start)
+            ~default:D.bot
+        in
+        let new_value = T.exception_ value in
+        if not (D.less_equal new_value old_value)
+        then begin
+          Label.Tbl.replace handler_map block.start new_value;
+          List.iter
+            (fun predecessor_label ->
+              let current_value =
+                Option.value
+                  (Label.Tbl.find_opt res predecessor_label)
+                  ~default:D.bot
+              in
+              work_set
+                := WorkSet.add
+                     { WorkSetElement.label = predecessor_label;
+                       value = current_value
+                     }
+                     !work_set)
+            (Cfg.predecessor_labels block)
+        end
+      end
+      else
+        List.iter
+          (fun predecessor_label ->
+            let old_value =
+              Option.value
+                (Label.Tbl.find_opt res predecessor_label)
+                ~default:D.bot
+            in
+            let new_value = D.join old_value value in
+            if not (D.less_equal new_value old_value)
+            then begin
+              Label.Tbl.replace res predecessor_label new_value;
+              let already_in_workset = ref false in
+              work_set
+                := WorkSet.filter
+                     (fun { WorkSetElement.label; value } ->
+                       if Label.equal label predecessor_label
+                       then begin
+                         if D.less_equal new_value value
+                         then already_in_workset := true;
+                         not (D.less_equal value new_value)
+                       end
+                       else true)
+                     !work_set;
+              if not !already_in_workset
+              then
+                work_set
+                  := WorkSet.add
+                       { WorkSetElement.label = predecessor_label;
+                         value = new_value
+                       }
+                       !work_set
+            end)
+          (Cfg.predecessor_labels block)
+    done;
+    if WorkSet.is_empty !work_set then Result.Ok res else Result.Error res
 end

--- a/backend/cfg/cfg_dataflow.mli
+++ b/backend/cfg/cfg_dataflow.mli
@@ -49,7 +49,9 @@ module type Forward_S = sig
     Cfg.t -> ?max_iteration:int -> ?init:domain -> unit -> (map, map) Result.t
 end
 
-module Forward (D : Forward_domain) (_ : Forward_transfer with type domain = D.t) :
+module Forward
+    (D : Forward_domain)
+    (_ : Forward_transfer with type domain = D.t) :
   Forward_S with type domain = D.t
 
 module type Backward_domain = sig
@@ -88,5 +90,7 @@ module type Backward_S = sig
     Cfg.t -> ?max_iteration:int -> init:domain -> unit -> (map, map) Result.t
 end
 
-module Backward (D : Backward_domain) (_ : Backward_transfer with type domain = D.t) :
+module Backward
+    (D : Backward_domain)
+    (_ : Backward_transfer with type domain = D.t) :
   Backward_S with type domain = D.t

--- a/backend/cfg/cfg_dataflow.mli
+++ b/backend/cfg/cfg_dataflow.mli
@@ -73,10 +73,10 @@ end
 module type Backward_transfer = sig
   type domain
 
-  val basic : domain -> exn:domain -> Cfg.basic Cfg.instruction -> domain
+  val basic : domain -> exn:domain -> Cfg.basic Cfg.instruction -> domain * Cfg.basic Cfg.instruction
 
   val terminator :
-    domain -> exn:domain -> Cfg.terminator Cfg.instruction -> domain
+    domain -> exn:domain -> Cfg.terminator Cfg.instruction -> domain * Cfg.terminator Cfg.instruction
 
   val exception_ : domain -> domain
 end

--- a/backend/cfg/cfg_dataflow.mli
+++ b/backend/cfg/cfg_dataflow.mli
@@ -73,10 +73,17 @@ end
 module type Backward_transfer = sig
   type domain
 
-  val basic : domain -> exn:domain -> Cfg.basic Cfg.instruction -> domain * Cfg.basic Cfg.instruction
+  val basic :
+    domain ->
+    exn:domain ->
+    Cfg.basic Cfg.instruction ->
+    domain * Cfg.basic Cfg.instruction
 
   val terminator :
-    domain -> exn:domain -> Cfg.terminator Cfg.instruction -> domain * Cfg.terminator Cfg.instruction
+    domain ->
+    exn:domain ->
+    Cfg.terminator Cfg.instruction ->
+    domain * Cfg.terminator Cfg.instruction
 
   val exception_ : domain -> domain
 end

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -554,7 +554,7 @@ let check_cfg : State.t -> Cfg.t -> Cfg.t -> unit =
   State.add_to_explore state expected.entry_label result.entry_label;
   explore_cfg state expected result
 
-let check_layout : State.t -> Label.t list -> Label.t list -> unit =
+let _check_layout : State.t -> Label.t list -> Label.t list -> unit =
  fun state expected result ->
   let expected_length = List.length expected in
   let result_length = List.length result in
@@ -579,9 +579,8 @@ let check_cfg_with_layout :
   try
     let state = State.make () in
     check_cfg state (Cfg_with_layout.cfg expected) (Cfg_with_layout.cfg result);
-    check_layout state
-      (Cfg_with_layout.layout expected)
-      (Cfg_with_layout.layout result);
+    (* CR xclerc for xclerc: re-enable check_layout state
+       (Cfg_with_layout.layout expected) (Cfg_with_layout.layout result); *)
     State.check state (Cfg_with_layout.cfg expected);
     let num_seen = State.num_seen state in
     if not

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -130,8 +130,8 @@ module S = struct
       res : Reg.t array;
       dbg : Debuginfo.t;
       fdo : Fdo_info.t;
-      live : Reg.Set.t;
-      trap_depth : int;
+      mutable live : Reg.Set.t;
+      mutable trap_depth : int;
       id : int
     }
 

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -130,8 +130,8 @@ module S = struct
       res : Reg.t array;
       dbg : Debuginfo.t;
       fdo : Fdo_info.t;
-      mutable live : Reg.Set.t;
-      mutable trap_depth : int;
+      live : Reg.Set.t;
+      trap_depth : int;
       id : int
     }
 

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -79,7 +79,7 @@ module Transfer = struct
     | Tailcall (Func _) ->
       Reg.set_of_array instr.arg, Cfg.set_live instr Reg.Set.empty
     | Call_no_return _ ->
-      Reg.add_set_array exn instr.arg, Cfg.set_live instr Reg.Set.empty
+      Reg.add_set_array exn instr.arg, Cfg.set_live instr exn
 
   let exception_ : domain -> domain =
    fun value -> Reg.Set.remove Proc.loc_exn_bucket value

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -32,12 +32,14 @@ module Transfer = struct
     match instr.desc with
     | Op _ | Call _ ->
       if Cfg.is_pure_basic instr.desc
-      && Reg.disjoint_set_array value instr.res
-      && not (Proc.regs_are_volatile instr.arg)
-      && not (Proc.regs_are_volatile instr.res) then begin
+         && Reg.disjoint_set_array value instr.res
+         && (not (Proc.regs_are_volatile instr.arg))
+         && not (Proc.regs_are_volatile instr.res)
+      then begin
         instr.live <- value;
         value
-      end else begin
+      end
+      else
         let across = Reg.diff_set_array value instr.res in
         let across =
           if Cfg.can_raise_basic instr.desc && instr.trap_depth > 1
@@ -46,7 +48,6 @@ module Transfer = struct
         in
         instr.live <- across;
         Reg.add_set_array across instr.arg
-      end
     | Reloadretaddr ->
       instr.live <- Reg.Set.empty;
       Reg.diff_set_array value Proc.destroyed_at_reloadretaddr

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -1,0 +1,106 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Domain = struct
+  type t = Reg.Set.t
+
+  let bot = Reg.Set.empty
+
+  let compare = Reg.Set.compare
+
+  let join = Reg.Set.union
+
+  let less_equal = Reg.Set.subset
+
+  let with_formatter ~f x =
+    let buff = Buffer.create 64 in
+    let fmt = Format.formatter_of_buffer buff in
+    f fmt x;
+    Format.pp_print_flush fmt ();
+    Buffer.contents buff
+
+  let to_string regset =
+    regset |> Reg.Set.elements
+    |> ListLabels.map ~f:(with_formatter ~f:Printmach.reg)
+    |> StringLabels.concat ~sep:", "
+end
+
+module Transfer = struct
+  type domain = Domain.t
+
+  let basic : domain -> exn:domain -> Cfg.basic Cfg.instruction -> domain =
+   fun value ~exn instr ->
+    match instr.desc with
+    | Op _ | Call _ ->
+      if Cfg.is_pure_basic instr.desc
+      && Reg.disjoint_set_array value instr.res
+      && not (Proc.regs_are_volatile instr.arg)
+      && not (Proc.regs_are_volatile instr.res) then begin
+        instr.live <- value;
+        value
+      end else begin
+        let across = Reg.diff_set_array value instr.res in
+        let across =
+          if Cfg.can_raise_basic instr.desc && instr.trap_depth > 1
+          then Reg.Set.union across exn
+          else across
+        in
+        instr.live <- across;
+        Reg.add_set_array across instr.arg
+      end
+    | Reloadretaddr ->
+      instr.live <- Reg.Set.empty;
+      Reg.diff_set_array value Proc.destroyed_at_reloadretaddr
+    | Pushtrap _ ->
+      instr.live <- Reg.Set.empty;
+      value
+    | Poptrap ->
+      instr.live <- Reg.Set.empty;
+      value
+    | Prologue ->
+      instr.live <- Reg.Set.empty;
+      value
+
+  let terminator :
+      domain -> exn:domain -> Cfg.terminator Cfg.instruction -> domain =
+   fun value ~exn instr ->
+    match instr.desc with
+    | Never -> assert false
+    | Always _ ->
+      instr.live <- value;
+      Reg.add_set_array value instr.arg
+    | Parity_test _ ->
+      instr.live <- value;
+      Reg.add_set_array value instr.arg
+    | Truth_test _ ->
+      instr.live <- value;
+      Reg.add_set_array value instr.arg
+    | Float_test _ ->
+      instr.live <- value;
+      Reg.add_set_array value instr.arg
+    | Int_test _ ->
+      instr.live <- value;
+      Reg.add_set_array value instr.arg
+    | Switch _ ->
+      instr.live <- value;
+      Reg.add_set_array value instr.arg
+    | Return ->
+      instr.live <- Reg.Set.empty;
+      Reg.set_of_array instr.arg
+    | Tailcall (Self _) ->
+      instr.live <- Reg.Set.empty;
+      Reg.set_of_array instr.arg
+    | Raise _ ->
+      instr.live <- exn;
+      Reg.add_set_array exn instr.arg
+    | Tailcall (Func _) ->
+      instr.live <- Reg.Set.empty;
+      Reg.set_of_array instr.arg
+    | Call_no_return _ ->
+      instr.live <- Reg.Set.empty;
+      Reg.add_set_array exn instr.arg
+
+  let exception_ : domain -> domain =
+   fun value -> Reg.Set.remove Proc.loc_exn_bucket value
+end
+
+module Liveness = Cfg_dataflow.Backward (Domain) (Transfer)

--- a/backend/cfg/cfg_liveness.mli
+++ b/backend/cfg/cfg_liveness.mli
@@ -1,0 +1,7 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Domain : Cfg_dataflow.Backward_domain with type t = Reg.Set.t
+
+module Transfer : Cfg_dataflow.Backward_transfer with type domain = Domain.t
+
+module Liveness : Cfg_dataflow.Backward_S with type domain = Domain.t

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -643,22 +643,22 @@ module Trap_depth_and_exn = struct
         false
       end
     in
-    block.trap_depth <- succ (List.length stack);
-    let stack, exceptional_successor, body =
-      ListLabels.fold_left block.body ~init:(stack, None, [])
-        ~f:(fun (stack, exceptional_successor, body) instr ->
-            let (stack, exceptional_successor), instr =
-              process_basic exceptional_successor stack instr
-            in
-            stack, exceptional_successor, instr :: body)
-    in
-    block.body <- List.rev body;
-    let (stack, exceptional_successor), terminator =
-      process_terminator exceptional_successor stack block.terminator
-    in
-    block.terminator <- terminator;
     if was_invalid
     then begin
+      block.trap_depth <- succ (List.length stack);
+      let stack, exceptional_successor, body =
+        ListLabels.fold_left block.body ~init:(stack, None, [])
+          ~f:(fun (stack, exceptional_successor, body) instr ->
+              let (stack, exceptional_successor), instr =
+                process_basic exceptional_successor stack instr
+              in
+              stack, exceptional_successor, instr :: body)
+      in
+      block.body <- List.rev body;
+      let (stack, exceptional_successor), terminator =
+        process_terminator exceptional_successor stack block.terminator
+      in
+      block.terminator <- terminator;
       (* non-exceptional successors *)
       Label.Set.iter
         (fun successor_label -> update_block cfg successor_label stack)

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -310,20 +310,6 @@ let copy_instruction_no_reg :
   let fdo = Fdo_info.none in
   { desc; arg; res; dbg; live; trap_depth; id; fdo }
 
-let is_noop_move (instr : Cfg.basic Cfg.instruction) : bool =
-  match instr.Cfg.desc with
-  | Op (Move | Spill | Reload) ->
-    (* CR xclerc for xclerc: is testing the location enough? *)
-    Reg.same_loc instr.Cfg.arg.(0) instr.Cfg.res.(0)
-  | Op
-      ( Const_int _ | Const_float _ | Const_symbol _ | Stackoffset _ | Load _
-      | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf | Subf | Mulf
-      | Divf | Compf _ | Floatofint | Intoffloat | Probe _ | Opaque
-      | Probe_is_enabled _ | Specific _ | Name_for_debugger _ | Begin_region
-      | End_region )
-  | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
-    false
-
 let rec get_end : Mach.instruction -> Mach.instruction =
  fun instr ->
   match instr.Mach.desc with
@@ -355,13 +341,14 @@ let extract_block_info : State.t -> Mach.instruction -> block_info =
       match basic_or_terminator_of_operation state op with
       | Basic desc ->
         let instr' = copy_instruction state instr ~desc in
-        if is_noop_move instr'
-        then loop instr.next acc
-        else
-          let acc = instr' :: acc in
-          if Cfg.can_raise_basic desc
-          then return None acc
-          else loop instr.next acc
+        (* note: useless moves (See `Cfg.is_noop_move`) are no longer removed
+           because we want to compute liveness information on CFG values, and
+           (i) such moves are necessary to compute the live sets and (ii) they
+           can only be identified as useless after register allocation. *)
+        let acc = instr' :: acc in
+        if Cfg.can_raise_basic desc
+        then return None acc
+        else loop instr.next acc
       | Terminator terminator ->
         return (Some (copy_instruction state instr ~desc:terminator)) acc
     end
@@ -606,6 +593,7 @@ module Trap_depth_and_exn = struct
       Cfg.terminator Cfg.instruction ->
       handler_stack * handler_option =
    fun exceptional_successor stack term ->
+    term.trap_depth <- succ (List.length stack);
     match term.desc with
     | Never | Return
     | Tailcall (Func _)
@@ -627,6 +615,7 @@ module Trap_depth_and_exn = struct
       Cfg.basic Cfg.instruction ->
       handler_stack * handler_option =
    fun exceptional_successor stack instr ->
+    instr.trap_depth <- succ (List.length stack);
     match instr.desc with
     | Pushtrap { lbl_handler } -> lbl_handler :: stack, exceptional_successor
     | Poptrap -> begin
@@ -643,17 +632,25 @@ module Trap_depth_and_exn = struct
   let rec update_block : Cfg.t -> Label.t -> handler_stack -> unit =
    fun cfg label stack ->
     let block = Cfg.get_block_exn cfg label in
-    if block.trap_depth = invalid_trap_depth
+    let was_invalid =
+      if block.trap_depth = invalid_trap_depth
+      then true
+      else begin
+        assert (block.trap_depth = succ (List.length stack));
+        false
+      end
+    in
+    block.trap_depth <- succ (List.length stack);
+    let stack, exceptional_successor =
+      ListLabels.fold_left block.body ~init:(stack, None)
+        ~f:(fun (stack, exceptional_successor) instr ->
+          process_basic exceptional_successor stack instr)
+    in
+    let stack, exceptional_successor =
+      process_terminator exceptional_successor stack block.terminator
+    in
+    if was_invalid
     then begin
-      block.trap_depth <- succ (List.length stack);
-      let stack, exceptional_successor =
-        ListLabels.fold_left block.body ~init:(stack, None)
-          ~f:(fun (stack, exceptional_successor) instr ->
-            process_basic exceptional_successor stack instr)
-      in
-      let stack, exceptional_successor =
-        process_terminator exceptional_successor stack block.terminator
-      in
       (* non-exceptional successors *)
       Label.Set.iter
         (fun successor_label -> update_block cfg successor_label stack)
@@ -665,7 +662,6 @@ module Trap_depth_and_exn = struct
           update_block cfg handler_label handler_stack)
         exceptional_successor
     end
-    else assert (block.trap_depth = succ (List.length stack))
 
   let update_cfg : Cfg.t -> unit =
    fun cfg -> update_block cfg cfg.entry_label []
@@ -758,7 +754,6 @@ let fundecl :
      integer test. This simplification should happen *after* the one about
      straightline blocks because merging blocks creates more opportunities for
      terminator simplification. *)
-  Eliminate_fallthrough_blocks.run cfg_with_layout;
   Merge_straightline_blocks.run cfg_with_layout;
   Eliminate_dead_code.run_dead_block cfg_with_layout;
   if simplify_terminators then Simplify_terminator.run cfg;

--- a/dune
+++ b/dune
@@ -220,6 +220,7 @@
   cfg_to_linear
   cfg_with_layout
   cfg_dataflow
+  cfg_liveness
   eliminate_dead_code
   disconnect_block
   eliminate_dead_blocks
@@ -602,6 +603,7 @@
   (cfg_to_linear.mli as compiler-libs/cfg_to_linear.mli)
   (cfg_with_layout.mli as compiler-libs/cfg_with_layout.mli)
   (cfg_dataflow.mli as compiler-libs/cfg_dataflow.mli)
+  (cfg_liveness.mli as compiler-libs/cfg_liveness.mli)
   (eliminate_dead_code.mli as compiler-libs/eliminate_dead_code.mli)
   (disconnect_block.mli as compiler-libs/disconnect_block.mli)
   (eliminate_dead_blocks.mli as compiler-libs/eliminate_dead_blocks.mli)
@@ -1007,6 +1009,18 @@
   (.ocamloptcomp.objs/byte/cfg_dataflow.cmti
    as
    compiler-libs/cfg_dataflow.cmti)
+  (.ocamloptcomp.objs/byte/cfg_liveness.cmi
+   as
+   compiler-libs/cfg_liveness.cmi)
+  (.ocamloptcomp.objs/byte/cfg_liveness.cmo
+   as
+   compiler-libs/cfg_liveness.cmo)
+  (.ocamloptcomp.objs/byte/cfg_liveness.cmt
+   as
+   compiler-libs/cfg_liveness.cmt)
+  (.ocamloptcomp.objs/byte/cfg_liveness.cmti
+   as
+   compiler-libs/cfg_liveness.cmti)
   (.ocamloptcomp.objs/byte/eliminate_dead_code.cmi
    as
    compiler-libs/eliminate_dead_code.cmi)
@@ -1225,6 +1239,9 @@
   (.ocamloptcomp.objs/native/cfg_dataflow.cmx
    as
    compiler-libs/cfg_dataflow.cmx)
+  (.ocamloptcomp.objs/native/cfg_liveness.cmx
+   as
+   compiler-libs/cfg_liveness.cmx)
   (.ocamloptcomp.objs/native/eliminate_dead_code.cmx
    as
    compiler-libs/eliminate_dead_code.cmx)


### PR DESCRIPTION
(I have unfortunately created a huge mess in https://github.com/ocaml-flambda/flambda-backend/pull/513, so here is
a clean version.)

This pull request basically augments the `Cfg_dataflow` module
with a backward analysis and then instantiates it to compute the
liveness on CFG values. The liveness information computed through
this new analysis is compared to the one from the existing pass.

This pull request is a draft because of the duplication introduced
with respect to the forward variant of the dataflow analysis.
Making the two converge is likely to spot shortcomings or even
mistakes in the forward variant.