### PR TITLE
Split simplify_toplevel into simplify_toplevel and simplify_function_body.

### DIFF
--- a/middle_end/flambda2/simplify/env/closure_info.mli
+++ b/middle_end/flambda2/simplify/env/closure_info.mli
@@ -34,7 +34,7 @@ val in_a_closure :
   exn_continuation:Continuation.t ->
   t
 
-type in_or_out_of_closure = private
+type in_or_out_of_closure =
   | In_a_closure
   | Not_in_a_closure
 

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -48,6 +48,16 @@ type simplify_toplevel =
   exn_cont_scope:Scope.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
+type simplify_function_body =
+  Downwards_acc.t ->
+  Expr.t ->
+  return_continuation:Continuation.t ->
+  return_arity:Flambda_arity.With_subkinds.t ->
+  exn_continuation:Continuation.t ->
+  return_cont_scope:Scope.t ->
+  exn_cont_scope:Scope.t ->
+  Rebuilt_expr.t * Upwards_acc.t
+
 let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var
     ~result_kind =
   let env = DA.typing_env dacc in

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -82,6 +82,16 @@ type simplify_toplevel =
   exn_cont_scope:Scope.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
+type simplify_function_body =
+  Downwards_acc.t ->
+  Expr.t ->
+  return_continuation:Continuation.t ->
+  return_arity:Flambda_arity.With_subkinds.t ->
+  exn_continuation:Continuation.t ->
+  return_cont_scope:Scope.t ->
+  exn_cont_scope:Scope.t ->
+  Rebuilt_expr.t * Upwards_acc.t
+
 val simplify_projection :
   Downwards_acc.t ->
   original_term:Named.t ->

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -16,31 +16,10 @@
 
 open! Simplify_import
 
-(* CR-someday mshinwell: Need to simplify each [dbg] we come across. *)
-(* CR-someday mshinwell: Consider defunctionalising to remove the [k]. *)
-
-let rec simplify_expr dacc expr ~down_to_up =
-  match Expr.descr expr with
-  | Let let_expr -> simplify_let dacc let_expr ~down_to_up
-  | Let_cont let_cont ->
-    Simplify_let_cont_expr.simplify_let_cont ~simplify_expr dacc let_cont
-      ~down_to_up
-  | Apply apply ->
-    Simplify_apply_expr.simplify_apply ~simplify_expr dacc apply ~down_to_up
-  | Apply_cont apply_cont ->
-    Simplify_apply_cont_expr.simplify_apply_cont dacc apply_cont ~down_to_up
-  | Switch switch ->
-    Simplify_switch_expr.simplify_switch
-      ~simplify_let:Simplify_let_expr.simplify_let ~simplify_toplevel dacc
-      switch ~down_to_up
-  | Invalid { message } ->
-    (* CR mshinwell: Make sure that a program can be simplified to just
-       [Invalid]. *)
-    down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
-        EB.rebuild_invalid uacc (Message message) ~after_rebuild)
-
-and simplify_toplevel dacc expr ~return_continuation ~return_arity
-    ~exn_continuation ~return_cont_scope ~exn_cont_scope =
+let simplify_toplevel_common dacc simplify
+    ~(in_or_out_of_closure : Closure_info.in_or_out_of_closure)
+    ~return_continuation ~return_arity ~exn_continuation ~return_cont_scope
+    ~exn_cont_scope =
   (* The usage analysis needs a continuation whose handler holds the toplevel
      code of the function. Since such a continuation does not exist, we create a
      dummy one here. *)
@@ -51,13 +30,12 @@ and simplify_toplevel dacc expr ~return_continuation ~return_arity
     DA.map_data_flow dacc ~f:(Data_flow.init_toplevel dummy_toplevel_cont [])
   in
   let expr, uacc =
