### PR TITLE
Backport the main safepoints PRs

### DIFF
--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -239,7 +239,7 @@ method class_of_operation op =
   | Istackoffset _ -> Op_other
   | Iload(_,_,mut) -> Op_load mut
   | Istore(_,_,asg) -> Op_store asg
-  | Ialloc _ -> assert false                   (* treated specially *)
+  | Ialloc _ | Ipoll _ -> assert false     (* treated specially *)
   | Iintop(Icheckbound) -> Op_checkbound
   | Iintop _ -> Op_pure
   | Iintop_imm(Icheckbound, _) -> Op_checkbound
@@ -295,14 +295,14 @@ method private cse n i k =
   | Iop Iopaque ->
       (* Assume arbitrary side effects from Iopaque *)
       self#cse empty_numbering i.next (fun next -> k { i with next; })
-  | Iop (Ialloc _) ->
+  | Iop (Ialloc _) | Iop (Ipoll _) ->
       (* For allocations, we must avoid extending the live range of a
          pseudoregister across the allocation if this pseudoreg
          is a derived heap pointer (a pointer into the heap that does
          not point to the beginning of a Caml block).  PR#6484 is an
          example of this situation.  Such pseudoregs have type [Addr].
          Pseudoregs with types other than [Addr] can be kept.
-         Moreover, allocation can trigger the asynchronous execution
+         Moreover, allocations and polls can trigger the asynchronous execution
          of arbitrary Caml code (finalizer, signal handler, context
          switch), which can contain non-initializing stores.
          Hence, all equations over mutable loads must be removed. *)

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -49,7 +49,7 @@ method! class_of_operation op =
   | Istackoffset _ | Iload _ | Istore _ | Ialloc _
   | Iintop _ | Iintop_imm _
   | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _ | Iopaque
-  | Ibeginregion | Iendregion
+  | Ibeginregion | Iendregion | Ipoll _
     -> super#class_of_operation op
 
 end

--- a/backend/amd64/cfg_stack_operands.ml
+++ b/backend/amd64/cfg_stack_operands.ml
@@ -237,6 +237,7 @@ let terminator (map : spilled_map) (term : Cfg.terminator Cfg.instruction) =
   | Raise _
   | Switch _
   | Tailcall _
-  | Call_no_return _ ->
+  | Call_no_return _
+  | Poll_and_jump _ ->
     (* no rewrite *)
     May_still_have_spilled_registers

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -850,6 +850,27 @@ let emit_instr fallthrough i =
       local_realloc_sites :=
         { lr_lbl = lbl_call;
           lr_return_lbl = lbl_after_alloc } :: !local_realloc_sites
+  | Lop(Ipoll { return_label }) ->
+      I.cmp (domain_field Domainstate.Domain_young_limit) r15;
+      let gc_call_label = new_label () in
+      let lbl_after_poll = match return_label with
+                  | None -> new_label()
+                  | Some(lbl) -> lbl in
+      let lbl_frame =
+        record_frame_label i.live (Dbg_alloc [])
+      in
+      begin match return_label with
+      | None -> I.jbe (label gc_call_label)
+      | Some return_label -> I.ja (label return_label)
+      end;
+      call_gc_sites :=
+        { gc_lbl = gc_call_label;
+          gc_return_lbl = lbl_after_poll;
+          gc_frame = lbl_frame; } :: !call_gc_sites;
+      begin match return_label with
+      | None -> def_label lbl_after_poll
+      | Some _ -> I.jmp (label gc_call_label)
+      end
   | Lop(Iintop(Icomp cmp)) ->
       I.cmp (arg i 1) (arg i 0);
       I.set (cond cmp) al;
@@ -1138,7 +1159,8 @@ let emit_instr fallthrough i =
 
       begin match system with
       | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
-      | S_macosx | S_win64 -> () (* with LLVM/OS X and MASM, use the text segment *)
+      | S_macosx | S_win64 -> ()
+        (* with LLVM/OS X and MASM, use the text segment *)
       | _ -> D.section [".rodata"] None []
       end;
       D.align ~data:true 4;

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -438,12 +438,13 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   match terminator with
   | Never -> assert false
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-  | Return | Raise _ | Tailcall _ | Poll_and_jump _ ->
+  | Return | Raise _ | Tailcall _ ->
     if fp then [| rbp |] else [||]
   | Switch _ ->
     [| rax; rdx |]
   | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; } ->
     if alloc then all_phys_regs else destroyed_at_c_call
+  | Poll_and_jump _ -> destroyed_at_alloc_or_poll
 
 (* Maximal register pressure *)
 

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -383,7 +383,7 @@ let destroyed_at_reloadretaddr = [| |]
 let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   match basic with
   | Call (P (Alloc _)) ->
-    destroyed_at_alloc
+    destroyed_at_alloc_or_poll
   | Reloadretaddr ->
     destroyed_at_reloadretaddr
   | Pushtrap _ ->
@@ -438,7 +438,7 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   match terminator with
   | Never -> assert false
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-  | Return | Raise _ | Tailcall _ ->
+  | Return | Raise _ | Tailcall _ | Poll_and_jump _ ->
     if fp then [| rbp |] else [||]
   | Switch _ ->
     [| rax; rdx |]

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -159,7 +159,7 @@ method! reload_operation op arg res =
   | Itailcall_ind|Itailcall_imm _|Iextcall _|Istackoffset _|Iload (_, _, _)
   | Istore (_, _, _)|Ialloc _|Iname_for_debugger _|Iprobe _|Iprobe_is_enabled _
   | Ivalueofint | Iintofvalue | Iopaque
-  | Ibeginregion | Iendregion
+  | Ibeginregion | Iendregion | Ipoll _
     -> (* Other operations: all args and results in registers,
           except moves and probes. *)
       super#reload_operation op arg res

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -158,7 +158,7 @@ let pseudoregs_for_operation op arg res =
   | Iconst_symbol _|Icall_ind|Icall_imm _|Itailcall_ind|Itailcall_imm _
   | Iextcall _|Istackoffset _|Iload (_, _, _) | Istore (_, _, _)|Ialloc _
   | Iname_for_debugger _|Iprobe _|Iprobe_is_enabled _ | Iopaque
-  | Ibeginregion | Iendregion
+  | Ibeginregion | Iendregion | Ipoll _
     -> raise Use_default
 
 let select_locality (l : Cmm.prefetch_temporal_locality_hint)
@@ -418,4 +418,5 @@ method! insert_op_debug env op dbg rs rd =
 
 end
 
-let fundecl f = (new selector)#emit_fundecl f
+let fundecl ~future_funcnames f =
+  (new selector)#emit_fundecl ~future_funcnames f

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -44,6 +44,7 @@ type cmm_label = int
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
 type specific_operation =
+  | Ifar_poll of { return_label: cmm_label option }
   | Ifar_alloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo }
   | Ifar_intop_checkbound
   | Ifar_intop_imm_checkbound of { bound : int; }
@@ -112,6 +113,8 @@ let int_of_bswap_bitwidth = function
 
 let print_specific_operation printreg op ppf arg =
   match op with
+  | Ifar_poll _ ->
+    fprintf ppf "(far) poll"
   | Ifar_alloc { bytes; } ->
     fprintf ppf "(far) alloc %i" bytes
   | Ifar_intop_checkbound ->
@@ -228,7 +231,7 @@ let equal_specific_operation left right =
     Int.equal (int_of_bswap_bitwidth left) (int_of_bswap_bitwidth right)
   | Imove32, Imove32 -> true
   | Isignext left, Isignext right -> Int.equal left right
