### PR TITLE
Fix build_upstream post-PR703

### DIFF
--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -135,7 +135,10 @@ and array_kind = Lambda.array_kind =
 and value_kind = Lambda.value_kind =
   (* CR mshinwell: Pfloatval should be renamed to Pboxedfloatval *)
     Pgenval | Pfloatval | Pboxedintval of boxed_integer | Pintval
-  | Pvariant of { tag : int; fields : value_kind list }
+  | Pvariant of {
+      consts : int list;
+      non_consts : (int * value_kind list) list;
+    }
   | Parrayval of array_kind
 
 and block_shape = Lambda.block_shape

--- a/ocaml/middle_end/clambda_primitives.mli
+++ b/ocaml/middle_end/clambda_primitives.mli
@@ -138,7 +138,10 @@ and array_kind = Lambda.array_kind =
 and value_kind = Lambda.value_kind =
   (* CR mshinwell: Pfloatval should be renamed to Pboxedfloatval *)
     Pgenval | Pfloatval | Pboxedintval of boxed_integer | Pintval
-  | Pvariant of { tag : int; fields : value_kind list }
+  | Pvariant of {
+      consts : int list;
+      non_consts : (int * value_kind list) list;
+    }
   | Parrayval of array_kind
 
 and block_shape = Lambda.block_shape

--- a/ocaml/middle_end/printclambda.ml
+++ b/ocaml/middle_end/printclambda.ml
@@ -24,23 +24,33 @@ let mutable_flag = function
   | Lambda.Mutable-> "[mut]"
   | Lambda.Immutable | Lambda.Immutable_unique -> ""
 
-let value_kind =
+let rec value_kind0 ppf kind =
   let open Lambda in
-  function
-  | Pgenval -> ""
-  | Pintval -> ":int"
-  | Pfloatval -> ":float"
-  | Parrayval Pgenarray -> ":genarray"
-  | Parrayval Pintarray -> ":intarray"
-  | Parrayval Pfloatarray -> ":floatarray"
-  | Parrayval Paddrarray -> ":addrarray"
-  | Pboxedintval Pnativeint -> ":nativeint"
-  | Pboxedintval Pint32 -> ":int32"
-  | Pboxedintval Pint64 -> ":int64"
-  | Pvariant { tag; fields } ->
-    asprintf ":[%d: %a]" tag
-      (Format.pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ",@ ")
-         Printlambda.value_kind') fields
+  match kind with
+  | Pgenval -> Format.pp_print_string ppf ""
+  | Pintval -> Format.pp_print_string ppf ":int"
+  | Pfloatval -> Format.pp_print_string ppf ":float"
+  | Parrayval Pgenarray -> Format.pp_print_string ppf ":genarray"
+  | Parrayval Pintarray -> Format.pp_print_string ppf ":intarray"
+  | Parrayval Pfloatarray -> Format.pp_print_string ppf ":floatarray"
+  | Parrayval Paddrarray -> Format.pp_print_string ppf ":addrarray"
+  | Pboxedintval Pnativeint -> Format.pp_print_string ppf ":nativeint"
+  | Pboxedintval Pint32 -> Format.pp_print_string ppf ":int32"
+  | Pboxedintval Pint64 -> Format.pp_print_string ppf ":int64"
+  | Pvariant { consts; non_consts } ->
+    Format.fprintf ppf "@[<hov 1>[(consts (%a))@ (non_consts (%a))]@]"
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space Format.pp_print_int)
+      consts
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space
+          (fun ppf (tag, fields) ->
+            fprintf ppf "@[<hov 1>[%d:@ %a]@]" tag
+              (Format.pp_print_list
+                ~pp_sep:(fun ppf () -> fprintf ppf ",@ ")
+                value_kind0)
+              fields))
+      non_consts
+
+let value_kind kind = Format.asprintf "%a" value_kind0 kind
 
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x


### PR DESCRIPTION
PR703 broke `build_upstream` due to some simple changes that hadn't been made in the `ocaml/middle_end/` subdirectory.