### PR TITLE
Allow value slots (closure environment entries) to be of non-Value kind

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1285,7 +1285,11 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
         let named =
           Named.create_prim
             (Unary
-               ( Project_value_slot { project_from = function_slot; value_slot },
+               ( Project_value_slot
+                   { project_from = function_slot;
+                     value_slot;
+                     kind = K.With_subkind.any_value
+                   },
                  my_closure' ))
             Debuginfo.none
         in
@@ -1585,7 +1589,9 @@ let close_functions acc external_env ~current_region function_declarations =
         (* We're sure [external_simple] is a variable since
            [value_slot_from_idents] has already filtered constants and symbols
            out. *)
-        Value_slot.Map.add value_slot external_simple map)
+        Value_slot.Map.add value_slot
+          (external_simple, K.With_subkind.any_value)
+          map)
       value_slots_from_idents Value_slot.Map.empty
   in
   let set_of_closures =

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -315,7 +315,8 @@ let unop env (unop : Fexpr.unop) : Flambda_primitive.unary_primitive =
   | Project_value_slot { project_from; value_slot } ->
     let value_slot = fresh_or_existing_value_slot env value_slot in
     let project_from = fresh_or_existing_function_slot env project_from in
-    Project_value_slot { project_from; value_slot }
+    Project_value_slot
+      { project_from; value_slot; kind = Flambda_kind.With_subkind.any_value }
   | Project_function_slot { move_from; move_to } ->
     let move_from = fresh_or_existing_function_slot env move_from in
     let move_to = fresh_or_existing_function_slot env move_to in
@@ -415,9 +416,10 @@ let set_of_closures env fun_decls value_slots =
     |> Function_slot.Lmap.of_list |> Function_declarations.create
   in
   let value_slots = Option.value value_slots ~default:[] in
-  let value_slots : Simple.t Value_slot.Map.t =
+  let value_slots : (Simple.t * Flambda_kind.With_subkind.t) Value_slot.Map.t =
     let convert ({ var; value } : Fexpr.one_value_slot) =
-      fresh_or_existing_value_slot env var, simple env value
+      ( fresh_or_existing_value_slot env var,
+        (simple env value, Flambda_kind.With_subkind.any_value) )
     in
     List.map convert value_slots |> Value_slot.Map.of_list
   in

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -437,7 +437,7 @@ let unop env (op : Flambda_primitive.unary_primitive) : Fexpr.unop =
   | Opaque_identity _ -> Opaque_identity
   | Unbox_number bk -> Unbox_number bk
   | Untag_immediate -> Untag_immediate
-  | Project_value_slot { project_from; value_slot } ->
+  | Project_value_slot { project_from; value_slot; kind = _ } ->
     let project_from = Env.translate_function_slot env project_from in
     let value_slot = Env.translate_value_slot env value_slot in
     Project_value_slot { project_from; value_slot }
@@ -520,7 +520,13 @@ let prim env (p : Flambda_primitive.t) : Fexpr.prim =
 
 let value_slots env map =
   List.map
-    (fun (var, value) ->
+    (fun (var, (value, kind)) ->
+      if not
+           (Flambda_kind.equal
+              (Flambda_kind.With_subkind.kind kind)
+              Flambda_kind.value)
+      then
+        Misc.fatal_errorf "Value slot %a not of kind Value" Simple.print value;
       let var = Env.translate_value_slot env var in
       let value = simple env value in
       { Fexpr.var; value })

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -521,8 +521,9 @@ let create_let_symbols uacc lifted_constant ~body =
                   }
               in
               Binary (Block_load (block_access_kind, Immutable), symbol, index)
-            | Project_value_slot { project_from; value_slot } ->
-              Unary (Project_value_slot { project_from; value_slot }, symbol)
+            | Project_value_slot { project_from; value_slot; kind } ->
+              Unary
+                (Project_value_slot { project_from; value_slot; kind }, symbol)
           in
           ( Named.create_prim prim Debuginfo.none,
             coercion_from_proj_to_var,

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -294,7 +294,8 @@ let apply_projection t proj =
       | Block_load { index } ->
         T.meet_block_field_simple typing_env ~min_name_mode:Name_mode.normal ty
           index
-      | Project_value_slot { project_from = _; value_slot } ->
+      | Project_value_slot { project_from = _; value_slot; kind = _ } ->
+        (* CR mshinwell: could use [kind]? *)
         T.meet_project_value_slot_simple typing_env
           ~min_name_mode:Name_mode.normal ty value_slot
     in

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -104,7 +104,8 @@ let rebuild_let simplify_named_result removed_operations
     in
     after_rebuild body uacc
 
-let record_one_value_slot_for_data_flow symbol value_slot simple data_flow =
+let record_one_value_slot_for_data_flow symbol value_slot (simple, _kind)
+    data_flow =
   DF.record_value_slot (Name.symbol symbol) value_slot
     (Simple.free_names simple) data_flow
 

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -579,16 +579,18 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
   in
   let value_slot_types =
     Value_slot.Map.map
-      (fun value_slot ->
+      (fun (value_slot, kind_with_subkind) ->
+        let kind = K.With_subkind.kind kind_with_subkind in
         Simple.pattern_match value_slot
-          ~const:(fun _ -> T.alias_type_of K.value value_slot)
+          ~const:(fun _ ->
+            T.alias_type_of K.value value_slot, kind_with_subkind)
           ~name:(fun name ~coercion ->
             Name.pattern_match name
               ~var:(fun var ->
                 match Variable.Map.find var closure_bound_vars_inverse with
                 | exception Not_found ->
                   assert (DE.mem_variable (DA.denv dacc) var);
-                  T.alias_type_of K.value value_slot
+                  T.alias_type_of kind value_slot, kind_with_subkind
                 | function_slot ->
                   let closure_symbol =
                     Function_slot.Map.find function_slot closure_symbols_map
@@ -596,8 +598,9 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
                   let simple =
                     Simple.with_coercion (Simple.symbol closure_symbol) coercion
                   in
-                  T.alias_type_of K.value simple)
-              ~symbol:(fun _sym -> T.alias_type_of K.value value_slot)))
+                  T.alias_type_of kind simple, kind_with_subkind)
+              ~symbol:(fun _sym ->
+                T.alias_type_of kind value_slot, kind_with_subkind)))
       value_slots
   in
   let context =
