### PR TITLE
Allow lifting of immutable arrays

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -601,9 +601,9 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
         If_then_else
           ( Unary (Is_boxed_float, elt),
             Variadic
-              ( Make_array (Naked_floats, Immutable, mode),
+              ( Make_array (Naked_floats, mutability, mode),
                 List.map unbox_float args ),
-            Variadic (Make_array (Values, Immutable, mode), args) )))
+            Variadic (Make_array (Values, mutability, mode), args) )))
   | Popaque, [arg] -> Unary (Opaque_identity, arg)
   | Pduprecord (repr, num_fields), [arg] ->
     let kind : P.Duplicate_block_kind.t =

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -87,6 +87,7 @@ type static_data =
   | Boxed_nativeint of targetint or_variable
   | Immutable_float_block of float or_variable list
   | Immutable_float_array of float or_variable list
+  | Immutable_value_array of field_of_block list
   | Empty_array
   | Mutable_string of { initial_value : string }
   | Immutable_string of string

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -662,6 +662,9 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         | Immutable_float_array elements ->
           static_const
             (Immutable_float_array (List.map (or_variable float env) elements))
+        | Immutable_value_array elements ->
+          static_const
+            (Immutable_value_array (List.map (field_of_block env) elements))
         | Empty_array -> static_const Empty_array
         | Mutable_string { initial_value = s } ->
           static_const (Mutable_string { initial_value = s })

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -579,6 +579,8 @@ let static_const env (sc : Static_const.t) : Fexpr.static_data =
     Immutable_float_block (List.map (or_variable float env) elements)
   | Immutable_float_array elements ->
     Immutable_float_array (List.map (or_variable float env) elements)
+  | Immutable_value_array elements ->
+    Immutable_value_array (List.map (field_of_block env) elements)
   | Empty_array -> Empty_array
   | Mutable_string { initial_value } -> Mutable_string { initial_value }
   | Immutable_string s -> Immutable_string s

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -295,6 +295,10 @@ let static_data ppf : static_data -> unit = function
     Format.fprintf ppf "Float_array [|%a|]"
       (pp_semi_list float_or_variable)
       elements
+  | Immutable_value_array elements ->
+    Format.fprintf ppf "Value_array [|%a|]"
+      (pp_semi_list field_of_block)
+      elements
   | Empty_array -> Format.fprintf ppf "Empty_array"
   | Mutable_string { initial_value = s } ->
     Format.fprintf ppf "mutable \"%s\"" (s |> String.escaped)

--- a/middle_end/flambda2/simplify/lifting/reification.ml
+++ b/middle_end/flambda2/simplify/lifting/reification.ml
@@ -17,34 +17,35 @@
 open! Simplify_import
 
 let create_static_const dacc dbg (to_lift : T.to_lift) : RSC.t =
+  let[@inline always] convert_fields fields =
+    ListLabels.map fields ~f:(fun field ->
+        let module F = Field_of_static_block in
+        Simple.pattern_match' field
+          ~var:(fun var ~coercion ->
+            if not (Coercion.is_id coercion)
+            then
+              Misc.fatal_errorf "Expected identity coercion on variable:@ %a"
+                Simple.print field;
+            F.Dynamically_computed (var, dbg))
+          ~symbol:(fun sym ~coercion ->
+            if not (Coercion.is_id coercion)
+            then
+              Misc.fatal_errorf "Expected identity coercion on symbol:@ %a"
+                Simple.print field;
+            F.Symbol sym)
+          ~const:(fun const ->
+            match Reg_width_const.descr const with
+            | Tagged_immediate imm -> F.Tagged_immediate imm
+            | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+            | Naked_nativeint _ ->
+              Misc.fatal_errorf
+                "Expected a constant of kind [Value] but got %a (dbg %a)"
+                Reg_width_const.print const Debuginfo.print_compact dbg))
+  in
   let art = DA.are_rebuilding_terms dacc in
   match to_lift with
   | Immutable_block { tag; is_unique; fields } ->
