### PR TITLE
Rework merge straightline code

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -228,8 +228,8 @@ let remove_block_exn t label =
   | _ -> Label.Tbl.remove t.blocks label
 
 let remove_blocks t labels_to_remove =
-  Label.Tbl.filter_map_inplace (fun l b ->
-    if Label.Set.mem l labels_to_remove then None else (Some b))
+  Label.Tbl.filter_map_inplace
+    (fun l b -> if Label.Set.mem l labels_to_remove then None else Some b)
     t.blocks
 
 let get_block t label = Label.Tbl.find_opt t.blocks label

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -227,6 +227,11 @@ let remove_block_exn t label =
     Misc.fatal_errorf "Cfg.remove_block_exn: block %d not found" label
   | _ -> Label.Tbl.remove t.blocks label
 
+let remove_blocks t labels_to_remove =
+  Label.Tbl.filter_map_inplace (fun l b ->
+    if Label.Set.mem l labels_to_remove then None else (Some b))
+    t.blocks
+
 let get_block t label = Label.Tbl.find_opt t.blocks label
 
 let get_block_exn t label =

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -166,6 +166,8 @@ val add_block_exn : t -> basic_block -> unit
 
 val remove_block_exn : t -> Label.t -> unit
 
+val remove_blocks : t -> Label.Set.t -> unit
+
 val get_block : t -> Label.t -> basic_block option
 
 val get_block_exn : t -> Label.t -> basic_block

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -67,9 +67,7 @@ let remove_block t label =
 let remove_blocks t labels_to_remove =
   if not (Label.Set.is_empty labels_to_remove)
   then (
-    Label.Set.iter
-      (fun label -> Cfg.remove_block_exn t.cfg label)
-      labels_to_remove;
+    Cfg.remove_blocks t.cfg labels_to_remove;
     t.layout
       <- List.filter (fun l -> not (Label.Set.mem l labels_to_remove)) t.layout;
     t.new_labels <- Label.Set.diff t.new_labels labels_to_remove)

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -65,13 +65,14 @@ let remove_block t label =
   t.new_labels <- Label.Set.remove label t.new_labels
 
 let remove_blocks t labels_to_remove =
-  if not (Label.Set.is_empty labels_to_remove) then begin
+  if not (Label.Set.is_empty labels_to_remove)
+  then (
     Label.Set.iter
       (fun label -> Cfg.remove_block_exn t.cfg label)
       labels_to_remove;
-    t.layout <- List.filter (fun l -> not (Label.Set.mem l labels_to_remove)) t.layout;
-    t.new_labels <- Label.Set.diff t.new_labels labels_to_remove
-  end
+    t.layout
+      <- List.filter (fun l -> not (Label.Set.mem l labels_to_remove)) t.layout;
+    t.new_labels <- Label.Set.diff t.new_labels labels_to_remove)
 
 let add_block t (block : Cfg.basic_block) ~after =
   t.new_labels <- Label.Set.add block.start t.new_labels;

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -64,6 +64,15 @@ let remove_block t label =
   t.layout <- List.filter (fun l -> not (Label.equal l label)) t.layout;
   t.new_labels <- Label.Set.remove label t.new_labels
 
+let remove_blocks t labels_to_remove =
+  if not (Label.Set.is_empty labels_to_remove) then begin
+    Label.Set.iter
+      (fun label -> Cfg.remove_block_exn t.cfg label)
+      labels_to_remove;
+    t.layout <- List.filter (fun l -> not (Label.Set.mem l labels_to_remove)) t.layout;
+    t.new_labels <- Label.Set.diff t.new_labels labels_to_remove
+  end
+
 let add_block t (block : Cfg.basic_block) ~after =
   t.new_labels <- Label.Set.add block.start t.new_labels;
   let initial_len = List.length t.layout in

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -50,9 +50,9 @@ val add_block : t -> Cfg.basic_block -> after:Label.t -> unit
 (** Remove from cfg, layout, and other data-structures that track labels. *)
 val remove_block : t -> Label.t -> unit
 
-(* CR-soon gyorsh: [remove_block] is expensive because [layout] is
-   implemented as [list]. Bulk removal is a temporary workaround, until
-   we optimize [layout] implementation. *)
+(* CR-soon gyorsh: [remove_block] is expensive because [layout] is implemented
+   as [list]. Bulk removal is a temporary workaround, until we optimize [layout]
+   implementation. *)
 val remove_blocks : t -> Label.Set.t -> unit
 
 val is_trap_handler : t -> Label.t -> bool

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -50,6 +50,9 @@ val add_block : t -> Cfg.basic_block -> after:Label.t -> unit
 (** Remove from cfg, layout, and other data-structures that track labels. *)
 val remove_block : t -> Label.t -> unit
 
+(* CR-soon gyorsh: [remove_block] is expensive because [layout] is
+   implemented as [list]. Bulk removal is a temporary workaround, until
+   we optimize [layout] implementation. *)
 val remove_blocks : t -> Label.Set.t -> unit
 
 val is_trap_handler : t -> Label.t -> bool

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -49,6 +49,7 @@ val add_block : t -> Cfg.basic_block -> after:Label.t -> unit
 
 (** Remove from cfg, layout, and other data-structures that track labels. *)
 val remove_block : t -> Label.t -> unit
+val remove_blocks : t -> Label.Set.t -> unit
 
 val is_trap_handler : t -> Label.t -> bool
 

