### PR TITLE
Format asm_targets

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -550,6 +550,7 @@ check-fmt:
            [ "$$(git status --porcelain backend/cfg)" != "" ] || \
            [ "$$(git status --porcelain middle_end/mangling.ml)" != "" ] || \
            [ "$$(git status --porcelain middle_end/mangling.mli)" != "" ] || \
+           [ "$$(git status --porcelain backend/asm_targets)" != "" ] || \
            [ "$$(git status --porcelain tools/merge_archives.ml)" != "" ]; then \
 	  echo; \
 	  echo "Tree must be clean before running 'make check-fmt'"; \
@@ -560,6 +561,7 @@ check-fmt:
            [ "$$(git diff backend/cfg)" != "" ] || \
            [ "$$(git diff middle_end/mangling.ml)" != "" ] || \
            [ "$$(git diff middle_end/mangling.mli)" != "" ] || \
+           [ "$$(git diff backend/asm_targets)" != "" ] || \
            [ "$$(git diff tools/merge_archives.ml)" != "" ]; then \
 	  echo; \
 	  echo "The following code was not formatted correctly:"; \

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -113,10 +113,10 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
         Asm_label.print label Asm_section.print lbl_section Asm_section.print
         this_section;
     (* CR-someday bkhajwal: Be aware of MASM label type annotation *)
-    (* CR poechsel: This assumes that no [D.text] or [D.section] were
-    emitted since the last call to [switch_to_section].
-    If we emit dwarf separately from other assembly everything will be fine,
-    otherwise this might break. *)
+    (* CR poechsel: This assumes that no [D.text] or [D.section] were emitted
+       since the last call to [switch_to_section]. If we emit dwarf separately
+       from other assembly everything will be fine, otherwise this might
+       break. *)
     D.label (Asm_label.encode label)
 
   let switch_to_section section =
@@ -146,12 +146,10 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     sections_seen := [];
     temp_var_counter := 0;
     current_dwarf_section_ref := None;
-    (* Forward label references are illegal in GAS.
-       To avoid it, emit the beginning of all dwarf sections in advance. *)
-    begin
-      if is_gas () then
-        List.iter switch_to_section (Asm_section.dwarf_sections_in_order ())
-    end;
+    (* Forward label references are illegal in GAS. To avoid it, emit the
+       beginning of all dwarf sections in advance. *)
+    if is_gas ()
+    then List.iter switch_to_section (Asm_section.dwarf_sections_in_order ());
     (* Stop dsymutil complaining about empty __debug_line sections (produces
        bogus error "line table parameters mismatch") by making sure such
        sections are never empty. *)
@@ -199,8 +197,8 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
 
   let string =
     with_comment (fun str ->
-      assert_string_has_no_null_bytes str;
-      D.bytes str)
+        assert_string_has_no_null_bytes str;
+        D.bytes str)
 
   let cache_string ?comment section str =
     assert_string_has_no_null_bytes str;
@@ -278,7 +276,7 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
 
   let between_symbol_in_current_unit_and_label_offset ?comment:_ ~upper:_
       ~lower:_ ~offset_upper:_ () =
-      (* CR poechsel: use the arguments *)
+    (* CR poechsel: use the arguments *)
     A.emit_line "between_symbol_in_current_unit_and_label_offset"
 
   let new_temp_var () =

--- a/backend/asm_targets/asm_directives_intf.ml
+++ b/backend/asm_targets/asm_directives_intf.ml
@@ -223,18 +223,12 @@ module type S = sig
   (** Emit an offset into a DWARF section given a label identifying the place
       within such section. *)
   val offset_into_dwarf_section_label :
-    ?comment:string ->
-    Asm_section.dwarf_section ->
-    Asm_label.t ->
-    unit
+    ?comment:string -> Asm_section.dwarf_section -> Asm_label.t -> unit
 
   (** Emit an offset into a DWARF section given a symbol identifying the place
       within such section. The symbol may only be in a compilation unit
       different from the current one if the supplied section is [Debug_info].
       The symbol must always be in the given section. *)
   val offset_into_dwarf_section_symbol :
-    ?comment:string ->
-    Asm_section.dwarf_section ->
-    Asm_symbol.t ->
-    unit
+    ?comment:string -> Asm_section.dwarf_section -> Asm_symbol.t -> unit
 end

--- a/backend/asm_targets/asm_label.ml
+++ b/backend/asm_targets/asm_label.ml
@@ -52,13 +52,14 @@ include Identifiable.Make (struct
 end)
 
 let create_int section label =
