### PR TITLE
CFG/IRC: liveness cache

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -367,6 +367,7 @@ let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
   ++ pass_dump_if ppf_dump dump_cse "After CSE"
   ++ Profile.record ~accumulate:true "checkmach" (Checkmach.fundecl ppf_dump)
   ++ Profile.record ~accumulate:true "regalloc" (fun (fd : Mach.fundecl) ->
+  ++ (fun (fd : Mach.fundecl) ->
     let force_linscan = should_use_linscan fd in
     match force_linscan, register_allocator with
     | false, IRC ->
@@ -376,6 +377,7 @@ let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
           fd
           ++ Profile.record ~accumulate:true "cfgize" cfgize
           ++ Profile.record ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
+          ++ Profile.record ~accumulate:true "cfg_irc" Cfg_irc.run
         in
         let cfg_description = Profile.record ~accumulate:true "cfg_create_description" Cfg_regalloc_validate.Description.create cfg in
         cfg

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -376,8 +376,8 @@ let compile_fundecl ?dwarf ~ppf_dump fd_cmm =
         let cfg =
           fd
           ++ Profile.record ~accumulate:true "cfgize" cfgize
+          ++ Cfg_with_liveness.make
           ++ Profile.record ~accumulate:true "cfg_deadcode" Cfg_deadcode.run
-          ++ Profile.record ~accumulate:true "cfg_irc" Cfg_irc.run
         in
         let cfg_description = Profile.record ~accumulate:true "cfg_create_description" Cfg_regalloc_validate.Description.create cfg in
         cfg

--- a/backend/cfg/cfg_deadcode.mli
+++ b/backend/cfg/cfg_deadcode.mli
@@ -1,5 +1,5 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-(* Dead code elimination: remove pure instructions whose results are not
-   used. *)
+(* Dead code elimination: remove pure instructions whose results are
+   not used. *)
 val run : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg/cfg_deadcode.mli
+++ b/backend/cfg/cfg_deadcode.mli
@@ -1,5 +1,5 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-(* Dead code elimination: remove pure instructions whose results are
-   not used. *)
+(* Dead code elimination: remove pure instructions whose results are not
+   used. *)
 val run : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg/cfg_deadcode.mli
+++ b/backend/cfg/cfg_deadcode.mli
@@ -2,4 +2,4 @@
 
 (* Dead code elimination: remove pure instructions whose results are not
    used. *)
-val run : Cfg_with_layout.t -> Cfg_with_layout.t
+val run : Cfg_with_liveness.t -> Cfg_with_liveness.t

--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -603,7 +603,8 @@ let run : Cfg_with_liveness.t -> Cfg_with_liveness.t =
     List.iter spilling ~f:(fun reg -> State.add_spilled_nodes state reg);
     (* note: rewrite will remove the `spilling` registers from the "spilled"
        work list and set the field to unknown. *)
-    rewrite state cfg_with_liveness spilling ~reset:false);
+    rewrite state cfg_with_liveness spilling ~reset:false;
+    Cfg_with_liveness.invalidate_liveness cfg_with_liveness);
   main ~round:1 state cfg_with_liveness;
   (* note: slots need to be updated before prologue removal *)
   if irc_debug

--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -603,7 +603,7 @@ let run : Cfg_with_liveness.t -> Cfg_with_liveness.t =
     List.iter spilling ~f:(fun reg -> State.add_spilled_nodes state reg);
     (* note: rewrite will remove the `spilling` registers from the "spilled"
        work list and set the field to unknown. *)
-    rewrite state cfg_with_lliveness spilling ~reset:false);
+    rewrite state cfg_with_liveness spilling ~reset:false);
   main ~round:1 state cfg_with_liveness;
   (* note: slots need to be updated before prologue removal *)
   if irc_debug

--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -5,9 +5,10 @@ open! Cfg_irc_utils
 open! Cfg_irc_split
 module State = Cfg_irc_state
 
