### PR TITLE
Create install directory before installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ _install: compiler
 
 # Copy _install to the final install directory (no-op if they are the same)
 install: _install
+	mkdir -p '$(prefix)'
 	rsync --chmod=u+rw,go+r -rl _install/ '$(prefix)'
 
 main_prefix = _build/install/main


### PR DESCRIPTION
The new install logic in #585 uses `rsync` to install everything, but `rsync` doesn't like it when the parent directory of the target doesn't exist. So, this patch ensures the target directory exists before `rsync` is called.