### PR TITLE
Better check for physically not equal cases

### DIFF
--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -791,86 +791,29 @@ end
 
 module Binary_float_comp = Binary_arith_like (Float_ops_for_binary_comp)
 
-module Int_ops_for_binary_eq_comp (I : A.Int_number_kind) : sig
-  include Binary_arith_like_sig with type op = P.equality_comparison
-end = struct
-  module Lhs = I.Num
-  module Rhs = I.Num
-  module Result = Targetint_31_63
-
-  type op = P.equality_comparison
-
-  let arg_kind = I.standard_int_or_float_kind
-
-  let result_kind = K.naked_immediate
-
-  let ok_to_evaluate _env = true
-
-  let prover_lhs = I.unboxed_prover
-
-  let prover_rhs = I.unboxed_prover
-
-  let unknown _ = T.any_naked_immediate
-
-  let these = T.these_naked_immediates
-
-  let term imm : Named.t =
-    Named.create_simple (Simple.const (Reg_width_const.naked_immediate imm))
-
-  module Pair = I.Num.Pair
-
-  let cross_product = I.Num.cross_product
-
-  module Num = I.Num
-
-  let op (op : P.equality_comparison) n1 n2 =
-    let bool b = Targetint_31_63.bool b in
-    match op with
-    | Eq -> Some (bool (Num.compare n1 n2 = 0))
-    | Neq -> Some (bool (Num.compare n1 n2 <> 0))
-
-  let op_lhs_unknown _op ~rhs:_ = Cannot_simplify
-
-  let op_rhs_unknown _op ~lhs:_ = Cannot_simplify
-end
-[@@inline always]
-
-module Int_ops_for_binary_eq_comp_tagged_immediate =
-  Int_ops_for_binary_eq_comp (A.For_tagged_immediates)
-module Binary_int_eq_comp_tagged_immediate =
-  Binary_arith_like (Int_ops_for_binary_eq_comp_tagged_immediate)
-
-let simplify_phys_equal (op : P.equality_comparison) dacc ~original_term dbg
-    ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var =
+let simplify_phys_equal (op : P.equality_comparison) dacc ~original_term _dbg
+    ~arg1:_ ~arg1_ty ~arg2:_ ~arg2_ty ~result_var =
   (* This primitive is only used for arguments of kind [Value]. *)
-  let const bool =
+  let typing_env = DA.typing_env dacc in
+  (* Note: We don't compare the arguments themselves for equality. Instead, we
+     know that [simplify_simple] always returns alias types, so we let the
+     prover do the matching. *)
+  match T.prove_physical_equality typing_env arg1_ty arg2_ty with
+  | Proved bool ->
+    let result = match op with Eq -> bool | Neq -> not bool in
     let dacc =
       DA.add_variable dacc result_var
-        (T.this_naked_immediate (Targetint_31_63.bool bool))
+        (T.this_naked_immediate (Targetint_31_63.bool result))
     in
     SPR.create
-      (Named.create_simple (Simple.untagged_const_bool bool))
+      (Named.create_simple (Simple.untagged_const_bool result))
       ~try_reify:false dacc
