### PR TITLE
Improve debug printing for cfg

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -241,7 +241,7 @@ let test_cfgize (f : Mach.fundecl) (res : Linear.fundecl) : unit =
   Eliminate_dead_code.run_dead_block expected;
   Simplify_terminator.run (Cfg_with_layout.cfg expected);
   let result = recompute_liveness_on_cfg result in
-  Cfg_equivalence.check_cfg_with_layout f expected result;
+  Cfg_equivalence.check_cfg_with_layout ~mach:f expected result;
   if ocamlcfg_verbose then begin
     Format.eprintf "the CFG on both code paths are equivalent for function %s.\n%!"
       f.Mach.fun_name;

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -248,58 +248,56 @@ let dump_basic ppf (i : basic instruction) =
   let open Format in
   if i.stack_offset > 0 then fprintf ppf "[T%d] " i.stack_offset;
   fprintf ppf "%d: " i.id;
-  if Array.length i.res > 0 then
-    fprintf ppf "%a := " Printmach.regs i.res;
+  if Array.length i.res > 0 then fprintf ppf "%a := " Printmach.regs i.res;
   (match i.desc with
-   | Op op -> dump_op ppf op
-   | Call call ->
-      fprintf ppf "Call ";
-      dump_call ppf call
-   | Reloadretaddr -> fprintf ppf "Reloadretaddr"
-   | Pushtrap { lbl_handler } -> fprintf ppf "Pushtrap handler=%d" lbl_handler
-   | Poptrap -> fprintf ppf "Poptrap"
-   | Prologue -> fprintf ppf "Prologue");
+  | Op op -> dump_op ppf op
+  | Call call ->
+    fprintf ppf "Call ";
+    dump_call ppf call
+  | Reloadretaddr -> fprintf ppf "Reloadretaddr"
+  | Pushtrap { lbl_handler } -> fprintf ppf "Pushtrap handler=%d" lbl_handler
+  | Poptrap -> fprintf ppf "Poptrap"
+  | Prologue -> fprintf ppf "Prologue");
   fprintf ppf " %a" Printmach.regs i.arg
 
 let dump_terminator ppf ?(sep = "\n") (ti : terminator instruction) =
   let open Format in
   if ti.stack_offset > 0 then fprintf ppf "[T%d] " ti.stack_offset;
   fprintf ppf "%d: " ti.id;
