### PR TITLE
Fix build_upstream prefix again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ _build_upstream/config.status: ocaml/configure.ac
 	mkdir _build_upstream
 	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build_upstream
 	(cd _build_upstream && \
-	  ./configure -C $(CONFIGURE_ARGS) --prefix=$$(pwd)/_install \
+	  ./configure -C $(CONFIGURE_ARGS) --prefix=$(prefix) \
 	    --disable-ocamldoc \
 	    --enable-ocamltest)
 


### PR DESCRIPTION
The previous PR wasn't quite right as it turns out this build_upstream target needs the final installation prefix.  This seems to build m32 now (although there is still a problem with `CONFIGURE_ARGS` quoting, or lack of).