### PR TITLE
Various minor DWARF fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@ README.md       @mshinwell
 build_ocaml_compiler.sexp       @poechsel
 
 backend/                        @gretay-js @xclerc
-backend/debug/                  @mshinwell
+backend/debug/                  @mshinwell @poechsel
 
 driver/                         @mshinwell
 

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1243,8 +1243,7 @@ let fundecl fundecl =
       cfi_adjust_cfa_offset (-n);
     end;
   end;
-  let end_symbol = Dwarf_ocaml.Dwarf_concrete_instances.end_symbol_name fundecl.fun_name in
-  D.label (emit_symbol end_symbol);
+  def_label fundecl.fun_end_label;
   cfi_endproc ();
   emit_function_type_and_size fundecl.fun_name
 

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -1049,6 +1049,10 @@ let fundecl fundecl =
   List.iter emit_call_bound_error !bound_error_sites;
   assert (List.length !call_gc_sites = num_call_gc);
   assert (List.length !bound_error_sites = num_check_bound);
+  let end_label =
+    Dwarf_ocaml.Dwarf_concrete_instances.end_label fundecl.fun_name
+  in
+  D.label end_label;
   cfi_endproc();
   emit_symbol_type emit_symbol fundecl.fun_name "function";
   emit_symbol_size fundecl.fun_name;

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -1049,7 +1049,7 @@ let fundecl fundecl =
   List.iter emit_call_bound_error !bound_error_sites;
   assert (List.length !call_gc_sites = num_call_gc);
   assert (List.length !bound_error_sites = num_check_bound);
-  def_label fundecl.fun_end_label;
+  `{emit_label fundecl.fun_end_label}:\n`;
   cfi_endproc();
   emit_symbol_type emit_symbol fundecl.fun_name "function";
   emit_symbol_size fundecl.fun_name;

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -1049,10 +1049,7 @@ let fundecl fundecl =
   List.iter emit_call_bound_error !bound_error_sites;
   assert (List.length !call_gc_sites = num_call_gc);
   assert (List.length !bound_error_sites = num_check_bound);
-  let end_label =
-    Dwarf_ocaml.Dwarf_concrete_instances.end_label fundecl.fun_name
-  in
-  D.label end_label;
+  def_label fundecl.fun_end_label;
   cfi_endproc();
   emit_symbol_type emit_symbol fundecl.fun_name "function";
   emit_symbol_size fundecl.fun_name;

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -158,7 +158,7 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     D.text ()
 
   let with_comment f ?comment x =
-    Option.iter D.comment comment;
+    if A.debugging_comments_in_asm_files then Option.iter D.comment comment;
     f x
 
   let ( >> ) f g x = g (f x)
@@ -202,6 +202,7 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
 
   let cache_string ?comment section str =
     assert_string_has_no_null_bytes str;
+    let comment = if A.debugging_comments_in_asm_files then comment else None in
     let cached : Cached_string.t = { section; str; comment } in
     match Cached_string.Map.find cached !cached_strings with
     | label -> label

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -294,11 +294,11 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     (* CR poechsel: use the arguments *)
     A.emit_line "between_labels_64_bit"
 
-  let between_symbol_in_current_unit_and_label_offset ?comment ~upper ~lower
-      ~offset_upper () =
+  let between_symbol_in_current_unit_and_label_offset ?comment:comment' ~upper
+      ~lower ~offset_upper () =
     (* CR mshinwell: add checks, as above: check_symbol_in_current_unit lower;
        check_symbol_and_label_in_same_section lower upper; *)
-    if A.debugging_comments_in_asm_files then Option.iter D.comment comment;
+    Option.iter D.comment comment';
     if Targetint.compare offset_upper Targetint.zero = 0
     then
       let expr =

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -223,7 +223,7 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     cached_strings := Cached_string.Map.empty;
     Option.iter switch_to_section old_dwarf_section
 
