### PR TITLE
Add intrinsics for CMOV

### DIFF
--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -245,6 +245,7 @@ method class_of_operation op =
   | Iintop_imm(Icheckbound, _) -> Op_checkbound
   | Iintop_imm(_, _) -> Op_pure
   | Icompf _
+  | Icsel _
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue -> Op_pure
   | Ispecific _ -> Op_other

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -43,6 +43,7 @@ method! class_of_operation op =
     end
   | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Icompf _
+  | Icsel _
   | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _ | Iextcall _

--- a/backend/amd64/cfg_stack_operands.ml
+++ b/backend/amd64/cfg_stack_operands.ml
@@ -183,6 +183,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
     may_use_stack_operand_for_result map instr ~num_args:2
   | Op(Intop_imm((Iadd | Isub | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr), _)) ->
     may_use_stack_operand_for_result map instr ~num_args:1
+  | Op (Csel _) (* CR gyorsh: optimize *)
   | Op (Specific (Ilfence | Isfence | Imfence))
   | Op (Intop(Imulh _ | Imul | Idiv | Imod))
   | Op (Intop_imm ((Imulh _ | Imul | Idiv | Imod), _))
@@ -205,7 +206,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
     May_still_have_spilled_registers
   | Op (Intop Icheckbound)
   | Op (Intop_imm ((Ipopcnt | Iclz _ | Ictz _ | Icheckbound), _)) ->
-    (* should no happen *)
+    (* should not happen *)
     fatal "unexpected instruction"
   end
 

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -464,6 +464,32 @@ let emit_float_test cmp i ~(taken:X86_ast.condition -> unit) =
       I.comisd (arg i 1) (arg i 0);(* swap compare *)
       taken B                      (* taken if unordered or x<y i.e. !(x>=y) *)
 
+let emit_test i ~(taken:X86_ast.condition -> unit) = function
+  | Itruetest ->
+    output_test_zero i.arg.(0);
+    taken NE
+  | Ifalsetest ->
+    output_test_zero i.arg.(0);
+    taken E
+  | Iinttest cmp ->
+    I.cmp (arg i 1) (arg i 0);
+    taken (cond cmp)
+  | Iinttest_imm((Isigned Ceq | Isigned Cne |
+                  Iunsigned Ceq | Iunsigned Cne) as cmp, 0) ->
+    output_test_zero i.arg.(0);
+    taken (cond cmp)
+  | Iinttest_imm(cmp, n) ->
+    I.cmp (int n) (arg i 0);
+    taken (cond cmp)
+  | Ifloattest cmp ->
+    emit_float_test cmp i ~taken
+  | Ioddtest ->
+    I.test (int 1) (arg8 i 0);
+    taken NE
+  | Ieventest ->
+    I.test (int 1) (arg8 i 0);
+    taken E
+
 (* Deallocate the stack frame before a return or tail call *)
 
 let output_epilogue f =
@@ -1099,32 +1125,6 @@ let emit_instr fallthrough i =
       I.jmp (label lbl)
   | Lcondbranch(tst, lbl) ->
       let lbl = label lbl in
-      let emit_test i ~(taken:X86_ast.condition -> unit) = function
-      | Itruetest ->
-          output_test_zero i.arg.(0);
-          taken NE
-      | Ifalsetest ->
-          output_test_zero i.arg.(0);
-          taken E
-      | Iinttest cmp ->
-          I.cmp (arg i 1) (arg i 0);
-          taken (cond cmp)
-      | Iinttest_imm((Isigned Ceq | Isigned Cne |
-                      Iunsigned Ceq | Iunsigned Cne) as cmp, 0) ->
-          output_test_zero i.arg.(0);
-          taken (cond cmp)
-      | Iinttest_imm(cmp, n) ->
-          I.cmp (int n) (arg i 0);
-          taken (cond cmp)
-      | Ifloattest cmp ->
-          emit_float_test cmp i ~taken
-      | Ioddtest ->
-          I.test (int 1) (arg8 i 0);
-          taken NE
-      | Ieventest ->
-          I.test (int 1) (arg8 i 0);
-          taken E
-      in
       emit_test i tst ~taken:(fun c -> I.j c lbl)
   | Lcondbranch3(lbl0, lbl1, lbl2) ->
       I.cmp (int 1) (arg i 0);

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1031,6 +1031,15 @@ let emit_instr fallthrough i =
   | Lop(Iintop Ipopcnt) ->
       assert (!popcnt_support);
       I.popcnt (arg i 0) (res i 0)
+  | Lop(Icsel tst) ->
+    let len = Array.length i.arg in
+    let ifso = i.arg.(len - 2) in
+    let ifnot = i.arg.(len - 1) in
+    assert (Reg.same_loc ifnot i.res.(0));
+    let taken c =
+      I.cmov c (reg ifso) (res i 0)
+    in
+    emit_test i tst ~taken
   | Lop(Ispecific Irdtsc) ->
     I.rdtsc ();
     let rdx = Reg64 RDX in

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -412,7 +412,7 @@ let output_test_zero arg =
 
 (* Output a floating-point compare and branch *)
 
