### PR TITLE
IRC: work lists as arrays

### DIFF
--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -244,7 +244,7 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
     | true -> fatal "spill_work_list is empty"
     | false ->
       State.fold_spill_work_list state ~init:(Reg.dummy, Float.max_float)
-        ~f:(fun reg ((_curr_reg, curr_min_cost) as acc) ->
+        ~f:(fun ((_curr_reg, curr_min_cost) as acc) reg ->
           let reg_cost = weighted_cost reg in
           if reg_cost < curr_min_cost then reg, reg_cost else acc)
       |> fst)

--- a/backend/cfg/cfg_irc_state.ml
+++ b/backend/cfg/cfg_irc_state.ml
@@ -4,20 +4,24 @@ open! Cfg_regalloc_utils
 open! Cfg_irc_utils
 
 module RegWorkList = ArraySet.Make (struct
-    type t = Reg.t
-    let compare left right = Int.compare left.Reg.stamp right.Reg.stamp
-    let dummy = { Reg.dummy with stamp = -1; }
-  end)
+  type t = Reg.t
+
+  let compare left right = Int.compare left.Reg.stamp right.Reg.stamp
+
+  let dummy = { Reg.dummy with stamp = -1 }
+end)
 
 let reg_set_of_reg_work_list (rwl : RegWorkList.t) : Reg.Set.t =
   RegWorkList.fold rwl ~init:Reg.Set.empty ~f:(fun acc elem ->
-    Reg.Set.add elem acc)
+      Reg.Set.add elem acc)
 
 module InstructionWorkList = ArraySet.Make (struct
-    type t = Instruction.t
-    let compare = Instruction.compare
-    let dummy = {
-      Cfg.desc = Cfg.Prologue;
+  type t = Instruction.t
+
+  let compare = Instruction.compare
+
+  let dummy =
+    { Cfg.desc = Cfg.Prologue;
       arg = [||];
       res = [||];
       dbg = Debuginfo.none;
@@ -25,11 +29,12 @@ module InstructionWorkList = ArraySet.Make (struct
       live = Reg.Set.empty;
       stack_offset = -1;
       id = -1;
-      irc_work_list = Unknown_list;
+      irc_work_list = Unknown_list
     }
-  end)
+end)
 
-let instruction_set_of_instruction_work_list (iwl : InstructionWorkList.t) : Instruction.Set.t =
+let instruction_set_of_instruction_work_list (iwl : InstructionWorkList.t) :
+    Instruction.Set.t =
   InstructionWorkList.fold iwl ~init:Instruction.Set.empty ~f:(fun acc elem ->
       Instruction.Set.add elem acc)
 
@@ -247,7 +252,8 @@ let[@inline] remove_spill_work_list state reg =
 let[@inline] fold_spill_work_list state ~f ~init =
   RegWorkList.fold state.spill_work_list ~f ~init
 
-let[@inline] spill_work_list state = reg_set_of_reg_work_list state.spill_work_list
+let[@inline] spill_work_list state =
+  reg_set_of_reg_work_list state.spill_work_list
 
 let[@inline] is_empty_spilled_nodes state =
   RegWorkList.is_empty state.spilled_nodes
@@ -568,8 +574,12 @@ let[@inline] invariant state =
         ( "freeze_work_list",
           reg_set_of_reg_work_list state.freeze_work_list,
           Reg.Freeze );
-        "spill_work_list", reg_set_of_reg_work_list state.spill_work_list, Reg.Spill;
-        "spilled_nodes", reg_set_of_reg_work_list state.spilled_nodes, Reg.Spilled;
+        ( "spill_work_list",
+          reg_set_of_reg_work_list state.spill_work_list,
+          Reg.Spill );
+        ( "spilled_nodes",
+          reg_set_of_reg_work_list state.spilled_nodes,
+          Reg.Spilled );
         ( "coalesced_nodes",
           reg_set_of_reg_work_list state.coalesced_nodes,
           Reg.Coalesced );
@@ -577,11 +587,16 @@ let[@inline] invariant state =
         "select_stack", Reg.Set.of_list state.select_stack, Reg.Select_stack ];
     (* move sets are disjoint *)
     check_disjoint ~is_disjoint:Instruction.Set.disjoint
