### PR TITLE
Data flow: do not enforce dependencies on mutually defined code IDs

### DIFF
--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -163,17 +163,16 @@ let record_lifted_constant_for_data_flow data_flow lifted_constant =
   in
   let being_defined =
     let bound_symbols = Lifted_constant.bound_symbols lifted_constant in
+    (* Note: We're not registering code IDs in the set, because we can actually
+       make the code bindings deleted individually. In particular, code IDs that
+       are only used in the newer_version_of field of another binding will be
+       deleted as expected. *)
     let symbols = Bound_symbols.being_defined bound_symbols in
-    let code_ids = Bound_symbols.code_being_defined bound_symbols in
     Name_occurrences.empty
     |> Symbol.Set.fold
          (fun symbol acc ->
            Name_occurrences.add_symbol acc symbol Name_mode.normal)
          symbols
-    |> Code_id.Set.fold
-         (fun code_id acc ->
-           Name_occurrences.add_code_id acc code_id Name_mode.normal)
-         code_ids
   in
   ListLabels.fold_left
     (LC.definitions lifted_constant)


### PR DESCRIPTION
This reflects the ability to make individual code bindings deleted during the rebuilding step.

This PR helps ensuring that code that has never gone through `Simplify` cannot end up in the final term.

Here is one example that was problematic (from the `Queue` module):
```ocaml
let rec aux c () = match c with
  | Nil -> Seq.Nil
  | Cons { content=x; next; } -> Seq.Cons (x, aux next)
```
Here simplifying the partial application of `aux` creates a new code ID (`aux_n0_partial_n1`), and a new set of closures that uses this code ID.
When the set of closures is simplified, a new version of the code ID is created (`aux_n0_partial_n2`), and we end up at toplevel with four lifted bindings: the closure symbol `aux_n0`, the specialised code ID `aux_n0_n3`, and both versions of the partial code stub. The only dependency to the old partial code ID is through the `newer_version_of` field of the new partial code ID, but because of that dependency `Lifted_constant_state` has to group all bindings together (otherwise we would get first the three other bindings together, then the old partial code ID binding; but this means that the new partial code ID is defined as the newer version of a code ID that isn't bound yet, and we don't want that to be allowed).

The property that all code in the result term must have gone through Simplify will become required in a subsequent PR for closure offsets.