### PR TITLE
Factorize cmx preparation between classic mode and simplify

### DIFF
--- a/middle_end/flambda2/classic_mode_types/dune
+++ b/middle_end/flambda2/classic_mode_types/dune
@@ -10,6 +10,8 @@
    -open
    Flambda2_identifiers
    -open
+   Flambda2_nominal
+   -open
    Flambda2_term_basics))
  (ocamlopt_flags
   (:standard -O3))
@@ -17,4 +19,5 @@
   stdlib
   ocamlcommon
   flambda2_identifiers
+  flambda2_nominal
   flambda2_term_basics))

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -26,3 +26,17 @@ type 'code t =
 let is_unknown = function
   | Value_unknown -> true
   | Closure_approximation _ | Block_approximation _ -> false
+
+let rec free_names ~code_free_names approx =
+  match approx with
+  | Value_unknown -> Name_occurrences.empty
+  | Block_approximation (approxs, _) ->
+    Array.fold_left
+      (fun names approx ->
+        Name_occurrences.union names (free_names ~code_free_names approx))
+      Name_occurrences.empty approxs
+  | Closure_approximation (code_id, closure_id, code) ->
+    Name_occurrences.add_code_id
+      (Name_occurrences.add_closure_id (code_free_names code) closure_id
+         Name_mode.normal)
+      code_id Name_mode.normal

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -24,3 +24,6 @@ type 'code t =
   | Block_approximation of 'code t array * Alloc_mode.t
 
 val is_unknown : 'a t -> bool
+
+val free_names :
+  code_free_names:('code -> Name_occurrences.t) -> 'code t -> Name_occurrences.t

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -258,10 +258,14 @@ let prepare_cmx_from_approx ~approxs ~module_symbol ~exported_offsets
   if Flambda_features.opaque ()
   then None
   else
-    let typing_env =
+    let create_typing_env reachable_names =
+      let approxs =
+        Symbol.Map.filter
+          (fun sym _ -> Name_occurrences.mem_symbol reachable_names sym)
+          approxs
+      in
       TE.Serializable.create_from_closure_conversion_approx approxs
     in
-    let create_typing_env _ = typing_env in
     let free_names_of_name name =
       let symbol = Name.must_be_symbol name in
       match Symbol.Map.find_opt symbol approxs with

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -263,15 +263,13 @@ let prepare_cmx_from_approx ~approxs ~module_symbol ~exported_offsets
     in
     let create_typing_env _ = typing_env in
     let free_names_of_name name =
-      match Name.must_be_symbol_opt name with
+      let symbol = Name.must_be_symbol name in
+      match Symbol.Map.find_opt symbol approxs with
       | None -> None
-      | Some symbol -> (
-        match Symbol.Map.find_opt symbol approxs with
-        | None -> None
-        | Some approx ->
-          Some
-            (Value_approximation.free_names
-               ~code_free_names:Code_or_metadata.free_names approx))
+      | Some approx ->
+        Some
+          (Value_approximation.free_names
+             ~code_free_names:Code_or_metadata.free_names approx)
     in
     prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
       ~used_closure_vars

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -47,6 +47,7 @@ val prepare_cmx_file_contents :
 
 val prepare_cmx_from_approx :
   approxs:Code_or_metadata.t Value_approximation.t Symbol.Map.t ->
+  module_symbol:Symbol.t ->
   exported_offsets:Exported_offsets.t ->
   used_closure_vars:Var_within_closure.Set.t ->
   Exported_code.t ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1994,10 +1994,13 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
       let free_names = Acc.free_names acc in
       Or_unknown.Known
         Closure_offsets.
-          { closure_ids_normal = Name_occurrences.closure_ids free_names;
-            closure_ids_in_types = Closure_id.Set.empty;
-            closure_vars_normal = Name_occurrences.closure_vars free_names;
-            closure_vars_in_types = Var_within_closure.Set.empty
+          { closure_ids_normal = Name_occurrences.closure_ids_normal free_names;
+            closure_ids_in_types =
+              Name_occurrences.closure_ids_in_types free_names;
+            closure_vars_normal =
+              Name_occurrences.closure_vars_normal free_names;
+            closure_vars_in_types =
+              Name_occurrences.closure_vars_in_types free_names
           }
     in
     Closure_offsets.finalize_offsets (Acc.closure_offsets acc)
@@ -2012,7 +2015,7 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
   in
   let cmx =
     Flambda_cmx.prepare_cmx_from_approx ~approxs:symbols_approximations
-      ~exported_offsets ~used_closure_vars all_code
+      ~module_symbol ~exported_offsets ~used_closure_vars all_code
   in
   ( Flambda_unit.create ~return_continuation:return_cont ~exn_continuation ~body
       ~module_symbol ~used_closure_vars:(Known used_closure_vars),

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1985,7 +1985,7 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
   in
   let all_code =
     Exported_code.add_code (Acc.code acc)
-      ~keep_code:(fun _ -> true)
+      ~keep_code:(fun _ -> false)
       (Exported_code.mark_as_imported
          (Flambda_cmx.get_imported_code cmx_loader ()))
   in


### PR DESCRIPTION
(From #424, [relevant diff](https://github.com/ocaml-flambda/flambda-backend/pull/571/commits/07a3992cbea76a59fca77e59099044f189d120a3))

This allows classic mode generated cmx to benefit from unreachables removal from exportation and fix a bug making them incompatible with their use in simplify.