### PR TITLE
Fix infinite loop in inlining report printer

### DIFF
--- a/middle_end/flambda2/simplify_shared/inlining_report.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_report.ml
@@ -593,8 +593,7 @@ module Inlining_tree = struct
       (fun (dbg, key) (v : item) ->
         match key, v with
         | Scope (Unknown, _), _ ->
-          print_title ~depth ~label:"Unknown" ~f:Format.pp_print_text ppf "";
-          print ~compilation_unit ppf ~depth:(depth + 1) t
+          print_title ~depth ~label:"Unknown" ~f:Format.pp_print_text ppf ""
         | Scope (Module, name), Scope t ->
           print_title ~depth ~label:"Module" ~f:Format.pp_print_text ppf name;
           print ~compilation_unit ppf ~depth:(depth + 1) t


### PR DESCRIPTION
Spotted on the opam package `regenerate`, which compiles its test files with `-inlining-report`.