### PR TITLE
Don't create new nested loops by preventing inlining of continuations inside the handler of a recursive continuation

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -990,7 +990,8 @@ module Let_cont_with_acc = struct
     let body_free_names, acc, body = Acc.eval_branch_free_names acc ~f:body in
     let acc =
       Acc.with_free_names
-        (Name_occurrences.union body_free_names handlers_free_names)
+        (Name_occurrences.union body_free_names
+           (Name_occurrences.increase_counts handlers_free_names))
         acc
     in
     create_recursive acc handlers ~body ~cost_metrics_of_handlers

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -375,6 +375,13 @@ module Acc = struct
     | Trackable_arguments of Env.value_approximation list
     | Untrackable
 
+  type closure_info =
+    { return_continuation : Continuation.t;
+      exn_continuation : Exn_continuation.t;
+      my_closure : Variable.t;
+      is_purely_tailrec : bool
+    }
+
   type t =
     { declared_symbols : (Symbol.t * Static_const.t) list;
       lifted_sets_of_closures :
@@ -389,7 +396,8 @@ module Acc = struct
       seen_a_function : bool;
       symbol_for_global : Ident.t -> Symbol.t;
       slot_offsets : Slot_offsets.t;
-      regions_closed_early : Ident.Set.t
+      regions_closed_early : Ident.Set.t;
+      closure_infos : closure_info list
     }
 
   let cost_metrics t = t.cost_metrics
@@ -414,7 +422,8 @@ module Acc = struct
       seen_a_function = false;
       symbol_for_global;
       slot_offsets;
-      regions_closed_early = Ident.Set.empty
+      regions_closed_early = Ident.Set.empty;
+      closure_infos = []
     }
 
   let declared_symbols t = t.declared_symbols
@@ -451,15 +460,47 @@ module Acc = struct
   let add_free_names free_names t =
     { t with free_names = Name_occurrences.union free_names t.free_names }
 
-  let add_name_to_free_names ~name t =
+  let add_free_names_and_check_my_closure_use free_names t =
+    let t =
+      match t.closure_infos with
+      | [] -> t
+      | closure_info :: closure_infos ->
+        if closure_info.is_purely_tailrec
+           && Name_occurrences.mem_var free_names closure_info.my_closure
+        then
+          { t with
+            closure_infos =
+              { closure_info with is_purely_tailrec = false } :: closure_infos
+          }
+        else t
+    in
+    add_free_names free_names t
+
+  let add_name_to_free_names ~is_tail_call ~name t =
+    let closure_infos =
+      match is_tail_call, t.closure_infos with
+      | true, closure_infos -> closure_infos
+      | false, [] -> []
+      | false, closure_info :: closure_infos ->
+        if closure_info.is_purely_tailrec
+           && Name.equal (Name.var closure_info.my_closure) name
+        then { closure_info with is_purely_tailrec = false } :: closure_infos
+        else t.closure_infos
+    in
     { t with
+      closure_infos;
       free_names = Name_occurrences.add_name t.free_names name Name_mode.normal
     }
 
-  let add_simple_to_free_names acc simple =
+  let add_simple_to_free_names_maybe_tail_call ~is_tail_call acc simple =
     Simple.pattern_match simple
       ~const:(fun _ -> acc)
