### PR TITLE
Review of `nominal`

### DIFF
--- a/middle_end/flambda2/algorithms/container_types.ml
+++ b/middle_end/flambda2/algorithms/container_types.ml
@@ -135,7 +135,19 @@ module Make_map (T : Thing) (Set : Set_plus_stdlib with type elt = T.t) = struct
         | Some datum1, Some datum2 -> Some (f key datum1 datum2))
       t1 t2
 
-  let inter_domain_is_non_empty _ _ = Misc.fatal_error "Not yet implemented"
+  exception Found_common_element
+
+  let inter_domain_is_non_empty t1 t2 =
+    match
+      merge
+        (fun _ datum1_opt datum2_opt ->
+          match datum1_opt, datum2_opt with
+          | None, None | None, Some _ | Some _, None -> None
+          | Some _, Some _ -> raise Found_common_element)
+        t1 t2
+    with
+    | (_ : _ t) -> false
+    | exception Found_common_element -> true
 
   exception More_than_one_binding
 

--- a/middle_end/flambda2/nominal/name_abstraction.ml
+++ b/middle_end/flambda2/nominal/name_abstraction.ml
@@ -60,13 +60,23 @@ let apply_renaming (type bindable)
     let term' = apply_renaming_to_term term perm in
     if bindable == bindable' && term == term' then t else bindable', term'
 
-module Make_matching_and_renaming0
-    (Bindable : Bindable.S) (Term : sig
-      type t
+let free_names (type bindable)
+    (module Bindable : Bindable.S with type t = bindable) (bindable, term)
+    ~free_names_of_term =
+  Name_occurrences.diff (free_names_of_term term) (Bindable.free_names bindable)
 
-      val apply_renaming : t -> Renaming.t -> t
-    end) =
-struct
+let all_ids_for_export (type bindable)
+    (module Bindable : Bindable.S with type t = bindable) (bindable, term)
+    ~all_ids_for_export_of_term =
+  Ids_for_export.union
+    (Bindable.all_ids_for_export bindable)
+    (all_ids_for_export_of_term term)
+
+module Make (Bindable : Bindable.S) (Term : Term) = struct
+  type nonrec t = (Bindable.t, Term.t) t
+
+  let create bindable term = bindable, term
+
   let[@inline always] pattern_match (bindable, term) ~f =
     pattern_match
       (module Bindable)
@@ -91,59 +101,10 @@ struct
 
   let[@inline always] ( let<> ) t f =
     pattern_match t ~f:(fun bindable term -> f (bindable, term))
-end
-[@@inline always]
 
-module Make_ids_for_export0 (Bindable : Bindable.S) (Term : Contains_ids.S) =
-struct
-  let all_ids_for_export (bindable, term) =
-    Ids_for_export.union
-      (Bindable.all_ids_for_export bindable)
-      (Term.all_ids_for_export term)
-end
-[@@inline always]
-
-module Make (Bindable : Bindable.S) (Term : Term) = struct
-  type nonrec t = (Bindable.t, Term.t) t
-
-  let create bindable term = bindable, term
-
-  include Make_matching_and_renaming0 (Bindable) (Term)
-  include Make_ids_for_export0 (Bindable) (Term)
-end
-[@@inline always]
-
-module Make_free_names
-    (Bindable : Bindable.S) (Term : sig
-      include Term
-
-      val free_names : t -> Name_occurrences.t
-    end) =
-struct
-  type nonrec t = (Bindable.t, Term.t) t
-
-  let free_names (bindable, term) =
-    Name_occurrences.diff (Term.free_names term) (Bindable.free_names bindable)
-end
-[@@inline always]
-
-module Make_matching_and_renaming
-    (Bindable : Bindable.S) (Term : sig
-      type t
-
-      val apply_renaming : t -> Renaming.t -> t
-    end) =
-struct
-  type nonrec t = (Bindable.t, Term.t) t
-
-  include Make_matching_and_renaming0 (Bindable) (Term)
-end
-[@@inline always]
-
-module Make_ids_for_export (Bindable : Bindable.S) (Term : Contains_ids.S) =
-struct
-  type nonrec t = (Bindable.t, Term.t) t
-
-  include Make_ids_for_export0 (Bindable) (Term)
+  let all_ids_for_export t =
+    all_ids_for_export
+      (module Bindable)
+      t ~all_ids_for_export_of_term:Term.all_ids_for_export
 end
 [@@inline always]

