### PR TITLE
Provers: split functions between prove_* and check_* versions

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -169,9 +169,9 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
 
 let get_rec_info dacc ~function_type =
   let rec_info = FT.rec_info function_type in
-  match Flambda2_types.check_rec_info (DA.typing_env dacc) rec_info with
+  match Flambda2_types.meet_rec_info (DA.typing_env dacc) rec_info with
   | Known_result rec_info -> rec_info
-  | Unknown -> Rec_info_expr.unknown
+  | Need_meet -> Rec_info_expr.unknown
   | Invalid -> (* CR vlaviron: ? *) Rec_info_expr.do_not_inline
 
 let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -169,10 +169,10 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
 
 let get_rec_info dacc ~function_type =
   let rec_info = FT.rec_info function_type in
-  match Flambda2_types.prove_rec_info (DA.typing_env dacc) rec_info with
-  | Proved rec_info -> rec_info
+  match Flambda2_types.check_rec_info (DA.typing_env dacc) rec_info with
+  | Known_result rec_info -> rec_info
   | Unknown -> Rec_info_expr.unknown
-  | Invalid -> Rec_info_expr.do_not_inline
+  | Invalid -> (* CR vlaviron: ? *) Rec_info_expr.do_not_inline
 
 let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
     Call_site_inlining_decision_type.t =

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -101,10 +101,10 @@ let inline dacc ~apply ~unroll_to function_decl =
         Code_metadata.print code_metadata
   in
   let rec_info =
-    match T.prove_rec_info (DE.typing_env denv) (FT.rec_info function_decl) with
-    | Proved rec_info -> rec_info
+    match T.check_rec_info (DE.typing_env denv) (FT.rec_info function_decl) with
+    | Known_result rec_info -> rec_info
     | Unknown -> Rec_info_expr.unknown
-    | Invalid -> Rec_info_expr.do_not_inline
+    | Invalid -> (* CR vlaviron: ? *) Rec_info_expr.do_not_inline
   in
   let denv = DE.enter_inlined_apply ~called_code:code ~apply denv in
   let params_and_body = Code.params_and_body code in

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -101,9 +101,9 @@ let inline dacc ~apply ~unroll_to function_decl =
         Code_metadata.print code_metadata
   in
   let rec_info =
-    match T.check_rec_info (DE.typing_env denv) (FT.rec_info function_decl) with
+    match T.meet_rec_info (DE.typing_env denv) (FT.rec_info function_decl) with
     | Known_result rec_info -> rec_info
-    | Unknown -> Rec_info_expr.unknown
+    | Need_meet -> Rec_info_expr.unknown
     | Invalid -> (* CR vlaviron: ? *) Rec_info_expr.do_not_inline
   in
   let denv = DE.enter_inlined_apply ~called_code:code ~apply denv in

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -292,14 +292,14 @@ let apply_projection t proj =
     let proof =
       match Symbol_projection.projection proj with
       | Block_load { index } ->
-        T.prove_block_field_simple typing_env ~min_name_mode:Name_mode.normal ty
+        T.check_block_field_simple typing_env ~min_name_mode:Name_mode.normal ty
           (Targetint_31_63.int index)
       | Project_value_slot { project_from = _; value_slot } ->
-        T.prove_project_value_slot_simple typing_env
+        T.check_project_value_slot_simple typing_env
           ~min_name_mode:Name_mode.normal ty value_slot
     in
     match proof with
-    | Proved simple -> Some simple
+    | Known_result simple -> Some simple
     | Unknown ->
       (* [Simplify_named], which calls this function, requires [Some] to be
          returned iff the projection is from a symbol defined in the same

--- a/middle_end/flambda2/simplify/number_adjuncts.ml
+++ b/middle_end/flambda2/simplify/number_adjuncts.ml
@@ -71,7 +71,7 @@ module type Number_kind_common = sig
   val unboxed_prover :
     Flambda2_types.Typing_env.t ->
     Flambda2_types.t ->
-    Num.Set.t Flambda2_types.proof_of_operation
+    Num.Set.t Flambda2_types.meet_shortcut
 
   val this_unboxed : Num.t -> Flambda2_types.t
 
@@ -122,7 +122,7 @@ module type Boxable = sig
   val boxed_prover :
     Flambda2_types.Typing_env.t ->
     Flambda2_types.t ->
-    Num.Set.t Flambda2_types.proof_of_operation
+    Num.Set.t Flambda2_types.meet_shortcut
 
   val this_boxed : Num.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
@@ -218,7 +218,7 @@ module For_tagged_immediates : Int_number_kind = struct
 
   let standard_int_kind : K.Standard_int.t = Tagged_immediate
 
-  let unboxed_prover = T.check_equals_tagged_immediates
+  let unboxed_prover = T.meet_equals_tagged_immediates
 
   let this_unboxed = T.this_tagged_immediate
 
@@ -291,7 +291,7 @@ module For_naked_immediates : Int_number_kind = struct
 
   let standard_int_kind : K.Standard_int.t = Naked_immediate
 
-  let unboxed_prover = T.check_naked_immediates
+  let unboxed_prover = T.meet_naked_immediates
 
   let this_unboxed = T.this_naked_immediate
 
@@ -337,13 +337,13 @@ module For_floats : Boxable_number_kind = struct
 
   let boxable_number_kind = K.Boxable_number.Naked_float
 
-  let unboxed_prover = T.check_naked_floats
+  let unboxed_prover = T.meet_naked_floats
 
   let this_unboxed = T.this_naked_float
 
   let these_unboxed = T.these_naked_floats
 
-  let boxed_prover = T.check_boxed_floats
+  let boxed_prover = T.meet_boxed_floats
 
   let this_boxed = T.this_boxed_float
 
@@ -406,13 +406,13 @@ module For_int32s : Boxable_int_number_kind = struct
 
   let boxable_number_kind = K.Boxable_number.Naked_int32
 
-  let unboxed_prover = T.check_naked_int32s
+  let unboxed_prover = T.meet_naked_int32s
 
   let this_unboxed = T.this_naked_int32
 
   let these_unboxed = T.these_naked_int32s
 
-  let boxed_prover = T.check_boxed_int32s
+  let boxed_prover = T.meet_boxed_int32s
 
   let this_boxed = T.this_boxed_int32
 
@@ -475,13 +475,13 @@ module For_int64s : Boxable_int_number_kind = struct
 
   let boxable_number_kind = K.Boxable_number.Naked_int64
 
-  let unboxed_prover = T.check_naked_int64s
+  let unboxed_prover = T.meet_naked_int64s
 
   let this_unboxed = T.this_naked_int64
 
   let these_unboxed = T.these_naked_int64s
 
-  let boxed_prover = T.check_boxed_int64s
+  let boxed_prover = T.meet_boxed_int64s
 
   let this_boxed = T.this_boxed_int64
 
@@ -540,13 +540,13 @@ module For_nativeints : Boxable_int_number_kind = struct
 
   let boxable_number_kind = K.Boxable_number.Naked_nativeint
 
-  let unboxed_prover = T.check_naked_nativeints
+  let unboxed_prover = T.meet_naked_nativeints
 
   let this_unboxed = T.this_naked_nativeint
 
   let these_unboxed = T.these_naked_nativeints
 
-  let boxed_prover = T.check_boxed_nativeints
+  let boxed_prover = T.meet_boxed_nativeints
 
   let this_boxed = T.this_boxed_nativeint
 

--- a/middle_end/flambda2/simplify/number_adjuncts.ml
+++ b/middle_end/flambda2/simplify/number_adjuncts.ml
@@ -71,7 +71,7 @@ module type Number_kind_common = sig
   val unboxed_prover :
     Flambda2_types.Typing_env.t ->
     Flambda2_types.t ->
-    Num.Set.t Flambda2_types.proof
+    Num.Set.t Flambda2_types.proof_of_operation
 
   val this_unboxed : Num.t -> Flambda2_types.t
 
@@ -122,7 +122,7 @@ module type Boxable = sig
   val boxed_prover :
     Flambda2_types.Typing_env.t ->
     Flambda2_types.t ->
-    Num.Set.t Flambda2_types.proof
+    Num.Set.t Flambda2_types.proof_of_operation
 
   val this_boxed : Num.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
@@ -218,7 +218,7 @@ module For_tagged_immediates : Int_number_kind = struct
 
   let standard_int_kind : K.Standard_int.t = Tagged_immediate
 
-  let unboxed_prover = T.prove_equals_tagged_immediates
+  let unboxed_prover = T.check_equals_tagged_immediates
 
   let this_unboxed = T.this_tagged_immediate
 
@@ -291,7 +291,7 @@ module For_naked_immediates : Int_number_kind = struct
 
   let standard_int_kind : K.Standard_int.t = Naked_immediate
 
-  let unboxed_prover = T.prove_naked_immediates
+  let unboxed_prover = T.check_naked_immediates
 
   let this_unboxed = T.this_naked_immediate
 
@@ -337,13 +337,13 @@ module For_floats : Boxable_number_kind = struct
 
   let boxable_number_kind = K.Boxable_number.Naked_float
 
-  let unboxed_prover = T.prove_naked_floats
+  let unboxed_prover = T.check_naked_floats
 
   let this_unboxed = T.this_naked_float
 
   let these_unboxed = T.these_naked_floats
 
-  let boxed_prover = T.prove_boxed_floats
+  let boxed_prover = T.check_boxed_floats
 
   let this_boxed = T.this_boxed_float
 
@@ -406,13 +406,13 @@ module For_int32s : Boxable_int_number_kind = struct
 
   let boxable_number_kind = K.Boxable_number.Naked_int32
 
-  let unboxed_prover = T.prove_naked_int32s
+  let unboxed_prover = T.check_naked_int32s
 
   let this_unboxed = T.this_naked_int32
 
   let these_unboxed = T.these_naked_int32s
 
-  let boxed_prover = T.prove_boxed_int32s
+  let boxed_prover = T.check_boxed_int32s
 
   let this_boxed = T.this_boxed_int32
 
@@ -475,13 +475,13 @@ module For_int64s : Boxable_int_number_kind = struct
 
   let boxable_number_kind = K.Boxable_number.Naked_int64
 
-  let unboxed_prover = T.prove_naked_int64s
+  let unboxed_prover = T.check_naked_int64s
 
   let this_unboxed = T.this_naked_int64
 
   let these_unboxed = T.these_naked_int64s
 
-  let boxed_prover = T.prove_boxed_int64s
+  let boxed_prover = T.check_boxed_int64s
 
   let this_boxed = T.this_boxed_int64
 
@@ -540,13 +540,13 @@ module For_nativeints : Boxable_int_number_kind = struct
 
   let boxable_number_kind = K.Boxable_number.Naked_nativeint
 
-  let unboxed_prover = T.prove_naked_nativeints
+  let unboxed_prover = T.check_naked_nativeints
 
   let this_unboxed = T.this_naked_nativeint
 
   let these_unboxed = T.these_naked_nativeints
 
-  let boxed_prover = T.prove_boxed_nativeints
+  let boxed_prover = T.check_boxed_nativeints
 
   let this_boxed = T.this_boxed_nativeint
 

--- a/middle_end/flambda2/simplify/number_adjuncts.ml
+++ b/middle_end/flambda2/simplify/number_adjuncts.ml
@@ -119,11 +119,6 @@ module type Boxable = sig
 
   val boxable_number_kind : K.Boxable_number.t
 
-  val boxed_prover :
-    Flambda2_types.Typing_env.t ->
-    Flambda2_types.t ->
-    Num.Set.t Flambda2_types.meet_shortcut
-
   val this_boxed : Num.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
   val these_boxed : Num.Set.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
@@ -343,8 +338,6 @@ module For_floats : Boxable_number_kind = struct
 
   let these_unboxed = T.these_naked_floats
 
-  let boxed_prover = T.meet_boxed_floats
-
   let this_boxed = T.this_boxed_float
 
   let these_boxed = T.these_boxed_floats
@@ -411,8 +404,6 @@ module For_int32s : Boxable_int_number_kind = struct
   let this_unboxed = T.this_naked_int32
 
   let these_unboxed = T.these_naked_int32s
-
-  let boxed_prover = T.meet_boxed_int32s
 
   let this_boxed = T.this_boxed_int32
 
@@ -481,8 +472,6 @@ module For_int64s : Boxable_int_number_kind = struct
 
   let these_unboxed = T.these_naked_int64s
 
-  let boxed_prover = T.meet_boxed_int64s
-
   let this_boxed = T.this_boxed_int64
 
   let these_boxed = T.these_boxed_int64s
@@ -545,8 +534,6 @@ module For_nativeints : Boxable_int_number_kind = struct
   let this_unboxed = T.this_naked_nativeint
 
   let these_unboxed = T.these_naked_nativeints
-
-  let boxed_prover = T.meet_boxed_nativeints
 
   let this_boxed = T.this_boxed_nativeint
 

--- a/middle_end/flambda2/simplify/number_adjuncts.mli
+++ b/middle_end/flambda2/simplify/number_adjuncts.mli
@@ -118,11 +118,6 @@ module type Boxable = sig
 
   val boxable_number_kind : Flambda_kind.Boxable_number.t
 
-  val boxed_prover :
-    Flambda2_types.Typing_env.t ->
-    Flambda2_types.t ->
-    Num.Set.t Flambda2_types.meet_shortcut
-
   val this_boxed : Num.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 
   val these_boxed : Num.Set.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t

--- a/middle_end/flambda2/simplify/number_adjuncts.mli
+++ b/middle_end/flambda2/simplify/number_adjuncts.mli
@@ -68,7 +68,7 @@ module type Number_kind_common = sig
   val unboxed_prover :
     Flambda2_types.Typing_env.t ->
     Flambda2_types.t ->
-    Num.Set.t Flambda2_types.proof
+    Num.Set.t Flambda2_types.proof_of_operation
 
   val this_unboxed : Num.t -> Flambda2_types.t
 
@@ -121,7 +121,7 @@ module type Boxable = sig
   val boxed_prover :
     Flambda2_types.Typing_env.t ->
     Flambda2_types.t ->
-    Num.Set.t Flambda2_types.proof
+    Num.Set.t Flambda2_types.proof_of_operation
 
   val this_boxed : Num.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 

--- a/middle_end/flambda2/simplify/number_adjuncts.mli
+++ b/middle_end/flambda2/simplify/number_adjuncts.mli
@@ -68,7 +68,7 @@ module type Number_kind_common = sig
   val unboxed_prover :
     Flambda2_types.Typing_env.t ->
     Flambda2_types.t ->
-    Num.Set.t Flambda2_types.proof_of_operation
+    Num.Set.t Flambda2_types.meet_shortcut
 
   val this_unboxed : Num.t -> Flambda2_types.t
 
@@ -121,7 +121,7 @@ module type Boxable = sig
   val boxed_prover :
     Flambda2_types.Typing_env.t ->
     Flambda2_types.t ->
-    Num.Set.t Flambda2_types.proof_of_operation
+    Num.Set.t Flambda2_types.meet_shortcut
 
   val this_boxed : Num.t -> Alloc_mode.t Or_unknown.t -> Flambda2_types.t
 

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -836,8 +836,8 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
   (* CR-someday mshinwell: Should this be using [meet_shape], like for
      primitives? *)
   let denv = DA.denv dacc in
-  match T.prove_single_closures_entry (DE.typing_env denv) callee_ty with
-  | Proved
+  match T.check_single_closures_entry (DE.typing_env denv) callee_ty with
+  | Known_result
       ( callee's_function_slot,
         closure_alloc_mode,
         _closures_entry,

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -836,7 +836,7 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
   (* CR-someday mshinwell: Should this be using [meet_shape], like for
      primitives? *)
   let denv = DA.denv dacc in
-  match T.check_single_closures_entry (DE.typing_env denv) callee_ty with
+  match T.meet_single_closures_entry (DE.typing_env denv) callee_ty with
   | Known_result
       ( callee's_function_slot,
         closure_alloc_mode,
@@ -871,7 +871,7 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
       ~recursive:(Code_metadata.recursive callee's_code_metadata)
       ~must_be_detupled ~closure_alloc_mode ~apply_alloc_mode func_decl_type
       ~down_to_up
-  | Unknown -> type_unavailable ()
+  | Need_meet -> type_unavailable ()
   | Invalid ->
     let rebuild uacc ~after_rebuild =
       let uacc = UA.notify_removed ~operation:Removed_operations.call uacc in

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -356,7 +356,7 @@ let specialise_array_kind dacc (array_kind : P.Array_kind.t) ~array_ty :
     | Proved () ->
       (* Specialise the array operation to [Immediates]. *)
       Ok P.Array_kind.Immediates
-    | Unknown | Wrong_kind -> (
+    | Unknown -> (
       (* Check for float arrays *)
       match T.meet_is_flat_float_array typing_env array_ty with
       | Known_result false | Need_meet -> Ok array_kind

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -342,25 +342,25 @@ let specialise_array_kind dacc (array_kind : P.Array_kind.t) ~array_ty :
   match array_kind with
   | Naked_floats -> (
     match
-      T.check_is_array_with_element_kind typing_env array_ty
+      T.meet_is_array_with_element_kind typing_env array_ty
         ~element_kind:K.With_subkind.naked_float
     with
-    | Known_result (Exact | Compatible) | Unknown -> Ok array_kind
+    | Known_result (Exact | Compatible) | Need_meet -> Ok array_kind
     | Known_result Incompatible | Invalid -> Bottom)
   | Immediates -> (
     match
-      T.check_is_array_with_element_kind typing_env array_ty
+      T.meet_is_array_with_element_kind typing_env array_ty
         ~element_kind:K.With_subkind.tagged_immediate
     with
-    | Known_result (Exact | Compatible) | Unknown -> Ok array_kind
+    | Known_result (Exact | Compatible) | Need_meet -> Ok array_kind
     | Known_result Incompatible | Invalid -> Bottom)
   | Values -> (
     match
-      T.check_is_array_with_element_kind typing_env array_ty
+      T.meet_is_array_with_element_kind typing_env array_ty
         ~element_kind:K.With_subkind.tagged_immediate
     with
     | Known_result Exact ->
       (* Specialise the array operation to [Immediates]. *)
       Ok P.Array_kind.Immediates
-    | Known_result Compatible | Unknown -> Ok array_kind
+    | Known_result Compatible | Need_meet -> Ok array_kind
     | Known_result Incompatible | Invalid -> Bottom)

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -341,26 +341,26 @@ let specialise_array_kind dacc (array_kind : P.Array_kind.t) ~array_ty :
   let typing_env = DA.typing_env dacc in
   match array_kind with
   | Naked_floats -> (
-    match
-      T.meet_is_array_with_element_kind typing_env array_ty
-        ~element_kind:K.With_subkind.naked_float
-    with
-    | Known_result (Exact | Compatible) | Need_meet -> Ok array_kind
-    | Known_result Incompatible | Invalid -> Bottom)
+    match T.prove_is_flat_float_array typing_env array_ty with
+    | Proved true | Unknown -> Ok array_kind
+    | Proved false -> Bottom
+    | Wrong_kind -> Ok array_kind)
   | Immediates -> (
-    match
-      T.meet_is_array_with_element_kind typing_env array_ty
-        ~element_kind:K.With_subkind.tagged_immediate
-    with
-    | Known_result (Exact | Compatible) | Need_meet -> Ok array_kind
-    | Known_result Incompatible | Invalid -> Bottom)
+    (* The only thing worth checking is for float arrays, as that would allow us
+       to remove the branch *)
+    match T.prove_is_flat_float_array typing_env array_ty with
+    | Proved false | Unknown -> Ok array_kind
+    | Proved true -> Bottom
+    | Wrong_kind -> Ok array_kind)
   | Values -> (
-    match
-      T.meet_is_array_with_element_kind typing_env array_ty
-        ~element_kind:K.With_subkind.tagged_immediate
-    with
-    | Known_result Exact ->
+    (* Try to specialise to immediates *)
+    match T.prove_is_immediates_array typing_env array_ty with
+    | Proved () ->
       (* Specialise the array operation to [Immediates]. *)
       Ok P.Array_kind.Immediates
-    | Known_result Compatible | Need_meet -> Ok array_kind
-    | Known_result Incompatible | Invalid -> Bottom)
+    | Unknown | Wrong_kind -> (
+      (* Check for float arrays *)
+      match T.prove_is_flat_float_array typing_env array_ty with
+      | Proved false | Unknown -> Ok array_kind
+      | Proved true -> Bottom
+      | Wrong_kind -> Ok array_kind))

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -341,17 +341,15 @@ let specialise_array_kind dacc (array_kind : P.Array_kind.t) ~array_ty :
   let typing_env = DA.typing_env dacc in
   match array_kind with
   | Naked_floats -> (
-    match T.prove_is_flat_float_array typing_env array_ty with
-    | Proved true | Unknown -> Ok array_kind
-    | Proved false -> Bottom
-    | Wrong_kind -> Ok array_kind)
+    match T.meet_is_flat_float_array typing_env array_ty with
+    | Known_result true | Need_meet -> Ok array_kind
+    | Known_result false | Invalid -> Bottom)
   | Immediates -> (
     (* The only thing worth checking is for float arrays, as that would allow us
        to remove the branch *)
-    match T.prove_is_flat_float_array typing_env array_ty with
-    | Proved false | Unknown -> Ok array_kind
-    | Proved true -> Bottom
-    | Wrong_kind -> Ok array_kind)
+    match T.meet_is_flat_float_array typing_env array_ty with
+    | Known_result false | Need_meet -> Ok array_kind
+    | Known_result true | Invalid -> Bottom)
   | Values -> (
     (* Try to specialise to immediates *)
     match T.prove_is_immediates_array typing_env array_ty with
@@ -360,7 +358,6 @@ let specialise_array_kind dacc (array_kind : P.Array_kind.t) ~array_ty :
       Ok P.Array_kind.Immediates
     | Unknown | Wrong_kind -> (
       (* Check for float arrays *)
-      match T.prove_is_flat_float_array typing_env array_ty with
-      | Proved false | Unknown -> Ok array_kind
-      | Proved true -> Bottom
-      | Wrong_kind -> Ok array_kind))
+      match T.meet_is_flat_float_array typing_env array_ty with
+      | Known_result false | Need_meet -> Ok array_kind
+      | Known_result true | Invalid -> Bottom))

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -342,25 +342,25 @@ let specialise_array_kind dacc (array_kind : P.Array_kind.t) ~array_ty :
   match array_kind with
   | Naked_floats -> (
     match
-      T.prove_is_array_with_element_kind typing_env array_ty
+      T.check_is_array_with_element_kind typing_env array_ty
         ~element_kind:K.With_subkind.naked_float
     with
-    | Proved (Exact | Compatible) | Unknown -> Ok array_kind
-    | Proved Incompatible | Invalid -> Bottom)
+    | Known_result (Exact | Compatible) | Unknown -> Ok array_kind
+    | Known_result Incompatible | Invalid -> Bottom)
   | Immediates -> (
     match
-      T.prove_is_array_with_element_kind typing_env array_ty
+      T.check_is_array_with_element_kind typing_env array_ty
         ~element_kind:K.With_subkind.tagged_immediate
     with
-    | Proved (Exact | Compatible) | Unknown -> Ok array_kind
-    | Proved Incompatible | Invalid -> Bottom)
+    | Known_result (Exact | Compatible) | Unknown -> Ok array_kind
+    | Known_result Incompatible | Invalid -> Bottom)
   | Values -> (
     match
-      T.prove_is_array_with_element_kind typing_env array_ty
+      T.check_is_array_with_element_kind typing_env array_ty
         ~element_kind:K.With_subkind.tagged_immediate
     with
-    | Proved Exact ->
+    | Known_result Exact ->
       (* Specialise the array operation to [Immediates]. *)
       Ok P.Array_kind.Immediates
-    | Proved Compatible | Unknown -> Ok array_kind
-    | Proved Incompatible | Invalid -> Bottom)
+    | Known_result Compatible | Unknown -> Ok array_kind
+    | Known_result Incompatible | Invalid -> Bottom)

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -111,9 +111,9 @@ let simplify_comparison ~dbg ~dacc ~cont ~tagged_prim ~float_prim
   | ( Proved (Boxed (Naked_float | Naked_int32 | Naked_int64 | Naked_nativeint)),
       Proved (Boxed _) )
   (* One or two of the arguments is not known *)
-  | (Unknown | Wrong_kind), (Unknown | Wrong_kind)
-  | (Unknown | Wrong_kind), Proved (Tagged_immediate | Boxed _)
-  | Proved (Tagged_immediate | Boxed _), (Unknown | Wrong_kind) ->
+  | Unknown, Unknown
+  | Unknown, Proved (Tagged_immediate | Boxed _)
+  | Proved (Tagged_immediate | Boxed _), Unknown ->
     Unchanged { return_types = Unknown }
 
 let simplify_caml_make_vect dacc ~len_ty ~init_value_ty : t =
@@ -133,23 +133,19 @@ let simplify_caml_make_vect dacc ~len_ty ~init_value_ty : t =
            optimisation on will always yield a flat array of naked floats. *)
         Ok (Known Flambda_kind.With_subkind.naked_float)
       | Proved false | Unknown -> Ok Unknown
-      | Wrong_kind -> Bottom
   in
-  let length : _ Or_bottom.t =
-    match T.prove_is_a_tagged_immediate typing_env len_ty with
-    | Proved () | Unknown -> Ok len_ty
-    | Wrong_kind -> Bottom
-  in
-  match element_kind, length with
-  | Bottom, Bottom | Ok _, Bottom | Bottom, Ok _ -> Invalid
-  | Ok element_kind, Ok length ->
+  match element_kind with
+  | Bottom -> Invalid
+  | Ok element_kind ->
     (* CR-someday mshinwell: We should really adjust the kind of the parameter
        of the return continuation, e.g. to go from "any value" to "float array"
        -- but that will need some more infrastructure, since the actual
        continuation definition needs to be changed on the upwards traversal.
        Also we would need to think about what would happen if there were other
        uses of the return continuation possibly with different kinds. *)
