### PR TITLE
Add unboxed version of continuation parameters in classic mode

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -872,8 +872,8 @@ let close_let_cont acc env ~name ~is_exn_handler ~params
     params, wrapper, coupled_kinds
   in
   let acc, handler_params, wrapper =
-    match recursive, Flambda_features.classic_mode () with
-    | Nonrecursive, true ->
+    if Flambda_features.classic_mode ()
+    then
       let handler_params, wrapper, coupled_kinds =
         naked_params_wrapper handler_params
       in
@@ -885,7 +885,7 @@ let close_let_cont acc env ~name ~is_exn_handler ~params
         else Acc.set_unboxed_continuation_params name coupled_kinds acc
       in
       acc, handler_params, wrapper
-    | Recursive, _ | _, false -> acc, handler_params, fun k acc env -> k acc env
+    else acc, handler_params, fun k acc env -> k acc env
   in
   let handler acc =
     let handler_env =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -992,10 +992,8 @@ let close_exact_or_unknown_apply acc env
 let close_apply_cont acc env ~dbg cont trap_action args : Expr_with_acc.t =
   let acc, args = find_simples acc env args in
   let trap_action = close_trap_action_opt trap_action in
-  let args_approx = List.map (Env.find_value_approximation env) args in
   let acc, apply_cont =
-    Apply_cont_with_acc.create acc ~env ?trap_action ~args_approx cont ~args
-      ~dbg
+    Apply_cont_with_acc.create acc ~env ?trap_action cont ~args ~dbg
   in
   Expr_with_acc.create_apply_cont acc apply_cont
 
@@ -1666,9 +1664,8 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
   let body acc env =
     let arg = find_simple_from_id env wrapper_id in
     let acc, apply_cont =
-      Apply_cont_with_acc.create acc ~env
-        ~args_approx:[Env.find_value_approximation env arg]
-        apply_continuation ~args:[arg] ~dbg:Debuginfo.none
+      Apply_cont_with_acc.create acc ~env apply_continuation ~args:[arg]
+        ~dbg:Debuginfo.none
     in
     Expr_with_acc.create_apply_cont acc apply_cont
   in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -793,9 +793,14 @@ module Apply_cont_with_acc = struct
     let acc = Acc.add_free_names (Apply_cont.free_names apply_cont) acc in
     acc, apply_cont
 
-  let create acc ?env ?trap_action ?args_approx cont ~args ~dbg =
+  let create acc ?env ?trap_action cont ~args ~dbg =
+    let args_approxs args =
+      match env with
+      | None -> None
+      | Some env -> Some (List.map (Env.find_value_approximation env) args)
+    in
     let apply_cont acc args =
-      create0 acc ?trap_action ?args_approx cont ~args ~dbg
+      create0 acc ?trap_action ?args_approx:(args_approxs args) cont ~args ~dbg
     in
     match Acc.continuation_signature cont acc, env with
     | All_values, _ ->
@@ -843,8 +848,7 @@ module Apply_cont_with_acc = struct
         in
         acc, Wrapped (apply_cont, wrapper)
 
-  let goto acc cont =
-    create acc cont ~args:[] ?args_approx:None ~dbg:Debuginfo.none
+  let goto acc cont = create acc cont ~args:[] ~dbg:Debuginfo.none
 end
 
 module Continuation_handler_with_acc = struct

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -125,10 +125,15 @@ end
 module Env = struct
   type value_approximation = Code_or_metadata.t Value_approximation.t
 
