### PR TITLE
Extend Pblock value kind to handle variants

### DIFF
--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -339,7 +339,7 @@ let join_unboxed_number_kind ~strict k1 k2 =
 
 let is_strict = function
   | Pfloatval | Pboxedintval _ -> false
-  | Pintval | Pgenval | Pblock _ | Parrayval _ -> true
+  | Pintval | Pgenval | Pvariant _ | Parrayval _ -> true
 
 let rec is_unboxed_number_cmm = function
     | Cop(Calloc mode, [Cconst_natint (hdr, _); _], dbg)
@@ -386,10 +386,10 @@ let rec is_unboxed_number_cmm = function
     | Cassign _
     | Ctuple _
     | Cop _ -> No_unboxing
-    | Cifthenelse (_, _, _, _, _, _, Vval (Pintval | Pblock _))
-    | Cswitch (_, _,  _, _, Vval (Pintval | Pblock _))
-    | Ctrywith (_, _, _, _, _, Vval (Pintval | Pblock _))
-    | Ccatch (_, _, _, Vval (Pintval | Pblock _)) ->
+    | Cifthenelse (_, _, _, _, _, _, Vval (Pintval | Pvariant _))
+    | Cswitch (_, _,  _, _, Vval (Pintval | Pvariant _))
+    | Ctrywith (_, _, _, _, _, Vval (Pintval | Pvariant _))
+    | Ccatch (_, _, _, Vval (Pintval | Pvariant _)) ->
       No_unboxing
     | Cifthenelse (_, _, a, _, b, _, Vval kind) ->
       join_unboxed_number_kind ~strict:(is_strict kind)

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -135,7 +135,10 @@ and array_kind = Lambda.array_kind =
 and value_kind = Lambda.value_kind =
   (* CR mshinwell: Pfloatval should be renamed to Pboxedfloatval *)
     Pgenval | Pfloatval | Pboxedintval of boxed_integer | Pintval
-  | Pblock of { tag : int; fields : value_kind list }
+  | Pvariant of {
+      consts : int list;
+      non_consts : (int * value_kind list) list;
+    }
   | Parrayval of array_kind
 
 and block_shape = Lambda.block_shape

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -138,7 +138,10 @@ and array_kind = Lambda.array_kind =
 and value_kind = Lambda.value_kind =
   (* CR mshinwell: Pfloatval should be renamed to Pboxedfloatval *)
     Pgenval | Pfloatval | Pboxedintval of boxed_integer | Pintval
-  | Pblock of { tag : int; fields : value_kind list }
+  | Pvariant of {
+      consts : int list;
+      non_consts : (int * value_kind list) list;
+    }
   | Parrayval of array_kind
 
 and block_shape = Lambda.block_shape

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -30,7 +30,7 @@ let convert_block_of_values_field (value_kind : L.value_kind) :
   | Pboxedintval Pint64 -> Boxed_int64
   | Pboxedintval Pnativeint -> Boxed_nativeint
   | Pintval -> Immediate
-  | Pblock _ | Parrayval _ -> Any_value
+  | Pvariant _ | Parrayval _ -> Any_value
 
 let convert_integer_comparison_prim (comp : L.integer_comparison) :
     P.binary_primitive =

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -276,9 +276,9 @@ module With_subkind = struct
       | Boxed_int64
       | Boxed_nativeint
       | Tagged_immediate
