### PR TITLE
Add comment on renaming.mli

### DIFF
--- a/middle_end/flambda2/nominal/renaming.mli
+++ b/middle_end/flambda2/nominal/renaming.mli
@@ -17,6 +17,9 @@
 (** Handling of permutations and import freshening upon all kinds of bindable
     names and other identifiers (e.g. constants).
 
+    We use permutations instead of substitutions because they cannot
+    accidentally disturb the binding structure of terms. See [Name_abstraction].
+
     Unlike [Name_occurrences] this module does not segregate names according to
     where they occur (e.g. in terms or in types). *)
 


### PR DESCRIPTION
...explaining why permutations are used instead of substitutions.