### PR TITLE
Add field fun_args to Cfg.t

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -44,6 +44,7 @@ type basic_block =
 type t =
   { blocks : basic_block Label.Tbl.t;
     fun_name : string;
+    fun_args : Reg.t array;
     fun_dbg : Debuginfo.t;
     entry_label : Label.t;
     fun_fast : bool;
@@ -52,9 +53,10 @@ type t =
     fun_num_stack_slots : int array
   }
 
-let create ~fun_name ~fun_dbg ~fun_fast ~fun_contains_calls ~fun_num_stack_slots
-    =
+let create ~fun_name ~fun_args ~fun_dbg ~fun_fast ~fun_contains_calls
+    ~fun_num_stack_slots =
   { fun_name;
+    fun_args;
     fun_dbg;
     entry_label = 1;
     blocks = Label.Tbl.create 31;

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -69,6 +69,7 @@ type basic_block =
 type t = private
   { blocks : basic_block Label.Tbl.t;  (** Map from labels to blocks *)
     fun_name : string;  (** Function name, used for printing messages *)
+    fun_args : Reg.t array;  (** Function arguments *)
     fun_dbg : Debuginfo.t;  (** Dwarf debug info for function entry. *)
     entry_label : Label.t;
         (** This label must be the first in all layouts of this cfg. *)
@@ -80,6 +81,7 @@ type t = private
 
 val create :
   fun_name:string ->
+  fun_args:Reg.t array ->
   fun_dbg:Debuginfo.t ->
   fun_fast:bool ->
   fun_contains_calls:bool ->

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -69,7 +69,10 @@ type basic_block =
 type t = private
   { blocks : basic_block Label.Tbl.t;  (** Map from labels to blocks *)
     fun_name : string;  (** Function name, used for printing messages *)
-    fun_args : Reg.t array;  (** Function arguments *)
+    fun_args : Reg.t array;
+        (** Function arguments. When Cfg is constructed from Linear, this
+            information is not needed (Linear.fundecl does not have fun_args
+            field) and [fun_args] is an empty array as a dummy value. *)
     fun_dbg : Debuginfo.t;  (** Dwarf debug info for function entry. *)
     entry_label : Label.t;
         (** This label must be the first in all layouts of this cfg. *)

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -404,7 +404,7 @@ let print_assembly (blocks : Cfg.basic_block list) =
   let layout = List.map (fun (b : Cfg.basic_block) -> b.start) blocks in
   let fun_name = "_fun_start_" in
   let cfg =
-    Cfg.create ~fun_name ~fun_dbg:Debuginfo.none ~fun_fast:false
+    Cfg.create ~fun_name ~fun_args:[||] ~fun_dbg:Debuginfo.none ~fun_fast:false
       ~fun_contains_calls:true ~fun_num_stack_slots:[||]
   in
   List.iter

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -702,7 +702,7 @@ let fundecl :
     Cfg_with_layout.t =
  fun fundecl ~preserve_orig_labels ~simplify_terminators ->
   let { Mach.fun_name;
-        fun_args = _;
+        fun_args;
         fun_body;
         fun_codegen_options;
         fun_dbg;
@@ -718,7 +718,7 @@ let fundecl :
     Proc.prologue_required ~fun_contains_calls ~fun_num_stack_slots
   in
   let cfg =
-    Cfg.create ~fun_name ~fun_dbg ~fun_fast ~fun_contains_calls
+    Cfg.create ~fun_name ~fun_args ~fun_dbg ~fun_fast ~fun_contains_calls
       ~fun_num_stack_slots
   in
   let state =

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -619,8 +619,8 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
 let run (f : Linear.fundecl) ~preserve_orig_labels =
   let t =
     let cfg =
-      Cfg.create ~fun_name:f.fun_name ~fun_dbg:f.fun_dbg ~fun_fast:f.fun_fast
-        ~fun_contains_calls:f.fun_contains_calls
+      Cfg.create ~fun_name:f.fun_name ~fun_args:[||] ~fun_dbg:f.fun_dbg
+        ~fun_fast:f.fun_fast ~fun_contains_calls:f.fun_contains_calls
         ~fun_num_stack_slots:f.fun_num_stack_slots
     in
     create cfg ~tailrec_label:f.fun_tailrec_entry_point_label


### PR DESCRIPTION
When Cfg is constructed from Mach, we can get the information from `Mach.fundecl.fun_args`.

When Cfg is constructed from Linear, this information is not available (Linear.fundecl does not have `fun_args` field, this information is not needed any more / has been compiled away) and so we assign an empty array as a dummy value for this field.   

This field is not actively used after selection, except in `Spill` and `Available_regs`. In `Liveness` it's only used to check the result. We should keep it for Cfg for these uses and for debugging.