### PR TITLE
Remove Unix and Bigarray deps from ocamloptcomp

### DIFF
--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -26,7 +26,8 @@ type middle_end =
 
 (** Compile an implementation from Lambda using the given middle end. *)
 val compile_implementation
-   : ?toplevel:(string -> bool)
+   : (module Owee.Unix_intf.S)
+  -> ?toplevel:(string -> bool)
   -> backend:(module Backend_intf.S)
   -> filename:string
   -> prefixname:string
@@ -39,7 +40,8 @@ val compile_implementation
     The Flambda 2 middle end neither uses the Clambda language nor the
     Cmmgen pass.  Instead it emits Cmm directly. *)
 val compile_implementation_flambda2
-   : ?toplevel:(string -> bool)
+   : (module Owee.Unix_intf.S)
+  -> ?toplevel:(string -> bool)
   -> ?keep_symbol_tables:bool
   -> filename:string
   -> prefixname:string
@@ -61,7 +63,7 @@ val compile_implementation_flambda2
   -> unit
 
 val compile_implementation_linear :
-    string -> progname:string -> unit
+    (module Owee.Unix_intf.S) -> string -> progname:string -> unit
 
 val compile_phrase
   : ?dwarf:Dwarf_ocaml.Dwarf.t
@@ -94,7 +96,8 @@ val compile_unit
   Might return an instance of [Dwarf_ocaml.Dwarf.t] that can be used to generate
   dwarf information for the target system. *)
 val emit_begin_assembly_with_dwarf
-   : disable_dwarf:bool
+   : (module Owee.Unix_intf.S)
+  -> disable_dwarf:bool
   -> emit_begin_assembly:(init_dwarf:(unit -> unit) -> unit)
   -> sourcefile:string
   -> unit

--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -309,7 +309,7 @@ let make_globals_map units_list =
     interfaces
     defined
 
-let make_startup_file ~ppf_dump ~named_startup_file ~filename genfns units =
+let make_startup_file unix ~ppf_dump ~named_startup_file ~filename genfns units =
   Location.input_name := "caml_startup"; (* set name of "current" input *)
   Compilenv.reset "_startup"; (* set the name of the "current" compunit *)
   let dwarf =
@@ -319,7 +319,7 @@ let make_startup_file ~ppf_dump ~named_startup_file ~filename genfns units =
       if named_startup_file then filename
       else ".startup"
     in
-    Asmgen.emit_begin_assembly_with_dwarf
+    Asmgen.emit_begin_assembly_with_dwarf unix
       ~disable_dwarf:(not !Dwarf_flags.dwarf_for_startup_file)
       ~emit_begin_assembly:Emit.begin_assembly
       ~sourcefile:filename
@@ -430,7 +430,7 @@ let reset () =
 
 (* Main entry point *)
 
-let link ~ppf_dump objfiles output_name =
+let link unix ~ppf_dump objfiles output_name =
   Profile.record_call output_name (fun () ->
     let stdlib = "stdlib.cmxa" in
     let stdexit = "std_exit.cmx" in
@@ -459,7 +459,8 @@ let link ~ppf_dump objfiles output_name =
       ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
       ~obj_filename:startup_obj
       ~may_reduce_heap:true
-      (fun () -> make_startup_file ~ppf_dump ~named_startup_file ~filename:startup genfns units_tolink);
+      (fun () -> make_startup_file unix ~ppf_dump ~named_startup_file
+        ~filename:startup genfns units_tolink);
     Emitaux.reduce_heap_size ~reset:(fun () -> reset ());
     Misc.try_finally
       (fun () -> call_linker ml_objfiles startup_obj output_name)

--- a/backend/asmlink.mli
+++ b/backend/asmlink.mli
@@ -18,7 +18,8 @@
 open Misc
 open Format
 
-val link: ppf_dump:formatter -> string list -> string -> unit
+val link: (module Owee.Unix_intf.S) -> ppf_dump:formatter ->
+  string list -> string -> unit
 
 val link_shared: ppf_dump:formatter -> string list -> string -> unit
 

--- a/backend/asmpackager.mli
+++ b/backend/asmpackager.mli
@@ -17,7 +17,8 @@
    original compilation units as sub-modules. *)
 
 val package_files
-   : ppf_dump:Format.formatter
+   : (module Owee.Unix_intf.S)
+  -> ppf_dump:Format.formatter
   -> Env.t
   -> string list
   -> string

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -246,7 +246,7 @@ let write buf header section_table symbol_table relocation_tables string_table =
     relocation_tables;
   String_table.write string_table strtab.sh_offset buf
 
