### PR TITLE
Fix destroyed registers for pushtrap instructions

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -313,6 +313,9 @@ let destroyed_at_alloc =
   else
     [| r11 |]
 
+let destroyed_at_pushtrap =
+  [| r11 |]
+
 let destroyed_at_oper = function
     Iop(Icall_ind | Icall_imm _ | Iextcall { alloc = true; }) ->
     all_phys_regs
@@ -324,7 +327,9 @@ let destroyed_at_oper = function
   | Iop(Iintop(Imulh _ | Icomp _) | Iintop_imm((Icomp _), _))
         -> [| rax |]
   | Iswitch(_, _) -> [| rax; rdx |]
-  | Itrywith _ -> [| r11 |]
+  | Itrywith _ -> destroyed_at_pushtrap
+  | Iexit (_, traps) when List.exists (function Cmm.Push _ -> true | Pop -> false) traps ->
+    destroyed_at_pushtrap
   | Iop(Ispecific (Irdtsc | Irdpmc)) -> [| rax; rdx |]
   | Iop(Ispecific(Isqrtf | Isextend32 | Izextend32 | Icrc32q | Ilea _
                  | Istore_int (_, _, _) | Ioffset_loc (_, _)

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -316,6 +316,9 @@ let destroyed_at_alloc =
 let destroyed_at_pushtrap =
   [| r11 |]
 
+let has_pushtrap traps =
+  List.exists (function Cmm.Push _ -> true | Pop -> false) traps
+
 let destroyed_at_oper = function
     Iop(Icall_ind | Icall_imm _ | Iextcall { alloc = true; }) ->
     all_phys_regs
@@ -328,8 +331,8 @@ let destroyed_at_oper = function
         -> [| rax |]
   | Iswitch(_, _) -> [| rax; rdx |]
   | Itrywith _ -> destroyed_at_pushtrap
-  | Iexit (_, traps) when List.exists (function Cmm.Push _ -> true | Pop -> false) traps ->
-    destroyed_at_pushtrap
+  | Iexit (_, traps) when has_pushtrap traps -> destroyed_at_pushtrap
+  | Ireturn traps when has_pushtrap traps -> assert false
   | Iop(Ispecific (Irdtsc | Irdpmc)) -> [| rax; rdx |]
   | Iop(Ispecific(Isqrtf | Isextend32 | Izextend32 | Icrc32q | Ilea _
                  | Istore_int (_, _, _) | Ioffset_loc (_, _)


### PR DESCRIPTION
Note that while `Ireturn` also contains trap actions, it should never contain any `Push` actions. I could add an assertion if needed.
On `arm64`, `Lpushtrap` uses a temporary register that is not used for generic values, so nothing needs to be patched.