### PR TITLE
Fix compilation error after merge

### DIFF
--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -318,3 +318,4 @@ let is_pure_specific : specific_operation -> bool = function
   | Isqrtf -> true
   | Ibswap _ -> true
   | Imove32 -> true
+  | Isignext _ -> true


### PR DESCRIPTION
Caused by an undetected conflict between #556 and #547.

This makes the CI fail and prevents us from merging other PRs.