### PR TITLE
Fix wrong stub attributes

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -991,9 +991,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
     let id = Ident.create_local (name_for_function func) in
     let dbg = Debuginfo.from_location func.loc in
     let func =
-      cps_function env ~fid:id ~stub:false
-        ~recursive:(Non_recursive : Recursive.t)
-        func
+      cps_function env ~fid:id ~recursive:(Non_recursive : Recursive.t) func
     in
     let body acc ccenv = apply_cps_cont k ~dbg acc env ccenv id in
     CC.close_let_rec acc ccenv ~function_declarations:[func] ~body
@@ -1486,20 +1484,19 @@ and cps_function_bindings env (bindings : (Ident.t * L.lambda) list) =
       match binding with
       | [(fun_id, def)] ->
         let fundef =
-          cps_function env ~fid:fun_id ~stub:false ~recursive:(recursive fun_id)
+          cps_function env ~fid:fun_id ~recursive:(recursive fun_id)
             ~precomputed_free_idents:(Ident.Map.find fun_id free_idents)
             def
         in
         bindings @ [fundef]
       | [(fun_id, def); (inner_id, inner_def)] ->
         let fundef =
-          cps_function env ~fid:fun_id ~stub:false ~recursive:(recursive fun_id)
+          cps_function env ~fid:fun_id ~recursive:(recursive fun_id)
             ~precomputed_free_idents:(Ident.Map.find fun_id free_idents)
             def
         in
         let inner_fundef =
-          cps_function env ~fid:inner_id ~stub:true
-            ~recursive:(recursive inner_id)
+          cps_function env ~fid:inner_id ~recursive:(recursive inner_id)
             ~precomputed_free_idents:(Ident.Map.find inner_id free_idents)
             inner_def
         in
@@ -1508,11 +1505,9 @@ and cps_function_bindings env (bindings : (Ident.t * L.lambda) list) =
       (* checked above *))
     [] bindings_with_wrappers
 
-and cps_function env ~fid ~stub ~(recursive : Recursive.t)
-    ?precomputed_free_idents
+and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     ({ kind; params; return; body; attr; loc; mode; region } : L.lfunction) :
     Function_decl.t =
-  let attr = { attr with stub = attr.stub || stub } in
   let num_trailing_local_params =
     match kind with Curried { nlocal } -> nlocal | Tupled -> 0
   in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1479,31 +1479,13 @@ and cps_function_bindings env (bindings : (Ident.t * L.lambda) list) =
     then Recursive
     else Non_recursive
   in
-  List.fold_left
-    (fun bindings binding ->
-      match binding with
-      | [(fun_id, def)] ->
-        let fundef =
-          cps_function env ~fid:fun_id ~recursive:(recursive fun_id)
-            ~precomputed_free_idents:(Ident.Map.find fun_id free_idents)
-            def
-        in
-        bindings @ [fundef]
-      | [(fun_id, def); (inner_id, inner_def)] ->
-        let fundef =
-          cps_function env ~fid:fun_id ~recursive:(recursive fun_id)
-            ~precomputed_free_idents:(Ident.Map.find fun_id free_idents)
-            def
-        in
-        let inner_fundef =
-          cps_function env ~fid:inner_id ~recursive:(recursive inner_id)
-            ~precomputed_free_idents:(Ident.Map.find inner_id free_idents)
-            inner_def
-        in
-        bindings @ [fundef; inner_fundef]
-      | _ -> assert false
-      (* checked above *))
-    [] bindings_with_wrappers
+  let bindings_with_wrappers = List.flatten bindings_with_wrappers in
+  List.map
+    (fun (fun_id, def) ->
+      cps_function env ~fid:fun_id ~recursive:(recursive fun_id)
+        ~precomputed_free_idents:(Ident.Map.find fun_id free_idents)
+        def)
+    bindings_with_wrappers
 
 and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     ({ kind; params; return; body; attr; loc; mode; region } : L.lfunction) :


### PR DESCRIPTION
We used to hardcode the stub status of wrappers for function with default arguments, and we got them wrong. For a while it didn't matter because we never actually triggered the splitting code, but during this period we added a safety check that stubs don't have inlining attributes and now that the splitting triggers again this safety check tells us about the mistake.
Now that we actually have correct handling of the stub flag from the Lambda attributes, there's no point in hardcoding the flag anymore, and that gives us the correct flag for free.