-      [ "coalesced_moves", instruction_set_of_instruction_work_list state.coalesced_moves;
-        "constrained_moves", instruction_set_of_instruction_work_list state.constrained_moves;
-        "frozen_moves", instruction_set_of_instruction_work_list state.frozen_moves;
-        "work_list_moves", instruction_set_of_instruction_work_list state.work_list_moves;
-        "active_moves", instruction_set_of_instruction_work_list state.active_moves ];
+      [ ( "coalesced_moves",
+          instruction_set_of_instruction_work_list state.coalesced_moves );
+        ( "constrained_moves",
+          instruction_set_of_instruction_work_list state.constrained_moves );
+        ( "frozen_moves",
+          instruction_set_of_instruction_work_list state.frozen_moves );
+        ( "work_list_moves",
+          instruction_set_of_instruction_work_list state.work_list_moves );
+        ( "active_moves",
+          instruction_set_of_instruction_work_list state.active_moves ) ];
     List.iter ~f:check_set_and_field_consistency_instr
       [ ( "coalesced_moves",
           instruction_set_of_instruction_work_list state.coalesced_moves,

--- a/backend/cfg/cfg_irc_state.ml
+++ b/backend/cfg/cfg_irc_state.ml
@@ -3,31 +3,50 @@
 open! Cfg_regalloc_utils
 open! Cfg_irc_utils
 
-module RegWorkList =
-  WorkList.Make
-    (struct
-      type t = Reg.t
+module RegWorkList = ArraySet.Make (struct
+    type t = Reg.t
+    let compare left right = Int.compare left.Reg.stamp right.Reg.stamp
+    let dummy = { Reg.dummy with stamp = -1; }
+  end)
 
-      let compare left right = Int.compare left.Reg.stamp right.Reg.stamp
-    end)
-    (Reg.Set)
+let reg_set_of_reg_work_list (rwl : RegWorkList.t) : Reg.Set.t =
+  RegWorkList.fold rwl ~init:Reg.Set.empty ~f:(fun acc elem ->
+    Reg.Set.add elem acc)
 
-module InstructionWorkList = WorkList.Make (Instruction) (Instruction.Set)
+module InstructionWorkList = ArraySet.Make (struct
+    type t = Instruction.t
+    let compare = Instruction.compare
+    let dummy = {
+      Cfg.desc = Cfg.Prologue;
+      arg = [||];
+      res = [||];
+      dbg = Debuginfo.none;
+      fdo = Fdo_info.none;
+      live = Reg.Set.empty;
+      stack_offset = -1;
+      id = -1;
+      irc_work_list = Unknown_list;
+    }
+  end)
+
+let instruction_set_of_instruction_work_list (iwl : InstructionWorkList.t) : Instruction.Set.t =
+  InstructionWorkList.fold iwl ~init:Instruction.Set.empty ~f:(fun acc elem ->
+      Instruction.Set.add elem acc)
 
 type t =
   { mutable initial : Reg.t list;
-    mutable simplify_work_list : RegWorkList.t;
-    mutable freeze_work_list : RegWorkList.t;
-    mutable spill_work_list : RegWorkList.t;
-    mutable spilled_nodes : RegWorkList.t;
-    mutable coalesced_nodes : RegWorkList.t;
+    simplify_work_list : RegWorkList.t;
+    freeze_work_list : RegWorkList.t;
+    spill_work_list : RegWorkList.t;
+    spilled_nodes : RegWorkList.t;
+    coalesced_nodes : RegWorkList.t;
     mutable colored_nodes : Reg.t list;
     mutable select_stack : Reg.t list;
-    mutable coalesced_moves : InstructionWorkList.t;
-    mutable constrained_moves : InstructionWorkList.t;
-    mutable frozen_moves : InstructionWorkList.t;
-    mutable work_list_moves : InstructionWorkList.t;
-    mutable active_moves : InstructionWorkList.t;
+    coalesced_moves : InstructionWorkList.t;
+    constrained_moves : InstructionWorkList.t;
+    frozen_moves : InstructionWorkList.t;
+    work_list_moves : InstructionWorkList.t;
+    active_moves : InstructionWorkList.t;
     adj_set : RegisterStamp.PairSet.t;
     move_list : Instruction.Set.t Reg.Tbl.t;
     stack_slots : int Reg.Tbl.t;
@@ -56,20 +75,20 @@ let[@inline] make ~initial ~next_instruction_id () =
       reg.Reg.interf <- [];
       reg.Reg.degree <- Degree.infinite);
   let num_registers = List.length initial in
-  let expected_max_size = num_registers in
-  let simplify_work_list = RegWorkList.make ~expected_max_size in
-  let freeze_work_list = RegWorkList.make ~expected_max_size in
-  let spill_work_list = RegWorkList.make ~expected_max_size in
-  let spilled_nodes = RegWorkList.make ~expected_max_size in
-  let coalesced_nodes = RegWorkList.make ~expected_max_size in
+  let original_capacity = num_registers in
+  let simplify_work_list = RegWorkList.make ~original_capacity in
+  let freeze_work_list = RegWorkList.make ~original_capacity in
+  let spill_work_list = RegWorkList.make ~original_capacity in
+  let spilled_nodes = RegWorkList.make ~original_capacity in
+  let coalesced_nodes = RegWorkList.make ~original_capacity in
   let colored_nodes = [] in
   let select_stack = [] in
-  let expected_max_size = pred next_instruction_id in
-  let coalesced_moves = InstructionWorkList.make ~expected_max_size in
-  let constrained_moves = InstructionWorkList.make ~expected_max_size in
-  let frozen_moves = InstructionWorkList.make ~expected_max_size in
-  let work_list_moves = InstructionWorkList.make ~expected_max_size in
-  let active_moves = InstructionWorkList.make ~expected_max_size in
+  let original_capacity = pred next_instruction_id in
+  let coalesced_moves = InstructionWorkList.make ~original_capacity in
+  let constrained_moves = InstructionWorkList.make ~original_capacity in
+  let frozen_moves = InstructionWorkList.make ~original_capacity in
+  let work_list_moves = InstructionWorkList.make ~original_capacity in
+  let active_moves = InstructionWorkList.make ~original_capacity in
   let adj_set = RegisterStamp.PairSet.make ~num_registers in
   let move_list = Reg.Tbl.create 128 in
   let stack_slots = Reg.Tbl.create 128 in
@@ -140,26 +159,26 @@ let[@inline] reset state ~new_temporaries =
        @ RegWorkList.to_list state.coalesced_nodes;
   List.iter state.initial ~f:(fun reg -> reg.Reg.irc_work_list <- Initial);
   unknown_reg_work_list state.simplify_work_list;
-  state.simplify_work_list <- RegWorkList.empty state.simplify_work_list;
+  RegWorkList.clear state.simplify_work_list;
   unknown_reg_work_list state.freeze_work_list;
-  state.freeze_work_list <- RegWorkList.empty state.freeze_work_list;
+  RegWorkList.clear state.freeze_work_list;
   unknown_reg_work_list state.spill_work_list;
-  state.spill_work_list <- RegWorkList.empty state.spill_work_list;
+  RegWorkList.clear state.spill_work_list;
   unknown_reg_work_list state.spilled_nodes;
-  state.spilled_nodes <- RegWorkList.empty state.spilled_nodes;
-  state.coalesced_nodes <- RegWorkList.empty state.coalesced_nodes;
+  RegWorkList.clear state.spilled_nodes;
+  RegWorkList.clear state.coalesced_nodes;
   state.colored_nodes <- [];
   assert (state.select_stack = []);
   unknown_instruction_work_list state.coalesced_moves;
-  state.coalesced_moves <- InstructionWorkList.empty state.coalesced_moves;
+  InstructionWorkList.clear state.coalesced_moves;
   unknown_instruction_work_list state.constrained_moves;
-  state.constrained_moves <- InstructionWorkList.empty state.constrained_moves;
+  InstructionWorkList.clear state.constrained_moves;
   unknown_instruction_work_list state.frozen_moves;
-  state.frozen_moves <- InstructionWorkList.empty state.frozen_moves;
+  InstructionWorkList.clear state.frozen_moves;
   unknown_instruction_work_list state.work_list_moves;
-  state.work_list_moves <- InstructionWorkList.empty state.work_list_moves;
+  InstructionWorkList.clear state.work_list_moves;
   unknown_instruction_work_list state.active_moves;
-  state.active_moves <- InstructionWorkList.empty state.active_moves;
+  InstructionWorkList.clear state.active_moves;
   RegisterStamp.PairSet.clear state.adj_set;
   Reg.Tbl.clear state.move_list;
   state.introduced_temporaries
@@ -182,14 +201,13 @@ let[@inline] is_empty_simplify_work_list state =
 
 let[@inline] add_simplify_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Simplify;
-  state.simplify_work_list <- RegWorkList.add state.simplify_work_list reg
+  RegWorkList.add state.simplify_work_list reg
 
 let[@inline] choose_and_remove_simplify_work_list state =
   match RegWorkList.choose_and_remove state.simplify_work_list with
   | None -> fatal "simplify_work_list is empty"
-  | Some (res, rwl) ->
+  | Some res ->
     res.Reg.irc_work_list <- Reg.Unknown_list;
-    state.simplify_work_list <- rwl;
     res
 
 let[@inline] is_empty_freeze_work_list state =
@@ -200,18 +218,17 @@ let[@inline] mem_freeze_work_list _state reg =
 
 let[@inline] add_freeze_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Freeze;
-  state.freeze_work_list <- RegWorkList.add state.freeze_work_list reg
+  RegWorkList.add state.freeze_work_list reg
 
 let[@inline] remove_freeze_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Unknown_list;
-  state.freeze_work_list <- RegWorkList.remove state.freeze_work_list reg
+  RegWorkList.remove state.freeze_work_list reg
 
 let[@inline] choose_and_remove_freeze_work_list state =
   match RegWorkList.choose_and_remove state.freeze_work_list with
   | None -> fatal "freeze_work_list is empty"
-  | Some (res, rwl) ->
+  | Some res ->
     res.Reg.irc_work_list <- Reg.Unknown_list;
-    state.freeze_work_list <- rwl;
     res
 
 let[@inline] is_empty_spill_work_list state =
@@ -221,34 +238,34 @@ let[@inline] mem_spill_work_list _state reg = reg.Reg.irc_work_list = Reg.Spill
 
 let[@inline] add_spill_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Spill;
-  state.spill_work_list <- RegWorkList.add state.spill_work_list reg
+  RegWorkList.add state.spill_work_list reg
 
 let[@inline] remove_spill_work_list state reg =
   reg.Reg.irc_work_list <- Reg.Unknown_list;
-  state.spill_work_list <- RegWorkList.remove state.spill_work_list reg
+  RegWorkList.remove state.spill_work_list reg
 
 let[@inline] fold_spill_work_list state ~f ~init =
   RegWorkList.fold state.spill_work_list ~f ~init
 
-let[@inline] spill_work_list state = RegWorkList.to_set state.spill_work_list
+let[@inline] spill_work_list state = reg_set_of_reg_work_list state.spill_work_list
 
 let[@inline] is_empty_spilled_nodes state =
   RegWorkList.is_empty state.spilled_nodes
 
 let[@inline] add_spilled_nodes state reg =
   reg.Reg.irc_work_list <- Reg.Spilled;
-  state.spilled_nodes <- RegWorkList.add state.spilled_nodes reg
+  RegWorkList.add state.spilled_nodes reg
 
 let[@inline] spilled_nodes state = RegWorkList.to_list state.spilled_nodes
 
 let[@inline] clear_spilled_nodes state =
   RegWorkList.iter state.spilled_nodes ~f:(fun reg ->
       reg.Reg.irc_work_list <- Reg.Unknown_list);
-  state.spilled_nodes <- RegWorkList.empty state.spilled_nodes
+  RegWorkList.clear state.spilled_nodes
 
 let[@inline] add_coalesced_nodes state reg =
   reg.Reg.irc_work_list <- Reg.Coalesced;
-  state.coalesced_nodes <- RegWorkList.add state.coalesced_nodes reg
+  RegWorkList.add state.coalesced_nodes reg
 
 let[@inline] iter_coalesced_nodes state ~f =
   RegWorkList.iter state.coalesced_nodes ~f
@@ -277,30 +294,28 @@ let[@inline] iter_and_clear_select_stack state ~f =
 
 let[@inline] add_coalesced_moves state instr =
   instr.Cfg.irc_work_list <- Coalesced;
-  state.coalesced_moves <- InstructionWorkList.add state.coalesced_moves instr
+  InstructionWorkList.add state.coalesced_moves instr
 
 let[@inline] add_constrained_moves state instr =
   instr.Cfg.irc_work_list <- Constrained;
-  state.constrained_moves
-    <- InstructionWorkList.add state.constrained_moves instr
+  InstructionWorkList.add state.constrained_moves instr
 
 let[@inline] add_frozen_moves state instr =
   instr.Cfg.irc_work_list <- Frozen;
-  state.frozen_moves <- InstructionWorkList.add state.frozen_moves instr
+  InstructionWorkList.add state.frozen_moves instr
 
 let[@inline] is_empty_work_list_moves state =
   InstructionWorkList.is_empty state.work_list_moves
 
 let[@inline] add_work_list_moves state instr =
   instr.Cfg.irc_work_list <- Work_list;
-  state.work_list_moves <- InstructionWorkList.add state.work_list_moves instr
+  InstructionWorkList.add state.work_list_moves instr
 
 let[@inline] choose_and_remove_work_list_moves state =
   match InstructionWorkList.choose_and_remove state.work_list_moves with
   | None -> fatal "work_list_moves is empty"
-  | Some (res, iwl) ->
+  | Some res ->
     res.Cfg.irc_work_list <- Unknown_list;
-    state.work_list_moves <- iwl;
     res
 
 let[@inline] mem_active_moves _state instr =
@@ -308,11 +323,11 @@ let[@inline] mem_active_moves _state instr =
 
 let[@inline] add_active_moves state instr =
   instr.Cfg.irc_work_list <- Active;
-  state.active_moves <- InstructionWorkList.add state.active_moves instr
+  InstructionWorkList.add state.active_moves instr
 
 let[@inline] remove_active_moves state instr =
   instr.Cfg.irc_work_list <- Unknown_list;
-  state.active_moves <- InstructionWorkList.remove state.active_moves instr
+  InstructionWorkList.remove state.active_moves instr
 
 let[@inline] mem_adj_set state reg1 reg2 =
   RegisterStamp.PairSet.mem state.adj_set
@@ -399,8 +414,8 @@ let[@inline] enable_moves_one state reg =
       match m.irc_work_list with
       | Active ->
         m.irc_work_list <- Work_list;
-        state.active_moves <- InstructionWorkList.remove state.active_moves m;
-        state.work_list_moves <- InstructionWorkList.add state.work_list_moves m
+        InstructionWorkList.remove state.active_moves m;
+        InstructionWorkList.add state.work_list_moves m
       | _ -> ())
 
 let[@inline] decr_degree state reg =
@@ -414,14 +429,14 @@ let[@inline] decr_degree state reg =
       enable_moves_one state reg;
       iter_adjacent state reg ~f:(fun r -> enable_moves_one state r);
       reg.Reg.irc_work_list <- Reg.Unknown_list;
-      state.spill_work_list <- RegWorkList.remove state.spill_work_list reg;
+      RegWorkList.remove state.spill_work_list reg;
       if is_move_related state reg
       then (
         reg.Reg.irc_work_list <- Reg.Freeze;
-        state.freeze_work_list <- RegWorkList.add state.freeze_work_list reg)
+        RegWorkList.add state.freeze_work_list reg)
       else (
         reg.Reg.irc_work_list <- Reg.Simplify;
-        state.simplify_work_list <- RegWorkList.add state.simplify_work_list reg)))
+        RegWorkList.add state.simplify_work_list reg)))
 
 let[@inline] find_move_list state reg =
   match Reg.Tbl.find_opt state.move_list reg with
