### PR TITLE
Fix failure of alias analysis when aliasing one of my_closure, my_region or my_depth

### DIFF
--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -49,6 +49,7 @@ type simplify_function_body =
   exn_cont_scope:Scope.t ->
   loopify_state:Loopify_state.t ->
   params:Bound_parameters.t ->
+  implicit_params:Bound_parameters.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
 let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -92,6 +92,7 @@ type simplify_function_body =
   exn_cont_scope:Scope.t ->
   loopify_state:Loopify_state.t ->
   params:Bound_parameters.t ->
+  implicit_params:Bound_parameters.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
 val simplify_projection :

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -140,8 +140,8 @@ and simplify_function_body dacc expr ~return_continuation ~return_arity
         Simplify_let_cont_expr.simplify_as_recursive_let_cont ~simplify_expr
           dacc
           (call_self_cont_expr, handlers))
-      ~params ~implicit_params ~return_continuation ~return_arity ~exn_continuation
-      ~return_cont_scope ~exn_cont_scope
+      ~params ~implicit_params ~return_continuation ~return_arity
+      ~exn_continuation ~return_cont_scope ~exn_cont_scope
 
 and[@inline always] simplify_let dacc let_expr ~down_to_up =
   Simplify_let_expr.simplify_let ~simplify_expr ~simplify_function_body dacc

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -114,13 +114,14 @@ let rec simplify_expr dacc expr ~down_to_up =
 
 and simplify_function_body dacc expr ~return_continuation ~return_arity
     ~exn_continuation ~return_cont_scope ~exn_cont_scope
-    ~(loopify_state : Loopify_state.t) ~params =
+    ~(loopify_state : Loopify_state.t) ~params ~implicit_params =
   match loopify_state with
   | Do_not_loopify ->
     simplify_toplevel_common dacc
       (fun dacc -> simplify_expr dacc expr)
-      ~params ~return_continuation ~return_arity ~exn_continuation
-      ~return_cont_scope ~exn_cont_scope
+      ~params:(Bound_parameters.append params implicit_params)
+      ~return_continuation ~return_arity ~exn_continuation ~return_cont_scope
+      ~exn_cont_scope
   | Loopify cont ->
     let call_self_cont_expr =
       let args = Bound_parameters.simples params in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -177,6 +177,13 @@ let simplify_function_body context ~outer_dacc function_slot_opt
       ~exn_continuation ~return_arity:(Code.result_arity code)
       ~return_cont_scope:Scope.initial
       ~exn_cont_scope:(Scope.next Scope.initial) ~loopify_state ~params
+      ~implicit_params:
+        (Bound_parameters.create
+           [ Bound_parameter.create my_closure
+               Flambda_kind.With_subkind.any_value;
+             Bound_parameter.create my_region Flambda_kind.With_subkind.region;
+             Bound_parameter.create my_depth Flambda_kind.With_subkind.rec_info
+           ])
   with
   | body, uacc ->
     let dacc_after_body = UA.creation_dacc uacc in

--- a/middle_end/flambda2/tests/ref_to_var/alias_my_closure.ml
+++ b/middle_end/flambda2/tests/ref_to_var/alias_my_closure.ml
@@ -1,0 +1,8 @@
+external magic : 'a -> 'b = "%opaque"
+
+let g y =
+  let rec spl () =
+    let relist f ps = magic f in
+    if magic y then relist spl 0 else relist spl 1
+  in
+  spl y


### PR DESCRIPTION
Before this, the flow analysis crashed due to `my_closure` being seen as a needed additional argument to the toplevel continuation if it was detected invariant.