### PR TITLE
Check for -save-ir-after simplify_cfg without -ocamlcfg flag

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -154,6 +154,8 @@ let write_ir prefix =
     Linear_format.save filename linear_unit_info
   end;
   if should_save_cfg_before_emit () then begin
+    if not !Flambda_backend_flags.use_ocamlcfg then
+      Misc.fatal_error "Flag '-save-ir-after simplify_cfg' requires '-ocamlcfg'";
     let filename = Compiler_pass.(to_output_filename Simplify_cfg ~prefix) in
     cfg_unit_info.items <- List.rev cfg_unit_info.items;
     Cfg_format.save filename cfg_unit_info


### PR DESCRIPTION
Minor bug fix. If `-save-ir-after simplify_cfg` flag is passed without `-ocamlcfg` flag, the compiler would generate an invalid `*.cmir-cfg` file that has data but no code and a cascade of linker errors for all function symbols to be `undefined`.  

The fix is just a fatal error instead of a proper user error because these flags are intended to be added by the build system (but I'm happy to fix it if anyone feels strongly that it should be a user error).

The fix is not in argument parsing because `-save-ir-after` is handled in `ocaml/` subfolder.

