### PR TITLE
IRC: `Deadcode` pass on the CFG representation

### DIFF
--- a/backend/cfg/cfg_deadcode.ml
+++ b/backend/cfg/cfg_deadcode.ml
@@ -1,0 +1,35 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open! Cfg_regalloc_utils
+
+let live_before : type a. a Cfg.instruction -> liveness -> Reg.Set.t =
+ fun instr liveness ->
+  match Cfg_dataflow.Instr.Tbl.find_opt liveness instr.id with
+  | None -> fatal "no liveness information for instruction %d" instr.id
+  | Some { Cfg_liveness.before; across = _ } -> before
+
+let remove_deadcode (body : Instruction.t list) liveness used_after :
+    Instruction.t list =
+  List.fold_right body ~init:([], used_after)
+    ~f:(fun (instr : Instruction.t) (acc, used_after) ->
+      let before = live_before instr liveness in
+      let is_deadcode =
+        match instr.desc with
+        | Op _ as op ->
+          Cfg.is_pure_basic op
+          && Reg.disjoint_set_array used_after instr.res
+          && (not (Proc.regs_are_volatile instr.arg))
+          && not (Proc.regs_are_volatile instr.res)
+        | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> false
+      in
+      let acc = if is_deadcode then acc else instr :: acc in
+      acc, before)
+  |> fst
+
+let run cfg_with_layout =
+  let liveness = liveness_analysis cfg_with_layout in
+  Cfg.iter_blocks (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun _label block ->
+      block.body
+        <- remove_deadcode block.body liveness
+             (live_before block.terminator liveness));
+  cfg_with_layout

--- a/backend/cfg/cfg_deadcode.mli
+++ b/backend/cfg/cfg_deadcode.mli
@@ -1,0 +1,3 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val run : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/dune
+++ b/dune
@@ -232,6 +232,7 @@
   cfg_to_linear
   cfg_with_layout
   cfg_dataflow
+  cfg_deadcode
   cfg_liveness
   cfg_regalloc_utils
   cfg_irc
@@ -741,6 +742,7 @@
   (cfg_to_linear.mli as compiler-libs/cfg_to_linear.mli)
   (cfg_with_layout.mli as compiler-libs/cfg_with_layout.mli)
   (cfg_dataflow.mli as compiler-libs/cfg_dataflow.mli)
+  (cfg_deadcode.mli as compiler-libs/cfg_deadcode.mli)
   (cfg_liveness.mli as compiler-libs/cfg_liveness.mli)
   (cfg_regalloc_utils.mli as compiler-libs/cfg_regalloc_utils.mli)
   (cfg_irc.mli as compiler-libs/cfg_irc.mli)
@@ -1165,6 +1167,18 @@
   (.ocamloptcomp.objs/byte/cfg_dataflow.cmti
    as
    compiler-libs/cfg_dataflow.cmti)
+  (.ocamloptcomp.objs/byte/cfg_deadcode.cmi
+   as
+   compiler-libs/cfg_deadcode.cmi)
+  (.ocamloptcomp.objs/byte/cfg_deadcode.cmo
+   as
+   compiler-libs/cfg_deadcode.cmo)
+  (.ocamloptcomp.objs/byte/cfg_deadcode.cmt
+   as
+   compiler-libs/cfg_deadcode.cmt)
+  (.ocamloptcomp.objs/byte/cfg_deadcode.cmti
+   as
+   compiler-libs/cfg_deadcode.cmti)
   (.ocamloptcomp.objs/byte/cfg_liveness.cmi
    as
    compiler-libs/cfg_liveness.cmi)
@@ -1448,6 +1462,9 @@
   (.ocamloptcomp.objs/native/cfg_dataflow.cmx
    as
    compiler-libs/cfg_dataflow.cmx)
+  (.ocamloptcomp.objs/native/cfg_deadcode.cmx
+   as
+   compiler-libs/cfg_deadcode.cmx)
   (.ocamloptcomp.objs/native/cfg_liveness.cmx
    as
    compiler-libs/cfg_liveness.cmx)


### PR DESCRIPTION
This pull request reimplements upstream's `Deadcode`
pass over CFG values, in order to make the IRC pipeline
more independent (forking after upstream's `CSE` pass).

TODO:
- more testing (only tested on the compiler distribution so far)
- see whether/when we could avoid recomputing the liveness