### PR TITLE
Save Mach as Cfg after Selection

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -71,14 +71,29 @@ let linear_unit_info =
     for_pack = None;
   }
 
-let cfg_unit_info =
+let new_cfg_unit_info () =
   { Cfg_format.unit_name = "";
     items = [];
     for_pack = None;
   }
 
+let cfg_unit_info = new_cfg_unit_info ()
+
+module Map = Map.Make(Compiler_pass)
+
+let (pass_to_cfg : Cfg_format.cfg_unit_info Map.t) =
+  Map.empty
+  |> Map.add Compiler_pass.Selection (new_cfg_unit_info ())
+
 let reset () =
   start_from_emit := false;
+  Map.iter (fun pass (cfg_unit_info : Cfg_format.cfg_unit_info) ->
+    if should_save_ir_after pass then begin
+      cfg_unit_info.unit_name <- Compilenv.current_unit_name ();
+      cfg_unit_info.items <- [];
+      cfg_unit_info.for_pack <- !Clflags.for_package;
+    end)
+    pass_to_cfg;
   if should_save_before_emit () then begin
     linear_unit_info.unit_name <- Compilenv.current_unit_name ();
     linear_unit_info.items <- [];
@@ -91,6 +106,11 @@ let reset () =
   end
 
 let save_data dl =
+  Map.iter (fun pass (cfg_unit_info: Cfg_format.cfg_unit_info) ->
+    if should_save_ir_after pass && (not !start_from_emit) then begin
+      cfg_unit_info.items <- Cfg_format.(Data dl) :: cfg_unit_info.items
+    end)
+    pass_to_cfg;
   if should_save_before_emit () then begin
     linear_unit_info.items <- Linear_format.(Data dl) :: linear_unit_info.items
   end;
@@ -111,7 +131,23 @@ let save_cfg f =
   end;
   f
 
+let save_mach_as_cfg pass f =
+  if should_save_ir_after pass && (not !start_from_emit) then begin
+    let cfg =
+      Cfgize.fundecl f ~preserve_orig_labels:false ~simplify_terminators:true
+    in
+    let cfg_unit_info = Map.find pass pass_to_cfg in
+    cfg_unit_info.items <- Cfg_format.(Cfg cfg) :: cfg_unit_info.items
+  end;
+  f
+
 let write_ir prefix =
+  Map.iter (fun pass (cfg_unit_info : Cfg_format.cfg_unit_info)  ->
+    if should_save_ir_after pass && (not !start_from_emit) then begin
+      let filename = Compiler_pass.(to_output_filename pass ~prefix) in
+      cfg_unit_info.items <- List.rev cfg_unit_info.items;
+      Cfg_format.save filename cfg_unit_info end)
+    pass_to_cfg;
   if should_save_before_emit () then begin
     let filename = Compiler_pass.(to_output_filename Scheduling ~prefix) in
     linear_unit_info.items <- List.rev linear_unit_info.items;
@@ -270,6 +306,7 @@ let compile_fundecl ~ppf_dump fd_cmm =
   ++ Profile.record ~accumulate:true "selection" Selection.fundecl
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_sel
   ++ pass_dump_if ppf_dump dump_selection "After instruction selection"
+  ++ save_mach_as_cfg Compiler_pass.Selection
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_combine
   ++ pass_dump_if ppf_dump dump_combine "After allocation combining"

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -98,7 +98,7 @@ let main argv ppf ~flambda2 =
           Compenv.fatal "Please specify at most one of -pack, -a, -shared, -c, \
                          -output-obj";
       | Some ((P.Parsing | P.Typing | P.Scheduling
-              | P.Simplify_cfg | P.Emit) as p) ->
+              | P.Simplify_cfg | P.Emit | P.Selection) as p) ->
         assert (P.is_compilation_pass p);
         Printf.ksprintf Compenv.fatal
           "Options -i and -stop-after (%s) \

--- a/ocaml/driver/maindriver.ml
+++ b/ocaml/driver/maindriver.ml
@@ -63,7 +63,8 @@ let main argv ppf =
            are  incompatible with -pack, -a, -output-obj"
           (String.concat "|"
              (P.available_pass_names ~filter:(fun _ -> true) ~native:false))
-      | Some (P.Scheduling | P.Simplify_cfg | P.Emit) -> assert false (* native only *)
+      | Some (P.Scheduling | P.Simplify_cfg | P.Emit | P.Selection) ->
+        assert false (* native only *)
     end;
     if !make_archive then begin
       Compmisc.init_path ();

--- a/ocaml/driver/optmaindriver.ml
+++ b/ocaml/driver/optmaindriver.ml
@@ -76,7 +76,7 @@ let main argv ppf =
           Compenv.fatal "Please specify at most one of -pack, -a, -shared, -c, \
                          -output-obj";
       | Some ((P.Parsing | P.Typing | P.Scheduling
-              | P.Simplify_cfg | P.Emit) as p) ->
+              | P.Simplify_cfg | P.Emit | P.Selection) as p) ->
         assert (P.is_compilation_pass p);
         Printf.ksprintf Compenv.fatal
           "Options -i and -stop-after (%s) \

