### PR TITLE
Prefetch value with offset builtins

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3540,22 +3540,22 @@ let transl_builtin name args dbg typ_res =
     ext_pointer_prefetch ~is_write:false Moderate (one_arg name args) dbg
   | "caml_prefetch_read_low_ext_pointer" ->
     ext_pointer_prefetch ~is_write:false Low (one_arg name args) dbg
-  (* Native_pointer prefetch *)
-  | "caml_prefetch_write_high_native_pointer_unboxed" ->
+  (* Value and unboxed Native_pointer prefetch *)
+  | "caml_prefetch_write_high" ->
     prefetch ~is_write:true High (one_arg name args) dbg
-  | "caml_prefetch_write_moderate_native_pointer_unboxed" ->
+  | "caml_prefetch_write_moderate" ->
     prefetch ~is_write:true Moderate (one_arg name args) dbg
-  | "caml_prefetch_write_low_native_pointer_unboxed" ->
+  | "caml_prefetch_write_low" ->
     prefetch ~is_write:true Low (one_arg name args) dbg
-  | "caml_prefetch_write_none_native_pointer_unboxed" ->
+  | "caml_prefetch_write_none" ->
     prefetch ~is_write:true Nonlocal (one_arg name args) dbg
-  | "caml_prefetch_read_none_native_pointer_unboxed" ->
+  | "caml_prefetch_read_none" ->
     prefetch ~is_write:false Nonlocal (one_arg name args) dbg
-  | "caml_prefetch_read_high_native_pointer_unboxed" ->
+  | "caml_prefetch_read_high" ->
     prefetch ~is_write:false High (one_arg name args) dbg
-  | "caml_prefetch_read_moderate_native_pointer_unboxed" ->
+  | "caml_prefetch_read_moderate" ->
     prefetch ~is_write:false Moderate (one_arg name args) dbg
-  | "caml_prefetch_read_low_native_pointer_unboxed" ->
+  | "caml_prefetch_read_low" ->
     prefetch ~is_write:false Low (one_arg name args) dbg
   (* Prefetch value with offset *)
   | "caml_prefetch_write_high_val_offset_untagged" ->


### PR DESCRIPTION
Adding bulitins for prefetching values with an arbitrary byte offset. This reuses the existing prefetching path.