### PR TITLE
Refactoring of Lambda_to_flambda_primitives

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -634,7 +634,7 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
     in
     k acc (Some (Named.create_simple (Simple.symbol sym)))
   | prim, args ->
-    Lambda_to_flambda_primitives.convert_and_bind acc env exn_continuation
+    Lambda_to_flambda_primitives.convert_and_bind acc exn_continuation
       ~big_endian:(Env.big_endian env)
       ~register_const_string:(fun acc -> register_const_string acc)
       prim ~args dbg k
@@ -669,7 +669,7 @@ let close_named acc env ~let_bound_var (named : IR.named)
         ( Box_number (Untagged_immediate, Heap),
           Prim (Unary (Get_tag, Simple named)) )
     in
-    Lambda_to_flambda_primitives_helpers.bind_rec acc env None
+    Lambda_to_flambda_primitives_helpers.bind_rec acc None
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
       (fun acc named -> k acc (Some named))
@@ -677,7 +677,7 @@ let close_named acc env ~let_bound_var (named : IR.named)
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
       Nullary Begin_region
     in
-    Lambda_to_flambda_primitives_helpers.bind_rec acc env None
+    Lambda_to_flambda_primitives_helpers.bind_rec acc None
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
       (fun acc named -> k acc (Some named))
@@ -686,7 +686,7 @@ let close_named acc env ~let_bound_var (named : IR.named)
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
       Unary (End_region, Simple named)
     in
-    Lambda_to_flambda_primitives_helpers.bind_rec acc env None
+    Lambda_to_flambda_primitives_helpers.bind_rec acc None
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
       (fun acc named -> k acc (Some named))

--- a/middle_end/flambda2/from_lambda/lambda_conversions.ml
+++ b/middle_end/flambda2/from_lambda/lambda_conversions.ml
@@ -246,6 +246,3 @@ let convert_bigarray_layout (layout : L.bigarray_layout) :
 
 let convert_field_read_semantics (sem : L.field_read_semantics) : Mutability.t =
   match sem with Reads_agree -> Immutable | Reads_vary -> Mutable
-
-let convert_lambda_block_size (size : int) : _ Or_unknown.t =
-  Known (Targetint_31_63.Imm.of_int size)

--- a/middle_end/flambda2/from_lambda/lambda_conversions.mli
+++ b/middle_end/flambda2/from_lambda/lambda_conversions.mli
@@ -85,6 +85,4 @@ val convert_bigarray_layout :
 
 val convert_field_read_semantics : Lambda.field_read_semantics -> Mutability.t
 
-val convert_lambda_block_size : int -> Targetint_31_63.Imm.t Or_unknown.t
-
 val alloc_mode : Lambda.alloc_mode -> Alloc_mode.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1013,13 +1013,12 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
       Printlambda.primitive prim
 
 module Acc = Closure_conversion_aux.Acc
-module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
-let convert_and_bind acc env ~big_endian exn_cont ~register_const_string
+let convert_and_bind acc ~big_endian exn_cont ~register_const_string
     (prim : L.primitive) ~(args : Simple.t list) (dbg : Debuginfo.t)
     (cont : Acc.t -> Flambda.Named.t option -> Acc.t * Expr_with_acc.t) :
     Acc.t * Expr_with_acc.t =
   let expr = convert_lprim ~big_endian prim args dbg in
-  H.bind_rec acc env exn_cont ~register_const_string expr dbg (fun acc named ->
+  H.bind_rec acc exn_cont ~register_const_string expr dbg (fun acc named ->
       cont acc (Some named))

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -338,12 +338,9 @@ let array_access_validity_condition array index =
         Prim (Unary (Array_length, array)) ) ]
 
 let check_array_access ~dbg ~array ~index primitive : H.expr_primitive =
-  Checked
-    { primitive;
-      validity_conditions = array_access_validity_condition array index;
-      failure = Index_out_of_bounds;
-      dbg
-    }
+  checked_access ~primitive
+    ~conditions:(array_access_validity_condition array index)
+    ~dbg
 
 let array_load_unsafe ~array ~index (array_kind : P.Array_kind.t) :
     H.expr_primitive =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
