### PR TITLE
Allow Bottom element kind for empty arrays

### DIFF
--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -334,6 +334,9 @@ let clear_demoted_trap_action_and_patch_unused_exn_bucket uacc apply_cont =
   let apply_cont = clear_demoted_trap_action uacc apply_cont in
   patch_unused_exn_bucket uacc apply_cont
 
+(* Warning: This function relies on [T.meet_is_flat_float_array], which could
+   return any kind for empty arrays. So this function is only safe for
+   operations that are invalid on empty arrays. *)
 let specialise_array_kind dacc (array_kind : P.Array_kind.t) ~array_ty :
     _ Or_bottom.t =
   let typing_env = DA.typing_env dacc in

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -136,6 +136,9 @@ val apply_cont_use_kind :
 val clear_demoted_trap_action_and_patch_unused_exn_bucket :
   Upwards_acc.t -> Apply_cont.t -> Apply_cont.t
 
+(** Warning: This function relies on [T.meet_is_flat_float_array], which could
+    return any kind for empty arrays. So this function is only safe for
+    operations that are invalid on empty arrays. *)
 val specialise_array_kind :
   Downwards_acc.t ->
   Flambda_primitive.Array_kind.t ->

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -121,38 +121,32 @@ let simplify_comparison ~dbg ~dacc ~cont ~tagged_prim ~float_prim
 
 let simplify_caml_make_vect dacc ~len_ty ~init_value_ty : t =
   let typing_env = DA.typing_env dacc in
-  let element_kind : _ Or_unknown.t Or_bottom.t =
+  let element_kind : _ Or_unknown_or_bottom.t =
     (* We can't deduce subkind information, e.g. an array is all-immediates
        rather than arbitrary values, but we can deduce kind information. *)
     if not (Flambda_features.flat_float_array ())
-    then
-      Ok
-        (Known
-           (Flambda_kind.With_subkind.create (T.kind init_value_ty) Anything))
+    then Ok (Flambda_kind.With_subkind.create (T.kind init_value_ty) Anything)
     else
       match T.prove_is_or_is_not_a_boxed_float typing_env init_value_ty with
       | Proved true ->
         (* A boxed float provided to [caml_make_vect] with the float array
            optimisation on will always yield a flat array of naked floats. *)
-        Ok (Known Flambda_kind.With_subkind.naked_float)
-      | Proved false | Unknown -> Ok Unknown
+        Ok Flambda_kind.With_subkind.naked_float
+      | Proved false | Unknown -> Unknown
   in
-  match element_kind with
-  | Bottom -> Invalid
-  | Ok element_kind ->
-    (* CR-someday mshinwell: We should really adjust the kind of the parameter
-       of the return continuation, e.g. to go from "any value" to "float array"
-       -- but that will need some more infrastructure, since the actual
-       continuation definition needs to be changed on the upwards traversal.
-       Also we would need to think about what would happen if there were other
-       uses of the return continuation possibly with different kinds.
+  (* CR-someday mshinwell: We should really adjust the kind of the parameter of
+     the return continuation, e.g. to go from "any value" to "float array" --
+     but that will need some more infrastructure, since the actual continuation
+     definition needs to be changed on the upwards traversal. Also we would need
+     to think about what would happen if there were other uses of the return
+     continuation possibly with different kinds.
 
-       Also maybe we should allow static allocation of these arrays for
-       reasonable sizes. *)
-    let type_of_returned_array =
-      T.mutable_array ~element_kind ~length:len_ty Alloc_mode.For_types.heap
-    in
-    Unchanged { return_types = Known [type_of_returned_array] }
+     Also maybe we should allow static allocation of these arrays for reasonable
+     sizes. *)
+  let type_of_returned_array =
+    T.mutable_array ~element_kind ~length:len_ty Alloc_mode.For_types.heap
+  in
+  Unchanged { return_types = Known [type_of_returned_array] }
 
 let simplify_returning_extcall ~dbg ~cont ~exn_cont:_ dacc fun_name args
     ~arg_types =

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -165,7 +165,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let fields, field_tys = List.split fields_with_tys in
     let dacc =
       bind_result_sym
