### PR TITLE
Fix stack offset in cfg with Istackoffset

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1115,11 +1115,9 @@ let emit_instr fallthrough i =
       emit_named_text_section !function_name
   | Lentertrap ->
       ()
-  | Ladjust_trap_depth { delta_traps; } ->
-      (* each trap occupies 16 bytes on the stack *)
-      let delta = 16 * delta_traps in
-      cfi_adjust_cfa_offset delta;
-      stack_offset := !stack_offset + delta
+  | Ladjust_stack_offset { delta_bytes; } ->
+      cfi_adjust_cfa_offset delta_bytes;
+      stack_offset := !stack_offset + delta_bytes
   | Lpushtrap { lbl_handler; } ->
       let load_label_addr s arg =
         if !Clflags.pic_code then

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -487,3 +487,5 @@ let operation_supported = function
   | Ccheckbound
   | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cbeginregion | Cendregion
     -> true
+
+let trap_size_in_bytes = 16

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -556,7 +556,7 @@ module BR = Branch_relaxation.Make (struct
         + begin match lbl2 with None -> 0 | Some _ -> 1 end
     | Lswitch jumptbl -> 3 + Array.length jumptbl
     | Lentertrap -> 0
-    | Ladjust_trap_depth _ -> 0
+    | Ladjust_stack_offset _ -> 0
     | Lpushtrap _ -> 4
     | Lpoptrap -> 1
     | Lraise k ->
@@ -978,11 +978,9 @@ let emit_instr i =
 *)
     | Lentertrap ->
         ()
-    | Ladjust_trap_depth { delta_traps } ->
-        (* each trap occupies 16 bytes on the stack *)
-        let delta = 16 * delta_traps in
-        cfi_adjust_cfa_offset delta;
-        stack_offset := !stack_offset + delta
+    | Ladjust_stack_offset { delta_bytes } ->
+        cfi_adjust_cfa_offset delta_bytes;
+        stack_offset := !stack_offset + delta_bytes
     | Lpushtrap { lbl_handler; } ->
         `	adr	{emit_reg reg_tmp1}, {emit_label lbl_handler}\n`;
         stack_offset := !stack_offset + 16;

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -339,3 +339,5 @@ let operation_supported = function
   | Cprobe _ | Cprobe_is_enabled _ | Copaque
   | Cbeginregion | Cendregion
     -> true
+
+let trap_size_in_bytes = 16

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -407,7 +407,9 @@ let is_noop_move instr =
     false
 
 let set_stack_offset (instr : _ instruction) stack_offset =
-  if instr.stack_offset = stack_offset then instr else { instr with stack_offset }
+  if instr.stack_offset = stack_offset
+  then instr
+  else { instr with stack_offset }
 
 let set_live (instr : _ instruction) live =
   if Reg.Set.equal instr.live live then instr else { instr with live }

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -147,7 +147,7 @@ let get_block_exn t label =
     Misc.fatal_errorf "Cfg.get_block_exn: block %d not found" label
   | block -> block
 
-let can_raise_interproc block = block.can_raise && block.trap_depth = 1
+let can_raise_interproc block = block.can_raise && Option.is_none block.exn
 
 let fun_name t = t.fun_name
 

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -34,7 +34,7 @@ type basic_block =
     mutable body : basic instruction list;
     mutable terminator : terminator instruction;
     mutable predecessors : Label.Set.t;
-    mutable trap_depth : int;
+    mutable stack_offset : int;
     mutable exn : Label.t option;
     mutable can_raise : bool;
     mutable is_trap_handler : bool;
@@ -406,8 +406,8 @@ let is_noop_move instr =
   | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
     false
 
-let set_trap_depth (instr : _ instruction) trap_depth =
-  if instr.trap_depth = trap_depth then instr else { instr with trap_depth }
+let set_stack_offset (instr : _ instruction) stack_offset =
+  if instr.stack_offset = stack_offset then instr else { instr with stack_offset }
 
 let set_live (instr : _ instruction) live =
   if Reg.Set.equal instr.live live then instr else { instr with live }

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -38,8 +38,8 @@ type basic_block =
     mutable predecessors : Label.Set.t;
         (** All predecessors, both normal and exceptional paths. *)
     mutable stack_offset : int;
