### PR TITLE
Static check for noalloc: ignore allocations post-dominated by a raise

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -90,12 +90,12 @@ module type Spec = sig
 
   val annotation : Cmm.property
 
-  (** [ignore_postdominated_by_raise = true]
-      Do not perform checks on paths that must lead to a raise, as indicated by a [raise]
-      with a backtrace, i.e., paths postdominated by [raise_notrace] are not ignored.
+  (** [ignore_postdominated_by_raise = true] Do not perform checks on paths that
+      must lead to a raise, as indicated by a [raise] with a backtrace, i.e.,
+      paths postdominated by [raise_notrace] are not ignored.
 
-      In other words, when a function returns normally, it is guaranteed to pass the
-      check, but not upon exceptional return.  *)
+      In other words, when a function returns normally, it is guaranteed to pass
+      the check, but not upon exceptional return. *)
   val ignore_postdominated_by_raise : bool
 end
 (* CR-someday gyorsh: We may also want annotations on call sites, not only on

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -246,6 +246,7 @@ type expression =
 
 type property =
   | Noalloc
+  | Noalloc_exn
 
 type codegen_option =
   | Reduce_code_size

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -255,6 +255,7 @@ type expression =
 
 type property =
   | Noalloc
+  | Noalloc_exn
 
 type codegen_option =
   | Reduce_code_size

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4172,6 +4172,7 @@ let cmm_arith_size (e : Cmm.expression) =
 
 let transl_property : Lambda.property -> Cmm.property = function
   | Noalloc -> Noalloc
+  | Noalloc_exn -> Noalloc_exn
 
 let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
   | Default_check -> []

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -340,7 +340,8 @@ and sequence ppf = function
 and expression ppf e = fprintf ppf "%a" expr e
 
 let property : Cmm.property -> string = function
-    | Noalloc -> "noalloc"
+  | Noalloc -> "noalloc"
+  | Noalloc_exn -> "noalloc_exn"
 
 let codegen_option = function
   | Reduce_code_size -> "reduce_code_size"

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -50,6 +50,10 @@ type checks =
     (* CR gyorsh: refactor to use lists. *)
     mutable ui_noalloc_functions: Misc.Stdlib.String.Set.t;
     (* Functions without allocations and indirect calls *)
+
+    mutable ui_noalloc_exn_functions: Misc.Stdlib.String.Set.t;
+    (* Same as noalloc, except no restrictions on instructions
+       (allocations and indirect calls) post-dominated by a raise. *)
   }
 
 type unit_infos =

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -90,16 +90,20 @@ end = struct
   let create () =
     {
       ui_noalloc_functions = String.Set.empty;
+      ui_noalloc_exn_functions = String.Set.empty;
     }
 
   let reset t =
-    t.ui_noalloc_functions <- String.Set.empty
+    t.ui_noalloc_functions <- String.Set.empty;
+    t.ui_noalloc_exn_functions <- String.Set.empty
 
   let merge src ~into:dst =
     if !Flambda_backend_flags.alloc_check
     then (
       dst.ui_noalloc_functions
-        <- String.Set.union dst.ui_noalloc_functions src.ui_noalloc_functions)
+      <- String.Set.union dst.ui_noalloc_functions src.ui_noalloc_functions;
+      dst.ui_noalloc_exn_functions
+      <- String.Set.union dst.ui_noalloc_exn_functions src.ui_noalloc_exn_functions)
 end
 
 let cached_checks : Cmx_format.checks = Checks.create ()

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -11,13 +11,21 @@
 (**************************************************************************)
 
 module Property = struct
-  type t = Noalloc
+  type t =
+    | Noalloc
+    | Noalloc_exn
 
-  let to_string = function Noalloc -> "noalloc"
+  let to_string = function Noalloc -> "noalloc" | Noalloc_exn -> "noalloc_exn"
 
-  let equal x y = match x, y with Noalloc, Noalloc -> true
+  let equal x y =
+    match x, y with
+    | Noalloc, Noalloc -> true
+    | Noalloc_exn, Noalloc_exn -> true
+    | (Noalloc | Noalloc_exn), _ -> false
 
