### PR TITLE
Fix recording of call decisions in inlining records

### DIFF
--- a/middle_end/flambda2/simplify_shared/inlining_report.mli
+++ b/middle_end/flambda2/simplify_shared/inlining_report.mli
@@ -83,6 +83,7 @@ module Inlining_tree : sig
   type decision_or_reference =
     | Decision of Decision_with_context.t
     | Reference of Inlining_history.Absolute.t
+    | Unavailable
 
   type item =
     | Call of


### PR DESCRIPTION
Fixes a few issues related to recording of calls in inlining reports:
- Reference to decisions made in another place where printed incorrectly
- When building the inlining tree decisions on calls where registered wrongly and would sometime forget the real decision
- Decisions for unknown calls where recorded as a reference to another place instead of as unavailable.