-        (** Stack offset of the start of the block.
-            Used for emitting adjust trap on edges from one block to the next. *)
+        (** Stack offset of the start of the block. Used for emitting adjust
+            trap on edges from one block to the next. *)
     mutable exn : Label.t option;
         (** All possible handlers of a raise that (1) can be triggered either by
             an explicit raise, or instructions such as calls and allocations,
@@ -57,12 +57,12 @@ type basic_block =
             during dead block elimination for checking. *)
         (* CR-someday gyorsh: The current implementation allows multiple
            pushtraps in each block means that different trap stacks are
-           associated with the block at different points. At most one instruction
-           in each block can raise, and always the last one.
-           After we split the blocks based on
-           Pushtrap/Poptrap, each block will have a unique trap stack associated
-           with it. [exns] will not be needed, as the exn-successor will be
-           uniquely determined by can_raise + top of trap stack. *)
+           associated with the block at different points. At most one
+           instruction in each block can raise, and always the last one. After
+           we split the blocks based on Pushtrap/Poptrap, each block will have a
+           unique trap stack associated with it. [exns] will not be needed, as
+           the exn-successor will be uniquely determined by can_raise + top of
+           trap stack. *)
   }
 
 (** Control Flow Graph of a function. *)

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -510,9 +510,10 @@ let check_basic_block : State.t -> Cfg.basic_block -> Cfg.basic_block -> unit =
      && is_valid_stack_offset result.stack_offset
   then begin
     if not (Int.equal expected.stack_offset result.stack_offset)
-    then different location
-           (Printf.sprintf "stack offset: expected=%d result=%d"
-              expected.stack_offset result.stack_offset);
+    then
+      different location
+        (Printf.sprintf "stack offset: expected=%d result=%d"
+           expected.stack_offset result.stack_offset);
     let location = location ^ " (exceptional successors)" in
     match expected.exn, result.exn with
     | None, None -> ()

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -378,7 +378,7 @@ let check_instruction :
   if is_valid_stack_offset expected.stack_offset
      && is_valid_stack_offset result.stack_offset
      && not (Int.equal expected.stack_offset result.stack_offset)
-  then different location "trap depth";
+  then different location "stack offset";
   (* note: not comparing `id` fields on purpose *)
   ()
 

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -510,7 +510,9 @@ let check_basic_block : State.t -> Cfg.basic_block -> Cfg.basic_block -> unit =
      && is_valid_stack_offset result.stack_offset
   then begin
     if not (Int.equal expected.stack_offset result.stack_offset)
-    then different location "trap depth";
+    then different location
+           (Printf.sprintf "stack offset: expected=%d result=%d"
+              expected.stack_offset result.stack_offset);
     let location = location ^ " (exceptional successors)" in
     match expected.exn, result.exn with
     | None, None -> ()

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -175,7 +175,7 @@ let equal_raise_kind : Lambda.raise_kind -> Lambda.raise_kind -> bool =
 let array_equal eq left right =
   Array.length left = Array.length right && Array.for_all2 eq left right
 
-let is_valid_trap_depth : int -> bool = fun trap_depth -> trap_depth >= 0
+let is_valid_stack_offset : int -> bool = fun stack_offset -> stack_offset >= 0
 
 let check_external_call_operation :
     location ->
@@ -375,9 +375,9 @@ let check_instruction :
   then different location "FDO info";
   if check_live && not (Reg.Set.equal expected.live result.live)
   then different location "live register set";
-  if is_valid_trap_depth expected.trap_depth
-     && is_valid_trap_depth result.trap_depth
-     && not (Int.equal expected.trap_depth result.trap_depth)
+  if is_valid_stack_offset expected.stack_offset
+     && is_valid_stack_offset result.stack_offset
+     && not (Int.equal expected.stack_offset result.stack_offset)
   then different location "trap depth";
   (* note: not comparing `id` fields on purpose *)
   ()
@@ -506,10 +506,10 @@ let check_basic_block : State.t -> Cfg.basic_block -> Cfg.basic_block -> unit =
     result.terminator;
   (* State.add_label_sets_to_check state (location ^ " (predecessors)")
      expected.predecessors result.predecessors; *)
-  if is_valid_trap_depth expected.trap_depth
-     && is_valid_trap_depth result.trap_depth
+  if is_valid_stack_offset expected.stack_offset
+     && is_valid_stack_offset result.stack_offset
   then begin