-  let from_lambda : Lambda.property -> t = function Noalloc -> Noalloc
+  let from_lambda : Lambda.property -> t = function
+    | Noalloc -> Noalloc
+    | Noalloc_exn -> Noalloc_exn
 end
 
 type t =

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -11,7 +11,9 @@
 (**************************************************************************)
 (** Annotations on function declaration (not call sites) *)
 module Property : sig
-  type t = Noalloc
+  type t =
+    | Noalloc
+    | Noalloc_exn
 end
 
 type t =

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -251,6 +251,7 @@ end)
 
 let transl_property : Check_attribute.Property.t -> Cmm.property = function
   | Noalloc -> Noalloc
+  | Noalloc_exn -> Noalloc_exn
 
 let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list =
   function

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -374,6 +374,7 @@ type local_attribute =
 
 type property =
   | Noalloc
+  | Noalloc_exn
 
 type check_attribute =
   | Default_check

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -287,6 +287,7 @@ type local_attribute =
 
 type property =
   | Noalloc
+  | Noalloc_exn
 
 type check_attribute =
   | Default_check

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -553,6 +553,7 @@ let name_of_primitive = function
 let check_attribute ppf check =
   let check_property = function
     | Noalloc -> "noalloc"
+    | Noalloc_exn -> "noalloc"
   in
   match check with
   | Default_check -> ()

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -41,6 +41,7 @@ let is_local_attribute = function
 let is_property_attribute p a =
   match p, a with
   | Noalloc, {txt=("noalloc_strict"|"ocaml.noalloc_strict")} -> true
+  | Noalloc_exn, {txt=("noalloc"|"ocaml.noalloc")} -> true
   | _ -> false
 
 let find_attribute p attributes =
@@ -235,7 +236,7 @@ let get_check_attribute l =
     match get_property_attribute l p with
     | Default_check -> None
     | a -> Some a)
-    [Noalloc]
+    [Noalloc; Noalloc_exn]
 
 let check_local_inline loc attr =
   match attr.local, attr.inline with
@@ -301,6 +302,7 @@ let add_local_attribute expr loc attributes =
 let add_check_attribute expr loc attributes =
   let to_string = function
     | Noalloc -> "noalloc_strict"
+    | Noalloc_exn -> "noalloc"
   in
   let to_string = function
     | Assert p -> to_string p
@@ -312,7 +314,8 @@ let add_check_attribute expr loc attributes =
   | Lfunction({ attr = { stub = false } as attr } as funct), [check] ->
       begin match attr.check with
       | Default_check -> ()
-      | Assert Noalloc | Assume Noalloc ->
+      | Assert (Noalloc | Noalloc_exn)
+      | Assume (Noalloc | Noalloc_exn) ->
           Location.prerr_warning loc
             (Warnings.Duplicated_attribute (to_string check))
       end;

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -40,7 +40,7 @@ let is_local_attribute = function
 
 let is_property_attribute p a =
   match p, a with
-  | Noalloc, {txt=("noalloc"|"ocaml.noalloc")} -> true
+  | Noalloc, {txt=("noalloc_strict"|"ocaml.noalloc_strict")} -> true
   | _ -> false
 
 let find_attribute p attributes =
@@ -300,7 +300,7 @@ let add_local_attribute expr loc attributes =
 
 let add_check_attribute expr loc attributes =
   let to_string = function