@@ -705,8 +708,8 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
 
 type lifting_decision_result =
   { can_lift : bool;
-    value_slots : Simple.t Value_slot.Map.t;
-    value_slot_types : T.t Value_slot.Map.t;
+    value_slots : (Simple.t * K.With_subkind.t) Value_slot.Map.t;
+    value_slot_types : (T.t * K.With_subkind.t) Value_slot.Map.t;
     symbol_projections : Symbol_projection.t Variable.Map.t
   }
 
@@ -723,7 +726,7 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
      available.) *)
   let value_slots, value_slot_types, symbol_projections =
     Value_slot.Map.fold
-      (fun value_slot env_entry
+      (fun value_slot (env_entry, kind)
            (value_slots, value_slot_types, symbol_projections) ->
         let env_entry, ty, symbol_projections =
           let ty =
@@ -747,9 +750,11 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
           in
           simple, ty, symbol_projections
         in
-        let value_slots = Value_slot.Map.add value_slot env_entry value_slots in
+        let value_slots =
+          Value_slot.Map.add value_slot (env_entry, kind) value_slots
+        in
         let value_slot_types =
-          Value_slot.Map.add value_slot ty value_slot_types
+          Value_slot.Map.add value_slot (ty, kind) value_slot_types
         in
         value_slots, value_slot_types, symbol_projections)
       (Set_of_closures.value_slots set_of_closures)
@@ -791,7 +796,7 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
          | Unknown -> false)
        | Heap -> true
   in
-  let value_slot_permits_lifting _value_slot simple =
+  let value_slot_permits_lifting _value_slot (simple, _kind) =
     can_lift_coercion (Simple.coercion simple)
     && Simple.pattern_match' simple
          ~const:(fun _ -> true)

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
@@ -72,14 +72,14 @@ let previously_free_depth_variables t = t.previously_free_depth_variables
 let compute_value_slot_types_inside_function ~value_slot_types
     ~degraded_value_slots =
   Value_slot.Map.mapi
-    (fun value_slot type_prior_to_sets ->
+    (fun value_slot (type_prior_to_sets, kind) ->
       let type_prior_to_sets =
         (* See comment below about [degraded_value_slots]. *)
         if Value_slot.Set.mem value_slot degraded_value_slots
         then T.any_value
         else type_prior_to_sets
       in
-      type_prior_to_sets)
+      type_prior_to_sets, kind)
     value_slot_types
 
 let compute_closure_types_inside_functions ~denv ~all_sets_of_closures
