### PR TITLE
Create the stublibs directory on install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -277,6 +277,7 @@ install: stage2
 	rm -f $(prefix)/bin/flambda_backend.main*
 	rm -rf $(prefix)/lib/ocaml-variants
 	rm -rf $(prefix)/lib/stublibs
+	mkdir $(prefix)/lib/stublibs
 	rm -f $(prefix)/lib/ocaml/META
 	rm -f $(prefix)/lib/ocaml/dune-package
 	rm -f $(prefix)/lib/ocaml/compiler-libs/*.cmo


### PR DESCRIPTION
`ocamlfind` will install stubs in this directory if it exists, and one package (`z3_tptp`) expects it to exist. The Makefile from upstream always creates it on install too, so this reduces divergence.