### PR TITLE
Slash symbol table sizes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
         "ocaml.sandbox": {
                 "kind": "opam",
-                "switch": "4.12.0+closure+local"
+                "switch": "4.12.0"
         }
 }

--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,12 @@ boot-runtest: boot-compiler
 	$(dune) runtest $(ws_boot) $(coverage_dune_flags) --force
 
 runtime-stdlib: boot-compiler
-	$(dune) build $(ws_runstd) --only-package=ocaml_runtime_stdlib @install
+	$(dune) build --verbose $(ws_runstd) --only-package=ocaml_runtime_stdlib @install
 #	dune does not believe the compiler can make .cmxs unless the following file exists
 	@touch _build/install/runtime_stdlib/lib/ocaml_runtime_stdlib/dynlink.cmxa
 
 compiler: runtime-stdlib
-	$(dune) build $(ws_main) --only-package=ocaml @install ocaml/ocamltest/ocamltest.byte
+	$(dune) build $(ws_main) --verbose --only-package=ocaml @install ocaml/ocamltest/ocamltest.byte
 
 runtest: compiler
 	$(dune) runtest $(ws_main)

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1259,9 +1259,15 @@ let emit_item = function
   | Csingle f -> D.long  (Const (Int64.of_int32 (Int32.bits_of_float f)))
   | Cdouble f -> D.qword (Const (Int64.bits_of_float f))
   | Csymbol_address s -> add_used_symbol s; D.qword (ConstLabel (emit_symbol s))
+  | Coffset_symbol_address { symbol; bytes } ->
+    add_used_symbol symbol;
+    D.qword (ConstAdd (
+      ConstLabel (emit_symbol symbol),
+      const_nat (Int64.to_nativeint (Targetint.to_int64 bytes))))
   | Cstring s -> D.bytes s
   | Cskip n -> if n > 0 then D.space n
   | Calign n -> D.align n
+  | Ccomment s -> D.comment s
 
 let data l =
   D.data ();

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -267,9 +267,11 @@ type data_item =
   | Csingle of float
   | Cdouble of float
   | Csymbol_address of string
+  | Coffset_symbol_address of { symbol : string; bytes : Targetint.t }
   | Cstring of string
   | Cskip of int
   | Calign of int
+  | Ccomment of string
 
 type phrase =
     Cfunction of fundecl

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -276,9 +276,11 @@ type data_item =
   | Csingle of float
   | Cdouble of float
   | Csymbol_address of string
+  | Coffset_symbol_address of { symbol : string; bytes : Targetint.t }
   | Cstring of string
   | Cskip of int
   | Calign of int
+  | Ccomment of string
 
 type phrase =
     Cfunction of fundecl

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4098,6 +4098,9 @@ let cfloat f = Cmm.Cdouble f
 
 let symbol_address s = Cmm.Csymbol_address s
 
+let offset_symbol_address symbol ~bytes =
+  Cmm.Coffset_symbol_address { symbol; bytes }
+
 let define_symbol ~global s =
   if global
   then [Cmm.Cglobal_symbol s; Cmm.Cdefine_symbol s]
@@ -4114,9 +4117,6 @@ let fundecl fun_name fun_args fun_body fun_codegen_options fun_dbg =
 
 (* Gc root table *)
 
-let gc_root_table ~make_symbol syms =
+let gc_root_table ~make_symbol sym_addresses =
   let table_symbol = make_symbol ?unitname:None (Some "gc_roots") in
-  cdata
-    (define_symbol ~global:true table_symbol
-    @ List.map symbol_address syms
-    @ [cint 0n])
+  cdata (define_symbol ~global:true table_symbol @ sym_addresses @ [cint 0n])

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1147,8 +1147,11 @@ val cint : nativeint -> data_item
 (** Static float. *)
 val cfloat : float -> data_item
 
-(** Static symbol. *)
+(** Address of symbol. *)
 val symbol_address : string -> data_item
+
+(** Address of symbol plus byte offset. *)
+val offset_symbol_address : string -> bytes:Targetint.t -> data_item
 
 (** Definition for a static symbol. *)
 val define_symbol : global:bool -> string -> data_item list
@@ -1174,5 +1177,5 @@ val cdata : data_item list -> phrase
 (** Create the gc root table from a list of root symbols. *)
 val gc_root_table :
   make_symbol:(?unitname:string -> string option -> string) ->
-  string list ->
+  data_item list ->
   phrase

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -362,9 +362,12 @@ let data_item ppf = function
   | Csingle f -> fprintf ppf "single %F" f
   | Cdouble f -> fprintf ppf "double %F" f
   | Csymbol_address s -> fprintf ppf "addr \"%s\"" s
-  | Cstring s -> fprintf ppf "string \"%s\"" s
+  | Coffset_symbol_address { symbol; bytes } ->
+    fprintf ppf "(addr \"%s\" + %a)" symbol Targetint.print bytes
+  | Cstring s -> fprintf ppf "string[len=%d] \"%s\"" (String.length s) s
   | Cskip n -> fprintf ppf "skip %i" n
   | Calign n -> fprintf ppf "align %i" n
+  | Ccomment s -> fprintf ppf "# %s" s
 
 let data ppf dl =
   let items ppf = List.iter (fun d -> fprintf ppf "@ %a" data_item d) dl in

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -41,7 +41,7 @@ let rec load_cmx_file_contents loader comp_unit =
     | Some cmx ->
       let resolver comp_unit = load_cmx_file_contents loader comp_unit in
       let get_imported_names () = loader.imported_names in
-      let typing_env, all_code =
+      let typing_env, all_code, offsets =
         Flambda_cmx_format.import_typing_env_and_code cmx
       in
       let typing_env =
@@ -51,7 +51,6 @@ let rec load_cmx_file_contents loader comp_unit =
       loader.imported_names
         <- Name.Set.union newly_imported_names loader.imported_names;
       loader.imported_code <- EC.merge all_code loader.imported_code;
-      let offsets = Flambda_cmx_format.exported_offsets cmx in
       Exported_offsets.import_offsets offsets;
       loader.imported_units
         <- Compilation_unit.Map.add comp_unit (Some typing_env)
@@ -238,10 +237,9 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
 
 let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
     ~exported_offsets all_code =
-  match final_typing_env with
-  | None -> None
-  | Some _ when Flambda_features.opaque () -> None
-  | Some final_typing_env ->
+  if Flambda_features.opaque ()
+  then None
+  else
     let typing_env, canonicalise =
       TE.Pre_serializable.create final_typing_env ~used_value_slots
     in

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -38,7 +38,7 @@ val load_symbol_approx :
   loader -> Symbol.t -> Code_or_metadata.t Value_approximation.t
 
 val prepare_cmx_file_contents :
-  final_typing_env:Flambda2_types.Typing_env.t option ->
+  final_typing_env:Flambda2_types.Typing_env.t ->
   module_symbol:Symbol.t ->
   used_value_slots:Value_slot.Set.t ->
   exported_offsets:Exported_offsets.t ->

--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -33,18 +33,31 @@ type t0 =
     all_code : Exported_code.t;
     exported_offsets : Exported_offsets.t;
     used_value_slots : Value_slot.Set.t;
-    table_data : table_data
+    table_data : table_data option
   }
 
 type t = t0 list
 
 let create ~final_typing_env ~all_code ~exported_offsets ~used_value_slots =
+  [ { original_compilation_unit = Compilation_unit.get_current_exn ();
+      final_typing_env;
+      all_code;
+      exported_offsets;
+      used_value_slots;
+      table_data = None
+    } ]
+
+let prepare_for_serialization0 t =
   let typing_env_exported_ids =
-    Flambda2_types.Typing_env.Serializable.all_ids_for_export final_typing_env
+    Flambda2_types.Typing_env.Serializable.all_ids_for_export t.final_typing_env
   in