-    if not (Int.equal expected.trap_depth result.trap_depth)
+    if not (Int.equal expected.stack_offset result.stack_offset)
     then different location "trap depth";
     let location = location ^ " (exceptional successors)" in
     match expected.exn, result.exn with

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -131,7 +131,7 @@ module S = struct
       dbg : Debuginfo.t;
       fdo : Fdo_info.t;
       live : Reg.Set.t;
-      trap_depth : int;
+      stack_offset : int;
       id : int
     }
 

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -57,7 +57,7 @@ struct
       else
         let across = Reg.diff_set_array before instr.res in
         let across =
-          if Cfg.can_raise_basic instr.desc && instr.trap_depth > 1
+          if Cfg.can_raise_basic instr.desc && instr.stack_offset > 0
           then Reg.Set.union across exn.before
           else across
         in

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -331,7 +331,8 @@ let adjust_trap_depth body (block : Cfg.basic_block)
   then body
   else
     let delta_traps = block_trap_depth - prev_trap_depth in
-    to_linear_instr (Ladjust_trap_depth { delta_traps }) ~next:body
+    let delta_bytes = Proc.trap_size_in_bytes delta_traps in
+    to_linear_instr (Ladjust_stack_offset { delta_bytes }) ~next:body
 
 (* CR-someday gyorsh: handle duplicate labels in new layout: print the same
    block more than once. *)

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -323,15 +323,14 @@ let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
         && not (Label.Set.mem block.start new_labels)
       | Return | Raise _ | Tailcall _ | Call_no_return _ -> assert false)
 
-let adjust_trap_depth body (block : Cfg.basic_block)
+let adjust_stack_offset body (block : Cfg.basic_block)
     ~(prev_block : Cfg.basic_block) =
-  let block_trap_depth = block.trap_depth in
-  let prev_trap_depth = prev_block.terminator.trap_depth in
-  if block_trap_depth = prev_trap_depth
+  let block_stack_offset = block.stack_offset in
+  let prev_stack_offset = prev_block.terminator.stack_offset in
+  if block_stack_offset = prev_stack_offset
   then body
   else
-    let delta_traps = block_trap_depth - prev_trap_depth in
-    let delta_bytes = Proc.trap_size_in_bytes delta_traps in
+    let delta_bytes = block_stack_offset - prev_stack_offset in
     to_linear_instr (Ladjust_stack_offset { delta_bytes }) ~next:body
 
 (* CR-someday gyorsh: handle duplicate labels in new layout: print the same
@@ -376,7 +375,7 @@ let run cfg_with_layout =
           then body
           else to_linear_instr (Llabel block.start) ~next:body
         in
-        adjust_trap_depth body block ~prev_block
+        adjust_stack_offset body block ~prev_block
     in
     next := { Linear_utils.label; insn }
   done;

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -634,6 +634,7 @@ module Trap_depth_and_exn = struct
           ~can_raise:(Cfg.can_raise_basic instr.desc),
         instr )
 
+  (* CR gyorsh: how to handle Istackoffset correctly here? *)
   let rec update_block : Cfg.t -> Label.t -> handler_stack -> unit =
    fun cfg label stack ->
     let block = Cfg.get_block_exn cfg label in

--- a/backend/cfg/extra_debug.ml
+++ b/backend/cfg/extra_debug.ml
@@ -39,7 +39,7 @@ let add cl =
    *          Lreloadretaddr
    *          Llabel
    *          Lentertrap
