### PR TITLE
Revert "Make [Invalid] take a structured form for invalid terms"

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -1067,9 +1067,7 @@ let rec exprs env e1 e2 : Expr.t Comparison.t =
         apply_cont_exprs env apply_cont1 apply_cont2
         |> Comparison.map ~f:Expr.create_apply_cont
       | Switch switch1, Switch switch2 -> switch_exprs env switch1 switch2
-      | Invalid invalid1, Invalid invalid2 ->
-        let message1 = Flambda.Invalid.to_string invalid1 in
-        let message2 = Flambda.Invalid.to_string invalid2 in
+      | Invalid { message = message1 }, Invalid { message = message2 } ->
         if String.equal message1 message2
         then Equivalent
         else Different { approximant = e1 }

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -607,7 +607,7 @@ let rec expr env e =
   | Apply app -> apply_expr env app
   | Apply_cont app_cont -> apply_cont_expr env app_cont
   | Switch switch -> switch_expr env switch
-  | Invalid invalid -> invalid_expr env invalid
+  | Invalid { message } -> invalid_expr env ~message
 
 and let_expr env le =
   Flambda.Let_expr.pattern_match le ~f:(fun bound ~body : Fexpr.expr ->
@@ -982,8 +982,7 @@ and switch_expr env switch : Fexpr.expr =
   in
   Switch { scrutinee; cases }
 
-and invalid_expr _env invalid : Fexpr.expr =
-  Invalid { message = Flambda.Invalid.to_string invalid }
+and invalid_expr _env ~message : Fexpr.expr = Invalid { message }
 
 (* Iter on all sets of closures of a given program. *)
 module Iter = struct
@@ -994,7 +993,7 @@ module Iter = struct
     | Apply e' -> apply_expr f_c f_s e'
     | Apply_cont e' -> apply_cont f_c f_s e'
     | Switch e' -> switch f_c f_s e'
-    | Invalid _ -> ()
+    | Invalid { message = _ } -> ()
 
   and named let_expr (bound_pattern : Bound_pattern.t) f_c f_s n =
     match (n : Named.t) with

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -117,11 +117,11 @@ let rec simplify_expr dacc expr ~down_to_up =
     Simplify_switch_expr.simplify_switch
       ~simplify_let:Simplify_let_expr.simplify_let ~simplify_function_body dacc
       switch ~down_to_up
-  | Invalid invalid ->
+  | Invalid { message } ->
     (* CR mshinwell: Make sure that a program can be simplified to just
        [Invalid]. *)
     down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
-        EB.rebuild_invalid uacc invalid ~after_rebuild)
+        EB.rebuild_invalid uacc (Message message) ~after_rebuild)
 
 and simplify_function_body dacc expr ~return_continuation ~return_arity
     ~exn_continuation ~return_cont_scope ~exn_cont_scope

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -50,7 +50,7 @@ and expr_descr = private
           frames from the stack, which thus allows for the raising of
           exceptions. *)
   | Switch of Switch.t  (** Conditional control flow. *)
-  | Invalid of invalid
+  | Invalid of { message : string }
       (** Code proved type-incorrect and therefore unreachable. *)
 
 and let_expr
@@ -97,22 +97,18 @@ and static_const_or_code = private
 
 and static_const_group
 
-and invalid =
-  | Body_of_unreachable_continuation of Continuation.t
-  | Apply_cont_of_unreachable_continuation of Continuation.t
-  | Defining_expr_of_let of Bound_pattern.t * named
-  | Closure_type_was_invalid of Apply_expr.t
-  | Zero_switch_arms
-  | Code_not_rebuilt
-  | To_cmm_dummy_body
-  | Application_never_returns of Apply_expr.t
-  | Over_application_never_returns of Apply_expr.t
-  | Message of string
-
 module Invalid : sig
-  type t = invalid
-
-  val to_string : t -> string
+  type t =
+    | Body_of_unreachable_continuation of Continuation.t
+    | Apply_cont_of_unreachable_continuation of Continuation.t
+    | Defining_expr_of_let of Bound_pattern.t * named
+    | Closure_type_was_invalid of Apply.t
+    | Zero_switch_arms
+    | Code_not_rebuilt
+    | To_cmm_dummy_body
+    | Application_never_returns of Apply.t
+    | Over_application_never_returns of Apply.t
+    | Message of string
 end
 
 module Expr : sig

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -299,8 +299,7 @@ let rec expr env res e =
   | Apply e' -> apply_expr env res e'
   | Apply_cont e' -> apply_cont env res e'
   | Switch e' -> switch env res e'
-  | Invalid invalid ->
-    C.invalid res ~message:(Flambda.Invalid.to_string invalid)
+  | Invalid { message } -> C.invalid res ~message
 
 and let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body =
   let v = Bound_var.var v in


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#975

Looks like there might be a bug; some random renaming-related errors have been seen.