### PR TITLE
Switch the implementation of out of bounds

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -159,11 +159,9 @@ let expression_for_failure acc env exn_cont ~register_const_string primitive dbg
     (* CR mshinwell: Share this text with elsewhere. *)
     let acc, error_text = register_const_string acc "index out of bounds" in
     let invalid_argument =
-    (* [Predef.invalid_argument] is not exposed; the following avoids a
-       change to the frontend. *)
-      let matches ident =
-        String.equal (Ident.name ident) "Invalid_argument"
-      in
+      (* [Predef.invalid_argument] is not exposed; the following avoids a change
+         to the frontend. *)
+      let matches ident = String.equal (Ident.name ident) "Invalid_argument" in
       let invalid_argument =
         match List.find matches Predef.all_predef_exns with
         | exception Not_found ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -115,8 +115,8 @@ let raise_exn_for_failure acc ~dbg exn_cont exn_bucket extra_let_binding =
       (Bound_pattern.singleton bound_var)
       defining_expr ~body:apply_cont
 
-let expression_for_failure acc _env exn_cont ~register_const_string primitive dbg
-    (failure : failure) =
+let expression_for_failure acc _env exn_cont ~register_const_string primitive
+    dbg (failure : failure) =
   let exn_cont =
     match exn_cont with
     | Some exn_cont -> exn_cont

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -115,7 +115,7 @@ let raise_exn_for_failure acc ~dbg exn_cont exn_bucket extra_let_binding =
       (Bound_pattern.singleton bound_var)
       defining_expr ~body:apply_cont
 
-let expression_for_failure acc env exn_cont ~register_const_string primitive dbg
+let expression_for_failure acc _env exn_cont ~register_const_string primitive dbg
     (failure : failure) =
   let exn_cont =
     match exn_cont with


### PR DESCRIPTION
Previously, the raising of the out of bounds exn caled into a C function. That was mainly because at the time, we could not lift exception (iirc it was before the introduction of the Immutable unique thing, so exn were declared as mutable to avoid copying).

Now that exceptions are lifted as expected, we can restore the code path that uses apply_cont to raise the exception.

Also: the old code was mistakenly using `~alloc:false` for the extcall, which meant that there were no backtraces for these exceptions, so this commit also restores backtraces for out of bounds.

I don't whether to be happy that out_of_bounds exception seem to be rare in ocaml, or to be horrified that we got this far with flambda-backend without realizing that we didn't have backtraces for out of bounds...