### PR TITLE
Fix duplicate lifted constants for code of lifted sets of closures

### DIFF
--- a/middle_end/flambda2/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/downwards_acc.ml
@@ -103,7 +103,7 @@ let continuation_uses_env t = t.continuation_uses_env
 
 let code_age_relation t = TE.code_age_relation (DE.typing_env (denv t))
 
-let with_code_age_relation t code_age_relation =
+let with_code_age_relation t ~code_age_relation =
   let typing_env =
     TE.with_code_age_relation (DE.typing_env (denv t)) code_age_relation
   in

--- a/middle_end/flambda2/simplify/env/downwards_acc.mli
+++ b/middle_end/flambda2/simplify/env/downwards_acc.mli
@@ -53,7 +53,7 @@ val demoted_exn_handlers : t -> Continuation.Set.t
 
 val code_age_relation : t -> Code_age_relation.t
 
-val with_code_age_relation : t -> Code_age_relation.t -> t
+val with_code_age_relation : t -> code_age_relation:Code_age_relation.t -> t
 
 val typing_env : t -> Flambda2_types.Typing_env.t
 

--- a/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
@@ -109,6 +109,7 @@ let all_defined_symbols t =
       LC.all_defined_symbols const |> Symbol.Set.union symbols)
 
 let add_to_denv ?maybe_already_defined denv lifted =
+  let initial_denv = denv in
   let maybe_already_defined =
     match maybe_already_defined with None -> false | Some () -> true
   in
@@ -128,7 +129,7 @@ let add_to_denv ?maybe_already_defined denv lifted =
         let types_of_symbols = LC.types_of_symbols lifted_constant in
         Symbol.Map.fold
           (fun sym (denv_at_definition, typ) typing_env ->
-            if maybe_already_defined && DE.mem_symbol denv sym
+            if maybe_already_defined && DE.mem_symbol initial_denv sym
             then typing_env
             else
               let sym = Name.symbol sym in

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -362,6 +362,8 @@ module Group = struct
 
   let fold_left t ~init ~f = ListLabels.fold_left t.consts ~init ~f
 
+  let add const t = { consts = const :: t.consts; free_names = Unknown }
+
   let concat t1 t2 =
     let free_names : _ Or_unknown.t =
       match t1.free_names, t2.free_names with

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -147,5 +147,7 @@ module Group : sig
       intermediate lists. *)
   val to_list : t -> rebuilt_static_const list
 
+  val add : rebuilt_static_const -> t -> t
+
   val concat : t -> t -> t
 end

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -1245,24 +1245,17 @@ let simplify_lifted_set_of_closures0 context ~closure_symbols
       ~closure_bound_names_inside ~value_slots ~value_slot_types
   in
   let dacc = introduce_code dacc code in
-  let code_patterns =
-    Code_id.Lmap.keys code |> List.map Bound_static.Pattern.code
-  in
   let set_of_closures_pattern =
     Bound_static.Pattern.set_of_closures closure_symbols
   in
-  let bound_static =
-    set_of_closures_pattern :: code_patterns |> Bound_static.create
-  in
-  let code_static_consts = Code_id.Lmap.data code in
+  let bound_static = [set_of_closures_pattern] |> Bound_static.create in
   let set_of_closures_static_const =
     Rebuilt_static_const.create_set_of_closures
       (DA.are_rebuilding_terms dacc)
       set_of_closures
   in
   let static_consts =
-    set_of_closures_static_const :: code_static_consts
-    |> Rebuilt_static_const.Group.create
+    [set_of_closures_static_const] |> Rebuilt_static_const.Group.create
   in
   bound_static, static_consts, dacc
 

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -488,6 +488,7 @@ let extract_accumulators_from_function outer_dacc ~dacc_after_body
     UA.shareable_constants uacc_after_upwards_traversal
   in
   let slot_offsets = DA.slot_offsets dacc_after_body in
+  let code_age_relation = TE.code_age_relation (DA.typing_env dacc_after_body) in
   let outer_dacc =
     DA.add_to_lifted_constant_accumulator ~also_add_to_env:() outer_dacc
       lifted_consts_this_function
@@ -496,7 +497,8 @@ let extract_accumulators_from_function outer_dacc ~dacc_after_body
     |> DA.with_code_ids_to_remember ~code_ids_to_remember
     |> DA.with_used_value_slots ~used_value_slots
     |> DA.with_shareable_constants ~shareable_constants
-    |> DA.with_slot_offsets ~slot_offsets,
+    |> DA.with_slot_offsets ~slot_offsets
+    |> DA.with_code_age_relation ~code_age_relation,
     lifted_consts_this_function )
 
 type simplify_function_result =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -488,7 +488,9 @@ let extract_accumulators_from_function outer_dacc ~dacc_after_body
     UA.shareable_constants uacc_after_upwards_traversal
   in
   let slot_offsets = DA.slot_offsets dacc_after_body in
-  let code_age_relation = TE.code_age_relation (DA.typing_env dacc_after_body) in
+  let code_age_relation =
+    TE.code_age_relation (DA.typing_env dacc_after_body)
+  in
   let outer_dacc =
     DA.add_to_lifted_constant_accumulator ~also_add_to_env:() outer_dacc
       lifted_consts_this_function

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -813,7 +813,9 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
           | None -> code
           | Some new_code -> (code_id, new_code) :: code
         in
-        let fun_types = Function_slot.Map.add function_slot function_type fun_types in
+        let fun_types =
+          Function_slot.Map.add function_slot function_type fun_types
+        in
         result_function_decls_in_set, code, fun_types, outer_dacc)
       all_function_decls_in_set
       ([], [], Function_slot.Map.empty, outer_dacc)
@@ -1156,8 +1158,7 @@ let simplify_non_lifted_set_of_closures dacc (bound_vars : Bound_pattern.t)
       set_of_closures ~value_slots ~value_slot_types
 
 let simplify_lifted_set_of_closures0 dacc context ~closure_symbols
-    ~closure_bound_names_inside ~value_slots ~value_slot_types
-    set_of_closures =
+    ~closure_bound_names_inside ~value_slots ~value_slot_types set_of_closures =
   let closure_bound_names =
     Function_slot.Lmap.map Bound_name.create_symbol closure_symbols
     |> Function_slot.Lmap.bindings |> Function_slot.Map.of_list


### PR DESCRIPTION
Found while working on #164. The code generated by simplifying a lifted set of closures is already added to the lifted constants of the accumulator in the shared `simplify_set_of_closures0` function, so returning it as a new binding in `simplify_lifted_set_of_closures0` creates a duplicate binding. If the code and the closure are mutually recursive, this should be handled by the normal mechanism in `Lifted_constant_state`.