### PR TITLE
IRC: logic error in the second call to `rewrite`

### DIFF
--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -585,7 +585,10 @@ let run : Cfg_with_layout.t -> Cfg_with_layout.t =
         log ~indent:0 "%a <- spilling_because_split_or_unused" Printmach.reg r);
   (match spilling_because_split_or_unused with
   | [] -> ()
-  | _ :: _ as spilling -> rewrite state cfg_with_layout spilling ~reset:false);
+  | _ :: _ as spilling ->
+    List.iter spilling ~f:(fun reg -> reg.Reg.irc_work_list <- Spilled);
+    rewrite state cfg_with_layout spilling ~reset:false;
+    List.iter spilling ~f:(fun reg -> reg.Reg.irc_work_list <- Unknown_list));
   let liveness = main ~round:1 state cfg_with_layout in
   (* note: slots need to be updated before prologue removal *)
   if irc_debug

--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -586,10 +586,9 @@ let run : Cfg_with_layout.t -> Cfg_with_layout.t =
   (match spilling_because_split_or_unused with
   | [] -> ()
   | _ :: _ as spilling ->
-
     List.iter spilling ~f:(fun reg -> State.add_spilled_nodes state reg);
-    (* note: rewrite will remove the `spilling` registers from the
-       "spilled" work list and set the field to unknown. *)
+    (* note: rewrite will remove the `spilling` registers from the "spilled"
+       work list and set the field to unknown. *)
     rewrite state cfg_with_layout spilling ~reset:false);
   let liveness = main ~round:1 state cfg_with_layout in
   (* note: slots need to be updated before prologue removal *)

--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -586,9 +586,11 @@ let run : Cfg_with_layout.t -> Cfg_with_layout.t =
   (match spilling_because_split_or_unused with
   | [] -> ()
   | _ :: _ as spilling ->
-    List.iter spilling ~f:(fun reg -> reg.Reg.irc_work_list <- Spilled);
-    rewrite state cfg_with_layout spilling ~reset:false;
-    List.iter spilling ~f:(fun reg -> reg.Reg.irc_work_list <- Unknown_list));
+
+    List.iter spilling ~f:(fun reg -> State.add_spilled_nodes state reg);
+    (* note: rewrite will remove the `spilling` registers from the
+       "spilled" work list and set the field to unknown. *)
+    rewrite state cfg_with_layout spilling ~reset:false);
   let liveness = main ~round:1 state cfg_with_layout in
   (* note: slots need to be updated before prologue removal *)
   if irc_debug


### PR DESCRIPTION
The `rewrite` function expects the registers it gets to
be spilled (technically to have their `irc_work_list`
field set to `Spilled`). Before this pull request, it is
not the case with the second call to `rewrite` (the
one from `run`). I have not been able to produce
a miscompilation, but I think there is the potential
for one, in particular if the register ends up in the
list because because it is in `res` but not in `arg`.
