### PR TITLE
Remove difference of behaviour when not rebuilding terms

### DIFF
--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -600,7 +600,7 @@ let rec expr env e =
   | Apply app -> apply_expr env app
   | Apply_cont app_cont -> apply_cont_expr env app_cont
   | Switch switch -> switch_expr env switch
-  | Invalid { message } -> invalid_expr env ~message
+  | Invalid invalid -> invalid_expr env invalid
 
 and let_expr env le =
   Flambda.Let_expr.pattern_match le ~f:(fun bound ~body : Fexpr.expr ->
@@ -975,7 +975,8 @@ and switch_expr env switch : Fexpr.expr =
   in
   Switch { scrutinee; cases }
 
-and invalid_expr _env ~message : Fexpr.expr = Invalid { message }
+and invalid_expr _env invalid : Fexpr.expr =
+  Invalid { message = Flambda.Invalid.to_string invalid }
 
 (* Iter on all sets of closures of a given program. *)
 module Iter = struct
@@ -986,7 +987,7 @@ module Iter = struct
     | Apply e' -> apply_expr f_c f_s e'
     | Apply_cont e' -> apply_cont f_c f_s e'
     | Switch e' -> switch f_c f_s e'
-    | Invalid { message = _ } -> ()
+    | Invalid _ -> ()
 
   and named let_expr (bound_pattern : Bound_pattern.t) f_c f_s n =
     match (n : Named.t) with

--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -33,13 +33,17 @@ let to_apply_cont t =
   | Let _ | Let_cont _ | Apply _ | Switch _ | Invalid _ -> None
 
 let can_be_removed_as_invalid t are_rebuilding =
-  if ART.do_not_rebuild_terms are_rebuilding
-  then false
-  else
-    match Expr.descr t with
-    | Invalid _ ->
-      if Flambda_features.Debug.keep_invalid_handlers () then false else true
-    | Let _ | Let_cont _ | Apply _ | Apply_cont _ | Switch _ -> false
+  match Expr.descr t with
+  | Invalid invalid ->
+    if Flambda_features.Debug.keep_invalid_handlers ()
+    then false
+    else if ART.do_not_rebuild_terms are_rebuilding
+    then
+      match[@ocaml.warning "-4"] invalid with
+      | Code_not_rebuilt -> false
+      | _ -> true
+    else true
+  | Let _ | Let_cont _ | Apply _ | Apply_cont _ | Switch _ -> false
 
 let [@ocamlformat "disable"] print are_rebuilding ppf t =
   if ART.do_not_rebuild_terms are_rebuilding then

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -106,11 +106,11 @@ let rec simplify_expr dacc expr ~down_to_up =
     Simplify_switch_expr.simplify_switch
       ~simplify_let:Simplify_let_expr.simplify_let ~simplify_function_body dacc
       switch ~down_to_up
-  | Invalid { message } ->
+  | Invalid invalid ->
     (* CR mshinwell: Make sure that a program can be simplified to just
        [Invalid]. *)
     down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
-        EB.rebuild_invalid uacc (Message message) ~after_rebuild)
+        EB.rebuild_invalid uacc invalid ~after_rebuild)
 
 and simplify_function_body dacc expr ~return_continuation ~return_arity
     ~exn_continuation ~return_cont_scope ~exn_cont_scope

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -64,7 +64,7 @@ and expr_descr =
   | Apply of Apply.t
   | Apply_cont of Apply_cont.t
   | Switch of Switch.t
