### PR TITLE
Add low/high PC ranges to compilation unit DIEs

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -435,11 +435,18 @@ let build_dwarf ~asm_directives:(module Asm_directives : Asm_targets.Asm_directi
   let unit_name =
     Compilation_unit.get_persistent_ident (Compilation_unit.get_current_exn ())
   in
+  let code_begin =
+    Compilenv.make_symbol (Some "code_begin") |> Asm_targets.Asm_symbol.create
+  in
+  let code_end =
+    Compilenv.make_symbol (Some "code_end") |> Asm_targets.Asm_symbol.create
+  in
   Dwarf.create
     ~sourcefile
     ~unit_name
     ~asm_directives:(module Asm_directives)
     ~get_file_id:(Emitaux.get_file_num ~file_emitter:X86_dsl.D.file)
+    ~code_begin ~code_end
 
 let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
     module Asm_targets.Asm_directives.Make(struct

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -29,7 +29,8 @@ type t =
 (* CR mshinwell: On OS X 10.11 (El Capitan), dwarfdump doesn't seem to be able
    to read our 64-bit DWARF output. *)
 
-let create ~sourcefile ~unit_name ~asm_directives ~get_file_id =
+let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_begin
+    ~code_end =
   begin
     match !Dwarf_flags.gdwarf_format with
     | Thirty_two -> Dwarf_format.set Thirty_two
@@ -37,6 +38,7 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id =
   end;
   let compilation_unit_proto_die =
     Dwarf_compilation_unit.compile_unit_proto_die ~sourcefile ~unit_name
+      ~code_begin ~code_end
   in
   let compilation_unit_header_label = Asm_label.create (DWARF Debug_info) in
   let state =

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
@@ -28,6 +28,8 @@ val create :
   unit_name:Ident.t ->
   asm_directives:(module Asm_directives.S) ->
   get_file_id:(string -> int) ->
+  code_begin:Asm_symbol.t ->
+  code_end:Asm_symbol.t ->
   t
 
 val dwarf_for_fundecl : t -> Dwarf_concrete_instances.fundecl -> unit

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.ml
@@ -18,7 +18,7 @@ open Asm_targets
 open Dwarf_high
 module DAH = Dwarf_attribute_helpers
 
-let compile_unit_proto_die ~sourcefile ~unit_name =
+let compile_unit_proto_die ~sourcefile ~unit_name ~code_begin ~code_end =
   let source_filename =
     (* CR mshinwell: Think more about build reproducibility and what we should
        be putting here (and also in the compilation directory attribute). For
@@ -35,7 +35,8 @@ let compile_unit_proto_die ~sourcefile ~unit_name =
       DAH.create_ocaml_unit_name unit_name;
       DAH.create_ocaml_compiler_version Sys.ocaml_version;
       DAH.create_stmt_list
-        ~debug_line_label:(Asm_label.for_dwarf_section Asm_section.Debug_line)
-    ]
+        ~debug_line_label:(Asm_label.for_dwarf_section Asm_section.Debug_line);
+      DAH.create_low_pc_from_symbol code_begin;
+      DAH.create_high_pc_from_symbol ~low_pc:code_begin code_end ]
   in
   Proto_die.create ~parent:None ~tag:Compile_unit ~attribute_values ()

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_compilation_unit.mli
@@ -16,7 +16,12 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+open Asm_targets
 open Dwarf_high
 
 val compile_unit_proto_die :
-  sourcefile:string -> unit_name:Ident.t -> Proto_die.t
+  sourcefile:string ->
+  unit_name:Ident.t ->
+  code_begin:Asm_symbol.t ->
+  code_end:Asm_symbol.t ->
+  Proto_die.t


### PR DESCRIPTION
LLVM is expecting these to be present: https://github.com/llvm/llvm-project/commit/c3f30a7fc6a166910d4b674301e9108f537daf3c