### PR TITLE
Fix OCAMLPARAM for dwarf related  flags

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -802,29 +802,29 @@ module Flambda_backend_options_impl = struct
 end
 
 module type Debugging_options = sig
-  val _restrict_to_upstream_dwarf : unit -> unit
-  val _no_restrict_to_upstream_dwarf : unit -> unit
-  val _dwarf_for_startup_file : unit -> unit
-  val _no_dwarf_for_startup_file : unit -> unit
+  val restrict_to_upstream_dwarf : unit -> unit
+  val no_restrict_to_upstream_dwarf : unit -> unit
+  val dwarf_for_startup_file : unit -> unit
+  val no_dwarf_for_startup_file : unit -> unit
 end
 
 module Make_debugging_options (F : Debugging_options) = struct
   let list3 = [
-    mk_restrict_to_upstream_dwarf F._restrict_to_upstream_dwarf;
-    mk_no_restrict_to_upstream_dwarf F._no_restrict_to_upstream_dwarf;
-    mk_dwarf_for_startup_file F._dwarf_for_startup_file;
-    mk_no_dwarf_for_startup_file F._no_dwarf_for_startup_file;
+    mk_restrict_to_upstream_dwarf F.restrict_to_upstream_dwarf;
+    mk_no_restrict_to_upstream_dwarf F.no_restrict_to_upstream_dwarf;
+    mk_dwarf_for_startup_file F.dwarf_for_startup_file;
+    mk_no_dwarf_for_startup_file F.no_dwarf_for_startup_file;
    ]
 end
 
 module Debugging_options_impl = struct
-  let _restrict_to_upstream_dwarf () =
+  let restrict_to_upstream_dwarf () =
     Debugging.restrict_to_upstream_dwarf := true
-  let _no_restrict_to_upstream_dwarf () =
+  let no_restrict_to_upstream_dwarf () =
     Debugging.restrict_to_upstream_dwarf := false
-  let _dwarf_for_startup_file () =
+  let dwarf_for_startup_file () =
     Debugging.dwarf_for_startup_file := true
-  let _no_dwarf_for_startup_file () =
+  let no_dwarf_for_startup_file () =
     Debugging.dwarf_for_startup_file := false
 end
 

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -860,9 +860,6 @@ module Extra_params = struct
       end;
       true
     in
-    let clear' option =
-      Compenv.setter ppf (fun b -> b) name [ option ] v; false
-    in
     match name with
     | "internal-assembler" -> set' Flambda_backend_flags.internal_assembler
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
@@ -886,11 +883,8 @@ module Extra_params = struct
                 Flambda_backend_flags.max_long_frames_threshold))
       end
     | "dasm-comments" -> set' Flambda_backend_flags.dasm_comments
-    | "dno-asm-comments" -> clear' Flambda_backend_flags.dasm_comments
     | "gupstream-dwarf" -> set' Debugging.restrict_to_upstream_dwarf
-    | "gno-upstream-dwarf" -> clear' Debugging.restrict_to_upstream_dwarf
     | "gstartup" -> set' Debugging.dwarf_for_startup_file
-    | "gno-startup" -> clear' Debugging.dwarf_for_startup_file
     | "flambda2-join-points" -> set Flambda2.join_points
     | "flambda2-result-types" ->
       (match String.lowercase_ascii v with

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -100,10 +100,10 @@ end
 
 (** Command line arguments required for ocamlopt.*)
 module type Debugging_options = sig
-  val _restrict_to_upstream_dwarf : unit -> unit
-  val _no_restrict_to_upstream_dwarf : unit -> unit
-  val _dwarf_for_startup_file : unit -> unit
-  val _no_dwarf_for_startup_file : unit -> unit
+  val restrict_to_upstream_dwarf : unit -> unit
+  val no_restrict_to_upstream_dwarf : unit -> unit
+  val dwarf_for_startup_file : unit -> unit
+  val no_dwarf_for_startup_file : unit -> unit
 end
 
 (** Command line arguments required for ocamlopt. *)


### PR DESCRIPTION
A minor bug in parsing OCAMLPARAM leads to compilation failure when using the new dwarf support (off by default), for example:

```
$ OCAMLPARAM="_,gno-upstream-dwarf=1,gstartup=1,dno-asm-comments=1" make runtest-upstream
File "_none_", line 1:
Warning 46 [bad-env-variable]: illegal environment variable OCAMLPARAM : Warning: discarding value of variable "gno-upstream-dwarf" in OCAMLPARAM
```

The bug is that `clear'` should return `true` (indicating that the param was successfully applied), not false.
It affects the followign params: 
`dno-asm-comments`
`gno-upstream-dwarf`
`gno-startup`

The fix is actually just to remove the "no" version of these params. Unlike command line arguments, params have to be set explicitly, so only one param is needed per boolean flag.

This PR also includes a little cleanup of the related variables.
