### PR TITLE
Cleaned handling of links between nodes in inlining reports.

### DIFF
--- a/middle_end/flambda2/simplify_shared/inlining_report.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_report.ml
@@ -476,8 +476,8 @@ module Inlining_tree = struct
         end
         | Some (Scope _ | Fundecl _) ->
           Misc.fatal_errorf
-            "A key of type call or fundeclhould be associated with an item of \
-             type Call")
+            "A key of type call or fundecl should be associated with an item \
+             of type Call")
       t
 
   let insert_or_update_fundecl ?decision_with_context ~dbg ~name
@@ -613,8 +613,9 @@ module Inlining_tree = struct
           (Compilation_unit.string_for_printing defined_in)
     in
     Format.fprintf ppf
-      "@[<v>The decision to inline this call was taken in %a at %a.@]" cu ()
-      IHA.print to_
+      "@[<hov>The@ decision@ to@ inline@ this@ call@ was@ taken@ in@ %a@ at@ \
+       %a.@]"
+      cu () IHA.print to_
 
   let rec print ~compilation_unit ~depth ~path ppf t =
     Map.iter

--- a/middle_end/flambda2/simplify_shared/inlining_report.mli
+++ b/middle_end/flambda2/simplify_shared/inlining_report.mli
@@ -80,11 +80,18 @@ module Inlining_tree : sig
 
   module Map : Map.S with type key = Key.t
 
+  type decision_or_reference =
+    | Decision of Decision_with_context.t
+    | Reference of Inlining_history.Absolute.t
+
   type item =
-    | Construct of
+    | Call of
+        { decision : decision_or_reference;
+          tree : t
+        }
+    | Fundecl of
         { decisions : decisions;
-          tree : t;
-          uid : Uid.t
+          body : t
         }
     | Scope of t
 

--- a/middle_end/flambda2/terms/inlining_history.mli
+++ b/middle_end/flambda2/terms/inlining_history.mli
@@ -53,7 +53,7 @@
 module Absolute : sig
   type t
 
-  and path = private
+  and path =
     | Empty
     | Unknown of { prev : path }
     | Function of


### PR DESCRIPTION
An inlining decision on the call to [foo] is implicitly associated with the actual
definition of the function [foo] called ([foo] could have been created while 
inlining another call and we need to be aware of that).

In inlining reports such decisions are represented in the org file using a system
of internal links & uid of inlining paths.

These uids were stored inside the inlining tree -- that was done to "simplify" the 
code a bit, which I believe was a mistake.

Uids are now computed when needed and the types of elements stored
in the tree are now:
```
type decision_or_reference =
    | Decision of Decision_with_context.t
    | Reference of Inlining_history.Absolute.t

type item =
    | Call of
        { decision : decision_or_reference;
          tree : t
        }
    | Fundecl of
        { decisions : decisions;
          body : t
        }
    | Scope of t
```
Instead of simply:
```
type item =
    | Construct of
        { decisions : decisions;
          tree : t;
          uid : Uid.t
        }
    | Scope of t
```
