### PR TITLE
Add Stack_allocation_by_default to build_ocaml_compiler.sexp

### DIFF
--- a/build_ocaml_compiler.sexp
+++ b/build_ocaml_compiler.sexp
@@ -8,6 +8,7 @@
   uses_autoconf
   is_flambda_backend
   build_m32_from_upstream
+  stack_allocation_by_default
   ))
  (features (
    normal


### PR DESCRIPTION
This is for JS-internal tooling.