-    let type_of_returned_array = T.array_of_length ~element_kind ~length in
+    let type_of_returned_array =
+      T.array_of_length ~element_kind ~length:len_ty
+    in
     Unchanged { return_types = Known [type_of_returned_array] }
 
 let simplify_returning_extcall ~dbg ~cont ~exn_cont:_ dacc fun_name args

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -111,9 +111,9 @@ let simplify_comparison ~dbg ~dacc ~cont ~tagged_prim ~float_prim
   | ( Proved (Boxed (Naked_float | Naked_int32 | Naked_int64 | Naked_nativeint)),
       Proved (Boxed _) )
   (* One or two of the arguments is not known *)
-  | (Unknown | Invalid | Wrong_kind), (Unknown | Invalid | Wrong_kind)
-  | (Unknown | Invalid | Wrong_kind), Proved (Tagged_immediate | Boxed _)
-  | Proved (Tagged_immediate | Boxed _), (Unknown | Invalid | Wrong_kind) ->
+  | (Unknown | Wrong_kind), (Unknown | Wrong_kind)
+  | (Unknown | Wrong_kind), Proved (Tagged_immediate | Boxed _)
+  | Proved (Tagged_immediate | Boxed _), (Unknown | Wrong_kind) ->
     Unchanged { return_types = Unknown }
 
 let simplify_caml_make_vect dacc ~len_ty ~init_value_ty : t =
@@ -133,12 +133,12 @@ let simplify_caml_make_vect dacc ~len_ty ~init_value_ty : t =
            optimisation on will always yield a flat array of naked floats. *)
         Ok (Known Flambda_kind.With_subkind.naked_float)
       | Proved false | Unknown -> Ok Unknown
-      | Invalid | Wrong_kind -> Bottom
+      | Wrong_kind -> Bottom
   in
   let length : _ Or_bottom.t =
     match T.prove_is_a_tagged_immediate typing_env len_ty with
     | Proved () | Unknown -> Ok len_ty
-    | Invalid | Wrong_kind -> Bottom
+    | Wrong_kind -> Bottom
   in
   match element_kind, length with
   | Bottom, Bottom | Ok _, Bottom | Bottom, Ok _ -> Invalid

--- a/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
@@ -63,11 +63,11 @@ let rec simplify_rec_info_expr0 denv orig ~on_unknown : Rec_info_expr.t =
   | Const _ -> orig
   | Var dv -> (
     let ty = TE.find (DE.typing_env denv) (Name.var dv) (Some K.rec_info) in
-    match T.check_rec_info (DE.typing_env denv) ty with
+    match T.meet_rec_info (DE.typing_env denv) ty with
     | Known_result rec_info_expr ->
       (* All bound names are fresh, so fine to use the same environment *)
       simplify_rec_info_expr0 denv rec_info_expr ~on_unknown
-    | Unknown -> (
+    | Need_meet -> (
       match on_unknown with
       | Leave_unevaluated -> orig
       | Assume_value value -> value)

--- a/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
@@ -63,8 +63,8 @@ let rec simplify_rec_info_expr0 denv orig ~on_unknown : Rec_info_expr.t =
   | Const _ -> orig
   | Var dv -> (
     let ty = TE.find (DE.typing_env denv) (Name.var dv) (Some K.rec_info) in
-    match T.prove_rec_info (DE.typing_env denv) ty with
-    | Proved rec_info_expr ->
+    match T.check_rec_info (DE.typing_env denv) ty with
+    | Known_result rec_info_expr ->
       (* All bound names are fresh, so fine to use the same environment *)
       simplify_rec_info_expr0 denv rec_info_expr ~on_unknown
     | Unknown -> (
@@ -73,7 +73,7 @@ let rec simplify_rec_info_expr0 denv orig ~on_unknown : Rec_info_expr.t =
       | Assume_value value -> value)
     | Invalid ->
       (* Shouldn't currently be possible *)
-      Misc.fatal_errorf "Invalid result from [prove_rec_info] of %a" T.print ty)
+      Misc.fatal_errorf "Invalid result from [check_rec_info] of %a" T.print ty)
   | Succ ri -> (
     match simplify_rec_info_expr0 denv ri ~on_unknown with
     | Const { depth; unrolling } -> compute_succ ~depth ~unrolling

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -1116,7 +1116,7 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
                            (DA.typing_env dacc) var K.value
                        with
                        | Proved () -> true
-                       | Unknown | Wrong_kind -> false)
+                       | Unknown -> false)
                      | Heap -> true)
                      && (DE.is_defined_at_toplevel (DA.denv dacc) var
                         (* If [var] is known to be a symbol projection, it

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -1110,9 +1110,13 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
                   (* the closure bound vars will be replaced by symbols upon
                      lifting *)
                   || (match Set_of_closures.alloc_mode set_of_closures with
-                     | Local ->
-                       T.never_holds_locally_allocated_values
-                         (DA.typing_env dacc) var K.value
+                     | Local -> (
+                       match
+                         T.never_holds_locally_allocated_values
+                           (DA.typing_env dacc) var K.value
+                       with
+                       | Proved () -> true
+                       | Unknown | Wrong_kind -> false)
                      | Heap -> true)
                      && (DE.is_defined_at_toplevel (DA.denv dacc) var
                         (* If [var] is known to be a symbol projection, it

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -232,6 +232,7 @@ let simplify_tag_immediate dacc ~original_term ~arg:_ ~arg_ty:naked_number_ty
 let simplify_is_int_or_get_tag dacc ~original_term ~scrutinee ~scrutinee_ty:_
     ~result_var ~make_shape =
   (* CR mshinwell: Check [scrutinee_ty] (e.g. its kind)? *)
+  (* CR vlaviron: We could use prover functions to simplify but it's probably not going to help that much *)
   let dacc = DA.add_variable dacc result_var (make_shape scrutinee) in
   Simplified_named.reachable original_term ~try_reify:true, dacc
 
@@ -623,6 +624,7 @@ let simplify_is_flat_float_array dacc ~original_term ~arg:_ ~arg_ty ~result_var
     =
   assert (Flambda_features.flat_float_array ());
   match
+    (* CR: Should use prove_ function *)
     T.meet_is_array_with_element_kind (DA.typing_env dacc) arg_ty
       ~element_kind:K.With_subkind.naked_float
   with

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -174,7 +174,7 @@ let simplify_unbox_number (boxable_number_kind : K.Boxable_number.t) dacc
        certain and it is [Heap]. (As per [Flambda_primitive] we don't currently
        CSE local allocations.) *)
     match alloc_mode with
-    | Unknown | Proved Local | Wrong_kind -> dacc
+    | Unknown | Proved Local -> dacc
     | Proved Heap ->
       let boxing_prim : P.t =
         Unary
@@ -616,10 +616,6 @@ let simplify_is_boxed_float dacc ~original_term ~arg:_ ~arg_ty ~result_var =
     let ty = T.unknown K.naked_immediate in
     let dacc = DA.add_variable dacc result_var ty in
     Simplified_named.reachable original_term ~try_reify:false, dacc
-  | Wrong_kind ->
-    let ty = T.bottom K.naked_immediate in
-    let dacc = DA.add_variable dacc result_var ty in
-    Simplified_named.invalid (), dacc
 
 let simplify_is_flat_float_array dacc ~original_term ~arg:_ ~arg_ty ~result_var
     =

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -233,7 +233,14 @@ let simplify_is_int_or_get_tag dacc ~original_term ~scrutinee ~scrutinee_ty:_
     ~result_var ~make_shape =
   (* CR mshinwell: Check [scrutinee_ty] (e.g. its kind)? *)
   (* CR vlaviron: We could use prover functions to simplify but it's probably
-     not going to help that much *)
+     not going to help that much.
+
+     Example: Option.is_none is compiled to a single [Is_int] primitive
+     (followed by [Tag_immediate]), and if called on a value with statically
+     known shape then the type that will be propagated is not the most precise
+     ([Is_int x] instead of a constant). However, in practice the information
+     can be recovered both when switching on the value (through regular meet) or
+     when trying to lift a block containing the value (through reify). *)
   let dacc = DA.add_variable dacc result_var (make_shape scrutinee) in
   Simplified_named.reachable original_term ~try_reify:true, dacc
 

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -46,7 +46,7 @@ let make_optimistic_number_decision tenv param_type
   | Proved () ->
     let naked_number = Extra_param_and_args.create ~name:decider.param_name in
     Some (Unbox (Number (decider.kind, naked_number)))
-  | Wrong_kind | Invalid | Unknown -> None
+  | Wrong_kind | Unknown -> None
 
 let decide tenv param_type deciders : U.decision option =
   List.find_map (make_optimistic_number_decision tenv param_type) deciders
@@ -86,7 +86,7 @@ let rec make_optimistic_decision ~depth tenv ~param_type : U.decision =
               tag size
           in
           Unbox (Unique_tag_and_size { tag; fields })
-        | Proved _ | Wrong_kind | Invalid | Unknown -> (
+        | Proved _ | Wrong_kind | Unknown -> (
           match T.prove_variant_like tenv param_type with
           | Proved { const_ctors; non_const_ctors_with_sizes }
             when unbox_variants ->
@@ -105,8 +105,8 @@ let rec make_optimistic_decision ~depth tenv ~param_type : U.decision =
                 non_const_ctors_with_sizes
             in
             Unbox (Variant { tag; const_ctors; fields_by_tag })
-          | Proved _ | Wrong_kind | Invalid | Unknown -> (
-            match T.prove_single_closures_entry' tenv param_type with
+          | Proved _ | Wrong_kind | Unknown -> (
+            match T.prove_single_closures_entry tenv param_type with
             | Proved (function_slot, _, closures_entry, _fun_decl)
               when unbox_closures ->
               let vars_within_closure =
@@ -114,7 +114,7 @@ let rec make_optimistic_decision ~depth tenv ~param_type : U.decision =
               in
               Unbox
                 (Closure_single_entry { function_slot; vars_within_closure })
-            | Proved _ | Wrong_kind | Invalid | Unknown ->
+            | Proved _ | Wrong_kind | Unknown ->
               Do_not_unbox Incomplete_parameter_type)))
 
 and make_optimistic_fields ~add_tag_to_name ~depth tenv param_type (tag : Tag.t)

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -29,7 +29,7 @@ type unboxer =
     invalid_const : Const.t;
     unboxing_prim : Simple.t -> P.t;
     prove_simple :
-      TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.proof_of_operation
+      TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.meet_shortcut
   }
 
 module type Number_S = sig
@@ -55,7 +55,7 @@ module Immediate = struct
         Const.naked_immediate
           (Targetint_31_63.int (Targetint_31_63.Imm.of_int 0xabcd));
       unboxing_prim;
-      prove_simple = T.check_tagging_of_simple
+      prove_simple = T.meet_tagging_of_simple
     }
 end
 
@@ -72,7 +72,7 @@ module Float = struct
     { var_name = "unboxed_float";
       invalid_const = Const.naked_float Numeric_types.Float_by_bit_pattern.zero;
       unboxing_prim;
-      prove_simple = T.check_boxed_float_containing_simple
+      prove_simple = T.meet_boxed_float_containing_simple
     }
 end
 
@@ -89,7 +89,7 @@ module Int32 = struct
     { var_name = "unboxed_int32";
       invalid_const = Const.naked_int32 Int32.(div 0xabcd0l 2l);
       unboxing_prim;
-      prove_simple = T.check_boxed_int32_containing_simple
+      prove_simple = T.meet_boxed_int32_containing_simple
     }
 end
 
@@ -106,7 +106,7 @@ module Int64 = struct
     { var_name = "unboxed_int64";
       invalid_const = Const.naked_int64 Int64.(div 0xdcba0L 2L);
       unboxing_prim;
-      prove_simple = T.check_boxed_int64_containing_simple
+      prove_simple = T.meet_boxed_int64_containing_simple
     }
 end
 
@@ -123,7 +123,7 @@ module Nativeint = struct
     { var_name = "unboxed_nativeint";
       invalid_const = Const.naked_nativeint Targetint_32_64.zero;
       unboxing_prim;
-      prove_simple = T.check_boxed_nativeint_containing_simple
+      prove_simple = T.meet_boxed_nativeint_containing_simple
     }
 end
 
@@ -138,7 +138,7 @@ module Field = struct
       unboxing_prim = (fun block -> unboxing_prim bak ~block ~index);
       prove_simple =
         (fun tenv ~min_name_mode t ->
-          T.check_block_field_simple tenv ~min_name_mode t index)
+          T.meet_block_field_simple tenv ~min_name_mode t index)
     }
 end
 
@@ -154,6 +154,6 @@ module Closure_field = struct
         (fun closure -> unboxing_prim function_slot ~closure value_slot);
       prove_simple =
         (fun tenv ~min_name_mode t ->
-          T.check_project_value_slot_simple tenv ~min_name_mode t value_slot)
+          T.meet_project_value_slot_simple tenv ~min_name_mode t value_slot)
     }
 end

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -21,14 +21,15 @@ open! Simplify_import
 type number_decider =
   { param_name : string;
     kind : K.Naked_number_kind.t;
-    prove_is_a_boxed_number : TE.t -> T.t -> unit T.proof_allowing_kind_mismatch
+    prove_is_a_boxed_number : TE.t -> T.t -> unit T.proof_of_property
   }
 
 type unboxer =
   { var_name : string;
     invalid_const : Const.t;
     unboxing_prim : Simple.t -> P.t;
-    prove_simple : TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.proof
+    prove_simple :
+      TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.proof_of_operation
   }
 
 module type Number_S = sig
@@ -54,7 +55,7 @@ module Immediate = struct
         Const.naked_immediate
           (Targetint_31_63.int (Targetint_31_63.Imm.of_int 0xabcd));
       unboxing_prim;
-      prove_simple = T.prove_is_always_tagging_of_simple
+      prove_simple = T.check_tagging_of_simple
     }
 end
 
@@ -71,7 +72,7 @@ module Float = struct
     { var_name = "unboxed_float";
       invalid_const = Const.naked_float Numeric_types.Float_by_bit_pattern.zero;
       unboxing_prim;
-      prove_simple = T.prove_boxed_float_containing_simple
+      prove_simple = T.check_boxed_float_containing_simple
     }
 end
 
@@ -88,7 +89,7 @@ module Int32 = struct
     { var_name = "unboxed_int32";
       invalid_const = Const.naked_int32 Int32.(div 0xabcd0l 2l);
       unboxing_prim;
-      prove_simple = T.prove_boxed_int32_containing_simple
+      prove_simple = T.check_boxed_int32_containing_simple
     }
 end
 
@@ -105,7 +106,7 @@ module Int64 = struct
     { var_name = "unboxed_int64";
       invalid_const = Const.naked_int64 Int64.(div 0xdcba0L 2L);
       unboxing_prim;
-      prove_simple = T.prove_boxed_int64_containing_simple
+      prove_simple = T.check_boxed_int64_containing_simple
     }
 end
 
@@ -122,7 +123,7 @@ module Nativeint = struct
     { var_name = "unboxed_nativeint";
       invalid_const = Const.naked_nativeint Targetint_32_64.zero;
       unboxing_prim;
-      prove_simple = T.prove_boxed_nativeint_containing_simple
+      prove_simple = T.check_boxed_nativeint_containing_simple
     }
 end
 
@@ -137,7 +138,7 @@ module Field = struct
       unboxing_prim = (fun block -> unboxing_prim bak ~block ~index);
       prove_simple =
         (fun tenv ~min_name_mode t ->
-          T.prove_block_field_simple tenv ~min_name_mode t index)
+          T.check_block_field_simple tenv ~min_name_mode t index)
     }
 end
 
@@ -153,6 +154,6 @@ module Closure_field = struct
         (fun closure -> unboxing_prim function_slot ~closure value_slot);
       prove_simple =
         (fun tenv ~min_name_mode t ->
-          T.prove_project_value_slot_simple tenv ~min_name_mode t value_slot)
+          T.check_project_value_slot_simple tenv ~min_name_mode t value_slot)
     }
 end

--- a/middle_end/flambda2/simplify/unboxing/unboxers.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.mli
@@ -21,14 +21,15 @@ open! Simplify_import
 type number_decider =
   { param_name : string;
     kind : K.Naked_number_kind.t;
-    prove_is_a_boxed_number : TE.t -> T.t -> unit T.proof_allowing_kind_mismatch
+    prove_is_a_boxed_number : TE.t -> T.t -> unit T.proof_of_property
   }
 
 type unboxer =
   { var_name : string;
     invalid_const : Const.t;
     unboxing_prim : Simple.t -> P.t;
-    prove_simple : TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.proof
+    prove_simple :
+      TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.proof_of_operation
   }
 
 module type Number_S = sig

--- a/middle_end/flambda2/simplify/unboxing/unboxers.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.mli
@@ -29,7 +29,7 @@ type unboxer =
     invalid_const : Const.t;
     unboxing_prim : Simple.t -> P.t;
     prove_simple :
-      TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.proof_of_operation
+      TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.meet_shortcut
   }
 
 module type Number_S = sig

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -65,7 +65,7 @@ let unbox_arg (unboxer : Unboxers.unboxer) ~typing_env_at_use arg_being_unboxed
         EPA.Extra_arg.Already_in_scope (Simple.const unboxer.invalid_const)
       in
       extra_arg, Poison
-    | Unknown ->
+    | Need_meet ->
       let var = Variable.create unboxer.var_name in
       let prim = unboxer.unboxing_prim arg_at_use in
       let extra_arg = EPA.Extra_arg.New_let_binding (var, prim) in
@@ -112,11 +112,11 @@ let extra_arg_for_ctor ~typing_env_at_use = function
         (Simple.untagged_const_int (Targetint_31_63.Imm.of_int 0))
     | Some arg_type -> (
       match
-        T.check_tagging_of_simple typing_env_at_use
+        T.meet_tagging_of_simple typing_env_at_use
           ~min_name_mode:Name_mode.normal arg_type
       with
       | Known_result simple -> EPA.Extra_arg.Already_in_scope simple
-      | Unknown -> prevent_current_unboxing ()
+      | Need_meet -> prevent_current_unboxing ()
       | Invalid ->
         (* [Invalid] this means that we are in an impossible-to-reach case, and
            thus as in other cases, we only need to provide well-kinded
@@ -231,8 +231,8 @@ and compute_extra_args_for_one_decision_and_use_aux ~(pass : U.pass) rewrite_id
       match type_of_arg_being_unboxed arg_being_unboxed with
       | None -> invalid ()
       | Some arg_type -> (
-        match T.check_variant_like typing_env_at_use arg_type with
-        | Unknown -> prevent_current_unboxing ()
+        match T.meet_variant_like typing_env_at_use arg_type with
+        | Need_meet -> prevent_current_unboxing ()
         | Invalid -> invalid ()
         | Known_result { const_ctors; non_const_ctors_with_sizes } ->
           compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
@@ -23,6 +23,7 @@ type do_not_unbox_reason =
   | Max_depth_exceeded
   | Incomplete_parameter_type
   | Not_enough_information_at_use
+  | Not_of_kind_value
 
 module Extra_param_and_args = struct
   type t =
@@ -97,6 +98,7 @@ let print_do_not_unbox_reason ppf = function
   | Incomplete_parameter_type -> Format.fprintf ppf "incomplete_parameter_type"
   | Not_enough_information_at_use ->
     Format.fprintf ppf "not_enough_information_at_use"
+  | Not_of_kind_value -> Format.fprintf ppf "not_of_kind_value"
 
 let rec print_decision ppf = function
   | Do_not_unbox reason ->

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
@@ -26,6 +26,7 @@ type do_not_unbox_reason =
   | Max_depth_exceeded
   | Incomplete_parameter_type
   | Not_enough_information_at_use
+  | Not_of_kind_value
 
 module Extra_param_and_args : sig
   type t = private

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -530,9 +530,9 @@ val type_for_const : Reg_width_const.t -> t
 
 val kind_for_const : Reg_width_const.t -> Flambda_kind.t
 
-type 'a proof_of_operation = private
+type 'a meet_shortcut = private
   | Known_result of 'a
-  | Unknown
+  | Need_meet
   | Invalid
 
 type 'a proof_of_property = private
@@ -544,36 +544,33 @@ type 'a proof_of_property = private
 val prove_equals_tagged_immediates :
   Typing_env.t -> t -> Targetint_31_63.Set.t proof_of_property
 
-val check_equals_tagged_immediates :
-  Typing_env.t -> t -> Targetint_31_63.Set.t proof_of_operation
+val meet_equals_tagged_immediates :
+  Typing_env.t -> t -> Targetint_31_63.Set.t meet_shortcut
 
-val check_naked_immediates :
-  Typing_env.t -> t -> Targetint_31_63.Set.t proof_of_operation
+val meet_naked_immediates :
+  Typing_env.t -> t -> Targetint_31_63.Set.t meet_shortcut
 
-val check_equals_single_tagged_immediate :
-  Typing_env.t -> t -> Targetint_31_63.t proof_of_operation
+val meet_equals_single_tagged_immediate :
+  Typing_env.t -> t -> Targetint_31_63.t meet_shortcut
 
-val check_naked_floats :
-  Typing_env.t ->
-  t ->
-  Numeric_types.Float_by_bit_pattern.Set.t proof_of_operation
+val meet_naked_floats :
+  Typing_env.t -> t -> Numeric_types.Float_by_bit_pattern.Set.t meet_shortcut
 
-val check_naked_int32s :
-  Typing_env.t -> t -> Numeric_types.Int32.Set.t proof_of_operation
+val meet_naked_int32s :
+  Typing_env.t -> t -> Numeric_types.Int32.Set.t meet_shortcut
 
-val check_naked_int64s :
-  Typing_env.t -> t -> Numeric_types.Int64.Set.t proof_of_operation
+val meet_naked_int64s :
+  Typing_env.t -> t -> Numeric_types.Int64.Set.t meet_shortcut
 
-val check_naked_nativeints :
-  Typing_env.t -> t -> Targetint_32_64.Set.t proof_of_operation
+val meet_naked_nativeints :
+  Typing_env.t -> t -> Targetint_32_64.Set.t meet_shortcut
 
 type variant_like_proof = private
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
     non_const_ctors_with_sizes : Targetint_31_63.Imm.t Tag.Scannable.Map.t
   }
 
-val check_variant_like :
-  Typing_env.t -> t -> variant_like_proof proof_of_operation
+val meet_variant_like : Typing_env.t -> t -> variant_like_proof meet_shortcut
 
 val prove_variant_like :
   Typing_env.t -> t -> variant_like_proof proof_of_property
@@ -606,19 +603,17 @@ val prove_is_a_boxed_nativeint : Typing_env.t -> t -> unit proof_of_property
 val prove_is_or_is_not_a_boxed_float :
   Typing_env.t -> t -> bool proof_of_property
 
-val check_boxed_floats :
-  Typing_env.t ->
-  t ->
-  Numeric_types.Float_by_bit_pattern.Set.t proof_of_operation
+val meet_boxed_floats :
+  Typing_env.t -> t -> Numeric_types.Float_by_bit_pattern.Set.t meet_shortcut
 
-val check_boxed_int32s :
-  Typing_env.t -> t -> Numeric_types.Int32.Set.t proof_of_operation
+val meet_boxed_int32s :
+  Typing_env.t -> t -> Numeric_types.Int32.Set.t meet_shortcut
 
-val check_boxed_int64s :
-  Typing_env.t -> t -> Numeric_types.Int64.Set.t proof_of_operation
+val meet_boxed_int64s :
+  Typing_env.t -> t -> Numeric_types.Int64.Set.t meet_shortcut
 
-val check_boxed_nativeints :
-  Typing_env.t -> t -> Targetint_32_64.Set.t proof_of_operation
+val meet_boxed_nativeints :
+  Typing_env.t -> t -> Targetint_32_64.Set.t meet_shortcut
 
 val prove_unique_tag_and_size :
   Typing_env.t -> t -> (Tag.t * Targetint_31_63.Imm.t) proof_of_property
@@ -631,25 +626,25 @@ type array_kind_compatibility =
   | Incompatible
 
 (** This function deems non-[Array] types of kind [Value] to be [Invalid]. *)
-val check_is_array_with_element_kind :
+val meet_is_array_with_element_kind :
   Typing_env.t ->
   t ->
   element_kind:Flambda_kind.With_subkind.t ->
-  array_kind_compatibility proof_of_operation
+  array_kind_compatibility meet_shortcut
 
 (* CR mshinwell: Fix comment and/or function name *)
 
 (** Prove that the given type, of kind [Value], is a closures type describing
     exactly one set of closures. The function declaration type corresponding to
     such closure is returned together with its function slot, if it is known. *)
-val check_single_closures_entry :
+val meet_single_closures_entry :
   Typing_env.t ->
   t ->
   (Function_slot.t
   * Alloc_mode.t Or_unknown.t
   * Closures_entry.t
   * Function_type.t)
-  proof_of_operation
+  meet_shortcut
 
 val prove_single_closures_entry :
   Typing_env.t ->
@@ -660,7 +655,7 @@ val prove_single_closures_entry :
   * Function_type.t)
   proof_of_property
 
-val check_strings : Typing_env.t -> t -> String_info.Set.t proof_of_operation
+val meet_strings : Typing_env.t -> t -> String_info.Set.t meet_shortcut
 
 (** Attempt to show that the provided type describes the tagged version of a
     unique naked immediate [Simple].
@@ -675,51 +670,51 @@ val prove_tagging_of_simple :
     describe, the tagged version of a unique naked immediate [Simple]. It is
     guaranteed that if a [Simple] is returned, the type does not describe any
     other tagged immediate. *)
-val check_tagging_of_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
+val meet_tagging_of_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t meet_shortcut
 
-val check_boxed_float_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
+val meet_boxed_float_containing_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t meet_shortcut
 
-val check_boxed_int32_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
+val meet_boxed_int32_containing_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t meet_shortcut
 
-val check_boxed_int64_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
+val meet_boxed_int64_containing_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t meet_shortcut
 
-val check_boxed_nativeint_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
+val meet_boxed_nativeint_containing_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t meet_shortcut
 
-val check_block_field_simple :
+val meet_block_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   t ->
   Targetint_31_63.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_variant_field_simple :
+val meet_variant_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   t ->
   Tag.t ->
   Targetint_31_63.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_project_value_slot_simple :
+val meet_project_value_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   t ->
   Value_slot.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_project_function_slot_simple :
+val meet_project_function_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   t ->
   Function_slot.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_rec_info : Typing_env.t -> t -> Rec_info_expr.t proof_of_operation
+val meet_rec_info : Typing_env.t -> t -> Rec_info_expr.t meet_shortcut
 
 val prove_alloc_mode_of_boxed_number :
   Typing_env.t -> t -> Alloc_mode.t proof_of_property

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -538,7 +538,6 @@ type 'a meet_shortcut = private
 type 'a proof_of_property = private
   | Proved of 'a
   | Unknown
-  | Wrong_kind
 
 (* CR mshinwell: Should remove "_equals_" from these names *)
 val prove_equals_tagged_immediates :

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -608,7 +608,7 @@ val prove_unique_tag_and_size :
 
 val prove_is_int : Typing_env.t -> t -> bool proof_of_property
 
-val prove_is_flat_float_array : Typing_env.t -> t -> bool proof_of_property
+val meet_is_flat_float_array : Typing_env.t -> t -> bool meet_shortcut
 
 val prove_is_immediates_array : Typing_env.t -> t -> unit proof_of_property
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -608,17 +608,9 @@ val prove_unique_tag_and_size :
 
 val prove_is_int : Typing_env.t -> t -> bool proof_of_property
 
-type array_kind_compatibility =
-  | Exact
-  | Compatible
-  | Incompatible
+val prove_is_flat_float_array : Typing_env.t -> t -> bool proof_of_property
 
-(** This function deems non-[Array] types of kind [Value] to be [Invalid]. *)
-val meet_is_array_with_element_kind :
-  Typing_env.t ->
-  t ->
-  element_kind:Flambda_kind.With_subkind.t ->
-  array_kind_compatibility meet_shortcut
+val prove_is_immediates_array : Typing_env.t -> t -> unit proof_of_property
 
 (* CR mshinwell: Fix comment and/or function name *)
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -672,14 +672,6 @@ val meet_block_field_simple :
   Targetint_31_63.t ->
   Simple.t meet_shortcut
 
-val meet_variant_field_simple :
-  Typing_env.t ->
-  min_name_mode:Name_mode.t ->
-  t ->
-  Tag.t ->
-  Targetint_31_63.t ->
-  Simple.t meet_shortcut
-
 val meet_project_value_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -603,18 +603,6 @@ val prove_is_a_boxed_nativeint : Typing_env.t -> t -> unit proof_of_property
 val prove_is_or_is_not_a_boxed_float :
   Typing_env.t -> t -> bool proof_of_property
 
-val meet_boxed_floats :
-  Typing_env.t -> t -> Numeric_types.Float_by_bit_pattern.Set.t meet_shortcut
-
-val meet_boxed_int32s :
-  Typing_env.t -> t -> Numeric_types.Int32.Set.t meet_shortcut
-
-val meet_boxed_int64s :
-  Typing_env.t -> t -> Numeric_types.Int64.Set.t meet_shortcut
-
-val meet_boxed_nativeints :
-  Typing_env.t -> t -> Targetint_32_64.Set.t meet_shortcut
-
 val prove_unique_tag_and_size :
   Typing_env.t -> t -> (Tag.t * Targetint_31_63.Imm.t) proof_of_property
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -530,42 +530,53 @@ val type_for_const : Reg_width_const.t -> t
 
 val kind_for_const : Reg_width_const.t -> Flambda_kind.t
 
-type 'a proof = private
-  | Proved of 'a
+type 'a proof_of_operation = private
+  | Known_result of 'a
   | Unknown
   | Invalid
 
-type 'a proof_allowing_kind_mismatch = private
+type 'a proof_of_property = private
   | Proved of 'a
   | Unknown
-  | Invalid
   | Wrong_kind
 
 (* CR mshinwell: Should remove "_equals_" from these names *)
 val prove_equals_tagged_immediates :
-  Typing_env.t -> t -> Targetint_31_63.Set.t proof
+  Typing_env.t -> t -> Targetint_31_63.Set.t proof_of_property
 
-val prove_naked_immediates : Typing_env.t -> t -> Targetint_31_63.Set.t proof
+val check_equals_tagged_immediates :
+  Typing_env.t -> t -> Targetint_31_63.Set.t proof_of_operation
 
-val prove_equals_single_tagged_immediate :
-  Typing_env.t -> t -> Targetint_31_63.t proof
+val check_naked_immediates :
+  Typing_env.t -> t -> Targetint_31_63.Set.t proof_of_operation
 
-val prove_naked_floats :
-  Typing_env.t -> t -> Numeric_types.Float_by_bit_pattern.Set.t proof
+val check_equals_single_tagged_immediate :
+  Typing_env.t -> t -> Targetint_31_63.t proof_of_operation
 
-val prove_naked_int32s : Typing_env.t -> t -> Numeric_types.Int32.Set.t proof
+val check_naked_floats :
+  Typing_env.t ->
+  t ->
+  Numeric_types.Float_by_bit_pattern.Set.t proof_of_operation
 
-val prove_naked_int64s : Typing_env.t -> t -> Numeric_types.Int64.Set.t proof
+val check_naked_int32s :
+  Typing_env.t -> t -> Numeric_types.Int32.Set.t proof_of_operation
 
-val prove_naked_nativeints : Typing_env.t -> t -> Targetint_32_64.Set.t proof
+val check_naked_int64s :
+  Typing_env.t -> t -> Numeric_types.Int64.Set.t proof_of_operation
+
+val check_naked_nativeints :
+  Typing_env.t -> t -> Targetint_32_64.Set.t proof_of_operation
 
 type variant_like_proof = private
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
     non_const_ctors_with_sizes : Targetint_31_63.Imm.t Tag.Scannable.Map.t
   }
 
