### PR TITLE
Slot offsets review, with arity fix

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -210,8 +210,8 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
 
      In the case of the exported code, we already have offsets for all
      function_slots/vars reachable from the code of the current compilation
-     unit, but since we also re-export code from other compilation units, we
-     need to take those into account. *)
+     unit, but since we also re-export code metadata (including return types)
+     from other compilation units, we need to take those into account. *)
   (* CR gbury: it might be more efficient to not compute the free names for all
      exported code, but fold over the exported code to avoid allocating some
      free_names *)
@@ -221,13 +221,13 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
   in
   let exported_offsets =
     exported_offsets
-    |> Slot_offsets.reexport_function_slots
+    |> Exported_offsets.reexport_function_slots
          (Name_occurrences.all_function_slots free_names_of_all_code)
-    |> Slot_offsets.reexport_value_slots
+    |> Exported_offsets.reexport_value_slots
          (Name_occurrences.all_value_slots free_names_of_all_code)
-    |> Slot_offsets.reexport_function_slots
+    |> Exported_offsets.reexport_function_slots
          (Name_occurrences.all_function_slots slots_used_in_typing_env)
-    |> Slot_offsets.reexport_value_slots
+    |> Exported_offsets.reexport_value_slots
          (Name_occurrences.all_value_slots slots_used_in_typing_env)
   in
   Some

--- a/middle_end/flambda2/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/upwards_acc.ml
@@ -78,7 +78,7 @@ let create ~required_names ~reachable_code_ids ~compute_slot_offsets uenv dacc =
   let are_rebuilding_terms = DE.are_rebuilding_terms (DA.denv dacc) in
   let generate_phantom_lets = DE.generate_phantom_lets (DA.denv dacc) in
   let slot_offsets : _ Or_unknown.t =
