### PR TITLE
Improve lifting criterion for variables that are symbol projections

### DIFF
--- a/middle_end/flambda2/simplify/lifting/reification.ml
+++ b/middle_end/flambda2/simplify/lifting/reification.ml
@@ -131,10 +131,11 @@ let try_to_reify dacc dbg (term : Simplified_named.t) ~bound_to
   let typing_env = DE.typing_env denv in
   let reify_result =
     T.reify ~allowed_if_free_vars_defined_in:typing_env
-      ~additional_free_var_criterion:(fun var ->
-        DE.is_defined_at_toplevel denv var
-        || Option.is_some (DE.find_symbol_projection denv var))
-      ~allow_unique:true typing_env ~min_name_mode:NM.normal ty
+      ~var_is_defined_at_toplevel:(fun var ->
+        DE.is_defined_at_toplevel denv var)
+      ~var_is_symbol_projection:(fun var ->
+        Option.is_some (DE.find_symbol_projection denv var))
+      typing_env ty
   in
   match reify_result with
   | Lift to_lift ->

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -1107,23 +1107,28 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
                      allocation mode is [Local] and we cannot show that such
                      variables never hold locally-allocated blocks (pointers to
                      which from statically-allocated blocks are forbidden). Also
-                     see comment in types/reify.ml. *)
-                  (match Set_of_closures.alloc_mode set_of_closures with
-                  | Local -> (
-                    match
-                      T.never_holds_locally_allocated_values
-                        (DA.typing_env dacc) var K.value
-                    with
-                    | Proved () -> true
-                    | Unknown -> false)
-                  | Heap -> true)
-                  && (DE.is_defined_at_toplevel (DA.denv dacc) var
-                     (* If [var] is known to be a symbol projection, it doesn't
-                        matter if it isn't in scope at the place where we will
-                        eventually insert the "let symbol", as the binding to
-                        the projection from the relevant symbol can always be
-                        rematerialised. *)
-                     || Variable.Map.mem var symbol_projections)))
+                     see comment in types/reify.ml.
+
+                     If [var] is known to be a symbol projection, it doesn't
+                     matter if it isn't in scope at the place where we will
+                     eventually insert the "let symbol", as the binding to the
+                     projection from the relevant symbol can always be
+                     rematerialised. Likewise no
+                     [never_holds_locally_allocated_values] check is needed in
+                     the symbol projection case, since we are projecting from a
+                     value that has already been deemed eligible for lifting. *)
+                  Variable.Map.mem var symbol_projections
+                  || DE.is_defined_at_toplevel (DA.denv dacc) var
+                     &&
+                     match Set_of_closures.alloc_mode set_of_closures with
+                     | Local -> (
+                       match
+                         T.never_holds_locally_allocated_values
+                           (DA.typing_env dacc) var K.value
+                       with
+                       | Proved () -> true
+                       | Unknown -> false)
+                     | Heap -> true))
          value_slots
   in
   { can_lift; value_slots; value_slot_types; symbol_projections }

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -1100,14 +1100,13 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
                 ~const:(fun _ -> true)
                 ~symbol:(fun _ ~coercion:_ -> true)
                 ~var:(fun var ~coercion:_ ->
-                  (* Variables, including ones bound to symbol projections
-                     (since such projections might be from inconstant symbols
-                     that were lifted [Local] allocations), in the definition of
-                     the set of closures will currently prevent lifting if the
-                     allocation mode is [Local] and we cannot show that such
-                     variables never hold locally-allocated blocks (pointers to
-                     which from statically-allocated blocks are forbidden). Also
-                     see comment in types/reify.ml.
+                  (* Variables (excluding ones bound to symbol projections; see
+                     below) in the definition of the set of closures will
+                     currently prevent lifting if the allocation mode is [Local]
+                     and we cannot show that such variables never hold
+                     locally-allocated blocks (pointers to which from
+                     statically-allocated blocks are forbidden). Also see
+                     comment in types/reify.ml.
 
                      If [var] is known to be a symbol projection, it doesn't
                      matter if it isn't in scope at the place where we will

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -724,12 +724,10 @@ type reification_result = private
   | Invalid
 
 val reify :
-  ?allowed_if_free_vars_defined_in:Typing_env.t ->
-  ?additional_free_var_criterion:(Variable.t -> bool) ->
-  ?disallowed_free_vars:Variable.Set.t ->
-  ?allow_unique:bool ->
+  allowed_if_free_vars_defined_in:Typing_env.t ->
+  var_is_defined_at_toplevel:(Variable.t -> bool) ->
+  var_is_symbol_projection:(Variable.t -> bool) ->
   Typing_env.t ->
-  min_name_mode:Name_mode.t ->
   t ->
   reification_result
 

--- a/middle_end/flambda2/types/reify.mli
+++ b/middle_end/flambda2/types/reify.mli
@@ -39,11 +39,9 @@ type reification_result = private
   | Invalid
 
 val reify :
-  ?allowed_if_free_vars_defined_in:Typing_env.t ->
-  ?additional_free_var_criterion:(Variable.t -> bool) ->
-  ?disallowed_free_vars:Variable.Set.t ->
-  ?allow_unique:bool ->
+  allowed_if_free_vars_defined_in:Typing_env.t ->
+  var_is_defined_at_toplevel:(Variable.t -> bool) ->
+  var_is_symbol_projection:(Variable.t -> bool) ->
   Typing_env.t ->
-  min_name_mode:Name_mode.t ->
   Type_grammar.t ->
   reification_result


### PR DESCRIPTION
Currently the check `T.never_holds_locally_allocated_values` is being applied for variables filling block fields, value slots etc. during the determination of eligibility for lifting.  This should not be necessary when one of these variables is known to be a symbol projection, since the projection is always from a lifted value in this case, and thus such value cannot have contained any local values.

This PR also tidies the interface to `T.reify` which was a bit weird, with some unused / constant-valued parameters.