### PR TITLE
Better handling of mutable prim free names in flow analysis

### DIFF
--- a/middle_end/flambda2/simplify/flow/data_flow_graph.ml
+++ b/middle_end/flambda2/simplify/flow/data_flow_graph.ml
@@ -246,16 +246,6 @@ let add_name_occurrences name_occurrences
   in
   { t with unconditionally_used; code_id_unconditionally_used }
 
-let mutable_prim_free_names (mutable_prim : T.Mutable_prim.t) :
-    Name_occurrences.t =
-  match mutable_prim with
-  | Is_int block | Get_tag block | Block_load { block; _ } ->
-    Name_occurrences.singleton_variable block Name_mode.normal
-  | Block_set { block; value; _ } ->
-    Name_occurrences.add_variable (Simple.free_names value) block
-      Name_mode.normal
-  | Make_block { fields; _ } -> Simple.List.free_names fields
-
 let add_continuation_info map ~return_continuation ~exn_continuation
     ~used_value_slots _
     T.Continuation_info.
@@ -321,15 +311,18 @@ let add_continuation_info map ~return_continuation ~exn_continuation
   in
   let t =
     List.fold_left
-      (fun t T.Mutable_let_prim.{ bound_var; prim; named_rewrite_id = _ } ->
+      (fun t
+           T.Mutable_let_prim.
+             { bound_var; prim; original_prim; named_rewrite_id = _ } ->
         let src = Name.var bound_var in
         match prim with
         | Is_int _ | Get_tag _ | Make_block _ | Block_load _ ->
           Name_occurrences.fold_names
             ~f:(fun t dst -> add_dependency ~src ~dst t)
-            (mutable_prim_free_names prim)
+            (Flambda_primitive.free_names original_prim)
             ~init:t
-        | Block_set _ -> add_name_occurrences (mutable_prim_free_names prim) t)
+        | Block_set _ ->
+          add_name_occurrences (Flambda_primitive.free_names original_prim) t)
       t mutable_let_prims_rev
   in
   let t =

--- a/middle_end/flambda2/simplify/flow/data_flow_graph.ml
+++ b/middle_end/flambda2/simplify/flow/data_flow_graph.ml
@@ -315,6 +315,11 @@ let add_continuation_info map ~return_continuation ~exn_continuation
            T.Mutable_let_prim.
              { bound_var; prim; original_prim; named_rewrite_id = _ } ->
         let src = Name.var bound_var in
+        (* This is an over-aproximation of the the dependencies after mutable
+           unboxing, but: if no unboxing happen this is the correct
+           dependencies, if some unboxing happens, then we will run a second
+           round of optimisation on the current function (if this is the code of
+           a function) that will actually remove those spurious dependencies *)
         match prim with
         | Is_int _ | Get_tag _ | Make_block _ | Block_load _ ->
           Name_occurrences.fold_names

--- a/middle_end/flambda2/simplify/flow/flow_acc.ml
+++ b/middle_end/flambda2/simplify/flow/flow_acc.ml
@@ -144,10 +144,10 @@ let record_var_alias var definition t =
       let defined = Variable.Set.add var elt.defined in
       { elt with direct_aliases; defined })
 
