### PR TITLE
Flush hack for end_region

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -723,7 +723,12 @@ module M = Map.Make (struct
   let compare x y = compare y x
 end)
 
-let flush_delayed_lets ?(entering_loop = false) env res =
+type flush_mode =
+  | Entering_loop
+  | Branching_point
+  | Flush_everything
+
+let flush_delayed_lets ~mode env res =
   (* Generate a wrapper function to introduce the delayed let-bindings. *)
   let wrap_flush order_map e =
     M.fold
@@ -755,22 +760,28 @@ let flush_delayed_lets ?(entering_loop = false) env res =
           flush binding;
           None
         | Must_inline_and_duplicate -> (
-          let r, split_res = split_complex_binding ~env ~res:!res b in
-          res := r;
-          match split_res with
-          | Already_split -> Some binding
-          | Split { new_bindings; split_binding } ->
-            List.iter flush new_bindings;
-            Some (Binding split_binding))
+          begin match mode with
+            | Flush_everything -> flush binding; None
+            | Branching_point | Entering_loop ->
+              let r, split_res = split_complex_binding ~env ~res:!res b in
+              res := r;
+              match split_res with
+              | Already_split -> Some binding
+              | Split { new_bindings; split_binding } ->
+                List.iter flush new_bindings;
+                Some (Binding split_binding)
+          end)
         | Must_inline_once -> (
-          match To_cmm_effects.classify_by_effects_and_coeffects b.effs with
+          match mode, To_cmm_effects.classify_by_effects_and_coeffects b.effs with
           (* when not entering a loop, and with pure/generative effects at most,
              we can wait to split the binding, so that we can have a chance to
              try and push the arguments down the branch (otherwise, when we
              split, the arguments of the splittable binding would be flushed
              before the branch in control flow). *)
-          | (Pure | Generative_immutable) when not entering_loop -> Some binding
-          | Pure | Generative_immutable | Coeffect_only | Effect -> (
+          | Flush_everything, _ -> flush binding; None
+          | Branching_point, (Pure | Generative_immutable) -> Some binding
+          | (Branching_point | Entering_loop),
+            (Pure | Generative_immutable | Coeffect_only | Effect) -> (
             let r, split_res = split_complex_binding ~env ~res:!res b in
             res := r;
             match split_res with
@@ -784,12 +795,11 @@ let flush_delayed_lets ?(entering_loop = false) env res =
              inlined, ensuring that the corresponding expressions are sunk down
              as far as possible, including past control flow branching
              points. *)
-          | Pure ->
-            if entering_loop
-            then (
-              flush binding;
-              None)
-            else Some binding
+            | Pure ->
+              begin match mode with
+                | Flush_everything | Entering_loop -> flush binding; None
+                | Branching_point -> Some binding
+              end
           | Generative_immutable | Coeffect_only | Effect ->
             flush binding;
             None))

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -227,10 +227,15 @@ val inline_variable :
   Variable.t ->
   Cmm.expression * t * To_cmm_result.t * Effects_and_coeffects.t
 
+type flush_mode =
+  | Entering_loop
+  | Branching_point
+  | Flush_everything
+
 (** Wrap the given Cmm expression with all the delayed let bindings accumulated
     in the environment. *)
 val flush_delayed_lets :
-  ?entering_loop:bool ->
+  mode:flush_mode ->
   t ->
   To_cmm_result.t ->
   (Cmm.expression -> Cmm.expression) * t * To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -365,9 +365,9 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
        and coeffects that are not precise enough. Particularly, an immutable
        load of a locally allocated block is considered as pure, and thus can be
        moved past an end_region. Here we also need to flush everything,
-       including must_inline bindings, particularly projections that may
-       project from locally allocated closures (and that must not be moved past
-       an end_region). *)
+       including must_inline bindings, particularly projections that may project
+       from locally allocated closures (and that must not be moved past an
+       end_region). *)
     let wrap, env, res =
       Env.flush_delayed_lets ~mode:Flush_everything env res
     in

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -365,7 +365,7 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
        and coeffects that are not precise enough. Particularly, an immutable
        load of a locally allocated block is considered as pure, and thus can be
        moved past an end_region. Here we also need to flush everything,
-       including must_inline bindings, particularly projections that mayb
+       including must_inline bindings, particularly projections that may
        project from locally allocated closures (and that must not be moved past
        an end_region). *)
     let wrap, env, res =


### PR DESCRIPTION
This introduces a flush of every binding (including must_inline bindings) before every end_region primitives. Otherwise, some primitives that project from local blocks can sometimes be moved past an end_region, thus reading from freed memory, and resulting in segfaults (or worse).