@@ -537,59 +552,59 @@ let[@inline] invariant state =
     check_disjoint ~is_disjoint:Reg.Set.disjoint
       [ "precolored", Reg.set_of_array all_precolored_regs;
         "initial", Reg.Set.of_list state.initial;
-        "simplify_work_list", RegWorkList.to_set state.simplify_work_list;
-        "freeze_work_list", RegWorkList.to_set state.freeze_work_list;
-        "spill_work_list", RegWorkList.to_set state.spill_work_list;
-        "spilled_nodes", RegWorkList.to_set state.spilled_nodes;
-        "coalesced_nodes", RegWorkList.to_set state.coalesced_nodes;
+        "simplify_work_list", reg_set_of_reg_work_list state.simplify_work_list;
+        "freeze_work_list", reg_set_of_reg_work_list state.freeze_work_list;
+        "spill_work_list", reg_set_of_reg_work_list state.spill_work_list;
+        "spilled_nodes", reg_set_of_reg_work_list state.spilled_nodes;
+        "coalesced_nodes", reg_set_of_reg_work_list state.coalesced_nodes;
         "colored_nodes", Reg.Set.of_list state.colored_nodes;
         "select_stack", Reg.Set.of_list state.select_stack ];
     List.iter ~f:check_set_and_field_consistency_reg
       [ "precolored", Reg.set_of_array all_precolored_regs, Reg.Precolored;
         "initial", Reg.Set.of_list state.initial, Reg.Initial;
         ( "simplify_work_list",
-          RegWorkList.to_set state.simplify_work_list,
+          reg_set_of_reg_work_list state.simplify_work_list,
           Reg.Simplify );
         ( "freeze_work_list",
-          RegWorkList.to_set state.freeze_work_list,
+          reg_set_of_reg_work_list state.freeze_work_list,
           Reg.Freeze );
-        "spill_work_list", RegWorkList.to_set state.spill_work_list, Reg.Spill;
-        "spilled_nodes", RegWorkList.to_set state.spilled_nodes, Reg.Spilled;
+        "spill_work_list", reg_set_of_reg_work_list state.spill_work_list, Reg.Spill;
+        "spilled_nodes", reg_set_of_reg_work_list state.spilled_nodes, Reg.Spilled;
         ( "coalesced_nodes",
-          RegWorkList.to_set state.coalesced_nodes,
+          reg_set_of_reg_work_list state.coalesced_nodes,
           Reg.Coalesced );
         "colored_nodes", Reg.Set.of_list state.colored_nodes, Reg.Colored;
         "select_stack", Reg.Set.of_list state.select_stack, Reg.Select_stack ];
     (* move sets are disjoint *)
     check_disjoint ~is_disjoint:Instruction.Set.disjoint
