### PR TITLE
Static check for noalloc and friends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,6 +373,7 @@ fmt:
 	  $$(find backend/debug \
 	    \( -name "*.ml" -or -name "*.mli" \))
 	ocamlformat -i backend/cmm_helpers.ml{,i}
+	ocamlformat -i backend/checkmach.ml{,i}
 	ocamlformat -i tools/merge_archives.ml
 	ocamlformat -i \
 	  $$(find backend/debug/dwarf \
@@ -387,6 +388,7 @@ check-fmt:
            [ "$$(git status --porcelain backend/asm_targets)" != "" ] || \
            [ "$$(git status --porcelain backend/debug)" != "" ] || \
            [ "$$(git status --porcelain backend/cmm_helpers.ml{,i})" != "" ] || \
+           [ "$$(git status --porcelain backend/checkmach.ml{,i})" != "" ] || \
            [ "$$(git status --porcelain tools/merge_archives.ml)" != "" ]; then \
 	  echo; \
 	  echo "Tree must be clean before running 'make check-fmt'"; \
@@ -400,6 +402,7 @@ check-fmt:
            [ "$$(git diff backend/asm_targets)" != "" ] || \
            [ "$$(git diff backend/debug)" != "" ] || \
            [ "$$(git diff backend/cmm_helpers.ml{,i})" != "" ] || \
+           [ "$$(git diff backend/checkmach.ml{,i})" != "" ] || \
            [ "$$(git diff tools/merge_archives.ml)" != "" ]; then \
 	  echo; \
 	  echo "The following code was not formatted correctly:"; \

--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -2,6 +2,8 @@ cmm_helpers.ml
 cmm_helpers.mli
 internal_assembler/*.ml
 internal_assembler/*.mli
+checkmach.ml
+checkmach.mli
 cfg/**/*.ml
 cfg/**/*.mli
 asm_targets/**/*.ml

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -88,6 +88,7 @@ let (pass_to_cfg : Cfg_format.cfg_unit_info Compiler_pass_map.t) =
   |> Compiler_pass_map.add Compiler_pass.Selection (new_cfg_unit_info ())
 
 let reset () =
+  Checkmach.reset_unit_info ();
   start_from_emit := false;
   Compiler_pass_map.iter (fun pass (cfg_unit_info : Cfg_format.cfg_unit_info) ->
     if should_save_ir_after pass then begin
@@ -360,6 +361,7 @@ let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
   ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_live
   ++ pass_dump_if ppf_dump dump_live "Liveness analysis"
+  ++ Checkmach.fundecl ppf_dump
   ++ (fun (fd : Mach.fundecl) ->
     let force_linscan = should_use_linscan fd in
       match force_linscan, register_allocator with
@@ -448,6 +450,7 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduc
        Misc.try_finally
          (fun () ->
             gen ();
+            Checkmach.record_unit_info ();
             write_ir output_prefix)
          ~always:(fun () ->
              if create_asm then close_out !Emitaux.output_channel)

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -438,7 +438,8 @@ let compile_genfuns ?dwarf ~ppf_dump f =
        (Cmm_helpers.Generic_fns_tbl.of_fns
           (Compilenv.current_unit_infos ()).ui_generic_fns))
 
-let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduce_heap gen =
+let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduce_heap
+        ~ppf_dump gen =
   reset ();
   let create_asm = should_emit () &&
                    (keep_asm || not !Emitaux.binary_backend_available) in
@@ -450,7 +451,7 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduc
        Misc.try_finally
          (fun () ->
             gen ();
-            Checkmach.record_unit_info ();
+            Checkmach.record_unit_info ppf_dump;
             write_ir output_prefix)
          ~always:(fun () ->
              if create_asm then close_out !Emitaux.output_channel)
@@ -603,7 +604,7 @@ let asm_filename output_prefix =
 
 let compile_implementation unix ?toplevel ~backend ~filename ~prefixname
       ~middle_end ~ppf_dump (program : Lambda.program) =
-  compile_unit ~output_prefix:prefixname
+  compile_unit ~ppf_dump ~output_prefix:prefixname
     ~asm_filename:(asm_filename prefixname) ~keep_asm:!keep_asm_file
     ~obj_filename:(prefixname ^ ext_obj)
     ~may_reduce_heap:(Option.is_none toplevel)
@@ -618,7 +619,7 @@ let compile_implementation unix ?toplevel ~backend ~filename ~prefixname
 let compile_implementation_flambda2 unix ?toplevel ?(keep_symbol_tables=true)
     ~filename ~prefixname ~size:module_block_size_in_words ~module_ident
     ~module_initializer ~flambda2 ~ppf_dump ~required_globals () =
-  compile_unit ~output_prefix:prefixname
+  compile_unit ~ppf_dump ~output_prefix:prefixname
     ~asm_filename:(asm_filename prefixname) ~keep_asm:!keep_asm_file
     ~obj_filename:(prefixname ^ ext_obj)
     ~may_reduce_heap:(Option.is_none toplevel)

--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -62,8 +62,12 @@ val compile_implementation_flambda2
   -> unit
   -> unit
 
-val compile_implementation_linear :
-    (module Compiler_owee.Unix_intf.S) -> string -> progname:string -> unit
+val compile_implementation_linear
+  : (module Compiler_owee.Unix_intf.S)
+  -> string
+  -> progname:string
+  -> ppf_dump:Format.formatter
+  -> unit
 
 val compile_phrase
   : ?dwarf:Dwarf_ocaml.Dwarf.t
@@ -85,6 +89,7 @@ val compile_unit
    -> keep_asm:bool
    -> obj_filename:string
    -> may_reduce_heap:bool
+   -> ppf_dump:Format.formatter
    -> (unit -> unit)
    -> unit
 

--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -388,6 +388,7 @@ let link_shared ~ppf_dump objfiles output_name =
       ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
       ~obj_filename:startup_obj
       ~may_reduce_heap:true
+      ~ppf_dump
       (fun () ->
          make_shared_startup_file ~ppf_dump genfns units_tolink
       );
@@ -459,6 +460,7 @@ let link unix ~ppf_dump objfiles output_name =
       ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
       ~obj_filename:startup_obj
       ~may_reduce_heap:true
+      ~ppf_dump
       (fun () -> make_startup_file unix ~ppf_dump ~named_startup_file
         ~filename:startup genfns units_tolink);
     Emitaux.reduce_heap_size ~reset:(fun () -> reset ());

--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -282,6 +282,8 @@ let build_package_cmx members cmxfile =
     else
       Clambda (get_approx ui)
   in
+  let ui_checks = Compilenv.Checks.create () in
+  List.iter (fun info -> Compilenv.Checks.merge info.ui_checks ~into:ui_checks) units;
   Export_info_for_pack.clear_import_state ();
   let pkg_infos =
     { ui_name = ui.ui_name;
@@ -304,6 +306,7 @@ let build_package_cmx members cmxfile =
       ui_force_link =
           List.exists (fun info -> info.ui_force_link) units;
       ui_export_info;
+      ui_checks;
     } in
   Compilenv.write_unit_info pkg_infos cmxfile
 

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -41,6 +41,7 @@ module S = struct
   type external_call_operation =
     { func_symbol : string;
       alloc : bool;
+      effects : Cmm.effects;
       ty_res : Cmm.machtype;
       ty_args : Cmm.exttype list
     }

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -78,7 +78,8 @@ let destroyed_at_basic : Cfg.basic -> Reg.t array =
     | P (External { func_symbol; alloc; ty_res; ty_args; effects }) ->
       let func = func_symbol in
       let returns = true in
-      at_oper (Iop (Iextcall { func; ty_res; ty_args; alloc; returns; effects }))
+      at_oper
+        (Iop (Iextcall { func; ty_res; ty_args; alloc; returns; effects }))
     | P (Alloc { bytes; dbginfo; mode }) ->
       at_oper (Iop (Ialloc { bytes; dbginfo; mode }))
     | P (Checkbound { immediate }) -> (
@@ -123,7 +124,8 @@ let destroyed_at_terminator : Cfg.terminator -> Reg.t array =
   | Call_no_return { func_symbol; alloc; ty_res; ty_args; effects } ->
     let func = func_symbol in
     let returns = false in
-    at_oper (Mach.Iop (Iextcall { func; ty_res; ty_args; alloc; returns; effects }))
+    at_oper
+      (Mach.Iop (Iextcall { func; ty_res; ty_args; alloc; returns; effects }))
 
 let[@inline] int_max (left : int) (right : int) = Stdlib.max left right
 

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -75,10 +75,10 @@ let destroyed_at_basic : Cfg.basic -> Reg.t array =
              { ident; which_parameter; provenance; is_assignment }))
   | Call c -> (
     match c with
-    | P (External { func_symbol; alloc; ty_res; ty_args }) ->
+    | P (External { func_symbol; alloc; ty_res; ty_args; effects }) ->
       let func = func_symbol in
       let returns = true in
-      at_oper (Iop (Iextcall { func; ty_res; ty_args; alloc; returns }))
+      at_oper (Iop (Iextcall { func; ty_res; ty_args; alloc; returns; effects }))
     | P (Alloc { bytes; dbginfo; mode }) ->
       at_oper (Iop (Ialloc { bytes; dbginfo; mode }))
     | P (Checkbound { immediate }) -> (
@@ -120,10 +120,10 @@ let destroyed_at_terminator : Cfg.terminator -> Reg.t array =
     | Func (Direct { func_symbol }) ->
       let func = func_symbol in
       at_oper (Mach.Iop (Itailcall_imm { func })))
-  | Call_no_return { func_symbol; alloc; ty_res; ty_args } ->
+  | Call_no_return { func_symbol; alloc; ty_res; ty_args; effects } ->
     let func = func_symbol in
     let returns = false in
-    at_oper (Mach.Iop (Iextcall { func; ty_res; ty_args; alloc; returns }))
+    at_oper (Mach.Iop (Iextcall { func; ty_res; ty_args; alloc; returns; effects }))
 
 let[@inline] int_max (left : int) (right : int) = Stdlib.max left right
 

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -149,8 +149,10 @@ let basic_or_terminator_of_operation :
          (if String.equal (State.get_fun_name state) func
          then Self { destination = State.get_tailrec_label state }
          else Func (Direct { func_symbol = func })))
-  | Iextcall { func; ty_res; ty_args; alloc; returns } ->
-    let external_call = { Cfg.func_symbol = func; alloc; ty_res; ty_args } in
+  | Iextcall { func; ty_res; ty_args; alloc; effects; returns } ->
+    let external_call =
+      { Cfg.func_symbol = func; alloc; effects; ty_res; ty_args }
+    in
     if returns
     then Basic (Call (P (External external_call)))
     else Terminator (Call_no_return external_call)

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -373,8 +373,8 @@ let to_basic (mop : Mach.operation) : C.basic =
   match mop with
   | Icall_ind -> Call (F Indirect)
   | Icall_imm { func } -> Call (F (Direct { func_symbol = func }))
-  | Iextcall { func; alloc; ty_args; ty_res; returns = true } ->
-    Call (P (External { func_symbol = func; alloc; ty_args; ty_res }))
+  | Iextcall { func; alloc; effects; ty_args; ty_res; returns = true } ->
+    Call (P (External { func_symbol = func; alloc; effects; ty_args; ty_res }))
   | Iintop Icheckbound -> Call (P (Checkbound { immediate = None }))
   | Iintop
       (( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
@@ -584,9 +584,9 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
       in
       add_terminator t block i desc ~stack_offset ~traps;
       create_blocks t i.next block ~stack_offset ~traps
-    | Iextcall { func; alloc; ty_args; ty_res; returns = false } ->
+    | Iextcall { func; alloc; effects; ty_args; ty_res; returns = false } ->
       let desc =
-        C.Call_no_return { func_symbol = func; alloc; ty_args; ty_res }
+        C.Call_no_return { func_symbol = func; alloc; effects; ty_args; ty_res }
       in
       add_terminator t block i desc ~stack_offset ~traps;
       create_blocks t i.next block ~stack_offset ~traps

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -1,0 +1,637 @@
+(**********************************************************************************
+ *                             MIT License                                        *
+ *                                                                                *
+ *                                                                                *
+ * Copyright (c) 2022-2022 Jane Street Group LLC                                  *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ *                                                                                *
+ **********************************************************************************)
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+module StringSet = Misc.Stdlib.String.Set
+
+type error =
+  | Annotation of
+      { fun_name : string;
+        check : string
+      }
+
+exception Error of error
+
+module Value = struct
+  type t =
+    | Pass
+    | Fail
+    | Unknown
+
+  let to_string = function
+    | Pass -> "pass"
+    | Fail -> "fail"
+    | Unknown -> "unknown"
+end
+
+module Func_info = struct
+  type t =
+    { name : string;  (** function name *)
+      mutable value : Value.t;  (** the result of the check *)
+      mutable callers : string list;
+          (** unresolved dependencies. if not empty then value is Unknown. *)
+      mutable in_current_unit : bool;
+          (** is the function known to be defined in the current unit? *)
+      mutable annotated : bool  (** is the function annotated *)
+    }
+
+  let create name value =
+    { name; value; callers = []; in_current_unit = false; annotated = false }
+end
+
+(* Return true if [str] starts with "caml_apply". This is conservative. *)
+let is_caml_apply str =
+  (* CR-someday gyorsh: propagate information about caml_apply from cmm to mach
+     instead of reverse-engineering it from the symbol name. *)
+  let caml_apply_prefix = "caml_apply" in
+  let caml_apply_len = String.length caml_apply_prefix in
+  String.length str >= caml_apply_len
+  && String.sub str 0 caml_apply_len = caml_apply_prefix
+
+(** Configure the check for effects, allocations, or indirect calls only. *)
+
+module type Spec = sig
+  (** Which check is it? Used in error messages. *)
+  val name : string
+
+  (** Is the check enabled? *)
+  val enabled : unit -> bool
+
+  val is_allocation_allowed : bool
+
+  val is_effect_allowed : bool
+
+  val ignore_path_to_raise : bool
+
+  (** Record that the callee passed the check. *)
+  val add_callee : string -> Cmx_format.checks -> unit
+
+  (** Does the callee pass the check (i.e., satisfies the conditions such as no
+      allocation)? Returns [true] if the callee passed the check or the callee
+      is annotated to be skipped by this check. *)
+  val check_callee : string -> Cmx_format.checks -> bool
+
+  (** returns true when the check passes. *)
+  val check_specific : Arch.specific_operation -> bool
+
+  val annotation : Cmm.codegen_option
+end
+(* CR gyorsh: Annotations are not yet implemented. We may also want annotations
+   on call sites, not only on functions. *)
+
+(** Check one function. *)
+module Analysis (S : Spec) : sig
+  val fundecl : Format.formatter -> Mach.fundecl -> unit
+
+  val reset_unit_info : unit -> unit
+
+  val record_unit_info : Format.formatter -> Cmx_format.checks -> unit
+end = struct
+  (** Information about functions that we have seen so far for the current
+      compilation unit. *)
+  module Unit_info : sig
+    (** mutable state *)
+    type t
+
+    val create : unit -> t
+
+    val reset : t -> unit
+
+    (** Resolve all dependencies, record all names associated with Pass, and
+        check all annotated names. *)
+    val resolve_all : Format.formatter -> t -> Cmx_format.checks -> unit
+
+    val is_fail : t -> string -> bool
+
+    val get_value : t -> string -> Value.t option
+
+    val add_value : Format.formatter -> t -> string -> Value.t -> unit
+
+    val add_dep : t -> callee:string -> caller:string -> unit
+
+    val in_current_unit : t -> string -> unit
+
+    val annotated : t -> string -> unit
+  end = struct
+    (** map function name to the information about it *)
+    type t = (string, Func_info.t) Hashtbl.t
+
+    let create () : (string, Func_info.t) Hashtbl.t = Hashtbl.create 17
+
+    let reset t = Hashtbl.reset t
+
+    let is_fail t name =
+      match Hashtbl.find_opt t name with
+      | None -> false
+      | Some (func_info : Func_info.t) -> (
+        match func_info.value with Fail -> true | Pass | Unknown -> false)
+
+    let in_current_unit t name =
+      let func_info : Func_info.t =
+        match Hashtbl.find_opt t name with
+        | None ->
+          let func_info = Func_info.create name Unknown in
+          Hashtbl.replace t name func_info;
+          func_info
+        | Some func_info -> func_info
+      in
+      func_info.in_current_unit <- true
+
+    let record t name value =
+      match Hashtbl.find_opt t name with
+      | None ->
+        let func_info = Func_info.create name value in
+        Hashtbl.replace t name func_info
+      | Some (old : Func_info.t) ->
+        if old.value = value
+        then ()
+        else if old.value = Value.Unknown
+        then old.value <- value
+        else
+          Misc.fatal_errorf
+            "Checkmach %s record: can't set %s to %s, already set to %s" S.name
+            name (Value.to_string value)
+            (Value.to_string old.value)
+
+    (* Resolve everything that depends on [callee]. *)
+    let rec resolve ppf t callee (value : Value.t) =
+      record t callee value;
+      match Hashtbl.find_opt t callee with
+      | None -> assert false
+      | Some (func_info : Func_info.t) -> (
+        match value with
+        | Unknown ->
+          Misc.fatal_errorf "Checkmach %s: can't resolve %s to Unknown" S.name
+            callee
+        | Pass ->
+          (* If [callee] passes the check and has a caller that depends on it,
+             we can resolve the [caller] to Pass only when it does not depend on
+             any other callees, but we don't keep the information about reverse
+             dependencies, so we just leave the dependency edge. *)
+          func_info.callers <- []
+        | Fail ->
+          (* If [callee] fails the check, all its callers fail the check. *)
+          let callers = func_info.callers in
+          func_info.callers <- [];
+          List.iter
+            (fun caller ->
+              if !Flambda_backend_flags.dump_checkmach && not (is_fail t caller)
+              then
+                Format.fprintf ppf
+                  "*** check %s failed in %s: callee %s resolved to fail\n"
+                  S.name caller callee;
+              resolve ppf t caller Value.Fail)
+            callers)
+
+    (* [resolve_all] makes 3 passes *)
+    let resolve_all ppf t checks =
+      (* Resolve functions not defined in the current unit as [Fail]. If they
+         were [Pass], they would not have been recorded. *)
+      Hashtbl.iter
+        (fun callee (func_info : Func_info.t) ->
+          if not func_info.in_current_unit then resolve ppf t callee Fail)
+        t;
+      (* Record all remaining [Unknown] as [Pass].
+
+         If there is a call from [f] to [g], and we have seen the definitions of
+         [f] and [g], then if [g] failed the check, we would have already
+         removed the dependency and recorded both [f] and [g] as [Fail].
+         Therefore, either [g] passed the check or there is a cycle of
+         dependencies involving [f]. For all functions in the dependency cycle,
+         we have already determined that they don't have any forbidden
+         instructions directly. Therefore the entire cycle passes the check.*)
+      Hashtbl.iter
+        (fun _callee (func_info : Func_info.t) ->
+          match func_info.value with
+          | Unknown ->
+            func_info.value <- Pass;
+            func_info.callers <- []
+          | Pass | Fail -> assert (List.length func_info.callers = 0))
+        t;
+      (* Check annotations. Return all function names associated with Pass. *)
+      if S.enabled ()
+      then
+        Hashtbl.iter
+          (fun _callee (func_info : Func_info.t) ->
+            if func_info.in_current_unit
+            then
+              match func_info.value with
+              | Unknown -> assert false
+              | Pass -> S.add_callee func_info.name checks
+              | Fail ->
+                if func_info.annotated
+                then
+                  raise
+                    (Error
+                       (Annotation { fun_name = func_info.name; check = S.name })))
+          t
+
+    let add_dep t ~callee ~caller =
+      record t callee Unknown;
+      record t caller Unknown;
+      let func_info : Func_info.t = Hashtbl.find t callee in
+      if not (List.mem caller func_info.callers)
+      then func_info.callers <- caller :: func_info.callers
+
+    let add_value ppf t name value = resolve ppf t name value
+
+    let get_value t name =
+      match Hashtbl.find_opt t name with
+      | None -> None
+      | Some (func_info : Func_info.t) -> Some func_info.value
+
+    let annotated t name =
+      let func_info : Func_info.t = Hashtbl.find t name in
+      func_info.annotated <- true
+  end
+
+  let unit_info = Unit_info.create ()
+
+  let reset_unit_info () = Unit_info.reset unit_info
+
+  let record_unit_info ppf_dump checks =
+    Unit_info.resolve_all ppf_dump unit_info checks
+
+  type t =
+    { ppf : Format.formatter;
+      fun_name : string;
+      mutable unresolved_dependencies : bool
+    }
+
+  let report t ~msg ~desc dbg =
+    if !Flambda_backend_flags.dump_checkmach
+    then
+      Format.fprintf t.ppf "*** check %s %s in %s: %s at %a\n" S.name msg
+        t.fun_name desc Debuginfo.print_compact dbg
+
+  exception Bail
+
+  let report_fail t desc dbg =
+    report t ~msg:"failed" ~desc dbg;
+    Unit_info.add_value t.ppf unit_info t.fun_name Fail;
+    if not !Flambda_backend_flags.dump_checkmach then raise_notrace Bail
+
+  let check_call t callee ~desc dbg =
+    if is_caml_apply callee
+       (* This check is only an optimization, to keep dependencies small. *)
+    then report_fail t desc dbg
+    else if not (S.check_callee callee Compilenv.cached_checks)
+    then
+      match Unit_info.get_value unit_info callee with
+      | Some Pass -> ()
+      | None | Some Unknown ->
+        if Unit_info.is_fail unit_info t.fun_name
+        then report t ~msg:"verbose" ~desc dbg
+        else begin
+          Unit_info.add_dep unit_info ~callee ~caller:t.fun_name;
+          t.unresolved_dependencies <- true;
+          report t ~msg:"unknown" ~desc dbg
+        end
+      | Some Fail -> report_fail t desc dbg
+
+  (** Returns [false] when the check fails (e.g., allocation or indirect call
+      found). *)
+  let check_operation t (op : Mach.operation) dbg =
+    match op with
+    | Imove | Ispill | Ireload | Iconst_int _ | Iconst_float _ | Iconst_symbol _
+    | Iload _ | Icompf _ | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
+    | Ifloatofint | Iintoffloat
+    | Iintop_imm
+        ( ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
+          | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ ),
+          _ )
+    | Iintop
+        ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
+        | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ )
+    | Iname_for_debugger _ ->
+      assert (Mach.operation_is_pure op)
+    | Istackoffset _ | Iprobe_is_enabled _ | Iopaque | Ibeginregion | Iendregion
+      ->
+      ()
+    | Istore _ -> if not S.is_effect_allowed then report_fail t "store" dbg
+    | Iintop Icheckbound | Iintop_imm (Icheckbound, _) ->
+      report_fail t "checkbound" dbg
+    | Ialloc { mode = Alloc_local; _ } -> ()
+    | Ialloc { mode = Alloc_heap; _ } ->
+      if not S.is_allocation_allowed then report_fail t "allocation" dbg
+    | Iprobe { name; handler_code_sym } ->
+      let desc = Printf.sprintf "probe %s handler %s" name handler_code_sym in
+      check_call t handler_code_sym ~desc dbg
+    | Icall_ind -> report_fail t "indirect call" dbg
+    | Itailcall_ind -> report_fail t "indirect tailcall" dbg
+    | Icall_imm { func } ->
+      check_call t func ~desc:("direct call to " ^ func) dbg
+    | Itailcall_imm { func } ->
+      check_call t func ~desc:("direct tailcall to " ^ func) dbg
+    | Iextcall { alloc = false; effects = No_effects; _ } -> ()
+    | Iextcall { func; alloc = false; effects = Arbitrary_effects; _ } ->
+      if not S.is_effect_allowed
+      then report_fail t ("external call to " ^ func) dbg
+    | Iextcall { func; alloc = true; _ } ->
+      if not S.is_allocation_allowed
+      then report_fail t ("external call to " ^ func) dbg
+    | Ispecific s ->
+      if not (S.check_specific s)
+      then report_fail t "Arch.specific_operation" dbg
+
+  (* let rec check_instr t (i : Mach.instruction) =
+   *   match (i.desc : Mach.instruction_desc) with
+   *   | Iend -> ()
+   *   | Iop op ->
+   *     check_operation t op i.dbg;
+   *     check_instr t i.next
+   *   | Iifthenelse (_c, ifso, ifnot) ->
+   *     check_instr t ifso;
+   *     check_instr t ifnot;
+   *     check_instr t i.next
+   *   | Iswitch (_index, cases) ->
+   *     Array.iter (check_instr t) cases;
+   *     check_instr t i.next
+   *   | Icatch (_rec, _ts, handlers, body) ->
+   *     check_instr t body;
+   *     List.iter (fun (_n, _ts, handler) -> check_instr t handler) handlers;
+   *     check_instr t i.next
+   *   | Itrywith (body, _kind, (_ts, handler)) ->
+   *     check_instr t body;
+   *     check_instr t handler;
+   *     check_instr t i.next
+   *   | Iraise (Raise_regular | Raise_reraise) -> report_fail t "raise" i.dbg
+   *   | Iraise Raise_notrace -> ()
+   *   | Ireturn _ -> ()
+   *   | Iexit _ -> () *)
+
+  (** Returns [true] when [i] is post-dominated by a raise. If [i] is not, then
+      checks [i] for the property in [S]. *)
+  let rec check_instr_exn t (i : Mach.instruction) raise_after =
+    match (i.desc : Mach.instruction_desc) with
+    | Iend -> raise_after
+    | Iop op ->
+      let raise_after = check_instr_exn t i.next raise_after in
+      if not raise_after then check_operation t op i.dbg;
+      raise_after
+    | Iifthenelse (_c, ifso, ifnot) ->
+      let raise_after = check_instr_exn t i.next raise_after in
+      let raise_after_ifso = check_instr_exn t ifso raise_after in
+      let raise_after_ifnot = check_instr_exn t ifnot raise_after in
+      raise_after_ifso && raise_after_ifnot
+    | Iswitch (_index, cases) ->
+      let raise_after = check_instr_exn t i.next raise_after in
+      Array.for_all (fun case -> check_instr_exn t case raise_after) cases
+    | Icatch (_rec, _ts, handlers, body) ->
+      (* conservative *)
+      let raise_after = check_instr_exn t i.next raise_after in
+      let _ = check_instr_exn t body raise_after in
+      List.iter
+        (fun (_n, _ts, handler) -> check_instr_exn t handler false |> ignore)
+        handlers;
+      false
+    | Itrywith (body, _kind, (_ts, handler)) ->
+      (* conservative *)
+      let _ = check_instr_exn t i.next raise_after in
+      let _ = check_instr_exn t body false in
+      let _ = check_instr_exn t handler false in
+      false
+    | Iraise (Raise_regular | Raise_reraise) ->
+      if S.ignore_path_to_raise
+      then true
+      else (
+        report_fail t "raise" i.dbg;
+        false)
+    | Iraise Raise_notrace -> false
+    | Ireturn _ -> false
+    | Iexit _ -> false
+
+  let debug t expected =
+    match Unit_info.get_value unit_info t.fun_name with
+    | None -> assert false
+    | Some v ->
+      (* just checking for consistency with the recorded value *)
+      if not (v = expected)
+      then
+        Misc.fatal_errorf
+          "Checkmach %s: Wrong result for %s, expected %s, found %s" S.name
+          t.fun_name (Value.to_string expected) (Value.to_string v)
+
+  let fundecl ppf (f : Mach.fundecl) =
+    if S.enabled ()
+    then
+      Profile.record_call ~accumulate:true ("check " ^ S.name) (fun () ->
+          let fun_name = f.fun_name in
+          let t = { ppf; fun_name; unresolved_dependencies = false } in
+          Unit_info.in_current_unit unit_info fun_name;
+          (try
+             let _ = check_instr_exn t f.fun_body false in
+             if (not t.unresolved_dependencies)
+                && not (Unit_info.is_fail unit_info t.fun_name)
+             then begin
+               report t ~msg:"passed" ~desc:"" f.fun_dbg;
+               Unit_info.add_value t.ppf unit_info fun_name Pass
+             end
+           with Bail -> debug t Fail);
+          if List.mem S.annotation f.fun_codegen_options
+          then Unit_info.annotated unit_info fun_name)
+end
+
+module Spec_alloc : Spec = struct
+  let name = "alloc"
+
+  let enabled () = !Flambda_backend_flags.alloc_check
+
+  let is_allocation_allowed = false
+
+  let is_effect_allowed = true
+
+  let ignore_path_to_raise = false
+
+  let check_callee s (checks : Cmx_format.checks) =
+    StringSet.mem s checks.ui_noalloc_functions
+    || StringSet.mem s checks.ui_noeffects_functions
+
+  let add_callee s (checks : Cmx_format.checks) =
+    if not (check_callee s checks)
+    then
+      checks.ui_noalloc_functions <- StringSet.add s checks.ui_noalloc_functions
+
+  (** conservative *)
+  let check_specific s = not (Arch.operation_can_raise s)
+
+  let annotation = Cmm.Noalloc_check
+end
+
+module Spec_alloc_exn : Spec = struct
+  let name = "alloc_exn"
+
+  let enabled () = !Flambda_backend_flags.alloc_check
+
+  let is_allocation_allowed = false
+
+  let is_effect_allowed = true
+
+  let ignore_path_to_raise = true
+
+  let check_callee s (checks : Cmx_format.checks) =
+    StringSet.mem s checks.ui_noalloc_exn_functions
+    || StringSet.mem s checks.ui_noalloc_functions
+    || StringSet.mem s checks.ui_noeffects_functions
+
+  let add_callee s (checks : Cmx_format.checks) =
+    if not (check_callee s checks)
+    then
+      checks.ui_noalloc_exn_functions
+        <- StringSet.add s checks.ui_noalloc_exn_functions
+
+  (** conservative *)
+  let check_specific s = not (Arch.operation_can_raise s)
+
+  let annotation = Cmm.Noalloc_check
+end
+
+module Spec_indirect_calls : Spec = struct
+  let name = "indirect"
+
+  let enabled () = !Flambda_backend_flags.indirect_call_check
+
+  let is_allocation_allowed = true
+
+  let is_effect_allowed = true
+
+  let ignore_path_to_raise = false
+
+  let check_callee s (checks : Cmx_format.checks) =
+    StringSet.mem s checks.ui_noindirect_functions
+    || StringSet.mem s checks.ui_noalloc_functions
+    || StringSet.mem s checks.ui_noeffects_functions
+
+  let add_callee s (checks : Cmx_format.checks) =
+    if not (check_callee s checks)
+    then
+      checks.ui_noindirect_functions
+        <- StringSet.add s checks.ui_noindirect_functions
+
+  (** conservative *)
+  let check_specific s = not (Arch.operation_can_raise s)
+
+  let annotation = Cmm.Noindirect_calls_check
+end
+
+module Spec_effects : Spec = struct
+  let name = "effects"
+
+  let enabled () = !Flambda_backend_flags.effect_check
+
+  let is_allocation_allowed = false
+
+  let is_effect_allowed = false
+
+  let ignore_path_to_raise = false
+
+  let check_callee s (checks : Cmx_format.checks) =
+    StringSet.mem s checks.ui_noeffects_functions
+
+  let add_callee s (checks : Cmx_format.checks) =
+    if not (check_callee s checks)
+    then
+      checks.ui_noeffects_functions
+        <- StringSet.add s checks.ui_noeffects_functions
+
+  (** conservative *)
+  let check_specific s =
+    Arch.operation_is_pure s && not (Arch.operation_can_raise s)
+
+  let annotation = Cmm.Noeffect_check
+end
+
+(***************************************************************************
+ *   Statically checks that the input function satisfies the following
+ *   - no allocations on the heap (local allocations are ignored)
+ *   - no indirect calls (incl. no indirect tailcalls)
+ *   - raise_notrace is allowed, but no other raise kinds
+ *   - all direct calls (incl. tailcalls and probes) are to functions the
+ *     satisfy the same conditions.
+ *****************************************************************************)
+module Check_alloc = Analysis (Spec_alloc)
+
+(** Same as [Check_alloc] but raises are allowed and no restrictions on
+    instructions post-dominated by a raise with backtrace. *)
+module Check_alloc_exn = Analysis (Spec_alloc_exn)
+
+(** Same as [Check_alloc] except allocations are allowed. *)
+module Check_indirect_calls = Analysis (Spec_indirect_calls)
+
+(** Same as [Check_alloc] but effects (incl. writes to heap) are not allowed. *)
+module Check_effects = Analysis (Spec_effects)
+
+(* CR gyorsh: We can check both at the same time in one pass, or even as part of
+   another pass, such as dead code elimination. For simplicity, it's a separate
+   pass for each at the moment. It is possible the indirect check succeeds but
+   alloc check fails. *)
+
+(* If a function is "noalloc", then it also has no indirect calls, but not vice
+   versa. Similarly, fi a function is noeffects, then it is also noalloc but not
+   vice versa.
+
+   Don't store the function twice if both checks are enabled:
+   [noalloc_functions] is disjoint from [noindirect_functions], and their union
+   represents all functions statically shown to have no indirect calls. The set
+   [noindirect_functions] itself only contains function that have an allocation,
+   as determined by the static checks. Similarly for [noeffects_functions]. *)
+
+let fundecl ppf_dump fd =
+  Check_effects.fundecl ppf_dump fd;
+  Check_alloc.fundecl ppf_dump fd;
+  Check_alloc_exn.fundecl ppf_dump fd;
+  Check_indirect_calls.fundecl ppf_dump fd;
+  fd
+
+let reset_unit_info () =
+  Check_effects.reset_unit_info ();
+  Check_alloc.reset_unit_info ();
+  Check_alloc_exn.reset_unit_info ();
+  Check_indirect_calls.reset_unit_info ();
+  ()
+
+let record_unit_info ppf_dump =
+  (* Order is important here, if more than one check is enabled, noeffects =>
+     noalloc => noalloc_exn => noindirect_calls, and they are represented in
+     using disjoint sets. *)
+  let checks = (Compilenv.current_unit_infos ()).ui_checks in
+  Check_effects.record_unit_info ppf_dump checks;
+  Check_alloc.record_unit_info ppf_dump checks;
+  Check_alloc_exn.record_unit_info ppf_dump checks;
+  Check_indirect_calls.record_unit_info ppf_dump checks;
+  Compilenv.cache_checks checks
+
+(* Error report *)
+
+let report_error ppf = function
+  | Annotation { fun_name; check } ->
+    Format.fprintf ppf "Annotation check for %s on function %s failed" check
+      fun_name
+
+let () =
+  Location.register_error_of_exn (function
+    | Error err -> Some (Location.error_of_printer_file report_error err)
+    | _ -> None)

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -506,7 +506,7 @@ module Spec_alloc_exn : Spec = struct
   (** conservative *)
   let check_specific s = not (Arch.operation_can_raise s)
 
-  let annotation = Cmm.Noalloc_check
+  let annotation = Cmm.Noalloc_exn_check
 end
 
 module Spec_indirect_calls : Spec = struct

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -305,11 +305,10 @@ end = struct
       | None | Some Unknown ->
         if Unit_info.is_fail unit_info t.fun_name
         then report t ~msg:"verbose" ~desc dbg
-        else begin
+        else (
           Unit_info.add_dep unit_info ~callee ~caller:t.fun_name;
           t.unresolved_dependencies <- true;
-          report t ~msg:"unknown" ~desc dbg
-        end
+          report t ~msg:"unknown" ~desc dbg)
       | Some Fail -> report_fail t desc dbg
 
   (** Returns [false] when the check fails (e.g., allocation or indirect call
@@ -443,23 +442,20 @@ end = struct
           let t = { ppf; fun_name; unresolved_dependencies = false } in
           Unit_info.in_current_unit unit_info fun_name;
           if List.mem (S.annotation Lambda.Assume) f.fun_codegen_options
-          then begin
+          then (
             report t ~msg:"assumed" ~desc:"" f.fun_dbg;
-            Unit_info.add_value t.ppf unit_info fun_name Pass
-          end
-          else begin
+            Unit_info.add_value t.ppf unit_info fun_name Pass)
+          else (
             (try
                let _ = check_instr_exn t f.fun_body false in
                if (not t.unresolved_dependencies)
                   && not (Unit_info.is_fail unit_info t.fun_name)
-               then begin
+               then (
                  report t ~msg:"passed" ~desc:"" f.fun_dbg;
-                 Unit_info.add_value t.ppf unit_info fun_name Pass
-               end
+                 Unit_info.add_value t.ppf unit_info fun_name Pass)
              with Bail -> debug t Fail);
             if List.mem (S.annotation Lambda.Assert) f.fun_codegen_options
-            then Unit_info.annotated unit_info fun_name
-          end)
+            then Unit_info.annotated unit_info fun_name))
 end
 
 module Spec_alloc : Spec = struct

--- a/backend/checkmach.mli
+++ b/backend/checkmach.mli
@@ -1,0 +1,48 @@
+(**********************************************************************************
+ *                             MIT License                                        *
+ *                                                                                *
+ *                                                                                *
+ * Copyright (c) 2022-2022 Jane Street Group LLC                                  *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ *                                                                                *
+ **********************************************************************************)
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+(** Maintains shared state per compilation unit *)
+
+(** Removes all information *)
+val reset_unit_info : unit -> unit
+
+(** Records the result in [Compilenv] to be saved to [cmx]. *)
+val record_unit_info : Format.formatter -> unit
+
+(** Analyzes the function, performs all checks that are enabled, and accumulates
+    the results. *)
+val fundecl : Format.formatter -> Mach.fundecl -> Mach.fundecl
+
+type error =
+  | Annotation of
+      { fun_name : string;
+        check : string
+      }
+
+exception Error of error
+
+val report_error : Format.formatter -> error -> unit

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -249,6 +249,7 @@ type codegen_option =
   | No_CSE
   | Use_linscan_regalloc
   | Noalloc_check
+  | Noalloc_exn_check
   | Noeffect_check
   | Noindirect_calls_check
 

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -248,10 +248,10 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Noalloc_check
-  | Noalloc_exn_check
-  | Noeffect_check
-  | Noindirect_calls_check
+  | Noalloc of Lambda.check_mode
+  | Noalloc_exn of Lambda.check_mode
+  | Noeffect of Lambda.check_mode
+  | Noindirect_calls of Lambda.check_mode
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -248,6 +248,9 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
+  | Noalloc_check
+  | Noeffect_check
+  | Noindirect_calls_check
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -258,6 +258,7 @@ type codegen_option =
   | No_CSE
   | Use_linscan_regalloc
   | Noalloc_check
+  | Noalloc_exn_check
   | Noeffect_check
   | Noindirect_calls_check
 

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -257,6 +257,9 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
+  | Noalloc_check
+  | Noeffect_check
+  | Noindirect_calls_check
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -257,10 +257,10 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Noalloc_check
-  | Noalloc_exn_check
-  | Noeffect_check
-  | Noindirect_calls_check
+  | Noalloc of Lambda.check_mode
+  | Noalloc_exn of Lambda.check_mode
+  | Noeffect of Lambda.check_mode
+  | Noindirect_calls of Lambda.check_mode
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1460,6 +1460,12 @@ and transl_letrec env bindings cont =
         fill_blocks rem
   in init_blocks bsz
 
+let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
+  | Noalloc_check -> [ Noalloc_check ]
+  | Noalloc_exn_check -> [ Noalloc_exn_check ]
+  | Noeffects_check -> [ Noeffect_check ]
+  | Default_check -> []
+
 (* Translate a function definition *)
 
 let transl_function f =
@@ -1471,6 +1477,7 @@ let transl_function f =
     else
       transl env body in
   let fun_codegen_options =
+    transl_attrib f.attrib @
     if !Clflags.optimize_for_speed then
       []
     else

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1461,9 +1461,9 @@ and transl_letrec env bindings cont =
   in init_blocks bsz
 
 let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
-  | Noalloc_check -> [ Noalloc_check ]
-  | Noalloc_exn_check -> [ Noalloc_exn_check ]
-  | Noeffects_check -> [ Noeffect_check ]
+  | Noalloc m -> [ Noalloc m]
+  | Noalloc_exn m -> [ Noalloc_exn m ]
+  | Noeffects m -> [ Noeffect m ]
   | Default_check -> []
 
 (* Translate a function definition *)

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -59,7 +59,7 @@ type operation =
   | Itailcall_imm of { func : string; }
   | Iextcall of { func : string;
                   ty_res : Cmm.machtype; ty_args : Cmm.exttype list;
-                  alloc : bool; returns : bool; }
+                  alloc : bool; effects: Cmm.effects; returns : bool; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode * mutable_flag
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -62,7 +62,7 @@ type operation =
   | Itailcall_imm of { func : string; }
   | Iextcall of { func : string;
                   ty_res : Cmm.machtype; ty_args : Cmm.exttype list;
-                  alloc : bool; returns : bool; }
+                  alloc : bool; effects: Cmm.effects; returns : bool; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode * mutable_flag
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -339,14 +339,18 @@ and sequence ppf = function
 
 and expression ppf e = fprintf ppf "%a" expr e
 
+let mode : Lambda.check_mode -> string = function
+    | Assert -> "assert"
+    | Assume -> "assume"
+
 let print_codegen_option = function
   | Reduce_code_size -> "reduce_code_size"
   | No_CSE -> "no_cse"
   | Use_linscan_regalloc -> "linscan"
-  | Noalloc_check -> "noalloc_check"
-  | Noalloc_exn_check -> "noalloc_exn_check"
-  | Noeffect_check -> "noeffect_check"
-  | Noindirect_calls_check -> "noindirect_calls_check"
+  | Noalloc m -> "noalloc_"^(mode m)
+  | Noalloc_exn m -> "noalloc_exn_"^(mode m)
+  | Noeffect m -> "noeffect_"^(mode m)
+  | Noindirect_calls m -> "noindirect_calls_assert"
 
 let print_codegen_options ppf l =
   List.iter (fun c -> fprintf ppf " %s" (print_codegen_option c)) l

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -339,6 +339,18 @@ and sequence ppf = function
 
 and expression ppf e = fprintf ppf "%a" expr e
 
+let print_codegen_option = function
+  | Reduce_code_size -> "reduce_code_size"
+  | No_CSE -> "no_cse"
+  | Use_linscan_regalloc -> "linscan"
+  | Noalloc_check -> "noalloc_check"
+  | Noalloc_exn_check -> "noalloc_exn_check"
+  | Noeffect_check -> "noeffect_check"
+  | Noindirect_calls_check -> "noindirect_calls_check"
+
+let print_codegen_options ppf l =
+  List.iter (fun c -> fprintf ppf " %s" (print_codegen_option c)) l
+
 let fundecl ppf f =
   let print_cases ppf cases =
     let first = ref true in
@@ -348,8 +360,8 @@ let fundecl ppf f =
        fprintf ppf "%a: %a" VP.print id machtype ty)
      cases in
   with_location_mapping ~label:"Function" ~dbg:f.fun_dbg ppf (fun () ->
-  fprintf ppf "@[<1>(function%s %s@;<1 4>@[<1>(%a)@]@ @[%a@])@]@."
-         (location f.fun_dbg) f.fun_name
+  fprintf ppf "@[<1>(function%s%a@ %s@;<1 4>@[<1>(%a)@]@ @[%a@])@]@."
+         (location f.fun_dbg) print_codegen_options f.fun_codegen_options f.fun_name
          print_cases f.fun_args sequence f.fun_body)
 
 let data_item ppf = function

