### PR TITLE
Static check for noalloc: better user error

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -50,7 +50,7 @@ end
 module Func_info = struct
   type t =
     { name : string;  (** function name *)
-      mutable dbg : Debuginfo.t option;
+      mutable loc : Location.t option;
           (** Source location for error messages. *)
       mutable value : Value.t;  (** the result of the check *)
       mutable callers : string list;
@@ -62,7 +62,7 @@ module Func_info = struct
 
   let create name value =
     { name;
-      dbg = None;
+      loc = None;
       value;
       callers = [];
       in_current_unit = false;
@@ -150,8 +150,8 @@ end = struct
         | Some func_info -> func_info
       in
       func_info.in_current_unit <- true;
-      match func_info.dbg with
-      | None -> func_info.dbg <- Some dbg
+      match func_info.loc with
+      | None -> func_info.loc <- Some (Debuginfo.to_location dbg)
       | Some _ -> Misc.fatal_errorf "Duplicate symbol name %s" name
 
     let record t name value =
@@ -240,7 +240,7 @@ end = struct
                 then
                   raise
                     (Error
-                       ( Debuginfo.to_location (Option.get func_info.dbg),
+                       ( Option.get func_info.loc,
                          Annotation
                            { fun_name = func_info.name; check = S.name } )))
           t

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -33,7 +33,7 @@ type error =
         check : string
       }
 
-exception Error of error
+exception Error of Location.t * error
 
 module Value = struct
   type t =
@@ -50,6 +50,8 @@ end
 module Func_info = struct
   type t =
     { name : string;  (** function name *)
+      mutable dbg : Debuginfo.t option;
+          (** Source location for error messages. *)
       mutable value : Value.t;  (** the result of the check *)
       mutable callers : string list;
           (** unresolved dependencies. if not empty then value is Unknown. *)
@@ -59,7 +61,13 @@ module Func_info = struct
     }
 
   let create name value =
-    { name; value; callers = []; in_current_unit = false; annotated = false }
+    { name;
+      dbg = None;
+      value;
+      callers = [];
+      in_current_unit = false;
+      annotated = false
+    }
 end
 
 module type Spec = sig
@@ -115,7 +123,7 @@ end = struct
 
     val add_dep : t -> callee:string -> caller:string -> unit
 
-    val in_current_unit : t -> string -> unit
+    val in_current_unit : t -> string -> Debuginfo.t -> unit
 
     val annotated : t -> string -> unit
   end = struct
@@ -132,7 +140,7 @@ end = struct
       | Some (func_info : Func_info.t) -> (
         match func_info.value with Fail -> true | Pass | Unknown -> false)
 
-    let in_current_unit t name =
+    let in_current_unit t name dbg =
       let func_info : Func_info.t =
         match Hashtbl.find_opt t name with
         | None ->
@@ -141,7 +149,10 @@ end = struct
           func_info
         | Some func_info -> func_info
       in
-      func_info.in_current_unit <- true
+      func_info.in_current_unit <- true;
+      match func_info.dbg with
+      | None -> func_info.dbg <- Some dbg
+      | Some _ -> Misc.fatal_errorf "Duplicate symbol name %s" name
 
     let record t name value =
       match Hashtbl.find_opt t name with
@@ -229,7 +240,9 @@ end = struct
                 then
                   raise
                     (Error
-                       (Annotation { fun_name = func_info.name; check = S.name })))
+                       ( Debuginfo.to_location (Option.get func_info.dbg),
+                         Annotation
+                           { fun_name = func_info.name; check = S.name } )))
           t
 
     let add_dep t ~callee ~caller =
@@ -390,7 +403,7 @@ end = struct
       Profile.record_call ~accumulate:true ("check " ^ S.name) (fun () ->
           let fun_name = f.fun_name in
           let t = { ppf; fun_name; unresolved_dependencies = false } in
-          Unit_info.in_current_unit unit_info fun_name;
+          Unit_info.in_current_unit unit_info fun_name f.fun_dbg;
           if List.mem (Cmm.Assume S.annotation) f.fun_codegen_options
           then (
             report t ~msg:"assumed" ~desc:"fundecl" f.fun_dbg;
@@ -458,5 +471,5 @@ let report_error ppf = function
 
 let () =
   Location.register_error_of_exn (function
-    | Error err -> Some (Location.error_of_printer_file report_error err)
+    | Error (loc, err) -> Some (Location.error_of_printer ~loc report_error err)
     | _ -> None)

--- a/backend/checkmach.mli
+++ b/backend/checkmach.mli
@@ -43,6 +43,6 @@ type error =
         check : string
       }
 
-exception Error of error
+exception Error of Location.t * error
 
 val report_error : Format.formatter -> error -> unit

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
-File "fail1.ml", line 1:
+File "fail1.ml", line 3, characters 21-65:
 Error: Annotation check for noalloc failed on function camlFail1__test15_HIDE_STAMP

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
-File "fail2.ml", line 1:
+File "fail2.ml", line 1, characters 19-28:
 Error: Annotation check for noalloc failed on function camlFail2__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
-File "fail3.ml", line 1:
+File "fail3.ml", line 2, characters 19-33:
 Error: Annotation check for noalloc failed on function camlFail3__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
-File "fail4.ml", line 1:
+File "fail4.ml", line 2, characters 19-33:
 Error: Annotation check for noalloc failed on function camlFail4__test_HIDE_STAMP


### PR DESCRIPTION
On top of #825 - only the last two commits are new.

Print the source location of the function in the user error message when the `[@assert noalloc]` annotation on the function fails with -alloc-check flag. 

The message is still not great: the debug info points to the function (not the annotation) because that's what we have in the backend. Perhaps we can carry around the location (or Debuginfo.t) along with the attribute, as part of Lambda.check_attribute, but it's not done for anything else of this sort, and seems not worth it (code complexity and memory footprint). 

As it is, the check will already hold on to all the `fun_dbg` of the entire compilation unit until the end. If this becomes a problem, we can try checking annotations earlier, instead of waiting until the end of the compilation unit, but somethings cannot be resolved until the end.