### PR TITLE
Improve the semantics of asynchronous exceptions [old version]

### DIFF
--- a/async_exns.ml
+++ b/async_exns.ml
@@ -1,0 +1,47 @@
+let () =
+  try
+    let b = Bytes.create 42 in
+    Gc.finalise_last (fun () -> raise Exit) b;
+    Sys.with_async_exns (fun () ->
+      try
+        let _ = Sys.opaque_identity b in
+        while true do
+          let _ = Sys.opaque_identity (42, Random.int 42) in
+          ()
+        done
+      with exn -> assert false
+    )
+  with
+  | Finaliser_raised Exit -> Printf.printf "OK\n%!"
+  | _ -> assert false
+
+exception E
+
+let () =
+  try
+    Sys.with_async_exns (fun () ->
+      Sys.bracket ~acquire:(fun () ->
+          let b = Bytes.create 42 in
+          let finalised = ref false in
+          Gc.finalise_last
+            (fun () -> finalised := true; raise Exit)
+            b;
+          for x = 0 to 1_000_000 do
+            let _ = Sys.opaque_identity (42, Random.int 42) in
+            ()
+          done;
+          assert !finalised;
+          12345)
+        ~release:(fun n -> Printf.printf "release %d\n%!" n)
+        (fun n ->
+          let b2 = Bytes.create 42 in
+          Gc.finalise_last (fun () -> raise E) b2;
+          for x = 0 to 1_000_000 do
+            let _ = Sys.opaque_identity (42, Random.int 42) in
+            ()
+          done;
+          assert false
+        )
+    )
+  with Finaliser_raised E -> Printf.printf "OK\n"
+  | _ -> assert false

--- a/ocaml/runtime/amd64.S
+++ b/ocaml/runtime/amd64.S
@@ -565,6 +565,9 @@ ENDFUNCTION(G(caml_c_call))
 
 /* Start the OCaml program */
 
+/* CR mshinwell: check failure of "unwind" test on macos (doesn't fail
+   on macos CI though) */
+
 FUNCTION(G(caml_start_program))
        CFI_STARTPROC
     /* Save callee-save registers */
@@ -573,10 +576,22 @@ FUNCTION(G(caml_start_program))
         movq    C_ARG_1, %r14
     /* Initial entry point is G(caml_program) */
         LEA_VAR(caml_program, %r12)
-    /* Common code for caml_start_program and caml_callback* */
+LBL(caml_start_program_async_exn):
+    /* Register the same exception handler as below for async exceptions */
+        pushq   Caml_state(async_exception_pointer); CFI_ADJUST (8)
+        movq    %rsp, %r13
+        subq    $40, %r13
+        movq    %r13, Caml_state(async_exception_pointer)
+        jmp     LBL(107a)
+    /* Common code for caml_start_program and caml_callback*.
+       If you update the number of stack pushes, update the number 40
+       above. */
 LBL(caml_start_program):
+    /* Save the current async exception pointer */
+        pushq   Caml_state(async_exception_pointer); CFI_ADJUST (8)
+LBL(107a):
+    /* Stack is 16-aligned at this point */
     /* Build a callback link */
-        subq    $8, %rsp; CFI_ADJUST (8)        /* stack 16-aligned */
         pushq   Caml_state(gc_regs); CFI_ADJUST(8)
         pushq   Caml_state(last_return_address); CFI_ADJUST(8)
         pushq   Caml_state(bottom_of_stack); CFI_ADJUST(8)
@@ -600,7 +615,9 @@ LBL(109):
         popq    Caml_state(bottom_of_stack); CFI_ADJUST(-8)
         popq    Caml_state(last_return_address); CFI_ADJUST(-8)
         popq    Caml_state(gc_regs); CFI_ADJUST(-8)
-        addq    $8, %rsp; CFI_ADJUST (-8);
+    /* Restore the asynchronous exception pointer (this will be a no-op
+       if this function was not invoked via [caml_start_program_async_exn]). */
+        popq    Caml_state(async_exception_pointer); CFI_ADJUST(-8)
     /* Restore callee-save registers. */
         POP_CALLEE_SAVE_REGS
     /* Return to caller. */
@@ -687,6 +704,18 @@ LBL(112):
 CFI_ENDPROC
 ENDFUNCTION(G(caml_raise_exception))
 
+/* Raise an async exception from C */
+
+FUNCTION(G(caml_raise_async_exception))
+CFI_STARTPROC
+        movq    C_ARG_1, %r14   /* Caml_state */
+        /* %rax is about to be clobbered anyway */
+        movq    Caml_state(async_exception_pointer), %rax
+        movq    %rax, Caml_state(exception_pointer)
+        jmp     G(caml_raise_exception)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_raise_async_exception))
+
 /* Raise a Stack_overflow exception on return from segv_handler()
    (in runtime/signals_nat.c).  On entry, the stack is full, so we
    cannot record a backtrace.
@@ -696,7 +725,7 @@ ENDFUNCTION(G(caml_raise_exception))
 FUNCTION(G(caml_stack_overflow))
         movq    C_ARG_1, %r14                 /* Caml_state */
         LEA_VAR(caml_exn_Stack_overflow, %rax)
-        movq    Caml_state(exception_pointer), %rsp /* cut the stack */
+        movq    Caml_state(async_exception_pointer), %rsp /* cut the stack */
      /* Recover previous exn handler */
         popq    Caml_state(exception_pointer)
         ret                                   /* jump to handler's code */
@@ -745,6 +774,20 @@ CFI_STARTPROC
         jmp     LBL(caml_start_program)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_callback3_asm))
+
+/* Variant of caml_callback_asm that installs an async exn trap frame. */
+FUNCTION(G(caml_callback_asm_async_exn))
+CFI_STARTPROC
+    /* Save callee-save registers */
+        PUSH_CALLEE_SAVE_REGS
+    /* Initial loading of arguments */
+        movq    C_ARG_1, %r14      /* Caml_state */
+        movq    C_ARG_2, %rbx      /* closure */
+        movq    0(C_ARG_3), %rax   /* argument */
+        movq    0(%rbx), %r12      /* code pointer */
+        jmp     LBL(caml_start_program_async_exn)
+CFI_ENDPROC
+ENDFUNCTION(G(caml_callback_asm_async_exn))
 
 FUNCTION(G(caml_ml_array_bound_error))
 CFI_STARTPROC

