### PR TITLE
Symlink ocamlopttoplevel to ocamltoplevel libs for 32-bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,10 @@ build_upstream: ocaml/config.status
 install_upstream: build_upstream
 	(cd _build_upstream && $(MAKE) install)
 	cp ocaml/VERSION $(prefix)/lib/ocaml/
+	ln -s $(prefix)/lib/ocaml/compiler-libs/ocamltoplevel.cmxa \
+	  ocamlopttoplevel.cmxa
+	ln -s $(prefix)/lib/ocaml/compiler-libs/ocamltoplevel.a \
+	  ocamlopttoplevel.a
 
 .PHONY: build_and_test_upstream
 build_and_test_upstream: build_upstream


### PR DESCRIPTION
Some problems have been caused on 32-bit builds by the removal of the `ocamlopttoplevel` library; various workarounds are required until we have time to mirror the upstream changes into `native_toplevel/` in `flambda-backend`.  This is hopefully the only one that is actually needed in the compiler tree.