### PR TITLE
Link try-regions to parents

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -700,9 +700,13 @@ let close_named acc env ~let_bound_var (named : IR.named)
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
       (fun acc named -> k acc (Some named))
-  | Begin_region ->
+  | Begin_region { try_region_parent } ->
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
-      Nullary Begin_region
+      match try_region_parent with
+      | None -> Nullary Begin_region
+      | Some try_region_parent ->
+        let try_region_parent = find_simple_from_id env try_region_parent in
+        Unary (Begin_try_region, Simple try_region_parent)
     in
     Lambda_to_flambda_primitives_helpers.bind_rec acc None
       ~register_const_string:(fun acc -> register_const_string acc)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -35,7 +35,7 @@ module IR = struct
   type named =
     | Simple of simple
     | Get_tag of Ident.t
-    | Begin_region
+    | Begin_region of { try_region_parent : Ident.t option }
     | End_region of Ident.t
     | Prim of
         { prim : Lambda.primitive;
@@ -84,7 +84,10 @@ module IR = struct
     | Simple (Var id) -> Ident.print ppf id
     | Simple (Const cst) -> Printlambda.structured_constant ppf cst
     | Get_tag id -> fprintf ppf "@[<2>(Gettag %a)@]" Ident.print id
-    | Begin_region -> fprintf ppf "Begin_region"
+    | Begin_region { try_region_parent = None } -> fprintf ppf "Begin_region"
+    | Begin_region { try_region_parent = Some try_region_parent } ->
+      fprintf ppf "@[<2>(Begin_region@ (try_region_parent %a))@]" Ident.print
+        try_region_parent
     | End_region id -> fprintf ppf "@[<2>(End_region@ %a)@]" Ident.print id
     | Prim { prim; args; _ } ->
       fprintf ppf "@[<2>(%a %a)@]" Printlambda.primitive prim

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -37,7 +37,7 @@ module IR : sig
   type named =
     | Simple of simple
     | Get_tag of Ident.t (* Intermediary primitive for block switch *)
-    | Begin_region
+    | Begin_region of { try_region_parent : Ident.t option }
     | End_region of Ident.t
         (** [Begin_region] and [End_region] are needed because these primitives
             don't exist in Lambda *)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1215,12 +1215,17 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
        generation pass ensures that there will be an enclosing region around the
        whole [Ltrywith] (possibly not immediately enclosing, but maybe further
        out). The only reason we need a [Begin_region] here is to be able to
-       unwind the local allocation stack if the exception handler is invoked. We
-       need an [End_region] too so that, on the non-exceptional path at the end
-       of the [try] block, the local allocation stack is correctly unwound in
-       the case where the region around the whole [Ltrywith] is unused. (See
-       [uses_local_try] in regions.ml in the testsuite.) *)
-    CC.close_let acc ccenv region Not_user_visible Begin_region
+       unwind the local allocation stack if the exception handler is invoked.
+       There is no corresponding [End_region] on the non-exceptional path
+       because there might be a local allocation in the "try" block that needs
+       to be returned. In effect, such allocations are treated as if they were
+       in the parent region, although they will be annotated with the region
+       identifier of the "try region". To handle this correctly we annotate the
+       [Begin_region] with its parent region. This use of the parent region will
+       ensure that the parent does not get deleted unless the try region is
+       unused. *)
+    CC.close_let acc ccenv region Not_user_visible
+      (Begin_region { try_region_parent = Some (Env.current_region env) })
       ~body:(fun acc ccenv ->
         maybe_insert_let_cont "try_with_result" kind k acc env ccenv
           (fun acc env ccenv k ->
@@ -1244,13 +1249,10 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                         cps_tail acc env ccenv body poptrap_continuation
                           handler_continuation))
                   ~handler:(fun acc env ccenv ->
-                    CC.close_let acc ccenv (Ident.create_local "unit")
-                      Not_user_visible (End_region region)
-                      ~body:(fun acc ccenv ->
-                        let env = Env.leaving_try_region env in
-                        apply_cont_with_extra_args acc env ccenv ~dbg k
-                          (Some (IR.Pop { exn_handler = handler_continuation }))
-                          [IR.Var body_result])))
+                    let env = Env.leaving_try_region env in
+                    apply_cont_with_extra_args acc env ccenv ~dbg k
+                      (Some (IR.Pop { exn_handler = handler_continuation }))
+                      [IR.Var body_result]))
               ~handler:(fun acc env ccenv ->
                 CC.close_let acc ccenv (Ident.create_local "unit")
                   Not_user_visible (End_region region) ~body:(fun acc ccenv ->
@@ -1307,7 +1309,8 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
        continuation for the code after the body. *)
     let region = Ident.create_local "region" in
     let dbg = Debuginfo.none in
-    CC.close_let acc ccenv region Not_user_visible Begin_region
+    CC.close_let acc ccenv region Not_user_visible
+      (Begin_region { try_region_parent = None })
       ~body:(fun acc ccenv ->
         maybe_insert_let_cont "body_return" Pgenval k acc env ccenv
           (fun acc env ccenv k ->

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -448,7 +448,8 @@ let unop env (op : Flambda_primitive.unary_primitive) : Fexpr.unop =
   | String_length string_or_bytes -> String_length string_or_bytes
   | Int_as_pointer | Boolean_not | Duplicate_block _ | Duplicate_array _
   | Bigarray_length _ | Int_arith _ | Float_arith _ | Reinterpret_int64_as_float
-  | Is_boxed_float | Is_flat_float_array | End_region | Obj_dup ->
+  | Is_boxed_float | Is_flat_float_array | Begin_try_region | End_region
+  | Obj_dup ->
     Misc.fatal_errorf "TODO: Unary primitive: %a"
       Flambda_primitive.Without_args.print
       (Flambda_primitive.Without_args.Unary op)

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -470,6 +470,9 @@ let simplify_is_flat_float_array dacc ~original_term ~arg:_ ~arg_ty ~result_var
 let simplify_opaque_identity dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var K.value ~original_term
 
+let simplify_begin_try_region dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
+  SPR.create_unknown dacc ~result_var K.region ~original_term
+
 let simplify_end_region dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
   let ty = T.this_tagged_immediate Targetint_31_63.zero in
   let dacc = DA.add_variable dacc result_var ty in
@@ -592,6 +595,7 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
       simplify_duplicate_array ~kind ~source_mutability ~destination_mutability
     | Duplicate_block { kind } -> simplify_duplicate_block ~kind
     | Opaque_identity { middle_end_only = _ } -> simplify_opaque_identity
+    | Begin_try_region -> simplify_begin_try_region
     | End_region -> simplify_end_region
     | Obj_dup -> simplify_obj_dup dbg
   in

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -333,6 +333,7 @@ let unary_prim_size prim =
   | Project_value_slot _ -> 1 (* load *)
   | Is_boxed_float -> 4 (* tag load + comparison *)
   | Is_flat_float_array -> 4 (* tag load + comparison *)
+  | Begin_try_region -> 1
   | End_region -> 1
   | Obj_dup -> alloc_extcall_size + 1
 

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -206,7 +206,8 @@ type nullary_primitive =
       (** Returns a boolean saying whether the given tracing probe is enabled. *)
   | Begin_region
       (** Starting delimiter of local allocation region, returning a region
-          name. *)
+          name. For regions for the "try" part of a "try...with", use
+          [Begin_try_region] (below) instead. *)
 
 (** Untagged binary integer arithmetic operations.
 
@@ -288,6 +289,9 @@ type unary_primitive =
       (** Only valid when the float array optimisation is enabled. *)
   | Is_flat_float_array
       (** Only valid when the float array optimisation is enabled. *)
+  | Begin_try_region
+      (** Starting delimiter of local allocation region, when used for a "try"
+          body, accepting the parent region as argument. *)
   | End_region
       (** Ending delimiter of local allocation region, accepting a region name. *)
   | Obj_dup  (** Corresponds to [Obj.dup]; see the documentation in obj.mli. *)

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -93,6 +93,16 @@ let unit0 ~offsets flambda_unit ~all_code =
       (Flambda_unit.return_continuation flambda_unit)
       ~param_types:(List.map snd return_cont_params)
   in
+  (* [my_region] can be referenced in [Begin_try_region] primitives so must be
+     in the environment; but the Cmm value to which it is bound will never be
+     used. *)
+  let env =
+    Env.bind_variable env
+      (Flambda_unit.toplevel_my_region flambda_unit)
+      ~defining_expr:(C.unit ~dbg:Debuginfo.none)
+      ~num_normal_occurrences_of_bound_vars:Variable.Map.empty
+      ~effects_and_coeffects_of_defining_expr:Effects_and_coeffects.pure
+  in
   let r = R.create ~module_symbol:(Flambda_unit.module_symbol flambda_unit) in
   let body, res = To_cmm_expr.expr env r (Flambda_unit.body flambda_unit) in
   let body =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -617,6 +617,7 @@ let unary_primitive env res dbg f arg =
         ~else_dbg:dbg )
   | Is_flat_float_array ->
     None, res, C.eq ~dbg (C.get_tag arg dbg) (C.floatarray_tag dbg)
+  | Begin_try_region -> None, res, C.beginregion ~dbg
   | End_region -> None, res, C.return_unit dbg (C.endregion ~dbg arg)
 
 let binary_primitive env dbg f x y =


### PR DESCRIPTION
Code generation for local allocation regions in `try...with` blocks is currently incorrect after this commit: https://github.com/ocaml-flambda/flambda-backend/pull/809/commits/2311e03f4d0f7def4caca361b43e95efd4651b3c

There must not be an `End_region` at the end of the `try` block as a local allocation done within the block may need to be returned.  This PR implements @lthls 's suggestion from 7th September (see Slack) which links the "try region" `Begin_region` primitives to their parent, and unwinds the above change.  The comment in this diff explains how it works.