### PR TITLE
Add keep-invalid-handlers flag

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -252,6 +252,20 @@ let mk_no_flambda2_debug_concrete_types_only_on_canonicals f =
       Flambda2.Debug.Default.concrete_types_only_on_canonicals)
 ;;
 
+let mk_flambda2_debug_keep_invalid_handlers f =
+  "-flambda2-debug-keep-invalid-handlers", Arg.Unit f,
+  Printf.sprintf " Keep branches simplified\n\
+      \     to Invalid%s (Flambda 2 only)"
+    (format_default Flambda2.Debug.Default.keep_invalid_handlers)
+;;
+
+let mk_no_flambda2_debug_keep_invalid_handlers f =
+  "-no-flambda2-debug-keep-invalid-handlers", Arg.Unit f,
+  Printf.sprintf " Delete branches simplified\n\
+      \     to Invalid%s (Flambda 2 only)"
+    (format_not_default Flambda2.Debug.Default.keep_invalid_handlers)
+;;
+
 let mk_flambda2_inline_max_depth f =
   "-flambda2-inline-max-depth", Arg.String f,
   Printf.sprintf "<int>|<round>=<int>[,...]\n\
@@ -419,6 +433,8 @@ module type Flambda_backend_options = sig
   val no_flambda2_debug_permute_every_name : unit -> unit
   val flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
   val no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
+  val flambda2_debug_keep_invalid_handlers : unit -> unit
+  val no_flambda2_debug_keep_invalid_handlers : unit -> unit
 
   val flambda2_inline_max_depth : string -> unit
   val flambda2_inline_max_rec_depth : string -> unit
@@ -506,6 +522,10 @@ struct
       F.flambda2_debug_concrete_types_only_on_canonicals;
     mk_no_flambda2_debug_concrete_types_only_on_canonicals
       F.no_flambda2_debug_concrete_types_only_on_canonicals;
+    mk_flambda2_debug_keep_invalid_handlers
+      F.flambda2_debug_keep_invalid_handlers;
+    mk_no_flambda2_debug_keep_invalid_handlers
+      F.no_flambda2_debug_keep_invalid_handlers;
 
     mk_flambda2_inline_max_depth F.flambda2_inline_max_depth;
     mk_flambda2_inline_max_rec_depth F.flambda2_inline_max_rec_depth;
@@ -605,6 +625,10 @@ module Flambda_backend_options_impl = struct
     set' Flambda2.Debug.concrete_types_only_on_canonicals
   let no_flambda2_debug_concrete_types_only_on_canonicals =
     clear' Flambda2.Debug.concrete_types_only_on_canonicals
+  let flambda2_debug_keep_invalid_handlers =
+    set' Flambda2.Debug.keep_invalid_handlers
+  let no_flambda2_debug_keep_invalid_handlers =
+    clear' Flambda2.Debug.keep_invalid_handlers
 
   let flambda2_inline_max_depth spec =
     Clflags.Int_arg_helper.parse spec
@@ -799,6 +823,8 @@ module Extra_params = struct
        set' Flambda2.Debug.permute_every_name
     | "flambda2-debug-concrete-types-only-on-canonicals" ->
        set' Flambda2.Debug.concrete_types_only_on_canonicals
+    | "flambda2-debug-keep-invalid-handlers" ->
+       set' Flambda2.Debug.keep_invalid_handlers
     | _ -> false
 end
 

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -56,6 +56,8 @@ module type Flambda_backend_options = sig
   val no_flambda2_debug_permute_every_name : unit -> unit
   val flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
   val no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
+  val flambda2_debug_keep_invalid_handlers : unit -> unit
+  val no_flambda2_debug_keep_invalid_handlers : unit -> unit
 
   val flambda2_inline_max_depth : string -> unit
   val flambda2_inline_max_rec_depth : string -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -168,11 +168,13 @@ module Flambda2 = struct
     module Default = struct
       let permute_every_name = false
       let concrete_types_only_on_canonicals = false
+      let keep_invalid_handlers = true
     end
 
     let permute_every_name = ref Default.permute_every_name
     let concrete_types_only_on_canonicals =
       ref Default.concrete_types_only_on_canonicals
+    let keep_invalid_handlers = ref Default.keep_invalid_handlers
   end
 
   module I = Clflags.Int_arg_helper

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -115,10 +115,12 @@ module Flambda2 : sig
     module Default : sig
       val permute_every_name : bool
       val concrete_types_only_on_canonicals : bool
+      val keep_invalid_handlers : bool
     end
 
     val permute_every_name : bool ref
     val concrete_types_only_on_canonicals : bool ref
+    val keep_invalid_handlers : bool ref
   end
 
   module Inlining : sig

--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -40,8 +40,7 @@ let is_unreachable t are_rebuilding =
   else
     match Expr.descr t with
     | Invalid _ ->
-      (* CR mshinwell: Change this to [true]. *)
-      false
+      if Flambda_features.Debug.keep_invalid_handlers () then false else true
     | Let _ | Let_cont _ | Apply _ | Apply_cont _ | Switch _ -> false
 
 let [@ocamlformat "disable"] print are_rebuilding ppf t =

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -174,6 +174,9 @@ module Debug = struct
 
   let concrete_types_only_on_canonicals () =
     !Flambda_backend_flags.Flambda2.Debug.concrete_types_only_on_canonicals
+
+  let keep_invalid_handlers () =
+    !Flambda_backend_flags.Flambda2.Debug.keep_invalid_handlers
 end
 
 module Expert = struct

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -100,6 +100,8 @@ module Debug : sig
   val permute_every_name : unit -> bool
 
   val concrete_types_only_on_canonicals : unit -> bool
+
+  val keep_invalid_handlers : unit -> bool
 end
 
 module Expert : sig


### PR DESCRIPTION
When the flag is on, continuation handlers that have been later simplified to Invalid are kept in the result term. This is particularly useful if they turned out to be actually reachable (either because of `Obj` or a compiler error), as this generates a runtime error with a bit of context.
When the flag is off, these branches are considered dead and completely removed from the result.
The flag is true by default.

The branches that are found unreachable by looking at the type of the scrutinee are not affected by this flag, and will always be deleted.