-      | Block of
-          { tag : Tag.t;
-            fields : t list
+      | Variant of
+          { consts : Targetint_31_63.Set.t;
+            non_consts : t list Tag.Scannable.Map.t
           }
       | Float_block of { num_fields : int }
       | Float_array
@@ -300,19 +300,34 @@ module With_subkind = struct
       | Value_array, Value_array
       | Generic_array, Generic_array ->
         true
-      | ( Block { tag = t1; fields = fields1 },
-          Block { tag = t2; fields = fields2 } ) ->
-        Tag.equal t1 t2
-        && List.length fields1 = List.length fields2
-        && List.for_all2
-             (fun d when_used_at -> compatible d ~when_used_at)
-             fields1 fields2
+      | ( Variant { consts = consts1; non_consts = non_consts1 },
+          Variant { consts = consts2; non_consts = non_consts2 } ) ->
+        if not (Targetint_31_63.Set.equal consts1 consts2)
+        then false
+        else
+          let tags1 = Tag.Scannable.Map.keys non_consts1 in
+          let tags2 = Tag.Scannable.Map.keys non_consts2 in
+          if not (Tag.Scannable.Set.equal tags1 tags2)
+          then false
+          else
+            let field_lists1 = Tag.Scannable.Map.data non_consts1 in
+            let field_lists2 = Tag.Scannable.Map.data non_consts2 in
+            assert (List.compare_lengths field_lists1 field_lists2 = 0);
+            List.for_all2
+              (fun fields1 fields2 ->
+                if List.compare_lengths fields1 fields2 <> 0
+                then false
+                else
+                  List.for_all2
+                    (fun d when_used_at -> compatible d ~when_used_at)
+                    fields1 fields2)
+              field_lists1 field_lists2
       | ( Float_block { num_fields = num_fields1 },
           Float_block { num_fields = num_fields2 } ) ->
         num_fields1 = num_fields2
       (* Subkinds of [Value] may always be used at [Value] (but not the
          converse): *)
-      | ( ( Block _ | Float_block _ | Float_array | Immediate_array
+      | ( ( Variant _ | Float_block _ | Float_array | Immediate_array
           | Value_array | Generic_array | Boxed_float | Boxed_int32
           | Boxed_int64 | Boxed_nativeint | Tagged_immediate ),
           Anything ) ->
@@ -324,7 +339,7 @@ module With_subkind = struct
         true
       (* All other combinations are incompatible: *)
       | ( ( Anything | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
-          | Tagged_immediate | Block _ | Float_block _ | Float_array
+          | Tagged_immediate | Variant _ | Float_block _ | Float_array
           | Immediate_array | Value_array | Generic_array ),
           _ ) ->
         false
@@ -335,7 +350,7 @@ module With_subkind = struct
       let rec print ppf t =
         let colour = Flambda_colours.subkind () in
         match t with
-        | Anything -> ()
+        | Anything -> Format.fprintf ppf "*"
         | Tagged_immediate ->
           Format.fprintf ppf "@<0>%s=tagged_@<1>\u{2115}@<1>\u{1d55a}@<0>%s"
             colour
@@ -356,10 +371,15 @@ module With_subkind = struct
           Format.fprintf ppf "@<0>%s=boxed_@<1>\u{2115}@<1>\u{2115}@<0>%s"
             colour
             (Flambda_colours.normal ())
-        | Block { tag; fields } ->
-          Format.fprintf ppf "@<0>%s=Block{%a: %a}@<0>%s" colour Tag.print tag
-            (Format.pp_print_list ~pp_sep:Format.pp_print_space print)
-            fields
+        | Variant { consts; non_consts } ->
+          Format.fprintf ppf
+            "@<0>%s=Variant((consts (%a))@ (non_consts (%a)))@<0>%s" colour
+            Targetint_31_63.Set.print consts
+            (Tag.Scannable.Map.print (fun ppf fields ->
+                 Format.fprintf ppf "[%a]"
+                   (Format.pp_print_list ~pp_sep:Format.pp_print_space print)
+                   fields))
+            non_consts
             (Flambda_colours.normal ())
         | Float_block { num_fields } ->
           Format.fprintf ppf "@<0>%s=Float_block(%d)@<0>%s" colour num_fields
@@ -399,7 +419,7 @@ module With_subkind = struct
       match subkind with
       | Anything -> ()
       | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
-      | Tagged_immediate | Block _ | Float_block _ | Float_array
+      | Tagged_immediate | Variant _ | Float_block _ | Float_array
       | Immediate_array | Value_array | Generic_array ->
         Misc.fatal_errorf "Subkind %a is not valid for kind %a" Subkind.print
           subkind print kind));
@@ -448,7 +468,14 @@ module With_subkind = struct
         "Block with fields of non-Value kind (use \
          [Flambda_kind.With_subkind.float_block] for float records)";
     let fields = List.map (fun t -> t.subkind) fields in
-    create value (Block { tag; fields })
+    match Tag.Scannable.of_tag tag with
+    | Some tag ->
+      create value
+        (Variant
+           { consts = Targetint_31_63.Set.empty;
+             non_consts = Tag.Scannable.Map.singleton tag fields
+           })
+    | None -> Misc.fatal_errorf "Tag %a is not scannable" Tag.print tag
 
   let float_block ~num_fields = create value (Float_block { num_fields })
 
@@ -468,12 +495,34 @@ module With_subkind = struct
     | Pboxedintval Pint64 -> boxed_int64
     | Pboxedintval Pnativeint -> boxed_nativeint
     | Pintval -> tagged_immediate
-    | Pblock { tag; fields } ->
-      (* If we have [Obj.double_array_tag] here, this is always an all-float
-         block, not an array. *)
-      if tag = Obj.double_array_tag
-      then float_block ~num_fields:(List.length fields)
-      else block (Tag.create_exn tag) (List.map from_lambda fields)
+    | Pvariant { consts; non_consts } -> (
+      match consts, non_consts with
+      | [], [] -> Misc.fatal_error "[Pvariant] with no constructors at all"
+      | [], [(tag, fields)] when tag = Obj.double_array_tag ->
+        (* If we have [Obj.double_array_tag] here, this is always an all-float
+           block, not an array. *)
+        float_block ~num_fields:(List.length fields)
+      | [], _ :: _ | _ :: _, [] | _ :: _, _ :: _ ->
+        let consts =
+          Targetint_31_63.Set.of_list
+            (List.map
+               (fun const ->
+                 Targetint_31_63.int (Targetint_31_63.Imm.of_int const))
+               consts)
+        in
+        let non_consts =
+          List.fold_left
+            (fun non_consts (tag, fields) ->
+              match Tag.Scannable.create tag with
+              | Some tag ->
+                Tag.Scannable.Map.add tag
+                  (List.map (fun vk -> subkind (from_lambda vk)) fields)
+                  non_consts
+              | None ->
+                Misc.fatal_errorf "Non-scannable tag %d in [Pvariant]" tag)
+            Tag.Scannable.Map.empty non_consts
+        in
+        create value (Variant { consts; non_consts }))
     | Parrayval Pfloatarray -> float_array
     | Parrayval Pintarray -> immediate_array
     | Parrayval Paddrarray -> value_array
@@ -489,7 +538,7 @@ module With_subkind = struct
         Format.fprintf ppf "@[%a%a@]" print kind Subkind.print subkind
       | ( (Naked_number _ | Region | Rec_info),
           ( Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
-          | Tagged_immediate | Block _ | Float_block _ | Float_array
+          | Tagged_immediate | Variant _ | Float_block _ | Float_array
           | Immediate_array | Value_array | Generic_array ) ) ->
         assert false
     (* see [create] *)
@@ -511,7 +560,9 @@ module With_subkind = struct
     match t.subkind with
     | Anything -> false
     | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
-    | Tagged_immediate | Block _ | Float_block _ | Float_array | Immediate_array
-    | Value_array | Generic_array ->
+    | Tagged_immediate | Variant _ | Float_block _ | Float_array
+    | Immediate_array | Value_array | Generic_array ->
       true
+
+  let erase_subkind t = { t with subkind = Anything }
 end

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -131,9 +131,9 @@ module With_subkind : sig
       | Boxed_int64
       | Boxed_nativeint
       | Tagged_immediate
-      | Block of
-          { tag : Tag.t;
-            fields : t list
+      | Variant of
+          { consts : Targetint_31_63.Set.t;
+            non_consts : t list Tag.Scannable.Map.t
           }
       | Float_block of { num_fields : int }
       | Float_array
@@ -197,6 +197,8 @@ module With_subkind : sig
   val from_lambda : Lambda.value_kind -> t
 
   val compatible : t -> when_used_at:t -> bool
+
+  val erase_subkind : t -> t
 
   include Container_types.S with type t := t
 end

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -142,7 +142,7 @@ let kind_with_subkind ppf (k : kind_with_subkind) =
   | Value -> (
     match Flambda_kind.With_subkind.subkind k with
     | Anything -> str "val"
-    | Block _ -> str "block" (* CR mshinwell: improve this *)
+    | Variant _ -> str "variant" (* CR mshinwell: improve this *)
     | Float_block _ -> str "float_block"
     | Boxed_float -> str "float boxed"
     | Boxed_int32 -> str "int32 boxed"

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -711,7 +711,7 @@ and transl_catch env nfail ids body handler dbg =
          let strict =
            match kind with
            | Pfloatval | Pboxedintval _ -> false
-           | Pintval | Pgenval | Pblock _ | Parrayval _ -> true
+           | Pintval | Pgenval | Pvariant _ | Parrayval _ -> true
          in
          u := join_unboxed_number_kind ~strict !u
              (is_unboxed_number_cmm ~strict c)
@@ -1179,7 +1179,7 @@ and transl_let env str kind id exp transl_body =
            we do it only if this indeed allows us to get rid of
            some allocations in the bound expression. *)
         is_unboxed_number_cmm ~strict:false cexp
-    | _, (Pgenval | Pblock _ | Parrayval _) ->
+    | _, (Pgenval | Pvariant _ | Parrayval _) ->
         (* Here we don't know statically that the bound expression
            evaluates to an unboxable number type.  We need to be stricter
            and ensure that all possible branches in the expression

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -193,7 +193,13 @@ and array_kind =
 
 and value_kind =
     Pgenval | Pfloatval | Pboxedintval of boxed_integer | Pintval
-  | Pblock of { tag : int; fields : value_kind list }
+  | Pvariant of {
+      consts : int list;
+      non_consts : (int * value_kind list) list;
+      (** [non_consts] must be non-empty.  For constant variants [Pintval]
+          must be used.  This causes a small loss of precision but it is not
+          expected to be significant. *)
+    }
   | Parrayval of array_kind
 
 and block_shape =

--- a/ocaml/lambda/printlambda.mli
+++ b/ocaml/lambda/printlambda.mli
@@ -24,6 +24,9 @@ val lambda: formatter -> lambda -> unit
 val program: formatter -> program -> unit
 val primitive: formatter -> primitive -> unit
 val name_of_primitive : primitive -> string
+val variant_kind : (formatter -> value_kind -> unit) ->
+  formatter -> consts:int list -> non_consts:(int * value_kind list) list ->
+  unit
 val value_kind : formatter -> value_kind -> unit
 val value_kind' : formatter -> value_kind -> unit
 val block_shape : formatter -> value_kind list option -> unit

--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -135,7 +135,7 @@ and array_kind = Lambda.array_kind =
 and value_kind = Lambda.value_kind =
   (* CR mshinwell: Pfloatval should be renamed to Pboxedfloatval *)
     Pgenval | Pfloatval | Pboxedintval of boxed_integer | Pintval
-  | Pblock of { tag : int; fields : value_kind list }
+  | Pvariant of { tag : int; fields : value_kind list }
   | Parrayval of array_kind
 
 and block_shape = Lambda.block_shape

--- a/ocaml/middle_end/clambda_primitives.mli
+++ b/ocaml/middle_end/clambda_primitives.mli
@@ -138,7 +138,7 @@ and array_kind = Lambda.array_kind =
 and value_kind = Lambda.value_kind =
   (* CR mshinwell: Pfloatval should be renamed to Pboxedfloatval *)
     Pgenval | Pfloatval | Pboxedintval of boxed_integer | Pintval
-  | Pblock of { tag : int; fields : value_kind list }
+  | Pvariant of { tag : int; fields : value_kind list }
   | Parrayval of array_kind
 
 and block_shape = Lambda.block_shape

--- a/ocaml/middle_end/printclambda.ml
+++ b/ocaml/middle_end/printclambda.ml
@@ -37,7 +37,7 @@ let value_kind =
   | Pboxedintval Pnativeint -> ":nativeint"
   | Pboxedintval Pint32 -> ":int32"
   | Pboxedintval Pint64 -> ":int64"
-  | Pblock { tag; fields } ->
+  | Pvariant { tag; fields } ->
     asprintf ":[%d: %a]" tag
       (Format.pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ",@ ")
          Printlambda.value_kind') fields

--- a/ocaml/testsuite/tests/basic-modules/anonymous.ocamlc.reference
+++ b/ocaml/testsuite/tests/basic-modules/anonymous.ocamlc.reference
@@ -1,5 +1,8 @@
 (setglobal Anonymous!
-  (seq (ignore (let (x =[0: [int], [int]] [0: 13 37]) (makeblock 0 x)))
+  (seq
+    (ignore
+      (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 13 37])
+        (makeblock 0 x)))
     (let
       (A =
          (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 25 6]
@@ -7,12 +10,16 @@
        B =
          (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 35 6]
            [0: [0]]))
-      (seq (ignore (let (x =[0: [int], [int]] [0: 4 2]) (makeblock 0 x)))
+      (seq
+        (ignore
+          (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 4 2])
+            (makeblock 0 x)))
         (apply (field 1 (global CamlinternalMod!)) [0: [0]] A
           (module-defn(A) Anonymous anonymous.ml(23):567-608 A))
         (apply (field 1 (global CamlinternalMod!)) [0: [0]] B
           (module-defn(B) Anonymous anonymous.ml(33):703-773
-            (let (x =[0: *, *] [0: "foo" "bar"]) (makeblock 0))))
+            (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
+              (makeblock 0))))
         (let (f = (function param : int 0) s = (makemutable 0 ""))
           (seq
             (ignore

--- a/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
+++ b/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
@@ -1,4 +1,7 @@
-(seq (ignore (let (x =[0: [int], [int]] [0: 13 37]) (makeblock 0 x)))
+(seq
+  (ignore
+    (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 13 37])
+      (makeblock 0 x)))
   (let
     (A =
        (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 25 6]
@@ -6,12 +9,16 @@
      B =
        (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 35 6]
          [0: [0]]))
-    (seq (ignore (let (x =[0: [int], [int]] [0: 4 2]) (makeblock 0 x)))
+    (seq
+      (ignore
+        (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 4 2])
+          (makeblock 0 x)))
       (apply (field 1 (global CamlinternalMod!)) [0: [0]] A
         (module-defn(A) Anonymous anonymous.ml(23):567-608 A))
       (apply (field 1 (global CamlinternalMod!)) [0: [0]] B
         (module-defn(B) Anonymous anonymous.ml(33):703-773
-          (let (x =[0: *, *] [0: "foo" "bar"]) (makeblock 0))))
+          (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
+            (makeblock 0))))
       (let (f = (function param : int 0) s = (makemutable 0 ""))
         (seq
           (ignore

--- a/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
+++ b/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
@@ -1,4 +1,7 @@
-(seq (ignore (let (x =[0: [int], [int]] [0: 13 37]) (makeblock 0 x)))
+(seq
+  (ignore
+    (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 13 37])
+      (makeblock 0 x)))
   (let
     (A =
        (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 25 6]
@@ -6,10 +9,14 @@
      B =
        (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 35 6]
          [0: [0]]))
-    (seq (ignore (let (x =[0: [int], [int]] [0: 4 2]) (makeblock 0 x)))
+    (seq
+      (ignore
+        (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 4 2])
+          (makeblock 0 x)))
       (apply (field 1 (global CamlinternalMod!)) [0: [0]] A A)
       (apply (field 1 (global CamlinternalMod!)) [0: [0]] B
-        (let (x =[0: *, *] [0: "foo" "bar"]) (makeblock 0)))
+        (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
+          (makeblock 0)))
       (setfield_ptr(root-init) 0 (global Anonymous!) A)
       (setfield_ptr(root-init) 1 (global Anonymous!) B)
       (let (f = (function param : int 0))

--- a/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -55,6 +55,7 @@ match (3, 2, 1) with
                *match*/283 =a (field 1 *match*/279))
               (exit 5 *match*/279)))))
      with (6) 0)
