### PR TITLE
Fix DE.find_code_exn

### DIFF
--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -427,18 +427,11 @@ let mem_code t id =
 let find_code_exn t id =
   match Code_id.Map.find id t.all_code with
   | code -> Code_or_metadata.create code
-  | exception Not_found -> (
-    (* This [find_exn] call doesn't load any .cmx files, but in the majority of
-       cases will succeed. *)
-    match Exported_code.find_exn (t.get_imported_code ()) id with
-    | code_or_metadata -> code_or_metadata
-    | exception Not_found -> (
-      (* In this case either the code ID isn't bound due to a compiler error or
-         we haven't yet loaded the relevant .cmx file. Make sure the .cmx is
-         loaded and try again. *)
-      match TE.resolver t.typing_env (Code_id.get_compilation_unit id) with
-      | None -> raise Not_found
-      | Some _typing_env -> Exported_code.find_exn (t.get_imported_code ()) id))
+  | exception Not_found ->
+    let (_ : TE.Serializable.t option) =
+      TE.resolver t.typing_env (Code_id.get_compilation_unit id)
+    in
+    Exported_code.find_exn (t.get_imported_code ()) id
 
 let define_code t ~code_id ~code =
   if not


### PR DESCRIPTION
As discussed on Slack there is a bug which can cause `.cmx` files to silently fail to load, in the case where the load is triggered by a lookup of a code ID.