### PR TITLE
.ocamlformat grouping changes for middle_end/

### DIFF
--- a/middle_end/.ocamlformat
+++ b/middle_end/.ocamlformat
@@ -4,7 +4,6 @@ assignment-operator=begin-line
 cases-exp-indent=2
 doc-comments=before
 dock-collection-brackets=false
-exp-grouping=preserve
 if-then-else=keyword-first
 parens-tuple=multi-line-only
 space-around-lists=false

--- a/middle_end/flambda2/.ocamlformat
+++ b/middle_end/flambda2/.ocamlformat
@@ -4,7 +4,6 @@ assignment-operator=begin-line
 cases-exp-indent=2
 doc-comments=before
 dock-collection-brackets=false
-exp-grouping=preserve
 if-then-else=keyword-first
 parens-tuple=multi-line-only
 space-around-lists=false

--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -359,9 +359,8 @@ end = struct
   let rec update key f t =
     let iv = is_value_of t in
     match descr t with
-    | Empty -> begin
-      match f None with None -> empty iv | Some datum -> leaf iv key datum
-    end
+    | Empty -> (
+      match f None with None -> empty iv | Some datum -> leaf iv key datum)
     | Leaf (key', datum) -> (
       if key = key'
       then
@@ -404,12 +403,11 @@ end = struct
     match descr t0, descr t1 with
     | Empty, _ -> t1
     | _, Empty -> t0
-    | Leaf (i, d0), Leaf (j, d1) when i = j -> begin
+    | Leaf (i, d0), Leaf (j, d1) when i = j -> (
       (* CR mshinwell: [join] in [Typing_env_level] is relying on the fact that
          the arguments to [f] are always in the correct order, i.e. that the
          first datum comes from [t0] and the second from [t1]. Document. *)
-      match f i d0 d1 with None -> empty iv | Some datum -> leaf iv i datum
-    end
+      match f i d0 d1 with None -> empty iv | Some datum -> leaf iv i datum)
     | Leaf (i, d0), Leaf (j, _) -> join i (leaf iv i d0) j t1
     | Leaf (i, d), Branch (prefix, bit, t10, t11) ->
       if match_prefix i prefix bit
@@ -472,16 +470,14 @@ end = struct
     match descr t0, descr t1 with
     | Empty, _ -> empty iv
     | _, Empty -> empty iv
-    | Leaf (i, d0), _ -> begin
+    | Leaf (i, d0), _ -> (
       match find i t1 with
       | exception Not_found -> empty iv
-      | d1 -> leaf iv i (f i d0 d1)
-    end
-    | _, Leaf (i, d1) -> begin
+      | d1 -> leaf iv i (f i d0 d1))
+    | _, Leaf (i, d1) -> (
       match find i t0 with
       | exception Not_found -> empty iv
-      | d0 -> leaf iv i (f i d0 d1)
-    end
+      | d0 -> leaf iv i (f i d0 d1))
     | Branch (prefix0, bit0, t00, t01), Branch (prefix1, bit1, t10, t11) ->
       if equal_prefix prefix0 bit0 prefix1 bit1
       then branch prefix0 bit0 (inter iv f t00 t10) (inter iv f t01 t11)
@@ -698,29 +694,25 @@ end = struct
     (* Empty cases, just recurse and be sure to call f on all leaf cases
        recursively *)
     | Empty, Empty -> empty iv
-    | Empty, Leaf (i, d) -> begin
-      match f i None (Some d) with None -> empty iv | Some d' -> leaf iv i d'
-    end
-    | Leaf (i, d), Empty -> begin
-      match f i (Some d) None with None -> empty iv | Some d' -> leaf iv i d'
-    end
+    | Empty, Leaf (i, d) -> (
+      match f i None (Some d) with None -> empty iv | Some d' -> leaf iv i d')
+    | Leaf (i, d), Empty -> (
+      match f i (Some d) None with None -> empty iv | Some d' -> leaf iv i d')
     | Empty, Branch (prefix, bit, t10, t11) ->
       branch prefix bit (merge' iv f t0 t10) (merge' iv f t0 t11)
     | Branch (prefix, bit, t00, t01), Empty ->
       branch prefix bit (merge' iv f t00 t1) (merge' iv f t01 t1)
     (* Leaf cases *)
-    | Leaf (i, d0), Leaf (j, d1) when i = j -> begin
+    | Leaf (i, d0), Leaf (j, d1) when i = j -> (
       match f i (Some d0) (Some d1) with
       | None -> empty iv
-      | Some datum -> leaf iv i datum
-    end
-    | Leaf (i, d0), Leaf (j, d1) -> begin
+      | Some datum -> leaf iv i datum)
+    | Leaf (i, d0), Leaf (j, d1) -> (
       match f i (Some d0) None, f j None (Some d1) with
       | None, None -> empty iv
       | Some d0, None -> leaf iv i d0
       | None, Some d1 -> leaf iv j d1
-      | Some d0, Some d1 -> join i (leaf iv i d0) j (leaf iv j d1)
-    end
+      | Some d0, Some d1 -> join i (leaf iv i d0) j (leaf iv j d1))
     (* leaf <-> Branch cases *)
     | Leaf (i, d), Branch (prefix, bit, t10, t11) -> (
       if match_prefix i prefix bit
@@ -807,12 +799,11 @@ end = struct
     let rec aux acc () =
       match acc with
       | [] -> Seq.Nil
-      | t0 :: r -> begin
+      | t0 :: r -> (
         match descr t0 with
         | Empty -> aux r ()
         | Leaf (key, value) -> Seq.Cons (Binding.create key value, aux r)
-        | Branch (_, _, t1, t2) -> aux (t1 :: t2 :: r) ()
-      end
+        | Branch (_, _, t1, t2) -> aux (t1 :: t2 :: r) ())
     in
     aux [t]
 
@@ -878,7 +869,7 @@ module Set = struct
   let filter_map f t =
     let rec loop f acc = function
       | Empty -> acc
-      | Leaf i -> begin match f i with None -> acc | Some j -> add j acc end
+      | Leaf i -> ( match f i with None -> acc | Some j -> add j acc)
       | Branch (_, _, t0, t1) -> loop f (loop f acc t0) t1
     in
     loop f Empty t

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -212,13 +212,12 @@ module Inlining = struct
         |> Flambda_arity.length
       in
       if fun_params_length > List.length (Apply_expr.args apply)
-      then begin
+      then (
         Inlining_report.record_decision_at_call_site_for_known_function ~tracker
           ~apply ~pass:After_closure_conversion ~unrolling_depth:None
           ~callee:(Code.absolute_history code)
           ~are_rebuilding_terms Definition_says_not_to_inline;
-        Not_inlinable
-      end
+        Not_inlinable)
       else
         let inlined_call = Apply_expr.inlined apply in
         let decision, res =
@@ -422,7 +421,7 @@ let close_c_call acc env ~loc ~let_bound_var
       then Misc.fatal_errorf "Expected arity one for %s" prim_native_name
       else
         match prim_native_repr_args, prim_native_repr_res with
-        | [(_, Unboxed_integer Pint64)], (_, Unboxed_float) -> begin
+        | [(_, Unboxed_integer Pint64)], (_, Unboxed_float) -> (
           match args with
           | [arg] ->
             let result = Variable.create "reinterpreted_int64" in
@@ -440,8 +439,7 @@ let close_c_call acc env ~loc ~let_bound_var
               (Named.create_prim prim dbg)
               ~body:return_result_expr
           | [] | _ :: _ ->
-            Misc.fatal_errorf "Expected one arg for %s" prim_native_name
-        end
+            Misc.fatal_errorf "Expected one arg for %s" prim_native_name)
         | _, _ ->
           Misc.fatal_errorf "Wrong argument and/or result kind(s) for %s"
             prim_native_name)
@@ -728,7 +726,7 @@ let close_let acc env id user_visible defining_expr
           Some
             (Env.add_block_approximation body_env (Name.var var) approxs
                alloc_mode)
-        | Prim (Binary (Block_load _, block, field), _) -> begin
+        | Prim (Binary (Block_load _, block, field), _) -> (
           match Env.find_value_approximation body_env block with
           | Value_unknown -> Some body_env
           | Closure_approximation _ | Value_symbol _ ->
@@ -770,7 +768,7 @@ let close_let acc env id user_visible defining_expr
               Some (Env.add_simple_to_substitute env id (Simple.symbol sym))
             | _ ->
               Some (Env.add_value_approximation body_env (Name.var var) approx))
-        end
+          )
         | _ -> Some body_env
       in
       let var = VB.create var Name_mode.normal in
@@ -1270,7 +1268,7 @@ let close_one_function acc ~external_env ~by_function_slot decl
     let code = Code_or_metadata.create code in
     let meta = Code_or_metadata.remember_only_metadata code in
     if Flambda_features.classic_mode ()
-    then begin
+    then (
       Inlining_report.record_decision_at_function_definition ~absolute_history
         ~code_metadata:(Code_or_metadata.code_metadata meta)
         ~pass:After_closure_conversion
@@ -1278,8 +1276,7 @@ let close_one_function acc ~external_env ~by_function_slot decl
         inlining_decision;
       if Function_decl_inlining_decision_type.must_be_inlined inlining_decision
       then code
-      else meta
-    end
+      else meta)
     else meta
   in
   let acc = Acc.add_code ~code_id ~code acc in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -958,7 +958,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
         block,
         Simple Simple.const_zero,
         new_ref_value )
-  | Pctconst const, _ -> begin
+  | Pctconst const, _ -> (
     (* CR mshinwell: This doesn't seem to be zero-arity like it should be *)
     (* CR pchambart: It's not obvious when this one should be converted.
        mshinwell: Have put an implementation here for now. *)
@@ -980,8 +980,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
     | Ostype_win32 -> Simple (Simple.const_bool (Sys.os_type = "Win32"))
     | Ostype_cygwin -> Simple (Simple.const_bool (Sys.os_type = "Cygwin"))
     | Backend_type ->
-      Simple Simple.const_zero (* constructor 0 is the same as Native here *)
-  end
+      Simple Simple.const_zero (* constructor 0 is the same as Native here *))
   | Pbswap16, [arg] ->
     tag_int
       (Unary (Int_arith (Naked_immediate, Swap_byte_endianness), untag_int arg))
@@ -990,7 +989,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
   | Pbbswap (Pnativeint, mode), [arg] ->
     bbswap Naked_nativeint Naked_nativeint mode arg
   | Pint_as_pointer, [arg] -> Unary (Int_as_pointer, arg)
-  | Pbigarrayref (unsafe, num_dimensions, kind, layout), args -> begin
+  | Pbigarrayref (unsafe, num_dimensions, kind, layout), args -> (
     match
       P.bigarray_kind_from_lambda kind, P.bigarray_layout_from_lambda layout
     with
@@ -1012,9 +1011,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
     | _, None ->
       Misc.fatal_errorf
         "Lambda_to_flambda_primitives.convert_lprim: Pbigarrayref primitives \
-         with an unknown layout should have been removed by Lambda_to_flambda."
-  end
-  | Pbigarrayset (unsafe, num_dimensions, kind, layout), args -> begin
+         with an unknown layout should have been removed by Lambda_to_flambda.")
+  | Pbigarrayset (unsafe, num_dimensions, kind, layout), args -> (
     match
       P.bigarray_kind_from_lambda kind, P.bigarray_layout_from_lambda layout
     with
@@ -1037,8 +1035,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
     | _, None ->
       Misc.fatal_errorf
         "Lambda_to_flambda_primitives.convert_lprim: Pbigarrayref primitives \
-         with an unknown layout should have been removed by Lambda_to_flambda."
-  end
+         with an unknown layout should have been removed by Lambda_to_flambda.")
   | Pbigarraydim dimension, [arg] ->
     tag_int (Unary (Bigarray_length { dimension }, arg))
   | Pbigstring_load_16 true (* unsafe *), [big_str; index] ->

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -347,18 +347,16 @@ module With_subkind = struct
     }
 
   let create (kind : kind) (subkind : Subkind.t) =
-    begin
-      match kind with
-      | Value -> ()
-      | Naked_number _ | Region | Rec_info -> (
-        match subkind with
-        | Anything -> ()
-        | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
-        | Tagged_immediate | Block _ | Float_block _ | Float_array
-        | Immediate_array | Value_array | Generic_array ->
-          Misc.fatal_errorf "Subkind %a is not valid for kind %a" Subkind.print
-            subkind print kind)
-    end;
+    (match kind with
+    | Value -> ()
+    | Naked_number _ | Region | Rec_info -> (
+      match subkind with
+      | Anything -> ()
+      | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
+      | Tagged_immediate | Block _ | Float_block _ | Float_array
+      | Immediate_array | Value_array | Generic_array ->
+        Misc.fatal_errorf "Subkind %a is not valid for kind %a" Subkind.print
+          subkind print kind));
     { kind; subkind }
 
   let kind t = t.kind

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -273,13 +273,12 @@ end = struct
     | Empty, Potentially_many map | Potentially_many map, Empty ->
       N.Map.is_empty map
     | One (n1, name_mode1), Potentially_many map
-    | Potentially_many map, One (n1, name_mode1) -> begin
+    | Potentially_many map, One (n1, name_mode1) -> (
       match N.Map.get_singleton map with
       | None -> false
       | Some (n2, for_one_name2) ->
         let for_one_name1 = For_one_name.one_occurrence name_mode1 in
-        N.equal n1 n2 && For_one_name.equal for_one_name1 for_one_name2
-    end
+        N.equal n1 n2 && For_one_name.equal for_one_name1 for_one_name2)
     | (Empty | One _), _ -> false
 
   let empty = Empty
@@ -541,16 +540,15 @@ end = struct
        closure allocation if [max_name_mode] is captured. *)
     match max_name_mode with
     | Normal -> t
-    | Phantom -> begin
+    | Phantom -> (
       match t with
       | Empty -> Empty
-      | One (name, name_mode) -> begin
+      | One (name, name_mode) -> (
         match name_mode with
         | Normal | Phantom -> One (name, Name_mode.phantom)
         | In_types ->
           Misc.fatal_errorf "Cannot downgrade [In_types] to [Phantom]:@ %a"
-            print t
-      end
+            print t)
       | Potentially_many map ->
         let map =
           N.Map.map_sharing
@@ -559,18 +557,16 @@ end = struct
                 for_one_name Name_mode.phantom)
             map
         in
-        Potentially_many map
-    end
-    | In_types -> begin
+        Potentially_many map)
+    | In_types -> (
       match t with
       | Empty -> Empty
-      | One (name, name_mode) -> begin
+      | One (name, name_mode) -> (
         match name_mode with
         | Normal | In_types -> One (name, Name_mode.in_types)
         | Phantom ->
           Misc.fatal_errorf "Cannot downgrade [Phantom] to [In_types]:@ %a"
-            print t
-      end
+            print t)
       | Potentially_many map ->
         let map =
           N.Map.map_sharing
@@ -579,8 +575,7 @@ end = struct
                 for_one_name Name_mode.in_types)
             map
         in
-        Potentially_many map
-    end
+        Potentially_many map)
 
   let for_all t ~f =
     match t with

--- a/middle_end/flambda2/nominal/permutation.ml
+++ b/middle_end/flambda2/nominal/permutation.ml
@@ -37,7 +37,7 @@ module Make (N : Container_types.S) = struct
 
   let[@inline always] invariant { forwards; backwards } =
     if check_invariants
-    then begin
+    then (
       let is_bijection map =
         let domain = N.Map.keys map in
         let range_list = N.Map.data map in
@@ -53,8 +53,7 @@ module Make (N : Container_types.S) = struct
             match N.Map.find n2 backwards with
             | exception Not_found -> false
             | n1' -> N.equal n1 n1')
-          forwards)
-    end
+          forwards))
 
   let apply t n =
     match N.Map.find n t.forwards with exception Not_found -> n | n -> n

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -360,19 +360,17 @@ let depth_or_infinity (d : int Or_infinity.t) : Fexpr.rec_info =
 
 let rec rec_info env (ri : Rec_info_expr.t) : Fexpr.rec_info =
   match ri with
-  | Const { depth; unrolling } -> begin
+  | Const { depth; unrolling } -> (
     match unrolling with
     | Not_unrolling -> depth_or_infinity depth
     | Unrolling { remaining_depth } ->
       Unroll (remaining_depth, depth_or_infinity depth)
-    | Do_not_unroll -> begin
+    | Do_not_unroll -> (
       match depth with
       | Infinity -> Do_not_inline
       | Finite _ ->
         Misc.fatal_errorf "unexpected finite depth with Do_not_unroll:@ %a"
-          Rec_info_expr.print ri
-    end
-  end
+          Rec_info_expr.print ri))
   | Var dv -> Var (Env.find_var_exn env dv)
   | Succ ri -> Succ (rec_info env ri)
   | Unroll_to (d, ri) -> Unroll (d, rec_info env ri)
@@ -803,9 +801,8 @@ and static_let_expr env bound_static defining_expr body : Fexpr.expr =
     let rec loop only_set (bindings : Fexpr.symbol_binding list) =
       match bindings with
       | [] -> only_set
-      | Set_of_closures set :: bindings -> begin
-        match only_set with None -> loop (Some set) bindings | Some _ -> None
-      end
+      | Set_of_closures set :: bindings -> (
+        match only_set with None -> loop (Some set) bindings | Some _ -> None)
       | (Data _ | Code _ | Deleted_code _ | Closure _) :: bindings ->
         loop only_set bindings
     in

