### PR TITLE
Save cfg after cfg-simplify when compiling with IRC

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -302,6 +302,7 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
         ++ Cfg_with_liveness.cfg_with_layout
         ++ Profile.record ~accumulate:true "cfg_validate_description" (Cfg_regalloc_validate.run cfg_description)
         ++ Profile.record ~accumulate:true "cfg_simplify" Cfg_regalloc_utils.simplify_cfg
+        ++ Profile.record ~accumulate:true "save_cfg" save_cfg
         ++ Profile.record ~accumulate:true "cfg_reorder_blocks"
              (reorder_blocks_random ppf_dump)
         ++ Profile.record ~accumulate:true "cfg_to_linear" Cfg_to_linear.run)


### PR DESCRIPTION
Adding back a hook mistakenly dropped in recent refactorig in #1041 for -ocamlcfg.