### PR TITLE
Compiler flag -reorder-blocks-random for FDO testing

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -252,11 +252,10 @@ let reorder_blocks_random ppf_dump cl =
   | None -> cl
   | Some seed ->
      (* Initialize random state based on user-provided seed and function name.
-        Per-function random state (instead of per-compilation unit or
-        per call to ocamlopt) is good for debugging: it gives us
-        deterministic builds for each user-provided seed, regardless
-        of the order of functions in the file or
-        the order of files on the command line. *)
+        Per-function random state (instead of per call to ocamlopt)
+        is good for debugging: it gives us deterministic builds
+        for each user-provided seed, regardless
+        of the order of files on the command line. *)
      let fun_name = (Cfg_with_layout.cfg cl).fun_name in
      let random_state = Random.State.make [| seed; Hashtbl.hash fun_name |] in
      Cfg_with_layout.reorder_blocks_random ~random_state cl;

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -250,7 +250,15 @@ let test_cfgize (f : Mach.fundecl) (res : Linear.fundecl) : unit =
 let reorder_blocks_random ppf_dump cl =
   match !Flambda_backend_flags.reorder_blocks_random with
   | None -> cl
-  | Some random_state ->
+  | Some seed ->
+     (* Initialize random state based on user-provided seed and function name.
+        Per-function random state (instead of per-compilation unit or
+        per call to ocamlopt) is good for debugging: it gives us
+        deterministic builds for each user-provided seed, regardless
+        of the order of functions in the file or
+        the order of files on the command line. *)
+     let fun_name = (Cfg_with_layout.cfg cl).fun_name in
+     let random_state = Random.State.make [| seed; Hashtbl.hash fun_name |] in
      Cfg_with_layout.reorder_blocks_random ~random_state cl;
      pass_dump_cfg_if ppf_dump Flambda_backend_flags.dump_cfg
        "After reorder_blocks_random" cl

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -247,6 +247,14 @@ let test_cfgize (f : Mach.fundecl) (res : Linear.fundecl) : unit =
       f.Mach.fun_name;
   end
 
+let reorder_blocks_random ppf_dump cl =
+  match !Flambda_backend_flags.reorder_blocks_random with
+  | None -> cl
+  | Some random_state ->
+     Cfg_with_layout.reorder_blocks_random ~random_state cl;
+     pass_dump_cfg_if ppf_dump Flambda_backend_flags.dump_cfg
+       "After reorder_blocks_random" cl
+
 let compile_fundecl ~ppf_dump fd_cmm =
   Proc.init ();
   Reg.reset();
@@ -292,6 +300,7 @@ let compile_fundecl ~ppf_dump fd_cmm =
       ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cfg
       ++ pass_dump_cfg_if ppf_dump Flambda_backend_flags.dump_cfg "After linear_to_cfg"
       ++ save_cfg
+      ++ reorder_blocks_random ppf_dump
       ++ Profile.record ~accumulate:true "cfg_to_linear" Cfg_to_linear.run
       ++ pass_dump_linear_if ppf_dump dump_linear "After cfg_to_linear"
     end else

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -177,6 +177,7 @@ let save_as_dot t ?show_instr ?show_exn ?annotate_block ?annotate_succ msg =
 module Permute = struct
   (* Implementation of this module is copied from Base *)
   external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+
   external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
 
   let default_random_state = Random.State.make_self_init ()

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -177,19 +177,18 @@ let save_as_dot t ?show_instr ?show_exn ?annotate_block ?annotate_succ msg =
 module Permute = struct
   (* Implementation of this module is copied from Base *)
   external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
-
-  let swap t i j =
-    (* CR-someday: use unsafe gets. *)
-    let elt_i = t.(i) in
-    let elt_j = t.(j) in
-    unsafe_set t i elt_j;
-    unsafe_set t j elt_i
+  external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
 
   let default_random_state = Random.State.make_self_init ()
 
   let array ?(random_state = default_random_state) t =
-    let len = Array.length t in
-    let num_swaps = len - 1 in
+    let swap t i j =
+      let elt_i = unsafe_get t i in
+      let elt_j = unsafe_get t j in
+      unsafe_set t i elt_j;
+      unsafe_set t j elt_i
+    in
+    let num_swaps = Array.length t - 1 in
     for i = num_swaps downto 1 do
       (* [random_i] is drawn from [0,i] *)
       let random_i = Random.State.int random_state (i + 1) in

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -198,12 +198,12 @@ module Permute = struct
   let list ?(random_state = default_random_state) list =
     match list with
     (* special cases to speed things up in trivial cases *)
