### PR TITLE
Transform tail-recursive functions into recursive continuations

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1093,8 +1093,28 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
   let params = Function_decl.params decl in
   let return = Function_decl.return decl in
   let return_continuation = Function_decl.return_continuation decl in
-  let recursive = Function_decl.recursive decl in
+  let acc, exn_continuation =
+    close_exn_continuation acc external_env
+      (Function_decl.exn_continuation decl)
+  in
+  assert (
+    match Exn_continuation.extra_args exn_continuation with
+    | [] -> true
+    | _ :: _ -> false);
   let my_closure = Variable.create "my_closure" in
+  let recursive = Function_decl.recursive decl in
+  (* Mark function available for loopify only if it is a single recursive
+     function *)
+  let is_single_recursive_function =
+    match recursive, Function_decls.to_list function_declarations with
+    | Recursive, [_] -> true
+    | Recursive, ([] | _ :: _ :: _) -> false
+    | Non_recursive, _ -> false
+  in
+  let acc =
+    Acc.push_closure_info acc ~return_continuation ~exn_continuation ~my_closure
+      ~is_purely_tailrec:is_single_recursive_function
+  in
   let my_region = Function_decl.my_region decl in
   let function_slot = Function_decl.function_slot decl in
   let my_depth = Variable.create "my_depth" in
@@ -1280,14 +1300,6 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
     Let_with_acc.create acc bound (Named.create_rec_info next_depth_expr) ~body
   in
   let cost_metrics = Acc.cost_metrics acc in
-  let acc, exn_continuation =
-    close_exn_continuation acc external_env
-      (Function_decl.exn_continuation decl)
-  in
-  assert (
-    match Exn_continuation.extra_args exn_continuation with
-    | [] -> true
-    | _ :: _ -> false);
   let inline : Inline_attribute.t =
     (* We make a decision based on [fallback_inlining_heuristic] here to try to
        mimic Closure's behaviour as closely as possible, particularly when there
@@ -1321,6 +1333,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
     |> Acc.remove_continuation_from_free_names
          (Exn_continuation.exn_handler exn_continuation)
   in
+  let closure_info, acc = Acc.pop_closure_info acc in
   let params_arity = Bound_parameters.arity_with_subkinds params in
   let is_tupled =
     match Function_decl.kind decl with Curried _ -> false | Tupled -> true
@@ -1331,6 +1344,15 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
     else if stub
     then Function_decl_inlining_decision_type.Stub
     else Function_decl_inlining_decision_type.Not_yet_decided
+  in
+  let loopify : Loopify_attribute.t =
+    match Function_decl.loop decl with
+    | Always_loop -> Always_loopify
+    | Never_loop -> Never_loopify
+    | Default_loop ->
+      if closure_info.is_purely_tailrec
+      then Default_loopify_and_tailrec
+      else Default_loopify_and_not_tailrec
   in
   let code =
     Code.create code_id ~params_and_body
@@ -1351,7 +1373,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
       ~dbg ~is_tupled
       ~is_my_closure_used:
         (Function_params_and_body.is_my_closure_used params_and_body)
-      ~inlining_decision ~absolute_history ~relative_history
+      ~inlining_decision ~absolute_history ~relative_history ~loopify
   in
   let approx =
     let code = Code_or_metadata.create code in
@@ -1480,6 +1502,7 @@ let close_functions acc external_env ~current_region function_declarations =
             ~inlining_decision:Recursive
             ~absolute_history:(Inlining_history.Absolute.empty compilation_unit)
             ~relative_history:Inlining_history.Relative.empty
+            ~loopify:Never_loopify
         in
         let code = Code_or_metadata.create_metadata_only metadata in
         let approx =
@@ -2216,6 +2239,9 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
           defining_expr ~body)
       (acc, body) (Acc.declared_symbols acc)
   in
+  if Option.is_some (Acc.top_closure_info acc)
+  then
+    Misc.fatal_error "Information on nested closures should be empty at the end";
   let get_code_metadata code_id =
     Code_id.Map.find code_id (Acc.code acc) |> Code.code_metadata
   in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1740,6 +1740,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
         specialise = Default_specialise;
         local = Default_local;
         check = Default_check;
+        loop = Default_loop;
         is_a_functor = false;
         stub = false;
         poll = Default_poll

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -616,6 +616,8 @@ module Function_decls = struct
 
     let poll_attribute t = t.attr.poll
 
