### PR TITLE
Relax inlining depth limit slightly

### DIFF
--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -128,7 +128,10 @@ module Inlining = struct
       | Round round -> IH.get ~key:round !I.max_depth
       | Default opt_level -> (default_for_opt_level opt_level).max_depth
     in
-    depth * depth_scaling_factor
+    (* This computation (rather than just [depth * depth_scaling_factor]) gives
+       a bit more leeway for always-inlined functions, which reduce the depth by
+       much less than [depth_scaling_factor], to be inlined. *)
+    ((depth + 1) * depth_scaling_factor) - 1
 
   let max_rec_depth round_or_default =
     match round_or_default with


### PR DESCRIPTION
This is one of two small changes to the inlining heuristics that should produce better behaviour.  It alters the inlining depth limit calculation so that there is a bit more leeway for always-inlined functions (which only increase the depth by 1 versus the scaled depth limit), without bumping the depth up, which I think might cause us to spend a lot more time speculating.  (In due course we should really do a proper analysis to work out what causes compilation time to rise so significantly as the depth limit is raised.)