### PR TITLE
Add sequence-blank-line=compact to .ocamlformat files

### DIFF
--- a/backend/.ocamlformat
+++ b/backend/.ocamlformat
@@ -8,6 +8,7 @@ doc-comments=before
 dock-collection-brackets=false
 if-then-else=keyword-first
 parens-tuple=multi-line-only
+sequence-blank-line=compact
 space-around-lists=false
 space-around-variants=false
 type-decl=sparse

--- a/backend/cfg/eliminate_fallthrough_blocks.ml
+++ b/backend/cfg/eliminate_fallthrough_blocks.ml
@@ -76,7 +76,6 @@ let rec disconnect_fallthrough_blocks cfg_with_layout =
 
 let run cfg_with_layout =
   let cfg = CL.cfg cfg_with_layout in
-
   (* Find and disconnect fallthrough blocks (i.e., blocks with empty body and a
      single successor) by rerouting their predecessors to point directly to
      their successors. It can create a new fallthrough block, for example: if we

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -283,7 +283,6 @@ let check_and_register_traps t =
           \                           with an Lentertrap instruction." label
           label)
     t.trap_handlers;
-
   (* propagate remaining trap stacks to handlers *)
   t.unresolved_traps_to_pop <- resolve_traps_to_pop t t.unresolved_traps_to_pop;
   if List.compare_length_with t.unresolved_traps_to_pop 0 > 0
@@ -293,13 +292,10 @@ let check_and_register_traps t =
       (* not a fatal error because of dead blocks *)
       Printf.printf "%d" (List.length t.unresolved_traps_to_pop);
     Misc.fatal_error "Unresolved traps at the end of cfg construction");
-
   (* check that trap stacks at the start of all blocks are resolved *)
   C.iter_blocks t.cfg ~f:(check_traps t);
-
   (* compute block.exns successors using t.exns. *)
   C.iter_blocks t.cfg ~f:(register_exns t);
-
   (* after all exn successors are computed, check that if a block can_raise,
      then it has a registered exn successor or interproc exn. *)
   let f _ (block : C.basic_block) =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2372,7 +2372,6 @@ let send_function (arity, mode) =
                           dbg () ) ],
                     dbg () ) ) ) )
   in
