### PR TITLE
Add a flag to regions to control `Iendregion` elision

### DIFF
--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -88,7 +88,7 @@ and instrument = function
      in
      Ccatch (isrec, cases, instrument body, kind)
   | Cexit (ex, args, traps) -> Cexit (ex, List.map instrument args, traps)
-  | Cregion e -> Cregion (instrument e)
+  | Cregion (p, e) -> Cregion (p, instrument e)
   | Ctail e -> Ctail (instrument e)
 
   (* these are base cases and have no logging *)

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -243,7 +243,7 @@ type expression =
   | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
       * expression * Debuginfo.t * value_kind
-  | Cregion of expression
+  | Cregion of Clambda.tail_policy * expression
   | Ctail of expression
 
 type property =
@@ -311,7 +311,7 @@ let iter_shallow_tail f = function
       f e1;
       f e2;
       true
-  | Cregion e ->
+  | Cregion (_, e) ->
       f e;
       true
   | Ctail e ->
@@ -357,8 +357,8 @@ let map_shallow_tail ?kind f = function
   | Ctrywith(e1, kind', id, e2, dbg, kind_before) ->
       Ctrywith(f e1, kind', id, f e2, dbg,
               Option.value kind ~default:kind_before)
-  | Cregion e ->
-      Cregion(f e)
+  | Cregion (p, e) ->
+      Cregion(p, f e)
   | Ctail e ->
       Ctail(f e)
   | Cexit _ | Cop (Craise _, _, _) as cmm ->
@@ -413,7 +413,7 @@ let iter_shallow f = function
       List.iter f el
   | Ctrywith (e1, _kind, _id, e2, _dbg, _value_kind) ->
       f e1; f e2
-  | Cregion e ->
+  | Cregion (_, e) ->
       f e
   | Ctail e ->
       f e
@@ -450,8 +450,8 @@ let map_shallow f = function
       Cexit (n, List.map f el, traps)
   | Ctrywith (e1, kind, id, e2, dbg, value_kind) ->
       Ctrywith (f e1, kind, id, f e2, dbg, value_kind)
-  | Cregion e ->
-      Cregion (f e)
+  | Cregion (p, e) ->
+      Cregion (p, f e)
   | Ctail e ->
       Ctail (f e)
   | Cconst_int _

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -252,7 +252,7 @@ type expression =
   | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
       * expression * Debuginfo.t * value_kind
-  | Cregion of expression
+  | Cregion of Clambda.tail_policy * expression
   | Ctail of expression
 
 type property =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2191,7 +2191,7 @@ let cache_public_method meths tag cache dbg =
 
 let has_local_allocs e =
   let rec loop = function
-    | Cregion e ->
+    | Cregion (_, e) ->
       (* Local allocations within a nested region do not affect this region,
          except inside a Ctail block *)
       loop_until_tail e
@@ -2220,9 +2220,12 @@ let remove_region_tail e =
   in
   match has_tail e with () -> e | exception Exit -> remove_tail e
 
-let region e =
-  (* [Cregion e] is equivalent to [e] if [e] contains no local allocs *)
-  if has_local_allocs e then Cregion e else remove_region_tail e
+let region p e =
+  (* [Cregion (p, e)] is equivalent to [e] if [e] contains no local allocs *)
+  if has_local_allocs e then
+    Cregion (p, e)
+  else
+    remove_region_tail e
 
 (* CR mshinwell: These will be filled in by later pull requests. *)
 let placeholder_dbg () = Debuginfo.none

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -771,8 +771,8 @@ val send :
   Debuginfo.t ->
   expression
 
-(** Construct [Cregion e], eliding some useless regions *)
-val region : expression -> expression
+(** Construct [Cregion (p, e)], eliding some useless regions *)
+val region : Clambda.tail_policy -> expression -> expression
 
 (** [cextcall prim args dbg type_of_result] returns Cextcall operation that
     corresponds to [prim]. If [prim] is a C builtin supported on the target,

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -176,7 +176,7 @@ let rec check env (expr : Cmm.expression) =
        not reported as an error. *)
     check env body;
     check env handler
-  | Cregion e -> check env e
+  | Cregion (_, e) -> check env e
   | Ctail e -> check env e
 
 let run ppf (fundecl : Cmm.fundecl) =

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -196,7 +196,7 @@ let rec expr_size env = function
       | RHS_block blocksize -> RHS_infix { blocksize; offset }
       | RHS_nonrec -> RHS_nonrec
       | _ -> assert false)
-  | Uregion exp ->
+  | Uregion (_, exp) ->
       expr_size env exp
   | Utail exp ->
       expr_size env exp
@@ -376,7 +376,7 @@ let rec is_unboxed_number_cmm = function
           No_unboxing
       end
     | Cexit _ | Cop (Craise _, _, _) -> No_result
-    | Csequence (_, a) | Cregion a | Ctail a
+    | Csequence (_, a) | Cregion (_, a) | Ctail a
     | Clet (_, _, a) | Cphantom_let (_, _, a) | Clet_mut (_, _, _, a) ->
       is_unboxed_number_cmm a
     | Cconst_int _
@@ -759,8 +759,8 @@ let rec transl env e =
   | Uunreachable ->
       let dbg = Debuginfo.none in
       Cop(Cload (Word_int, Mutable), [Cconst_int (0, dbg)], dbg)
-  | Uregion e ->
-      region (transl env e)
+  | Uregion (p, e) ->
+      region p (transl env e)
   | Utail e ->
       Ctail (transl env e)
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -29,6 +29,10 @@ let rec_flag ppf = function
   | Nonrecursive -> ()
   | Recursive -> fprintf ppf " rec"
 
+let tail_policy ppf : Clambda.tail_policy -> unit = function
+  | May_drop_tail -> ()
+  | Must_keep_tail -> fprintf ppf " keep_tail"
+
 let machtype_component ppf = function
   | Val -> fprintf ppf "val"
   | Addr -> fprintf ppf "addr"
@@ -340,8 +344,8 @@ let rec expr ppf = function
             trywith_kind kind sequence e1 VP.print id;
       with_location_mapping ~label:"Ctrywith" ~dbg ppf (fun () ->
             fprintf ppf "%a)@]" sequence e2);
