### PR TITLE
CFG/IRC: dedicated type for list of instructions

### DIFF
--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -31,9 +31,56 @@ include module type of struct
   include Cfg_intf.S
 end
 
+module BasicInstructionList : sig
+  type instr = basic instruction
+
+  type cell
+
+  val insert_before : cell -> instr -> unit
+
+  val insert_after : cell -> instr -> unit
+
+  val instr : cell -> instr
+
+  type t
+
+  val make_empty : unit -> t
+
+  val make_single : instr -> t
+
+  val of_list : instr list -> t
+
+  val hd : t -> instr option
+
+  val add_begin : t -> instr -> unit
+
+  val add_end : t -> instr -> unit
+
+  val is_empty : t -> bool
+
+  val length : t -> int
+
+  val filter_left : t -> f:(instr -> bool) -> unit
+
+  val filter_right : t -> f:(instr -> bool) -> unit
+
+  val iter : t -> f:(instr -> unit) -> unit
+
+  val iter_cell : t -> f:(cell -> unit) -> unit
+
+  val iter2 : t -> t -> f:(instr -> instr -> unit) -> unit
+
+  val fold_left : t -> f:('a -> instr -> 'a) -> init:'a -> 'a
+
+  val fold_right : t -> f:(instr -> 'a -> 'a) -> init:'a -> 'a
+
+  (* Adds all of the elements of `from` to `to_`, and clears `from`. *)
+  val transfer : to_:t -> from:t -> unit -> unit
+end
+
 type basic_block =
   { start : Label.t;
-    mutable body : basic instruction list;
+    body : BasicInstructionList.t;
     mutable terminator : terminator instruction;
     mutable predecessors : Label.Set.t;
         (** All predecessors, both normal and exceptional paths. *)
@@ -109,6 +156,8 @@ val replace_successor_labels :
     vice versa. *)
 val can_raise_interproc : basic_block -> bool
 
+val first_instruction_id : basic_block -> int
+
 val mem_block : t -> Label.t -> bool
 
 val remove_block_exn : t -> Label.t -> unit
@@ -168,9 +217,7 @@ val is_pure_basic : basic -> bool
 
 val is_noop_move : basic instruction -> bool
 
-val set_stack_offset : 'a instruction -> int -> 'a instruction
-
-val set_live : 'a instruction -> Reg.Set.t -> 'a instruction
+val set_stack_offset : 'a instruction -> int -> unit
 
 val string_of_irc_work_list : irc_work_list -> string
 

--- a/backend/cfg/cfg_dataflow.ml
+++ b/backend/cfg/cfg_dataflow.ml
@@ -340,7 +340,7 @@ module Forward (D : Domain_S) (T : Forward_transfer with type domain = D.t) :
       in
       let normal, exceptional =
         transfer T.terminator
