### PR TITLE
Install an ocamldoc binary

### DIFF
--- a/ocaml/ocamldoc/dune
+++ b/ocaml/ocamldoc/dune
@@ -99,6 +99,7 @@
 (install
   (files
 ;    (odoc_byte.bc as ocamldoc.byte)
+    (odoc_native.exe as ocamldoc)
     (odoc_native.exe as ocamldoc.opt))
   (section bin)
   (package ocaml))


### PR DESCRIPTION
In combination with https://github.com/ocaml-flambda/flambda2-opam/pull/11, this should (hopefully) restore the opam CI.