### PR TITLE
Force the version of `re`

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -23,6 +23,9 @@ jobs:
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
+    - name: Install a recent version of re
+      run: opam install 're>=1.10.0'
+
     - name: Install ocamlformat 0.19.0
       run: opam pin -y ocamlformat 0.19.0
 


### PR DESCRIPTION
As diagnosed by @gpetiot, and experimentally confirmed
by @lthls and @lukemaurer, `re` needs to be `>=1.10` in
order for `ocamlformat` to correctly interpret `**` patterns
in `.ocamlformat-enabled` files.

This pull request hence tweaks the CI workflow to ensure
such a version is installed before `ocamlformat` itself is
installed.