### PR TITLE
Rename Owee -> Compiler_owee and install artifacts

### DIFF
--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -26,7 +26,7 @@ type middle_end =
 
 (** Compile an implementation from Lambda using the given middle end. *)
 val compile_implementation
-   : (module Owee.Unix_intf.S)
+   : (module Compiler_owee.Unix_intf.S)
   -> ?toplevel:(string -> bool)
   -> backend:(module Backend_intf.S)
   -> filename:string
@@ -40,7 +40,7 @@ val compile_implementation
     The Flambda 2 middle end neither uses the Clambda language nor the
     Cmmgen pass.  Instead it emits Cmm directly. *)
 val compile_implementation_flambda2
-   : (module Owee.Unix_intf.S)
+   : (module Compiler_owee.Unix_intf.S)
   -> ?toplevel:(string -> bool)
   -> ?keep_symbol_tables:bool
   -> filename:string
@@ -63,7 +63,7 @@ val compile_implementation_flambda2
   -> unit
 
 val compile_implementation_linear :
-    (module Owee.Unix_intf.S) -> string -> progname:string -> unit
+    (module Compiler_owee.Unix_intf.S) -> string -> progname:string -> unit
 
 val compile_phrase
   : ?dwarf:Dwarf_ocaml.Dwarf.t
@@ -96,7 +96,7 @@ val compile_unit
   Might return an instance of [Dwarf_ocaml.Dwarf.t] that can be used to generate
   dwarf information for the target system. *)
 val emit_begin_assembly_with_dwarf
-   : (module Owee.Unix_intf.S)
+   : (module Compiler_owee.Unix_intf.S)
   -> disable_dwarf:bool
   -> emit_begin_assembly:(init_dwarf:(unit -> unit) -> unit)
   -> sourcefile:string

--- a/backend/asmlink.mli
+++ b/backend/asmlink.mli
@@ -18,7 +18,7 @@
 open Misc
 open Format
 
-val link: (module Owee.Unix_intf.S) -> ppf_dump:formatter ->
+val link: (module Compiler_owee.Unix_intf.S) -> ppf_dump:formatter ->
   string list -> string -> unit
 
 val link_shared: ppf_dump:formatter -> string list -> string -> unit

--- a/backend/asmpackager.mli
+++ b/backend/asmpackager.mli
@@ -17,7 +17,7 @@
    original compilation units as sub-modules. *)
 
 val package_files
-   : (module Owee.Unix_intf.S)
+   : (module Compiler_owee.Unix_intf.S)
   -> ppf_dump:Format.formatter
   -> Env.t
   -> string list

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -30,7 +30,7 @@ let isprefix s1 s2 =
 let is_label name =
   String.length name >= 2 && Char.equal name.[0] '.' && Char.equal name.[1] 'L'
 
-let make_identification : Owee.Owee_elf.identification =
+let make_identification : Compiler_owee.Owee_elf.identification =
   { elf_class = 2;
     elf_data = 1;
     elf_version = 1;
@@ -38,7 +38,7 @@ let make_identification : Owee.Owee_elf.identification =
     elf_abiversion = 0
   }
 
