### PR TITLE
Update hacking-runtest rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,10 +315,6 @@ hacking: _build/_bootinstall
 
 .PHONY: hacking-runtest
 hacking-runtest: _build/_bootinstall
-	$(dune) runtest $(ws_boot) $(coverage_dune_flags) -w
-
-.PHONY: hacking-with-runtest
-hacking-with-runtest: _build/_bootinstall
 	$(dune) build $(ws_boot) $(coverage_dune_flags) -w boot_ocamlopt.exe @runtest
 
 # Only needed for running the test tools by hand; runtest will take care of

--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,10 @@ hacking: _build/_bootinstall
 hacking-runtest: _build/_bootinstall
 	$(dune) runtest $(ws_boot) $(coverage_dune_flags) -w
 
+.PHONY: hacking-with-runtest
+hacking-with-runtest: _build/_bootinstall
+	$(dune) build $(ws_boot) $(coverage_dune_flags) -w boot_ocamlopt.exe @runtest
+
 # Only needed for running the test tools by hand; runtest will take care of
 # building them using Dune
 .PHONY: test-tools


### PR DESCRIPTION
When hacking I found it useful to both build the `boot_ocamlopt.exe` and run the tests with the `dune --watch` command.
I was running some manual tests from the terminal so I needed to have `boot_ocamlopt.exe` up to date but running the automatic tests was also helpful (in case I broke something simple).

I propose adding `boot_ocamlopt.exe` target to the `make hacking-runtest` rule.

This doesn't slow down the dune build with `make hacking-runtest` much but has the advantage of keeping `boot_ocamlopt.exe` up to date.