-  in
-  if Simple.equal arg1 arg2
-  then match op with Eq -> const true | Neq -> const false
-  else
-    let typing_env = DA.typing_env dacc in
-    match T.prove_physically_not_equal typing_env arg1_ty arg2_ty with
-    | Proved () -> ( match op with Eq -> const false | Neq -> const true)
-    | Unknown -> (
-      let proof1 = T.prove_equals_tagged_immediates typing_env arg1_ty in
-      let proof2 = T.prove_equals_tagged_immediates typing_env arg2_ty in
-      match proof1, proof2 with
-      | Proved _, Proved _ ->
-        Binary_int_eq_comp_tagged_immediate.simplify op dacc ~original_term dbg
-          ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var
-      | Unknown, Unknown | Proved _, Unknown | Unknown, Proved _ ->
-        let dacc =
-          DA.add_variable dacc result_var
-            (T.these_naked_immediates Targetint_31_63.all_bools)
-        in
-        SPR.create original_term ~try_reify:false dacc)
+  | Unknown ->
+    let dacc =
+      DA.add_variable dacc result_var
+        (T.these_naked_immediates Targetint_31_63.all_bools)
+    in
+    SPR.create original_term ~try_reify:false dacc
 
 let[@inline always] simplify_immutable_block_load0
     (access_kind : P.Block_access_kind.t) ~min_name_mode dacc ~original_term

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -702,6 +702,9 @@ val meet_rec_info : Typing_env.t -> t -> Rec_info_expr.t meet_shortcut
 val prove_alloc_mode_of_boxed_number :
   Typing_env.t -> t -> Alloc_mode.t proof_of_property
 
