### PR TITLE
Replace ocaml.1 with ocaml_1 in provider name for stapsdt elf notes

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1560,7 +1560,7 @@ let emit_probe_notes0 () =
        | false -> D.qword (ConstLabel "_.stapsdt.base")
        | true -> D.qword (const 0));
       D.qword (ConstLabel semaphore_label);
-      D.bytes "ocaml.1\000";
+      D.bytes "ocaml_1\000";
       D.bytes (probe_name ^ "\000");
       D.bytes (args ^ "\000")
     in


### PR DESCRIPTION
We piggyback on the provider field of stapsdt elf notes to indicate the version of ocaml-probes. (The experiemental mechanism for enabling ocaml-probes is separate from systemtap and subject to change so it was useful to have a version number, see https://github.com/ocaml-flambda/flambda-backend/pull/60#issuecomment-893321498.)

Looks like `perf` parses the provider field of stapsdt elf notes expecting its syntax to be a C symbol name (i.e., dots are not allowed).  For example, if `test.exe` has any ocaml-probes, then `perf record test.exe` sometimes prints this warning:
```
Semantic error :sdt_ocaml.1 is bad for event name -it must follow C symbol-naming rule.
```
It seems to generate `perf.data` just fine if we don't use these probes with -e.  
Thanks @Xyene for reporting this issue.
