### PR TITLE
Track all occurrences of closure vars and closure ids in Name_occurrences

### DIFF
--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -37,6 +37,6 @@ let rec free_names ~code_free_names approx =
       Name_occurrences.empty approxs
   | Closure_approximation (code_id, closure_id, code) ->
     Name_occurrences.add_code_id
-      (Name_occurrences.add_closure_id (code_free_names code) closure_id
-         Name_mode.normal)
+      (Name_occurrences.add_closure_id_in_types (code_free_names code)
+         closure_id)
       code_id Name_mode.normal

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -222,13 +222,13 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
   let exported_offsets =
     exported_offsets
     |> Closure_offsets.reexport_closure_ids
-         (Name_occurrences.closure_ids free_names_of_all_code)
+         (Name_occurrences.all_closure_ids free_names_of_all_code)
     |> Closure_offsets.reexport_closure_vars
-         (Name_occurrences.closure_vars free_names_of_all_code)
+         (Name_occurrences.all_closure_vars free_names_of_all_code)
     |> Closure_offsets.reexport_closure_ids
-         (Name_occurrences.closure_ids closure_elts_used_in_typing_env)
+         (Name_occurrences.all_closure_ids closure_elts_used_in_typing_env)
     |> Closure_offsets.reexport_closure_vars