--- a/middle_end/flambda2/parser/parse_flambda.ml
+++ b/middle_end/flambda2/parser/parse_flambda.ml
@@ -163,9 +163,7 @@ let parse ~symbol_for_global filename =
          let flambda =
            Fexpr_to_flambda.conv ~symbol_for_global ~module_ident fexpr
          in
-         begin
-           match old_comp_unit with
-           | Some old_comp_unit -> Compilation_unit.set_current old_comp_unit
-           | None -> ()
-         end;
+         (match old_comp_unit with
+         | Some old_comp_unit -> Compilation_unit.set_current old_comp_unit
+         | None -> ());
          flambda)

--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -128,7 +128,7 @@ let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
             | [], [] -> None
             | [], _ | _, [] ->
               Misc.fatal_error "Mismatching params and args arity"
-            | arg :: args, param :: params -> begin
+            | arg :: args, param :: params -> (
               match (arg : EA.t) with
               | Already_in_scope arg when Simple.equal arg simple ->
                 (* If [param] has an extra equation associated to it, we
@@ -139,8 +139,7 @@ let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
                 else Some (BP.simple param)
               | Already_in_scope _ | New_let_binding _
               | New_let_binding_with_named_args _ ->
-                find_name simple params args
-            end
+                find_name simple params args)
           in
           fun arg ->
             find_name arg
@@ -157,14 +156,13 @@ let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
                     ~name_mode_of_existing_simple:NM.normal
                 with
                 | exception Not_found -> None
-                | arg -> begin
+                | arg -> (
                   match find_new_name arg with
                   | None ->
                     if TE.mem_simple typing_env_at_fork arg
                     then Some arg
                     else None
-                  | Some _ as arg_opt -> arg_opt
-                end)
+                  | Some _ as arg_opt -> arg_opt))
           in
           match prim with
           | None -> eligible
@@ -354,10 +352,9 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
         in
         if not propagate
         then cse
-        else begin
+        else (
           have_propagated_something := true;
-          add cse prim ~bound_to (Scope.next scope_at_fork)
-        end)
+          add cse prim ~bound_to (Scope.next scope_at_fork)))
       cse cse_at_fork
   in
   if not !have_propagated_something

--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -382,10 +382,9 @@ module Dependency_graph = struct
         let older_enqueued =
           if Code_id.Set.mem src older_enqueued
           then older_enqueued
-          else begin
+          else (
             Queue.push src older_queue;
-            Code_id.Set.add src older_enqueued
-          end
+            Code_id.Set.add src older_enqueued)
         in
         reachable_code_ids t code_id_queue code_id_enqueued older_queue
           older_enqueued name_queue name_enqueued
@@ -396,7 +395,7 @@ module Dependency_graph = struct
       | exception Queue.Empty ->
         reachable_code_ids t code_id_queue code_id_enqueued older_queue
           older_enqueued name_queue name_enqueued
-      | src -> begin
+      | src -> (
         match
           Code_age_relation.get_older_version_of t.code_age_relation src
         with
@@ -405,7 +404,7 @@ module Dependency_graph = struct
             older_enqueued name_queue name_enqueued
         | Some dst ->
           if Code_id.Set.mem dst older_enqueued
-          then begin
+          then (
             if Code_id.Set.mem dst code_id_enqueued
             then
               reachable_older_code_ids t code_id_queue code_id_enqueued
@@ -414,13 +413,11 @@ module Dependency_graph = struct
               let code_id_enqueued = Code_id.Set.add dst code_id_enqueued in
               Queue.push dst code_id_queue;
               reachable_older_code_ids t code_id_queue code_id_enqueued
-                older_queue older_enqueued name_queue name_enqueued
-          end
+                older_queue older_enqueued name_queue name_enqueued)
           else
             let older_enqueued = Code_id.Set.add dst older_enqueued in
             reachable_older_code_ids t code_id_queue code_id_enqueued
-              older_queue older_enqueued name_queue name_enqueued
-      end
+              older_queue older_enqueued name_queue name_enqueued)
   end
 
   let empty code_age_relation =

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -176,7 +176,7 @@ let create_immutable_string are_rebuilding str =
 
 let map_set_of_closures t ~f =
   match t with
-  | Normal { const; _ } -> begin
+  | Normal { const; _ } -> (
     match const with
     | Code _ | Deleted_code -> t
     | Static_const const -> (
@@ -192,8 +192,7 @@ let map_set_of_closures t ~f =
       | Block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
       | Boxed_nativeint _ | Immutable_float_block _ | Immutable_float_array _
       | Empty_array | Mutable_string _ | Immutable_string _ ->
-        t)
-  end
+        t))
   | Block_not_rebuilt _ | Set_of_closures_not_rebuilt _ | Code_not_rebuilt _ ->
     t
 
@@ -232,24 +231,22 @@ let deleted_code =
 
 let make_all_code_deleted t =
   match t with
-  | Normal { const; _ } -> begin
+  | Normal { const; _ } -> (
     match Static_const_or_code.to_code const with
     | None -> t
-    | Some _code -> deleted_code
-  end
+    | Some _code -> deleted_code)
   | Block_not_rebuilt _ | Set_of_closures_not_rebuilt _ -> t
   | Code_not_rebuilt _ -> deleted_code
 
 let make_code_deleted t ~if_code_id_is_member_of =
   match t with
-  | Normal { const; _ } -> begin
+  | Normal { const; _ } -> (
     match Static_const_or_code.to_code const with
     | None -> t
     | Some code ->
       if Code_id.Set.mem (Code.code_id code) if_code_id_is_member_of
       then deleted_code
-      else t
-  end
+      else t)
   | Block_not_rebuilt _ | Set_of_closures_not_rebuilt _ -> t
   | Code_not_rebuilt code ->
     if Code_id.Set.mem

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -287,20 +287,18 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         "cannot simplify a partial application that never returns"
     | Return continuation -> continuation
   in
-  begin
-    match Apply.inlined apply with
-    | Always_inlined | Never_inlined ->
-      Location.prerr_warning
-        (Debuginfo.to_location dbg)
-        (Warnings.Inlining_impossible
-           "[@inlined] attributes may not be used on partial applications")
-    | Unroll _ ->
-      Location.prerr_warning
-        (Debuginfo.to_location dbg)
-        (Warnings.Inlining_impossible
-           "[@unroll] attributes may not be used on partial applications")
-    | Default_inlined | Hint_inlined -> ()
-  end;
+  (match Apply.inlined apply with
+  | Always_inlined | Never_inlined ->
+    Location.prerr_warning
+      (Debuginfo.to_location dbg)
+      (Warnings.Inlining_impossible
+         "[@inlined] attributes may not be used on partial applications")
+  | Unroll _ ->
+    Location.prerr_warning
+      (Debuginfo.to_location dbg)
+      (Warnings.Inlining_impossible
+         "[@unroll] attributes may not be used on partial applications")
+  | Default_inlined | Hint_inlined -> ());
   let arity = Flambda_arity.With_subkinds.cardinal param_arity in
   let args_arity = List.length args in
   assert (arity > args_arity);
@@ -597,15 +595,13 @@ let simplify_direct_function_call ~simplify_expr dacc apply
     ~callee's_function_slot ~result_arity ~result_types ~recursive ~arg_types:_
     ~must_be_detupled ~closure_alloc_mode ~apply_alloc_mode function_decl
     ~down_to_up =
-  begin
-    match Apply.probe_name apply, Apply.inlined apply with
-    | None, _ | Some _, Never_inlined -> ()
-    | Some _, (Hint_inlined | Unroll _ | Default_inlined | Always_inlined) ->
-      Misc.fatal_errorf
-        "[Apply] terms with a [probe_name] (i.e. that call a tracing probe) \
-         must always be marked as [Never_inline]:@ %a"
-        Apply.print apply
-  end;
+  (match Apply.probe_name apply, Apply.inlined apply with
+  | None, _ | Some _, Never_inlined -> ()
+  | Some _, (Hint_inlined | Unroll _ | Default_inlined | Always_inlined) ->
+    Misc.fatal_errorf
+      "[Apply] terms with a [probe_name] (i.e. that call a tracing probe) must \
+       always be marked as [Never_inline]:@ %a"
+      Apply.print apply);
   let result_arity_of_application =
     Call_kind.return_arity (Apply.call_kind apply)
   in

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1179,39 +1179,35 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
       simplify_immutable_block_load access_kind ~min_name_mode
     | Array_load (array_kind, mutability) ->
       simplify_array_load array_kind mutability
-    | Int_arith (kind, op) -> begin
+    | Int_arith (kind, op) -> (
       match kind with
       | Tagged_immediate -> Binary_int_arith_tagged_immediate.simplify op
       | Naked_immediate -> Binary_int_arith_naked_immediate.simplify op
       | Naked_int32 -> Binary_int_arith_int32.simplify op
       | Naked_int64 -> Binary_int_arith_int64.simplify op
-      | Naked_nativeint -> Binary_int_arith_nativeint.simplify op
-    end
-    | Int_shift (kind, op) -> begin
+      | Naked_nativeint -> Binary_int_arith_nativeint.simplify op)
+    | Int_shift (kind, op) -> (
       match kind with
       | Tagged_immediate -> Binary_int_shift_tagged_immediate.simplify op
       | Naked_immediate -> Binary_int_shift_naked_immediate.simplify op
       | Naked_int32 -> Binary_int_shift_int32.simplify op
       | Naked_int64 -> Binary_int_shift_int64.simplify op
-      | Naked_nativeint -> Binary_int_shift_nativeint.simplify op
-    end
-    | Int_comp (kind, Signed, op) -> begin
+      | Naked_nativeint -> Binary_int_shift_nativeint.simplify op)
+    | Int_comp (kind, Signed, op) -> (
       match kind with
       | Tagged_immediate -> Binary_int_comp_tagged_immediate.simplify op
       | Naked_immediate -> Binary_int_comp_naked_immediate.simplify op
       | Naked_int32 -> Binary_int_comp_int32.simplify op
       | Naked_int64 -> Binary_int_comp_int64.simplify op
-      | Naked_nativeint -> Binary_int_comp_nativeint.simplify op
-    end
-    | Int_comp (kind, Unsigned, op) -> begin
+      | Naked_nativeint -> Binary_int_comp_nativeint.simplify op)
+    | Int_comp (kind, Unsigned, op) -> (
       match kind with
       | Tagged_immediate ->
         Binary_int_comp_unsigned_tagged_immediate.simplify op
       | Naked_immediate -> Binary_int_comp_unsigned_naked_immediate.simplify op
       | Naked_int32 -> Binary_int_comp_unsigned_int32.simplify op
       | Naked_int64 -> Binary_int_comp_unsigned_int64.simplify op
-      | Naked_nativeint -> Binary_int_comp_unsigned_nativeint.simplify op
-    end
+      | Naked_nativeint -> Binary_int_comp_unsigned_nativeint.simplify op)
     | Float_arith op -> Binary_float_arith.simplify op
     | Float_comp op -> Binary_float_comp.simplify op
     | Phys_equal (kind, op) -> simplify_phys_equal op kind

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -68,12 +68,10 @@ let is_self_tail_call dacc apply =
       (Exn_continuation.create ~exn_handler:fun_exn_cont ~extra_args:[])
       apply_exn_cont
     (* 2nd check: return continuations match *)
-    && begin
-         match Apply.continuation apply with
-         (* a function that raises unconditionally can be a tail-call *)
-         | Never_returns -> true
-         | Return apply_cont -> Continuation.equal fun_cont apply_cont
-       end
+    && (match Apply.continuation apply with
+       (* a function that raises unconditionally can be a tail-call *)
+       | Never_returns -> true
+       | Return apply_cont -> Continuation.equal fun_cont apply_cont)
     &&
     (* 3rd check: check this is a self-call. *)
     match Apply.call_kind apply with
@@ -280,7 +278,7 @@ let apply_cont_use_kind ~context apply_cont : Continuation_use_kind.t =
     | Switch_branch -> Non_inlinable { escaping = false }
   in
   match Continuation.sort (AC.continuation apply_cont) with
-  | Normal_or_exn -> begin
+  | Normal_or_exn -> (
     match Apply_cont.trap_action apply_cont with
     | None -> default
     | Some (Push _) -> Non_inlinable { escaping = false }
@@ -297,8 +295,7 @@ let apply_cont_use_kind ~context apply_cont : Continuation_use_kind.t =
         if Flambda_features.debug ()
         then Non_inlinable { escaping = true }
         else Non_inlinable { escaping = false }
-      | Some No_trace -> Non_inlinable { escaping = false })
-  end
+      | Some No_trace -> Non_inlinable { escaping = false }))
   | Return | Toplevel_return -> Non_inlinable { escaping = false }
   | Define_root_symbol ->
     assert (Option.is_none (Apply_cont.trap_action apply_cont));

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -91,14 +91,13 @@ let compute_used_params uacc params ~is_exn_handler ~is_single_inlinable_use
       (* CR mshinwell: We should have a robust means of propagating which
          parameter is the exception bucket. Then this hack can be removed. *)
       if !first && is_exn_handler
-      then begin
+      then (
         (* If this argument is actually unused, the apply_conts is updated
            accordingly in simplify_apply_cont. Apply_cont_rewrite can't at the
            moment represent this transformation, so it has to be done manualy *)
         first := false;
-        true
-      end
-      else begin
+        true)
+      else (
         first := false;
         let param_var = BP.var param in
         let num =
@@ -118,8 +117,7 @@ let compute_used_params uacc params ~is_exn_handler ~is_single_inlinable_use
                handler = %a" BP.print param Name_occurrences.print free_names
               (RE.print (UA.are_rebuilding_terms uacc))
               handler;
-          true
-      end
+          true)
     in
     let params_used_as_normal, params_not_used_as_normal =
       List.partition param_is_used params
@@ -149,7 +147,7 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
   let cost_metrics = UA.cost_metrics uacc in
   let uacc, params, new_phantom_params =
     match recursive with
-    | Recursive -> begin
+    | Recursive -> (
       (* In the recursive case, we have already added an apply_cont_rewrite for
          the recursive continuation to eliminate unused parameters in its
          handler. *)
@@ -178,8 +176,7 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
         in
         ( uacc,
           Bound_parameters.create (used_params @ used_extra_params),
-          new_phantom_params )
-    end
+          new_phantom_params ))
     | Non_recursive ->
       (* If the continuation is going to be inlined out, we don't need to spend
          time here calculating unused parameters, since the creation of
@@ -288,15 +285,14 @@ let rebuild_non_recursive_let_cont_handler cont
             sooner than that whether to keep the [Let_cont] (in order to keep
             free name sets correct). *)
          is_single_inlinable_use