+val prove_physically_not_equal :
+  Typing_env.t -> t -> t -> unit proof_of_property
+
 type to_lift = private
   | Immutable_block of
       { tag : Tag.Scannable.t;

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -702,8 +702,7 @@ val meet_rec_info : Typing_env.t -> t -> Rec_info_expr.t meet_shortcut
 val prove_alloc_mode_of_boxed_number :
   Typing_env.t -> t -> Alloc_mode.t proof_of_property
 
-val prove_physically_not_equal :
-  Typing_env.t -> t -> t -> unit proof_of_property
+val prove_physical_equality : Typing_env.t -> t -> t -> bool proof_of_property
 
 type to_lift = private
   | Immutable_block of

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -2623,9 +2623,7 @@ let get_alias_exn t =
   | Region ty -> TD.get_alias_exn ty
 
 let get_alias_opt t =
-  match get_alias_exn t with
-  | s -> Some s
-  | exception Not_found -> None
+  match get_alias_exn t with s -> Some s | exception Not_found -> None
 
 let is_obviously_bottom t =
   match t with

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -2622,6 +2622,11 @@ let get_alias_exn t =
   | Rec_info ty -> TD.get_alias_exn ty
   | Region ty -> TD.get_alias_exn ty
 
+let get_alias_opt t =
+  match get_alias_exn t with
+  | s -> Some s
+  | exception Not_found -> None
+
 let is_obviously_bottom t =
   match t with
   | Value ty -> TD.is_obviously_bottom ty

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -165,6 +165,8 @@ val apply_coercion : t -> Coercion.t -> t
 
 val get_alias_exn : t -> Simple.t
 
+val get_alias_opt : t -> Simple.t option
+
 val is_obviously_bottom : t -> bool
 
 val is_obviously_unknown : t -> bool

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -825,127 +825,210 @@ let never_holds_locally_allocated_values env var kind : _ proof_of_property =
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     Proved ()
 
-let prove_physically_not_equal env t1 t2 =
+let prove_physical_equality env t1 t2 =
+  let incompatible_naked_numbers t1 t2 =
+    match expand_head env t1, expand_head env t2 with
+    | Naked_float (Ok s1), Naked_float (Ok s2) ->
+      let module FS = Numeric_types.Float_by_bit_pattern.Set in
+      FS.is_empty (FS.inter (s1 :> FS.t) (s2 :> FS.t))
+    | Naked_int32 (Ok s1), Naked_int32 (Ok s2) ->
+      let module IS = Numeric_types.Int32.Set in
+      IS.is_empty (IS.inter (s1 :> IS.t) (s2 :> IS.t))
+    | Naked_int64 (Ok s1), Naked_int64 (Ok s2) ->
+      let module IS = Numeric_types.Int64.Set in
+      IS.is_empty (IS.inter (s1 :> IS.t) (s2 :> IS.t))
+    | Naked_nativeint (Ok s1), Naked_nativeint (Ok s2) ->
+      let module IS = Targetint_32_64.Set in
+      IS.is_empty (IS.inter (s1 :> IS.t) (s2 :> IS.t))
+    | _, _ -> false
+  in
   let check_heads () : _ proof_of_property =
-    (* CR vlaviron: Add a flag for this *)
-    if true
-    then Unknown
-    else
-      (* More expensive check *)
-      match expand_head env t1, expand_head env t2 with
-      | ( ( Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
-          | Naked_nativeint _ | Rec_info _ | Region _ ),
-          _ ) ->
-        wrong_kind "Value" t1
-      | ( _,
-          ( Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
-          | Naked_nativeint _ | Rec_info _ | Region _ ) ) ->
-        wrong_kind "Value" t2
-      | Value (Unknown | Bottom), _ | _, Value (Unknown | Bottom) -> Unknown
-      | Value (Ok head1), Value (Ok head2) -> (
-        match head1, head2 with
-        (* Basic cases: similar heads -> Unknown *)
-        | Boxed_float _, Boxed_float _ -> Unknown
-        | Boxed_int32 _, Boxed_int32 _ -> Unknown
-        | Boxed_int64 _, Boxed_int64 _ -> Unknown
-        | Boxed_nativeint _, Boxed_nativeint _ -> Unknown
-        | Closures _, Closures _ -> Unknown
-        | String _, String _ -> Unknown
-        (* Immediates and allocated values -> Proved *)
-        | ( Variant
-              { immediates = _;
-                blocks = Known blocks;
-                is_unique = _;
-                alloc_mode = _
-              },
-            ( Mutable_block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
-            | Boxed_nativeint _ | Closures _ | String _ | Array _ ) )
-        | ( ( Mutable_block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
-            | Boxed_nativeint _ | Closures _ | String _ | Array _ ),
-            Variant
-              { immediates = _;
-                blocks = Known blocks;
-                is_unique = _;
-                alloc_mode = _
-              } )
-          when TG.Row_like_for_blocks.is_bottom blocks ->
-          Proved ()
-        | ( Variant
-              { immediates = immediates1;
-                blocks = blocks1;
-                is_unique = _;
-                alloc_mode = _
-              },
-            Variant
-              { immediates = immediates2;
-                blocks = blocks2;
-                is_unique = _;
-                alloc_mode = _
-              } ) -> (
-          match immediates1, immediates2, blocks1, blocks2 with
-          | Known imms, _, _, Known blocks
-            when TG.is_obviously_bottom imms
-                 && TG.Row_like_for_blocks.is_bottom blocks ->
-            Proved ()
-          | _, Known imms, Known blocks, _
-            when TG.is_obviously_bottom imms
-                 && TG.Row_like_for_blocks.is_bottom blocks ->
-            Proved ()
-          | _, _, _, _ -> Unknown)
-        (* Boxed numbers with non-numbers or different kinds -> Proved *)
-        | ( Boxed_float _,
-            ( Variant _ | Mutable_block _ | Boxed_int32 _ | Boxed_int64 _
-            | Boxed_nativeint _ | Closures _ | String _ | Array _ ) )
-        | ( ( Variant _ | Mutable_block _ | Boxed_int32 _ | Boxed_int64 _
-            | Boxed_nativeint _ | Closures _ | String _ | Array _ ),
-            Boxed_float _ )
-        | ( Boxed_int32 _,
-            ( Variant _ | Mutable_block _ | Boxed_int64 _ | Boxed_nativeint _
-            | Closures _ | String _ | Array _ ) )
-        | ( ( Variant _ | Mutable_block _ | Boxed_int64 _ | Boxed_nativeint _
-            | Closures _ | String _ | Array _ ),
-            Boxed_int32 _ )
-        | ( Boxed_int64 _,
-            ( Variant _ | Mutable_block _ | Boxed_nativeint _ | Closures _
-            | String _ | Array _ ) )
-        | ( ( Variant _ | Mutable_block _ | Boxed_nativeint _ | Closures _
-            | String _ | Array _ ),
-            Boxed_int64 _ )
-        | ( Boxed_nativeint _,
-            (Variant _ | Mutable_block _ | Closures _ | String _ | Array _) )
-        | ( (Variant _ | Mutable_block _ | Closures _ | String _ | Array _),
-            Boxed_nativeint _ ) ->
-          Proved ()
-        (* Closures and non-closures -> Proved *)
-        | Closures _, (Variant _ | Mutable_block _ | String _ | Array _)
-        | (Variant _ | Mutable_block _ | String _ | Array _), Closures _ ->
-          Proved ()
-        (* Strings and non-strings -> Proved *)
-        | String _, (Variant _ | Mutable_block _ | Array _)
-        | (Variant _ | Mutable_block _ | Array _), String _ ->
-          Proved ()
-        (* Variants, mutable blocks and arrays are allowed to alias to each
-           other *)
-        | ( (Variant _ | Mutable_block _ | Array _),
-            (Variant _ | Mutable_block _ | Array _) ) ->
-          Unknown)
+    match expand_head env t1, expand_head env t2 with
+    | ( ( Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+        | Naked_nativeint _ | Rec_info _ | Region _ ),
+        _ ) ->
+      wrong_kind "Value" t1
+    | ( _,
+        ( Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+        | Naked_nativeint _ | Rec_info _ | Region _ ) ) ->
+      wrong_kind "Value" t2
+    | Value (Unknown | Bottom), _ | _, Value (Unknown | Bottom) -> Unknown
+    | Value (Ok head1), Value (Ok head2) -> (
+      match head1, head2 with
+      (* Basic cases:
+       * similar heads -> Unknown
+       * incompatible contents -> Proved false
+       *)
+      | Boxed_float (t1, _), Boxed_float (t2, _) ->
+        if incompatible_naked_numbers t1 t2 then Proved false else Unknown
+      | Boxed_int32 (t1, _), Boxed_int32 (t2, _) ->
+        if incompatible_naked_numbers t1 t2 then Proved false else Unknown
+      | Boxed_int64 (t1, _), Boxed_int64 (t2, _) ->
+        if incompatible_naked_numbers t1 t2 then Proved false else Unknown
+      | Boxed_nativeint (t1, _), Boxed_nativeint (t2, _) ->
+        if incompatible_naked_numbers t1 t2 then Proved false else Unknown
+      | Closures _, Closures _ -> Unknown
+      | String s1, String s2 ->
+        let module SS = String_info.Set in
+        if SS.is_empty (SS.inter s1 s2) then Proved false else Unknown
+      (* Immediates and allocated values -> Proved false *)
+      | ( Variant
+            { immediates = _;
+              blocks = Known blocks;
+              is_unique = _;
+              alloc_mode = _
+            },
+          ( Mutable_block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+          | Boxed_nativeint _ | Closures _ | String _ | Array _ ) )
+      | ( ( Mutable_block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+          | Boxed_nativeint _ | Closures _ | String _ | Array _ ),
+          Variant
+            { immediates = _;
+              blocks = Known blocks;
+              is_unique = _;
+              alloc_mode = _
+            } )
+        when TG.Row_like_for_blocks.is_bottom blocks ->
+        Proved false
+      (* Variants:
+       * incompatible immediates and incompatible block tags -> Proved false
+       * same immediate on both sides, no blocks -> Proved true
+       *)
+      | ( Variant
+            { immediates = immediates1;
+              blocks = blocks1;
+              is_unique = _;
+              alloc_mode = _
+            },
+          Variant
+            { immediates = immediates2;
+              blocks = blocks2;
+              is_unique = _;
+              alloc_mode = _
+            } ) -> (
+        match immediates1, immediates2, blocks1, blocks2 with
+        | Known imms, _, _, Known blocks
+          when TG.is_obviously_bottom imms
+               && TG.Row_like_for_blocks.is_bottom blocks ->
+          Proved false
+        | _, Known imms, Known blocks, _
+          when TG.is_obviously_bottom imms
+               && TG.Row_like_for_blocks.is_bottom blocks ->
+          Proved false
+        | Known imms1, Known imms2, Known blocks1, Known blocks2 -> (
+          let immediates_equality : _ generic_proof =
+            match
+              ( prove_naked_immediates_generic env imms1,
+                prove_naked_immediates_generic env imms2 )
+            with
+            | Invalid, _ | _, Invalid -> Invalid
+            | Unknown, _ | _, Unknown -> Unknown
+            | Proved imms1, Proved imms2 -> (
+              let module S = Targetint_31_63.Set in
+              if S.is_empty (S.inter imms1 imms2)
+              then Proved false
+              else
+                match S.get_singleton imms1, S.get_singleton imms2 with
+                | None, _ | _, None -> Unknown
+                | Some imm1, Some imm2 ->
+                  (* We've ruled out the empty intersection case, so the numbers
+                     have to be equal *)
+                  assert (Targetint_31_63.equal imm1 imm2);
+                  Proved true)
+          in
+          let blocks_equality : _ generic_proof =
+            let is_bottom1 = TG.Row_like_for_blocks.is_bottom blocks1 in
+            let is_bottom2 = TG.Row_like_for_blocks.is_bottom blocks2 in
+            if is_bottom1 && is_bottom2
+            then Invalid
+            else if is_bottom1 || is_bottom2
+            then Proved false
+            else
+              match
+                ( TG.Row_like_for_blocks.get_singleton blocks1,
+                  TG.Row_like_for_blocks.get_singleton blocks2 )
+              with
+              | None, _ | _, None -> Unknown
+              | Some ((tag1, size1), _fields1), Some ((tag2, size2), _fields2)
+                ->
+                if Tag.equal tag1 tag2 && Targetint_31_63.equal size1 size2
+                then
+                  (* CR vlaviron and chambart: We could add a special case for
+                     extension constructors, to try to remove dead branches in
+                     try...with handlers *)
+                  Unknown
+                else
+                  (* Different tags or sizes: the blocks can't be physically
+                     equal. *)
+                  Proved false
+          in
+          (* Note: the [Proved true, Proved true] case cannot be converted to
+             [Proved true] *)
+          match immediates_equality, blocks_equality with
+          | Proved b, Invalid | Invalid, Proved b -> Proved b
+          | Proved false, Proved false -> Proved false
+          | _, _ -> Unknown)
+        | _, _, _, _ -> Unknown)
+      (* Boxed numbers with non-numbers or different kinds -> Proved *)
+      | ( Boxed_float _,
+          ( Variant _ | Mutable_block _ | Boxed_int32 _ | Boxed_int64 _
+          | Boxed_nativeint _ | Closures _ | String _ | Array _ ) )
+      | ( ( Variant _ | Mutable_block _ | Boxed_int32 _ | Boxed_int64 _
+          | Boxed_nativeint _ | Closures _ | String _ | Array _ ),
+          Boxed_float _ )
+      | ( Boxed_int32 _,
+          ( Variant _ | Mutable_block _ | Boxed_int64 _ | Boxed_nativeint _
+          | Closures _ | String _ | Array _ ) )
+      | ( ( Variant _ | Mutable_block _ | Boxed_int64 _ | Boxed_nativeint _
+          | Closures _ | String _ | Array _ ),
+          Boxed_int32 _ )
+      | ( Boxed_int64 _,
+          ( Variant _ | Mutable_block _ | Boxed_nativeint _ | Closures _
+          | String _ | Array _ ) )
+      | ( ( Variant _ | Mutable_block _ | Boxed_nativeint _ | Closures _
+          | String _ | Array _ ),
+          Boxed_int64 _ )
+      | ( Boxed_nativeint _,
+          (Variant _ | Mutable_block _ | Closures _ | String _ | Array _) )
+      | ( (Variant _ | Mutable_block _ | Closures _ | String _ | Array _),
+          Boxed_nativeint _ ) ->
+        Proved false
+      (* Closures and non-closures -> Proved *)
+      | Closures _, (Variant _ | Mutable_block _ | String _ | Array _)
+      | (Variant _ | Mutable_block _ | String _ | Array _), Closures _ ->
+        Proved false
+      (* Strings and non-strings -> Proved *)
+      | String _, (Variant _ | Mutable_block _ | Array _)
+      | (Variant _ | Mutable_block _ | Array _), String _ ->
+        Proved false
+      (* Variants, mutable blocks and arrays are allowed to alias to each
+         other *)
+      | ( (Variant _ | Mutable_block _ | Array _),
+          (Variant _ | Mutable_block _ | Array _) ) ->
+        Unknown)
   in
   match TG.get_alias_opt t1, TG.get_alias_opt t2 with
   | Some s1, Some s2 ->
     let const c1 =
       Simple.pattern_match' s2
         ~const:(fun c2 : _ proof_of_property ->
-          if Reg_width_const.equal c1 c2 then Unknown else Proved ())
-        ~symbol:(fun _ ~coercion:_ : _ proof_of_property -> Proved ())
+          if Reg_width_const.equal c1 c2 then Proved true else Proved false)
+        ~symbol:(fun _ ~coercion:_ : _ proof_of_property -> Proved false)
         ~var:(fun _ ~coercion:_ -> check_heads ())
     in
     let symbol sym1 ~coercion:_ =
       Simple.pattern_match' s2