-      ~name:(fun name ~coercion:_ -> add_name_to_free_names ~name acc)
+      ~name:(fun name ~coercion ->
+        let acc = add_name_to_free_names ~is_tail_call ~name acc in
+        add_free_names (Coercion.free_names coercion) acc)
+
+  let add_simple_to_free_names acc simple =
+    add_simple_to_free_names_maybe_tail_call ~is_tail_call:false acc simple
 
   let remove_code_id_or_symbol_from_free_names code_id_or_symbol t =
     { t with
@@ -538,6 +579,36 @@ module Acc = struct
         set_of_closures
     in
     { t with slot_offsets }
+
+  let top_closure_info t =
+    match t.closure_infos with
+    | [] -> None
+    | closure_info :: _ -> Some closure_info
+
+  let push_closure_info t ~return_continuation ~exn_continuation ~my_closure
+      ~is_purely_tailrec =
+    { t with
+      closure_infos =
+        { return_continuation; exn_continuation; my_closure; is_purely_tailrec }
+        :: t.closure_infos
+    }
+
+  let pop_closure_info t =
+    let closure_info, closure_infos =
+      match t.closure_infos with
+      | [] -> Misc.fatal_error "pop_closure_info called on empty stack"
+      | closure_info :: closure_infos -> closure_info, closure_infos
+    in
+    let closure_infos =
+      match closure_infos with
+      | [] -> []
+      | closure_info2 :: closure_infos2 ->
+        if closure_info2.is_purely_tailrec
+           && Name_occurrences.mem_var t.free_names closure_info2.my_closure
+        then { closure_info2 with is_purely_tailrec = false } :: closure_infos2
+        else closure_infos
+    in
+    closure_info, { t with closure_infos }
 end
 
 module Function_decls = struct
@@ -615,6 +686,8 @@ module Function_decls = struct
     let specialise t = t.attr.specialise
 
     let poll_attribute t = t.attr.poll
+
+    let loop t = t.attr.loop
 
     let is_a_functor t = t.attr.is_a_functor
 
@@ -709,7 +782,40 @@ module Expr_with_acc = struct
         (Code_size.apply apply |> Cost_metrics.from_size)
         acc
     in
-    let acc = Acc.add_free_names (Apply_expr.free_names apply) acc in
+    let is_tail_call =
+      match Acc.top_closure_info acc with
+      | None -> false
+      | Some { return_continuation; exn_continuation; _ } -> (
+        (match Apply_expr.continuation apply with
+        | Never_returns -> true
+        | Return cont -> Continuation.equal cont return_continuation)
+        && Exn_continuation.equal
+             (Apply_expr.exn_continuation apply)
+             exn_continuation
+        (* If the return and exn continuation match, the call is in tail
+           position, but could still be an under- or over-application. By
+           checking that it is a direct call, we are sure it has the correct
+           arity. *)
+        &&
+        match Apply.call_kind apply with
+        | Function { function_call = Direct _; _ } -> true
+        | Function
+            { function_call = Indirect_unknown_arity | Indirect_known_arity _;
+              _
+            } ->
+          false
+        | Method _ -> false
+        | C_call _ -> false)
+    in
+    let acc =
+      Acc.add_simple_to_free_names_maybe_tail_call ~is_tail_call acc
+        (Apply.callee apply)
+    in
+    let acc =
+      Acc.add_free_names_and_check_my_closure_use
+        (Apply_expr.free_names_except_callee apply)
+        acc
+    in
     let acc =
       match Apply_expr.continuation apply with
       | Never_returns -> acc
@@ -742,7 +848,11 @@ module Apply_cont_with_acc = struct
   let create acc ?trap_action ?args_approx cont ~args ~dbg =
     let apply_cont = Apply_cont.create ?trap_action cont ~args ~dbg in
     let acc = Acc.add_continuation_application ~cont args_approx acc in
-    let acc = Acc.add_free_names (Apply_cont.free_names apply_cont) acc in
+    let acc =
+      Acc.add_free_names_and_check_my_closure_use
+        (Apply_cont.free_names apply_cont)
+        acc
+    in
     acc, apply_cont
 
   let goto acc cont =
@@ -797,7 +907,18 @@ module Let_with_acc = struct
           ~code_id:(fun acc cid -> Acc.remove_code_id_from_free_names cid acc)
       in
       let let_expr = Let.create let_bound named ~body ~free_names_of_body in
-      let acc = Acc.add_free_names (Named.free_names named) acc in
+      let is_project_value_slot =
+        match[@ocaml.warning "-4"] (named : Named.t) with
+        | Prim (Unary (Project_value_slot _, _), _) -> true
+        | _ -> false
+      in
+      let acc =
+        if is_project_value_slot
+        then Acc.add_free_names (Named.free_names named) acc
+        else
+          Acc.add_free_names_and_check_my_closure_use (Named.free_names named)
+            acc
+      in
       acc, Expr.create_let let_expr
 end
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -179,6 +179,13 @@ end
 
 (** Used to pipe some data through closure conversion *)
 module Acc : sig
+  type closure_info = private
+    { return_continuation : Continuation.t;
+      exn_continuation : Exn_continuation.t;
+      my_closure : Variable.t;
+      is_purely_tailrec : bool
+    }
+
   type t
 
   val create :
@@ -252,6 +259,18 @@ module Acc : sig
 
   val add_set_of_closures_offsets :
     is_phantom:bool -> t -> Set_of_closures.t -> t
+
+  val top_closure_info : t -> closure_info option
+
+  val push_closure_info :
+    t ->
+    return_continuation:Continuation.t ->
+    exn_continuation:Exn_continuation.t ->
+    my_closure:Variable.t ->
+    is_purely_tailrec:bool ->
+    t
+
+  val pop_closure_info : t -> closure_info * t
 end
 
 (** Used to represent information about a set of function declarations during
@@ -304,6 +323,8 @@ module Function_decls : sig
     val specialise : t -> Lambda.specialise_attribute
 
     val poll_attribute : t -> Lambda.poll_attribute
+
+    val loop : t -> Lambda.loop_attribute
 
     val is_a_functor : t -> bool
 

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -67,6 +67,8 @@ end) : sig
   val for_all : t -> f:(N.t -> bool) -> bool
 
   val filter : t -> f:(N.t -> bool) -> t
+
+  val increase_counts : t -> t
 end = struct
   module For_one_name : sig
     type t
@@ -89,6 +91,8 @@ end = struct
     val max_name_mode_opt : t -> Name_mode.t option
 
     val union : t -> t -> t
+
+    val increase_count : t -> t
   end = struct
     (* CR mshinwell: Provide 32-bit implementation? Probably not worth it now I
        suppose. *)
@@ -189,6 +193,15 @@ end = struct
             (num_occurrences_in_types t1 + num_occurrences_in_types t2)
       lor encode_phantom_occurrences
             (num_occurrences_phantom t1 + num_occurrences_phantom t2)
+
+    let increase_count t =
+      let increase_if_not_zero n = if n = 0 then n else succ n in
+      encode_normal_occurrences
+        (increase_if_not_zero (num_occurrences_normal t))
+      lor encode_in_types_occurrences
+            (increase_if_not_zero (num_occurrences_in_types t))
+      lor encode_phantom_occurrences
+            (increase_if_not_zero (num_occurrences_phantom t))
   end
 
   type t = For_one_name.t N.Map.t
@@ -308,6 +321,8 @@ end = struct
   let for_all t ~f = N.Map.for_all (fun name _ -> f name) t
 
   let filter t ~f = N.Map.filter (fun name _ -> f name) t
+
+  let increase_counts t = N.Map.map For_one_name.increase_count t
 end
 [@@inline always]
 
@@ -1128,3 +1143,51 @@ let ids_for_export
       (For_code_ids.keys newer_version_of_code_ids)
   in
   Ids_for_export.create ~variables ~symbols ~code_ids ~continuations ()
+
+let increase_counts
+    { names;
+      continuations;
+      continuations_with_traps;
+      continuations_in_trap_actions;
+      function_slots_in_projections;
+      value_slots_in_projections;
+      function_slots_in_declarations;
+      value_slots_in_declarations;
+      code_ids;
+      newer_version_of_code_ids
+    } =
+  let names = For_names.increase_counts names in
+  let continuations = For_continuations.increase_counts continuations in
+  let continuations_with_traps =
+    For_continuations.increase_counts continuations_with_traps
+  in
+  let continuations_in_trap_actions =
+    For_continuations.increase_counts continuations_in_trap_actions
+  in
+  let function_slots_in_projections =
+    For_function_slots.increase_counts function_slots_in_projections
+  in
+  let value_slots_in_projections =
+    For_value_slots.increase_counts value_slots_in_projections
+  in
+  let function_slots_in_declarations =
+    For_function_slots.increase_counts function_slots_in_declarations
+  in
+  let value_slots_in_declarations =
+    For_value_slots.increase_counts value_slots_in_declarations
+  in
+  let code_ids = For_code_ids.increase_counts code_ids in
+  let newer_version_of_code_ids =
+    For_code_ids.increase_counts newer_version_of_code_ids
+  in
+  { names;
+    continuations;
+    continuations_with_traps;
+    continuations_in_trap_actions;
+    function_slots_in_projections;
+    value_slots_in_projections;
+    function_slots_in_declarations;
+    value_slots_in_declarations;
+    code_ids;
+    newer_version_of_code_ids
+  }

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -189,3 +189,5 @@ val fold_continuations_including_in_trap_actions :
   t -> init:'a -> f:('a -> Continuation.t -> 'a) -> 'a
 
 val fold_code_ids : t -> init:'a -> f:('a -> Code_id.t -> 'a) -> 'a
+
+val increase_counts : t -> t

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -778,6 +778,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         in
         let code =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
+          (* CR ncourant: same for loopify *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
             ~newer_version_of ~params_arity ~num_trailing_local_params:0
             ~result_arity ~result_types:Unknown
@@ -793,6 +794,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
               (Inlining_history.Absolute.empty
                  (Compilation_unit.get_current_exn ()))
             ~relative_history:Inlining_history.Relative.empty
+            ~loopify:Never_loopify
         in
         Flambda.Static_const_or_code.create_code code
     in

--- a/middle_end/flambda2/simplify/env/closure_info.ml
+++ b/middle_end/flambda2/simplify/env/closure_info.ml
@@ -19,7 +19,8 @@ type t =
   | Closure of
       { code_id : Code_id.t;
         return_continuation : Continuation.t;
-        exn_continuation : Continuation.t
+        exn_continuation : Continuation.t;
+        my_closure : Variable.t
       }
 
 let [@ocamlformat "disable"] print ppf = function
@@ -27,23 +28,25 @@ let [@ocamlformat "disable"] print ppf = function
     Format.fprintf ppf "not_in_a_closure"
   | In_a_set_of_closures_but_not_yet_in_a_specific_closure ->
     Format.fprintf ppf "in_a_set_of_closures"
-  | Closure { code_id; return_continuation; exn_continuation; } ->
+  | Closure { code_id; return_continuation; exn_continuation; my_closure } ->
     Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(code_id@ %a)@]@ \
       @[<hov 1>(return_continuation@ %a)@]@ \
-      @[<hov 1>(exn_continuation@ %a)@]\
+      @[<hov 1>(exn_continuation@ %a)@]@ \
+      @[<hov 1>(my_closure@ %a)@]\
       )@]"
       Code_id.print code_id
       Continuation.print return_continuation
       Continuation.print exn_continuation
