### PR TITLE
Allow free names of Code.t to be an overapproximation

### DIFF
--- a/middle_end/flambda2/identifiers/name.ml
+++ b/middle_end/flambda2/identifiers/name.ml
@@ -20,6 +20,9 @@ let is_var t = pattern_match t ~var:(fun _ -> true) ~symbol:(fun _ -> false)
 
 let is_symbol t = pattern_match t ~var:(fun _ -> false) ~symbol:(fun _ -> true)
 
+let to_var t =
+  pattern_match t ~var:(fun var -> Some var) ~symbol:(fun _ -> None)
+
 let to_symbol t =
   pattern_match t ~var:(fun _ -> None) ~symbol:(fun symbol -> Some symbol)
 
@@ -30,6 +33,14 @@ let set_of_symbol_set symbols =
   Symbol.Set.fold
     (fun sym t_set -> Set.add (symbol sym) t_set)
     symbols Set.empty
+
+let set_to_var_set t =
+  Set.fold
+    (fun name vars ->
+      match to_var name with
+      | None -> vars
+      | Some var -> Variable.Set.add var vars)
+    t Variable.Set.empty
 
 let set_to_symbol_set t =
   Set.fold

--- a/middle_end/flambda2/identifiers/name.mli
+++ b/middle_end/flambda2/identifiers/name.mli
@@ -25,6 +25,8 @@ val set_of_var_set : Variable.Set.t -> Set.t
 
 val set_of_symbol_set : Symbol.Set.t -> Set.t
 
+val set_to_var_set : Set.t -> Variable.Set.t
+
 val set_to_symbol_set : Set.t -> Symbol.Set.t
 
 val is_var : t -> bool

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -35,6 +35,8 @@ val equal : t -> t -> bool
 
 val apply_renaming : t -> Renaming.t -> t
 
+include Contains_ids.S with type t := t
+
 (** True if and only if [not (equal (apply_renaming t renaming) t)] *)
 val affected_by_renaming : t -> Renaming.t -> bool
 


### PR DESCRIPTION
Currently this was implicitly forbidden and could lead to failures when importing, because `Simple`s in unused value slots would still be counted as free names of `Code` even though the slots get erased by `Renaming` upon import.  These failures actually only show up in classic mode because that is the only place where the imported free name sets get relied upon.

This patch will have a small compilation time penalty but in practice it's probably negligible, and the alternative (segregating names in `Name_occurrences` so the ones known to be involved with value slots can be subtracted out upon import) seems worse.

This fixes the problem seen with `parsexp` compilation.