-
   let body = Clet (VP.create clos', clos, body) in
   let cache = cache in
   let fun_name = send_function_name arity mode in

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -372,7 +372,6 @@ let fundecl (f : M.fundecl) =
   then (
     assert (Hashtbl.length avail_at_exit = 0);
     avail_at_raise := RAS.Unreachable;
-
     current_trap_stack := M.Uncaught;
     let fun_args = R.set_of_array f.fun_args in
     let avail_before = RAS.Ok (RD.Set.without_debug_info fun_args) in

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -34,7 +34,6 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_begin
   (match !Dwarf_flags.gdwarf_format with
   | Thirty_two -> Dwarf_format.set Thirty_two
   | Sixty_four -> Dwarf_format.set Sixty_four);
-
   let compilation_unit_proto_die =
     Dwarf_compilation_unit.compile_unit_proto_die ~sourcefile ~unit_name
       ~code_begin ~code_end

--- a/middle_end/.ocamlformat
+++ b/middle_end/.ocamlformat
@@ -8,6 +8,7 @@ doc-comments=before
 dock-collection-brackets=false
 if-then-else=keyword-first
 parens-tuple=multi-line-only
+sequence-blank-line=compact
 space-around-lists=false
 space-around-variants=false
 type-decl=sparse

--- a/middle_end/flambda2/.ocamlformat
+++ b/middle_end/flambda2/.ocamlformat
@@ -6,6 +6,7 @@ doc-comments=before
 dock-collection-brackets=false
 if-then-else=keyword-first
 parens-tuple=multi-line-only
+sequence-blank-line=compact
 space-around-lists=false
 space-around-variants=false
 type-decl=sparse

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -281,7 +281,6 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
     | None -> dead_code lam letrec)
   | Lmutlet (k, id, def, body) ->
     let letrec = prepare_letrec recursive_set current_let body letrec in
-
     (* Variable let comes from mutable values, and reading from it is considered
        as inspections by Typecore.check_recursive_expression.
 
@@ -367,7 +366,6 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
         recursive_set
     in
     let outer_vars = Ident.Set.inter vars recursive_set in
-
     if Ident.Set.is_empty outer_vars
     then
       (* Non recursive relative to top-level letrec, we can avoid dissecting it
@@ -526,7 +524,6 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
 
 let dissect_letrec ~bindings ~body =
   let letbound = Ident.Set.of_list (List.map fst bindings) in
-
   let letrec =
     List.fold_right
       (fun (id, def) letrec ->
@@ -543,7 +540,6 @@ let dissect_letrec ~bindings ~body =
         needs_region = false
       }
   in
-
   let preallocations =
     List.map
       (fun (id, { block_type; size }) ->
@@ -557,7 +553,6 @@ let dissect_letrec ~bindings ~body =
         id, Lprim (Pccall desc, [size], Loc_unknown))
       letrec.blocks
   in
-
   let real_body = body in
   let bound_ids_freshening =
     List.map (fun (bound_id, _) -> bound_id, Ident.rename bound_id) bindings
@@ -571,7 +566,6 @@ let dissect_letrec ~bindings ~body =
       let args = List.map (fun (bound_id, _) -> Lvar bound_id) bindings in
       Lstaticraise (cont, args)
   in
-
   let effects_then_body = lsequence (letrec.effects, body) in
   let functions =
     match letrec.functions with
@@ -594,7 +588,6 @@ let dissect_letrec ~bindings ~body =
       with_preallocations letrec.consts
   in
   let substituted = Lambda.rename letrec.substitution with_constants in
-
   if not letrec.needs_region
   then substituted
   else

--- a/middle_end/flambda2/simplify_shared/inlining_report.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_report.ml
@@ -237,7 +237,6 @@ module Context = struct
               `Int requested_inline ] ]
           |> Table.create
         in
-
         Format.fprintf ppf
           "@[<v>@[<h>Code@ size@ was@ estimated@ to@ be@ %a@]@,\
            @,\
@@ -545,9 +544,7 @@ module Inlining_tree = struct
               ~apply_to_child m)
       | Inline { prev } -> insert_or_update_descendant prev ~apply_to_child
     in
-
     let { path; dbg; decision_with_context } = decision in
-
     if Compilation_unit.equal compilation_unit (IHA.compilation_unit path)
     then
       let path = IHA.path path in
@@ -654,14 +651,12 @@ module Inlining_tree = struct
           Format.fprintf ppf "@[<hov>Defined@ %a@]@,@,"
             (Uid.print_link_hum ~compilation_unit)
             (Uid.create ~compilation_unit (IHA.path callee));
-
           (match decision with
           | Decision decision_with_context ->
             Format.fprintf ppf "@[<v>%a@]" print_decision_with_context
               decision_with_context
           | Reference path -> print_reference ~compilation_unit ppf path
           | Unavailable -> print_unavailable ppf ());
-
           Format.fprintf ppf "@]@,@,";
           print ppf ~compilation_unit ~depth:(depth + 1)
             ~path:(IHA.Inline { prev = path })

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -791,7 +791,6 @@ and print_let_expr ppf ({ let_abst = _; defining_expr } as t) : unit =
       | Simple _ | Prim _ | Set_of_closures _ | Static_consts _ ->
         Flambda_colours.variable ()
   in
-
   let rec let_body (expr : expr) =
     match descr expr with
     | Let ({ let_abst = _; defining_expr } as t) ->

--- a/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
+++ b/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
@@ -795,7 +795,6 @@ module Types = struct
           | [] -> false
           | _ :: _ -> true)
       in
-
       let k, v = Generator.one_of list r in
       list, k, v
     in
@@ -838,138 +837,73 @@ let () =
       Arbitrary.bind_generator (Generator.small_nat ~less_than:6)
         ~f:(fun length -> Arbitrary.list set ~length)
     in
-
     let c ?n ?seed name f arbitrary_impls =
       Runner.check runner ~name:("Set: " ^ name) ?n ?seed ~arbitrary_impls ~f
     in
-
     c "sets are valid" valid [set];
-
     c "mem vs. empty" mem_empty [elt];
-
     c "is_empty vs. equal" is_empty_vs_equal [set];
-
     c "add is valid" add_valid [elt; set];
-
     c "add then mem" add_mem [elt; set];
-
     c "add then subset" add_subset [elt; set];
-
     c "add then cardinal" add_cardinal [elt; set];
-
     c "add existing element" add_elt [set_and_element];
-
     c "singleton is valid" singleton_valid [elt];
-
     c "singleton vs. elements" singleton_vs_elements [elt];
-
     c "remove is valid" remove_valid [elt; set];
-
     c "remove element then mem" remove_elt_not_mem [set_and_element];
-
     c "remove element then subset" remove_elt_subset [set_and_element];
-
     c "remove element then cardinal" remove_elt_cardinal [set_and_element];
-
     c "remove non-element" remove_non_elt [elt; set];
-
     c "union is valid" union_valid [set; set];
-
     c "union is superset of arguments" union_subset [set; set];
-
     c "union has no extra elements" union_mem [set; set];
-
     c "union with self" union_with_self [set];
-
     c "inter is valid" inter_valid [set; set];
-
     c "inter" inter [set; set];
-
     c "inter with self" inter_with_self [set];
-
     c "disjoint" disjoint [set; set];
-
     c "diff is valid" diff_valid [set; set];
-
     c "diff" diff [set; set];
-
     c "diff with self" diff_with_self [set];
-
     c "compare vs. equal" compare_vs_equal [set; set];
-
     c "compare is reflexive" compare_refl [set];
-
     c "compare is antisymmetric" compare_antisym [set; set];
-
     c "compare is transitive" compare_trans [set; set; set];
-
     c "equal vs. List.equal" equal_vs_list [set; set];
-
     c "subset is reflexive" subset_refl [set];
-
     c "subset is antisymmetric" subset_antisym [set; set];
-
     c "subset is transitive" subset_trans [set; set; set];
-
     c "subset vs. mem" subset_vs_mem [set; set];
-
     c "iter vs. fold" iter_vs_fold [set];
-
     c "map is valid" map_valid [elt_to_elt; set];
-
     c "map vs. List.map" map_vs_list [elt_to_elt; set];
-
     c "for_all" for_all [elt_to_bool; set];
-
     c "exists" exists [elt_to_bool; set];
-
     c "filter is valid" filter_valid [elt_to_bool; set];
-
     c "filter vs. List.filter" filter_vs_list [elt_to_bool; set];
-
     c "filter_map vs. List.filter_map" filter_map_vs_list
       [elt_to_elt_option; set];
-
     c "partition is valid" partition_valid [elt_to_bool; set];
-
     c "partition" partition [elt_to_bool; set];
-
     c "cardinal vs. List.length" cardinal_vs_list_length [set];
-
     c "elements" elements [set];
-
     c "min_elt vs. min_elt_opt" min_elt_vs_opt [set];
-
     c "max_elt vs. max_elt_opt" max_elt_vs_opt [set];
-
     c "min_elt" min_elt [set];
-
     c "max_elt" max_elt [set];
-
     c "choose vs. choose_opt" choose_vs_opt [set];
-
     c "choose" choose [set];
-
     c "split is valid" split_valid [elt; set];
-
     c "split vs. filter" split_vs_filter [elt; set];
-
     c "split vs. mem" split_vs_mem [elt; set];
-
     c "find on element" find_elt [set];
-
     c "find on non-element" find_non_elt [elt; set];
-
     c "of_list is valid" of_list_valid [elt_list];
-
     c "of_list then elements" of_list_then_elements [elt_list];
-
     c "elements_then_of_list" elements_then_of_list [set];
-
     c "to_seq" to_seq [set];
-
     c "union_list" union_list [set_list];
-
     c "get_singleton" get_singleton [set]
   in
   let () =
@@ -996,171 +930,91 @@ let () =
     let merging_function = Arbitrary.fn3 (Arbitrary.option value) in
     let union_function = Arbitrary.fn3 (Arbitrary.option value) in
     let inter_function = Arbitrary.fn3 value in
-
     let c ?n ?seed name f arbitrary_impls =
       Runner.check runner ~name:("Map: " ^ name) ?n ?seed ~arbitrary_impls ~f
     in
-
     c "maps are valid" valid [map];
-
     c "find_opt vs. find" find_opt_vs_find [key; map];
-
     c "find_opt of empty" find_opt_empty [key];
-
     c "mem" mem [key; map];
-
     c "is_empty vs. equal" is_empty_vs_equal [map];
-
     c "add is valid" add_valid [key; value; map];
-
     c "add then find_opt" add_same [key; value; map];
-
     c "add then find_opt other" add_other [key; key; value; map];
-
     c "update is valid" update_valid [key; value_option_to_value_option; map];
-
     c "update then find_opt" update_same [key; value_option_to_value_option; map];
-
     c "update then find_opt other" update_other
       [key; key; value_option_to_value_option; map];
-
     c "singleton is valid" singleton_valid [key; value];
-
     c "singleton then find_opt" singleton_same [key; value];
-
     c "singleton then find_opt of other" singleton_other [key; key; value];
-
     c "remove is valid" remove_valid [key; map];
-
     c "remove then find_opt" remove_same [key; map];
-
     c "remove then find_opt of other" remove_other [key; key; map];
-
     c "merge is valid" merge_valid [merging_function; map; map];
-
     c "merge" merge [merging_function; map_and_binding; map_and_binding];
-
     c "union is valid" union_valid [union_function; map; map];
-
     c "union" union [union_function; map_and_binding; map_and_binding];
-
     c "union then mem" union_mem [union_function; map; map];
-
     c "compare vs. equal" compare_vs_equal [map; map];
-
     c "compare is reflexive" compare_refl [map];
-
     c "compare is antisymmetric" compare_antisym [map; map];
-
     c "compare is transitive" compare_trans [map; map; map];
-
     c "equal vs. List.equal" equal_vs_list [map; map];
-
     c "iter vs. fold" iter_vs_fold [map];
-
     c "for_all vs. List.for_all" for_all_vs_list [key_and_value_to_bool; map];
-
     c "exists vs. List.exists" exists_vs_list [key_and_value_to_bool; map];
-
     c "filter is valid" filter_valid [key_and_value_to_bool; map];
-
     c "filter returns subset" filter_subset [key_and_value_to_bool; map];
-
     c "filter then find_opt" filter_find_opt
       [key_and_value_to_bool; map_and_binding];
-
     c "filter_map is valid" filter_map_valid [key_and_value_to_value_option; map];
-
     c "filter_map_subset" filter_map_subset [key_and_value_to_value_option; map];
-
     c "filter_map" filter_map [key_and_value_to_value_option; map_and_binding];
-
     c "partition is valid" partition_valid [key_and_value_to_bool; map];
-
     c "partition" partition [key_and_value_to_bool; map];
-
     c "cardinal vs. List.length" cardinal_vs_list_length [map];
-
     c "find_opt of element vs. List.assoc_opt" find_opt_elt_vs_list_assoc_opt
       [map_and_binding];
-
     c "find_opt of non-element vs. List.assoc_opt"
       find_opt_other_vs_list_assoc_opt [key; map];
-
     c "min_binding vs. min_binding_opt" min_binding_vs_opt [map];
-
     c "max_binding vs. max_binding_opt" max_binding_vs_opt [map];
-
     c "min_binding_opt" min_binding_opt [map];
-
     c "max_binding_opt" max_binding_opt [map];
-
     c "choose vs. choose_opt" choose_vs_opt [map];
-
     c "choose_opt" choose_opt [map];
-
     c "split is valid" split_valid [key; map];
-
     c "split on element" split_elt [map_and_binding];
-
     c "split on non-element" split_other [key; map];
-
     c "split vs. filter" split_vs_filter [key; map];
-
     c "map is valid" map_valid [value_to_value; map];
-
     c "map" Map_specs.map [value_to_value; map];
-
     c "mapi is valid" mapi_valid [key_and_value_to_value; map];
-
     c "mapi" mapi [key_and_value_to_value; map];
-
     c "to_seq vs. bindings" to_seq_vs_bindings [map];
-
     c "of_list is valid" of_list_valid [bindings];
-
     c "of_list then bindings" of_list_then_bindings [bindings];
-
     c "bindings_then_of_list" bindings_then_of_list [map];
-
     c "map_keys is valid" map_keys_valid [key_to_key; map];
-
     c "map_keys" map_keys [key_to_key; map];
-
     c "keys vs. Set.of_list" keys_vs_of_list [map];
-
     c "data vs. bindings" data_vs_bindings [map];
-
     c "of_set vs. of_list" of_set_vs_of_list [key_to_value; set];
-
     c "diff_domains valid" diff_domains_valid [map; map];
-
     c "diff_domains" diff_domains [map_and_binding; map];
-
     c "diff_domains of self" diff_domains_self [map];
-
     c "inter is valid" inter_valid [inter_function; map; map];
-
     c "inter then find_opt" inter_then_find_opt [inter_function; map; map];
-
     c "inter vs. filter" inter_vs_filter [inter_function; map; map];
-
     c "inter_domain_is_non_empty" inter_domain_is_non_empty [map; map];
-
     c "get_singleton" get_singleton [map];
-
     c "replace is valid" replace_valid [key; value_to_value; map];
-
     c "replace of elt" replace_elt [value_to_value; map_and_binding];
-
     c "replace then find_opt" replace_same [key; value_to_value; map];
-
     c "replace then find_opt other" replace_other [key; key; value_to_value; map];
-
     c "map_sharing is valid" map_sharing_valid [value_to_value; map];
-
     c "map_sharing vs. map" map_sharing_vs_map [value_to_value; map];
-
     c "map_sharing of id" map_sharing_id [map];
     ()
   in

--- a/middle_end/flambda2/tests/lib/minicheck/arbitrary.ml
+++ b/middle_end/flambda2/tests/lib/minicheck/arbitrary.ml
@@ -185,7 +185,6 @@ let tuple (ts : ('a, 'reprs, 'r) Tuple.Of2(T).t) :
     | [] -> []
     | { impl; _ } :: ts -> impl :: impls ts
   in
-
   let rec get_values :
       type a reprs r.
       (a, reprs, r) Tuple.Of2(T).t -> (reprs, r) Tuple.t -> (a, r) Tuple.t =
@@ -196,7 +195,6 @@ let tuple (ts : ('a, 'reprs, 'r) Tuple.Of2(T).t) :
       get_value repr :: get_values ts reprs
     | _ :: _, [] | [], _ :: _ -> assert false
   in
-
   let impl = tuple_impl (impls ts) in
   let get_value = get_values ts in
   { impl; get_value }

--- a/middle_end/flambda2/tests/lib/minicheck/generator.ml
+++ b/middle_end/flambda2/tests/lib/minicheck/generator.ml
@@ -55,7 +55,6 @@ let log_int =
        isn't true for JavaScript *)
     Sys.word_size - 1
   in
-
   fun r ->
     (* Pick a random size for our int, then pick an integer uniformly but only
        keep that many bits. (This doesn't produce an actual log-uniform

--- a/middle_end/flambda2/tests/lib/minicheck/runner.ml
+++ b/middle_end/flambda2/tests/lib/minicheck/runner.ml
@@ -141,7 +141,6 @@ let check :
   let run arbitrary_impl f =
     check0 ?n ?seed ?verbose t ~arbitrary_impl ~f ~name
   in
-
   match arbitrary_impls with
   | [] -> run Arbitrary.unit (fun () -> f)
   | [arb] -> run arb f

--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -98,7 +98,6 @@ let meet_variants_don't_lose_aliases () =
   let vb = Variable.create "b" in
   let v_variant = Variable.create "variant" in
   let env = defines env [vx; vy; va; vb; v_variant] in
-
   let const_ctors = T.bottom K.naked_immediate in
   let ty1 =
     let non_const_ctors =
@@ -147,7 +146,6 @@ let test_meet_two_blocks () =
   let block2 = Variable.create "block2" in
   let field2 = Variable.create "field2" in
   let env = defines env [block1; block2; field1; field2] in
-
   let env =
     TE.add_equation env (Name.var block1)
       (T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
@@ -160,7 +158,6 @@ let test_meet_two_blocks () =
          (Known Heap)
          ~fields:[T.alias_type_of K.value (Simple.var field2)])
   in
-
   (* let test b1 b2 env =
    *   let eq_block2 = T.alias_type_of K.value (Simple.var b2) in
    *   let env =

--- a/middle_end/flambda2/tests/mlexamples/camlinternalFormat.ml
+++ b/middle_end/flambda2/tests/mlexamples/camlinternalFormat.ml
@@ -1410,7 +1410,6 @@ let bprint_fmt buf fmt =
       fmtiter rest ign_flag
     | End_of_format -> ()
   in
-
   fmtiter fmt false
 
 (***)
@@ -3006,19 +3005,16 @@ let fmt_ebb_of_string ?legacy_behavior str =
        ' (if the number is positive, pad with a space) does not make sense, but
        the legacy (< 4.02) implementation was happy to just ignore the space. *)
   in
-
   (* Raise [Failure] with a friendly error message. *)
   let invalid_format_message str_ind msg =
     failwith_message "invalid format %S: at character number %d, %s" str str_ind
       msg
   in
-
   (* Used when the end of the format (or the current sub-format) was encountered
      unexpectedly. *)
   let unexpected_end_of_format end_ind =
     invalid_format_message end_ind "unexpected end of format"
   in
-
   (* Used for %0c: no other widths are implemented *)
   let invalid_nonnull_char_width str_ind =
     invalid_format_message str_ind
@@ -3031,7 +3027,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       "invalid format %S: at character number %d, '%c' without %s" str str_ind c
       s
   in
-
   (* Raise [Failure] with a friendly error message about an unexpected
      character. *)
   let expected_character str_ind expected read =
@@ -3039,7 +3034,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       "invalid format %S: at character number %d, %s expected, read %C" str
       str_ind expected read
   in
-
   (* Parse the string from beg_ind (included) to end_ind (excluded). *)
   let rec parse : type e f. int -> int -> (_, _, e, f) fmt_ebb =
    fun beg_ind end_ind -> parse_literal beg_ind beg_ind end_ind
@@ -3276,7 +3270,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
     and ign_used = ref false
     and pad_used = ref false
     and prec_used = ref false in
-
     (* Access to options, update flags. *)
     let get_plus () =
       plus_used := true;
@@ -3300,7 +3293,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       pad_used := true;
       padprec
     in
-
     let get_int_pad () =
       (* %5.3d is accepted and meaningful: pad to length 5 with spaces, but
          first pad with zeros upto length 3 (0-padding is the interpretation of
@@ -3326,7 +3318,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       | (Lit_padding _ as pad), _ -> pad
       | (Arg_padding _ as pad), _ -> pad
     in
-
     (* Check that padty <> Zeros. *)
     let check_no_0 symb (type a b) (pad : (a, b) padding) =
       match pad with
@@ -3342,7 +3333,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
         then Arg_padding Right
         else incompatible_flag pct_ind str_ind symb "0"
     in
-
     (* Get padding as a pad_option (see "%_", "%{", "%(" and "%["). (no need for
        legacy mode tweaking, those were rejected by the legacy parser as
        well) *)
@@ -3362,7 +3352,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
     in
     let get_pad_opt c = opt_of_pad c (get_pad ()) in
     let get_padprec_opt c = opt_of_pad c (get_padprec ()) in
-
     (* Get precision as a prec_option (see "%_f"). (no need for legacy mode
        tweaking, those were rejected by the legacy parser as well) *)
     let get_prec_opt () =
@@ -3371,7 +3360,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       | Lit_precision ndec -> Some ndec
       | Arg_precision -> incompatible_flag pct_ind str_ind '_' "'*'"
     in
-
     let fmt_result =
       match symb with
       | ',' -> parse str_ind end_ind
@@ -3746,7 +3734,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
   (* Parse and construct a char set. *)
   and parse_char_set str_ind end_ind =
     if str_ind = end_ind then unexpected_end_of_format end_ind;
-
     let char_set = create_char_set () in
     let add_char c = add_in_char_set char_set c in
     let add_range c c' =
@@ -3754,14 +3741,12 @@ let fmt_ebb_of_string ?legacy_behavior str =
         add_in_char_set char_set (char_of_int i)
       done
     in
-
     let fail_single_percent str_ind =
       failwith_message
         "invalid format %S: '%%' alone is not accepted in character sets, use \
          %%%% instead at position %d."
         str str_ind
     in
-
     (* Parse the first character of a char set. *)
     let rec parse_char_set_start str_ind end_ind =
       if str_ind = end_ind then unexpected_end_of_format end_ind;
@@ -3993,7 +3978,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
        in sub-format %S"
       str pct_ind option symb subfmt
   in
-
   parse 0 (String.length str)
 
 (******************************************************************************)

--- a/middle_end/flambda2/tests/mlexamples/camlinternalFormat2.ml
+++ b/middle_end/flambda2/tests/mlexamples/camlinternalFormat2.ml
@@ -1412,7 +1412,6 @@ let bprint_fmt buf fmt =
       fmtiter rest ign_flag
     | End_of_format -> ()
   in
-
   fmtiter fmt false
 
 (***)

--- a/middle_end/flambda2/tests/mlexamples/cif.ml
+++ b/middle_end/flambda2/tests/mlexamples/cif.ml
@@ -1412,7 +1412,6 @@ let bprint_fmt buf fmt =
       fmtiter rest ign_flag
     | End_of_format -> ()
   in
-
   fmtiter fmt false
 
 (***)
@@ -3008,19 +3007,16 @@ let fmt_ebb_of_string ?legacy_behavior str =
        ' (if the number is positive, pad with a space) does not make sense, but
        the legacy (< 4.02) implementation was happy to just ignore the space. *)
   in
-
   (* Raise [Failure] with a friendly error message. *)
   let invalid_format_message str_ind msg =
     failwith_message "invalid format %S: at character number %d, %s" str str_ind
       msg
   in
-
   (* Used when the end of the format (or the current sub-format) was encountered
      unexpectedly. *)
   let unexpected_end_of_format end_ind =
     invalid_format_message end_ind "unexpected end of format"
   in
-
   (* Used for %0c: no other widths are implemented *)
   let invalid_nonnull_char_width str_ind =
     invalid_format_message str_ind
@@ -3033,7 +3029,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       "invalid format %S: at character number %d, '%c' without %s" str str_ind c
       s
   in
-
   (* Raise [Failure] with a friendly error message about an unexpected
      character. *)
   let expected_character str_ind expected read =
@@ -3041,7 +3036,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       "invalid format %S: at character number %d, %s expected, read %C" str
       str_ind expected read
   in
-
   (* Parse the string from beg_ind (included) to end_ind (excluded). *)
   let rec parse : type e f. int -> int -> (_, _, e, f) fmt_ebb =
    fun beg_ind end_ind -> parse_literal beg_ind beg_ind end_ind
@@ -3278,7 +3272,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
     and ign_used = ref false
     and pad_used = ref false
     and prec_used = ref false in
-
     (* Access to options, update flags. *)
     let get_plus () =
       plus_used := true;
@@ -3302,7 +3295,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       pad_used := true;
       padprec
     in
-
     let get_int_pad () =
       (* %5.3d is accepted and meaningful: pad to length 5 with spaces, but
          first pad with zeros upto length 3 (0-padding is the interpretation of
@@ -3328,7 +3320,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       | (Lit_padding _ as pad), _ -> pad
       | (Arg_padding _ as pad), _ -> pad
     in
-
     (* Check that padty <> Zeros. *)
     let check_no_0 symb (type a b) (pad : (a, b) padding) =
       match pad with
@@ -3344,7 +3335,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
         then Arg_padding Right
         else incompatible_flag pct_ind str_ind symb "0"
     in
-
     (* Get padding as a pad_option (see "%_", "%{", "%(" and "%["). (no need for
        legacy mode tweaking, those were rejected by the legacy parser as
        well) *)
@@ -3364,7 +3354,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
     in
     let get_pad_opt c = opt_of_pad c (get_pad ()) in
     let get_padprec_opt c = opt_of_pad c (get_padprec ()) in
-
     (* Get precision as a prec_option (see "%_f"). (no need for legacy mode
        tweaking, those were rejected by the legacy parser as well) *)
     let get_prec_opt () =
@@ -3373,7 +3362,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
       | Lit_precision ndec -> Some ndec
       | Arg_precision -> incompatible_flag pct_ind str_ind '_' "'*'"
     in
-
     let fmt_result =
       match symb with
       | ',' -> parse str_ind end_ind
@@ -3748,7 +3736,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
   (* Parse and construct a char set. *)
   and parse_char_set str_ind end_ind =
     if str_ind = end_ind then unexpected_end_of_format end_ind;
-
     let char_set = create_char_set () in
     let add_char c = add_in_char_set char_set c in
     let add_range c c' =
@@ -3756,14 +3743,12 @@ let fmt_ebb_of_string ?legacy_behavior str =
         add_in_char_set char_set (char_of_int i)
       done
     in
-
     let fail_single_percent str_ind =
       failwith_message
         "invalid format %S: '%%' alone is not accepted in character sets, use \
          %%%% instead at position %d."
         str str_ind
     in
-
     (* Parse the first character of a char set. *)
     let rec parse_char_set_start str_ind end_ind =
       if str_ind = end_ind then unexpected_end_of_format end_ind;
@@ -3995,7 +3980,6 @@ let fmt_ebb_of_string ?legacy_behavior str =
        in sub-format %S"
       str pct_ind option symb subfmt
   in
-
   parse 0 (String.length str)
 
 (******************************************************************************)

--- a/middle_end/flambda2/tests/mlexamples/offset.ml
+++ b/middle_end/flambda2/tests/mlexamples/offset.ml
@@ -1,7 +1,6 @@
 let[@inline always] inline a b =
   let r = Random.int 10 in
   let s = Random.int 10 in
-
   let rec f x = if a then r + x else 0
   and g x y = if b then s + (x * y) else 0
   and h x y = (if a then f (x + y) else 0) + if b then g x y else 0 in

--- a/tools/.ocamlformat
+++ b/tools/.ocamlformat
@@ -7,6 +7,7 @@ dock-collection-brackets=false
 exp-grouping=preserve
 if-then-else=keyword-first
 parens-tuple=multi-line-only
+sequence-blank-line=compact
 space-around-lists=false
 space-around-variants=false
 type-decl=sparse


### PR DESCRIPTION
This prevents blank lines being used in the middle of functions, which generally I've found to be a good indicator that a large function needs splitting up.  In some other circumstances this produces significantly more compact code, which seems like a good thing.