### PR TITLE
CI job to test IRC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,35 +14,42 @@ jobs:
             os: ubuntu-latest
             ocamlparam: ''
             check_arch: true
+            register_allocator: upstream
 
           - name: closure_cfg_local
             config: --enable-middle-end=closure --enable-stack-allocation
             os: ubuntu-latest
             ocamlparam: _,ocamlcfg=1
+            register_allocator: upstream
 
           - name: flambda1
             config: --enable-middle-end=flambda
             os: ubuntu-latest
             ocamlparam: ''
+            register_allocator: upstream
 
           - name: flambda1_cfg_local
             config: --enable-middle-end=flambda --enable-stack-allocation
             os: ubuntu-latest
             ocamlparam: _,ocamlcfg=1
+            register_allocator: upstream
 
           - name: flambda2
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
             ocamlparam: ''
+            register_allocator: upstream
 
           - name: flambda2_cfg_local
             config: --enable-middle-end=flambda2 --enable-stack-allocation
             os: ubuntu-latest
             ocamlparam: _,ocamlcfg=1
+            register_allocator: upstream
 
           - name: flambda2_macos
             config: --enable-middle-end=flambda2
             os: macos-latest
+            register_allocator: upstream
 
           - name: irc
             config: --enable-middle-end=closure
@@ -50,12 +57,16 @@ jobs:
             ocamlparam: ''
             check_arch: true
             register_allocator: irc
+            irc_split: off
+            irc_spilling_heuristics: flat_uses
 
     env:
       J: "3"
       # On macOS, the testsuite is slow, so run only on push to main (#507)
       run_testsuite: "${{matrix.os != 'macos-latest' || (github.event_name == 'push' && github.event.ref == 'refs/heads/main')}}"
       REGISTER_ALLOCATOR: "${{matrix.register_allocator}}"
+      IRC_SPLIT: "${{matrix.irc_split}}"
+      IRC_SPILLING_HEURISTICS: "${{matrix.irc_spilling_heuristics}}"
 
     steps:
     - name: Checkout the Flambda backend repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,42 +14,35 @@ jobs:
             os: ubuntu-latest
             ocamlparam: ''
             check_arch: true
-            register_allocator: upstream
 
           - name: closure_cfg_local
             config: --enable-middle-end=closure --enable-stack-allocation
             os: ubuntu-latest
             ocamlparam: _,ocamlcfg=1
-            register_allocator: upstream
 
           - name: flambda1
             config: --enable-middle-end=flambda
             os: ubuntu-latest
             ocamlparam: ''
-            register_allocator: upstream
 
           - name: flambda1_cfg_local
             config: --enable-middle-end=flambda --enable-stack-allocation
             os: ubuntu-latest
             ocamlparam: _,ocamlcfg=1
-            register_allocator: upstream
 
           - name: flambda2
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
             ocamlparam: ''
-            register_allocator: upstream
 
           - name: flambda2_cfg_local
             config: --enable-middle-end=flambda2 --enable-stack-allocation
             os: ubuntu-latest
             ocamlparam: _,ocamlcfg=1
-            register_allocator: upstream
 
           - name: flambda2_macos
             config: --enable-middle-end=flambda2
             os: macos-latest
-            register_allocator: upstream
 
           - name: irc
             config: --enable-middle-end=closure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
             os: macos-latest
 
           - name: irc
-            config: --enable-middle-end=closure
+            config: --enable-middle-end=flambda2
             os: ubuntu-latest
             ocamlparam: ''
             check_arch: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,14 @@ jobs:
             config: --enable-middle-end=flambda2
             os: macos-latest
 
+          - name: irc
+            config: --enable-middle-end=closure
+            os: ubuntu-latest
+            ocamlparam: ''
+            check_arch: true
+            env:
+              REGISTER_ALLOCATOR=irc
+
     env:
       J: "3"
       # On macOS, the testsuite is slow, so run only on push to main (#507)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,13 +49,13 @@ jobs:
             os: ubuntu-latest
             ocamlparam: ''
             check_arch: true
-            env:
-              REGISTER_ALLOCATOR=irc
+            register_allocator: irc
 
     env:
       J: "3"
       # On macOS, the testsuite is slow, so run only on push to main (#507)
       run_testsuite: "${{matrix.os != 'macos-latest' || (github.event_name == 'push' && github.event.ref == 'refs/heads/main')}}"
+      REGISTER_ALLOCATOR: "${{matrix.register_allocator}}"
 
     steps:
     - name: Checkout the Flambda backend repo

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -335,6 +335,7 @@ let register_allocator : register_allocator =
   | Some id ->
     match String.lowercase_ascii id with
     | "irc" -> IRC
+    | "upstream" -> Upstream
     | _ -> Misc.fatal_errorf "unknown register allocator %S" id
 
 let compile_fundecl ?dwarf ~ppf_dump fd_cmm =

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -335,7 +335,7 @@ let register_allocator : register_allocator =
   | Some id ->
     match String.lowercase_ascii id with
     | "irc" -> IRC
-    | "upstream" -> Upstream
+    | "" | "upstream" -> Upstream
     | _ -> Misc.fatal_errorf "unknown register allocator %S" id
 
 let compile_fundecl ?dwarf ~ppf_dump fd_cmm =


### PR DESCRIPTION
This pull request adds a new CI job to exercise
the IRC allocator. Contrary to the commit message,
this is done with flambda2, for a rather bad reason:
the new pipeline disagrees with the existing one on
one test case (namely `catch-rec-deadhandler.cmm`)
and this test is disabled with flambda2.