### PR TITLE
Disable poll insertion by default

### DIFF
--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -27,7 +27,7 @@ let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-red
 let alloc_check = ref false             (* -alloc-check *)
 let dump_checkmach = ref false          (* -dcheckmach *)
 
-let disable_poll_insertion = ref false  (* -disable-poll-insertion *)
+let disable_poll_insertion = ref true   (* -disable-poll-insertion *)
 let allow_long_frames = ref true        (* -no-long-frames *)
 (* Keep the value of [max_long_frames_threshold] in sync with LONG_FRAME_MARKER
    in ocaml/runtime/roots_nat.c *)

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -27,6 +27,8 @@ let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-red
 let alloc_check = ref false             (* -alloc-check *)
 let dump_checkmach = ref false          (* -dcheckmach *)
 
+(* CR-soon gyorsh: re-enable tests testsuite/tests/asmcomp/poll_*
+   when changing the default for [disable_poll_insertion] to false. *)
 let disable_poll_insertion = ref true   (* -disable-poll-insertion *)
 let allow_long_frames = ref true        (* -no-long-frames *)
 (* Keep the value of [max_long_frames_threshold] in sync with LONG_FRAME_MARKER

--- a/testsuite/tests/asmcomp/poll_attr_both.ml
+++ b/testsuite/tests/asmcomp/poll_attr_both.ml
@@ -1,13 +1,14 @@
 (* TEST
-  * setup-ocamlopt.byte-build-env
-  ** ocamlopt.byte
+  * skip
+  ** setup-ocamlopt.byte-build-env
+  *** ocamlopt.byte
 ocamlopt_byte_exit_status = "2"
-  *** check-ocamlopt.byte-output
+  **** check-ocamlopt.byte-output
 
-  * setup-ocamlopt.opt-build-env
-  ** ocamlopt.opt
+  ** setup-ocamlopt.opt-build-env
+  *** ocamlopt.opt
 ocamlopt_opt_exit_status = "2"
-  *** check-ocamlopt.opt-output
+  **** check-ocamlopt.opt-output
 *)
 
 let[@inline never][@local never] v x = x + 1

--- a/testsuite/tests/asmcomp/poll_attr_inserted.ml
+++ b/testsuite/tests/asmcomp/poll_attr_inserted.ml
@@ -1,13 +1,14 @@
 (* TEST
-  * setup-ocamlopt.byte-build-env
-  ** ocamlopt.byte
+  * skip
+  ** setup-ocamlopt.byte-build-env
+  *** ocamlopt.byte
 ocamlopt_byte_exit_status = "2"
-  *** check-ocamlopt.byte-output
+  **** check-ocamlopt.byte-output
 
-  * setup-ocamlopt.opt-build-env
-  ** ocamlopt.opt
+  ** setup-ocamlopt.opt-build-env
+  *** ocamlopt.opt
 ocamlopt_opt_exit_status = "2"
-  *** check-ocamlopt.opt-output
+  **** check-ocamlopt.opt-output
 *)
 
 let[@poll error] c x =

--- a/testsuite/tests/asmcomp/poll_attr_prologue.ml
+++ b/testsuite/tests/asmcomp/poll_attr_prologue.ml
@@ -1,13 +1,14 @@
 (* TEST
-  * setup-ocamlopt.byte-build-env
-  ** ocamlopt.byte
+  * skip
+  ** setup-ocamlopt.byte-build-env
+  *** ocamlopt.byte
 ocamlopt_byte_exit_status = "2"
-  *** check-ocamlopt.byte-output
+  **** check-ocamlopt.byte-output
 
-  * setup-ocamlopt.opt-build-env
-  ** ocamlopt.opt
+  ** setup-ocamlopt.opt-build-env
+  *** ocamlopt.opt
 ocamlopt_opt_exit_status = "2"
-  *** check-ocamlopt.opt-output
+  **** check-ocamlopt.opt-output
 *)
 
 let[@poll error] rec c x l =

--- a/testsuite/tests/asmcomp/poll_attr_user.ml
+++ b/testsuite/tests/asmcomp/poll_attr_user.ml
@@ -1,13 +1,14 @@
 (* TEST
-  * setup-ocamlopt.byte-build-env
-  ** ocamlopt.byte
+  *
+  ** setup-ocamlopt.byte-build-env
+  *** ocamlopt.byte
 ocamlopt_byte_exit_status = "2"
-  *** check-ocamlopt.byte-output
+  **** check-ocamlopt.byte-output
 
-  * setup-ocamlopt.opt-build-env
-  ** ocamlopt.opt
+  ** setup-ocamlopt.opt-build-env
+  *** ocamlopt.opt
 ocamlopt_opt_exit_status = "2"
-  *** check-ocamlopt.opt-output
+  **** check-ocamlopt.opt-output
 *)
 
 let[@inline never][@local never] v x = x + 1


### PR DESCRIPTION
Change default of `Flambda_backend_flags.disable_poll_insertion` to `true`, and update the tests to `skip` for now.

Poll insertion can still be enabled via `OCAMLPARAM` for user code (won't affect stdlib and otherlibs).

See also https://github.com/ocaml-flambda/flambda-backend/pull/967 for a proposal of a configure option to control poll point insertion.