-let build : State.t -> Cfg_with_layout.t -> liveness -> unit =
- fun state cfg_with_layout liveness ->
+let build : State.t -> Cfg_with_liveness.t -> unit =
+ fun state cfg_with_liveness ->
   if irc_debug then log ~indent:1 "build";
+  let liveness = Cfg_with_liveness.liveness cfg_with_liveness in
   let add_edges_live (id : Instruction.id) ~(def : Reg.t array)
       ~(move_src : Reg.t) ~(destroyed : Reg.t array) : unit =
     let live = Cfg_dataflow.Instr.Tbl.find liveness id in
@@ -25,6 +26,7 @@ let build : State.t -> Cfg_with_layout.t -> liveness -> unit =
           Array.iter destroyed ~f:(fun reg2 -> State.add_edge state reg1 reg2))
         live.across
   in
+  let cfg_with_layout = Cfg_with_liveness.cfg_with_layout cfg_with_liveness in
   Cfg_with_layout.iter_instructions cfg_with_layout
     ~instruction:(fun (instr : Instruction.t) ->
       if is_move_instruction instr
@@ -319,8 +321,9 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
       let alias = State.find_alias state n in
       n.Reg.irc_color <- alias.Reg.irc_color)
 
-let rewrite : State.t -> Cfg_with_layout.t -> Reg.t list -> reset:bool -> unit =
- fun state cfg_with_layout spilled_nodes ~reset ->
+let rewrite : State.t -> Cfg_with_liveness.t -> Reg.t list -> reset:bool -> unit
+    =
+ fun state cfg_with_liveness spilled_nodes ~reset ->
   if irc_debug then log ~indent:1 "rewrite";
   let spilled_map : Reg.t Reg.Tbl.t =
     List.fold_left spilled_nodes ~init:(Reg.Tbl.create 17)
