### PR TITLE
Refactor Code_metadata

### DIFF
--- a/middle_end/flambda2/simplify/non_constructed_code.ml
+++ b/middle_end/flambda2/simplify/non_constructed_code.ml
@@ -16,57 +16,21 @@
 
 type t = unit Code0.t
 
-let code_id = Code0.code_id
+let code_metadata = Code0.code_metadata
 
-let newer_version_of = Code0.newer_version_of
+module Metadata_view = struct
+  type nonrec 'a t = t
+  let metadata = code_metadata
+end
+include (Code_metadata.Code_metadata_accessors) (Metadata_view)
 
-let params_arity = Code0.params_arity
+let create_with_metadata =
+  Code0.create_with_metadata
+    ~print_function_params_and_body:Unit.print ~params_and_body:()
 
-let num_leading_heap_params = Code0.num_leading_heap_params
-
-let num_trailing_local_params = Code0.num_trailing_local_params
-
-let result_arity = Code0.result_arity
-
-let result_types = Code0.result_types
-
-let stub = Code0.stub
-
-let inline = Code0.inline
-
-let is_a_functor = Code0.is_a_functor
-
-let recursive = Code0.recursive
-
-let cost_metrics = Code0.cost_metrics
-
-let inlining_arguments = Code0.inlining_arguments
-
-let absolute_history = Code0.absolute_history
-
-let relative_history = Code0.relative_history
-
-let dbg = Code0.dbg
-
-let is_tupled = Code0.is_tupled
-
-let is_my_closure_used = Code0.is_my_closure_used
-
-let inlining_decision = Code0.inlining_decision
-
-let contains_no_escaping_local_allocs = Code0.contains_no_escaping_local_allocs
-
-let create code_id ~free_names_of_params_and_body ~newer_version_of
-    ~params_arity ~num_trailing_local_params ~result_arity ~result_types
-    ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor ~recursive
-    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
-    ~inlining_decision ~absolute_history ~relative_history =
-  Code0.create ~print_function_params_and_body:Unit.print code_id
-    ~params_and_body:() ~free_names_of_params_and_body ~newer_version_of
-    ~params_arity ~num_trailing_local_params ~result_arity ~result_types
-    ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor ~recursive
-    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
-    ~inlining_decision ~absolute_history ~relative_history
+let create =
+  Code0.create
+    ~print_function_params_and_body:Unit.print ~params_and_body:()
 
 let print = Code0.print ~print_function_params_and_body:Unit.print
 

--- a/middle_end/flambda2/simplify/non_constructed_code.mli
+++ b/middle_end/flambda2/simplify/non_constructed_code.mli
@@ -19,68 +19,22 @@
 
 type t = unit Code0.t
 
-val code_id : t -> Code_id.t
+val code_metadata : t -> Code_metadata.t
 
-val newer_version_of : t -> Code_id.t option
+module Metadata_view : sig
+  type nonrec 'a t = t
+  val metadata : 'a t -> Code_metadata.t
+end
+include Code_metadata.Code_metadata_accessors_result_type(Metadata_view).S
 
-val params_arity : t -> Flambda_arity.With_subkinds.t
-
-val num_leading_heap_params : t -> int
-
-val num_trailing_local_params : t -> int
-
-val result_arity : t -> Flambda_arity.With_subkinds.t
-
-val result_types : t -> Result_types.t
-
-val stub : t -> bool
-
-val inline : t -> Inline_attribute.t
-
-val is_a_functor : t -> bool
-
-val recursive : t -> Recursive.t
-
-val cost_metrics : t -> Cost_metrics.t
-
-val inlining_arguments : t -> Inlining_arguments.t
-
-val dbg : t -> Debuginfo.t
-
-val is_tupled : t -> bool
-
-val is_my_closure_used : t -> bool
-
-val inlining_decision : t -> Function_decl_inlining_decision_type.t
-
-val contains_no_escaping_local_allocs : t -> bool
-
-val absolute_history : t -> Inlining_history.Absolute.t
-
-val relative_history : t -> Inlining_history.Relative.t
+val create_with_metadata :
+  free_names_of_params_and_body:Name_occurrences.t ->
+  code_metadata:Code_metadata.t ->
+  t
 
 val create :
