### PR TITLE
Allow the compiler to build with stock Dune

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       id: cache
       with:
         path: ${{ github.workspace }}/ocaml-412/_install
-        key: ${{ matrix.os }}-cache-ocaml-412-dune-2.7.0-275-gf01752f7
+        key: ${{ matrix.os }}-cache-ocaml-412-dune-341
 
     - name: Checkout OCaml 4.12
       uses: actions/checkout@master
@@ -111,8 +111,8 @@ jobs:
       uses: actions/checkout@master
       if: steps.cache.outputs.cache-hit != 'true'
       with:
-        repository: 'ocaml-flambda/dune'
-        ref: 'special_dune'
+        repository: 'ocaml/dune'
+        ref: '3.4.1'
         path: 'dune'
 
     - name: Build dune

--- a/README.md
+++ b/README.md
@@ -20,10 +20,7 @@ One-time setup:
 ```
 $ opam switch 4.12.0  # or "opam switch create 4.12.0" if you haven't got that switch already
 $ eval $(opam env)
-$ git clone https://github.com/ocaml-flambda/dune
-$ cd dune  # We'll refer to this "dune" directory below as $DUNE_DIR
-$ git checkout origin/special_dune
-$ make release
+$ opam install dune
 ```
 
 You probably then want to fork the `ocaml-flambda/flambda-backend` repo to your own Github org.

--- a/dune
+++ b/dune
@@ -483,9 +483,12 @@
 
 (install
  (files
-  (external/owee/libcompiler_owee_stubs_native.a
+  (external/owee/libcompiler_owee_stubs.a
    as
-   compiler-libs/libcompiler_owee_stubs_native.a)
+   compiler-libs/libcompiler_owee_stubs.a)
+  (external/owee/libcompiler_owee_stubs.a
+   as
+   compiler-libs/libcompiler_owee_stubs_native.a) ; for special_dune compat
   (ocamloptcomp_with_flambda2.cma as compiler-libs/ocamloptcomp.cma)
   (ocamloptcomp_with_flambda2.cmxa as compiler-libs/ocamloptcomp.cmxa)
   (ocamloptcomp_with_flambda2.a as compiler-libs/ocamloptcomp.a))

--- a/external/memtrace/src/dune
+++ b/external/memtrace/src/dune
@@ -1,4 +1,4 @@
 (library
  (name memtrace)
- (libraries unix threads))
+ (libraries unix))
 

