### PR TITLE
Join for Pfield to allow optimisation of matches broken by PR #88

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1716,6 +1716,7 @@ module StoreExpForSwitch =
           | _ -> None
         in
         Some (continuation, index)
+      let join_actions_to_be_shared cmm _ = cmm
       let compare_key (cont, index) (cont', index') =
         match cont, cont' with
         | Some i, Some i' when i = i' -> 0
@@ -1731,6 +1732,7 @@ module StoreExp =
       let make_key = function
         | Cexit (Lbl i,[],[]) -> Some i
         | _ -> None
+      let join_actions_to_be_shared cmm _ = cmm
       let compare_key = Stdlib.compare
     end)
 

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -30,6 +30,8 @@ module Storer =
       type t = lambda
       type key = lambda
       let make_key =  Lambda.make_key
+      let join_actions_to_be_shared =
+        Lambda.join_actions_to_be_shared ~printer:Printlambda.lambda
       let compare_key = Stdlib.compare
     end)
 

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -780,6 +780,8 @@ module Switch_storer = Switch.Store (struct
     | exception Not_comparable -> None
     | key -> Some key
 
+  let join_actions_to_be_shared expr _ = expr
+
   let compare_key e1 e2 =
     (* The environment [env] maps variables bound in [e2] to the corresponding
        bound variables in [e1]. Every variable to compare in [e2] must have an

--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -3461,10 +3461,13 @@ lambda/simplif.cmi : \
     lambda/lambda.cmi \
     typing/ident.cmi
 lambda/switch.cmo : \
+    utils/numbers.cmi \
     lambda/switch.cmi
 lambda/switch.cmx : \
+    utils/numbers.cmx \
     lambda/switch.cmi
-lambda/switch.cmi :
+lambda/switch.cmi : \
+    utils/numbers.cmi
 lambda/translattribute.cmo : \
     utils/warnings.cmi \
     typing/typedtree.cmi \

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -1616,6 +1616,7 @@ module StoreExpForSwitch =
           | _ -> None
         in
         Some (continuation, index)
+      let join_actions_to_be_shared cmm _ = cmm
       let compare_key (cont, index) (cont', index') =
         match cont, cont' with
         | Some i, Some i' when i = i' -> 0
@@ -1631,6 +1632,7 @@ module StoreExp =
       let make_key = function
         | Cexit (i,[]) -> Some i
         | _ -> None
+      let join_actions_to_be_shared cmm _ = cmm
       let compare_key = Stdlib.compare
     end)
 

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -516,6 +516,7 @@ module Storer =
   Switch.Store
     (struct type t = lambda type key = lambda
       let compare_key = Stdlib.compare
+      let join_actions_to_be_shared lam _ = lam
       let make_key = Lambda.make_key end)
 
 (* Compile an expression.

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -393,8 +393,15 @@ type program =
        [getfield 0; ...; getfield (main_module_block_size - 1)])
 *)
 
-(* Sharing key *)
+(* Sharing key
+   Beware: even if two keys compare equal (using [Stdlib.compare]), it is
+   necessary to call [join_actions_to_be_shared] to get the correct term
+   for sharing.
+*)
 val make_key: lambda -> lambda option
+val join_actions_to_be_shared :
+  printer:(Format.formatter -> lambda -> unit) ->
+  lambda -> lambda -> lambda
 
 val const_unit: structured_constant
 val const_int : int -> structured_constant

--- a/ocaml/lambda/switch.mli
+++ b/ocaml/lambda/switch.mli
@@ -43,6 +43,7 @@ module type Stored = sig
   type t
   type key
   val compare_key : key -> key -> int
+  val join_actions_to_be_shared : t -> t -> t
   val make_key : t -> key option
 end
 

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -30,6 +30,8 @@ module Storer =
       type t = lambda
       type key = lambda
       let make_key =  Lambda.make_key
+      let join_actions_to_be_shared =
+        Lambda.join_actions_to_be_shared ~printer:Printlambda.lambda
       let compare_key = Stdlib.compare
     end)
 

--- a/ocaml/middle_end/flambda/flambda_utils.ml
+++ b/ocaml/middle_end/flambda/flambda_utils.ml
@@ -775,6 +775,8 @@ module Switch_storer = Switch.Store (struct
     | exception Not_comparable -> None
     | key -> Some key
 
+  let join_actions_to_be_shared expr _ = expr
+
   let compare_key e1 e2 =
     (* The environment [env] maps variables bound in [e2] to the corresponding
        bound variables in [e1]. Every variable to compare in [e2] must have an


### PR DESCRIPTION
PR #88 broke an optimisation which is being relied on at JS.  For code like the following:
```
type t =
  | A of { x : int; }
  | B of { mutable x : int; }
  | C of { x : int; }

let get t =
  match t with
  | A r -> r.x
  | B r -> r.x
  | C r -> r.x
```
the `Lambda` code should be a single `Pfield`.  Unfortunately after PR #88 this doesn't happen because of the differences in the "field read semantics".  It should be noted that even prior to PR #88 the pattern was fragile: inline record matches `{ x }` did not optimise as desired.

This is a bit of a nuisance to fix because of how sharing keys are used in `Lambda` and I experimented with a couple of approaches (one involving a different comparison function on sharing keys, which I abandoned as it would have added a lot of boilerplate code).  I think the current approach here seems reasonable.

@lpw25 has volunteered to review this in the first instance.