+      Variable.print my_closure
 
 let not_in_a_closure = Not_in_a_closure
 
 let in_a_set_of_closures =
   In_a_set_of_closures_but_not_yet_in_a_specific_closure
 
-let in_a_closure code_id ~return_continuation ~exn_continuation =
-  Closure { code_id; return_continuation; exn_continuation }
+let in_a_closure code_id ~return_continuation ~exn_continuation ~my_closure =
+  Closure { code_id; return_continuation; exn_continuation; my_closure }
 
 type in_or_out_of_closure =
   | In_a_closure

--- a/middle_end/flambda2/simplify/env/continuation_uses.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses.ml
@@ -103,3 +103,6 @@ let get_typing_env_no_more_than_one_use t =
   | _ :: _ ->
     Misc.fatal_errorf "Only zero or one continuation use(s) expected:@ %a" print
       t
+
+let mark_non_inlinable t =
+  { t with uses = List.map U.mark_non_inlinable t.uses }

--- a/middle_end/flambda2/simplify/env/continuation_uses.mli
+++ b/middle_end/flambda2/simplify/env/continuation_uses.mli
@@ -52,3 +52,5 @@ val get_typing_env_no_more_than_one_use :
   t -> Flambda2_types.Typing_env.t option
 
 val union : t -> t -> t
+
+val mark_non_inlinable : t -> t

--- a/middle_end/flambda2/simplify/env/continuation_uses_env.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses_env.ml
@@ -71,3 +71,9 @@ let remove t cont =
   { continuation_uses = Continuation.Map.remove cont t.continuation_uses }
 
 let delete_continuation_uses = remove
+
+let mark_non_inlinable { continuation_uses } =
+  let continuation_uses =
+    Continuation.Map.map Continuation_uses.mark_non_inlinable continuation_uses
+  in
+  { continuation_uses }

--- a/middle_end/flambda2/simplify/env/continuation_uses_env.mli
+++ b/middle_end/flambda2/simplify/env/continuation_uses_env.mli
@@ -27,3 +27,5 @@ val get_continuation_uses : t -> Continuation.t -> Continuation_uses.t option
 val remove : t -> Continuation.t -> t
 
 val union : t -> t -> t
+
+val mark_non_inlinable : t -> t

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -44,7 +44,8 @@ type t =
     closure_info : Closure_info.t;
     get_imported_code : unit -> Exported_code.t;
     all_code : Code.t Code_id.Map.t;
-    inlining_history_tracker : Inlining_history.Tracker.t
+    inlining_history_tracker : Inlining_history.Tracker.t;
+    loopify_state : Loopify_state.t
   }
 
 let print_debuginfo ppf dbg =
@@ -60,6 +61,7 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
                 do_not_rebuild_terms; closure_info;
                 unit_toplevel_return_continuation; all_code;
                 get_imported_code = _; inlining_history_tracker = _;
+                loopify_state
               } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(round@ %d)@]@ \
@@ -75,7 +77,8 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
       @[<hov 1>(cse@ @[<hov 1>%a@])@]@ \
       @[<hov 1>(do_not_rebuild_terms@ %b)@]@ \
       @[<hov 1>(closure_info@ %a)@]@ \
-      @[<hov 1>(all_code@ %a)@]\
+      @[<hov 1>(all_code@ %a)@]@ \
+      @[<hov 1>(loopify_state@ %a)@]\
       )@]"
     round
     TE.print typing_env
@@ -91,6 +94,7 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
     do_not_rebuild_terms
     Closure_info.print closure_info
     (Code_id.Map.print Code.print) all_code
+    Loopify_state.print loopify_state
 
 let create ~round ~(resolver : resolver)
     ~(get_imported_names : get_imported_names)
@@ -119,7 +123,8 @@ let create ~round ~(resolver : resolver)
     all_code = Code_id.Map.empty;
     get_imported_code;
     inlining_history_tracker =
-      Inlining_history.Tracker.empty (Compilation_unit.get_current_exn ())
+      Inlining_history.Tracker.empty (Compilation_unit.get_current_exn ());
+    loopify_state = Loopify_state.do_not_loopify
   }
 
 let all_code t = t.all_code
@@ -178,7 +183,8 @@ let enter_set_of_closures
       closure_info = _;
       get_imported_code;
       all_code;
-      inlining_history_tracker
+      inlining_history_tracker;
+      loopify_state = _
     } =
   { round;
     typing_env = TE.closure_env typing_env;
@@ -195,7 +201,8 @@ let enter_set_of_closures
     closure_info = Closure_info.in_a_set_of_closures;
     get_imported_code;
     all_code;
-    inlining_history_tracker
+    inlining_history_tracker;
+    loopify_state = Loopify_state.do_not_loopify
   }
 
 let define_variable t var kind =
@@ -478,10 +485,11 @@ let set_rebuild_terms t = { t with do_not_rebuild_terms = false }
 let are_rebuilding_terms t =
   Are_rebuilding_terms.of_bool (not t.do_not_rebuild_terms)
 
-let enter_closure code_id ~return_continuation ~exn_continuation t =
+let enter_closure code_id ~return_continuation ~exn_continuation ~my_closure t =
   { t with
     closure_info =
       Closure_info.in_a_closure code_id ~return_continuation ~exn_continuation
+        ~my_closure
   }
 
 let closure_info t = t.closure_info
@@ -535,3 +543,7 @@ let generate_phantom_lets t =
   (* It would be a waste of time generating phantom lets when not rebuilding
      terms, since they have no effect on cost metrics. *)
   && Are_rebuilding_terms.are_rebuilding (are_rebuilding_terms t)
+
+let loopify_state t = t.loopify_state
+
+let set_loopify_state loopify_state t = { t with loopify_state }

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -182,6 +182,7 @@ val enter_closure :
   Code_id.t ->
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
+  my_closure:Variable.t ->
   t ->
   t
 
@@ -201,3 +202,7 @@ val inlining_history_tracker : t -> Inlining_history.Tracker.t
 val set_inlining_history_tracker : Inlining_history.Tracker.t -> t -> t
 
 val relative_history : t -> Inlining_history.Relative.t
