### PR TITLE
Fix unused variable warning in st_stubs.c

### DIFF
--- a/ocaml/otherlibs/systhreads/st_stubs.c
+++ b/ocaml/otherlibs/systhreads/st_stubs.c
@@ -618,7 +618,9 @@ CAMLprim value caml_thread_new(value clos)          /* ML */
 CAMLexport int caml_c_thread_register(void)
 {
   caml_thread_t th;
+#ifdef NATIVE_CODE
   st_retcode err;
+#endif
 
   /* Already registered? */
   if (st_tls_get(thread_descriptor_key) != NULL) return 0;


### PR DESCRIPTION
We should adjust build settings so these warnings are errors, presumably...