### PR TITLE
Long frames in frametable

### DIFF
--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -136,16 +136,13 @@ let get_flags debuginfo =
          not (Debuginfo.is_none d.Debuginfo.alloc_dbg)) dbgs
     then 3 else 2
 
-(* Keep in sync with ocaml/runtime/stack.h *)
-let frame_size_long = 0x7FFF
-
 let is_long n =
   assert (n >= 0);
   (* Long frames must fit in 32-bit integer and
      not truncated upon conversion from int on any target. *)
   if n > 0x3FFF_FFFF then
     raise (Error(Stack_frame_way_too_large n));
-  n >= frame_size_long
+  n >= !Flambda_backend_flags.long_frames_threshold
 
 let record_frame_descr ~label ~frame_size ~live_offset debuginfo =
   assert (frame_size land 3 = 0);
@@ -225,7 +222,7 @@ let emit_frames a =
     a.efa_code_label fd.fd_lbl;
     (* For short format, the size is guaranteed
        to be less than the constant below. *)
-    if fd.fd_long then a.efa_16 frame_size_long;
+    if fd.fd_long then a.efa_16 Flambda_backend_flags.max_long_frames_threshold;
     let emit_16_or_32 =
       if fd.fd_long then emit_32 else a.efa_16
     in

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -137,7 +137,6 @@ let get_flags debuginfo =
     then 3 else 2
 
 (* Keep in sync with ocaml/runtime/stack.h *)
