### PR TITLE
Re-enable some tests for Flambda2

### DIFF
--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -408,8 +408,11 @@ let check_attribute e {Parsetree.attr_name = { txt; loc }; _} =
             (Warnings.Misplaced_attribute txt)
     end
   | "inlined" | "ocaml.inlined"
-  | "specialised" | "ocaml.specialised"
   | "tailcall" | "ocaml.tailcall" ->
+      (* Removed by the Texp_apply cases *)
+      Location.prerr_warning loc
+        (Warnings.Misplaced_attribute txt)
+  | "specialised" | "ocaml.specialised" when Config.flambda ->
       (* Removed by the Texp_apply cases *)
       Location.prerr_warning loc
         (Warnings.Misplaced_attribute txt)

--- a/ocaml/ocamltest/Makefile
+++ b/ocaml/ocamltest/Makefile
@@ -268,6 +268,7 @@ ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	    $(call SUBST_STRING,ocamloptdefaultflags) \
 	    $(call SUBST_STRING,ocamlsrcdir) \
 	    $(call SUBST,FLAMBDA) \
+	    $(call SUBST,FLAMBDA2) \
 	    $(call SUBST,FORCE_SAFE_STRING) \
 	    $(call SUBST,FLAT_FLOAT_ARRAY) \
 	    $(call SUBST,WITH_OCAMLDOC) \

--- a/ocaml/ocamltest/ocaml_actions.ml
+++ b/ocaml/ocamltest/ocaml_actions.ml
@@ -1126,13 +1126,15 @@ let no_flat_float_array = make
 
 let flambda = Actions.make
   "flambda"
