### PR TITLE
Flambda2_types: move alloc_mode from Variant to Row_like_for_blocks

### DIFF
--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1308,27 +1308,23 @@ end = struct
           | Variant
               { immediates = Unknown;
                 blocks = _;
-                is_unique = _;
-                alloc_mode = _
+                is_unique = _
               }
           | Variant
               { immediates = _;
                 blocks = Unknown;
-                is_unique = _;
-                alloc_mode = _
+                is_unique = _
               } ->
             Value_unknown
           | Variant
               { immediates = Known imms;
                 blocks = Known blocks;
-                is_unique = _;
-                alloc_mode
-              } ->
+                is_unique = _              } ->
             if TG.is_obviously_bottom imms
             then
               match TG.Row_like_for_blocks.get_singleton blocks with
               | None -> Value_unknown
-              | Some ((_tag, _size), fields) ->
+              | Some ((_tag, _size), fields, alloc_mode) ->
                 let fields =
                   List.map type_to_approx
                     (TG.Product.Int_indexed.components fields)

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1305,21 +1305,12 @@ end = struct
                 Closure_approximation
                   { code_id; function_slot; code = code_or_meta; symbol = None }
               ))
-          | Variant
-              { immediates = Unknown;
-                blocks = _;
-                is_unique = _
-              }
-          | Variant
-              { immediates = _;
-                blocks = Unknown;
-                is_unique = _
-              } ->
+          | Variant { immediates = Unknown; blocks = _; is_unique = _ }
+          | Variant { immediates = _; blocks = Unknown; is_unique = _ } ->
             Value_unknown
           | Variant
-              { immediates = Known imms;
-                blocks = Known blocks;
-                is_unique = _              } ->
+              { immediates = Known imms; blocks = Known blocks; is_unique = _ }
+            ->
             if TG.is_obviously_bottom imms
             then
               match TG.Row_like_for_blocks.get_singleton blocks with

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -56,7 +56,7 @@ let these_naked_nativeints is = TG.these_naked_nativeints is
 
 let any_tagged_immediate =
   TG.create_variant ~is_unique:false ~immediates:Unknown
-    ~blocks:(Known TG.Row_like_for_blocks.bottom) (Known Alloc_mode.heap)
+    ~blocks:(Known TG.Row_like_for_blocks.bottom)
 
 let these_tagged_immediates0 imms =
   match Targetint_31_63.Set.get_singleton imms with
@@ -67,7 +67,7 @@ let these_tagged_immediates0 imms =
     else
       TG.create_variant ~is_unique:false
         ~immediates:(Known (these_naked_immediates imms))
-        ~blocks:(Known TG.Row_like_for_blocks.bottom) (Known Alloc_mode.heap)
+        ~blocks:(Known TG.Row_like_for_blocks.bottom)
 
 let these_tagged_immediates imms = these_tagged_immediates0 imms
 
@@ -109,20 +109,19 @@ let any_boxed_nativeint = TG.box_nativeint TG.any_naked_nativeint Unknown
 
 let any_block =
   TG.create_variant ~is_unique:false
-    ~immediates:(Known TG.bottom_naked_immediate) ~blocks:Unknown Unknown
+    ~immediates:(Known TG.bottom_naked_immediate) ~blocks:Unknown
 
-let blocks_with_these_tags tags : _ Or_unknown.t =
+let blocks_with_these_tags tags alloc_mode : _ Or_unknown.t =
   if not (Tag.Set.for_all Tag.is_structured_block tags)
   then Unknown
   else
     let blocks =
       TG.Row_like_for_blocks.create_blocks_with_these_tags ~field_kind:K.value
-        tags
+        tags alloc_mode
     in
     Known
       (TG.create_variant ~is_unique:false
-         ~immediates:(Known TG.bottom_naked_immediate) ~blocks:(Known blocks)
-         Unknown)
+         ~immediates:(Known TG.bottom_naked_immediate) ~blocks:(Known blocks))
 
 let immutable_block ~is_unique tag ~field_kind alloc_mode ~fields =
   match Targetint_31_63.of_int_option (List.length fields) with