-    if compute_slot_offsets then Known (Slot_offsets.create ()) else Unknown
+    if compute_slot_offsets then Known Slot_offsets.empty else Unknown
   in
   { uenv;
     creation_dacc = dacc;

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -79,33 +79,23 @@ let run ~cmx_loader ~round unit =
     Name_occurrences.all_function_slots name_occurrences
   in
   let all_value_slots = Name_occurrences.all_value_slots name_occurrences in
-  let used_value_slots, exported_offsets =
+  let ({ used_value_slots; exported_offsets } : Slot_offsets.result) =
     match UA.slot_offsets uacc with
     | Unknown ->
       Misc.fatal_error "Slot offsets must be computed and cannot be unknown"
-    | Known slot_offsets -> (
-      let used_slots : Slot_offsets.used_slots Or_unknown.t =
-        Known
-          { function_slots_in_normal_projections;
-            all_function_slots;
-            value_slots_in_normal_projections;
-            all_value_slots
-          }
+    | Known slot_offsets ->
+      let used_slots : Slot_offsets.used_slots =
+        { function_slots_in_normal_projections;
+          all_function_slots;
+          value_slots_in_normal_projections;
+          all_value_slots
+        }
       in
       let get_code_metadata code_id =
         Exported_code.find_exn all_code code_id
         |> Code_or_metadata.code_metadata
       in
-      match
-        Slot_offsets.finalize_offsets slot_offsets ~get_code_metadata
-          ~used_slots
-      with
-      | Known used_value_slots, offsets -> used_value_slots, offsets
-      | Unknown, _ ->
-        (* could be an assert false *)
-        Misc.fatal_error
-          "Slot_offsets should not have returned Unknown when given a Known \
-           used_names.")
+      Slot_offsets.finalize_offsets slot_offsets ~get_code_metadata ~used_slots
   in
   let cmx =
     Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol

--- a/middle_end/flambda2/simplify_shared/exported_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.ml
@@ -133,3 +133,41 @@ let merge env1 env2 =
   { function_slot_offsets; value_slot_offsets }
 
 let import_offsets env = current_offsets := merge env !current_offsets
+
+(* CR gbury: considering that the goal is to have `offsets` significantly
+   smaller than the `imported_offsets`, it might be better for performance to
+   check whether the function slot is already in the offsets before looking it
+   up in the imported offsets ? *)
+let reexport_function_slots function_slot_set offsets =
+  let imported_offsets = imported_offsets () in
+  Function_slot.Set.fold
+    (fun function_slot offsets ->
+      if Compilation_unit.is_current
+           (Function_slot.get_compilation_unit function_slot)
+      then offsets
+      else
+        match function_slot_offset imported_offsets function_slot with
+        | None ->
+          Misc.fatal_errorf
+            "Function slot %a is used in the current compilation unit, but not \
+             present in the imported offsets."
+            Function_slot.print function_slot
+        | Some info -> add_function_slot_offset offsets function_slot info)
+    function_slot_set offsets
+
+let reexport_value_slots value_slot_set offsets =
+  let imported_offsets = imported_offsets () in
+  Value_slot.Set.fold
+    (fun value_slot offsets ->
+      if Compilation_unit.is_current
+           (Value_slot.get_compilation_unit value_slot)
+      then offsets
+      else
+        match value_slot_offset imported_offsets value_slot with
+        | None ->
+          Misc.fatal_errorf
+            "value slot %a is used in the current compilation unit, but not \
+             present in the imported offsets."
+            Value_slot.print value_slot
+        | Some info -> add_value_slot_offset offsets value_slot info)
+    value_slot_set offsets

--- a/middle_end/flambda2/simplify_shared/exported_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.mli
@@ -76,3 +76,11 @@ val imported_offsets : unit -> t
 
 (** Merge the offsets from two files *)
 val merge : t -> t -> t
+
+(** Ensure the offsets for the given function slots are in the given exported
+    offsets. *)
+val reexport_function_slots : Function_slot.Set.t -> t -> t
+
+(** Ensure the offsets for the given function slots are in the given exported
+    offsets. *)
+val reexport_value_slots : Value_slot.Set.t -> t -> t

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -12,10 +12,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
+(* CR chambart/gbury: This module could be renamed into [set_of_closures_layout]
+   or similar. *)
 
 open! Flambda.Import
 module EO = Exported_offsets
+
+type words = int
+
+type result =
+  { exported_offsets : EO.t;
+    used_value_slots : Value_slot.Set.t
+  }
 
 type used_slots =
   { function_slots_in_normal_projections : Function_slot.Set.t;
@@ -29,68 +37,26 @@ let[@inline] value_slot_is_used ~used_value_slots v =
   then Value_slot.Set.mem v used_value_slots
   else true
 
-let keep_value_slot ~used_value_slots v =
-  match (used_value_slots : _ Or_unknown.t) with
-  | Unknown -> true
-  | Known used_value_slots -> value_slot_is_used ~used_value_slots v
+let[@inline] function_slot_is_used ~used_function_slots v =
+  if Compilation_unit.is_current (Function_slot.get_compilation_unit v)
+  then Function_slot.Set.mem v used_function_slots
+  else true
 
-(* CR gbury: considering that the goal is to have `offsets` significantly
-   smaller than the `imported_offsets`, it might be better for performance to
-   check whether the function slot is already in the offsets before looking it
-   up in the imported offsets ? *)
-let reexport_function_slots function_slot_set offsets =
-  let imported_offsets = EO.imported_offsets () in
-  Function_slot.Set.fold
-    (fun function_slot offsets ->
-      if Compilation_unit.is_current
-           (Function_slot.get_compilation_unit function_slot)
-      then offsets
-      else
-        match EO.function_slot_offset imported_offsets function_slot with
-        | None ->
-          Misc.fatal_errorf
-            "Function slot %a is used in the current compilation unit, but not \
-             present in the imported offsets."
-            Function_slot.print function_slot
-        | Some info -> EO.add_function_slot_offset offsets function_slot info)
-    function_slot_set offsets
+(* Compute offsets of the runtime memory layout of sets of closures. These
+   offsets are computed in words, not in bytes.
 
-let reexport_value_slots value_slot_set offsets =
-  let imported_offsets = EO.imported_offsets () in
-  Value_slot.Set.fold
-    (fun value_slot offsets ->
-      if Compilation_unit.is_current
-           (Value_slot.get_compilation_unit value_slot)
-      then offsets
-      else
-        match EO.value_slot_offset imported_offsets value_slot with
-        | None ->
-          Misc.fatal_errorf
-            "value slot %a is used in the current compilation unit, but not \
-             present in the imported offsets."
-            Value_slot.print value_slot
-        | Some info -> EO.add_value_slot_offset offsets value_slot info)
-    value_slot_set offsets
-
-(* Compute offsets ("indexes") for slots within a block having tag Closure_tag.
-
-   A particular function slot or value slot might appear in more than one such
-   block. However at present we insist that slots must have the same offset in
-   all blocks where they appear.
-
-   We assume an ideal (i.e. compact) layout for a block describing a set of
-   closures is the following: *)
+   The layout for a block describing a set of closures is the following: *)
 (*
  * |----------------------|
  * | Closure_tag header   |
  * |----------------------| offset 0
- * | function slot 0      | <- pointer to the block
+ * | function slot 0      | <- pointer to the block (and pointer to function slot 0)
  * | (pos 0, size 2 or 3) |
  * |----------------------|
- * | Infix_tag header     |
+ * | Infix_tag header     | (size=1)
  * |----------------------|
- * | function slot 1      |
- * | (pos x, size 2 or 3) |  (x=3 if function slot 0 is of size 2 for instance)
+ * | function slot 1      | <- pointer to function slot 1
+ * | (pos x, size 2 or 3) |  (x=1+size_of_function_slot_0)
  * |----------------------|
  * | Infix_tag header     |
  * |----------------------|
@@ -103,7 +69,7 @@ let reexport_value_slots value_slot_set offsets =
  * | last function slot   |
  * |                      |
  * |----------------------|
- * | value slot 0         | <- start of the environment part of the block
+ * | value slot 0  size=1 | <- start of the environment part of the block
  * |----------------------|
  * | value slot 1         |
  * |----------------------|
@@ -116,220 +82,324 @@ let reexport_value_slots value_slot_set offsets =
 (* However, that ideal layout may not be possible in certain circumstances, as
    there may be arbitrary holes between slots (i.e. unused words in the block).
 
-   Starting from OCaml 4.12, all function slots must occur before all value
-   slots, since the offset to the start of the environment is recorded in the
-   arity field of each function slot.
+   All function slots must occur before all value slots, since the offset to the
+   start of the environment is recorded in the arity field of each function
+   slot. *)
 
-   This additional requirement makes more constraints impossible to satisfy (to
-   be clear, there are situations impossible to satisfy regardless of this
-   requirement; it's just that this requirement makes some situations that were
-   previously possible to satisfy be now unsatisfiable).
+module Layout = struct
+  type slot =
+    | Value_slot of Value_slot.t
+    | Infix_header
+    | Function_slot of
+        { size : words;
+          function_slot : Function_slot.t
+        }
 
-   For instance, it is perfectly possible to have a situation where a value slot
-   has been fixed at offset 3 (because it is in a simple set of closures with
-   one function of arity > 1 in another cmx), however it is in a set of closures
-   with more than one function slot in the current compilation unit. In this
-   case, it is impossible to make all the function slots fit before the value
-   slot in the block. *)
+  type t =
+    { startenv : words;
+      empty_env : bool;
+      slots : (words * slot) list
+    }
 
-type layout_slot =
-  | Value_slot of Value_slot.t
-  | Infix_header
-  | Function_slot of Function_slot.t
+  let print_slot fmt = function
+    | Value_slot v -> Format.fprintf fmt "value_slot %a" Value_slot.print v
+    | Infix_header -> Format.fprintf fmt "infix_header"
+    | Function_slot { size; function_slot } ->
+      Format.fprintf fmt "function_slot(%d) %a" size Function_slot.print
+        function_slot
 
-type layout =
-  { startenv : int;
-    empty_env : bool;
-    slots : (int * layout_slot) list
-  }
+  let print fmt l =
+    Format.fprintf fmt "@[<v>startenv: %d;@ " l.startenv;
+    List.iter
+      (fun (i, slot) -> Format.fprintf fmt "@[<h>%d %a@]@," i print_slot slot)
+      l.slots;
+    Format.fprintf fmt "@]"
 
-let order_function_slots env l acc =
-  Function_slot.Lmap.fold
-    (fun function_slot _ acc ->
-      match EO.function_slot_offset env function_slot with
-      | Some Dead_function_slot -> acc
-      | Some (Live_function_slot { size = _; offset }) ->
-        Numeric_types.Int.Map.add offset (Function_slot function_slot) acc
-      | None ->
-        Misc.fatal_errorf "No function_slot offset for %a" Function_slot.print
-          function_slot)
-    l acc
+  let order_function_slots env l acc =
+    Function_slot.Lmap.fold
+      (fun function_slot _ acc ->
+        match EO.function_slot_offset env function_slot with
+        | Some Dead_function_slot -> acc
+        | Some (Live_function_slot { size; offset }) ->
+          Numeric_types.Int.Map.add offset
+            (Function_slot { size; function_slot })
+            acc
+        | None ->
+          Misc.fatal_errorf "No function_slot offset for %a" Function_slot.print
+            function_slot)
+      l acc
 
-let order_value_slots env l acc =
-  Value_slot.Map.fold
-    (fun value_slot _ acc ->
-      match EO.value_slot_offset env value_slot with
-      | Some Dead_value_slot -> acc
-      | Some (Live_value_slot { offset }) ->
-        Numeric_types.Int.Map.add offset (Value_slot value_slot) acc
-      | None ->
-        Misc.fatal_errorf "No value slot offset for %a" Value_slot.print
-          value_slot)
-    l acc
+  let order_value_slots env l acc =
+    Value_slot.Map.fold
+      (fun value_slot _ acc ->
+        match EO.value_slot_offset env value_slot with
+        | Some Dead_value_slot -> acc
+        | Some (Live_value_slot { offset }) ->
+          Numeric_types.Int.Map.add offset (Value_slot value_slot) acc
+        | None ->
+          Misc.fatal_errorf "No value slot offset for %a" Value_slot.print
+            value_slot)
+      l acc
 
-let layout_aux j slot (startenv, acc_slots) =
-  match slot with
-  (* Starting from OCaml 4.12, all function slots *must* precede all value
-     slots. The algorithms in this file should thus only generate slot
-     assignments that respect this invariant. If that is not the case, this is a
-     fatal error given that the start of the environment (i.e. the offset of the
-     first value slot, with the added property that all slots after that are
-     value slots (or at least scannable by the GC)), is needed by the GC when
-     scanning the block. Thus, if we see a function slot, we check that then the
-     environment has not started yet (i.e. we have not seen any value slots). *)
-  | Function_slot _ when j = 0 ->
-    assert (acc_slots = []);
-    assert (startenv = None);
-    (* see comment above *)
-    let acc_slots = [0, slot] in
-    startenv, acc_slots
-  | Function_slot _ ->
-    assert (startenv = None);
-    (* see comment above *)
-    let acc_slots = (j, slot) :: (j - 1, Infix_header) :: acc_slots in
-    startenv, acc_slots
-  | Value_slot _ ->
-    let startenv =
-      match startenv with
-      | Some i ->
-        assert (i < j);
-        startenv
-      | None -> Some j
+  let layout_aux offset slot (startenv, acc_slots) =
+    match slot with
+    (* Starting from OCaml 4.12, all function slots *must* precede all value
+       slots. The algorithms in this file should thus only generate slot
+       assignments that respect this invariant. If that is not the case, this is
+       a fatal error given that the start of the environment (i.e. the offset of
+       the first value slot, with the added property that all slots after that
+       are value slots (or at least scannable by the GC)), is needed by the GC
+       when scanning the block. Thus, if we see a function slot, we check that
+       then the environment has not started yet (i.e. we have not seen any value
+       slots). *)
+    | Function_slot _ when offset = 0 ->
+      assert (acc_slots = []);
+      assert (startenv = None);
+      (* see comment above *)
+      let acc_slots = [0, slot] in
+      startenv, acc_slots
+    | Function_slot _ ->
+      assert (startenv = None);
+      (* see comment above *)
+      let acc_slots =
+        (offset, slot) :: (offset - 1, Infix_header) :: acc_slots
+      in
+      startenv, acc_slots
+    | Value_slot _ ->
+      let startenv =
+        match startenv with
+        | Some i ->
+          assert (i < offset);
+          startenv
+        | None -> Some offset
+      in
+      let acc_slots = (offset, slot) :: acc_slots in
+      startenv, acc_slots
+    | Infix_header ->
+      (* Internal invariant: such layout slots are not generated by the {order}
+         function, so they should not appear. *)
+      assert false
+
+  let make env function_slots value_slots =
+    let map =
+      Numeric_types.Int.Map.empty
+      |> order_value_slots env value_slots
+      |> order_function_slots env function_slots
     in
-    let acc_slots = (j, slot) :: acc_slots in
-    startenv, acc_slots
-  | Infix_header ->
-    (* Internal invariant: such layout slots are not generated by the {order}
-       function, so they should not appear. *)
-    assert false
-
-let layout env function_slots value_slots =
-  let map =
-    Numeric_types.Int.Map.empty
-    |> order_value_slots env value_slots
-    |> order_function_slots env function_slots
-  in
-  let startenv_opt, acc_slots =
-    Numeric_types.Int.Map.fold layout_aux map (None, [])
-  in
-  let startenv, empty_env =
-    (* If there are no value slots, the start of env is considered to be the
-       (non-existing) slot after the last slot used, and if the set is empty,
-       the value does not matter. *)
-    match startenv_opt, acc_slots with
-    | Some i, _ -> i, false
-    | None, [] -> 0, true
-    | None, (j, Function_slot function_slot) :: _ -> (
-      match EO.function_slot_offset env function_slot with
-      | Some (Live_function_slot { size; _ }) -> j + size, true
-      | Some Dead_function_slot | None ->
-        (* the function slot was found earlier during the call to
-           order_function_slots *)
-        assert false)
-    | None, (_, Infix_header) :: _ ->
-      (* Cannot happen because a infix header is *always* preceded by a function
-         slot (because the slot list is reversed) *)
-      assert false
-    | None, (_, Value_slot _) :: _ ->
-      (* Cannot happen because if there is a value slot in the acc, then
-         startenv_opt should be Some _ *)
-      assert false
-  in
-  let slots = List.rev acc_slots in
-  (* The Gc assumes that a Closure_tag block actually starts with a function
-     slot at offset 0. Or more precisely, the GC unconditionally reads the
-     second field of a Closure_tag block to find out the start of environment.
-     Thus we add a check here to ensure that the slots start with a function
-     slot at offset 0. *)
-  match slots with
-  | (0, Function_slot _) :: _ -> { startenv; slots; empty_env }
-  | _ ->
-    Misc.fatal_error
-      "Sets of closures must start with a function slot at offset 0"
-
-let print_layout_slot fmt = function
-  | Value_slot v -> Format.fprintf fmt "value_slot %a" Value_slot.print v
-  | Infix_header -> Format.fprintf fmt "infix_header"
-  | Function_slot cid ->
-    Format.fprintf fmt "function_slot %a" Function_slot.print cid
-
-let print_layout fmt l =
-  Format.fprintf fmt "@[<v>startenv: %d;@ " l.startenv;
-  List.iter
-    (fun (i, slot) ->
-      Format.fprintf fmt "@[<h>%d %a@]@," i print_layout_slot slot)
-    l.slots;
-  Format.fprintf fmt "@]"
+    let startenv_opt, rev_slots =
+      Numeric_types.Int.Map.fold layout_aux map (None, [])
+    in
+    let startenv, empty_env =
+      (* If there are no value slots, the start of env is considered to be the
+         (non-existing) slot after the last slot used, and if the set is empty,
+         the value does not matter. *)
+      match startenv_opt, rev_slots with
+      | Some i, _ -> i, false
+      | None, [] -> 0, true (* will raise a fatal_error later *)
+      | None, (offset, Function_slot { size; _ }) :: _ -> offset + size, true
+      | None, (_, Infix_header) :: _ ->
+        (* Cannot happen because a infix header is *always* preceded by a
+           function slot (because the slot list is reversed) *)
+        assert false
+      | None, (_, Value_slot _) :: _ ->
+        (* Cannot happen because if there is a value slot in the acc, then
+           startenv_opt should be Some _ *)
+        assert false
+    in
+    let slots = List.rev rev_slots in
+    (* The Gc assumes that a Closure_tag block actually starts with a function
+       slot at offset 0. Or more precisely, the GC unconditionally reads the
+       second field of a Closure_tag block to find out the start of environment.
+       Thus we add a check here to ensure that the slots start with a function
+       slot at offset 0. *)
+    let res = { startenv; slots; empty_env } in
+    match slots with
+    | (0, Function_slot _) :: _ -> res
+    | [] | (_, (Function_slot _ | Infix_header | Value_slot _)) :: _ ->
+      Misc.fatal_errorf
+        "Sets of closures must start with a function slot at offset 0:@\n%a"
+        print res
+end
 
 (* Greedy algorithm *)
 
-module Greedy = struct
-  (** Greedy algorithm for assigning offsets ("indexes") to slots.
+module Greedy : sig
+  type state
 
-      Slots are assigned using a "first comes, first served" basis, filling
-      upwards from 0.
+  val print : Format.formatter -> state -> unit
 
-      As much as is possible, the algorithm tries to put all the function slots
-      first, and then all the value slots; however, that may be impossible
-      because of constraints read from a .cmx file.
+  val create_initial_state : unit -> state
 
-      This strategy should be able to correctly compute offsets for all
-      legitimate situations, with no expected blowup of computation time.
-      However the generated offsets can be far from optimal (i.e. leave more
-      holes than necessary). *)
+  val create_slots_for_set :
+    state ->
+    get_code_metadata:(Code_id.t -> Code_metadata.t) ->
+    Set_of_closures.t ->
+    unit
+
+  val finalize : used_slots:used_slots -> state -> result
+end = struct
+  (* Greedy algorithm for assigning offsets (in terms of words) to slots.
+
+     The goal is to assign an offset to each slot (function slot or value slot).
+     As input we have: - a size for each slot (currently between 1 and 3) - for
+     each slot, a set of sets of closures in which it appears - some slots have
+     already fixed offsets (i.e. slots from other compilation units)
+
+     The constraints we want to satisfy are: - each slot has a unique offset -
+     for each set of closures, the slots that appear in it should not overlap.
+     Two slots s and s' overlap s.offset + s.size <= s'.offset (assuming
+     s.offset <= s'.offset) - for each set of closures, the offset for all
+     function slots is smaller than the offset of all value slots
+
+     Some inputs can be unsatisfiable. This can only occur because of the fixed
+     offsets imposed by previous compilation units. However, the current
+     flambda2 does not generate such unsatisfiable situations.
+
+     Slots are assigned using a "first comes, first served" basis, filling
+     upwards from 0. This is complete (for satisfiable cases), but may return a
+     non-optimal assignement of offsets (in the sens that there may be more
+     unused fields in sets of closures than necessary), however that case should
+     be fairly rare given the current behaviour of Simplify. *)
+
+  (* *)
+
+  type value_slot = Value
+
+  type function_slot = Function
+
+  (* silence warning 37 (unused constructor) *)
+  let _ = Value, Function
+
+  type _ slot_desc =
+    | Function_slot : Function_slot.t -> function_slot slot_desc
+    | Value_slot : Value_slot.t -> value_slot slot_desc
+
+  (* This module helps to distinguish between the two different notions of
+     offsets that are used for function slots:
+
+     - the exported offset (i.e. the one used with Exported_offsets.* , and that
+     is used by to_cmm), it the pointer to the first word of the closure, i.e it
+     points **after** the header for the closure (whether it is the Closure
+     header or the Infix header)
+
+     - when computing offsets we instead need to use the first offset in the
+     block actually used by a slot, which includes the Infix header (but not the
+     Closure header). *)
+  module Exported_offset : sig
+    type t
+
+    val print : Format.formatter -> t -> unit
+
+    val from_exported_offset : int -> t
+
+    val mk : _ slot_desc -> first_offset_used_including_header:int -> t
+
+    val range_used_by : _ slot_desc -> t -> slot_size:int -> int * int
+
+    val add_slot_to_exported_offsets :
+      EO.t -> _ slot_desc -> t -> slot_size:int -> EO.t
+  end = struct
+    type t = Offset of words
+    (* This is the offset as exported, i.e. for function slots it points
+       **after** the header word. *)
+    [@@unboxed]
+
+    let print fmt (Offset pos) = Format.fprintf fmt "%d" pos
+
+    let from_exported_offset pos = Offset pos
+
+    let mk (type a) (slot : a slot_desc) ~first_offset_used_including_header =
+      let offset =
+        match slot with
+        | Function_slot _ -> first_offset_used_including_header + 1
+        | Value_slot _ -> first_offset_used_including_header
+      in
+      Offset offset
+
+    let range_used_by (type a) (slot : a slot_desc) (Offset pos) ~slot_size =
+      match slot with
+      | Function_slot _ -> pos - 1, pos + slot_size
+      | Value_slot _ -> pos, pos + slot_size
+
+    let add_slot_to_exported_offsets (type a) offsets (slot : a slot_desc)
+        (Offset pos) ~slot_size =
+      match slot with
+      | Function_slot function_slot ->
+        let (info : EO.function_slot_info) =
+          EO.Live_function_slot { offset = pos; size = slot_size }
+        in
+        EO.add_function_slot_offset offsets function_slot info
+      | Value_slot value_slot ->
+        let (info : EO.value_slot_info) = EO.Live_value_slot { offset = pos } in
+        EO.add_value_slot_offset offsets value_slot info
+  end
 
   (* Internal types *)
 
-  type slot_desc =
-    | Function_slot of Function_slot.t
-    | Value_slot of Value_slot.t
-
   type slot_pos =
-    | Assigned of int
+    | Assigned of Exported_offset.t
     | Unassigned
     | Removed
 
   type set_of_closures =
     { id : int;
+      (* metadata used for priorities *)
+      num_value_slots : int;
+      num_function_slots : int;
       (* Info about start of environment *)
-      mutable first_slot_used_by_value_slots : int;
-      mutable first_slot_after_function_slots : int;
-      (* Slots to be allocated *)
-      mutable unallocated_function_slots : slot list;
-      mutable unallocated_value_slots : slot list;
-      mutable allocated_slots : slot Numeric_types.Int.Map.t
+      mutable first_slot_used_by_value_slots : words;
+      mutable first_slot_after_function_slots : words;
+      (* invariant : first_slot_after_function_slots <=
+         first_slot_used_by_calue_slots *)
+      mutable allocated_slots : any_slot Numeric_types.Int.Map.t
+          (* map indexed by the offset of the first word used by a slot
+             (including its infix header if it exists). *)
     }
 
-  and slot =
-    { desc : slot_desc;
+  and 'a slot =
+    { desc : 'a slot_desc;
       mutable pos : slot_pos;
       mutable size : int;
-      mutable sets : set_of_closures list
+      mutable sets : set_of_closures list;
+      (* metadata used for priorities *)
+      mutable occurrences : int;
+      mutable lowest_num_slots_in_sets : int
     }
+
+  and any_slot = Slot : _ slot -> any_slot [@@unboxed]
 
   (** Intermediate state to store offsets for function and value slots before
       computing the actual offsets of these elements within a block. *)
   type state =
-    { used_offsets : EO.t;
-      function_slots : slot Function_slot.Map.t;
-      value_slots : slot Value_slot.Map.t;
-      sets_of_closures : set_of_closures list
+    { mutable used_offsets : EO.t;
+      mutable function_slots : function_slot slot Function_slot.Map.t;
+      mutable value_slots : value_slot slot Value_slot.Map.t;
+      mutable sets_of_closures : set_of_closures list;
+      mutable function_slots_to_assign : function_slot slot list;
+      mutable value_slots_to_assign : value_slot slot list
     }
 
   (* Create structures *)
 
   (* create a fresh slot (with no position allocated yet) *)
-  let create_slot size desc = { desc; size; pos = Unassigned; sets = [] }
+  let create_slot ~size desc pos =
+    { desc;
+      size;
+      pos;
+      sets = [];
+      occurrences = 0;
+      lowest_num_slots_in_sets = max_int
+    }
 
-  let make_set =
+  let create_set =
     let c = ref 0 in
-    fun _ ->
+    fun ~num_value_slots ~num_function_slots ->
       incr c;
       { id = !c;
+        num_value_slots;
+        num_function_slots;
         first_slot_after_function_slots = 0;
         first_slot_used_by_value_slots = max_int;
-        unallocated_function_slots = [];
-        unallocated_value_slots = [];
         allocated_slots = Numeric_types.Int.Map.empty
       }
 
@@ -337,7 +407,9 @@ module Greedy = struct
     { used_offsets = EO.empty;
       function_slots = Function_slot.Map.empty;
       value_slots = Value_slot.Map.empty;
-      sets_of_closures = []
+      sets_of_closures = [];
+      function_slots_to_assign = [];
+      value_slots_to_assign = []
     }
 
   (* debug printing *)
@@ -346,59 +418,82 @@ module Greedy = struct
   let print_set_ids fmt l =
     List.iter (function s -> Format.fprintf fmt "%a,@ " print_set_id s) l
 
-  let print_desc fmt = function
+  let print_desc (type a) fmt (slot_desc : a slot_desc) =
+    match slot_desc with
     | Function_slot c -> Format.fprintf fmt "%a" Function_slot.print c
     | Value_slot v -> Format.fprintf fmt "%a" Value_slot.print v
 
-  let print_slot_desc fmt s = print_desc fmt s.desc
-
-  let print_slot_descs fmt l =
-    List.iter (function s -> Format.fprintf fmt "%a,@ " print_slot_desc s) l
-
   let print_slot_pos fmt = function
-    | Assigned i -> Format.fprintf fmt "%d" i
+    | Assigned offset -> Format.fprintf fmt "%a" Exported_offset.print offset
     | Unassigned -> Format.fprintf fmt "?"
     | Removed -> Format.fprintf fmt "x"
 
-  let print_slot fmt s =
-    Format.fprintf fmt "@[<h>[pos: %a;@ size: %d;@ sets: %a;@ desc: %a]@]@,"
-      print_slot_pos s.pos s.size print_set_ids s.sets print_desc s.desc
-
-  let print_slots fmt map =
-    Numeric_types.Int.Map.iter (fun _ slot -> print_slot fmt slot) map
-
-  let print_set fmt s =
+  let print_slot fmt
+      { pos; size; sets; desc; occurrences; lowest_num_slots_in_sets } =
     Format.fprintf fmt
-      "@[<v 2>%d:@ @[<v>first_slot_after_function_slots: %d;@ \
-       first_slot_used_by_value_slots: %d;@ unallocated_function_slots: \
-       @[<v>%a@];@ unallocated_value_slots: @[<v>%a@];@ allocated: \
-       @[<v>%a@]@]@]"
-      s.id s.first_slot_after_function_slots s.first_slot_used_by_value_slots
-      print_slot_descs s.unallocated_function_slots print_slot_descs
-      s.unallocated_value_slots print_slots s.allocated_slots
+      "@[<h>[pos: %a;@ size: %d;@ sets: %a;@ desc: %a;@ occurrences: %d;@ \
+       lowest_num_slots_in_sets: %d]@]@,"
+      print_slot_pos pos size print_set_ids sets print_desc desc occurrences
+      lowest_num_slots_in_sets
+
+  let print_any_slot fmt (Slot slot) = print_slot fmt slot
+
+  let print_any_slot_map fmt map =
+    Numeric_types.Int.Map.iter (fun _ slot -> print_any_slot fmt slot) map
+
+  let print_slot_list fmt list =
+    let pp_sep fmt () = Format.fprintf fmt ";@ " in
+    Format.pp_print_list ~pp_sep print_slot fmt list
+
+  let[@ocamlformat "disable"] print_set fmt s =
+    Format.fprintf fmt
+      "@[<v 2>%d:@ \
+         @[<v>first_slot_after_function_slots: %d;@ \
+              first_slot_used_by_value_slots: %d;@ \
+              allocated: @[<v>%a@]\
+          @]\
+        @]"
+      s.id
+      s.first_slot_after_function_slots
+      s.first_slot_used_by_value_slots
+      print_any_slot_map s.allocated_slots
 
   let print_sets fmt l =
     List.iter (function s -> Format.fprintf fmt "%a@ " print_set s) l
 
-  let [@ocamlformat "disable"] print fmt state =
+  let [@ocamlformat "disable"] print fmt {
+      used_offsets = _; function_slots = _; value_slots = _;
+      sets_of_closures; function_slots_to_assign; value_slots_to_assign; } =
     Format.fprintf fmt
-      "@[<v 2>Sets of closures:@ %a@]"
-      print_sets state.sets_of_closures
+      "@[<hov 1>(@,\
+          (function slots to assign@ @[<hov>%a@])@ \
+          (value slots to assign@ @[<hov>%a@])\
+          (sets of closures@ @[<hov>%a@])@,\
+       )@]"
+      print_slot_list function_slots_to_assign
+      print_slot_list value_slots_to_assign
+      print_sets sets_of_closures
   [@@warning "-32"]
 
   (* Keep the value slots offsets in sets up-to-date *)
 
-  let update_set_for_slot slot set =
+  let update_set_for_slot (type a) (slot : a slot) set =
     (match slot.pos with
     | Unassigned | Removed -> ()
-    | Assigned i -> (
+    | Assigned offset -> (
       match slot.desc with
       | Value_slot _ ->
+        let start, _ =
+          Exported_offset.range_used_by slot.desc offset ~slot_size:1
+        in
         set.first_slot_used_by_value_slots
-          <- min set.first_slot_used_by_value_slots i
+          <- min set.first_slot_used_by_value_slots start
       | Function_slot _ ->
+        let _, last =
+          Exported_offset.range_used_by slot.desc offset ~slot_size:slot.size
+        in
         set.first_slot_after_function_slots
-          <- max set.first_slot_after_function_slots (i + slot.size)));
+          <- max set.first_slot_after_function_slots last));
     if set.first_slot_used_by_value_slots < set.first_slot_after_function_slots
     then
       Misc.fatal_errorf
@@ -407,84 +502,110 @@ module Greedy = struct
 
   (* Slots *)
 
-  let is_function_slot slot =
-    match slot.desc with
-    | Function_slot _ ->
-      assert (slot.size = 2 || slot.size = 3);
-      true
-    | Value_slot _ ->
-      assert (slot.size = 1);
-      false
+  let range_used_by slot =
+    match slot.pos with
+    | Unassigned | Removed -> assert false
+    | Assigned offset ->
+      Exported_offset.range_used_by slot.desc offset ~slot_size:slot.size
 
-  let add_slot_offset_to_set offset slot set =
+  let add_slot_offset_to_set (type a) (slot : a slot) set =
+    let first_used_offset_by_slot, _ = range_used_by slot in
     update_set_for_slot slot set;
-    let map = set.allocated_slots in
-    assert (not (Numeric_types.Int.Map.mem offset map));
-    let map = Numeric_types.Int.Map.add offset slot map in
-    set.allocated_slots <- map
+    assert (
+      not
+        (Numeric_types.Int.Map.mem first_used_offset_by_slot set.allocated_slots));
+    set.allocated_slots
+      <- Numeric_types.Int.Map.add first_used_offset_by_slot (Slot slot)
+           set.allocated_slots
 
-  let add_slot_offset env slot offset =
+  let add_slot_offset state slot offset =
     assert (slot.pos = Unassigned);
     slot.pos <- Assigned offset;
-    List.iter (add_slot_offset_to_set offset slot) slot.sets;
-    match slot.desc with
-    | Function_slot c ->
-      let (info : EO.function_slot_info) =
-        EO.Live_function_slot { offset; size = slot.size }
-      in
-      EO.add_function_slot_offset env c info
-    | Value_slot v ->
-      let (info : EO.value_slot_info) = EO.Live_value_slot { offset } in
-      EO.add_value_slot_offset env v info
+    List.iter (add_slot_offset_to_set slot) slot.sets;
+    state.used_offsets
+      <- Exported_offset.add_slot_to_exported_offsets state.used_offsets
+           slot.desc offset ~slot_size:slot.size
 
-  let mark_slot_as_removed env slot =
+  let mark_slot_as_removed (type a) state (slot : a slot) =
     match slot.pos with
-    | Removed -> env
+    | Removed -> Misc.fatal_error "Slot already marked as removed"
     | Unassigned -> (
       slot.pos <- Removed;
       match slot.desc with
-      | Function_slot _ ->
-        (* CR gbury: we can actually remove function slots now, so this branch
-           could be updated accordingly. *)
-        Misc.fatal_error "Function_slot cannot be removed currently"
+      | Function_slot function_slot ->
+        let (info : EO.function_slot_info) = EO.Dead_function_slot in
+        state.used_offsets
+          <- EO.add_function_slot_offset state.used_offsets function_slot info
       | Value_slot v ->
         let (info : EO.value_slot_info) = EO.Dead_value_slot in
-        EO.add_value_slot_offset env v info)
+        state.used_offsets <- EO.add_value_slot_offset state.used_offsets v info
+      )
     | Assigned _ ->
       Misc.fatal_error "Cannot remove slot which is already assigned"
 
   (* Blocks with tag Closure_tag *)
 
-  let add_set_to_state state set =
-    { state with sets_of_closures = set :: state.sets_of_closures }
-
-  let add_unallocated_slot_to_set slot set =
+  let add_unallocated_slot_to_set (type a) state (slot : a slot) set =
     slot.sets <- set :: slot.sets;
     update_set_for_slot slot set;
     match slot.desc with
     | Function_slot _ ->
-      set.unallocated_function_slots <- slot :: set.unallocated_function_slots
+      state.function_slots_to_assign <- slot :: state.function_slots_to_assign
     | Value_slot _ ->
-      set.unallocated_value_slots <- slot :: set.unallocated_value_slots
+      state.value_slots_to_assign <- slot :: state.value_slots_to_assign
+
+  let add_allocated_slot_to_set slot set =
+    slot.sets <- set :: slot.sets;
+    add_slot_offset_to_set slot set
+
+  let update_metadata_for_function_slot set slot =
+    slot.occurrences <- slot.occurrences + 1;
+    slot.lowest_num_slots_in_sets
+      <- min slot.lowest_num_slots_in_sets set.num_function_slots
+
+  let update_metadata_for_value_slot set slot =
+    slot.occurrences <- slot.occurrences + 1;
+    slot.lowest_num_slots_in_sets
+      <- min slot.lowest_num_slots_in_sets set.num_value_slots
+
+  (* priority work queue *)
+
+  let compare_priority slot1 slot2 =
+    match slot1.occurrences, slot2.occurrences with
+    (* slots not shared are put at the end of the work queue, in an order that
+       doesn't matter since they are not shared *)
+    | 1, 1 -> 0
+    | 1, _ -> 1
+    | _, 1 -> -1
+    | _, _ -> (
+      match
+        compare slot1.lowest_num_slots_in_sets slot2.lowest_num_slots_in_sets
+      with
+      | 0 -> (
+        (* slots with the largest number of occurrences first *)
+        match compare slot2.occurrences slot1.occurrences with
+        | 0 ->
+          (* slots of size 3 before those of size 2 *)
+          compare slot2.size slot1.size
+        | c -> c)
+      | c ->
+        (* slots with the smallest "lowest number of slots" in sets first *)
+        c)
 
   (* Accumulator state *)
 
   let use_function_slot_info state c info =
-    let used_offsets = EO.add_function_slot_offset state.used_offsets c info in
-    { state with used_offsets }
+    state.used_offsets <- EO.add_function_slot_offset state.used_offsets c info
 
   let add_function_slot state function_slot slot =
-    let function_slots =
-      Function_slot.Map.add function_slot slot state.function_slots
-    in
-    { state with function_slots }
+    state.function_slots
+      <- Function_slot.Map.add function_slot slot state.function_slots
 
   let use_value_slot_info state var info =
-    let used_offsets = EO.add_value_slot_offset state.used_offsets var info in
-    { state with used_offsets }
+    state.used_offsets <- EO.add_value_slot_offset state.used_offsets var info
 
   let add_value_slot state var slot =
-    { state with value_slots = Value_slot.Map.add var slot state.value_slots }
+    state.value_slots <- Value_slot.Map.add var slot state.value_slots
 
   let find_function_slot state closure =
     Function_slot.Map.find_opt closure state.function_slots
@@ -493,345 +614,316 @@ module Greedy = struct
 
   (* Create slots (and create the cross-referencing). *)
 
-  let rec create_function_slots set state get_code_metadata = function
-    | [] -> state
-    | (c, code_id) :: r ->
-      let s, state =
-        match find_function_slot state c with
-        | Some s -> s, state
-        | None -> (
-          if Compilation_unit.is_current (Function_slot.get_compilation_unit c)
-          then
-            let code_metadata = get_code_metadata code_id in
-            let module CM = Code_metadata in
-            let is_tupled = CM.is_tupled code_metadata in
-            let params_arity = CM.params_arity code_metadata in
-            let arity = Flambda_arity.With_subkinds.cardinal params_arity in
-            let size = if arity = 1 && not is_tupled then 2 else 3 in
-            let s = create_slot size (Function_slot c) in
-            s, add_function_slot state c s
-          else
-            (* We should be guaranteed that the corresponding compilation unit's
-               cmx file has been read during the downward traversal. *)
-            let imported_offsets = EO.imported_offsets () in
-            match EO.function_slot_offset imported_offsets c with
-            | None ->
-              (* This means that there is no cmx for the given function slot
-                 (either because of opaque, (or missing cmx ?), or that the
-                 offset is missing from the cmx. In any case, this is a hard
-                 error: the function slot must have been given an offset by its
-                 own compilation unit, and we must know it to avoid choosing a
-                 different one. *)
-              Misc.fatal_errorf
-                "Could not find the offset for function slot %a from another \
-                 compilation unit (because of -opaque, or missing cmx)."
-                Function_slot.print c
-            | Some Dead_function_slot ->
-              Misc.fatal_errorf
-                "The function slot %a is dead in its original compilation \
-                 unit, it should not occur in a set of closures in this \
-                 compilation unit."
-                Function_slot.print c
-            | Some (Live_function_slot { offset; size } as info) ->
-              let s =
-                { desc = Function_slot c;
-                  size;
-                  pos = Assigned offset;
-                  sets = []
-                }
-              in
-              s, add_function_slot (use_function_slot_info state c info) c s)
+  let create_function_slot set state get_code_metadata function_slot code_id =
+    if Compilation_unit.is_current
+         (Function_slot.get_compilation_unit function_slot)
+    then (
+      let size =
+        let code_metadata = get_code_metadata code_id in
+        let module CM = Code_metadata in
+        let is_tupled = CM.is_tupled code_metadata in
+        let params_arity = CM.params_arity code_metadata in
+        let arity = Flambda_arity.With_subkinds.cardinal params_arity in
+        if (arity = 0 || arity = 1) && not is_tupled then 2 else 3
       in
-      let () = add_unallocated_slot_to_set s set in
-      create_function_slots set state get_code_metadata r
-
-  let rec create_value_slots set state = function
-    | [] -> state
-    | v :: r ->
-      let s, state =
-        match find_value_slot state v with
-        | Some s -> s, state
-        | None -> (
-          if Compilation_unit.is_current (Value_slot.get_compilation_unit v)
-          then
-            let s = create_slot 1 (Value_slot v) in
-            s, add_value_slot state v s
-          else
-            (* Same as the comments for the function_slots *)
-            let imported_offsets = EO.imported_offsets () in
-            match EO.value_slot_offset imported_offsets v with
-            | None ->
-              (* See comment for the function_slot *)
-              Misc.fatal_errorf
-                "Could not find the offset for value slot %a from another \
-                 compilation unit (because of -opaque, or missing cmx)."
-                Value_slot.print v
-            | Some Dead_value_slot ->
-              Misc.fatal_errorf
-                "The value slot %a has been removed by its original \
-                 compilation unit, it should not occur in a set of closures in \
-                 this compilation unit."
-                Value_slot.print v
-            | Some (Live_value_slot { offset } as info) ->
-              let s =
-                { desc = Value_slot v;
-                  size = 1;
-                  pos = Assigned offset;
-                  sets = []
-                }
-              in
-              s, add_value_slot (use_value_slot_info state v info) v s)
-      in
-      let () = add_unallocated_slot_to_set s set in
-      create_value_slots set state r
-
-  let create_slots_for_set state get_code_metadata set_id =
-    let set = make_set set_id in
-    let state = add_set_to_state state set in
-    (* Fill closure slots *)
-    let function_decls = Set_of_closures.function_decls set_id in
-    let closure_map = Function_declarations.funs function_decls in
-    let function_slots = Function_slot.Map.bindings closure_map in
-    let state =
-      create_function_slots set state get_code_metadata function_slots
-    in
-    (* Fill value slot slots *)
-    let env_map = Set_of_closures.value_slots set_id in
-    let value_slots = List.map fst (Value_slot.Map.bindings env_map) in
-    let state = create_value_slots set state value_slots in
-    state
-
-  (* Folding functions. To avoid pathological cases in allocating slots to
-     offsets, folding on slots is done by consuming the first unallocated slot
-     of each set of closures, and then repeating until all slots have been
-     consumed. *)
-
-  let rec fold_on_unallocated_function_slots f acc state =
-    let has_work_been_done = ref false in
-    let aux acc set =
-      match set.unallocated_function_slots with
-      | [] -> acc
-      | slot :: r ->
-        has_work_been_done := true;
-        set.unallocated_function_slots <- r;
-        f acc slot
-    in
-    let res = List.fold_left aux acc state.sets_of_closures in
-    if not !has_work_been_done
-    then res
-    else fold_on_unallocated_function_slots f res state
-
-  let rec fold_on_unallocated_value_slots ~used_value_slots f_kept f_removed acc
-      state =
-    let has_work_been_done = ref false in
-    let rec aux acc set =
-      match set.unallocated_value_slots with
-      | [] -> acc
-      | ({ desc = Value_slot v; _ } as slot) :: r ->
-        set.unallocated_value_slots <- r;
-        if keep_value_slot ~used_value_slots v
-        then (
-          has_work_been_done := true;
-          f_kept acc slot)
-        else aux (f_removed acc slot) set
-      | { desc = Function_slot _; _ } :: _ -> assert false
-      (* invariant *)
-    in
-    let res = List.fold_left aux acc state.sets_of_closures in
-    if not !has_work_been_done
-    then res
+      let s = create_slot ~size (Function_slot function_slot) Unassigned in
+      add_function_slot state function_slot s;
+      add_unallocated_slot_to_set state s set;
+      s)
     else
-      fold_on_unallocated_value_slots ~used_value_slots f_kept f_removed res
-        state
+      (* We should be guaranteed that the corresponding compilation unit's cmx
+         file has been read during the downward traversal. *)
+      let imported_offsets = EO.imported_offsets () in
+      match EO.function_slot_offset imported_offsets function_slot with
+      | None ->
+        (* This means that there is no cmx for the given function slot (either
+           because of opaque, (or missing cmx ?), or that the offset is missing
+           from the cmx. In any case, this is a hard error: the function slot
+           must have been given an offset by its own compilation unit, and we
+           must know it to avoid choosing a different one. *)
+        Misc.fatal_errorf
+          "Could not find the offset for function slot %a from another \
+           compilation unit (because of -opaque, or missing cmx)."
+          Function_slot.print function_slot
+      | Some Dead_function_slot ->
+        Misc.fatal_errorf
+          "The function slot %a is dead in its original compilation unit, it \
+           should not occur in a set of closures in this compilation unit."
+          Function_slot.print function_slot
+      | Some (Live_function_slot { offset; size } as info) ->
+        let offset = Exported_offset.from_exported_offset offset in
+        let s =
+          create_slot ~size (Function_slot function_slot) (Assigned offset)
+        in
+        use_function_slot_info state function_slot info;
+        add_function_slot state function_slot s;
+        add_allocated_slot_to_set s set;
+        s
+
+  let create_value_slot set state value_slot =
+    if Compilation_unit.is_current (Value_slot.get_compilation_unit value_slot)
+    then (
+      let s = create_slot ~size:1 (Value_slot value_slot) Unassigned in
+      add_value_slot state value_slot s;
+      add_unallocated_slot_to_set state s set;
+      s)
+    else
+      (* Same as the comments for the function_slots *)
+      let imported_offsets = EO.imported_offsets () in
+      match EO.value_slot_offset imported_offsets value_slot with
+      | None ->
+        (* See comment for the function_slot *)
+        Misc.fatal_errorf
+          "Could not find the offset for value slot %a from another \
+           compilation unit (because of -opaque, or missing cmx)."
+          Value_slot.print value_slot
+      | Some Dead_value_slot ->
+        Misc.fatal_errorf
+          "The value slot %a has been removed by its original compilation \
+           unit, it should not occur in a set of closures in this compilation \
+           unit."
+          Value_slot.print value_slot
+      | Some (Live_value_slot { offset } as info) ->
+        let offset = Exported_offset.from_exported_offset offset in
+        let s = create_slot ~size:1 (Value_slot value_slot) (Assigned offset) in
+        use_value_slot_info state value_slot info;
+        add_value_slot state value_slot s;
+        add_allocated_slot_to_set s set;
+        s
+
+  let create_slots_for_set state ~get_code_metadata set_of_closures =
+    let env_map = Set_of_closures.value_slots set_of_closures in
+    let closure_map =
+      let function_decls = Set_of_closures.function_decls set_of_closures in
+      Function_declarations.funs function_decls
+    in
+    let set =
+      create_set
+        ~num_value_slots:(Value_slot.Map.cardinal env_map)
+        ~num_function_slots:(Function_slot.Map.cardinal closure_map)
+    in
+    state.sets_of_closures <- set :: state.sets_of_closures;
+    (* Fill closure slots *)
+    Function_slot.Map.iter
+      (fun function_slot code_id ->
+        let s =
+          match
+            Function_slot.Map.find_opt function_slot state.function_slots
+          with
+          | None ->
+            create_function_slot set state get_code_metadata function_slot
+              code_id
+          | Some s -> s
+        in
+        update_metadata_for_function_slot set s)
+      closure_map;
+    (* Fill value slot slots *)
+    Value_slot.Map.iter
+      (fun value_slot _ ->
+        let s =
+          match Value_slot.Map.find_opt value_slot state.value_slots with
+          | None -> create_value_slot set state value_slot
+          | Some s -> s
+        in
+        update_metadata_for_value_slot set s)
+      env_map
 
   (* Find the first space available to fit a given slot.
 
      This function returns the first free offset with enough space to fit the
      slot (potential header included), but points at the start of the free space
-     (so the header word for function slots). Function {assign_offset} is here
-     to compute the actual offset/position from this free space start position.
+     (so the header word for function slots).
 
-     This function is a bit more complicated than necessary because each slot's
-     size does not include the headers for function slots. There are two reasons
-     for that choice:
+     In this function, for function slots, we manipulate offsets that include
+     the header (for both Infix header and Closure header). That means that we
+     start the search at offset -1, which is a valid offset for the first
+     function slot.
 
-     - the function slot at offset 0 does not need a header since it uses the
-     header of the whole block, so the necessity of a header is actually
-     dependant on the position of the function slot.
+     Note that since we enforce that each set of closures must have at least one
+     function slot (and that function slot must have a smaller offset than value
+     slots), we also guarantee that a value slot cannot be assigned at offset
+     -1. *)
 
-     - that way, the offset/position of a slot corresponds to the actual ocaml
-     pointer (which points at the first field of a block rather than the
-     header). *)
-
-  let first_free_offset slot set start =
-    let map = set.allocated_slots in
-    (* space needed to fit a slot at the current offset. *)
-    let needed_space curr =
-      if is_function_slot slot && curr <> 0 then slot.size + 1 else slot.size
+  let first_free_offset (type a) (slot : a slot) set start =
+    (* space needed to fit the slot *)
+    let needed_space =
+      match slot.desc with
+      | Function_slot _ -> slot.size + 1 (* header word *)
+      | Value_slot _ -> slot.size
     in
-    (* first offset used by a slot *)
-    let first_used_by s =
-      match s.pos with
-      | Unassigned | Removed -> assert false
-      | Assigned pos -> if is_function_slot s && pos <> 0 then pos - 1 else pos
-    in
-    (* first potentially free offset after a slot *)
-    let first_free_after slot =
-      match slot.pos with
-      | Unassigned | Removed -> assert false
-      | Assigned i -> i + slot.size
+    (* Ensure that for value slots, we are after all function slots. *)
+    let curr =
+      match slot.desc with
+      | Function_slot _ -> start
+      | Value_slot _ ->
+        (* first_slot_after_function_slots is always >=0, thus ensuring we do
+           not place a value slot at offset -1 *)
+        max start set.first_slot_after_function_slots
     in
     (* Adjust a starting position to not point in the middle of a block.
        Additionally, ensure the value slot slots are put after the function
        slots. *)
-    let adjust (curr : int) =
-      let curr =
-        if is_function_slot slot
-        then curr
-        else max curr set.first_slot_after_function_slots
-      in
-      match Numeric_types.Int.Map.find_last (fun i -> i <= curr) map with
+    let curr =
+      match
+        Numeric_types.Int.Map.find_last (fun i -> i <= curr) set.allocated_slots
+      with
       | exception Not_found -> curr
-      | j, s ->
-        assert (Assigned j = s.pos);
-        max curr (first_free_after s)
+      | _, Slot s ->
+        let _first_used_by_s, first_free_after_s = range_used_by s in
+        max curr first_free_after_s
     in
     (* find the first available space for the slot. *)
     let rec loop curr =
-      match Numeric_types.Int.Map.find_first (fun i -> i >= curr) map with
+      match
+        Numeric_types.Int.Map.find_first
+          (fun i -> i >= curr)
+          set.allocated_slots
+      with
       | exception Not_found -> curr
-      | _, next_slot ->
-        let available_space = first_used_by next_slot - curr in
+      | _, Slot next_slot ->
+        let next_slot_start, first_free_after_next_slot =
+          range_used_by next_slot
+        in
+        let available_space = next_slot_start - curr in
         assert (available_space >= 0);
-        if available_space >= needed_space curr
+        if available_space >= needed_space
         then curr
-        else loop (first_free_after next_slot)
+        else loop first_free_after_next_slot
     in
-    loop (adjust start)
-
-  (** Assign an offset using the current offset, assuming there is enough space *)
-  let assign_offset slot offset =
-    if not (is_function_slot slot)
-    then
-      offset
-      (* Function slots need a header (Infix_tag) before them, except for the
-         first one (which uses the Closure_tag header of the block itself). *)
-    else if offset = 0
-    then offset
-    else offset + 1
+    loop curr
 
   (* Loop to find the first free offset available for a slot given the set of
      sets in which it appears. *)
-  let rec first_available_offset slot start first_set other_sets =
-    let aux ((_, offset) as acc) s =
-      let new_offset = first_free_offset slot s offset in
-      assert (new_offset >= offset);
-      if new_offset = offset then acc else true, new_offset
-    in
-    let start = first_free_offset slot first_set start in
-    let changed, offset = List.fold_left aux (false, start) other_sets in
-    if not changed
-    then assign_offset slot offset
-    else first_available_offset slot offset first_set other_sets
-
-  let first_available_offset slot start = function
-    | s :: r -> first_available_offset slot start s r
-    | [] ->
-      (* Internal invariant: a slot cannot have an empty list of sets it belongs
-         to (at least not slots for which we need to assign an offset), thus
-         this case cannot happen. *)
-      assert false
+  let rec first_available_offset slot ~minimal_offset = function
+    | [set] ->
+      let offset = first_free_offset slot set minimal_offset in
+      Exported_offset.mk slot.desc ~first_offset_used_including_header:offset
+    | sets ->
+      let offset =
+        List.fold_left
+          (fun offset set ->
+            let new_offset = first_free_offset slot set offset in
+            assert (new_offset >= offset);
+            new_offset)
+          minimal_offset sets
+      in
+      if minimal_offset = offset
+      then
+        Exported_offset.mk slot.desc ~first_offset_used_including_header:offset
+      else first_available_offset slot ~minimal_offset:offset sets
 
   (* Assign offsets to function slots *)
 
-  let assign_slot_offset env slot =
+  let assign_slot_offset state slot =
     match slot.pos with
     | Unassigned ->
-      let offset = first_available_offset slot 0 slot.sets in
-      add_slot_offset env slot offset
-    | Assigned _pos -> env
+      let offset = first_available_offset slot ~minimal_offset:~-1 slot.sets in
+      add_slot_offset state slot offset
+    | Assigned _pos -> Misc.fatal_error "Slot has already been assigned"
     | Removed ->
       Misc.fatal_error
         "Slot has been explicitly removed, it cannot be assigned anymore"
 
-  let assign_function_slot_offsets state env =
-    fold_on_unallocated_function_slots assign_slot_offset env state
+  let assign_function_slot_offsets ~used_function_slots state =
+    let function_slots_to_assign =
+      List.sort compare_priority state.function_slots_to_assign
+    in
+    state.function_slots_to_assign <- [];
+    List.iter
+      (function
+        | { desc = Function_slot f; _ } as slot ->
+          if function_slot_is_used ~used_function_slots f
+          then assign_slot_offset state slot
+          else
+            assign_slot_offset state slot
+            (* CR chambart/gbury: we currently do not track the used function
+               slots precisely enough in simplify/data_flow *)
+            (* else mark_slot_as_removed state slot *))
+      function_slots_to_assign
 
-  let assign_value_slot_offsets ~used_value_slots state env =
-    fold_on_unallocated_value_slots ~used_value_slots assign_slot_offset
-      mark_slot_as_removed env state
+  let assign_value_slot_offsets ~used_value_slots state =
+    let value_slots_to_assign =
+      List.sort compare_priority state.value_slots_to_assign
+    in
+    state.value_slots_to_assign <- [];
+    List.iter
+      (function
+        | { desc = Value_slot v; _ } as slot ->
+          if value_slot_is_used ~used_value_slots v
+          then assign_slot_offset state slot
+          else mark_slot_as_removed state slot)
+      value_slots_to_assign
 
-  (* Ensure function slots/value slots that are used in projections in the
-     current compilation unit are present in the offsets returned by finalize *)
-  let imported_and_used_offsets ~used_slots state =
-    match (used_slots : _ Or_unknown.t) with
-    | Known
-        { function_slots_in_normal_projections;
+  (* Ensure function slots/value slots that appear in the code for the current
+     compilation unit are present in the offsets returned by finalize *)
+  let add_used_imported_offsets ~used_slots state =
+    let { function_slots_in_normal_projections;
           all_function_slots;
           value_slots_in_normal_projections;
           all_value_slots
-        } ->
-      state.used_offsets
-      |> reexport_function_slots function_slots_in_normal_projections
-      |> reexport_function_slots all_function_slots
-      |> reexport_value_slots value_slots_in_normal_projections
-      |> reexport_value_slots all_value_slots
-    | Unknown -> EO.imported_offsets ()
+        } =
+      used_slots
+    in
+    state.used_offsets
+      <- state.used_offsets
+         |> EO.reexport_function_slots function_slots_in_normal_projections
+         |> EO.reexport_function_slots all_function_slots
+         |> EO.reexport_value_slots value_slots_in_normal_projections
+         |> EO.reexport_value_slots all_value_slots
 
   (* We only want to keep value slots that appear in the creation of a set of
      closures, *and* appear as projection (at normal name mode). And we need to
      mark value_slots/ids that are not live, as dead in the exported_offsets, so
      that later compilation unit do not mistake that for a missing offset info
      on a value_slot/id. *)
-  let live_value_slots state offsets used_slots =
-    match (used_slots : used_slots Or_unknown.t) with
-    | Unknown -> Or_unknown.Unknown, offsets
-    | Known
-        { value_slots_in_normal_projections;
-          function_slots_in_normal_projections;
-          _
-        } ->
-      let offsets =
-        Function_slot.Set.fold
-          (fun function_slot acc ->
-            if Compilation_unit.is_current
-                 (Function_slot.get_compilation_unit function_slot)
-            then
-              match find_function_slot state function_slot with
-              | Some _ -> acc
-              | None ->
-                EO.add_function_slot_offset acc function_slot Dead_function_slot
-            else acc)
-          function_slots_in_normal_projections offsets
-      in
-      let offsets = ref offsets in
-      let used_value_slots =
-        Value_slot.Set.filter
-          (fun value_slot ->
-            if Compilation_unit.is_current
-                 (Value_slot.get_compilation_unit value_slot)
-            then (
-              (* a value slot appears in a set of closures iff it has a slot *)
-              match find_value_slot state value_slot with
-              | Some _ -> true
-              | None ->
-                offsets
-                  := EO.add_value_slot_offset !offsets value_slot
-                       Dead_value_slot;
-                false)
-            else true)
-          value_slots_in_normal_projections
-      in
-      Or_unknown.Known used_value_slots, !offsets
+  let live_slots state
+      { value_slots_in_normal_projections;
+        function_slots_in_normal_projections;
+        _
+      } =
+    let live_function_slots =
+      Function_slot.Set.filter
+        (fun function_slot ->
+          if Compilation_unit.is_current
+               (Function_slot.get_compilation_unit function_slot)
+          then (
+            match find_function_slot state function_slot with
+            | Some _ -> true
+            | None ->
+              state.used_offsets
+                <- EO.add_function_slot_offset state.used_offsets function_slot
+                     Dead_function_slot;
+              false)
+          else true)
+        function_slots_in_normal_projections
+    in
+    let live_value_slots =
+      Value_slot.Set.filter
+        (fun value_slot ->
+          if Compilation_unit.is_current
+               (Value_slot.get_compilation_unit value_slot)
+          then (
+            (* a value slot appears in a set of closures iff it has a slot *)
+            match find_value_slot state value_slot with
+            | Some _ -> true
+            | None ->
+              state.used_offsets
+                <- EO.add_value_slot_offset state.used_offsets value_slot
+                     Dead_value_slot;
+              false)
+          else true)
+        value_slots_in_normal_projections
+    in
+    live_function_slots, live_value_slots
 
   (* Transform an internal accumulator state for slots into an actual mapping
      that assigns offsets. *)
   let finalize ~used_slots state =
-    let offsets = imported_and_used_offsets ~used_slots state in
-    let used_value_slots, offsets = live_value_slots state offsets used_slots in
-    let offsets = assign_function_slot_offsets state offsets in
-    let offsets = assign_value_slot_offsets ~used_value_slots state offsets in
-    used_value_slots, offsets
+    add_used_imported_offsets ~used_slots state;
+    let used_function_slots, used_value_slots = live_slots state used_slots in
+    assign_function_slot_offsets ~used_function_slots state;
+    assign_value_slot_offsets ~used_value_slots state;
+    { used_value_slots; exported_offsets = state.used_offsets }
 end
 
 type t = Set_of_closures.t list
@@ -839,7 +931,7 @@ type t = Set_of_closures.t list
 let print fmt l =
   Format.fprintf fmt "@[<hv>%a@]" (Format.pp_print_list Set_of_closures.print) l
 
-let create () = []
+let empty = []
 
 let add_set_of_closures l ~is_phantom set_of_closures =
   if is_phantom then l else set_of_closures :: l
@@ -852,22 +944,8 @@ let finalize_offsets ~get_code_metadata ~used_slots l =
   let state = ref (Greedy.create_initial_state ()) in
   Misc.try_finally
     (fun () ->
-      List.iter
-        (fun set_of_closures ->
-          state
-            := Greedy.create_slots_for_set !state get_code_metadata
-                 set_of_closures)
-        l;
+      List.iter (Greedy.create_slots_for_set !state ~get_code_metadata) l;
       Greedy.finalize ~used_slots !state)
     ~always:(fun () ->
       if Flambda_features.dump_slot_offsets ()
       then Format.eprintf "%a@." Greedy.print !state)
-
-let function_slot_symbol function_slot =
-  let compunit = Function_slot.get_compilation_unit function_slot in
-  let name = Compilation_unit.get_linkage_name compunit in
-  Format.asprintf "%a__%s" Linkage_name.print name
-    (Function_slot.to_string function_slot)
-
-let code_symbol ~function_slot_symbol =
-  Format.asprintf "%s_code" function_slot_symbol

--- a/middle_end/flambda2/simplify_shared/slot_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.mli
@@ -33,11 +33,26 @@ type used_slots =
             of name mode *)
   }
 
+(** The result of the slot offset computation *)
+type result =
+  { exported_offsets : Exported_offsets.t;
+        (** This includes all offsets for function/value slots that occur in the
+            current compilation unit. This includes offsets for slots from other
+            compilation units that appear in the current compilation unit.
+
+            Some slots can be marked as dead, because they are unused but
+            simplify could not remove them. For instance, this occurs for unused
+            value slots of non-liftable functions (.e.g in functors). *)
+    used_value_slots : Value_slot.Set.t
+        (** This is the set of values slots that appears after simplify, minus
+            the slots that are marked as dead in [exported_offsets]. *)
+  }
+
 (** Printing function. *)
 val print : Format.formatter -> t -> unit
 
 (** Create an empty set of constraints. *)
-val create : unit -> t
+val empty : t
 
 (** Add a set of closure to the set of constraints. *)
 val add_set_of_closures : t -> is_phantom:bool -> Set_of_closures.t -> t
@@ -51,56 +66,43 @@ val add_offsets_from_function : t -> from_function:t -> t
     for more details). *)
 val finalize_offsets :
   get_code_metadata:(Code_id.t -> Code_metadata.t) ->
-  used_slots:used_slots Or_unknown.t ->
+  used_slots:used_slots ->
   t ->
-  Value_slot.Set.t Or_unknown.t * Exported_offsets.t
-
-(** {2 Helper functions} *)
-
-(** Returns the function symbol for a function slot. *)
-val function_slot_symbol : Function_slot.t -> string
-
-(** Turn a function slot symbol (as returned by [function_slot_symbol]) into the
-    symbol for the corresponding piece of code. *)
-val code_symbol : function_slot_symbol:string -> string
-
-(** Ensure the offsets for the given function slots are in the given exported
-    offsets. *)
-val reexport_function_slots :
-  Function_slot.Set.t -> Exported_offsets.t -> Exported_offsets.t
-
-(** Ensure the offsets for the given function slots are in the given exported
-    offsets. *)
-val reexport_value_slots :
-  Value_slot.Set.t -> Exported_offsets.t -> Exported_offsets.t
+  result
 
 (** {2 Offsets & Layouts} *)
+module Layout : sig
+  (**)
 
-(** Layout slots, aka what might be found in a block at a given offset. A layout
-    slot can take up more than one word of memory (this is the case for
-    closures, which can take either 2 or 3 words depending on arity). *)
-type layout_slot = private
-  | Value_slot of Value_slot.t
-  | Infix_header
-  | Function_slot of Function_slot.t
-(**)
+  (** Layout slots, aka what might be found in a block at a given offset. A
+      layout slot can take up more than one word of memory (this is the case for
+      closures, which can take either 2 or 3 words depending on arity). *)
+  type slot = private
+    | Value_slot of Value_slot.t
+    | Infix_header
+    | Function_slot of
+        { size : int;
+          function_slot : Function_slot.t
+        }
+  (**)
 
-(** Alias for complete layouts. The list is sorted according to offsets (in
-    increasing order). *)
-type layout = private
-  { startenv : int;
-    empty_env : bool;
-    slots : (int * layout_slot) list
-  }
+  (** Alias for complete layouts. The list is sorted according to offsets (in
+      increasing order). *)
+  type t = private
+    { startenv : int;
+      empty_env : bool;
+      slots : (int * slot) list
+    }
 
-(** Order the given function slots and env vars into a list of layout slots
-    together with their respective offset. Note that there may be holes between
-    the offsets. *)
-val layout :
-  Exported_offsets.t -> _ Function_slot.Lmap.t -> _ Value_slot.Map.t -> layout
+  (** Order the given function slots and env vars into a list of layout slots
+      together with their respective offset. Note that there may be holes
+      between the offsets. *)
+  val make :
+    Exported_offsets.t -> _ Function_slot.Lmap.t -> _ Value_slot.Map.t -> t
 
-(** Printing function for layouts. *)
-val print_layout : Format.formatter -> layout -> unit
+  (** Printing function for layouts. *)
+  val print : Format.formatter -> t -> unit
 
-(** Printing functions for layout slots. *)
-val print_layout_slot : Format.formatter -> layout_slot -> unit
+  (** Printing functions for layout slots. *)
+  val print_slot : Format.formatter -> slot -> unit
+end

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -149,7 +149,13 @@ end = struct
       (* We build here the **reverse** list of fields for the function slot *)
       match closure_code_pointers with
       | Full_application_only ->
-        assert (size = 2);
+        if size <> 2
+        then
+          Misc.fatal_errorf
+            "fill_slot: Function slot %a is of size %d, but it is used to \
+             store code ID %a which is classified as Full_application_only (so \
+             the expected size is 2)"
+            Function_slot.print function_slot size Code_id.print code_id;
         let acc =
           P.int ~dbg closure_info
           :: P.symbol_from_linkage_name ~dbg code_linkage_name
@@ -157,7 +163,13 @@ end = struct
         in
         acc, slot_offset + size, env, Ece.pure, updates
       | Full_and_partial_application ->
-        assert (size = 3);
+        if size <> 3
+        then
+          Misc.fatal_errorf
+            "fill_slot: Function slot %a is of size %d, but it is used to \
+             store code ID %a which is classified as \
+             Full_and_partial_application (so the expected size is 3)"
+            Function_slot.print function_slot size Code_id.print code_id;
         let acc =
           P.symbol_from_linkage_name ~dbg code_linkage_name
           :: P.int ~dbg closure_info

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -90,13 +90,13 @@ end) : sig
     Env.t ->
     Ece.t ->
     prev_updates:Cmm.expression option ->
