### PR TITLE
Compiler hooks can access allocations found by check allocations

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -494,6 +494,8 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduc
          (fun () ->
             gen ();
             Checkmach.record_unit_info ppf_dump;
+            if !Checkmach.keep_all_details then
+              Compiler_hooks.execute Compiler_hooks.Check_allocations (Checkmach.details ());
             write_ir output_prefix)
          ~always:(fun () ->
              if create_asm then close_out !Emitaux.output_channel)

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -47,7 +47,8 @@ module Detail = struct
         }
     | Direct_call of string (* Function name *)
     | Direct_tailcall of string (* Function name *)
-    | Direct_call_unknown of string (* Function name *)
+    | Direct_call_unknown of string
+    (* Function in which the call originates from *)
     | Extcall of string (* Function name *)
     | Arch_specific
 
@@ -61,7 +62,8 @@ module Detail = struct
       Printf.sprintf "probe %s handler %s" name handler_code_sym
     | Direct_call n -> Printf.sprintf "direct call to %s" n
     | Direct_tailcall n -> Printf.sprintf "direct tailcall to %s" n
-    | Direct_call_unknown n -> Printf.sprintf "call to unknown function %s" n
+    | Direct_call_unknown n ->
+      Printf.sprintf "call to unknown function within function %s" n
     | Extcall n -> Printf.sprintf "external call to %s" n
     | Arch_specific -> "Arch.specific_operation"
 

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -45,10 +45,10 @@ module Detail = struct
         { name : string;
           handler_code_sym : string
         }
-    | Direct_call of string
-    | Direct_tailcall of string
-    | Direct_call_unknown of string
-    | Extcall of string
+    | Direct_call of string (* Function name *)
+    | Direct_tailcall of string (* Function name *)
+    | Direct_call_unknown of string (* Function name *)
+    | Extcall of string (* Function name *)
     | Arch_specific
 
   let string_of_kind = function
@@ -61,7 +61,7 @@ module Detail = struct
       Printf.sprintf "probe %s handler %s" name handler_code_sym
     | Direct_call n -> Printf.sprintf "direct call to %s" n
     | Direct_tailcall n -> Printf.sprintf "direct tailcall to %s" n
-    | Direct_call_unknown _ -> "unknown"
+    | Direct_call_unknown n -> Printf.sprintf "call to unknown function %s" n
     | Extcall n -> Printf.sprintf "external call to %s" n
     | Arch_specific -> "Arch.specific_operation"
 

--- a/backend/checkmach.mli
+++ b/backend/checkmach.mli
@@ -88,6 +88,6 @@ val keep_all_details : bool ref
 
 type details = (string, Detail.t list) Hashtbl.t
 
-(* Asserts that [keep_all_details] has been set to true and returns details about
-   all allocations in this compilation unit. *)
+(* Asserts that [keep_all_details] has been set to true and returns details
+   about all allocations in this compilation unit. *)
 val details : unit -> details

--- a/backend/checkmach.mli
+++ b/backend/checkmach.mli
@@ -56,10 +56,10 @@ end
 
 module Detail : sig
   type context =
-    | In_raise (* The current allocation occured in a raise*)
-    | In_catch (* The current allocation occured in a catch block *)
+    | In_raise (* The current allocation occurred in a raise*)
+    | In_catch (* The current allocation occurred in a catch block *)
     | Somewhere_else
-  (* The current allocation occured somewhere else in the code *)
+  (* The current allocation occurred somewhere else in the code *)
 
   type kind =
     | Caml_alloc
@@ -88,6 +88,6 @@ val keep_all_details : bool ref
 
 type details = (string, Detail.t list) Hashtbl.t
 