+
+val loopify_state : t -> Loopify_state.t
+
+val set_loopify_state : Loopify_state.t -> t -> t

--- a/middle_end/flambda2/simplify/env/one_continuation_use.ml
+++ b/middle_end/flambda2/simplify/env/one_continuation_use.ml
@@ -40,3 +40,8 @@ let use_kind t = t.kind
 let arg_types t = t.arg_types
 
 let env_at_use t = t.env
+
+let mark_non_inlinable t =
+  match t.kind with
+  | Inlinable -> { t with kind = Non_inlinable { escaping = false } }
+  | Non_inlinable _ -> t

--- a/middle_end/flambda2/simplify/env/one_continuation_use.mli
+++ b/middle_end/flambda2/simplify/env/one_continuation_use.mli
@@ -35,3 +35,5 @@ val use_kind : t -> Continuation_use_kind.t
 val arg_types : t -> T.t list
 
 val env_at_use : t -> DE.t
+
+val mark_non_inlinable : t -> t

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -195,6 +195,15 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
     in
     if not (Code_or_metadata.code_present code_or_metadata)
     then Missing_code
+    else if Loopify_attribute.was_loopified
+              (Code_metadata.loopify
+                 (Code_or_metadata.code_metadata code_or_metadata))
+            &&
+            match inlined with
+            | Unroll _ -> true
+            | Never_inlined | Default_inlined | Always_inlined | Hint_inlined ->
+              false
+    then Unroll_attribute_used_with_loopified_function
     else
       (* The unrolling process is rather subtle, but it boils down to two steps:
 

--- a/middle_end/flambda2/simplify/loopify_state.ml
+++ b/middle_end/flambda2/simplify/loopify_state.ml
@@ -2,11 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                     Nathanaëlle Courant, OCamlPro                      *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2022 OCamlPro SAS                                          *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,13 +12,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Flambda
+type t =
+  | Do_not_loopify
+  | Loopify of Continuation.t
 
-val simplify_let_cont :
-  simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  Let_cont.t Simplify_common.expr_simplifier
+let print ppf = function
+  | Do_not_loopify -> Format.fprintf ppf "do_not_loopify"
+  | Loopify cont ->
+    Format.fprintf ppf "@[<hov 1>(loopify@ %a)@]" Continuation.print cont
 
-val simplify_as_recursive_let_cont :
-  simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  (Expr.t * Continuation_handler.t Continuation.Map.t)
-  Simplify_common.expr_simplifier
+let do_not_loopify = Do_not_loopify
+
+let loopify cont = Loopify cont

--- a/middle_end/flambda2/simplify/loopify_state.mli
+++ b/middle_end/flambda2/simplify/loopify_state.mli
@@ -2,10 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                        Guillaume Bury, OCamlPro                        *)
+(*                     Nathanaëlle Courant, OCamlPro                      *)
 (*                                                                        *)
