### PR TITLE
Rewriting of continuation parameter aliases

### DIFF
--- a/middle_end/flambda2/simplify/env/continuation_uses.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses.ml
@@ -96,6 +96,11 @@ let get_arg_types_by_use_id t =
         arg_maps arg_types)
     empty_arg_maps t.uses
 
+let get_use_ids t =
+  List.fold_left
+    (fun uses use -> Apply_cont_rewrite_id.Set.add (U.id use) uses)
+    Apply_cont_rewrite_id.Set.empty t.uses
+
 let get_typing_env_no_more_than_one_use t =
   match t.uses with
   | [] -> None

--- a/middle_end/flambda2/simplify/env/continuation_uses.mli
+++ b/middle_end/flambda2/simplify/env/continuation_uses.mli
@@ -44,6 +44,8 @@ type arg_types_by_use_id = arg_at_use Apply_cont_rewrite_id.Map.t list
 
 val get_arg_types_by_use_id : t -> arg_types_by_use_id
 
+val get_use_ids : t -> Apply_cont_rewrite_id.Set.t
+
 val number_of_uses : t -> int
 
 val arity : t -> Flambda_arity.t

--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -93,10 +93,7 @@ type continuation_parameters =
   }
 
 type continuation_param_aliases =
-  { aliases : Variable.t Variable.Map.t;
-    (* TODO Verify if this is useful *)
-    aliases_kind : Flambda_kind.t Variable.Map.t;
-    (* TODO Verify if this is useful *)
+  { aliases_kind : Flambda_kind.t Variable.Map.t;
     continuation_parameters : continuation_parameters Continuation.Map.t
   }
 
@@ -199,31 +196,27 @@ let [@ocamlformat "disable"] print ppf { stack; map; extra; dummy_toplevel_cont 
     print_extra extra
 
 let [@ocamlformat "disable"] print_continuation_param_aliases ppf
-    { aliases; aliases_kind; continuation_parameters } =
+    { aliases_kind; continuation_parameters } =
   Format.fprintf ppf
     "@[<hov 1>(\
-       @[<hov 1>(aliases@ %a)@]@ \
        @[<hov 1>(aliases_kind@ %a)@]@ \
        @[<hov 1>(continuation_parameters@ %a)@]\
      )@]"
-    (Variable.Map.print Variable.print) aliases
     (Variable.Map.print Flambda_kind.print) aliases_kind
     (Continuation.Map.print print_continuation_parameters) continuation_parameters
 
 let [@ocamlformat "disable"] _print_result ppf
     { dead_variable_result = { required_names; reachable_code_ids };
-      continuation_param_aliases = { aliases; aliases_kind; continuation_parameters } } =
+      continuation_param_aliases = { aliases_kind; continuation_parameters } } =
   Format.fprintf ppf
     "@[<hov 1>(\
        @[<hov 1>(required_names@ %a)@]@ \
        @[<hov 1>(reachable_code_ids@ %a)@]@ \
-       @[<hov 1>(aliases@ %a)@]@ \
        @[<hov 1>(aliases_kind@ %a)@]@ \
        @[<hov 1>(continuation_parameters@ %a)@]\
      )@]"
     Name.Set.print required_names
     Reachable_code_ids.print reachable_code_ids
-    (Variable.Map.print Variable.print) aliases
     (Variable.Map.print Flambda_kind.print) aliases_kind
     (Continuation.Map.print print_continuation_parameters) continuation_parameters
 
@@ -1729,7 +1722,7 @@ let analyze ?print_name ~return_continuation ~exn_continuation
       let result =
         { dead_variable_result;
           continuation_param_aliases =
-            { aliases; aliases_kind; continuation_parameters }
+            { aliases_kind; continuation_parameters }
         }
       in
       if debug then Format.eprintf "/// result@\n%a@\n@." _print_result result;

--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -432,7 +432,7 @@ let add_apply_conts ~result_cont ~exn_cont t =
           (function
             | None -> Some (Apply_cont_rewrite_id.Set.singleton rewrite_id)
             | Some set -> Some (Apply_cont_rewrite_id.Set.add rewrite_id set))
-          elt.apply_result_conts
+          elt.apply_exn_conts
       in
       let add_func_result cont rewrite_id apply_cont_args =
         Continuation.Map.update cont

--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -948,7 +948,7 @@ module Dominator_graph = struct
           Apply_cont_rewrite_id.Map.fold
             (fun _rewrite_id args t ->
               Numeric_types.Int.Map.fold
-                (fun i dst t ->
+                (fun i (dst : Cont_arg.t) t ->
                   (* Note on the direction of the edge:
 
                      We later do a dominator analysis on this graph. To do so,
@@ -956,7 +956,12 @@ module Dominator_graph = struct
                      used as argument (of an apply_cont), that maps to ~src (as
                      param of a continuation). *)
                   let src = params.(i) in
-                  add_edge ~src ~dst t)
+                  match dst with
+                  | Simple dst -> add_edge ~src ~dst t
+                  | Function_result -> add_root src t
+                  | New_let_binding (var, _) ->
+                    let t = add_root var t in
+                    add_edge ~src ~dst:(Simple.var var) t)
                 args t)
             rewrite_ids t)
       elt.apply_cont_args t

--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -231,32 +231,36 @@ let extend_args_with_extra_args t =
                   let extra_args = EPA.extra_args epa in
                   Apply_cont_rewrite_id.Map.mapi
                     (fun rewrite_id args ->
-                      let extra_args =
+                      match
                         Apply_cont_rewrite_id.Map.find rewrite_id extra_args
-                      in
-                      let max_arg, _ = Numeric_types.Int.Map.max_binding args in
-                      let extra_args =
-                        List.map
-                          (function
-                            | EPA.Extra_arg.Already_in_scope s ->
-                              Cont_arg.Simple s
-                            | EPA.Extra_arg.New_let_binding (v, prim) ->
-                              Cont_arg.New_let_binding
-                                (v, Flambda_primitive.free_names prim)
-                            | EPA.Extra_arg.New_let_binding_with_named_args
-                                (v, _) ->
-                              Cont_arg.New_let_binding
-                                (v, Name_occurrences.empty))
-                          extra_args
-                      in
-                      let _, args =
-                        List.fold_left
-                          (fun (i, args) extra_arg ->
-                            i + 1, Numeric_types.Int.Map.add i extra_arg args)
-                          (max_arg + 1, args)
-                          extra_args
-                      in
-                      args)
+                      with
+                      | exception Not_found -> args
+                      | extra_args ->
+                        let max_arg, _ =
+                          Numeric_types.Int.Map.max_binding args
+                        in
+                        let extra_args =
+                          List.map
+                            (function
+                              | EPA.Extra_arg.Already_in_scope s ->
+                                Cont_arg.Simple s
+                              | EPA.Extra_arg.New_let_binding (v, prim) ->
+                                Cont_arg.New_let_binding
+                                  (v, Flambda_primitive.free_names prim)
+                              | EPA.Extra_arg.New_let_binding_with_named_args
+                                  (v, _) ->
+                                Cont_arg.New_let_binding
+                                  (v, Name_occurrences.empty))
+                            extra_args
+                        in
+                        let _, args =
+                          List.fold_left
+                            (fun (i, args) extra_arg ->
+                              i + 1, Numeric_types.Int.Map.add i extra_arg args)
+                            (max_arg + 1, args)
+                            extra_args
+                        in
+                        args)
                     rewrite_ids)
               elt.apply_cont_args
           in

--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -1572,8 +1572,8 @@ module Control_flow_graph = struct
         cont_map
 
     let edge ~ctx ~color ppf src dst =
-      Format.fprintf ppf "%a -> %a [color=\"%s\"];@\n" (node_id ~ctx) src
-        (node_id ~ctx) dst color
+      Format.fprintf ppf "%a -> %a [color=\"%s\"];@\n" (node_id ~ctx) dst
+        (node_id ~ctx) src color
 
     let edges ~ctx ~color ppf edge_map =
       Continuation.Map.iter

--- a/middle_end/flambda2/simplify/env/data_flow.ml
+++ b/middle_end/flambda2/simplify/env/data_flow.ml
@@ -948,8 +948,7 @@ module Dominator_graph = struct
 
   module Dot = struct
     let node_id ~ctx ppf (variable : Variable.t) =
-      (* note: this is ... somewhat safe *)
-      Format.fprintf ppf "node_%d_%d" ctx (Obj.magic variable : int)
+      Format.fprintf ppf "node_%d_%d" ctx (variable :> int)
 
     let node ~ctx ~root ppf var =
       if root

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -78,11 +78,19 @@ val add_used_in_current_handler : Name_occurrences.t -> t -> t
 (** Add the given continuation as being used as the return continuation for a
     function call. *)
 val add_apply_conts :
-  result_cont:Continuation.t option -> exn_cont:Continuation.t -> t -> t
+  result_cont:(Apply_cont_rewrite_id.t * Continuation.t) option ->
+  exn_cont:(Apply_cont_rewrite_id.t * Continuation.t) ->
+  t ->
+  t
 
 (** Add, for the current continuation handler, uses for an apply cont of the
     given continuation with given arguments occurrences. *)
-val add_apply_cont_args : Continuation.t -> Simple.t list -> t -> t
+val add_apply_cont_args :
+  rewrite_id:Apply_cont_rewrite_id.t ->
+  Continuation.t ->
+  Simple.t list ->
+  t ->
+  t
 
 (** Add extra params and args to a continuation. *)
 val add_extra_params_and_args :

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -132,6 +132,9 @@ type continuation_parameters = private
     recursive_continuation_wrapper : recursive_continuation_wrapper
   }
 
+val print_continuation_parameters :
+  Format.formatter -> continuation_parameters -> unit
+
 type continuation_param_aliases =
   { aliases : Variable.t Variable.Map.t;
     (* TODO Verify if this is useful *)

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -79,7 +79,7 @@ val add_used_in_current_handler : Name_occurrences.t -> t -> t
     function call. *)
 val add_apply_conts :
   result_cont:(Apply_cont_rewrite_id.t * Continuation.t) option ->