--- a/backend/printcmm.mli
+++ b/backend/printcmm.mli
@@ -33,3 +33,4 @@ val fundecl : formatter -> Cmm.fundecl -> unit
 val data : formatter -> Cmm.data_item list -> unit
 val phrase : formatter -> Cmm.phrase -> unit
 val temporal_locality : Cmm.prefetch_temporal_locality_hint -> string
+val print_codegen_options : formatter -> Cmm.codegen_option list -> unit

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -264,8 +264,10 @@ let fundecl ppf f =
       ""
     else
       " " ^ Debuginfo.to_string f.fun_dbg in
-  fprintf ppf "@[<v 2>%s(%a)%s@,%a@]"
-    f.fun_name regs f.fun_args dbg instr f.fun_body
+  fprintf ppf "@[<v 2>%s(%a)%s%a@,%a@]"
+    f.fun_name regs f.fun_args dbg
+    Printcmm.print_codegen_options f.fun_codegen_options
+    instr f.fun_body
 
 let phase msg ppf f =
   fprintf ppf "*** %s@.%a@." msg fundecl f

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -582,8 +582,8 @@ method select_operation op args _dbg =
   | (Cextcall { func; builtin = true }, _) ->
      Misc.fatal_errorf "Selection.select_operation: builtin not recognized %s"
        func ();
