### PR TITLE
Fix CI failure in test for -alloc-check

### DIFF
--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -14,5 +14,5 @@
      ; This is still flaky and temporary, until @assert annotations can be checked.
      (with-stdout-to output.corrected
        (with-stdin-from t.cmx.output
-         (bash "sed -n '/Functions with neither allocations nor indirect calls:/,$p' | grep -v camlT__entry | wc -l ")))
+         (bash "sed -n '/Functions with neither allocations nor indirect calls:/,$p' | grep -v camlT__entry | wc -l | sed 's/^ *//g' ")))
      (diff output output.corrected))))


### PR DESCRIPTION
A test introduced in #778 (using dune runtest instead of ocamltest) fails on the CI sometimes with flambda2 because of extra spaces introduced in the output. I don't know what it happened. Pushing the same revision again the test passes.  Maybe something different in the github ci vm.

This PR tries to hack around it by trimming leading spaces of the output of the test.