### PR TITLE
IRC: Better worklists

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -164,6 +164,10 @@ let write_ir prefix =
 let should_emit () =
   not (should_stop_after Compiler_pass.Scheduling)
 
+let should_use_linscan fd =
+  !use_linscan ||
+  List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options
+
 let if_emit_do f x = if should_emit () then f x else ()
 let emit_begin_assembly ~init_dwarf:init_dwarf =
   if_emit_do (fun init_dwarf -> Emit.begin_assembly ~init_dwarf) init_dwarf
@@ -196,8 +200,7 @@ let rec regalloc ~ppf_dump round fd =
                 ": function too complex, cannot complete register allocation");
   dump_if ppf_dump dump_live "Liveness analysis" fd;
   let num_stack_slots =
-    if !use_linscan ||
-       List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options then begin
+    if should_use_linscan then begin
       (* Linear Scan *)
       Interval.build_intervals fd;
       if !dump_interval then Printmach.intervals ppf_dump ();
@@ -357,10 +360,7 @@ let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_live
   ++ pass_dump_if ppf_dump dump_live "Liveness analysis"
   ++ (fun (fd : Mach.fundecl) ->
-      let force_linscan =
-        !use_linscan ||
-        List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options
-      in
+    let force_linscan = should_use_linscan fd in
       match force_linscan, register_allocator with
       | false, IRC ->
         let res =

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -357,8 +357,12 @@ let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_live
   ++ pass_dump_if ppf_dump dump_live "Liveness analysis"
   ++ (fun (fd : Mach.fundecl) ->
-      match register_allocator with
-      | IRC ->
+      let force_linscan =
+        !use_linscan ||
+        List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options
+      in
+      match force_linscan, register_allocator with
+      | false, IRC ->
         let res =
           fd
           ++ Profile.record ~accumulate:true "cfgize" cfgize
@@ -366,7 +370,7 @@ let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
         in
         (Cfg_regalloc_utils.simplify_cfg res)
         ++ Profile.record ~accumulate:true "cfg_to_linear" Cfg_to_linear.run
-      | Upstream ->
+      | true, _ | false, Upstream ->
         let res =
           fd
           ++ Profile.record ~accumulate:true "spill" Spill.fundecl

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -200,7 +200,7 @@ let rec regalloc ~ppf_dump round fd =
                 ": function too complex, cannot complete register allocation");
   dump_if ppf_dump dump_live "Liveness analysis" fd;
   let num_stack_slots =
-    if should_use_linscan then begin
+    if should_use_linscan fd then begin
       (* Linear Scan *)
       Interval.build_intervals fd;
       if !dump_interval then Printmach.intervals ppf_dump ();

--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -493,6 +493,8 @@ let rec main : round:int -> State.t -> Cfg_with_layout.t -> liveness =
     let adj_set = State.adj_set state in
     log ~indent:1 "(%d pairs in adj_set)"
       (RegisterStamp.PairSet.cardinal adj_set);
+    (* CR-someday xclerc for xclerc: remove (kept for the moment for debugging,
+       but does not deserve to be controlled by a vaiable) *)
     if false
     then
       (* may produce a *lot* of lines... *)

--- a/backend/cfg/cfg_irc_state.ml
+++ b/backend/cfg/cfg_irc_state.ml
@@ -3,20 +3,31 @@
 open! Cfg_regalloc_utils
 open! Cfg_irc_utils
 
+module RegWorkList =
+  WorkList.Make
+    (struct
+      type t = Reg.t
+
+      let compare left right = Int.compare left.Reg.stamp right.Reg.stamp
+    end)
+    (Reg.Set)
+
+module InstructionWorkList = WorkList.Make (Instruction) (Instruction.Set)
+
 type t =
   { mutable initial : Reg.t list;
-    mutable simplify_work_list : Reg.t list;
-    mutable freeze_work_list : Reg.t list;
-    mutable spill_work_list : Reg.t list;
-    mutable spilled_nodes : Reg.t list;
-    mutable coalesced_nodes : Reg.t list;
+    mutable simplify_work_list : RegWorkList.t;
+    mutable freeze_work_list : RegWorkList.t;
+    mutable spill_work_list : RegWorkList.t;
+    mutable spilled_nodes : RegWorkList.t;
+    mutable coalesced_nodes : RegWorkList.t;
     mutable colored_nodes : Reg.t list;
     mutable select_stack : Reg.t list;
-    mutable coalesced_moves : Instruction.t list;
-    mutable constrained_moves : Instruction.t list;
-    mutable frozen_moves : Instruction.t list;
-    mutable work_list_moves : Instruction.t list;
-    mutable active_moves : Instruction.t list;
+    mutable coalesced_moves : InstructionWorkList.t;
+    mutable constrained_moves : InstructionWorkList.t;
+    mutable frozen_moves : InstructionWorkList.t;
+    mutable work_list_moves : InstructionWorkList.t;
+    mutable active_moves : InstructionWorkList.t;
     adj_set : RegisterStamp.PairSet.t;
     move_list : Instruction.Set.t Reg.Tbl.t;
     stack_slots : int Reg.Tbl.t;
@@ -44,19 +55,22 @@ let[@inline] make ~initial ~next_instruction_id () =
       reg.Reg.irc_alias <- None;
       reg.Reg.interf <- [];
       reg.Reg.degree <- Degree.infinite);
-  let simplify_work_list = [] in
-  let freeze_work_list = [] in
-  let spill_work_list = [] in
-  let spilled_nodes = [] in
-  let coalesced_nodes = [] in
+  let num_registers = List.length initial in
+  let expected_max_size = num_registers in
+  let simplify_work_list = RegWorkList.make ~expected_max_size in
+  let freeze_work_list = RegWorkList.make ~expected_max_size in
+  let spill_work_list = RegWorkList.make ~expected_max_size in
+  let spilled_nodes = RegWorkList.make ~expected_max_size in
+  let coalesced_nodes = RegWorkList.make ~expected_max_size in
   let colored_nodes = [] in
   let select_stack = [] in
-  let coalesced_moves = [] in
-  let constrained_moves = [] in
-  let frozen_moves = [] in
-  let work_list_moves = [] in
-  let active_moves = [] in
-  let adj_set = RegisterStamp.PairSet.make () in
+  let expected_max_size = pred next_instruction_id in
+  let coalesced_moves = InstructionWorkList.make ~expected_max_size in
+  let constrained_moves = InstructionWorkList.make ~expected_max_size in
+  let frozen_moves = InstructionWorkList.make ~expected_max_size in
+  let work_list_moves = InstructionWorkList.make ~expected_max_size in
+  let active_moves = InstructionWorkList.make ~expected_max_size in
+  let adj_set = RegisterStamp.PairSet.make ~num_registers in
   let move_list = Reg.Tbl.create 128 in
   let stack_slots = Reg.Tbl.create 128 in
   let num_stack_slots = Array.make Proc.num_register_classes 0 in
@@ -100,11 +114,11 @@ let[@inline] add_initial_list state regs =
   state.initial <- regs @ state.initial
 
 let[@inline] reset state ~new_temporaries =
-  let unknown_list_reg (l : Reg.t list) : unit =
-    List.iter l ~f:(fun (reg : Reg.t) -> reg.irc_work_list <- Unknown_list)
+  let unknown_reg_work_list (rwl : RegWorkList.t) : unit =
+    RegWorkList.iter rwl ~f:(fun reg -> reg.irc_work_list <- Unknown_list)
   in
-  let unknown_list_instr (l : Instruction.t list) : unit =
-    List.iter l ~f:(fun (instr : Instruction.t) ->
+  let unknown_instruction_work_list (iwl : InstructionWorkList.t) : unit =
+    InstructionWorkList.iter iwl ~f:(fun instr ->
         instr.irc_work_list <- Unknown_list)
   in
   List.iter (Reg.all_registers ()) ~f:(fun reg ->
@@ -121,29 +135,31 @@ let[@inline] reset state ~new_temporaries =
       reg.Reg.irc_alias <- None;
       reg.Reg.interf <- [];
       assert (reg.Reg.degree = Degree.infinite));
-  state.initial <- new_temporaries @ state.colored_nodes @ state.coalesced_nodes;
+  state.initial
+    <- new_temporaries @ state.colored_nodes
+       @ RegWorkList.to_list state.coalesced_nodes;
   List.iter state.initial ~f:(fun reg -> reg.Reg.irc_work_list <- Initial);
-  unknown_list_reg state.simplify_work_list;
-  state.simplify_work_list <- [];
-  unknown_list_reg state.freeze_work_list;
-  state.freeze_work_list <- [];
-  unknown_list_reg state.spill_work_list;
-  state.spill_work_list <- [];
-  unknown_list_reg state.spilled_nodes;
-  state.spilled_nodes <- [];
-  state.coalesced_nodes <- [];
+  unknown_reg_work_list state.simplify_work_list;
+  state.simplify_work_list <- RegWorkList.empty state.simplify_work_list;
+  unknown_reg_work_list state.freeze_work_list;
+  state.freeze_work_list <- RegWorkList.empty state.freeze_work_list;
+  unknown_reg_work_list state.spill_work_list;
+  state.spill_work_list <- RegWorkList.empty state.spill_work_list;
+  unknown_reg_work_list state.spilled_nodes;
+  state.spilled_nodes <- RegWorkList.empty state.spilled_nodes;
+  state.coalesced_nodes <- RegWorkList.empty state.coalesced_nodes;
   state.colored_nodes <- [];
   assert (state.select_stack = []);
-  unknown_list_instr state.coalesced_moves;
-  state.coalesced_moves <- [];
-  unknown_list_instr state.constrained_moves;
-  state.constrained_moves <- [];
-  unknown_list_instr state.frozen_moves;
-  state.frozen_moves <- [];
-  unknown_list_instr state.work_list_moves;
-  state.work_list_moves <- [];
-  unknown_list_instr state.active_moves;
-  state.active_moves <- [];
+  unknown_instruction_work_list state.coalesced_moves;
+  state.coalesced_moves <- InstructionWorkList.empty state.coalesced_moves;
+  unknown_instruction_work_list state.constrained_moves;
+  state.constrained_moves <- InstructionWorkList.empty state.constrained_moves;
+  unknown_instruction_work_list state.frozen_moves;
+  state.frozen_moves <- InstructionWorkList.empty state.frozen_moves;
+  unknown_instruction_work_list state.work_list_moves;
+  state.work_list_moves <- InstructionWorkList.empty state.work_list_moves;
+  unknown_instruction_work_list state.active_moves;
+  state.active_moves <- InstructionWorkList.empty state.active_moves;
   RegisterStamp.PairSet.clear state.adj_set;
   Reg.Tbl.clear state.move_list;
   state.introduced_temporaries
@@ -161,80 +177,81 @@ let[@inline] get_and_clear_initial state =
   state.initial <- [];
   res
 
-let[@inline] is_empty_simplify_work_list state = state.simplify_work_list = []
+let[@inline] is_empty_simplify_work_list state =
+  RegWorkList.is_empty state.simplify_work_list
 
 let[@inline] add_simplify_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Simplify;
-  state.simplify_work_list <- reg :: state.simplify_work_list
-
-let[@inline] remove_reg (reg : Reg.t) (l : Reg.t list) : Reg.t list =
-  let rec filter reg acc = function
-    | [] -> acc
-    | hd :: tl ->
-      if Reg.same reg hd then filter reg acc tl else filter reg (hd :: acc) tl
-  in
-  filter reg [] l
+  state.simplify_work_list <- RegWorkList.add state.simplify_work_list reg
 
 let[@inline] choose_and_remove_simplify_work_list state =
-  match state.simplify_work_list with
-  | [] -> fatal "simplify_work_list is empty"
-  | hd :: tl ->
-    state.simplify_work_list <- remove_reg hd tl;
-    hd
+  match RegWorkList.choose_and_remove state.simplify_work_list with
+  | None -> fatal "simplify_work_list is empty"
+  | Some (res, rwl) ->
+    res.Reg.irc_work_list <- Reg.Unknown_list;
+    state.simplify_work_list <- rwl;
+    res
 
-let[@inline] is_empty_freeze_work_list state = state.freeze_work_list = []
+let[@inline] is_empty_freeze_work_list state =
+  RegWorkList.is_empty state.freeze_work_list
 
 let[@inline] mem_freeze_work_list _state reg =
   reg.Reg.irc_work_list = Reg.Freeze
 
 let[@inline] add_freeze_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Freeze;
-  state.freeze_work_list <- reg :: state.freeze_work_list
+  state.freeze_work_list <- RegWorkList.add state.freeze_work_list reg
 
 let[@inline] remove_freeze_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Unknown_list;
-  state.freeze_work_list <- remove_reg reg state.freeze_work_list
+  state.freeze_work_list <- RegWorkList.remove state.freeze_work_list reg
 
 let[@inline] choose_and_remove_freeze_work_list state =
-  match state.freeze_work_list with
-  | [] -> fatal "freeze_work_list is empty"
-  | hd :: tl ->
-    hd.Reg.irc_work_list <- Reg.Unknown_list;
-    state.freeze_work_list <- remove_reg hd tl;
-    hd
+  match RegWorkList.choose_and_remove state.freeze_work_list with
+  | None -> fatal "freeze_work_list is empty"
+  | Some (res, rwl) ->
+    res.Reg.irc_work_list <- Reg.Unknown_list;
+    state.freeze_work_list <- rwl;
+    res
 
-let[@inline] is_empty_spill_work_list state = state.spill_work_list = []
+let[@inline] is_empty_spill_work_list state =
+  RegWorkList.is_empty state.spill_work_list
 
 let[@inline] mem_spill_work_list _state reg = reg.Reg.irc_work_list = Reg.Spill
 
 let[@inline] add_spill_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Spill;
-  state.spill_work_list <- reg :: state.spill_work_list
+  state.spill_work_list <- RegWorkList.add state.spill_work_list reg
 
 let[@inline] remove_spill_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Unknown_list;
-  state.spill_work_list <- remove_reg reg state.spill_work_list
+  state.spill_work_list <- RegWorkList.remove state.spill_work_list reg
 
-let[@inline] spill_work_list state = state.spill_work_list
+let[@inline] fold_spill_work_list state ~f ~init =
+  RegWorkList.fold state.spill_work_list ~f ~init
 
-let[@inline] is_empty_spilled_nodes state = state.spilled_nodes = []
+let[@inline] spill_work_list state = RegWorkList.to_set state.spill_work_list
+
+let[@inline] is_empty_spilled_nodes state =
+  RegWorkList.is_empty state.spilled_nodes
 
 let[@inline] add_spilled_nodes state reg =
   reg.Reg.irc_work_list <- Reg.Spilled;
-  state.spilled_nodes <- reg :: state.spilled_nodes
+  state.spilled_nodes <- RegWorkList.add state.spilled_nodes reg
 
-let[@inline] spilled_nodes state = state.spilled_nodes
+let[@inline] spilled_nodes state = RegWorkList.to_list state.spilled_nodes
 
 let[@inline] clear_spilled_nodes state =
-  List.iter state.spilled_nodes ~f:(fun reg ->
+  RegWorkList.iter state.spilled_nodes ~f:(fun reg ->
       reg.Reg.irc_work_list <- Reg.Unknown_list);
-  state.spilled_nodes <- []
+  state.spilled_nodes <- RegWorkList.empty state.spilled_nodes
 
 let[@inline] add_coalesced_nodes state reg =
   reg.Reg.irc_work_list <- Reg.Coalesced;
-  state.coalesced_nodes <- reg :: state.coalesced_nodes
+  state.coalesced_nodes <- RegWorkList.add state.coalesced_nodes reg
 
-let[@inline] coalesced_nodes state = state.coalesced_nodes
+let[@inline] iter_coalesced_nodes state ~f =
+  RegWorkList.iter state.coalesced_nodes ~f
 
 let[@inline] add_colored_nodes state reg =
   reg.Reg.irc_work_list <- Reg.Colored;
@@ -260,54 +277,46 @@ let[@inline] iter_and_clear_select_stack state ~f =
 
 let[@inline] add_coalesced_moves state instr =
   instr.Cfg.irc_work_list <- Coalesced;
-  state.coalesced_moves <- instr :: state.coalesced_moves
+  state.coalesced_moves <- InstructionWorkList.add state.coalesced_moves instr
 
 let[@inline] add_constrained_moves state instr =
   instr.Cfg.irc_work_list <- Constrained;
-  state.constrained_moves <- instr :: state.constrained_moves
+  state.constrained_moves
+    <- InstructionWorkList.add state.constrained_moves instr
 
 let[@inline] add_frozen_moves state instr =
   instr.Cfg.irc_work_list <- Frozen;
-  state.frozen_moves <- instr :: state.frozen_moves
+  state.frozen_moves <- InstructionWorkList.add state.frozen_moves instr
 
-let[@inline] is_empty_work_list_moves state = state.work_list_moves = []
+let[@inline] is_empty_work_list_moves state =
+  InstructionWorkList.is_empty state.work_list_moves
 
 let[@inline] add_work_list_moves state instr =
   instr.Cfg.irc_work_list <- Work_list;
-  state.work_list_moves <- instr :: state.work_list_moves
-
-let[@inline] remove_instr (instr : Instruction.t) (l : Instruction.t list) :
-    Instruction.t list =
-  let rec filter instr acc = function
-    | [] -> acc
-    | hd :: tl ->
-      if hd.Cfg.id = instr.Cfg.id
-      then filter instr acc tl
-      else filter instr (hd :: acc) tl
-  in
-  filter instr [] l
+  state.work_list_moves <- InstructionWorkList.add state.work_list_moves instr
 
 let[@inline] choose_and_remove_work_list_moves state =
-  match state.work_list_moves with
-  | [] -> fatal "work_list_moves is empty"
-  | hd :: tl ->
-    hd.Cfg.irc_work_list <- Unknown_list;
-    state.work_list_moves <- remove_instr hd tl;
-    hd
+  match InstructionWorkList.choose_and_remove state.work_list_moves with
+  | None -> fatal "work_list_moves is empty"
+  | Some (res, iwl) ->
+    res.Cfg.irc_work_list <- Unknown_list;
+    state.work_list_moves <- iwl;
+    res
 
 let[@inline] mem_active_moves _state instr =
   instr.Cfg.irc_work_list = Cfg.Active
 
 let[@inline] add_active_moves state instr =
   instr.Cfg.irc_work_list <- Active;
-  state.active_moves <- instr :: state.active_moves
+  state.active_moves <- InstructionWorkList.add state.active_moves instr
 
 let[@inline] remove_active_moves state instr =
   instr.Cfg.irc_work_list <- Unknown_list;
-  state.active_moves <- remove_instr instr state.active_moves
+  state.active_moves <- InstructionWorkList.remove state.active_moves instr
 
 let[@inline] mem_adj_set state reg1 reg2 =
-  RegisterStamp.PairSet.mem state.adj_set reg1.Reg.stamp reg2.Reg.stamp
+  RegisterStamp.PairSet.mem state.adj_set
+    (RegisterStamp.pair reg1.Reg.stamp reg2.Reg.stamp)
 
 let[@inline] adj_list _state reg = reg.Reg.interf
 
@@ -318,11 +327,12 @@ let[@inline] add_edge state u v =
     | Unknown -> true
     | Stack (Local _ | Incoming _ | Outgoing _ | Domainstate _) -> false
   in
+  let pair = RegisterStamp.pair u.Reg.stamp v.Reg.stamp in
   if (not (Reg.same u v))
      && is_interesting_reg u && is_interesting_reg v && same_reg_class u v
-     && not (RegisterStamp.PairSet.mem state.adj_set u.Reg.stamp v.Reg.stamp)
+     && not (RegisterStamp.PairSet.mem state.adj_set pair)
   then (
-    RegisterStamp.PairSet.add state.adj_set u.Reg.stamp v.Reg.stamp;
+    RegisterStamp.PairSet.add state.adj_set pair;
     let add_adj_list x y = x.Reg.interf <- y :: x.Reg.interf in
     let incr_degree x =
       let deg = x.Reg.degree in
@@ -358,24 +368,30 @@ let[@inline] is_empty_node_moves state reg =
   | None -> true
   | Some move_list ->
     not
-      (Instruction.Set.exists move_list ~f:(fun instr ->
+      (Instruction.Set.exists
+         (fun instr ->
            match instr.irc_work_list with
            | Active | Work_list -> true
-           | _ -> false))
+           | _ -> false)
+         move_list)
 
 let[@inline] iter_node_moves state reg ~f =
   match Reg.Tbl.find_opt state.move_list reg with
   | None -> ()
   | Some move_list ->
-    Instruction.Set.iter move_list ~f:(fun instr ->
+    Instruction.Set.iter
+      (fun instr ->
         match instr.irc_work_list with Active | Work_list -> f instr | _ -> ())
+      move_list
 
 let[@inline] is_move_related state reg =
   match Reg.Tbl.find_opt state.move_list reg with
   | None -> false
   | Some move_list ->
-    Instruction.Set.exists move_list ~f:(fun instr ->
+    Instruction.Set.exists
+      (fun instr ->
         match instr.irc_work_list with Active | Work_list -> true | _ -> false)
+      move_list
 
 let[@inline] enable_moves_one state reg =
   let n = reg in
@@ -383,8 +399,8 @@ let[@inline] enable_moves_one state reg =
       match m.irc_work_list with
       | Active ->
         m.irc_work_list <- Work_list;
-        state.active_moves <- remove_instr m state.active_moves;
-        state.work_list_moves <- m :: state.work_list_moves
+        state.active_moves <- InstructionWorkList.remove state.active_moves m;
+        state.work_list_moves <- InstructionWorkList.add state.work_list_moves m
       | _ -> ())
 
 let[@inline] decr_degree state reg =
@@ -398,14 +414,14 @@ let[@inline] decr_degree state reg =
       enable_moves_one state reg;
       iter_adjacent state reg ~f:(fun r -> enable_moves_one state r);
       reg.Reg.irc_work_list <- Reg.Unknown_list;
-      state.spill_work_list <- remove_reg reg state.spill_work_list;
+      state.spill_work_list <- RegWorkList.remove state.spill_work_list reg;
       if is_move_related state reg
       then (
         reg.Reg.irc_work_list <- Reg.Freeze;
-        state.freeze_work_list <- reg :: state.freeze_work_list)
+        state.freeze_work_list <- RegWorkList.add state.freeze_work_list reg)
       else (
         reg.Reg.irc_work_list <- Reg.Simplify;
-        state.simplify_work_list <- reg :: state.simplify_work_list)))
+        state.simplify_work_list <- RegWorkList.add state.simplify_work_list reg)))
 
 let[@inline] find_move_list state reg =
   match Reg.Tbl.find_opt state.move_list reg with
