### PR TITLE
Fix .cmt for included signatures

### DIFF
--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -1481,8 +1481,8 @@ and transl_signature env sg =
           else
             Tincl_structure, extract_sig env smty.pmty_loc mty
         in
-        let tsg, newenv = Env.enter_signature ~scope sg env in
-        List.iter (Signature_names.check_sig_item names item.psig_loc) tsg;
+        let sg, newenv = Env.enter_signature ~scope sg env in
+        List.iter (Signature_names.check_sig_item names item.psig_loc) sg;
         let incl =
           { incl_mod = tmty;
             incl_type = sg;
@@ -1491,7 +1491,7 @@ and transl_signature env sg =
             incl_loc = sloc;
           }
         in
-        mksig (Tsig_include incl) env loc, tsg, newenv
+        mksig (Tsig_include incl) env loc, sg, newenv
     | Psig_class cl ->
         let (classes, newenv) = Typeclass.class_descriptions env cl in
         List.iter (fun cls ->


### PR DESCRIPTION
Fix a bug introduced with `include functor` that breaks odoc.