### PR TITLE
Fix eliding of inlining arguments during printing

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -267,7 +267,7 @@ let mk_flambda2_inline_max_depth f =
   Printf.sprintf "<int>|<round>=<int>[,...]\n\
       \     Maximum depth of search for inlining opportunities inside\n\
       \     inlined functions (default %d) (Flambda 2 only)"
-    Flambda_backend_flags.Flambda2.Inlining.Default.max_depth
+    Flambda_backend_flags.Flambda2.Inlining.Default.default_arguments.max_depth
 ;;
 
 let mk_flambda2_inline_max_rec_depth f =
@@ -275,7 +275,8 @@ let mk_flambda2_inline_max_rec_depth f =
   Printf.sprintf "<int>|<round>=<int>[,...]\n\
       \     Maximum depth of search for inlining opportunities inside\n\
       \     inlined recursive functions (default %d) (Flambda 2 only)"
-    Flambda_backend_flags.Flambda2.Inlining.Default.max_rec_depth
+    Flambda_backend_flags.Flambda2.Inlining.Default.default_arguments.
+      max_rec_depth
 ;;
 
 let mk_flambda2_inline_cost arg descr ~default f =
@@ -288,29 +289,32 @@ let mk_flambda2_inline_cost arg descr ~default f =
     default
 ;;
 
+module Flambda2_inlining_default =
+  Flambda_backend_flags.Flambda2.Inlining.Default
+
 let mk_flambda2_inline_call_cost =
   mk_flambda2_inline_cost "call" "a call"
-    ~default:Flambda_backend_flags.Flambda2.Inlining.Default.call_cost
+    ~default:Flambda2_inlining_default.default_arguments.call_cost
 
 let mk_flambda2_inline_alloc_cost =
   mk_flambda2_inline_cost "alloc" "an allocation"
-    ~default:Flambda_backend_flags.Flambda2.Inlining.Default.alloc_cost
+    ~default:Flambda2_inlining_default.default_arguments.alloc_cost
 
 let mk_flambda2_inline_prim_cost =
   mk_flambda2_inline_cost "prim" "a primitive"
-    ~default:Flambda_backend_flags.Flambda2.Inlining.Default.prim_cost
+    ~default:Flambda2_inlining_default.default_arguments.prim_cost
 
 let mk_flambda2_inline_branch_cost =
   mk_flambda2_inline_cost "branch" "a conditional"
-    ~default:Flambda_backend_flags.Flambda2.Inlining.Default.branch_cost
+    ~default:Flambda2_inlining_default.default_arguments.branch_cost
 
 let mk_flambda2_inline_indirect_call_cost =
   mk_flambda2_inline_cost "indirect" "an indirect call"
-    ~default:Flambda_backend_flags.Flambda2.Inlining.Default.indirect_call_cost
+    ~default:Flambda2_inlining_default.default_arguments.indirect_call_cost
 
 let mk_flambda2_inline_poly_compare_cost =
   mk_flambda2_inline_cost "poly-compare" "a polymorphic comparison"
-    ~default:Flambda_backend_flags.Flambda2.Inlining.Default.poly_compare_cost
+    ~default:Flambda2_inlining_default.default_arguments.poly_compare_cost
 
 (* CR-someday mshinwell: We should have a check that the parameters provided by
    the user are sensible, e.g. small_function_size <= large_function_size. *)
@@ -321,7 +325,7 @@ let mk_flambda2_inline_small_function_size f =
       \     Functions with a cost less than this will always be inlined\n\
       \     unless an attribute instructs otherwise (default %d)\n\
       \     (Flambda 2 only)"
-    Flambda_backend_flags.Flambda2.Inlining.Default.small_function_size
+    Flambda2_inlining_default.default_arguments.small_function_size
 ;;
 
 let mk_flambda2_inline_large_function_size f =
@@ -331,7 +335,7 @@ let mk_flambda2_inline_large_function_size f =
       \     unless an attribute instructs otherwise (default %d); speculative\n\
       \     inlining will be disabled if equal to the small function size\n\
       \     (Flambda 2 only)"
-    Flambda_backend_flags.Flambda2.Inlining.Default.large_function_size
+    Flambda2_inlining_default.default_arguments.large_function_size
 ;;
 
 let mk_flambda2_inline_threshold f =
@@ -339,7 +343,7 @@ let mk_flambda2_inline_threshold f =
     Printf.sprintf "<float>|<round>=<float>[,...]\n\
         \     Aggressiveness of inlining (default %.02f, higher numbers mean\n\
         \     more aggressive) (Flambda 2 only)"
