### PR TITLE
IRC: loop infos and better spilling heuristics

### DIFF
--- a/backend/cfg/cfg_irc_utils.ml
+++ b/backend/cfg/cfg_irc_utils.ml
@@ -213,15 +213,14 @@ module Spilling_heuristics = struct
   type t =
     | Set_choose
     | Flat_uses
-  (* CR xclerc for xclerc: | Hierarchical_uses *)
+    | Hierarchical_uses
 
-  let all =
-    [Set_choose; Flat_uses (* CR xclerc for xclerc: Hierarchical_uses; *)]
+  let all = [Set_choose; Flat_uses; Hierarchical_uses]
 
   let to_string = function
     | Set_choose -> "set_choose"
     | Flat_uses -> "flat_uses"
-  (* CR xclerc for xclerc: | Hierarchical_uses -> "hierarchical_uses" *)
+    | Hierarchical_uses -> "hierarchical_uses"
 
   let env =
     let available_heuristics () =
@@ -239,8 +238,7 @@ module Spilling_heuristics = struct
         match String.lowercase_ascii id with
         | "set_choose" | "set-choose" -> Set_choose
         | "flat_uses" | "flat-uses" -> Flat_uses
-        (* CR xclerc for xclerc: | "hierarchical_uses" | "hierarchical-uses" ->
-           Hierarchical_uses *)
+        | "hierarchical_uses" | "hierarchical-uses" -> Hierarchical_uses
         | _ ->
           fatal "unknown heuristics %S (possible values: %s)" id
             (available_heuristics ())))

--- a/backend/cfg/cfg_irc_utils.mli
+++ b/backend/cfg/cfg_irc_utils.mli
@@ -83,7 +83,7 @@ module Spilling_heuristics : sig
   type t =
     | Set_choose
     | Flat_uses
-  (* CR xclerc for xclerc: | Hierarchical_uses *)
+    | Hierarchical_uses
 
   val all : t list
 

--- a/backend/cfg/cfg_loop_infos.ml
+++ b/backend/cfg/cfg_loop_infos.ml
@@ -78,6 +78,7 @@ end
 
 module EdgeMap : Map.S with type key = Edge.t = Map.Make (Edge)
 
