### PR TITLE
Ensure that arms are merged iff the common alias is in required_names

### DIFF
--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -232,7 +232,7 @@ module Typing_env : sig
 
     val get_singleton : t -> Simple.t option
 
-    val choose_opt : t -> Simple.t option
+    val find_best : t -> Simple.t option
 
     val inter : t -> t -> t
 


### PR DESCRIPTION
This is a fix for a bug that we found using the refactor of simplify_let_cont.

It can happen that among the alias_set of mergeable arms in a switch, some of the aliases are not marked as required by data_flow. To avoid using an alias that will be removed, we now first filter the alias set using the required names. 

Additionally, instead of using `Alias_set.choose_opt`, which is dependant on the ordering of the variables/symbols (which made the original bug rather annoying to minimize), we switch to using `find_best`, which should be better in all cases (in particular, in our bug/example, the chosen alias was a variable, even though there was a symbol in the set of aliases).