-let make_header identification shnum e_shoff : Owee.Owee_elf.header =
+let make_header identification shnum e_shoff : Compiler_owee.Owee_elf.header =
   { e_ident = identification;
     e_type = 1;
     e_machine = 0x3E;
@@ -63,7 +63,7 @@ let create_section name ~sh_type ~size ~offset ?align ?entsize ?flags ?sh_link
   let sh_link = Option.value ~default:0 sh_link in
   let sh_info = Option.value ~default:0 sh_info in
   let sh_name_str = X86_proc.Section_name.to_string name in
-  let section : Owee.Owee_elf.section =
+  let section : Compiler_owee.Owee_elf.section =
     { sh_name = String_table.current_length shstrtab;
       sh_type;
       sh_flags;
@@ -82,7 +82,7 @@ let create_section name ~sh_type ~size ~offset ?align ?entsize ?flags ?sh_link
 
 let make_section sections name ~sh_type ~size ?align ?entsize ?flags ?sh_link
     ?sh_info ?body shstrtab =
-  let section : Owee.Owee_elf.section =
+  let section : Compiler_owee.Owee_elf.section =
     create_section name ~sh_type ~size
       ~offset:(Section_table.current_offset sections)
       ?align ?entsize ?flags ?sh_link ?sh_info shstrtab
@@ -230,7 +230,7 @@ let create_relocation_tables compiler_sections symbol_table string_table =
     (Section_name.Map.bindings compiler_sections)
 
 let write buf header section_table symbol_table relocation_tables string_table =
-  Owee.Owee_elf.write_elf buf header (Section_table.get_sections section_table);
+  Compiler_owee.Owee_elf.write_elf buf header (Section_table.get_sections section_table);
   Section_table.write_bodies section_table buf;
   let symtab =
     Section_table.get_section section_table
@@ -291,7 +291,7 @@ let assemble unix asm output_file =
       (Section_table.current_offset sections)
   in
   let elf =
-    Owee.Owee_buf.map_binary_write unix output_file
+    Compiler_owee.Owee_buf.map_binary_write unix output_file
       (Int64.to_int (Section_table.current_offset sections)
       + (header.e_shnum * header.e_shentsize))
   in

--- a/backend/internal_assembler/internal_assembler.mli
+++ b/backend/internal_assembler/internal_assembler.mli
@@ -22,7 +22,7 @@
 
 (** Create .o file. **)
 val assemble :
-  (module Owee.Unix_intf.S) ->
+  (module Compiler_owee.Unix_intf.S) ->
   (X86_proc.Section_name.t * X86_ast.asm_line list) list ->
   string ->
   unit

--- a/backend/internal_assembler/relocation_entry.ml
+++ b/backend/internal_assembler/relocation_entry.ml
@@ -20,9 +20,9 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE. *)
 type t =
-  { r_offset : Owee.Owee_buf.u64;
-    r_info : Owee.Owee_buf.u64;
-    r_addend : Owee.Owee_buf.u64
+  { r_offset : Compiler_owee.Owee_buf.u64;
+    r_info : Compiler_owee.Owee_buf.u64;
+    r_addend : Compiler_owee.Owee_buf.u64
   }
 
 let create_relocation ~offset ~info ~addend =
@@ -78,7 +78,7 @@ let create_relocation (relocation : X86_binary_emitter.Relocation.t)
     r_addend = addend
   }
 
-open Owee.Owee_buf
+open Compiler_owee.Owee_buf
 
 let write t cursor =
   Write.u64 cursor t.r_offset;

--- a/backend/internal_assembler/relocation_entry.mli
+++ b/backend/internal_assembler/relocation_entry.mli
@@ -25,4 +25,4 @@ type t
 val create_relocation :
   X86_binary_emitter.Relocation.t -> Symbol_table.t -> String_table.t -> t
 
-val write : t -> Owee.Owee_buf.cursor -> unit
+val write : t -> Compiler_owee.Owee_buf.cursor -> unit

--- a/backend/internal_assembler/relocation_table.ml
+++ b/backend/internal_assembler/relocation_table.ml
@@ -48,7 +48,7 @@ let write t section_table buf =
   | Some table ->
     List.iteri
       (fun i relocation ->
-        let open Owee.Owee_buf in
+        let open Compiler_owee.Owee_buf in
         (* 24 is the size of each relocation entry *)
         let idx = (i * 24) + Int64.to_int table.sh_offset in
         Relocation_entry.write relocation (cursor buf ~at:idx))

--- a/backend/internal_assembler/relocation_table.mli
+++ b/backend/internal_assembler/relocation_table.mli
@@ -35,4 +35,4 @@ val num_relocations : t -> int
 
 val section_name : t -> X86_proc.Section_name.t
 
-val write : t -> Section_table.t -> Owee.Owee_buf.t -> unit
+val write : t -> Section_table.t -> Compiler_owee.Owee_buf.t -> unit

--- a/backend/internal_assembler/section_table.ml
+++ b/backend/internal_assembler/section_table.ml
@@ -27,14 +27,14 @@ type section_body =
   }
 
 type t =