--- a/ocaml/runtime/caml/domain_state.tbl
+++ b/ocaml/runtime/caml/domain_state.tbl
@@ -21,6 +21,10 @@ DOMAIN_STATE(value*, young_limit)
 DOMAIN_STATE(char*, exception_pointer)
 /* Exception pointer that points into the current stack */
 
+DOMAIN_STATE(char*, async_exception_pointer)
+/* Async exception pointer that points into the current stack */
+DOMAIN_STATE(char, async_exceptions_masked)
+
 DOMAIN_STATE(void*, young_base)
 DOMAIN_STATE(value*, young_start)
 DOMAIN_STATE(value*, young_end)

--- a/ocaml/runtime/caml/fail.h
+++ b/ocaml/runtime/caml/fail.h
@@ -39,6 +39,9 @@
 #define SYS_BLOCKED_IO 9        /* "Sys_blocked_io" */
 #define ASSERT_FAILURE_EXN 10   /* "Assert_failure" */
 #define UNDEFINED_RECURSIVE_MODULE_EXN 11 /* "Undefined_recursive_module" */
+#define FINALISER_RAISED_EXN 12           /* "Finaliser_raised" */
+#define MEMPROF_CALLBACK_RAISED_EXN 13    /* "Memprof_callback_raised" */
+#define SIGNAL_HANDLER_RAISED_EXN 14      /* "Signal_handler_raised" */
 
 #ifdef POSIX_SIGNALS
 struct longjmp_buffer {
@@ -66,6 +69,21 @@ struct longjmp_buffer {
 int caml_is_special_exception(value exn);
 
 CAMLextern value caml_raise_if_exception(value res);
+CAMLextern value caml_raise_async_if_exception(value res);
+
+typedef enum
+{
+  pending_SIGNAL_HANDLER,
+  pending_FINALISER,
+  pending_MEMPROF_CALLBACK
+} pending_action_type;
+
+CAMLextern value caml_wrap_if_async_exn(value result,
+  pending_action_type action);
+
+/* Note that caml_raise_async may return (in the case where asynchronous
+   exceptions are masked). */
+CAMLextern value caml_raise_async(value res);
 
 #endif /* CAML_INTERNALS */
 
@@ -111,6 +129,10 @@ CAMLnoreturn_end;
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_out_of_memory (void)
+CAMLnoreturn_end;
+
+CAMLnoreturn_start
+CAMLextern void caml_raise_out_of_memory_fatal (void)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start

--- a/ocaml/runtime/caml/signals.h
+++ b/ocaml/runtime/caml/signals.h
@@ -25,6 +25,7 @@
 #endif
 #include "misc.h"
 #include "mlvalues.h"
+#include "fail.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -83,7 +84,8 @@ value caml_execute_signal_exn(int signal_number, int in_signal_handler);
 CAMLextern void caml_record_signal(int signal_number);
 CAMLextern value caml_process_pending_signals_exn(void);
 void caml_set_action_pending (void);
-value caml_do_pending_actions_exn (void);
+
+value caml_do_pending_actions_exn ();
 value caml_process_pending_actions_with_root (value extra_root); // raises
 value caml_process_pending_actions_with_root_exn (value extra_root);
 int caml_set_signal_action(int signo, int action);

--- a/ocaml/runtime/caml/stack.h
+++ b/ocaml/runtime/caml/stack.h
@@ -141,6 +141,7 @@ extern intnat * caml_frametable[];
 #define caml_last_return_address (Caml_state_field(last_return_address))
 #define caml_gc_regs (Caml_state_field(gc_regs))
 #define caml_exception_pointer (Caml_state_field(exception_pointer))
+#define caml_async_exception_pointer (Caml_state_field(async_exception_pointer))
 
 CAMLextern frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp);
 

--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -23,7 +23,7 @@
      callback.c weak.c
    finalise.c stacks.c dynlink.c backtrace_byt.c backtrace.c
      afl.c
-   bigarray.c eventlog.c)
+   bigarray.c eventlog.c fail_nat.c)
  (action  (with-stdout-to %{targets} (run %{dep:gen_primitives.sh}))))
 
 ; Shouldn't this use foreign build sandboxing?

--- a/ocaml/runtime/fail_nat.c
+++ b/ocaml/runtime/fail_nat.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include "caml/alloc.h"
+#include "caml/callback.h"
 #include "caml/domain.h"
 #include "caml/fail.h"
 #include "caml/io.h"
@@ -37,29 +38,33 @@
 typedef value caml_generated_constant[1];
 
 extern caml_generated_constant
-  caml_exn_Out_of_memory,
-  caml_exn_Sys_error,
-  caml_exn_Failure,
-  caml_exn_Invalid_argument,
-  caml_exn_End_of_file,
-  caml_exn_Division_by_zero,
-  caml_exn_Not_found,
-  caml_exn_Match_failure,
-  caml_exn_Sys_blocked_io,
-  caml_exn_Stack_overflow,
-  caml_exn_Assert_failure,
-  caml_exn_Undefined_recursive_module;
+    caml_exn_Out_of_memory,
+    caml_exn_Sys_error,
+    caml_exn_Failure,
+    caml_exn_Invalid_argument,
+    caml_exn_End_of_file,
+    caml_exn_Division_by_zero,
+    caml_exn_Not_found,
+    caml_exn_Match_failure,
+    caml_exn_Sys_blocked_io,
+    caml_exn_Stack_overflow,
+    caml_exn_Assert_failure,
+    caml_exn_Undefined_recursive_module,
+    caml_exn_Finaliser_raised,
+    caml_exn_Memprof_callback_raised,
+    caml_exn_Signal_handler_raised;
 
 /* Exception raising */
 
-CAMLnoreturn_start
-  extern void caml_raise_exception (caml_domain_state* state, value bucket)
-CAMLnoreturn_end;
+CAMLnoreturn_start extern void caml_raise_exception(caml_domain_state *state, value bucket)
+    CAMLnoreturn_end;
 