-(*   Copyright 2021--2021 OCamlPro SAS                                    *)
-(*   Copyright 2021--2021 Jane Street Group LLC                           *)
+(*   Copyright 2022 OCamlPro SAS                                          *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,30 +13,11 @@
 (**************************************************************************)
 
 type t = private
-  | Not_in_a_closure
-  | In_a_set_of_closures_but_not_yet_in_a_specific_closure
-  | Closure of
-      { code_id : Code_id.t;
-        return_continuation : Continuation.t;
-        exn_continuation : Continuation.t;
-        my_closure : Variable.t
-      }
+  | Do_not_loopify
+  | Loopify of Continuation.t
 
 val print : Format.formatter -> t -> unit
 
-val not_in_a_closure : t
+val do_not_loopify : t
 
-val in_a_set_of_closures : t
-
-val in_a_closure :
-  Code_id.t ->
-  return_continuation:Continuation.t ->
-  exn_continuation:Continuation.t ->
-  my_closure:Variable.t ->
-  t
-
-type in_or_out_of_closure =
-  | In_a_closure
-  | Not_in_a_closure
-
-val in_or_out_of_closure : t -> in_or_out_of_closure
+val loopify : Continuation.t -> t

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -128,7 +128,7 @@ let rebuild_non_inlined_direct_full_application apply ~use_id ~exn_cont_use_id
   in
   after_rebuild expr uacc
 
-let simplify_direct_full_application ~simplify_expr dacc apply function_type
+let simplify_direct_full_application0 ~simplify_expr dacc apply function_type
     ~params_arity ~result_arity ~(result_types : _ Or_unknown_or_bottom.t)
     ~down_to_up ~coming_from_indirect ~callee's_code_metadata =
   let inlined =
@@ -273,6 +273,47 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
       ~rebuild:
         (rebuild_non_inlined_direct_full_application apply ~use_id
            ~exn_cont_use_id ~result_arity ~coming_from_indirect)
+
+let loopify_decision_for_call dacc apply =
+  let denv = DA.denv dacc in
+  match DE.closure_info denv with
+  | Not_in_a_closure | In_a_set_of_closures_but_not_yet_in_a_specific_closure ->
+    Loopify_state.do_not_loopify
+  | Closure { return_continuation; exn_continuation; my_closure; _ } ->
+    let tenv = DE.typing_env denv in
+    let[@inline always] canon simple =
+      Simple.without_coercion (TE.get_canonical_simple_exn tenv simple)
+    in
+    if Simple.equal (canon (Simple.var my_closure)) (canon (Apply.callee apply))
+       && (match Apply.continuation apply with
+          | Never_returns ->
+            (* If we never return, then this call is a tail-call *)
+            true
+          | Return apply_return_continuation ->
+            Continuation.equal apply_return_continuation return_continuation)
+       && Exn_continuation.equal
+            (Apply.exn_continuation apply)
+            (Exn_continuation.create ~exn_handler:exn_continuation
+               ~extra_args:[])
+    then DE.loopify_state denv
+    else Loopify_state.do_not_loopify
+
+let simplify_self_tail_call dacc apply self_cont ~down_to_up =
+  Simplify_apply_cont_expr.simplify_apply_cont dacc
+    (Apply_cont_expr.create self_cont ~args:(Apply.args apply)
+       ~dbg:(Apply.dbg apply))
+    ~down_to_up
+
+let simplify_direct_full_application ~simplify_expr dacc apply function_type
+    ~params_arity ~result_arity ~result_types ~down_to_up ~coming_from_indirect
+    ~callee's_code_metadata =
+  match loopify_decision_for_call dacc apply with
+  | Loopify self_cont ->
+    simplify_self_tail_call dacc apply self_cont ~down_to_up
+  | Do_not_loopify ->
+    simplify_direct_full_application0 ~simplify_expr dacc apply function_type
+      ~params_arity ~result_arity ~result_types ~down_to_up
+      ~coming_from_indirect ~callee's_code_metadata
 
 (* CR mshinwell: need to work out what to do for local alloc transformations
    when there are zero args. *)
@@ -517,6 +558,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
           ~is_my_closure_used:
             (Function_params_and_body.is_my_closure_used params_and_body)
           ~inlining_decision:Stub ~absolute_history ~relative_history
+          ~loopify:Never_loopify
       in
       Static_const_or_code.create_code code
     in

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -47,6 +47,8 @@ type simplify_function_body =
   exn_continuation:Continuation.t ->
   return_cont_scope:Scope.t ->
   exn_cont_scope:Scope.t ->
+  loopify_state:Loopify_state.t ->
+  params:Bound_parameters.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
 let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -90,6 +90,8 @@ type simplify_function_body =
   exn_continuation:Continuation.t ->
   return_cont_scope:Scope.t ->
   exn_cont_scope:Scope.t ->
+  loopify_state:Loopify_state.t ->
+  params:Bound_parameters.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
 val simplify_projection :

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -134,13 +134,8 @@ and simplify_function_body dacc expr ~return_continuation ~return_arity
       Expr.create_apply_cont (Apply_cont_expr.create cont ~args ~dbg:[])
     in
     let handlers =
-      let fresh_params = Bound_parameters.rename params in
-      let renaming =
-        Bound_parameters.renaming params ~guaranteed_fresh:fresh_params
-      in
       Continuation.Map.singleton cont
-        (Continuation_handler.create fresh_params
-           ~handler:(Expr.apply_renaming expr renaming)
+        (Continuation_handler.create params ~handler:expr
            ~free_names_of_handler:Unknown ~is_exn_handler:false)
     in
     simplify_toplevel_common dacc

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -120,11 +120,36 @@ let rec simplify_expr dacc expr ~down_to_up =
         EB.rebuild_invalid uacc (Message message) ~after_rebuild)
 
 and simplify_function_body dacc expr ~return_continuation ~return_arity
-    ~exn_continuation ~return_cont_scope ~exn_cont_scope =
-  simplify_toplevel_common dacc
-    (fun dacc -> simplify_expr dacc expr)
-    ~in_or_out_of_closure:In_a_closure ~return_continuation ~return_arity
     ~exn_continuation ~return_cont_scope ~exn_cont_scope
+    ~(loopify_state : Loopify_state.t) ~params =
+  match loopify_state with
+  | Do_not_loopify ->
+    simplify_toplevel_common dacc
+      (fun dacc -> simplify_expr dacc expr)
+      ~in_or_out_of_closure:In_a_closure ~return_continuation ~return_arity
+      ~exn_continuation ~return_cont_scope ~exn_cont_scope
+  | Loopify cont ->
+    let call_self_cont_expr =
+      let args = Bound_parameters.simples params in
+      Expr.create_apply_cont (Apply_cont_expr.create cont ~args ~dbg:[])
+    in
+    let handlers =
+      let fresh_params = Bound_parameters.rename params in
+      let renaming =
+        Bound_parameters.renaming params ~guaranteed_fresh:fresh_params
+      in
+      Continuation.Map.singleton cont
+        (Continuation_handler.create fresh_params
+           ~handler:(Expr.apply_renaming expr renaming)
+           ~free_names_of_handler:Unknown ~is_exn_handler:false)
+    in
+    simplify_toplevel_common dacc
+      (fun dacc ->
+        Simplify_let_cont_expr.simplify_as_recursive_let_cont ~simplify_expr
+          dacc
+          (call_self_cont_expr, handlers))
+      ~in_or_out_of_closure:In_a_closure ~return_continuation ~return_arity
+      ~exn_continuation ~return_cont_scope ~exn_cont_scope
 
 and[@inline always] simplify_let dacc let_expr ~down_to_up =
   Simplify_let_expr.simplify_let ~simplify_expr ~simplify_function_body dacc

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -833,12 +833,18 @@ let prepare_to_rebuild_one_recursive_let_cont_handler cont params
 
 let after_downwards_traversal_of_one_recursive_let_cont_handler cont
     unboxing_decisions ~down_to_up params ~original_cont_scope
-    ~cont_uses_in_body dacc ~rebuild:rebuild_handler =
+    ~cont_uses_in_body ~body_continuation_uses_env dacc ~rebuild:rebuild_handler
+    =
   let dacc = DA.map_data_flow dacc ~f:(Data_flow.exit_continuation cont) in
+  let handler_continuation_uses_env = DA.continuation_uses_env dacc in
+  let continuation_uses_env =
+    CUE.union body_continuation_uses_env
+      (CUE.mark_non_inlinable handler_continuation_uses_env)
+  in
   let arg_types_by_use_id =
     (* At this point all uses (in both the body and the handler) of [cont] are
        in [dacc]. *)
-    match CUE.get_continuation_uses (DA.continuation_uses_env dacc) cont with
+    match CUE.get_continuation_uses continuation_uses_env cont with
     | None ->
       ListLabels.map (Bound_parameters.to_list params) ~f:(fun _ ->
           Apply_cont_rewrite_id.Map.empty)
@@ -855,7 +861,7 @@ let after_downwards_traversal_of_one_recursive_let_cont_handler cont
     DA.map_data_flow dacc ~f:(fun data_flow ->
         Data_flow.add_extra_params_and_args cont extra_params_and_args data_flow)
   in
-  let cont_uses_env = CUE.remove (DA.continuation_uses_env dacc) cont in
+  let cont_uses_env = CUE.remove continuation_uses_env cont in
   let dacc = DA.with_continuation_uses_env dacc ~cont_uses_env in
   down_to_up dacc
     ~rebuild:
@@ -891,14 +897,16 @@ let simplify_recursive_let_cont_handlers ~simplify_expr ~denv_before_body
   let dacc =
     DA.map_denv dacc ~f:(fun denv -> DE.set_at_unit_toplevel_state denv false)
   in
+  let body_continuation_uses_env = DA.continuation_uses_env dacc in
   let cont_uses_in_body =
-    CUE.get_continuation_uses (DA.continuation_uses_env dacc) cont
+    CUE.get_continuation_uses body_continuation_uses_env cont
   in
   match cont_uses_in_body with
   | None ->
     let rebuild uacc ~after_rebuild = after_rebuild None uacc in
     down_to_up dacc ~rebuild
   | Some cont_uses_in_body ->
+    let dacc = DA.with_continuation_uses_env dacc ~cont_uses_env:CUE.empty in
     let arg_types_by_use_id_in_body =
       Continuation_uses.get_arg_types_by_use_id cont_uses_in_body
     in
@@ -933,7 +941,7 @@ let simplify_recursive_let_cont_handlers ~simplify_expr ~denv_before_body
       ~down_to_up:
         (after_downwards_traversal_of_one_recursive_let_cont_handler cont
            unboxing_decisions params ~original_cont_scope ~down_to_up
-           ~cont_uses_in_body)
+           ~cont_uses_in_body ~body_continuation_uses_env)
 
 let rebuild_recursive_let_cont_expr are_rebuilding_terms ~body
     ~free_names_of_body ~handlers =

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -1024,12 +1024,9 @@ let simplify_recursive_let_cont_stage1 ~simplify_expr ~denv_before_body ~body
          ~original_cont_scope ~down_to_up)
 
 let simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up ~body
