### PR TITLE
Fix build_upstream-32-bit CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
 
           - name: build_upstream-32-bit
             config: --enable-middle-end=closure CC="gcc -m32" AS="as --32" ASPP="gcc -m32 -c" -host i386-linux PARTIALLD="ld -r -melf_i386"
-            os: ubuntu-latest
+            os: ubuntu-20.04
 
     env:
       J: "3"


### PR DESCRIPTION
GitHub action's `ubuntu-latest` image is currently [migrating](https://github.com/actions/runner-images#ongoing-migrations) from `20.04` to `22.04`, and `build_upstream-32-bit` fails under `22.04` due to [linker errors](https://github.com/ocaml-flambda/flambda-backend/actions/runs/3619413110/jobs/6111566601#step:11:2060). We should fix it properly, but I just specified `20.04` for now.