-    | Noalloc -> "noalloc"
+    | Noalloc -> "noalloc_strict"
   in
   let to_string = function
     | Assert p -> to_string p

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -1,3 +1,6 @@
+;; CR-someday gyorsh: refactor this file using something like cinaps to
+;; avoid copy-paste of the rules for different files.
+
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
@@ -92,6 +95,25 @@
  (enabled_if (= %{context_name} "main"))
  (deps fail4.output fail4.output.corrected)
  (action (diff fail4.output fail4.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail5.output.corrected)
+ (deps (:ml fail5.ml) filter.sh)
+ (action
+   (with-outputs-to fail5.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail5.output fail5.output.corrected)
+ (action (diff fail5.output fail5.output.corrected)))
+
 
 ;; test for expected compilation errors
 

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -5,13 +5,13 @@
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps s.ml t.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -c -alloc-check -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -alloc-check -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps t5.ml test_assume.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -c -alloc-check -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -alloc-check -O3)))
 
 (rule
  (alias   runtest)
@@ -21,7 +21,7 @@
                   ;; (or %{ocaml-config:flambda} %{ocaml-config:flambda2})
                   ))
  (deps test_flambda.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -c -alloc-check -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -alloc-check -O3)))
 
 (rule
  (enabled_if (= %{context_name} "main"))
@@ -31,7 +31,7 @@
    (with-outputs-to fail1.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
-     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c -alloc-check -O3))
     (run "./filter.sh")
    ))))
 
@@ -49,7 +49,7 @@
    (with-outputs-to fail2.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
-     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c -alloc-check -O3))
     (run "./filter.sh")
    ))))
 
@@ -67,7 +67,7 @@
    (with-outputs-to fail3.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
-     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c -alloc-check -O3))
     (run "./filter.sh")
    ))))
 
@@ -86,7 +86,7 @@
    (with-outputs-to fail4.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
-     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c -alloc-check -O3))
     (run "./filter.sh")
    ))))
 
@@ -104,7 +104,7 @@
    (with-outputs-to fail5.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
-     (run %{bin:ocamlopt.opt} %{ml} -color never -error-style short -c -alloc-check -O3))
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c -alloc-check -O3))
     (run "./filter.sh")
    ))))
 