-  let all_code_exported_ids = Exported_code.all_ids_for_export all_code in
+  let all_code_exported_ids = Exported_code.all_ids_for_export t.all_code in
+  let exported_offsets_ids =
+    Exported_offsets.all_ids_for_export t.exported_offsets
+  in
   let exported_ids =
-    Ids_for_export.union typing_env_exported_ids all_code_exported_ids
+    Ids_for_export.union typing_env_exported_ids
+      (Ids_for_export.union all_code_exported_ids exported_offsets_ids)
   in
   let symbols =
     Symbol.Set.fold
@@ -81,13 +94,9 @@ let create ~final_typing_env ~all_code ~exported_offsets ~used_value_slots =
   let table_data =
     { symbols; variables; simples; consts; code_ids; continuations }
   in
-  [ { original_compilation_unit = Compilation_unit.get_current_exn ();
-      final_typing_env;
-      all_code;
-      exported_offsets;
-      used_value_slots;
-      table_data
-    } ]
+  { t with table_data = Some table_data }
+
+let prepare_for_serialization t = List.map prepare_for_serialization0 t
 
 module Make_importer (S : sig
   type t
@@ -136,13 +145,22 @@ module Const_importer = Make_importer (Reg_width_const)
 module Code_id_importer = Make_importer (Code_id)
 module Continuation_importer = Make_importer (Continuation)
 
+let check_was_prepared_for_serialization t =
+  match t.table_data with
+  | Some table_data -> table_data
+  | None ->
+    Misc.fatal_errorf
+      "[Flambda_cmx_format.t] value for %a was not prepared for serialization"
+      Compilation_unit.print t.original_compilation_unit
+
 let import_typing_env_and_code0 t =
-  let symbols = Symbol_importer.import t.table_data.symbols in
-  let variables = Variable_importer.import t.table_data.variables in
-  let simples = Simple_importer.import t.table_data.simples in
-  let consts = Const_importer.import t.table_data.consts in
-  let code_ids = Code_id_importer.import t.table_data.code_ids in
-  let continuations = Continuation_importer.import t.table_data.continuations in
+  let table_data = check_was_prepared_for_serialization t in
+  let symbols = Symbol_importer.import table_data.symbols in
+  let variables = Variable_importer.import table_data.variables in
+  let simples = Simple_importer.import table_data.simples in
+  let consts = Const_importer.import table_data.consts in
+  let code_ids = Code_id_importer.import table_data.code_ids in
+  let continuations = Continuation_importer.import table_data.continuations in
   let used_value_slots = t.used_value_slots in
   let original_compilation_unit = t.original_compilation_unit in
   let renaming =
@@ -154,7 +172,10 @@ let import_typing_env_and_code0 t =
       renaming
   in
   let all_code = Exported_code.apply_renaming code_ids renaming t.all_code in
-  typing_env, all_code
+  let exported_offsets =
+    Exported_offsets.apply_renaming t.exported_offsets renaming
+  in
+  typing_env, all_code, exported_offsets
 
 let import_typing_env_and_code t =
   match t with
@@ -162,20 +183,20 @@ let import_typing_env_and_code t =
   | [t0] -> import_typing_env_and_code0 t0
   | t0 :: rem ->
     List.fold_left
-      (fun (typing_env, code) t0 ->
-        let typing_env0, code0 = import_typing_env_and_code0 t0 in
+      (fun (typing_env, code, exported_offsets) t0 ->
+        let typing_env0, code0, exported_offsets0 =
+          import_typing_env_and_code0 t0
+        in
         let typing_env =
           Flambda2_types.Typing_env.Serializable.merge typing_env typing_env0
         in
         let code = Exported_code.merge code code0 in
-        typing_env, code)
+        let exported_offsets =
+          Exported_offsets.merge exported_offsets exported_offsets0
+        in
+        typing_env, code, exported_offsets)
       (import_typing_env_and_code0 t0)
       rem
-
-let exported_offsets t =
-  List.fold_left
-    (fun offsets t0 -> Exported_offsets.merge offsets t0.exported_offsets)
-    Exported_offsets.empty t
 
 let functions_info t =
   List.fold_left
@@ -189,29 +210,30 @@ let with_exported_offsets t exported_offsets =
     Misc.fatal_error "Cannot set exported offsets on multiple units"
 
 let update_for_pack0 ~pack_units ~pack t =
+  let table_data = check_was_prepared_for_serialization t in
   let symbols =
-    Symbol_importer.update_for_pack ~pack_units ~pack t.table_data.symbols
+    Symbol_importer.update_for_pack ~pack_units ~pack table_data.symbols
   in
   let variables =
-    Variable_importer.update_for_pack ~pack_units ~pack t.table_data.variables
+    Variable_importer.update_for_pack ~pack_units ~pack table_data.variables
   in
   let simples =
-    Simple_importer.update_for_pack ~pack_units ~pack t.table_data.simples
+    Simple_importer.update_for_pack ~pack_units ~pack table_data.simples
   in
   let consts =
-    Const_importer.update_for_pack ~pack_units ~pack t.table_data.consts
+    Const_importer.update_for_pack ~pack_units ~pack table_data.consts
   in
   let code_ids =
-    Code_id_importer.update_for_pack ~pack_units ~pack t.table_data.code_ids
+    Code_id_importer.update_for_pack ~pack_units ~pack table_data.code_ids
   in
   let continuations =
     Continuation_importer.update_for_pack ~pack_units ~pack
-      t.table_data.continuations
+      table_data.continuations
   in
   let table_data =
     { symbols; variables; simples; consts; code_ids; continuations }
   in
-  { t with table_data }
+  { t with table_data = Some table_data }
 
 let update_for_pack ~pack_units ~pack t_opt =
   match t_opt with
@@ -232,12 +254,12 @@ let print0 ppf t =
   Format.fprintf ppf "@[<hov>Original unit:@ %a@]@;" Compilation_unit.print
     t.original_compilation_unit;
   Compilation_unit.set_current t.original_compilation_unit;
-  let typing_env, code = import_typing_env_and_code0 t in
+  let typing_env, code, exported_offsets = import_typing_env_and_code0 t in
   Format.fprintf ppf "@[<hov>Typing env:@ %a@]@;"
     Flambda2_types.Typing_env.Serializable.print typing_env;
   Format.fprintf ppf "@[<hov>Code:@ %a@]@;" Exported_code.print code;
   Format.fprintf ppf "@[<hov>Offsets:@ %a@]@;" Exported_offsets.print
-    t.exported_offsets
+    exported_offsets
 
 let [@ocamlformat "disable"] print ppf t =
   let rec print_rest ppf = function

--- a/middle_end/flambda2/cmx/flambda_cmx_format.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.mli
@@ -27,10 +27,13 @@ val create :
   used_value_slots:Value_slot.Set.t ->
   t
 
-val import_typing_env_and_code :
-  t -> Flambda2_types.Typing_env.Serializable.t * Exported_code.t
+val prepare_for_serialization : t -> t
 
-val exported_offsets : t -> Exported_offsets.t
+val import_typing_env_and_code :
+  t ->
+  Flambda2_types.Typing_env.Serializable.t
+  * Exported_code.t
+  * Exported_offsets.t
 
 val functions_info : t -> Exported_code.t
 

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -63,8 +63,12 @@ let run ~cmx_loader ~round unit =
         ~symbol:(fun _symbol -> ()));
   let final_typing_env =
     let cont_uses_env = DA.continuation_uses_env (UA.creation_dacc uacc) in
-    Continuation_uses_env.get_typing_env_no_more_than_one_use cont_uses_env
-      return_continuation
+    match
+      Continuation_uses_env.get_typing_env_no_more_than_one_use cont_uses_env
+        return_continuation
+    with
+    | Some typing_env -> typing_env
+    | None -> TE.create ~resolver ~get_imported_names
   in
   let all_code =
     Exported_code.merge (UA.all_code uacc)