-      Flambda_backend_flags.Flambda2.Inlining.Default.threshold
+      Flambda2_inlining_default.default_arguments.threshold
 
 let mk_flambda2_speculative_inlining_only_if_arguments_useful f =
   "-flambda2-speculative-inlining-only-if-arguments-useful", Arg.Unit f,

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -183,113 +183,119 @@ module Flambda2 = struct
   module F = Clflags.Float_arg_helper
 
   module Inlining = struct
+    type inlining_arguments = {
+      max_depth : int;
+      max_rec_depth : int;
+      call_cost : float;
+      alloc_cost : float;
+      prim_cost : float;
+      branch_cost : float;
+      indirect_call_cost : float;
+      poly_compare_cost : float;
+      small_function_size : int;
+      large_function_size : int;
+      threshold : float;
+    }
+
     module Default = struct
       let cost_divisor = 8.
 
-      let max_depth = 1
-      let max_rec_depth = 0
-
-      let call_cost = 5. /. cost_divisor
-      let alloc_cost = 7. /. cost_divisor
-      let prim_cost = 3. /. cost_divisor
-      let branch_cost = 5. /. cost_divisor
-      let indirect_call_cost = 4. /. cost_divisor
-      let poly_compare_cost = 10. /. cost_divisor
-
-      let small_function_size = 10
-      let large_function_size = 10
-
-      let threshold = 10.
+      let default_arguments = {
+        max_depth = 1;
+        max_rec_depth = 0;
+        call_cost = 5. /. cost_divisor;
+        alloc_cost = 7. /. cost_divisor;
+        prim_cost = 3. /. cost_divisor;
+        branch_cost = 5. /. cost_divisor;
+        indirect_call_cost = 4. /. cost_divisor;
+        poly_compare_cost = 10. /. cost_divisor;
+        small_function_size = 10;
+        large_function_size = 10;
+        threshold = 10.;
+      }
 
       let speculative_inlining_only_if_arguments_useful = true
     end
 
-    let max_depth = ref (I.default Default.max_depth)
-    let max_rec_depth = ref (I.default Default.max_rec_depth)
+    let max_depth = ref (I.default Default.default_arguments.max_depth)
+    let max_rec_depth = ref (I.default Default.default_arguments.max_rec_depth)
 
-    let call_cost = ref (F.default Default.call_cost)
-    let alloc_cost = ref (F.default Default.alloc_cost)
-    let prim_cost = ref (F.default Default.prim_cost)
-    let branch_cost = ref (F.default Default.branch_cost)
-    let indirect_call_cost = ref (F.default Default.indirect_call_cost)
-    let poly_compare_cost = ref (F.default Default.poly_compare_cost)
+    let call_cost = ref (F.default Default.default_arguments.call_cost)
+    let alloc_cost = ref (F.default Default.default_arguments.alloc_cost)
+    let prim_cost = ref (F.default Default.default_arguments.prim_cost)
+    let branch_cost = ref (F.default Default.default_arguments.branch_cost)
+    let indirect_call_cost =
+      ref (F.default Default.default_arguments.indirect_call_cost)
+    let poly_compare_cost =
+      ref (F.default Default.default_arguments.poly_compare_cost)
 
-    let small_function_size = ref (I.default Default.small_function_size)
-    let large_function_size = ref (I.default Default.large_function_size)
+    let small_function_size =
+      ref (I.default Default.default_arguments.small_function_size)
+    let large_function_size =
+      ref (I.default Default.default_arguments.large_function_size)
 
-    let threshold = ref (F.default Default.threshold)
+    let threshold = ref (F.default Default.default_arguments.threshold)
 
     let speculative_inlining_only_if_arguments_useful =
       ref Default.speculative_inlining_only_if_arguments_useful
 
     let report_bin = ref false
 
-    type inlining_arguments = {
-      max_depth : int option;
-      max_rec_depth : int option;
-      call_cost : float option;
-      alloc_cost : float option;
-      prim_cost : float option;
-      branch_cost : float option;
-      indirect_call_cost : float option;
-      poly_compare_cost : float option;
-      small_function_size : int option;
-      large_function_size : int option;
-      threshold : float option;
-    }
-
     let use_inlining_arguments_set ?round (arg : inlining_arguments) =
       let set_int = Clflags.set_int_arg round in
       let set_float = Clflags.set_float_arg round in