-    (int * Slot_offsets.layout_slot) list ->
+    (int * Slot_offsets.Layout.slot) list ->
     P.cmm_term list * int * Env.t * Ece.t * Cmm.expression option
 end = struct
   (* The [offset]s here are measured in units of words. *)
   let fill_slot for_static_sets decls dbg ~startenv value_slots env acc
       ~slot_offset updates slot =
-    match (slot : Slot_offsets.layout_slot) with
+    match (slot : Slot_offsets.Layout.slot) with
     | Infix_header ->
       let field = P.infix_header ~function_slot_offset:(slot_offset + 1) ~dbg in
       field :: acc, slot_offset + 1, env, Ece.pure, updates
@@ -125,8 +125,8 @@ end = struct
             env, [P.int ~dbg 1n], updates)
       in
       List.rev_append fields acc, slot_offset + 1, env, eff, updates
-    | Function_slot c -> (
-      let code_id = Function_slot.Map.find c decls in
+    | Function_slot { size; function_slot } -> (
+      let code_id = Function_slot.Map.find function_slot decls in
       let code_linkage_name = Code_id.linkage_name code_id in
       let arity, closure_code_pointers, dbg =
         get_func_decl_params_arity env code_id
@@ -138,7 +138,9 @@ end = struct
         match for_static_sets with
         | None -> acc
         | Some { closure_symbols; _ } ->
-          let function_symbol = Function_slot.Map.find c closure_symbols in
+          let function_symbol =
+            Function_slot.Map.find function_slot closure_symbols
+          in
           List.rev_append
             (P.define_global_symbol
                (Symbol.linkage_name_as_string function_symbol))
@@ -147,13 +149,15 @@ end = struct
       (* We build here the **reverse** list of fields for the function slot *)
       match closure_code_pointers with
       | Full_application_only ->
+        assert (size = 2);
         let acc =
           P.int ~dbg closure_info
           :: P.symbol_from_linkage_name ~dbg code_linkage_name
           :: acc
         in
-        acc, slot_offset + 2, env, Ece.pure, updates
+        acc, slot_offset + size, env, Ece.pure, updates
       | Full_and_partial_application ->
+        assert (size = 3);
         let acc =
           P.symbol_from_linkage_name ~dbg code_linkage_name
           :: P.int ~dbg closure_info
@@ -161,7 +165,7 @@ end = struct
                (Linkage_name.create (C.curry_function_sym arity))
           :: acc
         in
-        acc, slot_offset + 3, env, Ece.pure, updates)
+        acc, slot_offset + size, env, Ece.pure, updates)
 
   let rec fill_layout0 for_static_sets decls dbg ~startenv value_slots env effs
       acc updates ~starting_offset slots =
