### PR TITLE
Revert "Boxing operations factorisation in from_lambda"

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -361,13 +361,13 @@ let close_c_call acc env ~loc ~let_bound_var
        prim_native_repr_res
      } :
       Primitive.description) ~(args : Simple.t list) exn_continuation dbg
-    ~current_region (k : Acc.t -> Env.t -> Named.t option -> Expr_with_acc.t) :
+    ~current_region (k : Acc.t -> Named.t option -> Expr_with_acc.t) :
     Expr_with_acc.t =
   (* We always replace the original let-binding with an Flambda expression, so
      we call [k] with [None], to get just the closure-converted body of that
      binding. *)
   let cost_metrics_of_body, free_names_of_body, acc, body =
-    Acc.measure_cost_metrics acc ~f:(fun acc -> k acc env None)
+    Acc.measure_cost_metrics acc ~f:(fun acc -> k acc None)
   in
   let box_return_value =
     match prim_native_repr_res with
@@ -563,8 +563,7 @@ let close_exn_continuation acc env (exn_continuation : IR.exn_continuation) =
 
 let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
     loc (exn_continuation : IR.exn_continuation option) ~current_region
-    (k : Acc.t -> Env.t -> Named.t option -> Expr_with_acc.t) : Expr_with_acc.t
-    =
+    (k : Acc.t -> Named.t option -> Expr_with_acc.t) : Expr_with_acc.t =
   let acc, exn_continuation =
     match exn_continuation with
     | None -> acc, None
@@ -595,14 +594,14 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
     in
     let acc, simple = use_of_symbol_as_simple acc symbol in
     let named = Named.create_simple simple in
-    k acc env (Some named)
+    k acc (Some named)
   | Pgetpredef id, [] ->
     let symbol =
       Flambda2_import.Symbol.for_predef_ident id |> Symbol.create_wrapped
     in
     let acc, simple = use_of_symbol_as_simple acc symbol in
     let named = Named.create_simple simple in
-    k acc env (Some named)
+    k acc (Some named)
   | Praise raise_kind, [_] ->
     let exn_continuation =
       match exn_continuation with
@@ -672,10 +671,10 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
         (* Inconsistent with outer match *)
         assert false
     in
-    k acc env (Some (Named.create_simple (Simple.symbol sym)))
+    k acc (Some (Named.create_simple (Simple.symbol sym)))
   | prim, args ->
-    Lambda_to_flambda_primitives.convert_and_bind acc env ~let_bound_var
-      exn_continuation ~big_endian:(Env.big_endian env)
+    Lambda_to_flambda_primitives.convert_and_bind acc exn_continuation
+      ~big_endian:(Env.big_endian env)
       ~register_const_string:(fun acc -> register_const_string acc)
       prim ~args dbg ~current_region k
 
@@ -688,26 +687,25 @@ let close_trap_action_opt trap_action =
     trap_action
 
 let close_named acc env ~let_bound_var (named : IR.named)
-    (k : Acc.t -> Env.t -> Named.t option -> Expr_with_acc.t) : Expr_with_acc.t
-    =
+    (k : Acc.t -> Named.t option -> Expr_with_acc.t) : Expr_with_acc.t =
   match named with
   | Simple (Var id) ->
     assert (not (Ident.is_global_or_predef id));
     let acc, simple = find_simple acc env (Var id) in
     let named = Named.create_simple simple in
-    k acc env (Some named)
+    k acc (Some named)
   | Simple (Const cst) ->
     let acc, named, _name = close_const acc cst in
-    k acc env (Some named)
+    k acc (Some named)
   | Get_tag var ->
     let named = find_simple_from_id env var in
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
       Unary (Tag_immediate, Prim (Unary (Get_tag, Simple named)))
     in
-    Lambda_to_flambda_primitives_helpers.bind_rec acc env None
+    Lambda_to_flambda_primitives_helpers.bind_rec acc None
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
-      (fun acc env named -> k acc env (Some named))
+      (fun acc named -> k acc (Some named))
   | Begin_region { try_region_parent } ->
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
       match try_region_parent with