+val check_variant_like :
+  Typing_env.t -> t -> variant_like_proof proof_of_operation
+
 val prove_variant_like :
-  Typing_env.t -> t -> variant_like_proof proof_allowing_kind_mismatch
+  Typing_env.t -> t -> variant_like_proof proof_of_property
 
 (** If [ty] is known to represent a boxed number or a tagged integer,
     [prove_is_a_boxed_number env ty] is [Proved kind]. [kind] is the kind of the
@@ -580,44 +591,39 @@ type boxed_or_tagged_number = private
   | Tagged_immediate
 
 val prove_is_a_boxed_or_tagged_number :
-  Typing_env.t -> t -> boxed_or_tagged_number proof_allowing_kind_mismatch
+  Typing_env.t -> t -> boxed_or_tagged_number proof_of_property
 
-val prove_is_a_tagged_immediate :
-  Typing_env.t -> t -> unit proof_allowing_kind_mismatch
+val prove_is_a_tagged_immediate : Typing_env.t -> t -> unit proof_of_property
 
-val prove_is_a_boxed_float :
-  Typing_env.t -> t -> unit proof_allowing_kind_mismatch
+val prove_is_a_boxed_float : Typing_env.t -> t -> unit proof_of_property
 
-val prove_is_a_boxed_int32 :
-  Typing_env.t -> t -> unit proof_allowing_kind_mismatch
+val prove_is_a_boxed_int32 : Typing_env.t -> t -> unit proof_of_property
 
-val prove_is_a_boxed_int64 :
-  Typing_env.t -> t -> unit proof_allowing_kind_mismatch
+val prove_is_a_boxed_int64 : Typing_env.t -> t -> unit proof_of_property
 
-val prove_is_a_boxed_nativeint :
-  Typing_env.t -> t -> unit proof_allowing_kind_mismatch
+val prove_is_a_boxed_nativeint : Typing_env.t -> t -> unit proof_of_property
 
 val prove_is_or_is_not_a_boxed_float :
-  Typing_env.t -> t -> bool proof_allowing_kind_mismatch
+  Typing_env.t -> t -> bool proof_of_property
 
-val prove_boxed_floats :
-  Typing_env.t -> t -> Numeric_types.Float_by_bit_pattern.Set.t proof
-
-val prove_boxed_int32s : Typing_env.t -> t -> Numeric_types.Int32.Set.t proof
-
-val prove_boxed_int64s : Typing_env.t -> t -> Numeric_types.Int64.Set.t proof
-
-val prove_boxed_nativeints : Typing_env.t -> t -> Targetint_32_64.Set.t proof
-
-val prove_tags_and_sizes :
-  Typing_env.t -> t -> Targetint_31_63.Imm.t Tag.Map.t proof
-
-val prove_unique_tag_and_size :
+val check_boxed_floats :
   Typing_env.t ->
   t ->
-  (Tag.t * Targetint_31_63.Imm.t) proof_allowing_kind_mismatch
+  Numeric_types.Float_by_bit_pattern.Set.t proof_of_operation
 
-val prove_is_int : Typing_env.t -> t -> bool proof
+val check_boxed_int32s :
+  Typing_env.t -> t -> Numeric_types.Int32.Set.t proof_of_operation
+
+val check_boxed_int64s :
+  Typing_env.t -> t -> Numeric_types.Int64.Set.t proof_of_operation
+
+val check_boxed_nativeints :
+  Typing_env.t -> t -> Targetint_32_64.Set.t proof_of_operation
+
+val prove_unique_tag_and_size :
+  Typing_env.t -> t -> (Tag.t * Targetint_31_63.Imm.t) proof_of_property
+
+val prove_is_int : Typing_env.t -> t -> bool proof_of_property
 
 type array_kind_compatibility =
   | Exact
@@ -625,17 +631,26 @@ type array_kind_compatibility =
   | Incompatible
 
 (** This function deems non-[Array] types of kind [Value] to be [Invalid]. *)
-val prove_is_array_with_element_kind :
+val check_is_array_with_element_kind :
   Typing_env.t ->
   t ->
   element_kind:Flambda_kind.With_subkind.t ->
-  array_kind_compatibility proof
+  array_kind_compatibility proof_of_operation
 
 (* CR mshinwell: Fix comment and/or function name *)
 
 (** Prove that the given type, of kind [Value], is a closures type describing
     exactly one set of closures. The function declaration type corresponding to
     such closure is returned together with its function slot, if it is known. *)
+val check_single_closures_entry :
+  Typing_env.t ->
+  t ->
+  (Function_slot.t
+  * Alloc_mode.t Or_unknown.t
+  * Closures_entry.t
+  * Function_type.t)
+  proof_of_operation
+
 val prove_single_closures_entry :
   Typing_env.t ->
   t ->
@@ -643,18 +658,9 @@ val prove_single_closures_entry :
   * Alloc_mode.t Or_unknown.t
   * Closures_entry.t
   * Function_type.t)
-  proof
+  proof_of_property
 
-val prove_single_closures_entry' :
-  Typing_env.t ->
-  t ->
-  (Function_slot.t
-  * Alloc_mode.t Or_unknown.t
-  * Closures_entry.t
-  * Function_type.t)
-  proof_allowing_kind_mismatch
-
-val prove_strings : Typing_env.t -> t -> String_info.Set.t proof
+val check_strings : Typing_env.t -> t -> String_info.Set.t proof_of_operation
 
 (** Attempt to show that the provided type describes the tagged version of a
     unique naked immediate [Simple].
@@ -662,66 +668,61 @@ val prove_strings : Typing_env.t -> t -> String_info.Set.t proof
     This function will return [Unknown] if values of the provided type might
     sometimes, but not always, be a tagged immediate (for example if it is a
     variant type involving blocks). *)
-val prove_is_always_tagging_of_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof
+val prove_tagging_of_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_property
 
 (** Attempt to show that the provided type _can_ describe, but might not always
     describe, the tagged version of a unique naked immediate [Simple]. It is
     guaranteed that if a [Simple] is returned, the type does not describe any
     other tagged immediate. *)
-val prove_could_be_tagging_of_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof
+val check_tagging_of_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
 
-val prove_boxed_float_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof
+val check_boxed_float_containing_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
 
-val prove_boxed_int32_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof
+val check_boxed_int32_containing_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
 
-val prove_boxed_int64_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof
+val check_boxed_int64_containing_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
 
-val prove_boxed_nativeint_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof
+val check_boxed_nativeint_containing_simple :
+  Typing_env.t -> min_name_mode:Name_mode.t -> t -> Simple.t proof_of_operation
 
-val prove_block_field_simple :
+val check_block_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   t ->
   Targetint_31_63.t ->
-  Simple.t proof
+  Simple.t proof_of_operation
 
-val prove_variant_field_simple :
+val check_variant_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   t ->
   Tag.t ->
   Targetint_31_63.t ->
-  Simple.t proof
+  Simple.t proof_of_operation
 
-val prove_project_value_slot_simple :
+val check_project_value_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   t ->
   Value_slot.t ->
-  Simple.t proof
+  Simple.t proof_of_operation
 
-val prove_project_function_slot_simple :
+val check_project_function_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   t ->
   Function_slot.t ->
-  Simple.t proof
+  Simple.t proof_of_operation
 
-val prove_rec_info : Typing_env.t -> t -> Rec_info_expr.t proof
+val check_rec_info : Typing_env.t -> t -> Rec_info_expr.t proof_of_operation
 
 val prove_alloc_mode_of_boxed_number :
-  Typing_env.t -> t -> Alloc_mode.t Or_unknown.t
-
-type var_or_symbol_or_tagged_immediate = private
-  | Var of Variable.t
-  | Symbol of Symbol.t
-  | Tagged_immediate of Targetint_31_63.t
+  Typing_env.t -> t -> Alloc_mode.t proof_of_property
 
 type to_lift =
   (* private *)
@@ -729,7 +730,7 @@ type to_lift =
   | Immutable_block of
       { tag : Tag.Scannable.t;
         is_unique : bool;
-        fields : var_or_symbol_or_tagged_immediate list
+        fields : Simple.t list
       }
   | Boxed_float of Numeric_types.Float_by_bit_pattern.t
   | Boxed_int32 of Numeric_types.Int32.t
@@ -739,11 +740,6 @@ type to_lift =
 
 type reification_result = private
   | Lift of to_lift (* CR mshinwell: rename? *)
-  | Lift_set_of_closures of
-      { function_slot : Function_slot.t;
-        function_types : Function_type.t Function_slot.Map.t;
-        value_slots : Simple.t Value_slot.Map.t
-      }
   | Simple of Simple.t
   | Cannot_reify
   | Invalid
@@ -759,7 +755,7 @@ val reify :
   reification_result
 
 val never_holds_locally_allocated_values :
-  Typing_env.t -> Variable.t -> Flambda_kind.t -> bool
+  Typing_env.t -> Variable.t -> Flambda_kind.t -> unit proof_of_property
 
 val extract_symbol_approx :
   Typing_env.t ->

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -122,6 +122,7 @@ and row_like_for_closures =
   }
 
 and closures_entry =
+  (* CR: Forbid the Bottom case in function types (propagate to the whole environment *)
   { function_types : function_type Or_unknown_or_bottom.t Function_slot.Map.t;
     closure_types : function_slot_indexed_product;
     value_slot_types : value_slot_indexed_product

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -122,8 +122,9 @@ and row_like_for_closures =
   }
 
 and closures_entry =
-  (* CR: Forbid the Bottom case in function types (propagate to the whole environment *)
-  { function_types : function_type Or_unknown_or_bottom.t Function_slot.Map.t;
+  { (* CR: Forbid the Bottom case in function types (propagate to the whole
+       environment *)
+    function_types : function_type Or_unknown_or_bottom.t Function_slot.Map.t;
     closure_types : function_slot_indexed_product;
     value_slot_types : value_slot_indexed_product
   }

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -117,6 +117,7 @@ and row_like_for_closures =
   { known_closures :
       (Set_of_closures_contents.t, closures_entry) row_like_case
       Function_slot.Map.t;
+    (* CR: this field is always Bottom, we should remove it *)
     other_closures :
       (Set_of_closures_contents.t, closures_entry) row_like_case Or_bottom.t
   }
@@ -2322,24 +2323,6 @@ module Row_like_for_blocks = struct
         with
         | Unknown -> Unknown
         | Known res -> Ok res)
-
-  let get_variant_field t variant_tag field_index : _ Or_unknown_or_bottom.t =
-    let index = Targetint_31_63.to_targetint field_index in
-    let aux { index = size; maps_to; env_extension = _ } :
-        _ Or_unknown_or_bottom.t =
-      match size with
-      | Known i when i <= index -> Bottom
-      | Known _ | At_least _ -> (
-        match
-          project_int_indexed_product maps_to (Targetint_31_63.Imm.to_int index)
-        with
-        | Unknown -> Unknown
-        | Known res -> Ok res)
-    in
-    match Tag.Map.find variant_tag t.known_tags with
-    | case -> aux case
-    | exception Not_found -> (
-      match t.other_tags with Bottom -> Bottom | Ok case -> aux case)
 end
 
 module Row_like_for_closures = struct

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -396,8 +396,8 @@ module Row_like_for_blocks : sig
 
       - The nth field exists, is unique, but has Unknown type
 
-      This will return Bottom if there is no nth field
-      (the read is invalid, and will produce bottom)
+      This will return Bottom if there is no nth field (the read is invalid, and
+      will produce bottom)
 
       The handling of those cases could be improved:
 

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -390,17 +390,16 @@ module Row_like_for_blocks : sig
 
       This will return Unknown if:
 
-      - There is no nth field (the read is invalid, and will produce bottom)
-
       - The block type represents a disjunction (several possible tags)
 
       - The tag or size is not exactly known
 
       - The nth field exists, is unique, but has Unknown type
 
-      The handling of those cases could be improved:
+      This will return Bottom if there is no nth field
+      (the read is invalid, and will produce bottom)
 
-      - When there is no valid field, Bottom could be returned instead
+      The handling of those cases could be improved:
 
       - In the case of disjunctions, if all possible nth fields point to the
       same type, this type could be returned directly.
@@ -413,8 +412,8 @@ module Row_like_for_blocks : sig
       last case where we already know what the result of the meet will be. *)
   val get_field : t -> Targetint_31_63.t -> flambda_type Or_unknown_or_bottom.t
 
-  val get_variant_field :
-    t -> Tag.t -> Targetint_31_63.t -> flambda_type Or_unknown_or_bottom.t
+  (* val get_variant_field :
+   *   t -> Tag.t -> Targetint_31_63.t -> flambda_type Or_unknown_or_bottom.t *)
 
   val is_bottom : t -> bool
 

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -412,9 +412,6 @@ module Row_like_for_blocks : sig
       last case where we already know what the result of the meet will be. *)
   val get_field : t -> Targetint_31_63.t -> flambda_type Or_unknown_or_bottom.t
 
-  (* val get_variant_field :
-   *   t -> Tag.t -> Targetint_31_63.t -> flambda_type Or_unknown_or_bottom.t *)
-
   val is_bottom : t -> bool
 
   (** The [Maps_to] value which [meet] returns contains the join of all

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -448,14 +448,15 @@ let prove_unique_tag_and_size env t :
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Wrong_kind
 
-let prove_is_flat_float_array env t : bool proof_of_property =
+let meet_is_flat_float_array env t : bool meet_shortcut =
   match expand_head env t with
-  | Value (Unknown | Bottom) -> Unknown
-  | Value (Ok (Array { element_kind = Unknown; _ })) -> Unknown
+  | Value Unknown -> Need_meet
+  | Value Bottom -> Invalid
+  | Value (Ok (Array { element_kind = Unknown; _ })) -> Need_meet
   | Value (Ok (Array { element_kind = Known element_kind; _ })) -> (
     match K.With_subkind.kind element_kind with
-    | Value -> Proved false
-    | Naked_number Naked_float -> Proved true
+    | Value -> Known_result false
+    | Naked_number Naked_float -> Known_result true
     | Naked_number
         (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint)
     | Region | Rec_info ->
@@ -463,13 +464,15 @@ let prove_is_flat_float_array env t : bool proof_of_property =
         element_kind)
   | Value
       (Ok
-        ( Variant _ | Mutable_block _ | Boxed_float _ | Boxed_int32 _
-        | Boxed_int64 _ | Boxed_nativeint _ | Closures _ | String _ )) ->
-    Unknown
+        ( Boxed_float _ | Boxed_int32 _ | Boxed_int64 _ | Boxed_nativeint _
+        | Closures _ | String _ )) ->
+    Invalid
+  | Value (Ok (Variant _ | Mutable_block _)) ->
+    (* In case of untyped code using array primitives on regular blocks *)
+    Need_meet
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Wrong_kind
-(* Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t *)
+    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
 
 let prove_is_immediates_array env t : unit proof_of_property =
   match expand_head env t with

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -37,7 +37,8 @@ type 'a meet_shortcut =
 type 'a proof_of_property =
   | Proved of 'a
   | Unknown
-  | Wrong_kind (* CR: try to find real uses and remove the rest *)
+  | Wrong_kind
+(* CR: try to find real uses and remove the rest *)
 
 type 'a generic_proof =
   | Proved of 'a
@@ -45,8 +46,7 @@ type 'a generic_proof =
   | Invalid
   | Wrong_kind
 
-(* CR: Naming
-   Either Sub-module or complete name *)
+(* CR: Naming Either Sub-module or complete name *)
 let as_meet_shortcut (p : _ generic_proof) : _ meet_shortcut =
   match p with
   | Proved x -> Known_result x
@@ -218,8 +218,11 @@ let meet_equals_tagged_immediates env t : _ meet_shortcut =
     match immediates with
     | Unknown -> Need_meet
     | Known imms -> meet_naked_immediates env imms)
-  | Value (Ok (Mutable_block _ | Boxed_float _ | Boxed_int32 _| Boxed_int64 _ 
-              | Boxed_nativeint _|Closures _|String _|Array _)) -> Invalid
+  | Value
+      (Ok
+        ( Mutable_block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+        | Boxed_nativeint _ | Closures _ | String _ | Array _ )) ->
+    Invalid
   | Value Unknown -> Need_meet
   | Value Bottom
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
@@ -241,8 +244,8 @@ type _ meet_naked_number_kind =
   | Int64 : Int64.Set.t meet_naked_number_kind
   | Nativeint : Targetint_32_64.Set.t meet_naked_number_kind
 
-let[@inline] meet_naked_number (type a) (kind : a meet_naked_number_kind) env t :
-    a meet_shortcut =
+let[@inline] meet_naked_number (type a) (kind : a meet_naked_number_kind) env t
+    : a meet_shortcut =
   let head_to_proof (head : _ Or_unknown_or_bottom.t) ~is_empty :
       _ meet_shortcut =
     match head with
@@ -251,7 +254,8 @@ let[@inline] meet_naked_number (type a) (kind : a meet_naked_number_kind) env t 
     | Bottom -> Invalid
   in
   let wrong_kind () =
-    let kind_string = match kind with
+    let kind_string =
+      match kind with
       | Float -> "Naked_float"
       | Int32 -> "Naked_int32"
       | Int64 -> "Naked_int64"
@@ -331,9 +335,13 @@ let prove_variant_like_generic env t : variant_like_proof generic_proof =
           in
           Proved { const_ctors; non_const_ctors_with_sizes })))
   | Value (Ok (Mutable_block _)) -> Unknown
-  | Value (Ok (Array _)) -> Unknown (* We could return Invalid in a strict mode *)
-  | Value (Ok (Closures _| Boxed_float _|Boxed_int32 _|Boxed_int64 _|
-     Boxed_nativeint _|String _)) -> Invalid
+  | Value (Ok (Array _)) ->
+    Unknown (* We could return Invalid in a strict mode *)
+  | Value
+      (Ok
+        ( Closures _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+        | Boxed_nativeint _ | String _ )) ->
+    Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
   | Naked_immediate _ -> Wrong_kind
@@ -440,52 +448,49 @@ let prove_unique_tag_and_size env t :
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Wrong_kind
 
-type array_kind_compatibility =
-  | Exact
-  | Compatible
-  | Incompatible
-
 let prove_is_flat_float_array env t : bool proof_of_property =
   match expand_head env t with
   | Value (Unknown | Bottom) -> Unknown
   | Value (Ok (Array { element_kind = Unknown; _ })) -> Unknown
-  | Value (Ok (Array { element_kind = Known element_kind; _ })) ->
-    begin match K.With_subkind.kind element_kind with
-      | Value -> Proved false
-      | Naked_number Naked_float -> Proved true
-      | Naked_number (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint) | Region | Rec_info ->
-        Misc.fatal_errorf "Wrong element kind for array: %a" K.With_subkind.print element_kind
-    end
-  | Value (Ok (Variant _ | Mutable_block _| Boxed_float _|Boxed_int32 _|Boxed_int64 _|
-     Boxed_nativeint _|Closures _|String _)) -> Unknown
+  | Value (Ok (Array { element_kind = Known element_kind; _ })) -> (
+    match K.With_subkind.kind element_kind with
+    | Value -> Proved false
+    | Naked_number Naked_float -> Proved true
+    | Naked_number
+        (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint)
+    | Region | Rec_info ->
+      Misc.fatal_errorf "Wrong element kind for array: %a" K.With_subkind.print
+        element_kind)
+  | Value
+      (Ok
+        ( Variant _ | Mutable_block _ | Boxed_float _ | Boxed_int32 _
+        | Boxed_int64 _ | Boxed_nativeint _ | Closures _ | String _ )) ->
+    Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Wrong_kind
-    (* Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t *)
+(* Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t *)
 
-let meet_is_array_with_element_kind env t ~element_kind : _ meet_shortcut =
+let prove_is_immediates_array env t : unit proof_of_property =
   match expand_head env t with