-    rec_handlers =
-  let module CH = Continuation_handler in
-  assert (not (Continuation_handlers.contains_exn_handler rec_handlers));
+    handlers =
   let denv_before_body = DA.denv dacc in
   let original_cont_scope = DE.get_continuation_scope denv_before_body in
-  let handlers = Continuation_handlers.to_map rec_handlers in
   let cont, cont_handler =
     match Continuation.Map.bindings handlers with
     | [] | _ :: _ :: _ ->
@@ -1038,14 +1035,22 @@ let simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up ~body
          yet implemented"
     | [c] -> c
   in
-  CH.pattern_match cont_handler
+  Continuation_handler.pattern_match cont_handler
     ~f:
       (simplify_recursive_let_cont_stage1 ~simplify_expr ~denv_before_body ~body
          cont ~original_cont_scope ~down_to_up dacc)
 
+let simplify_as_recursive_let_cont ~simplify_expr dacc (body, handlers)
+    ~down_to_up =
+  simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up ~body
+    handlers
+
 let simplify_recursive_let_cont ~simplify_expr dacc recs ~down_to_up =
-  Recursive_let_cont_handlers.pattern_match recs
-    ~f:(simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up)
+  Recursive_let_cont_handlers.pattern_match recs ~f:(fun ~body rec_handlers ->
+      assert (not (Continuation_handlers.contains_exn_handler rec_handlers));
+      let handlers = Continuation_handlers.to_map rec_handlers in
+      simplify_recursive_let_cont_stage0 ~simplify_expr dacc ~down_to_up ~body
+        handlers)
 
 let simplify_let_cont ~simplify_expr dacc (let_cont : Let_cont.t) ~down_to_up =
   match let_cont with

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -765,6 +765,10 @@ let rebuild_recursive_let_cont_handlers cont ~params ~original_cont_scope
       in
       uacc, Some handlers
   in
+  let name_occurrences =
+    Name_occurrences.increase_counts (UA.name_occurrences uacc)
+  in
+  let uacc = UA.with_name_occurrences uacc ~name_occurrences in
   after_rebuild handlers uacc
 
 let after_one_recursive_let_cont_handler_rebuilt cont ~original_cont_scope

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -29,7 +29,7 @@ module C = Simplify_set_of_closures_context
 let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
     ~my_depth function_slot_opt ~closure_bound_names_inside_function
     ~inlining_arguments ~absolute_history code_id ~return_continuation
-    ~exn_continuation ~return_cont_params code_metadata =
+    ~exn_continuation ~return_cont_params ~loopify_state code_metadata =
   let dacc = C.dacc_inside_functions context in
   let num_leading_heap_params =
     Code_metadata.num_leading_heap_params code_metadata
@@ -85,6 +85,8 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
     LCS.add_to_denv ~maybe_already_defined:() denv
       (DA.get_lifted_constants outer_dacc)
     |> DE.enter_closure code_id ~return_continuation ~exn_continuation
+         ~my_closure
+    |> DE.set_loopify_state loopify_state
     |> DE.increment_continuation_scope
   in
   let denv = DE.add_parameters_with_unknown_types denv return_cont_params in
@@ -143,6 +145,7 @@ type simplify_function_body_result =
     free_names_of_code : NO.t;
     return_cont_uses : Continuation_uses.t option;
     is_my_closure_used : bool;
+    recursive : Recursive.t;
     uacc_after_upwards_traversal : UA.t
   }
 
@@ -151,11 +154,17 @@ let simplify_function_body context ~outer_dacc function_slot_opt
     code_id ~return_cont_params code ~return_continuation ~exn_continuation
     params ~body ~my_closure ~is_my_closure_used:_ ~my_region ~my_depth
     ~free_names_of_body:_ =
+  let loopify_state =
+    if Loopify_attribute.should_loopify (Code.loopify code)
+    then Loopify_state.loopify (Continuation.create ~name:"self" ())
+    else Loopify_state.do_not_loopify
+  in
   let dacc_at_function_entry =
     dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
       ~my_depth function_slot_opt ~closure_bound_names_inside_function
       ~inlining_arguments ~absolute_history code_id ~return_continuation
-      ~exn_continuation ~return_cont_params (Code.code_metadata code)
+      ~exn_continuation ~return_cont_params ~loopify_state
+      (Code.code_metadata code)
   in
   let dacc = dacc_at_function_entry in
   if not (DA.no_lifted_constants dacc)
@@ -167,7 +176,7 @@ let simplify_function_body context ~outer_dacc function_slot_opt
     C.simplify_function_body context dacc body ~return_continuation
       ~exn_continuation ~return_arity:(Code.result_arity code)
       ~return_cont_scope:Scope.initial
-      ~exn_cont_scope:(Scope.next Scope.initial)
+      ~exn_cont_scope:(Scope.next Scope.initial) ~loopify_state ~params
   with
   | body, uacc ->
     let dacc_after_body = UA.creation_dacc uacc in
@@ -185,6 +194,11 @@ let simplify_function_body context ~outer_dacc function_slot_opt
     let is_my_closure_used = NO.mem_var free_names_of_body my_closure in
     let previously_free_depth_variables =
       NO.create_variables (C.previously_free_depth_variables context) NM.normal
+    in
+    let recursive : Recursive.t =
+      if Name_occurrences.mem_var free_names_of_body my_depth
+      then Recursive
+      else Non_recursive
     in
     let free_names_of_code =
       free_names_of_body
@@ -216,6 +230,7 @@ let simplify_function_body context ~outer_dacc function_slot_opt
       free_names_of_code;
       return_cont_uses;
       is_my_closure_used;
+      recursive;
       uacc_after_upwards_traversal = uacc
     }
   | exception Misc.Fatal_error ->
@@ -329,6 +344,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
         free_names_of_code;
         return_cont_uses;
         is_my_closure_used;
+        recursive;
         uacc_after_upwards_traversal
       } =
     Function_params_and_body.pattern_match
@@ -355,7 +371,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
     let decision =
       Function_decl_inlining_decision.make_decision ~inlining_arguments
         ~inline:(Code.inline code) ~stub:(Code.stub code) ~cost_metrics
-        ~is_a_functor:(Code.is_a_functor code) ~recursive:(Code.recursive code)
+        ~is_a_functor:(Code.is_a_functor code) ~recursive
     in
     Inlining_report.record_decision_at_function_definition ~absolute_history
       ~code_metadata:(Code.code_metadata code) ~pass:After_simplify
@@ -387,6 +403,19 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       in
       DA.with_slot_offsets outer_dacc ~slot_offsets
   in
+  let loopify : Loopify_attribute.t =
+    match Code.loopify code with
+    | Always_loopify ->
+      (* CR ncourant: in this case, the function had a [@loop] attribute, so we
+         want to keep it in case we perform another pass. It might be better to
+         only keep it that way if it is still recursive, however, but this is
+         simpler. *)
+      Always_loopify
+    | Never_loopify -> Never_loopify
+    | Already_loopified -> Already_loopified
+    | Default_loopify_and_tailrec -> Already_loopified
+    | Default_loopify_and_not_tailrec -> Never_loopify
+  in
   let code =
     Rebuilt_static_const.create_code
       (DA.are_rebuilding_terms dacc_after_body)
