### PR TITLE
Remove filename from system frametable (amd64)

### DIFF
--- a/ocaml/runtime/amd64.S
+++ b/ocaml/runtime/amd64.S
@@ -768,9 +768,6 @@ G(caml_system__frametable):
         .value  -1          /* negative frame size => use callback link */
         .value  0           /* no roots here */
         .align  EIGHT_ALIGN
-        .quad   16
-        .quad   0
-        .string "amd64.S"
 
 #if defined(SYS_macosx)
         .literal16


### PR DESCRIPTION
This is a clean-up, removing lines that were added in https://github.com/ocaml/ocaml/pull/663 for spacetime. The lines may have become out of date since the format of debug info stored in the frametable has changed with the introduction of `Dbg_alloc`. The lines has also been removed upstream. 