### PR TITLE
Add NO = Name_occurrences alias and label NO.remove* functions

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -129,7 +129,8 @@ let compute_reachable_names_and_code ~module_symbol ~free_names_of_name code =
                 free_names
             in
             let new_names =
-              Name_occurrences.diff names_to_consider names_already_added
+              Name_occurrences.diff names_to_consider
+                ~without:names_already_added
             in
             Name_occurrences.union new_names names_to_add
       in
@@ -150,7 +151,8 @@ let compute_reachable_names_and_code ~module_symbol ~free_names_of_name code =
               .with_only_names_and_code_ids_promoting_newer_version_of ty_names
             in
             let new_names =
-              Name_occurrences.diff names_to_consider names_already_added
+              Name_occurrences.diff names_to_consider
+                ~without:names_already_added
             in
             Name_occurrences.union new_names names_to_add
           | None ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -461,9 +461,11 @@ module Acc = struct
       ~const:(fun _ -> acc)
       ~name:(fun name ~coercion:_ -> add_name_to_free_names ~name acc)
 
-  let remove_code_id_or_symbol_from_free_names cis t =
+  let remove_code_id_or_symbol_from_free_names code_id_or_symbol t =
     { t with
-      free_names = Name_occurrences.remove_code_id_or_symbol t.free_names cis
+      free_names =
+        Name_occurrences.remove_code_id_or_symbol t.free_names
+          ~code_id_or_symbol
     }
 
   let remove_symbol_from_free_names symbol t =
@@ -472,7 +474,7 @@ module Acc = struct
       t
 
   let remove_var_from_free_names var t =
-    { t with free_names = Name_occurrences.remove_var t.free_names var }
+    { t with free_names = Name_occurrences.remove_var t.free_names ~var }
 
   let add_continuation_application ~cont args_approx t =
     let continuation_application =
@@ -495,10 +497,10 @@ module Acc = struct
         Continuation.Map.add cont Untrackable t.continuation_applications
     }
 
-  let remove_continuation_from_free_names cont t =
+  let remove_continuation_from_free_names continuation t =
     { t with
       free_names =
-        Name_occurrences.remove_continuation t.free_names cont
+        Name_occurrences.remove_continuation t.free_names ~continuation
         (* We don't remove the continuation from [t.continuation_applications]
            here because we need this information of the module block to escape
            its scope to build the .cmx in [Closure_conversion.close_program]. *)

--- a/middle_end/flambda2/nominal/name_abstraction.ml
+++ b/middle_end/flambda2/nominal/name_abstraction.ml
@@ -65,7 +65,8 @@ let apply_renaming (type bindable)
 let free_names (type bindable)
     (module Bindable : Bindable.S with type t = bindable) (bindable, term)
     ~free_names_of_term =
-  Name_occurrences.diff (free_names_of_term term) (Bindable.free_names bindable)
+  Name_occurrences.diff (free_names_of_term term)
+    ~without:(Bindable.free_names bindable)
 
 let ids_for_export (type bindable)
     (module Bindable : Bindable.S with type t = bindable) (bindable, term)

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -683,17 +683,18 @@ let diff
       code_ids = code_ids1;
       newer_version_of_code_ids = newer_version_of_code_ids1
     }
-    { names = names2;
-      continuations = continuations2;
-      continuations_with_traps = continuations_with_traps2;
-      continuations_in_trap_actions = continuations_in_trap_actions2;
-      function_slots_in_projections = function_slots_in_projections2;
-      value_slots_in_projections = value_slots_in_projections2;
-      function_slots_in_declarations = function_slots_in_declarations2;
-      value_slots_in_declarations = value_slots_in_declarations2;
-      code_ids = code_ids2;
-      newer_version_of_code_ids = newer_version_of_code_ids2
-    } =
+    ~without:
+      { names = names2;
+        continuations = continuations2;
+        continuations_with_traps = continuations_with_traps2;
+        continuations_in_trap_actions = continuations_in_trap_actions2;
+        function_slots_in_projections = function_slots_in_projections2;
+        value_slots_in_projections = value_slots_in_projections2;
+        function_slots_in_declarations = function_slots_in_declarations2;
+        value_slots_in_declarations = value_slots_in_declarations2;
+        code_ids = code_ids2;
+        newer_version_of_code_ids = newer_version_of_code_ids2
+      } =
   let names = For_names.diff names1 names2 in
   let continuations = For_continuations.diff continuations1 continuations2 in
   let continuations_with_traps =
