### PR TITLE
Elide inlining history when printing flambda2 terms

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -37,6 +37,9 @@ let mk_heap_reduction_threshold f =
     Flambda_backend_flags.default_heap_reduction_threshold
 ;;
 
+let mk_dump_inlining_paths f =
+  "-dump-inlining-paths", Arg.Unit f, " Dump inlining paths when dumping flambda2 terms"
+
 module Flambda2 = Flambda_backend_flags.Flambda2
 
 let mk_flambda2_result_types_functors_only f =
@@ -382,6 +385,7 @@ let mk_dfreshen f =
 module type Flambda_backend_options = sig
   val ocamlcfg : unit -> unit
   val no_ocamlcfg : unit -> unit
+  val dump_inlining_paths : unit -> unit
   val dcfg : unit -> unit
 
   val use_cpp_mangling : unit -> unit
@@ -444,6 +448,7 @@ end
 module Make_flambda_backend_options (F : Flambda_backend_options) =
 struct
   let list2 = [
+    mk_dump_inlining_paths F.dump_inlining_paths;
     mk_ocamlcfg F.ocamlcfg;
     mk_no_ocamlcfg F.no_ocamlcfg;
     mk_dcfg F.dcfg;
@@ -542,6 +547,8 @@ module Flambda_backend_options_impl = struct
   let ocamlcfg = set' Flambda_backend_flags.use_ocamlcfg
   let no_ocamlcfg = clear' Flambda_backend_flags.use_ocamlcfg
   let dcfg = set' Flambda_backend_flags.dump_cfg
+
+  let dump_inlining_paths = set' Flambda_backend_flags.dump_inlining_paths
 
   let use_cpp_mangling = set' Flambda_backend_flags.use_cpp_mangling
 
@@ -701,6 +708,7 @@ module Extra_params = struct
     in
     match name with
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
+    | "dump-inlining-paths" -> set' Flambda_backend_flags.dump_inlining_paths
     | "use-cpp-mangling" -> set' Flambda_backend_flags.use_cpp_mangling
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
     | "flambda2-join-points" -> set Flambda2.join_points

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -22,6 +22,7 @@
 module type Flambda_backend_options = sig
   val ocamlcfg : unit -> unit
   val no_ocamlcfg : unit -> unit
+  val dump_inlining_paths : unit -> unit
   val dcfg : unit -> unit
 
   val use_cpp_mangling : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -25,6 +25,8 @@ type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3
 type 'a or_default = Set of 'a | Default
 
+let dump_inlining_paths = ref false
+
 let opt_level = ref Default
 
 let flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3 =

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -26,6 +26,8 @@ type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3
 type 'a or_default = Set of 'a | Default
 
+val dump_inlining_paths : bool ref
+
 val opt_level : opt_level or_default ref
 
 module Flambda2 : sig

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -72,15 +72,14 @@ type t =
 
 let [@ocamlformat "disable"] print ppf
     { callee; continuation; exn_continuation; args; call_kind;
-      dbg; inlined; inlining_state; probe_name; relative_history } =
+      dbg; inlined; inlining_state; probe_name; relative_history=_ } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(%a\u{3008}%a\u{3009}\u{300a}%a\u{300b}@ (%a))@]@ \
       @[<hov 1>(call_kind@ %a)@]@ \
       @[<hov 1>@<0>%s(dbg@ %a)@<0>%s@]@ \
       @[<hov 1>(inline@ %a)@]@ \
       @[<hov 1>(inlining_state@ %a)@]@ \
-      @[<hov 1>(probe_name@ %a)@]@ \
-      @[<hov 1>(relative_history@ %a)@]\
+      @[<hov 1>(probe_name@ %a)@]\
       )@]"
     Simple.print callee
     Result_continuation.print continuation
@@ -97,7 +96,6 @@ let [@ocamlformat "disable"] print ppf
       | None -> Format.pp_print_string ppf "()"
       | Some probe_name -> Format.pp_print_string ppf probe_name)
     probe_name
-    Inlining_history.Relative.print relative_history
 
 let invariant
     ({ callee;

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -70,15 +70,21 @@ type t =
     relative_history : Inlining_history.Relative.t
   }
 
+let [@ocamlformat "disable"] print_inlining_paths ppf relative_history =
+  if !Flambda_backend_flags.dump_inlining_paths then
+    Format.fprintf ppf "@[<hov 1>(relative_history@ %a)@]@ "
+      Inlining_history.Relative.print relative_history
+
 let [@ocamlformat "disable"] print ppf
     { callee; continuation; exn_continuation; args; call_kind;
-      dbg; inlined; inlining_state; probe_name; relative_history=_ } =
+      dbg; inlined; inlining_state; probe_name; relative_history } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(%a\u{3008}%a\u{3009}\u{300a}%a\u{300b}@ (%a))@]@ \
       @[<hov 1>(call_kind@ %a)@]@ \
       @[<hov 1>@<0>%s(dbg@ %a)@<0>%s@]@ \
       @[<hov 1>(inline@ %a)@]@ \
       @[<hov 1>(inlining_state@ %a)@]@ \
