### PR TITLE
Add two new methods to targetint for dwarf

### DIFF
--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -140,12 +140,15 @@ utils/target_system.cmx : \
     utils/target_system.cmi
 utils/target_system.cmi :
 utils/targetint.cmo : \
+    utils/numbers.cmi \
     utils/misc.cmi \
     utils/targetint.cmi
 utils/targetint.cmx : \
+    utils/numbers.cmx \
     utils/misc.cmx \
     utils/targetint.cmi
-utils/targetint.cmi :
+utils/targetint.cmi : \
+    utils/numbers.cmi
 utils/terminfo.cmo : \
     utils/terminfo.cmi
 utils/terminfo.cmx : \
@@ -340,6 +343,7 @@ parsing/lexer.cmo : \
     utils/misc.cmi \
     parsing/location.cmi \
     parsing/docstrings.cmi \
+    utils/clflags.cmi \
     parsing/lexer.cmi
 parsing/lexer.cmx : \
     utils/warnings.cmx \
@@ -347,6 +351,7 @@ parsing/lexer.cmx : \
     utils/misc.cmx \
     parsing/location.cmx \
     parsing/docstrings.cmx \
+    utils/clflags.cmx \
     parsing/lexer.cmi
 parsing/lexer.cmi : \
     parsing/parser.cmi \
@@ -522,6 +527,7 @@ typing/ctype.cmo : \
     typing/types.cmi \
     typing/type_immediacy.cmi \
     typing/subst.cmi \
+    typing/primitive.cmi \
     typing/predef.cmi \
     typing/path.cmi \
     utils/misc.cmi \
@@ -538,6 +544,7 @@ typing/ctype.cmx : \
     typing/types.cmx \
     typing/type_immediacy.cmx \
     typing/subst.cmx \
+    typing/primitive.cmx \
     typing/predef.cmx \
     typing/path.cmx \
     utils/misc.cmx \
@@ -553,6 +560,7 @@ typing/ctype.cmx : \
 typing/ctype.cmi : \
     typing/types.cmi \
     typing/type_immediacy.cmi \
+    typing/primitive.cmi \
     typing/path.cmi \
     parsing/longident.cmi \
     typing/ident.cmi \
@@ -690,6 +698,7 @@ typing/includecore.cmo : \
     typing/typedtree.cmi \
     typing/type_immediacy.cmi \
     typing/printtyp.cmi \
+    typing/primitive.cmi \
     typing/path.cmi \
     typing/ident.cmi \
     typing/env.cmi \
@@ -703,6 +712,7 @@ typing/includecore.cmx : \
     typing/typedtree.cmx \
     typing/type_immediacy.cmx \
     typing/printtyp.cmx \
+    typing/primitive.cmx \
     typing/path.cmx \
     typing/ident.cmx \
     typing/env.cmx \
@@ -1051,6 +1061,7 @@ typing/printtyped.cmo : \
     parsing/location.cmi \
     typing/ident.cmi \
     utils/clflags.cmi \
+    typing/btype.cmi \
     parsing/asttypes.cmi \
     typing/printtyped.cmi
 typing/printtyped.cmx : \
@@ -1063,6 +1074,7 @@ typing/printtyped.cmx : \
     parsing/location.cmx \
     typing/ident.cmx \
     utils/clflags.cmx \
+    typing/btype.cmx \
     parsing/asttypes.cmi \
     typing/printtyped.cmi
 typing/printtyped.cmi : \
@@ -1260,6 +1272,7 @@ typing/typecore.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/local_store.cmi \
     typing/ident.cmi \
     parsing/extensions.cmi \
     typing/env.cmi \
@@ -1291,6 +1304,7 @@ typing/typecore.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    utils/local_store.cmx \
     typing/ident.cmx \
     parsing/extensions.cmx \
     typing/env.cmx \
@@ -1313,6 +1327,7 @@ typing/typecore.cmi : \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/clflags.cmi \
+    typing/btype.cmi \
     parsing/asttypes.cmi
 typing/typedecl.cmo : \
     utils/warnings.cmi \
@@ -1562,6 +1577,7 @@ typing/typemod.cmo : \
     utils/load_path.cmi \
     typing/includemod.cmi \
     typing/ident.cmi \
+    typing/envaux.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/config.cmi \
@@ -1594,6 +1610,7 @@ typing/typemod.cmx : \
     utils/load_path.cmx \
     typing/includemod.cmx \
     typing/ident.cmx \
+    typing/envaux.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/config.cmx \
@@ -2369,7 +2386,6 @@ asmcomp/cmm_helpers.cmo : \
     asmcomp/strmatch.cmi \
     asmcomp/proc.cmi \
     typing/primitive.cmi \
-    utils/numbers.cmi \
     utils/misc.cmi \
     lambda/lambda.cmi \
     lambda/debuginfo.cmi \
