### PR TITLE
Review of kinds/ directory; add tagging+untagging primitives

### DIFF
--- a/middle_end/flambda2/bound_identifiers/bound_parameters.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameters.ml
@@ -60,9 +60,12 @@ let var_set t = Variable.Set.of_list (vars t)
 
 let rename t = List.map (fun t -> BP.rename t) t
 
-let arity t = List.map (fun t -> Flambda_kind.With_subkind.kind (BP.kind t)) t
+let arity t =
+  List.map (fun t -> Flambda_kind.With_subkind.kind (BP.kind t)) t
+  |> Flambda_arity.create
 
-let arity_with_subkinds t = List.map (fun t -> BP.kind t) t
+let arity_with_subkinds t =
+  List.map (fun t -> BP.kind t) t |> Flambda_arity.With_subkinds.create
 
 let free_names t =
   List.fold_left

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -765,7 +765,8 @@ module Let_with_acc = struct
             ~find_code_characteristics:(fun code_id ->
               let code = Code_id.Map.find code_id code_mapping in
               { cost_metrics = Code.cost_metrics code;
-                params_arity = List.length (Code.params_arity code)
+                params_arity =
+                  Flambda_arity.With_subkinds.cardinal (Code.params_arity code)
               })
             set_of_closures
         | Rec_info _ -> Cost_metrics.zero

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1622,7 +1622,7 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~scrutinee
           match Tag.Scannable.create sw_tag with
           | Some tag ->
             let tag' = Tag.Scannable.to_tag tag in
-            if Tag.is_structured_block_but_not_a_variant tag'
+            if Tag.is_structured_block_but_not_data_constructor tag'
             then
               Misc.fatal_errorf
                 "Bad tag %a in [Lswitch] (tag is that of a scannable block, \

--- a/middle_end/flambda2/kinds/flambda_arity.ml
+++ b/middle_end/flambda2/kinds/flambda_arity.ml
@@ -14,9 +14,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 type t = Flambda_kind.t list
+
+type arity = t
 
 let nullary = []
 
@@ -24,23 +26,25 @@ let create t = t
 
 let length t = List.length t
 
+let to_list t = t
+
 include Container_types.Make (struct
   type nonrec t = t
 
-  let compare t1 t2 = Misc.Stdlib.List.compare Flambda_kind.compare t1 t2
+  let compare t1 t2 = List.compare Flambda_kind.compare t1 t2
 
   let equal t1 t2 = compare t1 t2 = 0
 
   let hash = Hashtbl.hash
 
-  let [@ocamlformat "disable"] print ppf t =
+  let print ppf t =
     match t with
     | [] -> Format.pp_print_string ppf "Nullary"
     | _ ->
       Format.fprintf ppf "@[%a@]"
         (Format.pp_print_list
-          ~pp_sep:(fun ppf () -> Format.fprintf ppf " @<1>\u{2a2f} ")
-          Flambda_kind.print)
+           ~pp_sep:(fun ppf () -> Format.fprintf ppf " @<1>\u{2a2f} ")
+           Flambda_kind.print)
         t
 end)
 
@@ -54,30 +58,29 @@ let is_singleton_value t =
   | _ -> false
 
 module With_subkinds = struct
-  type arity = t
-
   type t = Flambda_kind.With_subkind.t list
 
   let create t = t
 
+  let to_list t = t
+
   include Container_types.Make (struct
     type nonrec t = t
 
-    let compare t1 t2 =
-      Misc.Stdlib.List.compare Flambda_kind.With_subkind.compare t1 t2
+    let compare t1 t2 = List.compare Flambda_kind.With_subkind.compare t1 t2
 
     let equal t1 t2 = compare t1 t2 = 0
 
     let hash = Hashtbl.hash
 
-    let [@ocamlformat "disable"] print ppf t =
+    let print ppf t =
       match t with
       | [] -> Format.pp_print_string ppf "Nullary"
       | _ ->
         Format.fprintf ppf "@[%a@]"
           (Format.pp_print_list
-            ~pp_sep:(fun ppf () -> Format.fprintf ppf " @<1>\u{2a2f} ")
-            Flambda_kind.With_subkind.print)
+             ~pp_sep:(fun ppf () -> Format.fprintf ppf " @<1>\u{2a2f} ")
+             Flambda_kind.With_subkind.print)
           t
   end)
 
@@ -89,6 +92,12 @@ module With_subkinds = struct
              Flambda_kind.value ->
       true
     | _ -> false
+
+  let cardinal t = List.length t
+
+  let nullary = []
+
+  let is_nullary t = match t with [] -> true | _ :: _ -> false
 
   let to_arity t = List.map Flambda_kind.With_subkind.kind t
 

--- a/middle_end/flambda2/kinds/flambda_arity.mli
+++ b/middle_end/flambda2/kinds/flambda_arity.mli
@@ -14,16 +14,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Generalization of the concepts of "number of arguments" and "number of
-    return values". *)
+(** Arities are lists of kinds, sometimes with subkinds, used to describe things
+    such as the kinding of function and continuation parameter lists. *)
 
