### PR TITLE
Use Import_info.t in Cmt_format

### DIFF
--- a/ocaml/file_formats/cmt_format.ml
+++ b/ocaml/file_formats/cmt_format.ml
@@ -181,9 +181,9 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi shape =
            Compilation_unit.Name.compare modname1 modname2
          in
          let get_imports () =
-           Env.imports ()
-           |> List.sort compare_imports
-           |> Array.of_list
+           let imports = Array.of_list (Env.imports ()) in
+           Array.sort compare_imports imports;
+           imports
          in
          let cmt = {
            cmt_modname = modname;

--- a/ocaml/file_formats/cmt_format.ml
+++ b/ocaml/file_formats/cmt_format.ml
@@ -45,9 +45,6 @@ and binary_part =
 | Partial_signature_item of signature_item
 | Partial_module_type of module_type
 
-type import_info =
-  (Compilation_unit.Name.t * (Compilation_unit.t * Digest.t) option)
-
 type cmt_infos = {
   cmt_modname : Compilation_unit.t;
   cmt_annots : binary_annots;
@@ -60,7 +57,7 @@ type cmt_infos = {
   cmt_loadpath : string list;
   cmt_source_digest : Digest.t option;
   cmt_initial_env : Env.t;
-  cmt_imports : import_info list;
+  cmt_imports : Import_info.t array;
   cmt_interface_digest : Digest.t option;
   cmt_use_summaries : bool;
   cmt_uid_to_loc : Location.t Shape.Uid.Tbl.t;
@@ -178,15 +175,15 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi shape =
            | Some cmi -> Some (output_cmi temp_file_name oc cmi)
          in
          let source_digest = Option.map Digest.file sourcefile in
+         let compare_imports import1 import2 =
+           let modname1 = Import_info.name import1 in
+           let modname2 = Import_info.name import2 in
+           Compilation_unit.Name.compare modname1 modname2
+         in
          let get_imports () =
            Env.imports ()
-           |> List.map (fun import ->
-                let name = Import_info.name import in
-                let crc_with_unit = Import_info.crc_with_unit import in
-                name, crc_with_unit)
-         in
-         let compare_imports (modname1, _crc1) (modname2, _crc2) =
-           Compilation_unit.Name.compare modname1 modname2
+           |> List.sort compare_imports
+           |> Array.of_list
          in
          let cmt = {
            cmt_modname = modname;
@@ -200,7 +197,7 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi shape =
            cmt_source_digest = source_digest;
            cmt_initial_env = if need_to_clear_env then
                keep_only_summary initial_env else initial_env;
-           cmt_imports = List.sort compare_imports (get_imports ());
+           cmt_imports = get_imports ();
            cmt_interface_digest = this_crc;
            cmt_use_summaries = need_to_clear_env;
            cmt_uid_to_loc = Env.get_uid_to_loc_tbl ();

--- a/ocaml/file_formats/cmt_format.mli
+++ b/ocaml/file_formats/cmt_format.mli
@@ -48,11 +48,6 @@ and binary_part =
   | Partial_signature_item of signature_item
   | Partial_module_type of module_type
 
-(* CR mshinwell: this should be removed in favour of [Import_info.t],
-   but will require a new Merlin *)
-type import_info =
-  (Compilation_unit.Name.t * (Compilation_unit.t * Digest.t) option)
-
 type cmt_infos = {
   cmt_modname : Compilation_unit.t;
   cmt_annots : binary_annots;
@@ -65,7 +60,7 @@ type cmt_infos = {
   cmt_loadpath : string list;
   cmt_source_digest : string option;
   cmt_initial_env : Env.t;
-  cmt_imports : import_info list;
+  cmt_imports : Import_info.t array;
   cmt_interface_digest : Digest.t option;
   cmt_use_summaries : bool;
   cmt_uid_to_loc : Location.t Shape.Uid.Tbl.t;

--- a/ocaml/tools/objinfo.ml
+++ b/ocaml/tools/objinfo.ml
@@ -70,10 +70,6 @@ let print_impl_import import =
   let crco = Import_info.crc import in
   print_name_crc (Compilation_unit.name unit) crco
 
-let print_old_intf_import (name, data) =
-  let crco = data |> Option.map (fun (_unit, crc) -> crc) in
-  print_name_crc name crco
-
 let print_line name =
   printf "\t%s\n" name
 
@@ -123,7 +119,7 @@ let print_cmt_infos cmt =
   let open Cmt_format in
   printf "Cmt unit name: %a\n" Compilation_unit.output cmt.cmt_modname;
   print_string "Cmt interfaces imported:\n";
-  List.iter print_old_intf_import cmt.cmt_imports;
+  Array.iter print_intf_import cmt.cmt_imports;
   printf "Source file: %s\n"
          (match cmt.cmt_sourcefile with None -> "(none)" | Some f -> f);
   printf "Compilation flags:";

--- a/ocaml/tools/ocamlcmt.ml
+++ b/ocaml/tools/ocamlcmt.ml
@@ -86,11 +86,13 @@ let print_info cmt =
     Compilation_unit.Name.compare name1 name2
   in
   let imports =
-    cmt.cmt_imports
-    |> Array.to_list
-    |> List.map (fun import ->
-         Import_info.name import, Import_info.crc_with_unit import)
-    |> List.sort compare_imports
+    let imports =
+      Array.map (fun import ->
+          Import_info.name import, Import_info.crc_with_unit import)
+        cmt.cmt_imports
+    in
+    Array.sort compare_imports imports;
+    Array.to_list imports
   in
   List.iter (fun (name, crco) ->
     let crc =

--- a/ocaml/tools/ocamlcmt.ml
+++ b/ocaml/tools/ocamlcmt.ml
@@ -85,6 +85,13 @@ let print_info cmt =
   let compare_imports (name1, _crco1) (name2, _crco2) =
     Compilation_unit.Name.compare name1 name2
   in
+  let imports =
+    cmt.cmt_imports
+    |> Array.to_list
+    |> List.map (fun import ->
+         Import_info.name import, Import_info.crc_with_unit import)
+    |> List.sort compare_imports
+  in
   List.iter (fun (name, crco) ->
     let crc =
       match crco with
@@ -92,7 +99,7 @@ let print_info cmt =
       | Some (_unit, crc) -> Digest.to_hex crc
     in
     Printf.fprintf oc "import: %a %s\n" Compilation_unit.Name.output name crc;
-  ) (List.sort compare_imports cmt.cmt_imports);
+  ) imports;
   Printf.fprintf oc "%!";
   begin match !target_filename with
   | None -> ()

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -78,10 +78,6 @@ let print_impl_import import =
   let crco = Import_info.crc import in
   print_name_crc (Compilation_unit.name unit) crco
 
-let print_old_intf_import (name, data) =
-  let crco = data |> Option.map (fun (_unit, crc) -> crc) in
-  print_name_crc name crco
-
 let print_line name = printf "\t%s\n" name
 
 let print_name_line cu =
@@ -128,7 +124,7 @@ let print_cmt_infos cmt =
   let open Cmt_format in
   printf "Cmt unit name: %a\n" Compilation_unit.output cmt.cmt_modname;
   print_string "Cmt interfaces imported:\n";
-  List.iter print_old_intf_import cmt.cmt_imports;
+  Array.iter print_intf_import cmt.cmt_imports;
   printf "Source file: %s\n"
     (match cmt.cmt_sourcefile with None -> "(none)" | Some f -> f);
   printf "Compilation flags:";


### PR DESCRIPTION
This is a follow-on to #1036.  It uses the new `Import_info.t` arrays in `Cmt_format`.

This change will need a new Merlin.  cc @antalsz (note there are new files `ocaml/utils/import_info.ml{,i}`)