### PR TITLE
Fix CR about evaluation order in To_cmm_primitive etc.

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -162,14 +162,16 @@ let mk_no_flambda2_expert_fallback_inlining_heuristic f =
 let mk_flambda2_expert_inline_effects_in_cmm f =
   "-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
   Printf.sprintf " Allow inlining of effectful\n\
-      \     expressions in the produced Cmm code%s (Flambda 2 only)"
+      \     expressions in the produced Cmm code\n\
+      \     into any context%s (Flambda 2 only)"
     (format_default Flambda2.Expert.Default.inline_effects_in_cmm)
 ;;
 
 let mk_no_flambda2_expert_inline_effects_in_cmm f =
   "-no-flambda2-expert-inline-effects-in-cmm", Arg.Unit f,
-  Printf.sprintf " Prevent inlining of effectful\n\
-      \     expressions in the produced Cmm code%s (Flambda 2 only)"
+  Printf.sprintf " Only allow inlining of effectful\n\
+      \     expressions in the produced Cmm code into\n\
+      \     the arguments of allocation primitives%s (Flambda 2 only)"
     (format_not_default Flambda2.Expert.Default.inline_effects_in_cmm)
 ;;
 

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -51,37 +51,17 @@ let classify_let_binding var
       (* Could be May_inline technically, but it doesn't matter since it can
          only be flushed by the env. *)
   end