@@ -845,21 +846,21 @@ let value_slot_is_used_or_imported t value_slot =
   Value_slot.is_imported value_slot
   || For_value_slots.mem t.value_slots_in_projections value_slot
 
-let remove_var t var =
+let remove_var t ~var =
   if For_names.is_empty t.names
   then t
   else
     let names = For_names.remove t.names (Name.var var) in
     { t with names }
 
-let remove_symbol t symbol =
+let remove_symbol t ~symbol =
   if For_names.is_empty t.names
   then t
   else
     let names = For_names.remove t.names (Name.symbol symbol) in
     { t with names }
 
-let remove_code_id t code_id =
+let remove_code_id t ~code_id =
   if For_code_ids.is_empty t.code_ids
      && For_code_ids.is_empty t.newer_version_of_code_ids
   then t
@@ -870,22 +871,22 @@ let remove_code_id t code_id =
     in
     { t with code_ids; newer_version_of_code_ids }
 
-let remove_code_id_or_symbol t (cis : Code_id_or_symbol.t) =
-  Code_id_or_symbol.pattern_match cis
-    ~code_id:(fun code_id -> remove_code_id t code_id)
-    ~symbol:(fun symbol -> remove_symbol t symbol)
+let remove_code_id_or_symbol t ~(code_id_or_symbol : Code_id_or_symbol.t) =
+  Code_id_or_symbol.pattern_match code_id_or_symbol
+    ~code_id:(fun code_id -> remove_code_id t ~code_id)
+    ~symbol:(fun symbol -> remove_symbol t ~symbol)
 
-let remove_continuation t k =
+let remove_continuation t ~continuation =
   if For_continuations.is_empty t.continuations
      && For_continuations.is_empty t.continuations_in_trap_actions
   then t
   else
-    let continuations = For_continuations.remove t.continuations k in
+    let continuations = For_continuations.remove t.continuations continuation in
     let continuations_with_traps =
-      For_continuations.remove t.continuations_with_traps k
+      For_continuations.remove t.continuations_with_traps continuation
     in
     let continuations_in_trap_actions =
