### PR TITLE
Fix miscompilation in comballoc for local allocations

### DIFF
--- a/backend/comballoc.ml
+++ b/backend/comballoc.ml
@@ -75,6 +75,15 @@ let rec combine i allocstate =
       let newnext = combine_restart i.next in
       (instr_cons_debug i.desc i.arg i.res i.dbg newnext,
        allocstate)
+  | Iop(Ibeginregion|Iendregion) -> begin
+      match allocstate with
+      | Pending_alloc { mode = Alloc_local; _ } ->
+          let newnext = combine_restart i.next in
+          (instr_cons_debug i.desc i.arg i.res i.dbg newnext, allocstate)
+      | No_alloc | Pending_alloc { mode = Alloc_heap; _ } ->
+          let newnext, s' = combine i.next allocstate in
+          (instr_cons_debug i.desc i.arg i.res i.dbg newnext, s')
+    end
   | Iop _ ->
       let (newnext, s') = combine i.next allocstate in
       (instr_cons_debug i.desc i.arg i.res i.dbg newnext, s')


### PR DESCRIPTION
Comballoc was happily moving local allocations across the beginning and end of regions. It should definitely not do that. @stedolan is going to add a test case later.