### PR TITLE
Track per-parameter modes in Lambda

### DIFF
--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1065,7 +1065,8 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
           (lfunction
                ~kind
                ~return:Pgenval
-               ~params:(List.map (fun v -> v, Pgenval) final_args)
+               ~params:
+                 (List.map (fun v -> v, Pgenval, new_clos_mode) final_args)
                ~body:(Lapply{
                  ap_loc=loc;
                  ap_func=(Lvar funct_var);
@@ -1451,13 +1452,14 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
     let fun_params =
       if !useless_env
       then params
-      else params @ [env_param, Pgenval]
+      else params @ [env_param, Pgenval, alloc_heap]
     in
     let f =
       {
         label  = fundesc.fun_label;
         arity  = fundesc.fun_arity;
-        params = List.map (fun (var, kind) -> VP.create var, kind) fun_params;
+        params =
+          List.map (fun (var, kind, _) -> VP.create var, kind) fun_params;
         return;
         body   = ubody;
         dbg;
@@ -1471,7 +1473,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
        their wrapper functions) to be inlined *)
     let n =
       List.fold_left
-        (fun n (id, _) -> n + if V.name id = "*opt*" then 8 else 1)
+        (fun n (id, _, _) -> n + if V.name id = "*opt*" then 8 else 1)
         0
         fun_params
     in
@@ -1487,7 +1489,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
       | Never_inline -> min_int
       | Unroll _ -> assert false
     in
-    let fun_params = List.map (fun (var, _) -> VP.create var) fun_params in
+    let fun_params = List.map (fun (var, _, _) -> VP.create var) fun_params in
     if lambda_smaller ubody threshold
     then fundesc.fun_inline <- Some(fun_params, ubody);
 

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -233,7 +233,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let set_of_closures =
       let decl =
         Function_decl.create ~let_rec_ident:None ~closure_bound_var ~kind ~mode
-          ~region ~params:(List.map fst params) ~body ~attr ~loc
+          ~region ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
       in
       close_functions t env (Function_decls.create [decl])
     in
@@ -284,7 +284,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
             let function_declaration =
               Function_decl.create ~let_rec_ident:(Some let_rec_ident)
                 ~closure_bound_var ~kind ~mode ~region
-                ~params:(List.map fst params) ~body ~attr ~loc
+                ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
             in
             Some function_declaration
           | _ -> None)
@@ -704,7 +704,7 @@ and close_let_bound_expression t ?let_rec_ident let_bound_var env
     in
     let decl =
       Function_decl.create ~let_rec_ident ~closure_bound_var ~kind ~mode ~region
-        ~params:(List.map fst params) ~body ~attr ~loc
+        ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
     in
     let set_of_closures_var = Variable.rename let_bound_var in
     let set_of_closures =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -617,7 +617,7 @@ module Function_decls = struct
       { let_rec_ident : Ident.t;
         function_slot : Function_slot.t;
         kind : Lambda.function_kind;
-        params : (Ident.t * Lambda.value_kind) list;
+        params : (Ident.t * Lambda.value_kind * Lambda.alloc_mode) list;
         return : Lambda.value_kind;
         return_continuation : Continuation.t;
         exn_continuation : IR.exn_continuation;
@@ -628,14 +628,14 @@ module Function_decls = struct
         loc : Lambda.scoped_location;
         recursive : Recursive.t;
         closure_alloc_mode : Lambda.alloc_mode;
-        num_trailing_local_params : int;
+        num_trailing_local_closures : int;
         contains_no_escaping_local_allocs : bool
       }
 
     let create ~let_rec_ident ~function_slot ~kind ~params ~return
         ~return_continuation ~exn_continuation ~my_region ~body
         ~(attr : Lambda.function_attribute) ~loc ~free_idents_of_body recursive
-        ~closure_alloc_mode ~num_trailing_local_params
+        ~closure_alloc_mode ~num_trailing_local_closures
         ~contains_no_escaping_local_allocs =
       let let_rec_ident =
         match let_rec_ident with
@@ -656,7 +656,7 @@ module Function_decls = struct
         loc;
         recursive;
         closure_alloc_mode;
-        num_trailing_local_params;
+        num_trailing_local_closures;
         contains_no_escaping_local_allocs
       }
 
@@ -700,7 +700,7 @@ module Function_decls = struct
 
     let closure_alloc_mode t = t.closure_alloc_mode
 
-    let num_trailing_local_params t = t.num_trailing_local_params
+    let num_trailing_local_closures t = t.num_trailing_local_closures
 
     let contains_no_escaping_local_allocs t =
       t.contains_no_escaping_local_allocs
@@ -748,7 +748,7 @@ module Function_decls = struct
     set_diff
       (set_diff
          (all_free_idents function_decls)
-         (List.map fst (all_params function_decls)))
+         (List.map Misc.fst3 (all_params function_decls)))
       (let_rec_idents function_decls)
 
   let create function_decls alloc_mode =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -284,7 +284,7 @@ module Function_decls : sig
       let_rec_ident:Ident.t option ->
       function_slot:Function_slot.t ->
       kind:Lambda.function_kind ->
-      params:(Ident.t * Lambda.value_kind) list ->
+      params:(Ident.t * Lambda.value_kind * Lambda.alloc_mode) list ->
       return:Lambda.value_kind ->
       return_continuation:Continuation.t ->
       exn_continuation:IR.exn_continuation ->
@@ -295,7 +295,7 @@ module Function_decls : sig
       free_idents_of_body:Ident.Set.t ->
       Recursive.t ->
       closure_alloc_mode:Lambda.alloc_mode ->
-      num_trailing_local_params:int ->
+      num_trailing_local_closures:int ->
       contains_no_escaping_local_allocs:bool ->
       t
 
@@ -305,7 +305,7 @@ module Function_decls : sig
 
     val kind : t -> Lambda.function_kind
 
-    val params : t -> (Ident.t * Lambda.value_kind) list
+    val params : t -> (Ident.t * Lambda.value_kind * Lambda.alloc_mode) list
 
     val return : t -> Lambda.value_kind
 
@@ -337,7 +337,7 @@ module Function_decls : sig
 
     val closure_alloc_mode : t -> Lambda.alloc_mode
 
-    val num_trailing_local_params : t -> int
+    val num_trailing_local_closures : t -> int
 
     val contains_no_escaping_local_allocs : t -> bool
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1513,7 +1513,7 @@ and cps_function env ~fid ~stub ~(recursive : Recursive.t)
     ({ kind; params; return; body; attr; loc; mode; region } : L.lfunction) :
     Function_decl.t =
   let attr = { attr with stub = attr.stub || stub } in
-  let num_trailing_local_params =
+  let num_trailing_local_closures =
     match kind with Curried { nlocal } -> nlocal | Tupled -> 0
   in
   let body_cont = Continuation.create ~sort:Return () in