@@ -495,12 +511,14 @@ let[@inline] check_set_and_field_consistency_reg (work_list, set, field_value) =
 
 let[@inline] check_set_and_field_consistency_instr (work_list, set, field_value)
     =
-  Instruction.Set.iter set ~f:(fun instr ->
+  Instruction.Set.iter
+    (fun instr ->
       if instr.Cfg.irc_work_list <> field_value
       then
         fatal "instruction %d is in %s but its field equals %S" instr.Cfg.id
           work_list
           (Cfg.string_of_irc_work_list instr.Cfg.irc_work_list))
+    set
 
 let[@inline] check_inter_has_no_duplicates (reg : Reg.t) : unit =
   let l = reg.Reg.interf in
@@ -509,6 +527,7 @@ let[@inline] check_inter_has_no_duplicates (reg : Reg.t) : unit =
   then fatal "interf list for %a is not a set" Printmach.reg reg
 
 let[@inline] invariant state =
+  (* CR xclerc for xclerc: avoid multiple conversions to sets. *)
   if irc_debug && irc_invariants
   then (
     (* interf (list) is morally a set *)
@@ -518,52 +537,59 @@ let[@inline] invariant state =
     check_disjoint ~is_disjoint:Reg.Set.disjoint
       [ "precolored", Reg.set_of_array all_precolored_regs;
         "initial", Reg.Set.of_list state.initial;
-        "simplify_work_list", Reg.Set.of_list state.simplify_work_list;
-        "freeze_work_list", Reg.Set.of_list state.freeze_work_list;
-        "spill_work_list", Reg.Set.of_list state.spill_work_list;
-        "spilled_nodes", Reg.Set.of_list state.spilled_nodes;
-        "coalesced_nodes", Reg.Set.of_list state.coalesced_nodes;
+        "simplify_work_list", RegWorkList.to_set state.simplify_work_list;
+        "freeze_work_list", RegWorkList.to_set state.freeze_work_list;
+        "spill_work_list", RegWorkList.to_set state.spill_work_list;
+        "spilled_nodes", RegWorkList.to_set state.spilled_nodes;
+        "coalesced_nodes", RegWorkList.to_set state.coalesced_nodes;
         "colored_nodes", Reg.Set.of_list state.colored_nodes;
         "select_stack", Reg.Set.of_list state.select_stack ];
     List.iter ~f:check_set_and_field_consistency_reg
       [ "precolored", Reg.set_of_array all_precolored_regs, Reg.Precolored;
         "initial", Reg.Set.of_list state.initial, Reg.Initial;
         ( "simplify_work_list",
-          Reg.Set.of_list state.simplify_work_list,
+          RegWorkList.to_set state.simplify_work_list,
           Reg.Simplify );
-        "freeze_work_list", Reg.Set.of_list state.freeze_work_list, Reg.Freeze;
-        "spill_work_list", Reg.Set.of_list state.spill_work_list, Reg.Spill;
-        "spilled_nodes", Reg.Set.of_list state.spilled_nodes, Reg.Spilled;
-        "coalesced_nodes", Reg.Set.of_list state.coalesced_nodes, Reg.Coalesced;
+        ( "freeze_work_list",
+          RegWorkList.to_set state.freeze_work_list,
+          Reg.Freeze );
+        "spill_work_list", RegWorkList.to_set state.spill_work_list, Reg.Spill;
+        "spilled_nodes", RegWorkList.to_set state.spilled_nodes, Reg.Spilled;
+        ( "coalesced_nodes",
+          RegWorkList.to_set state.coalesced_nodes,
+          Reg.Coalesced );
         "colored_nodes", Reg.Set.of_list state.colored_nodes, Reg.Colored;
         "select_stack", Reg.Set.of_list state.select_stack, Reg.Select_stack ];
     (* move sets are disjoint *)
     check_disjoint ~is_disjoint:Instruction.Set.disjoint
-      [ "coalesced_moves", Instruction.Set.of_list state.coalesced_moves;
-        "constrained_moves", Instruction.Set.of_list state.constrained_moves;
-        "frozen_moves", Instruction.Set.of_list state.frozen_moves;
-        "work_list_moves", Instruction.Set.of_list state.work_list_moves;
-        "active_moves", Instruction.Set.of_list state.active_moves ];
+      [ "coalesced_moves", InstructionWorkList.to_set state.coalesced_moves;
+        "constrained_moves", InstructionWorkList.to_set state.constrained_moves;
+        "frozen_moves", InstructionWorkList.to_set state.frozen_moves;
+        "work_list_moves", InstructionWorkList.to_set state.work_list_moves;
+        "active_moves", InstructionWorkList.to_set state.active_moves ];
     List.iter ~f:check_set_and_field_consistency_instr
       [ ( "coalesced_moves",
-          Instruction.Set.of_list state.coalesced_moves,
+          InstructionWorkList.to_set state.coalesced_moves,
           Cfg.Coalesced );
         ( "constrained_moves",
-          Instruction.Set.of_list state.constrained_moves,
+          InstructionWorkList.to_set state.constrained_moves,
           Cfg.Constrained );
-        "frozen_moves", Instruction.Set.of_list state.frozen_moves, Cfg.Frozen;
+        ( "frozen_moves",
+          InstructionWorkList.to_set state.frozen_moves,
+          Cfg.Frozen );
         ( "work_list_moves",
-          Instruction.Set.of_list state.work_list_moves,
+          InstructionWorkList.to_set state.work_list_moves,
           Cfg.Work_list );
-        "active_moves", Instruction.Set.of_list state.active_moves, Cfg.Active
-      ];
+        ( "active_moves",
+          InstructionWorkList.to_set state.active_moves,
+          Cfg.Active ) ];
     (* degree is consistent with adjacency lists/sets *)
     let work_lists =
       Reg.Set.union
-        (Reg.Set.of_list state.simplify_work_list)
+        (RegWorkList.to_set state.simplify_work_list)
         (Reg.Set.union
-           (Reg.Set.of_list state.freeze_work_list)
-           (Reg.Set.of_list state.spill_work_list))
+           (RegWorkList.to_set state.freeze_work_list)
+           (RegWorkList.to_set state.spill_work_list))
     in
     let work_lists_or_precolored =
       Reg.Set.union (Reg.set_of_array all_precolored_regs) work_lists

