### PR TITLE
Static check for noalloc: even nicer error messages

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -251,8 +251,8 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Assert of property
-  | Assume of property
+  | Assert of property * Debuginfo.t
+  | Assume of property * Debuginfo.t
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -260,8 +260,8 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Assert of property
-  | Assume of property
+  | Assert of property * Debuginfo.t
+  | Assume of property * Debuginfo.t
 
 type fundecl =
   { fun_name: string;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4175,5 +4175,5 @@ let transl_property : Lambda.property -> Cmm.property = function
 
 let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
   | Default_check -> []
-  | Assert p -> [Assert (transl_property p)]
-  | Assume p -> [Assume (transl_property p)]
+  | Assert (p,dbg) -> [Assert ((transl_property p), Debuginfo.from_location dbg)]
+  | Assume (p,dbg) -> [Assume ((transl_property p), Debuginfo.from_location dbg)]

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -346,8 +346,8 @@ let codegen_option = function
   | Reduce_code_size -> "reduce_code_size"
   | No_CSE -> "no_cse"
   | Use_linscan_regalloc -> "linscan"
-  | Assert p -> "assert "^(property p)
-  | Assume p -> "assume "^(property p)
+  | Assert (p,_) -> "assert "^(property p)
+  | Assume (p,_) -> "assume "^(property p)
 
 let print_codegen_options ppf l =
   List.iter (fun c -> fprintf ppf " %s" (codegen_option c)) l

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -16,8 +16,8 @@ end
 
 type t =
   | Default_check
-  | Assert of Property.t
-  | Assume of Property.t
+  | Assert of Property.t * Debuginfo.t
+  | Assume of Property.t * Debuginfo.t
 
 val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -255,8 +255,8 @@ let transl_property : Check_attribute.Property.t -> Cmm.property = function
 let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list =
   function
   | Default_check -> []
-  | Assert p -> [Assert (transl_property p)]
-  | Assume p -> [Assume (transl_property p)]
+  | Assert (p,dbg) -> [Assert (transl_property p, dbg)]
+  | Assume (p,dbg) -> [Assume (transl_property p, dbg)]
 
 (* Translation of the bodies of functions. *)
 

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -377,8 +377,8 @@ type property =
 
 type check_attribute =
   | Default_check
-  | Assert of property
-  | Assume of property
+  | Assert of property * scoped_location
+  | Assume of property * scoped_location
 
 type function_kind = Curried of {nlocal: int} | Tupled
 

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -372,6 +372,8 @@ type local_attribute =
   | Never_local (* [@local never] *)
   | Default_local (* [@local maybe] or no [@local] attribute *)
 
+type scoped_location = Debuginfo.Scoped_location.t
+
 type property =
   | Noalloc
 
@@ -403,8 +405,6 @@ type function_attribute = {
   is_a_functor: bool;
   stub: bool;
 }
-
-type scoped_location = Debuginfo.Scoped_location.t
 
 type lambda =
     Lvar of Ident.t

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -290,8 +290,8 @@ type property =
 
 type check_attribute =
   | Default_check
-  | Assert of property
-  | Assume of property
+  | Assert of property * scoped_location
+  | Assume of property * scoped_location
 
 type function_kind = Curried of {nlocal: int} | Tupled
 (* [nlocal] determines how many arguments may be partially applied

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -285,6 +285,8 @@ type local_attribute =
   | Never_local (* [@local never] *)
   | Default_local (* [@local maybe] or no [@local] attribute *)
 
+type scoped_location = Debuginfo.Scoped_location.t
+
 type property =
   | Noalloc
 
@@ -323,8 +325,6 @@ type function_attribute = {
   is_a_functor: bool;
   stub: bool;
 }
-
-type scoped_location = Debuginfo.Scoped_location.t
 
 type lambda =
     Lvar of Ident.t

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -556,8 +556,8 @@ let check_attribute ppf check =
   in
   match check with
   | Default_check -> ()
-  | Assert p -> fprintf ppf "assert %s@ " (check_property p)
-  | Assume p -> fprintf ppf "assume %s@ " (check_property p)
+  | Assert (p,_) -> fprintf ppf "assert %s@ " (check_property p)
+  | Assume (p,_) -> fprintf ppf "assume %s@ " (check_property p)
 
 let function_attribute ppf { inline; specialise; check; local; is_a_functor; stub } =
   if is_a_functor then

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
-File "fail1.ml", line 3, characters 21-65:
+File "fail1.ml", line 3, characters 5-12:
 Error: Annotation check for noalloc failed on function camlFail1__test15_HIDE_STAMP

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
-File "fail2.ml", line 1, characters 19-28:
+File "fail2.ml", line 1, characters 5-12:
 Error: Annotation check for noalloc failed on function camlFail2__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
-File "fail3.ml", line 2, characters 19-33:
+File "fail3.ml", line 2, characters 5-12:
 Error: Annotation check for noalloc failed on function camlFail3__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
-File "fail4.ml", line 2, characters 19-33:
+File "fail4.ml", line 2, characters 5-12:
 Error: Annotation check for noalloc failed on function camlFail4__test_HIDE_STAMP


### PR DESCRIPTION
Improves the error messages introduced in #826 to point to the annotation (instead of highlighting the entire function's body). I tested it in the editor on a bunch of large functions and I think it is more convenient.

Unfortunately, to do it we need to keep track of the location of the attribute all the way through the middle-end. It's not a big code change, because the `Debuginfo.t` propagated alongside the `property` doesn't need to be updated.
