### PR TITLE
Add layout type in Lambda

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1901,7 +1901,7 @@ module SArgBlocks = struct
 
   type loc = Debuginfo.t
 
-  type nonrec value_kind = value_kind
+  type layout = value_kind
 
   (* CR mshinwell: GPR#2294 will fix the Debuginfo here *)
 
@@ -3886,3 +3886,5 @@ let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
   | Default_check -> []
   | Assert p -> [Assert (transl_property p)]
   | Assume p -> [Assume (transl_property p)]
+
+let kind_of_layout (Lambda.Pvalue kind) = Vval kind

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1195,3 +1195,5 @@ val transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list
 
 (* CR lmaurer: Return [Linkage_name.t] instead *)
 val make_symbol : ?compilation_unit:Compilation_unit.t -> string -> string
+
+val kind_of_layout : Lambda.layout -> value_kind

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -654,27 +654,27 @@ let rec transl env e =
           (untag_int (transl env arg) dbg)
           s.us_index_consts
           (Array.map (fun expr -> transl env expr, dbg) s.us_actions_consts)
-          dbg (Vval kind)
+          dbg (kind_of_layout kind)
       else if Array.length s.us_index_consts = 0 then
         bind "switch" (transl env arg) (fun arg ->
-          transl_switch dbg (Vval kind) env (get_tag arg dbg)
+          transl_switch dbg (kind_of_layout kind) env (get_tag arg dbg)
             s.us_index_blocks s.us_actions_blocks)
       else
         bind "switch" (transl env arg) (fun arg ->
           Cifthenelse(
           Cop(Cand, [arg; Cconst_int (1, dbg)], dbg),
           dbg,
-          transl_switch dbg (Vval kind) env
+          transl_switch dbg (kind_of_layout kind) env
             (untag_int arg dbg) s.us_index_consts s.us_actions_consts,
           dbg,
-          transl_switch dbg (Vval kind) env
+          transl_switch dbg (kind_of_layout kind) env
             (get_tag arg dbg) s.us_index_blocks s.us_actions_blocks,
-          dbg, Vval kind))
+          dbg, kind_of_layout kind))
   | Ustringswitch(arg,sw,d, kind) ->
       let dbg = Debuginfo.none in
       bind "switch" (transl env arg)
         (fun arg ->
-          strmatch_compile dbg (Vval kind) arg (Option.map (transl env) d)
+          strmatch_compile dbg (kind_of_layout kind) arg (Option.map (transl env) d)
             (List.map (fun (s,act) -> s,transl env act) sw))
   | Ustaticfail (nfail, args) ->
       let cargs = List.map (transl env) args in
@@ -684,21 +684,21 @@ let rec transl env e =
   | Ucatch(nfail, [], body, handler, kind) ->
       let dbg = Debuginfo.none in
       let env_body = enter_catch_body env nfail in
-      make_catch (Vval kind) nfail
+      make_catch (kind_of_layout kind) nfail
         (transl env_body body)
         (transl env handler) dbg
   | Ucatch(nfail, ids, body, handler, kind) ->
       let dbg = Debuginfo.none in
-      transl_catch (Vval kind) env nfail ids body handler dbg
+      transl_catch (kind_of_layout kind) env nfail ids body handler dbg
   | Utrywith(body, exn, handler, kind) ->
       let dbg = Debuginfo.none in
       let new_body = transl (incr_depth env) body in
-      Ctrywith(new_body, Regular, exn, transl env handler, dbg, Vval kind)
+      Ctrywith(new_body, Regular, exn, transl env handler, dbg, kind_of_layout kind)
   | Uifthenelse(cond, ifso, ifnot, kind) ->
       let ifso_dbg = Debuginfo.none in
       let ifnot_dbg = Debuginfo.none in
       let dbg = Debuginfo.none in
-      transl_if env (Vval kind) Unknown dbg cond
+      transl_if env (kind_of_layout kind) Unknown dbg cond
         ifso_dbg (transl env ifso) ifnot_dbg (transl env ifnot)
   | Usequence(exp1, exp2) ->
       Csequence(remove_unit(transl env exp1), transl env exp2)
@@ -773,7 +773,7 @@ and transl_catch (kind : Cmm.value_kind) env nfail ids body handler dbg =
      each argument.  *)
   let report args =
     List.iter2
-      (fun (_id, kind, u) c ->
+      (fun (_id, Pvalue kind, u) c ->
          let strict = is_strict kind in
          u := join_unboxed_number_kind ~strict !u
              (is_unboxed_number_cmm c)
@@ -1221,7 +1221,7 @@ and transl_unbox_sized size dbg env exp =
   | Thirty_two -> transl_unbox_int dbg env Pint32 exp
   | Sixty_four -> transl_unbox_int dbg env Pint64 exp
 
-and transl_let env str (kind : Lambda.value_kind) id exp transl_body =
+and transl_let env str (Pvalue kind : Lambda.layout) id exp transl_body =
   let dbg = Debuginfo.none in
   let cexp = transl env exp in
   let unboxing =

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -58,31 +58,31 @@ and ulambda =
       scanned_slots : ulambda list ;
     }
   | Uoffset of ulambda * int
-  | Ulet of mutable_flag * value_kind * Backend_var.With_provenance.t
+  | Ulet of mutable_flag * layout * Backend_var.With_provenance.t
       * ulambda * ulambda
   | Uphantom_let of Backend_var.With_provenance.t
       * uphantom_defining_expr option * ulambda
   | Uletrec of (Backend_var.With_provenance.t * ulambda) list * ulambda
   | Uprim of Clambda_primitives.primitive * ulambda list * Debuginfo.t
-  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * Lambda.value_kind
+  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * layout
   | Ustringswitch of
       ulambda *
       (string * ulambda) list *
       ulambda option *
-      Lambda.value_kind
+      layout
   | Ustaticfail of int * ulambda list
   | Ucatch of
       int *
-      (Backend_var.With_provenance.t * value_kind) list *
+      (Backend_var.With_provenance.t * layout) list *
       ulambda *
       ulambda *
-      Lambda.value_kind
+      layout
   | Utrywith of
       ulambda *
       Backend_var.With_provenance.t *
       ulambda *
-      Lambda.value_kind
-  | Uifthenelse of ulambda * ulambda * ulambda * Lambda.value_kind
+      layout
+  | Uifthenelse of ulambda * ulambda * ulambda * layout
   | Usequence of ulambda * ulambda
   | Uwhile of ulambda * ulambda
   | Ufor of Backend_var.With_provenance.t * ulambda * ulambda
@@ -98,8 +98,8 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : arity;
-  params : (Backend_var.With_provenance.t * value_kind) list;
-  return : value_kind;
+  params : (Backend_var.With_provenance.t * layout) list;
+  return : layout;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -69,31 +69,31 @@ and ulambda =
       scanned_slots : ulambda list
     }
   | Uoffset of ulambda * int
-  | Ulet of mutable_flag * value_kind * Backend_var.With_provenance.t
+  | Ulet of mutable_flag * layout * Backend_var.With_provenance.t
       * ulambda * ulambda
   | Uphantom_let of Backend_var.With_provenance.t
       * uphantom_defining_expr option * ulambda
   | Uletrec of (Backend_var.With_provenance.t * ulambda) list * ulambda
   | Uprim of Clambda_primitives.primitive * ulambda list * Debuginfo.t
-  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * Lambda.value_kind
+  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * Lambda.layout
   | Ustringswitch of
       ulambda *
       (string * ulambda) list *
       ulambda option *
-      Lambda.value_kind
+      Lambda.layout
   | Ustaticfail of int * ulambda list
   | Ucatch of
       int *
-      (Backend_var.With_provenance.t * value_kind) list *
+      (Backend_var.With_provenance.t * layout) list *
       ulambda *
       ulambda *
-      Lambda.value_kind
+      Lambda.layout
   | Utrywith of
       ulambda *
       Backend_var.With_provenance.t *
       ulambda *
-      Lambda.value_kind
-  | Uifthenelse of ulambda * ulambda * ulambda * Lambda.value_kind
+      Lambda.layout
+  | Uifthenelse of ulambda * ulambda * ulambda * Lambda.layout
   | Usequence of ulambda * ulambda
   | Uwhile of ulambda * ulambda
   | Ufor of Backend_var.With_provenance.t * ulambda * ulambda
@@ -109,8 +109,8 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : arity;
-  params : (Backend_var.With_provenance.t * value_kind) list;
-  return : value_kind;
+  params : (Backend_var.With_provenance.t * layout) list;
+  return : layout;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -141,6 +141,9 @@ and value_kind = Lambda.value_kind =
     }
   | Parrayval of array_kind
 
+and layout = Lambda.layout =
+  | Pvalue of value_kind
+
 and block_shape = Lambda.block_shape
 and boxed_integer = Primitive.boxed_integer =
     Pnativeint | Pint32 | Pint64

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -144,6 +144,9 @@ and value_kind = Lambda.value_kind =
     }
   | Parrayval of array_kind
 
+and layout = Lambda.layout =
+  | Pvalue of value_kind
+
 and block_shape = Lambda.block_shape
 and boxed_integer = Primitive.boxed_integer =
     Pnativeint | Pint32 | Pint64

--- a/middle_end/flambda/augment_specialised_args.ml
+++ b/middle_end/flambda/augment_specialised_args.ml
@@ -22,8 +22,8 @@ module B = Inlining_cost.Benefit
 
 module Definition = struct
   type t =
-    | Existing_inner_free_var of Variable.t * Lambda.value_kind
-    | Projection_from_existing_specialised_arg of Projection.t * Lambda.value_kind
+    | Existing_inner_free_var of Variable.t * Lambda.layout
+    | Projection_from_existing_specialised_arg of Projection.t * Lambda.layout
 
   include Identifiable.Make (struct
     type nonrec t = t
@@ -48,10 +48,10 @@ module Definition = struct
       match t with
       | Existing_inner_free_var (var, kind) ->
         Format.fprintf ppf "Existing_inner_free_var (%a, %a)"
-          Variable.print var Printlambda.value_kind kind
+          Variable.print var Printlambda.layout kind
       | Projection_from_existing_specialised_arg (projection, kind) ->
         Format.fprintf ppf "Projection_from_existing_specialised_arg (%a, %a)"
-          Projection.print projection Printlambda.value_kind kind
+          Projection.print projection Printlambda.layout kind
 
     let output _ _ = failwith "Definition.output not yet implemented"
   end)

--- a/middle_end/flambda/augment_specialised_args.mli
+++ b/middle_end/flambda/augment_specialised_args.mli
@@ -18,8 +18,8 @@
 
 module Definition : sig
   type t =
-    | Existing_inner_free_var of Variable.t * Lambda.value_kind
-    | Projection_from_existing_specialised_arg of Projection.t * Lambda.value_kind
+    | Existing_inner_free_var of Variable.t * Lambda.layout
+    | Projection_from_existing_specialised_arg of Projection.t * Lambda.layout
 end
 
 module What_to_specialise : sig

--- a/middle_end/flambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/closure_conversion_aux.ml
@@ -19,8 +19,8 @@ open! Int_replace_polymorphic_compare
 
 module Env = struct
   type t = {
-    variables : (Variable.t * Lambda.value_kind) Ident.tbl;
-    mutable_variables : (Mutable_variable.t * Lambda.value_kind) Ident.tbl;
+    variables : (Variable.t * Lambda.layout) Ident.tbl;
+    mutable_variables : (Mutable_variable.t * Lambda.layout) Ident.tbl;
     static_exceptions : Static_exception.t Numbers.Int.Map.t;
     globals : Symbol.t Numbers.Int.Map.t;
     at_toplevel : bool;
@@ -92,7 +92,7 @@ module Function_decls = struct
       kind : Lambda.function_kind;
       mode : Lambda.alloc_mode;
       region : bool;
-      params : (Ident.t * Lambda.value_kind) list;
+      params : (Ident.t * Lambda.layout) list;
       body : Lambda.lambda;
       free_idents_of_body : Ident.Set.t;
       attr : Lambda.function_attribute;
@@ -185,7 +185,7 @@ module Function_decls = struct
       (* For "let rec"-bound functions. *)
       List.fold_right (fun function_decl env ->
           Env.add_var env (Function_decl.let_rec_ident function_decl)
-            (Function_decl.closure_bound_var function_decl) Pgenval)
+            (Function_decl.closure_bound_var function_decl) Lambda.layout_function)
         t.function_decls (Env.clear_local_bindings external_env)
     in
     (* For free variables. *)

--- a/middle_end/flambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/closure_conversion_aux.mli
@@ -26,16 +26,16 @@ module Env : sig
 
   val empty : t
 
-  val add_var : t -> Ident.t -> Variable.t -> Lambda.value_kind -> t
-  val add_vars : t -> Ident.t list -> (Variable.t * Lambda.value_kind) list -> t
+  val add_var : t -> Ident.t -> Variable.t -> Lambda.layout -> t
+  val add_vars : t -> Ident.t list -> (Variable.t * Lambda.layout) list -> t
 
-  val find_var : t -> Ident.t -> Variable.t * Lambda.value_kind
-  val find_var_exn : t -> Ident.t -> Variable.t * Lambda.value_kind
+  val find_var : t -> Ident.t -> Variable.t * Lambda.layout
+  val find_var_exn : t -> Ident.t -> Variable.t * Lambda.layout
 
   val add_mutable_var :
-    t -> Ident.t -> Mutable_variable.t -> Lambda.value_kind -> t
+    t -> Ident.t -> Mutable_variable.t -> Lambda.layout -> t
   val find_mutable_var_exn :
-    t -> Ident.t -> Mutable_variable.t * Lambda.value_kind
+    t -> Ident.t -> Mutable_variable.t * Lambda.layout
 
   val add_static_exception : t -> int -> Static_exception.t -> t
   val find_static_exception : t -> int -> Static_exception.t
@@ -60,7 +60,7 @@ module Function_decls : sig
       -> kind:Lambda.function_kind
       -> mode:Lambda.alloc_mode
       -> region:bool
-      -> params:(Ident.t * Lambda.value_kind) list
+      -> params:(Ident.t * Lambda.layout) list
       -> body:Lambda.lambda
       -> attr:Lambda.function_attribute
       -> loc:Lambda.scoped_location
@@ -71,7 +71,7 @@ module Function_decls : sig
     val kind : t -> Lambda.function_kind
     val mode : t -> Lambda.alloc_mode
     val region : t -> bool
-    val params : t -> (Ident.t * Lambda.value_kind) list
+    val params : t -> (Ident.t * Lambda.layout) list
     val body : t -> Lambda.lambda
     val inline : t -> Lambda.inline_attribute
     val specialise : t -> Lambda.specialise_attribute

--- a/middle_end/flambda/closure_offsets.ml
+++ b/middle_end/flambda/closure_offsets.ml
@@ -70,7 +70,7 @@ let add_closure_offsets
   in
   let gc_invisible_free_vars, gc_visible_free_vars =
     Variable.Map.partition (fun _ (free_var : Flambda.specialised_to) ->
-        Lambda.equal_value_kind free_var.kind Pintval)
+        match free_var.kind with Pvalue Pintval -> true | Pvalue _ -> false)
       free_vars
   in
   let free_variable_offsets, free_variable_pos =

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -59,7 +59,7 @@ type project_var = Projection.project_var
 type specialised_to = {
   var : Variable.t;
   projection : Projection.t option;
-  kind : Lambda.value_kind;
+  kind : Lambda.layout;
 }
 
 type t =
@@ -70,13 +70,13 @@ type t =
   | Apply of apply
   | Send of send
   | Assign of assign
-  | If_then_else of Variable.t * t * t * Lambda.value_kind
+  | If_then_else of Variable.t * t * t * Lambda.layout
   | Switch of Variable.t * switch
   | String_switch of Variable.t * (string * t) list * t option
-                     * Lambda.value_kind
+                     * Lambda.layout
   | Static_raise of Static_exception.t * Variable.t list
-  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.value_kind
-  | Try_with of t * Variable.t * t * Lambda.value_kind
+  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.layout
+  | Try_with of t * Variable.t * t * Lambda.layout
   | While of t * t
   | For of for_loop
   | Region of t
@@ -107,7 +107,7 @@ and let_expr = {
 and let_mutable = {
   var : Mutable_variable.t;
   initial_value : Variable.t;
-  contents_kind : Lambda.value_kind;
+  contents_kind : Lambda.layout;
   body : t;
 }
 
@@ -149,7 +149,7 @@ and switch = {
   numblocks : Numbers.Int.Set.t;
   blocks : (int * t) list;
   failaction : t option;
-  kind:  Lambda.value_kind;
+  kind:  Lambda.layout;
 }
 
 and for_loop = {
@@ -192,12 +192,12 @@ let print_specialised_to ppf (spec_to : specialised_to) =
   | None ->
     fprintf ppf "%a[%a]"
       Variable.print spec_to.var
-      Printlambda.value_kind spec_to.kind
+      Printlambda.layout spec_to.kind
   | Some projection ->
     fprintf ppf "%a(= %a)[%a]"
       Variable.print spec_to.var
       Projection.print projection
-      Printlambda.value_kind spec_to.kind
+      Printlambda.layout spec_to.kind
 
 (* CR-soon mshinwell: delete uses of old names *)
 let print_project_var = Projection.print_project_var
@@ -264,10 +264,10 @@ let rec lam ppf (flam : t) =
       let expr = letbody body in
       fprintf ppf ")@]@ %a)@]" lam expr
   | Let_mutable { var = mut_var; initial_value = var; body; contents_kind } ->
-    let print_kind ppf (kind : Lambda.value_kind) =
+    let print_kind ppf (kind : Lambda.layout) =
       match kind with
-      | Pgenval -> ()
-      | _ -> Format.fprintf ppf " %a" Printlambda.value_kind kind
+      | Pvalue Pgenval -> ()
+      | _ -> Format.fprintf ppf " %a" Printlambda.layout kind
     in
     fprintf ppf "@[<2>(let_mutable%a@ @[<2>%a@ %a@]@ %a)@]"
       print_kind contents_kind
@@ -1328,7 +1328,7 @@ let equal_specialised_to (spec_to1 : specialised_to)
       | Some _, None | None, Some _ -> false
       | Some proj1, Some proj2 -> Projection.equal proj1 proj2
     end
-    && Lambda.equal_value_kind spec_to1.kind spec_to2.kind
+    && Lambda.equal_layout spec_to1.kind spec_to2.kind
 
 let compare_project_var = Projection.compare_project_var
 let compare_project_closure = Projection.compare_project_closure

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -87,7 +87,7 @@ type specialised_to = {
       [specialised_args] respectively) in the same set of closures.
       As such, this field describes a relation of projections between
       either the [free_vars] or the [specialised_args]. *)
-  kind : Lambda.value_kind;
+  kind : Lambda.layout;
 }
 
 (** Flambda terms are partitioned in a pseudo-ANF manner; many terms are
@@ -105,14 +105,14 @@ type t =
   | Apply of apply
   | Send of send
   | Assign of assign
-  | If_then_else of Variable.t * t * t * Lambda.value_kind
+  | If_then_else of Variable.t * t * t * Lambda.layout
   | Switch of Variable.t * switch
   | String_switch of Variable.t * (string * t) list * t option
-                     * Lambda.value_kind
+                     * Lambda.layout
   (** Restrictions on [Lambda.Lstringswitch] also apply to [String_switch]. *)
   | Static_raise of Static_exception.t * Variable.t list
-  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.value_kind
-  | Try_with of t * Variable.t * t * Lambda.value_kind
+  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.layout
+  | Try_with of t * Variable.t * t * Lambda.layout
   | While of t * t
   | For of for_loop
   | Region of t
@@ -188,7 +188,7 @@ and let_expr = private {
 and let_mutable = {
   var : Mutable_variable.t;
   initial_value : Variable.t;
-  contents_kind : Lambda.value_kind;
+  contents_kind : Lambda.layout;
   body : t;
 }
 
@@ -352,7 +352,7 @@ and switch = {
   numblocks : Numbers.Int.Set.t; (** Number of tag block cases *)
   blocks : (int * t) list; (** Tag block cases *)
   failaction : t option; (** Action to take if none matched *)
-  kind : Lambda.value_kind
+  kind : Lambda.layout
 }
 
 (** Equivalent to the similar type in [Lambda]. *)

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -52,7 +52,7 @@ let ignore_tag (_ : Tag.t) = ()
 let ignore_inlined_attribute (_ : Lambda.inlined_attribute) = ()
 let ignore_specialise_attribute (_ : Lambda.specialise_attribute) = ()
 let ignore_probe (_ : Lambda.probe) = ()
-let ignore_value_kind (_ : Lambda.value_kind) = ()
+let ignore_layout (_ : Lambda.layout) = ()
 
 exception Binding_occurrence_not_from_current_compilation_unit of Variable.t
 exception Mutable_binding_occurrence_not_from_current_compilation_unit of
@@ -158,7 +158,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       loop (add_binding_occurrence env var) body
     | Let_mutable { var = mut_var; initial_value = var;
                     body; contents_kind } ->
-      ignore_value_kind contents_kind;
+      ignore_layout contents_kind;
       check_variable_is_bound env var;
       loop (add_mutable_binding_occurrence env mut_var) body
     | Let_rec (defs, body) ->
@@ -179,12 +179,12 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       loop (add_binding_occurrence env bound_var) body
     | Static_catch (static_exn, vars, body, handler, kind) ->
       ignore_static_exception static_exn;
-      ignore_value_kind kind;
+      ignore_layout kind;
       loop env body;
       loop (add_binding_occurrences env vars) handler
     | Try_with (body, var, handler, kind) ->
       loop env body;
-      ignore_value_kind kind;
+      ignore_layout kind;
       loop (add_binding_occurrence env var) handler
     (* Everything else: *)
     | Var var -> check_variable_is_bound env var
@@ -211,14 +211,14 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       ignore_debuginfo dbg
     | If_then_else (cond, ifso, ifnot, kind) ->
       check_variable_is_bound env cond;
-      ignore_value_kind kind;
+      ignore_layout kind;
       loop env ifso;
       loop env ifnot
     | Switch (arg, { numconsts; consts; numblocks; blocks; failaction; kind }) ->
       check_variable_is_bound env arg;
       ignore_int_set numconsts;
       ignore_int_set numblocks;
-      ignore_value_kind kind;
+      ignore_layout kind;
       List.iter (fun (n, e) ->
           ignore_int n;
           loop env e)
@@ -230,7 +230,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
           ignore_string label;
           loop env case)
         cases;
-      ignore_value_kind kind;
+      ignore_layout kind;
       Option.iter (loop env) e_opt
     | Static_raise (static_exn, es) ->
       ignore_static_exception static_exn;

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -240,9 +240,9 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
   match flam with
   | Var var -> subst_var env var
   | Let { var; defining_expr; body; _ } ->
-    (* TODO: synthesize proper value_kind *)
+    (* TODO: synthesize proper layout *)
     let id, env_body = Env.add_fresh_ident env var in
-    Ulet (Immutable, Pgenval, VP.create id,
+    Ulet (Immutable, Lambda.layout_top, VP.create id,
       to_clambda_named t env var defining_expr,
       to_clambda t env_body body)
   | Let_mutable { var = mut_var; initial_value = var; body; contents_kind } ->
@@ -326,7 +326,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
     let env_handler, ids =
       List.fold_right (fun var (env, ids) ->
           let id, env = Env.add_fresh_ident env var in
-          env, (VP.create id, Lambda.Pgenval) :: ids)
+          env, (VP.create id, Lambda.layout_top) :: ids)
         vars (env, [])
     in
     Ucatch (Static_exception.to_int static_exn, ids,
@@ -562,7 +562,7 @@ and to_clambda_set_of_closures t env
     let env_body, params =
       List.fold_right (fun var (env, params) ->
           let id, env = Env.add_fresh_ident env (Parameter.var var) in
-          env, id :: params)
+          env, (VP.create id, Parameter.kind var) :: params)
         function_decl.params (env, [])
     in
     let label =
@@ -572,11 +572,8 @@ and to_clambda_set_of_closures t env
     in
     { label;
       arity = clambda_arity function_decl;
-      params =
-        List.map
-          (fun var -> VP.create var, Lambda.Pgenval)
-          (params @ [env_var]);
-      return = Lambda.Pgenval;
+      params = params @ [VP.create env_var, Lambda.layout_function];
+      return = Lambda.layout_top;
       body = to_clambda t env_body function_decl.body;
       dbg = function_decl.dbg;
       env = Some env_var;
@@ -588,7 +585,9 @@ and to_clambda_set_of_closures t env
   let functions = List.map to_clambda_function all_functions in
   let not_scanned_fv, scanned_fv =
     Variable.Map.partition (fun _ (free_var : Flambda.specialised_to) ->
-        Lambda.equal_value_kind free_var.kind Pintval)
+        match free_var.kind with
+        | Pvalue Pintval -> true
+        | Pvalue _ -> false)
       free_vars
   in
   let to_closure_args free_vars =
@@ -624,7 +623,7 @@ and to_clambda_closed_set_of_closures t env symbol
     let env_body, params =
       List.fold_right (fun var (env, params) ->
           let id, env = Env.add_fresh_ident env (Parameter.var var) in
-          env, id :: params)
+          env, (VP.create id, Parameter.kind var) :: params)
         function_decl.params (env, [])
     in
     let body =