@@ -251,7 +251,7 @@ let create ~dacc_prior_to_sets ~simplify_function_body ~all_sets_of_closures
     List.concat_map
       (fun value_slot_types ->
         Value_slot.Map.mapi
-          (fun value_slot ty ->
+          (fun value_slot (ty, _kind) ->
             let vars = TE.free_names_transitive (DE.typing_env denv) ty in
             NO.fold_variables vars ~init:Variable.Set.empty
               ~f:(fun free_depth_variables var ->

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.mli
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.mli
@@ -28,7 +28,7 @@ val create :
   simplify_function_body:Simplify_common.simplify_function_body ->
   all_sets_of_closures:Set_of_closures.t list ->
   closure_bound_names_all_sets:Bound_name.t Function_slot.Map.t list ->
-  value_slot_types_all_sets:T.t Value_slot.Map.t list ->
+  value_slot_types_all_sets:(T.t * K.With_subkind.t) Value_slot.Map.t list ->
   t
 
 val create_for_stub :

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -43,8 +43,8 @@ let simplify_project_function_slot ~move_from ~move_to ~min_name_mode dacc
            ~this_function_slot:move_from closures)
       ~result_var ~result_kind:K.value
 
-let simplify_project_value_slot function_slot value_slot ~min_name_mode dacc
-    ~original_term ~arg:closure ~arg_ty:closure_ty ~result_var =
+let simplify_project_value_slot function_slot value_slot kind ~min_name_mode
+    dacc ~original_term ~arg:closure ~arg_ty:closure_ty ~result_var =
   let result =
     (* We try a faster method before falling back to [simplify_projection]. *)
     match
@@ -75,15 +75,16 @@ let simplify_project_value_slot function_slot value_slot ~min_name_mode dacc
           ~shape:
             (T.closure_with_at_least_this_value_slot
                ~this_function_slot:function_slot value_slot
-               ~value_slot_var:(Bound_var.var result_var))
-          ~result_var ~result_kind:K.value
+               ~value_slot_var:(Bound_var.var result_var) ~value_slot_kind:kind)
+          ~result_var ~result_kind:(K.With_subkind.kind kind)
       in
       let dacc = DA.add_use_of_value_slot result.dacc value_slot in
       SPR.with_dacc result dacc
   in
   let dacc =
     Simplify_common.add_symbol_projection result.dacc ~projected_from:closure
-      (Symbol_projection.Projection.project_value_slot function_slot value_slot)
+      (Symbol_projection.Projection.project_value_slot function_slot value_slot
+         kind)
       ~projection_bound_to:result_var
   in
   SPR.with_dacc result dacc
@@ -552,8 +553,8 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
   let original_term = Named.create_prim original_prim dbg in
   let simplifier =
     match prim with
-    | Project_value_slot { project_from; value_slot } ->
-      simplify_project_value_slot project_from value_slot ~min_name_mode
+    | Project_value_slot { project_from; value_slot; kind } ->
+      simplify_project_value_slot project_from value_slot ~min_name_mode kind
     | Project_function_slot { move_from; move_to } ->
       simplify_project_function_slot ~move_from ~move_to ~min_name_mode
     | Unbox_number boxable_number_kind ->

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -61,14 +61,15 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
   | Unbox (Closure_single_entry { function_slot; vars_within_closure }) ->
     let denv =
       Value_slot.Map.fold
-        (fun _ ({ epa = { param = var; _ }; _ } : U.field_decision) denv ->
+        (fun _ (({ epa = { param = var; _ }; _ } : U.field_decision), _) denv ->
           let v = VB.create var Name_mode.normal in
           DE.define_variable denv v K.value)
         vars_within_closure denv
     in
     let map =
       Value_slot.Map.map
-        (fun ({ epa = { param = var; _ }; _ } : U.field_decision) -> var)
+        (fun (({ epa = { param = var; _ }; _ } : U.field_decision), kind) ->
+          var, kind)
         vars_within_closure
     in
     let shape =
@@ -77,7 +78,7 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     in
     let denv = add_equation_on_var denv param_var shape in
     Value_slot.Map.fold
-      (fun _ (field : U.field_decision) denv ->
+      (fun _ ((field : U.field_decision), _) denv ->
         denv_of_decision denv ~param_var:field.epa.param field.decision)
       vars_within_closure denv
   | Unbox (Variant { tag; const_ctors; fields_by_tag }) ->

--- a/middle_end/flambda2/simplify/unboxing/is_unboxing_beneficial.ml
+++ b/middle_end/flambda2/simplify/unboxing/is_unboxing_beneficial.ml
@@ -48,11 +48,12 @@ let rec filter_non_beneficial_decisions decision : U.decision =
     let is_unboxing_beneficial = ref false in
     let vars_within_closure =
       Value_slot.Map.map
-        (fun ({ epa; decision } : U.field_decision) : U.field_decision ->
+        (fun (({ epa; decision } : U.field_decision), kind) :
+             (U.field_decision * _) ->
           is_unboxing_beneficial
             := !is_unboxing_beneficial || is_unboxing_beneficial_for_epa epa;
           let decision = filter_non_beneficial_decisions decision in
-          { epa; decision })
+          { epa; decision }, kind)
         vars_within_closure
     in
     if !is_unboxing_beneficial

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -176,12 +176,12 @@ and make_optimistic_fields ~add_tag_to_name ~depth tenv param_type (tag : Tag.t)
 and make_optimistic_vars_within_closure ~depth tenv closures_entry =
   let map = T.Closures_entry.value_slot_types closures_entry in
   Value_slot.Map.mapi
-    (fun value_slot var_type : U.field_decision ->
+    (fun value_slot (var_type, kind) : (U.field_decision * _) ->
       let epa =
         Extra_param_and_args.create ~name:(Value_slot.to_string value_slot)
       in
       let decision =
         make_optimistic_decision ~depth:(depth + 1) tenv ~param_type:var_type
       in
-      { epa; decision })
+      { epa; decision }, kind)
     map

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -139,15 +139,16 @@ module Field = struct
 end
 
 module Closure_field = struct
-  let unboxing_prim function_slot ~closure value_slot =
+  let unboxing_prim function_slot ~closure value_slot kind =
     P.Unary
-      (Project_value_slot { project_from = function_slot; value_slot }, closure)
+      ( Project_value_slot { project_from = function_slot; value_slot; kind },
+        closure )
 
-  let unboxer function_slot value_slot =
+  let unboxer function_slot value_slot kind =
     { var_name = "closure_field_at_use";
       invalid_const = Const.const_zero;
       unboxing_prim =
-        (fun closure -> unboxing_prim function_slot ~closure value_slot);
+        (fun closure -> unboxing_prim function_slot ~closure value_slot kind);
       prove_simple =
         (fun tenv ~min_name_mode t ->
           T.meet_project_value_slot_simple tenv ~min_name_mode t value_slot)

--- a/middle_end/flambda2/simplify/unboxing/unboxers.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.mli
@@ -60,7 +60,13 @@ module Field : sig
 end
 
 module Closure_field : sig
-  val unboxing_prim : Function_slot.t -> closure:Simple.t -> Value_slot.t -> P.t
+  val unboxing_prim :
+    Function_slot.t ->
+    closure:Simple.t ->
+    Value_slot.t ->
+    Flambda_kind.With_subkind.t ->
+    P.t
 
-  val unboxer : Function_slot.t -> Value_slot.t -> unboxer
+  val unboxer :
+    Function_slot.t -> Value_slot.t -> Flambda_kind.With_subkind.t -> unboxer
 end

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
@@ -58,7 +58,8 @@ type unboxing_decision =
       }
   | Closure_single_entry of
       { function_slot : Function_slot.t;
-        vars_within_closure : field_decision Value_slot.Map.t
+        vars_within_closure :
+          (field_decision * Flambda_kind.With_subkind.t) Value_slot.Map.t
       }
   | Number of Flambda_kind.Naked_number_kind.t * Extra_param_and_args.t
 
@@ -119,7 +120,8 @@ let rec print_decision ppf = function
       "@[<hov 1>(closure_single_entry@ @[<hov>(function_slot@ %a)@]@ @[<hv \
        2>(value_slots@ %a)@])@]"
       Function_slot.print function_slot
-      (Value_slot.Map.print print_field_decision)
+      (Value_slot.Map.print (fun ppf (decision, _kind) ->
+           print_field_decision ppf decision))
       vars_within_closure
   | Unbox (Number (kind, epa)) ->
     Format.fprintf ppf

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
@@ -49,7 +49,8 @@ type unboxing_decision =
       }
   | Closure_single_entry of
       { function_slot : Function_slot.t;
-        vars_within_closure : field_decision Value_slot.Map.t
+        vars_within_closure :
+          (field_decision * Flambda_kind.With_subkind.t) Value_slot.Map.t
       }
   (* By "single entry" we mean that the corresponding set of closures only
      contains a single closure. *)

--- a/middle_end/flambda2/term_basics/symbol_projection.mli
+++ b/middle_end/flambda2/term_basics/symbol_projection.mli
@@ -17,12 +17,14 @@ module Projection : sig
     | Block_load of { index : Targetint_31_63.t }
     | Project_value_slot of
         { project_from : Function_slot.t;
-          value_slot : Value_slot.t
+          value_slot : Value_slot.t;
+          kind : Flambda_kind.With_subkind.t
         }
 
   val block_load : index:Targetint_31_63.t -> t
 
-  val project_value_slot : Function_slot.t -> Value_slot.t -> t
+  val project_value_slot :
+    Function_slot.t -> Value_slot.t -> Flambda_kind.With_subkind.t -> t
 end
 
 type t

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -649,7 +649,8 @@ type unary_primitive =
       }
   | Project_value_slot of
       { project_from : Function_slot.t;
-        value_slot : Value_slot.t
+        value_slot : Value_slot.t;
+        kind : Flambda_kind.With_subkind.t
       }
   | Is_boxed_float
   | Is_flat_float_array
@@ -766,11 +767,21 @@ let compare_unary_primitive p1 p2 =
     let c = Function_slot.compare move_from1 move_from2 in
     if c <> 0 then c else Function_slot.compare move_to1 move_to2
   | ( Project_value_slot
-        { project_from = function_slot1; value_slot = value_slot1 },
+        { project_from = function_slot1;
+          value_slot = value_slot1;
+          kind = kind1
+        },
       Project_value_slot
-        { project_from = function_slot2; value_slot = value_slot2 } ) ->
+        { project_from = function_slot2;
+          value_slot = value_slot2;
+          kind = kind2
+        } ) ->
     let c = Function_slot.compare function_slot1 function_slot2 in
-    if c <> 0 then c else Value_slot.compare value_slot1 value_slot2
+    if c <> 0
+    then c
+    else
+      let c = Value_slot.compare value_slot1 value_slot2 in
+      if c <> 0 then c else K.With_subkind.compare kind1 kind2
   | ( Opaque_identity { middle_end_only = middle_end_only1 },
       Opaque_identity { middle_end_only = middle_end_only2 } ) ->
     Bool.compare middle_end_only1 middle_end_only2
@@ -824,9 +835,10 @@ let print_unary_primitive ppf p =
   | Project_function_slot { move_from; move_to } ->
     Format.fprintf ppf "@[(Project_function_slot@ (%a \u{2192} %a))@]"
       Function_slot.print move_from Function_slot.print move_to
-  | Project_value_slot { project_from; value_slot } ->
-    Format.fprintf ppf "@[(Project_value_slot@ (%a@ %a))@]" Function_slot.print
-      project_from Value_slot.print value_slot
+  | Project_value_slot { project_from; value_slot; kind } ->
+    Format.fprintf ppf "@[(Project_value_slot@ (%a@ %a@ %a))@]"
+      Function_slot.print project_from Value_slot.print value_slot
+      K.With_subkind.print kind
   | Is_boxed_float -> fprintf ppf "Is_boxed_float"
   | Is_flat_float_array -> fprintf ppf "Is_flat_float_array"
   | End_region -> Format.pp_print_string ppf "End_region"
@@ -987,7 +999,7 @@ let free_names_unary_primitive p =
       (Name_occurrences.add_function_slot_in_projection Name_occurrences.empty
          move_to Name_mode.normal)
       move_from Name_mode.normal
-  | Project_value_slot { value_slot; project_from } ->
+  | Project_value_slot { value_slot; project_from; kind = _ } ->
     Name_occurrences.add_function_slot_in_projection
       (Name_occurrences.add_value_slot_in_projection Name_occurrences.empty
          value_slot Name_mode.normal)

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -273,7 +273,8 @@ type unary_primitive =
           closures. *)
   | Project_value_slot of
       { project_from : Function_slot.t;
-        value_slot : Value_slot.t
+        value_slot : Value_slot.t;
+        kind : Flambda_kind.With_subkind.t
       }
       (** Project a value slot from a set of closures -- in other words, read an
           entry from the closure environment (the captured variables). *)