-  | Cregion e ->
-      fprintf ppf "@[<2>(region@ %a)@]" sequence e
+  | Cregion (p, e) ->
+      fprintf ppf "@[<2>(region%a@ %a)@]" tail_policy p sequence e
   | Ctail e ->
       fprintf ppf "@[<2>(tail@ %a)@]" sequence e
 

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -22,6 +22,9 @@ open Lambda
 type function_label = string
 type arity = Lambda.function_kind * int
 type apply_kind = Lambda.region_close * Lambda.alloc_mode
+type tail_policy =
+  | Must_keep_tail
+  | May_drop_tail
 
 type ustructured_constant =
   | Uconst_float of float
@@ -88,7 +91,7 @@ and ulambda =
       meth_kind * ulambda * ulambda * ulambda list
       * apply_kind * Debuginfo.t
   | Uunreachable
-  | Uregion of ulambda
+  | Uregion of tail_policy * ulambda
   | Utail of ulambda
 
 and ufunction = {

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -23,6 +23,18 @@ type function_label = string
 type arity = Lambda.function_kind * int
 type apply_kind = Lambda.region_close * Lambda.alloc_mode
 
+(** Controls how [tail] expressions must be handled when generating code for a
+    region. May also entail invariants on the region itself. *)
+type tail_policy =
+  | Must_keep_tail
+  (** An [Iendregion] instruction must be generated for each [tail] expression
+      occurring in this region. Guarantees that there will be a [tail] (or
+      close-at-apply [apply]) at every tail position of the region. *)
+  | May_drop_tail
+  (** The [Iendregion] for a [tail] expression not occurring in (function-level)
+      tail position may be elided, and there may or may not be [tail]
+      expressions in this region. *)
+
 type ustructured_constant =
   | Uconst_float of float
   | Uconst_int32 of int32
@@ -99,7 +111,7 @@ and ulambda =
       meth_kind * ulambda * ulambda * ulambda list
       * apply_kind * Debuginfo.t
   | Uunreachable
-  | Uregion of ulambda
+  | Uregion of tail_policy * ulambda
   | Utail of ulambda
 
 and ufunction = {

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -66,14 +66,14 @@ let getglobal dbg id =
   let symbol = Compilenv.symbol_for_global id |> Linkage_name.to_string in
   Uprim (P.Pread_symbol symbol, [], dbg)
 
-let region ulam =
+let region policy ulam =
   let is_trivial =
     match ulam with
     | Uvar _ | Uconst _ -> true
     | _ -> false
   in
   if is_trivial then ulam
-  else Uregion ulam
+  else Uregion (policy, ulam)
 
 let tail ulam =
   let is_trivial =
@@ -119,7 +119,7 @@ let occurs_var var u =
     | Usend(_, met, obj, args, _, _) ->
         occurs met || occurs obj || List.exists occurs args
     | Uunreachable -> false
-    | Uregion e -> occurs e
+    | Uregion (_, e) -> occurs e
     | Utail e -> occurs e
   and occurs_array a =
     try
@@ -232,7 +232,7 @@ let lambda_smaller lam threshold =
         size := !size + 8;
         lambda_size met; lambda_size obj; lambda_list_size args
     | Uunreachable -> ()
-    | Uregion e ->
+    | Uregion (_, e) ->
         size := !size + 2;
         lambda_size e
     | Utail e ->
@@ -261,7 +261,7 @@ let rec is_pure = function
   | Uoffset(arg, _) -> is_pure arg
   | Ulet(Immutable, _, _var, def, body) ->
       is_pure def && is_pure body
-  | Uregion body -> is_pure body
+  | Uregion (_, body) -> is_pure body
   | Utail body -> is_pure body
   | _ -> false
 
@@ -738,8 +738,8 @@ let rec substitute loc ((backend, fpc) as st) sb rn ulam =
             List.map (substitute loc st sb rn) ul, pos, dbg)
   | Uunreachable ->
       Uunreachable
-  | Uregion e ->
-      region (substitute loc st sb rn e)
+  | Uregion (p, e) ->
+      region p (substitute loc st sb rn e)
   | Utail e ->
       tail (substitute loc st sb rn e)
 
@@ -1110,7 +1110,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
           in
           let body =
             match mode, fundesc.fun_region with
-            | Alloc_heap, false -> region body
+            | Alloc_heap, false -> region May_drop_tail body
             | _ -> body
           in
           let body =
@@ -1340,7 +1340,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       assert false
   | Lregion lam ->
       let ulam, approx = close env lam in
-      region ulam, approx
+      region May_drop_tail ulam, approx
 
 and close_list env = function
     [] -> []
@@ -1638,7 +1638,7 @@ let collect_exported_structured_constants a =
     | Uassign (_, u) -> ulam u
     | Usend (_, u1, u2, ul, _, _) -> ulam u1; ulam u2; List.iter ulam ul
     | Uunreachable -> ()
-    | Uregion u -> ulam u
+    | Uregion (_, u) -> ulam u
     | Utail u -> ulam u
   in
   approx a

--- a/middle_end/flambda/build_export_info.ml
+++ b/middle_end/flambda/build_export_info.ml
@@ -258,7 +258,7 @@ let rec approx_of_expr (env : Env.t) (flam : Flambda.t) : Export_info.approx =
         Closure_id.Map.find closure_id results
       | _ -> Value_unknown
     end
-  | Region body ->
+  | Region (_, body) ->
     approx_of_expr env body
   | Tail body ->
     approx_of_expr env body

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -587,7 +587,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     Misc.fatal_error "[Lifused] should have been removed by \
         [Simplif.simplify_lets]"
   | Lregion body ->
-    Region (close t env body)
+    Region (May_drop_tail, close t env body)
 
 (** Perform closure conversion on a set of function declarations, returning a
     set of closures.  (The set will often only contain a single function;

--- a/middle_end/flambda/effect_analysis.ml
+++ b/middle_end/flambda/effect_analysis.ml
@@ -45,7 +45,7 @@ let rec no_effects (flam : Flambda.t) =
     (* If there is a [raise] in [body], the whole [Try_with] may have an
        effect, so there is no need to test the handler. *)
     no_effects body
-  | Region body ->
+  | Region (_, body) ->
     no_effects body
   | Tail body ->
     no_effects body

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -78,7 +78,7 @@ type t =
   | Try_with of t * Variable.t * t * Lambda.value_kind
   | While of t * t
   | For of for_loop
-  | Region of t
+  | Region of Clambda.tail_policy * t
   | Tail of t
   | Proved_unreachable
 
@@ -350,8 +350,13 @@ let rec lam ppf (flam : t) =
       (match direction with
         Asttypes.Upto -> "to" | Asttypes.Downto -> "downto")
       Variable.print to_value lam body
-  | Region body ->
-    fprintf ppf "@[<2>(region@ %a)@]" lam body
+  | Region (p, body) ->
+    let policy ppf () =
+      match p with
+      | May_drop_tail -> ()
+      | Must_keep_tail -> fprintf ppf "<keep_tail>"
+    in
+    fprintf ppf "@[<2>(region%a@ %a)@]" policy () lam body
   | Tail body ->
     fprintf ppf "@[<2>(tail@ %a)@]" lam body
 
@@ -626,7 +631,7 @@ let rec variables_usage ?ignore_uses_as_callee ?ignore_uses_as_argument
         free_variable meth;
         free_variable obj;
         List.iter free_variable args;
-      | Region body ->
+      | Region (_, body) ->
         aux body
       | Tail body ->
         aux body
@@ -827,7 +832,7 @@ let iter_general ~toplevel f f_named maybe_named =
       | String_switch (_, sw, def, _) ->
         List.iter (fun (_,l) -> aux l) sw;
         Option.iter aux def
-      | Region body ->
+      | Region (_, body) ->
         aux body
       | Tail body ->
         aux body
@@ -902,10 +907,6 @@ module With_free_variables = struct
         free_vars_of_body;
       }
 
-  let create_region (t : expr t) =
-    let Expr (body, fv) = t in
-    Expr (Region body, fv)
-
   let expr (t : expr t) =
     match t with
     | Expr (expr, free_vars) -> Named (Expr expr, free_vars)
@@ -930,7 +931,7 @@ let fold_lets_option
   let finish ~last_body ~acc ~rev_lets =
     let module W = With_free_variables in
     let acc, t =
-      List.fold_left (fun (acc, t) (has_region, var, defining_expr) ->
+      List.fold_left (fun (acc, t) (var, defining_expr) ->
           let free_vars_of_body = W.free_variables t in
           let acc, var, defining_expr =
             filter_defining_expr acc var defining_expr free_vars_of_body
@@ -941,7 +942,6 @@ let fold_lets_option
             | Some defining_expr ->
               W.of_expr (W.create_let_reusing_body var defining_expr t)
           in
-          let t = if has_region then W.create_region t else t in
           acc, t)
         (acc, W.of_expr last_body)
         rev_lets
@@ -950,13 +950,11 @@ let fold_lets_option
   in
   let rec loop (t : t) ~acc ~rev_lets =
     match t with
-    | Let { var; defining_expr; body; _ }
-    | Region (Let { var; defining_expr; body; _ }) ->
+    | Let { var; defining_expr; body; _ } ->
       let acc, var, defining_expr =
         for_defining_expr acc var defining_expr
       in
-      let has_region = match t with Region _ -> true | _ -> false in
-      let rev_lets = (has_region, var, defining_expr) :: rev_lets in
+      let rev_lets = (var, defining_expr) :: rev_lets in
       loop body ~acc ~rev_lets
     | t ->
       let last_body, acc = for_last_body acc t in

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -114,7 +114,7 @@ type t =
   | Try_with of t * Variable.t * t * Lambda.value_kind
   | While of t * t
   | For of for_loop
-  | Region of t
+  | Region of Clambda.tail_policy * t
   | Tail of t
   | Proved_unreachable
 

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -238,7 +238,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
     | While (e1, e2) ->
       loop env e1;
       loop env e2
-    | Region e ->
+    | Region (_, e) ->
       loop env e
     | Tail e ->
       loop env e

--- a/middle_end/flambda/flambda_iterators.ml
+++ b/middle_end/flambda/flambda_iterators.ml
@@ -45,7 +45,7 @@ let apply_on_subexpressions f f_named (flam : Flambda.t) =
   | While (f1,f2) ->
     f f1; f f2
   | For { body; _ } -> f body
-  | Region body -> f body
+  | Region (_, body) -> f body
   | Tail body -> f body
 
 let rec list_map_sharing f l =
@@ -161,12 +161,12 @@ let map_subexpressions f f_named (tree:Flambda.t) : Flambda.t =
       tree
     else
       For { bound_var; from_value; to_value; direction; body = new_body; }
-  | Region body ->
+  | Region (p, body) ->
     let new_body = f body in
     if new_body == body then
       tree
     else
-      Region new_body
+      Region (p, new_body)
   | Tail body ->
     let new_body = f body in
     if new_body == body then
@@ -398,12 +398,12 @@ let map_general ~toplevel f f_named tree =
           else
             For { bound_var; from_value; to_value; direction;
               body = new_body; }
-        | Region body ->
+        | Region (p, body) ->
           let new_body = aux body in
           if new_body == body then
             tree
           else
-            Region new_body
+            Region (p, new_body)
         | Tail body ->
           let new_body = aux body in
           if new_body == body then

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -356,7 +356,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
   | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
     Usend (kind, subst_var env meth, subst_var env obj,
       subst_vars env args, (reg_close,mode), dbg)
-  | Region body ->
+  | Region (policy, body) ->
       let body = to_clambda t env body in
       let is_trivial =
         match body with
@@ -364,7 +364,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
         | _ -> false
       in
       if is_trivial then body
-      else Uregion body
+      else Uregion (policy, body)
   | Tail body ->
       let body = to_clambda t env body in
       let is_trivial =

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -88,6 +88,14 @@ let equal_direction_flag
   | Downto, Downto -> true
   | (Upto | Downto), _ -> false
 
+let equal_tail_policy
+      (x : Clambda.tail_policy)
+      (y : Clambda.tail_policy) =
+  match x, y with
+  | Must_keep_tail, Must_keep_tail -> true
+  | May_drop_tail, May_drop_tail -> true
+  | (Must_keep_tail | May_drop_tail), _ -> false
+
 let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
   l1 == l2 || (* it is ok for the string case: if they are physically the same,
                  it is the same original branch *)
@@ -156,8 +164,8 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
       && equal_direction_flag direction1 direction2
       && same body1 body2
   | For _, _ | _, For _ -> false
-  | Region body1, Region body2 ->
-    same body1 body2
+  | Region (policy1, body1), Region (policy2, body2) ->
+    equal_tail_policy policy1 policy2 && same body1 body2
   | Region _, _ | _, Region _ -> false
   | Tail body1, Tail body2 ->
     same body1 body2

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -297,7 +297,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_var meth curr;
       mark_var obj curr;
       List.iter (fun arg -> mark_var arg curr) args
-    | Region body ->
+    | Region (_, body) ->
       mark_curr curr;
       mark_loop ~toplevel [] body
     | Tail body ->

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -908,7 +908,7 @@ and simplify_over_application env r ~args ~args_approxs ~function_decls
   let expr = Lift_code.lift_lets_expr expr ~toplevel:true in
   let expr =
     match mode, function_decl.A.region with
-    | Lambda.Alloc_heap, false -> Flambda.Region expr
+    | Lambda.Alloc_heap, false -> Flambda.Region (May_drop_tail, expr)
     | _ -> expr
   in
   let expr =
@@ -1427,13 +1427,13 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
         in
         let branch, r = simplify env r branch in
         branch, R.map_benefit r B.remove_branch)
-  | Region body ->
+  | Region (policy, body) ->
      let use_outer_region = R.may_use_region r in
      let r = R.set_region_use r false in
      let body, r = simplify env r body in
      let use_inner_region = R.may_use_region r in
      let r = R.set_region_use r use_outer_region in
-     if use_inner_region then Region body, r
+     if use_inner_region then Region (policy, body), r
      else body, r
   | Tail body ->
      let r = R.set_region_use r true in

--- a/middle_end/flambda/inlining_cost.ml
+++ b/middle_end/flambda/inlining_cost.ml
@@ -121,7 +121,7 @@ let lambda_smaller' lam ~than:threshold =
       size := !size + 2; lambda_size cond; lambda_size body
     | For { body; _ } ->
       size := !size + 4; lambda_size body
-    | Region body ->
+    | Region (_, body) ->
       size := !size + 2; lambda_size body
     | Tail body ->
       lambda_size body

--- a/middle_end/flambda/ref_to_variables.ml
+++ b/middle_end/flambda/ref_to_variables.ml
@@ -80,7 +80,7 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
       loop body
     | Static_raise (_, args) ->
       set := Variable.Set.union (Variable.Set.of_list args) !set
-    | Region body ->
+    | Region (_, body) ->
       loop body
     | Tail body ->
       loop body

--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -238,7 +238,7 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
       ignore_debuginfo dbg
     | Uunreachable ->
       ()
-    | Uregion e ->
+    | Uregion (_, e) ->
       loop ~depth e
     | Utail e ->
       loop ~depth e
@@ -467,7 +467,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
       ignore_debuginfo dbg
     | Uunreachable ->
       let_stack := []
-    | Uregion e ->
+    | Uregion (_, e) ->
       let_stack := [];
       loop e
     | Utail e ->
@@ -616,9 +616,9 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
     Usend (kind, e1, e2, args, pos, dbg)
   | Uunreachable ->
     Uunreachable
-  | Uregion e ->
+  | Uregion (p, e) ->
     let e = substitute_let_moveable is_let_moveable env e in
-    Uregion (e)
+    Uregion (p, e)
   | Utail e ->
     let e = substitute_let_moveable is_let_moveable env e in
     Utail (e)
@@ -846,9 +846,9 @@ let rec un_anf_and_moveable var_info env (clam : Clambda.ulambda)
     Usend (kind, e1, e2, args, pos, dbg), Fixed
   | Uunreachable ->
     Uunreachable, Fixed
-  | Uregion e ->
+  | Uregion (p, e) ->
     let e = un_anf var_info env e in
-    Uregion e, Fixed
+    Uregion (p, e), Fixed
   | Utail e ->
     let e = un_anf var_info env e in
     Utail e, Fixed

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -120,6 +120,10 @@ and apply_kind ppf : apply_kind -> unit = function
   | (Rc_normal | Rc_nontail), Alloc_local -> fprintf ppf "apply[L]"
   | Rc_close_at_apply, Alloc_local -> fprintf ppf "apply[end_region][L]"
 
+and tail_policy ppf : tail_policy -> unit = function
+  | Must_keep_tail -> fprintf ppf "region[keep_tail]"
+  | May_drop_tail -> fprintf ppf "region"
+
 and lam ppf = function
   | Uvar id ->
       V.print ppf id
@@ -271,8 +275,8 @@ and lam ppf = function
         form kind lam obj lam met args largs
   | Uunreachable ->
       fprintf ppf "unreachable"
-  | Uregion e ->
-      fprintf ppf "@[<2>(region@ %a)@]" lam e
+  | Uregion (p, e) ->
+      fprintf ppf "@[<2>(%a@ %a)@]" tail_policy p lam e
   | Utail e ->
       fprintf ppf "@[<2>(tail@ %a)@]" lam e
 

--- a/ocaml/asmcomp/afl_instrument.ml
+++ b/ocaml/asmcomp/afl_instrument.ml
@@ -87,7 +87,7 @@ and instrument = function
      in
      Ccatch (isrec, cases, instrument body)
   | Cexit (ex, args) -> Cexit (ex, List.map instrument args)
-  | Cregion e -> Cregion (instrument e)
+  | Cregion (p, e) -> Cregion (p, instrument e)
   | Ctail e -> Ctail (instrument e)
 
   (* these are base cases and have no logging *)

--- a/ocaml/asmcomp/cmm.ml
+++ b/ocaml/asmcomp/cmm.ml
@@ -200,7 +200,7 @@ type expression =
   | Cexit of int * expression list
   | Ctrywith of expression * Backend_var.With_provenance.t * expression
       * Debuginfo.t
-  | Cregion of expression
+  | Cregion of Clambda.tail_policy * expression
   | Ctail of expression
 
 type codegen_option =
@@ -262,7 +262,7 @@ let iter_shallow_tail f = function
       f e1;
       f e2;
       true
-  | Cregion e ->
+  | Cregion (_, e) ->
       f e;
       true
   | Ctail e ->
@@ -304,8 +304,8 @@ let map_shallow_tail f = function
       Ccatch(rec_flag, List.map map_h handlers, f body)
   | Ctrywith(e1, id, e2, dbg) ->
       Ctrywith(f e1, id, f e2, dbg)
-  | Cregion e ->
-      Cregion(f e)
+  | Cregion (p, e) ->
+      Cregion(p, f e)
   | Ctail e ->
       Ctail(f e)
   | Cexit _ | Cop (Craise _, _, _) as cmm ->
@@ -360,7 +360,7 @@ let iter_shallow f = function
       List.iter f el
   | Ctrywith (e1, _id, e2, _dbg) ->
       f e1; f e2
-  | Cregion e ->
+  | Cregion (_, e) ->
       f e
   | Ctail e ->
       f e
@@ -397,8 +397,8 @@ let map_shallow f = function
       Cexit (n, List.map f el)
   | Ctrywith (e1, id, e2, dbg) ->
       Ctrywith (f e1, id, f e2, dbg)
-  | Cregion e ->
-      Cregion (f e)
+  | Cregion (p, e) ->
+      Cregion (p, f e)
   | Ctail e ->
       Ctail (f e)
   | Cconst_int _

--- a/ocaml/asmcomp/cmm.mli
+++ b/ocaml/asmcomp/cmm.mli
@@ -201,7 +201,7 @@ and expression =
   | Cexit of int * expression list
   | Ctrywith of expression * Backend_var.With_provenance.t * expression
       * Debuginfo.t
-  | Cregion of expression
+  | Cregion of Clambda.tail_policy * expression
   | Ctail of expression
 
 type codegen_option =

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -1840,7 +1840,7 @@ let cache_public_method meths tag cache dbg =
 
 let has_local_allocs e =
   let rec loop = function
-    | Cregion e ->
+    | Cregion (_, e) ->
         (* Local allocations within a nested region do not affect this region,
            except inside a Ctail block *)
         loop_until_tail e
@@ -1877,10 +1877,10 @@ let remove_region_tail e =
   | () -> e
   | exception Exit -> remove_tail e
 
-let region e =
-  (* [Cregion e] is equivalent to [e] if [e] contains no local allocs *)
+let region p e =
+  (* [Cregion (p, e)] is equivalent to [e] if [e] contains no local allocs *)
   if has_local_allocs e then
-    Cregion e
+    Cregion (p, e)
   else
     remove_region_tail e
 

--- a/ocaml/asmcomp/cmm_helpers.mli
+++ b/ocaml/asmcomp/cmm_helpers.mli
@@ -571,8 +571,8 @@ val send :
   Lambda.meth_kind -> expression -> expression -> expression list
   -> Clambda.apply_kind -> Debuginfo.t -> expression
 
-(** Construct [Cregion e], eliding some useless regions *)
-val region : expression -> expression
+(** Construct [Cregion (p, e)], eliding some useless regions *)
+val region : Clambda.tail_policy -> expression -> expression
 
 (** Generic Cmm fragments *)
 

--- a/ocaml/asmcomp/cmm_invariants.ml
+++ b/ocaml/asmcomp/cmm_invariants.ml
@@ -173,7 +173,7 @@ let rec check env (expr : Cmm.expression) =
        not reported as an error. *)
     check env body;
     check env handler
-  | Cregion e -> check env e
+  | Cregion (_, e) -> check env e
   | Ctail e -> check env e
 
 let run ppf (fundecl : Cmm.fundecl) =

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -171,7 +171,7 @@ let rec expr_size env = function
       | RHS_block blocksize -> RHS_infix { blocksize; offset }
       | RHS_nonrec -> RHS_nonrec
       | _ -> assert false)