-let emit_float_test cmp i lbl =
+let emit_float_test cmp i ~(taken:X86_ast.condition -> unit) =
   (* Effect of comisd on flags and conditional branches:
                      ZF PF CF  cond. branches taken
         unordered     1  1  1  je, jb, jbe, jp
@@ -425,44 +425,44 @@ let emit_float_test cmp i lbl =
   match cmp with
   | CFeq when arg i 1 = arg i 0 ->
       I.ucomisd (arg i 1) (arg i 0);
-      I.j NP lbl
+      taken NP
   | CFeq ->
       let next = new_label() in
       I.ucomisd (arg i 1) (arg i 0);
-      I.jp (label next);          (* skip if unordered *)
-      I.je lbl;                   (* branch taken if x=y *)
+      I.jp (label next);           (* skip if unordered *)
+      taken E;                     (* branch taken if x=y *)
       def_label next
   | CFneq when arg i 1 = arg i 0 ->
       I.ucomisd (arg i 1) (arg i 0);
-      I.jp lbl
+      taken P
   | CFneq ->
       I.ucomisd (arg i 1) (arg i 0);
-      I.jp lbl;                   (* branch taken if unordered *)
-      I.jne lbl                   (* branch taken if x<y or x>y *)
+      taken P;                     (* branch taken if unordered *)
+      taken NE                     (* branch taken if x<y or x>y *)
   | CFlt ->
       I.comisd (arg i 0) (arg i 1);
-      I.ja lbl                    (* branch taken if y>x i.e. x<y *)
+      taken A                      (* branch taken if y>x i.e. x<y *)
   | CFnlt ->
       I.comisd (arg i 0) (arg i 1);
-      I.jbe lbl                   (* taken if unordered or y<=x i.e. !(x<y) *)
+      taken BE                     (* taken if unordered or y<=x i.e. !(x<y) *)
   | CFle ->
       I.comisd (arg i 0) (arg i 1);(* swap compare *)
-      I.jae lbl                    (* branch taken if y>=x i.e. x<=y *)
+      taken AE                     (* branch taken if y>=x i.e. x<=y *)
   | CFnle ->
       I.comisd (arg i 0) (arg i 1);(* swap compare *)
-      I.jb lbl                     (* taken if unordered or y<x i.e. !(x<=y) *)
+      taken B                      (* taken if unordered or y<x i.e. !(x<=y) *)
   | CFgt ->
       I.comisd (arg i 1) (arg i 0);
-      I.ja lbl                     (* branch taken if x>y *)
+      taken A                      (* branch taken if x>y *)
   | CFngt ->
       I.comisd (arg i 1) (arg i 0);
-      I.jbe lbl                    (* taken if unordered or x<=y i.e. !(x>y) *)
+      taken BE                     (* taken if unordered or x<=y i.e. !(x>y) *)
   | CFge ->
       I.comisd (arg i 1) (arg i 0);(* swap compare *)
-      I.jae lbl                    (* branch taken if x>=y *)
+      taken AE                     (* branch taken if x>=y *)
   | CFnge ->
       I.comisd (arg i 1) (arg i 0);(* swap compare *)
-      I.jb lbl                     (* taken if unordered or x<y i.e. !(x>=y) *)
+      taken B                      (* taken if unordered or x<y i.e. !(x>=y) *)
 
 (* Deallocate the stack frame before a return or tail call *)
 
@@ -1099,32 +1099,33 @@ let emit_instr fallthrough i =
       I.jmp (label lbl)
   | Lcondbranch(tst, lbl) ->
       let lbl = label lbl in
-      begin match tst with
+      let emit_test i ~(taken:X86_ast.condition -> unit) = function
       | Itruetest ->
           output_test_zero i.arg.(0);
-          I.jne lbl
+          taken NE
       | Ifalsetest ->
           output_test_zero i.arg.(0);
-          I.je lbl
+          taken E
       | Iinttest cmp ->
           I.cmp (arg i 1) (arg i 0);
-          I.j (cond cmp) lbl
+          taken (cond cmp)
       | Iinttest_imm((Isigned Ceq | Isigned Cne |
                       Iunsigned Ceq | Iunsigned Cne) as cmp, 0) ->
           output_test_zero i.arg.(0);
-          I.j (cond cmp) lbl
+          taken (cond cmp)
       | Iinttest_imm(cmp, n) ->
           I.cmp (int n) (arg i 0);
-          I.j (cond cmp) lbl
+          taken (cond cmp)
       | Ifloattest cmp ->
-          emit_float_test cmp i lbl
+          emit_float_test cmp i ~taken
       | Ioddtest ->
           I.test (int 1) (arg8 i 0);
-          I.jne lbl
+          taken NE
       | Ieventest ->
           I.test (int 1) (arg8 i 0);
-          I.je lbl
-      end
+          taken E
+      in
+      emit_test i tst ~taken:(fun c -> I.j c lbl)
   | Lcondbranch3(lbl0, lbl1, lbl2) ->
       I.cmp (int 1) (arg i 0);
       begin match lbl0 with

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -359,6 +359,7 @@ let destroyed_at_oper = function
                | Double ), _, _))
   | Iop(Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
        | Icompf _
+       | Icsel _
        | Ifloatofint | Iintoffloat
        | Ivalueofint | Iintofvalue
        | Iconst_int _ | Iconst_float _ | Iconst_symbol _
@@ -409,6 +410,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
                     | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _),_)
        | Negf | Absf | Addf | Subf | Mulf | Divf
        | Compf _
+       | Csel _
        | Floatofint | Intoffloat
        | Valueofint | Intofvalue
        | Probe_is_enabled _
@@ -462,6 +464,7 @@ let safe_register_pressure = function
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue
   | Icompf _
+  | Icsel _
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Istackoffset _ | Iload (_, _, _) | Istore (_, _, _)
@@ -497,6 +500,7 @@ let max_register_pressure =
             | Double ),
             _, _)
   | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
