### PR TITLE
Handle return unit for PAUSE instrinsic 

### DIFF
--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -322,7 +322,7 @@ method! select_operation op args dbg =
          Ispecific Ifloat_min, args
       | "caml_float_max_unboxed", [|Float|] ->
          Ispecific Ifloat_max, args
-      | "caml_pause_hint", [|Val|] ->
+      | "caml_pause_hint", ([|Val|] | [| |]) ->
          Ispecific Ipause, args
       | _ ->
         super#select_operation op args dbg


### PR DESCRIPTION
The return value of PAUSE intrinsics is unit. The type of this return value can be represented in the backend as either `[| Val |]` or empty array (i.e., `Cmm.void_typ`), depending on where the external call is, because `Cmm_helpers.remove_unit` can turn the first representation to the second. For example, 
```
external pause : unit -> unit = "caml_pause_hint" [@@noalloc] [@@builtin]

for i = 0 to n do pause () done
```
the body of the loop compiled to a function call instead of a single instruction (before this patch).

In `Selection` for amd64, we match target-specific intrinsics using their name and return type. We don't use return type in `Cmmgen` for it, and also have `Cmm_helpers.return_unit` for intrinsics recognized at `Cmmgen`, but there is nothing like this in `Selection` for target-specific intrinsics that return unit. We only have one right now, PAUSE for amd64, which I fixed directly.  An alternative is just remove the matching on types (they were added for extra safety). Not sure what a proper fix would be. 