+      %a
       @[<hov 1>(probe_name@ %a)@]\
       )@]"
     Simple.print callee
@@ -91,6 +97,7 @@ let [@ocamlformat "disable"] print ppf
     (Flambda_colours.normal ())
     Inlined_attribute.print inlined
     Inlining_state.print inlining_state
+    print_inlining_paths relative_history
     (fun ppf probe_name ->
       match probe_name with
       | None -> Format.pp_print_string ppf "()"

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -142,13 +142,22 @@ module Option = struct
     | Some contents -> Format.fprintf ppf "%a" print_contents contents
 end
 
+let [@ocamlformat "disable"] print_inlining_paths ppf
+                                (relative_history, absolute_history) =
+  if !Flambda_backend_flags.dump_inlining_paths then
+    Format.fprintf ppf
+      "@[<hov 1>(relative_history@ %a)@]@ \
+       @[<hov 1>(absolute_history@ %a)@]@ "
+      Inlining_history.Relative.print relative_history
+      Inlining_history.Absolute.print absolute_history
+
 let [@ocamlformat "disable"] print ppf
       { code_id = _; newer_version_of; stub; inline; is_a_functor;
         params_arity; num_trailing_local_params; result_arity;
         result_types; contains_no_escaping_local_allocs;
         recursive; cost_metrics; inlining_arguments;
         dbg; is_tupled; is_my_closure_used; inlining_decision;
-        absolute_history=_; relative_history=_} =
+        absolute_history; relative_history} =
   let module C = Flambda_colours in
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>@<0>%s(newer_version_of@ %a)@<0>%s@]@ \
@@ -166,6 +175,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>@<0>%s(dbg@ %a)@<0>%s@]@ \
       @[<hov 1>@<0>%s(is_tupled@ %b)@<0>%s@]@ \
       @[<hov 1>(is_my_closure_used@ %b)@]@ \
+      %a
       @[<hov 1>(inlining_decision@ %a)@]\
       )@]"
     (if Option.is_none newer_version_of then Flambda_colours.elide ()
@@ -220,6 +230,7 @@ let [@ocamlformat "disable"] print ppf
     is_tupled
     (Flambda_colours.normal ())
     is_my_closure_used
+    print_inlining_paths (relative_history, absolute_history)
     Function_decl_inlining_decision_type.print inlining_decision
 
 let free_names

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -147,7 +147,8 @@ let [@ocamlformat "disable"] print ppf
         params_arity; num_trailing_local_params; result_arity;
         result_types; contains_no_escaping_local_allocs;
         recursive; cost_metrics; inlining_arguments;
-        dbg; is_tupled; is_my_closure_used; inlining_decision; absolute_history; relative_history} =
+        dbg; is_tupled; is_my_closure_used; inlining_decision;
+        absolute_history=_; relative_history=_} =
   let module C = Flambda_colours in
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>@<0>%s(newer_version_of@ %a)@<0>%s@]@ \
@@ -165,9 +166,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>@<0>%s(dbg@ %a)@<0>%s@]@ \
       @[<hov 1>@<0>%s(is_tupled@ %b)@<0>%s@]@ \
       @[<hov 1>(is_my_closure_used@ %b)@]@ \
-      @[<hov 1>(inlining_decision@ %a)@]@ \
-      @[<hov 1>(absolute_history@ %a)@]@ \
-      @[<hov 1>(relative_history@ %a)@]\
+      @[<hov 1>(inlining_decision@ %a)@]\
       )@]"
     (if Option.is_none newer_version_of then Flambda_colours.elide ()
     else Flambda_colours.normal ())
@@ -222,8 +221,6 @@ let [@ocamlformat "disable"] print ppf
     (Flambda_colours.normal ())
     is_my_closure_used
     Function_decl_inlining_decision_type.print inlining_decision
-    Inlining_history.Absolute.print absolute_history
-    Inlining_history.Relative.print relative_history
 
 let free_names
     { code_id = _;


### PR DESCRIPTION
On big programs inlining histories can grow big in size will render the output of `-dflambda` ineligible. This PR prevents inlining histories from being printed. 