### PR TITLE
Add a missing Extract_exception

### DIFF
--- a/ocaml/runtime/signals.c
+++ b/ocaml/runtime/signals.c
@@ -221,7 +221,7 @@ void caml_raise_async_if_exception(value res, const char* where)
 {
   if (Is_exception_result(res)) {
     check_async_exn(res, where);
-    caml_raise_async(res);
+    caml_raise_async(Extract_exception(res));
   }
 }
 


### PR DESCRIPTION
There was a bug in #802 where a call to `Extract_exception` was missing, causing problems such as segfaults when you ctrl-C the toplevel.

(This should have been caught by a runtime assertion, but it turns out the flambda-backend CI never runs with the debug runtime enabled. @mshinwell is working on a PR to fix this, which would have caught this issue)