### PR TITLE
Cpp mangling is now a configuration option

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -27,9 +27,6 @@ let mk_dcfg f =
   "-dcfg", Arg.Unit f, " (undocumented)"
 ;;
 
-let mk_use_cpp_mangling f =
-  "-gcpp-mangling", Arg.Unit f, " Use C++ mangling for function symbols"
-
 let mk_heap_reduction_threshold f =
   "-heap-reduction-threshold",
   Arg.Int f,
@@ -388,8 +385,6 @@ module type Flambda_backend_options = sig
   val dump_inlining_paths : unit -> unit
   val dcfg : unit -> unit
 
-  val use_cpp_mangling : unit -> unit
-
   val heap_reduction_threshold : int -> unit
 
   val flambda2_join_points : unit -> unit
@@ -452,8 +447,6 @@ struct
     mk_ocamlcfg F.ocamlcfg;
     mk_no_ocamlcfg F.no_ocamlcfg;
     mk_dcfg F.dcfg;
-
-    mk_use_cpp_mangling F.use_cpp_mangling;
 
     mk_heap_reduction_threshold F.heap_reduction_threshold;
 
@@ -549,8 +542,6 @@ module Flambda_backend_options_impl = struct
   let dcfg = set' Flambda_backend_flags.dump_cfg
 
   let dump_inlining_paths = set' Flambda_backend_flags.dump_inlining_paths
-
-  let use_cpp_mangling = set' Flambda_backend_flags.use_cpp_mangling
 
   let heap_reduction_threshold x =
     Flambda_backend_flags.heap_reduction_threshold := x
@@ -709,7 +700,6 @@ module Extra_params = struct
     match name with
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
     | "dump-inlining-paths" -> set' Flambda_backend_flags.dump_inlining_paths
-    | "gcpp-mangling" -> set' Flambda_backend_flags.use_cpp_mangling
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
     | "flambda2-join-points" -> set Flambda2.join_points
     | "flambda2-result-types" ->

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -25,8 +25,6 @@ module type Flambda_backend_options = sig
   val dump_inlining_paths : unit -> unit
   val dcfg : unit -> unit
 
-  val use_cpp_mangling : unit -> unit
-
   val heap_reduction_threshold : int -> unit
 
   val flambda2_join_points : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -16,8 +16,6 @@
 let use_ocamlcfg = ref false            (* -ocamlcfg *)
 let dump_cfg = ref false                (* -dcfg *)
 
-let use_cpp_mangling = ref false        (* -use-cpp-mangling *)
-
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)
 

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -17,8 +17,6 @@
 val use_ocamlcfg : bool ref
 val dump_cfg : bool ref
 
-val use_cpp_mangling : bool ref
-
 val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
 

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -120,7 +120,7 @@ let make_symbol ?(unitname = current_unit.ui_symbol) idopt =
   | Some id -> concat_symbol prefix id
 
 let make_fun_symbol ?(unitname = current_unit.ui_symbol) loc id =
-  if !Flambda_backend_flags.use_cpp_mangling then
+  if Config.with_cpp_mangling then
     Mangling.fun_symbol ~unitname ~loc ~id
   else
     make_symbol ~unitname (Some id)
@@ -483,13 +483,13 @@ let cpp_closure_symbol closure_id =
   Symbol.of_global_linkage compilation_unit (Linkage_name.create linkage_name)
 
 let function_label closure_id =
-  if !Flambda_backend_flags.use_cpp_mangling then
+  if Config.with_cpp_mangling then
     cpp_function_label closure_id
   else
     legacy_function_label closure_id
 
 let closure_symbol closure_id =
-  if !Flambda_backend_flags.use_cpp_mangling then
+  if Config.with_cpp_mangling then
     cpp_closure_symbol closure_id
   else
     legacy_closure_symbol closure_id

--- a/ocaml/Makefile.config.in
+++ b/ocaml/Makefile.config.in
@@ -225,6 +225,7 @@ WITH_OCAMLDOC=@ocamldoc@
 WITH_OCAMLTEST=@ocamltest@
 ASM_CFI_SUPPORTED=@asm_cfi_supported@
 WITH_FRAME_POINTERS=@frame_pointers@
+WITH_CPP_MANGLING=@cpp_mangling@
 WITH_PROFINFO=@profinfo@
 PROFINFO_WIDTH=@profinfo_width@
 WITH_FPIC=@fpic@

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -840,6 +840,7 @@ enable_bigarray_lib
 enable_ocamldoc
 enable_ocamltest
 enable_frame_pointers
+enable_cpp_mangling
 enable_naked_pointers
 enable_naked_pointers_checker
 enable_spacetime
@@ -1512,6 +1513,7 @@ Optional Features:
   --disable-ocamldoc      do not build the ocamldoc documentation system
   --disable-ocamltest     do not build the ocamltest driver
   --enable-frame-pointers use frame pointers in runtime and generated code