+(* CR-soon xclerc for xclerc: consider deduplicating. *)
 let compute_back_edges cfg dominators =
   Cfg.fold_blocks cfg ~init:[] ~f:(fun src_label src_block acc ->
       let dst_labels =
@@ -110,7 +111,9 @@ let compute_loop_of_back_edge cfg { Edge.src; dst } =
   in
   visit [src] (Label.Set.add src (Label.Set.singleton dst))
 
-type loops = Label.Set.t EdgeMap.t
+type loop = Label.Set.t
+
+type loops = loop EdgeMap.t
 
 let compute_loops_of_back_edges cfg back_edges =
   List.fold_left back_edges ~init:EdgeMap.empty ~f:(fun acc edge ->

--- a/backend/cfg/cfg_loop_infos.ml
+++ b/backend/cfg/cfg_loop_infos.ml
@@ -1,0 +1,169 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module List = ListLabels
+
+let fatal = Misc.fatal_errorf
+
+let debug = false
+
+type dominators = Label.Set.t Label.Map.t
+
+let compute_dominators (cfg : Cfg.t) =
+  (* CR-soon xclerc for xclerc: this is a naive implementation, that could
+     clearly be optimized and/or rely on the dataflow framework. *)
+  let all_labels =
+    Cfg.fold_blocks cfg ~init:Label.Set.empty ~f:(fun label _block acc ->
+        Label.Set.add label acc)
+  in
+  let init =
+    Cfg.fold_blocks cfg ~init:Label.Map.empty ~f:(fun label _block acc ->
+        Label.Map.add label
+          (if Label.equal label cfg.entry_label
+          then Label.Set.singleton cfg.entry_label
+          else all_labels)
+          acc)
+  in
+  let rec loop curr =
+    let get_curr label =
+      match Label.Map.find_opt label curr with
+      | None ->
+        fatal "Cfg_loop_infos.compute_dominators: unknown label %d" label
+      | Some set -> set
+    in
+    let dominators, changed =
+      Label.Set.fold
+        (fun label (dominators, changed) ->
+          let new_value =
+            if Label.equal label cfg.entry_label
+            then Label.Set.singleton cfg.entry_label
+            else
+              let predecessor_labels =
+                Cfg.predecessor_labels (Cfg.get_block_exn cfg label)
+              in
+              match predecessor_labels with
+              | [] -> Label.Set.singleton label
+              | hd :: tl ->
+                Label.Set.add label
+                  (List.fold_left tl ~init:(get_curr hd) ~f:(fun acc label ->
+                       Label.Set.inter acc (get_curr label)))
+          in
+          ( Label.Map.add label new_value dominators,
+            changed || not (Label.Set.equal new_value (get_curr label)) ))
+        all_labels (Label.Map.empty, false)
+    in
+    if changed then loop dominators else dominators
+  in
+  loop init
+
+let is_dominating dominators left right =
+  match Label.Map.find_opt right dominators with
+  | None -> fatal "Cfg_loop_infos.is_dominating: unknown label %d" right
+  | Some set -> Label.Set.mem left set
+
+let is_strictly_dominating dominators left right =
+  (not (Label.equal left right)) && is_dominating dominators left right
+
+module Edge = struct
+  type t =
+    { src : Label.t;
+      dst : Label.t
+    }
+
+  let compare { src = left_src; dst = left_dst }
+      { src = right_src; dst = right_dst } =
+    match Label.compare left_src right_src with
+    | 0 -> Label.compare left_dst right_dst
+    | c -> c
+end
+
+module EdgeMap : Map.S with type key = Edge.t = Map.Make (Edge)
+
+let compute_back_edges cfg dominators =
+  Cfg.fold_blocks cfg ~init:[] ~f:(fun src_label src_block acc ->
+      let dst_labels =
+        (* CR-soon xclerc for xclerc: probably safe to pass `~exn:false`. *)
+        Cfg.successor_labels ~normal:true ~exn:true src_block
+      in
+      Label.Set.fold
+        (fun dst_label acc ->
+          let is_back_edge = is_dominating dominators dst_label src_label in
+          if is_back_edge
+          then { Edge.src = src_label; dst = dst_label } :: acc
+          else acc)
+        dst_labels acc)
+
+let compute_loop_of_back_edge cfg { Edge.src; dst } =
+  let rec visit stack acc =
+    match stack with
+    | [] -> acc
+    | hd :: tl ->
+      let block = Cfg.get_block_exn cfg hd in
+      let predecessor_labels = Cfg.predecessor_labels block in
+      let stack, acc =
+        List.fold_left predecessor_labels ~init:(tl, acc)
+          ~f:(fun (stack, acc) predecessor_label ->
+            if not (Label.Set.mem predecessor_label acc)
+            then predecessor_label :: stack, Label.Set.add predecessor_label acc
+            else stack, acc)
+      in
+      visit stack acc
+  in
+  visit [src] (Label.Set.add src (Label.Set.singleton dst))
+
+type loops = Label.Set.t EdgeMap.t
+
+let compute_loops_of_back_edges cfg back_edges =
+  List.fold_left back_edges ~init:EdgeMap.empty ~f:(fun acc edge ->
+      EdgeMap.add edge (compute_loop_of_back_edge cfg edge) acc)
+
+type loop_depths = int Label.Map.t
+
+let compute_loop_depths cfg (loops : loops) =
+  let init =
+    Cfg.fold_blocks cfg ~init:Label.Map.empty ~f:(fun label _block acc ->
+        Label.Map.add label 0 acc)
+  in
+  EdgeMap.fold
+    (fun _edge labels acc ->
+      Label.Set.fold
+        (fun label acc ->
+          Label.Map.update label
+            (function
+              | None ->
+                fatal "Cfg_loop_infos.compute_loop_depths: unknown label %d"
+                  label
+              | Some depth -> Some (succ depth))
+            acc)
+        labels acc)
+    loops init
+
+type t =
+  { dominators : dominators;
+    back_edges : Edge.t list;
+    loops : loops;
+    loop_depths : loop_depths
+  }
+
+let build cfg =
+  let dominators = compute_dominators cfg in
+  let back_edges = compute_back_edges cfg dominators in
+  let loops = compute_loops_of_back_edges cfg back_edges in
+  let loop_depths = compute_loop_depths cfg loops in
+  if debug
+  then (
+    Format.eprintf "*** Cfg_loop_infos.build for %S\n" cfg.Cfg.fun_name;
+    Label.Map.iter
+      (fun label dominators ->
+        Format.eprintf "dominators for %d:\n" label;
+        Label.Set.iter (Format.eprintf "- %d\n") dominators)
+      dominators;
+    Format.eprintf "back edges:\n";
+    List.iter back_edges ~f:(fun { Edge.src; dst } ->
+        Format.eprintf "- %d -> %d\n" src dst);
+    EdgeMap.iter
+      (fun { Edge.src; dst } labels ->
+        Format.eprintf "loop for back edge %d -> %d:\n" src dst;
+        Label.Set.iter (Format.eprintf "- %d:\n") labels)
+      loops;
+    Label.Map.iter (Format.eprintf "loop depth for %d is %d\n") loop_depths);
+  { dominators; back_edges; loops; loop_depths }

--- a/backend/cfg/cfg_loop_infos.ml
+++ b/backend/cfg/cfg_loop_infos.ml
@@ -93,6 +93,8 @@ let compute_back_edges cfg dominators =
           else acc)
         dst_labels acc)
 
