### PR TITLE
IRC: stack operands

### DIFF
--- a/backend/amd64/cfg_stack_operands.ml
+++ b/backend/amd64/cfg_stack_operands.ml
@@ -1,0 +1,220 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open! Cfg_regalloc_utils
+
+let debug = true
+
+let may_use_stack_operand_for_second_argument
+  : type a . spilled_map -> a Cfg.instruction -> stack_operands_rewrite
+  = fun map instr ->
+  if debug then begin
+    check_lengths instr ~of_arg:2 ~of_res:1;
+    check_same "res(0)" instr.res.(0) "arg(0)" instr.arg.(0);
+  end;
+  begin match is_spilled instr.arg.(1) with
+  | false -> ()
+  | true ->
+    use_stack_operand map instr.arg 1;
+  end;
+  May_still_have_spilled_registers
+
+let may_use_stack_operand_for_only_argument
+  : type a . has_result:bool -> spilled_map -> a Cfg.instruction -> stack_operands_rewrite
+  = fun ~has_result map instr ->
+  if debug then check_lengths instr ~of_arg:1 ~of_res:(if has_result then 1 else 0);
+  begin match is_spilled instr.arg.(0) with
+  | false -> ()
+  | true ->
+    use_stack_operand map instr.arg 0
+  end;
+  if has_result then
+    May_still_have_spilled_registers
+  else
+    All_spilled_registers_rewritten
+
+let may_use_stack_operand_for_only_result
+  : type a . spilled_map -> a Cfg.instruction -> stack_operands_rewrite
+  = fun map instr ->
+  if debug then check_lengths instr ~of_arg:0 ~of_res:1;
+  begin match is_spilled instr.res.(0) with
+  | false ->
+    All_spilled_registers_rewritten
+  | true ->
+    use_stack_operand map instr.res 0;
+    All_spilled_registers_rewritten
+  end
+
+let may_use_stack_operand_for_result
+  : type a . num_args:int -> spilled_map -> a Cfg.instruction -> stack_operands_rewrite
+  = fun ~num_args map instr ->
+  if debug then begin
+    check_lengths instr ~of_arg:num_args ~of_res:1;
+  end;
+  begin match is_spilled instr.res.(0) with
+  | false -> ()
+  | true ->
+    if Reg.same instr.arg.(0) instr.res.(0) then begin
+      use_stack_operand map instr.arg 0;
+    end;
+    use_stack_operand map instr.res 0;
+  end;
+  May_still_have_spilled_registers
+
+type result =
+  | No_result
+  | Result_can_be_on_stack
+  | Result_cannot_be_on_stack
+
+let binary_operation
+  : type a . spilled_map -> a Cfg.instruction -> result -> stack_operands_rewrite
+  = fun map instr result ->
+  if debug then begin
+    match result with
+    | No_result ->
+      check_lengths instr ~of_arg:2 ~of_res:0
+    | Result_can_be_on_stack ->
+      check_lengths instr ~of_arg:2 ~of_res:1;
+      check_same "res(0)" instr.res.(0) "arg(0)" instr.arg.(0)
+    | Result_cannot_be_on_stack ->
+      check_lengths instr ~of_arg:2 ~of_res:1
+  end;
+  begin match is_spilled instr.arg.(0), is_spilled instr.arg.(1) with
+  | false, false ->
+    begin match result with
+    | No_result | Result_can_be_on_stack ->
+      All_spilled_registers_rewritten
+    | Result_cannot_be_on_stack ->
+      May_still_have_spilled_registers
+    end
+  | false, true ->
+    use_stack_operand map instr.arg 1;
+    begin match result with
+    | No_result ->
+      All_spilled_registers_rewritten
+    | Result_can_be_on_stack | Result_cannot_be_on_stack ->
+      May_still_have_spilled_registers
+    end
+  | true, false ->
+    (* note: slightly different from the case above, because arg.(0) and res.(0) are the same. *)
+    begin match result with
+    | No_result ->
+      use_stack_operand map instr.arg 0;
+      All_spilled_registers_rewritten
+    | Result_can_be_on_stack ->
+      use_stack_operand map instr.res 0;
+      use_stack_operand map instr.arg 0;
+      All_spilled_registers_rewritten
+    | Result_cannot_be_on_stack ->
+      use_stack_operand map instr.arg 0;
+      May_still_have_spilled_registers
+    end;
+  | true, true ->
+    if Reg.same instr.arg.(0) instr.arg.(1) then
+      May_still_have_spilled_registers
+    else begin
+      match result with
+      | No_result ->
+        (* CR xclerc for xclerc: try and find for a criterion to choose between
+           the two. *)
+        use_stack_operand map instr.arg 0;
+        May_still_have_spilled_registers
+      | Result_can_be_on_stack ->
+        use_stack_operand map instr.arg 0;
+        use_stack_operand map instr.res 0;
+        May_still_have_spilled_registers
+      | Result_cannot_be_on_stack ->
+        use_stack_operand map instr.arg 1;
+        May_still_have_spilled_registers
+    end
+  end
+
+let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
+  begin match instr.desc with
+  | Call (P (Checkbound { immediate = None; } )) ->
+    binary_operation map instr No_result
+  | Call (P (Checkbound { immediate = Some _; } )) ->
+    may_use_stack_operand_for_only_argument map instr ~has_result:false
+  | Op (Addf | Subf | Mulf | Divf)
+  | Op (Specific (Ifloat_min | Ifloat_max | Icrc32q)) ->
+    may_use_stack_operand_for_second_argument map instr
+  | Op (Floatofint | Intoffloat) ->
+    may_use_stack_operand_for_only_argument map instr ~has_result:true
+  | Op (Const_symbol _) ->
+    if !Clflags.pic_code || !Clflags.dlcode || Arch.win64 then
+      May_still_have_spilled_registers
+    else
+      may_use_stack_operand_for_only_result map instr
+  | Op (Const_int n) ->
+    if n <= 0x7FFFFFFFn && n >= -0x80000000n then begin
+      may_use_stack_operand_for_only_result map instr
+    end else begin
+      May_still_have_spilled_registers
+    end
+  | Op (Intop (Iadd | Isub | Iand | Ior | Ixor)) ->
+    binary_operation map instr Result_can_be_on_stack
+  | Op (Intop (Icomp _)) ->
+    binary_operation map instr Result_cannot_be_on_stack
+  | Op (Specific (Ifloat_iround | Ifloat_round _))
+  | Op (Intop_imm (Icomp _, _)) ->
+    may_use_stack_operand_for_only_argument map instr ~has_result:true
+  | Op (Intop_imm (Iadd, _)) when (Reg.same_loc instr.arg.(0) instr.res.(0)) ->
+    May_still_have_spilled_registers
+  | Op (Intop(Ilsl | Ilsr | Iasr)) ->
+    may_use_stack_operand_for_result map instr ~num_args:2
+  | Op(Intop_imm((Iadd | Isub | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr), _)) ->
+    may_use_stack_operand_for_result map instr ~num_args:1
+  | Op (Probe _) ->
+    may_use_stack_operands_everywhere map instr
+  | Op (Specific (Ilfence | Isfence | Imfence))
+  | Op (Intop(Imulh _ | Imul | Idiv | Imod))
+  | Op (Intop_imm ((Imulh _ | Imul | Idiv | Imod), _))
+  | Op (Specific (Irdtsc | Irdpmc))
+  | Op (Intop (Ipopcnt | Iclz _| Ictz _))
+  | Op (Move | Spill | Reload | Negf | Absf | Const_float _ | Compf _ | Stackoffset _
+       | Load _ | Store _ | Name_for_debugger _ | Probe_is_enabled _
+       | Opaque | Begin_region | End_region )
+  | Op (Specific (Isqrtf | Isextend32 | Izextend32 | Ilea _
+                 | Istore_int (_, _, _)
+                 | Ioffset_loc (_, _) | Ifloatarithmem (_, _)
+                 | Ipause
+                 | Iprefetch _
+                 | Ibswap _| Ifloatsqrtf _))
+  | Call (P (External _ | Alloc _) | F (Indirect | Direct _))
+  | Reloadretaddr
+  | Pushtrap _
+  | Poptrap
+  | Prologue ->
+    (* no rewrite *)
+    May_still_have_spilled_registers
+  | Op (Intop Icheckbound)
+  | Op (Intop_imm ((Ipopcnt | Iclz _ | Ictz _ | Icheckbound), _)) ->
+    (* should no happen *)
+    fatal "unexpected instruction"
+  end
+
+let terminator (map : spilled_map) (term : Cfg.terminator Cfg.instruction) =
+  ignore map;
+  match (term : Cfg.terminator Cfg.instruction).desc with
+  | Never -> fatal "unexpected terminator"
+
+  | Int_test { lt = _; eq = _; gt =_; is_signed = _; imm = None; } ->
+    binary_operation map term No_result
+  | Int_test { lt = _; eq = _; gt =_; is_signed = _; imm = Some _; }
+  | Parity_test { ifso = _; ifnot = _; }
+  | Truth_test { ifso = _; ifnot = _; } ->
+    may_use_stack_operand_for_only_argument ~has_result:false map term
+  | Float_test _ ->
+    (* CR-someday xclerc for xclerc: this could be optimized, but the representation
+       makes it more difficult than the cases above, because (i) multiple
+       branching instructions may be emitted and (ii) the operand constraints
+       depend on the exact kind of branch (because we sometimes swap the
+       operands). *)
+    May_still_have_spilled_registers
+  | Always _
+  | Return
+  | Raise _
+  | Switch _
+  | Tailcall _
+  | Call_no_return _ ->
+    (* no rewrite *)
+    May_still_have_spilled_registers