--- a/backend/cfg/cfg_irc_state.mli
+++ b/backend/cfg/cfg_irc_state.mli
@@ -43,7 +43,9 @@ val add_spill_work_list : t -> Reg.t -> unit
 
 val remove_spill_work_list : t -> Reg.t -> unit
 
-val spill_work_list : t -> Reg.t list
+val fold_spill_work_list : t -> f:(Reg.t -> 'a -> 'a) -> init:'a -> 'a
+
+val spill_work_list : t -> Reg.Set.t
 
 val is_empty_spilled_nodes : t -> bool
 
@@ -55,7 +57,7 @@ val clear_spilled_nodes : t -> unit
 
 val add_coalesced_nodes : t -> Reg.t -> unit
 
-val coalesced_nodes : t -> Reg.t list
+val iter_coalesced_nodes : t -> f:(Reg.t -> unit) -> unit
 
 val add_colored_nodes : t -> Reg.t -> unit
 

--- a/backend/cfg/cfg_irc_utils.ml
+++ b/backend/cfg/cfg_irc_utils.ml
@@ -69,7 +69,7 @@ module RegisterStamp = struct
   (* CR xclerc for xclerc: consider using a bit matrix *)
 
   module PS = Hashtbl.Make (struct
-    type nonrec t = t * t
+    type t = pair
 
     let equal (left : t) (right : t) : bool =
       Int.equal (fst left) (fst right) && Int.equal (snd left) (snd right)

--- a/backend/cfg/cfg_irc_utils.ml
+++ b/backend/cfg/cfg_irc_utils.ml
@@ -58,6 +58,14 @@ end
 module RegisterStamp = struct
   type t = int
 
+  type pair = t * t
+
+  let pair (x : t) (y : t) = if x <= y then x, y else y, x
+
+  let fst = fst
+
+  let snd = snd
+
   (* CR xclerc for xclerc: consider using a bit matrix *)
 
   module PS = Hashtbl.Make (struct
@@ -68,28 +76,24 @@ module RegisterStamp = struct
 
     let hash ((x, y) : t) =
       (* CR xclerc for xclerc: review *)
-      (x lsl 10) lxor y
+      (x lsl 17) lxor y
   end)
 
   module PairSet = struct
-    type stamp = t
-
     type t = unit PS.t
 
-    let make () = PS.create 256
+    let default_size = 256
+
+    let make ~num_registers =
+      let estimated_size = (num_registers * num_registers) asr 5 in
+      PS.create
+        (if estimated_size < default_size then default_size else estimated_size)
 
     let clear set = PS.clear set
 
-    (* CR xclerc for xclec: the caller is likely to call mem and add, so build
-       the pair there *)
+    let mem set (x : pair) = PS.mem set x
 
-    let mem set (x : stamp) (y : stamp) =
-      let v = if x <= y then x, y else y, x in
-      PS.mem set v
-
-    let add set (x : stamp) (y : stamp) =
-      let v = if x <= y then x, y else y, x in
-      PS.replace set v ()
+    let add set (x : pair) = PS.replace set x ()
 
     let cardinal set = PS.length set
 
@@ -229,4 +233,105 @@ module Spilling_heuristics = struct
         | _ ->
           fatal "unknown heuristics %S (possible values: %s)" id
             (available_heuristics ())))