-[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
-(* CR mshinwell: This should be made abstract. *)
+type t
 
-type t = Flambda_kind.t list
+type arity = t
 
 val create : Flambda_kind.t list -> t
+
+val to_list : t -> Flambda_kind.t list
 
 val nullary : t
 
@@ -38,16 +40,23 @@ val is_singleton_value : t -> bool
 include Container_types.S with type t := t
 
 module With_subkinds : sig
-  type arity = t
-
-  type t = Flambda_kind.With_subkind.t list
+  type t
 
   val create : Flambda_kind.With_subkind.t list -> t
+
+  val to_list : t -> Flambda_kind.With_subkind.t list
+
+  val nullary : t
+
+  val is_nullary : t -> bool
+
+  val cardinal : t -> int
 
   val is_singleton_value : t -> bool
 
   val to_arity : t -> arity
 
+  (** [of_arity] sets the subkind information to [Anything]. *)
   val of_arity : arity -> t
 
   val compatible : t -> when_used_at:t -> bool

--- a/middle_end/flambda2/kinds/tag.ml
+++ b/middle_end/flambda2/kinds/tag.ml
@@ -37,14 +37,13 @@ let min_tag = 0
 
 let max_tag = 255
 
-let create tag = if tag < min_tag || tag > max_tag then None else Some tag
-
 let create_exn tag =
   if tag < min_tag || tag > max_tag
   then Misc.fatal_error (Printf.sprintf "Tag.create_exn %d" tag)
   else tag
 
-let create_from_targetint_imm ti =
+let create_from_targetint imm =
+  let ti = Targetint_31_63.to_targetint imm in
   let min_tag = Targetint_31_63.Imm.of_int min_tag in
   let max_tag = Targetint_31_63.Imm.of_int max_tag in
   if Targetint_31_63.Imm.compare ti min_tag >= 0
@@ -52,16 +51,10 @@ let create_from_targetint_imm ti =
   then Some (Targetint_31_63.Imm.to_int ti)
   else None
 
-let create_from_targetint imm =
-  create_from_targetint_imm (Targetint_31_63.to_targetint imm)
-
 let to_int t = t
 
-let to_targetint t = Targetint_32_64.of_int (to_int t)
-
-let to_targetint_ocaml t = Targetint_31_63.Imm.of_int (to_int t)
-
-let to_target_imm t = Targetint_31_63.int (to_targetint_ocaml t)
+let to_targetint_31_63 t =
+  Targetint_31_63.int (Targetint_31_63.Imm.of_int (to_int t))
 
 let zero = 0
 
@@ -82,8 +75,6 @@ let object_tag = Obj.object_tag
 let forward_tag = Obj.forward_tag
 
 let lazy_tag = Obj.lazy_tag
-
-let arbitrary = max_int
 
 module Scannable = struct
   type nonrec t = t
@@ -113,17 +104,6 @@ module Scannable = struct
   let object_tag = Obj.object_tag
 end
 
-let to_scannable_set set =
-  Set.fold
-    (fun t result ->
-      match Scannable.create t with
-      | None -> result
-      | Some scannable -> Scannable.Set.add scannable result)
-    set Scannable.Set.empty
-
-let is_structured_block t =
-  match Scannable.create t with None -> false | Some _ -> true
-
 module Non_scannable = struct
   type nonrec t = t
 
@@ -145,13 +125,8 @@ module Non_scannable = struct
     if tag < min_tag || tag >= Obj.no_scan_tag then None else Some tag
 end
 
-let is_structured_block_but_not_a_variant t =
-  is_structured_block t && t > Obj.last_non_constant_constructor_tag
+let is_structured_block t =
+  match Scannable.create t with None -> false | Some _ -> true
 
-let all_regular_tags =
-  let rec compute_all_tags acc n =
-    if n > Obj.last_non_constant_constructor_tag
-    then acc
-    else compute_all_tags (Set.add n acc) (succ n)
-  in
-  compute_all_tags Set.empty 0
+let is_structured_block_but_not_data_constructor t =
+  is_structured_block t && t > Obj.last_non_constant_constructor_tag

--- a/middle_end/flambda2/kinds/tag.mli
+++ b/middle_end/flambda2/kinds/tag.mli
@@ -16,31 +16,22 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-(** Tags on runtime boxed values. *)
+(** Tags on OCaml values. *)
 
 include Container_types.S
 
 type tag = t
 
-val create : int -> t option
-
 val create_exn : int -> t
 
 val create_from_targetint : Targetint_31_63.t -> t option
 
-val create_from_targetint_imm : Targetint_31_63.Imm.t -> t option
-
 val to_int : t -> int
 
-val to_target_imm : t -> Targetint_31_63.t
-
-val to_targetint : t -> Targetint_32_64.t
-
-val to_targetint_ocaml : t -> Targetint_31_63.Imm.t
+val to_targetint_31_63 : t -> Targetint_31_63.t
 
 val zero : t
 
-(* CR mshinwell: Remove "_tag" suffixes *)
 val string_tag : t
 
 val closure_tag : t
@@ -59,22 +50,14 @@ val forward_tag : t
 
 val lazy_tag : t
 
-(** A tag to be used when a [Tag.t] must be provided, but it will never be
-    used. *)
-val arbitrary : t
-
 (** Returns [true] iff the supplied tag is that of a GC-scannable block. *)
 val is_structured_block : t -> bool
 
-(** Returns [true] iff the supplied tag is that of a GC-scannable block, but the
-    block is not treated like a variant, for example a lazy value. *)
-val is_structured_block_but_not_a_variant : t -> bool
+(** Returns [true] iff the supplied tag is that of a GC-scannable block, but
+    outside the range of data constructors (or arrays, records, etc.), for
+    example a lazy value. *)
+val is_structured_block_but_not_data_constructor : t -> bool
 
-(** Returns the set of all tags allowed for regular blocks *)
-val all_regular_tags : Set.t
-
-(* CR mshinwell: This name should be changed---all "value"s are scannable.
-   "Structured"? *)
 module Scannable : sig
   (** Tags that are strictly less than [No_scan_tag], corresponding to blocks
       with fields that can be scanned by the GC. *)
@@ -100,8 +83,6 @@ module Scannable : sig
 
   include Container_types.S with type t := t
 end
-
-val to_scannable_set : Set.t -> Scannable.Set.t
 
 module Non_scannable : sig
   (** Tags that are at or above [No_scan_tag], corresponding to blocks whose

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -184,7 +184,6 @@ type box_kind = Flambda_kind.Boxable_number.t =
   | Naked_int32
   | Naked_int64
   | Naked_nativeint
-  | Untagged_immediate
 
 type generic_array_specialisation =
   | No_specialisation
@@ -270,6 +269,8 @@ type unop =
       }
   | String_length of string_or_bytes
   | Unbox_number of box_kind
+  | Untag_immediate
+  | Tag_immediate
 
 type 'a comparison_behaviour = 'a Flambda_primitive.comparison_behaviour =
   | Yielding_bool of 'a

--- a/middle_end/flambda2/parser/flambda_parser.ml
+++ b/middle_end/flambda2/parser/flambda_parser.ml
@@ -10805,7 +10805,7 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : 'tv_unop = 
 # 352 "flambda_parser.mly"
-                 ( Box_number Untagged_immediate )
+                 ( Tag_immediate )
 # 10810 "flambda_parser_in.ml"
          in
         {
@@ -10930,7 +10930,7 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : 'tv_unop = 
 # 357 "flambda_parser.mly"
-                   ( Unbox_number Untagged_immediate )
+                   ( Untag_immediate )
 # 10935 "flambda_parser_in.ml"
          in
         {

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -349,12 +349,12 @@ unop:
     RPAREN
     { Project_function_slot { move_from; move_to } }
   | PRIM_STRING_LENGTH { String_length String }
-  | PRIM_TAG_IMM { Box_number Untagged_immediate }
+  | PRIM_TAG_IMM { Tag_immediate }
   | PRIM_UNBOX_FLOAT { Unbox_number Naked_float }
   | PRIM_UNBOX_INT32 { Unbox_number Naked_int32 }
   | PRIM_UNBOX_INT64 { Unbox_number Naked_int64 }
   | PRIM_UNBOX_NATIVEINT { Unbox_number Naked_nativeint }
-  | PRIM_UNTAG_IMM { Unbox_number Untagged_immediate }
+  | PRIM_UNTAG_IMM { Untag_immediate }
 
 infix_binop:
   | o = binary_int_arith_op { Int_arith o }

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -429,7 +429,7 @@ let kind_with_subkind (k : Flambda_kind.With_subkind.t) =
   convert (Flambda_kind.With_subkind.descr k)
 
 let arity (a : Flambda_arity.With_subkinds.t) : Fexpr.arity =
-  List.map kind_with_subkind a
+  List.map kind_with_subkind (Flambda_arity.With_subkinds.to_list a)
 
 let is_default_kind_with_subkind (k : Flambda_kind.With_subkind.t) =
   match Flambda_kind.With_subkind.descr k with
@@ -444,7 +444,9 @@ let kind_with_subkind_opt (k : Flambda_kind.With_subkind.t) :
   if is_default_kind_with_subkind k then None else Some (kind_with_subkind k)
 
 let is_default_arity (a : Flambda_arity.With_subkinds.t) =
-  match a with [k] -> is_default_kind_with_subkind k | _ -> false
+  match Flambda_arity.With_subkinds.to_list a with
+  | [k] -> is_default_kind_with_subkind k
+  | _ -> false
 
 let arity_opt (a : Flambda_arity.With_subkinds.t) : Fexpr.arity option =
   if is_default_arity a then None else Some (arity a)
@@ -466,11 +468,13 @@ let unop env (op : Flambda_primitive.unary_primitive) : Fexpr.unop =
   | Array_length -> Array_length
   (* CR mshinwell: support local allocs in fexpr *)
   | Box_number (bk, _alloc_mode) -> Box_number bk
+  | Tag_immediate -> Tag_immediate
   | Get_tag -> Get_tag
   | Is_int -> Is_int
   | Num_conv { src; dst } -> Num_conv { src; dst }
   | Opaque_identity -> Opaque_identity
   | Unbox_number bk -> Unbox_number bk
+  | Untag_immediate -> Untag_immediate
   | Project_value_slot { project_from; value_slot } ->
     let project_from = Env.translate_function_slot env project_from in
     let value_slot = Env.translate_value_slot env value_slot in

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -414,18 +414,17 @@ let binop ppf binop a b =
 
 let unop ppf u =
   let str s = Format.pp_print_string ppf s in
-  let box_or_unbox verb_not_imm verb_imm (bk : box_kind) =
+  let box_or_unbox verb_not_imm (bk : box_kind) =
     let print verb obj = Format.fprintf ppf "%%%s_%s" verb obj in
     match bk with
     | Naked_float -> print verb_not_imm "float"
     | Naked_int32 -> print verb_not_imm "int32"
     | Naked_int64 -> print verb_not_imm "int64"
     | Naked_nativeint -> print verb_not_imm "nativeint"
-    | Untagged_immediate -> print verb_imm "imm"
   in
   match u with
   | Array_length -> str "%array_length"
-  | Box_number bk -> box_or_unbox "Box" "Tag" bk
+  | Box_number bk -> box_or_unbox "Box" bk
   | Get_tag -> str "%get_tag"
   | Is_int -> str "%is_int"
   | Num_conv { src; dst } ->
@@ -440,7 +439,9 @@ let unop ppf u =
       function_slot move_from function_slot move_to
   | String_length Bytes -> str "%bytes_length"
   | String_length String -> str "%string_length"
-  | Unbox_number bk -> box_or_unbox "unbox" "untag" bk
+  | Unbox_number bk -> box_or_unbox "unbox" bk
+  | Untag_immediate -> str "%untag_imm"
+  | Tag_immediate -> str "%tag_imm"
 
 let ternop ppf t a1 a2 a3 =
   match t with

--- a/middle_end/flambda2/simplify/continuation_in_env.ml
+++ b/middle_end/flambda2/simplify/continuation_in_env.ml
@@ -74,7 +74,7 @@ let arity t =
         cost_metrics_of_handler = _
       } ->
     Bound_parameters.arity_with_subkinds params
-  | Non_inlinable_zero_arity _ -> []
+  | Non_inlinable_zero_arity _ -> Flambda_arity.With_subkinds.nullary
   | Non_inlinable_non_zero_arity { arity }
   | Toplevel_or_function_return_or_exn_continuation { arity }
   | Unreachable { arity } ->

--- a/middle_end/flambda2/simplify/env/continuation_uses.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses.ml
@@ -84,7 +84,9 @@ let get_arg_types_by_use_id t =
           in
           Apply_cont_rewrite_id.Map.add (U.id use) arg_at_use arg_map)
         args (U.arg_types use))