+type loop = Label.Set.t
+
 let compute_loop_of_back_edge cfg { Edge.src; dst } =
   let rec visit stack acc =
     match stack with
@@ -110,8 +112,6 @@ let compute_loop_of_back_edge cfg { Edge.src; dst } =
       visit stack acc
   in
   visit [src] (Label.Set.add src (Label.Set.singleton dst))
-
-type loop = Label.Set.t
 
 type loops = loop EdgeMap.t
 

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -1,0 +1,47 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type dominators = Label.Set.t Label.Map.t
+
+val compute_dominators : Cfg.t -> dominators
+
+val is_dominating : dominators -> Label.t -> Label.t -> bool
+(* [is_dominating doms x y] is [true] iff [x] is dominating [y] according to
+   [dominators]. *)
+
+val is_strictly_dominating : dominators -> Label.t -> Label.t -> bool
+(* [is_strictly_dominating doms x y] is [true] iff [x] is strictly dominating
+   [y] according to [dominators]. *)
+
+module Edge : sig
+  type t =
+    { src : Label.t;
+      dst : Label.t
+    }
+
+  val compare : t -> t -> int
+end
+
+module EdgeMap : Map.S with type key = Edge.t
+
+val compute_back_edges : Cfg.t -> dominators -> Edge.t list
+
+val compute_loop_of_back_edge : Cfg.t -> Edge.t -> Label.Set.t
+(* Assumes the passed edge is a back edge. *)
+
+type loops = Label.Set.t EdgeMap.t
+
+val compute_loops_of_back_edges : Cfg.t -> Edge.t list -> loops
+(* Assumes the passed edges are back edges. *)
+
+type loop_depths = int Label.Map.t
+
+val compute_loop_depths : Cfg.t -> loops -> loop_depths
+
+type t =
+  { dominators : dominators;
+    back_edges : Edge.t list;
+    loops : loops;
+    loop_depths : loop_depths
+  }
+
+val build : Cfg.t -> t

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -30,7 +30,7 @@ val compute_loop_of_back_edge : Cfg.t -> Edge.t -> Label.Set.t
 (* Assumes the passed edge is a back edge. *)
 
 type loop = Label.Set.t