-          (ListLabels.fold_left block.body ~init:(value, value)
+          (Cfg.BasicInstructionList.fold_left block.body ~init:(value, value)
              ~f:(transfer T.basic))
           block.terminator
       in
@@ -479,8 +479,8 @@ module Backward (D : Domain_S) (T : Backward_transfer with type domain = D.t) :
         transfer block.terminator (T.terminator normal ~exn block.terminator)
       in
       let value =
-        ListLabels.fold_right block.body ~init:value ~f:(fun instr value ->
-            transfer instr (T.basic value ~exn instr))
+        Cfg.BasicInstructionList.fold_right block.body ~init:value
+          ~f:(fun instr value -> transfer instr (T.basic value ~exn instr))
       in
       let value =
         if block.is_trap_handler

--- a/backend/cfg/cfg_deadcode.ml
+++ b/backend/cfg/cfg_deadcode.ml
@@ -8,37 +8,30 @@ let live_before : type a. a Cfg.instruction -> liveness -> Reg.Set.t =
   | None -> fatal "no liveness information for instruction %d" instr.id
   | Some { Cfg_liveness.before; across = _ } -> before
 
-let remove_deadcode (body : Instruction.t list) liveness used_after :
-    Instruction.t list * bool =
-  let body, _, changed =
-    List.fold_right body ~init:([], used_after, false)
-      ~f:(fun (instr : Instruction.t) (acc, used_after, changed) ->
-        let before = live_before instr liveness in
-        let is_deadcode =
-          match instr.desc with
-          | Op _ as op ->
-            Cfg.is_pure_basic op
-            && Reg.disjoint_set_array used_after instr.res
-            && (not (Proc.regs_are_volatile instr.arg))
-            && not (Proc.regs_are_volatile instr.res)
-          | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> false
-        in
-        let acc = if is_deadcode then acc else instr :: acc in
-        acc, before, changed || is_deadcode)
-  in
-  body, changed
+let remove_deadcode (body : Cfg.BasicInstructionList.t) changed liveness
+    used_after : unit =
+  let used_after = ref used_after in
+  Cfg.BasicInstructionList.filter_right body ~f:(fun (instr : Instruction.t) ->
+      let before = live_before instr liveness in
+      let is_deadcode =
+        match instr.desc with
+        | Op _ as op ->
+          Cfg.is_pure_basic op
+          && Reg.disjoint_set_array !used_after instr.res
+          && (not (Proc.regs_are_volatile instr.arg))
+          && not (Proc.regs_are_volatile instr.res)
+        | Call _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> false
+      in
+      used_after := before;
+      changed := !changed || is_deadcode;
+      not is_deadcode)
 
 let run cfg_with_liveness =
   let liveness = Cfg_with_liveness.liveness cfg_with_liveness in
-  let invalidate =
-    Cfg.fold_blocks (Cfg_with_liveness.cfg cfg_with_liveness) ~init:false
-      ~f:(fun _label block changed ->
-        let new_body, body_changed =
-          remove_deadcode block.body liveness
-            (live_before block.terminator liveness)
-        in
-        block.body <- new_body;
-        changed || body_changed)
-  in
-  if invalidate then Cfg_with_liveness.invalidate_liveness cfg_with_liveness;
+  let changed = ref false in
+  Cfg.iter_blocks (Cfg_with_liveness.cfg cfg_with_liveness)
+    ~f:(fun _label block ->
+      remove_deadcode block.body changed liveness
+        (live_before block.terminator liveness));
+  if !changed then Cfg_with_liveness.invalidate_liveness cfg_with_liveness;
   cfg_with_liveness

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -138,10 +138,10 @@ module S = struct
     { desc : 'a;
       mutable arg : Reg.t array;
       mutable res : Reg.t array;
-      dbg : Debuginfo.t;
-      fdo : Fdo_info.t;
-      live : Reg.Set.t;
-      stack_offset : int;
+      mutable dbg : Debuginfo.t;
+      mutable fdo : Fdo_info.t;
+      mutable live : Reg.Set.t;
+      mutable stack_offset : int;
       id : int;
       mutable irc_work_list : irc_work_list
     }

--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -54,7 +54,7 @@ let build : State.t -> Cfg_with_liveness.t -> unit =
   Cfg.iter_blocks (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun _label block ->
       if block.is_trap_handler
       then
-        let first_id = Cfg_regalloc_utils.first_instruction_id block in
+        let first_id = Cfg.first_instruction_id block in
         let live = Cfg_dataflow.Instr.Tbl.find liveness first_id in
         Reg.Set.iter
           (fun reg1 ->
@@ -321,6 +321,11 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
       let alias = State.find_alias state n in
       n.Reg.irc_color <- alias.Reg.irc_color)
 
+type direction =
+  | Load_before_cell of Cfg.BasicInstructionList.cell
+  | Store_after_cell of Cfg.BasicInstructionList.cell
+  | Load_after_list of Cfg.BasicInstructionList.t
+
 let rewrite : State.t -> Cfg_with_liveness.t -> Reg.t list -> reset:bool -> unit
     =
  fun state cfg_with_liveness spilled_nodes ~reset ->
@@ -364,20 +369,9 @@ let rewrite : State.t -> Cfg_with_liveness.t -> Reg.t list -> reset:bool -> unit
     done;
     !i < len
   in
-  let[@inline] instruction_contains_spilled (instr : Instruction.t) : bool =
-    array_contains_spilled instr.arg || array_contains_spilled instr.res
-  in
-  let rec instruction_list_contains_spilled (l : Instruction.t list) : bool =
-    match l with
-    | [] -> false
-    | hd :: tl ->
-      instruction_contains_spilled hd || instruction_list_contains_spilled tl
-  in
-  let rewrite_instruction ~(direction : [`load | `store])
+  let rewrite_instruction ~(direction : direction)
       ~(sharing : (Reg.t * [`load | `store]) Reg.Tbl.t)
-      (acc : Instruction.t list) (instr : _ Cfg.instruction) :
-      Instruction.t list =
-    let res = ref acc in
+      (instr : _ Cfg.instruction) : unit =
     let f (reg : Reg.t) : Reg.t =
       if reg.Reg.irc_work_list = Reg.Spilled
       then (
@@ -386,89 +380,72 @@ let rewrite : State.t -> Cfg_with_liveness.t -> Reg.t list -> reset:bool -> unit
           | None -> assert false
           | Some r -> r
         in
-        let move =
-          match direction with `load -> Move.Load | `store -> Move.Store
+        let move, move_dir =
+          match direction with
+          | Load_before_cell _ | Load_after_list _ -> Move.Load, `load
+          | Store_after_cell _ -> Move.Store, `store
         in
         let add_instr, temp =
           match Reg.Tbl.find_opt sharing reg with
           | None ->
             let new_temp = make_new_temporary ~move reg in
-            Reg.Tbl.add sharing reg (new_temp, direction);
+            Reg.Tbl.add sharing reg (new_temp, move_dir);
             true, new_temp
-          | Some (r, dir) -> dir <> direction, r
-        in
-        let from, to_ =
-          match direction with
-          | `load -> spilled, temp
-          | `store -> temp, spilled
+          | Some (r, dir) -> dir <> move_dir, r
         in
         (if add_instr
         then
+          let from, to_ =
+            match move_dir with
+            | `load -> spilled, temp
+            | `store -> temp, spilled
+          in
           let new_instr =
             Move.make_instr move
               ~id:(State.get_and_incr_instruction_id state)
               ~copy:instr ~from ~to_
           in
-          res := new_instr :: !res);
+          match direction with
+          | Load_before_cell cell ->
+            Cfg.BasicInstructionList.insert_before cell new_instr
+          | Store_after_cell cell ->
+            Cfg.BasicInstructionList.insert_after cell new_instr
+          | Load_after_list list ->
+            Cfg.BasicInstructionList.add_end list new_instr);
         temp)
       else reg
     in
-    (match direction with
-    | `load -> instr.arg <- Array.map instr.arg ~f
-    | `store -> instr.res <- Array.map instr.res ~f);
-    !res
+    match direction with
+    | Load_before_cell _ | Load_after_list _ ->
+      if array_contains_spilled instr.arg
+      then instr.arg <- Array.map instr.arg ~f
+    | Store_after_cell _ ->
+      if array_contains_spilled instr.res
+      then instr.res <- Array.map instr.res ~f
   in
-  let rec rewrite_body_and_terminator (acc : Instruction.t list)
-      (body : Instruction.t list) (terminator : Cfg.terminator Cfg.instruction)
-      : Instruction.t list =
-    (* CR xclerc for xclerc: we can discover by calling `Cfg_stack_operands.xyz`
-       that we actually did not need to reallocate the list; it is a bit
-       unfortunate, given the efforts made to try to avoid the reallocation. *)
-    match body with
-    | [] -> (
-      match Cfg_stack_operands.terminator spilled_map terminator with
-      | All_spilled_registers_rewritten -> List.rev acc
-      | May_still_have_spilled_registers ->
-        let acc =
-          rewrite_instruction ~direction:`load ~sharing:(Reg.Tbl.create 8) acc
-            terminator
-        in
-        List.rev acc)
-    | hd :: tl -> (
-      match Cfg_stack_operands.basic spilled_map hd with
-      | All_spilled_registers_rewritten ->
-        let acc = hd :: acc in
-        rewrite_body_and_terminator acc tl terminator
-      | May_still_have_spilled_registers ->
-        let sharing = Reg.Tbl.create 8 in
-        let acc = rewrite_instruction ~direction:`load ~sharing acc hd in
-        let acc = hd :: acc in
-        let acc = rewrite_instruction ~direction:`store ~sharing acc hd in
-        rewrite_body_and_terminator acc tl terminator)
-  in
+  let liveness = Cfg_with_liveness.liveness cfg_with_liveness in
   Cfg.iter_blocks (Cfg_with_liveness.cfg cfg_with_liveness)
     ~f:(fun label block ->
       (* CR xclerc for xclerc: we currently assume that a terminator does not
          "define" a register that may be spilled. Calls are reasonably fine
          since their result is in a precolored register. *)
       assert (not (array_contains_spilled block.terminator.res));
-      let body_needs_rewrite =
-        instruction_list_contains_spilled block.body
-        || array_contains_spilled block.terminator.arg
-      in
-      if body_needs_rewrite
+      if irc_debug
       then (
-        let liveness = Cfg_with_liveness.liveness cfg_with_liveness in
-        if irc_debug
-        then (
-          log ~indent:2 "body of #%d, before:" label;
-          log_body_and_terminator ~indent:3 block.body block.terminator liveness);
-        block.body <- rewrite_body_and_terminator [] block.body block.terminator;
-        if irc_debug
-        then (
-          log ~indent:2 "and after:";
-          log_body_and_terminator ~indent:3 block.body block.terminator liveness;
-          log ~indent:2 "end")));
+        log ~indent:2 "body of #%d, before:" label;
+        log_body_and_terminator ~indent:3 block.body block.terminator liveness);
+      Cfg.BasicInstructionList.iter_cell block.body ~f:(fun cell ->
+          let sharing = Reg.Tbl.create 8 in
+          let instr = Cfg.BasicInstructionList.instr cell in
+          rewrite_instruction ~direction:(Load_before_cell cell) ~sharing instr;
+          rewrite_instruction ~direction:(Store_after_cell cell) ~sharing instr);
+      rewrite_instruction ~direction:(Load_after_list block.body)
+        ~sharing:(Reg.Tbl.create 8) block.terminator;
+      if irc_debug
+      then (
+        log ~indent:2 "and after:";
+        log_body_and_terminator ~indent:3 block.body block.terminator liveness;
+        log ~indent:2 "end"));
   if reset
   then State.reset state ~new_temporaries:!new_temporaries
   else (
@@ -582,11 +559,7 @@ let run : Cfg_with_liveness.t -> Cfg_with_liveness.t =
   let spilling_because_split =
     match Lazy.force Split_mode.env with
     | Off -> []
-    | Naive -> (
-      match naive_split_points cfg_with_layout with
-      | [] -> []
-      | _ :: _ as split_points ->
-        naive_split_cfg state cfg_with_liveness split_points)
+    | Naive -> naive_split_cfg state cfg_with_liveness
   in
   let spilling_because_split_or_unused : Reg.t list =
     Reg.Set.fold

--- a/backend/cfg/cfg_irc_split.ml
+++ b/backend/cfg/cfg_irc_split.ml
@@ -4,64 +4,13 @@ open! Cfg_regalloc_utils
 open! Cfg_irc_utils
 module State = Cfg_irc_state
 
-let naive_split_points : Cfg_with_layout.t -> Instruction.id list =
- fun cfg_with_layout ->
-  if irc_debug then log ~indent:1 "naive_split_points";
-  Cfg_with_layout.fold_instructions cfg_with_layout ~init:[]
-    ~instruction:(fun acc (instr : Instruction.t) ->
-      (* CR xclerc for xclerc: we may want to split [heuristically] in more
-         situations. *)
-      let split =
-        match instr.desc with
-        | Call (P (External _) | F (Direct _)) -> true
-        | _ -> false
-      in
-      if split
-      then (
-        if irc_debug then log ~indent:2 "should split at %d" instr.id;
-        instr.id :: acc)
-      else acc)
-    ~terminator:(fun acc _term -> acc)
-  |> List.rev
-
-type naive_split_instr =
-  { before : Instruction.t;
-    after : Instruction.t;
-    new_regs : Reg.t list
-  }
-
-let[@inline] naive_split_instr :
-    State.t ->
-    Reg.t Reg.Tbl.t ->
-    Instruction.t ->
-    Reg.t ->
-    Reg.t list ->
-    naive_split_instr =
- fun state subst instr reg new_regs ->
-  let new_reg, new_regs =
-    match Reg.Tbl.find_opt subst reg with
-    | Some r -> r, new_regs
-    | None ->
-      let new_reg =
-        make_temporary ~same_class_and_base_name_as:reg ~name_prefix:"split"
-      in
-      State.add_introduced_temporaries_one state new_reg;
-      State.add_initial_one state new_reg;
-      State.add_spilled_nodes state new_reg;
-      Reg.Tbl.replace subst reg new_reg;
-      new_reg, new_reg :: new_regs
-  in
-  let before =
-    Move.make_instr Move.Plain
-      ~id:(State.get_and_incr_instruction_id state)
-      ~copy:instr ~from:reg ~to_:new_reg
-  in
-  let after =
-    Move.make_instr Move.Plain
-      ~id:(State.get_and_incr_instruction_id state)
-      ~copy:instr ~from:new_reg ~to_:reg
-  in
-  { before; after; new_regs }
+let is_naive_split_point : Instruction.t -> bool =
+ fun instr ->
+  (* CR xclerc for xclerc: we may want to split [heuristically] in more
+     situations. *)
+  match instr.desc with
+  | Call (P (External _) | F (Direct _)) -> true
+  | _ -> false
 
 let[@inline] apply_regs : Reg.t Reg.Tbl.t -> Reg.t array -> Reg.t array =
  fun subst arr ->
@@ -74,76 +23,61 @@ let[@inline] apply_instr : Reg.t Reg.Tbl.t -> Instruction.t -> unit =
   instr.arg <- apply_regs subst instr.arg;
   instr.res <- apply_regs subst instr.res
 
-type naive_split_body =
-  { body : Instruction.t list;
-    split_points : Instruction.id list;
-    new_regs : Reg.t list
-  }
-
-let rec naive_split_body :
+let[@inline] naive_split_instr :
     State.t ->
     liveness ->
+    Reg.t list ref ->
     Reg.t Reg.Tbl.t ->
-    Instruction.t list ->
-    Instruction.t list ->
-    Instruction.id list ->
-    Reg.t list ->
-    naive_split_body =
- fun state liveness subst acc body split_points new_regs ->
-  match body, split_points with
-  | [], _ -> { body = List.rev acc; split_points; new_regs }
-  | _, [] -> { body = List.rev acc @ body; split_points = []; new_regs }
-  | hd_body :: tl_body, hd_split_points :: tl_split_points ->
-    if hd_body.Cfg.id = hd_split_points
+    Cfg.BasicInstructionList.cell ->
+    unit =
+ fun state liveness new_regs subst cell ->
+  let instr = Cfg.BasicInstructionList.instr cell in
+  if is_naive_split_point instr
+  then (
+    let live = Cfg_dataflow.Instr.Tbl.find liveness instr.id in
+    if irc_debug
     then (
-      let live = Cfg_dataflow.Instr.Tbl.find liveness hd_body.Cfg.id in
-      if irc_debug
-      then (
-        log ~indent:2 "splitting at %d" hd_split_points;
-        Reg.Set.iter
-          (fun reg -> log ~indent:3 "register %a is live" Printmach.reg reg)
-          live.across);
-      let acc, new_regs, instrs_after =
-        Reg.Set.fold
-          (fun reg (acc, new_regs, instrs_after) ->
-            let { before; after; new_regs } =
-              naive_split_instr state subst hd_body reg new_regs
+      log ~indent:2 "splitting at %d" instr.id;
+      Reg.Set.iter
+        (fun reg -> log ~indent:3 "register %a is live" Printmach.reg reg)
+        live.across);
+    Reg.Set.iter
+      (fun reg ->
+        let new_reg =
+          match Reg.Tbl.find_opt subst reg with
+          | Some r -> r
+          | None ->
+            let new_reg =
+              make_temporary ~same_class_and_base_name_as:reg
+                ~name_prefix:"split"
             in
-            before :: acc, new_regs, after :: instrs_after)
-          live.across (acc, new_regs, [])
-      in
-      apply_instr subst hd_body;
-      naive_split_body state liveness subst
-        (instrs_after @ (hd_body :: acc))
-        tl_body tl_split_points new_regs)
-    else
-      naive_split_body state liveness subst (hd_body :: acc) tl_body
-        split_points new_regs
+            State.add_introduced_temporaries_one state new_reg;
+            State.add_initial_one state new_reg;
+            State.add_spilled_nodes state new_reg;
+            Reg.Tbl.replace subst reg new_reg;
+            new_regs := new_reg :: !new_regs;
+            new_reg
+        in
+        Cfg.BasicInstructionList.insert_before cell
+          (Move.make_instr Move.Plain
+             ~id:(State.get_and_incr_instruction_id state)
+             ~copy:instr ~from:reg ~to_:new_reg);
+        Cfg.BasicInstructionList.insert_after cell
+          (Move.make_instr Move.Plain
+             ~id:(State.get_and_incr_instruction_id state)
+             ~copy:instr ~from:new_reg ~to_:reg);
+        apply_instr subst instr)
+      live.across)
 
-let naive_split_cfg :
-    State.t -> Cfg_with_liveness.t -> Instruction.id list -> Reg.t list =
- fun state cfg_with_liveness split_points ->
+let naive_split_cfg : State.t -> Cfg_with_liveness.t -> Reg.t list =
+ fun state cfg_with_liveness ->
   if irc_debug then log ~indent:1 "naive_split";
+  let new_regs = ref [] in
   let subst = Reg.Tbl.create 32 in
   let liveness = Cfg_with_liveness.liveness cfg_with_liveness in
-  let split_points, new_regs =
-    Cfg.fold_blocks (Cfg_with_liveness.cfg cfg_with_liveness)
-      ~init:(split_points, [])
-      ~f:(fun label block ((split_points, new_regs) as acc) ->
-        match split_points with
-        | [] -> acc
-        | hd :: _ ->
-          if irc_debug then log ~indent:2 "splitting in #%d" label;
-          if List.exists block.body ~f:(fun instr -> instr.Cfg.id = hd)
-          then (
-            let { body; split_points; new_regs } =
-              naive_split_body state liveness subst [] block.body split_points
-                new_regs
-            in
-            block.body <- body;
-            split_points, new_regs)
-          else acc)
-  in
-  assert (split_points = []);
-  Cfg_with_liveness.invalidate_liveness cfg_with_liveness;
-  new_regs
+  Cfg.iter_blocks (Cfg_with_liveness.cfg cfg_with_liveness)
+    ~f:(fun label block ->
+      if irc_debug then log ~indent:2 "splitting in #%d" label;
+      Cfg.BasicInstructionList.iter_cell block.body ~f:(fun cell ->
+          naive_split_instr state liveness new_regs subst cell));
+  !new_regs

--- a/backend/cfg/cfg_irc_split.mli
+++ b/backend/cfg/cfg_irc_split.mli
@@ -1,8 +1,3 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-open Cfg_regalloc_utils
-
-val naive_split_points : Cfg_with_layout.t -> Instruction.id list
-
-val naive_split_cfg :
-  Cfg_irc_state.t -> Cfg_with_liveness.t -> Instruction.id list -> Reg.t list
+val naive_split_cfg : Cfg_irc_state.t -> Cfg_with_liveness.t -> Reg.t list

--- a/backend/cfg/cfg_irc_utils.ml
+++ b/backend/cfg/cfg_irc_utils.ml
@@ -43,14 +43,15 @@ let log_instruction_suffix (instr : _ Cfg.instruction) (liveness : liveness) :
 
 let log_body_and_terminator :
     indent:int ->
-    Cfg.basic Cfg.instruction list ->
+    Cfg.BasicInstructionList.t ->
     Cfg.terminator Cfg.instruction ->
     liveness ->
     unit =
  fun ~indent body term liveness ->
   if irc_debug && irc_verbose
   then (
-    List.iter body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+    Cfg.BasicInstructionList.iter body
+      ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
         log_instruction_prefix ~indent instr;
         Cfg.dump_basic Format.err_formatter instr.Cfg.desc;
         log_instruction_suffix instr liveness);

--- a/backend/cfg/cfg_irc_utils.mli
+++ b/backend/cfg/cfg_irc_utils.mli
@@ -12,7 +12,7 @@ val log : indent:int -> ('a, Format.formatter, unit) format -> 'a
 
 val log_body_and_terminator :
   indent:int ->
-  Cfg.basic Cfg.instruction list ->
+  Cfg.BasicInstructionList.t ->
   Cfg.terminator Cfg.instruction ->
   liveness ->
   unit

--- a/backend/cfg/cfg_regalloc_utils.mli
+++ b/backend/cfg/cfg_regalloc_utils.mli
@@ -26,8 +26,6 @@ module Instruction : sig
   module IdMap : MoreLabels.Map.S with type key = id
 end
 
-val first_instruction_id : Cfg.basic_block -> int
-
 type cfg_infos =
   { arg : Reg.Set.t;
     res : Reg.Set.t;

--- a/backend/cfg/cfg_regalloc_validate.ml
+++ b/backend/cfg/cfg_regalloc_validate.ml
@@ -1180,7 +1180,7 @@ let test (desc : Description.t) (cfg : Cfg_with_layout.t) :
     let entrypoint_equations =
       let cfg = Cfg_with_layout.cfg cfg in
       let entry_block = Cfg.entry_label cfg |> Cfg.get_block_exn cfg in
-      let entry_id = Cfg_regalloc_utils.first_instruction_id entry_block in
+      let entry_id = Cfg.first_instruction_id entry_block in
       Cfg_dataflow.Instr.Tbl.find res_instr entry_id
     in
     verify_entrypoint entrypoint_equations desc cfg

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -307,9 +307,9 @@ let run cfg_with_layout =
       | (Some _ | None), None -> ()
       | None, Some _ -> tailrec_label := terminator_tailrec_label
       | Some old_trl, Some new_trl -> assert (Label.equal old_trl new_trl));
-      List.fold_left
-        (fun next i -> basic_to_linear i ~next)
-        terminator (List.rev block.body)
+      Cfg.BasicInstructionList.fold_right
+        ~f:(fun i next -> basic_to_linear i ~next)
+        ~init:terminator block.body
     in
     let insn =
       if i = 0

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -79,7 +79,9 @@ let dump ppf t ~msg =
   let print_block label =
     let block = Label.Tbl.find t.cfg.blocks label in
     fprintf ppf "\n%d:\n" label;
-    List.iter (fprintf ppf "%a\n" Cfg.print_basic) block.body;
+    Cfg.BasicInstructionList.iter
+      ~f:(fprintf ppf "%a\n" Cfg.print_basic)
+      block.body;
     Cfg.print_terminator ppf block.terminator;
     fprintf ppf "\npredecessors:";
     Label.Set.iter (fprintf ppf " %d") block.predecessors;
@@ -187,7 +189,7 @@ let print_dot ?(show_instr = true) ?(show_exn = true)
       (print_row
          (print_cell ~col_span:col_count ~align:Center
             (Format.dprintf ".L%d:I%d:S%d%s%s%s" label show_index
-               (List.length block.body)
+               (Cfg.BasicInstructionList.length block.body)
                (if block.stack_offset > 0
                then ":T" ^ string_of_int block.stack_offset
                else "")
@@ -203,8 +205,8 @@ let print_dot ?(show_instr = true) ?(show_exn = true)
                   Format.pp_print_int)
                (Label.Set.to_seq block.predecessors))))
         ppf;
-      List.iter
-        (fun (i : _ Cfg.instruction) ->
+      Cfg.BasicInstructionList.iter
+        ~f:(fun (i : _ Cfg.instruction) ->
           (print_row
              (print_cell ~align:Right (Format.dprintf "%d" i.id)
              ++ annotate_instr (`Basic i)))