@@ -716,19 +714,19 @@ let close_named acc env ~let_bound_var (named : IR.named)
         let try_region_parent = find_simple_from_id env try_region_parent in
         Unary (Begin_try_region, Simple try_region_parent)
     in
-    Lambda_to_flambda_primitives_helpers.bind_rec acc env None
+    Lambda_to_flambda_primitives_helpers.bind_rec acc None
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
-      (fun acc env named -> k acc env (Some named))
+      (fun acc named -> k acc (Some named))
   | End_region id ->
     let named = find_simple_from_id env id in
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
       Unary (End_region, Simple named)
     in
-    Lambda_to_flambda_primitives_helpers.bind_rec acc env None
+    Lambda_to_flambda_primitives_helpers.bind_rec acc None
       ~register_const_string:(fun acc -> register_const_string acc)
       prim Debuginfo.none
-      (fun acc env named -> k acc env (Some named))
+      (fun acc named -> k acc (Some named))
   | Prim { prim; args; loc; exn_continuation; region } ->
     close_primitive acc env ~let_bound_var named prim ~args loc exn_continuation
       ~current_region:(fst (Env.find_var env region))
@@ -736,21 +734,19 @@ let close_named acc env ~let_bound_var (named : IR.named)
 
 let close_let acc env id user_visible kind defining_expr
     ~(body : Acc.t -> Env.t -> Expr_with_acc.t) : Expr_with_acc.t =
-  (* CR keryan : We can avoid having the bound variable in the environment of
-     the defining expression but it should not appear there anyway *)
-  let env, var = Env.add_var_like env id user_visible kind in
-  let cont acc env (defining_expr : Named.t option) =
+  let body_env, var = Env.add_var_like env id user_visible kind in
+  let cont acc (defining_expr : Named.t option) =
     match defining_expr with
     | Some (Simple simple) ->
       let body_env = Env.add_simple_to_substitute env id simple kind in
       body acc body_env
-    | None -> body acc env
+    | None -> body acc body_env
     | Some (Prim ((Nullary Begin_region | Unary (End_region, _)), _))
       when not (Flambda_features.stack_allocation_enabled ()) ->
       (* We use [body_env] to ensure the region variables are still in the
          environment, to avoid lookup errors, even though the [Let] won't be
          generated. *)
-      body acc env
+      body acc body_env
     | Some defining_expr -> (
       let body_env =
         match defining_expr with
@@ -759,17 +755,17 @@ let close_let acc env id user_visible kind defining_expr
             List.map
               (fun field ->
                 match Simple.must_be_symbol field with
-                | None -> Env.find_value_approximation env field
+                | None -> Env.find_value_approximation body_env field
                 | Some (sym, _) -> Value_approximation.Value_symbol sym)
               fields
             |> Array.of_list
           in
           Some
-            (Env.add_block_approximation env (Name.var var) approxs
+            (Env.add_block_approximation body_env (Name.var var) approxs
                (Alloc_mode.For_allocations.as_type alloc_mode))
         | Prim (Binary (Block_load _, block, field), _) -> (
-          match Env.find_value_approximation env block with
-          | Value_unknown -> Some env
+          match Env.find_value_approximation body_env block with
+          | Value_unknown -> Some body_env
           | Closure_approximation _ | Value_symbol _ | Value_int _ ->
             (* Here we assume [block] has already been substituted as a known
                symbol if it exists, and rely on the invariant that the
@@ -808,9 +804,10 @@ let close_let acc env id user_visible kind defining_expr
                  let-binding later. *)
               Some
                 (Env.add_simple_to_substitute env id (Simple.symbol sym) kind)
-            | _ -> Some (Env.add_value_approximation env (Name.var var) approx))
+            | _ ->
+              Some (Env.add_value_approximation body_env (Name.var var) approx))
           )
-        | _ -> Some env
+        | _ -> Some body_env
       in
       let var = VB.create var Name_mode.normal in
       let bound_pattern = Bound_pattern.singleton var in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -130,16 +130,11 @@ end
 module Env = struct
   type value_approximation = Code_or_metadata.t Value_approximation.t
 
