### PR TITLE
Suggest `git clean -dfX` rather than `-dfx`

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -156,7 +156,7 @@ where `<FLAMBDA_BACKEND>` is the path to your clone and `<DUNE>` is the path to 
 ## Bootstrapping the ocaml subtree
 
 This can be done following the usual upstream procedures,
-working entirely within the `ocaml/` subdirectory.  Thoroughly clean the tree (e.g. `git clean -dfx`),
+working entirely within the `ocaml/` subdirectory.  Thoroughly clean the tree (e.g. `git clean -dfX`),
 go into `ocaml/`, then run the upstream configure script.  After that perform the bootstrap (e.g.
 `make world` followed by `make bootstrap`).  Before recompiling the Flambda backend as normal it would
 be advisable to clean the whole tree again.
@@ -190,7 +190,7 @@ needs to exist during the installation step):
 ```
 
 Note that if the Flambda backend tree is already configured, it should be cleaned
-thoroughly (e.g. `git clean -dfx`) before reconfiguring with a different prefix.
+thoroughly (e.g. `git clean -dfX`) before reconfiguring with a different prefix.
 
 Then build the compiler normally (`make`).
 Once that is done, we're ready to install the compiler:


### PR DESCRIPTION
The `git clean -dfx` command suggested in `HACKING.md` deletes any file that's untracked but not ignored, which is unnecessary and possibly a nasty surprise. `git clean -dfX` instead *only* deletes ignored files.