### PR TITLE
Fix capitalization of `%Tag_imm` primitive in printing fexpr

### DIFF
--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -439,7 +439,7 @@ let unop ppf u =
   | String_length String -> str "%string_length"
   | Unbox_number bk -> box_or_unbox "unbox" bk
   | Untag_immediate -> str "%untag_imm"
-  | Tag_immediate -> str "%tag_imm"
+  | Tag_immediate -> str "%Tag_imm"
 
 let ternop ppf t a1 a2 a3 =
   match t with

--- a/middle_end/flambda2/tests/mlexamples/tests0.flt
+++ b/middle_end/flambda2/tests/mlexamples/tests0.flt
@@ -1,6 +1,9 @@
 let $camlTests0__first_const18 = Block 0 () in
 let code size(31)
-      f_0 (param : imm tagged) my_closure my_region my_depth -> k * k1 : imm tagged =
+      f_0 (param : imm tagged)
+        my_closure my_region my_depth
+        -> k * k1
+        : imm tagged =
   let next_depth = rec_info (succ my_depth) in
   (let prim = %is_int 0 in
    let is_scrutinee_int = %Tag_imm prim in
@@ -29,7 +32,10 @@ in
 ===>
 let code f_0 deleted in
 let code size(1) newer_version_of(f_0)
-      f_0_1 (param : imm tagged) my_closure my_region my_depth -> k * k1 : imm tagged =
+      f_0_1 (param : imm tagged)
+        my_closure my_region my_depth
+        -> k * k1
+        : imm tagged =
   cont k (0)
 in
 let $camlTests0__f_1 = closure f_0_1 @f in


### PR DESCRIPTION
I've also regenerated the test to be sure that printing now works (in the one very simple example). In the long run:

* The primitives should probably all be made lowercase for simplicity and for consistency with the IR (currently the "constructor-like" ones get initial caps).
* We should be testing fexpr printing as well as parsing (roundtrip test).