-  | Invalid of { message : string }
+  | Invalid of invalid
 
 and let_expr_t0 =
   { num_normal_occurrences_of_bound_vars : Num_occurrences.t Variable.Map.t;
@@ -135,6 +135,21 @@ and static_const_or_code =
 
 and static_const_group = static_const_or_code list
 
+and invalid =
+  (* Note that continuations and other names defined here may reference dead
+     code and have been eliminated, as the free names of an invalid term are
+     empty. *)
+  | Body_of_unreachable_continuation of Continuation.t
+  | Apply_cont_of_unreachable_continuation of Continuation.t
+  | Defining_expr_of_let of Bound_pattern.t * named
+  | Closure_type_was_invalid of Apply_expr.t
+  | Zero_switch_arms
+  | Code_not_rebuilt
+  | To_cmm_dummy_body
+  | Application_never_returns of Apply_expr.t
+  | Over_application_never_returns of Apply_expr.t
+  | Message of string
+
 let rec descr expr =
   With_delayed_renaming.descr expr
     ~apply_renaming_descr:apply_renaming_expr_descr
@@ -158,7 +173,9 @@ and apply_renaming_expr_descr t renaming =
   | Switch switch ->
     let switch' = Switch.apply_renaming switch renaming in
     if switch == switch' then t else Switch switch'
-  | Invalid _ -> t
+  | Invalid invalid ->
+    let invalid' = apply_renaming_invalid invalid renaming in
+    if invalid == invalid' then t else Invalid invalid'
 
 and apply_renaming_named (named : named) renaming : named =
   match named with
@@ -322,6 +339,34 @@ and apply_renaming_static_const_group t renaming =
       apply_renaming_static_const_or_code static_const renaming)
     t
 
+and apply_renaming_invalid invalid renaming =
+  match invalid with
+  | Body_of_unreachable_continuation cont ->
+    let cont' = Renaming.apply_continuation renaming cont in
+    if cont == cont' then invalid else Body_of_unreachable_continuation cont'
+  | Apply_cont_of_unreachable_continuation cont ->
+    let cont' = Renaming.apply_continuation renaming cont in
+    if cont == cont'
+    then invalid
+    else Apply_cont_of_unreachable_continuation cont'
+  | Defining_expr_of_let (bp, named) ->
+    let bp' = Bound_pattern.apply_renaming bp renaming in
+    let named' = apply_renaming_named named renaming in
+    if bp == bp' && named == named'
+    then invalid
+    else Defining_expr_of_let (bp', named')
+  | Closure_type_was_invalid apply ->
+    let apply' = Apply.apply_renaming apply renaming in
+    if apply == apply' then invalid else Closure_type_was_invalid apply'
+  | Application_never_returns apply ->
+    let apply' = Apply.apply_renaming apply renaming in
+    if apply == apply' then invalid else Application_never_returns apply'
+  | Over_application_never_returns apply ->
+    let apply' = Apply.apply_renaming apply renaming in
+    if apply == apply' then invalid else Over_application_never_returns apply'
+  | Zero_switch_arms | Code_not_rebuilt | To_cmm_dummy_body | Message _ ->
+    invalid
+
 let rec ids_for_export_continuation_handler_t0
     { handler; num_normal_occurrences_of_params = _ } =
   ids_for_export handler
@@ -349,7 +394,7 @@ and ids_for_export t =
   | Apply apply -> Apply.ids_for_export apply
   | Apply_cont apply_cont -> Apply_cont.ids_for_export apply_cont
   | Switch switch -> Switch.ids_for_export switch
-  | Invalid _ -> Ids_for_export.empty
+  | Invalid invalid -> ids_for_export_invalid invalid
 
 and ids_for_export_let_expr_t0
     { body; num_normal_occurrences_of_bound_vars = _ } =
@@ -416,6 +461,22 @@ and ids_for_export_static_const_or_code t =
 
 and ids_for_export_static_const_group t =
   List.map ids_for_export_static_const_or_code t |> Ids_for_export.union_list
+
+and ids_for_export_invalid invalid =
+  match invalid with
+  | Body_of_unreachable_continuation cont
+  | Apply_cont_of_unreachable_continuation cont ->
+    Ids_for_export.singleton_continuation cont
+  | Defining_expr_of_let (bp, named) ->
+    Ids_for_export.union
+      (Bound_pattern.ids_for_export bp)
+      (ids_for_export_named named)
+  | Closure_type_was_invalid apply
+  | Application_never_returns apply
+  | Over_application_never_returns apply ->
+    Apply.ids_for_export apply
+  | Zero_switch_arms | Code_not_rebuilt | To_cmm_dummy_body | Message _ ->
+    Ids_for_export.empty
 
 type flattened_for_printing_descr =
   | Flat_code of Code_id.t * function_params_and_body Code0.t
