### PR TITLE
Fix stack_offset propagation for trap handler blocks in Cfgize

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -407,7 +407,8 @@ let is_noop_move instr =
     false
 
 let set_stack_offset (instr : _ instruction) stack_offset =
-  if stack_offset < 0 then
+  if stack_offset < 0
+  then
     Misc.fatal_errorf "Cfg.set_stack_offset: expected non-negative got %d"
       stack_offset;
   if instr.stack_offset = stack_offset

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -407,6 +407,9 @@ let is_noop_move instr =
     false
 
 let set_stack_offset (instr : _ instruction) stack_offset =
+  if stack_offset < 0 then
+    Misc.fatal_errorf "Cfg.set_stack_offset: expected non-negative got %d"
+      stack_offset;
   if instr.stack_offset = stack_offset
   then instr
   else { instr with stack_offset }

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -648,9 +648,7 @@ module Stack_offset_and_exn = struct
       if block.stack_offset = invalid_stack_offset
       then true
       else begin
-        assert (
-          block.stack_offset = compute_stack_offset ~stack_offset ~traps
-          && block.stack_offset >= Proc.trap_size_in_bytes * List.length traps);
+        assert (block.stack_offset = compute_stack_offset ~stack_offset ~traps);
         false
       end
     in

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -680,9 +680,8 @@ module Stack_offset_and_exn = struct
         assert (Option.is_none block.exn);
         match traps with
         | [] -> ()
-        | handler_label :: rest ->
+        | handler_label :: _ ->
           block.exn <- Some handler_label;
-          update_block cfg handler_label ~stack_offset ~traps:rest
       end
     end
 

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -678,8 +678,7 @@ module Stack_offset_and_exn = struct
         assert (Option.is_none block.exn);
         match traps with
         | [] -> ()
-        | handler_label :: _ ->
-          block.exn <- Some handler_label;
+        | handler_label :: _ -> block.exn <- Some handler_label
       end
     end
 


### PR DESCRIPTION
`Cfgize.Stack_offset_and_exn` should not propagate `stack_offset` along exn edges.  The `traps` value is correct, but the `stack_offset` is not because there could be `Istackoffset` between the pushtrap and the instruction that can raise, but that extra offset would be rolled back during raise, before execution flows to the trap handler block. The correct value is the one propagated to trap handler blocks from immediately prior to a pushtrap. 

This was caught by an assertion (cfgize line 651, about mismatch of an assigned stack_offset of a block and the propagated value), when encountered Istackoffset inside a try-with. In simpler situations, the values happen to be the same when propagated either way so the assert didn't trigger.

The first commit is the main change. 
