### PR TITLE
Speed up register allocation by permanently spilling registers (Port #11102)

### DIFF
--- a/backend/coloring.ml
+++ b/backend/coloring.ml
@@ -198,6 +198,9 @@ let allocate_registers() =
           best_slot := n
         end
       done;
+      (* Mark this register as spilled so that we don't waste time trying
+         to put in in a register if we have to redo regalloc due to Reload *)
+      reg.spill <- true;
       (* Found one? *)
       if !best_slot >= 0 then
         reg.loc <- Stack(Local !best_slot)


### PR DESCRIPTION
port [ocaml/ocaml##11102](https://github.com/ocaml/ocaml/pull/11102)