### PR TITLE
Improved colour API with nested colour regions

### DIFF
--- a/middle_end/flambda2/bound_identifiers/bound_parameter.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.ml
@@ -35,10 +35,10 @@ include Container_types.Make (struct
     Hashtbl.hash (Variable.hash param, Flambda_kind.With_subkind.hash kind)
 
   let [@ocamlformat "disable"] print ppf { param; kind; } =
-    Format.fprintf ppf "@[(@<0>%s%a@<0>%s @<1>\u{2237} %a)@]"
-      (Flambda_colours.parameter ())
+    Format.fprintf ppf "@[(%t%a%t @<1>\u{2237} %a)@]"
+      Flambda_colours.parameter
       Variable.print param
-      (Flambda_colours.normal ())
+      Flambda_colours.pop
       Flambda_kind.With_subkind.print kind
 end)
 

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -92,33 +92,23 @@ let get_global_info comp_unit =
 let print_rawflambda ppf unit =
   if Flambda_features.dump_rawflambda ()
   then
-    Format.fprintf ppf "\n%sAfter CPS conversion:%s@ %a@."
-      (Flambda_colours.each_file ())
-      (Flambda_colours.normal ())
-      Flambda_unit.print unit;
+    Format.fprintf ppf "\n%tAfter CPS conversion:%t@ %a@."
+      Flambda_colours.each_file Flambda_colours.pop Flambda_unit.print unit;
   if Flambda_features.dump_rawfexpr ()
   then
-    Format.fprintf ppf "\n%sAfter CPS conversion:%s@ %a@."
-      (Flambda_colours.each_file ())
-      (Flambda_colours.normal ())
-      Print_fexpr.flambda_unit
+    Format.fprintf ppf "\n%tAfter CPS conversion:%t@ %a@."
+      Flambda_colours.each_file Flambda_colours.pop Print_fexpr.flambda_unit
       (unit |> Flambda_to_fexpr.conv)
 
 let print_flambda name ppf unit =
   if Flambda_features.dump_flambda ()
   then
-    Format.fprintf ppf "\n%sAfter %s:%s@ %a@."
-      (Flambda_colours.each_file ())
-      name
-      (Flambda_colours.normal ())
-      Flambda_unit.print unit;
+    Format.fprintf ppf "\n%tAfter %s:%t@ %a@." Flambda_colours.each_file name
+      Flambda_colours.pop Flambda_unit.print unit;
   if Flambda_features.dump_fexpr ()
   then
-    Format.fprintf ppf "\n%sAfter %s:%s@ %a@."
-      (Flambda_colours.each_file ())
-      name
-      (Flambda_colours.normal ())
-      Print_fexpr.flambda_unit
+    Format.fprintf ppf "\n%tAfter %s:%t@ %a@." Flambda_colours.each_file name
+      Flambda_colours.pop Print_fexpr.flambda_unit
       (unit |> Flambda_to_fexpr.conv)
 
 let output_flexpect ~ml_filename ~raw_flambda:old_unit new_unit =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1163,13 +1163,12 @@ let close_one_function acc ~external_env ~by_function_slot decl
       let bt = Printexc.get_raw_backtrace () in
       Format.eprintf
         "\n\
-         %sContext is:%s closure converting function@ with [our_let_rec_ident] \
+         %tContext is:%t closure converting function@ with [our_let_rec_ident] \
          %a (function slot %a)"
         (* @ \ *)
         (* and body:@ %a *)
-        (Flambda_colours.error ())
-        (Flambda_colours.normal ())
-        Ident.print our_let_rec_ident Function_slot.print function_slot;
+        Flambda_colours.error Flambda_colours.pop Ident.print our_let_rec_ident
+        Function_slot.print function_slot;
       (* print body *)
       Printexc.raise_with_backtrace Misc.Fatal_error bt
   in

--- a/middle_end/flambda2/identifiers/coercion0.ml
+++ b/middle_end/flambda2/identifiers/coercion0.ml
@@ -88,17 +88,15 @@ module Make (Rec_info_expr : Rec_info_expr0.S) :
 
   let [@ocamlformat "disable"] print ppf = function
     | Id ->
-      Format.fprintf ppf "@<0>%sid@<0>%s"
-        (Flambda_colours.elide ())
-        (Flambda_colours.normal ())
+      Format.fprintf ppf "%tid%t"
+        Flambda_colours.elide
+        Flambda_colours.pop
     | Change_depth { from; to_; } ->
-      Format.fprintf ppf "@<0>%s@[<hov 1>(depth@ %a@<0>%s ->@ %a@<0>%s)@]@<0>%s"
-        (Flambda_colours.coercion ())
+      Format.fprintf ppf "%t@[<hov 1>(depth@ %a ->@ %a)@]%t"
+        Flambda_colours.coercion
         Rec_info_expr.print from
-        (Flambda_colours.coercion ())
         Rec_info_expr.print to_
-        (Flambda_colours.coercion ())
-        (Flambda_colours.normal ())
+        Flambda_colours.pop
 
   let equal t1 t2 =
     t1 == t2

--- a/middle_end/flambda2/identifiers/continuation.ml
+++ b/middle_end/flambda2/identifiers/continuation.ml
@@ -165,11 +165,11 @@ module T0 = struct
   let hash t = Hashtbl.hash t
 
   let print ppf t =
-    Format.fprintf ppf "@<0>%s" (Flambda_colours.continuation ());
+    Format.fprintf ppf "%t" Flambda_colours.continuation;
     if String.equal (name t) "k"
     then Format.fprintf ppf "k%d" (name_stamp t)
     else Format.fprintf ppf "%s/%d" (name t) (name_stamp t);
-    Format.fprintf ppf "@<0>%s" (Flambda_colours.normal ())
+    Format.fprintf ppf "%t" Flambda_colours.pop
 end
 
 include T0

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -57,35 +57,35 @@ module Const_data = struct
     let [@ocamlformat "disable"] print ppf (t : t) =
       match t with
       | Naked_immediate i ->
-        Format.fprintf ppf "@<0>%s#%a@<0>%s"
-          (Flambda_colours.naked_number ())
+        Format.fprintf ppf "%t#%a%t"
+          Flambda_colours.naked_number
           Targetint_31_63.print i
-          (Flambda_colours.normal ())
+          Flambda_colours.pop
       | Tagged_immediate i ->
-        Format.fprintf ppf "@<0>%s%a@<0>%s"
-          (Flambda_colours.tagged_immediate ())
+        Format.fprintf ppf "%t%a%t"
+          Flambda_colours.tagged_immediate
           Targetint_31_63.print i
-          (Flambda_colours.normal ())
+          Flambda_colours.pop
       | Naked_float f ->
-        Format.fprintf ppf "@<0>%s#%a@<0>%s"
-          (Flambda_colours.naked_number ())
+        Format.fprintf ppf "%t#%a%t"
+          Flambda_colours.naked_number
           Numeric_types.Float_by_bit_pattern.print f
-          (Flambda_colours.normal ())
+          Flambda_colours.pop
       | Naked_int32 n ->
-        Format.fprintf ppf "@<0>%s#%ldl@<0>%s"
-          (Flambda_colours.naked_number ())
+        Format.fprintf ppf "%t#%ldl%t"
+          Flambda_colours.naked_number
           n
-          (Flambda_colours.normal ())
+          Flambda_colours.pop
       | Naked_int64 n ->
-        Format.fprintf ppf "@<0>%s#%LdL@<0>%s"
-          (Flambda_colours.naked_number ())
+        Format.fprintf ppf "%t#%LdL%t"
+          Flambda_colours.naked_number
           n
-          (Flambda_colours.normal ())
+          Flambda_colours.pop
       | Naked_nativeint n ->
-        Format.fprintf ppf "@<0>%s#%an@<0>%s"
-          (Flambda_colours.naked_number ())
+        Format.fprintf ppf "%t#%an%t"
+          Flambda_colours.naked_number
           Targetint_32_64.print n
-          (Flambda_colours.normal ())
+          Flambda_colours.pop
 
     let compare t1 t2 =
       match t1, t2 with
@@ -489,11 +489,11 @@ module Symbol = struct
     let hash = Id.hash
 
     let print ppf t =
-      Format.fprintf ppf "@<0>%s" (Flambda_colours.symbol ());
+      Format.fprintf ppf "%t" Flambda_colours.symbol;
       Compilation_unit.print ppf (compilation_unit t);
       Format.pp_print_string ppf ".";
       Linkage_name.print ppf (linkage_name t);
-      Format.fprintf ppf "@<0>%s" (Flambda_colours.normal ())
+      Format.fprintf ppf "%t" Flambda_colours.pop
   end
 
   include T0
@@ -542,11 +542,11 @@ module Name = struct
     let hash = Id.hash
 
     let print ppf t =
-      Format.fprintf ppf "@<0>%s" (Flambda_colours.name ());
+      Format.fprintf ppf "%t" Flambda_colours.name;
       pattern_match t
         ~var:(fun var -> Variable.print ppf var)
         ~symbol:(fun symbol -> Symbol.print ppf symbol);
