### PR TITLE
Print -dprofile/-dtimings output to stdout like 4.12

### DIFF
--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -36,7 +36,7 @@ let with_info ~native ~tool_name ~source_file ~output_prefix ~dump_ext k =
   Env.set_unit_name module_name;
   let env = Compmisc.initial_env() in
   let dump_file = String.concat "." [output_prefix; dump_ext] in
-  Compmisc.with_ppf_dump ~file_prefix:dump_file @@ fun ppf_dump ->
+  Compmisc.with_ppf_dump ~file_prefix:dump_file (fun ppf_dump ->
   k {
     module_name;
     output_prefix;
@@ -45,7 +45,7 @@ let with_info ~native ~tool_name ~source_file ~output_prefix ~dump_ext k =
     ppf_dump;
     tool_name;
     native;
-  }
+  })
 
 (** Compile a .mli file *)
 

--- a/ocaml/driver/compmisc.ml
+++ b/ocaml/driver/compmisc.ml
@@ -83,7 +83,7 @@ let rec make_directory dir =
       Sys.mkdir dir 0o777
     end
 
-let with_ppf_dump ~file_prefix f =
+let with_ppf_dump ?stdout ~file_prefix f =
   let with_ch ch =
     let ppf = Format.formatter_of_out_channel ch in
     ppf,
@@ -93,7 +93,12 @@ let with_ppf_dump ~file_prefix f =
   in
   let ppf_dump, finally =
     match !Clflags.dump_dir, !Clflags.dump_into_file with
-    | None, false -> Format.err_formatter, ignore
+    | None, false ->
+        let formatter =
+          if Option.is_some stdout then Format.std_formatter
+          else Format.err_formatter
+        in
+        formatter, ignore
     | None, true -> with_ch (open_out (file_prefix ^ ".dump"))
     | Some d, _ ->
         let () = make_directory Filename.(dirname @@ concat d @@ file_prefix) in

--- a/ocaml/driver/compmisc.mli
+++ b/ocaml/driver/compmisc.mli
@@ -20,4 +20,5 @@ val initial_env : unit -> Env.t
 val set_from_env : 'a option ref -> 'a Clflags.env_reader -> unit
 val read_clflags_from_env : unit -> unit
 
-val with_ppf_dump : file_prefix:string -> (Format.formatter -> 'a) -> 'a
+val with_ppf_dump : ?stdout:unit ->
+  file_prefix:string -> (Format.formatter -> 'a) -> 'a

--- a/ocaml/driver/maindriver.ml
+++ b/ocaml/driver/maindriver.ml
@@ -111,6 +111,6 @@ let main argv ppf =
     Location.report_exception ppf x;
     2
   | () ->
-    Compmisc.with_ppf_dump ~file_prefix:"profile"
+    Compmisc.with_ppf_dump ~stdout:() ~file_prefix:"profile"
       (fun ppf -> Profile.print ppf !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision);
     0

--- a/ocaml/driver/optmaindriver.ml
+++ b/ocaml/driver/optmaindriver.ml
@@ -137,6 +137,6 @@ let main argv ppf =
     Location.report_exception ppf x;
     2
   | () ->
-      Compmisc.with_ppf_dump ~file_prefix:"profile"
+      Compmisc.with_ppf_dump ~stdout:() ~file_prefix:"profile"
         (fun ppf -> Profile.print ppf !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision);
       0


### PR DESCRIPTION
At least at present, we need `-dprofile` and `-dtimings` output to go to stdout not stderr, like 4.12 -- otherwise jenga complains.  We should be able to revert this change in due course, when we have better methods of collecting this data.