--- a/backend/amd64/cfg_stack_operands.ml
+++ b/backend/amd64/cfg_stack_operands.ml
@@ -123,7 +123,7 @@ let binary_operation
         use_stack_operand map instr.res 0;
         May_still_have_spilled_registers
       | Result_cannot_be_on_stack ->
-        use_stack_operand map instr.arg 1;
+        use_stack_operand map instr.arg 0;
         May_still_have_spilled_registers
     end
   end

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -160,7 +160,8 @@ method! reload_operation op arg res =
   | Istore (_, _, _)|Ialloc _|Iname_for_debugger _|Iprobe _|Iprobe_is_enabled _
   | Iopaque
   | Ibeginregion | Iendregion
-    -> (* Other operations: all args and results in registers *)
+    -> (* Other operations: all args and results in registers,
+          except moves and probes. *)
       super#reload_operation op arg res
 
 method! reload_test tst arg =

--- a/backend/arm64/cfg_stack_operands.ml
+++ b/backend/arm64/cfg_stack_operands.ml
@@ -1,0 +1,36 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open! Cfg_regalloc_utils
+
+let debug = true
+
+let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
+  match instr.desc with
+  | Op (Probe _) ->
+    may_use_stack_operands_everywhere map instr
+  | Op (Specific Imove32) ->
+    if debug then check_lengths instr ~of_arg:1 ~of_res:1;
+    begin match is_spilled instr.arg.(0), is_spilled instr.res.(0) with
+    | false, false ->
+      All_spilled_registers_rewritten
+    | false, true ->
+      use_stack_operand map instr.res 0;
+      All_spilled_registers_rewritten
+    | true, false ->
+      use_stack_operand map instr.arg 0;
+      All_spilled_registers_rewritten
+    | true, true ->
+      if Reg.same instr.arg.(0) instr.res.(0) then begin
+        All_spilled_registers_rewritten
+      end else begin
+        use_stack_operand map instr.res 0;
+        May_still_have_spilled_registers
+      end
+    end
+  | _ ->
+    (* no rewrite *)
+    May_still_have_spilled_registers
+
+let terminator _ _ =
+  (* no rewrite *)
+  May_still_have_spilled_registers