+    let loop t = t.attr.loop
+
     let is_a_functor t = t.attr.is_a_functor
 
     let check_attribute t = t.attr.check

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -179,6 +179,13 @@ end
 
 (** Used to pipe some data through closure conversion *)
 module Acc : sig
+  type closure_info = private
+    { return_continuation : Continuation.t;
+      exn_continuation : Exn_continuation.t;
+      my_closure : Variable.t;
+      is_purely_tailrec : bool
+    }
+
   type t
 
   val create :
@@ -252,6 +259,18 @@ module Acc : sig
 
   val add_set_of_closures_offsets :
     is_phantom:bool -> t -> Set_of_closures.t -> t
+
+  val top_closure_info : t -> closure_info option
+
+  val push_closure_info :
+    t ->
+    return_continuation:Continuation.t ->
+    exn_continuation:Exn_continuation.t ->
+    my_closure:Variable.t ->
+    is_purely_tailrec:bool ->
+    t
+
+  val pop_closure_info : t -> closure_info * t
 end
 
 (** Used to represent information about a set of function declarations during

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -305,6 +305,8 @@ module Function_decls : sig
 
     val poll_attribute : t -> Lambda.poll_attribute
 
+    val loop : t -> Lambda.loop_attribute
+
     val is_a_functor : t -> bool
 
     val check_attribute : t -> Lambda.check_attribute

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -778,6 +778,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         in
         let code =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
+          (* CR ncourant: same for loopify *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
             ~newer_version_of ~params_arity ~num_trailing_local_params:0
             ~result_arity ~result_types:Unknown
@@ -793,6 +794,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
               (Inlining_history.Absolute.empty
                  (Compilation_unit.get_current_exn ()))
             ~relative_history:Inlining_history.Relative.empty
+            ~loopify:Never_loopify
         in
         Flambda.Static_const_or_code.create_code code
     in

--- a/middle_end/flambda2/simplify/env/closure_info.ml
+++ b/middle_end/flambda2/simplify/env/closure_info.ml
@@ -19,7 +19,8 @@ type t =
   | Closure of
       { code_id : Code_id.t;
         return_continuation : Continuation.t;
-        exn_continuation : Continuation.t
+        exn_continuation : Continuation.t;
+        my_closure : Variable.t
       }
 
 let [@ocamlformat "disable"] print ppf = function
@@ -27,23 +28,25 @@ let [@ocamlformat "disable"] print ppf = function
     Format.fprintf ppf "not_in_a_closure"
   | In_a_set_of_closures_but_not_yet_in_a_specific_closure ->
     Format.fprintf ppf "in_a_set_of_closures"
-  | Closure { code_id; return_continuation; exn_continuation; } ->
+  | Closure { code_id; return_continuation; exn_continuation; my_closure } ->
     Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(code_id@ %a)@]@ \
       @[<hov 1>(return_continuation@ %a)@]@ \
-      @[<hov 1>(exn_continuation@ %a)@]\
+      @[<hov 1>(exn_continuation@ %a)@]@ \
+      @[<hov 1>(my_closure@ %a)@]\
       )@]"
       Code_id.print code_id
       Continuation.print return_continuation
       Continuation.print exn_continuation
+      Variable.print my_closure
 
 let not_in_a_closure = Not_in_a_closure
 
 let in_a_set_of_closures =
   In_a_set_of_closures_but_not_yet_in_a_specific_closure
 
-let in_a_closure code_id ~return_continuation ~exn_continuation =
-  Closure { code_id; return_continuation; exn_continuation }
+let in_a_closure code_id ~return_continuation ~exn_continuation ~my_closure =
+  Closure { code_id; return_continuation; exn_continuation; my_closure }
 
 type in_or_out_of_closure =
   | In_a_closure

--- a/middle_end/flambda2/simplify/env/closure_info.mli
+++ b/middle_end/flambda2/simplify/env/closure_info.mli
@@ -19,7 +19,8 @@ type t = private
   | Closure of
       { code_id : Code_id.t;
         return_continuation : Continuation.t;
-        exn_continuation : Continuation.t
+        exn_continuation : Continuation.t;
+        my_closure : Variable.t
       }
 
 val print : Format.formatter -> t -> unit
@@ -32,6 +33,7 @@ val in_a_closure :
   Code_id.t ->
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
+  my_closure:Variable.t ->
   t
 
 type in_or_out_of_closure =

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -478,10 +478,11 @@ let set_rebuild_terms t = { t with do_not_rebuild_terms = false }
 let are_rebuilding_terms t =
   Are_rebuilding_terms.of_bool (not t.do_not_rebuild_terms)
 
