### PR TITLE
Remove field Linear.fun_end_label

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -361,6 +361,52 @@ let emit_call_bound_errors () =
     emit_call "caml_ml_array_bound_error"
   end
 
+(* Record function info for dwarf and emit label if needed. *)
+let emit_dwarf_for_fundecl fun_name fun_dbg =
+  match Emitaux.Dwarf_helpers.record_dwarf_for_fundecl ~fun_name fun_dbg with
+  | None -> ()
+  | Some label -> def_label label
+
+let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
+    module Asm_targets.Asm_directives.Make(struct
+
+      let emit_line str = X86_dsl.D.comment str
+
+      let get_file_num file_name =
+        Emitaux.get_file_num ~file_emitter:X86_dsl.D.file file_name
+
+      let debugging_comments_in_asm_files =
+        !Flambda_backend_flags.dasm_comments
+
+      module D = struct
+        open X86_ast
+
+        include X86_dsl.D
+
+        type data_type =
+          | NONE | DWORD | QWORD
+
+        type nonrec constant = constant
+        let const_int64 num = Const num
+        let const_label str = ConstLabel str
+        let const_add c1 c2 = ConstAdd (c1, c2)
+        let const_sub c1 c2 = ConstSub (c1, c2)
+
+        let label ?data_type str =
+          let typ =
+            Option.map
+              (function
+                | NONE -> X86_ast.NONE
+                | DWORD -> X86_ast.DWORD
+                | QWORD -> X86_ast.QWORD)
+              data_type
+          in
+          label ?typ str
+      end
+    end)
+  )
+
+
 (* Names for instructions *)
 
 let instr_for_intop = function
@@ -525,12 +571,15 @@ let emit_float_constant f lbl =
   _label (emit_label lbl);
   D.qword (Const f)
 
-let emit_global_label s =
-  let lbl = Cmm_helpers.make_symbol s in
+let emit_global_label_for_symbol lbl =
   add_def_symbol lbl;
   let lbl = emit_symbol lbl in
   D.global lbl;
   _label lbl
+
+let emit_global_label s =
+  let lbl = Cmm_helpers.make_symbol s in
+  emit_global_label_for_symbol lbl
 
 let move (src : Reg.t) (dst : Reg.t) =
   if src.loc <> dst.loc then
@@ -1303,7 +1352,7 @@ let fundecl fundecl =
       cfi_adjust_cfa_offset (-n);
     end;
   end;
-  def_label fundecl.fun_end_label;
+  emit_dwarf_for_fundecl fundecl.fun_name fundecl.fun_dbg;
   cfi_endproc ();
   emit_function_type_and_size fundecl.fun_name
 
@@ -1341,14 +1390,17 @@ let reset_all () =
   float_constants := [];
   all_functions := []
 
-let begin_assembly unix ~init_dwarf =
+let begin_assembly unix =
   reset_all ();
 
   if !Flambda_backend_flags.internal_assembler &&
      !Emitaux.binary_backend_available then
     X86_proc.register_internal_assembler (Internal_assembler.assemble unix);
 
-  init_dwarf ();
+  let code_begin = Cmm_helpers.make_symbol "code_begin" in
+  let code_end = Cmm_helpers.make_symbol "code_end" in
+  Emitaux.Dwarf_helpers.begin_dwarf ~build_asm_directives ~code_begin ~code_end
+    ~file_emitter:D.file;
 
   if system = S_win64 then begin
     D.extrn "caml_call_gc" NEAR;
@@ -1382,8 +1434,8 @@ let begin_assembly unix ~init_dwarf =
   D.data ();
   emit_global_label "data_begin";
 