-  let comment str = D.comment str
+  let comment str = if A.debugging_comments_in_asm_files then D.comment str
 
   let define_data_symbol symbol =
     (* CR-someday bkhajwal: Asm_symbol currently is just a string, if

--- a/backend/asm_targets/asm_directives_intf.ml
+++ b/backend/asm_targets/asm_directives_intf.ml
@@ -29,6 +29,8 @@ module type Arg = sig
   (* Should be Emitaux.get_file_num *)
   val get_file_num : string -> int
 
+  val debugging_comments_in_asm_files : bool
+
   module D : sig
     type constant
 

--- a/backend/asm_targets/asm_label.ml
+++ b/backend/asm_targets/asm_label.ml
@@ -125,4 +125,6 @@ let for_dwarf_section (dwarf_section : Asm_section.dwarf_section) =
   | Debug_line -> Lazy.force debug_line_label
 
 let for_section (section : Asm_section.t) =
-  match section with DWARF dwarf_section -> for_dwarf_section dwarf_section
+  match section with
+  | DWARF dwarf_section -> for_dwarf_section dwarf_section
+  | Text -> Misc.fatal_error "Not yet implemented"

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -38,7 +38,9 @@ type dwarf_section =
   | Debug_str
   | Debug_line
 
-type t = DWARF of dwarf_section
+type t =
+  | DWARF of dwarf_section
+  | Text
 
 type section_details =
   { names : string list;
@@ -96,6 +98,7 @@ let details t ~first_occurrence =
       let flags = if first_occurrence then Some "" else None in
       let args = if first_occurrence then ["%progbits"] else [] in
       [name], flags, args
+    | Text, _ -> Misc.fatal_error "Not yet implemented"
   in
   { names; flags; args }
 
@@ -116,6 +119,7 @@ let print ppf t =
     | DWARF Debug_rnglists -> "(DWARF Debug_rnglists)"
     | DWARF Debug_str -> "(DWARF Debug_str)"
     | DWARF Debug_line -> "(DWARF Debug_line)"
+    | Text -> "Text"
   in
   Format.pp_print_string ppf str
 

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -40,9 +40,9 @@ type dwarf_section =
   | Debug_str
   | Debug_line
 
-(* Right now [Asm_section] is only meant to represent dwarf sections. This type
-   is kept as-is to make it obvious. *)
-type t = DWARF of dwarf_section
+type t =
+  | DWARF of dwarf_section
+  | Text
 
 val to_string : t -> string
 

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -177,9 +177,13 @@ let emit_fundecl ~dwarf =
         match dwarf with
         | None -> ()
         | Some dwarf ->
+          let fun_end_label =
+            Asm_targets.Asm_label.create_int Text fundecl.fun_end_label
+          in
           let fundecl : Dwarf_concrete_instances.fundecl =
-            { fun_name = fundecl.fun_name
-            ; fun_dbg = fundecl.fun_dbg
+            { fun_name = fundecl.fun_name;
+              fun_dbg = fundecl.fun_dbg;
+              fun_end_label;
             }
           in
           Dwarf.dwarf_for_fundecl dwarf fundecl

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -445,6 +445,9 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
       let get_file_num file_name =
         Emitaux.get_file_num ~file_emitter:X86_dsl.D.file file_name
 
+      let debugging_comments_in_asm_files =
+        !Flambda_backend_flags.dasm_comments
+
       module D = struct
         open X86_ast
 
@@ -473,12 +476,16 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
     end)
   )
 
-let emit_begin_assembly_with_dwarf  ~emit_begin_assembly ~sourcefile () =
+let emit_begin_assembly_with_dwarf ~disable_dwarf ~emit_begin_assembly ~sourcefile () =
   let no_dwarf () =
     emit_begin_assembly ~init_dwarf:(fun () -> ());
     None
   in
-  let can_emit = !Clflags.debug && not(!Dwarf_flags.restrict_to_upstream_dwarf) in
+  let can_emit =
+    !Clflags.debug
+    && not !Dwarf_flags.restrict_to_upstream_dwarf
+    && not disable_dwarf
+  in
   match can_emit, Target_system.architecture (), Target_system.derived_system () with
   | true, X86_64, _ ->
     let asm_directives = build_asm_directives () in
@@ -494,7 +501,10 @@ let emit_begin_assembly_with_dwarf  ~emit_begin_assembly ~sourcefile () =
   | false, _, _ -> no_dwarf ()
 
 let end_gen_implementation0 ?toplevel ~ppf_dump ~sourcefile make_cmm =
-  let dwarf = emit_begin_assembly_with_dwarf ~emit_begin_assembly ~sourcefile () in
+  let dwarf =
+    emit_begin_assembly_with_dwarf ~disable_dwarf:false ~emit_begin_assembly
+      ~sourcefile ()
+  in
   make_cmm ()
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cmm
   ++ Profile.record "compile_phrases" (List.iter (compile_phrase ?dwarf ~ppf_dump))
@@ -571,7 +581,10 @@ let linear_gen_implementation filename =
     | Func f -> emit_fundecl ~dwarf f
   in
   start_from_emit := true;
-  let dwarf = emit_begin_assembly_with_dwarf ~emit_begin_assembly ~sourcefile:filename () in
+  let dwarf =
+    emit_begin_assembly_with_dwarf ~disable_dwarf:false ~emit_begin_assembly
+      ~sourcefile:filename ()
+  in
   Profile.record "Emit" (List.iter (emit_item ~dwarf)) linear_unit_info.items;
   emit_end_assembly dwarf
 

--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -94,7 +94,8 @@ val compile_unit
   Might return an instance of [Dwarf_ocaml.Dwarf.t] that can be used to generate
   dwarf information for the target system. *)
 val emit_begin_assembly_with_dwarf