@@ -517,9 +578,9 @@ and print ppf (t : expr) =
       Flambda_colours.pop Apply.print apply
   | Apply_cont apply_cont -> Apply_cont.print ppf apply_cont
   | Switch switch -> Switch.print ppf switch
-  | Invalid { message } ->
-    fprintf ppf "@[(%tinvalid%t@ @[<hov 1>%s@])@]"
-      Flambda_colours.invalid_keyword Flambda_colours.pop message
+  | Invalid invalid ->
+    fprintf ppf "@[(%tinvalid%t@ @[<hov 1>%a@])@]"
+      Flambda_colours.invalid_keyword Flambda_colours.pop print_invalid invalid
 
 and print_continuation_handler (recursive : Recursive.t) ppf k
     ({ cont_handler_abst = _; is_exn_handler } as t) occurrences ~first =
@@ -843,6 +904,35 @@ and print_static_const_or_code ppf static_const_or_code =
     fprintf ppf "@[<hov 1>(%tDeleted_code%t)@]" Flambda_colours.static_part
       Flambda_colours.pop
   | Static_const const -> Static_const.print ppf const
+
+and print_invalid ppf invalid =
+  match invalid with
+  | Body_of_unreachable_continuation cont ->
+    fprintf ppf "(Body_of_unreachable_continuation@ %a)" Continuation.print cont
+  | Apply_cont_of_unreachable_continuation cont ->
+    fprintf ppf "(Apply_cont_of_unreachable_continuation@ %a)"
+      Continuation.print cont
+  | Defining_expr_of_let (bound_pattern, defining_expr) ->
+    fprintf ppf
+      "@[<hov 1>(Defining_expr_of_let@ @[<hov 1>(bound_pattern@ %a)@]@ @[<hov \
+       1>(defining_expr@ %a)@])@]"
+      Bound_pattern.print bound_pattern print_named defining_expr
+  | Closure_type_was_invalid apply_expr ->
+    fprintf ppf
+      "@[<hov 1>(Closure_type_was_invalid@ @[<hov 1>(apply_expr@ %a)@])@]"
+      Apply_expr.print apply_expr
+  | Zero_switch_arms -> fprintf ppf "Zero_switch_arms"
+  | Code_not_rebuilt -> fprintf ppf "Code_not_rebuilt"
+  | To_cmm_dummy_body -> fprintf ppf "To_cmm_dummy_body"
+  | Application_never_returns apply_expr ->
+    fprintf ppf
+      "@[<hov 1>(Application_never_returns@ @[<hov 1>(apply_expr@ %a)@])@]"
+      Apply_expr.print apply_expr
+  | Over_application_never_returns apply_expr ->
+    fprintf ppf
+      "@[<hov 1>(Over_application_never_returns@ @[<hov 1>(apply_expr@ %a)@])@]"
+      Apply_expr.print apply_expr
+  | Message message -> fprintf ppf "%s" message
 
 module Continuation_handler = struct
   module T0 = struct
@@ -1380,48 +1470,9 @@ module Named = struct
 end
 
 module Invalid = struct
-  type t =
-    | Body_of_unreachable_continuation of Continuation.t
-    | Apply_cont_of_unreachable_continuation of Continuation.t
-    | Defining_expr_of_let of Bound_pattern.t * Named.t
-    | Closure_type_was_invalid of Apply_expr.t
-    | Zero_switch_arms
-    | Code_not_rebuilt
-    | To_cmm_dummy_body
-    | Application_never_returns of Apply.t
-    | Over_application_never_returns of Apply.t
-    | Message of string
+  type t = invalid
 