-  exn_cont:(Apply_cont_rewrite_id.t * Exn_continuation.t) ->
+  exn_cont:Apply_cont_rewrite_id.t * Exn_continuation.t ->
   t ->
   t
 
@@ -116,10 +116,23 @@ type dead_variable_result =
     reachable_code_ids : Reachable_code_ids.t
   }
 
+type recursive_continuation_wrapper = private
+  | No_wrapper
+  | Wrapper_needed
+
+type continuation_parameters = private
+  { removed_aliased_params_and_extra_params : Variable.Set.t;
+    lets_to_introduce : Variable.t Variable.Map.t;
+    extra_args_for_aliases : Variable.Set.t;
+    recursive_continuation_wrapper : recursive_continuation_wrapper
+  }
+
 type continuation_param_aliases =
   { aliases : Variable.t Variable.Map.t;
+    (* TODO Verify if this is useful *)
     aliases_kind : Flambda_kind.t Variable.Map.t;
-    extra_args_for_aliases : Variable.Set.t Continuation.Map.t
+    (* TODO Verify if this is useful *)
+    continuation_parameters : continuation_parameters Continuation.Map.t
   }
 
 val print_continuation_param_aliases :

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -35,11 +35,12 @@ val print : Format.formatter -> t -> unit
 (* {2 Creation and updates} *)
 
 (** Empty uses *)
-val empty : t
+val empty : unit -> t
 
 (** Initialize the analysis so that the stack consists of a single toplevel
     continuation. *)
-val init_toplevel : Continuation.t -> Variable.t list -> t -> t
+val init_toplevel :
+  dummy_toplevel_cont:Continuation.t -> Variable.t list -> t -> t
 
 (** Add a new continuation on the stack. Used when entering a continuation
     handler. *)
@@ -73,7 +74,8 @@ val add_used_in_current_handler : Name_occurrences.t -> t -> t
 
 (** Add the given continuation as being used as the return continuation for a
     function call. *)
-val add_apply_result_cont : Continuation.t -> t -> t
+val add_apply_conts :
+  result_cont:Continuation.t option -> exn_cont:Continuation.t -> t -> t
 
 (** Add, for the current continuation handler, uses for an apply cont of the
     given continuation with given arguments occurrences. *)
@@ -106,6 +108,7 @@ type result = private
 
 (** Analyze the uses. *)
 val analyze :
+  ?print_name:string ->
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
   code_age_relation:Code_age_relation.t ->

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -43,7 +43,8 @@ val init_toplevel : Continuation.t -> Variable.t list -> t -> t
 
 (** Add a new continuation on the stack. Used when entering a continuation
     handler. *)
-val enter_continuation : Continuation.t -> Variable.t list -> t -> t
+val enter_continuation :
+  Continuation.t -> recursive:bool -> Variable.t list -> t -> t
 
 (** Pop the current top of the stack. Used when exiting the current continuation
     handler. *)

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -79,7 +79,7 @@ val add_used_in_current_handler : Name_occurrences.t -> t -> t
     function call. *)
 val add_apply_conts :
   result_cont:(Apply_cont_rewrite_id.t * Continuation.t) option ->
-  exn_cont:(Apply_cont_rewrite_id.t * Continuation.t) ->
+  exn_cont:(Apply_cont_rewrite_id.t * Exn_continuation.t) ->
   t ->
   t
 

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -110,6 +110,7 @@ type dead_variable_result =
 
 type continuation_param_aliases =
   { aliases : Variable.t Variable.Map.t;
+    aliases_kind : Flambda_kind.t Variable.Map.t;
     extra_args_for_aliases : Variable.Set.t Continuation.Map.t
   }
 

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -101,14 +101,25 @@ module Reachable_code_ids : sig
   val print : Format.formatter -> t -> unit
 end
 
-(** The result of an analysis of the uses of variables in continuations. *)
-type result = private
+type dead_variable_result =
   { required_names : Name.Set.t;
         (** The set of all variables that are in fact used to compute the
             returned value of the function being analyzed. *)
-    reachable_code_ids : Reachable_code_ids.t;
-    aliases : Variable.t Variable.Map.t;
-    extra_args_for_aliases : Variable.Set.t Continuation.Map.t;
+    reachable_code_ids : Reachable_code_ids.t
+  }
+
+type continuation_param_aliases =
+  { aliases : Variable.t Variable.Map.t;
+    extra_args_for_aliases : Variable.Set.t Continuation.Map.t
+  }
+
+val print_continuation_param_aliases :
+  Format.formatter -> continuation_param_aliases -> unit
+
+(** The result of an analysis of the uses of variables in continuations. *)
+type result = private
+  { dead_variable_result : dead_variable_result;
+    continuation_param_aliases : continuation_param_aliases
   }
 
 (** Analyze the uses. *)

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -106,7 +106,9 @@ type result = private
   { required_names : Name.Set.t;
         (** The set of all variables that are in fact used to compute the
             returned value of the function being analyzed. *)
-    reachable_code_ids : Reachable_code_ids.t
+    reachable_code_ids : Reachable_code_ids.t;
+    aliases : Variable.t Variable.Map.t;
+    extra_args_for_aliases : Variable.Set.t Continuation.Map.t;
   }
 
 (** Analyze the uses. *)

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -45,7 +45,12 @@ val init_toplevel :
 (** Add a new continuation on the stack. Used when entering a continuation
     handler. *)
 val enter_continuation :
-  Continuation.t -> recursive:bool -> Bound_parameters.t -> t -> t
+  Continuation.t ->
+  recursive:bool ->
+  is_exn_handler:bool ->
+  Bound_parameters.t ->
+  t ->
+  t
 
 (** Pop the current top of the stack. Used when exiting the current continuation
     handler. *)

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -136,10 +136,7 @@ val print_continuation_parameters :
   Format.formatter -> continuation_parameters -> unit
 
 type continuation_param_aliases =
-  { aliases : Variable.t Variable.Map.t;
-    (* TODO Verify if this is useful *)
-    aliases_kind : Flambda_kind.t Variable.Map.t;
-    (* TODO Verify if this is useful *)
+  { aliases_kind : Flambda_kind.t Variable.Map.t;
     continuation_parameters : continuation_parameters Continuation.Map.t
   }
 

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -40,12 +40,12 @@ val empty : unit -> t
 (** Initialize the analysis so that the stack consists of a single toplevel
     continuation. *)
 val init_toplevel :
-  dummy_toplevel_cont:Continuation.t -> Variable.t list -> t -> t
+  dummy_toplevel_cont:Continuation.t -> Bound_parameters.t -> t -> t
 
 (** Add a new continuation on the stack. Used when entering a continuation
     handler. *)
 val enter_continuation :
-  Continuation.t -> recursive:bool -> Variable.t list -> t -> t
+  Continuation.t -> recursive:bool -> Bound_parameters.t -> t -> t
 
 (** Pop the current top of the stack. Used when exiting the current continuation
     handler. *)

--- a/middle_end/flambda2/simplify/env/data_flow.mli
+++ b/middle_end/flambda2/simplify/env/data_flow.mli
@@ -51,6 +51,9 @@ val enter_continuation :
     handler. *)
 val exit_continuation : Continuation.t -> t -> t
 
+(** That variable is defined in the current handler *)
+val record_defined_var : Variable.t -> t -> t
+
 (** Add a variable binding from the current handler. *)
 val record_var_binding :
   Variable.t -> Name_occurrences.t -> generate_phantom_lets:bool -> t -> t

--- a/middle_end/flambda2/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/downwards_acc.ml
@@ -63,7 +63,7 @@ let create denv continuation_uses_env =
     shareable_constants = Static_const.Map.empty;
     used_value_slots = Name_occurrences.empty;
     lifted_constants = LCS.empty;
-    data_flow = Data_flow.empty;
+    data_flow = Data_flow.empty ();
     demoted_exn_handlers = Continuation.Set.empty;
     code_ids_to_remember = Code_id.Set.empty
   }

--- a/middle_end/flambda2/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/upwards_acc.ml
@@ -203,3 +203,5 @@ let is_demoted_exn_handler t cont =
 let slot_offsets t = t.slot_offsets
 
 let with_slot_offsets t slot_offsets = { t with slot_offsets }
+
+let continuation_param_aliases t = t.continuation_param_aliases

--- a/middle_end/flambda2/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/upwards_acc.ml
@@ -34,7 +34,7 @@ type t =
     are_rebuilding_terms : ART.t;
     generate_phantom_lets : bool;
     (* CR gbury: required_names and reachable_code_ids should be exposed in the
-       same field *)
+       same field, as a Data_flow.dead_variable_result field. *)
     required_names : Name.Set.t;
     reachable_code_ids : Data_flow.Reachable_code_ids.t Or_unknown.t;
     demoted_exn_handlers : Continuation.Set.t;

--- a/middle_end/flambda2/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda2/simplify/env/upwards_acc.mli
@@ -23,6 +23,7 @@ val create :
   required_names:Name.Set.t ->
   reachable_code_ids:Data_flow.Reachable_code_ids.t Or_unknown.t ->
   compute_slot_offsets:bool ->
+  continuation_param_aliases:Data_flow.continuation_param_aliases ->
   Upwards_env.t ->
   Downwards_acc.t ->
   t

--- a/middle_end/flambda2/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda2/simplify/env/upwards_acc.mli
@@ -103,3 +103,5 @@ val is_demoted_exn_handler : t -> Continuation.t -> bool
 val slot_offsets : t -> Slot_offsets.t Or_unknown.t
 
 val with_slot_offsets : t -> Slot_offsets.t Or_unknown.t -> t
+
+val continuation_param_aliases : t -> Data_flow.continuation_param_aliases

--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -148,6 +148,16 @@ let add_apply_cont_rewrite t cont rewrite =
   in
   { t with apply_cont_rewrites }
 
