### PR TITLE
Use -linscan for module entry functions

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -139,7 +139,8 @@ let rec regalloc ~ppf_dump round fd =
                 ": function too complex, cannot complete register allocation");
   dump_if ppf_dump dump_live "Liveness analysis" fd;
   let num_stack_slots =
-    if !use_linscan then begin
+    if !use_linscan ||
+       List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options then begin
       (* Linear Scan *)
       Interval.build_intervals fd;
       if !dump_interval then Printmach.intervals ppf_dump ();

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -243,6 +243,7 @@ type expression =
 type codegen_option =
   | Reduce_code_size
   | No_CSE
+  | Use_linscan_regalloc
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -252,6 +252,7 @@ type expression =
 type codegen_option =
   | Reduce_code_size
   | No_CSE
+  | Use_linscan_regalloc
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1576,8 +1576,9 @@ let compunit (ulam, preallocated_blocks, constants) =
                          if Config.flambda then [
                            Reduce_code_size;
                            No_CSE;
+                           Use_linscan_regalloc;
                          ]
-                         else [ Reduce_code_size ];
+                         else [ Reduce_code_size; Use_linscan_regalloc ];
                        fun_dbg  = Debuginfo.none }] in
   let c2 = transl_clambda_constants constants c1 in
   let c3 = transl_all_functions c2 in

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -1656,8 +1656,8 @@ let unit ~offsets ~make_symbol unit ~all_code =
         let fun_name = Compilenv.make_symbol (Some "entry") in
         let fun_codegen =
           if Flambda_features.backend_cse_at_toplevel ()
-          then [Cmm.Reduce_code_size]
-          else [Cmm.Reduce_code_size; Cmm.No_CSE]
+          then [Cmm.Reduce_code_size; Cmm.Use_linscan_regalloc]
+          else [Cmm.Reduce_code_size; Cmm.Use_linscan_regalloc; Cmm.No_CSE]
         in
         C.cfunction (C.fundecl fun_name [] body fun_codegen dbg)
       in


### PR DESCRIPTION
Linscan is much faster on large functions, and module entry functions are large and not performance sensitive (they only run once, to initialise things), so this can speed compilation a lot.