-      then begin
+      then (
         (* Note that [Continuation_uses] won't set [is_single_inlinable_use] if
            [cont] is an exception handler. *)
         assert (not is_exn_handler);
         (* We pass the parameters and the handler expression, rather than the
            [CH.t], to avoid re-opening the name abstraction. *)
         UE.add_linearly_used_inlinable_continuation uenv cont scope ~params
-          ~handler ~free_names_of_handler ~cost_metrics_of_handler
-      end
+          ~handler ~free_names_of_handler ~cost_metrics_of_handler)
       else
         let behaviour =
           (* CR-someday mshinwell: This could be replaced by a more
@@ -306,7 +302,7 @@ let rebuild_non_recursive_let_cont_handler cont
           then Unknown
           else
             match RE.to_apply_cont handler with
-            | Some apply_cont -> begin
+            | Some apply_cont -> (
               match Apply_cont.trap_action apply_cont with
               | Some _ -> Unknown
               | None ->
@@ -314,8 +310,7 @@ let rebuild_non_recursive_let_cont_handler cont
                 let params = Bound_parameters.simples params in
                 if Misc.Stdlib.List.compare Simple.compare args params = 0
                 then Alias_for (Apply_cont.continuation apply_cont)
-                else Unknown
-            end
+                else Unknown)
             | None ->
               if RE.is_unreachable handler (UA.are_rebuilding_terms uacc)
               then Unreachable

--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -187,10 +187,10 @@ let removed_operations (named : Named.t) result =
   let descr = Simplify_named_result.descr result in
   let zero = Removed_operations.zero in
   match named with
-  | Set_of_closures _ -> begin
+  | Set_of_closures _ -> (
     match descr with
     | Multiple_bindings_to_symbols _ -> Removed_operations.alloc
-    | Single_term { simplified_defining_expr; _ } -> begin
+    | Single_term { simplified_defining_expr; _ } -> (
       match simplified_defining_expr with
       | Reachable { named = Set_of_closures _; _ }
       | Reachable_try_reify { named = Set_of_closures _; _ } ->
@@ -204,18 +204,15 @@ let removed_operations (named : Named.t) result =
       | Reachable_try_reify { named = Prim _; _ }
       | Reachable_try_reify { named = Simple _; _ }
       | Reachable_try_reify { named = Rec_info _; _ } ->
-        assert false
-    end
-    | Zero_terms -> assert false
-  end
-  | Static_consts _ -> begin
+        assert false)
+    | Zero_terms -> assert false)
+  | Static_consts _ -> (
     match descr with
     | Zero_terms -> zero
-    | Single_term _ | Multiple_bindings_to_symbols _ -> assert false
-  end
-  | Simple _ -> begin
+    | Single_term _ | Multiple_bindings_to_symbols _ -> assert false)
+  | Simple _ -> (
     match descr with
-    | Single_term { simplified_defining_expr; _ } -> begin
+    | Single_term { simplified_defining_expr; _ } -> (
       match simplified_defining_expr with
       | Reachable { named = Simple _; _ }
       | Reachable_try_reify { named = Simple _; _ } ->
@@ -228,13 +225,11 @@ let removed_operations (named : Named.t) result =
       | Reachable_try_reify { named = Set_of_closures _; _ }
       | Reachable_try_reify { named = Prim _; _ }
       | Reachable_try_reify { named = Rec_info _; _ } ->
-        assert false
-    end
-    | Zero_terms | Multiple_bindings_to_symbols _ -> assert false
-  end
-  | Prim (original_prim, _) -> begin
+        assert false)
+    | Zero_terms | Multiple_bindings_to_symbols _ -> assert false)
+  | Prim (original_prim, _) -> (
     match descr with
-    | Single_term { simplified_defining_expr; _ } -> begin
+    | Single_term { simplified_defining_expr; _ } -> (
       match simplified_defining_expr with
       | Reachable { named = Prim (rewritten_prim, _); _ }
       | Reachable_try_reify { named = Prim (rewritten_prim, _); _ } ->
@@ -249,10 +244,8 @@ let removed_operations (named : Named.t) result =
         Removed_operations.prim original_prim
       | Reachable { named = Rec_info _; _ }
       | Reachable_try_reify { named = Rec_info _; _ } ->
-        assert false
-    end
-    | Zero_terms | Multiple_bindings_to_symbols _ -> assert false
-  end
+        assert false)
+    | Zero_terms | Multiple_bindings_to_symbols _ -> assert false)
   | Rec_info _ -> zero
 
 let simplify_named dacc bound_pattern named ~simplify_toplevel =

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -21,14 +21,12 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     dbg ~result_var =
   match prim with
   | Optimised_out result_kind ->
-    begin
-      match Bound_var.name_mode result_var with
-      | Phantom -> ()
-      | Normal | In_types ->
-        Misc.fatal_errorf
-          "The 'optimised_out' primitive should only be used in bindings of \
-           phantom variables"
-    end;
+    (match Bound_var.name_mode result_var with
+    | Phantom -> ()
+    | Normal | In_types ->
+      Misc.fatal_errorf
+        "The 'optimised_out' primitive should only be used in bindings of \
+         phantom variables");
     let named = Named.create_prim original_prim dbg in
     let ty = T.unknown result_kind in
     let dacc = DA.add_variable dacc result_var ty in

--- a/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
@@ -67,28 +67,26 @@ let rec simplify_rec_info_expr0 denv orig ~on_unknown : Rec_info_expr.t =
     | Proved rec_info_expr ->
       (* All bound names are fresh, so fine to use the same environment *)
       simplify_rec_info_expr0 denv rec_info_expr ~on_unknown
-    | Unknown -> begin
+    | Unknown -> (
       match on_unknown with
       | Leave_unevaluated -> orig
-      | Assume_value value -> value
-    end
+      | Assume_value value -> value)
     | Invalid ->
       (* Shouldn't currently be possible *)
       Misc.fatal_errorf "Invalid result from [prove_rec_info] of %a" T.print ty)
-  | Succ ri -> begin
+  | Succ ri -> (
     match simplify_rec_info_expr0 denv ri ~on_unknown with
     | Const { depth; unrolling } -> compute_succ ~depth ~unrolling
     | (Var _ | Succ _ | Unroll_to _) as new_ri ->
-      if ri == new_ri then orig else Rec_info_expr.succ new_ri
-  end
-  | Unroll_to (unroll_depth, ri) -> begin
+      if ri == new_ri then orig else Rec_info_expr.succ new_ri)
+  | Unroll_to (unroll_depth, ri) -> (
     match simplify_rec_info_expr0 denv ri ~on_unknown with
     | Const { depth; unrolling } ->
       compute_unroll_to ~depth ~old_unrolling_state:unrolling
         ~unroll_to:unroll_depth
     | (Var _ | Succ _ | Unroll_to _) as new_ri ->
       if ri == new_ri then orig else Rec_info_expr.unroll_to unroll_depth new_ri
-  end
+    )
 
 let simplify_rec_info_expr dacc rec_info_expr =
   let ans =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -430,7 +430,7 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_depth
             DE.add_variable denv
               (Bound_var.create my_closure NM.normal)
               (T.unknown K.value)
-          | Some function_slot -> begin
+          | Some function_slot -> (
             match
               Function_slot.Map.find function_slot
                 closure_bound_names_inside_function
@@ -446,8 +446,7 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_depth
               let name = Bound_name.name name in
               DE.add_variable denv
                 (Bound_var.create my_closure NM.normal)
-                (T.alias_type_of K.value (Simple.name name))
-          end
+                (T.alias_type_of K.value (Simple.name name)))
         in
         let denv =
           let my_depth = Bound_var.create my_depth Name_mode.normal in

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -276,11 +276,10 @@ let simplify_static_consts dacc (bound_static : Bound_static.t) static_consts
             | None ->
               (* Not rebuilding terms: return the original code *)
               code, Rebuilt_static_const.create_code' code, dacc
-            | Some static_const_or_code -> begin
+            | Some static_const_or_code -> (
               match Static_const_or_code.to_code static_const_or_code with
               | None -> assert false
-              | Some code -> code, static_const, dacc_after_function
-            end
+              | Some code -> code, static_const, dacc_after_function)
           else code, Rebuilt_static_const.create_code' code, dacc
         in
         let dacc =

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -670,24 +670,22 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     | Get_tag -> simplify_get_tag
     | Array_length -> simplify_array_length
     | String_length _ -> simplify_string_length
-    | Int_arith (kind, op) -> begin
+    | Int_arith (kind, op) -> (
       match kind with
       | Tagged_immediate -> Unary_int_arith_tagged_immediate.simplify op
       | Naked_immediate -> Unary_int_arith_naked_immediate.simplify op
       | Naked_int32 -> Unary_int_arith_naked_int32.simplify op
       | Naked_int64 -> Unary_int_arith_naked_int64.simplify op
-      | Naked_nativeint -> Unary_int_arith_naked_nativeint.simplify op
-    end
+      | Naked_nativeint -> Unary_int_arith_naked_nativeint.simplify op)
     | Float_arith op -> simplify_float_arith_op op
-    | Num_conv { src; dst } -> begin
+    | Num_conv { src; dst } -> (
       match src with
       | Tagged_immediate -> Simplify_int_conv_tagged_immediate.simplify ~dst
       | Naked_immediate -> Simplify_int_conv_naked_immediate.simplify ~dst
       | Naked_float -> Simplify_int_conv_naked_float.simplify ~dst
       | Naked_int32 -> Simplify_int_conv_naked_int32.simplify ~dst
       | Naked_int64 -> Simplify_int_conv_naked_int64.simplify ~dst
-      | Naked_nativeint -> Simplify_int_conv_naked_nativeint.simplify ~dst
-    end
+      | Naked_nativeint -> Simplify_int_conv_naked_nativeint.simplify ~dst)
     | Boolean_not -> simplify_boolean_not
     | Reinterpret_int64_as_float -> simplify_reinterpret_int64_as_float
     | Is_boxed_float -> simplify_is_boxed_float

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -105,7 +105,7 @@ let rec make_optimistic_decision ~depth tenv ~param_type : U.decision =
                 non_const_ctors_with_sizes
             in
             Unbox (Variant { tag; const_ctors; fields_by_tag })
-          | Proved _ | Wrong_kind | Invalid | Unknown -> begin
+          | Proved _ | Wrong_kind | Invalid | Unknown -> (
             match T.prove_single_closures_entry' tenv param_type with
             | Proved (function_slot, _, closures_entry, _fun_decl)
               when unbox_closures ->
@@ -115,8 +115,7 @@ let rec make_optimistic_decision ~depth tenv ~param_type : U.decision =
               Unbox
                 (Closure_single_entry { function_slot; vars_within_closure })
             | Proved _ | Wrong_kind | Invalid | Unknown ->
-              Do_not_unbox Incomplete_parameter_type
-          end))
+              Do_not_unbox Incomplete_parameter_type)))
 
 and make_optimistic_fields ~add_tag_to_name ~depth tenv param_type (tag : Tag.t)
     size =

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -127,15 +127,14 @@ let extra_args_for_const_ctor_of_variant
     (const_ctors_decision : U.const_ctors_decision) ~typing_env_at_use
     rewrite_id variant_arg : U.const_ctors_decision =
   match const_ctors_decision with
-  | Zero -> begin
+  | Zero -> (
     match variant_arg with
     | Not_a_constant_constructor -> const_ctors_decision
     | Maybe_constant_constructor _ ->
       Misc.fatal_errorf
         "The unboxed variant parameter was determined to have no constant \
          cases when deciding to unbox it (using the parameter type), but at \
-         the use site, it is a constant constructor."
-  end
+         the use site, it is a constant constructor.")
   | At_least_one { ctor = Do_not_unbox reason; is_int } ->
     let is_int =
       Extra_param_and_args.update_param_args is_int rewrite_id
@@ -230,7 +229,7 @@ and compute_extra_args_for_one_decision_and_use_aux ~(pass : U.pass) rewrite_id
       in
       match type_of_arg_being_unboxed arg_being_unboxed with
       | None -> invalid ()
-      | Some arg_type -> begin
+      | Some arg_type -> (
         match T.prove_variant_like typing_env_at_use arg_type with
         | Wrong_kind -> Misc.fatal_errorf "Kind error while unboxing a variant"
         | Unknown -> prevent_current_unboxing ()
@@ -240,8 +239,7 @@ and compute_extra_args_for_one_decision_and_use_aux ~(pass : U.pass) rewrite_id
             arg_being_unboxed ~tag_from_decision:tag ~const_ctors_from_decision
             ~fields_by_tag_from_decision:fields_by_tag
             ~const_ctors_at_use:const_ctors
-            ~non_const_ctors_with_sizes_at_use:non_const_ctors_with_sizes
-      end)
+            ~non_const_ctors_with_sizes_at_use:non_const_ctors_with_sizes))
   | Unbox (Number (Naked_float, epa)) ->
     compute_extra_arg_for_number Naked_float Unboxers.Float.unboxer epa
       rewrite_id ~typing_env_at_use arg_being_unboxed

--- a/middle_end/flambda2/simplify_shared/inlining_report.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_report.ml
@@ -657,14 +657,12 @@ module Inlining_tree = struct
             (Uid.print_link_hum ~compilation_unit)
             (Uid.create ~compilation_unit (IHA.path callee));
 
-          begin
-            match decision with
-            | Decision decision_with_context ->
-              Format.fprintf ppf "@[<v>%a@]" print_decision_with_context
-                decision_with_context
-            | Reference path -> print_reference ~compilation_unit ppf path
-            | Unavailable -> print_unavailable ppf ()
-          end;
+          (match decision with
+          | Decision decision_with_context ->
+            Format.fprintf ppf "@[<v>%a@]" print_decision_with_context
+              decision_with_context
+          | Reference path -> print_reference ~compilation_unit ppf path
+          | Unavailable -> print_unavailable ppf ());
 
           Format.fprintf ppf "@]@,@,";
           print ppf ~compilation_unit ~depth:(depth + 1)
@@ -716,11 +714,10 @@ let output_then_forget_decisions ~output_prefix =
           (Lazy.force tree);
         close_out out_channel);
       if Flambda_features.inlining_report_bin ()
