### PR TITLE
Various classic mode fixes, WIP

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -159,7 +159,7 @@ module Env : sig
   val add_block_approximation :
     t -> Name.t -> value_approximation array -> Alloc_mode.For_types.t -> t
 
-  val add_approximation_alias : t -> Name.t -> Name.t -> t
+  val add_approximation_alias : t -> Simple.t -> alias:Name.t -> t
 
   val find_value_approximation : t -> Simple.t -> value_approximation
 
@@ -386,7 +386,7 @@ module Apply_cont_with_acc : sig
   val create :
     Acc.t ->
     ?trap_action:Trap_action.t ->
-    ?args_approx:Env.value_approximation list ->
+    args_approx:Env.value_approximation list option ->
     Continuation.t ->
     args:Simple.t list ->
     dbg:Debuginfo.t ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -85,7 +85,8 @@ let raise_exn_for_failure acc ~dbg exn_cont exn_bucket extra_let_binding =
     exn_bucket :: extra_args
   in
   let acc, apply_cont =
-    Apply_cont_with_acc.create acc ~trap_action exn_handler ~args ~dbg
+    Apply_cont_with_acc.create acc ~trap_action exn_handler ~args
+      ~args_approx:None ~dbg
   in
   let acc, apply_cont = Expr_with_acc.create_apply_cont acc apply_cont in
   match extra_let_binding with
@@ -335,7 +336,7 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
       let acc, apply_cont =
         Apply_cont_with_acc.create acc join_point_cont
           ~args:[Simple.var ifso_result]
-          ~dbg
+          ~args_approx:None ~dbg
       in
       let acc, body = Expr_with_acc.create_apply_cont acc apply_cont in
       Let_with_acc.create acc
@@ -348,7 +349,7 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
       let acc, apply_cont =
         Apply_cont_with_acc.create acc join_point_cont
           ~args:[Simple.var ifnot_result]
-          ~dbg
+          ~args_approx:None ~dbg
       in
       let acc, body = Expr_with_acc.create_apply_cont acc apply_cont in
       Let_with_acc.create acc

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -18,6 +18,9 @@ module R = To_cmm_result
 module P = Flambda_primitive
 module Ece = Effects_and_coeffects
 