+end
+
+(* CR xclerc for xclerc: consider dynamic sorted arrays *)
+module WorkList = struct
+  module type S = sig
+    type e
+
+    type t
+
+    module Set : Set.S with type elt = e
+
+    val make : expected_max_size:int -> t
+
+    val empty : t -> t
+
+    val is_empty : t -> bool
+
+    val add : t -> e -> t
+
+    val remove : t -> e -> t
+
+    val choose_and_remove : t -> (e * t) option
+
+    val iter : t -> f:(e -> unit) -> unit
+
+    val fold : t -> f:(e -> 'a -> 'a) -> init:'a -> 'a
+
+    val to_list : t -> e list
+
+    val to_set : t -> Set.t
+  end
+
+  module Make (E : Set.OrderedType) (ES : Set.S with type elt = E.t) :
+    S with type e = E.t and module Set = ES = struct
+    module Set = ES
+
+    let cut_off = 16
+
+    type e = E.t
+
+    type t =
+      | List of e List.t
+      | Set of Set.t
+
+    let empty_list = List []
+
+    let empty_set = Set Set.empty
+
+    let make ~expected_max_size =
+      if expected_max_size < cut_off then empty_list else empty_set
+
+    let empty t = match t with List _ -> empty_list | Set _ -> empty_set
+
+    let is_empty t =
+      match t with
+      | List l -> ( match l with [] -> true | _ :: _ -> false)
+      | Set s -> Set.is_empty s
+
+    let add t e =
+      match t with
+      | List l ->
+        if List.exists l ~f:(fun x -> E.compare x e = 0)
+        then t
+        else List (e :: l)
+      | Set s ->
+        let s' = Set.add e s in
+        if s == s' then t else Set s'
+
+    let remove t e =
+      match t with
+      | List l ->
+        let rec filter e acc = function
+          | [] -> acc
+          | hd :: tl ->
+            if E.compare e hd = 0 then acc @ tl else filter e (hd :: acc) tl
+        in
+        List (filter e [] l)
+      | Set s ->
+        let s' = Set.remove e s in
+        if s == s' then t else Set s'
+
+    let choose_and_remove t =
+      match t with
+      | List l -> ( match l with [] -> None | hd :: tl -> Some (hd, List tl))
+      | Set s -> (
+        match Set.choose_opt s with
+        | None -> None
+        | Some e -> Some (e, Set (Set.remove e s)))
+
+    let iter t ~f =
+      match t with List l -> List.iter l ~f | Set s -> Set.iter f s
+
+    let fold t ~f ~init =
+      match t with
+      | List l -> List.fold_left l ~f:(fun acc elem -> f elem acc) ~init
+      | Set s -> Set.fold f s init
+
+    let to_list t = match t with List l -> l | Set s -> Set.elements s
+
+    let to_set t = match t with List l -> Set.of_list l | Set s -> s
+  end
 end

