### PR TITLE
Update float operations effects and coeffects to respects the float_const_prop flag

### DIFF
--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -669,7 +669,9 @@ let unary_primitive_eligible_for_cse p ~arg =
   | Int_as_pointer -> true
   | Opaque_identity -> false
   | Int_arith _ -> true
-  | Float_arith _ -> Flambda_features.float_const_prop ()
+  | Float_arith _ ->
+    (* See comment in effects_and_coeffects *)
+    Flambda_features.float_const_prop ()
   | Num_conv _ | Boolean_not | Reinterpret_int64_as_float -> true
   | Unbox_number _ -> false
   | Box_number (_, Local) ->
@@ -919,7 +921,8 @@ let effects_and_coeffects_of_unary_primitive p =
        changed by user code, and thus float optimizations are allowed).
        Therefore, when 'float_const_prop () = false', we add coeffects to float
        operations so that they cannot be moved through an effectful operation.
-       (e.g. a call to a c stub that changes the rounding mode). *)
+       (e.g. a call to a c stub that changes the rounding mode). See also the
+       comment in binary_primitive_eligible_for_cse. *)
     if Flambda_features.float_const_prop ()
     then Effects.No_effects, Coeffects.No_coeffects
     else Effects.No_effects, Coeffects.Has_coeffects
@@ -1039,7 +1042,8 @@ let binary_primitive_eligible_for_cse p =
        what the situation is with regard to 80-bit precision floating-point
        support on Intel processors (and indeed whether we make use of that). As
        such, we don't CSE these comparisons unless we would also CSE
-       floating-point arithmetic operations. *)
+       floating-point arithmetic operations. See also the comment in
+       effects_and_coeffects of unary primitives. *)
     Flambda_features.float_const_prop ()
 
 let compare_binary_primitive p1 p2 =

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -619,6 +619,25 @@ let prim env res dbg p =
     let expr = variadic_primitive env dbg f args in
     expr, None, env, res, effs
 
+let effects_and_coeffects_of_prim p =
+  let effs = Flambda_primitive.effects_and_coeffects p in
+  match (p : Flambda_primitive.t) with
+  (* Float operations are not really pure since they actually access the
+     globally mutable rounding mode, which can be changed (but only from C
+     code). The Flambda_features.float_const_prop tracks whether we are allowed
+     to make optimizations assuming a non-changing rounding mode (i.e.
+     'float_const_prop () = true' means that the rounding should not be changed
+     by user code, and thus float optimizations are allowed). Therefore, when
+     'float_const_prop () = false', we add coeffects to float operations so that
+     they cannot be moved through an effectful operation. (e.g. a call to a c
+     stub that changes the rounding mode). *)
+  | Unary (Float_arith _, _) | Binary ((Float_arith _ | Float_comp _), _, _) ->
+    if Flambda_features.float_const_prop ()
+    then effs
+    else Ece.join effs Ece.read (* *)
+  (* Other operations *)
+  | Nullary _ | Unary _ | Binary _ | Ternary _ | Variadic _ -> effs
+
 (* Kinds and types *)
 
 let check_arity arity args = List.compare_lengths arity args = 0
@@ -873,7 +892,7 @@ and let_expr_simple body env res v ~num_normal_occurrences_of_bound_vars s =
 and let_expr_prim body env res v ~num_normal_occurrences_of_bound_vars p dbg =
   let v = Bound_var.var v in
   let cmm_expr, extra, env, res, effs = prim env res dbg p in
-  let effs = Ece.join effs (Flambda_primitive.effects_and_coeffects p) in
+  let effs = Ece.join effs (effects_and_coeffects_of_prim p) in
   let env =
     let_expr_bind ?extra env v ~num_normal_occurrences_of_bound_vars cmm_expr
       effs


### PR DESCRIPTION
See the added comment in `flambda_primitive.ml`.
This makes it so that `to_cmm` will not move float operations past a potential rounding mode change.