-  | (Cextcall { func; alloc; ty; ty_args; returns; builtin = false }, _) ->
-    Iextcall { func; alloc; ty_res = ty; ty_args; returns }, args
+  | (Cextcall { func; alloc; effects; ty; ty_args; returns; builtin = false }, _) ->
+    Iextcall { func; alloc; effects; ty_res = ty; ty_args; returns }, args
   | (Cload (chunk, mut), [arg]) ->
       let (addr, eloc) = self#select_addressing chunk arg in
       (Iload(chunk, addr, select_mutable_flag mut), [eloc])

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -52,6 +52,21 @@ let mk_heap_reduction_threshold f =
     Flambda_backend_flags.default_heap_reduction_threshold
 ;;
 
+let mk_alloc_check f =
+  "-alloc-check", Arg.Unit f, " Check that annoted functions do not allocate \
+                                and do not have indirect calls"
+
+let mk_indirect_call_check f =
+  "-indirect-call-check", Arg.Unit f, " Check that annoted functions \
+                                       do not have indirect calls"
+
+let mk_effect_check f =
+  "-effect-check", Arg.Unit f, " Check that annoted functions do not write to the heap, \
+                                 do not allocate, and do not have indirect calls"
+
+let mk_dcheckmach f =
+  "-dcheckmach", Arg.Unit f, " (undocumented)"
+
 let mk_dump_inlining_paths f =
   "-dump-inlining-paths", Arg.Unit f, " Dump inlining paths when dumping flambda2 terms"
 