--- a/backend/cfg/cfg_irc_utils.mli
+++ b/backend/cfg/cfg_irc_utils.mli
@@ -91,6 +91,7 @@ module Spilling_heuristics : sig
   val env : t Lazy.t
 end
 
+(* Actually work "sets", uses "lists" to follow the article/book. *)
 module WorkList : sig
   module type S = sig
     type e

--- a/backend/cfg/cfg_irc_utils.mli
+++ b/backend/cfg/cfg_irc_utils.mli
@@ -23,22 +23,28 @@ end
 module RegisterStamp : sig
   type t = int
 
-  module PairSet : sig
-    type stamp := t
+  type pair
 
+  val pair : t -> t -> pair
+
+  val fst : pair -> t
+
+  val snd : pair -> t
+
+  module PairSet : sig
     type t
 
-    val make : unit -> t
+    val make : num_registers:int -> t
 
     val clear : t -> unit
 
-    val mem : t -> stamp -> stamp -> bool
+    val mem : t -> pair -> bool
 
-    val add : t -> stamp -> stamp -> unit
+    val add : t -> pair -> unit
 
     val cardinal : t -> int
 
-    val iter : t -> f:(stamp * stamp -> unit) -> unit
+    val iter : t -> f:(pair -> unit) -> unit
   end
 end
 