-   *          Ladjust_trap_depth
+   *          Ladjust_stack_offset
    *    There is nothing wrong with emitting .loc directives for them,
    *    but its redundant.
    *    Only Lreloadretaddr has a corresponding Cfg instruction.

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -42,9 +42,7 @@ type t =
             back to Linear (and restore [Lentertrap]). *)
     trap_stacks : T.t Label.Tbl.t;
         (** Maps labels of blocks to trap handler stacks at the beginning of the
-            block. [cfg.block.trap_depth] can be derived from the corresponding
-            trap_stack, except when the block is dead and the trap stack is not
-            known, represented by None. *)
+            block. *)
     (* CR-someday gyorsh: The need for this is because we need to record
        trap_stack for a block that hasn't been created yet. If we change
        create_empty_block to get_or_create, then we don't need this hashtbl and
@@ -104,7 +102,7 @@ let get_new_linear_id t =
   t.next_linear_id <- id + 1;
   id
 
-let create_instruction t desc ~trap_depth (i : Linear.instruction) :
+let create_instruction t desc ~stack_offset (i : Linear.instruction) :
     _ C.instruction =
   { desc;
     arg = i.arg;
@@ -112,7 +110,7 @@ let create_instruction t desc ~trap_depth (i : Linear.instruction) :
     dbg = i.dbg;
     fdo = i.fdo;
     live = i.live;
-    trap_depth;
+    stack_offset;
     id = get_new_linear_id t
   }
 
@@ -154,7 +152,7 @@ let record_exn t (block : C.basic_block) traps =
   | Some _ ->
     Misc.fatal_errorf "Cannot record another exception for %d" block.start
 
-let create_empty_block t start ~trap_depth ~traps =
+let create_empty_block t start ~stack_offset ~traps =
   let terminator : C.terminator C.instruction =
     { desc = C.Never (* placeholder for terminator, to be replaced *);
       arg = [||];
@@ -162,7 +160,7 @@ let create_empty_block t start ~trap_depth ~traps =
       dbg = Debuginfo.none;
       fdo = Fdo_info.none;
       live = Reg.Set.empty;
-      trap_depth;
+      stack_offset;
       id = get_new_linear_id t
     }
   in
@@ -172,7 +170,7 @@ let create_empty_block t start ~trap_depth ~traps =
       terminator;
       exn = None;
       predecessors = Label.Set.empty;
-      trap_depth;
+      stack_offset;
       is_trap_handler = false;
       can_raise = false;
       dead = false
@@ -220,12 +218,12 @@ let check_traps t label (block : C.basic_block) =
       T.print trap_stack_at_start);
     match T.to_list_exn trap_stack_at_start with
     | trap_labels ->
-      if List.compare_length_with trap_labels block.trap_depth <> 0
+      if (List.length trap_labels - 1) * Proc.trap_size_in_bytes > block.stack_offset
       then
         Misc.fatal_errorf
-          "Malformed linear IR: mismatch trap_depth=%d, but \
+          "Malformed linear IR: mismatch stack_offset=%d, but \
            trap_stack_at_start length=%d"
-          block.trap_depth (List.length trap_labels)
+          block.stack_offset (List.length trap_labels)
     | exception T.Unresolved ->
       (* At the end of the cfg construction, some blocks may have unresolved
          trap stacks. All these blocks must be dead, i.e., unreachable from
@@ -313,7 +311,7 @@ let get_or_make_label t (insn : Linear.instruction) : Linear_utils.labelled_insn
   | Llabel label -> { label; insn }
   | Lend -> Misc.fatal_error "Unexpected end of function instead of label"
   | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Lbranch _ | Lcondbranch _
-  | Lcondbranch3 _ | Lswitch _ | Lentertrap | Ladjust_trap_depth _ | Lpushtrap _
+  | Lcondbranch3 _ | Lswitch _ | Lentertrap | Ladjust_stack_offset _ | Lpushtrap _
   | Lpoptrap | Lraise _ ->
     let label = Cmm.new_label () in
     t.new_labels <- Label.Set.add label t.new_labels;
@@ -352,7 +350,7 @@ let block_is_registered t (block : C.basic_block) =
   Label.Tbl.mem t.cfg.blocks block.start
 
 let add_terminator t (block : C.basic_block) (i : L.instruction)
-    (desc : C.terminator) ~trap_depth ~traps =
+    (desc : C.terminator) ~stack_offset ~traps =
   (* All terminators are followed by a label, except branches we created for
      fallthroughs in Linear. *)
   (match desc with
@@ -364,7 +362,7 @@ let add_terminator t (block : C.basic_block) (i : L.instruction)
       Misc.fatal_errorf "Linear instruction not followed by label:@ %a"
         Printlinear.instr
         { i with Linear.next = Linear.end_instr });
-  block.terminator <- create_instruction t desc ~trap_depth i;
+  block.terminator <- create_instruction t desc ~stack_offset i;
   if Cfg.can_raise_terminator desc then record_exn t block traps;
   register_block t block traps
 
@@ -415,42 +413,43 @@ let to_basic (mop : Mach.operation) : C.basic =
   | Itailcall_ind | Itailcall_imm _ | Iextcall { returns = false; _ } ->
     assert false
 
-let rec adjust_traps (i : L.instruction) ~trap_depth ~traps =
+let rec adjust_traps (i : L.instruction) ~stack_offset ~traps =
   (* We do not emit any executable code for this insn; it only moves the virtual
      stack pointer in the emitter. We do not have a corresponding insn in [Cfg]
      because the required adjustment can change when blocks are reordered.
      Instead we regenerate the instructions when converting back to linear. We
-     use [delta_traps] only to compute [trap_depth]s of other instructions. *)
+     use [delta_bytes] only to compute [stack_offsets]s of other instructions. *)
   match i.desc with
