### PR TITLE
Fix ocamlformat

### DIFF
--- a/backend/.ocamlformat
+++ b/backend/.ocamlformat
@@ -6,7 +6,6 @@ assignment-operator=begin-line
 cases-exp-indent=2
 doc-comments=before
 dock-collection-brackets=false
-exp-grouping=preserve
 if-then-else=keyword-first
 parens-tuple=multi-line-only
 space-around-lists=false

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -123,10 +123,9 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     let first_occurrence =
       if List.mem section !sections_seen
       then false
-      else begin
+      else (
         sections_seen := section :: !sections_seen;
-        true
-      end
+        true)
     in
     match !current_dwarf_section_ref with
     | Some section' when Asm_section.equal section section' ->

--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -69,13 +69,12 @@ let escape name =
 let symbol_prefix () =
   (* CR mshinwell: needs checking *)
   match Target_system.architecture () with
-  | IA32 | X86_64 | AArch64 -> begin
+  | IA32 | X86_64 | AArch64 -> (
     match Target_system.derived_system () with
     | Linux | Win32 | Win64 | MinGW_32 | MinGW_64 | Cygwin | FreeBSD | NetBSD
     | OpenBSD | Generic_BSD | Solaris | BeOS | GNU | Dragonfly | Unknown ->
       "" (* checked ok. *)
-    | MacOS_like -> "_" (* checked ok. *)
-  end
+    | MacOS_like -> "_" (* checked ok. *))
   | ARM | POWER | Z | Riscv -> ""
 
 let to_escaped_string ?suffix ~symbol_prefix t =

--- a/backend/cfg/cfg_dataflow.ml
+++ b/backend/cfg/cfg_dataflow.ml
@@ -118,15 +118,14 @@ module Forward
             in
             let new_value = D.join old_value value in
             if not (D.compare new_value old_value <= 0)
-            then begin
+            then (
               Label.Tbl.replace res successor_label new_value;
               work_set
                 := WorkSet.add
                      { WorkSetElement.label = successor_label;
                        value = new_value
                      }
-                     !work_set
-            end)
+                     !work_set))
           (Cfg.successor_labels ~normal ~exn block)
       in
       update ~normal:true ~exn:false normal;
@@ -280,7 +279,7 @@ module Backward
       in
       let value = transfer_block instr_map element.value ~exn block in
       if block.is_trap_handler
-      then begin
+      then (
         let old_value =
           Option.value
             (Label.Tbl.find_opt handler_map block.start)
@@ -288,7 +287,7 @@ module Backward
         in
         let new_value = T.exception_ value in
         if not (D.less_equal new_value old_value)
-        then begin
+        then (
           Label.Tbl.replace handler_map block.start new_value;
           List.iter
             (fun predecessor_label ->
@@ -303,9 +302,7 @@ module Backward
                        value = current_value
                      }
                      !work_set)
-            (Cfg.predecessor_labels block)
-        end
-      end
+            (Cfg.predecessor_labels block)))
       else
         List.iter
           (fun predecessor_label ->
@@ -316,18 +313,17 @@ module Backward
             in
             let new_value = D.join old_value value in
             if not (D.less_equal new_value old_value)
-            then begin
+            then (
               Label.Tbl.replace res_block predecessor_label new_value;
               let already_in_workset = ref false in
               work_set
                 := WorkSet.filter
                      (fun { WorkSetElement.label; value } ->
                        if Label.equal label predecessor_label
-                       then begin
+                       then (
                          if D.less_equal new_value value
                          then already_in_workset := true;
-                         not (D.less_equal value new_value)
-                       end
+                         not (D.less_equal value new_value))
                        else true)
                      !work_set;
               if not !already_in_workset
@@ -337,8 +333,7 @@ module Backward
                        { WorkSetElement.label = predecessor_label;
                          value = new_value
                        }
-                       !work_set
-            end)
+                       !work_set))
           (Cfg.predecessor_labels block)
     done;
     let return x =

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -605,15 +605,14 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
       let desc = to_basic mop in
       block.body <- create_instruction t desc i ~stack_offset :: block.body;
       if Mach.operation_can_raise mop