-         (Name_occurrences.closure_vars closure_elts_used_in_typing_env)
+         (Name_occurrences.all_closure_vars closure_elts_used_in_typing_env)
   in
   Some
     (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -364,18 +364,9 @@ and subst_static_const env (static_const : Static_const_or_code.t) :
 and subst_code env (code : Code.t) : Code.t =
   let params_and_body = Code.params_and_body code in
   let params_and_body = subst_params_and_body env params_and_body in
-  let _names_and_closure_vars names =
-    Name_occurrences.(
-      union
-        (restrict_to_closure_vars names)
-        (with_only_names_and_code_ids_promoting_newer_version_of names
-        |> without_code_ids))
-  in
   let free_names_of_params_and_body =
     (* CR mshinwell: This needs fixing XXX *)
     Name_occurrences.empty
-    (* Flambda.Function_params_and_body.free_names params_and_body |>
-       names_and_closure_vars *)
   in
   let newer_version_of =
     Option.map (subst_code_id env) (Code.newer_version_of code)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1994,13 +1994,12 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
       let free_names = Acc.free_names acc in
       Or_unknown.Known
         Closure_offsets.
-          { closure_ids_normal = Name_occurrences.closure_ids_normal free_names;
-            closure_ids_in_types =
-              Name_occurrences.closure_ids_in_types free_names;
+          { closure_ids_normal =
+              Name_occurrences.closure_ids_in_normal_projections free_names;
+            closure_ids_in_types = Name_occurrences.all_closure_ids free_names;
             closure_vars_normal =
-              Name_occurrences.closure_vars_normal free_names;
-            closure_vars_in_types =
-              Name_occurrences.closure_vars_in_types free_names
+              Name_occurrences.closure_vars_in_normal_projections free_names;
+            closure_vars_in_types = Name_occurrences.all_closure_vars free_names
           }
     in
     Closure_offsets.finalize_offsets (Acc.closure_offsets acc)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1994,12 +1994,12 @@ let close_program ~symbol_for_global ~big_endian ~cmx_loader ~module_ident
       let free_names = Acc.free_names acc in
       Or_unknown.Known
         Closure_offsets.
-          { closure_ids_normal =
+          { closure_ids_in_normal_projections =
               Name_occurrences.closure_ids_in_normal_projections free_names;
-            closure_ids_in_types = Name_occurrences.all_closure_ids free_names;
-            closure_vars_normal =
+            all_closure_ids = Name_occurrences.all_closure_ids free_names;
+            closure_vars_in_normal_projections =
               Name_occurrences.closure_vars_in_normal_projections free_names;
-            closure_vars_in_types = Name_occurrences.all_closure_vars free_names
+            all_closure_vars = Name_occurrences.all_closure_vars free_names
           }
     in
     Closure_offsets.finalize_offsets (Acc.closure_offsets acc)

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -64,9 +64,21 @@ val add_symbol : t -> Symbol.t -> Name_mode.t -> t
 
 val add_name : t -> Name.t -> Name_mode.t -> t
 
-val add_closure_id : t -> Closure_id.t -> Name_mode.t -> t
+val add_closure_id_in_projection : t -> Closure_id.t -> Name_mode.t -> t
 
-val add_closure_var : t -> Var_within_closure.t -> Name_mode.t -> t
+val add_closure_var_in_projection :
+  t -> Var_within_closure.t -> Name_mode.t -> t
+
+val add_closure_id_in_declaration : t -> Closure_id.t -> Name_mode.t -> t
+
+val add_closure_var_in_declaration :
+  t -> Var_within_closure.t -> Name_mode.t -> t
+
+(** Closure_variables and closure IDs in types count as both projection and
+    declaration *)
+val add_closure_id_in_types : t -> Closure_id.t -> t
+
+val add_closure_var_in_types : t -> Var_within_closure.t -> t
 
 val singleton_code_id : Code_id.t -> Name_mode.t -> t
 
@@ -88,7 +100,7 @@ val create_variables' : Name_mode.t -> Variable.Set.t -> t
 
 val create_names : Name.Set.t -> Name_mode.t -> t
 
-val create_closure_vars : Var_within_closure.Set.t -> t
+(* val create_closure_vars : Var_within_closure.Set.t -> t *)
 
 (** [diff t1 t2] removes from [t1] all those names that occur in [t2].
 
@@ -120,17 +132,13 @@ val continuations_with_traps : t -> Continuation.Set.t
 
 val continuations_including_in_trap_actions : t -> Continuation.Set.t
 
-val closure_ids : t -> Closure_id.Set.t
+val closure_ids_in_normal_projections : t -> Closure_id.Set.t
 
-val closure_ids_normal : t -> Closure_id.Set.t
+val all_closure_ids : t -> Closure_id.Set.t
 
-val closure_ids_in_types : t -> Closure_id.Set.t
+val closure_vars_in_normal_projections : t -> Var_within_closure.Set.t
 
-val closure_vars : t -> Var_within_closure.Set.t
-
-val closure_vars_normal : t -> Var_within_closure.Set.t
-
-val closure_vars_in_types : t -> Var_within_closure.Set.t
+val all_closure_vars : t -> Var_within_closure.Set.t
 
 val symbols : t -> Symbol.Set.t
 
@@ -140,15 +148,11 @@ val newer_version_of_code_ids : t -> Code_id.Set.t
 
 val only_newer_version_of_code_ids : t -> Code_id.Set.t
 
-val restrict_to_closure_vars : t -> t
-
 val restrict_to_closure_vars_and_closure_ids : t -> t
 
 val code_ids_and_newer_version_of_code_ids : t -> Code_id.Set.t
 
 val without_code_ids : t -> t
-
-val without_closure_vars : t -> t
 
 val with_only_variables : t -> t
 
@@ -175,7 +179,7 @@ val mem_code_id : t -> Code_id.t -> bool
 
 val mem_newer_version_of_code_id : t -> Code_id.t -> bool
 
-val mem_closure_var : t -> Var_within_closure.t -> bool
+val mem_closure_var_in_projections : t -> Var_within_closure.t -> bool
 
 val closure_var_is_used_or_imported : t -> Var_within_closure.t -> bool
 
@@ -185,7 +189,7 @@ val remove_code_id_or_symbol : t -> Code_id_or_symbol.t -> t
 
 val remove_continuation : t -> Continuation.t -> t
 
-val remove_one_occurrence_of_closure_var :
+val remove_one_occurrence_of_closure_var_in_projections :
   t -> Var_within_closure.t -> Name_mode.t -> t
 
 val greatest_name_mode_var : t -> Variable.t -> Name_mode.Or_absent.t

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -785,20 +785,9 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
               ~exn_continuation:(Exn_continuation.exn_handler exn_continuation)
               params ~body ~my_closure ~my_depth ~free_names_of_body:Unknown
           in
-          (* CR lmaurer: Add
-           * [Name_occurrences.with_only_names_and_closure_vars] *)
-          let _names_and_closure_vars names =
-            Name_occurrences.(
-              union
-                (restrict_to_closure_vars names)
-                (with_only_names_and_code_ids_promoting_newer_version_of names
-                |> without_code_ids))
-          in
           let free_names =
             (* CR mshinwell: This needs fixing XXX *)
             Name_occurrences.empty
-            (* Flambda.Function_params_and_body.free_names params_and_body |>
-               names_and_closure_vars *)
           in
           ( params,
             params_and_body,

--- a/middle_end/flambda2/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/downwards_acc.ml
@@ -159,8 +159,8 @@ let shareable_constants t = t.shareable_constants
 let add_use_of_closure_var t closure_var =
   { t with
     used_closure_vars =
-      Name_occurrences.add_closure_var t.used_closure_vars closure_var
-        Name_mode.normal
+      Name_occurrences.add_closure_var_in_projection t.used_closure_vars
+        closure_var Name_mode.normal
   }
 
 let used_closure_vars t = t.used_closure_vars

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -70,18 +70,14 @@ let run ~cmx_loader ~round unit =
       (Exported_code.mark_as_imported (get_imported_code ()))
   in
   let name_occurrences = UA.name_occurrences uacc in
-  let closure_ids_normal =
+  let closure_ids_in_normal_projections =
     Name_occurrences.closure_ids_in_normal_projections name_occurrences
   in
-  let closure_vars_normal =
+  let closure_vars_in_normal_projections =
     Name_occurrences.closure_vars_in_normal_projections name_occurrences
   in
-  let closure_ids_in_types =
-    Name_occurrences.all_closure_ids name_occurrences
-  in
-  let closure_vars_in_types =
-    Name_occurrences.all_closure_vars name_occurrences
-  in
+  let all_closure_ids = Name_occurrences.all_closure_ids name_occurrences in
+  let all_closure_vars = Name_occurrences.all_closure_vars name_occurrences in
   let used_closure_vars, exported_offsets =
     match UA.closure_offsets uacc with
     | Unknown ->
@@ -89,10 +85,10 @@ let run ~cmx_loader ~round unit =
     | Known closure_offsets -> (
       let used_names : Closure_offsets.used_names Or_unknown.t =
         Known
-          { closure_vars_normal;
-            closure_ids_normal;
-            closure_vars_in_types;
-            closure_ids_in_types
+          { closure_ids_in_normal_projections;
+            all_closure_ids;
+            closure_vars_in_normal_projections;
+            all_closure_vars
           }
       in
       let get_code_metadata code_id =

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -71,16 +71,16 @@ let run ~cmx_loader ~round unit =
   in
   let name_occurrences = UA.name_occurrences uacc in
   let closure_ids_normal =
-    Name_occurrences.closure_ids_normal name_occurrences
+    Name_occurrences.closure_ids_in_normal_projections name_occurrences
   in
   let closure_vars_normal =
-    Name_occurrences.closure_vars_normal name_occurrences
+    Name_occurrences.closure_vars_in_normal_projections name_occurrences
   in
   let closure_ids_in_types =
-    Name_occurrences.closure_ids_in_types name_occurrences
+    Name_occurrences.all_closure_ids name_occurrences
   in
   let closure_vars_in_types =
-    Name_occurrences.closure_vars_in_types name_occurrences
+    Name_occurrences.all_closure_vars name_occurrences
   in
   let used_closure_vars, exported_offsets =
     match UA.closure_offsets uacc with

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -435,7 +435,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
               Cost_metrics.from_size (Code_size.prim prim)
             in
             let free_names =
-              Name_occurrences.add_closure_var free_names closure_var NM.normal
+              Name_occurrences.add_closure_var_in_projection free_names
+                closure_var NM.normal
             in
             let expr =
               Let.create

--- a/middle_end/flambda2/simplify_shared/closure_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/closure_offsets.mli
@@ -21,16 +21,16 @@ type t
 
 (** The type of names that are used (and pertinent for offset computing) *)
 type used_names =
-  { closure_ids_normal : Closure_id.Set.t;
+  { closure_ids_in_normal_projections : Closure_id.Set.t;
         (** Closure ids that appear in projections with normal name mode *)
-    closure_ids_in_types : Closure_id.Set.t;
-        (** Closure ids that appear in types (and thus can be eventually used in
-            normal name mode later) *)
-    closure_vars_normal : Var_within_closure.Set.t;
+    all_closure_ids : Closure_id.Set.t;
+        (** All closure ids, both in projections and declarations, irrespective
+            of name mode *)
+    closure_vars_in_normal_projections : Var_within_closure.Set.t;
         (** Closure vars that appear in projections with normal name mode *)
-    closure_vars_in_types : Var_within_closure.Set.t
-        (** Closure vars that appear in types (and thus can be eventually used
-            in normal name mode later) *)
+    all_closure_vars : Var_within_closure.Set.t
+        (** All closure vars, both in projections and declarations, irrespective
+            of name mode *)
   }
 
 (** Printing function. *)

--- a/middle_end/flambda2/term_basics/symbol_projection.ml
+++ b/middle_end/flambda2/term_basics/symbol_projection.ml
@@ -97,8 +97,9 @@ let free_names { symbol; projection } =
   match projection with
   | Block_load _ -> free_names
   | Project_var { project_from; var } ->
-    Name_occurrences.add_closure_id
-      (Name_occurrences.add_closure_var free_names var Name_mode.normal)
+    Name_occurrences.add_closure_id_in_projection
+      (Name_occurrences.add_closure_var_in_projection free_names var
+         Name_mode.normal)
       project_from Name_mode.normal
 
 let all_ids_for_export { symbol; projection = _ } =

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -161,7 +161,7 @@ let free_names t =
       { function_call = Direct { code_id; closure_id; return_arity = _ };
         alloc_mode = _
       } ->
-    Name_occurrences.add_closure_id
+    Name_occurrences.add_closure_id_in_projection
       (Name_occurrences.add_code_id Name_occurrences.empty code_id
          Name_mode.normal)
       closure_id Name_mode.normal

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1472,14 +1472,14 @@ let free_names t =
   match t with
   | Nullary _ -> Name_occurrences.empty
   | Unary (Select_closure { move_from; move_to }, x0) ->
-    Name_occurrences.add_closure_id
-      (Name_occurrences.add_closure_id (Simple.free_names x0) move_to
-         Name_mode.normal)
+    Name_occurrences.add_closure_id_in_projection
+      (Name_occurrences.add_closure_id_in_projection (Simple.free_names x0)
+         move_to Name_mode.normal)
       move_from Name_mode.normal
   | Unary (Project_var { var = clos_var; project_from }, x0) ->
-    Name_occurrences.add_closure_id
-      (Name_occurrences.add_closure_var (Simple.free_names x0) clos_var
-         Name_mode.normal)
+    Name_occurrences.add_closure_id_in_projection
+      (Name_occurrences.add_closure_var_in_projection (Simple.free_names x0)
+         clos_var Name_mode.normal)
       project_from Name_mode.normal
   | Unary (_prim, x0) -> Simple.free_names x0
   | Binary (_prim, x0, x1) ->

--- a/middle_end/flambda2/terms/function_declarations.ml
+++ b/middle_end/flambda2/terms/function_declarations.ml
@@ -43,8 +43,11 @@ let [@ocamlformat "disable"] print ppf { in_order; _ } =
 
 let free_names { funs; _ } =
   Closure_id.Map.fold
-    (fun _closure_id code_id syms ->
-      Name_occurrences.add_code_id syms code_id Name_mode.normal)
+    (fun closure_id code_id syms ->
+      Name_occurrences.add_code_id
+        (Name_occurrences.add_closure_id_in_declaration syms closure_id
+           Name_mode.normal)
+        code_id Name_mode.normal)
     funs Name_occurrences.empty
 
 (* Note: the call to {create} at the end already takes into account the

--- a/middle_end/flambda2/types/grammar/set_of_closures_contents.ml
+++ b/middle_end/flambda2/types/grammar/set_of_closures_contents.ml
@@ -78,7 +78,7 @@ let apply_renaming { closures; closure_vars } renaming =
 let free_names { closures = _; closure_vars } =
   Var_within_closure.Set.fold
     (fun closure_var free_names ->
-      Name_occurrences.add_closure_var free_names closure_var Name_mode.normal)
+      Name_occurrences.add_closure_var_in_types free_names closure_var)
     closure_vars Name_occurrences.empty
 
 let remove_unused_closure_vars { closures; closure_vars } ~used_closure_vars =

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -284,9 +284,9 @@ and free_names_closures_entry ~follow_closure_vars
     Closure_id.Map.fold
       (fun closure_id function_decl free_names ->
         Name_occurrences.union free_names
-          (Name_occurrences.add_closure_id
+          (Name_occurrences.add_closure_id_in_types
              (free_names_function_type ~follow_closure_vars function_decl)
-             closure_id Name_mode.normal))
+             closure_id))
       function_types Name_occurrences.empty
   in
   let closure_elements_free_names =
@@ -313,11 +313,11 @@ and free_names_var_within_closure_indexed_product ~follow_closure_vars
     { var_within_closure_components_by_index } =
   Var_within_closure.Map.fold
     (fun closure_var t free_names_acc ->
-      Name_occurrences.add_closure_var
+      Name_occurrences.add_closure_var_in_types
         (Name_occurrences.union
            (free_names0 ~follow_closure_vars t)
            free_names_acc)
-        closure_var Name_mode.normal)
+        closure_var)
     var_within_closure_components_by_index Name_occurrences.empty
 
 and free_names_int_indexed_product ~follow_closure_vars { fields; kind = _ } =


### PR DESCRIPTION
A relatively straightforward patch that allows `Name_occurrences` to track all closure IDs and closure variables. The distinction between closure variables used in projections and those only used in declarations is still there, but now we can rely on the pre-computed free names of imported functions to know which closure IDs and closure vars need to be re-exported after inlining.