--- a/middle_end/flambda2/simplify_shared/exported_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.ml
@@ -39,7 +39,8 @@ type value_slot_info =
 
 type t =
   { function_slot_offsets : function_slot_info Function_slot.Map.t;
-    value_slot_offsets : value_slot_info Value_slot.Map.t
+    value_slot_offsets : value_slot_info Value_slot.Map.t;
+    symbol_offsets : Targetint.t Symbol.Map.t
   }
 
 let print_function_slot_info fmt = function
@@ -52,14 +53,21 @@ let print_value_slot_info fmt (info : value_slot_info) =
   | Dead_value_slot -> Format.fprintf fmt "@[<h>(removed)@]"
   | Live_value_slot { offset } -> Format.fprintf fmt "@[<h>(o:%d)@]" offset
 
-let [@ocamlformat "disable"] print fmt env =
-  Format.fprintf fmt "{@[<v>closures: @[<v>%a@]@,value_slots: @[<v>%a@]@]}"
-    (Function_slot.Map.print print_function_slot_info) env.function_slot_offsets
-    (Value_slot.Map.print print_value_slot_info) env.value_slot_offsets
+let [@ocamlformat "disable"] print fmt
+      { function_slot_offsets; value_slot_offsets; symbol_offsets } =
+  Format.fprintf fmt "@[<hov 1>(\
+      @[<hov 1>(function_slot_offsets@ %a)@] \
+      @[<hov 1>(value_slot_offsets@ %a)@] \
+      @[<hov 1>(symbol_offsets@ %a)@]\
+      )@]"
+    (Function_slot.Map.print print_function_slot_info) function_slot_offsets
+    (Value_slot.Map.print print_value_slot_info) value_slot_offsets
+    (Symbol.Map.print Targetint.print) symbol_offsets
 
 let empty =
   { function_slot_offsets = Function_slot.Map.empty;
-    value_slot_offsets = Value_slot.Map.empty
+    value_slot_offsets = Value_slot.Map.empty;
+    symbol_offsets = Symbol.Map.empty
   }
 
 let equal_function_slot_info (info1 : function_slot_info)
@@ -102,6 +110,14 @@ let add_value_slot_offset env value_slot offset =
     in
     { env with value_slot_offsets }
 
+let add_symbol_offset env symbol ~bytes =
+  match Symbol.Map.find symbol env.symbol_offsets with
+  | _ ->
+    Misc.fatal_errorf "Symbol offset for %a already defined" Symbol.print symbol
+  | exception Not_found ->
+    let symbol_offsets = Symbol.Map.add symbol bytes env.symbol_offsets in
+    { env with symbol_offsets }
+
 let function_slot_offset env closure =
   match Function_slot.Map.find closure env.function_slot_offsets with
   | exception Not_found -> None
@@ -111,6 +127,14 @@ let value_slot_offset env value_slot =
   match Value_slot.Map.find value_slot env.value_slot_offsets with
   | exception Not_found -> None
   | res -> Some res
+
+let symbol_offset_in_bytes env symbol =
+  match Symbol.Map.find symbol env.symbol_offsets with
+  | exception Not_found -> None
+  | res -> Some res
+
+(* CR mshinwell: remove once debugged *)
+let symbol_offsets t = t.symbol_offsets
 
 let map_function_slot_offsets env f =
   Function_slot.Map.mapi f env.function_slot_offsets
@@ -122,16 +146,43 @@ let current_offsets = ref empty
 let imported_offsets () = !current_offsets
 
 let merge env1 env2 =
-  let function_slot_offsets =
-    Function_slot.Map.disjoint_union ~eq:equal_function_slot_info
-      ~print:print_function_slot_info env1.function_slot_offsets
-      env2.function_slot_offsets
-  in
-  let value_slot_offsets =
-    Value_slot.Map.disjoint_union ~eq:equal_value_slot_info
-      ~print:print_value_slot_info env1.value_slot_offsets
-      env2.value_slot_offsets
-  in
-  { function_slot_offsets; value_slot_offsets }
+  try
+    let function_slot_offsets =
+      Function_slot.Map.disjoint_union ~eq:equal_function_slot_info
+        ~print:print_function_slot_info env1.function_slot_offsets
+        env2.function_slot_offsets
+    in
+    let value_slot_offsets =
+      Value_slot.Map.disjoint_union ~eq:equal_value_slot_info
+        ~print:print_value_slot_info env1.value_slot_offsets
+        env2.value_slot_offsets
+    in
+    let symbol_offsets =
+      Symbol.Map.disjoint_union ~eq:Targetint.equal ~print:Targetint.print
+        env1.symbol_offsets env2.symbol_offsets
+    in
+    { function_slot_offsets; value_slot_offsets; symbol_offsets }
+  with Invalid_argument str as exn ->
+    if String.equal str "disjoint_union"
+    then
+      Misc.fatal_errorf "Cannot merge [Exported_offsets]:@ \n%a@ \n%a" print
+        env1 print env2
+    else raise exn
 
 let import_offsets env = current_offsets := merge env !current_offsets
+
+let apply_renaming { function_slot_offsets; value_slot_offsets; symbol_offsets }
+    renaming =
+  let symbol_offsets =
+    Symbol.Map.fold
+      (fun symbol offset result ->
+        Symbol.Map.add (Renaming.apply_symbol renaming symbol) offset result)
+      symbol_offsets Symbol.Map.empty
+  in
+  { function_slot_offsets; value_slot_offsets; symbol_offsets }
+
+let all_ids_for_export
+    { function_slot_offsets = _; value_slot_offsets = _; symbol_offsets } =
+  Symbol.Map.fold
+    (fun symbol _offset ids -> Ids_for_export.add_symbol ids symbol)
+    symbol_offsets Ids_for_export.empty

--- a/middle_end/flambda2/simplify_shared/exported_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.mli
@@ -55,11 +55,17 @@ val value_slot_offset : t -> Value_slot.t -> value_slot_info option
     the given function slot. *)
 val function_slot_offset : t -> Function_slot.t -> function_slot_info option
 
+val symbol_offset_in_bytes : t -> Symbol.t -> Targetint.t option
+
 (** Record the assignment of the given offset to the given function slot *)
 val add_function_slot_offset : t -> Function_slot.t -> function_slot_info -> t
 
 (** Record the assignment of the given offset to the given value slot *)
 val add_value_slot_offset : t -> Value_slot.t -> value_slot_info -> t