-  Code_id.t ->
   free_names_of_params_and_body:Name_occurrences.t ->
-  newer_version_of:Code_id.t option ->
-  params_arity:Flambda_arity.With_subkinds.t ->
-  num_trailing_local_params:int ->
-  result_arity:Flambda_arity.With_subkinds.t ->
-  result_types:Result_types.t ->
-  contains_no_escaping_local_allocs:bool ->
-  stub:bool ->
-  inline:Inline_attribute.t ->
-  is_a_functor:bool ->
-  recursive:Recursive.t ->
-  cost_metrics:Cost_metrics.t ->
-  inlining_arguments:Inlining_arguments.t ->
-  dbg:Debuginfo.t ->
-  is_tupled:bool ->
-  is_my_closure_used:bool ->
-  inlining_decision:Function_decl_inlining_decision_type.t ->
-  absolute_history:Inlining_history.Absolute.t ->
-  relative_history:Inlining_history.Relative.t ->
-  t
+  t Code_metadata.create_type
 
 include Contains_names.S with type t := t
 

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -28,28 +28,9 @@ val print : Format.formatter -> t -> unit
 
 val create_code :
   Are_rebuilding_terms.t ->
-  Code_id.t ->
   params_and_body:Rebuilt_expr.Function_params_and_body.t ->
   free_names_of_params_and_body:Name_occurrences.t ->