-    (List.map (fun _ -> Apply_cont_rewrite_id.Map.empty) t.arity)
+    (List.map
+       (fun _ -> Apply_cont_rewrite_id.Map.empty)
+       (Flambda_arity.to_list t.arity))
     t.uses
 
 let get_typing_env_no_more_than_one_use t =

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -729,7 +729,7 @@ let rewrite_exn_continuation rewrite id exn_cont =
       "Arity of exception continuation %a does not match@ [original_params] \
        (%a)"
       Exn_continuation.print exn_cont Bound_parameters.print original_params';
-  assert (List.length exn_cont_arity >= 1);
+  assert (Flambda_arity.With_subkinds.cardinal exn_cont_arity >= 1);
   let pre_existing_extra_params_with_args =
     List.combine (List.tl original_params)
       (Exn_continuation.extra_args exn_cont)
@@ -833,8 +833,14 @@ let add_wrapper_for_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id
     | Continuation cont -> (
       (* In this case, any generated [Apply_cont] will sit inside a wrapper that
          binds [kinded_params]. *)
-      let params = List.map (fun _kind -> Variable.create "param") arity in
-      let params = List.map2 BP.create params arity in
+      let params =
+        List.map
+          (fun _kind -> Variable.create "param")
+          (Flambda_arity.With_subkinds.to_list arity)
+      in
+      let params =
+        List.map2 BP.create params (Flambda_arity.With_subkinds.to_list arity)
+      in
       let args = List.map BP.simple params in
       let params = Bound_parameters.create params in
       let apply_cont = Apply_cont.create cont ~args ~dbg:Debuginfo.none in

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -101,7 +101,8 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
             (UE.create (DA.are_rebuilding_terms dacc))
             (Exn_continuation.exn_handler exn_continuation)
             scope
-            [Flambda_kind.With_subkind.any_value]
+            (Flambda_arity.With_subkinds.create
+               [Flambda_kind.With_subkind.any_value])
         in
         let uenv =
           match Apply.continuation apply with

--- a/middle_end/flambda2/simplify/number_adjuncts.ml
+++ b/middle_end/flambda2/simplify/number_adjuncts.ml
@@ -129,8 +129,6 @@ module type Boxable = sig
   val these_boxed : Num.Set.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
   val box : Flambda2_types.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
-
-  type naked_number_kind
 end
 
 module type Boxable_number_kind = sig
@@ -355,8 +353,6 @@ module For_floats : Boxable_number_kind = struct
 
   let term_unboxed f =
     Named.create_simple (Simple.const (Reg_width_const.naked_float f))
-
-  type naked_number_kind = K.naked_float
 end
 
 module For_int32s : Boxable_int_number_kind = struct
@@ -426,8 +422,6 @@ module For_int32s : Boxable_int_number_kind = struct
 
   let term_unboxed i =
     Named.create_simple (Simple.const (Reg_width_const.naked_int32 i))
-
-  type naked_number_kind = K.naked_int32
 end
 
 module For_int64s : Boxable_int_number_kind = struct
@@ -497,8 +491,6 @@ module For_int64s : Boxable_int_number_kind = struct
 
   let term_unboxed i =
     Named.create_simple (Simple.const (Reg_width_const.naked_int64 i))
-
-  type naked_number_kind = K.naked_int64
 end
 
 module For_nativeints : Boxable_int_number_kind = struct
@@ -564,6 +556,4 @@ module For_nativeints : Boxable_int_number_kind = struct
 
   let term_unboxed i =
     Named.create_simple (Simple.const (Reg_width_const.naked_nativeint i))
-
-  type naked_number_kind = K.naked_nativeint
 end

--- a/middle_end/flambda2/simplify/number_adjuncts.mli
+++ b/middle_end/flambda2/simplify/number_adjuncts.mli
@@ -128,8 +128,6 @@ module type Boxable = sig
   val these_boxed : Num.Set.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
   val box : Flambda2_types.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
-
-  type naked_number_kind
 end
 
 module type Boxable_number_kind = sig

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -47,8 +47,9 @@ let run ~cmx_loader ~round unit =
   let dacc = DA.create denv Continuation_uses_env.empty in
   let body, uacc =
     Simplify_expr.simplify_toplevel dacc (FU.body unit) ~return_continuation
-      ~return_arity:[K.With_subkind.any_value] ~exn_continuation
-      ~return_cont_scope ~exn_cont_scope
+      ~return_arity:
+        (Flambda_arity.With_subkinds.create [K.With_subkind.any_value])
+      ~exn_continuation ~return_cont_scope ~exn_cont_scope
   in
   let body = Rebuilt_expr.to_expr body (UA.are_rebuilding_terms uacc) in
   let name_occurrences = UA.name_occurrences uacc in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -762,9 +762,7 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
         dacc )
     | Indirect_known_arity { param_arity; return_arity } ->
       let args_arity =