-      Format.fprintf ppf "@<0>%s" (Flambda_colours.normal ())
+      Format.fprintf ppf "%t" Flambda_colours.pop
   end
 
   include T0
@@ -779,10 +779,8 @@ module Code_id = struct
     let hash = Id.hash
 
     let print ppf t =
-      Format.fprintf ppf "@<0>%s%a@<0>%s"
-        (Flambda_colours.code_id ())
-        Linkage_name.print (linkage_name t)
-        (Flambda_colours.normal ())
+      Format.fprintf ppf "%t%a%t" Flambda_colours.code_id Linkage_name.print
+        (linkage_name t) Flambda_colours.pop
   end
 
   include T0

--- a/middle_end/flambda2/identifiers/rec_info_expr0.ml
+++ b/middle_end/flambda2/identifiers/rec_info_expr0.ml
@@ -152,23 +152,23 @@ struct
     | Const { depth; unrolling } ->
       begin match unrolling with
       | Not_unrolling ->
-        Format.fprintf ppf "@<0>%s%a@<0>%s"
-          (Flambda_colours.rec_info ())
+        Format.fprintf ppf "%t%a%t"
+          Flambda_colours.rec_info
           (Or_infinity.print ~f:Format.pp_print_int) depth
-          (Flambda_colours.normal ())
+          Flambda_colours.pop
       | Unrolling _ | Do_not_unroll ->
         Format.fprintf ppf
-          "@<0>%s@[<hov 1>(%a@ %a)@]@<0>%s"
-        (Flambda_colours.rec_info ())
+          "%t@[<hov 1>(%a@ %a)@]%t"
+        Flambda_colours.rec_info
         (Or_infinity.print ~f:Format.pp_print_int) depth
         Unrolling_state.print unrolling
-        (Flambda_colours.normal ())
+        Flambda_colours.pop
       end
     | Var dv ->
-      Format.fprintf ppf "@<0>%s%a@<0>%s"
-        (Flambda_colours.depth_variable ())
+      Format.fprintf ppf "%t%a%t"
+        Flambda_colours.depth_variable
         Variable.print dv
-        (Flambda_colours.normal ())
+        Flambda_colours.pop
     | Succ t ->
       Format.fprintf ppf "@[<hov 1>(succ@ %a)@]" print t
     | Unroll_to (unroll_depth, t) ->

--- a/middle_end/flambda2/identifiers/slot.ml
+++ b/middle_end/flambda2/identifiers/slot.ml
@@ -35,7 +35,7 @@ module type S = sig
 end
 
 module Make (P : sig
-  val colour : unit -> string
+  val colour : Format.formatter -> unit
 end) : S = struct
   type t =
     { compilation_unit : Compilation_unit.t;
@@ -62,14 +62,14 @@ end) : S = struct
       Hashtbl.hash (t.name_stamp, Compilation_unit.hash t.compilation_unit)
 
     let print ppf t =
-      Format.fprintf ppf "@<0>%s" (P.colour ());
+      Format.fprintf ppf "%t" P.colour;
       if Compilation_unit.equal t.compilation_unit
            (Compilation_unit.get_current_exn ())
       then Format.fprintf ppf "%s/%d" t.name t.name_stamp
       else
         Format.fprintf ppf "%a.%s/%d" Compilation_unit.print t.compilation_unit
           t.name t.name_stamp;
-      Format.fprintf ppf "@<0>%s" (Flambda_colours.normal ())
+      Format.fprintf ppf "%t" Flambda_colours.pop
   end)
 
   include Self

--- a/middle_end/flambda2/identifiers/slot.mli
+++ b/middle_end/flambda2/identifiers/slot.mli
@@ -35,5 +35,5 @@ module type S = sig
 end
 
 module Make (_ : sig
-  val colour : unit -> string
+  val colour : Format.formatter -> unit
 end) : S

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -67,49 +67,43 @@ include Container_types.Make (struct
   let hash = Hashtbl.hash
 
   let print ppf t =
-    let colour = Flambda_colours.kind () in
+    let colour = Flambda_colours.kind in
     match t with
     | Value ->
       if Flambda_features.unicode ()
-      then
-        Format.fprintf ppf "@<0>%s@<1>\u{1d54d}@<0>%s" colour
-          (Flambda_colours.normal ())
+      then Format.fprintf ppf "%t@<1>\u{1d54d}%t" colour Flambda_colours.pop
       else Format.fprintf ppf "Val"
     | Naked_number naked_number_kind ->
       if Flambda_features.unicode ()
       then
         match naked_number_kind with
         | Naked_immediate ->
-          Format.fprintf ppf "@<0>%s@<1>\u{2115}@<1>\u{1d55a}@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t@<1>\u{2115}@<1>\u{1d55a}%t" colour
+            Flambda_colours.pop
         | Naked_float ->
-          Format.fprintf ppf "@<0>%s@<1>\u{2115}@<1>\u{1d557}@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t@<1>\u{2115}@<1>\u{1d557}%t" colour
+            Flambda_colours.pop
         | Naked_int32 ->
-          Format.fprintf ppf
-            "@<0>%s@<1>\u{2115}@<1>\u{1d7db}@<1>\u{1d7da}@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t@<1>\u{2115}@<1>\u{1d7db}@<1>\u{1d7da}%t" colour
+            Flambda_colours.pop
         | Naked_int64 ->
-          Format.fprintf ppf
-            "@<0>%s@<1>\u{2115}@<1>\u{1d7de}@<1>\u{1d7dc}@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t@<1>\u{2115}@<1>\u{1d7de}@<1>\u{1d7dc}%t" colour
+            Flambda_colours.pop
         | Naked_nativeint ->
-          Format.fprintf ppf "@<0>%s@<1>\u{2115}@<1>\u{2115}@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t@<1>\u{2115}@<1>\u{2115}%t" colour
+            Flambda_colours.pop
       else
         Format.fprintf ppf "(Naked_number %a)" Naked_number_kind.print
           naked_number_kind
     | Region ->
       if Flambda_features.unicode ()
       then
-        Format.fprintf ppf "@<0>%s@<1>\u{1d53d}@<1>\u{1d558}@<0>%s" colour
-          (Flambda_colours.normal ())
+        Format.fprintf ppf "%t@<1>\u{1d53d}@<1>\u{1d558}%t" colour
+          Flambda_colours.pop
       else Format.fprintf ppf "Region"
     | Rec_info ->
       if Flambda_features.unicode ()
-      then
-        Format.fprintf ppf "@<0>%s@<1>\u{211d}@<0>%s" colour
-          (Flambda_colours.normal ())
+      then Format.fprintf ppf "%t@<1>\u{211d}%t" colour Flambda_colours.pop
       else Format.fprintf ppf "Rec"
 end)
 
@@ -348,54 +342,43 @@ module With_subkind = struct
       type nonrec t = t
 
       let rec print ppf t =
-        let colour = Flambda_colours.subkind () in
+        let colour = Flambda_colours.subkind in
         match t with
         | Anything -> Format.fprintf ppf "*"
         | Tagged_immediate ->
-          Format.fprintf ppf "@<0>%s=tagged_@<1>\u{2115}@<1>\u{1d55a}@<0>%s"
-            colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=tagged_@<1>\u{2115}@<1>\u{1d55a}%t" colour
+            Flambda_colours.pop
         | Boxed_float ->
-          Format.fprintf ppf "@<0>%s=boxed_@<1>\u{2115}@<1>\u{1d557}@<0>%s"
-            colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=boxed_@<1>\u{2115}@<1>\u{1d557}%t" colour
+            Flambda_colours.pop
         | Boxed_int32 ->
-          Format.fprintf ppf
-            "@<0>%s=boxed_@<1>\u{2115}@<1>\u{1d7db}@<1>\u{1d7da}@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=boxed_@<1>\u{2115}@<1>\u{1d7db}@<1>\u{1d7da}%t"
+            colour Flambda_colours.pop
         | Boxed_int64 ->
-          Format.fprintf ppf
-            "@<0>%s=boxed_@<1>\u{2115}@<1>\u{1d7de}@<1>\u{1d7dc}@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=boxed_@<1>\u{2115}@<1>\u{1d7de}@<1>\u{1d7dc}%t"
+            colour Flambda_colours.pop
         | Boxed_nativeint ->
-          Format.fprintf ppf "@<0>%s=boxed_@<1>\u{2115}@<1>\u{2115}@<0>%s"
-            colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=boxed_@<1>\u{2115}@<1>\u{2115}%t" colour
+            Flambda_colours.pop
         | Variant { consts; non_consts } ->