@@ -134,8 +133,7 @@ let immutable_block ~is_unique tag ~field_kind alloc_mode ~fields =
       ~blocks:
         (Known
            (TG.Row_like_for_blocks.create ~field_kind ~field_tys:fields
-              (Closed tag)))
-      alloc_mode
+              (Closed tag) alloc_mode))
 
 let immutable_block_with_size_at_least ~tag ~n ~field_kind ~field_n_minus_one =
   let n = Targetint_31_63.to_int n in
@@ -148,8 +146,7 @@ let immutable_block_with_size_at_least ~tag ~n ~field_kind ~field_n_minus_one =
   TG.create_variant ~is_unique:false
     ~immediates:(Known (bottom K.naked_immediate))
     ~blocks:
-      (Known (TG.Row_like_for_blocks.create ~field_kind ~field_tys (Open tag)))
-    Unknown
+      (Known (TG.Row_like_for_blocks.create ~field_kind ~field_tys (Open tag) Unknown))
 
 let variant ~const_ctors ~non_const_ctors alloc_mode =
   let blocks =
@@ -159,10 +156,10 @@ let variant ~const_ctors ~non_const_ctors alloc_mode =
           Tag.Map.add (Tag.Scannable.to_tag tag) ty non_const_ctors)
         non_const_ctors Tag.Map.empty
     in
-    TG.Row_like_for_blocks.create_exactly_multiple ~field_tys_by_tag
+    TG.Row_like_for_blocks.create_exactly_multiple ~field_tys_by_tag alloc_mode
   in
   TG.create_variant ~is_unique:false ~immediates:(Known const_ctors)
-    ~blocks:(Known blocks) alloc_mode
+    ~blocks:(Known blocks)
 
 let exactly_this_closure function_slot ~all_function_slots_in_set:function_types
     ~all_closure_types_in_set:closure_types

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -146,7 +146,9 @@ let immutable_block_with_size_at_least ~tag ~n ~field_kind ~field_n_minus_one =
   TG.create_variant ~is_unique:false
     ~immediates:(Known (bottom K.naked_immediate))
     ~blocks:
-      (Known (TG.Row_like_for_blocks.create ~field_kind ~field_tys (Open tag) Unknown))
+      (Known
+         (TG.Row_like_for_blocks.create ~field_kind ~field_tys (Open tag)
+            Unknown))
 
 let variant ~const_ctors ~non_const_ctors alloc_mode =
   let blocks =

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -83,7 +83,8 @@ val any_boxed_nativeint : Type_grammar.t
 val any_block : Type_grammar.t
 
 (* Note this is only for blocks (variants, tuples, etc), not arrays! *)
-val blocks_with_these_tags : Tag.Set.t -> Alloc_mode.t Or_unknown.t -> Type_grammar.t Or_unknown.t
+val blocks_with_these_tags :
+  Tag.Set.t -> Alloc_mode.t Or_unknown.t -> Type_grammar.t Or_unknown.t
 
 val immutable_block :
   is_unique:bool ->

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -83,7 +83,7 @@ val any_boxed_nativeint : Type_grammar.t
 val any_block : Type_grammar.t
 
 (* Note this is only for blocks (variants, tuples, etc), not arrays! *)
-val blocks_with_these_tags : Tag.Set.t -> Type_grammar.t Or_unknown.t
+val blocks_with_these_tags : Tag.Set.t -> Alloc_mode.t Or_unknown.t -> Type_grammar.t Or_unknown.t
 
 val immutable_block :
   is_unique:bool ->

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -452,9 +452,7 @@ and apply_renaming_head_of_kind_value head renaming =
     in
     if immediates == immediates' && blocks == blocks'
     then head