-      set_int max_depth Default.max_depth arg.max_depth;
-      set_int max_rec_depth Default.max_rec_depth arg.max_rec_depth;
-      set_float call_cost Default.call_cost arg.call_cost;
-      set_float alloc_cost Default.alloc_cost arg.alloc_cost;
-      set_float prim_cost Default.prim_cost arg.prim_cost;
-      set_float branch_cost Default.branch_cost arg.branch_cost;
+      set_int max_depth Default.default_arguments.max_depth
+        (Some arg.max_depth);
+      set_int max_rec_depth Default.default_arguments.max_rec_depth
+        (Some arg.max_rec_depth);
+      set_float call_cost Default.default_arguments.call_cost
+        (Some arg.call_cost);
+      set_float alloc_cost Default.default_arguments.alloc_cost
+        (Some arg.alloc_cost);
+      set_float prim_cost Default.default_arguments.prim_cost
+        (Some arg.prim_cost);
+      set_float branch_cost Default.default_arguments.branch_cost
+        (Some arg.branch_cost);
       set_float indirect_call_cost
-        Default.indirect_call_cost arg.indirect_call_cost;
+        Default.default_arguments.indirect_call_cost
+        (Some arg.indirect_call_cost);
       set_float poly_compare_cost
-        Default.poly_compare_cost arg.poly_compare_cost;
+        Default.default_arguments.poly_compare_cost
+        (Some arg.poly_compare_cost);
       set_int small_function_size
-        Default.small_function_size arg.small_function_size;
+        Default.default_arguments.small_function_size
+        (Some arg.small_function_size);
       set_int large_function_size
-        Default.large_function_size arg.large_function_size;
-      set_float threshold Default.threshold arg.threshold
+        Default.default_arguments.large_function_size
+        (Some arg.large_function_size);
+      set_float threshold Default.default_arguments.threshold
+        (Some arg.threshold)
 
     let oclassic_arguments = {
-      max_depth = None;
-      max_rec_depth = None;
-      call_cost = None;
-      alloc_cost = None;
-      prim_cost = None;
-      branch_cost = None;
-      indirect_call_cost = None;
-      poly_compare_cost = None;
+      Default.default_arguments with
       (* We set the small and large function sizes to the same value here to
          recover "classic mode" semantics (no speculative inlining). *)
-      small_function_size = Some Default.small_function_size;
-      large_function_size = Some Default.small_function_size;
+      large_function_size = Default.default_arguments.small_function_size;
       (* [threshold] matches the current compiler's default.  (The factor of
          8 in that default is accounted for by [cost_divisor], above.) *)
-      threshold = Some 10.;
+      threshold = 10.;
     }
 
     let o2_arguments = {
-      max_depth = Some 3;
-      max_rec_depth = Some 0;
-      call_cost = Some (3.0 *. Default.call_cost);
-      alloc_cost = Some (3.0 *. Default.alloc_cost);
-      prim_cost = Some (3.0 *. Default.prim_cost);
-      branch_cost = Some (3.0 *. Default.branch_cost);
-      indirect_call_cost = Some (3.0 *. Default.indirect_call_cost);
-      poly_compare_cost = Some (3.0 *. Default.poly_compare_cost);
-      small_function_size = Some (10 * Default.small_function_size);
-      large_function_size = Some (50 * Default.large_function_size);
-      threshold = Some 100.;
+      max_depth = 3;
+      max_rec_depth = 0;
+      call_cost = 3.0 *. Default.default_arguments.call_cost;
+      alloc_cost = 3.0 *. Default.default_arguments.alloc_cost;
+      prim_cost = 3.0 *. Default.default_arguments.prim_cost;
+      branch_cost = 3.0 *. Default.default_arguments.branch_cost;
+      indirect_call_cost = 3.0 *. Default.default_arguments.indirect_call_cost;
+      poly_compare_cost = 3.0 *. Default.default_arguments.poly_compare_cost;
+      small_function_size = 10 * Default.default_arguments.small_function_size;
+      large_function_size = 50 * Default.default_arguments.large_function_size;
+      threshold = 100.;
     }
 
-    let o3_arguments = { o2_arguments with max_depth = Some 6 }
+    let o3_arguments = { o2_arguments with max_depth = 6 }
   end
 end
 

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -127,24 +127,28 @@ module Flambda2 : sig
   end
 
   module Inlining : sig