-      then begin
+      then (
         (* Instruction that can raise is always at the end of a block. *)
         record_exn t block traps;
         let fallthrough = get_or_make_label t i.next in
         let desc : Cfg.terminator = Always fallthrough.label in
         let i_no_reg = { i with arg = [||]; res = [||]; fdo = Fdo_info.none } in
         add_terminator t block i_no_reg desc ~stack_offset ~traps;
-        create_blocks t fallthrough.insn block ~stack_offset ~traps
-      end
+        create_blocks t fallthrough.insn block ~stack_offset ~traps)
       else create_blocks t i.next block ~stack_offset ~traps)
 
 let run (f : Linear.fundecl) ~preserve_orig_labels =

--- a/backend/cfg/merge_straightline_blocks.ml
+++ b/backend/cfg/merge_straightline_blocks.ml
@@ -66,7 +66,7 @@ let rec merge_blocks (modified : bool) (cfg_with_layout : Cfg_with_layout.t) :
              && List.compare_length_with b2_predecessors 1 = 0
              && Cfg.is_pure_terminator b1_block.terminator.desc
              && not b1_block.can_raise
-          then begin
+          then (
             assert (Label.equal b1_label (List.hd b2_predecessors));
             (* modify b1 *)
             b1_block.body <- b1_block.body @ b2_block.body;
@@ -85,8 +85,7 @@ let rec merge_blocks (modified : bool) (cfg_with_layout : Cfg_with_layout.t) :
             b2_block.terminator
               <- { b2_block.terminator with desc = Cfg_intf.S.Never };
             b2_block.exn <- None;
-            true
-          end
+            true)
           else merged
         | _ -> merged)
       cfg.blocks false

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -300,7 +300,7 @@ let mk_if_then_else dbg value_kind cond ifso_dbg ifso ifnot_dbg ifnot =
 let mk_not dbg cmm =
   match cmm with
   | Cop (Caddi, [Cop (Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], dbg')
-    -> begin
+    -> (
     match c with
     | Cop (Ccmpi cmp, [c1; c2], dbg'') ->
       tag_int
@@ -317,8 +317,7 @@ let mk_not dbg cmm =
       Cop
         ( Csubi,
           [Cconst_int (3, dbg); Cop (Clsl, [c; Cconst_int (1, dbg)], dbg)],
-          dbg )
-  end
+          dbg ))
   | Cconst_int (3, _) -> Cconst_int (1, dbg)
   | Cconst_int (1, _) -> Cconst_int (3, dbg)
   | c ->
@@ -654,11 +653,10 @@ let unbox_float dbg =
     | Cop (Calloc _, [Cconst_natint (hdr, _); c], _)
       when Nativeint.equal hdr float_header ->
       c
-    | Cconst_symbol (s, _dbg) as cmm -> begin
+    | Cconst_symbol (s, _dbg) as cmm -> (
       match Cmmgen_state.structured_constant_of_sym s with
       | Some (Uconst_float x) -> Cconst_float (x, dbg) (* or keep _dbg? *)
-      | _ -> Cop (Cload (Double, Immutable), [cmm], dbg)
-    end
+      | _ -> Cop (Cload (Double, Immutable), [cmm], dbg))
     | cmm -> Cop (Cload (Double, Immutable), [cmm], dbg))
 
 (* Complex *)
@@ -1333,7 +1331,7 @@ let unbox_int dbg bi =
     | Cop (Calloc _, [hdr; ops; contents], _dbg)
       when alloc_matches_boxed_int bi ~hdr ~ops ->
       contents