-let assemble asm output_file =
+let assemble unix asm output_file =
   let compiler_sections = get_sections asm in
   let string_table = String_table.create () in
   let sh_string_table = String_table.create () in
@@ -291,7 +291,7 @@ let assemble asm output_file =
       (Section_table.current_offset sections)
   in
   let elf =
-    Owee.Owee_buf.map_binary_write output_file
+    Owee.Owee_buf.map_binary_write unix output_file
       (Int64.to_int (Section_table.current_offset sections)
       + (header.e_shnum * header.e_shentsize))
   in

--- a/backend/internal_assembler/internal_assembler.mli
+++ b/backend/internal_assembler/internal_assembler.mli
@@ -22,4 +22,7 @@
 
 (** Create .o file. **)
 val assemble :
-  (X86_proc.Section_name.t * X86_ast.asm_line list) list -> string -> unit
+  (module Owee.Unix_intf.S) ->
+  (X86_proc.Section_name.t * X86_ast.asm_line list) list ->
+  string ->
+  unit

--- a/driver/boot_ocamlopt.ml
+++ b/driver/boot_ocamlopt.ml
@@ -1,3 +1,4 @@
 let () =
-  exit (Optmaindriver.main Sys.argv Format.err_formatter
+  exit (Optmaindriver.main (module Unix : Owee.Unix_intf.S) Sys.argv
+    Format.err_formatter
     ~flambda2:Flambda2.lambda_to_cmm)

--- a/driver/flambda_backend_main.ml
+++ b/driver/flambda_backend_main.ml
@@ -2,5 +2,6 @@ let () =
   (match Sys.backend_type with
    | Native -> Memtrace.trace_if_requested ~context:"ocamlopt" ()
    | Bytecode | Other _ -> ());
-  exit (Optmaindriver.main Sys.argv Format.err_formatter
+  exit (Optmaindriver.main (module Unix : Owee.Unix_intf.S)
+    Sys.argv Format.err_formatter
     ~flambda2:Flambda2.lambda_to_cmm)

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -18,7 +18,8 @@
 val interface: source_file:string -> output_prefix:string -> unit
 
 val implementation
-   : backend:(module Backend_intf.S)
+   : (module Owee.Unix_intf.S)
+  -> backend:(module Backend_intf.S)
   -> flambda2:(
     ppf_dump:Format.formatter ->
     prefixname:string ->
@@ -35,6 +36,7 @@ val implementation
 (** {2 Internal functions} **)
 
 val clambda :
+  (module Owee.Unix_intf.S) ->
   Compile_common.info ->
   (module Backend_intf.S) ->
   Typedtree.structure * Typedtree.module_coercion -> unit
@@ -43,6 +45,7 @@ val clambda :
 *)
 
 val flambda :
+  (module Owee.Unix_intf.S) ->
   Compile_common.info ->
   (module Backend_intf.S) ->
   Typedtree.structure * Typedtree.module_coercion -> unit

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -39,7 +39,7 @@ let usage = "Usage: ocamlopt <options> <files>\nOptions are:"
 module Options = Flambda_backend_args.Make_optcomp_options
         (Flambda_backend_args.Default.Optmain)
 
-let main argv ppf ~flambda2 =
+let main unix argv ppf ~flambda2 =
   native_code := true;
   let columns =
     match Sys.getenv "COLUMNS" with
@@ -74,7 +74,7 @@ let main argv ppf ~flambda2 =
     begin try
       Compenv.process_deferred_actions
         (ppf,
-         Optcompile.implementation ~backend ~flambda2,
+         Optcompile.implementation unix ~backend ~flambda2,
          Optcompile.interface,
          ".cmx",
          ".cmxa");
@@ -117,7 +117,8 @@ let main argv ppf ~flambda2 =
       Compmisc.init_path ();
       let target = Compenv.extract_output !output_name in
       Compmisc.with_ppf_dump ~file_prefix:target (fun ppf_dump ->
-        Asmpackager.package_files ~ppf_dump (Compmisc.initial_env ())
+        Asmpackager.package_files unix
+          ~ppf_dump (Compmisc.initial_env ())
           (Compenv.get_objfiles ~with_ocamlparam:false) target ~backend
           ~flambda2);
       Warnings.check_fatal ();
@@ -149,7 +150,8 @@ let main argv ppf ~flambda2 =
       Compmisc.init_path ();
       Compmisc.with_ppf_dump ~file_prefix:target (fun ppf_dump ->
           let objs = Compenv.get_objfiles ~with_ocamlparam:true in
-          Asmlink.link ~ppf_dump objs target);
+          Asmlink.link unix
+            ~ppf_dump objs target);
       Warnings.check_fatal ();
     end;
   with

--- a/driver/optmaindriver.mli
+++ b/driver/optmaindriver.mli
@@ -19,7 +19,8 @@
    NB: Due to internal state in the compiler, calling [main] twice during
    the same process is unsupported. *)
 val main
