### PR TITLE
Fix intrinsics Cmm translation for Flambda 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,7 @@ fmt:
 	ocamlformat -i \
 	  $$(find backend/debug \
 	    \( -name "*.ml" -or -name "*.mli" \))
+	ocamlformat -i backend/cmm_helpers.ml{,i}
 	ocamlformat -i tools/merge_archives.ml
 	ocamlformat -i \
 	  $$(find backend/debug/dwarf \
@@ -379,6 +380,7 @@ check-fmt:
            [ "$$(git status --porcelain middle_end/mangling.mli)" != "" ] || \
            [ "$$(git status --porcelain backend/asm_targets)" != "" ] || \
            [ "$$(git status --porcelain backend/debug)" != "" ] || \
+           [ "$$(git status --porcelain backend/cmm_helpers.ml{,i})" != "" ] || \
            [ "$$(git status --porcelain tools/merge_archives.ml)" != "" ]; then \
 	  echo; \
 	  echo "Tree must be clean before running 'make check-fmt'"; \
@@ -391,6 +393,7 @@ check-fmt:
            [ "$$(git diff middle_end/mangling.mli)" != "" ] || \
            [ "$$(git diff backend/asm_targets)" != "" ] || \
            [ "$$(git diff backend/debug)" != "" ] || \
+           [ "$$(git diff backend/cmm_helpers.ml{,i})" != "" ] || \
            [ "$$(git diff tools/merge_archives.ml)" != "" ]; then \
 	  echo; \
 	  echo "The following code was not formatted correctly:"; \

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4031,19 +4031,24 @@ let indirect_full_call ~dbg ty alloc_mode f = function
 
 let extcall ~dbg ~returns ~alloc ~is_c_builtin ~ty_args name typ_res args =
   if not returns then assert (typ_res = typ_void);
-  Cop
-    ( Cextcall
-        { func = name;
-          ty = typ_res;
-          alloc;
-          ty_args;
-          returns;
-          builtin = is_c_builtin;
-          effects = Arbitrary_effects;
-          coeffects = Has_coeffects
-        },
-      args,
-      dbg )
+  let default =
+    Cop
+      ( Cextcall
+          { func = name;
+            ty = typ_res;
+            alloc;
+            ty_args;
+            returns;
+            builtin = is_c_builtin;
+            effects = Arbitrary_effects;
+            coeffects = Has_coeffects
+          },
+        args,
+        dbg )
+  in
+  if is_c_builtin
+  then match transl_builtin name args dbg with Some op -> op | None -> default
+  else default
 
 let bigarray_load ~dbg ~elt_kind ~elt_size ~elt_chunk ~bigarray ~offset =
   let ba_data_f = field_address bigarray 1 dbg in

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -777,11 +777,16 @@ val cextcall :
 (** Generate generic functions *)
 module Generic_fns_tbl : sig
   type t
+
   val make : unit -> t
+
   val add : t -> Cmx_format.generic_fns -> unit
+
   val of_fns : Cmx_format.generic_fns -> t
+
   val entries : t -> Cmx_format.generic_fns
 end
+
 val generic_functions : bool -> Generic_fns_tbl.t -> Cmm.phrase list
 
 val placeholder_dbg : unit -> Debuginfo.t

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -58,6 +58,8 @@ type t = private
         param_arity : Flambda_arity.t;
         return_arity : Flambda_arity.t;
         is_c_builtin : bool
+            (* CR mshinwell: This should have the effects and coeffects
+               fields *)
       }
 
 include Expr_std.S with type t := t


### PR DESCRIPTION
#673 has shown up that Flambda 2 was not translating any intrinsics.  This patch should fix it.  Tested by building the `ocaml_intrinsics` library (with #673 too) and no errors occurring.

Based on #675.