-let enter_closure code_id ~return_continuation ~exn_continuation t =
+let enter_closure code_id ~return_continuation ~exn_continuation ~my_closure t =
   { t with
     closure_info =
       Closure_info.in_a_closure code_id ~return_continuation ~exn_continuation
+        ~my_closure
   }
 
 let closure_info t = t.closure_info

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -202,3 +202,7 @@ val inlining_history_tracker : t -> Inlining_history.Tracker.t
 val set_inlining_history_tracker : Inlining_history.Tracker.t -> t -> t
 
 val relative_history : t -> Inlining_history.Relative.t
+
+val loopify_state : t -> Loopify_state.t
+
+val set_loopify_state : Loopify_state.t -> t -> t

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -182,6 +182,7 @@ val enter_closure :
   Code_id.t ->
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
+  my_closure:Variable.t ->
   t ->
   t
 

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -195,6 +195,15 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
     in
     if not (Code_or_metadata.code_present code_or_metadata)
     then Missing_code
+    else if Loopify_attribute.was_loopified
+              (Code_metadata.loopify
+                 (Code_or_metadata.code_metadata code_or_metadata))
+            &&
+            match inlined with
+            | Unroll _ -> true
+            | Never_inlined | Default_inlined | Always_inlined | Hint_inlined ->
+              false
+    then Unroll_attribute_used_with_loopified_function
     else
       (* The unrolling process is rather subtle, but it boils down to two steps:
 

--- a/middle_end/flambda2/simplify/loopify_state.ml
+++ b/middle_end/flambda2/simplify/loopify_state.ml
@@ -2,11 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                     Nathanaëlle Courant, OCamlPro                      *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2022 OCamlPro SAS                                          *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,13 +12,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Flambda
+type t =
+  | Do_not_loopify
+  | Loopify of Continuation.t
 
-val simplify_let_cont :
-  simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  Let_cont.t Simplify_common.expr_simplifier
+let print ppf = function
+  | Do_not_loopify -> Format.fprintf ppf "do_not_loopify"
+  | Loopify cont ->
+    Format.fprintf ppf "@[<hov 1>(loopify@ %a)@]" Continuation.print cont
 
-val simplify_as_recursive_let_cont :
-  simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  (Expr.t * Continuation_handler.t Continuation.Map.t)
-  Simplify_common.expr_simplifier
+let do_not_loopify = Do_not_loopify
+
+let loopify cont = Loopify cont

--- a/middle_end/flambda2/simplify/loopify_state.mli
+++ b/middle_end/flambda2/simplify/loopify_state.mli
@@ -2,11 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                     Nathanaëlle Courant, OCamlPro                      *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2022 OCamlPro SAS                                          *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,13 +12,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Flambda
+type t = private
+  | Do_not_loopify
+  | Loopify of Continuation.t
 
-val simplify_let_cont :
-  simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  Let_cont.t Simplify_common.expr_simplifier
+val print : Format.formatter -> t -> unit
 
-val simplify_as_recursive_let_cont :
-  simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  (Expr.t * Continuation_handler.t Continuation.Map.t)
-  Simplify_common.expr_simplifier
+val do_not_loopify : t
+
+val loopify : Continuation.t -> t

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -47,6 +47,8 @@ type simplify_function_body =
   exn_continuation:Continuation.t ->
   return_cont_scope:Scope.t ->
   exn_cont_scope:Scope.t ->
+  loopify_state:Loopify_state.t ->
+  params:Bound_parameters.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
 let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -90,6 +90,8 @@ type simplify_function_body =
   exn_continuation:Continuation.t ->
   return_cont_scope:Scope.t ->
   exn_cont_scope:Scope.t ->
+  loopify_state:Loopify_state.t ->
+  params:Bound_parameters.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
 val simplify_projection :

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -120,11 +120,36 @@ let rec simplify_expr dacc expr ~down_to_up =
         EB.rebuild_invalid uacc (Message message) ~after_rebuild)
 
 and simplify_function_body dacc expr ~return_continuation ~return_arity
-    ~exn_continuation ~return_cont_scope ~exn_cont_scope =
-  simplify_toplevel_common dacc
-    (fun dacc -> simplify_expr dacc expr)
-    ~in_or_out_of_closure:In_a_closure ~return_continuation ~return_arity
     ~exn_continuation ~return_cont_scope ~exn_cont_scope
