### PR TITLE
More error checking for natdynlink symbols

### DIFF
--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -354,7 +354,9 @@ let make_startup_file unix ~ppf_dump ~sourcefile_for_dwarf genfns units =
   let name_list =
     List.flatten (List.map (fun u -> u.defines) units) in
   compile_phrase (Cmm_helpers.entry_point name_list);
-  List.iter compile_phrase (Cmm_helpers.generic_functions false genfns);
+  List.iter compile_phrase
+    (Cmm_helpers.emit_preallocated_blocks []
+      (Cmm_helpers.generic_functions false genfns));
   Array.iteri
     (fun i name -> compile_phrase (Cmm_helpers.predef_exception i name))
     Runtimedef.builtin_exceptions;
@@ -393,7 +395,8 @@ let make_shared_startup_file unix ~ppf_dump ~sourcefile_for_dwarf genfns units =
     sourcefile_for_dwarf;
   Emit.begin_assembly unix;
   List.iter compile_phrase
-    (Cmm_helpers.generic_functions true genfns);
+    (Cmm_helpers.emit_preallocated_blocks []
+      (Cmm_helpers.generic_functions true genfns));
   let dynunits = List.map (fun u -> Option.get u.dynunit) units in
   compile_phrase (Cmm_helpers.plugin_header dynunits);
   compile_phrase

--- a/ocaml/asmcomp/asmlink.ml
+++ b/ocaml/asmcomp/asmlink.ml
@@ -273,7 +273,9 @@ let make_startup_file ~ppf_dump units_list ~crc_interfaces =
     List.flatten (List.map (fun (info,_,_) -> info.ui_defines) units_list) in
   compile_phrase (Cmm_helpers.entry_point name_list);
   let units = List.map (fun (info,_,_) -> info) units_list in
-  List.iter compile_phrase (Cmm_helpers.generic_functions false units);
+  List.iter compile_phrase
+    (Cmm_helpers.emit_preallocated_blocks []
+      (Cmm_helpers.generic_functions false units));
   Array.iteri
     (fun i name -> compile_phrase (Cmm_helpers.predef_exception i name))
     Runtimedef.builtin_exceptions;
@@ -309,7 +311,8 @@ let make_shared_startup_file ~ppf_dump units =
   Compilenv.reset shared_startup_comp_unit;
   Emit.begin_assembly ();
   List.iter compile_phrase
-    (Cmm_helpers.generic_functions true (List.map fst units));
+    (Cmm_helpers.emit_preallocated_blocks []
+      (Cmm_helpers.generic_functions true (List.map fst units)));
   compile_phrase (Cmm_helpers.plugin_header units);
   compile_phrase
     (Cmm_helpers.global_table (List.map (fun (ui,_) -> ui.ui_unit) units));


### PR DESCRIPTION
The logic in `runtime/dynlink_nat.c` silently continues if various important symbols are not found while trying to load a `cmxs` plugin, which made the bug in #980 hard to find. This patch changes it to error if any of those symbols are not found (except the entry function, which is correctly not present on `shared_startup` files).

There is one change to the backend: all shared library modules including `shared_startup` files now generate a `gc_roots` symbol, even if unnecessary, as this seems less error-prone.