-      For_continuations.remove t.continuations_in_trap_actions k
+      For_continuations.remove t.continuations_in_trap_actions continuation
     in
     { t with
       continuations;

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -96,14 +96,14 @@ val create_names : Name.Set.t -> Name_mode.t -> t
 
 (* val create_value_slots : Value_slot.Set.t -> t *)
 
-(** [diff t1 t2] removes from [t1] all those names that occur in [t2].
+(** [diff t1 ~without:t2] removes from [t1] all those names that occur in [t2].
 
     The number of occurrences of any names in the return value will be exactly
     the same as in [t1].
 
     Note that a code ID in [t2] will not only be removed from the code ID set in
     [t1] but also the newer-version-of code ID set in [t1]. *)
-val diff : t -> t -> t
+val diff : t -> without:t -> t
 
 val union : t -> t -> t
 
@@ -171,11 +171,11 @@ val mem_code_id : t -> Code_id.t -> bool
 
 val value_slot_is_used_or_imported : t -> Value_slot.t -> bool
 
-val remove_var : t -> Variable.t -> t
+val remove_var : t -> var:Variable.t -> t
 
-val remove_code_id_or_symbol : t -> Code_id_or_symbol.t -> t
+val remove_code_id_or_symbol : t -> code_id_or_symbol:Code_id_or_symbol.t -> t
 
-val remove_continuation : t -> Continuation.t -> t
+val remove_continuation : t -> continuation:Continuation.t -> t
 
 val greatest_name_mode_var : t -> Variable.t -> Name_mode.Or_absent.t
 

--- a/middle_end/flambda2/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/upwards_acc.ml
@@ -164,7 +164,9 @@ let used_value_slots t = t.used_value_slots
 let shareable_constants t = t.shareable_constants
 
 let remove_all_occurrences_of_free_names t to_remove =
-  let name_occurrences = Name_occurrences.diff t.name_occurrences to_remove in
+  let name_occurrences =
+    Name_occurrences.diff t.name_occurrences ~without:to_remove
+  in
   { t with name_occurrences }
 
 let clear_cost_metrics t = { t with cost_metrics = Cost_metrics.zero }

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -209,7 +209,7 @@ let create_let uacc (bound_vars : Bound_pattern.t) (defining_expr : Named.t)
       let without_bound_vars =
         Bound_pattern.fold_all_bound_vars bound_vars ~init:free_names_of_body
           ~f:(fun free_names bound_var ->
-            Name_occurrences.remove_var free_names (VB.var bound_var))
+            Name_occurrences.remove_var free_names ~var:(VB.var bound_var))
       in
       Name_occurrences.union without_bound_vars free_names_of_defining_expr
     in
@@ -351,8 +351,8 @@ let create_raw_let_symbol uacc bound_static static_consts ~body =
       Name_occurrences.union free_names_of_static_consts free_names_of_body
     in
     Code_id_or_symbol.Set.fold
-      (fun code_id_or_sym free_names ->
-        Name_occurrences.remove_code_id_or_symbol free_names code_id_or_sym)
+      (fun code_id_or_symbol free_names ->
+        Name_occurrences.remove_code_id_or_symbol free_names ~code_id_or_symbol)
       (Bound_static.everything_being_defined bound_static)
       name_occurrences
   in
@@ -626,7 +626,7 @@ let bind_let_cont (uacc : UA.t) (body : RE.t)
   let name_occurrences =
     Name_occurrences.remove_continuation
       (Name_occurrences.union free_names_of_body free_names_of_handler)
-      cont
+      ~continuation:cont
   in
   let uacc =
     UA.with_name_occurrences uacc ~name_occurrences
@@ -864,7 +864,8 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
       let free_names_of_handler =
         ListLabels.fold_left (Bound_parameters.to_list params) ~init:free_names
           ~f:(fun free_names param ->
-            Name_occurrences.remove_var free_names (Bound_parameter.var param))
+            Name_occurrences.remove_var free_names
+              ~var:(Bound_parameter.var param))
       in
       New_wrapper
         { cont; handler; free_names_of_handler; cost_metrics_of_handler }

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -14,13 +14,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module DE = Downwards_env
-module BP = Bound_parameter
-module LCS = Lifted_constant_state
-module T = Flambda2_types
-module TE = Flambda2_types.Typing_env
+open Simplify_import
 module U = One_continuation_use
