### PR TITLE
Improved handling of calls inside values for inlining reports

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -337,7 +337,7 @@ module Inlining = struct
             ~result_arity:(Code.result_arity code) ~make_inlined_body)
 end
 
-let close_c_call acc env ~let_bound_var
+let close_c_call acc env ~loc ~let_bound_var
     ({ prim_name;
        prim_arity;
        prim_alloc;
@@ -452,7 +452,8 @@ let close_c_call acc env ~let_bound_var
         Apply.create ~callee ~continuation:(Return return_continuation)
           exn_continuation ~args ~call_kind dbg ~inlined:Default_inlined
           ~inlining_state:(Inlining_state.default ~round:0)
-          ~probe_name:None ~relative_history:(Env.relative_history env)
+          ~probe_name:None
+          ~relative_history:(Env.relative_history_from_scoped ~loc env)
       in
       Expr_with_acc.create_apply acc apply
   in
@@ -567,7 +568,7 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
           IR.print_named named
       | Some exn_continuation -> exn_continuation
     in
-    close_c_call acc env ~let_bound_var prim ~args exn_continuation dbg k
+    close_c_call acc env ~loc ~let_bound_var prim ~args exn_continuation dbg k
   | Pgetglobal id, [] ->
     let is_predef_exn = Ident.is_predef id in
     if not (is_predef_exn || not (Ident.same id (Env.current_unit_id env)))
@@ -896,7 +897,8 @@ let close_exact_or_unknown_apply acc env
       (Debuginfo.from_location loc)
       ~inlined:inlined_call
       ~inlining_state:(Inlining_state.default ~round:0)
-      ~probe_name ~relative_history:(Env.relative_history env)
+      ~probe_name
+      ~relative_history:(Env.relative_history_from_scoped ~loc env)
   in
   if Flambda_features.classic_mode ()
   then
@@ -1629,7 +1631,8 @@ let wrap_over_application acc env full_call (apply : IR.apply) over_args
       Apply.create ~callee:(Simple.var returned_func) ~continuation
         apply_exn_continuation ~args ~call_kind apply_dbg ~inlined
         ~inlining_state:(Inlining_state.default ~round:0)
-        ~probe_name ~relative_history:(Env.relative_history env)
+        ~probe_name
+        ~relative_history:(Env.relative_history_from_scoped ~loc:apply.loc env)
     in
     match needs_region with
     | None -> Expr_with_acc.create_apply acc over_application

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -345,7 +345,7 @@ module Env = struct
     | Value_unknown -> t
     | approx -> add_value_approximation t alias approx
 
-  let use_path_to_root t path_to_root =
+  let set_path_to_root t path_to_root =
     if path_to_root = Debuginfo.Scoped_location.Loc_unknown
     then t
     else { t with path_to_root }
@@ -358,8 +358,9 @@ module Env = struct
   let inlining_history_tracker { inlining_history_tracker; _ } =
     inlining_history_tracker
 
-  let relative_history { inlining_history_tracker; _ } =
-    Inlining_history.Tracker.relative inlining_history_tracker
+  let relative_history_from_scoped ~loc { path_to_root; _ } =
+    Inlining_history.Relative.between_scoped_locations ~parent:path_to_root
+      ~child:loc
 end
 
 module Acc = struct

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -158,15 +158,23 @@ module Env : sig
 
   val big_endian : t -> bool
 
-  val use_path_to_root : t -> Debuginfo.Scoped_location.t -> t
+  val set_path_to_root : t -> Debuginfo.Scoped_location.t -> t
 
   val path_to_root : t -> Debuginfo.Scoped_location.t
 
+  (* The inlining tracker is used to ensure that absolute histories are shared
+     between functions defined under the same scope. *)
   val use_inlining_history_tracker : t -> Inlining_history.Tracker.t -> t
 
   val inlining_history_tracker : t -> Inlining_history.Tracker.t
 
-  val relative_history : t -> Inlining_history.Relative.t
+  (* Relative paths are build directly from scoped locations.
+
+     This is fine because when we convert a function call we know that it was
+     never inlined beforehand and thus should inherit a path corresponding to
+     its true location in the source file. *)
+  val relative_history_from_scoped :
+    loc:Debuginfo.Scoped_location.t -> t -> Inlining_history.Relative.t
 end
 
 (** Used to pipe some data through closure conversion *)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -168,7 +168,7 @@ module Env : sig
 
   val inlining_history_tracker : t -> Inlining_history.Tracker.t
 
-  (* Relative paths are build directly from scoped locations.
+  (* Relative paths are built directly from scoped locations.
 
      This is fine because when we convert a function call we know that it was
      never inlined beforehand and thus should inherit a path corresponding to

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1604,7 +1604,7 @@ and cps_function env ~fid ~stub ~(recursive : Recursive.t) ?free_idents
       ~name:(Ident.name fid)
   in
   let body acc ccenv =
-    let ccenv = CCenv.use_path_to_root ccenv loc in
+    let ccenv = CCenv.set_path_to_root ccenv loc in
     cps_tail acc new_env ccenv body body_cont body_exn_cont
   in
   Function_decl.create ~let_rec_ident:(Some fid) ~function_slot ~kind ~params

--- a/middle_end/flambda2/terms/inlining_history.mli
+++ b/middle_end/flambda2/terms/inlining_history.mli
@@ -107,6 +107,12 @@ module Relative : sig
   val compare : t -> t -> int
 
   val print : Format.formatter -> t -> unit
+
+  (* [between_scoped_location ~parent ~child] returns the relative path between
+     [Absolute.of_scoped_location parent] and [Absolute.of_scope_location
+     child] *)
+  val between_scoped_locations :
+    parent:Debuginfo.Scoped_location.t -> child:Debuginfo.Scoped_location.t -> t
 end
 
 module Tracker : sig


### PR DESCRIPTION
Take the following code sample:
```
(* File Foo.ml *)
module A = struct
  let a = f ()
end
```
Inlining reports were showing the call to `f` to happen in `Foo` while it actually happened under `Foo.A`.
The reason behind this misreporting was that the scoping information wasn't used when creating
the relative path for a call. 
This PR use the location information on the call to build the correct relative path. This is fine
because closure conversion won't inline Lambda terms directly: the inliner is only able to inline
terms that were only visited and does not even try to maintain correct debuginfo -- or histories --
 on those. 