--- a/backend/cfg/cfg_regalloc_utils.mli
+++ b/backend/cfg/cfg_regalloc_utils.mli
@@ -40,7 +40,8 @@ type cfg_infos =
 
 (* CR xclerc for xclerc: this function currently reset the worklist to
    "unknown", but that should be done elsewhere as functions in this module are
-   supposed to be independent of IRC.*)
+   supposed to be independent of IRC. note: we are also copying arg/res for all
+   instructions, to break sharing. *)
 val collect_cfg_infos : Cfg_with_layout.t -> cfg_infos
 
 type liveness = Cfg_liveness.Liveness.domain Cfg_dataflow.Instr.Tbl.t
@@ -73,7 +74,8 @@ val simplify_cfg : Cfg_with_layout.t -> Cfg_with_layout.t
 
 val precondition : Cfg_with_layout.t -> unit
 
-val postcondition : Cfg_with_layout.t -> unit
+(* CR-soon xclerc for xclerc: remove the `allow_stack_operands` parameter. *)
+val postcondition : Cfg_with_layout.t -> allow_stack_operands:bool -> unit
 
 val save_cfg : string -> Cfg_with_layout.t -> unit
 
@@ -85,3 +87,26 @@ val update_live_fields : Cfg_with_layout.t -> liveness -> unit
 
 (* The spill cost is currently the number of occurrences of the register. *)
 val update_spill_cost : Cfg_with_layout.t -> unit