--- a/middle_end/flambda2/terms/set_of_closures.mli
+++ b/middle_end/flambda2/terms/set_of_closures.mli
@@ -25,7 +25,7 @@ val is_empty : t -> bool
 (** Create a set of closures given the code for its functions and the closure
     variables. *)
 val create :
-  value_slots:Simple.t Value_slot.Map.t ->
+  value_slots:(Simple.t * Flambda_kind.With_subkind.t) Value_slot.Map.t ->
   Alloc_mode.For_allocations.t ->
   Function_declarations.t ->
   t
@@ -34,7 +34,7 @@ val create :
 val function_decls : t -> Function_declarations.t
 
 (** The values of each value slot (the environment, or captured variables). *)
-val value_slots : t -> Simple.t Value_slot.Map.t
+val value_slots : t -> (Simple.t * Flambda_kind.With_subkind.t) Value_slot.Map.t
 
 (** Returns true iff the given set of closures has no value slots. *)
 val is_closed : t -> bool

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -576,7 +576,7 @@ let unary_primitive env res dbg f arg =
       let message = dead_slots_msg dbg [c1; c2] [] in
       let expr, res = C.invalid res ~message in
       None, res, expr)
-  | Project_value_slot { project_from; value_slot } -> (
+  | Project_value_slot { project_from; value_slot; kind = _ } -> (
     match
       value_slot_offset env value_slot, function_slot_offset env project_from
     with

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -284,7 +284,8 @@ end
 module Closures_entry : sig
   type t
 
-  val value_slot_types : t -> flambda_type Value_slot.Map.t
+  val value_slot_types :
+    t -> (flambda_type * Flambda_kind.With_subkind.t) Value_slot.Map.t
 end
 
 val free_names : t -> Name_occurrences.t
@@ -464,7 +465,8 @@ val exactly_this_closure :
   all_function_slots_in_set:
     Function_type.t Or_unknown_or_bottom.t Function_slot.Map.t ->
   all_closure_types_in_set:t Function_slot.Map.t ->
-  all_value_slots_in_set:flambda_type Value_slot.Map.t ->
+  all_value_slots_in_set:
+    (flambda_type * Flambda_kind.With_subkind.t) Value_slot.Map.t ->
   Alloc_mode.For_types.t ->
   flambda_type
 
@@ -477,11 +479,12 @@ val closure_with_at_least_this_value_slot :
   this_function_slot:Function_slot.t ->
   Value_slot.t ->
   value_slot_var:Variable.t ->
+  value_slot_kind:Flambda_kind.With_subkind.t ->
   flambda_type
 
 val closure_with_at_least_these_value_slots :
   this_function_slot:Function_slot.t ->
-  Variable.t Value_slot.Map.t ->
+  (Variable.t * Flambda_kind.With_subkind.t) Value_slot.Map.t ->
   flambda_type
 
 val array_of_length :

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -220,9 +220,10 @@ let closure_with_at_least_these_function_slots ~this_function_slot
 
 let closure_with_at_least_these_value_slots ~this_function_slot value_slots =
   let value_slot_types =
-    let type_of_var v = TG.alias_type_of K.value (Simple.var v) in
     let value_slot_components_by_index =
-      Value_slot.Map.map type_of_var value_slots
+      Value_slot.Map.map
+        (fun (var, kind) -> TG.alias_type_of K.value (Simple.var var), kind)
+        value_slots
     in
     TG.Product.Value_slot_indexed.create value_slot_components_by_index
   in
@@ -241,9 +242,9 @@ let closure_with_at_least_these_value_slots ~this_function_slot value_slots =
   TG.create_closures (Alloc_mode.For_types.unknown ()) by_function_slot
 
 let closure_with_at_least_this_value_slot ~this_function_slot value_slot
-    ~value_slot_var =
+    ~value_slot_var ~value_slot_kind =
   closure_with_at_least_these_value_slots ~this_function_slot
-    (Value_slot.Map.singleton value_slot value_slot_var)
+    (Value_slot.Map.singleton value_slot (value_slot_var, value_slot_kind))
 
 let type_for_const const =
   match RWC.descr const with

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -112,7 +112,8 @@ val exactly_this_closure :
   all_function_slots_in_set:
     Type_grammar.function_type Or_unknown_or_bottom.t Function_slot.Map.t ->
   all_closure_types_in_set:Type_grammar.t Function_slot.Map.t ->
-  all_value_slots_in_set:Type_grammar.t Value_slot.Map.t ->
+  all_value_slots_in_set:
+    (Type_grammar.t * Flambda_kind.With_subkind.t) Value_slot.Map.t ->
   Alloc_mode.For_types.t ->
   Type_grammar.t
 
@@ -123,13 +124,14 @@ val closure_with_at_least_these_function_slots :
 
 val closure_with_at_least_these_value_slots :
   this_function_slot:Function_slot.t ->
-  Variable.t Value_slot.Map.t ->
+  (Variable.t * Flambda_kind.With_subkind.t) Value_slot.Map.t ->
   Type_grammar.t
 
 val closure_with_at_least_this_value_slot :
   this_function_slot:Function_slot.t ->
   Value_slot.t ->
   value_slot_var:Variable.t ->
+  value_slot_kind:Flambda_kind.With_subkind.t ->
   Type_grammar.t
 
 val type_for_const : Reg_width_const.t -> Type_grammar.t

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -118,7 +118,9 @@ and function_slot_indexed_product = private
   { function_slot_components_by_index : t Function_slot.Map.t }
 
 and value_slot_indexed_product = private
-  { value_slot_components_by_index : t Value_slot.Map.t }
+  { value_slot_components_by_index :
+      (t * Flambda_kind.With_subkind.t) Value_slot.Map.t
+  }
 
 and int_indexed_product = private
   { fields : t array;
@@ -301,7 +303,8 @@ module Product : sig
 
     val top : t
 
-    val create : flambda_type Value_slot.Map.t -> t
+    val create :
+      (flambda_type * Flambda_kind.With_subkind.t) Value_slot.Map.t -> t
 
     val width : t -> Targetint_31_63.t
   end
@@ -345,7 +348,8 @@ module Closures_entry : sig
   val find_function_type :
     t -> Function_slot.t -> Function_type.t Or_unknown_or_bottom.t
 
-  val value_slot_types : t -> flambda_type Value_slot.Map.t
+  val value_slot_types :
+    t -> (flambda_type * Flambda_kind.With_subkind.t) Value_slot.Map.t
 end
 
 module Row_like_index : sig
@@ -463,7 +467,10 @@ module Row_like_for_closures : sig
 
   (** Same as For_blocks.get_field: attempt to find the type associated to the
       given environment variable without an expensive meet. *)
-  val get_env_var : t -> Value_slot.t -> flambda_type Or_unknown.t
+  val get_env_var :
+    t ->
+    Value_slot.t ->
+    (flambda_type * Flambda_kind.With_subkind.t) Or_unknown.t
 
   (** Similar to [get_env_var] but for closures within the set. *)
   val get_closure : t -> Function_slot.t -> flambda_type Or_unknown.t

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -768,7 +768,7 @@ let meet_project_value_slot_simple env ~min_name_mode t env_var :
   | Value (Ok (Closures { by_function_slot; alloc_mode = _ })) -> (
     match TG.Row_like_for_closures.get_env_var by_function_slot env_var with
     | Unknown -> Need_meet
-    | Known ty -> (
+    | Known (ty, _kind) -> (
       match TG.get_alias_exn ty with
       | simple -> (
         match TE.get_canonical_simple_exn env ~min_name_mode simple with


### PR DESCRIPTION
I quickly sketched this out to see whether there were likely to be any problems inside Flambda 2; it seems ok.  We would need something like this for parts of the forthcoming unboxed types proposal (e.g. naked floats being passed to functions, which could cause them to appear inside closures after partial applications).

I have an idea for the closure representation part of this which avoids changing the runtime.  It involves segregating value slots into ones of `Value` kind, and everything else.  This is easy now that the Flambda 2 terms give the kinds.  Then the non-`Value` ones would be put in fields after the last code pointers, immediately prior to the  `startenv` point.  I think this will avoid disturbing the placement of any code pointers, yet also conceal these non-scannable fields from the GC.  (We could also, indeed, put any value slots known to be of kind `Value` but subkind `Tagged_immediate` in the non-scannable area.)

So the question is @Gbury : how difficult would it be to adapt `Slot_offsets` for such a layout?

This would be needed for Closure and Flambda 1 too.