### PR TITLE
Fixes for macOS DWARF

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -441,7 +441,6 @@ let emit_begin_assembly_with_dwarf  ~emit_begin_assembly ~sourcefile () =
   in
   let can_emit = !Clflags.debug && not(!Dwarf_flags.restrict_to_upstream_dwarf) in
   match can_emit, Target_system.architecture (), Target_system.derived_system () with
-  | true, _, MacOS_like -> no_dwarf ()
   | true, X86_64, _ ->
     let asm_directives = build_asm_directives () in
     let (module Asm_directives : Asm_targets.Asm_directives_intf.S) = asm_directives in


### PR DESCRIPTION
This allows the recently-added support to work on macOS.  You need to run `dsymutil` (the DWARF linker) on an executable after linking but before debugging.  That process needs the `.o` files and may produce a warning about the object file for the startup file being missing; this is harmless (at least for now).

Testing:
![Screenshot 2022-04-29 at 16 06 40](https://user-images.githubusercontent.com/1315488/165972205-d7a71967-3546-443c-8e56-ea6b0cbc482f.png)

