### PR TITLE
Support in to_cmm for substituting and duplicating primitives

### DIFF
--- a/middle_end/flambda2/terms/effects_and_coeffects.ml
+++ b/middle_end/flambda2/terms/effects_and_coeffects.ml
@@ -12,21 +12,28 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = Effects.t * Coeffects.t
+type t = Effects.t * Coeffects.t * Placement.t
 
-let [@ocamlformat "disable"] print fmt (eff, coeff) =
-  Format.fprintf fmt "%a * %a" Effects.print eff Coeffects.print coeff
+let [@ocamlformat "disable"] print fmt (eff, coeff, dup) =
+  Format.fprintf fmt "%a * %a * %a" Effects.print eff Coeffects.print coeff Placement.print dup
 
-let compare (e1, c1) (e2, c2) =
-  match Effects.compare e1 e2 with 0 -> Coeffects.compare c1 c2 | res -> res
+let compare (e1, c1, d1) (e2, c2, d2) =
+  match Effects.compare e1 e2 with
+  | 0 -> (
+    match Coeffects.compare c1 c2 with
+    | 0 -> Placement.compare d1 d2
+    | res -> res)
+  | res -> res
 
 (* Some useful constants *)
-let pure : t = No_effects, No_coeffects
+let pure : t = No_effects, No_coeffects, Strict
 
-let all : t = Arbitrary_effects, Has_coeffects
+let pure_duplicatable : t = No_effects, No_coeffects, Delay
 
-let read : t = No_effects, Has_coeffects
+let all : t = Arbitrary_effects, Has_coeffects, Strict
+
+let read : t = No_effects, Has_coeffects, Strict
 
 (* Joining effects and coeffects *)
-let join (eff1, coeff1) (eff2, coeff2) =
-  Effects.join eff1 eff2, Coeffects.join coeff1 coeff2
+let join (eff1, coeff1, dup1) (eff2, coeff2, dup2) =
+  Effects.join eff1 eff2, Coeffects.join coeff1 coeff2, Placement.join dup1 dup2

--- a/middle_end/flambda2/terms/effects_and_coeffects.ml
+++ b/middle_end/flambda2/terms/effects_and_coeffects.ml
@@ -29,12 +29,12 @@ let compare (e1, c1, d1) (e2, c2, d2) =
 (* Some useful constants *)
 let pure : t = No_effects, No_coeffects, Strict
 
-let pure_duplicatable : t = No_effects, No_coeffects, Delay
+let pure_can_be_duplicated : t = No_effects, No_coeffects, Delay
 
 let all : t = Arbitrary_effects, Has_coeffects, Strict
 
 let read : t = No_effects, Has_coeffects, Strict
 
-(* Joining effects and coeffects *)
+(* Joining effects, coeffects and placement *)
 let join (eff1, coeff1, dup1) (eff2, coeff2, dup2) =
   Effects.join eff1 eff2, Coeffects.join coeff1 coeff2, Placement.join dup1 dup2

--- a/middle_end/flambda2/terms/effects_and_coeffects.ml
+++ b/middle_end/flambda2/terms/effects_and_coeffects.ml
@@ -14,8 +14,9 @@
 
 type t = Effects.t * Coeffects.t * Placement.t
 
-let [@ocamlformat "disable"] print fmt (eff, coeff, dup) =
-  Format.fprintf fmt "%a * %a * %a" Effects.print eff Coeffects.print coeff Placement.print dup
+let print fmt (eff, coeff, dup) =
+  Format.fprintf fmt "%a * %a * %a" Effects.print eff Coeffects.print coeff
+    Placement.print dup
 
 let compare (e1, c1, d1) (e2, c2, d2) =
   match Effects.compare e1 e2 with

--- a/middle_end/flambda2/terms/effects_and_coeffects.mli
+++ b/middle_end/flambda2/terms/effects_and_coeffects.mli
@@ -12,9 +12,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Effects and coeffects *)
+(* Effects, coeffects and placements *)
 
-(** A pair of an effect and a coeffect. *)
+(** A triple of an effect, a coeffect, and a placement. *)
 type t = Effects.t * Coeffects.t * Placement.t
 
 (** Print *)
@@ -23,21 +23,23 @@ val print : Format.formatter -> t -> unit
 (** Comparison. *)
 val compare : t -> t -> int
 
-(** The value stating that no effects of coeffects take place. This is exactly
-    [No_effects, No_coeffects, Strict]. *)
+(** The value stating that no effects or coeffects take place, with a strict
+    placement. This is exactly [No_effects, No_coeffects, Strict]. *)
 val pure : t
 
-(** The value stating that no effects of coeffects take place. This is exactly
+(** The value stating that no effects of coeffects take place, and that the
+    expression can be moved and duplicated if needed. This is exactly
     [No_effects, No_coeffects, Delay]. *)
-val pure_duplicatable : t
+val pure_can_be_duplicated : t
 
-(** The value stating that any effects and/or coeffects may take place. This is
-    exactly [Arbitrary_effects, Has_coeffects, Strict]. *)
+(** The value stating that any effects and/or coeffects may take place (with
+    strict placement). This is exactly [Arbitrary_effects, Has_coeffects,
+    Strict]. *)
 val all : t
 
-(** The value stating that a read (i.e only a coeffect) takes place. This is
-    [No_effects, Has_coeffects, Strict]. *)
+(** The value stating that a read (i.e only a coeffect) takes place (with strict
+    placement). This is [No_effects, Has_coeffects, Strict]. *)
 val read : t
 
-(** Join two effects and coeffects. *)
+(** Join two effects, coeffects and placements. *)
 val join : t -> t -> t

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -282,7 +282,7 @@ let reading_from_a_block mutable_or_immutable =
     | Immutable | Immutable_unique -> Coeffects.No_coeffects
     | Mutable -> Coeffects.Has_coeffects
   in
-  effects, coeffects
+  effects, coeffects, Placement.Strict
 
 let reading_from_an_array (array_kind : Array_kind.t)
     (mutable_or_immutable : Mutability.t) =
@@ -294,14 +294,14 @@ let reading_from_an_array (array_kind : Array_kind.t)
     | Immutable | Immutable_unique -> Coeffects.No_coeffects
     | Mutable -> Coeffects.Has_coeffects
   in
-  effects, coeffects
+  effects, coeffects, Placement.Strict
 
 let reading_from_a_string_or_bigstring mutable_or_immutable =
   reading_from_a_block mutable_or_immutable
 
 let writing_to_a_block =
   let effects = effects_of_operation Writing in
-  effects, Coeffects.No_coeffects
+  effects, Coeffects.No_coeffects, Placement.Strict
 
 let writing_to_an_array = writing_to_a_block
 
@@ -470,10 +470,12 @@ end
 let reading_from_a_bigarray kind =
   match (kind : Bigarray_kind.t) with
   | Complex32 | Complex64 ->
-    Effects.Only_generative_effects Immutable, Coeffects.Has_coeffects
+    ( Effects.Only_generative_effects Immutable,
+      Coeffects.Has_coeffects,
+      Placement.Strict )
   | Float32 | Float64 | Sint8 | Uint8 | Sint16 | Uint16 | Int32 | Int64
   | Int_width_int | Targetint_width_int ->
-    Effects.No_effects, Coeffects.Has_coeffects
+    Effects.No_effects, Coeffects.Has_coeffects, Placement.Strict
 
 (* The bound checks are taken care of outside the array primitive (using an
    explicit test and switch in the flambda code, see
@@ -486,7 +488,7 @@ let writing_to_a_bigarray kind =
     (* Technically, the write of a complex generates read of fields from the
        given complex, but since those reads are immutable, there is no
        observable coeffect. *) ->
-    Effects.Arbitrary_effects, Coeffects.No_coeffects
+    Effects.Arbitrary_effects, Coeffects.No_coeffects, Placement.Strict
 
 let bigarray_index_kind = K.value
 
@@ -613,15 +615,19 @@ let result_kind_of_nullary_primitive p : result_kind =
 
 let effects_and_coeffects_of_nullary_primitive p =
   match p with
-  | Invalid _ -> Effects.Arbitrary_effects, Coeffects.Has_coeffects
-  | Optimised_out _ -> Effects.No_effects, Coeffects.No_coeffects
+  | Invalid _ ->
+    Effects.Arbitrary_effects, Coeffects.Has_coeffects, Placement.Strict
+  | Optimised_out _ ->
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
   | Probe_is_enabled _ ->
     (* This doesn't really have effects, but we want to make sure it never gets
        moved around. *)
-    Effects.Arbitrary_effects, Coeffects.Has_coeffects
+    Effects.Arbitrary_effects, Coeffects.Has_coeffects, Placement.Strict
   | Begin_region ->
     (* Ensure these don't get moved, but allow them to be deleted. *)
-    Effects.Only_generative_effects Mutable, Coeffects.Has_coeffects
+    ( Effects.Only_generative_effects Mutable,
+      Coeffects.Has_coeffects,
+      Placement.Strict )
 
 let nullary_classify_for_printing p =
   match p with
@@ -899,7 +905,8 @@ let effects_and_coeffects_of_unary_primitive p =
     | Immutable ->
       (* [Obj.truncate] has now been removed. *)
       ( Effects.Only_generative_effects destination_mutability,
-        Coeffects.No_coeffects )
+        Coeffects.No_coeffects,
+        Placement.Strict )
     | Immutable_unique ->
       (* CR vlaviron: this should never occur, but it's hard to express it
          without duplicating the mutability type
@@ -908,24 +915,31 @@ let effects_and_coeffects_of_unary_primitive p =
          avoid confusion in the future. It could maybe be a submodule of
          [Mutability]. *)
       ( Effects.Only_generative_effects destination_mutability,
-        Coeffects.No_coeffects )
+        Coeffects.No_coeffects,
+        Placement.Strict )
     | Mutable ->
       ( Effects.Only_generative_effects destination_mutability,
-        Coeffects.Has_coeffects ))
+        Coeffects.Has_coeffects,
+        Placement.Strict ))
   | Duplicate_block { kind = _ } ->
     (* We have to assume that the fields might be mutable. (This information
        isn't currently propagated from [Lambda].) *)
-    Effects.Only_generative_effects Mutable, Coeffects.Has_coeffects
-  | Is_int _ -> Effects.No_effects, Coeffects.No_coeffects
+    ( Effects.Only_generative_effects Mutable,
+      Coeffects.Has_coeffects,
+      Placement.Strict )
+  | Is_int _ -> Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
   | Get_tag ->
     (* [Obj.truncate] has now been removed. *)
-    Effects.No_effects, Coeffects.No_coeffects
-  | String_length _ -> Effects.No_effects, Coeffects.No_coeffects
-  | Int_as_pointer -> Effects.No_effects, Coeffects.No_coeffects
-  | Opaque_identity _ -> Effects.Arbitrary_effects, Coeffects.Has_coeffects
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
+  | String_length _ ->
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
+  | Int_as_pointer ->
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
+  | Opaque_identity _ ->
+    Effects.Arbitrary_effects, Coeffects.Has_coeffects, Placement.Strict
   | Int_arith (_, (Neg | Swap_byte_endianness))
   | Num_conv _ | Boolean_not | Reinterpret_int64_as_float ->
-    Effects.No_effects, Coeffects.No_coeffects
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
   | Float_arith (Abs | Neg) ->
     (* Float operations are not really pure since they actually access the
        globally mutable rounding mode, which can be changed (but only from C
@@ -938,11 +952,11 @@ let effects_and_coeffects_of_unary_primitive p =
        (e.g. a call to a c stub that changes the rounding mode). See also the
        comment in binary_primitive_eligible_for_cse. *)
     if Flambda_features.float_const_prop ()
-    then Effects.No_effects, Coeffects.No_coeffects
-    else Effects.No_effects, Coeffects.Has_coeffects
+    then Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
+    else Effects.No_effects, Coeffects.Has_coeffects, Placement.Strict
   (* Since Obj.truncate has been deprecated, array_length should have no
      observable effect *)
-  | Array_length -> Effects.No_effects, Coeffects.No_coeffects
+  | Array_length -> Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
   | Bigarray_length { dimension = _ } ->
     (* This is pretty much a direct access to a field of the bigarray, different
        from reading one of the values actually stored inside the array, hence
@@ -950,29 +964,35 @@ let effects_and_coeffects_of_unary_primitive p =
        Block_load). *)
     reading_from_a_block Mutable
   | Unbox_number _ | Untag_immediate ->
-    Effects.No_effects, Coeffects.No_coeffects
-  | Tag_immediate -> Effects.No_effects, Coeffects.No_coeffects
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
+  | Tag_immediate ->
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
   | Box_number (_, alloc_mode) ->
+    (* Ensure boxing operations for numbers are inlined/substituted in to_cmm *)
+    let placement : Placement.t =
+      if Flambda_features.classic_mode () then Delay else Strict
+    in
     let coeffects : Coeffects.t =
       match alloc_mode with
       | Heap -> Coeffects.No_coeffects
       | Local _ -> Coeffects.Has_coeffects
     in
-    Effects.Only_generative_effects Immutable, coeffects
+    Effects.Only_generative_effects Immutable, coeffects, placement
   | Project_function_slot _ | Project_value_slot _ ->
-    Effects.No_effects, Coeffects.No_coeffects
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Delay
   | Is_boxed_float | Is_flat_float_array ->
     (* Tags on heap blocks are immutable. *)
-    Effects.No_effects, Coeffects.No_coeffects
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
   | End_region ->
     (* These can't be [Only_generative_effects] or the primitives would get
        deleted without regard to prior uses of the region. Instead there are
        special cases in [Simplify_let_expr] and [Expr_builder] for this
        primitive. *)
-    Effects.Arbitrary_effects, Coeffects.Has_coeffects
+    Effects.Arbitrary_effects, Coeffects.Has_coeffects, Placement.Strict
   | Obj_dup ->
     ( Effects.Only_generative_effects Mutable (* Mutable is conservative *),
-      Coeffects.Has_coeffects )
+      Coeffects.Has_coeffects,
+      Placement.Strict )
 
 let unary_classify_for_printing p =
   match p with
@@ -1238,21 +1258,21 @@ let effects_and_coeffects_of_binary_primitive p =
     reading_from_a_string_or_bigstring Immutable
   | String_or_bigstring_load ((Bytes | Bigstring), _) ->
     reading_from_a_string_or_bigstring Mutable
-  | Phys_equal _ -> Effects.No_effects, Coeffects.No_coeffects
+  | Phys_equal _ -> Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
   | Int_arith (_kind, (Add | Sub | Mul | Div | Mod | And | Or | Xor)) ->
-    Effects.No_effects, Coeffects.No_coeffects
-  | Int_shift _ -> Effects.No_effects, Coeffects.No_coeffects
-  | Int_comp _ -> Effects.No_effects, Coeffects.No_coeffects
+    Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
+  | Int_shift _ -> Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
+  | Int_comp _ -> Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
   | Float_arith (Add | Sub | Mul | Div) ->
     (* See comments for Unary Float_arith *)
     if Flambda_features.float_const_prop ()
-    then Effects.No_effects, Coeffects.No_coeffects
-    else Effects.No_effects, Coeffects.Has_coeffects
+    then Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
+    else Effects.No_effects, Coeffects.Has_coeffects, Placement.Strict
   | Float_comp _ ->
     (* See comments for Unary Float_arith *)
     if Flambda_features.float_const_prop ()
-    then Effects.No_effects, Coeffects.No_coeffects
-    else Effects.No_effects, Coeffects.Has_coeffects
+    then Effects.No_effects, Coeffects.No_coeffects, Placement.Strict
+    else Effects.No_effects, Coeffects.Has_coeffects, Placement.Strict
 
 let binary_classify_for_printing p =
   match p with
@@ -1490,12 +1510,12 @@ let effects_and_coeffects_of_variadic_primitive p ~args =
       | Local _ -> Coeffects.Has_coeffects
     in
     if List.length args >= 1
-    then Effects.Only_generative_effects mut, coeffects
+    then Effects.Only_generative_effects mut, coeffects, Placement.Strict
     else
       (* Zero-sized blocks and arrays are immutable and statically allocated,
          However, we currently only lift primitives that have *exactly*
          generative effects. *)
-      Effects.Only_generative_effects Immutable, coeffects
+      Effects.Only_generative_effects Immutable, coeffects, Placement.Strict
 
 let variadic_classify_for_printing p =
   match p with Make_block _ | Make_array _ -> Constructive
@@ -1767,20 +1787,21 @@ let effects_and_coeffects (t : t) =
 
 let no_effects_or_coeffects t =
   match effects_and_coeffects t with
-  | No_effects, No_coeffects -> true
+  | No_effects, No_coeffects, _ -> true
   | ( (No_effects | Only_generative_effects _ | Arbitrary_effects),
-      (No_coeffects | Has_coeffects) ) ->
+      (No_coeffects | Has_coeffects),
+      _ ) ->
     false
 
 let at_most_generative_effects t =
   match effects_and_coeffects t with