-          Format.fprintf ppf
-            "@<0>%s=Variant((consts (%a))@ (non_consts (%a)))@<0>%s" colour
-            Targetint_31_63.Set.print consts
+          Format.fprintf ppf "%t=Variant((consts (%a))@ (non_consts (%a)))%t"
+            colour Targetint_31_63.Set.print consts
             (Tag.Scannable.Map.print (fun ppf fields ->
                  Format.fprintf ppf "[%a]"
                    (Format.pp_print_list ~pp_sep:Format.pp_print_space print)
                    fields))
-            non_consts
-            (Flambda_colours.normal ())
+            non_consts Flambda_colours.pop
         | Float_block { num_fields } ->
-          Format.fprintf ppf "@<0>%s=Float_block(%d)@<0>%s" colour num_fields
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=Float_block(%d)%t" colour num_fields
+            Flambda_colours.pop
         | Float_array ->
-          Format.fprintf ppf "@<0>%s=Float_array@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=Float_array%t" colour Flambda_colours.pop
         | Immediate_array ->
-          Format.fprintf ppf "@<0>%s=Immediate_array@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=Immediate_array%t" colour Flambda_colours.pop
         | Value_array ->
-          Format.fprintf ppf "@<0>%s=Value_array@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=Value_array%t" colour Flambda_colours.pop
         | Generic_array ->
-          Format.fprintf ppf "@<0>%s=Generic_array@<0>%s" colour
-            (Flambda_colours.normal ())
+          Format.fprintf ppf "%t=Generic_array%t" colour Flambda_colours.pop
 
       let compare = Stdlib.compare
 

--- a/middle_end/flambda2/lattices/or_unknown.ml
+++ b/middle_end/flambda2/lattices/or_unknown.ml
@@ -19,14 +19,13 @@ type 'a t =
   | Unknown
 
 let print f ppf t =
-  let colour = Flambda_colours.top_or_bottom_type () in
+  let colour = Flambda_colours.top_or_bottom_type in
   match t with
   | Known contents -> Format.fprintf ppf "%a" f contents
   | Unknown ->
     if Flambda_features.unicode ()
-    then
-      Format.fprintf ppf "%s@<1>\u{22a4}%s" colour (Flambda_colours.normal ())
-    else Format.fprintf ppf "%sT%s" colour (Flambda_colours.normal ())
+    then Format.fprintf ppf "%t@<1>\u{22a4}%t" colour Flambda_colours.pop
+    else Format.fprintf ppf "%tT%t" colour Flambda_colours.pop
 
 let compare compare_contents t1 t2 =
   match t1, t2 with

--- a/middle_end/flambda2/simplify/env/continuation_uses.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses.ml
@@ -50,11 +50,10 @@ let add_use t kind ~env_at_use id ~arg_types =
     let bt = Printexc.get_raw_backtrace () in
     Format.eprintf
       "\n\
-       %sContext is:%s adding use of %a with arg types@ (%a);@ existing uses:@ \
+       %tContext is:%t adding use of %a with arg types@ (%a);@ existing uses:@ \
        %a; environment:@ %a"
-      (Flambda_colours.error ())
-      (Flambda_colours.normal ())
-      Continuation.print t.continuation
+      Flambda_colours.error Flambda_colours.pop Continuation.print
+      t.continuation
       (Format.pp_print_list ~pp_sep:Format.pp_print_space T.print)
       arg_types print t DE.print env_at_use;
     Printexc.raise_with_backtrace Misc.Fatal_error bt

--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -142,11 +142,10 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
         let bt = Printexc.get_raw_backtrace () in
         Format.eprintf
           "\n\
-           %sContext is:%s simplifying 'let symbol' binding of@ %a@ with \
+           %tContext is:%t simplifying 'let symbol' binding of@ %a@ with \
            downwards accumulator:@ %a\n"
-          (Flambda_colours.error ())
-          (Flambda_colours.normal ())
-          Bound_static.print bound_static DA.print dacc;
+          Flambda_colours.error Flambda_colours.pop Bound_static.print
+          bound_static DA.print dacc;
         Printexc.raise_with_backtrace Misc.Fatal_error bt
     in
     let dacc, lifted_constants =
@@ -226,9 +225,8 @@ let simplify_named dacc bound_pattern named ~simplify_toplevel =
     let bt = Printexc.get_raw_backtrace () in
     Format.eprintf
       "\n\
-       %sContext is:%s simplifying [Let] binding@ %a =@ %a@ with downwards \
+       %tContext is:%t simplifying [Let] binding@ %a =@ %a@ with downwards \
        accumulator:@ %a\n"
-      (Flambda_colours.error ())
-      (Flambda_colours.normal ())
-      Bound_pattern.print bound_pattern Named.print named DA.print dacc;
+      Flambda_colours.error Flambda_colours.pop Bound_pattern.print
+      bound_pattern Named.print named DA.print dacc;
     Printexc.raise_with_backtrace Misc.Fatal_error bt

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -640,11 +640,10 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
           let bt = Printexc.get_raw_backtrace () in
           Format.eprintf
             "\n\
-             %sContext is:%s simplifying function with function slot %a,@ \
+             %tContext is:%t simplifying function with function slot %a,@ \
              params %a,@ return continuation %a,@ exn continuation %a,@ \
              my_closure %a,@ body:@ %a@ with downwards accumulator:@ %a\n"
-            (Flambda_colours.error ())
-            (Flambda_colours.normal ())
+            Flambda_colours.error Flambda_colours.pop
             (Format.pp_print_option Function_slot.print)
             function_slot_opt Bound_parameters.print params Continuation.print
             return_continuation Continuation.print exn_continuation

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -68,21 +68,21 @@ include Container_types.Make (struct
       | Toplevel_return, Some trap_action, _::_ ->
         "module_init_end", Some trap_action
     in
-    Format.fprintf ppf "@[<hov 1>%a@<0>%s%s@<0>%s %a"
+    Format.fprintf ppf "@[<hov 1>%a%t%s%t %a"
       Trap_action.Option.print trap_action
-      (Flambda_colours.expr_keyword ())
+      Flambda_colours.expr_keyword
       name
-      (Flambda_colours.normal ())
+      Flambda_colours.pop
       Continuation.print k;
     begin match args with
     | [] -> ()
     | args ->
       Format.fprintf ppf " %a" Simple.List.print args
     end;
-    Format.fprintf ppf "@<0>%s%a@<0>%s@]"
-      (Flambda_colours.elide ())
+    Format.fprintf ppf "%t%a%t@]"
+      Flambda_colours.elide
       print_or_elide_debuginfo dbg
-      (Flambda_colours.normal ())
+      Flambda_colours.pop
 
   let hash _ = Misc.fatal_error "Not yet implemented"
 

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -93,7 +93,7 @@ let [@ocamlformat "disable"] print ppf
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(%a\u{3008}%a\u{3009}\u{300a}%a\u{300b}@ (%a))@]@ \
       @[<hov 1>(call_kind@ %a)@]@ \
-      @[<hov 1>@<0>%s(dbg@ %a)@<0>%s@]@ \
+      @[<hov 1>%t(dbg@ %a)%t@]@ \
       @[<hov 1>(inline@ %a)@]@ \
       @[<hov 1>(inlining_state@ %a)@]@ \
       %a\
@@ -105,9 +105,9 @@ let [@ocamlformat "disable"] print ppf
     Exn_continuation.print exn_continuation
     Simple.List.print args
     Call_kind.print call_kind
-    (Flambda_colours.debuginfo ())
+    Flambda_colours.debuginfo
     Debuginfo.print_compact dbg
-    (Flambda_colours.normal ())
+    Flambda_colours.pop
     Inlined_attribute.print inlined
     Inlining_state.print inlining_state
     print_inlining_paths relative_history

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -112,11 +112,11 @@ let [@ocamlformat "disable"] print ppf t =
       Alloc_mode.print alloc_mode
   | C_call { alloc; param_arity; return_arity; is_c_builtin; } ->
     fprintf ppf "@[(C@ @[(alloc %b)@]@ @[(is_c_builtin %b)@]@ \
-        @<0>%s@<1>\u{2237}@<0>%s %a @<1>\u{2192} %a)@]"
+        %t@<1>\u{2237}%t %a @<1>\u{2192} %a)@]"
       alloc
       is_c_builtin
-      (Flambda_colours.elide ())
-      (Flambda_colours.normal ())
+      Flambda_colours.elide
+      Flambda_colours.pop
       Flambda_arity.print param_arity
       Flambda_arity.print return_arity
 

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -159,75 +159,75 @@ let [@ocamlformat "disable"] print ppf
         absolute_history; relative_history} =
   let module C = Flambda_colours in
   Format.fprintf ppf "@[<hov 1>(\
-      @[<hov 1>@<0>%s(newer_version_of@ %a)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(stub@ %b)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(inline@ %a)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(is_a_functor@ %b)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(params_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
+      @[<hov 1>%t(newer_version_of@ %a)%t@]@ \
+      @[<hov 1>%t(stub@ %b)%t@]@ \
+      @[<hov 1>%t(inline@ %a)%t@]@ \
+      @[<hov 1>%t(is_a_functor@ %b)%t@]@ \
+      @[<hov 1>%t(params_arity@ %t%a%t)%t@]@ \
       @[<hov 1>(num_trailing_local_params@ %d)@]@ \