@@ -641,8 +640,8 @@ and to_clambda_closed_set_of_closures t env symbol
     in
     { label;
       arity = clambda_arity function_decl;
-      params = List.map (fun var -> VP.create var, Lambda.Pgenval) params;
-      return = Lambda.Pgenval;
+      params;
+      return = Lambda.layout_top;
       body;
       dbg = function_decl.dbg;
       env = None;

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -109,7 +109,7 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
     ->
     Mutable_variable.equal mv1 mv2
       && Variable.equal v1 v2
-      && Lambda.equal_value_kind ck1 ck2
+      && Lambda.equal_layout ck1 ck2
       && same b1 b2
   | Let_mutable _, _ | _, Let_mutable _ -> false
   | Let_rec (bl1, a1), Let_rec (bl2, a2) ->
@@ -123,7 +123,7 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
       && Misc.Stdlib.List.equal
         (fun (s1, e1) (s2, e2) -> String.equal s1 s2 && same e1 e2) s1 s2
       && Option.equal same d1 d2
-      && Lambda.equal_value_kind k1 k2
+      && Lambda.equal_layout k1 k2
   | String_switch _, _ | _, String_switch _ -> false
   | Static_raise (e1, a1), Static_raise (e2, a2) ->
     Static_exception.equal e1 e2 && Misc.Stdlib.List.equal Variable.equal a1 a2
@@ -133,15 +133,15 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
       && Misc.Stdlib.List.equal Variable.equal v1 v2
       && same a1 a2
       && same b1 b2
-      && Lambda.equal_value_kind k1 k2
+      && Lambda.equal_layout k1 k2
   | Static_catch _, _ | _, Static_catch _ -> false
   | Try_with (a1, v1, b1, k1), Try_with (a2, v2, b2, k2) ->
     same a1 a2 && Variable.equal v1 v2 && same b1 b2
-    && Lambda.equal_value_kind k1 k2
+    && Lambda.equal_layout k1 k2
   | Try_with _, _ | _, Try_with _ -> false
   | If_then_else (a1, b1, c1, k1), If_then_else (a2, b2, c2, k2) ->
     Variable.equal a1 a2 && same b1 b2 && same c1 c2
-    && Lambda.equal_value_kind k1 k2
+    && Lambda.equal_layout k1 k2
   | If_then_else _, _ | _, If_then_else _ -> false
   | While (a1, b1), While (a2, b2) ->
     same a1 a2 && same b1 b2
@@ -243,7 +243,7 @@ and sameswitch (fs1 : Flambda.switch) (fs2 : Flambda.switch) =
     && Misc.Stdlib.List.equal samecase fs1.consts fs2.consts
     && Misc.Stdlib.List.equal samecase fs1.blocks fs2.blocks
     && Option.equal same fs1.failaction fs2.failaction
-    && Lambda.equal_value_kind fs1.kind fs2.kind
+    && Lambda.equal_layout fs1.kind fs2.kind
 
 let can_be_merged = same
 

--- a/middle_end/flambda/flambda_utils.mli
+++ b/middle_end/flambda/flambda_utils.mli
@@ -69,7 +69,7 @@ val make_closure_declaration
   -> region:bool
   -> body:Flambda.t
   -> params:Parameter.t list
-  -> free_variables:Lambda.value_kind Variable.Map.t
+  -> free_variables:Lambda.layout Variable.Map.t
   -> Flambda.t
 
 val toplevel_substitution

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -864,7 +864,7 @@ and simplify_partial_application env r ~lhs_of_application
         (List.map (fun p -> Parameter.var p, Parameter.kind p) freshened_params)
     in
     let free_variables =
-      Variable.Map.add lhs_of_application Lambda.Pgenval free_variables
+      Variable.Map.add lhs_of_application Lambda.layout_function free_variables
     in
     Flambda_utils.make_closure_declaration ~id:closure_variable
       ~is_classic_mode:false

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -344,7 +344,7 @@ let add_fun_var ~lhs_of_application ~closure_id_being_applied ~state ~fun_var =
     in
     let let_bindings = (outside_var, expr) :: state.let_bindings in
     let spec : Flambda.specialised_to =
-      { var = outside_var; projection = None; kind = Pgenval }
+      { var = outside_var; projection = None; kind = Lambda.layout_top }
     in
     let new_free_vars_with_old_projections =
       Variable.Map.add inside_var spec state.new_free_vars_with_old_projections

--- a/middle_end/flambda/lift_code.ml
+++ b/middle_end/flambda/lift_code.ml
@@ -21,7 +21,7 @@ type lifter = Flambda.program -> Flambda.program
 
 type def =
   | Immutable of Variable.t * Flambda.named Flambda.With_free_variables.t
-  | Mutable of Mutable_variable.t * Variable.t * Lambda.value_kind
+  | Mutable of Mutable_variable.t * Variable.t * Lambda.layout
 
 let rebuild_let (defs : def list) (body : Flambda.t) =
   let module W = Flambda.With_free_variables in

--- a/middle_end/flambda/parameter.ml
+++ b/middle_end/flambda/parameter.ml
@@ -24,7 +24,7 @@ open! Int_replace_polymorphic_compare
 type parameter = {
   var : Variable.t;
   mode : Lambda.alloc_mode;
-  kind : Lambda.value_kind;
+  kind : Lambda.layout;
 }
 
 let wrap var mode kind = { var; mode; kind }
@@ -55,7 +55,7 @@ module M =
         | Lambda.Alloc_heap -> ""
         | Lambda.Alloc_local -> "[->L]" in
       Format.fprintf ppf "%a%s[%a]"
-        Variable.print var mode Printlambda.value_kind kind
+        Variable.print var mode Printlambda.layout kind
 
     let output o { var; mode = _ ; kind = _ } =
       Variable.output o var

--- a/middle_end/flambda/parameter.mli
+++ b/middle_end/flambda/parameter.mli
@@ -23,7 +23,7 @@ type t
 type parameter = t
 
 (** Make a parameter from a variable with default attributes *)
-val wrap : Variable.t -> Lambda.alloc_mode -> Lambda.value_kind -> t
+val wrap : Variable.t -> Lambda.alloc_mode -> Lambda.layout -> t
 
 val var : t -> Variable.t
 
@@ -31,7 +31,7 @@ val var : t -> Variable.t
     up to and including this parameter *)
 val alloc_mode : t -> Lambda.alloc_mode
 
-val kind : t -> Lambda.value_kind
+val kind : t -> Lambda.layout
 
 (** Rename the inner variable of the parameter *)
 val rename

--- a/middle_end/flambda/ref_to_variables.ml
+++ b/middle_end/flambda/ref_to_variables.ml
@@ -147,7 +147,7 @@ let eliminate_ref_of_expr flam =
                 (Let_mutable { var = field_var;
                                initial_value = init;
                                body;
-                               contents_kind = kind } : Flambda.t))
+                               contents_kind = Lambda.Pvalue kind } : Flambda.t))
             (0,body) l shape in
         expr
       | Let _ | Let_mutable _

--- a/middle_end/flambda/simple_value_approx.ml
+++ b/middle_end/flambda/simple_value_approx.ml
@@ -244,7 +244,8 @@ let augment_with_symbol_field t symbol field =
   | Some _ -> t
 let replace_description t descr = { t with descr }
 
-let augment_with_kind t (kind:Lambda.value_kind) =
+let augment_with_kind t (layout:Lambda.layout) =
+  let Pvalue kind = layout in
   match kind with
   | Pgenval -> t
   | Pfloatval ->
@@ -270,13 +271,13 @@ let augment_with_kind t (kind:Lambda.value_kind) =
     end
   | _ -> t
 
-let augment_kind_with_approx t (kind:Lambda.value_kind) : Lambda.value_kind =
+let augment_kind_with_approx t (kind:Lambda.layout) : Lambda.layout =
   match t.descr with
-  | Value_float _ -> Pfloatval
-  | Value_int _ -> Pintval
-  | Value_boxed_int (Int32, _) -> Pboxedintval Pint32
-  | Value_boxed_int (Int64, _) -> Pboxedintval Pint64
-  | Value_boxed_int (Nativeint, _) -> Pboxedintval Pnativeint
+  | Value_float _ -> Pvalue Pfloatval
+  | Value_int _ -> Pvalue Pintval
+  | Value_boxed_int (Int32, _) -> Pvalue (Pboxedintval Pint32)
+  | Value_boxed_int (Int64, _) -> Pvalue (Pboxedintval Pint64)
+  | Value_boxed_int (Nativeint, _) -> Pvalue (Pboxedintval Pnativeint)
   | _ -> kind
 
 let value_unknown reason = approx (Value_unknown reason)
@@ -369,7 +370,7 @@ let value_mutable_float_array ~size =
 let value_immutable_float_array (contents:t array) =
   let size = Array.length contents in
   let contents =
-    Array.map (fun t -> augment_with_kind t Pfloatval) contents
+    Array.map (fun t -> augment_with_kind t Lambda.layout_float) contents
   in
   approx (Value_float_array { contents = Contents contents; size; } )
 

--- a/middle_end/flambda/simple_value_approx.mli
+++ b/middle_end/flambda/simple_value_approx.mli
@@ -307,10 +307,10 @@ val augment_with_symbol_field : t -> Symbol.t -> int -> t
 val replace_description : t -> descr -> t
 
 (** Improve the description by taking the kind into account *)
-val augment_with_kind : t -> Lambda.value_kind -> t
+val augment_with_kind : t -> Lambda.layout -> t
 
 (** Improve the kind by taking the description into account *)
-val augment_kind_with_approx : t -> Lambda.value_kind -> Lambda.value_kind
+val augment_kind_with_approx : t -> Lambda.layout -> Lambda.layout
 
 val equal_boxed_int : 'a boxed_int -> 'a -> 'b boxed_int -> 'b -> bool
 

--- a/middle_end/flambda/simplify_primitives.ml
+++ b/middle_end/flambda/simplify_primitives.ml
@@ -111,11 +111,12 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
   | Pmakeblock(tag_int, (Immutable | Immutable_unique), shape, mode) ->
     let tag = Tag.create_exn tag_int in
     let shape = match shape with
-      | None -> List.map (fun _ -> Lambda.Pgenval) args
-      | Some shape -> shape
+      | None -> List.map (fun _ -> Lambda.layout_top) args
+      | Some shape -> List.map (fun kind -> Lambda.Pvalue kind) shape
     in
     let approxs = List.map2 A.augment_with_kind approxs shape in
     let shape = List.map2 A.augment_kind_with_approx approxs shape in
+    let shape = List.map (fun (Lambda.Pvalue kind) -> kind) shape in
     Prim (Pmakeblock(tag_int, Lambda.Immutable, Some shape, mode), args, dbg),
     A.value_block tag (Array.of_list approxs), C.Benefit.zero
   | Praise _ ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1770,7 +1770,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
     List.mapi
       (fun n _kind_with_subkind ->
         ( Ident.create_local ("param" ^ string_of_int (args_arity + n)),
-          Lambda.Pgenval ))
+          Lambda.layout_top ))
       (Flambda_arity.With_subkinds.to_list missing_args)
   in
   let return_continuation = Continuation.create ~sort:Return () in
@@ -1834,7 +1834,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
     (* CR keryan: Same as above, better kind for return type *)
     [ Function_decl.create ~let_rec_ident:(Some wrapper_id) ~function_slot
         ~kind:(Lambda.Curried { nlocal = num_trailing_local_params })
-        ~params ~return:Lambda.Pgenval ~return_continuation ~exn_continuation
+        ~params ~return:Lambda.layout_top ~return_continuation ~exn_continuation
         ~my_region:apply.region ~body:fbody ~attr ~loc:apply.loc
         ~free_idents_of_body ~closure_alloc_mode ~num_trailing_local_params
         ~contains_no_escaping_local_allocs Recursive.Non_recursive ]

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -45,7 +45,7 @@ val close_let_cont :
   Env.t ->
   name:Continuation.t ->
   is_exn_handler:bool ->
-  params:(Ident.t * IR.user_visible * Lambda.value_kind) list ->
+  params:(Ident.t * IR.user_visible * Lambda.layout) list ->
   recursive:Asttypes.rec_flag ->
   handler:(Acc.t -> Env.t -> Expr_with_acc.t) ->
   body:(Acc.t -> Env.t -> Expr_with_acc.t) ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -21,7 +21,7 @@ module IR = struct
 
   type exn_continuation =
     { exn_handler : Continuation.t;
-      extra_args : (simple * Lambda.value_kind) list
+      extra_args : (simple * Lambda.layout) list
     }
 
   type trap_action =
@@ -614,8 +614,8 @@ module Function_decls = struct
       { let_rec_ident : Ident.t;
         function_slot : Function_slot.t;
         kind : Lambda.function_kind;
-        params : (Ident.t * Lambda.value_kind) list;
-        return : Lambda.value_kind;
+        params : (Ident.t * Lambda.layout) list;
+        return : Lambda.layout;
         return_continuation : Continuation.t;
         exn_continuation : IR.exn_continuation;
         my_region : Ident.t;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -23,7 +23,7 @@ module IR : sig
 
   type exn_continuation =
     { exn_handler : Continuation.t;
-      extra_args : (simple * Lambda.value_kind) list
+      extra_args : (simple * Lambda.layout) list
     }
 
   type trap_action =
@@ -290,8 +290,8 @@ module Function_decls : sig
       let_rec_ident:Ident.t option ->
       function_slot:Function_slot.t ->
       kind:Lambda.function_kind ->
-      params:(Ident.t * Lambda.value_kind) list ->
-      return:Lambda.value_kind ->
+      params:(Ident.t * Lambda.layout) list ->
+      return:Lambda.layout ->
       return_continuation:Continuation.t ->
       exn_continuation:IR.exn_continuation ->
       my_region:Ident.t ->
@@ -311,9 +311,9 @@ module Function_decls : sig
 
     val kind : t -> Lambda.function_kind
 
-    val params : t -> (Ident.t * Lambda.value_kind) list
+    val params : t -> (Ident.t * Lambda.layout) list
 
-    val return : t -> Lambda.value_kind
+    val return : t -> Lambda.layout
 
     val return_continuation : t -> Continuation.t
 

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -156,7 +156,7 @@ type letrec =
 
 type let_def =
   { let_kind : Lambda.let_kind;
-    value_kind : Lambda.value_kind;
+    layout : Lambda.layout;
     ident : Ident.t
   }
 
@@ -212,7 +212,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
       let pre ~tail : Lambda.lambda =
         Llet
           ( current_let.let_kind,
-            current_let.value_kind,
+            current_let.layout,
             current_let.ident,
             lam,
             letrec.pre ~tail )
@@ -241,7 +241,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
     let lam =
       List.fold_left
         (fun body (id, def) : Lambda.lambda ->
-          Llet (Strict, Pgenval, id, def, body))
+          Llet (Strict, Lambda.layout_top, id, def, body))
         (Lambda.Lprim (prim, args, dbg))
         defs
     in
@@ -302,8 +302,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
       assert (not (Ident.Set.mem id free_vars_body));
       (* It is not used, we only keep the effect *)
       { letrec with effects = Lsequence (def, letrec.effects) }
-  | Llet (((Strict | Alias | StrictOpt) as let_kind), value_kind, id, def, body)
-    ->
+  | Llet (((Strict | Alias | StrictOpt) as let_kind), layout, id, def, body) ->
     let letbound = Ident.Set.add id letrec.letbound in
     let letrec = { letrec with letbound } in
     let free_vars = Lambda.free_variables def in
@@ -312,13 +311,13 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
       (* Non recursive let *)
       let letrec = prepare_letrec recursive_set current_let body letrec in
       let pre ~tail : Lambda.lambda =
-        Llet (let_kind, value_kind, id, def, letrec.pre ~tail)
+        Llet (let_kind, layout, id, def, letrec.pre ~tail)
       in
       { letrec with pre }
     else
       let recursive_set = Ident.Set.add id recursive_set in
       let letrec = prepare_letrec recursive_set current_let body letrec in
-      let let_def = { let_kind; value_kind; ident = id } in
+      let let_def = { let_kind; layout; ident = id } in
       prepare_letrec recursive_set (Some let_def) def letrec
   | Lsequence (lam1, lam2) ->
     let letrec = prepare_letrec recursive_set current_let lam2 letrec in
@@ -387,7 +386,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
         List.fold_right
           (fun (id, def) (letrec, inner_effects, inner_functions) ->
             let let_def =
-              { let_kind = Strict; value_kind = Pgenval; ident = id }
+              { let_kind = Strict; layout = Lambda.layout_top; ident = id }
             in
             if Ident.Set.mem id outer_vars
             then
@@ -513,7 +512,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
       match current_let with
       | Some cl ->
         fun ~tail : Lambda.lambda ->
-          Llet (cl.let_kind, cl.value_kind, cl.ident, lam, letrec.pre ~tail)
+          Llet (cl.let_kind, cl.layout, cl.ident, lam, letrec.pre ~tail)
       | None -> fun ~tail : Lambda.lambda -> Lsequence (lam, letrec.pre ~tail)
     in
     { letrec with pre }
@@ -527,7 +526,9 @@ let dissect_letrec ~bindings ~body =
   let letrec =
     List.fold_right
       (fun (id, def) letrec ->
-        let let_def = { let_kind = Strict; value_kind = Pgenval; ident = id } in
+        let let_def =
+          { let_kind = Strict; layout = Lambda.layout_top; ident = id }
+        in
         prepare_letrec letbound (Some let_def) def letrec)
       bindings
       { blocks = [];
@@ -579,12 +580,19 @@ let dissect_letrec ~bindings ~body =
   let with_non_rec = letrec.pre ~tail:functions in
   let with_preallocations =
     List.fold_left
-      (fun body (id, binding) -> Llet (Strict, Pgenval, id, binding, body))
+      (fun body (id, binding) ->
+        Llet (Strict, Lambda.layout_top, id, binding, body))
       with_non_rec preallocations
   in
   let with_constants =
     List.fold_left
-      (fun body (id, const) -> Llet (Strict, Pgenval, id, Lconst const, body))
+      (fun body (id, const) ->
+        Llet
+          ( Strict,
+            Lambda.structured_constant_layout const,
+            id,
+            Lconst const,
+            body ))
       with_preallocations letrec.consts
   in
   let substituted = Lambda.rename letrec.substitution with_constants in
@@ -593,9 +601,11 @@ let dissect_letrec ~bindings ~body =
   else
     Lstaticcatch
       ( Lregion (Lambda.rename bound_ids_freshening substituted),
-        (cont, List.map (fun (bound_id, _) -> bound_id, Pgenval) bindings),
+        ( cont,
+          List.map (fun (bound_id, _) -> bound_id, Lambda.layout_top) bindings
+        ),
         real_body,
-        Pgenval )
+        Lambda.layout_top )
 
 type dissected =
   | Dissected of Lambda.lambda

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -110,7 +110,7 @@ let convert_block_shape (shape : L.block_shape) ~num_fields =
         "Flambda_arity.of_block_shape: num_fields is %d yet the shape has %d \
          fields"
         num_fields shape_length;
-    List.map K.With_subkind.from_lambda shape
+    List.map K.With_subkind.from_lambda_value_kind shape
 
 let check_float_array_optimisation_enabled () =
   if not (Flambda_features.flat_float_array ())

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -476,7 +476,7 @@ module With_subkind = struct
     | Naked_int64 -> naked_int64
     | Naked_nativeint -> naked_nativeint
 
-  let rec from_lambda (vk : Lambda.value_kind) =
+  let rec from_lambda_value_kind (vk : Lambda.value_kind) =
     match vk with
     | Pgenval -> any_value
     | Pfloatval -> boxed_float
@@ -502,7 +502,9 @@ module With_subkind = struct
               match Tag.Scannable.create tag with
               | Some tag ->
                 Tag.Scannable.Map.add tag
-                  (List.map (fun vk -> subkind (from_lambda vk)) fields)
+                  (List.map
+                     (fun vk -> subkind (from_lambda_value_kind vk))
+                     fields)
                   non_consts
               | None ->
                 Misc.fatal_errorf "Non-scannable tag %d in [Pvariant]" tag)
@@ -513,6 +515,8 @@ module With_subkind = struct
     | Parrayval Pintarray -> immediate_array
     | Parrayval Paddrarray -> value_array
     | Parrayval Pgenarray -> generic_array
