### PR TITLE
Rename perm -> renaming

### DIFF
--- a/middle_end/flambda2/bound_identifiers/bound_parameter.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.ml
@@ -61,8 +61,8 @@ let equal_kinds t1 t2 = Flambda_kind.With_subkind.equal t1.kind t2.kind
 let free_names ({ param = _; kind = _ } as t) =
   Name_occurrences.singleton_variable (var t) Name_mode.normal
 
-let apply_renaming { param; kind } perm =
-  let param = Renaming.apply_variable perm param in
+let apply_renaming { param; kind } renaming =
+  let param = Renaming.apply_variable renaming param in
   create param kind
 
 let all_ids_for_export { param; kind = _ } =

--- a/middle_end/flambda2/bound_identifiers/bound_static.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_static.ml
@@ -36,12 +36,13 @@ module Pattern = struct
     | Block_like symbol ->
       Format.fprintf ppf "@[<hov 1>(Block_like@ %a)@]" Symbol.print symbol
 
-  let apply_renaming t perm =
+  let apply_renaming t renaming =
     match t with
-    | Code code_id -> Code (Renaming.apply_code_id perm code_id)
+    | Code code_id -> Code (Renaming.apply_code_id renaming code_id)
     | Set_of_closures map ->
-      Set_of_closures (Function_slot.Lmap.map (Renaming.apply_symbol perm) map)
-    | Block_like symbol -> Block_like (Renaming.apply_symbol perm symbol)
+      Set_of_closures
+        (Function_slot.Lmap.map (Renaming.apply_symbol renaming) map)
+    | Block_like symbol -> Block_like (Renaming.apply_symbol renaming symbol)
 
   let free_names t =
     match t with
@@ -158,8 +159,8 @@ let everything_being_defined t =
   List.map Pattern.everything_being_defined t
   |> Code_id_or_symbol.Set.union_list
 
-let apply_renaming t perm =
-  List.map (fun pattern -> Pattern.apply_renaming pattern perm) t
+let apply_renaming t renaming =
+  List.map (fun pattern -> Pattern.apply_renaming pattern renaming) t
 
 let free_names t = List.map Pattern.free_names t |> Name_occurrences.union_list
 

--- a/middle_end/flambda2/bound_identifiers/bound_var.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_var.ml
@@ -37,7 +37,8 @@ let with_name_mode t name_mode = { t with name_mode }
 
 let rename t = with_var t (Variable.rename t.var)
 
-let apply_renaming t perm = with_var t (Renaming.apply_variable perm t.var)
+let apply_renaming t renaming =
+  with_var t (Renaming.apply_variable renaming t.var)
 
 let free_names t = Name_occurrences.singleton_variable t.var t.name_mode
 

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -1264,23 +1264,23 @@ and cont_handlers env handler1 handler2 =
 let flambda_units u1 u2 =
   let ret_cont = Continuation.create ~sort:Toplevel_return () in
   let exn_cont = Continuation.create () in
-  let mk_perm u =
-    let perm = Renaming.empty in
-    let perm =
-      Renaming.add_fresh_continuation perm
+  let mk_renaming u =
+    let renaming = Renaming.empty in
+    let renaming =
+      Renaming.add_fresh_continuation renaming
         (Flambda_unit.return_continuation u)
         ~guaranteed_fresh:ret_cont
     in
-    let perm =
-      Renaming.add_fresh_continuation perm
+    let renaming =
+      Renaming.add_fresh_continuation renaming
         (Flambda_unit.exn_continuation u)
         ~guaranteed_fresh:exn_cont
     in
-    perm
+    renaming
   in
   let env = Env.create () in
-  let body1 = Expr.apply_renaming (Flambda_unit.body u1) (mk_perm u1) in
-  let body2 = Expr.apply_renaming (Flambda_unit.body u2) (mk_perm u2) in
+  let body1 = Expr.apply_renaming (Flambda_unit.body u1) (mk_renaming u1) in
+  let body2 = Expr.apply_renaming (Flambda_unit.body u2) (mk_renaming u2) in
   exprs env body1 body2
   |> Comparison.map ~f:(fun body ->
          let module_symbol = Flambda_unit.module_symbol u1 in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -267,13 +267,13 @@ module Inlining = struct
         (Named.create_rec_info rec_info)
         ~body
     in
-    let apply_renaming (acc, body) perm =
+    let apply_renaming (acc, body) renaming =
       let acc =
         Acc.with_free_names
-          (Name_occurrences.apply_renaming (Acc.free_names acc) perm)
+          (Name_occurrences.apply_renaming (Acc.free_names acc) renaming)
           acc
       in
-      acc, Expr.apply_renaming body perm
+      acc, Expr.apply_renaming body renaming
     in
     Inlining_helpers.make_inlined_body ~callee ~params ~args ~my_closure
       ~my_depth ~rec_info ~body:(acc, body) ~exn_continuation

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -214,13 +214,14 @@ end = struct
         | Some for_one_name -> Some (For_one_name.add for_one_name name_mode))
       t
 