+  | Icsel _
   | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
@@ -538,6 +542,7 @@ let operation_supported = function
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
+  | Ccsel
   | Cbswap _
   | Cclz _ | Cctz _
   | Ccmpi _ | Caddv | Cadda | Ccmpa _

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -542,7 +542,7 @@ let operation_supported = function
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
-  | Ccsel
+  | Ccsel _
   | Cbswap _
   | Cclz _ | Cctz _
   | Ccmpi _ | Caddv | Cadda | Ccmpa _

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -159,8 +159,9 @@ method! reload_operation op arg res =
         weird). *)
       if stackp res.(0)
       then begin
-        (* [reload_test] may lose some sharing between the arguments for the test,
-           and the last two.  *)
+        (* CR-soon gyorsh: [reload_test] may lose some sharing
+           between the arguments of the test and the last two arguments
+           and the result of the move. *)
         let r = self#makereg res.(0) in
         let len = Array.length arg in
         let arg' = Array.copy arg in

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -147,7 +147,7 @@ method! reload_operation op arg res =
       then super#reload_operation op arg res
       else (arg, res)
   | Icsel tst ->
-      (* Last argument and result must the same register.
+      (* Last argument and result must be in the same register.
          Result must be in register. The last two arguments are used
          for emitting cmov, the remaining for [Mach.test]. *)
     (*  CR gyorsh: we already use Array.sub here,
@@ -159,6 +159,8 @@ method! reload_operation op arg res =
         weird). *)
       if stackp res.(0)
       then begin
+        (* [reload_test] may lose some sharing between the arguments for the test,
+           and the last two.  *)
         let r = self#makereg res.(0) in
         let len = Array.length arg in
         let arg' = Array.copy arg in

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -146,6 +146,29 @@ method! reload_operation op arg res =
       if !Clflags.pic_code || !Clflags.dlcode || Arch.win64
       then super#reload_operation op arg res
       else (arg, res)