+
+  let from_lambda (Pvalue vk : Lambda.layout) = from_lambda_value_kind vk
 
   include Container_types.Make (struct
     type nonrec t = t

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -196,7 +196,9 @@ module With_subkind : sig
 
   val of_naked_number_kind : Naked_number_kind.t -> t
 
-  val from_lambda : Lambda.value_kind -> t
+  val from_lambda_value_kind : Lambda.value_kind -> t
+
+  val from_lambda : Lambda.layout -> t
 
   val compatible : t -> when_used_at:t -> bool
 

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -51,6 +51,7 @@ let rec value_kind0 ppf kind =
       non_consts
 
 let value_kind kind = Format.asprintf "%a" value_kind0 kind
+let layout (Lambda.Pvalue kind) = value_kind kind
 
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x
@@ -81,11 +82,11 @@ and one_fun ppf f =
       (fun (x, k) ->
          fprintf ppf "@ %a%a"
            VP.print x
-           Printlambda.value_kind k
+           Printlambda.layout k
       )
   in
   fprintf ppf "(fun@ %s%s%a@ %d@ @[<2>%a@]@ @[<2>%a@])"
-    f.label (value_kind f.return) Printlambda.check_attribute f.check
+    f.label (layout f.return) Printlambda.check_attribute f.check
     (snd f.arity) idents f.params lam f.body
 
 and phantom_defining_expr ppf = function
@@ -150,12 +151,12 @@ and lam ppf = function
         | Ulet(mut, kind, id, arg, body) ->
             fprintf ppf "@ @[<2>%a%s%s@ %a@]"
               VP.print id
-              (mutable_flag mut) (value_kind kind) lam arg;
+              (mutable_flag mut) (layout kind) lam arg;
             letbody body
         | _ -> ul in
       fprintf ppf "@[<2>(let@ @[<hv 1>(@[<2>%a%s%s@ %a@]"
         VP.print id (mutable_flag mut)
-          (value_kind kind) lam arg;
+          (layout kind) lam arg;
       let expr = letbody body in
       fprintf ppf ")@]@ %a)@]" lam expr
   | Uphantom_let (id, defining_expr, body) ->
@@ -234,7 +235,7 @@ and lam ppf = function
              (fun (x, k) ->
                 fprintf ppf " %a%a"
                  VP.print x
-                 Printlambda.value_kind k
+                 Printlambda.layout k
              )
              vars
         )

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -122,7 +122,7 @@ let close_phrase lam =
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in
-    Llet(Strict, Pgenval, id, glob, l)
+    Llet(Strict, Lambda.layout_top, id, glob, l)
   ) (free_variables lam) lam
 
 let toplevel_value id =

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -1573,7 +1573,8 @@ struct
   type arg = expression
   type test = expression
   type act = expression
-  type nonrec value_kind = value_kind
+
+  type layout = value_kind
 
   (* CR mshinwell: GPR#2294 will fix the Debuginfo here *)
 
@@ -2997,3 +2998,6 @@ let emit_preallocated_blocks preallocated_blocks cont =
   in
   let c1 = emit_gc_roots_table ~symbols cont in
   List.fold_left preallocate_block c1 preallocated_blocks
+
+let kind_of_layout (Lambda.Pvalue kind) = Vval kind
+

--- a/ocaml/asmcomp/cmm_helpers.mli
+++ b/ocaml/asmcomp/cmm_helpers.mli
@@ -658,3 +658,5 @@ val emit_preallocated_blocks :
   Clambda.preallocated_block list -> phrase list -> phrase list
 
 val make_symbol : ?compilation_unit:Compilation_unit.t -> string -> string
+
+val kind_of_layout : Lambda.layout -> value_kind

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -227,6 +227,9 @@ and value_kind =
     }
   | Parrayval of array_kind
 
+and layout =
+  | Pvalue of value_kind
+
 and block_shape =
   value_kind list option
 
@@ -286,6 +289,12 @@ let rec equal_value_kind x y =
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval | Pvariant _
       | Parrayval _), _ -> false
 
+let equal_layout (Pvalue x) (Pvalue y) = equal_value_kind x y
+
+let must_be_value layout =
+  match layout with
+  | Pvalue v -> v
+  (* | _ -> Misc.fatal_error "Layout is not a value" *)
 
 type structured_constant =
     Const_base of constant
@@ -416,17 +425,17 @@ type lambda =
   | Lconst of structured_constant
   | Lapply of lambda_apply
   | Lfunction of lfunction
-  | Llet of let_kind * value_kind * Ident.t * lambda * lambda
-  | Lmutlet of value_kind * Ident.t * lambda * lambda
+  | Llet of let_kind * layout * Ident.t * lambda * lambda
+  | Lmutlet of layout * Ident.t * lambda * lambda
   | Lletrec of (Ident.t * lambda) list * lambda
   | Lprim of primitive * lambda list * scoped_location
-  | Lswitch of lambda * lambda_switch * scoped_location * value_kind
+  | Lswitch of lambda * lambda_switch * scoped_location * layout
   | Lstringswitch of
-      lambda * (string * lambda) list * lambda option * scoped_location * value_kind
+      lambda * (string * lambda) list * lambda option * scoped_location * layout
   | Lstaticraise of int * lambda list
-  | Lstaticcatch of lambda * (int * (Ident.t * value_kind) list) * lambda * value_kind
-  | Ltrywith of lambda * Ident.t * lambda * value_kind
-  | Lifthenelse of lambda * lambda * lambda * value_kind
+  | Lstaticcatch of lambda * (int * (Ident.t * layout) list) * lambda * layout
+  | Ltrywith of lambda * Ident.t * lambda * layout
+  | Lifthenelse of lambda * lambda * lambda * layout
   | Lsequence of lambda * lambda
   | Lwhile of lambda_while
   | Lfor of lambda_for
@@ -440,8 +449,8 @@ type lambda =
 
 and lfunction =
   { kind: function_kind;
-    params: (Ident.t * value_kind) list;
-    return: value_kind;
+    params: (Ident.t * layout) list;
+    return: layout;
     body: lambda;
     attr: function_attribute; (* specified with [@inline] attribute *)
     loc: scoped_location;
@@ -537,6 +546,27 @@ let lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region =
   Lfunction { kind; params; return; body; attr; loc; mode; region }
 
 let lambda_unit = Lconst const_unit
+
+let layout_unit = Pvalue Pintval
+let layout_int = Pvalue Pintval
+let layout_array kind = Pvalue (Parrayval kind)
+let layout_block = Pvalue Pgenval
+let layout_list =
+  Pvalue (Pvariant { consts = [0] ; non_consts = [0, [Pgenval; Pgenval]] })
+let layout_field = Pvalue Pgenval
+let layout_function = Pvalue Pgenval
+let layout_object = Pvalue Pgenval
+let layout_class = Pvalue Pgenval
+let layout_module = Pvalue Pgenval
+let layout_module_field = Pvalue Pgenval
+let layout_functor = Pvalue Pgenval
+let layout_float = Pvalue Pfloatval
+let layout_string = Pvalue Pgenval
+let layout_boxedint bi = Pvalue (Pboxedintval bi)
+let layout_lazy = Pvalue Pgenval
+let layout_lazy_contents = Pvalue Pgenval
+
+let layout_top = Pvalue Pgenval
 
 let default_function_attribute = {
   inline = Default_inline;
@@ -649,21 +679,21 @@ let make_key e =
 
 (***************)
 
-let name_lambda strict arg fn =
+let name_lambda strict arg layout fn =
   match arg with
     Lvar id -> fn id
   | _ ->
       let id = Ident.create_local "let" in
-      Llet(strict, Pgenval, id, arg, fn id)
+      Llet(strict, layout, id, arg, fn id)
 
 let name_lambda_list args fn =
   let rec name_list names = function
     [] -> fn (List.rev names)
-  | (Lvar _ as arg) :: rem ->
+  | (Lvar _ as arg, _) :: rem ->
       name_list (arg :: names) rem
-  | arg :: rem ->
+  | (arg, layout) :: rem ->
       let id = Ident.create_local "let" in
-      Llet(Strict, Pgenval, id, arg, name_list (Lvar id :: names) rem) in
+      Llet(Strict, layout, id, arg, name_list (Lvar id :: names) rem) in
   name_list [] args
 
 
@@ -1056,10 +1086,10 @@ let shallow_map ~tail ~non_tail:f = function
   | Lfunction { kind; params; return; body; attr; loc; mode; region } ->
       Lfunction { kind; params; return; body = f body; attr; loc;
                   mode; region }
-  | Llet (str, k, v, e1, e2) ->
-      Llet (str, k, v, f e1, tail e2)
-  | Lmutlet (k, v, e1, e2) ->
-      Lmutlet (k, v, f e1, tail e2)
+  | Llet (str, layout, v, e1, e2) ->
+      Llet (str, layout, v, f e1, tail e2)
+  | Lmutlet (layout, v, e1, e2) ->
+      Lmutlet (layout, v, f e1, tail e2)
   | Lletrec (idel, e2) ->
       Lletrec (List.map (fun (v, e) -> (v, f e)) idel, tail e2)
   | Lprim (Psequand as p, [l1; l2], loc)
@@ -1067,7 +1097,7 @@ let shallow_map ~tail ~non_tail:f = function
       Lprim(p, [f l1; tail l2], loc)
   | Lprim (p, el, loc) ->
       Lprim (p, List.map f el, loc)
-  | Lswitch (e, sw, loc,kind) ->
+  | Lswitch (e, sw, loc, layout) ->
       Lswitch (f e,
                { sw_numconsts = sw.sw_numconsts;
                  sw_consts = List.map (fun (n, e) -> (n, tail e)) sw.sw_consts;
@@ -1075,21 +1105,21 @@ let shallow_map ~tail ~non_tail:f = function
                  sw_blocks = List.map (fun (n, e) -> (n, tail e)) sw.sw_blocks;
                  sw_failaction = Option.map tail sw.sw_failaction;
                },
-               loc,kind)
-  | Lstringswitch (e, sw, default, loc,kind) ->
+               loc, layout)
+  | Lstringswitch (e, sw, default, loc, layout) ->
       Lstringswitch (
         f e,
         List.map (fun (s, e) -> (s, tail e)) sw,
         Option.map tail default,
-        loc, kind)
+        loc, layout)
   | Lstaticraise (i, args) ->
       Lstaticraise (i, List.map f args)
-  | Lstaticcatch (body, id, handler, kind) ->
-      Lstaticcatch (tail body, id, tail handler, kind)
-  | Ltrywith (e1, v, e2, kind) ->
-      Ltrywith (f e1, v, tail e2, kind)
-  | Lifthenelse (e1, e2, e3, kind) ->
-      Lifthenelse (f e1, tail e2, tail e3, kind)
+  | Lstaticcatch (body, id, handler, layout) ->
+      Lstaticcatch (tail body, id, tail handler, layout)
+  | Ltrywith (e1, v, e2, layout) ->
+      Ltrywith (f e1, v, tail e2, layout)
+  | Lifthenelse (e1, e2, e3, layout) ->
+      Lifthenelse (f e1, tail e2, tail e3, layout)
   | Lsequence (e1, e2) ->
       Lsequence (f e1, tail e2)
   | Lwhile lw ->
@@ -1116,13 +1146,10 @@ let map f =
 
 (* To let-bind expressions to variables *)
 
-let bind_with_value_kind str (var, kind) exp body =
+let bind_with_layout str (var, layout) exp body =
   match exp with
     Lvar var' when Ident.same var var' -> body
-  | _ -> Llet(str, kind, var, exp, body)
-
-let bind str var exp body =
-  bind_with_value_kind str (var, Pgenval) exp body
+  | _ -> Llet(str, layout, var, exp, body)
 
 let negate_integer_comparison = function
   | Ceq -> Cne
@@ -1289,3 +1316,16 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pprobe_is_enabled _ -> None
   | Pobj_dup -> Some alloc_heap
   | Pobj_magic -> None
+
+let constant_layout = function
+  | Const_int _ | Const_char _ -> Pvalue Pintval
+  | Const_string _ -> Pvalue Pgenval
+  | Const_int32 _ -> Pvalue (Pboxedintval Pint32)
+  | Const_int64 _ -> Pvalue (Pboxedintval Pint64)
+  | Const_nativeint _ -> Pvalue (Pboxedintval Pnativeint)
+  | Const_float _ -> Pvalue Pfloatval
+
+let structured_constant_layout = function
+  | Const_base const -> constant_layout const
+  | Const_block _ | Const_immstring _ -> Pvalue Pgenval
+  | Const_float_array _ | Const_float_block _ -> Pvalue (Parrayval Pfloatarray)

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -151,8 +151,8 @@ let expand_record_head h =
   | _ -> h
 
 let bind_alias p id ~arg ~action =
-  let k = Typeopt.value_kind p.pat_env p.pat_type in
-  bind_with_value_kind Alias (id, k) arg action
+  let k = Typeopt.layout p.pat_env p.pat_type in
+  bind_with_layout Alias (id, k) arg action
 
 let head_loc ~scopes head =
   Scoped_location.of_location ~scopes head.pat_loc
@@ -938,7 +938,7 @@ type 'row pattern_matching = {
 type handler = {
   provenance : matrix;
   exit : int;
-  vars : (Ident.t * Lambda.value_kind) list;
+  vars : (Ident.t * Lambda.layout) list;
   pm : initial_clause pattern_matching
 }
 
@@ -1576,7 +1576,7 @@ and precompile_or ~arg (cls : Simple.clause list) ors args def k =
               Typedtree.pat_bound_idents_full orp
               |> List.filter (fun (id, _, _) -> Ident.Set.mem id pm_fv)
               |> List.map (fun (id, _, ty) ->
-                     (id, Typeopt.value_kind orp.pat_env ty))
+                     (id, Typeopt.layout orp.pat_env ty))
             in
             let or_num = next_raise_count () in
             let new_patl = Patterns.omega_list patl in
@@ -1903,12 +1903,12 @@ let inline_lazy_force_cond arg pos loc =
   let force_fun = Lazy.force code_force_lazy_block in
   Llet
     ( Strict,
-      Pgenval,
+      Lambda.layout_lazy,
       idarg,
       arg,
       Llet
         ( Alias,
-          Pgenval,
+          Lambda.layout_int,
           tag,
           Lprim (Pccall prim_obj_tag, [ varg ], loc),
           Lifthenelse
@@ -1936,7 +1936,7 @@ let inline_lazy_force_cond arg pos loc =
                       ap_probe=None
                     },
                   (* ... arg *)
-                  varg, Pgenval), Pgenval) ) )
+                  varg, Lambda.layout_lazy_contents), Lambda.layout_lazy_contents) ) )
 
 let inline_lazy_force_switch arg pos loc =
   let idarg = Ident.create_local "lzarg" in
@@ -1944,7 +1944,7 @@ let inline_lazy_force_switch arg pos loc =
   let force_fun = Lazy.force code_force_lazy_block in
   Llet
     ( Strict,
-      Pgenval,
+      Lambda.layout_lazy,
       idarg,
       arg,
       Lifthenelse
@@ -1974,7 +1974,7 @@ let inline_lazy_force_switch arg pos loc =
                   ];
                 sw_failaction = Some varg
               },
-              loc, Pgenval), Pgenval) )
+              loc, Lambda.layout_lazy_contents), Lambda.layout_lazy_contents) )
 
 let inline_lazy_force arg pos loc =
   if !Clflags.afl_instrument then
@@ -2166,12 +2166,12 @@ let prim_string_notequal =
 let prim_string_compare =
   Pccall (Primitive.simple ~name:"caml_string_compare" ~arity:2 ~alloc:false)
 
-let bind_sw arg k =
+let bind_sw arg layout k =
   match arg with
   | Lvar _ -> k arg
   | _ ->
       let id = Ident.create_local "switch" in
-      Llet (Strict, Pgenval, id, arg, k (Lvar id))
+      Llet (Strict, layout, id, arg, k (Lvar id))
 
 (* Sequential equality tests *)
 
@@ -2185,7 +2185,7 @@ let make_string_test_sequence loc kind arg sw d =
       )
     | Some d -> (d, sw)
   in