-  { mutable sections : Owee.Owee_elf.section list;
+  { mutable sections : Compiler_owee.Owee_elf.section list;
     mutable num_sections : int;
     section_tb : int Section_name.Tbl.t;
     mutable section_bodies : section_body list;
     mutable current_offset : int64
   }
 
-open Owee.Owee_elf
+open Compiler_owee.Owee_elf
 
 let create () =
   { sections =
@@ -92,8 +92,8 @@ let get_section_bodies t = t.section_bodies
 let write_bodies t buf =
   List.iter
     (fun sec_body ->
-      Owee.Owee_buf.Write.fixed_bytes
-        (Owee.Owee_buf.cursor buf ~at:sec_body.offset)
+      Compiler_owee.Owee_buf.Write.fixed_bytes
+        (Compiler_owee.Owee_buf.cursor buf ~at:sec_body.offset)
         (Bytes.length sec_body.body)
         sec_body.body)
     t.section_bodies

--- a/backend/internal_assembler/section_table.mli
+++ b/backend/internal_assembler/section_table.mli
@@ -26,7 +26,7 @@ type t
 val create : unit -> t
 
 val add_section :
-  t -> X86_proc.Section_name.t -> ?body:bytes -> Owee.Owee_elf.section -> unit
+  t -> X86_proc.Section_name.t -> ?body:bytes -> Compiler_owee.Owee_elf.section -> unit
 
 val current_offset : t -> int64
 
@@ -34,11 +34,11 @@ val num_sections : t -> int
 
 val get_sec_idx : t -> X86_proc.Section_name.t -> int
 
-val get_section : t -> X86_proc.Section_name.t -> Owee.Owee_elf.section
+val get_section : t -> X86_proc.Section_name.t -> Compiler_owee.Owee_elf.section
 
 val get_section_opt :
-  t -> X86_proc.Section_name.t -> Owee.Owee_elf.section option
+  t -> X86_proc.Section_name.t -> Compiler_owee.Owee_elf.section option
 
-val get_sections : t -> Owee.Owee_elf.section array
+val get_sections : t -> Compiler_owee.Owee_elf.section array
 
-val write_bodies : t -> Owee.Owee_buf.t -> unit
+val write_bodies : t -> Compiler_owee.Owee_buf.t -> unit

--- a/backend/internal_assembler/string_table.ml
+++ b/backend/internal_assembler/string_table.ml
@@ -34,7 +34,7 @@ let add_string t string =
 let current_length t = t.current_length
 
 let write t sh_offset buf =
-  let cursor = Owee.Owee_buf.cursor buf ~at:(Int64.to_int sh_offset) in
+  let cursor = Compiler_owee.Owee_buf.cursor buf ~at:(Int64.to_int sh_offset) in
   List.iter
-    (Owee.Owee_buf.Write.zero_terminated_string cursor)
+    (Compiler_owee.Owee_buf.Write.zero_terminated_string cursor)
     (List.rev t.strings)

--- a/backend/internal_assembler/string_table.mli
+++ b/backend/internal_assembler/string_table.mli
@@ -28,4 +28,4 @@ val add_string : t -> string -> unit
 
 val current_length : t -> int
 
-val write : t -> int64 -> Owee.Owee_buf.t -> unit
+val write : t -> int64 -> Compiler_owee.Owee_buf.t -> unit

--- a/backend/internal_assembler/symbol_entry.ml
+++ b/backend/internal_assembler/symbol_entry.ml
@@ -20,12 +20,12 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE. *)
 type t =
-  { st_name : Owee.Owee_buf.u32;
-    st_info : Owee.Owee_buf.u8;
-    st_other : Owee.Owee_buf.u8;
-    st_shndx : Owee.Owee_buf.u16;
-    st_value : Owee.Owee_buf.u64;
-    st_size : Owee.Owee_buf.u64;
+  { st_name : Compiler_owee.Owee_buf.u32;
+    st_info : Compiler_owee.Owee_buf.u8;
+    st_other : Compiler_owee.Owee_buf.u8;
+    st_shndx : Compiler_owee.Owee_buf.u16;
+    st_value : Compiler_owee.Owee_buf.u64;
+    st_size : Compiler_owee.Owee_buf.u64;
     st_name_str : string
   }
 
@@ -125,7 +125,7 @@ let get_shndx t = t.st_shndx
 
 let get_name_str t = t.st_name_str
 
-open Owee.Owee_buf
+open Compiler_owee.Owee_buf
 
 let write t cursor =
   Write.u32 cursor t.st_name;

--- a/backend/internal_assembler/symbol_entry.mli
+++ b/backend/internal_assembler/symbol_entry.mli
@@ -37,7 +37,7 @@ type symbol_type =
 
 val create_undef_symbol : string -> String_table.t -> t
 
-val create_section_symbol : Owee.Owee_buf.u16 -> t
+val create_section_symbol : Compiler_owee.Owee_buf.u16 -> t
 
 val create_symbol :
   X86_binary_emitter.symbol -> 'a -> Section_table.t -> String_table.t -> t
@@ -48,8 +48,8 @@ val get_bind : t -> bind
 
 val get_type : t -> symbol_type
 
-val get_shndx : t -> Owee.Owee_buf.u16
+val get_shndx : t -> Compiler_owee.Owee_buf.u16
 
 val get_name_str : t -> string
 
-val write : t -> Owee__Owee_buf.cursor -> unit
+val write : t -> Compiler_owee.Owee_buf.cursor -> unit

--- a/backend/internal_assembler/symbol_table.ml
+++ b/backend/internal_assembler/symbol_table.ml
@@ -110,5 +110,5 @@ let write t sh_offset buf =
   List.iteri
     (fun i symbol ->
       let idx = (i * 24) + Int64.to_int sh_offset in
-      Symbol_entry.write symbol (Owee.Owee_buf.cursor buf ~at:idx))
+      Symbol_entry.write symbol (Compiler_owee.Owee_buf.cursor buf ~at:idx))
     (List.rev t.local_symbols @ List.rev t.global_symbols)

--- a/backend/internal_assembler/symbol_table.mli
+++ b/backend/internal_assembler/symbol_table.mli
@@ -43,9 +43,9 @@ val num_locals : t -> int
 
 val make_undef_symbol : t -> string -> String_table.t -> unit
 
-val make_section_symbol : t -> Owee.Owee_buf.u16 -> 'a -> Symbol_entry.t
+val make_section_symbol : t -> Compiler_owee.Owee_buf.u16 -> 'a -> Symbol_entry.t
 
 val make_symbol :
   t -> X86_binary_emitter.symbol -> Section_table.t -> String_table.t -> unit
 
-val write : t -> int64 -> Owee.Owee_buf.t -> unit
+val write : t -> int64 -> Compiler_owee.Owee_buf.t -> unit

--- a/driver/boot_ocamlopt.ml
+++ b/driver/boot_ocamlopt.ml
@@ -1,4 +1,4 @@
 let () =
-  exit (Optmaindriver.main (module Unix : Owee.Unix_intf.S) Sys.argv
+  exit (Optmaindriver.main (module Unix : Compiler_owee.Unix_intf.S) Sys.argv
     Format.err_formatter
     ~flambda2:Flambda2.lambda_to_cmm)

--- a/driver/flambda_backend_main.ml
+++ b/driver/flambda_backend_main.ml
@@ -2,6 +2,6 @@ let () =
   (match Sys.backend_type with
    | Native -> Memtrace.trace_if_requested ~context:"ocamlopt" ()
    | Bytecode | Other _ -> ());
-  exit (Optmaindriver.main (module Unix : Owee.Unix_intf.S)
+  exit (Optmaindriver.main (module Unix : Compiler_owee.Unix_intf.S)
     Sys.argv Format.err_formatter
     ~flambda2:Flambda2.lambda_to_cmm)

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -18,7 +18,7 @@
 val interface: source_file:string -> output_prefix:string -> unit
 
 val implementation
-   : (module Owee.Unix_intf.S)
+   : (module Compiler_owee.Unix_intf.S)
   -> backend:(module Backend_intf.S)
   -> flambda2:(
     ppf_dump:Format.formatter ->
@@ -36,7 +36,7 @@ val implementation
 (** {2 Internal functions} **)
 
 val clambda :
-  (module Owee.Unix_intf.S) ->
+  (module Compiler_owee.Unix_intf.S) ->
   Compile_common.info ->
   (module Backend_intf.S) ->
   Typedtree.structure * Typedtree.module_coercion -> unit
@@ -45,7 +45,7 @@ val clambda :
 *)
 
 val flambda :
-  (module Owee.Unix_intf.S) ->
+  (module Compiler_owee.Unix_intf.S) ->
   Compile_common.info ->
   (module Backend_intf.S) ->
   Typedtree.structure * Typedtree.module_coercion -> unit

--- a/driver/optmaindriver.mli
+++ b/driver/optmaindriver.mli
@@ -19,7 +19,7 @@
    NB: Due to internal state in the compiler, calling [main] twice during
    the same process is unsupported. *)
 val main
-   : (module Owee.Unix_intf.S)
+   : (module Compiler_owee.Unix_intf.S)
   -> string array
   -> Format.formatter
   -> flambda2:(

--- a/dune
+++ b/dune
@@ -276,7 +276,7 @@
   flambda2_identifiers
   flambda2_cmx
   dwarf_ocaml
-  owee))
+  compiler_owee))
 
 (library
  (name flambda_backend_common)
@@ -402,7 +402,7 @@
    %{dep:middle_end/flambda2/from_lambda/flambda2_from_lambda.a}
    %{dep:middle_end/flambda2/simplify/flambda2_simplify.a}
    %{dep:middle_end/flambda2/parser/flambda2_parser.a}
-   %{dep:external/owee/owee.a}
+   %{dep:external/owee/compiler_owee.a}
    %{dep:ocamloptcomp.a}
    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.a}
    %{dep:middle_end/flambda2/flambda2.a})))
