### PR TITLE
Tidy up Targetint_31_63 etc.

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -755,7 +755,7 @@ let close_let acc env id user_visible defining_expr
                 ~const:(fun const ->
                   match Reg_width_const.descr const with
                   | Tagged_immediate i ->
-                    let i = Targetint_31_63.(to_int i) in
+                    let i = Targetint_31_63.to_int i in
                     if i >= Array.length approx
                     then
                       Misc.fatal_errorf

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -93,11 +93,9 @@ let rec declare_const acc (const : Lambda.structured_constant) :
     Acc.t * Field_of_static_block.t * string =
   match const with
   | Const_base (Const_int c) ->
-    ( acc,
-      Tagged_immediate (Targetint_31_63.int (Targetint_31_63.Imm.of_int c)),
-      "int" )
+    acc, Tagged_immediate (Targetint_31_63.of_int c), "int"
   | Const_base (Const_char c) ->
-    acc, Tagged_immediate (Targetint_31_63.char c), "char"
+    acc, Tagged_immediate (Targetint_31_63.of_char c), "char"
   | Const_base (Const_string (s, _, _)) ->
     let const, name =
       if Flambda_features.safe_string ()
@@ -155,8 +153,8 @@ let rec declare_const acc (const : Lambda.structured_constant) :
 let close_const0 acc (const : Lambda.structured_constant) =
   let acc, const, name = declare_const acc const in
   match const with
-  | Tagged_immediate c ->
-    acc, Simple.const (Reg_width_const.tagged_immediate c), name
+  | Tagged_immediate i ->
+    acc, Simple.const (Reg_width_const.tagged_immediate i), name
   | Symbol s ->
     let acc, simple = use_of_symbol_as_simple acc s in
     acc, simple, name
@@ -757,7 +755,7 @@ let close_let acc env id user_visible defining_expr
                 ~const:(fun const ->
                   match Reg_width_const.descr const with
                   | Tagged_immediate i ->
-                    let i = Targetint_31_63.(Imm.to_int (to_targetint i)) in
+                    let i = Targetint_31_63.(to_int i) in
                     if i >= Array.length approx
                     then
                       Misc.fatal_errorf
@@ -941,7 +939,7 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
           Apply_cont_with_acc.create acc ?trap_action cont ~args
             ~dbg:condition_dbg
         in
-        acc, (Targetint_31_63.int (Targetint_31_63.Imm.of_int case), action))
+        acc, (Targetint_31_63.of_int case, action))
       acc sw.consts
   in
   match arms, sw.failaction with