+  type boxing =
+    | Boxed_from of Name.t
+    | Unboxed_from of Name.t
+
   type t =
     { variables : Variable.t Ident.Map.t;
       globals : Symbol.t Numeric_types.Int.Map.t;
       simples_to_substitute : Simple.t Ident.Map.t;
+      box_mapping : boxing Name.Map.t;
       current_unit_id : Ident.t;
       current_depth : Variable.t option;
       symbol_for_global : Ident.t -> Symbol.t;
@@ -194,6 +199,7 @@ module Env = struct
     { variables = Ident.Map.empty;
       globals = Numeric_types.Int.Map.empty;
       simples_to_substitute = Ident.Map.empty;
+      box_mapping = Name.Map.empty;
       current_unit_id = Compilation_unit.get_persistent_ident compilation_unit;
       current_depth = None;
       value_approximations = Name.Map.empty;
@@ -211,6 +217,7 @@ module Env = struct
       { variables = _;
         globals;
         simples_to_substitute;
+        box_mapping = _;
         current_unit_id;
         symbol_for_global;
         current_depth;
@@ -228,6 +235,7 @@ module Env = struct
     { variables = Ident.Map.empty;
       globals;
       simples_to_substitute;
+      box_mapping = Name.Map.empty;
       current_unit_id;
       current_depth;
       value_approximations;
@@ -311,6 +319,23 @@ module Env = struct
 
   let find_simple_to_substitute_exn t id =
     Ident.Map.find id t.simples_to_substitute
+
+  let add_boxing_pair t ~unboxed ~boxed =
+    let box_mapping =
+      Name.Map.add boxed (Boxed_from unboxed) t.box_mapping
+      |> Name.Map.add unboxed (Unboxed_from boxed)
+    in
+    { t with box_mapping }
+
+  let find_boxed_of t name =
+    match Name.Map.find name t.box_mapping with
+    | Unboxed_from n -> n
+    | Boxed_from _ -> name
+
+  let find_unboxed_of t name =
+    match Name.Map.find name t.box_mapping with
+    | Boxed_from n -> n
+    | Unboxed_from _ -> name
 
   let add_value_approximation t name approx =
     if Value_approximation.is_unknown approx

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -341,18 +341,6 @@ end
 
 open! Flambda.Import
 
-module Expr_with_acc : sig
-  type t = Acc.t * Expr.t
-
-  val create_apply_cont : Acc.t -> Apply_cont.t -> t
-
-  val create_apply : Acc.t -> Apply.t -> t
-
-  val create_switch : Acc.t -> Switch.t -> t
-
-  val create_invalid : Acc.t -> Flambda.Invalid.t -> t
-end
-
 module Apply_cont_with_acc : sig
   val create :
     Acc.t ->
@@ -364,6 +352,18 @@ module Apply_cont_with_acc : sig
     Acc.t * Apply_cont.t
 
   val goto : Acc.t -> Continuation.t -> Acc.t * Apply_cont.t
+end
+
+module Expr_with_acc : sig
+  type t = Acc.t * Expr.t
+
+  val create_apply_cont : Acc.t -> Apply_cont.t -> t
+
+  val create_apply : Acc.t -> Apply.t -> t
+
+  val create_switch : Acc.t -> Switch.t -> t
+
+  val create_invalid : Acc.t -> Flambda.Invalid.t -> t
 end
 
 module Let_with_acc : sig

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -362,7 +362,6 @@ module Apply_cont_with_acc : sig
     Acc.t ->
     ?env:Env.t ->
     ?trap_action:Trap_action.t ->
-    ?args_approx:Env.value_approximation list ->
     Continuation.t ->
     args:Simple.t list ->
     dbg:Debuginfo.t ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -137,6 +137,12 @@ module Env : sig
 
   val find_simple_to_substitute_exn : t -> Ident.t -> Simple.t
 
+  val add_boxing_pair : t -> unboxed:Name.t -> boxed:Name.t -> t
+
+  val find_boxed_of : t -> Name.t -> Name.t
+
+  val find_unboxed_of : t -> Name.t -> Name.t
+
   val add_value_approximation : t -> Name.t -> value_approximation -> t
 
   val add_block_approximation :

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -183,6 +183,17 @@ end
 
 (** Used to pipe some data through closure conversion *)
 module Acc : sig
+  type boxing_coupled_kind =
+    | No_box of Flambda_kind.With_subkind.t
+    | Box_couple of
+        { boxed : Flambda_kind.With_subkind.t;
+          unboxed : Flambda_kind.With_subkind.t
+        }
+
+  type continuation_signature =
+    | All_values (* Default behaviour *)
+    | Naked_numbers of boxing_coupled_kind list
+
   type t
 
   val create :
@@ -228,7 +239,7 @@ module Acc : sig
   val mark_continuation_as_untrackable : Continuation.t -> t -> t
 
   val set_unboxed_continuation_params :
-    Continuation.t -> Flambda_kind.With_subkind.t list -> t -> t
+    Continuation.t -> boxing_coupled_kind list -> t -> t
 
   val continuation_known_arguments :
     cont:Continuation.t -> t -> Env.value_approximation list option

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1137,10 +1137,13 @@ module Acc = Closure_conversion_aux.Acc
 module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
-let convert_and_bind acc env ~big_endian exn_cont ~register_const_string
-    (prim : L.primitive) ~(args : Simple.t list) (dbg : Debuginfo.t)
+let convert_and_bind acc env ~let_bound_var ~big_endian exn_cont
+    ~register_const_string (prim : L.primitive) ~(args : Simple.t list)
+    (dbg : Debuginfo.t)
     (cont : Acc.t -> Env.t -> Flambda.Named.t option -> Expr_with_acc.t) :
     Expr_with_acc.t =
   let expr = convert_lprim ~big_endian prim args dbg in
   H.bind_rec acc env exn_cont ~register_const_string expr dbg
-    (fun acc env named -> cont acc env (Some named))
+    (fun acc env named ->
+      let env, named = H.simplify_boxing env ~bound_var:let_bound_var named in
+      cont acc env (Some named))

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1134,12 +1134,13 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
       Printlambda.primitive prim
 
 module Acc = Closure_conversion_aux.Acc
+module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
-let convert_and_bind acc ~big_endian exn_cont ~register_const_string
+let convert_and_bind acc env ~big_endian exn_cont ~register_const_string
     (prim : L.primitive) ~(args : Simple.t list) (dbg : Debuginfo.t)
-    (cont : Acc.t -> Flambda.Named.t option -> Expr_with_acc.t) :
+    (cont : Acc.t -> Env.t -> Flambda.Named.t option -> Expr_with_acc.t) :
     Expr_with_acc.t =
   let expr = convert_lprim ~big_endian prim args dbg in
-  H.bind_rec acc exn_cont ~register_const_string expr dbg (fun acc named ->
-      cont acc (Some named))
+  H.bind_rec acc env exn_cont ~register_const_string expr dbg
+    (fun acc env named -> cont acc env (Some named))

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
@@ -21,6 +21,7 @@ module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 val convert_and_bind :
   Acc.t ->
   Env.t ->
+  let_bound_var:Variable.t ->
   big_endian:bool ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
@@ -15,15 +15,17 @@
 (**************************************************************************)
 
 module Acc = Closure_conversion_aux.Acc
+module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
 val convert_and_bind :
   Acc.t ->
+  Env.t ->
   big_endian:bool ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->
   Lambda.primitive ->
   args:Simple.t list ->
   Debuginfo.t ->
-  (Acc.t -> Flambda.Named.t option -> Expr_with_acc.t) ->
+  (Acc.t -> Env.t -> Flambda.Named.t option -> Expr_with_acc.t) ->
   Expr_with_acc.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -64,7 +64,7 @@ let rec print_expr_primitive ppf expr_primitive =
 let print_simple_or_prim ppf (simple_or_prim : simple_or_prim) =
   match simple_or_prim with
   | Simple simple -> Simple.print ppf simple
-  | Prim _ -> Format.pp_print_string ppf "<prim>"
+  | Prim p -> print_expr_primitive ppf p
 
 let print_list_of_simple_or_prim ppf simple_or_prim_list =
   Format.fprintf ppf "@[(%a)@]"
@@ -152,6 +152,45 @@ let expression_for_failure acc exn_cont ~register_const_string primitive dbg
     raise_exn_for_failure acc ~dbg exn_cont (Simple.var exn_bucket)
       (Some extra_let_binding)
 
+let simplify_boxing env ~bound_var (named : Named.t) =
+  match named with
+  | Prim (Unary (prim, arg), _) -> (
+    let arg_name arg =
+      Simple.pattern_match
+        ~name:(fun n ~coercion:_ -> n)
+        ~const:(fun _ -> assert false)
+        arg
+    in
+    match prim with
+    | Unbox_number _ -> (
+      let arg = arg_name arg in
+      match Env.find_unboxed_of env arg with
+      | unboxed -> env, Named.create_simple (Simple.name unboxed)
+      | exception Not_found ->
+        let env =
+          Env.add_boxing_pair env ~boxed:arg ~unboxed:(Name.var bound_var)
+        in
+        env, named)
+    | Box_number _ -> (
+      let arg = arg_name arg in
+      match Env.find_boxed_of env arg with
+      | boxed -> env, Named.create_simple (Simple.name boxed)
+      | exception Not_found ->
+        let env =
+          Env.add_boxing_pair env ~unboxed:arg ~boxed:(Name.var bound_var)
+        in
+        env, named)
+    | Duplicate_block _ | Duplicate_array _ | Is_int _ | Get_tag | Array_length
+    | Bigarray_length _ | String_length _ | Int_as_pointer | Opaque_identity
+    | Int_arith _ | Float_arith _ | Num_conv _ | Boolean_not
+    | Reinterpret_int64_as_float | Untag_immediate | Tag_immediate
+    | Project_function_slot _ | Project_value_slot _ | Is_boxed_float
+    | Is_flat_float_array | End_region ->
+      env, named)
+  | Prim ((Nullary _ | Binary _ | Ternary _ | Variadic _), _)
+  | Simple _ | Set_of_closures _ | Static_consts _ | Rec_info _ ->
+    env, named
+
 let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
     (dbg : Debuginfo.t) (cont : Acc.t -> Env.t -> Named.t -> Expr_with_acc.t) :
     Expr_with_acc.t =
@@ -203,8 +242,7 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
         let cont acc env arg =
           build_cont acc env args_to_convert (arg :: converted_args)
         in
-        bind_rec_primitive acc env exn_cont ~register_const_string
-          arg dbg cont
+        bind_rec_primitive acc env exn_cont ~register_const_string arg dbg cont
     in
     build_cont acc env (List.rev args) []
   | Checked { validity_conditions; primitive; failure; dbg } ->
@@ -330,10 +368,14 @@ and bind_rec_primitive acc env exn_cont ~register_const_string
   match prim with
   | Simple s -> cont acc env s
   | Prim p ->
-    let cont acc env (named : Named.t) =
-      let var = Variable.create "prim" in
-      let var' = VB.create var Name_mode.normal in
-      let acc, body = cont acc env (Simple.var var) in
-      Let_with_acc.create acc (Bound_pattern.singleton var') named ~body
+    let cont acc env named =
+      let bound_var = Variable.create "prim" in
+      let var' = VB.create bound_var Name_mode.normal in
+      let env, named = simplify_boxing env ~bound_var named in
+      match named with
+      | Simple s -> cont acc env s
+      | Prim _ | Set_of_closures _ | Static_consts _ | Rec_info _ ->
+        let acc, body = cont acc env (Simple.var bound_var) in
+        Let_with_acc.create acc (Bound_pattern.singleton var') named ~body
     in
     bind_rec acc env exn_cont ~register_const_string p dbg cont

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -270,12 +270,9 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
                   Apply_cont_with_acc.goto acc condition_passed_cont
                 in
                 let acc, failure = Apply_cont_with_acc.goto acc failure_cont in
-                Expr_with_acc.create_switch acc
-                  (Switch.create ~condition_dbg:dbg ~scrutinee:prim_result
-                     ~arms:
-                       (Targetint_31_63.Map.of_list
-                          [ Targetint_31_63.bool_true, condition_passed;
-                            Targetint_31_63.bool_false, failure ])))
+                Expr_with_acc.create_if_then_else acc ~condition_dbg:dbg
+                  ~scrutinee:prim_result ~if_true:condition_passed
+                  ~if_false:failure)
           in
           Let_cont_with_acc.build_non_recursive acc condition_passed_cont
             ~handler_params:Bound_parameters.empty
@@ -310,12 +307,9 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
       let acc, ifso_cont = Apply_cont_with_acc.goto acc ifso_cont in
       let acc, ifnot_cont = Apply_cont_with_acc.goto acc ifnot_cont in
       let acc, switch =
-        Expr_with_acc.create_switch acc
-          (Switch.create ~condition_dbg:dbg ~scrutinee:(Simple.var cond_result)
-             ~arms:
-               (Targetint_31_63.Map.of_list
-                  [ Targetint_31_63.bool_true, ifso_cont;
-                    Targetint_31_63.bool_false, ifnot_cont ]))
+        Expr_with_acc.create_if_then_else acc ~condition_dbg:dbg
+          ~scrutinee:(Simple.var cond_result) ~if_true:ifso_cont
+          ~if_false:ifnot_cont
       in
       Let_with_acc.create acc
         (Bound_pattern.singleton cond_result_pat)
@@ -328,7 +322,7 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
       bind_rec acc env exn_cont ~register_const_string ifso dbg
       @@ fun acc _env ifso ->
       let acc, apply_cont =
-        Apply_cont_with_acc.create acc join_point_cont
+        Apply_cont_with_acc.create acc ~env join_point_cont
           ~args:[Simple.var ifso_result] ~dbg
       in
       let acc, body = Expr_with_acc.create_apply_cont acc apply_cont in
@@ -340,7 +334,7 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
       bind_rec acc env exn_cont ~register_const_string ifnot dbg
       @@ fun acc _env ifnot ->
       let acc, apply_cont =
-        Apply_cont_with_acc.create acc join_point_cont
+        Apply_cont_with_acc.create acc ~env join_point_cont
           ~args:[Simple.var ifnot_result] ~dbg
       in
       let acc, body = Expr_with_acc.create_apply_cont acc apply_cont in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -54,6 +54,9 @@ val print_list_of_simple_or_prim :
 
 open Closure_conversion_aux
 
+val simplify_boxing :
+  Env.t -> bound_var:Variable.t -> Flambda.Named.t -> Env.t * Flambda.Named.t
+
 val bind_rec :
   Acc.t ->
   Env.t ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -56,9 +56,10 @@ open Closure_conversion_aux
 
 val bind_rec :
   Acc.t ->
+  Env.t ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->
   expr_primitive ->
   Debuginfo.t ->
-  (Acc.t -> Flambda.Named.t -> Expr_with_acc.t) ->
+  (Acc.t -> Env.t -> Flambda.Named.t -> Expr_with_acc.t) ->
   Expr_with_acc.t


### PR DESCRIPTION
Building on #776, this exposes unboxed version of values to continuations.

This on its own is not always an improvement on the generated code and might generate useless parameters and operations, as it would be tricky to remove them without a second pass.
Two things are missing to be close to Closure's unboxing behaviour:
- Proper unboxing around C calls, which for now handles this its own way to respect the previous invariant. I believe this is the last thing we need to have classic mode pass the testsuite.
- A way to remove useless continuation parameters to avoid the noise in cmm generation. It is difficult to remove them in from_lambda, but possible to detect and pass the information to To_cmm, which, at first sight, should have less difficulties to ignore such parameters.