### PR TITLE
Add a type for the return value of Block_set (and similar prims)

### DIFF
--- a/middle_end/flambda2/simplify/simplify_primitive_result.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive_result.ml
@@ -31,6 +31,13 @@ let create_simplified simplified_named ~try_reify dacc =
 let create_invalid dacc =
   { simplified_named = Invalid; try_reify = false; dacc }
 
+let create_unit dacc ~result_var ~original_term =
+  (* CR gbury: would it make sense to have a Flambda2_types.unit instead
+     of this ? *)
+  let ty = Flambda2_types.this_tagged_immediate Targetint_31_63.zero in
+  let dacc = Downwards_acc.add_variable dacc result_var ty in
+  create original_term ~try_reify:false dacc
+
 let create_unknown dacc ~result_var kind ~original_term =
   let ty = Flambda2_types.unknown kind in
   let dacc = Downwards_acc.add_variable dacc result_var ty in

--- a/middle_end/flambda2/simplify/simplify_primitive_result.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive_result.ml
@@ -32,8 +32,8 @@ let create_invalid dacc =
   { simplified_named = Invalid; try_reify = false; dacc }
 
 let create_unit dacc ~result_var ~original_term =
-  (* CR gbury: would it make sense to have a Flambda2_types.unit instead
-     of this ? *)
+  (* CR gbury: would it make sense to have a Flambda2_types.unit instead of this
+     ? *)
   let ty = Flambda2_types.this_tagged_immediate Targetint_31_63.zero in
   let dacc = Downwards_acc.add_variable dacc result_var ty in
   create original_term ~try_reify:false dacc

--- a/middle_end/flambda2/simplify/simplify_primitive_result.mli
+++ b/middle_end/flambda2/simplify/simplify_primitive_result.mli
@@ -29,6 +29,12 @@ val create_simplified :
 
 val create_invalid : Downwards_acc.t -> t
 
+val create_unit :
+  Downwards_acc.t ->
+  result_var:Bound_var.t ->
+  original_term:Flambda.Named.t ->
+  t
+
 val create_unknown :
   Downwards_acc.t ->
   result_var:Bound_var.t ->

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -36,22 +36,23 @@ let simplify_array_set (array_kind : P.Array_kind.t) init_or_assign dacc
            (Array_set (array_kind, init_or_assign), array, index, new_value))
         dbg
     in
-    let dacc = DA.add_variable dacc result_var T.any_value in
+    let unit_ty = Flambda2_types.this_tagged_immediate Targetint_31_63.zero in
+    let dacc = DA.add_variable dacc result_var unit_ty in
     SPR.create named ~try_reify:false dacc
 
 let simplify_block_set _block_access_kind _init_or_assign dacc ~original_term
     _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_ ~result_var =
-  SPR.create_unknown dacc ~result_var K.value ~original_term
+  SPR.create_unit dacc ~result_var ~original_term
 
 let simplify_bytes_or_bigstring_set _bytes_like_value _string_accessor_width
     dacc ~original_term _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_
     ~arg3_ty:_ ~result_var =
-  SPR.create_unknown dacc ~result_var K.value ~original_term
+  SPR.create_unit dacc ~result_var ~original_term
 
 let simplify_bigarray_set ~num_dimensions:_ _bigarray_kind _bigarray_layout dacc
     ~original_term _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_
     ~result_var =
-  SPR.create_unknown dacc ~result_var K.value ~original_term
+  SPR.create_unit dacc ~result_var ~original_term
 
 let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty dbg ~result_var =


### PR DESCRIPTION
Block_set (and other similar primitives) have a return value of type unit, which we can statically know. This PR adds the adequate binding in the typing env to record that information. This then allows the rest of simplify to systematically replace every use of the return value of a block_set by the tagged integer 0.

Besides the improvement this provides in cutting unneeded dependencies, this also fixes a bug in mutable unboxing (aka ref-to-var): indeed let's consider the following example:
```ocaml
let[@inline never] foo () = ()

(* ensure that we need flambda2 to unbox the ref *)
let[@inline always] incr x = x := !x + 1

let bar x =
  let r = ref x in
  let u = incr r in
  foo u
```

Even if it's useless, without this patch, the return value of the block_set of the ref, i.e. `Psetfieldxxx` is used as argument to `foo`. The code for mutable unboxing will then proceed to remove the block_set when unboxing the ref, and currently, directly removes the whole let_prim, ultimately leaving one occurrence of `Psetfieldxxx` as argument to `foo`,even though `Psetfieldxxx` is not defined anywhere anymore. Instead, this PR ensures, that any such `Psetfield` will always be replaced by the tagged integer `0`, and thus mutable unboxing can remove the whole `let_prim` without problems.

Note: in the mutable unboxing pass, we could, instead of removing the whole let_prim, replace the `Block_set` primitive with the tagged integer `0`. However, since that is done on the way up that would leave a binding `let Psetfieldxxx = 0 in ...` whereas with this PR, we do the substitution on the way down, which seems overall better.