@@ -1543,7 +1543,7 @@ and cps_function env ~fid ~stub ~(recursive : Recursive.t)
   Function_decl.create ~let_rec_ident:(Some fid) ~function_slot ~kind ~params
     ~return ~return_continuation:body_cont ~exn_continuation ~my_region ~body
     ~attr ~loc ~free_idents_of_body recursive ~closure_alloc_mode:mode
-    ~num_trailing_local_params ~contains_no_escaping_local_allocs:region
+    ~num_trailing_local_closures ~contains_no_escaping_local_allocs:region
 
 and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
     ~scrutinee (k : Continuation.t) (k_exn : Continuation.t) : Expr_with_acc.t =

--- a/middle_end/flambda2/lattices/or_unknown.ml
+++ b/middle_end/flambda2/lattices/or_unknown.ml
@@ -18,6 +18,8 @@ type 'a t =
   | Known of 'a
   | Unknown
 
+let known x = Known x
+
 let print f ppf t =
   let colour = Flambda_colours.top_or_bottom_type in
   match t with

--- a/middle_end/flambda2/lattices/or_unknown.mli
+++ b/middle_end/flambda2/lattices/or_unknown.mli
@@ -18,6 +18,8 @@ type 'a t =
   | Known of 'a
   | Unknown
 
+val known : 'a -> 'a t
+
 val print : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 
 val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -776,12 +776,17 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         let cost_metrics =
           Cost_metrics.from_size (Code_size.of_int code_size)
         in