-  type boxing =
-    | Boxed_from of Name.t
-    | Unboxed_from of Name.t
-
   type t =
     { variables : (Variable.t * Flambda_kind.With_subkind.t) Ident.Map.t;
       globals : Symbol.t Numeric_types.Int.Map.t;
       simples_to_substitute :
         (Simple.t * Flambda_kind.With_subkind.t) Ident.Map.t;
-      box_mapping : boxing Name.Map.t;
       current_unit : Compilation_unit.t;
       current_depth : Variable.t option;
       value_approximations : value_approximation Name.Map.t;
@@ -209,7 +204,6 @@ module Env = struct
     { variables = Ident.Map.empty;
       globals = Numeric_types.Int.Map.empty;
       simples_to_substitute = Ident.Map.empty;
-      box_mapping = Name.Map.empty;
       current_unit;
       current_depth = None;
       value_approximations = Name.Map.empty;
@@ -226,7 +220,6 @@ module Env = struct
       { variables = _;
         globals;
         simples_to_substitute;
-        box_mapping = _;
         current_unit;
         current_depth;
         value_approximations;
@@ -243,7 +236,6 @@ module Env = struct
     { variables = Ident.Map.empty;
       globals;
       simples_to_substitute;
-      box_mapping = Name.Map.empty;
       current_unit;
       current_depth;
       value_approximations;
@@ -329,23 +321,6 @@ module Env = struct
 
   let find_simple_to_substitute_exn t id =
     Ident.Map.find id t.simples_to_substitute
-
-  let add_boxing_pair t ~unboxed ~boxed =
-    let box_mapping =
-      Name.Map.add boxed (Boxed_from unboxed) t.box_mapping
-      |> Name.Map.add unboxed (Unboxed_from boxed)
-    in
-    { t with box_mapping }
-
-  let find_boxed_of t name =
-    match Name.Map.find name t.box_mapping with
-    | Unboxed_from n -> n
-    | Boxed_from _ -> name
-
-  let find_unboxed_of t name =
-    match Name.Map.find name t.box_mapping with
-    | Boxed_from n -> n
-    | Unboxed_from _ -> name
 
   let add_value_approximation t name approx =
     if Value_approximation.is_unknown approx

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -148,12 +148,6 @@ module Env : sig
   val find_simple_to_substitute_exn :
     t -> Ident.t -> Simple.t * Flambda_kind.With_subkind.t
 
-  val add_boxing_pair : t -> unboxed:Name.t -> boxed:Name.t -> t
-
-  val find_boxed_of : t -> Name.t -> Name.t
-
-  val find_unboxed_of : t -> Name.t -> Name.t
-
   val add_value_approximation : t -> Name.t -> value_approximation -> t
 
   val add_block_approximation :

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1207,16 +1207,12 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
       Printlambda.primitive prim
 
 module Acc = Closure_conversion_aux.Acc
-module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
-let convert_and_bind acc env ~let_bound_var ~big_endian exn_cont
-    ~register_const_string (prim : L.primitive) ~(args : Simple.t list)
-    (dbg : Debuginfo.t) ~current_region
-    (cont : Acc.t -> Env.t -> Flambda.Named.t option -> Expr_with_acc.t) :
-    Expr_with_acc.t =
+let convert_and_bind acc ~big_endian exn_cont ~register_const_string
+    (prim : L.primitive) ~(args : Simple.t list) (dbg : Debuginfo.t)
+    ~current_region (cont : Acc.t -> Flambda.Named.t option -> Expr_with_acc.t)
+    : Expr_with_acc.t =
   let expr = convert_lprim ~big_endian prim args dbg ~current_region in
-  H.bind_rec acc env exn_cont ~register_const_string expr dbg
-    (fun acc env named ->
-      let env, named = H.simplify_boxing env ~bound_var:let_bound_var named in
-      cont acc env (Some named))
+  H.bind_rec acc exn_cont ~register_const_string expr dbg (fun acc named ->
+      cont acc (Some named))

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
@@ -15,13 +15,10 @@
 (**************************************************************************)
 
 module Acc = Closure_conversion_aux.Acc
-module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
 val convert_and_bind :
   Acc.t ->
-  Env.t ->
-  let_bound_var:Variable.t ->
   big_endian:bool ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->
@@ -29,5 +26,5 @@ val convert_and_bind :
   args:Simple.t list ->
   Debuginfo.t ->
   current_region:Variable.t ->
-  (Acc.t -> Env.t -> Flambda.Named.t option -> Expr_with_acc.t) ->
+  (Acc.t -> Flambda.Named.t option -> Expr_with_acc.t) ->
   Expr_with_acc.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -64,7 +64,7 @@ let rec print_expr_primitive ppf expr_primitive =
 let print_simple_or_prim ppf (simple_or_prim : simple_or_prim) =
   match simple_or_prim with
   | Simple simple -> Simple.print ppf simple
-  | Prim p -> print_expr_primitive ppf p
+  | Prim _ -> Format.pp_print_string ppf "<prim>"
 
 let print_list_of_simple_or_prim ppf simple_or_prim_list =
   Format.fprintf ppf "@[(%a)@]"
@@ -153,107 +153,64 @@ let expression_for_failure acc exn_cont ~register_const_string primitive dbg
     raise_exn_for_failure acc ~dbg exn_cont (Simple.var exn_bucket)
       (Some extra_let_binding)
 
-let simplify_boxing env ~bound_var (named : Named.t) =
-  match named with
-  | Prim (Unary (prim, arg), _) -> (
-    let arg_name arg =
-      Simple.pattern_match
-        ~name:(fun n ~coercion:_ -> n)
-        ~const:(fun _ ->
-          (* CR keryan : This is not true with un/tag operations, which could
-             also benefit from this in the futur *)
-          Misc.fatal_error
-            "Constant found on un/boxing operation, should have been lifted.")
-        arg
-    in
-    match prim with
-    | Unbox_number _ -> (
-      let arg = arg_name arg in
-      match Env.find_unboxed_of env arg with
-      | unboxed -> env, Named.create_simple (Simple.name unboxed)
-      | exception Not_found ->
-        let env =
-          Env.add_boxing_pair env ~boxed:arg ~unboxed:(Name.var bound_var)
-        in
-        env, named)
-    | Box_number _ -> (
-      let arg = arg_name arg in
-      match Env.find_boxed_of env arg with
-      | boxed -> env, Named.create_simple (Simple.name boxed)
-      | exception Not_found ->
-        let env =
-          Env.add_boxing_pair env ~unboxed:arg ~boxed:(Name.var bound_var)
-        in
-        env, named)
-    | Duplicate_block _ | Duplicate_array _ | Is_int _ | Get_tag | Array_length
-    | Bigarray_length _ | String_length _ | Int_as_pointer | Opaque_identity _
-    | Int_arith _ | Float_arith _ | Num_conv _ | Boolean_not
-    | Reinterpret_int64_as_float | Untag_immediate | Tag_immediate
-    | Project_function_slot _ | Project_value_slot _ | Is_boxed_float
-    | Is_flat_float_array | Begin_try_region | End_region | Obj_dup ->
-      env, named)
-  | Prim ((Nullary _ | Binary _ | Ternary _ | Variadic _), _)
-  | Simple _ | Set_of_closures _ | Static_consts _ | Rec_info _ ->
-    env, named
-
-let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
-    (dbg : Debuginfo.t) (cont : Acc.t -> Env.t -> Named.t -> Expr_with_acc.t) :
+let rec bind_rec acc exn_cont ~register_const_string (prim : expr_primitive)
+    (dbg : Debuginfo.t) (cont : Acc.t -> Named.t -> Expr_with_acc.t) :
     Expr_with_acc.t =
   match prim with
   | Simple simple ->
     let named = Named.create_simple simple in
-    cont acc env named
+    cont acc named
   | Nullary prim ->
     let named = Named.create_prim (Nullary prim) dbg in
-    cont acc env named
+    cont acc named
   | Unary (prim, arg) ->
-    let cont acc env (arg : Simple.t) =
+    let cont acc (arg : Simple.t) =
       let named = Named.create_prim (Unary (prim, arg)) dbg in
-      cont acc env named
+      cont acc named
     in
-    bind_rec_primitive acc env exn_cont ~register_const_string arg dbg cont
+    bind_rec_primitive acc exn_cont ~register_const_string arg dbg cont
   | Binary (prim, arg1, arg2) ->
-    let cont acc env (arg2 : Simple.t) =
-      let cont acc env (arg1 : Simple.t) =
+    let cont acc (arg2 : Simple.t) =
+      let cont acc (arg1 : Simple.t) =
         let named = Named.create_prim (Binary (prim, arg1, arg2)) dbg in
-        cont acc env named
+        cont acc named
       in
-      bind_rec_primitive acc env exn_cont ~register_const_string arg1 dbg cont
+      bind_rec_primitive acc exn_cont ~register_const_string arg1 dbg cont
     in
-    bind_rec_primitive acc env exn_cont ~register_const_string arg2 dbg cont
+    bind_rec_primitive acc exn_cont ~register_const_string arg2 dbg cont
   | Ternary (prim, arg1, arg2, arg3) ->
-    let cont acc env (arg3 : Simple.t) =
-      let cont acc env (arg2 : Simple.t) =
-        let cont acc env (arg1 : Simple.t) =
+    let cont acc (arg3 : Simple.t) =
+      let cont acc (arg2 : Simple.t) =
+        let cont acc (arg1 : Simple.t) =
           let named =
             Named.create_prim (Ternary (prim, arg1, arg2, arg3)) dbg
           in
-          cont acc env named
+          cont acc named
         in
-        bind_rec_primitive acc env exn_cont ~register_const_string arg1 dbg cont
+        bind_rec_primitive acc exn_cont ~register_const_string arg1 dbg cont
       in
-      bind_rec_primitive acc env exn_cont ~register_const_string arg2 dbg cont
+      bind_rec_primitive acc exn_cont ~register_const_string arg2 dbg cont
     in
-    bind_rec_primitive acc env exn_cont ~register_const_string arg3 dbg cont
+    bind_rec_primitive acc exn_cont ~register_const_string arg3 dbg cont
   | Variadic (prim, args) ->
-    let cont acc env args =
+    let cont acc args =
       let named = Named.create_prim (Variadic (prim, args)) dbg in
-      cont acc env named
+      cont acc named
     in
-    let rec build_cont acc env args_to_convert converted_args =
+    let rec build_cont acc args_to_convert converted_args =
       match args_to_convert with
-      | [] -> cont acc env converted_args
+      | [] -> cont acc converted_args
       | arg :: args_to_convert ->
-        let cont acc env arg =
-          build_cont acc env args_to_convert (arg :: converted_args)
+        let cont acc arg =
+          build_cont acc args_to_convert (arg :: converted_args)
         in
-        bind_rec_primitive acc env exn_cont ~register_const_string arg dbg cont
+        bind_rec_primitive acc exn_cont ~register_const_string arg dbg cont
     in
-    build_cont acc env (List.rev args) []
+    build_cont acc (List.rev args) []
   | Checked { validity_conditions; primitive; failure; dbg } ->
     let primitive_cont = Continuation.create () in
     let primitive_handler_expr acc =
-      bind_rec acc env exn_cont ~register_const_string primitive dbg cont
+      bind_rec acc exn_cont ~register_const_string primitive dbg cont
     in
     let failure_cont = Continuation.create () in
     let failure_handler_expr acc =
@@ -269,8 +226,8 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
         (fun condition_passed_expr expr_primitive acc ->
           let condition_passed_cont = Continuation.create () in
           let body acc =
-            bind_rec_primitive acc env exn_cont ~register_const_string
-              (Prim expr_primitive) dbg (fun acc _env prim_result ->
+            bind_rec_primitive acc exn_cont ~register_const_string
+              (Prim expr_primitive) dbg (fun acc prim_result ->
                 let acc, condition_passed =
                   Apply_cont_with_acc.goto acc condition_passed_cont
                 in
@@ -309,8 +266,7 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
     let result_param =
       Bound_parameter.create result_var Flambda_kind.With_subkind.any_value
     in
-    bind_rec acc env exn_cont ~register_const_string cond dbg
-    @@ fun acc env cond ->
+    bind_rec acc exn_cont ~register_const_string cond dbg @@ fun acc cond ->
     let compute_cond_and_switch acc =
       let acc, ifso_cont = Apply_cont_with_acc.goto acc ifso_cont in
       let acc, ifnot_cont = Apply_cont_with_acc.goto acc ifnot_cont in
@@ -327,11 +283,10 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
         cond ~body:switch
     in
     let join_handler_expr acc =
-      cont acc env (Named.create_simple (Simple.var result_var))
+      cont acc (Named.create_simple (Simple.var result_var))
     in
     let ifso_handler_expr acc =
-      bind_rec acc env exn_cont ~register_const_string ifso dbg
-      @@ fun acc _env ifso ->
+      bind_rec acc exn_cont ~register_const_string ifso dbg @@ fun acc ifso ->
       let acc, apply_cont =
         Apply_cont_with_acc.create acc join_point_cont
           ~args:[Simple.var ifso_result]
@@ -343,8 +298,7 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
         ifso ~body
     in
     let ifnot_handler_expr acc =
-      bind_rec acc env exn_cont ~register_const_string ifnot dbg
-      @@ fun acc _env ifnot ->
+      bind_rec acc exn_cont ~register_const_string ifnot dbg @@ fun acc ifnot ->
       let acc, apply_cont =
         Apply_cont_with_acc.create acc join_point_cont
           ~args:[Simple.var ifnot_result]
@@ -369,20 +323,16 @@ let rec bind_rec acc env exn_cont ~register_const_string (prim : expr_primitive)
       ~handler_params:(Bound_parameters.create [result_param])
       ~handler:join_handler_expr ~body ~is_exn_handler:false
 
-and bind_rec_primitive acc env exn_cont ~register_const_string
+and bind_rec_primitive acc exn_cont ~register_const_string
     (prim : simple_or_prim) (dbg : Debuginfo.t)
-    (cont : Acc.t -> Env.t -> Simple.t -> Expr_with_acc.t) : Expr_with_acc.t =
+    (cont : Acc.t -> Simple.t -> Expr_with_acc.t) : Expr_with_acc.t =
   match prim with
-  | Simple s -> cont acc env s
+  | Simple s -> cont acc s
   | Prim p ->
-    let cont acc env named =
-      let bound_var = Variable.create "prim" in
-      let var' = VB.create bound_var Name_mode.normal in
-      let env, named = simplify_boxing env ~bound_var named in
-      match named with
-      | Simple s -> cont acc env s
-      | Prim _ | Set_of_closures _ | Static_consts _ | Rec_info _ ->
-        let acc, body = cont acc env (Simple.var bound_var) in
-        Let_with_acc.create acc (Bound_pattern.singleton var') named ~body
+    let var = Variable.create "prim" in
+    let var' = VB.create var Name_mode.normal in
+    let cont acc (named : Named.t) =
+      let acc, body = cont acc (Simple.var var) in
+      Let_with_acc.create acc (Bound_pattern.singleton var') named ~body
     in
-    bind_rec acc env exn_cont ~register_const_string p dbg cont
+    bind_rec acc exn_cont ~register_const_string p dbg cont

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -54,15 +54,11 @@ val print_list_of_simple_or_prim :
 
 open Closure_conversion_aux
 
-val simplify_boxing :
-  Env.t -> bound_var:Variable.t -> Flambda.Named.t -> Env.t * Flambda.Named.t
-
 val bind_rec :
   Acc.t ->
-  Env.t ->
   Exn_continuation.t option ->
   register_const_string:(Acc.t -> string -> Acc.t * Symbol.t) ->
   expr_primitive ->
   Debuginfo.t ->
-  (Acc.t -> Env.t -> Flambda.Named.t -> Expr_with_acc.t) ->
+  (Acc.t -> Flambda.Named.t -> Expr_with_acc.t) ->
   Expr_with_acc.t


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#776

As mentioned on Slack this hits the error on line 166 of `lambda_to_flambda_primitives_helpers.ml`.  I had only seen that error previously in classic mode, but it happens at `-O3` on `jstable.ml` from `js_of_ocaml`.