### PR TITLE
Remove num_trailing_local_closures

### DIFF
--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -232,7 +232,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let set_of_closures =
       let decl =
         Function_decl.create ~let_rec_ident:None ~closure_bound_var ~kind ~mode
-          ~region ~params:(List.map fst params) ~body ~attr ~loc
+          ~region ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
       in
       close_functions t env (Function_decls.create [decl])
     in
@@ -283,7 +283,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
             let function_declaration =
               Function_decl.create ~let_rec_ident:(Some let_rec_ident)
                 ~closure_bound_var ~kind ~mode ~region
-                ~params:(List.map fst params) ~body ~attr ~loc
+                ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
             in
             Some function_declaration
           | _ -> None)
@@ -715,7 +715,7 @@ and close_let_bound_expression t ?let_rec_ident let_bound_var env
     in
     let decl =
       Function_decl.create ~let_rec_ident ~closure_bound_var ~kind ~mode ~region
-        ~params:(List.map fst params) ~body ~attr ~loc
+        ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
     in
     let set_of_closures_var = Variable.rename let_bound_var in
     let set_of_closures =

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -24,7 +24,8 @@ type 'code t =
       { code_id : Code_id.t;
         function_slot : Function_slot.t;
         code : 'code;
-        symbol : Symbol.t option
+        symbol : Symbol.t option;
+        alloc_mode : Alloc_mode.t
       }
   | Block_approximation of 'code t array * Alloc_mode.t
 
@@ -60,7 +61,8 @@ let rec free_names ~code_free_names approx =
       (fun names approx ->
         Name_occurrences.union names (free_names ~code_free_names approx))
       Name_occurrences.empty approxs
-  | Closure_approximation { code_id; function_slot; code; symbol } ->
+  | Closure_approximation
+      { code_id; function_slot; code; symbol; alloc_mode = _ } ->
     let free_names = code_free_names code in
     let free_names =
       match symbol with

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -24,7 +24,8 @@ type 'code t =
       { code_id : Code_id.t;
         function_slot : Function_slot.t;
         code : 'code;
-        symbol : Symbol.t option
+        symbol : Symbol.t option;
+        alloc_mode : Alloc_mode.t
       }
   | Block_approximation of 'code t array * Alloc_mode.t
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -544,7 +544,7 @@ module Function_decls = struct
       { let_rec_ident : Ident.t;
         function_slot : Function_slot.t;
         kind : Lambda.function_kind;
-        params : (Ident.t * Lambda.value_kind) list;
+        params : (Ident.t * Lambda.value_kind * Lambda.alloc_mode) list;
         return : Lambda.value_kind;
         return_continuation : Continuation.t;
         exn_continuation : IR.exn_continuation;
@@ -556,14 +556,14 @@ module Function_decls = struct
         stub : bool;
         recursive : Recursive.t;
         closure_alloc_mode : Lambda.alloc_mode;
-        num_trailing_local_params : int;
+        num_trailing_local_closures : int;
         contains_no_escaping_local_allocs : bool
       }
 
     let create ~let_rec_ident ~function_slot ~kind ~params ~return
         ~return_continuation ~exn_continuation ~my_region ~body ~attr ~loc
         ~free_idents_of_body ~stub recursive ~closure_alloc_mode
-        ~num_trailing_local_params ~contains_no_escaping_local_allocs =
+        ~num_trailing_local_closures ~contains_no_escaping_local_allocs =
       let let_rec_ident =
         match let_rec_ident with
         | None -> Ident.create_local "unnamed_function"
@@ -584,7 +584,7 @@ module Function_decls = struct
         stub;
         recursive;
         closure_alloc_mode;
-        num_trailing_local_params;
+        num_trailing_local_closures;
         contains_no_escaping_local_allocs
       }
 
@@ -624,7 +624,7 @@ module Function_decls = struct
 
     let closure_alloc_mode t = t.closure_alloc_mode
 
-    let num_trailing_local_params t = t.num_trailing_local_params
+    let num_trailing_local_closures t = t.num_trailing_local_closures
 
     let contains_no_escaping_local_allocs t =
       t.contains_no_escaping_local_allocs
