### PR TITLE
CFG: Simplify liveness computation

### DIFF
--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -151,7 +151,7 @@ module S = struct
         (** This instruction loads the return address from a predefined hidden
             address (e.g. bottom of the current frame) and stores it in a
             special hidden register. It can use standard registers for that
-            purpose. They are definied in [Proc.destroyed_at_reloadretaddr]. *)
+            purpose. They are defined in [Proc.destroyed_at_reloadretaddr]. *)
     | Pushtrap of { lbl_handler : Label.t }
     | Poptrap
     | Prologue

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -148,6 +148,10 @@ module S = struct
     | Op of operation
     | Call of call_operation
     | Reloadretaddr
+        (** This instruction loads the return address from a predefined hidden
+            address (e.g. bottom of the current frame) and stores it in a
+            special hidden register. It can use standard registers for that
+            purpose. They are definied in [Proc.destroyed_at_reloadretaddr]. *)
     | Pushtrap of { lbl_handler : Label.t }
     | Poptrap
     | Prologue

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -97,8 +97,8 @@ module Transfer :
     | Tailcall (Self _) ->
       (* CR-someday azewierzejew: If the stamps for the tail call DomainState
          argument and parameter were the same and Tailcall (Self _) had
-         [instr.arg = instr.reg] (either by removing the args or adding results
-         because currently there is nonempty array in args but empty in res)
+         [instr.arg = instr.res] (either by removing the args or adding results
+         because currently there is a nonempty array in args but empty in res)
          then it would behave exactly the same as every other instruction. *)
       (* We have to handle this as a special case because the registers for a
          given DomainState argument and parameter pair have different stamps. *)

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -51,69 +51,67 @@ module Transfer :
 
   type nonrec error = error
 
+  let[@inline always] instruction { before; across = _ } ~can_raise ~exn
+      (instr : _ Cfg.instruction) =
+    let across = Reg.diff_set_array before instr.res in
+    let across =
+      if can_raise then Reg.Set.union across exn.before else across
+    in
+    let before = Reg.add_set_array across instr.arg in
+    { before; across }
+
   let basic :
       domain ->
       exn:domain ->
       Cfg.basic Cfg.instruction ->
       (domain, error) result =
-   fun { before; across = _ } ~exn instr ->
+   fun ({ before; across = _ } as domain) ~exn instr ->
     Result.ok
     @@
     match instr.desc with
-    | Op _ | Call _ ->
+    | Op _ | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
       if Cfg.is_pure_basic instr.desc
          && Reg.disjoint_set_array before instr.res
          && (not (Proc.regs_are_volatile instr.arg))
          && not (Proc.regs_are_volatile instr.res)
-      then { before; across = before }
+      then
+        (* If the operation is without side-effects and the result is unused
+           then don't mark the arguments as used because this instruction could
+           be removed. *)
+        { before; across = before }
       else
-        let across = Reg.diff_set_array before instr.res in
-        let across =
-          if Cfg.can_raise_basic instr.desc && instr.stack_offset > 0
-          then Reg.Set.union across exn.before
-          else across
-        in
-        let before = Reg.add_set_array across instr.arg in
-        { before; across }
-    | Reloadretaddr ->
-      { before = Reg.diff_set_array before Proc.destroyed_at_reloadretaddr;
-        across = Reg.Set.empty
-      }
-    | Pushtrap _ -> { before; across = before }
-    | Poptrap -> { before; across = before }
-    | Prologue -> { before; across = before }
+        instruction
+          ~can_raise:(Cfg.can_raise_basic instr.desc)
+          ~exn domain instr
 
   let terminator :
       domain ->
       exn:domain ->
       Cfg.terminator Cfg.instruction ->
       (domain, error) result =
-   fun { before; across = _ } ~exn instr ->
+   fun domain ~exn instr ->
     Result.ok
     @@
     match instr.desc with
     | Never -> assert false
-    | Always _ ->
-      { before = Reg.add_set_array before instr.arg; across = before }
-    | Parity_test _ ->
-      { before = Reg.add_set_array before instr.arg; across = before }
-    | Truth_test _ ->
-      { before = Reg.add_set_array before instr.arg; across = before }
-    | Float_test _ ->
-      { before = Reg.add_set_array before instr.arg; across = before }
-    | Int_test _ ->
-      { before = Reg.add_set_array before instr.arg; across = before }
-    | Switch _ ->
-      { before = Reg.add_set_array before instr.arg; across = before }
-    | Return -> { before = Reg.set_of_array instr.arg; across = Reg.Set.empty }
     | Tailcall (Self _) ->
-      { before = Reg.set_of_array instr.arg; across = Reg.Set.empty }
-    | Raise _ ->
-      { before = Reg.add_set_array exn.before instr.arg; across = exn.before }
-    | Tailcall (Func _) ->
-      { before = Reg.set_of_array instr.arg; across = Reg.Set.empty }
+      (* CR-someday azewierzejew: If the stamps for the tail call DomainState
+         argument and parameter were the same and Tailcall (Self _) had
+         [instr.arg = instr.reg] (either by removing the args or adding results
+         because currently there is nonempty array in args but empty in res)
+         then it would behave exactly the same as every other instruction. *)
+      (* We have to handle this as a special case because the registers for a
+         given DomainState argument and parameter pair have different stamps. *)
+      instruction
+        ~can_raise:(Cfg.can_raise_terminator instr.desc)
+        ~exn Domain.bot instr
+    | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+    | Switch _ | Return | Raise _
+    | Tailcall (Func _)
     | Call_no_return _ ->
-      { before = Reg.add_set_array exn.before instr.arg; across = exn.before }
+      instruction
+        ~can_raise:(Cfg.can_raise_terminator instr.desc)
+        ~exn domain instr
 
   let exception_ : domain -> (domain, error) result =
    fun { before; across = _ } ->


### PR DESCRIPTION
All the different cases and conditions in the transfer functions that encoded what already is true.
The `Reloadretaddr`, `Pushtrap`, `Poptrap` and `Prologue` work correctly with the generic case because of the definition of `can_raise`.
One difference is that previously `across` for `Reloadretaddr` was always empty despite passing through `before` of the previous function which seems actually like a mistake.

The same goes for the terminators. `Always`, all the tests and `Switch` work correctly with generic case because `can_raise` is `false`.
`Tailcall (Func _)` and `Return` simply assume the incoming set is `Set.empty` which is actually because there are no successor (and no trap handling block).
`Raise` and `Call_no_return` simply assume there is no successor and that `can_raise = 1`.

One special example is `Tailcall (Self _)`. That is because it's actually an `Always` but this also renames all the `instr.arg` into `fun_args` while having the `instr.res` empty. And because `Reg.t` for stack locations can have different stamps for the same location we cannot assume that `before` is the same as `instr.arg` (because it isn't when stack locations are present).

Changed definition of `is_pure_basic` for `Prologue`, `Poptrap` and `Pushtrap` to `false` because they modify the stack pointer which isn't pure.

Changed `can_raise_basic` for `Probe_is_enabled` to `false` because that's how it's defined in `backend/mach.ml` and `ocaml/asmcomp/mach.ml` and having instruction that is pure but also can raise seems like a mistake.