@@ -83,4 +89,37 @@ module Spilling_heuristics : sig
   val to_string : t -> string
 
   val env : t Lazy.t
+end
+
+module WorkList : sig
+  module type S = sig
+    type e
+
+    type t
+
+    module Set : Set.S with type elt = e
+
+    val make : expected_max_size:int -> t
+
+    val empty : t -> t
+
+    val is_empty : t -> bool
+
+    val add : t -> e -> t
+
+    val remove : t -> e -> t
+
+    val choose_and_remove : t -> (e * t) option
+
+    val iter : t -> f:(e -> unit) -> unit
+
+    val fold : t -> f:(e -> 'a -> 'a) -> init:'a -> 'a
+
+    val to_list : t -> e list
+
+    val to_set : t -> Set.t
+  end
+
+  module Make (E : Set.OrderedType) (ES : Set.S with type elt = E.t) :
+    S with type e = E.t and module Set = ES
 end

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -16,10 +16,12 @@ module Instruction = struct
 
   type t = Cfg.basic Cfg.instruction
 
-  module Set = MoreLabels.Set.Make (struct
+  let compare (left : t) (right : t) : int = Int.compare left.id right.id
+
+  module Set = Set.Make (struct
     type nonrec t = t
 
-    let compare (left : t) (right : t) : int = Int.compare left.id right.id
+    let compare = compare
   end)
 
   module IdSet = MoreLabels.Set.Make (Int)

--- a/backend/cfg/cfg_regalloc_utils.mli
+++ b/backend/cfg/cfg_regalloc_utils.mli
@@ -13,7 +13,9 @@ module Instruction : sig
 
   type t = Cfg.basic Cfg.instruction
 
-  module Set : MoreLabels.Set.S with type elt = t
+  val compare : t -> t -> int
+
+  module Set : Set.S with type elt = t
 
   module IdSet : MoreLabels.Set.S with type elt = id
 


### PR DESCRIPTION
This pull request mainly changes the representation
of the _worklists_ (really _worksets_), used by IRC.

In #678, they are implemented as bare lists, which
is unsurprisingly not efficient when there are a lot of
temporaries. Simply switching to `Set` is not a panacea,
because when there are few elements, a list is indeed
more efficient.

After comparing function-per-function the time IRC
takes when using `List` and `Set` to implement work
sets, it became clear that:
- lists were always faster when there were less then
  12 temporaries;
- sets were always faster when there were more than
  18 temporaries.

_Hence_ the cut-off point at 16 in this PR.

An upcoming PR will experiment with another
representation, based on (dynamic) sorted arrays.