### PR TITLE
Properly erase subkinds in Eligible_for_cse

### DIFF
--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -444,8 +444,7 @@ module Eligible_for_cse : sig
 
   include Contains_names.S with type t := t
 
-  val create :
-    ?map_arg:(Simple.t -> Simple.t) -> primitive_application -> t option
+  val create : primitive_application -> t option
 
   val create_exn : primitive_application -> t
 


### PR DESCRIPTION
This wasn't happening because it was guarded by the `map_arg` parameter, which wasn't being passed.  We don't need the mapping functionality now so this has been removed.