### PR TITLE
Merge libowee_stubs_native into ocamloptcomp

### DIFF
--- a/dune
+++ b/dune
@@ -394,6 +394,7 @@
    %{dep:middle_end/flambda2/from_lambda/flambda2_from_lambda.a}
    %{dep:middle_end/flambda2/simplify/flambda2_simplify.a}
    %{dep:middle_end/flambda2/parser/flambda2_parser.a}
+   %{dep:external/owee/libowee_stubs_native.a}
    %{dep:external/owee/owee.a}
    %{dep:ocamloptcomp.a}
    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.a}


### PR DESCRIPTION
This was an omission in #757 causing JS builds to fail.