@@ -418,6 +433,10 @@ module type Flambda_backend_options = sig
   val dno_asm_comments : unit -> unit
 
   val heap_reduction_threshold : int -> unit
+  val alloc_check : unit -> unit
+  val indirect_call_check : unit -> unit
+  val effect_check : unit -> unit
+  val dcheckmach : unit -> unit
 
   val internal_assembler : unit -> unit
 
@@ -488,6 +507,10 @@ struct
     mk_dno_asm_comments F.dno_asm_comments;
 
     mk_heap_reduction_threshold F.heap_reduction_threshold;
+    mk_alloc_check F.alloc_check;
+    mk_indirect_call_check F.indirect_call_check;
+    mk_effect_check F.effect_check;
+    mk_dcheckmach F.dcheckmach;
 
     mk_internal_assembler F.internal_assembler;
 
@@ -593,6 +616,10 @@ module Flambda_backend_options_impl = struct
 
   let heap_reduction_threshold x =
     Flambda_backend_flags.heap_reduction_threshold := x
+  let alloc_check = set' Flambda_backend_flags.alloc_check
+  let indirect_call_check = set' Flambda_backend_flags.indirect_call_check
+  let effect_check = set' Flambda_backend_flags.effect_check
+  let dcheckmach = set' Flambda_backend_flags.dump_checkmach
 
   let internal_assembler = set' Flambda_backend_flags.internal_assembler
 
@@ -789,6 +816,10 @@ module Extra_params = struct
     | "reorder-blocks-random" ->
        set_int_option' Flambda_backend_flags.reorder_blocks_random
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
+    | "alloc-check" -> set' Flambda_backend_flags.alloc_check
+    | "indirect-call-check" -> set' Flambda_backend_flags.indirect_call_check
+    | "effect-check" -> set' Flambda_backend_flags.effect_check
+    | "dump-checkmach" -> set' Flambda_backend_flags.dump_checkmach
     | "dasm-comments" -> set' Flambda_backend_flags.dasm_comments
     | "dno-asm-comments" -> clear' Flambda_backend_flags.dasm_comments
     | "gupstream-dwarf" -> set' Debugging.restrict_to_upstream_dwarf

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -33,6 +33,10 @@ module type Flambda_backend_options = sig
   val dno_asm_comments : unit -> unit
 
   val heap_reduction_threshold : int -> unit
+  val alloc_check : unit -> unit
+  val indirect_call_check : unit -> unit
+  val effect_check : unit -> unit
+  val dcheckmach : unit -> unit
 
   val internal_assembler : unit -> unit
 

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -24,6 +24,10 @@ let dasm_comments = ref false (* -dasm-comments *)
 
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)
+let alloc_check = ref false             (* -alloc-check *)
+let indirect_call_check = ref false     (* -indirect-call-check *)
+let effect_check = ref false            (* -effect-check *)
+let dump_checkmach = ref false          (* -dcheckmach *)
 
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -25,6 +25,10 @@ val dasm_comments : bool ref
 
 val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
+val alloc_check : bool ref
+val indirect_call_check : bool ref
+val effect_check : bool ref
+val dump_checkmach : bool ref
 
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -134,6 +134,6 @@ let implementation unix ~backend ~flambda2 ~start_from ~source_file
       ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_impl)
       ~hook_typed_tree:(Compiler_hooks.execute Compiler_hooks.Typed_tree_impl)
       info ~backend
-  | Emit -> emit unix info
+  | Emit -> emit unix info ~ppf_dump:info.ppf_dump
   | _ -> Misc.fatal_errorf "Cannot start from %s"
            (Clflags.Compiler_pass.to_string start_from)

--- a/dune
+++ b/dune
@@ -202,6 +202,7 @@
   printcmm
   printlinear
   printmach
+  checkmach
   proc
   reg
   reload
@@ -710,6 +711,7 @@
   (printcmm.mli as compiler-libs/printcmm.mli)
   (printlinear.mli as compiler-libs/printlinear.mli)
   (printmach.mli as compiler-libs/printmach.mli)
+  (checkmach.mli as compiler-libs/mach_checks.mli)
   (proc.mli as compiler-libs/proc.mli)
   (reg.mli as compiler-libs/reg.mli)
   (reload.mli as compiler-libs/reload.mli)
@@ -1020,6 +1022,11 @@
   (.ocamloptcomp.objs/byte/printmach.cmo as compiler-libs/printmach.cmo)
   (.ocamloptcomp.objs/byte/printmach.cmt as compiler-libs/printmach.cmt)
   (.ocamloptcomp.objs/byte/printmach.cmti as compiler-libs/printmach.cmti)
+  (.ocamloptcomp.objs/native/checkmach.cmx as compiler-libs/checkmach.cmx)
+  (.ocamloptcomp.objs/byte/checkmach.cmi as compiler-libs/checkmach.cmi)
+  (.ocamloptcomp.objs/byte/checkmach.cmo as compiler-libs/checkmach.cmo)
+  (.ocamloptcomp.objs/byte/checkmach.cmt as compiler-libs/checkmach.cmt)
+  (.ocamloptcomp.objs/byte/checkmach.cmti as compiler-libs/checkmach.cmti)
   (.ocamloptcomp.objs/byte/proc.cmi as compiler-libs/proc.cmi)
   (.ocamloptcomp.objs/byte/proc.cmo as compiler-libs/proc.cmo)
   (.ocamloptcomp.objs/byte/proc.cmt as compiler-libs/proc.cmt)

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -44,6 +44,23 @@ type generic_fns =
     apply_fun: apply_fn list;
     send_fun: apply_fn list }
 