@@ -2392,7 +2408,6 @@ asmcomp/cmm_helpers.cmx : \
     asmcomp/strmatch.cmx \
     asmcomp/proc.cmx \
     typing/primitive.cmx \
-    utils/numbers.cmx \
     utils/misc.cmx \
     lambda/lambda.cmx \
     lambda/debuginfo.cmx \
@@ -2501,6 +2516,7 @@ asmcomp/coloring.cmi :
 asmcomp/comballoc.cmo : \
     asmcomp/reg.cmi \
     asmcomp/mach.cmi \
+    lambda/lambda.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
     asmcomp/arch.cmo \
@@ -2508,6 +2524,7 @@ asmcomp/comballoc.cmo : \
 asmcomp/comballoc.cmx : \
     asmcomp/reg.cmx \
     asmcomp/mach.cmx \
+    lambda/lambda.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
     asmcomp/arch.cmx \
@@ -3162,6 +3179,7 @@ middle_end/compilenv.cmi : \
     middle_end/flambda/simple_value_approx.cmi \
     middle_end/flambda/base_types/set_of_closures_id.cmi \
     middle_end/linkage_name.cmi \
+    lambda/lambda.cmi \
     typing/ident.cmi \
     middle_end/flambda/export_info.cmi \
     middle_end/compilation_unit.cmi \
@@ -3240,9 +3258,11 @@ middle_end/printclambda_primitives.cmx : \
 middle_end/printclambda_primitives.cmi : \
     middle_end/clambda_primitives.cmi
 middle_end/semantics_of_primitives.cmo : \
+    lambda/lambda.cmi \
     middle_end/clambda_primitives.cmi \
     middle_end/semantics_of_primitives.cmi
 middle_end/semantics_of_primitives.cmx : \
+    lambda/lambda.cmx \
     middle_end/clambda_primitives.cmx \
     middle_end/semantics_of_primitives.cmi
 middle_end/semantics_of_primitives.cmi : \
@@ -3556,6 +3576,7 @@ lambda/translcore.cmo : \
     typing/ident.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
+    typing/ctype.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
     typing/btype.cmi \
@@ -3584,12 +3605,14 @@ lambda/translcore.cmx : \
     typing/ident.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \
+    typing/ctype.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
     typing/btype.cmx \
     parsing/asttypes.cmi \
     lambda/translcore.cmi
 lambda/translcore.cmi : \
+    typing/types.cmi \
     typing/typedtree.cmi \
     typing/path.cmi \
     parsing/location.cmi \
@@ -3654,6 +3677,7 @@ lambda/translobj.cmo : \
     lambda/lambda.cmi \
     typing/ident.cmi \
     typing/env.cmi \
+    lambda/debuginfo.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
     typing/btype.cmi \
@@ -3665,6 +3689,7 @@ lambda/translobj.cmx : \
     lambda/lambda.cmx \
     typing/ident.cmx \
     typing/env.cmx \
+    lambda/debuginfo.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
     typing/btype.cmx \
@@ -3681,7 +3706,6 @@ lambda/translprim.cmo : \
     typing/primitive.cmi \
     typing/predef.cmi \
     typing/path.cmi \
-    utils/misc.cmi \
     lambda/matching.cmi \
     parsing/location.cmi \
     lambda/lambda.cmi \
@@ -3699,7 +3723,6 @@ lambda/translprim.cmx : \
     typing/primitive.cmx \
     typing/predef.cmx \
     typing/path.cmx \
-    utils/misc.cmx \
     lambda/matching.cmx \
     parsing/location.cmx \
     lambda/lambda.cmx \
@@ -3773,6 +3796,7 @@ file_formats/cmt_format.cmi : \
     file_formats/cmi_format.cmi
 file_formats/cmx_format.cmi : \
     utils/misc.cmi \
+    lambda/lambda.cmi \
     middle_end/flambda/export_info.cmi \
     middle_end/clambda.cmi
 file_formats/cmxs_format.cmi : \
@@ -3910,6 +3934,7 @@ middle_end/flambda/augment_specialised_args.cmo : \
     middle_end/flambda/pass_wrapper.cmi \
     middle_end/flambda/parameter.cmi \
     utils/misc.cmi \
+    lambda/lambda.cmi \
     middle_end/internal_variable_names.cmi \
     utils/int_replace_polymorphic_compare.cmi \
     middle_end/flambda/inlining_cost.cmi \
@@ -3929,6 +3954,7 @@ middle_end/flambda/augment_specialised_args.cmx : \
     middle_end/flambda/pass_wrapper.cmx \
     middle_end/flambda/parameter.cmx \
     utils/misc.cmx \
+    lambda/lambda.cmx \
     middle_end/internal_variable_names.cmx \
     utils/int_replace_polymorphic_compare.cmx \
     middle_end/flambda/inlining_cost.cmx \
