### PR TITLE
Static check for noalloc: rename attribute

### DIFF
--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -40,7 +40,7 @@ let is_local_attribute = function
 
 let is_property_attribute p a =
   match p, a with
-  | Noalloc, {txt=("noalloc"|"ocaml.noalloc")} -> true
+  | Noalloc, {txt=("noalloc_strict"|"ocaml.noalloc_strict")} -> true
   | _ -> false
 
 let find_attribute p attributes =
@@ -300,7 +300,7 @@ let add_local_attribute expr loc attributes =
 
 let add_check_attribute expr loc attributes =
   let to_string = function
-    | Noalloc -> "noalloc"
+    | Noalloc -> "noalloc_strict"
   in
   let to_string = function
     | Assert p -> to_string p

--- a/tests/backend/checkmach/fail1.ml
+++ b/tests/backend/checkmach/fail1.ml
@@ -1,3 +1,3 @@
 let[@inline never] test14 n = Float.of_int n
 
-let[@noalloc] test15 n = Int64.to_int (Int64.of_float (test14 n))
+let[@noalloc_strict] test15 n = Int64.to_int (Int64.of_float (test14 n))

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
-File "fail1.ml", line 3, characters 21-65:
+File "fail1.ml", line 3, characters 28-72:
 Error: Annotation check for noalloc failed on function camlFail1__test15_HIDE_STAMP

--- a/tests/backend/checkmach/fail2.ml
+++ b/tests/backend/checkmach/fail2.ml
@@ -1,1 +1,1 @@
-let[@noalloc] test x = (x,x)
+let[@noalloc_strict] test x = (x,x)

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
-File "fail2.ml", line 1, characters 19-28:
+File "fail2.ml", line 1, characters 26-35:
 Error: Annotation check for noalloc failed on function camlFail2__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail3.ml
+++ b/tests/backend/checkmach/fail3.ml
@@ -1,2 +1,2 @@
 (* Always inlined from a different file *)
-let[@noalloc] test n = T3.test4 n
+let[@noalloc_strict] test n = T3.test4 n

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
-File "fail3.ml", line 2, characters 19-33:
+File "fail3.ml", line 2, characters 26-40:
 Error: Annotation check for noalloc failed on function camlFail3__test_HIDE_STAMP

--- a/tests/backend/checkmach/fail4.ml
+++ b/tests/backend/checkmach/fail4.ml
@@ -1,2 +1,2 @@
 (* T.test1 is never inlined and allocates. *)
-let[@noalloc] test n = T4.test1 n
+let[@noalloc_strict] test n = T4.test1 n

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
-File "fail4.ml", line 2, characters 19-33:
+File "fail4.ml", line 2, characters 26-40:
 Error: Annotation check for noalloc failed on function camlFail4__test_HIDE_STAMP

--- a/tests/backend/checkmach/s.ml
+++ b/tests/backend/checkmach/s.ml
@@ -1,2 +1,2 @@
-let[@noalloc][@inline never] foo n m = n + m
+let[@noalloc_strict][@inline never] foo n m = n + m
 let[@inline never] bar n m = (n, m)

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -11,11 +11,11 @@ let[@inline never] test1 n =
 
 let[@inline never] test2 n  = List.length(test1 n)
 
-let[@noalloc][@inline never] test3 l  = List.length l
+let[@noalloc_strict][@inline never] test3 l  = List.length l
 
-let[@noalloc][@inline never] test6 n = n + 37
+let[@noalloc_strict][@inline never] test6 n = n + 37
 
-let[@noalloc][@inline never] test7 n m = (test6 n) * (test6 m)
+let[@noalloc_strict][@inline never] test7 n m = (test6 n) * (test6 m)
 
 exception Exn_string of string
 exception Exn_int of int
@@ -33,16 +33,16 @@ let[@inline never] test9 n =
   try test8 n
   with _ -> 0
 
-let[@noalloc][@inline never] test10 n =
+let[@noalloc_strict][@inline never] test10 n =
   match n with
   | 1 -> raise_notrace Exn
   | _ -> 10
 
-let[@noalloc][@inline never] test11 n =
+let[@noalloc_strict][@inline never] test11 n =
   try test10 n
   with Exn -> 10
 
