### PR TITLE
Export Cfg_with_layout.print_dot

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -386,8 +386,7 @@ let is_pure_basic : basic -> bool = function
   | Poptrap -> true
   | Prologue -> true
 
-let print_basic ppf i =
-  Format.fprintf ppf "%a" dump_basic i
+let print_basic ppf i = Format.fprintf ppf "%a" dump_basic i
 
 let print_terminator ?sep ppf ti =
   Format.fprintf ppf "%a" (dump_terminator ?sep) ti

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -386,11 +386,11 @@ let is_pure_basic : basic -> bool = function
   | Poptrap -> true
   | Prologue -> true
 
-let print_basic oc i =
-  Format.kasprintf (Printf.fprintf oc "%s") "%a" dump_basic i
+let print_basic ppf i =
+  Format.fprintf ppf "%a" dump_basic i
 
-let print_terminator oc ?sep ti =
-  Format.kasprintf (Printf.fprintf oc "%s") "%a" (dump_terminator ?sep) ti
+let print_terminator ?sep ppf ti =
+  Format.fprintf ppf "%a" (dump_terminator ?sep) ti
 
 let is_noop_move instr =
   match instr.desc with

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -127,9 +127,9 @@ val dump_terminator :
 val dump_basic : Format.formatter -> basic instruction -> unit
 
 val print_terminator :
-  out_channel -> ?sep:string -> terminator instruction -> unit
+  ?sep:string -> Format.formatter -> terminator instruction -> unit
 
-val print_basic : out_channel -> basic instruction -> unit
+val print_basic : Format.formatter -> basic instruction -> unit
 
 (* CR-someday gyorsh: Current version of cfg is a half-way house in terms of its
    exception handling. It has a lot of redundancy and the result of the

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -58,6 +58,13 @@ val save_as_dot :
   string ->
   unit
 
-val print : t -> out_channel -> string -> unit
+val print_dot :
+  ?show_instr:bool ->
+  ?show_exn:bool ->
+  ?annotate_block:(Label.t -> string) ->
+  ?annotate_succ:(Label.t -> Label.t -> string) ->
+  Format.formatter ->
+  t ->
+  unit
 
 val dump : Format.formatter -> t -> msg:string -> unit


### PR DESCRIPTION
This PR exports `Cfg_with_layout.print_dot`.

To do that I had to replace occurrences of `out_channel` by `Format.formatter`.
This led me to remove `Cfg_with_layout.print` but former calls to `Cfg_with_layout.print oc t msg`
can be replaced with `Cfg_with_layout.dump ~msg (Format.formatter_of_out_channel oc) t msg`
going forward.