### PR TITLE
Resimplify functions that benefited from mutable unboxing

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -243,6 +243,13 @@ let mk_no_flambda2_expert_can_inline_recursive_functions f =
     (format_not_default Flambda2.Expert.Default.can_inline_recursive_functions)
 ;;
 
+let mk_flambda2_expert_max_function_simplify_run f =
+  "-flambda2-expert-max-function-simplify-run", Arg.Int f,
+  Printf.sprintf " Do not run simplification of function more\n\
+      \     than this (default %d) (Flambda 2 only)"
+    Flambda2.Expert.Default.max_function_simplify_run
+;;
+
 let mk_flambda2_debug_concrete_types_only_on_canonicals f =
   "-flambda2-debug-concrete-types-only-on-canonicals", Arg.Unit f,
   Printf.sprintf " Check that concrete\n\
@@ -488,6 +495,7 @@ module type Flambda_backend_options = sig
   val flambda2_expert_max_unboxing_depth : int -> unit
   val flambda2_expert_can_inline_recursive_functions : unit -> unit
   val no_flambda2_expert_can_inline_recursive_functions : unit -> unit
+  val flambda2_expert_max_function_simplify_run : int -> unit
   val flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
   val no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
   val flambda2_debug_keep_invalid_handlers : unit -> unit
@@ -583,6 +591,8 @@ struct
       F.flambda2_expert_can_inline_recursive_functions;
     mk_no_flambda2_expert_can_inline_recursive_functions
       F.no_flambda2_expert_can_inline_recursive_functions;
+    mk_flambda2_expert_max_function_simplify_run
+      F.flambda2_expert_max_function_simplify_run;
     mk_flambda2_debug_concrete_types_only_on_canonicals
       F.flambda2_debug_concrete_types_only_on_canonicals;
     mk_no_flambda2_debug_concrete_types_only_on_canonicals
@@ -698,6 +708,8 @@ module Flambda_backend_options_impl = struct
     Flambda2.Expert.can_inline_recursive_functions := Flambda_backend_flags.Set true
   let no_flambda2_expert_can_inline_recursive_functions () =
     Flambda2.Expert.can_inline_recursive_functions := Flambda_backend_flags.Set false
+  let flambda2_expert_max_function_simplify_run runs =
+    Flambda2.Expert.max_function_simplify_run := Flambda_backend_flags.Set runs
   let flambda2_debug_concrete_types_only_on_canonicals =
     set' Flambda2.Debug.concrete_types_only_on_canonicals
   let no_flambda2_debug_concrete_types_only_on_canonicals =
@@ -905,6 +917,8 @@ module Extra_params = struct
        set_int Flambda2.Expert.max_unboxing_depth
     | "flambda2-expert-can-inline-recursive-functions" ->
        set Flambda2.Expert.can_inline_recursive_functions
+    | "flambda2-expert-max-function-simplify-run" ->
+       set_int Flambda2.Expert.max_function_simplify_run
     | "flambda2-inline-max-depth" ->
        Clflags.Int_arg_helper.parse v
          "Bad syntax in OCAMLPARAM for 'flambda2-inline-max-depth'"

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -64,6 +64,7 @@ module type Flambda_backend_options = sig
   val flambda2_expert_max_unboxing_depth : int -> unit
   val flambda2_expert_can_inline_recursive_functions : unit -> unit
   val no_flambda2_expert_can_inline_recursive_functions : unit -> unit
+  val flambda2_expert_max_function_simplify_run : int -> unit
   val flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
   val no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
   val flambda2_debug_keep_invalid_handlers : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -133,6 +133,7 @@ module Flambda2 = struct
       let max_block_size_for_projections = None
       let max_unboxing_depth = 3
       let can_inline_recursive_functions = false
