### PR TITLE
Backport sigaltstack fix from trunk

### DIFF
--- a/ocaml/runtime/caml/signals.h
+++ b/ocaml/runtime/caml/signals.h
@@ -87,7 +87,7 @@ value caml_do_pending_actions_exn (void);
 value caml_process_pending_actions_with_root (value extra_root); // raises
 value caml_process_pending_actions_with_root_exn (value extra_root);
 int caml_set_signal_action(int signo, int action);
-CAMLextern void caml_setup_stack_overflow_detection(void);
+CAMLextern int caml_setup_stack_overflow_detection(void);
 
 CAMLextern void (*caml_enter_blocking_section_hook)(void);
 CAMLextern void (*caml_leave_blocking_section_hook)(void);

--- a/ocaml/runtime/signals_byt.c
+++ b/ocaml/runtime/signals_byt.c
@@ -81,4 +81,4 @@ int caml_set_signal_action(int signo, int action)
     return 0;
 }
 
-CAMLexport void caml_setup_stack_overflow_detection(void) {}
+CAMLexport int caml_setup_stack_overflow_detection(void) { return 0; }


### PR DESCRIPTION
Backport ocaml/ocaml#10266 (without the `Changes` diff which caused conflict).

This has become necessary on my machine as it seems archlinux has (finally) decided to upgrade its glibc.