### PR TITLE
Fixes to meet_env_extension

### DIFF
--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -933,7 +933,7 @@ and meet_env_extension0 env (ext1 : TEE.t) (ext2 : TEE.t) extra_extensions :
     | Some simple2 ->
       Simple.pattern_match simple2
         ~const:(fun _ -> false)
-        ~name:(fun name2 ~coercion:_ ->
+        ~name:(fun name2 ~coercion:coercion1to2 ->
           match Name.Map.find_opt name2 ext with
           | None -> false
           | Some ty3 -> (
@@ -942,7 +942,10 @@ and meet_env_extension0 env (ext1 : TEE.t) (ext2 : TEE.t) extra_extensions :
             | Some simple3 ->
               Simple.pattern_match simple3
                 ~const:(fun _ -> false)
-                ~name:(fun name3 ~coercion:_ -> Name.equal name1 name3)))
+                ~name:(fun name3 ~coercion:coercion2to3 ->
+                  Name.equal name1 name3
+                  && Coercion.is_id
+                       (Coercion.compose_exn coercion1to2 ~then_:coercion2to3))))
   in
   let equations, extra_extensions =
     Name.Map.fold

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -960,7 +960,12 @@ and meet_env_extension0 env (ext1 : TEE.t) (ext2 : TEE.t) extra_extensions :
               then Name.Map.remove name eqs
               else Name.Map.add (* replace *) name ty eqs
             in
-            eqs, new_ext :: extra_extensions))
+            let extra_extensions =
+              if TEE.is_empty new_ext
+              then extra_extensions
+              else new_ext :: extra_extensions
+            in
+            eqs, extra_extensions))
       (TEE.to_map ext2)
       (TEE.to_map ext1, extra_extensions)
   in


### PR DESCRIPTION
First commit skips the addition of redundant equations (aliases that are already present the other way around). This may prevent infinite loops in some cases.
Second commit stops adding empty env extensions to the work list; these env extensions are no-ops when handled but can make debugging harder (and cause unneeded allocations).