-        T.arity_of_list arg_types |> Flambda_arity.to_list
-        |> List.map (fun kind -> K.With_subkind.create kind Anything)
-        |> Flambda_arity.With_subkinds.create
+        T.arity_of_list arg_types |> Flambda_arity.With_subkinds.of_arity
       in
       if not
            (Flambda_arity.With_subkinds.compatible args_arity
@@ -785,9 +783,7 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
       call_kind, use_id, dacc
     | Direct { return_arity; _ } ->
       let param_arity =
-        T.arity_of_list arg_types |> Flambda_arity.to_list
-        |> List.map (fun kind -> K.With_subkind.create kind Anything)
-        |> Flambda_arity.With_subkinds.create
+        T.arity_of_list arg_types |> Flambda_arity.With_subkinds.of_arity
       in
       (* Some types have regressed in precision. Since this used to be a direct
          call, however, we know the function's arity even though we don't know

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -53,7 +53,7 @@ let simplify_direct_tuple_application ~simplify_expr dacc apply
     ~params_arity:param_arity ~result_arity ~apply_alloc_mode
     ~contains_no_escaping_local_allocs ~down_to_up =
   let dbg = Apply.dbg apply in
-  let n = List.length param_arity in
+  let n = Flambda_arity.With_subkinds.cardinal param_arity in
   (* Split the tuple argument from other potential over application arguments *)
   let tuple, over_application_args =
     match Apply.args apply with
@@ -70,8 +70,8 @@ let simplify_direct_tuple_application ~simplify_expr dacc apply
   (* Change the application to operate on the fields of the tuple *)
   let apply =
     Apply.with_args apply
-    @@ List.map (fun (v, _) -> Simple.var v) vars_and_fields
-    @ over_application_args
+      (List.map (fun (v, _) -> Simple.var v) vars_and_fields
+      @ over_application_args)
   in
   (* Immediately simplify over_applications to avoid having direct applications
      with the wrong arity. *)
@@ -183,14 +183,16 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
       | Return apply_return_continuation ->
         Result_types.pattern_match result_types
           ~f:(fun ~params ~results env_extension ->
-            if List.length params_arity <> Bound_parameters.cardinal params
+            if Flambda_arity.With_subkinds.cardinal params_arity
+               <> Bound_parameters.cardinal params
             then
               Misc.fatal_errorf
                 "Params arity %a does not match up with params in the result \
                  types structure:@ %a@ for application:@ %a"
                 Flambda_arity.With_subkinds.print params_arity
                 Result_types.print result_types Apply.print apply;
-            if List.length result_arity <> Bound_parameters.cardinal results
+            if Flambda_arity.With_subkinds.cardinal result_arity
+               <> Bound_parameters.cardinal results
             then
               Misc.fatal_errorf
                 "Result arity %a does not match up with the result types \
@@ -212,6 +214,9 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
                   DE.add_equation_on_variable denv (BP.var param)
                     (T.alias_type_of (K.With_subkind.kind (BP.kind param)) arg))
                 denv params args
+            in
+            let result_arity =
+              Flambda_arity.With_subkinds.to_list result_arity
             in
             let denv =
               List.fold_left2
@@ -296,7 +301,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
            "[@unroll] attributes may not be used on partial applications")
     | Default_inlined | Hint_inlined -> ()
   end;
-  let arity = List.length param_arity in
+  let arity = Flambda_arity.With_subkinds.cardinal param_arity in
   let args_arity = List.length args in
   assert (arity > args_arity);
   let applied_args, remaining_param_arity =
@@ -307,7 +312,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
           Misc.fatal_errorf "Non-[value] kind in partial application: %a"
             Apply.print apply;
         arg)