+  | Icsel tst ->
+      (* Last argument and result must the same register.
+         Result must be in register. The last two arguments are used
+         for emitting cmov, the remaining for [Mach.test]. *)
+    (*  CR gyorsh: we already use Array.sub here,
+        so no reason for this convoluted arrangement,
+        using the first two args for cmov would simplify most of the
+        code as it won't need to have [len], it will be able to have indexes
+        directly, but then in Emit we will have to do Array.sub again
+        to call emit_test (unless emit_test takes an index, which is also
+        weird). *)
+      if stackp res.(0)
+      then begin
+        let r = self#makereg res.(0) in
+        let len = Array.length arg in
+        let arg' = Array.copy arg in
+        let test_arg = self#reload_test tst (Array.sub arg 0 (len - 2)) in
+        for i = 0 to len - 2 do
+          arg'.(i) <- test_arg.(i)
+        done;
+        arg'.(len - 1) <- r;
+        (arg', [|r|])
+      end else  (arg, res)
   | Iintop (Ipopcnt | Iclz _| Ictz _)
   | Ispecific  (Isqrtf | Isextend32 | Izextend32 | Ilea _
                | Istore_int (_, _, _)

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -145,6 +145,12 @@ let pseudoregs_for_operation op arg res =
   | Ispecific Icrc32q ->
     (* arg.(0) and res.(0) must be the same *)
     ([|res.(0); arg.(1)|], res)
+  | Icsel _ ->
+    (* last arg must be the same as res.(0) *)
+    let len = Array.length arg in
+    let arg = Array.copy arg in
+    arg.(len-1) <- res.(0);
+    (arg, res)
   (* Other instructions are regular *)
   | Iintop (Ipopcnt|Iclz _|Ictz _|Icomp _|Icheckbound)
   | Iintop_imm ((Imulh _|Idiv|Imod|Icomp _|Icheckbound

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -349,6 +349,7 @@ let operation_can_raise = function
 
 let operation_allocates = function
   | Ifar_alloc _ -> true
+  | Ifar_poll _
   | Ifar_intop_checkbound
   | Ifar_intop_imm_checkbound _
   | Ishiftcheckbound _

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -514,6 +514,7 @@ module BR = Branch_relaxation.Make (struct
       | 16 | 24 | 32 -> 1
       | _ -> 1 + num_instructions_for_intconst (Nativeint.of_int num_bytes)
       end
+    | Lop (Icsel _) -> 4
     | Lop (Ibeginregion | Iendregion) ->
        Misc.fatal_error "Local allocations not supported on this architecture"
     | Lop (Iintop (Icomp _)) -> 2
@@ -972,6 +973,33 @@ let emit_instr i =
     | Lop (Iname_for_debugger _) -> ()
     | Lop (Iprobe _ | Iprobe_is_enabled _) ->
         fatal_error ("Probes not supported.")
+    | Lop (Icsel tst) ->
+        begin match tst with
+        | Itruetest ->
+          `	cmp	{emit_reg i.arg.(0)}, #0\n`;
+            `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, ne\n`
+        | Ifalsetest ->
+          `	cmp	{emit_reg i.arg.(0)}, #0\n`;
+            `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, eq\n`
+        | Iinttest cmp ->
+            let comp = name_for_comparison cmp in
+            `	cmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
+            `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(2)}, {emit_reg i.arg.(3)}, {emit_string comp}\n`
+        | Iinttest_imm(cmp, n) ->
+            let comp = name_for_comparison cmp in
+            emit_cmpimm i.arg.(0) n;
+            `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, {emit_string comp}\n`
+        | Ifloattest cmp ->
+            let comp = name_for_float_comparison cmp in
+            `	fcmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
+            `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(2)}, {emit_reg i.arg.(3)}, {emit_string comp}\n`
+        | Ioddtest ->
+          `	tst	{emit_reg i.arg.(0)}, #1\n`;
+            `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, ne\n`
+        | Ieventest ->
+          `	tst	{emit_reg i.arg.(0)}, #1\n`;
+            `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, eq\n`
+        end
     | Lreloadretaddr ->
         ()
     | Lreturn ->

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -701,6 +701,20 @@ let name_for_float_comparison = function
   | CFge -> "ge"
   | CFnge -> "lt"
 
+let move src dst =
+  if src.loc <> dst.loc then begin
+    match (src, dst) with
+    | {loc = Reg _; typ = Float}, {loc = Reg _} ->
+      `	fmov	{emit_reg dst}, {emit_reg src}\n`
+    | {loc = Reg _}, {loc = Reg _} ->
+      `	mov	{emit_reg dst}, {emit_reg src}\n`
+    | {loc = Reg _}, {loc = Stack _} ->
+      `	str	{emit_reg src}, {emit_stack dst}\n`
+    | {loc = Stack _}, {loc = Reg _} ->
+      `	ldr	{emit_reg dst}, {emit_stack src}\n`
+    | _ ->
+      assert false
+  end
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -717,20 +731,7 @@ let emit_instr i =
         `	str	x30, [sp, #{emit_int (n-8)}]\n`
       end
     | Lop(Imove | Ispill | Ireload) ->
-        let src = i.arg.(0) and dst = i.res.(0) in
-        if src.loc <> dst.loc then begin
-          match (src, dst) with
-          | {loc = Reg _; typ = Float}, {loc = Reg _} ->
-              `	fmov	{emit_reg dst}, {emit_reg src}\n`
-          | {loc = Reg _}, {loc = Reg _} ->
-              `	mov	{emit_reg dst}, {emit_reg src}\n`
-          | {loc = Reg _}, {loc = Stack _} ->
-              `	str	{emit_reg src}, {emit_stack dst}\n`
-          | {loc = Stack _}, {loc = Reg _} ->
-              `	ldr	{emit_reg dst}, {emit_stack src}\n`
-          | _ ->
-              assert false
-        end
+        move i.arg.(0) i.res.(0)
     | Lop(Ispecific Imove32) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
@@ -974,6 +975,12 @@ let emit_instr i =
     | Lop (Iprobe _ | Iprobe_is_enabled _) ->
         fatal_error ("Probes not supported.")
     | Lop (Icsel tst) ->
+      let len = Array.length i.arg in
+      let ifso = i.arg.(len - 2) in
+      let ifnot = i.arg.(len - 1) in
+      if Reg.same_loc ifso ifnot then
+        move ifso i.res.(0)
+      else
         begin match tst with
         | Itruetest ->
             `	cmp	{emit_reg i.arg.(0)}, #0\n`;

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -976,10 +976,10 @@ let emit_instr i =
     | Lop (Icsel tst) ->
         begin match tst with
         | Itruetest ->
-          `	cmp	{emit_reg i.arg.(0)}, #0\n`;
+            `	cmp	{emit_reg i.arg.(0)}, #0\n`;
             `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, ne\n`
         | Ifalsetest ->
-          `	cmp	{emit_reg i.arg.(0)}, #0\n`;
+            `	cmp	{emit_reg i.arg.(0)}, #0\n`;
             `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, eq\n`
         | Iinttest cmp ->
             let comp = name_for_comparison cmp in
@@ -994,10 +994,10 @@ let emit_instr i =
             `	fcmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
             `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(2)}, {emit_reg i.arg.(3)}, {emit_string comp}\n`
         | Ioddtest ->
-          `	tst	{emit_reg i.arg.(0)}, #1\n`;
+            `	tst	{emit_reg i.arg.(0)}, #1\n`;
             `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, ne\n`
         | Ieventest ->
-          `	tst	{emit_reg i.arg.(0)}, #1\n`;
+            `	tst	{emit_reg i.arg.(0)}, #1\n`;
             `	csel	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, eq\n`
         end
     | Lreloadretaddr ->

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -368,7 +368,7 @@ let operation_supported = function
   | Cnegf | Cabsf | Caddf | Csubf | Cmulf | Cdivf
   | Cfloatofint | Cintoffloat | Cintofvalue | Cvalueofint
   | Ccmpf _
-  | Ccsel
+  | Ccsel _
   | Craise _
   | Ccheckbound
   | Cprobe _ | Cprobe_is_enabled _ | Copaque

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -368,6 +368,7 @@ let operation_supported = function
   | Cnegf | Cabsf | Caddf | Csubf | Cmulf | Cdivf
   | Cfloatofint | Cintoffloat | Cintofvalue | Cvalueofint
   | Ccmpf _
+  | Ccsel
   | Craise _
   | Ccheckbound
   | Cprobe _ | Cprobe_is_enabled _ | Copaque

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -548,6 +548,14 @@ let is_noop_move instr =
     | Unknown -> false
     | Reg _ | Stack _ -> Reg.same_loc instr.arg.(0) instr.res.(0))
     && Proc.register_class instr.arg.(0) = Proc.register_class instr.res.(0)
+  | Op (Csel _) -> (
+    match instr.res.(0).loc with
+    | Unknown -> false
+    | Reg _ | Stack _ ->
+      let len = Array.length instr.arg in
+      let ifso = instr.arg.(len - 2) in
+      let ifnot = instr.arg.(len - 1) in
+      Reg.same_loc instr.res.(0) ifso && Reg.same_loc instr.res.(0) ifnot)
   | Op
       ( Const_int _ | Const_float _ | Const_symbol _ | Stackoffset _ | Load _
       | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf | Subf | Mulf

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -315,6 +315,7 @@ let dump_op ppf = function
   | Mulf -> Format.fprintf ppf "mulf"
   | Divf -> Format.fprintf ppf "divf"
   | Compf _ -> Format.fprintf ppf "compf"
+  | Csel _ -> Format.fprintf ppf "csel"
   | Floatofint -> Format.fprintf ppf "floattoint"
   | Intoffloat -> Format.fprintf ppf "intoffloat"
   | Valueofint -> Format.fprintf ppf "valueofint"
@@ -506,6 +507,7 @@ let is_pure_operation : operation -> bool = function
   | Mulf -> true
   | Divf -> true
   | Compf _ -> true
+  | Csel _ -> true
   | Floatofint -> true
   | Intoffloat -> true
   (* Conservative to ensure valueofint/intofvalue are not eliminated before

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -73,6 +73,7 @@ module S = struct
     | Mulf
     | Divf
     | Compf of Mach.float_comparison (* CR gyorsh: can merge with float_test? *)
+    | Csel of Mach.test
     | Floatofint
     | Intoffloat
     | Valueofint

--- a/backend/cfg/cfg_irc_utils.ml
+++ b/backend/cfg/cfg_irc_utils.ml
@@ -142,6 +142,7 @@ let is_move_basic : Cfg.basic -> bool =
     | Mulf -> false
     | Divf -> false
     | Compf _ -> false
+    | Csel _ -> false
     | Floatofint -> false
     | Intoffloat -> false
     | Valueofint -> false

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -187,6 +187,7 @@ let precondition : Cfg_with_layout.t -> unit =
       | Mulf -> ()
       | Divf -> ()
       | Compf _ -> ()
+      | Csel _ -> ()
       | Floatofint -> ()
       | Intoffloat -> ()
       | Valueofint -> ()

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -27,6 +27,7 @@ let from_basic (basic : basic) : Linear.instruction_desc =
       | Mulf -> Imulf
       | Divf -> Idivf
       | Compf c -> Icompf c
+      | Csel c -> Icsel c
       | Floatofint -> Ifloatofint
       | Intoffloat -> Iintoffloat
       | Valueofint -> Ivalueofint

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -189,6 +189,7 @@ let basic_or_terminator_of_operation :
          | Ilsr | Iasr | Iclz _ | Ictz _ | Ipopcnt | Icomp _ ) as op),
         imm ) ->
     Basic (Op (Intop_imm (op, imm)))
+  | Icsel tst -> Basic (Op (Csel tst))
   | Icompf comp -> Basic (Op (Compf comp))
   | Inegf -> Basic (Op Negf)
   | Iabsf -> Basic (Op Absf)
@@ -660,7 +661,7 @@ module Stack_offset_and_exn = struct
     | Op
         ( Move | Spill | Reload | Const_int _ | Const_float _ | Const_symbol _
         | Load _ | Store _ | Intop _ | Intop_imm _ | Negf | Absf | Addf | Subf
-        | Mulf | Divf | Compf _ | Floatofint | Intoffloat | Valueofint
+        | Mulf | Divf | Compf _ | Floatofint | Intoffloat | Valueofint | Csel _
         | Intofvalue | Probe_is_enabled _ | Opaque | Begin_region | End_region
         | Specific _ | Name_for_debugger _ )
     | Reloadretaddr | Prologue ->

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -568,6 +568,7 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
            | Ipopcnt | Iclz _ | Ictz _ | Ilsl | Ilsr | Iasr | Icomp _ ) as op),
           i ) ->
       basic (Intop_imm (op, i))