-  | Value Unknown -> Need_meet
-  | Value Bottom -> Invalid
-  | Value (Ok (Array { element_kind = Unknown; _ })) -> Need_meet
-  | Value (Ok (Array { element_kind = Known element_kind'; _ })) ->
-    if K.With_subkind.equal element_kind' element_kind
-    then Known_result Exact
-    else if K.With_subkind.compatible element_kind ~when_used_at:element_kind'
-            || K.With_subkind.compatible element_kind'
-                 ~when_used_at:element_kind
-    then Known_result Compatible
-    else Known_result Incompatible
-  | Value (Ok (Variant _ | Mutable_block _)) ->
-    (* CR vlaviron: This case is here to avoiding breaking code such as:
-     * Array.get (Obj.magic (0, 0)) 1
-     * If we decide that this code should segfault, we could return Invalid. *)
-    Need_meet
-  | Value (Ok (Boxed_float _|Boxed_int32 _|Boxed_int64 _|
-     Boxed_nativeint _|Closures _|String _)) -> Invalid
+  | Value (Unknown | Bottom) -> Unknown
+  | Value (Ok (Array { element_kind = Unknown; _ })) -> Unknown
+  | Value (Ok (Array { element_kind = Known element_kind; _ })) -> (
+    match K.With_subkind.subkind element_kind with
+    | Tagged_immediate -> Proved ()
+    | Anything | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
+    | Block _ | Float_block _ | Float_array | Immediate_array | Value_array
+    | Generic_array ->
+      Unknown)
+  | Value
+      (Ok
+        ( Variant _ | Mutable_block _ | Boxed_float _ | Boxed_int32 _
+        | Boxed_int64 _ | Boxed_nativeint _ | Closures _ | String _ )) ->
+    Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
+    Wrong_kind
+(* Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t *)
 
 let prove_single_closures_entry_generic env t : _ generic_proof =
   match expand_head env t with

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -29,179 +29,54 @@ let is_bottom = Expand_head.is_bottom
 let expand_head env ty =
   Expand_head.expand_head env ty |> Expand_head.Expanded_type.descr_oub
 
-type 'a proof =
-  | Proved of 'a
+type 'a proof_of_operation =
+  | Known_result of 'a
   | Unknown
   | Invalid
 
-type 'a proof_allowing_kind_mismatch =
+type 'a proof_of_property =
+  | Proved of 'a
+  | Unknown
+  | Wrong_kind
+
+type 'a generic_proof =
   | Proved of 'a
   | Unknown
   | Invalid
   | Wrong_kind
 
-type var_or_symbol_or_tagged_immediate =
-  | Var of Variable.t
-  | Symbol of Symbol.t
-  | Tagged_immediate of Targetint_31_63.t
+let as_operation (p : _ generic_proof) : _ proof_of_operation =
+  match p with
+  | Proved x -> Known_result x
+  | Unknown -> Unknown
+  | Invalid | Wrong_kind -> Invalid
 
-let prove_equals_to_var_or_symbol_or_tagged_immediate env t :
-    (var_or_symbol_or_tagged_immediate * Coercion.t) proof =
+let as_property (p : _ generic_proof) : _ proof_of_property =
+  match p with
+  | Proved x -> Proved x
+  | Unknown | Invalid -> Unknown
+  | Wrong_kind -> Wrong_kind
+
+let prove_equals_to_simple_of_kind_value env t : Simple.t proof_of_property =
   let original_kind = TG.kind t in
   if not (K.equal original_kind K.value)
-  then Misc.fatal_errorf "Type %a is not of kind value" TG.print t;
-  (* XXX This probably shouldn't be using [get_alias] *)
-  (* XXX This needs to match the equal-to-tagged-immediates function below *)
-  match TG.get_alias_exn t with
-  | exception Not_found -> Unknown
-  | simple ->
-    Simple.pattern_match simple
-      ~const:(fun cst : _ proof ->
-        match Reg_width_const.descr cst with
-        | Tagged_immediate imm -> Proved (Tagged_immediate imm, Coercion.id)
-        | _ ->
-          Misc.fatal_errorf
-            "[Simple] %a in the [Equals] field has a kind different from that \
-             returned by [kind] (%a):@ %a"
-            Simple.print simple K.print original_kind TG.print t)
-      ~name:(fun _ ~coercion:_ : _ proof ->
-        match
-          TE.get_canonical_simple_exn env simple ~min_name_mode:Name_mode.normal
-        with
-        | exception Not_found -> Unknown
-        | simple ->
-          (* CR mshinwell: Instead, get all aliases and find a Symbol, to avoid
-             relying on the fact that if there is a Symbol alias then it will be
-             canonical *)
-          Simple.pattern_match simple
-            ~const:(fun cst : _ proof ->
-              match Reg_width_const.descr cst with
-              | Tagged_immediate imm ->
-                Proved (Tagged_immediate imm, Coercion.id)
-              | _ ->
-                let kind = TG.kind t in
-                Misc.fatal_errorf
-                  "Kind returned by [get_canonical_simple] (%a) doesn't match \
-                   the kind of the returned [Simple] %a:@ %a"
-                  K.print kind Simple.print simple TG.print t)
-            ~name:(fun name ~coercion ->
-              Name.pattern_match name
-                ~var:
-                  (fun var :
-                       (var_or_symbol_or_tagged_immediate * Coercion.t) proof ->
-                  Proved (Var var, coercion))
-                ~symbol:
-                  (fun symbol :
-                       (var_or_symbol_or_tagged_immediate * Coercion.t) proof ->
-                  Proved (Symbol symbol, coercion))))
+  then Wrong_kind
+  else
+    match TG.get_alias_exn t with
+    | exception Not_found ->
+      (* CR vlaviron: We could try to turn singleton types into constants here.
+         I think there are already a few hacks to generate constant aliases
+         instead of singleton types when possible, so we might never end up here
+         with a singleton type in practice. *)
+      Unknown
+    | simple -> (
+      match
+        TE.get_canonical_simple_exn env simple ~min_name_mode:Name_mode.normal
+      with
+      | exception Not_found -> Unknown
+      | simple -> Proved simple)
 
-let prove_single_closures_entry' env t : _ proof_allowing_kind_mismatch =
-  match expand_head env t with
-  | Value (Ok (Closures { by_function_slot; alloc_mode })) -> (
-    match TG.Row_like_for_closures.get_singleton by_function_slot with
-    | None -> Unknown
-    | Some ((function_slot, set_of_closures_contents), closures_entry) -> (
-      let function_slots =
-        Set_of_closures_contents.closures set_of_closures_contents
-      in
-      assert (Function_slot.Set.mem function_slot function_slots);
-      let function_type =
-        TG.Closures_entry.find_function_type closures_entry function_slot
-      in
-      match function_type with
-      | Bottom -> Invalid
-      | Unknown -> Unknown
-      | Ok function_type ->
-        Proved (function_slot, alloc_mode, closures_entry, function_type)))
-  | Value (Ok _) -> Invalid
-  | Value Unknown -> Unknown
-  | Value Bottom -> Invalid
-  | Naked_immediate _ -> Wrong_kind
-  | Naked_float _ -> Wrong_kind
-  | Naked_int32 _ -> Wrong_kind
-  | Naked_int64 _ -> Wrong_kind
-  | Naked_nativeint _ -> Wrong_kind
-  | Rec_info _ -> Wrong_kind
-  | Region _ -> Wrong_kind
-
-let prove_single_closures_entry env t : _ proof =
-  match prove_single_closures_entry' env t with
-  | Proved proof -> Proved proof
-  | Unknown -> Unknown
-  | Invalid -> Invalid
-  | Wrong_kind -> Misc.fatal_errorf "Type has wrong kind: %a" TG.print t
-
-(* CR mshinwell: Try to functorise or otherwise factor out across the various
-   number kinds. *)
-let prove_naked_floats env t : _ proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Naked_float]:@ %a" TG.print t
-  in
-  match expand_head env t with
-  | Naked_float (Ok fs) -> if Float.Set.is_empty fs then Invalid else Proved fs
-  | Naked_float Unknown -> Unknown
-  | Naked_float Bottom -> Invalid
-  | Value _ -> wrong_kind ()
-  | Naked_immediate _ -> wrong_kind ()
-  | Naked_int32 _ -> wrong_kind ()
-  | Naked_int64 _ -> wrong_kind ()
-  | Naked_nativeint _ -> wrong_kind ()
-  | Rec_info _ -> wrong_kind ()
-  | Region _ -> wrong_kind ()
-
-let prove_naked_int32s env t : _ proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Naked_int32]:@ %a" TG.print t
-  in
-  match expand_head env t with
-  | Naked_int32 (Ok is) -> if Int32.Set.is_empty is then Invalid else Proved is
-  | Naked_int32 Unknown -> Unknown
-  | Naked_int32 Bottom -> Invalid
-  | Value _ -> wrong_kind ()
-  | Naked_immediate _ -> wrong_kind ()
-  | Naked_float _ -> wrong_kind ()
-  | Naked_int64 _ -> wrong_kind ()
-  | Naked_nativeint _ -> wrong_kind ()
-  | Rec_info _ -> wrong_kind ()
-  | Region _ -> wrong_kind ()
-
-let prove_naked_int64s env t : _ proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Naked_int64]:@ %a" TG.print t
-  in
-  match expand_head env t with
-  | Naked_int64 (Ok is) -> if Int64.Set.is_empty is then Invalid else Proved is
-  | Naked_int64 Unknown -> Unknown
-  | Naked_int64 Bottom -> Invalid
-  | Value _ -> wrong_kind ()
-  | Naked_immediate _ -> wrong_kind ()
-  | Naked_float _ -> wrong_kind ()
-  | Naked_int32 _ -> wrong_kind ()
-  | Naked_nativeint _ -> wrong_kind ()
-  | Rec_info _ -> wrong_kind ()
-  | Region _ -> wrong_kind ()
-
-let prove_naked_nativeints env t : _ proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Naked_nativeint]:@ %a" TG.print t
-  in
-  match expand_head env t with
-  | Naked_nativeint (Ok is) ->
-    if Targetint_32_64.Set.is_empty is then Invalid else Proved is
-  | Naked_nativeint Unknown -> Unknown
-  | Naked_nativeint Bottom -> Invalid
-  | Value _ -> wrong_kind ()
-  | Naked_immediate _ -> wrong_kind ()
-  | Naked_float _ -> wrong_kind ()
-  | Naked_int32 _ -> wrong_kind ()
-  | Naked_int64 _ -> wrong_kind ()
-  | Rec_info _ -> wrong_kind ()
-  | Region _ -> wrong_kind ()
-
-let prove_is_int env t : bool proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
-  in
+let prove_is_int_generic env t : bool generic_proof =
   match expand_head env t with
   | Value (Ok (Variant blocks_imms)) -> (
     match blocks_imms.blocks, blocks_imms.immediates with
@@ -223,37 +98,24 @@ let prove_is_int env t : bool proof =
     Proved false
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
-  | Naked_immediate _ -> wrong_kind ()
-  | Naked_float _ -> wrong_kind ()
-  | Naked_int32 _ -> wrong_kind ()
-  | Naked_int64 _ -> wrong_kind ()
-  | Naked_nativeint _ -> wrong_kind ()
-  | Rec_info _ -> wrong_kind ()
-  | Region _ -> wrong_kind ()
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    Wrong_kind
 
-let prove_tags_must_be_a_block env t : Tag.Set.t proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
-  in
+let prove_is_int env t = as_property (prove_is_int_generic env t)
+
+(* Note: this function returns a generic proof because we want to propagate the
+   Invalid cases to prove_naked_immediates_generic, but it's not suitable for
+   implementing [check_get_tag] because it doesn't ignore the immediates part of
+   the variant. *)
+let prove_get_tag_generic env t : Tag.Set.t generic_proof =
   match expand_head env t with
   | Value (Ok (Variant blocks_imms)) -> (
     match blocks_imms.immediates with
     | Unknown -> Unknown
     | Known imms -> (
       if not (is_bottom env imms)
-      then
-        (* CR vlaviron: This case could be completely ignored if we're only
-           interested in the set of tags this type can have. It is there because
-           this function used to return Invalid when it couldn't definitively
-           prove that this type represents a block, but this caused a number of
-           problems so this was switched to Unknown (which, unlike Invalid, is
-           always sound). There remain a question of whether we actually want
-           two different variants of this function, one for simplification of
-           the get_tag primitive which may reasonably expect to error if its
-           argument cannot be proved to be a block, and one for simplification
-           of CSE parameters containing a get_tag equation, which can occur at
-           places where the type is not known to be a block. *)
-        Unknown
+      then Unknown
       else
         match blocks_imms.blocks with
         | Unknown -> Unknown
@@ -267,44 +129,34 @@ let prove_tags_must_be_a_block env t : Tag.Set.t proof =
   | Value
       (Ok (Boxed_float _ | Boxed_int32 _ | Boxed_int64 _ | Boxed_nativeint _))
     ->
-    Proved (Tag.Set.singleton Tag.custom_tag)
+    Unknown
   | Value (Ok (Mutable_block _)) -> Unknown
-  | Value (Ok (Closures _)) ->
-    Proved (Tag.Set.of_list [Tag.closure_tag; Tag.infix_tag])
-  | Value (Ok (String _)) -> Proved (Tag.Set.singleton Tag.string_tag)
-  | Value (Ok (Array _)) ->
-    Proved (Tag.Set.of_list [Tag.zero; Tag.double_array_tag])
+  | Value (Ok (Closures _)) -> Unknown
+  | Value (Ok (String _)) -> Unknown
+  | Value (Ok (Array _)) -> Unknown
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
-  (* CR mshinwell: Here and elsewhere, use or-patterns. *)
-  | Naked_immediate _ -> wrong_kind ()
-  | Naked_float _ -> wrong_kind ()
-  | Naked_int32 _ -> wrong_kind ()
-  | Naked_int64 _ -> wrong_kind ()
-  | Naked_nativeint _ -> wrong_kind ()
-  | Rec_info _ -> wrong_kind ()
-  | Region _ -> wrong_kind ()
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    Wrong_kind
 
-let prove_naked_immediates env t : Targetint_31_63.Set.t proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Naked_immediate]:@ %a" TG.print t
-  in
+let prove_get_tag env t = as_property (prove_get_tag_generic env t)
+
+let prove_naked_immediates_generic env t : Targetint_31_63.Set.t generic_proof =
   match expand_head env t with
   | Naked_immediate (Ok (Naked_immediates is)) ->
     if Targetint_31_63.Set.is_empty is then Invalid else Proved is
   | Naked_immediate (Ok (Is_int scrutinee_ty)) -> (
-    match prove_is_int env scrutinee_ty with
+    match prove_is_int_generic env scrutinee_ty with
     | Proved true ->
       Proved (Targetint_31_63.Set.singleton Targetint_31_63.bool_true)
     | Proved false ->
       Proved (Targetint_31_63.Set.singleton Targetint_31_63.bool_false)
     | Unknown -> Unknown
-    | Invalid -> Invalid)
+    | Invalid -> Invalid
+    | Wrong_kind -> Wrong_kind)
   | Naked_immediate (Ok (Get_tag block_ty)) -> (
-    (* CR vlaviron: see the comment in prove_tags_must_be_a_block. See also
-       prove_equals_tagged_immediates below, which returns Unknown when the
-       blocks part is not bottom. *)
-    match prove_tags_must_be_a_block env block_ty with
+    match prove_get_tag_generic env block_ty with
     | Proved tags ->
       let is =
         Tag.Set.fold
@@ -314,105 +166,116 @@ let prove_naked_immediates env t : Targetint_31_63.Set.t proof =
       in
       Proved is
     | Unknown -> Unknown
-    | Invalid -> Invalid)
+    | Invalid -> Invalid
+    | Wrong_kind -> Wrong_kind)
   | Naked_immediate Unknown -> Unknown
   | Naked_immediate Bottom -> Invalid
-  | Value _ -> wrong_kind ()
-  | Naked_float _ -> wrong_kind ()
-  | Naked_int32 _ -> wrong_kind ()
-  | Naked_int64 _ -> wrong_kind ()
-  | Naked_nativeint _ -> wrong_kind ()
-  | Rec_info _ -> wrong_kind ()
-  | Region _ -> wrong_kind ()
+  | Value _ -> Wrong_kind
+  | Naked_float _ -> Wrong_kind
+  | Naked_int32 _ -> Wrong_kind
+  | Naked_int64 _ -> Wrong_kind
+  | Naked_nativeint _ -> Wrong_kind
+  | Rec_info _ -> Wrong_kind
+  | Region _ -> Wrong_kind
 
-let prove_equals_tagged_immediates env t : Targetint_31_63.Set.t proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
-  in
+let check_naked_immediates env t =
+  as_operation (prove_naked_immediates_generic env t)
+
+let prove_equals_tagged_immediates env t : _ proof_of_property =
   match expand_head env t with
-  | Value (Ok (Variant blocks_imms)) -> (
-    match blocks_imms.blocks, blocks_imms.immediates with
-    | Unknown, Unknown | Unknown, Known _ | Known _, Unknown -> Unknown
-    | Known blocks, Known imms ->
-      (* CR mshinwell: Check this. Again it depends on the context; is this a
-         context where variants are ok? *)
-      if not (TG.Row_like_for_blocks.is_bottom blocks)
-      then Unknown
-      else prove_naked_immediates env imms)
-  | Value (Ok (Mutable_block _)) -> Unknown
-  | Value (Ok _) -> Invalid
-  | Value Unknown -> Unknown
-  | Value Bottom -> Invalid
-  | Naked_immediate _ -> wrong_kind ()
-  | Naked_float _ -> wrong_kind ()
-  | Naked_int32 _ -> wrong_kind ()
-  | Naked_int64 _ -> wrong_kind ()
-  | Naked_nativeint _ -> wrong_kind ()
-  | Rec_info _ -> wrong_kind ()
-  | Region _ -> wrong_kind ()
+  | Value (Ok (Variant { immediates; blocks; is_unique = _; alloc_mode = _ }))
+    -> (
+    match blocks with
+    | Unknown -> Unknown
+    | Known blocks ->
+      if TG.Row_like_for_blocks.is_bottom blocks
+      then
+        match immediates with
+        | Unknown -> Unknown
+        | Known imms -> (
+          match check_naked_immediates env imms with
+          | Known_result imms -> Proved imms
+          | Invalid | Unknown -> Unknown)
+      else Unknown)
+  | Value (Ok _ | Unknown | Bottom) -> Unknown
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    Wrong_kind
 
-let prove_equals_single_tagged_immediate env t : _ proof =
-  match prove_equals_tagged_immediates env t with
-  | Proved imms -> (
+let check_equals_tagged_immediates env t : _ proof_of_operation =
+  match expand_head env t with
+  | Value
+      (Ok (Variant { immediates; blocks = _; is_unique = _; alloc_mode = _ }))
+    -> (
+    match immediates with
+    | Unknown -> Unknown
+    | Known imms -> check_naked_immediates env imms)
+  | Value (Ok _ | Unknown) -> Unknown
+  | Value Bottom
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    Invalid
+
+let check_equals_single_tagged_immediate env t : _ proof_of_operation =
+  match check_equals_tagged_immediates env t with
+  | Known_result imms -> (
     match Targetint_31_63.Set.get_singleton imms with
-    | Some imm -> Proved imm
+    | Some imm -> Known_result imm
     | None -> Unknown)
   | Unknown -> Unknown
   | Invalid -> Invalid
 
-let prove_tags_and_sizes env t : Targetint_31_63.Imm.t Tag.Map.t proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
+type _ check_naked_number_kind =
+  | Float : Float.Set.t check_naked_number_kind
+  | Int32 : Int32.Set.t check_naked_number_kind
+  | Int64 : Int64.Set.t check_naked_number_kind
+  | Nativeint : Targetint_32_64.Set.t check_naked_number_kind
+
+let check_naked_number (type a) (kind : a check_naked_number_kind) env t :
+    a proof_of_operation =
+  let set_oub_to_proof (set_oub : _ Or_unknown_or_bottom.t) ~is_empty :
+      _ proof_of_operation =
+    match set_oub with
+    | Ok set -> if is_empty set then Invalid else Known_result set
+    | Unknown -> Unknown
+    | Bottom -> Invalid
   in
   match expand_head env t with
-  | Value (Ok (Variant blocks_imms)) -> (
-    match blocks_imms.immediates with
-    (* CR mshinwell: Care. Should this return [Unknown] or [Invalid] if there is
-       the possibility of the type representing a tagged immediate? *)
-    | Unknown -> Unknown
-    | Known immediates ->
-      if is_bottom env immediates
-      then
-        match blocks_imms.blocks with
-        | Unknown -> Unknown
-        | Known blocks -> (
-          match TG.Row_like_for_blocks.all_tags_and_sizes blocks with
-          | Unknown -> Unknown
-          | Known tags_and_sizes -> Proved tags_and_sizes)
-      else Unknown)
-  | Value (Ok (Mutable_block _)) -> Unknown
-  | Value (Ok _) -> Invalid
-  | Value Unknown -> Unknown
-  | Value Bottom -> Invalid
-  (* CR mshinwell: Here and elsewhere, use or-patterns. *)
-  | Naked_immediate _ -> wrong_kind ()
-  | Naked_float _ -> wrong_kind ()
-  | Naked_int32 _ -> wrong_kind ()
-  | Naked_int64 _ -> wrong_kind ()
-  | Naked_nativeint _ -> wrong_kind ()
-  | Rec_info _ -> wrong_kind ()
-  | Region _ -> wrong_kind ()
+  | Value _ -> Invalid
+  | Naked_immediate _ -> Invalid
+  | Rec_info _ -> Invalid
+  | Region _ -> Invalid
+  | Naked_float fs -> (
+    match kind with
+    | Float -> set_oub_to_proof fs ~is_empty:Float.Set.is_empty
+    | _ -> Invalid)
+  | Naked_int32 is -> (
+    match kind with
+    | Int32 -> set_oub_to_proof is ~is_empty:Int32.Set.is_empty
+    | _ -> Invalid)
+  | Naked_int64 is -> (
+    match kind with
+    | Int64 -> set_oub_to_proof is ~is_empty:Int64.Set.is_empty
+    | _ -> Invalid)
+  | Naked_nativeint is -> (
+    match kind with
+    | Nativeint -> set_oub_to_proof is ~is_empty:Targetint_32_64.Set.is_empty
+    | _ -> Invalid)
 
-let prove_unique_tag_and_size env t :
-    (Tag.t * Targetint_31_63.Imm.t) proof_allowing_kind_mismatch =
-  if not (Flambda_kind.equal (TG.kind t) Flambda_kind.value)
-  then Wrong_kind
-  else
-    match prove_tags_and_sizes env t with
-    | Invalid -> Invalid
-    | Unknown -> Unknown
-    | Proved tags_to_sizes -> (
-      match Tag.Map.get_singleton tags_to_sizes with
-      | None -> Unknown
-      | Some (tag, size) -> Proved (tag, size))
+let check_naked_floats = check_naked_number Float
+
+let check_naked_int32s = check_naked_number Int32
+
+let check_naked_int64s = check_naked_number Int64
+
+let check_naked_nativeints = check_naked_number Nativeint
 
 type variant_like_proof =
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
     non_const_ctors_with_sizes : Targetint_31_63.Imm.t Tag.Scannable.Map.t
   }
 
-let prove_variant_like env t : variant_like_proof proof_allowing_kind_mismatch =
-  (* Format.eprintf "prove_variant:@ %a\n%!" TG.print t; *)
+let prove_variant_like_generic env t : variant_like_proof generic_proof =
   match expand_head env t with
   | Value (Ok (Variant blocks_imms)) -> (
     match blocks_imms.blocks with
@@ -440,10 +303,10 @@ let prove_variant_like env t : variant_like_proof proof_allowing_kind_mismatch =
             match blocks_imms.immediates with
             | Unknown -> Unknown
             | Known imms -> (
-              match prove_naked_immediates env imms with
+              match check_naked_immediates env imms with
               | Unknown -> Unknown
               | Invalid -> Known Targetint_31_63.Set.empty
-              | Proved const_ctors -> Known const_ctors)
+              | Known_result const_ctors -> Known const_ctors)
           in
           Proved { const_ctors; non_const_ctors_with_sizes })))
   | Value (Ok (Mutable_block _)) -> Unknown
@@ -458,272 +321,258 @@ let prove_variant_like env t : variant_like_proof proof_allowing_kind_mismatch =
   | Rec_info _ -> Wrong_kind
   | Region _ -> Wrong_kind
 
+let check_variant_like env t = as_operation (prove_variant_like_generic env t)
+
+let prove_variant_like env t = as_property (prove_variant_like_generic env t)
+
 type boxed_or_tagged_number =
   | Boxed of Flambda_kind.Boxable_number.t
   | Tagged_immediate
 
 let prove_is_a_boxed_or_tagged_number env t :
-    boxed_or_tagged_number proof_allowing_kind_mismatch =
+    boxed_or_tagged_number proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
-  | Value (Ok (Variant { blocks; immediates; is_unique = _; alloc_mode = _ }))
+  | Value
+      (Ok (Variant { blocks; immediates = _; is_unique = _; alloc_mode = _ }))
     -> (
-    match blocks, immediates with
-    | Unknown, Unknown -> Unknown
-    | Unknown, Known imms -> if is_bottom env imms then Invalid else Unknown
-    | Known blocks, Unknown ->
+    match blocks with
+    | Unknown -> Unknown
+    | Known blocks ->
       if TG.Row_like_for_blocks.is_bottom blocks
-      then Proved Tagged_immediate
-      else Unknown
-    | Known blocks, Known imms ->
-      if is_bottom env imms
-      then Invalid
-      else if TG.Row_like_for_blocks.is_bottom blocks
       then Proved Tagged_immediate
       else Unknown)
   | Value (Ok (Boxed_float _)) -> Proved (Boxed Naked_float)
   | Value (Ok (Boxed_int32 _)) -> Proved (Boxed Naked_int32)
   | Value (Ok (Boxed_int64 _)) -> Proved (Boxed Naked_int64)
   | Value (Ok (Boxed_nativeint _)) -> Proved (Boxed Naked_nativeint)
-  | Value _ -> Invalid
+  | Value _ -> Unknown
   | _ -> Wrong_kind
 