+let replace_apply_cont_rewrite t cont rewrite =
+  if not (Continuation.Map.mem cont t.apply_cont_rewrites)
+  then
+    Misc.fatal_errorf "Must redefine [Apply_cont_rewrite] for %a"
+      Continuation.print cont;
+  let apply_cont_rewrites =
+    Continuation.Map.add cont rewrite t.apply_cont_rewrites
+  in
+  { t with apply_cont_rewrites }
+
 let find_apply_cont_rewrite t cont =
   match Continuation.Map.find cont t.apply_cont_rewrites with
   | exception Not_found -> None

--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -162,8 +162,3 @@ let find_apply_cont_rewrite t cont =
   match Continuation.Map.find cont t.apply_cont_rewrites with
   | exception Not_found -> None
   | rewrite -> Some rewrite
-
-let delete_apply_cont_rewrite t cont =
-  { t with
-    apply_cont_rewrites = Continuation.Map.remove cont t.apply_cont_rewrites
-  }

--- a/middle_end/flambda2/simplify/env/upwards_env.mli
+++ b/middle_end/flambda2/simplify/env/upwards_env.mli
@@ -66,5 +66,3 @@ val add_apply_cont_rewrite : t -> Continuation.t -> Apply_cont_rewrite.t -> t
 val replace_apply_cont_rewrite : t -> Continuation.t -> Apply_cont_rewrite.t -> t
 
 val find_apply_cont_rewrite : t -> Continuation.t -> Apply_cont_rewrite.t option
-
-val delete_apply_cont_rewrite : t -> Continuation.t -> t

--- a/middle_end/flambda2/simplify/env/upwards_env.mli
+++ b/middle_end/flambda2/simplify/env/upwards_env.mli
@@ -63,6 +63,7 @@ val resolve_exn_continuation_aliases :
   t -> Exn_continuation.t -> Exn_continuation.t
 
 val add_apply_cont_rewrite : t -> Continuation.t -> Apply_cont_rewrite.t -> t
+val replace_apply_cont_rewrite : t -> Continuation.t -> Apply_cont_rewrite.t -> t
 
 val find_apply_cont_rewrite : t -> Continuation.t -> Apply_cont_rewrite.t option
 

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -230,6 +230,14 @@ let create_let uacc (bound_vars : Bound_pattern.t) (defining_expr : Named.t)
       uacc,
       let_creation_result )
 
+let create_let_binding uacc bound_vars defining_expr
+    ~free_names_of_defining_expr ~body ~cost_metrics_of_defining_expr =
+  let re, uacc, _ =
+    create_let uacc bound_vars defining_expr ~free_names_of_defining_expr ~body
+      ~cost_metrics_of_defining_expr
+  in
+  re, uacc
+
 let create_coerced_singleton_let uacc var defining_expr
     ~coercion_from_defining_expr_to_var ~free_names_of_defining_expr ~body
     ~cost_metrics_of_defining_expr =

--- a/middle_end/flambda2/simplify/expr_builder.mli
+++ b/middle_end/flambda2/simplify/expr_builder.mli
@@ -25,6 +25,15 @@
 
 open! Flambda.Import
 
+val create_let_binding :
+  Upwards_acc.t ->
+  Bound_pattern.t ->
+  Named.t ->
+  free_names_of_defining_expr:Name_occurrences.t ->
+  body:Rebuilt_expr.t ->
+  cost_metrics_of_defining_expr:Cost_metrics.t ->
+  Rebuilt_expr.t * Upwards_acc.t
+
 (** Create [Let] binding(s) around a given body. (The type of this function
     prevents it from being used to create "let symbol" bindings; use the other
     functions in this module instead.) Bindings will be elided if they are

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -68,7 +68,7 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
   in
   let dacc =
     DA.map_data_flow dacc ~f:(fun _ ->
-        Data_flow.init_toplevel dummy_toplevel_cont [] Data_flow.empty)
+        Data_flow.init_toplevel ~dummy_toplevel_cont [] (Data_flow.empty ()))
   in
   let _, uacc =
     simplify_expr dacc expr ~down_to_up:(fun dacc ~rebuild ->

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -68,7 +68,8 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
   in
   let dacc =
     DA.map_data_flow dacc ~f:(fun _ ->
-        Data_flow.init_toplevel ~dummy_toplevel_cont [] (Data_flow.empty ()))
+        Data_flow.init_toplevel ~dummy_toplevel_cont Bound_parameters.empty
+          (Data_flow.empty ()))
   in
   let _, uacc =
     simplify_expr dacc expr ~down_to_up:(fun dacc ~rebuild ->

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -92,7 +92,7 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
            Thus we here provide empty/dummy values for the used_value_slots and
            code_age_relation, and ignore the reachable_code_id part of the
            data_flow analysis. *)
-        let ({ required_names; reachable_code_ids = _ } : Data_flow.result) =
+        let ({ required_names; reachable_code_ids = _; _ } : Data_flow.result) =
           Data_flow.analyze data_flow ~code_age_relation:Code_age_relation.empty
             ~used_value_slots:Unknown ~return_continuation:function_return_cont
             ~exn_continuation:(Exn_continuation.exn_handler exn_continuation)

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -92,7 +92,10 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
            Thus we here provide empty/dummy values for the used_value_slots and
            code_age_relation, and ignore the reachable_code_id part of the
            data_flow analysis. *)
-        let ({ required_names; reachable_code_ids = _; _ } : Data_flow.result) =
+        let ({ dead_variable_result = { required_names; reachable_code_ids = _ };
+               continuation_param_aliases
+             }
+              : Data_flow.result) =
           Data_flow.analyze data_flow ~code_age_relation:Code_age_relation.empty
             ~used_value_slots:Unknown ~return_continuation:function_return_cont
             ~exn_continuation:(Exn_continuation.exn_handler exn_continuation)
@@ -118,7 +121,7 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
         in
         let uacc =
           UA.create ~required_names ~reachable_code_ids:Unknown
-            ~compute_slot_offsets:false uenv dacc
+            ~compute_slot_offsets:false ~continuation_param_aliases uenv dacc
         in
         rebuild uacc ~after_rebuild:(fun expr uacc -> expr, uacc))
   in

--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -98,6 +98,13 @@ module Continuation_handler = struct
     else
       Continuation_handler.create params ~handler
         ~free_names_of_handler:(Known free_names_of_handler) ~is_exn_handler
+
+  let create' are_rebuilding params ~handler ~is_exn_handler =
+    if ART.do_not_rebuild_terms are_rebuilding
+    then dummy
+    else
+      Continuation_handler.create params ~handler ~free_names_of_handler:Unknown
+        ~is_exn_handler
 end
 
 let create_non_recursive_let_cont are_rebuilding cont handler ~body
@@ -116,6 +123,12 @@ let create_non_recursive_let_cont' are_rebuilding cont handler ~body
     Let_cont.create_non_recursive' ~cont handler ~body
       ~num_free_occurrences_of_cont_in_body:
         (Known num_free_occurrences_of_cont_in_body) ~is_applied_with_traps
+
+let create_non_recursive_let_cont_without_free_names are_rebuilding cont handler ~body =
+  if ART.do_not_rebuild_terms are_rebuilding
+  then term_not_rebuilt
+  else
+    Let_cont.create_non_recursive cont handler ~body ~free_names_of_body:Unknown
 
 let create_recursive_let_cont are_rebuilding handlers ~body =
   if ART.do_not_rebuild_terms are_rebuilding

--- a/middle_end/flambda2/simplify/rebuilt_expr.mli
+++ b/middle_end/flambda2/simplify/rebuilt_expr.mli
@@ -87,6 +87,13 @@ module Continuation_handler : sig
     free_names_of_handler:Name_occurrences.t ->
     is_exn_handler:bool ->
     t
+
+  val create' :
+    Are_rebuilding_terms.t ->
+    Bound_parameters.t ->
+    handler:rebuilt_expr ->
+    is_exn_handler:bool ->
+    t
 end
 
 val create_non_recursive_let_cont :
@@ -104,6 +111,13 @@ val create_non_recursive_let_cont' :
   body:t ->
   num_free_occurrences_of_cont_in_body:Num_occurrences.t ->
   is_applied_with_traps:bool ->
+  t
+
+val create_non_recursive_let_cont_without_free_names :
+  Are_rebuilding_terms.t ->
+  Continuation.t ->
+  Continuation_handler.t ->
+  body:t ->
   t
 
 val create_recursive_let_cont :

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -46,8 +46,7 @@ let run ~cmx_loader ~round unit =
   let dacc = DA.create denv Continuation_uses_env.empty in
   let body, uacc =
     Simplify_expr.simplify_toplevel dacc (FU.body unit)
-      ~params:Bound_parameters.empty
-      ~return_continuation
+      ~params:Bound_parameters.empty ~return_continuation
       ~return_arity:
         (Flambda_arity.With_subkinds.create [K.With_subkind.any_value])
       ~exn_continuation ~return_cont_scope ~exn_cont_scope

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -45,7 +45,9 @@ let run ~cmx_loader ~round unit =
      remark for the cmx contents) *)
   let dacc = DA.create denv Continuation_uses_env.empty in
   let body, uacc =
-    Simplify_expr.simplify_toplevel dacc (FU.body unit) ~return_continuation
+    Simplify_expr.simplify_toplevel dacc (FU.body unit)
+      ~params:Bound_parameters.empty
+      ~return_continuation
       ~return_arity:
         (Flambda_arity.With_subkinds.create [K.With_subkind.any_value])
       ~exn_continuation ~return_cont_scope ~exn_cont_scope

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -133,12 +133,6 @@ let simplify_apply_cont dacc apply_cont ~down_to_up =
   let { S.simples = args; simple_tys = arg_types } =
     S.simplify_simples dacc (AC.args apply_cont)
   in
-  let dacc =
-    let record_args_for_data_flow data_flow =
-      Data_flow.add_apply_cont_args (AC.continuation apply_cont) args data_flow
-    in
-    DA.map_data_flow dacc ~f:record_args_for_data_flow
-  in
   let use_kind =
     Simplify_common.apply_cont_use_kind ~context:Apply_cont_expr apply_cont
   in