@@ -436,7 +436,7 @@
    %{dep:middle_end/flambda2/from_lambda/flambda2_from_lambda.cma}
    %{dep:middle_end/flambda2/simplify/flambda2_simplify.cma}
    %{dep:middle_end/flambda2/parser/flambda2_parser.cma}
-   %{dep:external/owee/owee.cma}
+   %{dep:external/owee/compiler_owee.cma}
    %{dep:ocamloptcomp.cma}
    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.cma}
    %{dep:middle_end/flambda2/flambda2.cma})))
@@ -470,7 +470,7 @@
    %{dep:middle_end/flambda2/from_lambda/flambda2_from_lambda.cmxa}
    %{dep:middle_end/flambda2/simplify/flambda2_simplify.cmxa}
    %{dep:middle_end/flambda2/parser/flambda2_parser.cmxa}
-   %{dep:external/owee/owee.cmxa}
+   %{dep:external/owee/compiler_owee.cmxa}
    %{dep:ocamloptcomp.cmxa}
    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.cmxa}
    %{dep:middle_end/flambda2/flambda2.cmxa})))
@@ -484,7 +484,9 @@
 
 (install
  (files
-  (external/owee/libowee_stubs_native.a as compiler-libs/libowee_stubs_native.a)
+  (external/owee/libcompiler_owee_stubs_native.a
+   as
+   compiler-libs/libcompiler_owee_stubs_native.a)
   (ocamloptcomp_with_flambda2.cma as compiler-libs/ocamloptcomp.cma)
   (ocamloptcomp_with_flambda2.cmxa as compiler-libs/ocamloptcomp.cmxa)
   (ocamloptcomp_with_flambda2.a as compiler-libs/ocamloptcomp.a))
@@ -599,35 +601,85 @@
   (unbox_free_vars_of_closures.mli
    as
    compiler-libs/unbox_free_vars_of_closures.mli)
-  (.ocamloptcomp.objs/native/internal_assembler.cmx as compiler-libs/internal_assembler.cmx)
-  (.ocamloptcomp.objs/byte/internal_assembler.cmi as compiler-libs/internal_assembler.cmi)
-  (.ocamloptcomp.objs/byte/internal_assembler.cmo as compiler-libs/internal_assembler.cmo)
-  (.ocamloptcomp.objs/byte/internal_assembler.cmt as compiler-libs/internal_assembler.cmt)
-  (.ocamloptcomp.objs/byte/internal_assembler.cmti as compiler-libs/internal_assembler.cmti)
+  (.ocamloptcomp.objs/native/internal_assembler.cmx
+   as
+   compiler-libs/internal_assembler.cmx)
+  (.ocamloptcomp.objs/byte/internal_assembler.cmi
+   as
+   compiler-libs/internal_assembler.cmi)
+  (.ocamloptcomp.objs/byte/internal_assembler.cmo
+   as
+   compiler-libs/internal_assembler.cmo)
+  (.ocamloptcomp.objs/byte/internal_assembler.cmt
+   as
+   compiler-libs/internal_assembler.cmt)
+  (.ocamloptcomp.objs/byte/internal_assembler.cmti
+   as
+   compiler-libs/internal_assembler.cmti)
   (relocation_entry.mli as compiler-libs/relocation_entry.mli)
-  (.ocamloptcomp.objs/native/relocation_entry.cmx as compiler-libs/relocation_entry.cmx)
-  (.ocamloptcomp.objs/byte/relocation_entry.cmi as compiler-libs/relocation_entry.cmi)
-  (.ocamloptcomp.objs/byte/relocation_entry.cmo as compiler-libs/relocation_entry.cmo)
-  (.ocamloptcomp.objs/byte/relocation_entry.cmt as compiler-libs/relocation_entry.cmt)
-  (.ocamloptcomp.objs/byte/relocation_entry.cmti as compiler-libs/relocation_entry.cmti)
+  (.ocamloptcomp.objs/native/relocation_entry.cmx
+   as
+   compiler-libs/relocation_entry.cmx)
+  (.ocamloptcomp.objs/byte/relocation_entry.cmi
+   as
+   compiler-libs/relocation_entry.cmi)
+  (.ocamloptcomp.objs/byte/relocation_entry.cmo
+   as
+   compiler-libs/relocation_entry.cmo)
+  (.ocamloptcomp.objs/byte/relocation_entry.cmt
+   as
+   compiler-libs/relocation_entry.cmt)
+  (.ocamloptcomp.objs/byte/relocation_entry.cmti
+   as
+   compiler-libs/relocation_entry.cmti)
   (section_table.mli as compiler-libs/section_table.mli)
-  (.ocamloptcomp.objs/native/section_table.cmx as compiler-libs/section_table.cmx)
-  (.ocamloptcomp.objs/byte/section_table.cmi as compiler-libs/section_table.cmi)
-  (.ocamloptcomp.objs/byte/section_table.cmo as compiler-libs/section_table.cmo)
-  (.ocamloptcomp.objs/byte/section_table.cmt as compiler-libs/section_table.cmt)
-  (.ocamloptcomp.objs/byte/section_table.cmti as compiler-libs/section_table.cmti)
+  (.ocamloptcomp.objs/native/section_table.cmx
+   as
+   compiler-libs/section_table.cmx)
+  (.ocamloptcomp.objs/byte/section_table.cmi
+   as
+   compiler-libs/section_table.cmi)
+  (.ocamloptcomp.objs/byte/section_table.cmo
+   as
+   compiler-libs/section_table.cmo)
+  (.ocamloptcomp.objs/byte/section_table.cmt
+   as
+   compiler-libs/section_table.cmt)
+  (.ocamloptcomp.objs/byte/section_table.cmti
+   as
+   compiler-libs/section_table.cmti)
   (string_table.mli as compiler-libs/string_table.mli)
-  (.ocamloptcomp.objs/native/string_table.cmx as compiler-libs/string_table.cmx)
-  (.ocamloptcomp.objs/byte/string_table.cmi as compiler-libs/string_table.cmi)
-  (.ocamloptcomp.objs/byte/string_table.cmo as compiler-libs/string_table.cmo)
-  (.ocamloptcomp.objs/byte/string_table.cmt as compiler-libs/string_table.cmt)
-  (.ocamloptcomp.objs/byte/string_table.cmti as compiler-libs/string_table.cmti)
+  (.ocamloptcomp.objs/native/string_table.cmx
+   as
+   compiler-libs/string_table.cmx)
+  (.ocamloptcomp.objs/byte/string_table.cmi
+   as
+   compiler-libs/string_table.cmi)
+  (.ocamloptcomp.objs/byte/string_table.cmo
+   as
+   compiler-libs/string_table.cmo)
+  (.ocamloptcomp.objs/byte/string_table.cmt
+   as
+   compiler-libs/string_table.cmt)
+  (.ocamloptcomp.objs/byte/string_table.cmti
+   as
+   compiler-libs/string_table.cmti)
   (symbol_table.mli as compiler-libs/symbol_table.mli)
-  (.ocamloptcomp.objs/native/symbol_table.cmx as compiler-libs/symbol_table.cmx)
-  (.ocamloptcomp.objs/byte/symbol_table.cmi as compiler-libs/symbol_table.cmi)
-  (.ocamloptcomp.objs/byte/symbol_table.cmo as compiler-libs/symbol_table.cmo)
-  (.ocamloptcomp.objs/byte/symbol_table.cmt as compiler-libs/symbol_table.cmt)
-  (.ocamloptcomp.objs/byte/symbol_table.cmti as compiler-libs/symbol_table.cmti)
+  (.ocamloptcomp.objs/native/symbol_table.cmx
+   as
+   compiler-libs/symbol_table.cmx)
+  (.ocamloptcomp.objs/byte/symbol_table.cmi
+   as
+   compiler-libs/symbol_table.cmi)
+  (.ocamloptcomp.objs/byte/symbol_table.cmo
+   as
+   compiler-libs/symbol_table.cmo)
+  (.ocamloptcomp.objs/byte/symbol_table.cmt
+   as
+   compiler-libs/symbol_table.cmt)
+  (.ocamloptcomp.objs/byte/symbol_table.cmti
+   as
+   compiler-libs/symbol_table.cmti)
   (unbox_specialised_args.mli as compiler-libs/unbox_specialised_args.mli)
   (afl_instrument.mli as compiler-libs/afl_instrument.mli)
   (asmgen.mli as compiler-libs/asmgen.mli)
@@ -1137,18 +1189,10 @@
   (.ocamloptcomp.objs/byte/cfg_regalloc_utils.cmti
    as
    compiler-libs/cfg_regalloc_utils.cmti)
-  (.ocamloptcomp.objs/byte/cfg_irc.cmi
-   as
-   compiler-libs/cfg_irc.cmi)
-  (.ocamloptcomp.objs/byte/cfg_irc.cmo
-   as
-   compiler-libs/cfg_irc.cmo)
-  (.ocamloptcomp.objs/byte/cfg_irc.cmt
-   as
-   compiler-libs/cfg_irc.cmt)
-  (.ocamloptcomp.objs/byte/cfg_irc.cmti
-   as
-   compiler-libs/cfg_irc.cmti)
+  (.ocamloptcomp.objs/byte/cfg_irc.cmi as compiler-libs/cfg_irc.cmi)
+  (.ocamloptcomp.objs/byte/cfg_irc.cmo as compiler-libs/cfg_irc.cmo)
+  (.ocamloptcomp.objs/byte/cfg_irc.cmt as compiler-libs/cfg_irc.cmt)
+  (.ocamloptcomp.objs/byte/cfg_irc.cmti as compiler-libs/cfg_irc.cmti)
   (.ocamloptcomp.objs/byte/cfg_irc_utils.cmi
    as
    compiler-libs/cfg_irc_utils.cmi)
@@ -1410,9 +1454,7 @@
   (.ocamloptcomp.objs/native/cfg_regalloc_utils.cmx
    as
    compiler-libs/cfg_regalloc_utils.cmx)
-  (.ocamloptcomp.objs/native/cfg_irc.cmx
-   as
-   compiler-libs/cfg_irc.cmx)
+  (.ocamloptcomp.objs/native/cfg_irc.cmx as compiler-libs/cfg_irc.cmx)
   (.ocamloptcomp.objs/native/cfg_irc_utils.cmx
    as
    compiler-libs/cfg_irc_utils.cmx)
@@ -3330,4 +3372,205 @@
    compiler-libs/dwarf_ocaml__Dwarf_compilation_unit.cmx)
   (backend/debug/dwarf/dwarf_ocaml/.dwarf_ocaml.objs/native/dwarf_ocaml__Dwarf_state.cmx
    as
-   compiler-libs/dwarf_ocaml__Dwarf_state.cmx)))
+   compiler-libs/dwarf_ocaml__Dwarf_state.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_elf_notes.cmx
+   as
+   compiler_owee__Owee_elf_notes.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_traverse.cmx
+   as
+   compiler_owee__Owee_traverse.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_interval_map.cmx
+   as
+   compiler_owee__Owee_interval_map.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Unix_intf.cmx
+   as
+   compiler_owee__Unix_intf.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_macho.cmx
+   as
+   compiler_owee__Owee_macho.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_location.cmx
+   as
+   compiler_owee__Owee_location.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee.cmx
+   as
+   compiler_owee.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_elf.cmx
+   as
+   compiler_owee__Owee_elf.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_form.cmx
+   as
+   compiler_owee__Owee_form.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_debug_line.cmx
+   as
+   compiler_owee__Owee_debug_line.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_marker.cmx
+   as
+   compiler_owee__Owee_marker.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_linux_maps.cmx
+   as
+   compiler_owee__Owee_linux_maps.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_graph.cmx
+   as
+   compiler_owee__Owee_graph.cmx)
+  (external/owee/.compiler_owee.objs/native/compiler_owee__Owee_buf.cmx
+   as
+   compiler_owee__Owee_buf.cmx)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_elf.cmo
+   as
+   compiler_owee__Owee_elf.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_elf.cmt
+   as
+   compiler_owee__Owee_elf.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_macho.cmti
+   as
+   compiler_owee__Owee_macho.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_elf.cmi
+   as
+   compiler_owee__Owee_elf.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_marker.cmt
+   as
+   compiler_owee__Owee_marker.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_form.cmi
+   as
+   compiler_owee__Owee_form.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_linux_maps.cmt
+   as
+   compiler_owee__Owee_linux_maps.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_marker.cmo
+   as
+   compiler_owee__Owee_marker.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_debug_line.cmi
+   as
+   compiler_owee__Owee_debug_line.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_marker.cmti
+   as
+   compiler_owee__Owee_marker.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_elf_notes.cmti
+   as
+   compiler_owee__Owee_elf_notes.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_linux_maps.cmo
+   as
+   compiler_owee__Owee_linux_maps.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_form.cmo
+   as
+   compiler_owee__Owee_form.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_debug_line.cmt
+   as
+   compiler_owee__Owee_debug_line.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_buf.cmti
+   as
+   compiler_owee__Owee_buf.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_form.cmt
+   as
+   compiler_owee__Owee_form.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_linux_maps.cmi
+   as
+   compiler_owee__Owee_linux_maps.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_marker.cmi
+   as
+   compiler_owee__Owee_marker.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_debug_line.cmo
+   as
+   compiler_owee__Owee_debug_line.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_graph.cmo
+   as
+   compiler_owee__Owee_graph.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_graph.cmt
+   as
+   compiler_owee__Owee_graph.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_graph.cmi
+   as
+   compiler_owee__Owee_graph.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_buf.cmt
+   as
+   compiler_owee__Owee_buf.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_buf.cmo
+   as
+   compiler_owee__Owee_buf.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_interval_map.cmti
+   as
+   compiler_owee__Owee_interval_map.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_buf.cmi
+   as
+   compiler_owee__Owee_buf.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_location.cmti
+   as
+   compiler_owee__Owee_location.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_traverse.cmt
+   as
+   compiler_owee__Owee_traverse.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_interval_map.cmt
+   as
+   compiler_owee__Owee_interval_map.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_elf_notes.cmo
+   as
+   compiler_owee__Owee_elf_notes.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_traverse.cmo
+   as
+   compiler_owee__Owee_traverse.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_interval_map.cmo
+   as
+   compiler_owee__Owee_interval_map.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_elf_notes.cmt
+   as
+   compiler_owee__Owee_elf_notes.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_elf_notes.cmi
+   as
+   compiler_owee__Owee_elf_notes.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_interval_map.cmi
+   as
+   compiler_owee__Owee_interval_map.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_debug_line.cmti
+   as
+   compiler_owee__Owee_debug_line.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_traverse.cmi
+   as
+   compiler_owee__Owee_traverse.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_location.cmt
+   as
+   compiler_owee__Owee_location.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Unix_intf.cmi
+   as
+   compiler_owee__Unix_intf.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_location.cmo
+   as
+   compiler_owee__Owee_location.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_macho.cmi
+   as
+   compiler_owee__Owee_macho.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_macho.cmt
+   as
+   compiler_owee__Owee_macho.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Unix_intf.cmo
+   as
+   compiler_owee__Unix_intf.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_linux_maps.cmti
+   as
+   compiler_owee__Owee_linux_maps.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_location.cmi
+   as
+   compiler_owee__Owee_location.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Unix_intf.cmt
+   as
+   compiler_owee__Unix_intf.cmt)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_macho.cmo
+   as
+   compiler_owee__Owee_macho.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee.cmi
+   as
+   compiler_owee.cmi)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_elf.cmti
+   as
+   compiler_owee__Owee_elf.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee.cmo
+   as
+   compiler_owee.cmo)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_traverse.cmti
+   as
+   compiler_owee__Owee_traverse.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee__Owee_form.cmti
+   as
+   compiler_owee__Owee_form.cmti)
+  (external/owee/.compiler_owee.objs/byte/compiler_owee.cmt
+   as
+   compiler_owee.cmt)))

