### PR TITLE
Fix pack imports in Flambda 1

### DIFF
--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -241,10 +241,10 @@ let build_package_cmx members cmxfile =
       let ui_export_info =
         List.fold_left (fun acc info ->
             Export_info.merge acc
-              (Export_info_for_pack.import_for_pack ~pack_units:(Lazy.force pack_units)
-                ~pack
-                (get_export_info_flambda1 info)))
-          (get_export_info_flambda1 ui)
+              (get_export_info_flambda1 info))
+          (Export_info_for_pack.import_for_pack ~pack_units:(Lazy.force pack_units)
+             ~pack
+             (get_export_info_flambda1 ui))
           units
       in
       Flambda1 ui_export_info


### PR DESCRIPTION
#753 introduced a bug in the code to import packs for Flambda 1: instead of calling `Export_info_for_pack.import_for_pack` on all units then on the pack itself, it was called twice on the units but not on the packed unit. This resulted in fatal errors when compiling users of the pack.
Cc @lukemaurer