-/* Used by the stack overflow handler -> deactivate ASAN (see
-   segv_handler in signals_nat.c). */
-CAMLno_asan
-void caml_raise(value v)
+CAMLnoreturn_start extern void caml_raise_async_exception(
+  caml_domain_state *state, value bucket)
+    CAMLnoreturn_end;
+
+CAMLno_asan static value prepare_for_raise(value v, char *exception_pointer,
+  int *turned_into_async_exn)
 {
   Unlock_exn();
 
@@ -68,32 +73,152 @@ void caml_raise(value v)
   // avoid calling caml_raise recursively
   v = caml_process_pending_actions_with_root_exn(v);
   if (Is_exception_result(v))
+  {
     v = Extract_exception(v);
 
-  if (Caml_state->exception_pointer == NULL) caml_fatal_uncaught_exception(v);
+    /* [v] should now be raised as an asynchronous exception. */
 
-  while (Caml_state->local_roots != NULL &&
-         (char *) Caml_state->local_roots < Caml_state->exception_pointer) {
-    Caml_state->local_roots = Caml_state->local_roots->next;
+    if (Caml_state->async_exception_pointer == NULL)
+      caml_fatal_uncaught_exception(v);
+
+    *turned_into_async_exn = 1;
+    return v;
   }
 
-  caml_raise_exception(Caml_state, v);
+  if (exception_pointer == NULL)
+    caml_fatal_uncaught_exception(v);
+
+  *turned_into_async_exn = 0;
+  return v;
+}
+
+CAMLno_asan static void unwind_local_roots(char *exception_pointer)
+{
+  while (Caml_state->local_roots != NULL &&
+         (char *)Caml_state->local_roots < exception_pointer)
+  {
+    Caml_state->local_roots = Caml_state->local_roots->next;
+  }
 }
 
 /* Used by the stack overflow handler -> deactivate ASAN (see
    segv_handler in signals_nat.c). */
+CAMLno_asan void caml_raise(value v)
+{
+  int is_async_exn;
+  v = prepare_for_raise(v, Caml_state->exception_pointer, &is_async_exn);
+
+  if (is_async_exn)
+  {
+    unwind_local_roots(Caml_state->async_exception_pointer);
+    caml_raise_async_exception(Caml_state, v);
+  }
+  else
+  {
+    unwind_local_roots(Caml_state->exception_pointer);
+    caml_raise_exception(Caml_state, v);
+  }
+}
+
+CAMLno_asan void caml_raise_never_async(value v)
+{
+  int is_async_exn;
+  v = prepare_for_raise(v, Caml_state->exception_pointer, &is_async_exn);
+
+  unwind_local_roots(Caml_state->exception_pointer);
+  caml_raise_exception(Caml_state, v);
+}
+
+CAMLexport value caml_wrap_if_async_exn(value result,
+  pending_action_type action)
+{
+  CAMLparam1(result);
+  value exn;
+  value tag = Val_unit;
+  value wrapped;
+
+  if (!Is_exception_result(result)) CAMLreturn(result);
+
+  /* CR mshinwell: think more about these cases (the eintr.ml gc test can
+     trigger them -- signal handler executed from signal handler,
+     presumably) */
+
+  exn = Extract_exception(result);
+
+  if (Is_block(exn)
+      && Wosize_val(exn) == 2
+      && (Field(exn, 0) == (value) caml_exn_Signal_handler_raised
+          || Field(exn, 1) == (value) caml_exn_Finaliser_raised
+          || Field(exn, 2) == (value) caml_exn_Memprof_callback_raised))
+  {
+    /* Don't double-wrap exceptions. */
+    CAMLreturn(result);
+  }
+
+  wrapped = caml_alloc_small(2, 0);
+
+  switch (action)
+  {
+    case pending_SIGNAL_HANDLER:
+      tag = (value) caml_exn_Signal_handler_raised;
+      break;
+
+    case pending_FINALISER:
+      tag = (value) caml_exn_Finaliser_raised;
+      break;
+
+    case pending_MEMPROF_CALLBACK:
+      tag = (value) caml_exn_Memprof_callback_raised;
+      break;
+
+    default:
+      CAMLassert(0);
+  }
+
+  Field(wrapped, 0) = tag;
+  Field(wrapped, 1) = exn;
+
+  CAMLreturn(Make_exception_result(wrapped));
+}
+
 CAMLno_asan
-void caml_raise_constant(value tag)
+CAMLprim value caml_raise_async(value exn)
+{
+  int turned_into_async_exn;
+
+  if (Caml_state->async_exceptions_masked)
+  {
+    if (exn == (value) caml_exn_Stack_overflow)
+    {
+      fprintf(stderr, "[ocaml] Stack overflow\n");
+      abort();
+    }
+    return Val_unit;
+  }
+
+  exn = prepare_for_raise(exn, Caml_state->async_exception_pointer,
+    &turned_into_async_exn);
+
+  unwind_local_roots(Caml_state->async_exception_pointer);
+
+  caml_raise_async_exception(Caml_state, exn);
+
+  return Val_unit;
+}
+
+/* Used by the stack overflow handler -> deactivate ASAN (see
+   segv_handler in signals_nat.c). */
+CAMLno_asan void caml_raise_constant(value tag)
 {
   caml_raise(tag);
 }
 
 void caml_raise_with_arg(value tag, value arg)
 {
-  CAMLparam2 (tag, arg);
-  CAMLlocal1 (bucket);
+  CAMLparam2(tag, arg);
+  CAMLlocal1(bucket);
 
-  bucket = caml_alloc_small (2, 0);
+  bucket = caml_alloc_small(2, 0);
   Field(bucket, 0) = tag;
   Field(bucket, 1) = arg;
   caml_raise(bucket);
@@ -102,15 +227,16 @@ void caml_raise_with_arg(value tag, value arg)
 
 void caml_raise_with_args(value tag, int nargs, value args[])
 {
-  CAMLparam1 (tag);
-  CAMLxparamN (args, nargs);
+  CAMLparam1(tag);
+  CAMLxparamN(args, nargs);
   value bucket;
   int i;
 
   CAMLassert(1 + nargs <= Max_young_wosize);
-  bucket = caml_alloc_small (1 + nargs, 0);
+  bucket = caml_alloc_small(1 + nargs, 0);
   Field(bucket, 0) = tag;
-  for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
+  for (i = 0; i < nargs; i++)
+    Field(bucket, 1 + i) = args[i];
   caml_raise(bucket);
   CAMLnoreturn;
 }
@@ -123,82 +249,100 @@ void caml_raise_with_string(value tag, char const *msg)
   CAMLnoreturn;
 }
 
-void caml_failwith (char const *msg)
+void caml_failwith(char const *msg)
 {
-  caml_raise_with_string((value) caml_exn_Failure, msg);
+  caml_raise_with_string((value)caml_exn_Failure, msg);
 }
 
-void caml_failwith_value (value msg)
+void caml_failwith_value(value msg)
 {
-  caml_raise_with_arg((value) caml_exn_Failure, msg);
+  caml_raise_with_arg((value)caml_exn_Failure, msg);
 }
 
-void caml_invalid_argument (char const *msg)
+void caml_invalid_argument(char const *msg)
 {
-  caml_raise_with_string((value) caml_exn_Invalid_argument, msg);
+  caml_raise_with_string((value)caml_exn_Invalid_argument, msg);
 }
 
-void caml_invalid_argument_value (value msg)
+void caml_invalid_argument_value(value msg)
 {
-  caml_raise_with_arg((value) caml_exn_Invalid_argument, msg);
+  caml_raise_with_arg((value)caml_exn_Invalid_argument, msg);
 }
 
 void caml_raise_out_of_memory(void)
 {
-  caml_raise_constant((value) caml_exn_Out_of_memory);
+  /* Note that this is not an async exn. */
+  caml_raise_constant((value)caml_exn_Out_of_memory);
+}
+
+void caml_raise_out_of_memory_fatal(void)
+{
+  fprintf(stderr, "[ocaml] Out of memory\n");
+  abort();
 }
 
 /* Used by the stack overflow handler -> deactivate ASAN (see
    segv_handler in signals_nat.c). */
-CAMLno_asan
-void caml_raise_stack_overflow(void)
+CAMLno_asan void caml_raise_stack_overflow(void)
 {
-  caml_raise_constant((value) caml_exn_Stack_overflow);
+  caml_raise_async((value)caml_exn_Stack_overflow);
+  abort();  /* CR mshinwell: what are we supposed to use for "unreachable"? */
 }
 
 void caml_raise_sys_error(value msg)
 {
-  caml_raise_with_arg((value) caml_exn_Sys_error, msg);
+  caml_raise_with_arg((value)caml_exn_Sys_error, msg);
 }
 
 void caml_raise_end_of_file(void)
 {
-  caml_raise_constant((value) caml_exn_End_of_file);
+  caml_raise_constant((value)caml_exn_End_of_file);
 }
 
 void caml_raise_zero_divide(void)
 {
-  caml_raise_constant((value) caml_exn_Division_by_zero);
+  caml_raise_constant((value)caml_exn_Division_by_zero);
 }
 
 void caml_raise_not_found(void)
 {
-  caml_raise_constant((value) caml_exn_Not_found);
+  caml_raise_constant((value)caml_exn_Not_found);
 }
 
 void caml_raise_sys_blocked_io(void)
 {
-  caml_raise_constant((value) caml_exn_Sys_blocked_io);
+  caml_raise_constant((value)caml_exn_Sys_blocked_io);
 }
 
 CAMLexport value caml_raise_if_exception(value res)
 {
-  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
+  if (Is_exception_result(res))
+    caml_raise(Extract_exception(res));
   return res;
+}
+
+CAMLexport value caml_raise_async_if_exception(value result)
+{
+  if (Is_exception_result(result))
+    caml_raise_async(Extract_exception(result));
+
+  return result;
 }
 
 /* We use a pre-allocated exception because we can't
    do a GC before the exception is raised (lack of stack descriptors
    for the ccall to [caml_array_bound_error]).  */
 
-static const value * caml_array_bound_error_exn = NULL;
+static const value *caml_array_bound_error_exn = NULL;
 
 void caml_array_bound_error(void)
 {
-  if (caml_array_bound_error_exn == NULL) {
+  if (caml_array_bound_error_exn == NULL)
+  {
     caml_array_bound_error_exn =
-      caml_named_value("Pervasives.array_bound_error");
-    if (caml_array_bound_error_exn == NULL) {
+        caml_named_value("Pervasives.array_bound_error");
+    if (caml_array_bound_error_exn == NULL)
+    {
       fprintf(stderr, "Fatal error: exception "
                       "Invalid_argument(\"index out of bounds\")\n");
       exit(2);
@@ -210,8 +354,37 @@ void caml_array_bound_error(void)
   caml_raise_exception(Caml_state, *caml_array_bound_error_exn);
 }
 
-int caml_is_special_exception(value exn) {
-  return exn == (value) caml_exn_Match_failure
-    || exn == (value) caml_exn_Assert_failure
-    || exn == (value) caml_exn_Undefined_recursive_module;
+int caml_is_special_exception(value exn)
+{
+  return exn == (value)caml_exn_Match_failure || exn == (value)caml_exn_Assert_failure || exn == (value)caml_exn_Undefined_recursive_module;
+}
+
+extern value (caml_callback_asm_async_exn)
+  (caml_domain_state* state, value closure, value* args);
+
+CAMLprim value caml_with_async_exns(value body_callback)
+{
+  value unit = Val_unit;
+  value result = caml_callback_asm_async_exn(Caml_state, body_callback, &unit);
+
+  if (!Is_exception_result(result))
+    return result;
+
+  /* All exceptions, including any async ones that arise during processing
+     in [caml_raise], must be raised as non-async exceptions from this
+     point. */
+  caml_raise_never_async(Extract_exception(result));
+  abort(); /* unreachable */
+}
+
+CAMLprim value caml_mask_async_exns(value unit)
+{
+  Caml_state->async_exceptions_masked = 1;
+  return Val_unit;
+}
+
+CAMLprim value caml_unmask_async_exns(value unit)
+{
+  Caml_state->async_exceptions_masked = 0;
+  return Val_unit;
 }

--- a/ocaml/runtime/finalise.c
+++ b/ocaml/runtime/finalise.c
@@ -183,7 +183,8 @@ value caml_final_do_calls_exn (void)
       -- to_do_hd->size;
       f = to_do_hd->item[to_do_hd->size];
       running_finalisation_function = 1;
-      res = caml_callback_exn (f.fun, f.val + f.offset);
+      res = caml_wrap_if_async_exn (caml_callback_exn (f.fun, f.val + f.offset),
+        pending_FINALISER);
       running_finalisation_function = 0;
       if (Is_exception_result (res)) return res;
     }

--- a/ocaml/runtime/gc_ctrl.c
+++ b/ocaml/runtime/gc_ctrl.c
@@ -539,7 +539,7 @@ CAMLprim value caml_gc_minor(value v)
   // call the gc and call finalisers
   exn = caml_process_pending_actions_exn();
   CAML_EV_END(EV_EXPLICIT_GC_MINOR);
-  caml_raise_if_exception(exn);
+  caml_raise_async_if_exception(exn);
   return Val_unit;
 }
 
@@ -571,7 +571,7 @@ CAMLprim value caml_gc_major(value v)
   // call finalisers
   exn = caml_process_pending_actions_exn();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
-  caml_raise_if_exception(exn);
+  caml_raise_async_if_exception(exn);
   return Val_unit;
 }
 
@@ -596,7 +596,7 @@ CAMLprim value caml_gc_full_major(value v)
 
 cleanup:
   CAML_EV_END(EV_EXPLICIT_GC_FULL_MAJOR);
-  caml_raise_if_exception(exn);
+  caml_raise_async_if_exception(exn);
 
   return Val_unit;
 }
@@ -617,7 +617,7 @@ CAMLprim value caml_gc_major_slice (value v)
     caml_major_collection_slice (Long_val (v));
   }
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR_SLICE);
-  caml_raise_if_exception (exn);
+  caml_raise_async_if_exception (exn);
   return Val_long (0);
 }
 