-      then begin
+      then (
         let ch = open_out_bin (output_prefix ^ ".inlining") in
         let metadata = { compilation_unit } in
         let report : report = `Flambda2_1_0_0 (metadata, Lazy.force tree) in
         Marshal.to_channel ch report [];
-        close_out ch
-      end;
+        close_out ch);
       Lazy.force tree)

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -219,14 +219,13 @@ let layout env function_slots value_slots =
     match startenv_opt, acc_slots with
     | Some i, _ -> i, false
     | None, [] -> 0, true
-    | None, (j, Function_slot function_slot) :: _ -> begin
+    | None, (j, Function_slot function_slot) :: _ -> (
       match EO.function_slot_offset env function_slot with
       | Some (Live_function_slot { size; _ }) -> j + size, true
       | Some Dead_function_slot | None ->
         (* the function slot was found earlier during the call to
            order_function_slots *)
-        assert false
-    end
+        assert false)
     | None, (_, Infix_header) :: _ ->
       (* Cannot happen because a infix header is *always* preceded by a function
          slot (because the slot list is reversed) *)
@@ -390,19 +389,16 @@ module Greedy = struct
   (* Keep the value slots offsets in sets up-to-date *)
 
   let update_set_for_slot slot set =
-    begin
-      match slot.pos with
-      | Unassigned | Removed -> ()
-      | Assigned i -> begin
-        match slot.desc with
-        | Value_slot _ ->
-          set.first_slot_used_by_value_slots
-            <- min set.first_slot_used_by_value_slots i
-        | Function_slot _ ->
-          set.first_slot_after_function_slots
-            <- max set.first_slot_after_function_slots (i + slot.size)
-      end
-    end;
+    (match slot.pos with
+    | Unassigned | Removed -> ()
+    | Assigned i -> (
+      match slot.desc with
+      | Value_slot _ ->
+        set.first_slot_used_by_value_slots
+          <- min set.first_slot_used_by_value_slots i
+      | Function_slot _ ->
+        set.first_slot_after_function_slots
+          <- max set.first_slot_after_function_slots (i + slot.size)));
     if set.first_slot_used_by_value_slots < set.first_slot_after_function_slots
     then
       Misc.fatal_errorf
@@ -634,10 +630,9 @@ module Greedy = struct
       | ({ desc = Value_slot v; _ } as slot) :: r ->
         set.unallocated_value_slots <- r;
         if keep_value_slot ~used_value_slots v
-        then begin
+        then (
           has_work_been_done := true;
-          f_kept acc slot
-        end
+          f_kept acc slot)
         else aux (f_removed acc slot) set
       | { desc = Function_slot _; _ } :: _ -> assert false
       (* invariant *)

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -26,10 +26,9 @@ type t =
 let print_or_elide_debuginfo ppf dbg =
   if Debuginfo.is_none dbg
   then Format.pp_print_string ppf ""
-  else begin
+  else (
     Format.pp_print_string ppf " ";
-    Debuginfo.print_compact ppf dbg
-  end
+    Debuginfo.print_compact ppf dbg)
 
 include Container_types.Make (struct
   type nonrec t = t

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -116,20 +116,17 @@ let invariant
        probe_name = _;
        relative_history = _
      } as t) =
-  begin
-    match call_kind with
-    | Function _ | Method _ -> ()
-    | C_call { alloc = _; param_arity = _; return_arity = _; is_c_builtin = _ }
-      ->
-      if not (Simple.is_symbol callee)
-      then
-        (* CR-someday mshinwell: We could expose indirect C calls at the source
-           language level. *)
-        Misc.fatal_errorf
-          "For [C_call] applications the callee must be directly specified as \
-           a [Symbol]:@ %a"
-          print t
-  end;
+  (match call_kind with
+  | Function _ | Method _ -> ()
+  | C_call { alloc = _; param_arity = _; return_arity = _; is_c_builtin = _ } ->
+    if not (Simple.is_symbol callee)
+    then
+      (* CR-someday mshinwell: We could expose indirect C calls at the source
+         language level. *)
+      Misc.fatal_errorf
+        "For [C_call] applications the callee must be directly specified as a \
+         [Symbol]:@ %a"
+        print t);
   match continuation with
   | Never_returns ->
     let return_arity = Call_kind.return_arity call_kind in

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -134,13 +134,11 @@ let indirect_function_call_known_arity ~param_arity ~return_arity alloc_mode =
 let method_call kind ~obj alloc_mode = Method { kind; obj; alloc_mode }
 
 let c_call ~alloc ~param_arity ~return_arity ~is_c_builtin =
-  begin
-    match Flambda_arity.to_list return_arity with
-    | [] | [_] -> ()
-    | _ :: _ :: _ ->
-      Misc.fatal_errorf "Illegal return arity for C call: %a"
-        Flambda_arity.print return_arity
-  end;
+  (match Flambda_arity.to_list return_arity with
+  | [] | [_] -> ()
+  | _ :: _ :: _ ->
+    Misc.fatal_errorf "Illegal return arity for C call: %a" Flambda_arity.print
+      return_arity);
   C_call { alloc; param_arity; return_arity; is_c_builtin }
 
 let return_arity t =

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -92,17 +92,14 @@ let create code_id ~newer_version_of ~params_arity ~num_trailing_local_params
     ~(inline : Inline_attribute.t) ~is_a_functor ~recursive ~cost_metrics
     ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision
     ~absolute_history ~relative_history =
-  begin
-    match stub, inline with
-    | true, (Available_inline | Never_inline | Default_inline)
-    | ( false,
-        ( Never_inline | Default_inline | Always_inline | Available_inline
-        | Unroll _ ) ) ->
-      ()
-    | true, (Always_inline | Unroll _) ->
-      Misc.fatal_error
-        "Stubs may not be annotated as [Always_inline] or [Unroll]"
-  end;
+  (match stub, inline with
+  | true, (Available_inline | Never_inline | Default_inline)
+  | ( false,
+      ( Never_inline | Default_inline | Always_inline | Available_inline
+      | Unroll _ ) ) ->
+    ()
+  | true, (Always_inline | Unroll _) ->
+    Misc.fatal_error "Stubs may not be annotated as [Always_inline] or [Unroll]");
   if num_trailing_local_params < 0
      || num_trailing_local_params
         > Flambda_arity.With_subkinds.cardinal params_arity

--- a/middle_end/flambda2/terms/exn_continuation.ml
+++ b/middle_end/flambda2/terms/exn_continuation.ml
@@ -67,14 +67,11 @@ include Container_types.Make (struct
 end)
 
 let create ~exn_handler ~extra_args =
-  begin
-    match Continuation.sort exn_handler with
-    | Normal_or_exn -> ()
-    | _ ->
-      Misc.fatal_errorf
-        "Continuation %a has wrong sort (must be [Normal_or_exn])"
-        Continuation.print exn_handler
-  end;
+  (match Continuation.sort exn_handler with
+  | Normal_or_exn -> ()
+  | _ ->
+    Misc.fatal_errorf "Continuation %a has wrong sort (must be [Normal_or_exn])"
+      Continuation.print exn_handler);
   { exn_handler; extra_args }
 
 let exn_handler t = t.exn_handler
@@ -96,10 +93,9 @@ let apply_renaming ({ exn_handler; extra_args } as t) renaming =
         let simple' = Simple.apply_renaming simple renaming in
         if simple == simple'
         then extra_arg
-        else begin
+        else (
           extra_args_changed := true;
-          simple', kind
-        end)
+          simple', kind))
       extra_args
   in
   let extra_args' =

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -583,11 +583,9 @@ and print_continuation_handler (recursive : Recursive.t) ppf k
   let fprintf = Format.fprintf in
   if not first then fprintf ppf "@ ";
   let print params ~handler =
-    begin
-      match descr handler with
-      | Apply_cont _ | Invalid _ -> fprintf ppf "@[<hov 0>"
-      | Let _ | Let_cont _ | Apply _ | Switch _ -> fprintf ppf "@[<v 0>"
-    end;
+    (match descr handler with
+    | Apply_cont _ | Invalid _ -> fprintf ppf "@[<hov 0>"
+    | Let _ | Let_cont _ | Apply _ | Switch _ -> fprintf ppf "@[<v 0>");
     fprintf ppf "@[<hov 1>@<0>%s%a@<0>%s%s@<0>%s%s@<0>%s"
       (Flambda_colours.continuation_definition ())
       Continuation.print k
@@ -868,13 +866,12 @@ and print_flattened ppf
 and flatten_let_symbol t : _ * expr =
   let rec flatten (expr : expr) : _ * expr =
     match descr expr with
-    | Let t -> begin
+    | Let t -> (
       match flatten_for_printing t with
       | Some (flattened, body) ->
         let flattened', body = flatten body in
         flattened @ flattened', body
-      | None -> [], expr
-    end
+      | None -> [], expr)
     | Let_cont _ | Apply _ | Apply_cont _ | Switch _ | Invalid _ -> [], expr
   in
   match flatten_for_printing t with
@@ -1226,32 +1223,29 @@ module Let_expr = struct
 
   let create (bound_pattern : Bound_pattern.t) (defining_expr : named) ~body
       ~(free_names_of_body : _ Or_unknown.t) =
-    begin
-      match defining_expr, bound_pattern with
-      | Prim _, Singleton _
-      | Simple _, Singleton _
-      | Rec_info _, Singleton _
-      | Set_of_closures _, Set_of_closures _ ->
-        ()
-      | Set_of_closures _, Singleton _ ->
-        Misc.fatal_errorf
-          "Cannot bind a [Set_of_closures] to a [Singleton]:@ %a =@ %a"
-          Bound_pattern.print bound_pattern print_named defining_expr
-      | _, Set_of_closures _ ->
-        Misc.fatal_errorf
-          "Cannot bind a non-[Set_of_closures] to a [Set_of_closures]:@ %a =@ \
-           %a"
-          Bound_pattern.print bound_pattern print_named defining_expr
-      | Static_consts _, Static _ -> ()
-      | Static_consts _, Singleton _ ->
-        Misc.fatal_errorf
-          "Cannot bind a [Static_const] to a [Singleton]:@ %a =@ %a"
-          Bound_pattern.print bound_pattern print_named defining_expr
-      | (Simple _ | Prim _ | Set_of_closures _ | Rec_info _), Static _ ->
-        Misc.fatal_errorf
-          "Cannot bind a non-[Static_const] to [Symbols]:@ %a =@ %a"
-          Bound_pattern.print bound_pattern print_named defining_expr
-    end;
+    (match defining_expr, bound_pattern with
+    | Prim _, Singleton _
+    | Simple _, Singleton _
+    | Rec_info _, Singleton _
+    | Set_of_closures _, Set_of_closures _ ->
+      ()
+    | Set_of_closures _, Singleton _ ->
+      Misc.fatal_errorf
+        "Cannot bind a [Set_of_closures] to a [Singleton]:@ %a =@ %a"
+        Bound_pattern.print bound_pattern print_named defining_expr
+    | _, Set_of_closures _ ->
+      Misc.fatal_errorf
+        "Cannot bind a non-[Set_of_closures] to a [Set_of_closures]:@ %a =@ %a"
+        Bound_pattern.print bound_pattern print_named defining_expr
+    | Static_consts _, Static _ -> ()
+    | Static_consts _, Singleton _ ->
+      Misc.fatal_errorf
+        "Cannot bind a [Static_const] to a [Singleton]:@ %a =@ %a"
+        Bound_pattern.print bound_pattern print_named defining_expr
+    | (Simple _ | Prim _ | Set_of_closures _ | Rec_info _), Static _ ->
+      Misc.fatal_errorf
+        "Cannot bind a non-[Static_const] to [Symbols]:@ %a =@ %a"
+        Bound_pattern.print bound_pattern print_named defining_expr);
     let num_normal_occurrences_of_bound_vars =
       match free_names_of_body with
       | Unknown -> Variable.Map.empty

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -370,20 +370,18 @@ type ordered_comparison =
 let print_ordered_comparison ppf signedness c =
   let fprintf = Format.fprintf in
   match signedness with
-  | Unsigned -> begin
+  | Unsigned -> (
     match c with
     | Lt -> fprintf ppf "<u"
     | Le -> fprintf ppf "<=u"
     | Gt -> fprintf ppf ">u"
-    | Ge -> fprintf ppf ">=u"
-  end
-  | Signed -> begin
+    | Ge -> fprintf ppf ">=u")
+  | Signed -> (
     match c with
     | Lt -> fprintf ppf "<"
     | Le -> fprintf ppf "<="
     | Gt -> fprintf ppf ">"
-    | Ge -> fprintf ppf ">="
-  end
+    | Ge -> fprintf ppf ">=")
 
 let print_ordered_comparison_and_behaviour ppf signedness behaviour =
   match behaviour with
@@ -913,7 +911,7 @@ let effects_and_coeffects_of_unary_primitive p =
   match p with
   | Duplicate_array { kind = _; source_mutability; destination_mutability; _ }
   | Duplicate_block { kind = _; source_mutability; destination_mutability; _ }
-    -> begin
+    -> (
     match source_mutability with
     | Immutable ->
       (* [Obj.truncate] has now been removed. *)
@@ -928,8 +926,7 @@ let effects_and_coeffects_of_unary_primitive p =
         Coeffects.No_coeffects )
     | Mutable ->
       ( Effects.Only_generative_effects destination_mutability,
-        Coeffects.Has_coeffects )
-  end
+        Coeffects.Has_coeffects ))
   | Is_int -> Effects.No_effects, Coeffects.No_coeffects
   | Get_tag ->
     (* [Obj.truncate] has now been removed. *)
@@ -1750,12 +1747,11 @@ module Eligible_for_cse = struct
   let filter_map_args t ~f =
     match t with
     | Nullary _ -> Some t
-    | Unary (prim, arg) -> begin
+    | Unary (prim, arg) -> (
       match f arg with
       | None -> None
-      | Some arg' -> if arg == arg' then Some t else Some (Unary (prim, arg'))
-    end
-    | Binary (prim, arg1, arg2) -> begin
+      | Some arg' -> if arg == arg' then Some t else Some (Unary (prim, arg')))
+    | Binary (prim, arg1, arg2) -> (
       match f arg1 with
       | None -> None
       | Some arg1' -> (
@@ -1764,9 +1760,8 @@ module Eligible_for_cse = struct
         | Some arg2' ->
           if arg1 == arg1' && arg2 == arg2'
           then Some t
-          else Some (Binary (prim, arg1', arg2')))
-    end
-    | Ternary (prim, arg1, arg2, arg3) -> begin
+          else Some (Binary (prim, arg1', arg2'))))
+    | Ternary (prim, arg1, arg2, arg3) -> (
       match f arg1 with
       | None -> None
       | Some arg1' -> (
@@ -1778,8 +1773,7 @@ module Eligible_for_cse = struct
           | Some arg3' ->
             if arg1 == arg1' && arg2 == arg2' && arg3 == arg3'
             then Some t
-            else Some (Ternary (prim, arg1', arg2', arg3'))))
-    end
+            else Some (Ternary (prim, arg1', arg2', arg3')))))
     | Variadic (prim, args) ->
       let args' = List.filter_map f args in
       if List.compare_lengths args args' = 0

--- a/middle_end/flambda2/terms/removed_operations.ml
+++ b/middle_end/flambda2/terms/removed_operations.ml
@@ -47,20 +47,18 @@ let alloc = { zero with alloc = 1 }
 
 let prim (prim : Flambda_primitive.t) =
   match prim with
-  | Unary (prim, _) -> begin
+  | Unary (prim, _) -> (
     match prim with
     | Duplicate_block _ | Duplicate_array _ | Box_number _ | Unbox_number _ ->
       alloc
     | _ ->
       (* Some allocating primitives ([Num_conv] to naked_int64 on arch32 for
          example) are not counted here. *)
-      { zero with prim = 1 }
-  end
+      { zero with prim = 1 })
   | Nullary _ -> zero
   | Binary (_, _, _) | Ternary (_, _, _, _) -> { zero with prim = 1 }
-  | Variadic (prim, _) -> begin
-    match prim with Make_block _ | Make_array _ -> alloc
-  end
+  | Variadic (prim, _) -> (
+    match prim with Make_block _ | Make_array _ -> alloc)
 
 let branch = { zero with branch = 1 }
 

--- a/middle_end/flambda2/terms/set_of_closures.ml
+++ b/middle_end/flambda2/terms/set_of_closures.ml
@@ -129,10 +129,9 @@ let apply_renaming ({ function_decls; value_slots; alloc_mode } as t) renaming =
           let simple' = Simple.apply_renaming simple renaming in
           if not (simple == simple') then changed := true;
           Some simple')
-        else begin
+        else (
           changed := true;
-          None
-        end)
+          None))
       value_slots
   in
   if function_decls == function_decls' && not !changed

--- a/middle_end/flambda2/tests/mlexamples/array.ml
+++ b/middle_end/flambda2/tests/mlexamples/array.ml
@@ -445,11 +445,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -566,7 +564,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -576,8 +574,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -710,10 +707,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()
@@ -961,11 +957,10 @@ let sort cmp a =
     let i31 = i + i + i + 1 in
     let x = ref i31 in
     if i31 + 2 < l
-    then begin
+    then (
       if cmp (get a i31) (get a (i31 + 1)) < 0 then x := i31 + 1;
       if cmp (get a !x) (get a (i31 + 2)) < 0 then x := i31 + 2;
-      !x
-    end
+      !x)
     else if i31 + 1 < l && cmp (get a i31) (get a (i31 + 1)) < 0
     then i31 + 1
     else if i31 < l
@@ -975,10 +970,9 @@ let sort cmp a =
   let rec trickledown l i e =
     let j = maxson l i in
     if cmp (get a j) e > 0
-    then begin
+    then (
       set a i (get a j);
-      trickledown l j e
-    end
+      trickledown l j e)
     else set a i e
   in
   let trickle l i e = try trickledown l i e with Bottom i -> set a i e in
@@ -992,10 +986,9 @@ let sort cmp a =
     let father = (i - 1) / 3 in
     assert (i <> father);
     if cmp (get a father) e < 0
-    then begin
+    then (
       set a i (get a father);
-      if father > 0 then trickleup father e else set a 0 e
-    end
+      if father > 0 then trickleup father e else set a 0 e)
     else set a i e
   in
   let l = length a in
@@ -1020,20 +1013,18 @@ let stable_sort cmp a =
     let src1r = src1ofs + src1len and src2r = src2ofs + src2len in
     let rec loop i1 s1 i2 s2 d =
       if cmp s1 s2 <= 0
-      then begin
+      then (
         set dst d s1;
         let i1 = i1 + 1 in
         if i1 < src1r
         then loop i1 (get a i1) i2 s2 (d + 1)
-        else blit src2 i2 dst (d + 1) (src2r - i2)
-      end
-      else begin
+        else blit src2 i2 dst (d + 1) (src2r - i2))
+      else (
         set dst d s2;
         let i2 = i2 + 1 in
         if i2 < src2r
         then loop i1 s1 i2 (get src2 i2) (d + 1)
-        else blit a i1 dst (d + 1) (src1r - i1)
-      end
+        else blit a i1 dst (d + 1) (src1r - i1))
     in
     loop src1ofs (get a src1ofs) src2ofs (get src2 src2ofs) dstofs
   in

--- a/middle_end/flambda2/tests/mlexamples/buffer.ml
+++ b/middle_end/flambda2/tests/mlexamples/buffer.ml
@@ -463,11 +463,9 @@ let flush_all () =
   let rec iter = function
     | [] -> ()
     | a :: l ->
-      begin
-        try flush a
-        with Sys_error _ ->
-          () (* ignore channels closed during a preceding flush. *)
-      end;
+      (try flush a
+       with Sys_error _ ->
+         () (* ignore channels closed during a preceding flush. *));
       iter l
   in
   iter (out_channels_list ())
@@ -584,7 +582,7 @@ let input_line chan =
       | [] -> raise End_of_file
       | _ -> build_result (bytes_create len) len accu
     else if n > 0
-    then begin
+    then (
       (* n > 0: newline found in buffer *)
       let res = bytes_create (n - 1) in
       ignore (unsafe_input chan res 0 (n - 1));
@@ -594,8 +592,7 @@ let input_line chan =
       | [] -> res
       | _ ->
         let len = len + n - 1 in
-        build_result (bytes_create len) len (res :: accu)
-    end
+        build_result (bytes_create len) len (res :: accu))
     else
       (* n < 0: newline not found *)
       let beg = bytes_create (-n) in
@@ -727,10 +724,9 @@ let at_exit f =
   exit_function
     := fun () ->
          if not !f_already_ran
-         then begin
+         then (
            f_already_ran := true;
-           f ()
-         end;
+           f ());
          g ()
 
 let do_at_exit () = !exit_function ()
@@ -1044,7 +1040,7 @@ let add_substitute b f s =
   let lim = String.length s in
   let rec subst previous i =
     if i < lim
-    then begin
+    then (
       match s.[i] with
       | '$' as current when previous = '\\' ->
         add_char b current;
@@ -1061,8 +1057,7 @@ let add_substitute b f s =
       | '\\' as current -> subst current (i + 1)
       | current ->
         add_char b current;
-        subst current (i + 1)
-    end
+        subst current (i + 1))
     else if previous = '\\'
     then add_char b previous
   in

--- a/middle_end/flambda2/tests/mlexamples/bytes.ml
+++ b/middle_end/flambda2/tests/mlexamples/bytes.ml
@@ -398,39 +398,37 @@ let escaped s =
     let s' = create !n in
     n := 0;
     for i = 0 to length s - 1 do
-      begin
-        match unsafe_get s i with
-        | ('\"' | '\\') as c ->
-          unsafe_set s' !n '\\';
-          incr n;
-          unsafe_set s' !n c
-        | '\n' ->
-          unsafe_set s' !n '\\';
-          incr n;
-          unsafe_set s' !n 'n'
-        | '\t' ->
-          unsafe_set s' !n '\\';
-          incr n;
-          unsafe_set s' !n 't'
-        | '\r' ->
-          unsafe_set s' !n '\\';
-          incr n;
-          unsafe_set s' !n 'r'
-        | '\b' ->
-          unsafe_set s' !n '\\';
-          incr n;
-          unsafe_set s' !n 'b'
-        | ' ' .. '~' as c -> unsafe_set s' !n c
-        | c ->
-          let a = char_code c in
-          unsafe_set s' !n '\\';
-          incr n;
-          unsafe_set s' !n (char_chr (48 + (a / 100)));
-          incr n;
-          unsafe_set s' !n (char_chr (48 + (a / 10 mod 10)));
-          incr n;
-          unsafe_set s' !n (char_chr (48 + (a mod 10)))
-      end;
+      (match unsafe_get s i with
+      | ('\"' | '\\') as c ->
+        unsafe_set s' !n '\\';
+        incr n;
+        unsafe_set s' !n c
+      | '\n' ->
+        unsafe_set s' !n '\\';
+        incr n;
+        unsafe_set s' !n 'n'
+      | '\t' ->
+        unsafe_set s' !n '\\';
+        incr n;
+        unsafe_set s' !n 't'
+      | '\r' ->
+        unsafe_set s' !n '\\';
+        incr n;
+        unsafe_set s' !n 'r'
+      | '\b' ->
+        unsafe_set s' !n '\\';
+        incr n;
+        unsafe_set s' !n 'b'
+      | ' ' .. '~' as c -> unsafe_set s' !n c
+      | c ->
+        let a = char_code c in
+        unsafe_set s' !n '\\';
+        incr n;
+        unsafe_set s' !n (char_chr (48 + (a / 100)));
+        incr n;
+        unsafe_set s' !n (char_chr (48 + (a / 10 mod 10)));
+        incr n;
+        unsafe_set s' !n (char_chr (48 + (a mod 10))));
       incr n
     done;
     s'

--- a/middle_end/flambda2/tests/mlexamples/camlinternalFormat.ml
+++ b/middle_end/flambda2/tests/mlexamples/camlinternalFormat.ml
@@ -448,11 +448,9 @@ let flush_all () =
   let rec iter = function
     | [] -> ()
     | a :: l ->
-      begin
-        try flush a
-        with Sys_error _ ->
-          () (* ignore channels closed during a preceding flush. *)
-      end;
+      (try flush a
+       with Sys_error _ ->
+         () (* ignore channels closed during a preceding flush. *));
       iter l
   in
   iter (out_channels_list ())
@@ -569,7 +567,7 @@ let input_line chan =
       | [] -> raise End_of_file
       | _ -> build_result (bytes_create len) len accu
     else if n > 0
-    then begin
+    then (
       (* n > 0: newline found in buffer *)
       let res = bytes_create (n - 1) in
       ignore (unsafe_input chan res 0 (n - 1));
@@ -579,8 +577,7 @@ let input_line chan =
       | [] -> res
       | _ ->
         let len = len + n - 1 in
-        build_result (bytes_create len) len (res :: accu)
-    end
+        build_result (bytes_create len) len (res :: accu))
     else
       (* n < 0: newline not found *)
       let beg = bytes_create (-n) in
@@ -712,10 +709,9 @@ let at_exit f =
   exit_function
     := fun () ->
          if not !f_already_ran
-         then begin
+         then (
            f_already_ran := true;
-           f ()
-         end;
+           f ());
          g ()
 
 let do_at_exit () = !exit_function ()
@@ -2194,20 +2190,16 @@ let fix_padding padty width str =
   then str
   else
     let res = Bytes.make width (if padty = Zeros then '0' else ' ') in
-    begin
-      match padty with
-      | Left -> String.blit str 0 res 0 len
-      | Right -> String.blit str 0 res (width - len) len
-      | Zeros when len > 0 && (str.[0] = '+' || str.[0] = '-' || str.[0] = ' ')
-        ->
-        Bytes.set res 0 str.[0];
-        String.blit str 1 res (width - len + 1) (len - 1)
-      | Zeros when len > 1 && str.[0] = '0' && (str.[1] = 'x' || str.[1] = 'X')
-        ->
-        Bytes.set res 1 str.[1];
-        String.blit str 2 res (width - len + 2) (len - 2)
-      | Zeros -> String.blit str 0 res (width - len) len
-    end;
+    (match padty with
+    | Left -> String.blit str 0 res 0 len
+    | Right -> String.blit str 0 res (width - len) len
+    | Zeros when len > 0 && (str.[0] = '+' || str.[0] = '-' || str.[0] = ' ') ->
+      Bytes.set res 0 str.[0];
+      String.blit str 1 res (width - len + 1) (len - 1)
+    | Zeros when len > 1 && str.[0] = '0' && (str.[1] = 'x' || str.[1] = 'X') ->
+      Bytes.set res 1 str.[1];
+      String.blit str 2 res (width - len + 2) (len - 2)
+    | Zeros -> String.blit str 0 res (width - len) len);
     Bytes.unsafe_to_string res
 
 (* Add '0' padding to int, int32, nativeint or int64 string representation. *)
@@ -3147,7 +3139,7 @@ let fmt_ebb_of_string ?legacy_behavior str =
     | '*' ->
       parse_after_padding pct_ind (str_ind + 1) end_ind minus plus hash space
         ign (Arg_padding padty)
-    | _ -> begin
+    | _ -> (
       match padty with
       | Left ->
         if not legacy_behavior
@@ -3162,8 +3154,7 @@ let fmt_ebb_of_string ?legacy_behavior str =
           (Lit_padding (Right, 0))
       | Right ->
         parse_after_padding pct_ind str_ind end_ind minus plus hash space ign
-          No_padding
-    end
+          No_padding)
   (* Is precision defined? *)
   and parse_after_padding :
       type x e f.
@@ -3598,7 +3589,7 @@ let fmt_ebb_of_string ?legacy_behavior str =
        Such checks need to be disabled in legacy mode, as the legacy parser
        silently ignored incompatible flags. *)
     if not legacy_behavior
-    then begin
+    then (
       if (not !plus_used) && plus
       then incompatible_flag pct_ind str_ind symb "'+'";
       if (not !hash_used) && hash
@@ -3612,8 +3603,7 @@ let fmt_ebb_of_string ?legacy_behavior str =
         incompatible_flag pct_ind str_ind
           (if ign then '_' else symb)
           "`precision'";
-      if ign && plus then incompatible_flag pct_ind str_ind '_' "'+'"
-    end;
+      if ign && plus then incompatible_flag pct_ind str_ind '_' "'+'");
     (* this last test must not be disabled in legacy mode, as ignoring it would
        typically result in a different typing than what the legacy parser
        used *)

