### PR TITLE
Cause always-inline attributes to increment the inlining depth less quickly

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -237,7 +237,8 @@ module Inlining = struct
           | Default_inlined | Unroll _ ->
             (* Closure ignores completely [@unrolled] attributes, so it seems
                safe to do the same. *)
-            ( Call_site_inlining_decision_type.Definition_says_inline,
+            ( Call_site_inlining_decision_type.Definition_says_inline
+                { was_inline_always = false },
               Inlinable code )
         in
         Inlining_report.record_decision_at_call_site_for_known_function ~tracker

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -190,7 +190,8 @@ val inlining_arguments : t -> Inlining_arguments.t
 
 val set_inlining_arguments : Inlining_arguments.t -> t -> t
 
-val enter_inlined_apply : called_code:Code.t -> apply:Apply.t -> t -> t
+val enter_inlined_apply :
+  called_code:Code.t -> apply:Apply.t -> was_inline_always:bool -> t -> t
 
 val generate_phantom_lets : t -> bool
 

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -59,7 +59,8 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
        inside of [speculative_inlining] we will always have [unroll_to] = None.
        We are not disabling unrolling when speculating, it just happens that no
        unrolling can happen while speculating right now. *)
-    Inlining_transforms.inline dacc ~apply ~unroll_to:None function_type
+    Inlining_transforms.inline dacc ~apply ~unroll_to:None
+      ~was_inline_always:false function_type
   in
   let scope = DE.get_continuation_scope (DA.denv dacc) in
   let dummy_toplevel_cont =
@@ -148,7 +149,11 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
     |> Code_metadata.inlining_decision
   in
   if Function_decl_inlining_decision_type.must_be_inlined decision
-  then Definition_says_inline
+  then
+    Definition_says_inline
+      { was_inline_always =
+          Function_decl_inlining_decision_type.has_attribute_inline decision
+      }
   else if Function_decl_inlining_decision_type.cannot_be_inlined decision
   then Definition_says_not_to_inline
   else if env_prohibits_inlining

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -83,7 +83,7 @@ let wrap_inlined_body_for_exn_extra_args ~extra_args ~apply_exn_continuation
     ~apply_exn_continuation ~apply_return_continuation ~result_arity
     ~make_inlined_body ~apply_cont_create ~let_cont_create
 
-let inline dacc ~apply ~unroll_to function_decl =
+let inline dacc ~apply ~unroll_to ~was_inline_always function_decl =
   let callee = Apply.callee apply in
   let args = Apply.args apply in
   let apply_return_continuation = Apply.continuation apply in
@@ -103,7 +103,9 @@ let inline dacc ~apply ~unroll_to function_decl =
     | Need_meet -> Rec_info_expr.unknown
     | Invalid -> (* CR vlaviron: ? *) Rec_info_expr.do_not_inline
   in
-  let denv = DE.enter_inlined_apply ~called_code:code ~apply denv in
+  let denv =
+    DE.enter_inlined_apply ~called_code:code ~apply ~was_inline_always denv
+  in
   let params_and_body = Code.params_and_body code in
   Function_params_and_body.pattern_match params_and_body
     ~f:(fun

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.mli
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.mli
@@ -20,5 +20,6 @@ val inline :
   Downwards_acc.t ->
   apply:Apply.t ->
   unroll_to:int option ->
+  was_inline_always:bool ->
   Flambda2_types.Function_type.t ->
   Downwards_acc.t * Expr.t

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -165,9 +165,10 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
             "[@inlined] attribute was not used on this function \
              application{Do_not_inline}";
       None
-    | Inline { unroll_to } ->
+    | Inline { unroll_to; was_inline_always } ->
       let dacc, inlined =
-        Inlining_transforms.inline dacc ~apply ~unroll_to function_type
+        Inlining_transforms.inline dacc ~apply ~unroll_to ~was_inline_always
+          function_type
       in
       Some (dacc, inlined)
   in

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -33,7 +33,7 @@ type t =
       }
   | Attribute_always
   | Attribute_unroll of int
-  | Definition_says_inline
+  | Definition_says_inline of { was_inline_always : bool }
   | Speculatively_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
@@ -49,6 +49,9 @@ type can_inline = private
       { warn_if_attribute_ignored : bool;
         because_of_definition : bool
       }
-  | Inline of { unroll_to : int option }
+  | Inline of
+      { unroll_to : int option;
+        was_inline_always : bool
+      }
 
 val can_inline : t -> can_inline

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
@@ -135,6 +135,13 @@ let must_be_inlined t =
   | Must_be_inlined -> true
   | Cannot_be_inlined | Could_possibly_be_inlined -> false
 
+let has_attribute_inline t =
+  match t with
+  | Attribute_inline -> true
+  | Not_yet_decided | Never_inline_attribute | Function_body_too_large _ | Stub
+  | Small_function _ | Speculatively_inlinable _ | Functor _ | Recursive ->
+    false
+
 let cannot_be_inlined t =
   match behaviour t with
   | Cannot_be_inlined -> true

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
@@ -38,6 +38,8 @@ val report : Format.formatter -> t -> unit
 
 val must_be_inlined : t -> bool
 
+val has_attribute_inline : t -> bool
+
 val cannot_be_inlined : t -> bool
 
 val equal : t -> t -> bool

--- a/middle_end/flambda2/terms/inlining_state.ml
+++ b/middle_end/flambda2/terms/inlining_state.ml
@@ -19,7 +19,7 @@ type t =
     depth : int
   }
 
-let increment_depth t = { t with depth = t.depth + 1 }
+let increment_depth t ~by = { t with depth = t.depth + by }
 
 let default ~round = { arguments = Inlining_arguments.create ~round; depth = 0 }
 

--- a/middle_end/flambda2/terms/inlining_state.mli
+++ b/middle_end/flambda2/terms/inlining_state.mli
@@ -28,7 +28,7 @@ val create : arguments:Inlining_arguments.t -> depth:int -> t
 
 val depth : t -> int
 
-val increment_depth : t -> t
+val increment_depth : t -> by:int -> t
 
 val is_depth_exceeded : t -> bool
 

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -113,10 +113,15 @@ module Inlining = struct
     | Round of int
     | Default
 
+  let depth_scaling_factor = 10 (* See [Downwards_env.enter_inlined_apply] *)
+
   let max_depth round_or_default =
-    match round_or_default with
-    | Round round -> IH.get ~key:round !I.max_depth
-    | Default -> D.max_depth
+    let depth =
+      match round_or_default with
+      | Round round -> IH.get ~key:round !I.max_depth
+      | Default -> D.max_depth
+    in
+    depth * depth_scaling_factor
 
   let max_rec_depth round_or_default =
     match round_or_default with

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -77,6 +77,9 @@ module Inlining : sig
     | Round of int
     | Default
 
+  val depth_scaling_factor : int
+
+  (** [max_depth] returns the user's value multipled by [depth_scaling_factor]. *)
   val max_depth : round_or_default -> int
 
   val max_rec_depth : round_or_default -> int


### PR DESCRIPTION
Functions annotated with `[@inline always]` or `[@inlined always]` should be inlined every time.  However we need some protection against implicit recursion turning into explicit recursion in the simplifier and then blowing up.  The idea here is to scale the depth limit internally and increment the current depth by far less when one of these attributes is in effect.

We will need to devote some time in the future to working out why raising the maximum depth causes significant problems with compilation speed (at least on the JS tree).