### PR TITLE
Tentative fix for macOS CI

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -465,6 +465,9 @@ runtest-upstream:
 	done > _runtest/flambda2-test-list
 	(export OCAMLSRCDIR=$$(pwd)/_runtest; \
 	 export CAML_LD_LIBRARY_PATH=$$(pwd)/_runtest/lib/ocaml/stublibs; \
+	 if $$(which gfortran > /dev/null 2>&1); then \
+	   export LIBRARY_PATH=$$(dirname $$(gfortran -print-file-name=libgfortran.a)); \
+	 fi; \
 	 cd _runtest/testsuite \
 	  && if $$(which parallel > /dev/null 2>&1); \
              then \


### PR DESCRIPTION
The `macos_build_and_test_flambda2` has been failing
recently because `libgfortran.a` (which is used by one or
two tests) could not be found.

This patch simply sets `LIBRARY_PATH` to the path of the
aforementioned file. I have been using it on my macOS
laptop for some time, but never on Linux. I expect it to make
no difference on Linux, but the CI will confirm/infirm.