### PR TITLE
Use Dwarf_flags.dwarf_format in [offset_into_dwarf_section_label]

### DIFF
--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -300,7 +300,12 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
          Symbol sym (* not really a symbol, but OK. *) *)
       Misc.fatal_error "not implemented"
 
-  let offset_into_dwarf_section_label ?comment section upper =
+  let const ~width constant =
+    match width with
+    | Dwarf_flags.Thirty_two -> D.long constant
+    | Dwarf_flags.Sixty_four -> D.qword constant
+
+  let offset_into_dwarf_section_label ?comment ~width section upper =
     let upper_section = Asm_label.section upper in
     let expected_section : Asm_section.t = DWARF section in
     if not (Asm_section.equal upper_section expected_section)
@@ -329,9 +334,9 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
              (D.const_label (Asm_label.encode lower)))
       else D.const_label (Asm_label.encode upper)
     in
-    D.qword expr
+    const ~width expr
 
-  let offset_into_dwarf_section_symbol ?comment:_ _section _symbol =
+  let offset_into_dwarf_section_symbol ?comment:_ ~width:_ _section _symbol =
     (* CR poechsel: use the arguments *)
     A.emit_line "offset_into_dwarf_section_symbol"
 end

--- a/backend/asm_targets/asm_directives_intf.ml
+++ b/backend/asm_targets/asm_directives_intf.ml
@@ -223,12 +223,20 @@ module type S = sig
   (** Emit an offset into a DWARF section given a label identifying the place
       within such section. *)
   val offset_into_dwarf_section_label :
-    ?comment:string -> Asm_section.dwarf_section -> Asm_label.t -> unit
+    ?comment:string ->
+    width:Dwarf_flags.dwarf_format ->
+    Asm_section.dwarf_section ->
+    Asm_label.t ->
+    unit
 
   (** Emit an offset into a DWARF section given a symbol identifying the place
       within such section. The symbol may only be in a compilation unit
       different from the current one if the supplied section is [Debug_info].
       The symbol must always be in the given section. *)
   val offset_into_dwarf_section_symbol :
-    ?comment:string -> Asm_section.dwarf_section -> Asm_symbol.t -> unit
+    ?comment:string ->
+    width:Dwarf_flags.dwarf_format ->
+    Asm_section.dwarf_section ->
+    Asm_symbol.t ->
+    unit
 end

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.ml
@@ -294,6 +294,7 @@ let size { value; comment = _ } =
 
 let emit ~asm_directives { value; comment } =
   let module A = (val asm_directives : Asm_directives.S) in
+  let width_for_ref_addr_or_sec_offset = !Dwarf_flags.gdwarf_format in
   match value with
   | Flag_true -> begin
     (* See DWARF-4 specification p.148 *)
@@ -316,7 +317,8 @@ let emit ~asm_directives { value; comment } =
   | Indirect_string str ->
     (* "Indirect" strings are collected together into ".debug_str". *)
     let label = A.cache_string ?comment (DWARF Debug_str) str in
-    A.offset_into_dwarf_section_label ?comment Debug_str label;
+    A.offset_into_dwarf_section_label ?comment Debug_str label
+      ~width:width_for_ref_addr_or_sec_offset;
     if !Clflags.keep_asm_file
     then
       let str_len = String.length str in
@@ -341,24 +343,34 @@ let emit ~asm_directives { value; comment } =
     A.symbol_plus_offset sym ~offset_in_bytes
   | Offset_into_debug_line label ->
     A.offset_into_dwarf_section_label ?comment Debug_line label
+      ~width:width_for_ref_addr_or_sec_offset
   | Offset_into_debug_line_from_symbol symbol ->
     A.offset_into_dwarf_section_symbol ?comment Debug_line symbol
+      ~width:width_for_ref_addr_or_sec_offset
   | Offset_into_debug_info lbl ->
     A.offset_into_dwarf_section_label ?comment Debug_info lbl
+      ~width:width_for_ref_addr_or_sec_offset
   | Offset_into_debug_info_from_symbol sym ->
     A.offset_into_dwarf_section_symbol ?comment Debug_info sym
+      ~width:width_for_ref_addr_or_sec_offset
   | Offset_into_debug_addr label ->
     A.offset_into_dwarf_section_label ?comment Debug_addr label
+      ~width:width_for_ref_addr_or_sec_offset
   | Offset_into_debug_loc label ->
     A.offset_into_dwarf_section_label ?comment Debug_loc label
+      ~width:width_for_ref_addr_or_sec_offset
   | Offset_into_debug_ranges label ->
     A.offset_into_dwarf_section_label ?comment Debug_ranges label
+      ~width:width_for_ref_addr_or_sec_offset
   | Offset_into_debug_loclists label ->
     A.offset_into_dwarf_section_label ?comment Debug_loclists label
+      ~width:width_for_ref_addr_or_sec_offset
   | Offset_into_debug_rnglists label ->
     A.offset_into_dwarf_section_label ?comment Debug_rnglists label
+      ~width:width_for_ref_addr_or_sec_offset
   | Offset_into_debug_abbrev label ->
     A.offset_into_dwarf_section_label ?comment Debug_abbrev label
+      ~width:width_for_ref_addr_or_sec_offset
   | Distance_between_labels_16_bit { upper; lower } ->
     (* We rely on the assembler for overflow checking here and in the 32-bit
        case below. *)


### PR DESCRIPTION
[offset_into_dwarf_section_label] should generate a 32-bit value instead of a 64-bit value when generating 32-bit dwarf.