-  if Array.length ti.res > 0 then
-    fprintf ppf "%a := " Printmach.regs ti.res;
+  if Array.length ti.res > 0 then fprintf ppf "%a := " Printmach.regs ti.res;
   (match ti.desc with
-   | Never -> fprintf ppf "deadend%s" sep
-   | Always l -> fprintf ppf "goto %d%s" l sep
-   | Parity_test { ifso; ifnot } ->
-      fprintf ppf "if even goto %d%sif odd goto %d%s" ifso sep ifnot sep
-   | Truth_test { ifso; ifnot } ->
-      fprintf ppf "if true goto %d%sif false goto %d%s" ifso sep ifnot sep
-   | Float_test { lt; eq; gt; uo } ->
-      fprintf ppf "if < goto %d%s" lt sep;
-      fprintf ppf "if = goto %d%s" eq sep;
-      fprintf ppf "if > goto %d%s" gt sep;
-      fprintf ppf "if uo goto %d%s" uo sep
-   | Int_test { lt; eq; gt; is_signed; imm } ->
-      let cmp =
-        Printf.sprintf " %s%s"
-          (if is_signed then "s" else "u")
-          (match imm with None -> "" | Some i -> " " ^ Int.to_string i)
-      in
-      fprintf ppf "if <%s goto %d%s" cmp lt sep;
-      fprintf ppf "if =%s goto %d%s" cmp eq sep;
-      fprintf ppf "if >%s goto %d%s" cmp gt sep
-   | Switch labels ->
-      fprintf ppf "switch%s" sep;
-      for i = 0 to Array.length labels - 1 do
-        fprintf ppf "case %d: goto %d%s" i labels.(i) sep
-      done
-   | Call_no_return { func_symbol : string; _ } ->
-      fprintf ppf "Call_no_return %s%s" func_symbol sep
-   | Return -> fprintf ppf "Return%s" sep
-   | Raise _ -> fprintf ppf "Raise%s" sep
-   | Tailcall (Self _) -> fprintf ppf "Tailcall self%s" sep
-   | Tailcall (Func _) -> fprintf ppf "Tailcall%s" sep);
-   if Array.length ti.arg > 0 then fprintf ppf " %a%s" Printmach.regs ti.arg sep
+  | Never -> fprintf ppf "deadend%s" sep
+  | Always l -> fprintf ppf "goto %d%s" l sep
+  | Parity_test { ifso; ifnot } ->
+    fprintf ppf "if even goto %d%sif odd goto %d%s" ifso sep ifnot sep
+  | Truth_test { ifso; ifnot } ->
+    fprintf ppf "if true goto %d%sif false goto %d%s" ifso sep ifnot sep
+  | Float_test { lt; eq; gt; uo } ->
+    fprintf ppf "if < goto %d%s" lt sep;
+    fprintf ppf "if = goto %d%s" eq sep;
+    fprintf ppf "if > goto %d%s" gt sep;
+    fprintf ppf "if uo goto %d%s" uo sep
+  | Int_test { lt; eq; gt; is_signed; imm } ->
+    let cmp =
+      Printf.sprintf " %s%s"
+        (if is_signed then "s" else "u")
+        (match imm with None -> "" | Some i -> " " ^ Int.to_string i)
+    in
+    fprintf ppf "if <%s goto %d%s" cmp lt sep;
+    fprintf ppf "if =%s goto %d%s" cmp eq sep;
+    fprintf ppf "if >%s goto %d%s" cmp gt sep
+  | Switch labels ->
+    fprintf ppf "switch%s" sep;
+    for i = 0 to Array.length labels - 1 do
+      fprintf ppf "case %d: goto %d%s" i labels.(i) sep
+    done
+  | Call_no_return { func_symbol : string; _ } ->
+    fprintf ppf "Call_no_return %s%s" func_symbol sep
+  | Return -> fprintf ppf "Return%s" sep
+  | Raise _ -> fprintf ppf "Raise%s" sep
+  | Tailcall (Self _) -> fprintf ppf "Tailcall self%s" sep
+  | Tailcall (Func _) -> fprintf ppf "Tailcall%s" sep);
+  if Array.length ti.arg > 0 then fprintf ppf " %a%s" Printmach.regs ti.arg sep
 
 let can_raise_terminator (i : terminator) =
   match i with

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -244,28 +244,27 @@ let dump_call ppf = function
     | Direct { func_symbol : string; _ } ->
       Format.fprintf ppf "direct %s" func_symbol)
 
-let dump_basic ppf (i : basic instruction) =
+let dump_instr ~sep ~(f : Format.formatter -> 'a -> unit) ppf (i : 'a instruction) =
   let open Format in
   if i.stack_offset > 0 then fprintf ppf "[T%d] " i.stack_offset;
   fprintf ppf "%d: " i.id;
   if Array.length i.res > 0 then fprintf ppf "%a := " Printmach.regs i.res;
-  (match i.desc with
+  f ppf i.desc;
+  if Array.length i.arg > 0 then fprintf ppf " %a%s" Printmach.regs i.arg sep
+
+let dump_basic ppf (basic : basic) =
+  let open Format in
+  match basic with
   | Op op -> dump_op ppf op
-  | Call call ->
-    fprintf ppf "Call ";
-    dump_call ppf call
+  | Call call -> fprintf ppf "Call %a" dump_call call;
   | Reloadretaddr -> fprintf ppf "Reloadretaddr"
   | Pushtrap { lbl_handler } -> fprintf ppf "Pushtrap handler=%d" lbl_handler
   | Poptrap -> fprintf ppf "Poptrap"
-  | Prologue -> fprintf ppf "Prologue");
-  fprintf ppf " %a" Printmach.regs i.arg
+  | Prologue -> fprintf ppf "Prologue"
 
-let dump_terminator ppf ?(sep = "\n") (ti : terminator instruction) =
+let dump_terminator ?(sep = "\n") ppf (terminator : terminator) =
   let open Format in
-  if ti.stack_offset > 0 then fprintf ppf "[T%d] " ti.stack_offset;
-  fprintf ppf "%d: " ti.id;
-  if Array.length ti.res > 0 then fprintf ppf "%a := " Printmach.regs ti.res;
-  (match ti.desc with
+  match terminator with
   | Never -> fprintf ppf "deadend%s" sep
   | Always l -> fprintf ppf "goto %d%s" l sep
   | Parity_test { ifso; ifnot } ->
@@ -296,8 +295,13 @@ let dump_terminator ppf ?(sep = "\n") (ti : terminator instruction) =
   | Return -> fprintf ppf "Return%s" sep
   | Raise _ -> fprintf ppf "Raise%s" sep
   | Tailcall (Self _) -> fprintf ppf "Tailcall self%s" sep
-  | Tailcall (Func _) -> fprintf ppf "Tailcall%s" sep);
-  if Array.length ti.arg > 0 then fprintf ppf " %a%s" Printmach.regs ti.arg sep
+  | Tailcall (Func _) -> fprintf ppf "Tailcall%s" sep
+
+let print_basic ppf (i : basic instruction) =
+  dump_instr ~sep:"" ~f:dump_basic ppf i
+
+let print_terminator ?(sep = "\n") ppf (ti : terminator instruction) =
+  dump_instr ~sep ~f:(dump_terminator ~sep) ppf ti
 
 let can_raise_terminator (i : terminator) =
   match i with
