### PR TITLE
Speed up linking by changing cmxa format

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -386,7 +386,9 @@ let compile_genfuns ?dwarf ~ppf_dump f =
        | (Cfunction {fun_name = name}) as ph when f name ->
            compile_phrase ?dwarf ~ppf_dump ph
        | _ -> ())
-    (Cmm_helpers.generic_functions true [Compilenv.current_unit_infos ()])
+    (Cmm_helpers.generic_functions true
+       (Cmm_helpers.Generic_fns_tbl.of_fns
+          (Compilenv.current_unit_infos ()).ui_generic_fns))
 
 let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduce_heap gen =
   reset ();

--- a/backend/asmlibrarian.ml
+++ b/backend/asmlibrarian.ml
@@ -18,6 +18,7 @@
 open Misc
 open Config
 open Cmx_format
+module String = Misc.Stdlib.String
 
 type error =
     File_not_found of string
@@ -62,8 +63,36 @@ let create_archive file_list lib_name =
          (fun file_name (unit, crc) ->
             Asmlink.check_consistency file_name unit crc)
          file_list descr_list;
+       let cmis = Asmlink.extract_crc_interfaces () |> Array.of_list in
+       let cmxs = Asmlink.extract_crc_implementations () |> Array.of_list in
+       let cmi_index = String.Tbl.create 42 in
+       Array.iteri (fun i (name, _crc) -> String.Tbl.add cmi_index name i) cmis;
+       let cmx_index = String.Tbl.create 42 in
+       Array.iteri (fun i (name, _crc) -> String.Tbl.add cmx_index name i) cmxs;
+       let genfns = Cmm_helpers.Generic_fns_tbl.make () in
+       let mk_bitmap arr ix entries =
+         let module B = Misc.Bitmap in
+         let b = B.make (Array.length arr) in
+         entries |> List.iter (fun (name, _crc) -> B.set b (String.Tbl.find ix name));
+         b
+       in
+       let units =
+         List.map (fun (unit, crc) ->
+           Cmm_helpers.Generic_fns_tbl.add genfns unit.ui_generic_fns;
+           { li_name = unit.ui_name;
+             li_symbol = unit.ui_symbol;
+             li_crc = crc;
+             li_defines = unit.ui_defines;
+             li_force_link = unit.ui_force_link;
+             li_imports_cmi = mk_bitmap cmis cmi_index unit.ui_imports_cmi;
+             li_imports_cmx = mk_bitmap cmxs cmx_index unit.ui_imports_cmx })
+         descr_list
+       in
        let infos =
