### PR TITLE
Remove `cmm_helpers.ml` from `backend/.ocamlformat-enable`

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -1,5 +1,3 @@
-cmm_helpers.ml
-cmm_helpers.mli
 internal_assembler/*.ml
 internal_assembler/*.mli
 checkmach.ml


### PR DESCRIPTION
As far as I know, `cmm_helpers.ml` is the only file with ocamlformat enabled that is kept in sync with upstream. A world with fewer conflicts is a better world.