### PR TITLE
Fixes for Flambda 2 when Config.stack_allocation is false

### DIFF
--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -306,7 +306,8 @@ let nullary_prim_size prim =
   match (prim : Flambda_primitive.nullary_primitive) with
   | Optimised_out _ -> 0
   | Probe_is_enabled { name = _ } -> 4
-  | Begin_region -> 1
+  | Begin_region ->
+    if Flambda_features.stack_allocation_enabled () then 1 else 0
 
 let unary_prim_size prim =
   match (prim : Flambda_primitive.unary_primitive) with
@@ -331,7 +332,7 @@ let unary_prim_size prim =
   | Project_value_slot _ -> 1 (* load *)
   | Is_boxed_float -> 4 (* tag load + comparison *)
   | Is_flat_float_array -> 4 (* tag load + comparison *)
-  | End_region -> 1
+  | End_region -> if Flambda_features.stack_allocation_enabled () then 1 else 0
 
 let binary_prim_size prim =
   match (prim : Flambda_primitive.binary_primitive) with

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1757,3 +1757,9 @@ module Without_args = struct
     | Ternary prim -> print_ternary_primitive ppf prim
     | Variadic prim -> print_variadic_primitive ppf prim
 end
+
+let is_begin_or_end_region t =
+  match t with
+  | Nullary Begin_region | Unary (End_region, _) -> true
+  | _ -> false
+  [@@ocaml.warning "-fragile-match"]

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -476,3 +476,5 @@ val equal_binary_primitive : binary_primitive -> binary_primitive -> bool
 val equal_ternary_primitive : ternary_primitive -> ternary_primitive -> bool
 
 val equal_variadic_primitive : variadic_primitive -> variadic_primitive -> bool
+
+val is_begin_or_end_region : t -> bool

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -301,6 +301,10 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
       bind_var_to_simple ~dbg env v ~num_normal_occurrences_of_bound_vars s
     in
     expr env res body
+  | Singleton _, Prim (p, _)
+    when Flambda_primitive.is_begin_or_end_region p
+         && not (Flambda_features.stack_allocation_enabled ()) ->
+    expr env res body
   | Singleton v, Prim (p, dbg) ->
     let v = Bound_var.var v in
     let defining_expr, extra, env, res, effs =

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -221,3 +221,5 @@ module Expert = struct
     !Flambda_backend_flags.Flambda2.Expert.can_inline_recursive_functions
     |> with_default ~f:(fun d -> d.can_inline_recursive_functions)
 end
+
+let stack_allocation_enabled () = Config.stack_allocation

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -124,3 +124,5 @@ module Expert : sig
 
   val can_inline_recursive_functions : unit -> bool
 end
+
+val stack_allocation_enabled : unit -> bool


### PR DESCRIPTION
Similarly to #812 , when `Config.stack_allocation` is `false`, nothing is to be allocated on the local stack:

1. Don't emit Cmm code for `Begin_region` and `End_region` Flambda 2 primitives.  These primitives are still present in the Flambda 2 terms because, as of #809 , region variables are mandatory in allocating primitives and application expressions.
2. Count `Begin_region` and `End_region` as having zero code size.