+      let max_function_simplify_run = 2
     end
 
     type flags = {
@@ -142,6 +143,7 @@ module Flambda2 = struct
       max_block_size_for_projections : int option;
       max_unboxing_depth : int;
       can_inline_recursive_functions : bool;
+      max_function_simplify_run : int;
     }
 
     let default = {
@@ -151,6 +153,7 @@ module Flambda2 = struct
       max_block_size_for_projections = Default.max_block_size_for_projections;
       max_unboxing_depth = Default.max_unboxing_depth;
       can_inline_recursive_functions = Default.can_inline_recursive_functions;
+      max_function_simplify_run = Default.max_function_simplify_run;
     }
 
     let oclassic = {
@@ -174,6 +177,7 @@ module Flambda2 = struct
     let max_block_size_for_projections = ref Default
     let max_unboxing_depth = ref Default
     let can_inline_recursive_functions = ref Default
+    let max_function_simplify_run = ref Default
   end
 
   module Debug = struct

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -101,6 +101,7 @@ module Flambda2 : sig
       val max_block_size_for_projections : int option
       val max_unboxing_depth : int
       val can_inline_recursive_functions : bool
+      val max_function_simplify_run : int
     end
 
     type flags = {
@@ -110,6 +111,7 @@ module Flambda2 : sig
       max_block_size_for_projections : int option;
       max_unboxing_depth : int;
       can_inline_recursive_functions : bool;
+      max_function_simplify_run : int;
     }
 
     val default_for_opt_level : opt_level or_default -> flags
@@ -120,6 +122,7 @@ module Flambda2 : sig
     val max_block_size_for_projections : int option or_default ref
     val max_unboxing_depth : int or_default ref
     val can_inline_recursive_functions : bool or_default ref
+    val max_function_simplify_run : int or_default ref
   end
 
   module Debug : sig

--- a/middle_end/flambda2/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/upwards_acc.ml
@@ -36,7 +36,7 @@ type t =
     demoted_exn_handlers : Continuation.Set.t;
     slot_offsets : Slot_offsets.t Or_unknown.t;
     flow_result : Flow_types.Flow_result.t;
-    resimplify : bool;
+    resimplify : bool
   }
 
 let [@ocamlformat "disable"] print ppf
@@ -107,7 +107,7 @@ let create ~flow_result ~compute_slot_offsets uenv dacc =
     demoted_exn_handlers = DA.demoted_exn_handlers dacc;
     slot_offsets;
     flow_result;
-    resimplify = false;
+    resimplify = false
   }
 
 let creation_dacc t = t.creation_dacc

--- a/middle_end/flambda2/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda2/simplify/env/upwards_acc.mli
@@ -107,3 +107,7 @@ val reachable_code_ids : t -> Flow_types.Reachable_code_ids.t Or_unknown.t
 val continuation_param_aliases : t -> Flow_types.Alias_result.t
 
 val mutable_unboxing_result : t -> Flow_types.Mutable_unboxing_result.t
+
+val set_resimplify : t -> t
+
+val resimplify : t -> bool

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -57,9 +57,10 @@ let create_code are_rebuilding ~params_and_body ~free_names_of_params_and_body =
   if ART.do_not_rebuild_terms are_rebuilding
   then
     Code_metadata.createk (fun code_metadata ->
-        Code_not_rebuilt
-          (Non_constructed_code.create_with_metadata
-             ~free_names_of_params_and_body ~code_metadata))
+        ( Code_not_rebuilt
+            (Non_constructed_code.create_with_metadata
+               ~free_names_of_params_and_body ~code_metadata),
+          None ))
   else
     let params_and_body =
       Rebuilt_expr.Function_params_and_body.to_function_params_and_body
@@ -70,10 +71,11 @@ let create_code are_rebuilding ~params_and_body ~free_names_of_params_and_body =
           Code.create_with_metadata ~params_and_body
             ~free_names_of_params_and_body ~code_metadata
         in
-        Normal
-          { const = Static_const_or_code.create_code code;
-            free_names = Code.free_names code
-          })
+        ( Normal
+            { const = Static_const_or_code.create_code code;
+              free_names = Code.free_names code
+            },
+          Some code ))
 
 let create_code' code =
   Normal

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -30,7 +30,7 @@ val create_code :
   Are_rebuilding_terms.t ->
   params_and_body:Rebuilt_expr.Function_params_and_body.t ->
   free_names_of_params_and_body:Name_occurrences.t ->