@@ -338,7 +340,7 @@ let iter_instructions :
     unit =
  fun cfg_with_layout ~instruction ~terminator ->
   Cfg.iter_blocks cfg_with_layout.cfg ~f:(fun _label block ->
-      List.iter instruction block.body;
+      Cfg.BasicInstructionList.iter ~f:instruction block.body;
       terminator block.terminator)
 
 let fold_instructions :
@@ -350,6 +352,8 @@ let fold_instructions :
     a =
  fun cfg_with_layout ~instruction ~terminator ~init ->
   Cfg.fold_blocks cfg_with_layout.cfg ~init ~f:(fun _label block acc ->
-      let acc = List.fold_left instruction acc block.body in
+      let acc =
+        Cfg.BasicInstructionList.fold_left ~f:instruction ~init:acc block.body
+      in
       let acc = terminator acc block.terminator in
       acc)

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -348,7 +348,7 @@ let rec get_end : Mach.instruction -> Mach.instruction =
     get_end instr.Mach.next
 
 type block_info =
-  { instrs : Cfg.basic Cfg.instruction list;
+  { instrs : Cfg.BasicInstructionList.t;
     last : Mach.instruction;
     terminator : Cfg.terminator Cfg.instruction option
   }
@@ -361,10 +361,7 @@ type block_info =
 let extract_block_info : State.t -> Mach.instruction -> block_info =
  fun state first ->
   let rec loop (instr : Mach.instruction) acc =
-    let return terminator instrs =
-      let instrs = List.rev instrs in
-      { instrs; last = instr; terminator }
-    in
+    let return terminator instrs = { instrs; last = instr; terminator } in
     match instr.desc with
     | Iop (Ipoll _) -> return None acc
     | Iop
@@ -386,7 +383,7 @@ let extract_block_info : State.t -> Mach.instruction -> block_info =
            because we want to compute liveness information on CFG values, and
            (i) such moves are necessary to compute the live sets and (ii) they
            can only be identified as useless after register allocation. *)