-let prove_is_a_tagged_immediate env t : _ proof_allowing_kind_mismatch =
+let prove_is_a_tagged_immediate env t : _ proof_of_property =
   match prove_is_a_boxed_or_tagged_number env t with
   | Proved Tagged_immediate -> Proved ()
   | Proved _ -> Unknown
-  | Invalid -> Invalid
   | Wrong_kind -> Wrong_kind
   | Unknown -> Unknown
 
-let prove_is_a_boxed_float env t : _ proof_allowing_kind_mismatch =
+let prove_is_a_boxed_float env t : _ proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value (Ok (Boxed_float _)) -> Proved ()
-  | Value _ -> Invalid
+  | Value _ -> Unknown
   | _ -> Wrong_kind
 
-let prove_is_or_is_not_a_boxed_float env t : _ proof_allowing_kind_mismatch =
+let prove_is_or_is_not_a_boxed_float env t : _ proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
-  | Value Bottom -> Invalid
+  | Value Bottom -> Unknown
   | Value (Ok (Boxed_float _)) -> Proved true
   | Value (Ok _) -> Proved false
   | _ -> Wrong_kind
 
-let prove_is_a_boxed_int32 env t : _ proof_allowing_kind_mismatch =
+let prove_is_a_boxed_int32 env t : _ proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value (Ok (Boxed_int32 _)) -> Proved ()
-  | Value _ -> Invalid
+  | Value _ -> Unknown
   | _ -> Wrong_kind
 
-let prove_is_a_boxed_int64 env t : _ proof_allowing_kind_mismatch =
+let prove_is_a_boxed_int64 env t : _ proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value (Ok (Boxed_int64 _)) -> Proved ()
-  | Value _ -> Invalid
+  | Value _ -> Unknown
   | _ -> Wrong_kind
 
-let prove_is_a_boxed_nativeint env t : _ proof_allowing_kind_mismatch =
+let prove_is_a_boxed_nativeint env t : _ proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value (Ok (Boxed_nativeint _)) -> Proved ()
-  | Value _ -> Invalid
+  | Value _ -> Unknown
   | _ -> Wrong_kind
 
-(* CR mshinwell: Factor out code from the following. *)
-
-let prove_boxed_floats env t : _ proof =
-  let result_var = Variable.create "result" in
-  let result_var' = Bound_var.create result_var Name_mode.normal in
-  let result_simple = Simple.var result_var in
-  let result_kind = K.naked_float in
-  let shape =
-    TG.box_float (TG.alias_type_of result_kind result_simple) Unknown
-  in
-  match
-    Meet_and_join.meet_shape env t ~shape ~result_var:result_var' ~result_kind
-  with
-  | Bottom -> Invalid
-  | Ok env_extension ->
-    let env =
-      TE.add_definition env
-        (Bound_name.create (Name.var result_var) Name_mode.normal)
-        result_kind
-    in
-    let env =
-      TE.add_env_extension env env_extension ~meet_type:Meet_and_join.meet
-    in
-    let t = TE.find env (Name.var result_var) (Some result_kind) in
-    prove_naked_floats env t
-
-let prove_boxed_int32s env t : _ proof =
-  let result_var = Variable.create "result" in
-  let result_var' = Bound_var.create result_var Name_mode.normal in
-  let result_simple = Simple.var result_var in
-  let result_kind = K.naked_int32 in
-  let shape =
-    TG.box_int32 (TG.alias_type_of result_kind result_simple) Unknown
-  in
-  match
-    Meet_and_join.meet_shape env t ~shape ~result_var:result_var' ~result_kind
-  with
-  | Bottom -> Invalid
-  | Ok env_extension ->
-    let env =
-      TE.add_definition env
-        (Bound_name.create (Name.var result_var) Name_mode.normal)
-        result_kind
-    in
-    let env =
-      TE.add_env_extension env env_extension ~meet_type:Meet_and_join.meet
-    in
-    let t = TE.find env (Name.var result_var) (Some result_kind) in
-    prove_naked_int32s env t
-
-let prove_boxed_int64s env t : _ proof =
-  let result_var = Variable.create "result" in
-  let result_var' = Bound_var.create result_var Name_mode.normal in
-  let result_simple = Simple.var result_var in
-  let result_kind = K.naked_int64 in
-  let shape =
-    TG.box_int64 (TG.alias_type_of result_kind result_simple) Unknown
-  in
-  match
-    Meet_and_join.meet_shape env t ~shape ~result_var:result_var' ~result_kind
-  with
-  | Bottom -> Invalid
-  | Ok env_extension ->
-    let env =
-      TE.add_definition env
-        (Bound_name.create (Name.var result_var) Name_mode.normal)
-        result_kind
-    in
-    let env =
-      TE.add_env_extension env env_extension ~meet_type:Meet_and_join.meet
-    in
-    let t = TE.find env (Name.var result_var) (Some result_kind) in
-    prove_naked_int64s env t
-
-let prove_boxed_nativeints env t : _ proof =
-  let result_var = Variable.create "result" in
-  let result_var' = Bound_var.create result_var Name_mode.normal in
-  let result_simple = Simple.var result_var in
-  let result_kind = K.naked_nativeint in
-  let shape =
-    TG.box_nativeint (TG.alias_type_of result_kind result_simple) Unknown
-  in
-  match
-    Meet_and_join.meet_shape env t ~shape ~result_var:result_var' ~result_kind
-  with
-  | Bottom -> Invalid
-  | Ok env_extension ->
-    let env =
-      TE.add_definition env
-        (Bound_name.create (Name.var result_var) Name_mode.normal)
-        result_kind
-    in
-    let env =
-      TE.add_env_extension env env_extension ~meet_type:Meet_and_join.meet
-    in
-    let t = TE.find env (Name.var result_var) (Some result_kind) in
-    prove_naked_nativeints env t
-
-let prove_strings env t : String_info.Set.t proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
-  in
+let check_boxed_floats env t : _ proof_of_operation =
   match expand_head env t with
-  | Value (Ok (String strs)) -> Proved strs
-  | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
-  | Value Bottom -> Invalid
+  | Value (Ok (Boxed_float (ty, _mode))) -> check_naked_floats env ty
+  | Value _ -> Invalid
+  | _ -> Invalid
+
+let check_boxed_int32s env t : _ proof_of_operation =
+  match expand_head env t with
+  | Value Unknown -> Unknown
+  | Value (Ok (Boxed_int32 (ty, _mode))) -> check_naked_int32s env ty
+  | Value _ -> Invalid
+  | _ -> Invalid
+
+let check_boxed_int64s env t : _ proof_of_operation =
+  match expand_head env t with
+  | Value Unknown -> Unknown
+  | Value (Ok (Boxed_int64 (ty, _mode))) -> check_naked_int64s env ty
+  | Value _ -> Invalid
+  | _ -> Invalid
+
+let check_boxed_nativeints env t : _ proof_of_operation =
+  match expand_head env t with
+  | Value Unknown -> Unknown
+  | Value (Ok (Boxed_nativeint (ty, _mode))) -> check_naked_nativeints env ty
+  | Value _ -> Invalid
+  | _ -> Invalid
+
+let prove_unique_tag_and_size env t :
+    (Tag.t * Targetint_31_63.Imm.t) proof_of_property =
+  match expand_head env t with
+  | Value (Ok (Variant blocks_imms)) -> (
+    match blocks_imms.immediates with
+    | Unknown -> Unknown
+    | Known immediates ->
+      if is_bottom env immediates
+      then
+        match blocks_imms.blocks with
+        | Unknown -> Unknown
+        | Known blocks -> (
+          match TG.Row_like_for_blocks.get_singleton blocks with
+          | None -> Unknown
+          | Some (tag_and_size, _fields) -> Proved tag_and_size)
+      else Unknown)
+  | Value (Ok (Mutable_block _)) | Value (Ok _) | Value Unknown | Value Bottom
+    ->
+    Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    wrong_kind ()
+    Wrong_kind
 
 type array_kind_compatibility =
   | Exact
   | Compatible
   | Incompatible
 
-let prove_is_array_with_element_kind env t ~element_kind : _ proof =
+let check_is_array_with_element_kind env t ~element_kind : _ proof_of_operation
+    =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
   | Value (Ok (Array { element_kind = Unknown; _ })) -> Unknown
   | Value (Ok (Array { element_kind = Known element_kind'; _ })) ->
     if K.With_subkind.equal element_kind' element_kind
-    then Proved Exact
+    then Known_result Exact
     else if K.With_subkind.compatible element_kind ~when_used_at:element_kind'
             || K.With_subkind.compatible element_kind'
                  ~when_used_at:element_kind
-    then Proved Compatible
-    else Proved Incompatible
+    then Known_result Compatible
+    else Known_result Incompatible
+  | Value (Ok (Variant _)) ->
+    (* CR vlaviron: This case is here to avoiding breaking code such as:
+     * Array.get (Obj.magic (0, 0)) 1
+     * If we decide that this code should segfault, we could return Invalid. *)
+    Unknown
   | Value (Ok _)
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Invalid
 
-type prove_tagging_function =
-  | Prove_could_be_tagging_of_simple
-  | Prove_is_always_tagging_of_simple
+let prove_single_closures_entry_generic env t : _ generic_proof =
+  match expand_head env t with
+  | Value (Ok (Closures { by_function_slot; alloc_mode })) -> (
+    match TG.Row_like_for_closures.get_singleton by_function_slot with
+    | None -> Unknown
+    | Some ((function_slot, set_of_closures_contents), closures_entry) -> (
+      let function_slots =
+        Set_of_closures_contents.closures set_of_closures_contents
+      in
+      assert (Function_slot.Set.mem function_slot function_slots);
+      let function_type =
+        TG.Closures_entry.find_function_type closures_entry function_slot
+      in
+      match function_type with
+      | Bottom | Unknown -> Unknown
+      | Ok function_type ->
+        Proved (function_slot, alloc_mode, closures_entry, function_type)))
+  | Value
+      (Ok
+        ( Variant _ | Mutable_block _ | Boxed_float _ | Boxed_int32 _
+        | Boxed_int64 _ | Boxed_nativeint _ | String _ | Array _ )) ->
+    Invalid
+  | Value Unknown -> Unknown
+  | Value Bottom -> Invalid
+  | Naked_immediate _ -> Wrong_kind
+  | Naked_float _ -> Wrong_kind
+  | Naked_int32 _ -> Wrong_kind
+  | Naked_int64 _ -> Wrong_kind
+  | Naked_nativeint _ -> Wrong_kind
+  | Rec_info _ -> Wrong_kind
+  | Region _ -> Wrong_kind
 
-let prove_is_tagging_of_simple ~prove_function env ~min_name_mode t :
-    Simple.t proof =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
-  in
+let check_single_closures_entry env t =
+  as_operation (prove_single_closures_entry_generic env t)
+
+let prove_single_closures_entry env t =
+  as_property (prove_single_closures_entry_generic env t)
+
+let check_strings env t : String_info.Set.t proof_of_operation =
+  match expand_head env t with
+  | Value (Ok (String strs)) -> Known_result strs
+  | Value (Ok _) -> Invalid
+  | Value Unknown -> Unknown
+  | Value Bottom -> Invalid
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    Invalid
+
+type tagging_proof_kind =
+  | Prove
+  | Check
+
+let prove_tagging_of_simple_aux proof_kind env ~min_name_mode t :
+    Simple.t generic_proof =
   match expand_head env t with
   | Value (Ok (Variant { immediates; blocks; is_unique = _; alloc_mode = _ }))
     -> (
-    match blocks with
-    | Unknown -> Unknown
-    | Known blocks -> (
-      match prove_function with
-      | Prove_is_always_tagging_of_simple
-        when not (TG.Row_like_for_blocks.is_bottom blocks) ->
-        Unknown
-      | Prove_is_always_tagging_of_simple
-        (* when (Row_like_for_blocks.is_bottom blocks) *)
-      | Prove_could_be_tagging_of_simple -> (
-        match immediates with
-        | Unknown -> Unknown
-        | Known t -> (
-          let from_alias =
-            match
-              TE.get_canonical_simple_exn env ~min_name_mode
-                (TG.get_alias_exn t)
-            with
-            | simple -> Some simple
-            | exception Not_found -> None
-          in
-          match from_alias with
-          | Some simple -> Proved simple
-          | None -> (
-            match prove_naked_immediates env t with
-            | Unknown -> Unknown
-            | Invalid -> Invalid
-            | Proved imms -> (
-              match Targetint_31_63.Set.get_singleton imms with
-              | Some imm ->
-                Proved (Simple.const (Reg_width_const.naked_immediate imm))
-              | None -> Unknown))))))
-  | Value Unknown -> Unknown
-  | Value _ -> Invalid
+    let prove_immediates () =
+      match immediates with
+      | Unknown -> Unknown
+      | Known t -> (
+        let from_alias =
+          match
+            TE.get_canonical_simple_exn env ~min_name_mode (TG.get_alias_exn t)
+          with
+          | simple -> Some simple
+          | exception Not_found -> None
+        in
+        match from_alias with
+        | Some simple -> Proved simple
+        | None -> (
+          match check_naked_immediates env t with
+          | Unknown -> Unknown
+          | Invalid -> Invalid
+          | Known_result imms -> (
+            match Targetint_31_63.Set.get_singleton imms with
+            | Some imm ->
+              Proved (Simple.const (Reg_width_const.naked_immediate imm))
+            | None -> Unknown)))
+    in
+    match proof_kind, blocks with
+    | Prove, Unknown -> Unknown
+    | Prove, Known blocks ->
+      if TG.Row_like_for_blocks.is_bottom blocks
+      then prove_immediates ()
+      else Unknown
+    | Check, _ -> prove_immediates ())
+  | Value _ -> Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    wrong_kind ()
+    Wrong_kind
 
-let prove_is_always_tagging_of_simple =
-  prove_is_tagging_of_simple ~prove_function:Prove_is_always_tagging_of_simple
+let prove_tagging_of_simple env ~min_name_mode t =
+  as_property (prove_tagging_of_simple_aux Prove env ~min_name_mode t)
 
-let prove_could_be_tagging_of_simple =
-  prove_is_tagging_of_simple ~prove_function:Prove_could_be_tagging_of_simple
+let check_tagging_of_simple env ~min_name_mode t =
+  as_operation (prove_tagging_of_simple_aux Check env ~min_name_mode t)
 
-let[@inline always] prove_boxed_number_containing_simple
-    ~contents_of_boxed_number env ~min_name_mode t : Simple.t proof =
+let[@inline always] check_boxed_number_containing_simple
+    ~contents_of_boxed_number env ~min_name_mode t : Simple.t proof_of_operation
+    =
   match expand_head env t with
   | Value (Ok ty_value) -> (
     match contents_of_boxed_number ty_value with
@@ -732,7 +581,7 @@ let[@inline always] prove_boxed_number_containing_simple
       match
         TE.get_canonical_simple_exn env ~min_name_mode (TG.get_alias_exn ty)
       with
-      | simple -> Proved simple
+      | simple -> Known_result simple
       | exception Not_found -> Unknown))
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
@@ -740,8 +589,8 @@ let[@inline always] prove_boxed_number_containing_simple
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
 
-let prove_boxed_float_containing_simple =
-  prove_boxed_number_containing_simple
+let check_boxed_float_containing_simple =
+  check_boxed_number_containing_simple
     ~contents_of_boxed_number:(fun (ty_value : TG.head_of_kind_value) ->
       match ty_value with
       | Boxed_float (ty, _) -> Some ty
@@ -749,8 +598,8 @@ let prove_boxed_float_containing_simple =
       | Boxed_nativeint _ | Closures _ | String _ | Array _ ->
         None)
 
-let prove_boxed_int32_containing_simple =
-  prove_boxed_number_containing_simple
+let check_boxed_int32_containing_simple =
+  check_boxed_number_containing_simple
     ~contents_of_boxed_number:(fun (ty_value : TG.head_of_kind_value) ->
       match ty_value with
       | Boxed_int32 (ty, _) -> Some ty
@@ -758,8 +607,8 @@ let prove_boxed_int32_containing_simple =
       | Boxed_nativeint _ | Closures _ | String _ | Array _ ->
         None)
 
-let prove_boxed_int64_containing_simple =
-  prove_boxed_number_containing_simple
+let check_boxed_int64_containing_simple =
+  check_boxed_number_containing_simple
     ~contents_of_boxed_number:(fun (ty_value : TG.head_of_kind_value) ->
       match ty_value with
       | Boxed_int64 (ty, _) -> Some ty
@@ -767,8 +616,8 @@ let prove_boxed_int64_containing_simple =
       | Boxed_nativeint _ | Closures _ | String _ | Array _ ->
         None)
 
-let prove_boxed_nativeint_containing_simple =
-  prove_boxed_number_containing_simple
+let check_boxed_nativeint_containing_simple =
+  check_boxed_number_containing_simple
     ~contents_of_boxed_number:(fun (ty_value : TG.head_of_kind_value) ->
       match ty_value with
       | Boxed_nativeint (ty, _) -> Some ty
@@ -776,35 +625,31 @@ let prove_boxed_nativeint_containing_simple =
       | Boxed_int64 _ | Closures _ | String _ | Array _ ->
         None)
 
-let[@inline] prove_block_field_simple_aux env ~min_name_mode t get_field :
-    Simple.t proof =
+let[@inline] check_block_field_simple_aux env ~min_name_mode t get_field :
+    Simple.t proof_of_operation =
   let wrong_kind () =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
   match expand_head env t with
-  | Value (Ok (Variant { immediates; blocks; is_unique = _; alloc_mode = _ }))
+  | Value
+      (Ok (Variant { immediates = _; blocks; is_unique = _; alloc_mode = _ }))
     -> (
-    match immediates with
+    match blocks with
     | Unknown -> Unknown
-    | Known imms -> (
-      match blocks with
-      | Unknown -> Unknown
-      | Known blocks -> (
-        if TG.Row_like_for_blocks.is_bottom blocks
-        then Invalid
-        else if not (TG.is_obviously_bottom imms)
-        then Unknown
-        else
-          match (get_field blocks : _ Or_unknown_or_bottom.t) with
-          | Bottom -> Invalid
-          | Unknown -> Unknown
-          | Ok ty -> (
-            match TG.get_alias_exn ty with
-            | simple -> (
-              match TE.get_canonical_simple_exn env ~min_name_mode simple with
-              | simple -> Proved simple
-              | exception Not_found -> Unknown)
-            | exception Not_found -> Unknown))))
+    | Known blocks -> (
+      if TG.Row_like_for_blocks.is_bottom blocks
+      then Invalid
+      else
+        match (get_field blocks : _ Or_unknown_or_bottom.t) with
+        | Bottom -> Invalid
+        | Unknown -> Unknown
+        | Ok ty -> (
+          match TG.get_alias_exn ty with
+          | simple -> (
+            match TE.get_canonical_simple_exn env ~min_name_mode simple with
+            | simple -> Known_result simple
+            | exception Not_found -> Unknown)
+          | exception Not_found -> Unknown)))
   | Value (Ok (Mutable_block _)) -> Unknown
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
@@ -813,20 +658,20 @@ let[@inline] prove_block_field_simple_aux env ~min_name_mode t get_field :
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     wrong_kind ()
 
-let prove_block_field_simple env ~min_name_mode t field_index =
+let check_block_field_simple env ~min_name_mode t field_index =
   let[@inline] get blocks =
     TG.Row_like_for_blocks.get_field blocks field_index
   in
-  (prove_block_field_simple_aux [@inlined]) env ~min_name_mode t get
+  (check_block_field_simple_aux [@inlined]) env ~min_name_mode t get
 
-let prove_variant_field_simple env ~min_name_mode t variant_tag field_index =
+let check_variant_field_simple env ~min_name_mode t variant_tag field_index =
   let[@inline] get blocks =
     TG.Row_like_for_blocks.get_variant_field blocks variant_tag field_index
   in
-  (prove_block_field_simple_aux [@inlined]) env ~min_name_mode t get
+  (check_block_field_simple_aux [@inlined]) env ~min_name_mode t get
 
-let prove_project_function_slot_simple env ~min_name_mode t function_slot :
-    Simple.t proof =
+let check_project_function_slot_simple env ~min_name_mode t function_slot :
+    Simple.t proof_of_operation =
   let wrong_kind () =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
@@ -840,7 +685,7 @@ let prove_project_function_slot_simple env ~min_name_mode t function_slot :
       match TG.get_alias_exn ty with
       | simple -> (
         match TE.get_canonical_simple_exn env ~min_name_mode simple with
-        | simple -> Proved simple
+        | simple -> Known_result simple
         | exception Not_found -> Unknown)
       | exception Not_found -> Unknown))
   | Value (Ok _) -> Invalid
@@ -850,8 +695,8 @@ let prove_project_function_slot_simple env ~min_name_mode t function_slot :
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     wrong_kind ()
 
-let prove_project_value_slot_simple env ~min_name_mode t env_var :
-    Simple.t proof =
+let check_project_value_slot_simple env ~min_name_mode t env_var :
+    Simple.t proof_of_operation =
   let wrong_kind () =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
@@ -863,7 +708,7 @@ let prove_project_value_slot_simple env ~min_name_mode t env_var :
       match TG.get_alias_exn ty with
       | simple -> (
         match TE.get_canonical_simple_exn env ~min_name_mode simple with
-        | simple -> Proved simple
+        | simple -> Known_result simple
         | exception Not_found -> Unknown)
       | exception Not_found -> Unknown))
   | Value (Ok _) -> Invalid
@@ -873,32 +718,35 @@ let prove_project_value_slot_simple env ~min_name_mode t env_var :
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     wrong_kind ()
 
-let prove_rec_info env t : Rec_info_expr.t proof =
+let check_rec_info env t : Rec_info_expr.t proof_of_operation =
   let wrong_kind () =
     Misc.fatal_errorf "Kind error: expected [Rec_info]:@ %a" TG.print t
   in
   match expand_head env t with
-  | Rec_info (Ok rec_info_expr) -> Proved rec_info_expr
+  | Rec_info (Ok rec_info_expr) -> Known_result rec_info_expr
   | Rec_info Unknown -> Unknown
   | Rec_info Bottom -> Invalid
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Region _ ->
     wrong_kind ()
 
-let prove_alloc_mode_of_boxed_number env t : Alloc_mode.t Or_unknown.t =
+let prove_alloc_mode_of_boxed_number env t : Alloc_mode.t proof_of_property =
   match expand_head env t with
   | Value (Ok (Boxed_float (_, alloc_mode)))
   | Value (Ok (Boxed_int32 (_, alloc_mode)))
   | Value (Ok (Boxed_int64 (_, alloc_mode)))
-  | Value (Ok (Boxed_nativeint (_, alloc_mode))) ->
-    alloc_mode
+  | Value (Ok (Boxed_nativeint (_, alloc_mode))) -> (
+    match alloc_mode with
+    | Unknown -> Unknown
+    | Known alloc_mode -> Proved alloc_mode)
   | Value (Ok (Variant _ | Mutable_block _ | String _ | Array _ | Closures _))
-  | Value (Unknown | Bottom)
+  | Value (Unknown | Bottom) ->
+    Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Unknown
+    Wrong_kind
 
-let never_holds_locally_allocated_values env var kind =
+let never_holds_locally_allocated_values env var kind : _ proof_of_property =
   let t = TE.find env (Name.var var) (Some kind) in
   match expand_head env t with
   | Value (Ok (Boxed_float (_, alloc_mode)))
@@ -908,14 +756,16 @@ let never_holds_locally_allocated_values env var kind =
   | Value (Ok (Variant { alloc_mode; _ }))
   | Value (Ok (Mutable_block { alloc_mode }))
   | Value (Ok (Closures { alloc_mode; _ })) -> (
-    match alloc_mode with Known Heap -> true | Known Local | Unknown -> false)
+    match alloc_mode with
+    | Known Heap -> Proved ()
+    | Known Local | Unknown -> Unknown)
   | Value (Ok (Array _)) ->
     (* CR mshinwell: For this function it would now be useful to track the alloc
        mode on arrays. *)
-    false
-  | Value (Ok (String _)) -> true
-  | Value Unknown -> false
-  | Value Bottom -> true
+    Unknown
+  | Value (Ok (String _)) -> Proved ()
+  | Value Unknown -> Unknown
+  | Value Bottom -> Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    true
+    Proved ()

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -660,7 +660,10 @@ let meet_block_field_simple env ~min_name_mode t field_index :
       if TG.Row_like_for_blocks.is_bottom blocks
       then Invalid
       else
-        match (TG.Row_like_for_blocks.get_field blocks field_index : _ Or_unknown_or_bottom.t) with
+        match
+          (TG.Row_like_for_blocks.get_field blocks field_index
+            : _ Or_unknown_or_bottom.t)
+        with
         | Bottom -> Invalid
         | Unknown -> Need_meet
         | Ok ty -> (

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -29,6 +29,9 @@ let is_bottom = Expand_head.is_bottom
 let expand_head env ty =
   Expand_head.expand_head env ty |> Expand_head.Expanded_type.descr_oub
 
+let wrong_kind kind_string t =
+  Misc.fatal_errorf "Kind error: expected [%s]:@ %a" kind_string TG.print t
+
 type 'a meet_shortcut =
   | Known_result of 'a
   | Need_meet
@@ -37,33 +40,25 @@ type 'a meet_shortcut =
 type 'a proof_of_property =
   | Proved of 'a
   | Unknown
-  | Wrong_kind
-(* CR: try to find real uses and remove the rest *)
 
 type 'a generic_proof =
   | Proved of 'a
   | Unknown
   | Invalid
-  | Wrong_kind
 
-(* CR: Naming Either Sub-module or complete name *)
 let as_meet_shortcut (p : _ generic_proof) : _ meet_shortcut =
   match p with
   | Proved x -> Known_result x
   | Unknown -> Need_meet
-  (* CR: Consider fatal error for Wrong_kind *)
-  | Invalid | Wrong_kind -> Invalid
+  | Invalid -> Invalid
 
 let as_property (p : _ generic_proof) : _ proof_of_property =
-  match p with
-  | Proved x -> Proved x
-  | Unknown | Invalid -> Unknown
-  | Wrong_kind -> Wrong_kind
+  match p with Proved x -> Proved x | Unknown | Invalid -> Unknown
 
 let prove_equals_to_simple_of_kind_value env t : Simple.t proof_of_property =
   let original_kind = TG.kind t in
   if not (K.equal original_kind K.value)
-  then Wrong_kind
+  then wrong_kind "Value" t
   else
     (* CR: add TE.get_alias_opt *)
     match TG.get_alias_exn t with
@@ -104,7 +99,7 @@ let prove_is_int_generic env t : bool generic_proof =
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Wrong_kind
+    wrong_kind "Value" t
 
 let prove_is_int env t = as_property (prove_is_int_generic env t)
 
@@ -112,7 +107,7 @@ let prove_is_int env t = as_property (prove_is_int_generic env t)
    Invalid cases to prove_naked_immediates_generic, but it's not suitable for
    implementing [meet_get_tag] because it doesn't ignore the immediates part of
    the variant. *)
