### PR TITLE
Treat my_region as parameter in To_cmm

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -93,9 +93,7 @@ let unit0 ~offsets flambda_unit ~all_code =
       (Flambda_unit.return_continuation flambda_unit)
       ~param_types:(List.map snd return_cont_params)
   in
-  (* [my_region] can be referenced in [Begin_try_region] primitives so must be
-     in the environment; but the Cmm value to which it is bound will never be
-     used. *)
+  (* See comment in [To_cmm_set_of_closures] about binding [my_region] *)
   let env, _bound_var =
     Env.create_bound_parameter env
       (Flambda_unit.toplevel_my_region flambda_unit)

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -96,12 +96,9 @@ let unit0 ~offsets flambda_unit ~all_code =
   (* [my_region] can be referenced in [Begin_try_region] primitives so must be
      in the environment; but the Cmm value to which it is bound will never be
      used. *)
-  let env =
-    Env.bind_variable env
+  let env, _bound_var =
+    Env.create_bound_parameter env
       (Flambda_unit.toplevel_my_region flambda_unit)
-      ~defining_expr:(C.unit ~dbg:Debuginfo.none)
-      ~num_normal_occurrences_of_bound_vars:Variable.Map.empty
-      ~effects_and_coeffects_of_defining_expr:Effects_and_coeffects.pure
   in
   let r = R.create ~module_symbol:(Flambda_unit.module_symbol flambda_unit) in
   let body, res = To_cmm_expr.expr env r (Flambda_unit.body flambda_unit) in

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -303,7 +303,7 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
   (* [my_region] can be referenced in [Begin_try_region] primitives so must be
      in the environment; however it should never end up in actual generated
      code, so we don't need any binder for it (this is why we can ignore
-     [_bound_var]. If it does end up in generated code, Selection will complain
+     [_bound_var]). If it does end up in generated code, Selection will complain
      and refuse to compile the code. *)
   let env, _bound_var = Env.create_bound_parameter env my_region in
   (* Translate the arg list and body *)

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -303,11 +303,7 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
   (* [my_region] can be referenced in [Begin_try_region] primitives so must be
      in the environment; but the Cmm value to which it is bound will never be
      used. *)
-  let env =
-    Env.bind_variable env my_region ~defining_expr:(C.unit ~dbg:fun_dbg)
-      ~num_normal_occurrences_of_bound_vars:Variable.Map.empty
-      ~effects_and_coeffects_of_defining_expr:Ece.pure
-  in
+  let env, _bound_var = Env.create_bound_parameter env my_region in
   (* Translate the arg list and body *)
   let env, fun_args = C.bound_parameters env params in
   let fun_body, res = translate_expr env res body in

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -301,8 +301,10 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
     Env.enter_function_body env ~return_continuation ~exn_continuation
   in
   (* [my_region] can be referenced in [Begin_try_region] primitives so must be
-     in the environment; but the Cmm value to which it is bound will never be
-     used. *)
+     in the environment; however it should never end up in actual generated
+     code, so we don't need any binder for it (this is why we can ignore
+     [_bound_var]. If it does end up in generated code, Selection will complain
+     and refuse to compile the code. *)
   let env, _bound_var = Env.create_bound_parameter env my_region in
   (* Translate the arg list and body *)
   let env, fun_args = C.bound_parameters env params in


### PR DESCRIPTION
This should fix the dummy bindings for regions that appeared after #989.