@@ -443,7 +446,8 @@ let rewrite : State.t -> Cfg_with_layout.t -> Reg.t list -> reset:bool -> unit =
         let acc = rewrite_instruction ~direction:`store ~sharing acc hd in
         rewrite_body_and_terminator acc tl terminator)
   in
-  Cfg.iter_blocks (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun label block ->
+  Cfg.iter_blocks (Cfg_with_liveness.cfg cfg_with_liveness)
+    ~f:(fun label block ->
       (* CR xclerc for xclerc: we currently assume that a terminator does not
          "define" a register that may be spilled. Calls are reasonably fine
          since their result is in a precolored register. *)
@@ -454,15 +458,16 @@ let rewrite : State.t -> Cfg_with_layout.t -> Reg.t list -> reset:bool -> unit =
       in
       if body_needs_rewrite
       then (
+        let liveness = Cfg_with_liveness.liveness cfg_with_liveness in
         if irc_debug
         then (
           log ~indent:2 "body of #%d, before:" label;
-          log_body_and_terminator ~indent:3 block.body block.terminator);
+          log_body_and_terminator ~indent:3 block.body block.terminator liveness);
         block.body <- rewrite_body_and_terminator [] block.body block.terminator;
         if irc_debug
         then (
           log ~indent:2 "and after:";
-          log_body_and_terminator ~indent:3 block.body block.terminator;
+          log_body_and_terminator ~indent:3 block.body block.terminator liveness;
           log ~indent:2 "end")));
   if reset
   then State.reset state ~new_temporaries:!new_temporaries
@@ -475,12 +480,12 @@ let rewrite : State.t -> Cfg_with_layout.t -> Reg.t list -> reset:bool -> unit =
    seems to be fine with 4 *)
 let max_rounds = 50
 
-let rec main : round:int -> State.t -> Cfg_with_layout.t -> liveness =
- fun ~round state cfg_with_layout ->
+let rec main : round:int -> State.t -> Cfg_with_liveness.t -> unit =
+ fun ~round state cfg_with_liveness ->
   if round > max_rounds
   then
     fatal "register allocation was not succesful after %d rounds (%s)"
-      max_rounds (Cfg_with_layout.cfg cfg_with_layout).fun_name;
+      max_rounds (Cfg_with_liveness.cfg cfg_with_liveness).fun_name;
   if irc_debug then log ~indent:0 "main, round #%d" round;
   let work_lists_desc state (name, f) =
     Printf.sprintf "%s:%s" name (if f state then "{}" else "...")
@@ -496,8 +501,8 @@ let rec main : round:int -> State.t -> Cfg_with_layout.t -> liveness =
   let log_work_list_desc prefix =
     if irc_debug then log ~indent:1 "%s -- %s" prefix (work_lists_desc state)
   in
-  let liveness = liveness_analysis cfg_with_layout in
-  build state cfg_with_layout liveness;
+  build state cfg_with_liveness;
+  let cfg_with_layout = Cfg_with_liveness.cfg_with_layout cfg_with_liveness in
   if irc_debug
   then (
     let adj_set = State.adj_set state in
@@ -538,20 +543,20 @@ let rec main : round:int -> State.t -> Cfg_with_layout.t -> liveness =
   assign_colors state cfg_with_layout;
   State.invariant state;
   match State.spilled_nodes state with
-  | [] ->
-    if irc_debug then log ~indent:1 "(end of main)";
-    liveness
+  | [] -> if irc_debug then log ~indent:1 "(end of main)"
   | _ :: _ as spilled_nodes ->
     if irc_debug
     then
       List.iter spilled_nodes ~f:(fun reg ->
           log ~indent:1 "/!\\ register %a needs to be spilled" Printmach.reg reg);
-    rewrite state cfg_with_layout spilled_nodes ~reset:true;
+    rewrite state cfg_with_liveness spilled_nodes ~reset:true;
     State.invariant state;
-    main ~round:(succ round) state cfg_with_layout
+    Cfg_with_liveness.invalidate_liveness cfg_with_liveness;
+    main ~round:(succ round) state cfg_with_liveness
 
-let run : Cfg_with_layout.t -> Cfg_with_layout.t =
- fun cfg_with_layout ->
+let run : Cfg_with_liveness.t -> Cfg_with_liveness.t =
+ fun cfg_with_liveness ->
+  let cfg_with_layout = Cfg_with_liveness.cfg_with_layout cfg_with_liveness in
   on_fatal ~f:(fun () -> save_cfg "irc" cfg_with_layout);
   if irc_debug
   then log ~indent:0 "run (%S)" (Cfg_with_layout.cfg cfg_with_layout).fun_name;
@@ -581,8 +586,7 @@ let run : Cfg_with_layout.t -> Cfg_with_layout.t =
       match naive_split_points cfg_with_layout with
       | [] -> []
       | _ :: _ as split_points ->
-        let liveness = liveness_analysis cfg_with_layout in
-        naive_split_cfg state cfg_with_layout split_points liveness)
+        naive_split_cfg state cfg_with_liveness split_points)
   in
   let spilling_because_split_or_unused : Reg.t list =
     Reg.Set.fold
@@ -599,8 +603,8 @@ let run : Cfg_with_layout.t -> Cfg_with_layout.t =
     List.iter spilling ~f:(fun reg -> State.add_spilled_nodes state reg);
     (* note: rewrite will remove the `spilling` registers from the "spilled"
        work list and set the field to unknown. *)
-    rewrite state cfg_with_layout spilling ~reset:false);
-  let liveness = main ~round:1 state cfg_with_layout in
+    rewrite state cfg_with_lliveness spilling ~reset:false);
+  main ~round:1 state cfg_with_liveness;
   (* note: slots need to be updated before prologue removal *)
   if irc_debug
   then
@@ -611,10 +615,11 @@ let run : Cfg_with_layout.t -> Cfg_with_layout.t =
     ~num_stack_slots:(State.num_stack_slots state);
   remove_prologue_if_not_required cfg_with_layout;
   update_register_locations ();
-  update_live_fields cfg_with_layout liveness;
+  update_live_fields cfg_with_layout
+    (Cfg_with_liveness.liveness cfg_with_liveness);
   if irc_debug && irc_invariants
   then (
     log ~indent:0 "postcondition";
     postcondition cfg_with_layout ~allow_stack_operands:true);
   Array.iter all_precolored_regs ~f:(fun reg -> reg.Reg.degree <- 0);
-  cfg_with_layout
+  cfg_with_liveness

--- a/backend/cfg/cfg_irc.mli
+++ b/backend/cfg/cfg_irc.mli
@@ -1,3 +1,3 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-val run : Cfg_with_layout.t -> Cfg_with_layout.t
+val run : Cfg_with_liveness.t -> Cfg_with_liveness.t

--- a/backend/cfg/cfg_irc_split.ml
+++ b/backend/cfg/cfg_irc_split.ml
@@ -121,16 +121,13 @@ let rec naive_split_body :
         split_points new_regs
 
 let naive_split_cfg :
-    State.t ->
-    Cfg_with_layout.t ->
-    Instruction.id list ->
-    liveness ->
-    Reg.t list =
- fun state cfg_with_layout split_points liveness ->
+    State.t -> Cfg_with_liveness.t -> Instruction.id list -> Reg.t list =
+ fun state cfg_with_liveness split_points ->
   if irc_debug then log ~indent:1 "naive_split";
   let subst = Reg.Tbl.create 32 in
+  let liveness = Cfg_with_liveness.liveness cfg_with_liveness in
   let split_points, new_regs =
-    Cfg.fold_blocks (Cfg_with_layout.cfg cfg_with_layout)
+    Cfg.fold_blocks (Cfg_with_liveness.cfg cfg_with_liveness)
       ~init:(split_points, [])
       ~f:(fun label block ((split_points, new_regs) as acc) ->
         match split_points with
@@ -148,4 +145,5 @@ let naive_split_cfg :
           else acc)
   in
   assert (split_points = []);
+  Cfg_with_liveness.invalidate_liveness cfg_with_liveness;
   new_regs

--- a/backend/cfg/cfg_irc_split.mli
+++ b/backend/cfg/cfg_irc_split.mli
@@ -5,8 +5,4 @@ open Cfg_regalloc_utils
 val naive_split_points : Cfg_with_layout.t -> Instruction.id list
 
 val naive_split_cfg :
-  Cfg_irc_state.t ->
-  Cfg_with_layout.t ->
-  Instruction.id list ->
-  liveness ->
-  Reg.t list
+  Cfg_irc_state.t -> Cfg_with_liveness.t -> Instruction.id list -> Reg.t list

--- a/backend/cfg/cfg_irc_utils.mli
+++ b/backend/cfg/cfg_irc_utils.mli
@@ -14,6 +14,7 @@ val log_body_and_terminator :
   indent:int ->
   Cfg.basic Cfg.instruction list ->
   Cfg.terminator Cfg.instruction ->
+  liveness ->
   unit
 
 module Color : sig

--- a/backend/cfg/cfg_with_liveness.ml
+++ b/backend/cfg/cfg_with_liveness.ml
@@ -1,0 +1,32 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+open! Cfg_regalloc_utils
+
+type t =
+  { cfg_with_layout : Cfg_with_layout.t;
+    mutable liveness : liveness option
+  }
+
+let make cfg_with_layout = { cfg_with_layout; liveness = None }
+
+let cfg_with_layout t = t.cfg_with_layout
+
+let cfg t = Cfg_with_layout.cfg t.cfg_with_layout
+
+let[@inline] compute_liveness_if_necessary t =
+  match t.liveness with
+  | Some liveness -> liveness
+  | None ->
+    let liveness = liveness_analysis t.cfg_with_layout in
+    t.liveness <- Some liveness;
+    liveness
+
+let liveness t = compute_liveness_if_necessary t
+
+let liveness_find t id =
+  Cfg_dataflow.Instr.Tbl.find (compute_liveness_if_necessary t) id
+
+let liveness_find_opt t id =
+  Cfg_dataflow.Instr.Tbl.find_opt (compute_liveness_if_necessary t) id
+
+let invalidate_liveness t = t.liveness <- None

--- a/backend/cfg/cfg_with_liveness.mli
+++ b/backend/cfg/cfg_with_liveness.mli
@@ -1,0 +1,21 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+open! Cfg_regalloc_utils
+
+type t
+(* Holds a Cfg_with_layout.t value, and a "cache" of the liveness information
+   that can be invalidated. *)
+
+val make : Cfg_with_layout.t -> t
+
+val cfg_with_layout : t -> Cfg_with_layout.t
+
+val cfg : t -> Cfg.t
+
+val liveness : t -> liveness
+
+val liveness_find : t -> int -> Cfg_liveness.Liveness.domain
+
+val liveness_find_opt : t -> int -> Cfg_liveness.Liveness.domain option
+
+val invalidate_liveness : t -> unit

--- a/dune
+++ b/dune
@@ -240,6 +240,7 @@
   cfg_intf
   cfg_to_linear
   cfg_with_layout
+  cfg_with_liveness
   cfg_dataflow
   cfg_deadcode
   cfg_liveness
@@ -754,6 +755,7 @@
   (cfg.mli as compiler-libs/cfg.mli)
   (cfg_to_linear.mli as compiler-libs/cfg_to_linear.mli)
   (cfg_with_layout.mli as compiler-libs/cfg_with_layout.mli)
+  (cfg_with_liveness.mli as compiler-libs/cfg_with_liveness.mli)
   (cfg_dataflow.mli as compiler-libs/cfg_dataflow.mli)
   (cfg_deadcode.mli as compiler-libs/cfg_deadcode.mli)
   (cfg_liveness.mli as compiler-libs/cfg_liveness.mli)
@@ -1176,6 +1178,18 @@
   (.ocamloptcomp.objs/byte/cfg_with_layout.cmti
    as
    compiler-libs/cfg_with_layout.cmti)
+  (.ocamloptcomp.objs/byte/cfg_with_liveness.cmi
+   as
+   compiler-libs/cfg_with_liveness.cmi)
+  (.ocamloptcomp.objs/byte/cfg_with_liveness.cmo
+   as
+   compiler-libs/cfg_with_liveness.cmo)
+  (.ocamloptcomp.objs/byte/cfg_with_liveness.cmt
+   as
+   compiler-libs/cfg_with_liveness.cmt)
+  (.ocamloptcomp.objs/byte/cfg_with_liveness.cmti
+   as
+   compiler-libs/cfg_with_liveness.cmti)
   (.ocamloptcomp.objs/byte/cfg_dataflow.cmi
    as
    compiler-libs/cfg_dataflow.cmi)
@@ -1517,6 +1531,9 @@
   (.ocamloptcomp.objs/native/cfg_with_layout.cmx
    as
    compiler-libs/cfg_with_layout.cmx)
+  (.ocamloptcomp.objs/native/cfg_with_liveness.cmx
+   as
+   compiler-libs/cfg_with_liveness.cmx)
   (.ocamloptcomp.objs/native/cfg_dataflow.cmx
    as
    compiler-libs/cfg_dataflow.cmx)


### PR DESCRIPTION
This PR introduces a new module, namely `Cfg_with_liveness`,
which is basically a couple of a `Cfg_with_layout.t` and its
liveness information. The liveness information is seen as a "cache"
that can be invalidated. The problem it is trying to address can
be seen in the IRC code (and #779): if we want to avoid recomputing
the liveness needlessly, we need to to be a bit clever and to pass
it from a function/pass to the next. With the "cache" approach, the
liveness information is computed when needed, the code must
_simply_ invalidate the cache when appropriate.

notes: lightly tested ~~on top of #779~~