-  bind_sw arg (fun arg ->
+  bind_sw arg Lambda.layout_string (fun arg ->
       List.fold_right
         (fun (str, lam) k ->
           Lifthenelse
@@ -2230,6 +2230,7 @@ let rec do_make_string_test_tree loc kind arg sw delta d =
     let lt, (s, act), gt = split len sw in
     bind_sw
       (Lprim (prim_string_compare, [ arg; Lconst (Const_immstring s) ], loc))
+      Lambda.layout_int
       (fun r ->
         tree_way_test loc kind r
           (do_make_string_test_tree loc kind arg lt delta d)
@@ -2239,9 +2240,9 @@ let rec do_make_string_test_tree loc kind arg sw delta d =
 (* Entry point *)
 let expand_stringswitch loc kind arg sw d =
   match d with
-  | None -> bind_sw arg (fun arg -> do_make_string_test_tree loc kind arg sw 0 None)
+  | None -> bind_sw arg Lambda.layout_string (fun arg -> do_make_string_test_tree loc kind arg sw 0 None)
   | Some e ->
-      bind_sw arg (fun arg ->
+      bind_sw arg Lambda.layout_string (fun arg ->
           make_catch kind e (fun d ->
               do_make_string_test_tree loc kind arg sw 1 (Some d)))
 
@@ -2367,7 +2368,7 @@ module SArg = struct
   type test = Lambda.lambda
   type act = Lambda.lambda
 
-  type value_kind = Lambda.value_kind
+  type layout = Lambda.layout
 
   let make_prim p args = Lprim (p, args, Loc_unknown)
 
@@ -2384,7 +2385,8 @@ module SArg = struct
           let newvar = Ident.create_local "switcher" in
           (newvar, Lvar newvar)
     in
-    bind Alias newvar arg (body newarg)
+    (* [switch.ml] will only call bind with an integer argument *)
+    bind_with_layout Alias (newvar, Lambda.layout_int) arg (body newarg)
 
   let make_const i = Lconst (Const_base (Const_int i))
 
@@ -2838,7 +2840,7 @@ let combine_constructor value_kind loc arg pat_env cstr partial ctx def
                       (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem, value_kind))
                   nonconsts default
               in
-              Llet (Alias, Pgenval, tag,
+              Llet (Alias, Lambda.layout_block, tag,
                     Lprim (Pfield (0, Reads_agree), [ arg ], loc),
                     tests)
         in
@@ -2936,7 +2938,7 @@ let call_switcher_variant_constr value_kind loc fail arg int_lambda_list =
   let v = Ident.create_local "variant" in
   Llet
     ( Alias,
-      Pgenval,
+      Lambda.layout_int,
       v,
       Lprim (nonconstant_variant_field 0, [ arg ], loc),
       call_switcher value_kind loc fail (Lvar v) min_int max_int int_lambda_list )
@@ -3019,7 +3021,7 @@ let combine_array value_kind loc arg kind partial ctx def (len_lambda_list, tota
     let switch =
       call_switcher value_kind loc fail (Lvar newvar) 0 max_int len_lambda_list
     in
-    bind Alias newvar (Lprim (Parraylength kind, [ arg ], loc)) switch
+    bind_with_layout Alias (newvar, Lambda.layout_int) (Lprim (Parraylength kind, [ arg ], loc)) switch
   in
   (lambda1, Jumps.union local_jumps total1)
 
@@ -3097,7 +3099,7 @@ let compile_orhandlers value_kind compile_fun lambda1 total1 ctx to_catch =
           | Lstaticraise (j, args) ->
               if i = j then
                 ( List.fold_right2
-                    (bind_with_value_kind Alias)
+                    (bind_with_layout Alias)
                     vars args handler_i,
                   Jumps.map (Context.rshift_num (ncols mat)) total_i )
               else
@@ -3136,7 +3138,7 @@ let rec approx_present v = function
   | Lvar vv -> Ident.same v vv
   | _ -> true
 
-let rec lower_bind v arg lam =
+let rec lower_bind v arg_layout arg lam =
   match lam with
   | Lifthenelse (cond, ifso, ifnot, kind) -> (
       let pcond = approx_present v cond
@@ -3145,33 +3147,33 @@ let rec lower_bind v arg lam =
       match (pcond, pso, pnot) with
       | false, false, false -> lam
       | false, true, false ->
-          Lifthenelse (cond, lower_bind v arg ifso, ifnot, kind)
+          Lifthenelse (cond, lower_bind v arg_layout arg ifso, ifnot, kind)
       | false, false, true ->
-          Lifthenelse (cond, ifso, lower_bind v arg ifnot, kind)
-      | _, _, _ -> bind Alias v arg lam
+          Lifthenelse (cond, ifso, lower_bind v arg_layout arg ifnot, kind)
+      | _, _, _ -> bind_with_layout Alias (v, arg_layout) arg lam
     )
   | Lswitch (ls, ({ sw_consts = [ (i, act) ]; sw_blocks = [] } as sw), loc,
              kind)
     when not (approx_present v ls) ->
-      Lswitch (ls, { sw with sw_consts = [ (i, lower_bind v arg act) ] },
+      Lswitch (ls, { sw with sw_consts = [ (i, lower_bind v arg_layout arg act) ] },
                loc, kind)
   | Lswitch (ls, ({ sw_consts = []; sw_blocks = [ (i, act) ] } as sw),
              loc, kind)
     when not (approx_present v ls) ->
-      Lswitch (ls, { sw with sw_blocks = [ (i, lower_bind v arg act) ] },
+      Lswitch (ls, { sw with sw_blocks = [ (i, lower_bind v arg_layout arg act) ] },
                loc, kind)
   | Llet (Alias, k, vv, lv, l) ->
       if approx_present v lv then
-        bind Alias v arg lam
+        bind_with_layout Alias (v, arg_layout) arg lam
       else
-        Llet (Alias, k, vv, lv, lower_bind v arg l)
-  | _ -> bind Alias v arg lam
+        Llet (Alias, k, vv, lv, lower_bind v arg_layout arg l)
+  | _ -> bind_with_layout Alias (v, arg_layout) arg lam
 
-let bind_check str v arg lam =
+let bind_check str v arg_layout arg lam =
   match (str, arg) with
-  | _, Lvar _ -> bind str v arg lam
-  | Alias, _ -> lower_bind v arg lam
-  | _, _ -> bind str v arg lam
+  | _, Lvar _ -> bind_with_layout str (v, arg_layout) arg lam
+  | Alias, _ -> lower_bind v arg_layout arg lam
+  | _, _ -> bind_with_layout str (v, arg_layout) arg lam
 
 let comp_exit ctx m =
   match Default_environment.pop m.default with
@@ -3276,7 +3278,7 @@ and compile_match_nonempty ~scopes value_kind repr partial ctx
       let m = { m with args; cases } in
       let first_match, rem =
         split_and_precompile_half_simplified ~arg:newarg m in
-      combine_handlers ~scopes value_kind repr partial ctx (v, str, arg) first_match rem
+      combine_handlers ~scopes value_kind repr partial ctx (v, str, Lambda.layout_top, arg) first_match rem
   | _ -> assert false
 
 and compile_match_simplified ~scopes value_kind  repr partial ctx
@@ -3287,11 +3289,11 @@ and compile_match_simplified ~scopes value_kind  repr partial ctx
       let args = (arg, Alias) :: argl in
       let m = { m with args } in
       let first_match, rem = split_and_precompile_simplified m in
-      combine_handlers value_kind ~scopes repr partial ctx (v, str, arg)
+      combine_handlers value_kind ~scopes repr partial ctx (v, str, Lambda.layout_top, arg)
         first_match rem
   | _ -> assert false
 
-and combine_handlers ~scopes value_kind repr partial ctx (v, str, arg)
+and combine_handlers ~scopes value_kind repr partial ctx (v, str, arg_layout, arg)
     first_match rem =
   let lam, total =
     comp_match_handlers value_kind
@@ -3303,7 +3305,7 @@ and combine_handlers ~scopes value_kind repr partial ctx (v, str, arg)
          repr)
       partial ctx first_match rem
   in
-  (bind_check str v arg lam, total)
+  (bind_check str v arg_layout arg lam, total)
 
 (* verbose version of do_compile_matching, for debug *)
 and do_compile_matching_pr ~scopes value_kind repr partial ctx x =
@@ -3717,7 +3719,7 @@ let for_let ~scopes loc param pat body_kind body =
       Lsequence (param, body)
   | Tpat_var (id, _) ->
       (* fast path, and keep track of simple bindings to unboxable numbers *)
-      let k = Typeopt.value_kind pat.pat_env pat.pat_type in
+      let k = Typeopt.layout pat.pat_env pat.pat_type in
       Llet (Strict, k, id, param, body)
   | _ ->
       let opt = ref false in
@@ -3725,7 +3727,7 @@ let for_let ~scopes loc param pat body_kind body =
       let catch_ids = pat_bound_idents_full pat in
       let ids_with_kinds =
         List.map
-          (fun (id, _, typ) -> (id, Typeopt.value_kind pat.pat_env typ))
+          (fun (id, _, typ) -> (id, Typeopt.layout pat.pat_env typ))
           catch_ids
       in
       let ids = List.map (fun (id, _, _) -> id) catch_ids in
@@ -3847,6 +3849,7 @@ let do_for_multiple_match ~scopes value_kind loc paraml mode pat_act_list partia
     and idl = List.map (function
       | Lvar id -> id
       | _ -> Ident.create_local "*match*") paraml in
+    let idl_with_layouts = List.map (fun id -> (id, Lambda.layout_top)) idl in
     let args = List.map (fun id -> (Lvar id, Alias)) idl in
     let flat_next = flatten_precompiled size args next
     and flat_nexts =
@@ -3856,7 +3859,7 @@ let do_for_multiple_match ~scopes value_kind loc paraml mode pat_act_list partia
       comp_match_handlers value_kind (compile_flattened ~scopes value_kind repr) partial
         (Context.start size) flat_next flat_nexts
     in
-    List.fold_right2 (bind Strict) idl paraml lam, total
+    List.fold_right2 (bind_with_layout Strict) idl_with_layouts paraml lam, total
   )
 
 (* PR#4828: Believe it or not, the 'paraml' argument below
@@ -3870,7 +3873,7 @@ let param_to_var param =
 let bind_opt (v, eo) k =
   match eo with
   | None -> k
-  | Some e -> Lambda.bind Strict v e k
+  | Some e -> Lambda.bind_with_layout Strict (v, Lambda.layout_top) e k
 
 let for_multiple_match ~scopes value_kind loc paraml mode pat_act_list partial =
   let v_paraml = List.map param_to_var paraml in

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -21,24 +21,24 @@ open Debuginfo.Scoped_location
 
 (* Entry points to match compiler *)
 val for_function:
-        scopes:scopes -> value_kind -> Location.t ->
+        scopes:scopes -> layout -> Location.t ->
         int ref option -> lambda -> (pattern * lambda) list -> partial ->
         lambda
 val for_trywith:
-        scopes:scopes -> value_kind -> Location.t ->
+        scopes:scopes -> layout -> Location.t ->
         lambda -> (pattern * lambda) list ->
         lambda
 val for_let:
         scopes:scopes -> Location.t ->
-        lambda -> pattern -> value_kind -> lambda ->
+        lambda -> pattern -> layout -> lambda ->
         lambda
 val for_multiple_match:
-        scopes:scopes -> value_kind -> Location.t ->
+        scopes:scopes -> layout -> Location.t ->
         lambda list -> alloc_mode -> (pattern * lambda) list -> partial ->
         lambda
 
 val for_tupled_function:
-        scopes:scopes -> Location.t -> value_kind ->
+        scopes:scopes -> Location.t -> layout ->
         Ident.t list -> (pattern list * lambda) list -> partial ->
         lambda
 
@@ -48,7 +48,7 @@ val flatten_pattern: int -> pattern -> pattern list
 
 (* Expand stringswitch to  string test tree *)
 val expand_stringswitch:
-    scoped_location -> value_kind -> lambda -> (string * lambda) list ->
+    scoped_location -> layout -> lambda -> (string * lambda) list ->
     lambda option -> lambda
 
 val inline_lazy_force : lambda -> region_close -> scoped_location -> lambda

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -95,17 +95,19 @@ and value_kind' ppf = function
   | Pvariant { consts; non_consts; } ->
     variant_kind value_kind' ppf ~consts ~non_consts
 
+let layout ppf (Pvalue k) = value_kind ppf k
+
 let return_kind ppf (mode, kind) =
   let smode = alloc_mode mode in
   match kind with
-  | Pgenval when is_heap_mode mode -> ()
-  | Pgenval -> fprintf ppf ": %s@ " smode
-  | Pintval -> fprintf ppf ": int@ "
-  | Pfloatval -> fprintf ppf ": %sfloat@ " smode
-  | Parrayval elt_kind ->
+  | Pvalue Pgenval when is_heap_mode mode -> ()
+  | Pvalue Pgenval -> fprintf ppf ": %s@ " smode
+  | Pvalue Pintval -> fprintf ppf ": int@ "
+  | Pvalue Pfloatval -> fprintf ppf ": %sfloat@ " smode
+  | Pvalue (Parrayval elt_kind) ->
      fprintf ppf ": %s%sarray@ " smode (array_kind elt_kind)
-  | Pboxedintval bi -> fprintf ppf ": %s%s@ " smode (boxed_integer_name bi)
-  | Pvariant { consts; non_consts; } ->
+  | Pvalue (Pboxedintval bi) -> fprintf ppf ": %s%s@ " smode (boxed_integer_name bi)
+  | Pvalue (Pvariant { consts; non_consts; }) ->
     variant_kind value_kind' ppf ~consts ~non_consts
 
 let field_kind ppf = function
@@ -646,7 +648,7 @@ let rec lam ppf = function
         match kind with
         | Curried _ ->
             List.iter (fun (param, k) ->
-                fprintf ppf "@ %a%a" Ident.print param value_kind k) params
+                fprintf ppf "@ %a%a" Ident.print param layout k) params
         | Tupled ->
             fprintf ppf " (";
             let first = ref true in
@@ -654,7 +656,7 @@ let rec lam ppf = function
               (fun (param, k) ->
                 if !first then first := false else fprintf ppf ",@ ";
                 Ident.print ppf param;
-                value_kind ppf k)
+                layout ppf k)
               params;
             fprintf ppf ")" in
       let rmode = if region then alloc_heap else alloc_local in
@@ -676,7 +678,7 @@ let rec lam ppf = function
         | Lmutlet(k, id, arg, body) as l ->
            if sp then fprintf ppf "@ ";
            fprintf ppf "@[<2>%a =%s%a@ %a@]"
-             Ident.print id (let_kind l) value_kind k lam arg;
+             Ident.print id (let_kind l) layout k lam arg;
            letbody ~sp:true body
         | expr -> expr in
       fprintf ppf "@[<2>(let@ @[<hv 1>(";
@@ -744,7 +746,7 @@ let rec lam ppf = function
         lam lbody i
         (fun ppf vars ->
            List.iter
-             (fun (x, k) -> fprintf ppf " %a%a" Ident.print x value_kind k)
+             (fun (x, k) -> fprintf ppf " %a%a" Ident.print x layout k)
              vars
         )
         vars

--- a/ocaml/lambda/printlambda.mli
+++ b/ocaml/lambda/printlambda.mli
@@ -29,6 +29,7 @@ val variant_kind : (formatter -> value_kind -> unit) ->
   unit
 val value_kind : formatter -> value_kind -> unit
 val value_kind' : formatter -> value_kind -> unit
+val layout : formatter -> layout -> unit
 val block_shape : formatter -> value_kind list option -> unit
 val record_rep : formatter -> Types.record_representation -> unit
 val print_bigarray :

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -553,8 +553,8 @@ let simplify_lets lam =
       let slbody = simplif lbody in
       begin try
         let kind = match kind_ref with
-          | None -> Pgenval
-          | Some [field_kind] -> field_kind
+          | None -> Lambda.layout_field
+          | Some [field_kind] -> Pvalue field_kind
           | Some _ -> assert false
         in
         mkmutlet kind v slinit (eliminate_ref v slbody)
@@ -780,7 +780,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
         let body = if add_region then Lregion body else body in
         let inner_fun =
           lfunction ~kind:(Curried {nlocal=0})
-            ~params:(List.map (fun id -> id, Pgenval) new_ids)
+            ~params:(List.map (fun id -> id, Lambda.layout_top) new_ids)
             ~return ~body ~attr ~loc ~mode ~region:true
         in
         (wrapper_body, (inner_id, inner_fun))

--- a/ocaml/lambda/simplif.mli
+++ b/ocaml/lambda/simplif.mli
@@ -32,8 +32,8 @@ val simplify_lambda: lambda -> lambda
 val split_default_wrapper
    : id:Ident.t
   -> kind:function_kind
-  -> params:(Ident.t * Lambda.value_kind) list
-  -> return:Lambda.value_kind
+  -> params:(Ident.t * Lambda.layout) list
+  -> return:Lambda.layout
   -> body:lambda
   -> attr:function_attribute
   -> loc:Lambda.scoped_location

--- a/ocaml/lambda/switch.ml
+++ b/ocaml/lambda/switch.ml
@@ -118,7 +118,7 @@ sig
   type arg
   type test
   type act
-  type value_kind
+  type layout
 
   val bind : arg -> (arg -> act) -> act
   val make_const : int -> arg
@@ -129,10 +129,10 @@ sig
   val make_is_nonzero : arg -> test
   val arg_as_test : arg -> test
 
-  val make_if : value_kind -> test -> act -> act -> act
-  val make_switch : loc -> value_kind -> arg -> int array -> act array -> act
+  val make_if : layout -> test -> act -> act -> act
+  val make_switch : loc -> layout -> arg -> int array -> act array -> act
 
-  val make_catch : value_kind -> act -> int * (act -> act)
+  val make_catch : layout -> act -> int * (act -> act)
   val make_exit : int -> act
 end
 

--- a/ocaml/lambda/switch.mli
+++ b/ocaml/lambda/switch.mli
@@ -81,8 +81,8 @@ module type S =
     type test
     (* type of actions *)
     type act
-    (* type of value kind *)
-    type value_kind
+    (* type of layouts *)
+    type layout
 
     (* Various constructors, for making a binder,
         adding one integer, etc. *)
@@ -112,14 +112,14 @@ module type S =
        to a boolean test *)
     val arg_as_test : arg -> test
     (* [make_if cond ifso ifnot] generates a conditional branch *)
-    val make_if : value_kind -> test -> act -> act -> act
+    val make_if : layout -> test -> act -> act -> act
    (* construct an actual switch :
       make_switch arg cases acts
       NB:  cases is in the value form *)
-    val make_switch : loc -> value_kind -> arg -> int array -> act array -> act
+    val make_switch : loc -> layout -> arg -> int array -> act array -> act
 
    (* Build last minute sharing of action stuff *)
-   val make_catch : value_kind -> act -> int * (act -> act)
+   val make_catch : layout -> act -> int * (act -> act)
    val make_exit : int -> act
   end
 
@@ -140,7 +140,7 @@ module Make :
 (* Standard entry point, sharing is tracked *)
       val zyva :
           Arg.loc ->
-          Arg.value_kind ->
+          Arg.layout ->
           (int * int) ->
            Arg.arg ->
            (int * int * int) array ->
@@ -149,7 +149,7 @@ module Make :
 
 (* Output test sequence, sharing tracked *)
      val test_sequence :
-           Arg.value_kind ->
+           Arg.layout ->
            Arg.arg ->
            (int * int * int) array ->
            (Arg.act, _) t_store ->

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -62,7 +62,7 @@ and offset = Offset of lambda
 let offset_code (Offset t) = t
 
 let add_dst_params ({var; offset} : Ident.t destination) params =
-  (var, Pgenval) :: (offset, Pintval) :: params
+  (var, Lambda.layout_block) :: (offset, Lambda.layout_int) :: params
 
 let add_dst_args ({var; offset} : offset destination) args =
   Lvar var :: offset_code offset :: args
@@ -134,7 +134,7 @@ end = struct
     let placeholder_pos = List.length constr.before in
     let placeholder_pos_lam = Lconst (Const_base (Const_int placeholder_pos)) in
     let block_var = Ident.create_local "block" in
-    Llet (Strict, Pgenval, block_var, k_with_placeholder,
+    Llet (Strict, Lambda.layout_block, block_var, k_with_placeholder,
           body {
             var = block_var;
             offset = Offset placeholder_pos_lam ;
@@ -165,7 +165,7 @@ end = struct
       List.fold_right (fun binding body ->
           match binding with
           | None -> body
-          | Some (v, lam) -> Llet(Strict, Pgenval, v, lam, body)
+          | Some (v, lam) -> Llet(Strict, Lambda.layout_field, v, lam, body)
         ) bindings body in
     fun ~block_id constr body ->
     bind_list ~block_id ~arg_offset:0 constr.before @@ fun vbefore ->

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -27,7 +27,7 @@ type error = Tags of label * label
 
 exception Error of Location.t * error
 
-let lfunction ?(kind=Curried {nlocal=0}) ?(region=true) params body =
+let lfunction ?(kind=Curried {nlocal=0}) ?(region=true) return_layout params body =
   if params = [] then body else
   match kind, body with
   | Curried {nlocal=0},
@@ -35,14 +35,14 @@ let lfunction ?(kind=Curried {nlocal=0}) ?(region=true) params body =
                body = body'; attr; loc}
     when List.length params + List.length params' <= Lambda.max_arity() ->
       lfunction ~kind ~params:(params @ params')
-                ~return:Pgenval
+                ~return:return_layout
                 ~body:body'
                 ~attr
                 ~loc
                 ~mode:alloc_heap
                 ~region
   |  _ ->
-      lfunction ~kind ~params ~return:Pgenval
+      lfunction ~kind ~params ~return:return_layout
                 ~body
                 ~attr:default_function_attribute
                 ~loc:Loc_unknown
@@ -96,7 +96,7 @@ let transl_val tbl create name =
 let transl_vals tbl create strict vals rem =
   List.fold_right
     (fun (name, id) rem ->
-      Llet(strict, Pgenval, id, transl_val tbl create name, rem))
+      Llet(strict, Lambda.layout_int, id, transl_val tbl create name, rem))
     vals rem
 
 let meths_super tbl meths inh_meths =
@@ -112,7 +112,7 @@ let meths_super tbl meths inh_meths =
 let bind_super tbl (vals, meths) cl_init =
   transl_vals tbl false StrictOpt vals
     (List.fold_right (fun (_nm, id, def) rem ->
-         Llet(StrictOpt, Pgenval, id, def, rem))
+         Llet(StrictOpt, Lambda.layout_object, id, def, rem))
        meths cl_init)
 
 let create_object cl obj init =
@@ -125,7 +125,7 @@ let create_object cl obj init =
              [obj; Lvar cl]))
   else begin
    (inh_init,
-    Llet(Strict, Pgenval, obj',
+    Llet(Strict, Lambda.layout_object, obj',
             mkappl (oo_prim "create_object_opt", [obj; Lvar cl]),
          Lsequence(obj_init,
                    if not has_init then Lvar obj' else
@@ -194,11 +194,11 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
        let build params rem =
          let param = name_pattern "param" pat in
          Lambda.lfunction
-                   ~kind:(Curried {nlocal=0}) ~params:((param, Pgenval)::params)
-                   ~return:Pgenval
+                   ~kind:(Curried {nlocal=0}) ~params:((param, Lambda.layout_top)::params)
+                   ~return:Lambda.layout_top
                    ~attr:default_function_attribute
                    ~loc:(of_location ~scopes pat.pat_loc)
-                   ~body:(Matching.for_function ~scopes Pgenval pat.pat_loc
+                   ~body:(Matching.for_function ~scopes Lambda.layout_top pat.pat_loc
                              None (Lvar param) [pat, rem] partial)
                    ~mode:alloc_heap
                    ~region:true
@@ -219,7 +219,7 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
         build_object_init ~scopes cl_table obj (vals @ params)
           inh_init obj_init cl
       in
-      (inh_init, Translcore.transl_let ~scopes rec_flag defs Pgenval obj_init)
+      (inh_init, Translcore.transl_let ~scopes rec_flag defs Lambda.layout_top obj_init)
   | Tcl_open (_, cl)
   | Tcl_constraint (cl, _, _, _, _) ->
       build_object_init ~scopes cl_table obj params inh_init obj_init cl
@@ -238,12 +238,12 @@ let rec build_object_init_0
       let ((_,inh_init), obj_init) =
         build_object_init ~scopes cl_table obj params (envs,[]) copy_env cl in
       let obj_init =
-        if ids = [] then obj_init else lfunction [self, Pgenval] obj_init in
-      (inh_init, lfunction [env, Pgenval] (subst_env env inh_init obj_init))
+        if ids = [] then obj_init else lfunction Lambda.layout_top [self, Lambda.layout_top] obj_init in
+      (inh_init, lfunction Lambda.layout_top [env, Lambda.layout_top] (subst_env env inh_init obj_init))
 
 
 let bind_method tbl lab id cl_init =
-  Llet(Strict, Pgenval, id, mkappl (oo_prim "get_method_label",
+  Llet(Strict, Lambda.layout_int, id, mkappl (oo_prim "get_method_label",
                            [Lvar tbl; transl_label lab]),
        cl_init)
 
@@ -258,11 +258,11 @@ let bind_methods tbl meths vals cl_init =
     if nvals = 0 then "get_method_labels", [] else
     "new_methods_variables", [transl_meth_list (List.map fst vals)]
   in
-  Llet(Strict, Pgenval, ids,
+  Llet(Strict, Lambda.layout_array Pintarray, ids,
        mkappl (oo_prim getter,
                [Lvar tbl; transl_meth_list (List.map fst methl)] @ names),
        List.fold_right
-         (fun (_lab,id) lam -> decr i; Llet(StrictOpt, Pgenval, id,
+         (fun (_lab,id) lam -> decr i; Llet(StrictOpt, Lambda.layout_int, id,
                                            lfield ids !i, lam))
          (methl @ vals) cl_init)
 
@@ -300,7 +300,7 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
       begin match inh_init with
       | (_, path_lam, obj_init)::inh_init ->
           (inh_init,
-           Llet (Strict, Pgenval, obj_init,
+           Llet (Strict, Lambda.layout_object, obj_init,
                  mkappl(Lprim(class_field 1, [path_lam], Loc_unknown), Lvar cla ::
                         if top then [Lprim(class_field 3, [path_lam], Loc_unknown)]
                         else []),
@@ -338,7 +338,7 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
                   if !Clflags.native_code && List.length met_code = 1 then
                     (* Force correct naming of method for profiles *)
                     let met = Ident.create_local ("method_" ^ name.txt) in
-                    [Llet(Strict, Pgenval, met, List.hd met_code, Lvar met)]
+                    [Llet(Strict, Lambda.layout_top, met, List.hd met_code, Lvar met)]
                   else met_code
                 in
                 (inh_init, cl_init,
@@ -391,22 +391,22 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
           let cl_init =
             List.fold_left
               (fun init (nm, id, _) ->
-                Llet(StrictOpt, Pgenval, id,
+                Llet(StrictOpt, Lambda.layout_top, id,
                      lfield inh (index nm concr_meths + ofs),
                      init))
               cl_init methids in
           let cl_init =
             List.fold_left
               (fun init (nm, id) ->
-                Llet(StrictOpt, Pgenval, id,
+                Llet(StrictOpt, Lambda.layout_top, id,
                      lfield inh (index nm vals + 1), init))
               cl_init valids in
           (inh_init,
-           Llet (Strict, Pgenval, inh,
+           Llet (Strict, Lambda.layout_array Pgenarray, inh,
                  mkappl(oo_prim "inherits", narrow_args @
                         [path_lam;
                          Lconst(const_int (if top then 1 else 0))]),
-                 Llet(StrictOpt, Pgenval, obj_init, lfield inh 0, cl_init)))
+                 Llet(StrictOpt, Lambda.layout_top, obj_init, lfield inh 0, cl_init)))
       | _ ->
           let core cl_init =
             build_class_init
@@ -428,7 +428,7 @@ let rec build_class_lets ~scopes cl =
     Tcl_let (rec_flag, defs, _vals, cl') ->
       let env, wrap = build_class_lets ~scopes cl' in
       (env, fun x ->
-          Translcore.transl_let ~scopes rec_flag defs Pgenval (wrap x))
+          Translcore.transl_let ~scopes rec_flag defs Lambda.layout_top (wrap x))
   | _ ->
       (cl.cl_env, fun x -> x)
 
@@ -464,11 +464,11 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
       let build params rem =
         let param = name_pattern "param" pat in
         Lambda.lfunction
-                  ~kind:(Curried {nlocal=0}) ~params:((param, Pgenval)::params)
-                  ~return:Pgenval
+                  ~kind:(Curried {nlocal=0}) ~params:((param, Lambda.layout_top)::params)
+                  ~return:Lambda.layout_top
                   ~attr:default_function_attribute
                   ~loc:(of_location ~scopes pat.pat_loc)
-                  ~body:(Matching.for_function ~scopes Pgenval pat.pat_loc
+                  ~body:(Matching.for_function ~scopes Lambda.layout_top pat.pat_loc
                             None (Lvar param) [pat, rem] partial)
                   ~mode:alloc_heap
                   ~region:true
@@ -486,7 +486,7 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
   | Tcl_let (rec_flag, defs, _vals, cl) ->
       let path, path_lam, obj_init =
         transl_class_rebind ~scopes obj_init cl vf in
-      (path, path_lam, Translcore.transl_let ~scopes rec_flag defs Pgenval obj_init)
+      (path, path_lam, Translcore.transl_let ~scopes rec_flag defs Lambda.layout_top obj_init)
   | Tcl_structure _ -> raise Exit
   | Tcl_constraint (cl', _, _, _, _) ->
       let path, path_lam, obj_init =
@@ -507,11 +507,11 @@ let rec transl_class_rebind_0 ~scopes (self:Ident.t) obj_init cl vf =
       let path, path_lam, obj_init =
         transl_class_rebind_0 ~scopes self obj_init cl vf
       in
-      (path, path_lam, Translcore.transl_let ~scopes rec_flag defs Pgenval obj_init)
+      (path, path_lam, Translcore.transl_let ~scopes rec_flag defs Lambda.layout_top obj_init)
   | _ ->
       let path, path_lam, obj_init =
         transl_class_rebind ~scopes obj_init cl vf in
-      (path, path_lam, lfunction [self, Pgenval] obj_init)
+      (path, path_lam, lfunction Lambda.layout_top [self, Lambda.layout_top] obj_init)
 
 let transl_class_rebind ~scopes cl vf =
   try
@@ -532,7 +532,7 @@ let transl_class_rebind ~scopes cl vf =
     in
     let _, path_lam, obj_init' =
       transl_class_rebind_0 ~scopes self obj_init0 cl vf in
-    let id = (obj_init' = lfunction [self, Pgenval] obj_init0) in
+    let id = (obj_init' = lfunction Lambda.layout_top [self, Lambda.layout_top] obj_init0) in
     if id then path_lam else
 
     let cla = Ident.create_local "class"
@@ -541,15 +541,15 @@ let transl_class_rebind ~scopes cl vf =
     and table = Ident.create_local "table"
     and envs = Ident.create_local "envs" in
     Llet(
-    Strict, Pgenval, new_init, lfunction [obj_init, Pgenval] obj_init',
+    Strict, Lambda.layout_function, new_init, lfunction Lambda.layout_top [obj_init, Lambda.layout_top] obj_init',
     Llet(
-    Alias, Pgenval, cla, path_lam,
+    Alias, Lambda.layout_class, cla, path_lam,
     Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
           [mkappl(Lvar new_init, [lfield cla 0]);
-           lfunction [table, Pgenval]
-             (Llet(Strict, Pgenval, env_init,
+           lfunction Lambda.layout_top [table, Lambda.layout_top]
+             (Llet(Strict, Lambda.layout_top, env_init,
                    mkappl(lfield cla 1, [Lvar table]),
-                   lfunction [envs, Pgenval]
+                   lfunction Lambda.layout_top [envs, Lambda.layout_top]
                      (mkappl(Lvar new_init,
                              [mkappl(Lvar env_init, [Lvar envs])]))));
            lfield cla 2;
@@ -745,7 +745,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   let no_env_update _ _ env = env in
   let msubst arr = function
       Lfunction {kind = Curried _ as kind; region;
-                 params = (self, Pgenval) :: args; body} ->
+                 params = (self, layout) :: args; body} ->
         let env = Ident.create_local "env" in
         let body' =
           if new_ids = [] then body else
@@ -754,11 +754,11 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
           (* Doesn't seem to improve size for bytecode *)
           (* if not !Clflags.native_code then raise Not_found; *)
           if not arr || !Clflags.debug then raise Not_found;
-          builtin_meths [self] env env2 (lfunction args body')
+          builtin_meths [self] env env2 (lfunction Lambda.layout_top args body')
         with Not_found ->
-          [lfunction ~kind ~region ((self, Pgenval) :: args)
+          [lfunction ~kind ~region Lambda.layout_top ((self, layout) :: args)
              (if not (Ident.Set.mem env (free_variables body')) then body' else
-              Llet(Alias, Pgenval, env,
+              Llet(Alias, Lambda.layout_top, env,
                    Lprim(Pfield_computed Reads_vary,
                          [Lvar self; Lvar env2],
                          Loc_unknown),
@@ -777,8 +777,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
     if top then lam else
     (* must be called only once! *)
     let lam = Lambda.subst no_env_update (subst env1 lam 1 new_ids_init) lam in
-    Llet(Alias, Pgenval, env1, (if l = [] then Lvar envs else lfield envs 0),
-    Llet(Alias, Pgenval, env1',
+    Llet(Alias, Lambda.layout_top, env1, (if l = [] then Lvar envs else lfield envs 0),
+    Llet(Alias, Lambda.layout_top, env1',
          (if !new_ids_init = [] then Lvar env1 else lfield env1 0),
          lam))
   in
@@ -808,10 +808,10 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       if name' <> name then raise(Error(cl.cl_loc, Tags(name, name'))))
     tags pub_meths;
   let ltable table lam =
-    Llet(Strict, Pgenval, table,
+    Llet(Strict, Lambda.layout_array Pgenarray, table,
          mkappl (oo_prim "create_table", [transl_meth_list pub_meths]), lam)
   and ldirect obj_init =
-    Llet(Strict, Pgenval, obj_init, cl_init,
+    Llet(Strict, Lambda.layout_top, obj_init, cl_init,
          Lsequence(mkappl (oo_prim "init_class", [Lvar cla]),
                    mkappl (Lvar obj_init, [lambda_unit])))
   in
@@ -824,11 +824,11 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                            ~kind:(Curried {nlocal=0})
                            ~attr:default_function_attribute
                            ~loc:Loc_unknown
-                           ~return:Pgenval
+                           ~return:Lambda.layout_top
                            ~mode:alloc_heap
                            ~region:true
-                           ~params:[cla, Pgenval] ~body:cl_init) in
-    Llet(Strict, Pgenval, class_init, cl_init, lam (free_variables cl_init))
+                           ~params:[cla, Lambda.layout_class] ~body:cl_init) in
+    Llet(Strict, Lambda.layout_top, class_init, cl_init, lam (free_variables cl_init))
   and lbody fv =
     if List.for_all (fun id -> not (Ident.Set.mem id fv)) ids then
       mkappl (oo_prim "make_class",[transl_meth_list pub_meths;
@@ -836,7 +836,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
     else
       ltable table (
       Llet(
-      Strict, Pgenval, env_init, mkappl (Lvar class_init, [Lvar table]),
+      Strict, Lambda.layout_top, env_init, mkappl (Lvar class_init, [Lvar table]),
       Lsequence(
       mkappl (oo_prim "init_class", [Lvar table]),
       Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
@@ -849,10 +849,10 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                           ~kind:(Curried {nlocal=0})
                           ~attr:default_function_attribute
                           ~loc:Loc_unknown
-                          ~return:Pgenval
+                          ~return:Lambda.layout_top
                           ~mode:alloc_heap
                           ~region:true
-                          ~params:[cla, Pgenval] ~body:cl_init;
+                          ~params:[cla, Lambda.layout_class] ~body:cl_init;
            lambda_unit; lenvs],
          Loc_unknown)
   in
@@ -883,13 +883,13 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       (List.rev inh_init)
   in
   let make_envs lam =
-    Llet(StrictOpt, Pgenval, envs,
+    Llet(StrictOpt, Lambda.layout_top, envs,
          (if linh_envs = [] then lenv else
          Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
                lenv :: linh_envs, Loc_unknown)),
          lam)
   and def_ids cla lam =
-    Llet(StrictOpt, Pgenval, env2,
+    Llet(StrictOpt, Lambda.layout_int, env2,
          mkappl (oo_prim "new_variable", [Lvar cla; transl_label ""]),
          lam)
   in
@@ -904,18 +904,18 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       inh_paths
   in
   let lclass lam =
-    Llet(Strict, Pgenval, class_init,
+    Llet(Strict, Lambda.layout_class, class_init,
          Lambda.lfunction
-                   ~kind:(Curried {nlocal=0}) ~params:[cla, Pgenval]
-                   ~return:Pgenval
+                   ~kind:(Curried {nlocal=0}) ~params:[cla, Lambda.layout_class]
+                   ~return:Lambda.layout_top
                    ~attr:default_function_attribute
                    ~loc:Loc_unknown
                    ~mode:alloc_heap
                    ~region:true
                    ~body:(def_ids cla cl_init), lam)
   and lcache lam =
-    if inh_keys = [] then Llet(Alias, Pgenval, cached, Lvar tables, lam) else
-    Llet(Strict, Pgenval, cached,
+    if inh_keys = [] then Llet(Alias, Lambda.layout_top, cached, Lvar tables, lam) else
+    Llet(Strict, Lambda.layout_top, cached,
          mkappl (oo_prim "lookup_tables",
                 [Lvar tables; Lprim(Pmakearray(Paddrarray, Immutable, alloc_heap),
                                     inh_keys, Loc_unknown)]),
@@ -926,7 +926,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   in
   let ldirect () =
     ltable cla
-      (Llet(Strict, Pgenval, env_init, def_ids cla cl_init,
+      (Llet(Strict, Lambda.layout_top, env_init, def_ids cla cl_init,
             Lsequence(mkappl (oo_prim "init_class", [Lvar cla]),
                       lset cached 0 (Lvar env_init))))
   and lclass_virt () =
@@ -937,8 +937,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
          ~loc:Loc_unknown
          ~mode:alloc_heap
          ~region:true
-         ~return:Pgenval
-         ~params:[cla, Pgenval]
+         ~return:Lambda.layout_top
+         ~params:[cla, Lambda.layout_class]
          ~body:(def_ids cla cl_init))
   in
   let lupdate_cache =
@@ -954,7 +954,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
          so that the program's behaviour does not change between runs *)
       lupdate_cache
     else
-      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache, Pgenval) in
+      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache, Lambda.layout_top) in
   llets (
   lcache (
   Lsequence(lcheck_cache,

--- a/ocaml/lambda/translcomprehension.ml
+++ b/ocaml/lambda/translcomprehension.ml
@@ -10,22 +10,22 @@ type let_kind_or_mut =
 
 type binding =
   { let_kind : let_kind_or_mut;
-    value_kind : value_kind;
+    layout : layout;
     var : Ident.t;
     init : lambda }
 
-let binding let_kind value_kind var init =
-  {let_kind=Let let_kind; value_kind; var; init}
+let binding let_kind layout var init =
+  {let_kind=Let let_kind; layout; var; init}
 
-let binding_mut value_kind var init =
-  {let_kind=Mutlet; value_kind; var; init}
+let binding_mut layout var init =
+  {let_kind=Mutlet; layout; var; init}
 
-let gen_binding {let_kind; value_kind; var; init} body =
+let gen_binding {let_kind; layout; var; init} body =
   match let_kind with
   | Let let_kind ->
-    Llet(let_kind, value_kind, var, init, body)
+    Llet(let_kind, layout, var, init, body)
   | Mutlet ->
-    Lmutlet(value_kind, var, init, body)
+    Lmutlet(layout, var, init, body)
 
 let gen_bindings bindings body =
   List.fold_right gen_binding bindings body
@@ -53,11 +53,11 @@ let transl_arr_clause ~transl_exp ~scopes ~loc clause body =
         let in_var = Ident.create_local "in_var" in
         let in_kind = Typeopt.array_kind e2 in
         let in_binding =
-          binding Strict Pgenval in_var (transl_exp ~scopes e2)
+          binding Strict (Lambda.layout_array in_kind) in_var (transl_exp ~scopes e2)
         in
         let len_binding =
           let init = Lprim( (Parraylength(in_kind)), [Lvar(in_var)], loc) in
-          binding Alias Pintval len_var init
+          binding Alias Lambda.layout_int len_var init
         in
         let index = Ident.create_local "index" in
         let for_ = Lfor {
@@ -69,7 +69,7 @@ let transl_arr_clause ~transl_exp ~scopes ~loc clause body =
             Matching.for_let ~scopes pat.pat_loc
               (Lprim(Parrayrefu(in_kind),
                      [Lvar(in_var); Lvar(index)], loc))
-              pat (valuekind_of_arraykind in_kind) body;
+              pat (Pvalue (valuekind_of_arraykind in_kind)) body;
           for_region = true
         }
         in
@@ -77,11 +77,11 @@ let transl_arr_clause ~transl_exp ~scopes ~loc clause body =
     | From_to(id, _, e2, e3, dir) ->
         let from_var = Ident.create_local "from" in
         let from_binding =
-          binding Strict Pintval from_var (transl_exp ~scopes e2)
+          binding Strict Lambda.layout_int from_var (transl_exp ~scopes e2)
         in
         let to_var = Ident.create_local "to" in
         let to_binding =
-          binding Strict Pintval to_var (transl_exp ~scopes e3)
+          binding Strict Lambda.layout_int to_var (transl_exp ~scopes e3)
         in
         let low, high =
           match dir with
@@ -92,7 +92,7 @@ let transl_arr_clause ~transl_exp ~scopes ~loc clause body =
           let init =
             Lprim(Psubint, [Lprim(Paddint, [high; int 1], loc); low], loc)
           in
-          binding Alias Pintval len_var init
+          binding Alias Lambda.layout_int len_var init
         in
         let for_ = Lfor {
           for_id = id;
@@ -117,7 +117,7 @@ let iterate_arr_block ~transl_exp ~loc ~scopes
     match guard with
     | None -> body
     | Some guard ->
-      Lifthenelse(transl_exp ~scopes guard, body, lambda_unit, Pintval)
+      Lifthenelse(transl_exp ~scopes guard, body, lambda_unit, Lambda.layout_int)
   in
   let body, length_opt, bindings =
     List.fold_left
@@ -136,7 +136,7 @@ let iterate_arr_block ~transl_exp ~loc ~scopes
       (body, None, []) clauses
   in
   let length = Option.value length_opt ~default:(int 0) in
-  let length_binding = binding Alias Pintval length_var length in
+  let length_binding = binding Alias Lambda.layout_int length_var length in
   let bindings = List.append bindings [length_binding] in
   bindings, body
 
@@ -166,13 +166,13 @@ let make_array ~loc ~kind ~size ~array =
          replaced when an example value (to create the array) is known.
          That is also why the biding is a Variable. *)
       let init = Lprim(Pmakearray(Pgenarray, Immutable, alloc_heap), [], loc) in
-      binding_mut Pgenval array init
+      binding_mut (Lambda.layout_array kind) array init
   | Pintarray | Paddrarray ->
       let init = make_array_prim ~loc size (int 0) in
-      binding Strict Pgenval array init
+      binding Strict (Lambda.layout_array kind) array init
   | Pfloatarray ->
       let init = make_floatarray_prim ~loc size in
-      binding Strict Pgenval array init
+      binding Strict (Lambda.layout_array kind) array init
 
 (* Generate code to initialise an element of an "uninitialised" array *)
 let init_array_elem ~loc ~kind ~size ~array ~index ~value =
@@ -187,7 +187,7 @@ let init_array_elem ~loc ~kind ~size ~array ~index ~value =
       let make_array =
         Lassign(array, make_array_prim ~loc size (Lvar value))
       in
-      Lifthenelse(is_first_iteration, make_array, set_elem, Pintval)
+      Lifthenelse(is_first_iteration, make_array, set_elem, Lambda.layout_int)
   | Pintarray | Paddrarray | Pfloatarray -> set_elem
 
 (* Generate code to blit elements into an "uninitialised" array *)
@@ -212,14 +212,14 @@ let init_array_elems ~loc ~kind ~size ~array ~index ~src ~len =
       in
       Lsequence(
         Lifthenelse(is_first_iteration,
-          Lifthenelse(is_not_empty, make_array, lambda_unit, Pintval),
-          lambda_unit, Pintval),
+          Lifthenelse(is_not_empty, make_array, lambda_unit, Lambda.layout_unit),
+          lambda_unit, Lambda.layout_unit),
         blit)
   | Pintarray | Paddrarray | Pfloatarray -> blit
 
 (* Binding for a counter *)
 let make_counter counter =
-  binding_mut Pintval counter (int 0)
+  binding_mut Lambda.layout_int counter (int 0)
 
 (* Code to increment a counter *)
 let increment_counter ~loc counter step =
@@ -230,7 +230,7 @@ type block_lambda =
   | With_size of { body : lambda; raise_count: int }
 
 let transl_arr_block ~transl_exp ~loc ~scopes
-          global_counter body array_kind value_kind block =
+          global_counter body array_kind layout block =
   let length_var = Ident.create_local "len" in
   let size =
     match body with
@@ -252,7 +252,7 @@ let transl_arr_block ~transl_exp ~loc ~scopes
   let set_result =
     match body with
     | Without_size {body} ->
-        Llet(Strict, value_kind, elem_var, body,
+        Llet(Strict, layout, elem_var, body,
           Lsequence(init_elem, increment_counter ~loc counter_var (int 1)))
     | With_size {body; raise_count} ->
         let elem_len_var = Ident.create_local "len" in
@@ -263,9 +263,9 @@ let transl_arr_block ~transl_exp ~loc ~scopes
              Lvar elem_len_var], loc)
         in
         Lstaticcatch(body,
-          (raise_count, [(elem_var, Pgenval); (elem_len_var, Pintval)]),
+          (raise_count, [(elem_var, layout); (elem_len_var, Lambda.layout_int)]),
           Lsequence(init_elem, Lsequence(set_len,
-             increment_counter ~loc counter_var (int 2))), Pintval)
+             increment_counter ~loc counter_var (int 2))), Lambda.layout_int)
   in
   let bindings, loops =
     iterate_arr_block ~transl_exp ~loc ~scopes block length_var set_result
@@ -308,10 +308,10 @@ let sub_array ~loc src src_pos len =
   Lprim (Pccall prim, [src; src_pos; len], loc)
 
 let transl_single_arr_block ~transl_exp ~loc ~scopes
-      block body array_kind value_kind =
+      block body array_kind layout =
   let body =
     transl_arr_block ~transl_exp ~loc ~scopes None
-      (Without_size {body}) array_kind value_kind block
+      (Without_size {body}) array_kind layout block
   in
   match body with
   | Without_size { body } -> body
@@ -319,8 +319,8 @@ let transl_single_arr_block ~transl_exp ~loc ~scopes
       let array_var = Ident.create_local "array" in
       let len_var = Ident.create_local "len" in
       Lstaticcatch(body,
-          (raise_count, [(array_var, Pgenval); (len_var, Pintval)]),
-          sub_array ~loc (Lvar array_var) (int 0) (Lvar len_var), Pintval)
+          (raise_count, [(array_var, layout); (len_var, Lambda.layout_int)]),
+          sub_array ~loc (Lvar array_var) (int 0) (Lvar len_var), Lambda.layout_int)
 
 type intermediate_array_shape =
   | Array_of_elements
@@ -347,7 +347,7 @@ let concat_arrays ~loc arr kind shape global_count_var =
       | None ->
         let var = Ident.create_local "len" in
         let init = Lprim((Parraylength kind), [Lvar(arr_var)], loc) in
-        let binding = binding Alias Pintval var init in
+        let binding = binding Alias Lambda.layout_int var init in
         var, [binding]
     in
     match shape with
@@ -369,7 +369,7 @@ let concat_arrays ~loc arr kind shape global_count_var =
           for_from = int 0;
           for_to = last_index;
           for_dir = Upto;
-          for_body = Llet(Strict, Pgenval, sub_arr_var, sub_arr,
+          for_body = Llet(Strict, Lambda.layout_array kind, sub_arr_var, sub_arr,
                           loop shape sub_arr_var None);
           for_region = true })
     | Array_of_filtered_arrays shape ->
@@ -392,8 +392,8 @@ let concat_arrays ~loc arr kind shape global_count_var =
                 wh_cond_region = true;
                 wh_body =
                   Lsequence(
-                    Llet(Strict, Pgenval, sub_arr_var, sub_arr,
-                         Llet(Strict, Pintval, sub_arr_len_var, sub_arr_len,
+                    Llet(Strict, Lambda.layout_array kind, sub_arr_var, sub_arr,
+                         Llet(Strict, Lambda.layout_int, sub_arr_len_var, sub_arr_len,
                               loop shape sub_arr_var (Some sub_arr_len_var))),
                     increment_counter ~loc index_var (int 2));
                 wh_body_region = true}))
@@ -401,7 +401,7 @@ let concat_arrays ~loc arr kind shape global_count_var =
   match arr with
   | Without_size { body } ->
       let array_var = Ident.create_local "array" in
-      Llet(Strict, Pgenval, array_var, body,
+      Llet(Strict, Lambda.layout_array kind, array_var, body,
            gen_binding res_binding
              (gen_binding counter_binding
                 (Lsequence
@@ -411,28 +411,28 @@ let concat_arrays ~loc arr kind shape global_count_var =
       let array_var = Ident.create_local "array" in
       let len_var = Ident.create_local "len" in
       Lstaticcatch(body,
-          (raise_count, [(array_var, Pgenval); (len_var, Pintval)]),
+          (raise_count, [(array_var, Lambda.layout_array kind); (len_var, Lambda.layout_int)]),
            gen_binding res_binding
              (gen_binding counter_binding
                 ((Lsequence
                     (loop shape array_var (Some len_var),
-                     res_var)))), Pgenval)
+                     res_var)))), Lambda.layout_array kind)
 
 let transl_arr_comprehension ~transl_exp ~loc ~scopes
       ~array_kind exp blocks =
   let body = transl_exp ~scopes exp in
-  let value_kind = Typeopt.value_kind exp.exp_env exp.exp_type in
+  let layout = Typeopt.layout exp.exp_env exp.exp_type in
   match blocks with
   | [] -> assert false
   | [block] ->
       transl_single_arr_block ~transl_exp ~loc ~scopes
-        block body array_kind value_kind
+        block body array_kind layout
   | inner_block :: rest ->
       let counter_var = Ident.create_local "counter" in
       let counter_binding = make_counter counter_var in
       let body =
         transl_arr_block ~transl_exp ~loc ~scopes (Some counter_var)
-          (Without_size {body}) array_kind value_kind inner_block
+          (Without_size {body}) array_kind layout inner_block
       in
       let shape, body =
         List.fold_left
@@ -444,7 +444,7 @@ let transl_arr_comprehension ~transl_exp ~loc ~scopes
              in
              let body =
                transl_arr_block ~transl_exp ~loc ~scopes None
-                 body Paddrarray Pgenval block
+                 body Paddrarray (Lambda.layout_array Paddrarray) block
              in
              shape, body)
           (Array_of_elements, body) rest
@@ -468,7 +468,7 @@ let transl_list_comp type_comp body acc_var mats ~transl_exp ~scopes ~loc =
   let param, pval, args, func, body, mats =
     match type_comp with
     | From_to (param, _,e2,e3, dir) ->
-      let pval = Pintval in
+      let pval = Lambda.layout_int in
       let from_var = Ident.create_local "from" in
       let to_var = Ident.create_local "to_" in
       let args = [Lvar(from_var); Lvar(to_var); Lvar(new_acc)] in
@@ -479,7 +479,7 @@ let transl_list_comp type_comp body acc_var mats ~transl_exp ~scopes ~loc =
       param, pval, args, func, body, mats
     | In (pat, in_) ->
       let pat_id = Ident.create_local "pat" in
-      let pval = Typeopt.value_kind pat.pat_env pat.pat_type in
+      let pval = Typeopt.layout pat.pat_env pat.pat_type in
       let in_var = Ident.create_local "in_var" in
       let args = [Lvar(in_var); Lvar(new_acc)] in
       let func = in_comp_prim () in
@@ -492,8 +492,8 @@ let transl_list_comp type_comp body acc_var mats ~transl_exp ~scopes ~loc =
   let fn =
     lfunction
       ~kind:(Curried {nlocal=0})
-      ~params:[param, pval; acc_var, Pgenval]
-      ~return:Pgenval
+      ~params:[param, pval; acc_var, Lambda.layout_list]
+      ~return:Lambda.layout_list
       ~attr:default_function_attribute
       ~loc
       ~body
@@ -514,7 +514,7 @@ let transl_list_comp type_comp body acc_var mats ~transl_exp ~scopes ~loc =
 
 let transl_list_comprehension ~transl_exp ~loc ~scopes body blocks =
   let acc_var = Ident.create_local "acc" in
-  let value_kind = Typeopt.value_kind body.exp_env body.exp_type in
+  let layout = Typeopt.layout body.exp_env body.exp_type in
   let bdy =
     Lprim(
       Pmakeblock(0, Immutable, None, alloc_heap),
@@ -526,7 +526,7 @@ let transl_list_comprehension ~transl_exp ~loc ~scopes body blocks =
         match block.guard with
         | None -> body
         | Some guard ->
-          Lifthenelse((transl_exp ~scopes  guard), body, Lvar(acc_var), value_kind)
+          Lifthenelse((transl_exp ~scopes  guard), body, Lvar(acc_var), layout)
       in
       let body, acc_var, materialize =
         List.fold_left
@@ -535,13 +535,13 @@ let transl_list_comprehension ~transl_exp ~loc ~scopes body blocks =
           (body, acc_var, []) block.clauses
         in
         let body = List.fold_right (fun (id, arr) body ->
-          Llet(Strict, Pgenval, id, arr, body))
+          Llet(Strict, Lambda.layout_list, id, arr, body))
           materialize body
         in
         body, acc_var)
     (bdy, acc_var) blocks
   in
-  Llet(Alias, Pintval, res_var, int 0, (*Empty list.*)
+  Llet(Alias, Lambda.layout_list, res_var, int 0, (*Empty list.*)
     Lapply{
         ap_loc=loc;
         ap_func=comp_rev ();

--- a/ocaml/lambda/translcore.mli
+++ b/ocaml/lambda/translcore.mli
@@ -35,7 +35,7 @@ val transl_apply: scopes:scopes
                   -> (arg_label * apply_arg) list
                   -> scoped_location -> lambda
 val transl_let: scopes:scopes -> ?in_structure:bool
-                  -> rec_flag -> value_binding list -> value_kind -> lambda -> lambda
+                  -> rec_flag -> value_binding list -> layout -> lambda -> lambda
 
 val transl_extension_constructor: scopes:scopes ->
   Env.t -> Longident.t option ->

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -82,7 +82,7 @@ let transl_type_extension ~scopes env rootpath tyext body =
         transl_extension_constructor ~scopes env
           (field_path rootpath ext.ext_id) ext
       in
-      Llet(Strict, Pgenval, ext.ext_id, lam, body))
+      Llet(Strict, Lambda.layout_block, ext.ext_id, lam, body))
     tyext.tyext_constructors
     body
 
@@ -93,7 +93,7 @@ let rec apply_coercion loc strict restr arg =
     Tcoerce_none ->
       arg
   | Tcoerce_structure(pos_cc_list, id_pos_list) ->
-      name_lambda strict arg (fun id ->
+      name_lambda strict arg Lambda.layout_module (fun id ->
         let get_field pos =
           if pos < 0 then lambda_unit
           else
@@ -108,13 +108,13 @@ let rec apply_coercion loc strict restr arg =
   | Tcoerce_functor(cc_arg, cc_res) ->
       let param = Ident.create_local "funarg" in
       let carg = apply_coercion loc Alias cc_arg (Lvar param) in
-      apply_coercion_result loc strict arg [param, Pgenval] [carg] cc_res
+      apply_coercion_result loc strict arg [param, Lambda.layout_module] [carg] cc_res
   | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode } ->
       let poly_mode = Option.map Translcore.transl_alloc_mode pc_poly_mode in
       Translprim.transl_primitive loc pc_desc pc_env pc_type ~poly_mode None
   | Tcoerce_alias (env, path, cc) ->
       let lam = transl_module_path loc env path in
-      name_lambda strict arg
+      name_lambda strict arg Lambda.layout_module
         (fun _ -> apply_coercion loc Alias cc lam)
 
 and apply_coercion_field loc get_field (pos, cc) =
@@ -126,14 +126,14 @@ and apply_coercion_result loc strict funct params args cc_res =
     let param = Ident.create_local "funarg" in
     let arg = apply_coercion loc Alias cc_arg (Lvar param) in
     apply_coercion_result loc strict funct
-      ((param, Pgenval) :: params) (arg :: args) cc_res
+      ((param, Lambda.layout_module) :: params) (arg :: args) cc_res
   | _ ->
-      name_lambda strict funct
+      name_lambda strict funct Lambda.layout_functor
         (fun id ->
            lfunction
              ~kind:(Curried {nlocal=0})
              ~params:(List.rev params)
-             ~return:Pgenval
+             ~return:Lambda.layout_module
              ~attr:{ default_function_attribute with
                         is_a_functor = true;
                         stub = true; }
@@ -163,7 +163,7 @@ and wrap_id_pos_list loc id_pos_list get_field lam =
     List.fold_left (fun (lam, s) (id',pos,c) ->
       if Ident.Set.mem id' fv then
         let id'' = Ident.create_local (Ident.name id') in
-        (Llet(Alias, Pgenval, id'',
+        (Llet(Alias, Lambda.layout_top, id'',
              apply_coercion loc Alias c (get_field pos),lam),
          Ident.Map.add id' id'' s)
       else (lam, s))
@@ -254,7 +254,7 @@ let preallocate_letrec ~bindings ~body =
          Primitive.simple ~name:"caml_alloc_dummy" ~arity:1 ~alloc:true
        in
        let size : lambda = Lconst (Const_base (Const_int size)) in
-       Llet (Strict, Pgenval, id,
+       Llet (Strict, Lambda.layout_block, id,
              Lprim (Pccall desc, [size], Loc_unknown), body))
     body_with_initialization bindings
 
@@ -406,7 +406,7 @@ let eval_rec_bindings bindings cont =
   | (_, None, _) :: rem ->
       bind_inits rem
   | (Id id, Some(loc, shape), _rhs) :: rem ->
-      Llet(Strict, Pgenval, id,
+      Llet(Strict, Lambda.layout_module, id,
            Lapply{
              ap_loc=Loc_unknown;
              ap_func=mod_prim "init_mod";
@@ -425,7 +425,7 @@ let eval_rec_bindings bindings cont =
   | (Ignore_loc loc, None, rhs) :: rem ->
       Lsequence(Lprim(Pignore, [rhs], loc), bind_strict rem)
   | (Id id, None, rhs) :: rem ->
-      Llet(Strict, Pgenval, id, rhs, bind_strict rem)
+      Llet(Strict, Lambda.layout_top, id, rhs, bind_strict rem)
   | (_id, Some _, _rhs) :: rem ->
       bind_strict rem
   and patch_forwards = function
@@ -532,8 +532,8 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
     List.fold_left (fun (params, body) (param, loc, arg_coercion) ->
         let param' = Ident.rename param in
         let arg = apply_coercion loc Alias arg_coercion (Lvar param') in
-        let params = (param', Pgenval) :: params in
-        let body = Llet (Alias, Pgenval, param, arg, body) in
+        let params = (param', Lambda.layout_module) :: params in
+        let body = Llet (Alias, Lambda.layout_module, param, arg, body) in
         params, body)
       ([], transl_module ~scopes res_coercion body_path body)
       functor_params_rev
@@ -541,7 +541,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
   lfunction
     ~kind:(Curried {nlocal=0})
     ~params
-    ~return:Pgenval
+    ~return:Lambda.layout_module
     ~attr:{
       inline = inline_attribute;
       specialise = Default_specialise;
@@ -664,7 +664,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
       | Tstr_value(rec_flag, pat_expr_list) ->
           (* Translate bindings first *)
           let mk_lam_let =
-            transl_let ~scopes ~in_structure:true rec_flag pat_expr_list Pgenval in
+            transl_let ~scopes ~in_structure:true rec_flag pat_expr_list Lambda.layout_module_field in
           let ext_fields =
             List.rev_append (let_bound_idents pat_expr_list) fields in
           (* Then, translate remainder of struct *)
@@ -690,7 +690,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
           let body, size =
             transl_structure ~scopes loc (id::fields) cc rootpath final_env rem
           in
-          Llet(Strict, Pgenval, id,
+          Llet(Strict, Lambda.layout_block, id,
                transl_extension_constructor ~scopes
                                             item.str_env
                                             path
@@ -729,7 +729,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                   lev_env = Env.empty;
                 })
               in
-              Llet(pure_module mb.mb_expr, Pgenval, id, module_body, body), size
+              Llet(pure_module mb.mb_expr, Lambda.layout_module, id, module_body, body), size
           end
       | Tstr_module ({mb_presence=Mp_absent}) ->
           transl_structure ~scopes loc fields cc rootpath final_env rem
@@ -784,7 +784,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                 let body, size =
                   rebind_idents (pos + 1) (id :: newfields) ids
                 in
-                Llet(Alias, Pgenval, id,
+                Llet(Alias, Lambda.layout_module_field, id,
                      Lprim(mod_field pos, [Lvar mid],
                            of_location ~scopes incl.incl_loc), body),
                 size
@@ -802,7 +802,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                 Strict, transl_include_functor ~generative:true modl ccs
                           scopes loc
           in
-          Llet(let_kind, Pgenval, mid, modl, body),
+          Llet(let_kind, Lambda.layout_module, mid, modl, body),
           size
 
       | Tstr_open od ->
@@ -824,13 +824,13 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                   let body, size =
                     rebind_idents (pos + 1) (id :: newfields) ids
                   in
-                  Llet(Alias, Pgenval, id,
+                  Llet(Alias, Lambda.layout_module_field, id,
                       Lprim(mod_field pos, [Lvar mid],
                             of_location ~scopes od.open_loc), body),
                   size
               in
               let body, size = rebind_idents 0 fields ids in
-              Llet(pure, Pgenval, mid,
+              Llet(pure, Lambda.layout_module, mid,
                    transl_module ~scopes Tcoerce_none None od.open_expr, body),
               size
           end
@@ -1109,7 +1109,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             let ids = let_bound_idents pat_expr_list in
             let lam =
               transl_let ~scopes ~in_structure:true rec_flag pat_expr_list
-                 Pintval (* unit *)
+                 Lambda.layout_unit
                  (store_idents Loc_unknown ids)
             in
             Lsequence(Lambda.subst no_env_update subst lam,
@@ -1141,7 +1141,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                                            path
                                            ext.tyexn_constructor
             in
-            Lsequence(Llet(Strict, Pgenval, id,
+            Lsequence(Llet(Strict, Lambda.layout_block, id,
                            Lambda.subst no_env_update subst lam,
                            store_ident loc id),
                       transl_store ~scopes rootpath
@@ -1171,7 +1171,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             (* Careful: see next case *)
             let subst = !transl_store_subst in
             Lsequence(lam,
-                      Llet(Strict, Pgenval, id,
+                      Llet(Strict, Lambda.layout_module, id,
                            Lambda.subst no_env_update subst
                              (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
                                     List.map (fun id -> Lvar id)
@@ -1200,7 +1200,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             let subst = !transl_store_subst in
             let field = field_of_str loc str in
             Lsequence(lam,
-                      Llet(Strict, Pgenval, id,
+                      Llet(Strict, Lambda.layout_module, id,
                            Lambda.subst no_env_update subst
                              (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
                                     List.map field map, loc)),
@@ -1224,7 +1224,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                the compilation unit (add_ident true returns subst unchanged).
                If not, we can use the value from the global
                (add_ident true adds id -> Pgetglobal... to subst). *)
-            Llet(Strict, Pgenval, id, Lambda.subst no_env_update subst lam,
+            Llet(Strict, Lambda.layout_module, id, Lambda.subst no_env_update subst lam,
                  Lsequence(store_ident (of_location ~scopes loc) id,
                            transl_store ~scopes rootpath
                              (add_ident true id subst)
@@ -1290,7 +1290,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                   transl_store ~scopes rootpath (add_idents true ids0 subst)
                     cont rem
               | id :: ids, arg :: args ->
-                  Llet(Alias, Pgenval, id,
+                  Llet(Alias, Lambda.layout_module_field, id,
                        Lambda.subst no_env_update subst (field arg),
                        Lsequence(store_ident (of_location ~scopes loc) id,
                                  loop ids args))
@@ -1315,7 +1315,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               | [] -> transl_store
                         ~scopes rootpath (add_idents true ids subst) cont rem
               | id :: idl ->
-                  Llet(Alias, Pgenval, id, Lprim(mod_field pos, [Lvar mid],
+                  Llet(Alias, Lambda.layout_module_field, id, Lprim(mod_field pos, [Lvar mid],
                                                  loc),
                        Lsequence(store_ident loc id,
                                  store_idents (pos + 1) idl))
@@ -1328,7 +1328,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               | Tincl_gen_functor ccs ->
                   transl_include_functor ~generative:true modl ccs scopes loc
             in
-            Llet(Strict, Pgenval, mid,
+            Llet(Strict, Lambda.layout_module, mid,
                  Lambda.subst no_env_update subst modl,
                  store_idents 0 ids)
         | Tstr_open od ->
@@ -1345,7 +1345,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                   | [] -> transl_store ~scopes rootpath
                             (add_idents true ids0 subst) cont rem
                   | id :: idl ->
-                      Llet(Alias, Pgenval, id, Lvar ids.(pos),
+                      Llet(Alias, Lambda.layout_module_field, id, Lvar ids.(pos),
                            Lsequence(store_ident loc id,
                                      store_idents (pos + 1) idl))
                 in
@@ -1368,14 +1368,14 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         [] -> transl_store ~scopes rootpath
                                 (add_idents true ids subst) cont rem
                       | id :: idl ->
-                          Llet(Alias, Pgenval, id,
+                          Llet(Alias, Lambda.layout_module_field, id,
                                Lprim(mod_field pos,
                                      [Lvar mid], loc),
                                Lsequence(store_ident loc id,
                                          store_idents (pos + 1) idl))
                     in
                     Llet(
-                      pure, Pgenval, mid,
+                      pure, Lambda.layout_module, mid,
                       Lambda.subst no_env_update subst
                         (transl_module ~scopes Tcoerce_none None od.open_expr),
                       store_idents 0 ids)
@@ -1583,7 +1583,7 @@ let toploop_setvalue id lam =
 let toploop_setvalue_id id = toploop_setvalue id (Lvar id)
 
 let close_toplevel_term (lam, ()) =
-  Ident.Set.fold (fun id l -> Llet(Strict, Pgenval, id,
+  Ident.Set.fold (fun id l -> Llet(Strict, Lambda.layout_top, id,
                                   toploop_getvalue id, l))
                 (free_variables lam) lam
 
@@ -1600,7 +1600,7 @@ let transl_toplevel_item ~scopes item =
   | Tstr_value(rec_flag, pat_expr_list) ->
       let idents = let_bound_idents pat_expr_list in
       transl_let ~scopes ~in_structure:true rec_flag pat_expr_list
-        Pintval (* unit *)
+        Lambda.layout_unit
         (make_sequence toploop_setvalue_id idents)
   | Tstr_typext(tyext) ->
       let idents =
@@ -1673,7 +1673,7 @@ let transl_toplevel_item ~scopes item =
           Lsequence(toploop_setvalue id
                       (Lprim(mod_field pos, [Lvar mid], Loc_unknown)),
                     set_idents (pos + 1) ids) in
-      Llet(Strict, Pgenval, mid, modl, set_idents 0 ids)
+      Llet(Strict, Lambda.layout_module, mid, modl, set_idents 0 ids)
   | Tstr_primitive descr ->
       record_primitive descr.val_val;
       lambda_unit
@@ -1696,7 +1696,7 @@ let transl_toplevel_item ~scopes item =
                             (Lprim(mod_field pos, [Lvar mid], Loc_unknown)),
                           set_idents (pos + 1) ids)
           in
-          Llet(pure, Pgenval, mid,
+          Llet(pure, Lambda.layout_module, mid,
                transl_module ~scopes Tcoerce_none None od.open_expr,
                set_idents 0 ids)
       end
@@ -1790,7 +1790,7 @@ let transl_store_package component_names target_name coercion =
       in
       let blk = Ident.create_local "block" in
       (List.length pos_cc_list,
-       Llet (Strict, Pgenval, blk,
+       Llet (Strict, Lambda.layout_module, blk,
              apply_coercion Loc_unknown Strict coercion components,
              make_sequence
                (fun pos _id ->

--- a/ocaml/lambda/translobj.ml
+++ b/ocaml/lambda/translobj.ml
@@ -95,7 +95,10 @@ let transl_label_init_general f =
          let const =
            Lprim (Popaque, [Lconst c], Debuginfo.Scoped_location.Loc_unknown)
          in
-         Llet(Alias, Pgenval, id, const, expr))
+         (* CR ncourant: this *should* not be too precise for the moment,
+            but we should take care, or fix the underlying cause that led
+            us to using [Popaque]. *)
+         Llet(Alias, Lambda.structured_constant_layout c, id, const, expr))
       consts expr
   in
   (*let expr =
@@ -118,7 +121,7 @@ let transl_label_init_flambda f =
   let expr =
     if !method_count = 0 then expr
     else
-      Llet (Strict, Pgenval, method_cache_id,
+      Llet (Strict, Lambda.layout_array Pgenarray, method_cache_id,
         Lprim (Pccall prim_makearray,
                [int !method_count; int 0],
                Loc_unknown),
@@ -186,7 +189,7 @@ let oo_wrap env req f x =
                         [lambda_unit; lambda_unit; lambda_unit],
                         Loc_unknown)
                 in
-                Llet(StrictOpt, Pgenval, id,
+                Llet(StrictOpt, Lambda.layout_class, id,
                      Lprim (Popaque, [cl], Loc_unknown),
                      lambda))
              lambda !classes

--- a/ocaml/middle_end/clambda.ml
+++ b/ocaml/middle_end/clambda.ml
@@ -58,31 +58,31 @@ and ulambda =
       scanned_slots : ulambda list ;
     }
   | Uoffset of ulambda * int
-  | Ulet of mutable_flag * value_kind * Backend_var.With_provenance.t
+  | Ulet of mutable_flag * layout * Backend_var.With_provenance.t
       * ulambda * ulambda
   | Uphantom_let of Backend_var.With_provenance.t
       * uphantom_defining_expr option * ulambda
   | Uletrec of (Backend_var.With_provenance.t * ulambda) list * ulambda
   | Uprim of Clambda_primitives.primitive * ulambda list * Debuginfo.t
-  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * Lambda.value_kind
+  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * layout
   | Ustringswitch of
       ulambda *
       (string * ulambda) list *
       ulambda option *
-      Lambda.value_kind
+      layout
   | Ustaticfail of int * ulambda list
   | Ucatch of
       int *
-      (Backend_var.With_provenance.t * value_kind) list *
+      (Backend_var.With_provenance.t * layout) list *
       ulambda *
       ulambda *
-      Lambda.value_kind
+      layout
   | Utrywith of
       ulambda *
       Backend_var.With_provenance.t *
       ulambda *
-      Lambda.value_kind
-  | Uifthenelse of ulambda * ulambda * ulambda * Lambda.value_kind
+      layout
+  | Uifthenelse of ulambda * ulambda * ulambda * layout
   | Usequence of ulambda * ulambda
   | Uwhile of ulambda * ulambda
   | Ufor of Backend_var.With_provenance.t * ulambda * ulambda
@@ -98,8 +98,8 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : arity;
-  params : (Backend_var.With_provenance.t * value_kind) list;
-  return : value_kind;
+  params : (Backend_var.With_provenance.t * layout) list;
+  return : layout;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;

--- a/ocaml/middle_end/clambda.mli
+++ b/ocaml/middle_end/clambda.mli
@@ -69,31 +69,31 @@ and ulambda =
       scanned_slots : ulambda list
     }
   | Uoffset of ulambda * int
-  | Ulet of mutable_flag * value_kind * Backend_var.With_provenance.t
+  | Ulet of mutable_flag * layout * Backend_var.With_provenance.t
       * ulambda * ulambda
   | Uphantom_let of Backend_var.With_provenance.t
       * uphantom_defining_expr option * ulambda
   | Uletrec of (Backend_var.With_provenance.t * ulambda) list * ulambda
   | Uprim of Clambda_primitives.primitive * ulambda list * Debuginfo.t
-  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * Lambda.value_kind
+  | Uswitch of ulambda * ulambda_switch * Debuginfo.t * Lambda.layout
   | Ustringswitch of
       ulambda *
       (string * ulambda) list *
       ulambda option *
-      Lambda.value_kind
+      Lambda.layout
   | Ustaticfail of int * ulambda list
   | Ucatch of
       int *
-      (Backend_var.With_provenance.t * value_kind) list *
+      (Backend_var.With_provenance.t * layout) list *
       ulambda *
       ulambda *
-      Lambda.value_kind
+      Lambda.layout
   | Utrywith of
       ulambda *
       Backend_var.With_provenance.t *
       ulambda *
-      Lambda.value_kind
-  | Uifthenelse of ulambda * ulambda * ulambda * Lambda.value_kind
+      Lambda.layout
+  | Uifthenelse of ulambda * ulambda * ulambda * Lambda.layout
   | Usequence of ulambda * ulambda
   | Uwhile of ulambda * ulambda
   | Ufor of Backend_var.With_provenance.t * ulambda * ulambda
@@ -109,8 +109,8 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : arity;
-  params : (Backend_var.With_provenance.t * value_kind) list;
-  return : value_kind;
+  params : (Backend_var.With_provenance.t * layout) list;
+  return : layout;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;

--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -141,6 +141,9 @@ and value_kind = Lambda.value_kind =
     }
   | Parrayval of array_kind
 
+and layout = Lambda.layout =
+  | Pvalue of value_kind
+
 and block_shape = Lambda.block_shape
 and boxed_integer = Primitive.boxed_integer =
     Pnativeint | Pint32 | Pint64

--- a/ocaml/middle_end/clambda_primitives.mli
+++ b/ocaml/middle_end/clambda_primitives.mli
@@ -144,6 +144,9 @@ and value_kind = Lambda.value_kind =
     }
   | Parrayval of array_kind
 
+and layout = Lambda.layout =
+  | Pvalue of value_kind
+
 and block_shape = Lambda.block_shape
 and boxed_integer = Primitive.boxed_integer =
     Pnativeint | Pint32 | Pint64

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -59,8 +59,8 @@ let rec add_to_closure_env env_param pos cenv = function
 
 let is_gc_ignorable kind =
   match kind with
-  | Pintval -> true
-  | Pgenval | Pfloatval | Pboxedintval _ | Pvariant _ | Parrayval _ -> false
+  | Pvalue Pintval -> true
+  | Pvalue (Pgenval | Pfloatval | Pboxedintval _ | Pvariant _ | Parrayval _) -> false
 
 let split_closure_fv kinds fv =
   List.partition (fun id -> is_gc_ignorable (V.Map.find id kinds)) fv
@@ -768,7 +768,7 @@ type env = {
   cenv : ulambda V.Map.t;
   fenv : value_approximation V.Map.t;
   mutable_vars : V.Set.t;
-  kinds: value_kind V.Map.t;
+  kinds: layout V.Map.t;
   catch_env : int Int.Map.t;
 }
 
@@ -831,7 +831,7 @@ let bind_params { backend; mutable_vars; _ } loc fdesc params args funct body =
           in
           let body' = aux (V.Map.add (VP.var p1) u2 subst) pl al body in
           if occurs_var (VP.var p1) body then
-            Ulet(Immutable, Pgenval, p1', u1, body')
+            Ulet(Immutable, Lambda.layout_top, p1', u1, body')
           else if is_erasable a1 then body'
           else Usequence(a1, body')
         end
@@ -896,14 +896,14 @@ let direct_apply env fundesc ufunct uargs pos mode ~probe ~loc ~attribute =
        List.fold_left (fun app (binding,_) ->
            match binding with
            | None -> app
-           | Some (v, e) -> Ulet(Immutable, Pgenval, v, e, app))
+           | Some (v, e) -> Ulet(Immutable, Lambda.layout_top, v, e, app))
          (if fundesc.fun_closed then
             Usequence (ufunct,
                        Udirect_apply (fundesc.fun_label, app_args,
                                       probe, kind, dbg))
           else
             let clos = V.create_local "clos" in
-            Ulet(Immutable, Pgenval, VP.create clos, ufunct,
+            Ulet(Immutable, Lambda.layout_function, VP.create clos, ufunct,
                  Udirect_apply(fundesc.fun_label, app_args @ [Uvar clos],
                                probe, kind, dbg)))
          args
@@ -1057,7 +1057,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           (V.create_local "arg", arg) ) uargs in
         (* CR mshinwell: Edit when Lapply has kinds *)
         let kinds =
-          List.fold_left (fun kinds (arg, _) -> V.Map.add arg Pgenval kinds)
+          List.fold_left (fun kinds (arg, _) -> V.Map.add arg Lambda.layout_top kinds)
             kinds first_args
         in
         let final_args =
@@ -1068,7 +1068,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
               [] -> body
             | (arg1, arg2) :: args ->
               iter args
-                (Ulet (Immutable, Pgenval, VP.create arg1, arg2, body))
+                (Ulet (Immutable, Lambda.layout_top, VP.create arg1, arg2, body))
         in
         let internal_args =
           (List.map (fun (arg1, _arg2) -> Lvar arg1) first_args)
@@ -1076,7 +1076,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
         in
         let funct_var = V.create_local "funct" in
         let fenv = V.Map.add funct_var fapprox fenv in
-        let kinds = V.Map.add funct_var Pgenval kinds in
+        let kinds = V.Map.add funct_var Lambda.layout_function kinds in
         let new_clos_mode, kind =
           (* If the closure has a local suffix, and we've supplied
              enough args to hit it, then the closure must be local
@@ -1098,8 +1098,8 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           close { backend; fenv; cenv; mutable_vars; kinds; catch_env }
           (lfunction
              ~kind
-             ~return:Pgenval
-             ~params:(List.map (fun v -> v, Pgenval) final_args)
+             ~return:Lambda.layout_top
+             ~params:(List.map (fun v -> v, Lambda.layout_top) final_args)
              ~body:(Lapply{
                 ap_loc=loc;
                 ap_func=(Lvar funct_var);
@@ -1118,7 +1118,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
         in
         let new_fun =
           iter first_args
-            (Ulet (Immutable, Pgenval, VP.create funct_var, ufunct, new_fun))
+            (Ulet (Immutable, Lambda.layout_function, VP.create funct_var, ufunct, new_fun))
         in
         warning_if_forced_inlined ~loc ~attribute "Partial application";
         fail_if_probe ~probe "Partial application";
@@ -1130,7 +1130,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           let args = List.map (fun arg -> V.create_local "arg", arg) uargs in
           (* CR mshinwell: Edit when Lapply has kinds *)
           let kinds =
-            List.fold_left (fun kinds (var, _) -> V.Map.add var Pgenval kinds)
+            List.fold_left (fun kinds (var, _) -> V.Map.add var Lambda.layout_top kinds)
               kinds args
           in
           let (first_args, rem_args) = split_list nparams args in
@@ -1159,7 +1159,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           in
           let result =
             List.fold_left (fun body (id, defining_expr) ->
-                Ulet (Immutable, Pgenval, VP.create id, defining_expr, body))
+                Ulet (Immutable, Lambda.layout_top, VP.create id, defining_expr, body))
               body
               args
           in
@@ -1212,8 +1212,8 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
             infos fenv in
         let kinds_body =
           List.fold_right
-            (fun (id, _pos, _approx) kinds -> V.Map.add id Pgenval kinds)
-            infos (V.Map.add clos_ident Pgenval kinds)
+            (fun (id, _pos, _approx) kinds -> V.Map.add id Lambda.layout_function kinds)
+            infos (V.Map.add clos_ident Lambda.layout_function kinds)
         in
         let (ubody, approx) =
           close
@@ -1231,14 +1231,14 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
             (fun (id, pos, _approx) sb ->
               V.Map.add id (Uoffset(Uvar clos_ident, pos)) sb)
             infos V.Map.empty in
-        (Ulet(Immutable, Pgenval, VP.create clos_ident, clos,
+        (Ulet(Immutable, Lambda.layout_function, VP.create clos_ident, clos,
               substitute Debuginfo.none (backend, !Clflags.float_const_prop) sb
                 None ubody),
          approx)
       end else begin
         (* General case: recursive definition of values *)
         let kinds =
-          List.fold_left (fun kinds (id, _) -> V.Map.add id Pgenval kinds)
+          List.fold_left (fun kinds (id, _) -> V.Map.add id Lambda.layout_top kinds)
             kinds defs
         in
         let rec clos_defs = function
@@ -1268,7 +1268,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
       in
       let arg, _approx = close env arg in
       let id = Ident.create_local "dummy" in
-      Ulet(Immutable, Pgenval, VP.create id, arg, cst), approx
+      Ulet(Immutable, Lambda.layout_top, VP.create id, arg, cst), approx
   | Lprim(Pignore, [arg], _loc) ->
       let expr, approx = make_const_int 0 in
       Usequence(fst (close env arg), expr), approx
@@ -1375,7 +1375,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
   | Ltrywith(body, id, handler, kind) ->
       let (ubody, _) = close env body in
       let (uhandler, _) =
-        close { env with kinds = V.Map.add id Pgenval kinds } handler
+        close { env with kinds = V.Map.add id Lambda.layout_block kinds } handler
       in
       (Utrywith(ubody, VP.create id, uhandler, kind), Value_unknown)
   | Lifthenelse(arg, ifso, ifnot, kind) ->
@@ -1400,7 +1400,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
       let (ulo, _) = close env for_from in
       let (uhi, _) = close env for_to in
       let (ubody, _) =
-        close { env with kinds = V.Map.add for_id Pintval kinds } for_body
+        close { env with kinds = V.Map.add for_id Lambda.layout_int kinds } for_body
       in
       (Ufor(VP.create for_id, ulo, uhi, for_dir, ubody), Value_unknown)
   | Lassign(id, lam) ->
@@ -1496,7 +1496,7 @@ and close_functions { backend; fenv; cenv; mutable_vars; kinds; catch_env } fun_
     List.fold_right
       (fun (id, _params, _return, _body, _mode, _fundesc, _dbg)
            kinds ->
-         V.Map.add id Pgenval kinds)
+         V.Map.add id Lambda.layout_function kinds)
       uncurried_defs kinds in
   (* Determine the offsets of each function's closure in the shared block *)
   let env_pos = ref (-1) in
@@ -1532,7 +1532,7 @@ and close_functions { backend; fenv; cenv; mutable_vars; kinds; catch_env } fun_
     let kinds_body =
       List.fold_right
         (fun (id, kind) kinds -> V.Map.add id kind kinds)
-        params (V.Map.add env_param Pgenval kinds_rec)
+        params (V.Map.add env_param Lambda.layout_function kinds_rec)
     in
     let (ubody, approx) =
       close
@@ -1549,7 +1549,7 @@ and close_functions { backend; fenv; cenv; mutable_vars; kinds; catch_env } fun_
     let fun_params =
       if !useless_env
       then params
-      else params @ [env_param, Pgenval]
+      else params @ [env_param, Lambda.layout_function]
     in
     let f =
       {

--- a/ocaml/middle_end/flambda/augment_specialised_args.ml
+++ b/ocaml/middle_end/flambda/augment_specialised_args.ml
@@ -22,8 +22,8 @@ module B = Inlining_cost.Benefit
 
 module Definition = struct
   type t =
-    | Existing_inner_free_var of Variable.t * Lambda.value_kind
-    | Projection_from_existing_specialised_arg of Projection.t * Lambda.value_kind
+    | Existing_inner_free_var of Variable.t * Lambda.layout
+    | Projection_from_existing_specialised_arg of Projection.t * Lambda.layout
 
   include Identifiable.Make (struct
     type nonrec t = t
@@ -48,10 +48,10 @@ module Definition = struct
       match t with
       | Existing_inner_free_var (var, kind) ->
         Format.fprintf ppf "Existing_inner_free_var (%a, %a)"
-          Variable.print var Printlambda.value_kind kind
+          Variable.print var Printlambda.layout kind
       | Projection_from_existing_specialised_arg (projection, kind) ->
         Format.fprintf ppf "Projection_from_existing_specialised_arg (%a, %a)"
-          Projection.print projection Printlambda.value_kind kind
+          Projection.print projection Printlambda.layout kind
 
     let output _ _ = failwith "Definition.output not yet implemented"
   end)

--- a/ocaml/middle_end/flambda/augment_specialised_args.mli
+++ b/ocaml/middle_end/flambda/augment_specialised_args.mli
@@ -18,8 +18,8 @@
 
 module Definition : sig
   type t =
-    | Existing_inner_free_var of Variable.t * Lambda.value_kind
-    | Projection_from_existing_specialised_arg of Projection.t * Lambda.value_kind
+    | Existing_inner_free_var of Variable.t * Lambda.layout
+    | Projection_from_existing_specialised_arg of Projection.t * Lambda.layout
 end
 
 module What_to_specialise : sig

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -43,12 +43,12 @@ let add_default_argument_wrappers lam =
                    mode; region}, body) ->
       begin match
         Simplif.split_default_wrapper ~id ~kind ~params
-          ~body:fbody ~return:Pgenval ~attr ~loc ~mode ~region
+          ~body:fbody ~return:Lambda.layout_top ~attr ~loc ~mode ~region
       with
-      | [fun_id, def] -> Llet (Alias, Pgenval, fun_id, def, body)
+      | [fun_id, def] -> Llet (Alias, Lambda.layout_function, fun_id, def, body)
       | [fun_id, def; inner_fun_id, def_inner] ->
-        Llet (Alias, Pgenval, inner_fun_id, def_inner,
-              Llet (Alias, Pgenval, fun_id, def, body))
+        Llet (Alias, Lambda.layout_function, inner_fun_id, def_inner,
+              Llet (Alias, Lambda.layout_function, fun_id, def, body))
       | _ -> assert false
       end
     | Lletrec (defs, body) as lam ->
@@ -60,7 +60,7 @@ let add_default_argument_wrappers lam =
                  | (id, Lambda.Lfunction {kind; params; body; attr; loc;
                                           mode; region}) ->
                    Simplif.split_default_wrapper ~id ~kind ~params ~body
-                     ~return:Pgenval ~attr ~loc ~mode ~region
+                     ~return:Lambda.layout_top ~attr ~loc ~mode ~region
                  | _ -> assert false)
                defs)
         in
@@ -102,7 +102,7 @@ let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
   in
   (* Tupled functions are always Alloc_heap. See translcore.ml *)
   let alloc_mode = Lambda.alloc_heap in
-  let tuple_param = Parameter.wrap tuple_param_var alloc_mode Pgenval in
+  let tuple_param = Parameter.wrap tuple_param_var alloc_mode Lambda.layout_block in
   Flambda.create_function_declaration ~params:[tuple_param] ~alloc_mode ~region
     ~body ~stub:true ~dbg:Debuginfo.none ~inline:Default_inline
     ~specialise:Default_specialise ~is_a_functor:false
@@ -195,12 +195,12 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
   | Lconst cst ->
     let cst, name = close_const t cst in
     name_expr cst ~name
-  | Llet ((Strict | Alias | StrictOpt), value_kind, id, defining_expr, body) ->
+  | Llet ((Strict | Alias | StrictOpt), layout, id, defining_expr, body) ->
     let var = Variable.create_with_same_name_as_ident id in
     let defining_expr =
       close_let_bound_expression t var env defining_expr
     in
-    let body = close t (Env.add_var env id var value_kind) body in
+    let body = close t (Env.add_var env id var layout) body in
     Flambda.create_let var defining_expr body
   | Lmutlet (block_kind, id, defining_expr, body) ->
     let mut_var = Mutable_variable.create_with_same_name_as_ident id in
@@ -259,7 +259,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
   | Lletrec (defs, body) ->
     let env =
       List.fold_right (fun (id,  _) env ->
-          Env.add_var env id (Variable.create_with_same_name_as_ident id) Pgenval)
+          Env.add_var env id (Variable.create_with_same_name_as_ident id) Lambda.layout_top)
         defs env
     in
     let function_declarations =
@@ -393,7 +393,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
                      case in the array data types work.
                      mshinwell: deferred CR *)
                   name_expr ~name:Names.result
-                    (Prim (prim, [numerator; denominator], dbg)), Pintval))))))
+                    (Prim (prim, [numerator; denominator], dbg)), Lambda.layout_int))))))
   | Lprim ((Pdivint Safe | Pmodint Safe
            | Pdivbint { is_safe = Safe } | Pmodbint { is_safe = Safe }), _, _)
       when not !Clflags.unsafe ->
@@ -405,7 +405,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let cond = Variable.create Names.cond_sequor in
     Flambda.create_let const_true (Const (Int 1))
       (Flambda.create_let cond (Expr arg1)
-        (If_then_else (cond, Var const_true, arg2, Pintval)))
+        (If_then_else (cond, Var const_true, arg2, Lambda.layout_int)))
   | Lprim (Psequand, [arg1; arg2], _) ->
     let arg1 = close t env arg1 in
     let arg2 = close t env arg2 in
@@ -413,7 +413,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let cond = Variable.create Names.const_sequand in
     Flambda.create_let const_false (Const (Int 0))
       (Flambda.create_let cond (Expr arg1)
-        (If_then_else (cond, arg2, Var const_false, Pintval)))
+        (If_then_else (cond, arg2, Var const_false, Lambda.layout_int)))
   | Lprim ((Psequand | Psequor), _, _) ->
     Misc.fatal_error "Psequand / Psequor must have exactly two arguments"
   | Lprim ((Pbytes_to_string | Pbytes_of_string | Pobj_magic),
@@ -450,7 +450,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
         end
       in
       close t env
-        (Lambda.Llet(Strict, Pgenval, Ident.create_local "dummy",
+        (Lambda.Llet(Strict, Lambda.layout_unit, Ident.create_local "dummy",
                      arg, Lconst const))
   | Lprim (Pfield _, [Lprim (Pgetglobal cu, [],_)], _)
       when Compilation_unit.equal cu t.current_unit ->
@@ -529,7 +529,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
   | Ltrywith (body, id, handler, kind) ->
     let var = Variable.create_with_same_name_as_ident id in
     Try_with (close t env body, var,
-              close t (Env.add_var env id var Pgenval) handler,
+              close t (Env.add_var env id var Lambda.layout_block) handler,
               kind)
   | Lifthenelse (cond, ifso, ifnot, kind) ->
     let cond = close t env cond in
@@ -547,7 +547,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let bound_var = Variable.create_with_same_name_as_ident for_id in
     let from_value = Variable.create Names.for_from in
     let to_value = Variable.create Names.for_to in
-    let body = close t (Env.add_var env for_id bound_var Pintval) for_body in
+    let body = close t (Env.add_var env for_id bound_var Lambda.layout_int) for_body in
     Flambda.create_let from_value (Expr (close t env for_from))
       (Flambda.create_let to_value (Expr (close t env for_to))
         (For { bound_var; from_value; to_value; direction=for_dir; body; }))

--- a/ocaml/middle_end/flambda/closure_conversion_aux.ml
+++ b/ocaml/middle_end/flambda/closure_conversion_aux.ml
@@ -19,8 +19,8 @@ open! Int_replace_polymorphic_compare
 
 module Env = struct
   type t = {
-    variables : (Variable.t * Lambda.value_kind) Ident.tbl;
-    mutable_variables : (Mutable_variable.t * Lambda.value_kind) Ident.tbl;
+    variables : (Variable.t * Lambda.layout) Ident.tbl;
+    mutable_variables : (Mutable_variable.t * Lambda.layout) Ident.tbl;
     static_exceptions : Static_exception.t Numbers.Int.Map.t;
     globals : Symbol.t Numbers.Int.Map.t;
     at_toplevel : bool;
@@ -92,7 +92,7 @@ module Function_decls = struct
       kind : Lambda.function_kind;
       mode : Lambda.alloc_mode;
       region : bool;
-      params : (Ident.t * Lambda.value_kind) list;
+      params : (Ident.t * Lambda.layout) list;
       body : Lambda.lambda;
       free_idents_of_body : Ident.Set.t;
       attr : Lambda.function_attribute;
@@ -184,7 +184,7 @@ module Function_decls = struct
       (* For "let rec"-bound functions. *)
       List.fold_right (fun function_decl env ->
           Env.add_var env (Function_decl.let_rec_ident function_decl)
-            (Function_decl.closure_bound_var function_decl) Pgenval)
+            (Function_decl.closure_bound_var function_decl) Lambda.layout_function)
         t.function_decls (Env.clear_local_bindings external_env)
     in
     (* For free variables. *)

--- a/ocaml/middle_end/flambda/closure_conversion_aux.mli
+++ b/ocaml/middle_end/flambda/closure_conversion_aux.mli
@@ -26,16 +26,16 @@ module Env : sig
 
   val empty : t
 
-  val add_var : t -> Ident.t -> Variable.t -> Lambda.value_kind -> t
-  val add_vars : t -> Ident.t list -> (Variable.t * Lambda.value_kind) list -> t
+  val add_var : t -> Ident.t -> Variable.t -> Lambda.layout -> t
+  val add_vars : t -> Ident.t list -> (Variable.t * Lambda.layout) list -> t
 
-  val find_var : t -> Ident.t -> Variable.t * Lambda.value_kind
-  val find_var_exn : t -> Ident.t -> Variable.t * Lambda.value_kind
+  val find_var : t -> Ident.t -> Variable.t * Lambda.layout
+  val find_var_exn : t -> Ident.t -> Variable.t * Lambda.layout
 
   val add_mutable_var :
-    t -> Ident.t -> Mutable_variable.t -> Lambda.value_kind -> t
+    t -> Ident.t -> Mutable_variable.t -> Lambda.layout -> t
   val find_mutable_var_exn :
-    t -> Ident.t -> Mutable_variable.t * Lambda.value_kind
+    t -> Ident.t -> Mutable_variable.t * Lambda.layout
 
   val add_static_exception : t -> int -> Static_exception.t -> t
   val find_static_exception : t -> int -> Static_exception.t
@@ -60,7 +60,7 @@ module Function_decls : sig
       -> kind:Lambda.function_kind
       -> mode:Lambda.alloc_mode
       -> region:bool
-      -> params:(Ident.t * Lambda.value_kind) list
+      -> params:(Ident.t * Lambda.layout) list
       -> body:Lambda.lambda
       -> attr:Lambda.function_attribute
       -> loc:Lambda.scoped_location
@@ -71,7 +71,7 @@ module Function_decls : sig
     val kind : t -> Lambda.function_kind
     val mode : t -> Lambda.alloc_mode
     val region : t -> bool
-    val params : t -> (Ident.t * Lambda.value_kind) list
+    val params : t -> (Ident.t * Lambda.layout) list
     val body : t -> Lambda.lambda
     val inline : t -> Lambda.inline_attribute
     val specialise : t -> Lambda.specialise_attribute

--- a/ocaml/middle_end/flambda/closure_offsets.ml
+++ b/ocaml/middle_end/flambda/closure_offsets.ml
@@ -70,7 +70,7 @@ let add_closure_offsets
   in
   let gc_invisible_free_vars, gc_visible_free_vars =
     Variable.Map.partition (fun _ (free_var : Flambda.specialised_to) ->
-        Lambda.equal_value_kind free_var.kind Pintval)
+        match free_var.kind with Pvalue Pintval -> true | Pvalue _ -> false)
       free_vars
   in
   let free_variable_offsets, free_variable_pos =

--- a/ocaml/middle_end/flambda/flambda.mli
+++ b/ocaml/middle_end/flambda/flambda.mli
@@ -87,7 +87,7 @@ type specialised_to = {
       [specialised_args] respectively) in the same set of closures.
       As such, this field describes a relation of projections between
       either the [free_vars] or the [specialised_args]. *)
-  kind : Lambda.value_kind;
+  kind : Lambda.layout;
 }
 
 (** Flambda terms are partitioned in a pseudo-ANF manner; many terms are
@@ -105,14 +105,14 @@ type t =
   | Apply of apply
   | Send of send
   | Assign of assign
-  | If_then_else of Variable.t * t * t * Lambda.value_kind
+  | If_then_else of Variable.t * t * t * Lambda.layout
   | Switch of Variable.t * switch
   | String_switch of Variable.t * (string * t) list * t option
-                     * Lambda.value_kind
+                     * Lambda.layout
   (** Restrictions on [Lambda.Lstringswitch] also apply to [String_switch]. *)
   | Static_raise of Static_exception.t * Variable.t list
-  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.value_kind
-  | Try_with of t * Variable.t * t * Lambda.value_kind
+  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.layout
+  | Try_with of t * Variable.t * t * Lambda.layout
   | While of t * t
   | For of for_loop
   | Region of t
@@ -188,7 +188,7 @@ and let_expr = private {
 and let_mutable = {
   var : Mutable_variable.t;
   initial_value : Variable.t;
-  contents_kind : Lambda.value_kind;
+  contents_kind : Lambda.layout;
   body : t;
 }
 
@@ -350,7 +350,7 @@ and switch = {
   numblocks : Numbers.Int.Set.t; (** Number of tag block cases *)
   blocks : (int * t) list; (** Tag block cases *)
   failaction : t option; (** Action to take if none matched *)
-  kind : Lambda.value_kind
+  kind : Lambda.layout
 }
 
 (** Equivalent to the similar type in [Lambda]. *)

--- a/ocaml/middle_end/flambda/flambda_invariants.ml
+++ b/ocaml/middle_end/flambda/flambda_invariants.ml
@@ -52,7 +52,7 @@ let ignore_tag (_ : Tag.t) = ()
 let ignore_inlined_attribute (_ : Lambda.inlined_attribute) = ()
 let ignore_specialise_attribute (_ : Lambda.specialise_attribute) = ()
 let ignore_probe (_ : Lambda.probe) = ()
-let ignore_value_kind (_ : Lambda.value_kind) = ()
+let ignore_layout (_ : Lambda.layout) = ()
 
 exception Binding_occurrence_not_from_current_compilation_unit of Variable.t
 exception Mutable_binding_occurrence_not_from_current_compilation_unit of
@@ -158,7 +158,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       loop (add_binding_occurrence env var) body
     | Let_mutable { var = mut_var; initial_value = var;
                     body; contents_kind } ->
-      ignore_value_kind contents_kind;
+      ignore_layout contents_kind;
       check_variable_is_bound env var;
       loop (add_mutable_binding_occurrence env mut_var) body
     | Let_rec (defs, body) ->
@@ -179,12 +179,12 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       loop (add_binding_occurrence env bound_var) body
     | Static_catch (static_exn, vars, body, handler, kind) ->
       ignore_static_exception static_exn;
-      ignore_value_kind kind;
+      ignore_layout kind;
       loop env body;
       loop (add_binding_occurrences env vars) handler
     | Try_with (body, var, handler, kind) ->
       loop env body;
-      ignore_value_kind kind;
+      ignore_layout kind;
       loop (add_binding_occurrence env var) handler
     (* Everything else: *)
     | Var var -> check_variable_is_bound env var
@@ -211,14 +211,14 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       ignore_debuginfo dbg
     | If_then_else (cond, ifso, ifnot, kind) ->
       check_variable_is_bound env cond;
-      ignore_value_kind kind;
+      ignore_layout kind;
       loop env ifso;
       loop env ifnot
     | Switch (arg, { numconsts; consts; numblocks; blocks; failaction; kind }) ->
       check_variable_is_bound env arg;
       ignore_int_set numconsts;
       ignore_int_set numblocks;
-      ignore_value_kind kind;
+      ignore_layout kind;
       List.iter (fun (n, e) ->
           ignore_int n;
           loop env e)
@@ -230,7 +230,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
           ignore_string label;
           loop env case)
         cases;
-      ignore_value_kind kind;
+      ignore_layout kind;
       Option.iter (loop env) e_opt
     | Static_raise (static_exn, es) ->
       ignore_static_exception static_exn;

--- a/ocaml/middle_end/flambda/flambda_utils.ml
+++ b/ocaml/middle_end/flambda/flambda_utils.ml
@@ -109,7 +109,7 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
     ->
     Mutable_variable.equal mv1 mv2
       && Variable.equal v1 v2
-      && Lambda.equal_value_kind ck1 ck2
+      && Lambda.equal_layout ck1 ck2
       && same b1 b2
   | Let_mutable _, _ | _, Let_mutable _ -> false
   | Let_rec (bl1, a1), Let_rec (bl2, a2) ->
@@ -123,7 +123,7 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
       && Misc.Stdlib.List.equal
         (fun (s1, e1) (s2, e2) -> String.equal s1 s2 && same e1 e2) s1 s2
       && Option.equal same d1 d2
-      && Lambda.equal_value_kind k1 k2
+      && Lambda.equal_layout k1 k2
   | String_switch _, _ | _, String_switch _ -> false
   | Static_raise (e1, a1), Static_raise (e2, a2) ->
     Static_exception.equal e1 e2 && Misc.Stdlib.List.equal Variable.equal a1 a2
@@ -133,15 +133,15 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
       && Misc.Stdlib.List.equal Variable.equal v1 v2
       && same a1 a2
       && same b1 b2
-      && Lambda.equal_value_kind k1 k2
+      && Lambda.equal_layout k1 k2
   | Static_catch _, _ | _, Static_catch _ -> false
   | Try_with (a1, v1, b1, k1), Try_with (a2, v2, b2, k2) ->
     same a1 a2 && Variable.equal v1 v2 && same b1 b2
-    && Lambda.equal_value_kind k1 k2
+    && Lambda.equal_layout k1 k2
   | Try_with _, _ | _, Try_with _ -> false
   | If_then_else (a1, b1, c1, k1), If_then_else (a2, b2, c2, k2) ->
     Variable.equal a1 a2 && same b1 b2 && same c1 c2
-    && Lambda.equal_value_kind k1 k2
+    && Lambda.equal_layout k1 k2
   | If_then_else _, _ | _, If_then_else _ -> false
   | While (a1, b1), While (a2, b2) ->
     same a1 a2 && same b1 b2
@@ -243,7 +243,7 @@ and sameswitch (fs1 : Flambda.switch) (fs2 : Flambda.switch) =
     && Misc.Stdlib.List.equal samecase fs1.consts fs2.consts
     && Misc.Stdlib.List.equal samecase fs1.blocks fs2.blocks
     && Option.equal same fs1.failaction fs2.failaction
-    && Lambda.equal_value_kind fs1.kind fs2.kind
+    && Lambda.equal_layout fs1.kind fs2.kind
 
 let can_be_merged = same
 

--- a/ocaml/middle_end/flambda/flambda_utils.mli
+++ b/ocaml/middle_end/flambda/flambda_utils.mli
@@ -69,7 +69,7 @@ val make_closure_declaration
   -> region:bool
   -> body:Flambda.t
   -> params:Parameter.t list
-  -> free_variables:Lambda.value_kind Variable.Map.t
+  -> free_variables:Lambda.layout Variable.Map.t
   -> Flambda.t
 
 val toplevel_substitution

--- a/ocaml/middle_end/flambda/inline_and_simplify.ml
+++ b/ocaml/middle_end/flambda/inline_and_simplify.ml
@@ -863,7 +863,7 @@ and simplify_partial_application env r ~lhs_of_application
         (List.map (fun p -> Parameter.var p, Parameter.kind p) freshened_params)
     in
     let free_variables =
-      Variable.Map.add lhs_of_application Lambda.Pgenval free_variables
+      Variable.Map.add lhs_of_application Lambda.layout_function free_variables
     in
     Flambda_utils.make_closure_declaration ~id:closure_variable
       ~is_classic_mode:false

--- a/ocaml/middle_end/flambda/inlining_transforms.ml
+++ b/ocaml/middle_end/flambda/inlining_transforms.ml
@@ -344,7 +344,7 @@ let add_fun_var ~lhs_of_application ~closure_id_being_applied ~state ~fun_var =
     in
     let let_bindings = (outside_var, expr) :: state.let_bindings in
     let spec : Flambda.specialised_to =
-      { var = outside_var; projection = None; kind = Pgenval }
+      { var = outside_var; projection = None; kind = Lambda.layout_top }
     in
     let new_free_vars_with_old_projections =
       Variable.Map.add inside_var spec state.new_free_vars_with_old_projections

--- a/ocaml/middle_end/flambda/lift_code.ml
+++ b/ocaml/middle_end/flambda/lift_code.ml
@@ -21,7 +21,7 @@ type lifter = Flambda.program -> Flambda.program
 
 type def =
   | Immutable of Variable.t * Flambda.named Flambda.With_free_variables.t
-  | Mutable of Mutable_variable.t * Variable.t * Lambda.value_kind
+  | Mutable of Mutable_variable.t * Variable.t * Lambda.layout
 
 let rebuild_let (defs : def list) (body : Flambda.t) =
   let module W = Flambda.With_free_variables in

--- a/ocaml/middle_end/flambda/parameter.ml
+++ b/ocaml/middle_end/flambda/parameter.ml
@@ -24,7 +24,7 @@ open! Int_replace_polymorphic_compare
 type parameter = {
   var : Variable.t;
   mode : Lambda.alloc_mode;
-  kind : Lambda.value_kind;
+  kind : Lambda.layout;
 }
 
 let wrap var mode kind = { var; mode; kind }
@@ -55,7 +55,7 @@ module M =
         | Lambda.Alloc_heap -> ""
         | Lambda.Alloc_local -> "[->L]" in
       Format.fprintf ppf "%a%s[%a]"
-        Variable.print var mode Printlambda.value_kind kind
+        Variable.print var mode Printlambda.layout kind
 
     let output o { var; mode = _ ; kind = _ } =
       Variable.output o var

--- a/ocaml/middle_end/flambda/parameter.mli
+++ b/ocaml/middle_end/flambda/parameter.mli
@@ -23,7 +23,7 @@ type t
 type parameter = t
 
 (** Make a parameter from a variable with default attributes *)
-val wrap : Variable.t -> Lambda.alloc_mode -> Lambda.value_kind -> t
+val wrap : Variable.t -> Lambda.alloc_mode -> Lambda.layout -> t
 
 val var : t -> Variable.t
 
@@ -31,7 +31,7 @@ val var : t -> Variable.t
     up to and including this parameter *)
 val alloc_mode : t -> Lambda.alloc_mode
 
-val kind : t -> Lambda.value_kind
+val kind : t -> Lambda.layout
 
 (** Rename the inner variable of the parameter *)
 val rename

--- a/ocaml/middle_end/flambda/ref_to_variables.ml
+++ b/ocaml/middle_end/flambda/ref_to_variables.ml
@@ -147,7 +147,7 @@ let eliminate_ref_of_expr flam =
                 (Let_mutable { var = field_var;
                                initial_value = init;
                                body;
-                               contents_kind = kind } : Flambda.t))
+                               contents_kind = Lambda.Pvalue kind } : Flambda.t))
             (0,body) l shape in
         expr
       | Let _ | Let_mutable _

--- a/ocaml/middle_end/flambda/simple_value_approx.ml
+++ b/ocaml/middle_end/flambda/simple_value_approx.ml
@@ -243,7 +243,8 @@ let augment_with_symbol_field t symbol field =
   | Some _ -> t
 let replace_description t descr = { t with descr }
 
-let augment_with_kind t (kind:Lambda.value_kind) =
+let augment_with_kind t (layout:Lambda.layout) =
+  let Pvalue kind = layout in
   match kind with
   | Pgenval -> t
   | Pfloatval ->
@@ -269,13 +270,13 @@ let augment_with_kind t (kind:Lambda.value_kind) =
     end
   | _ -> t
 
-let augment_kind_with_approx t (kind:Lambda.value_kind) : Lambda.value_kind =
+let augment_kind_with_approx t (kind:Lambda.layout) : Lambda.layout =
   match t.descr with
-  | Value_float _ -> Pfloatval
-  | Value_int _ -> Pintval
-  | Value_boxed_int (Int32, _) -> Pboxedintval Pint32
-  | Value_boxed_int (Int64, _) -> Pboxedintval Pint64
-  | Value_boxed_int (Nativeint, _) -> Pboxedintval Pnativeint
+  | Value_float _ -> Pvalue Pfloatval
+  | Value_int _ -> Pvalue Pintval
+  | Value_boxed_int (Int32, _) -> Pvalue (Pboxedintval Pint32)
+  | Value_boxed_int (Int64, _) -> Pvalue (Pboxedintval Pint64)
+  | Value_boxed_int (Nativeint, _) -> Pvalue (Pboxedintval Pnativeint)
   | _ -> kind
 
 let value_unknown reason = approx (Value_unknown reason)
@@ -368,7 +369,7 @@ let value_mutable_float_array ~size =
 let value_immutable_float_array (contents:t array) =
   let size = Array.length contents in
   let contents =
-    Array.map (fun t -> augment_with_kind t Pfloatval) contents
+    Array.map (fun t -> augment_with_kind t Lambda.layout_float) contents
   in
   approx (Value_float_array { contents = Contents contents; size; } )
 

--- a/ocaml/middle_end/flambda/simple_value_approx.mli
+++ b/ocaml/middle_end/flambda/simple_value_approx.mli
@@ -306,10 +306,10 @@ val augment_with_symbol_field : t -> Symbol.t -> int -> t
 val replace_description : t -> descr -> t
 
 (** Improve the description by taking the kind into account *)
-val augment_with_kind : t -> Lambda.value_kind -> t
+val augment_with_kind : t -> Lambda.layout -> t
 
 (** Improve the kind by taking the description into account *)
-val augment_kind_with_approx : t -> Lambda.value_kind -> Lambda.value_kind
+val augment_kind_with_approx : t -> Lambda.layout -> Lambda.layout
 
 val equal_boxed_int : 'a boxed_int -> 'a -> 'b boxed_int -> 'b -> bool
 

--- a/ocaml/middle_end/flambda/simplify_primitives.ml
+++ b/ocaml/middle_end/flambda/simplify_primitives.ml
@@ -111,11 +111,12 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
   | Pmakeblock(tag_int, (Immutable | Immutable_unique), shape, mode) ->
     let tag = Tag.create_exn tag_int in
     let shape = match shape with
-      | None -> List.map (fun _ -> Lambda.Pgenval) args
-      | Some shape -> shape
+      | None -> List.map (fun _ -> Lambda.layout_top) args
+      | Some shape -> List.map (fun kind -> Lambda.Pvalue kind) shape
     in
     let approxs = List.map2 A.augment_with_kind approxs shape in
     let shape = List.map2 A.augment_kind_with_approx approxs shape in
+    let shape = List.map (fun (Lambda.Pvalue kind) -> kind) shape in
     Prim (Pmakeblock(tag_int, Lambda.Immutable, Some shape, mode), args, dbg),
     A.value_block tag (Array.of_list approxs), C.Benefit.zero
   | Praise _ ->

--- a/ocaml/middle_end/flambda/un_anf.ml
+++ b/ocaml/middle_end/flambda/un_anf.ml
@@ -55,10 +55,10 @@ let ignore_primitive (_ : Clambda_primitives.primitive) = ()
 let ignore_string (_ : string) = ()
 let ignore_int_array (_ : int array) = ()
 let ignore_var_with_provenance (_ : VP.t) = ()
-let ignore_params_with_value_kind (_ : (VP.t * Lambda.value_kind) list) = ()
+let ignore_params_with_layout (_ : (VP.t * Lambda.layout) list) = ()
 let ignore_direction_flag (_ : Asttypes.direction_flag) = ()
 let ignore_meth_kind (_ : Lambda.meth_kind) = ()
-let ignore_value_kind (_ : Lambda.value_kind) = ()
+let ignore_layout (_ : Lambda.layout) = ()
 
 (* CR-soon mshinwell: check we aren't traversing function bodies more than
    once (need to analyse exactly what the calls are from Cmmgen into this
@@ -154,8 +154,8 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
              environment_vars :=
                V.Set.add (VP.var env_var) !environment_vars);
           ignore_function_label label;
-          ignore_params_with_value_kind params;
-          ignore_value_kind return;
+          ignore_params_with_layout params;
+          ignore_layout return;
           loop ~depth:(depth + 1) body;
           ignore_debuginfo dbg;
           ignore_var_option env)
@@ -163,7 +163,7 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
     | Uoffset (expr, offset) ->
       loop ~depth expr;
       ignore_int offset
-    | Ulet (_let_kind, _value_kind, var, def, body) ->
+    | Ulet (_let_kind, _layout, var, def, body) ->
       add_definition t (VP.var var) depth;
       loop ~depth def;
       loop ~depth body
@@ -200,9 +200,9 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
       ignore_int static_exn;
       List.iter (loop ~depth) args
     | Ucatch (static_exn, vars, body, handler, kind) ->
-      ignore_value_kind kind;
+      ignore_layout kind;
       ignore_int static_exn;
-      ignore_params_with_value_kind vars;
+      ignore_params_with_layout vars;
       loop ~depth body;
       loop ~depth handler
     | Utrywith (body, var, handler, _kind) ->
@@ -325,8 +325,8 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
       (* Start a new let stack for speed. *)
       List.iter (fun {Clambda. label; arity=_; params; return; body; dbg; env; mode=_; poll=_} ->
           ignore_function_label label;
-          ignore_params_with_value_kind params;
-          ignore_value_kind return;
+          ignore_params_with_layout params;
+          ignore_layout return;
           let_stack := [];
           loop body;
           let_stack := [];
@@ -337,7 +337,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
       (* [expr] should usually be a variable. *)
       examine_argument_list [expr];
       ignore_int offset
-    | Ulet (_let_kind, _value_kind, var, def, body) ->
+    | Ulet (_let_kind, _layout, var, def, body) ->
       let var = VP.var var in
       begin match def with
       | Uconst _ ->
@@ -389,7 +389,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
           loop action)
         us_actions_blocks;
       ignore_debuginfo dbg;
-      ignore_value_kind kind;
+      ignore_layout kind;
       let_stack := []
     | Ustringswitch (cond, branches, default, kind) ->
       examine_argument_list [cond];
@@ -400,15 +400,15 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
         branches;
       let_stack := [];
       Option.iter loop default;
-      ignore_value_kind kind;
+      ignore_layout kind;
       let_stack := []
     | Ustaticfail (static_exn, args) ->
       ignore_int static_exn;
       examine_argument_list args
     | Ucatch (static_exn, vars, body, handler, kind) ->
-      ignore_value_kind kind;
+      ignore_layout kind;
       ignore_int static_exn;
-      ignore_params_with_value_kind vars;
+      ignore_params_with_layout vars;
       let_stack := [];
       loop body;
       let_stack := [];
@@ -420,7 +420,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
       let_stack := [];
       ignore_var_with_provenance var;
       loop handler;
-      ignore_value_kind kind;
+      ignore_layout kind;
       let_stack := []
     | Uifthenelse (cond, ifso, ifnot, kind) ->
       examine_argument_list [cond];
@@ -428,7 +428,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
       loop ifso;
       let_stack := [];
       loop ifnot;
-      ignore_value_kind kind;
+      ignore_layout kind;
       let_stack := []
     | Usequence (e1, e2) ->
       loop e1;
@@ -519,7 +519,7 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
   | Uoffset (clam, n) ->
     let clam = substitute_let_moveable is_let_moveable env clam in
     Uoffset (clam, n)
-  | Ulet (let_kind, value_kind, var, def, body) ->
+  | Ulet (let_kind, layout, var, def, body) ->
     let def = substitute_let_moveable is_let_moveable env def in
     if V.Set.mem (VP.var var) is_let_moveable then
       let env = V.Map.add (VP.var var) def env in
@@ -539,7 +539,7 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
         | _ ->
           Uphantom_let (var, None, body)
     else
-      Ulet (let_kind, value_kind,
+      Ulet (let_kind, layout,
             var, def, substitute_let_moveable is_let_moveable env body)
   | Uphantom_let (var, defining_expr, body) ->
     let body = substitute_let_moveable is_let_moveable env body in
@@ -717,10 +717,10 @@ let rec un_anf_and_moveable var_info env (clam : Clambda.ulambda)
   | Uoffset (clam, n) ->
     let clam, moveable = un_anf_and_moveable var_info env clam in
     Uoffset (clam, n), both_moveable Moveable moveable
-  | Ulet (_let_kind, _value_kind, var, def, Uvar var')
+  | Ulet (_let_kind, _layout, var, def, Uvar var')
       when V.same (VP.var var) var' ->
     un_anf_and_moveable var_info env def
-  | Ulet (let_kind, value_kind, var, def, body) ->
+  | Ulet (let_kind, layout, var, def, body) ->
     let def, def_moveable = un_anf_and_moveable var_info env def in
     let is_linear = V.Set.mem (VP.var var) var_info.linear_let_bound_vars in
     let is_used = V.Set.mem (VP.var var) var_info.used_let_bound_vars in
@@ -769,7 +769,7 @@ let rec un_anf_and_moveable var_info env (clam : Clambda.ulambda)
         (* Moveable but not used linearly. *)
     | Fixed, _, _, _ ->
       let body, body_moveable = un_anf_and_moveable var_info env body in
-      Ulet (let_kind, value_kind, var, def, body),
+      Ulet (let_kind, layout, var, def, body),
       both_moveable def_moveable body_moveable
     end
   | Uphantom_let (var, defining_expr, body) ->

--- a/ocaml/middle_end/printclambda.ml
+++ b/ocaml/middle_end/printclambda.ml
@@ -51,6 +51,7 @@ let rec value_kind0 ppf kind =
       non_consts
 
 let value_kind kind = Format.asprintf "%a" value_kind0 kind
+let layout (Lambda.Pvalue kind) = value_kind kind
 
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x
@@ -81,11 +82,11 @@ and one_fun ppf f =
       (fun (x, k) ->
          fprintf ppf "@ %a%a"
            VP.print x
-           Printlambda.value_kind k
+           Printlambda.layout k
       )
   in
   fprintf ppf "(fun@ %s%s@ %d@ @[<2>%a@]@ @[<2>%a@])"
-    f.label (value_kind f.return) (snd f.arity) idents f.params lam f.body
+    f.label (layout f.return) (snd f.arity) idents f.params lam f.body
 
 and phantom_defining_expr ppf = function
   | Uphantom_const const -> uconstant ppf const
@@ -149,12 +150,12 @@ and lam ppf = function
         | Ulet(mut, kind, id, arg, body) ->
             fprintf ppf "@ @[<2>%a%s%s@ %a@]"
               VP.print id
-              (mutable_flag mut) (value_kind kind) lam arg;
+              (mutable_flag mut) (layout kind) lam arg;
             letbody body
         | _ -> ul in
       fprintf ppf "@[<2>(let@ @[<hv 1>(@[<2>%a%s%s@ %a@]"
         VP.print id (mutable_flag mut)
-          (value_kind kind) lam arg;
+          (layout kind) lam arg;
       let expr = letbody body in
       fprintf ppf ")@]@ %a)@]" lam expr
   | Uphantom_let (id, defining_expr, body) ->
@@ -233,7 +234,7 @@ and lam ppf = function
              (fun (x, k) ->
                 fprintf ppf " %a%a"
                  VP.print x
-                 Printlambda.value_kind k
+                 Printlambda.layout k
              )
              vars
         )

--- a/ocaml/toplevel/native/topeval.ml
+++ b/ocaml/toplevel/native/topeval.ml
@@ -62,7 +62,7 @@ let close_phrase lam =
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in
-    Llet(Strict, Pgenval, id, glob, l)
+    Llet(Strict, Lambda.layout_top, id, glob, l)
   ) (free_variables lam) lam
 
 let toplevel_value id =

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -359,10 +359,12 @@ let value_kind env ty =
   in
   value_kind
 
-let function_return_value_kind env ty =
+let layout env ty = Lambda.Pvalue (value_kind env ty)
+
+let function_return_layout env ty =
   match is_function_type env ty with
-  | Some (_lhs, rhs) -> value_kind env rhs
-  | None -> Pgenval
+  | Some (_lhs, rhs) -> layout env rhs
+  | None -> Lambda.layout_top
 
 (** Whether a forward block is needed for a lazy thunk on a value, i.e.
     if the value can be represented as a float/forward/lazy *)
@@ -401,3 +403,6 @@ let classify_lazy_argument : Typedtree.expression ->
 let value_kind_union (k1 : Lambda.value_kind) (k2 : Lambda.value_kind) =
   if Lambda.equal_value_kind k1 k2 then k1
   else Pgenval
+
+let layout_union (Pvalue layout1) (Pvalue layout2) =
+  Pvalue (value_kind_union layout1 layout2)

--- a/ocaml/typing/typeopt.mli
+++ b/ocaml/typing/typeopt.mli
@@ -28,8 +28,8 @@ val array_kind : Typedtree.expression -> Lambda.array_kind
 val array_pattern_kind : Typedtree.pattern -> Lambda.array_kind
 val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
-val value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
-val function_return_value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
+val layout : Env.t -> Types.type_expr -> Lambda.layout
+val function_return_layout : Env.t -> Types.type_expr -> Lambda.layout
 
 val classify_lazy_argument : Typedtree.expression ->
                              [ `Constant_or_function
@@ -37,7 +37,7 @@ val classify_lazy_argument : Typedtree.expression ->
                              | `Identifier of [`Forward_value | `Other]
                              | `Other]
 
-val value_kind_union :
-      Lambda.value_kind -> Lambda.value_kind -> Lambda.value_kind
-  (** [value_kind_union k1 k2] is a value_kind at least as general as
-      [k1] and [k2] *)
+val layout_union :
+      Lambda.layout -> Lambda.layout -> Lambda.layout
+  (** [layout_union layout1 layout2] is a layout at least as general as
+      [layout1] and [layout2] *)


### PR DESCRIPTION
For now, we simply have the type `type layout = Pvalue of value_kind`, to prepare for the addition of layouts everywhere. Besides, this also adds several pre-defined layouts (often equal to `Pvalue Pgenval`), so that we know why `Pgenval` was used, for instance whether it was a true `top` value or whether it was the kind of a function.

There are quite a number of `layout_top` instances, which will need to be removed with further PRs, as there is no `top` layout once we start getting non-value layouts. Hopefully, this PR is the one with the most global effect, and other PRs can start cleaning the code with a smaller scope at a time.

I'd especially like reviews concerning the `translmod`, `translobj` and `translclass` files, where there were a lot of instances of `Pgenval`, and I was unsure how to categorize a lot of them (so they ended up as `layout_top`).