+  --enable-cpp-mangling   use cpp mangling for exported symbols
   --disable-naked-pointers
                           do not allow naked pointers
   --enable-naked-pointers-checker
@@ -3128,6 +3130,12 @@ fi
 # Check whether --enable-frame-pointers was given.
 if test "${enable_frame_pointers+set}" = set; then :
   enableval=$enable_frame_pointers;
+fi
+
+
+# Check whether --enable-cpp-mangling was given.
+if test "${enable_cpp_mangling+set}" = set; then :
+  enableval=$enable_cpp_mangling;
 fi
 
 

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -710,6 +710,7 @@ cmm_invariants
 flambda_invariants
 flambda2
 flambda
+cpp_mangling
 frame_pointers
 profinfo_width
 profinfo
@@ -2844,6 +2845,7 @@ VERSION=4.12.0
 
 
  # TODO: rename this variable
+
 
 
 
@@ -16815,6 +16817,16 @@ else
   { $as_echo "$as_me:${as_lineno-$LINENO}: not using frame pointers" >&5
 $as_echo "$as_me: not using frame pointers" >&6;}
   frame_pointers=false
+fi
+
+## CPP mangling
+
+if test x"$enable_cpp_mangling" = "xyes"; then :
+  cpp_mangling=true
+    $as_echo "#define WITH_CPP_MANGLING 1" >>confdefs.h
+
+else
+  cpp_mangling=false
 fi
 
 ## No naked pointers

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -279,6 +279,10 @@ AC_ARG_ENABLE([frame-pointers],
   [AS_HELP_STRING([--enable-frame-pointers],
     [use frame pointers in runtime and generated code])])
 
+AC_ARG_ENABLE([cpp-mangling],
+  [AS_HELP_STRING([--enable-cpp-mangling],
+    [use cpp mangling for exported symbols])])
+
 AC_ARG_ENABLE([naked-pointers],
   [AS_HELP_STRING([--disable-naked-pointers],
     [do not allow naked pointers])])

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -152,6 +152,7 @@ AC_SUBST([install_source_artifacts])
 AC_SUBST([profinfo])
 AC_SUBST([profinfo_width])
 AC_SUBST([frame_pointers])
+AC_SUBST([cpp_mangling])
 AC_SUBST([flambda])
 AC_SUBST([flambda2])
 AC_SUBST([flambda_invariants])
@@ -1737,6 +1738,13 @@ AS_IF([test x"$enable_frame_pointers" = "xyes"],
   )],
   [AC_MSG_NOTICE([not using frame pointers])
   frame_pointers=false])
+
+## CPP mangling
+
+AS_IF([test x"$enable_cpp_mangling" = "xyes"],
+  [cpp_mangling=true
+    AC_DEFINE([WITH_CPP_MANGLING])],
+  [cpp_mangling=false])
 
 ## No naked pointers
 

--- a/ocaml/utils/Makefile
+++ b/ocaml/utils/Makefile
@@ -86,6 +86,7 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST,SYSTHREAD_SUPPORT) \
 	    $(call SUBST,TARGET) \
 	    $(call SUBST,WITH_FRAME_POINTERS) \
+	    $(call SUBST,WITH_CPP_MANGLING) \
 	    $(call SUBST,WITH_PROFINFO) \
 	    $(call SUBST,FLAT_FLOAT_ARRAY) \
 	    $(call SUBST,FUNCTION_SECTIONS) \

--- a/ocaml/utils/config.mli
+++ b/ocaml/utils/config.mli
@@ -164,6 +164,9 @@ val asm_cfi_supported: bool
 val with_frame_pointers : bool
 (** Whether assembler should maintain frame pointers *)
 
+val with_cpp_mangling : bool
+(** Whether symbol names should be following the cpp mangling convention *)
+
 val ext_obj: string
 (** Extension for object files, e.g. [.o] under Unix. *)
 

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -135,6 +135,7 @@ let system = "%%SYSTEM%%"
 let asm = "%%ASM%%"
 let asm_cfi_supported = %%ASM_CFI_SUPPORTED%%
 let with_frame_pointers = %%WITH_FRAME_POINTERS%%
+let with_cpp_mangling = %%WITH_CPP_MANGLING%%
 let profinfo = %%WITH_PROFINFO%%
 let profinfo_width = %%PROFINFO_WIDTH%%
 
@@ -190,6 +191,7 @@ let configuration_variables =
   p "asm" asm;
   p_bool "asm_cfi_supported" asm_cfi_supported;
   p_bool "with_frame_pointers" with_frame_pointers;
+  p_bool "with_cpp_mangling" with_cpp_mangling;
   p "ext_exe" ext_exe;
   p "ext_obj" ext_obj;
   p "ext_asm" ext_asm;


### PR DESCRIPTION
Programs compiled with cpp-mangling on requires the stdlib (and the compilerlibs) to have also been build with cpp-mangling.
Right now cpp-mangling is turned on with a compilation flag, making a mistake easy to happen.
This PR removes this compilation flag and replaces it with a configuration option.