-   : string array
+   : (module Owee.Unix_intf.S)
+  -> string array
   -> Format.formatter
   -> flambda2:(
     ppf_dump:Format.formatter ->

--- a/dune
+++ b/dune
@@ -319,7 +319,8 @@
   flambda2_ui
   flambda2_to_cmm
   ocamloptcomp
-  ocamlcommon)
+  ocamlcommon
+  unix)
  (modules flambda_backend_main))
 
 (rule
@@ -341,7 +342,8 @@
   flambda2_ui
   flambda2_to_cmm
   ocamloptcomp
-  ocamlcommon)
+  ocamlcommon
+  unix)
  (modules flambda_backend_main_native))
 
 (rule
@@ -364,7 +366,8 @@
   flambda2_ui
   flambda2_to_cmm
   ocamloptcomp
-  ocamlcommon)
+  ocamlcommon
+  unix)
  (modules boot_ocamlopt))
 
 ; The input archives (.a, .cma and .cmxa) to the following three rules

--- a/external/owee/dune
+++ b/external/owee/dune
@@ -7,7 +7,6 @@
    (:include %{project_root}/sharedlib_cflags.sexp)
    (:include %{project_root}/oc_cppflags.sexp)))
 )
- (libraries unix bigarray)
  (synopsis "OCaml library to work with DWARF format"))
 
 (install

--- a/external/owee/owee_buf.ml
+++ b/external/owee/owee_buf.ml
@@ -8,7 +8,8 @@ type cursor = {
   mutable position: int;
 }
 
-let map_binary path =
+let map_binary unix path =
+  let module Unix = (val unix : Unix_intf.S) in
   let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
   let len = Unix.lseek fd 0 Unix.SEEK_END in
   let t =
@@ -18,7 +19,8 @@ let map_binary path =
   Unix.close fd;
   t
 
-let map_binary_write path size =
+let map_binary_write unix path size =
+  let module Unix = (val unix : Unix_intf.S) in
   let fd = Unix.openfile path [Unix.O_CREAT; Unix.O_RDWR] 0o644 in
   let t =
     Bigarray.array1_of_genarray
@@ -186,7 +188,7 @@ external bigstring_set32_unsafe :
 
 external bigstring_set64_unsafe :
   t -> byte_offset:int -> int64 -> unit = "%caml_bigstring_set64u"
-  
+
 module Write = struct
   let u8 t w  =
     Bigarray.Array1.unsafe_set t.buffer t.position w;
@@ -241,7 +243,7 @@ module Write = struct
   let zero_terminated_bytes t s =
     fixed_bytes t (Bytes.length s) s;
     u8 t 0
-    
+
   let fixed_string t length s =
     let {buffer; position} = t in
     unsafe_blit_str

--- a/external/owee/owee_buf.mli
+++ b/external/owee/owee_buf.mli
@@ -3,8 +3,8 @@
 type t =
   (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-val map_binary : string -> t
-val map_binary_write : string -> int -> t
+val map_binary : (module Unix_intf.S) -> string -> t
+val map_binary_write : (module Unix_intf.S) -> string -> int -> t
 
 (* Size of buffer remains int, because the size (aka dim) of
    Bigarray.Array1 is int, not int64. It should be enough in practice,

--- a/external/owee/owee_linux_maps.ml
+++ b/external/owee/owee_linux_maps.ml
@@ -41,5 +41,6 @@ let scan_file fname =
 let scan_pid pid =
   Printf.ksprintf scan_file "/proc/%d/maps" pid
 
-let scan_self () =
+let scan_self unix =
+  let module Unix = (val unix : Unix_intf.S) in
   scan_pid (Unix.getpid ())

--- a/external/owee/owee_linux_maps.mli
+++ b/external/owee/owee_linux_maps.mli
@@ -25,4 +25,4 @@ val scan_lines : Scanf.Scanning.in_channel -> entry list
 val scan_file : string -> entry list
 
 val scan_pid : int -> entry list
-val scan_self : unit -> entry list
+val scan_self : (module Unix_intf.S) -> entry list

--- a/external/owee/owee_location.mli
+++ b/external/owee/owee_location.mli
@@ -17,11 +17,12 @@ val extract : (_ -> _) -> t
     To succeed, debug information must be available for the location.
 
     This call might be quite expensive.  *)
-val lookup : t -> (string * int * int) option
+val lookup : (module Unix_intf.S) -> t -> (string * int * int) option
 
 (** Convenience function composing lookup and extract, to immediately turn a
     function into a position. *)
-val locate : (_ -> _) -> (string * int * int) option
+val locate : (module Unix_intf.S) -> (_ -> _)
+  -> (string * int * int) option
 
 val nearest_symbol : t -> string
 

--- a/external/owee/owee_traverse.mli
+++ b/external/owee/owee_traverse.mli
@@ -4,7 +4,8 @@ type location = Owee_location.t
 
 type 'a trace = Trace of int * string * 'a list * 'a trace list lazy_t
 
-val dump_trace : location trace list -> unit
-val dump_graphviz : location trace list -> out_channel -> unit
+val dump_trace : (module Unix_intf.S) -> location trace list -> unit
+val dump_graphviz : (module Unix_intf.S) -> location trace list ->
+  out_channel -> unit
 
 val extract_trace : ?search_depth:int -> 'a -> location trace list

--- a/external/owee/unix_intf.ml
+++ b/external/owee/unix_intf.ml
@@ -1,0 +1,48 @@
+(* A first-class module avoids a link-time dependency on [Unix], which would
+   cause ocamloptcomp to depend on [Unix], thus breaking compilerlibs clients.
+   The signature is written out explicitly rather than using "module type of"
+   on the [Unix] module so that the dune file doesn't need to have [unix] in the
+   [libraries] stanza.  This ensures accidental uses of [Unix] will be
+   caught. *)
+module type S = sig
+  type file_descr
+
+  type open_flag =
+      O_RDONLY
+    | O_WRONLY
+    | O_RDWR
+    | O_NONBLOCK
+    | O_APPEND
+    | O_CREAT
+    | O_TRUNC
+    | O_EXCL
+    | O_NOCTTY
+    | O_DSYNC
+    | O_SYNC
+    | O_RSYNC
+    | O_SHARE_DELETE
+    | O_CLOEXEC
+    | O_KEEPEXEC
+
+  type file_perm = int
+
+  val openfile : string -> open_flag list -> file_perm -> file_descr
+
+  val close : file_descr -> unit
+
+  type seek_command =
+      SEEK_SET
+    | SEEK_CUR
+    | SEEK_END
+
+  val lseek : file_descr -> int -> seek_command -> int
+
+  val map_file :
+    file_descr ->
+    ?pos:int64 ->
+    ('a, 'b) Stdlib.Bigarray.kind ->
+    'c Stdlib.Bigarray.layout -> bool -> int array ->
+    ('a, 'b, 'c) Stdlib.Bigarray.Genarray.t
+
+  val getpid : unit -> int
+end

--- a/native_toplevel/dune
+++ b/native_toplevel/dune
@@ -23,7 +23,7 @@
  (libraries ocamlcommon ocamlbytecomp ocamloptcomp
    flambda_backend_common
    flambda2_ui
-   flambda2 dynlink_internal)
+   flambda2 dynlink_internal unix)
  (modules genprintval_native opttoploop opttopdirs opttopmain))
 
 (rule

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -277,7 +277,9 @@ let default_load ppf (program : Lambda.program) =
   in
   let filename = Filename.chop_extension dll in
   if Config.flambda2 then begin
-    Asmgen.compile_implementation_flambda2 () ~toplevel:need_symbol
+    Asmgen.compile_implementation_flambda2
+      (module Unix : Owee.Unix_intf.S)
+      () ~toplevel:need_symbol
       ~filename ~prefixname:filename
       ~flambda2:Flambda2.lambda_to_cmm ~ppf_dump:ppf
       ~size:program.main_module_block_size
@@ -290,7 +292,9 @@ let default_load ppf (program : Lambda.program) =
       if Config.flambda then Flambda_middle_end.lambda_to_clambda
       else Closure_middle_end.lambda_to_clambda
     in
-    Asmgen.compile_implementation ~toplevel:need_symbol
+    Asmgen.compile_implementation
+      (module Unix : Owee.Unix_intf.S)
+      ~toplevel:need_symbol
       ~backend ~filename ~prefixname:filename
       ~middle_end ~ppf_dump:ppf program
   end;


### PR DESCRIPTION
This hopefully will be the last fix necessary arising from #757 .  We can't add `Unix` or `Bigarray` deps to `ocamloptcomp` as it will break compilerlibs clients.

@gretay-js @xclerc Could one of you please read the whole of this PR, most of it is just plumbing through of a first-class module.