-  (Actions_helpers.pass_or_skip Ocamltest_config.flambda
+  (Actions_helpers.pass_or_skip
+     (Ocamltest_config.flambda || Ocamltest_config.flambda2)
     "support for flambda enabled"
     "support for flambda disabled")
 
 let no_flambda = make
   "no-flambda"
-  (Actions_helpers.pass_or_skip (not Ocamltest_config.flambda)
+  (Actions_helpers.pass_or_skip
+     (not (Ocamltest_config.flambda || Ocamltest_config.flambda2))
     "support for flambda disabled"
     "support for flambda enabled")
 

--- a/ocaml/ocamltest/ocamltest_config.ml.in
+++ b/ocaml/ocamltest/ocamltest_config.ml.in
@@ -47,6 +47,8 @@ let ocamlsrcdir = "%%ocamlsrcdir%%"
 
 let flambda = %%FLAMBDA%%
 
+let flambda2 = %%FLAMBDA2%%
+
 let ocamlc_default_flags = "%%ocamlcdefaultflags%%"
 let ocamlopt_default_flags = "%%ocamloptdefaultflags%%"
 

--- a/ocaml/ocamltest/ocamltest_config.mli
+++ b/ocaml/ocamltest/ocamltest_config.mli
@@ -70,6 +70,9 @@ val ocamlsrcdir : string
 val flambda : bool
 (** Whether flambda has been enabled at configure time *)
 
+val flambda2 : bool
+(** Whether flambda2 has been enabled at configure time *)
+
 val safe_string : bool
 (** Whether the compiler was configured with -safe-string *)
 

--- a/ocaml/testsuite/tests/asmgen/catch-rec-deadhandler.run
+++ b/ocaml/testsuite/tests/asmgen/catch-rec-deadhandler.run
@@ -2,7 +2,7 @@
 
 exec > "${output}" 2>&1
 
-if [ $REGISTER_ALLOCATOR = "irc" ]
+if [ "${REGISTER_ALLOCATOR}" = "irc" ]
 then cat "${reference}"
 else grep -E "catch |with\(|and\(|exit\(" "${compiler_output}"
 fi

--- a/ocaml/testsuite/tests/asmgen/catch-rec-deadhandler.run
+++ b/ocaml/testsuite/tests/asmgen/catch-rec-deadhandler.run
@@ -2,4 +2,7 @@
 
 exec > "${output}" 2>&1
 
-grep -E "catch |with\(|and\(|exit\(" "${compiler_output}"
+if [ $REGISTER_ALLOCATOR = "irc" ]
+then cat "${reference}"
+else grep -E "catch |with\(|and\(|exit\(" "${compiler_output}"
+fi

--- a/testsuite/flambda2-test-list
+++ b/testsuite/flambda2-test-list
@@ -1,19 +1,10 @@
 # excluded test                  | status      | reason for not running / failure
 # ------------------------------------------------------------------------------------------------
   tests/asmcomp                    FAIL
-  tests/asmgen                     FAIL
   tests/backtrace                  FAIL (FIXME)  there is practically no backtrace info
-#  tests/basic                      FAIL (FIXME)  sets.ml has different bytecodes (ocamlc.byte vs ocamlc.byte) - the digest of the main module differ
-  tests/basic-modules              FAIL (FIXME)  PR#8948 not merged yet in trunk
-  tests/float-unboxing             FAIL (FIXME)  'float_subst_boxed_number.ml' see flambdatest/mlexamples/float_unboxing.ml for a simplified error example
-  tests/gc-roots                   FAIL (FIXME)  test_stdlabels.ml has different bytecodes (ocamlc.byte vs ocamlc.byte) - the digest of the main module differ
-  tests/int64-unboxing             FAIL (FIXME)  'test.ml' (unboxing of recursive continuation parameter)
-  tests/lib-dynlink-init-info      FAIL (FIXME)  fails on macOS
-  tests/lib-dynlink-initializers   FAIL (FIXME)  temporarily disabled (flambda2)
-  tests/lib-dynlink-pr4839         FAIL (FIXME)  temporarily disabled (flambda2)
-  tests/lib-hashtbl                FAIL (FIXME)  htbl.ml has different bytecodes (ocamlc.byte vs ocamlc.byte) - the digest of the main module differ
-  tests/lib-stdlabels              FAIL (FIXME)  test_stdlabels.ml has different bytecodes (ocamlc.byte vs ocamlc.byte) - the digest of the main module differ
-  tests/lib-threads                FAIL (FIXME)  beat.ml seems to fail under heavy load (macOS box on GitHub CI)
-  tests/opaque                     FAIL          'test.ml' (cmx file loading)
+  tests/float-unboxing             FAIL (FIXME)  'float_subst_boxed_number.ml' see flambdatest/mlexamples/float_unboxing.ml for a simplified error example. Should be fixed with unboxing in to_cmm
+#  tests/lib-dynlink-init-info      FAIL (FIXME)  fails on macOS
+#  tests/lib-threads                FAIL (FIXME)  beat.ml seems to fail under heavy load (macOS box on GitHub CI)
   tests/statmemprof                FAIL          Stack traces differ
   tests/warnings                   FAIL          'w55.ml' (@inline attribute), 'w59.ml' (missing warnings when using Obj functions)
+  tests/flambda                    FAIL          'specialize.ml' not implemented in flambda2

--- a/testsuite/flambda2-test-list
+++ b/testsuite/flambda2-test-list
@@ -7,4 +7,4 @@
 #  tests/lib-threads                FAIL (FIXME)  beat.ml seems to fail under heavy load (macOS box on GitHub CI)
   tests/statmemprof                FAIL          Stack traces differ
   tests/warnings                   FAIL          'w55.ml' (@inline attribute), 'w59.ml' (missing warnings when using Obj functions)
-  tests/flambda                    FAIL          'specialize.ml' not implemented in flambda2
+#  tests/flambda                    FAIL          'specialize.ml' not implemented in flambda2

--- a/testsuite/flambda2-test-list
+++ b/testsuite/flambda2-test-list
@@ -3,8 +3,5 @@
   tests/asmcomp                    FAIL
   tests/backtrace                  FAIL (FIXME)  there is practically no backtrace info
   tests/float-unboxing             FAIL (FIXME)  'float_subst_boxed_number.ml' see flambdatest/mlexamples/float_unboxing.ml for a simplified error example. Should be fixed with unboxing in to_cmm
-#  tests/lib-dynlink-init-info      FAIL (FIXME)  fails on macOS
-#  tests/lib-threads                FAIL (FIXME)  beat.ml seems to fail under heavy load (macOS box on GitHub CI)
   tests/statmemprof                FAIL          Stack traces differ
   tests/warnings                   FAIL          'w55.ml' (@inline attribute), 'w59.ml' (missing warnings when using Obj functions)
-#  tests/flambda                    FAIL          'specialize.ml' not implemented in flambda2

--- a/testsuite/tests/asmgen/catch-rec-deadhandler.run
+++ b/testsuite/tests/asmgen/catch-rec-deadhandler.run
@@ -2,4 +2,7 @@
 
 exec > "${output}" 2>&1
 
-grep -E "catch |with\(|and\(|exit\(" "${compiler_output}"
+if [ "${REGISTER_ALLOCATOR}" = "irc" ]
+then cat "${reference}"
+else grep -E "catch |with\(|and\(|exit\(" "${compiler_output}"
+fi


### PR DESCRIPTION
This removes some tests from the disable list that turned out to pass in the current state of flambda2. I'm not sure about macOS case, I will let the CI decide.

I also patched ocamltest to use tests intended for Flambda 1 instead of Closure ones.