@@ -672,7 +672,7 @@ module Function_decls = struct
     set_diff
       (set_diff
          (all_free_idents function_decls)
-         (List.map fst (all_params function_decls)))
+         (List.map Misc.fst3 (all_params function_decls)))
       (let_rec_idents function_decls)
 
   let create function_decls alloc_mode =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -176,7 +176,12 @@ module Env = struct
             let approxs = Array.map filter_inlinable approxs in
             Value_approximation.Block_approximation (approxs, alloc_mode)
           | Closure_approximation
-              { code_id; function_slot; code = Code_present code; _ } -> (
+              { code_id;
+                function_slot;
+                code = Code_present code;
+                alloc_mode;
+                _
+              } -> (
             match[@ocaml.warning "-fragile-match"]
               Inlining.definition_inlining_decision (Code.inline code)
                 (Code.cost_metrics code)
@@ -187,7 +192,8 @@ module Env = struct
                 { code_id;
                   function_slot;
                   code = Code_or_metadata.(remember_only_metadata (create code));
-                  symbol = None
+                  symbol = None;
+                  alloc_mode
                 })
         in
         let approx = filter_inlinable approx in
@@ -556,14 +562,13 @@ module Function_decls = struct
         stub : bool;
         recursive : Recursive.t;
         closure_alloc_mode : Lambda.alloc_mode;
-        num_trailing_local_closures : int;
         contains_no_escaping_local_allocs : bool
       }
 
     let create ~let_rec_ident ~function_slot ~kind ~params ~return
         ~return_continuation ~exn_continuation ~my_region ~body ~attr ~loc
         ~free_idents_of_body ~stub recursive ~closure_alloc_mode
-        ~num_trailing_local_closures ~contains_no_escaping_local_allocs =
+        ~contains_no_escaping_local_allocs =
       let let_rec_ident =
         match let_rec_ident with
         | None -> Ident.create_local "unnamed_function"
@@ -584,7 +589,6 @@ module Function_decls = struct
         stub;
         recursive;
         closure_alloc_mode;
-        num_trailing_local_closures;
         contains_no_escaping_local_allocs
       }
 
@@ -623,8 +627,6 @@ module Function_decls = struct
     let recursive t = t.recursive
 
     let closure_alloc_mode t = t.closure_alloc_mode
-
-    let num_trailing_local_closures t = t.num_trailing_local_closures
 
     let contains_no_escaping_local_allocs t =
       t.contains_no_escaping_local_allocs

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -277,7 +277,6 @@ module Function_decls : sig
       stub:bool ->
       Recursive.t ->
       closure_alloc_mode:Lambda.alloc_mode ->
-      num_trailing_local_closures:int ->
       contains_no_escaping_local_allocs:bool ->
       t
 
@@ -314,8 +313,6 @@ module Function_decls : sig
     val recursive : t -> Recursive.t
 
     val closure_alloc_mode : t -> Lambda.alloc_mode
-
-    val num_trailing_local_closures : t -> int
 
     val contains_no_escaping_local_allocs : t -> bool
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -265,7 +265,7 @@ module Function_decls : sig
       let_rec_ident:Ident.t option ->
       function_slot:Function_slot.t ->
       kind:Lambda.function_kind ->
-      params:(Ident.t * Lambda.value_kind) list ->
+      params:(Ident.t * Lambda.value_kind * Lambda.alloc_mode) list ->
       return:Lambda.value_kind ->
       return_continuation:Continuation.t ->
       exn_continuation:IR.exn_continuation ->
@@ -277,7 +277,7 @@ module Function_decls : sig
       stub:bool ->
       Recursive.t ->
       closure_alloc_mode:Lambda.alloc_mode ->
-      num_trailing_local_params:int ->
+      num_trailing_local_closures:int ->
       contains_no_escaping_local_allocs:bool ->
       t
 
@@ -287,7 +287,7 @@ module Function_decls : sig
 
     val kind : t -> Lambda.function_kind
 
-    val params : t -> (Ident.t * Lambda.value_kind) list
+    val params : t -> (Ident.t * Lambda.value_kind * Lambda.alloc_mode) list
 
     val return : t -> Lambda.value_kind
 
@@ -315,7 +315,7 @@ module Function_decls : sig
 
     val closure_alloc_mode : t -> Lambda.alloc_mode
 
-    val num_trailing_local_params : t -> int
+    val num_trailing_local_closures : t -> int
 
     val contains_no_escaping_local_allocs : t -> bool
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1505,9 +1505,6 @@ and cps_function env ~fid ~stub ~(recursive : Recursive.t)
     ?precomputed_free_idents
     ({ kind; params; return; body; attr; loc; mode; region } : L.lfunction) :
     Function_decl.t =