-      @[<hov 1>@<0>%s(result_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
+      @[<hov 1>%t(result_arity@ %t%a%t)%t@]@ \
       @[<hov 1>(result_types@ @[<hov 1>(%a)@])@]@ \
       @[<hov 1>(contains_no_escaping_local_allocs@ %b)@]@ \
-      @[<hov 1>@<0>%s(recursive@ %a)@<0>%s@]@ \
+      @[<hov 1>%t(recursive@ %a)%t@]@ \
       @[<hov 1>(cost_metrics@ %a)@]@ \
       @[<hov 1>(inlining_arguments@ %a)@]@ \
-      @[<hov 1>@<0>%s(dbg@ %a)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(is_tupled@ %b)@<0>%s@]@ \
+      @[<hov 1>%t(dbg@ %a)%t@]@ \
+      @[<hov 1>%t(is_tupled@ %b)%t@]@ \
       @[<hov 1>(is_my_closure_used@ %b)@]@ \
       %a\
       @[<hov 1>(inlining_decision@ %a)@]\
       )@]"
-    (if Option.is_none newer_version_of then Flambda_colours.elide ()
-    else Flambda_colours.normal ())
+    (if Option.is_none newer_version_of then Flambda_colours.elide
+    else Flambda_colours.none)
     (Option.print_compact Code_id.print) newer_version_of
-    (Flambda_colours.normal ())
-    (if not stub then Flambda_colours.elide () else C.normal ())
+    Flambda_colours.pop
+    (if not stub then Flambda_colours.elide else C.none)
     stub
-    (Flambda_colours.normal ())
+    Flambda_colours.pop
     (if Inline_attribute.is_default inline
-    then Flambda_colours.elide ()
-    else C.normal ())
+    then Flambda_colours.elide
+    else C.none)
     Inline_attribute.print inline
-    (Flambda_colours.normal ())
-    (if not is_a_functor then Flambda_colours.elide () else C.normal ())
+    Flambda_colours.pop
+    (if not is_a_functor then Flambda_colours.elide else C.none)
     is_a_functor
-    (Flambda_colours.normal ())
+    Flambda_colours.pop
     (if Flambda_arity.With_subkinds.is_singleton_value params_arity
-    then Flambda_colours.elide ()
-    else Flambda_colours.normal ())
-    (Flambda_colours.normal ())
+    then Flambda_colours.elide
+    else Flambda_colours.none)
+    Flambda_colours.pop
     Flambda_arity.With_subkinds.print params_arity
     (if Flambda_arity.With_subkinds.is_singleton_value params_arity
-    then Flambda_colours.elide ()
-    else Flambda_colours.normal ())
-    (Flambda_colours.normal ())
+    then Flambda_colours.elide
+    else Flambda_colours.none)
+    Flambda_colours.pop
     num_trailing_local_params
     (if Flambda_arity.With_subkinds.is_singleton_value result_arity
-    then Flambda_colours.elide ()
-    else Flambda_colours.normal ())
-    (Flambda_colours.normal ())
+    then Flambda_colours.elide
+    else Flambda_colours.none)
+    Flambda_colours.pop
     Flambda_arity.With_subkinds.print result_arity
     (if Flambda_arity.With_subkinds.is_singleton_value result_arity
-    then Flambda_colours.elide ()
-    else Flambda_colours.normal ())
-    (Flambda_colours.normal ())
+    then Flambda_colours.elide
+    else Flambda_colours.none)
+    Flambda_colours.pop
     Result_types.print result_types
     contains_no_escaping_local_allocs
     (match recursive with
-    | Non_recursive -> Flambda_colours.elide ()
-    | Recursive -> Flambda_colours.normal ())
+    | Non_recursive -> Flambda_colours.elide
+    | Recursive -> Flambda_colours.none)
     Recursive.print recursive
-    (Flambda_colours.normal ())
+    Flambda_colours.pop
     Cost_metrics.print cost_metrics
     Inlining_arguments.print inlining_arguments
-    (Flambda_colours.debuginfo ())
+    Flambda_colours.debuginfo
     Debuginfo.print_compact dbg
-    (Flambda_colours.normal ())
+    Flambda_colours.pop
     (if is_tupled
-    then Flambda_colours.normal ()
-    else Flambda_colours.elide ())
+    then Flambda_colours.none
+    else Flambda_colours.elide)
     is_tupled
-    (Flambda_colours.normal ())
+    Flambda_colours.pop
     is_my_closure_used
     print_inlining_paths (relative_history, absolute_history)
     Function_decl_inlining_decision_type.print inlining_decision

--- a/middle_end/flambda2/terms/exn_continuation.ml
+++ b/middle_end/flambda2/terms/exn_continuation.ml
@@ -32,20 +32,20 @@ include Container_types.Make (struct
     | _ ->
       Format.fprintf ppf "@[<hov 1>(\
           @[<hov 1>(exn_handler@ %a)@]@ \
-          @[<hov 1>@<0>%s(extra_args@ @<0>%s(%a)@<0>%s@<0>)@<0>%s@]\
+          @[<hov 1>%t(extra_args@ %t(%a)%t@<0>)%t@]\
           )@]"
         Continuation.print exn_handler
         (match extra_args with
-         | [] -> Flambda_colours.elide ()
-         | _ -> Flambda_colours.normal ())
-        (Flambda_colours.normal ())
+         | [] -> Flambda_colours.elide
+         | _ -> Flambda_colours.none)
+        Flambda_colours.pop
         (Format.pp_print_list
           ~pp_sep:Format.pp_print_space print_simple_and_kind)
         extra_args
         (match extra_args with
-         | [] -> Flambda_colours.elide ()
-         | _ -> Flambda_colours.normal ())
-        (Flambda_colours.normal ())
+         | [] -> Flambda_colours.elide
+         | _ -> Flambda_colours.none)
+        Flambda_colours.pop
 
   let compare_simple_and_kind (simple1, kind1) (simple2, kind2) =
     let c = Simple.compare simple1 simple2 in

--- a/middle_end/flambda2/terms/field_of_static_block.ml
+++ b/middle_end/flambda2/terms/field_of_static_block.ml
@@ -47,20 +47,14 @@ include Container_types.Make (struct
   let print ppf t =
     match t with
     | Symbol symbol ->
-      Format.fprintf ppf "%s%a%s"
-        (Flambda_colours.symbol ())
-        Symbol.print symbol
-        (Flambda_colours.normal ())
+      Format.fprintf ppf "%t%a%t" Flambda_colours.symbol Symbol.print symbol
+        Flambda_colours.pop
     | Tagged_immediate immediate ->
-      Format.fprintf ppf "%s%a%s"
-        (Flambda_colours.tagged_immediate ())
-        Targetint_31_63.print immediate
-        (Flambda_colours.normal ())
+      Format.fprintf ppf "%t%a%t" Flambda_colours.tagged_immediate
+        Targetint_31_63.print immediate Flambda_colours.pop
     | Dynamically_computed (var, _dbg) ->
-      Format.fprintf ppf "%s%a%s"
-        (Flambda_colours.variable ())
-        Variable.print var
-        (Flambda_colours.normal ())
+      Format.fprintf ppf "%t%a%t" Flambda_colours.variable Variable.print var
+        Flambda_colours.pop
 end)
 
 let apply_renaming t renaming =

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -431,8 +431,8 @@ type flattened_for_printing =
 
 let _shape_colour descr =
   match descr with
-  | Flat_code _ | Flat_deleted_code _ -> Flambda_colours.code_id ()
-  | Flat_set_of_closures _ | Flat_block_like _ -> Flambda_colours.symbol ()
+  | Flat_code _ | Flat_deleted_code _ -> Flambda_colours.code_id
+  | Flat_set_of_closures _ | Flat_block_like _ -> Flambda_colours.symbol
 
 let rec named_must_be_static_consts (named : named) =
   match named with
@@ -513,17 +513,13 @@ and print ppf (t : expr) =
   | Let let_expr -> print_let_expr ppf let_expr
   | Let_cont let_cont -> print_let_cont_expr ppf let_cont
   | Apply apply ->
-    Format.fprintf ppf "@[<hov 1>(@<0>%sapply@<0>%s@ %a)@]"
-      (Flambda_colours.expr_keyword ())
-      (Flambda_colours.normal ())
-      Apply.print apply
+    Format.fprintf ppf "@[<hov 1>(%tapply%t@ %a)@]" Flambda_colours.expr_keyword
+      Flambda_colours.pop Apply.print apply
   | Apply_cont apply_cont -> Apply_cont.print ppf apply_cont
   | Switch switch -> Switch.print ppf switch
   | Invalid { message } ->
