### PR TITLE
Unify unknown trap stacks that are physical equal

### DIFF
--- a/backend/cfg/trap_stack.ml
+++ b/backend/cfg/trap_stack.ml
@@ -192,20 +192,23 @@ module Make (D : D) = struct
 
   let link ~(src : t) ~(dst : t) =
     assert (!src = Unknown);
-    (* check that there is no path from dst to src. it guarantees that the link
-       from src to dst that we install is not going to close a cycle, which will
-       cause non-termination of other operations on the stack. *)
-    let rec loop cur =
-      if cur == src then Misc.fatal_error "Trap_stack.unify created a cycle.";
-      match !cur with
-      | Unknown -> ()
-      | Empty -> ()
-      | Link t -> loop t
-      | Push { h = _; t } -> loop t
-    in
-    loop dst;
-    (* create a link from src to dst. *)
-    src := Link dst
+    if src == dst
+    then ()
+    else
+      (* check that there is no path from dst to src. it guarantees that the
+         link from src to dst that we install is not going to close a cycle,
+         which will cause non-termination of other operations on the stack. *)
+      let rec loop cur =
+        if cur == src then Misc.fatal_error "Trap_stack.unify created a cycle.";
+        match !cur with
+        | Unknown -> ()
+        | Empty -> ()
+        | Link t -> loop t
+        | Push { h = _; t } -> loop t
+      in
+      loop dst;
+      (* create a link from src to dst. *)
+      src := Link dst
 
   (* Given acyclic [s1] and [s2], [unify s1 s2] terminates because every step
      removes one unknown or reduces the length of one of the argument stacks by


### PR DESCRIPTION
In `Trap_stacks`, unifying two `Unknown` stacks is in general an error, except when the stacks are physically equal. This PR adds the special condition.

Without this condition, when the compiler is invoked with -ocamlcfg flag, it fails on some input programs during `Linear_to_cfg`. We have only seen this when debug printing is enabled, because then the input Linear IR is itself the result of `Cfg_to_linear`, and has more blocks, because we split blocks after every raise (since #312). The splitting can be improved separately to avoid it probably, but currently it is not "looking ahead" to see if there is a label, and so it creates many blocks that start with an "unknown" trap stack,  which are eliminated later by `Eliminate_fallthrough_blocks`. An alternative is to run this pass before printing, but it makes debugging certain things impossible.