+
+val add_symbol_offset : t -> Symbol.t -> bytes:Targetint.t -> t
+
+val symbol_offsets : t -> Targetint.t Symbol.Map.t
 
 val map_function_slot_offsets :
   t -> (Function_slot.t -> function_slot_info -> 'a) -> 'a Function_slot.Map.t
@@ -76,3 +82,7 @@ val imported_offsets : unit -> t
 
 (** Merge the offsets from two files *)
 val merge : t -> t -> t
+
+val apply_renaming : t -> Renaming.t -> t
+
+val all_ids_for_export : t -> Ids_for_export.t

--- a/middle_end/flambda2/to_cmm/to_cmm.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm.mli
@@ -20,4 +20,4 @@ val unit :
   make_symbol:(?unitname:string -> string option -> string) ->
   Flambda_unit.t ->
   all_code:Exported_code.t ->
-  Cmm.phrase list
+  Cmm.phrase list * Exported_offsets.t

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -700,23 +700,23 @@ let prim env res dbg p =
     let extra, expr = nullary_primitive env dbg prim in
     expr, extra, env, res, Ece.pure
   | Unary (f, x) ->
-    let x, env, eff = C.simple ~dbg env x in
+    let x, env, eff = C.simple ~dbg env res x in
     let extra, res, expr = unary_primitive env res dbg f x in
     expr, extra, env, res, eff
   | Binary (f, x, y) ->
-    let x, env, effx = C.simple ~dbg env x in
-    let y, env, effy = C.simple ~dbg env y in
+    let x, env, effx = C.simple ~dbg env res x in
+    let y, env, effy = C.simple ~dbg env res y in
     let effs = Ece.join effx effy in
     let expr = binary_primitive env dbg f x y in
     expr, None, env, res, effs
   | Ternary (f, x, y, z) ->
-    let x, env, effx = C.simple ~dbg env x in
-    let y, env, effy = C.simple ~dbg env y in
-    let z, env, effz = C.simple ~dbg env z in
+    let x, env, effx = C.simple ~dbg env res x in
+    let y, env, effy = C.simple ~dbg env res y in
+    let z, env, effz = C.simple ~dbg env res z in
     let effs = Ece.join (Ece.join effx effy) effz in
     let expr = ternary_primitive env dbg f x y z in
     expr, None, env, res, effs
   | Variadic (f, l) ->
-    let args, env, effs = C.simple_list ~dbg env l in
+    let args, env, effs = C.simple_list ~dbg env res l in
     let expr = variadic_primitive env dbg f args in
     expr, None, env, res, effs

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -19,20 +19,51 @@ module C = Cmm_helpers
 type t =
   { gc_roots : Symbol.t list;
     data_list : Cmm.phrase list;
+    offset_data_list : Cmm.data_item list;
     functions : Cmm.fundecl list;
     current_data : Cmm.data_item list;
     module_symbol : Symbol.t;
-    module_symbol_defined : bool
+    module_symbol_defined : bool;
+    offsets : Exported_offsets.t;
+    next_symbol_offset : Targetint.t;
+    data_symbol : Symbol.t
   }
 
-let create ~module_symbol =
+let create ~module_symbol ~data_symbol offsets =
   { gc_roots = [];
     data_list = [];
+    offset_data_list = [];
     functions = [];
     current_data = [];
     module_symbol;
-    module_symbol_defined = false
+    module_symbol_defined = false;
+    offsets;
+    next_symbol_offset = Targetint.of_int 0;
+    data_symbol
   }
+
+let record_symbol_offset t symbol ~size_in_words_excluding_header =
+  let offsets =
+    Exported_offsets.add_symbol_offset t.offsets symbol
+      ~bytes:t.next_symbol_offset
+  in
+  Format.eprintf "OFFSET for %a = %a bytes\n%!" Symbol.print symbol
+    Targetint.print t.next_symbol_offset;
+  let next_symbol_offset =
+    Targetint.add t.next_symbol_offset
+      (Targetint.of_int (8 * (size_in_words_excluding_header + 1)))
+  in
+  { t with offsets; next_symbol_offset }
+
+let increment_symbol_offset t ~size_in_words =
+  let next_symbol_offset =
+    Targetint.add t.next_symbol_offset (Targetint.of_int (8 * size_in_words))
+  in
+  Format.eprintf "increment_symbol_offset: %a -> %a\n%!" Targetint.print
+    t.next_symbol_offset Targetint.print next_symbol_offset;
+  { t with next_symbol_offset }
+
+let is_module_symbol t symbol = Symbol.equal t.module_symbol symbol
 
 let check_for_module_symbol t symbol =
   if Symbol.equal symbol t.module_symbol
@@ -42,15 +73,16 @@ let check_for_module_symbol t symbol =
       Misc.fatal_errorf
         "check_for_module_symbol %a: Module block symbol (%a) already defined"
         Symbol.print symbol Symbol.print t.module_symbol;
-    { t with module_symbol_defined = true }
+    { t with module_symbol_defined = true }, true
   end
-  else t
+  else t, false
 
 let defines_a_symbol data =
   match (data : Cmm.data_item) with
   | Cdefine_symbol _ -> true
   | Cglobal_symbol _ | Cint8 _ | Cint16 _ | Cint32 _ | Cint _ | Csingle _
-  | Cdouble _ | Csymbol_address _ | Cstring _ | Cskip _ | Calign _ ->
+  | Cdouble _ | Csymbol_address _ | Coffset_symbol_address _ | Cstring _
+  | Cskip _ | Calign _ | Ccomment _ ->
     false
 
 let add_to_data_list x l =
@@ -61,14 +93,36 @@ let add_to_data_list x l =
     then
       Misc.fatal_errorf
         "data list does not define any symbol, its elements will be unusable: \
-         %a"
-        Printcmm.data x;
+         %a\n\n\
+         Backtrace:\n\
+         %s\n"
+        Printcmm.data x
+        (Printexc.raw_backtrace_to_string (Printexc.get_callstack 100));
     C.cdata x :: l
 
 let archive_data r =
   { r with
     current_data = [];
     data_list = add_to_data_list r.current_data r.data_list
+  }
+
+let filter_offset_data data =
+  List.filter_map
+    (fun (data_item : Cmm.data_item) : Cmm.data_item option ->
+      match data_item with
+      | Cdefine_symbol symbol -> Some (Ccomment symbol (* ^ ":" *))
+      | Cglobal_symbol _ -> None
+      | Cint8 _ | Cint16 _ | Cint32 _ | Cint _ | Csingle _ | Cdouble _
+      | Csymbol_address _ | Coffset_symbol_address _ | Cstring _ | Cskip _
+      | Calign _ | Ccomment _ ->
+        Some data_item)
+    data
+
+let archive_offset_data r =
+  (* CR mshinwell: Add [Ccomment] to [Cmm.data_item] for debugging. *)
+  { r with
+    current_data = [];
+    offset_data_list = r.offset_data_list @ filter_offset_data r.current_data
   }
 
 let update_data r f = { r with current_data = f r.current_data }
@@ -80,17 +134,76 @@ let set_data r l =
       Misc.fatal_errorf "To_cmm_result.set_data: %s"
         "about to lose some translated static data items")
 
-let add_archive_data_items r l =
-  { r with data_list = add_to_data_list l r.data_list }
-
 let add_gc_roots r l = { r with gc_roots = l @ r.gc_roots }
 
 let add_function r f = { r with functions = f :: r.functions }
 