@@ -643,7 +643,7 @@ CAMLprim value caml_gc_compaction(value v)
 
  cleanup:
   CAML_EV_END(EV_EXPLICIT_GC_COMPACT);
-  caml_raise_if_exception(exn);
+  caml_raise_async_if_exception(exn);
   return Val_unit;
 }
 

--- a/ocaml/runtime/gen_primitives.sh
+++ b/ocaml/runtime/gen_primitives.sh
@@ -25,7 +25,7 @@ export LC_ALL=C
       alloc array compare extern floats gc_ctrl hash intern interp ints io \
       lexing md5 meta memprof obj parsing signals str sys callback weak \
       finalise stacks dynlink backtrace_byt backtrace afl \
-      bigarray eventlog
+      bigarray eventlog fail_nat
   do
       sed -n -e 's/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p' "$prim.c"
   done

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -469,7 +469,7 @@ Caml_inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
 
   if (wosize > Max_wosize) {
     if (raise_oom)
-      caml_raise_out_of_memory ();
+      caml_raise_out_of_memory_fatal ();
     else
       return 0;
   }
@@ -483,7 +483,7 @@ Caml_inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
       else if (Caml_state->in_minor_collection)
         caml_fatal_error ("out of memory");
       else
-        caml_raise_out_of_memory ();
+        caml_raise_out_of_memory_fatal ();
     }
     caml_fl_add_blocks ((value) new_block);
     hp = caml_fl_allocate (wosize);