-      [ "coalesced_moves", InstructionWorkList.to_set state.coalesced_moves;
-        "constrained_moves", InstructionWorkList.to_set state.constrained_moves;
-        "frozen_moves", InstructionWorkList.to_set state.frozen_moves;
-        "work_list_moves", InstructionWorkList.to_set state.work_list_moves;
-        "active_moves", InstructionWorkList.to_set state.active_moves ];
+      [ "coalesced_moves", instruction_set_of_instruction_work_list state.coalesced_moves;
+        "constrained_moves", instruction_set_of_instruction_work_list state.constrained_moves;
+        "frozen_moves", instruction_set_of_instruction_work_list state.frozen_moves;
+        "work_list_moves", instruction_set_of_instruction_work_list state.work_list_moves;
+        "active_moves", instruction_set_of_instruction_work_list state.active_moves ];
     List.iter ~f:check_set_and_field_consistency_instr
       [ ( "coalesced_moves",
-          InstructionWorkList.to_set state.coalesced_moves,
+          instruction_set_of_instruction_work_list state.coalesced_moves,
           Cfg.Coalesced );
         ( "constrained_moves",
-          InstructionWorkList.to_set state.constrained_moves,
+          instruction_set_of_instruction_work_list state.constrained_moves,
           Cfg.Constrained );
         ( "frozen_moves",
-          InstructionWorkList.to_set state.frozen_moves,
+          instruction_set_of_instruction_work_list state.frozen_moves,
           Cfg.Frozen );
         ( "work_list_moves",
-          InstructionWorkList.to_set state.work_list_moves,
+          instruction_set_of_instruction_work_list state.work_list_moves,
           Cfg.Work_list );
         ( "active_moves",
-          InstructionWorkList.to_set state.active_moves,
+          instruction_set_of_instruction_work_list state.active_moves,
           Cfg.Active ) ];
     (* degree is consistent with adjacency lists/sets *)
     let work_lists =
       Reg.Set.union
