### PR TITLE
Reload: check stack slot and register class when deciding whether a move is a no-op

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -507,7 +507,7 @@ let emit_global_label s =
   _label lbl
 
 let move (src : Reg.t) (dst : Reg.t) =
-  if src.loc <> dst.loc then
+  if src.loc <> dst.loc || Proc.register_class src <> Proc.register_class dst then
     begin match src.typ, src.loc, dst.typ, dst.loc with
     | Float, Reg.Reg _, Float, Reg.Reg _ -> I.movapd (reg src) (reg dst)
     | Float, _, Float, _ -> I.movsd (reg src) (reg dst)

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -507,7 +507,7 @@ let emit_global_label s =
   _label lbl
 
 let move (src : Reg.t) (dst : Reg.t) =
-  if src.loc <> dst.loc || Proc.register_class src <> Proc.register_class dst then
+  if src.loc <> dst.loc then
     begin match src.typ, src.loc, dst.typ, dst.loc with
     | Float, Reg.Reg _, Float, Reg.Reg _ -> I.movapd (reg src) (reg dst)
     | Float, _, Float, _ -> I.movsd (reg src) (reg dst)

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -453,12 +453,11 @@ let is_pure_basic : basic -> bool = function
 
 let is_noop_move instr =
   match instr.desc with
-  | Op (Move | Spill | Reload) -> (
-    match instr.arg.(0).loc with
+  | Op (Move | Spill | Reload) ->
+    (match instr.arg.(0).loc with
     | Unknown -> false
-    | Reg _ | Stack _ ->
-      Reg.same_loc instr.arg.(0) instr.res.(0))
-      && Proc.register_class instr.arg.(0) = Proc.register_class instr.res.(0)
+    | Reg _ | Stack _ -> Reg.same_loc instr.arg.(0) instr.res.(0))
+    && Proc.register_class instr.arg.(0) = Proc.register_class instr.res.(0)
   | Op
       ( Const_int _ | Const_float _ | Const_symbol _ | Stackoffset _ | Load _
       | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf | Subf | Mulf

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -456,7 +456,9 @@ let is_noop_move instr =
   | Op (Move | Spill | Reload) -> (
     match instr.arg.(0).loc with
     | Unknown -> false
-    | Reg _ | Stack _ -> Reg.same_loc instr.arg.(0) instr.res.(0))
+    | Reg _ | Stack _ ->
+      Reg.same_loc instr.arg.(0) instr.res.(0))
+      && Proc.register_class instr.arg.(0) = Proc.register_class instr.res.(0)
   | Op
       ( Const_int _ | Const_float _ | Const_symbol _ | Stackoffset _ | Load _
       | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf | Subf | Mulf

--- a/backend/reloadgen.ml
+++ b/backend/reloadgen.ml
@@ -65,8 +65,14 @@ method reload_operation op arg res =
   match op with
     Imove | Ireload | Ispill ->
       begin match arg.(0), res.(0) with
-        {loc = Stack s1}, {loc = Stack s2} when s1 <> s2 ->
-          ([| self#makereg arg.(0) |], res)
+        {loc = Stack s1}, {loc = Stack s2} ->
+          if s1 = s2
+          && Proc.register_class arg.(0) = Proc.register_class res.(0) then
+            (* nothing will be emitted later,
+               not necessary to apply constraints *)
+            (arg, res)
+          else
+            ([| self#makereg arg.(0) |], res)
       | _ ->
           (arg, res)
       end


### PR DESCRIPTION
I think there might be a bug in [Reloadgen](https://github.com/ocaml-flambda/flambda-backend/blob/main/backend/reloadgen.ml#L68), which
is both quite unlikely and amd64-specific.

The issue is that `Reloadgen` accepts to leave both
operands of a move on the stack if they share the
same slot because it knows no instruction will be
emitted later, which means the constraints on the
operands are meaningless.

However, slots are bare integers, and each register
class indexes its slots from `0`. So, if we are unlucky
enough, it looks like a move with operands _(i)_ in
different register classes and _(ii)_ the same slot
will be considered as a nop when they should not.

(I think the same code pattern in arm64's [Reload](https://github.com/ocaml-flambda/flambda-backend/blob/main/backend/arm64/reload.ml)
is fine because on this architecture the operands
of a move are guaranteed to be in the same
register class.)