-        (T.immutable_array ~element_kind:(Known K.With_subkind.naked_float)
+        (T.immutable_array ~element_kind:(Ok K.With_subkind.naked_float)
            ~fields:field_tys Alloc_mode.For_types.heap)
     in
     ( Rebuilt_static_const.create_immutable_float_array
@@ -179,7 +179,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
     let fields, field_tys = List.split fields_with_tys in
     let dacc =
       bind_result_sym
-        (T.immutable_array ~element_kind:(Known K.With_subkind.any_value)
+        (T.immutable_array ~element_kind:(Ok K.With_subkind.any_value)
            ~fields:field_tys Alloc_mode.For_types.heap)
     in
     ( Rebuilt_static_const.create_immutable_value_array
@@ -198,7 +198,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
        specialised non-empty array and the empty array." *)
     let dacc =
       bind_result_sym
-        (T.array_of_length ~element_kind:Unknown
+        (T.array_of_length ~element_kind:Bottom
            ~length:(T.this_tagged_immediate Targetint_31_63.zero)
            Alloc_mode.For_types.heap)
     in

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -187,15 +187,6 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
         fields,
       dacc )
   | Empty_array ->
-    (* CR-someday lmaurer: Comment from lthls:
-
-       "Given that no element can be read from it (or stored in it), any kind
-       would work, but if we introduce a specific Invalid kind for these empty
-       arrays we might even be able to delete all the code that tries to read
-       from or write to a known empty array (although one would hope that the
-       bounds check would already be proved to always fail). [...] That might be
-       also useful for preserving the array kind during a join between a
-       specialised non-empty array and the empty array." *)
     let dacc =
       bind_result_sym
         (T.array_of_length ~element_kind:Bottom

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -126,10 +126,9 @@ let simplify_make_array (array_kind : P.Array_kind.t)
       let alloc_mode = Alloc_mode.For_allocations.as_type alloc_mode in
       match mutable_or_immutable with
       | Mutable ->
-        T.mutable_array ~element_kind:(Known element_kind) ~length alloc_mode
+        T.mutable_array ~element_kind:(Ok element_kind) ~length alloc_mode
       | Immutable ->
-        T.immutable_array ~element_kind:(Known element_kind) ~fields:tys
-          alloc_mode
+        T.immutable_array ~element_kind:(Ok element_kind) ~fields:tys alloc_mode
       | Immutable_unique ->
         Misc.fatal_errorf "Immutable_unique is not expected for arrays:@ %a"
           Named.print original_term

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -487,19 +487,19 @@ val closure_with_at_least_these_value_slots :
   flambda_type
 
 val array_of_length :
-  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
   length:flambda_type ->
   Alloc_mode.For_types.t ->
   flambda_type
 
 val mutable_array :
-  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
   length:flambda_type ->
   Alloc_mode.For_types.t ->
   flambda_type
 
 val immutable_array :
-  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
   fields:flambda_type list ->
   Alloc_mode.For_types.t ->
   flambda_type
@@ -619,7 +619,9 @@ val prove_is_immediates_array : Typing_env.t -> t -> unit proof_of_property
 val meet_is_immutable_array :
   Typing_env.t ->
   t ->
-  (Flambda_kind.With_subkind.t Or_unknown.t * t * Alloc_mode.For_types.t)
+  (Flambda_kind.With_subkind.t Or_unknown_or_bottom.t
+  * t
+  * Alloc_mode.For_types.t)
   meet_shortcut
 
 val meet_single_closures_entry :

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -315,14 +315,14 @@ let rec unknown_with_subkind ?(alloc_mode = Alloc_mode.For_types.unknown ())
       ~fields:(List.init num_fields (fun _ -> TG.any_naked_float))
       alloc_mode
   | Float_array ->
-    TG.mutable_array ~element_kind:(Known Flambda_kind.With_subkind.naked_float)
+    TG.mutable_array ~element_kind:(Ok Flambda_kind.With_subkind.naked_float)
       ~length:any_tagged_immediate alloc_mode
   | Immediate_array ->
     TG.mutable_array
-      ~element_kind:(Known Flambda_kind.With_subkind.tagged_immediate)
+      ~element_kind:(Ok Flambda_kind.With_subkind.tagged_immediate)
       ~length:any_tagged_immediate alloc_mode
   | Value_array ->
-    TG.mutable_array ~element_kind:(Known Flambda_kind.With_subkind.any_value)
+    TG.mutable_array ~element_kind:(Ok Flambda_kind.With_subkind.any_value)
       ~length:any_tagged_immediate alloc_mode
   | Generic_array ->
     TG.mutable_array ~element_kind:Unknown ~length:any_tagged_immediate

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -64,7 +64,7 @@ and head_of_kind_value =
       }
   | String of String_info.Set.t
   | Array of
-      { element_kind : Flambda_kind.With_subkind.t Or_unknown.t;
+      { element_kind : Flambda_kind.With_subkind.t Or_unknown_or_bottom.t;
         length : t;
         contents : array_contents Or_unknown.t;
         alloc_mode : Alloc_mode.For_types.t
@@ -755,13 +755,13 @@ and print_head_of_kind_value ppf head =
   | Array { element_kind; length; contents = Unknown; alloc_mode } ->
     Format.fprintf ppf
       "@[<hov 1>(Array@ (element_kind@ %a)@ (length@ %a)@ (alloc_mode@ %a))@]"
-      (Or_unknown.print Flambda_kind.With_subkind.print)
+      (Or_unknown_or_bottom.print Flambda_kind.With_subkind.print)
       element_kind print length Alloc_mode.For_types.print alloc_mode
   | Array { element_kind; length; contents = Known Mutable; alloc_mode } ->
     Format.fprintf ppf
       "@[<hov 1>(Mutable_array@ (element_kind@ %a)@ (length@ %a)@ (alloc_mode@ \
        %a))@]"
-      (Or_unknown.print Flambda_kind.With_subkind.print)
+      (Or_unknown_or_bottom.print Flambda_kind.With_subkind.print)
       element_kind print length Alloc_mode.For_types.print alloc_mode
   | Array
       { element_kind;
@@ -772,7 +772,7 @@ and print_head_of_kind_value ppf head =
     Format.fprintf ppf
       "@[<hov 1>(Immutable_array@ (element_kind@ %a)@ (length@ %a)@ \
        (alloc_mode@ %a)@ (fields@ (%a)))@]"
-      (Or_unknown.print Flambda_kind.With_subkind.print)
+      (Or_unknown_or_bottom.print Flambda_kind.With_subkind.print)
       element_kind print length Alloc_mode.For_types.print alloc_mode
       (Format.pp_print_list ~pp_sep:Format.pp_print_space print)
       fields

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -57,7 +57,7 @@ and head_of_kind_value = private
       }
   | String of String_info.Set.t
   | Array of
-      { element_kind : Flambda_kind.With_subkind.t Or_unknown.t;
+      { element_kind : Flambda_kind.With_subkind.t Or_unknown_or_bottom.t;
         length : t;
         contents : array_contents Or_unknown.t;
         alloc_mode : Alloc_mode.For_types.t
@@ -268,19 +268,19 @@ val this_immutable_string : string -> t
 val mutable_string : size:int -> t
 
 val array_of_length :
-  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
   length:t ->
   Alloc_mode.For_types.t ->
   t
 
 val mutable_array :
-  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
   length:t ->
   Alloc_mode.For_types.t ->
   t
 
 val immutable_array :
-  element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+  element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
   fields:t list ->
   Alloc_mode.For_types.t ->
   t
@@ -577,7 +577,7 @@ module Head_of_kind_value : sig
   val create_string : String_info.Set.t -> t
 
   val create_array_with_contents :
-    element_kind:Flambda_kind.With_subkind.t Or_unknown.t ->
+    element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
     length:flambda_type ->
     array_contents Or_unknown.t ->
     Alloc_mode.For_types.t ->

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -395,8 +395,9 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
       meet_array_contents env array_contents1 array_contents2
     in
     let<* length, env_extension' = meet env length1 length2 in
-    (* Note: If the element kind is Bottom, we could meet the length type with
-       the constant 0 (only the empty array can have element kind Bottom *)
+    (* CR-someday vlaviron: If the element kind is Bottom, we could meet the
+       length type with the constant 0 (only the empty array can have element
+       kind Bottom). *)
     let<+ env_extension = meet_env_extension env env_extension env_extension' in
     ( TG.Head_of_kind_value.create_array_with_contents ~element_kind ~length
         contents alloc_mode,

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -495,7 +495,10 @@ let meet_is_flat_float_array env t : bool meet_shortcut =
   | Value Unknown -> Need_meet
   | Value Bottom -> Invalid
   | Value (Ok (Array { element_kind = Unknown; _ })) -> Need_meet
-  | Value (Ok (Array { element_kind = Known element_kind; _ })) -> (
+  | Value (Ok (Array { element_kind = Bottom; _ })) ->
+    (* Empty array case. We cannot return Bottom, but any result is correct. *)
+    Known_result false
+  | Value (Ok (Array { element_kind = Ok element_kind; _ })) -> (
     match K.With_subkind.kind element_kind with
     | Value -> Known_result false
     | Naked_number Naked_float -> Known_result true
@@ -520,7 +523,10 @@ let prove_is_immediates_array env t : unit proof_of_property =
   match expand_head env t with
   | Value (Unknown | Bottom) -> Unknown
   | Value (Ok (Array { element_kind = Unknown; _ })) -> Unknown
-  | Value (Ok (Array { element_kind = Known element_kind; _ })) -> (
+  | Value (Ok (Array { element_kind = Bottom; _ })) ->
+    (* Empty array case. We cannot return Bottom, but any result is correct. *)
+    Proved ()
+  | Value (Ok (Array { element_kind = Ok element_kind; _ })) -> (
     match K.With_subkind.subkind element_kind with
     | Tagged_immediate -> Proved ()
     | Anything | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -496,7 +496,9 @@ let meet_is_flat_float_array env t : bool meet_shortcut =
   | Value Bottom -> Invalid
   | Value (Ok (Array { element_kind = Unknown; _ })) -> Need_meet
   | Value (Ok (Array { element_kind = Bottom; _ })) ->
-    (* Empty array case. We cannot return Bottom, but any result is correct. *)
+    (* Empty array case. We cannot return Invalid, but any other result is
+       correct. We arbitrarily pick [false], as this is what we would get if we
+       looked at the tag at runtime. *)
     Known_result false
   | Value (Ok (Array { element_kind = Ok element_kind; _ })) -> (
     match K.With_subkind.kind element_kind with
@@ -524,7 +526,8 @@ let prove_is_immediates_array env t : unit proof_of_property =
   | Value (Unknown | Bottom) -> Unknown
   | Value (Ok (Array { element_kind = Unknown; _ })) -> Unknown
   | Value (Ok (Array { element_kind = Bottom; _ })) ->
-    (* Empty array case. We cannot return Bottom, but any result is correct. *)
+    (* Empty array case. We cannot return Invalid, but it's correct to state
+       that any value contained in this array must be an immediate. *)
     Proved ()
   | Value (Ok (Array { element_kind = Ok element_kind; _ })) -> (
     match K.With_subkind.subkind element_kind with

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -120,7 +120,7 @@ val meet_is_flat_float_array :
 val meet_is_immutable_array :
   Typing_env.t ->
   Type_grammar.t ->
-  (Flambda_kind.With_subkind.t Or_unknown.t
+  (Flambda_kind.With_subkind.t Or_unknown_or_bottom.t
   * Type_grammar.t
   * Alloc_mode.For_types.t)
   meet_shortcut

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -384,7 +384,10 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
       | _ :: _ -> (
         match element_kind with
         | Unknown -> try_canonical_simple ()
-        | Known element_kind -> (
+        | Bottom ->
+          (* Note: we could use [Lift Empty_array] here *)
+          try_canonical_simple ()
+        | Ok element_kind -> (
           let kind = Flambda_kind.With_subkind.kind element_kind in
           match kind with
           | Value -> (

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -385,7 +385,7 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
         match element_kind with
         | Unknown -> try_canonical_simple ()
         | Bottom ->
-          (* Note: we could use [Lift Empty_array] here *)
+          (* CR someday vlaviron: we could use [Lift Empty_array] here *)
           try_canonical_simple ()
         | Ok element_kind -> (
           let kind = Flambda_kind.With_subkind.kind element_kind in


### PR DESCRIPTION
This should fix the errors with empty arrays used at different types.