-    let fields =
-      ListLabels.map fields ~f:(fun field ->
-          let module F = Field_of_static_block in
-          Simple.pattern_match' field
-            ~var:(fun var ~coercion ->
-              if not (Coercion.is_id coercion)
-              then
-                Misc.fatal_errorf "Expected identity coercion on variable:@ %a"
-                  Simple.print field;
-              F.Dynamically_computed (var, dbg))
-            ~symbol:(fun sym ~coercion ->
-              if not (Coercion.is_id coercion)
-              then
-                Misc.fatal_errorf "Expected identity coercion on symbol:@ %a"
-                  Simple.print field;
-              F.Symbol sym)
-            ~const:(fun const ->
-              match Reg_width_const.descr const with
-              | Tagged_immediate imm -> F.Tagged_immediate imm
-              | Naked_immediate _ | Naked_float _ | Naked_int32 _
-              | Naked_int64 _ | Naked_nativeint _ ->
-                Misc.fatal_errorf
-                  "Expected a constant of kind [Value] but got %a (dbg %a)"
-                  Reg_width_const.print const Debuginfo.print_compact dbg))
-    in
+    let fields = convert_fields fields in
     let mut : Mutability.t =
       if is_unique then Immutable_unique else Immutable
     in
@@ -53,6 +54,12 @@ let create_static_const dacc dbg (to_lift : T.to_lift) : RSC.t =
   | Boxed_int32 i -> RSC.create_boxed_int32 art (Const i)
   | Boxed_int64 i -> RSC.create_boxed_int64 art (Const i)
   | Boxed_nativeint i -> RSC.create_boxed_nativeint art (Const i)
+  | Immutable_float_array { fields } ->
+    let fields = List.map (fun f -> Or_variable.Const f) fields in
+    RSC.create_immutable_float_array art fields
+  | Immutable_value_array { fields } ->
+    let fields = convert_fields fields in
+    RSC.create_immutable_value_array art fields
   | Empty_array -> RSC.create_empty_array art
 
 let lift dacc ty ~bound_to static_const : _ Or_invalid.t * DA.t =

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -157,6 +157,18 @@ let create_immutable_float_array are_rebuilding fields =
     Block_not_rebuilt { free_names }
   else create_normal_non_code (Immutable_float_array fields)
 
+let create_immutable_value_array are_rebuilding fields =
+  if ART.do_not_rebuild_terms are_rebuilding
+  then
+    let free_names =
+      ListLabels.fold_left fields ~init:Name_occurrences.empty
+        ~f:(fun free_names field ->
+          Name_occurrences.union free_names
+            (Field_of_static_block.free_names field))
+    in
+    Block_not_rebuilt { free_names }
+  else create_normal_non_code (Immutable_value_array fields)
+
 let create_empty_array are_rebuilding =
   if ART.do_not_rebuild_terms are_rebuilding
   then Block_not_rebuilt { free_names = Name_occurrences.empty }
@@ -189,7 +201,8 @@ let map_set_of_closures t ~f =
           }
       | Block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
       | Boxed_nativeint _ | Immutable_float_block _ | Immutable_float_array _
-      | Empty_array | Mutable_string _ | Immutable_string _ ->
+      | Immutable_value_array _ | Empty_array | Mutable_string _
+      | Immutable_string _ ->
         t))
   | Block_not_rebuilt _ | Set_of_closures_not_rebuilt _ | Code_not_rebuilt _ ->
     t

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -88,6 +88,9 @@ val create_immutable_float_array :
   Numeric_types.Float_by_bit_pattern.t Or_variable.t list ->
   t
 
+val create_immutable_value_array :
+  Are_rebuilding_terms.t -> Field_of_static_block.t list -> t
+
 val create_empty_array : Are_rebuilding_terms.t -> t
 
 val create_mutable_string : Are_rebuilding_terms.t -> initial_value:string -> t

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1006,6 +1006,9 @@ let simplify_array_load (array_kind : P.Array_kind.t) mutability dacc
     let dacc = DA.add_variable dacc result_var ty in
     SPR.create_invalid dacc
   | Ok array_kind ->