-  | (Ifar_alloc _  | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
+  | (Ifar_alloc _  | Ifar_poll _ | Ifar_intop_checkbound | Ifar_intop_imm_checkbound _
     | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _
     | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
     | Inegmulsubf | Isqrtf | Ibswap _ | Imove32 | Isignext _), _ -> false
@@ -304,7 +307,7 @@ let is_logical_immediate x =
 (* Specific operations that are pure *)
 
 let operation_is_pure : specific_operation -> bool = function
-  | Ifar_alloc _ -> false
+  | Ifar_alloc _ | Ifar_poll _ -> false
   | Ifar_intop_checkbound -> false
   | Ifar_intop_imm_checkbound _ -> false
   | Ishiftarith _ -> true
@@ -326,6 +329,7 @@ let operation_is_pure : specific_operation -> bool = function
 
 let operation_can_raise = function
   | Ifar_alloc _
+  | Ifar_poll _
   | Ifar_intop_checkbound
   | Ifar_intop_imm_checkbound _
   | Ishiftcheckbound _

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -397,6 +397,8 @@ let num_call_gc_and_check_bound_points instr =
     | Lend -> totals
     | Lop (Ialloc _) when !fastcode_flag ->
       loop instr.next (call_gc + 1, check_bound)
+    | Lop (Ipoll _) ->
+      loop instr.next (call_gc + 1, check_bound)
     | Lop (Iintop Icheckbound)
     | Lop (Iintop_imm (Icheckbound, _))
     | Lop (Ispecific (Ishiftcheckbound _)) ->
@@ -409,6 +411,7 @@ let num_call_gc_and_check_bound_points instr =
     (* The following four should never be seen, since this function is run
        before branch relaxation. *)
     | Lop (Ispecific (Ifar_alloc _))
+    | Lop (Ispecific (Ifar_poll _))
     | Lop (Ispecific Ifar_intop_checkbound)
     | Lop (Ispecific (Ifar_intop_imm_checkbound _))
     | Lop (Ispecific (Ifar_shiftcheckbound _)) -> assert false
@@ -455,6 +458,7 @@ module BR = Branch_relaxation.Make (struct
 
     let classify_instr = function
       | Lop (Ialloc _)
+      | Lop (Ipoll _)
       | Lop (Iintop Icheckbound)
       | Lop (Iintop_imm (Icheckbound, _))
       | Lop (Ispecific (Ishiftcheckbound _)) -> Some Bcc
@@ -502,6 +506,8 @@ module BR = Branch_relaxation.Make (struct
       based + begin match size with Single -> 2 | _ -> 1 end
     | Lop (Ialloc _) when !fastcode_flag -> 5
     | Lop (Ispecific (Ifar_alloc _)) when !fastcode_flag -> 6
+    | Lop (Ipoll _) -> 3
+    | Lop (Ispecific (Ifar_poll _)) -> 4
     | Lop (Ialloc { bytes = num_bytes; _ })
     | Lop (Ispecific (Ifar_alloc { bytes = num_bytes; _ })) ->
       begin match num_bytes with
@@ -567,6 +573,9 @@ module BR = Branch_relaxation.Make (struct
       | Lambda.Raise_notrace -> 4
       end
 
+  let relax_poll ~return_label =
+    Lop (Ispecific (Ifar_poll { return_label }))
+
   let relax_allocation ~num_bytes ~dbginfo =
     Lop (Ispecific (Ifar_alloc { bytes = num_bytes; dbginfo }))
 
@@ -623,6 +632,40 @@ let assembly_code_for_allocation i ~n ~far ~dbginfo =
     end;
     `{emit_label lbl_frame}:	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`
   end
+
+let assembly_code_for_poll i ~far ~return_label =
+  let lbl_frame = record_frame_label i.live (Dbg_alloc []) in
+  let lbl_call_gc = new_label() in
+  let lbl_after_poll = match return_label with
+  | None -> new_label()
+  | Some lbl -> lbl in
+  let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
+    `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`;
+    `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp1}\n`;
+  if not far then begin
+    match return_label with
+    | None ->
+        `	b.ls	{emit_label lbl_call_gc}\n`;
+        `{emit_label lbl_after_poll}:\n`
+    | Some return_label ->
+        `	b.hi	{emit_label return_label}\n`;
+        `	b	{emit_label lbl_call_gc}\n`;
+  end else begin
+    match return_label with
+    | None ->
+        `	b.hi	{emit_label lbl_after_poll}\n`;
+        `	b	{emit_label lbl_call_gc}\n`;
+        `{emit_label lbl_after_poll}:\n`
+    | Some return_label ->
+        let lbl = new_label () in
+        `	b.ls	{emit_label lbl}\n`;
+        `	b	{emit_label return_label}\n`;
+        `{emit_label lbl}:	b	{emit_label lbl_call_gc}\n`
+  end;
+  call_gc_sites :=
+    { gc_lbl = lbl_call_gc;
+      gc_return_lbl = lbl_after_poll;
+      gc_frame_lbl = lbl_frame; } :: !call_gc_sites
 
 (* Output .text section directive, or named .text.caml.<name> if enabled. *)
 
@@ -794,6 +837,10 @@ let emit_instr i =
         assembly_code_for_allocation i ~n ~far:true ~dbginfo
     | Lop(Ialloc { mode = Alloc_local } | Ibeginregion | Iendregion) ->
        Misc.fatal_error "Local allocations not supported on this architecture"
+    | Lop(Ipoll { return_label }) ->
+        assembly_code_for_poll i ~far:false ~return_label
+    | Lop(Ispecific (Ifar_poll { return_label })) ->
+        assembly_code_for_poll i ~far:true ~return_label
     | Lop(Iintop_imm(Iadd, n)) ->
         emit_addimm i.res.(0) i.arg.(0) n
     | Lop(Iintop_imm(Isub, n)) ->

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -288,6 +288,8 @@ let destroyed_at_reloadretaddr = [| |]
 
 let destroyed_at_pushtrap = [| |]
 
+let destroyed_at_alloc_or_poll = [| reg_x8 |]
+
 (* note: keep this function in sync with `destroyed_at_oper` above. *)
 let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   match basic with
@@ -296,7 +298,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Call (F (Indirect | Direct _)) ->
     all_phys_regs
   | Call (P (Alloc _)) ->
-    [| reg_x8 |]
+    destroyed_at_alloc_or_poll
   | Reloadretaddr ->
     destroyed_at_reloadretaddr
   | Pushtrap _ ->
@@ -318,6 +320,7 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
     [||]
   | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; } ->
     if alloc then all_phys_regs else destroyed_at_c_call
+  | Poll_and_jump _ -> destroyed_at_alloc_or_poll
 
 (* Maximal register pressure *)
 

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -275,7 +275,7 @@ let destroyed_at_oper = function
       all_phys_regs
   | Iop(Iextcall { alloc = false; }) ->
       destroyed_at_c_call
-  | Iop(Ialloc _) ->
+  | Iop(Ialloc _) | Iop(Ipoll _) ->
       [| reg_x8 |]
   | Iop( Iintoffloat | Ifloatofint
        | Iload(Single, _, _) | Istore(Single, _, _)) ->
@@ -323,12 +323,12 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
 
 let safe_register_pressure = function
   | Iextcall _ -> 7
-  | Ialloc _ -> 22
+  | Ialloc _ | Ipoll _ -> 22
   | _ -> 23
 
 let max_register_pressure = function
   | Iextcall _ -> [| 7; 8 |]  (* 7 integer callee-saves, 8 FP callee-saves *)
-  | Ialloc _ -> [| 22; 32 |]
+  | Ialloc _ | Ipoll _ -> [| 22; 32 |]
   | Iintoffloat | Ifloatofint
   | Iload(Single, _, _) | Istore(Single, _, _) -> [| 23; 31 |]
   | _ -> [| 23; 32 |]

--- a/backend/arm64/selection.ml
+++ b/backend/arm64/selection.ml
@@ -214,4 +214,5 @@ method! insert_move_extcall_arg env ty_arg src dst =
   else self#insert_moves env src dst
 end
 
-let fundecl f = (new selector)#emit_fundecl f
+let fundecl ~future_funcnames f = (new selector)#emit_fundecl
+                                            ~future_funcnames f

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -25,6 +25,8 @@ open Cmm
 
 open Dwarf_ocaml
 
+module String = Misc.Stdlib.String
+
 type error =
   | Assembler_error of string
   | Mismatched_for_pack of Compilation_unit.Prefix.t
@@ -345,12 +347,13 @@ let register_allocator : register_allocator =
     | "" | "upstream" -> Upstream
     | _ -> Misc.fatal_errorf "unknown register allocator %S" id
 
-let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
+let compile_fundecl ?dwarf ~ppf_dump ~funcnames fd_cmm =
   Proc.init ();
   Reg.reset();
   fd_cmm
   ++ Profile.record ~accumulate:true "cmm_invariants" (cmm_invariants ppf_dump)
-  ++ Profile.record ~accumulate:true "selection" Selection.fundecl
+  ++ Profile.record ~accumulate:true "selection"
+       (Selection.fundecl ~future_funcnames:funcnames)
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_sel
   ++ pass_dump_if ppf_dump dump_selection "After instruction selection"
   ++ Profile.record ~accumulate:true "save_mach_as_cfg" (save_mach_as_cfg Compiler_pass.Selection)
@@ -391,6 +394,8 @@ let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
           ++ Profile.record ~accumulate:true "liveness" liveness
           ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl
           ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_live
+          ++ Profile.record ~accumulate:true "polling"
+               (Polling.instrument_fundecl ~future_funcnames:funcnames)
           ++ pass_dump_if ppf_dump dump_live "Liveness analysis"
           ++ Profile.record ~accumulate:true "spill" Spill.fundecl
           ++ Profile.record ~accumulate:true "liveness" liveness
@@ -435,12 +440,31 @@ let compile_data dl =
   ++ save_data
   ++ emit_data
 
-let compile_phrase ?dwarf ~ppf_dump p =
-  if !dump_cmm then fprintf ppf_dump "%a@." Printcmm.phrase p;
-  match p with
-  | Cfunction fd -> compile_fundecl ?dwarf ~ppf_dump fd
-  | Cdata dl -> compile_data dl
+let compile_phrases ?dwarf ~ppf_dump ps =
+    let funcnames =
+      List.fold_left (fun s p ->
+          match p with
+          | Cfunction fd -> String.Set.add fd.fun_name s
+          | Cdata _ -> s)
+        String.Set.empty ps
+    in
+    let rec compile ~funcnames ps =
+      match ps with
+      | [] -> ()
+      | p :: ps ->
+          if !dump_cmm then fprintf ppf_dump "%a@." Printcmm.phrase p;
+          match p with
+          | Cfunction fd ->
+            compile_fundecl ?dwarf ~ppf_dump ~funcnames fd;
+            compile ~funcnames:(String.Set.remove fd.fun_name funcnames) ps
+          | Cdata dl ->
+            compile_data dl;
+            compile ~funcnames ps
+    in
+    compile ~funcnames ps
 
+let compile_phrase ?dwarf ~ppf_dump p =
+  compile_phrases ?dwarf ~ppf_dump [p]
 
 (* For the native toplevel: generates generic functions unless
    they are already available in the process *)
@@ -589,7 +613,7 @@ let end_gen_implementation0 unix ?toplevel ~ppf_dump ~sourcefile make_cmm =
   in
   make_cmm ()
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cmm
-  ++ Profile.record "compile_phrases" (List.iter (compile_phrase ?dwarf ~ppf_dump))
+  ++ Profile.record "compile_phrases" (compile_phrases ?dwarf ~ppf_dump)
   ++ (fun () -> ());
   (match toplevel with None -> () | Some f -> compile_genfuns ~ppf_dump f);
   (* We add explicit references to external primitive symbols.  This

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -356,7 +356,11 @@ let compile_fundecl ?dwarf ~ppf_dump ~funcnames fd_cmm =
        (Selection.fundecl ~future_funcnames:funcnames)
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_sel
   ++ pass_dump_if ppf_dump dump_selection "After instruction selection"
-  ++ Profile.record ~accumulate:true "save_mach_as_cfg" (save_mach_as_cfg Compiler_pass.Selection)
+  ++ Profile.record ~accumulate:true "save_mach_as_cfg"
+       (save_mach_as_cfg Compiler_pass.Selection)
+  ++ Profile.record ~accumulate:true "polling"
+       (Polling.instrument_fundecl ~future_funcnames:funcnames)
+  ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_polling
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_combine
   ++ pass_dump_if ppf_dump dump_combine "After allocation combining"

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -398,8 +398,6 @@ let compile_fundecl ?dwarf ~ppf_dump ~funcnames fd_cmm =
           ++ Profile.record ~accumulate:true "liveness" liveness
           ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl
           ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_live
-          ++ Profile.record ~accumulate:true "polling"
-               (Polling.instrument_fundecl ~future_funcnames:funcnames)
           ++ pass_dump_if ppf_dump dump_live "Liveness analysis"
           ++ Profile.record ~accumulate:true "spill" Spill.fundecl
           ++ Profile.record ~accumulate:true "liveness" liveness

--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -51,6 +51,7 @@ module Make (T : Branch_relaxation_intf.S) = struct
       in
       match instr.desc with
       | Lop (Ialloc _)
+      | Lop (Ipoll { return_label = None })
       | Lop (Iintop (Icheckbound))
       | Lop (Iintop_imm (Icheckbound, _))
       | Lop (Ispecific _) ->
@@ -64,6 +65,11 @@ module Make (T : Branch_relaxation_intf.S) = struct
         opt_branch_overflows map pc lbl0 max_branch_offset
           || opt_branch_overflows map pc lbl1 max_branch_offset
           || opt_branch_overflows map pc lbl2 max_branch_offset
+      | Lop (Ipoll { return_label = Some lbl }) ->
+        (* A poll-and-branch instruction can branch to the label lbl,
+           but also to an out-of-line code block. *)
+        code_size + max_out_of_line_code_offset - pc >= max_branch_offset
+        || branch_overflows map pc lbl max_branch_offset
       | _ ->
         Misc.fatal_error "Unsupported instruction for branch relaxation"
 
@@ -86,6 +92,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
           fixup did_fix (pc + T.instr_size instr.desc) instr.next
         else
           match instr.desc with
+          | Lop (Ipoll { return_label }) ->
+            instr.desc <- T.relax_poll ~return_label;
+            fixup true (pc + T.instr_size instr.desc) instr.next
           | Lop (Ialloc { bytes = num_bytes; dbginfo }) ->
             instr.desc <- T.relax_allocation ~num_bytes ~dbginfo;
             fixup true (pc + T.instr_size instr.desc) instr.next

--- a/backend/branch_relaxation_intf.ml
+++ b/backend/branch_relaxation_intf.ml
@@ -39,6 +39,7 @@ module type S = sig
 
        N.B. The only instructions supported are the following:
                 - Lop (Ialloc _)
+                - Lop (Ipoll _)
                 - Lop (Iintop Icheckbound)
                 - Lop (Iintop_imm (Icheckbound, _))
                 - Lop (Ispecific _)
@@ -64,6 +65,11 @@ module type S = sig
      : num_bytes:int
     -> dbginfo:Debuginfo.alloc_dbginfo
     -> Linear.instruction_desc
+
+  val relax_poll
+     : return_label:Cmm.label option
+    -> Linear.instruction_desc
+
   val relax_intop_checkbound
      : unit
     -> Linear.instruction_desc

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -82,6 +82,7 @@ let successor_labels_normal ti =
     |> Label.Set.add uo
   | Int_test { lt; gt; eq; imm = _; is_signed = _ } ->
     Label.Set.singleton lt |> Label.Set.add gt |> Label.Set.add eq
+  | Poll_and_jump return_label -> Label.Set.singleton return_label
 
 let successor_labels ~normal ~exn block =
   match normal, exn with
@@ -126,6 +127,7 @@ let replace_successor_labels t ~normal ~exn block ~f =
       | Float_test { lt; eq; gt; uo } ->
         Float_test { lt = f lt; eq = f eq; gt = f gt; uo = f uo }
       | Switch labels -> Switch (Array.map f labels)
+      | Poll_and_jump return_label -> Poll_and_jump (f return_label)
       | Tailcall (Self { destination }) ->
         Tailcall (Self { destination = f destination })
       | Tailcall (Func Indirect)
@@ -316,6 +318,8 @@ let dump_terminator' ?(print_reg = Printmach.reg) ?(args = [||]) ?(sep = "\n")
   | Raise _ -> fprintf ppf "Raise%a" print_args args
   | Tailcall (Self _) -> fprintf ppf "Tailcall self%a" print_args args
   | Tailcall (Func _) -> fprintf ppf "Tailcall%a" print_args args
+  | Poll_and_jump return_label ->
+    Format.fprintf ppf "@[(poll_and_jump %a)@]" Label.print return_label
 
 let dump_terminator ?sep ppf terminator = dump_terminator' ?sep ppf terminator
 
@@ -351,7 +355,7 @@ let print_instruction ppf i = print_instruction' ppf i
 
 let can_raise_terminator (i : terminator) =
   match i with
-  | Raise _ | Tailcall (Func _) | Call_no_return _ -> true
+  | Raise _ | Tailcall (Func _) | Call_no_return _ | Poll_and_jump _ -> true
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Switch _ | Return
   | Tailcall (Self _) ->
@@ -402,7 +406,7 @@ let can_raise_basic : basic -> bool = function
    moment, which we might want to reconsider later. *)
 let is_pure_terminator desc =
   match (desc : terminator) with
-  | Raise _ | Call_no_return _ | Tailcall _ | Return -> false
+  | Raise _ | Call_no_return _ | Tailcall _ | Return | Poll_and_jump _ -> false
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Switch _ ->
     (* CR gyorsh: fix for memory operands *)

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -319,7 +319,7 @@ let dump_terminator' ?(print_reg = Printmach.reg) ?(args = [||]) ?(sep = "\n")
   | Tailcall (Self _) -> fprintf ppf "Tailcall self%a" print_args args
   | Tailcall (Func _) -> fprintf ppf "Tailcall%a" print_args args
   | Poll_and_jump return_label ->
-    Format.fprintf ppf "@[(poll_and_jump %a)@]" Label.print return_label
+    Format.fprintf ppf "Poll_and_jump %a" Label.print return_label
 
 let dump_terminator ?sep ppf terminator = dump_terminator' ?sep ppf terminator
 

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -488,6 +488,9 @@ let check_terminator_instruction :
     check_tail_call_operation state location tc1 tc2
   | Call_no_return cn1, Call_no_return cn2 ->
     check_external_call_operation location cn1 cn2
+  | Poll_and_jump return_label1, Poll_and_jump return_label2
+    when Label.equal return_label1 return_label2 ->
+    ()
   | _ -> different location "terminator");
   (* CR xclerc for xclerc: temporary, for testing *)
   let check_arg =

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -494,7 +494,8 @@ let check_terminator_instruction :
     match expected.desc with
     | Always _ -> false
     | Never | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-    | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _ ->
+    | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _
+    | Poll_and_jump _ ->
       true
   in
   check_instruction ~check_live:false ~check_dbg:false ~check_arg (-1) location

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -182,6 +182,7 @@ module S = struct
     | Raise of Lambda.raise_kind
     | Tailcall of tail_call_operation
     | Call_no_return of external_call_operation
+    | Poll_and_jump of Label.t
 end
 
 (* CR-someday gyorsh: Switch can be translated to Branch. *)

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -92,7 +92,7 @@ module Transfer :
     | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
     | Switch _ | Return | Raise _
     | Tailcall (Func _)
-    | Call_no_return _ ->
+    | Call_no_return _ | Poll_and_jump _ ->
       instruction
         ~can_raise:(Cfg.can_raise_terminator instr.desc)
         ~exn domain instr

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -354,10 +354,9 @@ let add_terminator t (block : C.basic_block) (i : L.instruction)
      fallthroughs in Linear. *)
   (match desc with
   | Never -> Misc.fatal_error "Cannot add terminator: Never"
-  | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+  | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _ -> ()
+  | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _
   | Poll_and_jump _ ->
-    ()
-  | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _ ->
     if not (Linear_utils.defines_label i.next)
     then
       Misc.fatal_errorf "Linear instruction not followed by label:@ %a"

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -354,9 +354,10 @@ let add_terminator t (block : C.basic_block) (i : L.instruction)
      fallthroughs in Linear. *)
   (match desc with
   | Never -> Misc.fatal_error "Cannot add terminator: Never"
-  | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _ -> ()
-  | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _
+  | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Poll_and_jump _ ->
+    ()
+  | Switch _ | Return | Raise _ | Tailcall _ | Call_no_return _ ->
     if not (Linear_utils.defines_label i.next)
     then
       Misc.fatal_errorf "Linear instruction not followed by label:@ %a"

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -101,13 +101,13 @@ let block (block : C.basic_block) =
   | Call_no_return _
   | Tailcall (Self _ | Func _)
   | Raise _ | Return | Poll_and_jump _ ->
-  (* CR xclerc: I wonder whether Merge_straightline_block should be updated
-to optimize a Poll_and_jump block where block is empty, and
-has a terminator such as Always block'.
+    (* CR xclerc: I wonder whether Merge_straightline_block should be updated to
+       optimize a Poll_and_jump block where block is empty, and has a terminator
+       such as Always block'.
 
-(Note that the blocks are currently and correctly not merged
-because Poll_and_jump block can raise. The optimization I
-suggest would be to rewrite it to Poll_and_jump block'.) *)
+       (Note that the blocks are currently and correctly not merged because
+       Poll_and_jump block can raise. The optimization I suggest would be to
+       rewrite it to Poll_and_jump block'.) *)
     ()
 
 let run cfg = C.iter_blocks cfg ~f:(fun _ b -> block b)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -101,6 +101,13 @@ let block (block : C.basic_block) =
   | Call_no_return _
   | Tailcall (Self _ | Func _)
   | Raise _ | Return | Poll_and_jump _ ->
+  (* CR xclerc: I wonder whether Merge_straightline_block should be updated
+to optimize a Poll_and_jump block where block is empty, and
+has a terminator such as Always block'.
+
+(Note that the blocks are currently and correctly not merged
+because Poll_and_jump block can raise. The optimization I
+suggest would be to rewrite it to Poll_and_jump block'.) *)
     ()
 
 let run cfg = C.iter_blocks cfg ~f:(fun _ b -> block b)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -98,6 +98,9 @@ let block (block : C.basic_block) =
       let l = Label.Set.min_elt labels in
       block.terminator <- { block.terminator with desc = Always l }
   | Switch labels -> simplify_switch block labels
-  | Call_no_return _ | Tailcall (Self _ | Func _) | Raise _ | Return -> ()
+  | Call_no_return _
+  | Tailcall (Self _ | Func _)
+  | Raise _ | Return | Poll_and_jump _ ->
+    ()
 
 let run cfg = C.iter_blocks cfg ~f:(fun _ b -> block b)

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -335,7 +335,11 @@ end = struct
       report_fail t "checkbound" dbg
     | Ialloc { mode = Alloc_local; _ } -> ()
     | Ialloc { mode = Alloc_heap; _ } -> report_fail t "allocation" dbg
-    | Ipoll _ -> report_fail t "polling point" dbg
+    | Ipoll _ ->
+      (* Polling points may trigger finalisers, signal handlers or memprof
+         callbacks, but any allocations done therein don't count towards the
+         calling function being "allocating". *)
+      ()
     | Iprobe { name; handler_code_sym } ->
       let desc = Printf.sprintf "probe %s handler %s" name handler_code_sym in
       check_call t handler_code_sym ~desc dbg

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -335,6 +335,7 @@ end = struct
       report_fail t "checkbound" dbg
     | Ialloc { mode = Alloc_local; _ } -> ()
     | Ialloc { mode = Alloc_heap; _ } -> report_fail t "allocation" dbg
+    | Ipoll _ -> report_fail t "polling point" dbg
     | Iprobe { name; handler_code_sym } ->
       let desc = Printf.sprintf "probe %s handler %s" name handler_code_sym in
       check_call t handler_code_sym ~desc dbg

--- a/backend/comballoc.ml
+++ b/backend/comballoc.ml
@@ -71,7 +71,7 @@ let rec combine i allocstate =
           i.arg i.res i.dbg next, allocstate)
       end
   | Iop(Icall_ind | Icall_imm _ | Iextcall _ |
-        Itailcall_ind | Itailcall_imm _ | Iprobe _ |
+        Itailcall_ind | Itailcall_imm _ | Ipoll _ | Iprobe _ |
         Iintop Icheckbound | Iintop_imm (Icheckbound, _)) ->
       let newnext = combine_restart i.next in
       (instr_cons_debug i.desc i.arg i.res i.dbg newnext,

--- a/backend/dataflow.ml
+++ b/backend/dataflow.ml
@@ -24,7 +24,7 @@ end
 
 module Backward(D: DOMAIN) = struct
 
-let analyze ?(exnhandler = fun x -> x) ~transfer instr =
+let analyze ?(exnhandler = fun x -> x) ?(exnescape = D.bot) ~transfer instr =
 
   let lbls =
     (Hashtbl.create 20 : (int, D.t) Hashtbl.t) in
@@ -80,7 +80,7 @@ let analyze ?(exnhandler = fun x -> x) ~transfer instr =
     | Iraise _ ->
         transfer i ~next:D.bot ~exn
   in
-    let b = before D.bot D.bot instr in
+    let b = before D.bot exnescape instr in
     (b, get_lbl)
 
 end

--- a/backend/dataflow.mli
+++ b/backend/dataflow.mli
@@ -28,6 +28,7 @@ end
 module Backward(D: DOMAIN) : sig
 
   val analyze: ?exnhandler: (D.t -> D.t) ->
+               ?exnescape: D.t ->
                transfer: (Mach.instruction -> next: D.t -> exn: D.t -> D.t) ->
                Mach.instruction ->
                D.t * (int -> D.t)
@@ -80,6 +81,10 @@ module Backward(D: DOMAIN) : sig
      the beginning of the handler and removes the register
      [Proc.loc_exn_bucket] that carries the exception value.  If not
      specified, [exnhandler] defaults to the identity function.
+
+     The optional [exnescape] argument deals with unhandled exceptions.
+     It is the abstract state corresponding to exiting the function on an
+     unhandled exception.  It defaults to [D.bot].
   *)
 
 end

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -45,7 +45,8 @@ and instruction_desc =
 
 let has_fallthrough = function
   | Lreturn | Lbranch _ | Lswitch _ | Lraise _
-  | Lop Itailcall_ind | Lop (Itailcall_imm _) -> false
+  | Lop Itailcall_ind | Lop (Itailcall_imm _)
+  | Lop (Ipoll { return_label = Some _ }) -> false
   | _ -> true
 
 type fundecl =

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -168,6 +168,19 @@ let linear i n contains_calls =
     | Iop(Imove | Ireload | Ispill)
       when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
         linear env i.Mach.next n
+    | Iop((Ipoll { return_label = None; _ }) as op) ->
+        (* If the poll call does not already specify where to jump to after
+           the poll (the expected situation in the current implementation),
+           absorb any branch after the poll call into the poll call itself.
+           This, in particular, optimises polls at the back edges of loops. *)
+        let n = linear env i.Mach.next n in
+        let op, n =
+          match n.desc with
+          | Lbranch lbl ->
+            Mach.Ipoll { return_label = Some lbl }, n.next
+          | _ -> op, n
+        in
+        copy_instr (Lop op) i n
     | Iop op ->
         copy_instr (Lop op) i (linear env i.Mach.next n)
     | Ireturn traps ->

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -209,7 +209,7 @@ let operation_can_raise op =
   match op with
   | Icall_ind | Icall_imm _ | Iextcall _
   | Iintop (Icheckbound) | Iintop_imm (Icheckbound, _)
-  | Iprobe _ | Ipoll _ -> true
+  | Iprobe _ -> true
   | Ispecific sop -> Arch.operation_can_raise sop
   | Iintop_imm((Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
                | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _|Ictz _|Icomp _), _)
@@ -222,7 +222,7 @@ let operation_can_raise op =
   | Istackoffset _ | Istore _  | Iload (_, _, _) | Iname_for_debugger _
   | Itailcall_imm _ | Itailcall_ind
   | Iopaque | Ibeginregion | Iendregion
-  | Iprobe_is_enabled _ | Ialloc _
+  | Iprobe_is_enabled _ | Ialloc _ | Ipoll _
     -> false
 
 let free_conts_for_handlers fundecl =

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -73,6 +73,7 @@ type operation =
   | Ivalueofint | Iintofvalue
   | Iopaque
   | Ispecific of Arch.specific_operation
+  | Ipoll of { return_label: Cmm.label option }
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
       provenance : unit option; is_assignment : bool; }
   | Iprobe of { name: string; handler_code_sym: string; }
@@ -179,12 +180,12 @@ let rec instr_iter f i =
             | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue
             | Ispecific _ | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _
             | Iopaque
-            | Ibeginregion | Iendregion) ->
+            | Ibeginregion | Iendregion | Ipoll _) ->
         instr_iter f i.next
 
 let operation_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
+  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _ | Ipoll _
   | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque
   (* Conservative to ensure valueofint/intofvalue are not eliminated before emit. *)
   | Ivalueofint | Iintofvalue -> false
@@ -208,7 +209,7 @@ let operation_can_raise op =
   match op with
   | Icall_ind | Icall_imm _ | Iextcall _
   | Iintop (Icheckbound) | Iintop_imm (Icheckbound, _)
-  | Iprobe _ -> true
+  | Iprobe _ | Ipoll _ -> true
   | Ispecific sop -> Arch.operation_can_raise sop
   | Iintop_imm((Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
                | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _|Ictz _|Icomp _), _)

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -77,6 +77,7 @@ type operation =
   | Ivalueofint | Iintofvalue
   | Iopaque
   | Ispecific of Arch.specific_operation
+  | Ipoll of { return_label: Cmm.label option }
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
       provenance : unit option; is_assignment : bool; }
     (** [Iname_for_debugger] has the following semantics:

--- a/backend/polling.ml
+++ b/backend/polling.ml
@@ -1,0 +1,243 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*      Xavier Leroy and Damien Doligez, projet Cambium, INRIA Paris      *)
+(*               Sadiq Jaffer, OCaml Labs Consultancy Ltd                 *)
+(*          Stephen Dolan and Mark Shinwell, Jane Street Europe           *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2021 OCaml Labs Consultancy Ltd                            *)
+(*   Copyright 2021 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Mach
+
+module Int = Numbers.Int
+module String = Misc.Stdlib.String
+
+let function_is_assumed_to_never_poll func =
+  String.begins_with ~prefix:"caml_apply" func
+
+(* Detection of recursive handlers that are not guaranteed to poll
+   at every loop iteration. *)
+
+(* We use a backwards dataflow analysis to compute a mapping from handlers H
+   (= loop heads) to either "safe" or "unsafe".
+
+   H is "safe" if every path starting from H goes through an Ialloc,
+   Ipoll, Ireturn, Itailcall_ind or Itailcall_imm instruction.
+
+   H is "unsafe", therefore, if starting from H we can loop infinitely
+   without crossing an Ialloc or Ipoll instruction.
+*)
+
+type unsafe_or_safe = Unsafe | Safe
+
+module Unsafe_or_safe = struct
+  type t = unsafe_or_safe
+
+  let bot = Unsafe
+
+  let join t1 t2 =
+    match t1, t2 with
+    | Unsafe, Unsafe
+    | Unsafe, Safe
+    | Safe, Unsafe -> Unsafe
+    | Safe, Safe -> Safe
+
+  let lessequal t1 t2 =
+    match t1, t2 with
+    | Unsafe, Unsafe
+    | Unsafe, Safe
+    | Safe, Safe -> true
+    | Safe, Unsafe -> false
+end
+
+module PolledLoopsAnalysis = Dataflow.Backward(Unsafe_or_safe)
+
+let polled_loops_analysis funbody =
+  let transfer i ~next ~exn =
+    match i.desc with
+    | Iend -> next
+    | Iop (Ialloc _ | Ipoll _)
+    | Iop (Itailcall_ind | Itailcall_imm _) -> Safe
+    | Iop op ->
+      if operation_can_raise op
+      then Unsafe_or_safe.join next exn
+      else next
+    | Ireturn _ -> Safe
+    | Iifthenelse _ | Iswitch _ | Icatch _ | Iexit _ | Itrywith _ -> next
+    | Iraise _ -> exn
+  in
+  (* [exnescape] is [Safe] because we can't loop infinitely having
+     returned from the function via an unhandled exception. *)
+  snd (PolledLoopsAnalysis.analyze ~exnescape:Safe ~transfer funbody)
+
+(* Detection of functions that can loop via a tail-call without going
+   through a poll point. *)
+
+(* We use a backwards dataflow analysis to compute a single value: either
+   "Might_not_poll" or "Always_polls".
+
+   "Might_not_poll" means there exists a path from the function entry to a
+   Potentially Recursive Tail Call (an Itailcall_ind or
+   Itailcall_imm to a forward function)
+   that does not go through an Ialloc or Ipoll instruction.
+
+   "Always_polls", therefore, means the function always polls (via Ialloc or
+   Ipoll) before doing a PRTC.
+*)
+
+type polls_before_prtc = Might_not_poll | Always_polls
+
+module Polls_before_prtc = struct
+  type t = polls_before_prtc
+
+  let bot = Always_polls
+
+  let join t1 t2 =
+    match t1, t2 with
+    | Might_not_poll, Might_not_poll
+    | Might_not_poll, Always_polls
+    | Always_polls, Might_not_poll -> Might_not_poll
+    | Always_polls, Always_polls -> Always_polls
+
+  let lessequal t1 t2 =
+    match t1, t2 with
+    | Always_polls, Always_polls
+    | Always_polls, Might_not_poll
+    | Might_not_poll, Might_not_poll -> true
+    | Might_not_poll, Always_polls -> false
+end
+
+module PTRCAnalysis = Dataflow.Backward(Polls_before_prtc)
+
+let potentially_recursive_tailcall ~future_funcnames funbody =
+  let transfer i ~next ~exn =
+    match i.desc with
+    | Iend -> next
+    | Iop (Ialloc _ | Ipoll _) -> Always_polls
+    | Iop (Itailcall_ind) -> Might_not_poll
+    | Iop (Itailcall_imm { func }) ->
+      (* We optimise by making a partial ordering over Mach functions: in
+         definition order within a compilation unit, and dependency order
+         between compilation units. This order is acyclic, as OCaml does not
+         allow circular dependencies between modules.  It's also finite, so if
+         there's an infinite sequence of function calls then something has to
+         make a forward reference.
+
+         Also, in such an infinite sequence of function calls, at most finitely
+         many of them can be non-tail calls. (If there are infinitely many
+         non-tail calls, then the program soon terminates with a stack
+         overflow).
+
+         So, every such infinite sequence must contain many forward-referencing
+         tail calls, so polling only on those suffices.  This is checked using
+         the set [future_funcnames]. *)
+      if String.Set.mem func future_funcnames
+         || function_is_assumed_to_never_poll func
+      then Might_not_poll
+      else Always_polls
+    | Iop op ->
+      if operation_can_raise op
+      then Polls_before_prtc.join next exn
+      else next
+    | Ireturn _ -> Always_polls
+    | Iifthenelse _ | Iswitch _ | Icatch _ | Iexit _ | Itrywith _ -> next
+    | Iraise _ -> exn
+  in
+  fst (PTRCAnalysis.analyze ~transfer funbody)
+
+(* We refer to the set of recursive handler labels that need extra polling
+   as the "unguarded back edges" ("ube").
+
+   Given the result of the analysis of recursive handlers, add [Ipoll]
+   instructions at the [Iexit] instructions before unguarded back edges,
+   thus ensuring that every loop contains a poll point.  Also compute whether
+   the resulting function contains any [Ipoll] instructions.
+*)
+
+let contains_polls = ref false
+
+let add_poll i =
+  contains_polls := true;
+  Mach.instr_cons (Iop (Ipoll { return_label = None })) [||] [||] i
+
+let instr_body handler_safe i =
+  let add_unsafe_handler ube (k, _trap_stack, _) =
+    match handler_safe k with
+    | Safe -> ube
+    | Unsafe -> Int.Set.add k ube
+  in
+  let rec instr ube i =
+    match i.desc with
+    | Iifthenelse (test, i0, i1) ->
+      { i with
+        desc = Iifthenelse (test, instr ube i0, instr ube i1);
+        next = instr ube i.next;
+      }
+    | Iswitch (index, cases) ->
+      { i with
+        desc = Iswitch (index, Array.map (instr ube) cases);
+        next = instr ube i.next;
+      }
+    | Icatch (rc, trap_stack, hdl, body) ->
+      let ube' =
+        match rc with
+        | Cmm.Recursive -> List.fold_left add_unsafe_handler ube hdl
+        | Cmm.Nonrecursive -> ube in
+      let instr_handler (k, trap_stack, i0) =
+        let i1 = instr ube' i0 in
+        (k, trap_stack, i1) in
+      (* Since we are only interested in unguarded _back_ edges, we don't
+         use [ube'] for instrumenting [body], but just [ube] instead. *)
+      let body = instr ube body in
+      { i with
+        desc = Icatch (rc,
+                       trap_stack,
+                       List.map instr_handler hdl,
+                       body);
+        next = instr ube i.next;
+      }
+    | Iexit (k, _trap_actions) ->
+      if Int.Set.mem k ube
+      then add_poll i
+      else i
+    | Itrywith (body, kind, (trap_stack, hdl)) ->
+      { i with
+        desc = Itrywith (instr ube body, kind, (trap_stack, instr ube hdl));
+        next = instr ube i.next;
+      }
+    | Iend | Ireturn _ | Iraise _ -> i
+    | Iop op ->
+      begin match op with
+      | Ipoll _ -> contains_polls := true
+      | _ -> ()
+      end;
+      { i with next = instr ube i.next }
+  in
+  instr Int.Set.empty i
+
+let instrument_fundecl ~future_funcnames:_ (f : Mach.fundecl) : Mach.fundecl =
+  if function_is_assumed_to_never_poll f.fun_name then f
+  else begin
+    let handler_needs_poll = polled_loops_analysis f.fun_body in
+    contains_polls := false;
+    let new_body = instr_body handler_needs_poll f.fun_body in
+    let new_contains_calls = f.fun_contains_calls || !contains_polls in
+    { f with fun_body = new_body; fun_contains_calls = new_contains_calls }
+  end
+
+let requires_prologue_poll ~future_funcnames ~fun_name i =
+  if function_is_assumed_to_never_poll fun_name then false
+  else
+    match potentially_recursive_tailcall ~future_funcnames i with
+    | Might_not_poll -> true
+    | Always_polls -> false

--- a/backend/polling.ml
+++ b/backend/polling.ml
@@ -24,6 +24,7 @@ module String = Misc.Stdlib.String
 
 let function_is_assumed_to_never_poll func =
   String.begins_with ~prefix:"caml_apply" func
+  || String.begins_with ~prefix:"caml_send" func
 
 (* Detection of recursive handlers that are not guaranteed to poll
    at every loop iteration. *)

--- a/backend/polling.mli
+++ b/backend/polling.mli
@@ -2,10 +2,14 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*      Xavier Leroy and Damien Doligez, projet Cambium, INRIA Paris      *)
+(*               Sadiq Jaffer, OCaml Labs Consultancy Ltd                 *)
+(*          Stephen Dolan and Mark Shinwell, Jane Street Europe           *)
 (*                                                                        *)
-(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
+(*   Copyright 2021 OCaml Labs Consultancy Ltd                            *)
+(*   Copyright 2021 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,8 +17,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Selection of pseudo-instructions, assignment of pseudo-registers,
-   sequentialization. *)
+(** Analyses related to the insertion of [Ipoll] operations. *)
 
-val fundecl: future_funcnames:Misc.Stdlib.String.Set.t
-    -> Cmm.fundecl -> Mach.fundecl
+val instrument_fundecl : future_funcnames:Misc.Stdlib.String.Set.t
+    -> Mach.fundecl -> Mach.fundecl
+
+val requires_prologue_poll : future_funcnames:Misc.Stdlib.String.Set.t
+    -> fun_name:string -> Mach.instruction -> bool

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -34,7 +34,7 @@ let instr' ?(print_reg = Printmach.reg) ppf i =
       fprintf ppf "prologue"
   | Lop op ->
       begin match op with
-      | Ialloc _ | Icall_ind | Icall_imm _ | Iextcall _ | Iprobe _ ->
+      | Ialloc _ | Ipoll _ | Icall_ind | Icall_imm _ | Iextcall _ | Iprobe _ ->
           fprintf ppf "@[<1>{%a}@]@," regsetaddr i.live
       | _ -> ()
       end;

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -202,6 +202,12 @@ let operation' ?(print_reg = reg) op arg ppf res =
   | Iendregion -> fprintf ppf "endregion %a" reg arg.(0)
   | Ispecific op ->
       Arch.print_specific_operation reg op ppf arg
+  | Ipoll { return_label } ->
+      fprintf ppf "poll call";
+      (match return_label with
+      | None -> ()
+      | Some return_label ->
+        fprintf ppf " returning to L%d" return_label)
   | Iprobe {name;handler_code_sym} ->
     fprintf ppf "probe \"%s\" %s %a" name handler_code_sym regs arg
   | Iprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled \"%s\"" name

--- a/backend/schedgen.ml
+++ b/backend/schedgen.ml
@@ -154,7 +154,7 @@ method oper_in_basic_block = function
   | Itailcall_imm _ -> false
   | Iextcall _ -> false
   | Istackoffset _ -> false
-  | Ialloc _ -> false
+  | Ialloc _ | Ipoll _ -> false
   | Iprobe _ -> false
   | _ -> true
 

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -557,9 +557,9 @@ method mark_instr = function
       self#mark_call
   | Iop (Itailcall_ind | Itailcall_imm _) ->
       self#mark_tailcall
-  | Iop (Ialloc _) ->
-      self#mark_call (* caml_alloc*, caml_garbage_collection *)
-  | Iop (Iintop(Icheckbound) | Iintop_imm(Icheckbound, _)) ->
+  | Iop (Ialloc _) | Iop (Ipoll _) ->
+      self#mark_call (* caml_alloc*, caml_garbage_collection (incl. polls) *)
+  | Iop (Iintop (Icheckbound) | Iintop_imm(Icheckbound, _)) ->
       self#mark_c_tailcall (* caml_ml_array_bound_error *)
   | Iraise raise_kind ->
     begin match raise_kind with
@@ -711,12 +711,15 @@ method insert_debug _env desc dbg arg res =
 method insert _env desc arg res =
   instr_seq <- instr_cons desc arg res instr_seq
 
-method extract =
+method extract_onto o =
   let rec extract res i =
     if i == dummy_instr
-    then res
-    else extract {i with next = res} i.next in
-  extract (end_instr ()) instr_seq
+      then res
+      else extract {i with next = res} i.next in
+    extract o instr_seq
+
+method extract =
+  self#extract_onto (end_instr ())
 
 (* Insert a sequence of moves from one pseudoreg set to another. *)
 
@@ -1535,7 +1538,7 @@ method private emit_tail_sequence env exp =
 
 (* Sequentialization of a function definition *)
 
-method emit_fundecl f =
+method emit_fundecl ~future_funcnames f =
   current_function_name := f.Cmm.fun_name;
   let rargs =
     List.map
@@ -1547,13 +1550,23 @@ method emit_fundecl f =
     List.fold_right2
       (fun (id, _ty) r env -> env_add id r env)
       f.Cmm.fun_args rargs env_empty in
-  self#insert_moves env loc_arg rarg;
   self#emit_tail env f.Cmm.fun_body;
   let body = self#extract in
-  instr_iter (fun instr -> self#mark_instr instr.Mach.desc) body;
+  instr_seq <- dummy_instr;
+  self#insert_moves env loc_arg rarg;
+  let polled_body =
+    if Polling.requires_prologue_poll ~future_funcnames
+         ~fun_name:f.Cmm.fun_name body
+      then
+      instr_cons (Iop(Ipoll { return_label = None })) [||] [||] body
+    else
+      body
+    in
+  let body_with_prologue = self#extract_onto polled_body in
+  instr_iter (fun instr -> self#mark_instr instr.Mach.desc) body_with_prologue;
   { fun_name = f.Cmm.fun_name;
     fun_args = loc_arg;
-    fun_body = body;
+    fun_body = body_with_prologue;
     fun_codegen_options = f.Cmm.fun_codegen_options;
     fun_dbg  = f.Cmm.fun_dbg;
     fun_num_stack_slots = Array.make Proc.num_register_classes 0;

--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -142,12 +142,14 @@ class virtual selector_generic : object
      above; overloading this is useful if Ispecific instructions need
      marking *)
 
-  (* The following method is the entry point and should not be overridden. *)
-  method emit_fundecl : Cmm.fundecl -> Mach.fundecl
+  (* The following method is the entry point and should not be overridden *)
+  method emit_fundecl : future_funcnames:Misc.Stdlib.String.Set.t
+                                              -> Cmm.fundecl -> Mach.fundecl
 
   (* The following methods should not be overridden.  They cannot be
      declared "private" in the current implementation because they
      are not always applied to "self", but ideally they should be private. *)
+  method extract_onto : Mach.instruction -> Mach.instruction
   method extract : Mach.instruction
   method insert :
     environment -> Mach.instruction_desc -> Reg.t array -> Reg.t array -> unit

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -27,6 +27,7 @@ type _ pass =
   | Raw_clambda : Clambda.ulambda pass
   | Clambda : Clambda.ulambda pass
 
+  | Mach_polling : Mach.fundecl pass
   | Mach_combine : Mach.fundecl pass
   | Mach_cse : Mach.fundecl pass
   | Mach_spill : Mach.fundecl pass
@@ -53,6 +54,7 @@ type t = {
   mutable flambda1 : (Flambda.program -> unit) list;
   mutable raw_clambda : (Clambda.ulambda -> unit) list;
   mutable clambda : (Clambda.ulambda -> unit) list;
+  mutable mach_polling : (Mach.fundecl -> unit) list;
   mutable mach_combine : (Mach.fundecl -> unit) list;
   mutable mach_cse : (Mach.fundecl -> unit) list;
   mutable mach_spill : (Mach.fundecl -> unit) list;
@@ -78,6 +80,7 @@ let hooks : t = {
   flambda1 = [];
   raw_clambda = [];
   clambda = [];
+  mach_polling = [];
   mach_combine = [];
   mach_cse = [];
   mach_spill = [];
@@ -111,6 +114,7 @@ let register : type a. a pass -> (a -> unit) -> unit =
   | Clambda -> hooks.clambda <- f :: hooks.clambda
 
   | Mach_combine -> hooks.mach_combine <- f :: hooks.mach_combine
+  | Mach_polling -> hooks.mach_polling <- f :: hooks.mach_polling
   | Mach_cse -> hooks.mach_cse <- f :: hooks.mach_cse
   | Mach_spill -> hooks.mach_spill <- f :: hooks.mach_spill
   | Mach_live -> hooks.mach_live <- f :: hooks.mach_live
@@ -137,6 +141,7 @@ let execute : type a. a pass -> a -> unit =
   | Flambda1 -> execute_hooks hooks.flambda1 arg
   | Raw_clambda -> execute_hooks hooks.raw_clambda arg
   | Clambda -> execute_hooks hooks.clambda arg
+  | Mach_polling -> execute_hooks hooks.mach_polling arg
   | Mach_combine -> execute_hooks hooks.mach_combine arg
   | Mach_cse -> execute_hooks hooks.mach_cse arg
   | Mach_spill -> execute_hooks hooks.mach_spill arg
@@ -165,6 +170,7 @@ let clear : type a. a pass -> unit =
   | Flambda1 -> hooks.flambda1 <- []
   | Raw_clambda -> hooks.raw_clambda <- []
   | Clambda -> hooks.clambda <- []
+  | Mach_polling -> hooks.mach_polling <- []
   | Mach_combine -> hooks.mach_combine <- []
   | Mach_cse -> hooks.mach_cse <- []
   | Mach_spill -> hooks.mach_spill <- []

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -40,6 +40,7 @@ type _ pass =
   | Raw_clambda : Clambda.ulambda pass
   | Clambda : Clambda.ulambda pass
 
+  | Mach_polling : Mach.fundecl pass
   | Mach_combine : Mach.fundecl pass
   | Mach_cse : Mach.fundecl pass
   | Mach_spill : Mach.fundecl pass

--- a/dune
+++ b/dune
@@ -190,6 +190,7 @@
   linscan
   liveness
   mach
+  polling
   printcmm
   printlinear
   printmach
@@ -707,6 +708,7 @@
   (linscan.mli as compiler-libs/linscan.mli)
   (liveness.mli as compiler-libs/liveness.mli)
   (mach.mli as compiler-libs/mach.mli)
+  (polling.mli as compiler-libs/polling.mli)
   (printcmm.mli as compiler-libs/printcmm.mli)
   (printlinear.mli as compiler-libs/printlinear.mli)
   (printmach.mli as compiler-libs/printmach.mli)
@@ -1012,6 +1014,10 @@
   (.ocamloptcomp.objs/byte/opterrors.cmo as compiler-libs/opterrors.cmo)
   (.ocamloptcomp.objs/byte/opterrors.cmt as compiler-libs/opterrors.cmt)
   (.ocamloptcomp.objs/byte/opterrors.cmti as compiler-libs/opterrors.cmti)
+  (.ocamloptcomp.objs/byte/polling.cmi as compiler-libs/polling.cmi)
+  (.ocamloptcomp.objs/byte/polling.cmo as compiler-libs/polling.cmo)
+  (.ocamloptcomp.objs/byte/polling.cmt as compiler-libs/polling.cmt)
+  (.ocamloptcomp.objs/byte/polling.cmti as compiler-libs/polling.cmti)
   (.ocamloptcomp.objs/byte/printcmm.cmi as compiler-libs/printcmm.cmi)
   (.ocamloptcomp.objs/byte/printcmm.cmo as compiler-libs/printcmm.cmo)
   (.ocamloptcomp.objs/byte/printcmm.cmt as compiler-libs/printcmm.cmt)
@@ -1480,6 +1486,7 @@
   (.ocamloptcomp.objs/native/optcompile.cmx as compiler-libs/optcompile.cmx)
   (.ocamloptcomp.objs/native/opterrors.cmx as compiler-libs/opterrors.cmx)
   (.ocamloptcomp.objs/native/printcmm.cmx as compiler-libs/printcmm.cmx)
+  (.ocamloptcomp.objs/native/polling.cmx as compiler-libs/polling.cmx)
   (.ocamloptcomp.objs/native/printlinear.cmx
    as
    compiler-libs/printlinear.cmx)

--- a/ocaml/runtime/caml/domain_state.tbl
+++ b/ocaml/runtime/caml/domain_state.tbl
@@ -14,8 +14,8 @@
 /*                                                                        */
 /**************************************************************************/
 
-DOMAIN_STATE(value*, young_ptr)
 DOMAIN_STATE(value*, young_limit)
+DOMAIN_STATE(value*, young_ptr)
 /* Minor heap limit. See minor_gc.c. */
 
 DOMAIN_STATE(char*, exception_pointer)

--- a/ocaml/runtime/signals_nat.c
+++ b/ocaml/runtime/signals_nat.c
@@ -79,14 +79,23 @@ void caml_garbage_collection(void)
      including allocations combined by Comballoc */
   alloc_len = (unsigned char*)(&d->live_ofs[d->num_live]);
   nallocs = *alloc_len++;
-  for (i = 0; i < nallocs; i++) {
-    allocsz += Whsize_wosize(Wosize_encoded_alloc_len(alloc_len[i]));
-  }
-  /* We have computed whsize (including header), but need wosize (without) */
-  allocsz -= 1;
 
-  caml_alloc_small_dispatch(allocsz, CAML_DO_TRACK | CAML_FROM_CAML,
-                            nallocs, alloc_len);
+  if (nallocs == 0) {
+    /* This is a poll */
+    caml_process_pending_actions();
+  }
+  else
+  {
+    for (i = 0; i < nallocs; i++) {
+      allocsz += Whsize_wosize(Wosize_encoded_alloc_len(alloc_len[i]));
+    }
+
+    /* We have computed whsize (including header), but need wosize (without) */
+    allocsz -= 1;
+
+    caml_alloc_small_dispatch(allocsz, CAML_DO_TRACK | CAML_FROM_CAML,
+                              nallocs, alloc_len);
+  }
 }
 
 DECLARE_SIGNAL_HANDLER(handle_signal)

--- a/ocaml/testsuite/tests/asmgen/main.c
+++ b/ocaml/testsuite/tests/asmgen/main.c
@@ -18,6 +18,14 @@
 #include <stdlib.h>
 #include <time.h>
 
+/* This stub isn't needed for msvc32, since it's already in asmgen_i386nt.asm */
+#if !defined(_MSC_VER) || !defined(_M_IX86)
+void caml_call_gc()
+{
+
+}
+#endif
+
 void caml_ml_array_bound_error(void)
 {
   fprintf(stderr, "Fatal error: out-of-bound access in array or string\n");

--- a/ocaml/testsuite/tests/asmgen/mainarith.c
+++ b/ocaml/testsuite/tests/asmgen/mainarith.c
@@ -22,6 +22,10 @@
 #include <caml/config.h>
 #define FMT ARCH_INTNAT_PRINTF_FORMAT
 
+void caml_call_poll()
+{
+}
+
 void caml_ml_array_bound_error(void)
 {
   fprintf(stderr, "Fatal error: out-of-bound access in array or string\n");

--- a/ocaml/testsuite/tests/backend/polling.c
+++ b/ocaml/testsuite/tests/backend/polling.c
@@ -1,0 +1,18 @@
+#define CAML_NAME_SPACE
+#define CAML_INTERNALS
+
+#include <caml/domain_state.h>
+#include <caml/signals.h>
+
+CAMLprim value request_minor_gc(value v) {
+  Caml_state->requested_minor_gc = 1;
+  Caml_state->requested_major_slice = 1;
+  caml_something_to_do = 1;
+  Caml_state->young_limit = Caml_state->young_alloc_end;
+
+  return Val_unit;
+}
+
+CAMLprim value minor_gcs(value v) {
+  return Val_long(Caml_state->stat_minor_collections);
+}

--- a/ocaml/testsuite/tests/backend/polling_insertion.ml
+++ b/ocaml/testsuite/tests/backend/polling_insertion.ml
@@ -1,0 +1,293 @@
+(* TEST
+   modules = "polling.c"
+   compare_programs = "false"
+   * arch64
+   ** native
+*)
+
+(* This set of tests examine poll insertion behaviour. We do this by requesting
+   and checking the number of minor collections at various points to determine
+   whether a poll was correctly added. There are some subtleties because
+   [caml_empty_minor_heap] will not increment the minor_collections stat if
+   nothing has been allocated on the minor heap, so we sometimes need to
+   add an allocation before we call [request_minor_gc]. The [minor_gcs]
+   function returns the number of minor collections so far without allocating.
+
+   ignore(Sys.opaque_identity(ref 41)) is used wherever we want to do an
+   allocation in order to use some minor heap so the minor collections stat is
+   incremented.
+
+   ignore(Sys.opaque_identity(ref 42)) is used wherever we want an allocation
+   for the purposes of testing whether a poll would be elided or not.
+*)
+
+external request_minor_gc : unit -> unit = "request_minor_gc"
+external minor_gcs : unit -> int = "minor_gcs"
+
+(* This function tests that polls are added to loops *)
+let polls_added_to_loops () =
+  let minors_before = minor_gcs () in
+  request_minor_gc ();
+  for a = 0 to 1 do
+    ignore (Sys.opaque_identity 42)
+  done;
+  let minors_now = minor_gcs () in
+  assert (minors_before < minors_now)
+
+
+(* This function should have no prologue poll but will have
+   one in the loop. *)
+let func_with_added_poll_because_loop () =
+  (* We do two loop iterations so that the poll is triggered whether
+     in poll-at-top or poll-at-bottom mode. *)
+  for a = 0 to Sys.opaque_identity(1) do
+    ignore (Sys.opaque_identity 42)
+  done
+  [@@inline never]
+
+let func_with_no_prologue_poll () =
+  (* this function does not have indirect or 'forward' tail call nor
+      does it call a synthesised function with suppressed polls. *)
+  ignore(Sys.opaque_identity(minor_gcs ()))
+  [@@inline never]
+
+let prologue_polls_in_functions () =
+  ignore(Sys.opaque_identity(ref 41));
+  let minors_before = minor_gcs () in
+  request_minor_gc ();
+  func_with_added_poll_because_loop ();
+  let minors_now = minor_gcs () in
+  assert (minors_before < minors_now);
+
+  ignore(Sys.opaque_identity(ref 41));
+  let minors_before = minor_gcs () in
+  request_minor_gc ();
+  func_with_no_prologue_poll ();
+  let minors_now = minor_gcs () in
+  assert (minors_before = minors_now)
+
+(* These next functions test that polls are not added to functions that
+   unconditionally allocate.
+   [allocating_func] allocates unconditionally
+   [allocating_func_if] allocates unconditionally but does so
+   on two separate branches *)
+let allocating_func minors_before =
+  let minors_now = minor_gcs () in
+  assert (minors_before = minors_now);
+  (* No poll yet *)
+  ignore (Sys.opaque_identity (ref 42));
+  let minors_now2 = minor_gcs () in
+  assert (minors_before + 1 = minors_now2);
+  (* Polled at alloc *)
+  [@@inline never]
+
+let allocating_func_if minors_before =
+  let minors_now = minor_gcs () in
+  assert (minors_before = minors_now);
+  (* No poll yet *)
+  if minors_before > 0 then ignore (Sys.opaque_identity (ref 42))
+  else ignore (Sys.opaque_identity (ref 42));
+  let minors_now2 = minor_gcs () in
+  assert (minors_before + 1 = minors_now2);
+  (* Polled at alloc *)
+  [@@inline never]
+
+let allocating_func_nested_ifs minors_before =
+  let minors_now = minor_gcs () in
+  assert (minors_before = minors_now);
+  (* No poll yet *)
+  if Sys.opaque_identity(minors_before) > 0 then
+    if Sys.opaque_identity(minors_before) > 1 then
+      ignore (Sys.opaque_identity (ref 42))
+    else
+      ignore (Sys.opaque_identity (ref 42))
+  else
+    if Sys.opaque_identity(minors_before) < 5 then
+      ignore (Sys.opaque_identity (ref 42))
+    else
+      ignore (Sys.opaque_identity (ref 42));
+  let minors_now2 = minor_gcs () in
+  assert (minors_before + 1 = minors_now2);
+  (* Polled at alloc *)
+  [@@inline never]
+
+let allocating_func_match minors_before =
+  let minors_now = minor_gcs () in
+  assert (minors_before = minors_now);
+  (* No poll yet *)
+  match minors_before with
+  | 0 -> ignore (Sys.opaque_identity (ref 42))
+  | _ -> ignore (Sys.opaque_identity (ref 42));
+  let minors_now2 = minor_gcs () in
+  assert (minors_before + 1 = minors_now2);
+  (* Polled at alloc *)
+  [@@inline never]
+
+let polls_not_added_unconditionally_allocating_functions () =
+  let minors_before = minor_gcs () in
+  ignore(Sys.opaque_identity(ref 41));
+  request_minor_gc ();
+  allocating_func minors_before;
+  let minors_before = minor_gcs () in
+  ignore(Sys.opaque_identity(ref 41));
+  request_minor_gc ();
+  allocating_func_if minors_before;
+  let minors_before = minor_gcs () in
+  ignore(Sys.opaque_identity(ref 41));
+  request_minor_gc ();
+  allocating_func_nested_ifs minors_before;
+  let minors_before = minor_gcs () in
+  ignore(Sys.opaque_identity(ref 41));
+  request_minor_gc ();
+  allocating_func_match minors_before
+
+(* This function tests that polls are not added to the back edge of
+   where loop bodies allocat unconditionally *)
+let polls_not_added_to_allocating_loops () =
+  let current_minors = ref (minor_gcs ()) in
+  request_minor_gc ();
+  for a = 0 to 1 do
+    (* Since the loop body allocates there should be no poll points *)
+    let minors_now = minor_gcs () in
+      assert(minors_now = !current_minors);
+      ignore(Sys.opaque_identity(ref 42));
+      let minors_now2 = minor_gcs () in
+        assert(minors_now+1 = minors_now2);
+        current_minors := minors_now2;
+        ignore(Sys.opaque_identity(ref 41));
+        request_minor_gc ()
+  done
+
+(* this next set of functions tests that self tail recursive functions
+   have polls added correctly *)
+let rec self_rec_func n =
+  match n with
+  | 0 -> 0
+  | _ ->
+    begin
+    let n1 = Sys.opaque_identity(n-1) in
+      (self_rec_func[@tailcall]) n1
+    end
+
+let polls_added_to_self_recursive_functions () =
+  let minors_before = minor_gcs () in
+    request_minor_gc ();
+    ignore(self_rec_func 2);
+    let minors_after = minor_gcs () in
+      (* should be at least one minor gc from polls in self_rec_func *)
+      assert(minors_before+1 = minors_after)
+
+(* this pair of mutually recursive functions is to test that a poll is
+   correctly placed in the first one compiled *)
+let rec mut_rec_func_even d =
+  match d with
+  | 0 -> 0
+  | _ -> mut_rec_func_odd (d-1)
+and mut_rec_func_odd d =
+  mut_rec_func_even (d-1)
+and mut_rec_func d =
+  match d with
+  | n when n mod 2 == 0
+    -> mut_rec_func_even n
+  | n -> mut_rec_func_odd n
+
+let polls_added_to_mutually_recursive_functions () =
+  let minors_before = minor_gcs () in
+  request_minor_gc ();
+  ignore(mut_rec_func 3);
+  let minors_after = minor_gcs () in
+    (* should be at least one minor gc from polls in mut_rec_func *)
+    assert(minors_before < minors_after)
+
+(* this is to test that indirect tail calls (which might result in a self
+   call) have polls inserted in them.
+   These correspond to Itailcall_ind at Mach *)
+let do_indirect_tail_call f n =
+  f (n-1)
+  [@@inline never]
+
+let polls_added_to_indirect_tail_calls () =
+  let f = fun n -> n+1 in
+  let minors_before = minor_gcs () in
+  request_minor_gc ();
+  ignore(do_indirect_tail_call f 3);
+  let minors_after = minor_gcs () in
+    (* should be at one minor gc from the poll in do_indirect_tail_call *)
+    assert(minors_before+1 = minors_after)
+
+(* this is to test that indirect non-tail calls do not have a poll placed
+   in them. These correspond to Icall_ind at Mach *)
+let do_indirect_call f n =
+  n * f (n-1)
+  [@@inline never]
+
+let polls_not_added_to_indirect_calls () =
+  let f = fun n -> n+1 in
+  let minors_before = minor_gcs () in
+  request_minor_gc ();
+  ignore(do_indirect_call f 3);
+  let minors_after = minor_gcs () in
+    (* should be at one minor gc from the poll in do_indirect_tail_call *)
+    assert(minors_before = minors_after)
+
+(* this set of functions tests that we don't poll for immediate
+  (non-tail) calls. These correspond to Icall_imm at Mach *)
+let call_func1 n =
+  Sys.opaque_identity(n-1)
+  [@@inline never]
+
+let call_func2 n =
+  n * (call_func1 (Sys.opaque_identity(n+1)))
+  [@@inline never]
+
+let polls_not_added_to_immediate_calls () =
+  let minors_before = minor_gcs () in
+  request_minor_gc ();
+  ignore(call_func1 100);
+  let minors_after = minor_gcs () in
+    (* should be no minor collections *)
+    assert(minors_before = minors_after)
+
+let[@inline never][@local never] app minors_before f x y =
+  let minors_after_prologue = minor_gcs () in
+    assert(minors_before+1 = minors_after_prologue);
+    request_minor_gc ();
+    f x y
+
+let polls_not_added_in_caml_apply () =
+  let minors_before = minor_gcs() in
+    request_minor_gc();
+    ignore(Sys.opaque_identity(app minors_before (fun x y -> x * y) 5 4));
+    let minors_after = minor_gcs() in
+      assert(minors_before+1 = minors_after)
+
+let () =
+  ignore(Sys.opaque_identity(ref 41));
+  polls_added_to_loops (); (* relies on there being some minor heap usage *)
+
+  ignore(Sys.opaque_identity(ref 41));
+  prologue_polls_in_functions ();
+
+  ignore(Sys.opaque_identity(ref 41));
+  polls_added_to_self_recursive_functions ();
+
+  ignore(Sys.opaque_identity(ref 41));
+  polls_added_to_mutually_recursive_functions ();
+
+  ignore(Sys.opaque_identity(ref 41));
+  polls_added_to_indirect_tail_calls ();
+
+  ignore(Sys.opaque_identity(ref 41));
+  polls_not_added_to_indirect_calls ();
+
+  ignore(Sys.opaque_identity(ref 41));
+  polls_not_added_to_immediate_calls ();
+
+  ignore(Sys.opaque_identity(ref 41));
+  polls_not_added_unconditionally_allocating_functions ();
+
+  ignore(Sys.opaque_identity(ref 41));
+  polls_not_added_to_allocating_loops ();
+
+  ignore(Sys.opaque_identity(ref 41));
+  polls_not_added_in_caml_apply ()

--- a/testsuite/tests/asmgen/main.c
+++ b/testsuite/tests/asmgen/main.c
@@ -18,6 +18,14 @@
 #include <stdlib.h>
 #include <time.h>
 
+/* This stub isn't needed for msvc32, since it's already in asmgen_i386nt.asm */
+#if !defined(_MSC_VER) || !defined(_M_IX86)
+void caml_call_gc()
+{
+
+}
+#endif
+
 void caml_ml_array_bound_error(void)
 {
   fprintf(stderr, "Fatal error: out-of-bound access in array or string\n");

--- a/testsuite/tests/asmgen/mainarith.c
+++ b/testsuite/tests/asmgen/mainarith.c
@@ -22,6 +22,10 @@
 #include <caml/config.h>
 #define FMT ARCH_INTNAT_PRINTF_FORMAT
 
+void caml_call_poll()
+{
+}
+
 void caml_ml_array_bound_error(void)
 {
   fprintf(stderr, "Fatal error: out-of-bound access in array or string\n");


### PR DESCRIPTION
This includes the main safepoints PR ocaml/ocaml#10404 plus the fixes from ocaml/ocaml#10498 (except the first part which is in #737 ) and ocaml/ocaml#10523.

I have provided an implementation of the `Ipoll` instruction in `Cfg`.

This PR does not include a backport of the `[@poll error]` attribute (ocaml/ocaml#10462) which involves threading a new flag through the middle end.  I will work on this one next.

We will then need one or more attributes to selectively disable poll insertion for critical code.

As discussed these changes have not been applied to `ocaml/asmcomp/` as those will be picked up when `ocaml-jst` is rebased to 4.14 soon.

This shouldn't be merged until we've finished #194 and also agreed on exactly how safepoints will be enabled/disabled for testing etc. (@lpw25 and I were discussing using a `-extension` flag but @stedolan was less keen on this.)