-    | Cconst_symbol (s, _dbg) as cmm -> begin
+    | Cconst_symbol (s, _dbg) as cmm -> (
       match Cmmgen_state.structured_constant_of_sym s, bi with
       | Some (Uconst_nativeint n), Primitive.Pnativeint ->
         natint_const_untagged dbg n
@@ -1352,8 +1350,7 @@ let unbox_int dbg bi =
           else
             Ctuple
               [natint_const_untagged dbg low; natint_const_untagged dbg high]
-      | _ -> default cmm
-    end
+      | _ -> default cmm)
     | cmm -> default cmm)
 
 let make_unsigned_int bi arg dbg =
@@ -1972,11 +1969,9 @@ let transl_int_switch dbg value_kind arg low high cases default =
           (* pact <> 0 *)
           (plow, phigh, pact)
           ::
-          begin
-            if act = 0
-            then inters (phigh + 1) i 0 rem
-            else (phigh + 1, i - 1, 0) :: inters i i act rem
-          end
+          (if act = 0
+          then inters (phigh + 1) i 0 rem
+          else (phigh + 1, i - 1, 0) :: inters i i act rem)
     in
     let inters =
       match cases with
@@ -2000,12 +1995,11 @@ let transl_switch_clambda loc value_kind arg index cases =
     let act = index.(i) in
     if act = !this_act
     then decr this_low
-    else begin
+    else (
       inters := (!this_low, !this_high, !this_act) :: !inters;
       this_high := i;
       this_low := i;
-      this_act := act
-    end
+      this_act := act)
   done;
   inters := (0, !this_high, !this_act) :: !inters;
   match !inters with

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -369,13 +369,12 @@ and join branches ~avail_before =
 
 let fundecl (f : M.fundecl) =
   if !Clflags.debug && !Clflags.debug_runavail
-  then begin
+  then (
     assert (Hashtbl.length avail_at_exit = 0);
     avail_at_raise := RAS.Unreachable;
 
     current_trap_stack := M.Uncaught;
     let fun_args = R.set_of_array f.fun_args in
     let avail_before = RAS.Ok (RD.Set.without_debug_info fun_args) in
-    ignore (available_regs f.fun_body ~avail_before : RAS.t)
-  end;
+    ignore (available_regs f.fun_body ~avail_before : RAS.t));
   f

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -80,22 +80,20 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
     let add_subrange t ~subrange =
       let start_pos = Subrange.start_pos subrange in
       let start_pos_offset = Subrange.start_pos_offset subrange in
-      begin
-        match t.min_pos_and_offset with
-        | None -> t.min_pos_and_offset <- Some (start_pos, start_pos_offset)
-        | Some (min_pos, min_pos_offset) ->
-          (* This may seem dubious, but is correct by virtue of the way label
-             counters are allocated sequentially and the fact that, below, we go
-             through the code from lowest (code) address to highest. As such the
-             label with the highest integer value should be the one with the
-             highest address, and vice-versa. (Note that we also exploit the
-             ordering when constructing DWARF-4 location lists, to ensure that
-             they are sorted in increasing program counter order by start
-             address.) *)
-          let c = compare start_pos min_pos in
-          if c < 0 || (c = 0 && start_pos_offset < min_pos_offset)
-          then t.min_pos_and_offset <- Some (start_pos, start_pos_offset)
-      end;
+      (match t.min_pos_and_offset with
+      | None -> t.min_pos_and_offset <- Some (start_pos, start_pos_offset)
+      | Some (min_pos, min_pos_offset) ->
+        (* This may seem dubious, but is correct by virtue of the way label
+           counters are allocated sequentially and the fact that, below, we go
+           through the code from lowest (code) address to highest. As such the
+           label with the highest integer value should be the one with the
+           highest address, and vice-versa. (Note that we also exploit the
+           ordering when constructing DWARF-4 location lists, to ensure that
+           they are sorted in increasing program counter order by start
+           address.) *)
+        let c = compare start_pos min_pos in
+        if c < 0 || (c = 0 && start_pos_offset < min_pos_offset)
+        then t.min_pos_and_offset <- Some (start_pos, start_pos_offset));
       t.subranges <- subrange :: t.subranges
 
     let estimate_lowest_address t =

