### PR TITLE
Propagate types for CSE params

### DIFF
--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -25,6 +25,51 @@ type result =
     escapes : bool
   }
 
+let introduce_extra_params_for_join typing_env use_envs_with_ids
+    ~extra_params_and_args =
+  if EPA.is_empty extra_params_and_args
+  then typing_env, use_envs_with_ids
+  else
+    let extra_params = EPA.extra_params extra_params_and_args in
+    let typing_env =
+      TE.add_definitions_of_params typing_env ~params:extra_params
+    in
+    let use_envs_with_ids =
+      List.map
+        (fun (env_at_use, use_id, kind) ->
+          let env_at_use =
+            TE.add_definitions_of_params env_at_use ~params:extra_params
+          in
+          let extra_args =
+            try
+              Apply_cont_rewrite_id.Map.find use_id
+                (EPA.extra_args extra_params_and_args)
+            with Not_found ->
+              Misc.fatal_errorf
+                "No extra args for rewrite Id %a@.Extra params and args: %a"
+                Apply_cont_rewrite_id.print use_id EPA.print
+                extra_params_and_args
+          in
+          let env_at_use =
+            List.fold_left2
+              (fun env_at_use param (arg : EPA.Extra_arg.t) ->
+                match arg with
+                | Already_in_scope s ->
+                  TE.add_equation env_at_use (BP.name param)
+                    (T.alias_type_of
+                       (BP.kind param |> Flambda_kind.With_subkind.kind)
+                       s)
+                | New_let_binding _ | New_let_binding_with_named_args _ ->
+                  env_at_use)
+              env_at_use
+              (Bound_parameters.to_list extra_params)
+              extra_args
+          in
+          env_at_use, use_id, kind)
+        use_envs_with_ids
+    in
+    typing_env, use_envs_with_ids
+
 let join ?cut_after denv params ~consts_lifted_during_body ~use_envs_with_ids =
   let typing_env = DE.typing_env denv in
   let definition_scope = DE.get_continuation_scope denv in
@@ -47,10 +92,16 @@ let join ?cut_after denv params ~consts_lifted_during_body ~use_envs_with_ids =
       ~get_cse:(fun (use_env, _, _) -> DE.cse use_env)
       ~params
   in
-  let extra_params_and_args =
+  let extra_params_and_args, typing_env, use_envs_with_ids' =
     match cse_join_result with
-    | None -> Continuation_extra_params_and_args.empty
-    | Some cse_join_result -> cse_join_result.extra_params
+    | None ->
+      Continuation_extra_params_and_args.empty, typing_env, use_envs_with_ids'
+    | Some cse_join_result ->
+      let typing_env, use_envs_with_ids' =
+        introduce_extra_params_for_join typing_env use_envs_with_ids'
+          ~extra_params_and_args:cse_join_result.extra_params
+      in
+      cse_join_result.extra_params, typing_env, use_envs_with_ids'
   in
   let extra_allowed_names =
     match cse_join_result with
@@ -58,14 +109,12 @@ let join ?cut_after denv params ~consts_lifted_during_body ~use_envs_with_ids =
     | Some cse_join_result -> cse_join_result.extra_allowed_names
   in
   let cut_after = Option.value cut_after ~default:definition_scope in
-  let env =
-    T.cut_and_n_way_join typing_env use_envs_with_ids' ~params ~cut_after
-      ~extra_lifted_consts_in_use_envs ~extra_allowed_names
-  in
   let handler_env =
-    env
-    |> TE.add_definitions_of_params
-         ~params:(EPA.extra_params extra_params_and_args)
+    T.cut_and_n_way_join typing_env use_envs_with_ids'
+      ~params:
+        (Bound_parameters.append params
+           (EPA.extra_params extra_params_and_args))
+      ~cut_after ~extra_lifted_consts_in_use_envs ~extra_allowed_names
   in
   let handler_env =
     match cse_join_result with


### PR DESCRIPTION
Ensure that parameters introduced by CSE have reasonably precise type equations. At each use, an alias is added between the CSE parameter and the simple that the primitive is bound to in the branch. The join then takes care of preserving the type as well as possible.

Based on #426.