### PR TITLE
Simplify_extcall: adapt C function names

### DIFF
--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -155,42 +155,42 @@ let simplify_returning_extcall ~dbg ~cont ~exn_cont:_ dacc fun_name args
     ~arg_types =
   match fun_name, args, arg_types with
   (* Polymorphic comparisons *)
-  | ".extern__caml_compare", [a; b], [a_ty; b_ty] ->
+  | "caml_compare", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
       ~float_prim:(Float_comp (Yielding_int_like_compare_functions ()))
       ~tagged_prim:
         (Int_comp (Tagged_immediate, Yielding_int_like_compare_functions Signed))
       ~boxed_int_prim:(fun kind ->
         Int_comp (kind, Yielding_int_like_compare_functions Signed))
-  | ".extern__caml_equal", [a; b], [a_ty; b_ty] ->
+  | "caml_equal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
       ~tagged_prim:(Phys_equal Eq) ~float_prim:(Float_comp (Yielding_bool Eq))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool Eq))
-  | ".extern__caml_notequal", [a; b], [a_ty; b_ty] ->
+  | "caml_notequal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
       ~tagged_prim:(Phys_equal Neq) ~float_prim:(Float_comp (Yielding_bool Neq))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool Neq))
-  | ".extern__caml_lessequal", [a; b], [a_ty; b_ty] ->
+  | "caml_lessequal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
       ~float_prim:(Float_comp (Yielding_bool (Le ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Le Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Le Signed)))
-  | ".extern__caml_lessthan", [a; b], [a_ty; b_ty] ->
+  | "caml_lessthan", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
       ~float_prim:(Float_comp (Yielding_bool (Lt ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Lt Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Lt Signed)))
-  | ".extern__caml_greaterequal", [a; b], [a_ty; b_ty] ->
+  | "caml_greaterequal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
       ~float_prim:(Float_comp (Yielding_bool (Ge ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Ge Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Ge Signed)))
-  | ".extern__caml_greaterthan", [a; b], [a_ty; b_ty] ->
+  | "caml_greaterthan", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
       ~float_prim:(Float_comp (Yielding_bool (Gt ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Gt Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Gt Signed)))
-  | ".extern__caml_make_vect", [_; _], [len_ty; init_value_ty] ->
+  | "caml_make_vect", [_; _], [len_ty; init_value_ty] ->
     simplify_caml_make_vect dacc ~len_ty ~init_value_ty
   | _ -> Unchanged { return_types = Unknown }
 


### PR DESCRIPTION
Follow-up to #683, which broke the simplification of C calls (e.g. specialisation of comparison primitives).