+(* Symbols of function that pass certain checks for special properties. *)
+type checks =
+  {
+    mutable ui_noeffects_functions: Misc.Stdlib.String.Set.t;
+    (* Functions without effects, allocations, raises with traces, and indirect calls *)
+
+    mutable ui_noalloc_functions: Misc.Stdlib.String.Set.t;
+    (* Functions without allocations, raises with traces, and indirect calls *)
+
+     mutable ui_noalloc_exn_functions: Misc.Stdlib.String.Set.t;
+    (* Same as noalloc, but raises are allowed and no restrictions on instructions
+       post-dominated by a raise with trace. *)
+
+    mutable ui_noindirect_functions: Misc.Stdlib.String.Set.t;
+    (* Functions without indirect calls *)
+}
+
 type unit_infos =
   { mutable ui_name: modname;             (* Name of unit implemented *)
     mutable ui_symbol: string;            (* Prefix for symbols *)
@@ -52,6 +69,7 @@ type unit_infos =
     mutable ui_imports_cmx: crcs;         (* Infos imported *)
     mutable ui_generic_fns: generic_fns;  (* Generic functions needed *)
     mutable ui_export_info: export_info;
+    mutable ui_checks: checks;
     mutable ui_force_link: bool }         (* Always linked *)
 
 (* Each .a library has a matching .cmxa file that provides the following

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -100,6 +100,7 @@ and ufunction = {
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;
   mode   : Lambda.alloc_mode;
+  attrib : Lambda.check_attribute;
 }
 
 and ulambda_switch =

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -111,6 +111,7 @@ and ufunction = {
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;
   mode   : Lambda.alloc_mode;
+  attrib : Lambda.check_attribute;
 }
 
 and ulambda_switch =

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1394,9 +1394,10 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
   let uncurried_defs =
     List.map
       (function
-          (id, Lfunction({kind; params; return; body; loc; mode; region}
+          (id, Lfunction({kind; params; return; body; attr; loc; mode; region}
                          as funct)) ->
             Lambda.check_lfunction funct;
+            let attrib = attr.check in
             let label = Compilenv.make_fun_symbol loc (V.unique_name id) in
             let arity = List.length params in
             let fundesc =
@@ -1407,20 +1408,20 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
                fun_float_const_prop = !Clflags.float_const_prop;
                fun_region = region} in
             let dbg = Debuginfo.from_location loc in
-            (id, params, return, body, mode, fundesc, dbg)
+            (id, params, return, body, mode, attrib, fundesc, dbg)
         | (_, _) -> fatal_error "Closure.close_functions")
       fun_defs in
   (* Build an approximate fenv for compiling the functions *)
   let fenv_rec =
     List.fold_right
-      (fun (id, _params, _return, _body, mode, fundesc, _dbg) fenv ->
+      (fun (id, _params, _return, _body, mode, _attrib, fundesc, _dbg) fenv ->
         V.Map.add id (Value_closure(mode, fundesc, Value_unknown)) fenv)
       uncurried_defs fenv in
   (* Determine the offsets of each function's closure in the shared block *)
   let env_pos = ref (-1) in
   let clos_offsets =
     List.map
-      (fun (_id, _params, _return, _body, _mode, fundesc, _dbg) ->
+      (fun (_id, _params, _return, _body, _mode, _attrib, fundesc, _dbg) ->
         let pos = !env_pos + 1 in
         env_pos := !env_pos + 1 +
           (match fundesc.fun_arity with (Curried _, (0|1)) -> 2 | _ -> 3);
@@ -1431,13 +1432,13 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
      does not use its environment parameter is invalidated. *)
   let useless_env = ref initially_closed in
   (* Translate each function definition *)
-  let clos_fundef (id, params, return, body, mode, fundesc, dbg) env_pos =
+  let clos_fundef (id, params, return, body, mode, attrib, fundesc, dbg) env_pos =
     let env_param = V.create_local "env" in
     let cenv_fv =
       build_closure_env env_param (fv_pos - env_pos) fv in
     let cenv_body =
       List.fold_right2
-        (fun (id, _params, _return, _body, _mode, _fundesc, _dbg) pos env ->
+        (fun (id, _params, _return, _body, _mode, _attrib, _fundesc, _dbg) pos env ->
           V.Map.add id (Uoffset(Uvar env_param, pos - env_pos)) env)
         uncurried_defs clos_offsets cenv_fv in
     let (ubody, approx) =
@@ -1459,6 +1460,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
         dbg;
         env = Some env_param;
         mode;
+        attrib;
       }
     in
     (* give more chance of function with default parameters (i.e.
@@ -1497,7 +1499,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
          recompile *)
         Compilenv.backtrack snap; (* PR#6337 *)
         List.iter
-          (fun (_id, _params, _return, _body, _mode, fundesc, _dbg) ->
+          (fun (_id, _params, _return, _body, _mode, _attrib, fundesc, _dbg) ->
              fundesc.fun_closed <- false;
              fundesc.fun_inline <- None;
           )

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -112,6 +112,25 @@ val need_send_fun: int -> Lambda.alloc_mode -> unit
         (* Record the need of a currying (resp. application,
            message sending) function with the given arity *)
 
+module Checks : sig
+  (* mutable state *)
+  type t = Cmx_format.checks
+
+  val create : unit -> t
+
+  val reset : t -> unit
+
+  (* [merge_checks c ~into] modifies [into] by adding information from [src]. *)
+  val merge : t -> into:t -> unit
+end
+
+(* Return cached information about functions (from other complication units)
+   that satisfy certain properties. *)
+val cached_checks : Cmx_format.checks
+
+(* [cache_checks c] adds [c] to [cached_checks] *)
+val cache_checks : Cmx_format.checks -> unit
+
 val new_const_symbol : unit -> string
 val closure_symbol : Closure_id.t -> Symbol.t
         (* Symbol of a function if the function is

--- a/middle_end/flambda/augment_specialised_args.ml
+++ b/middle_end/flambda/augment_specialised_args.ml
@@ -546,6 +546,7 @@ module Make (T : S) = struct
         ~stub:true
         ~inline:Default_inline
         ~specialise:Default_specialise
+        ~check:Default_check
         ~is_a_functor:false
         ~closure_origin:function_decl.closure_origin
     in
@@ -639,6 +640,7 @@ module Make (T : S) = struct
           ~stub:function_decl.stub
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
+          ~check:function_decl.check
           ~is_a_functor:function_decl.is_a_functor
           ~closure_origin
       in

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -107,7 +107,7 @@ let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
   let tuple_param = Parameter.wrap tuple_param_var alloc_mode in
   Flambda.create_function_declaration ~params:[tuple_param] ~alloc_mode ~region
     ~body ~stub:true ~inline:Default_inline
-    ~specialise:Default_specialise ~is_a_functor:false
+    ~specialise:Default_specialise ~check:Default_check ~is_a_functor:false
     ~closure_origin:(Closure_origin.create (Closure_id.wrap closure_bound_var))
 
 let register_const t (constant:Flambda.constant_defining_value) name
@@ -650,6 +650,7 @@ and close_functions t external_env function_declarations : Flambda.named =
         ~body ~stub
         ~inline:(Function_decl.inline decl)
         ~specialise:(Function_decl.specialise decl)
+        ~check:(Function_decl.check decl)
         ~is_a_functor:(Function_decl.is_a_functor decl)
         ~closure_origin
     in

--- a/middle_end/flambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/closure_conversion_aux.ml
@@ -125,6 +125,7 @@ module Function_decls = struct
     let free_idents t = t.free_idents_of_body
     let inline t = t.attr.inline
     let specialise t = t.attr.specialise
+    let check t = t.attr.check
     let is_a_functor t = t.attr.is_a_functor
     let stub t = t.attr.stub
     let loc t = t.loc

--- a/middle_end/flambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/closure_conversion_aux.mli
@@ -73,6 +73,7 @@ module Function_decls : sig
     val body : t -> Lambda.lambda
     val inline : t -> Lambda.inline_attribute
     val specialise : t -> Lambda.specialise_attribute
+    val check : t -> Lambda.check_attribute
     val is_a_functor : t -> bool
     val stub : t -> bool
     val loc : t -> Lambda.scoped_location

--- a/middle_end/flambda/export_info_for_pack.ml
+++ b/middle_end/flambda/export_info_for_pack.ml
@@ -146,6 +146,7 @@ and import_function_declarations_for_pack_aux units pack
           ~stub:function_decl.stub
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
+          ~check:function_decl.check
           ~is_a_functor:function_decl.is_a_functor
           ~closure_origin:function_decl.closure_origin)
       function_decls.funs

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -407,11 +407,15 @@ and print_function_declaration ppf var (f : function_declaration) =
     | Never_specialise -> " *never_specialise*"
     | Default_specialise -> ""
   in
+  let mode : Lambda.check_mode -> string = function
+    | Assert -> "assert"
+    | Assume -> "assume"
+  in
   let check =
     match f.check with
-    | Noalloc_check -> " *noalloc_check*"
-    | Noalloc_exn_check -> " *noalloc_exn_check*"
-    | Noeffects_check -> " *noeffects_check*"
+    | Noalloc m -> Printf.sprintf " *noalloc_%s*" (mode m)
+    | Noalloc_exn m -> Printf.sprintf " *noalloc_exn_%s*" (mode m)
+    | Noeffects m -> Printf.sprintf " *noeffects_%s*" (mode m)
     | Default_check -> ""
   in
   fprintf ppf "@[<2>(%a%s%s%s%s%s@ =@ fun@[<2>%a@] ->@ @[<2>%a@])@]@ "

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -137,6 +137,7 @@ and function_declaration = {
   dbg : Debuginfo.t;
   inline : Lambda.inline_attribute;
   specialise : Lambda.specialise_attribute;
+  check : Lambda.check_attribute;
   is_a_functor : bool;
 }
 
@@ -406,8 +407,15 @@ and print_function_declaration ppf var (f : function_declaration) =
     | Never_specialise -> " *never_specialise*"
     | Default_specialise -> ""
   in
-  fprintf ppf "@[<2>(%a%s%s%s%s@ =@ fun@[<2>%a@] ->@ @[<2>%a@])@]@ "
-    Variable.print var stub is_a_functor inline specialise
+  let check =
+    match f.check with
+    | Noalloc_check -> " *noalloc_check*"
+    | Noalloc_exn_check -> " *noalloc_exn_check*"
+    | Noeffects_check -> " *noeffects_check*"
+    | Default_check -> ""
+  in
+  fprintf ppf "@[<2>(%a%s%s%s%s%s@ =@ fun@[<2>%a@] ->@ @[<2>%a@])@]@ "
+    Variable.print var stub is_a_functor inline specialise check
     params f.params lam f.body
 
 and print_set_of_closures ppf (set_of_closures : set_of_closures) =
@@ -1042,6 +1050,7 @@ let update_body_of_function_declaration (func_decl: function_declaration)
     stub = func_decl.stub;
     dbg = func_decl.dbg;
     inline = func_decl.inline;
+    check = func_decl.check;
     specialise = func_decl.specialise;
     is_a_functor = func_decl.is_a_functor;
   }
@@ -1056,7 +1065,9 @@ let rec check_param_modes mode = function
 
 let create_function_declaration ~params ~alloc_mode ~region ~body ~stub
       ~(inline : Lambda.inline_attribute)
-      ~(specialise : Lambda.specialise_attribute) ~is_a_functor
+      ~(specialise : Lambda.specialise_attribute)
+      ~(check : Lambda.check_attribute)
+      ~is_a_functor
       ~closure_origin
       : function_declaration =
   begin match stub, inline with
@@ -1090,6 +1101,7 @@ let create_function_declaration ~params ~alloc_mode ~region ~body ~stub
     dbg = dbg_origin;
     inline;
     specialise;
+    check;
     is_a_functor;
   }
 

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -336,6 +336,8 @@ and function_declaration = private {
   (** Inlining requirements from the source code. *)
   specialise : Lambda.specialise_attribute;
   (** Specialising requirements from the source code. *)
+  check : Lambda.check_attribute;
+  (** Check function properties requirements from the source code  *)
   is_a_functor : bool;
   (** Whether the function is known definitively to be a functor. *)
 }
@@ -567,6 +569,7 @@ val create_function_declaration
   -> stub:bool
   -> inline:Lambda.inline_attribute
   -> specialise:Lambda.specialise_attribute
+  -> check:Lambda.check_attribute
   -> is_a_functor:bool
   -> closure_origin:Closure_origin.t
   -> function_declaration

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -578,6 +578,7 @@ and to_clambda_set_of_closures t env
       dbg = function_decl.dbg;
       env = Some env_var;
       mode = set_of_closures.alloc_mode;
+      attrib = function_decl.check;
     }
   in
   let funs = List.map to_clambda_function all_functions in
@@ -627,6 +628,7 @@ and to_clambda_closed_set_of_closures t env symbol
       dbg = function_decl.dbg;
       env = None;
       mode = Lambda.alloc_heap;
+      attrib = function_decl.check;
     }
   in
   let ufunct = List.map to_clambda_function functions in

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -364,7 +364,7 @@ let make_closure_declaration
     Flambda.create_function_declaration
       ~params:(List.map subst_param params) ~alloc_mode  ~region
       ~body ~stub ~inline:Default_inline
-      ~specialise:Default_specialise ~is_a_functor:false
+      ~specialise:Default_specialise ~check:Default_check ~is_a_functor:false
       ~closure_origin:(Closure_origin.create (Closure_id.wrap id))
   in
   assert (Variable.Set.equal (Variable.Set.map subst free_variables)

--- a/middle_end/flambda/freshening.ml
+++ b/middle_end/flambda/freshening.ml
@@ -326,6 +326,7 @@ module Project_var = struct
             ~body
             ~stub:func_decl.stub
             ~inline:func_decl.inline ~specialise:func_decl.specialise
+            ~check:func_decl.check
             ~is_a_functor:func_decl.is_a_functor
             ~closure_origin:func_decl.closure_origin
         in

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -615,6 +615,7 @@ and simplify_set_of_closures original_env r
         ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
         ~body ~stub:function_decl.stub
         ~inline:function_decl.inline ~specialise:function_decl.specialise
+        ~check:function_decl.check
         ~is_a_functor:function_decl.is_a_functor
         ~closure_origin:function_decl.closure_origin
     in
@@ -1500,6 +1501,7 @@ and duplicate_function ~env ~(set_of_closures : Flambda.set_of_closures)
       ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
       ~body ~stub:function_decl.stub
       ~inline:function_decl.inline ~specialise:function_decl.specialise
+      ~check:function_decl.check
       ~is_a_functor:function_decl.is_a_functor
       ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
   in

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -543,6 +543,7 @@ let rewrite_function ~lhs_of_application ~closure_id_being_applied
       ~stub:function_body.stub
       ~inline:function_body.inline
       ~specialise:function_body.specialise
+      ~check:function_body.check
       ~is_a_functor:function_body.is_a_functor
       ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
   in

--- a/middle_end/flambda/remove_unused_arguments.ml
+++ b/middle_end/flambda/remove_unused_arguments.ml
@@ -43,7 +43,8 @@ let remove_params unused (fun_decl: Flambda.function_declaration)
     ~params:used_params ~alloc_mode:fun_decl.alloc_mode ~region:fun_decl.region
     ~body
     ~stub:fun_decl.stub ~inline:fun_decl.inline
-    ~specialise:fun_decl.specialise ~is_a_functor:fun_decl.is_a_functor
+    ~specialise:fun_decl.specialise ~check:fun_decl.check
+    ~is_a_functor:fun_decl.is_a_functor
     ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
 
 let make_stub unused var (fun_decl : Flambda.function_declaration)
@@ -107,7 +108,9 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
       ~alloc_mode:fun_decl.alloc_mode ~region:fun_decl.region
       ~body
       ~stub:true ~inline:Default_inline
-      ~specialise:Default_specialise ~is_a_functor:fun_decl.is_a_functor
+      ~specialise:Default_specialise
+      ~check:Default_check
+      ~is_a_functor:fun_decl.is_a_functor
       ~closure_origin:fun_decl.closure_origin
   in
   function_decl, renamed, additional_specialised_args

--- a/middle_end/flambda/simple_value_approx.ml
+++ b/middle_end/flambda/simple_value_approx.ml
@@ -80,6 +80,7 @@ and function_body = {
   dbg : Debuginfo.t;
   inline : Lambda.inline_attribute;
   specialise : Lambda.specialise_attribute;
+  check : Lambda.check_attribute;
   is_a_functor : bool;
   body : Flambda.t;
 }
@@ -944,6 +945,7 @@ let function_declaration_approx ~keep_body fun_var
              inline = fun_decl.inline;
              dbg = fun_decl.dbg;
              specialise = fun_decl.specialise;
+             check = fun_decl.check;
              is_a_functor = fun_decl.is_a_functor;
              free_variables = fun_decl.free_variables;
              free_symbols = fun_decl.free_symbols; }

--- a/middle_end/flambda/simple_value_approx.mli
+++ b/middle_end/flambda/simple_value_approx.mli
@@ -156,6 +156,7 @@ and function_body = private {
   dbg : Debuginfo.t;
   inline : Lambda.inline_attribute;
   specialise : Lambda.specialise_attribute;
+  check : Lambda.check_attribute;
   is_a_functor : bool;
   body : Flambda.t;
 }

--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -147,7 +147,8 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
     | Uclosure (functions, captured_variables) ->
       List.iter (loop ~depth) captured_variables;
       List.iter (fun (
-        { Clambda. label; arity=_; params; return; body; dbg; env; mode=_} as clos) ->
+        { Clambda. label; arity=_; params; return; body; dbg; env; mode=_;
+            attrib=_} as clos) ->
           (match closure_environment_var clos with
            | None -> ()
            | Some env_var ->
@@ -323,7 +324,8 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
     | Uclosure (functions, captured_variables) ->
       ignore_ulambda_list captured_variables;
       (* Start a new let stack for speed. *)
-      List.iter (fun {Clambda. label; arity=_; params; return; body; dbg; env; mode=_} ->
+      List.iter (fun {Clambda. label; arity=_; params; return; body; dbg; env; mode=_;
+                      attrib=_} ->
           ignore_function_label label;
           ignore_params_with_value_kind params;
           ignore_value_kind return;

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1565,6 +1565,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
       { inline = Default_inline;
         specialise = Default_specialise;
         local = Default_local;
+        check = Default_check;
         is_a_functor = false;
         stub = false
       }

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -52,11 +52,15 @@ let rec value_kind0 ppf kind =
 
 let value_kind kind = Format.asprintf "%a" value_kind0 kind
 
+let mode : Lambda.check_mode -> string = function
+  | Assert -> "assert"
+    | Assume -> "assume"
+
 let check : Lambda.check_attribute -> string = function
   | Default_check -> ""
-  | Noalloc_check -> " noalloc_check"
-  | Noalloc_exn_check -> " noalloc_exn_check"
-  | Noeffects_check -> " noeffects_check"
+  | Noalloc m -> " noalloc_assert"^(mode m)
+  | Noalloc_exn m -> " noalloc_exn_"^(mode m)
+  | Noeffects m -> " noeffects_"^(mode m)
 
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -52,6 +52,12 @@ let rec value_kind0 ppf kind =
 
 let value_kind kind = Format.asprintf "%a" value_kind0 kind
 
+let check : Lambda.check_attribute -> string = function
+  | Default_check -> ""
+  | Noalloc_check -> " noalloc_check"
+  | Noalloc_exn_check -> " noalloc_exn_check"
+  | Noeffects_check -> " noeffects_check"
+
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x
   | Uconst_int32 x -> fprintf ppf "%ldl" x
@@ -84,8 +90,8 @@ and one_fun ppf f =
            Printlambda.value_kind k
       )
   in
-  fprintf ppf "(fun@ %s%s@ %d@ @[<2>%a@]@ @[<2>%a@])"
-    f.label (value_kind f.return) (snd f.arity) idents f.params lam f.body
+  fprintf ppf "(fun@ %s%s%s@ %d@ @[<2>%a@]@ @[<2>%a@])"
+    f.label (value_kind f.return) (check f.attrib) (snd f.arity) idents f.params lam f.body
 
 and phantom_defining_expr ppf = function
   | Uphantom_const const -> uconstant ppf const

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -370,6 +370,12 @@ type local_attribute =
   | Never_local (* [@local never] *)
   | Default_local (* [@local maybe] or no [@local] attribute *)
 
+type check_attribute =
+  | Default_check
+  | Noeffects_check
+  | Noalloc_check
+  | Noalloc_exn_check
+
 type function_kind = Curried of {nlocal: int} | Tupled
 
 type let_kind = Strict | Alias | StrictOpt
@@ -389,6 +395,7 @@ type function_attribute = {
   inline : inline_attribute;
   specialise : specialise_attribute;
   local: local_attribute;
+  check : check_attribute;
   is_a_functor: bool;
   stub: bool;
 }

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -370,11 +370,15 @@ type local_attribute =
   | Never_local (* [@local never] *)
   | Default_local (* [@local maybe] or no [@local] attribute *)
 
+type check_mode =
+  | Assert
+  | Assume
+
 type check_attribute =
   | Default_check
-  | Noeffects_check
-  | Noalloc_check
-  | Noalloc_exn_check
+  | Noeffects of check_mode
+  | Noalloc of check_mode
+  | Noalloc_exn of check_mode
 
 type function_kind = Curried of {nlocal: int} | Tupled
 

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -527,6 +527,7 @@ let default_function_attribute = {
   inline = Default_inline;
   specialise = Default_specialise;
   local = Default_local;
+  check = Default_check ;
   is_a_functor = false;
   stub = false;
 }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -283,6 +283,12 @@ type local_attribute =
   | Never_local (* [@local never] *)
   | Default_local (* [@local maybe] or no [@local] attribute *)
 
+type check_attribute =
+  | Default_check
+  | Noeffects_check
+  | Noalloc_check
+  | Noalloc_exn_check
+
 type function_kind = Curried of {nlocal: int} | Tupled
 (* [nlocal] determines how many arguments may be partially applied
    before the resulting closure must be locally allocated.
@@ -309,6 +315,7 @@ type function_attribute = {
   inline : inline_attribute;
   specialise : specialise_attribute;
   local: local_attribute;
+  check : check_attribute;
   is_a_functor: bool;
   stub: bool;
 }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -283,11 +283,15 @@ type local_attribute =
   | Never_local (* [@local never] *)
   | Default_local (* [@local maybe] or no [@local] attribute *)
 
+type check_mode =
+  | Assert
+  | Assume
+
 type check_attribute =
   | Default_check
-  | Noeffects_check
-  | Noalloc_check
-  | Noalloc_exn_check
+  | Noeffects of check_mode
+  | Noalloc of check_mode
+  | Noalloc_exn of check_mode
 
 type function_kind = Curried of {nlocal: int} | Tupled
 (* [nlocal] determines how many arguments may be partially applied

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -548,6 +548,18 @@ let name_of_primitive = function
   | Popaque -> "Popaque"
   | Pprobe_is_enabled _ -> "Pprobe_is_enabled"
 
+let check_attribute ppf check =
+  let check_mode = function
+    | Assert -> "assert"
+    | Assume -> "assume"
+  in
+  begin match check with
+  | Default_check -> ()
+  | Noalloc m -> fprintf ppf "%s noalloc@ " (check_mode m)
+  | Noalloc_exn m -> fprintf ppf "%s noalloc_exn@ " (check_mode m)
+  | Noeffects m -> fprintf ppf "%s noeffects@ " (check_mode m)
+    end
+
 let function_attribute ppf { inline; specialise; check; local; is_a_functor; stub } =
   if is_a_functor then
     fprintf ppf "is_a_functor@ ";
@@ -570,12 +582,7 @@ let function_attribute ppf { inline; specialise; check; local; is_a_functor; stu
   | Always_local -> fprintf ppf "always_local@ "
   | Never_local -> fprintf ppf "never_local@ "
   end;
-  begin match check with
-  | Default_check -> ()
-  | Noalloc_check -> fprintf ppf "noalloc_check@ "
-  | Noalloc_exn_check -> fprintf ppf "noalloc_exn_check@ "
-  | Noeffects_check -> fprintf ppf "noeffects_check@ "
-  end
+  check_attribute ppf check
 
 let apply_tailcall_attribute ppf = function
   | Default_tailcall -> ()

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -548,7 +548,7 @@ let name_of_primitive = function
   | Popaque -> "Popaque"
   | Pprobe_is_enabled _ -> "Pprobe_is_enabled"
 
-let function_attribute ppf { inline; specialise; local; is_a_functor; stub } =
+let function_attribute ppf { inline; specialise; check; local; is_a_functor; stub } =
   if is_a_functor then
     fprintf ppf "is_a_functor@ ";
   if stub then
@@ -569,6 +569,12 @@ let function_attribute ppf { inline; specialise; local; is_a_functor; stub } =
   | Default_local -> ()
   | Always_local -> fprintf ppf "always_local@ "
   | Never_local -> fprintf ppf "never_local@ "
+  end;
+  begin match check with
+  | Default_check -> ()
+  | Noalloc_check -> fprintf ppf "noalloc_check@ "
+  | Noalloc_exn_check -> fprintf ppf "noalloc_exn_check@ "
+  | Noeffects_check -> fprintf ppf "noeffects_check@ "
   end
 
 let apply_tailcall_attribute ppf = function

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -818,6 +818,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
         { inline = Never_inline;
           specialise = Always_specialise;
           local = Never_local;
+          check = Default_check;
           is_a_functor = false;
           stub = false;
         } in

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -534,6 +534,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
       inline = inline_attribute;
       specialise = Default_specialise;
       local = Default_local;
+      check = Default_check;
       is_a_functor = true;
       stub = false;
     };

--- a/ocaml/otherlibs/bigarray/dune
+++ b/ocaml/otherlibs/bigarray/dune
@@ -20,7 +20,7 @@
    -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
- (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp) -alloc-check -indirect-call-check)
  (library_flags (:standard -linkall)))
 
 (install

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -20,7 +20,7 @@
     -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48
     -warn-error A -bin-annot -safe-string -strict-formats
   ))
-  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp)-alloc-check -indirect-call-check)
   (modules
     binutils
     local_store

--- a/ocaml/otherlibs/str/dune
+++ b/ocaml/otherlibs/str/dune
@@ -20,7 +20,7 @@
    -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
- (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp) -alloc-check -indirect-call-check)
  (library_flags (:standard -linkall))
  (foreign_stubs (language c) (names strstubs)
   (flags ((:include %{project_root}/oc_cflags.sexp)

--- a/ocaml/otherlibs/systhreads/dune
+++ b/ocaml/otherlibs/systhreads/dune
@@ -23,7 +23,7 @@
     semaphore
     thread)
   (flags -w +33..39 -warn-error A -g -bin-annot -safe-string)
-  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp) -alloc-check -indirect-call-check)
   (libraries unix)
   (library_flags -linkall)
   (c_library_flags -lpthread)

--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -20,7 +20,7 @@
    -absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot
    -g -safe-string -strict-sequence -strict-formats
  ))
- (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp) -alloc-check -indirect-call-check)
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall))
  ; UnixLabels is compiled separately as it needs the -nolabels flag.  We can't
  ; currently use an attribute in the .ml file to enable this behaviour as