@@ -15,12 +15,10 @@
 (**************************************************************************)
 
 module Acc = Closure_conversion_aux.Acc
-module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
 val convert_and_bind :
   Acc.t ->
-  Env.t ->
   big_endian:bool ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -115,8 +115,8 @@ let raise_exn_for_failure acc ~dbg exn_cont exn_bucket extra_let_binding =
       (Bound_pattern.singleton bound_var)
       defining_expr ~body:apply_cont
 
-let expression_for_failure acc exn_cont ~register_const_string primitive
-    dbg (failure : failure) =
+let expression_for_failure acc exn_cont ~register_const_string primitive dbg
+    (failure : failure) =
   let exn_cont =
     match exn_cont with
     | Some exn_cont -> exn_cont
@@ -250,8 +250,8 @@ let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
     in
     let failure_cont = Continuation.create () in
     let failure_handler_expr acc =
-      expression_for_failure acc exn_cont ~register_const_string primitive
-        dbg failure
+      expression_for_failure acc exn_cont ~register_const_string primitive dbg
+        failure
     in
     let check_validity_conditions =
       let prim_apply_cont acc =
@@ -321,8 +321,7 @@ let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
       cont acc (Named.create_simple (Simple.var result_var))
     in
     let ifso_handler_expr acc =
-      bind_rec acc exn_cont ~register_const_string ifso dbg
-      @@ fun acc ifso ->
+      bind_rec acc exn_cont ~register_const_string ifso dbg @@ fun acc ifso ->
       let acc, apply_cont =
         Apply_cont_with_acc.create acc join_point_cont
           ~args:[Simple.var ifso_result] ~dbg
@@ -333,8 +332,7 @@ let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
         ifso ~body
     in
     let ifnot_handler_expr acc =
-      bind_rec acc exn_cont ~register_const_string ifnot dbg
-      @@ fun acc ifnot ->
+      bind_rec acc exn_cont ~register_const_string ifnot dbg @@ fun acc ifnot ->
       let acc, apply_cont =
         Apply_cont_with_acc.create acc join_point_cont
           ~args:[Simple.var ifnot_result] ~dbg

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -87,9 +87,9 @@ let print_list_of_simple_or_prim ppf simple_or_prim_list =
     (Format.pp_print_list ~pp_sep:Format.pp_print_space print_simple_or_prim)
     simple_or_prim_list
 
-let caml_ml_array_bound_error =
-  let name = Linkage_name.create "caml_ml_array_bound_error" in
-  Symbol.create (Compilation_unit.external_symbols ()) name
+(* let caml_ml_array_bound_error =
+ *   let name = Linkage_name.create "caml_ml_array_bound_error" in
+ *   Symbol.create (Compilation_unit.external_symbols ()) name *)
 
 let raise_exn_for_failure acc ~dbg exn_cont exn_bucket extra_let_binding =
   let exn_handler = Exn_continuation.exn_handler exn_cont in
@@ -102,7 +102,7 @@ let raise_exn_for_failure acc ~dbg exn_cont exn_bucket extra_let_binding =
         (fun (simple, _kind) -> simple)
         (Exn_continuation.extra_args exn_cont)
     in
-    [exn_bucket] @ extra_args
+    exn_bucket :: extra_args
   in
   let acc, apply_cont =
     Apply_cont_with_acc.create acc ~trap_action exn_handler ~args ~dbg

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -58,7 +58,6 @@ open Closure_conversion_aux
 
 val bind_rec :
   Acc.t ->
-  Env.t ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->
   expr_primitive ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -47,8 +47,6 @@ and simple_or_prim =
   | Simple of Simple.t
   | Prim of expr_primitive
 
-val caml_ml_array_bound_error : Symbol.t
-
 val print_expr_primitive : Format.formatter -> expr_primitive -> unit
 
 val print_simple_or_prim : Format.formatter -> simple_or_prim -> unit


### PR DESCRIPTION
This factorizes a lot of very similar construction for bigarray and division primitives. With some additional cleanup.