### PR TITLE
Add build system hooks for ocaml-jst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ boot_ocamlobjinfo = tools/flambda_backend_objinfo.exe
 ocamldir = ocaml
 toplevels_installed = top opttop
 
+$(ocamldir)/duneconf/jst-extra.inc:
+	echo > $@
+
 include ocaml/Makefile.common-jst
 
 .PHONY: ci

--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -94,7 +94,9 @@ $(ocamldir)/duneconf/dirs-to-ignore.inc:
 	echo "(data_only_dirs yacc $(ocaml_subdirs_to_ignore))" > $@
 
 _build/_bootinstall: Makefile.config duneconf/boot.ws duneconf/runtime_stdlib.ws duneconf/main.ws \
-	$(ocamldir)/duneconf/dirs-to-ignore.inc
+	$(ocamldir)/duneconf/dirs-to-ignore.inc \
+	$(ocamldir)/duneconf/jst-extra.inc \
+	dune-project
 
 	echo -n '$(NATDYNLINKOPTS)' > $(ocamldir)/otherlibs/dynlink/natdynlinkops
 


### PR DESCRIPTION
This patch is a no-op, but gives me somewhere to hook in other dune rules for `ocaml-jst`.