--- a/middle_end/flambda2/tests/mlexamples/camlinternalFormat2.ml
+++ b/middle_end/flambda2/tests/mlexamples/camlinternalFormat2.ml
@@ -447,11 +447,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -568,7 +566,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -578,8 +576,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -712,10 +709,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()
@@ -2198,20 +2194,16 @@ let fix_padding padty width str =
   then str
   else
     let res = Bytes.make width (if padty = Zeros then '0' else ' ') in
-    begin
-      match padty with
-      | Left -> String.blit str 0 res 0 len
-      | Right -> String.blit str 0 res (width - len) len
-      | Zeros when len > 0 && (str.[0] = '+' || str.[0] = '-' || str.[0] = ' ')
-        ->
-        Bytes.set res 0 str.[0];
-        String.blit str 1 res (width - len + 1) (len - 1)
-      | Zeros when len > 1 && str.[0] = '0' && (str.[1] = 'x' || str.[1] = 'X')
-        ->
-        Bytes.set res 1 str.[1];
-        String.blit str 2 res (width - len + 2) (len - 2)
-      | Zeros -> String.blit str 0 res (width - len) len
-    end;
+    (match padty with
+    | Left -> String.blit str 0 res 0 len
+    | Right -> String.blit str 0 res (width - len) len
+    | Zeros when len > 0 && (str.[0] = '+' || str.[0] = '-' || str.[0] = ' ') ->
+      Bytes.set res 0 str.[0];
+      String.blit str 1 res (width - len + 1) (len - 1)
+    | Zeros when len > 1 && str.[0] = '0' && (str.[1] = 'x' || str.[1] = 'X') ->
+      Bytes.set res 1 str.[1];
+      String.blit str 2 res (width - len + 2) (len - 2)
+    | Zeros -> String.blit str 0 res (width - len) len);
     Bytes.unsafe_to_string res
 
 (* Add '0' padding to int, int32, nativeint or int64 string representation. *)

--- a/middle_end/flambda2/tests/mlexamples/camlinternalLazy.ml
+++ b/middle_end/flambda2/tests/mlexamples/camlinternalLazy.ml
@@ -445,11 +445,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -566,7 +564,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -576,8 +574,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -710,10 +707,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/digest.ml
+++ b/middle_end/flambda2/tests/mlexamples/digest.ml
@@ -445,11 +445,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -566,7 +564,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -576,8 +574,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -710,10 +707,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/exn_extra_args.ml
+++ b/middle_end/flambda2/tests/mlexamples/exn_extra_args.ml
@@ -12,13 +12,11 @@ let[@inline never] input_line () = "bar"
 
 let ld_conf_contents () =
   let path = ref [] in
-  begin
-    try
-      try
-        while true do
-          path := input_line () :: !path
-        done
-      with End_of_file -> ()
-    with Sys_error _ -> ()
-  end;
+  (try
+     try
+       while true do
+         path := input_line () :: !path
+       done
+     with End_of_file -> ()
+   with Sys_error _ -> ());
   !path

--- a/middle_end/flambda2/tests/mlexamples/float.ml
+++ b/middle_end/flambda2/tests/mlexamples/float.ml
@@ -784,11 +784,10 @@ module Array = struct
       let i31 = i + i + i + 1 in
       let x = ref i31 in
       if i31 + 2 < l
-      then begin
+      then (
         if cmp (get a i31) (get a (i31 + 1)) < 0 then x := i31 + 1;
         if cmp (get a !x) (get a (i31 + 2)) < 0 then x := i31 + 2;
-        !x
-      end
+        !x)
       else if i31 + 1 < l && cmp (get a i31) (get a (i31 + 1)) < 0
       then i31 + 1
       else if i31 < l
@@ -798,10 +797,9 @@ module Array = struct
     let rec trickledown l i e =
       let j = maxson l i in
       if cmp (get a j) e > 0
-      then begin
+      then (
         set a i (get a j);
-        trickledown l j e
-      end
+        trickledown l j e)
       else set a i e
     in
     let trickle l i e = try trickledown l i e with Bottom i -> set a i e in
@@ -815,10 +813,9 @@ module Array = struct
       let father = (i - 1) / 3 in
       assert (i <> father);
       if cmp (get a father) e < 0
-      then begin
+      then (
         set a i (get a father);
-        if father > 0 then trickleup father e else set a 0 e
-      end
+        if father > 0 then trickleup father e else set a 0 e)
       else set a i e
     in
     let l = length a in
@@ -844,20 +841,18 @@ module Array = struct
       let src1r = src1ofs + src1len and src2r = src2ofs + src2len in
       let rec loop i1 s1 i2 s2 d =
         if cmp s1 s2 <= 0
-        then begin
+        then (
           set dst d s1;
           let i1 = i1 + 1 in
           if i1 < src1r
           then loop i1 (get a i1) i2 s2 (d + 1)
-          else blit src2 i2 dst (d + 1) (src2r - i2)
-        end
-        else begin
+          else blit src2 i2 dst (d + 1) (src2r - i2))
+        else (
           set dst d s2;
           let i2 = i2 + 1 in
           if i2 < src2r
           then loop i1 s1 i2 (get src2 i2) (d + 1)
-          else blit a i1 dst (d + 1) (src1r - i1)
-        end
+          else blit a i1 dst (d + 1) (src1r - i1))
       in
       loop src1ofs (get a src1ofs) src2ofs (get src2 src2ofs) dstofs
     in

--- a/middle_end/flambda2/tests/mlexamples/int64.ml
+++ b/middle_end/flambda2/tests/mlexamples/int64.ml
@@ -445,11 +445,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -566,7 +564,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -576,8 +574,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -710,10 +707,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/lazy.ml
+++ b/middle_end/flambda2/tests/mlexamples/lazy.ml
@@ -430,11 +430,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -551,7 +549,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -561,8 +559,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -695,10 +692,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/m2.ml
+++ b/middle_end/flambda2/tests/mlexamples/m2.ml
@@ -429,11 +429,9 @@ let flush_all () =
   let rec iter = function
     | [] -> ()
     | a :: l ->
-      begin
-        try flush a
-        with Sys_error _ ->
-          () (* ignore channels closed during a preceding flush. *)
-      end;
+      (try flush a
+       with Sys_error _ ->
+         () (* ignore channels closed during a preceding flush. *));
       iter l
   in
   iter (out_channels_list ())
@@ -550,7 +548,7 @@ let input_line chan =
       | [] -> raise End_of_file
       | _ -> build_result (bytes_create len) len accu
     else if n > 0
-    then begin
+    then (
       (* n > 0: newline found in buffer *)
       let res = bytes_create (n - 1) in
       ignore (unsafe_input chan res 0 (n - 1));
@@ -560,8 +558,7 @@ let input_line chan =
       | [] -> res
       | _ ->
         let len = len + n - 1 in
-        build_result (bytes_create len) len (res :: accu)
-    end
+        build_result (bytes_create len) len (res :: accu))
     else
       (* n < 0: newline not found *)
       let beg = bytes_create (-n) in
@@ -674,10 +671,9 @@ let at_exit f =
   exit_function
     := fun () ->
          if not !f_already_ran
-         then begin
+         then (
            f_already_ran := true;
-           f ()
-         end;
+           f ());
          g ()
 
 let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/map.ml
+++ b/middle_end/flambda2/tests/mlexamples/map.ml
@@ -657,12 +657,11 @@ module Make (Ord : OrderedType) = struct
     let rec aux low m c =
       match m with
       | Empty -> c
-      | Node { l; v; d; r; _ } -> begin
+      | Node { l; v; d; r; _ } -> (
         match Ord.compare v low with
         | 0 -> More (v, d, r, c)
         | n when n < 0 -> aux low r c
-        | _ -> aux low l (More (v, d, r, c))
-      end
+        | _ -> aux low l (More (v, d, r, c)))
     in
     seq_of_enum_ (aux low m End)
 end

--- a/middle_end/flambda2/tests/mlexamples/marshal.ml
+++ b/middle_end/flambda2/tests/mlexamples/marshal.ml
@@ -445,11 +445,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -566,7 +564,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -576,8 +574,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -710,10 +707,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/mutable_vars1.ml
+++ b/middle_end/flambda2/tests/mlexamples/mutable_vars1.ml
@@ -19,10 +19,6 @@ external incr : int ref -> unit = "%incr"
 let escape_string s s' =
   let n = ref 0 in
   for i = 0 to length s do