+    ~(loopify_state : Loopify_state.t) ~params =
+  match loopify_state with
+  | Do_not_loopify ->
+    simplify_toplevel_common dacc
+      (fun dacc -> simplify_expr dacc expr)
+      ~in_or_out_of_closure:In_a_closure ~return_continuation ~return_arity
+      ~exn_continuation ~return_cont_scope ~exn_cont_scope
+  | Loopify cont ->
+    let call_self_cont_expr =
+      let args = Bound_parameters.simples params in
+      Expr.create_apply_cont (Apply_cont_expr.create cont ~args ~dbg:[])
+    in
+    let handlers =
+      let fresh_params = Bound_parameters.rename params in
+      let renaming =
+        Bound_parameters.renaming params ~guaranteed_fresh:fresh_params
+      in
+      Continuation.Map.singleton cont
+        (Continuation_handler.create fresh_params
+           ~handler:(Expr.apply_renaming expr renaming)
+           ~free_names_of_handler:Unknown ~is_exn_handler:false)
+    in
+    simplify_toplevel_common dacc
+      (fun dacc ->
+        Simplify_let_cont_expr.simplify_as_recursive_let_cont ~simplify_expr
+          dacc
+          (call_self_cont_expr, handlers))
+      ~in_or_out_of_closure:In_a_closure ~return_continuation ~return_arity
+      ~exn_continuation ~return_cont_scope ~exn_cont_scope
 
 and[@inline always] simplify_let dacc let_expr ~down_to_up =
   Simplify_let_expr.simplify_let ~simplify_expr ~simplify_function_body dacc

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -1024,12 +1024,9 @@ let simplify_recursive_let_cont_stage1 ~simplify_expr ~denv_before_body ~body
          ~original_cont_scope ~down_to_up)
 
 let simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up ~body
-    rec_handlers =
-  let module CH = Continuation_handler in
-  assert (not (Continuation_handlers.contains_exn_handler rec_handlers));
+    handlers =
   let denv_before_body = DA.denv dacc in
   let original_cont_scope = DE.get_continuation_scope denv_before_body in
-  let handlers = Continuation_handlers.to_map rec_handlers in
   let cont, cont_handler =
     match Continuation.Map.bindings handlers with
     | [] | _ :: _ :: _ ->
@@ -1038,14 +1035,22 @@ let simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up ~body
          yet implemented"
     | [c] -> c
   in
-  CH.pattern_match cont_handler
+  Continuation_handler.pattern_match cont_handler
     ~f:
       (simplify_recursive_let_cont_stage1 ~simplify_expr ~denv_before_body ~body
          cont ~original_cont_scope ~down_to_up dacc)
 
+let simplify_as_recursive_let_cont ~simplify_expr dacc (body, handlers)
+    ~down_to_up =
+  simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up ~body
+    handlers
+
 let simplify_recursive_let_cont ~simplify_expr dacc recs ~down_to_up =
-  Recursive_let_cont_handlers.pattern_match recs
-    ~f:(simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up)
+  Recursive_let_cont_handlers.pattern_match recs ~f:(fun ~body rec_handlers ->
+      assert (not (Continuation_handlers.contains_exn_handler rec_handlers));
+      let handlers = Continuation_handlers.to_map rec_handlers in
+      simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up ~body
+        handlers)
 
 let simplify_let_cont ~simplify_expr dacc (let_cont : Let_cont.t) ~down_to_up =
   match let_cont with

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -29,7 +29,7 @@ module C = Simplify_set_of_closures_context
 let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
     ~my_depth function_slot_opt ~closure_bound_names_inside_function
     ~inlining_arguments ~absolute_history code_id ~return_continuation
-    ~exn_continuation ~return_cont_params code_metadata =
+    ~exn_continuation ~return_cont_params ~loopify_state code_metadata =
   let dacc = C.dacc_inside_functions context in
   let num_leading_heap_params =
     Code_metadata.num_leading_heap_params code_metadata
@@ -86,6 +86,7 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
       (DA.get_lifted_constants outer_dacc)
     |> DE.enter_closure code_id ~return_continuation ~exn_continuation
          ~my_closure
+    |> DE.set_loopify_state loopify_state
     |> DE.increment_continuation_scope
   in
   let denv = DE.add_parameters_with_unknown_types denv return_cont_params in
@@ -144,6 +145,7 @@ type simplify_function_body_result =
     free_names_of_code : NO.t;
     return_cont_uses : Continuation_uses.t option;
     is_my_closure_used : bool;
+    recursive : Recursive.t;
     uacc_after_upwards_traversal : UA.t
   }
 