-    | [] | [ _ ] -> list
-    | [ x; y ] -> if Random.State.bool random_state then [ y; x ] else list
+    | [] | [_] -> list
+    | [x; y] -> if Random.State.bool random_state then [y; x] else list
     | _ ->
-       let arr = Array.of_list list in
-       array ~random_state arr;
-       Array.to_list arr
+      let arr = Array.of_list list in
+      array ~random_state arr;
+      Array.to_list arr
 end
 
 let reorder_blocks_random ?random_state t =

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -173,3 +173,44 @@ let save_as_dot t ?show_instr ?show_exn ?annotate_block ?annotate_succ msg =
       print_dot ?show_instr ?show_exn ?annotate_block ?annotate_succ ppf t)
     ~always:(fun () -> close_out oc)
     ~exceptionally:(fun _exn -> Misc.remove_file filename)
+
+module Permute = struct
+  (* Implementation of this module is copied from Base *)
+  external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+
+  let swap t i j =
+    let elt_i = t.(i) in
+    let elt_j = t.(j) in
+    unsafe_set t i elt_j;
+    unsafe_set t j elt_i
+
+  let default_random_state = Random.State.make_self_init ()
+
+  let array ?(random_state = default_random_state) t =
+    let len = Array.length t in
+    let num_swaps = len - 1 in
+    for i = num_swaps downto 1 do
+      (* [random_i] is drawn from [0,i] *)
+      let random_i = Random.State.int random_state (i + 1) in
+      swap t i random_i
+    done
+
+  let list ?(random_state = default_random_state) list =
+    match list with
+    (* special cases to speed things up in trivial cases *)
+    | [] | [ _ ] -> list
+    | [ x; y ] -> if Random.State.bool random_state then [ y; x ] else list
+    | _ ->
+       let arr = Array.of_list list in
+       array ~random_state arr;
+       Array.to_list arr
+end
+
+let reorder_blocks_random ?random_state t =
+  (* Ensure entry exit invariants *)
+  let original_layout = layout t in
+  let new_layout =
+    List.hd original_layout
+    :: Permute.list ?random_state (List.tl original_layout)
+  in
+  set_layout t new_layout

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -179,6 +179,7 @@ module Permute = struct
   external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
 
   let swap t i j =
+    (* CR-someday: use unsafe gets. *)
     let elt_i = t.(i) in
     let elt_j = t.(j) in
     unsafe_set t i elt_j;
@@ -207,7 +208,7 @@ module Permute = struct
 end
 
 let reorder_blocks_random ?random_state t =
-  (* Ensure entry exit invariants *)
+  (* Ensure entry block remains first *)
   let original_layout = layout t in
   let new_layout =
     List.hd original_layout

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -70,8 +70,8 @@ val print_dot :
 val dump : Format.formatter -> t -> msg:string -> unit
 
 (** Change layout: randomly reorder the blocks, keeping the entry block first.
-    This function is intended for testing and enabled by
-    compiler flag "-reorder-blocks-random".
+    This function is intended for testing and enabled by compiler flag
+    "-reorder-blocks-random".
 
     Side-effects [random_state] by repeated calls to [Random.State.int] and
     [Random.State.bool]. *)

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -70,6 +70,8 @@ val print_dot :
 val dump : Format.formatter -> t -> msg:string -> unit
 
 (** Change layout: randomly reorder the blocks, keeping the entry block first.
+    This function is intended for testing and enabled by
+    compiler flag "-reorder-blocks-random".
 
     Side-effects [random_state] by repeated calls to [Random.State.int] and
     [Random.State.bool]. *)

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -71,6 +71,6 @@ val dump : Format.formatter -> t -> msg:string -> unit
 
 (** Change layout: randomly reorder the blocks, keeping the entry block first.
 
-   Side-effects [random_state] by repeated calls to [Random.State.int] and
-   [Random.State.bool]. *)
+    Side-effects [random_state] by repeated calls to [Random.State.int] and
+    [Random.State.bool]. *)
 val reorder_blocks_random : ?random_state:Random.State.t -> t -> unit

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -68,3 +68,9 @@ val print_dot :
   unit
 
 val dump : Format.formatter -> t -> msg:string -> unit