-   with (5 x/274[0: [int], [int], [int]]) (seq (ignore x/274) 1)))
+   with (5 x/274[(consts ()) (non_consts ([0: [int], [int], [int]]))])
+    (seq (ignore x/274) 1)))
 - : bool = false
 |}];;

--- a/ocaml/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/ocaml/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -16,7 +16,7 @@ let last_is_anys = function
 [%%expect{|
 (let
   (last_is_anys/10 =
-     (function param/12[0: [int], [int]] : int
+     (function param/12[(consts ()) (non_consts ([0: [int], [int]]))] : int
        (catch
          (if (field 0 param/12) (if (field 1 param/12) (exit 1) 1)
            (if (field 1 param/12) (exit 1) 2))
@@ -33,7 +33,7 @@ let last_is_vars = function
 [%%expect{|
 (let
   (last_is_vars/17 =
-     (function param/21[0: [int], [int]] : int
+     (function param/21[(consts ()) (non_consts ([0: [int], [int]]))] : int
        (catch
          (if (field 0 param/21) (if (field 1 param/21) (exit 3) 1)
            (if (field 1 param/21) (exit 3) 2))
@@ -75,7 +75,8 @@ let f = function
    B/26 = (apply (field 0 (global Toploop!)) "B/26")
    A/25 = (apply (field 0 (global Toploop!)) "A/25")
    f/28 =
-     (function param/30[0: *, [int], [int]] : int
+     (function param/30[(consts ()) (non_consts ([0: *, [int], [int]]))]
+       : int
        (let (*match*/31 =a (field 0 param/30))
          (catch
            (if (== *match*/31 A/25) (if (field 1 param/30) 1 (exit 8))

--- a/ocaml/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/ocaml/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -143,35 +143,219 @@
      eta_int32_ge = (function prim prim stub (Int32.>= prim prim))
      eta_int64_ge = (function prim prim stub (Int64.>= prim prim))
      eta_nativeint_ge = (function prim prim stub (Nativeint.>= prim prim))
-     int_vec = [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]
-     bool_vec = [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
-     intlike_vec = [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
-     float_vec = [0: [0: 1. 1.] [0: [0: 1. 2.] [0: [0: 2. 1.] 0]]]
-     string_vec = [0: [0: "1" "1"] [0: [0: "1" "2"] [0: [0: "2" "1"] 0]]]
-     int32_vec = [0: [0: 1l 1l] [0: [0: 1l 2l] [0: [0: 2l 1l] 0]]]
-     int64_vec = [0: [0: 1L 1L] [0: [0: 1L 2L] [0: [0: 2L 1L] 0]]]
-     nativeint_vec = [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0]]]
+     int_vec =[(consts (0))
+               (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]
+     bool_vec =[(consts (0))
+                (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
+     intlike_vec =[(consts (0))
+                   (non_consts ([0: *,
+                                 [(consts (0)) (non_consts ([0: *, *]))]]))]
+       [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
+     float_vec =[(consts (0))
+                 (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       [0: [0: 1. 1.] [0: [0: 1. 2.] [0: [0: 2. 1.] 0]]]
+     string_vec =[(consts (0))
+                  (non_consts ([0: *,
+                                [(consts (0)) (non_consts ([0: *, *]))]]))]
+       [0: [0: "1" "1"] [0: [0: "1" "2"] [0: [0: "2" "1"] 0]]]
+     int32_vec =[(consts (0))
+                 (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       [0: [0: 1l 1l] [0: [0: 1l 2l] [0: [0: 2l 1l] 0]]]
+     int64_vec =[(consts (0))
+                 (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       [0: [0: 1L 1L] [0: [0: 1L 2L] [0: [0: 2L 1L] 0]]]
+     nativeint_vec =[(consts (0))
+                     (non_consts ([0: *,
+                                   [(consts (0)) (non_consts ([0: *, *]))]]))]
+       [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0]]]
      test_vec =
-       (function cmp eq ne lt gt le ge vec : [0: [0: *, *], *]
-         (let
-           (uncurry =
-              (function f param[0: *, *]
-                (apply f (field 0 param) (field 1 param)))
-            map =
-              (function f l
-                (apply (field 18 (global Stdlib__List!)) (apply uncurry f) l)))
-           (makeblock 0 ([0: *, *],*)
-             (makeblock 0 (apply map gen_cmp vec) (apply map cmp vec))
-             (apply map
-               (function gen spec : [0: *, *]
-                 (makeblock 0 (apply map gen vec) (apply map spec vec)))
-               (makeblock 0 ([0: *, *],*) (makeblock 0 gen_eq eq)
-                 (makeblock 0 ([0: *, *],*) (makeblock 0 gen_ne ne)
-                   (makeblock 0 ([0: *, *],*) (makeblock 0 gen_lt lt)
-                     (makeblock 0 ([0: *, *],*) (makeblock 0 gen_gt gt)
-                       (makeblock 0 ([0: *, *],*) (makeblock 0 gen_le le)
-                         (makeblock 0 ([0: *, *],*) (makeblock 0 gen_ge ge)
-                           0)))))))))))
+       (function cmp eq ne lt gt le ge
+         vec[(consts (0))
+             (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+         [(consts ())
+          (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))],
+                        [(consts (0)) (non_consts ([0: *, *]))]]))](let
+                                                                    (uncurry =
+                                                                    (function
+                                                                    f
+                                                                    param
+                                                                    [(consts ())
+                                                                    (non_consts (
+                                                                    [0: *, *]))]
+                                                                    (apply f
+                                                                    (field 0
+                                                                    param)
+                                                                    (field 1
+                                                                    param)))
+                                                                    map =
+                                                                    (function
+                                                                    f
+                                                                    l[(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))]
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))]
+                                                                    (apply
+                                                                    (field 18
+                                                                    (global Stdlib__List!))
+                                                                    (apply
+                                                                    uncurry
+                                                                    f) l)))
+                                                                    (makeblock 0 (
+                                                                    [(consts ())
+                                                                    (non_consts (
+                                                                    [0:
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
+                                                                    (makeblock 0 (
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
+                                                                    (apply
+                                                                    map
+                                                                    gen_cmp
+                                                                    vec)
+                                                                    (apply
+                                                                    map cmp
+                                                                    vec))
+                                                                    (apply
+                                                                    map
+                                                                    (function
+                                                                    gen spec
+                                                                    [(consts ())
+                                                                    (non_consts (
+                                                                    [0:
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))]
+                                                                    (makeblock 0 (
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
+                                                                    (apply
+                                                                    map gen
+                                                                    vec)
+                                                                    (apply
+                                                                    map spec
+                                                                    vec)))
+                                                                    (makeblock 0 (
+                                                                    [(consts ())
+                                                                    (non_consts (
+                                                                    [0: *, *]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
+                                                                    (makeblock 0
+                                                                    gen_eq
+                                                                    eq)
+                                                                    (makeblock 0 (
+                                                                    [(consts ())
+                                                                    (non_consts (
+                                                                    [0: *, *]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
+                                                                    (makeblock 0
+                                                                    gen_ne
+                                                                    ne)
+                                                                    (makeblock 0 (
+                                                                    [(consts ())
+                                                                    (non_consts (
+                                                                    [0: *, *]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
+                                                                    (makeblock 0
+                                                                    gen_lt
+                                                                    lt)
+                                                                    (makeblock 0 (
+                                                                    [(consts ())
+                                                                    (non_consts (
+                                                                    [0: *, *]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
+                                                                    (makeblock 0
+                                                                    gen_gt
+                                                                    gt)
+                                                                    (makeblock 0 (
+                                                                    [(consts ())
+                                                                    (non_consts (
+                                                                    [0: *, *]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
+                                                                    (makeblock 0
+                                                                    gen_le
+                                                                    le)
+                                                                    (makeblock 0 (
+                                                                    [(consts ())
+                                                                    (non_consts (
+                                                                    [0: *, *]))],
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
+                                                                    (makeblock 0
+                                                                    gen_ge
+                                                                    ge) 0)))))))))))
     (seq
       (apply test_vec int_cmp int_eq int_ne int_lt int_gt int_le int_ge
         int_vec)
@@ -191,29 +375,93 @@
         nativeint_gt nativeint_le nativeint_ge nativeint_vec)
       (let
         (eta_test_vec =
-           (function cmp eq ne lt gt le ge vec : [0: [0: *, *], *]
+           (function cmp eq ne lt gt le ge
+             vec[(consts (0))
+                 (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+             [(consts ())
+              (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))],
+                            [(consts (0)) (non_consts ([0: *, *]))]]))]
              (let
                (uncurry =
-                  (function f param[0: *, *]
+                  (function f param[(consts ()) (non_consts ([0: *, *]))]
                     (apply f (field 0 param) (field 1 param)))
                 map =
-                  (function f l
+                  (function f
+                    l[(consts (0))
+                      (non_consts ([0: *,
+                                    [(consts (0)) (non_consts ([0: *, *]))]]))]
+                    [(consts (0))
+                     (non_consts ([0: *,
+                                   [(consts (0)) (non_consts ([0: *, *]))]]))]
                     (apply (field 18 (global Stdlib__List!))
                       (apply uncurry f) l)))
-               (makeblock 0 ([0: *, *],*)
-                 (makeblock 0 (apply map eta_gen_cmp vec)
-                   (apply map cmp vec))
+               (makeblock 0 ([(consts ())
+                              (non_consts ([0:
+                                            [(consts (0))
+                                             (non_consts ([0: *, *]))],
+                                            [(consts (0))
+                                             (non_consts ([0: *, *]))]]))],
+                 [(consts (0))
+                  (non_consts ([0: *,
+                                [(consts (0)) (non_consts ([0: *, *]))]]))])
+                 (makeblock 0 ([(consts (0))
+                                (non_consts ([0: *,
+                                              [(consts (0))
+                                               (non_consts ([0: *, *]))]]))],
+                   [(consts (0))
+                    (non_consts ([0: *,
+                                  [(consts (0)) (non_consts ([0: *, *]))]]))])
+                   (apply map eta_gen_cmp vec) (apply map cmp vec))
                  (apply map
-                   (function gen spec : [0: *, *]
-                     (makeblock 0 (apply map gen vec) (apply map spec vec)))
-                   (makeblock 0 ([0: *, *],*) (makeblock 0 eta_gen_eq eq)
-                     (makeblock 0 ([0: *, *],*) (makeblock 0 eta_gen_ne ne)
-                       (makeblock 0 ([0: *, *],*) (makeblock 0 eta_gen_lt lt)
-                         (makeblock 0 ([0: *, *],*)
+                   (function gen spec
+                     [(consts ())
+                      (non_consts ([0:
+                                    [(consts (0)) (non_consts ([0: *, *]))],
+                                    [(consts (0)) (non_consts ([0: *, *]))]]))]
+                     (makeblock 0 ([(consts (0))
+                                    (non_consts ([0: *,
+                                                  [(consts (0))
+                                                   (non_consts ([0: *, *]))]]))],
+                       [(consts (0))
+                        (non_consts ([0: *,
+                                      [(consts (0)) (non_consts ([0: *, *]))]]))])
+                       (apply map gen vec) (apply map spec vec)))
+                   (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],
+                     [(consts (0))
+                      (non_consts ([0: *,
+                                    [(consts (0)) (non_consts ([0: *, *]))]]))])
+                     (makeblock 0 eta_gen_eq eq)
+                     (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],
+                       [(consts (0))
+                        (non_consts ([0: *,
+                                      [(consts (0)) (non_consts ([0: *, *]))]]))])
+                       (makeblock 0 eta_gen_ne ne)
+                       (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],
+                         [(consts (0))
+                          (non_consts ([0: *,
+                                        [(consts (0))
+                                         (non_consts ([0: *, *]))]]))])
+                         (makeblock 0 eta_gen_lt lt)
+                         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],
+                           [(consts (0))
+                            (non_consts ([0: *,
+                                          [(consts (0))
+                                           (non_consts ([0: *, *]))]]))])
                            (makeblock 0 eta_gen_gt gt)
-                           (makeblock 0 ([0: *, *],*)
+                           (makeblock 0 ([(consts ())
+                                          (non_consts ([0: *, *]))],[(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *,
+                                                                    [(consts (0))
+                                                                    (non_consts (
+                                                                    [0: *, *]))]]))])
                              (makeblock 0 eta_gen_le le)
-                             (makeblock 0 ([0: *, *],*)
+                             (makeblock 0 ([(consts ())
+                                            (non_consts ([0: *, *]))],
+                               [(consts (0))
+                                (non_consts ([0: *,
+                                              [(consts (0))
+                                               (non_consts ([0: *, *]))]]))])
                                (makeblock 0 eta_gen_ge ge) 0)))))))))))
         (seq
           (apply eta_test_vec eta_int_cmp eta_int_eq eta_int_ne eta_int_lt

--- a/ocaml/testsuite/tests/translprim/ref_spec.compilers.reference
+++ b/ocaml/testsuite/tests/translprim/ref_spec.compilers.reference
@@ -4,7 +4,7 @@
      var_ref = (makemutable 0 65)
      vargen_ref = (makemutable 0 65)
      cst_ref = (makemutable 0 (int) 0)
-     gen_ref = (makemutable 0 0)
+     gen_ref = (makemutable 0 ([(consts (0)) (non_consts ([0: *]))]) 0)
      flt_ref = (makemutable 0 (float) 0.))
     (seq (setfield_imm 0 int_ref 2) (setfield_imm 0 var_ref 66)
       (setfield_ptr 0 vargen_ref [0: 66 0]) (setfield_ptr 0 vargen_ref 67)
@@ -15,7 +15,8 @@
          var_rec = (makemutable 0 (int,*) 0 65)
          vargen_rec = (makemutable 0 (int,*) 0 65)
          cst_rec = (makemutable 0 (int,int) 0 0)
-         gen_rec = (makemutable 0 (int,*) 0 0)
+         gen_rec =
+           (makemutable 0 (int,[(consts (0)) (non_consts ([0: *]))]) 0 0)
          flt_rec = (makemutable 0 (int,float) 0 0.)
          flt_rec' = (makefloatblock Mutable 0. 0.))
         (seq (setfield_imm 1 int_rec 2) (setfield_imm 1 var_rec 66)


### PR DESCRIPTION
This replaces the existing `Pblock` value kind used in `Lambda` with a `Pvariant` kind.  This allows Flambda 2 to have more precise types for function parameters.

I'll tidy up the printing functions after any review comments have been received on the remainder.