### PR TITLE
Immediately split must inline and duplicate bindings

### DIFF
--- a/middle_end/flambda2/terms/coeffects.ml
+++ b/middle_end/flambda2/terms/coeffects.ml
@@ -22,8 +22,8 @@ type t =
 
 let [@ocamlformat "disable"] print ppf co =
   match co with
-  | No_coeffects -> Format.fprintf ppf "no coeffects"
-  | Has_coeffects -> Format.fprintf ppf "has coeffects"
+  | No_coeffects -> Format.fprintf ppf "No_coeffects"
+  | Has_coeffects -> Format.fprintf ppf "Has_coeffects"
 
 let compare co1 co2 =
   match co1, co2 with

--- a/middle_end/flambda2/terms/effects.ml
+++ b/middle_end/flambda2/terms/effects.ml
@@ -24,12 +24,12 @@ type t =
 let [@ocamlformat "disable"] print ppf eff =
   match eff with
   | No_effects ->
-      Format.fprintf ppf "no effects"
+      Format.fprintf ppf "No_effects"
   | Only_generative_effects mut ->
-      Format.fprintf ppf "only generative effects %a"
+      Format.fprintf ppf "Only_generative_effects(%a)"
         Mutability.print mut
   | Arbitrary_effects ->
-      Format.fprintf ppf "Arbitrary effects"
+      Format.fprintf ppf "Arbitrary_effects"
 
 let compare eff1 eff2 =
   match eff1, eff2 with

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -373,6 +373,9 @@ let create_binding (type a) ?extra env effs var ~(inline : a inline)
      another variable, a constant, or a symbol). *)
   match bound_expr with
   | (Split { cmm_expr } | Simple { cmm_expr }) when is_cmm_simple cmm_expr ->
+    (* trivial/simple cmm expression (as decided by [is_cmm_simple]) do not have
+       effects and coeffects *)
+    let effs = Ece.pure_can_be_duplicated in
     create_binding_aux ?extra env effs var ~inline:Must_inline_and_duplicate
       (Split { cmm_expr })
   | Simple _ | Split _ | Splittable_prim _ ->

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -428,7 +428,8 @@ let new_bindings_for_splitting order args =
           (* we need to rebind the argument *)
           let new_cmm_var =
             Backend_var.With_provenance.create ?provenance:None
-              (Backend_var.create_local (Format.asprintf "to_cmm_split_%d" order))
+              (Backend_var.create_local
+                 (Format.asprintf "to_cmm_split_%d" order))
           in
           let binding =
             Binding
@@ -513,7 +514,7 @@ let split_complex_binding ~env ~res (binding : complex binding) =
 
 (* Adding binding to the env and split them *)
 
-let rec add_binding_to_env ?extra env res var ((Binding binding) as b) =
+let rec add_binding_to_env ?extra env res var (Binding binding as b) =
   let env =
     let bindings = Variable.Map.add var b env.bindings in
     let cmm_expr = C.var (Backend_var.With_provenance.var binding.cmm_var) in
@@ -523,9 +524,11 @@ let rec add_binding_to_env ?extra env res var ((Binding binding) as b) =
       | None -> env.vars_extra
       | Some info -> Variable.Map.add var info env.vars_extra
     in
-    { env with bindings; vars; vars_extra; }
+    { env with bindings; vars; vars_extra }
   in
