### PR TITLE
Boxing operations factorisation in from_lambda

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -361,13 +361,13 @@ let close_c_call acc env ~loc ~let_bound_var
        prim_native_repr_res
      } :
       Primitive.description) ~(args : Simple.t list) exn_continuation dbg
-    ~current_region (k : Acc.t -> Named.t option -> Expr_with_acc.t) :
+    ~current_region (k : Acc.t -> Env.t -> Named.t option -> Expr_with_acc.t) :
     Expr_with_acc.t =
   (* We always replace the original let-binding with an Flambda expression, so
      we call [k] with [None], to get just the closure-converted body of that
      binding. *)
   let cost_metrics_of_body, free_names_of_body, acc, body =
-    Acc.measure_cost_metrics acc ~f:(fun acc -> k acc None)
+    Acc.measure_cost_metrics acc ~f:(fun acc -> k acc env None)
   in
   let box_return_value =
     match prim_native_repr_res with
@@ -562,7 +562,8 @@ let close_exn_continuation acc env (exn_continuation : IR.exn_continuation) =
 
 let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
     loc (exn_continuation : IR.exn_continuation option) ~current_region
-    (k : Acc.t -> Named.t option -> Expr_with_acc.t) : Expr_with_acc.t =
+    (k : Acc.t -> Env.t -> Named.t option -> Expr_with_acc.t) : Expr_with_acc.t
+    =
   let acc, exn_continuation =
     match exn_continuation with
     | None -> acc, None
@@ -593,14 +594,14 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
     in
     let acc, simple = use_of_symbol_as_simple acc symbol in
     let named = Named.create_simple simple in
-    k acc (Some named)
+    k acc env (Some named)
   | Pgetpredef id, [] ->
     let symbol =
       Flambda2_import.Symbol.for_predef_ident id |> Symbol.create_wrapped
     in
     let acc, simple = use_of_symbol_as_simple acc symbol in
     let named = Named.create_simple simple in
-    k acc (Some named)
+    k acc env (Some named)
   | Praise raise_kind, [_] ->
     let exn_continuation =
       match exn_continuation with
@@ -670,9 +671,9 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
         (* Inconsistent with outer match *)
         assert false
     in
-    k acc (Some (Named.create_simple (Simple.symbol sym)))
+    k acc env (Some (Named.create_simple (Simple.symbol sym)))
   | prim, args ->
-    Lambda_to_flambda_primitives.convert_and_bind acc exn_continuation
+    Lambda_to_flambda_primitives.convert_and_bind acc env exn_continuation
       ~big_endian:(Env.big_endian env)
       ~register_const_string:(fun acc -> register_const_string acc)
       prim ~args dbg ~current_region k
@@ -686,25 +687,26 @@ let close_trap_action_opt trap_action =
     trap_action
 
 let close_named acc env ~let_bound_var (named : IR.named)
-    (k : Acc.t -> Named.t option -> Expr_with_acc.t) : Expr_with_acc.t =
+    (k : Acc.t -> Env.t -> Named.t option -> Expr_with_acc.t) : Expr_with_acc.t
+    =
   match named with
   | Simple (Var id) ->
     assert (not (Ident.is_global_or_predef id));
     let acc, simple = find_simple acc env (Var id) in
     let named = Named.create_simple simple in
-    k acc (Some named)
+    k acc env (Some named)
   | Simple (Const cst) ->
     let acc, named, _name = close_const acc cst in
-    k acc (Some named)
+    k acc env (Some named)
   | Get_tag var ->
     let named = find_simple_from_id env var in
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
       Unary (Tag_immediate, Prim (Unary (Get_tag, Simple named)))
     in
-    Lambda_to_flambda_primitives_helpers.bind_rec acc None
+    Lambda_to_flambda_primitives_helpers.bind_rec acc env None
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
-      (fun acc named -> k acc (Some named))
+      (fun acc env named -> k acc env (Some named))
   | Begin_region { try_region_parent } ->
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
       match try_region_parent with
@@ -713,19 +715,19 @@ let close_named acc env ~let_bound_var (named : IR.named)
         let try_region_parent = find_simple_from_id env try_region_parent in
         Unary (Begin_try_region, Simple try_region_parent)
     in
-    Lambda_to_flambda_primitives_helpers.bind_rec acc None
+    Lambda_to_flambda_primitives_helpers.bind_rec acc env None
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
-      (fun acc named -> k acc (Some named))
+      (fun acc env named -> k acc env (Some named))
   | End_region id ->
     let named = find_simple_from_id env id in
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
       Unary (End_region, Simple named)
     in