@@ -152,11 +154,17 @@ let simplify_function_body context ~outer_dacc function_slot_opt
     code_id ~return_cont_params code ~return_continuation ~exn_continuation
     params ~body ~my_closure ~is_my_closure_used:_ ~my_region ~my_depth
     ~free_names_of_body:_ =
+  let loopify_state =
+    if Loopify_attribute.should_loopify (Code.loopify code)
+    then Loopify_state.loopify (Continuation.create ~name:"self" ())
+    else Loopify_state.do_not_loopify
+  in
   let dacc_at_function_entry =
     dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
       ~my_depth function_slot_opt ~closure_bound_names_inside_function
       ~inlining_arguments ~absolute_history code_id ~return_continuation
-      ~exn_continuation ~return_cont_params (Code.code_metadata code)
+      ~exn_continuation ~return_cont_params ~loopify_state
+      (Code.code_metadata code)
   in
   let dacc = dacc_at_function_entry in
   if not (DA.no_lifted_constants dacc)
@@ -168,7 +176,7 @@ let simplify_function_body context ~outer_dacc function_slot_opt
     C.simplify_function_body context dacc body ~return_continuation
       ~exn_continuation ~return_arity:(Code.result_arity code)
       ~return_cont_scope:Scope.initial
-      ~exn_cont_scope:(Scope.next Scope.initial)
+      ~exn_cont_scope:(Scope.next Scope.initial) ~loopify_state ~params
   with
   | body, uacc ->
     let dacc_after_body = UA.creation_dacc uacc in
@@ -186,6 +194,11 @@ let simplify_function_body context ~outer_dacc function_slot_opt
     let is_my_closure_used = NO.mem_var free_names_of_body my_closure in
     let previously_free_depth_variables =
       NO.create_variables (C.previously_free_depth_variables context) NM.normal
+    in
+    let recursive : Recursive.t =
+      if Name_occurrences.mem_var free_names_of_body my_depth
+      then Recursive
+      else Non_recursive
     in
     let free_names_of_code =
       free_names_of_body
@@ -217,6 +230,7 @@ let simplify_function_body context ~outer_dacc function_slot_opt
       free_names_of_code;
       return_cont_uses;
       is_my_closure_used;
+      recursive;
       uacc_after_upwards_traversal = uacc
     }
   | exception Misc.Fatal_error ->
@@ -330,6 +344,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
         free_names_of_code;
         return_cont_uses;
         is_my_closure_used;
+        recursive;
         uacc_after_upwards_traversal
       } =
     Function_params_and_body.pattern_match
@@ -356,7 +371,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
     let decision =
       Function_decl_inlining_decision.make_decision ~inlining_arguments
         ~inline:(Code.inline code) ~stub:(Code.stub code) ~cost_metrics
-        ~is_a_functor:(Code.is_a_functor code) ~recursive:(Code.recursive code)
+        ~is_a_functor:(Code.is_a_functor code) ~recursive
     in
     Inlining_report.record_decision_at_function_definition ~absolute_history
       ~code_metadata:(Code.code_metadata code) ~pass:After_simplify
@@ -388,6 +403,19 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       in
       DA.with_slot_offsets outer_dacc ~slot_offsets
   in
+  let loopify : Loopify_attribute.t =
+    match Code.loopify code with
+    | Always_loopify ->
+      (* CR ncourant: in this case, the function had a [@loop] attribute, so we
+         want to keep it in case we perform another pass. It might be better to
+         only keep it that way if it is still recursive, however, but this is
+         simpler. *)
+      Always_loopify
+    | Never_loopify -> Never_loopify
+    | Already_loopified -> Already_loopified
+    | Default_loopify_and_tailrec -> Already_loopified
+    | Default_loopify_and_not_tailrec -> Never_loopify
+  in
   let code =
     Rebuilt_static_const.create_code
       (DA.are_rebuilding_terms dacc_after_body)
@@ -401,7 +429,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       ~poll_attribute:(Code.poll_attribute code) ~is_a_functor
       ~recursive:(Code.recursive code) ~cost_metrics ~inlining_arguments
       ~dbg:(Code.dbg code) ~is_tupled:(Code.is_tupled code) ~is_my_closure_used
-      ~inlining_decision ~absolute_history ~relative_history
+      ~inlining_decision ~absolute_history ~relative_history ~loopify
   in
   { code_id; code = Some code; outer_dacc }
 

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -85,6 +85,7 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
     LCS.add_to_denv ~maybe_already_defined:() denv
       (DA.get_lifted_constants outer_dacc)
     |> DE.enter_closure code_id ~return_continuation ~exn_continuation