-  | (No_effects | Only_generative_effects _), _ -> true
-  | Arbitrary_effects, _ -> false
+  | (No_effects | Only_generative_effects _), _, _ -> true
+  | Arbitrary_effects, _, _ -> false
 
 let only_generative_effects t =
   match effects_and_coeffects t with
-  | Only_generative_effects _, _ -> true
-  | (No_effects | Arbitrary_effects), _ -> false
+  | Only_generative_effects _, _, _ -> true
+  | (No_effects | Arbitrary_effects), _, _ -> false
 
 module Eligible_for_cse = struct
   type t = primitive_application
@@ -1799,14 +1820,15 @@ module Eligible_for_cse = struct
     let eligible = prim_eligible && List.exists Simple.is_var (args t) in
     let effects_and_coeffects_ok =
       match effects_and_coeffects t with
-      | No_effects, No_coeffects -> true
-      | Only_generative_effects Immutable, No_coeffects ->
+      | No_effects, No_coeffects, _ -> true
+      | Only_generative_effects Immutable, No_coeffects, _ ->
         (* Allow constructions of immutable blocks to be shared. *)
         true
       | ( ( No_effects
           | Only_generative_effects (Immutable | Immutable_unique | Mutable)
           | Arbitrary_effects ),
-          (No_coeffects | Has_coeffects) ) ->
+          (No_coeffects | Has_coeffects),
+          _ ) ->
         false
     in
     if not ((not eligible) || effects_and_coeffects_ok)

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1976,7 +1976,6 @@ module Without_args = struct
     | Binary prim -> effects_and_coeffects_of_binary_primitive prim
     | Ternary prim -> effects_and_coeffects_of_ternary_primitive prim
     | Variadic prim -> effects_and_coeffects_of_variadic_primitive prim
-
 end
 
 let is_begin_or_end_region t =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -381,9 +381,8 @@ module Without_args : sig
   val print : Format.formatter -> t -> unit
 
   (** Describe the effects and coeffects that the application of the given
-    primitive may have. *)
+      primitive may have. *)
   val effects_and_coeffects : t -> Effects_and_coeffects.t
-
 end
 
 (** A description of the kind of values which a unary primitive expects as its

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -379,6 +379,11 @@ module Without_args : sig
     | Variadic of variadic_primitive
 
   val print : Format.formatter -> t -> unit
+
+  (** Describe the effects and coeffects that the application of the given
+    primitive may have. *)
+  val effects_and_coeffects : t -> Effects_and_coeffects.t
+
 end
 
 (** A description of the kind of values which a unary primitive expects as its

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -432,7 +432,7 @@ val result_kind' : t -> Flambda_kind.t
 
 (** Describe the effects and coeffects that the application of the given
     primitive may have. *)
-val effects_and_coeffects : t -> Effects.t * Coeffects.t
+val effects_and_coeffects : t -> Effects_and_coeffects.t
 
 (** Returns [true] iff the given primitive has neither effects nor coeffects. *)
 val no_effects_or_coeffects : t -> bool

--- a/middle_end/flambda2/terms/placement.ml
+++ b/middle_end/flambda2/terms/placement.ml
@@ -2,9 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                        Guillaume Bury, OCamlPro                        *)
+(*                      Vincent Laviron, OCamlPro                         *)
 (*                                                                        *)
-(*   Copyright 2019--2019 OCamlPro SAS                                    *)
+(*   Copyright 2022 OCamlPro SAS                                          *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,27 +12,23 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Translation of Flambda primitives to Cmm. *)
+type t =
+  | Delay
+  | Strict
 
-val prim_simple :
-  To_cmm_env.t ->
-  To_cmm_result.t ->
-  Debuginfo.t ->
-  Flambda_primitive.t ->
-  To_cmm_env.simple To_cmm_env.bound_expr
-  * To_cmm_env.extra_info option
-  * To_cmm_env.t
-  * To_cmm_result.t
-  * Effects_and_coeffects.t
+let [@ocamlformat "disable"] print ppf dup =
+  match dup with
+  | Delay -> Format.fprintf ppf "duplicatable"
+  | Strict -> Format.fprintf ppf "non-duplicatable"
 
-val prim_complex :
-  effects_and_coeffects_of_prim:Flambda2_terms.Effects_and_coeffects.t ->
-  To_cmm_env.t ->
-  To_cmm_result.t ->
-  Debuginfo.t ->
-  Flambda_primitive.t ->
-  To_cmm_env.complex To_cmm_env.bound_expr
-  * To_cmm_env.extra_info option
-  * To_cmm_env.t
-  * To_cmm_result.t
-  * Effects_and_coeffects.t
+let compare dup1 dup2 =
+  match dup1, dup2 with
+  | Delay, Delay -> 0
+  | Delay, Strict -> -1
+  | Strict, Strict -> 0
+  | Strict, Delay -> 1
+
+let join dup1 dup2 =
+  match dup1, dup2 with
+  | Delay, Delay -> Delay
+  | Delay, Strict | Strict, Strict | Strict, Delay -> Strict

--- a/middle_end/flambda2/terms/placement.ml
+++ b/middle_end/flambda2/terms/placement.ml
@@ -16,19 +16,18 @@ type t =
   | Delay
   | Strict
 
-let [@ocamlformat "disable"] print ppf dup =
-  match dup with
-  | Delay -> Format.fprintf ppf "duplicatable"
-  | Strict -> Format.fprintf ppf "non-duplicatable"
+let print ppf = function
+  | Delay -> Format.fprintf ppf "Delay"
+  | Strict -> Format.fprintf ppf "Strict"
 
-let compare dup1 dup2 =
-  match dup1, dup2 with
+let compare placement1 placement2 =
+  match placement1, placement2 with
   | Delay, Delay -> 0
   | Delay, Strict -> -1
   | Strict, Strict -> 0
   | Strict, Delay -> 1
 
-let join dup1 dup2 =
-  match dup1, dup2 with
+let join placement1 placement2 =
+  match placement1, placement2 with
   | Delay, Delay -> Delay
   | Delay, Strict | Strict, Strict | Strict, Delay -> Strict

--- a/middle_end/flambda2/terms/placement.mli
+++ b/middle_end/flambda2/terms/placement.mli
@@ -2,9 +2,13 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                        Guillaume Bury, OCamlPro                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*            Mark Shinwell and Xavier Clerc, Jane Street Europe          *)
 (*                                                                        *)
