### PR TITLE
Differentiate is_int primitive between generic and variant-only versions

### DIFF
--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -85,7 +85,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Parraysetu kind -> Parraysetu kind
   | Parrayrefs kind -> Parrayrefs kind
   | Parraysets kind -> Parraysets kind
-  | Pisint -> Pisint
+  | Pisint _ -> Pisint
   | Pisout -> Pisout
   | Pcvtbint (src, dest, m) -> Pcvtbint (src, dest, m)
   | Pnegbint (bi,m) -> Pnegbint (bi,m)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -636,7 +636,7 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
       | Psubfloat _ | Pmulfloat _ | Pdivfloat _ | Pfloatcomp _ | Pstringlength
       | Pstringrefu | Pstringrefs | Pbyteslength | Pbytesrefu | Pbytessetu
       | Pbytesrefs | Pbytessets | Pduparray _ | Parraylength _ | Parrayrefu _
-      | Parraysetu _ | Parrayrefs _ | Parraysets _ | Pisint | Pisout
+      | Parraysetu _ | Parrayrefs _ | Parraysets _ | Pisint _ | Pisout
       | Pbintofint _ | Pintofbint _ | Pcvtbint _ | Pnegbint _ | Paddbint _
       | Psubbint _ | Pmulbint _ | Pdivbint _ | Pmodbint _ | Pandbint _
       | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -783,10 +783,10 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pnegfloat _ | Pabsfloat _ | Paddfloat _ | Psubfloat _ | Pmulfloat _
   | Pdivfloat _ | Pfloatcomp _ | Pstringlength | Pstringrefu | Pbyteslength
   | Pbytesrefu | Pbytessetu | Pmakearray _ | Pduparray _ | Parraylength _
-  | Parrayrefu _ | Parraysetu _ | Pisint | Pisout | Pbintofint _ | Pintofbint _
-  | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _
-  | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
-  | Pasrbint _ | Pbintcomp _ | Pbigarraydim _
+  | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisout | Pbintofint _
+  | Pintofbint _ | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _
+  | Pmulbint _ | Pdivbint _ | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _
+  | Plslbint _ | Plsrbint _ | Pasrbint _ | Pbintcomp _ | Pbigarraydim _
   | Pbigarrayref (true, _, _, _)
   | Pbigarrayset (true, _, _, _)
   | Pstring_load_16 true
@@ -1764,7 +1764,7 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
             in
             CC.close_let acc ccenv is_scrutinee_int Not_user_visible
               (Prim
-                 { prim = Pisint;
+                 { prim = Pisint { variant_only = true };
                    args = [Var scrutinee];
                    loc = Loc_unknown;
                    exn_continuation = None

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -795,7 +795,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
   | Pbytes_set_64 false (* safe *), [bytes; index; new_value] ->
     bytes_like_set_safe ~dbg ~size_int ~access_size:Sixty_four Bytes bytes index
       new_value
-  | Pisint, [arg] -> tag_int (Unary (Is_int, arg))
+  | Pisint { variant_only }, [arg] ->
+    tag_int (Unary (Is_int { variant_only }, arg))
   | Pisout, [arg1; arg2] ->
     tag_int
       (Binary
@@ -1087,7 +1088,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
       | Pnegfloat _ | Pabsfloat _ | Pstringlength | Pbyteslength | Pbintofint _
       | Pintofbint _ | Pnegbint _ | Popaque | Pduprecord _ | Parraylength _
       | Pduparray _ | Pfloatfield _ | Pcvtbint _ | Poffsetref _ | Pbswap16
-      | Pbbswap _ | Pisint | Pint_as_pointer | Pbigarraydim _ ),
+      | Pbbswap _ | Pisint _ | Pint_as_pointer | Pbigarraydim _ ),
       ([] | _ :: _ :: _) ) ->
     Misc.fatal_errorf
       "Closure_conversion.convert_primitive: Wrong arity for unary primitive \

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -309,7 +309,7 @@ let unop env (unop : Fexpr.unop) : Flambda_primitive.unary_primitive =
   | Tag_immediate -> Tag_immediate
   | Untag_immediate -> Untag_immediate
   | Get_tag -> Get_tag
-  | Is_int -> Is_int
+  | Is_int -> Is_int { variant_only = true } (* CR vlaviron: discuss *)
   | Num_conv { src; dst } -> Num_conv { src; dst }
   | Opaque_identity -> Opaque_identity
   | Project_value_slot { project_from; value_slot } ->

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -432,7 +432,7 @@ let unop env (op : Flambda_primitive.unary_primitive) : Fexpr.unop =
   | Box_number (bk, _alloc_mode) -> Box_number bk
   | Tag_immediate -> Tag_immediate
   | Get_tag -> Get_tag
-  | Is_int -> Is_int
+  | Is_int _ -> Is_int (* CR vlaviron: discuss *)
   | Num_conv { src; dst } -> Num_conv { src; dst }
   | Opaque_identity -> Opaque_identity
   | Unbox_number bk -> Unbox_number bk

--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -240,7 +240,7 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
            the join of the types will usually give us the relevant equation
            anyway. *)
         match[@ocaml.warning "-fragile-match"] EP.to_primitive prim with