--- a/external/memtrace/src/memprof_tracer.ml
+++ b/external/memtrace/src/memprof_tracer.ml
@@ -1,3 +1,7 @@
+module Thread = struct
+  let yield () : unit = failwith "only single threaded programs supported"
+end
+
 type t =
   { mutable locked : bool;
     mutable locked_ext : bool;

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -94,7 +94,7 @@
    ;; some of COMP
    pparse main_args compenv compmisc makedepend compile_common
    ; manual update: mli only files
-   cmo_format
+   annot asttypes cmo_format outcometree parsetree debug_event
  ))
 
 (library

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -65,9 +65,14 @@
     bytesections
     dll
     meta
-    symtable)
+    symtable
+    asttypes
+    parsetree
+    outcometree
+    cmo_format
+    cmxs_format
+    debug_event)
   (modules_without_implementation
-    ; Bug in Dune: copy_files rules don't trigger for these
     asttypes
     parsetree
     outcometree

--- a/ocaml/otherlibs/str/dune
+++ b/ocaml/otherlibs/str/dune
@@ -31,7 +31,7 @@
   (files
     .str.objs/native/str.cmx
     libstr_stubs.a
-    libstr_stubs_native.a
+    (libstr_stubs.a as libstr_stubs_native.a) ; for special_dune compat
     (dllstr_stubs.so as stublibs/dllstr_stubs.so)
     str.cmxa
     str.a

--- a/ocaml/otherlibs/systhreads/byte/dune
+++ b/ocaml/otherlibs/systhreads/byte/dune
@@ -1,0 +1,17 @@
+(copy_files# ../*.{c,h,ml,mli})
+
+(library
+  (name threads)
+  (modes byte)
+  (wrapped false)
+  (flags -w +33..39 -warn-error A -g -bin-annot -safe-string)
+  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+  (libraries unix)
+  (library_flags -linkall)
+  (c_library_flags -lpthread)
+  (foreign_stubs
+    (language c)
+    (names st_stubs)
+    (flags ((:include %{project_root}/oc_cflags.sexp)
+            (:include %{project_root}/sharedlib_cflags.sexp)
+            (:include %{project_root}/oc_cppflags.sexp)))))

--- a/ocaml/otherlibs/systhreads/dune
+++ b/ocaml/otherlibs/systhreads/dune
@@ -12,56 +12,20 @@
 ;*                                                                        *
 ;**************************************************************************
 
-(library
-  (name threads)
-  (modes byte native)
-  (wrapped false)
-  (modules
-    condition
-    event
-    mutex
-    semaphore
-    thread)
-  (flags -w +33..39 -warn-error A -g -bin-annot -safe-string)
-  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
-  (libraries unix)
-  (library_flags -linkall)
-  (c_library_flags -lpthread)
-  (foreign_stubs
-    (language c)
-    (names st_stubs_byte)
-    (mode byte)
-    (flags ((:include %{project_root}/oc_cflags.sexp)
-            (:include %{project_root}/sharedlib_cflags.sexp)
-            (:include %{project_root}/oc_cppflags.sexp))))
-  (foreign_stubs
-    (language c)
-    (names st_stubs_native)
-    (mode native)
-    (flags ((-DNATIVE_CODE)
-            (:include %{project_root}/oc_cflags.sexp)
-            (:include %{project_root}/sharedlib_cflags.sexp)
-            (:include %{project_root}/oc_cppflags.sexp)))))
-
-(rule
-  (targets st_stubs_byte.c)
-  (action (copy st_stubs.c %{targets})))
-
-(rule
-  (targets st_stubs_native.c)
-  (action (copy st_stubs.c %{targets})))
 
 ; For some reason the C header files aren't being found if this library
 ; is given a public name, so we do the installation manually.
 (install
   (files
-    (threads.cma as threads/threads.cma)
-    (threads.cmxa as threads/threads.cmxa)
-    (threads.a as threads/threads.a)
+    (byte/threads.cma as threads/threads.cma)
+    (native/threadsnat.cmxa as threads/threads.cmxa)
+    (native/threadsnat.a as threads/threads.a)
 
-    libthreads_stubs.a
-    libthreads_stubs_native.a
-    (dllthreads_stubs.so as stublibs/dllthreads_stubs.so)
+    (byte/libthreads_stubs.a as libthreads_stubs.a)
+    (byte/dllthreads_stubs.so as stublibs/dllthreads_stubs.so)
+    (native/libthreadsnat_stubs.a as libthreadsnat_stubs.a)
+    (native/libthreadsnat_stubs.a as libthreadsnat_stubs_native.a) ; for special_dune compat
+
 
     (thread.mli as threads/thread.mli)
     (condition.mli as threads/condition.mli)
@@ -71,23 +35,24 @@
 
     (threads.h as caml/threads.h)
 
-    (.threads.objs/native/condition.cmx as threads/condition.cmx)
-    (.threads.objs/native/event.cmx as threads/event.cmx)
-    (.threads.objs/native/mutex.cmx as threads/mutex.cmx)
-    (.threads.objs/native/semaphore.cmx as threads/semaphore.cmx)
-    (.threads.objs/native/thread.cmx as threads/thread.cmx)
+    (native/.threadsnat.objs/native/condition.cmx as threads/condition.cmx)
+    (native/.threadsnat.objs/native/event.cmx as threads/event.cmx)
+    (native/.threadsnat.objs/native/mutex.cmx as threads/mutex.cmx)
+    (native/.threadsnat.objs/native/semaphore.cmx as threads/semaphore.cmx)
+    (native/.threadsnat.objs/native/thread.cmx as threads/thread.cmx)
 
-    (.threads.objs/byte/condition.cmi as threads/condition.cmi)
-    (.threads.objs/byte/condition.cmti as threads/condition.cmti)
-    (.threads.objs/byte/event.cmi as threads/event.cmi)
-    (.threads.objs/byte/event.cmti as threads/event.cmti)
-    (.threads.objs/byte/mutex.cmi as threads/mutex.cmi)
-    (.threads.objs/byte/mutex.cmti as threads/mutex.cmti)
-    (.threads.objs/byte/semaphore.cmi as threads/semaphore.cmi)
-    (.threads.objs/byte/semaphore.cmti as threads/semaphore.cmti)
-    (.threads.objs/byte/thread.cmi as threads/thread.cmi)
-    (.threads.objs/byte/thread.cmti as threads/thread.cmti)
+    (byte/.threads.objs/byte/condition.cmi as threads/condition.cmi)
+    (byte/.threads.objs/byte/condition.cmti as threads/condition.cmti)
+    (byte/.threads.objs/byte/event.cmi as threads/event.cmi)
+    (byte/.threads.objs/byte/event.cmti as threads/event.cmti)
+    (byte/.threads.objs/byte/mutex.cmi as threads/mutex.cmi)
+    (byte/.threads.objs/byte/mutex.cmti as threads/mutex.cmti)
+    (byte/.threads.objs/byte/semaphore.cmi as threads/semaphore.cmi)
+    (byte/.threads.objs/byte/semaphore.cmti as threads/semaphore.cmti)
+    (byte/.threads.objs/byte/thread.cmi as threads/thread.cmi)
+    (byte/.threads.objs/byte/thread.cmti as threads/thread.cmti)
   )
   (section lib)
   (package ocaml))
+
 

--- a/ocaml/otherlibs/systhreads/native/dune
+++ b/ocaml/otherlibs/systhreads/native/dune
@@ -1,0 +1,18 @@
+(copy_files# ../*.{c,h,ml,mli})
+
+(library
+  (name threadsnat)
+  (modes native)
+  (wrapped false)
+  (flags -w +33..39 -warn-error A -g -bin-annot -safe-string)
+  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+  (libraries unix)
+  (library_flags -linkall)
+  (c_library_flags -lpthread)
+  (foreign_stubs
+    (language c)
+    (names st_stubs)
+    (flags ((-DNATIVE_CODE)
+            (:include %{project_root}/oc_cflags.sexp)
+            (:include %{project_root}/sharedlib_cflags.sexp)
+            (:include %{project_root}/oc_cppflags.sexp)))))

--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -19,13 +19,10 @@
  (flags (
    -absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot
    -g -safe-string -strict-sequence -strict-formats
+   -nolabels   ; for UnixLabels
  ))
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall))
- ; UnixLabels is compiled separately as it needs the -nolabels flag.  We can't
- ; currently use an attribute in the .ml file to enable this behaviour as
- ; the system compiler used to build the boot compiler won't understand it.
- (modules (:standard \ unixLabels))
  (foreign_stubs (language c) (names
    accept access addrofstr alarm bind channels chdir chmod chown chroot close
    fsync closedir connect cst2constr cstringv dup dup2 envir errmsg execv execve
@@ -43,63 +40,22 @@
            (:include %{project_root}/oc_cppflags.sexp)))
  ))
 
