### PR TITLE
Static check for noalloc: attributes

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -409,7 +409,7 @@ end = struct
 end
 
 module Spec_alloc : Spec = struct
-  let name = "alloc"
+  let name = "noalloc"
 
   let enabled () = !Flambda_backend_flags.alloc_check
 
@@ -453,7 +453,7 @@ let record_unit_info ppf_dump =
 
 let report_error ppf = function
   | Annotation { fun_name; check } ->
-    Format.fprintf ppf "Annotation check for %s on function %s failed" check
+    Format.fprintf ppf "Annotation check for %s failed on function %s" check
       fun_name
 
 let () =

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -80,7 +80,7 @@ module type Spec = sig
   (** returns true when the check passes. *)
   val check_specific : Arch.specific_operation -> bool
 
-  val annotation : Lambda.property
+  val annotation : Cmm.property
 end
 (* CR-someday gyorsh: We may also want annotations on call sites, not only on
    functions. *)
@@ -424,7 +424,7 @@ module Spec_alloc : Spec = struct
 
   let check_specific s = not (Arch.operation_allocates s)
 
-  let annotation = Lambda.Noalloc
+  let annotation = Cmm.Noalloc
 end
 
 (***************************************************************************

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -267,7 +267,7 @@ end = struct
   let report t ~msg ~desc dbg =
     if !Flambda_backend_flags.dump_checkmach
     then
-      Format.fprintf t.ppf "*** check %s %s in %s: %s at %a\n" S.name msg
+      Format.fprintf t.ppf "*** check %s %s in %s: %s %a\n" S.name msg
         t.fun_name desc Debuginfo.print_compact dbg
 
   exception Bail
@@ -393,7 +393,7 @@ end = struct
           Unit_info.in_current_unit unit_info fun_name;
           if List.mem (Cmm.Assume S.annotation) f.fun_codegen_options
           then (
-            report t ~msg:"assumed" ~desc:"" f.fun_dbg;
+            report t ~msg:"assumed" ~desc:"fundecl" f.fun_dbg;
             Unit_info.add_value t.ppf unit_info fun_name Pass)
           else (
             (try
@@ -401,7 +401,7 @@ end = struct
                if (not t.unresolved_dependencies)
                   && not (Unit_info.is_fail unit_info t.fun_name)
                then (
-                 report t ~msg:"passed" ~desc:"" f.fun_dbg;
+                 report t ~msg:"passed" ~desc:"fundecl" f.fun_dbg;
                  Unit_info.add_value t.ppf unit_info fun_name Pass)
              with Bail -> debug t Fail);
             if List.mem (Cmm.Assert S.annotation) f.fun_codegen_options

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -248,7 +248,8 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Noalloc_check
+  | Assert of Lambda.property
+  | Assume of Lambda.property
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -244,12 +244,15 @@ type expression =
   | Cregion of expression
   | Ctail of expression
 
+type property =
+  | Noalloc
+
 type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Assert of Lambda.property
-  | Assume of Lambda.property
+  | Assert of property
+  | Assume of property
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -253,12 +253,15 @@ type expression =
   | Cregion of expression
   | Ctail of expression
 
+type property =
+  | Noalloc
+
 type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Assert of Lambda.property
-  | Assume of Lambda.property
+  | Assert of property
+  | Assume of property
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -257,7 +257,8 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Noalloc_check
+  | Assert of Lambda.property
+  | Assume of Lambda.property
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4169,3 +4169,8 @@ let cmm_arith_size (e : Cmm.expression) =
   | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _ | Cregion _
   | Ctail _ ->
     None
+
+let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
+  | Default_check -> []
+  | Assert p -> [Assert p]
+  | Assume p -> [Assume p]

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4170,7 +4170,10 @@ let cmm_arith_size (e : Cmm.expression) =
   | Ctail _ ->
     None
 
+let transl_property : Lambda.property -> Cmm.property = function
+  | Noalloc -> Noalloc
+
 let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
   | Default_check -> []
-  | Assert p -> [Assert p]
-  | Assume p -> [Assume p]
+  | Assert p -> [Assert (transl_property p)]
+  | Assume p -> [Assume (transl_property p)]

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1206,3 +1206,5 @@ val gc_root_table :
    If [None] is returned, that means "no estimate available". The expression
    should be assumed to be potentially large. *)
 val cmm_arith_size : expression -> int option
+
+val transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1471,7 +1471,7 @@ let transl_function f =
     else
       transl env body in
   let fun_codegen_options =
-    transl_attrib f.attrib @
+    transl_attrib f.check @
     if !Clflags.optimize_for_speed then
       []
     else

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1471,6 +1471,7 @@ let transl_function f =
     else
       transl env body in
   let fun_codegen_options =
+    transl_attrib f.attrib @
     if !Clflags.optimize_for_speed then
       []
     else

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -339,7 +339,7 @@ and sequence ppf = function
 
 and expression ppf e = fprintf ppf "%a" expr e
 
-let property : Lambda.property -> string = function
+let property : Cmm.property -> string = function
     | Noalloc -> "noalloc"
 
 let codegen_option = function

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -339,11 +339,15 @@ and sequence ppf = function
 
 and expression ppf e = fprintf ppf "%a" expr e
 
+let property : Lambda.property -> string = function
+    | Noalloc -> "noalloc"
+
 let codegen_option = function
   | Reduce_code_size -> "reduce_code_size"
   | No_CSE -> "no_cse"
   | Use_linscan_regalloc -> "linscan"
-  | Noalloc_check -> "noalloc_check"
+  | Assert p -> "assert "^(property p)
+  | Assume p -> "assume "^(property p)
 
 let print_codegen_options ppf l =
   List.iter (fun c -> fprintf ppf " %s" (codegen_option c)) l

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -100,7 +100,7 @@ and ufunction = {
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;
   mode   : Lambda.alloc_mode;
-  attrib : Lambda.check_attribute;
+  check  : Lambda.check_attribute;
 }
 
 and ulambda_switch =

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -100,6 +100,7 @@ and ufunction = {
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;
   mode   : Lambda.alloc_mode;
+  attrib : Lambda.check_attribute;
 }
 
 and ulambda_switch =

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -111,7 +111,7 @@ and ufunction = {
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;
   mode   : Lambda.alloc_mode;
-  attrib : Lambda.check_attribute;
+  check  : Lambda.check_attribute;
 }
 
 and ulambda_switch =

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -111,6 +111,7 @@ and ufunction = {
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;
   mode   : Lambda.alloc_mode;
+  attrib : Lambda.check_attribute;
 }
 
 and ulambda_switch =

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1432,7 +1432,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
      does not use its environment parameter is invalidated. *)
   let useless_env = ref initially_closed in
   (* Translate each function definition *)
-  let clos_fundef (id, params, return, body, mode, attrib, fundesc, dbg) env_pos =
+  let clos_fundef (id, params, return, body, mode, check, fundesc, dbg) env_pos =
     let env_param = V.create_local "env" in
     let cenv_fv =
       build_closure_env env_param (fv_pos - env_pos) fv in
@@ -1460,7 +1460,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
         dbg;
         env = Some env_param;
         mode;
