### PR TITLE
Stop storing unknown function result types

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1337,11 +1337,7 @@ let close_one_function acc ~external_env ~by_function_slot decl
       ~num_trailing_local_params:(Function_decl.num_trailing_local_params decl)
       ~result_arity:
         (Flambda_arity.With_subkinds.create [K.With_subkind.from_lambda return])
-      ~result_types:
-        (Result_types.create_unknown ~params
-           ~result_arity:
-             (Flambda_arity.With_subkinds.create
-                [K.With_subkind.from_lambda return]))
+      ~result_types:Unknown
       ~contains_no_escaping_local_allocs:
         (Function_decl.contains_no_escaping_local_allocs decl)
       ~stub ~inline

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -716,7 +716,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
               [Flambda_kind.With_subkind.any_value]
           | Some ar -> arity ar
         in
-        let ( params,
+        let ( _params,
               params_and_body,
               free_names_of_params_and_body,
               is_my_closure_used ) =
@@ -780,11 +780,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
             ~newer_version_of ~params_arity ~num_trailing_local_params:0
-            ~result_arity
-            ~result_types:
-              (Result_types.create_unknown
-                 ~params:(Bound_parameters.create params)
-                 ~result_arity)
+            ~result_arity ~result_types:Unknown
             ~contains_no_escaping_local_allocs:false ~stub:false ~inline
             ~is_a_functor:false ~recursive
             ~cost_metrics (* CR poechsel: grab inlining arguments from fexpr. *)

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -694,12 +694,12 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
     decision
   in
   let is_a_functor = Code.is_a_functor code in
-  let result_types =
+  let result_types : _ Or_unknown_or_bottom.t =
     if not (Flambda_features.function_result_types ~is_a_functor)
-    then Result_types.create_unknown ~params ~result_arity
+    then Unknown
     else
       match return_cont_uses with
-      | None -> Result_types.create_bottom ~params ~result_arity
+      | None -> Bottom
       | Some uses ->
         let code_age_relation_after_function =
           TE.code_age_relation (DA.typing_env dacc_after_body)
@@ -741,7 +741,8 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
           T.make_suitable_for_environment typing_env
             (All_variables_except params_and_results) results_and_types
         in
-        Result_types.create ~params ~results:return_cont_params env_extension
+        Ok
+          (Result_types.create ~params ~results:return_cont_params env_extension)
   in
   let outer_dacc =
     (* This is the complicated part about slot offsets. We just traversed the

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -266,7 +266,7 @@ let [@ocamlformat "disable"] print ppf
     then Flambda_colours.elide
     else Flambda_colours.none)
     Flambda_colours.pop
- (Or_unknown_or_bottom.print   Result_types.print) result_types
+    (Or_unknown_or_bottom.print Result_types.print) result_types
     contains_no_escaping_local_allocs
     (match recursive with
     | Non_recursive -> Flambda_colours.elide

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -39,7 +39,7 @@ module type Code_metadata_accessors_result_type = sig
 
   val result_arity : 'a t -> Flambda_arity.With_subkinds.t
 
-  val result_types : 'a t -> Result_types.t
+  val result_types : 'a t -> Result_types.t Or_unknown_or_bottom.t
 
   val stub : 'a t -> bool
 
@@ -79,7 +79,7 @@ type 'a create_type =
   params_arity:Flambda_arity.With_subkinds.t ->
   num_trailing_local_params:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
-  result_types:Result_types.t ->
+  result_types:Result_types.t Or_unknown_or_bottom.t ->
   contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->

--- a/middle_end/flambda2/terms/result_types.ml
+++ b/middle_end/flambda2/terms/result_types.ml
@@ -127,32 +127,6 @@ let create ~params ~results env_extension =
   let bound = { Bound.params; results; other_vars } in
   A.create bound env_extension
 
-let create_trivial ~params ~result_arity create_type =
-  let results =
-    List.mapi
-      (fun i kind_with_subkind ->
-        Bound_parameter.create
-          (Variable.create ("result" ^ string_of_int i))
-          kind_with_subkind)
-      (Flambda_arity.With_subkinds.to_list result_arity)
-  in
-  let env_extension =
-    List.fold_left
-      (fun env_extension result ->
-        TEEV.add_or_replace_equation env_extension
-          (Bound_parameter.name result)
-          (create_type (Bound_parameter.kind result)))
-      TEEV.empty results
-  in
-  create ~params ~results:(Bound_parameters.create results) env_extension
-
-let create_unknown ~params ~result_arity =
-  create_trivial ~params ~result_arity (T.unknown_with_subkind ?alloc_mode:None)
-
-let create_bottom ~params ~result_arity =
-  create_trivial ~params ~result_arity (fun kind_with_subkind ->
-      T.bottom (Flambda_kind.With_subkind.kind kind_with_subkind))
-
 let pattern_match t ~f =
   A.pattern_match t
     ~f:(fun { Bound.params; results; other_vars = _ } env_extension ->

--- a/middle_end/flambda2/terms/result_types.mli
+++ b/middle_end/flambda2/terms/result_types.mli
@@ -20,12 +20,6 @@ val create :
   Flambda2_types.Typing_env_extension.With_extra_variables.t ->
   t
 
-val create_unknown :
-  params:Bound_parameters.t -> result_arity:Flambda_arity.With_subkinds.t -> t
-
-val create_bottom :
-  params:Bound_parameters.t -> result_arity:Flambda_arity.With_subkinds.t -> t
-
 val pattern_match :
   t ->
   f:


### PR DESCRIPTION
At the moment, when result types for functions are unknown, the relevant "unknown" type based on the result arity (including subkinds) is constructed and stored in the code metadata.  These end up in `.cmx` files, which is a waste of space.  This PR adjusts the type in `Code_metadata` to prevent this.  On the compiler this reduces `.cmx` file size by about 5%.  The code is also simplified.