+    | Icsel tst -> basic (Csel tst)
     | Ivalueofint -> basic Valueofint
     | Iintofvalue -> basic Intofvalue
     | Iprobe_is_enabled { name } -> basic (Probe_is_enabled { name })

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -325,7 +325,7 @@ end = struct
     | Iintop
         ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
         | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ )
-    | Iname_for_debugger _ ->
+    | Icsel _ | Iname_for_debugger _ ->
       assert (Mach.operation_is_pure op)
     | Istackoffset _ | Iprobe_is_enabled _ | Iopaque | Ibeginregion | Iendregion
       ->

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -190,6 +190,7 @@ and operation =
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool } | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
   | Cbswap of { bitwidth: bswap_bitwidth; }
+  | Ccsel
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -190,7 +190,7 @@ and operation =
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool } | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
   | Cbswap of { bitwidth: bswap_bitwidth; }
-  | Ccsel
+  | Ccsel of machtype
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -191,7 +191,7 @@ and operation =
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool }  | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
   | Cbswap of { bitwidth: bswap_bitwidth; }
-  | Ccsel
+  | Ccsel of machtype
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -191,6 +191,7 @@ and operation =
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool }  | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
   | Cbswap of { bitwidth: bswap_bitwidth; }
+  | Ccsel
   | Cclz of { arg_is_non_zero: bool; }
   | Cctz of { arg_is_non_zero: bool; }
   | Cpopcnt

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3371,11 +3371,8 @@ let transl_builtin name args dbg typ_res =
   | "caml_unsigned_int64_mulh_unboxed" -> mulhi ~signed:false Pint64 args dbg
   | "caml_int32_unsigned_to_int_trunc_unboxed_to_untagged" ->
     Some (zero_extend_32 dbg (one_arg name args))