-        attrib;
+        check;
       }
     in
     (* give more chance of function with default parameters (i.e.

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1394,9 +1394,10 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
   let uncurried_defs =
     List.map
       (function
-          (id, Lfunction({kind; params; return; body; loc; mode; region}
+          (id, Lfunction({kind; params; return; body; attr; loc; mode; region}
                          as funct)) ->
             Lambda.check_lfunction funct;
+            let attrib = attr.check in
             let label = Compilenv.make_fun_symbol loc (V.unique_name id) in
             let arity = List.length params in
             let fundesc =
@@ -1407,20 +1408,20 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
                fun_float_const_prop = !Clflags.float_const_prop;
                fun_region = region} in
             let dbg = Debuginfo.from_location loc in
-            (id, params, return, body, mode, fundesc, dbg)
+            (id, params, return, body, mode, attrib, fundesc, dbg)
         | (_, _) -> fatal_error "Closure.close_functions")
       fun_defs in
   (* Build an approximate fenv for compiling the functions *)
   let fenv_rec =
     List.fold_right
-      (fun (id, _params, _return, _body, mode, fundesc, _dbg) fenv ->
+      (fun (id, _params, _return, _body, mode, _attrib, fundesc, _dbg) fenv ->
         V.Map.add id (Value_closure(mode, fundesc, Value_unknown)) fenv)
       uncurried_defs fenv in
   (* Determine the offsets of each function's closure in the shared block *)
   let env_pos = ref (-1) in
   let clos_offsets =
     List.map
-      (fun (_id, _params, _return, _body, _mode, fundesc, _dbg) ->
+      (fun (_id, _params, _return, _body, _mode, _attrib, fundesc, _dbg) ->
         let pos = !env_pos + 1 in
         env_pos := !env_pos + 1 +
           (match fundesc.fun_arity with (Curried _, (0|1)) -> 2 | _ -> 3);
@@ -1431,13 +1432,13 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
      does not use its environment parameter is invalidated. *)
   let useless_env = ref initially_closed in
   (* Translate each function definition *)
-  let clos_fundef (id, params, return, body, mode, fundesc, dbg) env_pos =
+  let clos_fundef (id, params, return, body, mode, attrib, fundesc, dbg) env_pos =
     let env_param = V.create_local "env" in
     let cenv_fv =
       build_closure_env env_param (fv_pos - env_pos) fv in
     let cenv_body =
       List.fold_right2
-        (fun (id, _params, _return, _body, _mode, _fundesc, _dbg) pos env ->
+        (fun (id, _params, _return, _body, _mode, _attrib, _fundesc, _dbg) pos env ->
           V.Map.add id (Uoffset(Uvar env_param, pos - env_pos)) env)
         uncurried_defs clos_offsets cenv_fv in
     let (ubody, approx) =
@@ -1459,6 +1460,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
         dbg;
         env = Some env_param;
         mode;
+        attrib;
       }
     in
     (* give more chance of function with default parameters (i.e.
@@ -1497,7 +1499,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
          recompile *)
         Compilenv.backtrack snap; (* PR#6337 *)
         List.iter
-          (fun (_id, _params, _return, _body, _mode, fundesc, _dbg) ->
+          (fun (_id, _params, _return, _body, _mode, _attrib, fundesc, _dbg) ->
              fundesc.fun_closed <- false;
              fundesc.fun_inline <- None;
           )

--- a/middle_end/flambda/augment_specialised_args.ml
+++ b/middle_end/flambda/augment_specialised_args.ml
@@ -546,6 +546,7 @@ module Make (T : S) = struct
         ~stub:true
         ~inline:Default_inline
         ~specialise:Default_specialise
+        ~check:Default_check
         ~is_a_functor:false
         ~closure_origin:function_decl.closure_origin
     in
@@ -639,6 +640,7 @@ module Make (T : S) = struct
           ~stub:function_decl.stub
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
+          ~check:function_decl.check
           ~is_a_functor:function_decl.is_a_functor
           ~closure_origin
       in

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -107,7 +107,7 @@ let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
   let tuple_param = Parameter.wrap tuple_param_var alloc_mode in
   Flambda.create_function_declaration ~params:[tuple_param] ~alloc_mode ~region
     ~body ~stub:true ~inline:Default_inline
-    ~specialise:Default_specialise ~is_a_functor:false
+    ~specialise:Default_specialise ~check:Default_check ~is_a_functor:false
     ~closure_origin:(Closure_origin.create (Closure_id.wrap closure_bound_var))
 
 let register_const t (constant:Flambda.constant_defining_value) name
@@ -650,6 +650,7 @@ and close_functions t external_env function_declarations : Flambda.named =
         ~body ~stub
         ~inline:(Function_decl.inline decl)
         ~specialise:(Function_decl.specialise decl)
+        ~check:(Function_decl.check decl)
         ~is_a_functor:(Function_decl.is_a_functor decl)
         ~closure_origin
     in

--- a/middle_end/flambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/closure_conversion_aux.ml
@@ -125,6 +125,7 @@ module Function_decls = struct
     let free_idents t = t.free_idents_of_body
     let inline t = t.attr.inline
     let specialise t = t.attr.specialise
+    let check t = t.attr.check
     let is_a_functor t = t.attr.is_a_functor
     let stub t = t.attr.stub
     let loc t = t.loc

--- a/middle_end/flambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/closure_conversion_aux.mli
@@ -73,6 +73,7 @@ module Function_decls : sig
     val body : t -> Lambda.lambda
     val inline : t -> Lambda.inline_attribute
     val specialise : t -> Lambda.specialise_attribute
+    val check : t -> Lambda.check_attribute
     val is_a_functor : t -> bool
     val stub : t -> bool
     val loc : t -> Lambda.scoped_location

--- a/middle_end/flambda/export_info_for_pack.ml
+++ b/middle_end/flambda/export_info_for_pack.ml
@@ -146,6 +146,7 @@ and import_function_declarations_for_pack_aux units pack
           ~stub:function_decl.stub
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
+          ~check:function_decl.check
           ~is_a_functor:function_decl.is_a_functor
           ~closure_origin:function_decl.closure_origin)
       function_decls.funs

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -137,6 +137,7 @@ and function_declaration = {
   dbg : Debuginfo.t;
   inline : Lambda.inline_attribute;
   specialise : Lambda.specialise_attribute;
+  check : Lambda.check_attribute;
   is_a_functor : bool;
 }
 
@@ -406,8 +407,9 @@ and print_function_declaration ppf var (f : function_declaration) =
     | Never_specialise -> " *never_specialise*"
     | Default_specialise -> ""
   in
-  fprintf ppf "@[<2>(%a%s%s%s%s@ =@ fun@[<2>%a@] ->@ @[<2>%a@])@]@ "
+  fprintf ppf "@[<2>(%a%s%s%s%s%a@ =@ fun@[<2>%a@] ->@ @[<2>%a@])@]@ "
     Variable.print var stub is_a_functor inline specialise
+    Printlambda.check_attribute f.check
     params f.params lam f.body
 
 and print_set_of_closures ppf (set_of_closures : set_of_closures) =
@@ -1042,6 +1044,7 @@ let update_body_of_function_declaration (func_decl: function_declaration)
     stub = func_decl.stub;
     dbg = func_decl.dbg;
     inline = func_decl.inline;
+    check = func_decl.check;
     specialise = func_decl.specialise;
     is_a_functor = func_decl.is_a_functor;
   }
@@ -1056,7 +1059,9 @@ let rec check_param_modes mode = function
 
 let create_function_declaration ~params ~alloc_mode ~region ~body ~stub
       ~(inline : Lambda.inline_attribute)
-      ~(specialise : Lambda.specialise_attribute) ~is_a_functor
+      ~(specialise : Lambda.specialise_attribute)
+      ~(check : Lambda.check_attribute)
+      ~is_a_functor
       ~closure_origin
       : function_declaration =
   begin match stub, inline with
@@ -1090,6 +1095,7 @@ let create_function_declaration ~params ~alloc_mode ~region ~body ~stub
     dbg = dbg_origin;
     inline;
     specialise;
+    check;
     is_a_functor;
   }
 

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -336,6 +336,8 @@ and function_declaration = private {
   (** Inlining requirements from the source code. *)
   specialise : Lambda.specialise_attribute;
   (** Specialising requirements from the source code. *)
+  check : Lambda.check_attribute;
+  (** Check function properties requirements from the source code  *)
   is_a_functor : bool;
   (** Whether the function is known definitively to be a functor. *)
 }
@@ -567,6 +569,7 @@ val create_function_declaration
   -> stub:bool
   -> inline:Lambda.inline_attribute
   -> specialise:Lambda.specialise_attribute
+  -> check:Lambda.check_attribute
   -> is_a_functor:bool
   -> closure_origin:Closure_origin.t
   -> function_declaration

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -578,7 +578,7 @@ and to_clambda_set_of_closures t env
       dbg = function_decl.dbg;
       env = Some env_var;
       mode = set_of_closures.alloc_mode;
-      attrib = function_decl.check;
+      check = function_decl.check;
     }
   in
   let funs = List.map to_clambda_function all_functions in
@@ -628,7 +628,7 @@ and to_clambda_closed_set_of_closures t env symbol
       dbg = function_decl.dbg;
       env = None;
       mode = Lambda.alloc_heap;
-      attrib = function_decl.check;
+      check = function_decl.check;
     }
   in
   let ufunct = List.map to_clambda_function functions in

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -578,6 +578,7 @@ and to_clambda_set_of_closures t env
       dbg = function_decl.dbg;
       env = Some env_var;
       mode = set_of_closures.alloc_mode;
+      attrib = function_decl.check;
     }
   in
   let funs = List.map to_clambda_function all_functions in
@@ -627,6 +628,7 @@ and to_clambda_closed_set_of_closures t env symbol
       dbg = function_decl.dbg;
       env = None;
       mode = Lambda.alloc_heap;
+      attrib = function_decl.check;
     }
   in
   let ufunct = List.map to_clambda_function functions in

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -364,7 +364,7 @@ let make_closure_declaration
     Flambda.create_function_declaration
       ~params:(List.map subst_param params) ~alloc_mode  ~region
       ~body ~stub ~inline:Default_inline
-      ~specialise:Default_specialise ~is_a_functor:false
+      ~specialise:Default_specialise ~check:Default_check ~is_a_functor:false
       ~closure_origin:(Closure_origin.create (Closure_id.wrap id))
   in
   assert (Variable.Set.equal (Variable.Set.map subst free_variables)

--- a/middle_end/flambda/freshening.ml
+++ b/middle_end/flambda/freshening.ml
@@ -326,6 +326,7 @@ module Project_var = struct
             ~body
             ~stub:func_decl.stub
             ~inline:func_decl.inline ~specialise:func_decl.specialise
+            ~check:func_decl.check
             ~is_a_functor:func_decl.is_a_functor
             ~closure_origin:func_decl.closure_origin
         in

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -615,6 +615,7 @@ and simplify_set_of_closures original_env r
         ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
         ~body ~stub:function_decl.stub
         ~inline:function_decl.inline ~specialise:function_decl.specialise
+        ~check:function_decl.check
         ~is_a_functor:function_decl.is_a_functor
         ~closure_origin:function_decl.closure_origin
     in
@@ -1500,6 +1501,7 @@ and duplicate_function ~env ~(set_of_closures : Flambda.set_of_closures)
       ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
       ~body ~stub:function_decl.stub
       ~inline:function_decl.inline ~specialise:function_decl.specialise
+      ~check:function_decl.check
       ~is_a_functor:function_decl.is_a_functor
       ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
   in

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -543,6 +543,7 @@ let rewrite_function ~lhs_of_application ~closure_id_being_applied
       ~stub:function_body.stub
       ~inline:function_body.inline
       ~specialise:function_body.specialise
+      ~check:function_body.check
       ~is_a_functor:function_body.is_a_functor
       ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
   in

--- a/middle_end/flambda/remove_unused_arguments.ml
+++ b/middle_end/flambda/remove_unused_arguments.ml
@@ -43,7 +43,8 @@ let remove_params unused (fun_decl: Flambda.function_declaration)
     ~params:used_params ~alloc_mode:fun_decl.alloc_mode ~region:fun_decl.region
     ~body
     ~stub:fun_decl.stub ~inline:fun_decl.inline
-    ~specialise:fun_decl.specialise ~is_a_functor:fun_decl.is_a_functor
+    ~specialise:fun_decl.specialise ~check:fun_decl.check
+    ~is_a_functor:fun_decl.is_a_functor
     ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
 
 let make_stub unused var (fun_decl : Flambda.function_declaration)
@@ -107,7 +108,9 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
       ~alloc_mode:fun_decl.alloc_mode ~region:fun_decl.region
       ~body
       ~stub:true ~inline:Default_inline
-      ~specialise:Default_specialise ~is_a_functor:fun_decl.is_a_functor
+      ~specialise:Default_specialise
+      ~check:Default_check
+      ~is_a_functor:fun_decl.is_a_functor
       ~closure_origin:fun_decl.closure_origin
   in
   function_decl, renamed, additional_specialised_args

--- a/middle_end/flambda/simple_value_approx.ml
+++ b/middle_end/flambda/simple_value_approx.ml
@@ -80,6 +80,7 @@ and function_body = {
   dbg : Debuginfo.t;
   inline : Lambda.inline_attribute;
   specialise : Lambda.specialise_attribute;
+  check : Lambda.check_attribute;
   is_a_functor : bool;
   body : Flambda.t;
 }
@@ -944,6 +945,7 @@ let function_declaration_approx ~keep_body fun_var
              inline = fun_decl.inline;
              dbg = fun_decl.dbg;
              specialise = fun_decl.specialise;
+             check = fun_decl.check;
              is_a_functor = fun_decl.is_a_functor;
              free_variables = fun_decl.free_variables;
              free_symbols = fun_decl.free_symbols; }

--- a/middle_end/flambda/simple_value_approx.mli
+++ b/middle_end/flambda/simple_value_approx.mli
@@ -156,6 +156,7 @@ and function_body = private {
   dbg : Debuginfo.t;
   inline : Lambda.inline_attribute;
   specialise : Lambda.specialise_attribute;
+  check : Lambda.check_attribute;
   is_a_functor : bool;
   body : Flambda.t;
 }

--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -147,7 +147,8 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
     | Uclosure (functions, captured_variables) ->
       List.iter (loop ~depth) captured_variables;
       List.iter (fun (
-        { Clambda. label; arity=_; params; return; body; dbg; env; mode=_} as clos) ->
+        { Clambda. label; arity=_; params; return; body; dbg; env; mode=_;
+            attrib=_} as clos) ->
           (match closure_environment_var clos with
            | None -> ()
            | Some env_var ->
@@ -323,7 +324,8 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
     | Uclosure (functions, captured_variables) ->
       ignore_ulambda_list captured_variables;
       (* Start a new let stack for speed. *)
-      List.iter (fun {Clambda. label; arity=_; params; return; body; dbg; env; mode=_} ->
+      List.iter (fun {Clambda. label; arity=_; params; return; body; dbg; env; mode=_;
+                      attrib=_} ->
           ignore_function_label label;
           ignore_params_with_value_kind params;
           ignore_value_kind return;

--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -148,7 +148,7 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
       List.iter (loop ~depth) captured_variables;
       List.iter (fun (
         { Clambda. label; arity=_; params; return; body; dbg; env; mode=_;
-            attrib=_} as clos) ->
+            check=_} as clos) ->
           (match closure_environment_var clos with
            | None -> ()
            | Some env_var ->
@@ -325,7 +325,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
       ignore_ulambda_list captured_variables;
       (* Start a new let stack for speed. *)
       List.iter (fun {Clambda. label; arity=_; params; return; body; dbg; env; mode=_;
-                      attrib=_} ->
+                      check=_} ->
           ignore_function_label label;
           ignore_params_with_value_kind params;
           ignore_value_kind return;

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1341,6 +1341,7 @@ let close_one_function acc ~external_env ~by_function_slot decl
       ~contains_no_escaping_local_allocs:
         (Function_decl.contains_no_escaping_local_allocs decl)
       ~stub ~inline
+      ~check:(Function_decl.check_attribute decl)
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1642,6 +1642,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
       { inline = Default_inline;
         specialise = Default_specialise;
         local = Default_local;
+        check = Default_check;
         is_a_functor = false;
         stub = false
       }

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1341,7 +1341,7 @@ let close_one_function acc ~external_env ~by_function_slot decl
       ~contains_no_escaping_local_allocs:
         (Function_decl.contains_no_escaping_local_allocs decl)
       ~stub ~inline
-      ~check:(Function_decl.check_attribute decl)
+      ~check:(Check_attribute.from_lambda (Function_decl.check_attribute decl))
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -610,6 +610,8 @@ module Function_decls = struct
 
     let is_a_functor t = t.attr.is_a_functor
 
+    let check_attribute t = t.attr.check
+
     let stub t = t.attr.stub
 
     let loc t = t.loc

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -305,6 +305,8 @@ module Function_decls : sig
 
     val is_a_functor : t -> bool
 
+    val check_attribute : t -> Lambda.check_attribute
+
     val stub : t -> bool
 
     val loc : t -> Lambda.scoped_location

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -782,6 +782,8 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
             ~newer_version_of ~params_arity ~num_trailing_local_params:0
             ~result_arity ~result_types:Unknown
             ~contains_no_escaping_local_allocs:false ~stub:false ~inline
+            ~check:Default_check ~is_a_functor:false ~recursive
+            (* CR gyorsh: should [check] be set properly? *)
             ~is_a_functor:false ~recursive
             ~cost_metrics (* CR poechsel: grab inlining arguments from fexpr. *)
             ~inlining_arguments:(Inlining_arguments.create ~round:0)

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -782,8 +782,8 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
             ~newer_version_of ~params_arity ~num_trailing_local_params:0
             ~result_arity ~result_types:Unknown
             ~contains_no_escaping_local_allocs:false ~stub:false ~inline
-            ~check:Default_check ~is_a_functor:false ~recursive
-            (* CR gyorsh: should [check] be set properly? *)
+            ~check:
+              Default_check (* CR gyorsh: should [check] be set properly? *)
             ~is_a_functor:false ~recursive
             ~cost_metrics (* CR poechsel: grab inlining arguments from fexpr. *)
             ~inlining_arguments:(Inlining_arguments.create ~round:0)

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -508,7 +508,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
           ~params_arity:(Bound_parameters.arity_with_subkinds remaining_params)
           ~num_trailing_local_params ~result_arity ~result_types:Unknown
           ~contains_no_escaping_local_allocs ~stub:true ~inline:Default_inline
-          ~is_a_functor:false ~recursive ~cost_metrics:cost_metrics_of_body
+          ~check:Lambda.Default_check ~is_a_functor:false ~recursive
+          ~cost_metrics:cost_metrics_of_body
           ~inlining_arguments:(DE.inlining_arguments (DA.denv dacc))
           ~dbg ~is_tupled:false
           ~is_my_closure_used:

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -508,7 +508,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
           ~params_arity:(Bound_parameters.arity_with_subkinds remaining_params)
           ~num_trailing_local_params ~result_arity ~result_types:Unknown
           ~contains_no_escaping_local_allocs ~stub:true ~inline:Default_inline
-          ~check:Lambda.Default_check ~is_a_functor:false ~recursive
+          ~check:Check_attribute.Default_check ~is_a_functor:false ~recursive
           ~cost_metrics:cost_metrics_of_body
           ~inlining_arguments:(DE.inlining_arguments (DA.denv dacc))
           ~dbg ~is_tupled:false

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -771,7 +771,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       ~result_arity ~result_types
       ~contains_no_escaping_local_allocs:
         (Code.contains_no_escaping_local_allocs code)
-      ~stub:(Code.stub code) ~inline:(Code.inline code)
+      ~stub:(Code.stub code) ~inline:(Code.inline code) ~check:(Code.check code)
       ~is_a_functor:(Code.is_a_functor code) ~recursive:(Code.recursive code)
       ~cost_metrics ~inlining_arguments ~dbg:(Code.dbg code)
       ~is_tupled:(Code.is_tupled code) ~is_my_closure_used ~inlining_decision

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -1,3 +1,15 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Copyright 2022 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 module Property = struct
   type t = Noalloc
 

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -28,8 +28,8 @@ type t =
 let print ppf t =
   match t with
   | Default_check -> ()
-  | Assert p -> Format.fprintf ppf "assert %s@ " (Property.to_string p)
-  | Assume p -> Format.fprintf ppf "assume %s@ " (Property.to_string p)
+  | Assert p -> Format.fprintf ppf "@[assert %s@]" (Property.to_string p)
+  | Assume p -> Format.fprintf ppf "@[assume %s@]" (Property.to_string p)
 
 let from_lambda : Lambda.check_attribute -> t = function
   | Default_check -> Default_check

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -1,0 +1,41 @@
+module Property = struct
+  type t =
+    | Noalloc
+
+  let to_string  = function
+    | Noalloc -> "noalloc"
+
+  let equal x y =
+    match x, y with
+    | Noalloc, Noalloc -> true
+
+  let from_lambda : Lambda.property -> t  = function
+    | Noalloc -> Noalloc
+end
+
+type t =
+  | Default_check
+  | Assert of Property.t
+  | Assume of Property.t
+
+let print ppf t =
+  match t with
+  | Default_check -> ()
+  | Assert p -> Format.fprintf ppf "assert %s@ " (Property.to_string p)
+  | Assume p -> Format.fprintf ppf "assume %s@ " (Property.to_string p)
+
+let from_lambda : Lambda.check_attribute -> t = function
+  | Default_check -> Default_check
+  | Assert p -> Assert (Property.from_lambda p)
+  | Assume p -> Assume (Property.from_lambda p)
+
+let equal x y =
+  match x, y with
+  | Default_check, Default_check -> true
+  | Assert p1, Assert p2
+  | Assume p1, Assume p2 -> Property.equal p1 p2
+  | (Default_check | Assert _ | Assume  _), _ -> false
+
+let is_default : t -> bool = function
+  | Default_check -> true
+  | Assert _ | Assume _ -> false

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -1,16 +1,11 @@
 module Property = struct
-  type t =
-    | Noalloc
+  type t = Noalloc
 
-  let to_string  = function
-    | Noalloc -> "noalloc"
+  let to_string = function Noalloc -> "noalloc"
 
-  let equal x y =
-    match x, y with
-    | Noalloc, Noalloc -> true
+  let equal x y = match x, y with Noalloc, Noalloc -> true
 
-  let from_lambda : Lambda.property -> t  = function
-    | Noalloc -> Noalloc
+  let from_lambda : Lambda.property -> t = function Noalloc -> Noalloc
 end
 
 type t =
@@ -32,9 +27,8 @@ let from_lambda : Lambda.check_attribute -> t = function
 let equal x y =
   match x, y with
   | Default_check, Default_check -> true
-  | Assert p1, Assert p2
-  | Assume p1, Assume p2 -> Property.equal p1 p2
-  | (Default_check | Assert _ | Assume  _), _ -> false
+  | Assert p1, Assert p2 | Assume p1, Assume p2 -> Property.equal p1 p2
+  | (Default_check | Assert _ | Assume _), _ -> false
 
 let is_default : t -> bool = function
   | Default_check -> true

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -1,7 +1,6 @@
 (** Annotations on function declaration (not call sites) *)
 module Property : sig
-  type t =
-    | Noalloc
+  type t = Noalloc
 end
 
 type t =

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -1,0 +1,18 @@
+(** Annotations on function declaration (not call sites) *)
+module Property : sig
+  type t =
+    | Noalloc
+end
+
+type t =
+  | Default_check
+  | Assert of Property.t
+  | Assume of Property.t
+
+val print : Format.formatter -> t -> unit
+
+val equal : t -> t -> bool
+
+val is_default : t -> bool
+
+val from_lambda : Lambda.check_attribute -> t

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -1,3 +1,14 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Copyright 2022 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
 (** Annotations on function declaration (not call sites) *)
 module Property : sig
   type t = Noalloc

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -24,6 +24,7 @@ type t =
     contains_no_escaping_local_allocs : bool;
     stub : bool;
     inline : Inline_attribute.t;
+    check : Lambda.check_attribute;
     is_a_functor : bool;
     recursive : Recursive.t;
     cost_metrics : Cost_metrics.t;
@@ -72,6 +73,8 @@ module Code_metadata_accessors (X : Metadata_view_type) = struct
   let stub t = (metadata t).stub
 
   let inline t = (metadata t).inline
+
+  let check t = (metadata t).check
 
   let is_a_functor t = (metadata t).is_a_functor
 
@@ -139,7 +142,7 @@ type 'a create_type =
 
 let createk k code_id ~newer_version_of ~params_arity ~num_trailing_local_params
     ~result_arity ~result_types ~contains_no_escaping_local_allocs ~stub
-    ~(inline : Inline_attribute.t) ~is_a_functor ~recursive ~cost_metrics
+    ~(inline : Inline_attribute.t) ~check ~is_a_functor ~recursive ~cost_metrics
     ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision
     ~absolute_history ~relative_history =
   (match stub, inline with
@@ -167,6 +170,7 @@ let createk k code_id ~newer_version_of ~params_arity ~num_trailing_local_params
       contains_no_escaping_local_allocs;
       stub;
       inline;
+      check;
       is_a_functor;
       recursive;
       cost_metrics;
@@ -206,7 +210,7 @@ let [@ocamlformat "disable"] print_inlining_paths ppf
       Inlining_history.Absolute.print absolute_history
 
 let [@ocamlformat "disable"] print ppf
-      { code_id = _; newer_version_of; stub; inline; is_a_functor;
+       { code_id = _; newer_version_of; stub; inline; check; is_a_functor;
         params_arity; num_trailing_local_params; result_arity;
         result_types; contains_no_escaping_local_allocs;
         recursive; cost_metrics; inlining_arguments;
@@ -217,6 +221,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>%t(newer_version_of@ %a)%t@]@ \
       @[<hov 1>%t(stub@ %b)%t@]@ \
       @[<hov 1>%t(inline@ %a)%t@]@ \
+      @[<hov 1>%t(check@ %a)%t@]@ \
       @[<hov 1>%t(is_a_functor@ %b)%t@]@ \
       @[<hov 1>%t(params_arity@ %t%a%t)%t@]@ \
       @[<hov 1>(num_trailing_local_params@ %d)@]@ \
@@ -243,6 +248,10 @@ let [@ocamlformat "disable"] print ppf
     then Flambda_colours.elide
     else C.none)
     Inline_attribute.print inline
+    Flambda_colours.pop
+    (if Lambda.(equal_check_attribute Default_check check)
+     then Flambda_colours.elide else C.none)
+    Printlambda.check_attribute check
     Flambda_colours.pop
     (if not is_a_functor then Flambda_colours.elide else C.none)
     is_a_functor
@@ -297,6 +306,7 @@ let free_names
       contains_no_escaping_local_allocs = _;
       stub = _;
       inline = _;
+      check = _;
       is_a_functor = _;
       recursive = _;
       cost_metrics = _;
@@ -334,6 +344,7 @@ let apply_renaming
        contains_no_escaping_local_allocs = _;
        stub = _;
        inline = _;
+       check = _;
        is_a_functor = _;
        recursive = _;
        cost_metrics = _;
@@ -382,6 +393,7 @@ let ids_for_export
       contains_no_escaping_local_allocs = _;
       stub = _;
       inline = _;
+      check = _;
       is_a_functor = _;
       recursive = _;
       cost_metrics = _;
@@ -416,6 +428,7 @@ let approx_equal
       contains_no_escaping_local_allocs = contains_no_escaping_local_allocs1;
       stub = stub1;
       inline = inline1;
+      check = check1;
       is_a_functor = is_a_functor1;
       recursive = recursive1;
       cost_metrics = cost_metrics1;
@@ -436,6 +449,7 @@ let approx_equal
       contains_no_escaping_local_allocs = contains_no_escaping_local_allocs2;
       stub = stub2;
       inline = inline2;
+      check = check2;
       is_a_functor = is_a_functor2;
       recursive = recursive2;
       cost_metrics = cost_metrics2;
@@ -456,6 +470,7 @@ let approx_equal
        contains_no_escaping_local_allocs2
   && Bool.equal stub1 stub2
   && Inline_attribute.equal inline1 inline2
+  && Lambda.equal_check_attribute check1 check2
   && Bool.equal is_a_functor1 is_a_functor2
   && Recursive.equal recursive1 recursive2
   && Cost_metrics.equal cost_metrics1 cost_metrics2

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -128,6 +128,7 @@ type 'a create_type =
   contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
+  check:Lambda.check_attribute ->
   is_a_functor:bool ->
   recursive:Recursive.t ->
   cost_metrics:Cost_metrics.t ->

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -24,7 +24,7 @@ type t =
     contains_no_escaping_local_allocs : bool;
     stub : bool;
     inline : Inline_attribute.t;
-    check : Lambda.check_attribute;
+    check : Check_attribute.t;
     is_a_functor : bool;
     recursive : Recursive.t;
     cost_metrics : Cost_metrics.t;
@@ -128,7 +128,7 @@ type 'a create_type =
   contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
-  check:Lambda.check_attribute ->
+  check:Check_attribute.t ->
   is_a_functor:bool ->
   recursive:Recursive.t ->
   cost_metrics:Cost_metrics.t ->
@@ -250,9 +250,9 @@ let [@ocamlformat "disable"] print ppf
     else C.none)
     Inline_attribute.print inline
     Flambda_colours.pop
-    (if Lambda.(equal_check_attribute Default_check check)
+    (if Check_attribute.is_default check
      then Flambda_colours.elide else C.none)
-    Printlambda.check_attribute check
+    Check_attribute.print check
     Flambda_colours.pop
     (if not is_a_functor then Flambda_colours.elide else C.none)
     is_a_functor
@@ -471,7 +471,7 @@ let approx_equal
        contains_no_escaping_local_allocs2
   && Bool.equal stub1 stub2
   && Inline_attribute.equal inline1 inline2
-  && Lambda.equal_check_attribute check1 check2
+  && Check_attribute.equal check1 check2
   && Bool.equal is_a_functor1 is_a_functor2
   && Recursive.equal recursive1 recursive2
   && Cost_metrics.equal cost_metrics1 cost_metrics2

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -222,7 +222,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>%t(newer_version_of@ %a)%t@]@ \
       @[<hov 1>%t(stub@ %b)%t@]@ \
       @[<hov 1>%t(inline@ %a)%t@]@ \
-      @[<hov 1>%t(check@ %a)%t@]@ \
+      @[<hov 1>%t(%a)%t@]@ \
       @[<hov 1>%t(is_a_functor@ %b)%t@]@ \
       @[<hov 1>%t(params_arity@ %t%a%t)%t@]@ \
       @[<hov 1>(num_trailing_local_params@ %d)@]@ \

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -45,7 +45,7 @@ module type Code_metadata_accessors_result_type = sig
 
   val inline : 'a t -> Inline_attribute.t
 
-  val check : 'a t -> Lambda.check_attribute
+  val check : 'a t -> Check_attribute.t
 
   val is_a_functor : 'a t -> bool
 
@@ -85,7 +85,7 @@ type 'a create_type =
   contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
-  check:Lambda.check_attribute ->
+  check:Check_attribute.t ->
   is_a_functor:bool ->
   recursive:Recursive.t ->
   cost_metrics:Cost_metrics.t ->

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -45,6 +45,8 @@ module type Code_metadata_accessors_result_type = sig
 
   val inline : 'a t -> Inline_attribute.t
 
+  val check : t -> Lambda.check_attribute
+
   val is_a_functor : 'a t -> bool
 
   val recursive : 'a t -> Recursive.t
@@ -83,6 +85,7 @@ type 'a create_type =
   contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
+  check:Lambda.check_attribute ->
   is_a_functor:bool ->
   recursive:Recursive.t ->
   cost_metrics:Cost_metrics.t ->

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -45,7 +45,7 @@ module type Code_metadata_accessors_result_type = sig
 
   val inline : 'a t -> Inline_attribute.t
 
-  val check : t -> Lambda.check_attribute
+  val check : 'a t -> Lambda.check_attribute
 
   val is_a_functor : 'a t -> bool
 

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -247,6 +247,16 @@ module Static = Make_layout_filler (struct
   let define_global_symbol sym = C.define_symbol ~global:true sym
 end)
 
+(* Translation of "check" attributes on functions. *)
+
+let transl_property : Check_attribute.Property.t -> Cmm.property = function
+  | Noalloc -> Noalloc
+
+let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list = function
+  | Default_check -> []
+  | Assert p -> [Assert (transl_property p)]
+  | Assume p -> [Assume (transl_property p)]
+
 (* Translation of the bodies of functions. *)
 
 let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
@@ -276,7 +286,7 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
   let env, fun_args = C.bound_parameters env params in
   let fun_body, res = translate_expr env res body in
   let fun_flags =
-    C.transl_attrib check
+    transl_check_attrib check
     @
     if Flambda_features.optimize_for_speed () then [] else [Cmm.Reduce_code_size]
   in

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -249,7 +249,7 @@ end)
 
 (* Translation of the bodies of functions. *)
 
-let params_and_body0 env res code_id ~fun_dbg ~return_continuation
+let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
     ~exn_continuation params ~body ~my_closure
     ~(is_my_closure_used : _ Or_unknown.t) ~translate_expr =
   let params =
@@ -276,12 +276,14 @@ let params_and_body0 env res code_id ~fun_dbg ~return_continuation
   let env, fun_args = C.bound_parameters env params in
   let fun_body, res = translate_expr env res body in
   let fun_flags =
+    C.transl_attrib check
+    @
     if Flambda_features.optimize_for_speed () then [] else [Cmm.Reduce_code_size]
   in
   let linkage_name = Linkage_name.to_string (Code_id.linkage_name code_id) in
   C.fundecl linkage_name fun_args fun_body fun_flags fun_dbg, res
 
-let params_and_body env res code_id p ~fun_dbg ~translate_expr =
+let params_and_body env res code_id p ~fun_dbg ~check ~translate_expr =
   Function_params_and_body.pattern_match p
     ~f:(fun
          ~return_continuation
@@ -295,7 +297,7 @@ let params_and_body env res code_id p ~fun_dbg ~translate_expr =
          ~free_names_of_body:_
        ->
       try
-        params_and_body0 env res code_id ~fun_dbg ~return_continuation
+        params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
           ~exn_continuation params ~body ~my_closure ~is_my_closure_used
           ~translate_expr
       with Misc.Fatal_error as e ->

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -252,7 +252,8 @@ end)
 let transl_property : Check_attribute.Property.t -> Cmm.property = function
   | Noalloc -> Noalloc
 
-let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list = function
+let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list =
+  function
   | Default_check -> []
   | Assert p -> [Assert (transl_property p)]
   | Assume p -> [Assume (transl_property p)]

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -42,6 +42,7 @@ val params_and_body :
   Code_id.t ->
   Function_params_and_body.t ->
   fun_dbg:Debuginfo.t ->
+  check:Lambda.check_attribute ->
   translate_expr:
     (To_cmm_env.t ->
     To_cmm_result.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -42,7 +42,7 @@ val params_and_body :
   Code_id.t ->
   Function_params_and_body.t ->
   fun_dbg:Debuginfo.t ->
-  check:Lambda.check_attribute ->
+  check:Check_attribute.t ->
   translate_expr:
     (To_cmm_env.t ->
     To_cmm_result.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -84,14 +84,14 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
   in
   R.update_data r (or_variable aux default v), updates
 
-let add_function env r ~params_and_body code_id p ~fun_dbg =
-  let fundecl, r = params_and_body env r code_id p ~fun_dbg in
+let add_function env r ~params_and_body code_id p ~fun_dbg ~check =
+  let fundecl, r = params_and_body env r code_id p ~fun_dbg ~check in
   R.add_function r fundecl
 
 let add_functions env ~params_and_body r (code : Code.t) =
   add_function env r ~params_and_body (Code.code_id code)
     (Code.params_and_body code)
-    ~fun_dbg:(Code.dbg code)
+    ~fun_dbg:(Code.dbg code) ~check:(Code.check code)
 
 let preallocate_set_of_closures (r, updates, env) ~closure_symbols
     set_of_closures =

--- a/middle_end/flambda2/to_cmm/to_cmm_static.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.mli
@@ -25,7 +25,7 @@ val static_consts :
     Code_id.t ->
     Function_params_and_body.t ->
     fun_dbg:Debuginfo.t ->
-    check:Lambda.check_attribute ->
+    check:Check_attribute.t ->
     Cmm.fundecl * To_cmm_result.t) ->
   Bound_static.t ->
   Static_const_group.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_static.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.mli
@@ -25,6 +25,7 @@ val static_consts :
     Code_id.t ->
     Function_params_and_body.t ->
     fun_dbg:Debuginfo.t ->
+    check:Lambda.check_attribute ->
     Cmm.fundecl * To_cmm_result.t) ->
   Bound_static.t ->
   Static_const_group.t ->

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -85,7 +85,7 @@ and one_fun ppf f =
       )
   in
   fprintf ppf "(fun@ %s%s%a@ %d@ @[<2>%a@]@ @[<2>%a@])"
-    f.label (value_kind f.return) Printlambda.check_attribute f.attrib
+    f.label (value_kind f.return) Printlambda.check_attribute f.check
     (snd f.arity) idents f.params lam f.body
 
 and phantom_defining_expr ppf = function

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -84,8 +84,9 @@ and one_fun ppf f =
            Printlambda.value_kind k
       )
   in
-  fprintf ppf "(fun@ %s%s@ %d@ @[<2>%a@]@ @[<2>%a@])"
-    f.label (value_kind f.return) (snd f.arity) idents f.params lam f.body
+  fprintf ppf "(fun@ %s%s%a@ %d@ @[<2>%a@]@ @[<2>%a@])"
+    f.label (value_kind f.return) Printlambda.check_attribute f.attrib
+    (snd f.arity) idents f.params lam f.body
 
 and phantom_defining_expr ppf = function
   | Uphantom_const const -> uconstant ppf const

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -380,17 +380,6 @@ type check_attribute =
   | Assert of property
   | Assume of property
 
-let equal_property x y =
-  match x, y with
-  | Noalloc, Noalloc -> true
-
-let equal_check_attribute x y =
-  match x, y with
-  | Default_check, Default_check -> true
-  | Assert p1, Assert p2
-  | Assume p1, Assume p2 -> equal_property p1 p2
-  | (Default_check | Assert _ | Assume  _), _ -> false
-
 type function_kind = Curried of {nlocal: int} | Tupled
 
 type let_kind = Strict | Alias | StrictOpt

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -372,6 +372,24 @@ type local_attribute =
   | Never_local (* [@local never] *)
   | Default_local (* [@local maybe] or no [@local] attribute *)
 
+type property =
+  | Noalloc
+
+type check_attribute =
+  | Default_check
+  | Assert of property
+  | Assume of property
+
+let equal_property x y =
+  match x, y with
+  | Noalloc, Noalloc -> true
+
+let equal_check_attribute x y =
+  match x, y with
+  | Default_check, Default_check -> true
+  | Assert p1, Assert p2 -> equal_property p1 p2
+  | (Default_check | Assert _ | Assume  _), _ -> false
+
 type function_kind = Curried of {nlocal: int} | Tupled
 
 type let_kind = Strict | Alias | StrictOpt
@@ -391,6 +409,7 @@ type function_attribute = {
   inline : inline_attribute;
   specialise : specialise_attribute;
   local: local_attribute;
+  check : check_attribute;
   is_a_functor: bool;
   stub: bool;
 }
@@ -522,6 +541,7 @@ let default_function_attribute = {
   inline = Default_inline;
   specialise = Default_specialise;
   local = Default_local;
+  check = Default_check ;
   is_a_functor = false;
   stub = false;
 }

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -387,7 +387,8 @@ let equal_property x y =
 let equal_check_attribute x y =
   match x, y with
   | Default_check, Default_check -> true
-  | Assert p1, Assert p2 -> equal_property p1 p2
+  | Assert p1, Assert p2
+  | Assume p1, Assume p2 -> equal_property p1 p2
   | (Default_check | Assert _ | Assume  _), _ -> false
 
 type function_kind = Curried of {nlocal: int} | Tupled

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -293,8 +293,6 @@ type check_attribute =
   | Assert of property
   | Assume of property
 
-val equal_check_attribute : check_attribute -> check_attribute -> bool
-
 type function_kind = Curried of {nlocal: int} | Tupled
 (* [nlocal] determines how many arguments may be partially applied
    before the resulting closure must be locally allocated.

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -285,6 +285,16 @@ type local_attribute =
   | Never_local (* [@local never] *)
   | Default_local (* [@local maybe] or no [@local] attribute *)
 
+type property =
+  | Noalloc
+
+type check_attribute =
+  | Default_check
+  | Assert of property
+  | Assume of property
+
+val equal_check_attribute : check_attribute -> check_attribute -> bool
+
 type function_kind = Curried of {nlocal: int} | Tupled
 (* [nlocal] determines how many arguments may be partially applied
    before the resulting closure must be locally allocated.
@@ -311,6 +321,7 @@ type function_attribute = {
   inline : inline_attribute;
   specialise : specialise_attribute;
   local: local_attribute;
+  check : check_attribute;
   is_a_functor: bool;
   stub: bool;
 }

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -550,7 +550,16 @@ let name_of_primitive = function
   | Pprobe_is_enabled _ -> "Pprobe_is_enabled"
   | Pobj_dup -> "Pobj_dup"
 
-let function_attribute ppf { inline; specialise; local; is_a_functor; stub } =
+let check_attribute ppf check =
+  let check_property = function
+    | Noalloc -> "noalloc"
+  in
+  match check with
+  | Default_check -> ()
+  | Assert p -> fprintf ppf "assert %s@ " (check_property p)
+  | Assume p -> fprintf ppf "assume %s@ " (check_property p)
+
+let function_attribute ppf { inline; specialise; check; local; is_a_functor; stub } =
   if is_a_functor then
     fprintf ppf "is_a_functor@ ";
   if stub then
@@ -571,7 +580,8 @@ let function_attribute ppf { inline; specialise; local; is_a_functor; stub } =
   | Default_local -> ()
   | Always_local -> fprintf ppf "always_local@ "
   | Never_local -> fprintf ppf "never_local@ "
-  end
+  end;
+  check_attribute ppf check
 
 let apply_tailcall_attribute ppf = function
   | Default_tailcall -> ()

--- a/ocaml/lambda/printlambda.mli
+++ b/ocaml/lambda/printlambda.mli
@@ -34,3 +34,4 @@ val record_rep : formatter -> Types.record_representation -> unit
 val print_bigarray :
   string -> bool -> Lambda.bigarray_kind -> formatter ->
   Lambda.bigarray_layout -> unit
+val check_attribute : formatter -> check_attribute -> unit

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -817,6 +817,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
         { inline = Never_inline;
           specialise = Always_specialise;
           local = Never_local;
+          check = Default_check;
           is_a_functor = false;
           stub = false;
         } in

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -534,6 +534,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
       inline = inline_attribute;
       specialise = Default_specialise;
       local = Default_local;
+      check = Default_check;
       is_a_functor = true;
       stub = false;
     };

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -97,6 +97,7 @@
 
 (rule
  (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
  (targets test_attribute_error_duplicate.output.corrected)
  (deps test_attribute_error_duplicate.ml)
  (action    (with-outputs-to test_attribute_error_duplicate.output.corrected

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -23,13 +23,13 @@
 (rule
  (enabled_if (= %{context_name} "main"))
  (targets fail1.output.corrected)
- (deps fail1.ml)
+ (deps (:ml fail1.ml) filter.sh)
  (action
    (with-outputs-to fail1.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
-     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))
-    (bash "sed 's/Error: Annotation check for noalloc failed on function .*$/Error: Annotation check for noalloc failed on function HIDE_NAME/'")
+     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+    (run "./filter.sh")
    ))))
 
 (rule
@@ -41,13 +41,13 @@
 (rule
  (enabled_if (= %{context_name} "main"))
  (targets fail2.output.corrected)
- (deps fail2.ml)
+ (deps (:ml fail2.ml) filter.sh)
  (action
    (with-outputs-to fail2.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
-     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))
-    (bash "sed 's/Error: Annotation check for noalloc failed on function .*$/Error: Annotation check for noalloc failed on function HIDE_NAME/'")
+     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+    (run "./filter.sh")
    ))))
 
 (rule
@@ -59,13 +59,13 @@
 (rule
  (enabled_if (= %{context_name} "main"))
  (targets fail3.output.corrected)
- (deps t3.ml fail3.ml)
+ (deps (:ml t3.ml fail3.ml) filter.sh)
   (action
    (with-outputs-to fail3.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
-     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))
-    (bash "sed 's/Error: Annotation check for noalloc failed on function .*$/Error: Annotation check for noalloc failed on function HIDE_NAME/'")
+     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+    (run "./filter.sh")
    ))))
 
 (rule
@@ -78,13 +78,13 @@
 (rule
  (enabled_if (= %{context_name} "main"))
  (targets fail4.output.corrected)
- (deps t4.ml fail4.ml)
+ (deps (:ml t4.ml fail4.ml) filter.sh)
   (action
    (with-outputs-to fail4.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
-     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))
-    (bash "sed 's/Error: Annotation check for noalloc failed on function .*$/Error: Annotation check for noalloc failed on function HIDE_NAME/'")
+     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+    (run "./filter.sh")
    ))))
 
 (rule

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -1,18 +1,94 @@
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
- (targets t.o t.cmx s.o s.cmx output.corrected t.cmx.output)
  (deps s.ml t.ml)
- (action
-    (progn
-     (run %{bin:ocamlopt.opt} %{deps} -c -alloc-check -O3)
-     (with-stdout-to t.cmx.output (run %{bin:ocamlobjinfo} t.cmx))
+ (action (run %{bin:ocamlopt.opt} %{deps} -c -alloc-check -O3)))
 
-     ; CR gyorsh: count the lines in the relevant section of the output of ocamlobjinfo,
-     ; instead of printing the function symbols whose names may differ
-     ; depending on configuration.
-     ; This is still flaky and temporary, until @assert annotations can be checked.
-     (with-stdout-to output.corrected
-       (with-stdin-from t.cmx.output
-         (bash "sed -n '/Functions with neither allocations nor indirect calls:/,$p' | grep -v camlT__entry | wc -l | sed 's/^ *//g' ")))
-     (diff output output.corrected))))
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume.ml)
+ (action (run %{bin:ocamlopt.opt} %{deps} -c -alloc-check -O3)))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main")
+                   %{ocaml-config:flambda}
+                  ;; what we really want to say but dune doesn't know about flambda2:
+                  ;; (or %{ocaml-config:flambda} %{ocaml-config:flambda2})
+                  ))
+ (deps test_flambda.ml)
+ (action (run %{bin:ocamlopt.opt} %{deps} -c -alloc-check -O3)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail1.output.corrected)
+ (deps fail1.ml)
+ (action
+   (with-outputs-to fail1.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))
+    (bash "sed 's/Error: Annotation check for noalloc failed on function .*$/Error: Annotation check for noalloc failed on function HIDE_NAME/'")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail1.output fail1.output.corrected)
+ (action (diff fail1.output fail1.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail2.output.corrected)
+ (deps fail2.ml)
+ (action
+   (with-outputs-to fail2.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))
+    (bash "sed 's/Error: Annotation check for noalloc failed on function .*$/Error: Annotation check for noalloc failed on function HIDE_NAME/'")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail2.output fail2.output.corrected)
+ (action (diff fail2.output fail2.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail3.output.corrected)
+ (deps t3.ml fail3.ml)
+  (action
+   (with-outputs-to fail3.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))
+    (bash "sed 's/Error: Annotation check for noalloc failed on function .*$/Error: Annotation check for noalloc failed on function HIDE_NAME/'")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail3.output fail3.output.corrected)
+ (action (diff fail3.output fail3.output.corrected)))
+
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail4.output.corrected)
+ (deps t4.ml fail4.ml)
+  (action
+   (with-outputs-to fail4.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))
+    (bash "sed 's/Error: Annotation check for noalloc failed on function .*$/Error: Annotation check for noalloc failed on function HIDE_NAME/'")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail4.output fail4.output.corrected)
+ (action (diff fail4.output fail4.output.corrected)))

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -92,3 +92,21 @@
  (enabled_if (= %{context_name} "main"))
  (deps fail4.output fail4.output.corrected)
  (action (diff fail4.output fail4.output.corrected)))