--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -20,7 +20,7 @@
    -absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot
    -g -safe-string -strict-sequence -strict-formats
  ))
- (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp) -alloc-check -indirect-call-check)
  (library_flags (:standard -linkall))
  ; UnixLabels is compiled separately as it needs the -nolabels flag.  We can't
  ; currently use an attribute in the .ml file to enable this behaviour as

--- a/ocaml/stdlib/dune
+++ b/ocaml/stdlib/dune
@@ -25,7 +25,7 @@
      -g -warn-error A -bin-annot -nostdlib
      -safe-string -strict-formats
  ))
- (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp) -alloc-check -indirect-call-check)
  (preprocess
    (per_module
      ((action

--- a/ocaml/utils/config.mlp
+++ b/ocaml/utils/config.mlp
@@ -103,14 +103,14 @@ and cmo_magic_number = "Caml1999O500"
 and cma_magic_number = "Caml1999A500"
 and cmx_magic_number =
   if flambda || flambda2 then
-    "Caml2021y501"
+    "Caml2021y502"
   else
-    "Caml2021Y501"
+    "Caml2021Y502"
 and cmxa_magic_number =
   if flambda || flambda2 then
-    "Caml2021z501"
+    "Caml2021z502"
   else
-    "Caml2021Z501"
+    "Caml2021Z502"
 and ast_impl_magic_number = "Caml1999M029"
 and ast_intf_magic_number = "Caml1999N029"
 and cmxs_magic_number = "Caml1999D501"

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -15,18 +15,20 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Dump info on .cmi, .cmo, .cmx, .cma, .cmxa, .cmxs files
-   and on bytecode executables. *)
+(* Dump info on .cmi, .cmo, .cmx, .cma, .cmxa, .cmxs files and on bytecode
+   executables. *)
 
 open Printf
 open Misc
 open Cmo_format
+module S = Misc.Stdlib.String.Set
 
-(* Command line options to prevent printing approximation,
-   function code and CRC
- *)
+(* Command line options to prevent printing approximation, function code and
+   CRC *)
 let no_approx = ref false
+
 let no_code = ref false
+
 let no_crc = ref false
 
 module Magic_number = Misc.Magic_number
@@ -34,34 +36,33 @@ module Magic_number = Misc.Magic_number
 let input_stringlist ic len =
   let get_string_list sect len =
     let rec fold s e acc =
-      if e != len then
-        if sect.[e] = '\000' then
-          fold (e+1) (e+1) (String.sub sect s (e-s) :: acc)
-        else fold s (e+1) acc
+      if e != len
+      then
+        if sect.[e] = '\000'
+        then fold (e + 1) (e + 1) (String.sub sect s (e - s) :: acc)
+        else fold s (e + 1) acc
       else acc
-    in fold 0 0 []
+    in
+    fold 0 0 []
   in
   let sect = really_input_string ic len in
   get_string_list sect len
 
 let dummy_crc = String.make 32 '-'
+
 let null_crc = String.make 32 '0'
 
 let string_of_crc crc = if !no_crc then null_crc else Digest.to_hex crc
 
 let print_name_crc (name, crco) =
   let crc =
-    match crco with
-      None -> dummy_crc
-    | Some crc -> string_of_crc crc
+    match crco with None -> dummy_crc | Some crc -> string_of_crc crc
   in
-    printf "\t%s\t%s\n" crc name
+  printf "\t%s\t%s\n" crc name
 
-let print_line name =
-  printf "\t%s\n" name
+let print_line name = printf "\t%s\n" name
 
-let print_required_global id =
-  printf "\t%s\n" (Ident.name id)
+let print_required_global id = printf "\t%s\n" (Ident.name id)
 
 let print_cmo_infos cu =
   printf "Unit name: %s\n" cu.cu_name;
@@ -71,15 +72,14 @@ let print_cmo_infos cu =
   List.iter print_required_global cu.cu_required_globals;
   printf "Uses unsafe features: ";
   (match cu.cu_primitives with
-    | [] -> printf "no\n"
-    | l  ->
-        printf "YES\n";
-        printf "Primitives declared in this module:\n";
-        List.iter print_line l);
+  | [] -> printf "no\n"
+  | l ->
+    printf "YES\n";
+    printf "Primitives declared in this module:\n";
+    List.iter print_line l);
   printf "Force link: %s\n" (if cu.cu_force_link then "YES" else "no")
 
-let print_spaced_string s =
-  printf " %s" s
+let print_spaced_string s = printf " %s" s
 
 let print_cma_infos (lib : Cmo_format.library) =
   printf "Force custom: %s\n" (if lib.lib_custom then "YES" else "no");
@@ -105,7 +105,7 @@ let print_cmt_infos cmt =
   print_string "Cmt interfaces imported:\n";
   List.iter print_name_crc cmt.cmt_imports;
   printf "Source file: %s\n"
-         (match cmt.cmt_sourcefile with None -> "(none)" | Some f -> f);
+    (match cmt.cmt_sourcefile with None -> "(none)" | Some f -> f);
   printf "Compilation flags:";
   Array.iter print_spaced_string cmt.cmt_args;
   printf "\nLoad path:";
@@ -113,8 +113,8 @@ let print_cmt_infos cmt =
   printf "\n";
   printf "cmt interface digest: %s\n"
     (match cmt.cmt_interface_digest with
-     | None -> ""
-     | Some crc -> string_of_crc crc)
+    | None -> ""
+    | Some crc -> string_of_crc crc)
 
 let print_general_infos name crc defines iter_cmi iter_cmx =
   printf "Name: %s\n" name;
@@ -128,9 +128,7 @@ let print_general_infos name crc defines iter_cmi iter_cmx =
 
 let print_global_table table =
   printf "Globals defined:\n";
-  Symtable.iter_global_map
-    (fun id _ -> print_line (Ident.name id))
-    table
+  Symtable.iter_global_map (fun id _ -> print_line (Ident.name id)) table
 
 open Cmx_format
 open Cmxs_format
@@ -138,58 +136,72 @@ open Cmxs_format
 let print_generic_fns gfns =
   let pr_afuns _ fns =
     let mode = function Lambda.Alloc_heap -> "" | Lambda.Alloc_local -> "L" in
-    List.iter (fun (arity,m) -> printf " %d%s" arity (mode m)) fns in
+    List.iter (fun (arity, m) -> printf " %d%s" arity (mode m)) fns
+  in
   let pr_cfuns _ fns =
-    List.iter (function
-      | (Lambda.Curried {nlocal},a) -> printf " %dL%d" a nlocal
-      | (Lambda.Tupled, a) -> printf " -%d" a) fns in
+    List.iter
+      (function
+        | Lambda.Curried { nlocal }, a -> printf " %dL%d" a nlocal
+        | Lambda.Tupled, a -> printf " -%d" a)
+      fns
+  in
   printf "Currying functions:%a\n" pr_cfuns gfns.curry_fun;
   printf "Apply functions:%a\n" pr_afuns gfns.apply_fun;
   printf "Send functions:%a\n" pr_afuns gfns.send_fun
-
 
 let print_cmx_infos (ui, crc) =
   print_general_infos ui.ui_name crc ui.ui_defines
     (fun f -> List.iter f ui.ui_imports_cmi)
     (fun f -> List.iter f ui.ui_imports_cmx);
-  begin match ui.ui_export_info with
-  | Clambda approx ->
-    if not !no_approx then begin
-      printf "Clambda approximation:\n";
-      Format.fprintf Format.std_formatter "  %a@." Printclambda.approx approx
-    end else
-      Format.printf "Clambda unit@.";
-  | Flambda1 export ->
-    if not !no_approx || not !no_code then
-      printf "Flambda export information:\n"
-    else
-      printf "Flambda unit\n";
-    if not !no_approx then begin
-      let cu =
-        Compilation_unit.create (Ident.create_persistent ui.ui_name)
-          (Linkage_name.create "__dummy__")
-      in
-      Compilation_unit.set_current cu;
-      let root_symbols =
-        List.map (fun s ->
-            Symbol.of_global_linkage cu (Linkage_name.create ("caml"^s)))
-          ui.ui_defines
-      in
-      Format.printf "approximations@ %a@.@."
-        Export_info.print_approx (export, root_symbols)
-    end;
-    if not !no_code then
-      Format.printf "functions@ %a@.@."
-        Export_info.print_functions export
-  | Flambda2 None ->
-    printf "Flambda 2 unit (with no export information)\n"
-  | Flambda2 (Some cmx) ->
-    printf "Flambda 2 export information:\n";
-    flush stdout;
-    Format.printf "%a\n%!" Flambda2_cmx.Flambda_cmx_format.print cmx
+  begin
+    match ui.ui_export_info with
+    | Clambda approx ->
+      if not !no_approx
+      then begin
+        printf "Clambda approximation:\n";
+        Format.fprintf Format.std_formatter "  %a@." Printclambda.approx approx
+      end
+      else Format.printf "Clambda unit@."
+    | Flambda1 export ->
+      if (not !no_approx) || not !no_code
+      then printf "Flambda export information:\n"
+      else printf "Flambda unit\n";
+      if not !no_approx
+      then begin
+        let cu =
+          Compilation_unit.create
+            (Ident.create_persistent ui.ui_name)
+            (Linkage_name.create "__dummy__")
+        in
+        Compilation_unit.set_current cu;
+        let root_symbols =
+          List.map
+            (fun s ->
+              Symbol.of_global_linkage cu (Linkage_name.create ("caml" ^ s)))
+            ui.ui_defines
+        in
+        Format.printf "approximations@ %a@.@." Export_info.print_approx
+          (export, root_symbols)
+      end;
+      if not !no_code
+      then Format.printf "functions@ %a@.@." Export_info.print_functions export
+    | Flambda2 None -> printf "Flambda 2 unit (with no export information)\n"
+    | Flambda2 (Some cmx) ->
+      printf "Flambda 2 export information:\n";
+      flush stdout;
+      Format.printf "%a\n%!" Flambda2_cmx.Flambda_cmx_format.print cmx
   end;
   print_generic_fns ui.ui_generic_fns;
-  printf "Force link: %s\n" (if ui.ui_force_link then "YES" else "no")
+  printf "Force link: %s\n" (if ui.ui_force_link then "YES" else "no");
+  printf "Functions without effects, allocations and indirect calls:\n";
+  S.iter print_line ui.ui_checks.ui_noeffects_functions;
+  printf "Functions without allocations and indirect calls:\n";
+  S.iter print_line ui.ui_checks.ui_noalloc_functions;
+  printf
+    "Functions without allocations and indirect calls not leading to raise:\n";
+  S.iter print_line ui.ui_checks.ui_noalloc_exn_functions;
+  printf "Functions without indirect calls:\n";
+  S.iter print_line ui.ui_checks.ui_noindirect_functions
 
 let print_cmxa_infos (lib : Cmx_format.library_infos) =
   printf "Extra C object files:";
@@ -199,21 +211,21 @@ let print_cmxa_infos (lib : Cmx_format.library_infos) =
   printf "\n";
   print_generic_fns lib.lib_generic_fns;
   let module B = Misc.Bitmap in
-  lib.lib_units |> List.iter (fun u ->
-    print_general_infos u.li_name u.li_crc u.li_defines
-      (fun f -> B.iter (fun i -> f lib.lib_imports_cmi.(i)) u.li_imports_cmi)
-      (fun f -> B.iter (fun i -> f lib.lib_imports_cmx.(i)) u.li_imports_cmx);
-    printf "Force link: %s\n" (if u.li_force_link then "YES" else "no"))
+  lib.lib_units
+  |> List.iter (fun u ->
+         print_general_infos u.li_name u.li_crc u.li_defines
+           (fun f ->
+             B.iter (fun i -> f lib.lib_imports_cmi.(i)) u.li_imports_cmi)
+           (fun f ->
+             B.iter (fun i -> f lib.lib_imports_cmx.(i)) u.li_imports_cmx);
+         printf "Force link: %s\n" (if u.li_force_link then "YES" else "no"))
 
 let print_cmxs_infos header =
   List.iter
     (fun ui ->
-       print_general_infos
-         ui.dynu_name
-         ui.dynu_crc
-         ui.dynu_defines
-         (fun f -> List.iter f ui.dynu_imports_cmi)
-         (fun f -> List.iter f ui.dynu_imports_cmx))
+      print_general_infos ui.dynu_name ui.dynu_crc ui.dynu_defines
+        (fun f -> List.iter f ui.dynu_imports_cmi)
+        (fun f -> List.iter f ui.dynu_imports_cmx))
     header.dynu_units
 
 let p_title title = printf "%s:\n" title
