### PR TITLE
Do not run `Merge_straightline_blocks.run` if `simplify_terminators` is false

### DIFF
--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -762,7 +762,7 @@ let fundecl :
      integer test. This simplification should happen *after* the one about
      straightline blocks because merging blocks creates more opportunities for
      terminator simplification. *)
-  Merge_straightline_blocks.run cfg_with_layout;
+  if simplify_terminators then Merge_straightline_blocks.run cfg_with_layout;
   Eliminate_dead_code.run_dead_block cfg_with_layout;
   if simplify_terminators then Simplify_terminator.run cfg;
   cfg_with_layout


### PR DESCRIPTION
The rationale behind the change was already present
in a comment in [`Asmgen`](https://github.com/ocaml-flambda/flambda-backend/blob/main/backend/asmgen.ml#L220) reproduced below:

```
  (* We do not simplify terminators here because it interferes with liveness
     when we have a terminator with:
     (i) all its edges leading to the same block;
     (ii) a condition making a pseudo-register live.
    In such a case, the terminator would be simplified to a mere jump, the
    condition would disappear, and the pseudo-register would no longer be
    live. Is it fine in itself, but would break the equivalence check. *)
```
Indeed, `Merge_straightline_blocks.run` can change
the terminator of a block.