-  newer_version_of:Code_id.t option ->
-  params_arity:Flambda_arity.With_subkinds.t ->
-  num_trailing_local_params:int ->
-  result_arity:Flambda_arity.With_subkinds.t ->
-  result_types:Result_types.t ->
-  contains_no_escaping_local_allocs:bool ->
-  stub:bool ->
-  inline:Inline_attribute.t ->
-  is_a_functor:bool ->
-  recursive:Recursive.t ->
-  cost_metrics:Cost_metrics.t ->
-  inlining_arguments:Inlining_arguments.t ->
-  dbg:Debuginfo.t ->
-  is_tupled:bool ->
-  is_my_closure_used:bool ->
-  inlining_decision:Function_decl_inlining_decision_type.t ->
-  absolute_history:Inlining_history.Absolute.t ->
-  relative_history:Inlining_history.Relative.t ->
-  t
+  t Code_metadata.create_type
 
 (* This function should be used when a [Code.t] is already in hand, e.g. from
    the input term to the simplifier, rather than when one needs to be

--- a/middle_end/flambda2/terms/code.ml
+++ b/middle_end/flambda2/terms/code.ml
@@ -18,60 +18,21 @@ type t = Flambda.Function_params_and_body.t Code0.t
 
 let code_metadata = Code0.code_metadata
 
-let code_id = Code0.code_id
-
 let params_and_body = Code0.params_and_body
 
-let newer_version_of = Code0.newer_version_of
+module Metadata_view = struct
+  type nonrec 'a t = t
+  let metadata = code_metadata
+end
+include (Code_metadata.Code_metadata_accessors) (Metadata_view)
 
-let params_arity = Code0.params_arity
+let create_with_metadata =
+  Code0.create_with_metadata
+    ~print_function_params_and_body:Flambda.Function_params_and_body.print
 
-let num_leading_heap_params = Code0.num_leading_heap_params
-
-let num_trailing_local_params = Code0.num_trailing_local_params
-
-let result_arity = Code0.result_arity
-
-let result_types = Code0.result_types
-
-let stub = Code0.stub
-
-let inline = Code0.inline
-
-let is_a_functor = Code0.is_a_functor
-
-let recursive = Code0.recursive
-
-let cost_metrics = Code0.cost_metrics
-
-let inlining_arguments = Code0.inlining_arguments
-
-let dbg = Code0.dbg
-
-let is_tupled = Code0.is_tupled
-
-let is_my_closure_used = Code0.is_my_closure_used
-
-let inlining_decision = Code0.inlining_decision
-
-let contains_no_escaping_local_allocs = Code0.contains_no_escaping_local_allocs
-
-let absolute_history = Code0.absolute_history
-
-let relative_history = Code0.relative_history
-
-let create code_id ~params_and_body ~free_names_of_params_and_body
-    ~newer_version_of ~params_arity ~num_trailing_local_params ~result_arity
-    ~result_types ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor
-    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
-    ~is_my_closure_used ~inlining_decision ~absolute_history ~relative_history =
+let create =
   Code0.create
     ~print_function_params_and_body:Flambda.Function_params_and_body.print
-    code_id ~params_and_body ~free_names_of_params_and_body ~newer_version_of
-    ~params_arity ~num_trailing_local_params ~result_arity ~result_types
-    ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor ~recursive
-    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
-    ~inlining_decision ~absolute_history ~relative_history
 
 let with_code_id = Code0.with_code_id
 

--- a/middle_end/flambda2/terms/code.mli
+++ b/middle_end/flambda2/terms/code.mli
@@ -22,71 +22,24 @@ type t = Flambda.Function_params_and_body.t Code0.t
 
 val code_metadata : t -> Code_metadata.t
 
-val code_id : t -> Code_id.t
-
 val params_and_body : t -> Flambda.Function_params_and_body.t
 
-val newer_version_of : t -> Code_id.t option
+module Metadata_view : sig
+  type nonrec 'a t = t
+  val metadata : 'a t -> Code_metadata.t
+end
+include Code_metadata.Code_metadata_accessors_result_type(Metadata_view).S
 
-val params_arity : t -> Flambda_arity.With_subkinds.t
-
-val num_leading_heap_params : t -> int
-
-val num_trailing_local_params : t -> int
-
-val result_arity : t -> Flambda_arity.With_subkinds.t
-
-val result_types : t -> Result_types.t
-
-val stub : t -> bool
-
-val inline : t -> Inline_attribute.t
-
-val is_a_functor : t -> bool
-
-val recursive : t -> Recursive.t
-
-val cost_metrics : t -> Cost_metrics.t
-
-val inlining_arguments : t -> Inlining_arguments.t
-
-val dbg : t -> Debuginfo.t
-
-val is_tupled : t -> bool
-
-val is_my_closure_used : t -> bool
-
-val inlining_decision : t -> Function_decl_inlining_decision_type.t
-
-val contains_no_escaping_local_allocs : t -> bool
-
-val absolute_history : t -> Inlining_history.Absolute.t
-
-val relative_history : t -> Inlining_history.Relative.t
-
-val create :
-  Code_id.t ->
+val create_with_metadata :
   params_and_body:Flambda.Function_params_and_body.t ->
   free_names_of_params_and_body:Name_occurrences.t ->
-  newer_version_of:Code_id.t option ->
-  params_arity:Flambda_arity.With_subkinds.t ->
-  num_trailing_local_params:int ->
-  result_arity:Flambda_arity.With_subkinds.t ->
-  result_types:Result_types.t ->
-  contains_no_escaping_local_allocs:bool ->
-  stub:bool ->
-  inline:Inline_attribute.t ->
-  is_a_functor:bool ->
-  recursive:Recursive.t ->
-  cost_metrics:Cost_metrics.t ->
-  inlining_arguments:Inlining_arguments.t ->
-  dbg:Debuginfo.t ->
-  is_tupled:bool ->
-  is_my_closure_used:bool ->
-  inlining_decision:Function_decl_inlining_decision_type.t ->
-  absolute_history:Inlining_history.Absolute.t ->
-  relative_history:Inlining_history.Relative.t ->
+  code_metadata:Code_metadata.t ->
   t
+
+val create :
+  params_and_body:Flambda.Function_params_and_body.t ->
+  free_names_of_params_and_body:Name_occurrences.t ->
+  t Code_metadata.create_type
 
 val with_code_id : Code_id.t -> t -> t
 

--- a/middle_end/flambda2/terms/code0.ml
+++ b/middle_end/flambda2/terms/code0.ml
@@ -22,50 +22,13 @@ type 'function_params_and_body t =
 
 let code_metadata t = t.code_metadata
 
-let code_id t = Code_metadata.code_id t.code_metadata
+module Metadata_view = struct
+  type nonrec 'function_params_and_body t = 'function_params_and_body t
+  let metadata t = t.code_metadata
+end
+include (Code_metadata.Code_metadata_accessors) (Metadata_view)
 
 let params_and_body t = t.params_and_body
-
-let newer_version_of t = Code_metadata.newer_version_of t.code_metadata
-
-let params_arity t = Code_metadata.params_arity t.code_metadata
-
-let num_leading_heap_params t =
-  Code_metadata.num_leading_heap_params t.code_metadata
-
-let num_trailing_local_params t =
-  Code_metadata.num_trailing_local_params t.code_metadata
-
-let result_arity t = Code_metadata.result_arity t.code_metadata
-
-let result_types t = Code_metadata.result_types t.code_metadata
-
-let stub t = Code_metadata.stub t.code_metadata
-
-let inline t = Code_metadata.inline t.code_metadata
-
-let is_a_functor t = Code_metadata.is_a_functor t.code_metadata
-
-let recursive t = Code_metadata.recursive t.code_metadata
-
-let cost_metrics t = Code_metadata.cost_metrics t.code_metadata
-
-let inlining_arguments t = Code_metadata.inlining_arguments t.code_metadata
-
-let dbg t = Code_metadata.dbg t.code_metadata
-
-let is_tupled t = Code_metadata.is_tupled t.code_metadata
-
-let is_my_closure_used t = Code_metadata.is_my_closure_used t.code_metadata
-
-let inlining_decision t = Code_metadata.inlining_decision t.code_metadata
-
-let contains_no_escaping_local_allocs t =
-  Code_metadata.contains_no_escaping_local_allocs t.code_metadata
-
-let absolute_history t = Code_metadata.absolute_history t.code_metadata
-
-let relative_history t = Code_metadata.relative_history t.code_metadata
 
 let check_free_names_of_params_and_body ~print_function_params_and_body code_id
     ~params_and_body ~free_names_of_params_and_body =
@@ -78,22 +41,22 @@ let check_free_names_of_params_and_body ~print_function_params_and_body code_id
       Name_occurrences.print free_names_of_params_and_body Code_id.print code_id
       print_function_params_and_body params_and_body
 
-let create ~print_function_params_and_body code_id ~params_and_body
-    ~free_names_of_params_and_body ~newer_version_of ~params_arity
-    ~num_trailing_local_params ~result_arity ~result_types
-    ~contains_no_escaping_local_allocs ~stub ~(inline : Inline_attribute.t)
-    ~is_a_functor ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
-    ~is_my_closure_used ~inlining_decision ~absolute_history ~relative_history =
-  check_free_names_of_params_and_body ~print_function_params_and_body code_id
+let create_with_metadata ~print_function_params_and_body ~params_and_body
+    ~free_names_of_params_and_body ~code_metadata =
+  check_free_names_of_params_and_body ~print_function_params_and_body
+    (Code_metadata.code_id code_metadata)
     ~params_and_body ~free_names_of_params_and_body;
-  let code_metadata =
-    Code_metadata.create code_id ~newer_version_of ~params_arity
-      ~num_trailing_local_params ~result_arity ~result_types
-      ~contains_no_escaping_local_allocs ~stub ~inline ~is_a_functor ~recursive
-      ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
-      ~inlining_decision ~absolute_history ~relative_history
-  in
   { params_and_body; free_names_of_params_and_body; code_metadata }
+
+let create ~print_function_params_and_body ~params_and_body
+    ~free_names_of_params_and_body =
+  Code_metadata.createk
+    (fun code_metadata ->
+       create_with_metadata
+       ~print_function_params_and_body
+       ~params_and_body
+       ~free_names_of_params_and_body
+       ~code_metadata)
 
 let with_code_id code_id t =
   { t with code_metadata = Code_metadata.with_code_id code_id t.code_metadata }

--- a/middle_end/flambda2/terms/code0.mli
+++ b/middle_end/flambda2/terms/code0.mli
@@ -18,76 +18,28 @@ type 'function_params_and_body t
 
 val code_metadata : _ t -> Code_metadata.t
 
-val code_id : 'function_params_and_body t -> Code_id.t
-
 val params_and_body : 'function_params_and_body t -> 'function_params_and_body
 
-val newer_version_of : 'function_params_and_body t -> Code_id.t option
+module Metadata_view : sig
+  type nonrec 'function_params_and_body t = 'function_params_and_body t
+  val metadata : 'function_params_and_body t -> Code_metadata.t
+end
+include Code_metadata.Code_metadata_accessors_result_type(Metadata_view).S
 
-val params_arity : 'function_params_and_body t -> Flambda_arity.With_subkinds.t
-
-val num_leading_heap_params : _ t -> int
-
-val num_trailing_local_params : _ t -> int
-
-val result_arity : 'function_params_and_body t -> Flambda_arity.With_subkinds.t
-
-val result_types : 'function_params_and_body t -> Result_types.t
-
-val stub : 'function_params_and_body t -> bool
-
-val inline : 'function_params_and_body t -> Inline_attribute.t
-
-val is_a_functor : 'function_params_and_body t -> bool
-
-val recursive : 'function_params_and_body t -> Recursive.t
-
-val cost_metrics : 'function_params_and_body t -> Cost_metrics.t
-
-val inlining_arguments : 'function_params_and_body t -> Inlining_arguments.t
-
-val dbg : 'function_params_and_body t -> Debuginfo.t
-
-val is_tupled : 'function_params_and_body t -> bool
-
-val is_my_closure_used : 'function_params_and_body t -> bool
-
-val inlining_decision :
-  'function_params_and_body t -> Function_decl_inlining_decision_type.t
-
-val contains_no_escaping_local_allocs : _ t -> bool
-
-val absolute_history :
-  'function_params_and_body t -> Inlining_history.Absolute.t
-
-val relative_history :
-  'function_params_and_body t -> Inlining_history.Relative.t
+val create_with_metadata :
+  print_function_params_and_body:
+    (Format.formatter -> 'function_params_and_body -> unit) ->
+  params_and_body:'function_params_and_body ->
+  free_names_of_params_and_body:Name_occurrences.t ->
+  code_metadata:Code_metadata.t ->
+  'function_params_and_body t
 
 val create :
   print_function_params_and_body:
     (Format.formatter -> 'function_params_and_body -> unit) ->
-  Code_id.t (** needed for [compare], although useful otherwise too *) ->
   params_and_body:'function_params_and_body ->
   free_names_of_params_and_body:Name_occurrences.t ->
-  newer_version_of:Code_id.t option ->
-  params_arity:Flambda_arity.With_subkinds.t ->
-  num_trailing_local_params:int ->
-  result_arity:Flambda_arity.With_subkinds.t ->
-  result_types:Result_types.t ->
-  contains_no_escaping_local_allocs:bool ->
-  stub:bool ->
-  inline:Inline_attribute.t ->
-  is_a_functor:bool ->
-  recursive:Recursive.t ->
-  cost_metrics:Cost_metrics.t ->
-  inlining_arguments:Inlining_arguments.t ->
-  dbg:Debuginfo.t ->
-  is_tupled:bool ->
-  is_my_closure_used:bool ->
-  inlining_decision:Function_decl_inlining_decision_type.t ->
-  absolute_history:Inlining_history.Absolute.t ->
-  relative_history:Inlining_history.Relative.t ->
-  'function_params_and_body t
+  'function_params_and_body t Code_metadata.create_type
 
 val with_code_id :
   Code_id.t -> 'function_params_and_body t -> 'function_params_and_body t

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -36,56 +36,100 @@ type t =
     relative_history : Inlining_history.Relative.t
   }
 
-let code_id { code_id; _ } = code_id
+type code_metadata = t
 
-let newer_version_of { newer_version_of; _ } = newer_version_of
+module type Metadata_view_type = sig
+  type 'a t
+  val metadata : 'a t -> code_metadata
+end
 
-let params_arity { params_arity; _ } = params_arity
+module Code_metadata_accessors(X : Metadata_view_type) = struct
+  open X
 
-let num_leading_heap_params { params_arity; num_trailing_local_params; _ } =
-  let n =
-    Flambda_arity.With_subkinds.cardinal params_arity
-    - num_trailing_local_params
-  in
-  assert (n >= 0);
-  (* see [create] *)
-  n
+  let code_id t = (metadata t).code_id
 
-let num_trailing_local_params { num_trailing_local_params; _ } =
-  num_trailing_local_params
+  let newer_version_of t = (metadata t).newer_version_of
 
-let result_arity { result_arity; _ } = result_arity
+  let params_arity t = (metadata t).params_arity
 
-let result_types { result_types; _ } = result_types
+  let num_leading_heap_params t =
+    let { params_arity; num_trailing_local_params; _ } = metadata t in
+    let n =
+      Flambda_arity.With_subkinds.cardinal params_arity
+      - num_trailing_local_params
+    in
+    assert (n >= 0);
+    (* see [create] *)
+    n
 
-let stub { stub; _ } = stub
+  let num_trailing_local_params t = (metadata t).num_trailing_local_params
 
-let inline { inline; _ } = inline
+  let result_arity t = (metadata t).result_arity
 
-let is_a_functor { is_a_functor; _ } = is_a_functor
+  let result_types t = (metadata t).result_types
 
-let recursive { recursive; _ } = recursive
+  let stub t = (metadata t).stub
 
-let cost_metrics { cost_metrics; _ } = cost_metrics
+  let inline t = (metadata t).inline
 
-let inlining_arguments { inlining_arguments; _ } = inlining_arguments
+  let is_a_functor t = (metadata t).is_a_functor
 
-let dbg { dbg; _ } = dbg
+  let recursive t = (metadata t).recursive
 
-let is_tupled { is_tupled; _ } = is_tupled
+  let cost_metrics t = (metadata t).cost_metrics
 
-let is_my_closure_used { is_my_closure_used; _ } = is_my_closure_used
+  let inlining_arguments t = (metadata t).inlining_arguments
 
-let inlining_decision { inlining_decision; _ } = inlining_decision
+  let dbg t = (metadata t).dbg
 
-let contains_no_escaping_local_allocs { contains_no_escaping_local_allocs; _ } =
-  contains_no_escaping_local_allocs
+  let is_tupled t = (metadata t).is_tupled
 
-let absolute_history { absolute_history; _ } = absolute_history
+  let is_my_closure_used t = (metadata t).is_my_closure_used
 
-let relative_history { relative_history; _ } = relative_history
+  let inlining_decision t = (metadata t).inlining_decision
 
-let create code_id ~newer_version_of ~params_arity ~num_trailing_local_params
+  let contains_no_escaping_local_allocs t =
+    (metadata t).contains_no_escaping_local_allocs
+
+  let absolute_history t = (metadata t).absolute_history
+
+  let relative_history t = (metadata t).relative_history
+end
+
+module Code_metadata_accessors_result_type(X : Metadata_view_type) = struct
+  module type S = module type of Code_metadata_accessors(X)
+end
+
+module Metadata_view = struct
+  type nonrec 'a t = t
+  let metadata t = t
+end
+
+include Code_metadata_accessors(Metadata_view)
+
+type 'a create_type =
+  Code_id.t ->
+  newer_version_of:Code_id.t option ->
+  params_arity:Flambda_arity.With_subkinds.t ->
+  num_trailing_local_params:int ->
+  result_arity:Flambda_arity.With_subkinds.t ->
+  result_types:Result_types.t ->
+  contains_no_escaping_local_allocs:bool ->
+  stub:bool ->
+  inline:Inline_attribute.t ->
+  is_a_functor:bool ->
+  recursive:Recursive.t ->
+  cost_metrics:Cost_metrics.t ->
+  inlining_arguments:Inlining_arguments.t ->
+  dbg:Debuginfo.t ->
+  is_tupled:bool ->
+  is_my_closure_used:bool ->
+  inlining_decision:Function_decl_inlining_decision_type.t ->
+  absolute_history:Inlining_history.Absolute.t ->
+  relative_history:Inlining_history.Relative.t ->
+  'a
+
+let createk k code_id ~newer_version_of ~params_arity ~num_trailing_local_params
     ~result_arity ~result_types ~contains_no_escaping_local_allocs ~stub
     ~(inline : Inline_attribute.t) ~is_a_functor ~recursive ~cost_metrics
     ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision
@@ -105,7 +149,7 @@ let create code_id ~newer_version_of ~params_arity ~num_trailing_local_params
     Misc.fatal_errorf
       "Illegal num_trailing_local_params=%d for params arity: %a"
       num_trailing_local_params Flambda_arity.With_subkinds.print params_arity;
-  { code_id;
+  k { code_id;
     newer_version_of;
     params_arity;
     num_trailing_local_params;
@@ -125,6 +169,8 @@ let create code_id ~newer_version_of ~params_arity ~num_trailing_local_params
     absolute_history;
     relative_history
   }
+
+let create = createk (fun t -> t)
 
 let with_code_id code_id t = { t with code_id }
 

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -16,47 +16,71 @@
 
 type t
 
-val code_id : t -> Code_id.t
+type code_metadata = t
 
-val newer_version_of : t -> Code_id.t option
+module type Metadata_view_type = sig
+  type 'a t
+  val metadata : 'a t -> code_metadata
+end
 
-val params_arity : t -> Flambda_arity.With_subkinds.t
+module Code_metadata_accessors_result_type :
+  functor (X : Metadata_view_type) -> sig
+    open! X
+    module type S = sig
+      val code_id : 'a t -> Code_id.t
 
-val num_leading_heap_params : t -> int
+      val newer_version_of : 'a t -> Code_id.t option
 
-val num_trailing_local_params : t -> int
+      val params_arity : 'a t -> Flambda_arity.With_subkinds.t
 
-val result_arity : t -> Flambda_arity.With_subkinds.t
+      val num_leading_heap_params : 'a t -> int
 
-val result_types : t -> Result_types.t
+      val num_trailing_local_params : 'a t -> int
 
-val stub : t -> bool
+      val result_arity : 'a t -> Flambda_arity.With_subkinds.t
 
-val inline : t -> Inline_attribute.t
+      val result_types : 'a t -> Result_types.t
 
-val is_a_functor : t -> bool
+      val stub : 'a t -> bool
 
-val recursive : t -> Recursive.t
+      val inline : 'a t -> Inline_attribute.t
 
-val cost_metrics : t -> Cost_metrics.t
+      val is_a_functor : 'a t -> bool
 
-val inlining_arguments : t -> Inlining_arguments.t
+      val recursive : 'a t -> Recursive.t
 
-val dbg : t -> Debuginfo.t
+      val cost_metrics : 'a t -> Cost_metrics.t
 
-val is_tupled : t -> bool
+      val inlining_arguments : 'a t -> Inlining_arguments.t
 
-val is_my_closure_used : t -> bool
+      val dbg : 'a t -> Debuginfo.t
 
-val inlining_decision : t -> Function_decl_inlining_decision_type.t
+      val is_tupled : 'a t -> bool
 
-val contains_no_escaping_local_allocs : t -> bool
+      val is_my_closure_used : 'a t -> bool
 
-val absolute_history : t -> Inlining_history.Absolute.t
+      val inlining_decision : 'a t -> Function_decl_inlining_decision_type.t
 
-val relative_history : t -> Inlining_history.Relative.t
+      val contains_no_escaping_local_allocs : 'a t -> bool
 
-val create :
+      val absolute_history : 'a t -> Inlining_history.Absolute.t
+
+      val relative_history : 'a t -> Inlining_history.Relative.t
+    end
+  end
+
+module Code_metadata_accessors :
+  functor (X : sig type 'a t val metadata : 'a t -> code_metadata end) ->
+    Code_metadata_accessors_result_type(X).S
+
+module Metadata_view : sig
+  type nonrec 'a t = t
+  val metadata : 'a t -> code_metadata
+end
+
+include Code_metadata_accessors_result_type(Metadata_view).S
+
+type 'a create_type =
   Code_id.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
@@ -76,7 +100,10 @@ val create :
   inlining_decision:Function_decl_inlining_decision_type.t ->
   absolute_history:Inlining_history.Absolute.t ->
   relative_history:Inlining_history.Relative.t ->
-  t
+  'a
+
+val createk : (t -> 'a) -> 'a create_type
+val create : t create_type
 
 val with_code_id : Code_id.t -> t -> t
 


### PR DESCRIPTION
Currently, adding a single field to Code_metadata entails changes to Code0, Code, Non_constructed_code and Rebuilt_static_const, as well as all the places where these are used. This eliminates such redundant changes when Code_metadata is modified, and only relevant places now need to be modified.