-module EPA = Continuation_extra_params_and_args
 
 type result =
   { handler_env : DE.t;
@@ -59,7 +54,7 @@ let join ?cut_after denv typing_env params ~env_at_fork_plus_params
   in
   let extra_allowed_names =
     match cse_join_result with
-    | None -> Name_occurrences.empty
+    | None -> NO.empty
     | Some cse_join_result -> cse_join_result.extra_allowed_names
   in
   let cut_after = Option.value cut_after ~default:definition_scope in

--- a/middle_end/flambda2/simplify/lifting/reification.ml
+++ b/middle_end/flambda2/simplify/lifting/reification.ml
@@ -91,7 +91,7 @@ let lift dacc ty ~bound_to static_const : _ Or_invalid.t * DA.t =
           bound_to;
       let symbol_projections =
         let free_names = RSC.free_names static_const in
-        Name_occurrences.fold_variables free_names ~init:Variable.Map.empty
+        NO.fold_variables free_names ~init:Variable.Map.empty
           ~f:(fun symbol_projections var ->
             match DE.find_symbol_projection (DA.denv dacc) var with
             | None -> symbol_projections

--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -145,7 +145,7 @@ let bind_no_simplification are_rebuilding ~bindings ~body ~cost_metrics_of_body
       let free_names =
         Name_occurrences.union
           (Named.free_names defining_expr)
-          (Name_occurrences.remove_var free_names (Bound_var.var var))
+          (Name_occurrences.remove_var free_names ~var:(Bound_var.var var))
       in
       let is_phantom = Name_mode.is_phantom (Bound_var.name_mode var) in
       let cost_metrics_of_defining_expr =

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -52,7 +52,7 @@ let run ~cmx_loader ~round unit =
   in
   let body = Rebuilt_expr.to_expr body (UA.are_rebuilding_terms uacc) in
   let name_occurrences = UA.name_occurrences uacc in
-  Name_occurrences.fold_names name_occurrences ~init:() ~f:(fun () name ->
+  NO.fold_names name_occurrences ~init:() ~f:(fun () name ->
       Name.pattern_match name
         ~var:(fun var ->
           if not (Variable.equal var toplevel_my_region)
@@ -77,15 +77,13 @@ let run ~cmx_loader ~round unit =
   in
   let name_occurrences = UA.name_occurrences uacc in
   let function_slots_in_normal_projections =
-    Name_occurrences.function_slots_in_normal_projections name_occurrences
+    NO.function_slots_in_normal_projections name_occurrences
   in
   let value_slots_in_normal_projections =
-    Name_occurrences.value_slots_in_normal_projections name_occurrences
+    NO.value_slots_in_normal_projections name_occurrences
   in
-  let all_function_slots =
-    Name_occurrences.all_function_slots name_occurrences
-  in
-  let all_value_slots = Name_occurrences.all_value_slots name_occurrences in
+  let all_function_slots = NO.all_function_slots name_occurrences in
+  let all_value_slots = NO.all_value_slots name_occurrences in
   let ({ used_value_slots; exported_offsets } : Slot_offsets.result) =
     match UA.slot_offsets uacc with
     | Unknown ->

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -461,8 +461,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
               Cost_metrics.from_size (Code_size.prim prim)
             in
             let free_names =
-              Name_occurrences.add_value_slot_in_projection free_names
-                value_slot NM.normal
+              NO.add_value_slot_in_projection free_names value_slot NM.normal
             in
             let expr =
               Let.create
@@ -478,8 +477,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
               free_names ))
         ( Expr.create_apply full_application,
           cost_metrics,
-          Apply.free_names full_application
-          |> Name_occurrences.without_names_or_continuations )
+          Apply.free_names full_application |> NO.without_names_or_continuations
+        )
         (List.rev applied_values)
     in
     let params_and_body =

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -14,16 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Flambda
-module DA = Downwards_acc
-module DE = Downwards_env
-module K = Flambda_kind
-module BP = Bound_parameter
-module P = Flambda_primitive
-module T = Flambda2_types
-module UA = Upwards_acc
-module UE = Upwards_env
-module AC = Apply_cont_expr
+open Simplify_import
 
 type 'a after_rebuild = Rebuilt_expr.t -> Upwards_acc.t -> 'a
 
@@ -185,8 +176,7 @@ let split_direct_over_application apply ~param_arity ~result_arity
         | Never_returns ->
           (* The whole overapplication never returns, so this point is
              unreachable. *)
-          ( Expr.create_invalid (Over_application_never_returns apply),
-            Name_occurrences.empty )
+          Expr.create_invalid (Over_application_never_returns apply), NO.empty
       in
       let handler_expr =
         Let.create
@@ -200,7 +190,7 @@ let split_direct_over_application apply ~param_arity ~result_arity
         |> Expr.create_let
       in
       let handler_expr_free_names =
-        Name_occurrences.add_variable call_return_continuation_free_names region
+        NO.add_variable call_return_continuation_free_names region
           Name_mode.normal
       in
       let handler =
@@ -243,7 +233,7 @@ let split_direct_over_application apply ~param_arity ~result_arity
       ~body:both_applications
       ~free_names_of_body:
         (Known
-           (Name_occurrences.union
+           (NO.union
               (Apply.free_names full_apply)
               perform_over_application_free_names))
     |> Expr.create_let

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -82,8 +82,8 @@ let simplify_toplevel_common dacc simplify
      required depends on whether we're dealing with a lambda or the whole
      compilation unit. Instead these checks are in [Simplify] or
      [Simplify_set_of_closures]. *)
-  Name_occurrences.fold_continuations_including_in_trap_actions
-    (UA.name_occurrences uacc) ~init:() ~f:(fun () cont ->
+  NO.fold_continuations_including_in_trap_actions (UA.name_occurrences uacc)
+    ~init:() ~f:(fun () cont ->
       if (not (Continuation.equal cont return_continuation))
          && not (Continuation.equal cont exn_continuation)
       then

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -49,7 +49,7 @@ let let_prim ~dbg v prim (free_names, body) =
   let named = Named.create_prim prim dbg in
   let free_names_of_body = Or_unknown.Known free_names in
   let let_expr = Let.create bindable named ~body ~free_names_of_body in
-  let free_names = Name_occurrences.remove_var free_names v in
+  let free_names = NO.remove_var free_names ~var:v in
   let expr = Expr.create_let let_expr in
   free_names, expr
 

--- a/middle_end/flambda2/simplify/simplify_import.ml
+++ b/middle_end/flambda2/simplify/simplify_import.ml
@@ -46,6 +46,7 @@ module BP = Bound_parameter
 module LC = Lifted_constant
 module LCS = Lifted_constant_state
 module NM = Name_mode
+module NO = Name_occurrences
 module P = Flambda_primitive
 module RE = Rebuilt_expr
 module RSC = Rebuilt_static_const

--- a/middle_end/flambda2/simplify/simplify_import.mli
+++ b/middle_end/flambda2/simplify/simplify_import.mli
@@ -46,6 +46,7 @@ module BP = Bound_parameter
 module LC = Lifted_constant
 module LCS = Lifted_constant_state
 module NM = Name_mode
+module NO = Name_occurrences
 module P = Flambda_primitive
 module RE = Rebuilt_expr
 module RSC = Rebuilt_static_const

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -123,12 +123,10 @@ let record_lifted_constant_definition_for_data_flow ~being_defined data_flow
   match D.descr definition with
   | Code code_id ->
     DF.record_code_id_binding code_id
-      (Name_occurrences.union being_defined (D.free_names definition))
+      (NO.union being_defined (D.free_names definition))
       data_flow
   | Block_like { symbol; _ } ->
-    let free_names =
-      Name_occurrences.union being_defined (D.free_names definition)
-    in
+    let free_names = NO.union being_defined (D.free_names definition) in
     DF.record_symbol_binding symbol free_names data_flow
   | Set_of_closures { closure_symbols_with_types; _ } -> (
     let expr = D.defining_expr definition in
@@ -136,7 +134,7 @@ let record_lifted_constant_definition_for_data_flow ~being_defined data_flow
     | Some (Static_const const) ->
       let set_of_closures = Static_const.must_be_set_of_closures const in
       let free_names =
-        Name_occurrences.union being_defined
+        NO.union being_defined
           (Function_declarations.free_names
              (Set_of_closures.function_decls set_of_closures))
       in
@@ -145,9 +143,7 @@ let record_lifted_constant_definition_for_data_flow ~being_defined data_flow
         (record_one_function_slot_for_data_flow ~free_names ~value_slots)
         closure_symbols_with_types data_flow
     | None | Some (Code _ | Deleted_code) ->
-      let free_names =
-        Name_occurrences.union being_defined (D.free_names definition)
-      in
+      let free_names = NO.union being_defined (D.free_names definition) in
       Function_slot.Lmap.fold
         (fun _ (symbol, _) data_flow ->
           DF.record_symbol_binding symbol free_names data_flow)
@@ -171,10 +167,9 @@ let record_lifted_constant_for_data_flow data_flow lifted_constant =
        are only used in the newer_version_of field of another binding will be
        deleted as expected. *)
     let symbols = Bound_static.symbols_being_defined bound_static in
-    Name_occurrences.empty
+    NO.empty
     |> Symbol.Set.fold
-         (fun symbol acc ->
-           Name_occurrences.add_symbol acc symbol Name_mode.normal)
+         (fun symbol acc -> NO.add_symbol acc symbol Name_mode.normal)
          symbols
   in
   ListLabels.fold_left
@@ -205,7 +200,7 @@ let record_new_defining_expression_binding_for_data_flow dacc data_flow
           if Option.is_some (P.is_end_region prim)
           then
             (* Format.eprintf "ignoring free names for %a\n%!" P.print prim;*)
-            Name_occurrences.empty
+            NO.empty
           else free_names
       in
       Bound_pattern.fold_all_bound_vars binding.let_bound ~init:data_flow

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -296,11 +296,10 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
               in
               let uacc =
                 UA.add_free_names uacc
-                  (Name_occurrences.union
+                  (NO.union
                      (Named.free_names do_tagging)
-                     (Name_occurrences.diff free_names_of_body
-                        (Name_occurrences.singleton_variable not_scrutinee
-                           NM.normal)))
+                     (NO.diff free_names_of_body
+                        ~without:(NO.singleton_variable not_scrutinee NM.normal)))
               in
               expr, uacc)
           | None -> normal_case uacc))
@@ -387,7 +386,7 @@ let simplify_switch ~simplify_let ~simplify_function_body dacc switch
     DA.map_data_flow dacc
       ~f:
         (Data_flow.add_used_in_current_handler
-           (Name_occurrences.singleton_variable tagged_scrutinee NM.normal))
+           (NO.singleton_variable tagged_scrutinee NM.normal))
   in
   simplify_let
     ~simplify_expr:(fun dacc _body ~down_to_up ->

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -702,7 +702,9 @@ let invariant_for_new_equation (t : t) name ty =
     let free_names = Name_occurrences.without_code_ids (TG.free_names ty) in
     if not (Name_occurrences.subset_domain free_names defined_names)
     then
-      let unbound_names = Name_occurrences.diff free_names defined_names in
+      let unbound_names =
+        Name_occurrences.diff free_names ~without:defined_names
+      in
       Misc.fatal_errorf "New equation@ %a@ =@ %a@ has unbound names@ (%a):@ %a"
         Name.print name TG.print ty Name_occurrences.print unbound_names print t)
 