-  emit_named_text_section (Cmm_helpers.make_symbol "code_begin");
-  emit_global_label "code_begin";
+  emit_named_text_section code_begin;
+  emit_global_label_for_symbol code_begin;
   if system = S_macosx then I.nop (); (* PR#4690 *)
   ()
 
@@ -1681,7 +1733,7 @@ let emit_trap_notes () =
     D.data ()
   end
 
-let end_assembly dwarf =
+let end_assembly () =
   if !float_constants <> [] then begin
     begin match system with
     | S_macosx -> D.section ["__TEXT";"__literal8"] None ["8byte_literals"]
@@ -1696,11 +1748,12 @@ let end_assembly dwarf =
   (* Emit probe handler wrappers *)
   List.iter emit_probe_handler_wrapper !probes;
 
-  emit_named_text_section (Cmm_helpers.make_symbol "code_end");
+  let code_end = Cmm_helpers.make_symbol "code_end" in
+  emit_named_text_section code_end;
   if system = S_macosx then I.nop ();
   (* suppress "ld warning: atom sorting error" *)
 
-  emit_global_label "code_end";
+  emit_global_label_for_symbol code_end;
 
   emit_imp_table();
 
@@ -1773,6 +1826,6 @@ let end_assembly dwarf =
     else
       None
   in
-  Option.iter Dwarf_ocaml.Dwarf.emit dwarf;
+  Emitaux.Dwarf_helpers.emit_dwarf ();
   X86_proc.generate_code asm;
   reset_all ()

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -1151,7 +1151,10 @@ let fundecl fundecl =
   List.iter emit_call_bound_error !bound_error_sites;
   assert (List.length !call_gc_sites = num_call_gc);
   assert (List.length !bound_error_sites = num_check_bound);
-  `{emit_label fundecl.fun_end_label}:\n`;
+  (match Emitaux.Dwarf_helpers.record_dwarf_for_fundecl
+           ~fun_name:fundecl.fun_name fundecl.fun_dbg with
+   | None -> ()
+   | Some label -> `{emit_label label}:\n`);
   cfi_endproc();
   emit_symbol_type emit_symbol fundecl.fun_name "function";
   emit_symbol_size fundecl.fun_name;
@@ -1188,7 +1191,7 @@ let data l =
 
 (* Beginning / end of an assembly file *)
 
-let begin_assembly _unix ~init_dwarf:_ =
+let begin_assembly _unix =
   reset_debug_info();
   `	.file	\"\"\n`;  (* PR#7037 *)
   let lbl_begin = Cmm_helpers.make_symbol "data_begin" in

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -167,21 +167,23 @@ let should_use_linscan fd =
   List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options
 
 let if_emit_do f x = if should_emit () then f x else ()
-let emit_begin_assembly = if_emit_do Emit.begin_assembly
-let emit_end_assembly filename =
+let emit_begin_assembly unix = if_emit_do Emit.begin_assembly unix
+let emit_end_assembly filename () =
   if_emit_do (fun () ->
     try Emit.end_assembly ()
      with Emitaux.Error e ->
        raise (Error (Asm_generation(filename, e))))
+    ()
 
-let emit_data = if_emit_do Emit.data
-let emit_fundecl =
+let emit_data dl = if_emit_do Emit.data dl
+let emit_fundecl f =
   if_emit_do
     (fun (fundecl : Linear.fundecl) ->
       try
         Profile.record ~accumulate:true "emit" Emit.fundecl fundecl
     with Emitaux.Error e ->
       raise (Error (Asm_generation(fundecl.Linear.fun_name, e))))
+    f
 
 let rec regalloc ~ppf_dump round fd =
   if round > 50 then

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -23,8 +23,6 @@ open Clflags
 open Misc
 open Cmm
 
-open Dwarf_ocaml
-
 module String = Misc.Stdlib.String
 
 type error =
@@ -169,35 +167,19 @@ let should_use_linscan fd =
   List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options
 
 let if_emit_do f x = if should_emit () then f x else ()
-let emit_begin_assembly unix ~init_dwarf:init_dwarf =
-  if_emit_do (fun init_dwarf -> Emit.begin_assembly unix ~init_dwarf) init_dwarf
+let emit_begin_assembly = if_emit_do Emit.begin_assembly
 let emit_end_assembly filename =
-  if_emit_do
-   (fun dwarf ->
-     try
-       Emit.end_assembly dwarf
+  if_emit_do (fun () ->
+    try Emit.end_assembly ()
      with Emitaux.Error e ->
        raise (Error (Asm_generation(filename, e))))
 
 let emit_data = if_emit_do Emit.data
-let emit_fundecl ~dwarf =
+let emit_fundecl =
   if_emit_do
     (fun (fundecl : Linear.fundecl) ->
       try
-        let () = Profile.record ~accumulate:true "emit" Emit.fundecl fundecl in
-        match dwarf with
-        | None -> ()
-        | Some dwarf ->
-          let fun_end_label =
-            Asm_targets.Asm_label.create_int Text fundecl.fun_end_label
-          in
-          let fundecl : Dwarf_concrete_instances.fundecl =
-            { fun_name = fundecl.fun_name;
-              fun_dbg = fundecl.fun_dbg;
-              fun_end_label;
-            }
-          in
-          Dwarf.dwarf_for_fundecl dwarf fundecl
+        Profile.record ~accumulate:true "emit" Emit.fundecl fundecl
     with Emitaux.Error e ->
       raise (Error (Asm_generation(fundecl.Linear.fun_name, e))))
 
@@ -276,7 +258,7 @@ let register_allocator : register_allocator =
     | "" | "upstream" -> Upstream
     | _ -> Misc.fatal_errorf "unknown register allocator %S" id
 
-let compile_fundecl ?dwarf ~ppf_dump ~funcnames fd_cmm =
+let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   Proc.init ();
   Reg.reset();
   fd_cmm
@@ -362,14 +344,14 @@ let compile_fundecl ?dwarf ~ppf_dump ~funcnames fd_cmm =
   ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl
   ++ pass_dump_linear_if ppf_dump dump_scheduling "After instruction scheduling"
   ++ Profile.record ~accumulate:true "save_linear" save_linear
-  ++ Profile.record ~accumulate:true "emit_fundecl" (emit_fundecl ~dwarf)
+  ++ Profile.record ~accumulate:true "emit_fundecl" emit_fundecl
 
 let compile_data dl =
   dl
   ++ save_data
   ++ emit_data
 
-let compile_phrases ?dwarf ~ppf_dump ps =
+let compile_phrases ~ppf_dump ps =
     let funcnames =
       List.fold_left (fun s p ->
           match p with
@@ -384,7 +366,7 @@ let compile_phrases ?dwarf ~ppf_dump ps =
           if !dump_cmm then fprintf ppf_dump "%a@." Printcmm.phrase p;
           match p with
           | Cfunction fd ->
-            compile_fundecl ?dwarf ~ppf_dump ~funcnames fd;
+            compile_fundecl ~ppf_dump ~funcnames fd;
             compile ~funcnames:(String.Set.remove fd.fun_name funcnames) ps
           | Cdata dl ->
             compile_data dl;
@@ -392,16 +374,16 @@ let compile_phrases ?dwarf ~ppf_dump ps =
     in
     compile ~funcnames ps
 
-let compile_phrase ?dwarf ~ppf_dump p =
-  compile_phrases ?dwarf ~ppf_dump [p]
+let compile_phrase ~ppf_dump p =
+  compile_phrases ~ppf_dump [p]
 
 (* For the native toplevel: generates generic functions unless
    they are already available in the process *)
-let compile_genfuns ?dwarf ~ppf_dump f =
+let compile_genfuns ~ppf_dump f =
   List.iter
     (function
        | (Cfunction {fun_name = name}) as ph when f name ->
-           compile_phrase ?dwarf ~ppf_dump ph
+           compile_phrase ~ppf_dump ph
        | _ -> ())
     (Cmm_helpers.generic_functions true
        (Cmm_helpers.Generic_fns_tbl.of_fns
@@ -446,98 +428,12 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduc
        if create_asm && not keep_asm then remove_file asm_filename
     )
 
-let build_dwarf ~asm_directives:(module Asm_directives : Asm_targets.Asm_directives_intf.S) sourcefile =
-  let unit_name =
-    (* CR lmaurer: This doesn't actually need to be an [Ident.t] *)
-    Symbol.for_current_unit ()
-    |> Symbol.linkage_name
-    |> Linkage_name.to_string
-    |> Ident.create_persistent
-  in
-  let code_begin =
-    Cmm_helpers.make_symbol "code_begin" |> Asm_targets.Asm_symbol.create
-  in
-  let code_end =
-    Cmm_helpers.make_symbol "code_end" |> Asm_targets.Asm_symbol.create
-  in
-  Dwarf.create
-    ~sourcefile
-    ~unit_name
-    ~asm_directives:(module Asm_directives)
-    ~get_file_id:(Emitaux.get_file_num ~file_emitter:X86_dsl.D.file)
-    ~code_begin ~code_end
-
-let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
-    module Asm_targets.Asm_directives.Make(struct
-
-      let emit_line str = X86_dsl.D.comment str
-
-      let get_file_num file_name =
-        Emitaux.get_file_num ~file_emitter:X86_dsl.D.file file_name
-
-      let debugging_comments_in_asm_files =
-        !Flambda_backend_flags.dasm_comments
-
-      module D = struct
-        open X86_ast
-
-        include X86_dsl.D
-
-        type data_type =
-          | NONE | DWORD | QWORD
-
-        type nonrec constant = constant
-        let const_int64 num = Const num
-        let const_label str = ConstLabel str
-        let const_add c1 c2 = ConstAdd (c1, c2)
-        let const_sub c1 c2 = ConstSub (c1, c2)
-
-        let label ?data_type str =
-          let typ =
-            Option.map
-              (function
-                | NONE -> X86_ast.NONE
-                | DWORD -> X86_ast.DWORD
-                | QWORD -> X86_ast.QWORD)
-              data_type
-          in
-          label ?typ str
-      end
-    end)
-  )
-
-let emit_begin_assembly_with_dwarf unix ~disable_dwarf ~emit_begin_assembly ~sourcefile () =
-  let no_dwarf () =
-    emit_begin_assembly unix ~init_dwarf:(fun () -> ());
-    None
-  in
-  let can_emit =
-    !Clflags.debug
-    && not !Dwarf_flags.restrict_to_upstream_dwarf
-    && not disable_dwarf
-  in
-  match can_emit, Target_system.architecture (), Target_system.derived_system () with
-  | true, X86_64, _ ->
-    let asm_directives = build_asm_directives () in
-    let (module Asm_directives : Asm_targets.Asm_directives_intf.S) = asm_directives in
-    let dwarf = ref None in
-    emit_begin_assembly unix ~init_dwarf:(fun () ->
-        Asm_targets.Asm_label.initialize ~new_label:Cmm.new_label;
-        Asm_directives.initialize ();
-        dwarf := Some (build_dwarf ~asm_directives sourcefile)
-    );
-    !dwarf
-  | true, _, _ -> no_dwarf ()
-  | false, _, _ -> no_dwarf ()
-
 let end_gen_implementation0 unix ?toplevel ~ppf_dump ~sourcefile make_cmm =
-  let dwarf =
-    emit_begin_assembly_with_dwarf unix ~disable_dwarf:false ~emit_begin_assembly
-      ~sourcefile ()
-  in
+  Emitaux.Dwarf_helpers.init ~disable_dwarf:false sourcefile;
+  emit_begin_assembly unix;
   make_cmm ()
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cmm
-  ++ Profile.record "compile_phrases" (compile_phrases ?dwarf ~ppf_dump)
+  ++ Profile.record "compile_phrases" (compile_phrases ~ppf_dump)
   ++ (fun () -> ());
   (match toplevel with None -> () | Some f -> compile_genfuns ~ppf_dump f);
   (* We add explicit references to external primitive symbols.  This
@@ -545,13 +441,13 @@ let end_gen_implementation0 unix ?toplevel ~ppf_dump ~sourcefile make_cmm =
      when part of a C library, won't be discarded by the linker.
      This is important if a module that uses such a symbol is later
      dynlinked. *)
-  compile_phrase ~ppf_dump ?dwarf
+  compile_phrase ~ppf_dump
     (Cmm_helpers.reference_symbols
        (List.filter_map (fun prim ->
            if not (Primitive.native_name_is_external prim) then None
            else Some (Primitive.native_name prim))
           !Translmod.primitive_declarations));
-  emit_end_assembly sourcefile dwarf
+  emit_end_assembly sourcefile ()
 
 let end_gen_implementation unix ?toplevel ~ppf_dump ~sourcefile clambda =
   end_gen_implementation0 unix ?toplevel ~ppf_dump ~sourcefile (fun () ->
@@ -612,17 +508,15 @@ let linear_gen_implementation unix filename =
   in
   if not (Compilation_unit.Prefix.equal current_package saved_package)
   then raise(Error(Mismatched_for_pack saved_package));
-  let emit_item ~dwarf = function
+  let emit_item = function
     | Data dl -> emit_data dl
-    | Func f -> emit_fundecl ~dwarf f
+    | Func f -> emit_fundecl f
   in
   start_from_emit := true;
-  let dwarf =
-    emit_begin_assembly_with_dwarf unix ~disable_dwarf:false
-      ~emit_begin_assembly ~sourcefile:filename ()
-  in
-  Profile.record "Emit" (List.iter (emit_item ~dwarf)) linear_unit_info.items;
-  emit_end_assembly filename dwarf
+  Emitaux.Dwarf_helpers.init ~disable_dwarf:false filename;
+  emit_begin_assembly unix;
+  Profile.record "Emit" (List.iter emit_item) linear_unit_info.items;
+  emit_end_assembly filename ()
 
 let compile_implementation_linear unix output_prefix ~progname =
   compile_unit ~may_reduce_heap:true ~output_prefix

--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -70,8 +70,7 @@ val compile_implementation_linear
   -> unit
 
 val compile_phrase
-  : ?dwarf:Dwarf_ocaml.Dwarf.t
-  -> ppf_dump:Format.formatter
+  : ppf_dump:Format.formatter
   -> Cmm.phrase
   -> unit
 
@@ -92,21 +91,3 @@ val compile_unit
    -> ppf_dump:Format.formatter
    -> (unit -> unit)
    -> unit
-
-(* First-class module building for DWARF *)
-
-(* Sets up assembly emitting.
-  Calls [emit_begin_assembly] (which in most case
-  should be something similar to [Emit.begin_assembly]).
-  Might return an instance of [Dwarf_ocaml.Dwarf.t] that can be used to generate
-  dwarf information for the target system. *)
-val emit_begin_assembly_with_dwarf
-   : (module Compiler_owee.Unix_intf.S)
-  -> disable_dwarf:bool
-  -> emit_begin_assembly:((module Compiler_owee.Unix_intf.S)
-                          -> init_dwarf:(unit -> unit) -> unit)
-  -> sourcefile:string
-  -> unit
-  -> Dwarf_ocaml.Dwarf.t option
-
-val build_asm_directives : unit -> (module Asm_targets.Asm_directives_intf.S)

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -371,7 +371,6 @@ let run cfg_with_layout =
     fun_num_stack_slots;
     fun_frame_required;
     fun_prologue_required;
-    fun_end_label = Cmm.new_label ()
   }
 
 (** debug print block as assembly *)

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -370,7 +370,7 @@ let run cfg_with_layout =
     fun_contains_calls;
     fun_num_stack_slots;
     fun_frame_required;
-    fun_prologue_required;
+    fun_prologue_required
   }
 
 (** debug print block as assembly *)

--- a/backend/emit.mli
+++ b/backend/emit.mli
@@ -17,5 +17,6 @@
 
 val fundecl: Linear.fundecl -> unit
 val data: Cmm.data_item list -> unit
-val begin_assembly: (module Compiler_owee.Unix_intf.S) -> init_dwarf:(unit -> unit) -> unit
-val end_assembly: Dwarf_ocaml.Dwarf.t option -> unit
+val begin_assembly: (module Compiler_owee.Unix_intf.S) -> unit
+val end_assembly: unit -> unit
+

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -107,6 +107,21 @@ type error =
   | Stack_frame_too_large of int
   | Stack_frame_way_too_large of int
 
+module Dwarf_helpers : sig
+  val init: disable_dwarf:bool -> string -> unit
+
+  val begin_dwarf
+    : build_asm_directives:(unit -> (module Asm_targets.Asm_directives_intf.S))
+    -> code_begin:string
+    -> code_end:string
+    -> file_emitter:(file_num:int -> file_name:string -> unit)
+    -> unit
+
+  val emit_dwarf : unit -> unit
+
+  val record_dwarf_for_fundecl : fun_name:string -> Debuginfo.t -> Cmm.label option
+end
+
 exception Error of error
 val report_error: Format.formatter -> error -> unit
 

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -59,7 +59,6 @@ type fundecl =
     fun_num_stack_slots: int array;
     fun_frame_required: bool;
     fun_prologue_required: bool;
-    fun_end_label: label;
   }
 
 (* Invert a test *)

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -59,7 +59,6 @@ type fundecl =
     fun_num_stack_slots: int array;
     fun_frame_required: bool;
     fun_prologue_required: bool;
-    fun_end_label: label;
   }
 
 val traps_to_bytes : int -> int

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -413,5 +413,4 @@ let fundecl f =
     fun_num_stack_slots;
     fun_frame_required;
     fun_prologue_required;
-    fun_end_label = Cmm.new_label ()
   }

--- a/backend/schedgen.ml
+++ b/backend/schedgen.ml
@@ -397,7 +397,6 @@ method schedule_fundecl f =
       fun_num_stack_slots = f.fun_num_stack_slots;
       fun_frame_required = f.fun_frame_required;
       fun_prologue_required = f.fun_prologue_required;
-      fun_end_label = Cmm.new_label ()
     }
   end else
     f

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -23,7 +23,7 @@ let compile_file filename =
   end; (* otherwise, stdout *)
   let compilation_unit = "test" |> Compilation_unit.of_string in
   Compilenv.reset compilation_unit;