@@ -221,14 +233,14 @@ let p_title title = printf "%s:\n" title
 let p_section title = function
   | [] -> ()
   | l ->
-      p_title title;
-      List.iter print_name_crc l
+    p_title title;
+    List.iter print_name_crc l
 
 let p_list title print = function
   | [] -> ()
   | l ->
-      p_title title;
-      List.iter print l
+    p_title title;
+    List.iter print l
 
 let dump_byte ic =
   Bytesections.read_toc ic;
@@ -236,187 +248,174 @@ let dump_byte ic =
   let toc = List.sort Stdlib.compare toc in
   List.iter
     (fun (section, _) ->
-       try
-         let len = Bytesections.seek_section ic section in
-         if len > 0 then match section with
-           | "CRCS" ->
-               p_section
-                 "Imported units"
-                 (input_value ic : (string * Digest.t option) list)
-           | "DLLS" ->
-               p_list
-                 "Used DLLs"
-                 print_line
-                 (input_stringlist ic len)
-           | "DLPT" ->
-               p_list
-                 "Additional DLL paths"
-                 print_line
-                 (input_stringlist ic len)
-           | "PRIM" ->
-               p_list
-                 "Primitives used"
-                 print_line
-                 (input_stringlist ic len)
-           | "SYMB" ->
-               print_global_table (input_value ic)
-           | _ -> ()
-       with _ -> ()
-    )
+      try
+        let len = Bytesections.seek_section ic section in
+        if len > 0
+        then
+          match section with
+          | "CRCS" ->
+            p_section "Imported units"
+              (input_value ic : (string * Digest.t option) list)
+          | "DLLS" -> p_list "Used DLLs" print_line (input_stringlist ic len)
+          | "DLPT" ->
+            p_list "Additional DLL paths" print_line (input_stringlist ic len)
+          | "PRIM" ->
+            p_list "Primitives used" print_line (input_stringlist ic len)
+          | "SYMB" -> print_global_table (input_value ic)
+          | _ -> ()
+      with _ -> ())
     toc
 
 let find_dyn_offset filename =
   match Binutils.read filename with
