### PR TITLE
Reduce switch with statically known scrutinee to a single branch in from_lambda

### DIFF
--- a/middle_end/flambda2/classic_mode_types/dune
+++ b/middle_end/flambda2/classic_mode_types/dune
@@ -11,6 +11,8 @@
    -open
    Flambda2_nominal
    -open
+   Flambda2_numbers
+   -open
    Flambda2_term_basics))
  (ocamlopt_flags
   (:standard -O3))
@@ -18,4 +20,5 @@
   ocamlcommon
   flambda2_identifiers
   flambda2_nominal
+  flambda2_numbers
   flambda2_term_basics))

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -19,12 +19,14 @@
 type 'code t =
   | Value_unknown
   | Value_symbol of Symbol.t
+  | Value_int of Targetint_31_63.t
   | Closure_approximation of Code_id.t * Function_slot.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 
 let rec print fmt = function
   | Value_unknown -> Format.fprintf fmt "?"
   | Value_symbol sym -> Symbol.print fmt sym
+  | Value_int i -> Targetint_31_63.print fmt i
   | Closure_approximation (code_id, _, _) ->
     Format.fprintf fmt "[%a]" Code_id.print code_id
   | Block_approximation (fields, _) ->
@@ -40,11 +42,13 @@ let rec print fmt = function
 
 let is_unknown = function
   | Value_unknown -> true
-  | Value_symbol _ | Closure_approximation _ | Block_approximation _ -> false
+  | Value_symbol _ | Value_int _ | Closure_approximation _
+  | Block_approximation _ ->
+    false
 
 let rec free_names ~code_free_names approx =
   match approx with
-  | Value_unknown -> Name_occurrences.empty
+  | Value_unknown | Value_int _ -> Name_occurrences.empty
   | Value_symbol sym -> Name_occurrences.singleton_symbol sym Name_mode.normal
   | Block_approximation (approxs, _) ->
     Array.fold_left

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -20,14 +20,19 @@ type 'code t =
   | Value_unknown
   | Value_symbol of Symbol.t
   | Value_int of Targetint_31_63.t
-  | Closure_approximation of Code_id.t * Function_slot.t * 'code
+  | Closure_approximation of
+      { code_id : Code_id.t;
+        function_slot : Function_slot.t;
+        code : 'code;
+        symbol : Symbol.t option
+      }
   | Block_approximation of 'code t array * Alloc_mode.t
 
 let rec print fmt = function
   | Value_unknown -> Format.fprintf fmt "?"
   | Value_symbol sym -> Symbol.print fmt sym
   | Value_int i -> Targetint_31_63.print fmt i
-  | Closure_approximation (code_id, _, _) ->
+  | Closure_approximation { code_id; _ } ->
     Format.fprintf fmt "[%a]" Code_id.print code_id
   | Block_approximation (fields, _) ->
     let len = Array.length fields in
@@ -55,8 +60,13 @@ let rec free_names ~code_free_names approx =
       (fun names approx ->
         Name_occurrences.union names (free_names ~code_free_names approx))
       Name_occurrences.empty approxs
-  | Closure_approximation (code_id, function_slot, code) ->
+  | Closure_approximation { code_id; function_slot; code; symbol } ->
+    let free_names = code_free_names code in
+    let free_names =
+      match symbol with
+      | None -> free_names
+      | Some sym -> Name_occurrences.add_symbol free_names sym Name_mode.normal
+    in
     Name_occurrences.add_code_id
-      (Name_occurrences.add_function_slot_in_types (code_free_names code)
-         function_slot)
+      (Name_occurrences.add_function_slot_in_types free_names function_slot)
       code_id Name_mode.normal

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -19,6 +19,7 @@
 type 'code t =
   | Value_unknown
   | Value_symbol of Symbol.t
+  | Value_int of Targetint_31_63.t
   | Closure_approximation of Code_id.t * Function_slot.t * 'code
   | Block_approximation of 'code t array * Alloc_mode.t
 

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -20,7 +20,12 @@ type 'code t =
   | Value_unknown
   | Value_symbol of Symbol.t
   | Value_int of Targetint_31_63.t