-(* CR gyorsh: if didn't care care about 32-bit, it could be FFFF. *)
 let frame_size_long = 0x7FFF
 
 let is_long n =

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -435,7 +435,7 @@ let reduce_heap_size ~reset =
 
 let report_error ppf = function
   | Stack_frame_too_large n ->
-      Format.fprintf ppf "stack frame too large (%d bytes). \
-                          Use -allow-long-frames compiler flag." n
+    Format.fprintf ppf "stack frame too large (%d bytes). \n\
+                        Use -long-frames compiler flag." n
   | Stack_frame_way_too_large n ->
-    Format.fprintf ppf "stack frame too large (%d bytes)" n
+    Format.fprintf ppf "stack frame too large (%d bytes)." n

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -222,7 +222,10 @@ let emit_frames a =
     a.efa_code_label fd.fd_lbl;
     (* For short format, the size is guaranteed
        to be less than the constant below. *)
-    if fd.fd_long then a.efa_16 Flambda_backend_flags.max_long_frames_threshold;
+    if fd.fd_long then begin
+      a.efa_16 Flambda_backend_flags.max_long_frames_threshold;
+      a.efa_align 4;
+    end;
     let emit_16_or_32 =
       if fd.fd_long then emit_32 else a.efa_16
     in

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -105,6 +105,7 @@ val reduce_heap_size : reset:(unit -> unit) -> unit
 
 type error =
   | Stack_frame_too_large of int
+  | Stack_frame_way_too_large of int
 
 exception Error of error
 val report_error: Format.formatter -> error -> unit

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -62,8 +62,11 @@ let mk_dcheckmach f =
 let mk_disable_poll_insertion f =
   "-disable-poll-insertion", Arg.Unit f, " Do not insert poll points"
 
-let mk_allow_long_frames f =
-  "-allow-long-frames", Arg.Unit f, " Allow stack frames longer than 2^16 bytes"
+let mk_long_frames f =
+  "-long-frames", Arg.Unit f, " Allow stack frames longer than 2^16 bytes"
+
+let mk_no_long_frames f =
+  "-no-long-frames", Arg.Unit f, " Do not allow stack frames longer than 2^16 bytes"
 
 let mk_dump_inlining_paths f =
   "-dump-inlining-paths", Arg.Unit f, " Dump inlining paths when dumping flambda2 terms"
@@ -440,7 +443,8 @@ module type Flambda_backend_options = sig
 
   val disable_poll_insertion : unit -> unit
 
-  val allow_long_frames : unit -> unit
+  val long_frames : unit -> unit
+  val no_long_frames : unit -> unit
 
   val internal_assembler : unit -> unit
 
@@ -515,7 +519,9 @@ struct
     mk_dcheckmach F.dcheckmach;
 
     mk_disable_poll_insertion F.disable_poll_insertion;
-    mk_allow_long_frames F.allow_long_frames;
+
+    mk_long_frames F.long_frames;
+    mk_no_long_frames F.no_long_frames;
 
     mk_internal_assembler F.internal_assembler;
 
@@ -625,8 +631,11 @@ module Flambda_backend_options_impl = struct
   let dcheckmach = set' Flambda_backend_flags.dump_checkmach
 
   let disable_poll_insertion = set' Flambda_backend_flags.disable_poll_insertion
-  let allow_long_frames =
-    set' Flambda_backend_flags.allow_long_frames
+
+  let long_frames = set' Flambda_backend_flags.allow_long_frames
+
+  let no_long_frames =
+    clear' Flambda_backend_flags.allow_long_frames
 
   let internal_assembler = set' Flambda_backend_flags.internal_assembler
 
@@ -826,7 +835,7 @@ module Extra_params = struct
     | "alloc-check" -> set' Flambda_backend_flags.alloc_check
     | "dump-checkmach" -> set' Flambda_backend_flags.dump_checkmach
     | "disable-poll-insertion" -> set' Flambda_backend_flags.disable_poll_insertion
-    | "allow-long-frames" -> set' Flambda_backend_flags.allow_long_frames
+    | "long-frames" -> set' Flambda_backend_flags.allow_long_frames
     | "dasm-comments" -> set' Flambda_backend_flags.dasm_comments
     | "dno-asm-comments" -> clear' Flambda_backend_flags.dasm_comments
     | "gupstream-dwarf" -> set' Debugging.restrict_to_upstream_dwarf

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -62,6 +62,9 @@ let mk_dcheckmach f =
 let mk_disable_poll_insertion f =
   "-disable-poll-insertion", Arg.Unit f, " Do not insert poll points"
 
+let mk_allow_long_frames f =
+  "-allow-long-frames", Arg.Unit f, " Allow stack frames longer than 2^16 bytes"
+
 let mk_dump_inlining_paths f =
   "-dump-inlining-paths", Arg.Unit f, " Dump inlining paths when dumping flambda2 terms"
 
@@ -436,6 +439,9 @@ module type Flambda_backend_options = sig
   val dcheckmach : unit -> unit
 
   val disable_poll_insertion : unit -> unit
+
+  val allow_long_frames : unit -> unit
+
   val internal_assembler : unit -> unit
 
   val flambda2_join_points : unit -> unit
@@ -509,6 +515,7 @@ struct
     mk_dcheckmach F.dcheckmach;
 
     mk_disable_poll_insertion F.disable_poll_insertion;
+    mk_allow_long_frames F.allow_long_frames;
 
     mk_internal_assembler F.internal_assembler;
 
@@ -618,6 +625,8 @@ module Flambda_backend_options_impl = struct
   let dcheckmach = set' Flambda_backend_flags.dump_checkmach
 
   let disable_poll_insertion = set' Flambda_backend_flags.disable_poll_insertion
+  let allow_long_frames =
+    set' Flambda_backend_flags.allow_long_frames
 
   let internal_assembler = set' Flambda_backend_flags.internal_assembler
 
@@ -817,6 +826,7 @@ module Extra_params = struct
     | "alloc-check" -> set' Flambda_backend_flags.alloc_check
     | "dump-checkmach" -> set' Flambda_backend_flags.dump_checkmach
     | "disable-poll-insertion" -> set' Flambda_backend_flags.disable_poll_insertion
+    | "allow-long-frames" -> set' Flambda_backend_flags.allow_long_frames
     | "dasm-comments" -> set' Flambda_backend_flags.dasm_comments
     | "dno-asm-comments" -> clear' Flambda_backend_flags.dasm_comments
     | "gupstream-dwarf" -> set' Debugging.restrict_to_upstream_dwarf

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -434,7 +434,7 @@ let set_long_frames_threshold n =
     raise
       (Arg.Bad
          (Printf.sprintf "Long frames threshold too big: 0x%x, \
-                          must be less of equal to 0x%x" n
+                          must be less or equal to 0x%x" n
             Flambda_backend_flags.max_long_frames_threshold));
   Flambda_backend_flags.long_frames_threshold := n
 

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -37,6 +37,7 @@ module type Flambda_backend_options = sig
   val dcheckmach : unit -> unit
 
   val disable_poll_insertion : unit -> unit
+  val allow_long_frames : unit -> unit
 
   val internal_assembler : unit -> unit
 

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -37,7 +37,8 @@ module type Flambda_backend_options = sig
   val dcheckmach : unit -> unit
 
   val disable_poll_insertion : unit -> unit
-  val allow_long_frames : unit -> unit
+  val long_frames : unit -> unit
+  val no_long_frames : unit -> unit
 
   val internal_assembler : unit -> unit
 

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -39,6 +39,7 @@ module type Flambda_backend_options = sig
   val disable_poll_insertion : unit -> unit
   val long_frames : unit -> unit
   val no_long_frames : unit -> unit
+  val long_frames_threshold : int -> unit
 
   val internal_assembler : unit -> unit
 

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -28,6 +28,8 @@ let alloc_check = ref false             (* -alloc-check *)
 let dump_checkmach = ref false          (* -dcheckmach *)
 
 let disable_poll_insertion = ref false  (* -disable-poll-insertion *)
+let allow_long_frames = ref false        (* -allow-long-frames *)
+
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3
 type 'a or_default = Set of 'a | Default

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -29,6 +29,10 @@ let dump_checkmach = ref false          (* -dcheckmach *)
 
 let disable_poll_insertion = ref false  (* -disable-poll-insertion *)
 let allow_long_frames = ref true        (* -no-long-frames *)
+(* Keep the value of [max_long_frames_threshold] in sync with LONG_FRAME_MARKER
+   in ocaml/runtime/roots_nat.c *)
+let max_long_frames_threshold = 0x7FFF
+let long_frames_threshold = ref max_long_frames_threshold (* -long-frames-debug-threshold n *)
 
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -28,7 +28,7 @@ let alloc_check = ref false             (* -alloc-check *)
 let dump_checkmach = ref false          (* -dcheckmach *)
 
 let disable_poll_insertion = ref false  (* -disable-poll-insertion *)
-let allow_long_frames = ref false        (* -allow-long-frames *)
+let allow_long_frames = ref true        (* -no-long-frames *)
 
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -32,7 +32,7 @@ let allow_long_frames = ref true        (* -no-long-frames *)
 (* Keep the value of [max_long_frames_threshold] in sync with LONG_FRAME_MARKER
    in ocaml/runtime/roots_nat.c *)
 let max_long_frames_threshold = 0x7FFF
-let long_frames_threshold = ref max_long_frames_threshold (* -long-frames-debug-threshold n *)
+let long_frames_threshold = ref max_long_frames_threshold (* -debug-long-frames-threshold n *)
 
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -30,6 +30,8 @@ val dump_checkmach : bool ref
 
 val disable_poll_insertion : bool ref
 val allow_long_frames : bool ref
+val max_long_frames_threshold : int
+val long_frames_threshold : int ref
 
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -29,6 +29,7 @@ val alloc_check : bool ref
 val dump_checkmach : bool ref
 
 val disable_poll_insertion : bool ref
+val allow_long_frames : bool ref
 
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3

--- a/dune-project
+++ b/dune-project
@@ -16,3 +16,4 @@
 (package
   (name ocaml_runtime_stdlib)
 )
+

--- a/ocaml/runtime/backtrace_nat.c
+++ b/ocaml/runtime/backtrace_nat.c
@@ -47,7 +47,7 @@ frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
     /* Skip to next frame */
     if (d->frame_size != 0xFFFF) {
       /* Regular frame, update sp/pc and return the frame descriptor */
-      *sp += (d->frame_size & 0xFFFC);
+      *sp += (get_frame_size(d) & 0xFFFFFFFC);
       *pc = Saved_return_address(*sp);
 #ifdef Mask_already_scanned
       *pc = Mask_already_scanned(*pc);
@@ -164,17 +164,19 @@ static debuginfo debuginfo_extract(frame_descr* d, int alloc_idx)
 {
   unsigned char* infoptr;
   uint32_t debuginfo_offset;
+  uint32_t frame_size;
 
   /* The special frames marking the top of an ML stack chunk are never
      returned by caml_next_frame_descriptor, so should never reach here. */
-  CAMLassert(d->frame_size != 0xffff);
+  CAMLassert(d->frame_size != 0xFFFF);
+  frame_size = get_frame_size(d);
 
-  if ((d->frame_size & 1) == 0) {
+  if ((frame_size & 1) == 0) {
     return NULL;
   }
   /* Recover debugging info */
-  infoptr = (unsigned char*)&d->live_ofs[d->num_live];
-  if (d->frame_size & 2) {
+  infoptr = get_end_of_live_ofs(d);
+  if (frame_size & 2) {
     CAMLassert(alloc_idx == -1 || (0 <= alloc_idx && alloc_idx < *infoptr));
     /* skip alloc_lengths */
     infoptr += *infoptr + 1;

--- a/ocaml/runtime/caml/stack.h
+++ b/ocaml/runtime/caml/stack.h
@@ -105,7 +105,8 @@ typedef struct {
 
 typedef struct {
   uintnat retaddr;
-  unsigned short marker;        /* frame_size_long */
+  unsigned short marker;        /* LONG_FRAME_MARKER */
+  unsigned short _pad;  /* Ensure frame_size is 4-byte aligned */
   uint32_t frame_size;
   uint32_t num_live;
   uint32_t live_ofs[1 /* num_live */];

--- a/ocaml/runtime/caml/stack.h
+++ b/ocaml/runtime/caml/stack.h
@@ -86,7 +86,6 @@ struct caml_context {
 };
 
 /* Structure of frame descriptors */
-
 typedef struct {
   uintnat retaddr;
   unsigned short frame_size;
@@ -103,6 +102,28 @@ typedef struct {
     Debug info is stored as relative offsets to debuginfo structures.
     num_debug is num_alloc if frame_size & 2, otherwise 1. */
 } frame_descr;
+
+typedef struct {
+  uintnat retaddr;
+  unsigned short marker;        /* frame_size_long */
+  uint32_t frame_size;
+  uint32_t num_live;
+  uint32_t live_ofs[1 /* num_live */];
+  /*
+    If frame_size & 2, then allocation info follows:
+  unsigned char num_allocs;
+  unsigned char alloc_lengths[num_alloc];
+
+    If frame_size & 1, then debug info follows:
+  uint32_t debug_info_offset[num_debug];
+
+    Debug info is stored as relative offsets to debuginfo structures.
+    num_debug is num_alloc if frame_size & 2, otherwise 1. */
+} frame_descr_long;
+
+/* Helpers for long frames */
+uint32_t get_frame_size(frame_descr *);
+unsigned char * get_end_of_live_ofs (frame_descr *d);
 
 /* Allocation lengths are encoded as 0-255, giving sizes 1-256 */
 #define Wosize_encoded_alloc_len(n) ((uintnat)(n) + 1)

--- a/ocaml/runtime/roots_nat.c
+++ b/ocaml/runtime/roots_nat.c
@@ -81,11 +81,11 @@ static link* frametables_list_tail(link *list) {
 }
 
 /* Special marker instead of frame_size for frame_descr in long format */
-static uint32_t LONG_FRAME = 0x7FFF;
+static uint32_t LONG_FRAME_MARKER = 0x7FFF;
 
 uint32_t get_frame_size(frame_descr *d) {
   CAMLassert(d && d->frame_size != 0xFFFF);
-  if (d->frame_size == LONG_FRAME) {
+  if (d->frame_size == LONG_FRAME_MARKER) {
     /* Handle long frames */
     frame_descr_long *dl = (frame_descr_long *)d;
     return (dl->frame_size);
@@ -97,7 +97,7 @@ uint32_t get_frame_size(frame_descr *d) {
 /* Skip to end of live_ofs */
 unsigned char * get_end_of_live_ofs (frame_descr *d) {
   CAMLassert(d && d->frame_size != 0xFFFF);
-  if (d->frame_size == LONG_FRAME) {
+  if (d->frame_size == LONG_FRAME_MARKER) {
     /* Handle long frames */
     frame_descr_long *dl = (frame_descr_long *)d;
     return ((unsigned char*)&dl->live_ofs[dl->num_live]);
@@ -651,7 +651,7 @@ void caml_do_local_roots_nat(scanning_action maj, scanning_action min,
       }
       if (d->frame_size != 0xFFFF) {
         /* Scan the roots in this frame */
-        if (d->frame_size == LONG_FRAME) {
+        if (d->frame_size == LONG_FRAME_MARKER) {
           /* Handle long frames */
           frame_descr_long *dl = (frame_descr_long *)d;
           uint32_t * p;

--- a/ocaml/runtime/roots_nat.c
+++ b/ocaml/runtime/roots_nat.c
@@ -84,8 +84,6 @@ static link* frametables_list_tail(link *list) {
 static uint32_t LONG_FRAME = 0x7FFF;
 
 uint32_t get_frame_size(frame_descr *d) {
-  /* CR gyorsh: where is the special frame size 0xFFFF emitted that marks the top of
-   an ML stack chunk? */
   CAMLassert(d && d->frame_size != 0xFFFF);
   if (d->frame_size == LONG_FRAME) {
     /* Handle long frames */

--- a/ocaml/runtime/signals_nat.c
+++ b/ocaml/runtime/signals_nat.c
@@ -72,12 +72,13 @@ void caml_garbage_collection(void)
       h = (h + 1) & caml_frame_descriptors_mask;
     }
     /* Must be an allocation frame */
-    CAMLassert(d && d->frame_size != 0xFFFF && (d->frame_size & 2));
+    CAMLassert(d && d->frame_size != 0xFFFF &&
+               (get_frame_size(d) & 2));
   }
 
   /* Compute the total allocation size at this point,
      including allocations combined by Comballoc */
-  alloc_len = (unsigned char*)(&d->live_ofs[d->num_live]);
+  alloc_len = get_end_of_live_ofs(d);
   nallocs = *alloc_len++;
 
   if (nallocs == 0) {

--- a/tests/backend/frame-too-long/dune
+++ b/tests/backend/frame-too-long/dune
@@ -4,10 +4,15 @@
  (ocamlopt_flags (:standard -linscan -Oclassic -debug-long-frames-threshold 100)))
 
 (rule
+ (enabled_if (= %{context_name} "main"))
+ (target t.output)
+ (deps t.exe)
+ (action (with-outputs-to t.output (run ./t.exe))))
+
+(rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
- (deps t.exe)
- (action (run ./t.exe)))
+ (action (diff t.expected t.output)))
 
 ;; t.ml was created using cinaps
 ;; (cinaps

--- a/tests/backend/frame-too-long/dune
+++ b/tests/backend/frame-too-long/dune
@@ -1,0 +1,14 @@
+(executable
+ (name t)
+ (modules t)
+ (ocamlopt_flags (:standard -linscan -Oclassic -debug-long-frames-threshold 100)))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps t.exe)
+ (action (run ./t.exe)))
+
+;; t.ml was created using cinaps
+;; (cinaps
+;;  (files t.ml))

--- a/tests/backend/frame-too-long/t.expected
+++ b/tests/backend/frame-too-long/t.expected
@@ -1,0 +1,1 @@
+i=10000 len=2 name=Raised at T.break in file "tests/backend/frame-too-long/t.ml", line 5, characters 2-15

--- a/tests/backend/frame-too-long/t.ml
+++ b/tests/backend/frame-too-long/t.ml
@@ -1,0 +1,86 @@
+let[@inline never] make n = List.init n Fun.id
+
+exception Exn of int
+let[@inline never] break n =
+  raise (Exn n)
+
+let[@inline never] check_backtrace n =
+  try
+    break n
+  with
+  | Exn i ->
+    let raw_backtrace = Printexc.get_raw_backtrace () in
+    let len = Printexc.raw_backtrace_length raw_backtrace in
+    assert (len > 0);
+    let slot = Printexc.get_raw_backtrace_slot raw_backtrace 0
+               |> Printexc.convert_raw_backtrace_slot  in
+    let name = Printexc.Slot.format 0 slot |> Option.get in
+    Printf.printf "i=%d len=%d name=%s\n" i len name;
+    ()
+
+let test n =
+  let l = make n in
+  (*$
+    for i = 1 to Sys.opaque_identity 20 do
+      Printf.printf "let a%d = Sys.opaque_identity 1 in\n" i
+    done;
+  *)let a1 = Sys.opaque_identity 1 in
+let a2 = Sys.opaque_identity 1 in
+let a3 = Sys.opaque_identity 1 in
+let a4 = Sys.opaque_identity 1 in
+let a5 = Sys.opaque_identity 1 in
+let a6 = Sys.opaque_identity 1 in
+let a7 = Sys.opaque_identity 1 in
+let a8 = Sys.opaque_identity 1 in
+let a9 = Sys.opaque_identity 1 in
+let a10 = Sys.opaque_identity 1 in
+let a11 = Sys.opaque_identity 1 in
+let a12 = Sys.opaque_identity 1 in
+let a13 = Sys.opaque_identity 1 in
+let a14 = Sys.opaque_identity 1 in
+let a15 = Sys.opaque_identity 1 in
+let a16 = Sys.opaque_identity 1 in
+let a17 = Sys.opaque_identity 1 in
+let a18 = Sys.opaque_identity 1 in
+let a19 = Sys.opaque_identity 1 in
+let a20 = Sys.opaque_identity 1 in
+(*$*)
+  check_backtrace n;
+  let l = make (List.length l) in
+  Gc.compact ();
+  [
+    (*$
+    for i = 1 to Sys.opaque_identity 20 do
+      Printf.printf "a%d;\n" i
+    done;
+  *)a1;
+a2;
+a3;
+a4;
+a5;
+a6;
+a7;
+a8;
+a9;
+a10;
+a11;
+a12;
+a13;
+a14;
+a15;
+a16;
+a17;
+a18;
+a19;
+a20;
+(*$*)
+  ]@l
+  |> Sys.opaque_identity
+
+
+let () =
+  Printexc.record_backtrace true;
+  10_000
+  |> Sys.opaque_identity
+  |> test
+  |> ignore


### PR DESCRIPTION
Current frametable format restricts stack frame size to 16 bit for compactness. In some corner cases (e.g., owl library's autogenerated file) when compiling with `-linscan`, this limit can be exceeded (e.g., see #791).  Usually the right way to handle this error is to restructure the code, but sometimes it is hard to do quickly and a temporary workaround is needed. 
This PR proposes a way to emit long frametable enteries as an extension of the current format. 
Add a compiler flag -allow-long-frames to turn on the new functionality.