-  let to_string t =
-    match t with
-    | Body_of_unreachable_continuation cont ->
-      Format.asprintf "(Body_of_unreachable_continuation@ %a)"
-        Continuation.print cont
-    | Apply_cont_of_unreachable_continuation cont ->
-      Format.asprintf "(Apply_cont_of_unreachable_continuation@ %a)"
-        Continuation.print cont
-    | Defining_expr_of_let (bound_pattern, defining_expr) ->
-      Format.asprintf
-        "@[<hov 1>(Defining_expr_of_let@ @[<hov 1>(bound_pattern@ %a)@]@ \
-         @[<hov 1>(defining_expr@ %a)@])@]"
-        Bound_pattern.print bound_pattern Named.print defining_expr
-    | Closure_type_was_invalid apply_expr ->
-      Format.asprintf
-        "@[<hov 1>(Closure_type_was_invalid@ @[<hov 1>(apply_expr@ %a)@])@]"
-        Apply_expr.print apply_expr
-    | Zero_switch_arms -> "Zero_switch_arms"
-    | Code_not_rebuilt -> "Code_not_rebuilt"
-    | To_cmm_dummy_body -> "To_cmm_dummy_body"
-    | Application_never_returns apply_expr ->
-      Format.asprintf
-        "@[<hov 1>(Application_never_returns@ @[<hov 1>(apply_expr@ %a)@])@]"
-        Apply_expr.print apply_expr
-    | Over_application_never_returns apply_expr ->
-      Format.asprintf
-        "@[<hov 1>(Over_application_never_returns@ @[<hov 1>(apply_expr@ \
-         %a)@])@]"
-        Apply_expr.print apply_expr
-    | Message message -> message
+  let to_string t = Format.asprintf "%a" print_invalid t
 end
 
 module Expr = struct
@@ -1449,8 +1500,7 @@ module Expr = struct
 
   let create_switch switch = create (Switch switch)
 
-  let create_invalid reason =
-    create (Invalid { message = Invalid.to_string reason })
+  let create_invalid reason = create (Invalid reason)
 end
 
 module Let_cont_expr = struct

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -50,7 +50,7 @@ and expr_descr = private
           frames from the stack, which thus allows for the raising of
           exceptions. *)
   | Switch of Switch.t  (** Conditional control flow. *)
-  | Invalid of { message : string }
+  | Invalid of invalid
       (** Code proved type-incorrect and therefore unreachable. *)
 
 and let_expr
@@ -97,18 +97,22 @@ and static_const_or_code = private
 
 and static_const_group
 
+and invalid =
+  | Body_of_unreachable_continuation of Continuation.t
+  | Apply_cont_of_unreachable_continuation of Continuation.t
+  | Defining_expr_of_let of Bound_pattern.t * named
+  | Closure_type_was_invalid of Apply_expr.t
+  | Zero_switch_arms
+  | Code_not_rebuilt
+  | To_cmm_dummy_body
+  | Application_never_returns of Apply_expr.t
+  | Over_application_never_returns of Apply_expr.t
+  | Message of string
+
 module Invalid : sig
-  type t =
-    | Body_of_unreachable_continuation of Continuation.t
-    | Apply_cont_of_unreachable_continuation of Continuation.t
-    | Defining_expr_of_let of Bound_pattern.t * named
-    | Closure_type_was_invalid of Apply.t
-    | Zero_switch_arms
-    | Code_not_rebuilt
-    | To_cmm_dummy_body
-    | Application_never_returns of Apply.t
-    | Over_application_never_returns of Apply.t
-    | Message of string
+  type t = invalid
+
+  val to_string : t -> string
 end
 
 module Expr : sig

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -298,7 +298,8 @@ let rec expr env res e =
   | Apply e' -> apply_expr env res e'
   | Apply_cont e' -> apply_cont env res e'
   | Switch e' -> switch env res e'
-  | Invalid { message } -> C.invalid res ~message
+  | Invalid invalid ->
+    C.invalid res ~message:(Flambda.Invalid.to_string invalid)
 
 and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
     ~num_normal_occurrences_of_bound_vars ~body =


### PR DESCRIPTION
Previously, `Invalid _` handlers were not removed when not rebuilding terms, so this led to a difference in behaviour compared to when they are rebuilt. This commit changes that so that behaviour is the same in both cases.