@@ -146,6 +140,14 @@ let simplify_apply_cont dacc apply_cont ~down_to_up =
     DA.record_continuation_use dacc
       (AC.continuation apply_cont)
       use_kind ~env_at_use:(DA.denv dacc) ~arg_types
+  in
+  let dacc =
+    let record_args_for_data_flow data_flow =
+      Data_flow.add_apply_cont_args
+        (AC.continuation apply_cont)
+        ~rewrite_id args data_flow
+    in
+    DA.map_data_flow dacc ~f:record_args_for_data_flow
   in
   let dbg = AC.debuginfo apply_cont in
   let dbg = DE.add_inlined_debuginfo (DA.denv dacc) dbg in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -39,9 +39,11 @@ let warn_not_inlined_if_needed apply reason =
 let record_free_names_of_apply_as_used0 apply ~use_id ~exn_cont_use_id data_flow
     =
   let data_flow =
+    (* TODO, free names contains extra args of exn continuation, this is too
+       much, we should get rid of that *)
     Data_flow.add_used_in_current_handler (Apply.free_names apply) data_flow
   in
-  let exn_cont = Exn_continuation.exn_handler (Apply.exn_continuation apply) in
+  let exn_cont = Apply.exn_continuation apply in
   let result_cont =
     match Apply.continuation apply, use_id with
     | Never_returns, None -> None

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -36,20 +36,25 @@ let warn_not_inlined_if_needed apply reason =
 
 (* Note that this considers that the extra arguments of the exn_continuation are
    always used. *)
-let record_free_names_of_apply_as_used0 apply data_flow =
+let record_free_names_of_apply_as_used0 apply ~use_id ~exn_cont_use_id data_flow
+    =
   let data_flow =
     Data_flow.add_used_in_current_handler (Apply.free_names apply) data_flow
   in
   let exn_cont = Exn_continuation.exn_handler (Apply.exn_continuation apply) in
   let result_cont =
-    match Apply.continuation apply with
-    | Never_returns -> None
-    | Return k -> Some k
+    match Apply.continuation apply, use_id with
+    | Never_returns, None -> None
+    | Return k, Some use_id -> Some (use_id, k)
+    | Never_returns, Some _ | Return _, None -> assert false
   in
-  Data_flow.add_apply_conts ~exn_cont ~result_cont data_flow
+  Data_flow.add_apply_conts
+    ~exn_cont:(exn_cont_use_id, exn_cont)
+    ~result_cont data_flow
 
-let record_free_names_of_apply_as_used dacc apply =
-  DA.map_data_flow dacc ~f:(record_free_names_of_apply_as_used0 apply)
+let record_free_names_of_apply_as_used dacc ~use_id ~exn_cont_use_id apply =
+  DA.map_data_flow dacc
+    ~f:(record_free_names_of_apply_as_used0 ~use_id ~exn_cont_use_id apply)
 
 let simplify_direct_tuple_application ~simplify_expr dacc apply
     ~params_arity:param_arity ~result_arity ~apply_alloc_mode
@@ -180,7 +185,6 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
   match inlined with
   | Some (dacc, inlined) -> simplify_expr dacc inlined ~down_to_up
   | None ->
-    let dacc = record_free_names_of_apply_as_used dacc apply in
     let dacc, use_id =
       match Apply.continuation apply with
       | Never_returns -> dacc, None
@@ -258,6 +262,9 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
         ~arg_types:
           (T.unknown_types_from_arity_with_subkinds
              (Exn_continuation.arity (Apply.exn_continuation apply)))
+    in
+    let dacc =
+      record_free_names_of_apply_as_used dacc ~use_id ~exn_cont_use_id apply
     in
     down_to_up dacc
       ~rebuild:
@@ -734,7 +741,6 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
       ~tracker:(DE.inlining_history_tracker denv)
       ~apply ();
   let env_at_use = denv in
-  let dacc = record_free_names_of_apply_as_used dacc apply in
   let dacc, exn_cont_use_id =
     DA.record_continuation_use dacc
       (Exn_continuation.exn_handler (Apply.exn_continuation apply))
@@ -793,6 +799,10 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
           apply_alloc_mode
       in
       call_kind, use_id, dacc
+  in
+  let dacc =
+    record_free_names_of_apply_as_used ~use_id:(Some use_id) ~exn_cont_use_id
+      dacc apply
   in
   down_to_up dacc
     ~rebuild:
@@ -950,7 +960,6 @@ let simplify_method_call dacc apply ~callee_ty ~kind:_ ~obj ~arg_types
     Misc.fatal_errorf
       "All arguments to a method call must be of kind [Value]:@ %a" Apply.print
       apply;
-  let dacc = record_free_names_of_apply_as_used dacc apply in
   let dacc, use_id =
     DA.record_continuation_use dacc apply_cont
       (Non_inlinable { escaping = true })
@@ -964,6 +973,10 @@ let simplify_method_call dacc apply ~callee_ty ~kind:_ ~obj ~arg_types
       ~arg_types:
         (T.unknown_types_from_arity_with_subkinds
            (Exn_continuation.arity (Apply.exn_continuation apply)))
+  in
+  let dacc =
+    record_free_names_of_apply_as_used dacc ~use_id:(Some use_id)
+      ~exn_cont_use_id apply
   in
   down_to_up dacc ~rebuild:(rebuild_method_call apply ~use_id ~exn_cont_use_id)
 
@@ -1019,7 +1032,6 @@ let simplify_c_call ~simplify_expr dacc apply ~callee_ty ~param_arity
     in
     simplify_expr dacc expr ~down_to_up
   | Unchanged { return_types } ->
-    let dacc = record_free_names_of_apply_as_used dacc apply in
     let dacc, use_id =
       match Apply.continuation apply with
       | Return apply_continuation ->
@@ -1047,6 +1059,9 @@ let simplify_c_call ~simplify_expr dacc apply ~callee_ty ~param_arity
         ~arg_types:
           (T.unknown_types_from_arity_with_subkinds
              (Exn_continuation.arity (Apply.exn_continuation apply)))
+    in
+    let dacc =
+      record_free_names_of_apply_as_used dacc ~use_id ~exn_cont_use_id apply
     in
     down_to_up dacc
       ~rebuild:(rebuild_c_call apply ~use_id ~exn_cont_use_id ~return_arity)

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -38,10 +38,15 @@ let warn_not_inlined_if_needed apply reason =
    always used. *)
 let record_free_names_of_apply_as_used0 apply ~use_id ~exn_cont_use_id data_flow
     =
+  let free_names_of_function_and_args =
+    let callee = Apply.callee apply in
+    let args = Apply.args apply in
+    Name_occurrences.union (Simple.free_names callee)
+      (Simple.List.free_names args)
+  in
   let data_flow =
-    (* TODO, free names contains extra args of exn continuation, this is too
-       much, we should get rid of that *)
-    Data_flow.add_used_in_current_handler (Apply.free_names apply) data_flow
+    Data_flow.add_used_in_current_handler free_names_of_function_and_args
+      data_flow
   in
   let exn_cont = Apply.exn_continuation apply in
   let result_cont =

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -34,8 +34,6 @@ let warn_not_inlined_if_needed apply reason =
       (Debuginfo.to_location (Apply.dbg apply))
       (Warnings.Inlining_impossible reason)
 
-(* Note that this considers that the extra arguments of the exn_continuation are
-   always used. *)
 let record_free_names_of_apply_as_used0 apply ~use_id ~exn_cont_use_id data_flow
     =
   let free_names_of_function_and_args =

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -40,9 +40,13 @@ let record_free_names_of_apply_as_used0 apply data_flow =
   let data_flow =
     Data_flow.add_used_in_current_handler (Apply.free_names apply) data_flow
   in
-  match Apply.continuation apply with
-  | Never_returns -> data_flow
-  | Return k -> Data_flow.add_apply_result_cont k data_flow
+  let exn_cont = Exn_continuation.exn_handler (Apply.exn_continuation apply) in
+  let result_cont =
+    match Apply.continuation apply with
+    | Never_returns -> None
+    | Return k -> Some k
+  in
+  Data_flow.add_apply_conts ~exn_cont ~result_cont data_flow
 
 let record_free_names_of_apply_as_used dacc apply =
   DA.map_data_flow dacc ~f:(record_free_names_of_apply_as_used0 apply)

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -41,6 +41,7 @@ type 'a expr_simplifier =
 type simplify_toplevel =
   Downwards_acc.t ->
   Expr.t ->
+  params:Bound_parameters.t ->
   return_continuation:Continuation.t ->
   return_arity:Flambda_arity.With_subkinds.t ->
   exn_continuation:Continuation.t ->

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -75,6 +75,7 @@ type 'a expr_simplifier =
 type simplify_toplevel =
   Downwards_acc.t ->
   Expr.t ->
+  params:Bound_parameters.t ->
   return_continuation:Continuation.t ->
   return_arity:Flambda_arity.With_subkinds.t ->
   exn_continuation:Continuation.t ->

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -81,7 +81,10 @@ and simplify_toplevel dacc expr ~params ~return_continuation ~return_arity
             assert false
           | Closure { code_id; _ } -> Code_id.name code_id
         in
-        let ({ required_names; reachable_code_ids; _ } : Data_flow.result) =
+        let ({ dead_variable_result = { required_names; reachable_code_ids };
+               continuation_param_aliases
+             }
+              : Data_flow.result) =
           Data_flow.analyze data_flow ~print_name ~code_age_relation
             ~used_value_slots ~return_continuation ~exn_continuation
         in
@@ -106,7 +109,7 @@ and simplify_toplevel dacc expr ~params ~return_continuation ~return_arity
         in
         let uacc =
           UA.create ~required_names ~reachable_code_ids
-            ~compute_slot_offsets:true uenv dacc
+            ~compute_slot_offsets:true ~continuation_param_aliases uenv dacc
         in
         rebuild uacc ~after_rebuild:(fun expr uacc -> expr, uacc))
   in

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -49,9 +49,7 @@ and simplify_toplevel dacc expr ~params ~return_continuation ~return_arity
   in
   let dacc =
     DA.map_data_flow dacc
