### PR TITLE
Revert "Track GC work for all managed bigarray allocations (upstream …

### DIFF
--- a/ocaml/runtime/bigarray.c
+++ b/ocaml/runtime/bigarray.c
@@ -89,7 +89,7 @@ CAMLexport value
 caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
 {
   uintnat num_elts, asize, size;
-  int i, is_managed;
+  int i;
   value res;
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
@@ -97,23 +97,23 @@ caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
   CAMLassert(num_dims >= 0 && num_dims <= CAML_BA_MAX_NUM_DIMS);
   CAMLassert((flags & CAML_BA_KIND_MASK) <= CAML_BA_CHAR);
   for (i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
-  num_elts = 1;
-  for (i = 0; i < num_dims; i++) {
-    if (caml_umul_overflow(num_elts, dimcopy[i], &num_elts))
-      caml_raise_out_of_memory();
-  }
-  if (caml_umul_overflow(num_elts,
-                         caml_ba_element_size[flags & CAML_BA_KIND_MASK],
-                         &size))
-    caml_raise_out_of_memory();
+  size = 0;
   if (data == NULL) {
+    num_elts = 1;
+    for (i = 0; i < num_dims; i++) {
+      if (caml_umul_overflow(num_elts, dimcopy[i], &num_elts))
+        caml_raise_out_of_memory();
+    }
+    if (caml_umul_overflow(num_elts,
+                           caml_ba_element_size[flags & CAML_BA_KIND_MASK],
+                           &size))
+      caml_raise_out_of_memory();
     data = malloc(size);
     if (data == NULL && size != 0) caml_raise_out_of_memory();
     flags |= CAML_BA_MANAGED;
   }
   asize = SIZEOF_BA_ARRAY + num_dims * sizeof(intnat);
-  is_managed = ((flags & CAML_BA_MANAGED_MASK) == CAML_BA_MANAGED);
-  res = caml_alloc_custom_mem(&caml_ba_ops, asize, is_managed ? size : 0);
+  res = caml_alloc_custom_mem(&caml_ba_ops, asize, size);
   b = Caml_ba_array_val(res);
   b->data = data;
   b->num_dims = num_dims;


### PR DESCRIPTION
…11022) (#569)"

This reverts commit 86fa8933b6bd1eb2bbb0aae8b6c9b63b32911861 from the 4.12 release branch.