### PR TITLE
Add strict mode for ocamldep

### DIFF
--- a/ocaml/driver/makedepend.ml
+++ b/ocaml/driver/makedepend.ml
@@ -328,17 +328,11 @@ let read_parse_and_extract parse_function extract_function def ast_kind
     end
   with x -> begin
     print_exception x;
-    if !strict then (
+    if !strict || not !allow_approximation then begin
       Error_occurred.set ();
       (String.Set.empty, def)
-    )
-    else (
-      if not !allow_approximation then begin
-        Error_occurred.set ();
-        (String.Set.empty, def)
-      end else
-        (read_and_approximate source_file, def)
-    )
+    end else
+      (read_and_approximate source_file, def)
   end
 
 let print_ml_dependencies source_file extracted_deps pp_deps =

--- a/ocaml/driver/makedepend.ml
+++ b/ocaml/driver/makedepend.ml
@@ -38,6 +38,7 @@ let allow_approximation = ref false
 let map_files = ref []
 let module_map = ref String.Map.empty
 let debug = ref false
+let strict = ref false
 
 module Error_occurred : sig
   val set : unit -> unit
@@ -327,11 +328,17 @@ let read_parse_and_extract parse_function extract_function def ast_kind
     end
   with x -> begin
     print_exception x;
-    if not !allow_approximation then begin
+    if !strict then (
       Error_occurred.set ();
       (String.Set.empty, def)
-    end else
-      (read_and_approximate source_file, def)
+    )
+    else (
+      if not !allow_approximation then begin
+        Error_occurred.set ();
+        (String.Set.empty, def)
+      end else
+        (read_and_approximate source_file, def)
+    )
   end
 
 let print_ml_dependencies source_file extracted_deps pp_deps =
@@ -415,7 +422,9 @@ let process_file_as process_fun def source_file =
       ));
   Location.input_name := source_file;
   try
-    if Sys.file_exists source_file then process_fun source_file else def
+    if !strict || Sys.file_exists source_file
+    then process_fun source_file
+    else def
   with x -> report_err x; def
 
 let process_file source_file ~ml_file ~mli_file ~def =
@@ -642,6 +651,8 @@ let run_main argv =
          " (Windows) Use forward slash / instead of backslash \\ in file paths";
      "-sort", Arg.Set sort_files,
         " Sort files according to their dependencies";
+     "-strict", Arg.Set strict,
+       " Fail if an input file does not exist";
      "-version", Arg.Unit print_version,
          " Print version and exit";
      "-vnum", Arg.Unit print_version_num,


### PR DESCRIPTION
This is like upstream ocaml/ocaml#11593 but should remove a race condition, by virtue of not doing a file-exists test prior to opening the source file.  Instead if the open fails then `ocamldep` will exit non-zero.

There is still printing of output in this case, e.g.:
```
% ./_install/bin/ocamldep -strict foo.ml || echo fail
File "foo.ml", line 1:
Error: I/O error: foo.ml: No such file or directory
foo.cmo :
foo.cmx :
fail
```