### PR TITLE
Add an opaque identity to Obj.is_int

### DIFF
--- a/ocaml/stdlib/obj.ml
+++ b/ocaml/stdlib/obj.ml
@@ -28,7 +28,7 @@ external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
 external obj_is_int : t -> bool = "%obj_is_int"
-let is_int t = obj_is_int (Sys.opaque_identity t)
+let [@inline always] is_int t = obj_is_int (Sys.opaque_identity t)
 let [@inline always] is_block a = not (is_int a)
 external tag : t -> int = "caml_obj_tag" [@@noalloc]
 (* For Flambda 2 there is a strict distinction between arrays and other

--- a/ocaml/stdlib/obj.ml
+++ b/ocaml/stdlib/obj.ml
@@ -27,7 +27,8 @@ type raw_data = nativeint
 external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
-external is_int : t -> bool = "%obj_is_int"
+external obj_is_int : t -> bool = "%obj_is_int"
+let is_int t = obj_is_int (Sys.opaque_identity t)
 let [@inline always] is_block a = not (is_int a)
 external tag : t -> int = "caml_obj_tag" [@@noalloc]
 (* For Flambda 2 there is a strict distinction between arrays and other

--- a/ocaml/stdlib/obj.mli
+++ b/ocaml/stdlib/obj.mli
@@ -29,7 +29,7 @@ external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
 val [@inline always] is_block : t -> bool
-external is_int : t -> bool = "%obj_is_int"
+val is_int : t -> bool
 external tag : t -> int = "caml_obj_tag" [@@noalloc]
 val size : t -> int
 external reachable_words : t -> int = "caml_obj_reachable_words"


### PR DESCRIPTION
Flambda 2 interprets the `Is_int` primitive as being for variants only.
So on the following example:
```ocaml
let str_len x =
  if Obj.is_int x then
    None
  else if Obj.tag x = Obj.string_tag then
    Some (String.length (Obj.obj x : string))
  else None
```
The `String.length` primitive sees an input that has gone through `Is_int`, so assumes it must be a variant, and simplifies to `Invalid`.
This occurs in practice in the ExtLib library: https://github.com/ygrek/ocaml-extlib/blob/0779f7a881c76f9aca3d5445e2f063ba38a76167/src/std.ml#L165