-    begin
-      match unsafe_get s i with
-      | '\x00' -> incr n
-      | c -> unsafe_set s' !n c
-    end;
+    (match unsafe_get s i with '\x00' -> incr n | c -> unsafe_set s' !n c);
     incr n
   done

--- a/middle_end/flambda2/tests/mlexamples/nativeint.ml
+++ b/middle_end/flambda2/tests/mlexamples/nativeint.ml
@@ -445,11 +445,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -566,7 +564,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -576,8 +574,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -710,10 +707,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/obj.ml
+++ b/middle_end/flambda2/tests/mlexamples/obj.ml
@@ -445,11 +445,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -566,7 +564,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -576,8 +574,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -710,10 +707,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/printexc.ml
+++ b/middle_end/flambda2/tests/mlexamples/printexc.ml
@@ -446,11 +446,9 @@ let flush_all () =
   let rec iter = function
     | [] -> ()
     | a :: l ->
-      begin
-        try flush a
-        with Sys_error _ ->
-          () (* ignore channels closed during a preceding flush. *)
-      end;
+      (try flush a
+       with Sys_error _ ->
+         () (* ignore channels closed during a preceding flush. *));
       iter l
   in
   iter (out_channels_list ())
@@ -567,7 +565,7 @@ let input_line chan =
       | [] -> raise End_of_file
       | _ -> build_result (bytes_create len) len accu
     else if n > 0
-    then begin
+    then (
       (* n > 0: newline found in buffer *)
       let res = bytes_create (n - 1) in
       ignore (unsafe_input chan res 0 (n - 1));
@@ -577,8 +575,7 @@ let input_line chan =
       | [] -> res
       | _ ->
         let len = len + n - 1 in
-        build_result (bytes_create len) len (res :: accu)
-    end
+        build_result (bytes_create len) len (res :: accu))
     else
       (* n < 0: newline not found *)
       let beg = bytes_create (-n) in
@@ -710,10 +707,9 @@ let at_exit f =
   exit_function
     := fun () ->
          if not !f_already_ran
-         then begin
+         then (
            f_already_ran := true;
-           f ()
-         end;
+           f ());
          g ()
 
 let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/random.ml
+++ b/middle_end/flambda2/tests/mlexamples/random.ml
@@ -445,11 +445,9 @@ module Stdlib = struct
     let rec iter = function
       | [] -> ()
       | a :: l ->
-        begin
-          try flush a
-          with Sys_error _ ->
-            () (* ignore channels closed during a preceding flush. *)
-        end;
+        (try flush a
+         with Sys_error _ ->
+           () (* ignore channels closed during a preceding flush. *));
         iter l
     in
     iter (out_channels_list ())
@@ -566,7 +564,7 @@ module Stdlib = struct
         | [] -> raise End_of_file
         | _ -> build_result (bytes_create len) len accu
       else if n > 0
-      then begin
+      then (
         (* n > 0: newline found in buffer *)
         let res = bytes_create (n - 1) in
         ignore (unsafe_input chan res 0 (n - 1));
@@ -576,8 +574,7 @@ module Stdlib = struct
         | [] -> res
         | _ ->
           let len = len + n - 1 in
-          build_result (bytes_create len) len (res :: accu)
-      end
+          build_result (bytes_create len) len (res :: accu))
       else
         (* n < 0: newline not found *)
         let beg = bytes_create (-n) in
@@ -710,10 +707,9 @@ module Stdlib = struct
     exit_function
       := fun () ->
            if not !f_already_ran
-           then begin
+           then (
              f_already_ran := true;
-             f ()
-           end;
+             f ());
            g ()
 
   let do_at_exit () = !exit_function ()

--- a/middle_end/flambda2/tests/mlexamples/set.ml
+++ b/middle_end/flambda2/tests/mlexamples/set.ml
@@ -784,12 +784,11 @@ module Make (Ord : OrderedType) = struct
     let rec aux low s c =
       match s with
       | Empty -> c
-      | Node { l; r; v; _ } -> begin
+      | Node { l; r; v; _ } -> (
         match Ord.compare v low with
         | 0 -> More (v, r, c)
         | n when n < 0 -> aux low r c
-        | _ -> aux low l (More (v, r, c))
-      end
+        | _ -> aux low l (More (v, r, c)))
     in
     seq_of_enum_ (aux low s End)
 end

--- a/middle_end/flambda2/tests/mlexamples/string.ml
+++ b/middle_end/flambda2/tests/mlexamples/string.ml
@@ -428,10 +428,9 @@ let split_on_char sep s =
   let j = ref (length s) in
   for i = length s - 1 downto 0 do
     if unsafe_get s i = sep
-    then begin
+    then (
       r := sub s (i + 1) (!j - i - 1) :: !r;
-      j := i
-    end
+      j := i)
   done;
   sub s 0 !j :: !r
 

--- a/middle_end/flambda2/tests/mlexamples/test_exn_handler_inlining.ml
+++ b/middle_end/flambda2/tests/mlexamples/test_exn_handler_inlining.ml
@@ -16,11 +16,9 @@ let g y =
 
 let f x =
   let c = ref x in
-  begin
-    try
-      while true do
-        c := g !c
-      done
-    with _ -> ()
-  end;
+  (try
+     while true do
+       c := g !c
+     done
+   with _ -> ());
   !c

--- a/middle_end/flambda2/tests/mlexamples/variants.ml
+++ b/middle_end/flambda2/tests/mlexamples/variants.ml
@@ -8,7 +8,7 @@ type t =
 
 let f t =
   match t with
-  | A0 -> begin match t with A0 -> 42 | A1 -> 43 | B _ -> 44 | C _ -> 45 end
+  | A0 -> ( match t with A0 -> 42 | A1 -> 43 | B _ -> 44 | C _ -> 45)
   | A1 -> 0
   | B x -> x
   | C (a, b) -> a + b

--- a/middle_end/flambda2/tests/tools/fldiff.ml
+++ b/middle_end/flambda2/tests/tools/fldiff.ml
@@ -6,14 +6,12 @@ let parse_flambda file =
   with
   | Ok unit -> unit
   | Error e ->
-    begin
-      match e with
-      | Parsing_error (msg, loc) ->
-        Format.eprintf "%a:@.Syntax error: %s@." Location.print_loc loc msg
-      | Lexing_error (error, loc) ->
-        Format.eprintf "%a:@.Lex error: %a@." Location.print_loc loc
-          Flambda_lex.pp_error error
-    end;
+    (match e with
+    | Parsing_error (msg, loc) ->
+      Format.eprintf "%a:@.Syntax error: %s@." Location.print_loc loc msg
+    | Lexing_error (error, loc) ->
+      Format.eprintf "%a:@.Lex error: %a@." Location.print_loc loc
+        Flambda_lex.pp_error error);
     exit 1
 
 let _ =

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -85,7 +85,7 @@ let save_corrected ~desc ~print ~orig_filename corrected =
 
 let run_flt_file filename : Outcome.t =
   match Parse_flambda.parse_expect_test_spec filename with
-  | Ok test_spec -> begin
+  | Ok test_spec -> (
     match
       run_expect_test ~symbol_for_global ~get_global_info ~extension:".flt"
         ~filename test_spec
@@ -97,8 +97,7 @@ let run_flt_file filename : Outcome.t =
       Format.eprintf "FAIL@.";
       save_corrected corrected ~desc:"test" ~print:Print_fexpr.expect_test_spec
         ~orig_filename:filename;
-      Failure
-  end
+      Failure)
   | Error e ->
     dump_error e;
     Error
@@ -128,11 +127,10 @@ let run_mdflx_file filename : Outcome.t =
     in
     if !all_passed
     then Outcome.Success
-    else begin
+    else (
       save_corrected corrected_doc ~desc:"document"
         ~print:Print_fexpr.markdown_doc ~orig_filename:filename;
-      Failure
-    end
+      Failure)
   | Error e ->
     dump_error e;
     Error

--- a/middle_end/flambda2/tests/tools/parseflambda.ml
+++ b/middle_end/flambda2/tests/tools/parseflambda.ml
@@ -31,14 +31,12 @@ let parse_flambda filename =
     Format.printf "back to fexpr:@.%a@." Print_fexpr.flambda_unit fl3;
     fl3
   | Error e ->
-    begin
-      match e with
-      | Parsing_error (msg, loc) ->
-        Format.eprintf "%a:@.Syntax error: %s@." Location.print_loc loc msg
-      | Lexing_error (error, loc) ->
-        Format.eprintf "%a:@.Lex error: %a@." Location.print_loc loc
-          Flambda_lex.pp_error error
-    end;
+    (match e with
+    | Parsing_error (msg, loc) ->
+      Format.eprintf "%a:@.Syntax error: %s@." Location.print_loc loc msg
+    | Lexing_error (error, loc) ->
+      Format.eprintf "%a:@.Lex error: %a@." Location.print_loc loc
+        Flambda_lex.pp_error error);
     exit 1
 
 let _ =

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -41,7 +41,7 @@ let classify_let_binding var
     ~(num_normal_occurrences_of_bound_vars : Num_occurrences.t Variable.Map.t) =
   match Variable.Map.find var num_normal_occurrences_of_bound_vars with
   | exception Not_found -> Regular
-  | Zero -> begin
+  | Zero -> (
     match
       classify_by_effects_and_coeffects effects_and_coeffects_of_defining_expr
     with
@@ -49,8 +49,7 @@ let classify_let_binding var
     | Effect ->
       Regular
       (* Could be May_inline technically, but it doesn't matter since it can
-         only be flushed by the env. *)
-  end
+         only be flushed by the env. *))
   | One ->
     (* Any defining expression used exactly once is considered for inlining at
        this stage. The environment is going to handle the details of preserving

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -688,14 +688,13 @@ and switch env res s =
      small switches with 3-5 arms). *)
   let scrutinee, tag_discriminant =
     match Targetint_31_63.Map.cardinal arms with
-    | 2 -> begin
+    | 2 -> (
       match match_var_with_extra_info env scrutinee with
       | None | Some Boxed_number -> e, false
       | Some (Untag e') ->
         let size_e = cmm_arith_size e in
         let size_e' = cmm_arith_size e' in
-        if size_e' < size_e then e', true else e, false
-    end
+        if size_e' < size_e then e', true else e, false)
     | _ -> e, false
   in
   let wrap, env = Env.flush_delayed_lets env in

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -599,7 +599,7 @@ let unary_primitive env res dbg f arg =
     (* We could have an [Env.Tag] which would be returned here, but probably
        unnecessary at the moment. *)
     None, res, C.tag_int arg dbg
-  | Project_function_slot { move_from = c1; move_to = c2 } -> begin
+  | Project_function_slot { move_from = c1; move_to = c2 } -> (
     match function_slot_offset env c1, function_slot_offset env c2 with
     | ( Live_function_slot { offset = c1_offset; _ },
         Live_function_slot { offset = c2_offset; _ } ) ->
@@ -618,9 +618,8 @@ let unary_primitive env res dbg f arg =
     | Dead_function_slot, Dead_function_slot ->
       let message = dead_slots_msg dbg [c1; c2] [] in
       let expr, res = C.invalid res ~message in
-      None, res, expr
-  end
-  | Project_value_slot { project_from; value_slot } -> begin
+      None, res, expr)
+  | Project_value_slot { project_from; value_slot } -> (
     match
       value_slot_offset env value_slot, function_slot_offset env project_from
     with
@@ -640,8 +639,7 @@ let unary_primitive env res dbg f arg =
     | Dead_value_slot, Dead_function_slot ->
       let message = dead_slots_msg dbg [project_from] [value_slot] in
       let expr, res = C.invalid res ~message in
-      None, res, expr
-  end
+      None, res, expr)
   | Is_boxed_float ->
     (* As a note, this omits the [Is_in_value_area] check that exists in
        [caml_make_array], which is used by non-Flambda 2 compilers. This seems

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -36,14 +36,13 @@ let create ~module_symbol =
 
 let check_for_module_symbol t symbol =
   if Symbol.equal symbol t.module_symbol
-  then begin
+  then (
     if t.module_symbol_defined
     then
       Misc.fatal_errorf
         "check_for_module_symbol %a: Module block symbol (%a) already defined"
         Symbol.print symbol Symbol.print t.module_symbol;
-    { t with module_symbol_defined = true }
-  end
+    { t with module_symbol_defined = true })
   else t
 
 let defines_a_symbol data =

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -27,11 +27,10 @@ let exttype_of_kind (k : Flambda_kind.t) : Cmm.exttype =
   | Naked_number Naked_float -> XFloat
   | Naked_number Naked_int64 -> XInt64
   | Naked_number Naked_int32 -> XInt32
-  | Naked_number (Naked_immediate | Naked_nativeint) -> begin
+  | Naked_number (Naked_immediate | Naked_nativeint) -> (
     match Targetint_32_64.num_bits with
     | Thirty_two -> XInt32
-    | Sixty_four -> XInt64
-  end
+    | Sixty_four -> XInt64)
   | Region -> Misc.fatal_error "[Region] kind not expected here"
   | Rec_info -> Misc.fatal_error "[Rec_info] kind not expected here"
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -40,7 +40,7 @@ let or_variable f default v cont =
 
 let rec static_block_updates symb env acc i = function
   | [] -> env, acc
-  | sv :: r -> begin
+  | sv :: r -> (
     match (sv : Field_of_static_block.t) with
     | Symbol _ | Tagged_immediate _ ->
       static_block_updates symb env acc (i + 1) r
@@ -49,12 +49,11 @@ let rec static_block_updates symb env acc i = function
         C.make_update env dbg Word_val ~symbol:(C.symbol ~dbg symb) var ~index:i
           ~prev_updates:acc
       in
-      static_block_updates symb env acc (i + 1) r
-  end
+      static_block_updates symb env acc (i + 1) r)
 
 let rec static_float_array_updates symb env acc i = function
   | [] -> env, acc
-  | sv :: r -> begin
+  | sv :: r -> (
     match (sv : _ Or_variable.t) with
     | Const _ -> static_float_array_updates symb env acc (i + 1) r
     | Var (var, dbg) ->
@@ -62,8 +61,7 @@ let rec static_float_array_updates symb env acc i = function
         C.make_update env dbg Double ~symbol:(C.symbol ~dbg symb) var ~index:i
           ~prev_updates:acc
       in
-      static_float_array_updates symb env acc (i + 1) r
-  end
+      static_float_array_updates symb env acc (i + 1) r)
 
 let static_boxed_number kind env symbol default emit transl v r updates =
   let aux x cont =

--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -167,7 +167,7 @@ end = struct
       (fun order aliases res_opt ->
         match res_opt with
         | Some _ -> res_opt
-        | None -> begin
+        | None -> (
           match Name_mode.compare_partial_order order min_name_mode with
           | None -> None
           | Some result ->
@@ -175,8 +175,7 @@ end = struct
             then
               let aliases = filter_by_scope order aliases in
               if Name.Map.is_empty aliases then None else Some aliases
-            else None
-        end)
+            else None))
       t.aliases None
 
   let mem t elt = Name.Map.mem elt t.all
@@ -658,7 +657,7 @@ let add_alias_between_canonical_elements ~binding_time_resolver
       get_aliases_of_canonical_element t ~canonical_element
     in
     if Flambda_features.check_invariants ()
-    then begin
+    then (
       assert (
         not
           (Aliases_of_canonical_element.mem aliases_of_canonical_element
@@ -666,8 +665,7 @@ let add_alias_between_canonical_elements ~binding_time_resolver
       assert (
         Aliases_of_canonical_element.is_empty
           (Aliases_of_canonical_element.inter aliases_of_canonical_element
-             aliases_of_to_be_demoted))
-    end;
+             aliases_of_to_be_demoted)));
     let aliases =
       (* CR lmaurer: Consider adding a combination [union] and [compose] to
          [Aliases_of_canonical_element] to save a map traversal here (a single
@@ -721,7 +719,7 @@ type add_result =
 let invariant_add_result ~binding_time_resolver ~binding_times_and_modes
     ~original_t { canonical_element; alias_of_demoted_element; t } =
   if Flambda_features.check_invariants ()
-  then begin
+  then (
     invariant ~binding_time_resolver ~binding_times_and_modes t;
     if not
          (defined_earlier ~binding_time_resolver ~binding_times_and_modes
@@ -738,8 +736,7 @@ let invariant_add_result ~binding_time_resolver ~binding_times_and_modes
         "Alias %a must not be must not be canonical anymore.@ Original alias \
          tracker:@ %a@ Resulting alias tracker:@ %a"
         Simple.print alias_of_demoted_element print original_t print t
-    | Alias_of_canonical _ -> ()
-  end
+    | Alias_of_canonical _ -> ())
 
 let add_alias ~binding_time_resolver ~binding_times_and_modes t
     ~canonical_element1 ~coercion_from_canonical_element2_to_canonical_element1
@@ -798,7 +795,7 @@ let add ~binding_time_resolver ~binding_times_and_modes t
       ~then_:(Coercion.inverse (Simple.coercion element1_with_coercion))
   in
   if Flambda_features.check_invariants ()
-  then begin
+  then (
     if Simple.equal canonical_element1 canonical_element2
     then
       Misc.fatal_errorf "Cannot alias an element to itself: %a" Simple.print
@@ -810,8 +807,7 @@ let add ~binding_time_resolver ~binding_times_and_modes t
           ~name:(fun _ ~coercion:_ -> ())
           ~const:(fun const2 ->
             Misc.fatal_errorf "Cannot add alias between two consts: %a, %a"
-              Reg_width_const.print const1 Reg_width_const.print const2))
-  end;
+              Reg_width_const.print const1 Reg_width_const.print const2)));
   let add_result =
     add_alias ~binding_time_resolver ~binding_times_and_modes t
       ~canonical_element1

--- a/middle_end/flambda2/types/env/code_age_relation.ml
+++ b/middle_end/flambda2/types/env/code_age_relation.ml
@@ -42,13 +42,12 @@ let rec all_ids_up_to_root t ~resolver id =
         Misc.fatal_errorf "Exception in resolver@ Backtrace is: %s"
           (Printexc.raw_backtrace_to_string (Printexc.get_raw_backtrace ()))
       | None -> Code_id.Set.singleton id
-      | Some t -> begin
+      | Some t -> (
         (* Inlining the base case, so that we do not recursively loop in case of
            a code_id that is not bound in the map *)
         match Code_id.Map.find id t with
         | exception Not_found -> Code_id.Set.singleton id
-        | older -> Code_id.Set.add id (all_ids_up_to_root t ~resolver older)
-      end)
+        | older -> Code_id.Set.add id (all_ids_up_to_root t ~resolver older)))
   | older -> Code_id.Set.add id (all_ids_up_to_root t ~resolver older)
 
 let num_ids_up_to_root t ~resolver id =

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -494,11 +494,10 @@ let mem ?min_name_mode t name =
       match name_mode, min_name_mode with
       | None, _ -> false
       | Some _, None -> true
-      | Some name_mode, Some min_name_mode -> begin
+      | Some name_mode, Some min_name_mode -> (
         match Name_mode.compare_partial_order min_name_mode name_mode with
         | None -> false
-        | Some c -> c <= 0
-      end)
+        | Some c -> c <= 0))
     ~symbol:(fun sym ->
       (* CR mshinwell: This might not take account of symbols in missing .cmx
          files *)
@@ -628,7 +627,7 @@ let invariant_for_alias (t : t) name ty =
 
 let invariant_for_new_equation (t : t) name ty =
   if Flambda_features.check_invariants ()
-  then begin
+  then (
     invariant_for_alias t name ty;
     (* CR mshinwell: This should check that precision is not decreasing. *)
     let defined_names =
@@ -642,8 +641,7 @@ let invariant_for_new_equation (t : t) name ty =
     then
       let unbound_names = Name_occurrences.diff free_names defined_names in
       Misc.fatal_errorf "New equation@ %a@ =@ %a@ has unbound names@ (%a):@ %a"
-        Name.print name TG.print ty Name_occurrences.print unbound_names print t
-  end
+        Name.print name TG.print ty Name_occurrences.print unbound_names print t)
 
 let rec add_equation0 (t : t) name ty =
   (if Flambda_features.Debug.concrete_types_only_on_canonicals ()

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -78,7 +78,7 @@ let extract_symbol_approx env symbol find_code =
            We should make a proper fix in the [Variant] case below in due course
            and return to having a fatal error here. *)
         Value_unknown
-      | Ok (Value ty) -> begin
+      | Ok (Value ty) -> (
         match ty with
         | Array _ | String _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
         | Boxed_nativeint _ | Mutable_block _ ->
@@ -86,7 +86,7 @@ let extract_symbol_approx env symbol find_code =
         | Closures { by_function_slot; alloc_mode = _ } -> (
           match Row_like_for_closures.get_singleton by_function_slot with
           | None -> Value_unknown
-          | Some ((function_slot, _contents), closures_entry) -> begin
+          | Some ((function_slot, _contents), closures_entry) -> (
             match
               Closures_entry.find_function_type closures_entry function_slot
             with
@@ -94,8 +94,7 @@ let extract_symbol_approx env symbol find_code =
             | Ok function_type ->
               let code_id = Function_type.code_id function_type in
               let code_or_meta = find_code code_id in
-              Closure_approximation (code_id, function_slot, code_or_meta)
-          end)
+              Closure_approximation (code_id, function_slot, code_or_meta)))
         | Variant
             { immediates = Unknown; blocks = _; is_unique = _; alloc_mode = _ }
         | Variant
@@ -122,12 +121,11 @@ let extract_symbol_approx env symbol find_code =
                 | Unknown -> Alloc_mode.Heap
               in
               Block_approximation (Array.of_list fields, alloc_mode)
-          else Value_unknown
-      end
+          else Value_unknown)
     in
     match Type_grammar.get_alias_exn ty with
     | exception Not_found -> expand ty