-  | Ok t ->
-      Binutils.symbol_offset t "caml_plugin_header"
-  | Error _ ->
-      None
+  | Ok t -> Binutils.symbol_offset t "caml_plugin_header"
+  | Error _ -> None
 
-let exit_err msg = print_endline msg; exit 2
+let exit_err msg =
+  print_endline msg;
+  exit 2
+
 let exit_errf fmt = Printf.ksprintf exit_err fmt
 
 let exit_magic_msg msg =
   exit_errf
-     "Wrong magic number:\n\
-      this tool only supports object files produced by compiler version\n\
-      \t%s\n\
-      %s"
+    "Wrong magic number:\n\
+     this tool only supports object files produced by compiler version\n\
+     \t%s\n\
+     %s"
     Sys.ocaml_version msg
 
 let exit_magic_error ~expected_kind err =
-  exit_magic_msg Magic_number.(match err with
-    | Parse_error err -> explain_parse_error expected_kind err
-    | Unexpected_error err -> explain_unexpected_error err)
+  exit_magic_msg
+    Magic_number.(
+      match err with
+      | Parse_error err -> explain_parse_error expected_kind err
+      | Unexpected_error err -> explain_unexpected_error err)
 
-(* assume that 'ic' is already positioned at the right place
-   depending on the format (usually right after the magic number,
-   but Exec and Cmxs differ) *)
+(* assume that 'ic' is already positioned at the right place depending on the
+   format (usually right after the magic number, but Exec and Cmxs differ) *)
 let dump_obj_by_kind filename ic obj_kind =
   let open Magic_number in
   match obj_kind with
-    | Cmo ->
-       let cu_pos = input_binary_int ic in
-       seek_in ic cu_pos;
-       let cu = (input_value ic : compilation_unit) in
-       close_in ic;
-       print_cmo_infos cu
-    | Cma ->
-       let toc_pos = input_binary_int ic in
-       seek_in ic toc_pos;
-       let toc = (input_value ic : library) in
-       close_in ic;
-       print_cma_infos toc
-    | Cmi | Cmt ->
-       close_in ic;
-       let cmi, cmt = Cmt_format.read filename in
-       begin match cmi with
-         | None -> ()
-         | Some cmi ->
-            print_cmi_infos cmi.Cmi_format.cmi_name cmi.Cmi_format.cmi_crcs
-       end;
-       begin match cmt with
-         | None -> ()
-         | Some cmt -> print_cmt_infos cmt
-       end
-    | Cmx _config ->
-       let ui = (input_value ic : unit_infos) in
-       let crc = Digest.input ic in
-       close_in ic;
-       print_cmx_infos (ui, crc)
-    | Cmxa _config ->
-       let li = (input_value ic : library_infos) in
-       close_in ic;
-       print_cmxa_infos li
-    | Exec ->
-       (* no assumptions on [ic] position,
-          [dump_byte] will seek at the right place *)
-       dump_byte ic;
-       close_in ic
-    | Cmxs ->
-       (* we assume we are at the offset of the dynamic information,
-          as returned by [find_dyn_offset]. *)
-       let header = (input_value ic : dynheader) in
-       close_in ic;
-       print_cmxs_infos header;
-    | Ast_impl | Ast_intf ->
-       exit_errf "The object file type %S \
-                  is currently unsupported by this tool."
-         (human_name_of_kind obj_kind)
+  | Cmo ->
+    let cu_pos = input_binary_int ic in
+    seek_in ic cu_pos;
+    let cu = (input_value ic : compilation_unit) in
+    close_in ic;
+    print_cmo_infos cu
+  | Cma ->
+    let toc_pos = input_binary_int ic in
+    seek_in ic toc_pos;
+    let toc = (input_value ic : library) in
+    close_in ic;
+    print_cma_infos toc
+  | Cmi | Cmt -> (
+    close_in ic;
+    let cmi, cmt = Cmt_format.read filename in
+    begin
+      match cmi with
+      | None -> ()
+      | Some cmi ->
+        print_cmi_infos cmi.Cmi_format.cmi_name cmi.Cmi_format.cmi_crcs
+    end;
+    match cmt with None -> () | Some cmt -> print_cmt_infos cmt)
+  | Cmx _config ->
+    let ui = (input_value ic : unit_infos) in
+    let crc = Digest.input ic in
+    close_in ic;
+    print_cmx_infos (ui, crc)
+  | Cmxa _config ->
+    let li = (input_value ic : library_infos) in
+    close_in ic;
+    print_cmxa_infos li
+  | Exec ->
+    (* no assumptions on [ic] position, [dump_byte] will seek at the right
+       place *)
+    dump_byte ic;
+    close_in ic
+  | Cmxs ->
+    (* we assume we are at the offset of the dynamic information, as returned by
+       [find_dyn_offset]. *)
+    let header = (input_value ic : dynheader) in
+    close_in ic;
+    print_cmxs_infos header
+  | Ast_impl | Ast_intf ->
+    exit_errf "The object file type %S is currently unsupported by this tool."
+      (human_name_of_kind obj_kind)
 
 let dump_obj filename =
   let open Magic_number in
   let dump_standard ic =
     match read_current_info ~expected_kind:None ic with
-      | Error ((Unexpected_error _) as err) ->
-         exit_magic_error ~expected_kind:None err
-      | Ok { kind; version = _ } ->
-         dump_obj_by_kind filename ic kind;
-         Ok ()
-      | Error (Parse_error head_error) ->
-         Error head_error
+    | Error (Unexpected_error _ as err) ->
+      exit_magic_error ~expected_kind:None err
+    | Ok { kind; version = _ } ->
+      dump_obj_by_kind filename ic kind;
+      Ok ()
+    | Error (Parse_error head_error) -> Error head_error
   and dump_exec ic =
     let pos_trailer = in_channel_length ic - Magic_number.magic_length in
     let _ = seek_in ic pos_trailer in
     let expected_kind = Some Exec in
     match read_current_info ~expected_kind ic with
-      | Error ((Unexpected_error _) as err) ->
-         exit_magic_error ~expected_kind err
-      | Ok _ ->
-         dump_obj_by_kind filename ic Exec;
-         Ok ()
-      | Error (Parse_error _)  ->
-         Error ()
+    | Error (Unexpected_error _ as err) -> exit_magic_error ~expected_kind err
+    | Ok _ ->
+      dump_obj_by_kind filename ic Exec;
+      Ok ()
+    | Error (Parse_error _) -> Error ()
   and dump_cmxs ic =
     flush stdout;
     match find_dyn_offset filename with
-      | None ->
-         exit_errf "Unable to read info on %s %s."
-           (human_name_of_kind Cmxs) filename
-      | Some offset ->
-         LargeFile.seek_in ic offset;
-         let header = (input_value ic : dynheader) in
-         let expected_kind = Some Cmxs in
-         match parse header.dynu_magic with
-           | Error err ->
-              exit_magic_error ~expected_kind (Parse_error err)
-           | Ok info ->
-         match check_current Cmxs info with
-           | Error err ->
-              exit_magic_error ~expected_kind (Unexpected_error err)
-           | Ok () ->
-         LargeFile.seek_in ic offset;
-         dump_obj_by_kind filename ic Cmxs;
-         ()
+    | None ->
+      exit_errf "Unable to read info on %s %s." (human_name_of_kind Cmxs)
+        filename
+    | Some offset -> (
+      LargeFile.seek_in ic offset;
+      let header = (input_value ic : dynheader) in
+      let expected_kind = Some Cmxs in
+      match parse header.dynu_magic with
+      | Error err -> exit_magic_error ~expected_kind (Parse_error err)
+      | Ok info -> (
+        match check_current Cmxs info with
+        | Error err -> exit_magic_error ~expected_kind (Unexpected_error err)
+        | Ok () ->
+          LargeFile.seek_in ic offset;
+          dump_obj_by_kind filename ic Cmxs;
+          ()))
   in
   printf "File %s\n" filename;
   let ic = open_in_bin filename in
   match dump_standard ic with
-    | Ok () -> ()
-    | Error head_error ->
-  match dump_exec ic with
+  | Ok () -> ()
+  | Error head_error -> (
+    match dump_exec ic with
     | Ok () -> ()
     | Error () ->
-  if Filename.check_suffix filename ".cmxs"
-  then dump_cmxs ic
-  else exit_magic_error ~expected_kind:None (Parse_error head_error)
+      if Filename.check_suffix filename ".cmxs"
+      then dump_cmxs ic
+      else exit_magic_error ~expected_kind:None (Parse_error head_error))
 
-let arg_list = [
-  "-no-approx", Arg.Set no_approx,
-    " Do not print module approximation information";
-  "-no-code", Arg.Set no_code,
-    " Do not print code from exported flambda functions";
-  "-null-crc", Arg.Set no_crc, " Print a null CRC for imported interfaces";
-  "-args", Arg.Expand Arg.read_arg,
-     "<file> Read additional newline separated command line arguments \n\
-     \      from <file>";
-  "-args0", Arg.Expand Arg.read_arg0,
-     "<file> Read additional NUL separated command line arguments from \n\
-     \      <file>";
-]
+let arg_list =
+  [ ( "-no-approx",
+      Arg.Set no_approx,
+      " Do not print module approximation information" );
+    ( "-no-code",
+      Arg.Set no_code,
+      " Do not print code from exported flambda functions" );
+    "-null-crc", Arg.Set no_crc, " Print a null CRC for imported interfaces";
+    ( "-args",
+      Arg.Expand Arg.read_arg,
+      "<file> Read additional newline separated command line arguments \n\
+      \      from <file>" );
+    ( "-args0",
+      Arg.Expand Arg.read_arg0,
+      "<file> Read additional NUL separated command line arguments from \n\
+      \      <file>" ) ]
+
 let arg_usage =
-   Printf.sprintf "%s [OPTIONS] FILES : give information on files" Sys.argv.(0)
+  Printf.sprintf "%s [OPTIONS] FILES : give information on files" Sys.argv.(0)
 
-let main() =
+let main () =
   Arg.parse_expand arg_list dump_obj arg_usage;
   exit 0
 


### PR DESCRIPTION
This PR adds an experimental new pass on Mach that statically checks certain interprocedural properties of functions and records the results in Cmx. The checks are off by default (except on the standard library) and can be turned on using compiler flags `-noalloc-check`,  `-noeffect-check`, `-noindirect-calls-check`.  

A function is "noalloc" if it satisfies the following conditions:
   - does not contain any allocations instructions on the heap (local allocations are ignored)
   - does not contain any indirect calls (incl. no indirect tailcalls)
   - raise_notrace is allowed, but no other raise kinds
   - all direct calls (incl. tailcalls and probe handlers) are to functions that satisfy the same conditions.

A function is "noalloc_exn" if it is noalloc except that any raise instructions are allowed and there are no constraints on instructions that are post-dominated by a  raise with backtrace (with a somewhat conservative interpretation for raise inside loops and try-with). This is probably the most useful check in practice, as it allows allocation on error paths.

A function is "noffect" if it is noalloc and does not contain any instructions that write to heap-allocated memory. It may be useful to have a version for "noeffect_exn" similarly to "noalloc_exn" above. 

A function is "noindirect_calls" if it does not contain any raise except raise_notrace, does not contain any indirect calls, and all direct calls are to functions that are "noindirect_calls". I'm not sure how useful the indirect calls check is, but it came for free.

These checks are combined with source level annotations on functions:
- `[@assert noalloc]`  on a function that cannot be shown statically to be "noalloc" results in a compilation error when compiled with -alloc-check flag.
- `[@assume noalloc]` is an escape hatch that would treat a function as "noalloc" without checking.
Similarly, for other properties above.

The analysis is implemented on Mach after all optimizations that can possibly remove allocation. It works the same way for all "middle-ends",  but adds function symbol names to cmx files. To reduce the overhead, cmx track names that pass the checks and don't duplicate, using the following implication between properties:

"noeffects" => "noalloc" => "noalloc_exn" and "noalloc" => "noindirect_calls"