-    else
-      Variant
-        { is_unique; blocks = blocks'; immediates = immediates' }
+    else Variant { is_unique; blocks = blocks'; immediates = immediates' }
   | Mutable_block { alloc_mode = _ } -> head
   | Boxed_float (ty, alloc_mode) ->
     let ty' = apply_renaming ty renaming in
@@ -994,7 +992,8 @@ and ids_for_export_row_like :
       (Ids_for_export.union from_known
          (ids_for_export_env_extension env_extension))
 
-and ids_for_export_row_like_for_blocks { known_tags; other_tags; alloc_mode = _ } =
+and ids_for_export_row_like_for_blocks
+    { known_tags; other_tags; alloc_mode = _ } =
   ids_for_export_row_like
     ~ids_for_export_maps_to:ids_for_export_int_indexed_product ~known:known_tags
     ~other:other_tags ~fold_known:Tag.Map.fold
@@ -1458,9 +1457,7 @@ and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value head
     in
     if immediates == immediates' && blocks == blocks'
     then head
-    else
-      Variant
-        { is_unique; blocks = blocks'; immediates = immediates' }
+    else Variant { is_unique; blocks = blocks'; immediates = immediates' }
   | Mutable_block { alloc_mode = _ } -> head
   | Boxed_float (ty, alloc_mode) ->
     let ty' =
@@ -1647,8 +1644,8 @@ and remove_unused_value_slots_and_shortcut_aliases_row_like :
   if known == known' && other == other' then None else Some (known', other')
 
 and remove_unused_value_slots_and_shortcut_aliases_row_like_for_blocks
-    ({ known_tags; other_tags; alloc_mode } as row_like_for_tags) ~used_value_slots
-    ~canonicalise =
+    ({ known_tags; other_tags; alloc_mode } as row_like_for_tags)
+    ~used_value_slots ~canonicalise =
   match
     remove_unused_value_slots_and_shortcut_aliases_row_like
       ~remove_unused_value_slots_and_shortcut_aliases_index:
@@ -1917,9 +1914,7 @@ and project_head_of_kind_value ~to_project ~expand head =
     in
     if immediates == immediates' && blocks == blocks'
     then head
-    else
-      Variant
-        { is_unique; blocks = blocks'; immediates = immediates' }
+    else Variant { is_unique; blocks = blocks'; immediates = immediates' }
   | Mutable_block _ -> head
   | Boxed_float (ty, alloc_mode) ->
     let ty' = project_variables_out ~to_project ~expand ty in
@@ -2168,8 +2163,7 @@ let kind t =
   | Rec_info _ -> K.rec_info
   | Region _ -> K.region
 
-let create_variant ~is_unique ~(immediates : _ Or_unknown.t) ~blocks
-    =
+let create_variant ~is_unique ~(immediates : _ Or_unknown.t) ~blocks =
   (match immediates with
   | Unknown -> ()
   | Known immediates ->
@@ -2300,12 +2294,14 @@ module Row_like_for_blocks = struct
     | Open of Tag.t Or_unknown.t
     | Closed of Tag.t
 
-  let bottom = { known_tags = Tag.Map.empty; other_tags = Bottom; alloc_mode = Unknown }
+  let bottom =
+    { known_tags = Tag.Map.empty; other_tags = Bottom; alloc_mode = Unknown }
 
   let is_bottom { known_tags; other_tags; alloc_mode = _ } =
     Tag.Map.is_empty known_tags && other_tags = Or_bottom.Bottom
 
-  let all_tags { known_tags; other_tags; alloc_mode = _ } : Tag.Set.t Or_unknown.t =
+  let all_tags { known_tags; other_tags; alloc_mode = _ } :
+      Tag.Set.t Or_unknown.t =
     match other_tags with
     | Ok _ -> Unknown
     | Bottom -> Known (Tag.Map.keys known_tags)
@@ -2425,7 +2421,10 @@ module Row_like_for_blocks = struct
         env_extension = { equations = Name.Map.empty }
       }
     in