@@ -1084,7 +1086,7 @@ let rec free_names_transitive_of_type_of_name t name ~result =
 
 and free_names_transitive0 t typ ~result =
   let free_names = TG.free_names typ in
-  let to_traverse = Name_occurrences.diff free_names result in
+  let to_traverse = Name_occurrences.diff free_names ~without:result in
   if Name_occurrences.is_empty to_traverse
   then result
   else

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -369,7 +369,9 @@ let free_variables_transitive ~free_names_of_type env free_vars_acc ty =
     if missing_kind env free_vars
     then raise Missing_cmx_file
     else
-      let to_traverse = Name_occurrences.diff free_vars free_vars_acc in
+      let to_traverse =
+        Name_occurrences.diff free_vars ~without:free_vars_acc
+      in
       let free_vars_acc = Name_occurrences.union free_vars_acc free_vars in
       Name_occurrences.fold_names to_traverse ~init:free_vars_acc
         ~f:(fun free_vars_acc name ->

--- a/middle_end/flambda2/types/join_levels.ml
+++ b/middle_end/flambda2/types/join_levels.ml
@@ -265,7 +265,7 @@ let join ~env_at_fork envs_with_levels ~params ~extra_lifted_consts_in_use_envs
        typing environment. *)
     let rec free_names_transitive0 typ ~result =
       let free_names = TG.free_names typ in
-      let to_traverse = Name_occurrences.diff free_names result in
+      let to_traverse = Name_occurrences.diff free_names ~without:result in
       Name_occurrences.fold_names to_traverse ~init:result
         ~f:(fun result name ->
           let result =


### PR DESCRIPTION
A module alias is added and used in `Simplify`, yielding more compact code.  I've also added labelled arguments to the `Name_occurrences.remove*` functions which enables a messy piece of code in `Simplify_set_of_closures` to be tidied up.