-        | Unary (Is_int, scrutinee) ->
+        | Unary (Is_int { variant_only = true }, scrutinee) ->
           Name.Map.add (Name.var var)
             (T.is_int_for_scrutinee ~scrutinee)
             extra_equations

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -194,9 +194,7 @@ let simplify_is_int ~variant_only dacc ~original_term ~arg:scrutinee
       let dacc = DA.add_variable dacc result_var ty in
       SPR.create original_term ~try_reify:false dacc
     | Unknown ->
-      let ty = T.unknown K.naked_immediate in
-      let dacc = DA.add_variable dacc result_var ty in
-      SPR.create original_term ~try_reify:false dacc
+      SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
 
 let simplify_get_tag dacc ~original_term ~arg:scrutinee ~arg_ty:scrutinee_ty
     ~result_var =
@@ -231,9 +229,7 @@ let simplify_string_length dacc ~original_term ~arg:_ ~arg_ty:str_ty ~result_var
       let dacc = DA.add_variable dacc result_var ty in
       SPR.create original_term ~try_reify:true dacc
   | Need_meet ->
-    let ty = T.unknown K.naked_immediate in
-    let dacc = DA.add_variable dacc result_var ty in
-    SPR.create original_term ~try_reify:false dacc
+    SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
   | Invalid -> SPR.create_invalid dacc
 
 module Unary_int_arith (I : A.Int_number_kind) = struct
@@ -252,12 +248,10 @@ module Unary_int_arith (I : A.Int_number_kind) = struct
       let dacc = DA.add_variable dacc result_var ty in
       SPR.create original_term ~try_reify:true dacc
     | Need_meet ->
-      let dacc =
-        DA.add_variable dacc result_var
-          (T.unknown
-             (K.Standard_int_or_float.to_kind I.standard_int_or_float_kind))
+      let result_kind =
+        K.Standard_int_or_float.to_kind I.standard_int_or_float_kind
       in
-      SPR.create original_term ~try_reify:false dacc
+      SPR.create_unknown dacc ~result_var result_kind ~original_term
     | Invalid -> SPR.create_invalid dacc
 end
 
@@ -356,9 +350,8 @@ module Make_simplify_int_conv (N : A.Number_kind) = struct
           end) in
           M.result)
       | Need_meet ->
-        let ty = T.unknown (K.Standard_int_or_float.to_kind dst) in
-        let dacc = DA.add_variable dacc result_var ty in
-        SPR.create original_term ~try_reify:false dacc
+        let result_kind = K.Standard_int_or_float.to_kind dst in
+        SPR.create_unknown dacc ~result_var result_kind ~original_term
       | Invalid -> SPR.create_invalid dacc
 end
 
@@ -437,9 +430,7 @@ let simplify_float_arith_op (op : P.unary_float_arith_op) dacc ~original_term
     let dacc = DA.add_variable dacc result_var ty in
     SPR.create original_term ~try_reify:true dacc
   | Known_result _ | Need_meet ->
-    let ty = T.unknown K.naked_float in
-    let dacc = DA.add_variable dacc result_var ty in
-    SPR.create original_term ~try_reify:false dacc
+    SPR.create_unknown dacc ~result_var K.naked_float ~original_term
   | Invalid -> SPR.create_invalid dacc
 
 let simplify_is_boxed_float dacc ~original_term ~arg:_ ~arg_ty ~result_var =
