### PR TITLE
Follow-up PR#829 (comballoc fixes for locals)

### DIFF
--- a/backend/comballoc.ml
+++ b/backend/comballoc.ml
@@ -12,6 +12,7 @@
 (*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 (* Combine heap allocations occurring in the same basic block *)
 
@@ -84,7 +85,16 @@ let rec combine i allocstate =
           let newnext, s' = combine i.next allocstate in
           (instr_cons_debug i.desc i.arg i.res i.dbg newnext, s')
     end
-  | Iop _ ->
+  | Iop((Imove|Ispill|Ireload|Inegf|Iabsf|Iaddf|Isubf|Imulf|Idivf|Ifloatofint|
+         Iintoffloat|Iopaque|Iconst_int _|Iconst_float _|
+         Iconst_symbol _|Istackoffset _|Iload (_, _, _)|Istore (_, _, _)|Icompf _|
+         Ispecific _|Iname_for_debugger _|Iprobe_is_enabled _))
+  | Iop(Iintop(Iadd | Isub | Imul | Idiv | Imod | Iand | Ior | Ixor
+              | Ilsl | Ilsr | Iasr | Ipopcnt | Imulh _
+              | Iclz _ | Ictz _ | Icomp _))
+  | Iop(Iintop_imm((Iadd | Isub | Imul | Idiv | Imod | Iand | Ior | Ixor
+                   | Ilsl | Ilsr | Iasr | Ipopcnt | Imulh _
+                   | Iclz _ | Ictz _ | Icomp _),_))  ->
       let (newnext, s') = combine i.next allocstate in
       (instr_cons_debug i.desc i.arg i.res i.dbg newnext, s')
   | Iifthenelse(test, ifso, ifnot) ->

--- a/ocaml/asmcomp/comballoc.ml
+++ b/ocaml/asmcomp/comballoc.ml
@@ -75,6 +75,15 @@ let rec combine i allocstate =
       let newnext = combine_restart i.next in
       (instr_cons_debug i.desc i.arg i.res i.dbg newnext,
        allocstate)
+  | Iop(Ibeginregion|Iendregion) -> begin
+      match allocstate with
+      | Pending_alloc { mode = Alloc_local; _ } ->
+        let newnext = combine_restart i.next in
+        (instr_cons_debug i.desc i.arg i.res i.dbg newnext, allocstate)
+      | No_alloc | Pending_alloc { mode = Alloc_heap; _ } ->
+        let newnext, s' = combine i.next allocstate in
+        (instr_cons_debug i.desc i.arg i.res i.dbg newnext, s')
+    end
   | Iop _ ->
       let (newnext, s') = combine i.next allocstate in
       (instr_cons_debug i.desc i.arg i.res i.dbg newnext, s')


### PR DESCRIPTION
- Apply the fix from #829 to `asmcomp` directory
- Turn warnings on in comballoc and make the match exhaustive

I will make a separate PR to turn warnings on in more files
in the backend. Also, I'm ignoring the formatting here, as we plan to
reformat everything in the backend subdirectory after #799 is merged.
