### PR TITLE
Increase max inlining depth at -O3

### DIFF
--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -287,7 +287,7 @@ module Flambda2 = struct
       threshold = Some 100.;
     }
 
-    let o3_arguments = o2_arguments
+    let o3_arguments = { o2_arguments with max_depth = Some 6 }
   end
 end
 


### PR DESCRIPTION
We need to take care raising this as problematic source files can become very slow to compile, but 6 seems fine on the JS tree, and we can consider further increases later.