+    (* CR mshinwell: Add proper support for immutable arrays here (probably not
+       required at present since they only go into [Duplicate_array]
+       operations). *)
     let result_kind' =
       P.Array_kind.element_kind array_kind |> K.With_subkind.kind
     in

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -147,7 +147,7 @@ let simplify_caml_make_vect dacc ~len_ty ~init_value_ty : t =
        Also maybe we should allow static allocation of these arrays for
        reasonable sizes. *)
     let type_of_returned_array =
-      T.array_of_length ~element_kind ~length:len_ty
+      T.mutable_array ~element_kind ~length:len_ty (Known Heap)
     in
     Unchanged { return_types = Known [type_of_returned_array] }
 

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -1414,7 +1414,8 @@ module Named = struct
                  ( Block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
                  | Boxed_nativeint _ | Immutable_float_block _
                  | Immutable_float_array _ | Mutable_string _
-                 | Immutable_string _ | Empty_array ) ->
+                 | Immutable_string _ | Empty_array | Immutable_value_array _ )
+               ->
                acc)
            init
 end

--- a/middle_end/flambda2/terms/static_const.mli
+++ b/middle_end/flambda2/terms/static_const.mli
@@ -30,6 +30,10 @@ type t =
       Numeric_types.Float_by_bit_pattern.t Or_variable.t list
   | Immutable_float_array of
       Numeric_types.Float_by_bit_pattern.t Or_variable.t list
+  | Immutable_value_array of Field_of_static_block.t list
+  (* CR mshinwell: Currently we are assuming that the two array constructors
+     above have non-empty field lists. Should we delete [Empty_array] and remove
+     this assumption? *)
   | Empty_array
   | Mutable_string of { initial_value : string }
   | Immutable_string of string

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -495,6 +495,19 @@ val closure_with_at_least_these_value_slots :
 val array_of_length :
   element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
   length:flambda_type ->