-  | One -> begin
-    match effects_and_coeffects_of_defining_expr with
-    (* The decision here is whether to consider the binding for inlining or not.
-       It is always correct to consider an effectful expression for inlining, as
-       the environment is going to handle the details of preserving the effects
-       and coeffects ordering (if inlining without reordering is impossible then
-       the expressions will be bound at some safe place instead).
+  | One ->
+    (* Any defining expression used exactly once is considered for inlining at
+       this stage. The environment is going to handle the details of preserving
+       the effects and coeffects ordering (if inlining without reordering is
+       impossible then the expressions will be bound at some safe place
+       instead).
 
-       So the decision here is about readability of the generated Cmm code
-       (effectful expressions as arguments to other primitives make it hard to
-       follow the order of evaluation) and locality (for deeply nested
-       expressions, binding the sub-expressions outside can keep them alive for
-       longer than strictly necessary).
-
-       The current choice of always inlining pure expressions and expressions
-       with only generative effects is guided by the relatively common case of
-       initialisation of huge static structures (including arrays). Without
-       inlining, all intermediate results would be live for long periods of time
-       and the default register allocator would have trouble dealing with that
-       (it's quadratic in the number of registers live at the same time).
-
-       Deep expressions involving arbitrary effects are less common, so inlining
-       for these expressions is controlled by the global [inline_effects_in_cmm]
-       setting. *)
-    | Only_generative_effects _, _ -> May_inline
-    | Arbitrary_effects, _ ->
-      if Flambda_features.Expert.inline_effects_in_cmm ()
-      then May_inline
-      else Regular
-    | No_effects, _ -> May_inline
-  end
+       Whether inlining of _effectful_ expressions _actually occurs_ depends on
+       the context. Currently this is very restricted, see comments in
+       [To_cmm_primitive]. *)
+    May_inline
   | More_than_one -> Regular
 
 type continuation_handler_classification =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -302,7 +302,7 @@ let will_not_inline_var env v =
     Misc.fatal_errorf "Variable %a not found in env" Variable.print v
   | e -> e, env, Ece.pure
 
-let inline_variable env var =
+let inline_variable ?consider_inlining_effectful_expressions env var =
   match Variable.Map.find var env.pures with
   | binding ->
     if not binding.may_inline
@@ -326,6 +326,10 @@ let inline_variable env var =
       if not (Variable.equal var var_from_stage)
       then will_not_inline_var env var
       else if binding.may_inline
+              &&
+              match consider_inlining_effectful_expressions with
+              | Some consider -> consider
+              | None -> Flambda_features.Expert.inline_effects_in_cmm ()
       then will_inline { env with stages = prev_stages } binding
       else will_not_inline env binding
     | Coeffect_only coeffects :: prev_stages -> (

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -323,13 +323,14 @@ let inline_variable ?consider_inlining_effectful_expressions env var =
          that of [var_from_stage], in the case where these variables are
          different. However if these two variables are in fact the same, we can
          consider inlining the defining expression. *)
+      let consider_inlining_effectful_expressions =
+        match consider_inlining_effectful_expressions with
+        | Some consider -> consider
+        | None -> Flambda_features.Expert.inline_effects_in_cmm ()
+      in
       if not (Variable.equal var var_from_stage)
       then will_not_inline_var env var
-      else if binding.may_inline
-              &&
-              match consider_inlining_effectful_expressions with
-              | Some consider -> consider
-              | None -> Flambda_features.Expert.inline_effects_in_cmm ()
+      else if binding.may_inline && consider_inlining_effectful_expressions
       then will_inline { env with stages = prev_stages } binding
       else will_not_inline env binding
     | Coeffect_only coeffects :: prev_stages -> (

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -136,7 +136,10 @@ val bind_variable :
 
 (** Try and inline an Flambda variable using the delayed let-bindings. *)
 val inline_variable :
-  t -> Variable.t -> Cmm.expression * t * Effects_and_coeffects.t
+  ?consider_inlining_effectful_expressions:bool ->
+  t ->
+  Variable.t ->
+  Cmm.expression * t * Effects_and_coeffects.t
 
 (** Wrap the given Cmm expression with all the delayed let bindings accumulated
     in the environment. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -692,31 +692,68 @@ let variadic_primitive _env dbg f args =
   | Make_block (kind, _mut, alloc_mode) -> make_block ~dbg kind alloc_mode args
   | Make_array (kind, _mut, alloc_mode) -> make_array ~dbg kind alloc_mode args
 
-(* CR Gbury: check the order in which the primitive arguments are given to
-   [Env.inline_variable]. *)
-let prim env res dbg p =
-  match (p : P.t) with
+let prim env res dbg (p : P.t) =
+  let consider_inlining_effectful_expressions =
+    (* By default we are very conservative about the inlining of effectful
+       expressions into the arguments of primitives. We only consider inlining
+       in the case where the primitive compiles directly to an allocation.
+       Unlike for most primitives, inlining of the arguments gives a real
+       benefit for these, by keeping live ranges shorter (which could be
+       critical for register allocation performance in cases such as
+       initialisation of very large arrays). We are also confident that the code
+       for compiling allocations does not incorrectly reorder or duplicate
+       arguments, whereas we are not universally confident about that for the
+       other Cmm translation functions.
+
+       This criterion should not be relaxed for any primitive until it is
+       certain that the Cmm translation for such primitive both respects
+       right-to-left evaluation order and does not duplicate any arguments. *)
+    match p with
+    | Nullary _ | Unary _ | Binary _ | Ternary _ -> None
+    | Variadic ((Make_block _ | Make_array _), _) -> Some true
+  in
+  let simple = C.simple ?consider_inlining_effectful_expressions ~dbg in
+  match p with
   | Nullary prim ->
     let extra, expr = nullary_primitive env dbg prim in
     expr, extra, env, res, Ece.pure
-  | Unary (f, x) ->
-    let x, env, eff = C.simple ~dbg env x in
-    let extra, res, expr = unary_primitive env res dbg f x in
+  | Unary (unary, x) ->
+    let x, env, eff = simple env x in
+    let extra, res, expr = unary_primitive env res dbg unary x in
     expr, extra, env, res, eff
-  | Binary (f, x, y) ->
-    let x, env, effx = C.simple ~dbg env x in
-    let y, env, effy = C.simple ~dbg env y in
+  | Binary (binary, x, y) ->
+    let x, env, effx = simple env x in
+    let y, env, effy = simple env y in
     let effs = Ece.join effx effy in
-    let expr = binary_primitive env dbg f x y in
+    let expr = binary_primitive env dbg binary x y in
     expr, None, env, res, effs
-  | Ternary (f, x, y, z) ->
-    let x, env, effx = C.simple ~dbg env x in
-    let y, env, effy = C.simple ~dbg env y in
-    let z, env, effz = C.simple ~dbg env z in
+  | Ternary (ternary, x, y, z) ->
+    let x, env, effx = simple env x in
+    let y, env, effy = simple env y in
+    let z, env, effz = simple env z in
     let effs = Ece.join (Ece.join effx effy) effz in
-    let expr = ternary_primitive env dbg f x y z in
+    let expr = ternary_primitive env dbg ternary x y z in
     expr, None, env, res, effs
-  | Variadic (f, l) ->
-    let args, env, effs = C.simple_list ~dbg env l in
-    let expr = variadic_primitive env dbg f args in
+  | Variadic (((Make_block _ | Make_array _) as variadic), l) ->
+    (* Somewhat counter-intuitively, this correctly matches right-to-left
+       evaluation order---ensuring maximal inlining---since [C.simple_list]
+       translates the first [Simple] in the list first. Consider in pseudo-code:
+
+       let x = <effect-x> in let y = <effect-y> in Make_block [y; x]
+
+       We would like both [x] and [y] to be inlined. The environment will have
+       [y] on the most recent stage since it was the most recent binding. The
+       [Simple] for [y] will be translated first by the code below, meaning
+       inlining is permitted (since [y] is on the most recent stage), producing
+       Make_block [effect-y; y]. Then the [Simple] for [x] will be translated,
+       producing the desired output Make_block [effect-y; effect-x]. The backend
+       will compile this to run effect-x before effect-y by virtue of
+       right-to-left evaluation order. This therefore matches the original code.
+
+       (Same for the binary and ternary cases above, although it usually isn't
+       relevant, as inline-effects-in-cmm is defaulted off.) *)
+    let args, env, effs =
+      C.simple_list ?consider_inlining_effectful_expressions ~dbg env l
+    in
+    let expr = variadic_primitive env dbg variadic args in
     expr, None, env, res, effs

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -37,6 +37,7 @@ val symbol_from_linkage_name :
 
 val symbol : dbg:Debuginfo.t -> Symbol.t -> Cmm.expression
 
+(** This does not inline effectful expressions. *)
 val name :
   To_cmm_env.t ->
   Name.t ->
@@ -44,7 +45,9 @@ val name :
 
 val const : dbg:Debuginfo.t -> Reg_width_const.t -> Cmm.expression
 
+(** [consider_inlining_effectful_expressions] defaults to [false]. *)
 val simple :
+  ?consider_inlining_effectful_expressions:bool ->
   dbg:Debuginfo.t ->
   To_cmm_env.t ->
   Simple.t ->
@@ -53,7 +56,10 @@ val simple :
 val simple_static :
   Simple.t -> [`Data of Cmm.data_item list | `Var of Variable.t]
 
+(** This function translates the [Simple] at the head of the list first.
+    [consider_inlining_effectful_expressions] defaults to [false]. *)
 val simple_list :
+  ?consider_inlining_effectful_expressions:bool ->
   dbg:Debuginfo.t ->
   To_cmm_env.t ->
   Simple.t list ->

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -45,7 +45,9 @@ val name :
 
 val const : dbg:Debuginfo.t -> Reg_width_const.t -> Cmm.expression
 
-(** [consider_inlining_effectful_expressions] defaults to [false]. *)
+(** The default behaviour is to use
+    [Flambda_features.Expert.inline_effects_in_cmm], which defaults to [false]
+    if no command-line flag is given. *)
 val simple :
   ?consider_inlining_effectful_expressions:bool ->
   dbg:Debuginfo.t ->
@@ -57,7 +59,7 @@ val simple_static :
   Simple.t -> [`Data of Cmm.data_item list | `Var of Variable.t]
 
 (** This function translates the [Simple] at the head of the list first.
-    [consider_inlining_effectful_expressions] defaults to [false]. *)
+    Regarding [consider_inlining_effectful_expressions], see [simple] above. *)
 val simple_list :
   ?consider_inlining_effectful_expressions:bool ->
   dbg:Debuginfo.t ->


### PR DESCRIPTION
This changes the semantics of the expert "inline effects in Cmm" flag.  This flag is off by default.  After this PR the "off" state has a different meaning: inlining of effects is still permitted into `Make_block` and `Make_array` primitives.  The comments explain what is going on.