-(* Assert that [keep_all_details] has been set to true and returns details about
+(* Asserts that [keep_all_details] has been set to true and returns details about
    all allocations in this compilation unit. *)
 val details : unit -> details

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -40,6 +40,7 @@ type _ pass =
   | Cmm : Cmm.phrase list pass
 
   | Inlining_tree : Flambda2_simplify_shared.Inlining_report.Inlining_tree.t pass
+  | Check_allocations : Checkmach.details pass
 
 type t = {
   mutable parse_tree_intf : (Parsetree.signature -> unit) list;
@@ -65,7 +66,8 @@ type t = {
   mutable linear : (Linear.fundecl -> unit) list;
   mutable cfg : (Cfg_with_layout.t -> unit) list;
   mutable cmm : (Cmm.phrase list -> unit) list;
-  mutable inlining_tree : (Flambda2_simplify_shared.Inlining_report.Inlining_tree.t -> unit) list
+  mutable inlining_tree : (Flambda2_simplify_shared.Inlining_report.Inlining_tree.t -> unit) list;
+  mutable check_allocations : (Checkmach.details -> unit) list
 }
 let hooks : t = {
   parse_tree_intf = [];
@@ -92,6 +94,7 @@ let hooks : t = {
   cfg = [];
   cmm = [];
   inlining_tree = [];
+  check_allocations = [];
 }
 
 let execute_hooks : type a. (a -> unit) list -> a -> unit = fun hooks arg ->
@@ -125,6 +128,7 @@ let register : type a. a pass -> (a -> unit) -> unit =
   | Cfg -> hooks.cfg <- f :: hooks.cfg
   | Cmm -> hooks.cmm <- f :: hooks.cmm
   | Inlining_tree -> hooks.inlining_tree <- f :: hooks.inlining_tree
+  | Check_allocations -> hooks.check_allocations <- f :: hooks.check_allocations
 
 let execute : type a. a pass -> a -> unit =
   fun representation arg ->
@@ -153,6 +157,7 @@ let execute : type a. a pass -> a -> unit =
   | Cfg -> execute_hooks hooks.cfg arg
   | Cmm -> execute_hooks hooks.cmm arg
   | Inlining_tree -> execute_hooks hooks.inlining_tree arg
+  | Check_allocations -> execute_hooks hooks.check_allocations arg
 
 let execute_and_pipe r a = execute r a; a
 
@@ -182,3 +187,4 @@ let clear : type a. a pass -> unit =
   | Cfg -> hooks.cfg <- []
   | Cmm -> hooks.cmm <- []
   | Inlining_tree -> hooks.inlining_tree <- []
+  | Check_allocations -> hooks.check_allocations <- []

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -128,7 +128,10 @@ let register : type a. a pass -> (a -> unit) -> unit =
   | Cfg -> hooks.cfg <- f :: hooks.cfg
   | Cmm -> hooks.cmm <- f :: hooks.cmm
   | Inlining_tree -> hooks.inlining_tree <- f :: hooks.inlining_tree
-  | Check_allocations -> hooks.check_allocations <- f :: hooks.check_allocations
+  | Check_allocations ->
+    Flambda_backend_flags.alloc_check := true;
+    Checkmach.keep_all_details := true;
+    hooks.check_allocations <- f :: hooks.check_allocations
 
 let execute : type a. a pass -> a -> unit =
   fun representation arg ->

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -129,6 +129,8 @@ let register : type a. a pass -> (a -> unit) -> unit =
   | Cmm -> hooks.cmm <- f :: hooks.cmm
   | Inlining_tree -> hooks.inlining_tree <- f :: hooks.inlining_tree
   | Check_allocations ->
+    if not !Flambda_backend_flags.alloc_check then
+      Misc.fatal_error "[-alloc-check] flag must be passed when the Check_allocations hook is requested";
     Checkmach.keep_all_details := true;
     hooks.check_allocations <- f :: hooks.check_allocations
 

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -129,7 +129,6 @@ let register : type a. a pass -> (a -> unit) -> unit =
   | Cmm -> hooks.cmm <- f :: hooks.cmm
   | Inlining_tree -> hooks.inlining_tree <- f :: hooks.inlining_tree
   | Check_allocations ->
-    Flambda_backend_flags.alloc_check := true;
     Checkmach.keep_all_details := true;
     hooks.check_allocations <- f :: hooks.check_allocations
 

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -53,6 +53,7 @@ type _ pass =
   | Cmm : Cmm.phrase list pass
 
   | Inlining_tree : Flambda2_simplify_shared.Inlining_report.Inlining_tree.t pass
+  | Check_allocations : Checkmach.details pass
 
 (* Register a new hook for [pass]. *)
 val register : 'a pass -> ('a -> unit) -> unit


### PR DESCRIPTION
This PR adds a new compiler hook to fetch all allocations discovered by the check allocations tool.
An allocation is considered to be:
- A call to `caml_alloc`
- A direct call that might allocate
- An indirect call
- A caml primitive (`caml_apply_`, `checkbound`)
- An arch specific operation

Each allocation is recorded with it's `kind` (see the list above), as well as some `context` (was it post-dominated by a raise? Did it occur from the "catch" part of a try with?). The type for `context` is here but not implemented as this will be done in a later PR.

Collection of all allocations is done when `Checkmach.keep_all_details` is set by true by the user. By default it is turned to off and can only be turned off by a program using the compilerlibs or when compiler hook on Check_allocations has been registered.