### PR TITLE
Remove nolabels attribute from unixLabels

### DIFF
--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -22,6 +22,10 @@
  ))
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall))
+ ; UnixLabels is compiled separately as it needs the -nolabels flag.  We can't
+ ; currently use an attribute in the .ml file to enable this behaviour as
+ ; the system compiler used to build the boot compiler won't understand it.
+ (modules (:standard \ unixLabels))
  (foreign_stubs (language c) (names
    accept access addrofstr alarm bind channels chdir chmod chown chroot close
    fsync closedir connect cst2constr cstringv dup dup2 envir errmsg execv execve
@@ -39,17 +43,58 @@
            (:include %{project_root}/oc_cppflags.sexp)))
  ))
 
+(library
+ (name unixlabels)
+ (libraries unix)
+ (wrapped false)
+ (modes byte native)
+ (flags (
+   -absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot
+   -g -safe-string -strict-sequence -strict-formats -nolabels
+ ))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+ (modules unixLabels)
+)
+
+(rule
+ (targets unix_merged.a)
+ (action
+  (run
+   %{dep:../../../tools/merge_dot_a_files.sh}
+   %{targets}
+   %{dep:unix.a}
+   %{dep:unixlabels.a})))
+
+(rule
+ (targets unix_merged.cma)
+ (action
+  (run
+   %{dep:../../../tools/merge_archives.exe}
+   %{targets}
+   %{dep:unix.cma}
+   %{dep:unixlabels.cma})))
+
+(rule
+ (targets unix_merged.cmxa)
+ (action
+  (run
+   %{dep:../../../tools/merge_archives.exe}
+   %{targets}
+   %{dep:unix.cmxa}
+   %{dep:unixlabels.cmxa})))
+
 (install
   (files
     .unix.objs/native/unix.cmx
-    .unix.objs/native/unixLabels.cmx
-    unix.cmxa
-    unix.a
-    unix.cma
+    .unixlabels.objs/native/unixLabels.cmx
+    (unix_merged.cmxa as unix.cmxa)
+    (unix_merged.a as unix.a)
+    (unix_merged.cma as unix.cma)
     .unix.objs/byte/unix.cmi
     .unix.objs/byte/unix.cmti
-    .unix.objs/byte/unixLabels.cmi
-    .unix.objs/byte/unixLabels.cmti
+    .unixlabels.objs/byte/unixLabels.cmi
+    .unixlabels.objs/byte/unixLabels.cmti
+    ; For the moment unix.cmxs does not include UnixLabels.
     unix.cmxs
     unix.mli
     unixLabels.mli

--- a/ocaml/otherlibs/unix/unixLabels.ml
+++ b/ocaml/otherlibs/unix/unixLabels.ml
@@ -15,6 +15,4 @@
 
 (* Module [UnixLabels]: labelled Unix module *)
 
-[@@@ocaml.nolabels]
-
 include Unix


### PR DESCRIPTION
This is an attempt to remove the `nolabels` attribute from `unixLabels.ml` so that the `unix` library can be used in the boot compiler.  We'd like this so that `owee` can be linked into the boot compiler, in turn enabling direct writing of `.o` files bypassing the system assembler (by using the binary emitter).

We'll probably have to merge this and test on the JS tree to see if it works ok.  One problem is that `unix.cmxs` will no longer contain `UnixLabels` but I'm hoping we can get away with that.

In due course if dune starts supporting per-file compilation flags, this could all be simplified.