@@ -451,9 +442,7 @@ let simplify_is_boxed_float dacc ~original_term ~arg:_ ~arg_ty ~result_var =
     let dacc = DA.add_variable dacc result_var ty in
     SPR.create original_term ~try_reify:true dacc
   | Unknown ->
-    let ty = T.unknown K.naked_immediate in
-    let dacc = DA.add_variable dacc result_var ty in
-    SPR.create original_term ~try_reify:false dacc
+    SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
 
 let simplify_is_flat_float_array dacc ~original_term ~arg:_ ~arg_ty ~result_var
     =
@@ -471,9 +460,7 @@ let simplify_is_flat_float_array dacc ~original_term ~arg:_ ~arg_ty ~result_var
   | Invalid -> SPR.create_invalid dacc
 
 let simplify_opaque_identity dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
-  let ty = T.unknown K.value in
-  let dacc = DA.add_variable dacc result_var ty in
-  SPR.create original_term ~try_reify:false dacc
+  SPR.create_unknown dacc ~result_var K.value ~original_term
 
 let simplify_end_region dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
   let ty = T.this_tagged_immediate Targetint_31_63.zero in
@@ -481,15 +468,11 @@ let simplify_end_region dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
   SPR.create original_term ~try_reify:false dacc
 
 let simplify_int_as_pointer dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
-  let ty = T.unknown K.value in
-  let dacc = DA.add_variable dacc result_var ty in
-  SPR.create original_term ~try_reify:false dacc
+  SPR.create_unknown dacc ~result_var K.value ~original_term
 
 let simplify_bigarray_length ~dimension:_ dacc ~original_term ~arg:_ ~arg_ty:_
     ~result_var =
-  let ty = T.unknown K.naked_immediate in
-  let dacc = DA.add_variable dacc result_var ty in
-  SPR.create original_term ~try_reify:false dacc
+  SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
 
 let simplify_duplicate_array ~kind:_ ~(source_mutability : Mutability.t)
     ~(destination_mutability : Mutability.t) dacc ~original_term ~arg:_ ~arg_ty

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -89,7 +89,7 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
         (T.get_tag_for_block ~block:(Simple.var param_var))
     in
     let get_tag_prim =
-      P.Eligible_for_cse.create_exn (Unary (Get_tag, Simple.var param_var))
+      P.Eligible_for_cse.create_get_tag ~block:(Name.var param_var)
     in
     let denv = DE.add_cse denv get_tag_prim ~bound_to:(Simple.var tag.param) in
     (* Same thing for is_int *)
@@ -104,7 +104,8 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
             (T.is_int_for_scrutinee ~scrutinee:(Simple.var param_var))
         in
         let is_int_prim =
-          P.Eligible_for_cse.create_exn (Unary (Is_int, Simple.var param_var))
+          P.Eligible_for_cse.create_is_int ~variant_only:true
+            ~immediate_or_block:(Name.var param_var)
         in
         let denv =
           DE.add_cse denv is_int_prim ~bound_to:(Simple.var is_int.param)

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -311,7 +311,7 @@ let nullary_prim_size prim =
 let unary_prim_size prim =
   match (prim : Flambda_primitive.unary_primitive) with
   | Duplicate_array _ | Duplicate_block _ -> alloc_extcall_size + 1
-  | Is_int -> 1
+  | Is_int _ -> 1
   | Get_tag -> 2
   | Array_length -> array_length_size
   | Bigarray_length _ -> 2 (* cadda + load *)

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -226,7 +226,7 @@ type unary_primitive =
         source_mutability : Mutability.t;
         destination_mutability : Mutability.t
       }
-  | Is_int
+  | Is_int of { variant_only : bool }
   | Get_tag
   | Array_length
   | Bigarray_length of { dimension : int }
@@ -449,7 +449,7 @@ module Eligible_for_cse : sig
 
   val create_exn : primitive_application -> t
 
-  val create_is_int : immediate_or_block:Name.t -> t
+  val create_is_int : variant_only:bool -> immediate_or_block:Name.t -> t
 
   val create_get_tag : block:Name.t -> t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -519,7 +519,7 @@ let unary_primitive env res dbg f arg =
       res,
       C.extcall ~dbg ~alloc:true ~returns:true ~is_c_builtin:false ~ty_args:[]
         "caml_obj_dup" Cmm.typ_val [arg] )