-      ~f:
-        (Data_flow.init_toplevel ~dummy_toplevel_cont
-           (Bound_parameters.vars params))
+      ~f:(Data_flow.init_toplevel ~dummy_toplevel_cont params)
   in
   let expr, uacc =
     simplify_expr dacc expr ~down_to_up:(fun dacc ~rebuild ->

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -39,7 +39,7 @@ let rec simplify_expr dacc expr ~down_to_up =
     down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
         EB.rebuild_invalid uacc (Message message) ~after_rebuild)
 
-and simplify_toplevel dacc expr ~return_continuation ~return_arity
+and simplify_toplevel dacc expr ~params ~return_continuation ~return_arity
     ~exn_continuation ~return_cont_scope ~exn_cont_scope =
   (* The usage analysis needs a continuation whose handler holds the toplevel
      code of the function. Since such a continuation does not exist, we create a
@@ -48,7 +48,10 @@ and simplify_toplevel dacc expr ~return_continuation ~return_arity
     Continuation.create ~name:"dummy_toplevel_continuation" ()
   in
   let dacc =
-    DA.map_data_flow dacc ~f:(Data_flow.init_toplevel ~dummy_toplevel_cont [])
+    DA.map_data_flow dacc
+      ~f:
+        (Data_flow.init_toplevel ~dummy_toplevel_cont
+           (Bound_parameters.vars params))
   in
   let expr, uacc =
     simplify_expr dacc expr ~down_to_up:(fun dacc ~rebuild ->

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -81,7 +81,7 @@ and simplify_toplevel dacc expr ~params ~return_continuation ~return_arity
             assert false
           | Closure { code_id; _ } -> Code_id.name code_id
         in
-        let ({ required_names; reachable_code_ids } : Data_flow.result) =
+        let ({ required_names; reachable_code_ids; _ } : Data_flow.result) =
           Data_flow.analyze data_flow ~print_name ~code_age_relation
             ~used_value_slots ~return_continuation ~exn_continuation
         in

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -173,11 +173,6 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
                 (Name_occurrences.singleton_variable bound_to Name_mode.normal)
               ~cost_metrics_of_defining_expr:Cost_metrics.zero ~body:handler
           in
-          (* let var_occur =
-           *   Name_occurrences.with_only_variables (UA.name_occurrences uacc)
-           * in
-           * Format.printf "ADD ALIAS LET %a = %a@.%a@." Variable.print var
-           *   Variable.print alias Name_occurrences.print var_occur; *)
           handler, uacc)
         continuation_parameters.lets_to_introduce (handler, uacc)
     in
@@ -204,9 +199,6 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
   let uacc, params, new_phantom_params, handler, free_names, cost_metrics =
     match recursive with
     | Recursive -> (
-      (* Format.printf "rebuild_one_continuation_handler %a@." Continuation.print
-       *   cont; *)
-
       (* In the recursive case, we have already added an apply_cont_rewrite for
          the recursive continuation to eliminate unused parameters in its
          handler. *)

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -805,7 +805,6 @@ type make_rewrite_context =
 
 let make_rewrite_for_recursive_continuation uacc ~cont ~original_cont_scope
     ~original_params ~context ~extra_params_and_args =
-  (* Format.printf "PARAMS: %a@." Bound_parameters.print original_params; *)
   let extra_params_and_args =
     match context with
     | In_handler -> extra_params_and_args
@@ -886,31 +885,9 @@ let recursive_let_cont_handler_wrapper_params uacc ~cont ~rewrite =
   let params = List.filter kept_param (original_params @ used_extra_params) in
   Bound_parameters.create params
 
-(* let rename_param bp =
- *   let var = BP.var bp in
- *   let kind = BP.kind bp in
- *   match Variable.Map.find var aliases with
- *   | exception Not_found -> bp
- *   | alias -> BP.create alias kind
- * in *)
-(* let original_params =
- *   Bound_parameters.to_list @@ Apply_cont_rewrite.original_params rewrite
- * in
- * let used_params = Apply_cont_rewrite.used_params rewrite in
- * let used_original_params =
- *   List.filter (fun param -> BP.Set.mem param used_params) original_params
- * in
- * let used_extra_params =
- *   Bound_parameters.to_list @@ Apply_cont_rewrite.used_extra_params rewrite
- * in
- * Bound_parameters.create
- *   (List.map rename_param (used_original_params @ used_extra_params)) *)
-
 let rebuild_recursive_let_cont_handlers cont ~params ~original_cont_scope
     cont_handler ~handler uacc ~after_rebuild ~extra_params_and_args
     ~original_params ~rewrite_ids =
-  (* Format.printf "rebuild_recursive_let_cont_handlers %a@." Continuation.print
-   *   cont; *)
   let uacc =
     UA.map_uenv uacc ~f:(fun uenv ->
         UE.add_non_inlinable_continuation uenv cont original_cont_scope ~params

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -715,9 +715,7 @@ let after_downwards_traversal_of_non_recursive_let_cont_body ~simplify_expr
     params ~handler ~down_to_up dacc_after_body ~rebuild:rebuild_body =
   let dacc_after_body =
     DA.map_data_flow dacc_after_body
-      ~f:
-        (Data_flow.enter_continuation cont ~recursive:false
-           (Bound_parameters.vars params))
+      ~f:(Data_flow.enter_continuation cont ~recursive:false params)
   in
   (* Before the upwards traversal of the body, we do the downwards traversal of
      the handler. *)
@@ -830,7 +828,9 @@ let prepare_to_rebuild_one_recursive_let_cont_handler cont params
     let Data_flow.{ extra_args_for_aliases; _ } =
       UA.continuation_param_aliases uacc
     in
-    let required_extra_args = Continuation.Map.find cont extra_args_for_aliases in
+    let required_extra_args =
+      Continuation.Map.find cont extra_args_for_aliases
+    in
     assert (Variable.Set.is_empty required_extra_args)
   in
   let extra_params_and_args =
@@ -911,9 +911,7 @@ let simplify_recursive_let_cont_handlers ~simplify_expr ~denv_before_body
     ~original_cont_scope ~down_to_up =
   let dacc_after_body =
     DA.map_data_flow dacc_after_body
-      ~f:
-        (Data_flow.enter_continuation cont ~recursive:true
-           (Bound_parameters.vars params))
+      ~f:(Data_flow.enter_continuation cont ~recursive:true params)
   in
   let denv =
     DE.add_parameters_with_unknown_types ~at_unit_toplevel:false

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -903,6 +903,16 @@ let rebuild_recursive_let_cont_handlers cont ~params ~original_cont_scope
   in
   let some_params = recursive_let_cont_handler_wrapper_params ~rewrite in
   let uacc =
+    (* If the arguments of the wrapper continuation and the recursive
+       continuation are different, we need to remove the arguments of the
+       wrapper from the free names of the handlers.
+
+       It is correct to do, even when no wrapper are going to be introduced: In
+       that case the rewrite inside the handler and the one for the body are the
+       same: the parameters computed by
+       [recursive_let_cont_handler_wrapper_params] are exactly the same as the
+       recursive continuation, which where already removed from uacc in
+       after_one_recursive_let_cont_handler_rebuilt *)
     let name_occurrences =
       List.fold_left
         (fun name_occurrences param ->

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -657,7 +657,9 @@ let after_downwards_traversal_of_non_recursive_let_cont_body ~simplify_expr
     params ~handler ~down_to_up dacc_after_body ~rebuild:rebuild_body =
   let dacc_after_body =
     DA.map_data_flow dacc_after_body
-      ~f:(Data_flow.enter_continuation cont (Bound_parameters.vars params))
+      ~f:
+        (Data_flow.enter_continuation cont ~recursive:false
+           (Bound_parameters.vars params))
   in
   (* Before the upwards traversal of the body, we do the downwards traversal of
      the handler. *)
@@ -836,7 +838,9 @@ let simplify_recursive_let_cont_handlers ~simplify_expr ~denv_before_body
     ~original_cont_scope ~down_to_up =
   let dacc_after_body =
     DA.map_data_flow dacc_after_body
-      ~f:(Data_flow.enter_continuation cont (Bound_parameters.vars params))
+      ~f:
+        (Data_flow.enter_continuation cont ~recursive:true
+           (Bound_parameters.vars params))
   in
   let denv =
     DE.add_parameters_with_unknown_types ~at_unit_toplevel:false

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -181,26 +181,6 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
           handler, uacc)
         continuation_parameters.lets_to_introduce (handler, uacc)
     in
-    (* let add_lets_around_handler uacc ~extra_params handler = * (\*
-       Format.printf "EPA: %a@." EPA.print extra_params_and_args; *\) * let
-       handler, uacc = * List.fold_left * (fun (handler, uacc) bp -> * let var =
-       BP.var bp in * let alias = * match Variable.Map.find var aliases with * |
-       exception Not_found -> None * | alias -> if Variable.equal alias var then
-       None else Some alias * in * match alias with * | None -> handler, uacc *
-       | Some alias -> * (\* Format.printf "ADD ALIAS LET %a = %a@."
-       Variable.print var * * Variable.print alias; *\) * let bound_pattern = *
-       Bound_pattern.singleton (Bound_var.create var Name_mode.normal) * in *
-       let named = Named.create_simple (Simple.var alias) in * let handler, uacc
-       = * Expr_builder.create_let_binding uacc bound_pattern named *
-       ~free_names_of_defining_expr: * (Name_occurrences.singleton_variable
-       alias Name_mode.normal) *
-       ~cost_metrics_of_defining_expr:Cost_metrics.zero ~body:handler * in * (\*
-       let var_occur = * * Name_occurrences.with_only_variables
-       (UA.name_occurrences uacc) * * in * * Format.printf "ADD ALIAS LET %a =
-       %a@.%a@." Variable.print var * * Variable.print alias
-       Name_occurrences.print var_occur; *\) * handler, uacc) * (handler, uacc)
-       * (Bound_parameters.to_list params @ Bound_parameters.to_list
-       extra_params) * in *)
     let handler, uacc =
       (* We might need to place lifted constants now, as they could depend on
          continuation parameters. As such we must also compute the unused
@@ -1121,61 +1101,6 @@ let rebuild_recursive_let_cont ~body handlers ~cost_metrics_of_handlers
         : Data_flow.continuation_parameters) =
     Continuation.Map.find cont continuation_parameters
   in
-
-  (* let require_wrapper =
-   *   let required_extra_args =
-   *     Continuation.Map.filter_map
-   *       (fun cont _handler ->
-   *         let rewrite = UE.find_apply_cont_rewrite (UA.uenv uacc) cont in
-   *         match rewrite with
-   *         | None ->
-   *           Format.eprintf "UENV:@.%a@." UE.print (UA.uenv uacc);
-   *           Misc.fatal_errorf "Recursive continuation must have a rewrite %a"
-   *             Continuation.print cont
-   *         | Some rewrite ->
-   *           let variable_has_aliases var =
-   *             match Variable.Map.find var aliases with
-   *             | exception Not_found -> false
-   *             | alias -> not (Variable.equal alias var)
-   *           in
-   *           let extra_args_for_aliases =
-   *             (Continuation.Map.find cont continuation_parameters)
-   *               .extra_args_for_aliases
-   *           in
-   *           let need_stuff =
-   *             let original_params =
-   *               Bound_parameters.to_list
-   *               @@ Apply_cont_rewrite.original_params rewrite
-   *             in
-   *             let used_params = Apply_cont_rewrite.used_params rewrite in
-   *             let used_original_params =
-   *               List.filter
-   *                 (fun param -> BP.Set.mem param used_params)
-   *                 original_params
-   *             in
-   *             let used_extra_params =
-   *               Bound_parameters.to_list
-   *               @@ Apply_cont_rewrite.used_extra_params rewrite
-   *             in
-   *             List.exists
-   *               (fun param ->
-   *                 Variable.Set.mem (BP.var param) extra_args_for_aliases
-   *                 || variable_has_aliases (BP.var param))
-   *               (used_original_params @ used_extra_params)
-   *           in
-   *           if need_stuff then Some () else None
-   *         (\* let params = Apply_cont_rewrite.original_params rewrite in
-   *          * match Continuation.Map.find cont extra_args_for_aliases with
-   *          * (\\* | exception Not_found -> None *\\)
-   *          * | set ->
-   *          *   if Variable.Set.is_empty set then None else Some (params, set)) *\))
-   *       handlers
-   *   in
-   *   match Continuation.Map.cardinal required_extra_args with
-   *   | 0 -> None
-   *   | 1 -> Some (Continuation.Map.min_binding required_extra_args)
-   *   | _ -> assert false
-   * in *)
   let expr, uacc =
     match recursive_continuation_wrapper with
     | No_wrapper ->
@@ -1238,32 +1163,6 @@ let rebuild_recursive_let_cont ~body handlers ~cost_metrics_of_handlers
           (UA.are_rebuilding_terms uacc)
           cont handler ~body
       in
-      (* let no_before = UA.name_occurrences uacc in *)
-      (* let uacc =
-       *   let name_occurrences =
-       *     List.fold_left
-       *       (fun name_occurrences param ->
-       *         Name_occurrences.remove_var name_occurrences (BP.var param))
-       *       (UA.name_occurrences uacc)
-       *       (Bound_parameters.to_list params)
-       *   in
-       *   UA.with_name_occurrences uacc ~name_occurrences
-       * in *)
-      (* let no_after = UA.name_occurrences uacc in *)
-      (* Format.printf
-       *   "XXXXXXXXXXXXXXXXXXXXXXX FREE NAMES@.%a@.@.@.EXPR@.%a@.@."
-       *   Name_occurrences.print no_before
-       *   (\* Name_occurrences.print no_after *\)
-       *   (RE.print (UA.are_rebuilding_terms uacc))
-       *   expr; *)
-      (* let should_have_been =
-       *   RE.create_recursive_let_cont
-       *     (UA.are_rebuilding_terms uacc)
-       *     handlers ~body
-       * in
-       * Format.printf "SHOULD HAVE BEEN@.%a@.@."
-       *   (RE.print (UA.are_rebuilding_terms uacc))
-       *   should_have_been; *)
       expr, uacc
   in
 

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -124,7 +124,7 @@ let compute_used_params uacc params ~is_exn_handler ~is_single_inlinable_use
 
 let add_extra_params_for_continuation_param_aliases cont uacc rewrite_ids
     extra_params_and_args =
-  let Data_flow.{ extra_args_for_aliases; _ } =
+  let Data_flow.{ extra_args_for_aliases; aliases_kind; _ } =
     UA.continuation_param_aliases uacc
   in
   let required_extra_args = Continuation.Map.find cont extra_args_for_aliases in
@@ -137,11 +137,12 @@ let add_extra_params_for_continuation_param_aliases cont uacc rewrite_ids
       in
       Format.printf "ADD ARG %a to %a@." Variable.print var Continuation.print
         cont;
-      (* THIS IS WRONG, but we do not propagate the kind yet. TODO *)
-      let dummy_wrong_kind = Flambda_kind.With_subkind.any_value in
-      EPA.add
-        ~extra_param:(Bound_parameter.create var dummy_wrong_kind)
-        ~extra_args epa)
+      let var_kind =
+        Flambda_kind.With_subkind.create
+          (Variable.Map.find var aliases_kind)
+          Anything
+      in
+      EPA.add ~extra_param:(Bound_parameter.create var var_kind) ~extra_args epa)
     required_extra_args extra_params_and_args
 
 let rebuild_one_continuation_handler cont ~at_unit_toplevel

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -194,7 +194,12 @@ let record_new_defining_expression_binding_for_data_flow dacc data_flow
         || Option.is_some (P.is_end_region prim)
     in
     if not can_be_removed
