### PR TITLE
Remove intrinsic caml_csel_float_unboxed

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3373,6 +3373,9 @@ let transl_builtin name args dbg typ_res =
     Some (zero_extend_32 dbg (one_arg name args))
   | "caml_csel_value" | "caml_csel_int_untagged" | "caml_csel_int64_unboxed"
   | "caml_csel_int32_unboxed" | "caml_csel_nativeint_unboxed" ->
+    (* Unboxed float variant of csel intrinsic is not currently supported. It
+       can be emitted on arm64 using FCSEL, but there appears to be no
+       corresponding instruction on amd64 for xmm registers. *)
     let op = Ccsel typ_res in
     let cond, ifso, ifnot = three_args name args in
     if_operation_supported op ~f:(fun () ->

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3372,8 +3372,7 @@ let transl_builtin name args dbg typ_res =
   | "caml_int32_unsigned_to_int_trunc_unboxed_to_untagged" ->
     Some (zero_extend_32 dbg (one_arg name args))
   | "caml_csel_value" | "caml_csel_int_untagged" | "caml_csel_int64_unboxed"
-  | "caml_csel_int32_unboxed" | "caml_csel_nativeint_unboxed"
-  | "caml_csel_float_unboxed" ->
+  | "caml_csel_int32_unboxed" | "caml_csel_nativeint_unboxed" ->
     let op = Ccsel typ_res in
     let cond, ifso, ifnot = three_args name args in
     if_operation_supported op ~f:(fun () ->


### PR DESCRIPTION
We get an assembler error with this intrinsics, because `cmov` is emitted with `xmm` registers for unboxed floats.
We can't use `fcmovcc` because it only works with `mmx` registers, not `xmm` registers.

Not sure why tests for `ocaml_intrinsics` library didn't catch it.