+let debug () =
+  match Sys.getenv "DEBUG" with exception Not_found -> false | _ -> true
+
 type cont =
   | Jump of
       { cont : Cmm.label;
@@ -587,10 +590,10 @@ and split_in_env env res var binding =
   let res, split_result = split_complex_binding ~env ~res binding in
   match split_result with
   | Already_split ->
-    Format.eprintf "split_in_env: Already_split\n%!";
+    if debug () then Format.eprintf "split_in_env: Already_split\n%!";
     env, res, binding
   | Split { new_bindings; split_binding } ->
-    Format.eprintf "split_in_env: Split\n%!";
+    if debug () then Format.eprintf "split_in_env: Split\n%!";
     let env =
       (* for duplicated bindings, we need to replace the original splittable
          binding with the new split binding in the bindings map of the env *)
@@ -763,27 +766,27 @@ let inline_variable ?consider_inlining_effectful_expressions env res var =
   | Binding binding -> (
     match binding.inline with
     | Do_not_inline ->
-      Format.eprintf "inline_variable: Do_not_inline\n%!";
+      if debug () then Format.eprintf "inline_variable: Do_not_inline\n%!";
       will_not_inline_simple env res binding
     | Must_inline_and_duplicate ->
-      Format.eprintf "inline_variable: Must_inline_and_dup\n%!";
+      if debug () then Format.eprintf "inline_variable: Must_inline_and_dup\n%!";
       split_and_inline env res var binding
     | Must_inline_once -> (
-      Format.eprintf "inline_variable: Must_inline_once...\n%!";
+      if debug () then Format.eprintf "inline_variable: Must_inline_once...\n%!";
       let env = remove_binding env var in
       match To_cmm_effects.classify_by_effects_and_coeffects binding.effs with
       | Pure | Generative_immutable ->
-        Format.eprintf "...Pure/Gen_immut\n%!";
+        if debug () then Format.eprintf "...Pure/Gen_immut\n%!";
         will_inline_complex env res binding
       | Effect | Coeffect_only -> (
         match
           pop_if_in_top_stage ?consider_inlining_effectful_expressions env var
         with
         | None ->
-          Format.eprintf "Eff/Coeff_only: None\n%!";
+          if debug () then Format.eprintf "Eff/Coeff_only: None\n%!";
           split_and_inline env res var binding
         | Some env ->
-          Format.eprintf "Eff/Coeff_only: Some\n%!";
+          if debug () then Format.eprintf "Eff/Coeff_only: Some\n%!";
           will_inline_complex env res binding))
     | May_inline_once -> (
       match To_cmm_effects.classify_by_effects_and_coeffects binding.effs with
@@ -823,22 +826,26 @@ let force_binding_to_be_split t res var =
 let add_alias t res ~var
     ~(num_normal_occurrences_of_var : Num_occurrences.t Variable.Map.t)
     ~alias_of =
-  Format.eprintf "add_alias var=%a (occs %a), alias_of=%a\n%!" Variable.print
-    var
-    (Variable.Map.print Num_occurrences.print)
-    num_normal_occurrences_of_var Variable.print alias_of;
+  if debug ()
+  then
+    Format.eprintf "add_alias var=%a (occs %a), alias_of=%a\n%!" Variable.print
+      var
+      (Variable.Map.print Num_occurrences.print)
+      num_normal_occurrences_of_var Variable.print alias_of;
   let t, res, inline = force_binding_to_be_split t res alias_of in
   let cmm_expr, t, res, ece = inline_variable t res alias_of in
-  Format.eprintf "cmm_expr for alias_of: %a\n%!" Printcmm.expression cmm_expr;
+  if debug ()
+  then
+    Format.eprintf "cmm_expr for alias_of: %a\n%!" Printcmm.expression cmm_expr;
   let[@inline] simple_case () =
-    Format.eprintf "...simple case\n%!";
+    if debug () then Format.eprintf "...simple case\n%!";
     let defining_expr : simple bound_expr = Simple { cmm_expr } in
     let inline : simple inline = Do_not_inline in
     bind_variable_with_decision t res var ~inline ~defining_expr
       ~effects_and_coeffects_of_defining_expr:ece
   in
   let[@inline] complex_case ~(inline_alias_of : complex inline) =
-    Format.eprintf "...complex case: ";
+    if debug () then Format.eprintf "...complex case: ";
     let defining_expr : complex bound_expr = Split { cmm_expr } in
     let inline : complex inline =
       match inline_alias_of with
@@ -850,13 +857,13 @@ let add_alias t res ~var
         in
         match num_occurrences_of_var with
         | Zero | One ->
-          Format.eprintf "Must_inline_once\n%!";
+          if debug () then Format.eprintf "Must_inline_once\n%!";
           Must_inline_once
         | More_than_one ->
-          Format.eprintf "Must_inline_and_dup (1)\n%!";
+          if debug () then Format.eprintf "Must_inline_and_dup (1)\n%!";
           Must_inline_and_duplicate)
       | Must_inline_and_duplicate ->
-        Format.eprintf "Must_inline_and_dup (2)\n%!";
+        if debug () then Format.eprintf "Must_inline_and_dup (2)\n%!";
         Must_inline_and_duplicate
     in
     bind_variable_with_decision t res var ~inline ~defining_expr

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -976,8 +976,11 @@ let flush_delayed_lets ~mode env res =
               Format.eprintf "flushing split binding? %b: %a = %a\n%!"
                 must_flush Backend_var.With_provenance.print b.cmm_var
                 print_bound_expr b.bound_expr;
-            if must_flush then flush split_binding;
-            None
+            if must_flush
+            then (
+              flush split_binding;
+              None)
+            else Some split_binding
           | Branching_point | Entering_loop -> Some split_binding)
         | Must_inline_once -> (
           match

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -816,7 +816,13 @@ let force_binding_to_be_split t res var =
         } ->
       t, res, Some (Any_inline inline)
     | Binding
-        ({ bound_expr = Split _ | Splittable_prim _;
+        { bound_expr = Split _;
+          inline = (Must_inline_once | Must_inline_and_duplicate) as inline;
+          _
+        } ->
+      t, res, Some (Any_inline inline)
+    | Binding
+        ({ bound_expr = Splittable_prim _;
            inline = (Must_inline_once | Must_inline_and_duplicate) as inline;
            _
          } as binding) ->

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -911,7 +911,10 @@ let flush_delayed_lets ~mode env res =
   let bindings_to_flush = ref M.empty in
   let flush (Binding b as binding) =
     if M.mem b.order !bindings_to_flush
-    then Misc.fatal_errorf "Duplicate order for bindings when flushing";
+    then
+      Misc.fatal_errorf "Duplicate order for bindings when flushing: %a = %a"
+        Backend_var.With_provenance.print b.cmm_var print_bound_expr
+        b.bound_expr;
     bindings_to_flush := M.add b.order binding !bindings_to_flush
   in
   let bindings_to_keep =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -960,6 +960,11 @@ let flush_delayed_lets ~mode env res =
           in
           match mode with
           | Flush_everything ->
+            if debug ()
+            then
+              Format.eprintf "flushing split binding: %a = %a\n%!"
+                Backend_var.With_provenance.print b.cmm_var print_bound_expr
+                b.bound_expr;
             flush split_binding;
             None
           | Branching_point | Entering_loop -> Some split_binding)

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -597,12 +597,11 @@ and split_in_env env res var binding =
     let env =
       (* for duplicated bindings, we need to replace the original splittable
          binding with the new split binding in the bindings map of the env *)
-      match split_binding.inline with
-      | Must_inline_once -> env
-      | Must_inline_and_duplicate ->
-        { env with
-          bindings = Variable.Map.add var (Binding split_binding) env.bindings
-        }
+      (* match split_binding.inline with | Must_inline_once -> env |
+         Must_inline_and_duplicate -> *)
+      { env with
+        bindings = Variable.Map.add var (Binding split_binding) env.bindings
+      }
     in
     let env, res =
       List.fold_left

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -221,6 +221,14 @@ val bind_variable :
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
   t * To_cmm_result.t
 
+val add_alias :
+  t ->
+  To_cmm_result.t ->
+  var:Variable.t ->
+  num_normal_occurrences_of_var:Num_occurrences.t Variable.Map.t ->
+  alias_of:Variable.t ->
+  t * To_cmm_result.t
+
 (** Try and inline an Flambda variable using the delayed let-bindings. *)
 val inline_variable :
   ?consider_inlining_effectful_expressions:bool ->

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -34,11 +34,11 @@ end
 
 let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
   match Simple.must_be_var s with
-  | Some (alias_of, _coercion) ->
+  | Some (alias_of, _coercion) when Flambda_features.classic_mode () ->
     Env.add_alias env res ~var:v
       ~num_normal_occurrences_of_var:num_normal_occurrences_of_bound_vars
       ~alias_of
-  | None ->
+  | Some _ | None ->
     let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
       C.simple ~dbg env res s
     in

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -33,14 +33,20 @@ end
 (* Bind a Cmm variable to the result of translating a [Simple] into Cmm. *)
 
 let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
-  let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
-    C.simple ~dbg env res s
-  in
-  let env, res =
-    Env.bind_variable env res v ~effects_and_coeffects_of_defining_expr
-      ~defining_expr ~num_normal_occurrences_of_bound_vars
-  in
-  env, res
+  match Simple.must_be_var s with
+  | Some (alias_of, _coercion) ->
+    Env.add_alias env res ~var:v
+      ~num_normal_occurrences_of_var:num_normal_occurrences_of_bound_vars
+      ~alias_of
+  | None ->
+    let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
+      C.simple ~dbg env res s
+    in
+    let env, res =
+      Env.bind_variable env res v ~effects_and_coeffects_of_defining_expr
+        ~defining_expr ~num_normal_occurrences_of_bound_vars
+    in
+    env, res
 
 (* Helpers for the translation of [Apply] expressions. *)
 


### PR DESCRIPTION
1. Experiment with making `args_approx` non-optional in `Closure_conversion`, I think we should probably do this.
2. Hack to ensure symbol approximations are propagated in `Closure_conversion`.  At the moment they are getting lost (probably between continuation bodies and handlers).
3. Handling of aliases in `To_cmm_env` (c.f. compilation of https://github.com/janestreet/bin_prot/blob/master/src/write.ml#L404 without boxing in classic mode)