-let[@noalloc][@inline never] test12 n =
+let[@noalloc_strict][@inline never] test12 n =
   let test n =
     match n with
     | 1 -> raise Exn
@@ -57,10 +57,10 @@ let[@inline never] test13 n =
 
 let test14 n = Float.of_int n
 
-let[@noalloc][@inline never] test15 n = Int64.to_int (Int64.of_float (test14 n))
+let[@noalloc_strict][@inline never] test15 n = Int64.to_int (Int64.of_float (test14 n))
 
-let[@noalloc] test16 n m = S.foo n m
-let[@noalloc] test17 n m = S.foo (S.foo n n) m
+let[@noalloc_strict] test16 n m = S.foo n m
+let[@noalloc_strict] test17 n m = S.foo (S.foo n n) m
 let test18 n m = S.foo n m
 
 exception Exn3 of (int * int)

--- a/tests/backend/checkmach/t5.ml
+++ b/tests/backend/checkmach/t5.ml
@@ -1,3 +1,3 @@
-let[@noalloc assume][@inline never] test x = [x;x+1]
+let[@noalloc_strict assume][@inline never] test x = [x;x+1]
 (* The test below to make sure "noalloc" on external is still handled correctly. *)
 external external_test : unit -> unit = "test" [@@noalloc]

--- a/tests/backend/checkmach/test_assume.ml
+++ b/tests/backend/checkmach/test_assume.ml
@@ -1,3 +1,3 @@
-let[@noalloc assume][@inline never] test1 n = (n,n)
-let[@noalloc] test2 n = test1 (n+1)
-let[@noalloc] test3 n = T5.test n
+let[@noalloc_strict assume][@inline never] test1 n = (n,n)
+let[@noalloc_strict] test2 n = test1 (n+1)
+let[@noalloc_strict] test3 n = T5.test n

--- a/tests/backend/checkmach/test_attribute_error_duplicate.ml
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.ml
@@ -1,3 +1,3 @@
-let[@noalloc][@noalloc] test1 x = x,x
-let[@noalloc assume][@noalloc] test2 x = x,x
-let[@noalloc check] test3 x = x,x
+let[@noalloc_strict][@noalloc_strict] test1 x = x,x
+let[@noalloc_strict assume][@noalloc_strict] test2 x = x,x
+let[@noalloc_strict check] test3 x = x,x

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -1,7 +1,7 @@
-File "test_attribute_error_duplicate.ml", line 1, characters 15-22:
-Warning 54 [duplicated-attribute]: the "noalloc" attribute is used more than once on this expression
-File "test_attribute_error_duplicate.ml", line 2, characters 22-29:
-Warning 54 [duplicated-attribute]: the "noalloc" attribute is used more than once on this expression
-File "test_attribute_error_duplicate.ml", line 3, characters 5-12:
-Warning 47 [attribute-payload]: illegal payload for attribute 'noalloc'.
+File "test_attribute_error_duplicate.ml", line 1, characters 22-36:
+Warning 54 [duplicated-attribute]: the "noalloc_strict" attribute is used more than once on this expression
+File "test_attribute_error_duplicate.ml", line 2, characters 29-43:
+Warning 54 [duplicated-attribute]: the "noalloc_strict" attribute is used more than once on this expression
+File "test_attribute_error_duplicate.ml", line 3, characters 5-19:
+Warning 47 [attribute-payload]: illegal payload for attribute 'noalloc_strict'.
 It must be either 'assume' or empty

--- a/tests/backend/checkmach/test_flambda.ml
+++ b/tests/backend/checkmach/test_flambda.ml
@@ -2,6 +2,6 @@
    separate file for them. *)
 let[@inline always] test4 n = (n+1,n)
 
-let[@noalloc][@inline never] test5 n =
+let[@noalloc_strict][@inline never] test5 n =
   let first,_ = (test4 (n + 1)) in
   first


### PR DESCRIPTION
Rename `[@noalloc]` to `[@noalloc_strict]` in preparation for the `[@noalloc_exn]` attributed that is introduced in #863 and should probably have a better name. 