-    Lambda_to_flambda_primitives_helpers.bind_rec acc None
+    Lambda_to_flambda_primitives_helpers.bind_rec acc env None
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
-      (fun acc named -> k acc (Some named))
+      (fun acc env named -> k acc env (Some named))
   | Prim { prim; args; loc; exn_continuation; region } ->
     close_primitive acc env ~let_bound_var named prim ~args loc exn_continuation
       ~current_region:(fst (Env.find_var env region))
@@ -734,7 +736,7 @@ let close_named acc env ~let_bound_var (named : IR.named)
 let close_let acc env id user_visible kind defining_expr
     ~(body : Acc.t -> Env.t -> Expr_with_acc.t) : Expr_with_acc.t =
   let body_env, var = Env.add_var_like env id user_visible kind in
-  let cont acc (defining_expr : Named.t option) =
+  let cont acc env (defining_expr : Named.t option) =
     match defining_expr with
     | Some (Simple simple) ->
       let body_env = Env.add_simple_to_substitute env id simple kind in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -148,6 +148,12 @@ module Env : sig
   val find_simple_to_substitute_exn :
     t -> Ident.t -> Simple.t * Flambda_kind.With_subkind.t
 
+  val add_boxing_pair : t -> unboxed:Name.t -> boxed:Name.t -> t
+
+  val find_boxed_of : t -> Name.t -> Name.t
+
+  val find_unboxed_of : t -> Name.t -> Name.t
+
   val add_value_approximation : t -> Name.t -> value_approximation -> t
 
   val add_block_approximation :

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1207,12 +1207,14 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
       Printlambda.primitive prim
 
 module Acc = Closure_conversion_aux.Acc
+module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
-let convert_and_bind acc ~big_endian exn_cont ~register_const_string
+let convert_and_bind acc env ~big_endian exn_cont ~register_const_string
     (prim : L.primitive) ~(args : Simple.t list) (dbg : Debuginfo.t)
-    ~current_region (cont : Acc.t -> Flambda.Named.t option -> Expr_with_acc.t)
-    : Expr_with_acc.t =
+    ~current_region
+    (cont : Acc.t -> Env.t -> Flambda.Named.t option -> Expr_with_acc.t) :
+    Expr_with_acc.t =
   let expr = convert_lprim ~big_endian prim args dbg ~current_region in
-  H.bind_rec acc exn_cont ~register_const_string expr dbg (fun acc named ->
-      cont acc (Some named))
+  H.bind_rec acc env exn_cont ~register_const_string expr dbg
+    (fun acc env named -> cont acc env (Some named))

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1210,11 +1210,13 @@ module Acc = Closure_conversion_aux.Acc
 module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
-let convert_and_bind acc env ~big_endian exn_cont ~register_const_string
-    (prim : L.primitive) ~(args : Simple.t list) (dbg : Debuginfo.t)
-    ~current_region
+let convert_and_bind acc env ~let_bound_var ~big_endian exn_cont
+    ~register_const_string (prim : L.primitive) ~(args : Simple.t list)
+    (dbg : Debuginfo.t) ~current_region
     (cont : Acc.t -> Env.t -> Flambda.Named.t option -> Expr_with_acc.t) :
     Expr_with_acc.t =
   let expr = convert_lprim ~big_endian prim args dbg ~current_region in
   H.bind_rec acc env exn_cont ~register_const_string expr dbg
-    (fun acc env named -> cont acc env (Some named))
+    (fun acc env named ->
+      let env, named = H.simplify_boxing env ~bound_var:let_bound_var named in
+      cont acc env (Some named))

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
@@ -21,6 +21,7 @@ module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 val convert_and_bind :
   Acc.t ->
   Env.t ->
+  let_bound_var:Variable.t ->
   big_endian:bool ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
@@ -15,10 +15,12 @@
 (**************************************************************************)
 
 module Acc = Closure_conversion_aux.Acc
+module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
 val convert_and_bind :
   Acc.t ->
+  Env.t ->
   big_endian:bool ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->
@@ -26,5 +28,5 @@ val convert_and_bind :
   args:Simple.t list ->
   Debuginfo.t ->
   current_region:Variable.t ->
-  (Acc.t -> Flambda.Named.t option -> Expr_with_acc.t) ->
+  (Acc.t -> Env.t -> Flambda.Named.t option -> Expr_with_acc.t) ->
   Expr_with_acc.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -159,7 +159,11 @@ let simplify_boxing env ~bound_var (named : Named.t) =
     let arg_name arg =
       Simple.pattern_match
         ~name:(fun n ~coercion:_ -> n)