-    fprintf ppf "@[(@<0>%sinvalid@<0>%s@ @[<hov 1>%s@])@]"
-      (Flambda_colours.invalid_keyword ())
-      (Flambda_colours.normal ())
-      message
+    fprintf ppf "@[(%tinvalid%t@ @[<hov 1>%s@])@]"
+      Flambda_colours.invalid_keyword Flambda_colours.pop message
 
 and print_continuation_handler (recursive : Recursive.t) ppf k
     ({ cont_handler_abst = _; is_exn_handler } as t) occurrences ~first =
@@ -533,21 +529,18 @@ and print_continuation_handler (recursive : Recursive.t) ppf k
     (match descr handler with
     | Apply_cont _ | Invalid _ -> fprintf ppf "@[<hov 0>"
     | Let _ | Let_cont _ | Apply _ | Switch _ -> fprintf ppf "@[<v 0>");
-    fprintf ppf "@[<hov 1>@<0>%s%a@<0>%s%s@<0>%s%s@<0>%s"
-      (Flambda_colours.continuation_definition ())
-      Continuation.print k
-      (Flambda_colours.expr_keyword ())
+    fprintf ppf "@[<hov 1>%t%a%t%t%s%t%t%s%t"
+      Flambda_colours.continuation_definition Continuation.print k
+      Flambda_colours.pop Flambda_colours.expr_keyword
       (match recursive with Non_recursive -> "" | Recursive -> " (rec)")
-      (Flambda_colours.continuation_annotation ())
+      Flambda_colours.pop Flambda_colours.continuation_annotation
       (if is_exn_handler then "[eh]" else "")
-      (Flambda_colours.normal ());
+      Flambda_colours.pop;
     if not (Bound_parameters.is_empty params)
     then fprintf ppf " %a" Bound_parameters.print params;
-    fprintf ppf "@<0>%s #%a:@<0>%s@]@ @[<hov 0>%a@]" (Flambda_colours.elide ())
+    fprintf ppf "%t #%a:%t@]@ @[<hov 0>%a@]" Flambda_colours.elide
       (Or_unknown.print Num_occurrences.print)
-      occurrences
-      (Flambda_colours.normal ())
-      print handler;
+      occurrences Flambda_colours.pop print handler;
     fprintf ppf "@]"
   in
   Name_abstraction.pattern_match_for_printing
@@ -564,17 +557,14 @@ and print_function_params_and_body ppf t =
       Bound_parameter.create my_closure (K.With_subkind.create K.value Anything)
     in
     fprintf ppf
-      "@[<hov 1>(@<0>%s@<1>\u{03bb}@<0>%s@[<hov \
-       1>@<1>\u{3008}%a@<1>\u{3009}@<1>\u{300a}%a@<1>\u{300b}%a %a @<0>%s%a \
-       @<0>%s.@<0>%s@]@ %a))@]"
-      (Flambda_colours.lambda ())
-      (Flambda_colours.normal ())
-      Continuation.print return_continuation Continuation.print exn_continuation
+      "@[<hov 1>(%t@<1>\u{03bb}%t@[<hov \
+       1>@<1>\u{3008}%a@<1>\u{3009}@<1>\u{300a}%a@<1>\u{300b}%a %a %t%a%t \
+       %t.%t@]@ %a))@]"
+      Flambda_colours.lambda Flambda_colours.pop Continuation.print
+      return_continuation Continuation.print exn_continuation
       Bound_parameters.print params Bound_parameter.print my_closure
-      (Flambda_colours.depth_variable ())
-      Variable.print my_depth (Flambda_colours.elide ())
-      (Flambda_colours.normal ())
-      print body
+      Flambda_colours.depth_variable Variable.print my_depth Flambda_colours.pop
+      Flambda_colours.elide Flambda_colours.pop print body
   in
   let module BFF = Bound_for_function in
   Name_abstraction.pattern_match_for_printing
@@ -701,9 +691,8 @@ and flatten_for_printing t =
     ~f:(fun bound_pattern { body; _ } -> print bound_pattern ~body)
 
 and print_closure_binding ppf (function_slot, sym) =
-  Format.fprintf ppf "@[%a @<0>%s\u{21a4}@<0>%s@ %a@]" Symbol.print sym
-    (Flambda_colours.elide ()) (Flambda_colours.elide ()) Function_slot.print
-    function_slot
+  Format.fprintf ppf "@[%a %t\u{21a4}%t@ %a@]" Symbol.print sym
+    Flambda_colours.elide Flambda_colours.pop Function_slot.print function_slot
 
 and print_flattened_descr_lhs ppf descr =
   match descr with
@@ -713,8 +702,8 @@ and print_flattened_descr_lhs ppf descr =
     Format.fprintf ppf "@[<hov 0>%a@]"
       (Format.pp_print_list
          ~pp_sep:(fun ppf () ->
-           Format.fprintf ppf "@<0>%s,@ @<0>%s" (Flambda_colours.elide ())
-             (Flambda_colours.normal ()))
+           Format.fprintf ppf "%t,@ %t" Flambda_colours.elide
+             Flambda_colours.pop)
          print_closure_binding)
       (Function_slot.Lmap.bindings closure_symbols)
   | Flat_block_like (symbol, _) -> Symbol.print ppf symbol
@@ -733,14 +722,9 @@ and print_flattened ppf
     } =
   fprintf ppf "@[<hov 1>";
   if second_or_later_rec_binding
-  then
-    fprintf ppf "@<0>%sand @<0>%s"
-      (Flambda_colours.expr_keyword ())
-      (Flambda_colours.normal ());
-  fprintf ppf "%a@<0>%s =@<0>%s@ %a@]" print_flattened_descr_lhs descr
-    (Flambda_colours.elide ())
-    (Flambda_colours.normal ())
-    print_flattened_descr_rhs descr
+  then fprintf ppf "%tand %t" Flambda_colours.expr_keyword Flambda_colours.pop;
+  fprintf ppf "%a%t =%t@ %a@]" print_flattened_descr_lhs descr
+    Flambda_colours.elide Flambda_colours.pop print_flattened_descr_rhs descr
 
 and flatten_let_symbol t : _ * expr =
   let rec flatten (expr : expr) : _ * expr =
@@ -784,12 +768,12 @@ and print_let_expr ppf ({ let_abst = _; defining_expr } as t) : unit =
   let let_bound_var_colour bound_pattern defining_expr =
     let name_mode = Bound_pattern.name_mode bound_pattern in
     if Name_mode.is_phantom name_mode
-    then Flambda_colours.elide ()
+    then Flambda_colours.elide
     else
       match (defining_expr : named) with
-      | Rec_info _ -> Flambda_colours.depth_variable ()
+      | Rec_info _ -> Flambda_colours.depth_variable
       | Simple _ | Prim _ | Set_of_closures _ | Static_consts _ ->
-        Flambda_colours.variable ()
+        Flambda_colours.variable
   in
   let rec let_body (expr : expr) =
     match descr expr with
@@ -797,11 +781,10 @@ and print_let_expr ppf ({ let_abst = _; defining_expr } as t) : unit =
       let print (bound_pattern : Bound_pattern.t) ~body =
         match bound_pattern with
         | Singleton _ | Set_of_closures _ ->
-          fprintf ppf "@ @[<hov 1>@<0>%s%a@<0>%s =@<0>%s@ %a@]"
+          fprintf ppf "@ @[<hov 1>%t%a%t%t =%t@ %a@]"
             (let_bound_var_colour bound_pattern defining_expr)
-            Bound_pattern.print bound_pattern (Flambda_colours.elide ())
-            (Flambda_colours.normal ())
-            print_named defining_expr;
+            Bound_pattern.print bound_pattern Flambda_colours.pop
+            Flambda_colours.elide Flambda_colours.pop print_named defining_expr;
           let_body body
         | Static _ -> expr
       in
@@ -815,11 +798,10 @@ and print_let_expr ppf ({ let_abst = _; defining_expr } as t) : unit =
     match bound_pattern with
     | Static _ -> print_let_static ppf t
     | Singleton _ | Set_of_closures _ ->
-      fprintf ppf "@[<v 0>@[<v 0>@[<hov 1>@<0>%s%a@<0>%s =@<0>%s@ %a@]"
+      fprintf ppf "@[<v 0>@[<v 0>@[<hov 1>%t%a%t%t =%t@ %a@]"
         (let_bound_var_colour bound_pattern defining_expr)
-        Bound_pattern.print bound_pattern (Flambda_colours.elide ())
-        (Flambda_colours.normal ())
-        print_named defining_expr;
+        Bound_pattern.print bound_pattern Flambda_colours.pop
+        Flambda_colours.elide Flambda_colours.pop print_named defining_expr;
       let expr = let_body body in
       fprintf ppf "@]@ %a@]" print expr
   in
@@ -837,10 +819,8 @@ and print_named ppf (t : named) =
   match t with
   | Simple simple -> Simple.print ppf simple
   | Prim (prim, dbg) ->