--- a/external/owee/dune
+++ b/external/owee/dune
@@ -1,16 +1,16 @@
 (library
- (name owee)
- ; (public_name owee)
- ; (wrapped false)
- (foreign_stubs (language c) (names owee_stubs)
-   (flags ((:include %{project_root}/oc_cflags.sexp)
-   (:include %{project_root}/sharedlib_cflags.sexp)
-   (:include %{project_root}/oc_cppflags.sexp)))
-)
+ (name compiler_owee)
+ (foreign_stubs
+  (language c)
+  (names owee_stubs)
+  (flags
+   ((:include %{project_root}/oc_cflags.sexp)
+    (:include %{project_root}/sharedlib_cflags.sexp)
+    (:include %{project_root}/oc_cppflags.sexp))))
  (synopsis "OCaml library to work with DWARF format"))
 
 (install
  (files
-  (dllowee_stubs.so as stublibs/dllowee_stubs.so))
-  (section lib)
-  (package ocaml))
+  (dllcompiler_owee_stubs.so as stublibs/dllcompiler_owee_stubs.so))
+ (section lib)
+ (package ocaml))

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -278,7 +278,7 @@ let default_load ppf (program : Lambda.program) =
   let filename = Filename.chop_extension dll in
   if Config.flambda2 then begin
     Asmgen.compile_implementation_flambda2
-      (module Unix : Owee.Unix_intf.S)
+      (module Unix : Compiler_owee.Unix_intf.S)
       () ~toplevel:need_symbol
       ~filename ~prefixname:filename
       ~flambda2:Flambda2.lambda_to_cmm ~ppf_dump:ppf
@@ -293,7 +293,7 @@ let default_load ppf (program : Lambda.program) =
       else Closure_middle_end.lambda_to_clambda
     in
     Asmgen.compile_implementation
-      (module Unix : Owee.Unix_intf.S)
+      (module Unix : Compiler_owee.Unix_intf.S)
       ~toplevel:need_symbol
       ~backend ~filename ~prefixname:filename
       ~middle_end ~ppf_dump:ppf program


### PR DESCRIPTION
This renames `Owee` inside the compiler to avoid any potential name clashes with compilerlibs clients also using the library from elsewhere.  The build artifacts are also installed.