--- a/backend/debug/dwarf/dwarf_high/proto_die.ml
+++ b/backend/debug/dwarf/dwarf_high/proto_die.ml
@@ -49,13 +49,11 @@ let attribute_values_map attribute_values =
 
 let create ?reference ?(sort_priority = -1) ?location_list_in_debug_loc_table
     ~parent ~tag ~attribute_values () =
-  begin
-    match parent with
-    | None ->
-      if tag <> Dwarf_tag.Compile_unit
-      then failwith "only compilation unit proto-DIEs may be without parents"
-    | Some _parent -> ()
-  end;
+  (match parent with
+  | None ->
+    if tag <> Dwarf_tag.Compile_unit
+    then failwith "only compilation unit proto-DIEs may be without parents"
+  | Some _parent -> ());
   let reference =
     match reference with
     | None -> Asm_label.create (DWARF Debug_info)
@@ -72,20 +70,18 @@ let create ?reference ?(sort_priority = -1) ?location_list_in_debug_loc_table
       location_list_in_debug_loc_table
     }
   in
-  begin
-    match parent with
-    | None -> ()
-    | Some parent ->
-      let with_same_sort_priority =
-        match Int.Map.find sort_priority parent.children_by_sort_priority with
-        | exception Not_found -> []
-        | children -> children
-      in
-      let with_same_sort_priority = t :: with_same_sort_priority in
-      parent.children_by_sort_priority
-        <- Int.Map.add sort_priority with_same_sort_priority
-             parent.children_by_sort_priority
-  end;
+  (match parent with
+  | None -> ()
+  | Some parent ->
+    let with_same_sort_priority =
+      match Int.Map.find sort_priority parent.children_by_sort_priority with
+      | exception Not_found -> []
+      | children -> children
+    in
+    let with_same_sort_priority = t :: with_same_sort_priority in
+    parent.children_by_sort_priority
+      <- Int.Map.add sort_priority with_same_sort_priority
+           parent.children_by_sort_priority);
   t
 
 let create_ignore ?reference ?sort_priority ?location_list_in_debug_loc_table

--- a/backend/debug/dwarf/dwarf_low/debug_info_section.ml
+++ b/backend/debug/dwarf/dwarf_low/debug_info_section.ml
@@ -76,16 +76,14 @@ let emit ~asm_directives t =
   A.define_label t.compilation_unit_header_label;
   Initial_length.emit ~asm_directives initial_length;
   Dwarf_version.emit ~asm_directives (dwarf_version ());
-  begin
-    match dwarf_version () with
-    | Four ->
-      Dwarf_value.emit ~asm_directives (debug_abbrev_offset t);
-      Dwarf_value.emit ~asm_directives address_width_in_bytes_on_target
-    | Five ->
-      Unit_type.emit ~asm_directives unit_type;
-      Dwarf_value.emit ~asm_directives address_width_in_bytes_on_target;
-      Dwarf_value.emit ~asm_directives (debug_abbrev_offset t)
-  end;
+  (match dwarf_version () with
+  | Four ->
+    Dwarf_value.emit ~asm_directives (debug_abbrev_offset t);
+    Dwarf_value.emit ~asm_directives address_width_in_bytes_on_target
+  | Five ->
+    Unit_type.emit ~asm_directives unit_type;
+    Dwarf_value.emit ~asm_directives address_width_in_bytes_on_target;
+    Dwarf_value.emit ~asm_directives (debug_abbrev_offset t));
   A.new_line ();
   A.comment "Debugging information entries:";
   A.new_line ();

--- a/backend/debug/dwarf/dwarf_low/debugging_information_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/debugging_information_entry.ml
@@ -45,23 +45,20 @@ let emit ~asm_directives t =
      need to point at the null DIE from anywhere else, so we elide emission of
      the label altogether. *)
   if not (Abbreviation_code.is_null t.abbreviation_code)
