### PR TITLE
Explicitly install some packages on Ubuntu.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,10 @@ jobs:
         PATH=$GITHUB_WORKSPACE/ocaml-412/_install/bin:$PATH make release
         cp dune.exe $GITHUB_WORKSPACE/ocaml-412/_install/bin/dune
 
+    - name: Install packages for the build and the testsuite
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install build-essential gfortran
+
     - name: Install GNU parallel
       if: matrix.os == 'macos-latest'
       run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install parallel


### PR DESCRIPTION
We have recently seen (_e.g_ on #782 or #844) CI
failures apparently caused by the absence of
Fortran.

This pull request thus tweaks the CI workflows to
explicitly install the "build essentials" and Fortran
on the Ubuntu jobs.