### PR TITLE
Inlined boxes

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -485,7 +485,7 @@ let unary_primitive env res dbg f arg =
     in
     extra, res, C.unbox_number ~dbg kind arg
   | Box_number (kind, alloc_mode) ->
-    None, res, C.box_number ~dbg kind alloc_mode arg
+    Some Env.Box, res, C.box_number ~dbg kind alloc_mode arg
   | Select_closure { move_from = c1; move_to = c2 } -> begin
     match Env.closure_offset env c1, Env.closure_offset env c2 with
     | Id_slot { offset = c1_offset; _ }, Id_slot { offset = c2_offset; _ } ->
@@ -1330,7 +1330,7 @@ and switch env res s =
     match Targetint_31_63.Map.cardinal arms with
     | 2 -> begin
       match match_var_with_extra_info env scrutinee with
-      | None -> e, false
+      | None | Some Box -> e, false
       | Some (Untag e') ->
         let size_e = cmm_arith_size e in
         let size_e' = cmm_arith_size e' in

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -1143,24 +1143,25 @@ and wrap_call_exn env e call k_exn =
 and wrap_cont env res effs call e =
   match Apply_expr.continuation e with
   | Never_returns ->
-    let wrap, _ = Env.flush_delayed_lets env in
+    let wrap, _ = Env.flush_delayed_lets ~before_call:true env in
     wrap call, res
   | Return k when Continuation.equal (Env.return_cont env) k ->
-    let wrap, _ = Env.flush_delayed_lets env in
+    let wrap, _ = Env.flush_delayed_lets ~before_call:true env in
     wrap call, res
   | Return k -> begin
     match Env.get_k env k with
     | Jump { types = []; cont } ->
-      let wrap, _ = Env.flush_delayed_lets env in
+      let wrap, _ = Env.flush_delayed_lets ~before_call:true env in
       wrap (C.sequence call (C.cexit cont [] [])), res
     | Jump { types = [_]; cont } ->
-      let wrap, _ = Env.flush_delayed_lets env in
+      let wrap, _ = Env.flush_delayed_lets ~before_call:true env in
       wrap (C.cexit cont [call] []), res
     | Inline
         { handler_params = [];
           handler_body = body;
           handler_params_occurrences = _
         } ->
+      let wrap, env = Env.flush_delayed_lets ~before_call:true env in
       let var = Variable.create "*apply_res*" in
       let num_normal_occurrences_of_bound_vars =
         Variable.Map.singleton var Num_occurrences.Zero
@@ -1168,19 +1169,22 @@ and wrap_cont env res effs call e =
       let env =
         let_expr_bind env var ~num_normal_occurrences_of_bound_vars call effs
       in
-      expr env res body
+      let cmm, res = expr env res body in
+      wrap cmm, res
     | Inline
         { handler_params = [param];
           handler_body = body;
           handler_params_occurrences
         } ->
+      let wrap, env = Env.flush_delayed_lets ~before_call:true env in
       let var = Bound_parameter.var param in
       let env =
         let_expr_bind env var
           ~num_normal_occurrences_of_bound_vars:handler_params_occurrences call
           effs
       in
-      expr env res body
+      let cmm, res = expr env res body in
+      wrap cmm, res
     | Jump _ | Inline _ ->
       (* TODO: add support using unboxed tuples *)
       Misc.fatal_errorf

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -137,8 +137,7 @@ type t =
        handlers *)
     pures : binding Variable.Map.t;
     (* pure bindings that can be inlined across stages. *)
-    stages : stage list
-    (* archived stages, in reverse chronological order. *)
+    stages : stage list (* archived stages, in reverse chronological order. *)
   }
 
 let mk offsets functions_info k_return ~exn_continuation:k_exn =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -369,7 +369,7 @@ let is_inlinable_box effs ~extra =
      this involves moving the arguments, so they must be pure (or at most
      generative). *)
   match (effs : Effects_and_coeffects.t), (extra : extra_info option) with
-  | (Only_generative_effects _, No_coeffects), Some Box -> true
+  | ((No_effects | Only_generative_effects _), No_coeffects), Some Box -> true
   | _, _ -> false
 
 let mk_binding ?extra env inline effs var cmm_expr =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -390,8 +390,9 @@ let mk_binding ?extra env inline effs var cmm_expr =
 let bind_pure env var b = { env with pures = Variable.Map.add var b env.pures }
 
 let bind_inlined_box env var b =
-  (* CR lmaurer: This violates the rule about moving allocations past function
-     calls. We should either fix it (not clear how) or be rid of that rule. *)
+  (* CR lmaurer: This violates our rule about not moving allocations past
+     function calls. We should either fix it (not clear how) or be rid of that
+     rule. *)
   bind_pure env var b
 
 let bind_eff env var b = { env with stages = Eff (var, b) :: env.stages }

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -127,7 +127,10 @@ val inline_variable :
 (** Wrap the given cmm expression with all the delayed let bindings accumulated
     in the environment. *)
 val flush_delayed_lets :
-  ?entering_loop:bool -> t -> (Cmm.expression -> Cmm.expression) * t
+  ?entering_loop:bool ->
+  ?before_call:bool ->
+  t ->
+  (Cmm.expression -> Cmm.expression) * t
 
 (** Fetch the extra info for a flambda variable (if any). *)
 val extra_info : t -> Variable.t -> extra_info option

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -127,10 +127,7 @@ val inline_variable :
 (** Wrap the given cmm expression with all the delayed let bindings accumulated
     in the environment. *)
 val flush_delayed_lets :
-  ?entering_loop:bool ->
-  ?before_call:bool ->
-  t ->
-  (Cmm.expression -> Cmm.expression) * t
+  ?entering_loop:bool -> t -> (Cmm.expression -> Cmm.expression) * t
 
 (** Fetch the extra info for a flambda variable (if any). *)
 val extra_info : t -> Variable.t -> extra_info option

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -89,6 +89,7 @@ type extra_info =
   | Untag of Cmm.expression
       (** The variable is bound to the result of untagging the cmm expression.
           This allows to have access to the cmm expression before untagging. *)
+  | Box  (** The variable is bound to a number being boxed. *)
 
 (** Create (and bind) a cmm variable for the given flambda variable, and return
     the new environment, and the created variable. Will fail (i.e. assertion


### PR DESCRIPTION
When generating cmm for `Box_number`, inline the variable if it's used exactly once. This fixes some cases of allocations that are used in only one branch of a switch getting allocated outside of the switch.