+    type inlining_arguments = private {
+      max_depth : int;
+      max_rec_depth : int;
+      call_cost : float;
+      alloc_cost : float;
+      prim_cost : float;
+      branch_cost : float;
+      indirect_call_cost : float;
+      poly_compare_cost : float;
+      small_function_size : int;
+      large_function_size : int;
+      threshold : float;
+    }
+
     module Default : sig
-      val max_depth : int
-      val max_rec_depth : int
-
-      val call_cost : float
-      val alloc_cost : float
-      val prim_cost : float
-      val branch_cost : float
-      val indirect_call_cost : float
-      val poly_compare_cost : float
-
-      val small_function_size : int
-      val large_function_size : int
-
-      val threshold : float
-
+      val default_arguments : inlining_arguments
       val speculative_inlining_only_if_arguments_useful : bool
     end
+
+    val oclassic_arguments : inlining_arguments
+    val o2_arguments : inlining_arguments
+    val o3_arguments : inlining_arguments
 
     val max_depth : Clflags.Int_arg_helper.parsed ref
     val max_rec_depth : Clflags.Int_arg_helper.parsed ref

--- a/middle_end/flambda2/terms/inlining_arguments.ml
+++ b/middle_end/flambda2/terms/inlining_arguments.ml
@@ -28,6 +28,33 @@ module Args = struct
       threshold : float
     }
 
+  let matches_opt_level
+      { max_inlining_depth;
+        max_rec_depth;
+        call_cost;
+        alloc_cost;
+        prim_cost;
+        branch_cost;
+        indirect_call_cost;
+        poly_compare_cost;
+        small_function_size;
+        large_function_size;
+        threshold
+      } opt_level =
+    let module I = Flambda_features.Inlining in
+    let round_or_default : I.round_or_default = Default opt_level in
+    Int.equal max_inlining_depth (I.max_depth round_or_default)
+    && Int.equal max_rec_depth (I.max_rec_depth round_or_default)
+    && Float.equal call_cost (I.call_cost round_or_default)
+    && Float.equal alloc_cost (I.alloc_cost round_or_default)
+    && Float.equal prim_cost (I.prim_cost round_or_default)
+    && Float.equal branch_cost (I.branch_cost round_or_default)
+    && Float.equal indirect_call_cost (I.indirect_call_cost round_or_default)
+    && Float.equal poly_compare_cost (I.poly_compare_cost round_or_default)
+    && Int.equal small_function_size (I.small_function_size round_or_default)
+    && Int.equal large_function_size (I.large_function_size round_or_default)
+    && Float.equal threshold (I.threshold round_or_default)
+
   let[@ocamlformat "disable"] print ppf t =
     let { max_inlining_depth; max_rec_depth;
           call_cost; alloc_cost; prim_cost; branch_cost;
@@ -36,26 +63,18 @@ module Args = struct
           threshold;
         } = t
     in
-    let module I = Flambda_features.Inlining in
-    if Int.equal max_inlining_depth (I.max_depth Default)
-       && Int.equal max_rec_depth (I.max_rec_depth Default)
-       && Float.equal call_cost (I.call_cost Default)
-       && Float.equal alloc_cost (I.alloc_cost Default)
-       && Float.equal prim_cost (I.prim_cost Default)
-       && Float.equal branch_cost (I.branch_cost Default)
-       && Float.equal indirect_call_cost (I.indirect_call_cost Default)
-       && Float.equal poly_compare_cost (I.poly_compare_cost Default)
-       && Int.equal small_function_size (I.small_function_size Default)
-       && Int.equal large_function_size (I.large_function_size Default)
-       && Float.equal threshold (I.threshold Default)
-    then
-      Format.fprintf ppf "%t<default>%t"
-        Flambda_colours.elide
-        Flambda_colours.pop
+    let module C = Flambda_colours in
+    if matches_opt_level t Oclassic
+    then Format.fprintf ppf "%tOclassic%t" C.elide C.pop
+    else if matches_opt_level t O2
+    then Format.fprintf ppf "%tO2%t" C.elide C.pop
+    else if matches_opt_level t O3
+    then Format.fprintf ppf "%tO3%t" C.elide C.pop
     else
       Format.fprintf ppf
         "@[<hov 1>(\
          @[<hov 1>(max_inlining_depth@ %d)@]@ \
+         @[<hov 1>(max_rec_depth@ %d)@]@ \
          @[<hov 1>(call_cost@ %f)@]@ \
          @[<hov 1>(alloc_cost@ %f)@]@ \
          @[<hov 1>(prim_cost@ %f)@]@ \
@@ -67,6 +86,7 @@ module Args = struct
          @[<hov 1>(threshold@ %f)@]\
          )@]"
         max_inlining_depth
