### PR TITLE
Error on unrecognized intrinsics

### DIFF
--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -579,7 +579,10 @@ method select_operation op args _dbg =
     (Icall_imm { func; }, rem)
   | (Capply _, _) ->
     (Icall_ind, args)
-  | (Cextcall { func; alloc; ty; ty_args; returns }, _) ->
+  | (Cextcall { func; alloc; ty; ty_args; returns; builtin = true }, _) ->
+     Misc.fatal_errorf "Selection.select_operation: builtin not recognized %s"
+       func ();
+  | (Cextcall { func; alloc; ty; ty_args; returns; builtin = false }, _) ->
     Iextcall { func; alloc; ty_res = ty; ty_args; returns }, args
   | (Cload (chunk, mut), [arg]) ->
       let (addr, eloc) = self#select_addressing chunk arg in

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -579,7 +579,7 @@ method select_operation op args _dbg =
     (Icall_imm { func; }, rem)
   | (Capply _, _) ->
     (Icall_ind, args)
-  | (Cextcall { func; alloc; ty; ty_args; returns; builtin = true }, _) ->
+  | (Cextcall { func; builtin = true }, _) ->
      Misc.fatal_errorf "Selection.select_operation: builtin not recognized %s"
        func ();
   | (Cextcall { func; alloc; ty; ty_args; returns; builtin = false }, _) ->


### PR DESCRIPTION
Follow-up on https://github.com/ocaml-flambda/flambda-backend/pull/672: all calls to a function with [@builtin] annotation should be recognized by the flambda-backend compiler. 