-let record_ref_named named_rewrite_id ~bound_to prim (t : t) =
+let record_ref_named named_rewrite_id ~bound_to original_prim prim (t : t) =
   update_top_of_stack ~t ~f:(fun cont_info ->
       let mutable_let_prim : T.Mutable_let_prim.t =
-        { bound_var = bound_to; named_rewrite_id; prim }
+        { bound_var = bound_to; named_rewrite_id; original_prim; prim }
       in
       let mutable_let_prims_rev =
         mutable_let_prim :: cont_info.mutable_let_prims_rev
@@ -357,21 +357,21 @@ let record_let_binding ~rewrite_id ~generate_phantom_lets ~let_bound
         match Simple.must_be_var simple with
         | Some (v, _) ->
           record_var_bindings
-            (record_ref_named rewrite_id ~bound_to:var (Is_int v) t)
+            (record_ref_named rewrite_id ~bound_to:var prim (Is_int v) t)
             Name_occurrences.empty
         | None -> record_var_bindings t free_names)
       | Unary (Get_tag, simple) -> (
         match Simple.must_be_var simple with
         | Some (v, _) ->
           record_var_bindings
-            (record_ref_named rewrite_id ~bound_to:var (Get_tag v) t)
+            (record_ref_named rewrite_id ~bound_to:var prim (Get_tag v) t)
             Name_occurrences.empty
         | None -> record_var_bindings t free_names)
       | Binary (Block_load (bak, mut), block, field) -> (
         match get_block_and_constant_field ~block ~field with
         | Some (block, field) ->
           record_var_bindings
-            (record_ref_named rewrite_id ~bound_to:var
+            (record_ref_named rewrite_id ~bound_to:var prim
                (Block_load { bak; mut; block; field })
                t)
             Name_occurrences.empty
@@ -379,13 +379,13 @@ let record_let_binding ~rewrite_id ~generate_phantom_lets ~let_bound
       | Ternary (Block_set (bak, _), block, field, value) -> (
         match get_block_and_constant_field ~block ~field with
         | Some (block, field) ->
-          record_ref_named rewrite_id ~bound_to:var
+          record_ref_named rewrite_id ~bound_to:var prim
             (Block_set { bak; block; field; value })
             t
         | None -> add_used_in_current_handler free_names t)
       | Variadic (Make_block (kind, mut, alloc_mode), fields) ->
         record_var_bindings
-          (record_ref_named rewrite_id ~bound_to:var
+          (record_ref_named rewrite_id ~bound_to:var prim
              (Make_block { kind; mut; alloc_mode; fields })
              t)
           Name_occurrences.empty

--- a/middle_end/flambda2/simplify/flow/flow_acc.ml
+++ b/middle_end/flambda2/simplify/flow/flow_acc.ml
@@ -144,7 +144,7 @@ let record_var_alias var definition t =
       let defined = Variable.Set.add var elt.defined in
       { elt with direct_aliases; defined })
 
-let record_ref_named named_rewrite_id ~bound_to original_prim prim (t : t) =
+let record_ref_named named_rewrite_id ~bound_to ~original_prim ~prim (t : t) =
   update_top_of_stack ~t ~f:(fun cont_info ->
       let mutable_let_prim : T.Mutable_let_prim.t =
         { bound_var = bound_to; named_rewrite_id; original_prim; prim }
@@ -346,10 +346,10 @@ let record_let_binding ~rewrite_id ~generate_phantom_lets ~let_bound
       let var = Bound_var.var bound_var in
       record_var_alias var simple t
     | Set_of_closures _ | Rec_info _ -> record_var_bindings t free_names
-    | Prim (prim, _) -> (
+    | Prim (original_prim, _) -> (
       let bound_var = Bound_pattern.must_be_singleton let_bound in
       let var = Bound_var.var bound_var in
-      match[@ocaml.warning "-4"] prim with
+      match[@ocaml.warning "-4"] original_prim with
       | Unary (End_region, _region) ->
         (* Uses of region variables in [End_region] don't count as uses. *)
         t
@@ -357,40 +357,42 @@ let record_let_binding ~rewrite_id ~generate_phantom_lets ~let_bound
         match Simple.must_be_var simple with
         | Some (v, _) ->
           record_var_bindings
-            (record_ref_named rewrite_id ~bound_to:var prim (Is_int v) t)
+            (record_ref_named rewrite_id ~bound_to:var ~original_prim
+               ~prim:(Is_int v) t)
             Name_occurrences.empty
         | None -> record_var_bindings t free_names)
       | Unary (Get_tag, simple) -> (
         match Simple.must_be_var simple with
         | Some (v, _) ->
           record_var_bindings
-            (record_ref_named rewrite_id ~bound_to:var prim (Get_tag v) t)
+            (record_ref_named rewrite_id ~bound_to:var ~original_prim
+               ~prim:(Get_tag v) t)
             Name_occurrences.empty
         | None -> record_var_bindings t free_names)
       | Binary (Block_load (bak, mut), block, field) -> (
         match get_block_and_constant_field ~block ~field with
         | Some (block, field) ->
           record_var_bindings
-            (record_ref_named rewrite_id ~bound_to:var prim
-               (Block_load { bak; mut; block; field })
+            (record_ref_named rewrite_id ~bound_to:var ~original_prim
+               ~prim:(Block_load { bak; mut; block; field })
                t)
             Name_occurrences.empty
         | None -> record_var_bindings t free_names)
       | Ternary (Block_set (bak, _), block, field, value) -> (
         match get_block_and_constant_field ~block ~field with
         | Some (block, field) ->
-          record_ref_named rewrite_id ~bound_to:var prim
-            (Block_set { bak; block; field; value })
+          record_ref_named rewrite_id ~bound_to:var ~original_prim
+            ~prim:(Block_set { bak; block; field; value })
             t
         | None -> add_used_in_current_handler free_names t)
       | Variadic (Make_block (kind, mut, alloc_mode), fields) ->
         record_var_bindings
-          (record_ref_named rewrite_id ~bound_to:var prim
-             (Make_block { kind; mut; alloc_mode; fields })
+          (record_ref_named rewrite_id ~bound_to:var ~original_prim
+             ~prim:(Make_block { kind; mut; alloc_mode; fields })
              t)
           Name_occurrences.empty
       | _ ->
-        if Flambda_primitive.at_most_generative_effects prim
+        if Flambda_primitive.at_most_generative_effects original_prim
         then (* the primitive can be removed *)
           record_var_bindings t free_names
         else

--- a/middle_end/flambda2/simplify/flow/flow_analysis.ml
+++ b/middle_end/flambda2/simplify/flow/flow_analysis.ml
@@ -95,7 +95,7 @@ let analyze ?(speculative = false) ?print_name ~return_continuation
           ~return_continuation ~exn_continuation
       in
       let pp_node = Mutable_unboxing.pp_node reference_analysis in
-      let reference_result, required_regions, unboxed_blocks =
+      let reference_result, unboxed_blocks =
         Mutable_unboxing.make_result reference_analysis
       in
       let continuation_parameters =
@@ -121,7 +121,7 @@ let analyze ?(speculative = false) ?print_name ~return_continuation
             in
             Name.Set.union required_names (Name.set_of_var_set params))
           reference_result.T.Mutable_unboxing_result.additionnal_epa
-          (Name.Set.union dead_variable_result.required_names required_regions)
+          dead_variable_result.required_names
       in
       let result =
         T.Flow_result.

--- a/middle_end/flambda2/simplify/flow/flow_types.ml
+++ b/middle_end/flambda2/simplify/flow/flow_types.ml
@@ -81,10 +81,11 @@ module Mutable_let_prim = struct
   type t =
     { bound_var : Variable.t;
       prim : Mutable_prim.t;
+      original_prim : Flambda_primitive.t;
       named_rewrite_id : Named_rewrite_id.t
     }
 
-  let print ppf { bound_var; prim; named_rewrite_id = _ } =
+  let print ppf { bound_var; prim; original_prim = _; named_rewrite_id = _ } =
     Format.fprintf ppf "%a = %a" Variable.print bound_var Mutable_prim.print
       prim
 

--- a/middle_end/flambda2/simplify/flow/flow_types.mli
+++ b/middle_end/flambda2/simplify/flow/flow_types.mli
@@ -68,6 +68,7 @@ module Mutable_let_prim : sig
   type t =
     { bound_var : Variable.t;
       prim : Mutable_prim.t;
+      original_prim : Flambda_primitive.t;
       named_rewrite_id : Named_rewrite_id.t
     }
 

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
@@ -504,7 +504,9 @@ module Fold_prims = struct
           in
           let env =
             List.fold_left
-              (fun env T.Mutable_let_prim.{ named_rewrite_id; bound_var; prim } ->
+              (fun env
+                   T.Mutable_let_prim.
+                     { named_rewrite_id; bound_var; prim; original_prim = _ } ->
                 apply_prim ~dom ~non_escaping_blocks env named_rewrite_id
                   bound_var prim)
               env

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
@@ -32,8 +32,7 @@ type t =
   { non_escaping_makeblocks : non_escaping_block Variable.Map.t;
     continuations_with_live_block : Variable.Set.t Continuation.Map.t;
     extra_params_and_args : (extra_params * extra_args) Continuation.Map.t;
-    rewrites : Named_rewrite.t Named_rewrite_id.Map.t;
-    required_regions : Name.Set.t
+    rewrites : Named_rewrite.t Named_rewrite_id.Map.t
   }
 
 (* Escaping analysis *)
@@ -200,22 +199,16 @@ let escaping ~(dom : Dominator_graph.alias_map) ~(dom_graph : Dominator_graph.t)
 
 (* *)
 
-let non_escaping_makeblocks_and_required_regions ~escaping ~source_info =
+let non_escaping_makeblocks ~escaping ~source_info =
   Continuation.Map.fold
-    (fun _cont (elt : T.Continuation_info.t) (map, regions) ->
+    (fun _cont (elt : T.Continuation_info.t) map ->
       List.fold_left
-        (fun (map, regions) T.Mutable_let_prim.{ bound_var = var; prim; _ } ->
+        (fun map T.Mutable_let_prim.{ bound_var = var; prim; _ } ->
           match prim with
-          | Block_load _ | Block_set _ | Is_int _ | Get_tag _ -> map, regions
-          | Make_block { kind; alloc_mode; fields; _ } ->
+          | Block_load _ | Block_set _ | Is_int _ | Get_tag _ -> map
+          | Make_block { kind; alloc_mode = _; fields; _ } ->
             if Variable.Set.mem var escaping
-            then
-              let regions =
-                match alloc_mode with
-                | Heap -> regions
-                | Local { region } -> Name.Set.add (Name.var region) regions
-              in
-              map, regions
+            then map
             else
               let non_escaping_block =
                 match kind with
@@ -229,10 +222,9 @@ let non_escaping_makeblocks_and_required_regions ~escaping ~source_info =
                         fields
                   }
               in
-              Variable.Map.add var non_escaping_block map, regions)
-        (map, regions) elt.mutable_let_prims_rev)
-    source_info.T.Acc.map
-    (Variable.Map.empty, Name.Set.empty)
+              Variable.Map.add var non_escaping_block map)
+        map elt.mutable_let_prims_rev)
+    source_info.T.Acc.map Variable.Map.empty
 
 let prims_using_block ~non_escaping_blocks ~dom prim =
   match (prim : T.Mutable_prim.t) with
@@ -549,9 +541,7 @@ let create ~(dom : Dominator_graph.alias_map) ~(dom_graph : Dominator_graph.t)
     escaping ~dom ~dom_graph ~source_info ~required_names ~return_continuation
       ~exn_continuation
   in
-  let non_escaping_blocks, required_regions =
-    non_escaping_makeblocks_and_required_regions ~escaping ~source_info
-  in
+  let non_escaping_blocks = non_escaping_makeblocks ~escaping ~source_info in
   if (not (Variable.Map.is_empty non_escaping_blocks))
      && Flambda_features.dump_flow ()
   then
@@ -582,8 +572,7 @@ let create ~(dom : Dominator_graph.alias_map) ~(dom_graph : Dominator_graph.t)
   { extra_params_and_args;
     non_escaping_makeblocks = non_escaping_blocks;
     continuations_with_live_block;
-    rewrites;
-    required_regions
+    rewrites
   }
 
 let pp_node { non_escaping_makeblocks = _; continuations_with_live_block; _ }
@@ -672,5 +661,4 @@ let make_result result =
   let additionnal_epa = add_to_extra_params_and_args result in
   let let_rewrites = result.rewrites in
   ( T.Mutable_unboxing_result.{ additionnal_epa; let_rewrites },
-    result.required_regions,
     Variable.Map.keys result.non_escaping_makeblocks )

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.mli
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.mli
@@ -24,7 +24,6 @@ val create :
   exn_continuation:Continuation.t ->
   t
 
-val make_result :
-  t -> Flow_types.Mutable_unboxing_result.t * Name.Set.t * Variable.Set.t
+val make_result : t -> Flow_types.Mutable_unboxing_result.t * Variable.Set.t
 
 val pp_node : t -> Format.formatter -> Continuation.t -> unit


### PR DESCRIPTION
We now use the free_names function from Flambda_primitive instead of a manual (and as it turns out, buggy) re-implementation.

This should fix a bug related to regions not being properly tracked in some cases due to the new code for mutable unboxing.