@@ -933,7 +933,7 @@ CAMLexport void* caml_stat_alloc_aligned(asize_t sz, int modulo,
   void *result = caml_stat_alloc_aligned_noexc(sz, modulo, b);
   /* malloc() may return NULL if size is 0 */
   if ((result == NULL) && (sz != 0))
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   return result;
 }
 
@@ -967,7 +967,7 @@ CAMLexport caml_stat_block caml_stat_alloc(asize_t sz)
   void *result = caml_stat_alloc_noexc(sz);
   /* malloc() may return NULL if size is 0 */
   if ((result == NULL) && (sz != 0))
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   return result;
 }
 
@@ -1014,7 +1014,7 @@ CAMLexport caml_stat_block caml_stat_resize(caml_stat_block b, asize_t sz)
 {
   void *result = caml_stat_resize_noexc(b, sz);
   if (result == NULL)
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   return result;
 }
 
@@ -1046,7 +1046,7 @@ CAMLexport caml_stat_string caml_stat_strdup(const char *s)
 {
   caml_stat_string result = caml_stat_strdup_noexc(s);
   if (result == NULL)
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   return result;
 }
 
@@ -1057,7 +1057,7 @@ CAMLexport wchar_t * caml_stat_wcsdup(const wchar_t *s)
   int slen = wcslen(s);
   wchar_t* result = caml_stat_alloc((slen + 1)*sizeof(wchar_t));
   if (result == NULL)
-    caml_raise_out_of_memory();
+    caml_raise_out_of_memory_fatal();
   memcpy(result, s, (slen + 1)*sizeof(wchar_t));
   return result;
 }