-  | "caml_csel_value"
-  | "caml_csel_int_untagged"
-  | "caml_csel_int64_unboxed"
-  | "caml_csel_int32_unboxed"
-  | "caml_csel_nativeint_unboxed"
+  | "caml_csel_value" | "caml_csel_int_untagged" | "caml_csel_int64_unboxed"
+  | "caml_csel_int32_unboxed" | "caml_csel_nativeint_unboxed"
   | "caml_csel_float_unboxed" ->
     let op = Ccsel typ_res in
     let cond, ifso, ifnot = three_args name args in
@@ -3554,7 +3551,10 @@ let cextcall (prim : Primitive.description) args dbg ret ty_args returns =
         dbg )
   in
   if prim.prim_c_builtin
-  then match transl_builtin name args dbg ret with Some op -> op | None -> default
+  then
+    match transl_builtin name args dbg ret with
+    | Some op -> op
+    | None -> default
   else default
 
 (* Symbols *)
@@ -4112,7 +4112,10 @@ let extcall ~dbg ~returns ~alloc ~is_c_builtin ~ty_args name typ_res args =
         dbg )
   in
   if is_c_builtin
-  then match transl_builtin name args dbg typ_res with Some op -> op | None -> default
+  then
+    match transl_builtin name args dbg typ_res with
+    | Some op -> op
+    | None -> default
   else default
 
 let bigarray_load ~dbg ~elt_kind ~elt_size ~elt_chunk ~bigarray ~index =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3371,17 +3371,13 @@ let transl_builtin name args dbg =
   | "caml_unsigned_int64_mulh_unboxed" -> mulhi ~signed:false Pint64 args dbg
   | "caml_int32_unsigned_to_int_trunc_unboxed_to_untagged" ->
     Some (zero_extend_32 dbg (one_arg name args))
-  | "caml_csel_value"
-  | "caml_csel_int_untagged"
-  | "caml_csel_int64_unboxed"
-  | "caml_csel_int32_unboxed"
-  | "caml_csel_nativeint_unboxed"
-  | "caml_csel_float_unboxed"
-    ->
+  | "caml_csel_value" | "caml_csel_int_untagged" | "caml_csel_int64_unboxed"
+  | "caml_csel_int32_unboxed" | "caml_csel_nativeint_unboxed"
+  | "caml_csel_float_unboxed" ->
     let op = Ccsel in
-    let cond,ifso,ifnot = three_args name args in
+    let cond, ifso, ifnot = three_args name args in
     if_operation_supported op ~f:(fun () ->
-      Cop (op, [test_bool dbg cond; ifso; ifnot], dbg))
+        Cop (op, [test_bool dbg cond; ifso; ifnot], dbg))
   (* Native_pointer: handled as unboxed nativeint *)
   | "caml_ext_pointer_as_native_pointer" ->
     Some (int_as_pointer (one_arg name args) dbg)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3217,6 +3217,12 @@ let bigstring_set size unsafe arg1 arg2 arg3 dbg =
                      check_bound unsafe size dbg (bigstring_length ba dbg) idx
                        (unaligned_set size ba_data idx newval dbg))))))
 
+let three_args name args =
+  match args with
+  | [arg1; arg2; arg3] -> arg1, arg2, arg3
+  | _ ->
+    Misc.fatal_errorf "Cmm_helpers: expected exactly 3 arguments for %s" name
+
 let two_args name args =
   match args with
   | [arg1; arg2] -> arg1, arg2
@@ -3365,6 +3371,17 @@ let transl_builtin name args dbg =
   | "caml_unsigned_int64_mulh_unboxed" -> mulhi ~signed:false Pint64 args dbg
   | "caml_int32_unsigned_to_int_trunc_unboxed_to_untagged" ->
     Some (zero_extend_32 dbg (one_arg name args))
+  | "caml_csel_value"
+  | "caml_csel_int_untagged"
+  | "caml_csel_int64_unboxed"
+  | "caml_csel_int32_unboxed"
+  | "caml_csel_nativeint_unboxed"
+  | "caml_csel_float_unboxed"
+    ->
+    let op = Ccsel in
+    let cond,ifso,ifnot = three_args name args in
+    if_operation_supported op ~f:(fun () ->
+      Cop (op, [test_bool dbg cond; ifso; ifnot], dbg))
   (* Native_pointer: handled as unboxed nativeint *)
   | "caml_ext_pointer_as_native_pointer" ->
     Some (int_as_pointer (one_arg name args) dbg)