-        ~const:(fun _ -> assert false)
+        ~const:(fun _ ->
+          (* CR keryan : This is not true with un/tag operations, which could
+             also benefit from this in the futur *)
+          Misc.fatal_error
+            "Constant found on un/boxing operation, should have been lifted.")
         arg
     in
     match prim with

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -153,64 +153,64 @@ let expression_for_failure acc exn_cont ~register_const_string primitive dbg
     raise_exn_for_failure acc ~dbg exn_cont (Simple.var exn_bucket)
       (Some extra_let_binding)
 
-let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
-    (dbg : Debuginfo.t) (cont : Acc.t -> Named.t -> Expr_with_acc.t) :
+let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
+    (dbg : Debuginfo.t) (cont : Acc.t -> Env.t -> Named.t -> Expr_with_acc.t) :
     Expr_with_acc.t =
   match prim with
   | Simple simple ->
     let named = Named.create_simple simple in
-    cont acc named
+    cont acc env named
   | Nullary prim ->
     let named = Named.create_prim (Nullary prim) dbg in
-    cont acc named
+    cont acc env named
   | Unary (prim, arg) ->
-    let cont acc (arg : Simple.t) =
+    let cont acc env (arg : Simple.t) =
       let named = Named.create_prim (Unary (prim, arg)) dbg in
-      cont acc named
+      cont acc env named
     in
-    bind_rec_primitive acc exn_cont ~register_const_string arg dbg cont
+    bind_rec_primitive acc env exn_cont ~register_const_string arg dbg cont
   | Binary (prim, arg1, arg2) ->
-    let cont acc (arg2 : Simple.t) =
-      let cont acc (arg1 : Simple.t) =
+    let cont acc env (arg2 : Simple.t) =
+      let cont acc env (arg1 : Simple.t) =
         let named = Named.create_prim (Binary (prim, arg1, arg2)) dbg in
-        cont acc named
+        cont acc env named
       in
-      bind_rec_primitive acc exn_cont ~register_const_string arg1 dbg cont
+      bind_rec_primitive acc env exn_cont ~register_const_string arg1 dbg cont
     in
-    bind_rec_primitive acc exn_cont ~register_const_string arg2 dbg cont
+    bind_rec_primitive acc env exn_cont ~register_const_string arg2 dbg cont
   | Ternary (prim, arg1, arg2, arg3) ->
-    let cont acc (arg3 : Simple.t) =
-      let cont acc (arg2 : Simple.t) =
-        let cont acc (arg1 : Simple.t) =
+    let cont acc env (arg3 : Simple.t) =
+      let cont acc env (arg2 : Simple.t) =
+        let cont acc env (arg1 : Simple.t) =
           let named =
             Named.create_prim (Ternary (prim, arg1, arg2, arg3)) dbg
           in
-          cont acc named
+          cont acc env named
         in
-        bind_rec_primitive acc exn_cont ~register_const_string arg1 dbg cont
+        bind_rec_primitive acc env exn_cont ~register_const_string arg1 dbg cont
       in
-      bind_rec_primitive acc exn_cont ~register_const_string arg2 dbg cont
+      bind_rec_primitive acc env exn_cont ~register_const_string arg2 dbg cont
     in
-    bind_rec_primitive acc exn_cont ~register_const_string arg3 dbg cont
+    bind_rec_primitive acc env exn_cont ~register_const_string arg3 dbg cont
   | Variadic (prim, args) ->
-    let cont acc args =
+    let cont acc env args =
       let named = Named.create_prim (Variadic (prim, args)) dbg in
-      cont acc named
+      cont acc env named
     in
-    let rec build_cont acc args_to_convert converted_args =
+    let rec build_cont acc env args_to_convert converted_args =
       match args_to_convert with
-      | [] -> cont acc converted_args
+      | [] -> cont acc env converted_args
       | arg :: args_to_convert ->
-        let cont acc arg =
-          build_cont acc args_to_convert (arg :: converted_args)
+        let cont acc env arg =
+          build_cont acc env args_to_convert (arg :: converted_args)
         in
-        bind_rec_primitive acc exn_cont ~register_const_string arg dbg cont
+        bind_rec_primitive acc env exn_cont ~register_const_string arg dbg cont
     in
-    build_cont acc (List.rev args) []
+    build_cont acc env (List.rev args) []
   | Checked { validity_conditions; primitive; failure; dbg } ->
     let primitive_cont = Continuation.create () in
     let primitive_handler_expr acc =
-      bind_rec acc exn_cont ~register_const_string primitive dbg cont
+      bind_rec acc env exn_cont ~register_const_string primitive dbg cont
     in
     let failure_cont = Continuation.create () in
     let failure_handler_expr acc =