+
+;; test for expected compilation errors
+
+(rule
+ (alias   runtest)
+ (targets test_attribute_error_duplicate.output.corrected)
+ (deps test_attribute_error_duplicate.ml)
+ (action    (with-outputs-to test_attribute_error_duplicate.output.corrected
+            (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_attribute_error_duplicate.output
+       test_attribute_error_duplicate.output.corrected)
+ (action
+        (diff test_attribute_error_duplicate.output
+              test_attribute_error_duplicate.output.corrected)))

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -7,7 +7,7 @@
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
- (deps test_assume.ml)
+ (deps t5.ml test_assume.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -c -alloc-check -O3)))
 
 (rule

--- a/tests/backend/checkmach/fail1.ml
+++ b/tests/backend/checkmach/fail1.ml
@@ -1,3 +1,3 @@
 let[@inline never] test14 n = Float.of_int n
 
-let[@assert noalloc] test15 n = Int64.to_int (Int64.of_float (test14 n))
+let[@noalloc] test15 n = Int64.to_int (Int64.of_float (test14 n))

--- a/tests/backend/checkmach/fail1.ml
+++ b/tests/backend/checkmach/fail1.ml
@@ -1,0 +1,3 @@
+let[@inline never] test14 n = Float.of_int n
+
+let[@assert noalloc] test15 n = Int64.to_int (Int64.of_float (test14 n))

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
 File "fail1.ml", line 1:
-Error: Annotation check for noalloc failed on function HIDE_NAME
+Error: Annotation check for noalloc failed on function camlFail1__test15_HIDE_NAME

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
 File "fail1.ml", line 1:
-Error: Annotation check for noalloc failed on function camlFail1__test15_HIDE_NAME
+Error: Annotation check for noalloc failed on function camlFail1__test15_HIDE_STAMP

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,0 +1,2 @@
+File "fail1.ml", line 1:
+Error: Annotation check for noalloc failed on function HIDE_NAME

--- a/tests/backend/checkmach/fail2.ml
+++ b/tests/backend/checkmach/fail2.ml
@@ -1,0 +1,1 @@
+let[@assert noalloc] test x = (x,x)

--- a/tests/backend/checkmach/fail2.ml
+++ b/tests/backend/checkmach/fail2.ml
@@ -1,1 +1,1 @@
-let[@assert noalloc] test x = (x,x)
+let[@noalloc] test x = (x,x)

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
 File "fail2.ml", line 1:
-Error: Annotation check for noalloc failed on function camlFail2__test_HIDE_NAME
+Error: Annotation check for noalloc failed on function camlFail2__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
 File "fail2.ml", line 1:
-Error: Annotation check for noalloc failed on function HIDE_NAME
+Error: Annotation check for noalloc failed on function camlFail2__test_HIDE_NAME

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,0 +1,2 @@
+File "fail2.ml", line 1:
+Error: Annotation check for noalloc failed on function HIDE_NAME

--- a/tests/backend/checkmach/fail3.ml
+++ b/tests/backend/checkmach/fail3.ml
@@ -1,0 +1,2 @@
+(* Always inlined from a different file *)
+let[@assert noalloc] test n = T3.test4 n

--- a/tests/backend/checkmach/fail3.ml
+++ b/tests/backend/checkmach/fail3.ml
@@ -1,2 +1,2 @@
 (* Always inlined from a different file *)
-let[@assert noalloc] test n = T3.test4 n
+let[@noalloc] test n = T3.test4 n

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
 File "fail3.ml", line 1:
-Error: Annotation check for noalloc failed on function camlFail3__test_HIDE_NAME
+Error: Annotation check for noalloc failed on function camlFail3__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,0 +1,2 @@
+File "fail3.ml", line 1:
+Error: Annotation check for noalloc failed on function HIDE_NAME

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
 File "fail3.ml", line 1:
-Error: Annotation check for noalloc failed on function HIDE_NAME
+Error: Annotation check for noalloc failed on function camlFail3__test_HIDE_NAME

--- a/tests/backend/checkmach/fail4.ml
+++ b/tests/backend/checkmach/fail4.ml
@@ -1,2 +1,2 @@
 (* T.test1 is never inlined and allocates. *)
-let[@assert noalloc] test n = T4.test1 n
+let[@noalloc] test n = T4.test1 n

--- a/tests/backend/checkmach/fail4.ml
+++ b/tests/backend/checkmach/fail4.ml
@@ -1,0 +1,2 @@
+(* T.test1 is never inlined and allocates. *)
+let[@assert noalloc] test n = T4.test1 n

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
 File "fail4.ml", line 1:
-Error: Annotation check for noalloc failed on function HIDE_NAME
+Error: Annotation check for noalloc failed on function camlFail4__test_HIDE_NAME

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
 File "fail4.ml", line 1:
-Error: Annotation check for noalloc failed on function camlFail4__test_HIDE_NAME
+Error: Annotation check for noalloc failed on function camlFail4__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,0 +1,2 @@
+File "fail4.ml", line 1:
+Error: Annotation check for noalloc failed on function HIDE_NAME

--- a/tests/backend/checkmach/filter.sh
+++ b/tests/backend/checkmach/filter.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -r 's/Error: Annotation check for noalloc failed on function caml(.*)_[0-9]+(_[0-9]+_code)?$/Error: Annotation check for noalloc failed on function caml\1_HIDE_NAME/'

--- a/tests/backend/checkmach/filter.sh
+++ b/tests/backend/checkmach/filter.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -r 's/Error: Annotation check for noalloc failed on function caml(.*)_[0-9]+(_[0-9]+_code)?$/Error: Annotation check for noalloc failed on function caml\1_HIDE_NAME/'
+sed -r 's/Error: Annotation check for noalloc failed on function caml(.*)_[0-9]+(_[0-9]+_code)?$/Error: Annotation check for noalloc failed on function caml\1_HIDE_STAMP/'

--- a/tests/backend/checkmach/s.ml
+++ b/tests/backend/checkmach/s.ml
@@ -1,2 +1,2 @@
-let[@assert noalloc][@inline never] foo n m = n + m
+let[@noalloc][@inline never] foo n m = n + m
 let[@inline never] bar n m = (n, m)

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -13,12 +13,6 @@ let[@inline never] test2 n  = List.length(test1 n)
 
 let[@assert noalloc][@inline never] test3 l  = List.length l
 
-let[@assert noalloc][@inline always] test4 n = (n+1,n)
-
-let[@assert noalloc][@inline never] test5 n =
-  let first,_ = (test4 (n + 1)) in
-  first
-
 let[@assert noalloc][@inline never] test6 n = n + 37
 
 let[@assert noalloc][@inline never] test7 n m = (test6 n) * (test6 m)
@@ -61,7 +55,7 @@ let[@inline never] test13 n =
   print_int n;
   print_newline ()
 
-let[@inline never] test14 n = Float.of_int n
+let test14 n = Float.of_int n
 
 let[@assert noalloc][@inline never] test15 n = Int64.to_int (Int64.of_float (test14 n))
 
@@ -74,9 +68,9 @@ type boo =
   | A
   | B of int
 
-(* CR gyorsh: analysysi for noalloc_exn is not yet implemented.
+(* CR gyorsh: analysis for noalloc_exn is not yet implemented.
    It ignores allocations post-dominated by a raise. *)
-let[@assert noalloc_exn][@inline never] test18 n boo =
+let(* [@assert noalloc_exn] *)[@inline never] test18 n boo =
   if n > 0 then n + n
   else begin
     let k = 45 in
@@ -96,7 +90,7 @@ let[@inline never] test19 n =
   in
   create n
 
-let[@assert noalloc_exn] rec foo n =
+let(* [@assert noalloc_exn] *) rec foo n =
   bar (n-1)
-and[@assert noalloc_exn] bar n =
+and(* [@assert noalloc_exn] *) bar n =
   foo (n-1)

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -11,11 +11,11 @@ let[@inline never] test1 n =
 
 let[@inline never] test2 n  = List.length(test1 n)
 
-let[@assert noalloc][@inline never] test3 l  = List.length l
+let[@noalloc][@inline never] test3 l  = List.length l
 
-let[@assert noalloc][@inline never] test6 n = n + 37
+let[@noalloc][@inline never] test6 n = n + 37
 
-let[@assert noalloc][@inline never] test7 n m = (test6 n) * (test6 m)
+let[@noalloc][@inline never] test7 n m = (test6 n) * (test6 m)
 
 exception Exn_string of string
 exception Exn_int of int
@@ -33,16 +33,16 @@ let[@inline never] test9 n =
   try test8 n
   with _ -> 0
 
-let[@assert noalloc][@inline never] test10 n =
+let[@noalloc][@inline never] test10 n =
   match n with
   | 1 -> raise_notrace Exn
   | _ -> 10
 
-let[@assert noalloc][@inline never] test11 n =
+let[@noalloc][@inline never] test11 n =
   try test10 n
   with Exn -> 10
 
-let[@assert noalloc][@inline never] test12 n =
+let[@noalloc][@inline never] test12 n =
   let test n =
     match n with
     | 1 -> raise Exn
@@ -57,10 +57,10 @@ let[@inline never] test13 n =
 
 let test14 n = Float.of_int n
 
-let[@assert noalloc][@inline never] test15 n = Int64.to_int (Int64.of_float (test14 n))
+let[@noalloc][@inline never] test15 n = Int64.to_int (Int64.of_float (test14 n))
 
-let[@assert noalloc] test16 n m = S.foo n m
-let[@assert noalloc] test17 n m = S.foo (S.foo n n) m
+let[@noalloc] test16 n m = S.foo n m
+let[@noalloc] test17 n m = S.foo (S.foo n n) m
 let test18 n m = S.foo n m
 
 exception Exn3 of (int * int)
@@ -70,7 +70,7 @@ type boo =
 
 (* CR gyorsh: analysis for noalloc_exn is not yet implemented.
    It ignores allocations post-dominated by a raise. *)
-let(* [@assert noalloc_exn] *)[@inline never] test18 n boo =
+let(* [@noalloc_exn] *)[@inline never] test18 n boo =
   if n > 0 then n + n
   else begin
     let k = 45 in
@@ -90,7 +90,7 @@ let[@inline never] test19 n =
   in
   create n
 
-let(* [@assert noalloc_exn] *) rec foo n =
+let(* [@noalloc_exn] *) rec foo n =
   bar (n-1)
-and(* [@assert noalloc_exn] *) bar n =
+and(* [@noalloc_exn] *) bar n =
   foo (n-1)

--- a/tests/backend/checkmach/t3.ml
+++ b/tests/backend/checkmach/t3.ml
@@ -1,0 +1,1 @@
+let[@inline always] test4 n = (n, n+1)

--- a/tests/backend/checkmach/t4.ml
+++ b/tests/backend/checkmach/t4.ml
@@ -1,0 +1,8 @@
+let[@inline never] test1 n =
+  let rec create n =
+    if n = 0 then []
+    else
+      (n :: create (n -1))
+  in
+  create n
+

--- a/tests/backend/checkmach/t5.ml
+++ b/tests/backend/checkmach/t5.ml
@@ -1,1 +1,3 @@
 let[@noalloc assume][@inline never] test x = [x;x+1]
+(* The test below to make sure "noalloc" on external is still handled correctly. *)
+external external_test : unit -> unit = "test" [@@noalloc]

--- a/tests/backend/checkmach/t5.ml
+++ b/tests/backend/checkmach/t5.ml
@@ -1,1 +1,1 @@
-let[@assume noalloc] test x = [x;x+1]
+let[@assume noalloc][@inline never] test x = [x;x+1]

--- a/tests/backend/checkmach/t5.ml
+++ b/tests/backend/checkmach/t5.ml
@@ -1,0 +1,1 @@
+let[@assume noalloc] test x = [x;x+1]

--- a/tests/backend/checkmach/t5.ml
+++ b/tests/backend/checkmach/t5.ml
@@ -1,1 +1,1 @@
-let[@assume noalloc][@inline never] test x = [x;x+1]
+let[@noalloc assume][@inline never] test x = [x;x+1]

--- a/tests/backend/checkmach/test_assume.ml
+++ b/tests/backend/checkmach/test_assume.ml
@@ -1,0 +1,2 @@
+let[@assume noalloc][@inline never] test1 n = (n,n)
+let[@assert noalloc] test2 n = test1 (n+1)

--- a/tests/backend/checkmach/test_assume.ml
+++ b/tests/backend/checkmach/test_assume.ml
@@ -1,3 +1,3 @@
-let[@assume noalloc][@inline never] test1 n = (n,n)
-let[@assert noalloc] test2 n = test1 (n+1)
-let[@assert noalloc] test3 n = T5.test n
+let[@noalloc assume][@inline never] test1 n = (n,n)
+let[@noalloc] test2 n = test1 (n+1)
+let[@noalloc] test3 n = T5.test n

--- a/tests/backend/checkmach/test_assume.ml
+++ b/tests/backend/checkmach/test_assume.ml
@@ -1,2 +1,3 @@
 let[@assume noalloc][@inline never] test1 n = (n,n)
 let[@assert noalloc] test2 n = test1 (n+1)
+let[@assert noalloc] test3 n = T5.test n

--- a/tests/backend/checkmach/test_attribute_error_duplicate.ml
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.ml
@@ -1,0 +1,3 @@
+let[@noalloc][@noalloc] test1 x = x,x
+let[@noalloc assume][@noalloc] test2 x = x,x
+let[@noalloc check] test3 x = x,x

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -1,0 +1,7 @@
+File "test_attribute_error_duplicate.ml", line 1, characters 15-22:
+Warning 54 [duplicated-attribute]: the "noalloc" attribute is used more than once on this expression
+File "test_attribute_error_duplicate.ml", line 2, characters 22-29:
+Warning 54 [duplicated-attribute]: the "noalloc" attribute is used more than once on this expression
+File "test_attribute_error_duplicate.ml", line 3, characters 5-12:
+Warning 47 [attribute-payload]: illegal payload for attribute 'noalloc'.
+It must be either 'assume' or empty

--- a/tests/backend/checkmach/test_flambda.ml
+++ b/tests/backend/checkmach/test_flambda.ml
@@ -1,0 +1,7 @@
+(* These checks fail with closure but pass with flambda and flambda2, so we have a
+   separate file for them. *)
+let[@inline always] test4 n = (n+1,n)
+
+let[@assert noalloc][@inline never] test5 n =
+  let first,_ = (test4 (n + 1)) in
+  first

--- a/tests/backend/checkmach/test_flambda.ml
+++ b/tests/backend/checkmach/test_flambda.ml
@@ -2,6 +2,6 @@
    separate file for them. *)
 let[@inline always] test4 n = (n+1,n)
 
-let[@assert noalloc][@inline never] test5 n =
+let[@noalloc][@inline never] test5 n =
   let first,_ = (test4 (n + 1)) in
   first


### PR DESCRIPTION
Follow-up on #778, this PR adds attributes `[@assert noalloc]` and `[@assume noalloc]`. This was a part of #707.

I think I managed to propagate the new attributes through flambda2: the tests pass and manual inspection of -dcmm of little examples confirms the presence of the annotations. However, I was just following the type errors, and the diff might be too big or missing something. There is a separate commit for it to help review.

Tests updated to use the attributes (instead of some silly counting), so should be more stable. 
