### PR TITLE
Always filter lifted constants in rebuild_let

### DIFF
--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -44,12 +44,10 @@ let rebuild_let simplify_named_result removed_operations
       (* See the comment in [simplify_let], below; this case is analogous. *)
       lifted_constants_from_defining_expr
     | Not_in_a_closure ->
-      if Are_rebuilding_terms.do_not_rebuild_terms
-           (UA.are_rebuilding_terms uacc)
-      then lifted_constants_from_defining_expr
-      else
-        LCS.fold lifted_constants_from_defining_expr ~init:LCS.empty
-          ~f:(keep_lifted_constant_only_if_used uacc)
+      (* We must filter even if not rebuilding terms, otherwise the free names
+         of the terms might get out of sync with [Data_flow]. *)
+      LCS.fold lifted_constants_from_defining_expr ~init:LCS.empty
+        ~f:(keep_lifted_constant_only_if_used uacc)
   in
   (* At this point, the free names in [uacc] are the free names of [body], plus
      all used value slots seen in the whole compilation unit. *)


### PR DESCRIPTION
Failure to filter these when not rebuilding terms (for speculative inlining) can lead to the free names of terms getting out of sync with `Data_flow`.