+let is_module_symbol' symbol =
+  let comp_unit = Compilation_unit.name (Symbol.compilation_unit symbol) in
+  let linkage_name = Symbol.linkage_name_as_string symbol in
+  String.equal ("caml" ^ comp_unit) linkage_name
+
+let symbol_offset_in_bytes t symbol =
+  match Exported_offsets.symbol_offset_in_bytes t.offsets symbol with
+  | Some bytes ->
+    (* Format.eprintf "LOCAL Symbol %a can be reached via offset %a\n"
+       Symbol.print symbol Targetint.print bytes; *)
+    Some bytes
+  | None -> (
+    match
+      Exported_offsets.symbol_offset_in_bytes
+        (Exported_offsets.imported_offsets ())
+        symbol
+    with
+    | Some bytes ->
+      (* CR mshinwell: To cope with missing .cmx files, this offset now needs to
+         go in [t.offsets]. *)
+      (* Format.eprintf "IMPORTED Symbol %a can be reached via offset %a\n"
+         Symbol.print symbol Targetint.print bytes; *)
+      Some bytes
+    | None ->
+      if (not (Symbol.is_predefined_exception symbol))
+         && not (is_module_symbol' symbol)
+      then
+        Misc.fatal_errorf "Cannot find offset for symbol %a, backtrace:@ \n%s"
+          Symbol.print symbol
+          (Printexc.raw_backtrace_to_string (Printexc.get_callstack 20));
+      None)
+
+let data_symbol_for_unit comp_unit =
+  Symbol.create comp_unit (Linkage_name.create "data_symbol")
+
+let static_symbol_address t symbol : Cmm.data_item =
+  match symbol_offset_in_bytes t symbol with
+  | None -> C.symbol_address (Symbol.linkage_name_as_string symbol)
+  | Some bytes ->
+    let data_symbol = data_symbol_for_unit (Symbol.compilation_unit symbol) in
+    if Targetint.equal bytes Targetint.zero
+    then C.symbol_address (Symbol.linkage_name_as_string data_symbol)
+    else
+      C.offset_symbol_address (Symbol.linkage_name_as_string data_symbol) ~bytes
+
+let expr_symbol_address t symbol dbg : Cmm.expression =
+  match symbol_offset_in_bytes t symbol with
+  | None -> C.symbol_from_string ~dbg (Symbol.linkage_name_as_string symbol)
+  | Some bytes ->
+    let sym_expr =
+      C.symbol_from_string ~dbg
+        (Symbol.linkage_name_as_string
+           (data_symbol_for_unit (Symbol.compilation_unit symbol)))
+    in
+    if Targetint.equal bytes Targetint.zero
+    then sym_expr
+    else
+      let bytes = Int64.to_nativeint (Targetint.to_int64 bytes) in
+      (* Beware: this must be all in machine integers, not tagged integers. *)
+      Cop (Caddi, [sym_expr; Cconst_natint (bytes, dbg)], dbg)
+
 type result =
   { data_items : Cmm.phrase list;
     gc_roots : Symbol.t list;
-    functions : Cmm.phrase list
+    functions : Cmm.phrase list;
+    offsets : Exported_offsets.t
   }
 
 let define_module_symbol_if_missing r =
@@ -116,8 +229,116 @@ let to_cmm r =
       r.functions
   in
   let function_phrases = List.map (fun f -> C.cfunction f) sorted_functions in
-  (* Return the data list, gc roots and function declarations *)
-  { data_items = r.data_list;
+  let data_items =
+    match r.offset_data_list with
+    | [] -> r.data_list
+    | header :: rest -> (
+      (* Move the first block header prior to the data symbol definition. *)
+      match header with
+      | Cint _ ->
+        C.cdata
+          (header
+           :: C.define_symbol ~global:true
+                (Symbol.linkage_name_as_string r.data_symbol)
+          @ rest)
+        :: r.data_list
+      | Cdefine_symbol _ | Cglobal_symbol _ | Cint8 _ | Cint16 _ | Cint32 _
+      | Csingle _ | Cdouble _ | Csymbol_address _ | Coffset_symbol_address _
+      | Cstring _ | Cskip _ | Calign _ | Ccomment _ ->
+        Misc.fatal_errorf
+          "Malformed [offset_data_list], expected block header to begin:@ %a"
+          Printcmm.data r.offset_data_list)
+  in
+  (match Sys.getenv "OFFSETS" with
+  | exception Not_found -> ()
+  | _ ->
+    Format.eprintf "Offsets:@ \n%a\n\n%!" Exported_offsets.print r.offsets;
+    Format.eprintf "Data items:@ \n";
+    let _offset =
+      List.fold_left
+        (fun offset (phrase : Cmm.phrase) ->
+          match phrase with
+          | Cfunction _ -> assert false
+          | Cdata items ->
+            List.fold_left
+              (fun offset (item : Cmm.data_item) ->
+                let next_offset =
+                  match item with
+                  | Cdefine_symbol _ | Cglobal_symbol _ | Ccomment _ -> offset
+                  | Cint8 _ -> offset + 1
+                  | Cint16 _ -> offset + 2
+                  | Cint32 _ -> offset + 4
+                  | Cint _ -> offset + 8
+                  | Csingle _ -> offset + 4
+                  | Cdouble _ -> offset + 8
+                  | Csymbol_address _ | Coffset_symbol_address _ -> offset + 8
+                  | Cstring s -> String.length s + offset
+                  | Cskip n -> offset + n
+                  | Calign _ -> Misc.fatal_error "Calign unsupported"
+                in
+                Format.eprintf "Offset dec. %06d: %a\n" offset Printcmm.data
+                  [item];
+                next_offset)
+              offset items)
+        (-8) data_items
+    in
+    Format.eprintf "\n\n");
+  let module String = Misc.Stdlib.String in
+  let _offset, cmm_offsets =
+    List.fold_left
+      (fun (offset, cmm_offsets) (phrase : Cmm.phrase) ->
+        match phrase with
+        | Cfunction _ -> assert false
+        | Cdata items ->
+          List.fold_left
+            (fun (offset, cmm_offsets) (item : Cmm.data_item) ->
+              let next_offset, cmm_offsets =
+                match item with
+                | Cdefine_symbol _ | Cglobal_symbol _ -> offset, cmm_offsets
+                | Ccomment sym_name ->
+                  let cmm_offsets =
+                    String.Map.add sym_name offset cmm_offsets
+                  in
+                  offset, cmm_offsets
+                | Cint8 _ -> offset + 1, cmm_offsets
+                | Cint16 _ -> offset + 2, cmm_offsets
+                | Cint32 _ -> offset + 4, cmm_offsets
+                | Cint _ -> offset + 8, cmm_offsets
+                | Csingle _ -> offset + 4, cmm_offsets
+                | Cdouble _ -> offset + 8, cmm_offsets
+                | Csymbol_address _ | Coffset_symbol_address _ ->
+                  offset + 8, cmm_offsets
+                | Cstring s -> String.length s + offset, cmm_offsets
+                | Cskip n -> offset + n, cmm_offsets
+                | Calign _ -> Misc.fatal_error "Calign unsupported"
+              in
+              next_offset, cmm_offsets)
+            (offset, cmm_offsets) items)
+      (-8, String.Map.empty) data_items
+  in
+  let exported_sym_offsets =
+    Exported_offsets.symbol_offsets r.offsets
+    |> Symbol.Map.bindings
+    |> List.sort (fun (_sym1, offset1) (_sym2, offset2) ->
+           Targetint.compare offset1 offset2)
+  in
+  List.iter
+    (fun (sym, offset) ->
+      let offset = Targetint.to_int offset in
+      let sym_name = Symbol.linkage_name_as_string sym in
+      match String.Map.find sym_name cmm_offsets with
+      | exception Not_found ->
+        Format.eprintf "Can't find: %a\n%!" Symbol.print sym
+      | offset' ->
+        if offset <> offset'
+        then
+          Misc.fatal_errorf
+            "Offset for symbol %a is %d in exported offsets but %d in Cmm data \
+             list"
+            Symbol.print sym offset offset')
+    exported_sym_offsets;
+  { data_items;
     gc_roots = r.gc_roots;
-    functions = function_phrases
+    functions = function_phrases;
+    offsets = r.offsets
   }

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -26,14 +26,18 @@
 type t
 
 (** Create a result structure. *)
-val create : module_symbol:Symbol.t -> t
+val create :
+  module_symbol:Symbol.t -> data_symbol:Symbol.t -> Exported_offsets.t -> t
 
-(** Archive the current data into the list of already-translated data. *)
+(** Archive the current data into the list of already-translated data. See note
+    on [archive_offset_data] below too. *)
 val archive_data : t -> t
 
-(** Add already-translated Cmm data items into the archived part of the result
-    structure. *)
-val add_archive_data_items : t -> Cmm.data_item list -> t
+(** Like [archive_data] but must be used if the current data item list contains
+    symbols that have been translated to offsets from the single data symbol. It
+    is not permissible to mix such symbols with those not translated in that
+    manner in the same current data list. *)
+val archive_offset_data : t -> t
 
 (** Update the current data part of the result structure. *)
 val update_data : t -> (Cmm.data_item list -> Cmm.data_item list) -> t
@@ -49,13 +53,29 @@ val add_gc_roots : t -> Symbol.t list -> t
 val add_function : t -> Cmm.fundecl -> t
 
 (** Record the given symbol as having been defined. This is used to keep track
-    of whether the module block symbol for the current unit has been defined. *)
-val check_for_module_symbol : t -> Symbol.t -> t
+    of whether the module block symbol for the current unit has been defined.
+    Returns whether the current symbol is the module symbol. *)
+val check_for_module_symbol : t -> Symbol.t -> t * bool
+
+val is_module_symbol : t -> Symbol.t -> bool
+
+val record_symbol_offset :
+  t -> Symbol.t -> size_in_words_excluding_header:int -> t
+
+val increment_symbol_offset : t -> size_in_words:int -> t
+
+(** Get the Cmm data item to fetch the address of a [Symbol] (which may be an
+    offset load from another symbol). *)
+val static_symbol_address : t -> Symbol.t -> Cmm.data_item
+
+(** Like [static_symbol_address] but for expressions. *)
+val expr_symbol_address : t -> Symbol.t -> Debuginfo.t -> Cmm.expression
 
 type result = private
   { data_items : Cmm.phrase list;
     gc_roots : Symbol.t list;
-    functions : Cmm.phrase list
+    functions : Cmm.phrase list;
+    offsets : Exported_offsets.t
   }
 
 (** Archive the current data and then return the translated data present in the

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -21,12 +21,18 @@ open! Flambda.Import
 type translate_expr =
   To_cmm_env.t -> To_cmm_result.t -> Expr.t -> Cmm.expression * To_cmm_result.t
 
+type pass =
+  | Offsets
+  | Data_items
+
 val let_static_set_of_closures :
+  pass ->
   To_cmm_env.t ->
+  To_cmm_result.t ->
   Symbol.t Function_slot.Map.t ->
   Set_of_closures.t ->
   prev_updates:Cmm.expression option ->
-  To_cmm_env.t * Cmm.data_item list * Cmm.expression option
+  To_cmm_env.t * To_cmm_result.t * Cmm.data_item list * Cmm.expression option
 
 val let_dynamic_set_of_closures :
   To_cmm_env.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -32,13 +32,15 @@ val tag_targetint : Targetint_32_64.t -> Targetint_32_64.t
 
 val nativeint_of_targetint : Targetint_32_64.t -> Nativeint.t
 
+(* Only used to be used for symbols without offsets *)
 val symbol_from_linkage_name :
   dbg:Debuginfo.t -> Linkage_name.t -> Cmm.expression
 
-val symbol : dbg:Debuginfo.t -> Symbol.t -> Cmm.expression
+val symbol : To_cmm_result.t -> dbg:Debuginfo.t -> Symbol.t -> Cmm.expression
 
 val name :
   To_cmm_env.t ->
+  To_cmm_result.t ->
   Name.t ->
   Cmm.expression * To_cmm_env.t * Effects_and_coeffects.t
 
@@ -47,15 +49,19 @@ val const : dbg:Debuginfo.t -> Reg_width_const.t -> Cmm.expression
 val simple :
   dbg:Debuginfo.t ->
   To_cmm_env.t ->
+  To_cmm_result.t ->
   Simple.t ->
   Cmm.expression * To_cmm_env.t * Effects_and_coeffects.t
 
 val simple_static :
-  Simple.t -> [`Data of Cmm.data_item list | `Var of Variable.t]
+  To_cmm_result.t ->
+  Simple.t ->
+  [`Data of Cmm.data_item list | `Var of Variable.t]
 
 val simple_list :
   dbg:Debuginfo.t ->
   To_cmm_env.t ->
+  To_cmm_result.t ->
   Simple.t list ->
   Cmm.expression list * To_cmm_env.t * Effects_and_coeffects.t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -24,9 +24,9 @@ end
 module SC = Static_const
 module R = To_cmm_result
 
-let static_value v =
+let static_value r v =
   match (v : Field_of_static_block.t) with
-  | Symbol s -> C.symbol_address (Symbol.linkage_name_as_string s)
+  | Symbol s -> To_cmm_result.static_symbol_address r s
   | Dynamically_computed _ -> C.cint 1n
   | Tagged_immediate i ->
     C.cint
@@ -38,31 +38,33 @@ let or_variable f default v cont =
   | Const c -> f c cont
   | Var _ -> f default cont
 
-let rec static_block_updates symb env acc i = function
+let rec static_block_updates symb env r acc i = function
   | [] -> env, acc
-  | sv :: r -> begin
+  | sv :: rem -> begin
     match (sv : Field_of_static_block.t) with
     | Symbol _ | Tagged_immediate _ ->
-      static_block_updates symb env acc (i + 1) r
+      static_block_updates symb env r acc (i + 1) rem
     | Dynamically_computed (var, dbg) ->
       let env, acc =
-        C.make_update env dbg Word_val ~symbol:(C.symbol ~dbg symb) var ~index:i
-          ~prev_updates:acc
+        C.make_update env dbg Word_val
+          ~symbol:(R.expr_symbol_address r symb dbg)
+          var ~index:i ~prev_updates:acc
       in
-      static_block_updates symb env acc (i + 1) r
+      static_block_updates symb env r acc (i + 1) rem
   end
 
-let rec static_float_array_updates symb env acc i = function
+let rec static_float_array_updates symb env r acc i = function
   | [] -> env, acc
-  | sv :: r -> begin
+  | sv :: rem -> begin
     match (sv : _ Or_variable.t) with
-    | Const _ -> static_float_array_updates symb env acc (i + 1) r
+    | Const _ -> static_float_array_updates symb env r acc (i + 1) rem
     | Var (var, dbg) ->
       let env, acc =
-        C.make_update env dbg Double ~symbol:(C.symbol ~dbg symb) var ~index:i
-          ~prev_updates:acc
+        C.make_update env dbg Double
+          ~symbol:(R.expr_symbol_address r symb dbg)
+          var ~index:i ~prev_updates:acc
       in
-      static_float_array_updates symb env acc (i + 1) r
+      static_float_array_updates symb env r acc (i + 1) rem
   end
 
 let static_boxed_number kind env symbol default emit transl v r updates =
@@ -75,8 +77,9 @@ let static_boxed_number kind env symbol default emit transl v r updates =
     match (v : _ Or_variable.t) with
     | Const _ -> env, None
     | Var (v, dbg) ->
-      C.make_update env dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
-        ~prev_updates:updates
+      C.make_update env dbg kind
+        ~symbol:(R.expr_symbol_address r symbol dbg)
+        v ~index:0 ~prev_updates:updates
   in
   R.update_data r (or_variable aux default v), updates
 
@@ -89,96 +92,67 @@ let add_functions env ~params_and_body r (code : Code.t) =
     (Code.params_and_body code)
     ~fun_dbg:(Code.dbg code)
 
-let preallocate_set_of_closures (r, updates, env) ~closure_symbols
-    set_of_closures =
-  let env, data, updates =
+let preallocate_set_of_closures (pass : To_cmm_set_of_closures.pass)
+    (r, updates, env) ~closure_symbols set_of_closures =
+  let env, r, data, updates =
     let closure_symbols =
       closure_symbols |> Function_slot.Lmap.bindings
       |> Function_slot.Map.of_list
     in
-    To_cmm_set_of_closures.let_static_set_of_closures env closure_symbols
+    To_cmm_set_of_closures.let_static_set_of_closures pass env r closure_symbols
       set_of_closures ~prev_updates:updates
   in
-  let r = R.set_data r data in
+  let r = match pass with Offsets -> r | Data_items -> R.set_data r data in
   r, updates, env
 
-let static_const0 env r ~updates (bound_static : Bound_static.Pattern.t)
+let static_const_offsets0 env r ~updates (bound_static : Bound_static.Pattern.t)
     (static_const : Static_const.t) =
   match bound_static, static_const with
-  | Block_like s, Block (tag, _mut, fields) ->
-    let r = R.check_for_module_symbol r s in
-    let tag = Tag.Scannable.to_int tag in
-    let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
-    let header = C.black_block_header tag (List.length fields) in
-    let env, static_fields =
-      List.fold_right
-        (fun v (env, static_fields) ->
-          let static_field = static_value v in
-          env, static_field :: static_fields)
-        fields (env, [])
+  | Block_like s, Block (_tag, _mut, fields) ->
+    let is_module_symbol = R.is_module_symbol r s in
+    let r =
+      if is_module_symbol
+      then r
+      else
+        R.record_symbol_offset r s
+          ~size_in_words_excluding_header:(List.length fields)
     in
-    let block = C.emit_block block_name header static_fields in
-    let env, updates = static_block_updates s env updates 0 fields in
-    env, R.set_data r block, updates
+    env, r, updates
   | Set_of_closures closure_symbols, Set_of_closures set_of_closures ->
     let r, updates, env =
-      preallocate_set_of_closures (r, updates, env) ~closure_symbols
+      preallocate_set_of_closures Offsets (r, updates, env) ~closure_symbols
         set_of_closures
     in
     env, r, updates
-  | Block_like s, Boxed_float v ->
-    let default = Numeric_types.Float_by_bit_pattern.zero in
-    let transl = Numeric_types.Float_by_bit_pattern.to_float in
-    let r, (env, updates) =
-      static_boxed_number Double env s default C.emit_float_constant transl v r
-        updates
-    in
+  | Block_like s, Boxed_float _ ->
+    let r = R.record_symbol_offset r s ~size_in_words_excluding_header:1 in
     env, r, updates
-  | Block_like s, Boxed_int32 v ->
-    let r, (env, updates) =
-      static_boxed_number Word_int env s 0l C.emit_int32_constant Fun.id v r
-        updates
-    in
+  | Block_like s, Boxed_int32 _ ->
+    let r = R.record_symbol_offset r s ~size_in_words_excluding_header:2 in
     env, r, updates
-  | Block_like s, Boxed_int64 v ->
-    let r, (env, updates) =
-      static_boxed_number Word_int env s 0L C.emit_int64_constant Fun.id v r
-        updates
-    in
+  | Block_like s, Boxed_int64 _ ->
+    let r = R.record_symbol_offset r s ~size_in_words_excluding_header:2 in
     env, r, updates
-  | Block_like s, Boxed_nativeint v ->
-    let default = Targetint_32_64.zero in
-    let transl = C.nativeint_of_targetint in
-    let r, (env, updates) =
-      static_boxed_number Word_int env s default C.emit_nativeint_constant
-        transl v r updates
-    in
+  | Block_like s, Boxed_nativeint _ ->
+    let r = R.record_symbol_offset r s ~size_in_words_excluding_header:2 in
     env, r, updates
   | Block_like s, (Immutable_float_block fields | Immutable_float_array fields)
     ->
-    let aux =
-      Or_variable.value_map ~default:0.
-        ~f:Numeric_types.Float_by_bit_pattern.to_float
+    let r =
+      R.record_symbol_offset r s
+        ~size_in_words_excluding_header:(List.length fields)
     in
-    let static_fields = List.map aux fields in
-    let float_array =
-      C.emit_float_array_constant
-        (Symbol.linkage_name_as_string s, Cmmgen_state.Global)
-        static_fields
-    in
-    let env, e = static_float_array_updates s env updates 0 fields in
-    env, R.update_data r float_array, e
+    env, r, updates
   | Block_like s, Empty_array ->
-    (* Recall: empty arrays have tag zero, even if their kind is naked float. *)
-    let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
-    let header = C.black_block_header 0 0 in
-    let block = C.emit_block block_name header [] in
-    env, R.set_data r block, updates
+    let r = R.record_symbol_offset r s ~size_in_words_excluding_header:0 in
+    env, r, updates
   | Block_like s, Mutable_string { initial_value = str }
   | Block_like s, Immutable_string str ->
-    let name = Symbol.linkage_name_as_string s in
-    let data = C.emit_string_constant (name, Cmmgen_state.Global) str in
-    env, R.update_data r data, updates
+    let r =
+      R.record_symbol_offset r s
+        ~size_in_words_excluding_header:((String.length str + 8) / 8)
+    in
+    env, r, updates
   | Block_like _, Set_of_closures _ ->
     Misc.fatal_errorf
       "[Set_of_closures] values cannot be bound by [Block_like] bindings:@ %a"
@@ -195,12 +169,108 @@ let static_const0 env r ~updates (bound_static : Bound_static.Pattern.t)
     Misc.fatal_errorf "Sets of closures cannot be bound by [Code] bindings:@ %a"
       SC.print static_const
 
-let static_const_or_code env r ~updates (bound_static : Bound_static.Pattern.t)
+let static_const0 env r ~updates (bound_static : Bound_static.Pattern.t)
+    (static_const : Static_const.t) =
+  match bound_static, static_const with
+  | Block_like s, Block (tag, _mut, fields) ->
+    let r, is_module_symbol = R.check_for_module_symbol r s in
+    let tag = Tag.Scannable.to_int tag in
+    let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
+    let header = C.black_block_header tag (List.length fields) in
+    let env, static_fields =
+      List.fold_right
+        (fun v (env, static_fields) ->
+          let static_field = static_value r v in
+          env, static_field :: static_fields)
+        fields (env, [])
+    in
+    let block = C.emit_block block_name header static_fields in
+    let env, updates = static_block_updates s env r updates 0 fields in
+    env, R.set_data r block, updates, not is_module_symbol
+  | Set_of_closures closure_symbols, Set_of_closures set_of_closures ->
+    let r, updates, env =
+      preallocate_set_of_closures Data_items (r, updates, env) ~closure_symbols
+        set_of_closures
+    in
+    env, r, updates, true
+  | Block_like s, Boxed_float v ->
+    let default = Numeric_types.Float_by_bit_pattern.zero in
+    let transl = Numeric_types.Float_by_bit_pattern.to_float in
+    let r, (env, updates) =
+      static_boxed_number Double env s default C.emit_float_constant transl v r
+        updates
+    in
+    env, r, updates, true
+  | Block_like s, Boxed_int32 v ->
+    let r, (env, updates) =
+      static_boxed_number Word_int env s 0l C.emit_int32_constant Fun.id v r
+        updates
+    in
+    env, r, updates, true
+  | Block_like s, Boxed_int64 v ->
+    let r, (env, updates) =
+      static_boxed_number Word_int env s 0L C.emit_int64_constant Fun.id v r
+        updates
+    in
+    env, r, updates, true
+  | Block_like s, Boxed_nativeint v ->
+    let default = Targetint_32_64.zero in
+    let transl = C.nativeint_of_targetint in
+    let r, (env, updates) =
+      static_boxed_number Word_int env s default C.emit_nativeint_constant
+        transl v r updates
+    in
+    env, r, updates, true
+  | Block_like s, (Immutable_float_block fields | Immutable_float_array fields)
+    ->
+    let aux =
+      Or_variable.value_map ~default:0.
+        ~f:Numeric_types.Float_by_bit_pattern.to_float
+    in
+    let static_fields = List.map aux fields in
+    let float_array =
+      C.emit_float_array_constant
+        (Symbol.linkage_name_as_string s, Cmmgen_state.Global)
+        static_fields
+    in
+    let env, e = static_float_array_updates s env r updates 0 fields in
+    env, R.update_data r float_array, e, true
+  | Block_like s, Empty_array ->
+    (* Recall: empty arrays have tag zero, even if their kind is naked float. *)
+    let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
+    let header = C.black_block_header 0 0 in
+    let block = C.emit_block block_name header [] in
+    env, R.set_data r block, updates, true
+  | Block_like s, Mutable_string { initial_value = str }
+  | Block_like s, Immutable_string str ->
+    let name = Symbol.linkage_name_as_string s in
+    let data = C.emit_string_constant (name, Cmmgen_state.Global) str in
+    env, R.update_data r data, updates, true
+  | Block_like _, Set_of_closures _ ->
+    Misc.fatal_errorf
+      "[Set_of_closures] values cannot be bound by [Block_like] bindings:@ %a"
+      SC.print static_const
+  | ( (Code _ | Set_of_closures _),
+      ( Block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+      | Boxed_nativeint _ | Immutable_float_block _ | Immutable_float_array _
+      | Empty_array | Mutable_string _ | Immutable_string _ ) ) ->
+    Misc.fatal_errorf
+      "Block-like constants cannot be bound by [Code] or [Set_of_closures] \
+       bindings:@ %a"
+      SC.print static_const
+  | Code _, Set_of_closures _ ->
+    Misc.fatal_errorf "Sets of closures cannot be bound by [Code] bindings:@ %a"
+      SC.print static_const
+
+let static_const_or_code_offsets env r ~updates
+    (bound_static : Bound_static.Pattern.t)
     (static_const_or_code : Static_const_or_code.t) =
   let env, r, updates =
     match bound_static, static_const_or_code with
-    | (Block_like _ | Set_of_closures _), Static_const static_const ->
-      static_const0 env r ~updates bound_static static_const
+    | Block_like _, Static_const static_const ->
+      static_const_offsets0 env r ~updates bound_static static_const
+    | Set_of_closures _, Static_const static_const ->
+      static_const_offsets0 env r ~updates bound_static static_const
     | Code code_id, Code code ->
       if not (Code_id.equal code_id (Code.code_id code))
       then
@@ -224,7 +294,47 @@ let static_const_or_code env r ~updates (bound_static : Bound_static.Pattern.t)
          bindings:@ %a@ =@ <deleted code>"
         Bound_static.Pattern.print bound_static
   in
-  env, R.archive_data r, updates
+  let r =
+    (* No data items should have been created. *)
+    R.set_data r []
+  in
+  env, r, updates
+
+let static_const_or_code env r ~updates (bound_static : Bound_static.Pattern.t)
+    (static_const_or_code : Static_const_or_code.t) =
+  let env, r, updates, is_offset_data =
+    match bound_static, static_const_or_code with
+    | Block_like _, Static_const static_const ->
+      static_const0 env r ~updates bound_static static_const
+    | Set_of_closures _, Static_const static_const ->
+      static_const0 env r ~updates bound_static static_const
+    | Code code_id, Code code ->
+      if not (Code_id.equal code_id (Code.code_id code))
+      then
+        Misc.fatal_errorf "Code ID mismatch:@ %a@ =@ %a"
+          Bound_static.Pattern.print bound_static Code.print code;
+      (* Nothing needs doing here as we've already added the code to the
+         environment. *)
+      env, r, updates, false
+    | Code _, Deleted_code -> env, r, updates, false
+    | Code _, Static_const static_const ->
+      Misc.fatal_errorf "Only code can be bound by [Code] bindings:@ %a@ =@ %a"
+        Bound_static.Pattern.print bound_static SC.print static_const
+    | (Set_of_closures _ | Block_like _), Code code ->
+      Misc.fatal_errorf
+        "Pieces of code cannot be bound by [Block_like] or [Set_of_closures] \
+         bindings:@ %a@ =@ %a"
+        Bound_static.Pattern.print bound_static Code.print code
+    | (Set_of_closures _ | Block_like _), Deleted_code ->
+      Misc.fatal_errorf
+        "Deleted code cannot be bound by [Block_like] or [Set_of_closures] \
+         bindings:@ %a@ =@ <deleted code>"
+        Bound_static.Pattern.print bound_static
+  in
+  let r =
+    if is_offset_data then R.archive_offset_data r else R.archive_data r
+  in
+  env, r, updates
 
 let static_consts0 env r ~params_and_body bound_static static_consts =
   (* We cannot both build the environment and compile any functions in one
@@ -238,14 +348,29 @@ let static_consts0 env r ~params_and_body bound_static static_consts =
       "Mismatch between [Bound_static] and [Static_const]s:@ %a@ =@ %a"
       Bound_static.print bound_static Static_const_group.print static_consts;
   let r =
+    (* There shouldn't be any data items pending at this point. *)
+    R.set_data r []
+  in
+  let _env, r, _updates =
+    ListLabels.fold_left2 bound_static' static_consts' ~init:(env, r, None)
+      ~f:(fun (env, r, updates) bound_symbol_pat const ->
+        static_const_or_code_offsets env r ~updates bound_symbol_pat const)
+  in
+  let env, r, updates =
+    ListLabels.fold_left2 bound_static' static_consts' ~init:(env, r, None)
+      ~f:(fun (env, r, updates) bound_symbol_pat const ->
+        static_const_or_code env r ~updates bound_symbol_pat const)
+  in
+  let r =
+    (* The function bodies must be translated after the static consts' data
+       items have been emitted, otherwise the ordering of the data items might
+       not match up with the assigned symbol offsets. *)
     ListLabels.fold_left static_consts' ~init:r ~f:(fun r static_const ->
         match Static_const_or_code.to_code static_const with
         | None -> r
         | Some code -> add_functions env ~params_and_body r code)
   in
-  ListLabels.fold_left2 bound_static' static_consts' ~init:(env, r, None)
-    ~f:(fun (env, r, updates) bound_symbol_pat const ->
-      static_const_or_code env r ~updates bound_symbol_pat const)
+  env, r, updates
 
 let static_consts env r ~params_and_body bound_static static_consts =
   try


### PR DESCRIPTION
@stedolan has been pondering whether we could reduce the number of relocations that the linker has to process by using fewer symbols and more "symbol + offset" calculations, with a view to speeding up linking times and reducing `.o` file and executable sizes (by virtue of smaller symbol tables).  This would probably require some tricky linking / object file format magic in full generality, which might be easier going via a binary (machine code) emitter.

I realised that a variant on this theme could be to just do this for data symbols, without any magic, and an experiment seemed worthwhile.  I thought about doing this in the backend but there are a couple of sticking points.  The offsets of symbols need to be stored in `.cmx` files, meaning the missing `.cmx` file case has to be handled, in a similar way to closure offsets.  It would also be unfortunate to move things out of the symbol tables to end up with various maps from strings, although one can imagine changing the representation of symbols in the compiler to just use integer stamps.  As a result I decided just to implement this in flambda2, which I thought would be fairly straightforward, although it turned out to be a bit tricky (mainly around the handling of closures recursively bound with other symbols).  In flambda2 the map from symbols is just a map from integers and my guess is that most of the symbol names will already be present in the associated tables.

It seems to produce interesting results though.  On `ocamlopt.opt` this appears to reduce executable size by 20%, object file size by 10% and the number of symbols by more than 60%.  The `.cmx` file size increase was 6%, although this patch isn't yet correctly recording the imported symbols in the exported offsets (this will only be noticed if a `.cmx` is missing), so this is probably going to be more like 10% in the end.  It would however be easy in flambda2 to simply drop the names of symbols all together, except perhaps when debugging the compiler, which would claw back some of the `.cmx` increase.

One problem is that loading the addresses of symbols has turned into a two-instruction sequence (on x86-64) which will need to be looked at.  I think at least for non-PIC compilation one instruction should suffice, I'm unsure about the other cases offhand.

There is still some debugging code in this PR in `to_cmm_result.ml`.