-  let classification = To_cmm_effects.classify_by_effects_and_coeffects binding.effs in
+  let classification =
+    To_cmm_effects.classify_by_effects_and_coeffects binding.effs
+  in
   let inline : _ inline = binding.inline in
   match inline with
   | Must_inline_and_duplicate -> (
@@ -577,8 +580,8 @@ and split_in_env env res var binding =
     let env, res =
       List.fold_left
         (fun (env, res) new_binding ->
-           let flambda_var = Variable.create "to_cmm_tmp" in
-           add_binding_to_env env res flambda_var new_binding)
+          let flambda_var = Variable.create "to_cmm_tmp" in
+          add_binding_to_env env res flambda_var new_binding)
         (env, res) new_bindings
     in
     env, res, split_binding

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -422,9 +422,9 @@ let new_bindings_for_splitting order args =
   let (new_bindings, _), new_cmm_args =
     List.fold_left_map
       (fun (new_bindings, order) (cmm_arg, arg_effs) ->
-        (* Cr gbury: here, instead of using [is_cmm_simple],
-           we could instead look at [arg_effs] and not create a new binding
-           if it has `pure_can_be_duplicated` effects (or any ece that allows
+        (* CR gbury: here, instead of using [is_cmm_simple], we could instead
+           look at [arg_effs] and not create a new binding if it has
+           `pure_can_be_duplicated` effects (or any ece that allows
            duplication). *)
         if is_cmm_simple cmm_arg
         then (new_bindings, order), cmm_arg
@@ -599,16 +599,15 @@ let bind_variable_with_decision (type a) ?extra env res var ~inline
       To_cmm_effects.classify_by_effects_and_coeffects effs
     in
     match[@ocaml.warning "-4"] (inline : a inline), classification with
-    | (Must_inline_once | Must_inline_and_duplicate), Generative_immutable ->
-      (* Even if the primitive/top of the cmm expr being bound, must be duplicated
-         (as specified by [inline]), that doesn't mean that its arguments (some of which
-         may have been inlined) are also duplicatable, so we must take care of only
-         downgrading the effects and coeffects to pure, and not the placement, which
-         must be kept. *)
-      begin match (effs : Ece.t) with
-        | _, _, Delay -> Ece.pure_can_be_duplicated
-        | _, _, Strict -> Ece.pure
-      end
+    | (Must_inline_once | Must_inline_and_duplicate), Generative_immutable -> (
+      (* Even if the primitive/top of the cmm expr being bound, must be
+         duplicated (as specified by [inline]), that doesn't mean that its
+         arguments (some of which may have been inlined) are also duplicatable,
+         so we must take care of only downgrading the effects and coeffects to
+         pure, and not the placement, which must be kept. *)
+      match (effs : Ece.t) with
+      | _, _, Delay -> Ece.pure_can_be_duplicated
+      | _, _, Strict -> Ece.pure)
     | _, _ -> effs
   in
   let binding = create_binding ~inline effs var defining_expr in

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -633,7 +633,7 @@ let bind_variable_with_decision (type a) ?extra env res var ~inline
          with Strict placement might be inlined inside a Delay allocation, and
          end up moved across a `Gc` function call beause of this. Such cases are
          currently impossible since only [Box_number] and [Project_value_slot]
-         have a Delay placement, but may appaer in the future if/when some more
+         have a Delay placement, but may appear in the future if/when some more
          primitives are marked as `Delay`. But even then, the only issue would
          be that some allocations would be accidentally re-ordered across `Gc`
          function calls.

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -202,22 +202,24 @@ val splittable_primitive :
 val bind_variable_to_primitive :
   ?extra:extra_info ->
   t ->
+  To_cmm_result.t ->
   Variable.t ->
   inline:'a inline ->
   defining_expr:'a bound_expr ->
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
-  t
+  t * To_cmm_result.t
 
 (** Bind a variable to the given Cmm expression, to allow for delaying the
     let-binding. *)
 val bind_variable :
   ?extra:extra_info ->
   t ->
+  To_cmm_result.t ->
   Variable.t ->
   defining_expr:Cmm.expression ->
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
-  t
+  t * To_cmm_result.t
 
 (** Try and inline an Flambda variable using the delayed let-bindings. *)
 val inline_variable :

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -36,8 +36,8 @@ let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
   let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
     C.simple ~dbg env res s
   in
-  let env =
-    Env.bind_variable env v ~effects_and_coeffects_of_defining_expr
+  let env, res =
+    Env.bind_variable env res v ~effects_and_coeffects_of_defining_expr
       ~defining_expr ~num_normal_occurrences_of_bound_vars
   in
   env, res
@@ -316,8 +316,8 @@ and let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body =
     let effects_and_coeffects_of_defining_expr =
       Ece.join args_effs effects_and_coeffects_of_prim
     in
-    let env =
-      Env.bind_variable_to_primitive ?extra env v ~inline
+    let env, res =
+      Env.bind_variable_to_primitive ?extra env res v ~inline
         ~effects_and_coeffects_of_defining_expr ~defining_expr
     in
     expr env res body
@@ -329,8 +329,8 @@ and let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body =
     let effects_and_coeffects_of_defining_expr =
       Ece.join args_effs effects_and_coeffects_of_prim
     in
-    let env =
-      Env.bind_variable_to_primitive env v ~inline
+    let env, res =
+      Env.bind_variable_to_primitive env res v ~inline
         ~effects_and_coeffects_of_defining_expr ~defining_expr
     in
     expr env res body
@@ -632,9 +632,9 @@ and apply_expr env res apply =
       | [] -> unsupported ()
       | [param] ->
         let var = Bound_parameter.var param in
-        let env =
-          Env.bind_variable env var ~effects_and_coeffects_of_defining_expr:effs
-            ~defining_expr:call
+        let env, res =
+          Env.bind_variable env res var
+            ~effects_and_coeffects_of_defining_expr:effs ~defining_expr:call
             ~num_normal_occurrences_of_bound_vars:handler_params_occurrences
         in
         expr env res body


### PR DESCRIPTION
This allows to remove the assertion that must_inline_and_duplicate bindings must not have effects and coeffects. In practice, before this PR the following code would trigger a fatal error when compiling with `-Oclassic`:

 ```ocaml
 let f a =
  let x = a.(1) in
  a.(1) <- 5.;
  (x +. 1.) +. x
 ```

In this example, the binding for `x` is of the form `Box_float (load_from_array ...)` which has coeffects (because of the array load), is must_inline (because of the `Box_float` primitive) and will be duplicated (because `x` has more than one occurrence). Currently, we treat must_inline_and_duplicate bindings as pure bindings, thus the assertion, which prevents the `a.(1)` read from being moved after the array set. This PR removes the assertion, which can be done if we immediately split a `must_inline_and_duplicate` binding when creating it, so that its arguments are properly registered as bindings that have effects and/or coeffects.

This PR also fixes a bug related to re-ordering of bindings (where bindings split from a `must_inline_once` were not registered in the stages, potentially allowing expression to be re-ordered past them without checking effects and coeffects). That said, I'm not sure that bug can be currently triggered in practice (you'd need classic mode, with effectful expression inlining/subtitution enabled for to_cmm, and code with exactly the correct shape).