-        (RegWorkList.to_set state.simplify_work_list)
+        (reg_set_of_reg_work_list state.simplify_work_list)
         (Reg.Set.union
-           (RegWorkList.to_set state.freeze_work_list)
-           (RegWorkList.to_set state.spill_work_list))
+           (reg_set_of_reg_work_list state.freeze_work_list)
+           (reg_set_of_reg_work_list state.spill_work_list))
     in
     let work_lists_or_precolored =
       Reg.Set.union (Reg.set_of_array all_precolored_regs) work_lists

--- a/backend/cfg/cfg_irc_state.mli
+++ b/backend/cfg/cfg_irc_state.mli
@@ -43,7 +43,7 @@ val add_spill_work_list : t -> Reg.t -> unit
 
 val remove_spill_work_list : t -> Reg.t -> unit
 
-val fold_spill_work_list : t -> f:(Reg.t -> 'a -> 'a) -> init:'a -> 'a
+val fold_spill_work_list : t -> f:('a -> Reg.t -> 'a) -> init:'a -> 'a
 
 val spill_work_list : t -> Reg.Set.t
 

--- a/backend/cfg/cfg_irc_utils.ml
+++ b/backend/cfg/cfg_irc_utils.ml
@@ -242,103 +242,141 @@ module Spilling_heuristics = struct
             (available_heuristics ())))
 end
 
