### PR TITLE
Add "stack_allocation" to build_ocaml_compiler.sexp

### DIFF
--- a/build_ocaml_compiler.sexp
+++ b/build_ocaml_compiler.sexp
@@ -18,5 +18,6 @@
    flambda2
    no_flat_float_array
    perf_demangled_symbols
+   stack_allocation
    ))
  )


### PR DESCRIPTION
This is for the JS-internal compiler build tool.