### PR TITLE
Add `-dtimings-precision` flag

### DIFF
--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -161,5 +161,5 @@ let main unix argv ppf ~flambda2 =
     Location.report_exception ppf x;
     2
   | () ->
-    Profile.print Format.std_formatter !Clflags.profile_columns;
+    Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
     0

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -466,6 +466,9 @@ let read_one_param ppf position name v =
      let if_on = if name = "timings" then [ `Time ] else Profile.all_columns in
      profile_columns := if check_bool ppf name v then if_on else []
 
+  | "timings-precision" ->
+     int_setter ppf "timings-precision" timings_precision v
+
   | "stop-after" ->
     set_compiler_pass ppf v ~name Clflags.stop_after ~filter:(fun _ -> true)
 

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -553,6 +553,12 @@ let mk_dtimings f =
   "-dtimings", Arg.Unit f, " Print timings information for each pass";
 ;;
 
+let mk_dtimings_precision f =
+  "-dtimings-precision", Arg.Int f, 
+    Printf.sprintf "<n>  Specify precision for timings information (default %d)"
+      Clflags.default_timings_precision
+;;
+
 let mk_dprofile f =
   "-dprofile", Arg.Unit f, Profile.options_doc
 ;;
@@ -1039,6 +1045,7 @@ module type Compiler_options = sig
 
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
+  val _dtimings_precision : int -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
 
@@ -1292,6 +1299,7 @@ struct
     mk_dinstr F._dinstr;
     mk_dcamlprimc F._dcamlprimc;
     mk_dtimings F._dtimings;
+    mk_dtimings_precision F._dtimings_precision;
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
 
@@ -1520,6 +1528,7 @@ struct
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
     mk_dtimings F._dtimings;
+    mk_dtimings_precision F._dtimings_precision;
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
     mk_dump_pass F._dump_pass;
@@ -1899,6 +1908,7 @@ module Default = struct
     let _config_var = Misc.show_config_variable_and_exit
     let _dprofile () = profile_columns := Profile.all_columns
     let _dtimings () = profile_columns := [`Time]
+    let _dtimings_precision n = timings_precision := n
     let _dump_into_file = set dump_into_file
     let _for_pack s = for_package := (Some s)
     let _g = set debug

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -120,6 +120,7 @@ module type Compiler_options = sig
 
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
+  val _dtimings_precision : int -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
 

--- a/ocaml/driver/maindriver.ml
+++ b/ocaml/driver/maindriver.ml
@@ -111,5 +111,5 @@ let main argv ppf =
     Location.report_exception ppf x;
     2
   | () ->
-    Profile.print Format.std_formatter !Clflags.profile_columns;
+    Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
     0

--- a/ocaml/driver/optmaindriver.ml
+++ b/ocaml/driver/optmaindriver.ml
@@ -136,5 +136,5 @@ let main argv ppf =
     Location.report_exception ppf x;
     2
   | () ->
-    Profile.print Format.std_formatter !Clflags.profile_columns;
+    Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
     0

--- a/ocaml/testsuite/tools/codegen_main.ml
+++ b/ocaml/testsuite/tools/codegen_main.ml
@@ -77,5 +77,5 @@ let main() =
 
 let () =
   main ();
-  Profile.print Format.std_formatter !Clflags.profile_columns;
+  Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
   exit 0

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -131,6 +131,8 @@ let dump_linear = ref false             (* -dlinear *)
 let dump_interval = ref false           (* -dinterval *)
 let keep_startup_file = ref false       (* -dstartup *)
 let dump_combine = ref false            (* -dcombine *)
+let default_timings_precision  = 3
+let timings_precision = ref default_timings_precision (* -dtimings-precision *)
 let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings *)
 
 let debug_runavail = ref false          (* -drunavail *)

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -176,6 +176,8 @@ val keep_docs : bool ref
 val keep_locs : bool ref
 val unsafe_string : bool ref
 val opaque : bool ref
+val default_timings_precision : int
+val timings_precision : int ref
 val profile_columns : Profile.column list ref
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -33,7 +33,7 @@ val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 
 type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
 
-val print : Format.formatter -> column list -> unit
+val print : Format.formatter -> column list -> timings_precision:int -> unit
 (** Prints the selected recorded profiling information to the formatter. *)
 
 (** Command line flags *)

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -77,5 +77,5 @@ let main() =
 
 let () =
   main ();
-  Profile.print Format.std_formatter !Clflags.profile_columns;
+  Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
   exit 0


### PR DESCRIPTION
When using `-dtimings` flag to benchmark the compiler the values we get are seconds, rounded to the third decimal place.

When adding that for thousands of files the rounding error quickly adds up and can produces strange atrifacts in the summary.

This PR adds a new flag `-dtimings-precision`. With that the precision of the output can be changed. The default is `3` same as before.