@@ -400,7 +429,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       ~poll_attribute:(Code.poll_attribute code) ~is_a_functor
       ~recursive:(Code.recursive code) ~cost_metrics ~inlining_arguments
       ~dbg:(Code.dbg code) ~is_tupled:(Code.is_tupled code) ~is_my_closure_used
-      ~inlining_decision ~absolute_history ~relative_history
+      ~inlining_decision ~absolute_history ~relative_history ~loopify
   in
   { code_id; code = Some code; outer_dacc }
 

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -33,6 +33,7 @@ type t =
   | Max_inlining_depth_exceeded
   | Recursion_depth_exceeded
   | Never_inlined_attribute
+  | Unroll_attribute_used_with_loopified_function
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
@@ -64,6 +65,8 @@ let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "Recursion_depth_exceeded"
   | Never_inlined_attribute ->
     Format.fprintf ppf "Never_inlined_attribute"
+  | Unroll_attribute_used_with_loopified_function ->
+    Format.fprintf ppf "Unroll_attribute_used_with_loopified_function"
   | Attribute_always ->
     Format.fprintf ppf "Attribute_always"
   | Definition_says_inline { was_inline_always } ->
@@ -126,6 +129,10 @@ let can_inline (t : t) : can_inline =
        attribute when we stop unrolling, which is fine *)
     Do_not_inline
       { warn_if_attribute_ignored = false; because_of_definition = true }