--- a/ocaml/runtime/memprof.c
+++ b/ocaml/runtime/memprof.c
@@ -450,7 +450,8 @@ Caml_inline value run_callback_exn(
   local->callback_status = ea == &entries_global ? t_idx : CB_LOCAL;
   t->running = local;
   t->user_data = Val_unit;      /* Release root. */
-  res = caml_callback_exn(cb, param);
+  res = caml_wrap_if_async_exn(caml_callback_exn(cb, param),
+    pending_MEMPROF_CALLBACK);
   if (local->callback_status == CB_STOPPED) {
     /* Make sure this entry has not been removed by [caml_memprof_stop] */
     local->callback_status = CB_IDLE;
@@ -620,6 +621,8 @@ value caml_memprof_handle_postponed_exn(void)
   /* We need to reset the suspended flag *after* flushing
      [local->entries] to make sure the floag is not set back to 1. */
   caml_memprof_set_suspended(0);
+
+
   return res;
 }
 
@@ -963,8 +966,14 @@ void caml_memprof_track_young(uintnat wosize, int from_caml,
      [local->entries] to make sure the floag is not set back to 1. */
   caml_memprof_set_suspended(0);
 
-  if (Is_exception_result(res))
-    caml_raise(Extract_exception(res));
+  if (Is_exception_result(res)) {
+    value exn = Extract_exception(res);
+    if (from_caml) {
+      caml_raise_async(exn);
+    } else {
+      caml_raise(exn);
+    }
+  }
 
   /* /!\ Since the heap is in an invalid state before initialization,
      very little heap operations are allowed until then. */

--- a/ocaml/runtime/signals.c
+++ b/ocaml/runtime/signals.c
@@ -153,7 +153,7 @@ CAMLexport void caml_enter_blocking_section(void)
 {
   while (1){
     /* Process all pending signals now */
-    caml_raise_if_exception(caml_process_pending_signals_exn());
+    caml_raise_async_if_exception(caml_process_pending_signals_exn());
     caml_enter_blocking_section_hook ();
     /* Check again for pending signals.
        If none, done; otherwise, try again */
@@ -224,7 +224,7 @@ value caml_execute_signal_exn(int signal_number, int in_signal_handler)
     caml_sigmask_hook(SIG_SETMASK, &sigs, NULL);
   }
 #endif
-  return res;
+  return caml_wrap_if_async_exn(res, pending_SIGNAL_HANDLER);
 }
 
 void caml_update_young_limit (void)
@@ -318,7 +318,7 @@ value caml_process_pending_actions_with_root_exn(value extra_root)
 value caml_process_pending_actions_with_root(value extra_root)
 {
   value res = process_pending_actions_with_root_exn(extra_root);
-  return caml_raise_if_exception(res);
+  return caml_raise_async_if_exception(res);
 }
 
 CAMLexport value caml_process_pending_actions_exn(void)
@@ -329,7 +329,7 @@ CAMLexport value caml_process_pending_actions_exn(void)
 CAMLexport void caml_process_pending_actions(void)
 {
   value exn = process_pending_actions_with_root_exn(Val_unit);
-  caml_raise_if_exception(exn);
+  caml_raise_async_if_exception(exn);
 }
 
 /* OS-independent numbering of signals */
@@ -486,6 +486,6 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     }
     caml_modify(&Field(caml_signal_handlers, sig), Field(action, 0));
   }
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  caml_raise_async_if_exception(caml_process_pending_signals_exn());
   CAMLreturn (res);
 }

--- a/ocaml/runtime/startup_nat.c
+++ b/ocaml/runtime/startup_nat.c
@@ -137,6 +137,7 @@ value caml_startup_common(char_os **argv, int pooling)
                 caml_init_custom_major_ratio, caml_init_custom_minor_ratio,
                 caml_init_custom_minor_max_bsz);
   init_static();
+  Caml_state->async_exceptions_masked = 0;
   caml_init_signals();
 #ifdef _WIN32
   caml_win32_overflow_detection();

--- a/ocaml/stdlib/stdlib.ml
+++ b/ocaml/stdlib/stdlib.ml
@@ -46,6 +46,9 @@ exception End_of_file = End_of_file
 exception Division_by_zero = Division_by_zero
 exception Sys_blocked_io = Sys_blocked_io
 exception Undefined_recursive_module = Undefined_recursive_module
+exception Signal_handler_raised = Signal_handler_raised
+exception Finaliser_raised = Finaliser_raised
+exception Memprof_callback_raised = Memprof_callback_raised
 
 (* Composition operators *)
 

--- a/ocaml/stdlib/stdlib.mli
+++ b/ocaml/stdlib/stdlib.mli
@@ -81,9 +81,10 @@ exception Not_found
    not be found. *)
 
 exception Out_of_memory
