### PR TITLE
Flambda1 region deletion and locals fixes

### DIFF
--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -676,11 +676,12 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
     inlined = inlined_requested; specialise = specialise_requested;
     probe = probe_requested;
   } = apply in
-  (* TODO: Most applications do not do local allocations in the current region,
-     but this is not yet tracked, so we conservatively assume they may.
-     Note that tail calls should always set the region used to true, because
-     removing the surrounding region would change their meaning. *)
-  let r = R.set_region_use r true in
+  let r =
+    match reg_close, mode with
+    | (Rc_normal | Rc_nontail), Alloc_heap -> r
+    | Rc_close_at_apply, _
+    | _, Alloc_local -> R.set_region_use r true
+  in
   let dbg = E.add_inlined_debuginfo env ~dbg in
   simplify_free_variable env lhs_of_application
     ~f:(fun env lhs_of_application lhs_of_application_approx ->

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -842,6 +842,13 @@ and simplify_partial_application env r ~lhs_of_application
     List.fold_left (fun _mode (p,_) -> Parameter.alloc_mode p)
       function_decl.A.alloc_mode applied_args
   in
+  if not (Lambda.sub_mode partial_mode mode) then
+    Misc.fatal_errorf "Partial application of %a with wrong mode at %s"
+      Closure_id.print closure_id_being_applied
+      (Debuginfo.to_string dbg);
+  let result_mode =
+    if function_decl.A.region then Lambda.alloc_heap else Lambda.alloc_local
+  in
   let wrapper_accepting_remaining_args =
     let body : Flambda.t =
       Apply {
@@ -850,7 +857,7 @@ and simplify_partial_application env r ~lhs_of_application
         kind = Direct closure_id_being_applied;
         dbg;
         reg_close = Rc_normal;
-        mode;
+        mode = result_mode;
         inlined = Default_inlined;
         specialise = Default_specialise;
         probe = None;

--- a/ocaml/Makefile.menhir
+++ b/ocaml/Makefile.menhir
@@ -111,6 +111,9 @@ import-menhirLib:
 	@ cp \
            $(addprefix `$(MENHIR) --suggest-menhirLib`/menhirLib.,ml mli) \
            boot/menhir
+# Partial applications of the form Obj.magic f x in menhirLib cause an issue with locals,
+# so rewrite these to Obj.magic (f x)
+	@ sed -i 's/\b\(in\|then\|with\|else\)\b/@@@\1/g; s/Obj.magic \([a-z0-9_]\+\( [a-z0-9_]\+\)\+\)/Obj.magic (\1)/g;  s/@@@//g' boot/menhir/menhirLib.ml
 
 
 ## demote-menhir

--- a/ocaml/boot/menhir/menhirLib.ml
+++ b/ocaml/boot/menhir/menhirLib.ml
@@ -1646,7 +1646,7 @@ module Make (T : TABLE) = struct
                    'a checkpoint
   = function
     | InputNeeded env ->
-        Obj.magic discard env
+        Obj.magic (discard env)
     | _ ->
         invalid_arg "offer expects InputNeeded"
 
@@ -1656,9 +1656,9 @@ module Make (T : TABLE) = struct
     | HandlingError env ->
         Obj.magic error ~strategy env
     | Shifting (_, env, please_discard) ->
-        Obj.magic run env please_discard
+        Obj.magic (run env please_discard)
     | AboutToReduce (env, prod) ->
-        Obj.magic reduce env prod
+        Obj.magic (reduce env prod)
     | _ ->
         invalid_arg "resume expects HandlingError | Shifting | AboutToReduce"
 

--- a/ocaml/middle_end/flambda/inline_and_simplify.ml
+++ b/ocaml/middle_end/flambda/inline_and_simplify.ml
@@ -675,11 +675,12 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
     inlined = inlined_requested; specialise = specialise_requested;
     probe = probe_requested;
   } = apply in
-  (* TODO: Most applications do not do local allocations in the current region,
-     but this is not yet tracked, so we conservatively assume they may.
-     Note that tail calls should always set the region used to true, because
-     removing the surrounding region would change their meaning. *)
-  let r = R.set_region_use r true in
+  let r =
+    match reg_close, mode with
+    | (Rc_normal | Rc_nontail), Alloc_heap -> r
+    | Rc_close_at_apply, _
+    | _, Alloc_local -> R.set_region_use r true
+  in
   let dbg = E.add_inlined_debuginfo env ~dbg in
   simplify_free_variable env lhs_of_application
     ~f:(fun env lhs_of_application lhs_of_application_approx ->

--- a/ocaml/middle_end/flambda/inline_and_simplify.ml
+++ b/ocaml/middle_end/flambda/inline_and_simplify.ml
@@ -841,6 +841,13 @@ and simplify_partial_application env r ~lhs_of_application
     List.fold_left (fun _mode (p,_) -> Parameter.alloc_mode p)
       function_decl.A.alloc_mode applied_args
   in
+  if not (Lambda.sub_mode partial_mode mode) then
+    Misc.fatal_errorf "Partial application of %a with wrong mode at %s"
+      Closure_id.print closure_id_being_applied
+      (Debuginfo.to_string dbg);
+  let result_mode =
+    if function_decl.A.region then Lambda.alloc_heap else Lambda.alloc_local
+  in
   let wrapper_accepting_remaining_args =
     let body : Flambda.t =
       Apply {
@@ -849,7 +856,7 @@ and simplify_partial_application env r ~lhs_of_application
         kind = Direct closure_id_being_applied;
         dbg;
         reg_close = Rc_normal;
-        mode;
+        mode = result_mode;
         inlined = Default_inlined;
         specialise = Default_specialise;
         probe = None;


### PR DESCRIPTION
The original impetus for this patch was to squash an old TODO in Flambda1's treatment of local regions. Flambda deletes unused regions, both as an optimisation in itself and because they inhibit other optimisations. Originally, it conservatively assumed that any region containing an application was used, since it didn't track whether applications may allocate on their caller's region.

Nowadays, that information is tracked in the `ap_mode` field, so we can make the optimisation more precise by marking a region used only for those applications which do allocate on their caller's region. This is the first commit.

---

However, this commit causes a testsuite failure. When Flambda1 generates a partial application closure (that is, expands a partial application `f a` to a closure `fun b -> f a b`), the `ap_mode` field on the generated application (`f a b`) was incorrect. Previously, this didn't matter (`ap_mode` was only used to control generation of the indirect call stubs `caml_applyN`, but the application generated here is never indirect), but with the new region-deletion logic it starts to matter.

So, the second commit here fixes the partial appliction modes, copying the correct logic from Closure. Since modes are available from two different sources (from the closure and from the application site), it also adds an assertion that these modes are compatible, which is ensured by typechecking.

---

However, _that_ commit caused the compiler to fail to build, due to the assertion above firing on a use of `Obj.magic` in `boot/menhir/menhirLib.ml` that looked like this:
```ocaml
Obj.magic discard env
```
Note that this is `(Obj.magic discard) env`, not `Obj.magic (discard env)` - the magic is being applied to the function rather than to its result. Since `discard` is a two-argument function, this is a partial application that can get the modes wrong. This turns out to be unsafe: the following example crashes in the debug runtime (and variants corrupt memory / segfault):
```ocaml
module M : sig
  val f : int -> string -> int * string
end = struct
  let[@inline never] pair a b =
    a, b

  let f x =
    Obj.magic pair x
end

let g = (Sys.opaque_identity M.f) 42
let () = Gc.compact ()
```
This code is completely safe without stack allocation, but with stack allocation turned on the compiler stack-allocates the partial application yet claims it is heap allocated via Obj.magic.

So, since the assertion seems to find real issues, I left it in. This will cause some compilation failures. I patched Menhir manually (and added a horrific sed script to do so on future menhir upgrades), but there may be other occurrences of this issue. The fix is to parenthesise calls to `Obj.magic` (or better, to give explicit type annotations indicating which types you plan to `magic` to and from)