### PR TITLE
Remove integer comparison involving nonconstant polymorphic variants

### DIFF
--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -2884,8 +2884,14 @@ let combine_variant value_kind loc row arg partial ctx def
         | [ (_, act1) ], [ (_, act2) ] when fail = None ->
             test_int_or_block arg act1 act2
         | _, [] ->
-            (* One can compare integers and pointers *)
-            make_test_sequence_variant_constant value_kind fail arg consts
+            begin match fail with
+            | None ->
+              make_test_sequence_variant_constant value_kind fail arg consts
+            | Some act ->
+              test_int_or_block arg
+                (make_test_sequence_variant_constant value_kind fail arg consts)
+                act
+            end
         | [], _ -> (
             let lam =
               call_switcher_variant_constr value_kind loc fail arg nonconsts


### PR DESCRIPTION
This hopefully means that we will be able to revert #729.