-  let apply_renaming t perm =
-    N.Map.map_keys (fun name -> N.apply_renaming name perm) t
+  let apply_renaming t renaming =
+    N.Map.map_keys (fun name -> N.apply_renaming name renaming) t
 
-  let affected_by_renaming t perm =
+  let affected_by_renaming t renaming =
     (* CR lmaurer: This is ultimately just [N.Map.inter_domain_is_not_equal]. *)
     N.Map.exists
-      (fun name _name_mode -> not (N.equal name (N.apply_renaming name perm)))
+      (fun name _name_mode ->
+        not (N.equal name (N.apply_renaming name renaming)))
       t
 
   let diff t1 t2 = N.Map.diff_domains t1 t2
@@ -315,34 +316,34 @@ end
 module For_names = For_one_variety_of_names (struct
   include Name
 
-  let apply_renaming t perm = Renaming.apply_name perm t
+  let apply_renaming t renaming = Renaming.apply_name renaming t
 end)
 
 module For_continuations = For_one_variety_of_names (struct
   include Continuation
 
-  let apply_renaming t perm = Renaming.apply_continuation perm t
+  let apply_renaming t renaming = Renaming.apply_continuation renaming t
 end)
 
 module For_function_slots = For_one_variety_of_names (struct
   include Function_slot
 
   (* We never bind [Function_slot]s using [Name_abstraction]. *)
-  let apply_renaming t _perm = t
+  let apply_renaming t _renaming = t
 end)
 
 module For_value_slots = For_one_variety_of_names (struct
   include Value_slot
 
   (* We never bind [Value_slot]s using [Name_abstraction]. *)
-  let apply_renaming t _perm = t
+  let apply_renaming t _renaming = t
 end)
 
 module For_code_ids = For_one_variety_of_names (struct
   include Code_id
 
   (* We never bind [Code_id]s using [Name_abstraction]. *)
-  let apply_renaming t perm = Renaming.apply_code_id perm t
+  let apply_renaming t renaming = Renaming.apply_code_id renaming t
 end)
 
 type t =

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -35,7 +35,7 @@ val equal : t -> t -> bool
 
 val apply_renaming : t -> Renaming.t -> t
 
-(** True if and only if [not (equal (apply_renaming t perm) t)] *)
+(** True if and only if [not (equal (apply_renaming t renaming) t)] *)
 val affected_by_renaming : t -> Renaming.t -> bool
 
 val singleton_continuation : Continuation.t -> t

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -17,20 +17,20 @@
 let make_inlined_body ~callee ~params ~args ~my_closure ~my_depth ~rec_info
     ~body ~exn_continuation ~return_continuation ~apply_exn_continuation
     ~apply_return_continuation ~bind_params ~bind_depth ~apply_renaming =
-  let perm = Renaming.empty in
-  let perm =
+  let renaming = Renaming.empty in
+  let renaming =
     match (apply_return_continuation : Flambda.Apply.Result_continuation.t) with
-    | Return k -> Renaming.add_continuation perm return_continuation k
-    | Never_returns -> perm
+    | Return k -> Renaming.add_continuation renaming return_continuation k
+    | Never_returns -> renaming
   in
-  let perm =
-    Renaming.add_continuation perm exn_continuation apply_exn_continuation
+  let renaming =
+    Renaming.add_continuation renaming exn_continuation apply_exn_continuation
   in
   let body =
     bind_params ~params:(my_closure :: params) ~args:(callee :: args) ~body
   in
   let body = bind_depth ~my_depth ~rec_info ~body in
-  apply_renaming body perm
+  apply_renaming body renaming
 
 let wrap_inlined_body_for_exn_support acc ~extra_args ~apply_exn_continuation
     ~apply_return_continuation ~result_arity ~make_inlined_body