-(* CR xclerc for xclerc: consider dynamic sorted arrays *)
-module WorkList = struct
-  module type S = sig
+module ArraySet = struct
+
+    module type S = sig
     type e
-
     type t
-
-    module Set : Set.S with type elt = e
-
-    val make : expected_max_size:int -> t
-
-    val empty : t -> t
-
+    val make : original_capacity:int -> t
+    val clear : t -> unit
     val is_empty : t -> bool
-
-    val add : t -> e -> t
-
-    val remove : t -> e -> t
-
-    val choose_and_remove : t -> (e * t) option
-
+    val choose_and_remove : t -> e option
+    val add : t -> e -> unit
+    val remove : t -> e -> unit
     val iter : t -> f:(e -> unit) -> unit
-
-    val fold : t -> f:(e -> 'a -> 'a) -> init:'a -> 'a
-
+    val fold : t -> f:('a -> e -> 'a) -> init:'a -> 'a
     val to_list : t -> e list
-
-    val to_set : t -> Set.t
   end
 
-  module Make (E : Set.OrderedType) (ES : Set.S with type elt = E.t) :
-    S with type e = E.t and module Set = ES = struct
-    module Set = ES
+  module type OrderedTypeWithDummy = sig
+    include Set.OrderedType
+    val dummy : t
+  end
 
-    let cut_off = 16
+  (* CR-someday xclerc for xclerc: consider using unsafe versions of blit and fill. *)
 
-    type e = E.t
-
-    type t =
-      | List of e List.t
-      | Set of Set.t
-
-    let empty_list = List []
-
-    let empty_set = Set Set.empty
-
-    let make ~expected_max_size =
-      if expected_max_size < cut_off then empty_list else empty_set
-
-    let empty t = match t with List _ -> empty_list | Set _ -> empty_set
-
+  module Make (T : OrderedTypeWithDummy) : S with type e = T.t = struct
+    type e = T.t
+    type t = {
+      mutable array : e array;
+      mutable length : int;
+    }
+    let make ~original_capacity =
+      let array = Array.make (max 1 original_capacity) T.dummy in
+      let length = 0 in
+      { array; length; }
+    let clear t =
+      Array.fill t.array ~pos:0 ~len:t.length T.dummy;
+      t.length <- 0
     let is_empty t =
-      match t with
-      | List l -> ( match l with [] -> true | _ :: _ -> false)
-      | Set s -> Set.is_empty s
-
+      Int.equal t.length 0
+    let index array length e =
+      let low = ref 0 in
+      let high = ref length in
+      while !low < !high do
+        let mid = (!low + !high) / 2 in
+        if T.compare e (Array.unsafe_get array mid) > 0 then
+          low := succ mid
+        else
+          high := mid
+      done;
+      !low
+    let new_length curr = if curr < 512 then 2 * curr else curr + 128
     let add t e =
-      match t with
-      | List l ->
-        if List.exists l ~f:(fun x -> E.compare x e = 0)
-        then t
-        else List (e :: l)
-      | Set s ->
-        let s' = Set.add e s in
-        if s == s' then t else Set s'
-
+      let idx = index t.array t.length e in
+      if idx >= Array.length t.array || T.compare e (Array.unsafe_get t.array idx) <> 0 then begin
+        if t.length = Array.length t.array then begin
+          (* reallocation *)
+          let new_array = Array.make (new_length (Array.length t.array)) T.dummy in
+          let len_before = idx in
+          if len_before > 0 then begin
+            Array.blit
+              ~src:t.array
+              ~src_pos:0
+              ~dst:new_array
+              ~dst_pos:0
+              ~len:len_before
+          end;
+          let len_after = t.length - idx in
+          if len_after > 0 then begin
+            Array.blit
+              ~src:t.array
+              ~src_pos:idx
+              ~dst:new_array
+              ~dst_pos:(succ idx)
+              ~len:len_after
+          end;
+          Array.unsafe_set new_array idx e;
+          t.array <- new_array;
+          t.length <- succ t.length
+        end else begin
+          (* insertion *)
+          let len = t.length - idx in
+          if len > 0 then begin
+            Array.blit
+              ~src:t.array
+              ~src_pos:idx
+              ~dst:t.array
+              ~dst_pos:(succ idx)
+              ~len
+          end;
+          Array.unsafe_set t.array idx e;
+          t.length <- succ t.length
+        end
+      end
     let remove t e =
-      match t with
-      | List l ->
-        let rec filter e acc = function
-          | [] -> acc
-          | hd :: tl ->
-            if E.compare e hd = 0 then acc @ tl else filter e (hd :: acc) tl
-        in
-        List (filter e [] l)
-      | Set s ->
-        let s' = Set.remove e s in
-        if s == s' then t else Set s'
-
+      let idx = index t.array t.length e in
+      if idx < Array.length t.array && T.compare e (Array.unsafe_get t.array idx) = 0 then begin
+        let len = t.length - idx - 1 in
+        if len > 0 then begin
+          Array.blit
+            ~src:t.array
+            ~src_pos:(succ idx)
+            ~dst:t.array
+            ~dst_pos:idx
+            ~len
+        end;
+        t.length <- pred t.length;
+        Array.unsafe_set t.array t.length T.dummy
+      end
     let choose_and_remove t =