+         ~my_closure
     |> DE.increment_continuation_scope
   in
   let denv = DE.add_parameters_with_unknown_types denv return_cont_params in

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -33,6 +33,7 @@ type t =
   | Max_inlining_depth_exceeded
   | Recursion_depth_exceeded
   | Never_inlined_attribute
+  | Unroll_attribute_used_with_loopified_function
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
@@ -64,6 +65,8 @@ let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "Recursion_depth_exceeded"
   | Never_inlined_attribute ->
     Format.fprintf ppf "Never_inlined_attribute"
+  | Unroll_attribute_used_with_loopified_function ->
+    Format.fprintf ppf "Unroll_attribute_used_with_loopified_function"
   | Attribute_always ->
     Format.fprintf ppf "Attribute_always"
   | Definition_says_inline { was_inline_always } ->
@@ -126,6 +129,10 @@ let can_inline (t : t) : can_inline =
        attribute when we stop unrolling, which is fine *)
     Do_not_inline
       { warn_if_attribute_ignored = false; because_of_definition = true }
+  | Unroll_attribute_used_with_loopified_function ->
+    (* We have an [@unrolled] attribute, but can't unroll loopified functions *)
+    Do_not_inline
+      { warn_if_attribute_ignored = true; because_of_definition = true }
   | Attribute_unroll unroll_to ->
     Inline { unroll_to = Some unroll_to; was_inline_always = false }
   | Definition_says_inline { was_inline_always } ->
@@ -156,6 +163,11 @@ let report_reason fmt t =
     Format.fprintf fmt "the@ maximum@ recursion@ depth@ has@ been@ exceeded"
   | Never_inlined_attribute ->
     Format.fprintf fmt "the@ call@ has@ an@ attribute@ forbidding@ inlining"
+  | Unroll_attribute_used_with_loopified_function ->
+    Format.fprintf fmt
+      "the@ code@ of@ this@ function@ has@ been@ transformed@ to@ a@ loop,@ \
+       which@ cannot@ be@ unrolled@ yet@ (consider@ adding@ [@loop never]@ to@ \
+       the@ definition)"
   | Attribute_always ->
     Format.fprintf fmt "the@ call@ has@ an@ [@@inline always]@ attribute"
   | Attribute_unroll n ->

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -26,6 +26,7 @@ type t =
   | Max_inlining_depth_exceeded
   | Recursion_depth_exceeded
   | Never_inlined_attribute
+  | Unroll_attribute_used_with_loopified_function
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -204,8 +204,8 @@ let relative_history t = t.relative_history
 
 let position t = t.position
 
-let free_names
-    { callee;
+let free_names_except_callee
+    { callee = _;
       continuation;
       exn_continuation;
       args;
@@ -219,12 +219,16 @@ let free_names
       region
     } =
   Name_occurrences.union_list
-    [ Simple.free_names callee;
-      Result_continuation.free_names continuation;
+    [ Result_continuation.free_names continuation;
       Exn_continuation.free_names exn_continuation;
       Simple.List.free_names args;
       Call_kind.free_names call_kind;
       Name_occurrences.singleton_variable region Name_mode.normal ]
+
+let free_names t =
+  Name_occurrences.union
+    (Simple.free_names t.callee)
+    (free_names_except_callee t)
 
 let apply_renaming
     ({ callee;

--- a/middle_end/flambda2/terms/apply_expr.mli
+++ b/middle_end/flambda2/terms/apply_expr.mli
@@ -19,6 +19,8 @@
 
 type t
 
+val free_names_except_callee : t -> Name_occurrences.t
+
 include Expr_std.S with type t := t
 
 include Contains_ids.S with type t := t

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -70,6 +70,8 @@ module type Code_metadata_accessors_result_type = sig
   val absolute_history : 'a t -> Inlining_history.Absolute.t
 
   val relative_history : 'a t -> Inlining_history.Relative.t
+
+  val loopify : 'a t -> Loopify_attribute.t
 end
 
 module Code_metadata_accessors : functor (X : Metadata_view_type) ->
@@ -99,6 +101,7 @@ type 'a create_type =
   inlining_decision:Function_decl_inlining_decision_type.t ->
   absolute_history:Inlining_history.Absolute.t ->
   relative_history:Inlining_history.Relative.t ->
+  loopify:Loopify_attribute.t ->
   'a
 
 val createk : (t -> 'a) -> 'a create_type

--- a/middle_end/flambda2/terms/loopify_attribute.ml
+++ b/middle_end/flambda2/terms/loopify_attribute.ml
@@ -1,0 +1,50 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                     Nathanaëlle Courant, OCamlPro                      *)
+(*                                                                        *)
+(*   Copyright 2022 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type t =
+  | Always_loopify
+  | Never_loopify
+  | Already_loopified
+  | Default_loopify_and_tailrec
+  | Default_loopify_and_not_tailrec
+
+let print ppf = function
+  | Always_loopify -> Format.fprintf ppf "Always_loopify"
+  | Never_loopify -> Format.fprintf ppf "Never_loopify"
+  | Already_loopified -> Format.fprintf ppf "Already_loopified"
+  | Default_loopify_and_tailrec ->
+    Format.fprintf ppf "Default_loopify_and_tailrec"
+  | Default_loopify_and_not_tailrec ->
+    Format.fprintf ppf "Default_loopify_and_not_tailrec"
+
+let should_loopify = function
+  | Always_loopify | Default_loopify_and_tailrec -> true
+  | Never_loopify | Already_loopified | Default_loopify_and_not_tailrec -> false
+
+let was_loopified = function
+  | Always_loopify | Already_loopified | Default_loopify_and_tailrec -> true
+  | Never_loopify | Default_loopify_and_not_tailrec -> false
+
+let equal t1 t2 =
+  match t1, t2 with
+  | Always_loopify, Always_loopify
+  | Never_loopify, Never_loopify
+  | Already_loopified, Already_loopified
+  | Default_loopify_and_tailrec, Default_loopify_and_tailrec
+  | Default_loopify_and_not_tailrec, Default_loopify_and_not_tailrec ->
+    true
+  | ( ( Always_loopify | Never_loopify | Already_loopified
+      | Default_loopify_and_tailrec | Default_loopify_and_not_tailrec ),
+      _ ) ->
+    false

--- a/middle_end/flambda2/terms/loopify_attribute.mli
+++ b/middle_end/flambda2/terms/loopify_attribute.mli
@@ -2,11 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                     Nathanaëlle Courant, OCamlPro                      *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2022 OCamlPro SAS                                          *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,13 +12,17 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Flambda
+type t =
+  | Always_loopify
+  | Never_loopify
+  | Already_loopified
+  | Default_loopify_and_tailrec
+  | Default_loopify_and_not_tailrec
 
-val simplify_let_cont :
-  simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  Let_cont.t Simplify_common.expr_simplifier
+val print : Format.formatter -> t -> unit
 
-val simplify_as_recursive_let_cont :
-  simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  (Expr.t * Continuation_handler.t Continuation.Map.t)
-  Simplify_common.expr_simplifier
+val should_loopify : t -> bool
+
+val was_loopified : t -> bool
+
+val equal : t -> t -> bool

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -386,6 +386,11 @@ type check_attribute =
   | Assert of property
   | Assume of property
 
+type loop_attribute =
+  | Always_loop (* [@loop] or [@loop always] *)
+  | Never_loop (* [@loop never] *)
+  | Default_loop (* no [@loop] attribute *)
+
 type function_kind = Curried of {nlocal: int} | Tupled
 
 type let_kind = Strict | Alias | StrictOpt
@@ -407,6 +412,7 @@ type function_attribute = {
   local: local_attribute;
   check : check_attribute;
   poll: poll_attribute;
+  loop: loop_attribute;
   is_a_functor: bool;
   stub: bool;
 }
@@ -540,6 +546,7 @@ let default_function_attribute = {
   local = Default_local;
   check = Default_check ;
   poll = Default_poll;
+  loop = Default_loop;
   is_a_functor = false;
   stub = false;
 }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -299,6 +299,11 @@ type poll_attribute =
   | Error_poll (* [@poll error] *)
   | Default_poll (* no [@poll] attribute *)
 
+type loop_attribute =
+  | Always_loop (* [@loop] or [@loop always] *)
+  | Never_loop (* [@loop never] *)
+  | Default_loop (* no [@loop] attribute *)
+
 type function_kind = Curried of {nlocal: int} | Tupled
 (* [nlocal] determines how many arguments may be partially applied
    before the resulting closure must be locally allocated.
@@ -327,6 +332,7 @@ type function_attribute = {
   local: local_attribute;
   check : check_attribute;
   poll: poll_attribute;
+  loop: loop_attribute;
   is_a_functor: bool;
   stub: bool;
 }

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -564,7 +564,7 @@ let check_attribute ppf check =
   | Assume p -> fprintf ppf "assume %s@ " (check_property p)
 
 let function_attribute ppf
-    { inline; specialise; check; local; is_a_functor; stub; poll } =
+    { inline; specialise; check; local; is_a_functor; stub; poll; loop } =
   if is_a_functor then
     fprintf ppf "is_a_functor@ ";
   if stub then
@@ -590,7 +590,12 @@ let function_attribute ppf
   | Default_poll -> ()
   | Error_poll -> fprintf ppf "error_poll@ "
   end;
-  check_attribute ppf check
+  check_attribute ppf check;
+  begin match loop with
+  | Default_loop -> ()
+  | Always_loop -> fprintf ppf "always_loop@ "
+  | Never_loop -> fprintf ppf "never_loop@ "
+  end
 
 let apply_tailcall_attribute ppf = function
   | Default_tailcall -> ()

--- a/ocaml/lambda/translattribute.mli
+++ b/ocaml/lambda/translattribute.mli
@@ -53,6 +53,16 @@ val get_local_attribute
    : Parsetree.attributes
   -> Lambda.local_attribute
 
+val add_loop_attribute
+  : Lambda.lambda
+  -> Location.t
+  -> Parsetree.attributes
+  -> Lambda.lambda
+
+val get_loop_attribute
+  : Parsetree.attributes
+  -> Lambda.loop_attribute
+
 val get_and_remove_inlined_attribute
    : Typedtree.expression
   -> Lambda.inlined_attribute * Typedtree.expression

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -818,6 +818,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           specialise = Always_specialise;
           local = Never_local;
           check = Default_check;
+          loop = Never_loop;
           is_a_functor = false;
           stub = false;
           poll = Default_poll;

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -548,6 +548,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
       local = Default_local;
       poll = Default_poll;
       check = Default_check;
+      loop = Never_loop;
       is_a_functor = true;
       stub = false;
     };

--- a/ocaml/testsuite/tests/functors/functors.compilers.reference
+++ b/ocaml/testsuite/tests/functors/functors.compilers.reference
@@ -2,14 +2,14 @@
   (let
     (O =
        (module-defn(O) Functors functors.ml(12):184-279
-         (function X is_a_functor always_inline
+         (function X is_a_functor always_inline never_loop
            (let
              (cow = (function x[int] : int (apply (field 0 X) x))
               sheep = (function x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 cow sheep))))
      F =
        (module-defn(F) Functors functors.ml(17):281-392
-         (function X Y is_a_functor always_inline
+         (function X Y is_a_functor always_inline never_loop
            (let
              (cow =
                 (function x[int] : int
@@ -18,7 +18,7 @@
              (makeblock 0 cow sheep))))
      F1 =
        (module-defn(F1) Functors functors.ml(31):516-632
-         (function X Y is_a_functor always_inline
+         (function X Y is_a_functor always_inline never_loop
            (let
              (cow =
                 (function x[int] : int
@@ -27,7 +27,7 @@
              (makeblock 0 sheep))))
      F2 =
        (module-defn(F2) Functors functors.ml(36):634-784
-         (function X Y is_a_functor always_inline
+         (function X Y is_a_functor always_inline never_loop
            (let
              (X =a (makeblock 0 (field 1 X))
               Y =a (makeblock 0 (field 1 Y))
@@ -41,7 +41,7 @@
          (let
            (F =
               (module-defn(F) Functors.M functors.ml(44):849-966
-                (function X Y is_a_functor always_inline
+                (function X Y is_a_functor always_inline never_loop
                   (let
                     (cow =
                        (function x[int] : int


### PR DESCRIPTION
This pull request introduces the transformation of tail-recursive calls in functions to a recursive continuation call, effectively transforming the function into a loop at the flambda2 stage and allowing further simplifications to be done (such as unboxing). By default, this transformation only happens if the function is purely tail-recursive as written (no instance of the function exists other than in a tail call in the body).
The `[@loop]` and `[@loop never]` attributes are added to control the transformation, the first by forcing the transformation to happen even if the function is not detected to be tail-recursive (for instance, if some calls are hidden behind inlining), while the second prevents the transformation from ever happening.
Since loop unrolling is not yet supported, the `[@unrolled]` attributes are incompatible with loopified functions, and the optimizer will warn about impossible inlining. If unrolling is important in those situations, the function can be marked with `[@loop never]` to present its transformation.

--
This is a rebase of #836 on top of all the parts that were split from it.