-  then begin
-    begin
-      match t.name with
-      | None -> ()
-      | Some symbol ->
-        A.define_data_symbol symbol
-        (* CR-someday poechsel: Understand what is going wrong when linking
-           large executables with global DWARF symbols. We don't need to export
-           them globally right now as we never cross-reference DIEs between
-           files but we will need to do it eventually (to reference the abstract
-           DIE for a function being inlined for instance). There should also be
-           a way to make these symbols not end up in the dynamic symbol table.
+  then (
+    (match t.name with
+    | None -> ()
+    | Some symbol ->
+      A.define_data_symbol symbol
+      (* CR-someday poechsel: Understand what is going wrong when linking large
+         executables with global DWARF symbols. We don't need to export them
+         globally right now as we never cross-reference DIEs between files but
+         we will need to do it eventually (to reference the abstract DIE for a
+         function being inlined for instance). There should also be a way to
+         make these symbols not end up in the dynamic symbol table.
 
-           A.global symbol *)
-    end;
-    A.define_label t.label
-  end;
+         A.global symbol *));
+    A.define_label t.label);
   Abbreviation_code.emit ~asm_directives t.abbreviation_code;
   ASS.Map.iter (fun _spec av -> AV.emit ~asm_directives av) t.attribute_values
 

--- a/backend/debug/dwarf/dwarf_low/dwarf_int.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_int.ml
@@ -81,12 +81,10 @@ let to_uint64_exn t =
   | Sixty_four t -> Uint64.of_nonnegative_int64_exn t
 
 let add t1 t2 =
-  begin
-    match t1, t2 with
-    | Thirty_two _, Thirty_two _ | Sixty_four _, Sixty_four _ -> ()
-    | Thirty_two _, Sixty_four _ | Sixty_four _, Thirty_two _ ->
-      Misc.fatal_error "Cannot intermix sizes of [Dwarf_int]s"
-  end;
+  (match t1, t2 with
+  | Thirty_two _, Thirty_two _ | Sixty_four _, Sixty_four _ -> ()
+  | Thirty_two _, Sixty_four _ | Sixty_four _, Thirty_two _ ->
+    Misc.fatal_error "Cannot intermix sizes of [Dwarf_int]s");
   let t1 = to_int64 t1 in
   let t2 = to_int64 t2 in
   of_int64_exn (Int64.add t1 t2)

--- a/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
@@ -642,7 +642,7 @@ struct
       value
         (V.distance_between_labels_32_bit ~comment:"call4 target" ~upper:label
            ~lower:compilation_unit_header_label ())
-    | DW_op_call_ref { label; compilation_unit_header_label } -> begin
+    | DW_op_call_ref { label; compilation_unit_header_label } -> (
       match Dwarf_format.get () with
       | Thirty_two ->
         value
@@ -651,8 +651,7 @@ struct
       | Sixty_four ->
         value
           (V.distance_between_labels_64_bit ~comment:"call_ref target"
-             ~upper:label ~lower:compilation_unit_header_label ())
-    end
+             ~upper:label ~lower:compilation_unit_header_label ()))
     | DW_op_nop | DW_op_reg0 | DW_op_reg1 | DW_op_reg2 | DW_op_reg3 | DW_op_reg4
     | DW_op_reg5 | DW_op_reg6 | DW_op_reg7 | DW_op_reg8 | DW_op_reg9
     | DW_op_reg10 | DW_op_reg11 | DW_op_reg12 | DW_op_reg13 | DW_op_reg14

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.ml
@@ -273,12 +273,11 @@ let size { value; comment = _ } =
   | Sleb128 i -> sleb128_size i
   | Absolute_address _ | Code_address_from_label _ | Code_address_from_symbol _
   | Code_address_from_label_symbol_diff _ | Code_address_from_symbol_diff _
-  | Code_address_from_symbol_plus_bytes _ -> begin
+  | Code_address_from_symbol_plus_bytes _ -> (
     match Targetint.size with
     | 32 -> Dwarf_int.four ()
     | 64 -> Dwarf_int.eight ()
-    | bits -> Misc.fatal_errorf "Unsupported Targetint.size %d" bits
-  end
+    | bits -> Misc.fatal_errorf "Unsupported Targetint.size %d" bits)
   | String str ->
     Dwarf_int.of_targetint_exn (Targetint.of_int (String.length str + 1))
   | Indirect_string _ | Offset_into_debug_line _