-      match t with
-      | List l -> ( match l with [] -> None | hd :: tl -> Some (hd, List tl))
-      | Set s -> (
-        match Set.choose_opt s with
-        | None -> None
-        | Some e -> Some (e, Set (Set.remove e s)))
-
+      if Int.equal t.length 0 then begin
+        None
+      end else begin
+        let idx = pred t.length in
+        t.length <- idx;
+        let res = Some (Array.unsafe_get t.array idx) in
+        Array.unsafe_set t.array idx T.dummy;
+        res
+      end
     let iter t ~f =
-      match t with List l -> List.iter l ~f | Set s -> Set.iter f s
-
+      for i = 0 to pred t.length do
+        f (Array.unsafe_get t.array i)
+      done
     let fold t ~f ~init =
-      match t with
-      | List l -> List.fold_left l ~f:(fun acc elem -> f elem acc) ~init
-      | Set s -> Set.fold f s init
-
-    let to_list t = match t with List l -> l | Set s -> Set.elements s
-
-    let to_set t = match t with List l -> Set.of_list l | Set s -> s
+      let res = ref init in
+      for i = 0 to pred t.length do
+        res := f !res (Array.unsafe_get t.array i)
+      done;
+      !res
+    let to_list t =
+      let rec loop arr idx acc =
+        if idx < 0 then
+          acc
+        else
+          loop arr (pred idx) (Array.unsafe_get arr idx :: acc)
+      in
+      loop t.array (pred t.length) []
   end
+
 end

--- a/backend/cfg/cfg_irc_utils.ml
+++ b/backend/cfg/cfg_irc_utils.ml
@@ -243,140 +243,146 @@ module Spilling_heuristics = struct
 end
 
 module ArraySet = struct
-
-    module type S = sig
+  module type S = sig
     type e
+
     type t
+
     val make : original_capacity:int -> t
+
     val clear : t -> unit
+
     val is_empty : t -> bool
+
     val choose_and_remove : t -> e option
+
     val add : t -> e -> unit
+
     val remove : t -> e -> unit
+
     val iter : t -> f:(e -> unit) -> unit
+
     val fold : t -> f:('a -> e -> 'a) -> init:'a -> 'a
+
     val to_list : t -> e list
   end
 
   module type OrderedTypeWithDummy = sig
     include Set.OrderedType
+
     val dummy : t
   end
 
-  (* CR-someday xclerc for xclerc: consider using unsafe versions of blit and fill. *)
+  (* CR-someday xclerc for xclerc: consider using unsafe versions of blit and
+     fill. *)
 
   module Make (T : OrderedTypeWithDummy) : S with type e = T.t = struct
     type e = T.t
-    type t = {
-      mutable array : e array;
-      mutable length : int;
-    }
+
+    type t =
+      { mutable array : e array;
+        mutable length : int
+      }
+
     let make ~original_capacity =
       let array = Array.make (max 1 original_capacity) T.dummy in
       let length = 0 in
-      { array; length; }
+      { array; length }
+
     let clear t =
       Array.fill t.array ~pos:0 ~len:t.length T.dummy;
       t.length <- 0
-    let is_empty t =
-      Int.equal t.length 0
+
+    let is_empty t = Int.equal t.length 0
+
     let index array length e =
       let low = ref 0 in
       let high = ref length in
       while !low < !high do
         let mid = (!low + !high) / 2 in
-        if T.compare e (Array.unsafe_get array mid) > 0 then
-          low := succ mid
-        else
-          high := mid
+        if T.compare e (Array.unsafe_get array mid) > 0
+        then low := succ mid
+        else high := mid
       done;
       !low
+
     let new_length curr = if curr < 512 then 2 * curr else curr + 128
+
     let add t e =
       let idx = index t.array t.length e in
-      if idx >= Array.length t.array || T.compare e (Array.unsafe_get t.array idx) <> 0 then begin
-        if t.length = Array.length t.array then begin
+      if idx >= Array.length t.array
+         || T.compare e (Array.unsafe_get t.array idx) <> 0
+      then (
+        if t.length = Array.length t.array
+        then (
           (* reallocation *)
-          let new_array = Array.make (new_length (Array.length t.array)) T.dummy in
+          let new_array =
+            Array.make (new_length (Array.length t.array)) T.dummy
+          in
           let len_before = idx in
-          if len_before > 0 then begin
-            Array.blit
-              ~src:t.array
-              ~src_pos:0
-              ~dst:new_array
-              ~dst_pos:0
-              ~len:len_before
-          end;
+          if len_before > 0
+          then
+            Array.blit ~src:t.array ~src_pos:0 ~dst:new_array ~dst_pos:0
+              ~len:len_before;
           let len_after = t.length - idx in
-          if len_after > 0 then begin
-            Array.blit
-              ~src:t.array
-              ~src_pos:idx
-              ~dst:new_array
-              ~dst_pos:(succ idx)
-              ~len:len_after
-          end;
+          if len_after > 0
+          then
+            Array.blit ~src:t.array ~src_pos:idx ~dst:new_array
+              ~dst_pos:(succ idx) ~len:len_after;
           Array.unsafe_set new_array idx e;
           t.array <- new_array;
-          t.length <- succ t.length
-        end else begin
+          t.length <- succ t.length)
+        else
           (* insertion *)
           let len = t.length - idx in
-          if len > 0 then begin
-            Array.blit
-              ~src:t.array
-              ~src_pos:idx
-              ~dst:t.array
-              ~dst_pos:(succ idx)
-              ~len
-          end;
+          if len > 0
+          then
+            Array.blit ~src:t.array ~src_pos:idx ~dst:t.array
+              ~dst_pos:(succ idx) ~len;
           Array.unsafe_set t.array idx e;
-          t.length <- succ t.length
-        end
-      end
+          t.length <- succ t.length)
+
     let remove t e =
       let idx = index t.array t.length e in
