### PR TITLE
Fix the traversal order during Typing_env.cut

### DIFF
--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -976,12 +976,9 @@ let cut t ~cut_after =
           loop result levels
         else result
     in
-    let levels =
-      (* Owing to the check above it is certain that we want [t.current_level]
-         included in the result. *)
-      t.current_level :: t.prev_levels
-    in
-    loop TEL.empty levels
+    (* Owing to the check above it is certain that we want [t.current_level]
+       included in the result. *)
+    loop (One_level.level t.current_level) t.prev_levels
 
 let type_simple_in_term_exn t ?min_name_mode simple =
   (* If [simple] is a variable then it should not come from a missing .cmx file,

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -101,7 +101,9 @@ type t =
     get_imported_names : unit -> Name.Set.t;
     defined_symbols : Symbol.Set.t;
     code_age_relation : Code_age_relation.t;
-    prev_levels : One_level.t Scope.Map.t;
+    prev_levels : One_level.t list;
+    (* [prev_levels] is sorted with the greatest scope at the head of the
+       list *)
     current_level : One_level.t;
     next_binding_time : Binding_time.t;
     min_binding_time : Binding_time.t (* Earlier variables have mode In_types *)
@@ -117,7 +119,7 @@ type typing_env = t
 
 let is_empty t =
   One_level.is_empty t.current_level
-  && Scope.Map.is_empty t.prev_levels
+  && (match t.prev_levels with [] -> true | _ :: _ -> false)
   && Symbol.Set.is_empty t.defined_symbols
 
 let aliases t =
@@ -133,10 +135,10 @@ let [@ocamlformat "disable"] print ppf
     Format.pp_print_string ppf "Empty"
   else
     let levels =
-      Scope.Map.add (One_level.scope current_level) current_level prev_levels
+      current_level :: prev_levels
     in
     let levels =
-      Scope.Map.filter (fun _ level -> not (One_level.is_empty level))
+      List.filter (fun level -> not (One_level.is_empty level))
         levels
     in
     Format.fprintf ppf
@@ -148,7 +150,8 @@ let [@ocamlformat "disable"] print ppf
        )@]"
       Symbol.Set.print defined_symbols
       Code_age_relation.print code_age_relation
-      (Scope.Map.print (One_level.print ~min_binding_time))
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space
+         (One_level.print ~min_binding_time))
       levels
       Aliases.print (aliases t)
 
@@ -354,7 +357,7 @@ let create ~resolver ~get_imported_names =
   { resolver;
     binding_time_resolver = binding_time_resolver resolver;
     get_imported_names;
-    prev_levels = Scope.Map.empty;
+    prev_levels = [];
     (* Since [Scope.prev] may be used in the simplifier on this scope, in order
        to allow an efficient implementation of [cut] (see below), we always
        increment the scope by one here. *)
@@ -367,7 +370,7 @@ let create ~resolver ~get_imported_names =
 
 let increment_scope t =
   let current_scope = current_scope t in
-  let prev_levels = Scope.Map.add current_scope t.current_level t.prev_levels in
+  let prev_levels = t.current_level :: t.prev_levels in
   let current_level =
     One_level.create (Scope.next current_scope) TEL.empty
       ~just_after_level:(One_level.just_after_level t.current_level)
@@ -962,16 +965,23 @@ let cut t ~cut_after =
   if Scope.( >= ) cut_after current_scope
   then TEL.empty
   else
-    let _, _, levels = Scope.Map.split cut_after t.prev_levels in
+    let rec loop result = function
+      | [] -> result
+      | one_level :: levels ->
+        if Scope.( > ) (One_level.scope one_level) cut_after
+        then
+          let result =
+            TEL.concat ~earlier:(One_level.level one_level) ~later:result
+          in
+          loop result levels
+        else result
+    in
     let levels =
       (* Owing to the check above it is certain that we want [t.current_level]
          included in the result. *)
-      Scope.Map.add current_scope t.current_level levels
+      t.current_level :: t.prev_levels
     in
-    Scope.Map.fold
-      (fun _scope one_level result ->
-        TEL.concat result (One_level.level one_level))
-      levels TEL.empty
+    loop TEL.empty levels
 
 let type_simple_in_term_exn t ?min_name_mode simple =
   (* If [simple] is a variable then it should not come from a missing .cmx file,

--- a/middle_end/flambda2/types/env/typing_env_level.ml
+++ b/middle_end/flambda2/types/env/typing_env_level.ml
@@ -136,7 +136,7 @@ let add_or_replace_equation t name ty =
   then { t with equations = Name.Map.remove name t.equations }
   else { t with equations = Name.Map.add name ty t.equations }
 
-let concat (t1 : t) (t2 : t) =
+let concat ~earlier:(t1 : t) ~later:(t2 : t) =
   let defined_vars =
     Variable.Map.union
       (fun var _data1 _data2 ->
@@ -160,6 +160,7 @@ let concat (t1 : t) (t2 : t) =
       t1.binding_times t2.binding_times
   in
   let equations =
+    (* We rely on the fact that equations in later levels are more precise *)
     Name.Map.union (fun _ _ty1 ty2 -> Some ty2) t1.equations t2.equations
   in
   let symbol_projections =

--- a/middle_end/flambda2/types/env/typing_env_level.mli
+++ b/middle_end/flambda2/types/env/typing_env_level.mli
@@ -47,7 +47,7 @@ val add_definition : t -> Variable.t -> Flambda_kind.t -> Binding_time.t -> t
 
 val add_or_replace_equation : t -> Name.t -> Type_grammar.t -> t
 
-val concat : t -> t -> t
+val concat : earlier:t -> later:t -> t
 
 val ids_for_export : t -> Ids_for_export.t
 


### PR DESCRIPTION
The solution in this PR, that was suggested by @chambart, stores previous levels as a list instead of a map. This makes the iteration order reliable, and is actually more efficient since we never needed to lookup levels by their scope.

We noticed further optimisation opportunities, for example not storing the cached level in the previous levels, but decided to leave those to an eventual later PR.
