### PR TITLE
Fix failed optimisation of let a = b

### DIFF
--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -78,7 +78,7 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
     let defining_expr =
       if simple == new_simple
       then Simplified_named.create named
-      else Simplified_named.create (Named.create_simple simple)
+      else Simplified_named.create (Named.create_simple new_simple)
     in
     Ok
       (Simplify_named_result.have_simplified_to_single_term dacc bound_pattern


### PR DESCRIPTION
Typo preventing `let a = b` from being simplified