@@ -295,7 +299,7 @@ let params_and_body env res code_id p ~fun_dbg ~translate_expr =
 (* Translation of sets of closures. *)
 
 let layout_for_set_of_closures env set =
-  Slot_offsets.layout (Env.exported_offsets env)
+  Slot_offsets.Layout.make (Env.exported_offsets env)
     (Set_of_closures.function_decls set |> Function_declarations.funs_in_order)
     (Set_of_closures.value_slots set)
 
@@ -314,7 +318,7 @@ let debuginfo_for_set_of_closures env set =
   match dbg with [] -> Debuginfo.none | dbg :: _ -> dbg
 
 let let_static_set_of_closures0 env closure_symbols
-    (layout : Slot_offsets.layout) set ~prev_updates =
+    (layout : Slot_offsets.Layout.t) set ~prev_updates =
   let fun_decls = Set_of_closures.function_decls set in
   let decls = Function_declarations.funs fun_decls in
   let value_slots = Set_of_closures.value_slots set in
@@ -324,9 +328,9 @@ let let_static_set_of_closures0 env closure_symbols
   let function_slot_offset_for_updates, closure_symbol_for_updates =
     match
       List.find_map
-        (fun (offset, (layout_slot : Slot_offsets.layout_slot)) ->
+        (fun (offset, (layout_slot : Slot_offsets.Layout.slot)) ->
           match layout_slot with
-          | Function_slot function_slot -> Some (offset, function_slot)
+          | Function_slot { function_slot; _ } -> Some (offset, function_slot)
           | Infix_header | Value_slot _ -> None)
         layout.slots
     with
@@ -422,7 +426,7 @@ let lift_set_of_closures env res ~body ~bound_vars layout set ~translate_expr =
   translate_expr env res body
 
 let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
-    (layout : Slot_offsets.layout) ~num_normal_occurrences_of_bound_vars
+    (layout : Slot_offsets.Layout.t) ~num_normal_occurrences_of_bound_vars
     ~(closure_alloc_mode : Alloc_mode.t) ~translate_expr =
   let fun_decls = Set_of_closures.function_decls set in
   let decls = Function_declarations.funs_in_order fun_decls in


### PR DESCRIPTION
This PR brings back #700 by reverting the revert commit, and adding the extra arity fix in `Slot_offsets.create_function_slot` on top.
The code before #700 was actually wrong, allocating a slot of size 3 for functions of arity 0, but the only consequence was that the allocated closures were bigger than necessary (the extra field is never seen by the GC, and I don't think the probe closures ever end up called indirectly so the code parts of the closure never get read).

I can transform the offending assertions in `To_cmm_set_of_closures` into proper fatal errors too, if needed.