### PR TITLE
Fix error message printing from Emit

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -171,7 +171,14 @@ let should_use_linscan fd =
 let if_emit_do f x = if should_emit () then f x else ()
 let emit_begin_assembly ~init_dwarf:init_dwarf =
   if_emit_do (fun init_dwarf -> Emit.begin_assembly ~init_dwarf) init_dwarf
-let emit_end_assembly = if_emit_do Emit.end_assembly
+let emit_end_assembly filename =
+  if_emit_do
+   (fun dwarf ->
+     try
+       Emit.end_assembly dwarf
+     with Emitaux.Error e ->
+       raise (Error (Asm_generation(filename, e))))
+
 let emit_data = if_emit_do Emit.data
 let emit_fundecl ~dwarf =
   if_emit_do
@@ -580,7 +587,7 @@ let end_gen_implementation0 unix ?toplevel ~ppf_dump ~sourcefile make_cmm =
            if not (Primitive.native_name_is_external prim) then None
            else Some (Primitive.native_name prim))
           !Translmod.primitive_declarations));
-  emit_end_assembly dwarf
+  emit_end_assembly sourcefile dwarf
 
 let end_gen_implementation unix ?toplevel ~ppf_dump ~sourcefile clambda =
   end_gen_implementation0 unix ?toplevel ~ppf_dump ~sourcefile (fun () ->
@@ -647,7 +654,7 @@ let linear_gen_implementation unix filename =
       ~emit_begin_assembly ~sourcefile:filename ()
   in
   Profile.record "Emit" (List.iter (emit_item ~dwarf)) linear_unit_info.items;
-  emit_end_assembly dwarf
+  emit_end_assembly filename dwarf
 
 let compile_implementation_linear unix output_prefix ~progname =
   compile_unit ~may_reduce_heap:true ~output_prefix
@@ -672,7 +679,7 @@ let report_error ppf = function
        (msg !Clflags.for_package) (msg saved)
   | Asm_generation(fn, err) ->
      fprintf ppf
-       "Error producing assembly code for function %s: %a"
+       "Error producing assembly code for %s: %a"
        fn Emitaux.report_error err
 
 let () =


### PR DESCRIPTION
Correctly handle exceptions raised during `Emit.end_assembly` and not only during `Emit.funcdecl`.

When compiling a function that results in a large frame (for the current frametable format), we were getting unhelpful error messages that look like this:
```
Fatal error: exception Emitaux.Error(_)
Raised at Emitaux.emit_frames.efa_16_checked in file "backend/emitaux.ml", line 190, characters 9-47
Called from Emitaux.emit_frames.emit_frame in file "backend/emitaux.ml", line 205, characters 4-45
Called from Stdlib__List.iter in file "list.ml", line 114, characters 12-15
Called from Emitaux.emit_frames in file "backend/emitaux.ml", line 283, characters 2-41
Called from Emit.end_assembly in file "backend/amd64/emit.mlp", line 1655, characters 2-931
Called from Asmgen.compile_unit.(fun) in file "backend/asmgen.ml", line 450, characters 12-18
...
```
With this PR, we will get a slightly nicer user error like this: 
```
File "owl_lapacke_bindings.ml", line 1:
    Error: Error producing assembly code for owl_lapacke_bindings.ml: stack frame too large (136785 bytes)
    - exit external/owl/src/owl/bindings bin_prefix_owl_cblas_parser__Owl_lapacke_bindings.cmx, 5.321s, exited with code 2
```
(when compiling the file with -linscan).

The error handling was introduced in https://github.com/ocaml/ocaml/pull/10085 for `emit_frame`  (which is actually called during `Emit.end_assembly`), so this PR is also needed upstream. 

I'm trying to move the check itself from `emit_frame` to `record_frame_descr`, so the user error can include have a function name as intended, but this PR is independently useful, as we may want to have other user error messages in the future.