-  | Ladjust_trap_depth { delta_traps } ->
-    let trap_depth = trap_depth + delta_traps in
-    if trap_depth < 0
+  | Ladjust_stack_offset { delta_bytes } ->
+    let stack_offset = stack_offset + delta_bytes in
+    if stack_offset < 0
     then
       Misc.fatal_errorf
-        "Ladjust_trap_depth %d moves the trap depth below zero: %d" delta_traps
-        trap_depth;
+        "Ladjust_stack_offset %d moves the trap depth below zero: %d" delta_bytes
+        stack_offset;
     let traps = T.unknown () in
-    adjust_traps i.next ~trap_depth ~traps
+    adjust_traps i.next ~stack_offset ~traps
   | Llabel _ ->
-    let trap_depth, traps, next = adjust_traps i.next ~trap_depth ~traps in
-    trap_depth, traps, { i with next }
+    let stack_offset, traps, next = adjust_traps i.next ~stack_offset ~traps in
+    stack_offset, traps, { i with next }
   | Lend | Lprologue | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap | Lop _
   | Lbranch _
   | Lcondbranch (_, _)
   | Lcondbranch3 (_, _, _)
   | Lswitch _ | Lpushtrap _ | Lraise _ ->
-    trap_depth, traps, i
+    stack_offset, traps, i
 
-(** [traps] represents the trap stack, with head being the top. [trap_depths] is
-    the depth of the trap stack. *)
+(** [traps] represents the trap stack, with head being the top.
+    [stack_offset] is the offset from the start of the frame
+    due to trap handler Lpushtrap or outgoing arguments Istackoffset. *)
 let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
-    ~trap_depth ~traps =
+    ~stack_offset ~traps =
   (* [traps] is constructed incrementally, because Ladjust_trap does not give
-     enough information to compute it upfront, but trap_depth is directly
+     enough information to compute it upfront, but stack_offset is directly
      computed. *)
-  let trap_depth, traps, i = adjust_traps i ~trap_depth ~traps in
+  let stack_offset, traps, i = adjust_traps i ~stack_offset ~traps in
   match i.desc with
-  | Ladjust_trap_depth _ -> assert false
+  | Ladjust_stack_offset _ -> assert false
   | Lend ->
     if not (block_is_registered t block)
     then
@@ -473,36 +472,25 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     if not (block_is_registered t block)
     then (
       let fallthrough : C.terminator = Always start in
-      block.terminator <- create_instruction t fallthrough i ~trap_depth;
+      block.terminator <- create_instruction t fallthrough i ~stack_offset;
       register_block t block traps);
     (* CR-someday gyorsh: check for multiple consecutive labels *)
-    let new_block = create_empty_block t start ~trap_depth ~traps in
-    create_blocks t i.next new_block ~trap_depth ~traps
+    let new_block = create_empty_block t start ~stack_offset ~traps in
+    create_blocks t i.next new_block ~stack_offset ~traps
   | Lreturn ->
-    if trap_depth <> 1
+    if stack_offset <> 0
     then
-      Misc.fatal_errorf "Trap depth is %d, but it must be 1 at Lreturn"
-        trap_depth;
-    add_terminator t block i Return ~trap_depth ~traps;
-    create_blocks t i.next block ~trap_depth ~traps
+      Misc.fatal_errorf "Stack offset is %d, but it must be 0 at Lreturn"
+        stack_offset;
+    add_terminator t block i Return ~stack_offset ~traps;
+    create_blocks t i.next block ~stack_offset ~traps
   | Lraise kind ->
