### PR TITLE
Revert "Use Import_info.t in Cmt_format"

### DIFF
--- a/ocaml/file_formats/cmt_format.ml
+++ b/ocaml/file_formats/cmt_format.ml
@@ -45,6 +45,9 @@ and binary_part =
 | Partial_signature_item of signature_item
 | Partial_module_type of module_type
 
+type import_info =
+  (Compilation_unit.Name.t * (Compilation_unit.t * Digest.t) option)
+
 type cmt_infos = {
   cmt_modname : Compilation_unit.t;
   cmt_annots : binary_annots;
@@ -57,7 +60,7 @@ type cmt_infos = {
   cmt_loadpath : string list;
   cmt_source_digest : Digest.t option;
   cmt_initial_env : Env.t;
-  cmt_imports : Import_info.t array;
+  cmt_imports : import_info list;
   cmt_interface_digest : Digest.t option;
   cmt_use_summaries : bool;
   cmt_uid_to_loc : Location.t Shape.Uid.Tbl.t;
@@ -175,15 +178,15 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi shape =
            | Some cmi -> Some (output_cmi temp_file_name oc cmi)
          in
          let source_digest = Option.map Digest.file sourcefile in
-         let compare_imports import1 import2 =
-           let modname1 = Import_info.name import1 in
-           let modname2 = Import_info.name import2 in
-           Compilation_unit.Name.compare modname1 modname2
-         in
          let get_imports () =
-           let imports = Array.of_list (Env.imports ()) in
-           Array.sort compare_imports imports;
-           imports
+           Env.imports ()
+           |> List.map (fun import ->
+                let name = Import_info.name import in
+                let crc_with_unit = Import_info.crc_with_unit import in
+                name, crc_with_unit)
+         in
+         let compare_imports (modname1, _crc1) (modname2, _crc2) =
+           Compilation_unit.Name.compare modname1 modname2
          in
          let cmt = {
            cmt_modname = modname;
@@ -197,7 +200,7 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi shape =
            cmt_source_digest = source_digest;
            cmt_initial_env = if need_to_clear_env then
                keep_only_summary initial_env else initial_env;
-           cmt_imports = get_imports ();
+           cmt_imports = List.sort compare_imports (get_imports ());
            cmt_interface_digest = this_crc;
            cmt_use_summaries = need_to_clear_env;
            cmt_uid_to_loc = Env.get_uid_to_loc_tbl ();

--- a/ocaml/file_formats/cmt_format.mli
+++ b/ocaml/file_formats/cmt_format.mli
@@ -48,6 +48,11 @@ and binary_part =
   | Partial_signature_item of signature_item
   | Partial_module_type of module_type
 
+(* CR mshinwell: this should be removed in favour of [Import_info.t],
+   but will require a new Merlin *)
+type import_info =
+  (Compilation_unit.Name.t * (Compilation_unit.t * Digest.t) option)
+
 type cmt_infos = {
   cmt_modname : Compilation_unit.t;
   cmt_annots : binary_annots;
@@ -60,7 +65,7 @@ type cmt_infos = {
   cmt_loadpath : string list;
   cmt_source_digest : string option;
   cmt_initial_env : Env.t;
-  cmt_imports : Import_info.t array;
+  cmt_imports : import_info list;
   cmt_interface_digest : Digest.t option;
   cmt_use_summaries : bool;
   cmt_uid_to_loc : Location.t Shape.Uid.Tbl.t;

--- a/ocaml/tools/objinfo.ml
+++ b/ocaml/tools/objinfo.ml
@@ -70,6 +70,10 @@ let print_impl_import import =
   let crco = Import_info.crc import in
   print_name_crc (Compilation_unit.name unit) crco
 
+let print_old_intf_import (name, data) =
+  let crco = data |> Option.map (fun (_unit, crc) -> crc) in
+  print_name_crc name crco
+
 let print_line name =
   printf "\t%s\n" name
 
@@ -119,7 +123,7 @@ let print_cmt_infos cmt =
   let open Cmt_format in
   printf "Cmt unit name: %a\n" Compilation_unit.output cmt.cmt_modname;
   print_string "Cmt interfaces imported:\n";
-  Array.iter print_intf_import cmt.cmt_imports;
+  List.iter print_old_intf_import cmt.cmt_imports;
   printf "Source file: %s\n"
          (match cmt.cmt_sourcefile with None -> "(none)" | Some f -> f);
   printf "Compilation flags:";

--- a/ocaml/tools/ocamlcmt.ml
+++ b/ocaml/tools/ocamlcmt.ml
@@ -85,15 +85,6 @@ let print_info cmt =
   let compare_imports (name1, _crco1) (name2, _crco2) =
     Compilation_unit.Name.compare name1 name2
   in
-  let imports =
-    let imports =
-      Array.map (fun import ->
-          Import_info.name import, Import_info.crc_with_unit import)
-        cmt.cmt_imports
-    in
-    Array.sort compare_imports imports;
-    Array.to_list imports
-  in
   List.iter (fun (name, crco) ->
     let crc =
       match crco with
@@ -101,7 +92,7 @@ let print_info cmt =
       | Some (_unit, crc) -> Digest.to_hex crc
     in
     Printf.fprintf oc "import: %a %s\n" Compilation_unit.Name.output name crc;
-  ) imports;
+  ) (List.sort compare_imports cmt.cmt_imports);
   Printf.fprintf oc "%!";
   begin match !target_filename with
   | None -> ()

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -78,6 +78,10 @@ let print_impl_import import =
   let crco = Import_info.crc import in
   print_name_crc (Compilation_unit.name unit) crco
 
+let print_old_intf_import (name, data) =
+  let crco = data |> Option.map (fun (_unit, crc) -> crc) in
+  print_name_crc name crco
+
 let print_line name = printf "\t%s\n" name
 
 let print_name_line cu =
@@ -124,7 +128,7 @@ let print_cmt_infos cmt =
   let open Cmt_format in
   printf "Cmt unit name: %a\n" Compilation_unit.output cmt.cmt_modname;
   print_string "Cmt interfaces imported:\n";
-  Array.iter print_intf_import cmt.cmt_imports;
+  List.iter print_old_intf_import cmt.cmt_imports;
   printf "Source file: %s\n"
     (match cmt.cmt_sourcefile with None -> "(none)" | Some f -> f);
   printf "Compilation flags:";


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#1037

I'm temporarily reverting this so another release can be tagged without needing to upgrade Merlin.