### PR TITLE
Refactor Patricia_tree to reduce duplicated code

### DIFF
--- a/middle_end/flambda2/algorithms/container_types.mli
+++ b/middle_end/flambda2/algorithms/container_types.mli
@@ -19,109 +19,25 @@
     {b Warning:} this module is unstable and part of
     {{!Compiler_libs}compiler-libs}. *)
 
-module type Thing_no_hash = sig
-  type t
+open Container_types_intf
 
-  include Map.OrderedType with type t := t
+module type Thing_no_hash = Thing_no_hash
 
-  val print : Format.formatter -> t -> unit
-end
-
-module type Thing = sig
-  type t
-
-  include Hashtbl.HashedType with type t := t
-
-  include Map.OrderedType with type t := t
-
-  val print : Format.formatter -> t -> unit
-end
+module type Thing = Thing
 
 module Pair : functor (A : Thing) (B : Thing) -> Thing with type t = A.t * B.t
 
-module type Set = sig
-  module T : Set.OrderedType
+module type Set = Set
 
-  include Set.S with type elt = T.t
+module Make_set (T : Thing_no_hash) : Set with type elt = T.t
 
-  val print : Format.formatter -> t -> unit
+module type Map = Map
 
-  val to_string : t -> string
+module type S = S
 
-  val of_list : elt list -> t
+module type S_plus_stdlib = S_plus_stdlib
 