-(* Blocks parts of a loop; if a node is part of several/nested loops, it will
+(* Blocks in a loop; if a node is part of several/nested loops, it will
    appear in several sets. *)
 
 type loops = loop EdgeMap.t

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -30,8 +30,8 @@ val compute_loop_of_back_edge : Cfg.t -> Edge.t -> Label.Set.t
 (* Assumes the passed edge is a back edge. *)
 
 type loop = Label.Set.t
-(* Blocks in a loop; if a node is part of several/nested loops, it will
-   appear in several sets. *)
+(* Blocks in a loop; if a node is part of several/nested loops, it will appear
+   in several sets. *)
 
 type loops = loop EdgeMap.t
 

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -26,12 +26,12 @@ module EdgeMap : Map.S with type key = Edge.t
 
 val compute_back_edges : Cfg.t -> dominators -> Edge.t list
 
-val compute_loop_of_back_edge : Cfg.t -> Edge.t -> loop
-(* Assumes the passed edge is a back edge. *)
-
 type loop = Label.Set.t
 (* Blocks in a loop; if a node is part of several/nested loops, it will appear
    in several sets. *)
+
+val compute_loop_of_back_edge : Cfg.t -> Edge.t -> loop
+(* Assumes the passed edge is a back edge. *)
 
 type loops = loop EdgeMap.t
 

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -6,11 +6,12 @@ val compute_dominators : Cfg.t -> dominators
 
 val is_dominating : dominators -> Label.t -> Label.t -> bool
 (* [is_dominating doms x y] is [true] iff [x] is dominating [y] according to
-   [dominators]. *)
+   [dominators]. All edges, regular and exceptional are treated the same way. *)
 
 val is_strictly_dominating : dominators -> Label.t -> Label.t -> bool
 (* [is_strictly_dominating doms x y] is [true] iff [x] is strictly dominating
-   [y] according to [dominators]. *)
+   [y] according to [dominators]. All edges, regular and exceptional are treated
+   the same way.*)
 
 module Edge : sig
   type t =
@@ -28,12 +29,17 @@ val compute_back_edges : Cfg.t -> dominators -> Edge.t list
 val compute_loop_of_back_edge : Cfg.t -> Edge.t -> Label.Set.t
 (* Assumes the passed edge is a back edge. *)
 
-type loops = Label.Set.t EdgeMap.t
+type loop = Label.Set.t
+(* Blocks parts of a loop; if a node is part of several/nested loops, it will
+   appear in several sets. *)
+
+type loops = loop EdgeMap.t
 
 val compute_loops_of_back_edges : Cfg.t -> Edge.t list -> loops
 (* Assumes the passed edges are back edges. *)
 
 type loop_depths = int Label.Map.t
+(* Maps labels to the number of nested loops it is part of. *)
 
 val compute_loop_depths : Cfg.t -> loops -> loop_depths
 

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -26,7 +26,7 @@ module EdgeMap : Map.S with type key = Edge.t
 
 val compute_back_edges : Cfg.t -> dominators -> Edge.t list
 
-val compute_loop_of_back_edge : Cfg.t -> Edge.t -> Label.Set.t
+val compute_loop_of_back_edge : Cfg.t -> Edge.t -> loop
 (* Assumes the passed edge is a back edge. *)
 
 type loop = Label.Set.t

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -396,6 +396,7 @@ let update_live_fields : Cfg_with_layout.t -> liveness -> unit =
       Cfg.BasicInstructionList.iter block.body ~f:set_liveness;
       set_liveness block.terminator)
 
+(* CR-soon xclerc for xclerc: consider adding an overflow check. *)
 let pow10 n =
   let res = ref 1 in
   for _ = 1 to n do
@@ -407,6 +408,7 @@ let update_spill_cost : Cfg_with_layout.t -> flat:bool -> unit -> unit =
  fun cfg_with_layout ~flat () ->
   List.iter (Reg.all_registers ()) ~f:(fun reg -> reg.Reg.spill_cost <- 0);
   let update_reg (cost : int) (reg : Reg.t) : unit =
+    (* CR-soon xclerc for xclerc: consider adding an overflow check. *)
     reg.Reg.spill_cost <- reg.Reg.spill_cost + cost
   in
   let update_array (cost : int) (regs : Reg.t array) : unit =

--- a/backend/cfg/cfg_regalloc_utils.mli
+++ b/backend/cfg/cfg_regalloc_utils.mli
@@ -79,8 +79,11 @@ val remove_prologue_if_not_required : Cfg_with_layout.t -> unit
 
 val update_live_fields : Cfg_with_layout.t -> liveness -> unit
 
