### PR TITLE
IRC & stack operand: bug is registers are spilled during different iterations

### DIFF
--- a/backend/amd64/cfg_stack_operands.ml
+++ b/backend/amd64/cfg_stack_operands.ml
@@ -92,7 +92,10 @@ let binary_operation
       | Result_cannot_be_on_stack ->
         assert (not (is_stack_operand instr.res.(0)));
         false
-      | Result_can_be_on_stack -> is_stack_operand instr.res.(0))
+      | Result_can_be_on_stack ->
+        (* note: actually unreachable since instr.res.(0) and
+           instr.arg.(0) are the same. *)
+        is_stack_operand instr.res.(0))
   in
   if already_has_memory_operand then
     May_still_have_spilled_registers

--- a/backend/amd64/cfg_stack_operands.ml
+++ b/backend/amd64/cfg_stack_operands.ml
@@ -96,55 +96,55 @@ let binary_operation
   in
   if already_has_memory_operand then
     May_still_have_spilled_registers
-  else
-  begin match is_spilled instr.arg.(0), is_spilled instr.arg.(1) with
-  | false, false ->
-    begin match result with
-    | No_result | Result_can_be_on_stack ->
-      All_spilled_registers_rewritten
-    | Result_cannot_be_on_stack ->
-      May_still_have_spilled_registers
-    end
-  | false, true ->
-    use_stack_operand map instr.arg 1;
-    begin match result with
-    | No_result ->
-      All_spilled_registers_rewritten
-    | Result_can_be_on_stack | Result_cannot_be_on_stack ->
-      May_still_have_spilled_registers
-    end
-  | true, false ->
-    (* note: slightly different from the case above, because arg.(0) and res.(0) are the same. *)
-    begin match result with
-    | No_result ->
-      use_stack_operand map instr.arg 0;
-      All_spilled_registers_rewritten
-    | Result_can_be_on_stack ->
-      use_stack_operand map instr.res 0;
-      use_stack_operand map instr.arg 0;
-      All_spilled_registers_rewritten
-    | Result_cannot_be_on_stack ->
-      use_stack_operand map instr.arg 0;
-      May_still_have_spilled_registers
-    end;
-  | true, true ->
-    if Reg.same instr.arg.(0) instr.arg.(1) then
-      May_still_have_spilled_registers
-    else begin
-      match result with
+  else begin
+    match is_spilled instr.arg.(0), is_spilled instr.arg.(1) with
+    | false, false ->
+      begin match result with
+      | No_result | Result_can_be_on_stack ->
+        All_spilled_registers_rewritten
+      | Result_cannot_be_on_stack ->
+        May_still_have_spilled_registers
+      end
+    | false, true ->
+      use_stack_operand map instr.arg 1;
+      begin match result with
       | No_result ->
-        (* CR xclerc for xclerc: try and find for a criterion to choose between
-           the two. *)
-        use_stack_operand map instr.arg 0;
+        All_spilled_registers_rewritten
+      | Result_can_be_on_stack | Result_cannot_be_on_stack ->
         May_still_have_spilled_registers
+      end
+    | true, false ->
+      (* note: slightly different from the case above, because arg.(0) and res.(0) are the same. *)
+      begin match result with
+      | No_result ->
+        use_stack_operand map instr.arg 0;
+        All_spilled_registers_rewritten
       | Result_can_be_on_stack ->
-        use_stack_operand map instr.arg 0;
         use_stack_operand map instr.res 0;
-        May_still_have_spilled_registers
+        use_stack_operand map instr.arg 0;
+        All_spilled_registers_rewritten
       | Result_cannot_be_on_stack ->
         use_stack_operand map instr.arg 0;
         May_still_have_spilled_registers
-    end
+      end;
+    | true, true ->
+      if Reg.same instr.arg.(0) instr.arg.(1) then
+        May_still_have_spilled_registers
+      else begin
+        match result with
+        | No_result ->
+          (* CR xclerc for xclerc: try and find for a criterion to choose between
+             the two. *)
+          use_stack_operand map instr.arg 0;
+          May_still_have_spilled_registers
+        | Result_can_be_on_stack ->
+          use_stack_operand map instr.arg 0;
+          use_stack_operand map instr.res 0;
+          May_still_have_spilled_registers
+        | Result_cannot_be_on_stack ->
+          use_stack_operand map instr.arg 0;
+          May_still_have_spilled_registers
+      end
   end
 
 let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =


### PR DESCRIPTION
This pull request fixes a bug in #771, which is
_guaranteed_ to be correct only if all the
registers of a given instruction are spilled during
the same iteration of IRC.

Indeed, in #771 we are only checking whether
the registers of an instruction are being spilled
to decide whether or not to use a stack operand.
This is fine if all registers are spilled during the
same iteration, as we will decide which value to
get from the stack. But if the registers are spilled
in two different iterations, we may decide to use
a stack operand the second time even though
(by having already done that the first time) we
would now have an instruction with two stack
operands.