-  let num_trailing_local_closures =
-    match kind with Curried { nlocal } -> nlocal | Tupled -> 0
-  in
   let body_cont = Continuation.create ~sort:Return () in
   let body_exn_cont = Continuation.create () in
   let free_idents_of_body =
@@ -1535,7 +1532,7 @@ and cps_function env ~fid ~stub ~(recursive : Recursive.t)
   Function_decl.create ~let_rec_ident:(Some fid) ~function_slot ~kind ~params
     ~return ~return_continuation:body_cont ~exn_continuation ~my_region ~body
     ~attr ~loc ~free_idents_of_body ~stub recursive ~closure_alloc_mode:mode
-    ~num_trailing_local_closures ~contains_no_escaping_local_allocs:region
+    ~contains_no_escaping_local_allocs:region
 
 and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
     ~scrutinee (k : Continuation.t) (k_exn : Continuation.t) : Expr_with_acc.t =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1505,7 +1505,7 @@ and cps_function env ~fid ~stub ~(recursive : Recursive.t)
     ?precomputed_free_idents
     ({ kind; params; return; body; attr; loc; mode; region } : L.lfunction) :
     Function_decl.t =
-  let num_trailing_local_params =
+  let num_trailing_local_closures =
     match kind with Curried { nlocal } -> nlocal | Tupled -> 0
   in
   let body_cont = Continuation.create ~sort:Return () in
@@ -1535,7 +1535,7 @@ and cps_function env ~fid ~stub ~(recursive : Recursive.t)
   Function_decl.create ~let_rec_ident:(Some fid) ~function_slot ~kind ~params
     ~return ~return_continuation:body_cont ~exn_continuation ~my_region ~body
     ~attr ~loc ~free_idents_of_body ~stub recursive ~closure_alloc_mode:mode
-    ~num_trailing_local_params ~contains_no_escaping_local_allocs:region
+    ~num_trailing_local_closures ~contains_no_escaping_local_allocs:region
 
 and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
     ~scrutinee (k : Continuation.t) (k_exn : Continuation.t) : Expr_with_acc.t =

--- a/middle_end/flambda2/lattices/or_unknown.ml
+++ b/middle_end/flambda2/lattices/or_unknown.ml
@@ -18,6 +18,8 @@ type 'a t =
   | Known of 'a
   | Unknown
 
+let known x = Known x
+
 let print f ppf t =
   let colour = Flambda_colours.top_or_bottom_type in
   match t with

--- a/middle_end/flambda2/lattices/or_unknown.mli
+++ b/middle_end/flambda2/lattices/or_unknown.mli
@@ -18,6 +18,8 @@ type 'a t =
   | Known of 'a
   | Unknown
 
+val known : 'a -> 'a t
+
 val print : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 
 val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -784,9 +784,9 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         let code =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
-            ~newer_version_of ~params_arity ~param_modes
-            ~num_trailing_local_closures:0 ~result_arity ~result_types:Unknown
-            ~contains_no_escaping_local_allocs:false ~stub:false ~inline
+            ~newer_version_of ~params_arity ~param_modes ~result_arity
+            ~result_types:Unknown ~contains_no_escaping_local_allocs:false
+            ~stub:false ~inline
             ~check:
               Default_check (* CR gyorsh: should [check] be set properly? *)
             ~is_a_functor:false ~recursive

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -776,11 +776,16 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         let cost_metrics =
           Cost_metrics.from_size (Code_size.of_int code_size)
         in
+        let param_modes =
+          List.map
+            (fun _ -> Alloc_mode.heap)
+            (Flambda_arity.With_subkinds.to_list params_arity)
+        in
         let code =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
-            ~newer_version_of ~params_arity ~num_trailing_local_params:0
-            ~result_arity ~result_types:Unknown
+            ~newer_version_of ~params_arity ~param_modes
+            ~num_trailing_local_closures:0 ~result_arity ~result_types:Unknown
             ~contains_no_escaping_local_allocs:false ~stub:false ~inline
             ~check:
               Default_check (* CR gyorsh: should [check] be set properly? *)

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -343,7 +343,7 @@ let add_parameters_with_unknown_types ?alloc_modes ?name_mode ?at_unit_toplevel
       then
         Misc.fatal_errorf "Params and alloc modes do not match up:@ %a"
           Bound_parameters.print params';