@@ -391,11 +395,6 @@ let is_pure_basic : basic -> bool = function
   | Pushtrap _ -> true
   | Poptrap -> true
   | Prologue -> true
-
-let print_basic ppf i = Format.fprintf ppf "%a" dump_basic i
-
-let print_terminator ?sep ppf ti =
-  Format.fprintf ppf "%a" (dump_terminator ?sep) ti
 
 let is_noop_move instr =
   match instr.desc with

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -118,11 +118,6 @@ val register_predecessors_for_all_blocks : t -> unit
 
 (** Printing *)
 
-val dump_terminator :
-  Format.formatter -> ?sep:string -> terminator instruction -> unit
-
-val dump_basic : Format.formatter -> basic instruction -> unit
-
 val print_terminator :
   ?sep:string -> Format.formatter -> terminator instruction -> unit
 

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -579,8 +579,11 @@ let save_cfg_as_dot : Cfg_with_layout.t -> string -> unit =
     ~annotate_succ:(Printf.sprintf "%d->%d") msg
 
 let check_cfg_with_layout :
-      ?mach:Mach.fundecl -> ?linear:Linear.fundecl ->
-      Cfg_with_layout.t -> Cfg_with_layout.t -> unit =
+    ?mach:Mach.fundecl ->
+    ?linear:Linear.fundecl ->
+    Cfg_with_layout.t ->
+    Cfg_with_layout.t ->
+    unit =
  fun ?mach ?linear expected result ->
   try
     let state = State.make () in

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -575,7 +575,7 @@ let _check_layout : State.t -> Label.t list -> Label.t list -> unit =
 let save_cfg_as_dot : Cfg_with_layout.t -> string -> unit =
  fun cfg_with_layout msg ->
   Cfg_with_layout.save_as_dot cfg_with_layout ~show_instr:true
-    ~show_exn:true (* ~annotate_block:(Printf.sprintf "label:%d") *)
+    ~show_exn:true
     ~annotate_succ:(Printf.sprintf "%d->%d") msg
 
 let check_cfg_with_layout :

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -574,8 +574,8 @@ let _check_layout : State.t -> Label.t list -> Label.t list -> unit =
 
 let save_cfg_as_dot : Cfg_with_layout.t -> string -> unit =
  fun cfg_with_layout msg ->
-  Cfg_with_layout.save_as_dot cfg_with_layout ~show_instr:true ~show_exn:true
-    ~annotate_block:(Printf.sprintf "label:%d")
+  Cfg_with_layout.save_as_dot cfg_with_layout ~show_instr:true
+    ~show_exn:true (* ~annotate_block:(Printf.sprintf "label:%d") *)
     ~annotate_succ:(Printf.sprintf "%d->%d") msg
 
 let check_cfg_with_layout :

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -579,8 +579,9 @@ let save_cfg_as_dot : Cfg_with_layout.t -> string -> unit =
     ~annotate_succ:(Printf.sprintf "%d->%d") msg
 
 let check_cfg_with_layout :
-    Mach.fundecl -> Cfg_with_layout.t -> Cfg_with_layout.t -> unit =
- fun f expected result ->
+      ?mach:Mach.fundecl -> ?linear:Linear.fundecl ->
+      Cfg_with_layout.t -> Cfg_with_layout.t -> unit =
+ fun ?mach ?linear expected result ->
   try
     let state = State.make () in
     check_cfg state (Cfg_with_layout.cfg expected) (Cfg_with_layout.cfg result);
@@ -595,7 +596,8 @@ let check_cfg_with_layout :
   with Different { location; message } ->
     save_cfg_as_dot expected "expected";
     save_cfg_as_dot result "result";