-    | simple -> begin
+    | simple -> (
       match
         Typing_env.get_canonical_simple_exn env simple
           ~min_name_mode:Name_mode.normal
@@ -139,8 +137,7 @@ let extract_symbol_approx env symbol find_code =
           Value_approximation.Value_symbol symbol
         in
         let[@inline always] const _const = expand ty in
-        Simple.pattern_match' simple ~var ~symbol ~const
-    end
+        Simple.pattern_match' simple ~var ~symbol ~const)
   in
   let get_symbol_type sym =
     Typing_env.find env (Name.symbol sym) (Some Flambda_kind.value)

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -1961,10 +1961,9 @@ and project_int_indexed_product ~to_project ~expand
     let field = fields.(i) in
     let field' = project_variables_out ~to_project ~expand field in
     if field != field'
-    then begin
+    then (
       changed := true;
-      fields'.(i) <- field'
-    end
+      fields'.(i) <- field')
   done;
   if !changed then { fields = fields'; kind } else product
 
@@ -1989,10 +1988,9 @@ and project_env_extension ~to_project ~expand ({ equations } as env_extension) =
           ~symbol:(fun _ -> keep_equation ())
           ~var:(fun var ->
             if Variable.Set.mem var to_project
-            then begin
+            then (
               changed := true;
-              acc
-            end
+              acc)
             else keep_equation ()))
       equations Name.Map.empty
   in
@@ -2011,17 +2009,15 @@ let kind t =
 
 let create_variant ~is_unique ~(immediates : _ Or_unknown.t) ~blocks alloc_mode
     =
-  begin
-    match immediates with
-    | Unknown -> ()
-    | Known immediates ->
-      if not (K.equal (kind immediates) K.naked_immediate)
-      then
-        Misc.fatal_errorf
-          "Cannot create [immediates] with type that is not of kind \
-           [Naked_immediate]:@ %a"
-          print immediates
-  end;
+  (match immediates with
+  | Unknown -> ()
+  | Known immediates ->
+    if not (K.equal (kind immediates) K.naked_immediate)
+    then
+      Misc.fatal_errorf
+        "Cannot create [immediates] with type that is not of kind \
+         [Naked_immediate]:@ %a"
+        print immediates);
   Value (TD.create (Variant { immediates; blocks; is_unique; alloc_mode }))
 
 let mutable_block alloc_mode = Value (TD.create (Mutable_block { alloc_mode }))
@@ -2173,17 +2169,15 @@ module Row_like_for_blocks = struct
       |> Flambda_kind.Set.get_singleton
     in
     (* CR pchambart: move to invariant check *)
-    begin
-      match field_kind' with
-      | None ->
-        if List.length field_tys <> 0
-        then Misc.fatal_error "[field_tys] must all be of the same kind"
-      | Some field_kind' ->
-        if not (Flambda_kind.equal field_kind field_kind')
-        then
-          Misc.fatal_errorf "Declared field kind %a doesn't match [field_tys]"
-            Flambda_kind.print field_kind
-    end;
+    (match field_kind' with
+    | None ->
+      if List.length field_tys <> 0
+      then Misc.fatal_error "[field_tys] must all be of the same kind"
+    | Some field_kind' ->
+      if not (Flambda_kind.equal field_kind field_kind')
+      then
+        Misc.fatal_errorf "Declared field kind %a doesn't match [field_tys]"
+          Flambda_kind.print field_kind);
 
     let tag : _ Or_unknown.t =
       let tag : _ Or_unknown.t =
@@ -2193,7 +2187,7 @@ module Row_like_for_blocks = struct
         | Closed tag -> Known tag
       in
       match tag with
-      | Unknown -> begin
+      | Unknown -> (
         match field_kind with
         | Value -> Unknown
         | Naked_number Naked_float -> Known Tag.double_array_tag
@@ -2203,17 +2197,15 @@ module Row_like_for_blocks = struct
         | Naked_number Naked_nativeint
         | Region | Rec_info ->
           Misc.fatal_errorf "Bad kind %a for fields" Flambda_kind.print
-            field_kind
-      end
-      | Known tag -> begin
+            field_kind)
+      | Known tag -> (
         match field_kind with
-        | Value -> begin
+        | Value -> (
           match Tag.Scannable.of_tag tag with
           | Some _ -> Known tag
           | None ->
             Misc.fatal_error
-              "Blocks full of [Value]s must have a tag less than [No_scan_tag]"
-        end
+              "Blocks full of [Value]s must have a tag less than [No_scan_tag]")
         | Naked_number Naked_float ->
           if not (Tag.equal tag Tag.double_array_tag)
           then
@@ -2226,17 +2218,15 @@ module Row_like_for_blocks = struct
         | Naked_number Naked_nativeint
         | Region | Rec_info ->
           Misc.fatal_errorf "Bad kind %a for fields" Flambda_kind.print
-            field_kind
-      end
+            field_kind)
     in
     let product = { kind = field_kind; fields = Array.of_list field_tys } in
     let size = Targetint_31_63.Imm.of_int (List.length field_tys) in
     match open_or_closed with
-    | Open _ -> begin
+    | Open _ -> (
       match tag with
       | Known tag -> create_at_least tag size product
-      | Unknown -> create_at_least_unknown_tag size product
-    end
+      | Unknown -> create_at_least_unknown_tag size product)
     | Closed _ -> (
       match tag with
       | Known tag -> create_exactly tag size product
@@ -2346,9 +2336,8 @@ module Row_like_for_blocks = struct
     in
     match Tag.Map.find variant_tag t.known_tags with
     | case -> aux case
-    | exception Not_found -> begin
-      match t.other_tags with Bottom -> Bottom | Ok case -> aux case
-    end
+    | exception Not_found -> (
+      match t.other_tags with Bottom -> Bottom | Ok case -> aux case)
 end
 
 module Row_like_for_closures = struct

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -418,16 +418,12 @@ and meet_variant env ~(blocks1 : TG.Row_like_for_blocks.t Or_unknown.t)
     let blocks : _ Or_unknown.t = Known TG.Row_like_for_blocks.bottom in
     Ok (blocks, immediates, env_extension)
   | Ok (blocks, env_extension1), Ok (immediates, env_extension2) ->
-    begin
-      match (blocks : _ Or_unknown.t) with
-      | Unknown -> ()
-      | Known blocks -> assert (not (TG.Row_like_for_blocks.is_bottom blocks))
-    end;
-    begin
-      match (immediates : _ Or_unknown.t) with
-      | Unknown -> ()
-      | Known imms -> assert (not (TG.is_obviously_bottom imms))
-    end;
+    (match (blocks : _ Or_unknown.t) with
+    | Unknown -> ()
+    | Known blocks -> assert (not (TG.Row_like_for_blocks.is_bottom blocks)));
+    (match (immediates : _ Or_unknown.t) with
+    | Unknown -> ()
+    | Known imms -> assert (not (TG.is_obviously_bottom imms)));
     let env_extension =
       let env = Meet_env.env env in
       let join_env = Join_env.create env ~left_env:env ~right_env:env in
@@ -715,11 +711,9 @@ and meet_closures_entry (env : Meet_env.t)
             any_bottom := true;
             None
           | Ok (func_type, env_extension) ->
-            begin
-              match meet_env_extension env !env_extensions env_extension with
-              | Bottom -> any_bottom := true
-              | Ok env_extension -> env_extensions := env_extension
-            end;
+            (match meet_env_extension env !env_extensions env_extension with
+            | Bottom -> any_bottom := true
+            | Ok env_extension -> env_extensions := env_extension);
             Some func_type))
       function_types1 function_types2
   in
@@ -759,15 +753,14 @@ and meet_generic_product :
     union
       (fun _index ty1 ty2 ->
         match meet env ty1 ty2 with
-        | Ok (ty, env_extension') -> begin
+        | Ok (ty, env_extension') -> (
           match meet_env_extension env !env_extension env_extension' with
           | Bottom ->
             any_bottom := true;
             Some (MTC.bottom_like ty1)
           | Ok extension ->
             env_extension := extension;
-            Some ty
-        end
+            Some ty)
         | Bottom ->
           any_bottom := true;
           Some (MTC.bottom_like ty1))
@@ -817,21 +810,19 @@ and meet_int_indexed_product env (prod1 : TG.Product.Int_indexed.t)
           match get_opt fields1, get_opt fields2 with
           | None, None -> assert false
           | Some t, None | None, Some t -> t
-          | Some ty1, Some ty2 -> begin
+          | Some ty1, Some ty2 -> (
             match meet env ty1 ty2 with
-            | Ok (ty, env_extension') -> begin
+            | Ok (ty, env_extension') -> (
               match meet_env_extension env !env_extension env_extension' with
               | Bottom ->
                 any_bottom := true;
                 MTC.bottom_like ty1
               | Ok extension ->
                 env_extension := extension;
-                ty
-            end
+                ty)
             | Bottom ->
               any_bottom := true;
-              MTC.bottom_like ty1
-          end)
+              MTC.bottom_like ty1))
     in
     if !any_bottom
     then Bottom
@@ -878,13 +869,12 @@ and meet_env_extension0 env (ext1 : TEE.t) (ext2 : TEE.t) extra_extensions :
         | None ->
           MTC.check_equation name ty;
           Name.Map.add name ty eqs, extra_extensions
-        | Some ty0 -> begin
+        | Some ty0 -> (
           match meet env ty0 ty with
           | Bottom -> raise Bottom_meet
           | Ok (ty, new_ext) ->
             MTC.check_equation name ty;
-            Name.Map.add (*replace*) name ty eqs, new_ext :: extra_extensions
-        end)
+            Name.Map.add (*replace*) name ty eqs, new_ext :: extra_extensions))
       (TEE.to_map ext2)
       (TEE.to_map ext1, extra_extensions)
   in
@@ -999,11 +989,10 @@ and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
         Known (ET.to_type (join_expanded_head env kind expanded1 expanded2))
       in
       match canonical_simple1, canonical_simple2 with
-      | Some simple1, Some simple2 -> begin
+      | Some simple1, Some simple2 -> (
         match Join_env.now_joining env simple1 simple2 with
         | Continue env -> join_heads env
-        | Stop -> unknown ()
-      end
+        | Stop -> unknown ())
       | Some _, None | None, Some _ | None, None -> join_heads env))
 
 and join_expanded_head env kind (expanded1 : ET.t) (expanded2 : ET.t) : ET.t =
@@ -1255,7 +1244,7 @@ and join_row_like :
        the same kinds. *)
     match case1, case2 with
     | None, None -> None
-    | Some case1, None -> begin
+    | Some case1, None -> (
       let only_case1 () =
         (* CF Type_descr.join_head_or_unknown_or_bottom, we need to join those
            to ensure that free variables not present in the target env are
@@ -1276,9 +1265,8 @@ and join_row_like :
         if matching_kinds case1 other_case
         then Some (join_case join_env case1 other_case)
         else (* If kinds don't match, the tags can't match *)
-          only_case1 ()
-    end
-    | None, Some case2 -> begin
+          only_case1 ())
+    | None, Some case2 -> (
       let only_case2 () =
         (* See at the other bottom case *)
         let join_env =
@@ -1295,8 +1283,7 @@ and join_row_like :
       | Ok other_case ->
         if matching_kinds other_case case2
         then Some (join_case join_env other_case case2)
-        else only_case2 ()
-    end
+        else only_case2 ())
     | Some case1, Some case2 -> Some (join_case join_env case1 case2)
   in
   let known =
@@ -1406,9 +1393,8 @@ and join_generic_product :
     (fun _index ty1_opt ty2_opt ->
       match ty1_opt, ty2_opt with
       | None, _ | _, None -> None
-      | Some ty1, Some ty2 -> begin
-        match join env ty1 ty2 with Known ty -> Some ty | Unknown -> None
-      end)
+      | Some ty1, Some ty2 -> (
+        match join env ty1 ty2 with Known ty -> Some ty | Unknown -> None))
     components_by_index1 components_by_index2
 
 and join_function_slot_indexed_product env
@@ -1459,10 +1445,9 @@ and join_int_indexed_product env
     then
       if Int.equal length1 length
       then fields1
-      else begin
+      else (
         assert (Int.equal length2 length);
-        fields2
-      end
+        fields2)
     else
       Array.init length (fun index ->
           if fields1.(index) == fields2.(index)
@@ -1504,7 +1489,7 @@ and join_env_extension env (ext1 : TEE.t) (ext2 : TEE.t) : TEE.t =
       (fun name ty1_opt ty2_opt ->
         match ty1_opt, ty2_opt with
         | None, _ | _, None -> None
-        | Some ty1, Some ty2 -> begin
+        | Some ty1, Some ty2 -> (
           match join env ty1 ty2 with
           | Known ty ->
             if MTC.is_alias_of_name ty name
@@ -1516,13 +1501,11 @@ and join_env_extension env (ext1 : TEE.t) (ext2 : TEE.t) : TEE.t =
                  ([name = name] would be rejected by [TE.add_equation]
                  anyway.) *)
               None
-            else begin
+            else (
               (* This should always pass due to the [is_alias_of_name] check. *)
               MTC.check_equation name ty;
-              Some ty
-            end
-          | Unknown -> None
-        end)
+              Some ty)
+          | Unknown -> None))
       (TEE.to_map ext1) (TEE.to_map ext2)
   in
   TEE.from_map equations

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -203,7 +203,7 @@ let prove_is_int env t : bool proof =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
   match expand_head env t with
-  | Value (Ok (Variant blocks_imms)) -> begin
+  | Value (Ok (Variant blocks_imms)) -> (
     match blocks_imms.blocks, blocks_imms.immediates with
     | Unknown, Unknown -> Unknown
     | Unknown, Known imms ->
@@ -215,8 +215,7 @@ let prove_is_int env t : bool proof =
       then if is_bottom env imms then Invalid else Proved true
       else if is_bottom env imms
       then Proved false
-      else Unknown
-  end
+      else Unknown)
   | Value
       (Ok
         ( Mutable_block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
@@ -237,7 +236,7 @@ let prove_tags_must_be_a_block env t : Tag.Set.t proof =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
   match expand_head env t with
-  | Value (Ok (Variant blocks_imms)) -> begin
+  | Value (Ok (Variant blocks_imms)) -> (
     match blocks_imms.immediates with
     | Unknown -> Unknown
     | Known imms -> (
@@ -264,8 +263,7 @@ let prove_tags_must_be_a_block env t : Tag.Set.t proof =
           match TG.Row_like_for_blocks.all_tags blocks with
           | Unknown -> Unknown
           | Known tags -> if Tag.Set.is_empty tags then Invalid else Proved tags
-          ))
-  end
+          )))
   | Value
       (Ok (Boxed_float _ | Boxed_int32 _ | Boxed_int64 _ | Boxed_nativeint _))
     ->
@@ -294,16 +292,15 @@ let prove_naked_immediates env t : Targetint_31_63.Set.t proof =
   match expand_head env t with
   | Naked_immediate (Ok (Naked_immediates is)) ->
     if Targetint_31_63.Set.is_empty is then Invalid else Proved is
-  | Naked_immediate (Ok (Is_int scrutinee_ty)) -> begin
+  | Naked_immediate (Ok (Is_int scrutinee_ty)) -> (
     match prove_is_int env scrutinee_ty with
     | Proved true ->
       Proved (Targetint_31_63.Set.singleton Targetint_31_63.bool_true)
     | Proved false ->
       Proved (Targetint_31_63.Set.singleton Targetint_31_63.bool_false)
     | Unknown -> Unknown
-    | Invalid -> Invalid
-  end
-  | Naked_immediate (Ok (Get_tag block_ty)) -> begin
+    | Invalid -> Invalid)
+  | Naked_immediate (Ok (Get_tag block_ty)) -> (
     (* CR vlaviron: see the comment in prove_tags_must_be_a_block. See also
        prove_equals_tagged_immediates below, which returns Unknown when the
        blocks part is not bottom. *)
@@ -317,8 +314,7 @@ let prove_naked_immediates env t : Targetint_31_63.Set.t proof =
       in
       Proved is
     | Unknown -> Unknown
-    | Invalid -> Invalid
-  end
+    | Invalid -> Invalid)
   | Naked_immediate Unknown -> Unknown
   | Naked_immediate Bottom -> Invalid
   | Value _ -> wrong_kind ()