-      if idx < Array.length t.array && T.compare e (Array.unsafe_get t.array idx) = 0 then begin
+      if idx < Array.length t.array
+         && T.compare e (Array.unsafe_get t.array idx) = 0
+      then (
         let len = t.length - idx - 1 in
-        if len > 0 then begin
-          Array.blit
-            ~src:t.array
-            ~src_pos:(succ idx)
-            ~dst:t.array
-            ~dst_pos:idx
-            ~len
-        end;
+        if len > 0
+        then
+          Array.blit ~src:t.array ~src_pos:(succ idx) ~dst:t.array ~dst_pos:idx
+            ~len;
         t.length <- pred t.length;
-        Array.unsafe_set t.array t.length T.dummy
-      end
+        Array.unsafe_set t.array t.length T.dummy)
+
     let choose_and_remove t =
-      if Int.equal t.length 0 then begin
-        None
-      end else begin
+      if Int.equal t.length 0
+      then None
+      else
         let idx = pred t.length in
         t.length <- idx;
         let res = Some (Array.unsafe_get t.array idx) in
         Array.unsafe_set t.array idx T.dummy;
         res
-      end
+
     let iter t ~f =
       for i = 0 to pred t.length do
         f (Array.unsafe_get t.array i)
       done
+
     let fold t ~f ~init =
       let res = ref init in
       for i = 0 to pred t.length do
         res := f !res (Array.unsafe_get t.array i)
       done;
       !res
+
     let to_list t =
       let rec loop arr idx acc =
-        if idx < 0 then
-          acc
-        else
-          loop arr (pred idx) (Array.unsafe_get arr idx :: acc)
+        if idx < 0
+        then acc
+        else loop arr (pred idx) (Array.unsafe_get arr idx :: acc)
       in
       loop t.array (pred t.length) []
   end
-
 end

--- a/backend/cfg/cfg_irc_utils.mli
+++ b/backend/cfg/cfg_irc_utils.mli
@@ -92,36 +92,26 @@ module Spilling_heuristics : sig
   val env : t Lazy.t
 end
 
-(* Actually work "sets", uses "lists" to follow the article/book. *)
-module WorkList : sig
-  module type S = sig
+module ArraySet : sig
+    module type S = sig
     type e
-
     type t
-
-    module Set : Set.S with type elt = e
-
-    val make : expected_max_size:int -> t
-
-    val empty : t -> t
-
+    val make : original_capacity:int -> t
+    val clear : t -> unit
     val is_empty : t -> bool
-
-    val add : t -> e -> t
-
-    val remove : t -> e -> t
-
-    val choose_and_remove : t -> (e * t) option
-
+    val choose_and_remove : t -> e option
+    val add : t -> e -> unit
+    val remove : t -> e -> unit
     val iter : t -> f:(e -> unit) -> unit
-
-    val fold : t -> f:(e -> 'a -> 'a) -> init:'a -> 'a
-
+    val fold : t -> f:('a -> e -> 'a) -> init:'a -> 'a
     val to_list : t -> e list
-
-    val to_set : t -> Set.t
   end
 
-  module Make (E : Set.OrderedType) (ES : Set.S with type elt = E.t) :
-    S with type e = E.t and module Set = ES
+  module type OrderedTypeWithDummy = sig
+    include Set.OrderedType
+    val dummy : t (* note: does not 0-compare to any "interesting" value *)
+  end
+
+  module Make (T : OrderedTypeWithDummy) : S with type e = T.t
+
 end

--- a/backend/cfg/cfg_irc_utils.mli
+++ b/backend/cfg/cfg_irc_utils.mli
@@ -93,25 +93,35 @@ module Spilling_heuristics : sig
 end
 
 module ArraySet : sig
-    module type S = sig
+  module type S = sig
     type e
+
     type t
+
     val make : original_capacity:int -> t
+
     val clear : t -> unit
+
     val is_empty : t -> bool
+
     val choose_and_remove : t -> e option
+
     val add : t -> e -> unit
+
     val remove : t -> e -> unit
+
     val iter : t -> f:(e -> unit) -> unit
+
     val fold : t -> f:('a -> e -> 'a) -> init:'a -> 'a
+
     val to_list : t -> e list
   end
 
   module type OrderedTypeWithDummy = sig
     include Set.OrderedType
+
     val dummy : t (* note: does not 0-compare to any "interesting" value *)
   end
 
   module Make (T : OrderedTypeWithDummy) : S with type e = T.t
-
 end


### PR DESCRIPTION
This pull request changes the representation of
the work lists/sets used by IRC to arrays. The
overall gain is modest (around 2%), but the code
(of IRC, particularly the state) feels simpler.

note: ~~very~~ lightly tested

~~(includes #774)~~