+  | Unroll_attribute_used_with_loopified_function ->
+    (* We have an [@unrolled] attribute, but can't unroll loopified functions *)
+    Do_not_inline
+      { warn_if_attribute_ignored = true; because_of_definition = true }
   | Attribute_unroll unroll_to ->
     Inline { unroll_to = Some unroll_to; was_inline_always = false }
   | Definition_says_inline { was_inline_always } ->
@@ -156,6 +163,11 @@ let report_reason fmt t =
     Format.fprintf fmt "the@ maximum@ recursion@ depth@ has@ been@ exceeded"
   | Never_inlined_attribute ->
     Format.fprintf fmt "the@ call@ has@ an@ attribute@ forbidding@ inlining"
+  | Unroll_attribute_used_with_loopified_function ->
+    Format.fprintf fmt
+      "the@ code@ of@ this@ function@ has@ been@ transformed@ to@ a@ loop,@ \
+       which@ cannot@ be@ unrolled@ yet@ (consider@ adding@ [@loop never]@ to@ \
+       the@ definition)"
   | Attribute_always ->
     Format.fprintf fmt "the@ call@ has@ an@ [@@inline always]@ attribute"
   | Attribute_unroll n ->

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -26,6 +26,7 @@ type t =
   | Max_inlining_depth_exceeded
   | Recursion_depth_exceeded
   | Never_inlined_attribute
+  | Unroll_attribute_used_with_loopified_function
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -204,8 +204,8 @@ let relative_history t = t.relative_history
 
 let position t = t.position
 
-let free_names
-    { callee;
+let free_names_except_callee
+    { callee = _;
       continuation;
       exn_continuation;
       args;
@@ -219,12 +219,16 @@ let free_names
       region
     } =
   Name_occurrences.union_list
-    [ Simple.free_names callee;
-      Result_continuation.free_names continuation;
+    [ Result_continuation.free_names continuation;
       Exn_continuation.free_names exn_continuation;
       Simple.List.free_names args;
       Call_kind.free_names call_kind;
       Name_occurrences.singleton_variable region Name_mode.normal ]
+
+let free_names t =
+  Name_occurrences.union
+    (Simple.free_names t.callee)
+    (free_names_except_callee t)
 
 let apply_renaming
     ({ callee;

--- a/middle_end/flambda2/terms/apply_expr.mli
+++ b/middle_end/flambda2/terms/apply_expr.mli
@@ -19,6 +19,8 @@
 
 type t
 
+val free_names_except_callee : t -> Name_occurrences.t
+
 include Expr_std.S with type t := t
 
 include Contains_ids.S with type t := t

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -70,6 +70,8 @@ module type Code_metadata_accessors_result_type = sig
   val absolute_history : 'a t -> Inlining_history.Absolute.t
 
   val relative_history : 'a t -> Inlining_history.Relative.t
+
+  val loopify : 'a t -> Loopify_attribute.t
 end
 
 module Code_metadata_accessors : functor (X : Metadata_view_type) ->
@@ -99,6 +101,7 @@ type 'a create_type =
   inlining_decision:Function_decl_inlining_decision_type.t ->
   absolute_history:Inlining_history.Absolute.t ->
   relative_history:Inlining_history.Relative.t ->
+  loopify:Loopify_attribute.t ->
   'a
 
 val createk : (t -> 'a) -> 'a create_type

--- a/middle_end/flambda2/terms/loopify_attribute.ml
+++ b/middle_end/flambda2/terms/loopify_attribute.ml
@@ -1,0 +1,50 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                     Nathanaëlle Courant, OCamlPro                      *)
+(*                                                                        *)
+(*   Copyright 2022 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type t =
+  | Always_loopify
+  | Never_loopify
+  | Already_loopified
+  | Default_loopify_and_tailrec
+  | Default_loopify_and_not_tailrec
+
+let print ppf = function
+  | Always_loopify -> Format.fprintf ppf "Always_loopify"
+  | Never_loopify -> Format.fprintf ppf "Never_loopify"
+  | Already_loopified -> Format.fprintf ppf "Already_loopified"
+  | Default_loopify_and_tailrec ->
+    Format.fprintf ppf "Default_loopify_and_tailrec"
+  | Default_loopify_and_not_tailrec ->
+    Format.fprintf ppf "Default_loopify_and_not_tailrec"
+
+let should_loopify = function
+  | Always_loopify | Default_loopify_and_tailrec -> true
+  | Never_loopify | Already_loopified | Default_loopify_and_not_tailrec -> false
+
+let was_loopified = function
+  | Always_loopify | Already_loopified | Default_loopify_and_tailrec -> true
+  | Never_loopify | Default_loopify_and_not_tailrec -> false
+
+let equal t1 t2 =
+  match t1, t2 with
+  | Always_loopify, Always_loopify
+  | Never_loopify, Never_loopify
+  | Already_loopified, Already_loopified
+  | Default_loopify_and_tailrec, Default_loopify_and_tailrec
+  | Default_loopify_and_not_tailrec, Default_loopify_and_not_tailrec ->
+    true
+  | ( ( Always_loopify | Never_loopify | Already_loopified
+      | Default_loopify_and_tailrec | Default_loopify_and_not_tailrec ),
+      _ ) ->
+    false

--- a/middle_end/flambda2/terms/loopify_attribute.mli
+++ b/middle_end/flambda2/terms/loopify_attribute.mli
@@ -2,10 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                        Guillaume Bury, OCamlPro                        *)
+(*                     Nathanaëlle Courant, OCamlPro                      *)
 (*                                                                        *)
-(*   Copyright 2021--2021 OCamlPro SAS                                    *)
-(*   Copyright 2021--2021 Jane Street Group LLC                           *)
+(*   Copyright 2022 OCamlPro SAS                                          *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,31 +12,17 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = private
-  | Not_in_a_closure
-  | In_a_set_of_closures_but_not_yet_in_a_specific_closure
-  | Closure of
-      { code_id : Code_id.t;
-        return_continuation : Continuation.t;
-        exn_continuation : Continuation.t;
-        my_closure : Variable.t
-      }
+type t =
+  | Always_loopify
+  | Never_loopify
+  | Already_loopified
+  | Default_loopify_and_tailrec
+  | Default_loopify_and_not_tailrec
 
 val print : Format.formatter -> t -> unit
 
-val not_in_a_closure : t
+val should_loopify : t -> bool
 
-val in_a_set_of_closures : t
+val was_loopified : t -> bool
 
-val in_a_closure :
-  Code_id.t ->
-  return_continuation:Continuation.t ->
-  exn_continuation:Continuation.t ->
-  my_closure:Variable.t ->
-  t
-
-type in_or_out_of_closure =
-  | In_a_closure
-  | Not_in_a_closure
-
-val in_or_out_of_closure : t -> in_or_out_of_closure
+val equal : t -> t -> bool

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -386,6 +386,11 @@ type check_attribute =
   | Assert of property
   | Assume of property
 
+type loop_attribute =
+  | Always_loop (* [@loop] or [@loop always] *)
+  | Never_loop (* [@loop never] *)
+  | Default_loop (* no [@loop] attribute *)
+
 type function_kind = Curried of {nlocal: int} | Tupled
 
 type let_kind = Strict | Alias | StrictOpt
@@ -407,6 +412,7 @@ type function_attribute = {
   local: local_attribute;
   check : check_attribute;
   poll: poll_attribute;
+  loop: loop_attribute;
   is_a_functor: bool;
   stub: bool;
 }
@@ -540,6 +546,7 @@ let default_function_attribute = {
   local = Default_local;
   check = Default_check ;
   poll = Default_poll;
+  loop = Default_loop;
   is_a_functor = false;
   stub = false;
 }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -299,6 +299,11 @@ type poll_attribute =
   | Error_poll (* [@poll error] *)
   | Default_poll (* no [@poll] attribute *)
 
+type loop_attribute =
+  | Always_loop (* [@loop] or [@loop always] *)
+  | Never_loop (* [@loop never] *)
+  | Default_loop (* no [@loop] attribute *)
+
 type function_kind = Curried of {nlocal: int} | Tupled
 (* [nlocal] determines how many arguments may be partially applied
    before the resulting closure must be locally allocated.
@@ -327,6 +332,7 @@ type function_attribute = {
   local: local_attribute;
   check : check_attribute;
   poll: poll_attribute;
+  loop: loop_attribute;
   is_a_functor: bool;
   stub: bool;
 }

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -564,7 +564,7 @@ let check_attribute ppf check =
   | Assume p -> fprintf ppf "assume %s@ " (check_property p)
 
 let function_attribute ppf
-    { inline; specialise; check; local; is_a_functor; stub; poll } =
+    { inline; specialise; check; local; is_a_functor; stub; poll; loop } =
   if is_a_functor then
     fprintf ppf "is_a_functor@ ";
   if stub then
@@ -590,7 +590,12 @@ let function_attribute ppf
   | Default_poll -> ()
   | Error_poll -> fprintf ppf "error_poll@ "
   end;
-  check_attribute ppf check
+  check_attribute ppf check;
+  begin match loop with
+  | Default_loop -> ()
+  | Always_loop -> fprintf ppf "always_loop@ "
+  | Never_loop -> fprintf ppf "never_loop@ "
+  end
 
 let apply_tailcall_attribute ppf = function
   | Default_tailcall -> ()

--- a/ocaml/lambda/translattribute.mli
+++ b/ocaml/lambda/translattribute.mli
@@ -53,6 +53,16 @@ val get_local_attribute
    : Parsetree.attributes
   -> Lambda.local_attribute
 
+val add_loop_attribute
+  : Lambda.lambda
+  -> Location.t
+  -> Parsetree.attributes
+  -> Lambda.lambda
+
+val get_loop_attribute
+  : Parsetree.attributes
+  -> Lambda.loop_attribute
+
 val get_and_remove_inlined_attribute
    : Typedtree.expression
   -> Lambda.inlined_attribute * Typedtree.expression

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -818,6 +818,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           specialise = Always_specialise;
           local = Never_local;
           check = Default_check;
+          loop = Never_loop;
           is_a_functor = false;
           stub = false;
           poll = Default_poll;

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -548,6 +548,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
       local = Default_local;
       poll = Default_poll;
       check = Default_check;
+      loop = Never_loop;
       is_a_functor = true;
       stub = false;
     };

--- a/ocaml/testsuite/tests/functors/functors.compilers.reference
+++ b/ocaml/testsuite/tests/functors/functors.compilers.reference
@@ -2,14 +2,14 @@
   (let
     (O =
        (module-defn(O) Functors functors.ml(12):184-279
-         (function X is_a_functor always_inline
+         (function X is_a_functor always_inline never_loop
            (let
              (cow = (function x[int] : int (apply (field 0 X) x))
               sheep = (function x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 cow sheep))))
      F =
        (module-defn(F) Functors functors.ml(17):281-392
-         (function X Y is_a_functor always_inline
+         (function X Y is_a_functor always_inline never_loop
            (let
              (cow =
                 (function x[int] : int
@@ -18,7 +18,7 @@
              (makeblock 0 cow sheep))))
      F1 =
        (module-defn(F1) Functors functors.ml(31):516-632
-         (function X Y is_a_functor always_inline
+         (function X Y is_a_functor always_inline never_loop
            (let
              (cow =
                 (function x[int] : int
@@ -27,7 +27,7 @@
              (makeblock 0 sheep))))
      F2 =
        (module-defn(F2) Functors functors.ml(36):634-784
-         (function X Y is_a_functor always_inline
+         (function X Y is_a_functor always_inline never_loop
            (let
              (X =a (makeblock 0 (field 1 X))
               Y =a (makeblock 0 (field 1 Y))
@@ -41,7 +41,7 @@
          (let
            (F =
               (module-defn(F) Functors.M functors.ml(44):849-966
-                (function X Y is_a_functor always_inline
+                (function X Y is_a_functor always_inline never_loop
                   (let
                     (cow =
                        (function x[int] : int


### PR DESCRIPTION
This re-enables loopify and prevents it from creating a lot of nested loops (since it re-enables loopify in the first commit, it should be reviewed commit-by-commit and not be squashed).