### PR TITLE
Remove obsolete pack-related code

### DIFF
--- a/middle_end/flambda2/identifiers/continuation.mli
+++ b/middle_end/flambda2/identifiers/continuation.mli
@@ -44,9 +44,6 @@ val export : t -> exported
 
 val import : exported -> t
 
-val map_compilation_unit :
-  (Compilation_unit.t -> Compilation_unit.t) -> exported -> exported
-
 val initialise : unit -> unit
 
 val reset : unit -> unit

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -140,7 +140,6 @@ end
 module Variable_data = struct
   type t =
     { compilation_unit : Compilation_unit.t;
-      previous_compilation_units : Compilation_unit.t list;
       name : string;
       name_stamp : int;
       user_visible : bool
@@ -148,8 +147,8 @@ module Variable_data = struct
 
   let flags = var_flags
 
-  let [@ocamlformat "disable"] print ppf { compilation_unit; previous_compilation_units = _;
-                  name; name_stamp; user_visible; } =
+  let [@ocamlformat "disable"] print ppf { compilation_unit; name; name_stamp;
+                                           user_visible; } =
     Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(compilation_unit@ %a)@]@ \
         @[<hov 1>(name@ %s)@]@ \
@@ -161,28 +160,14 @@ module Variable_data = struct
       name_stamp
       user_visible
 