-  | Uregion exp ->
+  | Uregion (_, exp) ->
       expr_size env exp
   | Utail exp ->
       expr_size env exp
@@ -704,8 +704,8 @@ let rec transl env e =
   | Uunreachable ->
       let dbg = Debuginfo.none in
       Cop(Cload (Word_int, Mutable), [Cconst_int (0, dbg)], dbg)
-  | Uregion e ->
-      region (transl env e)
+  | Uregion (p, e) ->
+      region p (transl env e)
   | Utail e ->
       Ctail (transl env e)
 

--- a/ocaml/asmcomp/printcmm.ml
+++ b/ocaml/asmcomp/printcmm.ml
@@ -25,6 +25,10 @@ let rec_flag ppf = function
   | Nonrecursive -> ()
   | Recursive -> fprintf ppf " rec"
 
+let tail_policy ppf : Clambda.tail_policy -> unit = function
+  | May_drop_tail -> ()
+  | Must_keep_tail -> fprintf ppf " keep_tail"
+
 let machtype_component ppf = function
   | Val -> fprintf ppf "val"
   | Addr -> fprintf ppf "addr"
@@ -270,8 +274,8 @@ let rec expr ppf = function
   | Ctrywith(e1, id, e2, _dbg) ->
       fprintf ppf "@[<2>(try@ %a@;<1 -2>with@ %a@ %a)@]"
              sequence e1 VP.print id sequence e2