-    fprintf ppf "@[<hov 1>(%a@<0>%s%a@<0>%s)@]" Flambda_primitive.print prim
-      (Flambda_colours.debuginfo ())
-      print_or_elide_debuginfo dbg
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%a%t%a%t)@]" Flambda_primitive.print prim
+      Flambda_colours.debuginfo print_or_elide_debuginfo dbg Flambda_colours.pop
   | Set_of_closures set_of_closures -> Set_of_closures.print ppf set_of_closures
   | Static_consts consts -> print_static_const_group ppf consts
   | Rec_info rec_info_expr -> Rec_info_expr.print ppf rec_info_expr
@@ -854,15 +834,13 @@ and print_static_const_group ppf static_const_group =
 and print_static_const_or_code ppf static_const_or_code =
   match static_const_or_code with
   | Code code ->
-    fprintf ppf "@[<hov 1>(@<0>%sCode@<0>%s@ %a)@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tCode%t@ %a)@]" Flambda_colours.static_part
+      Flambda_colours.pop
       (Code0.print ~print_function_params_and_body)
       code
   | Deleted_code ->
-    fprintf ppf "@[<hov 1>(@<0>%sDeleted_code@<0>%s)@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tDeleted_code%t)@]" Flambda_colours.static_part
+      Flambda_colours.pop
   | Static_const const -> Static_const.print ppf const
 
 module Continuation_handler = struct

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -571,8 +571,8 @@ let equal_nullary_primitive p1 p2 = compare_nullary_primitive p1 p2 = 0
 let print_nullary_primitive ppf p =
   match p with
   | Optimised_out _ ->
-    Format.fprintf ppf "@<0>%sOptimised_out@<0>%s" (Flambda_colours.elide ())
-      (Flambda_colours.normal ())
+    Format.fprintf ppf "%tOptimised_out%t" Flambda_colours.elide
+      Flambda_colours.pop
   | Probe_is_enabled { name } ->
     Format.fprintf ppf "@[<hov 1>(Probe_is_enabled@ %s)@]" name
   | Begin_region -> Format.pp_print_string ppf "Begin_region"
@@ -795,13 +795,11 @@ let print_unary_primitive ppf p =
   | Box_number (k, Local) ->
     fprintf ppf "Box_%a[local]" K.Boxable_number.print_lowercase_short k
   | Project_function_slot { move_from; move_to } ->
-    Format.fprintf ppf "@[(Project_function_slot@ (%a \u{2192} %a@<0>%s))@]"
+    Format.fprintf ppf "@[(Project_function_slot@ (%a \u{2192} %a))@]"
       Function_slot.print move_from Function_slot.print move_to
-      (Flambda_colours.prim_destructive ())
   | Project_value_slot { project_from; value_slot } ->
-    Format.fprintf ppf "@[(Project_value_slot@ (%a@ %a@<0>%s))@]"
-      Function_slot.print project_from Value_slot.print value_slot
-      (Flambda_colours.prim_destructive ())
+    Format.fprintf ppf "@[(Project_value_slot@ (%a@ %a))@]" Function_slot.print
+      project_from Value_slot.print value_slot
   | Is_boxed_float -> fprintf ppf "Is_boxed_float"
   | Is_flat_float_array -> fprintf ppf "Is_flat_float_array"
   | End_region -> Format.pp_print_string ppf "End_region"
@@ -1417,42 +1415,42 @@ include Container_types.Make (struct
   let [@ocamlformat "disable"] print ppf t =
     let colour =
       match classify_for_printing t with
-      | Constructive -> Flambda_colours.prim_constructive ()
-      | Destructive -> Flambda_colours.prim_destructive ()
-      | Neither -> Flambda_colours.prim_neither ()
+      | Constructive -> Flambda_colours.prim_constructive
+      | Destructive -> Flambda_colours.prim_destructive
+      | Neither -> Flambda_colours.prim_neither
     in
     match t with
     | Nullary prim ->
-      Format.fprintf ppf "@[<hov 1>@<0>%s%a@<0>%s@]"
+      Format.fprintf ppf "@[<hov 1>%t%a%t@]"
         colour
         print_nullary_primitive prim
-        (Flambda_colours.normal ())
+        Flambda_colours.pop
     | Unary (prim, v0) ->
-      Format.fprintf ppf "@[<hov 1>(@<0>%s%a@<0>%s@ %a)@]"
+      Format.fprintf ppf "@[<hov 1>(%t%a%t@ %a)@]"
         colour
         print_unary_primitive prim
-        (Flambda_colours.normal ())
+        Flambda_colours.pop
         Simple.print v0
     | Binary (prim, v0, v1) ->
-      Format.fprintf ppf "@[<hov 1>(@<0>%s%a@<0>%s@ %a@ %a)@]"
+      Format.fprintf ppf "@[<hov 1>(%t%a%t@ %a@ %a)@]"
         colour
         print_binary_primitive prim
-        (Flambda_colours.normal ())
+        Flambda_colours.pop
         Simple.print v0
         Simple.print v1
     | Ternary (prim, v0, v1, v2) ->
-      Format.fprintf ppf "@[<hov 1>(@<0>%s%a@<0>%s@ %a@ %a@ %a)@]"
+      Format.fprintf ppf "@[<hov 1>(%t%a%t@ %a@ %a@ %a)@]"
         colour
         print_ternary_primitive prim
-        (Flambda_colours.normal ())
+        Flambda_colours.pop
         Simple.print v0
         Simple.print v1
         Simple.print v2
     | Variadic (prim, vs) ->
-      Format.fprintf ppf "@[<hov 1>(@<0>%s%a@<0>%s@ %a)@]"
+      Format.fprintf ppf "@[<hov 1>(%t%a%t@ %a)@]"
         colour
         print_variadic_primitive prim
-        (Flambda_colours.normal ())
+        Flambda_colours.pop
         (Format.pp_print_list ~pp_sep:Format.pp_print_space Simple.print) vs
 end)
 

--- a/middle_end/flambda2/terms/inlining_arguments.ml
+++ b/middle_end/flambda2/terms/inlining_arguments.ml
@@ -49,9 +49,9 @@ module Args = struct
        && Int.equal large_function_size (I.large_function_size Default)
        && Float.equal threshold (I.threshold Default)
     then
-      Format.fprintf ppf "@<0>%s<default>@<0>%s"
-        (Flambda_colours.elide ())
-        (Flambda_colours.normal ())
+      Format.fprintf ppf "%t<default>%t"
+        Flambda_colours.elide
+        Flambda_colours.pop
     else
       Format.fprintf ppf
         "@[<hov 1>(\

--- a/middle_end/flambda2/terms/set_of_closures.ml
+++ b/middle_end/flambda2/terms/set_of_closures.ml
@@ -24,13 +24,13 @@ let [@ocamlformat "disable"] print ppf
       { function_decls;
         value_slots;alloc_mode;
       } =
-  Format.fprintf ppf "@[<hov 1>(%sset_of_closures%s@ \
+  Format.fprintf ppf "@[<hov 1>(%tset_of_closures%t@ \
       @[<hov 1>(function_decls@ %a)@]@ \
       @[<hov 1>(value_slots@ %a)@]@ \
       @[<hov 1>(alloc_mode@ %a)@]\
       )@]"
-    (Flambda_colours.prim_constructive ())
-    (Flambda_colours.normal ())
+    Flambda_colours.prim_constructive
+    Flambda_colours.pop
     (Function_declarations.print) function_decls
     (Value_slot.Map.print Simple.print) value_slots
     Alloc_mode.print alloc_mode
@@ -82,20 +82,20 @@ let [@ocamlformat "disable"] print ppf
         alloc_mode;
       } =
   if Value_slot.Map.is_empty value_slots then
-    Format.fprintf ppf "@[<hov 1>(%sset_of_closures%s@ %a@ \
+    Format.fprintf ppf "@[<hov 1>(%tset_of_closures%t@ %a@ \
         @[<hov 1>%a@]\
         )@]"
-      (Flambda_colours.prim_constructive ())
-      (Flambda_colours.normal ())
+      Flambda_colours.prim_constructive
+      Flambda_colours.pop
       Alloc_mode.print alloc_mode
       (Function_declarations.print) function_decls
   else
-    Format.fprintf ppf "@[<hov 1>(%sset_of_closures%s@ %a@ \
+    Format.fprintf ppf "@[<hov 1>(%tset_of_closures%t@ %a@ \
         @[<hov 1>%a@]@ \
         @[<hov 1>(env@ %a)@]\
         )@]"
-      (Flambda_colours.prim_constructive ())
-      (Flambda_colours.normal ())
+      Flambda_colours.prim_constructive
+      Flambda_colours.pop
       Alloc_mode.print alloc_mode
       Function_declarations.print function_decls
       (Value_slot.Map.print Simple.print) value_slots

--- a/middle_end/flambda2/terms/static_const.ml
+++ b/middle_end/flambda2/terms/static_const.ml
@@ -61,76 +61,76 @@ let immutable_string str = Immutable_string str
 let [@ocamlformat "disable"] print ppf t =
   match t with
   | Set_of_closures set ->
