### PR TITLE
Add `-no-output-cmi-for-missing-mli`

### DIFF
--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -438,6 +438,10 @@ let mk_o f =
 let mk_open f =
   "-open", Arg.String f, "<module>  Opens the module <module> before typing"
 
+let mk_no_output_cmi_for_missing_mli f =
+  "-no-output-cmi-for-missing-mli", Arg.Unit f,
+  " Don't output a .cmi when compiling a .ml without a .mli"
+
 let mk_output_obj f =
   "-output-obj", Arg.Unit f, " Output an object file instead of an executable"
 ;;
@@ -1028,6 +1032,7 @@ module type Compiler_options = sig
   val _noautolink : unit -> unit
   val _o : string -> unit
   val _opaque :  unit -> unit
+  val _no_output_cmi_for_missing_mli : unit -> unit
   val _output_obj : unit -> unit
   val _output_complete_obj : unit -> unit
   val _pack : unit -> unit
@@ -1251,6 +1256,7 @@ struct
     mk_o F._o;
     mk_opaque F._opaque;
     mk_open F._open;
+    mk_no_output_cmi_for_missing_mli F._no_output_cmi_for_missing_mli;
     mk_output_obj F._output_obj;
     mk_output_complete_obj F._output_complete_obj;
     mk_output_complete_exe F._output_complete_exe;
@@ -1456,6 +1462,7 @@ struct
     mk_o3 F._o3;
     mk_opaque F._opaque;
     mk_open F._open;
+    mk_no_output_cmi_for_missing_mli F._no_output_cmi_for_missing_mli;
     mk_output_obj F._output_obj;
     mk_output_complete_obj F._output_complete_obj;
     mk_p F._p;
@@ -1936,6 +1943,7 @@ module Default = struct
     let _noautolink = set no_auto_link
     let _o s = output_name := (Some s)
     let _opaque = set opaque
+    let _no_output_cmi_for_missing_mli = set no_output_cmi_for_missing_mli
     let _pack = set make_package
     let _plugin _p = plugin := true
     let _pp s = preprocessor := (Some s)

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -99,6 +99,7 @@ module type Compiler_options = sig
   val _noautolink : unit -> unit
   val _o : string -> unit
   val _opaque :  unit -> unit
+  val _no_output_cmi_for_missing_mli : unit -> unit
   val _output_obj : unit -> unit
   val _output_complete_obj : unit -> unit
   val _pack : unit -> unit

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3335,6 +3335,12 @@ let package_units initial_env objfiles cmifile modulename =
     if not !Clflags.dont_write_files then begin
       if !Clflags.no_output_cmi_for_missing_mli then begin
         if !Clflags.binary_annotations then begin
+          (* CR-someday lmaurer: This error is avoidable if we refactor. The
+             only reason it's raised is that the call to [save_cmt] below
+             relies on calling [Env.save_signature_with_imports] first. Probably
+             we'd want to split [Env.save_siganture_with_imports] so that we can
+             get the [Cmi_format.t] that /would/ be saved (or at least its
+             [cmi_sign]) without actually saving anything. *)
           raise(Error(Location.none, Env.empty, No_cmt_without_cmi_for_pack))
         end
       end else begin

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -143,6 +143,7 @@ type error =
   | Invalid_type_subst_rhs
   | Unpackable_local_modtype_subst of Path.t
   | With_cannot_remove_packed_modtype of Path.t * module_type
+  | No_cmt_without_cmi_for_pack
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -146,6 +146,7 @@ let flambda_invariant_checks =
   ref Config.with_flambda_invariants    (* -flambda-(no-)invariants *)
 
 let dont_write_files = ref false        (* set to true under ocamldoc *)
+let no_output_cmi_for_missing_mli = ref false (* -no-output-cmi-for-missing-mli *)
 
 let insn_sched_default = true
 let insn_sched = ref insn_sched_default (* -[no-]insn-sched *)

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -165,6 +165,7 @@ val inline_lifting_benefit : Int_arg_helper.parsed ref
 val default_inline_branch_factor : float
 val inline_branch_factor : Float_arg_helper.parsed ref
 val dont_write_files : bool ref
+val no_output_cmi_for_missing_mli : bool ref
 val std_include_flag : string -> string
 val std_include_dir : unit -> string list
 val shared : bool ref


### PR DESCRIPTION
This new option controls whether a `.cmi` is output in the case that we're compiling a `.ml` with no `.mli`. Handy when compiling in both bytecode and native so that we don't generate the same `.cmi` twice (and in the case of packs, we're apparently generating *different* `.cmi` files, possibly only due to differences in sharing in marshaled values).

Can't currently be combined with both `-pack` and `-bin-annot` simultaneously. This can probably be addressed if someone needs it.