-    then DF.add_used_in_current_handler free_names data_flow
+    then
+      let data_flow =
+        Bound_pattern.fold_all_bound_vars binding.let_bound ~init:data_flow
+          ~f:(fun data_flow v -> DF.record_defined_var (VB.var v) data_flow)
+      in
+      DF.add_used_in_current_handler free_names data_flow
     else
       let generate_phantom_lets = DE.generate_phantom_lets (DA.denv dacc) in
       let free_names =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -582,7 +582,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
             DA.print dacc;
         assert (not (DE.at_unit_toplevel (DA.denv dacc)));
         match
-          C.simplify_toplevel context dacc body ~return_continuation
+          C.simplify_toplevel context dacc body ~params ~return_continuation
             ~exn_continuation ~return_arity:(Code.result_arity code)
             ~return_cont_scope:Scope.initial
             ~exn_cont_scope:(Scope.next Scope.initial)

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -18,6 +18,8 @@ open! Simplify_import
 module TE = Flambda2_types.Typing_env
 module Alias_set = TE.Alias_set
 
+[@@@ocaml.warning "-37"]
+
 type mergeable_arms =
   | No_arms
   | Mergeable of
@@ -88,39 +90,44 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
       let maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms =
         let arms = Targetint_31_63.Map.add arm action arms in
         (* Check to see if this arm may be merged with others. *)
-        if Option.is_some (Apply_cont.trap_action action)
-        then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
-        else
-          match mergeable_arms with
-          | Not_mergeable ->
-            new_let_conts, arms, Not_mergeable, identity_arms, not_arms
-          | No_arms ->
-            let cont = Apply_cont.continuation action in
-            let args =
-              List.map
-                (fun arg -> find_all_aliases env_at_use arg)
-                (Apply_cont.args action)
-            in
-            ( new_let_conts,
-              arms,
-              Mergeable { cont; args },
-              identity_arms,
-              not_arms )
-          | Mergeable { cont; args } ->
-            if not (Continuation.equal cont (Apply_cont.continuation action))
-            then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
-            else
-              let args =
-                List.map2
-                  (fun arg_set arg ->
-                    Alias_set.inter (find_all_aliases env_at_use arg) arg_set)
-                  args (Apply_cont.args action)
-              in
-              ( new_let_conts,
-                arms,
-                Mergeable { cont; args },
-                identity_arms,
-                not_arms )
+        ignore mergeable_arms;
+        ignore env_at_use;
+        ignore find_all_aliases;
+        new_let_conts, arms, Not_mergeable, identity_arms, not_arms
+
+        (* if Option.is_some (Apply_cont.trap_action action)
+         * then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
+         * else
+         *   match mergeable_arms with
+         *   | Not_mergeable ->
+         *     new_let_conts, arms, Not_mergeable, identity_arms, not_arms
+         *   | No_arms ->
+         *     let cont = Apply_cont.continuation action in
+         *     let args =
+         *       List.map
+         *         (fun arg -> find_all_aliases env_at_use arg)
+         *         (Apply_cont.args action)
+         *     in
+         *     ( new_let_conts,
+         *       arms,
+         *       Mergeable { cont; args },
+         *       identity_arms,
+         *       not_arms )
+         *   | Mergeable { cont; args } ->
+         *     if not (Continuation.equal cont (Apply_cont.continuation action))
+         *     then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
+         *     else
+         *       let args =
+         *         List.map2
+         *           (fun arg_set arg ->
+         *             Alias_set.inter (find_all_aliases env_at_use arg) arg_set)
+         *           args (Apply_cont.args action)
+         *       in
+         *       ( new_let_conts,
+         *         arms,
+         *         Mergeable { cont; args },
+         *         identity_arms,
+         *         not_arms ) *)
       in
       (* Check to see if the arm is of a form that might mean the whole [Switch]
          is a boolean NOT. *)

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -120,44 +120,39 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
       let maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms =
         let arms = Targetint_31_63.Map.add arm action arms in
         (* Check to see if this arm may be merged with others. *)