-      alloc_modes
+      List.map Or_unknown.known alloc_modes
     | None -> List.map (fun _ -> Or_unknown.Unknown) params
   in
   let param_types =

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -107,7 +107,7 @@ val add_parameters :
   t
 
 val add_parameters_with_unknown_types :
-  ?alloc_modes:Alloc_mode.t Or_unknown.t list ->
+  ?alloc_modes:Alloc_mode.t list ->
   ?name_mode:Name_mode.t ->
   ?at_unit_toplevel:bool ->
   t ->

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -758,9 +758,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       (DA.are_rebuilding_terms dacc_after_body)
       code_id ~params_and_body ~free_names_of_params_and_body:free_names_of_code
       ~newer_version_of ~params_arity:(Code.params_arity code)
-      ~param_modes:(Code.param_modes code)
-      ~num_trailing_local_closures:(Code.num_trailing_local_closures code)
-      ~result_arity ~result_types
+      ~param_modes:(Code.param_modes code) ~result_arity ~result_types
       ~contains_no_escaping_local_allocs:
         (Code.contains_no_escaping_local_allocs code)
       ~stub:(Code.stub code) ~inline:(Code.inline code) ~check:(Code.check code)

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -395,19 +395,10 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
     ~exn_continuation ~return_cont_params code_metadata =
   let dacc =
     DA.map_denv (C.dacc_inside_functions context) ~f:(fun denv ->
-        let num_leading_heap_params =
-          Code_metadata.num_leading_heap_params code_metadata
-        in
-        let alloc_modes =
-          List.mapi
-            (fun index _ : Alloc_mode.t Or_unknown.t ->
-              if index < num_leading_heap_params
-              then Known Alloc_mode.heap
-              else Unknown)
-            (Bound_parameters.to_list params)
-        in
         let denv =
-          DE.add_parameters_with_unknown_types ~alloc_modes denv params
+          DE.add_parameters_with_unknown_types
+            ~alloc_modes:(Code_metadata.param_modes code_metadata)
+            denv params
         in
         let denv = DE.set_inlining_arguments inlining_arguments denv in
         let denv =
@@ -767,7 +758,8 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       (DA.are_rebuilding_terms dacc_after_body)
       code_id ~params_and_body ~free_names_of_params_and_body:free_names_of_code
       ~newer_version_of ~params_arity:(Code.params_arity code)
-      ~num_trailing_local_params:(Code.num_trailing_local_params code)
+      ~param_modes:(Code.param_modes code)
+      ~num_trailing_local_closures:(Code.num_trailing_local_closures code)
       ~result_arity ~result_types
       ~contains_no_escaping_local_allocs:
         (Code.contains_no_escaping_local_allocs code)

--- a/middle_end/flambda2/term_basics/alloc_mode.ml
+++ b/middle_end/flambda2/term_basics/alloc_mode.ml
@@ -29,6 +29,8 @@ let compare t1 t2 =
   | Heap, Local -> -1
   | Local, Heap -> 1
 
+let equal t1 t2 = compare t1 t2 = 0
+
 let heap = Heap
 
 let local () =

--- a/middle_end/flambda2/term_basics/alloc_mode.mli
+++ b/middle_end/flambda2/term_basics/alloc_mode.mli
@@ -22,6 +22,8 @@ val print : Format.formatter -> t -> unit
 
 val compare : t -> t -> int
 
+val equal : t -> t -> bool
+
 val heap : t
 
 (** Returns [Heap] if stack allocation is disabled! *)

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -33,9 +33,11 @@ module type Code_metadata_accessors_result_type = sig
 
   val params_arity : 'a t -> Flambda_arity.With_subkinds.t
 
-  val num_leading_heap_params : 'a t -> int
+  val param_modes : 'a t -> Alloc_mode.t list
 
-  val num_trailing_local_params : 'a t -> int
+  val num_leading_heap_closures : 'a t -> int
+
+  val num_trailing_local_closures : 'a t -> int
 
   val result_arity : 'a t -> Flambda_arity.With_subkinds.t
 
@@ -79,7 +81,8 @@ type 'a create_type =
   Code_id.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
-  num_trailing_local_params:int ->
+  param_modes:Alloc_mode.t list ->
+  num_trailing_local_closures:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   contains_no_escaping_local_allocs:bool ->

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -35,9 +35,10 @@ module type Code_metadata_accessors_result_type = sig
 
   val param_modes : 'a t -> Alloc_mode.t list
 
-  val num_leading_heap_closures : 'a t -> int
+  val num_trailing_local_closures :
+    'a t -> closure_alloc_mode:Alloc_mode.t -> int
 
-  val num_trailing_local_closures : 'a t -> int
+  val num_leading_heap_closures : 'a t -> closure_alloc_mode:Alloc_mode.t -> int
 
   val result_arity : 'a t -> Flambda_arity.With_subkinds.t
 
@@ -82,7 +83,6 @@ type 'a create_type =
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.With_subkinds.t ->
   param_modes:Alloc_mode.t list ->
-  num_trailing_local_closures:int ->
   result_arity:Flambda_arity.With_subkinds.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   contains_no_escaping_local_allocs:bool ->

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -41,7 +41,7 @@ let get_func_decl_params_arity t code_id =
     if Code_metadata.is_tupled info
     then Lambda.Tupled
     else
-      Lambda.Curried { nlocal = Code_metadata.num_trailing_local_params info }
+      Lambda.Curried { nlocal = Code_metadata.num_trailing_local_closures info }
   in
   let closure_code_pointers =
     match kind, num_params with

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -56,7 +56,7 @@ let these_naked_nativeints is = TG.these_naked_nativeints is
 
 let any_tagged_immediate =
   TG.create_variant ~is_unique:false ~immediates:Unknown
-    ~blocks:(Known TG.Row_like_for_blocks.bottom) (Known Alloc_mode.heap)
+    ~blocks:(Known TG.Row_like_for_blocks.bottom) Unknown
 
 let these_tagged_immediates0 imms =
   match Targetint_31_63.Set.get_singleton imms with
@@ -67,7 +67,7 @@ let these_tagged_immediates0 imms =
     else
       TG.create_variant ~is_unique:false
         ~immediates:(Known (these_naked_immediates imms))
-        ~blocks:(Known TG.Row_like_for_blocks.bottom) (Known Alloc_mode.heap)
+        ~blocks:(Known TG.Row_like_for_blocks.bottom) Unknown
 
 let these_tagged_immediates imms = these_tagged_immediates0 imms
 

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -597,7 +597,7 @@ let rec comp_expr env exp sz cont =
       let lbl = new_label() in
       let fv = Ident.Set.elements(free_variables exp) in
       let to_compile =
-        { params = List.map fst params; body = body; label = lbl;
+        { params = List.map fst3 params; body = body; label = lbl;
           free_vars = fv; num_defs = 1; rec_vars = []; rec_pos = 0 } in
       Stack.push to_compile functions_to_compile;
       comp_args env (List.map (fun n -> Lvar n) fv) sz
@@ -620,7 +620,7 @@ let rec comp_expr env exp sz cont =
           | (_id, Lfunction{params; body}) :: rem ->
               let lbl = new_label() in
               let to_compile =
-                { params = List.map fst params; body = body; label = lbl;
+                { params = List.map fst3 params; body = body; label = lbl;
                   free_vars = fv; num_defs = ndecl; rec_vars = rec_idents;
                   rec_pos = pos} in
               Stack.push to_compile functions_to_compile;

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -360,7 +360,7 @@ type lambda =
 
 and lfunction =
   { kind: function_kind;
-    params: (Ident.t * value_kind) list;
+    params: (Ident.t * value_kind * alloc_mode) list;
     return: value_kind;
     body: lambda;
     attr: function_attribute; (* specified with [@inline] attribute *)

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -638,15 +638,17 @@ let rec lam ppf = function
       let pr_params ppf params =
         match kind with
         | Curried _ ->
-            List.iter (fun (param, k) ->
-                fprintf ppf "@ %a%a" Ident.print param value_kind k) params
+            List.iter (fun (param, k, param_mode) ->
+                fprintf ppf "@ %a%s%a" Ident.print param
+                  (alloc_kind param_mode) value_kind k) params
         | Tupled ->
             fprintf ppf " (";
             let first = ref true in
             List.iter
-              (fun (param, k) ->
+              (fun (param, k, param_mode) ->
                 if !first then first := false else fprintf ppf ",@ ";
                 Ident.print ppf param;
+                Format.fprintf ppf "%s" (alloc_kind param_mode);
                 value_kind ppf k)
               params;
             fprintf ppf ")" in

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -379,8 +379,9 @@ let exact_application {kind; params; _} args =
       end
 
 let beta_reduce params body args =
-  List.fold_left2 (fun l (param, kind) arg -> Llet(Strict, kind, param, arg, l))
-                  body params args
+  List.fold_left2 (fun l (param, kind, _param_mode) arg ->
+      Llet(Strict, kind, param, arg, l))
+    body params args
 
 (* Simplification of lets *)
 
@@ -759,7 +760,8 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
   let rec aux map add_region = function
     | Llet(Strict, k, id, (Lifthenelse(Lvar optparam, _, _, _) as def), rest) when
         (not (Clflags.is_flambda2 ()))
-          && Ident.name optparam = "*opt*" && List.mem_assoc optparam params
+          && Ident.name optparam = "*opt*"
+          && List.exists (fun (param, _, _) -> Ident.same param optparam) params
           && not (List.mem_assoc optparam map)
       ->
         let wrapper_body, inner = aux ((optparam, id) :: map) add_region rest in
@@ -773,7 +775,8 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
             sw_failaction = None}, _dbg, _)
          as def), rest) when
         Clflags.is_flambda2 ()
-          && Ident.name optparam = "*opt*" && List.mem_assoc optparam params
+          && Ident.name optparam = "*opt*"
+          && List.exists (fun (param, _, _) -> Ident.same param optparam) params
           && not (List.mem_assoc optparam map)
       ->
         let wrapper_body, inner = aux ((optparam, id) :: map) add_region rest in
@@ -788,7 +791,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
 
         let inner_id = Ident.create_local (Ident.name fun_id ^ "_inner") in
         let map_param p = try List.assoc p map with Not_found -> p in
-        let args = List.map (fun (p, _) -> Lvar (map_param p)) params in
+        let args = List.map (fun (p, _, _) -> Lvar (map_param p)) params in
         let wrapper_body =
           Lapply {
             ap_func = Lvar inner_id;
@@ -802,7 +805,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
             ap_probe=None;
           }
         in
-        let inner_params = List.map map_param (List.map fst params) in
+        let inner_params = List.map map_param (List.map Misc.fst3 params) in
         let new_ids = List.map Ident.rename inner_params in
         let subst =
           List.fold_left2 (fun s id new_id ->
@@ -813,7 +816,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
         let body = if add_region then Lregion body else body in
         let inner_fun =
           Lfunction { kind = Curried {nlocal=0};
-            params = List.map (fun id -> id, Pgenval) new_ids;
+            params = List.map (fun id -> id, Pgenval, alloc_heap) new_ids;
             return; body; attr; loc; mode; region=true }
         in
         (wrapper_body, (inner_id, inner_fun))
@@ -982,7 +985,11 @@ let simplify_local_functions lam =
     in
     List.fold_right
       (fun (st, lf) lam ->
-         Lstaticcatch (lam, (st, lf.params), rewrite lf.body, lf.return)
+         let params =
+           List.map (fun (param, kind, _param_alloc_mode) -> param, kind)
+             lf.params
+         in
+         Lstaticcatch (lam, (st, params), rewrite lf.body, lf.return)
       )
       (LamTbl.find_all static lam0)
       lam

--- a/ocaml/lambda/simplif.mli
+++ b/ocaml/lambda/simplif.mli
@@ -32,7 +32,7 @@ val simplify_lambda: lambda -> lambda
 val split_default_wrapper
    : id:Ident.t
   -> kind:function_kind
-  -> params:(Ident.t * Lambda.value_kind) list
+  -> params:(Ident.t * Lambda.value_kind * Lambda.alloc_mode) list
   -> return:Lambda.value_kind
   -> body:lambda
   -> attr:function_attribute

--- a/ocaml/lambda/translcomprehension.ml
+++ b/ocaml/lambda/translcomprehension.ml
@@ -491,7 +491,7 @@ let transl_list_comp type_comp body acc_var mats ~transl_exp ~scopes ~loc =
   in
   let fn =
     Lfunction {kind = Curried {nlocal=0};
-              params= [param, pval; acc_var, Pgenval];
+              params= [param, pval, alloc_heap; acc_var, Pgenval, alloc_heap];
               return = Pgenval;
               attr = default_function_attribute;
               loc = loc;

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -95,7 +95,8 @@ let rec apply_coercion loc strict restr arg =
   | Tcoerce_functor(cc_arg, cc_res) ->
       let param = Ident.create_local "funarg" in
       let carg = apply_coercion loc Alias cc_arg (Lvar param) in
-      apply_coercion_result loc strict arg [param, Pgenval] [carg] cc_res
+      apply_coercion_result loc strict arg [param, Pgenval, alloc_heap]
+        [carg] cc_res
   | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode } ->
       let poly_mode = Option.map Translcore.transl_alloc_mode pc_poly_mode in
       Translprim.transl_primitive loc pc_desc pc_env pc_type ~poly_mode None
@@ -113,7 +114,7 @@ and apply_coercion_result loc strict funct params args cc_res =
     let param = Ident.create_local "funarg" in
     let arg = apply_coercion loc Alias cc_arg (Lvar param) in
     apply_coercion_result loc strict funct
-      ((param, Pgenval) :: params) (arg :: args) cc_res
+      ((param, Pgenval, alloc_heap) :: params) (arg :: args) cc_res
   | _ ->
       name_lambda strict funct
         (fun id ->
@@ -520,7 +521,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
     List.fold_left (fun (params, body) (param, loc, arg_coercion) ->
         let param' = Ident.rename param in
         let arg = apply_coercion loc Alias arg_coercion (Lvar param') in
-        let params = (param', Pgenval) :: params in
+        let params = (param', Pgenval, alloc_heap) :: params in
         let body = Llet (Alias, Pgenval, param, arg, body) in
         params, body)
       ([], transl_module ~scopes res_coercion body_path body)

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -752,12 +752,14 @@ let transl_primitive loc p env ty ~poly_mode path =
     | None -> prim
     | Some prim -> prim
   in
-  let rec make_params n =
-    if n <= 0 then []
-    else (Ident.create_local "prim", Pgenval) :: make_params (n-1)
+  let to_alloc_mode m = to_alloc_mode ~poly:poly_mode m in
+  let arg_modes = List.map to_alloc_mode p.prim_native_repr_args in
+  let params =
+    assert (List.compare_length_with arg_modes p.prim_arity = 0);
+    List.map (fun arg_mode -> Ident.create_local "prim", Pgenval, arg_mode)
+      arg_modes
   in
-  let params = make_params p.prim_arity in
-  let args = List.map (fun (id, _) -> Lvar id) params in
+  let args = List.map (fun (id, _, _) -> Lvar id) params in
   match params with
   | [] -> lambda_of_prim p.prim_name prim loc args None
   | _ ->
@@ -767,8 +769,6 @@ let transl_primitive loc p env ty ~poly_mode path =
          loc
      in
      let body = lambda_of_prim p.prim_name prim loc args None in
-     let to_alloc_mode m = to_alloc_mode ~poly:poly_mode m in
-     let arg_modes = List.map to_alloc_mode p.prim_native_repr_args in
      let region =
        match to_alloc_mode p.prim_native_repr_res with
        | Alloc_heap -> true

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -1062,7 +1062,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
           (Lfunction{
                kind;
                return = Pgenval;
-               params = List.map (fun v -> v, Pgenval) final_args;
+               params = List.map (fun v -> v, Pgenval, new_clos_mode) final_args;
                body = Lapply{
                  ap_loc=loc;
                  ap_func=(Lvar funct_var);
@@ -1454,13 +1454,14 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
     let fun_params =
       if !useless_env
       then params
-      else params @ [env_param, Pgenval]
+      else params @ [env_param, Pgenval, alloc_heap]
     in
     let f =
       {
         label  = fundesc.fun_label;
         arity  = fundesc.fun_arity;
-        params = List.map (fun (var, kind) -> VP.create var, kind) fun_params;
+        params =
+          List.map (fun (var, kind, _) -> VP.create var, kind) fun_params;
         return;
         body   = ubody;
         dbg;
@@ -1472,7 +1473,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
        their wrapper functions) to be inlined *)
     let n =
       List.fold_left
-        (fun n (id, _) -> n + if V.name id = "*opt*" then 8 else 1)
+        (fun n (id, _, _) -> n + if V.name id = "*opt*" then 8 else 1)
         0
         fun_params
     in
@@ -1488,7 +1489,7 @@ and close_functions { backend; fenv; cenv; mutable_vars } fun_defs =
       | Never_inline -> min_int
       | Unroll _ -> assert false
     in
-    let fun_params = List.map (fun (var, _) -> VP.create var) fun_params in
+    let fun_params = List.map (fun (var, _, _) -> VP.create var) fun_params in
     if lambda_smaller ubody threshold
     then fundesc.fun_inline <- Some(fun_params, ubody);
 

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -229,7 +229,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let set_of_closures =
       let decl =
         Function_decl.create ~let_rec_ident:None ~closure_bound_var ~kind ~mode
-          ~region ~params:(List.map fst params) ~body ~attr ~loc
+          ~region ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
       in
       close_functions t env (Function_decls.create [decl])
     in
@@ -279,7 +279,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
             let function_declaration =
               Function_decl.create ~let_rec_ident:(Some let_rec_ident)
                 ~closure_bound_var ~kind ~mode ~region
-                ~params:(List.map fst params) ~body ~attr ~loc
+                ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
             in
             Some function_declaration
           | _ -> None)
@@ -704,7 +704,7 @@ and close_let_bound_expression t ?let_rec_ident let_bound_var env
     let closure_bound_var = Variable.rename let_bound_var in
     let decl =
       Function_decl.create ~let_rec_ident ~closure_bound_var ~kind ~mode ~region
-        ~params:(List.map fst params) ~body ~attr ~loc
+        ~params:(List.map Misc.fst3 params) ~body ~attr ~loc
     in
     let set_of_closures_var = Variable.rename let_bound_var in
     let set_of_closures =

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -272,10 +272,10 @@ let expr sub x =
         let (rec_flag, list) = sub.value_bindings sub (rec_flag, list) in
         Texp_let (rec_flag, list, sub.expr sub exp)
     | Texp_function { arg_label; param; cases;
-                      partial; region; curry; warnings } ->
+                      partial; region; param_alloc_mode; curry; warnings } ->
         let cases = List.map (sub.case sub) cases in
         Texp_function { arg_label; param; cases;
-                        partial; region; curry; warnings }
+                        partial; region; curry; param_alloc_mode; warnings }
     | Texp_apply (exp, list, pos) ->
         Texp_apply (
           sub.expr sub exp,

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -4899,7 +4899,8 @@ and type_function ?in_function loc attrs env (expected_mode : expected_mode)
   re {
     exp_desc =
       Texp_function
-        { arg_label = l; param; cases; partial; region; curry; warnings };
+        { arg_label = l; param; cases; partial; region; curry;
+          param_alloc_mode = arg_mode; warnings };
     exp_loc = loc; exp_extra = [];
     exp_type =
       instance (newgenty (Tarrow((l,arg_mode,ret_mode), ty_arg, ty_res, Cok)));
@@ -5353,6 +5354,7 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
         { texp with exp_type = ty_fun; exp_mode = mode.mode;
             exp_desc = Texp_function { arg_label = Nolabel; param; cases;
                                        partial = Total; region = false; curry;
+                                       param_alloc_mode = marg;
                                        warnings = Warnings.backup () } }
       in
       Location.prerr_warning texp.exp_loc

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -110,6 +110,7 @@ and expression_desc =
   | Texp_function of { arg_label : arg_label; param : Ident.t;
       cases : value case list; partial : partial;
       region : bool; curry : fun_curry_state;
+      param_alloc_mode : Types.alloc_mode;
       warnings : Warnings.state; }
   | Texp_apply of expression * (arg_label * apply_arg) list * apply_position
   | Texp_match of expression * computation case list * partial

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -193,6 +193,7 @@ and expression_desc =
   | Texp_function of { arg_label : arg_label; param : Ident.t;
       cases : value case list; partial : partial;
       region : bool; curry : fun_curry_state;
+      param_alloc_mode : Types.alloc_mode;
       warnings : Warnings.state; }
         (** [Pexp_fun] and [Pexp_function] both translate to [Texp_function].
             See {!Parsetree} for more details.


### PR DESCRIPTION
Now that we have parameter modes in Flambda 2, I think we can do away with `num_trailing_local_closures` (the equivalent of `nlocal` in `Lambda`).  This does have one consequence: to simplify direct partial applications and to convert Flambda closure types back to classic mode approximations, we need to have known the closure alloc mode in the type.  I'm reckoning this should be ok, but worth noting.

This patch simplifies the logic for partial application simplification a bit in Simplify; unfortunately for classic mode that isn't the case, as going back to `Lambda` necessitates adding `nlocal`.

We could consider removing `nlocal` from `Lambda` as well in due course, I guess.

Based on #872.