### PR TITLE
Define separate dune profiles for boot and main build stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ define dune_boot_context
 (context (default
   (name default)
   ; CR sdolan: profile dev might be faster, but the compiler currently fails to build in dev.
-  (profile release)))
+  (profile boot)))
 endef
 
 define dune_runtime_stdlib_context
 (lang dune 2.8)
 (context (default
   (name runtime_stdlib)
-  (profile release)
+  (profile main)
   (paths
     (PATH ("$(CURDIR)/_build/_bootinstall/bin" :standard))
     (OCAMLLIB ("$(CURDIR)/_build/_bootinstall/lib/ocaml")))
@@ -40,7 +40,7 @@ define dune_main_context
 (lang dune 2.8)
 (context (default
   (name main)
-  (profile release)
+  (profile main)
   (paths
     (PATH ("$(CURDIR)/_build/_bootinstall/bin" :standard))
     (OCAMLLIB ("$(CURDIR)/_build/install/runtime_stdlib/lib/ocaml_runtime_stdlib")))

--- a/dune
+++ b/dune
@@ -11,7 +11,10 @@
 ; set warning as error in release profile
 
 (env
- (release
+ (main
+  (flags
+   (:standard -warn-error +A)))
+ (boot
   (flags
    (:standard -warn-error +A))))
 


### PR DESCRIPTION
This change will allow us to build stdlib (and the compiler itself) using new flambda-backend flags that are not yet available in the upstream compiler.  The profiles can also have `c_flags` field if we want to build C code with different options in the second stage. I didn't make a separe profile for `runtime_stdlib` dune workspace to avoid duplication for now.