-(** Exception raised by the garbage collector when there is
-   insufficient memory to complete the computation. (Not reliable for
-   allocations on the minor heap.) *)
+(** Exception raised by functions such as those for array and bigarray
+    creation when there is insufficient memory.  Failure to allocate
+    memory during garbage collection causes a fatal error, unlike in
+    previous versions. *)
 
 exception Stack_overflow
 (** Exception raised by the bytecode interpreter when the evaluation
@@ -118,6 +119,18 @@ exception Undefined_recursive_module of (string * int * int)
 (** Exception raised when an ill-founded recursive module definition
    is evaluated. The arguments are the location of the definition in
    the source code (file name, line number, column number). *)
+
+exception Signal_handler_raised of exn
+(** Exception raised from a signal handler.  This should be caught using
+    [Sys.with_async_exns].  Only for native code compilation. *)
+
+exception Finaliser_raised of exn
+(** Exception raised from a finaliser.  This should be caught using
+    [Sys.with_async_exns].  Only for native code compilation. *)
+
+exception Memprof_callback_raised of exn
+(** Exception raised from a memprof callback.  This should be caught using
+    [Sys.with_async_exns].  Only for native code compilation. *)
 
 (** {1 Comparisons} *)
 

--- a/ocaml/stdlib/sys.mlp
+++ b/ocaml/stdlib/sys.mlp
@@ -122,6 +122,60 @@ let catch_break on =
   else
     set_signal sigint Signal_default
 
+external with_async_exns : (unit -> 'a) -> 'a = "caml_with_async_exns"
+external mask_async_exns : unit -> unit = "caml_mask_async_exns"
+external unmask_async_exns : unit -> unit = "caml_unmask_async_exns"
+
+(*
+external reraise : exn -> 'a = "%reraise"
+let with_async_exns body =
+  try with_async_exns0 body
+  with
+  | Signal_handler_raised Break -> reraise Break
+  | exn -> raise exn
+*)
+
+external raise_async : exn -> unit = "caml_raise_async"
+
+let with_destructor f ~destructor =
+  match
+    with_async_exns (fun () ->
+      let result = f () in
+      mask_async_exns ();
+      result)
+  with
+  | result ->
+    unmask_async_exns ();
+    result
+  | exception exn -> (
+    (try destructor () with _ -> ());
+    let is_async_exn =
+      match exn with
+      | Finaliser_raised _ | Memprof_callback_raised _
+      | Signal_handler_raised _ | Stack_overflow -> true
+      | _ -> false
+    in
+    unmask_async_exns ();
+    while true do
+      if is_async_exn then raise_async exn
+      else raise exn
+    done;
+    assert false
+  )
+
+let bracket ~acquire ~release ?(release_on_fail = release) f =
+  mask_async_exns ();
+  match acquire () with
+  | exception exn ->
+    unmask_async_exns ();
+    raise exn
+  | resource ->
+    with_destructor (fun () ->
+        unmask_async_exns ();
+        let result = f resource in
+        release resource;
+        result)
+      ~destructor:(fun () -> release_on_fail resource)
 
 external enable_runtime_warnings: bool -> unit =
   "caml_ml_enable_runtime_warnings"

--- a/ocaml/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/ocaml/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 402, characters 28-54
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 405, characters 28-54
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/ocaml/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/ocaml/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 402, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 407, characters 2-45
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 405, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 410, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -12,16 +12,16 @@ match (3, 2, 1) with
 ;;
 [%%expect{|
 (let
-  (*match*/268 = 3
-   *match*/269 = 2
-   *match*/270 = 1
-   *match*/271 = *match*/268
-   *match*/272 = *match*/269
-   *match*/273 = *match*/270)
+  (*match*/271 = 3
+   *match*/272 = 2
+   *match*/273 = 1
+   *match*/274 = *match*/271
+   *match*/275 = *match*/272
+   *match*/276 = *match*/273)
   (catch
     (catch
-      (catch (if (!= *match*/272 3) (exit 3) (exit 1)) with (3)
-        (if (!= *match*/271 1) (exit 2) (exit 1)))
+      (catch (if (!= *match*/275 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/274 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
 - : bool = false
@@ -36,26 +36,26 @@ match (3, 2, 1) with
 ;;
 [%%expect{|
 (let
-  (*match*/276 = 3
-   *match*/277 = 2
-   *match*/278 = 1
-   *match*/279 = (makeblock 0 *match*/276 *match*/277 *match*/278))
+  (*match*/279 = 3
+   *match*/280 = 2
+   *match*/281 = 1
+   *match*/282 = (makeblock 0 *match*/279 *match*/280 *match*/281))
   (catch
     (catch
-      (let (*match*/280 =a (field 0 *match*/279))
+      (let (*match*/283 =a (field 0 *match*/282))
         (catch
-          (let (*match*/281 =a (field 1 *match*/279))
-            (if (!= *match*/281 3) (exit 7)
-              (let (*match*/282 =a (field 2 *match*/279))
-                (exit 5 *match*/279))))
+          (let (*match*/284 =a (field 1 *match*/282))
+            (if (!= *match*/284 3) (exit 7)
+              (let (*match*/285 =a (field 2 *match*/282))
+                (exit 5 *match*/282))))
          with (7)
-          (if (!= *match*/280 1) (exit 6)
+          (if (!= *match*/283 1) (exit 6)
             (let
-              (*match*/284 =a (field 2 *match*/279)
-               *match*/283 =a (field 1 *match*/279))
-              (exit 5 *match*/279)))))
+              (*match*/287 =a (field 2 *match*/282)
+               *match*/286 =a (field 1 *match*/282))
+              (exit 5 *match*/282)))))
      with (6) 0)
-   with (5 x/274[(consts ()) (non_consts ([0: [int], [int], [int]]))])
-    (seq (ignore x/274) 1)))
+   with (5 x/277[(consts ()) (non_consts ([0: [int], [int], [int]]))])
+    (seq (ignore x/277) 1)))
 - : bool = false
 |}];;

--- a/ocaml/testsuite/tests/generalized-open/gpr1506.ml
+++ b/ocaml/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,9 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t/330 introduced by this open appears in the signature
+Error: The type t/333 introduced by this open appears in the signature
        Line 1, characters 46-47:
-         The value x has no valid type if t/330 is hidden
+         The value x has no valid type if t/333 is hidden
 |}];;
 
 module A = struct
@@ -123,9 +123,9 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t/335 introduced by this open appears in the signature
+Error: The type t/338 introduced by this open appears in the signature
        Line 7, characters 8-9:
-         The value y has no valid type if t/335 is hidden
+         The value y has no valid type if t/338 is hidden
 |}];;
 
 module A = struct
@@ -142,9 +142,9 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t/340 introduced by this open appears in the signature
+Error: The type t/343 introduced by this open appears in the signature
        Line 6, characters 8-9:
-         The value y has no valid type if t/340 is hidden
+         The value y has no valid type if t/343 is hidden
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/ocaml/testsuite/tests/lib-systhreads/eintr.ml
+++ b/ocaml/testsuite/tests/lib-systhreads/eintr.ml
@@ -26,10 +26,14 @@ let request_signal () = Atomic.incr signals_requested
 let () =
   let (rd, wr) = Unix.pipe () in
   Sys.catch_break true;
-  request_signal ();
-  begin match Unix.read rd (Bytes.make 1 'a') 0 1 with
+  begin match
+    Sys.with_async_exns (fun () ->
+      request_signal ();
+      Unix.read rd (Bytes.make 1 'a') 0 1)
+  with
   | _ -> assert false
-  | exception Sys.Break -> print_endline "break: ok" end;
+  | exception (Signal_handler_raised Sys.Break) ->
+    print_endline "break: ok" end;
   Sys.catch_break false;
   Unix.close rd;
   Unix.close wr
@@ -71,19 +75,29 @@ let () =
   let before = Sys.opaque_identity (ref (mklist ())) in
   let during = Atomic.make (Sys.opaque_identity (mklist ())) in
   let siglist = ref [] in
-  Sys.set_signal Sys.sigint (Signal_handle (fun _ ->
-    Gc.full_major (); poke_stdout (); Gc.compact ();
-    siglist := mklist ();
-    raise Sys.Break));
-  request_signal ();
-  begin match
+  let test_body () =
+    (* Allocate [test_body]'s closure here, to avoid disturbing the
+       test in the context of [with_async_exns] below. *)
+    request_signal ();
     while true do
       poke_stdout ();
       Atomic.set during (mklist ())
     done
-  with
+  in
+  Sys.set_signal Sys.sigint (Signal_handle (fun _ ->
+    Gc.full_major (); poke_stdout (); Gc.compact ();
+    siglist := mklist ();
+    raise Sys.Break));
+  begin match Sys.with_async_exns test_body with
   | () -> assert false
-  | exception Sys.Break -> () end;
+  | exception (Signal_handler_raised Sys.Break) -> ()
+  (*
+  | exception (Signal_handler_raised exn) ->
+    print_string "Signal_handler_raised ";
+    print_endline (Printexc.to_string exn);
+    assert false
+  *)
+  end;
   let expected = Sys.opaque_identity (mklist ()) in
   assert (!before = expected);
   assert (Atomic.get during = expected);

--- a/ocaml/testsuite/tests/runtime-errors/stackoverflow.ml
+++ b/ocaml/testsuite/tests/runtime-errors/stackoverflow.ml
@@ -28,7 +28,7 @@ let rec f x =
   then 1 + f (x + 1)
   else
     try
-      1 + f (x + 1)
+      Sys.with_async_exns (fun () -> 1 + f (x + 1))
     with Stack_overflow ->
       print_string "x = "; print_int x; print_newline();
       raise Stack_overflow
@@ -36,7 +36,7 @@ let rec f x =
 let _ =
  begin
   try
-    ignore(f 0)
+    Sys.with_async_exns (fun () -> ignore(f 0))
   with Stack_overflow ->
     print_string "Stack overflow caught"; print_newline()
  end ;
@@ -44,7 +44,7 @@ let _ =
  Printexc.record_backtrace true;
  begin
   try
-    ignore(f 0)
+    Sys.with_async_exns (fun () -> ignore(f 0))
   with Stack_overflow ->
     print_string "second Stack overflow caught"; print_newline()
  end

--- a/ocaml/testsuite/tests/statmemprof/exception_callback.ml
+++ b/ocaml/testsuite/tests/statmemprof/exception_callback.ml
@@ -4,6 +4,8 @@
 
 open Gc.Memprof
 
+(* CR mshinwell: fix this test properly *)
+
 let alloc_tracker on_alloc =
   { null_tracker with
     alloc_minor = (fun info -> on_alloc info; None);

--- a/ocaml/testsuite/tests/statmemprof/exception_callback.reference
+++ b/ocaml/testsuite/tests/statmemprof/exception_callback.reference
@@ -1,1 +1,1 @@
-Fatal error: exception Failure("callback failed")
+Fatal error: exception Memprof_callback_raised(_)

--- a/ocaml/testsuite/tests/statmemprof/exception_callback_minor.ml
+++ b/ocaml/testsuite/tests/statmemprof/exception_callback_minor.ml
@@ -10,6 +10,8 @@ open Gc.Memprof
    its uncaught exception handler. *)
 let _ = Printexc.record_backtrace false
 
+(* CR mshinwell: fix this test properly *)
+
 let _ =
   start ~callstack_size:10 ~sampling_rate:1.
     { null_tracker with

--- a/ocaml/testsuite/tests/statmemprof/exception_callback_minor.reference
+++ b/ocaml/testsuite/tests/statmemprof/exception_callback_minor.reference
@@ -1,1 +1,1 @@
-Fatal error: exception File "exception_callback_minor.ml", line 16, characters 30-36: Assertion failed
+Fatal error: exception Memprof_callback_raised(_)

--- a/ocaml/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/ocaml/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,11 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/278 by t/282
+Error: Illegal shadowing of included type t/281 by t/285
        Line 2, characters 2-19:
-         Type t/278 came from this include
+         Type t/281 came from this include
        Line 3, characters 2-23:
-         The value print has no valid type if t/278 is shadowed
+         The value print has no valid type if t/281 is shadowed
 |}]
 
 module type Sunderscore = sig

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -96,6 +96,9 @@ and ident_sys_blocked_io = ident_create "Sys_blocked_io"
 and ident_assert_failure = ident_create "Assert_failure"
 and ident_undefined_recursive_module =
         ident_create "Undefined_recursive_module"
+and ident_finaliser_raised = ident_create "Finaliser_raised"
+and ident_signal_handler_raised = ident_create "Signal_handler_raised"
+and ident_memprof_callback_raised = ident_create "Memprof_callback_raised"
 
 let all_predef_exns = [
   ident_match_failure;
@@ -110,6 +113,9 @@ let all_predef_exns = [
   ident_sys_blocked_io;
   ident_assert_failure;
   ident_undefined_recursive_module;
+  ident_finaliser_raised;
+  ident_signal_handler_raised;
+  ident_memprof_callback_raised;
 ]
 
 let path_match_failure = Pident ident_match_failure
@@ -208,6 +214,9 @@ let common_initial_env add_type add_extension empty_env =
                          [newgenty (Ttuple[type_string; type_int; type_int])] (
   add_extension ident_undefined_recursive_module
                          [newgenty (Ttuple[type_string; type_int; type_int])] (
+  add_extension ident_finaliser_raised [type_exn] (
+  add_extension ident_signal_handler_raised [type_exn] (
+  add_extension ident_memprof_callback_raised [type_exn] (
   add_type ident_int64 (
   add_type ident_int32 (
   add_type ident_nativeint (
@@ -235,7 +244,7 @@ let common_initial_env add_type add_extension empty_env =
   add_type ident_int ~immediate:Always (
   add_type ident_extension_constructor (
   add_type ident_floatarray (
-    empty_env))))))))))))))))))))))))))))
+    empty_env)))))))))))))))))))))))))))))))
 
 let build_initial_env add_type add_exception empty_env =
   let common = common_initial_env add_type add_exception empty_env in