-        let acc = instr' :: acc in
+        Cfg.BasicInstructionList.add_end acc instr';
         if Cfg.can_raise_basic desc
         then return None acc
         else loop instr.next acc
@@ -397,7 +394,7 @@ let extract_block_info : State.t -> Mach.instruction -> block_info =
       return None acc
     | Iraise _ -> return None acc
   in
-  loop first []
+  loop first (Cfg.BasicInstructionList.make_empty ())
 
 (* Represents the control flow exiting the function without encountering a
    return. *)
@@ -419,33 +416,33 @@ let rec add_blocks :
   let { instrs; last; terminator } = extract_block_info state instr in
   let terminate_block ~trap_actions terminator =
     let body = instrs in
-    let body =
-      match starts_with_pushtrap with
-      | None -> body
-      | Some lbl_handler ->
-        make_instruction state ~desc:(Cfg.Pushtrap { lbl_handler }) :: body
-    in
-    let body =
-      body
-      @ List.map
-          (function
-            | Cmm.Push handler_id ->
-              let lbl_handler = State.get_catch_handler state ~handler_id in
-              make_instruction state ~desc:(Cfg.Pushtrap { lbl_handler })
-            | Cmm.Pop -> make_instruction state ~desc:Cfg.Poptrap)
-          trap_actions
-    in
-    let body =
-      match terminator.Cfg.desc with
-      | Cfg.Return ->
-        if State.get_contains_calls state
-        then body @ [make_instruction state ~desc:Cfg.Reloadretaddr]
-        else body
-      | Cfg.Never | Cfg.Always _ | Cfg.Parity_test _ | Cfg.Truth_test _
-      | Cfg.Float_test _ | Cfg.Int_test _ | Cfg.Switch _ | Cfg.Raise _
-      | Cfg.Tailcall _ | Cfg.Call_no_return _ | Cfg.Poll_and_jump _ ->
-        body
-    in
+    (match starts_with_pushtrap with
+    | None -> ()
+    | Some lbl_handler ->
+      Cfg.BasicInstructionList.add_begin body
+        (make_instruction state ~desc:(Cfg.Pushtrap { lbl_handler })));
+    List.iter
+      (fun trap_action ->
+        let instr =
+          match trap_action with
+          | Cmm.Push handler_id ->
+            let lbl_handler = State.get_catch_handler state ~handler_id in
+            make_instruction state ~desc:(Cfg.Pushtrap { lbl_handler })
+          | Cmm.Pop -> make_instruction state ~desc:Cfg.Poptrap
+        in
+        Cfg.BasicInstructionList.add_end body instr)
+      trap_actions;
+    (match terminator.Cfg.desc with
+    | Cfg.Return ->
+      if State.get_contains_calls state
+      then
+        Cfg.BasicInstructionList.add_end body
+          (make_instruction state ~desc:Cfg.Reloadretaddr)
+      else ()
+    | Cfg.Never | Cfg.Always _ | Cfg.Parity_test _ | Cfg.Truth_test _
+    | Cfg.Float_test _ | Cfg.Int_test _ | Cfg.Switch _ | Cfg.Raise _
+    | Cfg.Tailcall _ | Cfg.Call_no_return _ | Cfg.Poll_and_jump _ ->
+      ());
     let can_raise =
       (* Recompute [can_raise] and check that instructions in the middle of the
          block do not raise, i.e., only the terminator, or the last instruction
@@ -458,18 +455,16 @@ let rec add_blocks :
         | Poll_and_jump _ ->
           false
       in
-      let rec check = function
-        | [] -> false
-        | [last] ->
-          let res = Cfg.can_raise_basic last.Cfg.desc in
-          assert ((not res) || terminator_is_goto);
-          res
-        | hd :: tail ->
-          assert (not (Cfg.can_raise_basic hd.Cfg.desc));
-          check tail
+      let body_num_can_raise =
+        Cfg.BasicInstructionList.fold_left body ~init:0 ~f:(fun acc instr ->
+            if Cfg.can_raise_basic instr.Cfg.desc then succ acc else acc)
       in
-      let body_can_raise = check body in
-      Cfg.can_raise_terminator terminator.Cfg.desc || body_can_raise
+      match body_num_can_raise with
+      | 0 -> Cfg.can_raise_terminator terminator.Cfg.desc
+      | 1 ->
+        assert terminator_is_goto;
+        true
+      | _ -> assert false
     in
     State.add_block state ~label:start
       ~block:
@@ -637,10 +632,7 @@ module Stack_offset_and_exn = struct
     stack_offset + (Proc.trap_size_in_bytes * List.length traps)
 
   let check_and_set_stack_offset :
-      'a Cfg.instruction ->
-      stack_offset:int ->
-      traps:handler_stack ->
-      'a Cfg.instruction =
+      'a Cfg.instruction -> stack_offset:int -> traps:handler_stack -> unit =
    fun instr ~stack_offset ~traps ->
     assert (instr.stack_offset = invalid_stack_offset);
     Cfg.set_stack_offset instr (compute_stack_offset ~stack_offset ~traps)
@@ -649,10 +641,9 @@ module Stack_offset_and_exn = struct
       stack_offset:int ->
       traps:handler_stack ->
       Cfg.terminator Cfg.instruction ->
-      int * handler_stack * Cfg.terminator Cfg.instruction =
+      int * handler_stack =
    fun ~stack_offset ~traps term ->
-    assert (term.stack_offset = invalid_stack_offset);
-    let term = check_and_set_stack_offset term ~stack_offset ~traps in
+    check_and_set_stack_offset term ~stack_offset ~traps;
     match term.desc with
     | Tailcall (Self _) when List.length traps <> 0 || stack_offset <> 0 ->
       Misc.fatal_error
@@ -663,28 +654,28 @@ module Stack_offset_and_exn = struct
     | Tailcall (Func _)
     | Call_no_return _ | Raise _ | Always _ | Parity_test _ | Truth_test _
     | Float_test _ | Int_test _ | Switch _ | Poll_and_jump _ ->
-      stack_offset, traps, term
+      stack_offset, traps
 
   let rec process_basic :
       Cfg.t ->
       stack_offset:int ->
       traps:handler_stack ->
       Cfg.basic Cfg.instruction ->
-      int * handler_stack * Cfg.basic Cfg.instruction =
+      int * handler_stack =
    fun cfg ~stack_offset ~traps instr ->
-    let instr = check_and_set_stack_offset instr ~stack_offset ~traps in
+    check_and_set_stack_offset instr ~stack_offset ~traps;
     match instr.desc with
     | Pushtrap { lbl_handler } ->
       update_block cfg lbl_handler ~stack_offset ~traps;
-      stack_offset, lbl_handler :: traps, instr
+      stack_offset, lbl_handler :: traps
     | Poptrap -> (
       match traps with
       | [] ->
         Misc.fatal_error
           "Cfgize.Stack_offset_and_exn.process_basic: trying to pop from an \
            empty stack"
-      | _ :: traps -> stack_offset, traps, instr)
-    | Op (Stackoffset n) -> stack_offset + n, traps, instr
+      | _ :: traps -> stack_offset, traps)
+    | Op (Stackoffset n) -> stack_offset + n, traps
     | Op
         ( Move | Spill | Reload | Const_int _ | Const_float _ | Const_symbol _
         | Load _ | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf | Subf
@@ -692,7 +683,7 @@ module Stack_offset_and_exn = struct
         | Intofvalue | Probe _ | Probe_is_enabled _ | Opaque | Begin_region
         | End_region | Specific _ | Name_for_debugger _ )
     | Call _ | Reloadretaddr | Prologue ->