-    (* CR-someday gyorsh: Why does the compiler not generate adjust after raise?
-       raise pops the trap handler stack and then the next block may have a
-       different try depth. Also, why do we not need to update trap_depths and
-       traps here like for pop?
-
-       mshinwell: I don't think there's anything special about a raise for
-       Linearize; it may still add a trap adjustment. Think about this some
-       more...
-
-       gyorsh: it is now handled in register_block called from
-       add_terminator. *)
-    add_terminator t block i (Raise kind) ~trap_depth ~traps;
-    create_blocks t i.next block ~trap_depth ~traps
+    add_terminator t block i (Raise kind) ~stack_offset ~traps;
+    create_blocks t i.next block ~stack_offset ~traps
   | Lbranch lbl ->
     if !C.verbose then Printf.printf "Lbranch %d\n" lbl;
-    add_terminator t block i (Always lbl) ~trap_depth ~traps;
-    create_blocks t i.next block ~trap_depth ~traps
+    add_terminator t block i (Always lbl) ~stack_offset ~traps;
+    create_blocks t i.next block ~stack_offset ~traps
   | Lcondbranch (cond, lbl) ->
     (* This representation does not preserve the order of successors. *)
     let fallthrough = get_or_make_label t i.next in
@@ -518,8 +506,8 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
       | Iinttest_imm (cmp, n) ->
         Int_test (mk_int_test cmp ~lbl ~inv ~imm:(Some n))
     in
-    add_terminator t block i desc ~trap_depth ~traps;
-    create_blocks t fallthrough.insn block ~trap_depth ~traps
+    add_terminator t block i desc ~stack_offset ~traps;
+    create_blocks t fallthrough.insn block ~stack_offset ~traps
   | Lcondbranch3 (lbl0, lbl1, lbl2) ->
     let fallthrough = get_or_make_label t i.next in
     let get_dest lbl = Option.value lbl ~default:fallthrough.label in
@@ -531,27 +519,27 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
         gt = get_dest lbl2
       }
     in
-    add_terminator t block i (Int_test it) ~trap_depth ~traps;
-    create_blocks t fallthrough.insn block ~trap_depth ~traps
+    add_terminator t block i (Int_test it) ~stack_offset ~traps;
+    create_blocks t fallthrough.insn block ~stack_offset ~traps
   | Lswitch labels ->
     (* CR-someday gyorsh: get rid of switches entirely and re-generate them
        based on optimization and perf data? *)
-    add_terminator t block i (Switch labels) ~trap_depth ~traps;
-    create_blocks t i.next block ~trap_depth ~traps
+    add_terminator t block i (Switch labels) ~stack_offset ~traps;
+    create_blocks t i.next block ~stack_offset ~traps
   | Lpushtrap { lbl_handler } ->
     t.trap_handlers <- Label.Set.add lbl_handler t.trap_handlers;
     record_traps t lbl_handler traps;
     let desc = C.Pushtrap { lbl_handler } in
-    block.body <- create_instruction t desc ~trap_depth i :: block.body;
-    let trap_depth = trap_depth + 1 in
+    block.body <- create_instruction t desc ~stack_offset i :: block.body;
+    let stack_offset = stack_offset + Proc.trap_size_in_bytes in
     let traps = T.push traps lbl_handler in
-    create_blocks t i.next block ~trap_depth ~traps
+    create_blocks t i.next block ~stack_offset ~traps
   | Lpoptrap ->
     let desc = C.Poptrap in