--- a/middle_end/flambda2/nominal/name_abstraction.mli
+++ b/middle_end/flambda2/nominal/name_abstraction.mli
@@ -38,6 +38,10 @@ module Make (Bindable : Bindable.S) (Term : Term) : sig
   (** Concretion of an abstraction at a fresh name. *)
   val pattern_match : t -> f:(Bindable.t -> Term.t -> 'a) -> 'a
 
+  (** Like [pattern_match], but only freshen if
+      [Flambda_features.freshen_when_printing] is enabled. *)
+  val pattern_match_for_printing : t -> f:(Bindable.t -> Term.t -> 'a) -> 'a
+
   (** Concretion of a pair of abstractions at the same fresh name. *)
   val pattern_match_pair :
     t -> t -> f:(Bindable.t -> Term.t -> Term.t -> 'a) -> 'a
@@ -82,4 +86,16 @@ module Make_ids_for_export (Bindable : Bindable.S) (Term : Contains_ids.S) : sig
   include Contains_ids.S with type t := t
 end
 
-val peek_for_printing : ('bindable, 'term) t -> 'bindable * 'term
+val pattern_match :
+  (module Bindable.S with type t = 'bindable) ->
+  ('bindable, 'term) t ->
+  apply_renaming_to_term:('term -> Renaming.t -> 'term) ->
+  f:('bindable -> 'term -> 'a) ->
+  'a
+
+val pattern_match_for_printing :
+  (module Bindable.S with type t = 'bindable) ->
+  ('bindable, 'term) t ->
+  apply_renaming_to_term:('term -> Renaming.t -> 'term) ->
+  f:('bindable -> 'term -> 'a) ->
+  'a

--- a/middle_end/flambda2/nominal/name_abstraction.mli
+++ b/middle_end/flambda2/nominal/name_abstraction.mli
@@ -52,39 +52,15 @@ module Make (Bindable : Bindable.S) (Term : Term) : sig
   val apply_renaming : t -> Renaming.t -> t
 end
 
-module Make_free_names
-    (Bindable : Bindable.S) (Term : sig
-      include Term
+(*_ One-off versions of the functions, in the form most convenient to
+  [Flambda2_terms.Flambda] *)
 
-      val free_names : t -> Name_occurrences.t
-    end) : sig
-  type nonrec t = (Bindable.t, Term.t) t
-
-  val free_names : t -> Name_occurrences.t
-end
-
-module Make_matching_and_renaming
-    (Bindable : Bindable.S) (Term : sig
-      type t
-
-      val apply_renaming : t -> Renaming.t -> t
-    end) : sig
-  (* Like [Make] but only produces the let-operator and [apply_renaming]. *)
-
-  type nonrec t = (Bindable.t, Term.t) t
-
-  val apply_renaming : t -> Renaming.t -> t
-
-  val ( let<> ) : t -> (Bindable.t * Term.t -> 'a) -> 'a
-end
-
-module Make_ids_for_export (Bindable : Bindable.S) (Term : Contains_ids.S) : sig
-  (* Like [Make] but only produces [ids_for_export]. *)
-
-  type nonrec t = (Bindable.t, Term.t) t
-
-  include Contains_ids.S with type t := t
-end
+val apply_renaming :
+  (module Bindable.S with type t = 'bindable) ->
+  ('bindable, 'term) t ->
+  Renaming.t ->
+  apply_renaming_to_term:('term -> Renaming.t -> 'term) ->
+  ('bindable, 'term) t
 
 val pattern_match :
   (module Bindable.S with type t = 'bindable) ->
@@ -99,3 +75,15 @@ val pattern_match_for_printing :
   apply_renaming_to_term:('term -> Renaming.t -> 'term) ->
   f:('bindable -> 'term -> 'a) ->
   'a
+
+val free_names :
+  (module Bindable.S with type t = 'bindable) ->
+  ('bindable, 'term) t ->
+  free_names_of_term:('term -> Name_occurrences.t) ->
+  Name_occurrences.t
+
+val all_ids_for_export :
+  (module Bindable.S with type t = 'bindable) ->
+  ('bindable, 'term) t ->
+  all_ids_for_export_of_term:('term -> Ids_for_export.t) ->
+  Ids_for_export.t

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -53,8 +53,6 @@ end) : sig
 
   val remove : t -> N.t -> t
 
-  val remove_one_occurrence : t -> N.t -> Name_mode.t -> t
-
   val count : t -> N.t -> Num_occurrences.t
 
   val count_normal : t -> N.t -> Num_occurrences.t
@@ -82,13 +80,6 @@ end = struct
     val one_occurrence : Name_mode.t -> t
 
     val add : t -> Name_mode.t -> t
-
-    type remove_one_occurrence_result = private
-      | No_more_occurrences
-      | One_remaining_occurrence of Name_mode.t
-      | Multiple_remaining_occurrences of t
-
-    val remove_one_occurrence : t -> Name_mode.t -> remove_one_occurrence_result
 
     val num_occurrences : t -> int
 
@@ -169,48 +160,6 @@ end = struct
         encode_phantom_occurrences (1 + num_occurrences_phantom t)
         lor without_phantom_occurrences t
 
-    type remove_one_occurrence_result =
-      | No_more_occurrences
-      | One_remaining_occurrence of Name_mode.t
-      | Multiple_remaining_occurrences of t
-
-    let remove_one_occurrence t (name_mode : Name_mode.t) =
-      let t =
-        match name_mode with
-        | Normal ->
-          let num_occurrences =
-            let num = num_occurrences_normal t in
-            if num > 0 then num - 1 else 0
-          in
-          encode_normal_occurrences num_occurrences
-          lor without_normal_occurrences t
-        | In_types ->
-          let num_occurrences =
-            let num = num_occurrences_in_types t in
-            if num > 0 then num - 1 else 0
-          in
-          encode_in_types_occurrences num_occurrences
-          lor without_in_types_occurrences t
-        | Phantom ->
-          let num_occurrences =
-            let num = num_occurrences_phantom t in
-            if num > 0 then num - 1 else 0
-          in
-          encode_phantom_occurrences num_occurrences
-          lor without_phantom_occurrences t
-      in
-      match num_occurrences t with
-      | 0 -> No_more_occurrences
-      | 1 ->
-        if num_occurrences_normal t = 1
-        then One_remaining_occurrence Name_mode.normal
-        else if num_occurrences_phantom t = 1
-        then One_remaining_occurrence Name_mode.phantom
-        else if num_occurrences_in_types t = 1
-        then One_remaining_occurrence Name_mode.in_types
-        else assert false
-      | _ -> Multiple_remaining_occurrences t
-
     (* CR mshinwell: Add -strict-sequence to the build *)
 
     let downgrade_occurrences_at_strictly_greater_name_mode t
@@ -246,293 +195,99 @@ end = struct
             (num_occurrences_phantom t1 + num_occurrences_phantom t2)
   end
 
-  (* CR mshinwell: This type is a pain, see if it's really worth it *)
-  type t =
-    | Empty
-    | One of N.t * Name_mode.t
-    | Potentially_many of For_one_name.t N.Map.t
-
-  let map t =
-    match t with
-    | Empty -> N.Map.empty
-    | One (name, name_mode) ->
-      let for_one_name = For_one_name.one_occurrence name_mode in
-      N.Map.singleton name for_one_name
-    | Potentially_many map -> map
+  type t = For_one_name.t N.Map.t
 
   let [@ocamlformat "disable"] print ppf t =
-    N.Map.print For_one_name.print ppf (map t)
+    N.Map.print For_one_name.print ppf t
 
-  let equal t1 t2 =
-    match t1, t2 with
-    | Empty, Empty -> true
-    | One (n1, name_mode1), One (n2, name_mode2) ->
-      N.equal n1 n2 && Name_mode.equal name_mode1 name_mode2
-    | Potentially_many map1, Potentially_many map2 ->
-      N.Map.equal For_one_name.equal map1 map2
-    | Empty, Potentially_many map | Potentially_many map, Empty ->
-      N.Map.is_empty map
-    | One (n1, name_mode1), Potentially_many map
-    | Potentially_many map, One (n1, name_mode1) -> (
-      match N.Map.get_singleton map with
-      | None -> false
-      | Some (n2, for_one_name2) ->
-        let for_one_name1 = For_one_name.one_occurrence name_mode1 in
-        N.equal n1 n2 && For_one_name.equal for_one_name1 for_one_name2)
-    | (Empty | One _), _ -> false
+  let equal t1 t2 = N.Map.equal For_one_name.equal t1 t2
 
-  let empty = Empty
+  let empty = N.Map.empty
 
-  let is_empty t =
-    match t with
-    | Empty -> true
-    | One _ -> false
-    | Potentially_many map -> N.Map.is_empty map
+  let is_empty t = N.Map.is_empty t
 
-  let singleton name name_mode = One (name, name_mode)
+  let singleton name name_mode =
+    N.Map.singleton name (For_one_name.one_occurrence name_mode)
 
   let add t name name_mode =
-    match t with
-    | Empty -> singleton name name_mode
-    | One (name', name_mode') ->
-      if N.equal name name'
-      then
-        let for_one_name =
-          For_one_name.add (For_one_name.one_occurrence name_mode') name_mode
-        in
-        Potentially_many (N.Map.singleton name for_one_name)
-      else
-        let map =
-          N.Map.empty
-          |> N.Map.add name (For_one_name.one_occurrence name_mode)
-          |> N.Map.add name' (For_one_name.one_occurrence name_mode')
-        in
-        Potentially_many map
-    | Potentially_many map ->
-      let map =
-        N.Map.update name
-          (function
-            | None -> Some (For_one_name.one_occurrence name_mode)
-            | Some for_one_name ->
-              Some (For_one_name.add for_one_name name_mode))
-          map
-      in
-      Potentially_many map
+    N.Map.update name
+      (function
+        | None -> Some (For_one_name.one_occurrence name_mode)
+        | Some for_one_name -> Some (For_one_name.add for_one_name name_mode))
+      t
 
   let apply_renaming t perm =
-    match t with
-    | Empty -> Empty
-    | One (name, name_mode) ->
-      let name' = N.apply_renaming name perm in
-      if name == name' then t else One (name', name_mode)
-    | Potentially_many map ->
-      let map =
-        N.Map.fold
-          (fun name for_one_name result ->
-            let name = N.apply_renaming name perm in
-            N.Map.add name for_one_name result)
-          map N.Map.empty
-      in
-      Potentially_many map
+    N.Map.map_keys (fun name -> N.apply_renaming name perm) t
 
   let affected_by_renaming t perm =
-    match t with
-    | Empty -> false
-    | One (name, _name_mode) -> not (N.equal name (N.apply_renaming name perm))
-    | Potentially_many map ->
-      N.Map.exists
-        (fun name _name_mode -> not (N.equal name (N.apply_renaming name perm)))
-        map
+    (* CR lmaurer: This is ultimately just [N.Map.inter_domain_is_not_equal]. *)
+    N.Map.exists
+      (fun name _name_mode -> not (N.equal name (N.apply_renaming name perm)))
+      t
 
-  let diff t1 t2 =
-    match t1, t2 with
-    | (Empty | One _ | Potentially_many _), Empty -> t1
-    | Empty, (One _ | Potentially_many _) -> Empty
-    | One (name1, _), One (name2, _) ->
-      if N.equal name1 name2 then Empty else t1
-    | One (name1, _), Potentially_many map2 ->
-      if N.Map.mem name1 map2 then Empty else t1
-    | Potentially_many map1, One (name2, _) ->
-      (* CR mshinwell: This and the next case could go back to [Empty] *)
-      let map = N.Map.remove name2 map1 in
-      if N.Map.is_empty map then Empty else Potentially_many map
-    | Potentially_many map1, Potentially_many map2 ->
-      let map = N.Map.diff_domains map1 map2 in
-      if N.Map.is_empty map then Empty else Potentially_many map
+  let diff t1 t2 = N.Map.diff_domains t1 t2
 
   let union t1 t2 =
-    match t1, t2 with
-    | Empty, Empty -> Empty
-    | Empty, (One _ | Potentially_many _) -> t2
-    | (One _ | Potentially_many _), Empty -> t1
-    | One (name1, name_mode1), One (name2, name_mode2) ->
-      let map =
-        if N.equal name1 name2
-        then
-          N.Map.empty
-          |> N.Map.add name1
-               (For_one_name.add
-                  (For_one_name.one_occurrence name_mode1)
-                  name_mode2)
-        else
-          N.Map.empty
-          |> N.Map.add name1 (For_one_name.one_occurrence name_mode1)
-          |> N.Map.add name2 (For_one_name.one_occurrence name_mode2)
-      in
-      Potentially_many map
-    | One (name, name_mode), Potentially_many map
-    | Potentially_many map, One (name, name_mode) ->
-      let map =
-        N.Map.update name
-          (function
-            | None -> Some (For_one_name.one_occurrence name_mode)
-            | Some for_one_name ->
-              Some (For_one_name.add for_one_name name_mode))
-          map
-      in
-      Potentially_many map
-    | Potentially_many map1, Potentially_many map2 ->
-      let map =
-        N.Map.union
-          (fun _name for_one_name1 for_one_name2 ->
-            Some (For_one_name.union for_one_name1 for_one_name2))
-          map1 map2
-      in
-      Potentially_many map
+    N.Map.union
+      (fun _name for_one_name1 for_one_name2 ->
+        Some (For_one_name.union for_one_name1 for_one_name2))
+      t1 t2
 
-  let keys t =
-    match t with
-    | Empty -> N.Set.empty
-    | One (name, _) -> N.Set.singleton name
-    | Potentially_many map -> N.Map.keys map
+  let keys t = N.Map.keys t
 
   let subset_domain t1 t2 =
-    match t1, t2 with
-    | Empty, (Empty | One _ | Potentially_many _) -> true
-    | (One _ | Potentially_many _), Empty -> false
-    | One (name1, _), One (name2, _) -> N.equal name1 name2
-    | One (name1, _), Potentially_many map2 -> N.Map.mem name1 map2
-    | Potentially_many map1, One (name2, _) -> (
-      N.Map.is_empty map1
-      ||
-      match N.Map.get_singleton map1 with
-      | Some (name1, _) -> N.equal name1 name2
-      | None -> false)
-    | Potentially_many map1, Potentially_many map2 ->
-      N.Set.subset (N.Map.keys map1) (N.Map.keys map2)
+    (* CR lmaurer: Add this operation to [Patricia_tree]. ([N.Map.keys] being
+       O(n lg n) makes this especially painful.) *)
+    N.Set.subset (N.Map.keys t1) (N.Map.keys t2)
 
-  let inter_domain_is_non_empty t1 t2 =
-    match t1, t2 with
-    | Empty, (Empty | One _ | Potentially_many _)
-    | (One _ | Potentially_many _), Empty ->
-      false
-    | One (name1, _), One (name2, _) -> N.equal name1 name2
-    | One (name, _), Potentially_many map | Potentially_many map, One (name, _)
-      ->
-      N.Map.mem name map
-    | Potentially_many map1, Potentially_many map2 ->
-      N.Map.inter_domain_is_non_empty map1 map2
+  let inter_domain_is_non_empty t1 t2 = N.Map.inter_domain_is_non_empty t1 t2
 
-  let mem t name =
-    match t with
-    | Empty -> false
-    | One (name', _) -> N.equal name name'
-    | Potentially_many map -> N.Map.mem name map
+  let mem t name = N.Map.mem name t
 
-  let remove t name =
-    match t with
-    | Empty -> Empty
-    | One (name', _) -> if N.equal name name' then Empty else t
-    | Potentially_many map ->
-      let map = N.Map.remove name map in
-      if N.Map.is_empty map then Empty else Potentially_many map
-
-  let remove_one_occurrence t name name_mode =
-    match t with
-    | Empty -> Empty
-    | One (name', name_mode') ->
-      if N.equal name name' && Name_mode.equal name_mode name_mode'
-      then Empty
-      else t
-    | Potentially_many map -> (
-      match N.Map.find name map with
-      | exception Not_found -> Empty
-      | for_one_name -> (
-        match For_one_name.remove_one_occurrence for_one_name name_mode with
-        | No_more_occurrences -> Empty
-        | One_remaining_occurrence name_mode -> One (name, name_mode)
-        | Multiple_remaining_occurrences for_one_name ->
-          let map = N.Map.add name for_one_name map in
-          Potentially_many map))
+  let remove t name = N.Map.remove name t
 
   let count t name : Num_occurrences.t =
-    match t with
-    | Empty -> Zero
-    | One (name', _) -> if N.equal name name' then One else Zero
-    | Potentially_many map -> (
-      match N.Map.find name map with
-      | exception Not_found -> Zero
-      | for_one_name ->
-        let num_occurrences = For_one_name.num_occurrences for_one_name in
-        assert (num_occurrences >= 0);
-        if num_occurrences = 0
-        then Zero
-        else if num_occurrences = 1
-        then One
-        else More_than_one)
+    match N.Map.find name t with
+    | exception Not_found -> Zero
+    | for_one_name ->
+      let num_occurrences = For_one_name.num_occurrences for_one_name in
+      assert (num_occurrences >= 0);
+      if num_occurrences = 0
+      then Zero
+      else if num_occurrences = 1
+      then One
+      else More_than_one
 
   let count_normal t name : Num_occurrences.t =
-    match t with
-    | Empty -> Zero
-    | One (name', mode) ->
-      if N.equal name name' && Name_mode.is_normal mode then One else Zero
-    | Potentially_many map -> (
-      match N.Map.find name map with
-      | exception Not_found -> Zero
-      | for_one_name ->
-        let num_occurrences =
-          For_one_name.num_occurrences_normal for_one_name
-        in
-        assert (num_occurrences >= 0);
-        if num_occurrences = 0
-        then Zero
-        else if num_occurrences = 1
-        then One
-        else More_than_one)
+    match N.Map.find name t with
+    | exception Not_found -> Zero
+    | for_one_name ->
+      let num_occurrences = For_one_name.num_occurrences_normal for_one_name in
+      assert (num_occurrences >= 0);
+      if num_occurrences = 0
+      then Zero
+      else if num_occurrences = 1
+      then One
+      else More_than_one
 
   let greatest_name_mode t name : Name_mode.Or_absent.t =
-    match t with
-    | Empty -> Name_mode.Or_absent.absent
-    | One (name', name_mode) ->
-      if N.equal name name'
-      then Name_mode.Or_absent.present name_mode
-      else Name_mode.Or_absent.absent
-    | Potentially_many map -> (
-      match N.Map.find name map with
-      | exception Not_found -> Name_mode.Or_absent.absent
-      | for_one_name -> (
-        match For_one_name.max_name_mode_opt for_one_name with
-        | None -> Name_mode.Or_absent.absent
-        | Some name_mode -> Name_mode.Or_absent.present name_mode))
+    match N.Map.find name t with
+    | exception Not_found -> Name_mode.Or_absent.absent
+    | for_one_name -> (
+      match For_one_name.max_name_mode_opt for_one_name with
+      | None -> Name_mode.Or_absent.absent
+      | Some name_mode -> Name_mode.Or_absent.present name_mode)
 
   let fold t ~init ~f =
-    match t with
-    | Empty -> init
-    | One (name, _name_mode) -> f init name
-    | Potentially_many map ->
-      N.Map.fold (fun name _name_mode acc -> f acc name) map init
+    N.Map.fold (fun name _name_mode acc -> f acc name) t init
 
   let fold_with_mode t ~init ~f =
-    match t with
-    | Empty -> init
-    | One (name, name_mode) -> f init name name_mode
-    | Potentially_many map ->
-      N.Map.fold
-        (fun name name_mode acc ->
-          match For_one_name.max_name_mode_opt name_mode with
-          | Some name_mode -> f acc name name_mode
-          | None -> acc)
-        map init
+    N.Map.fold
+      (fun name name_mode acc ->
+        match For_one_name.max_name_mode_opt name_mode with
+        | Some name_mode -> f acc name name_mode
+        | None -> acc)
+      t init
 
   let downgrade_occurrences_at_strictly_greater_name_mode t
       (max_name_mode : Name_mode.t) =
@@ -540,56 +295,22 @@ end = struct
        closure allocation if [max_name_mode] is captured. *)
     match max_name_mode with
     | Normal -> t
-    | Phantom -> (
-      match t with
-      | Empty -> Empty
-      | One (name, name_mode) -> (
-        match name_mode with
-        | Normal | Phantom -> One (name, Name_mode.phantom)
-        | In_types ->
-          Misc.fatal_errorf "Cannot downgrade [In_types] to [Phantom]:@ %a"
-            print t)
-      | Potentially_many map ->
-        let map =
-          N.Map.map_sharing
-            (fun for_one_name ->
-              For_one_name.downgrade_occurrences_at_strictly_greater_name_mode
-                for_one_name Name_mode.phantom)
-            map
-        in
-        Potentially_many map)
-    | In_types -> (
-      match t with
-      | Empty -> Empty
-      | One (name, name_mode) -> (
-        match name_mode with
-        | Normal | In_types -> One (name, Name_mode.in_types)
-        | Phantom ->
-          Misc.fatal_errorf "Cannot downgrade [Phantom] to [In_types]:@ %a"
-            print t)
-      | Potentially_many map ->
-        let map =
-          N.Map.map_sharing
-            (fun for_one_name ->
-              For_one_name.downgrade_occurrences_at_strictly_greater_name_mode
-                for_one_name Name_mode.in_types)
-            map
-        in
-        Potentially_many map)
+    | Phantom ->
+      N.Map.map_sharing
+        (fun for_one_name ->
+          For_one_name.downgrade_occurrences_at_strictly_greater_name_mode
+            for_one_name Name_mode.phantom)
+        t
+    | In_types ->
+      N.Map.map_sharing
+        (fun for_one_name ->
+          For_one_name.downgrade_occurrences_at_strictly_greater_name_mode
+            for_one_name Name_mode.in_types)
+        t
 
-  let for_all t ~f =
-    match t with
-    | Empty -> true
-    | One (name, _) -> f name
-    | Potentially_many map -> N.Map.for_all (fun name _ -> f name) map
+  let for_all t ~f = N.Map.for_all (fun name _ -> f name) t
 
-  let filter t ~f =
-    match t with
-    | Empty -> t
-    | One (name, _) -> if f name then t else Empty
-    | Potentially_many map ->
-      let map = N.Map.filter (fun name _ -> f name) map in
-      if N.Map.is_empty map then Empty else Potentially_many map
+  let filter t ~f = N.Map.filter (fun name _ -> f name) t
 end
 [@@inlined always]
 
@@ -714,13 +435,6 @@ let add_continuation t cont ~has_traps =
   in
   { t with continuations; continuations_with_traps }
 
-let add_continuation_in_trap_action t cont =
-  { t with
-    continuations_in_trap_actions =
-      For_continuations.add t.continuations_in_trap_actions cont
-        Name_mode.normal
-  }
-
 let count_continuation t cont = For_continuations.count t.continuations cont
 
 let continuation_is_applied_with_traps t cont =
@@ -811,8 +525,6 @@ let create_variables vars name_mode =
       vars For_names.empty
   in
   { empty with names }
-
-let create_variables' name_mode vars = create_variables vars name_mode
 
 let create_names names name_mode =
   let names =
@@ -1122,9 +834,6 @@ let newer_version_of_code_ids t = For_code_ids.keys t.newer_version_of_code_ids
 let code_ids_and_newer_version_of_code_ids t =
   Code_id.Set.union (code_ids t) (newer_version_of_code_ids t)
 
-let only_newer_version_of_code_ids t =
-  Code_id.Set.diff (newer_version_of_code_ids t) (code_ids t)
-
 let mem_name t name = For_names.mem t.names name
 
 let mem_var t var = For_names.mem t.names (Name.var var)
@@ -1132,12 +841,6 @@ let mem_var t var = For_names.mem t.names (Name.var var)
 let mem_symbol t symbol = For_names.mem t.names (Name.symbol symbol)
 
 let mem_code_id t code_id = For_code_ids.mem t.code_ids code_id
-
-let mem_newer_version_of_code_id t code_id =
-  For_code_ids.mem t.newer_version_of_code_ids code_id
-
-let mem_value_slot_in_projections t value_slot =
-  For_value_slots.mem t.value_slots_in_projections value_slot
 
 let value_slot_is_used_or_imported t value_slot =
   Value_slot.is_imported value_slot
@@ -1190,16 +893,6 @@ let remove_continuation t k =
       continuations_with_traps;
       continuations_in_trap_actions
     }
-
-let remove_one_occurrence_of_value_slot_in_projections t value_slot name_mode =
-  if For_value_slots.is_empty t.value_slots_in_projections
-  then t
-  else
-    let value_slots_in_projections =
-      For_value_slots.remove_one_occurrence t.value_slots_in_projections
-        value_slot name_mode
-    in
-    { t with value_slots_in_projections }
 
 let greatest_name_mode_var t var =
   For_names.greatest_name_mode t.names (Name.var var)
@@ -1315,10 +1008,6 @@ let fold_continuations_including_in_trap_actions t ~init ~f =
   (* Note: continuations_with_traps is included in continuations *)
   let init = For_continuations.fold t.continuations ~init ~f in
   For_continuations.fold t.continuations_in_trap_actions ~init ~f
-
-let filter_names t ~f =
-  let names = For_names.filter t.names ~f in
-  { t with names }
 
 let fold_code_ids t ~init ~f = For_code_ids.fold t.code_ids ~init ~f
 

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -46,8 +46,6 @@ val singleton_continuation_in_trap_action : Continuation.t -> t
 
 val add_continuation : t -> Continuation.t -> has_traps:bool -> t
 
-val add_continuation_in_trap_action : t -> Continuation.t -> t
-
 val count_continuation : t -> Continuation.t -> Num_occurrences.t
 
 val continuation_is_applied_with_traps : t -> Continuation.t -> bool
@@ -93,8 +91,6 @@ val singleton_name : Name.t -> Name_mode.t -> t
 val singleton_symbol : Symbol.t -> Name_mode.t -> t
 
 val create_variables : Variable.Set.t -> Name_mode.t -> t
-
-val create_variables' : Name_mode.t -> Variable.Set.t -> t
 
 val create_names : Name.Set.t -> Name_mode.t -> t
 
@@ -144,8 +140,6 @@ val code_ids : t -> Code_id.Set.t
 
 val newer_version_of_code_ids : t -> Code_id.Set.t
 
-val only_newer_version_of_code_ids : t -> Code_id.Set.t
-
 val restrict_to_value_slots_and_function_slots : t -> t
 
 val code_ids_and_newer_version_of_code_ids : t -> Code_id.Set.t
@@ -175,10 +169,6 @@ val mem_name : t -> Name.t -> bool
 
 val mem_code_id : t -> Code_id.t -> bool
 
-val mem_newer_version_of_code_id : t -> Code_id.t -> bool
-
-val mem_value_slot_in_projections : t -> Value_slot.t -> bool
-
 val value_slot_is_used_or_imported : t -> Value_slot.t -> bool
 
 val remove_var : t -> Variable.t -> t
@@ -187,14 +177,9 @@ val remove_code_id_or_symbol : t -> Code_id_or_symbol.t -> t
 
 val remove_continuation : t -> Continuation.t -> t
 
-val remove_one_occurrence_of_value_slot_in_projections :
-  t -> Value_slot.t -> Name_mode.t -> t
-
 val greatest_name_mode_var : t -> Variable.t -> Name_mode.Or_absent.t
 
 val downgrade_occurrences_at_strictly_greater_name_mode : t -> Name_mode.t -> t
-
-val filter_names : t -> f:(Name.t -> bool) -> t
 
 val fold_names : t -> init:'a -> f:('a -> Name.t -> 'a) -> 'a
 

--- a/middle_end/flambda2/nominal/renaming.ml
+++ b/middle_end/flambda2/nominal/renaming.ml
@@ -108,37 +108,24 @@ end = struct
       original_compilation_unit
     }
 
-  let symbol t orig =
-    match Symbol.Map.find orig t.symbols with
-    | symbol -> symbol
-    | exception Not_found -> orig
+  let rename map orig ~find =
+    match find orig map with a -> a | exception Not_found -> orig
 
-  let variable t orig =
-    match Variable.Map.find orig t.variables with
-    | variable -> variable
-    | exception Not_found -> orig
+  let symbol t orig = rename t.symbols orig ~find:Symbol.Map.find
 
-  let const t orig =
-    match Const.Map.find orig t.consts with
-    | const -> const
-    | exception Not_found -> orig
+  let variable t orig = rename t.variables orig ~find:Variable.Map.find
 
-  let code_id t orig =
-    match Code_id.Map.find orig t.code_ids with
-    | code_id -> code_id
-    | exception Not_found -> orig
+  let const t orig = rename t.consts orig ~find:Const.Map.find
+
+  let code_id t orig = rename t.code_ids orig ~find:Code_id.Map.find
 
   let continuation t orig =
-    match Continuation.Map.find orig t.continuations with
-    | continuation -> continuation
-    | exception Not_found -> orig
+    rename t.continuations orig ~find:Continuation.Map.find
 
   let simple t simple =
     (* [t.simples] only holds those [Simple]s with [Coercion] (analogously to
        the grand table of [Simple]s, see reg_width_things.ml). *)
-    match Simple.Map.find simple t.simples with
-    | simple -> simple
-    | exception Not_found -> simple
+    rename t.simples simple ~find:Simple.Map.find
 
   let value_slot_is_used t var =
     if Value_slot.in_compilation_unit var t.original_compilation_unit

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -197,16 +197,11 @@ and apply_renaming_let_expr_t0
   else { body = body'; num_normal_occurrences_of_bound_vars }
 
 and apply_renaming_let_expr ({ let_abst; defining_expr } as t) renaming =
-  let module A =
-    Name_abstraction.Make_matching_and_renaming
-      (Bound_pattern)
-      (struct
-        type t = let_expr_t0
-
-        let apply_renaming = apply_renaming_let_expr_t0
-      end)
+  let let_abst' =
+    Name_abstraction.apply_renaming
+      (module Bound_pattern)
+      let_abst renaming ~apply_renaming_to_term:apply_renaming_let_expr_t0
   in
-  let let_abst' = A.apply_renaming let_abst renaming in
   let defining_expr' = apply_renaming_named defining_expr renaming in
   if let_abst == let_abst' && defining_expr == defining_expr'
   then t
@@ -231,17 +226,10 @@ and apply_renaming_let_cont_expr let_cont renaming =
 
 and apply_renaming_non_recursive_let_cont_handler
     { continuation_and_body; handler } renaming =
-  let module A =
-    Name_abstraction.Make_matching_and_renaming
-      (Bound_continuation)
-      (struct
-        type t = expr
-
-        let apply_renaming = apply_renaming
-      end)
-  in
   let continuation_and_body' =
-    A.apply_renaming continuation_and_body renaming
+    Name_abstraction.apply_renaming
+      (module Bound_continuation)
+      continuation_and_body renaming ~apply_renaming_to_term:apply_renaming
   in
   let handler' = apply_renaming_continuation_handler handler renaming in
   { handler = handler'; continuation_and_body = continuation_and_body' }
@@ -252,16 +240,10 @@ and apply_renaming_recursive_let_cont_handlers_t0 { handlers; body } renaming =
   { handlers = handlers'; body = body' }
 
 and apply_renaming_recursive_let_cont_handlers t renaming =
-  let module A =
-    Name_abstraction.Make_matching_and_renaming
-      (Bound_continuations)
-      (struct
-        type t = recursive_let_cont_handlers_t0
-
-        let apply_renaming = apply_renaming_recursive_let_cont_handlers_t0
-      end)
-  in
-  A.apply_renaming t renaming
+  Name_abstraction.apply_renaming
+    (module Bound_continuations)
+    t renaming
+    ~apply_renaming_to_term:apply_renaming_recursive_let_cont_handlers_t0
 
 and apply_renaming_continuation_handler_t0
     ({ handler; num_normal_occurrences_of_params } as t) renaming =
@@ -272,16 +254,12 @@ and apply_renaming_continuation_handler_t0
 
 and apply_renaming_continuation_handler
     ({ cont_handler_abst; is_exn_handler } as t) renaming =
-  let module A =
-    Name_abstraction.Make_matching_and_renaming
-      (Bound_parameters)
-      (struct
-        type t = continuation_handler_t0
-
-        let apply_renaming = apply_renaming_continuation_handler_t0
-      end)
+  let cont_handler_abst' =
+    Name_abstraction.apply_renaming
+      (module Bound_parameters)
+      cont_handler_abst renaming
+      ~apply_renaming_to_term:apply_renaming_continuation_handler_t0
   in
-  let cont_handler_abst' = A.apply_renaming cont_handler_abst renaming in
   if cont_handler_abst == cont_handler_abst'
   then t
   else { cont_handler_abst = cont_handler_abst'; is_exn_handler }
@@ -304,16 +282,12 @@ and apply_renaming_function_params_and_body_base { expr; free_names } renaming =
 
 and apply_renaming_function_params_and_body ({ abst; is_my_closure_used } as t)
     renaming =
-  let module A =
-    Name_abstraction.Make_matching_and_renaming
-      (Bound_for_function)
-      (struct
-        type t = function_params_and_body_base
-
-        let apply_renaming = apply_renaming_function_params_and_body_base
-      end)
+  let abst' =
+    Name_abstraction.apply_renaming
+      (module Bound_for_function)
+      abst renaming
+      ~apply_renaming_to_term:apply_renaming_function_params_and_body_base
   in
-  let abst' = A.apply_renaming abst renaming in
   if abst == abst' then t else { abst = abst'; is_my_closure_used }
 
 and apply_renaming_static_const_or_code
@@ -346,16 +320,10 @@ let rec all_ids_for_export_continuation_handler_t0
 
 and all_ids_for_export_continuation_handler
     { cont_handler_abst; is_exn_handler = _ } =
-  let module A =
-    Name_abstraction.Make_ids_for_export
-      (Bound_parameters)
-      (struct
-        type t = continuation_handler_t0
-
-        let all_ids_for_export = all_ids_for_export_continuation_handler_t0
-      end)
-  in
-  A.all_ids_for_export cont_handler_abst
+  Name_abstraction.all_ids_for_export
+    (module Bound_parameters)
+    cont_handler_abst
+    ~all_ids_for_export_of_term:all_ids_for_export_continuation_handler_t0
 
 and all_ids_for_export_continuation_handlers t =
   Continuation.Map.fold
@@ -380,17 +348,12 @@ and all_ids_for_export_let_expr_t0
   all_ids_for_export body
 
 and all_ids_for_export_let_expr { let_abst; defining_expr } =
-  let module A =
-    Name_abstraction.Make_ids_for_export
-      (Bound_pattern)
-      (struct
-        type t = let_expr_t0
-
-        let all_ids_for_export = all_ids_for_export_let_expr_t0
-      end)
-  in
   let defining_expr_ids = all_ids_for_export_named defining_expr in
-  let let_abst_ids = A.all_ids_for_export let_abst in
+  let let_abst_ids =
+    Name_abstraction.all_ids_for_export
+      (module Bound_pattern)
+      let_abst ~all_ids_for_export_of_term:all_ids_for_export_let_expr_t0
+  in
   Ids_for_export.union defining_expr_ids let_abst_ids
 
 and all_ids_for_export_named t =
@@ -411,17 +374,12 @@ and all_ids_for_export_let_cont_expr t =
 
 and all_ids_for_export_non_recursive_let_cont_handler
     { continuation_and_body; handler } =
-  let module A =
-    Name_abstraction.Make_ids_for_export
-      (Bound_continuation)
-      (struct
-        type t = expr
-
-        let all_ids_for_export = all_ids_for_export
-      end)
-  in
   let handler_ids = all_ids_for_export_continuation_handler handler in
-  let continuation_and_body_ids = A.all_ids_for_export continuation_and_body in
+  let continuation_and_body_ids =
+    Name_abstraction.all_ids_for_export
+      (module Bound_continuation)
+      continuation_and_body ~all_ids_for_export_of_term:all_ids_for_export
+  in
   Ids_for_export.union handler_ids continuation_and_body_ids
 
 and all_ids_for_export_recursive_let_cont_handlers_t0 { handlers; body } =
@@ -430,34 +388,21 @@ and all_ids_for_export_recursive_let_cont_handlers_t0 { handlers; body } =
   Ids_for_export.union body_ids handlers_ids
 
 and all_ids_for_export_recursive_let_cont_handlers t =
-  let module A =
-    Name_abstraction.Make_ids_for_export
-      (Bound_continuations)
-      (struct
-        type t = recursive_let_cont_handlers_t0
-
-        let all_ids_for_export =
-          all_ids_for_export_recursive_let_cont_handlers_t0
-      end)
-  in
-  A.all_ids_for_export t
+  Name_abstraction.all_ids_for_export
+    (module Bound_continuations)
+    t
+    ~all_ids_for_export_of_term:
+      all_ids_for_export_recursive_let_cont_handlers_t0
 
 and all_ids_for_export_function_params_and_body_base { expr; free_names = _ } =
   all_ids_for_export expr
 
 and all_ids_for_export_function_params_and_body { abst; is_my_closure_used = _ }
     =
-  let module A =
-    Name_abstraction.Make_ids_for_export
-      (Bound_for_function)
-      (struct
-        type t = function_params_and_body_base
-
-        let all_ids_for_export =
-          all_ids_for_export_function_params_and_body_base
-      end)
-  in
-  A.all_ids_for_export abst
+  Name_abstraction.all_ids_for_export
+    (module Bound_for_function)
+    abst
+    ~all_ids_for_export_of_term:all_ids_for_export_function_params_and_body_base
 
 and all_ids_for_export_static_const_or_code t =
   match t with

--- a/middle_end/flambda2/terms/result_types.ml
+++ b/middle_end/flambda2/terms/result_types.ml
@@ -114,15 +114,14 @@ module FN = Name_abstraction.Make_free_names (Bound) (TEEV)
 type t = A.t
 
 let print ppf t =
-  let { Bound.params; results; other_vars }, env_extension =
-    Name_abstraction.peek_for_printing t
-  in
-  Format.fprintf ppf
-    "@[<hov 1>(@[<hov 1>(params@ (%a))@]@ @[<hov 1>(results@ %a)@]@ @[<hov \
-     1>(other_vars@ (%a))@]@ @[<hov 1>(env_extension@ (%a))@])@]"
-    Bound_parameters.print params Bound_parameters.print results
-    (Format.pp_print_list ~pp_sep:Format.pp_print_space Variable.print)
-    other_vars TEEV.print env_extension
+  A.pattern_match_for_printing t
+    ~f:(fun { Bound.params; results; other_vars } env_extension ->
+      Format.fprintf ppf
+        "@[<hov 1>(@[<hov 1>(params@ (%a))@]@ @[<hov 1>(results@ %a)@]@ @[<hov \
+         1>(other_vars@ (%a))@]@ @[<hov 1>(env_extension@ (%a))@])@]"
+        Bound_parameters.print params Bound_parameters.print results
+        (Format.pp_print_list ~pp_sep:Format.pp_print_space Variable.print)
+        other_vars TEEV.print env_extension)
 
 let create ~params ~results env_extension =
   let other_vars =

--- a/middle_end/flambda2/terms/result_types.ml
+++ b/middle_end/flambda2/terms/result_types.ml
@@ -109,7 +109,6 @@ module Bound = struct
 end
 
 module A = Name_abstraction.Make (Bound) (TEEV)
-module FN = Name_abstraction.Make_free_names (Bound) (TEEV)
 
 type t = A.t
 
@@ -161,7 +160,10 @@ let pattern_match t ~f =
     ~f:(fun { Bound.params; results; other_vars = _ } env_extension ->
       f ~params ~results env_extension)
 
-let free_names = FN.free_names
+let free_names t =
+  Name_abstraction.free_names
+    (module Bound)
+    t ~free_names_of_term:TEEV.free_names
 
 let apply_renaming = A.apply_renaming
 


### PR DESCRIPTION
The biggest gains are from providing a non-functorized API in `Name_abstraction` and from always using `N.Map` in `Name_occurrences` (no measurable impact on compiler build time).