-      args param_arity
+      args
+      (Flambda_arity.With_subkinds.to_list param_arity)
   in
   let wrapper_var = Variable.create "partial_app" in
   let compilation_unit = Compilation_unit.get_current_exn () in
@@ -662,7 +668,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
 
          - Indirect calls adopt the calling convention consisting of a single
          tuple argument, irrespective of what [Code.params_arity] says. *)
-      let num_params = List.length params_arity in
+      let num_params = Flambda_arity.With_subkinds.cardinal params_arity in
       if provided_num_args = num_params
       then
         simplify_direct_full_application ~simplify_expr dacc apply function_decl
@@ -756,8 +762,9 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
         dacc )
     | Indirect_known_arity { param_arity; return_arity } ->
       let args_arity =
-        T.arity_of_list arg_types
+        T.arity_of_list arg_types |> Flambda_arity.to_list
         |> List.map (fun kind -> K.With_subkind.create kind Anything)
+        |> Flambda_arity.With_subkinds.create
       in
       if not
            (Flambda_arity.With_subkinds.compatible args_arity
@@ -778,8 +785,9 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
       call_kind, use_id, dacc
     | Direct { return_arity; _ } ->
       let param_arity =
-        T.arity_of_list arg_types
+        T.arity_of_list arg_types |> Flambda_arity.to_list
         |> List.map (fun kind -> K.With_subkind.create kind Anything)
+        |> Flambda_arity.With_subkinds.create
       in
       (* Some types have regressed in precision. Since this used to be a direct
          call, however, we know the function's arity even though we don't know
@@ -948,7 +956,9 @@ let simplify_method_call dacc apply ~callee_ty ~kind:_ ~obj ~arg_types
   in
   let denv = DA.denv dacc in
   DE.check_simple_is_bound denv obj;
-  let expected_arity = List.map (fun _ -> K.value) arg_types in
+  let expected_arity =
+    List.map (fun _ -> K.value) arg_types |> Flambda_arity.create
+  in
   let args_arity = T.arity_of_list arg_types in
   if not (Flambda_arity.equal expected_arity args_arity)
   then

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -133,7 +133,7 @@ let project_tuple ~dbg ~size ~field tuple =
 
 let split_direct_over_application apply ~param_arity ~result_arity
     ~(apply_alloc_mode : Alloc_mode.t) ~contains_no_escaping_local_allocs =
-  let arity = List.length param_arity in
+  let arity = Flambda_arity.With_subkinds.cardinal param_arity in
   let args = Apply.args apply in
   assert (arity < List.length args);
   let first_args, remaining_args = Misc.Stdlib.List.split_at arity args in
@@ -192,7 +192,7 @@ let split_direct_over_application apply ~param_arity ~result_arity
         List.mapi
           (fun i kind ->
             BP.create (Variable.create ("result" ^ string_of_int i)) kind)
-          result_arity
+          (Flambda_arity.With_subkinds.to_list result_arity)
       in
       let call_return_continuation, call_return_continuation_free_names =
         match Apply.continuation apply with

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -91,7 +91,8 @@ and simplify_toplevel dacc expr ~return_continuation ~return_arity
         in
         let uenv =
           UE.add_function_return_or_exn_continuation uenv exn_continuation
-            exn_cont_scope [K.With_subkind.any_value]
+            exn_cont_scope
+            (Flambda_arity.With_subkinds.create [K.With_subkind.any_value])
         in
         let uacc =
           UA.create ~required_names ~reachable_code_ids

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -500,7 +500,7 @@ let simplify_function0 context ~used_value_slots ~shareable_constants
         BP.create
           (Variable.create ("result" ^ string_of_int i))
           kind_with_subkind)
-      result_arity
+      (Flambda_arity.With_subkinds.to_list result_arity)
     |> Bound_parameters.create
   in
   let ( params,
@@ -1089,7 +1089,9 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
       in
       Cost_metrics.
         { cost_metrics = Code_metadata.cost_metrics code_metadata;
-          params_arity = List.length (Code_metadata.params_arity code_metadata)
+          params_arity =
+            Flambda_arity.With_subkinds.cardinal
+              (Code_metadata.params_arity code_metadata)
         }
     in
     Simplified_named.reachable_with_known_free_names ~find_code_characteristics

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -46,7 +46,7 @@ module Immediate = struct
       prove_is_a_boxed_number = T.prove_is_a_tagged_immediate
     }
 
-  let unboxing_prim simple = P.(Unary (Unbox_number Untagged_immediate, simple))
+  let unboxing_prim simple = P.(Unary (Untag_immediate, simple))
 
   let unboxer =
     { var_name = "naked_immediate";

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -89,7 +89,7 @@ let wrap_inlined_body_for_exn_support acc ~extra_args ~apply_exn_continuation
       let kinded_params =
         List.map
           (fun k -> Bound_parameter.create (Variable.create "wrapper_return") k)
-          result_arity
+          (Flambda_arity.With_subkinds.to_list result_arity)
       in
       let trap_action =
         Trap_action.Pop { exn_handler = wrapper; raise_kind = None }

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -510,7 +510,7 @@ module Greedy = struct
             let module CM = Code_metadata in
             let is_tupled = CM.is_tupled code_metadata in
             let params_arity = CM.params_arity code_metadata in
-            let arity = List.length params_arity in
+            let arity = Flambda_arity.With_subkinds.cardinal params_arity in
             let size = if arity = 1 && not is_tupled then 2 else 3 in
             let s = create_slot size (Function_slot c) in
             s, add_function_slot state c s

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -131,15 +131,14 @@ let invariant
           print t
   end;
   match continuation with
-  | Never_returns -> begin
-    match Call_kind.return_arity call_kind with
-    | [] -> ()
-    | a ->
+  | Never_returns ->
+    let return_arity = Call_kind.return_arity call_kind in
+    if not (Flambda_arity.With_subkinds.is_nullary return_arity)
+    then
       Misc.fatal_errorf
-        "This [Apply] never returns and so expects an empty arity, but has a \
-         call kind arity of %a:@ %a"
-        Flambda_arity.With_subkinds.print a print t
-  end
+        "This [Apply] never returns and so should have a nullary return arity, \
+         but instead has a return arity of %a:@ %a"
+        Flambda_arity.With_subkinds.print return_arity print t
   | Return _ -> ()
 
 let create ~callee ~continuation exn_continuation ~args ~call_kind dbg ~inlined

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -17,9 +17,8 @@
 [@@@ocaml.warning "+a-30-40-41-42"]
 
 let check_arity arity =
-  match Flambda_arity.With_subkinds.to_list arity with
-  | [] -> Misc.fatal_error "Invalid empty arity"
-  | _ :: _ -> ()
+  if Flambda_arity.With_subkinds.is_nullary arity
+  then Misc.fatal_error "Invalid nullary arity"
 
 let fprintf = Format.fprintf
 

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -45,7 +45,10 @@ let newer_version_of { newer_version_of; _ } = newer_version_of
 let params_arity { params_arity; _ } = params_arity
 
 let num_leading_heap_params { params_arity; num_trailing_local_params; _ } =
-  let n = List.length params_arity - num_trailing_local_params in
+  let n =
+    Flambda_arity.With_subkinds.cardinal params_arity
+    - num_trailing_local_params
+  in
   assert (n >= 0);
   (* see [create] *)
   n
@@ -101,7 +104,8 @@ let create code_id ~newer_version_of ~params_arity ~num_trailing_local_params
         "Stubs may not be annotated as [Always_inline] or [Unroll]"
   end;
   if num_trailing_local_params < 0
-     || num_trailing_local_params > List.length params_arity
+     || num_trailing_local_params
+        > Flambda_arity.With_subkinds.cardinal params_arity
   then
     Misc.fatal_errorf
       "Illegal num_trailing_local_params=%d for params arity: %a"

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -118,7 +118,6 @@ let arith_conversion_size src dst =
 let unbox_number kind =
   match (kind : Flambda_kind.Boxable_number.t) with
   | Naked_float -> 1 (* 1 load *)
-  | Untagged_immediate -> 1 (* 1 shift *)
   | Naked_int64 when arch32 -> 4 (* 2 Cadda + 2 loads *)
   | Naked_int32 | Naked_int64 | Naked_nativeint -> 2
 (* Cadda + load *)
@@ -126,7 +125,6 @@ let unbox_number kind =
 let box_number kind =
   match (kind : Flambda_kind.Boxable_number.t) with
   | Naked_float -> alloc_size (* 1 alloc *)
-  | Untagged_immediate -> 2 (* 1 shift + add *)
   | Naked_int32 when not arch32 -> 1 + alloc_size (* shift/sextend + alloc *)
   | Naked_int32 | Naked_int64 | Naked_nativeint -> alloc_size
 (* alloc *)
@@ -337,7 +335,9 @@ let unary_prim_size prim =
   | Boolean_not -> 1
   | Reinterpret_int64_as_float -> 0
   | Unbox_number k -> unbox_number k
+  | Untag_immediate -> 1 (* 1 shift *)
   | Box_number (k, _alloc_mode) -> box_number k
+  | Tag_immediate -> 2 (* 1 shift + add *)
   | Project_function_slot _ -> 1 (* caddv *)
   | Project_value_slot _ -> 1 (* load *)
   | Is_boxed_float -> 4 (* tag load + comparison *)

--- a/middle_end/flambda2/terms/exn_continuation.ml
+++ b/middle_end/flambda2/terms/exn_continuation.ml
@@ -105,7 +105,7 @@ let arity t =
   let exn_bucket_kind =
     Flambda_kind.With_subkind.create Flambda_kind.value Anything
   in
-  exn_bucket_kind :: extra_args
+  Flambda_arity.With_subkinds.create (exn_bucket_kind :: extra_args)
 
 let with_exn_handler t exn_handler = { t with exn_handler }
 

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -284,6 +284,8 @@ type unary_primitive =
   | Reinterpret_int64_as_float
   | Unbox_number of Flambda_kind.Boxable_number.t
   | Box_number of Flambda_kind.Boxable_number.t * Alloc_mode.t
+  | Untag_immediate
+  | Tag_immediate
   | Project_function_slot of
       { move_from : Function_slot.t;
         move_to : Function_slot.t

--- a/middle_end/flambda2/terms/result_types.ml
+++ b/middle_end/flambda2/terms/result_types.ml
@@ -134,7 +134,7 @@ let create_trivial ~params ~result_arity create_type =
         Bound_parameter.create
           (Variable.create ("result" ^ string_of_int i))
           kind_with_subkind)
-      result_arity
+      (Flambda_arity.With_subkinds.to_list result_arity)
   in
   let env_extension =
     List.fold_left

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -196,7 +196,9 @@ type closure_code_pointers =
 
 let get_func_decl_params_arity t code_id =
   let info = get_function_info t code_id in
-  let num_params = List.length (Code_metadata.params_arity info) in
+  let num_params =
+    Flambda_arity.With_subkinds.cardinal (Code_metadata.params_arity info)
+  in
   let kind : Lambda.function_kind =
     if Code_metadata.is_tupled info
     then Lambda.Tupled
@@ -281,7 +283,7 @@ let add_exn_handler env k arity =
   let env =
     { env with exn_handlers = Continuation.Set.add k env.exn_handlers }
   in
-  match arity with
+  match Flambda_arity.to_list arity with
   | [] -> Misc.fatal_error "Exception handler with no arguments"
   | [_] -> env, []
   | _ :: extra_args ->

--- a/middle_end/flambda2/to_cmm/to_cmm_helper.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_helper.ml
@@ -124,7 +124,7 @@ let primitive_boxed_int_of_standard_int b =
 
 let primitive_boxed_int_of_boxable_number b =
   match (b : Flambda_kind.Boxable_number.t) with
-  | Naked_float | Untagged_immediate -> assert false
+  | Naked_float -> assert false
   | Naked_int32 -> Primitive.Pint32
   | Naked_int64 -> Primitive.Pint64
   | Naked_nativeint -> Primitive.Pnativeint
@@ -132,7 +132,6 @@ let primitive_boxed_int_of_boxable_number b =
 let unbox_number ?(dbg = Debuginfo.none) kind arg =
   match (kind : Flambda_kind.Boxable_number.t) with
   | Naked_float -> unbox_float dbg arg
-  | Untagged_immediate -> untag_int arg dbg
   | _ ->
     let primitive_kind = primitive_boxed_int_of_boxable_number kind in
     unbox_int dbg primitive_kind arg
@@ -141,7 +140,6 @@ let box_number ?(dbg = Debuginfo.none) kind alloc_mode arg =
   let alloc_mode = convert_alloc_mode alloc_mode in
   match (kind : Flambda_kind.Boxable_number.t) with
   | Naked_float -> box_float dbg alloc_mode arg
-  | Untagged_immediate -> tag_int arg dbg
   | _ ->
     let primitive_kind = primitive_boxed_int_of_boxable_number kind in
     box_int_gen dbg primitive_kind alloc_mode arg

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -575,10 +575,12 @@ val prove_variant_like :
     [prove_is_a_boxed_number env ty] is [Invalid].
 
     Otherwise it is [Unknown] or [Wrong_kind] when [ty] is not of kind value. *)
-val prove_is_a_boxed_number :
-  Typing_env.t ->
-  t ->
-  Flambda_kind.Boxable_number.t proof_allowing_kind_mismatch
+type boxed_or_tagged_number = private
+  | Boxed of Flambda_kind.Boxable_number.t
+  | Tagged_immediate
+
+val prove_is_a_boxed_or_tagged_number :
+  Typing_env.t -> t -> boxed_or_tagged_number proof_allowing_kind_mismatch
 
 val prove_is_a_tagged_immediate :
   Typing_env.t -> t -> unit proof_allowing_kind_mismatch

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -297,7 +297,8 @@ let check_equation name ty =
 
 let arity_of_list ts = Flambda_arity.create (List.map TG.kind ts)
 
-let unknown_types_from_arity arity = List.map (fun kind -> unknown kind) arity
+let unknown_types_from_arity arity =
+  List.map (fun kind -> unknown kind) (Flambda_arity.to_list arity)
 
 let rec unknown_with_descr (descr : Flambda_kind.With_subkind.descr) =
   match descr with
@@ -341,6 +342,9 @@ let unknown_with_subkind kind =
   unknown_with_descr (Flambda_kind.With_subkind.descr kind)
 
 let unknown_types_from_arity_with_subkinds arity =
-  List.map (fun kind -> unknown_with_subkind kind) arity
+  List.map
+    (fun kind -> unknown_with_subkind kind)
+    (Flambda_arity.With_subkinds.to_list arity)
 
-let bottom_types_from_arity arity = List.map (fun kind -> bottom kind) arity
+let bottom_types_from_arity arity =
+  List.map (fun kind -> bottom kind) (Flambda_arity.to_list arity)

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -79,10 +79,14 @@ val prove_variant_like :
     [prove_is_a_boxed_number env ty] is [Invalid].
 
     Otherwise it is [Unknown] or [Wrong_kind] when [ty] is not of kind value. *)