+  Alloc_mode.t Or_unknown.t ->
+  flambda_type
+
+val mutable_array :
+  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  length:flambda_type ->
+  Alloc_mode.t Or_unknown.t ->
+  flambda_type
+
+val immutable_array :
+  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  fields:flambda_type list ->
+  Alloc_mode.t Or_unknown.t ->
   flambda_type
 
 (** Construct a type equal to the type of the given name. (The name must be
@@ -609,6 +622,19 @@ val meet_is_flat_float_array : Typing_env.t -> t -> bool meet_shortcut
 
 val prove_is_immediates_array : Typing_env.t -> t -> unit proof_of_property
 
+type array_contents = private
+  | Immutable of { fields : t list }
+  | Mutable
+
+val meet_is_array :
+  Typing_env.t ->
+  t ->
+  (Flambda_kind.With_subkind.t Or_unknown.t
+  * t
+  * array_contents Or_unknown.t
+  * Alloc_mode.t Or_unknown.t)
+  meet_shortcut
+
 val meet_single_closures_entry :
   Typing_env.t ->
   t ->
@@ -693,6 +719,9 @@ type to_lift = private
   | Boxed_int32 of Numeric_types.Int32.t
   | Boxed_int64 of Numeric_types.Int64.t
   | Boxed_nativeint of Targetint_32_64.t
+  | Immutable_float_array of
+      { fields : Numeric_types.Float_by_bit_pattern.t list }
+  | Immutable_value_array of { fields : Simple.t list }
   | Empty_array
 
 type reification_result = private

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -622,17 +622,10 @@ val meet_is_flat_float_array : Typing_env.t -> t -> bool meet_shortcut
 
 val prove_is_immediates_array : Typing_env.t -> t -> unit proof_of_property
 
-type array_contents = private
-  | Immutable of { fields : t list }
-  | Mutable
-
-val meet_is_array :
+val meet_is_immutable_array :
   Typing_env.t ->
   t ->
-  (Flambda_kind.With_subkind.t Or_unknown.t
-  * t
-  * array_contents Or_unknown.t
-  * Alloc_mode.t Or_unknown.t)
+  (Flambda_kind.With_subkind.t Or_unknown.t * t * Alloc_mode.t Or_unknown.t)
   meet_shortcut
 
 val meet_single_closures_entry :

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -332,16 +332,17 @@ let rec unknown_with_subkind ?(alloc_mode = Or_unknown.Unknown)
       alloc_mode
   | Float_array ->
     TG.mutable_array ~element_kind:(Known Flambda_kind.With_subkind.naked_float)
-      ~length:any_tagged_immediate Unknown
+      ~length:any_tagged_immediate alloc_mode
   | Immediate_array ->
     TG.mutable_array
       ~element_kind:(Known Flambda_kind.With_subkind.tagged_immediate)
-      ~length:any_tagged_immediate Unknown
+      ~length:any_tagged_immediate alloc_mode
   | Value_array ->
     TG.mutable_array ~element_kind:(Known Flambda_kind.With_subkind.any_value)
-      ~length:any_tagged_immediate Unknown
+      ~length:any_tagged_immediate alloc_mode
   | Generic_array ->
-    TG.mutable_array ~element_kind:Unknown ~length:any_tagged_immediate Unknown
+    TG.mutable_array ~element_kind:Unknown ~length:any_tagged_immediate
+      alloc_mode
 
 let unknown_types_from_arity_with_subkinds arity =
   List.map

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -331,18 +331,17 @@ let rec unknown_with_subkind ?(alloc_mode = Or_unknown.Unknown)
       ~fields:(List.init num_fields (fun _ -> TG.any_naked_float))
       alloc_mode
   | Float_array ->
-    TG.array_of_length
-      ~element_kind:(Known Flambda_kind.With_subkind.naked_float)
-      ~length:any_tagged_immediate
+    TG.mutable_array ~element_kind:(Known Flambda_kind.With_subkind.naked_float)
+      ~length:any_tagged_immediate Unknown
   | Immediate_array ->
-    TG.array_of_length
+    TG.mutable_array
       ~element_kind:(Known Flambda_kind.With_subkind.tagged_immediate)
-      ~length:any_tagged_immediate
+      ~length:any_tagged_immediate Unknown
   | Value_array ->
-    TG.array_of_length ~element_kind:(Known Flambda_kind.With_subkind.any_value)
-      ~length:any_tagged_immediate
+    TG.mutable_array ~element_kind:(Known Flambda_kind.With_subkind.any_value)
+      ~length:any_tagged_immediate Unknown
   | Generic_array ->
-    TG.array_of_length ~element_kind:Unknown ~length:any_tagged_immediate
+    TG.mutable_array ~element_kind:Unknown ~length:any_tagged_immediate Unknown
 
 let unknown_types_from_arity_with_subkinds arity =
   List.map

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -66,7 +66,9 @@ and head_of_kind_value =
   | String of String_info.Set.t
   | Array of
       { element_kind : Flambda_kind.With_subkind.t Or_unknown.t;
-        length : t
+        length : t;
+        contents : array_contents Or_unknown.t;
+        alloc_mode : Alloc_mode.t Or_unknown.t
       }
 
 and head_of_kind_naked_immediate =
@@ -151,6 +153,10 @@ and function_type =
            : bool Or_unknown.t *)
   }
 
+and array_contents =
+  | Immutable of { fields : t list }
+  | Mutable
+
 and env_extension = { equations : t Name.Map.t } [@@unboxed]
 
 type flambda_type = t
@@ -207,7 +213,23 @@ and free_names_head_of_kind_value0 ~follow_value_slots head =
   | Closures { by_function_slot; alloc_mode = _ } ->
     free_names_row_like_for_closures ~follow_value_slots by_function_slot
   | String _ -> Name_occurrences.empty
