### PR TITLE
Classic mode inlining fix

### DIFF
--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -22,6 +22,22 @@ type 'code t =
   | Closure_approximation of Code_id.t * Function_slot.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 
+let rec print fmt = function
+  | Value_unknown -> Format.fprintf fmt "?"
+  | Value_symbol sym -> Symbol.print fmt sym
+  | Closure_approximation (code_id, _, _) ->
+    Format.fprintf fmt "[%a]" Code_id.print code_id
+  | Block_approximation (fields, _) ->
+    let len = Array.length fields in
+    if len < 1
+    then Format.fprintf fmt "{}"
+    else (
+      Format.fprintf fmt "@[<hov 2>{%a" print fields.(0);
+      for i = 1 to len - 1 do
+        Format.fprintf fmt "@ %a" print fields.(i)
+      done;
+      Format.fprintf fmt "}@]")
+
 let is_unknown = function
   | Value_unknown -> true
   | Value_symbol _ | Closure_approximation _ | Block_approximation _ -> false

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -22,6 +22,8 @@ type 'code t =
   | Closure_approximation of Code_id.t * Function_slot.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 
+val print : Format.formatter -> 'a t -> unit
+
 val is_unknown : 'a t -> bool
 
 val free_names :

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -911,6 +911,7 @@ let close_exact_or_unknown_apply acc env
     match Inlining.inlinable env apply callee_approx with
     | Not_inlinable -> Expr_with_acc.create_apply acc apply
     | Inlinable func_desc ->
+      let acc = Acc.mark_continuation_as_untrackable continuation acc in
       Inlining.inline acc ~apply ~apply_depth:(Env.current_depth env) ~func_desc
   else Expr_with_acc.create_apply acc apply
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -219,6 +219,8 @@ module Acc : sig
 
   val remove_continuation_from_free_names : Continuation.t -> t -> t
 
+  val mark_continuation_as_untrackable : Continuation.t -> t -> t
+
   val continuation_known_arguments :
     cont:Continuation.t -> t -> Env.value_approximation list option
 


### PR DESCRIPTION
The return continuation of inlined function calls must be marked as `Untrackable`, as we're not traversing the inlined code.