-        ignore mergeable_arms;
-        ignore env_at_use;
-        ignore find_all_aliases;
-        new_let_conts, arms, Not_mergeable, identity_arms, not_arms
-
-        (* if Option.is_some (Apply_cont.trap_action action)
-         * then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
-         * else
-         *   match mergeable_arms with
-         *   | Not_mergeable ->
-         *     new_let_conts, arms, Not_mergeable, identity_arms, not_arms
-         *   | No_arms ->
-         *     let cont = Apply_cont.continuation action in
-         *     let args =
-         *       List.map
-         *         (fun arg -> find_all_aliases env_at_use arg)
-         *         (Apply_cont.args action)
-         *     in
-         *     ( new_let_conts,
-         *       arms,
-         *       Mergeable { cont; args },
-         *       identity_arms,
-         *       not_arms )
-         *   | Mergeable { cont; args } ->
-         *     if not (Continuation.equal cont (Apply_cont.continuation action))
-         *     then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
-         *     else
-         *       let args =
-         *         List.map2
-         *           (fun arg_set arg ->
-         *             Alias_set.inter (find_all_aliases env_at_use arg) arg_set)
-         *           args (Apply_cont.args action)
-         *       in
-         *       ( new_let_conts,
-         *         arms,
-         *         Mergeable { cont; args },
-         *         identity_arms,
-         *         not_arms ) *)
+        if Option.is_some (Apply_cont.trap_action action)
+        then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
+        else
+          match mergeable_arms with
+          | Not_mergeable ->
+            new_let_conts, arms, Not_mergeable, identity_arms, not_arms
+          | No_arms ->
+            let cont = Apply_cont.continuation action in
+            let args =
+              List.map
+                (fun arg -> find_all_aliases env_at_use arg)
+                (Apply_cont.args action)
+            in
+            ( new_let_conts,
+              arms,
+              Mergeable { cont; args },
+              identity_arms,
+              not_arms )
+          | Mergeable { cont; args } ->
+            if not (Continuation.equal cont (Apply_cont.continuation action))
+            then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
+            else
+              let args =
+                List.map2
+                  (fun arg_set arg ->
+                    Alias_set.inter (find_all_aliases env_at_use arg) arg_set)
+                  args (Apply_cont.args action)
+              in
+              ( new_let_conts,
+                arms,
+                Mergeable { cont; args },
+                identity_arms,
+                not_arms )
       in
       (* Check to see if the arm is of a form that might mean the whole [Switch]
          is a boolean NOT. *)

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -330,7 +330,10 @@ let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
     let action = Apply_cont.update_args action ~args in
     let dacc =
       DA.map_data_flow dacc
-        ~f:(Data_flow.add_apply_cont_args (Apply_cont.continuation action) args)
+        ~f:
+          (Data_flow.add_apply_cont_args ~rewrite_id
+             (Apply_cont.continuation action)
+             args)
     in
     let arms =
       Targetint_31_63.Map.add arm (action, rewrite_id, arity, env_at_use) arms

--- a/middle_end/flambda2/tests/ref_to_var/alias.ml
+++ b/middle_end/flambda2/tests/ref_to_var/alias.ml
@@ -1,0 +1,9 @@
+let id = Sys.opaque_identity
+
+let f x =
+  let r = ref x in
+  while id false do
+    let _ = id !r in
+    ()
+  done;
+  !r + 1

--- a/middle_end/flambda2/tests/ref_to_var/exn.ml
+++ b/middle_end/flambda2/tests/ref_to_var/exn.ml
@@ -1,0 +1,20 @@
+exception Saucisse
+
+let id = Sys.opaque_identity
+
+let g () = () [@@inline never]
+
+let f x =
+  let r = ref x in
+  let v =
+    try
+      while id false do
+        let _ = id !r in
+        (* if id false then raise Saucisse; *)
+        g ();
+        ()
+      done;
+      !r
+    with Saucisse -> !r + 1
+  in
+  v * !r

--- a/middle_end/flambda2/tests/ref_to_var/exn_2.ml
+++ b/middle_end/flambda2/tests/ref_to_var/exn_2.ml
@@ -1,0 +1,38 @@
+exception Saucisse
+
+let id = Sys.opaque_identity
+
+let g () = () [@@inline never]
+
+let f x tt =
+  let r = ref x in
+  let v =
+    try
+      while id false do
+        let _ = id !r in
+        (* if id false then raise Saucisse; *)
+        g ();
+        ()
+      done;
+      !r
+    with Saucisse -> !r + 1
+  in
+  v * !r
+  [@@inlined always]
+
+  let zozo z =
+    let uu w pp =
+      (f [@inlined always]) w pp
+    in
+    let a, b = if Sys.opaque_identity false then 1, 1 else 2, 2 in
+    let ouou x =
+      Sys.opaque_identity x
+    in
+    let a = ouou a in
+    let o = Sys.opaque_identity z in
+    if Sys.opaque_identity false then
+      let koko = Sys.opaque_identity a in
+      uu o koko
+    else
+      let kuku = Sys.opaque_identity b in
+      uu o kuku

--- a/middle_end/flambda2/tests/ref_to_var/exn_3.ml
+++ b/middle_end/flambda2/tests/ref_to_var/exn_3.ml
@@ -1,0 +1,48 @@
+exception Saucisse
+
+let id = Sys.opaque_identity
+
+let g () = () [@@inline never]
+
+let f x tt b =
+  let r = ref x in
+  let v =
+    try
+      while id false do
+        ()
+      done;
+      while id false do
+        let _ = id !r in
+        (* if id false then raise Saucisse; *)
+        g ();
+        if b then r := 12;
+        ()
+      done;
+      !r
+    with Saucisse -> !r + 1
+  in
+  v * !r
+  [@@inlined always]
+
+  let zozo z b =
+    let uu w pp =
+      f w pp b
+    in
+    let a, b = if Sys.opaque_identity false then 1, 1 else 2, 2 in
+    let ouou x =
+      Sys.opaque_identity x
+    in
+    let a = ouou a in
+    let o = Sys.opaque_identity z in
+    if Sys.opaque_identity false then
+      let koko = Sys.opaque_identity a in
+      uu o koko
+    else
+      let kuku = Sys.opaque_identity b in
+      uu o kuku
+  [@@inlined always]
+
+
+      let chose z =
+      ignore z;
+      zozo z false

--- a/middle_end/flambda2/tests/ref_to_var/recursive_cont_with_handler.ml
+++ b/middle_end/flambda2/tests/ref_to_var/recursive_cont_with_handler.ml
@@ -1,0 +1,90 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "-21-27-32"]
+
+module Id = struct
+  type t = int
+
+  let flags_size_in_bits = 3
+
+  let create t flags = t [@@inline never]
+
+  let mask_selecting_top_bits = -1 lsl flags_size_in_bits
+
+  let mask_selecting_bottom_bits = lnot mask_selecting_top_bits
+
+  let flags t = t land mask_selecting_bottom_bits [@@inline never]
+
+  let next t = t + 665577
+end
+
+module Data = struct
+  type t =
+    { compilation_unit : Compilation_unit.t;
+      previous_compilation_units : Compilation_unit.t list;
+      name : string;
+      name_stamp : int
+    }
+
+  let flags = 0
+
+  let hash
+      { compilation_unit; previous_compilation_units; name = _; name_stamp } =
+    Sys.opaque_identity 33
+
+  let equal t1 t2 = Sys.opaque_identity true
+end
+
+module Table = struct
+  module E = Data
+
+  module HT = struct
+    type _ t = unit
+
+    let create _ = assert false [@@inline never]
+
+    let add _ _ _ = assert false [@@inline never]
+
+    let find _ _ = assert false [@@inline never]
+  end
+
+  type t = E.t HT.t
+
+  let add t elt =
+    let id = Id.create (E.hash elt) E.flags in
+    match HT.find t id with
+    | existing_elt -> (
+      try
+        let starting_id = id in
+        (* XXXXXXXXXXX Id.next starting_id is added as an extra_arg_for_aliases
+           to the recursive continuation of the while. It shouldn't: WHY ? *)
+        let id = ref (Id.next starting_id) in
+        (* If there is a collision, we search for another slot, but take care
+           not to alter the flags bits. *)
+        while !id <> starting_id do
+          assert (Id.flags !id = E.flags);
+          match HT.find t !id with
+          | exception Not_found -> raise Exit
+          | existing_elt ->
+            if E.equal elt existing_elt then raise Exit else id := Id.next !id
+        done;
+        (* assert false *)
+        Misc.fatal_errorf "No hash values left for@"
+      with Exit -> assert false)
+
+  let add' t elt = (add [@inlined]) t elt
+end

--- a/middle_end/flambda2/tests/ref_to_var/recursive_cont_with_handler.ml
+++ b/middle_end/flambda2/tests/ref_to_var/recursive_cont_with_handler.ml
@@ -34,8 +34,8 @@ end
 
 module Data = struct
   type t =
-    { compilation_unit : Compilation_unit.t;
-      previous_compilation_units : Compilation_unit.t list;
+    { compilation_unit : unit;
+      previous_compilation_units : unit list;
       name : string;
       name_stamp : int
     }
@@ -48,6 +48,8 @@ module Data = struct
 
   let equal t1 t2 = Sys.opaque_identity true
 end
+
+let plop s = failwith s [@@inline never]
 
 module Table = struct
   module E = Data
@@ -82,9 +84,8 @@ module Table = struct
           | existing_elt ->
             if E.equal elt existing_elt then raise Exit else id := Id.next !id
         done;
-        (* assert false *)
-        Misc.fatal_errorf "No hash values left for@"
-      with Exit -> assert false)
+        plop "No hash values left for@"
+      with Exit -> ())
 
   let add' t elt = (add [@inlined]) t elt
 end