--- a/backend/cfg/cfg_with_layout.mli
+++ b/backend/cfg/cfg_with_layout.mli
@@ -49,6 +49,7 @@ val add_block : t -> Cfg.basic_block -> after:Label.t -> unit
 
 (** Remove from cfg, layout, and other data-structures that track labels. *)
 val remove_block : t -> Label.t -> unit
+
 val remove_blocks : t -> Label.Set.t -> unit
 
 val is_trap_handler : t -> Label.t -> bool

--- a/backend/cfg/eliminate_dead_code.ml
+++ b/backend/cfg/eliminate_dead_code.ml
@@ -64,8 +64,6 @@ let run_dead_block : Cfg_with_layout.t -> unit =
         block.terminator <- { block.terminator with desc = Cfg_intf.S.Never };
         block.exn <- None)
       unreachable_labels;
-    Label.Set.iter
-      (fun label -> Cfg_with_layout.remove_block cfg_with_layout label)
-      unreachable_labels;
+    Cfg_with_layout.remove_blocks cfg_with_layout unreachable_labels;
     (* CR xclerc for xclerc: temporary. *)
     Eliminate_dead_blocks.run cfg_with_layout

--- a/backend/cfg/merge_straightline_blocks.ml
+++ b/backend/cfg/merge_straightline_blocks.ml
@@ -42,7 +42,9 @@
  *  - its prececessors are set to empty;
  *  - (its other fields are left unchanged).
  *
- *  As a consequence, `b2` becomes dead. *)
+ *  As a consequence, `b2` becomes dead and is removed.
+ *  This pass does remove any other dead blocks.
+*)
 
 (* CR gyorsh: with the new requirement on b1 (that it cannot raise) this pass is
    even closer to eliminate_fallthrough_blocks. The only difference I think is

--- a/backend/cfg/merge_straightline_blocks.ml
+++ b/backend/cfg/merge_straightline_blocks.ml
@@ -44,7 +44,7 @@
  *
  *  As a consequence, `b2` becomes dead and is removed.
  *  This pass does remove any other dead blocks.
-*)
+ *)
 
 (* CR gyorsh: with the new requirement on b1 (that it cannot raise) this pass is
    even closer to eliminate_fallthrough_blocks. The only difference I think is

--- a/backend/cfg/merge_straightline_blocks.ml
+++ b/backend/cfg/merge_straightline_blocks.ml
@@ -47,8 +47,8 @@
 (* CR gyorsh: with the new requirement on b1 (that it cannot raise) this pass is
    even closer to eliminate_fallthrough_blocks. The only difference I think is
    that b1's body need not be empty here. *)
-let rec merge_blocks (removed : Label.Set.t) (cfg_with_layout : Cfg_with_layout.t) :
-    Label.Set.t =
+let rec merge_blocks (removed : Label.Set.t)
+    (cfg_with_layout : Cfg_with_layout.t) : Label.Set.t =
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
   let new_removed =
     Label.Tbl.fold

--- a/backend/cfg/merge_straightline_blocks.ml
+++ b/backend/cfg/merge_straightline_blocks.ml
@@ -47,12 +47,12 @@
 (* CR gyorsh: with the new requirement on b1 (that it cannot raise) this pass is
    even closer to eliminate_fallthrough_blocks. The only difference I think is
    that b1's body need not be empty here. *)
-let rec merge_blocks (modified : bool) (cfg_with_layout : Cfg_with_layout.t) :
-    bool =
+let rec merge_blocks (removed : Label.Set.t) (cfg_with_layout : Cfg_with_layout.t) :
+    Label.Set.t =
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  let merged =
+  let new_removed =
     Label.Tbl.fold
-      (fun b1_label (b1_block : Cfg.basic_block) merged ->
+      (fun b1_label (b1_block : Cfg.basic_block) acc ->
         let b1_successors =
           Cfg.successor_labels ~normal:true ~exn:false b1_block
         in
@@ -86,13 +86,15 @@ let rec merge_blocks (modified : bool) (cfg_with_layout : Cfg_with_layout.t) :
             b2_block.terminator
               <- { b2_block.terminator with desc = Cfg_intf.S.Never };
             b2_block.exn <- None;
-            true)
-          else merged
-        | _ -> merged)
-      cfg.blocks false
+            Label.Set.add b2_label acc)
+          else acc
+        | _ -> acc)
+      cfg.blocks Label.Set.empty
   in
-  if merged then merge_blocks true cfg_with_layout else modified
+  if not (Label.Set.is_empty new_removed)
+  then merge_blocks (Label.Set.union new_removed removed) cfg_with_layout
+  else removed
 
 let run (cfg_with_layout : Cfg_with_layout.t) : unit =
-  let modified = merge_blocks false cfg_with_layout in
-  if modified then Eliminate_dead_code.run_dead_block cfg_with_layout
+  merge_blocks Label.Set.empty cfg_with_layout
+  |> Cfg_with_layout.remove_blocks cfg_with_layout


### PR DESCRIPTION
The current representation of layout in `Cfg_with_layout` as linked list is inefficient when a block needs to be removed from a CFG, as @azewierzejew  pointed out a whilte ago. 

Various passes remove nodes one by one, which on some pathlogical examples leads to significant regression with `-ocamlcfg`. For example, on a couple of large files the compiler spends 2 min. when using cfgize compared to 13s when using linearize. In these examples, the time is spent in `Eliminate_dead_code` called from `Merge_straightline_code`.
This PR is a quick workaround that brings build time back down to approximately 17s (there other causes of overhead in cfgize).

`Merge_straightline_code` collects all the nodes that need to be removed and calls the new `Cfg_with_layout.remove_blocks` directly, because it cannot cause other nodes to become dead.