-(* The spill cost is currently the number of occurrences of the register. *)
-val update_spill_cost : Cfg_with_layout.t -> unit
+(* The spill cost is currently the number of occurrences of the register. If
+   [flat] is true, the same weight is given to all uses; if [flat] is false, the
+   information about loops in computed and used to give more weight to uses
+   inside (nested) loops. *)
+val update_spill_cost : Cfg_with_layout.t -> flat:bool -> unit -> unit
 
 val is_spilled : Reg.t -> bool
 

--- a/backend/cfg/cfg_regalloc_utils.mli
+++ b/backend/cfg/cfg_regalloc_utils.mli
@@ -81,7 +81,7 @@ val update_live_fields : Cfg_with_layout.t -> liveness -> unit
 
 (* The spill cost is currently the number of occurrences of the register. If
    [flat] is true, the same weight is given to all uses; if [flat] is false, the
-   information about loops in computed and used to give more weight to uses
+   information about loops is computed and used to give more weight to uses
    inside (nested) loops. *)
 val update_spill_cost : Cfg_with_layout.t -> flat:bool -> unit -> unit
 

--- a/dune
+++ b/dune
@@ -228,6 +228,7 @@
   cfg_dataflow
   cfg_deadcode
   cfg_liveness
+  cfg_loop_infos
   cfg_regalloc_utils
   cfg_regalloc_validate
   cfg_to_linear_desc
@@ -752,6 +753,7 @@
   (cfg_dataflow.mli as compiler-libs/cfg_dataflow.mli)
   (cfg_deadcode.mli as compiler-libs/cfg_deadcode.mli)
   (cfg_liveness.mli as compiler-libs/cfg_liveness.mli)
+  (cfg_loop_infos.mli as compiler-libs/cfg_loop_infos.mli)
   (cfg_regalloc_utils.mli as compiler-libs/cfg_regalloc_utils.mli)
   (cfg_regalloc_validate.mli as compiler-libs/cfg_regalloc_validate.mli)
   (cfg_to_linear_desc.mli as compiler-libs/cfg_to_linear_desc.mli)
@@ -1229,6 +1231,18 @@
   (.ocamloptcomp.objs/byte/cfg_liveness.cmti
    as
    compiler-libs/cfg_liveness.cmti)
+  (.ocamloptcomp.objs/byte/cfg_loop_infos.cmi
+   as
+   compiler-libs/cfg_loop_infos.cmi)
+  (.ocamloptcomp.objs/byte/cfg_loop_infos.cmo
+   as
+   compiler-libs/cfg_loop_infos.cmo)
+  (.ocamloptcomp.objs/byte/cfg_loop_infos.cmt
+   as
+   compiler-libs/cfg_loop_infos.cmt)
+  (.ocamloptcomp.objs/byte/cfg_loop_infos.cmti
+   as
+   compiler-libs/cfg_loop_infos.cmti)
   (.ocamloptcomp.objs/byte/cfg_regalloc_utils.cmi
    as
    compiler-libs/cfg_regalloc_utils.cmi)
@@ -1549,6 +1563,9 @@
   (.ocamloptcomp.objs/native/cfg_liveness.cmx
    as
    compiler-libs/cfg_liveness.cmx)
+  (.ocamloptcomp.objs/native/cfg_loop_infos.cmx
+   as
+   compiler-libs/cfg_loop_infos.cmx)
   (.ocamloptcomp.objs/native/cfg_regalloc_utils.cmx
    as
    compiler-libs/cfg_regalloc_utils.cmx)


### PR DESCRIPTION
This pull request implements a new spilling heuristics for IRC,
where the cost of a register use is not constant but depends on
the number of nested loops.

In order to implement that, a new module (namely `Cfg_loop_infos`)
contains various helpers computing dominators, back edges, and
loops from a CFG value.

The current implementation is rather naive and the data structures
not necessarily adequate, with the immediate goal of benchmarking
and gathering numbers to decide whether this is an area worth
investing.

So far, testing has been only manual. Using the debug and verbose
modes, I have checked on small examples the computations of the
new module and the spill costs from the new heuristics. I have also
run all the tests with the new heuristics (`ci` targets), even
though I chose to keep the current heuristics for the CI jobs.