@@ -123,7 +123,7 @@
  (targets test_attribute_error_duplicate.output.corrected)
  (deps test_attribute_error_duplicate.ml)
  (action    (with-outputs-to test_attribute_error_duplicate.output.corrected
-            (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -alloc-check -O3))))
+            (run %{bin:ocamlopt.opt} %{deps} -g -color never -error-style short -c -alloc-check -O3))))
 
 (rule
  (alias   runtest)

--- a/tests/backend/checkmach/fail1.ml
+++ b/tests/backend/checkmach/fail1.ml
@@ -1,3 +1,3 @@
 let[@inline never] test14 n = Float.of_int n
 
-let[@noalloc] test15 n = Int64.to_int (Int64.of_float (test14 n))
+let[@noalloc_strict] test15 n = Int64.to_int (Int64.of_float (test14 n))

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
 File "fail1.ml", line 3, characters 28-72:
-Error: Annotation check for noalloc failed on function camlFail1__test15_HIDE_STAMP
+Error: Annotation check for noalloc_strict failed on function camlFail1__test15_15

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
-File "fail1.ml", line 3, characters 21-65:
+File "fail1.ml", line 3, characters 28-72:
 Error: Annotation check for noalloc failed on function camlFail1__test15_HIDE_STAMP

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
 File "fail1.ml", line 3, characters 28-72:
-Error: Annotation check for noalloc_strict failed on function camlFail1__test15_15
+Error: Annotation check for noalloc_strict failed on function camlFail1__test15_HIDE_STAMP

--- a/tests/backend/checkmach/fail2.ml
+++ b/tests/backend/checkmach/fail2.ml
@@ -1,1 +1,1 @@
-let[@noalloc] test x = (x,x)
+let[@noalloc_strict] test x = (x,x)

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
-File "fail2.ml", line 1, characters 19-28:
+File "fail2.ml", line 1, characters 26-35:
 Error: Annotation check for noalloc failed on function camlFail2__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
 File "fail2.ml", line 1, characters 26-35:
-Error: Annotation check for noalloc failed on function camlFail2__test_HIDE_STAMP
+Error: Annotation check for noalloc_strict failed on function camlFail2__test_5

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
 File "fail2.ml", line 1, characters 26-35:
-Error: Annotation check for noalloc_strict failed on function camlFail2__test_5
+Error: Annotation check for noalloc_strict failed on function camlFail2__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail3.ml
+++ b/tests/backend/checkmach/fail3.ml
@@ -1,2 +1,2 @@
 (* Always inlined from a different file *)
-let[@noalloc] test n = T3.test4 n
+let[@noalloc_strict] test n = T3.test4 n

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
-File "fail3.ml", line 2, characters 19-33:
+File "fail3.ml", line 2, characters 26-40:
 Error: Annotation check for noalloc failed on function camlFail3__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
 File "fail3.ml", line 2, characters 26-40:
-Error: Annotation check for noalloc_strict failed on function camlFail3__test_31
+Error: Annotation check for noalloc_strict failed on function camlFail3__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
 File "fail3.ml", line 2, characters 26-40:
-Error: Annotation check for noalloc failed on function camlFail3__test_HIDE_STAMP
+Error: Annotation check for noalloc_strict failed on function camlFail3__test_31

--- a/tests/backend/checkmach/fail4.ml
+++ b/tests/backend/checkmach/fail4.ml
@@ -1,2 +1,2 @@
 (* T.test1 is never inlined and allocates. *)
-let[@noalloc] test n = T4.test1 n
+let[@noalloc_strict] test n = T4.test1 n

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
 File "fail4.ml", line 2, characters 26-40:
-Error: Annotation check for noalloc_strict failed on function camlFail4__test_51
+Error: Annotation check for noalloc_strict failed on function camlFail4__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
-File "fail4.ml", line 2, characters 19-33:
+File "fail4.ml", line 2, characters 26-40:
 Error: Annotation check for noalloc failed on function camlFail4__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
 File "fail4.ml", line 2, characters 26-40:
-Error: Annotation check for noalloc failed on function camlFail4__test_HIDE_STAMP
+Error: Annotation check for noalloc_strict failed on function camlFail4__test_51

--- a/tests/backend/checkmach/fail5.ml
+++ b/tests/backend/checkmach/fail5.ml
@@ -1,0 +1,5 @@
+exception Exn of (int * int)
+let[@noalloc] test x f =
+  (* alloc_exn check fails because of the indirect call to [f], that is not post-dominated
+     by a raise. *)
+  if x > 0 then f x else raise (Exn (f (x*x),f (x+x)))

--- a/tests/backend/checkmach/fail5.output
+++ b/tests/backend/checkmach/fail5.output
@@ -1,0 +1,2 @@
+File "fail5.ml", lines 2-5, characters 19-54:
+Error: Annotation check for noalloc failed on function camlFail5__test_HIDE_STAMP

--- a/tests/backend/checkmach/filter.sh
+++ b/tests/backend/checkmach/filter.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -r 's/Error: Annotation check for noalloc failed on function caml(.*)_[0-9]+(_[0-9]+_code)?$/Error: Annotation check for noalloc failed on function caml\1_HIDE_STAMP/'
+sed -r 's/Error: Annotation check for noalloc_strict failed on function caml(.*)_[0-9]+(_[0-9]+_code)?$/Error: Annotation check for noalloc_strict failed on function caml\1_HIDE_STAMP/' | sed -r 's/Error: Annotation check for noalloc failed on function caml(.*)_[0-9]+(_[0-9]+_code)?$/Error: Annotation check for noalloc failed on function caml\1_HIDE_STAMP/'

--- a/tests/backend/checkmach/s.ml
+++ b/tests/backend/checkmach/s.ml
@@ -1,2 +1,2 @@
-let[@noalloc][@inline never] foo n m = n + m
+let[@noalloc_strict][@inline never] foo n m = n + m
 let[@inline never] bar n m = (n, m)

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -92,3 +92,31 @@ let[@noalloc] rec foo n =
   bar (n-1)
 and[@noalloc] bar n =
   foo (n-1)
+
+let[@noalloc] always_allocate_and_raise n = raise (Exn3 (4,n))
+
+let[@inline never] f n = (n,n)
+
+(* compiles to a recursive catch that the check can handle *)
+let[@inline never] test20 n = Sys.opaque_identity n
+let[@noalloc] test21 n =
+  let i = ref 0 in
+  let j = ref 0 in
+  while !j < n do
+    while !i < n do
+      i := test20 !i
+    done;
+    if n > 0 then raise (Exn_int !i);
+  done;
+
+
+(*
+The check is too conservative about recursive catch to handle the following:
+
+let[@noalloc] test22 n =
+  let e = (Exn_int n) in
+  for i = 0 to n do
+    ();
+  done;
+  raise e
+*)

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -11,11 +11,11 @@ let[@inline never] test1 n =
 
 let[@inline never] test2 n  = List.length(test1 n)
 
-let[@noalloc][@inline never] test3 l  = List.length l
+let[@noalloc_strict][@inline never] test3 l  = List.length l
 
-let[@noalloc][@inline never] test6 n = n + 37
+let[@noalloc_strict][@inline never] test6 n = n + 37
 
-let[@noalloc][@inline never] test7 n m = (test6 n) * (test6 m)
+let[@noalloc_strict][@inline never] test7 n m = (test6 n) * (test6 m)
 
 exception Exn_string of string
 exception Exn_int of int
@@ -33,16 +33,16 @@ let[@inline never] test9 n =
   try test8 n
   with _ -> 0
 
-let[@noalloc][@inline never] test10 n =
+let[@noalloc_strict][@inline never] test10 n =
   match n with
   | 1 -> raise_notrace Exn
   | _ -> 10
 
-let[@noalloc][@inline never] test11 n =
+let[@noalloc_strict][@inline never] test11 n =
   try test10 n
   with Exn -> 10
 
-let[@noalloc][@inline never] test12 n =
+let[@noalloc_strict][@inline never] test12 n =
   let test n =
     match n with
     | 1 -> raise Exn
@@ -57,10 +57,10 @@ let[@inline never] test13 n =
 
 let test14 n = Float.of_int n
 
-let[@noalloc][@inline never] test15 n = Int64.to_int (Int64.of_float (test14 n))
+let[@noalloc_strict][@inline never] test15 n = Int64.to_int (Int64.of_float (test14 n))
 
-let[@noalloc] test16 n m = S.foo n m
-let[@noalloc] test17 n m = S.foo (S.foo n n) m
+let[@noalloc_strict] test16 n m = S.foo n m
+let[@noalloc_strict] test17 n m = S.foo (S.foo n n) m
 let test18 n m = S.foo n m
 
 exception Exn3 of (int * int)

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -68,9 +68,7 @@ type boo =
   | A
   | B of int
 
-(* CR gyorsh: analysis for noalloc_exn is not yet implemented.
-   It ignores allocations post-dominated by a raise. *)
-let(* [@noalloc_exn] *)[@inline never] test18 n boo =
+let[@noalloc][@inline never] test18 n boo =
   if n > 0 then n + n
   else begin
     let k = 45 in
@@ -90,7 +88,7 @@ let[@inline never] test19 n =
   in
   create n
 
-let(* [@noalloc_exn] *) rec foo n =
+let[@noalloc] rec foo n =
   bar (n-1)
-and(* [@noalloc_exn] *) bar n =
+and[@noalloc] bar n =
   foo (n-1)

--- a/tests/backend/checkmach/t5.ml
+++ b/tests/backend/checkmach/t5.ml
@@ -1,3 +1,8 @@
 let[@noalloc_strict assume][@inline never] test x = [x;x+1]
 (* The test below to make sure "noalloc" on external is still handled correctly. *)
 external external_test : unit -> unit = "test" [@@noalloc]
+
+let[@noalloc assume][@inline never] test4 x =
+  if x > (-100)
+  then x
+  else raise (Failure ("don't be so negative, "^(string_of_int x)))

--- a/tests/backend/checkmach/t5.ml
+++ b/tests/backend/checkmach/t5.ml
@@ -1,3 +1,3 @@
-let[@noalloc assume][@inline never] test x = [x;x+1]
+let[@noalloc_strict assume][@inline never] test x = [x;x+1]
 (* The test below to make sure "noalloc" on external is still handled correctly. *)
 external external_test : unit -> unit = "test" [@@noalloc]

--- a/tests/backend/checkmach/test_assume.ml
+++ b/tests/backend/checkmach/test_assume.ml
@@ -1,3 +1,3 @@
-let[@noalloc assume][@inline never] test1 n = (n,n)
-let[@noalloc] test2 n = test1 (n+1)
-let[@noalloc] test3 n = T5.test n
+let[@noalloc_strict assume][@inline never] test1 n = (n,n)
+let[@noalloc_strict] test2 n = test1 (n+1)
+let[@noalloc_strict] test3 n = T5.test n

--- a/tests/backend/checkmach/test_assume.ml
+++ b/tests/backend/checkmach/test_assume.ml
@@ -1,3 +1,9 @@
 let[@noalloc_strict assume][@inline never] test1 n = (n,n)
 let[@noalloc_strict] test2 n = test1 (n+1)
 let[@noalloc_strict] test3 n = T5.test n
+let no_annotations x y = x * y
+
+let[@noalloc] test4 x = if x > 0 then x
+  else raise (Failure ("be postitive, not "^(string_of_int x)))
+
+let[@noalloc] test5 x = T5.test4 x

--- a/tests/backend/checkmach/test_attribute_error_duplicate.ml
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.ml
@@ -1,3 +1,3 @@
-let[@noalloc][@noalloc] test1 x = x,x
-let[@noalloc assume][@noalloc] test2 x = x,x
-let[@noalloc check] test3 x = x,x
+let[@noalloc_strict][@noalloc_strict] test1 x = x,x
+let[@noalloc_strict assume][@noalloc_strict] test2 x = x,x
+let[@noalloc_strict check] test3 x = x,x

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -1,7 +1,7 @@
-File "test_attribute_error_duplicate.ml", line 1, characters 15-22:
-Warning 54 [duplicated-attribute]: the "noalloc" attribute is used more than once on this expression
-File "test_attribute_error_duplicate.ml", line 2, characters 22-29:
-Warning 54 [duplicated-attribute]: the "noalloc" attribute is used more than once on this expression
-File "test_attribute_error_duplicate.ml", line 3, characters 5-12:
-Warning 47 [attribute-payload]: illegal payload for attribute 'noalloc'.
+File "test_attribute_error_duplicate.ml", line 1, characters 22-36:
+Warning 54 [duplicated-attribute]: the "noalloc_strict" attribute is used more than once on this expression
+File "test_attribute_error_duplicate.ml", line 2, characters 29-43:
+Warning 54 [duplicated-attribute]: the "noalloc_strict" attribute is used more than once on this expression
+File "test_attribute_error_duplicate.ml", line 3, characters 5-19:
+Warning 47 [attribute-payload]: illegal payload for attribute 'noalloc_strict'.
 It must be either 'assume' or empty

--- a/tests/backend/checkmach/test_flambda.ml
+++ b/tests/backend/checkmach/test_flambda.ml
@@ -2,6 +2,6 @@
    separate file for them. *)
 let[@inline always] test4 n = (n+1,n)
 
