### PR TITLE
Add a test for frametable setup in natdynlinked libraries

### DIFF
--- a/ocaml/testsuite/tests/lib-dynlink-native/main.reference
+++ b/ocaml/testsuite/tests/lib-dynlink-native/main.reference
@@ -7,6 +7,9 @@ Registering module Plugin2
 2
 6
 1
+Raised by primitive operation at Plugin2.foo in file "plugin2.ml", line 4, characters 38-64
+Called from Plugin2.test_frametable in file "plugin2.ml", line 10, characters 2-72
+Called from Plugin2 in file "plugin2.ml", line 19, characters 2-20
 XXX
 Loading plugin_thread.so
 Registering module Plugin_thread

--- a/ocaml/testsuite/tests/lib-dynlink-native/plugin2.ml
+++ b/ocaml/testsuite/tests/lib-dynlink-native/plugin2.ml
@@ -1,8 +1,20 @@
 (*external ex: int -> int = "caml_ex"*)
 
+let foo a1 a2 a3 a4 a5 a6 a7 a8 a9 =
+  Printexc.print_raw_backtrace stdout (Printexc.get_callstack 4);
+  fun a10 a11 a12 a13 a14 a15 a16 a17 a18 -> ()
+
+(* Ensure that the frametable is set up correctly so that a [caml_curry_18]
+   frame can be traversed *)
+let[@inline never] test_frametable () =
+  (Sys.opaque_identity foo) 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18;
+  (* force non-tail call *)
+  let () = () in ()
+
 let () =
   Api.reg_mod "Plugin2";
   Api.add_cb (fun () -> print_endline "Callback from plugin2");
 (*  let i = ex 3 in*)
   List.iter (fun i -> Printf.printf "%i\n" i) Plugin.facts;
+  test_frametable ();
   Printf.printf "XXX\n"

--- a/ocaml/testsuite/tests/lib-dynlink-native/plugin2.ml
+++ b/ocaml/testsuite/tests/lib-dynlink-native/plugin2.ml
@@ -9,7 +9,7 @@ let foo a1 a2 a3 a4 a5 a6 a7 a8 a9 =
 let[@inline never] test_frametable () =
   (Sys.opaque_identity foo) 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18;
   (* force non-tail call *)
-  let () = () in ()
+  Sys.opaque_identity ()
 
 let () =
   Api.reg_mod "Plugin2";


### PR DESCRIPTION
Previously, we could miss that `caml_shared_startup` wasn't being invoked (see PR #980), causing memory corruption in rare cases due to the frametable missing information on `caml_curry_*` functions.