@@ -334,7 +330,7 @@ let prove_equals_tagged_immediates env t : Targetint_31_63.Set.t proof =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
   match expand_head env t with
-  | Value (Ok (Variant blocks_imms)) -> begin
+  | Value (Ok (Variant blocks_imms)) -> (
     match blocks_imms.blocks, blocks_imms.immediates with
     | Unknown, Unknown | Unknown, Known _ | Known _, Unknown -> Unknown
     | Known blocks, Known imms ->
@@ -342,8 +338,7 @@ let prove_equals_tagged_immediates env t : Targetint_31_63.Set.t proof =
          context where variants are ok? *)
       if not (TG.Row_like_for_blocks.is_bottom blocks)
       then Unknown
-      else prove_naked_immediates env imms
-  end
+      else prove_naked_immediates env imms)
   | Value (Ok (Mutable_block _)) -> Unknown
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
@@ -358,11 +353,10 @@ let prove_equals_tagged_immediates env t : Targetint_31_63.Set.t proof =
 
 let prove_equals_single_tagged_immediate env t : _ proof =
   match prove_equals_tagged_immediates env t with
-  | Proved imms -> begin
+  | Proved imms -> (
     match Targetint_31_63.Set.get_singleton imms with
     | Some imm -> Proved imm
-    | None -> Unknown
-  end
+    | None -> Unknown)
   | Unknown -> Unknown
   | Invalid -> Invalid
 
@@ -371,7 +365,7 @@ let prove_tags_and_sizes env t : Targetint_31_63.Imm.t Tag.Map.t proof =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
   in
   match expand_head env t with
-  | Value (Ok (Variant blocks_imms)) -> begin
+  | Value (Ok (Variant blocks_imms)) -> (
     match blocks_imms.immediates with
     (* CR mshinwell: Care. Should this return [Unknown] or [Invalid] if there is
        the possibility of the type representing a tagged immediate? *)
@@ -385,8 +379,7 @@ let prove_tags_and_sizes env t : Targetint_31_63.Imm.t Tag.Map.t proof =
           match TG.Row_like_for_blocks.all_tags_and_sizes blocks with
           | Unknown -> Unknown
           | Known tags_and_sizes -> Proved tags_and_sizes)
-      else Unknown
-  end
+      else Unknown)
   | Value (Ok (Mutable_block _)) -> Unknown
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
@@ -421,7 +414,7 @@ type variant_like_proof =
 let prove_variant_like env t : variant_like_proof proof_allowing_kind_mismatch =
   (* Format.eprintf "prove_variant:@ %a\n%!" TG.print t; *)
   match expand_head env t with
-  | Value (Ok (Variant blocks_imms)) -> begin
+  | Value (Ok (Variant blocks_imms)) -> (
     match blocks_imms.blocks with
     | Unknown -> Unknown
     | Known blocks -> (
@@ -446,15 +439,13 @@ let prove_variant_like env t : variant_like_proof proof_allowing_kind_mismatch =
           let const_ctors : _ Or_unknown.t =
             match blocks_imms.immediates with
             | Unknown -> Unknown
-            | Known imms -> begin
+            | Known imms -> (
               match prove_naked_immediates env imms with
               | Unknown -> Unknown
               | Invalid -> Known Targetint_31_63.Set.empty
-              | Proved const_ctors -> Known const_ctors
-            end
+              | Proved const_ctors -> Known const_ctors)
           in
-          Proved { const_ctors; non_const_ctors_with_sizes }))
-  end
+          Proved { const_ctors; non_const_ctors_with_sizes })))
   | Value (Ok (Mutable_block _)) -> Unknown
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
@@ -476,7 +467,7 @@ let prove_is_a_boxed_or_tagged_number env t :
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value (Ok (Variant { blocks; immediates; is_unique = _; alloc_mode = _ }))
-    -> begin
+    -> (
     match blocks, immediates with
     | Unknown, Unknown -> Unknown
     | Unknown, Known imms -> if is_bottom env imms then Invalid else Unknown
@@ -489,8 +480,7 @@ let prove_is_a_boxed_or_tagged_number env t :
       then Invalid
       else if TG.Row_like_for_blocks.is_bottom blocks
       then Proved Tagged_immediate
-      else Unknown
-  end
+      else Unknown)
   | Value (Ok (Boxed_float _)) -> Proved (Boxed Naked_float)
   | Value (Ok (Boxed_int32 _)) -> Proved (Boxed Naked_int32)
   | Value (Ok (Boxed_int64 _)) -> Proved (Boxed Naked_int64)
@@ -687,7 +677,7 @@ let prove_is_tagging_of_simple ~prove_function env ~min_name_mode t :
   in
   match expand_head env t with
   | Value (Ok (Variant { immediates; blocks; is_unique = _; alloc_mode = _ }))
-    -> begin
+    -> (
     match blocks with
     | Unknown -> Unknown
     | Known blocks -> (
@@ -719,8 +709,7 @@ let prove_is_tagging_of_simple ~prove_function env ~min_name_mode t :
               match Targetint_31_63.Set.get_singleton imms with
               | Some imm ->
                 Proved (Simple.const (Reg_width_const.naked_immediate imm))
-              | None -> Unknown)))))
-  end
+              | None -> Unknown))))))
   | Value Unknown -> Unknown
   | Value _ -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
@@ -736,7 +725,7 @@ let prove_could_be_tagging_of_simple =
 let[@inline always] prove_boxed_number_containing_simple
     ~contents_of_boxed_number env ~min_name_mode t : Simple.t proof =
   match expand_head env t with
-  | Value (Ok ty_value) -> begin
+  | Value (Ok ty_value) -> (
     match contents_of_boxed_number ty_value with
     | None -> Invalid
     | Some ty -> (
@@ -744,8 +733,7 @@ let[@inline always] prove_boxed_number_containing_simple
         TE.get_canonical_simple_exn env ~min_name_mode (TG.get_alias_exn ty)
       with
       | simple -> Proved simple
-      | exception Not_found -> Unknown)
-  end
+      | exception Not_found -> Unknown))
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
@@ -795,10 +783,10 @@ let[@inline] prove_block_field_simple_aux env ~min_name_mode t get_field :
   in
   match expand_head env t with
   | Value (Ok (Variant { immediates; blocks; is_unique = _; alloc_mode = _ }))
-    -> begin
+    -> (
     match immediates with
     | Unknown -> Unknown
-    | Known imms -> begin
+    | Known imms -> (
       match blocks with
       | Unknown -> Unknown
       | Known blocks -> (
@@ -810,17 +798,13 @@ let[@inline] prove_block_field_simple_aux env ~min_name_mode t get_field :
           match (get_field blocks : _ Or_unknown_or_bottom.t) with
           | Bottom -> Invalid
           | Unknown -> Unknown
-          | Ok ty -> begin
+          | Ok ty -> (
             match TG.get_alias_exn ty with
-            | simple -> begin
+            | simple -> (
               match TE.get_canonical_simple_exn env ~min_name_mode simple with
               | simple -> Proved simple
-              | exception Not_found -> Unknown
-            end
-            | exception Not_found -> Unknown
-          end)
-    end
-  end
+              | exception Not_found -> Unknown)
+            | exception Not_found -> Unknown))))
   | Value (Ok (Mutable_block _)) -> Unknown
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
@@ -852,15 +836,13 @@ let prove_project_function_slot_simple env ~min_name_mode t function_slot :
       TG.Row_like_for_closures.get_closure by_function_slot function_slot
     with
     | Unknown -> Unknown
-    | Known ty -> begin
+    | Known ty -> (
       match TG.get_alias_exn ty with
-      | simple -> begin
+      | simple -> (
         match TE.get_canonical_simple_exn env ~min_name_mode simple with
         | simple -> Proved simple
-        | exception Not_found -> Unknown
-      end
-      | exception Not_found -> Unknown
-    end)
+        | exception Not_found -> Unknown)
+      | exception Not_found -> Unknown))
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
@@ -877,15 +859,13 @@ let prove_project_value_slot_simple env ~min_name_mode t env_var :
   | Value (Ok (Closures { by_function_slot; alloc_mode = _ })) -> (
     match TG.Row_like_for_closures.get_env_var by_function_slot env_var with
     | Unknown -> Unknown
-    | Known ty -> begin
+    | Known ty -> (
       match TG.get_alias_exn ty with
-      | simple -> begin
+      | simple -> (
         match TE.get_canonical_simple_exn env ~min_name_mode simple with
         | simple -> Proved simple
-        | exception Not_found -> Unknown
-      end
-      | exception Not_found -> Unknown
-    end)
+        | exception Not_found -> Unknown)
+      | exception Not_found -> Unknown))
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -72,11 +72,9 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
       | None -> false
       | Some allowed_if_free_vars_defined_in -> (
         TE.mem ~min_name_mode allowed_if_free_vars_defined_in (Name.var var)
-        && begin
-             match additional_free_var_criterion with
-             | None -> true
-             | Some criterion -> criterion var
-           end
+        && (match additional_free_var_criterion with
+           | None -> true
+           | Some criterion -> criterion var)
         &&
         match disallowed_free_vars with
         | None -> true
@@ -172,19 +170,18 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
           else if TG.Row_like_for_blocks.is_bottom blocks
           then
             match Provers.prove_naked_immediates env imms with
-            | Proved imms -> begin
+            | Proved imms -> (
               match Targetint_31_63.Set.get_singleton imms with
               | None -> try_canonical_simple ()
               | Some imm ->
-                Simple (Simple.const (Reg_width_const.tagged_immediate imm))
-            end
+                Simple (Simple.const (Reg_width_const.tagged_immediate imm)))
             | Unknown -> try_canonical_simple ()
             | Invalid -> Invalid
           else try_canonical_simple ()
         | Known _, Unknown | Unknown, Known _ | Unknown, Unknown ->
           try_canonical_simple ())
     | Value (Ok (Mutable_block _)) -> try_canonical_simple ()
-    | Value (Ok (Closures { by_function_slot; alloc_mode })) -> begin
+    | Value (Ok (Closures { by_function_slot; alloc_mode })) -> (
       (* CR mshinwell: Here and above, move to separate function. *)
       match TG.Row_like_for_closures.get_singleton by_function_slot with
       | None -> try_canonical_simple ()
@@ -263,37 +260,33 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
                    all_value_slots ->
                 Value_slot.Map.fold
                   (fun value_slot simple all_value_slots ->
-                    begin
-                      match Value_slot.Map.find value_slot all_value_slots with
-                      | exception Not_found -> ()
-                      | existing_simple ->
-                        if not (Simple.equal simple existing_simple)
-                        then
-                          Misc.fatal_errorf
-                            "Disagreement on %a and %a (value slot %a)@ whilst \
-                             reifying set-of-closures from:@ %a"
-                            Simple.print simple Simple.print existing_simple
-                            Value_slot.print value_slot TG.print t
-                    end;
+                    (match Value_slot.Map.find value_slot all_value_slots with
+                    | exception Not_found -> ()
+                    | existing_simple ->
+                      if not (Simple.equal simple existing_simple)
+                      then
+                        Misc.fatal_errorf
+                          "Disagreement on %a and %a (value slot %a)@ whilst \
+                           reifying set-of-closures from:@ %a"
+                          Simple.print simple Simple.print existing_simple
+                          Value_slot.print value_slot TG.print t);
                     Value_slot.Map.add value_slot simple all_value_slots)
                   value_slot_simples all_value_slots)
               function_types_with_value_slots Value_slot.Map.empty
           in
-          Lift_set_of_closures { function_slot; function_types; value_slots }
-    end
+          Lift_set_of_closures { function_slot; function_types; value_slots })
     | Naked_immediate (Ok (Naked_immediates imms)) -> (
       match Targetint_31_63.Set.get_singleton imms with
       | None -> try_canonical_simple ()
       | Some i -> Simple (Simple.const (Reg_width_const.naked_immediate i)))
     (* CR mshinwell: share code with [prove_equals_tagged_immediates], above *)
-    | Naked_immediate (Ok (Is_int scrutinee_ty)) -> begin
+    | Naked_immediate (Ok (Is_int scrutinee_ty)) -> (
       match Provers.prove_is_int env scrutinee_ty with
       | Proved true -> Simple Simple.untagged_const_true
       | Proved false -> Simple Simple.untagged_const_false
       | Unknown -> try_canonical_simple ()
-      | Invalid -> Invalid
-    end
-    | Naked_immediate (Ok (Get_tag block_ty)) -> begin
+      | Invalid -> Invalid)
+    | Naked_immediate (Ok (Get_tag block_ty)) -> (
       match Provers.prove_tags_must_be_a_block env block_ty with
       | Proved tags -> (
         let is =
@@ -306,66 +299,57 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
         | None -> try_canonical_simple ()
         | Some i -> Simple (Simple.const (Reg_width_const.naked_immediate i)))
       | Unknown -> try_canonical_simple ()
-      | Invalid -> Invalid
-    end
-    | Naked_float (Ok fs) -> begin
+      | Invalid -> Invalid)
+    | Naked_float (Ok fs) -> (
       match Float.Set.get_singleton fs with
       | None -> try_canonical_simple ()
-      | Some f -> Simple (Simple.const (Reg_width_const.naked_float f))
-    end
-    | Naked_int32 (Ok ns) -> begin
+      | Some f -> Simple (Simple.const (Reg_width_const.naked_float f)))
+    | Naked_int32 (Ok ns) -> (
       match Int32.Set.get_singleton ns with
       | None -> try_canonical_simple ()
-      | Some n -> Simple (Simple.const (Reg_width_const.naked_int32 n))
-    end
-    | Naked_int64 (Ok ns) -> begin
+      | Some n -> Simple (Simple.const (Reg_width_const.naked_int32 n)))
+    | Naked_int64 (Ok ns) -> (
       match Int64.Set.get_singleton ns with
       | None -> try_canonical_simple ()
-      | Some n -> Simple (Simple.const (Reg_width_const.naked_int64 n))
-    end
-    | Naked_nativeint (Ok ns) -> begin
+      | Some n -> Simple (Simple.const (Reg_width_const.naked_int64 n)))
+    | Naked_nativeint (Ok ns) -> (
       match Targetint_32_64.Set.get_singleton ns with
       | None -> try_canonical_simple ()
-      | Some n -> Simple (Simple.const (Reg_width_const.naked_nativeint n))
-    end
+      | Some n -> Simple (Simple.const (Reg_width_const.naked_nativeint n)))
     (* CR-someday mshinwell: These could lift at toplevel when [ty_naked_float]
        is an alias type. That would require checking the alloc mode. *)
-    | Value (Ok (Boxed_float (ty_naked_float, _alloc_mode))) -> begin
+    | Value (Ok (Boxed_float (ty_naked_float, _alloc_mode))) -> (
       match Provers.prove_naked_floats env ty_naked_float with
       | Unknown -> try_canonical_simple ()
       | Invalid -> Invalid
       | Proved fs -> (
         match Float.Set.get_singleton fs with
         | None -> try_canonical_simple ()
-        | Some f -> Lift (Boxed_float f))
-    end
-    | Value (Ok (Boxed_int32 (ty_naked_int32, _alloc_mode))) -> begin
+        | Some f -> Lift (Boxed_float f)))
+    | Value (Ok (Boxed_int32 (ty_naked_int32, _alloc_mode))) -> (
       match Provers.prove_naked_int32s env ty_naked_int32 with
       | Unknown -> try_canonical_simple ()
       | Invalid -> Invalid
       | Proved ns -> (
         match Int32.Set.get_singleton ns with
         | None -> try_canonical_simple ()
-        | Some n -> Lift (Boxed_int32 n))
-    end
-    | Value (Ok (Boxed_int64 (ty_naked_int64, _alloc_mode))) -> begin
+        | Some n -> Lift (Boxed_int32 n)))
+    | Value (Ok (Boxed_int64 (ty_naked_int64, _alloc_mode))) -> (
       match Provers.prove_naked_int64s env ty_naked_int64 with
       | Unknown -> try_canonical_simple ()
       | Invalid -> Invalid
       | Proved ns -> (
         match Int64.Set.get_singleton ns with
         | None -> try_canonical_simple ()
-        | Some n -> Lift (Boxed_int64 n))
-    end
-    | Value (Ok (Boxed_nativeint (ty_naked_nativeint, _alloc_mode))) -> begin
+        | Some n -> Lift (Boxed_int64 n)))
+    | Value (Ok (Boxed_nativeint (ty_naked_nativeint, _alloc_mode))) -> (
       match Provers.prove_naked_nativeints env ty_naked_nativeint with
       | Unknown -> try_canonical_simple ()
       | Invalid -> Invalid
       | Proved ns -> (
         match Targetint_32_64.Set.get_singleton ns with
         | None -> try_canonical_simple ()
-        | Some n -> Lift (Boxed_nativeint n))
-    end
+        | Some n -> Lift (Boxed_nativeint n)))
     | Value (Ok (Array { length; element_kind = _ })) -> (
       match Provers.prove_equals_single_tagged_immediate env length with
       | Proved length ->


### PR DESCRIPTION
This makes ocamlformat always use parens for grouping, avoiding the mix of parens and `begin`/`end` which we have at the moment.  The code is more compact as a result.