-  t Code_metadata.create_type
+  (t * Code.t option) Code_metadata.create_type
 
 (* This function should be used when a [Code.t] is already in hand, e.g. from
    the input term to the simplifier, rather than when one needs to be

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -69,6 +69,13 @@ let simplify_toplevel_common dacc simplify ~params ~return_continuation
         let uacc =
           UA.create ~flow_result ~compute_slot_offsets:true uenv dacc
         in
+        let uacc =
+          if not
+               (Named_rewrite_id.Map.is_empty
+                  flow_result.mutable_unboxing_result.let_rewrites)
+          then UA.set_resimplify uacc
+          else uacc
+        in
         rebuild uacc ~after_rebuild:(fun expr uacc -> expr, uacc))
   in
   (* We don't check occurrences of variables or symbols here because the check

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -455,8 +455,6 @@ let introduce_code dacc code =
   |> LCS.singleton_list_of_constants
   |> DA.add_to_lifted_constant_accumulator ~also_add_to_env:() dacc
 
-let max_run_rounds = 2
-
 let simplify_function context ~outer_dacc function_slot code_id
     ~closure_bound_names_inside_function =
   match DE.find_code_exn (DA.denv (C.dacc_prior_to_sets context)) code_id with
@@ -476,7 +474,10 @@ let simplify_function context ~outer_dacc function_slot code_id
         in
         code_id, outer_dacc
       | Some (Rebuilding new_code, new_code_const) ->
-        if should_resimplify && count < max_run_rounds
+        let max_function_simplify_run =
+          Flambda_features.Expert.max_function_simplify_run ()
+        in
+        if should_resimplify && count < max_function_simplify_run
         then run ~outer_dacc ~code:new_code (count + 1)
         else
           let outer_dacc =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -295,10 +295,15 @@ let compute_result_types ~is_a_functor ~return_cont_uses ~dacc_after_body
     in
     Ok (Result_types.create ~params ~results:return_cont_params env_extension)
 
+type rebuilt_code =
+  | Rebuilding of Code.t
+  | Not_rebuilding
+
 type simplify_function_result =
   { code_id : Code_id.t;
-    code : Rebuilt_static_const.t option;
-    outer_dacc : DA.t
+    code : (rebuilt_code * Rebuilt_static_const.t) option;
+    outer_dacc : DA.t;
+    should_resimplify : bool
   }
 
 let simplify_function0 context ~outer_dacc function_slot_opt code_id code
@@ -354,6 +359,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
            ~closure_bound_names_inside_function ~inlining_arguments
            ~absolute_history code_id ~return_cont_params code)
   in
+  let should_resimplify = UA.resimplify uacc_after_upwards_traversal in
   let outer_dacc, lifted_consts_this_function =
     extract_accumulators_from_function outer_dacc ~dacc_after_body
       ~uacc_after_upwards_traversal
@@ -416,7 +422,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
     | Default_loopify_and_tailrec -> Already_loopified
     | Default_loopify_and_not_tailrec -> Never_loopify
   in
-  let code =
+  let code_const, new_code =
     Rebuilt_static_const.create_code
       (DA.are_rebuilding_terms dacc_after_body)
       code_id ~params_and_body ~free_names_of_params_and_body:free_names_of_code
@@ -431,22 +437,62 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       ~dbg:(Code.dbg code) ~is_tupled:(Code.is_tupled code) ~is_my_closure_used
       ~inlining_decision ~absolute_history ~relative_history ~loopify
   in
-  { code_id; code = Some code; outer_dacc }
+  let code =
+    let are_rebuilding = DA.are_rebuilding_terms dacc_after_body in
+    match new_code with
+    | None ->
+      assert (not (Are_rebuilding_terms.are_rebuilding are_rebuilding));
+      Not_rebuilding
+    | Some new_code ->
+      assert (Are_rebuilding_terms.are_rebuilding are_rebuilding);
+      Rebuilding new_code
+  in
+  { code_id; code = Some (code, code_const); outer_dacc; should_resimplify }
+
+let introduce_code dacc code =
+  Code_id.Lmap.bindings code
+  |> List.map (fun (code_id, code) -> LC.create_code code_id code)
+  |> LCS.singleton_list_of_constants
+  |> DA.add_to_lifted_constant_accumulator ~also_add_to_env:() dacc
+
+let max_run_rounds = 2
 
 let simplify_function context ~outer_dacc function_slot code_id
     ~closure_bound_names_inside_function =
   match DE.find_code_exn (DA.denv (C.dacc_prior_to_sets context)) code_id with
   | Code_present code when not (Code.stub code) ->