-  | Cregion e ->
-      fprintf ppf "@[<2>(region@ %a)@]" sequence e
+  | Cregion (p, e) ->
+      fprintf ppf "@[<2>(region@ %a@ %a)@]" tail_policy p sequence e
   | Ctail e ->
       fprintf ppf "@[<2>(tail@ %a)@]" sequence e
 

--- a/ocaml/asmcomp/selectgen.ml
+++ b/ocaml/asmcomp/selectgen.ml
@@ -24,7 +24,12 @@ module Int = Numbers.Int
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
-type region_stack = Reg.t array list
+type region_info =
+  { reg : Reg.t array;
+    tail_policy : Clambda.tail_policy;
+    in_tail_of_parent : bool;
+  }
+type region_stack = region_info list
 
 type environment =
   { vars : (Reg.t array
@@ -69,6 +74,16 @@ let env_empty = {
   region_tail = false;
 }
 
+let env_top_region env = List.hd env.regions
+
+let env_enter_region reg tail_policy env =
+  let region = { reg; tail_policy; in_tail_of_parent = env.region_tail } in
+  { env with regions = region :: env.regions; region_tail = true }
+
+let env_leave_region env =
+  let region_tail = (env_top_region env).in_tail_of_parent in
+  { env with regions = List.tl env.regions; region_tail }
+
 (* Assuming [rs] is equal to or a suffix of [env.regions],
    return the last region in [env.regions] but not [rs]
    (or None if they are equal) *)
@@ -76,10 +91,10 @@ let env_close_regions env rs =
   let rec aux v es rs =
     match es, rs with
     | [], [] -> v
-    | (r :: _), (r' :: _) when r == r' -> v
+    | (r :: _), (r' :: _) when r.reg == r'.reg -> v
     | [], _::_ ->
        Misc.fatal_error "Selectgen.env_close_regions: not a suffix"
-    | r :: es, rs -> aux (Some r) es rs
+    | r :: es, rs -> aux (Some r.reg) es rs
   in
   aux None env.regions rs
 
@@ -897,20 +912,35 @@ method emit_expr (env:environment) exp =
                     (end_region s2#extract)))
         [||] [||];
       r
-  | Cregion e ->
+  | Cregion (p, e) ->
      assert (Config.stack_allocation);
      let reg = self#regs_for typ_int in
      self#insert env (Iop Ibeginregion) [| |] reg;
-     let env = { env with regions = reg::env.regions; region_tail = true } in
-     begin match self#emit_expr env e with
-       None -> None
-     | Some _ as res ->
-        self#insert env (Iop Iendregion) reg [| |];
-        res
+     let env = env_enter_region reg p env in
+     begin match p with
+       May_drop_tail ->
+        begin match self#emit_expr env e with
+          None -> None
+        | Some _ as res ->
+           self#insert env (Iop Iendregion) reg [| |];
+           res
+        end
+     | Must_keep_tail ->
+        (* We're guaranteed to have tail expressions in all the right places, so
+           just press on *)
+        self#emit_expr env e
      end
   | Ctail e ->
       assert env.region_tail;
-      self#emit_expr env e
+      let { reg; tail_policy; _ } = env_top_region env in
+      begin match tail_policy with
+        May_drop_tail ->
+          self#emit_expr env e
+      | Must_keep_tail ->
+          self#insert env (Iop Iendregion) reg [| |];
+          let env = env_leave_region env in
+          self#emit_expr env e
+      end
 
 method private emit_sequence (env:environment) exp =
   let s = {< instr_seq = dummy_instr >} in
@@ -1091,7 +1121,7 @@ method private insert_return (env:environment) r =
   | Some r ->
       let loc = Proc.loc_results (Reg.typv r) in
       if env.region_tail then
-        self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+        self#insert env (Iop Iendregion) (env_top_region env).reg [||];
       self#insert_moves env r loc;
       self#insert env Ireturn loc [||]
 
@@ -1126,7 +1156,7 @@ method emit_tail (env:environment) exp =
             Icall_ind ->
               let r1 = self#emit_tuple env new_args in
               if endregion && tail then
-                self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+                self#insert env (Iop Iendregion) (env_top_region env).reg [||];
               let endregion = endregion && not tail in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
@@ -1145,7 +1175,7 @@ method emit_tail (env:environment) exp =
                   self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||]
                 end else begin
                   self#insert_move_results env loc_res rd stack_ofs;
-                  self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+                  self#insert env (Iop Iendregion) (env_top_region env).reg [||];
                   self#insert_moves env rd loc_res
                 end;
                 self#insert env Ireturn loc_res [||]
@@ -1153,7 +1183,7 @@ method emit_tail (env:environment) exp =
           | Icall_imm { func; } ->
               let r1 = self#emit_tuple env new_args in
               if endregion && tail then
-                self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+                self#insert env (Iop Iendregion) (env_top_region env).reg [||];
               let endregion = endregion && not tail in
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
               if stack_ofs = 0 && not endregion then begin
@@ -1175,7 +1205,7 @@ method emit_tail (env:environment) exp =
                   self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||]
                 end else begin
                   self#insert_move_results env loc_res rd stack_ofs;
-                  self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+                  self#insert env (Iop Iendregion) (env_top_region env).reg [||];
                   self#insert_moves env rd loc_res
                 end;
                 self#insert env Ireturn loc_res [||]
@@ -1256,21 +1286,21 @@ method emit_tail (env:environment) exp =
                     (end_region s2)))
         [||] [||];
       self#insert_return env opt_r1
-  | Cregion e ->
+  | Cregion (p, e) ->
       assert (Config.stack_allocation);
       if env.region_tail then
         self#emit_return env exp
       else begin
         let reg = self#regs_for typ_int in
         self#insert env (Iop Ibeginregion) [| |] reg;
-        let env' = { env with regions = reg::env.regions; region_tail = true } in
+        let env' = env_enter_region reg p env in
         self#emit_tail env' e
       end
   | Ctail e ->
       assert env.region_tail;
-      self#insert env' (Iop Iendregion) (List.hd env.regions) [| |];
-      self#emit_tail { env with regions = List.tl env.regions;
-                                region_tail = false } e
+      self#insert env' (Iop Iendregion) (env_top_region env).reg [| |];
+      let env' = env_leave_region env in
+      self#emit_tail env' e
   | Cop _
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
   | Cvar _