-  | Closure_approximation of Code_id.t * Function_slot.t * 'code
+  | Closure_approximation of
+      { code_id : Code_id.t;
+        function_slot : Function_slot.t;
+        code : 'code;
+        symbol : Symbol.t option
+      }
   | Block_approximation of 'code t array * Alloc_mode.t
 
 val print : Format.formatter -> 'a t -> unit

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -738,7 +738,7 @@ let close_let acc env id user_visible defining_expr
             (Env.add_block_approximation body_env (Name.var var) approxs
                alloc_mode)
         | Prim (Binary (Block_load _, block, field), _) -> (
-          match Env.find_value_approximation env block with
+          match Env.find_value_approximation body_env block with
           | Value_unknown -> Some body_env
           | Closure_approximation _ | Value_symbol _ | Value_int _ ->
             (* Here we assume [block] has already been substituted as a known

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -162,11 +162,12 @@ module Env = struct
               "Closure_conversion: approximation loader returned a Symbol \
                approximation (%a) for symbol %a"
               Symbol.print sym Symbol.print symbol
-          | Value_unknown | Closure_approximation _ | Block_approximation _ ->
+          | Value_unknown | Value_int _ | Closure_approximation _
+          | Block_approximation _ ->
             ());
         let rec filter_inlinable approx =
           match (approx : value_approximation) with
-          | Value_unknown | Value_symbol _
+          | Value_unknown | Value_symbol _ | Value_int _
           | Closure_approximation (_, _, Metadata_only _) ->
             approx
           | Block_approximation (approxs, alloc_mode) ->
@@ -339,8 +340,8 @@ module Env = struct
   let add_approximation_alias t name alias =
     match find_value_approximation t (Simple.name name) with
     | Value_unknown -> t
-    | (Value_symbol _ | Closure_approximation _ | Block_approximation _) as
-      approx ->
+    | ( Value_symbol _ | Value_int _ | Closure_approximation _
+      | Block_approximation _ ) as approx ->
       add_value_approximation t alias approx
 
   let set_path_to_root t path_to_root =

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1190,7 +1190,8 @@ end = struct
         let fields = List.map type_from_approx (Array.to_list fields) in
         MTC.immutable_block ~is_unique:false Tag.zero
           ~field_kind:Flambda_kind.value ~fields (Or_unknown.Known alloc_mode)
-      | Closure_approximation (code_id, function_slot, _code_opt) ->
+      | Closure_approximation { code_id; function_slot; code = _; symbol = _ }
+        ->
         let fun_decl =
           TG.Function_type.create code_id
             ~rec_info:(MTC.unknown Flambda_kind.rec_info)
@@ -1304,7 +1305,9 @@ end = struct
               | Ok function_type ->
                 let code_id = TG.Function_type.code_id function_type in
                 let code_or_meta = find_code code_id in
-                Closure_approximation (code_id, function_slot, code_or_meta)))
+                Closure_approximation
+                  { code_id; function_slot; code = code_or_meta; symbol = None }
+              ))
           | Variant
               { immediates = Unknown;
                 blocks = _;

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1183,6 +1183,7 @@ end = struct
     let rec type_from_approx approx =
       match (approx : _ Value_approximation.t) with
       | Value_unknown -> MTC.unknown Flambda_kind.value
+      | Value_int i -> TG.this_tagged_immediate i
       | Value_symbol symbol ->
         TG.alias_type_of Flambda_kind.value (Simple.symbol symbol)
       | Block_approximation (fields, alloc_mode) ->
@@ -1278,7 +1279,12 @@ end = struct
         | Unknown | Bottom -> Value_unknown
         | Ok (Equals simple) ->
           Simple.pattern_match' simple
-            ~const:(fun _ -> VA.Value_unknown)
+            ~const:(fun const ->
+              match Reg_width_const.descr const with
+              | Tagged_immediate i -> VA.Value_int i
+              | Naked_immediate _ | Naked_float _ | Naked_int32 _
+              | Naked_int64 _ | Naked_nativeint _ ->
+                VA.Value_unknown)
             ~var:(fun _ ~coercion:_ -> VA.Value_unknown)
             ~symbol:(fun symbol ~coercion:_ -> VA.Value_symbol symbol)
         | Ok (No_alias head) -> (

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1192,6 +1192,7 @@ end = struct
           ~field_kind:Flambda_kind.value ~fields (Or_unknown.Known alloc_mode)
       | Closure_approximation { code_id; function_slot; code = _; symbol = _ }
         ->
+        (* CR keryan: we should use the associated symbol at some point *)
         let fun_decl =
           TG.Function_type.create code_id
             ~rec_info:(MTC.unknown Flambda_kind.rec_info)


### PR DESCRIPTION
This improves various things to allow a better propagation of approximations through switches, and particularly the one that can be reduce to a single case.

Also fixes a bug in free_names accounting.