### PR TITLE
Regalloc utilities: do not rely on polymorphic max

### DIFF
--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -45,7 +45,8 @@ let first_instruction_id (block : Cfg.basic_block) : int =
   | [] -> block.terminator.id
   | first_instr :: _ -> first_instr.id
 
-let[@inline] int_max (left : int) (right : int) = Stdlib.max left right
+let[@inline] int_max (left : int) (right : int) =
+  if left >= right then left else right
 
 type cfg_infos =
   { arg : Reg.Set.t;


### PR DESCRIPTION
While reviewing another PR, I realized that
`Stdlib.max` was not being specialized. This
very short pull request thus manually specializes
the `int_max` function in `Cfg_regalloc_utils`.