### PR TITLE
Bugfix for Translmod.all_idents

### DIFF
--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -987,8 +987,9 @@ and all_idents = function
     | Tstr_class_type _ -> all_idents rem
 
     | Tstr_include{incl_type; incl_mod={mod_desc =
-                             Tmod_constraint ({mod_desc = Tmod_structure str},
-                                              _, _, _)}} ->
+                              ( Tmod_constraint ({mod_desc = Tmod_structure str},
+                                              _, _, _)
+                              | Tmod_structure str ) }} ->
         bound_value_identifiers incl_type
         @ all_idents str.str_items
         @ all_idents rem

--- a/ocaml/testsuite/tests/typing-modules/struct_include_optimisation.ml
+++ b/ocaml/testsuite/tests/typing-modules/struct_include_optimisation.ml
@@ -45,5 +45,20 @@ end : sig val d : int end)
 
 let () = count "reordering coercion"
 
+module Outer = struct
+  include (struct
+    module Inner = struct
+      include (struct
+        let e = next ()
+      end)
+    end
+  end)
+end
+
 let () =
-  Printf.printf "%20s: %d%d%d%d%d%d\n" "outputs" x y a b c d
+  (* The above might actually allocate the module blocks Outer and Inner,
+     but should not allocate more than 4 words (2 each) *)
+  assert (Gc.minor_words () -. allocs.total <= 4.)
+
+let () =
+  Printf.printf "%20s: %d%d%d%d%d%d%d\n" "outputs" x y a b c d Outer.Inner.e

--- a/ocaml/testsuite/tests/typing-modules/struct_include_optimisation.reference
+++ b/ocaml/testsuite/tests/typing-modules/struct_include_optimisation.reference
@@ -2,4 +2,4 @@
     trivial coercion: 0
      prefix coercion: 0
  reordering coercion: 0
-             outputs: 012347
+             outputs: 0123478


### PR DESCRIPTION
Fixes a bug in https://github.com/ocaml/ocaml/pull/11134 (which was ported to ocaml-jst), where the `include struct ... end` optimisation caused a compiler failure if used inside a nested module.