### PR TITLE
Fix extern_closure_up_to_env

### DIFF
--- a/ocaml/runtime/extern.c
+++ b/ocaml/runtime/extern.c
@@ -675,8 +675,8 @@ Caml_inline mlsize_t extern_closure_up_to_env(value v)
     if (Arity_closinfo(info) != 0 && Arity_closinfo(info) != 1) {
       extern_code_pointer((char *) Field(v, i++));
     }
-  } while (i < startenv);
-  CAMLassert(i == startenv);
+  } while (!Is_last_closinfo(info));
+  CAMLassert(i <= startenv);
   return startenv;
 }
 #endif


### PR DESCRIPTION
Whilst examining failures in no naked pointers mode I found a bug resulting from #938.  The function `extern_closure_up_to_env` wasn't correctly traversing closure values.