+
+val is_spilled : Reg.t -> bool
+
+val check_length : string -> 'a array -> int -> unit
+
+val check_lengths : of_arg:int -> of_res:int -> 'a Cfg.instruction -> unit
+
+val check_same : string -> Reg.t -> string -> Reg.t -> unit
+
+(* CR xclerc for xclerc: consider renaming the constructors *)
+type stack_operands_rewrite =
+  | All_spilled_registers_rewritten
+  | May_still_have_spilled_registers
+
+(* Substitution/map from registers to their spilled counterparts. *)
+type spilled_map = Reg.t Reg.Tbl.t
+
+val use_stack_operand : spilled_map -> Reg.t array -> int -> unit
+
+val may_use_stack_operands_array : spilled_map -> Reg.t array -> unit
+
+val may_use_stack_operands_everywhere :
+  spilled_map -> 'a Cfg.instruction -> stack_operands_rewrite

--- a/backend/cfg/cfg_regalloc_validate.ml
+++ b/backend/cfg/cfg_regalloc_validate.ml
@@ -442,7 +442,7 @@ end = struct
         "Register allocation added non-regalloc specific instruction no. %d" id
 
   let verify t cfg =
-    Cfg_regalloc_utils.postcondition cfg;
+    Cfg_regalloc_utils.postcondition cfg ~allow_stack_operands:true;
     verify_reg_array ~reg_arr:t.reg_fun_args ~context:"In function arguments"
       ~loc_arr:(Cfg_with_layout.cfg cfg).fun_args;
     let seen_ids =

--- a/backend/cfg/cfg_stack_operands.mli
+++ b/backend/cfg/cfg_stack_operands.mli
@@ -1,0 +1,16 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open! Cfg_regalloc_utils
+
+(* The functions below can rewrite (in place) a spilled register (in arg or
+   res), if the operand constraints of the instruction allow it. The passed
+   mapping is used to determine the location of the register on the stack; it
+   means that for all spilled registers, there is a mapping from the spilled
+   register to one whose location is on the stack (i.e. spilling slot for the
+   first register). The functions return a value indicating whether there may
+   still be spilled registers in arg or res. *)
+
+val basic : spilled_map -> Cfg.basic Cfg.instruction -> stack_operands_rewrite
+
+val terminator :
+  spilled_map -> Cfg.terminator Cfg.instruction -> stack_operands_rewrite