-    fprintf ppf "@[<hov 1>(@<0>%sSet_of_closures@<0>%s@ %a)@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tSet_of_closures%t@ %a)@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       Set_of_closures.print set
   | Block (tag, mut, fields) ->
-    fprintf ppf "@[<hov 1>(@<0>%s%sblock@<0>%s@ (tag %a)@ (%a))@]"
-      (Flambda_colours.static_part ())
+    fprintf ppf "@[<hov 1>(%t%sblock%t@ (tag %a)@ (%a))@]"
+      Flambda_colours.static_part
       (match mut with
         | Immutable -> "Immutable_"
         | Immutable_unique -> "Unique_"
         | Mutable -> "Mutable_")
-      (Flambda_colours.normal ())
+      Flambda_colours.pop
       Tag.Scannable.print tag
       (Format.pp_print_list ~pp_sep:Format.pp_print_space
         Field_of_static_block.print) fields
   | Boxed_float or_var ->
-    fprintf ppf "@[<hov 1>(@<0>%sBoxed_float@<0>%s@ %a)@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tBoxed_float%t@ %a)@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       (Or_variable.print Numeric_types.Float_by_bit_pattern.print) or_var
   | Boxed_int32 or_var ->
-    fprintf ppf "@[<hov 1>(@<0>%sBoxed_int32@<0>%s@ %a)@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tBoxed_int32%t@ %a)@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       (Or_variable.print Numeric_types.Int32.print) or_var
   | Boxed_int64 or_var ->
-    fprintf ppf "@[<hov 1>(@<0>%sBoxed_int64@<0>%s@ %a)@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tBoxed_int64%t@ %a)@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       (Or_variable.print Numeric_types.Int64.print) or_var
   | Boxed_nativeint or_var ->
-    fprintf ppf "@[<hov 1>(@<0>%sBoxed_nativeint@<0>%s@ %a)@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tBoxed_nativeint%t@ %a)@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       (Or_variable.print Targetint_32_64.print) or_var
   | Immutable_float_block fields ->
-    fprintf ppf "@[<hov 1>(@<0>%sImmutable_float_block@<0>%s@ @[[| %a |]@])@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tImmutable_float_block%t@ @[[| %a |]@])@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       (Format.pp_print_list
         ~pp_sep:(fun ppf () -> Format.pp_print_string ppf "@; ")
         (Or_variable.print Numeric_types.Float_by_bit_pattern.print))
       fields
   | Immutable_float_array fields ->
-    fprintf ppf "@[<hov 1>(@<0>%sImmutable_float_array@<0>%s@ @[[| %a |]@])@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tImmutable_float_array%t@ @[[| %a |]@])@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       (Format.pp_print_list
         ~pp_sep:(fun ppf () -> Format.pp_print_string ppf "@; ")
         (Or_variable.print Numeric_types.Float_by_bit_pattern.print))
       fields
   | Immutable_value_array fields ->
-    fprintf ppf "@[<hov 1>(@<0>%sImmutable_value_array@<0>%s@ (%a))@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tImmutable_value_array%t@ (%a))@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       (Format.pp_print_list ~pp_sep:Format.pp_print_space
         Field_of_static_block.print) fields
   | Empty_array ->
-    fprintf ppf "@<0>%sEmpty_array@<0>%s"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "%tEmpty_array%t"
+      Flambda_colours.static_part
+      Flambda_colours.pop
   | Mutable_string { initial_value = s; } ->
-    fprintf ppf "@[<hov 1>(@<0>%sMutable_string@<0>%s@ %S)@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tMutable_string%t@ %S)@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       s
   | Immutable_string s ->
-    fprintf ppf "@[<hov 1>(@<0>%sImmutable_string@<0>%s@ %S)@]"
-      (Flambda_colours.static_part ())
-      (Flambda_colours.normal ())
+    fprintf ppf "@[<hov 1>(%tImmutable_string%t@ %S)@]"
+      Flambda_colours.static_part
+      Flambda_colours.pop
       s
 
 include Container_types.Make (struct

--- a/middle_end/flambda2/terms/switch_expr.ml
+++ b/middle_end/flambda2/terms/switch_expr.ml
@@ -54,20 +54,18 @@ let print_arms ppf arms =
     (fun (action, discrs) ->
       if !spc then fprintf ppf "@ " else spc := true;
       let discrs = Targetint_31_63.Set.elements discrs in
-      fprintf ppf "@[<hov 2>@[<hov 0>| %a @<0>%s\u{21a6}@<0>%s@ @]%a@]"
+      fprintf ppf "@[<hov 2>@[<hov 0>| %a %t\u{21a6}%t@ @]%a@]"
         (Format.pp_print_list
            ~pp_sep:(fun ppf () -> Format.fprintf ppf "@ | ")
            Targetint_31_63.print)
-        discrs (Flambda_colours.elide ())
-        (Flambda_colours.normal ())
-        Apply_cont_expr.print action)
+        discrs Flambda_colours.elide Flambda_colours.pop Apply_cont_expr.print
+        action)
     arms
 
 let print ppf { condition_dbg = _; scrutinee; arms } =
-  fprintf ppf "@[<v 0>(@<0>%sswitch@<0>%s %a@ @[<v 0>%a@])@]"
-    (Flambda_colours.expr_keyword ())
-    (Flambda_colours.normal ())
-    Simple.print scrutinee print_arms arms
+  fprintf ppf "@[<v 0>(%tswitch%t %a@ @[<v 0>%a@])@]"
+    Flambda_colours.expr_keyword Flambda_colours.pop Simple.print scrutinee
+    print_arms arms
 
 let create ~condition_dbg ~scrutinee ~arms = { condition_dbg; scrutinee; arms }
 

--- a/middle_end/flambda2/terms/trap_action.ml
+++ b/middle_end/flambda2/terms/trap_action.ml
@@ -68,20 +68,20 @@ let [@ocamlformat "disable"] print ppf t =
   let fprintf = Format.fprintf in
   match t with
   | Push { exn_handler; } ->
-    fprintf ppf "%spush_trap%s %a %sthen%s "
-      (Flambda_colours.expr_keyword ())
-      (Flambda_colours.normal ())
+    fprintf ppf "%tpush_trap%t %a %tthen%t "
+      Flambda_colours.expr_keyword
+      Flambda_colours.pop
       Continuation.print exn_handler
-      (Flambda_colours.expr_keyword ())
-      (Flambda_colours.normal ())
+      Flambda_colours.expr_keyword
+      Flambda_colours.pop
   | Pop { exn_handler; raise_kind; } ->
-    fprintf ppf "%spop_trap%s%s %a %sthen%s "
-      (Flambda_colours.expr_keyword ())
-      (Flambda_colours.normal ())
+    fprintf ppf "%tpop_trap%t%s %a %tthen%t "
+      Flambda_colours.expr_keyword
+      Flambda_colours.pop
       (Raise_kind.option_to_string raise_kind)
       Continuation.print exn_handler
-      (Flambda_colours.expr_keyword ())
-      (Flambda_colours.normal ())
+      Flambda_colours.expr_keyword
+      Flambda_colours.pop
 
 (* Continuations used in trap actions are tracked separately, since sometimes,
    we don't want to count them as uses. However they must be tracked for lifting

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -300,12 +300,11 @@ let params_and_body env res code_id p ~fun_dbg ~translate_expr =
       with Misc.Fatal_error as e ->
         Format.eprintf
           "\n\
-           %sContext is:%s translating function %a to Cmm with return cont %a, \
+           %tContext is:%t translating function %a to Cmm with return cont %a, \
            exn cont %a and body:@ %a\n"
-          (Flambda_colours.error ())
-          (Flambda_colours.normal ())
-          Code_id.print code_id Continuation.print return_continuation
-          Continuation.print exn_continuation Expr.print body;
+          Flambda_colours.error Flambda_colours.pop Code_id.print code_id
+          Continuation.print return_continuation Continuation.print
+          exn_continuation Expr.print body;
         raise e)
 
 (* Translation of sets of closures. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -297,8 +297,6 @@ let static_consts env r ~params_and_body bound_static static_consts =
       |> Expr.create_let
     in
     Format.eprintf
-      "\n@[<v 0>%sContext is:%s translating `let symbol' to Cmm:@ %a@."
-      (Flambda_colours.error ())
-      (Flambda_colours.normal ())
-      Expr.print tmp_let_symbol;
+      "\n@[<v 0>%tContext is:%t translating `let symbol' to Cmm:@ %a@."
+      Flambda_colours.error Flambda_colours.pop Expr.print tmp_let_symbol;
     raise e

--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -289,7 +289,7 @@ module Alias_set = struct
 
   let [@ocamlformat "disable"] print ppf { const; names; } =
     let none ppf () =
-      Format.fprintf ppf "@<0>%s()" (Flambda_colours.elide ())
+      Format.fprintf ppf "%t()%t" Flambda_colours.elide Flambda_colours.pop
     in
     Format.fprintf ppf
       "@[<hov 1>(\
@@ -384,14 +384,14 @@ let [@ocamlformat "disable"] print ppf
   let print_element_and_coercion ppf (elt, coercion) =
     Format.fprintf ppf "@[<hov 1>(\
                         %a@ \
-                        @[<hov 1>@<0>%s(coercion@ %a)@<0>%s@]\
+                        @[<hov 1>%t(coercion@ %a)%t@]\
                         )@]"
       Simple.print elt
       (if Coercion.is_id coercion
-      then Flambda_colours.elide ()
-      else Flambda_colours.normal ())
+      then Flambda_colours.elide
+      else Flambda_colours.none)
       Coercion.print coercion