--- a/middle_end/flambda2/tests/ref_to_var/string.ml
+++ b/middle_end/flambda2/tests/ref_to_var/string.ml
@@ -1,0 +1,37 @@
+
+type 'a ref = { mutable contents : 'a }
+external ref : 'a -> ('a ref[@local_opt]) = "%makemutable"
+external ( ! ) : ('a ref[@local_opt]) -> 'a = "%field0"
+external ( := ) : ('a ref[@local_opt]) -> 'a -> unit = "%setfield0"
+external incr : (int ref[@local_opt]) -> unit = "%incr"
+external decr : (int ref[@local_opt]) -> unit = "%decr"
+
+external ( && ) : (bool[@local_opt]) -> (bool[@local_opt]) -> bool = "%sequand"
+
+external ( / ) : (int[@local_opt]) -> (int[@local_opt]) -> int = "%divint"
+external ( - ) : (int[@local_opt]) -> (int[@local_opt]) -> int = "%subint"
+external ( + ) : (int[@local_opt]) -> (int[@local_opt]) -> int = "%addint"
+
+external ( = ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%equal"
+external ( <> ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%notequal"
+external ( < ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%lessthan"
+external ( > ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%greaterthan"
+external ( <= ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%lessequal"
+external ( >= ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%greaterequal"
+external compare : ('a[@local_opt]) -> ('a[@local_opt]) -> int = "%compare"
+
+external length : string -> int = "%string_length"
+external unsafe_get : string -> int -> char = "%string_unsafe_get"
+
+let[@inline never] sub s ofs len = assert false
+
+let split_on_char sep s =
+  let r = ref [] in
+  let j = ref (length s) in
+  for i = length s - 1 downto 0 do
+    if unsafe_get s i = sep then begin
+      r := sub s (i + 1) (!j - i - 1) :: !r;
+      j := i
+    end
+  done;
+  sub s 0 !j :: !r

--- a/middle_end/flambda2/tests/ref_to_var/unbox_while.ml
+++ b/middle_end/flambda2/tests/ref_to_var/unbox_while.ml
@@ -1,0 +1,17 @@
+type 'a ref = { mutable contents : 'a }
+external ref : 'a -> ('a ref[@local_opt]) = "%makemutable"
+external ( ! ) : ('a ref[@local_opt]) -> 'a = "%field0"
+external ( := ) : ('a ref[@local_opt]) -> 'a -> unit = "%setfield0"
+external incr : (int ref[@local_opt]) -> unit = "%incr"
+external decr : (int ref[@local_opt]) -> unit = "%decr"
+
+external ( +. ) : (float[@local_opt]) -> (float[@local_opt]) -> (float[@local_opt]) = "%addfloat"
+
+
+let f x =
+  let r = ref x in
+  let g = ref 0. in
+  for i = 0 to 10 do
+    g := !g +. !r
+  done;
+  !g

--- a/middle_end/flambda2/tests/ref_to_var/unused_fun_return.ml
+++ b/middle_end/flambda2/tests/ref_to_var/unused_fun_return.ml
@@ -1,0 +1,58 @@
+[@@@ocaml.warning "-27"]
+
+let f x = x [@@inline never]
+
+let g x y =
+  let r = ref 0 in
+  let o = ref y in
+  while Sys.opaque_identity true do
+    let _v = f x in
+    let _w = f x in
+    r := y + !o
+  done;
+  !r
+
+let mouf x y =
+  let r = ref 0 in
+  (* This is not marked as invariant because not a variable. Would be
+     the same thing with a const : TODO improve this *)
+  let o = ref (1, 2) in
+  while Sys.opaque_identity true do
+    let _v = f x in
+    let _w = f x in
+    r := y + fst (Sys.opaque_identity !o)
+  done;
+  !r
+
+
+(* let g b x y z =
+ *   let kont r o =
+ *     while Sys.opaque_identity true do
+ *       let _v = f x in
+ *       let _w = f x in
+ *       r := y + !o
+ *     done;
+ *     !r
+ *   in
+ *   let r = ref 0 in
+ *   let o = ref 0 in
+ *   let mortadelle = Sys.opaque_identity y in
+ *   let () =
+ *     if b then
+ *       o := mortadelle
+ *     else
+ *       o := y
+ *   in
+ *     if Sys.opaque_identity false then
+ *       kont r o
+ *     else
+ *       begin
+ *         incr r;
+ *         kont r o
+ *       end
+ * 
+ * let plop b_plop x_plop y_plop z_plop =
+ *   (g[@inlined]) b_plop x_plop y_plop z_plop
+ * 
+ * let mouarf x_mouarf y_mouarf z_mouarf =
+ *   (plop[@inlined]) true x_mouarf y_mouarf z_mouarf *)

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -236,6 +236,8 @@ module Typing_env : sig
 
     val inter : t -> t -> t
 
+    val singleton : Simple.t -> t
+
     val print : Format.formatter -> t -> unit
   end
 

--- a/middle_end/flambda2/ui/flambda_colours.ml
+++ b/middle_end/flambda2/ui/flambda_colours.ml
@@ -24,11 +24,11 @@ let is_colour_enabled =
   let colour_enabled =
     lazy
       ((* This avoids having to alter misc.ml *)
-        let buf = Buffer.create 10 in
-        let ppf = Format.formatter_of_buffer buf in
-        Misc.Color.set_color_tag_handling ppf;
-        Format.fprintf ppf "@{<error>@}%!";
-        String.length (Buffer.contents buf) > 0)
+       let buf = Buffer.create 10 in
+       let ppf = Format.formatter_of_buffer buf in
+       Misc.Color.set_color_tag_handling ppf;
+       Format.fprintf ppf "@{<error>@}%!";
+       String.length (Buffer.contents buf) > 0)
   in
   fun () -> Lazy.force colour_enabled && not !disable_colours
 

--- a/middle_end/flambda2/ui/flambda_colours.mli
+++ b/middle_end/flambda2/ui/flambda_colours.mli
@@ -91,3 +91,5 @@ val error : directive
 val each_file : directive
 
 val lambda : directive
+
+val without_colours : f:(unit -> 'a) -> 'a


### PR DESCRIPTION
This is a first step for the 'ref to var' transformation.

This is a draft, still undergoing some cleanup. There still are some traces of some previous version in simplify_let_cont

`Data_flow` records additional information to be able to track precisely the flow of values. This is used to compute some kind of dominator graph of variable. We consider variables as aliased if they are in the same domination class. This is quite restrictive for an alias analysis, but this should cover the situation we expect for ref to var. In particular, this correctly handles recursion.

The only dependencies tracked are the continuation parameters. Since this is done at the bottom of the downward traversal, we expect all simple local aliases to have been resolved by the canonical alias mechanism.

When aliases are found, they are recorded in `uacc` and rewritten in the upward rebuild pass. The rebuild is minimal: only let conts have to be modified.

Imagine that this example was not simplified in the downward pass (which of course would have been).
```OCaml
let cont k1 a = return a
let cont k2 x = k1 x
let cont k3 y = k1 y
if b then k2 z else k3 z
```
Here `a` `x` `y` are all dominated by `z`.
This rewriting is quite mechanical. We add an extra param to every continuation where an aliased variable is used (or that contains an apply_cont to a continuation that uses the alias), and we let bind the original name of the variable to the new parameter.
```OCaml
let cont k1 a z = let a = z in return a
let cont k2 x z = let x = z in k1 x z
let cont k3 y z = let y = z in k1 y z
if b then k2 z z else k3 z z
```
And then remove the new unused parameter and arguments
```OCaml
let cont k1 z = let a = z in return a
let cont k2 z = let x = z in k1 z
let cont k3 z = let y = z in k1 z
if b then k2 z else k3 z
```
This avoids needing to rewrite every simple everywhere. Note that `z` parameter introduced is exactly the same variable (same stamp) as the dominator one. We think that there is no problem with that, but this has to be kept in mind. If this seems to risky, it would be possible to generate fresh names for the extra params. When the right variable is already present in scope, no new parameter is introduced, this is needed to handle recursive continuations properly.

There is one place where introducing new variables out of scope is problematic: in switch rewriting, for merging branches.
There is a search for all simples aliased to every argument of a continuation. Since we could be adding new arguments that where not in scope during the downward traversal, that search in the environment from the downward pass cannot work. We think that this search is never required on variables (this is documented in simplify_switch) so we avoided the problem by not doing it on variables. 

The point of this transformation is to remove constant parameters of recursive continuations and bind them out of the loop.
```OCaml
let cont k1 a =
  let rec k_loop b =
    ...
    k_loop b
  in
  k_loop a
```
Which would be rewritten to.
```OCaml
let cont k1 a =
  let rec k_loop =
    let b = a in
    ...
    k_loop
  in
  k_loop
```
Something there is no such surrounding continuation where arguments are in scope for the recursive one. In that case, we need to introduce a new one.
```OCaml
  let rec k_loop b =
    ...
    k_loop b
  in
  k_loop a
```
The wrapper continuation uses the name of the original recursive continuation.
```OCaml
let cont k_loop a =
  let rec k_loop =
    ...
    k_loop
  in
  k_loop a
```
Since the apply_cont to the recursive continuation and wrapper continuation do not have the same arguments, we need a different apply_cont_rewrite for the handler and the body.

There is a corner case for exception handlers. Since we can't remove the first parameter of an exception handler, the same mechanical rewrite of the parameters is not possible. If we where to introduce a dominator argument aliased to the first argument of an exception continuation, we instead introduce a let binding for dominator variable

```OCaml
let k exn =
  ...
```
would normally be transformed into
```OCaml
let k exn dominator =
  let exn = dominator in
  ...
```
But instead this is produced
```OCaml
let k exn =
  let dominator = exn in
  ...
```

This highlight that in general we are going to rename a lot continuation arguments to the original variable name. We don't know if this is the best name. It would be possible to prefer the local name instead.

Note: What I call dominator is not really what we usually think of as a dominator: the graph is the flow of variable, not of control flow. But they are very closely related. In particular there is no requirement for single entry point in the graph, compared to what is required normally for defining a dominator

There is a debugging graphviz output for aliases and control flow graph that is triggered by the environment variables "DOM_GRAPH" and "FLOW_GRAPH"

Note: the current implementation of the dominator computation only tracks variables.

```OCaml
let cont k1 a = return a
let cont k2 x = k1 x
let cont k3 y = k1 y
if b then k2 1 else k3 1
```
In that situation `1` should dominate `a`, but this is lost.

Note: this transformation occurs while going up: the fact that a variable is aliased to another cannot be used by the simplification. But this will be available for a second round of simplification if this is part of a function that is inlined