-      stack_offset, traps, instr
+      stack_offset, traps
 
   (* The argument [stack_offset] has a different meaning from the field
      [stack_offset] of Cfg's basic_blocks and instructions. The argument
@@ -713,19 +704,14 @@ module Stack_offset_and_exn = struct
     if was_invalid
     then (
       block.stack_offset <- compute_stack_offset ~stack_offset ~traps;
-      let stack_offset, traps, body =
-        ListLabels.fold_left block.body ~init:(stack_offset, traps, [])
-          ~f:(fun (stack_offset, traps, body) instr ->
-            let stack_offset, traps, instr =
-              process_basic cfg ~stack_offset ~traps instr
-            in
-            stack_offset, traps, instr :: body)
+      let stack_offset, traps =
+        Cfg.BasicInstructionList.fold_left block.body ~init:(stack_offset, traps)
+          ~f:(fun (stack_offset, traps) instr ->
+            process_basic cfg ~stack_offset ~traps instr)
       in
-      block.body <- List.rev body;
-      let stack_offset, traps, terminator =
+      let stack_offset, traps =
         process_terminator ~stack_offset ~traps block.terminator
       in
-      block.terminator <- terminator;
       (* non-exceptional successors *)
       Label.Set.iter
         (update_block cfg ~stack_offset ~traps)
@@ -794,14 +780,15 @@ let fundecl :
       { start = Cfg.entry_label cfg;
         body =
           (match prologue_required with
-          | false -> []
+          | false -> Cfg.BasicInstructionList.make_empty ()
           | true ->
-            let dbg = fun_body.dbg in
-            let fdo = Fdo_info.none in
             (* Note: the prologue must come after all `Iname_for_debugger`
                instructions (this is currently not a concern because we do not
                support such instructions). *)
-            [{ (make_instruction state ~desc:Cfg.Prologue) with dbg; fdo }]);
+            let instr = make_instruction state ~desc:Cfg.Prologue in
+            instr.dbg <- fun_body.dbg;
+            instr.fdo <- Fdo_info.none;
+            Cfg.BasicInstructionList.make_single instr);
         terminator =
           copy_instruction_no_reg state fun_body
             ~desc:(Cfg.Always tailrec_label);
@@ -816,7 +803,7 @@ let fundecl :
   State.add_block state ~label:tailrec_label
     ~block:
       { start = tailrec_label;
-        body = [];
+        body = Cfg.BasicInstructionList.make_empty ();
         terminator =
           copy_instruction_no_reg state fun_body ~desc:(Cfg.Always start_label);
         (* See [Cfg.register_predecessors_for_all_blocks] *)

--- a/backend/cfg/eliminate_fallthrough_blocks.ml
+++ b/backend/cfg/eliminate_fallthrough_blocks.ml
@@ -32,7 +32,7 @@ let is_fallthrough_block cfg_with_layout (block : C.basic_block) =
   let cfg = CL.cfg cfg_with_layout in
   if Label.equal cfg.entry_label block.start
      || block.is_trap_handler
-     || List.length block.body > 0
+     || (not (Cfg.BasicInstructionList.is_empty block.body))
      || not (C.is_pure_terminator block.terminator.desc)
   then None
   else

--- a/backend/cfg/extra_debug.ml
+++ b/backend/cfg/extra_debug.ml
@@ -50,17 +50,17 @@ let add cl =
       then prev
       else i.dbg
     in
-    let fdo = Fdo_info.create ~discriminator:i.id ~dbg in
-    dbg, { i with fdo }
+    i.fdo <- Fdo_info.create ~discriminator:i.id ~dbg;
+    dbg
   in
   let cfg = CL.cfg cl in
   let layout = CL.layout cl in
   let update_block prev label =
     let block = Cfg.get_block_exn cfg label in
-    let prev, new_body = List.fold_left_map update_instr prev block.body in
-    block.body <- new_body;
-    let prev, new_terminator = update_instr prev block.terminator in
-    block.terminator <- new_terminator;
+    let prev =
+      Cfg.BasicInstructionList.fold_left ~f:update_instr ~init:prev block.body
+    in
+    let prev = update_instr prev block.terminator in
     prev
   in
   ignore (List.fold_left update_block cfg.fun_dbg layout : Debuginfo.t)

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -168,7 +168,7 @@ let create_empty_block t start ~stack_offset ~traps =
   in
   let block : C.basic_block =
     { start;
-      body = [];
+      body = Cfg.BasicInstructionList.make_empty ();
       terminator;
       exn = None;
       predecessors = Label.Set.empty;
@@ -192,8 +192,6 @@ let register_block t (block : C.basic_block) traps =
     Misc.fatal_errorf "A block with starting label %d is already registered"
       block.start;
   if !C.verbose then Printf.printf "registering block %d\n" block.start;
-  (* Body is constructed in reverse, fix it now: *)
-  block.body <- List.rev block.body;
   (* Update trap stacks of normal successor blocks. *)
   Label.Set.iter
     (fun label -> record_traps t label traps)
@@ -535,13 +533,15 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     t.trap_handlers <- Label.Set.add lbl_handler t.trap_handlers;
     record_traps t lbl_handler traps;
     let desc = C.Pushtrap { lbl_handler } in
-    block.body <- create_instruction t desc ~stack_offset i :: block.body;
+    C.BasicInstructionList.add_end block.body
+      (create_instruction t desc ~stack_offset i);
     let stack_offset = stack_offset + Proc.trap_size_in_bytes in
     let traps = T.push traps lbl_handler in
     create_blocks t i.next block ~stack_offset ~traps
   | Lpoptrap ->
     let desc = C.Poptrap in
-    block.body <- create_instruction t desc ~stack_offset i :: block.body;
+    C.BasicInstructionList.add_end block.body
+      (create_instruction t desc ~stack_offset i);
     let stack_offset = stack_offset - Proc.trap_size_in_bytes in
     if stack_offset < 0
     then Misc.fatal_error "Lpoptrap moves the stack offset below zero";
@@ -557,16 +557,18 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     create_blocks t i.next block ~stack_offset ~traps
   | Lentertrap ->
     (* Must be the first instruction in the block. *)
-    assert (List.compare_length_with block.body 0 = 0);
+    assert (C.BasicInstructionList.is_empty block.body);
     block.is_trap_handler <- true;
     create_blocks t i.next block ~stack_offset ~traps
   | Lprologue ->
     let desc = C.Prologue in
-    block.body <- create_instruction t desc i ~stack_offset :: block.body;
+    C.BasicInstructionList.add_end block.body
+      (create_instruction t desc i ~stack_offset);
     create_blocks t i.next block ~stack_offset ~traps
   | Lreloadretaddr ->
     let desc = C.Reloadretaddr in
-    block.body <- create_instruction t desc i ~stack_offset :: block.body;
+    C.BasicInstructionList.add_end block.body
+      (create_instruction t desc i ~stack_offset);
     create_blocks t i.next block ~stack_offset ~traps
   | Lop mop -> (
     match mop with
@@ -593,7 +595,8 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
       create_blocks t i.next block ~stack_offset ~traps
     | Istackoffset bytes ->
       let desc = to_basic mop in
-      block.body <- create_instruction t desc i ~stack_offset :: block.body;
+      C.BasicInstructionList.add_end block.body
+        (create_instruction t desc i ~stack_offset);
       let stack_offset = stack_offset + bytes in
       create_blocks t i.next block ~stack_offset ~traps
     | Ipoll { return_label = None } ->
@@ -616,7 +619,8 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     | Iopaque | Iprobe _ | Iprobe_is_enabled _ | Ispecific _ | Ibeginregion
     | Iendregion | Iname_for_debugger _ ->
       let desc = to_basic mop in
-      block.body <- create_instruction t desc i ~stack_offset :: block.body;
+      C.BasicInstructionList.add_end block.body
+        (create_instruction t desc i ~stack_offset);
       if Mach.operation_can_raise mop
       then (
         (* Instruction that can raise is always at the end of a block. *)

--- a/backend/cfg/merge_straightline_blocks.ml
+++ b/backend/cfg/merge_straightline_blocks.ml
@@ -69,7 +69,8 @@ let rec merge_blocks (modified : bool) (cfg_with_layout : Cfg_with_layout.t) :
           then (
             assert (Label.equal b1_label (List.hd b2_predecessors));
             (* modify b1 *)
-            b1_block.body <- b1_block.body @ b2_block.body;
+            Cfg.BasicInstructionList.transfer ~to_:b1_block.body
+              ~from:b2_block.body ();
             b1_block.terminator <- b2_block.terminator;
             b1_block.exn <- b2_block.exn;
             b1_block.can_raise <- b2_block.can_raise;

--- a/backend/cfg/tests/check_regalloc_validation.ml
+++ b/backend/cfg/tests/check_regalloc_validation.ml
@@ -70,7 +70,7 @@ module Block = struct
       || Cfg.can_raise_terminator terminator.desc
     in
     { start;
-      body;
+      body = Cfg.BasicInstructionList.of_list body;
       terminator;
       predecessors = Label.Set.empty;
       stack_offset = 0;
@@ -173,7 +173,7 @@ let () =
   in
   Label.Tbl.add cfg.Cfg.blocks (Cfg.entry_label cfg)
     { start = Cfg.entry_label cfg;
-      body = [];
+      body = Cfg.BasicInstructionList.make_empty ();
       exn = None;
       can_raise = false;
       is_trap_handler = false;


### PR DESCRIPTION
This pull request introduces a dedicated type for
the instruction lists of the CFG basic blocks.

The type is abstract and naively implemented with
a list reference; another PR will change the actual
representation of the lists.