### PR TITLE
Fix ocamlobjinfo for cmx files and a bug with section handling

### DIFF
--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -160,8 +160,10 @@ let read_unit_info filename =
     end;
     let uir = (input_value ic : unit_infos_raw) in
     let first_section_offset = pos_in ic in
-    let sections = File_sections.create uir.uir_section_toc filename ic ~first_section_offset in
     seek_in ic (first_section_offset + uir.uir_sections_length);
+    let crc = Digest.input ic in
+    (* This consumes the channel *)
+    let sections = File_sections.create uir.uir_section_toc filename ic ~first_section_offset in
     let export_info =
       match uir.uir_export_info with
       | Clambda_raw info -> Clambda info
@@ -181,9 +183,6 @@ let read_unit_info filename =
       ui_force_link = uir.uir_force_link
     }
     in
-    let crc = Digest.input ic in
-    if Array.length uir.uir_section_toc = 0 then
-      close_in ic;
     (ui, crc)
   with End_of_file | Failure _ ->
     close_in ic;

--- a/utils/file_sections.ml
+++ b/utils/file_sections.ml
@@ -42,10 +42,12 @@ type t =
 (* For efficient concatenation *)
 
 let create section_toc file channel ~first_section_offset =
-  let channel = File_lru_cache.add_slot file channel file_lru in
   if Array.length section_toc = 0
-  then In_memory [||]
+  then (
+    close_in channel;
+    In_memory [||])
   else
+    let channel = File_lru_cache.add_slot file channel file_lru in
     let sections =
       Array.map
         (fun offset ->


### PR DESCRIPTION
This fixes the CR that was added for section reading, as well as fixing a couple of bugs:
- For files with sections, the CRC was read incorrectly as the beginning of the serialized code of the first section instead of what was after the sections
- This fixes that the input channel was closed twice by the section reading code if there were no sections at all, once directly after reading, and once when unloaded from the LRU cache.