-        ~const:(fun _ : _ proof_of_property -> Proved ())
+        ~const:(fun _ : _ proof_of_property -> Proved false)
         ~symbol:(fun sym2 ~coercion:_ : _ proof_of_property ->
-          if Symbol.equal sym1 sym2 then Unknown else Proved ())
+          if Symbol.equal sym1 sym2 then Proved true else Proved false)
         ~var:(fun _ ~coercion:_ -> check_heads ())
     in
-    let var _ ~coercion:_ = check_heads () in
+    let var var1 ~coercion:_ =
+      Simple.pattern_match' s2
+        ~const:(fun _ -> check_heads ())
+        ~symbol:(fun _ ~coercion:_ -> check_heads ())
+        ~var:(fun var2 ~coercion:_ : _ proof_of_property ->
+          if Variable.equal var1 var2 then Proved true else check_heads ())
+    in
     Simple.pattern_match' s1 ~const ~symbol ~var
   | None, Some _ | Some _, None | None, None -> check_heads ()

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -216,5 +216,5 @@ val prove_alloc_mode_of_boxed_number :
 val never_holds_locally_allocated_values :
   Typing_env.t -> Variable.t -> Flambda_kind.t -> unit proof_of_property
 
-val prove_physically_not_equal :
-  Typing_env.t -> Type_grammar.t -> Type_grammar.t -> unit proof_of_property
+val prove_physical_equality :
+  Typing_env.t -> Type_grammar.t -> Type_grammar.t -> bool proof_of_property

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -215,3 +215,6 @@ val prove_alloc_mode_of_boxed_number :
 
 val never_holds_locally_allocated_values :
   Typing_env.t -> Variable.t -> Flambda_kind.t -> unit proof_of_property
+
+val prove_physically_not_equal :
+  Typing_env.t -> Type_grammar.t -> Type_grammar.t -> unit proof_of_property


### PR DESCRIPTION
Following an earlier discussion on Slack, here is a draft implementation that simplifies away physical equality checks from values that can not be physically equal.

The first commit implements a basic check that handles comparison between a constant and a symbol, or two different constants, or (this is a bit more risky than the rest) two distinct symbols.
The second commit adds the code for looking at the types themselves, resolving a few more cases (but I expect that only the immediate/block case will be actually useful). It is currently not activated, and I think there's room to discuss whether we want to keep the code or not, and if we do whether we want to add a flag or systematically use it. I'll remove the draft status once we've reached consensus on that.