-  | Array { element_kind = _; length } -> free_names0 ~follow_value_slots length
+  | Array
+      { element_kind = _;
+        length;
+        contents = Unknown | Known Mutable;
+        alloc_mode = _
+      } ->
+    free_names0 ~follow_value_slots length
+  | Array
+      { element_kind = _;
+        length;
+        contents = Known (Immutable { fields });
+        alloc_mode = _
+      } ->
+    Name_occurrences.union
+      (free_names0 ~follow_value_slots length)
+      (List.map (free_names0 ~follow_value_slots) fields
+      |> Name_occurrences.union_list)
 
 and free_names_head_of_kind_naked_immediate0 ~follow_value_slots head =
   match head with
@@ -454,9 +476,40 @@ and apply_renaming_head_of_kind_value head renaming =
     then head
     else Closures { by_function_slot = by_function_slot'; alloc_mode }
   | String _ -> head
-  | Array { element_kind; length } ->
+  | Array { element_kind; length; contents = Unknown; alloc_mode } ->
     let length' = apply_renaming length renaming in
-    if length == length' then head else Array { element_kind; length = length' }
+    if length == length'
+    then head
+    else
+      Array { element_kind; length = length'; contents = Unknown; alloc_mode }
+  | Array { element_kind; length; contents = Known Mutable; alloc_mode } ->
+    let length' = apply_renaming length renaming in
+    if length == length'
+    then head
+    else
+      Array
+        { element_kind; length = length'; contents = Known Mutable; alloc_mode }
+  | Array
+      { element_kind;
+        length;
+        contents = Known (Immutable { fields });
+        alloc_mode
+      } ->
+    let length' = apply_renaming length renaming in
+    let fields' =
+      Misc.Stdlib.List.map_sharing
+        (fun field -> apply_renaming field renaming)
+        fields
+    in
+    if length == length' && fields == fields'
+    then head
+    else
+      Array
+        { element_kind;
+          length = length';
+          contents = Known (Immutable { fields = fields' });
+          alloc_mode
+        }
 
 and apply_renaming_head_of_kind_naked_immediate head renaming =
   match head with
@@ -679,10 +732,36 @@ and print_head_of_kind_value ppf head =
   | String str_infos ->
     Format.fprintf ppf "@[<hov 1>(Strings@ (%a))@]" String_info.Set.print
       str_infos
-  | Array { element_kind; length } ->
-    Format.fprintf ppf "@[<hov 1>(Array@ (element_kind@ %a)@ (length@ %a))@]"
+  | Array { element_kind; length; contents = Unknown; alloc_mode } ->
+    Format.fprintf ppf
+      "@[<hov 1>(Array@ (element_kind@ %a)@ (length@ %a)@ (alloc_mode@ %a))@]"
       (Or_unknown.print Flambda_kind.With_subkind.print)
       element_kind print length
+      (Or_unknown.print Alloc_mode.print)
+      alloc_mode
+  | Array { element_kind; length; contents = Known Mutable; alloc_mode } ->
+    Format.fprintf ppf
+      "@[<hov 1>(Mutable_array@ (element_kind@ %a)@ (length@ %a)@ (alloc_mode@ \
+       %a))@]"
+      (Or_unknown.print Flambda_kind.With_subkind.print)
+      element_kind print length
+      (Or_unknown.print Alloc_mode.print)
+      alloc_mode
+  | Array
+      { element_kind;
+        length;
+        contents = Known (Immutable { fields });
+        alloc_mode
+      } ->
+    Format.fprintf ppf
+      "@[<hov 1>(Immutable_array@ (element_kind@ %a)@ (length@ %a)@ \
+       (alloc_mode@ %a)@ (fields@ (%a)))@]"
+      (Or_unknown.print Flambda_kind.With_subkind.print)
+      element_kind print length
+      (Or_unknown.print Alloc_mode.print)
+      alloc_mode
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space print)
+      fields
 
 and print_head_of_kind_naked_immediate ppf head =
   match head with
@@ -854,7 +933,21 @@ and ids_for_export_head_of_kind_value head =
   | Closures { by_function_slot; alloc_mode = _ } ->
     ids_for_export_row_like_for_closures by_function_slot
   | String _ -> Ids_for_export.empty
-  | Array { element_kind = _; length } -> ids_for_export length
+  | Array
+      { element_kind = _;
+        length;
+        contents = Unknown | Known Mutable;
+        alloc_mode = _
+      } ->
+    ids_for_export length
+  | Array
+      { element_kind = _;
+        length;
+        contents = Known (Immutable { fields });
+        alloc_mode = _
+      } ->
+    Ids_for_export.union (ids_for_export length)
+      (List.map ids_for_export fields |> Ids_for_export.union_list)
 
 and ids_for_export_head_of_kind_naked_immediate head =
   match head with
@@ -1054,9 +1147,22 @@ and apply_coercion_head_of_kind_value head coercion : _ Or_bottom.t =
   | Boxed_int32 _ | Boxed_int64 _ | Boxed_nativeint _ | String _ ->
     (* Similarly, we don't have lifted coercions for these. *)
     if Coercion.is_id coercion then Ok head else Bottom
-  | Array { element_kind = _; length = _ } ->
+  | Array
+      { element_kind = _;
+        length = _;
+        contents = Unknown | Known Mutable;
+        alloc_mode = _
+      } ->
     (* This one's a bit more obvious: we wouldn't want to accidentally treat a
        coercion on integers as a coercion on array lengths. *)
+    if Coercion.is_id coercion then Ok head else Bottom
+  | Array
+      { element_kind = _;
+        length = _;
+        contents = Known (Immutable { fields = _ });
+        alloc_mode = _
+      } ->
+    (* Same as the block case (in [Variant]) above. *)
     if Coercion.is_id coercion then Ok head else Bottom
 
 and apply_coercion_head_of_kind_naked_immediate head coercion : _ Or_bottom.t =
@@ -1391,12 +1497,50 @@ and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value head
     then head
     else Closures { by_function_slot = by_function_slot'; alloc_mode }
   | String _ -> head
-  | Array { element_kind; length } ->
+  | Array { element_kind; length; contents = Unknown; alloc_mode } ->
     let length' =
       remove_unused_value_slots_and_shortcut_aliases length ~used_value_slots
         ~canonicalise
     in
-    if length == length' then head else Array { element_kind; length = length' }
+    if length == length'
+    then head
+    else
+      Array { element_kind; length = length'; contents = Unknown; alloc_mode }
+  | Array { element_kind; length; contents = Known Mutable; alloc_mode } ->
+    let length' =
+      remove_unused_value_slots_and_shortcut_aliases length ~used_value_slots
+        ~canonicalise
+    in
+    if length == length'
+    then head
+    else
+      Array
+        { element_kind; length = length'; contents = Known Mutable; alloc_mode }
+  | Array
+      { element_kind;
+        length;
+        contents = Known (Immutable { fields });
+        alloc_mode
+      } ->
+    let length' =
+      remove_unused_value_slots_and_shortcut_aliases length ~used_value_slots
+        ~canonicalise
+    in
+    let fields' =
+      Misc.Stdlib.List.map_sharing
+        (remove_unused_value_slots_and_shortcut_aliases ~used_value_slots
+           ~canonicalise)
+        fields
+    in
+    if length == length && fields == fields'
+    then head
+    else
+      Array
+        { element_kind;
+          length = length';
+          contents = Known (Immutable { fields = fields' });
+          alloc_mode
+        }
 
 and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_naked_immediate
     head ~used_value_slots ~canonicalise =
@@ -1799,9 +1943,40 @@ and project_head_of_kind_value ~to_project ~expand head =
     then head
     else Closures { by_function_slot = by_function_slot'; alloc_mode }
   | String _ -> head
-  | Array { element_kind; length } ->
+  | Array { element_kind; length; contents = Unknown; alloc_mode } ->
     let length' = project_variables_out ~to_project ~expand length in
-    if length == length' then head else Array { element_kind; length = length' }
+    if length == length'
+    then head
+    else
+      Array { element_kind; length = length'; contents = Unknown; alloc_mode }
+  | Array { element_kind; length; contents = Known Mutable; alloc_mode } ->
+    let length' = project_variables_out ~to_project ~expand length in
+    if length == length'
+    then head
+    else
+      Array
+        { element_kind; length = length'; contents = Known Mutable; alloc_mode }
+  | Array
+      { element_kind;
+        length;
+        contents = Known (Immutable { fields });
+        alloc_mode
+      } ->
+    let length' = project_variables_out ~to_project ~expand length in
+    let fields' =
+      Misc.Stdlib.List.map_sharing
+        (project_variables_out ~to_project ~expand)
+        fields
+    in
+    if length == length' && fields == fields'
+    then head
+    else
+      Array
+        { element_kind;
+          length = length';
+          contents = Known (Immutable { fields = fields' });
+          alloc_mode
+        }
 
 and project_head_of_kind_naked_immediate ~to_project ~expand head =
   match head with
@@ -2652,8 +2827,26 @@ let mutable_string ~size =
   in
   Value (TD.create (String string_info))
 
-let array_of_length ~element_kind ~length =
-  Value (TD.create (Array { element_kind; length }))
+let array_of_length ~element_kind ~length alloc_mode =
+  Value
+    (TD.create (Array { element_kind; length; contents = Unknown; alloc_mode }))
+
+let mutable_array ~element_kind ~length alloc_mode =
+  Value
+    (TD.create
+       (Array { element_kind; length; contents = Known Mutable; alloc_mode }))
+
+let immutable_array ~element_kind ~fields alloc_mode =
+  Value
+    (TD.create
+       (Array
+          { element_kind;
+            length =
+              this_tagged_immediate
+                (Targetint_31_63.of_int (List.length fields));
+            contents = Known (Immutable { fields });
+            alloc_mode
+          }))
 
 let this_rec_info (rec_info_expr : Rec_info_expr.t) =
   match rec_info_expr with
@@ -2730,7 +2923,8 @@ module Head_of_kind_value = struct
 
   let create_string info = String info
 
-  let create_array ~element_kind ~length = Array { element_kind; length }
+  let create_array_with_contents ~element_kind ~length contents alloc_mode =
+    Array { element_kind; length; contents; alloc_mode }
 end
 
 module type Head_of_kind_naked_number_intf = sig

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -1532,7 +1532,7 @@ and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value head
            ~canonicalise)
         fields
     in
-    if length == length && fields == fields'
+    if length == length' && fields == fields'
     then head
     else
       Array

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -59,7 +59,9 @@ and head_of_kind_value = private
   | String of String_info.Set.t
   | Array of
       { element_kind : Flambda_kind.With_subkind.t Or_unknown.t;
-        length : t
+        length : t;
+        contents : array_contents Or_unknown.t;
+        alloc_mode : Alloc_mode.t Or_unknown.t
       }
 
 and head_of_kind_naked_immediate = private
@@ -127,6 +129,10 @@ and function_type = private
   { code_id : Code_id.t;
     rec_info : t
   }
+
+and array_contents =
+  | Immutable of { fields : t list }
+  | Mutable
 
 and env_extension = private { equations : t Name.Map.t } [@@unboxed]
 
@@ -263,7 +269,22 @@ val this_immutable_string : string -> t
 val mutable_string : size:int -> t
 
 val array_of_length :
-  element_kind:Flambda_kind.With_subkind.t Or_unknown.t -> length:t -> t
+  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  length:t ->
+  Alloc_mode.t Or_unknown.t ->
+  t
+
+val mutable_array :
+  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  length:t ->
+  Alloc_mode.t Or_unknown.t ->
+  t
+
+val immutable_array :
+  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  fields:t list ->
+  Alloc_mode.t Or_unknown.t ->
+  t
 
 module Product : sig
   module Function_slot_indexed : sig
@@ -554,9 +575,11 @@ module Head_of_kind_value : sig
 
   val create_string : String_info.Set.t -> t
 
-  val create_array :
+  val create_array_with_contents :
     element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
     length:flambda_type ->
+    array_contents Or_unknown.t ->
+    Alloc_mode.t Or_unknown.t ->
     t
 end
 

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -566,6 +566,17 @@ let prove_single_closures_entry_generic env t : _ generic_proof =
 let meet_single_closures_entry env t =
   as_meet_shortcut (prove_single_closures_entry_generic env t)
 
+let meet_is_array env t : _ meet_shortcut =
+  match expand_head env t with
+  | Value Unknown -> Need_meet
+  | Value Bottom -> Invalid
+  | Value (Ok (Array { element_kind; length; contents; alloc_mode })) ->
+    Known_result (element_kind, length, contents, alloc_mode)
+  | Value (Ok _)
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Rec_info _ | Region _ ->
+    Invalid
+
 let prove_single_closures_entry env t =
   as_property (prove_single_closures_entry_generic env t)
 

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -566,12 +566,15 @@ let prove_single_closures_entry_generic env t : _ generic_proof =
 let meet_single_closures_entry env t =
   as_meet_shortcut (prove_single_closures_entry_generic env t)
 
-let meet_is_array env t : _ meet_shortcut =
+let meet_is_immutable_array env t : _ meet_shortcut =
   match expand_head env t with
   | Value Unknown -> Need_meet
   | Value Bottom -> Invalid
-  | Value (Ok (Array { element_kind; length; contents; alloc_mode })) ->
-    Known_result (element_kind, length, contents, alloc_mode)
+  | Value (Ok (Array { element_kind; length; contents; alloc_mode })) -> (
+    match contents with
+    | Known (Immutable _) -> Known_result (element_kind, length, alloc_mode)
+    | Known Mutable -> Invalid
+    | Unknown -> Need_meet)
   | Value (Ok _)
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Rec_info _ | Region _ ->

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -116,6 +116,15 @@ val prove_unique_fully_constructed_immutable_heap_block :
 val meet_is_flat_float_array :
   Typing_env.t -> Type_grammar.t -> bool meet_shortcut
 
+val meet_is_array :
+  Typing_env.t ->
+  Type_grammar.t ->
+  (Flambda_kind.With_subkind.t Or_unknown.t
+  * Type_grammar.t
+  * Type_grammar.array_contents Or_unknown.t
+  * Alloc_mode.t Or_unknown.t)
+  meet_shortcut
+
 val prove_is_immediates_array :
   Typing_env.t -> Type_grammar.t -> unit proof_of_property
 

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -116,12 +116,11 @@ val prove_unique_fully_constructed_immutable_heap_block :
 val meet_is_flat_float_array :
   Typing_env.t -> Type_grammar.t -> bool meet_shortcut
 
-val meet_is_array :
+val meet_is_immutable_array :
   Typing_env.t ->
   Type_grammar.t ->
   (Flambda_kind.With_subkind.t Or_unknown.t
   * Type_grammar.t
-  * Type_grammar.array_contents Or_unknown.t
   * Alloc_mode.t Or_unknown.t)
   meet_shortcut
 

--- a/middle_end/flambda2/types/reify.mli
+++ b/middle_end/flambda2/types/reify.mli
@@ -27,6 +27,9 @@ type to_lift = private
   | Boxed_int32 of Numeric_types.Int32.t
   | Boxed_int64 of Numeric_types.Int64.t
   | Boxed_nativeint of Targetint_32_64.t
+  | Immutable_float_array of
+      { fields : Numeric_types.Float_by_bit_pattern.t list }
+  | Immutable_value_array of { fields : Simple.t list }
   | Empty_array
 
 type reification_result = private


### PR DESCRIPTION
One of the changes made at the Simplify review session was to change the input of `Pduparray` so instead of taking blocks it was fed arrays.  Unfortunately this meant that the immutable arrays in question, being duplicated, could not be lifted.  This showed up in OPAM testing where two packages (`uri` and `down`) would not compile due to stack overflow.

This patch adds proper support for immutable arrays (except for projection operations which we don't need at present, as far as I know).