### PR TITLE
Prevent dynamic loading of the same .cmxs twice in private mode, etc.

### DIFF
--- a/ocaml/otherlibs/dynlink/dynlink.mli
+++ b/ocaml/otherlibs/dynlink/dynlink.mli
@@ -139,6 +139,13 @@ type error = private
   | Inconsistent_implementation of string
   | Module_already_loaded of string
   | Private_library_cannot_implement_interface of string
+  | Library_file_already_loaded_privately of { filename : string; }
+    (** In native code, it is forbidden to dynamically load the same .cmxs
+        file more than once in private mode. *)
+
+(* CR-someday mshinwell: Consider implementing the check required for
+   [Library_file_already_loaded_privately] in bytecode mode.  It might be
+   worth using [RTLD_NOLOAD] to help with this. *)
 
 exception Error of error
 (** Errors in dynamic linking are reported by raising the [Error]

--- a/ocaml/otherlibs/dynlink/dynlink_common.ml
+++ b/ocaml/otherlibs/dynlink/dynlink_common.ml
@@ -331,10 +331,10 @@ module Make (P : Dynlink_platform_intf.S) = struct
     | handle, units ->
       try
         global_state := check filename units !global_state ~priv;
-        P.run_shared_startup handle;
+        P.run_shared_startup handle ~filename ~priv;
         List.iter
           (fun unit_header ->
-             P.run handle ~unit_header ~priv;
+             P.run handle ~filename ~unit_header ~priv;
              if not priv then begin
                global_state := set_loaded filename unit_header !global_state
              end)

--- a/ocaml/otherlibs/dynlink/dynlink_platform_intf.ml
+++ b/ocaml/otherlibs/dynlink/dynlink_platform_intf.ml
@@ -60,8 +60,14 @@ module type S = sig
     -> priv:bool
     -> handle * (Unit_header.t list)
 
-  val run_shared_startup : handle -> unit
-  val run : handle -> unit_header:Unit_header.t -> priv:bool -> unit
+  val run_shared_startup : handle -> filename:string -> priv:bool -> unit
+
+  val run
+     : handle
+    -> filename:string
+    -> unit_header:Unit_header.t
+    -> priv:bool
+    -> unit
 
   val unsafe_get_global_value : bytecode_or_asm_symbol:string -> Obj.t option
 

--- a/ocaml/otherlibs/dynlink/dynlink_types.ml
+++ b/ocaml/otherlibs/dynlink/dynlink_types.ml
@@ -44,6 +44,7 @@ type error =
   | Inconsistent_implementation of string
   | Module_already_loaded of string
   | Private_library_cannot_implement_interface of string
+  | Library_file_already_loaded_privately of { filename : string; }
 
 exception Error of error
 
@@ -80,6 +81,9 @@ let error_message = function
   | Private_library_cannot_implement_interface name ->
     "The interface `" ^ name ^ "' cannot be implemented by a \
       library loaded privately"
+  | Library_file_already_loaded_privately { filename } ->
+    "The dynamic library file `" ^ filename ^ "' has already been loaded \
+      privately (make a copy of the file to load it a second time)"
 
 let () =
   Printexc.register_printer (function
@@ -111,6 +115,8 @@ let () =
         Printf.sprintf "Module_already_loaded %S" name
       | Private_library_cannot_implement_interface name ->
         Printf.sprintf "Private_library_cannot_implement_interface %S" name
+      | Library_file_already_loaded_privately { filename } ->
+        Printf.sprintf "Library_file_already_loaded_privately %S" filename
       in
       Some (Printf.sprintf "Dynlink.Error (Dynlink.%s)" msg)
     | _ -> None)

--- a/ocaml/otherlibs/dynlink/dynlink_types.mli
+++ b/ocaml/otherlibs/dynlink/dynlink_types.mli
@@ -43,6 +43,7 @@ type error =
   | Inconsistent_implementation of string
   | Module_already_loaded of string
   | Private_library_cannot_implement_interface of string
+  | Library_file_already_loaded_privately of { filename : string; }
 
 exception Error of error
 

--- a/ocaml/runtime/dynlink_nat.c
+++ b/ocaml/runtime/dynlink_nat.c
@@ -105,11 +105,13 @@ CAMLprim value caml_natdynlink_run(value handle_v, value symbol) {
 
   unit = String_val(symbol);
 
+  sym = optsym("__gc_roots");
+  /* [caml_register_dyn_global] can raise, so do it prior to registering
+     frametables etc. */
+  if (NULL != sym) caml_register_dyn_global(sym);
+
   sym = optsym("__frametable");
   if (NULL != sym) caml_register_frametable(sym);
-
-  sym = optsym("__gc_roots");
-  if (NULL != sym) caml_register_dyn_global(sym);
 
   sym = optsym("__data_begin");
   sym2 = optsym("__data_end");

--- a/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -5,8 +5,8 @@ Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 137, characters 16-25
 Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 139, characters 6-137
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-44
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-240
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-250
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-17
 Called from Test10_main in file "test10_main.ml", line 51, characters 13-69

--- a/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -3,12 +3,12 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 32, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml" (inlined), line 2, characters 15-38
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
-Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/dynlink.ml", line 250, characters 12-29
-Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/dynlink.ml", line 250, characters 12-29
-Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/dynlink.ml", line 252, characters 10-149
+Called from Dynlink.Native.ndl_run in file "otherlibs/dynlink/dynlink.ml", line 251, characters 8-25
+Called from Dynlink.Native.ndl_run in file "otherlibs/dynlink/dynlink.ml", line 251, characters 8-25
+Re-raised at Dynlink.Native.ndl_run in file "otherlibs/dynlink/dynlink.ml", line 263, characters 6-137
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-44
+Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-54
 Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
-Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-240
+Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-250
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-17
 Called from Test10_main in file "test10_main.ml", line 49, characters 30-87


### PR DESCRIPTION
We have spent a long time this week debugging a segfault that was caused by incorrect operation of the compactor arising from duplicates in `caml_dyn_globals` (we've encountered similar problems before, but with the non-dynamic globals list, e.g. in https://github.com/ocaml-flambda/flambda-backend/pull/87).  We suspect the duplicates in `caml_dyn_globals` occurred because of `Ocaml_plugin` using `Dynlink` in a re-entrant manner (inside `In_thread.run` in Async).