+        max_rec_depth
         call_cost
         alloc_cost
         prim_cost

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -104,74 +104,79 @@ let dump_slot_offsets () = !Flambda_backend_flags.Flambda2.Dump.slot_offsets
 let freshen_when_printing () = !Flambda_backend_flags.Flambda2.Dump.freshen
 
 module Inlining = struct
-  module D = Flambda_backend_flags.Flambda2.Inlining.Default
   module I = Flambda_backend_flags.Flambda2.Inlining
   module IH = Clflags.Int_arg_helper
   module FH = Clflags.Float_arg_helper
 
   type round_or_default =
     | Round of int
-    | Default
+    | Default of Flambda_backend_flags.opt_level
 
   let depth_scaling_factor = 10 (* See [Downwards_env.enter_inlined_apply] *)
+
+  let default_for_opt_level (opt_level : Flambda_backend_flags.opt_level) =
+    match opt_level with
+    | Oclassic -> I.oclassic_arguments
+    | O2 -> I.o2_arguments
+    | O3 -> I.o3_arguments
 
   let max_depth round_or_default =
     let depth =
       match round_or_default with
       | Round round -> IH.get ~key:round !I.max_depth
-      | Default -> D.max_depth
+      | Default opt_level -> (default_for_opt_level opt_level).max_depth
     in
     depth * depth_scaling_factor
 
   let max_rec_depth round_or_default =
     match round_or_default with
     | Round round -> IH.get ~key:round !I.max_rec_depth
-    | Default -> D.max_rec_depth
+    | Default opt_level -> (default_for_opt_level opt_level).max_rec_depth
 
   let call_cost round_or_default =
     match round_or_default with
     | Round round -> FH.get ~key:round !I.call_cost
-    | Default -> D.call_cost
+    | Default opt_level -> (default_for_opt_level opt_level).call_cost
 
   let alloc_cost round_or_default =
     match round_or_default with
     | Round round -> FH.get ~key:round !I.alloc_cost
-    | Default -> D.alloc_cost
+    | Default opt_level -> (default_for_opt_level opt_level).alloc_cost
 
   let prim_cost round_or_default =
     match round_or_default with
     | Round round -> FH.get ~key:round !I.prim_cost
-    | Default -> D.prim_cost
+    | Default opt_level -> (default_for_opt_level opt_level).prim_cost
 
   let branch_cost round_or_default =
     match round_or_default with
     | Round round -> FH.get ~key:round !I.branch_cost
-    | Default -> D.branch_cost
+    | Default opt_level -> (default_for_opt_level opt_level).branch_cost
 
   let indirect_call_cost round_or_default =
     match round_or_default with
     | Round round -> FH.get ~key:round !I.indirect_call_cost
-    | Default -> D.indirect_call_cost
+    | Default opt_level -> (default_for_opt_level opt_level).indirect_call_cost
 
   let poly_compare_cost round_or_default =
     match round_or_default with
     | Round round -> FH.get ~key:round !I.poly_compare_cost
-    | Default -> D.poly_compare_cost
+    | Default opt_level -> (default_for_opt_level opt_level).poly_compare_cost
 
   let small_function_size round_or_default =
     match round_or_default with
     | Round round -> IH.get ~key:round !I.small_function_size
-    | Default -> D.small_function_size
+    | Default opt_level -> (default_for_opt_level opt_level).small_function_size
 
   let large_function_size round_or_default =
     match round_or_default with
     | Round round -> IH.get ~key:round !I.large_function_size
-    | Default -> D.large_function_size
+    | Default opt_level -> (default_for_opt_level opt_level).large_function_size
 
   let threshold round_or_default =
     match round_or_default with
     | Round round -> FH.get ~key:round !I.threshold
-    | Default -> D.threshold
+    | Default opt_level -> (default_for_opt_level opt_level).threshold
 
   let speculative_inlining_only_if_arguments_useful () =
     !Flambda_backend_flags.Flambda2.Inlining

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -75,7 +75,7 @@ val freshen_when_printing : unit -> bool
 module Inlining : sig
   type round_or_default =
     | Round of int
-    | Default
+    | Default of Flambda_backend_flags.opt_level
 
   val depth_scaling_factor : int
 


### PR DESCRIPTION
The first of some printing fixes.  This one causes inlining arguments to be summarised as `Oclassic`, `O2` and `O3` when they match the defaults.  A bug fix is included: `max_rec_depth` wasn't getting printed.