-(* CR: Switch to Tag.Scannable *)
+(* CR vlaviron: Switch result to Tag.Scannable *)
 let prove_get_tag_generic env t : Tag.Set.t generic_proof =
   match expand_head env t with
   | Value (Ok (Variant blocks_imms)) -> (
@@ -143,11 +138,10 @@ let prove_get_tag_generic env t : Tag.Set.t generic_proof =
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Wrong_kind
+    wrong_kind "Value" t
 
 let prove_get_tag env t = as_property (prove_get_tag_generic env t)
 
-(* CR: Specialise to meet, Wrong_kind -> fatal error *)
 let prove_naked_immediates_generic env t : Targetint_31_63.Set.t generic_proof =
   match expand_head env t with
   | Naked_immediate (Ok (Naked_immediates is)) ->
@@ -159,8 +153,7 @@ let prove_naked_immediates_generic env t : Targetint_31_63.Set.t generic_proof =
     | Proved false ->
       Proved (Targetint_31_63.Set.singleton Targetint_31_63.bool_false)
     | Unknown -> Unknown
-    | Invalid -> Invalid
-    | Wrong_kind -> Wrong_kind)
+    | Invalid -> Invalid)
   | Naked_immediate (Ok (Get_tag block_ty)) -> (
     match prove_get_tag_generic env block_ty with
     | Proved tags ->
@@ -172,17 +165,12 @@ let prove_naked_immediates_generic env t : Targetint_31_63.Set.t generic_proof =
       in
       Proved is
     | Unknown -> Unknown
-    | Invalid -> Invalid
-    | Wrong_kind -> Wrong_kind)
+    | Invalid -> Invalid)
   | Naked_immediate Unknown -> Unknown
   | Naked_immediate Bottom -> Invalid
-  | Value _ -> Wrong_kind
-  | Naked_float _ -> Wrong_kind
-  | Naked_int32 _ -> Wrong_kind
-  | Naked_int64 _ -> Wrong_kind
-  | Naked_nativeint _ -> Wrong_kind
-  | Rec_info _ -> Wrong_kind
-  | Region _ -> Wrong_kind
+  | Value _ | Naked_float _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
+  | Rec_info _ | Region _ ->
+    wrong_kind "Naked_immediate" t
 
 let meet_naked_immediates env t =
   as_meet_shortcut (prove_naked_immediates_generic env t)
@@ -202,13 +190,12 @@ let prove_equals_tagged_immediates env t : _ proof_of_property =
           match prove_naked_immediates_generic env imms with
           | Proved imms -> Proved imms
           | Invalid -> Proved Targetint_31_63.Set.empty
-          | Unknown -> Unknown
-          | Wrong_kind -> Wrong_kind)
+          | Unknown -> Unknown)
       else Unknown)
   | Value (Ok _ | Unknown | Bottom) -> Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Wrong_kind
+    wrong_kind "Value" t
 
 let meet_equals_tagged_immediates env t : _ meet_shortcut =
   match expand_head env t with
@@ -261,7 +248,7 @@ let[@inline] meet_naked_number (type a) (kind : a meet_naked_number_kind) env t
       | Int64 -> "Naked_int64"
       | Nativeint -> "Naked_nativeint"
     in
-    Misc.fatal_errorf "Kind error: expected [%s]:@ %a" kind_string TG.print t
+    wrong_kind kind_string t
   in
   match expand_head env t with
   | Value _ -> wrong_kind ()
@@ -330,8 +317,7 @@ let prove_variant_like_generic env t : variant_like_proof generic_proof =
               match prove_naked_immediates_generic env imms with
               | Unknown -> Unknown
               | Invalid -> Known Targetint_31_63.Set.empty
-              | Proved const_ctors -> Known const_ctors
-              | Wrong_kind -> Misc.fatal_error "To remove")
+              | Proved const_ctors -> Known const_ctors)
           in
           Proved { const_ctors; non_const_ctors_with_sizes })))
   | Value (Ok (Mutable_block _)) -> Unknown
@@ -344,13 +330,9 @@ let prove_variant_like_generic env t : variant_like_proof generic_proof =
     Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
-  | Naked_immediate _ -> Wrong_kind
-  | Naked_float _ -> Wrong_kind
-  | Naked_int32 _ -> Wrong_kind
-  | Naked_int64 _ -> Wrong_kind
-  | Naked_nativeint _ -> Wrong_kind
-  | Rec_info _ -> Wrong_kind
-  | Region _ -> Wrong_kind
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    wrong_kind "Value" t
 
 let meet_variant_like env t =
   as_meet_shortcut (prove_variant_like_generic env t)
@@ -379,14 +361,16 @@ let prove_is_a_boxed_or_tagged_number env t :
   | Value (Ok (Boxed_int32 _)) -> Proved (Boxed Naked_int32)
   | Value (Ok (Boxed_int64 _)) -> Proved (Boxed Naked_int64)
   | Value (Ok (Boxed_nativeint _)) -> Proved (Boxed Naked_nativeint)
-  | Value _ -> Unknown
-  | _ -> Wrong_kind
+  | Value (Bottom | Ok (Mutable_block _ | Closures _ | String _ | Array _)) ->
+    Unknown
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    wrong_kind "Value" t
 
 let prove_is_a_tagged_immediate env t : _ proof_of_property =
   match prove_is_a_boxed_or_tagged_number env t with
   | Proved Tagged_immediate -> Proved ()
   | Proved _ -> Unknown
-  | Wrong_kind -> Wrong_kind
   | Unknown -> Unknown
 
 let prove_is_a_boxed_float env t : _ proof_of_property =
@@ -394,7 +378,9 @@ let prove_is_a_boxed_float env t : _ proof_of_property =
   | Value Unknown -> Unknown
   | Value (Ok (Boxed_float _)) -> Proved ()
   | Value _ -> Unknown
-  | _ -> Wrong_kind
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    wrong_kind "Value" t
 
 let prove_is_or_is_not_a_boxed_float env t : _ proof_of_property =
   match expand_head env t with
@@ -402,28 +388,36 @@ let prove_is_or_is_not_a_boxed_float env t : _ proof_of_property =
   | Value Bottom -> Unknown
   | Value (Ok (Boxed_float _)) -> Proved true
   | Value (Ok _) -> Proved false
-  | _ -> Wrong_kind
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    wrong_kind "Value" t
 
 let prove_is_a_boxed_int32 env t : _ proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value (Ok (Boxed_int32 _)) -> Proved ()
   | Value _ -> Unknown
-  | _ -> Wrong_kind
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    wrong_kind "Value" t
 
 let prove_is_a_boxed_int64 env t : _ proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value (Ok (Boxed_int64 _)) -> Proved ()
   | Value _ -> Unknown
-  | _ -> Wrong_kind
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    wrong_kind "Value" t
 
 let prove_is_a_boxed_nativeint env t : _ proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value (Ok (Boxed_nativeint _)) -> Proved ()
   | Value _ -> Unknown
-  | _ -> Wrong_kind
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    wrong_kind "Value" t
 
 let prove_unique_tag_and_size env t :
     (Tag.t * Targetint_31_63.Imm.t) proof_of_property =
@@ -446,7 +440,7 @@ let prove_unique_tag_and_size env t :
     Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Wrong_kind
+    wrong_kind "Value" t
 
 let meet_is_flat_float_array env t : bool meet_shortcut =
   match expand_head env t with
@@ -492,8 +486,7 @@ let prove_is_immediates_array env t : unit proof_of_property =
     Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Wrong_kind
-(* Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t *)
+    wrong_kind "Value" t
 
 let prove_single_closures_entry_generic env t : _ generic_proof =
   match expand_head env t with
@@ -520,13 +513,9 @@ let prove_single_closures_entry_generic env t : _ generic_proof =
     Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
-  | Naked_immediate _ -> Wrong_kind
-  | Naked_float _ -> Wrong_kind
-  | Naked_int32 _ -> Wrong_kind
-  | Naked_int64 _ -> Wrong_kind
-  | Naked_nativeint _ -> Wrong_kind
-  | Rec_info _ -> Wrong_kind
-  | Region _ -> Wrong_kind
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    wrong_kind "Value" t
 
 let meet_single_closures_entry env t =
   as_meet_shortcut (prove_single_closures_entry_generic env t)
@@ -586,7 +575,7 @@ let[@inline always] inspect_tagging_of_simple proof_kind env ~min_name_mode t :
   | Value _ -> Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Wrong_kind
+    wrong_kind "Value" t
 
 let prove_tagging_of_simple env ~min_name_mode t =
   as_property (inspect_tagging_of_simple Prove env ~min_name_mode t)
@@ -650,9 +639,6 @@ let meet_boxed_nativeint_containing_simple =
 
 let meet_block_field_simple env ~min_name_mode t field_index :
     Simple.t meet_shortcut =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
-  in
   match expand_head env t with
   | Value
       (Ok (Variant { immediates = _; blocks; is_unique = _; alloc_mode = _ }))
@@ -682,13 +668,10 @@ let meet_block_field_simple env ~min_name_mode t field_index :
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    wrong_kind ()
+    wrong_kind "Value" t
 
 let meet_project_function_slot_simple env ~min_name_mode t function_slot :
     Simple.t meet_shortcut =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
-  in
   match expand_head env t with
   | Value (Ok (Closures { by_function_slot; alloc_mode = _ })) -> (
     match
@@ -707,13 +690,10 @@ let meet_project_function_slot_simple env ~min_name_mode t function_slot :
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    wrong_kind ()
+    wrong_kind "Value" t
 
 let meet_project_value_slot_simple env ~min_name_mode t env_var :
     Simple.t meet_shortcut =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
-  in
   match expand_head env t with
   | Value (Ok (Closures { by_function_slot; alloc_mode = _ })) -> (
     match TG.Row_like_for_closures.get_env_var by_function_slot env_var with
@@ -730,19 +710,16 @@ let meet_project_value_slot_simple env ~min_name_mode t env_var :
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    wrong_kind ()
+    wrong_kind "Value" t
 
 let meet_rec_info env t : Rec_info_expr.t meet_shortcut =
-  let wrong_kind () =
-    Misc.fatal_errorf "Kind error: expected [Rec_info]:@ %a" TG.print t
-  in
   match expand_head env t with
   | Rec_info (Ok rec_info_expr) -> Known_result rec_info_expr
   | Rec_info Unknown -> Need_meet
   | Rec_info Bottom -> Invalid
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Region _ ->
-    wrong_kind ()
+    wrong_kind "Rec_info" t
 
 let prove_alloc_mode_of_boxed_number env t : Alloc_mode.t proof_of_property =
   match expand_head env t with
@@ -758,7 +735,7 @@ let prove_alloc_mode_of_boxed_number env t : Alloc_mode.t proof_of_property =
     Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Wrong_kind
+    wrong_kind "Value" t
 
 let never_holds_locally_allocated_values env var kind : _ proof_of_property =
   let t = TE.find env (Name.var var) (Some kind) in

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -29,9 +29,9 @@ let is_bottom = Expand_head.is_bottom
 let expand_head env ty =
   Expand_head.expand_head env ty |> Expand_head.Expanded_type.descr_oub
 
-type 'a proof_of_operation =
+type 'a meet_shortcut =
   | Known_result of 'a
-  | Unknown
+  | Need_meet
   | Invalid
 
 type 'a proof_of_property =
@@ -45,10 +45,10 @@ type 'a generic_proof =
   | Invalid
   | Wrong_kind
 
-let as_operation (p : _ generic_proof) : _ proof_of_operation =
+let as_meet_shortcut (p : _ generic_proof) : _ meet_shortcut =
   match p with
   | Proved x -> Known_result x
-  | Unknown -> Unknown
+  | Unknown -> Need_meet
   | Invalid | Wrong_kind -> Invalid
 
 let as_property (p : _ generic_proof) : _ proof_of_property =
@@ -106,7 +106,7 @@ let prove_is_int env t = as_property (prove_is_int_generic env t)
 
 (* Note: this function returns a generic proof because we want to propagate the
    Invalid cases to prove_naked_immediates_generic, but it's not suitable for
-   implementing [check_get_tag] because it doesn't ignore the immediates part of
+   implementing [meet_get_tag] because it doesn't ignore the immediates part of
    the variant. *)
 let prove_get_tag_generic env t : Tag.Set.t generic_proof =
   match expand_head env t with
@@ -178,8 +178,8 @@ let prove_naked_immediates_generic env t : Targetint_31_63.Set.t generic_proof =
   | Rec_info _ -> Wrong_kind
   | Region _ -> Wrong_kind
 
-let check_naked_immediates env t =
-  as_operation (prove_naked_immediates_generic env t)
+let meet_naked_immediates env t =
+  as_meet_shortcut (prove_naked_immediates_generic env t)
 
 let prove_equals_tagged_immediates env t : _ proof_of_property =
   match expand_head env t with
@@ -193,51 +193,51 @@ let prove_equals_tagged_immediates env t : _ proof_of_property =
         match immediates with
         | Unknown -> Unknown
         | Known imms -> (
-          match check_naked_immediates env imms with
+          match meet_naked_immediates env imms with
           | Known_result imms -> Proved imms
-          | Invalid | Unknown -> Unknown)
+          | Invalid | Need_meet -> Unknown)
       else Unknown)
   | Value (Ok _ | Unknown | Bottom) -> Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Wrong_kind
 
-let check_equals_tagged_immediates env t : _ proof_of_operation =
+let meet_equals_tagged_immediates env t : _ meet_shortcut =
   match expand_head env t with
   | Value
       (Ok (Variant { immediates; blocks = _; is_unique = _; alloc_mode = _ }))
     -> (
     match immediates with
-    | Unknown -> Unknown
-    | Known imms -> check_naked_immediates env imms)
-  | Value (Ok _ | Unknown) -> Unknown
+    | Unknown -> Need_meet
+    | Known imms -> meet_naked_immediates env imms)
+  | Value (Ok _ | Unknown) -> Need_meet
   | Value Bottom
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Invalid
 
-let check_equals_single_tagged_immediate env t : _ proof_of_operation =
-  match check_equals_tagged_immediates env t with
+let meet_equals_single_tagged_immediate env t : _ meet_shortcut =
+  match meet_equals_tagged_immediates env t with
   | Known_result imms -> (
     match Targetint_31_63.Set.get_singleton imms with
     | Some imm -> Known_result imm
-    | None -> Unknown)
-  | Unknown -> Unknown
+    | None -> Need_meet)
+  | Need_meet -> Need_meet
   | Invalid -> Invalid
 
-type _ check_naked_number_kind =
-  | Float : Float.Set.t check_naked_number_kind
-  | Int32 : Int32.Set.t check_naked_number_kind
-  | Int64 : Int64.Set.t check_naked_number_kind
-  | Nativeint : Targetint_32_64.Set.t check_naked_number_kind
+type _ meet_naked_number_kind =
+  | Float : Float.Set.t meet_naked_number_kind
+  | Int32 : Int32.Set.t meet_naked_number_kind
+  | Int64 : Int64.Set.t meet_naked_number_kind
+  | Nativeint : Targetint_32_64.Set.t meet_naked_number_kind
 
-let check_naked_number (type a) (kind : a check_naked_number_kind) env t :
-    a proof_of_operation =
+let meet_naked_number (type a) (kind : a meet_naked_number_kind) env t :
+    a meet_shortcut =
   let set_oub_to_proof (set_oub : _ Or_unknown_or_bottom.t) ~is_empty :
-      _ proof_of_operation =
+      _ meet_shortcut =
     match set_oub with
     | Ok set -> if is_empty set then Invalid else Known_result set
-    | Unknown -> Unknown
+    | Unknown -> Need_meet
     | Bottom -> Invalid
   in
   match expand_head env t with
@@ -262,13 +262,13 @@ let check_naked_number (type a) (kind : a check_naked_number_kind) env t :
     | Nativeint -> set_oub_to_proof is ~is_empty:Targetint_32_64.Set.is_empty
     | _ -> Invalid)
 
-let check_naked_floats = check_naked_number Float
+let meet_naked_floats = meet_naked_number Float
 
-let check_naked_int32s = check_naked_number Int32
+let meet_naked_int32s = meet_naked_number Int32
 
-let check_naked_int64s = check_naked_number Int64
+let meet_naked_int64s = meet_naked_number Int64
 
-let check_naked_nativeints = check_naked_number Nativeint
+let meet_naked_nativeints = meet_naked_number Nativeint
 
 type variant_like_proof =
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
@@ -303,8 +303,8 @@ let prove_variant_like_generic env t : variant_like_proof generic_proof =
             match blocks_imms.immediates with
             | Unknown -> Unknown
             | Known imms -> (
-              match check_naked_immediates env imms with
-              | Unknown -> Unknown
+              match meet_naked_immediates env imms with
+              | Need_meet -> Unknown
               | Invalid -> Known Targetint_31_63.Set.empty
               | Known_result const_ctors -> Known const_ctors)
           in
@@ -321,7 +321,8 @@ let prove_variant_like_generic env t : variant_like_proof generic_proof =
   | Rec_info _ -> Wrong_kind
   | Region _ -> Wrong_kind
 
-let check_variant_like env t = as_operation (prove_variant_like_generic env t)
+let meet_variant_like env t =
+  as_meet_shortcut (prove_variant_like_generic env t)
 
 let prove_variant_like env t = as_property (prove_variant_like_generic env t)
 
@@ -392,31 +393,31 @@ let prove_is_a_boxed_nativeint env t : _ proof_of_property =
   | Value _ -> Unknown
   | _ -> Wrong_kind
 
-let check_boxed_floats env t : _ proof_of_operation =
+let meet_boxed_floats env t : _ meet_shortcut =
   match expand_head env t with
-  | Value Unknown -> Unknown
-  | Value (Ok (Boxed_float (ty, _mode))) -> check_naked_floats env ty
+  | Value Unknown -> Need_meet
+  | Value (Ok (Boxed_float (ty, _mode))) -> meet_naked_floats env ty
   | Value _ -> Invalid
   | _ -> Invalid
 
-let check_boxed_int32s env t : _ proof_of_operation =
+let meet_boxed_int32s env t : _ meet_shortcut =
   match expand_head env t with
-  | Value Unknown -> Unknown
-  | Value (Ok (Boxed_int32 (ty, _mode))) -> check_naked_int32s env ty
+  | Value Unknown -> Need_meet
+  | Value (Ok (Boxed_int32 (ty, _mode))) -> meet_naked_int32s env ty
   | Value _ -> Invalid
   | _ -> Invalid
 
-let check_boxed_int64s env t : _ proof_of_operation =
+let meet_boxed_int64s env t : _ meet_shortcut =
   match expand_head env t with
-  | Value Unknown -> Unknown
-  | Value (Ok (Boxed_int64 (ty, _mode))) -> check_naked_int64s env ty
+  | Value Unknown -> Need_meet
+  | Value (Ok (Boxed_int64 (ty, _mode))) -> meet_naked_int64s env ty
   | Value _ -> Invalid
   | _ -> Invalid
 
-let check_boxed_nativeints env t : _ proof_of_operation =
+let meet_boxed_nativeints env t : _ meet_shortcut =
   match expand_head env t with
-  | Value Unknown -> Unknown
-  | Value (Ok (Boxed_nativeint (ty, _mode))) -> check_naked_nativeints env ty
+  | Value Unknown -> Need_meet
+  | Value (Ok (Boxed_nativeint (ty, _mode))) -> meet_naked_nativeints env ty
   | Value _ -> Invalid
   | _ -> Invalid
 
@@ -448,12 +449,11 @@ type array_kind_compatibility =
   | Compatible
   | Incompatible
 
-let check_is_array_with_element_kind env t ~element_kind : _ proof_of_operation
-    =
+let meet_is_array_with_element_kind env t ~element_kind : _ meet_shortcut =
   match expand_head env t with
-  | Value Unknown -> Unknown
+  | Value Unknown -> Need_meet
   | Value Bottom -> Invalid
-  | Value (Ok (Array { element_kind = Unknown; _ })) -> Unknown
+  | Value (Ok (Array { element_kind = Unknown; _ })) -> Need_meet
   | Value (Ok (Array { element_kind = Known element_kind'; _ })) ->
     if K.With_subkind.equal element_kind' element_kind
     then Known_result Exact
@@ -466,7 +466,7 @@ let check_is_array_with_element_kind env t ~element_kind : _ proof_of_operation
     (* CR vlaviron: This case is here to avoiding breaking code such as:
      * Array.get (Obj.magic (0, 0)) 1
      * If we decide that this code should segfault, we could return Invalid. *)
-    Unknown
+    Need_meet
   | Value (Ok _)
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
@@ -504,17 +504,17 @@ let prove_single_closures_entry_generic env t : _ generic_proof =
   | Rec_info _ -> Wrong_kind
   | Region _ -> Wrong_kind
 
-let check_single_closures_entry env t =
-  as_operation (prove_single_closures_entry_generic env t)
+let meet_single_closures_entry env t =
+  as_meet_shortcut (prove_single_closures_entry_generic env t)
 
 let prove_single_closures_entry env t =
   as_property (prove_single_closures_entry_generic env t)
 
-let check_strings env t : String_info.Set.t proof_of_operation =
+let meet_strings env t : String_info.Set.t meet_shortcut =
   match expand_head env t with
   | Value (Ok (String strs)) -> Known_result strs
   | Value (Ok _) -> Invalid
-  | Value Unknown -> Unknown
+  | Value Unknown -> Need_meet
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
@@ -543,8 +543,8 @@ let prove_tagging_of_simple_aux proof_kind env ~min_name_mode t :
         match from_alias with
         | Some simple -> Proved simple
         | None -> (
-          match check_naked_immediates env t with
-          | Unknown -> Unknown
+          match meet_naked_immediates env t with
+          | Need_meet -> Unknown
           | Invalid -> Invalid
           | Known_result imms -> (
             match Targetint_31_63.Set.get_singleton imms with
@@ -567,12 +567,11 @@ let prove_tagging_of_simple_aux proof_kind env ~min_name_mode t :
 let prove_tagging_of_simple env ~min_name_mode t =
   as_property (prove_tagging_of_simple_aux Prove env ~min_name_mode t)
 
-let check_tagging_of_simple env ~min_name_mode t =
-  as_operation (prove_tagging_of_simple_aux Check env ~min_name_mode t)
+let meet_tagging_of_simple env ~min_name_mode t =
+  as_meet_shortcut (prove_tagging_of_simple_aux Check env ~min_name_mode t)
 
-let[@inline always] check_boxed_number_containing_simple
-    ~contents_of_boxed_number env ~min_name_mode t : Simple.t proof_of_operation
-    =
+let[@inline always] meet_boxed_number_containing_simple
+    ~contents_of_boxed_number env ~min_name_mode t : Simple.t meet_shortcut =
   match expand_head env t with
   | Value (Ok ty_value) -> (
     match contents_of_boxed_number ty_value with
@@ -582,15 +581,15 @@ let[@inline always] check_boxed_number_containing_simple
         TE.get_canonical_simple_exn env ~min_name_mode (TG.get_alias_exn ty)
       with
       | simple -> Known_result simple
-      | exception Not_found -> Unknown))
-  | Value Unknown -> Unknown
+      | exception Not_found -> Need_meet))
+  | Value Unknown -> Need_meet
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
 
-let check_boxed_float_containing_simple =
-  check_boxed_number_containing_simple
+let meet_boxed_float_containing_simple =
+  meet_boxed_number_containing_simple
     ~contents_of_boxed_number:(fun (ty_value : TG.head_of_kind_value) ->
       match ty_value with
       | Boxed_float (ty, _) -> Some ty
@@ -598,8 +597,8 @@ let check_boxed_float_containing_simple =
       | Boxed_nativeint _ | Closures _ | String _ | Array _ ->
         None)
 
-let check_boxed_int32_containing_simple =
-  check_boxed_number_containing_simple
+let meet_boxed_int32_containing_simple =
+  meet_boxed_number_containing_simple
     ~contents_of_boxed_number:(fun (ty_value : TG.head_of_kind_value) ->
       match ty_value with
       | Boxed_int32 (ty, _) -> Some ty
@@ -607,8 +606,8 @@ let check_boxed_int32_containing_simple =
       | Boxed_nativeint _ | Closures _ | String _ | Array _ ->
         None)
 
-let check_boxed_int64_containing_simple =
-  check_boxed_number_containing_simple
+let meet_boxed_int64_containing_simple =
+  meet_boxed_number_containing_simple
     ~contents_of_boxed_number:(fun (ty_value : TG.head_of_kind_value) ->
       match ty_value with
       | Boxed_int64 (ty, _) -> Some ty
@@ -616,8 +615,8 @@ let check_boxed_int64_containing_simple =
       | Boxed_nativeint _ | Closures _ | String _ | Array _ ->
         None)
 
-let check_boxed_nativeint_containing_simple =
-  check_boxed_number_containing_simple
+let meet_boxed_nativeint_containing_simple =
+  meet_boxed_number_containing_simple
     ~contents_of_boxed_number:(fun (ty_value : TG.head_of_kind_value) ->
       match ty_value with
       | Boxed_nativeint (ty, _) -> Some ty
@@ -625,8 +624,8 @@ let check_boxed_nativeint_containing_simple =
       | Boxed_int64 _ | Closures _ | String _ | Array _ ->
         None)
 
-let[@inline] check_block_field_simple_aux env ~min_name_mode t get_field :
-    Simple.t proof_of_operation =
+let[@inline] meet_block_field_simple_aux env ~min_name_mode t get_field :
+    Simple.t meet_shortcut =
   let wrong_kind () =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
@@ -635,43 +634,43 @@ let[@inline] check_block_field_simple_aux env ~min_name_mode t get_field :
       (Ok (Variant { immediates = _; blocks; is_unique = _; alloc_mode = _ }))
     -> (
     match blocks with
-    | Unknown -> Unknown
+    | Unknown -> Need_meet
     | Known blocks -> (
       if TG.Row_like_for_blocks.is_bottom blocks
       then Invalid
       else
         match (get_field blocks : _ Or_unknown_or_bottom.t) with
         | Bottom -> Invalid
-        | Unknown -> Unknown
+        | Unknown -> Need_meet
         | Ok ty -> (
           match TG.get_alias_exn ty with
           | simple -> (
             match TE.get_canonical_simple_exn env ~min_name_mode simple with
             | simple -> Known_result simple
-            | exception Not_found -> Unknown)
-          | exception Not_found -> Unknown)))
-  | Value (Ok (Mutable_block _)) -> Unknown
+            | exception Not_found -> Need_meet)
+          | exception Not_found -> Need_meet)))
+  | Value (Ok (Mutable_block _)) -> Need_meet
   | Value (Ok _) -> Invalid