-val prove_is_a_boxed_number :
+type boxed_or_tagged_number = private
+  | Boxed of Flambda_kind.Boxable_number.t
+  | Tagged_immediate
+
+val prove_is_a_boxed_or_tagged_number :
   Typing_env.t ->
   Type_grammar.t ->
-  Flambda_kind.Boxable_number.t proof_allowing_kind_mismatch
+  boxed_or_tagged_number proof_allowing_kind_mismatch
 
 val prove_is_a_tagged_immediate :
   Typing_env.t -> Type_grammar.t -> unit proof_allowing_kind_mismatch

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -298,7 +298,8 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
       | Proved tags -> (
         let is =
           Tag.Set.fold
-            (fun tag is -> Targetint_31_63.Set.add (Tag.to_target_imm tag) is)
+            (fun tag is ->
+              Targetint_31_63.Set.add (Tag.to_targetint_31_63 tag) is)
             tags Targetint_31_63.Set.empty
         in
         match Targetint_31_63.Set.get_singleton is with


### PR DESCRIPTION
This tidies up the `kinds/` directory, including the removal of the `Untagged_immediate` constructor from `Flambda_kind.Boxable_number`.  As a result the `Box_number` and `Unbox_number` primitives no longer deal with tagging and untagging; two new primitives have been introduced instead.  This is neater and also removes the redundant allocation mode that currently has to be specified for tagging.