### PR TITLE
Mark partial application wrappers as stubs in Closure_conversion

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -229,10 +229,10 @@ module Inlining = struct
         let stub_policy =
           (* Imitating Closure in classic mode, which ignores stubs entirely.
              Otherwise we allow inlining stubs in stubs for simplify. *)
-          not (Flambda_features.classic_mode ()) && Code.stub code
+          (not (Flambda_features.classic_mode ())) && Code.stub code
         in
         let decision, res =
-          if not (Env.currently_in_stub env) || stub_policy
+          if (not (Env.currently_in_stub env)) || stub_policy
           then
             match inlined_call with
             | Never_inlined ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -226,8 +226,13 @@ module Inlining = struct
       else
         let code = Code_or_metadata.get_code code in
         let inlined_call = Apply_expr.inlined apply in
+        let stub_policy =
+          (* Imitating Closure in classic mode, which ignores stubs entirely.
+             Otherwise we allow inlining stubs in stubs for simplify. *)
+          not (Flambda_features.classic_mode ()) && Code.stub code
+        in
         let decision, res =
-          if Code.stub code || Env.can_inline_non_stub env
+          if not (Env.currently_in_stub env) || stub_policy
           then
             match inlined_call with
             | Never_inlined ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -379,7 +379,7 @@ module Env = struct
 
   let entering_stub t = { t with in_stub = true }
 
-  let can_inline_non_stub t = not t.in_stub
+  let currently_in_stub t = t.in_stub
 end
 
 module Acc = struct

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -138,7 +138,8 @@ module Env = struct
       approximation_for_external_symbol : Symbol.t -> value_approximation;
       big_endian : bool;
       path_to_root : Debuginfo.Scoped_location.t;
-      inlining_history_tracker : Inlining_history.Tracker.t
+      inlining_history_tracker : Inlining_history.Tracker.t;
+      in_stub : bool
     }
 
   let current_unit_id t = t.current_unit_id
@@ -217,7 +218,8 @@ module Env = struct
       symbol_for_global;
       big_endian;
       path_to_root = Debuginfo.Scoped_location.Loc_unknown;
-      inlining_history_tracker = Inlining_history.Tracker.empty compilation_unit
+      inlining_history_tracker = Inlining_history.Tracker.empty compilation_unit;
+      in_stub = false
     }
 
   let clear_local_bindings
@@ -231,7 +233,8 @@ module Env = struct
         approximation_for_external_symbol;
         big_endian;
         path_to_root;
-        inlining_history_tracker
+        inlining_history_tracker;
+        in_stub
       } =
     let simples_to_substitute =
       Ident.Map.filter
@@ -248,7 +251,8 @@ module Env = struct
       symbol_for_global;
       big_endian;
       path_to_root;
-      inlining_history_tracker
+      inlining_history_tracker;
+      in_stub
     }
 
   let with_depth t depth_var = { t with current_depth = Some depth_var }
@@ -372,6 +376,10 @@ module Env = struct
   let relative_history_from_scoped ~loc { path_to_root; _ } =
     Inlining_history.Relative.between_scoped_locations ~parent:path_to_root
       ~child:loc
+
+  let entering_stub t = { t with in_stub = true }
+
+  let can_inline_non_stub t = not t.in_stub
 end
 
 module Acc = struct

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -175,6 +175,10 @@ module Env : sig
      its true location in the source file. *)
   val relative_history_from_scoped :
     loc:Debuginfo.Scoped_location.t -> t -> Inlining_history.Relative.t
+
+  val entering_stub : t -> t
+
+  val can_inline_non_stub : t -> bool
 end
 
 (** Used to pipe some data through closure conversion *)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -178,7 +178,7 @@ module Env : sig
 
   val entering_stub : t -> t
 
-  val can_inline_non_stub : t -> bool
+  val currently_in_stub : t -> bool
 end
 
 (** Used to pipe some data through closure conversion *)


### PR DESCRIPTION
Also some code to handle inlining with stubs properly in classic mode.