### PR TITLE
Reduce inlining depth change when inlining small functions and stubs

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -153,7 +153,13 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
   then
     Definition_says_inline
       { was_inline_always =
-          Function_decl_inlining_decision_type.has_attribute_inline decision
+          true
+          (* CR mshinwell: We used to have
+             "Function_decl_inlining_decision_type.has_attribute_inline
+             decision" but this seems too restrictive: it's just fine to inline
+             long chains of tiny functions. If the new behaviour proves ok, we
+             might be able to delete [has_attribute_inline], and we should
+             probably rename [was_inline_always]. *)
       }
   else if Function_decl_inlining_decision_type.cannot_be_inlined decision
   then Definition_says_not_to_inline


### PR DESCRIPTION
Currently the inlining depth is only decreased by 1 (as opposed to the scaling factor, currently 10) when inlining a function marked with an inline-always attribute.  This patch also applies this behaviour to small functions and stubs.  At the moment we are failing to inline chains of small functions which are perfectly reasonable to inline (and which sometimes must be inlined to avoid boxing, e.g. ones via `Comparable` in `Base` that lead to floating-point comparison operations).

This may have a small compilation time impact but I'm hoping not too much, we should be able to evaluate that after merging.