-    Format.eprintf "%a\n%!" Printmach.fundecl f;
+    Option.iter (fun f -> Format.eprintf "%a\n%!" Printmach.fundecl f) mach;
+    Option.iter (fun f -> Format.eprintf "%a\n%!" Printlinear.fundecl f) linear;
     Misc.fatal_errorf "Cfg_equivalence: error in %s\n  %s: %s\n"
       (Cfg.fun_name (Cfg_with_layout.cfg expected))
       location message

--- a/backend/cfg/cfg_equivalence.mli
+++ b/backend/cfg/cfg_equivalence.mli
@@ -1,6 +1,9 @@
 val check_cfg_with_layout :
-  ?mach:Mach.fundecl -> ?linear:Linear.fundecl
-  -> Cfg_with_layout.t -> Cfg_with_layout.t -> unit
+  ?mach:Mach.fundecl ->
+  ?linear:Linear.fundecl ->
+  Cfg_with_layout.t ->
+  Cfg_with_layout.t ->
+  unit
 (* [check_cfg_with_layout f expected result] checks whether [expected] and
  * [result] are equivalent, failing (through [Misc.fatal_errorf]) if they
  *  are not.

--- a/backend/cfg/cfg_equivalence.mli
+++ b/backend/cfg/cfg_equivalence.mli
@@ -1,5 +1,6 @@
 val check_cfg_with_layout :
-  Mach.fundecl -> Cfg_with_layout.t -> Cfg_with_layout.t -> unit
+  ?mach:Mach.fundecl -> ?linear:Linear.fundecl
+  -> Cfg_with_layout.t -> Cfg_with_layout.t -> unit
 (* [check_cfg_with_layout f expected result] checks whether [expected] and
  * [result] are equivalent, failing (through [Misc.fatal_errorf]) if they
  *  are not.

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -109,8 +109,8 @@ let print_dot ?(show_instr = true) ?(show_exn = true) ?annotate_block
   let print_block_dot label (block : Cfg.basic_block) index =
     let name l = Printf.sprintf "\".L%d\"" l in
     let show_index = Option.value index ~default:(-1) in
-    Format.fprintf ppf "\n%s [shape=box label=\".L%d:I%d:S%d%s%s%s"
-      (name label) label show_index (List.length block.body)
+    Format.fprintf ppf "\n%s [shape=box label=\".L%d:I%d:S%d%s%s%s" (name label)
+      label show_index (List.length block.body)
       (if block.stack_offset > 0
       then ":T" ^ string_of_int block.stack_offset
       else "")

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -76,11 +76,9 @@ let dump ppf t ~msg =
     let block = Label.Tbl.find t.cfg.blocks label in
     fprintf ppf "\n%d:\n" label;
     List.iter
-      (fun i ->
-        Cfg.dump_basic ppf i;
-        fprintf ppf "\n")
+      (fprintf ppf "%a\n" Cfg.print_basic)
       block.body;
-    Cfg.dump_terminator ppf block.terminator;
+    Cfg.print_terminator ppf block.terminator;
     fprintf ppf "\npredecessors:";
     Label.Set.iter (fprintf ppf " %d") block.predecessors;
     fprintf ppf "\nsuccessors:";
@@ -126,11 +124,9 @@ let print_dot ?(show_instr = true) ?(show_exn = true) ?annotate_block
       Format.fprintf ppf "\\l";
       List.iter
         (fun i ->
-          Cfg.print_basic ppf i;
-          Format.fprintf ppf "\\l")
+          Format.fprintf ppf "%a\\l" Cfg.print_basic i)
         block.body;
-      Cfg.print_terminator ppf ~sep:"\\l" block.terminator;
-      Format.fprintf ppf "\\l");
+      Format.fprintf ppf "%a\\l" (Cfg.print_terminator ~sep:"\\l") block.terminator);
     Format.fprintf ppf "\"]\n";
     Label.Set.iter
       (fun l ->

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -264,7 +264,7 @@ let register_exns t label (block : C.basic_block) =
           label);
     if !C.verbose
     then
-      Printf.printf "%s: %d exn %s: " t.cfg.fun_name label
+      Printf.printf "%s: %d exn %s: \n" t.cfg.fun_name label
         (match block.exn with None -> "none" | Some l -> Int.to_string l)
 
 let check_and_register_traps t =


### PR DESCRIPTION
- When dumping CFG in dot format with -dot-detailed option, print arguments and result of each operation, and most importantly, print the stack offsets of all instructions and blocks (previously known as `trap_depth`).
- Add some newlines when dumping CFG in text formal
- When Cfg_equivalence fails, depending on whether the Cfg was constructed from Linear or from Mach, it's useful to print the source.