@@ -988,7 +986,7 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
       | Some (default, trap_action, args) ->
         Numeric_types.Int.Set.fold
           (fun case (acc, cases) ->
-            let case = Targetint_31_63.int (Targetint_31_63.Imm.of_int case) in
+            let case = Targetint_31_63.of_int case in
             if Targetint_31_63.Map.mem case cases
             then acc, cases
             else
@@ -1933,14 +1931,14 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
     let block_access : P.Block_access_kind.t =
       Values
         { tag = Known Tag.Scannable.zero;
-          size = Known (Targetint_31_63.Imm.of_int module_block_size_in_words);
+          size = Known (Targetint_31_63.of_int module_block_size_in_words);
           field_kind = Any_value
         }
     in
     List.fold_left
       (fun (acc, body) (pos, var) ->
         let var = VB.create var Name_mode.normal in
-        let pos = Targetint_31_63.int (Targetint_31_63.Imm.of_int pos) in
+        let pos = Targetint_31_63.of_int pos in
         let named =
           Named.create_prim
             (Binary

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -311,9 +311,9 @@ module Const = struct
 
   let untagged_const_zero = naked_immediate Targetint_31_63.zero
 
-  let untagged_const_int i = naked_immediate (Targetint_31_63.int i)
+  let untagged_const_int i = naked_immediate i
 
-  let const_int i = tagged_immediate (Targetint_31_63.int i)
+  let const_int i = tagged_immediate i
 
   let const_zero = tagged_immediate Targetint_31_63.zero
 

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -35,7 +35,7 @@ module Const : sig
 
   val untagged_const_zero : t
 
-  val untagged_const_int : Targetint_31_63.Imm.t -> t
+  val untagged_const_int : Targetint_31_63.t -> t
 
   val const_zero : t
 
@@ -43,7 +43,7 @@ module Const : sig
 
   val const_unit : t
 
-  val const_int : Targetint_31_63.Imm.t -> t
+  val const_int : Targetint_31_63.t -> t
 
   (** [naked_immediate] is similar to [naked_nativeint], but represents integers
       of width [n - 1] bits, where [n] is the native machine width. (By

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -507,7 +507,7 @@ module With_subkind = struct
           Targetint_31_63.Set.of_list
             (List.map
                (fun const ->
-                 Targetint_31_63.int (Targetint_31_63.Imm.of_int const))
+                  (Targetint_31_63.of_int const))
                consts)
         in
         let non_consts =

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -505,10 +505,7 @@ module With_subkind = struct
       | [], _ :: _ | _ :: _, [] | _ :: _, _ :: _ ->
         let consts =
           Targetint_31_63.Set.of_list
-            (List.map
-               (fun const ->
-                  (Targetint_31_63.of_int const))
-               consts)
+            (List.map (fun const -> Targetint_31_63.of_int const) consts)
         in
         let non_consts =
           List.fold_left

--- a/middle_end/flambda2/kinds/tag.ml
+++ b/middle_end/flambda2/kinds/tag.ml
@@ -40,19 +40,17 @@ let create_exn tag =
   then Misc.fatal_error (Printf.sprintf "Tag.create_exn %d" tag)
   else tag
 
-let create_from_targetint imm =
-  let ti = Targetint_31_63.to_targetint imm in
-  let min_tag = Targetint_31_63.Imm.of_int min_tag in
-  let max_tag = Targetint_31_63.Imm.of_int max_tag in
-  if Targetint_31_63.Imm.compare ti min_tag >= 0
-     && Targetint_31_63.Imm.compare ti max_tag <= 0
-  then Some (Targetint_31_63.Imm.to_int ti)
+let create_from_targetint ti =
+  let min_tag = Targetint_31_63.of_int min_tag in
+  let max_tag = Targetint_31_63.of_int max_tag in
+  if Targetint_31_63.compare ti min_tag >= 0
+     && Targetint_31_63.compare ti max_tag <= 0
+  then Some (Targetint_31_63.to_int ti)
   else None
 
 let to_int t = t
 
-let to_targetint_31_63 t =
-  Targetint_31_63.int (Targetint_31_63.Imm.of_int (to_int t))
+let to_targetint_31_63 t = Targetint_31_63.of_int (to_int t)
 
 let zero = 0
 

--- a/middle_end/flambda2/numbers/numeric_types.ml
+++ b/middle_end/flambda2/numbers/numeric_types.ml
@@ -23,7 +23,7 @@ module Int_base = Container_types.Make (struct
 
   let equal (i : int) j = i = j
 
-  let [@ocamlformat "disable"] print = Format.pp_print_int
+  let print = Format.pp_print_int
 end)
 
 module Int = struct
@@ -84,7 +84,7 @@ module Float = struct
 
     let equal (i : float) j = i = j
 
-    let [@ocamlformat "disable"] print = Format.pp_print_float
+    let print = Format.pp_print_float
   end)
 end
 
@@ -112,7 +112,7 @@ module Float_by_bit_pattern = struct
 
     let hash f = Hashtbl.hash f
 
-    let [@ocamlformat "disable"] print ppf t = Format.pp_print_float ppf (Int64.float_of_bits t)
+    let print ppf t = Format.pp_print_float ppf (Int64.float_of_bits t)
   end
 
   include T0
@@ -185,7 +185,7 @@ module Int32 = struct
 
     let hash f = Hashtbl.hash f
 
-    let [@ocamlformat "disable"] print ppf t = Format.fprintf ppf "%ld" t
+    let print ppf t = Format.fprintf ppf "%ld" t
   end
 
   module Self = Container_types.Make (T0)
@@ -225,7 +225,7 @@ module Int64 = struct
 
     let hash f = Hashtbl.hash f
 
-    let [@ocamlformat "disable"] print ppf t = Format.fprintf ppf "%Ld" t
+    let print ppf t = Format.fprintf ppf "%Ld" t
   end
 
   module Self = Container_types.Make (T0)

--- a/middle_end/flambda2/numbers/one_bit_fewer.ml
+++ b/middle_end/flambda2/numbers/one_bit_fewer.ml
@@ -27,8 +27,6 @@ module type S = sig
 
   val max_value : t
 
-  val max_string_length : t
-
   val minus_one : t
 
   val zero : t
@@ -133,8 +131,6 @@ module Make (I : S) : S with type t = I.t = struct
   let min_value = I.shift_right I.min_value 1
 
   let max_value = I.shift_right I.max_value 1
-
-  let max_string_length = I.min max_value I.max_string_length
 
   let minus_one = I.minus_one
 

--- a/middle_end/flambda2/numbers/one_bit_fewer.mli
+++ b/middle_end/flambda2/numbers/one_bit_fewer.mli
@@ -13,8 +13,6 @@ module type S = sig
 
   val max_value : t
 
-  val max_string_length : t
-
   val minus_one : t
 
   val zero : t

--- a/middle_end/flambda2/numbers/targetint_31_63.ml
+++ b/middle_end/flambda2/numbers/targetint_31_63.ml
@@ -14,280 +14,149 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let () =
-  match Targetint_32_64.num_bits with
-  | Sixty_four -> ()
-  | Thirty_two ->
-    if Flambda_features.flambda2_is_enabled ()
-    then Misc.fatal_error "Flambda 2 does not yet support 32-bit compilation"
-
-(* CR mshinwell/gbury: maybe we might want to consider adding some more checks
-   in some of the conversions functions to be more safe and more consistent in
-   the handling of overflows ? For instance One_bit_fewer.of_int silently
-   truncates the input int to make it fit, whereas we probably want to make it
-   produce an error ? *)
-
-module Imm = struct
-  module T0 = struct
-    include Numeric_types.Int64
-
-    let compare = Int64.compare
-
-    let equal = Int64.equal
-
-    let hash = hash
-
-    let print = print
-
-    let minus_one = -1L
-
-    let zero = 0L
-
-    let one = 1L
-
-    let ten = 10L
-
-    let hex_ff = 0xffL
-
-    let min_value = Int64.min_int
-
-    let max_value = Int64.max_int
-
-    let sub = Int64.sub
-
-    let neg = Int64.neg
-
-    let shift_left = Int64.shift_left
-
-    let shift_right = Int64.shift_right
-
-    let shift_right_logical = Int64.shift_right_logical
-
-    let xor = Int64.logxor
-
-    let or_ = Int64.logor
-
-    let and_ = Int64.logand
-
-    let mod_ = Int64.rem
-
-    let div = Int64.div
-
-    let mul = Int64.mul
-
-    let add = Int64.add
-
-    let bottom_byte_to_int t = Int64.to_int (Int64.logand t hex_ff)
-
-    let of_char c = Int64.of_int (Char.code c)
-
-    let of_int = Int64.of_int
-
-    let to_int = Int64.to_int
-
-    let of_int_option i = Some (of_int i)
-
-    let of_int32 t = Int64.of_int32 t
-
-    let to_int32 t = Int64.to_int32 t
-
-    let of_int64 t = t
-
-    let to_int64 t = t
-
-    let of_float = Int64.of_float
-
-    let to_float = Int64.to_float
-
-    let to_targetint = Targetint_32_64.of_int64
-
-    let of_targetint = Targetint_32_64.to_int64
-
-    let max_array_length = Int64.sub (Int64.shift_left 1L 54) 1L
-
-    let max_string_length = Int64.sub (Int64.mul 8L max_array_length) 1L
-
-    let max t1 t2 = if Int64.compare t1 t2 < 0 then t2 else t1
-
-    let min t1 t2 = if Int64.compare t1 t2 < 0 then t1 else t2
-
-    let ( <= ) t1 t2 = Stdlib.( <= ) (Int64.compare t1 t2) 0
-
-    let ( < ) t1 t2 = Stdlib.( < ) (Int64.compare t1 t2) 0
-
-    let to_int_option t =
-      let min_int_as_int64 = Int64.of_int Stdlib.min_int in
-      let max_int_as_int64 = Int64.of_int Stdlib.max_int in
-      if min_int_as_int64 <= t && t <= max_int_as_int64
-      then Some (to_int t)
-      else None
-
-    let to_int_exn t =
-      match to_int_option t with
-      | Some i -> i
-      | None ->
-        Misc.fatal_errorf "Targetint_31_63.Imm.to_int_exn: %Ld out of range" t
-
-    let get_least_significant_16_bits_then_byte_swap t =
-      let least_significant_byte = Int64.logand t 0xffL in
-      let second_to_least_significant_byte =
-        Int64.shift_right_logical (Int64.logand t 0xff00L) 8
-      in
-      Int64.logor second_to_least_significant_byte
-        (Int64.shift_left least_significant_byte 8)
-  end
-
-  include One_bit_fewer.Make (T0)
-  include Container_types.Make (T0)
-
-  let to_string t = Format.asprintf "%a" print t
-end
-
-type 'a or_wrong =
-  | Ok of 'a
-  | Wrong
-
-type t =
-  { value : Imm.t;
-    print_as_char : bool
-  }
-
-type immediate = t
+(* CR-someday mshinwell/gbury: maybe we might want to consider adding some more
+   checks in some of the conversions functions to be more safe and more
+   consistent in the handling of overflows ? For instance One_bit_fewer.of_int
+   silently truncates the input int to make it fit, whereas we probably want to
+   make it produce an error ? *)
 
 module T0 = struct
-  type nonrec t = t
+  include Numeric_types.Int64
 
-  let compare t1 t2 = Imm.compare t1.value t2.value
+  let compare = Int64.compare
 
-  let equal t1 t2 = Imm.equal t1.value t2.value
+  let equal = Int64.equal
 
-  let hash t = Imm.hash t.value
+  let hash = hash
 
-  let [@ocamlformat "disable"] print ppf t =
-    let print_as_char =
-      t.print_as_char
-      && Imm.compare t.value Imm.zero >= 0
-      && Imm.compare t.value Imm.hex_ff <= 0
+  let minus_one = -1L
+
+  let zero = 0L
+
+  let one = 1L
+
+  let ten = 10L
+
+  let hex_ff = 0xffL
+
+  let bool_true = one
+
+  let bool_false = zero
+
+  let bool b = if b then bool_true else bool_false
+
+  let min_value = Int64.min_int
+
+  let max_value = Int64.max_int
+
+  let print ppf t = Format.fprintf ppf "%a" print t
+
+  let bottom_byte_to_int t = Int64.to_int (Int64.logand t hex_ff)
+
+  let sub = Int64.sub
+
+  let neg = Int64.neg
+
+  let shift_left = Int64.shift_left
+
+  let shift_right = Int64.shift_right
+
+  let shift_right_logical = Int64.shift_right_logical
+
+  let xor = Int64.logxor
+
+  let or_ = Int64.logor
+
+  let and_ = Int64.logand
+
+  let mod_ = Int64.rem
+
+  let div = Int64.div
+
+  let mul = Int64.mul
+
+  let add = Int64.add
+
+  let of_char c = Int64.of_int (Char.code c)
+
+  let of_int = Int64.of_int
+
+  let to_int = Int64.to_int
+
+  let of_int_option i = Some (of_int i)
+
+  let of_int32 t = Int64.of_int32 t
+
+  let to_int32 t = Int64.to_int32 t
+
+  let of_int64 t = t
+
+  let to_int64 t = t
+
+  let of_float = Int64.of_float
+
+  let to_float = Int64.to_float
+
+  let to_targetint = Targetint_32_64.of_int64
+
+  let of_targetint = Targetint_32_64.to_int64
+
+  let max_array_length = Int64.sub (Int64.shift_left 1L 54) 1L
+
+  let max_string_length = Int64.sub (Int64.mul 8L max_array_length) 1L
+
+  let max t1 t2 = if Int64.compare t1 t2 < 0 then t2 else t1
+
+  let min t1 t2 = if Int64.compare t1 t2 < 0 then t1 else t2
+
+  let ( <= ) t1 t2 = Stdlib.( <= ) (Int64.compare t1 t2) 0
+
+  let ( >= ) t1 t2 = Stdlib.( >= ) (Int64.compare t1 t2) 0
+
+  let ( < ) t1 t2 = Stdlib.( < ) (Int64.compare t1 t2) 0
+
+  let to_int_option t =
+    let min_int_as_int64 = Int64.of_int Stdlib.min_int in
+    let max_int_as_int64 = Int64.of_int Stdlib.max_int in
+    if min_int_as_int64 <= t && t <= max_int_as_int64
+    then Some (to_int t)
+    else None
+
+  let to_int_exn t =
+    match to_int_option t with
+    | Some i -> i
+    | None -> Misc.fatal_errorf "Targetint_31_63.to_int_exn: %Ld out of range" t
+
+  let get_least_significant_16_bits_then_byte_swap t =
+    let least_significant_byte = Int64.logand t 0xffL in
+    let second_to_least_significant_byte =
+      Int64.shift_right_logical (Int64.logand t 0xff00L) 8
     in
-    if print_as_char then
-      Format.fprintf ppf "%C" (Char.chr (Imm.bottom_byte_to_int t.value))
-    else Format.fprintf ppf "%a" Imm.print t.value
+    Int64.logor second_to_least_significant_byte
+      (Int64.shift_left least_significant_byte 8)
+
+  let is_non_negative t = t >= zero
 end
 
-module Self = Container_types.Make (T0)
+module Self = struct
+  include T0
+
+  (* Note: the [include T0] must be first so that the [One_bit_fewer] functions
+     take precedence. *)
+  include One_bit_fewer.Make (T0)
+  include Container_types.Make (T0)
+end
+
 include Self
-
-module Pair = struct
-  include
-    Container_types.Make_pair
-      (struct
-        type nonrec t = t
-
-        include Self
-      end)
-      (struct
-        type nonrec t = t
-
-        include Self
-      end)
-
-  type nonrec t = t * t
-end
-
-let cross_product = Pair.create_from_cross_product
-
-let join t1 t2 : t or_wrong =
-  if not (Imm.equal t1.value t2.value)
-  then Wrong
-  else
-    let print_as_char = t1.print_as_char && t2.print_as_char in
-    Ok { value = t1.value; print_as_char }
-
-let join_set t1s t2s =
-  let only_in_t2s = Set.diff t2s t1s in
-  let join =
-    Set.fold
-      (fun t1 result ->
-        match Set.find t1 t2s with
-        | exception Not_found -> Set.add t1 result
-        | t2 -> (
-          match join t1 t2 with Wrong -> result | Ok t -> Set.add t result))
-      t1s Set.empty
-  in
-  Set.union join only_in_t2s
-
-let bool_true = { value = Imm.one; print_as_char = false }
-
-let bool_false = { value = Imm.zero; print_as_char = false }
-
-let bool b = if b then bool_true else bool_false
-
-let int value = { value; print_as_char = false }
-
-let char value = { value = Imm.of_char value; print_as_char = true }
-
-let to_targetint t = t.value
-
-let to_targetint' t = Imm.to_targetint t.value
-
-let map t ~f = { value = f t.value; print_as_char = t.print_as_char }
-
-let is_non_negative t = Imm.compare t.value Imm.zero >= 0
-
-let set_to_targetint_set (set : Set.t) : Imm.Set.t =
-  Set.fold
-    (fun t targetints -> Imm.Set.add t.value targetints)
-    set Imm.Set.empty
-
-let set_to_targetint_set' (set : Set.t) : Targetint_32_64.Set.t =
-  Set.fold
-    (fun t targetints ->
-      Targetint_32_64.Set.add (Imm.to_targetint t.value) targetints)
-    set Targetint_32_64.Set.empty
 
 let all_bools = Set.of_list [bool_true; bool_false]
 
-let zero_one_and_minus_one =
-  Set.of_list [int Imm.zero; int Imm.one; int Imm.minus_one]
+let zero_one_and_minus_one = Set.of_list [zero; one; minus_one]
 
-let map_value1 f t = { t with value = f t.value }
+module Pair = struct
+  type nonrec t = t * t
 
-let map_value2 f t0 t1 =
-  { value = f t0.value t1.value;
-    print_as_char = t0.print_as_char && t1.print_as_char
-  }
+  include Container_types.Make_pair (Self) (Self)
+end
 
-let map_value2' f t i = { t with value = f t.value i }
-
-let get_least_significant_16_bits_then_byte_swap =
-  map_value1 Imm.get_least_significant_16_bits_then_byte_swap
-
-let shift_right_logical = map_value2' Imm.shift_right_logical
-
-let shift_right = map_value2' Imm.shift_right
-
-let shift_left = map_value2' Imm.shift_left
-
-let xor = map_value2 Imm.xor
-
-let or_ = map_value2 Imm.or_
-
-let and_ = map_value2 Imm.and_
-
-let mod_ = map_value2 Imm.mod_
-
-let div = map_value2 Imm.div
-
-let mul = map_value2 Imm.mul
-
-let sub = map_value2 Imm.sub
-
-let add = map_value2 Imm.add
-
-let neg = map_value1 Imm.neg
-
-let minus_one = int Imm.minus_one
-
-let zero = int Imm.zero
-
-let one = int Imm.one
+let cross_product = Pair.create_from_cross_product

--- a/middle_end/flambda2/numbers/targetint_31_63.ml
+++ b/middle_end/flambda2/numbers/targetint_31_63.ml
@@ -23,17 +23,9 @@
 module T0 = struct
   include Numeric_types.Int64
 
-  let compare = Int64.compare
-
-  let equal = Int64.equal
-
   let hash = hash
 
   let minus_one = -1L
-
-  let zero = 0L
-
-  let one = 1L
 
   let ten = 10L
 
@@ -53,16 +45,6 @@ module T0 = struct
 
   let bottom_byte_to_int t = Int64.to_int (Int64.logand t hex_ff)
 
-  let sub = Int64.sub
-
-  let neg = Int64.neg
-
-  let shift_left = Int64.shift_left
-
-  let shift_right = Int64.shift_right
-
-  let shift_right_logical = Int64.shift_right_logical
-
   let xor = Int64.logxor
 
   let or_ = Int64.logor
@@ -71,39 +53,17 @@ module T0 = struct
 
   let mod_ = Int64.rem
 
-  let div = Int64.div
-
-  let mul = Int64.mul
-
-  let add = Int64.add
-
   let of_char c = Int64.of_int (Char.code c)
 
-  let of_int = Int64.of_int
-
-  let to_int = Int64.to_int
-
   let of_int_option i = Some (of_int i)
-
-  let of_int32 t = Int64.of_int32 t
-
-  let to_int32 t = Int64.to_int32 t
 
   let of_int64 t = t
 
   let to_int64 t = t
 
-  let of_float = Int64.of_float
-
-  let to_float = Int64.to_float
-
   let to_targetint = Targetint_32_64.of_int64
 
   let of_targetint = Targetint_32_64.to_int64
-
-  let max_array_length = Int64.sub (Int64.shift_left 1L 54) 1L
-
-  let max_string_length = Int64.sub (Int64.mul 8L max_array_length) 1L
 
   let max t1 t2 = if Int64.compare t1 t2 < 0 then t2 else t1
 

--- a/middle_end/flambda2/numbers/targetint_31_63.ml
+++ b/middle_end/flambda2/numbers/targetint_31_63.ml
@@ -23,8 +23,6 @@
 module T0 = struct
   include Numeric_types.Int64
 
-  let hash = hash
-
   let minus_one = -1L
 
   let ten = 10L
@@ -40,8 +38,6 @@ module T0 = struct
   let min_value = Int64.min_int
 
   let max_value = Int64.max_int
-
-  let print ppf t = Format.fprintf ppf "%a" print t
 
   let bottom_byte_to_int t = Int64.to_int (Int64.logand t hex_ff)
 

--- a/middle_end/flambda2/numbers/targetint_31_63.mli
+++ b/middle_end/flambda2/numbers/targetint_31_63.mli
@@ -28,9 +28,6 @@ val min_value : t
 (** The maximum integer representable on the target. *)
 val max_value : t
 
-(** The maximum string length on the target. *)
-val max_string_length : t
-
 (** The OCaml integer -1 *)
 val minus_one : t
 

--- a/middle_end/flambda2/numbers/targetint_31_63.mli
+++ b/middle_end/flambda2/numbers/targetint_31_63.mli
@@ -14,256 +14,174 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Operations using the semantics of the type "int" on the target machine. That
-    is to say, 31-bit arithmetic on 32-bit targets; and 63-bit arithmetic on
-    64-bit targets. *)
+(** Operations using the semantics of the OCaml type "int" on the target
+    machine. That is to say, 31-bit arithmetic on 32-bit targets; and 63-bit
+    arithmetic on 64-bit targets. *)
 
-(* CR mshinwell: Remove this [Imm] module *)
-module Imm : sig
-  type t
+type t
 
-  (* CR mshinwell: Maybe this should move somewhere else let max_array_length =
-     max_wosize () let max_string_length = word_size / 8 * max_array_length -
-     1 *)
-
-  (** The minimum ocaml integer representable on the target. *)
-  val min_value : t
-
-  (** The maximum ocaml integer representable on the target. *)
-  val max_value : t
-
-  (** The maximum string length on the target. *)
-  val max_string_length : t
-
-  (** The ocaml target integer -1 *)
-  val minus_one : t
-
-  (** The ocaml target integer 0. *)
-  val zero : t
-
-  (** The ocaml target integer 1. *)
-  val one : t
-
-  (** The ocaml target integer 10. *)
-  val ten : t
-
-  (** The ocaml target integer 0xff. *)
-  val hex_ff : t
-
-  val ( <= ) : t -> t -> bool
-
-  (** Comparisons functions on ocaml target integers. *)
-  val ( < ) : t -> t -> bool
-
-  (** Returns the 8 least significant bits of the ocaml target integer as a host
-      caml integer (cannot overflow). *)
-  val bottom_byte_to_int : t -> int
-
-  (** Returns the ocaml target integer corresponding to the ASCII code of the
-      given character. *)
-  val of_char : char -> t
-
-  (** Convert the given integer (type [int]) to a target ocaml integer (type
-      [t]), modulo the target word size minus one (for the tag bit). *)
-  val of_int : int -> t
-
-  (** Returns [None] iff the given [int] cannot be represented as a target
-      "int"-width integer, else returns the same as {!of_int}. *)
-  val of_int_option : int -> t option
-
-  (** Convert the given target integer (type [t]) to an integer (type [int]),
-      modulo the [int] size, i.e. high-order bits are lost during the
-      conversion. *)
-  val to_int : t -> int
-
-  (** Convert the given ocaml target integer (type [t]) to an integer (type
-      [int]). Returns [None] if the original ocaml target integer does not fit
-      into an integer *)
-  val to_int_option : t -> int option
-
-  (** Convert the given ocaml target integer (type [t]) to an integer (type
-      [int]).
-
-      @raise Fatal_error if the original ocaml target integer does not fit into
-      an integer *)
-  val to_int_exn : t -> int
-
-  (** Convert the given 32-bit integer (type [int32]) to a target ocaml integer,
-      modulo the size of a target ocaml integer. *)
-  val of_int32 : int32 -> t
-
-  (** Convert the given ocaml target integer to a 32-bit integer (type [int32]).
-      On 64-bit platforms, the 64-bit native integer is taken modulo 2{^ 32},
-      i.e. the top 32 bits are lost. On 32-bit platforms, the conversion is
-      exact. *)
-  val to_int32 : t -> int32
-
-  (** Convert the given 64-bit integer (type [int64]) to a target native
-      integer, modulo the size of a target ocaml integer. *)
-  val of_int64 : int64 -> t
-
-  (** Convert the given ocaml target integer to a 64-bit integer (type
-      [int64]). *)
-  val to_int64 : t -> int64
-
-  (** Convert the given target native integer (type [Targetint_32_64.t]) to an
-      ocaml target integer, modulo the size of an ocaml target integer. *)
-  val of_targetint : Targetint_32_64.t -> t
-
-  (** Convert the given ocaml target integer (type [t]) to a target native
-      integer (type [Targetint_32_64.t]). *)
-  val to_targetint : t -> Targetint_32_64.t
-
-  (** Convert the given floating-point number to an ocaml target integer,
-      discarding the fractional part (truncate towards 0). The result of the
-      conversion is undefined if, after truncation, the number is outside the
-      range \[{!Targetint_31_63.Imm.min_value},
-      {!Targetint_31_63.Imm.max_value}\]. *)
-  val of_float : float -> t
-
-  (** Convert the given target integer to a floating-point number. *)
-  val to_float : t -> float
-
-  (** Unary negation. *)
-  val neg : t -> t
-
-  (** Extract the least significant 16 bits from the given ocaml target integer,
-      exchange the order of the two bytes extracted, then form a new target
-      integer by zero-extending those two bytes. *)
-  val get_least_significant_16_bits_then_byte_swap : t -> t
-
-  (** Addition. *)
-  val add : t -> t -> t
-
-  (** Subtraction. *)
-  val sub : t -> t -> t
-
-  (** Multiplication. *)
-  val mul : t -> t -> t
-
-  val mod_ : t -> t -> t
-
-  (** Integer division and modulo. Raise [Division_by_zero] if the second
-      argument is zero. This division rounds the real quotient of its arguments
-      towards zero, as specified for {!Stdlib.(/)}. *)
-  val div : t -> t -> t
-
-  (** Bitwise logical and. *)
-  val and_ : t -> t -> t
-
-  (** Bitwise logical or. *)
-  val or_ : t -> t -> t
-
-  (** Bitwise logical exclusive or. *)
-  val xor : t -> t -> t
-
-  (** [shift_left x y] shifts [x] to the left by [y] bits. The result is
-      unspecified if [y < 0] or [y >= bitsize], where [bitsize] is [31] on a
-      32-bit platform and [63] on a 64-bit platform. *)
-  val shift_left : t -> int -> t
-
-  (** [Targetint_32_64.shift_right x y] shifts [x] to the right by [y] bits.
-      This is an arithmetic shift: the sign bit of [x] is replicated and
-      inserted in the vacated bits. The result is unspecified if [y < 0] or [y
-      >= bitsize]. *)
-  val shift_right : t -> int -> t
-
-  (** [Targetint_32_64.shift_right_logical x y] shifts [x] to the right by [y]
-      bits. This is a logical shift: zeroes are inserted in the vacated bits
-      regardless of the sign of [x]. The result is unspecified if [y < 0] or [y
-      >= bitsize]. *)
-  val shift_right_logical : t -> int -> t
-
-  (** Returns the smaller integer. *)
-  val min : t -> t -> t
-
-  (** Returns the larger integer. *)
-  val max : t -> t -> t
-
-  (* CR mshinwell: Add an [Array] module *)
-
-  include Container_types.S with type t := t
-
-  val to_string : t -> string
-end
-
-type 'a or_wrong = private
-  | Ok of 'a
-  | Wrong
-
-type t = private
-  { value : Imm.t;
-    print_as_char : bool
-  }
-
-type immediate = t
-
-(** The comparison function for type [t] ignores [print_as_char]. *)
 include Container_types.S with type t := t
 
-val one : t
+(** The minimum integer representable on the target. *)
+val min_value : t
 
-val zero : t
+(** The maximum integer representable on the target. *)
+val max_value : t
 
+(** The maximum string length on the target. *)
+val max_string_length : t
+
+(** The OCaml integer -1 *)
 val minus_one : t
 
-val join : t -> t -> t or_wrong
+(** The OCaml integer 0. *)
+val zero : t
 
-val join_set : Set.t -> Set.t -> Set.t
+(** The OCaml integer 1. *)
+val one : t
+
+(** The OCaml integer 10. *)
+val ten : t
+
+(** The OCaml integer 0xff. *)
+val hex_ff : t
+
+(** The set {-1, 0, 1}. *)
+val zero_one_and_minus_one : Set.t
+
+(** Boolean values. *)
+val bool : bool -> t
 
 val bool_true : t
 
 val bool_false : t
 
-val bool : bool -> t
+val all_bools : Set.t
 
-val int : Imm.t -> t
+(** Comparison functions. *)
+val ( <= ) : t -> t -> bool
 
-val char : char -> t
+val ( < ) : t -> t -> bool
 
-val map : t -> f:(Imm.t -> Imm.t) -> t
+(** Returns the 8 least significant bits of the OCaml integer as a host caml
+    integer (cannot overflow). *)
+val bottom_byte_to_int : t -> int
 
-val is_non_negative : t -> bool
+(** Returns the OCaml integer corresponding to the ASCII code of the given
+    character. *)
+val of_char : char -> t
 
-(* CR mshinwell: bad names *)
-val to_targetint : t -> Imm.t
+(** Convert the given integer (type [int]) to a OCaml integer (type [t]), modulo
+    the target word size minus one (for the tag bit). *)
+val of_int : int -> t
 
-val to_targetint' : t -> Targetint_32_64.t
+(** Returns [None] iff the given [int] cannot be represented as a target
+    "int"-width integer, else returns the same as {!of_int}. *)
+val of_int_option : int -> t option
 
-val set_to_targetint_set : Set.t -> Imm.Set.t
+(** Convert the given OCaml integer (type [t]) to an integer (type [int]),
+    modulo the [int] size, i.e. high-order bits are lost during the conversion. *)
+val to_int : t -> int
 
-val set_to_targetint_set' : Set.t -> Targetint_32_64.Set.t
+(** Convert the given OCaml integer (type [t]) to an integer (type [int]).
+    Returns [None] if the original OCaml integer does not fit into an integer *)
+val to_int_option : t -> int option
 
+(** Convert the given OCaml integer (type [t]) to an integer (type [int]).
+
+    @raise Fatal_error if the original OCaml integer does not fit into an
+    integer *)
+val to_int_exn : t -> int
+
+(** Convert the given 32-bit integer (type [int32]) to a OCaml integer, modulo
+    the size of a OCaml integer. *)
+val of_int32 : int32 -> t
+
+(** Convert the given OCaml integer to a 32-bit integer (type [int32]). On
+    64-bit platforms, the 64-bit native integer is taken modulo 2{^ 32}, i.e.
+    the top 32 bits are lost. On 32-bit platforms, the conversion is exact. *)
+val to_int32 : t -> int32
+
+(** Convert the given 64-bit integer (type [int64]) to a target native integer,
+    modulo the size of a OCaml integer. *)
+val of_int64 : int64 -> t
+
+(** Convert the given OCaml integer to a 64-bit integer (type [int64]). *)
+val to_int64 : t -> int64
+
+(** Convert the given target native integer (type [Targetint_32_64.t]) to an
+    OCaml integer, modulo the size of an OCaml integer. *)
+val of_targetint : Targetint_32_64.t -> t
+
+(** Convert the given OCaml integer (type [t]) to a target native integer (type
+    [Targetint_32_64.t]). *)
+val to_targetint : t -> Targetint_32_64.t
+
+(** Convert the given floating-point number to an OCaml integer, discarding the
+    fractional part (truncate towards 0). The result of the conversion is
+    undefined if, after truncation, the number is outside the range
+    \[{!Targetint_31_63.min_value}, {!Targetint_31_63.max_value}\]. *)
+val of_float : float -> t
+
+(** Convert the given OCaml integer to a floating-point number. *)
+val to_float : t -> float
+
+(** Unary negation. *)
 val neg : t -> t
 
+(** Extract the least significant 16 bits from the given OCaml integer, exchange
+    the order of the two bytes extracted, then form a new target integer by
+    zero-extending those two bytes. *)
+val get_least_significant_16_bits_then_byte_swap : t -> t
+
+(** Addition. *)
 val add : t -> t -> t
 
+(** Subtraction. *)
 val sub : t -> t -> t
 
+(** Multiplication. *)
 val mul : t -> t -> t
-
-val div : t -> t -> t
 
 val mod_ : t -> t -> t
 
+(** Integer division and modulo. Raise [Division_by_zero] if the second argument
+    is zero. This division rounds the real quotient of its arguments towards
+    zero, as specified for {!Stdlib.(/)}. *)
+val div : t -> t -> t
+
+(** Bitwise logical and. *)
 val and_ : t -> t -> t
 
+(** Bitwise logical or. *)
 val or_ : t -> t -> t
 
+(** Bitwise logical exclusive or. *)
 val xor : t -> t -> t
 
+(** [shift_left x y] shifts [x] to the left by [y] bits. The result is
+    unspecified if [y < 0] or [y >= bitsize], where [bitsize] is [31] on a
+    32-bit platform and [63] on a 64-bit platform. *)
 val shift_left : t -> int -> t
 
+(** [Targetint_32_64.shift_right x y] shifts [x] to the right by [y] bits. This
+    is an arithmetic shift: the sign bit of [x] is replicated and inserted in
+    the vacated bits. The result is unspecified if [y < 0] or [y >= bitsize]. *)
 val shift_right : t -> int -> t
 
+(** [Targetint_32_64.shift_right_logical x y] shifts [x] to the right by [y]
+    bits. This is a logical shift: zeroes are inserted in the vacated bits
+    regardless of the sign of [x]. The result is unspecified if [y < 0] or [y >=
+    bitsize]. *)
 val shift_right_logical : t -> int -> t
 
-val get_least_significant_16_bits_then_byte_swap : t -> t
+(** Returns the smaller integer. *)
+val min : t -> t -> t
 
-(** The set consisting of the representations of constant [true] and [false]. *)
-val all_bools : Set.t
+(** Returns the larger integer. *)
+val max : t -> t -> t
 
-val zero_one_and_minus_one : Set.t
+val is_non_negative : t -> bool
 
 module Pair : sig
   type nonrec t = t * t

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -224,9 +224,7 @@ let find_code_id env code_id =
 let targetint (i : Fexpr.targetint) : Targetint_32_64.t =
   Targetint_32_64.of_int64 i
 
-let immediate i =
-  i |> Targetint_32_64.of_string |> Targetint_31_63.Imm.of_targetint
-  |> Targetint_31_63.int
+let immediate i = i |> Targetint_32_64.of_string |> Targetint_31_63.of_targetint
 
 let float f = f |> Numeric_types.Float_by_bit_pattern.create
 
@@ -293,7 +291,7 @@ let field_of_block env (v : Fexpr.field_of_block) : Field_of_static_block.t =
   | Symbol s -> Symbol (get_symbol env s)
   | Tagged_immediate i ->
     let i = Targetint_32_64.of_string i in
-    Tagged_immediate (Targetint_31_63.int (Targetint_31_63.Imm.of_targetint i))
+    Tagged_immediate (Targetint_31_63.of_targetint i)
   | Dynamically_computed var ->
     let var = find_var env var in
     Dynamically_computed (var, Debuginfo.none)
@@ -340,7 +338,7 @@ let binop (binop : Fexpr.binop) : Flambda_primitive.binary_primitive =
     let size s : _ Or_unknown.t =
       match s with
       | None -> Unknown
-      | Some s -> Known (s |> Targetint_31_63.Imm.of_int64)
+      | Some s -> Known (s |> Targetint_31_63.of_int64)
     in
     let access_kind : Flambda_primitive.Block_access_kind.t =
       match access_kind with
@@ -554,9 +552,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
   | Switch { scrutinee; cases } ->
     let arms =
       List.map
-        (fun (case, apply) ->
-          ( Targetint_31_63.int (Targetint_31_63.Imm.of_int case),
-            apply_cont env apply ))
+        (fun (case, apply) -> Targetint_31_63.of_int case, apply_cont env apply)
         cases
       |> Targetint_31_63.Map.of_list
     in

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -344,10 +344,10 @@ let const c : Fexpr.const =
   match Reg_width_const.descr c with
   | Naked_immediate imm ->
     Naked_immediate
-      (imm |> Targetint_31_63.to_targetint' |> Targetint_32_64.to_string)
+      (imm |> Targetint_31_63.to_targetint |> Targetint_32_64.to_string)
   | Tagged_immediate imm ->
     Tagged_immediate
-      (imm |> Targetint_31_63.to_targetint' |> Targetint_32_64.to_string)
+      (imm |> Targetint_31_63.to_targetint |> Targetint_32_64.to_string)
   | Naked_float f -> Naked_float (f |> float)
   | Naked_int32 i -> Naked_int32 i
   | Naked_int64 i -> Naked_int64 i
@@ -419,8 +419,8 @@ let kinded_parameter env (kp : Bound_parameter.t) :
   let param, env = Env.bind_var env (Bound_parameter.var kp) in
   { param; kind = k }, env
 
-let targetint_ocaml (i : Targetint_31_63.Imm.t) : Fexpr.targetint =
-  i |> Targetint_31_63.Imm.to_int64
+let targetint_ocaml (i : Targetint_31_63.t) : Fexpr.targetint =
+  i |> Targetint_31_63.to_int64
 
 let recursive_flag (r : Recursive.t) : Fexpr.is_recursive =
   match r with Recursive -> Recursive | Non_recursive -> Nonrecursive
@@ -555,7 +555,7 @@ let field_of_block env (field : Field_of_static_block.t) : Fexpr.field_of_block
   | Symbol symbol -> Symbol (Env.find_symbol_exn env symbol)
   | Tagged_immediate imm ->
     Tagged_immediate
-      (imm |> Targetint_31_63.to_targetint' |> Targetint_32_64.to_string)
+      (imm |> Targetint_31_63.to_targetint |> Targetint_32_64.to_string)
   | Dynamically_computed (var, _dbg) ->
     Dynamically_computed (Env.find_var_exn env var)
 
@@ -956,7 +956,7 @@ and switch_expr env switch : Fexpr.expr =
     List.map
       (fun (imm, app_cont) ->
         let tag =
-          imm |> Targetint_31_63.to_targetint' |> Targetint_32_64.to_int
+          imm |> Targetint_31_63.to_targetint |> Targetint_32_64.to_int
         in
         let app_cont = apply_cont env app_cont in
         tag, app_cont)

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -293,7 +293,7 @@ let apply_projection t proj =
       match Symbol_projection.projection proj with
       | Block_load { index } ->
         T.prove_block_field_simple typing_env ~min_name_mode:Name_mode.normal ty
-          ( index)
+          index
       | Project_value_slot { project_from = _; value_slot } ->
         T.prove_project_value_slot_simple typing_env
           ~min_name_mode:Name_mode.normal ty value_slot

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -293,7 +293,7 @@ let apply_projection t proj =
       match Symbol_projection.projection proj with
       | Block_load { index } ->
         T.prove_block_field_simple typing_env ~min_name_mode:Name_mode.normal ty
-          (Targetint_31_63.int index)
+          ( index)
       | Project_value_slot { project_from = _; value_slot } ->
         T.prove_project_value_slot_simple typing_env
           ~min_name_mode:Name_mode.normal ty value_slot

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -457,8 +457,8 @@ end = struct
 
   let op_lhs_unknown (op : P.int_shift_op) ~rhs :
       Num.t binary_arith_outcome_for_one_side_only =
-    let module O = Targetint_31_63.Imm in
-    let rhs = Targetint_31_63.to_targetint rhs in
+    let module O = Targetint_31_63 in
+    let rhs = rhs in
     match op with
     | Lsl | Lsr | Asr ->
       (* Shifting either way by [Targetint_32_64.size] or above, or by a
@@ -564,7 +564,7 @@ end = struct
     | Yielding_int_like_compare_functions signed_or_unsigned -> (
       match signed_or_unsigned with
       | Signed ->
-        let int i = Targetint_31_63.int (Targetint_31_63.Imm.of_int i) in
+        let int i = Targetint_31_63.of_int i in
         let c = Num.compare n1 n2 in
         if c < 0
         then Some (int (-1))
@@ -572,7 +572,7 @@ end = struct
         then Some (int 0)
         else Some (int 1)
       | Unsigned ->
-        let int i = Targetint_31_63.int (Targetint_31_63.Imm.of_int i) in
+        let int i = Targetint_31_63.of_int i in
         let c = Num.compare_unsigned n1 n2 in
         if c < 0
         then Some (int (-1))
@@ -756,7 +756,7 @@ end = struct
         then Some (bool false)
         else Some (bool (F.IEEE_semantics.compare n1 n2 >= 0)))
     | Yielding_int_like_compare_functions () ->
-      let int i = Targetint_31_63.int (Targetint_31_63.Imm.of_int i) in
+      let int i = Targetint_31_63.of_int i in
       let c = F.IEEE_semantics.compare n1 n2 in
       if c < 0
       then Some (int (-1))
@@ -894,11 +894,7 @@ let[@inline always] simplify_immutable_block_load0
       in
       SPR.create (Named.create_simple simple) ~try_reify:false dacc
     | Unknown -> (
-      let n =
-        Targetint_31_63.Imm.add
-          (Targetint_31_63.to_targetint index)
-          Targetint_31_63.Imm.one
-      in
+      let n = Targetint_31_63.add index Targetint_31_63.one in
       (* CR-someday mshinwell: We should be able to use the size in the
          [access_kind] to constrain the type of the block *)
       let tag : _ Or_unknown.t =
@@ -911,7 +907,7 @@ let[@inline always] simplify_immutable_block_load0
                seem that the frontend currently emits code to create such
                blocks) and so it isn't clear whether such blocks should have tag
                zero (like zero-sized naked float arrays) or another tag. *)
-            if Targetint_31_63.Imm.equal size Targetint_31_63.Imm.zero
+            if Targetint_31_63.equal size Targetint_31_63.zero
             then Unknown
             else Known Tag.double_array_tag
           | Unknown -> Unknown)
@@ -978,8 +974,7 @@ let simplify_immutable_block_load access_kind ~min_name_mode dacc ~original_term
     Simple.pattern_match arg2
       ~const:(fun const ->
         match Reg_width_const.descr const with
-        | Tagged_immediate imm ->
-          let index = Targetint_31_63.to_targetint imm in
+        | Tagged_immediate index ->
           Simplify_common.add_symbol_projection result.dacc ~projected_from:arg1
             (Symbol_projection.Projection.block_load ~index)
             ~projection_bound_to:result_var

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -82,11 +82,11 @@ let project_tuple ~dbg ~size ~field tuple =
     Values
       { field_kind = Any_value;
         tag = Known Tag.Scannable.zero;
-        size = Known (Targetint_31_63.Imm.of_int size)
+        size = Known (Targetint_31_63.of_int size)
       }
   in
   let mutability : Mutability.t = Immutable in
-  let index = Simple.const_int (Targetint_31_63.Imm.of_int field) in
+  let index = Simple.const_int (Targetint_31_63.of_int field) in
   let prim = P.Binary (Block_load (bak, mutability), tuple, index) in
   Named.create_prim prim dbg
 

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -309,10 +309,7 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
   after_rebuild expr uacc
 
 let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
-  let shape =
-    let imm = Targetint_31_63.int (Targetint_31_63.to_targetint arm) in
-    T.this_naked_immediate imm
-  in
+  let shape = T.this_naked_immediate arm in
   match T.meet typing_env_at_use scrutinee_ty shape with
   | Bottom -> arms, dacc
   | Ok (_meet_ty, env_extension) ->

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -202,9 +202,7 @@ let simplify_string_length dacc ~original_term ~arg:_ ~arg_ty:str_ty ~result_var
     else
       let lengths =
         String_info.Set.elements str_infos
-        |> List.map String_info.size
-        |> List.map Targetint_31_63.int
-        |> Targetint_31_63.Set.of_list
+        |> List.map String_info.size |> Targetint_31_63.Set.of_list
       in
       let ty = T.these_naked_immediates lengths in
       let dacc = DA.add_variable dacc result_var ty in

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -96,7 +96,7 @@ let simplify_make_array (array_kind : P.Array_kind.t) ~mutable_or_immutable
   let args, tys = List.split args_with_tys in
   let length =
     match Targetint_31_63.of_int_option (List.length args) with
-    | Some ti -> T.this_tagged_immediate ( ti)
+    | Some ti -> T.this_tagged_immediate ti
     | None -> T.unknown K.value
   in
   let element_kind =

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -95,8 +95,8 @@ let simplify_make_array (array_kind : P.Array_kind.t) ~mutable_or_immutable
     alloc_mode dacc ~original_term:_ dbg ~args_with_tys ~result_var =
   let args, tys = List.split args_with_tys in
   let length =
-    match Targetint_31_63.Imm.of_int_option (List.length args) with
-    | Some ti -> T.this_tagged_immediate (Targetint_31_63.int ti)
+    match Targetint_31_63.of_int_option (List.length args) with
+    | Some ti -> T.this_tagged_immediate ( ti)
     | None -> T.unknown K.value
   in
   let element_kind =

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -126,7 +126,7 @@ and make_optimistic_fields ~add_tag_to_name ~depth tenv param_type (tag : Tag.t)
     Format.asprintf "%s%a_%d" field_base_name (pp_tag add_tag_to_name) tag n
   in
   let field_vars =
-    List.init (Targetint_31_63.Imm.to_int size) (fun i ->
+    List.init (Targetint_31_63.to_int size) (fun i ->
         Extra_param_and_args.create ~name:(field_name i))
   in
   let type_of_var (epa : Extra_param_and_args.t) =

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -48,9 +48,7 @@ module Immediate = struct
 
   let unboxer =
     { var_name = "naked_immediate";
-      invalid_const =
-        Const.naked_immediate
-          (Targetint_31_63.int (Targetint_31_63.Imm.of_int 0xabcd));
+      invalid_const = Const.naked_immediate (Targetint_31_63.of_int 0xabcd);
       unboxing_prim;
       prove_simple = T.prove_is_always_tagging_of_simple
     }

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -101,12 +101,12 @@ let extra_arg_for_is_int = function
 let extra_arg_for_ctor ~typing_env_at_use = function
   | Not_a_constant_constructor ->
     EPA.Extra_arg.Already_in_scope
-      (Simple.untagged_const_int (Targetint_31_63.Imm.of_int 0))
+      (Simple.untagged_const_int (Targetint_31_63.of_int 0))
   | Maybe_constant_constructor { arg_being_unboxed; _ } -> (
     match type_of_arg_being_unboxed arg_being_unboxed with
     | None ->
       EPA.Extra_arg.Already_in_scope
-        (Simple.untagged_const_int (Targetint_31_63.Imm.of_int 0))
+        (Simple.untagged_const_int (Targetint_31_63.of_int 0))
     | Some arg_type -> (
       match
         T.prove_could_be_tagging_of_simple typing_env_at_use
@@ -119,7 +119,7 @@ let extra_arg_for_ctor ~typing_env_at_use = function
            thus as in other cases, we only need to provide well-kinded
            values. *)
         EPA.Extra_arg.Already_in_scope
-          (Simple.untagged_const_int (Targetint_31_63.Imm.of_int 0))))
+          (Simple.untagged_const_int (Targetint_31_63.of_int 0))))
 
 let extra_args_for_const_ctor_of_variant
     (const_ctors_decision : U.const_ctors_decision) ~typing_env_at_use
@@ -257,7 +257,7 @@ and compute_extra_args_for_one_decision_and_use_aux ~(pass : U.pass) rewrite_id
 and compute_extra_args_for_block ~pass rewrite_id ~typing_env_at_use
     arg_being_unboxed tag fields : U.decision =
   let size =
-    Or_unknown.Known (Targetint_31_63.Imm.of_int (List.length fields))
+    Or_unknown.Known (Targetint_31_63.of_int (List.length fields))
   in
   let bak, invalid_const =
     if Tag.equal tag Tag.double_array_tag
@@ -356,7 +356,7 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
   in
   let tag_extra_arg =
     tag_at_use_site |> Tag.Scannable.to_targetint
-    |> Targetint_31_63.Imm.of_targetint |> Const.untagged_const_int
+    |> Targetint_31_63.of_targetint |> Const.untagged_const_int
     |> Simple.const
     |> fun x -> EPA.Extra_arg.Already_in_scope x
   in
@@ -370,11 +370,11 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
         let size = List.length block_fields in
         (* See doc/unboxing.md about invalid constants, poison and aliases. *)
         let invalid_const =
-          Const.const_int (Targetint_31_63.Imm.of_int 0xbaba)
+          Const.const_int (Targetint_31_63.of_int 0xbaba)
         in
         let bak : Flambda_primitive.Block_access_kind.t =
           Values
-            { size = Known (Targetint_31_63.Imm.of_int size);
+            { size = Known (Targetint_31_63.of_int size);
               tag = Known tag_decision;
               field_kind = Any_value
             }

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -256,9 +256,7 @@ and compute_extra_args_for_one_decision_and_use_aux ~(pass : U.pass) rewrite_id
 
 and compute_extra_args_for_block ~pass rewrite_id ~typing_env_at_use
     arg_being_unboxed tag fields : U.decision =
-  let size =
-    Or_unknown.Known (Targetint_31_63.of_int (List.length fields))
-  in
+  let size = Or_unknown.Known (Targetint_31_63.of_int (List.length fields)) in
   let bak, invalid_const =
     if Tag.equal tag Tag.double_array_tag
     then
@@ -356,8 +354,7 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
   in
   let tag_extra_arg =
     tag_at_use_site |> Tag.Scannable.to_targetint
-    |> Targetint_31_63.of_targetint |> Const.untagged_const_int
-    |> Simple.const
+    |> Targetint_31_63.of_targetint |> Const.untagged_const_int |> Simple.const
     |> fun x -> EPA.Extra_arg.Already_in_scope x
   in
   let tag =
@@ -369,9 +366,7 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
       (fun tag_decision block_fields ->
         let size = List.length block_fields in
         (* See doc/unboxing.md about invalid constants, poison and aliases. *)
-        let invalid_const =
-          Const.const_int (Targetint_31_63.of_int 0xbaba)
-        in
+        let invalid_const = Const.const_int (Targetint_31_63.of_int 0xbaba) in
         let bak : Flambda_primitive.Block_access_kind.t =
           Values
             { size = Known (Targetint_31_63.of_int size);

--- a/middle_end/flambda2/term_basics/simple.mli
+++ b/middle_end/flambda2/term_basics/simple.mli
@@ -38,7 +38,7 @@ val must_be_symbol : t -> (Symbol.t * Coercion.t) option
 val must_be_name : t -> (Name.t * Coercion.t) option
 
 (** The constant representating the given number of type "int". *)
-val const_int : Targetint_31_63.Imm.t -> t
+val const_int : Targetint_31_63.t -> t
 
 (** The constant representating the given boolean value. *)
 val const_bool : bool -> t
@@ -63,7 +63,7 @@ val const_zero : t
 
 val untagged_const_zero : t
 
-val untagged_const_int : Targetint_31_63.Imm.t -> t
+val untagged_const_int : Targetint_31_63.t -> t
 
 val const_one : t
 

--- a/middle_end/flambda2/term_basics/string_info.ml
+++ b/middle_end/flambda2/term_basics/string_info.ml
@@ -20,7 +20,7 @@ type string_contents =
 
 type t =
   { contents : string_contents;
-    size : Targetint_31_63.Imm.t
+    size : Targetint_31_63.t
   }
 
 let create ~contents ~size = { contents; size }
@@ -49,15 +49,16 @@ include Container_types.Make (struct
   let [@ocamlformat "disable"] print ppf { contents; size; } =
     match contents with
     | Unknown_or_mutable ->
-      Format.fprintf ppf "(size %a)" Targetint_31_63.Imm.print size
+      Format.fprintf ppf "(size %a)"
+        Targetint_31_63.print size
     | Contents s ->
       let s, dots =
-        let max_size = Targetint_31_63.Imm.ten in
-        let long = Targetint_31_63.Imm.compare size max_size > 0 in
+        let max_size = Targetint_31_63.ten in
+        let long = Targetint_31_63.compare size max_size > 0 in
         if long then String.sub s 0 8, "..."
         else s, ""
       in
       Format.fprintf ppf "(size %a) (contents \"%S\"%s)"
-        Targetint_31_63.Imm.print size
+        Targetint_31_63.print size
         s dots
 end)

--- a/middle_end/flambda2/term_basics/string_info.mli
+++ b/middle_end/flambda2/term_basics/string_info.mli
@@ -21,10 +21,10 @@ type string_contents =
 type t
 
 (* CR mshinwell: [size] shouldn't be needed when passing [Contents] *)
-val create : contents:string_contents -> size:Targetint_31_63.Imm.t -> t
+val create : contents:string_contents -> size:Targetint_31_63.t -> t
 
 val contents : t -> string_contents
 
-val size : t -> Targetint_31_63.Imm.t
+val size : t -> Targetint_31_63.t
 
 include Container_types.S with type t := t

--- a/middle_end/flambda2/term_basics/symbol_projection.ml
+++ b/middle_end/flambda2/term_basics/symbol_projection.ml
@@ -14,7 +14,7 @@
 
 module Projection = struct
   type t =
-    | Block_load of { index : Targetint_31_63.Imm.t }
+    | Block_load of { index : Targetint_31_63.t }
     | Project_value_slot of
         { project_from : Function_slot.t;
           value_slot : Value_slot.t
@@ -27,7 +27,7 @@ module Projection = struct
 
   let hash t =
     match t with
-    | Block_load { index } -> Targetint_31_63.Imm.hash index
+    | Block_load { index } -> Targetint_31_63.hash index
     | Project_value_slot { project_from; value_slot } ->
       Hashtbl.hash (Function_slot.hash project_from, Value_slot.hash value_slot)
 
@@ -37,7 +37,7 @@ module Projection = struct
       Format.fprintf ppf "@[<hov 1>(Block_load@ \
           @[<hov 1>(index@ %a)@]\
           )@]"
-        Targetint_31_63.Imm.print index
+        Targetint_31_63.print index
     | Project_value_slot { project_from; value_slot; } ->
       Format.fprintf ppf "@[<hov 1>(Project_value_slot@ \
           @[<hov 1>(project_from@ %a)@]@ \
@@ -49,7 +49,7 @@ module Projection = struct
   let compare t1 t2 =
     match t1, t2 with
     | Block_load { index = index1 }, Block_load { index = index2 } ->
-      Targetint_31_63.Imm.compare index1 index2
+      Targetint_31_63.compare index1 index2
     | ( Project_value_slot
           { project_from = project_from1; value_slot = value_slot1 },
         Project_value_slot

--- a/middle_end/flambda2/term_basics/symbol_projection.mli
+++ b/middle_end/flambda2/term_basics/symbol_projection.mli
@@ -14,13 +14,13 @@
 
 module Projection : sig
   type t = private
-    | Block_load of { index : Targetint_31_63.Imm.t }
+    | Block_load of { index : Targetint_31_63.t }
     | Project_value_slot of
         { project_from : Function_slot.t;
           value_slot : Value_slot.t
         }
 
-  val block_load : index:Targetint_31_63.Imm.t -> t
+  val block_load : index:Targetint_31_63.t -> t
 
   val project_value_slot : Function_slot.t -> Value_slot.t -> t
 end

--- a/middle_end/flambda2/term_basics/tag_and_size.ml
+++ b/middle_end/flambda2/term_basics/tag_and_size.ml
@@ -14,9 +14,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = Tag.t * Targetint_31_63.Imm.t
+type t = Tag.t * Targetint_31_63.t
 
-include Container_types.Make_pair (Tag) (Targetint_31_63.Imm)
+include Container_types.Make_pair (Tag) (Targetint_31_63)
 
 let tag (tag, _) = tag
 

--- a/middle_end/flambda2/term_basics/tag_and_size.mli
+++ b/middle_end/flambda2/term_basics/tag_and_size.mli
@@ -14,10 +14,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = Tag.t * Targetint_31_63.Imm.t
+type t = Tag.t * Targetint_31_63.t
 
 include Container_types.S with type t := t
 
 val tag : t -> Tag.t
 
-val size : t -> Targetint_31_63.Imm.t
+val size : t -> Targetint_31_63.t

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -98,9 +98,9 @@ module Duplicate_block_kind = struct
   type t =
     | Values of
         { tag : Tag.Scannable.t;
-          length : Targetint_31_63.Imm.t
+          length : Targetint_31_63.t
         }
-    | Naked_floats of { length : Targetint_31_63.Imm.t }
+    | Naked_floats of { length : Targetint_31_63.t }
 
   let [@ocamlformat "disable"] print ppf t =
     match t with
@@ -111,22 +111,22 @@ module Duplicate_block_kind = struct
           @[<hov 1>(length@ %a)@]\
           )@]"
         Tag.Scannable.print tag
-        Targetint_31_63.Imm.print length
+        Targetint_31_63.print length
     | Naked_floats { length; } ->
       Format.fprintf ppf
         "@[<hov 1>(Block_of_naked_floats@ \
           @[<hov 1>(length@ %a)@]\
           )@]"
-        Targetint_31_63.Imm.print length
+        Targetint_31_63.print length
 
   let compare t1 t2 =
     match t1, t2 with
     | ( Values { tag = tag1; length = length1 },
         Values { tag = tag2; length = length2 } ) ->
       let c = Tag.Scannable.compare tag1 tag2 in
-      if c <> 0 then c else Targetint_31_63.Imm.compare length1 length2
+      if c <> 0 then c else Targetint_31_63.compare length1 length2
     | Naked_floats { length = length1 }, Naked_floats { length = length2 } ->
-      Targetint_31_63.Imm.compare length1 length2
+      Targetint_31_63.compare length1 length2
     | Values _, Naked_floats _ -> -1
     | Naked_floats _, Values _ -> 1
 end
@@ -135,7 +135,7 @@ module Duplicate_array_kind = struct
   type t =
     | Immediates
     | Values
-    | Naked_floats of { length : Targetint_31_63.Imm.t option }
+    | Naked_floats of { length : Targetint_31_63.t option }
 
   let [@ocamlformat "disable"] print ppf t =
     match t with
@@ -146,13 +146,13 @@ module Duplicate_array_kind = struct
         "@[<hov 1>(Naked_floats@ \
           @[<hov 1>(length@ %a)@]\
           )@]"
-        (Misc.Stdlib.Option.print Targetint_31_63.Imm.print) length
+        (Misc.Stdlib.Option.print Targetint_31_63.print) length
 
   let compare t1 t2 =
     match t1, t2 with
     | Immediates, Immediates | Values, Values -> 0
     | Naked_floats { length = length1 }, Naked_floats { length = length2 } ->
-      Option.compare Targetint_31_63.Imm.compare length1 length2
+      Option.compare Targetint_31_63.compare length1 length2
     | Immediates, _ -> -1
     | _, Immediates -> 1
     | Values, _ -> -1
@@ -176,10 +176,10 @@ module Block_access_kind = struct
   type t =
     | Values of
         { tag : Tag.Scannable.t Or_unknown.t;
-          size : Targetint_31_63.Imm.t Or_unknown.t;
+          size : Targetint_31_63.t Or_unknown.t;
           field_kind : Block_access_field_kind.t
         }
-    | Naked_floats of { size : Targetint_31_63.Imm.t Or_unknown.t }
+    | Naked_floats of { size : Targetint_31_63.t Or_unknown.t }
 
   let [@ocamlformat "disable"] print ppf t =
     match t with
@@ -191,14 +191,14 @@ module Block_access_kind = struct
           @[<hov 1>(field_kind@ %a)@]\
           )@]"
         (Or_unknown.print Tag.Scannable.print) tag
-        (Or_unknown.print Targetint_31_63.Imm.print) size
+        (Or_unknown.print Targetint_31_63.print) size
         Block_access_field_kind.print field_kind
     | Naked_floats { size; } ->
       Format.fprintf ppf
         "@[<hov 1>(Naked_floats@ \
           @[<hov 1>(size@ %a)@]\
           )@]"
-        (Or_unknown.print Targetint_31_63.Imm.print) size
+        (Or_unknown.print Targetint_31_63.print) size
 
   let element_kind_for_load t =
     match t with Values _ -> K.value | Naked_floats _ -> K.naked_float
@@ -213,12 +213,12 @@ module Block_access_kind = struct
       if c <> 0
       then c
       else
-        let c = Or_unknown.compare Targetint_31_63.Imm.compare size1 size2 in
+        let c = Or_unknown.compare Targetint_31_63.compare size1 size2 in
         if c <> 0
         then c
         else Block_access_field_kind.compare field_kind1 field_kind2
     | Naked_floats { size = size1 }, Naked_floats { size = size2 } ->
-      Or_unknown.compare Targetint_31_63.Imm.compare size1 size2
+      Or_unknown.compare Targetint_31_63.compare size1 size2
     | Values _, Naked_floats _ -> -1
     | Naked_floats _, Values _ -> 1
 end

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -57,9 +57,9 @@ module Duplicate_block_kind : sig
   type t =
     | Values of
         { tag : Tag.Scannable.t;
-          length : Targetint_31_63.Imm.t
+          length : Targetint_31_63.t
         }
-    | Naked_floats of { length : Targetint_31_63.Imm.t }
+    | Naked_floats of { length : Targetint_31_63.t }
 
   val print : Format.formatter -> t -> unit
 
@@ -70,7 +70,7 @@ module Duplicate_array_kind : sig
   type t =
     | Immediates
     | Values
-    | Naked_floats of { length : Targetint_31_63.Imm.t option }
+    | Naked_floats of { length : Targetint_31_63.t option }
 
   val print : Format.formatter -> t -> unit
 
@@ -92,10 +92,10 @@ module Block_access_kind : sig
   type t =
     | Values of
         { tag : Tag.Scannable.t Or_unknown.t;
-          size : Targetint_31_63.Imm.t Or_unknown.t;
+          size : Targetint_31_63.t Or_unknown.t;
           field_kind : Block_access_field_kind.t
         }
-    | Naked_floats of { size : Targetint_31_63.Imm.t Or_unknown.t }
+    | Naked_floats of { size : Targetint_31_63.t Or_unknown.t }
 
   val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -59,7 +59,7 @@ let test_bottom_detection () =
   let alias name = T.alias_type_of Flambda_kind.value (Simple.name name) in
   let const n =
     T.alias_type_of Flambda_kind.value
-      (Simple.const (Reg_width_const.const_int (Targetint_31_63.Imm.of_int n)))
+      (Simple.const (Reg_width_const.const_int (Targetint_31_63.of_int n)))
   in
   let ty1 =
     T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
@@ -88,7 +88,7 @@ let test_bottom_recursive () =
   let alias name = T.alias_type_of Flambda_kind.value (Simple.name name) in
   let const n =
     T.alias_type_of Flambda_kind.value
-      (Simple.const (Reg_width_const.const_int (Targetint_31_63.Imm.of_int n)))
+      (Simple.const (Reg_width_const.const_int (Targetint_31_63.of_int n)))
   in
   let ty_x =
     T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -665,7 +665,7 @@ and switch env res switch =
   in
   let wrap, env = Env.flush_delayed_lets env in
   let prepare_discriminant ~must_tag d =
-    let targetint_d = Targetint_31_63.to_targetint' d in
+    let targetint_d = Targetint_31_63.to_targetint d in
     Targetint_32_64.to_int_checked
       (if must_tag then C.tag_targetint targetint_d else targetint_d)
   in

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -71,9 +71,9 @@ let name env name = name0 env name
 
 let const ~dbg cst =
   match Reg_width_const.descr cst with
-  | Naked_immediate i -> targetint ~dbg (Targetint_31_63.to_targetint' i)
+  | Naked_immediate i -> targetint ~dbg (Targetint_31_63.to_targetint i)
   | Tagged_immediate i ->
-    targetint ~dbg (tag_targetint (Targetint_31_63.to_targetint' i))
+    targetint ~dbg (tag_targetint (Targetint_31_63.to_targetint i))
   | Naked_float f -> float ~dbg (Numeric_types.Float_by_bit_pattern.to_float f)
   | Naked_int32 i -> int32 ~dbg i
   | Naked_int64 i -> int64 ~dbg i
@@ -93,11 +93,11 @@ let name_static name =
 let const_static cst =
   match Reg_width_const.descr cst with
   | Naked_immediate i ->
-    [cint (nativeint_of_targetint (Targetint_31_63.to_targetint' i))]
+    [cint (nativeint_of_targetint (Targetint_31_63.to_targetint i))]
   | Tagged_immediate i ->
     [ cint
         (nativeint_of_targetint
-           (tag_targetint (Targetint_31_63.to_targetint' i))) ]
+           (tag_targetint (Targetint_31_63.to_targetint i))) ]
   | Naked_float f -> [cfloat (Numeric_types.Float_by_bit_pattern.to_float f)]
   | Naked_int32 i -> [cint (Nativeint.of_int32 i)]
   | Naked_int64 i -> [cint (Int64.to_nativeint i)]

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -29,7 +29,7 @@ let static_value v =
   | Tagged_immediate i ->
     C.cint
       (C.nativeint_of_targetint
-         (C.tag_targetint (Targetint_31_63.to_targetint' i)))
+         (C.tag_targetint (Targetint_31_63.to_targetint i)))
 
 let or_variable f default v cont =
   match (v : _ Or_variable.t) with

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -614,9 +614,7 @@ val prove_boxed_int64s : Typing_env.t -> t -> Numeric_types.Int64.Set.t proof
 val prove_boxed_nativeints : Typing_env.t -> t -> Targetint_32_64.Set.t proof
 
 val prove_unique_tag_and_size :
-  Typing_env.t ->
-  t ->
-  (Tag.t * Targetint_31_63.t) proof_allowing_kind_mismatch
+  Typing_env.t -> t -> (Tag.t * Targetint_31_63.t) proof_allowing_kind_mismatch
 
 val prove_unique_fully_constructed_immutable_heap_block :
   Typing_env.t -> t -> (Tag_and_size.t * Simple.t list) proof

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -454,7 +454,7 @@ val immutable_block :
     variable. *)
 val immutable_block_with_size_at_least :
   tag:Tag.t Or_unknown.t ->
-  n:Targetint_31_63.Imm.t ->
+  n:Targetint_31_63.t ->
   field_kind:Flambda_kind.t ->
   field_n_minus_one:Variable.t ->
   t
@@ -470,7 +470,7 @@ val variant :
 val open_variant_from_const_ctors_type : const_ctors:t -> t
 
 val open_variant_from_non_const_ctor_with_size_at_least :
-  n:Targetint_31_63.Imm.t -> field_n_minus_one:Variable.t -> t
+  n:Targetint_31_63.t -> field_n_minus_one:Variable.t -> t
 
 val this_immutable_string : string -> t
 
@@ -565,7 +565,7 @@ val prove_naked_nativeints : Typing_env.t -> t -> Targetint_32_64.Set.t proof
 
 type variant_like_proof = private
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
-    non_const_ctors_with_sizes : Targetint_31_63.Imm.t Tag.Scannable.Map.t
+    non_const_ctors_with_sizes : Targetint_31_63.t Tag.Scannable.Map.t
   }
 
 val prove_variant_like :
@@ -616,7 +616,7 @@ val prove_boxed_nativeints : Typing_env.t -> t -> Targetint_32_64.Set.t proof
 val prove_unique_tag_and_size :
   Typing_env.t ->
   t ->
-  (Tag.t * Targetint_31_63.Imm.t) proof_allowing_kind_mismatch
+  (Tag.t * Targetint_31_63.t) proof_allowing_kind_mismatch
 
 val prove_unique_fully_constructed_immutable_heap_block :
   Typing_env.t -> t -> (Tag_and_size.t * Simple.t list) proof

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -130,7 +130,7 @@ let blocks_with_these_tags tags : _ Or_unknown.t =
          Unknown)
 
 let immutable_block ~is_unique tag ~field_kind alloc_mode ~fields =
-  match Targetint_31_63.Imm.of_int_option (List.length fields) with
+  match Targetint_31_63.of_int_option (List.length fields) with
   | None ->
     (* CR mshinwell: This should be a special kind of error. *)
     Misc.fatal_error "Block too long for target"
@@ -143,7 +143,7 @@ let immutable_block ~is_unique tag ~field_kind alloc_mode ~fields =
       alloc_mode
 
 let immutable_block_with_size_at_least ~tag ~n ~field_kind ~field_n_minus_one =
-  let n = Targetint_31_63.Imm.to_int n in
+  let n = Targetint_31_63.to_int n in
   let field_tys =
     List.init n (fun index ->
         if index < n - 1
@@ -174,7 +174,7 @@ let open_variant_from_const_ctors_type ~const_ctors =
     ~blocks:Unknown Unknown
 
 let open_variant_from_non_const_ctor_with_size_at_least ~n ~field_n_minus_one =
-  let n = Targetint_31_63.Imm.to_int n in
+  let n = Targetint_31_63.to_int n in
   let field_tys =
     List.init n (fun index ->
         if index < n - 1

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -101,7 +101,7 @@ val immutable_block :
 
 val immutable_block_with_size_at_least :
   tag:Tag.t Or_unknown.t ->
-  n:Targetint_31_63.Imm.t ->
+  n:Targetint_31_63.t ->
   field_kind:Flambda_kind.t ->
   field_n_minus_one:Variable.t ->
   Type_grammar.t
@@ -116,7 +116,7 @@ val open_variant_from_const_ctors_type :
   const_ctors:Type_grammar.t -> Type_grammar.t
 
 val open_variant_from_non_const_ctor_with_size_at_least :
-  n:Targetint_31_63.Imm.t -> field_n_minus_one:Variable.t -> Type_grammar.t
+  n:Targetint_31_63.t -> field_n_minus_one:Variable.t -> Type_grammar.t
 
 val exactly_this_closure :
   Function_slot.t ->

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -269,7 +269,7 @@ module Product : sig
 
     val create : flambda_type Function_slot.Map.t -> t
 
-    val width : t -> Targetint_31_63.Imm.t
+    val width : t -> Targetint_31_63.t
 
     (* CR mshinwell: check if this is used *)
     val components : t -> flambda_type list
@@ -282,7 +282,7 @@ module Product : sig
 
     val create : flambda_type Value_slot.Map.t -> t
 
-    val width : t -> Targetint_31_63.Imm.t
+    val width : t -> Targetint_31_63.t
 
     val components : t -> flambda_type list
   end
@@ -298,7 +298,7 @@ module Product : sig
 
     val field_kind : t -> Flambda_kind.t
 
-    val width : t -> Targetint_31_63.Imm.t
+    val width : t -> Targetint_31_63.t
 
     val components : t -> flambda_type list
   end
@@ -375,7 +375,7 @@ module Row_like_for_blocks : sig
 
   val all_tags : t -> Tag.Set.t Or_unknown.t
 
-  val all_tags_and_sizes : t -> Targetint_31_63.Imm.t Tag.Map.t Or_unknown.t
+  val all_tags_and_sizes : t -> Targetint_31_63.t Tag.Map.t Or_unknown.t
 
   val get_singleton : t -> (Tag_and_size.t * Product.Int_indexed.t) option
 

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -399,7 +399,7 @@ let prove_tags_and_sizes env t : _ proof =
   | Region _ -> wrong_kind ()
 
 let prove_unique_tag_and_size env t :
-    (Tag.t * Targetint_31_63.Imm.t) proof_allowing_kind_mismatch =
+    (Tag.t * Targetint_31_63.t) proof_allowing_kind_mismatch =
   if not (Flambda_kind.equal (TG.kind t) Flambda_kind.value)
   then Wrong_kind
   else
@@ -438,7 +438,7 @@ let prove_unique_fully_constructed_immutable_heap_block env t : _ proof =
 
 type variant_like_proof =
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
-    non_const_ctors_with_sizes : Targetint_31_63.Imm.t Tag.Scannable.Map.t
+    non_const_ctors_with_sizes : Targetint_31_63.t Tag.Scannable.Map.t
   }
 
 let prove_variant_like env t : variant_like_proof proof_allowing_kind_mismatch =

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -61,7 +61,7 @@ val prove_naked_nativeints :
 
 type variant_like_proof = private
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
-    non_const_ctors_with_sizes : Targetint_31_63.Imm.t Tag.Scannable.Map.t
+    non_const_ctors_with_sizes : Targetint_31_63.t Tag.Scannable.Map.t
   }
 
 val prove_variant_like :
@@ -124,7 +124,7 @@ val prove_tags_must_be_a_block :
 val prove_unique_tag_and_size :
   Typing_env.t ->
   Type_grammar.t ->
-  (Tag.t * Targetint_31_63.Imm.t) proof_allowing_kind_mismatch
+  (Tag.t * Targetint_31_63.t) proof_allowing_kind_mismatch
 
 val prove_unique_fully_constructed_immutable_heap_block :
   Typing_env.t -> Type_grammar.t -> (Tag_and_size.t * Simple.t list) proof

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -118,7 +118,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
             | None -> try_canonical_simple ()
             | Some ((tag, size), field_types) -> (
               assert (
-                Targetint_31_63.Imm.equal size
+                Targetint_31_63.equal size
                   (TG.Product.Int_indexed.width field_types));
               (* CR mshinwell: Could recognise other things, e.g. tagged
                  immediates and float arrays, supported by [Static_part]. *)


### PR DESCRIPTION
Mostly removing the wretched `Imm` module.  This means some integers will no longer print as characters, but that was a bit dubious anyway, and didn't work for `Switch`.

Plus a couple of unnecessary ocamlformat-disabling attributes removed in `Numeric_types`.