-    simplify_function0 context ~outer_dacc (Some function_slot) code_id code
-      ~closure_bound_names_inside_function
+    let rec run ~outer_dacc ~code count =
+      let { code_id; code = new_code; outer_dacc; should_resimplify } =
+        simplify_function0 context ~outer_dacc (Some function_slot) code_id code
+          ~closure_bound_names_inside_function
+      in
+      match new_code with
+      | None -> code_id, outer_dacc
+      | Some (Not_rebuilding, new_code_const) ->
+        (* Not rebuilding: there is no code to resimplify *)
+        let outer_dacc =
+          introduce_code outer_dacc
+            (Code_id.Lmap.singleton code_id new_code_const)
+        in
+        code_id, outer_dacc
+      | Some (Rebuilding new_code, new_code_const) ->
+        if should_resimplify && count < max_run_rounds
+        then run ~outer_dacc ~code:new_code (count + 1)
+        else
+          let outer_dacc =
+            introduce_code outer_dacc
+              (Code_id.Lmap.singleton code_id new_code_const)
+          in
+          code_id, outer_dacc
+    in
+    run ~outer_dacc ~code 0
   | Code_present _ | Metadata_only _ ->
     (* No new code ID is created in this case: there is no function body to be
        simplified and all other code metadata will remain the same. *)
-    { code_id; code = None; outer_dacc }
+    code_id, outer_dacc
 
 type simplify_set_of_closures0_result =
   { set_of_closures : Flambda.Set_of_closures.t;
-    code : Rebuilt_static_const.t Code_id.Lmap.t;
     dacc : Downwards_acc.t
   }
 
@@ -462,11 +508,11 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
   then
     Misc.fatal_errorf "Did not expect lifted constants in [dacc]:@ %a" DA.print
       dacc;
-  let all_function_decls_in_set, code, fun_types, outer_dacc =
+  let all_function_decls_in_set, fun_types, outer_dacc =
     Function_slot.Lmap.fold
       (fun function_slot old_code_id
-           (result_function_decls_in_set, code, fun_types, outer_dacc) ->
-        let { code_id; code = new_code; outer_dacc } =
+           (result_function_decls_in_set, fun_types, outer_dacc) ->
+        let code_id, outer_dacc =
           simplify_function context ~outer_dacc function_slot old_code_id
             ~closure_bound_names_inside_function:closure_bound_names_inside
         in
@@ -481,19 +527,12 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
         let result_function_decls_in_set =
           (function_slot, code_id) :: result_function_decls_in_set
         in
-        let code =
-          match new_code with
-          | None ->
-            (* CR mshinwell: Does this case ever occur? *)
-            code
-          | Some new_code -> (code_id, new_code) :: code
-        in
         let fun_types =
           Function_slot.Map.add function_slot function_type fun_types
         in
-        result_function_decls_in_set, code, fun_types, outer_dacc)
+        result_function_decls_in_set, fun_types, outer_dacc)
       all_function_decls_in_set
-      ([], [], Function_slot.Map.empty, outer_dacc)
+      ([], Function_slot.Map.empty, outer_dacc)
   in
   let code_ids_to_remember_this_set =
     List.fold_left
@@ -507,7 +546,6 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
   let all_function_decls_in_set =
     Function_slot.Lmap.of_list (List.rev all_function_decls_in_set)
   in
-  let code = Code_id.Lmap.of_list (List.rev code) in
   let closure_types_by_bound_name =
     let closure_types_via_aliases =
       Function_slot.Map.map
@@ -549,13 +587,7 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
     |> Set_of_closures.create ~value_slots
          (Set_of_closures.alloc_mode set_of_closures)
   in
-  { set_of_closures; code; dacc }
-
-let introduce_code dacc code =
-  Code_id.Lmap.bindings code
-  |> List.map (fun (code_id, code) -> LC.create_code code_id code)
-  |> LCS.singleton_list_of_constants
-  |> DA.add_to_lifted_constant_accumulator ~also_add_to_env:() dacc
+  { set_of_closures; dacc }
 
 let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
     ~closure_bound_vars set_of_closures ~value_slots ~symbol_projections