-  let hash
-      { compilation_unit;
-        previous_compilation_units;
-        name = _;
-        name_stamp;
-        user_visible = _
-      } =
-    let compilation_unit_hashes =
-      List.fold_left
-        (fun hash compilation_unit ->
-          hash2 hash (Compilation_unit.hash compilation_unit))
-        (Compilation_unit.hash compilation_unit)
-        previous_compilation_units
-    in
-    hash2 compilation_unit_hashes (Hashtbl.hash name_stamp)
+  let hash { compilation_unit; name = _; name_stamp; user_visible = _ } =
+    hash2 (Compilation_unit.hash compilation_unit) (Hashtbl.hash name_stamp)
 
   let equal t1 t2 =
     if t1 == t2
     then true
     else
       let { compilation_unit = compilation_unit1;
-            previous_compilation_units = previous_compilation_units1;
             name = _;
             name_stamp = name_stamp1;
             user_visible = _
@@ -190,25 +175,14 @@ module Variable_data = struct
         t1
       in
       let { compilation_unit = compilation_unit2;
-            previous_compilation_units = previous_compilation_units2;
             name = _;
             name_stamp = name_stamp2;
             user_visible = _
           } =
         t2
       in
-      let rec previous_compilation_units_match l1 l2 =
-        match l1, l2 with
-        | [], [] -> true
-        | [], _ :: _ | _ :: _, [] -> false
-        | unit1 :: tl1, unit2 :: tl2 ->
-          Compilation_unit.equal unit1 unit2
-          && previous_compilation_units_match tl1 tl2
-      in
       Int.equal name_stamp1 name_stamp2
       && Compilation_unit.equal compilation_unit1 compilation_unit2
-      && previous_compilation_units_match previous_compilation_units1
-           previous_compilation_units2
 end
 
 module Symbol0 = Flambda2_import.Symbol
@@ -340,10 +314,6 @@ module Const = struct
   let export t = find_data t
 
   let import (data : exported) = create data
-
-  let map_compilation_unit _f data =
-    (* No compilation unit in the data *)
-    data
 end
 
 module Variable = struct
@@ -377,7 +347,6 @@ module Variable = struct
     in
     let data : Variable_data.t =
       { compilation_unit = Compilation_unit.get_current_exn ();
-        previous_compilation_units = [];
         name;
         name_stamp;
         user_visible = Option.is_some user_visible
@@ -419,17 +388,6 @@ module Variable = struct
   let export t = find_data t
 
   let import (data : exported) = Table.add !grand_table_of_variables data
-
-  let map_compilation_unit f (data : exported) : exported =
-    let new_compilation_unit = f data.compilation_unit in
-    if Compilation_unit.equal new_compilation_unit data.compilation_unit
-    then data
-    else
-      { data with
-        compilation_unit = new_compilation_unit;
-        previous_compilation_units =
-          data.compilation_unit :: data.previous_compilation_units
-      }
 end
 
 module Symbol = struct
@@ -505,9 +463,6 @@ module Symbol = struct
   let export t = find_data t
 
   let import (data : exported) = Table.add !grand_table_of_symbols data
-
-  let map_compilation_unit f (data : exported) : exported =
-    Symbol0.with_compilation_unit data (f (Symbol0.compilation_unit data))
 end
 
 module Name = struct
@@ -709,11 +664,6 @@ module Simple = struct
        that the real import functions (in Renaming) are responsible for
        importing the underlying name/const. *)
     Table.add !grand_table_of_simples data
-
-  let map_compilation_unit _f data =
-    (* The compilation unit is not associated with the simple directly, only
-       with the underlying name, which has its own entry. *)
-    data
 end
 
 module Code_id = struct
@@ -794,9 +744,6 @@ module Code_id = struct
   let export t = find_data t
 
   let import (data : exported) = Table.add !grand_table_of_code_ids data
-
-  let map_compilation_unit f (data : exported) : exported =
-    { data with compilation_unit = f data.compilation_unit }
 end
 
 module Code_id_or_symbol = struct

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -77,9 +77,6 @@ module Const : sig
   val export : t -> exported
 
   val import : exported -> t
-
-  val map_compilation_unit :
-    (Compilation_unit.t -> Compilation_unit.t) -> exported -> exported
 end
 
 module Variable : sig
@@ -102,9 +99,6 @@ module Variable : sig
   val export : t -> exported
 
   val import : exported -> t
-
-  val map_compilation_unit :
-    (Compilation_unit.t -> Compilation_unit.t) -> exported -> exported
 end
 
 module Symbol : sig
@@ -132,9 +126,6 @@ module Symbol : sig
   val export : t -> exported
 
   val import : exported -> t
-
-  val map_compilation_unit :
-    (Compilation_unit.t -> Compilation_unit.t) -> exported -> exported
 
   val external_symbols_compilation_unit : unit -> Compilation_unit.t
 end
@@ -198,9 +189,6 @@ module Simple : sig
   val export : t -> exported
 
   val import : exported -> t
-
-  val map_compilation_unit :
-    (Compilation_unit.t -> Compilation_unit.t) -> exported -> exported
 end
 
 module Code_id : sig
@@ -235,9 +223,6 @@ module Code_id : sig
   val export : t -> exported
 
   val import : exported -> t
-
-  val map_compilation_unit :
-    (Compilation_unit.t -> Compilation_unit.t) -> exported -> exported
 end
 
 module Code_id_or_symbol : sig

--- a/middle_end/symbol_utils.ml
+++ b/middle_end/symbol_utils.ml
@@ -46,12 +46,4 @@ module Flambda = struct
   let for_code_of_closure closure_id =
     Symbol.for_name (Closure_id.get_compilation_unit closure_id)
       (Closure_id.unique_name closure_id)
-
-  (* CR-soon lmaurer: Be rid of this when we have prefixes set correctly to begin
-     with *)
-  let import_for_pack symbol ~pack =
-    let compilation_unit =
-      CU.with_for_pack_prefix (Symbol.compilation_unit symbol) pack
-    in
-    Symbol.with_compilation_unit symbol compilation_unit
 end

--- a/middle_end/symbol_utils.mli
+++ b/middle_end/symbol_utils.mli
@@ -26,6 +26,4 @@ module Flambda : sig
   val for_variable : Variable.t -> Symbol.t
   val for_closure : Closure_id.t -> Symbol.t
   val for_code_of_closure : Closure_id.t -> Symbol.t
-
-  val import_for_pack : Symbol.t -> pack:Compilation_unit.Prefix.t -> Symbol.t
 end

--- a/ocaml/middle_end/symbol_utils.ml
+++ b/ocaml/middle_end/symbol_utils.ml
@@ -16,8 +16,6 @@
 
 [@@@ocaml.warning "+a-9-30-40-41-42"]
 
-module CU = Compilation_unit
-
 module Flambda = struct
   let for_variable var =
     Symbol.for_name (Variable.get_compilation_unit var) (Variable.unique_name var)
@@ -29,12 +27,4 @@ module Flambda = struct
   let for_code_of_closure closure_id =
     Symbol.for_name (Closure_id.get_compilation_unit closure_id)
       (Closure_id.unique_name closure_id)
-
-  (* CR-soon lmaurer: Be rid of this when we have prefixes set correctly to begin
-     with *)
-  let import_for_pack symbol ~pack =
-    let compilation_unit =
-      CU.with_for_pack_prefix (Symbol.compilation_unit symbol) pack
-    in
-    Symbol.with_compilation_unit symbol compilation_unit
 end

--- a/ocaml/middle_end/symbol_utils.mli
+++ b/ocaml/middle_end/symbol_utils.mli
@@ -20,6 +20,4 @@ module Flambda : sig
   val for_variable : Variable.t -> Symbol.t
   val for_closure : Closure_id.t -> Symbol.t
   val for_code_of_closure : Closure_id.t -> Symbol.t
-
-  val import_for_pack : Symbol.t -> pack:Compilation_unit.Prefix.t -> Symbol.t
 end

--- a/ocaml/utils/symbol.ml
+++ b/ocaml/utils/symbol.ml
@@ -61,8 +61,6 @@ let linkage_name_for_ocamlobjinfo t =
 
 let compilation_unit t = t.compilation_unit
 
-let with_compilation_unit t compilation_unit = { t with compilation_unit }
-
 (* CR-someday lmaurer: Would be nicer to have some of this logic in
    [Linkage_name]; among other things, we could then define
    [Linkage_name.for_current_unit] *)
@@ -120,10 +118,6 @@ let for_compilation_unit compilation_unit =
 
 let for_current_unit () =
   for_compilation_unit (CU.get_current_exn ())
-
-let import_for_pack t ~pack =
-  let compilation_unit = CU.with_for_pack_prefix t.compilation_unit pack in
-  { t with compilation_unit; }
 
 let const_label = ref 0
 

--- a/ocaml/utils/symbol.mli
+++ b/ocaml/utils/symbol.mli
@@ -35,11 +35,7 @@ val for_compilation_unit : Compilation_unit.t -> t
 val for_current_unit : unit -> t
 val for_new_const_in_current_unit : unit -> t
 
-val import_for_pack : t -> pack:Compilation_unit.Prefix.t -> t
-
 val compilation_unit : t -> Compilation_unit.t
-
-val with_compilation_unit : t -> Compilation_unit.t -> t
 
 val linkage_name : t -> Linkage_name.t
 


### PR DESCRIPTION
In particular, all ids, symbols, etc. are created with the correct compilation unit, so there's no need to support changing it anywhere.