@@ -4573,6 +4599,7 @@ middle_end/flambda/flambda_utils.cmi : \
     middle_end/flambda/base_types/set_of_closures_id.cmi \
     middle_end/flambda/projection.cmi \
     middle_end/flambda/parameter.cmi \
+    lambda/lambda.cmi \
     middle_end/internal_variable_names.cmi \
     middle_end/flambda/flambda.cmi \
     middle_end/flambda/base_types/closure_id.cmi
@@ -4711,6 +4738,7 @@ middle_end/flambda/inline_and_simplify.cmo : \
     middle_end/flambda/base_types/static_exception.cmi \
     middle_end/flambda/simplify_primitives.cmi \
     middle_end/flambda/simple_value_approx.cmi \
+    middle_end/semantics_of_primitives.cmi \
     middle_end/flambda/remove_unused_arguments.cmi \
     middle_end/flambda/remove_free_vars_equal_to_args.cmi \
     middle_end/flambda/projection.cmi \
@@ -4754,6 +4782,7 @@ middle_end/flambda/inline_and_simplify.cmx : \
     middle_end/flambda/base_types/static_exception.cmx \
     middle_end/flambda/simplify_primitives.cmx \
     middle_end/flambda/simple_value_approx.cmx \
+    middle_end/semantics_of_primitives.cmx \
     middle_end/flambda/remove_unused_arguments.cmx \
     middle_end/flambda/remove_free_vars_equal_to_args.cmx \
     middle_end/flambda/projection.cmx \
@@ -5128,16 +5157,19 @@ middle_end/flambda/lift_let_to_initialize_symbol.cmi : \
     middle_end/backend_intf.cmi
 middle_end/flambda/parameter.cmo : \
     middle_end/variable.cmi \
+    lambda/lambda.cmi \
     utils/int_replace_polymorphic_compare.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/parameter.cmi
 middle_end/flambda/parameter.cmx : \
     middle_end/variable.cmx \
+    lambda/lambda.cmx \
     utils/int_replace_polymorphic_compare.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/parameter.cmi
 middle_end/flambda/parameter.cmi : \
     middle_end/variable.cmi \
+    lambda/lambda.cmi \
     utils/identifiable.cmi \
     middle_end/compilation_unit.cmi
 middle_end/flambda/pass_wrapper.cmo : \

--- a/ocaml/utils/targetint.ml
+++ b/ocaml/utils/targetint.ml
@@ -102,3 +102,11 @@ include (val
            | 64 -> (module Int64)
            | _ -> assert false
           ) : S)
+
+let size_in_bytes_as_targetint =
+  match size with 32 -> of_int32 4l | 64 -> of_int64 8L | _ -> assert false
+
+let to_uint64_exn t =
+  match repr t with
+  | Int32 t -> Numbers.Uint64.of_nonnegative_int32_exn t
+  | Int64 t -> Numbers.Uint64.of_nonnegative_int64_exn t

--- a/ocaml/utils/targetint.ml
+++ b/ocaml/utils/targetint.ml
@@ -106,7 +106,8 @@ include (val
 let size_in_bytes_as_targetint =
   match size with 32 -> of_int32 4l | 64 -> of_int64 8L | _ -> assert false
 
-let to_uint64_exn t =
+let nonnegative_to_uint64_exn t =
   match repr t with
   | Int32 t -> Numbers.Uint64.of_nonnegative_int32_exn t
   | Int64 t -> Numbers.Uint64.of_nonnegative_int64_exn t
+  

--- a/ocaml/utils/targetint.mli
+++ b/ocaml/utils/targetint.mli
@@ -205,3 +205,9 @@ val repr : t -> repr
 
 val print : Format.formatter -> t -> unit
 (** Print a target integer to a formatter. *)
+
+val size_in_bytes_as_targetint : t
+(** The width of a target integer in bytes, expressed as a value of type [t]. *)
+
+val to_uint64_exn : t -> Numbers.Uint64.t
+(** Convert the given target integer to an unsigned 64-bit integer. *)

--- a/ocaml/utils/targetint.mli
+++ b/ocaml/utils/targetint.mli
@@ -209,5 +209,5 @@ val print : Format.formatter -> t -> unit
 val size_in_bytes_as_targetint : t
 (** The width of a target integer in bytes, expressed as a value of type [t]. *)
 
-val to_uint64_exn : t -> Numbers.Uint64.t
-(** Convert the given target integer to an unsigned 64-bit integer. *)
+val nonnegative_to_uint64_exn : t -> Numbers.Uint64.t
+(** Convert the non-negative given target integer to an unsigned 64-bit integer. *)


### PR DESCRIPTION
Prerequisite for gdb support.

Add two new methods to `ocaml/utils/targetint.ml`