@@ -296,12 +295,11 @@ let emit ~asm_directives { value; comment } =
   let module A = (val asm_directives : Asm_directives.S) in
   let width_for_ref_addr_or_sec_offset = !Dwarf_flags.gdwarf_format in
   match value with
-  | Flag_true -> begin
+  | Flag_true -> (
     (* See DWARF-4 specification p.148 *)
     match comment with
     | None -> ()
-    | Some comment -> A.comment (comment ^ " (Flag_true elided)")
-  end
+    | Some comment -> A.comment (comment ^ " (Flag_true elided)"))
   | Bool b -> A.int8 ?comment (if b then Int8.one else Int8.zero)
   | Int8 i -> A.int8 ?comment i
   | Int16 i -> A.int16 ?comment i

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_entry.ml
@@ -161,47 +161,44 @@ struct
       else None
     in
     A.int8 ?comment (Int8.of_int_exn (P.code_for_entry_kind t.entry));
-    begin
-      match t.entry with
-      | End_of_list -> ()
-      | Base_addressx addr_index ->
-        Address_index.emit ~asm_directives ~comment:"base address" addr_index
-      | Startx_endx { start_inclusive; end_exclusive; payload } ->
-        Address_index.emit ~asm_directives ~comment:"start_inclusive"
-          start_inclusive;
-        Address_index.emit ~asm_directives ~comment:"end_exclusive"
-          end_exclusive;
-        Payload.emit ~asm_directives payload
-      | Startx_length { start_inclusive; length; payload } ->
-        Address_index.emit ~asm_directives ~comment:"start_inclusive"
-          start_inclusive;
-        A.targetint ~comment:"length" length;
-        Payload.emit ~asm_directives payload
-      | Offset_pair { start_offset_inclusive; end_offset_exclusive; payload } ->
-        Dwarf_value.emit ~asm_directives
-          (Dwarf_value.sleb128 ~comment:"start_offset_inclusive"
-             (Targetint.to_int64 start_offset_inclusive));
-        Dwarf_value.emit ~asm_directives
-          (Dwarf_value.sleb128 ~comment:"end_offset_exclusive"
-             (Targetint.to_int64 end_offset_exclusive));
-        Payload.emit ~asm_directives payload
-      | Base_address sym -> A.symbol sym
-      | Start_end { start_inclusive; end_exclusive; end_adjustment; payload } ->
-        Dwarf_value.emit ~asm_directives
-          (label_address ~comment:"start_inclusive" t start_inclusive
-             ~adjustment:0);
-        Dwarf_value.emit ~asm_directives
-          (label_address ~comment:"end_exclusive" t end_exclusive
-             ~adjustment:end_adjustment);
-        Payload.emit ~asm_directives payload
-      | Start_length { start_inclusive; length; payload } ->
-        Dwarf_value.emit ~asm_directives
-          (label_address ~comment:"start_inclusive" t start_inclusive
-             ~adjustment:0);
-        Dwarf_value.emit ~asm_directives
-          (Dwarf_value.uleb128 ~comment:"length"
-             (Targetint.nonnegative_to_uint64_exn length));
-        Payload.emit ~asm_directives payload
-    end;
+    (match t.entry with
+    | End_of_list -> ()
+    | Base_addressx addr_index ->
+      Address_index.emit ~asm_directives ~comment:"base address" addr_index
+    | Startx_endx { start_inclusive; end_exclusive; payload } ->
+      Address_index.emit ~asm_directives ~comment:"start_inclusive"
+        start_inclusive;
+      Address_index.emit ~asm_directives ~comment:"end_exclusive" end_exclusive;
+      Payload.emit ~asm_directives payload
+    | Startx_length { start_inclusive; length; payload } ->
+      Address_index.emit ~asm_directives ~comment:"start_inclusive"
+        start_inclusive;
+      A.targetint ~comment:"length" length;
+      Payload.emit ~asm_directives payload
+    | Offset_pair { start_offset_inclusive; end_offset_exclusive; payload } ->
+      Dwarf_value.emit ~asm_directives
+        (Dwarf_value.sleb128 ~comment:"start_offset_inclusive"
+           (Targetint.to_int64 start_offset_inclusive));
+      Dwarf_value.emit ~asm_directives
+        (Dwarf_value.sleb128 ~comment:"end_offset_exclusive"
+           (Targetint.to_int64 end_offset_exclusive));
+      Payload.emit ~asm_directives payload
+    | Base_address sym -> A.symbol sym
+    | Start_end { start_inclusive; end_exclusive; end_adjustment; payload } ->
+      Dwarf_value.emit ~asm_directives
+        (label_address ~comment:"start_inclusive" t start_inclusive
+           ~adjustment:0);
+      Dwarf_value.emit ~asm_directives
+        (label_address ~comment:"end_exclusive" t end_exclusive
+           ~adjustment:end_adjustment);
+      Payload.emit ~asm_directives payload
+    | Start_length { start_inclusive; length; payload } ->
+      Dwarf_value.emit ~asm_directives
+        (label_address ~comment:"start_inclusive" t start_inclusive
+           ~adjustment:0);
+      Dwarf_value.emit ~asm_directives
+        (Dwarf_value.uleb128 ~comment:"length"
+           (Targetint.nonnegative_to_uint64_exn length));
+      Payload.emit ~asm_directives payload);
     if !Clflags.keep_asm_file then A.new_line ()
 end