-    block.body <- create_instruction t desc ~trap_depth i :: block.body;
-    let trap_depth = trap_depth - 1 in
-    if trap_depth < 0
-    then Misc.fatal_error "Lpoptrap moves the trap depth below zero";
+    block.body <- create_instruction t desc ~stack_offset i :: block.body;
+    let stack_offset = stack_offset - Proc.trap_size_in_bytes in
+    if stack_offset < 0
+    then Misc.fatal_error "Lpoptrap moves the stack offset below zero";
     if !C.verbose
     then (
       Printf.printf "before pop: ";
@@ -561,26 +549,26 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     then (
       Printf.printf "after pop: ";
       T.print traps);
-    create_blocks t i.next block ~trap_depth ~traps
+    create_blocks t i.next block ~stack_offset ~traps
   | Lentertrap ->
     (* Must be the first instruction in the block. *)
     assert (List.compare_length_with block.body 0 = 0);
     block.is_trap_handler <- true;
-    create_blocks t i.next block ~trap_depth ~traps
+    create_blocks t i.next block ~stack_offset ~traps
   | Lprologue ->
     let desc = C.Prologue in
-    block.body <- create_instruction t desc i ~trap_depth :: block.body;
-    create_blocks t i.next block ~trap_depth ~traps
+    block.body <- create_instruction t desc i ~stack_offset :: block.body;
+    create_blocks t i.next block ~stack_offset ~traps
   | Lreloadretaddr ->
     let desc = C.Reloadretaddr in
-    block.body <- create_instruction t desc i ~trap_depth :: block.body;
-    create_blocks t i.next block ~trap_depth ~traps
+    block.body <- create_instruction t desc i ~stack_offset :: block.body;
+    create_blocks t i.next block ~stack_offset ~traps
   | Lop mop -> (
     match mop with
     | Itailcall_ind ->
       let desc = C.Tailcall (Func Indirect) in
-      add_terminator t block i desc ~trap_depth ~traps;
-      create_blocks t i.next block ~trap_depth ~traps
+      add_terminator t block i desc ~stack_offset ~traps;
+      create_blocks t i.next block ~stack_offset ~traps
     | Itailcall_imm { func = func_symbol } ->
       let desc =
         if String.equal func_symbol (C.fun_name t.cfg)
@@ -590,14 +578,14 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
           | Some destination -> C.Tailcall (Self { destination })
         else C.Tailcall (Func (Direct { func_symbol }))
       in
-      add_terminator t block i desc ~trap_depth ~traps;
-      create_blocks t i.next block ~trap_depth ~traps
+      add_terminator t block i desc ~stack_offset ~traps;
+      create_blocks t i.next block ~stack_offset ~traps
     | Iextcall { func; alloc; ty_args; ty_res; returns = false } ->
       let desc =
         C.Call_no_return { func_symbol = func; alloc; ty_args; ty_res }
       in
-      add_terminator t block i desc ~trap_depth ~traps;
-      create_blocks t i.next block ~trap_depth ~traps
+      add_terminator t block i desc ~stack_offset ~traps;
+      create_blocks t i.next block ~stack_offset ~traps
     | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
     | Ifloatofint | Iintoffloat | Iconst_int _ | Iconst_float _ | Icompf _
     | Iconst_symbol _ | Icall_ind | Icall_imm _ | Iextcall _ | Istackoffset _
@@ -608,7 +596,7 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     | Iopaque | Iprobe _ | Iprobe_is_enabled _ | Ispecific _ | Ibeginregion
     | Iendregion | Iname_for_debugger _ ->
       let desc = to_basic mop in
-      block.body <- create_instruction t desc i ~trap_depth :: block.body;
+      block.body <- create_instruction t desc i ~stack_offset :: block.body;
       if Mach.operation_can_raise mop
       then begin
         (* Instruction that can raise is always at the end of a block. *)
@@ -616,10 +604,10 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
         let fallthrough = get_or_make_label t i.next in
         let desc : Cfg.terminator = Always fallthrough.label in
         let i_no_reg = { i with arg = [||]; res = [||]; fdo = Fdo_info.none } in
-        add_terminator t block i_no_reg desc ~trap_depth ~traps;
-        create_blocks t fallthrough.insn block ~trap_depth ~traps
+        add_terminator t block i_no_reg desc ~stack_offset ~traps;
+        create_blocks t fallthrough.insn block ~stack_offset ~traps
       end
-      else create_blocks t i.next block ~trap_depth ~traps)
+      else create_blocks t i.next block ~stack_offset ~traps)
 
 let run (f : Linear.fundecl) ~preserve_orig_labels =
   let t =
@@ -638,9 +626,9 @@ let run (f : Linear.fundecl) ~preserve_orig_labels =
      hashtable can be made with the appropriate hashing and equality
      functions. *)
   let traps = T.push (T.empty ()) t.interproc_handler in
-  let trap_depth = 1 in
-  let entry_block = create_empty_block t t.cfg.entry_label ~trap_depth ~traps in
-  create_blocks t f.fun_body entry_block ~trap_depth ~traps;
+  let stack_offset = 0 in
+  let entry_block = create_empty_block t t.cfg.entry_label ~stack_offset ~traps in
+  create_blocks t f.fun_body entry_block ~stack_offset ~traps;
   (* Register predecessors now rather than during cfg construction, because of
      forward jumps: the blocks do not exist when the jump that reference them is
      processed. *)

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -586,9 +586,14 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
       in
       add_terminator t block i desc ~stack_offset ~traps;
       create_blocks t i.next block ~stack_offset ~traps
