### PR TITLE
Compiler hooks are compatible with inliner reports

### DIFF
--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -38,6 +38,8 @@ type _ pass =
   | Cfg : Cfg_with_layout.t pass
   | Cmm : Cmm.phrase list pass
 
+  | Inlining_tree : Flambda2_simplify_shared.Inlining_report.Inlining_tree.t pass
+
 type t = {
   mutable parse_tree_intf : (Parsetree.signature -> unit) list;
   mutable parse_tree_impl : (Parsetree.structure -> unit) list;
@@ -60,7 +62,8 @@ type t = {
   mutable mach_split : (Mach.fundecl -> unit) list;
   mutable linear : (Linear.fundecl -> unit) list;
   mutable cfg : (Cfg_with_layout.t -> unit) list;
-  mutable cmm : (Cmm.phrase list -> unit) list
+  mutable cmm : (Cmm.phrase list -> unit) list;
+  mutable inlining_tree : (Flambda2_simplify_shared.Inlining_report.Inlining_tree.t -> unit) list
 }
 let hooks : t = {
   parse_tree_intf = [];
@@ -85,6 +88,7 @@ let hooks : t = {
   linear = [];
   cfg = [];
   cmm = [];
+  inlining_tree = [];
 }
 
 let execute_hooks : type a. (a -> unit) list -> a -> unit = fun hooks arg ->
@@ -116,6 +120,7 @@ let register : type a. a pass -> (a -> unit) -> unit =
   | Linear -> hooks.linear <- f :: hooks.linear
   | Cfg -> hooks.cfg <- f :: hooks.cfg
   | Cmm -> hooks.cmm <- f :: hooks.cmm
+  | Inlining_tree -> hooks.inlining_tree <- f :: hooks.inlining_tree
 
 let execute : type a. a pass -> a -> unit =
   fun representation arg ->
@@ -142,6 +147,7 @@ let execute : type a. a pass -> a -> unit =
   | Linear -> execute_hooks hooks.linear arg
   | Cfg -> execute_hooks hooks.cfg arg
   | Cmm -> execute_hooks hooks.cmm arg
+  | Inlining_tree -> execute_hooks hooks.inlining_tree arg
 
 let execute_and_pipe r a = execute r a; a
 
@@ -169,3 +175,4 @@ let clear : type a. a pass -> unit =
   | Linear -> hooks.linear <- []
   | Cfg -> hooks.cfg <- []
   | Cmm -> hooks.cmm <- []
+  | Inlining_tree -> hooks.inlining_tree <- []

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -51,6 +51,8 @@ type _ pass =
   | Cfg : Cfg_with_layout.t pass
   | Cmm : Cmm.phrase list pass
 
+  | Inlining_tree : Flambda2_simplify_shared.Inlining_report.Inlining_tree.t pass
+
 (* Register a new hook for [pass]. *)
 val register : 'a pass -> ('a -> unit) -> unit
 

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -179,7 +179,9 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
         (if Flambda_features.inlining_report ()
         then
           let output_prefix = prefixname ^ ".cps_conv" in
-          let inlining_tree = Inlining_report.output_then_forget_decisions ~output_prefix in
+          let inlining_tree =
+            Inlining_report.output_then_forget_decisions ~output_prefix
+          in
           Compiler_hooks.execute Inlining_tree inlining_tree);
         raw_flambda, offsets, cmx, code
       end
@@ -197,7 +199,9 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
         (if Flambda_features.inlining_report ()
         then
           let output_prefix = Printf.sprintf "%s.%d" prefixname round in
-          let inlining_tree = Inlining_report.output_then_forget_decisions ~output_prefix in
+          let inlining_tree =
+            Inlining_report.output_then_forget_decisions ~output_prefix
+          in
           Compiler_hooks.execute Inlining_tree inlining_tree);
         Compiler_hooks.execute Flambda2 flambda;
         print_flambda "simplify" ppf flambda;

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -179,7 +179,8 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
         (if Flambda_features.inlining_report ()
         then
           let output_prefix = prefixname ^ ".cps_conv" in
-          Inlining_report.output_then_forget_decisions ~output_prefix);
+          let inlining_tree = Inlining_report.output_then_forget_decisions ~output_prefix in
+          Compiler_hooks.execute Inlining_tree inlining_tree);
         raw_flambda, offsets, cmx, code
       end
       else