-  val map : (elt -> elt) -> t -> t
-
-  val union_list : t list -> t
-
-  val intersection_is_empty : t -> t -> bool
-
-  val get_singleton : t -> elt option
-end
-
-module Make_set (T : Thing_no_hash) : Set with module T := T
-
-module type Map = sig
-  module T : Map.OrderedType
-
-  include Map.S with type key = T.t
-
-  module Set : Set with module T := T
-
-  val print_debug :
-    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
-
-  val of_list : (key * 'a) list -> 'a t
-
-  (** [disjoint_union m1 m2] contains all bindings from [m1] and [m2]. If some
-      binding is present in both and the associated value is not equal, a
-      Fatal_error is raised *)
-  val disjoint_union :
-    ?eq:('a -> 'a -> bool) ->
-    ?print:(Format.formatter -> 'a -> unit) ->
-    'a t ->
-    'a t ->
-    'a t
-
-  val rename : key t -> key -> key
-
-  val map_keys : (key -> key) -> 'a t -> 'a t
-
-  val keys : 'a t -> Set.t
-
-  val data : 'a t -> 'a list
-
-  val of_set : (key -> 'a) -> Set.t -> 'a t
-
-  val print :
-    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
-
-  val diff_domains : 'a t -> 'a t -> 'a t
-
-  val inter : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
-
-  val inter_domain_is_non_empty : 'a t -> 'a t -> bool
-
-  val get_singleton : 'a t -> (key * 'a) option
-
-  val replace : key -> ('a -> 'a) -> 'a t -> 'a t
-
-  val map_sharing : ('a -> 'a) -> 'a t -> 'a t
-end
-
-module type S = sig
-  type t
-
-  module T : Thing with type t = t
-
-  include Thing with type t := T.t
-
-  module Set : Set with module T := T
-
-  module Map : Map with module T := T with module Set = Set
-end
-
-module Make (T : Thing) : S with type t := T.t
+module Make (T : Thing) : S_plus_stdlib with type t := T.t
 
 module Make_pair (T1 : S) (T2 : S) : sig
   include S with type t := T1.t * T2.t

--- a/middle_end/flambda2/algorithms/container_types_intf.ml
+++ b/middle_end/flambda2/algorithms/container_types_intf.ml
@@ -107,10 +107,6 @@ module type Set = sig
 
   val to_string : t -> string
 
-  val of_list : elt list -> t
-
-  val map : (elt -> elt) -> t -> t
-
   val union_list : t list -> t
 
   val get_singleton : t -> elt option

--- a/middle_end/flambda2/algorithms/container_types_intf.ml
+++ b/middle_end/flambda2/algorithms/container_types_intf.ml
@@ -1,0 +1,261 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2016 OCamlPro SAS                                    *)
+(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module type Thing_no_hash = sig
+  type t
+
+  include Map.OrderedType with type t := t
+
+  val print : Format.formatter -> t -> unit
+end
+
+module type Thing = sig
+  type t
+
+  include Hashtbl.HashedType with type t := t
+
+  include Map.OrderedType with type t := t
+
+  val print : Format.formatter -> t -> unit
+end
+
+module type Set = sig
+  type elt
+
+  type t
+
+  val empty : t
+
+  val is_empty : t -> bool
+
+  val mem : elt -> t -> bool
+
+  val add : elt -> t -> t
+
+  val singleton : elt -> t
+
+  val remove : elt -> t -> t
+
+  val union : t -> t -> t
+
+  val inter : t -> t -> t
+
+  val disjoint : t -> t -> bool
+
+  val diff : t -> t -> t
+
+  val compare : t -> t -> int
+
+  val equal : t -> t -> bool
+
+  val subset : t -> t -> bool
+
+  val iter : (elt -> unit) -> t -> unit
+
+  val map : (elt -> elt) -> t -> t
+
+  val fold : (elt -> 'a -> 'a) -> t -> 'a -> 'a
+
+  val for_all : (elt -> bool) -> t -> bool
+
+  val exists : (elt -> bool) -> t -> bool
+
+  val filter : (elt -> bool) -> t -> t
+
+  val filter_map : (elt -> elt option) -> t -> t
+
+  val partition : (elt -> bool) -> t -> t * t
+
+  val cardinal : t -> int
+
+  val elements : t -> elt list
+
+  val min_elt : t -> elt
+
+  val min_elt_opt : t -> elt option
+
+  val max_elt : t -> elt
+
+  val max_elt_opt : t -> elt option
+
+  val choose : t -> elt
+
+  val choose_opt : t -> elt option
+
+  val split : elt -> t -> t * bool * t
+
+  val find : elt -> t -> elt
+
+  val of_list : elt list -> t
+
+  val to_seq : t -> elt Seq.t
+
+  val print : Format.formatter -> t -> unit
+
+  val to_string : t -> string
+
+  val of_list : elt list -> t
+
+  val map : (elt -> elt) -> t -> t
+
+  val union_list : t list -> t
+
+  val get_singleton : t -> elt option
+end
+
+module type Map = sig
+  type key
+
+  module Set : Set with type elt = key
+
+  type +!'a t
+
+  val empty : 'a t
+
+  val is_empty : 'a t -> bool
+
+  val mem : key -> 'a t -> bool
+
+  val add : key -> 'a -> 'a t -> 'a t
+
+  val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
+
+  val singleton : key -> 'a -> 'a t
+
+  val remove : key -> 'a t -> 'a t
+
+  val merge :
+    (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
+
+  val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
+  val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+  val iter : (key -> 'a -> unit) -> 'a t -> unit
+
+  val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+
+  val for_all : (key -> 'a -> bool) -> 'a t -> bool
+
+  val exists : (key -> 'a -> bool) -> 'a t -> bool
+
+  val filter : (key -> 'a -> bool) -> 'a t -> 'a t
+
+  val filter_map : (key -> 'a -> 'b option) -> 'a t -> 'b t
+
+  val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
+
+  val cardinal : 'a t -> int
+
+  val bindings : 'a t -> (key * 'a) list
+
+  val min_binding : 'a t -> key * 'a
+
+  val min_binding_opt : 'a t -> (key * 'a) option
+
+  val max_binding : 'a t -> key * 'a
+
+  val max_binding_opt : 'a t -> (key * 'a) option
+
+  val choose : 'a t -> key * 'a
+
+  val choose_opt : 'a t -> (key * 'a) option
+
+  val split : key -> 'a t -> 'a t * 'a option * 'a t
+
+  val find : key -> 'a t -> 'a
+
+  val find_opt : key -> 'a t -> 'a option
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+
+  val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
+
+  val to_seq : 'a t -> (key * 'a) Seq.t
+
+  val print_debug :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+  val of_list : (key * 'a) list -> 'a t
+
+  val disjoint_union :
+    ?eq:('a -> 'a -> bool) ->
+    ?print:(Format.formatter -> 'a -> unit) ->
+    'a t ->
+    'a t ->
+    'a t
+
+  val map_keys : (key -> key) -> 'a t -> 'a t
+
+  val keys : 'a t -> Set.t
+
+  val data : 'a t -> 'a list
+
+  val of_set : (key -> 'a) -> Set.t -> 'a t
+
+  val print :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+  val diff_domains : 'a t -> 'a t -> 'a t
+
+  val inter : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+
+  val inter_domain_is_non_empty : 'a t -> 'a t -> bool
+
+  val get_singleton : 'a t -> (key * 'a) option
+
+  val replace : key -> ('a -> 'a) -> 'a t -> 'a t
+
+  val map_sharing : ('a -> 'a) -> 'a t -> 'a t
+end
+
+module type S = sig
+  type t
+
+  module T : Thing with type t = t
+
+  include Thing with type t := T.t
+
+  module Set : Set with type elt = t
+
+  module Map : Map with type key = t and module Set = Set
+end
+
+module type Set_plus_stdlib = sig
+  include Set
+
+  include Stdlib.Set.S with type elt := elt and type t := t
+end
+
+module type Map_plus_stdlib = sig
+  include Map
+
+  include Stdlib.Map.S with type key := key and type 'a t := 'a t
+end
+
+module type S_plus_stdlib = sig
+  type t
+
+  module T : Thing with type t = t
+
+  include Thing with type t := T.t
+
+  module Set : Set_plus_stdlib with type elt = t
+
+  module Map : Map_plus_stdlib with type key = t and module Set = Set
+end

--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -216,8 +216,6 @@ module Tree_operations (Tree : Tree) : sig
 
   val subset : 'a t -> 'a t -> bool
 
-  val inter_domains : 'a t -> 'a t -> 'a t
-
   val find : key -> 'a t -> 'a
 
   val inter : 'c is_value -> (key -> 'a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
@@ -458,28 +456,6 @@ end = struct
       else if includes_prefix prefix1 bit1 prefix0 bit0
       then if zero_bit prefix0 bit1 then subset t0 t10 else subset t0 t11
       else false
-
-  let rec inter_domains t0 t1 =
-    let iv = is_value_of t0 in
-    match descr t0, descr t1 with
-    | Empty, _ -> empty iv
-    | _, Empty -> empty iv
-    | Leaf (i, _), _ -> if mem i t1 then t0 else empty iv
-    | _, Leaf (i, _) -> if mem i t0 then t1 else empty iv
-    | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
-      if equal_prefix prefix0 bit0 prefix1 bit1
-      then branch prefix0 bit0 (inter_domains t00 t10) (inter_domains t01 t11)
-      else if includes_prefix prefix0 bit0 prefix1 bit1
-      then
-        if zero_bit prefix1 bit0
-        then inter_domains t00 t1
-        else inter_domains t01 t1
-      else if includes_prefix prefix1 bit1 prefix0 bit0
-      then
-        if zero_bit prefix0 bit1
-        then inter_domains t0 t10
-        else inter_domains t0 t11
-      else empty iv
 
   let rec find i t =
     match descr t with
@@ -840,8 +816,6 @@ end = struct
     in
     aux [t]
 
-  (* CR mshinwell: copied from [Container_types] *)
-
   let[@inline always] of_list iv l =
     List.fold_left
       (fun map b -> add (Binding.key b) (Binding.value iv b) map)
@@ -974,8 +948,6 @@ module Map = struct
   let of_set f set = Set.fold (fun e map -> add e (f e) map) set empty
 
   let diff_domains = diff
-
-  let () = ignore Ops.inter_domains
 end
 
 module Make (X : sig

--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -52,450 +52,285 @@ let compare_prefix prefix0 bit0 prefix1 bit1 =
   let c = compare bit0 bit1 in
   if c = 0 then compare prefix0 prefix1 else c
 
-module Make_set (Elt : sig
-  val print : Format.formatter -> int -> unit
-end) =
-struct
-  type elt = int
+type key = int
 
-  type t =
+module type Tree = sig
+  type 'a t
+
+  (* A witness that ['a] is a valid type for a value stored in the tree. Maps
+     will allow ['a] to be any value but sets will only allow [unit]. *)
+  type 'a is_value [@@immediate]
+
+  (* Deduce that ['a] is a value type from a pre-existing ['a t]. *)
+  val is_value_of : 'a t -> 'a is_value
+
+  val empty : 'a is_value -> 'a t
+
+  val leaf : 'a is_value -> key -> 'a -> 'a t
+
+  val branch : key -> key -> 'a t -> 'a t -> 'a t
+
+  type 'a descr =
     | Empty
-    | Leaf of int
-    | Branch of int * int * t * t
+    | Leaf of key * 'a
+    | Branch of key * key * 'a t * 'a t
 
-  let empty = Empty
+  val descr : 'a t -> 'a descr
 
-  let is_empty t =
-    match t with Empty -> true | Leaf _ -> false | Branch _ -> false
+  module Binding : sig
+    type 'a t
 
-  let singleton i = Leaf i
+    val create : key -> 'a -> 'a t
 
-  let rec mem i = function
-    | Empty -> false
-    | Leaf j -> j = i
-    | Branch (prefix, bit, t0, t1) ->
-      if not (match_prefix i prefix bit)
-      then false
-      else if zero_bit i bit
-      then mem i t0
-      else mem i t1
+    val key : _ t -> key
 
-  let branch prefix bit t0 t1 =
-    match t0, t1 with
-    | Empty, _ -> t1
-    | _, Empty -> t0
-    | t0, t1 -> Branch (prefix, bit, t0, t1)
-
-  let join prefix0 t0 prefix1 t1 =
-    let bit = branching_bit prefix0 prefix1 in
-    if zero_bit prefix0 bit
-    then Branch (mask prefix0 bit, bit, t0, t1)
-    else Branch (mask prefix0 bit, bit, t1, t0)
-
-  (* CR mshinwell: This is now [add_or_replace] *)
-  let rec add i = function
-    | Empty -> Leaf i
-    | Leaf j as t -> if i = j then Leaf i else join i (Leaf i) j t
-    | Branch (prefix, bit, t0, t1) as t ->
-      if match_prefix i prefix bit
-      then
-        if zero_bit i bit
-        then Branch (prefix, bit, add i t0, t1)
-        else Branch (prefix, bit, t0, add i t1)
-      else join i (Leaf i) prefix t
-
-  let rec remove i = function
-    | Empty -> Empty
-    | Leaf j as t -> if i = j then Empty else t
-    | Branch (prefix, bit, t0, t1) as t ->
-      if match_prefix i prefix bit
-      then
-        if zero_bit i bit
-        then branch prefix bit (remove i t0) t1
-        else branch prefix bit t0 (remove i t1)
-      else t
-
-  let rec union t0 t1 =
-    match t0, t1 with
-    | Empty, _ -> t1
-    | _, Empty -> t0
-    | Leaf i, Leaf j when i = j -> Leaf i
-    | Leaf i, Leaf j -> join i (Leaf i) j t1
-    | Leaf i, Branch (prefix, bit, t10, t11) ->
-      if match_prefix i prefix bit
-      then
-        if zero_bit i bit
-        then branch prefix bit (union t0 t10) t11
-        else branch prefix bit t10 (union t0 t11)
-      else join i (Leaf i) prefix t1
-    | Branch (prefix, bit, t00, t01), Leaf i ->
-      if match_prefix i prefix bit
-      then
-        if zero_bit i bit
-        then branch prefix bit (union t1 t00) t01
-        else branch prefix bit t00 (union t1 t01)
-      else join i (Leaf i) prefix t0
-    | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
-      if equal_prefix prefix0 bit0 prefix1 bit1
-      then branch prefix0 bit0 (union t00 t10) (union t01 t11)
-      else if includes_prefix prefix0 bit0 prefix1 bit1
-      then
-        if zero_bit prefix1 bit0
-        then branch prefix0 bit0 (union t00 t1) t01
-        else branch prefix0 bit0 t00 (union t01 t1)
-      else if includes_prefix prefix1 bit1 prefix0 bit0
-      then
-        if zero_bit prefix0 bit1
-        then branch prefix1 bit1 (union t0 t10) t11
-        else branch prefix1 bit1 t10 (union t0 t11)
-      else join prefix0 t0 prefix1 t1
-
-  let rec subset t0 t1 =
-    match t0, t1 with
-    | Empty, _ -> true
-    | _, Empty -> false
-    | Branch _, Leaf _ -> false
-    | Leaf i, _ -> mem i t1
-    | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
-      if equal_prefix prefix0 bit0 prefix1 bit1
-      then subset t00 t10 && subset t01 t11
-      else if includes_prefix prefix1 bit1 prefix0 bit0
-      then if zero_bit prefix0 bit1 then subset t0 t10 else subset t0 t11
-      else false
-
-  let rec intersection_is_empty t0 t1 =
-    match t0, t1 with
-    | Empty, _ -> true
-    | _, Empty -> true
-    | Leaf i, _ -> not (mem i t1)
-    | _, Leaf i -> not (mem i t0)
-    | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
-      if equal_prefix prefix0 bit0 prefix1 bit1
-      then intersection_is_empty t00 t10 && intersection_is_empty t01 t11
-      else if includes_prefix prefix0 bit0 prefix1 bit1
-      then
-        if zero_bit prefix1 bit0
-        then intersection_is_empty t00 t1
-        else intersection_is_empty t01 t1
-      else if includes_prefix prefix1 bit1 prefix0 bit0
-      then
-        if zero_bit prefix0 bit1
-        then intersection_is_empty t0 t10
-        else intersection_is_empty t0 t11
-      else true
-
-  let rec inter t0 t1 =
-    match t0, t1 with
-    | Empty, _ -> Empty
-    | _, Empty -> Empty
-    | Leaf i, _ -> if mem i t1 then t0 else Empty
-    | _, Leaf i -> if mem i t0 then t1 else Empty
-    | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
-      if equal_prefix prefix0 bit0 prefix1 bit1
-      then branch prefix0 bit0 (inter t00 t10) (inter t01 t11)
-      else if includes_prefix prefix0 bit0 prefix1 bit1
-      then if zero_bit prefix1 bit0 then inter t00 t1 else inter t01 t1
-      else if includes_prefix prefix1 bit1 prefix0 bit0
-      then if zero_bit prefix0 bit1 then inter t0 t10 else inter t0 t11
-      else Empty
-
-  let rec diff t0 t1 =
-    match t0, t1 with
-    | Empty, _ -> Empty
-    | _, Empty -> t0
-    | Leaf i, _ -> if mem i t1 then Empty else t0
-    | _, Leaf i -> remove i t0
-    | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
-      if equal_prefix prefix0 bit0 prefix1 bit1
-      then branch prefix0 bit0 (diff t00 t10) (diff t01 t11)
-      else if includes_prefix prefix0 bit0 prefix1 bit1
-      then
-        if zero_bit prefix1 bit0
-        then branch prefix0 bit0 (diff t00 t1) t01
-        else branch prefix0 bit0 t00 (diff t01 t1)
-      else if includes_prefix prefix1 bit1 prefix0 bit0
-      then if zero_bit prefix0 bit1 then diff t0 t10 else diff t0 t11
-      else t0
-
-  let rec cardinal = function
-    | Empty -> 0
-    | Leaf _ -> 1
-    | Branch (_, _, t0, t1) -> cardinal t0 + cardinal t1
-
-  let rec iter f = function
-    | Empty -> ()
-    | Leaf elt -> f elt
-    | Branch (_, _, t0, t1) ->
-      iter f t0;
-      iter f t1
-
-  let rec fold f t acc =
-    match t with
-    | Empty -> acc
-    | Leaf elt -> f elt acc
-    | Branch (_, _, t0, t1) -> fold f t0 (fold f t1 acc)
-
-  let rec for_all p = function
-    | Empty -> true
-    | Leaf elt -> p elt
-    | Branch (_, _, t0, t1) -> for_all p t0 && for_all p t1
-
-  let rec exists p = function
-    | Empty -> false
-    | Leaf elt -> p elt
-    | Branch (_, _, t0, t1) -> exists p t0 || exists p t1
-
-  let filter p t =
-    let rec loop p acc = function
-      | Empty -> acc
-      | Leaf i -> if p i then add i acc else acc
-      | Branch (_, _, t0, t1) -> loop p (loop p acc t0) t1
-    in
-    loop p Empty t
-
-  let filter_map f t =
-    let rec loop f acc = function
-      | Empty -> acc
-      | Leaf i -> begin match f i with None -> acc | Some j -> add j acc end
-      | Branch (_, _, t0, t1) -> loop f (loop f acc t0) t1
-    in
-    loop f Empty t
-
-  let partition p t =
-    let rec loop ((true_, false_) as acc) = function
-      | Empty -> acc
-      | Leaf i -> if p i then add i true_, false_ else true_, add i false_
-      | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
-    in
-    loop (Empty, Empty) t
-
-  let rec choose = function
-    | Empty -> raise Not_found
-    | Leaf key -> key
-    | Branch (_, _, t0, _) -> choose t0
-
-  let choose_opt t =
-    match choose t with exception Not_found -> None | choice -> Some choice
-
-  let elements t =
-    let rec loop acc = function
-      | Empty -> acc
-      | Leaf i -> i :: acc
-      | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
-    in
-    loop [] t
-
-  let min_elt t =
-    let rec loop = function
-      | Empty -> raise Not_found
-      | Leaf i -> i
-      | Branch (_, _, t0, t1) ->
-        let i0 = loop t0 in
-        let i1 = loop t1 in
-        if i0 < i1 then i0 else i1
-    in
-    loop t
-
-  let min_elt_opt t =
-    match min_elt t with exception Not_found -> None | min -> Some min
-
-  let max_elt t =
-    let rec loop = function
-      | Empty -> raise Not_found
-      | Leaf i -> i
-      | Branch (_, _, t0, t1) ->
-        let i0 = loop t0 in
-        let i1 = loop t1 in
-        if i0 > i1 then i0 else i1
-    in
-    loop t
-
-  let max_elt_opt t =
-    match max_elt t with exception Not_found -> None | max -> Some max
-
-  let rec equal t0 t1 =
-    if t0 == t1
-    then true
-    else
-      match t0, t1 with
-      | Empty, Empty -> true
-      | Leaf i, Leaf j -> i = j
-      | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
-        if equal_prefix prefix0 bit0 prefix1 bit1
-        then equal t00 t10 && equal t01 t11
-        else false
-      | _, _ -> false
-
-  let rec compare t0 t1 =
-    match t0, t1 with
-    | Empty, Empty -> 0
-    | Leaf i, Leaf j -> if i = j then 0 else if i < j then -1 else 1
-    | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
-      let c = compare_prefix prefix0 bit0 prefix1 bit1 in
-      if c = 0
-      then
-        let c = compare t00 t10 in
-        if c = 0 then compare t01 t11 else c
-      else c
-    | Empty, Leaf _ -> 1
-    | Empty, Branch _ -> 1
-    | Leaf _, Branch _ -> 1
-    | Leaf _, Empty -> -1
-    | Branch _, Empty -> -1
-    | Branch _, Leaf _ -> -1
-
-  let split i t =
-    let rec loop ((lt, present, gt) as acc) = function
-      | Empty -> acc
-      | Leaf j ->
-        if i = j
-        then lt, true, gt
-        else if j < i
-        then add j lt, present, gt
-        else lt, present, add j gt
-      | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
-    in
-    loop (Empty, false, Empty) t
-
-  let find_opt _ _ = Misc.fatal_error "find_opt not yet implemented"
-
-  let find_first _ _ = Misc.fatal_error "find_first not yet implemented"
-
-  let find_first_opt _ _ = Misc.fatal_error "find_first_opt not yet implemented"
-
-  let find_last _ _ = Misc.fatal_error "find_last not yet implemented"
-
-  let find_last_opt _ _ = Misc.fatal_error "find_last_opt not yet implemented"
-
-  let get_singleton t =
-    match t with Empty | Branch _ -> None | Leaf elt -> Some elt
-
-  let to_seq t =
-    let rec aux acc () =
-      match acc with
-      | [] -> Seq.Nil
-      | t0 :: r -> begin
-        match t0 with
-        | Empty -> aux r ()
-        | Leaf x -> Seq.Cons (x, aux r)
-        | Branch (_, _, t1, t2) -> aux (t1 :: t2 :: r) ()
-      end
-    in
-    aux [t]
-
-  let to_rev_seq _ = Misc.fatal_error "to_rev_seq not yet implemented"
-
-  let to_seq_from _ _ = Misc.fatal_error "to_seq_from not yet implemented"
-
-  let add_seq _ _ = Misc.fatal_error "add_seq not yet implemented"
-
-  let of_seq _ = Misc.fatal_error "of_seq not yet implemented"
-
-  (* CR mshinwell: copied from [Container_types] *)
-
-  let [@ocamlformat "disable"] print ppf s =
-    let elts ppf s = iter (fun e -> Format.fprintf ppf "@ %a" Elt.print e) s in
-    Format.fprintf ppf "@[<1>{@[%a@ @]}@]" elts s
-
-  let to_string s = Format.asprintf "%a" print s
-
-  let find elt t = if mem elt t then elt else raise Not_found
-
-  let of_list l =
-    match l with
-    | [] -> empty
-    | [t] -> singleton t
-    | t :: q -> List.fold_left (fun acc e -> add e acc) (singleton t) q
-
-  let map f t = fold (fun elt acc -> add (f elt) acc) t empty
-
-  let rec union_list ts =
-    match ts with [] -> empty | t :: ts -> union t (union_list ts)
-
-  let disjoint _ _ = Misc.fatal_error "disjoint not yet implemented"
-end
-[@@inline always]
-
-module Make_map (Key : sig
-  val print : Format.formatter -> int -> unit
-end)
-(Set : Container_types.Set with module T := Numbers.Int) =
-struct
-  type key = int
-
-  module Set = Set
-
-  module T : sig
-    type +'a t = private
-      | Empty
-      | Leaf of int * 'a
-      | Branch of int * int * 'a t * 'a t
-
-    val empty : 'a t
-
-    val leaf : int -> 'a -> 'a t
-
-    val branch : int -> int -> 'a t -> 'a t -> 'a t
-
-    val branch_non_empty : int -> int -> 'a t -> 'a t -> 'a t
-  end = struct
-    type 'a t =
-      | Empty
-      | Leaf of int * 'a
-      | Branch of int * int * 'a t * 'a t
-
-    let empty = Empty
-
-    let leaf key datum = Leaf (key, datum) [@@inline always]
-
-    let branch prefix bit t0 t1 =
-      match t0, t1 with
-      | Empty, _ -> t1
-      | _, Empty -> t0
-      | _, _ -> Branch (prefix, bit, t0, t1)
-      [@@inline always]
-
-    let branch_non_empty prefix bit t0 t1 = Branch (prefix, bit, t0, t1)
-      [@@inline always]
+    val value : 'a is_value -> 'a t -> 'a
   end
 
-  include T
+  module Callback : sig
+    type ('a, 'b) t
+
+    val of_func : 'a is_value -> (key -> 'a -> 'b) -> ('a, 'b) t
+
+    val call : ('a, 'b) t -> key -> 'a -> 'b
+  end
+end
+
+module Set0 = struct
+  type 'a t =
+    | Empty : unit t
+    | Leaf : key -> unit t
+    | Branch : key * key * unit t * unit t -> unit t
+
+  type 'a is_value = Unit : unit is_value
+
+  let[@inline always] is_value_of (type a) (t : a t) : a is_value =
+    (* Crucially, this compiles down to just [Unit], making this function cost
+       nothing. *)
+    match t with Empty -> Unit | Leaf _ -> Unit | Branch _ -> Unit
+
+  let[@inline always] empty (type a) (Unit : a is_value) : a t = Empty
+
+  let[@inline always] leaf (type a) (Unit : a is_value) elt (() : a) : a t =
+    Leaf elt
+
+  let[@inline always] branch (type a) prefix bit (t0 : a t) (t1 : a t) : a t =
+    let Unit = is_value_of t0 in
+    Branch (prefix, bit, t0, t1)
+
+  type 'a descr =
+    | Empty
+    | Leaf of key * 'a
+    | Branch of key * key * 'a t * 'a t
+
+  let descr (type a) : a t -> a descr = function
+    | Empty -> Empty
+    | Leaf elt -> Leaf (elt, ())
+    | Branch (prefix, bit, t0, t1) -> Branch (prefix, bit, t0, t1)
+
+  module Binding = struct
+    type _ t = key
+
+    let[@inline always] create i _ = i
+
+    let[@inline always] key i = i
+
+    let[@inline always] value (type a) (Unit : a is_value) (_i : a t) : a = ()
+  end
+
+  module Callback = struct
+    type (_, 'b) t = key -> 'b
+
+    let[@inline always] of_func (type a) (Unit : a is_value)
+        (f : key -> a -> 'b) key =
+      (f [@inlined hint]) key ()
+
+    let[@inline always] call f key _ = f key
+  end
+end
+
+module _ : Tree = Set0
+
+module Map0 = struct
+  type 'a t =
+    | Empty
+    | Leaf of key * 'a
+    | Branch of key * key * 'a t * 'a t
+
+  type _ is_value = Any : 'a is_value
+
+  let[@inline always] is_value_of _ = Any
+
+  let[@inline always] empty Any = Empty
+
+  let[@inline always] leaf Any i d = Leaf (i, d)
+
+  let[@inline always] branch prefix bit t0 t1 = Branch (prefix, bit, t0, t1)
+
+  type 'a descr = 'a t =
+    | Empty
+    | Leaf of key * 'a
+    | Branch of key * key * 'a t * 'a t
+
+  let descr = Fun.id
+
+  module Binding = struct
+    type 'a t = key * 'a
+
+    let[@inline always] create i d = i, d
+
+    let[@inline always] key (i, _d) = i
+
+    let[@inline always] value Any (_i, d) = d
+  end
+
+  module Callback = struct
+    type ('a, 'b) t = key -> 'a -> 'b
+
+    let[@inline always] call f i d = f i d
+
+    let[@inline always] of_func Any f = f
+  end
+end
+
+module _ : Tree = Map0
+
+module Tree_operations (Tree : Tree) : sig
+  open! Tree
+
+  val is_empty : 'a t -> bool
+
+  val singleton : 'a is_value -> key -> 'a -> 'a t
+
+  val mem : key -> 'a t -> bool
+
+  val add : key -> 'a -> 'a t -> 'a t
+
+  val replace : key -> ('a -> 'a) -> 'a t -> 'a t
+
+  val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
+
+  val remove : key -> 'a t -> 'a t
+
+  val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
+  val subset : 'a t -> 'a t -> bool
+
+  val inter_domains : 'a t -> 'a t -> 'a t
+
+  val find : key -> 'a t -> 'a
+
+  val inter : 'c is_value -> (key -> 'a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+
+  val inter_domain_is_non_empty : 'a t -> 'b t -> bool
+
+  val diff : 'a t -> 'b t -> 'a t
+
+  val cardinal : _ t -> int
+
+  val iter : ('a, unit) Callback.t -> 'a t -> unit
+
+  val fold : ('a, 'b -> 'b) Callback.t -> 'a t -> 'b -> 'b
+
+  val for_all : ('a, bool) Callback.t -> 'a t -> bool
+
+  val exists : ('a, bool) Callback.t -> 'a t -> bool
+
+  val filter : ('a, bool) Callback.t -> 'a t -> 'a t
+
+  val partition : ('a, bool) Callback.t -> 'a t -> 'a t * 'a t
+
+  val choose : 'a t -> 'a Binding.t
+
+  val choose_opt : 'a t -> 'a Binding.t option
+
+  val min_binding : 'a t -> 'a Binding.t
+
+  val min_binding_opt : 'a t -> 'a Binding.t option
+
+  val max_binding : 'a t -> 'a Binding.t
+
+  val max_binding_opt : 'a t -> 'a Binding.t option
+
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+  val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+
+  val split :
+    found:('a -> 'b) -> not_found:'b -> key -> 'a t -> 'a t * 'b * 'a t
+
+  val to_list_unordered : 'a t -> 'a Binding.t list
+
+  val merge :
+    'c is_value ->
+    (key -> 'a option -> 'b option -> 'c option) ->
+    'a t ->
+    'b t ->
+    'c t
+
+  val find_opt : key -> 'a t -> 'a option
+
+  (* CR lmaurer: The [find_*] functions could be wrapped more efficiently, but
+     currently they're all unimplemented anyway *)
+  val find_first : (key -> 'a -> bool) -> 'a t -> 'a Binding.t
+
+  val find_first_opt : (key -> 'a -> bool) -> 'a t -> 'a Binding.t option
+
+  val find_last : (key -> 'a -> bool) -> 'a t -> 'a Binding.t
+
+  val find_last_opt : (key -> 'a -> bool) -> 'a t -> 'a Binding.t option
+
+  val get_singleton : 'a t -> 'a Binding.t option
+
+  val map : 'b is_value -> ('a -> 'b) -> 'a t -> 'b t
+
+  val map_sharing : ('a -> 'a) -> 'a t -> 'a t
+
+  val mapi : 'b is_value -> ('a, 'b) Callback.t -> 'a t -> 'b t
+
+  val to_seq : 'a t -> 'a Binding.t Seq.t
+
+  val to_rev_seq : 'a t -> 'a Binding.t Seq.t
+
+  val to_seq_from : key -> 'a t -> 'a Binding.t Seq.t
+
+  val add_seq : 'a Binding.t Seq.t -> 'a t -> 'a t
+
+  val of_seq : 'a is_value -> 'a Binding.t Seq.t -> 'a t
+
+  val of_list : 'a is_value -> 'a Binding.t list -> 'a t
+
+  val disjoint_union :
+    ?eq:('a -> 'a -> bool) ->
+    print:(Format.formatter -> key -> unit) ->
+    'a t ->
+    'a t ->
+    'a t
+
+  val rename : key t -> key -> key
+
+  val map_keys : (key -> key) -> 'a t -> 'a t
+end = struct
+  include Tree
+
+  let branch prefix bit t0 t1 =
+    match (descr [@inlined hint]) t0, (descr [@inlined hint]) t1 with
+    | Empty, _ -> t1
+    | _, Empty -> t0
+    | _, _ -> Tree.branch prefix bit t0 t1
+    [@@inline always]
+
+  let branch_non_empty prefix bit t0 t1 =
+    (Tree.branch [@inlined hint]) prefix bit t0 t1
+    [@@inline always]
 
   let is_empty t =
-    match t with Empty -> true | Leaf _ -> false | Branch _ -> false
+    match descr t with Empty -> true | Leaf _ -> false | Branch _ -> false
 
-  let print_debug print_datum ppf t =
-    let rec pp ppf t =
-      match t with
-      | Empty -> Format.pp_print_string ppf "()"
-      | Leaf (k, v) -> Format.fprintf ppf "@[<hv 1>(%x@ %a)@]" k print_datum v
-      | Branch (k1, k2, l, r) ->
-        Format.fprintf ppf "@[<hv 1>(branch@ %x@ %x@ %a@ %a)@]" k1 k2 pp l pp r
-    in
-    pp ppf t
+  let singleton iv i d = leaf iv i d
 
-  let singleton i d = leaf i d
-
-  let zero_bit i bit = i land bit = 0
-
-  let lowest_bit x = x land -x
-
-  let branching_bit prefix0 prefix1 = lowest_bit (prefix0 lxor prefix1)
-
-  let mask i bit = i land (bit - 1)
-
-  let match_prefix i prefix bit = mask i bit = prefix
-
-  let equal_prefix prefix0 bit0 prefix1 bit1 = bit0 = bit1 && prefix0 = prefix1
-
-  let includes_prefix prefix0 bit0 prefix1 bit1 =
-    bit0 - 1 < bit1 - 1 && match_prefix prefix1 prefix0 bit0
-
-  let compare_prefix prefix0 bit0 prefix1 bit1 =
-    let c = compare bit0 bit1 in
-    if c = 0 then compare prefix0 prefix1 else c
-
-  let rec mem i = function
+  let rec mem i t =
+    match descr t with
     | Empty -> false
     | Leaf (j, _) -> j = i
     | Branch (prefix, bit, t0, t1) ->
@@ -512,26 +347,30 @@ struct
     else branch (mask prefix0 bit) bit t1 t0
 
   (* CR mshinwell: This is now [add_or_replace], like [Map] *)
-  let rec add i d = function
-    | Empty -> leaf i d
-    | Leaf (j, _) as t -> if i = j then leaf i d else join i (leaf i d) j t
-    | Branch (prefix, bit, t0, t1) as t ->
+  let rec add i d t =
+    let iv = is_value_of t in
+    match descr t with
+    | Empty -> leaf iv i d
+    | Leaf (j, _) -> if i = j then leaf iv i d else join i (leaf iv i d) j t
+    | Branch (prefix, bit, t0, t1) ->
       if match_prefix i prefix bit
       then
         if zero_bit i bit
         then branch_non_empty prefix bit (add i d t0) t1
         else branch_non_empty prefix bit t0 (add i d t1)
-      else join i (leaf i d) prefix t
+      else join i (leaf iv i d) prefix t
 
-  let rec replace key f = function
-    | Empty -> empty
-    | Leaf (key', datum) as t ->
+  let rec replace key f t =
+    let iv = is_value_of t in
+    match descr t with
+    | Empty -> empty iv
+    | Leaf (key', datum) ->
       if key = key'
       then
         let datum = f datum in
-        leaf key datum
+        leaf iv key datum
       else t
-    | Branch (prefix, bit, t0, t1) as t ->
+    | Branch (prefix, bit, t0, t1) ->
       if match_prefix key prefix bit
       then
         if zero_bit key bit
@@ -539,19 +378,23 @@ struct
         else branch_non_empty prefix bit t0 (replace key f t1)
       else t
 
-  let rec update key f = function
+  let rec update key f t =
+    let iv = is_value_of t in
+    match descr t with
     | Empty -> begin
-      match f None with None -> empty | Some datum -> leaf key datum
+      match f None with None -> empty iv | Some datum -> leaf iv key datum
     end
-    | Leaf (key', datum) as t -> (
+    | Leaf (key', datum) -> (
       if key = key'
       then
-        match f (Some datum) with None -> empty | Some datum -> leaf key datum
+        match f (Some datum) with
+        | None -> empty iv
+        | Some datum -> leaf iv key datum
       else
         match f None with
         | None -> t
-        | Some datum -> join key (leaf key datum) key' t)
-    | Branch (prefix, bit, t0, t1) as t -> (
+        | Some datum -> join key (leaf iv key datum) key' t)
+    | Branch (prefix, bit, t0, t1) -> (
       if match_prefix key prefix bit
       then
         if zero_bit key bit
@@ -560,12 +403,14 @@ struct
       else
         match f None with
         | None -> t
-        | Some datum -> join key (leaf key datum) prefix t)
+        | Some datum -> join key (leaf iv key datum) prefix t)
 
-  let rec remove i = function
-    | Empty -> empty
-    | Leaf (j, _) as t -> if i = j then empty else t
-    | Branch (prefix, bit, t0, t1) as t ->
+  let rec remove i t =
+    let iv = is_value_of t in
+    match descr t with
+    | Empty -> empty iv
+    | Leaf (j, _) -> if i = j then empty iv else t
+    | Branch (prefix, bit, t0, t1) ->
       if match_prefix i prefix bit
       then
         if zero_bit i bit
@@ -577,23 +422,24 @@ struct
   (* CR pchambart: union x x is expensive, while it could be O(1). This would
      require that we demand f x x = x *)
   let rec union f t0 t1 =
-    match t0, t1 with
+    let iv = is_value_of t0 in
+    match descr t0, descr t1 with
     | Empty, _ -> t1
     | _, Empty -> t0
     | Leaf (i, d0), Leaf (j, d1) when i = j -> begin
       (* CR mshinwell: [join] in [Typing_env_level] is relying on the fact that
          the arguments to [f] are always in the correct order, i.e. that the
          first datum comes from [t0] and the second from [t1]. Document. *)
-      match f i d0 d1 with None -> empty | Some datum -> leaf i datum
+      match f i d0 d1 with None -> empty iv | Some datum -> leaf iv i datum
     end
-    | Leaf (i, d0), Leaf (j, _) -> join i (leaf i d0) j t1
+    | Leaf (i, d0), Leaf (j, _) -> join i (leaf iv i d0) j t1
     | Leaf (i, d), Branch (prefix, bit, t10, t11) ->
       if match_prefix i prefix bit
       then
         if zero_bit i bit
         then branch prefix bit (union f t0 t10) t11
         else branch prefix bit t10 (union f t0 t11)
-      else join i (leaf i d) prefix t1
+      else join i (leaf iv i d) prefix t1
     | Branch (prefix, bit, t00, t01), Leaf (i, d) ->
       if match_prefix i prefix bit
       then
@@ -602,7 +448,7 @@ struct
         if zero_bit i bit
         then branch prefix bit (union f t1 t00) t01
         else branch prefix bit t00 (union f t1 t01)
-      else join i (leaf i d) prefix t0
+      else join i (leaf iv i d) prefix t0
     | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
       if equal_prefix prefix0 bit0 prefix1 bit1
       then branch prefix0 bit0 (union f t00 t10) (union f t01 t11)
@@ -621,7 +467,7 @@ struct
   (* CR mshinwell: rename to subset_domain and inter_domain? *)
 
   let rec subset t0 t1 =
-    match t0, t1 with
+    match descr t0, descr t1 with
     | Empty, _ -> true
     | _, Empty -> false
     | Branch _, Leaf _ -> false
@@ -634,11 +480,12 @@ struct
       else false
 
   let rec inter_domains t0 t1 =
-    match t0, t1 with
-    | Empty, _ -> empty
-    | _, Empty -> empty
-    | Leaf (i, _), _ -> if mem i t1 then t0 else empty
-    | _, Leaf (i, _) -> if mem i t0 then t1 else empty
+    let iv = is_value_of t0 in
+    match descr t0, descr t1 with
+    | Empty, _ -> empty iv
+    | _, Empty -> empty iv
+    | Leaf (i, _), _ -> if mem i t1 then t0 else empty iv
+    | _, Leaf (i, _) -> if mem i t0 then t1 else empty iv
     | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
       if equal_prefix prefix0 bit0 prefix1 bit1
       then branch prefix0 bit0 (inter_domains t00 t10) (inter_domains t01 t11)
@@ -652,9 +499,10 @@ struct
         if zero_bit prefix0 bit1
         then inter_domains t0 t10
         else inter_domains t0 t11
-      else empty
+      else empty iv
 
-  let rec find i = function
+  let rec find i t =
+    match descr t with
     | Empty -> raise Not_found
     | Leaf (j, d) -> if j = i then d else raise Not_found
     | Branch (prefix, bit, t0, t1) ->
@@ -664,31 +512,33 @@ struct
       then find i t0
       else find i t1
 
-  let rec inter f t0 t1 =
-    match t0, t1 with
-    | Empty, _ -> empty
-    | _, Empty -> empty
+  let rec inter iv f t0 t1 =
+    match descr t0, descr t1 with
+    | Empty, _ -> empty iv
+    | _, Empty -> empty iv
     | Leaf (i, d0), _ -> begin
       match find i t1 with
-      | exception Not_found -> empty
-      | d1 -> leaf i (f i d0 d1)
+      | exception Not_found -> empty iv
+      | d1 -> leaf iv i (f i d0 d1)
     end
     | _, Leaf (i, d1) -> begin
       match find i t0 with
-      | exception Not_found -> empty
-      | d0 -> leaf i (f i d0 d1)
+      | exception Not_found -> empty iv
+      | d0 -> leaf iv i (f i d0 d1)
     end
     | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
       if equal_prefix prefix0 bit0 prefix1 bit1
-      then branch prefix0 bit0 (inter f t00 t10) (inter f t01 t11)
+      then branch prefix0 bit0 (inter iv f t00 t10) (inter iv f t01 t11)
       else if includes_prefix prefix0 bit0 prefix1 bit1
-      then if zero_bit prefix1 bit0 then inter f t00 t1 else inter f t01 t1
+      then
+        if zero_bit prefix1 bit0 then inter iv f t00 t1 else inter iv f t01 t1
       else if includes_prefix prefix1 bit1 prefix0 bit0
-      then if zero_bit prefix0 bit1 then inter f t0 t10 else inter f t0 t11
-      else empty
+      then
+        if zero_bit prefix0 bit1 then inter iv f t0 t10 else inter iv f t0 t11
+      else empty iv
 
   let rec inter_domain_is_non_empty t0 t1 =
-    match t0, t1 with
+    match descr t0, descr t1 with
     | Empty, _ | _, Empty -> false
     | Leaf (i, _), _ -> mem i t1
     | _, Leaf (i, _) -> mem i t0
@@ -709,10 +559,11 @@ struct
       else false
 
   let rec diff t0 t1 =
-    match t0, t1 with
-    | Empty, _ -> empty
+    let iv = is_value_of t0 in
+    match descr t0, descr t1 with
+    | Empty, _ -> empty iv
     | _, Empty -> t0
-    | Leaf (i, _), _ -> if mem i t1 then empty else t0
+    | Leaf (i, _), _ -> if mem i t1 then empty iv else t0
     | _, Leaf (i, _) -> remove i t0
     | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
       if equal_prefix prefix0 bit0 prefix1 bit1
@@ -726,91 +577,91 @@ struct
       then if zero_bit prefix0 bit1 then diff t0 t10 else diff t0 t11
       else t0
 
-  let rec cardinal = function
+  let rec cardinal t =
+    match descr t with
     | Empty -> 0
     | Leaf _ -> 1
     | Branch (_, _, t0, t1) -> cardinal t0 + cardinal t1
 
-  let rec iter f = function
+  let rec iter f t =
+    match descr t with
     | Empty -> ()
-    | Leaf (key, d) -> f key d
+    | Leaf (key, d) -> Callback.call f key d
     | Branch (_, _, t0, t1) ->
       iter f t0;
       iter f t1
 
   let rec fold f t acc =
-    match t with
+    match descr t with
     | Empty -> acc
-    | Leaf (key, d) -> f key d acc
+    | Leaf (key, d) -> Callback.call f key d acc
     | Branch (_, _, t0, t1) -> fold f t0 (fold f t1 acc)
 
-  let rec for_all p = function
+  let rec for_all p t =
+    match descr t with
     | Empty -> true
-    | Leaf (key, d) -> p key d
+    | Leaf (key, d) -> Callback.call p key d
     | Branch (_, _, t0, t1) -> for_all p t0 && for_all p t1
 
-  let rec exists p = function
+  let rec exists p t =
+    match descr t with
     | Empty -> false
-    | Leaf (key, d) -> p key d
+    | Leaf (key, d) -> Callback.call p key d
     | Branch (_, _, t0, t1) -> exists p t0 || exists p t1
 
   let filter p t =
-    let rec loop acc = function
+    let rec loop acc t =
+      match descr t with
       | Empty -> acc
-      | Leaf (i, d) -> if p i d then add i d acc else acc
+      | Leaf (i, d) -> if Callback.call p i d then add i d acc else acc
       | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
     in
-    loop empty t
+    loop (empty (is_value_of t)) t
 
   let partition p t =
-    let rec loop ((true_, false_) as acc) = function
+    let rec loop ((true_, false_) as acc) t =
+      match descr t with
       | Empty -> acc
       | Leaf (i, d) ->
-        if p i d then add i d true_, false_ else true_, add i d false_
+        if Callback.call p i d
+        then add i d true_, false_
+        else true_, add i d false_
       | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
     in
+    let empty = empty (is_value_of t) in
     loop (empty, empty) t
 
-  let rec choose = function
+  let rec choose t =
+    match descr t with
     | Empty -> raise Not_found
-    | Leaf (key, d) -> key, d
+    | Leaf (key, d) -> Binding.create key d
     | Branch (_, _, t0, _) -> choose t0
 
   let choose_opt t =
     match choose t with exception Not_found -> None | choice -> Some choice
 
-  let elements t =
-    let rec loop acc = function
-      | Empty -> acc
-      | Leaf (_, d) -> d :: acc
-      | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
-    in
-    loop [] t
-
-  let min_binding t =
-    let rec loop = function
+  let[@inline always] min_binding_by ~compare_key (t : 'a t) : 'a Binding.t =
+    let rec loop t =
+      match descr t with
       | Empty -> raise Not_found
-      | Leaf (i, d) -> i, d
+      | Leaf (i, d) -> Binding.create i d
       | Branch (_, _, t0, t1) ->
-        let i0, d0 = loop t0 in
-        let i1, d1 = loop t1 in
-        if i0 < i1 then i0, d0 else i1, d1
+        let b0 = loop t0 in
+        let b1 = loop t1 in
+        if (compare_key [@inlined hint]) (Binding.key b0) (Binding.key b1) < 0
+        then b0
+        else b1
     in
     loop t
+
+  let min_binding t = min_binding_by ~compare_key:Int.compare t
 
   let min_binding_opt t =
     match min_binding t with exception Not_found -> None | min -> Some min
 
   let max_binding t =
-    let rec loop = function
-      | Empty -> raise Not_found
-      | Leaf (i, d) -> i, d
-      | Branch (_, _, t0, t1) ->
-        let i0, d0 = loop t0 in
-        let i1, d1 = loop t1 in
-        if i0 > i1 then i0, d0 else i1, d1
-    in
-    loop t
+    let[@inline always] compare_key i1 i2 = Int.compare i2 i1 in
+    min_binding_by ~compare_key t
 
   let max_binding_opt t =
     match max_binding t with exception Not_found -> None | max -> Some max
@@ -819,7 +670,7 @@ struct
     if t0 == t1
     then true
     else
-      match t0, t1 with
+      match descr t0, descr t1 with
       | Empty, Empty -> true
       | Leaf (i, d0), Leaf (j, d1) -> i = j && f d0 d1
       | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
@@ -829,7 +680,7 @@ struct
       | _, _ -> false
 
   let rec compare f t0 t1 =
-    match t0, t1 with
+    match descr t0, descr t1 with
     | Empty, Empty -> 0
     | Leaf (i, d0), Leaf (j, d1) ->
       let c = if i = j then 0 else if i < j then -1 else 1 in
@@ -848,94 +699,119 @@ struct
     | Branch _, Empty -> -1
     | Branch _, Leaf _ -> -1
 
-  let split i t =
-    let rec loop ((lt, mem, gt) as acc) = function
+  let[@inline always] split ~found ~not_found i t =
+    let rec loop ((lt, mem, gt) as acc) t =
+      match descr t with
       | Empty -> acc
       | Leaf (j, d) ->
         if i = j
-        then lt, Some d, gt
+        then lt, (found [@inlined hint]) d, gt
         else if j < i
         then add j d lt, mem, gt
         else lt, mem, add j d gt
       | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
     in
-    loop (empty, None, empty) t
+    let empty = empty (is_value_of t) in
+    loop (empty, not_found, empty) t
 
-  let rec bindings_aux acc t =
-    match t with
-    | Empty -> acc
-    | Leaf (key, d) -> (key, d) :: acc
-    | Branch (_, _, t0, t1) -> bindings_aux (bindings_aux acc t0) t1
+  let to_list_unordered t =
+    let rec loop acc t =
+      match descr t with
+      | Empty -> acc
+      | Leaf (i, d) -> Binding.create i d :: acc
+      | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
+    in
+    loop [] t
 
-  let bindings s =
-    List.sort (fun (id1, _) (id2, _) -> Int.compare id1 id2) (bindings_aux [] s)
-
+  (* CR lmaurer: We could borrow Haskell's trick and generalize this function
+     quite a bit, giving us a single implementation of [union], [inter], etc.
+     without sacrificing sharing. It also avoids passing or returning options.
+     We could even turn it into a functor over three [Tree] instances and get
+     arbitrary combinations of taking and returning sets and maps. *)
   let rec merge' :
-      type a b c. (key -> a option -> b option -> c option) -> a t -> b t -> c t
-      =
-   fun f t0 t1 ->
-    match t0, t1 with
+      type a b c.
+      c Tree.is_value ->
+      (key -> a option -> b option -> c option) ->
+      a t ->
+      b t ->
+      c t =
+   fun iv f t0 t1 ->
+    let iv0 = is_value_of t0 in
+    let iv1 = is_value_of t1 in
+    match descr t0, descr t1 with
     (* Empty cases, just recurse and be sure to call f on all leaf cases
        recursively *)
-    | Empty, Empty -> empty
+    | Empty, Empty -> empty iv
     | Empty, Leaf (i, d) -> begin
-      match f i None (Some d) with None -> empty | Some d' -> leaf i d'
+      match f i None (Some d) with None -> empty iv | Some d' -> leaf iv i d'
     end
     | Leaf (i, d), Empty -> begin
-      match f i (Some d) None with None -> empty | Some d' -> leaf i d'
+      match f i (Some d) None with None -> empty iv | Some d' -> leaf iv i d'
     end
     | Empty, Branch (prefix, bit, t10, t11) ->
-      branch prefix bit (merge' f t0 t10) (merge' f t0 t11)
+      branch prefix bit (merge' iv f t0 t10) (merge' iv f t0 t11)
     | Branch (prefix, bit, t00, t01), Empty ->
-      branch prefix bit (merge' f t00 t1) (merge' f t01 t1)
+      branch prefix bit (merge' iv f t00 t1) (merge' iv f t01 t1)
     (* Leaf cases *)
     | Leaf (i, d0), Leaf (j, d1) when i = j -> begin
       match f i (Some d0) (Some d1) with
-      | None -> empty
-      | Some datum -> leaf i datum
+      | None -> empty iv
+      | Some datum -> leaf iv i datum
     end
     | Leaf (i, d0), Leaf (j, d1) -> begin
       match f i (Some d0) None, f j None (Some d1) with
-      | None, None -> empty
-      | Some d0, None -> leaf i d0
-      | None, Some d1 -> leaf j d1
-      | Some d0, Some d1 -> join i (leaf i d0) j (leaf j d1)
+      | None, None -> empty iv
+      | Some d0, None -> leaf iv i d0
+      | None, Some d1 -> leaf iv j d1
+      | Some d0, Some d1 -> join i (leaf iv i d0) j (leaf iv j d1)
     end
     (* leaf <-> Branch cases *)
     | Leaf (i, d), Branch (prefix, bit, t10, t11) -> (
       if match_prefix i prefix bit
       then
         if zero_bit i bit
-        then branch prefix bit (merge' f t0 t10) (merge' f empty t11)
-        else branch prefix bit (merge' f empty t10) (merge' f t0 t11)
+        then
+          branch prefix bit (merge' iv f t0 t10) (merge' iv f (empty iv0) t11)
+        else
+          branch prefix bit (merge' iv f (empty iv0) t10) (merge' iv f t0 t11)
       else
         match f i (Some d) None with
-        | None -> merge' f empty t1
-        | Some d -> join i (leaf i d) prefix (merge' f empty t1))
+        | None -> merge' iv f (empty iv0) t1
+        | Some d -> join i (leaf iv i d) prefix (merge' iv f (empty iv0) t1))
     | Branch (prefix, bit, t00, t01), Leaf (i, d) -> (
       if match_prefix i prefix bit
       then
         if zero_bit i bit
-        then branch prefix bit (merge' f t00 t1) (merge' f t01 empty)
-        else branch prefix bit (merge' f t00 empty) (merge' f t01 t1)
+        then
+          branch prefix bit (merge' iv f t00 t1) (merge' iv f t01 (empty iv1))
+        else
+          branch prefix bit (merge' iv f t00 (empty iv1)) (merge' iv f t01 t1)
       else
         match f i None (Some d) with
-        | None -> merge' f t0 empty
-        | Some d -> join i (leaf i d) prefix (merge' f t0 empty))
+        | None -> merge' iv f t0 (empty iv1)
+        | Some d -> join i (leaf iv i d) prefix (merge' iv f t0 (empty iv1)))
     | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
       if equal_prefix prefix0 bit0 prefix1 bit1
-      then branch prefix0 bit0 (merge' f t00 t10) (merge' f t01 t11)
+      then branch prefix0 bit0 (merge' iv f t00 t10) (merge' iv f t01 t11)
       else if includes_prefix prefix0 bit0 prefix1 bit1
       then
         if zero_bit prefix1 bit0
-        then branch prefix0 bit0 (merge' f t00 t1) (merge' f t01 empty)
-        else branch prefix0 bit0 (merge' f t00 empty) (merge' f t01 t1)
+        then
+          branch prefix0 bit0 (merge' iv f t00 t1) (merge' iv f t01 (empty iv1))
+        else
+          branch prefix0 bit0 (merge' iv f t00 (empty iv1)) (merge' iv f t01 t1)
       else if includes_prefix prefix1 bit1 prefix0 bit0
       then
         if zero_bit prefix0 bit1
-        then branch prefix1 bit1 (merge' f t0 t10) (merge' f empty t11)
-        else branch prefix1 bit1 (merge' f empty t10) (merge' f t0 t11)
-      else join prefix0 (merge' f t0 empty) prefix1 (merge' f empty t1)
+        then
+          branch prefix1 bit1 (merge' iv f t0 t10) (merge' iv f (empty iv0) t11)
+        else
+          branch prefix1 bit1 (merge' iv f (empty iv0) t10) (merge' iv f t0 t11)
+      else
+        join prefix0
+          (merge' iv f t0 (empty iv1))
+          prefix1
+          (merge' iv f (empty iv0) t1)
 
   let find_opt t key =
     match find t key with exception Not_found -> None | datum -> Some datum
@@ -949,41 +825,44 @@ struct
   let find_last_opt _ _ = Misc.fatal_error "find_last_opt not yet implemented"
 
   let get_singleton t =
-    match t with
+    match descr t with
     | Empty | Branch _ -> None
-    | Leaf (key, datum) -> Some (key, datum)
+    | Leaf (key, datum) -> Some (Binding.create key datum)
 
-  let rec map f t =
-    match t with
-    | Empty -> empty
-    | Leaf (k, datum) -> leaf k (f datum)
-    | Branch (prefix, bit, t0, t1) -> branch prefix bit (map f t0) (map f t1)
+  let rec map iv f t =
+    match descr t with
+    | Empty -> empty iv
+    | Leaf (k, datum) -> leaf iv k (f datum)
+    | Branch (prefix, bit, t0, t1) ->
+      branch prefix bit (map iv f t0) (map iv f t1)
 
   let rec map_sharing f t =
-    match t with
+    let iv = is_value_of t in
+    match descr t with
     | Empty -> t
     | Leaf (k, v) ->
       let v' = f v in
-      if v == v' then t else leaf k v'
+      if v == v' then t else leaf iv k v'
     | Branch (prefix, bit, t0, t1) ->
       let t0' = map_sharing f t0 in
       let t1' = map_sharing f t1 in
       if t0' == t0 && t1' == t1 then t else branch prefix bit t0' t1'
 
-  let rec mapi f t =
-    match t with
-    | Empty -> empty
-    | Leaf (key, datum) -> leaf key (f key datum)
-    | Branch (prefix, bit, t0, t1) -> branch prefix bit (mapi f t0) (mapi f t1)
+  let rec mapi iv f t =
+    match descr t with
+    | Empty -> empty iv
+    | Leaf (key, datum) -> leaf iv key (Callback.call f key datum)
+    | Branch (prefix, bit, t0, t1) ->
+      branch prefix bit (mapi iv f t0) (mapi iv f t1)
 
   let to_seq t =
     let rec aux acc () =
       match acc with
       | [] -> Seq.Nil
       | t0 :: r -> begin
-        match t0 with
+        match descr t0 with
         | Empty -> aux r ()
-        | Leaf (key, value) -> Seq.Cons ((key, value), aux r)
+        | Leaf (key, value) -> Seq.Cons (Binding.create key value, aux r)
         | Branch (_, _, t1, t2) -> aux (t1 :: t2 :: r) ()
       end
     in
@@ -999,25 +878,21 @@ struct
 
   (* CR mshinwell: copied from [Container_types] *)
 
-  let filter_map f t =
-    fold
-      (fun id v map -> match f id v with None -> map | Some r -> add id r map)
-      t empty
-
-  let of_list l = List.fold_left (fun map (id, v) -> add id v map) empty l
+  let[@inline always] of_list iv l =
+    List.fold_left
+      (fun map b -> add (Binding.key b) (Binding.value iv b) map)
+      (empty iv) l
 
   let merge f t0 t1 = merge' f t0 t1
 
   (* CR mshinwell: fix this *)
-  let disjoint_union ?eq ?print t1 t2 =
+  let[@inline always] disjoint_union ?eq ~print t1 t2 =
     if t1 == t2
     then t1
-    else begin
-      ignore print;
+    else
       let fail key =
         Misc.fatal_errorf
-          "Patricia_tree.disjoint_union: key %a is in intersection" Key.print
-          key
+          "Patricia_tree.disjoint_union: key %a is in intersection" print key
       in
       union
         (fun key datum1 datum2 ->
@@ -1025,35 +900,198 @@ struct
           | None -> fail key
           | Some eq -> if eq datum1 datum2 then Some datum1 else fail key)
         t1 t2
-    end
 
   let rename _ _ = Misc.fatal_error "rename not yet implemented"
 
-  let map_keys _ _ = Misc.fatal_error "map_keys not yet implemented"
+  let map_keys f t =
+    let iv = is_value_of t in
+    fold (Callback.of_func iv (fun i d acc -> add (f i) d acc)) t (empty iv)
+end
+[@@inline always]
 
-  let [@ocamlformat "disable"] print print_datum ppf t =
-    if is_empty t then
-      Format.fprintf ppf "{}"
-    else
-      Format.fprintf ppf "@[<hov 1>{%a}@]"
-        (Format.pp_print_list ~pp_sep:Format.pp_print_space
-          (fun ppf (key, datum) ->
-            Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
-              Key.print key print_datum datum))
-        (bindings t)
+module Set = struct
+  type elt = key
 
+  type t = unit t0
+
+  and 'a t0 = 'a Set0.t =
+    | Empty : unit t0
+    | Leaf : elt -> unit t0
+    | Branch : elt * elt * unit t0 * unit t0 -> unit t0
+
+  module Ops = Tree_operations (Set0)
+  include Ops
+  module Binding = Set0.Binding
+
+  let empty = Empty
+
+  let singleton i = Ops.singleton Unit i ()
+
+  let add i t = Ops.add i () t
+
+  (* CR lmaurer: This is slow, but [Ops.union] is hard to specialize *)
+  let union t0 t1 = Ops.union (fun _ () () -> Some ()) t0 t1
+
+  let intersection_is_empty t0 t1 = not (Ops.inter_domain_is_non_empty t0 t1)
+
+  (* CR lmaurer: Also should probably be specialized *)
+  let inter t0 t1 = Ops.inter Unit (fun _ () () -> ()) t0 t1
+
+  let rec union_list ts =
+    match ts with [] -> empty | t :: ts -> union t (union_list ts)
+
+  let filter_map f t =
+    let rec loop f acc = function
+      | Empty -> acc
+      | Leaf i -> begin match f i with None -> acc | Some j -> add j acc end
+      | Branch (_, _, t0, t1) -> loop f (loop f acc t0) t1
+    in
+    loop f Empty t
+
+  let elements = Ops.to_list_unordered
+
+  let min_elt = Ops.min_binding
+
+  let min_elt_opt = Ops.min_binding_opt
+
+  let max_elt = Ops.max_binding
+
+  let max_elt_opt = Ops.max_binding_opt
+
+  let equal t0 t1 = Ops.equal (fun () () -> true) t0 t1
+
+  let compare t0 t1 = Ops.compare (fun () () -> 0) t0 t1
+
+  let split i t = Ops.split ~found:(fun () -> true) ~not_found:false i t
+
+  let find_opt _ _ = Misc.fatal_error "find_opt not yet implemented"
+
+  let find_first f t = find_first (fun key () -> f key) t |> Binding.key
+
+  let find_first_opt f t =
+    find_first_opt (fun key () -> f key) t |> Option.map Binding.key
+
+  let find_last f t = find_last (fun key () -> f key) t |> Binding.key
+
+  let find_last_opt f t =
+    find_last_opt (fun key () -> f key) t |> Option.map Binding.key
+
+  let find elt t = if mem elt t then elt else raise Not_found
+
+  let of_seq seq = Ops.of_seq Unit seq
+
+  let of_list l = Ops.of_list Unit l
+
+  let map f t = Ops.map_keys f t
+
+  (* CR lmaurer: Obviously this is just [intersection_is_empty], no? *)
+  let disjoint _ _ = Misc.fatal_error "disjoint not yet implemented"
+end
+
+module Map = struct
+  include Map0
+  module Ops = Tree_operations (Map0)
+  include Ops
+
+  let empty = Empty
+
+  let singleton i d = Ops.singleton Any i d
+
+  let inter f t0 t1 = Ops.inter Any f t0 t1
+
+  let split i t = Ops.split ~found:(fun a -> Some a) ~not_found:None i t
+
+  let bindings s =
+    List.sort
+      (fun (id1, _) (id2, _) -> Int.compare id1 id2)
+      (Ops.to_list_unordered s)
+
+  let find_first f t = Ops.find_first (fun key _ -> f key) t
+
+  let find_first_opt f t = Ops.find_first_opt (fun key _ -> f key) t
+
+  let find_last f t = Ops.find_first (fun key _ -> f key) t
+
+  let find_last_opt f t = Ops.find_first_opt (fun key _ -> f key) t
+
+  let map f t = Ops.map Any f t
+
+  let mapi f t = Ops.mapi Any f t
+
+  let of_seq seq = Ops.of_seq Any seq
+
+  let filter_map f t =
+    fold
+      (fun id v map -> match f id v with None -> map | Some r -> add id r map)
+      t empty
+
+  let of_list l = Ops.of_list Any l
+
+  let merge f t0 t1 = Ops.merge Any f t0 t1
+
+  (* CR lmaurer: This should be doable as a map operation if we generalize
+     [Ops.map] by letting the returned tree be built by a different [Tree]
+     module *)
   let keys map = fold (fun k _ set -> Set.add k set) map Set.empty
 
   let data t = List.map snd (bindings t)
 
+  (* CR lmaurer: See comment on [keys] *)
   let of_set f set = Set.fold (fun e map -> add e (f e) map) set empty
 
   let diff_domains = diff
 
-  let () =
-    ignore subset;
-    ignore inter_domains;
-    ignore diff;
-    ignore elements
+  let () = ignore Ops.inter_domains
+end
+
+module Make (X : sig
+  val print : Format.formatter -> key -> unit
+end) =
+struct
+  module Set = struct
+    include Set
+    module Elt = X
+
+    let [@ocamlformat "disable"] print ppf s =
+      let elts ppf s = iter (fun e -> Format.fprintf ppf "@ %a" Elt.print e) s in
+      Format.fprintf ppf "@[<1>{@[%a@ @]}@]" elts s
+
+    let to_string s = Format.asprintf "%a" print s
+  end
+
+  module Map = struct
+    include Map
+    module Key = X
+
+    type nonrec key = key
+
+    module Set = Set
+
+    let [@ocamlformat "disable"] print_debug print_datum ppf t =
+      let rec pp ppf t =
+        match t with
+        | Empty -> Format.pp_print_string ppf "()"
+        | Leaf (k, v) -> Format.fprintf ppf "@[<hv 1>(%x@ %a)@]" k print_datum v
+        | Branch (k1, k2, l, r) ->
+          Format.fprintf ppf "@[<hv 1>(branch@ %x@ %x@ %a@ %a)@]" k1 k2 pp l
+            pp r
+      in
+      pp ppf t
+
+    let disjoint_union ?eq ?print t1 t2 =
+      ignore print;
+      Ops.disjoint_union ~print:Key.print ?eq t1 t2
+
+    let [@ocamlformat "disable"] print print_datum ppf t =
+      if is_empty t then
+        Format.fprintf ppf "{}"
+      else
+        Format.fprintf ppf "@[<hov 1>{%a}@]"
+          (Format.pp_print_list ~pp_sep:Format.pp_print_space
+             (fun ppf (key, datum) ->
+                Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
+                  Key.print key print_datum datum))
+          (bindings t)
+  end
 end
 [@@inline always]

--- a/middle_end/flambda2/algorithms/patricia_tree.mli
+++ b/middle_end/flambda2/algorithms/patricia_tree.mli
@@ -14,15 +14,11 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-module Make_set (_ : sig
+module Make (_ : sig
   val print : Format.formatter -> int -> unit
 end) : sig
-  include Container_types.Set with module T := Numbers.Int
-end
+  module Set : Container_types.Set with module T := Numbers.Int
 
-module Make_map (_ : sig
-  val print : Format.formatter -> int -> unit
-end)
-(Set : Container_types.Set with module T := Numbers.Int) : sig
-  include Container_types.Map with module T := Numbers.Int with module Set = Set
+  module Map :
+    Container_types.Map with module T := Numbers.Int with module Set = Set
 end

--- a/middle_end/flambda2/algorithms/patricia_tree.mli
+++ b/middle_end/flambda2/algorithms/patricia_tree.mli
@@ -17,8 +17,7 @@
 module Make (_ : sig
   val print : Format.formatter -> int -> unit
 end) : sig
-  module Set : Container_types.Set with module T := Numbers.Int
+  module Set : Container_types.Set with type elt = int
 
-  module Map :
-    Container_types.Map with module T := Numbers.Int with module Set = Set
+  module Map : Container_types.Map with type key = int with module Set = Set
 end

--- a/middle_end/flambda2/identifiers/continuation.ml
+++ b/middle_end/flambda2/identifiers/continuation.ml
@@ -184,16 +184,12 @@ include Container_types.Make (struct
     Format.fprintf ppf "@<0>%s" (Flambda_colours.normal ())
 end)
 
-module Set = Patricia_tree.Make_set (struct
+module Tree = Patricia_tree.Make (struct
   let print = print
 end)
 
-module Map =
-  Patricia_tree.Make_map
-    (struct
-      let print = print
-    end)
-    (Set)
+module Set = Tree.Set
+module Map = Tree.Map
 
 let export t = find_data t
 

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -343,16 +343,12 @@ module Const = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct
+  module Tree = Patricia_tree.Make (struct
     let print = print
   end)
 
-  module Map =
-    Patricia_tree.Make_map
-      (struct
-        let print = print
-      end)
-      (Set)
+  module Set = Tree.Set
+  module Map = Tree.Map
 
   let export t = find_data t
 
@@ -426,16 +422,12 @@ module Variable = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct
+  module Tree = Patricia_tree.Make (struct
     let print = print
   end)
 
-  module Map =
-    Patricia_tree.Make_map
-      (struct
-        let print = print
-      end)
-      (Set)
+  module Set = Tree.Set
+  module Map = Tree.Map
 
   let export t = find_data t
 
@@ -510,16 +502,12 @@ module Symbol = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct
+  module Tree = Patricia_tree.Make (struct
     let print = print
   end)
 
-  module Map =
-    Patricia_tree.Make_map
-      (struct
-        let print = print
-      end)
-      (Set)
+  module Set = Tree.Set
+  module Map = Tree.Map
 
   let export t = find_data t
 
@@ -567,16 +555,12 @@ module Name = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct
+  module Tree = Patricia_tree.Make (struct
     let print = print
   end)
 
-  module Map =
-    Patricia_tree.Make_map
-      (struct
-        let print = print
-      end)
-      (Set)
+  module Set = Tree.Set
+  module Map = Tree.Map
 end
 
 module Rec_info_expr = Rec_info_expr0.Make (Variable)
@@ -717,16 +701,12 @@ module Simple = struct
          [Coercion]"
         print t
 
-  module Set = Patricia_tree.Make_set (struct
+  module Tree = Patricia_tree.Make (struct
     let print = print
   end)
 
-  module Map =
-    Patricia_tree.Make_map
-      (struct
-        let print = print
-      end)
-      (Set)
+  module Set = Tree.Set
+  module Map = Tree.Map
 
   let export t = find_data t
 
@@ -810,17 +790,12 @@ module Code_id = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct
+  module Tree = Patricia_tree.Make (struct
     let print = print
   end)
 
-  module Map =
-    Patricia_tree.Make_map
-      (struct
-        let print = print
-      end)
-      (Set)
-
+  module Set = Tree.Set
+  module Map = Tree.Map
   module Lmap = Lmap.Make (T)
 
   let invert_map map =
@@ -879,17 +854,12 @@ module Code_id_or_symbol = struct
     include T0
   end
 
-  module Set = Patricia_tree.Make_set (struct
+  module Tree = Patricia_tree.Make (struct
     let print = print
   end)
 
-  module Map =
-    Patricia_tree.Make_map
-      (struct
-        let print = print
-      end)
-      (Set)
-
+  module Set = Tree.Set
+  module Map = Tree.Map
   module Lmap = Lmap.Make (T)
 
   let set_of_code_id_set code_ids =

--- a/middle_end/flambda2/numbers/numeric_types.mli
+++ b/middle_end/flambda2/numbers/numeric_types.mli
@@ -20,7 +20,7 @@
     {{!Compiler_libs}compiler-libs}. *)
 
 module Int : sig
-  include Container_types.S with type t = int
+  include Container_types.S_plus_stdlib with type t = int
 
   (** [zero_to_n n] is the set of numbers \{0, ..., n\} (inclusive). *)
   val zero_to_n : int -> Set.t

--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -308,7 +308,8 @@ module Dependency_graph = struct
     }
 
   module Reachable = struct
-    module Edge (Src_map : Map.S) (Dst_set : Set.S) = struct
+    module Edge (Src_map : Container_types.Map) (Dst_set : Container_types.Set) =
+    struct
       type src = Src_map.key
 
       type dst = Dst_set.elt

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -25,13 +25,13 @@ let keep_lifted_constant_only_if_used uacc acc lifted_constant =
     | Unknown -> Bound_static.binds_code bound
     | Known { live_code_ids = _; ancestors_of_live_code_ids } ->
       not
-        (Code_id.Set.intersection_is_empty
+        (Code_id.Set.disjoint
            (Bound_static.code_being_defined bound)
            ancestors_of_live_code_ids)
   in
   let symbols_live =
     not
-      (Name.Set.intersection_is_empty
+      (Name.Set.disjoint
          (Name.set_of_symbol_set (Bound_static.symbols_being_defined bound))
          (UA.required_names uacc))
   in

--- a/middle_end/flambda2/term_basics/scope.ml
+++ b/middle_end/flambda2/term_basics/scope.ml
@@ -39,13 +39,9 @@ let to_int t = t
 
 let max t1 t2 = max t1 t2
 
-module Set = Patricia_tree.Make_set (struct
+module Tree = Patricia_tree.Make (struct
   let print = print
 end)
 
-module Map =
-  Patricia_tree.Make_map
-    (struct
-      let print = print
-    end)
-    (Set)
+module Set = Tree.Set
+module Map = Tree.Map

--- a/middle_end/flambda2/types/env/binding_time.ml
+++ b/middle_end/flambda2/types/env/binding_time.ml
@@ -26,8 +26,9 @@ include T
 
 type binding_time = t
 
-module Set = Patricia_tree.Make_set (T)
-module Map = Patricia_tree.Make_map (T) (Set)
+module Tree = Patricia_tree.Make (T)
+module Set = Tree.Set
+module Map = Tree.Map
 
 let strictly_earlier (t : t) ~than = t < than
 


### PR DESCRIPTION
We use Patricia trees to implement both sets and maps. It's tempting then to define `Set.t` as `unit Map.t`, but this wastes a word for every member of every set.

This patch accomplishes much the same thing, without the storage overhead. The idea is to write most of the operations inside a functor that abstracts over the specific tree datatype. With a bit of care, this can be done so that all the abstraction inlines away.

(There is some overhead when compiled with Closure due to its limited inliner, but mostly only with sets (because `Map0.descr` is the identity but `Set0.descr` allocates). Avoiding further allocations largely requires either (a) major surgery on the algorithmic parts, or (b) either local allocations or unboxed types so that returning a view is cheap.)

Besides the obvious savings in repeated code, this should also make it easy to write efficient mixed set/map operations (like restricting a map to the keys in a set in O(n) time).

I've confirmed that the overhead is only ~2 seconds (out of ~100) when compiling the stage1 compiler (via Closure), and negligible when compiled with flambda2. (A few functions gain extra arguments that are always zero.)

There's a lot of changed code here, but most of the sensitive parts of `Make_map` are unchanged but for some extra syntactic noise.