-    { known_tags = Tag.Map.of_set (fun _ -> case) tags; other_tags = Bottom; alloc_mode }
+    { known_tags = Tag.Map.of_set (fun _ -> case) tags;
+      other_tags = Bottom;
+      alloc_mode
+    }
 
   let create_exactly_multiple ~field_tys_by_tag alloc_mode =
     let known_tags =
@@ -2453,7 +2452,8 @@ module Row_like_for_blocks = struct
     (* CR-someday mshinwell: add invariant check? *)
     { known_tags; other_tags; alloc_mode }
 
-  let all_tags_and_indexes { known_tags; other_tags; alloc_mode = _ } : _ Or_unknown.t =
+  let all_tags_and_indexes { known_tags; other_tags; alloc_mode = _ } :
+      _ Or_unknown.t =
     match other_tags with
     | Ok _ -> Unknown
     | Bottom -> Known (Tag.Map.map (fun case -> case.index) known_tags)
@@ -2997,9 +2997,7 @@ let rec recover_some_aliases t =
           ( Mutable_block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
           | Boxed_nativeint _ | String _ | Closures _ | Array _ )) ->
       t
-    | Ok
-        (No_alias
-          (Variant { immediates; blocks; is_unique = _ })) -> (
+    | Ok (No_alias (Variant { immediates; blocks; is_unique = _ })) -> (
       match blocks with
       | Unknown -> t
       | Known blocks -> (

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -43,8 +43,7 @@ and head_of_kind_value = private
   | Variant of
       { immediates : t Or_unknown.t;
         blocks : row_like_for_blocks Or_unknown.t;
-        is_unique : bool;
-        alloc_mode : Alloc_mode.t Or_unknown.t
+        is_unique : bool
       }
   (* CR mshinwell: It would be better to track per-field mutability. *)
   | Mutable_block of { alloc_mode : Alloc_mode.t Or_unknown.t }
@@ -97,7 +96,8 @@ and ('index, 'maps_to) row_like_case = private
 
 and row_like_for_blocks = private
   { known_tags : (Block_size.t, int_indexed_product) row_like_case Tag.Map.t;
-    other_tags : (Block_size.t, int_indexed_product) row_like_case Or_bottom.t
+    other_tags : (Block_size.t, int_indexed_product) row_like_case Or_bottom.t;
+    alloc_mode : Alloc_mode.t Or_unknown.t
   }
 
 and row_like_for_closures = private
@@ -259,7 +259,6 @@ val create_variant :
   is_unique:bool ->
   immediates:t Or_unknown.t ->
   blocks:row_like_for_blocks Or_unknown.t ->
-  Alloc_mode.t Or_unknown.t ->
   t
 
 val mutable_block : Alloc_mode.t Or_unknown.t -> t
@@ -383,24 +382,26 @@ module Row_like_for_blocks : sig
     field_kind:Flambda_kind.t ->
     field_tys:flambda_type list ->
     open_or_closed ->
+    Alloc_mode.t Or_unknown.t ->
     t
 
   val create_blocks_with_these_tags :
-    field_kind:Flambda_kind.t -> Tag.Set.t -> t
+    field_kind:Flambda_kind.t -> Tag.Set.t -> Alloc_mode.t Or_unknown.t -> t
 
   val create_exactly_multiple :
-    field_tys_by_tag:flambda_type list Tag.Map.t -> t
+    field_tys_by_tag:flambda_type list Tag.Map.t -> Alloc_mode.t Or_unknown.t -> t
 
   val create_raw :
     known_tags:(Block_size.t, int_indexed_product) row_like_case Tag.Map.t ->
     other_tags:(Block_size.t, int_indexed_product) row_like_case Or_bottom.t ->
+    alloc_mode:Alloc_mode.t Or_unknown.t ->
     t
 
   val all_tags : t -> Tag.Set.t Or_unknown.t
 
   val all_tags_and_sizes : t -> Targetint_31_63.t Tag.Map.t Or_unknown.t
 
-  val get_singleton : t -> (Tag_and_size.t * Product.Int_indexed.t) option
+  val get_singleton : t -> (Tag_and_size.t * Product.Int_indexed.t * Alloc_mode.t Or_unknown.t) option
 
   (** Get the nth field of the block if it is unambiguous.
 
@@ -556,7 +557,6 @@ module Head_of_kind_value : sig
     is_unique:bool ->
     blocks:Row_like_for_blocks.t Or_unknown.t ->
     immediates:flambda_type Or_unknown.t ->
-    Alloc_mode.t Or_unknown.t ->
     t
 
   val create_mutable_block : Alloc_mode.t Or_unknown.t -> t

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -389,7 +389,9 @@ module Row_like_for_blocks : sig
     field_kind:Flambda_kind.t -> Tag.Set.t -> Alloc_mode.t Or_unknown.t -> t
 
   val create_exactly_multiple :
-    field_tys_by_tag:flambda_type list Tag.Map.t -> Alloc_mode.t Or_unknown.t -> t
+    field_tys_by_tag:flambda_type list Tag.Map.t ->
+    Alloc_mode.t Or_unknown.t ->
+    t
 
   val create_raw :
     known_tags:(Block_size.t, int_indexed_product) row_like_case Tag.Map.t ->
@@ -401,7 +403,9 @@ module Row_like_for_blocks : sig
 
   val all_tags_and_sizes : t -> Targetint_31_63.t Tag.Map.t Or_unknown.t
 
-  val get_singleton : t -> (Tag_and_size.t * Product.Int_indexed.t * Alloc_mode.t Or_unknown.t) option
+  val get_singleton :
+    t ->
+    (Tag_and_size.t * Product.Int_indexed.t * Alloc_mode.t Or_unknown.t) option
 
   (** Get the nth field of the block if it is unambiguous.
 

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -322,35 +322,36 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
   | ( Variant
         { blocks = blocks1;
           immediates = imms1;
-          is_unique = is_unique1;
-          alloc_mode = alloc_mode1
+          is_unique = is_unique1
         },
       Variant
         { blocks = blocks2;
           immediates = imms2;
-          is_unique = is_unique2;
-          alloc_mode = alloc_mode2
+          is_unique = is_unique2
         } ) ->
-    let<* blocks, immediates, env_extension =
+    let<+ blocks, immediates, env_extension =
       meet_variant env ~blocks1 ~imms1 ~blocks2 ~imms2
     in
     (* Uniqueness tracks whether duplication/lifting is allowed. It must always
        be propagated, both for meet and join. *)
     let is_unique = is_unique1 || is_unique2 in
-    let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
-    ( TG.Head_of_kind_value.create_variant ~is_unique alloc_mode ~blocks
+    ( TG.Head_of_kind_value.create_variant ~is_unique ~blocks
         ~immediates,
       env_extension )
   | ( Mutable_block { alloc_mode = alloc_mode1 },
       Mutable_block { alloc_mode = alloc_mode2 } ) ->
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
     TG.Head_of_kind_value.create_mutable_block alloc_mode, TEE.empty
-  | ( Variant { alloc_mode = alloc_mode1; _ },
-      Mutable_block { alloc_mode = alloc_mode2 } )
-  | ( Mutable_block { alloc_mode = alloc_mode1 },
-      Variant { alloc_mode = alloc_mode2; _ } ) ->
-    let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
+  | ( Variant { blocks; _ },
+      (Mutable_block { alloc_mode = alloc_mode_mut } as mut_block) )
+  | ( (Mutable_block { alloc_mode = alloc_mode_mut } as mut_block),
+      Variant { blocks; _ } ) ->
+    begin match blocks with
+      | Unknown -> Ok (mut_block, TEE.empty)
+      | Known { alloc_mode = alloc_mode_immut; _ } ->
+    let<+ alloc_mode = meet_alloc_mode alloc_mode_mut alloc_mode_immut in
     TG.Head_of_kind_value.create_mutable_block alloc_mode, TEE.empty
+    end
   | Boxed_float (n1, alloc_mode1), Boxed_float (n2, alloc_mode2) ->
     let<* n, env_extension = meet env n1 n2 in
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
@@ -538,7 +539,7 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
           (* No blocks exist with this tag *))
         tags Tag.Set.empty
     in
-    match MTC.blocks_with_these_tags tags with
+    match MTC.blocks_with_these_tags tags Unknown with
     | Known shape ->
       let<+ ty, env_extension = meet env ty shape in
       TG.Head_of_kind_naked_immediate.create_get_tag ty, env_extension
@@ -715,17 +716,18 @@ and meet_row_like :
     Ok (known, other, env_extension)
 
 and meet_row_like_for_blocks env
-    ({ known_tags = known1; other_tags = other1 } : TG.Row_like_for_blocks.t)
-    ({ known_tags = known2; other_tags = other2 } : TG.Row_like_for_blocks.t) :
+    ({ known_tags = known1; other_tags = other1; alloc_mode = alloc_mode1 } : TG.Row_like_for_blocks.t)
+    ({ known_tags = known2; other_tags = other2; alloc_mode = alloc_mode2 } : TG.Row_like_for_blocks.t) :
     (TG.Row_like_for_blocks.t * TEE.t) Or_bottom.t =
-  let<+ known_tags, other_tags, env_extension =
+  let<* known_tags, other_tags, env_extension =
     meet_row_like ~meet_maps_to:meet_int_indexed_product
       ~equal_index:TG.Block_size.equal ~subset_index:TG.Block_size.subset
       ~union_index:TG.Block_size.union ~is_empty_map_known:Tag.Map.is_empty
       ~get_singleton_map_known:Tag.Map.get_singleton
       ~merge_map_known:Tag.Map.merge env ~known1 ~known2 ~other1 ~other2
   in
-  TG.Row_like_for_blocks.create_raw ~known_tags ~other_tags, env_extension
+  let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
+  TG.Row_like_for_blocks.create_raw ~known_tags ~other_tags ~alloc_mode, env_extension
 
 and meet_row_like_for_closures env
     ({ known_closures = known1; other_closures = other1 } :
@@ -1104,14 +1106,12 @@ and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
   | ( Variant
         { blocks = blocks1;
           immediates = imms1;
-          is_unique = is_unique1;
-          alloc_mode = alloc_mode1
+          is_unique = is_unique1
         },
       Variant
         { blocks = blocks2;
           immediates = imms2;
-          is_unique = is_unique2;
-          alloc_mode = alloc_mode2
+          is_unique = is_unique2
         } ) ->
     let>+ blocks, immediates =
       join_variant env ~blocks1 ~imms1 ~blocks2 ~imms2
@@ -1119,8 +1119,7 @@ and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
     (* Uniqueness tracks whether duplication/lifting is allowed. It must always
        be propagated, both for meet and join. *)
     let is_unique = is_unique1 || is_unique2 in
-    let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_variant ~is_unique alloc_mode ~blocks
+    TG.Head_of_kind_value.create_variant ~is_unique ~blocks
       ~immediates
   | ( Mutable_block { alloc_mode = alloc_mode1 },
       Mutable_block { alloc_mode = alloc_mode2 } ) ->
@@ -1416,15 +1415,16 @@ and join_row_like :
   known, other
 
 and join_row_like_for_blocks env
-    ({ known_tags = known1; other_tags = other1 } : TG.Row_like_for_blocks.t)
-    ({ known_tags = known2; other_tags = other2 } : TG.Row_like_for_blocks.t) =
+    ({ known_tags = known1; other_tags = other1; alloc_mode = alloc_mode1 } : TG.Row_like_for_blocks.t)
+    ({ known_tags = known2; other_tags = other2; alloc_mode = alloc_mode2 } : TG.Row_like_for_blocks.t) =
   let known_tags, other_tags =
     join_row_like ~join_maps_to:join_int_indexed_product
       ~maps_to_field_kind:TG.Product.Int_indexed.field_kind
       ~equal_index:TG.Block_size.equal ~inter_index:TG.Block_size.inter
       ~merge_map_known:Tag.Map.merge env ~known1 ~known2 ~other1 ~other2
   in
-  TG.Row_like_for_blocks.create_raw ~known_tags ~other_tags
+  let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
+  TG.Row_like_for_blocks.create_raw ~known_tags ~other_tags ~alloc_mode
 
 and join_row_like_for_closures env
     ({ known_closures = known1; other_closures = other1 } :

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -180,8 +180,7 @@ let meet_naked_immediates env t =
 
 let prove_equals_tagged_immediates env t : _ proof_of_property =
   match expand_head env t with
-  | Value (Ok (Variant { immediates; blocks; is_unique = _ }))
-    -> (
+  | Value (Ok (Variant { immediates; blocks; is_unique = _ })) -> (
     match blocks with
     | Unknown -> Unknown
     | Known blocks ->
@@ -202,9 +201,7 @@ let prove_equals_tagged_immediates env t : _ proof_of_property =
 
 let meet_equals_tagged_immediates env t : _ meet_shortcut =
   match expand_head env t with
-  | Value
-      (Ok (Variant { immediates; blocks = _; is_unique = _ }))
-    -> (
+  | Value (Ok (Variant { immediates; blocks = _; is_unique = _ })) -> (
     match immediates with
     | Unknown -> Need_meet
     | Known imms -> meet_naked_immediates env imms)
@@ -368,9 +365,7 @@ let prove_is_a_boxed_or_tagged_number env t :
     boxed_or_tagged_number proof_of_property =
   match expand_head env t with
   | Value Unknown -> Unknown
-  | Value
-      (Ok (Variant { blocks; immediates = _; is_unique = _ }))
-    -> (
+  | Value (Ok (Variant { blocks; immediates = _; is_unique = _ })) -> (
     match blocks with
     | Unknown -> Unknown
     | Known blocks ->
@@ -618,8 +613,7 @@ type tagging_proof_kind =
 let[@inline always] inspect_tagging_of_simple proof_kind env ~min_name_mode t :
     Simple.t generic_proof =
   match expand_head env t with
-  | Value (Ok (Variant { immediates; blocks; is_unique = _ }))
-    -> (
+  | Value (Ok (Variant { immediates; blocks; is_unique = _ })) -> (
     let inspect_immediates () =
       match immediates with
       | Unknown -> Unknown
@@ -718,9 +712,7 @@ let meet_boxed_nativeint_containing_simple =
 let meet_block_field_simple env ~min_name_mode t field_index :
     Simple.t meet_shortcut =
   match expand_head env t with
-  | Value
-      (Ok (Variant { immediates = _; blocks; is_unique = _ }))
-    -> (
+  | Value (Ok (Variant { immediates = _; blocks; is_unique = _ })) -> (
     match blocks with
     | Unknown -> Need_meet
     | Known blocks -> (
@@ -818,16 +810,16 @@ let prove_alloc_mode_of_boxed_number env t : Alloc_mode.t proof_of_property =
 let never_holds_locally_allocated_values env var kind : _ proof_of_property =
   let t = TE.find env (Name.var var) (Some kind) in
   match expand_head env t with
-  | Value (Ok (Variant { blocks; _ })) ->
-    begin match blocks with
-      | Unknown -> Unknown
-      | Known blocks ->
-        if TG.Row_like_for_blocks.is_bottom blocks then Proved ()
-        else begin match blocks.alloc_mode with
-          | Known Heap -> Proved ()
-          | Known Local | Unknown -> Unknown
-        end
-    end
+  | Value (Ok (Variant { blocks; _ })) -> (
+    match blocks with
+    | Unknown -> Unknown
+    | Known blocks -> (
+      if TG.Row_like_for_blocks.is_bottom blocks
+      then Proved ()
+      else
+        match blocks.alloc_mode with
+        | Known Heap -> Proved ()
+        | Known Local | Unknown -> Unknown))
   | Value (Ok (Boxed_float (_, alloc_mode)))
   | Value (Ok (Boxed_int32 (_, alloc_mode)))
   | Value (Ok (Boxed_int64 (_, alloc_mode)))
@@ -892,36 +884,21 @@ let prove_physical_equality env t1 t2 =
         let module SS = String_info.Set in
         if SS.is_empty (SS.inter s1 s2) then Proved false else Unknown
       (* Immediates and allocated values -> Proved false *)
-      | ( Variant
-            { immediates = _;
-              blocks = Known blocks;
-              is_unique = _
-            },
+      | ( Variant { immediates = _; blocks = Known blocks; is_unique = _ },
           ( Mutable_block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
           | Boxed_nativeint _ | Closures _ | String _ | Array _ ) )
       | ( ( Mutable_block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
           | Boxed_nativeint _ | Closures _ | String _ | Array _ ),
-          Variant
-            { immediates = _;
-              blocks = Known blocks;
-              is_unique = _
-            } )
+          Variant { immediates = _; blocks = Known blocks; is_unique = _ } )
         when TG.Row_like_for_blocks.is_bottom blocks ->
         Proved false
       (* Variants:
        * incompatible immediates and incompatible block tags -> Proved false
        * same immediate on both sides, no blocks -> Proved true
        *)
-      | ( Variant
-            { immediates = immediates1;
-              blocks = blocks1;
-              is_unique = _
-            },
-          Variant
-            { immediates = immediates2;
-              blocks = blocks2;
-              is_unique = _
-            } ) -> (
+      | ( Variant { immediates = immediates1; blocks = blocks1; is_unique = _ },
+          Variant { immediates = immediates2; blocks = blocks2; is_unique = _ }
+        ) -> (
         match immediates1, immediates2, blocks1, blocks2 with
         | Known imms, _, _, Known blocks
           when TG.is_obviously_bottom imms
@@ -975,9 +952,8 @@ let prove_physical_equality env t1 t2 =
                   TG.Row_like_for_blocks.get_singleton blocks2 )
               with
               | None, _ | _, None -> Unknown
-              | Some ((tag1, size1), _fields1, _alloc_mode1),
-                Some ((tag2, size2), _fields2, _alloc_mode2)
-                ->
+              | ( Some ((tag1, size1), _fields1, _alloc_mode1),
+                  Some ((tag2, size2), _fields2, _alloc_mode2) ) ->
                 if Tag.equal tag1 tag2 && Targetint_31_63.equal size1 size2
                 then
                   (* CR vlaviron and chambart: We could add a special case for

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -123,14 +123,14 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
     match
       Expand_head.expand_head env t |> Expand_head.Expanded_type.descr_oub
     with
-    | Value (Ok (Variant { is_unique; blocks; immediates; alloc_mode })) -> (
+    | Value (Ok (Variant { is_unique; blocks; immediates })) -> (
       match blocks, immediates with
       | Known blocks, Known imms ->
         if Expand_head.is_bottom env imms
         then
           match TG.Row_like_for_blocks.get_singleton blocks with
           | None -> try_canonical_simple ()
-          | Some ((tag, size), field_types) -> (
+          | Some ((tag, size), field_types, alloc_mode) -> (
             assert (
               Targetint_31_63.equal size
                 (TG.Product.Int_indexed.width field_types));


### PR DESCRIPTION
As discussed on Slack, allocation modes only make sense for the blocks part of the variant types. By moving the `alloc_mode` field to `Row_like_for_blocks`, we get rid of some issues that appear when we have to give an allocation mode to tagged immediates (`Unknown` makes us lose the alloc mode when joining a constant constructor with a non-constant constructor with known mode, and `Known Heap`, as we used to have, leads to wrongly assuming that locally-allocated variants can never be constants).

I've kept a separate formatting commit because the diff felt much easier to review on the first commit.