### PR TITLE
Refactor handling of -internal-assembler flag

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1327,7 +1327,8 @@ let reset_all () =
 let begin_assembly unix ~init_dwarf =
   reset_all ();
 
-  if !Flambda_backend_flags.internal_assembler then
+  if !Flambda_backend_flags.internal_assembler &&
+     !Emitaux.binary_backend_available then
     X86_proc.register_internal_assembler (Internal_assembler.assemble unix);
 
   init_dwarf ();

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1324,7 +1324,7 @@ let reset_all () =
   float_constants := [];
   all_functions := []
 
-let begin_assembly ~init_dwarf =
+let begin_assembly unix ~init_dwarf =
   reset_all ();
 
   init_dwarf ();

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1327,6 +1327,9 @@ let reset_all () =
 let begin_assembly unix ~init_dwarf =
   reset_all ();
 
+  if !Flambda_backend_flags.internal_assembler then
+    X86_proc.register_internal_assembler (Internal_assembler.assemble unix);
+
   init_dwarf ();
 
   if system = S_win64 then begin

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -1182,7 +1182,7 @@ let data l =
 
 (* Beginning / end of an assembly file *)
 
-let begin_assembly ~init_dwarf:_ =
+let begin_assembly _unix ~init_dwarf:_ =
   reset_debug_info();
   `	.file	\"\"\n`;  (* PR#7037 *)
   let lbl_begin = Cmm_helpers.make_symbol "data_begin" in

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -483,8 +483,6 @@ let compile_genfuns ?dwarf ~ppf_dump f =
 let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduce_heap
         ~ppf_dump gen =
   reset ();
-  if !Flambda_backend_flags.internal_assembler then
-    Emitaux.binary_backend_available := true;
   let create_asm = should_emit () &&
                    (keep_asm || not !Emitaux.binary_backend_available) in
   Emitaux.create_asm_file := create_asm;

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -167,8 +167,8 @@ let should_use_linscan fd =
   List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options
 
 let if_emit_do f x = if should_emit () then f x else ()
-let emit_begin_assembly ~init_dwarf:init_dwarf =
-  if_emit_do (fun init_dwarf -> Emit.begin_assembly ~init_dwarf) init_dwarf
+let emit_begin_assembly unix ~init_dwarf:init_dwarf =
+  if_emit_do (fun init_dwarf -> Emit.begin_assembly unix ~init_dwarf) init_dwarf
 let emit_end_assembly filename =
   if_emit_do
    (fun dwarf ->
@@ -586,7 +586,7 @@ let emit_begin_assembly_with_dwarf unix ~disable_dwarf ~emit_begin_assembly ~sou
     Emitaux.create_asm_file := !Clflags.keep_asm_file)
   else ();
   let no_dwarf () =
-    emit_begin_assembly ~init_dwarf:(fun () -> ());
+    emit_begin_assembly unix ~init_dwarf:(fun () -> ());
     None
   in
   let can_emit =
@@ -599,7 +599,7 @@ let emit_begin_assembly_with_dwarf unix ~disable_dwarf ~emit_begin_assembly ~sou
     let asm_directives = build_asm_directives () in
     let (module Asm_directives : Asm_targets.Asm_directives_intf.S) = asm_directives in
     let dwarf = ref None in
-    emit_begin_assembly ~init_dwarf:(fun () ->
+    emit_begin_assembly unix ~init_dwarf:(fun () ->
         Asm_targets.Asm_label.initialize ~new_label:Cmm.new_label;
         Asm_directives.initialize ();
         dwarf := Some (build_dwarf ~asm_directives sourcefile)

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -483,6 +483,8 @@ let compile_genfuns ?dwarf ~ppf_dump f =
 let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduce_heap
         ~ppf_dump gen =
   reset ();
+  if !Flambda_backend_flags.internal_assembler then
+    Emitaux.binary_backend_available := true;
   let create_asm = should_emit () &&
                    (keep_asm || not !Emitaux.binary_backend_available) in
   Emitaux.create_asm_file := create_asm;
@@ -580,11 +582,6 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
   )
 
 let emit_begin_assembly_with_dwarf unix ~disable_dwarf ~emit_begin_assembly ~sourcefile () =
-  if !Flambda_backend_flags.internal_assembler then
-    (
-    Emitaux.binary_backend_available := true;
-    Emitaux.create_asm_file := !Clflags.keep_asm_file)
-  else ();
   let no_dwarf () =
     emit_begin_assembly unix ~init_dwarf:(fun () -> ());
     None

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -581,7 +581,7 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
 
 let emit_begin_assembly_with_dwarf unix ~disable_dwarf ~emit_begin_assembly ~sourcefile () =
   if !Flambda_backend_flags.internal_assembler then
-    (X86_proc.register_internal_assembler (Internal_assembler.assemble unix);
+    (
     Emitaux.binary_backend_available := true;
     Emitaux.create_asm_file := !Clflags.keep_asm_file)
   else ();

--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -103,7 +103,8 @@ val compile_unit
 val emit_begin_assembly_with_dwarf
    : (module Compiler_owee.Unix_intf.S)
   -> disable_dwarf:bool
-  -> emit_begin_assembly:(init_dwarf:(unit -> unit) -> unit)
+  -> emit_begin_assembly:((module Compiler_owee.Unix_intf.S)
+                          -> init_dwarf:(unit -> unit) -> unit)
   -> sourcefile:string
   -> unit
   -> Dwarf_ocaml.Dwarf.t option

--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -376,14 +376,14 @@ let make_startup_file unix ~ppf_dump ~named_startup_file ~filename genfns units 
     force_linking_of_startup ~ppf_dump;
   Emit.end_assembly dwarf
 
-let make_shared_startup_file ~ppf_dump genfns units =
+let make_shared_startup_file unix ~ppf_dump genfns units =
   let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in
   Location.input_name := "caml_startup";
   let shared_startup_comp_unit =
     CU.create CU.Prefix.empty (CU.Name.of_string "_shared_startup")
   in
   Compilenv.reset shared_startup_comp_unit;
-  Emit.begin_assembly ~init_dwarf:(fun () -> ());
+  Emit.begin_assembly unix ~init_dwarf:(fun () -> ());
   List.iter compile_phrase
     (Cmm_helpers.generic_functions true genfns);
   let dynunits = List.map (fun u -> Option.get u.dynunit) units in
@@ -401,7 +401,7 @@ let call_linker_shared file_list output_name =
   if not (exitcode = 0)
   then raise(Error(Linking_error exitcode))
 
-let link_shared ~ppf_dump objfiles output_name =
+let link_shared unix ~ppf_dump objfiles output_name =
   Profile.record_call output_name (fun () ->
     let genfns = Cmm_helpers.Generic_fns_tbl.make () in
     let ml_objfiles, units_tolink =
@@ -420,7 +420,7 @@ let link_shared ~ppf_dump objfiles output_name =
       ~may_reduce_heap:true
       ~ppf_dump
       (fun () ->
-         make_shared_startup_file ~ppf_dump genfns units_tolink
+         make_shared_startup_file unix ~ppf_dump genfns units_tolink
       );
     call_linker_shared (startup_obj :: objfiles) output_name;
     remove_file startup_obj

--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -403,6 +403,10 @@ let call_linker_shared file_list output_name =
 
 let link_shared unix ~ppf_dump objfiles output_name =
   Profile.record_call output_name (fun () ->
+    if !Flambda_backend_flags.internal_assembler then
+      (* CR-soon gyorsh: workaround to turn off internal assembler temporarily,
+         until it is properly tested for shared library linking. *)
+      Emitaux.binary_backend_available := false;
     let genfns = Cmm_helpers.Generic_fns_tbl.make () in
     let ml_objfiles, units_tolink =
       List.fold_right (scan_file ~shared:true genfns) objfiles ([],[]) in
@@ -423,6 +427,9 @@ let link_shared unix ~ppf_dump objfiles output_name =
          make_shared_startup_file unix ~ppf_dump genfns units_tolink
       );
     call_linker_shared (startup_obj :: objfiles) output_name;
+    if !Flambda_backend_flags.internal_assembler then
+      (* CR gyorsh: restore after workaround. *)
+      Emitaux.binary_backend_available := true;
     remove_file startup_obj
   )
 

--- a/backend/asmlink.mli
+++ b/backend/asmlink.mli
@@ -21,7 +21,8 @@ open Format
 val link: (module Compiler_owee.Unix_intf.S) -> ppf_dump:formatter ->
   string list -> string -> unit
 
-val link_shared: ppf_dump:formatter -> string list -> string -> unit
+val link_shared: (module Compiler_owee.Unix_intf.S) ->
+  ppf_dump:formatter -> string list -> string -> unit
 
 val call_linker_shared: string list -> string -> unit
 

--- a/backend/emit.mli
+++ b/backend/emit.mli
@@ -17,5 +17,5 @@
 
 val fundecl: Linear.fundecl -> unit
 val data: Cmm.data_item list -> unit
-val begin_assembly: init_dwarf:(unit -> unit) -> unit
+val begin_assembly: (module Compiler_owee.Unix_intf.S) -> init_dwarf:(unit -> unit) -> unit
 val end_assembly: Dwarf_ocaml.Dwarf.t option -> unit

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -129,6 +129,8 @@ let implementation unix ~backend ~flambda2 ~start_from ~source_file
     else clambda unix info backend typed
   in
   with_info ~source_file ~output_prefix ~dump_ext:"cmx" @@ fun info ->
+  if !Flambda_backend_flags.internal_assembler then
+      Emitaux.binary_backend_available := true;
   match (start_from:Clflags.Compiler_pass.t) with
   | Parsing ->
     Compile_common.implementation

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -124,7 +124,7 @@ let main unix argv ppf ~flambda2 =
       Compmisc.init_path ();
       let target = Compenv.extract_output !output_name in
       Compmisc.with_ppf_dump ~file_prefix:target (fun ppf_dump ->
-        Asmlink.link_shared ~ppf_dump
+        Asmlink.link_shared unix ~ppf_dump
           (Compenv.get_objfiles ~with_ocamlparam:false) target);
       Warnings.check_fatal ();
     end

--- a/native_toplevel/opttopdirs.ml
+++ b/native_toplevel/opttopdirs.ml
@@ -85,7 +85,8 @@ let load_file ppf name0 =
       if Filename.check_suffix name ".cmx" || Filename.check_suffix name ".cmxa"
       then
         let cmxs = Filename.temp_file "caml" ".cmxs" in
-        Asmlink.link_shared ~ppf_dump:ppf [name] cmxs;
+        Asmlink.link_shared (module Unix : Compiler_owee.Unix_intf.S)
+          ~ppf_dump:ppf [name] cmxs;
         cmxs,true
       else
         name,false

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -23,7 +23,7 @@ let compile_file filename =
   end; (* otherwise, stdout *)
   let compilation_unit = "test" |> Compilation_unit.of_string in
   Compilenv.reset compilation_unit;
-  Emit.begin_assembly ~init_dwarf:(fun () -> ());
+  Emit.begin_assembly (module Unix : Compiler_owee.Unix_intf.S) ~init_dwarf:(fun () -> ());
   let ic = open_in filename in
   let lb = Lexing.from_channel ic in
   lb.Lexing.lex_curr_p <- Lexing.{ lb.lex_curr_p with pos_fname = filename };


### PR DESCRIPTION
A minor bug fix and small refactoring to move x86 specific code out of asmgen, mostly in preparation for another PR. 

Best reviewed commit by commit.

The combination of flags `-S -internal-assembler` caused compilation failure with the error
```
File "caml_startup", line 1:
Error: I/O error: Bad file descriptor
```
because `Clflags.keep_asm_file`   is not set for startup files, so it can't be used for setting `Emitaux.create_asm_file`, and anyway `compile_unit` is the right place to set it and it is called before `begin_emit_assembly_with_dwarf`.