--- a/backend/comballoc.ml
+++ b/backend/comballoc.ml
@@ -88,6 +88,7 @@ let rec combine i allocstate =
   | Iop((Imove|Ispill|Ireload|Inegf|Iabsf|Iaddf|Isubf|Imulf|Idivf|Ifloatofint|
          Iintoffloat|Ivalueofint|Iintofvalue|Iopaque|Iconst_int _|Iconst_float _|
          Iconst_symbol _|Istackoffset _|Iload (_, _, _)|Istore (_, _, _)|Icompf _|
+         Icsel _ |
          Ispecific _|Iname_for_debugger _|Iprobe_is_enabled _))
   | Iop(Iintop(Iadd | Isub | Imul | Idiv | Imod | Iand | Ior | Ixor
               | Ilsl | Ilsr | Iasr | Ipopcnt | Imulh _

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -170,7 +170,8 @@ let linear i n contains_calls =
         linear env i.Mach.next n
     | Iop((Icsel _) as op) ->
       (* CR gyorsh: this optimization can leave behind dead code
-         from computing the condition. *)
+         from computing the condition and the arguments, because there
+         is not dead code elimination after linearize. *)
       let len = Array.length i.Mach.arg in
       let ifso = i.Mach.arg.(len-2) in
       let ifnot = i.Mach.arg.(len-1) in

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -69,6 +69,7 @@ type operation =
   | Iintop_imm of integer_operation * int
   | Icompf of float_comparison
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
+  | Icsel of test
   | Ifloatofint | Iintoffloat
   | Ivalueofint | Iintofvalue
   | Iopaque
@@ -178,6 +179,7 @@ let rec instr_iter f i =
             | Iintop _ | Iintop_imm _
             | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
             | Icompf _
+            | Icsel _
             | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue
             | Ispecific _ | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _
             | Iopaque
@@ -200,6 +202,7 @@ let operation_is_pure = function
           | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _|Ictz _|Icomp _)
   | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Icompf _
+  | Icsel _
   | Ifloatofint | Iintoffloat
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _
   | Iload (_, _, _) | Iname_for_debugger _
@@ -218,6 +221,7 @@ let operation_can_raise op =
           | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _|Ictz _|Icomp _)
   | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Icompf _
+  | Icsel _
   | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _
   | Istackoffset _ | Istore _  | Iload (_, _, _) | Iname_for_debugger _

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -73,6 +73,7 @@ type operation =
   | Iintop_imm of integer_operation * int
   | Icompf of float_comparison
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
+  | Icsel of test
   | Ifloatofint | Iintoffloat
   | Ivalueofint | Iintofvalue
   | Iopaque

--- a/backend/polling.ml
+++ b/backend/polling.ml
@@ -246,6 +246,7 @@ let find_poll_alloc_or_calls instr =
             Iload _ | Istore _ | Iintop _ | Iintop_imm _ | Ifloatofint |
             Iintoffloat | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf |
             Iopaque | Ispecific _ | Ibeginregion | Iendregion |
+            Icsel _ |
             Icompf _ | Iname_for_debugger _ | Iprobe _ |
             Iprobe_is_enabled _ | Ivalueofint | Iintofvalue)-> None
       | Iend | Ireturn _ | Iifthenelse _ | Iswitch _ | Icatch _ | Iexit _ |

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -150,6 +150,15 @@ let trywith_kind ppf kind =
   | Regular -> ()
   | Delayed i -> fprintf ppf "<delayed %d>" i
 
+let to_string msg =
+  let b = Buffer.create 17 in
+  let ppf = Format.formatter_of_buffer b in
+  Format.fprintf ppf "Hello: ";
+  Format.kfprintf (fun ppf ->
+    Format.pp_print_flush ppf ();
+    Buffer.contents b
+  ) ppf msg
+
 let operation d = function
   | Capply(_ty, _) -> "app" ^ location d
   | Cextcall { func = lbl; _ } ->
@@ -193,7 +202,8 @@ let operation d = function
   | Csubf -> "-f"
   | Cmulf -> "*f"
   | Cdivf -> "/f"
-  | Ccsel -> "csel"
+  | Ccsel ret_typ ->
+    to_string "csel %a" machtype ret_typ
   | Cfloatofint -> "floatofint"
   | Cintoffloat -> "intoffloat"
   | Cvalueofint -> "valueofint"

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -153,7 +153,6 @@ let trywith_kind ppf kind =
 let to_string msg =
   let b = Buffer.create 17 in
   let ppf = Format.formatter_of_buffer b in