--- a/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.compilers.reference
+++ b/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.compilers.reference
@@ -1,1 +1,1 @@
-wrong argument 'typing'; option '-save-ir-after' expects one of: scheduling simplify_cfg.
+wrong argument 'typing'; option '-save-ir-after' expects one of: selection scheduling simplify_cfg.

--- a/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.compilers.reference
+++ b/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.compilers.reference
@@ -1,1 +1,1 @@
-wrong argument 'typing'; option '-save-ir-after' expects one of: selection scheduling simplify_cfg.
+wrong argument 'typing'; option '-save-ir-after' expects one of: scheduling simplify_cfg selection.

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -551,18 +551,18 @@ module Compiler_pass = struct
   let to_string = function
     | Parsing -> "parsing"
     | Typing -> "typing"
-    | Selection -> "selection"
     | Scheduling -> "scheduling"
     | Emit -> "emit"
     | Simplify_cfg -> "simplify_cfg"
+    | Selection -> "selection"
 
   let of_string = function
     | "parsing" -> Some Parsing
     | "typing" -> Some Typing
-    | "selection" -> Some Selection
     | "scheduling" -> Some Scheduling
     | "emit" -> Some Emit
     | "simplify_cfg" -> Some Simplify_cfg
+    | "selection" -> Some Selection
     | _ -> None
 
   let rank = function
@@ -576,10 +576,10 @@ module Compiler_pass = struct
   let passes = [
     Parsing;
     Typing;
-    Selection;
     Scheduling;
     Emit;
     Simplify_cfg;
+    Selection;
   ]
   let is_compilation_pass _ = true
   let is_native_only = function
@@ -594,7 +594,7 @@ module Compiler_pass = struct
     | Scheduling -> true
     | Simplify_cfg -> true
     | Selection -> true
-    | _ -> false
+    | Parsing | Typing | Emit -> false
 
   let available_pass_names ~filter ~native =
     passes

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -546,11 +546,12 @@ module Compiler_pass = struct
      - the manpages in man/ocaml{c,opt}.m
      - the manual manual/manual/cmds/unified-options.etex
   *)
-  type t = Parsing | Typing | Scheduling | Emit | Simplify_cfg
+  type t = Parsing | Typing | Scheduling | Emit | Simplify_cfg | Selection
 
   let to_string = function
     | Parsing -> "parsing"
     | Typing -> "typing"
+    | Selection -> "selection"
     | Scheduling -> "scheduling"
     | Emit -> "emit"
     | Simplify_cfg -> "simplify_cfg"
@@ -558,6 +559,7 @@ module Compiler_pass = struct
   let of_string = function
     | "parsing" -> Some Parsing
     | "typing" -> Some Typing
+    | "selection" -> Some Selection
     | "scheduling" -> Some Scheduling
     | "emit" -> Some Emit
     | "simplify_cfg" -> Some Simplify_cfg
@@ -566,6 +568,7 @@ module Compiler_pass = struct
   let rank = function
     | Parsing -> 0
     | Typing -> 1
+    | Selection -> 20
     | Simplify_cfg -> 49
     | Scheduling -> 50
     | Emit -> 60
@@ -573,6 +576,7 @@ module Compiler_pass = struct
   let passes = [
     Parsing;
     Typing;
+    Selection;
     Scheduling;
     Emit;
     Simplify_cfg;
@@ -582,12 +586,14 @@ module Compiler_pass = struct
     | Scheduling -> true
     | Emit -> true
     | Simplify_cfg -> true
+    | Selection -> true
     | Parsing | Typing -> false
 
   let enabled is_native t = not (is_native_only t) || is_native
   let can_save_ir_after = function
     | Scheduling -> true
     | Simplify_cfg -> true
+    | Selection -> true
     | _ -> false
 
   let available_pass_names ~filter ~native =
@@ -603,6 +609,7 @@ module Compiler_pass = struct
     match t with
     | Scheduling -> prefix ^ Compiler_ir.(extension Linear)
     | Simplify_cfg -> prefix ^ Compiler_ir.(extension Cfg)
+    | Selection -> prefix ^ Compiler_ir.(extension Cfg) ^ "-sel"
     | Emit | Parsing | Typing -> Misc.fatal_error "Not supported"
 
   let of_input_filename name =

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -254,7 +254,7 @@ module Compiler_ir : sig
 end
 
 module Compiler_pass : sig
-  type t = Parsing | Typing | Scheduling | Emit | Simplify_cfg
+  type t = Parsing | Typing | Scheduling | Emit | Simplify_cfg | Selection
   val of_string : string -> t option
   val to_string : t -> string
   val is_compilation_pass : t -> bool


### PR DESCRIPTION
- Add an option `select` to the existing compiler flag `-save-ir-after`. 
- If flag "-save-ir-after select" is provided, call `cfgize` after `Selection` to convert Mach to Cfg and then save it to a file.  

There is no file format to save Mach to a file (as an IR, not in textual form like we get from -dsel).  This is useful for debugging (cfg can be printed to .dot format that is easy to follow) and other tools that operate on CFGs can use it. 
