### PR TITLE
Review of To_cmm_primitive

### DIFF
--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1120,7 +1120,7 @@ val bigarray_load :
   elt_size:int ->
   elt_chunk:memory_chunk ->
   bigarray:expression ->
-  offset:expression ->
+  index:expression ->
   expression
 
 val bigarray_store :
@@ -1129,7 +1129,7 @@ val bigarray_store :
   elt_size:int ->
   elt_chunk:memory_chunk ->
   bigarray:expression ->
-  offset:expression ->
+  index:expression ->
   new_value:expression ->
   expression
 

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -145,6 +145,9 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename ~module_ident
      [@@@flambda_o3] attribute. *)
   if Flambda_features.classic_mode () then Clflags.use_linscan := true;
   Misc.Color.setup (Flambda_features.colour ());
+  (* CR-someday mshinwell: Note for future WebAssembly work: this thing about
+     the length of arrays will need fixing, I don't think it only applies to the
+     Cmm translation. *)
   (* When the float array optimisation is enabled, the length of an array needs
      to be computed differently according to the array kind, in the case where
      the width of a float is not equal to the machine word width (at present,

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -555,7 +555,7 @@ let transform_primitive env (prim : L.primitive) args loc =
     Primitive (L.Pnot, [L.Lprim (Pfloatcomp CFge, args, loc)], loc)
   | Pbigarrayref (_unsafe, num_dimensions, kind, layout), args -> (
     match
-      P.bigarray_kind_from_lambda kind, P.bigarray_layout_from_lambda layout
+      P.Bigarray_kind.from_lambda kind, P.Bigarray_layout.from_lambda layout
     with
     | Some _, Some _ -> Primitive (prim, args, loc)
     | None, None | None, Some _ | Some _, None ->
@@ -572,7 +572,7 @@ let transform_primitive env (prim : L.primitive) args loc =
            (see translprim).")
   | Pbigarrayset (_unsafe, num_dimensions, kind, layout), args -> (
     match
-      P.bigarray_kind_from_lambda kind, P.bigarray_layout_from_lambda layout
+      P.Bigarray_kind.from_lambda kind, P.Bigarray_layout.from_lambda layout
     with
     | Some _, Some _ -> Primitive (prim, args, loc)
     | None, None | None, Some _ | Some _, None ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -384,7 +384,7 @@ let bigarray_box_or_tag_raw_value_to_read kind alloc_mode =
     Misc.fatal_errorf "Don't know how to box %s after reading it in a bigarray"
       what
   in
-  match P.element_kind_of_bigarray_kind kind with
+  match P.Bigarray_kind.element_kind kind with
   | Value -> Fun.id
   | Naked_number Naked_immediate -> fun arg -> H.Unary (Tag_immediate, Prim arg)
   | Naked_number Naked_float ->
@@ -403,7 +403,7 @@ let bigarray_unbox_or_untag_value_to_store kind =
     Misc.fatal_errorf "Don't know how to unbox %s to store it in a bigarray"
       what
   in
-  match P.element_kind_of_bigarray_kind kind with
+  match P.Bigarray_kind.element_kind kind with
   | Value -> Fun.id
   | Naked_number Naked_immediate ->
     fun arg -> H.Prim (Unary (Untag_immediate, arg))
@@ -448,7 +448,7 @@ let bigarray_indexing layout b args =
       in
       check :: checks, offset
   in
-  match (layout : P.bigarray_layout) with
+  match (layout : P.Bigarray_layout.t) with
   | C -> aux num_dim (-1) (List.rev args)
   | Fortran ->
     aux 1 1
@@ -989,7 +989,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
   | Pint_as_pointer, [arg] -> Unary (Int_as_pointer, arg)
   | Pbigarrayref (unsafe, num_dimensions, kind, layout), args -> (
     match
-      P.bigarray_kind_from_lambda kind, P.bigarray_layout_from_lambda layout
+      P.Bigarray_kind.from_lambda kind, P.Bigarray_layout.from_lambda layout
     with
     | Some kind, Some layout ->
       let b, indexes =
@@ -1012,7 +1012,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
          with an unknown layout should have been removed by Lambda_to_flambda.")
   | Pbigarrayset (unsafe, num_dimensions, kind, layout), args -> (
     match
-      P.bigarray_kind_from_lambda kind, P.bigarray_layout_from_lambda layout
+      P.Bigarray_kind.from_lambda kind, P.Bigarray_layout.from_lambda layout
     with
     | Some kind, Some layout ->
       let b, indexes, value =

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -228,6 +228,13 @@ module Boxable_number = struct
     | Naked_int64 -> Naked_number Naked_int64
     | Naked_nativeint -> Naked_number Naked_nativeint
 
+  let primitive_kind t : Primitive.boxed_integer =
+    match t with
+    | Naked_float -> assert false
+    | Naked_int32 -> Pint32
+    | Naked_int64 -> Pint64
+    | Naked_nativeint -> Pnativeint
+
   include Container_types.Make (struct
     type nonrec t = t
 

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -113,6 +113,8 @@ module Boxable_number : sig
 
   val unboxed_kind : t -> kind
 
+  val primitive_kind : t -> Primitive.boxed_integer
+
   val print_lowercase : Format.formatter -> t -> unit
 
   val print_lowercase_short : Format.formatter -> t -> unit

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -399,80 +399,99 @@ let print_equality_comparison ppf op =
   | Eq -> Format.pp_print_string ppf "Eq"
   | Neq -> Format.pp_print_string ppf "Neq"
 
-type bigarray_kind =
-  | Float32
-  | Float64
-  | Sint8
-  | Uint8
-  | Sint16
-  | Uint16
-  | Int32
-  | Int64
-  | Int_width_int
-  | Targetint_width_int
-  | Complex32
-  | Complex64
+module Bigarray_kind = struct
+  type t =
+    | Float32
+    | Float64
+    | Sint8
+    | Uint8
+    | Sint16
+    | Uint16
+    | Int32
+    | Int64
+    | Int_width_int
+    | Targetint_width_int
+    | Complex32
+    | Complex64
 
-let element_kind_of_bigarray_kind k =
-  match k with
-  | Float32 | Float64 -> K.naked_float
-  | Sint8 | Uint8 | Sint16 | Uint16 -> K.naked_immediate
-  | Int32 -> K.naked_int32
-  | Int64 -> K.naked_int64
-  | Int_width_int -> K.naked_immediate
-  | Targetint_width_int -> K.naked_nativeint
-  | Complex32 | Complex64 ->
-    (* See [copy_two_doubles] in bigarray_stubs.c. *)
-    K.value
+  let element_kind t =
+    match t with
+    | Float32 | Float64 -> K.naked_float
+    | Sint8 | Uint8 | Sint16 | Uint16 -> K.naked_immediate
+    | Int32 -> K.naked_int32
+    | Int64 -> K.naked_int64
+    | Int_width_int -> K.naked_immediate
+    | Targetint_width_int -> K.naked_nativeint
+    | Complex32 | Complex64 ->
+      (* See [copy_two_doubles] in bigarray_stubs.c. *)
+      K.value
 
-let print_bigarray_kind ppf k =
-  let fprintf = Format.fprintf in
-  match k with
-  | Float32 -> fprintf ppf "Float32"
-  | Float64 -> fprintf ppf "Float64"
-  | Sint8 -> fprintf ppf "Sint8"
-  | Uint8 -> fprintf ppf "Uint8"
-  | Sint16 -> fprintf ppf "Sint16"
-  | Uint16 -> fprintf ppf "Uint16"
-  | Int32 -> fprintf ppf "Int32"
-  | Int64 -> fprintf ppf "Int64"
-  | Int_width_int -> fprintf ppf "Int_width_int"
-  | Targetint_width_int -> fprintf ppf "Targetint_width_int"
-  | Complex32 -> fprintf ppf "Complex32"
-  | Complex64 -> fprintf ppf "Complex64"
+  let print ppf t =
+    let fprintf = Format.fprintf in
+    match t with
+    | Float32 -> fprintf ppf "Float32"
+    | Float64 -> fprintf ppf "Float64"
+    | Sint8 -> fprintf ppf "Sint8"
+    | Uint8 -> fprintf ppf "Uint8"
+    | Sint16 -> fprintf ppf "Sint16"
+    | Uint16 -> fprintf ppf "Uint16"
+    | Int32 -> fprintf ppf "Int32"
+    | Int64 -> fprintf ppf "Int64"
+    | Int_width_int -> fprintf ppf "Int_width_int"
+    | Targetint_width_int -> fprintf ppf "Targetint_width_int"
+    | Complex32 -> fprintf ppf "Complex32"
+    | Complex64 -> fprintf ppf "Complex64"
 
-let bigarray_kind_from_lambda (kind : Lambda.bigarray_kind) =
-  match kind with
-  | Pbigarray_unknown -> None
-  | Pbigarray_float32 -> Some Float32
-  | Pbigarray_float64 -> Some Float64
-  | Pbigarray_sint8 -> Some Sint8
-  | Pbigarray_uint8 -> Some Uint8
-  | Pbigarray_sint16 -> Some Sint16
-  | Pbigarray_uint16 -> Some Uint16
-  | Pbigarray_int32 -> Some Int32
-  | Pbigarray_int64 -> Some Int64
-  | Pbigarray_caml_int -> Some Int_width_int
-  | Pbigarray_native_int -> Some Targetint_width_int
-  | Pbigarray_complex32 -> Some Complex32
-  | Pbigarray_complex64 -> Some Complex64
+  let from_lambda (kind : Lambda.bigarray_kind) =
+    match kind with
+    | Pbigarray_unknown -> None
+    | Pbigarray_float32 -> Some Float32
+    | Pbigarray_float64 -> Some Float64
+    | Pbigarray_sint8 -> Some Sint8
+    | Pbigarray_uint8 -> Some Uint8
+    | Pbigarray_sint16 -> Some Sint16
+    | Pbigarray_uint16 -> Some Uint16
+    | Pbigarray_int32 -> Some Int32
+    | Pbigarray_int64 -> Some Int64
+    | Pbigarray_caml_int -> Some Int_width_int
+    | Pbigarray_native_int -> Some Targetint_width_int
+    | Pbigarray_complex32 -> Some Complex32
+    | Pbigarray_complex64 -> Some Complex64
 
-type bigarray_layout =
-  | C
-  | Fortran
+  let to_lambda t : Lambda.bigarray_kind =
+    match t with
+    | Float32 -> Pbigarray_float32
+    | Float64 -> Pbigarray_float64
+    | Sint8 -> Pbigarray_sint8
+    | Uint8 -> Pbigarray_uint8
+    | Sint16 -> Pbigarray_sint16
+    | Uint16 -> Pbigarray_uint16
+    | Int32 -> Pbigarray_int32
+    | Int64 -> Pbigarray_int64
+    | Int_width_int -> Pbigarray_caml_int
+    | Targetint_width_int -> Pbigarray_native_int
+    | Complex32 -> Pbigarray_complex32
+    | Complex64 -> Pbigarray_complex64
+end
 
-let print_bigarray_layout ppf l =
-  let fprintf = Format.fprintf in
-  match l with C -> fprintf ppf "C" | Fortran -> fprintf ppf "Fortran"
+module Bigarray_layout = struct
+  type t =
+    | C
+    | Fortran
 
-let bigarray_layout_from_lambda (layout : Lambda.bigarray_layout) =
-  match layout with
-  | Pbigarray_unknown_layout -> None
-  | Pbigarray_c_layout -> Some C
-  | Pbigarray_fortran_layout -> Some Fortran
+  let print ppf t =
+    let fprintf = Format.fprintf in
+    match t with C -> fprintf ppf "C" | Fortran -> fprintf ppf "Fortran"
+
+  let from_lambda (layout : Lambda.bigarray_layout) =
+    match layout with
+    | Pbigarray_unknown_layout -> None
+    | Pbigarray_c_layout -> Some C
+    | Pbigarray_fortran_layout -> Some Fortran
+end
 
 let reading_from_a_bigarray kind =
-  match (kind : bigarray_kind) with
+  match (kind : Bigarray_kind.t) with
   | Complex32 | Complex64 ->
     Effects.Only_generative_effects Immutable, Coeffects.Has_coeffects
   | Float32 | Float64 | Sint8 | Uint8 | Sint16 | Uint16 | Int32 | Int64
@@ -483,7 +502,7 @@ let reading_from_a_bigarray kind =
    explicit test and switch in the flambda code, see
    lambda_to_flambda_primitives.ml). *)
 let writing_to_a_bigarray kind =
-  match (kind : bigarray_kind) with
+  match (kind : Bigarray_kind.t) with
   | Float32 | Float64 | Sint8 | Uint8 | Sint16 | Uint16 | Int32 | Int64
   | Int_width_int | Targetint_width_int | Complex32
   | Complex64
@@ -1039,7 +1058,7 @@ type binary_primitive =
   | Block_load of Block_access_kind.t * Mutability.t
   | Array_load of Array_kind.t * Mutability.t
   | String_or_bigstring_load of string_like_value * string_accessor_width
-  | Bigarray_load of num_dimensions * bigarray_kind * bigarray_layout
+  | Bigarray_load of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
   | Phys_equal of Flambda_kind.t * equality_comparison
   | Int_arith of Flambda_kind.Standard_int.t * binary_int_arith_op
   | Int_shift of Flambda_kind.Standard_int.t * int_shift_op
@@ -1143,7 +1162,7 @@ let print_binary_primitive ppf p =
   | Bigarray_load (num_dimensions, kind, layout) ->
     fprintf ppf
       "@[(Bigarray_load (num_dimensions@ %d)@ (kind@ %a)@ (layout@ %a))@]"
-      num_dimensions print_bigarray_kind kind print_bigarray_layout layout
+      num_dimensions Bigarray_kind.print kind Bigarray_layout.print layout
   | Phys_equal (kind, op) ->
     Format.fprintf ppf "@[(Phys_equal %a %a)@]" K.print kind
       print_equality_comparison op
@@ -1184,7 +1203,7 @@ let result_kind_of_binary_primitive p : result_kind =
     Singleton K.naked_immediate
   | String_or_bigstring_load (_, Thirty_two) -> Singleton K.naked_int32
   | String_or_bigstring_load (_, Sixty_four) -> Singleton K.naked_int64
-  | Bigarray_load (_, kind, _) -> Singleton (element_kind_of_bigarray_kind kind)
+  | Bigarray_load (_, kind, _) -> Singleton (Bigarray_kind.element_kind kind)
   | Int_arith (kind, _) | Int_shift (kind, _) ->
     Singleton (K.Standard_int.to_kind kind)
   | Float_arith _ -> Singleton K.naked_float
@@ -1226,7 +1245,7 @@ type ternary_primitive =
   | Block_set of Block_access_kind.t * Init_or_assign.t
   | Array_set of Array_kind.t * Init_or_assign.t
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
-  | Bigarray_set of num_dimensions * bigarray_kind * bigarray_layout
+  | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
 
 let ternary_primitive_eligible_for_cse p =
   match p with
@@ -1283,7 +1302,7 @@ let print_ternary_primitive ppf p =
   | Bigarray_set (num_dimensions, kind, layout) ->
     fprintf ppf
       "@[(Bigarray_set (num_dimensions@ %d)@ (kind@ %a)@ (layout@ %a))@]"
-      num_dimensions print_bigarray_kind kind print_bigarray_layout layout
+      num_dimensions Bigarray_kind.print kind Bigarray_layout.print layout
 
 let args_kind_of_ternary_primitive p =
   match p with
@@ -1306,7 +1325,7 @@ let args_kind_of_ternary_primitive p =
   | Bytes_or_bigstring_set (Bigstring, Sixty_four) ->
     bigstring_kind, bytes_or_bigstring_index_kind, K.naked_int64
   | Bigarray_set (_, kind, _) ->
-    bigarray_kind, bigarray_index_kind, element_kind_of_bigarray_kind kind
+    bigarray_kind, bigarray_index_kind, Bigarray_kind.element_kind kind
 
 let result_kind_of_ternary_primitive p : result_kind =
   match p with

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -158,26 +158,35 @@ type equality_comparison =
   | Eq
   | Neq
 
-type bigarray_kind =
-  (* | Unknown *)
-  | Float32
-  | Float64
-  | Sint8
-  | Uint8
-  | Sint16
-  | Uint16
-  | Int32
-  | Int64
-  | Int_width_int
-  | Targetint_width_int
-  | Complex32
-  | Complex64
+module Bigarray_kind : sig
+  type t =
+    | Float32
+    | Float64
+    | Sint8
+    | Uint8
+    | Sint16
+    | Uint16
+    | Int32
+    | Int64
+    | Int_width_int
+    | Targetint_width_int
+    | Complex32
+    | Complex64
 
-val element_kind_of_bigarray_kind : bigarray_kind -> Flambda_kind.t
+  val element_kind : t -> Flambda_kind.t
 
-type bigarray_layout =
-  | (* Unknown | *) C
-  | Fortran
+  val from_lambda : Lambda.bigarray_kind -> t option
+
+  val to_lambda : t -> Lambda.bigarray_kind
+end
+
+module Bigarray_layout : sig
+  type t =
+    | C
+    | Fortran
+
+  val from_lambda : Lambda.bigarray_layout -> t option
+end
 
 type string_accessor_width =
   | Eight
@@ -340,7 +349,7 @@ type binary_primitive =
   | Block_load of Block_access_kind.t * Mutability.t
   | Array_load of Array_kind.t * Mutability.t
   | String_or_bigstring_load of string_like_value * string_accessor_width
-  | Bigarray_load of num_dimensions * bigarray_kind * bigarray_layout
+  | Bigarray_load of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
   | Phys_equal of Flambda_kind.t * equality_comparison
   | Int_arith of Flambda_kind.Standard_int.t * binary_int_arith_op
   | Int_shift of Flambda_kind.Standard_int.t * int_shift_op
@@ -356,7 +365,7 @@ type ternary_primitive =
   | Block_set of Block_access_kind.t * Init_or_assign.t
   | Array_set of Array_kind.t * Init_or_assign.t
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
-  | Bigarray_set of num_dimensions * bigarray_kind * bigarray_layout
+  | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
 
 (** Primitives taking zero or more arguments. *)
 type variadic_primitive =
@@ -498,8 +507,3 @@ val equal_binary_primitive : binary_primitive -> binary_primitive -> bool
 val equal_ternary_primitive : ternary_primitive -> ternary_primitive -> bool
 
 val equal_variadic_primitive : variadic_primitive -> variadic_primitive -> bool
-
-val bigarray_kind_from_lambda : Lambda.bigarray_kind -> bigarray_kind option
-
-val bigarray_layout_from_lambda :
-  Lambda.bigarray_layout -> bigarray_layout option

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -169,7 +169,6 @@ let bigarray_store ~dbg kind ~bigarray ~index ~new_value =
 let string_like_load_aux ~dbg width ~str ~index =
   let index = C.untag_int index dbg in
   match (width : P.string_accessor_width) with
-  (* XXX sign extensions? Cmmgen appears to be all-unsigned *)
   | Eight -> C.load ~dbg Byte_unsigned Mutable ~addr:(C.add_int str index dbg)
   | Sixteen -> C.unaligned_load_16 str index dbg
   | Thirty_two -> C.sign_extend_32 dbg (C.unaligned_load_32 str index dbg)

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -386,7 +386,7 @@ let binary_int_arith_primitive0 _env dbg (kind : K.Standard_int.t)
       match kind with
       | Naked_int64 -> Pint64
       | Naked_nativeint -> Pnativeint
-      | Naked_immediate -> Misc.fatal_error "TBD"
+      | Naked_immediate -> Pint64 (* TEMPORARY until PR696 merged *)
       | Naked_int32 | Tagged_immediate -> assert false
     in
     (* XXX this is wrong for Naked_immediate ("TBD" case also needs fixing

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -244,6 +244,8 @@ let unary_int_arith_primitive _env dbg kind op arg =
   (* Special case for manipulating int64 on 32-bit hosts *)
   | Naked_int64, Neg when Target_system.is_32_bit -> C.unsupported_32_bit ()
   (* General case *)
+  | Naked_int32, Neg when Target_system.is_64_bit ->
+    C.sign_extend_32 dbg (C.sub_int (C.int ~dbg 0) arg dbg)
   | (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint), Neg ->
     (* XXX is this correct for Naked_immediate? *)
     C.sub_int (C.int ~dbg 0) arg dbg

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -284,6 +284,10 @@ let arithmetic_conversion dbg src dst arg =
   | Tagged_immediate, (Naked_int64 | Naked_nativeint | Naked_immediate) ->
     Some (Env.Untag arg), C.untag_int arg dbg
   (* Operations resulting in int32s must take care to sign extend the result *)
+  (* CR-someday xclerc: untag_int followed by sign_extend_32 sounds suboptimal,
+     as it performs asr 1; lsl 32; asr 32 while we could do lsl 31; asr 32
+     instead. (Beware of the optimizations / pattern matching in the helpers
+     though.) *)
   | Tagged_immediate, Naked_int32 ->
     None, C.sign_extend_32 dbg (C.untag_int arg dbg)
   | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Naked_int32

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -327,7 +327,7 @@ let arithmetic_conversion dbg src dst arg =
 
 let binary_phys_comparison _env dbg kind op x y =
   match (kind : K.t), (op : P.equality_comparison) with
-  (* int64 special case *)
+  (* int64 special case on 32-bit platforms *)
   | (Naked_number Naked_int64, Eq | Naked_number Naked_int64, Neq)
     when Target_system.is_32_bit ->
     C.unsupported_32_bit ()
@@ -343,16 +343,13 @@ let binary_phys_comparison _env dbg kind op x y =
     Misc.fatal_errorf "Invalid kind %a for binary_phys_comparison" K.print kind
 
 let binary_int_arith_primitive _env dbg kind op x y =
+  let sign_extend_32_can_delay_overflow f =
+    (* See comments below. *)
+    C.sign_extend_32 dbg (f (C.low_32 dbg x) (C.low_32 dbg y) dbg)
+  in
   match (kind : K.Standard_int.t), (op : P.binary_int_arith_op) with
-  (* Int64 bits ints on 32-bit archs *)
-  | Naked_int64, Add
-  | Naked_int64, Sub
-  | Naked_int64, Mul
-  | Naked_int64, Div
-  | Naked_int64, Mod
-  | Naked_int64, And
-  | Naked_int64, Or
-  | Naked_int64, Xor
+  (* 64-bit ints on 32-bit archs *)
+  | Naked_int64, (Add | Sub | Mul | Div | Mod | And | Or | Xor)
     when Target_system.is_32_bit ->
     C.unsupported_32_bit ()
   (* Tagged integers *)
@@ -364,21 +361,18 @@ let binary_int_arith_primitive _env dbg kind op x y =
   | Tagged_immediate, And -> C.and_int_caml x y dbg
   | Tagged_immediate, Or -> C.or_int_caml x y dbg
   | Tagged_immediate, Xor -> C.xor_int_caml x y dbg
-  (* Operations on 32-bits integers arguments must return something in the range
-     of 32-bits integers, hence the sign_extensions here *)
-  | Naked_int32, Add ->
-    C.sign_extend_32 dbg (C.add_int (C.low_32 dbg x) (C.low_32 dbg y) dbg)
-  | Naked_int32, Sub ->
-    C.sign_extend_32 dbg (C.sub_int (C.low_32 dbg x) (C.low_32 dbg y) dbg)
-  | Naked_int32, Mul ->
-    C.sign_extend_32 dbg (C.mul_int (C.low_32 dbg x) (C.low_32 dbg y) dbg)
-  | Naked_int32, Xor ->
-    C.sign_extend_32 dbg (C.xor_int (C.low_32 dbg x) (C.low_32 dbg y) dbg)
-  | Naked_int32, And ->
-    C.sign_extend_32 dbg (C.and_int (C.low_32 dbg x) (C.low_32 dbg y) dbg)
-  | Naked_int32, Or ->
-    C.sign_extend_32 dbg (C.or_int (C.low_32 dbg x) (C.low_32 dbg y) dbg)
-  (* Naked ints *)
+  (* Operations on 32-bit integer arguments must return something in the range
+     of 32-bit integers, hence the sign_extensions here. The [C.low_32]
+     operations (see above in [sign_extend_32_can_delay_overflow]) are used to
+     avoid unnecessary sign extensions, e.g. when chaining additions together.
+     Also see comment below about [C.low_32] in the [Div] and [Mod] cases. *)
+  | Naked_int32, Add -> sign_extend_32_can_delay_overflow C.add_int
+  | Naked_int32, Sub -> sign_extend_32_can_delay_overflow C.sub_int
+  | Naked_int32, Mul -> sign_extend_32_can_delay_overflow C.mul_int
+  | Naked_int32, Xor -> sign_extend_32_can_delay_overflow C.xor_int
+  | Naked_int32, And -> sign_extend_32_can_delay_overflow C.and_int
+  | Naked_int32, Or -> sign_extend_32_can_delay_overflow C.or_int
+  (* Naked ints not requiring sign extension *)
   | (Naked_int64 | Naked_nativeint | Naked_immediate), Add -> C.add_int x y dbg
   | (Naked_int64 | Naked_nativeint | Naked_immediate), Sub -> C.sub_int x y dbg
   | (Naked_int64 | Naked_nativeint | Naked_immediate), Mul -> C.mul_int x y dbg
@@ -393,6 +387,23 @@ let binary_int_arith_primitive _env dbg kind op x y =
     let bi = primitive_boxed_int_of_standard_int kind in
     C.safe_mod_bi Unsafe x y bi dbg
   | Naked_int32, Div ->
+    (* Note that it would be wrong to apply [C.low_32] to [x] and/or [y] here --
+       likewise in the next [Mod] case. [C.safe_div_bi] and [C.safe_mod_bi]
+       require sign-extended input for both the numerator and denominator.
+
+       Some background: The problem arises in cases like: (num1 * num2) / num3.
+       If an overflow occurs in the multiplication, then we must deal with it by
+       sign-extending before the division. Whereas (num1 * num2) * num3 can
+       delay the sign-extension until the very end, even in the case of overflow
+       in the middle. So in a way, div and mod are regular functions, while all
+       the others are special as they can delay overflow handling.
+
+       We don't have 32-bit registers in Cmm, so sign extension really means
+       modulo 2^31. (If we had 32-bit virtual registers, we could use them in
+       Cmm without sign extension and let the backend insert sign extensions if
+       it doesn't support operations on 32-bit physical registers. There was a
+       prototype developed of this but it was quite complicated and didn't get
+       merged.) *)
     let bi = primitive_boxed_int_of_standard_int kind in
     C.sign_extend_32 dbg (C.safe_div_bi Unsafe x y bi dbg)
   | Naked_int32, Mod ->

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -398,7 +398,7 @@ let binary_int_arith_primitive0 _env dbg (kind : K.Standard_int.t)
 
 (* Temporary wrapper until the PR for removing 32-bit support is done, to permit
    refactoring of the above function *)
-let binary_int_arith_primitive _env dbg kind op x y =
+let binary_int_arith_primitive env dbg kind op x y =
   match (kind : K.Standard_int.t), (op : P.binary_int_arith_op) with
   (* 64-bit ints on 32-bit archs *)
   | Naked_int64, (Add | Sub | Mul | Div | Mod | And | Or | Xor)
@@ -407,7 +407,7 @@ let binary_int_arith_primitive _env dbg kind op x y =
   | ( ( Tagged_immediate | Naked_int32 | Naked_int64 | Naked_nativeint
       | Naked_immediate ),
       (Add | Sub | Mul | Div | Mod | And | Or | Xor) ) ->
-    binary_int_arith_primitive0 _env dbg kind op x y
+    binary_int_arith_primitive0 env dbg kind op x y
 
 let binary_int_shift_primitive _env dbg kind op x y =
   match (kind : K.Standard_int.t), (op : P.int_shift_op) with
@@ -481,7 +481,7 @@ let binary_int_comp_primitive0 _env dbg (kind : K.Standard_int.t)
 
 (* Temporary wrapper until the PR for removing 32-bit support is done, to permit
    refactoring of the above function *)
-let binary_int_comp_primitive _env dbg kind signed cmp x y =
+let binary_int_comp_primitive env dbg kind signed cmp x y =
   match
     ( (kind : K.Standard_int.t),
       (signed : P.signed_or_unsigned),
@@ -500,7 +500,7 @@ let binary_int_comp_primitive _env dbg kind signed cmp x y =
       | Tagged_immediate ),
       (Signed | Unsigned),
       (Lt | Le | Gt | Ge) ) ->
-    binary_int_comp_primitive0 _env dbg kind signed cmp x y
+    binary_int_comp_primitive0 env dbg kind signed cmp x y
 
 let binary_int_comp_primitive_yielding_int _env dbg _kind
     (signed : P.signed_or_unsigned) x y =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -262,6 +262,7 @@ let unary_int_arith_primitive _env dbg kind op arg =
   | Naked_int64, Neg when Target_system.is_32_bit -> C.unsupported_32_bit ()
   (* General case *)
   | (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint), Neg ->
+    (* XXX is this right for Naked_immediate? Same above *)
     C.sub_int (C.int ~dbg 0) arg dbg
   (* Byte swap of 32-bits ints on 64-bit arch need a sign-extension *)
   | Naked_int32, Swap_byte_endianness when Target_system.is_64_bit ->
@@ -278,6 +279,7 @@ let unary_float_arith_primitive _env dbg op arg =
   | Neg -> C.float_neg ~dbg arg
 
 let arithmetic_conversion dbg src dst arg =
+  (* XXX make sure there are no problems here with Naked_immediate *)
   let open K.Standard_int_or_float in
   match src, dst with
   (* 64-bit on 32-bit host specific cases *)
@@ -397,6 +399,7 @@ let binary_int_arith_primitive0 _env dbg (kind : K.Standard_int.t)
       C.sign_extend_32 dbg (C.safe_mod_bi Unsafe x y bi dbg))
   | Naked_int64 | Naked_nativeint | Naked_immediate -> (
     (* Machine-width integers, no sign extension required. *)
+    (* XXX this is wrong for Naked_immediate *)
     match op with
     | Add -> C.add_int x y dbg
     | Sub -> C.sub_int x y dbg
@@ -410,6 +413,9 @@ let binary_int_arith_primitive0 _env dbg (kind : K.Standard_int.t)
     | Mod ->
       let bi = primitive_boxed_int_of_standard_int kind in
       C.safe_mod_bi Unsafe x y bi dbg)
+
+(* Add comment on flambda2 Swap_byte_endianness Naked_immediate case is bswap16,
+   not sign extended, unlike Naked_int64 *)
 
 (* Temporary wrapper until the PR for removing 32-bit support is done, to permit
    refactoring of the above function *)
@@ -447,6 +453,7 @@ let binary_int_shift_primitive _env dbg kind op x y =
     C.sign_extend_32 dbg (C.lsr_int arg y dbg)
   | Naked_int32, Asr -> C.sign_extend_32 dbg (C.asr_int x y dbg)
   (* Naked ints *)
+  (* XXX wrong for Naked_immediate *)
   | (Naked_int64 | Naked_nativeint | Naked_immediate), Lsl -> C.lsl_int x y dbg
   | (Naked_int64 | Naked_nativeint | Naked_immediate), Lsr -> C.lsr_int x y dbg
   | (Naked_int64 | Naked_nativeint | Naked_immediate), Asr -> C.asr_int x y dbg
@@ -475,6 +482,7 @@ let binary_int_comp_primitive0 _env dbg (kind : K.Standard_int.t)
     | Unsigned, Gt -> C.ugt ~dbg (C.ignore_low_bit_int x) y
     | Unsigned, Ge -> C.uge ~dbg x (C.ignore_low_bit_int y))
   | Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate -> (
+    (* XXX check if this is right *)
     match signed, cmp with
     | Signed, Lt -> C.lt ~dbg x y
     | Signed, Le -> C.le ~dbg x y

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -342,73 +342,87 @@ let binary_phys_comparison _env dbg kind op x y =
   | (Region | Rec_info), _ ->
     Misc.fatal_errorf "Invalid kind %a for binary_phys_comparison" K.print kind
 
+let binary_int_arith_primitive0 _env dbg (kind : K.Standard_int.t)
+    (op : P.binary_int_arith_op) x y =
+  match kind with
+  | Tagged_immediate -> (
+    match op with
+    | Add -> C.add_int_caml x y dbg
+    | Sub -> C.sub_int_caml x y dbg
+    | Mul -> C.mul_int_caml x y dbg
+    | Div -> C.div_int_caml Unsafe x y dbg
+    | Mod -> C.mod_int_caml Unsafe x y dbg
+    | And -> C.and_int_caml x y dbg
+    | Or -> C.or_int_caml x y dbg
+    | Xor -> C.xor_int_caml x y dbg)
+  | Naked_int32 -> (
+    (* Operations on 32-bit integer arguments must return something in the range
+       of 32-bit integers, hence the sign_extensions here. The [C.low_32]
+       operations (see above in [sign_extend_32_can_delay_overflow]) are used to
+       avoid unnecessary sign extensions, e.g. when chaining additions together.
+       Also see comment below about [C.low_32] in the [Div] and [Mod] cases. *)
+    let sign_extend_32_can_delay_overflow f =
+      C.sign_extend_32 dbg (f (C.low_32 dbg x) (C.low_32 dbg y) dbg)
+    in
+    match op with
+    | Add -> sign_extend_32_can_delay_overflow C.add_int
+    | Sub -> sign_extend_32_can_delay_overflow C.sub_int
+    | Mul -> sign_extend_32_can_delay_overflow C.mul_int
+    | Xor -> sign_extend_32_can_delay_overflow C.xor_int
+    | And -> sign_extend_32_can_delay_overflow C.and_int
+    | Or -> sign_extend_32_can_delay_overflow C.or_int
+    | Div ->
+      (* Note that it would be wrong to apply [C.low_32] to [x] and/or [y] here
+         -- likewise in the next [Mod] case. [C.safe_div_bi] and [C.safe_mod_bi]
+         require sign-extended input for both the numerator and denominator.
+
+         Some background: The problem arises in cases like: (num1 * num2) /
+         num3. If an overflow occurs in the multiplication, then we must deal
+         with it by sign-extending before the division. Whereas (num1 * num2) *
+         num3 can delay the sign-extension until the very end, even in the case
+         of overflow in the middle. So in a way, div and mod are regular
+         functions, while all the others are special as they can delay overflow
+         handling.
+
+         We don't have 32-bit registers in Cmm, so sign extension really means
+         modulo 2^31. (If we had 32-bit virtual registers, we could use them in
+         Cmm without sign extension and let the backend insert sign extensions
+         if it doesn't support operations on 32-bit physical registers. There
+         was a prototype developed of this but it was quite complicated and
+         didn't get merged.) *)
+      let bi = primitive_boxed_int_of_standard_int kind in
+      C.sign_extend_32 dbg (C.safe_div_bi Unsafe x y bi dbg)
+    | Mod ->
+      let bi = primitive_boxed_int_of_standard_int kind in
+      C.sign_extend_32 dbg (C.safe_mod_bi Unsafe x y bi dbg))
+  | Naked_int64 | Naked_nativeint | Naked_immediate -> (
+    (* Machine-width integers, no sign extension required. *)
+    match op with
+    | Add -> C.add_int x y dbg
+    | Sub -> C.sub_int x y dbg
+    | Mul -> C.mul_int x y dbg
+    | And -> C.and_int x y dbg
+    | Or -> C.or_int x y dbg
+    | Xor -> C.xor_int x y dbg
+    | Div ->
+      let bi = primitive_boxed_int_of_standard_int kind in
+      C.safe_div_bi Unsafe x y bi dbg
+    | Mod ->
+      let bi = primitive_boxed_int_of_standard_int kind in
+      C.safe_mod_bi Unsafe x y bi dbg)
+
+(* Temporary wrapper until the PR for removing 32-bit support is done, to permit
+   refactoring of the above function *)
 let binary_int_arith_primitive _env dbg kind op x y =
-  let sign_extend_32_can_delay_overflow f =
-    (* See comments below. *)
-    C.sign_extend_32 dbg (f (C.low_32 dbg x) (C.low_32 dbg y) dbg)
-  in
   match (kind : K.Standard_int.t), (op : P.binary_int_arith_op) with
   (* 64-bit ints on 32-bit archs *)
   | Naked_int64, (Add | Sub | Mul | Div | Mod | And | Or | Xor)
     when Target_system.is_32_bit ->
     C.unsupported_32_bit ()
-  (* Tagged integers *)
-  | Tagged_immediate, Add -> C.add_int_caml x y dbg
-  | Tagged_immediate, Sub -> C.sub_int_caml x y dbg
-  | Tagged_immediate, Mul -> C.mul_int_caml x y dbg
-  | Tagged_immediate, Div -> C.div_int_caml Unsafe x y dbg
-  | Tagged_immediate, Mod -> C.mod_int_caml Unsafe x y dbg
-  | Tagged_immediate, And -> C.and_int_caml x y dbg
-  | Tagged_immediate, Or -> C.or_int_caml x y dbg
-  | Tagged_immediate, Xor -> C.xor_int_caml x y dbg
-  (* Operations on 32-bit integer arguments must return something in the range
-     of 32-bit integers, hence the sign_extensions here. The [C.low_32]
-     operations (see above in [sign_extend_32_can_delay_overflow]) are used to
-     avoid unnecessary sign extensions, e.g. when chaining additions together.
-     Also see comment below about [C.low_32] in the [Div] and [Mod] cases. *)
-  | Naked_int32, Add -> sign_extend_32_can_delay_overflow C.add_int
-  | Naked_int32, Sub -> sign_extend_32_can_delay_overflow C.sub_int
-  | Naked_int32, Mul -> sign_extend_32_can_delay_overflow C.mul_int
-  | Naked_int32, Xor -> sign_extend_32_can_delay_overflow C.xor_int
-  | Naked_int32, And -> sign_extend_32_can_delay_overflow C.and_int
-  | Naked_int32, Or -> sign_extend_32_can_delay_overflow C.or_int
-  (* Naked ints not requiring sign extension *)
-  | (Naked_int64 | Naked_nativeint | Naked_immediate), Add -> C.add_int x y dbg
-  | (Naked_int64 | Naked_nativeint | Naked_immediate), Sub -> C.sub_int x y dbg
-  | (Naked_int64 | Naked_nativeint | Naked_immediate), Mul -> C.mul_int x y dbg
-  | (Naked_int64 | Naked_nativeint | Naked_immediate), And -> C.and_int x y dbg
-  | (Naked_int64 | Naked_nativeint | Naked_immediate), Or -> C.or_int x y dbg
-  | (Naked_int64 | Naked_nativeint | Naked_immediate), Xor -> C.xor_int x y dbg
-  (* Division and modulo need some extra care *)
-  | (Naked_int64 | Naked_nativeint | Naked_immediate), Div ->
-    let bi = primitive_boxed_int_of_standard_int kind in
-    C.safe_div_bi Unsafe x y bi dbg
-  | (Naked_int64 | Naked_nativeint | Naked_immediate), Mod ->
-    let bi = primitive_boxed_int_of_standard_int kind in
-    C.safe_mod_bi Unsafe x y bi dbg
-  | Naked_int32, Div ->
-    (* Note that it would be wrong to apply [C.low_32] to [x] and/or [y] here --
-       likewise in the next [Mod] case. [C.safe_div_bi] and [C.safe_mod_bi]
-       require sign-extended input for both the numerator and denominator.
-
-       Some background: The problem arises in cases like: (num1 * num2) / num3.
-       If an overflow occurs in the multiplication, then we must deal with it by
-       sign-extending before the division. Whereas (num1 * num2) * num3 can
-       delay the sign-extension until the very end, even in the case of overflow
-       in the middle. So in a way, div and mod are regular functions, while all
-       the others are special as they can delay overflow handling.
-
-       We don't have 32-bit registers in Cmm, so sign extension really means
-       modulo 2^31. (If we had 32-bit virtual registers, we could use them in
-       Cmm without sign extension and let the backend insert sign extensions if
-       it doesn't support operations on 32-bit physical registers. There was a
-       prototype developed of this but it was quite complicated and didn't get
-       merged.) *)
-    let bi = primitive_boxed_int_of_standard_int kind in
-    C.sign_extend_32 dbg (C.safe_div_bi Unsafe x y bi dbg)
-  | Naked_int32, Mod ->
-    let bi = primitive_boxed_int_of_standard_int kind in
-    C.sign_extend_32 dbg (C.safe_mod_bi Unsafe x y bi dbg)
+  | ( ( Tagged_immediate | Naked_int32 | Naked_int64 | Naked_nativeint
+      | Naked_immediate ),
+      (Add | Sub | Mul | Div | Mod | And | Or | Xor) ) ->
+    binary_int_arith_primitive0 _env dbg kind op x y
 
 let binary_int_shift_primitive _env dbg kind op x y =
   match (kind : K.Standard_int.t), (op : P.int_shift_op) with

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -14,6 +14,8 @@
 
 module Env = To_cmm_env
 module Ece = Effects_and_coeffects
+module EO = Exported_offsets
+module K = Flambda_kind
 module P = Flambda_primitive
 
 (* Cmm helpers *)
@@ -25,19 +27,14 @@ end
 (* Closure offsets *)
 
 let function_slot_offset env function_slot =
-  match
-    Exported_offsets.function_slot_offset (Env.exported_offsets env)
-      function_slot
-  with
+  match EO.function_slot_offset (Env.exported_offsets env) function_slot with
   | Some res -> res
   | None ->
     Misc.fatal_errorf "Missing offset for function slot %a" Function_slot.print
       function_slot
 
 let value_slot_offset env value_slot =
-  match
-    Exported_offsets.value_slot_offset (Env.exported_offsets env) value_slot
-  with
+  match EO.value_slot_offset (Env.exported_offsets env) value_slot with
   | Some res -> res
   | None ->
     Misc.fatal_errorf "Missing offset for value slot %a" Value_slot.print
@@ -45,26 +42,19 @@ let value_slot_offset env value_slot =
 
 (* Boxed numbers *)
 
-let primitive_boxed_int_of_boxable_number b =
-  match (b : Flambda_kind.Boxable_number.t) with
-  | Naked_float -> assert false
-  | Naked_int32 -> Primitive.Pint32
-  | Naked_int64 -> Primitive.Pint64
-  | Naked_nativeint -> Primitive.Pnativeint
-
 let unbox_number ?(dbg = Debuginfo.none) kind arg =
-  match (kind : Flambda_kind.Boxable_number.t) with
+  match (kind : K.Boxable_number.t) with
   | Naked_float -> C.unbox_float dbg arg
   | Naked_int32 | Naked_int64 | Naked_nativeint ->
-    let primitive_kind = primitive_boxed_int_of_boxable_number kind in
+    let primitive_kind = K.Boxable_number.primitive_kind kind in
     C.unbox_int dbg primitive_kind arg
 
 let box_number ?(dbg = Debuginfo.none) kind alloc_mode arg =
   let alloc_mode = Alloc_mode.to_lambda alloc_mode in
-  match (kind : Flambda_kind.Boxable_number.t) with
+  match (kind : K.Boxable_number.t) with
   | Naked_float -> C.box_float dbg alloc_mode arg
   | Naked_int32 | Naked_int64 | Naked_nativeint ->
-    let primitive_kind = primitive_boxed_int_of_boxable_number kind in
+    let primitive_kind = K.Boxable_number.primitive_kind kind in
     C.box_int_gen dbg primitive_kind alloc_mode arg
 
 (* Block creation and access. For these functions, [index] is a tagged
@@ -88,17 +78,11 @@ let check_alloc_fields = function
 
 let make_block ?(dbg = Debuginfo.none) kind alloc_mode args =
   check_alloc_fields args;
+  let mode = Alloc_mode.to_lambda alloc_mode in
   match (kind : P.Block_kind.t) with
-  | Values (tag, _) ->
-    C.make_alloc
-      ~mode:(Alloc_mode.to_lambda alloc_mode)
-      dbg (Tag.Scannable.to_int tag) args
+  | Values (tag, _) -> C.make_alloc ~mode dbg (Tag.Scannable.to_int tag) args
   | Naked_floats ->
-    C.make_float_alloc
-      ~mode:(Alloc_mode.to_lambda alloc_mode)
-      dbg
-      (Tag.to_int Tag.double_array_tag)
-      args
+    C.make_float_alloc ~mode dbg (Tag.to_int Tag.double_array_tag) args
 
 let block_load ?(dbg = Debuginfo.none) (kind : P.Block_access_kind.t)
     (mutability : Mutability.t) block index =
@@ -259,14 +243,14 @@ let dead_slots_msg dbg function_slots value_slots =
 (* Arithmetic primitives *)
 
 let primitive_boxed_int_of_standard_int x : Primitive.boxed_integer =
-  match (x : Flambda_kind.Standard_int.t) with
+  match (x : K.Standard_int.t) with
   | Naked_int32 -> Pint32
   | Naked_int64 -> Pint64
   | Naked_nativeint -> Pnativeint
   | Tagged_immediate | Naked_immediate -> assert false
 
 let unary_int_arith_primitive _env dbg kind op arg =
-  match (kind : Flambda_kind.Standard_int.t), (op : P.unary_int_arith_op) with
+  match (kind : K.Standard_int.t), (op : P.unary_int_arith_op) with
   | Tagged_immediate, Neg -> C.negint arg dbg
   | Tagged_immediate, Swap_byte_endianness ->
     (* CR mshinwell for gbury: This could maybe cause a fatal error now? *)
@@ -293,7 +277,7 @@ let unary_float_arith_primitive _env dbg op arg =
   | Neg -> C.float_neg ~dbg arg
 
 let arithmetic_conversion dbg src dst arg =
-  let open Flambda_kind.Standard_int_or_float in
+  let open K.Standard_int_or_float in
   match src, dst with
   (* 64-bit on 32-bit host specific cases *)
   | Naked_int64, Tagged_immediate
@@ -341,7 +325,7 @@ let arithmetic_conversion dbg src dst arg =
     None, C.sign_extend_32 dbg (C.int_of_float ~dbg arg)
 
 let binary_phys_comparison _env dbg kind op x y =
-  match (kind : Flambda_kind.t), (op : P.equality_comparison) with
+  match (kind : K.t), (op : P.equality_comparison) with
   (* int64 special case *)
   | (Naked_number Naked_int64, Eq | Naked_number Naked_int64, Neq)
     when Target_system.is_32_bit ->
@@ -352,7 +336,7 @@ let binary_phys_comparison _env dbg kind op x y =
   [@@ocaml.warning "-fragile-match"]
 
 let binary_int_arith_primitive _env dbg kind op x y =
-  match (kind : Flambda_kind.Standard_int.t), (op : P.binary_int_arith_op) with
+  match (kind : K.Standard_int.t), (op : P.binary_int_arith_op) with
   (* Int64 bits ints on 32-bit archs *)
   | Naked_int64, Add
   | Naked_int64, Sub
@@ -409,7 +393,7 @@ let binary_int_arith_primitive _env dbg kind op x y =
     C.sign_extend_32 dbg (C.safe_mod_bi Unsafe x y bi dbg)
 
 let binary_int_shift_primitive _env dbg kind op x y =
-  match (kind : Flambda_kind.Standard_int.t), (op : P.int_shift_op) with
+  match (kind : K.Standard_int.t), (op : P.int_shift_op) with
   (* Int64 special case *)
   | Naked_int64, Lsl when Target_system.is_32_bit ->
     C.unsupported_32_bit ()
@@ -437,7 +421,7 @@ let binary_int_shift_primitive _env dbg kind op x y =
 
 let binary_int_comp_primitive _env dbg kind signed cmp x y =
   match
-    ( (kind : Flambda_kind.Standard_int.t),
+    ( (kind : K.Standard_int.t),
       (signed : P.signed_or_unsigned),
       (cmp : P.ordered_comparison) )
   with
@@ -572,7 +556,7 @@ let unary_primitive env res dbg f arg =
     ( None,
       res,
       C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:false
-        ~ty_args:[C.exttype_of_kind Flambda_kind.naked_int64]
+        ~ty_args:[C.exttype_of_kind K.naked_int64]
         "caml_int64_float_of_bits_unboxed" Cmm.typ_float [arg] )
   | Unbox_number kind -> None, res, unbox_number ~dbg kind arg
   | Untag_immediate -> Some (Env.Untag arg), res, C.untag_int arg dbg

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -85,7 +85,7 @@ let make_block ~dbg kind alloc_mode args =
     C.make_float_alloc ~mode dbg (Tag.to_int Tag.double_array_tag) args
 
 let block_load ~dbg (kind : P.Block_access_kind.t) (mutability : Mutability.t)
-    block index =
+    ~block ~index =
   let mutability = Mutability.to_lambda mutability in
   match kind with
   | Values { field_kind = Any_value; _ } ->
@@ -95,17 +95,17 @@ let block_load ~dbg (kind : P.Block_access_kind.t) (mutability : Mutability.t)
   | Naked_floats _ -> C.unboxed_float_array_ref block index dbg
 
 let block_set ~dbg (kind : P.Block_access_kind.t) (init : P.Init_or_assign.t)
-    block index new_value =
+    ~block ~index ~new_value =
   let init_or_assign = P.Init_or_assign.to_lambda init in
-  match kind with
-  | Values { field_kind = Any_value; _ } ->
-    C.setfield_computed Pointer init_or_assign block index new_value dbg
-    |> C.return_unit dbg
-  | Values { field_kind = Immediate; _ } ->
-    C.setfield_computed Immediate init_or_assign block index new_value dbg
-    |> C.return_unit dbg
-  | Naked_floats _ ->
-    C.float_array_set block index new_value dbg |> C.return_unit dbg
+  let expr =
+    match kind with
+    | Values { field_kind = Any_value; _ } ->
+      C.setfield_computed Pointer init_or_assign block index new_value dbg
+    | Values { field_kind = Immediate; _ } ->
+      C.setfield_computed Immediate init_or_assign block index new_value dbg
+    | Naked_floats _ -> C.float_array_set block index new_value dbg
+  in
+  C.return_unit dbg expr
 
 (* Array creation and access. *)
 
@@ -124,102 +124,92 @@ let array_length ~dbg arr =
   assert (C.wordsize_shift = C.numfloat_shift);
   C.arraylength Paddrarray arr dbg
 
-let array_load ~dbg (kind : P.Array_kind.t) arr index =
+let array_load ~dbg (kind : P.Array_kind.t) ~arr ~index =
   match kind with
   | Immediates -> C.int_array_ref arr index dbg
   | Values -> C.addr_array_ref arr index dbg
   | Naked_floats -> C.unboxed_float_array_ref arr index dbg
 
-let addr_array_store init arr index value dbg =
+let addr_array_store init ~arr ~index ~new_value dbg =
   match (init : P.Init_or_assign.t) with
-  | Assignment Heap -> C.addr_array_set arr index value dbg
-  | Assignment Local -> C.addr_array_set_local arr index value dbg
-  | Initialization -> C.addr_array_initialize arr index value dbg
+  | Assignment Heap -> C.addr_array_set arr index new_value dbg
+  | Assignment Local -> C.addr_array_set_local arr index new_value dbg
+  | Initialization -> C.addr_array_initialize arr index new_value dbg
 
-let array_set ~dbg (kind : P.Array_kind.t) (init : P.Init_or_assign.t) arr index
-    value =
-  match kind with
-  | Immediates -> C.return_unit dbg (C.int_array_set arr index value dbg)
-  | Values -> C.return_unit dbg (addr_array_store init arr index value dbg)
-  | Naked_floats -> C.return_unit dbg (C.float_array_set arr index value dbg)
+let array_set ~dbg (kind : P.Array_kind.t) (init : P.Init_or_assign.t) ~arr
+    ~index ~new_value =
+  let expr =
+    match kind with
+    | Immediates -> C.int_array_set arr index new_value dbg
+    | Values -> addr_array_store init ~arr ~index ~new_value dbg
+    | Naked_floats -> C.float_array_set arr index new_value dbg
+  in
+  C.return_unit dbg expr
 
-(* Bigarrays. For these functions, [offset] is a tagged integer, representing
-   the desired position in the bigarray in units of the [elt_size] (so not
+(* Bigarrays. For these functions, [index] is a tagged integer, representing the
+   desired position in the bigarray in units of the [elt_size] (so not
    necessarily in bytes, words, etc). *)
 
-let bigarray_load ~dbg kind ~bigarray ~offset =
+let bigarray_load_or_store ~dbg kind ~bigarray ~index f =
   let elt_kind = P.Bigarray_kind.to_lambda kind in
   let elt_size = C.bigarray_elt_size_in_bytes elt_kind in
   let elt_chunk = C.bigarray_word_kind elt_kind in
-  C.bigarray_load ~dbg ~elt_kind ~elt_size ~elt_chunk ~bigarray ~offset
+  f ~dbg ~elt_kind ~elt_size ~elt_chunk ~bigarray ~index
 
-let bigarray_store ~dbg kind ~bigarray ~offset ~new_value =
-  let elt_kind = P.Bigarray_kind.to_lambda kind in
-  let elt_size = C.bigarray_elt_size_in_bytes elt_kind in
-  let elt_chunk = C.bigarray_word_kind elt_kind in
-  C.bigarray_store ~dbg ~elt_kind ~elt_size ~elt_chunk ~bigarray ~offset
-    ~new_value
+let bigarray_load ~dbg kind ~bigarray ~index =
+  bigarray_load_or_store ~dbg kind ~bigarray ~index C.bigarray_load
+
+let bigarray_store ~dbg kind ~bigarray ~index ~new_value =
+  bigarray_load_or_store ~dbg kind ~bigarray ~index
+    (C.bigarray_store ~new_value)
 
 (* String and bytes access. For these functions, [index] is a tagged integer. *)
 
-let string_like_load_aux ~dbg width ptr index =
+let string_like_load_aux ~dbg width ~str ~index =
+  let index = C.untag_int index dbg in
   match (width : P.string_accessor_width) with
-  | Eight ->
-    let index = C.untag_int index dbg in
-    C.load ~dbg Byte_unsigned Mutable ~addr:(C.add_int ptr index dbg)
-  | Sixteen ->
-    let index = C.untag_int index dbg in
-    C.unaligned_load_16 ptr index dbg
-  | Thirty_two ->
-    let index = C.untag_int index dbg in
-    C.sign_extend_32 dbg (C.unaligned_load_32 ptr index dbg)
+  (* XXX sign extensions? Cmmgen appears to be all-unsigned *)
+  | Eight -> C.load ~dbg Byte_unsigned Mutable ~addr:(C.add_int str index dbg)
+  | Sixteen -> C.unaligned_load_16 str index dbg
+  | Thirty_two -> C.sign_extend_32 dbg (C.unaligned_load_32 str index dbg)
   | Sixty_four ->
     if Target_system.is_32_bit
     then C.unsupported_32_bit ()
-    else
-      let index = C.untag_int index dbg in
-      C.unaligned_load_64 ptr index dbg
+    else C.unaligned_load_64 str index dbg
 
-let string_like_load ~dbg kind width block index =
+let string_like_load ~dbg kind width ~str ~index =
   match (kind : P.string_like_value) with
-  | String | Bytes -> string_like_load_aux ~dbg width block index
+  | String | Bytes -> string_like_load_aux ~dbg width ~str ~index
   | Bigstring ->
-    let ba_data_addr = C.field_address block 1 dbg in
+    let ba_data_addr = C.field_address str 1 dbg in
     let ba_data = C.load ~dbg Word_int Mutable ~addr:ba_data_addr in
-    C.bind "ba_data" ba_data (fun ptr ->
-        string_like_load_aux ~dbg width ptr index)
+    C.bind "ba_data" ba_data (fun str ->
+        string_like_load_aux ~dbg width ~str ~index)
 
-(* same as {string_like_load_aux} *)
-let bytes_like_set_aux ~dbg _kind width _block ptr idx value =
+let bytes_or_bigstring_set_aux ~dbg width ~bytes ~index ~new_value =
+  let index = C.untag_int index dbg in
   match (width : P.string_accessor_width) with
   | Eight ->
-    let idx = C.untag_int idx dbg in
-    C.store ~dbg Byte_unsigned Assignment ~addr:(C.add_int ptr idx dbg)
-      ~new_value:value
-  | Sixteen ->
-    let idx = C.untag_int idx dbg in
-    C.unaligned_set_16 ptr idx value dbg
-  | Thirty_two ->
-    let idx = C.untag_int idx dbg in
-    C.unaligned_set_32 ptr idx value dbg
+    let addr = C.add_int bytes index dbg in
+    C.store ~dbg Byte_unsigned Assignment ~addr ~new_value
+  | Sixteen -> C.unaligned_set_16 bytes index new_value dbg
+  | Thirty_two -> C.unaligned_set_32 bytes index new_value dbg
   | Sixty_four ->
     if Target_system.is_32_bit
     then C.unsupported_32_bit ()
-    else
-      let idx = C.untag_int idx dbg in
-      C.unaligned_set_64 ptr idx value dbg
+    else C.unaligned_set_64 bytes index new_value dbg
 
-let bytes_like_set ~dbg kind width block index value =
-  match (kind : P.bytes_like_value) with
-  | Bytes ->
-    C.return_unit dbg
-      (bytes_like_set_aux ~dbg kind width block block index value)
-  | Bigstring ->
-    let ba_data_addr = C.field_address block 1 dbg in
-    let ba_data = C.load ~dbg Word_int Mutable ~addr:ba_data_addr in
-    C.return_unit dbg
-      (C.bind "ba_data" ba_data (fun ptr ->
-           bytes_like_set_aux ~dbg kind width block ptr index value))
+let bytes_or_bigstring_set ~dbg kind width ~bytes ~index ~new_value =
+  let expr =
+    match (kind : P.bytes_like_value) with
+    | Bytes -> bytes_or_bigstring_set_aux ~dbg width ~bytes ~index ~new_value
+    | Bigstring ->
+      let addr = C.field_address bytes 1 dbg in
+      let ba_data = C.load ~dbg Word_int Mutable ~addr in
+      C.bind "ba_data" ba_data (fun bytes ->
+          bytes_or_bigstring_set_aux ~dbg width ~bytes ~index ~new_value)
+  in
+  C.return_unit dbg expr
 
 (* Handling of dead function and value slots *)
 
@@ -655,12 +645,12 @@ let unary_primitive env res dbg f arg =
 
 let binary_primitive env dbg f x y =
   match (f : P.binary_primitive) with
-  | Block_load (kind, mut) -> block_load ~dbg kind mut x y
-  | Array_load (kind, _mut) -> array_load ~dbg kind x y
+  | Block_load (kind, mut) -> block_load ~dbg kind mut ~block:x ~index:y
+  | Array_load (kind, _mut) -> array_load ~dbg kind ~arr:x ~index:y
   | String_or_bigstring_load (kind, width) ->
-    string_like_load ~dbg kind width x y
+    string_like_load ~dbg kind width ~str:x ~index:y
   | Bigarray_load (_dimensions, kind, _layout) ->
-    bigarray_load ~dbg kind ~bigarray:x ~offset:y
+    bigarray_load ~dbg kind ~bigarray:x ~index:y
   | Phys_equal (kind, op) -> binary_phys_comparison env dbg kind op x y
   | Int_arith (kind, op) -> binary_int_arith_primitive env dbg kind op x y
   | Int_shift (kind, op) -> binary_int_shift_primitive env dbg kind op x y
@@ -676,11 +666,14 @@ let binary_primitive env dbg f x y =
 
 let ternary_primitive _env dbg f x y z =
   match (f : P.ternary_primitive) with
-  | Block_set (block_access, init) -> block_set ~dbg block_access init x y z
-  | Array_set (array_kind, init) -> array_set ~dbg array_kind init x y z
-  | Bytes_or_bigstring_set (kind, width) -> bytes_like_set ~dbg kind width x y z
+  | Block_set (block_access, init) ->
+    block_set ~dbg block_access init ~block:x ~index:y ~new_value:z
+  | Array_set (array_kind, init) ->
+    array_set ~dbg array_kind init ~arr:x ~index:y ~new_value:z
+  | Bytes_or_bigstring_set (kind, width) ->
+    bytes_or_bigstring_set ~dbg kind width ~bytes:x ~index:y ~new_value:z
   | Bigarray_set (_dimensions, kind, _layout) ->
-    bigarray_store ~dbg kind ~bigarray:x ~offset:y ~new_value:z
+    bigarray_store ~dbg kind ~bigarray:x ~index:y ~new_value:z
 
 let variadic_primitive _env dbg f args =
   match (f : P.variadic_primitive) with

--- a/middle_end/flambda2/z3/comparisons.expect-output
+++ b/middle_end/flambda2/z3/comparisons.expect-output
@@ -1,0 +1,32 @@
+comparing OCaml values or their tagged representation is the same
+unsat
+
+comparing OCaml values or their shifted representation is the same
+unsat
+
+xc < yc  iff  x < (y & ~0x1)
+unsat
+
+Signed, Lt -> C.lt ~dbg x (C.ignore_low_bit_int y)
+unsat
+
+Signed, Le -> C.le ~dbg (C.ignore_low_bit_int x) y
+unsat
+
+Signed, Gt -> C.gt ~dbg (C.ignore_low_bit_int x) y
+unsat
+
+Signed, Ge -> C.ge ~dbg x (C.ignore_low_bit_int y)
+unsat
+
+Unsigned, Lt -> C.ult ~dbg x (C.ignore_low_bit_int y)
+unsat
+
+Unsigned, Le -> C.ule ~dbg (C.ignore_low_bit_int x) y
+unsat
+
+Unsigned, Gt -> C.ugt ~dbg (C.ignore_low_bit_int x) y
+unsat
+
+Unsigned, Ge -> C.uge ~dbg x (C.ignore_low_bit_int y))
+unsat

--- a/middle_end/flambda2/z3/comparisons.smt2
+++ b/middle_end/flambda2/z3/comparisons.smt2
@@ -1,0 +1,115 @@
+(define-sort ocaml_int  () (_ BitVec 63))
+(define-sort tagged_int () (_ BitVec 64))
+
+(define-fun shift ((x ocaml_int)) tagged_int
+ (bvshl ((_ zero_extend 1) x) (_ bv1 64)))
+
+(define-fun tag ((x ocaml_int)) tagged_int
+ (bvor
+  (bvshl ((_ zero_extend 1) x) (_ bv1 64))
+  (_ bv1 64)))
+
+(declare-const xc ocaml_int)
+(declare-const yc ocaml_int)
+
+(define-const x tagged_int (tag xc))
+(define-const y tagged_int (tag yc))
+
+(push)
+(echo "comparing OCaml values or their tagged representation is the same")
+(assert (not (=
+ (bvslt x y)
+ (bvslt xc yc))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "comparing OCaml values or their shifted representation is the same")
+(assert (not (=
+ (bvslt xc yc)
+ (bvslt (shift xc) (shift yc)))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "xc < yc  iff  x < (y & ~0x1)")
+(assert (not (=
+ (bvslt xc yc)
+ (bvslt x (bvand y (bvnot (_ bv1 64)))))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "Signed, Lt -> C.lt ~dbg x (C.ignore_low_bit_int y)")
+(assert (not (=
+ (bvslt xc yc)
+ (bvslt (tag xc) (shift yc)))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "Signed, Le -> C.le ~dbg (C.ignore_low_bit_int x) y")
+(assert (not (=
+ (bvsle xc yc)
+ (bvsle (shift xc) (tag yc)))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "Signed, Gt -> C.gt ~dbg (C.ignore_low_bit_int x) y")
+(assert (not (=
+ (bvsgt xc yc)
+ (bvsgt (shift xc) (tag yc)))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "Signed, Ge -> C.ge ~dbg x (C.ignore_low_bit_int y)")
+(assert (not (=
+ (bvsge xc yc)
+ (bvsge (tag xc) (shift yc)))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "Unsigned, Lt -> C.ult ~dbg x (C.ignore_low_bit_int y)")
+(assert (not (=
+ (bvult xc yc)
+ (bvult (tag xc) (shift yc)))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "Unsigned, Le -> C.ule ~dbg (C.ignore_low_bit_int x) y")
+(assert (not (=
+ (bvule xc yc)
+ (bvule (shift xc) (tag yc)))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "Unsigned, Gt -> C.ugt ~dbg (C.ignore_low_bit_int x) y")
+(assert (not (=
+ (bvugt xc yc)
+ (bvugt (shift xc) (tag yc)))))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "Unsigned, Ge -> C.uge ~dbg x (C.ignore_low_bit_int y))")
+(assert (not (=
+ (bvuge xc yc)
+ (bvuge (tag xc) (shift yc)))))
+(check-sat)
+(echo "")
+(pop)


### PR DESCRIPTION
Best read commit by commit.

@xclerc is going to look at the `Naked_immediate` cases, some of which appear to be wrong (a couple of them would have triggered `assert false`, indeed).

There is an open question as to whether 32-bit string loads should be sign extended.  It seems that the `Cmmgen` code doesn't do this, unless I misread it, and the `bytes.ml` implementation doesn't contain sign extensions (unlike in the 8 and 16 bit cases).  I wonder if this might be a bug in `Cmmgen`.