-  | Is_int -> None, res, C.and_int arg (C.int ~dbg 1) dbg
+  | Is_int _ -> None, res, C.and_int arg (C.int ~dbg 1) dbg
   | Get_tag -> None, res, C.get_tag arg dbg
   | Array_length -> None, res, array_length ~dbg arg
   | Bigarray_length { dimension } ->

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -66,8 +66,8 @@ and head_of_kind_value = private
 
 and head_of_kind_naked_immediate = private
   | Naked_immediates of Targetint_31_63.Set.t
-  | Is_int of t
-  | Get_tag of t
+  | Is_int of t (** For variants only *)
+  | Get_tag of t (** For variants only *)
 
 (** Invariant: the float/integer sets for naked float, int32, int64 and
     nativeint heads are non-empty. (Empty sets are represented as an overall

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -66,8 +66,8 @@ and head_of_kind_value = private
 
 and head_of_kind_naked_immediate = private
   | Naked_immediates of Targetint_31_63.Set.t
-  | Is_int of t (** For variants only *)
-  | Get_tag of t (** For variants only *)
+  | Is_int of t  (** For variants only *)
+  | Get_tag of t  (** For variants only *)
 
 (** Invariant: the float/integer sets for naked float, int32, int64 and
     nativeint heads are non-empty. (Empty sets are represented as an overall

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -76,6 +76,8 @@ let prove_equals_to_simple_of_kind_value env t : Simple.t proof_of_property =
       | exception Not_found -> Unknown
       | simple -> Proved simple)
 
+(* Note: this function is used for simplifying Obj.is_int, so should not assume
+   that the argument represents a variant *)
 let prove_is_int_generic env t : bool generic_proof =
   match expand_head env t with
   | Value (Ok (Variant blocks_imms)) -> (

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -380,7 +380,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Parrayrefs _ -> parrayrefs
   | Parraysets _ -> parraysets
   | Pctconst _ -> pctconst
-  | Pisint -> pisint
+  | Pisint _ -> pisint
   | Pisout -> pisout
   | Pbintofint _ -> pbintofint
   | Pintofbint _ -> pintofbint
@@ -488,7 +488,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Parrayrefs _ -> parrayrefs_arg
   | Parraysets _ -> parraysets_arg
   | Pctconst _ -> pctconst_arg
-  | Pisint -> pisint_arg
+  | Pisint _ -> pisint_arg
   | Pisout -> pisout_arg
   | Pbintofint _ -> pbintofint_arg
   | Pintofbint _ -> pintofbint_arg

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -123,7 +123,7 @@ let preserve_tailcall_for_prim = function
   | Pcompare_ints | Pcompare_floats | Pcompare_bints _
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
-  | Parrayrefs _ | Parraysets _ | Pisint | Pisout | Pbintofint _ | Pintofbint _
+  | Parrayrefs _ | Parraysets _ | Pisint _ | Pisout | Pbintofint _ | Pintofbint _
   | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _
   | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
   | Pasrbint _ | Pbintcomp _ | Pbigarrayref _ | Pbigarrayset _ | Pbigarraydim _
@@ -466,7 +466,7 @@ let comp_primitive p args =
        | Ostype_cygwin -> "ostype_cygwin"
        | Backend_type -> "backend_type" in
      Kccall(Printf.sprintf "caml_sys_const_%s" const_name, 1)
-  | Pisint -> Kisint
+  | Pisint _ -> Kisint
   | Pisout -> Kisout
   | Pbintofint (bi,_) -> comp_bint_primitive bi "of_int" args
   | Pintofbint bi -> comp_bint_primitive bi "to_int" args

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -156,7 +156,7 @@ type primitive =
   | Parrayrefs of array_kind
   | Parraysets of array_kind
   (* Test if the argument is a block or an immediate integer *)
-  | Pisint
+  | Pisint of { variant_only : bool }
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)
@@ -1164,7 +1164,7 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Parrayrefs (Pgenarray|Pfloatarray) ->
      (* The float box from flat floatarray access is always Alloc_heap *)
      Some alloc_heap
-  | Pisint | Pisout -> None
+  | Pisint _ | Pisout -> None
   | Pintofbint _ -> None
   | Pbintofint (_,m)
   | Pcvtbint (_,_,m)

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -126,7 +126,7 @@ type primitive =
   | Parrayrefs of array_kind
   | Parraysets of array_kind
   (* Test if the argument is a block or an immediate integer *)
-  | Pisint
+  | Pisint of { variant_only : bool }
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -1865,7 +1865,7 @@ let inline_lazy_force_switch arg pos loc =
       idarg,
       arg,
       Lifthenelse
-        ( Lprim (Pisint, [ varg ], loc),
+        ( Lprim (Pisint { variant_only = false }, [ varg ], loc),
           varg,
           Lswitch
             ( varg,
@@ -2803,7 +2803,7 @@ let combine_constructor value_kind loc arg pat_env cstr partial ctx def
                 match act0 with
                 | Some act ->
                     Lifthenelse
-                      ( Lprim (Pisint, [ arg ], loc),
+                      ( Lprim (Pisint { variant_only = true }, [ arg ], loc),
                         call_switcher value_kind loc fail_opt arg 0 (n - 1) consts,
                         act, value_kind )
                 | None ->
@@ -2858,7 +2858,8 @@ let combine_variant value_kind loc row arg partial ctx def
   else
     num_constr := max_int;
   let test_int_or_block arg if_int if_block =
-    Lifthenelse (Lprim (Pisint, [ arg ], loc), if_int, if_block, value_kind)
+    Lifthenelse (Lprim (Pisint { variant_only = true },
+                        [ arg ], loc), if_int, if_block, value_kind)
   in
   let sig_complete = List.length tag_lambda_list = !num_constr
   and one_action = same_actions tag_lambda_list in

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -354,7 +354,8 @@ let primitive ppf = function
        | Ostype_cygwin -> "ostype_cygwin"
        | Backend_type -> "backend_type" in
      fprintf ppf "sys.constant_%s" const_name
-  | Pisint -> fprintf ppf "isint"
+  | Pisint { variant_only } ->
+      fprintf ppf (if variant_only then "isint" else "obj_is_int")
   | Pisout -> fprintf ppf "isout"
   | Pbintofint (bi,m) -> print_boxed_integer "of_int" ppf bi m
   | Pintofbint bi -> print_boxed_integer "to_int" ppf bi alloc_heap
@@ -505,7 +506,7 @@ let name_of_primitive = function
   | Parrayrefs _ -> "Parrayrefs"
   | Parraysets _ -> "Parraysets"
   | Pctconst _ -> "Pctconst"
-  | Pisint -> "Pisint"
+  | Pisint _ -> "Pisint"
   | Pisout -> "Pisout"
   | Pbintofint _ -> "Pbintofint"
   | Pintofbint _ -> "Pintofbint"

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -220,7 +220,7 @@ let lookup_primitive loc poly pos p =
     | "%floatarray_safe_set" -> Primitive ((Parraysets Pfloatarray), 3)
     | "%floatarray_unsafe_get" -> Primitive ((Parrayrefu Pfloatarray), 2)
     | "%floatarray_unsafe_set" -> Primitive ((Parraysetu Pfloatarray), 3)
-    | "%obj_is_int" -> Primitive (Pisint, 1)
+    | "%obj_is_int" -> Primitive (Pisint { variant_only = false }, 1)
     | "%lazy_force" -> Lazy_force pos
     | "%nativeint_of_int" -> Primitive ((Pbintofint (Pnativeint, mode)), 1)
     | "%nativeint_to_int" -> Primitive ((Pintofbint Pnativeint), 1)
@@ -821,7 +821,7 @@ let lambda_primitive_needs_event_after = function
   | Pcompare_ints | Pcompare_floats
   | Pfloatcomp _ | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu
   | Pbytessetu | Pmakearray ((Pintarray | Paddrarray | Pfloatarray), _, _)
-  | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint | Pisout
+  | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisout
   | Pprobe_is_enabled _
   | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque -> false
 


### PR DESCRIPTION
This is a proper version of #747.
The `Pisint` lambda primitive and `Is_int` flambda2 primitive are augmented with a boolean distinguishing the generic version, exposed as `Obj.is_int`, and the version used for compiling pattern-matching on variants.
This allows Flambda 2 to still precisely handle variants without being incorrect on the `Obj.is_int` version.