### PR DESCRIPTION
This PR provides a way of making explicit the places where asynchronous exceptions may be raised.  This in particular stops exceptions arising from allocation points and thus matches up with the model used by Flambda 2.  One consequence is that the addition of safepoints will then work correctly with Flambda 2.  This supercedes #194.

The asynchronous exceptions are now nicely wrapped up as follows:
```
exception Stack_overflow
exception Finaliser_raised of exn
exception Memprof_callback_raised of exn
exception Signal_handler_raised of exn
```
Uses of `Out_of_memory` that were asynchronous exceptions (there were some uses that were not) now terminate the program.

There is currently a new function `Sys.with_async_exns` that can be used to identify a point at which asynchronous exceptions should be emitted.  There is also an experiment to implement the "bracket pattern" [like in Haskell](https://wiki.haskell.org/Bracket_pattern); see `Sys.bracket`.  There is a file containing a couple of tests which will need to be much enhanced.

Asynchronous exceptions are funneled via a new exception pointer in the domain state, which points at normal trap frames, forming a second exception stack.  The raising of asynchronous exceptions skips over traps that weren't inserted by `with_async_exns`.  The second exception stack, save for the head which is in the domain state, is just held in what are effectively local variables in the `caml_start_program` / `caml_callback` code (albeit written in assembler).

Note that `Stack_overflow` is special and can be raised directly from a signal handler.

Joint work with @stedolan and @lpw25 .