@@ -196,7 +197,8 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
         (if Flambda_features.inlining_report ()
         then
           let output_prefix = Printf.sprintf "%s.%d" prefixname round in
-          Inlining_report.output_then_forget_decisions ~output_prefix);
+          let inlining_tree = Inlining_report.output_then_forget_decisions ~output_prefix in
+          Compiler_hooks.execute Inlining_tree inlining_tree);
         Compiler_hooks.execute Flambda2 flambda;
         print_flambda "simplify" ppf flambda;
         output_flexpect ~ml_filename:filename ~raw_flambda flambda;

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -144,7 +144,7 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
          (DE.are_rebuilding_terms (DA.denv dacc))
     then
       Inlining_report.record_decision_at_call_site_for_known_function
-        ~pass:Inlining_report.Before_simplify ~unrolling_depth
+        ~pass:Inlining_report.Pass.Before_simplify ~unrolling_depth
         ~callee:(Code_metadata.absolute_history callee's_code_metadata)
         ~tracker:(DE.inlining_history_tracker (DA.denv dacc))
         ~are_rebuilding_terms:(DA.are_rebuilding_terms dacc)
@@ -723,7 +723,7 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
   if Are_rebuilding_terms.are_rebuilding (DE.are_rebuilding_terms denv)
   then
     Inlining_report.record_decision_at_call_site_for_unknown_function
-      ~pass:Inlining_report.Before_simplify
+      ~pass:Inlining_report.Pass.Before_simplify
       ~tracker:(DE.inlining_history_tracker denv)
       ~apply ();
   let env_at_use = denv in

--- a/middle_end/flambda2/simplify_shared/inlining_report.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_report.ml
@@ -68,16 +68,19 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-type pass =
-  | After_closure_conversion
-  | Before_simplify
-  | After_simplify
+module Pass = struct
+  type t =
+    | After_closure_conversion
+    | Before_simplify
+    | After_simplify
 
-let print_pass ppf pass =
-  match pass with
-  | After_closure_conversion -> Format.fprintf ppf "afte@r closure@ conversion"
-  | Before_simplify -> Format.fprintf ppf "before@ simplify"
-  | After_simplify -> Format.fprintf ppf "after@ simplify"
+  let print ppf pass =
+    match pass with
+    | After_closure_conversion ->
+      Format.fprintf ppf "afte@r closure@ conversion"
+    | Before_simplify -> Format.fprintf ppf "before@ simplify"
+    | After_simplify -> Format.fprintf ppf "after@ simplify"
+end
 
 module Table : sig
   (* Pretty print a table of values.
@@ -155,7 +158,7 @@ module Context = struct
       depth : int option;
       unrolling_depth : int option option;
       are_rebuilding_terms : Are_rebuilding_terms.t;
-      pass : pass
+      pass : Pass.t
     }
 
   let create ?depth ?unrolling_depth ?cost_metrics ~are_rebuilding_terms ~args
@@ -277,7 +280,7 @@ module Decision_with_context = struct
     | Fundecl c -> Function_decl_inlining_decision_type.report ppf c
 
   let print ppf { context; decision } =
-    Format.fprintf ppf "@[<v>@[<h>Decision@ taken@ *%a*@]@," print_pass
+    Format.fprintf ppf "@[<v>@[<h>Decision@ taken@ *%a*@]@," Pass.print
       context.pass;
     Format.fprintf ppf "@[<v 2>@,";
     Format.fprintf ppf "%a@,@[<h>%a@]@," Context.print context print_decision
@@ -387,12 +390,12 @@ end
 
 module Inlining_tree = struct
   module Key = struct
-    type scope_type =
+    type scope =
       | Module
       | Class
       | Unknown
 
-    let compare_scope_type a b =
+    let compare_scope a b =
       match a, b with
       | Module, Module | Class, Class | Unknown, Unknown -> 0
       | Module, (Class | Unknown) | Class, Unknown -> 1
@@ -400,20 +403,20 @@ module Inlining_tree = struct
 
     type element =
       | Fundecl of string
-      | Scope of scope_type * string
+      | Scope of scope * string
       | Call of Inlining_history.Absolute.t
-
-    type t = Debuginfo.t * element
 
     let compare_element a b =
       match a, b with
       | Fundecl s1, Fundecl s2 -> String.compare s1 s2
       | Call s1, Call s2 -> Inlining_history.Absolute.compare s1 s2
       | Scope (t1, s1), Scope (t2, s2) ->
-        let c = compare_scope_type t1 t2 in
+        let c = compare_scope t1 t2 in
         if c <> 0 then c else String.compare s1 s2
       | Fundecl _, (Call _ | Scope _) | Call _, Scope _ -> 1
       | (Call _ | Scope _), Fundecl _ | Scope _, Call _ -> -1
+
+    type t = Debuginfo.t * element
 
     let compare (dbg1, e1) (dbg2, e2) =
       let c = Debuginfo.compare dbg1 dbg2 in
@@ -662,4 +665,5 @@ let output_then_forget_decisions ~output_prefix =
         let report : report = `Flambda2_1_0_0 (metadata, Lazy.force tree) in
         Marshal.to_channel ch report [];
         close_out ch
-      end)
+      end;
+      Lazy.force tree)

--- a/middle_end/flambda2/simplify_shared/inlining_report.mli
+++ b/middle_end/flambda2/simplify_shared/inlining_report.mli
@@ -14,16 +14,90 @@
 
 (** Report inlining decisions *)
 
-type pass =
-  | After_closure_conversion
-  | Before_simplify
-  | After_simplify
+module Pass : sig
+  type t =
+    | After_closure_conversion
+    | Before_simplify
+    | After_simplify
+
+  val print : Format.formatter -> t -> unit
+end
+
+module Context : sig
+  (* Represents the context under which an inlining decision was taken. *)
+  type t =
+    { args : Inlining_arguments.t;
+      cost_metrics : Cost_metrics.t option;
+      depth : int option;
+      unrolling_depth : int option option;
+      are_rebuilding_terms : Are_rebuilding_terms.t;
+      pass : Pass.t
+    }
+
+  val print : Format.formatter -> t -> unit
+end
+
+module Decision_with_context : sig
+  type decision =
+    | Call of Call_site_inlining_decision_type.t
+    | Fundecl of Function_decl_inlining_decision_type.t
+
+  type t =
+    { context : Context.t;
+      decision : decision
+    }
+
+  val print : Format.formatter -> t -> unit
+end
+
+module Uid : sig
+  type t =
+    { compilation_unit : Compilation_unit.t;
+      t : string
+    }
+end
+
+module Inlining_tree : sig
+  module Key : sig
+    type scope =
+      | Module
+      | Class
+      | Unknown
+
+    val compare_scope : scope -> scope -> int
+
+    type element =
+      | Fundecl of string
+      | Scope of scope * string
+      | Call of Inlining_history.Absolute.t
+
+    val compare_element : element -> element -> int
+
+    type t = Debuginfo.t * element
+
+    val compare : t -> t -> int
+  end
+
+  module Map : Map.S with type key = Key.t
+
+  type item =
+    | Construct of
+        { decisions : decisions;
+          tree : t;
+          uid : Uid.t
+        }
+    | Scope of t
+
+  and t = item Map.t
+
+  and decisions = Decision_with_context.t list
+end
 
 val record_decision_at_call_site_for_known_function :
   tracker:Inlining_history.Tracker.t ->
   unrolling_depth:int option ->
   apply:Apply_expr.t ->
-  pass:pass ->
+  pass:Pass.t ->
   callee:Inlining_history.Absolute.t ->
   are_rebuilding_terms:Are_rebuilding_terms.t ->
   Call_site_inlining_decision_type.t ->
@@ -32,14 +106,14 @@ val record_decision_at_call_site_for_known_function :
 val record_decision_at_call_site_for_unknown_function :
   tracker:Inlining_history.Tracker.t ->
   apply:Apply_expr.t ->
-  pass:pass ->
+  pass:Pass.t ->
   unit ->
   unit
 
 val record_decision_at_function_definition :
   absolute_history:Inlining_history.Absolute.t ->
   code_metadata:Code_metadata.t ->
-  pass:pass ->
+  pass:Pass.t ->
   are_rebuilding_terms:Are_rebuilding_terms.t ->
   Function_decl_inlining_decision_type.t ->
   unit
@@ -49,4 +123,4 @@ val record_decision_at_function_definition :
 
     Note that this function should be called once for each round of
     simplification. *)
-val output_then_forget_decisions : output_prefix:string -> unit
+val output_then_forget_decisions : output_prefix:string -> Inlining_tree.t


### PR DESCRIPTION
Export the type of the inlining_tree and adds a hook to get it using compiler_hooks.