-  | Value Unknown -> Unknown
+  | Value Unknown -> Need_meet
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     wrong_kind ()
 
-let check_block_field_simple env ~min_name_mode t field_index =
+let meet_block_field_simple env ~min_name_mode t field_index =
   let[@inline] get blocks =
     TG.Row_like_for_blocks.get_field blocks field_index
   in
-  (check_block_field_simple_aux [@inlined]) env ~min_name_mode t get
+  (meet_block_field_simple_aux [@inlined]) env ~min_name_mode t get
 
-let check_variant_field_simple env ~min_name_mode t variant_tag field_index =
+let meet_variant_field_simple env ~min_name_mode t variant_tag field_index =
   let[@inline] get blocks =
     TG.Row_like_for_blocks.get_variant_field blocks variant_tag field_index
   in
-  (check_block_field_simple_aux [@inlined]) env ~min_name_mode t get
+  (meet_block_field_simple_aux [@inlined]) env ~min_name_mode t get
 
-let check_project_function_slot_simple env ~min_name_mode t function_slot :
-    Simple.t proof_of_operation =
+let meet_project_function_slot_simple env ~min_name_mode t function_slot :
+    Simple.t meet_shortcut =
   let wrong_kind () =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
@@ -680,51 +679,51 @@ let check_project_function_slot_simple env ~min_name_mode t function_slot :
     match
       TG.Row_like_for_closures.get_closure by_function_slot function_slot
     with
-    | Unknown -> Unknown
+    | Unknown -> Need_meet
     | Known ty -> (
       match TG.get_alias_exn ty with
       | simple -> (
         match TE.get_canonical_simple_exn env ~min_name_mode simple with
         | simple -> Known_result simple
-        | exception Not_found -> Unknown)
-      | exception Not_found -> Unknown))
+        | exception Not_found -> Need_meet)
+      | exception Not_found -> Need_meet))
   | Value (Ok _) -> Invalid
-  | Value Unknown -> Unknown
+  | Value Unknown -> Need_meet
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     wrong_kind ()
 
-let check_project_value_slot_simple env ~min_name_mode t env_var :
-    Simple.t proof_of_operation =
+let meet_project_value_slot_simple env ~min_name_mode t env_var :
+    Simple.t meet_shortcut =
   let wrong_kind () =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
   match expand_head env t with
   | Value (Ok (Closures { by_function_slot; alloc_mode = _ })) -> (
     match TG.Row_like_for_closures.get_env_var by_function_slot env_var with
-    | Unknown -> Unknown
+    | Unknown -> Need_meet
     | Known ty -> (
       match TG.get_alias_exn ty with
       | simple -> (
         match TE.get_canonical_simple_exn env ~min_name_mode simple with
         | simple -> Known_result simple
-        | exception Not_found -> Unknown)
-      | exception Not_found -> Unknown))
+        | exception Not_found -> Need_meet)
+      | exception Not_found -> Need_meet))
   | Value (Ok _) -> Invalid
-  | Value Unknown -> Unknown
+  | Value Unknown -> Need_meet
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     wrong_kind ()
 
-let check_rec_info env t : Rec_info_expr.t proof_of_operation =
+let meet_rec_info env t : Rec_info_expr.t meet_shortcut =
   let wrong_kind () =
     Misc.fatal_errorf "Kind error: expected [Rec_info]:@ %a" TG.print t
   in
   match expand_head env t with
   | Rec_info (Ok rec_info_expr) -> Known_result rec_info_expr
-  | Rec_info Unknown -> Unknown
+  | Rec_info Unknown -> Need_meet
   | Rec_info Bottom -> Invalid
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Region _ ->

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -543,14 +543,14 @@ let meet_strings env t : String_info.Set.t meet_shortcut =
 
 type tagging_proof_kind =
   | Prove
-  | Check
+  | Meet
 
-let prove_tagging_of_simple_aux proof_kind env ~min_name_mode t :
+let[@inline always] inspect_tagging_of_simple proof_kind env ~min_name_mode t :
     Simple.t generic_proof =
   match expand_head env t with
   | Value (Ok (Variant { immediates; blocks; is_unique = _; alloc_mode = _ }))
     -> (
-    let prove_immediates () =
+    let inspect_immediates () =
       match immediates with
       | Unknown -> Unknown
       | Known t -> (
@@ -577,19 +577,19 @@ let prove_tagging_of_simple_aux proof_kind env ~min_name_mode t :
     | Prove, Unknown -> Unknown
     | Prove, Known blocks ->
       if TG.Row_like_for_blocks.is_bottom blocks
-      then prove_immediates ()
+      then inspect_immediates ()
       else Unknown
-    | Check, _ -> prove_immediates ())
+    | Meet, _ -> inspect_immediates ())
   | Value _ -> Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Wrong_kind
 
 let prove_tagging_of_simple env ~min_name_mode t =
-  as_property (prove_tagging_of_simple_aux Prove env ~min_name_mode t)
+  as_property (inspect_tagging_of_simple Prove env ~min_name_mode t)
 
 let meet_tagging_of_simple env ~min_name_mode t =
-  as_meet_shortcut (prove_tagging_of_simple_aux Check env ~min_name_mode t)
+  as_meet_shortcut (inspect_tagging_of_simple Meet env ~min_name_mode t)
 
 let[@inline always] meet_boxed_number_containing_simple
     ~contents_of_boxed_number env ~min_name_mode t : Simple.t meet_shortcut =
@@ -645,7 +645,7 @@ let meet_boxed_nativeint_containing_simple =
       | Boxed_int64 _ | Closures _ | String _ | Array _ ->
         None)
 
-let[@inline] meet_block_field_simple_aux env ~min_name_mode t get_field :
+let meet_block_field_simple env ~min_name_mode t field_index :
     Simple.t meet_shortcut =
   let wrong_kind () =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
@@ -660,7 +660,7 @@ let[@inline] meet_block_field_simple_aux env ~min_name_mode t get_field :
       if TG.Row_like_for_blocks.is_bottom blocks
       then Invalid
       else
-        match (get_field blocks : _ Or_unknown_or_bottom.t) with
+        match (TG.Row_like_for_blocks.get_field blocks field_index : _ Or_unknown_or_bottom.t) with
         | Bottom -> Invalid
         | Unknown -> Need_meet
         | Ok ty -> (
@@ -677,18 +677,6 @@ let[@inline] meet_block_field_simple_aux env ~min_name_mode t get_field :
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     wrong_kind ()
-
-let meet_block_field_simple env ~min_name_mode t field_index =
-  let[@inline] get blocks =
-    TG.Row_like_for_blocks.get_field blocks field_index
-  in
-  (meet_block_field_simple_aux [@inlined]) env ~min_name_mode t get
-
-let meet_variant_field_simple env ~min_name_mode t variant_tag field_index =
-  let[@inline] get blocks =
-    TG.Row_like_for_blocks.get_variant_field blocks variant_tag field_index
-  in
-  (meet_block_field_simple_aux [@inlined]) env ~min_name_mode t get
 
 let meet_project_function_slot_simple env ~min_name_mode t function_slot :
     Simple.t meet_shortcut =

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -37,7 +37,7 @@ type 'a meet_shortcut =
 type 'a proof_of_property =
   | Proved of 'a
   | Unknown
-  | Wrong_kind
+  | Wrong_kind (* CR: try to find real uses and remove the rest *)
 
 type 'a generic_proof =
   | Proved of 'a
@@ -45,10 +45,13 @@ type 'a generic_proof =
   | Invalid
   | Wrong_kind
 
+(* CR: Naming
+   Either Sub-module or complete name *)
 let as_meet_shortcut (p : _ generic_proof) : _ meet_shortcut =
   match p with
   | Proved x -> Known_result x
   | Unknown -> Need_meet
+  (* CR: Consider fatal error for Wrong_kind *)
   | Invalid | Wrong_kind -> Invalid
 
 let as_property (p : _ generic_proof) : _ proof_of_property =
@@ -62,6 +65,7 @@ let prove_equals_to_simple_of_kind_value env t : Simple.t proof_of_property =
   if not (K.equal original_kind K.value)
   then Wrong_kind
   else
+    (* CR: add TE.get_alias_opt *)
     match TG.get_alias_exn t with
     | exception Not_found ->
       (* CR vlaviron: We could try to turn singleton types into constants here.
@@ -108,6 +112,7 @@ let prove_is_int env t = as_property (prove_is_int_generic env t)
    Invalid cases to prove_naked_immediates_generic, but it's not suitable for
    implementing [meet_get_tag] because it doesn't ignore the immediates part of
    the variant. *)
+(* CR: Switch to Tag.Scannable *)
 let prove_get_tag_generic env t : Tag.Set.t generic_proof =
   match expand_head env t with
   | Value (Ok (Variant blocks_imms)) -> (
@@ -142,6 +147,7 @@ let prove_get_tag_generic env t : Tag.Set.t generic_proof =
 
 let prove_get_tag env t = as_property (prove_get_tag_generic env t)
 
+(* CR: Specialise to meet, Wrong_kind -> fatal error *)
 let prove_naked_immediates_generic env t : Targetint_31_63.Set.t generic_proof =
   match expand_head env t with
   | Naked_immediate (Ok (Naked_immediates is)) ->
@@ -193,9 +199,11 @@ let prove_equals_tagged_immediates env t : _ proof_of_property =
         match immediates with
         | Unknown -> Unknown
         | Known imms -> (
-          match meet_naked_immediates env imms with
-          | Known_result imms -> Proved imms
-          | Invalid | Need_meet -> Unknown)
+          match prove_naked_immediates_generic env imms with
+          | Proved imms -> Proved imms
+          | Invalid -> Proved Targetint_31_63.Set.empty
+          | Unknown -> Unknown
+          | Wrong_kind -> Wrong_kind)
       else Unknown)
   | Value (Ok _ | Unknown | Bottom) -> Unknown
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
@@ -210,7 +218,9 @@ let meet_equals_tagged_immediates env t : _ meet_shortcut =
     match immediates with
     | Unknown -> Need_meet
     | Known imms -> meet_naked_immediates env imms)
-  | Value (Ok _ | Unknown) -> Need_meet
+  | Value (Ok (Mutable_block _ | Boxed_float _ | Boxed_int32 _| Boxed_int64 _ 
+              | Boxed_nativeint _|Closures _|String _|Array _)) -> Invalid
+  | Value Unknown -> Need_meet
   | Value Bottom
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
@@ -231,36 +241,45 @@ type _ meet_naked_number_kind =
   | Int64 : Int64.Set.t meet_naked_number_kind
   | Nativeint : Targetint_32_64.Set.t meet_naked_number_kind
 
-let meet_naked_number (type a) (kind : a meet_naked_number_kind) env t :
+let[@inline] meet_naked_number (type a) (kind : a meet_naked_number_kind) env t :
     a meet_shortcut =
-  let set_oub_to_proof (set_oub : _ Or_unknown_or_bottom.t) ~is_empty :
+  let head_to_proof (head : _ Or_unknown_or_bottom.t) ~is_empty :
       _ meet_shortcut =
-    match set_oub with
+    match head with
     | Ok set -> if is_empty set then Invalid else Known_result set
     | Unknown -> Need_meet
     | Bottom -> Invalid
   in
+  let wrong_kind () =
+    let kind_string = match kind with
+      | Float -> "Naked_float"
+      | Int32 -> "Naked_int32"
+      | Int64 -> "Naked_int64"
+      | Nativeint -> "Naked_nativeint"
+    in
+    Misc.fatal_errorf "Kind error: expected [%s]:@ %a" kind_string TG.print t
+  in
   match expand_head env t with
-  | Value _ -> Invalid
-  | Naked_immediate _ -> Invalid
-  | Rec_info _ -> Invalid
-  | Region _ -> Invalid
+  | Value _ -> wrong_kind ()
+  | Naked_immediate _ -> wrong_kind ()
+  | Rec_info _ -> wrong_kind ()
+  | Region _ -> wrong_kind ()
   | Naked_float fs -> (
     match kind with
-    | Float -> set_oub_to_proof fs ~is_empty:Float.Set.is_empty
-    | _ -> Invalid)
+    | Float -> head_to_proof fs ~is_empty:Float.Set.is_empty
+    | _ -> wrong_kind ())
   | Naked_int32 is -> (
     match kind with
-    | Int32 -> set_oub_to_proof is ~is_empty:Int32.Set.is_empty
-    | _ -> Invalid)
+    | Int32 -> head_to_proof is ~is_empty:Int32.Set.is_empty
+    | _ -> wrong_kind ())
   | Naked_int64 is -> (
     match kind with
-    | Int64 -> set_oub_to_proof is ~is_empty:Int64.Set.is_empty
-    | _ -> Invalid)
+    | Int64 -> head_to_proof is ~is_empty:Int64.Set.is_empty
+    | _ -> wrong_kind ())
   | Naked_nativeint is -> (
     match kind with
-    | Nativeint -> set_oub_to_proof is ~is_empty:Targetint_32_64.Set.is_empty
-    | _ -> Invalid)
+    | Nativeint -> head_to_proof is ~is_empty:Targetint_32_64.Set.is_empty
+    | _ -> wrong_kind ())
 
 let meet_naked_floats = meet_naked_number Float
 
@@ -285,6 +304,7 @@ let prove_variant_like_generic env t : variant_like_proof generic_proof =
       | Unknown -> Unknown
       | Known non_const_ctors_with_sizes -> (
         let non_const_ctors_with_sizes =
+          (* CR: we could ignore non-scannable tags for the meet_ version *)
           Tag.Map.fold
             (fun tag size (result : _ Or_unknown.t) : _ Or_unknown.t ->
               match result with
@@ -303,14 +323,17 @@ let prove_variant_like_generic env t : variant_like_proof generic_proof =
             match blocks_imms.immediates with
             | Unknown -> Unknown
             | Known imms -> (
-              match meet_naked_immediates env imms with
-              | Need_meet -> Unknown
+              match prove_naked_immediates_generic env imms with
+              | Unknown -> Unknown
               | Invalid -> Known Targetint_31_63.Set.empty
-              | Known_result const_ctors -> Known const_ctors)
+              | Proved const_ctors -> Known const_ctors
+              | Wrong_kind -> Misc.fatal_error "To remove")
           in
           Proved { const_ctors; non_const_ctors_with_sizes })))
   | Value (Ok (Mutable_block _)) -> Unknown
-  | Value (Ok _) -> Invalid
+  | Value (Ok (Array _)) -> Unknown (* We could return Invalid in a strict mode *)
+  | Value (Ok (Closures _| Boxed_float _|Boxed_int32 _|Boxed_int64 _|
+     Boxed_nativeint _|String _)) -> Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
   | Naked_immediate _ -> Wrong_kind
@@ -330,6 +353,7 @@ type boxed_or_tagged_number =
   | Boxed of Flambda_kind.Boxable_number.t
   | Tagged_immediate
 
+(* CR: Remove fragile matchs and reuse this function *)
 let prove_is_a_boxed_or_tagged_number env t :
     boxed_or_tagged_number proof_of_property =
   match expand_head env t with
@@ -393,34 +417,6 @@ let prove_is_a_boxed_nativeint env t : _ proof_of_property =
   | Value _ -> Unknown
   | _ -> Wrong_kind
 
-let meet_boxed_floats env t : _ meet_shortcut =
-  match expand_head env t with
-  | Value Unknown -> Need_meet
-  | Value (Ok (Boxed_float (ty, _mode))) -> meet_naked_floats env ty
-  | Value _ -> Invalid
-  | _ -> Invalid
-
-let meet_boxed_int32s env t : _ meet_shortcut =
-  match expand_head env t with
-  | Value Unknown -> Need_meet
-  | Value (Ok (Boxed_int32 (ty, _mode))) -> meet_naked_int32s env ty
-  | Value _ -> Invalid
-  | _ -> Invalid
-
-let meet_boxed_int64s env t : _ meet_shortcut =
-  match expand_head env t with
-  | Value Unknown -> Need_meet
-  | Value (Ok (Boxed_int64 (ty, _mode))) -> meet_naked_int64s env ty
-  | Value _ -> Invalid
-  | _ -> Invalid
-
-let meet_boxed_nativeints env t : _ meet_shortcut =
-  match expand_head env t with
-  | Value Unknown -> Need_meet
-  | Value (Ok (Boxed_nativeint (ty, _mode))) -> meet_naked_nativeints env ty
-  | Value _ -> Invalid
-  | _ -> Invalid
-
 let prove_unique_tag_and_size env t :
     (Tag.t * Targetint_31_63.Imm.t) proof_of_property =
   match expand_head env t with
@@ -449,6 +445,24 @@ type array_kind_compatibility =
   | Compatible
   | Incompatible
 
+let prove_is_flat_float_array env t : bool proof_of_property =
+  match expand_head env t with
+  | Value (Unknown | Bottom) -> Unknown
+  | Value (Ok (Array { element_kind = Unknown; _ })) -> Unknown
+  | Value (Ok (Array { element_kind = Known element_kind; _ })) ->
+    begin match K.With_subkind.kind element_kind with
+      | Value -> Proved false
+      | Naked_number Naked_float -> Proved true
+      | Naked_number (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint) | Region | Rec_info ->
+        Misc.fatal_errorf "Wrong element kind for array: %a" K.With_subkind.print element_kind
+    end
+  | Value (Ok (Variant _ | Mutable_block _| Boxed_float _|Boxed_int32 _|Boxed_int64 _|
+     Boxed_nativeint _|Closures _|String _)) -> Unknown
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    Wrong_kind
+    (* Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t *)
+
 let meet_is_array_with_element_kind env t ~element_kind : _ meet_shortcut =
   match expand_head env t with
   | Value Unknown -> Need_meet
@@ -462,15 +476,16 @@ let meet_is_array_with_element_kind env t ~element_kind : _ meet_shortcut =
                  ~when_used_at:element_kind
     then Known_result Compatible
     else Known_result Incompatible
-  | Value (Ok (Variant _)) ->
+  | Value (Ok (Variant _ | Mutable_block _)) ->
     (* CR vlaviron: This case is here to avoiding breaking code such as:
      * Array.get (Obj.magic (0, 0)) 1
      * If we decide that this code should segfault, we could return Invalid. *)
     Need_meet
-  | Value (Ok _)
+  | Value (Ok (Boxed_float _|Boxed_int32 _|Boxed_int64 _|
+     Boxed_nativeint _|Closures _|String _)) -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Invalid
+    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
 
 let prove_single_closures_entry_generic env t : _ generic_proof =
   match expand_head env t with
@@ -486,7 +501,8 @@ let prove_single_closures_entry_generic env t : _ generic_proof =
         TG.Closures_entry.find_function_type closures_entry function_slot
       in
       match function_type with
-      | Bottom | Unknown -> Unknown
+      | Bottom -> Invalid
+      | Unknown -> Unknown
       | Ok function_type ->
         Proved (function_slot, alloc_mode, closures_entry, function_type)))
   | Value
@@ -518,7 +534,7 @@ let meet_strings env t : String_info.Set.t meet_shortcut =
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->
-    Invalid
+    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
 
 type tagging_proof_kind =
   | Prove

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -16,12 +16,14 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-(** A [proof_of_operation] gives us the result of a particular operation. The
-    corresponding functions provide efficient alternatives to the generic meet
-    function, with similar semantics. *)
-type 'a proof_of_operation = private
+(** A [meet_shortcut] gives us the result of a particular operation. There are
+    various cases where we meet with a shape containing a particular variable
+    and make decisions depending on the type associated to that variable. But a
+    generic meet can be expensive, so this file contains functions that can
+    return an equivalent result in the easy cases. *)
+type 'a meet_shortcut = private
   | Known_result of 'a  (** Result has been succesfully computed *)
-  | Unknown  (** Exact result could not be computed or is Top *)
+  | Need_meet  (** Exact result could not be computed or is Top *)
   | Invalid  (** Result is Bottom *)
 
 (** A [proof_of_property] tells us whether the input type matches a given
@@ -40,36 +42,36 @@ val prove_equals_to_simple_of_kind_value :
 val prove_equals_tagged_immediates :
   Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t proof_of_property
 
-val check_equals_tagged_immediates :
-  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t proof_of_operation
+val meet_equals_tagged_immediates :
+  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t meet_shortcut
 
-val check_naked_immediates :
-  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t proof_of_operation
+val meet_naked_immediates :
+  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t meet_shortcut
 
-val check_equals_single_tagged_immediate :
-  Typing_env.t -> Type_grammar.t -> Targetint_31_63.t proof_of_operation
+val meet_equals_single_tagged_immediate :
+  Typing_env.t -> Type_grammar.t -> Targetint_31_63.t meet_shortcut
 
-val check_naked_floats :
+val meet_naked_floats :
   Typing_env.t ->
   Type_grammar.t ->
-  Numeric_types.Float_by_bit_pattern.Set.t proof_of_operation
+  Numeric_types.Float_by_bit_pattern.Set.t meet_shortcut
 
-val check_naked_int32s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int32.Set.t proof_of_operation
+val meet_naked_int32s :
+  Typing_env.t -> Type_grammar.t -> Numeric_types.Int32.Set.t meet_shortcut
 
-val check_naked_int64s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int64.Set.t proof_of_operation
+val meet_naked_int64s :
+  Typing_env.t -> Type_grammar.t -> Numeric_types.Int64.Set.t meet_shortcut
 
-val check_naked_nativeints :
-  Typing_env.t -> Type_grammar.t -> Targetint_32_64.Set.t proof_of_operation
+val meet_naked_nativeints :
+  Typing_env.t -> Type_grammar.t -> Targetint_32_64.Set.t meet_shortcut
 
 type variant_like_proof = private
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
     non_const_ctors_with_sizes : Targetint_31_63.Imm.t Tag.Scannable.Map.t
   }
 
-val check_variant_like :
-  Typing_env.t -> Type_grammar.t -> variant_like_proof proof_of_operation
+val meet_variant_like :
+  Typing_env.t -> Type_grammar.t -> variant_like_proof meet_shortcut
 
 val prove_variant_like :
   Typing_env.t -> Type_grammar.t -> variant_like_proof proof_of_property
@@ -99,19 +101,19 @@ val prove_is_a_boxed_nativeint :
 val prove_is_or_is_not_a_boxed_float :
   Typing_env.t -> Type_grammar.t -> bool proof_of_property
 
-val check_boxed_floats :
+val meet_boxed_floats :
   Typing_env.t ->
   Type_grammar.t ->
-  Numeric_types.Float_by_bit_pattern.Set.t proof_of_operation
+  Numeric_types.Float_by_bit_pattern.Set.t meet_shortcut
 
-val check_boxed_int32s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int32.Set.t proof_of_operation
+val meet_boxed_int32s :
+  Typing_env.t -> Type_grammar.t -> Numeric_types.Int32.Set.t meet_shortcut
 
-val check_boxed_int64s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int64.Set.t proof_of_operation
+val meet_boxed_int64s :
+  Typing_env.t -> Type_grammar.t -> Numeric_types.Int64.Set.t meet_shortcut
 
-val check_boxed_nativeints :
-  Typing_env.t -> Type_grammar.t -> Targetint_32_64.Set.t proof_of_operation
+val meet_boxed_nativeints :
+  Typing_env.t -> Type_grammar.t -> Targetint_32_64.Set.t meet_shortcut
 
 val prove_unique_tag_and_size :
   Typing_env.t ->
@@ -128,13 +130,13 @@ type array_kind_compatibility =
   | Compatible
   | Incompatible
 
-val check_is_array_with_element_kind :
+val meet_is_array_with_element_kind :
   Typing_env.t ->
   Type_grammar.t ->
   element_kind:Flambda_kind.With_subkind.t ->
-  array_kind_compatibility proof_of_operation
+  array_kind_compatibility meet_shortcut
 
-val check_single_closures_entry :
+val meet_single_closures_entry :
   Typing_env.t ->
   Type_grammar.t ->
   (Function_slot.t
@@ -142,7 +144,7 @@ val check_single_closures_entry :
   (* CR vlaviron: remove the Closures_entry.t field *)
   * Type_grammar.Closures_entry.t
   * Type_grammar.Function_type.t)
-  proof_of_operation
+  meet_shortcut
 
 val prove_single_closures_entry :
   Typing_env.t ->
@@ -154,8 +156,8 @@ val prove_single_closures_entry :
   * Type_grammar.Function_type.t)
   proof_of_property
 
