### PR TITLE
Test naked pointer root handling

### DIFF
--- a/ocaml/testsuite/tests/runtime-naked-pointers/np4.ml
+++ b/ocaml/testsuite/tests/runtime-naked-pointers/np4.ml
@@ -11,3 +11,4 @@ open Np
    in naked pointers mode only *)
 
 let x = do_gc [ make_raw_pointer 0n; make_raw_pointer 42n ]
+let y = do_gc (make_raw_pointer 42n)


### PR DESCRIPTION
This patch adds a test for the fix in #541 , ensuring that naked-pointers modes accepts roots containing naked pointers. (The existing test tested only naked pointers inside heap blocks, not roots)