-(*   Copyright 2019--2019 OCamlPro SAS                                    *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   Copyright 2017--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,32 +16,20 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Effects and coeffects *)
+(** Whether an expression can be moved around, including duplication *)
+type t =
+  | Delay
+      (** The expression should be placed as late as possible, even if it is
+          duplicated *)
+  | Strict
+      (** The expression must not be moved around (it has non-generative
+          effects, or coeffects, or doesn't benefit from being bound later *)
 
-(** A pair of an effect and a coeffect. *)
-type t = Effects.t * Coeffects.t * Placement.t
-
-(** Print *)
+(** Print function. *)
 val print : Format.formatter -> t -> unit
 
-(** Comparison. *)
+(** Comparison function. *)
 val compare : t -> t -> int
 
-(** The value stating that no effects of coeffects take place. This is exactly
-    [No_effects, No_coeffects, Strict]. *)
-val pure : t
-
-(** The value stating that no effects of coeffects take place. This is exactly
-    [No_effects, No_coeffects, Delay]. *)
-val pure_duplicatable : t
-
-(** The value stating that any effects and/or coeffects may take place. This is
-    exactly [Arbitrary_effects, Has_coeffects, Strict]. *)
-val all : t
-
-(** The value stating that a read (i.e only a coeffect) takes place. This is
-    [No_effects, Has_coeffects, Strict]. *)
-val read : t
-
-(** Join two effects and coeffects. *)
+(** Join *)
 val join : t -> t -> t

--- a/middle_end/flambda2/terms/placement.mli
+++ b/middle_end/flambda2/terms/placement.mli
@@ -16,14 +16,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Whether an expression can be moved around, including duplication *)
+(** Whether an expression can be moved around, including whether it can be
+    duplicated *)
 type t =
   | Delay
       (** The expression should be placed as late as possible, even if it is
           duplicated *)
   | Strict
       (** The expression must not be moved around (it has non-generative
-          effects, or coeffects, or doesn't benefit from being bound later *)
+          effects, or coeffects, or doesn't benefit from being bound later). *)
 
 (** Print function. *)
 val print : Format.formatter -> t -> unit

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -77,6 +77,7 @@ let unit0 ~offsets flambda_unit ~all_code =
      return the unit value). *)
   let env =
     Env.create offsets all_code ~return_continuation:dummy_k
+      ~trans_prim:To_cmm_primitive.trans_prim
       ~exn_continuation:(Flambda_unit.exn_continuation flambda_unit)
   in
   let _env, return_cont_params =

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -19,12 +19,12 @@ type effects_and_coeffects_classification =
   | Pure
   | Effect
   | Coeffect_only
-  | Generative_duplicable
+  | Generative_immutable
 
 let classify_by_effects_and_coeffects effs =
   (* See the comments on type [classification] in the .mli. *)
   match (effs : Effects_and_coeffects.t) with
-  | Only_generative_effects Immutable, No_coeffects, _ -> Generative_duplicable
+  | Only_generative_effects Immutable, No_coeffects, _ -> Generative_immutable
   | Arbitrary_effects, (Has_coeffects | No_coeffects), _
   | ( Only_generative_effects (Mutable | Immutable | Immutable_unique),
       (Has_coeffects | No_coeffects),
@@ -49,15 +49,14 @@ let classify_let_binding var
     match
       classify_by_effects_and_coeffects effects_and_coeffects_of_defining_expr
     with
-    | Coeffect_only | Generative_duplicable | Pure -> Drop_defining_expr
+    | Coeffect_only | Generative_immutable | Pure -> Drop_defining_expr
     | Effect ->
       Regular
       (* Could be May_inline technically, but it doesn't matter since it can
          only be flushed by the env. *))
   | One -> (
-    (* This case represents expressions that are guaranteed to be evaluated
-       exactly once at runtime (and thus do not include expressions inside
-       loops).
+    (* This case represents expressions that are guaranteed to be evaluated at
+       most once at runtime (and thus do not include expressions inside loops).
 
        Any defining expression used exactly once is considered for inlining at
        this stage. The environment is going to handle the details of preserving

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -19,20 +19,26 @@ type effects_and_coeffects_classification =
   | Pure
   | Effect
   | Coeffect_only
+  | Generative_duplicable
 
 let classify_by_effects_and_coeffects effs =
   (* See the comments on type [classification] in the .mli. *)
   match (effs : Effects_and_coeffects.t) with
-  | Arbitrary_effects, (Has_coeffects | No_coeffects)
-  | Only_generative_effects _, (Has_coeffects | No_coeffects) ->
+  | Only_generative_effects Immutable, No_coeffects, _ -> Generative_duplicable
+  | Arbitrary_effects, (Has_coeffects | No_coeffects), _
+  | ( Only_generative_effects (Mutable | Immutable | Immutable_unique),
+      (Has_coeffects | No_coeffects),
+      _ ) ->
     Effect
-  | No_effects, Has_coeffects -> Coeffect_only
-  | No_effects, No_coeffects -> Pure
+  | No_effects, Has_coeffects, _ -> Coeffect_only
+  | No_effects, No_coeffects, _ -> Pure
 
 type let_binding_classification =
-  | Regular
   | Drop_defining_expr
-  | May_inline
+  | Regular
+  | May_inline_once
+  | Must_inline_once
+  | Must_inline_and_duplicate
 
 let classify_let_binding var
     ~(effects_and_coeffects_of_defining_expr : Effects_and_coeffects.t)
@@ -43,13 +49,17 @@ let classify_let_binding var
     match
       classify_by_effects_and_coeffects effects_and_coeffects_of_defining_expr
     with
-    | Coeffect_only | Pure -> Drop_defining_expr
+    | Coeffect_only | Generative_duplicable | Pure -> Drop_defining_expr
     | Effect ->
       Regular
       (* Could be May_inline technically, but it doesn't matter since it can
          only be flushed by the env. *))
-  | One ->
-    (* Any defining expression used exactly once is considered for inlining at
+  | One -> (
+    (* This case represents expressions that are guaranteed to be evaluated
+       exactly once at runtime (and thus do not include expressions inside
+       loops).
+
+       Any defining expression used exactly once is considered for inlining at
        this stage. The environment is going to handle the details of preserving
        the effects and coeffects ordering (if inlining without reordering is
        impossible then the expressions will be bound at some safe place
@@ -58,8 +68,15 @@ let classify_let_binding var
        Whether inlining of _effectful_ expressions _actually occurs_ depends on
        the context. Currently this is very restricted, see comments in
        [To_cmm_primitive]. *)
-    May_inline
-  | More_than_one -> Regular
+    match effects_and_coeffects_of_defining_expr with
+    | _, _, Delay -> Must_inline_once
+    | _, _, Strict -> May_inline_once)
+  | More_than_one -> (
+    (* Note: expressions in loops are counted as having two occurrences to
+       ensure that they fall in this case *)
+    match effects_and_coeffects_of_defining_expr with
+    | _, _, Delay -> Must_inline_and_duplicate
+    | _, _, Strict -> Regular)
 
 type continuation_handler_classification =
   | Regular

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -73,7 +73,7 @@ let classify_let_binding var
     | _, _, Strict -> May_inline_once)
   | More_than_one -> (
     (* Note: expressions in loops are counted as having two occurrences to
-       ensure that they fall in this case *)
+       ensure that they fall into this case *)
     match effects_and_coeffects_of_defining_expr with
     | _, _, Delay -> Must_inline_and_duplicate
     | _, _, Strict -> Regular)

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.mli
@@ -32,8 +32,8 @@ type effects_and_coeffects_classification = private
           coeffectful expressions (and pure expressions), but cannot commute
           with an effectful expression. *)
   | Generative_duplicable
-      (** Only immutable generative effects. These are tecnically effects (since
-          functions in the `Gc` module can read counters related to
+      (** Only immutable generative effects. These are technically effects
+          (since functions in the `Gc` module can read counters related to
           allocations), but we are interested in moving allocation (e.g. for
           unboxing of numbers in classic mode). *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.mli
@@ -31,6 +31,11 @@ type effects_and_coeffects_classification = private
       (** Coeffects without any effect. These expression can commute with other
           coeffectful expressions (and pure expressions), but cannot commute
           with an effectful expression. *)
+  | Generative_duplicable
+      (** Only immutable generative effects. These are tecnically effects (since
+          functions in the `Gc` module can read counters related to
+          allocations), but we are interested in moving allocation (e.g. for
+          unboxing of numbers in classic mode). *)
 
 (** Return the classification of an expression with the given effects and
     coeffects. *)
@@ -40,9 +45,17 @@ val classify_by_effects_and_coeffects :
 (** Classification of [Let]-expressions, identifying what may be done with the
     defining expression. *)
 type let_binding_classification = private
-  | Regular  (** Proceed as normal, do not inline the defining expression. *)
   | Drop_defining_expr  (** The defining expression may be deleted. *)
-  | May_inline  (** The defining expression may be inlined at the use site. *)
+  | Regular  (** Proceed as normal, do not inline the defining expression. *)
+  | May_inline_once
+      (** The defining expression is guaranteed to be used once, and may be
+          inlined at the use site. *)
+  | Must_inline_once
+      (** The defining expression is guaranteed to be used once, and must
+          inlined at the use site. *)
+  | Must_inline_and_duplicate
+      (** The defining expression must be inlined at all use sites, and it is
+          used multiple times (or inside a loop). *)
 
 val classify_let_binding :
   Variable.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.mli
@@ -16,7 +16,7 @@
 open! Flambda.Import
 
 (** Classification of expressions based on their effects and coeffects. *)
-type effects_and_coeffects_classification = private
+type effects_and_coeffects_classification =
   | Pure
       (** Pure expressions can be commuted with *everything*, including
           effectful expressions such as function calls. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.mli
@@ -31,7 +31,7 @@ type effects_and_coeffects_classification = private
       (** Coeffects without any effect. These expression can commute with other
           coeffectful expressions (and pure expressions), but cannot commute
           with an effectful expression. *)
-  | Generative_duplicable
+  | Generative_immutable
       (** Only immutable generative effects. These are technically effects
           (since functions in the `Gc` module can read counters related to
           allocations), but we are interested in moving allocation (e.g. for

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -369,7 +369,7 @@ let create_binding_aux (type a) ?extra env effs var ~(inline : a inline)
     | None -> env.vars_extra
     | Some info -> Variable.Map.add var info env.vars_extra
   in
-  Format.eprintf "*** new binding@\n%a@\n@." print_any_binding binding;
+  (* Format.eprintf "*** new binding@\n%a@\n@." print_any_binding binding; *)
   let env = { env with bindings; vars; vars_extra } in
   env, binding
 
@@ -600,12 +600,14 @@ let split_complex_binding ~env ~res (binding : complex binding) =
         cmm_var = binding.cmm_var
       }
     in
-    Format.eprintf "*** new bindings:@\n@[<v>%a@]@."
-      (Format.pp_print_list
-         ~pp_sep:(fun ppf () -> Format.fprintf ppf "@,")
-         print_any_binding)
-      new_bindings;
-    Format.eprintf "*** split_binding:@\n%a@\n@." print_binding split_binding;
+    (*
+     * Format.eprintf "*** new bindings:@\n@[<v>%a@]@."
+     *   (Format.pp_print_list
+     *     ~pp_sep:(fun ppf () -> Format.fprintf ppf "@,")
+     *      print_any_binding)
+     *  new_bindings;
+     * Format.eprintf "*** split_binding:@\n%a@\n@." print_binding split_binding;
+     *)
     res, Split { new_bindings; split_binding }
 
 let remove_binding env var =
@@ -723,9 +725,8 @@ let inline_variable ?consider_inlining_effectful_expressions env res var =
           pop_from_top_stage ?consider_inlining_effectful_expressions env var
         with
         | None ->
-          Format.eprintf
-            "/// not inlining %a (because of stages)@\nstages: %a@\n@."
-            Variable.print var print_stages env.stages;
+          (* Format.eprintf "/// not inlining %a (because of stages)@\nstages:
+             %a@\n@." Variable.print var print_stages env.stages; *)
           will_not_inline_simple env res binding
         | Some env ->
           let env = remove_binding env var in

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -489,7 +489,9 @@ let will_inline_complex env { effs; bound_expr; _ } =
     cmm_expr, env, effs
 
 let will_not_inline_simple env { cmm_var; bound_expr = Simple _; _ } =
-  C.var (Backend_var.With_provenance.var cmm_var), env, Ece.pure_duplicatable
+  ( C.var (Backend_var.With_provenance.var cmm_var),
+    env,
+    Ece.pure_can_be_duplicated )
 
 let split_and_inline env var binding =
   match split_complex_binding binding with
@@ -561,7 +563,7 @@ let inline_variable ?consider_inlining_effectful_expressions env var =
     match Variable.Map.find var env.vars with
     | exception Not_found ->
       Misc.fatal_errorf "Variable %a not found in env" Variable.print var
-    | e -> e, env, Ece.pure_duplicatable)
+    | e -> e, env, Ece.pure_can_be_duplicated)
   | Binding binding -> (
     match binding.inline with
     | Do_not_inline -> will_not_inline_simple env binding

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -225,6 +225,10 @@ let print_stages ppf stages =
     (Format.pp_print_list ~pp_sep print_stage)
     stages
 
+let print ppf t =
+  Format.fprintf ppf "@[<hov 1>(@[<hov 1>(stages %a)@]@ )@]" print_stages
+    t.stages
+
 (* Code and closures *)
 
 let get_code_metadata env code_id =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -33,23 +33,62 @@ type extra_info =
 
 (* Delayed let-bindings (see the .mli) *)
 
-type binding =
+(* the binding kinds *)
+type simple = Simple
+
+type complex = Complex
+
+type _ inline =
+  | Do_not_inline : simple inline
+  | May_inline_once : simple inline
+  | Must_inline_once : complex inline
+  | Must_inline_and_duplicate : complex inline
+
+(* Note on the effects of splittable bindings:
+
+   The arguments are stored with their effects. This means that if we need to
+   split the binding, we can re-bind each argument with its correct effects.
+
+   The [prim_effects] field stores the effects of the primitive itself (the part
+   of the binding that can be duplicated).
+
+   When the binding is inlined without splitting, these effects are not used;
+   instead the effects of the whole expression are used (they are stored
+   alongside the binding, as for normal bindings).
+
+   When the binding is split, [make_expr] is called on variables only, and the
+   effects of the resulting expression are assumed to be exactly
+   [prim_effects]. *)
+type _ bound_expr =
+  | Simple : { cmm_expr : Cmm.expression } -> simple bound_expr
+  | Split : { cmm_expr : Cmm.expression } -> complex bound_expr
+  | Splittable :
+      { name : string;
+        (* For debugging purposes only *)
+        args : (Cmm.expression * Ece.t) list;
+        prim_effects : Ece.t;
+        make_expr : Cmm.expression list -> Cmm.expression
+      }
+      -> complex bound_expr
+
+type 'kind binding =
   { order : int;
-    may_inline : bool;
-    (* [may_inline] means that the defining expression of the binding is safe to
-       inline, but it doesn't necessarily _have_ to be inlined. *)
     effs : Ece.t;
-    cmm_var : Backend_var.With_provenance.t;
-    cmm_expr : Cmm.expression
+    inline : 'kind inline;
+    bound_expr : 'kind bound_expr;
+    cmm_var : Backend_var.With_provenance.t
   }
 
+type any_binding = Binding : _ binding -> any_binding [@@unboxed]
+
 type stage =
-  | Effect of Variable.t * binding
-  | Coeffect_only of binding Variable.Map.t
+  | Effect of Variable.t
+  | Coeffect_only of Variable.Set.t
 
 type t =
-  { (* Global information. This is computed once and remains valid for a whole
-       compilation unit. *)
+  { (* Global information.
+
+       This is computed once and remains valid for a whole compilation unit. *)
     offsets : Exported_offsets.t;
     (* Offsets for function and value slots. *)
     functions_info : Exported_code.t;
@@ -65,11 +104,6 @@ type t =
     exn_continuation : Continuation.t;
     (* The exception continuation of the current context (used to determine
        where to insert try-with blocks). *)
-    vars : Cmm.expression Variable.Map.t;
-    (* Cmm expressions (of the form [Cvar ...]) describing all Flambda variables
-       in scope. *)
-    vars_extra : extra_info Variable.Map.t;
-    (* Extra information (see above) associated with Flambda variables. *)
     conts : cont Continuation.Map.t;
     (* Information about whether each continuation in scope should have its
        handler inlined, or else reached via a jump. *)
@@ -78,8 +112,13 @@ type t =
     exn_conts_extra_args : Backend_var.t list Continuation.Map.t;
     (* Mutable variables used for compiling the "extra arguments" to exception
        handlers. *)
-    pures : binding Variable.Map.t;
-    (* Pure let-bindings that can be inlined across _stages_ (see the .mli). *)
+    vars_extra : extra_info Variable.Map.t;
+    (* Extra information associated with Flambda variables. *)
+    vars : Cmm.expression Variable.Map.t;
+    (* Cmm expressions (of the form [Cvar ...]) for all bound variables in
+       scope. *)
+    bindings : any_binding Variable.Map.t;
+    (* All bindings currently in env. *)
     stages : stage list (* Stages of let-bindings, most recent at the head. *)
   }
 
@@ -89,9 +128,9 @@ let create offsets functions_info ~return_continuation ~exn_continuation =
     offsets;
     functions_info;
     stages = [];
-    pures = Variable.Map.empty;
-    vars = Variable.Map.empty;
+    bindings = Variable.Map.empty;
     vars_extra = Variable.Map.empty;
+    vars = Variable.Map.empty;
     conts = Continuation.Map.empty;
     exn_handlers = Continuation.Set.singleton exn_continuation;
     exn_conts_extra_args = Continuation.Map.empty
@@ -103,6 +142,40 @@ let enter_function_body env ~return_continuation ~exn_continuation =
 let return_continuation env = env.return_continuation
 
 let exn_continuation env = env.exn_continuation
+
+let [@ocamlformat "disable"] print_inline (type a) ppf (inline : a inline) =
+  match inline with
+  | Do_not_inline -> Format.fprintf ppf "do_not_inline"
+  | May_inline_once -> Format.fprintf ppf "may_inline_once"
+  | Must_inline_once -> Format.fprintf ppf "must_inline_once"
+  | Must_inline_and_duplicate -> Format.fprintf ppf "must_inline_and_duplicate"
+
+let [@ocamlformat "disable"] print_bound_expr (type a) ppf (b : a bound_expr) =
+  match b with
+  | Simple { cmm_expr; } | Split { cmm_expr; } ->
+    Printcmm.expression ppf cmm_expr
+  | Splittable { name; args; prim_effects = _; make_expr = _; } ->
+    Format.fprintf ppf "@[<hov 1>(\
+      @[<hov 1>(name@ %s)@]@ \
+      @[<hov 1>(args@ @[<hov 1>(%a)@])@]\
+    )@]"
+      name
+      (Format.pp_print_list (fun ppf (cmm, _) -> Printcmm.expression ppf cmm)) args
+
+let [@ocamlformat "disable"] print_binding ppf
+    (Binding { order; inline; effs; cmm_var; bound_expr; }) =
+  Format.fprintf ppf "@[<hov 1>(\
+      @[<hov 1>(order@ %d)@]@ \
+      @[<hov 1>(inline@ %a)@]@ \
+      @[<hov 1>(effs@ %a)@]@ \
+      @[<hov 1>(var@ %a)@]@ \
+      @[<hov 1>(expr@ %a)@]\
+    )@]"
+    order
+    print_inline inline
+    Ece.print effs
+    Backend_var.With_provenance.print cmm_var
+    print_bound_expr bound_expr
 
 (* Code and closures *)
 
@@ -123,21 +196,22 @@ let gen_variable v =
   (* CR mshinwell: Fix [provenance] *)
   Backend_var.With_provenance.create ?provenance:None v
 
-let add_variable env v v' =
+let add_bound_param env v v' =
   let v'' = Backend_var.With_provenance.var v' in
   let vars = Variable.Map.add v (C.var v'') env.vars in
   { env with vars }
 
-let create_variable env v =
+let create_bound_parameter env v =
   if Variable.Map.mem v env.vars
   then
     Misc.fatal_errorf "Cannot rebind variable %a in To_cmm environment"
       Variable.print v;
   let v' = gen_variable v in
-  let env = add_variable env v v' in
+  let env = add_bound_param env v v' in
   env, v'
 
-let create_variables env vs = List.fold_left_map create_variable env vs
+let create_bound_parameters env vs =
+  List.fold_left_map create_bound_parameter env vs
 
 let extra_info env simple =
   match Simple.must_be_var simple with
@@ -208,150 +282,306 @@ let get_exn_extra_args env k =
 
 (* Variable binding (for potential inlining). Also see [To_cmm_effects]. *)
 
-let is_inlinable_box effs ~extra =
-  (* [effs] is the effects and coeffects of some primitive operation, arising
-     either from the primitive itself or its arguments. If this is a boxing
-     operation (as indicated by [extra]) then we want to inline the box. However
-     this involves moving the arguments, so they must be pure (or at most have
-     generative effects, with no coeffects). *)
-  match (effs : Ece.t), (extra : extra_info option) with
-  | ((No_effects | Only_generative_effects _), No_coeffects), Some Boxed_number
+let next_order = ref (-1)
+
+let simple cmm_expr = Simple { cmm_expr }
+
+let splittable_primitive name args prim_effects make_expr =
+  Splittable { name; args; prim_effects; make_expr }
+
+let complex_no_split name cmm_expr effs =
+  splittable_primitive name [] effs (fun _ -> cmm_expr)
+
+let is_cmm_simple cmm =
+  match[@ocaml.warning "-4"] (cmm : Cmm.expression) with
+  | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _ | Cvar _
     ->
     true
-  | ( ( (No_effects | Only_generative_effects _ | Arbitrary_effects),
-        (No_coeffects | Has_coeffects) ),
-      (None | Some Boxed_number | Some (Untag _)) ) ->
-    false
+  | _ -> false
 
-let create_binding =
-  let next_order = ref (-1) in
-  fun ?extra env ~may_inline effs var cmm_expr ->
-    let order =
-      incr next_order;
-      !next_order
+let create_binding_aux (type a) ?extra env effs var ~(inline : a inline)
+    (bound_expr : a bound_expr) =
+  let order =
+    let incr =
+      match bound_expr with
+      | Simple _ | Split _ -> 1
+      | Splittable { args; _ } -> List.length args + 1
     in
-    let cmm_var = gen_variable var in
-    let binding = { order; may_inline; effs; cmm_var; cmm_expr } in
-    let cmm_expr = C.var (Backend_var.With_provenance.var cmm_var) in
-    let env = { env with vars = Variable.Map.add var cmm_expr env.vars } in
-    let env =
-      match extra with
-      | None -> env
-      | Some info ->
-        { env with vars_extra = Variable.Map.add var info env.vars_extra }
-    in
-    env, binding
-
-let bind_variable0 ?extra env var ~effects_and_coeffects_of_defining_expr:effs
-    ~may_inline ~defining_expr =
-  let env, binding =
-    create_binding ?extra env ~may_inline effs var defining_expr
+    next_order := !next_order + incr;
+    !next_order
   in
-  if may_inline && is_inlinable_box effs ~extra
-  then
-    (* CR-someday lmaurer: This violates our rule about not moving allocations
-       past function calls. We should either fix it (not clear how) or be rid of
-       that rule. *)
-    { env with pures = Variable.Map.add var binding env.pures }
-  else
+  let cmm_var = gen_variable var in
+  let binding = Binding { order; inline; effs; cmm_var; bound_expr } in
+  let bindings = Variable.Map.add var binding env.bindings in
+  let cmm_expr = C.var (Backend_var.With_provenance.var cmm_var) in
+  let vars = Variable.Map.add var cmm_expr env.vars in
+  let vars_extra =
+    match extra with
+    | None -> env.vars_extra
+    | Some info -> Variable.Map.add var info env.vars_extra
+  in
+  let env = { env with bindings; vars; vars_extra } in
+  env, binding
+
+let create_binding (type a) ?extra env effs var ~(inline : a inline)
+    (bound_expr : a bound_expr) =
+  (* In order to avoid generating binding of the form: "let x = y in ...", when
+     'y' is trivial i.e. is a value that fits in a register, we mark 'x' as a
+     must_inline_and_duplicate (since it basically replaces a variable by either
+     another variable, a constant, or a symbol). *)
+  match bound_expr with
+  | Simple { cmm_expr } when is_cmm_simple cmm_expr ->
+    create_binding_aux ?extra env effs var ~inline:Must_inline_and_duplicate
+      (Split { cmm_expr })
+  | Simple _ | Split _ | Splittable _ ->
+    create_binding_aux ?extra env effs var ~inline bound_expr
+
+let bind_variable_with_decision (type a) ?extra env var ~inline
+    ~(defining_expr : a bound_expr) ~effects_and_coeffects_of_defining_expr:effs
+    =
+  let env, binding = create_binding ?extra env ~inline effs var defining_expr in
+  match (inline : a inline) with
+  | Must_inline_and_duplicate ->
+    (* check that the effects and coeffects allow the expression to be
+       duplicated without changing semantics *)
+    (match To_cmm_effects.classify_by_effects_and_coeffects effs with
+    | Pure | Generative_duplicable -> ()
+    | Coeffect_only | Effect ->
+      Misc.fatal_errorf
+        "Incorrect effects and/or coeffects for a duplicated binding: %a"
+        print_binding binding);
+    env
+  | May_inline_once | Must_inline_once | Do_not_inline -> (
     match To_cmm_effects.classify_by_effects_and_coeffects effs with
-    | Pure -> { env with pures = Variable.Map.add var binding env.pures }
-    | Effect -> { env with stages = Effect (var, binding) :: env.stages }
+    | Pure -> env
+    | Generative_duplicable -> (
+      match (inline : a inline) with
+      | Must_inline_once ->
+        (* CR: this allows to move allocations marked as `Must_inline_once` past
+           function calls (and other effectful expressions), which can break
+           some allocation-counting tests. *)
+        env
+      | May_inline_once | Do_not_inline ->
+        (* Generative expressions not marked as `must_inline` are treated as
+           having effects, since function from the `Gc` module can read counters
+           that are increased by allocations. *)
+        { env with stages = Effect var :: env.stages }
+      | Must_inline_and_duplicate -> assert false (* impossible to reach *))
+    | Effect -> { env with stages = Effect var :: env.stages }
     | Coeffect_only ->
       let stages =
         match env.stages with
-        | Coeffect_only bindings :: stages ->
+        | Coeffect_only vars :: stages ->
           (* Multiple coeffect-only bindings may be accumulated in the same
              stage. *)
-          Coeffect_only (Variable.Map.add var binding bindings) :: stages
+          Coeffect_only (Variable.Set.add var vars) :: stages
         | [] | Effect _ :: _ ->
-          Coeffect_only (Variable.Map.singleton var binding) :: env.stages
+          Coeffect_only (Variable.Set.singleton var) :: env.stages
       in
-      { env with stages }
+      { env with stages })
 
-let bind_variable ?extra env v
-    ~(num_normal_occurrences_of_bound_vars : _ Or_unknown.t)
-    ~effects_and_coeffects_of_defining_expr ~defining_expr =
-  let[@inline] bind_variable0 ~may_inline =
-    bind_variable0 env v ?extra ~effects_and_coeffects_of_defining_expr
-      ~may_inline ~defining_expr
+let bind_variable ?extra env var ~defining_expr
+    ~num_normal_occurrences_of_bound_vars
+    ~effects_and_coeffects_of_defining_expr =
+  let inline =
+    To_cmm_effects.classify_let_binding var
+      ~effects_and_coeffects_of_defining_expr
+      ~num_normal_occurrences_of_bound_vars
   in
-  match num_normal_occurrences_of_bound_vars with
-  | Unknown -> bind_variable0 ~may_inline:false
-  | Known num_normal_occurrences_of_bound_vars -> (
-    match
-      To_cmm_effects.classify_let_binding v
-        ~effects_and_coeffects_of_defining_expr
-        ~num_normal_occurrences_of_bound_vars
-    with
-    | Drop_defining_expr -> env
-    | May_inline -> bind_variable0 ~may_inline:true
-    | Regular -> bind_variable0 ~may_inline:false)
+  match inline with
+  | Drop_defining_expr -> env
+  | Regular ->
+    let defining_expr = simple defining_expr in
+    bind_variable_with_decision ?extra env var
+      ~effects_and_coeffects_of_defining_expr ~defining_expr
+      ~inline:Do_not_inline
+  | May_inline_once ->
+    let defining_expr = simple defining_expr in
+    bind_variable_with_decision ?extra env var
+      ~effects_and_coeffects_of_defining_expr ~defining_expr
+      ~inline:May_inline_once
+  | Must_inline_once ->
+    let name = Format.asprintf "%a" Printcmm.expression defining_expr in
+    let defining_expr =
+      complex_no_split name defining_expr effects_and_coeffects_of_defining_expr
+    in
+    bind_variable_with_decision ?extra env var
+      ~effects_and_coeffects_of_defining_expr ~defining_expr
+      ~inline:Must_inline_once
+  | Must_inline_and_duplicate ->
+    let name = Format.asprintf "%a" Printcmm.expression defining_expr in
+    let defining_expr =
+      complex_no_split name defining_expr effects_and_coeffects_of_defining_expr
+    in
+    bind_variable_with_decision ?extra env var
+      ~effects_and_coeffects_of_defining_expr ~defining_expr
+      ~inline:Must_inline_and_duplicate
+
+let bind_variable_to_primitive = bind_variable_with_decision
 
 (* Variable lookup (for potential inlining) *)
 
-let will_inline env binding = binding.cmm_expr, env, binding.effs
+let split_complex_binding (binding : complex binding) =
+  match binding.bound_expr with
+  | Split _ -> None
+  | Splittable { name = _; args; prim_effects; make_expr } ->
+    let (new_bindings, _), new_cmm_args =
+      List.fold_left_map
+        (fun (new_bindings, order) (cmm_arg, arg_effs) ->
+          if is_cmm_simple cmm_arg
+          then (new_bindings, order), cmm_arg
+          else
+            (* we need to rebind the argument *)
+            let new_cmm_var =
+              Backend_var.With_provenance.create ?provenance:None
+                (Backend_var.create_local
+                   (Format.asprintf "split_tmp_%d" order))
+            in
+            let binding =
+              Binding
+                { order;
+                  effs = arg_effs;
+                  inline = Do_not_inline;
+                  bound_expr = Simple { cmm_expr = cmm_arg };
+                  cmm_var = new_cmm_var
+                }
+            in
+            ( (binding :: new_bindings, order - 1),
+              C.var (Backend_var.With_provenance.var new_cmm_var) ))
+        ([], binding.order - 1)
+        args
+    in
+    let new_cmm_expr = make_expr new_cmm_args in
+    (match To_cmm_effects.classify_by_effects_and_coeffects prim_effects with
+    | Pure | Generative_duplicable -> ()
+    | Effect | Coeffect_only ->
+      Misc.fatal_errorf
+        "Once split, a 'must_inline_once' binding cannot have effects or \
+         coeffects, since it can be moved around to be inlined.");
+    let split_binding =
+      { order = binding.order;
+        effs = prim_effects;
+        inline = binding.inline;
+        bound_expr = Split { cmm_expr = new_cmm_expr };
+        cmm_var = binding.cmm_var
+      }
+    in
+    Some (new_bindings, split_binding)
 
-let will_not_inline env binding =
-  C.var (Backend_var.With_provenance.var binding.cmm_var), env, Ece.pure
+let remove_binding env var =
+  { env with bindings = Variable.Map.remove var env.bindings }
 
-let will_not_inline_var env v =
-  (* This is like [will_not_inline] but is used in the case where no delayed
-     [binding] is available. A preallocated [Cvar] expression will be used. *)
-  match Variable.Map.find v env.vars with
-  | exception Not_found ->
-    Misc.fatal_errorf "Variable %a not found in env" Variable.print v
-  | e -> e, env, Ece.pure
+let will_inline_simple env { effs; bound_expr = Simple { cmm_expr }; _ } =
+  cmm_expr, env, effs
+
+let will_inline_complex env { effs; bound_expr; _ } =
+  match bound_expr with
+  | Split { cmm_expr } -> cmm_expr, env, effs
+  | Splittable { name = _; args; prim_effects = _; make_expr } ->
+    let cmm_expr = make_expr (List.map fst args) in
+    cmm_expr, env, effs
+
+let will_not_inline_simple env { cmm_var; bound_expr = Simple _; _ } =
+  C.var (Backend_var.With_provenance.var cmm_var), env, Ece.pure_duplicatable
+
+let split_and_inline env var binding =
+  match split_complex_binding binding with
+  | None -> will_inline_complex env binding
+  | Some (new_bindings, split_binding) ->
+    let env =
+      (* for duplicated bindings, we need to replace the original splittable
+         binding with the new split binding in the bindings map of the env *)
+      match split_binding.inline with
+      | Must_inline_once -> env
+      | Must_inline_and_duplicate ->
+        { env with
+          bindings = Variable.Map.add var (Binding split_binding) env.bindings
+        }
+    in
+    let env =
+      List.fold_left
+        (fun env new_binding ->
+          let flambda_var = Variable.create "to_cmm_tmp" in
+          { env with
+            bindings = Variable.Map.add flambda_var new_binding env.bindings
+          })
+        env new_bindings
+    in
+    will_inline_complex env split_binding
+
+let pop_from_top_stage ?consider_inlining_effectful_expressions env var =
+  match env.stages with
+  | [] -> None
+  | Effect var_from_stage :: prev_stages ->
+    (* In this case [var_from_stage] corresponds to an effectful binding forming
+       the most recent stage. We also know that [var] doesn't have an available
+       pure defining expression (either because that expression isn't pure, or
+       because the corresponding binding has already been flushed). As such, we
+       can't move the defining expression for [var] past that of
+       [var_from_stage], in the case where these variables are different.
+       However if these two variables are in fact the same, we can consider
+       inlining the defining expression. *)
+    let consider_inlining_effectful_expressions =
+      match consider_inlining_effectful_expressions with
+      | Some consider -> consider
+      | None -> Flambda_features.Expert.inline_effects_in_cmm ()
+    in
+    if Variable.equal var var_from_stage
+       && consider_inlining_effectful_expressions
+    then Some { env with stages = prev_stages }
+    else None
+  | Coeffect_only vars_from_stage :: prev_stages ->
+    (* Here we see if [var] has a coeffect-only defining expression on the most
+       recent stage. If so, then we can commute it with any other expression on
+       the stage, since they all only have coeffects. The defining expression
+       for [var] may then be considered for inlining. *)
+    if Variable.Set.mem var vars_from_stage
+    then
+      let new_vars_in_stage = Variable.Set.remove var vars_from_stage in
+      let stages =
+        if Variable.Set.is_empty new_vars_in_stage
+        then prev_stages
+        else Coeffect_only new_vars_in_stage :: prev_stages
+      in
+      Some { env with stages }
+    else None
 
 let inline_variable ?consider_inlining_effectful_expressions env var =
-  match Variable.Map.find var env.pures with
-  | binding ->
-    if not binding.may_inline
-    then will_not_inline env binding
-    else
-      (* Pure bindings may be inlined at most once. *)
-      let pures = Variable.Map.remove var env.pures in
-      will_inline { env with pures } binding
+  match Variable.Map.find var env.bindings with
   | exception Not_found -> (
-    match env.stages with
-    | [] -> will_not_inline_var env var
-    | Effect (var_from_stage, binding) :: prev_stages ->
-      (* In this case [var_from_stage] corresponds to an effectful binding
-         forming the most recent stage. We also know that [var] doesn't have an
-         available pure defining expression (either because that expression
-         isn't pure, or because the corresponding binding has already been
-         flushed). As such, we can't move the defining expression for [var] past
-         that of [var_from_stage], in the case where these variables are
-         different. However if these two variables are in fact the same, we can
-         consider inlining the defining expression. *)
-      let consider_inlining_effectful_expressions =
-        match consider_inlining_effectful_expressions with
-        | Some consider -> consider
-        | None -> Flambda_features.Expert.inline_effects_in_cmm ()
-      in
-      if not (Variable.equal var var_from_stage)
-      then will_not_inline_var env var
-      else if binding.may_inline && consider_inlining_effectful_expressions
-      then will_inline { env with stages = prev_stages } binding
-      else will_not_inline env binding
-    | Coeffect_only coeffects :: prev_stages -> (
-      (* Here we see if [var] has a coeffect-only defining expression on the
-         most recent stage. If so, then we can commute it with any other
-         expression on the stage, since they all only have coeffects. The
-         defining expression for [var] may then be considered for inlining. *)
-      match Variable.Map.find var coeffects with
-      | exception Not_found -> will_not_inline_var env var
-      | binding ->
-        if not binding.may_inline
-        then will_not_inline env binding
-        else
-          let coeffects = Variable.Map.remove var coeffects in
-          let env =
-            if Variable.Map.is_empty coeffects
-            then { env with stages = prev_stages }
-            else { env with stages = Coeffect_only coeffects :: prev_stages }
-          in
-          will_inline env binding))
+    (* this happens for continuation parameters and bindings that have been
+       flushed *)
+    match Variable.Map.find var env.vars with
+    | exception Not_found ->
+      Misc.fatal_errorf "Variable %a not found in env" Variable.print var
+    | e -> e, env, Ece.pure_duplicatable)
+  | Binding binding -> (
+    match binding.inline with
+    | Do_not_inline -> will_not_inline_simple env binding
+    | Must_inline_and_duplicate -> split_and_inline env var binding
+    | Must_inline_once -> (
+      let env = remove_binding env var in
+      match To_cmm_effects.classify_by_effects_and_coeffects binding.effs with
+      | Pure | Generative_duplicable -> will_inline_complex env binding
+      | Effect | Coeffect_only -> (
+        match
+          pop_from_top_stage ?consider_inlining_effectful_expressions env var
+        with
+        | None -> split_and_inline env var binding
+        | Some env -> will_inline_complex env binding))
+    | May_inline_once -> (
+      match To_cmm_effects.classify_by_effects_and_coeffects binding.effs with
+      | Pure ->
+        let env = remove_binding env var in
+        will_inline_simple env binding
+      | Generative_duplicable | Effect | Coeffect_only -> (
+        match
+          pop_from_top_stage ?consider_inlining_effectful_expressions env var
+        with
+        | None -> will_not_inline_simple env binding
+        | Some env ->
+          let env = remove_binding env var in
+          will_inline_simple env binding)))
 
 (* Flushing delayed bindings *)
 
@@ -362,36 +592,75 @@ module M = Map.Make (struct
   let compare x y = compare y x
 end)
 
-let order_add b acc = M.add b.order b acc
-
-let order_add_map m acc =
-  Variable.Map.fold (fun _ b acc -> order_add b acc) m acc
-
 let flush_delayed_lets ?(entering_loop = false) env =
   (* Generate a wrapper function to introduce the delayed let-bindings. *)
-  let flush pures stages e =
-    let order_map = order_add_map pures M.empty in
-    let order_map =
-      List.fold_left
-        (fun acc -> function
-          | Effect (_, b) -> order_add b acc
-          | Coeffect_only m -> order_add_map m acc)
-        order_map stages
-    in
+  let wrap_flush order_map e =
     M.fold
-      (fun _ b acc ->
-        Cmm_helpers.letin b.cmm_var ~defining_expr:b.cmm_expr ~body:acc)
+      (fun _ (Binding b) acc ->
+        match b.inline, b.bound_expr with
+        (* We drop bindings that have been marked as being inlined and
+           duplicated. *)
+        | Must_inline_and_duplicate, _ | Must_inline_once, _ ->
+          Misc.fatal_errorf "'Must inline' bindings should never be flushed"
+        | May_inline_once, Simple { cmm_expr }
+        | Do_not_inline, Simple { cmm_expr } ->
+          Cmm_helpers.letin b.cmm_var ~defining_expr:cmm_expr ~body:acc)
       order_map e
   in
-  (* Unless entering a loop, only pure bindings that definitely cannot be
-     inlined are flushed now. The remainder are preserved, ensuring that the
-     corresponding expressions are sunk down as far as possible. *)
   (* CR-someday mshinwell: work out a criterion for allowing substitutions into
-     loops. *)
-  let pures_to_keep, pures_to_flush =
-    if entering_loop
-    then Variable.Map.empty, env.pures
-    else Variable.Map.partition (fun _ binding -> binding.may_inline) env.pures
+     loops. CR gbury: this is now done by creating a binding with the inline
+     status `Must_inline_and_duplicate`, so the caller of `to_cmm_env` has to
+     make that decision of whether to substitute inside loops. *)
+  let bindings_to_flush = ref M.empty in
+  let flush (Binding b as binding) =
+    if M.mem b.order !bindings_to_flush
+    then Misc.fatal_errorf "Duplicate order for bindings when flushing";
+    bindings_to_flush := M.add b.order binding !bindings_to_flush
   in
-  let flush e = flush pures_to_flush env.stages e in
-  flush, { env with stages = []; pures = pures_to_keep }
+  let bindings_to_keep =
+    Variable.Map.filter_map
+      (fun _ (Binding b as binding) ->
+        match b.inline with
+        | Do_not_inline ->
+          flush binding;
+          None
+        | Must_inline_and_duplicate -> (
+          match split_complex_binding b with
+          | None -> (* already split *) Some binding
+          | Some (arg_bindings, split_binding) ->
+            List.iter flush arg_bindings;
+            Some (Binding split_binding))
+        | Must_inline_once -> (
+          match To_cmm_effects.classify_by_effects_and_coeffects b.effs with
+          (* when not entering a loop, and with pure/generative effects at most,
+             we can wait to split the binding, so that we can have a chance to
+             try and push the arguments down the branch (otherwise, when we
+             split, the arguments of the splittable binding would be flushed
+             before the branch in control flow). *)
+          | (Pure | Generative_duplicable) when not entering_loop ->
+            Some binding
+          | Pure | Generative_duplicable | Coeffect_only | Effect -> (
+            match split_complex_binding b with
+            | None -> (* already split *) Some binding
+            | Some (arg_bindings, split_binding) ->
+              List.iter flush arg_bindings;
+              Some (Binding split_binding)))
+        | May_inline_once -> (
+          match To_cmm_effects.classify_by_effects_and_coeffects b.effs with
+          (* Unless entering a loop, we do not flush pure bindings that can be
+             inlined, ensuring that the corresponding expressions are sunk down
+             as far as possible, including past control flow branching
+             points. *)
+          | Pure ->
+            if entering_loop
+            then (
+              flush binding;
+              None)
+            else Some binding
+          | Generative_duplicable | Coeffect_only | Effect ->
+            flush binding;
+            None))
+      env.bindings
+  in
+  let flush e = wrap_flush !bindings_to_flush e in
+  flush, { env with stages = []; bindings = bindings_to_keep }

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -152,11 +152,11 @@ type _ bound_expr
 (** A simple cmm bound expression *)
 val simple : Cmm.expression -> simple bound_expr
 
-(** A bound expr that can be splitted if needed. This is used for primitives
-    that must be inlined, but whose arguments may not be inlinable or
-    duplicable, so that we can split the expression to be inliend from its
-    arguments if/when needed. The effects that are passed must correspond
-    respectively to each individual argument and to the primitive itself. *)
+(** A bound expr that can be split if needed. This is used for primitives that
+    must be inlined, but whose arguments may not be inlinable or duplicable, so
+    that we can split the expression to be inlined from its arguments if/when
+    needed. The effects that are passed must correspond respectively to each
+    individual argument and to the primitive itself. *)
 val splittable_primitive :
   string ->
   (Cmm.expression * Effects_and_coeffects.t) list ->

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -24,7 +24,6 @@ type extra_info =
       (** The variable is bound to the result of untagging the given Cmm
           expression. This allows to obtain the Cmm expression as it was before
           untagging. *)
-  | Boxed_number  (** The variable is bound to a boxed number. *)
 
 (** Record of all primitive translation functions, to avoid a cyclic
     dependency. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -26,17 +26,36 @@ type extra_info =
           untagging. *)
   | Boxed_number  (** The variable is bound to a boxed number. *)
 
-(** Record of all primitive translation functions, to avoid a cyclic dependency. *)
+(** Record of all primitive translation functions, to avoid a cyclic
+    dependency. *)
 type prim_res = extra_info option * To_cmm_result.t * Cmm.expression
-type ('env, 'prim, 'arity) prim_helper = 'env -> To_cmm_result.t -> Debuginfo.t -> 'prim -> 'arity
-type 'env trans_prim = {
-  nullary : ('env, Flambda_primitive.nullary_primitive, prim_res) prim_helper;
-  unary : ('env, Flambda_primitive.unary_primitive, Cmm.expression -> prim_res) prim_helper;
-  binary : ('env, Flambda_primitive.binary_primitive, Cmm.expression -> Cmm.expression -> prim_res) prim_helper;
-  ternary : ('env, Flambda_primitive.ternary_primitive, Cmm.expression -> Cmm.expression -> Cmm.expression -> prim_res) prim_helper;
-  variadic : ('env, Flambda_primitive.variadic_primitive, Cmm.expression list -> prim_res) prim_helper;
-}
 
+type ('env, 'prim, 'arity) prim_helper =
+  'env -> To_cmm_result.t -> Debuginfo.t -> 'prim -> 'arity
+
+type 'env trans_prim =
+  { nullary : ('env, Flambda_primitive.nullary_primitive, prim_res) prim_helper;
+    unary :
+      ( 'env,
+        Flambda_primitive.unary_primitive,
+        Cmm.expression -> prim_res )
+      prim_helper;
+    binary :
+      ( 'env,
+        Flambda_primitive.binary_primitive,
+        Cmm.expression -> Cmm.expression -> prim_res )
+      prim_helper;
+    ternary :
+      ( 'env,
+        Flambda_primitive.ternary_primitive,
+        Cmm.expression -> Cmm.expression -> Cmm.expression -> prim_res )
+      prim_helper;
+    variadic :
+      ( 'env,
+        Flambda_primitive.variadic_primitive,
+        Cmm.expression list -> prim_res )
+      prim_helper
+  }
 
 (** Create an environment for translating a toplevel expression. *)
 val create :
@@ -209,7 +228,10 @@ val inline_variable :
 (** Wrap the given Cmm expression with all the delayed let bindings accumulated
     in the environment. *)
 val flush_delayed_lets :
-  ?entering_loop:bool -> t -> To_cmm_result.t -> (Cmm.expression -> Cmm.expression) * t * To_cmm_result.t
+  ?entering_loop:bool ->
+  t ->
+  To_cmm_result.t ->
+  (Cmm.expression -> Cmm.expression) * t * To_cmm_result.t
 
 (** Fetch the extra info for a Flambda variable (if any), specified as a
     [Simple]. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -18,6 +18,9 @@
 (** Environment for Flambda to Cmm translation *)
 type t
 
+(** Printing function *)
+val print : Format.formatter -> t -> unit
+
 (** Extra information about bound variables, used for optimisation. *)
 type extra_info =
   | Untag of Cmm.expression

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -684,7 +684,7 @@ and switch env res switch =
     match Targetint_31_63.Map.cardinal arms with
     | 2 -> (
       match Env.extra_info env scrutinee with
-      | None | Some Boxed_number -> untagged_scrutinee_cmm, false
+      | None -> untagged_scrutinee_cmm, false
       | Some (Untag tagged_scrutinee_cmm) ->
         let size_untagged =
           Option.value

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -37,8 +37,8 @@ let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
     C.simple ~dbg env res s
   in
   let env =
-    Env.bind_variable env v ~effects_and_coeffects_of_defining_expr ~defining_expr
-      ~num_normal_occurrences_of_bound_vars
+    Env.bind_variable env v ~effects_and_coeffects_of_defining_expr
+      ~defining_expr ~num_normal_occurrences_of_bound_vars
   in
   env, res
 
@@ -94,21 +94,24 @@ let translate_apply0 env res apply =
       ( C.direct_call ~dbg ty pos
           (C.symbol_from_linkage_name ~dbg code_linkage_name)
           args,
-        env, res,
+        env,
+        res,
         Ece.all )
     | Some name ->
       ( C.probe ~dbg ~name
           ~handler_code_linkage_name:(Linkage_name.to_string code_linkage_name)
           ~args
         |> C.return_unit dbg,
-        env, res,
+        env,
+        res,
         Ece.all ))
   | Function { function_call = Indirect_unknown_arity; alloc_mode } ->
     fail_if_probe apply;
     ( C.indirect_call ~dbg Cmm.typ_val pos
         (Alloc_mode.For_types.to_lambda alloc_mode)
         callee args,
-      env, res,
+      env,
+      res,
       Ece.all )
   | Function
       { function_call = Indirect_known_arity { return_arity; param_arity };
@@ -128,7 +131,8 @@ let translate_apply0 env res apply =
       ( C.indirect_full_call ~dbg ty pos
           (Alloc_mode.For_types.to_lambda alloc_mode)
           callee args,
-        env, res,
+        env,
+        res,
         Ece.all )
   | Call_kind.C_call { alloc; return_arity; param_arity; is_c_builtin } ->
     fail_if_probe apply;
@@ -165,7 +169,8 @@ let translate_apply0 env res apply =
     in
     ( wrap dbg
         (C.extcall ~dbg ~alloc ~is_c_builtin ~returns ~ty_args callee ty args),
-      env, res,
+      env,
+      res,
       Ece.all )
   | Call_kind.Method { kind; obj; alloc_mode } ->
     fail_if_probe apply;
@@ -196,7 +201,9 @@ let translate_apply env res apply =
       let arg, env, res, _ = C.simple ~dbg env res arg in
       C.sequence (C.assign v arg) call, env, res
     in
-    let call, env, res = List.fold_left2 aux (call, env, res) extra_args mut_vars in
+    let call, env, res =
+      List.fold_left2 aux (call, env, res) extra_args mut_vars
+    in
     call, env, res, effs
   else
     Misc.fatal_errorf

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -32,16 +32,19 @@ end
 
 (* Bind a Cmm variable to the result of translating a [Simple] into Cmm. *)
 
-let bind_var_to_simple ~dbg env v ~num_normal_occurrences_of_bound_vars s =
-  let defining_expr, env, effects_and_coeffects_of_defining_expr =
-    C.simple ~dbg env s
+let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
+  let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
+    C.simple ~dbg env res s
   in
-  Env.bind_variable env v ~effects_and_coeffects_of_defining_expr ~defining_expr
-    ~num_normal_occurrences_of_bound_vars
+  let env =
+    Env.bind_variable env v ~effects_and_coeffects_of_defining_expr ~defining_expr
+      ~num_normal_occurrences_of_bound_vars
+  in
+  env, res
 
 (* Helpers for the translation of [Apply] expressions. *)
 
-let translate_apply0 env apply =
+let translate_apply0 env res apply =
   let callee_simple = Apply.callee apply in
   let args = Apply.args apply in
   let dbg = Apply.dbg apply in
@@ -50,8 +53,8 @@ let translate_apply0 env apply =
      effects/coeffects values currently ignored on the following two lines. At
      the moment they can be ignored as we always deem all calls to have
      arbitrary effects and coeffects. *)
-  let callee, env, _ = C.simple ~dbg env callee_simple in
-  let args, env, _ = C.simple_list ~dbg env args in
+  let callee, env, res, _ = C.simple ~dbg env res callee_simple in
+  let args, env, res, _ = C.simple_list ~dbg env res args in
   let fail_if_probe apply =
     match Apply.probe_name apply with
     | None -> ()
@@ -91,21 +94,21 @@ let translate_apply0 env apply =
       ( C.direct_call ~dbg ty pos
           (C.symbol_from_linkage_name ~dbg code_linkage_name)
           args,
-        env,
+        env, res,
         Ece.all )
     | Some name ->
       ( C.probe ~dbg ~name
           ~handler_code_linkage_name:(Linkage_name.to_string code_linkage_name)
           ~args
         |> C.return_unit dbg,
-        env,
+        env, res,
         Ece.all ))
   | Function { function_call = Indirect_unknown_arity; alloc_mode } ->
     fail_if_probe apply;
     ( C.indirect_call ~dbg Cmm.typ_val pos
         (Alloc_mode.For_types.to_lambda alloc_mode)
         callee args,
-      env,
+      env, res,
       Ece.all )
   | Function
       { function_call = Indirect_known_arity { return_arity; param_arity };
@@ -125,7 +128,7 @@ let translate_apply0 env apply =
       ( C.indirect_full_call ~dbg ty pos
           (Alloc_mode.For_types.to_lambda alloc_mode)
           callee args,
-        env,
+        env, res,
         Ece.all )
   | Call_kind.C_call { alloc; return_arity; param_arity; is_c_builtin } ->
     fail_if_probe apply;
@@ -162,22 +165,22 @@ let translate_apply0 env apply =
     in
     ( wrap dbg
         (C.extcall ~dbg ~alloc ~is_c_builtin ~returns ~ty_args callee ty args),
-      env,
+      env, res,
       Ece.all )
   | Call_kind.Method { kind; obj; alloc_mode } ->
     fail_if_probe apply;
-    let obj, env, _ = C.simple ~dbg env obj in
+    let obj, env, res, _ = C.simple ~dbg env res obj in
     let kind = Call_kind.Method_kind.to_lambda kind in
     let alloc_mode = Alloc_mode.For_types.to_lambda alloc_mode in
-    C.send kind callee obj args (pos, alloc_mode) dbg, env, Ece.all
+    C.send kind callee obj args (pos, alloc_mode) dbg, env, res, Ece.all
 
 (* Function calls that have an exn continuation with extra arguments must be
    wrapped with assignments for the mutable variables used to pass the extra
    arguments. *)
 (* CR mshinwell: Add first-class support in Cmm for the concept of an exception
    handler with extra arguments. *)
-let translate_apply env apply =
-  let call, env, effs = translate_apply0 env apply in
+let translate_apply env res apply =
+  let call, env, res, effs = translate_apply0 env res apply in
   let dbg = Apply.dbg apply in
   let k_exn = Apply.exn_continuation apply in
   let mut_vars =
@@ -189,12 +192,12 @@ let translate_apply env apply =
     (* Note wrt evaluation order: this is correct for the same reason as
        `To_cmm_shared.simple_list`, namely the first simple translated (and
        potentially inlined/substituted) is evaluted last. *)
-    let aux (call, env) (arg, _k) v =
-      let arg, env, _ = C.simple ~dbg env arg in
-      C.sequence (C.assign v arg) call, env
+    let aux (call, env, res) (arg, _k) v =
+      let arg, env, res, _ = C.simple ~dbg env res arg in
+      C.sequence (C.assign v arg) call, env, res
     in
-    let call, env = List.fold_left2 aux (call, env) extra_args mut_vars in
-    call, env, effs
+    let call, env, res = List.fold_left2 aux (call, env, res) extra_args mut_vars in
+    call, env, res, effs
   else
     Misc.fatal_errorf
       "Length of [extra_args] in exception continuation %a@ does not match \
@@ -208,7 +211,7 @@ let translate_apply env apply =
 (* Exception continuations always receive the exception value in their first
    argument. Additionally, they may have extra arguments that are passed to the
    handler via mutable variables (expected to be spilled to the stack). *)
-let translate_raise env apply exn_handler args =
+let translate_raise env res apply exn_handler args =
   match args with
   | exn :: extra ->
     let raise_kind =
@@ -221,17 +224,17 @@ let translate_raise env apply exn_handler args =
           Apply_cont.print apply
     in
     let dbg = Apply_cont.debuginfo apply in
-    let exn, env, _ = C.simple ~dbg env exn in
-    let extra, env, _ = C.simple_list ~dbg env extra in
+    let exn, env, res, _ = C.simple ~dbg env res exn in
+    let extra, env, res, _ = C.simple_list ~dbg env res extra in
     let mut_vars = Env.get_exn_extra_args env exn_handler in
-    let wrap, _ = Env.flush_delayed_lets env in
+    let wrap, _, res = Env.flush_delayed_lets env res in
     let cmm =
       List.fold_left2
         (fun expr arg v -> C.sequence (C.assign v arg) expr)
         (C.raise_prim raise_kind exn dbg)
         extra mut_vars
     in
-    wrap cmm
+    wrap cmm, res
   | [] ->
     Misc.fatal_errorf "Exception continuation %a has no arguments:@ \n%a"
       Continuation.print exn_handler Apply_cont.print apply
@@ -248,8 +251,8 @@ let translate_jump_to_continuation env res apply types cont args =
         [Cmm.Push cont]
     in
     let dbg = Apply_cont.debuginfo apply in
-    let args, env, _ = C.simple_list ~dbg env args in
-    let wrap, _ = Env.flush_delayed_lets env in
+    let args, env, res, _ = C.simple_list ~dbg env res args in
+    let wrap, _, res = Env.flush_delayed_lets env res in
     wrap (C.cexit cont args trap_actions), res
   else
     Misc.fatal_errorf "Types (%a) do not match arguments of@ %a"
@@ -258,15 +261,15 @@ let translate_jump_to_continuation env res apply types cont args =
 
 (* A call to the return continuation of the current block simply is the return
    value for the current block being translated. *)
-let translate_jump_to_return_continuation env apply return_cont args =
+let translate_jump_to_return_continuation env res apply return_cont args =
   match args with
   | [return_value] -> (
     let dbg = Apply_cont.debuginfo apply in
-    let return_value, env, _ = C.simple ~dbg env return_value in
-    let wrap, _ = Env.flush_delayed_lets env in
+    let return_value, env, res, _ = C.simple ~dbg env res return_value in
+    let wrap, _, res = Env.flush_delayed_lets env res in
     match Apply_cont.trap_action apply with
-    | None -> wrap return_value
-    | Some (Pop _) -> wrap (C.trap_return return_value [Cmm.Pop])
+    | None -> wrap return_value, res
+    | Some (Pop _) -> wrap (C.trap_return return_value [Cmm.Pop]), res
     | Some (Push _) ->
       Misc.fatal_errorf
         "Return continuation %a should not be applied with a Push trap action"
@@ -298,8 +301,8 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
     (* CR mshinwell: Try to get a proper [dbg] here (although the majority of
        these bindings should have been substituted out). *)
     let dbg = Debuginfo.none in
-    let env =
-      bind_var_to_simple ~dbg env v ~num_normal_occurrences_of_bound_vars s
+    let env, res =
+      bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s
     in
     expr env res body
   | Singleton _, Prim (p, _)
@@ -330,15 +333,14 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
       expr env res body
     in
     let complex_case (inline : Env.complex Env.inline) =
-      let defining_expr, extra, env, res, args_effs =
+      let defining_expr, env, res, args_effs =
         To_cmm_primitive.prim_complex env res dbg p
-          ~effects_and_coeffects_of_prim
       in
       let effects_and_coeffects_of_defining_expr =
         Ece.join args_effs effects_and_coeffects_of_prim
       in
       let env =
-        Env.bind_variable_to_primitive ?extra env v ~inline
+        Env.bind_variable_to_primitive env v ~inline
           ~effects_and_coeffects_of_defining_expr ~defining_expr
       in
       expr env res body
@@ -363,7 +365,7 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
     match update_opt with
     | None -> expr env res body
     | Some update ->
-      let wrap, env = Env.flush_delayed_lets env in
+      let wrap, env, res = Env.flush_delayed_lets env res in
       let body, res = expr env res body in
       wrap (C.sequence update body), res)
   | Singleton _, Rec_info _ -> expr env res body
@@ -423,7 +425,7 @@ and let_cont_not_inlined env res k handler body =
   (* CR gbury: "split" the environment according to which variables the handler
      and the body uses, to allow for inlining to proceed within each
      expression. *)
-  let wrap, env = Env.flush_delayed_lets env in
+  let wrap, env, res = Env.flush_delayed_lets env res in
   let is_exn_handler = Continuation_handler.is_exn_handler handler in
   let vars, arity, handler, res = continuation_handler env res handler in
   let catch_id, env =
@@ -505,7 +507,7 @@ and let_cont_rec env res conts body =
      occurrence) *)
   (* CR-someday mshinwell: As discussed, the tradeoff here is not clear, since
      flushing might increase register pressure. *)
-  let wrap, env = Env.flush_delayed_lets ~entering_loop:true env in
+  let wrap, env, res = Env.flush_delayed_lets ~entering_loop:true env res in
   (* Compute the environment for Ccatch ids *)
   let conts_to_handlers = Continuation_handlers.to_map conts in
   let env =
@@ -550,7 +552,7 @@ and continuation_handler env res handler =
       vars, arity, expr, res)
 
 and apply_expr env res apply =
-  let call, env, effs = translate_apply env apply in
+  let call, env, res, effs = translate_apply env res apply in
   (* With respect to flushing the environment we have three cases:
 
      1. The call never returns or jumps to another function
@@ -574,11 +576,11 @@ and apply_expr env res apply =
   match Apply.continuation apply with
   | Never_returns ->
     (* Case 1 *)
-    let wrap, _ = Env.flush_delayed_lets env in
+    let wrap, _, res = Env.flush_delayed_lets env res in
     wrap call, res
   | Return k when Continuation.equal (Env.return_continuation env) k ->
     (* Case 1 *)
-    let wrap, _ = Env.flush_delayed_lets env in
+    let wrap, _, res = Env.flush_delayed_lets env res in
     wrap call, res
   | Return k -> (
     let[@inline always] unsupported () =
@@ -593,7 +595,7 @@ and apply_expr env res apply =
     | Jump { param_types = []; cont = _ } -> unsupported ()
     | Jump { param_types = [_]; cont } ->
       (* Case 2 *)
-      let wrap, _ = Env.flush_delayed_lets env in
+      let wrap, _, res = Env.flush_delayed_lets env res in
       wrap (C.cexit cont [call] []), res
     | Inline { handler_params; handler_body = body; handler_params_occurrences }
       -> (
@@ -616,9 +618,9 @@ and apply_cont env res apply_cont =
   let k = Apply_cont.continuation apply_cont in
   let args = Apply_cont.args apply_cont in
   if Env.is_exn_handler env k
-  then translate_raise env apply_cont k args, res
+  then translate_raise env res apply_cont k args
   else if Continuation.equal (Env.return_continuation env) k
-  then translate_jump_to_return_continuation env apply_cont k args, res
+  then translate_jump_to_return_continuation env res apply_cont k args
   else
     match Env.get_continuation env k with
     | Jump { param_types; cont } ->
@@ -633,15 +635,15 @@ and apply_cont env res apply_cont =
       let handler_params = Bound_parameters.to_list handler_params in
       if List.compare_lengths args handler_params = 0
       then
-        let env =
+        let env, res =
           List.fold_left2
-            (fun env param ->
+            (fun (env, res) param ->
               bind_var_to_simple
                 ~dbg:(Apply_cont.debuginfo apply_cont)
-                env
+                env res
                 (Bound_parameter.var param)
                 ~num_normal_occurrences_of_bound_vars:handler_params_occurrences)
-            env handler_params args
+            (env, res) handler_params args
         in
         expr env res handler_body
       else
@@ -654,7 +656,7 @@ and apply_cont env res apply_cont =
 and switch env res switch =
   let scrutinee = Switch.scrutinee switch in
   let dbg = Switch.condition_dbg switch in
-  let untagged_scrutinee_cmm, env, _ = C.simple ~dbg env scrutinee in
+  let untagged_scrutinee_cmm, env, res, _ = C.simple ~dbg env res scrutinee in
   let arms = Switch.arms switch in
   (* For binary switches, which can be translated to an if-then-else, it can be
      interesting for the scrutinee to be tagged (particularly for switches
@@ -690,7 +692,7 @@ and switch env res switch =
         else untagged_scrutinee_cmm, false)
     | _ -> untagged_scrutinee_cmm, false
   in
-  let wrap, env = Env.flush_delayed_lets env in
+  let wrap, env, res = Env.flush_delayed_lets env res in
   let prepare_discriminant ~must_tag d =
     let targetint_d = Targetint_31_63.to_targetint d in
     Targetint_32_64.to_int_checked

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -702,27 +702,29 @@ let trans_prim : To_cmm_env.t To_cmm_env.trans_prim =
 
 let consider_inlining_effectful_expressions p =
   (* By default we are very conservative about the inlining of effectful
-     expressions into the arguments of primitives. We consider inlining
-     in the following cases:
+     expressions into the arguments of primitives. We consider inlining in the
+     following cases:
 
      - in the case where the primitive compiles directly to an allocation.
-       Unlike for most primitives, inlining of the arguments gives a real
-       benefit for these, by keeping live ranges shorter (which could be
-       critical for register allocation performance in cases such as
-       initialisation of very large arrays). We are also confident that the code
-       for compiling allocations does not incorrectly reorder or duplicate
-       arguments, whereas we are not universally confident about that for the
-       other Cmm translation functions.
+     Unlike for most primitives, inlining of the arguments gives a real benefit
+     for these, by keeping live ranges shorter (which could be critical for
+     register allocation performance in cases such as initialisation of very
+     large arrays). We are also confident that the code for compiling
+     allocations does not incorrectly reorder or duplicate arguments, whereas we
+     are not universally confident about that for the other Cmm translation
+     functions.
 
-     This criterion should not be relaxed for any primitive until it is
-     certain that the Cmm translation for such primitive both respects
-     right-to-left evaluation order and does not duplicate any arguments. *)
-    match[@ocaml.warning "-4"] (p : P.t) with
-    | Variadic ((Make_block _ | Make_array _), _) -> Some true
-    | Nullary _ | Unary _ | Binary _ | Ternary _ -> None
+     This criterion should not be relaxed for any primitive until it is certain
+     that the Cmm translation for such primitive both respects right-to-left
+     evaluation order and does not duplicate any arguments. *)
+  match[@ocaml.warning "-4"] (p : P.t) with
+  | Variadic ((Make_block _ | Make_array _), _) -> Some true
+  | Nullary _ | Unary _ | Binary _ | Ternary _ -> None
 
 let prim_simple env res dbg p =
-  let consider_inlining_effectful_expressions = consider_inlining_effectful_expressions p in
+  let consider_inlining_effectful_expressions =
+    consider_inlining_effectful_expressions p
+  in
   let arg = arg ?consider_inlining_effectful_expressions ~dbg in
   (* Somewhat counter-intuitively, the left-to-right translation below (e.g. [x]
      before [y] in the [Binary] case) correctly matches right-to-left evaluation
@@ -768,7 +770,9 @@ let prim_simple env res dbg p =
     Env.simple expr, None, env, res, effs
 
 let prim_complex env res dbg p =
-  let consider_inlining_effectful_expressions = consider_inlining_effectful_expressions p in
+  let consider_inlining_effectful_expressions =
+    consider_inlining_effectful_expressions p
+  in
   let arg = arg ?consider_inlining_effectful_expressions ~dbg in
   (* see comment in [prim_simple] *)
   let prim', args, effs, env, res =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -672,7 +672,9 @@ let arg_list ?consider_inlining_effectful_expressions ~dbg env l =
     let y, env, eff = arg ?consider_inlining_effectful_expressions ~dbg env x in
     y :: list, env, Ece.join eff effs
   in
-  let args, env, effs = List.fold_left aux ([], env, Ece.pure_duplicatable) l in
+  let args, env, effs =
+    List.fold_left aux ([], env, Ece.pure_can_be_duplicated) l
+  in
   List.rev args, env, effs
 
 let arg_list' ?consider_inlining_effectful_expressions ~dbg env l =
@@ -680,7 +682,9 @@ let arg_list' ?consider_inlining_effectful_expressions ~dbg env l =
     let y, env, eff = arg ?consider_inlining_effectful_expressions ~dbg env x in
     (y, eff) :: list, env, Ece.join eff effs
   in
-  let args, env, effs = List.fold_left aux ([], env, Ece.pure_duplicatable) l in
+  let args, env, effs =
+    List.fold_left aux ([], env, Ece.pure_can_be_duplicated) l
+  in
   List.rev args, env, effs
 
 let prim_simple env res dbg p =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -541,7 +541,8 @@ let unary_primitive env res dbg f arg =
   | String_length _ -> None, res, fun arg -> C.string_length arg dbg
   | Int_as_pointer -> None, res, fun arg -> C.int_as_pointer arg dbg
   | Opaque_identity { middle_end_only = true } -> None, res, fun arg -> arg
-  | Opaque_identity { middle_end_only = false } -> None, res, fun arg -> C.opaque arg dbg
+  | Opaque_identity { middle_end_only = false } ->
+    None, res, fun arg -> C.opaque arg dbg
   | Int_arith (kind, op) ->
     None, res, fun arg -> unary_int_arith_primitive env dbg kind op arg
   | Float_arith op ->

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -263,46 +263,46 @@ let arithmetic_conversion dbg src dst arg =
   let open K.Standard_int_or_float in
   match src, dst with
   (* Identity on floats *)
-  | Naked_float, Naked_float -> None, arg
+  | Naked_float, Naked_float -> None, Fun.id
   (* Conversions to and from tagged ints *)
   | ( (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate),
       Tagged_immediate ) ->
-    None, C.tag_int arg dbg
+    None, fun arg -> C.tag_int arg dbg
   | Tagged_immediate, (Naked_int64 | Naked_nativeint) ->
-    Some (Env.Untag arg), C.untag_int arg dbg
+    Some (Env.Untag arg), fun arg -> C.untag_int arg dbg
   (* Operations resulting in int32s must take care to sign extend the result *)
   (* CR-someday xclerc: untag_int followed by sign_extend_32 sounds suboptimal,
      as it performs asr 1; lsl 32; asr 32 while we could do lsl 31; asr 32
      instead. (Beware of the optimizations / pattern matching in the helpers
      though.) *)
   | Tagged_immediate, Naked_int32 ->
-    None, C.sign_extend_32 dbg (C.untag_int arg dbg)
+    None, fun arg -> C.sign_extend_32 dbg (C.untag_int arg dbg)
   | Tagged_immediate, Naked_immediate ->
-    None, C.sign_extend_63 dbg (C.untag_int arg dbg)
+    None, fun arg -> C.sign_extend_63 dbg (C.untag_int arg dbg)
   | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Naked_int32
     ->
-    None, C.sign_extend_32 dbg arg
+    None, fun arg -> C.sign_extend_32 dbg arg
   (* No-op conversions *)
   | Tagged_immediate, Tagged_immediate
   | Naked_int32, (Naked_int64 | Naked_nativeint | Naked_immediate)
   | Naked_int64, (Naked_int64 | Naked_nativeint | Naked_immediate)
   | Naked_nativeint, (Naked_int64 | Naked_nativeint | Naked_immediate)
   | Naked_immediate, (Naked_int64 | Naked_nativeint | Naked_immediate) ->
-    None, arg
+    None, Fun.id
   (* Int-Float conversions *)
   | Tagged_immediate, Naked_float ->
-    None, C.float_of_int ~dbg (C.untag_int arg dbg)
+    None, fun arg -> C.float_of_int ~dbg (C.untag_int arg dbg)
   | (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint), Naked_float
     ->
-    None, C.float_of_int ~dbg arg
+    None, fun arg -> C.float_of_int ~dbg arg
   | Naked_float, Tagged_immediate ->
-    None, C.tag_int (C.int_of_float ~dbg arg) dbg
+    None, fun arg -> C.tag_int (C.int_of_float ~dbg arg) dbg
   | Naked_float, (Naked_int64 | Naked_nativeint) ->
-    None, C.int_of_float ~dbg arg
+    None, fun arg -> C.int_of_float ~dbg arg
   | Naked_float, Naked_int32 ->
-    None, C.sign_extend_32 dbg (C.int_of_float ~dbg arg)
+    None, fun arg -> C.sign_extend_32 dbg (C.int_of_float ~dbg arg)
   | Naked_float, Naked_immediate ->
-    None, C.sign_extend_63 dbg (C.int_of_float ~dbg arg)
+    None, fun arg -> C.sign_extend_63 dbg (C.int_of_float ~dbg arg)
 
 let phys_equal _env dbg op x y =
   match (op : P.equality_comparison) with
@@ -526,83 +526,89 @@ let unary_primitive env res dbg f arg =
   | Duplicate_array _ | Duplicate_block _ | Obj_dup ->
     ( None,
       res,
-      C.extcall ~dbg ~alloc:true ~returns:true ~is_c_builtin:false ~ty_args:[]
-        "caml_obj_dup" Cmm.typ_val [arg] )
-  | Is_int _ -> None, res, C.and_int arg (C.int ~dbg 1) dbg
-  | Get_tag -> None, res, C.get_tag arg dbg
-  | Array_length -> None, res, array_length ~dbg arg
+      fun arg ->
+        C.extcall ~dbg ~alloc:true ~returns:true ~is_c_builtin:false ~ty_args:[]
+          "caml_obj_dup" Cmm.typ_val [arg] )
+  | Is_int _ -> None, res, fun arg -> C.and_int arg (C.int ~dbg 1) dbg
+  | Get_tag -> None, res, fun arg -> C.get_tag arg dbg
+  | Array_length -> None, res, fun arg -> array_length ~dbg arg
   | Bigarray_length { dimension } ->
     ( None,
       res,
-      C.load ~dbg Word_int Mutable
-        ~addr:(C.field_address arg (4 + dimension) dbg) )
-  | String_length _ -> None, res, C.string_length arg dbg
-  | Int_as_pointer -> None, res, C.int_as_pointer arg dbg
-  | Opaque_identity { middle_end_only = true } -> None, res, arg
-  | Opaque_identity { middle_end_only = false } -> None, res, C.opaque arg dbg
+      fun arg ->
+        C.load ~dbg Word_int Mutable
+          ~addr:(C.field_address arg (4 + dimension) dbg) )
+  | String_length _ -> None, res, fun arg -> C.string_length arg dbg
+  | Int_as_pointer -> None, res, fun arg -> C.int_as_pointer arg dbg
+  | Opaque_identity { middle_end_only = true } -> None, res, fun arg -> arg
+  | Opaque_identity { middle_end_only = false } -> None, res, fun arg -> C.opaque arg dbg
   | Int_arith (kind, op) ->
-    None, res, unary_int_arith_primitive env dbg kind op arg
-  | Float_arith op -> None, res, unary_float_arith_primitive env dbg op arg
+    None, res, fun arg -> unary_int_arith_primitive env dbg kind op arg
+  | Float_arith op ->
+    None, res, fun arg -> unary_float_arith_primitive env dbg op arg
   | Num_conv { src; dst } ->
     let extra, expr = arithmetic_conversion dbg src dst arg in
     extra, res, expr
-  | Boolean_not -> None, res, C.mk_not dbg arg
+  | Boolean_not -> None, res, fun arg -> C.mk_not dbg arg
   | Reinterpret_int64_as_float ->
     (* CR-someday mshinwell: We should add support for this operation in the
        backend. It isn't the identity as there may need to be a move between
        different register kinds (e.g. integer to XMM registers on x86-64). *)
     ( None,
       res,
-      C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:false
-        ~ty_args:[C.exttype_of_kind K.naked_int64]
-        "caml_int64_float_of_bits_unboxed" Cmm.typ_float [arg] )
-  | Unbox_number kind -> None, res, unbox_number ~dbg kind arg
-  | Untag_immediate -> Some (Env.Untag arg), res, C.untag_int arg dbg
+      fun arg ->
+        C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:false
+          ~ty_args:[C.exttype_of_kind K.naked_int64]
+          "caml_int64_float_of_bits_unboxed" Cmm.typ_float [arg] )
+  | Unbox_number kind -> None, res, fun arg -> unbox_number ~dbg kind arg
+  | Untag_immediate -> Some (Env.Untag arg), res, fun arg -> C.untag_int arg dbg
   | Box_number (kind, alloc_mode) ->
-    Some Env.Boxed_number, res, box_number ~dbg kind alloc_mode arg
+    Some Env.Boxed_number, res, fun arg -> box_number ~dbg kind alloc_mode arg
   | Tag_immediate ->
     (* We could return [Env.Tag] here, but probably unnecessary at the
        moment. *)
-    None, res, C.tag_int arg dbg
+    None, res, fun arg -> C.tag_int arg dbg
   | Project_function_slot { move_from = c1; move_to = c2 } -> (
     match function_slot_offset env c1, function_slot_offset env c2 with
     | ( Live_function_slot { offset = c1_offset; _ },
         Live_function_slot { offset = c2_offset; _ } ) ->
       (* Normal case. *)
       let diff = c2_offset - c1_offset in
-      None, res, C.infix_field_address ~dbg arg diff
+      None, res, fun arg -> C.infix_field_address ~dbg arg diff
     | Dead_function_slot, Live_function_slot _ ->
       (* Code whose projections involve dead slots (ones that have been removed)
          should be unreachable. *)
       let message = dead_slots_msg dbg [c1] [] in
       let expr, res = C.invalid res ~message in
-      None, res, expr
+      None, res, fun _ -> expr
     | Live_function_slot _, Dead_function_slot ->
       let message = dead_slots_msg dbg [c2] [] in
       let expr, res = C.invalid res ~message in
-      None, res, expr
+      None, res, fun _ -> expr
     | Dead_function_slot, Dead_function_slot ->
       let message = dead_slots_msg dbg [c1; c2] [] in
       let expr, res = C.invalid res ~message in
-      None, res, expr)
+      None, res, fun _ -> expr)
   | Project_value_slot { project_from; value_slot } -> (
     match
       value_slot_offset env value_slot, function_slot_offset env project_from
     with
     | Live_value_slot { offset }, Live_function_slot { offset = base; _ } ->
-      None, res, C.get_field_gen Asttypes.Immutable arg (offset - base) dbg
+      ( None,
+        res,
+        fun arg -> C.get_field_gen Asttypes.Immutable arg (offset - base) dbg )
     | Dead_value_slot, Live_function_slot _ ->
       let message = dead_slots_msg dbg [] [value_slot] in
       let expr, res = C.invalid res ~message in
-      None, res, expr
+      None, res, fun _ -> expr
     | Live_value_slot _, Dead_function_slot ->
       let message = dead_slots_msg dbg [project_from] [] in
       let expr, res = C.invalid res ~message in
-      None, res, expr
+      None, res, fun _ -> expr
     | Dead_value_slot, Dead_function_slot ->
       let message = dead_slots_msg dbg [project_from] [value_slot] in
       let expr, res = C.invalid res ~message in
-      None, res, expr)
+      None, res, fun _ -> expr)
   | Is_boxed_float ->
     (* As a note, this omits the [Is_in_value_area] check that exists in
        [caml_make_array], which is used by non-Flambda 2 compilers. This seems
@@ -610,14 +616,15 @@ let unary_primitive env res dbg f arg =
        that they will be forbidden entirely in OCaml 5. *)
     ( None,
       res,
-      C.ite
-        (C.and_int arg (C.int 1 ~dbg) dbg)
-        ~dbg ~then_:(C.int 0 ~dbg) ~then_dbg:dbg
-        ~else_:(C.eq (C.get_tag arg dbg) (C.int Obj.double_tag ~dbg) ~dbg)
-        ~else_dbg:dbg )
+      fun arg ->
+        C.ite
+          (C.and_int arg (C.int 1 ~dbg) dbg)
+          ~dbg ~then_:(C.int 0 ~dbg) ~then_dbg:dbg
+          ~else_:(C.eq (C.get_tag arg dbg) (C.int Obj.double_tag ~dbg) ~dbg)
+          ~else_dbg:dbg )
   | Is_flat_float_array ->
-    None, res, C.eq ~dbg (C.get_tag arg dbg) (C.floatarray_tag dbg)
-  | End_region -> None, res, C.return_unit dbg (C.endregion ~dbg arg)
+    None, res, fun arg -> C.eq ~dbg (C.get_tag arg dbg) (C.floatarray_tag dbg)
+  | End_region -> None, res, fun arg -> C.return_unit dbg (C.endregion ~dbg arg)
 
 let binary_primitive env dbg f x y =
   match (f : P.binary_primitive) with
@@ -656,7 +663,26 @@ let variadic_primitive _env dbg f args =
   | Make_block (kind, _mut, alloc_mode) -> make_block ~dbg kind alloc_mode args
   | Make_array (kind, _mut, alloc_mode) -> make_array ~dbg kind alloc_mode args
 
-let prim env res dbg (p : P.t) =
+let arg ?consider_inlining_effectful_expressions ~dbg env simple =
+  C.simple ?consider_inlining_effectful_expressions ~dbg env simple
+
+let arg_list ?consider_inlining_effectful_expressions ~dbg env l =
+  let aux (list, env, effs) x =
+    let y, env, eff = arg ?consider_inlining_effectful_expressions ~dbg env x in
+    y :: list, env, Ece.join eff effs
+  in
+  let args, env, effs = List.fold_left aux ([], env, Ece.pure_duplicatable) l in
+  List.rev args, env, effs
+
+let arg_list' ?consider_inlining_effectful_expressions ~dbg env l =
+  let aux (list, env, effs) x =
+    let y, env, eff = arg ?consider_inlining_effectful_expressions ~dbg env x in
+    (y, eff) :: list, env, Ece.join eff effs
+  in
+  let args, env, effs = List.fold_left aux ([], env, Ece.pure_duplicatable) l in
+  List.rev args, env, effs
+
+let prim_simple env res dbg p =
   let consider_inlining_effectful_expressions =
     (* By default we are very conservative about the inlining of effectful
        expressions into the arguments of primitives. We only consider inlining
@@ -672,11 +698,11 @@ let prim env res dbg (p : P.t) =
        This criterion should not be relaxed for any primitive until it is
        certain that the Cmm translation for such primitive both respects
        right-to-left evaluation order and does not duplicate any arguments. *)
-    match p with
+    match (p : P.t) with
     | Nullary _ | Unary _ | Binary _ | Ternary _ -> None
     | Variadic ((Make_block _ | Make_array _), _) -> Some true
   in
-  let simple = C.simple ?consider_inlining_effectful_expressions ~dbg in
+  let arg = arg ?consider_inlining_effectful_expressions ~dbg in
   (* Somewhat counter-intuitively, the left-to-right translation below (e.g. [x]
      before [y] in the [Binary] case) correctly matches right-to-left evaluation
      order---ensuring maximal inlining---since [C.simple_list] translates the
@@ -692,30 +718,90 @@ let prim env res dbg (p : P.t) =
      desired output Make_block [effect-y; effect-x]. The backend will compile
      this to run effect-x before effect-y by virtue of right-to-left evaluation
      order. This therefore matches the original source code. *)
-  match p with
+  match (p : P.t) with
   | Nullary prim ->
     let extra, expr, res = nullary_primitive env res dbg prim in
-    expr, extra, env, res, Ece.pure
+    Env.simple expr, extra, env, res, Ece.pure
   | Unary (unary, x) ->
-    let x, env, eff = simple env x in
+    let x, env, eff = arg env x in
     let extra, res, expr = unary_primitive env res dbg unary x in
-    expr, extra, env, res, eff
+    Env.simple (expr x), extra, env, res, eff
   | Binary (binary, x, y) ->
-    let x, env, effx = simple env x in
-    let y, env, effy = simple env y in
+    let x, env, effx = arg env x in
+    let y, env, effy = arg env y in
     let effs = Ece.join effx effy in
     let expr = binary_primitive env dbg binary x y in
-    expr, None, env, res, effs
+    Env.simple expr, None, env, res, effs
   | Ternary (ternary, x, y, z) ->
-    let x, env, effx = simple env x in
-    let y, env, effy = simple env y in
-    let z, env, effz = simple env z in
+    let x, env, effx = arg env x in
+    let y, env, effy = arg env y in
+    let z, env, effz = arg env z in
     let effs = Ece.join (Ece.join effx effy) effz in
     let expr = ternary_primitive env dbg ternary x y z in
-    expr, None, env, res, effs
+    Env.simple expr, None, env, res, effs
   | Variadic (((Make_block _ | Make_array _) as variadic), l) ->
     let args, env, effs =
-      C.simple_list ?consider_inlining_effectful_expressions ~dbg env l
+      arg_list ?consider_inlining_effectful_expressions ~dbg env l
     in
     let expr = variadic_primitive env dbg variadic args in
-    expr, None, env, res, effs
+    Env.simple expr, None, env, res, effs
+
+let prim_complex ~effects_and_coeffects_of_prim env res dbg p =
+  let consider_inlining_effectful_expressions =
+    (* see comment in [prim] *)
+    match (p : P.t) with
+    | Nullary _ | Unary _ | Binary _ | Ternary _ -> None
+    | Variadic ((Make_block _ | Make_array _), _) -> Some true
+  in
+  let arg = arg ?consider_inlining_effectful_expressions ~dbg in
+  (* see comment in [prim] *)
+  let prim', make_expr, args, extra, env, res, effs =
+    match (p : P.t) with
+    | Nullary prim ->
+      let prim' = P.Without_args.Nullary prim in
+      let extra, expr, res = nullary_primitive env res dbg prim in
+      let make_expr _ = expr in
+      prim', make_expr, [], extra, env, res, Ece.pure
+    | Unary (unary, x) ->
+      let prim' = P.Without_args.Unary unary in
+      let x, env, eff = arg env x in
+      let extra, res, expr = unary_primitive env res dbg unary x in
+      let make_expr = function
+        | [arg] -> expr arg
+        | _ -> Misc.fatal_errorf "bad arity for split unary primitive"
+      in
+      prim', make_expr, [x, eff], extra, env, res, eff
+    | Binary (binary, x, y) ->
+      let prim' = P.Without_args.Binary binary in
+      let x, env, effx = arg env x in
+      let y, env, effy = arg env y in
+      let effs = Ece.join effx effy in
+      let make_expr = function
+        | [x; y] -> binary_primitive env dbg binary x y
+        | _ -> Misc.fatal_errorf "bad arity for split binary primitive"
+      in
+      prim', make_expr, [x, effx; y, effy], None, env, res, effs
+    | Ternary (ternary, x, y, z) ->
+      let prim' = P.Without_args.Ternary ternary in
+      let x, env, effx = arg env x in
+      let y, env, effy = arg env y in
+      let z, env, effz = arg env z in
+      let effs = Ece.join (Ece.join effx effy) effz in
+      let make_expr = function
+        | [x; y; z] -> ternary_primitive env dbg ternary x y z
+        | _ -> Misc.fatal_errorf "bad arity for split ternary primitive"
+      in
+      prim', make_expr, [x, effx; y, effy; z, effz], None, env, res, effs
+    | Variadic (((Make_block _ | Make_array _) as variadic), l) ->
+      let prim' = P.Without_args.Variadic variadic in
+      let args, env, effs =
+        arg_list' ?consider_inlining_effectful_expressions ~dbg env l
+      in
+      let make_expr args = variadic_primitive env dbg variadic args in
+      prim', make_expr, args, None, env, res, effs
+  in
+  let name = Format.asprintf "%a" P.Without_args.print prim' in
+  let bound_expr =
+    Env.splittable_primitive name args effects_and_coeffects_of_prim make_expr
+  in
+  bound_expr, extra, env, res, effs

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.mli
@@ -14,6 +14,8 @@
 
 (** Translation of Flambda primitives to Cmm. *)
 
+val trans_prim : To_cmm_env.t To_cmm_env.trans_prim
+
 val prim_simple :
   To_cmm_env.t ->
   To_cmm_result.t ->
@@ -26,13 +28,11 @@ val prim_simple :
   * Effects_and_coeffects.t
 
 val prim_complex :
-  effects_and_coeffects_of_prim:Flambda2_terms.Effects_and_coeffects.t ->
   To_cmm_env.t ->
   To_cmm_result.t ->
   Debuginfo.t ->
   Flambda_primitive.t ->
   To_cmm_env.complex To_cmm_env.bound_expr
-  * To_cmm_env.extra_info option
   * To_cmm_env.t
   * To_cmm_result.t
   * Effects_and_coeffects.t

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -74,7 +74,10 @@ module Make_layout_filler (P : sig
     To_cmm_env.t ->
     To_cmm_result.t ->
     Simple.t ->
-    [`Data of cmm_term list | `Var of Variable.t] * To_cmm_env.t * To_cmm_result.t * Ece.t
+    [`Data of cmm_term list | `Var of Variable.t]
+    * To_cmm_env.t
+    * To_cmm_result.t
+    * Ece.t
 
   val infix_header : dbg:Debuginfo.t -> function_slot_offset:int -> cmm_term
 
@@ -93,7 +96,12 @@ end) : sig
     Ece.t ->
     prev_updates:Cmm.expression option ->
     (int * Slot_offsets.Layout.slot) list ->
-    P.cmm_term list * int * Env.t * To_cmm_result.t * Ece.t * Cmm.expression option
+    P.cmm_term list
+    * int
+    * Env.t
+    * To_cmm_result.t
+    * Ece.t
+    * Cmm.expression option
 end = struct
   (* The [offset]s here are measured in units of words. *)
   let fill_slot for_static_sets decls dbg ~startenv value_slots env res acc
@@ -181,8 +189,8 @@ end = struct
         in
         acc, slot_offset + size, env, res, Ece.pure, updates)
 
-  let rec fill_layout0 for_static_sets decls dbg ~startenv value_slots env res effs
-      acc updates ~starting_offset slots =
+  let rec fill_layout0 for_static_sets decls dbg ~startenv value_slots env res
+      effs acc updates ~starting_offset slots =
     match slots with
     | [] -> List.rev acc, starting_offset, env, res, effs, updates
     | (slot_offset, slot) :: slots ->
@@ -202,8 +210,8 @@ end = struct
           ~slot_offset updates slot
       in
       let effs = Ece.join eff effs in
-      fill_layout0 for_static_sets decls dbg ~startenv value_slots env res effs acc
-        updates ~starting_offset:next_offset slots
+      fill_layout0 for_static_sets decls dbg ~startenv value_slots env res effs
+        acc updates ~starting_offset:next_offset slots
 
   let fill_layout for_static_sets decls dbg ~startenv value_slots env res effs
       ~prev_updates slots =

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -456,7 +456,7 @@ let lift_set_of_closures env res ~body ~bound_vars layout set ~translate_expr
         let sym = C.symbol ~dbg (Function_slot.Map.find cid closure_symbols) in
         Env.bind_variable acc v ~defining_expr:sym
           ~num_normal_occurrences_of_bound_vars
-          ~effects_and_coeffects_of_defining_expr:Ece.pure_duplicatable)
+          ~effects_and_coeffects_of_defining_expr:Ece.pure_can_be_duplicated)
       env cids bound_vars
   in
   translate_expr env res body

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -513,7 +513,7 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   assert (
     match To_cmm_effects.classify_by_effects_and_coeffects peff with
     | Pure -> true
-    | Generative_duplicable | Effect | Coeffect_only -> false);
+    | Generative_immutable | Effect | Coeffect_only -> false);
   (* Helper function to get the a cmm expr for a closure offset *)
   let get_closure_by_offset env set_cmm function_slot =
     match

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -215,12 +215,13 @@ module Dynamic = Make_layout_filler (struct
 
   let int ~dbg i = C.nativeint ~dbg i
 
-  (* The reason why we can inline simple here is the same as in
+  (* The reason why we can inline simples here is the same as in
      `To_cmm_shared.simple_list`: the first simple translated (and thus in which
      an inlining/substitution can occur), is the last simple that will be
      evaluated, according to the right-to-left evaluation order. This is ensured
-     by the fact that we build each field of the set of closure in left-to-right
-     order, so that the first translated field is actually evaluated last. *)
+     by the fact that we build each field of the set of closures in
+     left-to-right order, so that the first translated field is actually
+     evaluated last. *)
   let simple ~dbg env simple =
     let term, env, eff = C.simple ~dbg env simple in
     `Data [term], env, eff

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -514,7 +514,7 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
     match To_cmm_effects.classify_by_effects_and_coeffects peff with
     | Pure -> true
     | Generative_immutable | Effect | Coeffect_only -> false);
-  (* Helper function to get the a cmm expr for a closure offset *)
+  (* Helper function to get the cmm expr for a closure offset *)
   let get_closure_by_offset env set_cmm function_slot =
     match
       Exported_offsets.function_slot_offset (Env.exported_offsets env)

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -21,10 +21,11 @@ type translate_expr =
 
 val let_static_set_of_closures :
   To_cmm_env.t ->
+  To_cmm_result.t ->
   Symbol.t Function_slot.Map.t ->
   Set_of_closures.t ->
   prev_updates:Cmm.expression option ->
-  To_cmm_env.t * Cmm.data_item list * Cmm.expression option
+  To_cmm_env.t * To_cmm_result.t * Cmm.data_item list * Cmm.expression option
 
 val let_dynamic_set_of_closures :
   To_cmm_env.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -65,7 +65,7 @@ let name0 ?consider_inlining_effectful_expressions env name =
       To_cmm_env.inline_variable ?consider_inlining_effectful_expressions env v)
     ~symbol:(fun s ->
       (* CR mshinwell: fix debuginfo? *)
-      symbol ~dbg:Debuginfo.none s, env, Ece.pure_duplicatable)
+      symbol ~dbg:Debuginfo.none s, env, Ece.pure_can_be_duplicated)
 
 let name env name = name0 env name
 
@@ -83,7 +83,7 @@ let simple ?consider_inlining_effectful_expressions ~dbg env s =
   Simple.pattern_match s
     ~name:(fun n ~coercion:_ ->
       name0 ?consider_inlining_effectful_expressions env n)
-    ~const:(fun c -> const ~dbg c, env, Ece.pure_duplicatable)
+    ~const:(fun c -> const ~dbg c, env, Ece.pure_can_be_duplicated)
 
 let name_static name =
   Name.pattern_match name
@@ -117,7 +117,9 @@ let simple_list ?consider_inlining_effectful_expressions ~dbg env l =
     in
     y :: list, env, Ece.join eff effs
   in
-  let args, env, effs = List.fold_left aux ([], env, Ece.pure_duplicatable) l in
+  let args, env, effs =
+    List.fold_left aux ([], env, Ece.pure_can_be_duplicated) l
+  in
   List.rev args, env, effs
 
 let bound_parameters env l =

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -62,7 +62,8 @@ let symbol ~dbg sym = symbol_from_linkage_name ~dbg (Symbol.linkage_name sym)
 let name0 ?consider_inlining_effectful_expressions env res name =
   Name.pattern_match name
     ~var:(fun v ->
-      To_cmm_env.inline_variable ?consider_inlining_effectful_expressions env res v)
+      To_cmm_env.inline_variable ?consider_inlining_effectful_expressions env
+        res v)
     ~symbol:(fun s ->
       (* CR mshinwell: fix debuginfo? *)
       symbol ~dbg:Debuginfo.none s, env, res, Ece.pure_can_be_duplicated)

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -65,7 +65,7 @@ let name0 ?consider_inlining_effectful_expressions env name =
       To_cmm_env.inline_variable ?consider_inlining_effectful_expressions env v)
     ~symbol:(fun s ->
       (* CR mshinwell: fix debuginfo? *)
-      symbol ~dbg:Debuginfo.none s, env, Ece.pure)
+      symbol ~dbg:Debuginfo.none s, env, Ece.pure_duplicatable)
 
 let name env name = name0 env name
 
@@ -83,7 +83,7 @@ let simple ?consider_inlining_effectful_expressions ~dbg env s =
   Simple.pattern_match s
     ~name:(fun n ~coercion:_ ->
       name0 ?consider_inlining_effectful_expressions env n)
-    ~const:(fun c -> const ~dbg c, env, Ece.pure)
+    ~const:(fun c -> const ~dbg c, env, Ece.pure_duplicatable)
 
 let name_static name =
   Name.pattern_match name
@@ -117,12 +117,12 @@ let simple_list ?consider_inlining_effectful_expressions ~dbg env l =
     in
     y :: list, env, Ece.join eff effs
   in
-  let args, env, effs = List.fold_left aux ([], env, Ece.pure) l in
+  let args, env, effs = List.fold_left aux ([], env, Ece.pure_duplicatable) l in
   List.rev args, env, effs
 
 let bound_parameters env l =
   let flambda_vars = Bound_parameters.vars l in
-  let env, cmm_vars = To_cmm_env.create_variables env flambda_vars in
+  let env, cmm_vars = To_cmm_env.create_bound_parameters env flambda_vars in
   let vars =
     List.map2
       (fun v v' -> v, machtype_of_kinded_parameter v')

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -38,8 +38,9 @@ val symbol : dbg:Debuginfo.t -> Symbol.t -> Cmm.expression
 (** This does not inline effectful expressions. *)
 val name :
   To_cmm_env.t ->
+  To_cmm_result.t ->
   Name.t ->
-  Cmm.expression * To_cmm_env.t * Effects_and_coeffects.t
+  Cmm.expression * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
 
 val const : dbg:Debuginfo.t -> Reg_width_const.t -> Cmm.expression
 
@@ -50,8 +51,9 @@ val simple :
   ?consider_inlining_effectful_expressions:bool ->
   dbg:Debuginfo.t ->
   To_cmm_env.t ->
+  To_cmm_result.t ->
   Simple.t ->
-  Cmm.expression * To_cmm_env.t * Effects_and_coeffects.t
+  Cmm.expression * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
 
 val simple_static :
   Simple.t -> [`Data of Cmm.data_item list | `Var of Variable.t]
@@ -62,8 +64,9 @@ val simple_list :
   ?consider_inlining_effectful_expressions:bool ->
   dbg:Debuginfo.t ->
   To_cmm_env.t ->
+  To_cmm_result.t ->
   Simple.t list ->
-  Cmm.expression list * To_cmm_env.t * Effects_and_coeffects.t
+  Cmm.expression list * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
 
 val bound_parameters :
   To_cmm_env.t ->
@@ -76,13 +79,14 @@ val invalid :
 (** Make an update to a statically-allocated block. *)
 val make_update :
   To_cmm_env.t ->
+  To_cmm_result.t ->
   Debuginfo.t ->
   Cmm.memory_chunk ->
   symbol:Cmm.expression ->
   Variable.t ->
   index:int ->
   prev_updates:Cmm.expression option ->
-  To_cmm_env.t * Cmm.expression option
+  To_cmm_env.t * To_cmm_result.t * Cmm.expression option
 
 val check_arity : Flambda_arity.With_subkinds.t -> _ list -> bool
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -300,4 +300,4 @@ let static_consts env r ~params_and_body bound_static static_consts =
     Format.eprintf
       "\n@[<v 0>%tContext is:%t translating `let symbol' to Cmm:@ %a@."
       Flambda_colours.error Flambda_colours.pop Expr.print tmp_let_symbol;
-    raise e Printexc.raise_with_backtrace e bt
+    Printexc.raise_with_backtrace e bt

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -44,8 +44,8 @@ let rec static_block_updates symb env res acc i = function
       static_block_updates symb env res acc (i + 1) r
     | Dynamically_computed (var, dbg) ->
       let env, res, acc =
-        C.make_update env res dbg Word_val ~symbol:(C.symbol ~dbg symb) var ~index:i
-          ~prev_updates:acc
+        C.make_update env res dbg Word_val ~symbol:(C.symbol ~dbg symb) var
+          ~index:i ~prev_updates:acc
       in
       static_block_updates symb env res acc (i + 1) r)
 
@@ -56,8 +56,8 @@ let rec static_float_array_updates symb env res acc i = function
     | Const _ -> static_float_array_updates symb env res acc (i + 1) r
     | Var (var, dbg) ->
       let env, res, acc =
-        C.make_update env res dbg Double ~symbol:(C.symbol ~dbg symb) var ~index:i
-          ~prev_updates:acc
+        C.make_update env res dbg Double ~symbol:(C.symbol ~dbg symb) var
+          ~index:i ~prev_updates:acc
       in
       static_float_array_updates symb env res acc (i + 1) r)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -36,39 +36,39 @@ let or_variable f default v cont =
   | Const c -> f c cont
   | Var _ -> f default cont
 
-let rec static_block_updates symb env acc i = function
-  | [] -> env, acc
+let rec static_block_updates symb env res acc i = function
+  | [] -> env, res, acc
   | sv :: r -> (
     match (sv : Field_of_static_block.t) with
     | Symbol _ | Tagged_immediate _ ->
-      static_block_updates symb env acc (i + 1) r
+      static_block_updates symb env res acc (i + 1) r
     | Dynamically_computed (var, dbg) ->
-      let env, acc =
-        C.make_update env dbg Word_val ~symbol:(C.symbol ~dbg symb) var ~index:i
+      let env, res, acc =
+        C.make_update env res dbg Word_val ~symbol:(C.symbol ~dbg symb) var ~index:i
           ~prev_updates:acc
       in
-      static_block_updates symb env acc (i + 1) r)
+      static_block_updates symb env res acc (i + 1) r)
 
-let rec static_float_array_updates symb env acc i = function
-  | [] -> env, acc
+let rec static_float_array_updates symb env res acc i = function
+  | [] -> env, res, acc
   | sv :: r -> (
     match (sv : _ Or_variable.t) with
-    | Const _ -> static_float_array_updates symb env acc (i + 1) r
+    | Const _ -> static_float_array_updates symb env res acc (i + 1) r
     | Var (var, dbg) ->
-      let env, acc =
-        C.make_update env dbg Double ~symbol:(C.symbol ~dbg symb) var ~index:i
+      let env, res, acc =
+        C.make_update env res dbg Double ~symbol:(C.symbol ~dbg symb) var ~index:i
           ~prev_updates:acc
       in
-      static_float_array_updates symb env acc (i + 1) r)
+      static_float_array_updates symb env res acc (i + 1) r)
 
 let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
-    r updates =
+    res updates =
   let aux x cont =
     emit
       (Symbol.linkage_name_as_string symbol, Cmmgen_state.Global)
       (transl x) cont
   in
-  let updates =
+  let env, res, updates =
     match (v : _ Or_variable.t) with
     | Const c ->
       (* Add the const to the cmmgen_state structured constants table so that
@@ -77,40 +77,40 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
       let symbol_name = Symbol.linkage_name_as_string symbol in
       let structured_constant = structured (transl c) in
       Cmmgen_state.add_structured_constant symbol_name structured_constant;
-      env, None
+      env, res, None
     | Var (v, dbg) ->
-      C.make_update env dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
+      C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
         ~prev_updates:updates
   in
-  R.update_data r (or_variable aux default v), updates
+  R.update_data res (or_variable aux default v), env, updates
 
-let add_function env r ~params_and_body code_id p ~fun_dbg ~check =
-  let fundecl, r = params_and_body env r code_id p ~fun_dbg ~check in
-  R.add_function r fundecl
+let add_function env res ~params_and_body code_id p ~fun_dbg ~check =
+  let fundecl, res = params_and_body env res code_id p ~fun_dbg ~check in
+  R.add_function res fundecl
 
-let add_functions env ~params_and_body r (code : Code.t) =
-  add_function env r ~params_and_body (Code.code_id code)
+let add_functions env ~params_and_body res (code : Code.t) =
+  add_function env res ~params_and_body (Code.code_id code)
     (Code.params_and_body code)
     ~fun_dbg:(Code.dbg code) ~check:(Code.check code)
 
-let preallocate_set_of_closures (r, updates, env) ~closure_symbols
+let preallocate_set_of_closures (res, updates, env) ~closure_symbols
     set_of_closures =
-  let env, data, updates =
+  let env, res, data, updates =
     let closure_symbols =
       closure_symbols |> Function_slot.Lmap.bindings
       |> Function_slot.Map.of_list
     in
-    To_cmm_set_of_closures.let_static_set_of_closures env closure_symbols
+    To_cmm_set_of_closures.let_static_set_of_closures env res closure_symbols
       set_of_closures ~prev_updates:updates
   in
-  let r = R.set_data r data in
-  r, updates, env
+  let res = R.set_data res data in
+  res, updates, env
 
-let static_const0 env r ~updates (bound_static : Bound_static.Pattern.t)
+let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     (static_const : Static_const.t) =
   match bound_static, static_const with
   | Block_like s, Block (tag, _mut, fields) ->
-    let r = R.check_for_module_symbol r s in
+    let res = R.check_for_module_symbol res s in
     let tag = Tag.Scannable.to_int tag in
     let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
     let header = C.black_block_header tag (List.length fields) in
@@ -122,46 +122,46 @@ let static_const0 env r ~updates (bound_static : Bound_static.Pattern.t)
         fields []
     in
     let block = C.emit_block block_name header static_fields in
-    let env, updates = static_block_updates s env updates 0 fields in
-    env, R.set_data r block, updates
+    let env, res, updates = static_block_updates s env res updates 0 fields in
+    env, R.set_data res block, updates
   | Set_of_closures closure_symbols, Set_of_closures set_of_closures ->
-    let r, updates, env =
-      preallocate_set_of_closures (r, updates, env) ~closure_symbols
+    let res, updates, env =
+      preallocate_set_of_closures (res, updates, env) ~closure_symbols
         set_of_closures
     in
-    env, r, updates
+    env, res, updates
   | Block_like symbol, Boxed_float v ->
     let default = Numeric_types.Float_by_bit_pattern.zero in
     let transl = Numeric_types.Float_by_bit_pattern.to_float in
     let structured f = Clambda.Uconst_float f in
-    let r, (env, updates) =
+    let res, env, updates =
       static_boxed_number ~kind:Double ~env ~symbol ~default
-        ~emit:C.emit_float_constant ~transl ~structured v r updates
+        ~emit:C.emit_float_constant ~transl ~structured v res updates
     in
-    env, r, updates
+    env, res, updates
   | Block_like symbol, Boxed_int32 v ->
     let structured i = Clambda.Uconst_int32 i in
-    let r, (env, updates) =
+    let res, env, updates =
       static_boxed_number ~kind:Word_int ~env ~symbol ~default:0l
-        ~emit:C.emit_int32_constant ~transl:Fun.id ~structured v r updates
+        ~emit:C.emit_int32_constant ~transl:Fun.id ~structured v res updates
     in
-    env, r, updates
+    env, res, updates
   | Block_like symbol, Boxed_int64 v ->
     let structured i = Clambda.Uconst_int64 i in
-    let r, (env, updates) =
+    let res, env, updates =
       static_boxed_number ~kind:Word_int ~env ~symbol ~default:0L
-        ~emit:C.emit_int64_constant ~transl:Fun.id ~structured v r updates
+        ~emit:C.emit_int64_constant ~transl:Fun.id ~structured v res updates
     in
-    env, r, updates
+    env, res, updates
   | Block_like symbol, Boxed_nativeint v ->
     let default = Targetint_32_64.zero in
     let transl = C.nativeint_of_targetint in
     let structured i = Clambda.Uconst_nativeint i in
-    let r, (env, updates) =
+    let res, env, updates =
       static_boxed_number ~kind:Word_int ~env ~symbol ~default
-        ~emit:C.emit_nativeint_constant ~transl ~structured v r updates
+        ~emit:C.emit_nativeint_constant ~transl ~structured v res updates
     in
-    env, r, updates
+    env, res, updates
   | Block_like s, (Immutable_float_block fields | Immutable_float_array fields)
     ->
     let aux =
@@ -174,8 +174,8 @@ let static_const0 env r ~updates (bound_static : Bound_static.Pattern.t)
         (Symbol.linkage_name_as_string s, Cmmgen_state.Global)
         static_fields
     in
-    let env, e = static_float_array_updates s env updates 0 fields in
-    env, R.update_data r float_array, e
+    let env, res, e = static_float_array_updates s env res updates 0 fields in
+    env, R.update_data res float_array, e
   | Block_like s, Immutable_value_array fields ->
     let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
     let header = C.black_block_header 0 (List.length fields) in
@@ -187,19 +187,19 @@ let static_const0 env r ~updates (bound_static : Bound_static.Pattern.t)
         fields []
     in
     let block = C.emit_block block_name header static_fields in
-    let env, updates = static_block_updates s env updates 0 fields in
-    env, R.set_data r block, updates
+    let env, res, updates = static_block_updates s env res updates 0 fields in
+    env, R.set_data res block, updates
   | Block_like s, Empty_array ->
     (* Recall: empty arrays have tag zero, even if their kind is naked float. *)
     let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
     let header = C.black_block_header 0 0 in
     let block = C.emit_block block_name header [] in
-    env, R.set_data r block, updates
+    env, R.set_data res block, updates
   | Block_like s, Mutable_string { initial_value = str }
   | Block_like s, Immutable_string str ->
     let name = Symbol.linkage_name_as_string s in
     let data = C.emit_string_constant (name, Cmmgen_state.Global) str in
-    env, R.update_data r data, updates
+    env, R.update_data res data, updates
   | Block_like _, Set_of_closures _ ->
     Misc.fatal_errorf
       "[Set_of_closures] values cannot be bound by [Block_like] bindings:@ %a"

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -286,6 +286,7 @@ let static_consts env r ~params_and_body bound_static static_consts =
     let r = R.add_gc_roots r roots in
     static_consts0 env r ~params_and_body bound_static static_consts
   with Misc.Fatal_error as e ->
+    let bt = Printexc.get_raw_backtrace () in
     (* Create a new "let symbol" with a dummy body to better print the bound
        symbols and static consts. *)
     let dummy_body = Expr.create_invalid To_cmm_dummy_body in
@@ -299,4 +300,4 @@ let static_consts env r ~params_and_body bound_static static_consts =
     Format.eprintf
       "\n@[<v 0>%tContext is:%t translating `let symbol' to Cmm:@ %a@."
       Flambda_colours.error Flambda_colours.pop Expr.print tmp_let_symbol;
-    raise e
+    raise e Printexc.raise_with_backtrace e bt


### PR DESCRIPTION
This supersedes #617 .

This PR include support to tag some primitives as "must inline". One part of that is to add to the effects_and_coeffects a field for primitive placement (originally introduced by @lthls in #617 ).

The main part of the changes are in `to_cmm_env` to support duplicating some primitives/expressions. In such cases, we need to properly bind the primitive's arguments to avoid duplicating them. This need a special case for "must inline" primitive that are used only once, so that we do not generated worse code than before, because we basically need to wait for the point of use of a variable (and not its binding point) in order to know whether we need to bind arguments separately or not. This brings the notion of a "must inline once" binding, that can be split (into its arguments and the primitive expression) if needed.

This PR includes a patch from @lthls that counts twice the occurrences inside a recursive continuation. This helps `to_cmm` be absolutely sure that a variable with a single occurrence will never occur inside a loop (and thus, if we substitute it, we do not duplicate its evaluation).

Additionally, this also includes a small patch to make use of the existing `cmmgen` mechanism for constants to unbox the contents of symbols that point to a boxed number. (this part can be split into a separate PR if needed).