-  assert(label >= 0);
+  assert (label >= 0);
   { section; label = Int label }
 
 let contains_escapable_char label =
   let found_escapable_char = ref false in
-  String.iter (fun c ->
-    if Asm_symbol.should_be_escaped c then found_escapable_char := true)
+  String.iter
+    (fun c ->
+      if Asm_symbol.should_be_escaped c then found_escapable_char := true)
     label;
   !found_escapable_char
 
@@ -67,9 +68,7 @@ let create_string section label =
   { section; label = String label }
 
 let label_prefix =
-  match Target_system.assembler ()  with
-  | MacOS -> "L"
-  | MASM | GAS_like -> ".L"
+  match Target_system.assembler () with MacOS -> "L" | MASM | GAS_like -> ".L"
 
 let encode (t : t) =
   match t.label with
@@ -78,18 +77,19 @@ let encode (t : t) =
 
 let section t = t.section
 
-let new_label_ref = ref (fun _section ->
-  Misc.fatal_error "[Asm_label.initialize] has not been called")
+let new_label_ref =
+  ref (fun _section ->
+      Misc.fatal_error "[Asm_label.initialize] has not been called")
 
 let initialize ~new_label =
   new_label_ref := fun section -> create_int section (new_label ())
+
 let create (section : Asm_section.t) = !new_label_ref section
 
-(* CR-someday poechsel: With a function such as
-  `index : Asm_section.dwarf_section -> int`, we
-  could maintain an association array and get rid of
-  all these variables plus the pattern matching in
-  for_dwarf_section. *)
+(* CR-someday poechsel: With a function such as `index :
+   Asm_section.dwarf_section -> int`, we could maintain an association array and
+   get rid of all these variables plus the pattern matching in
+   for_dwarf_section. *)
 
 let debug_info_label = lazy (create (DWARF Debug_info))
 

--- a/backend/asm_targets/asm_label.mli
+++ b/backend/asm_targets/asm_label.mli
@@ -30,8 +30,8 @@
     prefix (such as "L", ".L", etc).
 
     Label's numeric or textual names are unique within the assembly stream for a
-    single compilation unit, even across sections. [Asm_label] keeps track of 
-    the section a label belongs to, and doesn't check uniqueness.  
+    single compilation unit, even across sections. [Asm_label] keeps track of
+    the section a label belongs to, and doesn't check uniqueness.
 
     Note: Labels are not symbols in the usual sense---they are a construct in
     the assembler's metalanguage and not accessible in the object
@@ -58,8 +58,8 @@ val create_string : Asm_section.t -> string -> t
 val encode : t -> string
 
 (** To be called by the emitter at the very start of code generation.
-    [new_label] should always be [Cmm.new_label].
-    Needed to avoid a circular dependency. *)
+    [new_label] should always be [Cmm.new_label]. Needed to avoid a circular
+    dependency. *)
 val initialize : new_label:(unit -> int) -> unit
 
 (** Which section a label is in. *)

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -40,8 +40,8 @@ type dwarf_section =
   | Debug_str
   | Debug_line
 
-(* Right now [Asm_section] is only meant to represent dwarf sections.
-   This type is kept as-is to make it obvious. *)
+(* Right now [Asm_section] is only meant to represent dwarf sections. This type
+   is kept as-is to make it obvious. *)
 type t = DWARF of dwarf_section
 
 val to_string : t -> string

--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -25,8 +25,8 @@
  **********************************************************************************)
 
 let should_be_escaped = function
-| ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_') -> false
-| c -> true
+  | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> false
+  | c -> true
 
 module Thing = struct
   type t = string
@@ -57,13 +57,12 @@ let escape name =
   else
     (* Each escaped character is replaced by 3 characters (a $, and 2 for its
        hexadecimal representation)*)
-    let b = Buffer.create (String.length name + 2 * !escaped_nb) in
+    let b = Buffer.create (String.length name + (2 * !escaped_nb)) in
     String.iter
       (fun c ->
-        if should_be_escaped c then
-          Printf.bprintf b "$%02x" (Char.code c)
-        else
-            Buffer.add_char b c)
+        if should_be_escaped c
+        then Printf.bprintf b "$%02x" (Char.code c)
+        else Buffer.add_char b c)
       name;
     Buffer.contents b
 


### PR DESCRIPTION
Apply ocamlformat to backend/asm_targets.
[check-fmt] will know enforce that these files are correctly formatted.