--- a/backend/dune
+++ b/backend/dune
@@ -13,7 +13,7 @@
 ;**************************************************************************
 
 (rule
- (targets arch.ml CSE.ml proc.ml reload.ml scheduling.ml selection.ml)
+ (targets arch.ml cfg_stack_operands.ml CSE.ml proc.ml reload.ml scheduling.ml selection.ml)
  (mode    fallback)
  (deps    (glob_files amd64/*.ml)
           (glob_files arm64/*.ml))

--- a/dune
+++ b/dune
@@ -246,6 +246,7 @@
   cfg_regalloc_utils
   cfg_regalloc_validate
   cfg_to_linear_desc
+  cfg_stack_operands
   cfg_irc
   cfg_irc_state
   cfg_irc_utils
@@ -759,6 +760,7 @@
   (cfg_regalloc_utils.mli as compiler-libs/cfg_regalloc_utils.mli)
   (cfg_regalloc_validate.mli as compiler-libs/cfg_regalloc_validate.mli)
   (cfg_to_linear_desc.mli as compiler-libs/cfg_to_linear_desc.mli)
+  (cfg_stack_operands.mli as compiler-libs/cfg_stack_operands.mli)
   (cfg_irc.mli as compiler-libs/cfg_irc.mli)
   (cfg_irc_state.mli as compiler-libs/cfg_irc_state.mli)
   (cfg_irc_utils.mli as compiler-libs/cfg_irc_utils.mli)
@@ -1222,6 +1224,7 @@
   (.ocamloptcomp.objs/byte/cfg_regalloc_utils.cmti
    as
    compiler-libs/cfg_regalloc_utils.cmti)
+
   (.ocamloptcomp.objs/byte/cfg_regalloc_validate.cmi
    as
    compiler-libs/cfg_regalloc_validate.cmi)
@@ -1229,11 +1232,23 @@
    as
    compiler-libs/cfg_regalloc_validate.cmo)
   (.ocamloptcomp.objs/byte/cfg_regalloc_validate.cmt
-   as
-   compiler-libs/cfg_regalloc_validate.cmt)
+    as
+    compiler-libs/cfg_regalloc_validate.cmt)
   (.ocamloptcomp.objs/byte/cfg_regalloc_validate.cmti
+    as
+    compiler-libs/cfg_regalloc_validate.cmti)
+  (.ocamloptcomp.objs/byte/cfg_stack_operands.cmi
    as
-   compiler-libs/cfg_regalloc_validate.cmti)
+   compiler-libs/cfg_stack_operands.cmi)
+  (.ocamloptcomp.objs/byte/cfg_stack_operands.cmo
+   as
+   compiler-libs/cfg_stack_operands.cmo)
+  (.ocamloptcomp.objs/byte/cfg_stack_operands.cmt
+   as
+   compiler-libs/cfg_stack_operands.cmt)
+  (.ocamloptcomp.objs/byte/cfg_stack_operands.cmti
+   as
+   compiler-libs/cfg_stack_operands.cmti)
   (.ocamloptcomp.objs/byte/cfg_to_linear_desc.cmi
    as
    compiler-libs/cfg_to_linear_desc.cmi)
@@ -1515,8 +1530,11 @@
    as
    compiler-libs/cfg_regalloc_utils.cmx)
   (.ocamloptcomp.objs/native/cfg_regalloc_validate.cmx
+    as
+    compiler-libs/cfg_regalloc_validate.cmx)
+  (.ocamloptcomp.objs/native/cfg_stack_operands.cmx
    as
-   compiler-libs/cfg_regalloc_validate.cmx)
+   compiler-libs/cfg_stack_operands.cmx)
   (.ocamloptcomp.objs/native/cfg_to_linear_desc.cmx
    as
    compiler-libs/cfg_to_linear_desc.cmx)


### PR DESCRIPTION
This pull requests adds support for stack operands
to the IRC allocator. It is morally the equivalent of
upstream's `Reload` pass, although basically the
other way around:

- `Reload` reintroduces registers where stack operands
  would violate the constraints of an instruction;
- this pull request's `Cfg_stack_operand` module
  opportunistically rewrites a register to its assigned
  stack slot before IRC's `rewrite` function has the
  opportunity to add spill/reload instructions.

~~The new code is enabled by setting a new environment
variable, namely `IRC_STACK_OPERANDS`, to `1`.~~

~~This is still a bit draft-ish:~~

- ~~more testing would be useful (works on the repository)~~;
- ~~the `arg` and `res` copy situation is not great (either always
  do the copying, but in a more central place, or do it only
  when necessary)~~;
- ~~the aforementioned variable should go (eventually)~~.