### PR TITLE
Bump inlining threshold in classic mode

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -101,7 +101,7 @@ module Inlining = struct
     let inline_threshold =
       Clflags.Float_arg_helper.get ~key:0 !Clflags.inline_threshold
     in
-    let magic_scale_constant = 8. in
+    let magic_scale_constant = 20. in
     int_of_float (inline_threshold *. magic_scale_constant)
 
   let definition_inlining_decision inline cost_metrics =


### PR DESCRIPTION
Inlining threshold of classic mode is bound to `Clflags.inline_threshold` and, in practice, ends up as a neat 10. Too short for most functions in Flambda 2. So this patch bumps it to 25.

I'm not sure what would be the most reasonable value, as it would be difficult to emulate accurately Closure on that point.