### PR TITLE
CFG/IRC: restore support for stack operands

### DIFF
--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -435,12 +435,19 @@ let rewrite : State.t -> Cfg_with_liveness.t -> Reg.t list -> reset:bool -> unit
         log ~indent:2 "body of #%d, before:" label;
         log_body_and_terminator ~indent:3 block.body block.terminator liveness);
       Cfg.BasicInstructionList.iter_cell block.body ~f:(fun cell ->
-          let sharing = Reg.Tbl.create 8 in
           let instr = Cfg.BasicInstructionList.instr cell in
-          rewrite_instruction ~direction:(Load_before_cell cell) ~sharing instr;
-          rewrite_instruction ~direction:(Store_after_cell cell) ~sharing instr);
-      rewrite_instruction ~direction:(Load_after_list block.body)
-        ~sharing:(Reg.Tbl.create 8) block.terminator;
+          match Cfg_stack_operands.basic spilled_map instr with
+          | All_spilled_registers_rewritten -> ()
+          | May_still_have_spilled_registers ->
+            let sharing = Reg.Tbl.create 8 in
+            rewrite_instruction ~direction:(Load_before_cell cell) ~sharing instr;
+            rewrite_instruction ~direction:(Store_after_cell cell) ~sharing instr);
+      begin match Cfg_stack_operands.terminator spilled_map block.terminator with
+      | All_spilled_registers_rewritten -> ()
+      | May_still_have_spilled_registers ->
+        rewrite_instruction ~direction:(Load_after_list block.body)
+          ~sharing:(Reg.Tbl.create 8) block.terminator;
+      end;
       if irc_debug
       then (
         log ~indent:2 "and after:";

--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -440,14 +440,15 @@ let rewrite : State.t -> Cfg_with_liveness.t -> Reg.t list -> reset:bool -> unit
           | All_spilled_registers_rewritten -> ()
           | May_still_have_spilled_registers ->
             let sharing = Reg.Tbl.create 8 in
-            rewrite_instruction ~direction:(Load_before_cell cell) ~sharing instr;
-            rewrite_instruction ~direction:(Store_after_cell cell) ~sharing instr);
-      begin match Cfg_stack_operands.terminator spilled_map block.terminator with
+            rewrite_instruction ~direction:(Load_before_cell cell) ~sharing
+              instr;
+            rewrite_instruction ~direction:(Store_after_cell cell) ~sharing
+              instr);
+      (match Cfg_stack_operands.terminator spilled_map block.terminator with
       | All_spilled_registers_rewritten -> ()
       | May_still_have_spilled_registers ->
         rewrite_instruction ~direction:(Load_after_list block.body)
-          ~sharing:(Reg.Tbl.create 8) block.terminator;
-      end;
+          ~sharing:(Reg.Tbl.create 8) block.terminator);
       if irc_debug
       then (
         log ~indent:2 "and after:";


### PR DESCRIPTION
When I rebased #793, I somehow managed to
delete the code related to stack operands in
IRC.

This was spotted by a nightly check (failing to
allocate after 50 iterations when a probe and
many live variables are involved). I have checked
that the test passes again with this pull request.