-    simplify_expr dacc expr ~down_to_up:(fun dacc ~rebuild ->
+    simplify dacc ~down_to_up:(fun dacc ~rebuild ->
         let dacc =
           DA.map_data_flow dacc
             ~f:(Data_flow.exit_continuation dummy_toplevel_cont)
         in
         let data_flow = DA.data_flow dacc in
-        let closure_info = DE.closure_info (DA.denv dacc) in
         (* The code_age_relation and used value_slots are only correct at
            toplevel, and they are only necessary to compute the live code ids,
            which are only used when simplifying at the toplevel. So if we are in
@@ -65,7 +43,7 @@ and simplify_toplevel dacc expr ~return_continuation ~return_arity
            used_value_slots, and in return we do not use the reachable_code_id
            part of the data_flow analysis. *)
         let code_age_relation, used_value_slots =
-          match Closure_info.in_or_out_of_closure closure_info with
+          match in_or_out_of_closure with
           | In_a_closure -> Code_age_relation.empty, Or_unknown.Unknown
           | Not_in_a_closure ->
             ( DA.code_age_relation dacc,
@@ -80,7 +58,7 @@ and simplify_toplevel dacc expr ~return_continuation ~return_arity
            the the live code ids are unknown, which will prevent any from being
            mistakenly deleted. *)
         let reachable_code_ids : _ Or_unknown.t =
-          match Closure_info.in_or_out_of_closure closure_info with
+          match in_or_out_of_closure with
           | In_a_closure -> Unknown
           | Not_in_a_closure -> Known reachable_code_ids
         in
@@ -118,6 +96,43 @@ and simplify_toplevel dacc expr ~return_continuation ~return_arity
           exn_continuation);
   expr, uacc
 
+(* CR-someday mshinwell: Need to simplify each [dbg] we come across. *)
+(* CR-someday mshinwell: Consider defunctionalising to remove the [k]. *)
+
+let rec simplify_expr dacc expr ~down_to_up =
+  match Expr.descr expr with
+  | Let let_expr -> simplify_let dacc let_expr ~down_to_up
+  | Let_cont let_cont ->
+    Simplify_let_cont_expr.simplify_let_cont ~simplify_expr dacc let_cont
+      ~down_to_up
+  | Apply apply ->
+    Simplify_apply_expr.simplify_apply ~simplify_expr dacc apply ~down_to_up
+  | Apply_cont apply_cont ->
+    Simplify_apply_cont_expr.simplify_apply_cont dacc apply_cont ~down_to_up
+  | Switch switch ->
+    Simplify_switch_expr.simplify_switch
+      ~simplify_let:Simplify_let_expr.simplify_let ~simplify_function_body dacc
+      switch ~down_to_up
+  | Invalid { message } ->
+    (* CR mshinwell: Make sure that a program can be simplified to just
+       [Invalid]. *)
+    down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
+        EB.rebuild_invalid uacc (Message message) ~after_rebuild)
+
+and simplify_function_body dacc expr ~return_continuation ~return_arity
+    ~exn_continuation ~return_cont_scope ~exn_cont_scope =
+  simplify_toplevel_common dacc
+    (fun dacc -> simplify_expr dacc expr)
+    ~in_or_out_of_closure:In_a_closure ~return_continuation ~return_arity
+    ~exn_continuation ~return_cont_scope ~exn_cont_scope
+
 and[@inline always] simplify_let dacc let_expr ~down_to_up =
-  Simplify_let_expr.simplify_let ~simplify_expr ~simplify_toplevel dacc let_expr
-    ~down_to_up
+  Simplify_let_expr.simplify_let ~simplify_expr ~simplify_function_body dacc
+    let_expr ~down_to_up
+
+let simplify_toplevel dacc expr ~return_continuation ~return_arity
+    ~exn_continuation ~return_cont_scope ~exn_cont_scope =
+  simplify_toplevel_common dacc
+    (fun dacc -> simplify_expr dacc expr)
+    ~in_or_out_of_closure:Not_in_a_closure ~return_continuation ~return_arity
+    ~exn_continuation ~return_cont_scope ~exn_cont_scope

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -232,8 +232,8 @@ let update_data_flow dacc closure_info ~lifted_constants_from_defining_expr
     ~init:data_flow
     ~f:(record_new_defining_expression_binding_for_data_flow dacc)
 
