### PR TITLE
Typedtree compiler hook takes a Typetree.implementation

### DIFF
--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -17,7 +17,7 @@ type _ pass =
   | Parse_tree_intf : Parsetree.signature pass
   | Parse_tree_impl : Parsetree.structure pass
   | Typed_tree_intf : Typedtree.signature pass
-  | Typed_tree_impl : (Typedtree.structure * Typedtree.module_coercion) pass
+  | Typed_tree_impl : Typedtree.implementation pass
   | Raw_lambda : Lambda.program pass
   | Lambda : Lambda.program pass
   | Raw_flambda2 : Flambda2_terms.Flambda_unit.t pass
@@ -45,7 +45,7 @@ type t = {
   mutable parse_tree_intf : (Parsetree.signature -> unit) list;
   mutable parse_tree_impl : (Parsetree.structure -> unit) list;
   mutable typed_tree_intf : (Typedtree.signature -> unit) list;
-  mutable typed_tree_impl : ((Typedtree.structure * Typedtree.module_coercion) -> unit) list;
+  mutable typed_tree_impl : (Typedtree.implementation -> unit) list;
   mutable raw_lambda : (Lambda.program -> unit) list;
   mutable lambda : (Lambda.program -> unit) list;
   mutable raw_flambda2 : (Flambda2_terms.Flambda_unit.t -> unit) list;

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -30,7 +30,7 @@ type _ pass =
   | Parse_tree_intf : Parsetree.signature pass
   | Parse_tree_impl : Parsetree.structure pass
   | Typed_tree_intf : Typedtree.signature pass
-  | Typed_tree_impl : (Typedtree.structure * Typedtree.module_coercion) pass
+  | Typed_tree_impl : Typedtree.implementation pass
   | Raw_lambda : Lambda.program pass
   | Lambda : Lambda.program pass
   | Raw_flambda2 : Flambda2_terms.Flambda_unit.t pass

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -134,8 +134,7 @@ let implementation unix ~backend ~flambda2 ~start_from ~source_file
     Compile_common.implementation
       ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_impl)
       ~hook_typed_tree:(fun (impl : Typedtree.implementation) ->
-        Compiler_hooks.execute Compiler_hooks.Typed_tree_impl
-          (impl.structure, impl.coercion))
+        Compiler_hooks.execute Compiler_hooks.Typed_tree_impl impl)
       info ~backend
   | Emit -> emit unix info ~ppf_dump:info.ppf_dump
   | _ -> Misc.fatal_errorf "Cannot start from %s"


### PR DESCRIPTION
Changes the type supported by compiler hooks for the Typedtree IR.