### PR TITLE
Add flags -dcfg-equivalence-check and -dcfg-invariants

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -342,7 +342,7 @@ let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
   ++ Profile.record ~accumulate:true "linearize" (fun (f : Mach.fundecl) ->
       let res = Linearize.fundecl f in
       (* CR xclerc for xclerc: temporary, for testing. *)
-      if !Flambda_backend_flags.use_ocamlcfg then begin
+      if !Flambda_backend_flags.cfg_equivalence_check then begin
         test_cfgize f res;
       end;
       res)

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -27,6 +27,12 @@ let mk_dcfg f =
   "-dcfg", Arg.Unit f, " (undocumented)"
 ;;
 
+let mk_dcfg_invariants f =
+  "-dcfg-invariants", Arg.Unit f, " Extra sanity checks on Cfg"
+
+let mk_dcfg_equivalence_check f =
+  "-dcfg-equivalence-check", Arg.Unit f, " Extra sanity checks on Cfg transformations"
+
 let mk_reorder_blocks_random f =
   "-reorder-blocks-random",
   Arg.Int f,
@@ -378,6 +384,8 @@ module type Flambda_backend_options = sig
   val no_ocamlcfg : unit -> unit
   val dump_inlining_paths : unit -> unit
   val dcfg : unit -> unit
+  val dcfg_invariants : unit -> unit
+  val dcfg_equivalence_check : unit -> unit
 
   val reorder_blocks_random : int -> unit
 
@@ -441,6 +449,8 @@ struct
     mk_ocamlcfg F.ocamlcfg;
     mk_no_ocamlcfg F.no_ocamlcfg;
     mk_dcfg F.dcfg;
+    mk_dcfg_invariants F.dcfg_invariants;
+    mk_dcfg_equivalence_check F.dcfg_equivalence_check;
 
     mk_reorder_blocks_random F.reorder_blocks_random;
 
@@ -532,6 +542,8 @@ module Flambda_backend_options_impl = struct
   let ocamlcfg = set' Flambda_backend_flags.use_ocamlcfg
   let no_ocamlcfg = clear' Flambda_backend_flags.use_ocamlcfg
   let dcfg = set' Flambda_backend_flags.dump_cfg
+  let dcfg_invariants = set' Flambda_backend_flags.cfg_invariants
+  let dcfg_equivalence_check = set' Flambda_backend_flags.cfg_equivalence_check
 
   let reorder_blocks_random seed =
     Flambda_backend_flags.reorder_blocks_random := Some seed
@@ -712,6 +724,8 @@ module Extra_params = struct
     in
     match name with
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
+    | "cfg-invariants" -> set' Flambda_backend_flags.cfg_invariants
+    | "cfg-equivalence-check" -> set' Flambda_backend_flags.cfg_equivalence_check
     | "dump-inlining-paths" -> set' Flambda_backend_flags.dump_inlining_paths
     | "reorder-blocks-random" ->
        set_int_option' Flambda_backend_flags.reorder_blocks_random

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -24,6 +24,8 @@ module type Flambda_backend_options = sig
   val no_ocamlcfg : unit -> unit
   val dump_inlining_paths : unit -> unit
   val dcfg : unit -> unit
+  val dcfg_invariants : unit -> unit
+  val dcfg_equivalence_check : unit -> unit
 
   val reorder_blocks_random : int -> unit
 

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -15,6 +15,8 @@
 (**************************************************************************)
 let use_ocamlcfg = ref false            (* -ocamlcfg *)
 let dump_cfg = ref false                (* -dcfg *)
+let cfg_invariants = ref false          (* -dcfg-invariants *)
+let cfg_equivalence_check = ref false   (* -dcfg-equivalence-check *)
 
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -16,6 +16,8 @@
 (** Flambda-backend specific command line flags *)
 val use_ocamlcfg : bool ref
 val dump_cfg : bool ref
+val cfg_invariants : bool ref
+val cfg_equivalence_check : bool ref
 
 val reorder_blocks_random : int option ref
 


### PR DESCRIPTION
The flags enable extra checks for cfg:
-dcfg-equivalence-check compares two cfgs 
-dcfg-invariants checks basic properties of cfgs (not implemented yet)

The checks are off by default.