-let simplify_let0 ~simplify_expr ~simplify_toplevel dacc let_expr ~down_to_up
-    bound_pattern ~body =
+let simplify_let0 ~simplify_expr ~simplify_function_body dacc let_expr
+    ~down_to_up bound_pattern ~body =
   let module L = Flambda.Let in
   let original_dacc = dacc in
   (* Remember then clear the lifted constants memory in [DA] so we can easily
@@ -244,7 +244,7 @@ let simplify_let0 ~simplify_expr ~simplify_toplevel dacc let_expr ~down_to_up
   let defining_expr = L.defining_expr let_expr in
   let simplify_named_result, removed_operations =
     Simplify_named.simplify_named dacc bound_pattern defining_expr
-      ~simplify_toplevel
+      ~simplify_function_body
   in
   (* We must make sure that if [Invalid] is going to be produced, [uacc] doesn't
      contain any extraneous data for e.g. lifted constants that will never be
@@ -309,8 +309,10 @@ let simplify_let0 ~simplify_expr ~simplify_toplevel dacc let_expr ~down_to_up
     in
     simplify_expr dacc body ~down_to_up
 
-let simplify_let ~simplify_expr ~simplify_toplevel dacc let_expr ~down_to_up =
+let simplify_let ~simplify_expr ~simplify_function_body dacc let_expr
+    ~down_to_up =
   let module L = Flambda.Let in
   L.pattern_match let_expr
     ~f:
-      (simplify_let0 ~simplify_expr ~simplify_toplevel dacc let_expr ~down_to_up)
+      (simplify_let0 ~simplify_expr ~simplify_function_body dacc let_expr
+         ~down_to_up)

--- a/middle_end/flambda2/simplify/simplify_let_expr.mli
+++ b/middle_end/flambda2/simplify/simplify_let_expr.mli
@@ -18,5 +18,5 @@ open! Simplify_import
 
 val simplify_let :
   simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  simplify_toplevel:Simplify_common.simplify_toplevel ->
+  simplify_function_body:Simplify_common.simplify_function_body ->
   Let.t Simplify_common.expr_simplifier

--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -67,7 +67,7 @@ let create_lifted_constant (dacc, lifted_constants)
    for such sets. See comment in [Simplify_let_expr], function [rebuild_let]. *)
 
 let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
-    ~simplify_toplevel : Simplify_named_result.t Or_invalid.t =
+    ~simplify_function_body : Simplify_named_result.t Or_invalid.t =
   match named with
   | Simple simple ->
     let bound_var = Bound_pattern.must_be_singleton bound_pattern in
@@ -124,7 +124,7 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
   | Set_of_closures set_of_closures ->
     Ok
       (Simplify_set_of_closures.simplify_non_lifted_set_of_closures dacc
-         bound_pattern set_of_closures ~simplify_toplevel)
+         bound_pattern set_of_closures ~simplify_function_body)
   | Static_consts static_consts ->
     let bound_static = Bound_pattern.must_be_static bound_pattern in
     let binds_symbols = Bound_static.binds_symbols bound_static in
@@ -137,7 +137,7 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
     let bound_static, static_consts, dacc =
       try
         Simplify_static_const.simplify_static_consts dacc bound_static
-          static_consts ~simplify_toplevel
+          static_consts ~simplify_function_body
       with Misc.Fatal_error ->
         let bt = Printexc.get_raw_backtrace () in
         Format.eprintf
@@ -214,10 +214,10 @@ let removed_operations ~(original : Named.t) (result : _ Or_invalid.t) =
         Removed_operations.prim original_prim)
     | Rec_info _ -> zero)
 
-let simplify_named dacc bound_pattern named ~simplify_toplevel =
+let simplify_named dacc bound_pattern named ~simplify_function_body =
   try
     let simplified_named_or_invalid =
-      simplify_named0 ~simplify_toplevel dacc bound_pattern named
+      simplify_named0 ~simplify_function_body dacc bound_pattern named
     in
     ( simplified_named_or_invalid,
       removed_operations ~original:named simplified_named_or_invalid )

--- a/middle_end/flambda2/simplify/simplify_named.mli
+++ b/middle_end/flambda2/simplify/simplify_named.mli
@@ -20,5 +20,5 @@ val simplify_named :
   Downwards_acc.t ->
   Bound_pattern.t ->
   Flambda.Named.t ->
-  simplify_toplevel:Simplify_common.simplify_toplevel ->
+  simplify_function_body:Simplify_common.simplify_function_body ->
   Simplify_named_result.t Or_invalid.t * Removed_operations.t

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.mli
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.mli
@@ -31,7 +31,7 @@ val simplify_non_lifted_set_of_closures :
   Downwards_acc.t ->
   Bound_pattern.t ->
   Set_of_closures.t ->