+    | Istackoffset bytes ->
+      let desc = to_basic mop in
+      block.body <- create_instruction t desc i ~stack_offset :: block.body;
+      let stack_offset = stack_offset + bytes in
+      create_blocks t i.next block ~stack_offset ~traps
     | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
     | Ifloatofint | Iintoffloat | Iconst_int _ | Iconst_float _ | Icompf _
-    | Iconst_symbol _ | Icall_ind | Icall_imm _ | Iextcall _ | Istackoffset _
+    | Iconst_symbol _ | Icall_ind | Icall_imm _ | Iextcall _
     | Iload (_, _, _)
     | Istore (_, _, _)
     | Ialloc _ | Iintop _

--- a/backend/cfg/linear_utils.ml
+++ b/backend/cfg/linear_utils.ml
@@ -35,7 +35,7 @@ let labelled_insn_end = { label = -1; insn = Linear.end_instr }
 let rec defines_label (i : Linear.instruction) =
   match i.desc with
   | Lend | Llabel _ -> true
-  | Ladjust_trap_depth _ -> defines_label i.next
+  | Ladjust_stack_offset _ -> defines_label i.next
   | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Lbranch _ | Lcondbranch _
   | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lpushtrap _ | Lpoptrap | Lraise _
     ->

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -457,7 +457,7 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
     | Lend -> first_insn
     | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _
     | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
-    | Lentertrap | Lpushtrap _ | Lpoptrap | Ladjust_trap_depth _
+    | Lentertrap | Lpushtrap _ | Lpoptrap | Ladjust_stack_offset _
     | Lraise _ ->
       let subrange_state =
         Subrange_state.advance_over_instruction subrange_state insn

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -38,7 +38,7 @@ and instruction_desc =
   | Lcondbranch3 of label option * label option * label option
   | Lswitch of label array
   | Lentertrap
-  | Ladjust_trap_depth of { delta_traps : int; }
+  | Ladjust_stack_offset of { delta_bytes : int; }
   | Lpushtrap of { lbl_handler : label; }
   | Lpoptrap
   | Lraise of Lambda.raise_kind
@@ -91,3 +91,5 @@ let rec end_instr =
 let instr_cons d a r n =
   { desc = d; next = n; arg = a; res = r;
     dbg = Debuginfo.none; fdo = Fdo_info.none; live = Reg.Set.empty }
+
+let traps_to_bytes traps = Proc.trap_size_in_bytes * traps

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -38,7 +38,7 @@ and instruction_desc =
   | Lcondbranch3 of label option * label option * label option
   | Lswitch of label array
   | Lentertrap
-  | Ladjust_trap_depth of { delta_traps : int; }
+  | Ladjust_stack_offset of { delta_bytes : int; }
   | Lpushtrap of { lbl_handler : label; }
   | Lpoptrap
   | Lraise of Lambda.raise_kind
@@ -60,3 +60,5 @@ type fundecl =
     fun_frame_required: bool;
     fun_prologue_required: bool;
   }
+
+val traps_to_bytes : int -> int

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -61,8 +61,8 @@ let instr ppf i =
       fprintf ppf "@,endswitch"
   | Lentertrap ->
       fprintf ppf "enter trap"
-  | Ladjust_trap_depth { delta_traps } ->
-      fprintf ppf "adjust trap depth by %d traps" delta_traps
+  | Ladjust_stack_offset { delta_bytes } ->
+      fprintf ppf "adjust pseudo stack offset by %d bytes" delta_bytes
   | Lpushtrap { lbl_handler; } ->
       fprintf ppf "push trap %a" label lbl_handler
   | Lpoptrap ->

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -93,3 +93,6 @@ val init : unit -> unit
     Used in Cmmgen when converting [@@builtin] external calls
     to primitive operations. *)
 val operation_supported : Cmm.operation -> bool
+
+(** The number of bytes each trap occupies on the stack. *)
+val trap_size_in_bytes : int


### PR DESCRIPTION
Cfg to linear needs to take into account Istackoffset instructions when calculating virtual stack adjustment.

- change Ladjust_trap_depth in traps to Ladjust_stack_offset in bytes
- change trap_depth to stack_offset in Cfg

This PR is work in progress, mostly because cfgize needs to be fixed and more testing is needed with FDO. There is some debug printing that needs to be in a separate PR.