### PR TITLE
Only generate dwarf entries if the line & column looks legitimate

### DIFF
--- a/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.ml
@@ -112,6 +112,10 @@ let create_external ~is_visible_externally =
     let spec = AS.create External Flag in
     AV.create spec (V.bool ~comment:"not visible externally" false)
 
+let create_artificial () =
+  let spec = AS.create Artificial Flag_present in
+  AV.create spec (V.flag_true ~comment:"artificial" ())
+
 let create_decl_file file =
   let spec = AS.create Decl_file Udata in
   let file = Uint64.of_nonnegative_int_exn file in

--- a/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.mli
@@ -55,6 +55,8 @@ val create_stmt_list :
 val create_external :
   is_visible_externally:bool -> Dwarf_attribute_values.Attribute_value.t
 
+val create_artificial : unit -> Dwarf_attribute_values.Attribute_value.t
+
 val create_decl_file : int -> Dwarf_attribute_values.Attribute_value.t
 
 val create_decl_line : int -> Dwarf_attribute_values.Attribute_value.t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -45,21 +45,23 @@ let for_fundecl ~get_file_id state fundecl =
       let file, line, startchar = Location.get_pos_info loc.loc_start in
       get_file_id file, line, startchar
   in
-  let concrete_instance_proto_die =
-    Proto_die.create ~parent:(Some parent) ~tag:Subprogram
-      ~attribute_values:
-        [ DAH.create_name fun_name;
-          DAH.create_linkage_name ~linkage_name;
-          DAH.create_low_pc_from_symbol start_sym;
-          DAH.create_high_pc_from_symbol ~low_pc:start_sym end_sym;
-          DAH.create_entry_pc_from_symbol start_sym;
-          DAH.create_decl_file file_num;
-          DAH.create_decl_line line;
-          DAH.create_decl_column startchar;
-          DAH.create_stmt_list
-            ~debug_line_label:
-              (Asm_label.for_dwarf_section Asm_section.Debug_line) ]
-      ()
-  in
-  let name = Printf.sprintf "__concrete_instance_%s" fun_name in
-  Proto_die.set_name concrete_instance_proto_die (Asm_symbol.create name)
+  if line >= 0 && startchar >= 0 then begin
+    let concrete_instance_proto_die =
+      Proto_die.create ~parent:(Some parent) ~tag:Subprogram
+        ~attribute_values:
+          [ DAH.create_name fun_name;
+            DAH.create_linkage_name ~linkage_name;
+            DAH.create_low_pc_from_symbol start_sym;
+            DAH.create_high_pc_from_symbol ~low_pc:start_sym end_sym;
+            DAH.create_entry_pc_from_symbol start_sym;
+            DAH.create_decl_file file_num;
+            DAH.create_decl_line line;
+            DAH.create_decl_column startchar;
+            DAH.create_stmt_list
+              ~debug_line_label:
+                (Asm_label.for_dwarf_section Asm_section.Debug_line) ]
+        ()
+    in
+    let name = Printf.sprintf "__concrete_instance_%s" fun_name in
+    Proto_die.set_name concrete_instance_proto_die (Asm_symbol.create name)
+  end

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -44,14 +44,11 @@ let for_fundecl ~get_file_id state fundecl =
     else
       let file, line, startchar = Location.get_pos_info loc.loc_start in
       let attributes = [DAH.create_decl_file (get_file_id file)] in
-      let attributes =
-        if line > 0 then
-          (DAH.create_decl_line line) :: attributes
-        else attributes
-      in
-      if startchar > 0 then
-        (DAH.create_decl_column startchar) :: attributes
-      else attributes
+      if line < 0 then attributes
+      else if startchar < 0 then (DAH.create_decl_line line) :: attributes
+      else (* Both line and startchar are >= 0*)
+        (DAH.create_decl_line line) :: (DAH.create_decl_column startchar)
+        :: attributes
   in
   let attribute_values =
     location_attributes @


### PR DESCRIPTION
Compilation was failing for catala and beluga:
```
>> Fatal error: Uint64.of_nonnegative_int_exn: -1 is out of range
Fatal error: exception Misc.Fatal_error
Raised at Misc.fatal_errorf.(fun) in file "ocaml/utils/misc.ml", line 22, characters 14-31
Called from Dwarf_high__Dwarf_attribute_helpers.create_decl_column in file "backend/debug/dwarf/dwarf_high/dwarf_attribute_helpers.ml" (inlined), line 127, characters 15-51
Called from Dwarf_ocaml__Dwarf_concrete_instances.for_fundecl in file "backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml", line 58, characters 10-42
Called from Dwarf_ocaml__Dwarf.dwarf_for_fundecl in file "backend/debug/dwarf/dwarf_ocaml/dwarf.ml" (inlined), line 48, characters 2-85
Called from Asmgen.emit_fundecl.(fun) in file "backend/asmgen.ml", line 149, characters 10-47
```

It's likely that these packages are relying on a ppx that emits a location for which `Locatin.is_none` returns `false` but whose column is negative.