### PR TITLE
Fix inlined debuginfo on primitives

### DIFF
--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -85,6 +85,7 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
          defining_expr ~original_defining_expr:named)
   | Prim (prim, dbg) -> (
     let bound_var = Bound_pattern.must_be_singleton bound_pattern in
+    let dbg = DE.add_inlined_debuginfo (DA.denv dacc) dbg in
     let { Simplify_primitive_result.simplified_named; try_reify; dacc } =
       Simplify_primitive.simplify_primitive dacc prim dbg ~result_var:bound_var
     in

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -408,11 +408,13 @@ let simplify_switch0 dacc switch ~down_to_up =
       DA.map_flow_acc dacc
         ~f:(Flow.Acc.add_used_in_current_handler (Simple.free_names scrutinee))
   in
+  let condition_dbg =
+    DE.add_inlined_debuginfo (DA.denv dacc) (Switch.condition_dbg switch)
+  in
   down_to_up dacc
     ~rebuild:
-      (rebuild_switch ~arms
-         ~condition_dbg:(Switch.condition_dbg switch)
-         ~scrutinee ~scrutinee_ty ~dacc_before_switch)
+      (rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
+         ~dacc_before_switch)
 
 let simplify_switch ~simplify_let ~simplify_function_body dacc switch
     ~down_to_up =


### PR DESCRIPTION
I had long suspected flambda2 was missing frames in backtraces at certain points, but hadn't previously spotted the exact error.  Here it is.