-  : emit_begin_assembly:(init_dwarf:(unit -> unit) -> unit)
+   : disable_dwarf:bool
+  -> emit_begin_assembly:(init_dwarf:(unit -> unit) -> unit)
   -> sourcefile:string
   -> unit
   -> Dwarf_ocaml.Dwarf.t option

--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -284,6 +284,9 @@ let scan_file ~shared genfns file (objfiles, tolink) =
 
 (* Second pass: generate the startup file and link it with everything else *)
 
+let named_startup_file () =
+  !Clflags.keep_startup_file || !Emitaux.binary_backend_available
+
 let force_linking_of_startup ~ppf_dump =
   Asmgen.compile_phrase ~ppf_dump
     (Cmm.Cdata ([Cmm.Csymbol_address "caml_startup"]))
@@ -377,7 +380,7 @@ let link_shared ~ppf_dump objfiles output_name =
     Clflags.all_ccopts := !lib_ccopts @ !Clflags.all_ccopts;
     let objfiles = List.rev ml_objfiles @ List.rev !Clflags.ccobjs in
     let startup =
-      if !Clflags.keep_startup_file || !Emitaux.binary_backend_available
+      if named_startup_file ()
       then output_name ^ ".startup" ^ ext_asm
       else Filename.temp_file "camlstartup" ext_asm in
     let startup_obj = output_name ^ ".startup" ^ ext_obj in
@@ -446,9 +449,7 @@ let link ~ppf_dump objfiles output_name =
     Clflags.ccobjs := !Clflags.ccobjs @ !lib_ccobjs;
     Clflags.all_ccopts := !lib_ccopts @ !Clflags.all_ccopts;
                                                  (* put user's opts first *)
-    let named_startup_file =
-      !Clflags.keep_startup_file || !Emitaux.binary_backend_available
-    in
+    let named_startup_file = named_startup_file () in
     let startup =
       if named_startup_file
       then output_name ^ ".startup" ^ ext_asm

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -395,7 +395,8 @@ let run cfg_with_layout =
     fun_contains_calls;
     fun_num_stack_slots;
     fun_frame_required;
-    fun_prologue_required
+    fun_prologue_required;
+    fun_end_label = Cmm.new_label ()
   }
 
 (** debug print block as assembly *)

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -74,6 +74,8 @@ let use_g () =
 
 let restrict_to_upstream_dwarf = ref false
 
+let dwarf_for_startup_file = ref false
+
 let debug_thing thing = List.mem thing !current_debug_settings
 
 let set_debug_thing thing =

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
@@ -35,6 +35,8 @@ val use_g3 : unit -> unit
 
 val restrict_to_upstream_dwarf : bool ref
 
+val dwarf_for_startup_file : bool ref
+
 type dwarf_version =
   | Four
   | Five

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
@@ -19,21 +19,17 @@ open Dwarf_high
 module DAH = Dwarf_attribute_helpers
 
 let compile_unit_proto_die ~sourcefile ~unit_name =
-  let cwd = Sys.getcwd () in
-  let source_directory_path, source_filename =
-    if Filename.is_relative sourcefile
-    then cwd, sourcefile
-    else Filename.dirname sourcefile, Filename.basename sourcefile
-  in
-  let source_directory_path =
-    Location.rewrite_absolute_path source_directory_path
+  let source_filename =
+    (* CR mshinwell: Think more about build reproducibility and what we should
+       be putting here (and also in the compilation directory attribute). For
+       the moment this is very conservative. *)
+    Filename.basename sourcefile
   in
   let attribute_values =
     [ DAH.create_name source_filename;
-      DAH.create_comp_dir source_directory_path
       (* The [OCaml] attribute value here is only defined in DWARF-5, but it
          doesn't mean anything else in DWARF-4, so we always emit it. This saves
-         special-case logic in gdb based on the producer name. *);
+         special-case logic in gdb based on the producer name. *)
       DAH.create_language OCaml;
       DAH.create_producer "ocamlopt";
       DAH.create_ocaml_unit_name unit_name;

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -65,8 +65,11 @@ let for_fundecl ~get_file_id state fundecl =
           ~debug_line_label:(Asm_label.for_dwarf_section Asm_section.Debug_line)
       ]
   in
