### PR TITLE
Fix for regions in Selectgen under Flambda 2, plus better comment

### DIFF
--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -252,6 +252,8 @@ type expression =
   | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
       * expression * Debuginfo.t * value_kind
+  (** Only if the [trywith_kind] is [Regular] will a region be inserted for
+      the "try" block. *)
   | Cregion of expression
   | Ctail of expression
 

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1062,7 +1062,9 @@ method emit_expr (env:environment) exp =
          exceptional path. It must not be ended in the non-exception case
          as local allocations may be returned from the body of the "try". *)
       let end_region =
-        if Config.stack_allocation && not Config.flambda2 then begin
+        if Config.stack_allocation
+          && match kind with Regular -> true | Delayed _ -> false
+        then begin
           let reg = self#regs_for typ_int in
           self#insert env (Iop Ibeginregion) [| |] reg;
           fun handler_instruction -> instr_cons (Iop Iendregion) reg [| |] handler_instruction

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1059,9 +1059,10 @@ method emit_expr (env:environment) exp =
       end
   | Ctrywith(e1, kind, v, e2, _dbg, _value_kind) ->
       (* This region is used only to clean up local allocations in the
-         exceptional path. It need not be ended in the non-exception case. *)
+         exceptional path. It must not be ended in the non-exception case
+         as local allocations may be returned from the body of the "try". *)
       let end_region =
-        if Config.stack_allocation then begin
+        if Config.stack_allocation && not Config.flambda2 then begin
           let reg = self#regs_for typ_int in
           self#insert env (Iop Ibeginregion) [| |] reg;
           fun handler_instruction -> instr_cons (Iop Iendregion) reg [| |] handler_instruction


### PR DESCRIPTION
@lthls spotted that we were inserting begin/end region operations for `Ctrywith` even though, under Flambda 2, they have already been inserted.

This PR also clarifies a nearby comment.