-  Format.fprintf ppf "Hello: ";
   Format.kfprintf (fun ppf ->
     Format.pp_print_flush ppf ();
     Buffer.contents b

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -193,6 +193,7 @@ let operation d = function
   | Csubf -> "-f"
   | Cmulf -> "*f"
   | Cdivf -> "/f"
+  | Ccsel -> "csel"
   | Cfloatofint -> "floatofint"
   | Cintoffloat -> "intoffloat"
   | Cvalueofint -> "valueofint"

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -186,6 +186,10 @@ let operation' ?(print_reg = reg) op arg ppf res =
   | Isubf -> fprintf ppf "%a -f %a" reg arg.(0) reg arg.(1)
   | Imulf -> fprintf ppf "%a *f %a" reg arg.(0) reg arg.(1)
   | Idivf -> fprintf ppf "%a /f %a" reg arg.(0) reg arg.(1)
+  | Icsel tst ->
+    let len = Array.length arg in
+    fprintf ppf "csel %a ? %a : %a"
+      (test tst) arg reg arg.(len-2) reg arg.(len-1)
   | Ifloatofint -> fprintf ppf "floatofint %a" reg arg.(0)
   | Iintoffloat -> fprintf ppf "intoffloat %a" reg arg.(0)
   | Ivalueofint -> fprintf ppf "valueofint %a" reg arg.(0)

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -182,7 +182,7 @@ let oper_result_type = function
   | Caddv -> typ_val
   | Cadda -> typ_addr
   | Cnegf | Cabsf | Caddf | Csubf | Cmulf | Cdivf -> typ_float
-  | Ccsel -> typ_val
+  | Ccsel ty -> ty
   | Cfloatofint -> typ_float
   | Cintoffloat -> typ_int
   | Cvalueofint -> typ_val
@@ -459,7 +459,7 @@ method is_simple_expr = function
       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf
       | Cclz _ | Cctz _ | Cpopcnt
       | Cbswap _
-      | Ccsel
+      | Ccsel _
       | Cabsf | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
       | Cvalueofint | Cintofvalue
       | Ccmpf _ -> List.for_all self#is_simple_expr args
@@ -510,7 +510,7 @@ method effects_of exp =
       | Cprobe_is_enabled _ -> EC.coeffect_only Coeffect.Arbitrary
       | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor
       | Cbswap _
-      | Ccsel
+      | Ccsel _
       | Cclz _ | Cctz _ | Cpopcnt
       | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf | Cabsf
       | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
@@ -629,7 +629,7 @@ method select_operation op args _dbg =
   | (Cadda, _) -> self#select_arith_comm Iadd args
   | (Ccmpa comp, _) -> self#select_arith_comp (Iunsigned comp) args
   | (Ccmpf comp, _) -> (Icompf comp, args)
-  | (Ccsel, [cond; ifso; ifnot]) ->
+  | (Ccsel _, [cond; ifso; ifnot]) ->
      let (cond, earg) = self#select_condition cond in
      (Icsel cond, [ earg; ifso; ifnot ])
   | (Cnegf, _) -> (Inegf, args)

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -182,6 +182,7 @@ let oper_result_type = function
   | Caddv -> typ_val
   | Cadda -> typ_addr
   | Cnegf | Cabsf | Caddf | Csubf | Cmulf | Cdivf -> typ_float
+  | Ccsel -> typ_val
   | Cfloatofint -> typ_float
   | Cintoffloat -> typ_int
   | Cvalueofint -> typ_val
@@ -458,6 +459,7 @@ method is_simple_expr = function
       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf
       | Cclz _ | Cctz _ | Cpopcnt
       | Cbswap _
+      | Ccsel
       | Cabsf | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
       | Cvalueofint | Cintofvalue
       | Ccmpf _ -> List.for_all self#is_simple_expr args
@@ -508,6 +510,7 @@ method effects_of exp =
       | Cprobe_is_enabled _ -> EC.coeffect_only Coeffect.Arbitrary
       | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor
       | Cbswap _
+      | Ccsel
       | Cclz _ | Cctz _ | Cpopcnt
       | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf | Cabsf
       | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
@@ -626,6 +629,9 @@ method select_operation op args _dbg =
   | (Cadda, _) -> self#select_arith_comm Iadd args
   | (Ccmpa comp, _) -> self#select_arith_comp (Iunsigned comp) args
   | (Ccmpf comp, _) -> (Icompf comp, args)
+  | (Ccsel, [cond; ifso; ifnot]) ->
+     let (cond, earg) = self#select_condition cond in
+     (Icsel cond, [ earg; ifso; ifnot ])
   | (Cnegf, _) -> (Inegf, args)
   | (Cabsf, _) -> (Iabsf, args)
   | (Caddf, _) -> (Iaddf, args)

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -123,6 +123,7 @@ module I = struct
   let bswap x = emit (BSWAP x)
   let call x = emit (CALL x)
   let cdq () = emit CDQ
+  let cmov cond x y = emit (CMOV (cond, x, y))
   let cmp x y = emit (CMP (x, y))
   let cmpsd cond x y = emit (CMPSD (cond, x, y))
   let comisd x y = emit (COMISD (x, y))

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -118,6 +118,7 @@ module I : sig
   val bswap: arg -> unit
   val call: arg -> unit
   val cdq: unit -> unit
+  val cmov : condition -> arg -> arg -> unit
   val cmp: arg -> arg -> unit
   val cmpsd : float_condition -> arg -> arg -> unit
   val comisd: arg -> arg -> unit


### PR DESCRIPTION
Add intrinsic `select_value : bool -> 'a -> 'a -> 'a` to `Cmm`. 

Emitted as CMOV isntruction on amd64, CSEL on arm64.

Special cases for untagged `int`, and unboxed `int64`, `int32`, `nativeint`, and `float`. The untagged int intrinsics doesn't usually result in better code (becauase arithmetic operations can be performed directly tagged ints), but the unboxed versions often do when the arguments and result are involved in other computations.

Best reviewed by commit. 

Based on part of #172, without `if-conversion` transformation.

A follow-up PR will optimize `Cfg_stack_operands` for `Csel`.

Generated code is not ideal in some cases, for example:
```
external select_value : bool -> 'a -> 'a -> 'a = "caml_csel_value"
[@@noalloc] [@@no_effects] [@@no_coeffects] [@@builtin]

let min (x : int) (y : int) = I.select_value (x < y) x y in
let min2 (x : int) (y : int) = I.select_value (y < x) y x in
let nop_float (x : float) (y : float) : float =  I.select_value Float.(x > y) x x
```
`min` results in extra moves:

```
camlT__min_266:
    movq	%rax, %rdi
    movq	%rbx, %rax
    cmpq	%rax, %rdi
    cmovl	%rdi, %rax
    ret
```

whereas `min2` is fine
```
camlT__min2_273:
    cmpq	%rax, %rbx
    cmovl	%rbx, %rax
   ret
```

`nop_float` emits extra loads, because there is no dead code elimination  after register allocation:

```
camlT__nop_float_292:
     movsd	(%rbx), %xmm0
     movsd	(%rax), %xmm1
     ret 
```

Handling `Icsel of  Mach.test` directly as an amd64 `Ispecific` operation directly causes a dependency cycle between `Arch` and `Mach`. Adding it to `Mach` and not `Cmm` would be possible but error-prone because matching on the name of the intrinsics would need to be repeated in every target's `Selection`. 