-      (Flambda_colours.normal ())
+      Flambda_colours.pop
   in
   Format.fprintf ppf
     "@[<hov 1>(\

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1018,10 +1018,8 @@ let type_simple_in_term_exn t ?min_name_mode simple =
   with
   | exception Misc.Fatal_error ->
     let bt = Printexc.get_raw_backtrace () in
-    Format.eprintf "\n%sContext is:%s typing environment@ %a\n"
-      (Flambda_colours.error ())
-      (Flambda_colours.normal ())
-      print t;
+    Format.eprintf "\n%tContext is:%t typing environment@ %a\n"
+      Flambda_colours.error Flambda_colours.pop print t;
     Printexc.raise_with_backtrace Misc.Fatal_error bt
   | exception Binding_time_resolver_failure -> TG.alias_type_of kind simple
   | alias -> TG.alias_type_of kind alias
@@ -1048,10 +1046,8 @@ let get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
   with
   | exception Misc.Fatal_error ->
     let bt = Printexc.get_raw_backtrace () in
-    Format.eprintf "\n%sContext is:%s typing environment@ %a\n"
-      (Flambda_colours.error ())
-      (Flambda_colours.normal ())
-      print t;
+    Format.eprintf "\n%tContext is:%t typing environment@ %a\n"
+      Flambda_colours.error Flambda_colours.pop print t;
     Printexc.raise_with_backtrace Misc.Fatal_error bt
   | exception Binding_time_resolver_failure -> simple
   | alias -> alias

--- a/middle_end/flambda2/types/grammar/type_descr.ml
+++ b/middle_end/flambda2/types/grammar/type_descr.ml
@@ -105,9 +105,8 @@ end = struct
       match t with
       | No_alias head -> print_head ppf head
       | Equals simple ->
-        Format.fprintf ppf "@[(@<0>%s=@<0>%s %a)@]" (Flambda_colours.error ())
-          (Flambda_colours.normal ())
-          Simple.print simple
+        Format.fprintf ppf "@[(%t=%t %a)@]" Flambda_colours.error
+          Flambda_colours.pop Simple.print simple
 
     let[@inline always] apply_renaming ~apply_renaming_head t renaming =
       if Renaming.is_empty renaming
@@ -258,20 +257,16 @@ end
 include T
 
 let print ~print_head ppf t =
-  let colour = Flambda_colours.top_or_bottom_type () in
+  let colour = Flambda_colours.top_or_bottom_type in
   match descr t with
   | Unknown ->
     if Flambda_features.unicode ()
-    then
-      Format.fprintf ppf "@<0>%s@<1>\u{22a4}@<0>%s" colour
-        (Flambda_colours.normal ())
-    else Format.fprintf ppf "@<0>%sT@<0>%s" colour (Flambda_colours.normal ())
+    then Format.fprintf ppf "%t@<1>\u{22a4}%t" colour Flambda_colours.pop
+    else Format.fprintf ppf "%tT%t" colour Flambda_colours.pop
   | Bottom ->
     if Flambda_features.unicode ()
-    then
-      Format.fprintf ppf "@<0>%s@<1>\u{22a5}@<0>%s" colour
-        (Flambda_colours.normal ())
-    else Format.fprintf ppf "@<0>%s_|_@<0>%s" colour (Flambda_colours.normal ())
+    then Format.fprintf ppf "%t@<1>\u{22a5}%t" colour Flambda_colours.pop
+    else Format.fprintf ppf "%t_|_%t" colour Flambda_colours.pop
   | Ok descr -> Descr.print ~print_head ppf descr
 
 let[@inline always] apply_coercion ~apply_coercion_head coercion t :

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -811,12 +811,10 @@ and print_row_like :
   in
   if row_like_is_bottom ~known ~other ~is_empty_map_known
   then
-    let colour = Flambda_colours.top_or_bottom_type () in
+    let colour = Flambda_colours.top_or_bottom_type in
     if Flambda_features.unicode ()
-    then
-      Format.fprintf ppf "@<0>%s@<1>\u{22a5}@<0>%s" colour
-        (Flambda_colours.normal ())
-    else Format.fprintf ppf "%s_|_%s" colour (Flambda_colours.normal ())
+    then Format.fprintf ppf "%t@<1>\u{22a5}%t" colour Flambda_colours.pop
+    else Format.fprintf ppf "%t_|_%t" colour Flambda_colours.pop
   else
     let pp_env_extension ppf env_extension =
       if not (Name.Map.is_empty env_extension.equations)

--- a/middle_end/flambda2/ui/flambda_colours.mli
+++ b/middle_end/flambda2/ui/flambda_colours.mli
@@ -12,70 +12,82 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val normal : unit -> string
+(** A colour directive. Can be passed as an argument to [Format.printf] and
+    frients using the "%t" specifier. Each directive (besides [pop]) acts by
+    pushing a new state onto a stack, allowing the previous state to be restored
+    using [pop]. *)
+type directive = Format.formatter -> unit
 
-val prim_constructive : unit -> string
+(** Undo the most recent colour directive, restoring the previous state. Raises
+    a fatal error if the stack is empty. *)
+val pop : directive
 
-val prim_destructive : unit -> string
+(** Push a copy of the current state onto the stack. Useful when setting a
+    colour conditionally so that a following [pop] will always be matched. *)
+val none : directive
 
-val prim_neither : unit -> string
+val prim_constructive : directive
 
-val naked_number : unit -> string
+val prim_destructive : directive
 
-val tagged_immediate : unit -> string
+val prim_neither : directive
 
-val constructor : unit -> string
+val naked_number : directive
 
-val kind : unit -> string
+val tagged_immediate : directive
 
-val subkind : unit -> string
+val constructor : directive
 
-val top_or_bottom_type : unit -> string
+val kind : directive
 
-val debuginfo : unit -> string
+val subkind : directive
 
-val discriminant : unit -> string
+val top_or_bottom_type : directive
 
-val name : unit -> string
+val debuginfo : directive
 
-val parameter : unit -> string
+val discriminant : directive
 
-val symbol : unit -> string
+val name : directive
 
-val variable : unit -> string
+val parameter : directive
 
-val function_slot : unit -> string
+val symbol : directive
 
-val value_slot : unit -> string
+val variable : directive
 
-val code_id : unit -> string
+val function_slot : directive
 
-val expr_keyword : unit -> string
+val value_slot : directive
 
-val invalid_keyword : unit -> string
+val code_id : directive
 
-val static_keyword : unit -> string
+val expr_keyword : directive
 
-val static_part : unit -> string
+val invalid_keyword : directive
 
-val continuation : unit -> string
+val static_keyword : directive
 
-val continuation_definition : unit -> string
+val static_part : directive
 
-val continuation_annotation : unit -> string
+val continuation : directive
 
-val name_abstraction : unit -> string
+val continuation_definition : directive
 
-val rec_info : unit -> string
+val continuation_annotation : directive
 
-val coercion : unit -> string
+val name_abstraction : directive
 
-val depth_variable : unit -> string
+val rec_info : directive
 
-val elide : unit -> string
+val coercion : directive
 
-val error : unit -> string
+val depth_variable : directive
 
-val each_file : unit -> string
+val elide : directive
 
-val lambda : unit -> string
+val error : directive
+
+val each_file : directive
+
+val lambda : directive


### PR DESCRIPTION
This turns all the colour functions like `Flambda_colours.error` into functions of type `Format.formatter -> unit`, to be passed to the `%t` format specifier in `fprintf`. This bakes in the `@<0>` adjustment that makes sure the ANSI sequence doesn't cause excessive line wrapping (this adjustment was missing in several places before). In addition, the new `Flambda_colours.pop` function restores the previous colour state by popping from a stack. Previously, any code that applied a colour had to know what the previous colour was in order to revert; this way is easier and potentially more modular. (Also, it should now be possible to add a background colour to a whole region of code if we want.)

The one downside is that we need to be sure that every non-`pop` colour directive is matched by a `pop`. This, however, is no harder than keeping `@[` specifiers balanced.

Also, the state stack is kept in a global. It might be better to use `Format`'s semantic tags, which allow keeping per-formatter state.