--- a/ocaml/middle_end/clambda.ml
+++ b/ocaml/middle_end/clambda.ml
@@ -22,6 +22,9 @@ open Lambda
 type function_label = string
 type arity = Lambda.function_kind * int
 type apply_kind = Lambda.region_close * Lambda.alloc_mode
+type tail_policy =
+  | Must_keep_tail
+  | May_drop_tail
 
 type ustructured_constant =
   | Uconst_float of float
@@ -79,7 +82,7 @@ and ulambda =
       meth_kind * ulambda * ulambda * ulambda list
       * apply_kind * Debuginfo.t
   | Uunreachable
-  | Uregion of ulambda
+  | Uregion of tail_policy * ulambda
   | Utail of ulambda
 
 and ufunction = {

--- a/ocaml/middle_end/clambda.mli
+++ b/ocaml/middle_end/clambda.mli
@@ -23,6 +23,18 @@ type function_label = string
 type arity = Lambda.function_kind * int
 type apply_kind = Lambda.region_close * Lambda.alloc_mode
 
+(** Controls how [tail] expressions must be handled when generating code for a
+    region. May also entail invariants on the region itself. *)
+type tail_policy =
+  | Must_keep_tail
+  (** An [Iendregion] instruction must be generated for each [tail] expression
+      occurring in this region. Guarantees that there will be a [tail] (or
+      close-at-apply [apply]) at every tail position of the region. *)
+  | May_drop_tail
+  (** The [Iendregion] for a [tail] expression not occurring in (function-level)
+      tail position may be elided, and there may or may not be [tail]
+      expressions in this region. *)
+
 type ustructured_constant =
   | Uconst_float of float
   | Uconst_int32 of int32
@@ -90,7 +102,7 @@ and ulambda =
       meth_kind * ulambda * ulambda * ulambda list
       * apply_kind * Debuginfo.t
   | Uunreachable
-  | Uregion of ulambda
+  | Uregion of tail_policy * ulambda
   | Utail of ulambda
 
 and ufunction = {

--- a/ocaml/middle_end/flambda/build_export_info.ml
+++ b/ocaml/middle_end/flambda/build_export_info.ml
@@ -258,7 +258,7 @@ let rec approx_of_expr (env : Env.t) (flam : Flambda.t) : Export_info.approx =
         Closure_id.Map.find closure_id results
       | _ -> Value_unknown
     end
-  | Region body ->
+  | Region (_, body) ->
     approx_of_expr env body
   | Tail body ->
     approx_of_expr env body

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -578,7 +578,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     Misc.fatal_error "[Lifused] should have been removed by \
         [Simplif.simplify_lets]"
   | Lregion body ->
-    Region (close t env body)
+    Region (May_drop_tail, close t env body)
 
 (** Perform closure conversion on a set of function declarations, returning a
     set of closures.  (The set will often only contain a single function;

--- a/ocaml/middle_end/flambda/effect_analysis.ml
+++ b/ocaml/middle_end/flambda/effect_analysis.ml
@@ -45,7 +45,7 @@ let rec no_effects (flam : Flambda.t) =
     (* If there is a [raise] in [body], the whole [Try_with] may have an
        effect, so there is no need to test the handler. *)
     no_effects body
-  | Region body ->
+  | Region (_, body) ->
     no_effects body
   | Tail body ->
     no_effects body

--- a/ocaml/middle_end/flambda/flambda.mli
+++ b/ocaml/middle_end/flambda/flambda.mli
@@ -113,7 +113,7 @@ type t =
   | Try_with of t * Variable.t * t
   | While of t * t
   | For of for_loop
-  | Region of t
+  | Region of Clambda.tail_policy * t
   | Tail of t
   | Proved_unreachable
 

--- a/ocaml/middle_end/flambda/flambda_invariants.ml
+++ b/ocaml/middle_end/flambda/flambda_invariants.ml
@@ -233,7 +233,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
     | While (e1, e2) ->
       loop env e1;
       loop env e2
-    | Region e ->
+    | Region (_, e) ->
       loop env e
     | Tail e ->
       loop env e

--- a/ocaml/middle_end/flambda/flambda_iterators.ml
+++ b/ocaml/middle_end/flambda/flambda_iterators.ml
@@ -45,7 +45,7 @@ let apply_on_subexpressions f f_named (flam : Flambda.t) =
   | While (f1,f2) ->
     f f1; f f2
   | For { body; _ } -> f body
-  | Region body -> f body
+  | Region (_, body) -> f body
   | Tail body -> f body
 
 let rec list_map_sharing f l =
@@ -161,12 +161,12 @@ let map_subexpressions f f_named (tree:Flambda.t) : Flambda.t =
       tree
     else
       For { bound_var; from_value; to_value; direction; body = new_body; }
-  | Region body ->
+  | Region (p, body) ->
     let new_body = f body in
     if new_body == body then
       tree
     else
-      Region new_body
+      Region (p, new_body)
   | Tail body ->
     let new_body = f body in
     if new_body == body then
@@ -398,12 +398,12 @@ let map_general ~toplevel f f_named tree =
           else
             For { bound_var; from_value; to_value; direction;
               body = new_body; }
-        | Region body ->
+        | Region (p, body) ->
           let new_body = aux body in
           if new_body == body then
             tree
           else
-            Region new_body
+            Region (p, new_body)
         | Tail body ->
           let new_body = aux body in
           if new_body == body then

--- a/ocaml/middle_end/flambda/flambda_to_clambda.ml
+++ b/ocaml/middle_end/flambda/flambda_to_clambda.ml
@@ -355,7 +355,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
   | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
     Usend (kind, subst_var env meth, subst_var env obj,
       subst_vars env args, (reg_close,mode), dbg)
-  | Region body ->
+  | Region (policy, body) ->
       let body = to_clambda t env body in
       let is_trivial =
         match body with
@@ -363,7 +363,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
         | _ -> false
       in
       if is_trivial then body
-      else Uregion body
+      else Uregion (policy, body)
   | Tail body ->
       let body = to_clambda t env body in
       let is_trivial =

--- a/ocaml/middle_end/flambda/flambda_utils.ml
+++ b/ocaml/middle_end/flambda/flambda_utils.ml
@@ -88,6 +88,14 @@ let equal_direction_flag
   | Downto, Downto -> true
   | (Upto | Downto), _ -> false
 
+let equal_tail_policy
+      (x : Clambda.tail_policy)
+      (y : Clambda.tail_policy) =
+  match x, y with
+  | Must_keep_tail, Must_keep_tail -> true
+  | May_drop_tail, May_drop_tail -> true
+  | (Must_keep_tail | May_drop_tail), _ -> false
+
 let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
   l1 == l2 || (* it is ok for the string case: if they are physically the same,
                  it is the same original branch *)
@@ -152,8 +160,8 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
       && equal_direction_flag direction1 direction2
       && same body1 body2
   | For _, _ | _, For _ -> false
-  | Region body1, Region body2 ->
-    same body1 body2
+  | Region (policy1, body1), Region (policy2, body2) ->
+    equal_tail_policy policy1 policy2 && same body1 body2
   | Region _, _ | _, Region _ -> false
   | Tail body1, Tail body2 ->
     same body1 body2

--- a/ocaml/middle_end/flambda/inconstant_idents.ml
+++ b/ocaml/middle_end/flambda/inconstant_idents.ml
@@ -297,7 +297,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_var meth curr;
       mark_var obj curr;
       List.iter (fun arg -> mark_var arg curr) args
-    | Region body ->
+    | Region (_, body) ->
       mark_curr curr;
       mark_loop ~toplevel [] body
     | Tail body ->

--- a/ocaml/middle_end/flambda/inline_and_simplify.ml
+++ b/ocaml/middle_end/flambda/inline_and_simplify.ml
@@ -907,7 +907,7 @@ and simplify_over_application env r ~args ~args_approxs ~function_decls
   let expr = Lift_code.lift_lets_expr expr ~toplevel:true in
   let expr =
     match mode, function_decl.A.region with
-    | Lambda.Alloc_heap, false -> Flambda.Region expr
+    | Lambda.Alloc_heap, false -> Flambda.Region (May_drop_tail, expr)
     | _ -> expr
   in
   let expr =
@@ -1426,13 +1426,13 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
         in
         let branch, r = simplify env r branch in
         branch, R.map_benefit r B.remove_branch)
-  | Region body ->
+  | Region (policy, body) ->
      let use_outer_region = R.may_use_region r in
      let r = R.set_region_use r false in
      let body, r = simplify env r body in
      let use_inner_region = R.may_use_region r in
      let r = R.set_region_use r use_outer_region in
-     if use_inner_region then Region body, r
+     if use_inner_region then Region (policy, body), r
      else body, r
   | Tail body ->
      let r = R.set_region_use r true in

--- a/ocaml/middle_end/flambda/inlining_cost.ml
+++ b/ocaml/middle_end/flambda/inlining_cost.ml
@@ -121,7 +121,7 @@ let lambda_smaller' lam ~than:threshold =
       size := !size + 2; lambda_size cond; lambda_size body
     | For { body; _ } ->
       size := !size + 4; lambda_size body
-    | Region body ->
+    | Region (_, body) ->
       size := !size + 2; lambda_size body
     | Tail body ->
       lambda_size body

--- a/ocaml/middle_end/flambda/ref_to_variables.ml
+++ b/ocaml/middle_end/flambda/ref_to_variables.ml
@@ -80,7 +80,7 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
       loop body
     | Static_raise (_, args) ->
       set := Variable.Set.union (Variable.Set.of_list args) !set
-    | Region body ->
+    | Region (_, body) ->
       loop body
     | Tail body ->
       loop body

--- a/ocaml/middle_end/flambda/un_anf.ml
+++ b/ocaml/middle_end/flambda/un_anf.ml
@@ -235,7 +235,7 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
       ignore_debuginfo dbg
     | Uunreachable ->
       ()
-    | Uregion e ->
+    | Uregion (_, e) ->
       loop ~depth e
     | Utail e ->
       loop ~depth e
@@ -457,7 +457,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
       ignore_debuginfo dbg
     | Uunreachable ->
       let_stack := []
-    | Uregion e ->
+    | Uregion (_, e) ->
       let_stack := [];
       loop e
     | Utail e ->
@@ -606,9 +606,9 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
     Usend (kind, e1, e2, args, pos, dbg)
   | Uunreachable ->
     Uunreachable
-  | Uregion e ->
+  | Uregion (p, e) ->
     let e = substitute_let_moveable is_let_moveable env e in
-    Uregion (e)
+    Uregion (p, e)
   | Utail e ->
     let e = substitute_let_moveable is_let_moveable env e in
     Utail (e)
@@ -836,9 +836,9 @@ let rec un_anf_and_moveable var_info env (clam : Clambda.ulambda)
     Usend (kind, e1, e2, args, pos, dbg), Fixed
   | Uunreachable ->
     Uunreachable, Fixed
-  | Uregion e ->
+  | Uregion (p, e) ->
     let e = un_anf var_info env e in
-    Uregion e, Fixed
+    Uregion (p, e), Fixed
   | Utail e ->
     let e = un_anf var_info env e in
     Utail e, Fixed

--- a/ocaml/middle_end/printclambda.ml
+++ b/ocaml/middle_end/printclambda.ml
@@ -119,6 +119,10 @@ and apply_kind ppf : apply_kind -> unit = function
   | (Rc_normal | Rc_nontail), Alloc_local -> fprintf ppf "apply[L]"
   | Rc_close_at_apply, Alloc_local -> fprintf ppf "apply[end_region][L]"
 
+and tail_policy ppf : tail_policy -> unit = function
+  | Must_keep_tail -> fprintf ppf "region[keep_tail]"
+  | May_drop_tail -> fprintf ppf "region"
+
 and lam ppf = function
   | Uvar id ->
       V.print ppf id
@@ -269,8 +273,8 @@ and lam ppf = function
         form kind lam obj lam met args largs
   | Uunreachable ->
       fprintf ppf "unreachable"
-  | Uregion e ->
-      fprintf ppf "@[<2>(region@ %a)@]" lam e
+  | Uregion (p, e) ->
+      fprintf ppf "@[<2>(%a@ %a)@]" tail_policy p lam e
   | Utail e ->
       fprintf ppf "@[<2>(tail@ %a)@]" lam e
 


### PR DESCRIPTION
Currently, `selectgen.ml` omits the `Iendregion` instruction whenever it compiles a `tail` expression that is not in (function-level) tail position. This is safe under current assumptions, but a forthcoming PR will lift `region` expressions and, in doing so, move arbitrary code into `tail` expressions. A lifted `region` must therefore not omit the `Iendregion` when compiling a `tail`. In return, such a region will always _have_ a `tail` expression (or close-at-apply call), so `selectgen.ml` can compile a `region` expression without proactively _adding_ an `Iendregion`.

This adds a `tail_policy` flag to each `region` expression to control which behavior is required. The flag has values `May_drop_tail`, meaning there may or may not be a `tail` and the `Iendregion` may sometimes be elided from `tail`s; and `Must_keep_tail`, meaning there will be a `tail` and it must generate an `Iendregion`.

Two other small updates:

* Fixed a minor bug in `inline_and_simplify.ml` (by way of `flambda.ml`) that sometimes causes regions to be kept in place but otherwise ignored. Currently this is largely benign (at worst it will cause an unused region to be kept) but the lifting PR will need regions to be tracked precisely.

* Undid a formatting change in hand-synched `backend` code because life is short and conflicts are time-consuming.