-  Emit.begin_assembly (module Unix : Compiler_owee.Unix_intf.S) ~init_dwarf:(fun () -> ());
+  Emit.begin_assembly (module Unix : Compiler_owee.Unix_intf.S);
   let ic = open_in filename in
   let lb = Lexing.from_channel ic in
   lb.Lexing.lex_curr_p <- Lexing.{ lb.lex_curr_p with pos_fname = filename };
@@ -34,7 +34,7 @@ let compile_file filename =
     done
   with
       End_of_file ->
-        close_in ic; Emit.end_assembly None;
+        close_in ic; Emit.end_assembly ();
         if !write_asm_file then close_out !Emitaux.output_channel
     | Lexcmm.Error msg ->
         close_in ic; Lexcmm.report_error lb msg


### PR DESCRIPTION
On top of PR #1026. Best reviewed commit by commt.

The main motivation for this PR is to avoid calling `Cmm.new_label` during `Cfg_to_linear`.  

This is a refactoring PR, to move dwarf handling from `Asmgen` to `Emitaux`. It also moves `X86` specific code out of `Asmgen` and into `Emit`. 

As a result  of this change, we can remove the recently-added field `Linear.fun_end_label`. This field is not used until `Emit`, and the only reason it is initialized earlier is to coordinate between `Emit.fundecl` and the new dwarf emitter (which is  off by default). The early initialization of this label (using `Cmm.new_label`) during `Cfg_to_linear` makes FDO profiles  harder to interpret. 