-  let concrete_instance_proto_die =
+  let _concrete_instance_proto_die =
     Proto_die.create ~parent:(Some parent) ~tag:Subprogram ~attribute_values ()
   in
-  let name = Printf.sprintf "__concrete_instance_%s" fun_name in
-  Proto_die.set_name concrete_instance_proto_die (Asm_symbol.create name)
+  (* CR mshinwell: When cross-referencing of DIEs across files is necessary we
+     need to be careful about symbol table size. let name = Printf.sprintf
+     "__concrete_instance_%s" fun_name in Proto_die.set_name
+     concrete_instance_proto_die (Asm_symbol.create name) *)
+  ()

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.mli
@@ -14,11 +14,9 @@
 
 type fundecl =
   { fun_name : string;
-    fun_dbg : Debuginfo.t
+    fun_dbg : Debuginfo.t;
+    fun_end_label : Asm_targets.Asm_label.t
   }
 
 val for_fundecl :
   get_file_id:(string -> int) -> Dwarf_state.t -> fundecl -> unit
-
-(** End symbol name given start symbol name for a function block *)
-val end_symbol_name : start_symbol:string -> string

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -54,10 +54,11 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_tailrec_entry_point_label : label option;
-   fun_contains_calls: bool;
+    fun_contains_calls: bool;
     fun_num_stack_slots: int array;
     fun_frame_required: bool;
     fun_prologue_required: bool;
+    fun_end_label: label;
   }
 
 (* Invert a test *)

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -59,6 +59,7 @@ type fundecl =
     fun_num_stack_slots: int array;
     fun_frame_required: bool;
     fun_prologue_required: bool;
+    fun_end_label: label;
   }
 
 val traps_to_bytes : int -> int

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -389,4 +389,5 @@ let fundecl f =
     fun_num_stack_slots;
     fun_frame_required;
     fun_prologue_required;
+    fun_end_label = Cmm.new_label ()
   }

--- a/backend/schedgen.ml
+++ b/backend/schedgen.ml
@@ -397,6 +397,7 @@ method schedule_fundecl f =
       fun_num_stack_slots = f.fun_num_stack_slots;
       fun_frame_required = f.fun_frame_required;
       fun_prologue_required = f.fun_prologue_required;
+      fun_end_label = Cmm.new_label ()
     }
   end else
     f

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -29,6 +29,9 @@ module type Flambda_backend_options = sig
 
   val reorder_blocks_random : int -> unit
 
+  val dasm_comments : unit -> unit
+  val dno_asm_comments : unit -> unit
+
   val heap_reduction_threshold : int -> unit
 
   val flambda2_join_points : unit -> unit
@@ -86,6 +89,8 @@ end
 module type Debugging_options = sig
   val _restrict_to_upstream_dwarf : unit -> unit
   val _no_restrict_to_upstream_dwarf : unit -> unit
+  val _dwarf_for_startup_file : unit -> unit
+  val _no_dwarf_for_startup_file : unit -> unit
 end
 
 (** Command line arguments required for ocamlopt. *)

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -20,6 +20,8 @@ let cfg_equivalence_check = ref false   (* -dcfg-equivalence-check *)
 
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 
+let dasm_comments = ref false
+
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)
 

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -20,7 +20,7 @@ let cfg_equivalence_check = ref false   (* -dcfg-equivalence-check *)
 
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 
-let dasm_comments = ref false
+let dasm_comments = ref false (* -dasm-comments *)
 
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -21,6 +21,8 @@ val cfg_equivalence_check : bool ref
 
 val reorder_blocks_random : int option ref
 
+val dasm_comments : bool ref
+
 val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
 


### PR DESCRIPTION
We ran into a few problems building the JS tree with the new DWARF code including some build reproducibility check failures and significant executable size increases.  This patch should fix this as follows:
- Disable writing of the compilation directory into the DWARF, at least for now
- Be more conservative and only write the basename of the source filename into the DWARF
- Never write the temporary `.s` filename for the startup file into the DWARF
- Provide an option to never write DWARF for the startup file at all (this isn't really useful anyway at present), this is now set by default to not write such dwarf
- Provide an option to enable/disable writing of comments for compiler devs into the `.s` files, which currently only applies to DWARF as it is hard to decode without these, default off.
- Ensure that strings emitted via `Asm_directives` are shared correctly even if their comments differ, if comments are off.

The "upstream DWARF" option hadn't been exposed in `OCAMLPARAM` previously, this has been fixed.  (We have a plan to switch to a single `-X` option which will avoid this in the future, and make adding options much quicker.)

One remaining problem (probably only applicable to JS internal builds) is that compilers built from the `ocaml/` subdirectory only, e.g. for x86-32, do not understand `-gupstream-dwarf`.