### PR TITLE
Add target-specific compiler flags -ftrap-notes and -fno-trap-notes

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -28,6 +28,9 @@ let prefetchw_support = ref true
 (* PREFETCHWT1 is Intel Xeon Phi only. *)
 let prefetchwt1_support = ref false
 
+(* Emit elf notes with trap handling information. *)
+let trap_notes = ref true
+
 (* Machine-specific command-line options *)
 
 let command_line_options =
@@ -52,6 +55,10 @@ let command_line_options =
       " Use PREFETCHWT1 instructions (Intel Xeon Phi only)";
     "-fno-prefetchwt1", Arg.Clear prefetchwt1_support,
       " Do not use PREFETCHWT1 instructions (default)";
+    "-ftrap-notes", Arg.Set trap_notes,
+      " Emit .note.ocaml_eh section with trap handling information";
+    "-fno-trap-notes", Arg.Clear trap_notes,
+      " Do not emit .note.ocaml_eh section with trap handling information";
   ]
 
 (* Specific operations for the AMD64 processor *)

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -56,7 +56,7 @@ let command_line_options =
     "-fno-prefetchwt1", Arg.Clear prefetchwt1_support,
       " Do not use PREFETCHWT1 instructions (default)";
     "-ftrap-notes", Arg.Set trap_notes,
-      " Emit .note.ocaml_eh section with trap handling information";
+      " Emit .note.ocaml_eh section with trap handling information (default)";
     "-fno-trap-notes", Arg.Clear trap_notes,
       " Do not emit .note.ocaml_eh section with trap handling information";
   ]

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1608,7 +1608,8 @@ let emit_trap_notes () =
     emit_labels traps.push_traps;
     emit_labels traps.pop_traps
   in
-  if is_system_supported && not (Int.Set.is_empty traps.enter_traps) then begin
+  if is_system_supported && !Arch.trap_notes &&
+     not (Int.Set.is_empty traps.enter_traps) then begin
     D.section [".note.ocaml_eh"] (Some "?") [ "\"note\"" ];
     emit_elf_note ~owner:"OCaml" ~typ:1l ~emit_desc;
     (* Reuse stapsdt base section for calcluating addresses after pre-link *)


### PR DESCRIPTION
Control whether to emit trap notes, which were added in #616. The flag is only for amd64 for now.

The default is on, but it may be useful to disable them sometimes, for example if they are too big or won't be used. So far, the size increase for executables (built with closure) was on average 0.1% and object files slightly more at 0.33%.

The symmetric -ftrap-notes is added for consistency with other such flags.