### PR TITLE
Fix error-prone syntax resulting from reformatting

### DIFF
--- a/ocaml/utils/compilation_unit.ml
+++ b/ocaml/utils/compilation_unit.ml
@@ -215,11 +215,13 @@ let for_pack_prefix t =
 
 let create for_pack_prefix name =
   let empty_prefix = Prefix.is_empty for_pack_prefix in
-  if not empty_prefix
-  then (
-    Name.check_as_path_component name;
-    ListLabels.iter ~f:Name.check_as_path_component
-      (for_pack_prefix |> Prefix.to_list));
+  let () =
+    if not empty_prefix
+    then (
+      Name.check_as_path_component name;
+      ListLabels.iter ~f:Name.check_as_path_component
+        (for_pack_prefix |> Prefix.to_list))
+  in
   if empty_prefix
   then Sys.opaque_identity (Obj.repr name)
   else Sys.opaque_identity (Obj.repr { for_pack_prefix; name })


### PR DESCRIPTION
Having personally written bugs resulting directly from `);` being too ambiguous as to whether it ends an "expression" or "compound statement," so to speak, I've found using `let ()` to be the best alternative when `begin` and `end` are ruled out.