+
+(** Change layout: randomly reorder the blocks, keeping the entry block first.
+
+   Side-effects [random_state] by repeated calls to [Random.State.int] and
+   [Random.State.bool]. *)
+val reorder_blocks_random : ?random_state:Random.State.t -> t -> unit

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -540,32 +540,6 @@ struct
   ]
 end
 
-
-(* Build systems call 'ocamlopt' on a single file. When -seed is used for
-   random block layout, the same permutation will be applied to layout of all
-   functions that appear in the same source order (first function, second
-   function, etc) in different compilation units, because the random state
-   will be reinitialized from the beginning on each call to 'ocamlopt'.
-   To circumvent it while still having deterministic builds for a given
-   -seed, regardless of the order the build system calls it, we can use hash of
-   the file names as an additional seed, but here we don't have access to these
-   filenames. *)
-let make_random_state ?(files=[]) seed =
-  let random_state =
-    match files with
-    | [] -> Random.State.make [| seed |]
-    | _ ->
-       let hashes =
-         (* sort to make the initialization deterministic, regardless of
-               the order in which the files are passed on command line, in
-               the case there is more than one file. *)
-         List.sort String.compare files
-         |> List.map Hashtbl.hash
-       in
-       Random.State.make (Array.of_list (seed :: hashes))
-  in
-  Flambda_backend_flags.reorder_blocks_random := Some random_state
-
 module Flambda_backend_options_impl = struct
   let set r () = r := Flambda_backend_flags.Set true
   let clear r () = r := Flambda_backend_flags.Set false
@@ -577,7 +551,8 @@ module Flambda_backend_options_impl = struct
   let no_ocamlcfg = clear' Flambda_backend_flags.use_ocamlcfg
   let dcfg = set' Flambda_backend_flags.dump_cfg
 
-  let reorder_blocks_random seed = make_random_state seed
+  let reorder_blocks_random seed =
+    Flambda_backend_flags.reorder_blocks_random := Some seed
 
   let dump_inlining_paths = set' Flambda_backend_flags.dump_inlining_paths
 
@@ -735,15 +710,18 @@ module Extra_params = struct
     let set_int' option =
       Compenv.int_setter ppf name option v; true
     in
+    let set_int_option' option =
+      begin match Compenv.check_int ppf name v with
+       | Some seed -> option := Some seed
+       | None -> ()
+      end;
+      true
+    in
     match name with
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
     | "dump-inlining-paths" -> set' Flambda_backend_flags.dump_inlining_paths
     | "reorder-blocks-random" ->
-       begin match Compenv.check_int ppf name v with
-       | Some seed -> make_random_state seed
-       | None -> ()
-       end;
-       true
+       set_int_option' Flambda_backend_flags.reorder_blocks_random
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
     | "flambda2-join-points" -> set Flambda2.join_points
     | "flambda2-result-types" ->

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -25,6 +25,8 @@ module type Flambda_backend_options = sig
   val dump_inlining_paths : unit -> unit
   val dcfg : unit -> unit
 
+  val reorder_blocks_random : int -> unit
+
   val heap_reduction_threshold : int -> unit
 
   val flambda2_join_points : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -16,6 +16,8 @@
 let use_ocamlcfg = ref false            (* -ocamlcfg *)
 let dump_cfg = ref false                (* -dcfg *)
 
+let reorder_blocks_random = ref None    (* -dreorder-blocks-random seed *)
+
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)
 

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -16,7 +16,7 @@
 let use_ocamlcfg = ref false            (* -ocamlcfg *)
 let dump_cfg = ref false                (* -dcfg *)
 
-let reorder_blocks_random = ref None    (* -dreorder-blocks-random seed *)
+let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -17,7 +17,7 @@
 val use_ocamlcfg : bool ref
 val dump_cfg : bool ref
 
-val reorder_blocks_random : Random.State.t option ref
+val reorder_blocks_random : int option ref
 
 val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -17,6 +17,8 @@
 val use_ocamlcfg : bool ref
 val dump_cfg : bool ref
 
+val reorder_blocks_random : Random.State.t option ref
+
 val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
 


### PR DESCRIPTION
The flag has no effect without -ocamlcfg. The flag takes an integer seed as argument. 
It may be worth making the seed argument optional, and use `Random.self_init` by default, but it will make tests hard to reproduce and it's a pain to make a flag like that using Arg module.

The code is taken from ocamlfdo (where it has been reviewed and tested) and adapted to the compiler distribution, in particular to use Stdlib, instead of Base. 

Tested it on a bunch of small files, will test more with #608 (otherwise it hits the segfault in Base).