--- a/middle_end/flambda2/term_basics/rec_info_expr.ml
+++ b/middle_end/flambda2/term_basics/rec_info_expr.ml
@@ -16,17 +16,17 @@
 
 include Int_ids.Rec_info_expr
 
-let rec apply_renaming orig perm =
+let rec apply_renaming orig renaming =
   match orig with
   | Const _ -> orig
   | Var dv ->
-    let new_dv = Renaming.apply_variable perm dv in
+    let new_dv = Renaming.apply_variable renaming dv in
     if dv == new_dv then orig else var new_dv
   | Succ t ->
-    let new_t = apply_renaming t perm in
+    let new_t = apply_renaming t renaming in
     if t == new_t then orig else succ new_t
   | Unroll_to (unroll_depth, t) ->
-    let new_t = apply_renaming t perm in
+    let new_t = apply_renaming t renaming in
     if t == new_t then orig else unroll_to unroll_depth new_t
 
 let rec free_names_in_mode t mode =

--- a/middle_end/flambda2/term_basics/simple.ml
+++ b/middle_end/flambda2/term_basics/simple.ml
@@ -115,7 +115,7 @@ let free_names t = free_names_with_mode t Name_mode.normal
 
 let free_names_in_types t = free_names_with_mode t Name_mode.in_types
 
-let apply_renaming t perm = Renaming.apply_simple perm t
+let apply_renaming t renaming = Renaming.apply_simple renaming t
 
 module List = struct
   type nonrec t = t list
@@ -138,12 +138,12 @@ module List = struct
       (fun free t -> Name_occurrences.union free (free_names t))
       Name_occurrences.empty t
 
-  let apply_renaming t perm =
+  let apply_renaming t renaming =
     let changed = ref false in
     let result =
       List.map
         (fun simple ->
-          let simple' = apply_renaming simple perm in
+          let simple' = apply_renaming simple renaming in
           if not (simple == simple') then changed := true;
           simple')
         t
@@ -173,7 +173,7 @@ module With_kind = struct
 
   let free_names (simple, _kind) = free_names simple
 
-  let apply_renaming ((simple, kind) as t) perm =
-    let simple' = apply_renaming simple perm in
+  let apply_renaming ((simple, kind) as t) renaming =
+    let simple' = apply_renaming simple renaming in
     if simple == simple' then t else simple', kind
 end

--- a/middle_end/flambda2/terms/function_declarations.ml
+++ b/middle_end/flambda2/terms/function_declarations.ml
@@ -53,10 +53,10 @@ let free_names { funs; _ } =
 (* Note: the call to {create} at the end already takes into account the
    permutation applied to the function_declarations in {in_order}, so there is
    no need to apply_renaming the func_decls in the {funs} field. *)
-let apply_renaming ({ in_order; _ } as t) perm =
+let apply_renaming ({ in_order; _ } as t) renaming =
   let in_order' =
     Function_slot.Lmap.map_sharing
-      (fun code_id -> Renaming.apply_code_id perm code_id)
+      (fun code_id -> Renaming.apply_code_id renaming code_id)
       in_order
   in
   if in_order == in_order' then t else create in_order'

--- a/middle_end/flambda2/terms/switch_expr.ml
+++ b/middle_end/flambda2/terms/switch_expr.ml
@@ -95,11 +95,11 @@ let free_names { condition_dbg = _; scrutinee; arms } =
       Name_occurrences.union (Apply_cont_expr.free_names action) free_names)
     arms free_names_of_scrutinee
 
-let apply_renaming ({ condition_dbg; scrutinee; arms } as t) perm =
-  let scrutinee' = Simple.apply_renaming scrutinee perm in
+let apply_renaming ({ condition_dbg; scrutinee; arms } as t) renaming =
+  let scrutinee' = Simple.apply_renaming scrutinee renaming in
   let arms' =
     Targetint_31_63.Map.map_sharing
-      (fun action -> Apply_cont_expr.apply_renaming action perm)
+      (fun action -> Apply_cont_expr.apply_renaming action renaming)
       arms
   in
   if scrutinee == scrutinee' && arms == arms'


### PR DESCRIPTION
There were various uses of `perm` dating from the time when we only had permutations for renaming.  Now we also have the renamings associated with the import maps, all wrapped up in `Renaming.t`.