-let[@noalloc][@inline never] test5 n =
+let[@noalloc_strict][@inline never] test5 n =
   let first,_ = (test4 (n + 1)) in
   first

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -192,7 +192,11 @@ let print_cmx_infos (ui, crc) =
   print_generic_fns ui.ui_generic_fns;
   printf "Force link: %s\n" (if ui.ui_force_link then "YES" else "no");
   printf "Functions with neither allocations nor indirect calls:\n";
-  String.Set.iter print_line ui.ui_checks.ui_noalloc_functions
+  String.Set.iter print_line ui.ui_checks.ui_noalloc_functions;
+  printf
+    "Functions without allocations and indirect calls, \
+     except when post-dominated by a raise:\n";
+  String.Set.iter print_line ui.ui_checks.ui_noalloc_exn_functions
 
 let print_cmxa_infos (lib : Cmx_format.library_infos) =
   printf "Extra C object files:";


### PR DESCRIPTION
Adapted from another part of #707. 

This PR adds attributes `[@noalloc_exn ]` and `[@noalloc_exn assume]` which are similar to `[@noalloc]` and `[@noalloc assume]`, respectively, added in #825, except the allow allocation and indirect calls post-dominated by a `raise`. 

The way we currently determine post-dominators is conservative around `try-with` and some other cases, so might not be able to prove everything that the user expects.