@@ -226,8 +226,8 @@ let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
         (fun condition_passed_expr expr_primitive acc ->
           let condition_passed_cont = Continuation.create () in
           let body acc =
-            bind_rec_primitive acc exn_cont ~register_const_string
-              (Prim expr_primitive) dbg (fun acc prim_result ->
+            bind_rec_primitive acc env exn_cont ~register_const_string
+              (Prim expr_primitive) dbg (fun acc _env prim_result ->
                 let acc, condition_passed =
                   Apply_cont_with_acc.goto acc condition_passed_cont
                 in
@@ -266,7 +266,8 @@ let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
     let result_param =
       Bound_parameter.create result_var Flambda_kind.With_subkind.any_value
     in
-    bind_rec acc exn_cont ~register_const_string cond dbg @@ fun acc cond ->
+    bind_rec acc env exn_cont ~register_const_string cond dbg
+    @@ fun acc env cond ->
     let compute_cond_and_switch acc =
       let acc, ifso_cont = Apply_cont_with_acc.goto acc ifso_cont in
       let acc, ifnot_cont = Apply_cont_with_acc.goto acc ifnot_cont in
@@ -283,10 +284,11 @@ let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
         cond ~body:switch
     in
     let join_handler_expr acc =
-      cont acc (Named.create_simple (Simple.var result_var))
+      cont acc env (Named.create_simple (Simple.var result_var))
     in
     let ifso_handler_expr acc =
-      bind_rec acc exn_cont ~register_const_string ifso dbg @@ fun acc ifso ->
+      bind_rec acc env exn_cont ~register_const_string ifso dbg
+      @@ fun acc _env ifso ->
       let acc, apply_cont =
         Apply_cont_with_acc.create acc join_point_cont
           ~args:[Simple.var ifso_result] ~dbg
@@ -297,7 +299,8 @@ let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
         ifso ~body
     in
     let ifnot_handler_expr acc =
-      bind_rec acc exn_cont ~register_const_string ifnot dbg @@ fun acc ifnot ->
+      bind_rec acc env exn_cont ~register_const_string ifnot dbg
+      @@ fun acc _env ifnot ->
       let acc, apply_cont =
         Apply_cont_with_acc.create acc join_point_cont
           ~args:[Simple.var ifnot_result] ~dbg
@@ -321,16 +324,16 @@ let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
       ~handler_params:(Bound_parameters.create [result_param])
       ~handler:join_handler_expr ~body ~is_exn_handler:false
 
-and bind_rec_primitive acc exn_cont ~register_const_string
+and bind_rec_primitive acc env exn_cont ~register_const_string
     (prim : simple_or_prim) (dbg : Debuginfo.t)
-    (cont : Acc.t -> Simple.t -> Expr_with_acc.t) : Expr_with_acc.t =
+    (cont : Acc.t -> Env.t -> Simple.t -> Expr_with_acc.t) : Expr_with_acc.t =
   match prim with
-  | Simple s -> cont acc s
+  | Simple s -> cont acc env s
   | Prim p ->
-    let var = Variable.create "prim" in
-    let var' = VB.create var Name_mode.normal in
-    let cont acc (named : Named.t) =
-      let acc, body = cont acc (Simple.var var) in
+    let cont acc env (named : Named.t) =
+      let var = Variable.create "prim" in
+      let var' = VB.create var Name_mode.normal in
+      let acc, body = cont acc env (Simple.var var) in
       Let_with_acc.create acc (Bound_pattern.singleton var') named ~body
     in
-    bind_rec acc exn_cont ~register_const_string p dbg cont
+    bind_rec acc env exn_cont ~register_const_string p dbg cont

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -54,6 +54,9 @@ val print_list_of_simple_or_prim :
 
 open Closure_conversion_aux
 
+val simplify_boxing :
+  Env.t -> bound_var:Variable.t -> Flambda.Named.t -> Env.t * Flambda.Named.t
+
 val bind_rec :
   Acc.t ->
   Env.t ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -56,9 +56,10 @@ open Closure_conversion_aux
 
 val bind_rec :
   Acc.t ->
+  Env.t ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->
   expr_primitive ->
   Debuginfo.t ->
-  (Acc.t -> Flambda.Named.t -> Expr_with_acc.t) ->
+  (Acc.t -> Env.t -> Flambda.Named.t -> Expr_with_acc.t) ->
   Expr_with_acc.t


### PR DESCRIPTION
This is a first PR toward unboxing in classic mode.

It allows to reuse previously boxed/unboxed values instead of doubling down on the operation during primitive compilation, effectively providing a net reduction of code and allocations within continuation code in non-trivial cases.

Subsequent PRs are coming along to extend this between continuations.