--- a/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
+++ b/backend/debug/dwarf/dwarf_low/location_or_range_list_table.ml
@@ -117,7 +117,7 @@ struct
     A.comment "Base label:";
     A.define_label t.base_addr;
     if offset_array_supported ()
-    then begin
+    then (
       A.comment "Offset array:";
       let offset_array_size = offset_array_size t in
       List.iteri
@@ -129,8 +129,7 @@ struct
             else None
           in
           Dwarf_int.emit ~asm_directives ?comment offset)
-        t.lists
-    end;
+        t.lists);
     A.comment "Range or location list(s):";
     List.iter
       (fun { list; label; _ } ->

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -31,11 +31,10 @@ type t =
 
 let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_begin
     ~code_end =
-  begin
-    match !Dwarf_flags.gdwarf_format with
-    | Thirty_two -> Dwarf_format.set Thirty_two
-    | Sixty_four -> Dwarf_format.set Sixty_four
-  end;
+  (match !Dwarf_flags.gdwarf_format with
+  | Thirty_two -> Dwarf_format.set Thirty_two
+  | Sixty_four -> Dwarf_format.set Sixty_four);
+
   let compilation_unit_proto_die =
     Dwarf_compilation_unit.compile_unit_proto_die ~sourcefile ~unit_name
       ~code_begin ~code_end

--- a/middle_end/.ocamlformat
+++ b/middle_end/.ocamlformat
@@ -1,5 +1,7 @@
 # Please make a pull request to change this file.
-# Keep this file in sync with other .ocamlformat files in this repo.
+disable=true
+# There is an .ocamlformat-enable file in this directory.
+# Keep the remainder of this file in sync with other .ocamlformat files in this repo.
 assignment-operator=begin-line
 cases-exp-indent=2
 doc-comments=before

--- a/middle_end/.ocamlformat-enable
+++ b/middle_end/.ocamlformat-enable
@@ -1,0 +1,4 @@
+mangling.ml
+mangling.mli
+flambda2/**/*.ml
+flambda2/**/*.mli


### PR DESCRIPTION
- Add .ocamlformat-enable in middle_end directory, because only flambda2 subdirectory and `mangling.ml{,i}` are currently formatted. This is convenient in the editor with format on save.
- Synchronize .ocamlformat in backend to the change in #689 to always use parenthesis.
- Automatically generated reformatting of backend.