-         { lib_units = descr_list;
+         { lib_units = units;
+           lib_imports_cmi = cmis;
+           lib_imports_cmx = cmxs;
+           lib_generic_fns = Cmm_helpers.Generic_fns_tbl.entries genfns;
            lib_ccobjs = !Clflags.ccobjs;
            lib_ccopts = !Clflags.all_ccopts } in
        output_value outchan infos;

--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -294,12 +294,13 @@ let build_package_cmx members cmxfile =
           filter(Asmlink.extract_crc_interfaces());
       ui_imports_cmx =
           filter(Asmlink.extract_crc_implementations());
-      ui_curry_fun =
-          union(List.map (fun info -> info.ui_curry_fun) units);
-      ui_apply_fun =
-          union(List.map (fun info -> info.ui_apply_fun) units);
-      ui_send_fun =
-          union(List.map (fun info -> info.ui_send_fun) units);
+      ui_generic_fns =
+        { curry_fun =
+            union(List.map (fun info -> info.ui_generic_fns.curry_fun) units);
+          apply_fun =
+            union(List.map (fun info -> info.ui_generic_fns.apply_fun) units);
+          send_fun =
+            union(List.map (fun info -> info.ui_generic_fns.send_fun) units) };
       ui_force_link =
           List.exists (fun info -> info.ui_force_link) units;
       ui_export_info;

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -775,7 +775,14 @@ val cextcall :
 (** Generic Cmm fragments *)
 
 (** Generate generic functions *)
-val generic_functions : bool -> Cmx_format.unit_infos list -> Cmm.phrase list
+module Generic_fns_tbl : sig
+  type t
+  val make : unit -> t
+  val add : t -> Cmx_format.generic_fns -> unit
+  val of_fns : Cmx_format.generic_fns -> t
+  val entries : t -> Cmx_format.generic_fns
+end
+val generic_functions : bool -> Generic_fns_tbl.t -> Cmm.phrase list
 
 val placeholder_dbg : unit -> Debuginfo.t
 
@@ -807,7 +814,7 @@ val code_segment_table : string list -> phrase
 (** Generate data for a predefined exception *)
 val predef_exception : int -> string -> phrase
 
-val plugin_header : (Cmx_format.unit_infos * Digest.t) list -> phrase
+val plugin_header : Cmxs_format.dynunit list -> phrase
 
 (** Emit constant symbols *)
 

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -37,23 +37,40 @@ type export_info =
   | Flambda2 of Flambda2_cmx.Flambda_cmx_format.t option
 
 type apply_fn := int * Lambda.alloc_mode
+
+(* Curry/apply/send functions *)
+type generic_fns =
+  { curry_fun: Clambda.arity list;
+    apply_fun: apply_fn list;
+    send_fun: apply_fn list }
+
 type unit_infos =
   { mutable ui_name: modname;             (* Name of unit implemented *)
     mutable ui_symbol: string;            (* Prefix for symbols *)
     mutable ui_defines: string list;      (* Unit and sub-units implemented *)
     mutable ui_imports_cmi: crcs;         (* Interfaces imported *)
     mutable ui_imports_cmx: crcs;         (* Infos imported *)
-    mutable ui_curry_fun: Clambda.arity list; (* Currying functions needed *)
-    mutable ui_apply_fun: apply_fn list;  (* Apply functions needed *)
-    mutable ui_send_fun: apply_fn list;   (* Send functions needed *)
+    mutable ui_generic_fns: generic_fns;  (* Generic functions needed *)
     mutable ui_export_info: export_info;
     mutable ui_force_link: bool }         (* Always linked *)
 
 (* Each .a library has a matching .cmxa file that provides the following
    infos on the library: *)
 
+type lib_unit_info =
+  { li_name: modname;
+    li_symbol: string;
+    li_crc: Digest.t;
+    li_defines: string list;
+    li_force_link: bool;
+    li_imports_cmi : Bitmap.t;  (* subset of lib_imports_cmi *)
+    li_imports_cmx : Bitmap.t } (* subset of lib_imports_cmx *)
+
 type library_infos =
-  { lib_units: (unit_infos * Digest.t) list;  (* List of unit infos w/ MD5s *)
+  { lib_imports_cmi: (modname * Digest.t option) array;
+    lib_imports_cmx: (modname * Digest.t option) array;
+    lib_units: lib_unit_info list;
+    lib_generic_fns: generic_fns;
     (* In the following fields the lists are reversed with respect to
        how they end up being used on the command line. *)
     lib_ccobjs: string list;            (* C object files needed *)

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -88,9 +88,7 @@ let current_unit =
     ui_defines = [];
     ui_imports_cmi = [];
     ui_imports_cmx = [];
-    ui_curry_fun = [];
-    ui_apply_fun = [];
-    ui_send_fun = [];
+    ui_generic_fns = { curry_fun = []; apply_fun = []; send_fun = [] };
     ui_force_link = false;
     ui_export_info = default_ui_export_info }
 
@@ -137,9 +135,8 @@ let reset ?packname name =
   current_unit.ui_defines <- [symbol];
   current_unit.ui_imports_cmi <- [];
   current_unit.ui_imports_cmx <- [];
-  current_unit.ui_curry_fun <- [];
-  current_unit.ui_apply_fun <- [];
-  current_unit.ui_send_fun <- [];
+  current_unit.ui_generic_fns <-
+    { curry_fun = []; apply_fun = []; send_fun = [] };
   current_unit.ui_force_link <- !Clflags.link_everything;
   Hashtbl.clear exported_constants;
   structured_constants := structured_constants_empty;
@@ -349,17 +346,23 @@ let approx_env () = !merged_environment
 (* Record that a currying function or application function is needed *)
 
 let need_curry_fun arity =
-  if not (List.mem arity current_unit.ui_curry_fun) then
-    current_unit.ui_curry_fun <- arity :: current_unit.ui_curry_fun
+  let fns = current_unit.ui_generic_fns in
+  if not (List.mem arity fns.curry_fun) then
+    current_unit.ui_generic_fns <-
+      { fns with curry_fun = arity :: fns.curry_fun }
 
 let need_apply_fun n mode =
   assert(n > 0);
-  if not (List.mem (n,mode) current_unit.ui_apply_fun) then
-    current_unit.ui_apply_fun <- (n,mode) :: current_unit.ui_apply_fun
+  let fns = current_unit.ui_generic_fns in
+  if not (List.mem (n,mode) fns.apply_fun) then
+    current_unit.ui_generic_fns <-
+      { fns with apply_fun = (n,mode) :: fns.apply_fun }
 
 let need_send_fun n mode =
-  if not (List.mem (n,mode) current_unit.ui_send_fun) then
-    current_unit.ui_send_fun <- (n,mode) :: current_unit.ui_send_fun
+  let fns = current_unit.ui_generic_fns in
+  if not (List.mem (n,mode) fns.send_fun) then
+    current_unit.ui_generic_fns <-
+      { fns with send_fun = (n,mode) :: fns.send_fun }
 
 (* Write the description of the current unit *)
 

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -103,17 +103,17 @@ and cmo_magic_number = "Caml1999O500"
 and cma_magic_number = "Caml1999A500"
 and cmx_magic_number =
   if flambda || flambda2 then
-    "Caml2021y500"
+    "Caml2021y501"
   else
-    "Caml2021Y500"
+    "Caml2021Y501"
 and cmxa_magic_number =
   if flambda || flambda2 then
-    "Caml2021z500"
+    "Caml2021z501"
   else
-    "Caml2021Z500"
+    "Caml2021Z501"
 and ast_impl_magic_number = "Caml1999M029"
 and ast_intf_magic_number = "Caml1999N029"
-and cmxs_magic_number = "Caml1999D500"
+and cmxs_magic_number = "Caml1999D501"
 and cmt_magic_number = "Caml1999T500"
 and linear_magic_number = "Caml1999L500"
 and cfg_magic_number = "Caml2021G500"

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -903,6 +903,53 @@ type crcs = (modname * Digest.t option) list
 
 type alerts = string Stdlib.String.Map.t
 
+module Bitmap = struct
+  type t = {
+    length: int;
+    bits: bytes
+  }
+
+  let length_bytes len =
+    (len + 7) lsr 3
+
+  let make n =
+    { length = n;
+      bits = Bytes.make (length_bytes n) '\000' }
+
+  let unsafe_get_byte t n =
+    Char.code (Bytes.unsafe_get t.bits n)
+
+  let unsafe_set_byte t n x =
+    Bytes.unsafe_set t.bits n (Char.unsafe_chr x)
+
+  let check_bound t n =
+    if n < 0 || n >= t.length then invalid_arg "Bitmap.check_bound"
+
+  let set t n =
+    check_bound t n;
+    let pos = n lsr 3 and bit = 1 lsl (n land 7) in
+    unsafe_set_byte t pos (unsafe_get_byte t pos lor bit)
+
+  let clear t n =
+    check_bound t n;
+    let pos = n lsr 3 and nbit = 0xff lxor (1 lsl (n land 7)) in
+    unsafe_set_byte t pos (unsafe_get_byte t pos land nbit)
+
+  let get t n =
+    check_bound t n;
+    let pos = n lsr 3 and bit = 1 lsl (n land 7) in
+    (unsafe_get_byte t pos land bit) <> 0
+
+  let iter f t =
+    for i = 0 to length_bytes t.length - 1 do
+      let c = unsafe_get_byte t i in
+      let pos = i * 8 in
+      for j = 0 to 7 do
+        if c land (1 lsl j) <> 0 then
+          f (pos + j)
+      done
+    done
+end
 
 module EnvLazy = struct
   type ('a,'b) t = ('a,'b) eval ref

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -943,7 +943,7 @@ module Bitmap = struct
   let iter f t =
     for i = 0 to length_bytes t.length - 1 do
       let c = unsafe_get_byte t i in
-      let pos = i * 8 in
+      let pos = i lsl 3 in
       for j = 0 to 7 do
         if c land (1 lsl j) <> 0 then
           f (pos + j)

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -473,6 +473,14 @@ type crcs = (modname * Digest.t option) list
 
 type alerts = string Stdlib.String.Map.t
 
+module Bitmap : sig
+  type t
+  val make : int -> t
+  val set : t -> int -> unit
+  val clear : t -> int -> unit
+  val get : t -> int -> bool
+  val iter : (int -> unit) -> t -> unit
+end
 
 module EnvLazy: sig
   type ('a,'b) t


### PR DESCRIPTION
This patch improves linking time, by changing the cmxa format to be smaller and avoid redundant checking of module digests.

On large executables (~600 MB), this shortens linking time by about a third, makes the ocamlopt process take ~10x less memory, and reduces the size of cmxa files by anywhere from 5x to 70x.

(The patch grew larger than I'd like. If it's now unreviewably big, let me know and I'll split it up next week)

The main change is that the format of cmxa files goes from this:
```ocaml
type unit_infos =
  { mutable ui_name: modname;             (* Name of unit implemented *)
    mutable ui_symbol: string;            (* Prefix for symbols *)
    mutable ui_defines: string list;      (* Unit and sub-units implemented *)
    mutable ui_imports_cmi: crcs;         (* Interfaces imported *)
    mutable ui_imports_cmx: crcs;         (* Infos imported *)
    mutable ui_curry_fun: Clambda.arity list; (* Currying functions needed *)
    mutable ui_apply_fun: apply_fn list;  (* Apply functions needed *)
    mutable ui_send_fun: apply_fn list;   (* Send functions needed *)
    mutable ui_export_info: export_info;
    mutable ui_force_link: bool }         (* Always linked *)

type library_infos =
  { lib_units: (unit_infos * Digest.t) list;  (* List of unit infos w/ MD5s *)
    (* In the following fields the lists are reversed with respect to
       how they end up being used on the command line. *)
    lib_ccobjs: string list;            (* C object files needed *)
    lib_ccopts: string list }           (* Extra opts to C compiler *)
```
to this:
```ocaml
type lib_unit_info =
  { li_name: modname;
    li_symbol: string;
    li_crc: Digest.t;
    li_defines: string list;
    li_force_link: bool;
    li_imports_cmi : Bitmap.t;  (* subset of lib_imports_cmi *)
    li_imports_cmx : Bitmap.t } (* subset of lib_imports_cmx *)

type library_infos =
  { lib_imports_cmi: (modname * Digest.t option) array;
    lib_imports_cmx: (modname * Digest.t option) array;
    lib_units: lib_unit_info list;
    lib_generic_fns: generic_fns;
    (* In the following fields the lists are reversed with respect to
       how they end up being used on the command line. *)
    lib_ccobjs: string list;            (* C object files needed *)
    lib_ccopts: string list }           (* Extra opts to C compiler *)
```

Instead of keeping a set of imported cmi/cmx files and hashes for each module in a library, the cmxa file now contains one unified list of all of the cmi/cmx files and hashes, and each module contains a bitmap indicating which of these it depends on. Since the dependencies of individual modules in a library tend to be almost identical, this saves a lot of space, as well as saving time during linking (since we only need to check them for consistency once). Similarly, the set of generic functions (caml_curry and friends) is now maintained once per library rather than separately for each module.

The other change to linking is to read cmxas, check consistency and construct the list of objects to link in a single pass, rather than in three separate passes. This removes the need to hold all of the cmxa files in memory at once, greatly reducing the maximum memory usage (and speeding things up somewhat)