-(library
- (name unixlabels)
- (libraries unix)
- (wrapped false)
- (modes byte native)
- (flags (
-   -absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot
-   -g -safe-string -strict-sequence -strict-formats -nolabels
- ))
- (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
- (modules unixLabels)
-)
-
-(rule
- (targets unix_merged.a)
- (action
-  (run
-   %{dep:../../../tools/merge_dot_a_files.sh}
-   %{targets}
-   %{dep:unix.a}
-   %{dep:unixlabels.a})))
-
-(rule
- (targets unix_merged.cma)
- (action
-  (run
-   %{dep:../../../tools/merge_archives.exe}
-   %{targets}
-   %{dep:unix.cma}
-   %{dep:unixlabels.cma})))
-
-(rule
- (targets unix_merged.cmxa)
- (action
-  (run
-   %{dep:../../../tools/merge_archives.exe}
-   %{targets}
-   %{dep:unix.cmxa}
-   %{dep:unixlabels.cmxa})))
-
 (install
   (files
     .unix.objs/native/unix.cmx
-    .unixlabels.objs/native/unixLabels.cmx
-    (unix_merged.cmxa as unix.cmxa)
-    (unix_merged.a as unix.a)
-    (unix_merged.cma as unix.cma)
+    .unix.objs/native/unixLabels.cmx
+    unix.cmxa
+    unix.a
+    unix.cma
     .unix.objs/byte/unix.cmi
     .unix.objs/byte/unix.cmti
-    .unixlabels.objs/byte/unixLabels.cmi
-    .unixlabels.objs/byte/unixLabels.cmti
-    ; For the moment unix.cmxs does not include UnixLabels.
+    .unix.objs/byte/unixLabels.cmi
+    .unix.objs/byte/unixLabels.cmti
     unix.cmxs
     unix.mli
     unixLabels.mli
     libunix_stubs.a
-    libunix_stubs_native.a
+    (libunix_stubs.a as libunix_stubs_native.a) ; for special_dune compat
     (dllunix_stubs.so as stublibs/dllunix_stubs.so)
     (socketaddr.h as caml/socketaddr.h)
     (unixsupport.h as caml/unixsupport.h)


### PR DESCRIPTION
  - Build bytecode and native code versions of systhreads separately
  - Avoid using merge_archives to build Unix
  - Explicitly list mli-only files in (modules) stanzas

For compatibility with the existing `special_dune` patches, the dune files here redundantly install native stubs under the `libfoo_stubs_native.a` names that `special_dune` expects. (These lines will only be needed as long as special_dune is in use).

