### PR TITLE
Backport first part of ocaml/ocaml PR10498

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2377,7 +2377,7 @@ let send_function (arity, mode) =
   let cache = cache in
   let fun_name = send_function_name arity mode in
   let fun_args =
-    [obj, typ_val; tag, typ_int; cache, typ_val]
+    [obj, typ_val; tag, typ_int; cache, typ_addr]
     @ List.map (fun id -> id, typ_val) (List.tl args)
   in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -2002,7 +2002,7 @@ let send_function (arity, mode) =
   let cache = cache in
   let fun_name = send_function_name arity mode in
   let fun_args =
-    [obj, typ_val; tag, typ_int; cache, typ_val]
+    [obj, typ_val; tag, typ_int; cache, typ_addr]
     @ List.map (fun id -> (id, typ_val)) (List.tl args) in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
   Cfunction


### PR DESCRIPTION
It took me a while to work out what needs porting from ocaml/ocaml#10461 and ocaml/ocaml#10498 but it's just the commit given in https://github.com/ocaml-flambda/flambda-backend/issues/206.  The part of that commit which can be ported before safepoints is now on this PR.