-  simplify_toplevel:Simplify_common.simplify_toplevel ->
+  simplify_function_body:Simplify_common.simplify_function_body ->
   Simplify_named_result.t
 
 (** Simplify a group of possibly-recursive sets of closures, as may occur on the
@@ -41,12 +41,12 @@ val simplify_lifted_sets_of_closures :
   all_sets_of_closures_and_symbols:
     (Symbol.t Function_slot.Lmap.t * Set_of_closures.t) list ->
   closure_bound_names_all_sets:Bound_name.t Function_slot.Map.t list ->
-  simplify_toplevel:Simplify_common.simplify_toplevel ->
+  simplify_function_body:Simplify_common.simplify_function_body ->
   Bound_static.t * Rebuilt_static_const.Group.t * Downwards_acc.t
 
 val simplify_stub_function :
   Downwards_acc.t ->
   Code.t ->
   all_code:Code.t Code_id.Map.t ->
-  simplify_toplevel:Simplify_common.simplify_toplevel ->
+  simplify_function_body:Simplify_common.simplify_function_body ->
   Rebuilt_static_const.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -223,7 +223,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
       SC.print static_const
 
 let simplify_static_consts dacc (bound_static : Bound_static.t) static_consts
-    ~simplify_toplevel =
+    ~simplify_function_body =
   let bound_static_list = Bound_static.to_list bound_static in
   let static_consts_list = Static_const_group.to_list static_consts in
   if List.compare_lengths bound_static_list static_consts_list <> 0
@@ -292,7 +292,7 @@ let simplify_static_consts dacc (bound_static : Bound_static.t) static_consts
             in
             let static_const, dacc_after_function =
               Simplify_set_of_closures.simplify_stub_function dacc code
-                ~all_code ~simplify_toplevel
+                ~all_code ~simplify_function_body
             in
             let dacc_after_function =
               DA.add_to_lifted_constant_accumulator dacc_after_function
@@ -356,7 +356,7 @@ let simplify_static_consts dacc (bound_static : Bound_static.t) static_consts
   let bound_static'', static_consts'', dacc =
     Simplify_set_of_closures.simplify_lifted_sets_of_closures dacc
       ~all_sets_of_closures_and_symbols ~closure_bound_names_all_sets
-      ~simplify_toplevel
+      ~simplify_function_body
   in
   (* The ordering of these lists doesn't matter as they will go through
      [Sort_lifted_constants] before the terms are constructed. *)

--- a/middle_end/flambda2/simplify/simplify_static_const.mli
+++ b/middle_end/flambda2/simplify/simplify_static_const.mli
@@ -22,5 +22,5 @@ val simplify_static_consts :
   Downwards_acc.t ->
   Bound_static.t ->
   Static_const_group.t ->
-  simplify_toplevel:Simplify_common.simplify_toplevel ->
+  simplify_function_body:Simplify_common.simplify_function_body ->
   Bound_static.t * Rebuilt_static_const.Group.t * Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -367,7 +367,8 @@ let simplify_switch0 dacc switch ~down_to_up =
          ~condition_dbg:(Switch.condition_dbg switch)
          ~scrutinee ~scrutinee_ty ~dacc_before_switch)
 
-let simplify_switch ~simplify_let ~simplify_toplevel dacc switch ~down_to_up =
+let simplify_switch ~simplify_let ~simplify_function_body dacc switch
+    ~down_to_up =
   let tagged_scrutinee = Variable.create "tagged_scrutinee" in
   let tagging_prim =
     Named.create_prim
@@ -391,4 +392,4 @@ let simplify_switch ~simplify_let ~simplify_toplevel dacc switch ~down_to_up =
   simplify_let
     ~simplify_expr:(fun dacc _body ~down_to_up ->
       simplify_switch0 dacc switch ~down_to_up)
-    ~simplify_toplevel dacc let_expr ~down_to_up
+    ~simplify_function_body dacc let_expr ~down_to_up

--- a/middle_end/flambda2/simplify/simplify_switch_expr.mli
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.mli
@@ -17,7 +17,7 @@
 val simplify_switch :
   simplify_let:
     (simplify_expr:Flambda.Expr.t Simplify_common.expr_simplifier ->
-    simplify_toplevel:Simplify_common.simplify_toplevel ->
+    simplify_function_body:Simplify_common.simplify_function_body ->
     Flambda.Let.t Simplify_common.expr_simplifier) ->
-  simplify_toplevel:Simplify_common.simplify_toplevel ->
+  simplify_function_body:Simplify_common.simplify_function_body ->
   Flambda.Switch.t Simplify_common.expr_simplifier


### PR DESCRIPTION
This is a prerequisite for the rec-to-cont pull request, since it is needed to differentiate the two of them to pass function parameters to the new `simplify_function_body`.