@@ -609,7 +641,7 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
   let closure_bound_names_inside =
     C.closure_bound_names_inside_functions_exactly_one_set context
   in
-  let { set_of_closures; code; dacc } =
+  let { set_of_closures; dacc } =
     simplify_set_of_closures0 dacc context set_of_closures ~closure_bound_names
       ~closure_bound_names_inside ~value_slots ~value_slot_types
   in
@@ -620,7 +652,6 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
     Symbol.Set.cardinal closure_symbols_set
     = Function_slot.Map.cardinal closure_symbols_map);
   let denv = DA.denv dacc in
-  let dacc = introduce_code dacc code in
   let closure_symbols_with_types =
     Function_slot.Map.map
       (fun symbol ->
@@ -676,11 +707,10 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
   let closure_bound_names_inside =
     C.closure_bound_names_inside_functions_exactly_one_set context
   in
-  let { set_of_closures; code; dacc } =
+  let { set_of_closures; dacc } =
     simplify_set_of_closures0 dacc context set_of_closures ~closure_bound_names
       ~closure_bound_names_inside ~value_slots ~value_slot_types
   in
-  let dacc = introduce_code dacc code in
   let defining_expr =
     let named = Named.create_set_of_closures set_of_closures in
     let find_code_characteristics code_id =
@@ -839,11 +869,10 @@ let simplify_lifted_set_of_closures0 dacc context ~closure_symbols
     Function_slot.Lmap.map Bound_name.create_symbol closure_symbols
     |> Function_slot.Lmap.bindings |> Function_slot.Map.of_list
   in
-  let { set_of_closures; code; dacc } =
+  let { set_of_closures; dacc } =
     simplify_set_of_closures0 dacc context set_of_closures ~closure_bound_names
       ~closure_bound_names_inside ~value_slots ~value_slot_types
   in
-  let dacc = introduce_code dacc code in
   let set_of_closures_pattern =
     Bound_static.Pattern.set_of_closures closure_symbols
   in
@@ -917,9 +946,13 @@ let simplify_stub_function dacc code ~all_code ~simplify_function_body =
     (* Unused, the type of the value slot is going to be unknown *)
     Function_slot.Map.empty
   in
-  let { code_id = _; code; outer_dacc } =
+  let { code_id = _; code; outer_dacc; should_resimplify = _ } =
     simplify_function0 context ~outer_dacc:dacc None (Code.code_id code) code
       ~closure_bound_names_inside_function
   in
-  let code = match code with None -> assert false | Some code -> code in
+  let code =
+    match code with
+    | None -> assert false
+    | Some (_, code_constant) -> code_constant
+  in
   code, outer_dacc

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -227,6 +227,10 @@ module Expert = struct
   let can_inline_recursive_functions () =
     !Flambda_backend_flags.Flambda2.Expert.can_inline_recursive_functions
     |> with_default ~f:(fun d -> d.can_inline_recursive_functions)
+
+  let max_function_simplify_run () =
+    !Flambda_backend_flags.Flambda2.Expert.max_function_simplify_run
+    |> with_default ~f:(fun d -> d.max_function_simplify_run)
 end
 
 let stack_allocation_enabled () = Config.stack_allocation

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -125,6 +125,8 @@ module Expert : sig
   val max_unboxing_depth : unit -> int
 
   val can_inline_recursive_functions : unit -> bool
+
+  val max_function_simplify_run : unit -> int
 end
 
 val stack_allocation_enabled : unit -> bool


### PR DESCRIPTION
This allows to unbox in a code looking like:
```OCaml
type t = { a : int; b : float }

let g r = r := { !r with b = !r.b +. 1. }
[@@inline]

let f x =
  let r = ref x in
  for i = 0 to 10 do
    g r;
  done;
  !r.b +. 0.
```

Not that this cannot trigger if the code is not being rebuilt.
I'm not sure, but this might loose the benefit accounting of the first round.

Also there are other cases that would benefit from this. I leave that for later.