-val check_strings :
-  Typing_env.t -> Type_grammar.t -> String_info.Set.t proof_of_operation
+val meet_strings :
+  Typing_env.t -> Type_grammar.t -> String_info.Set.t meet_shortcut
 
 val prove_tagging_of_simple :
   Typing_env.t ->
@@ -163,67 +165,67 @@ val prove_tagging_of_simple :
   Type_grammar.t ->
   Simple.t proof_of_property
 
-val check_tagging_of_simple :
+val meet_tagging_of_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_boxed_float_containing_simple :
+val meet_boxed_float_containing_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_boxed_int32_containing_simple :
+val meet_boxed_int32_containing_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_boxed_int64_containing_simple :
+val meet_boxed_int64_containing_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_boxed_nativeint_containing_simple :
+val meet_boxed_nativeint_containing_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_block_field_simple :
+val meet_block_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   Targetint_31_63.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_variant_field_simple :
+val meet_variant_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   Tag.t ->
   Targetint_31_63.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_project_value_slot_simple :
+val meet_project_value_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   Value_slot.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_project_function_slot_simple :
+val meet_project_function_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   Function_slot.t ->
-  Simple.t proof_of_operation
+  Simple.t meet_shortcut
 
-val check_rec_info :
-  Typing_env.t -> Type_grammar.t -> Rec_info_expr.t proof_of_operation
+val meet_rec_info :
+  Typing_env.t -> Type_grammar.t -> Rec_info_expr.t meet_shortcut
 
 val prove_alloc_mode_of_boxed_number :
   Typing_env.t -> Type_grammar.t -> Alloc_mode.t proof_of_property

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -183,13 +183,13 @@ val meet_block_field_simple :
   Targetint_31_63.t ->
   Simple.t meet_shortcut
 
-val meet_variant_field_simple :
-  Typing_env.t ->
-  min_name_mode:Name_mode.t ->
-  Type_grammar.t ->
-  Tag.t ->
-  Targetint_31_63.t ->
-  Simple.t meet_shortcut
+(* val meet_variant_field_simple :
+ *   Typing_env.t ->
+ *   min_name_mode:Name_mode.t ->
+ *   Type_grammar.t ->
+ *   Tag.t ->
+ *   Targetint_31_63.t ->
+ *   Simple.t meet_shortcut *)
 
 val meet_project_value_slot_simple :
   Typing_env.t ->

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -111,8 +111,8 @@ val prove_is_int : Typing_env.t -> Type_grammar.t -> bool proof_of_property
 val prove_get_tag :
   Typing_env.t -> Type_grammar.t -> Tag.Set.t proof_of_property
 
-val prove_is_flat_float_array :
-  Typing_env.t -> Type_grammar.t -> bool proof_of_property
+val meet_is_flat_float_array :
+  Typing_env.t -> Type_grammar.t -> bool meet_shortcut
 
 val prove_is_immediates_array :
   Typing_env.t -> Type_grammar.t -> unit proof_of_property
@@ -182,14 +182,6 @@ val meet_block_field_simple :
   Type_grammar.t ->
   Targetint_31_63.t ->
   Simple.t meet_shortcut
-
-(* val meet_variant_field_simple :
- *   Typing_env.t ->
- *   min_name_mode:Name_mode.t ->
- *   Type_grammar.t ->
- *   Tag.t ->
- *   Targetint_31_63.t ->
- *   Simple.t meet_shortcut *)
 
 val meet_project_value_slot_simple :
   Typing_env.t ->

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -111,19 +111,11 @@ val prove_is_int : Typing_env.t -> Type_grammar.t -> bool proof_of_property
 val prove_get_tag :
   Typing_env.t -> Type_grammar.t -> Tag.Set.t proof_of_property
 
-type array_kind_compatibility =
-  | Exact
-  | Compatible
-  | Incompatible
+val prove_is_flat_float_array :
+  Typing_env.t -> Type_grammar.t -> bool proof_of_property
 
-val prove_is_flat_float_array : Typing_env.t -> Type_grammar.t ->
-  bool proof_of_property
-
-val meet_is_array_with_element_kind :
-  Typing_env.t ->
-  Type_grammar.t ->
-  element_kind:Flambda_kind.With_subkind.t ->
-  array_kind_compatibility meet_shortcut
+val prove_is_immediates_array :
+  Typing_env.t -> Type_grammar.t -> unit proof_of_property
 
 val meet_single_closures_entry :
   Typing_env.t ->

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -139,6 +139,7 @@ val check_single_closures_entry :
   Type_grammar.t ->
   (Function_slot.t
   * Alloc_mode.t Or_unknown.t
+  (* CR vlaviron: remove the Closures_entry.t field *)
   * Type_grammar.Closures_entry.t
   * Type_grammar.Function_type.t)
   proof_of_operation
@@ -148,6 +149,7 @@ val prove_single_closures_entry :
   Type_grammar.t ->
   (Function_slot.t
   * Alloc_mode.t Or_unknown.t
+  (* CR vlaviron: remove the Closures_entry.t field *)
   * Type_grammar.Closures_entry.t
   * Type_grammar.Function_type.t)
   proof_of_property

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -101,20 +101,6 @@ val prove_is_a_boxed_nativeint :
 val prove_is_or_is_not_a_boxed_float :
   Typing_env.t -> Type_grammar.t -> bool proof_of_property
 
-val meet_boxed_floats :
-  Typing_env.t ->
-  Type_grammar.t ->
-  Numeric_types.Float_by_bit_pattern.Set.t meet_shortcut
-
-val meet_boxed_int32s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int32.Set.t meet_shortcut
-
-val meet_boxed_int64s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int64.Set.t meet_shortcut
-
-val meet_boxed_nativeints :
-  Typing_env.t -> Type_grammar.t -> Targetint_32_64.Set.t meet_shortcut
-
 val prove_unique_tag_and_size :
   Typing_env.t ->
   Type_grammar.t ->
@@ -129,6 +115,9 @@ type array_kind_compatibility =
   | Exact
   | Compatible
   | Incompatible
+
+val prove_is_flat_float_array : Typing_env.t -> Type_grammar.t ->
+  bool proof_of_property
 
 val meet_is_array_with_element_kind :
   Typing_env.t ->

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -16,140 +16,133 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-type 'a proof = private
-  | Proved of 'a
-  | Unknown
-  | Invalid
+(** A [proof_of_operation] gives us the result of a particular operation. The
+    corresponding functions provide efficient alternatives to the generic meet
+    function, with similar semantics. *)
+type 'a proof_of_operation = private
+  | Known_result of 'a  (** Result has been succesfully computed *)
+  | Unknown  (** Exact result could not be computed or is Top *)
+  | Invalid  (** Result is Bottom *)
 
-type 'a proof_allowing_kind_mismatch = private
+(** A [proof_of_property] tells us whether the input type matches a given
+    property. The extra type parameter can hold additional information, for
+    instance [prove_is_boxed_number] can return which kind of boxed number. *)
+type 'a proof_of_property = private
   | Proved of 'a
   | Unknown
-  | Invalid
   | Wrong_kind
 
-type var_or_symbol_or_tagged_immediate = private
-  | Var of Variable.t
-  | Symbol of Symbol.t
-  | Tagged_immediate of Targetint_31_63.t
-
-val prove_equals_to_var_or_symbol_or_tagged_immediate :
-  Typing_env.t ->
-  Type_grammar.t ->
-  (var_or_symbol_or_tagged_immediate * Coercion.t) proof
+(** If this returns a simple, it is bound with mode Normal *)
+val prove_equals_to_simple_of_kind_value :
+  Typing_env.t -> Type_grammar.t -> Simple.t proof_of_property
 
 (* CR mshinwell: Should remove "_equals_" from these names *)
 val prove_equals_tagged_immediates :
-  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t proof
+  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t proof_of_property
 
-val prove_naked_immediates :
-  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t proof
+val check_equals_tagged_immediates :
+  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t proof_of_operation
 
-val prove_equals_single_tagged_immediate :
-  Typing_env.t -> Type_grammar.t -> Targetint_31_63.t proof
+val check_naked_immediates :
+  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Set.t proof_of_operation
 
-val prove_naked_floats :
+val check_equals_single_tagged_immediate :
+  Typing_env.t -> Type_grammar.t -> Targetint_31_63.t proof_of_operation
+
+val check_naked_floats :
   Typing_env.t ->
   Type_grammar.t ->
-  Numeric_types.Float_by_bit_pattern.Set.t proof
+  Numeric_types.Float_by_bit_pattern.Set.t proof_of_operation
 
-val prove_naked_int32s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int32.Set.t proof
+val check_naked_int32s :
+  Typing_env.t -> Type_grammar.t -> Numeric_types.Int32.Set.t proof_of_operation
 
-val prove_naked_int64s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int64.Set.t proof
+val check_naked_int64s :
+  Typing_env.t -> Type_grammar.t -> Numeric_types.Int64.Set.t proof_of_operation
 
-val prove_naked_nativeints :
-  Typing_env.t -> Type_grammar.t -> Targetint_32_64.Set.t proof
+val check_naked_nativeints :
+  Typing_env.t -> Type_grammar.t -> Targetint_32_64.Set.t proof_of_operation
 
 type variant_like_proof = private
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
     non_const_ctors_with_sizes : Targetint_31_63.Imm.t Tag.Scannable.Map.t
   }
 
+val check_variant_like :
+  Typing_env.t -> Type_grammar.t -> variant_like_proof proof_of_operation
+
 val prove_variant_like :
-  Typing_env.t ->
-  Type_grammar.t ->
-  variant_like_proof proof_allowing_kind_mismatch
+  Typing_env.t -> Type_grammar.t -> variant_like_proof proof_of_property
 
-(** If [ty] is known to represent a boxed number or a tagged integer,
-    [prove_is_a_boxed_number env ty] is [Proved kind]. [kind] is the kind of the
-    unboxed number.
-
-    If [ty] is known to represent something of kind value that is not a number
-    [prove_is_a_boxed_number env ty] is [Invalid].
-
-    Otherwise it is [Unknown] or [Wrong_kind] when [ty] is not of kind value. *)
 type boxed_or_tagged_number = private
   | Boxed of Flambda_kind.Boxable_number.t
   | Tagged_immediate
 
 val prove_is_a_boxed_or_tagged_number :
-  Typing_env.t ->
-  Type_grammar.t ->
-  boxed_or_tagged_number proof_allowing_kind_mismatch
+  Typing_env.t -> Type_grammar.t -> boxed_or_tagged_number proof_of_property
 
 val prove_is_a_tagged_immediate :
-  Typing_env.t -> Type_grammar.t -> unit proof_allowing_kind_mismatch
+  Typing_env.t -> Type_grammar.t -> unit proof_of_property
 
 val prove_is_a_boxed_float :
-  Typing_env.t -> Type_grammar.t -> unit proof_allowing_kind_mismatch
+  Typing_env.t -> Type_grammar.t -> unit proof_of_property
 
 val prove_is_a_boxed_int32 :
-  Typing_env.t -> Type_grammar.t -> unit proof_allowing_kind_mismatch
+  Typing_env.t -> Type_grammar.t -> unit proof_of_property
 
 val prove_is_a_boxed_int64 :
-  Typing_env.t -> Type_grammar.t -> unit proof_allowing_kind_mismatch
+  Typing_env.t -> Type_grammar.t -> unit proof_of_property
 
 val prove_is_a_boxed_nativeint :
-  Typing_env.t -> Type_grammar.t -> unit proof_allowing_kind_mismatch
+  Typing_env.t -> Type_grammar.t -> unit proof_of_property
 
 val prove_is_or_is_not_a_boxed_float :
-  Typing_env.t -> Type_grammar.t -> bool proof_allowing_kind_mismatch
+  Typing_env.t -> Type_grammar.t -> bool proof_of_property
 
-val prove_boxed_floats :
+val check_boxed_floats :
   Typing_env.t ->
   Type_grammar.t ->
-  Numeric_types.Float_by_bit_pattern.Set.t proof
+  Numeric_types.Float_by_bit_pattern.Set.t proof_of_operation
 
-val prove_boxed_int32s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int32.Set.t proof
+val check_boxed_int32s :
+  Typing_env.t -> Type_grammar.t -> Numeric_types.Int32.Set.t proof_of_operation
 
-val prove_boxed_int64s :
-  Typing_env.t -> Type_grammar.t -> Numeric_types.Int64.Set.t proof
+val check_boxed_int64s :
+  Typing_env.t -> Type_grammar.t -> Numeric_types.Int64.Set.t proof_of_operation
 
-val prove_boxed_nativeints :
-  Typing_env.t -> Type_grammar.t -> Targetint_32_64.Set.t proof
-
-val prove_tags_and_sizes :
-  Typing_env.t -> Type_grammar.t -> Targetint_31_63.Imm.t Tag.Map.t proof
-
-val prove_tags_must_be_a_block :
-  Typing_env.t -> Type_grammar.t -> Tag.Set.t proof
+val check_boxed_nativeints :
+  Typing_env.t -> Type_grammar.t -> Targetint_32_64.Set.t proof_of_operation
 
 val prove_unique_tag_and_size :
   Typing_env.t ->
   Type_grammar.t ->
-  (Tag.t * Targetint_31_63.Imm.t) proof_allowing_kind_mismatch
+  (Tag.t * Targetint_31_63.Imm.t) proof_of_property
 
-val prove_is_int : Typing_env.t -> Type_grammar.t -> bool proof
+val prove_is_int : Typing_env.t -> Type_grammar.t -> bool proof_of_property
+
+val prove_get_tag :
+  Typing_env.t -> Type_grammar.t -> Tag.Set.t proof_of_property
 
 type array_kind_compatibility =
   | Exact
   | Compatible
   | Incompatible
 
-(** This function deems non-[Array] types of kind [Value] to be [Invalid]. *)
-val prove_is_array_with_element_kind :
+val check_is_array_with_element_kind :
   Typing_env.t ->
   Type_grammar.t ->
   element_kind:Flambda_kind.With_subkind.t ->
-  array_kind_compatibility proof
+  array_kind_compatibility proof_of_operation
 
-(* CR mshinwell: Fix comment and/or function name *)
+val check_single_closures_entry :
+  Typing_env.t ->
+  Type_grammar.t ->
+  (Function_slot.t
+  * Alloc_mode.t Or_unknown.t
+  * Type_grammar.Closures_entry.t
+  * Type_grammar.Function_type.t)
+  proof_of_operation
 
-(** Prove that the given type, of kind [Value], is a closures type describing
-    exactly one set of closures. The function declaration type corresponding to
-    such closure is returned together with its function slot, if it is known. *)
 val prove_single_closures_entry :
   Typing_env.t ->
   Type_grammar.t ->
@@ -157,80 +150,81 @@ val prove_single_closures_entry :
   * Alloc_mode.t Or_unknown.t
   * Type_grammar.Closures_entry.t
   * Type_grammar.Function_type.t)
-  proof
+  proof_of_property
 
-val prove_single_closures_entry' :
+val check_strings :
+  Typing_env.t -> Type_grammar.t -> String_info.Set.t proof_of_operation
+
+val prove_tagging_of_simple :
   Typing_env.t ->
+  min_name_mode:Name_mode.t ->
   Type_grammar.t ->
-  (Function_slot.t
-  * Alloc_mode.t Or_unknown.t
-  * Type_grammar.Closures_entry.t
-  * Type_grammar.Function_type.t)
-  proof_allowing_kind_mismatch
+  Simple.t proof_of_property
 
-val prove_strings : Typing_env.t -> Type_grammar.t -> String_info.Set.t proof
+val check_tagging_of_simple :
+  Typing_env.t ->
+  min_name_mode:Name_mode.t ->
+  Type_grammar.t ->
+  Simple.t proof_of_operation
 
-(** Attempt to show that the provided type describes the tagged version of a
-    unique naked immediate [Simple].
+val check_boxed_float_containing_simple :
+  Typing_env.t ->
+  min_name_mode:Name_mode.t ->
+  Type_grammar.t ->
+  Simple.t proof_of_operation
 
-    This function will return [Unknown] if values of the provided type might
-    sometimes, but not always, be a tagged immediate (for example if it is a
-    variant type involving blocks). *)
-val prove_is_always_tagging_of_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> Type_grammar.t -> Simple.t proof
+val check_boxed_int32_containing_simple :
+  Typing_env.t ->
+  min_name_mode:Name_mode.t ->
+  Type_grammar.t ->
+  Simple.t proof_of_operation
 
-(** Attempt to show that the provided type _can_ describe, but might not always
-    describe, the tagged version of a unique naked immediate [Simple]. It is
-    guaranteed that if a [Simple] is returned, the type does not describe any
-    other tagged immediate. *)
-val prove_could_be_tagging_of_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> Type_grammar.t -> Simple.t proof
+val check_boxed_int64_containing_simple :
+  Typing_env.t ->
+  min_name_mode:Name_mode.t ->
+  Type_grammar.t ->
+  Simple.t proof_of_operation
 
-val prove_boxed_float_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> Type_grammar.t -> Simple.t proof
+val check_boxed_nativeint_containing_simple :
+  Typing_env.t ->
+  min_name_mode:Name_mode.t ->
+  Type_grammar.t ->
+  Simple.t proof_of_operation
 
-val prove_boxed_int32_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> Type_grammar.t -> Simple.t proof
-
-val prove_boxed_int64_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> Type_grammar.t -> Simple.t proof
-
-val prove_boxed_nativeint_containing_simple :
-  Typing_env.t -> min_name_mode:Name_mode.t -> Type_grammar.t -> Simple.t proof
-
-val prove_block_field_simple :
+val check_block_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   Targetint_31_63.t ->
-  Simple.t proof
+  Simple.t proof_of_operation
 
-val prove_variant_field_simple :
+val check_variant_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   Tag.t ->
   Targetint_31_63.t ->
-  Simple.t proof
+  Simple.t proof_of_operation
 
-val prove_project_value_slot_simple :
+val check_project_value_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   Value_slot.t ->
-  Simple.t proof
+  Simple.t proof_of_operation
 
-val prove_project_function_slot_simple :
+val check_project_function_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   Function_slot.t ->
-  Simple.t proof
+  Simple.t proof_of_operation
 
-val prove_rec_info : Typing_env.t -> Type_grammar.t -> Rec_info_expr.t proof
+val check_rec_info :
+  Typing_env.t -> Type_grammar.t -> Rec_info_expr.t proof_of_operation
 
 val prove_alloc_mode_of_boxed_number :
-  Typing_env.t -> Type_grammar.t -> Alloc_mode.t Or_unknown.t
+  Typing_env.t -> Type_grammar.t -> Alloc_mode.t proof_of_property
 
 val never_holds_locally_allocated_values :
-  Typing_env.t -> Variable.t -> Flambda_kind.t -> bool
+  Typing_env.t -> Variable.t -> Flambda_kind.t -> unit proof_of_property

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -32,7 +32,6 @@ type 'a meet_shortcut = private
 type 'a proof_of_property = private
   | Proved of 'a
   | Unknown
-  | Wrong_kind
 
 (** If this returns a simple, it is bound with mode Normal *)
 val prove_equals_to_simple_of_kind_value :

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -80,7 +80,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
         Provers.never_holds_locally_allocated_values env var Flambda_kind.value
       with
       | Proved () -> true
-      | Unknown | Wrong_kind -> false)
+      | Unknown -> false)
   in
   let canonical_simple =
     match TE.get_alias_then_canonical_simple_exn env ~min_name_mode t with
@@ -149,9 +149,9 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
                             | Naked_immediate _ | Naked_float _ | Naked_int32 _
                             | Naked_int64 _ | Naked_nativeint _ ->
                               (* This should never happen, as we should have got
-                                 [Wrong_kind] instead *)
+                                 a kind error instead *)
                               None)
-                      | Unknown | Wrong_kind -> None)
+                      | Unknown -> None)
                     field_types
                 in
                 if List.compare_lengths field_types field_simples = 0
@@ -302,8 +302,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
       match Provers.prove_is_int env scrutinee_ty with
       | Proved true -> Simple Simple.untagged_const_true
       | Proved false -> Simple Simple.untagged_const_false
-      | Unknown -> try_canonical_simple ()
-      | Wrong_kind -> Invalid)
+      | Unknown -> try_canonical_simple ())
     | Naked_immediate (Ok (Get_tag block_ty)) -> (
       match Provers.prove_get_tag env block_ty with
       | Proved tags -> (
@@ -316,8 +315,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
         match Targetint_31_63.Set.get_singleton is with
         | None -> try_canonical_simple ()
         | Some i -> Simple (Simple.const (Reg_width_const.naked_immediate i)))
-      | Unknown -> try_canonical_simple ()
-      | Wrong_kind -> Invalid)
+      | Unknown -> try_canonical_simple ())
     | Naked_float (Ok fs) -> (
       match Float.Set.get_singleton fs with
       | None -> try_canonical_simple ()

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -161,13 +161,13 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
                 else try_canonical_simple ())
           else if TG.Row_like_for_blocks.is_bottom blocks
           then
-            match Provers.check_naked_immediates env imms with
+            match Provers.meet_naked_immediates env imms with
             | Known_result imms -> (
               match Targetint_31_63.Set.get_singleton imms with
               | None -> try_canonical_simple ()
               | Some imm ->
                 Simple (Simple.const (Reg_width_const.tagged_immediate imm)))
-            | Unknown -> try_canonical_simple ()
+            | Need_meet -> try_canonical_simple ()
             | Invalid -> Invalid
           else try_canonical_simple ()
         | Known _, Unknown | Unknown, Known _ | Unknown, Unknown ->
@@ -337,44 +337,44 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
     (* CR-someday mshinwell: These could lift at toplevel when [ty_naked_float]
        is an alias type. That would require checking the alloc mode. *)
     | Value (Ok (Boxed_float (ty_naked_float, _alloc_mode))) -> (
-      match Provers.check_naked_floats env ty_naked_float with
-      | Unknown -> try_canonical_simple ()
+      match Provers.meet_naked_floats env ty_naked_float with
+      | Need_meet -> try_canonical_simple ()
       | Invalid -> Invalid
       | Known_result fs -> (
         match Float.Set.get_singleton fs with
         | None -> try_canonical_simple ()
         | Some f -> Lift (Boxed_float f)))
     | Value (Ok (Boxed_int32 (ty_naked_int32, _alloc_mode))) -> (
-      match Provers.check_naked_int32s env ty_naked_int32 with
-      | Unknown -> try_canonical_simple ()
+      match Provers.meet_naked_int32s env ty_naked_int32 with
+      | Need_meet -> try_canonical_simple ()
       | Invalid -> Invalid
       | Known_result ns -> (
         match Int32.Set.get_singleton ns with
         | None -> try_canonical_simple ()
         | Some n -> Lift (Boxed_int32 n)))
     | Value (Ok (Boxed_int64 (ty_naked_int64, _alloc_mode))) -> (
-      match Provers.check_naked_int64s env ty_naked_int64 with
-      | Unknown -> try_canonical_simple ()
+      match Provers.meet_naked_int64s env ty_naked_int64 with
+      | Need_meet -> try_canonical_simple ()
       | Invalid -> Invalid
       | Known_result ns -> (
         match Int64.Set.get_singleton ns with
         | None -> try_canonical_simple ()
         | Some n -> Lift (Boxed_int64 n)))
     | Value (Ok (Boxed_nativeint (ty_naked_nativeint, _alloc_mode))) -> (
-      match Provers.check_naked_nativeints env ty_naked_nativeint with
-      | Unknown -> try_canonical_simple ()
+      match Provers.meet_naked_nativeints env ty_naked_nativeint with
+      | Need_meet -> try_canonical_simple ()
       | Invalid -> Invalid
       | Known_result ns -> (
         match Targetint_32_64.Set.get_singleton ns with
         | None -> try_canonical_simple ()
         | Some n -> Lift (Boxed_nativeint n)))
     | Value (Ok (Array { length; element_kind = _ })) -> (
-      match Provers.check_equals_single_tagged_immediate env length with
+      match Provers.meet_equals_single_tagged_immediate env length with
       | Known_result length ->
         if Targetint_31_63.equal length Targetint_31_63.zero
         then Lift Empty_array
         else try_canonical_simple ()
-      | Unknown -> try_canonical_simple ()
+      | Need_meet -> try_canonical_simple ()
       | Invalid -> Invalid)
     | Value Bottom
     | Naked_immediate Bottom

--- a/middle_end/flambda2/types/reify.mli
+++ b/middle_end/flambda2/types/reify.mli
@@ -19,18 +19,13 @@
 (** Transformation of types into structures that can be used immediately to
     build terms. *)
 
-type var_or_symbol_or_tagged_immediate = private
-  | Var of Variable.t
-  | Symbol of Symbol.t
-  | Tagged_immediate of Targetint_31_63.t
-
 type to_lift =
   (* private *)
   (* CR mshinwell: resurrect *)
   | Immutable_block of
       { tag : Tag.Scannable.t;
         is_unique : bool;
-        fields : var_or_symbol_or_tagged_immediate list
+        fields : Simple.t list
       }
   | Boxed_float of Numeric_types.Float_by_bit_pattern.t
   | Boxed_int32 of Numeric_types.Int32.t
@@ -40,11 +35,6 @@ type to_lift =
 
 type reification_result = private
   | Lift of to_lift (* CR mshinwell: rename? *)
-  | Lift_set_of_closures of
-      { function_slot : Function_slot.t;
-        function_types : Type_grammar.Function_type.t Function_slot.Map.t;
-        value_slots : Simple.t Value_slot.Map.t
-      }
   | Simple of Simple.t
   | Cannot_reify
   | Invalid


### PR DESCRIPTION
The prove_* versions will return a Proof when the inputs type strictly
matches the property in question, while the check_* functions will return
a Known_result when the corresponding operation has a result that can be
easily extracted.

As an example, for untagging the `prove_tagging_of_simple` version will
return Unknown on option-like variants, while the `check_tagging_of_simple`
version will assume the block part of the type is irrelevant.