+        let param_modes =
+          List.map
+            (fun _ -> Alloc_mode.For_types.heap)
+            (Flambda_arity.With_subkinds.to_list params_arity)
+        in
         let code =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
           (* CR ncourant: same for loopify *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
-            ~newer_version_of ~params_arity ~num_trailing_local_params:0
-            ~result_arity ~result_types:Unknown
+            ~newer_version_of ~params_arity ~param_modes
+            ~num_trailing_local_closures:0 ~result_arity ~result_types:Unknown
             ~contains_no_escaping_local_allocs:false ~stub:false ~inline
             ~check:
               Default_check (* CR gyorsh: should [check] be set properly? *)

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -333,7 +333,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
     ~callee's_code_id ~callee's_code_metadata ~callee's_function_slot
     ~param_arity ~result_arity ~recursive ~down_to_up ~coming_from_indirect
     ~(closure_alloc_mode_from_type : Alloc_mode.For_types.t) ~current_region
-    ~num_trailing_local_params =
+    ~num_trailing_local_closures =
   (* Partial-applications are converted in full applications. Let's assume that
      [foo] takes 6 arguments. Then [foo a b c] gets transformed into:
 
@@ -389,17 +389,17 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
   let wrapper_function_slot =
     Function_slot.create compilation_unit ~name:"partial_app_closure"
   in
-  let new_closure_alloc_mode, num_trailing_local_params =
+  let new_closure_alloc_mode, num_trailing_local_closures =
     (* If the closure has a local suffix, and we've supplied enough args to hit
        it, then the closure must be local (because the args or closure might
        be). *)
-    let num_leading_heap_params = arity - num_trailing_local_params in
-    if args_arity <= num_leading_heap_params
-    then Alloc_mode.For_allocations.heap, num_trailing_local_params
+    let num_leading_heap_closures = arity - num_trailing_local_closures in
+    if args_arity <= num_leading_heap_closures
+    then Alloc_mode.For_allocations.heap, num_trailing_local_closures
     else
-      let num_supplied_local_args = args_arity - num_leading_heap_params in
+      let num_supplied_local_args = args_arity - num_leading_heap_closures in
       ( Alloc_mode.For_allocations.local ~region:current_region,
-        num_trailing_local_params - num_supplied_local_args )
+        num_trailing_local_closures - num_supplied_local_args )
   in
   (match closure_alloc_mode_from_type with
   | Heap_or_local -> ()
@@ -429,6 +429,11 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
           Bound_parameter.create param kind)
         remaining_param_arity
       |> Bound_parameters.create
+    in
+    let remaining_params_alloc_modes =
+      List.map
+        (fun _ -> Alloc_mode.For_allocations.as_type new_closure_alloc_mode)
+        remaining_param_arity
     in
     let call_kind =
       Call_kind.direct_function_call callee's_code_id ~return_arity:result_arity
@@ -560,10 +565,11 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         Code.create code_id ~params_and_body
           ~free_names_of_params_and_body:free_names ~newer_version_of:None
           ~params_arity:(Bound_parameters.arity_with_subkinds remaining_params)
-          ~num_trailing_local_params ~result_arity ~result_types:Unknown
-          ~contains_no_escaping_local_allocs ~stub:true ~inline:Default_inline
-          ~poll_attribute:Default ~check:Check_attribute.Default_check
-          ~is_a_functor:false ~recursive ~cost_metrics:cost_metrics_of_body
+          ~param_modes:remaining_params_alloc_modes ~num_trailing_local_closures
+          ~result_arity ~result_types:Unknown ~contains_no_escaping_local_allocs
+          ~stub:true ~inline:Default_inline ~poll_attribute:Default
+          ~check:Check_attribute.Default_check ~is_a_functor:false ~recursive
+          ~cost_metrics:cost_metrics_of_body
           ~inlining_arguments:(DE.inlining_arguments (DA.denv dacc))
           ~dbg ~is_tupled:false
           ~is_my_closure_used:
@@ -748,8 +754,8 @@ let simplify_direct_function_call ~simplify_expr dacc apply
           ~callee's_code_id ~callee's_code_metadata ~callee's_function_slot
           ~param_arity:params_arity ~result_arity ~recursive ~down_to_up
           ~coming_from_indirect ~closure_alloc_mode_from_type ~current_region
-          ~num_trailing_local_params:
-            (Code_metadata.num_trailing_local_params callee's_code_metadata)
+          ~num_trailing_local_closures:
+            (Code_metadata.num_trailing_local_closures callee's_code_metadata)
       else
         Misc.fatal_errorf
           "Function with %d params when simplifying direct OCaml function call \

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -31,17 +31,7 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
     ~inlining_arguments ~absolute_history code_id ~return_continuation
     ~exn_continuation ~return_cont_params ~loopify_state code_metadata =
   let dacc = C.dacc_inside_functions context in
-  let num_leading_heap_params =
-    Code_metadata.num_leading_heap_params code_metadata
-  in
-  let alloc_modes =
-    List.mapi
-      (fun index _ : Alloc_mode.For_types.t ->
-        if index < num_leading_heap_params
-        then Alloc_mode.For_types.heap
-        else Alloc_mode.For_types.unknown ())
-      (Bound_parameters.to_list params)
-  in
+  let alloc_modes = Code_metadata.param_modes code_metadata in
   let denv =
     DE.add_parameters_with_unknown_types ~alloc_modes (DA.denv dacc) params
     |> DE.set_inlining_arguments inlining_arguments
@@ -421,7 +411,8 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       (DA.are_rebuilding_terms dacc_after_body)
       code_id ~params_and_body ~free_names_of_params_and_body:free_names_of_code
       ~newer_version_of ~params_arity:(Code.params_arity code)
-      ~num_trailing_local_params:(Code.num_trailing_local_params code)
+      ~param_modes:(Code.param_modes code)
+      ~num_trailing_local_closures:(Code.num_trailing_local_closures code)
       ~result_arity ~result_types
       ~contains_no_escaping_local_allocs:
         (Code.contains_no_escaping_local_allocs code)

--- a/middle_end/flambda2/term_basics/alloc_mode.ml
+++ b/middle_end/flambda2/term_basics/alloc_mode.ml
@@ -32,6 +32,8 @@ module For_types = struct
     | Local, Heap_or_local -> -1
     | Heap_or_local, Local -> 1
 
+  let equal t1 t2 = compare t1 t2 = 0
+
   let heap = Heap
 
   let local () =

--- a/middle_end/flambda2/term_basics/alloc_mode.mli
+++ b/middle_end/flambda2/term_basics/alloc_mode.mli
@@ -23,6 +23,8 @@ module For_types : sig
 
   val compare : t -> t -> int
 
+  val equal : t -> t -> bool
+
   val heap : t
 
   (** Returns [Heap] if stack allocation is disabled! *)

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -18,7 +18,10 @@ type t =
   { code_id : Code_id.t;
     newer_version_of : Code_id.t option;
     params_arity : Flambda_arity.With_subkinds.t;
-    num_trailing_local_params : int;
+    param_modes : Alloc_mode.For_types.t list;
+    num_trailing_local_closures : int;
+    (* CR mshinwell: compute [num_trailing_local_closures] from
+       [param_modes]? *)
     result_arity : Flambda_arity.With_subkinds.t;
     result_types : Result_types.t Or_unknown_or_bottom.t;
     contains_no_escaping_local_allocs : bool;
@@ -56,17 +59,19 @@ module Code_metadata_accessors (X : Metadata_view_type) = struct
 
   let params_arity t = (metadata t).params_arity
 
-  let num_leading_heap_params t =
-    let { params_arity; num_trailing_local_params; _ } = metadata t in
+  let param_modes t = (metadata t).param_modes
+
+  let num_leading_heap_closures t =
+    let { params_arity; num_trailing_local_closures; _ } = metadata t in
     let n =
       Flambda_arity.With_subkinds.cardinal params_arity
-      - num_trailing_local_params
+      - num_trailing_local_closures
     in
     assert (n >= 0);
     (* see [create] *)
     n
 
-  let num_trailing_local_params t = (metadata t).num_trailing_local_params
+  let num_trailing_local_closures t = (metadata t).num_trailing_local_closures
 
   let result_arity t = (metadata t).result_arity
 
@@ -128,7 +133,8 @@ type 'a create_type =
   Code_id.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
-  num_trailing_local_params:int ->
+  param_modes:Alloc_mode.For_types.t list ->
+  num_trailing_local_closures:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   contains_no_escaping_local_allocs:bool ->
@@ -149,12 +155,12 @@ type 'a create_type =
   loopify:Loopify_attribute.t ->
   'a
 
-let createk k code_id ~newer_version_of ~params_arity ~num_trailing_local_params
-    ~result_arity ~result_types ~contains_no_escaping_local_allocs ~stub
-    ~(inline : Inline_attribute.t) ~check ~poll_attribute ~is_a_functor
-    ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
-    ~is_my_closure_used ~inlining_decision ~absolute_history ~relative_history
-    ~loopify =
+let createk k code_id ~newer_version_of ~params_arity ~param_modes
+    ~num_trailing_local_closures ~result_arity ~result_types
+    ~contains_no_escaping_local_allocs ~stub ~(inline : Inline_attribute.t)
+    ~check ~poll_attribute ~is_a_functor ~recursive ~cost_metrics
+    ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision
+    ~absolute_history ~relative_history ~loopify =
   (match stub, inline with
   | true, (Available_inline | Never_inline | Default_inline)
   | ( false,
@@ -163,18 +169,28 @@ let createk k code_id ~newer_version_of ~params_arity ~num_trailing_local_params
     ()
   | true, (Always_inline | Unroll _) ->
     Misc.fatal_error "Stubs may not be annotated as [Always_inline] or [Unroll]");
-  if num_trailing_local_params < 0
-     || num_trailing_local_params
+  if num_trailing_local_closures < 0
+     || num_trailing_local_closures
         > Flambda_arity.With_subkinds.cardinal params_arity
   then
     Misc.fatal_errorf
-      "Illegal num_trailing_local_params=%d for params arity: %a"
-      num_trailing_local_params Flambda_arity.With_subkinds.print params_arity;
+      "Illegal num_trailing_local_closures=%d for params arity: %a"
+      num_trailing_local_closures Flambda_arity.With_subkinds.print params_arity;
+  if List.compare_length_with param_modes
+       (Flambda_arity.With_subkinds.cardinal params_arity)
+     <> 0
+  then
+    Misc.fatal_errorf "Parameter modes do not match arity: %a and (%a)"
+      Flambda_arity.With_subkinds.print params_arity
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space
+         Alloc_mode.For_types.print)
+      param_modes;
   k
     { code_id;
       newer_version_of;
       params_arity;
-      num_trailing_local_params;
+      param_modes;
+      num_trailing_local_closures;
       result_arity;
       result_types;
       contains_no_escaping_local_allocs;
@@ -223,7 +239,8 @@ let [@ocamlformat "disable"] print_inlining_paths ppf
 
 let [@ocamlformat "disable"] print ppf
        { code_id = _; newer_version_of; stub; inline; check; poll_attribute;
-         is_a_functor; params_arity; num_trailing_local_params; result_arity;
+         is_a_functor; params_arity; param_modes;
+         num_trailing_local_closures; result_arity;
          result_types; contains_no_escaping_local_allocs;
          recursive; cost_metrics; inlining_arguments;
          dbg; is_tupled; is_my_closure_used; inlining_decision;
@@ -237,7 +254,8 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>%t(poll_attribute@ %a)%t@]@ \
       @[<hov 1>%t(is_a_functor@ %b)%t@]@ \
       @[<hov 1>%t(params_arity@ %t%a%t)%t@]@ \
-      @[<hov 1>(num_trailing_local_params@ %d)@]@ \
+      @[<hov 1>%t(param_modes@ %t(%a)%t)%t@]@ \
+      @[<hov 1>(num_trailing_local_closures@ %d)@]@ \
       @[<hov 1>%t(result_arity@ %t%a%t)%t@]@ \
       @[<hov 1>(result_types@ @[<hov 1>(%a)@])@]@ \
       @[<hov 1>(contains_no_escaping_local_allocs@ %b)@]@ \
@@ -283,7 +301,22 @@ let [@ocamlformat "disable"] print ppf
     then Flambda_colours.elide
     else Flambda_colours.none)
     Flambda_colours.pop
-    num_trailing_local_params
+    (if List.for_all
+      (fun mode -> Alloc_mode.For_types.equal mode Alloc_mode.For_types.heap)
+      param_modes
+    then Flambda_colours.elide
+    else Flambda_colours.none)
+    Flambda_colours.pop
+    (Format.pp_print_list ~pp_sep:Format.pp_print_space
+      Alloc_mode.For_types.print)
+    param_modes
+    (if List.for_all
+      (fun mode -> Alloc_mode.For_types.equal mode Alloc_mode.For_types.heap)
+      param_modes
+    then Flambda_colours.elide
+    else Flambda_colours.none)
+    Flambda_colours.pop
+    num_trailing_local_closures
     (if Flambda_arity.With_subkinds.is_singleton_value result_arity
     then Flambda_colours.elide
     else Flambda_colours.none)
@@ -319,7 +352,8 @@ let free_names
     { code_id = _;
       newer_version_of;
       params_arity = _;
-      num_trailing_local_params = _;
+      param_modes = _;
+      num_trailing_local_closures = _;
       result_arity = _;
       result_types;
       contains_no_escaping_local_allocs = _;
@@ -359,7 +393,8 @@ let apply_renaming
     ({ code_id;
        newer_version_of;
        params_arity = _;
-       num_trailing_local_params = _;
+       param_modes = _;
+       num_trailing_local_closures = _;
        result_arity = _;
        result_types;
        contains_no_escaping_local_allocs = _;
@@ -410,7 +445,8 @@ let ids_for_export
     { code_id;
       newer_version_of;
       params_arity = _;
-      num_trailing_local_params = _;
+      param_modes = _;
+      num_trailing_local_closures = _;
       result_arity = _;
       result_types;
       contains_no_escaping_local_allocs = _;
@@ -447,7 +483,8 @@ let approx_equal
     { code_id = code_id1;
       newer_version_of = newer_version_of1;
       params_arity = params_arity1;
-      num_trailing_local_params = num_trailing_local_params1;
+      param_modes = param_modes1;
+      num_trailing_local_closures = num_trailing_local_closures1;
       result_arity = result_arity1;
       result_types = _;
       contains_no_escaping_local_allocs = contains_no_escaping_local_allocs1;
@@ -470,7 +507,8 @@ let approx_equal
     { code_id = code_id2;
       newer_version_of = newer_version_of2;
       params_arity = params_arity2;
-      num_trailing_local_params = num_trailing_local_params2;
+      param_modes = param_modes2;
+      num_trailing_local_closures = num_trailing_local_closures2;
       result_arity = result_arity2;
       result_types = _;
       contains_no_escaping_local_allocs = contains_no_escaping_local_allocs2;
@@ -493,7 +531,8 @@ let approx_equal
   Code_id.equal code_id1 code_id2
   && (Option.equal Code_id.equal) newer_version_of1 newer_version_of2
   && Flambda_arity.With_subkinds.equal params_arity1 params_arity2
-  && Int.equal num_trailing_local_params1 num_trailing_local_params2
+  && List.equal Alloc_mode.For_types.equal param_modes1 param_modes2
+  && Int.equal num_trailing_local_closures1 num_trailing_local_closures2
   && Flambda_arity.With_subkinds.equal result_arity1 result_arity2
   && Bool.equal contains_no_escaping_local_allocs1
        contains_no_escaping_local_allocs2

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -33,9 +33,11 @@ module type Code_metadata_accessors_result_type = sig
 
   val params_arity : 'a t -> Flambda_arity.With_subkinds.t
 
-  val num_leading_heap_params : 'a t -> int
+  val param_modes : 'a t -> Alloc_mode.For_types.t list
 
-  val num_trailing_local_params : 'a t -> int
+  val num_leading_heap_closures : 'a t -> int
+
+  val num_trailing_local_closures : 'a t -> int
 
   val result_arity : 'a t -> Flambda_arity.With_subkinds.t
 
@@ -83,7 +85,8 @@ type 'a create_type =
   Code_id.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
-  num_trailing_local_params:int ->
+  param_modes:Alloc_mode.For_types.t list ->
+  num_trailing_local_closures:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   contains_no_escaping_local_allocs:bool ->

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -41,7 +41,7 @@ let get_func_decl_params_arity t code_id =
     if Code_metadata.is_tupled info
     then Lambda.Tupled
     else
-      Lambda.Curried { nlocal = Code_metadata.num_trailing_local_params info }
+      Lambda.Curried { nlocal = Code_metadata.num_trailing_local_closures info }
   in
   let closure_code_pointers =
     match kind, num_params with

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -618,7 +618,7 @@ let rec comp_expr env exp sz cont =
       let lbl = new_label() in
       let fv = Ident.Set.elements(free_variables exp) in
       let to_compile =
-        { params = List.map fst params; body = body; label = lbl;
+        { params = List.map fst3 params; body = body; label = lbl;
           free_vars = fv; num_defs = 1; rec_vars = []; rec_pos = 0 } in
       Stack.push to_compile functions_to_compile;
       comp_args env (List.map (fun n -> Lvar n) fv) sz
@@ -641,7 +641,7 @@ let rec comp_expr env exp sz cont =
           | (_id, Lfunction{params; body}) :: rem ->
               let lbl = new_label() in
               let to_compile =
-                { params = List.map fst params; body = body; label = lbl;
+                { params = List.map fst3 params; body = body; label = lbl;
                   free_vars = fv; num_defs = ndecl; rec_vars = rec_idents;
                   rec_pos = pos} in
               Stack.push to_compile functions_to_compile;

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -440,7 +440,7 @@ type lambda =
 
 and lfunction =
   { kind: function_kind;
-    params: (Ident.t * value_kind) list;
+    params: (Ident.t * value_kind * alloc_mode) list;
     return: value_kind;
     body: lambda;
     attr: function_attribute; (* specified with [@inline] attribute *)
@@ -736,7 +736,7 @@ let rec free_variables = function
       free_variables_list (free_variables fn) args
   | Lfunction{body; params} ->
       Ident.Set.diff (free_variables body)
-        (Ident.Set.of_list (List.map fst params))
+        (Ident.Set.of_list (List.map fst3 params))
   | Llet(_, _k, id, arg, body)
   | Lmutlet(_k, id, arg, body) ->
       Ident.Set.union
@@ -913,6 +913,12 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
         ((id', rhs) :: ids' , l)
       ) ids ([], l)
   in
+  let bind_many3 ids l =
+    List.fold_right (fun (id, rhs1, rhs2) (ids', l) ->
+        let id', l = bind id l in
+        ((id', rhs1, rhs2) :: ids' , l)
+      ) ids ([], l)
+  in
   let rec subst s l lam =
     match lam with
     | Lvar id as lam ->
@@ -937,7 +943,7 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
         Lapply{ap with ap_func = subst s l ap.ap_func;
                       ap_args = subst_list s l ap.ap_args}
     | Lfunction lf ->
-        let params, l' = bind_many lf.params l in
+        let params, l' = bind_many3 lf.params l in
         Lfunction {lf with params; body = subst s l' lf.body}
     | Llet(str, k, id, arg, body) ->
         let id, l' = bind id l in

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -370,7 +370,7 @@ type lambda =
 
 and lfunction = private
   { kind: function_kind;
-    params: (Ident.t * value_kind) list;
+    params: (Ident.t * value_kind * alloc_mode) list;
     return: value_kind;
     body: lambda;
     attr: function_attribute; (* specified with [@inline] attribute *)
@@ -460,7 +460,7 @@ val name_lambda_list: lambda list -> (lambda list -> lambda) -> lambda
 
 val lfunction :
   kind:function_kind ->
-  params:(Ident.t * value_kind) list ->
+  params:(Ident.t * value_kind * alloc_mode) list ->
   return:value_kind ->
   body:lambda ->
   attr:function_attribute -> (* specified with [@inline] attribute *)

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -645,15 +645,17 @@ let rec lam ppf = function
       let pr_params ppf params =
         match kind with
         | Curried _ ->
-            List.iter (fun (param, k) ->
-                fprintf ppf "@ %a%a" Ident.print param value_kind k) params
+            List.iter (fun (param, k, param_mode) ->
+                fprintf ppf "@ %a%s%a" Ident.print param
+                  (alloc_kind param_mode) value_kind k) params
         | Tupled ->
             fprintf ppf " (";
             let first = ref true in
             List.iter
-              (fun (param, k) ->
+              (fun (param, k, param_mode) ->
                 if !first then first := false else fprintf ppf ",@ ";
                 Ident.print ppf param;
+                Format.fprintf ppf "%s" (alloc_kind param_mode);
                 value_kind ppf k)
               params;
             fprintf ppf ")" in

--- a/ocaml/lambda/simplif.mli
+++ b/ocaml/lambda/simplif.mli
@@ -32,7 +32,7 @@ val simplify_lambda: lambda -> lambda
 val split_default_wrapper
    : id:Ident.t
   -> kind:function_kind
-  -> params:(Ident.t * Lambda.value_kind) list
+  -> params:(Ident.t * Lambda.value_kind * Lambda.alloc_mode) list
   -> return:Lambda.value_kind
   -> body:lambda
   -> attr:function_attribute

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -62,7 +62,7 @@ and offset = Offset of lambda
 let offset_code (Offset t) = t
 
 let add_dst_params ({var; offset} : Ident.t destination) params =
-  (var, Pgenval) :: (offset, Pintval) :: params
+  (var, Pgenval, alloc_heap) :: (offset, Pintval, alloc_heap) :: params
 
 let add_dst_args ({var; offset} : offset destination) args =
   Lvar var :: offset_code offset :: args

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -194,7 +194,8 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
        let build params rem =
          let param = name_pattern "param" pat in
          Lambda.lfunction
-                   ~kind:(Curried {nlocal=0}) ~params:((param, Pgenval)::params)
+                   ~kind:(Curried {nlocal=0})
+                   ~params:((param, Pgenval, alloc_heap)::params)
                    ~return:Pgenval
                    ~attr:default_function_attribute
                    ~loc:(of_location ~scopes pat.pat_loc)
@@ -238,8 +239,11 @@ let rec build_object_init_0
       let ((_,inh_init), obj_init) =
         build_object_init ~scopes cl_table obj params (envs,[]) copy_env cl in
       let obj_init =
-        if ids = [] then obj_init else lfunction [self, Pgenval] obj_init in
-      (inh_init, lfunction [env, Pgenval] (subst_env env inh_init obj_init))
+        if ids = [] then obj_init
+        else lfunction [self, Pgenval, alloc_heap] obj_init
+      in
+      (inh_init, lfunction [env, Pgenval, alloc_heap]
+        (subst_env env inh_init obj_init))
 
 
 let bind_method tbl lab id cl_init =
@@ -464,7 +468,8 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
       let build params rem =
         let param = name_pattern "param" pat in
         Lambda.lfunction
-                  ~kind:(Curried {nlocal=0}) ~params:((param, Pgenval)::params)
+                  ~kind:(Curried {nlocal=0})
+                  ~params:((param, Pgenval, alloc_heap)::params)
                   ~return:Pgenval
                   ~attr:default_function_attribute
                   ~loc:(of_location ~scopes pat.pat_loc)
@@ -511,7 +516,7 @@ let rec transl_class_rebind_0 ~scopes (self:Ident.t) obj_init cl vf =
   | _ ->
       let path, path_lam, obj_init =
         transl_class_rebind ~scopes obj_init cl vf in
-      (path, path_lam, lfunction [self, Pgenval] obj_init)
+      (path, path_lam, lfunction [self, Pgenval, alloc_heap] obj_init)
 
 let transl_class_rebind ~scopes cl vf =
   try
@@ -532,7 +537,7 @@ let transl_class_rebind ~scopes cl vf =
     in
     let _, path_lam, obj_init' =
       transl_class_rebind_0 ~scopes self obj_init0 cl vf in
-    let id = (obj_init' = lfunction [self, Pgenval] obj_init0) in
+    let id = (obj_init' = lfunction [self, Pgenval, alloc_heap] obj_init0) in
     if id then path_lam else
 
     let cla = Ident.create_local "class"
@@ -541,15 +546,16 @@ let transl_class_rebind ~scopes cl vf =
     and table = Ident.create_local "table"
     and envs = Ident.create_local "envs" in
     Llet(
-    Strict, Pgenval, new_init, lfunction [obj_init, Pgenval] obj_init',
+    Strict, Pgenval, new_init,
+      lfunction [obj_init, Pgenval, alloc_heap] obj_init',
     Llet(
     Alias, Pgenval, cla, path_lam,
     Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
           [mkappl(Lvar new_init, [lfield cla 0]);
-           lfunction [table, Pgenval]
+           lfunction [table, Pgenval, alloc_heap]
              (Llet(Strict, Pgenval, env_init,
                    mkappl(lfield cla 1, [Lvar table]),
-                   lfunction [envs, Pgenval]
+                   lfunction [envs, Pgenval, alloc_heap]
                      (mkappl(Lvar new_init,
                              [mkappl(Lvar env_init, [Lvar envs])]))));
            lfield cla 2;
@@ -603,7 +609,7 @@ let rec builtin_meths self env env2 body =
   | Lsend(Cached, met, arg, [_;_], _, _, _) ->
       let s, args = conv arg in
       ("send_"^s, met :: args)
-  | Lfunction {kind = Curried _; params = [x, _]; body} ->
+  | Lfunction {kind = Curried _; params = [x, _, _]; body} ->
       let rec enter self = function
         | Lprim(Parraysetu _, [Lvar s; Lvar n; Lvar x'], _)
           when Ident.same x x' && List.mem s self ->
@@ -686,7 +692,7 @@ let free_methods l =
         fv := Ident.Set.add meth !fv
     | Lsend _ -> ()
     | Lfunction{params} ->
-        List.iter (fun (param, _) -> fv := Ident.Set.remove param !fv) params
+        List.iter (fun (param, _, _) -> fv := Ident.Set.remove param !fv) params
     | Llet(_, _k, id, _arg, _body)
     | Lmutlet(_k, id, _arg, _body) ->
         fv := Ident.Set.remove id !fv
@@ -745,7 +751,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   let no_env_update _ _ env = env in
   let msubst arr = function
       Lfunction {kind = Curried _ as kind; region;
-                 params = (self, Pgenval) :: args; body} ->
+                 params = (self, Pgenval, alloc_heap) :: args; body} ->
         let env = Ident.create_local "env" in
         let body' =
           if new_ids = [] then body else
@@ -756,7 +762,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
           if not arr || !Clflags.debug then raise Not_found;
           builtin_meths [self] env env2 (lfunction args body')
         with Not_found ->
-          [lfunction ~kind ~region ((self, Pgenval) :: args)
+          [lfunction ~kind ~region ((self, Pgenval, alloc_heap) :: args)
              (if not (Ident.Set.mem env (free_variables body')) then body' else
               Llet(Alias, Pgenval, env,
                    Lprim(Pfield_computed Reads_vary,
@@ -827,7 +833,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                            ~return:Pgenval
                            ~mode:alloc_heap
                            ~region:true
-                           ~params:[cla, Pgenval] ~body:cl_init) in
+                           ~params:[cla, Pgenval, alloc_heap]
+                           ~body:cl_init) in
     Llet(Strict, Pgenval, class_init, cl_init, lam (free_variables cl_init))
   and lbody fv =
     if List.for_all (fun id -> not (Ident.Set.mem id fv)) ids then
@@ -852,7 +859,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                           ~return:Pgenval
                           ~mode:alloc_heap
                           ~region:true
-                          ~params:[cla, Pgenval] ~body:cl_init;
+                          ~params:[cla, Pgenval, alloc_heap]
+                          ~body:cl_init;
            lambda_unit; lenvs],
          Loc_unknown)
   in
@@ -906,7 +914,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   let lclass lam =
     Llet(Strict, Pgenval, class_init,
          Lambda.lfunction
-                   ~kind:(Curried {nlocal=0}) ~params:[cla, Pgenval]
+                   ~kind:(Curried {nlocal=0})
+                   ~params:[cla, Pgenval, alloc_heap]
                    ~return:Pgenval
                    ~attr:default_function_attribute
                    ~loc:Loc_unknown
@@ -938,7 +947,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
          ~mode:alloc_heap
          ~region:true
          ~return:Pgenval
-         ~params:[cla, Pgenval]
+         ~params:[cla, Pgenval, alloc_heap]
          ~body:(def_ids cla cl_init))
   in
   let lupdate_cache =

--- a/ocaml/lambda/translcomprehension.ml
+++ b/ocaml/lambda/translcomprehension.ml
@@ -492,7 +492,7 @@ let transl_list_comp type_comp body acc_var mats ~transl_exp ~scopes ~loc =
   let fn =
     lfunction
       ~kind:(Curried {nlocal=0})
-      ~params:[param, pval; acc_var, Pgenval]
+      ~params:[param, pval, alloc_heap; acc_var, Pgenval, alloc_heap]
       ~return:Pgenval
       ~attr:default_function_attribute
       ~loc

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -193,12 +193,13 @@ let rec push_defaults loc bindings use_lhs cases partial warnings =
   match cases with
     [{c_lhs=pat; c_guard=None;
       c_rhs={exp_desc = Texp_function { arg_label; param; cases; partial;
-                                        region; curry; warnings } }
+                                        region; curry; param_alloc_mode;
+                                        warnings } }
         as exp}] when bindings = [] || trivial_pat pat ->
       let cases = push_defaults exp.exp_loc bindings false cases partial warnings in
       [{c_lhs=pat; c_guard=None;
         c_rhs={exp with exp_desc = Texp_function { arg_label; param; cases;
-          partial; region; curry; warnings }}}]
+          partial; region; curry; param_alloc_mode; warnings }}}]
   | [{c_lhs=pat; c_guard=None;
       c_rhs={exp_attributes=[{Parsetree.attr_name = {txt="#default"};_}];
              exp_desc = Texp_let
@@ -361,12 +362,13 @@ and transl_exp0 ~in_new_scope ~scopes e =
       transl_let ~scopes rec_flag pat_expr_list
         body_kind (event_before ~scopes body (transl_exp ~scopes body))
   | Texp_function { arg_label = _; param; cases; partial;
-                    region; curry; warnings } ->
+                    region; curry; param_alloc_mode; warnings } ->
       let scopes =
         if in_new_scope then scopes
         else enter_anonymous_function ~scopes
       in
       transl_function ~scopes e param cases partial warnings region curry
+        ~param_alloc_mode
   | Texp_apply({ exp_desc = Texp_ident(path, _, {val_kind = Val_prim p},
                                        Id_prim pmode);
                 exp_type = prim_type } as funct, oargs, pos)
@@ -762,7 +764,8 @@ and transl_exp0 ~in_new_scope ~scopes e =
          (* other cases compile to a lazy block holding a function *)
          let scopes = enter_lazy ~scopes in
          let fn = lfunction ~kind:(Curried {nlocal=0})
-                            ~params:[Ident.create_local "param", Pgenval]
+                            ~params:[Ident.create_local "param", Pgenval,
+                                       alloc_heap]
                             ~return:Pgenval
                             ~attr:default_function_attribute
                             ~loc:(of_location ~scopes e.exp_loc)
@@ -837,7 +840,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
         let scopes = enter_value_definition ~scopes funcid in
         lfunction
           ~kind:(Curried {nlocal=0})
-          ~params:(List.map (fun v -> v, Pgenval) param_idents)
+          ~params:(List.map (fun v -> v, Pgenval, alloc_heap) param_idents)
           ~return:Pgenval
           ~body
           ~loc:(of_location ~scopes exp.exp_loc)
@@ -1016,7 +1019,8 @@ and transl_apply ~scopes
             | Alloc_local -> false
             | Alloc_heap -> true
           in
-          lfunction ~kind:(Curried {nlocal}) ~params:[id_arg, Pgenval]
+          lfunction ~kind:(Curried {nlocal})
+                    ~params:[id_arg, Pgenval, arg_mode]
                     ~return:Pgenval ~body ~mode ~region
                     ~attr:default_stub_attribute ~loc
         in
@@ -1038,9 +1042,10 @@ and transl_apply ~scopes
 
 and transl_curried_function
       ~scopes loc return
-      repr ~region ~curry partial warnings (param:Ident.t) cases =
+      repr ~region ~curry ~param_alloc_mode
+      partial warnings (param:Ident.t) cases =
   let max_arity = Lambda.max_arity () in
-  let rec loop ~scopes loc return ~arity ~region ~curry
+  let rec loop ~scopes loc return ~arity ~region ~curry ~param_alloc_mode
             partial warnings (param:Ident.t) cases =
     match curry, cases with
       More_args {partial_mode},
@@ -1049,7 +1054,7 @@ and transl_curried_function
                  Texp_function
                    { arg_label = _; param = param'; cases = cases';
                      partial = partial'; region = region';
-                     curry = curry';
+                     curry = curry'; param_alloc_mode = param_alloc_mode';
                      warnings = warnings' };
                exp_env; exp_type; exp_loc }}]
       when arity < max_arity ->
@@ -1062,6 +1067,7 @@ and transl_curried_function
         let ((fnkind, params, return, region), body) =
           loop ~scopes exp_loc return_kind
             ~arity:(arity + 1) ~region:region' ~curry:curry'
+            ~param_alloc_mode:param_alloc_mode'
             partial' warnings' param' cases'
         in
         let fnkind =
@@ -1075,7 +1081,8 @@ and transl_curried_function
              assert (nlocal = List.length params);
              Curried {nlocal = nlocal + 1}
         in
-        ((fnkind, (param, kind) :: params, return, region),
+        let param_alloc_mode = transl_alloc_mode param_alloc_mode in
+        ((fnkind, (param, kind, param_alloc_mode) :: params, return, region),
          Matching.for_function ~scopes return_kind loc None (Lvar param)
            [pat, body] partial)
       else begin
@@ -1088,18 +1095,18 @@ and transl_curried_function
             Warnings.restore prev
         | Partial -> ()
         end;
-        transl_tupled_function ~scopes ~arity ~region ~curry
+        transl_tupled_function ~scopes ~arity ~region ~curry ~param_alloc_mode
           loc return repr partial param cases
       end
     | curry, cases ->
-      transl_tupled_function ~scopes ~arity ~region ~curry
+      transl_tupled_function ~scopes ~arity ~region ~curry ~param_alloc_mode
         loc return repr partial param cases
   in
-  loop ~scopes loc return ~arity:1 ~region ~curry
+  loop ~scopes loc return ~arity:1 ~region ~curry ~param_alloc_mode
     partial warnings param cases
 
 and transl_tupled_function
-      ~scopes ~arity ~region ~curry loc return
+      ~scopes ~arity ~region ~curry ~param_alloc_mode loc return
       repr partial (param:Ident.t) cases =
   let partial_mode =
     match curry with
@@ -1136,9 +1143,10 @@ and transl_tupled_function
                 first_case_kinds cases
         in
         let tparams =
-          List.map (fun kind -> Ident.create_local "param", kind) kinds
+          List.map (fun kind -> Ident.create_local "param", kind, alloc_heap)
+            kinds
         in
-        let params = List.map fst tparams in
+        let params = List.map fst3 tparams in
         let body =
           Matching.for_tupled_function ~scopes loc return params
             (transl_tupled_cases ~scopes pats_expr_list) partial
@@ -1146,14 +1154,14 @@ and transl_tupled_function
         let region = region || not (may_allocate_in_region body) in
         ((Tupled, tparams, return, region), body)
     with Matching.Cannot_flatten ->
-      transl_function0 ~scopes loc ~region ~partial_mode
+      transl_function0 ~scopes loc ~region ~param_alloc_mode ~partial_mode
         return repr partial param cases
       end
-  | _ -> transl_function0 ~scopes loc ~region ~partial_mode
+  | _ -> transl_function0 ~scopes loc ~region ~param_alloc_mode ~partial_mode
            return repr partial param cases
 
 and transl_function0
-      ~scopes loc ~region ~partial_mode return
+      ~scopes loc ~region ~param_alloc_mode ~partial_mode return
       repr partial (param:Ident.t) cases =
     let kind =
       match cases with
@@ -1179,9 +1187,11 @@ and transl_function0
         | Alloc_local -> 1
         | Alloc_heap -> 0
     in
-    ((Curried {nlocal}, [param, kind], return, region), body)
+    let param_alloc_mode = transl_alloc_mode param_alloc_mode in
+    ((Curried {nlocal}, [param, kind, param_alloc_mode], return, region), body)
 
-and transl_function ~scopes e param cases partial warnings region curry =
+and transl_function ~scopes e param cases partial warnings region curry
+      ~param_alloc_mode =
   let mode = transl_exp_mode e in
   let ((kind, params, return, region), body) =
     event_function ~scopes e
@@ -1189,7 +1199,7 @@ and transl_function ~scopes e param cases partial warnings region curry =
          let pl = push_defaults e.exp_loc cases partial warnings in
          let return_kind = function_return_value_kind e.exp_env e.exp_type in
          transl_curried_function ~scopes e.exp_loc return_kind
-           repr ~region ~curry partial warnings param pl)
+           repr ~region ~curry ~param_alloc_mode partial warnings param pl)
   in
   let attr = default_function_attribute in
   let loc = of_location ~scopes e.exp_loc in
@@ -1526,7 +1536,8 @@ and transl_letop ~scopes loc env let_ ands param case partial warnings =
       event_function ~scopes case.c_rhs
         (function repr ->
            transl_curried_function ~scopes case.c_rhs.exp_loc return_kind
-             repr ~region:true ~curry partial warnings param [case])
+             repr ~region:true ~curry ~param_alloc_mode:(Amode Global) partial
+             warnings param [case])
     in
     let attr = default_function_attribute in
     let loc = of_location ~scopes case.c_rhs.exp_loc in

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -107,7 +107,8 @@ let rec apply_coercion loc strict restr arg =
   | Tcoerce_functor(cc_arg, cc_res) ->
       let param = Ident.create_local "funarg" in
       let carg = apply_coercion loc Alias cc_arg (Lvar param) in
-      apply_coercion_result loc strict arg [param, Pgenval] [carg] cc_res
+      apply_coercion_result loc strict arg [param, Pgenval, alloc_heap]
+        [carg] cc_res
   | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode } ->
       let poly_mode = Option.map Translcore.transl_alloc_mode pc_poly_mode in
       Translprim.transl_primitive loc pc_desc pc_env pc_type ~poly_mode None
@@ -125,7 +126,7 @@ and apply_coercion_result loc strict funct params args cc_res =
     let param = Ident.create_local "funarg" in
     let arg = apply_coercion loc Alias cc_arg (Lvar param) in
     apply_coercion_result loc strict funct
-      ((param, Pgenval) :: params) (arg :: args) cc_res
+      ((param, Pgenval, alloc_heap) :: params) (arg :: args) cc_res
   | _ ->
       name_lambda strict funct
         (fun id ->
@@ -531,7 +532,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
     List.fold_left (fun (params, body) (param, loc, arg_coercion) ->
         let param' = Ident.rename param in
         let arg = apply_coercion loc Alias arg_coercion (Lvar param') in
-        let params = (param', Pgenval) :: params in
+        let params = (param', Pgenval, alloc_heap) :: params in
         let body = Llet (Alias, Pgenval, param, arg, body) in
         params, body)
       ([], transl_module ~scopes res_coercion body_path body)

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -1067,7 +1067,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
           (lfunction
              ~kind
              ~return:Pgenval
-             ~params:(List.map (fun v -> v, Pgenval) final_args)
+             ~params:(List.map (fun v -> v, Pgenval, new_clos_mode) final_args)
              ~body:(Lapply{
                 ap_loc=loc;
                 ap_func=(Lvar funct_var);
@@ -1450,13 +1450,14 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
     let fun_params =
       if !useless_env
       then params
-      else params @ [env_param, Pgenval]
+      else params @ [env_param, Pgenval, alloc_heap]
     in
     let f =
       {
         label  = fundesc.fun_label;
         arity  = fundesc.fun_arity;
-        params = List.map (fun (var, kind) -> VP.create var, kind) fun_params;
+        params =
+          List.map (fun (var, kind, _) -> VP.create var, kind) fun_params;
         return;
         body   = ubody;
         dbg;
@@ -1469,7 +1470,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
        their wrapper functions) to be inlined *)
     let n =
       List.fold_left
-        (fun n (id, _) -> n + if V.name id = "*opt*" then 8 else 1)
+        (fun n (id, _, _) -> n + if V.name id = "*opt*" then 8 else 1)
         0
         fun_params
     in
@@ -1485,7 +1486,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
       | Never_inline -> min_int
       | Unroll _ -> assert false
     in
-    let fun_params = List.map (fun (var, _) -> VP.create var) fun_params in
+    let fun_params = List.map (fun (var, _, _) -> VP.create var) fun_params in
     if lambda_smaller ubody threshold
     then fundesc.fun_inline <- Some(fun_params, ubody);
 

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -229,7 +229,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let set_of_closures =
       let decl =
         Function_decl.create ~let_rec_ident:None ~closure_bound_var ~kind ~mode
-          ~region ~params:(List.map fst params) ~body ~attr ~loc
+          ~region ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
       in
       close_functions t env (Function_decls.create [decl])
     in
@@ -279,7 +279,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
             let function_declaration =
               Function_decl.create ~let_rec_ident:(Some let_rec_ident)
                 ~closure_bound_var ~kind ~mode ~region
-                ~params:(List.map fst params) ~body ~attr ~loc
+                ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
             in
             Some function_declaration
           | _ -> None)
@@ -692,7 +692,7 @@ and close_let_bound_expression t ?let_rec_ident let_bound_var env
     let closure_bound_var = Variable.rename let_bound_var in
     let decl =
       Function_decl.create ~let_rec_ident ~closure_bound_var ~kind ~mode ~region
-        ~params:(List.map fst params) ~body ~attr ~loc
+        ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
     in
     let set_of_closures_var = Variable.rename let_bound_var in
     let set_of_closures =

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -273,10 +273,10 @@ let expr sub x =
         let (rec_flag, list) = sub.value_bindings sub (rec_flag, list) in
         Texp_let (rec_flag, list, sub.expr sub exp)
     | Texp_function { arg_label; param; cases;
-                      partial; region; curry; warnings } ->
+                      partial; region; param_alloc_mode; curry; warnings } ->
         let cases = List.map (sub.case sub) cases in
         Texp_function { arg_label; param; cases;
-                        partial; region; curry; warnings }
+                        partial; region; curry; param_alloc_mode; warnings }
     | Texp_apply (exp, list, pos) ->
         Texp_apply (
           sub.expr sub exp,

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -5120,7 +5120,8 @@ and type_function ?in_function
   re {
     exp_desc =
       Texp_function
-        { arg_label; param; cases; partial; region; curry; warnings };
+        { arg_label; param; cases; partial; region; curry; warnings;
+          param_alloc_mode = arg_mode };
     exp_loc = loc; exp_extra = [];
     exp_type =
       instance (newgenty (Tarrow((arg_label,arg_mode,ret_mode),
@@ -5616,6 +5617,7 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
         { texp with exp_type = ty_fun; exp_mode = mode.mode;
             exp_desc = Texp_function { arg_label = Nolabel; param; cases;
                                        partial = Total; region = false; curry;
+                                       param_alloc_mode = marg;
                                        warnings = Warnings.backup () } }
       in
       Location.prerr_warning texp.exp_loc

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -111,6 +111,7 @@ and expression_desc =
   | Texp_function of { arg_label : arg_label; param : Ident.t;
       cases : value case list; partial : partial;
       region : bool; curry : fun_curry_state;
+      param_alloc_mode : Types.alloc_mode;
       warnings : Warnings.state; }
   | Texp_apply of expression * (arg_label * apply_arg) list * apply_position
   | Texp_match of expression * computation case list * partial

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -197,6 +197,7 @@ and expression_desc =
   | Texp_function of { arg_label : arg_label; param : Ident.t;
       cases : value case list; partial : partial;
       region : bool; curry : fun_curry_state;
+      param_alloc_mode : Types.alloc_mode;
       warnings : Warnings.state; }
         (** [Pexp_fun] and [Pexp_function] both translate to [Texp_function].
             See {!Parsetree} for more details.


### PR DESCRIPTION
This PR tracks the allocation mode of each function parameter separately in Lambda, which enables Flambda 2 to obtain an accurate view of what's going on, rather than relying on `nlocal`.  The latter is really about the modes of closures resulting from a partial application.  This means that for a function like the following:
```
let f (local_ x) y (local_ z) =
  let local_ p = x, z in
  (fst p) + (fst y), (snd p) + (snd y)
```
then `nlocal` will be 3 (corresponding to two possible partial application points, and a full application, all returning local closures) and currently Flambda 2 will think `y` is local.  However it is in fact global.