### PR TITLE
Layouts for parameters in lambda & remove most layout_top

### DIFF
--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -247,10 +247,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
             (id, def) :: defs, Lambda.Lvar id :: args)
         args ([], [])
     in
-    let arg_layout =
-      Typeopt.layout_union layout_field
-        (Typeopt.layout_union layout_int layout_block)
-    in
+    let arg_layout = Typeopt.layout_union layout_field layout_block in
     (* Bytecode evaluates effects in blocks from right to left, so reverse defs
        to preserve evaluation order. Relevant test: letrec/evaluation_order_3 *)
     let lam =

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -247,12 +247,16 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
             (id, def) :: defs, Lambda.Lvar id :: args)
         args ([], [])
     in
+    let arg_layout =
+      Typeopt.layout_union layout_field
+        (Typeopt.layout_union layout_int layout_block)
+    in
     (* Bytecode evaluates effects in blocks from right to left, so reverse defs
        to preserve evaluation order. Relevant test: letrec/evaluation_order_3 *)
     let lam =
       List.fold_left
         (fun body (id, def) : Lambda.lambda ->
-          Llet (Strict, Lambda.layout_block, id, def, body))
+          Llet (Strict, arg_layout, id, def, body))
         (Lambda.Lprim (prim, args, dbg))
         defs
     in

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -252,7 +252,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
     let lam =
       List.fold_left
         (fun body (id, def) : Lambda.lambda ->
-          Llet (Strict, Lambda.layout_top, id, def, body))
+          Llet (Strict, Lambda.layout_block, id, def, body))
         (Lambda.Lprim (prim, args, dbg))
         defs
     in
@@ -398,7 +398,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
         List.fold_right
           (fun (id, def) (letrec, inner_effects, inner_functions) ->
             let let_def =
-              { let_kind = Strict; layout = Lambda.layout_top; ident = id }
+              { let_kind = Strict; layout = Lambda.layout_letrec; ident = id }
             in
             if Ident.Set.mem id outer_vars
             then
@@ -539,7 +539,7 @@ let dissect_letrec ~bindings ~body =
     List.fold_right
       (fun (id, def) letrec ->
         let let_def =
-          { let_kind = Strict; layout = Lambda.layout_top; ident = id }
+          { let_kind = Strict; layout = Lambda.layout_letrec; ident = id }
         in
         prepare_letrec letbound (Some let_def) def letrec)
       bindings
@@ -593,7 +593,8 @@ let dissect_letrec ~bindings ~body =
   let with_preallocations =
     List.fold_left
       (fun body (id, binding) ->
-        Llet (Strict, Lambda.layout_top, id, binding, body))
+        (* Preallocations can only be blocks *)
+        Llet (Strict, Lambda.layout_block, id, binding, body))
       with_non_rec preallocations
   in
   let with_constants =
@@ -608,17 +609,18 @@ let dissect_letrec ~bindings ~body =
       with_preallocations letrec.consts
   in
   let substituted = Lambda.rename letrec.substitution with_constants in
+  let body_layout = Lambda.layout_top in
   if not letrec.needs_region
   then substituted
   else
     Lstaticcatch
-      ( Lregion
-          (Lambda.rename bound_ids_freshening substituted, Lambda.layout_top),
+      ( Lregion (Lambda.rename bound_ids_freshening substituted, body_layout),
         ( cont,
-          List.map (fun (bound_id, _) -> bound_id, Lambda.layout_top) bindings
-        ),
+          List.map
+            (fun (bound_id, _) -> bound_id, Lambda.layout_letrec)
+            bindings ),
         real_body,
-        Lambda.layout_top )
+        body_layout )
 
 type dissected =
   | Dissected of Lambda.lambda

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -496,6 +496,7 @@ val layout_lazy : layout
 val layout_lazy_contents : layout
 (* A layout that is Pgenval because we are missing layout polymorphism *)
 val layout_any_value : layout
+(* A layout that is Pgenval because it is bound by a letrec *)
 val layout_letrec : layout
 
 val layout_top : layout

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -926,7 +926,7 @@ end
 
 type 'row pattern_matching = {
   mutable cases : 'row list;
-  args : (lambda * let_kind) list;
+  args : (lambda * let_kind * layout) list;
       (** args are not just Ident.t in at least the following cases:
         - when matching the arguments of a constructor,
           direct field projections are used (make_field_args)
@@ -1433,7 +1433,7 @@ and precompile_var args cls def k =
      If the rest doesn't generate any split, abort and do_not_precompile. *)
   match args with
   | [] -> assert false
-  | _ :: ((Lvar v, _) as arg) :: rargs -> (
+  | _ :: ((Lvar v, _, _) as arg) :: rargs -> (
       (* We will use the name of the head column of the submatrix
          we compile, and this is the *second* column of our argument. *)
       match cls with
@@ -1451,7 +1451,7 @@ and precompile_var args cls def k =
                 (* we learned by pattern-matching on [args]
                    that [p::ps] has at least two arguments,
                    so [ps] must be non-empty *)
-                half_simplify_clause ~arg:(fst arg) (ps, act))
+                half_simplify_clause ~arg:(Lvar v) (ps, act))
               cls
           and var_def = Default_environment.pop_column def in
           let { me = first; matrix }, nexts =
@@ -1664,7 +1664,7 @@ let make_line_matching get_expr_args head def = function
       }
 
 type 'a division = {
-  args : (lambda * let_kind) list;
+  args : (lambda * let_kind * layout) list;
   cells : ('a * cell) list
 }
 
@@ -1754,7 +1754,7 @@ let get_pat_args_constr p rem =
   | { pat_desc = Tpat_construct (_, _, args, _) } -> args @ rem
   | _ -> assert false
 
-let get_expr_args_constr ~scopes head (arg, _mut) rem =
+let get_expr_args_constr ~scopes head (arg, _mut, layout) rem =
   let cstr =
     match head.pat_desc with
     | Patterns.Head.Construct cstr -> cstr
@@ -1766,19 +1766,19 @@ let get_expr_args_constr ~scopes head (arg, _mut) rem =
       if pos > last_pos then
         argl
       else
-        (Lprim (Pfield (pos, Reads_agree), [ arg ], loc), binding_kind)
+        (Lprim (Pfield (pos, Reads_agree), [ arg ], loc), binding_kind, layout_field)
           :: make_args (pos + 1)
     in
     make_args first_pos
   in
   if cstr.cstr_inlined <> None then
-    (arg, Alias) :: rem
+    (arg, Alias, layout) :: rem
   else
     match cstr.cstr_tag with
     | Cstr_constant _
     | Cstr_block _ ->
         make_field_accesses Alias 0 (cstr.cstr_arity - 1) rem
-    | Cstr_unboxed -> (arg, Alias) :: rem
+    | Cstr_unboxed -> (arg, Alias, layout) :: rem
     | Cstr_extension _ -> make_field_accesses Alias 1 cstr.cstr_arity rem
 
 let divide_constructor ~scopes ctx pm =
@@ -1796,10 +1796,10 @@ let get_expr_args_variant_constant = drop_expr_arg
 let nonconstant_variant_field index =
   Lambda.Pfield(index, Reads_agree)
 
-let get_expr_args_variant_nonconst ~scopes head (arg, _mut) rem =
+let get_expr_args_variant_nonconst ~scopes head (arg, _mut, _layout) rem =
   let loc = head_loc ~scopes head in
    let field_prim = nonconstant_variant_field 1 in
-  (Lprim (field_prim, [ arg ], loc), Alias) :: rem
+  (Lprim (field_prim, [ arg ], loc), Alias, layout_field) :: rem
 
 let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
   let rec divide = function
@@ -2006,9 +2006,9 @@ let inline_lazy_force arg pos loc =
          tables (~ 250 elts); conditionals are better *)
     inline_lazy_force_cond arg pos loc
 
-let get_expr_args_lazy ~scopes head (arg, _mut) rem =
+let get_expr_args_lazy ~scopes head (arg, _mut, _layout) rem =
   let loc = head_loc ~scopes head in
-  (inline_lazy_force arg Rc_normal loc, Strict) :: rem
+  (inline_lazy_force arg Rc_normal loc, Strict, layout_lazy_contents) :: rem
 
 let divide_lazy ~scopes head ctx pm =
   divide_line (Context.specialize head)
@@ -2024,14 +2024,14 @@ let get_pat_args_tuple arity p rem =
   | { pat_desc = Tpat_tuple args } -> args @ rem
   | _ -> assert false
 
-let get_expr_args_tuple ~scopes head (arg, _mut) rem =
+let get_expr_args_tuple ~scopes head (arg, _mut, _layout) rem =
   let loc = head_loc ~scopes head in
   let arity = Patterns.Head.arity head in
   let rec make_args pos =
     if pos >= arity then
       rem
     else
-      (Lprim (Pfield (pos, Reads_agree), [ arg ], loc), Alias)
+      (Lprim (Pfield (pos, Reads_agree), [ arg ], loc), Alias, layout_field)
         :: make_args (pos + 1)
   in
   make_args 0
@@ -2057,7 +2057,7 @@ let get_pat_args_record num_fields p rem =
       record_matching_line num_fields lbl_pat_list @ rem
   | _ -> assert false
 
-let get_expr_args_record ~scopes head (arg, _mut) rem =
+let get_expr_args_record ~scopes head (arg, _mut, layout) rem =
   let loc = head_loc ~scopes head in
   let all_labels =
     let open Patterns.Head in
@@ -2077,24 +2077,25 @@ let get_expr_args_record ~scopes head (arg, _mut) rem =
         | Immutable -> Reads_agree
         | Mutable -> Reads_vary
       in
-      let access =
+      let access, layout =
         match lbl.lbl_repres with
         | Record_regular
         | Record_inlined _ ->
-            Lprim (Pfield (lbl.lbl_pos, sem), [ arg ], loc)
-        | Record_unboxed _ -> arg
+            Lprim (Pfield (lbl.lbl_pos, sem), [ arg ], loc), layout_field
+        | Record_unboxed _ -> arg, layout
         | Record_float ->
            (* TODO: could optimise to Alloc_local sometimes *)
-           Lprim (Pfloatfield (lbl.lbl_pos, sem, alloc_heap), [ arg ], loc)
+           Lprim (Pfloatfield (lbl.lbl_pos, sem, alloc_heap), [ arg ], loc),
+           layout_float
         | Record_extension _ ->
-            Lprim (Pfield (lbl.lbl_pos + 1, sem), [ arg ], loc)
+            Lprim (Pfield (lbl.lbl_pos + 1, sem), [ arg ], loc), layout_field
       in
       let str =
         match lbl.lbl_mut with
         | Immutable -> Alias
         | Mutable -> StrictOpt
       in
-      (access, str) :: make_args (pos + 1)
+      (access, str, layout) :: make_args (pos + 1)
   in
   make_args 0
 
@@ -2121,7 +2122,7 @@ let get_pat_args_array p rem =
   | { pat_desc = Tpat_array (_, patl) } -> patl @ rem
   | _ -> assert false
 
-let get_expr_args_array ~scopes kind head (arg, _mut) rem =
+let get_expr_args_array ~scopes kind head (arg, _mut, _layout) rem =
   let am, len =
     let open Patterns.Head in
     match head.pat_desc with
@@ -2133,11 +2134,13 @@ let get_expr_args_array ~scopes kind head (arg, _mut) rem =
     if pos >= len then
       rem
     else
+      (* CR ncourant: could do better than layout_field using kind *)
       ( Lprim
           (Parrayrefu kind, [ arg; Lconst (Const_base (Const_int pos)) ], loc),
-        match am with
+        (match am with
         | Mutable   -> StrictOpt
-        | Immutable -> Alias )
+        | Immutable -> Alias);
+        layout_field)
       :: make_args (pos + 1)
   in
   make_args 0
@@ -3276,25 +3279,25 @@ and compile_match_nonempty ~scopes value_kind repr partial ctx
     (m : Typedtree.pattern Non_empty_row.t clause pattern_matching)=
   match m with
   | { cases = []; args = [] } -> comp_exit ctx m
-  | { args = (arg, str) :: argl } ->
+  | { args = (arg, str, layout) :: argl } ->
       let v, newarg = arg_to_var arg m.cases in
-      let args = (newarg, Alias) :: argl in
+      let args = (newarg, Alias, layout) :: argl in
       let cases = List.map (half_simplify_nonempty ~arg:newarg) m.cases in
       let m = { m with args; cases } in
       let first_match, rem =
         split_and_precompile_half_simplified ~arg:newarg m in
-      combine_handlers ~scopes value_kind repr partial ctx (v, str, Lambda.layout_top, arg) first_match rem
+      combine_handlers ~scopes value_kind repr partial ctx (v, str, layout, arg) first_match rem
   | _ -> assert false
 
 and compile_match_simplified ~scopes value_kind  repr partial ctx
     (m : Simple.clause pattern_matching) =
   match m with
   | { cases = []; args = [] } -> comp_exit ctx m
-  | { args = ((Lvar v as arg), str) :: argl } ->
-      let args = (arg, Alias) :: argl in
+  | { args = ((Lvar v as arg), str, layout) :: argl } ->
+      let args = (arg, Alias, layout) :: argl in
       let m = { m with args } in
       let first_match, rem = split_and_precompile_simplified m in
-      combine_handlers value_kind ~scopes repr partial ctx (v, str, Lambda.layout_top, arg)
+      combine_handlers value_kind ~scopes repr partial ctx (v, str, layout, arg)
         first_match rem
   | _ -> assert false
 
@@ -3332,7 +3335,7 @@ and do_compile_matching ~scopes value_kind repr partial ctx pmh =
   | Pm pm -> (
       let arg =
         match pm.args with
-        | (first_arg, _) :: _ -> first_arg
+        | (first_arg, _, _) :: _ -> first_arg
         | _ ->
             (* We arrive in do_compile_matching from:
                - compile_matching
@@ -3556,9 +3559,9 @@ let toplevel_handler ~scopes value_kind loc ~failer partial args cases compile_f
           check_total ~scopes value_kind loc ~failer total lam raise_num
       end
 
-let compile_matching ~scopes value_kind loc ~failer repr arg pat_act_list partial =
+let compile_matching ~scopes value_kind loc ~failer repr (arg, arg_layout) pat_act_list partial =
   let partial = check_partial pat_act_list partial in
-  let args = [ (arg, Strict) ] in
+  let args = [ (arg, Strict, arg_layout) ] in
   let rows = map_on_rows (fun pat -> (pat, [])) pat_act_list in
   toplevel_handler ~scopes value_kind loc ~failer partial args rows (fun partial pm ->
     compile_match_nonempty ~scopes value_kind repr partial (Context.start 1) pm)
@@ -3577,11 +3580,11 @@ let for_trywith ~scopes value_kind loc param pat_act_list =
      the reraise (hence the [_noloc]) to avoid seeing this
      silent reraise in exception backtraces. *)
   compile_matching ~scopes value_kind loc ~failer:(Reraise_noloc param)
-    None param pat_act_list Partial
+    None (param, layout_block) pat_act_list Partial
 
 let simple_for_let ~scopes value_kind loc param pat body =
   compile_matching ~scopes value_kind loc ~failer:Raise_match_failure
-    None param [ (pat, body) ] Partial
+    None (param, Typeopt.layout pat.pat_env pat.pat_type) [ (pat, body) ] Partial
 
 (* Optimize binding of immediate tuples
 
@@ -3748,7 +3751,8 @@ let for_let ~scopes loc param pat body_kind body =
 (* Easy case since variables are available *)
 let for_tupled_function ~scopes loc kind paraml pats_act_list partial =
   let partial = check_partial_list pats_act_list partial in
-  let args = List.map (fun id -> (Lvar id, Strict)) paraml in
+  (* The arguments of a tupled function are always values since they must be fields *)
+  let args = List.map (fun id -> (Lvar id, Strict, layout_field)) paraml in
   let handler =
     toplevel_handler ~scopes kind loc ~failer:Raise_match_failure
       partial args pats_act_list in
@@ -3839,23 +3843,25 @@ let do_for_multiple_match ~scopes value_kind loc paraml mode pat_act_list partia
   let repr = None in
   let arg =
     let sloc = Scoped_location.of_location ~scopes loc in
-    Lprim (Pmakeblock (0, Immutable, None, mode), paraml, sloc) in
+    (* CR ncourant: this can build a mixed block, but it should never actually be
+       created except if the pattern-matching binds it, in which case it should be
+       rejected by the typing. Do we really trust this case will not happen? *)
+    Lprim (Pmakeblock (0, Immutable, None, mode), List.map fst paraml, sloc) in
   let handler =
     let partial = check_partial pat_act_list partial in
     let rows = map_on_rows (fun p -> (p, [])) pat_act_list in
     toplevel_handler ~scopes value_kind loc ~failer:Raise_match_failure
-      partial [ (arg, Strict) ] rows in
+      partial [ (arg, Strict, layout_block) ] rows in
   handler (fun partial pm1 ->
     let pm1_half =
       { pm1 with cases = List.map (half_simplify_nonempty ~arg) pm1.cases }
     in
     let next, nexts = split_and_precompile_half_simplified ~arg pm1_half in
     let size = List.length paraml
-    and idl = List.map (function
-      | Lvar id -> id
-      | _ -> Ident.create_local "*match*") paraml in
-    let idl_with_layouts = List.map (fun id -> (id, Lambda.layout_top)) idl in
-    let args = List.map (fun id -> (Lvar id, Alias)) idl in
+    and idl_with_layouts = List.map (function
+      | Lvar id, layout -> id, layout
+      | _, layout -> Ident.create_local "*match*", layout) paraml in
+    let args = List.map (fun (id, layout) -> (Lvar id, Alias, layout)) idl_with_layouts in
     let flat_next = flatten_precompiled size args next
     and flat_nexts =
       List.map (fun (e, pm) -> (e, flatten_precompiled size args pm)) nexts
@@ -3864,24 +3870,24 @@ let do_for_multiple_match ~scopes value_kind loc paraml mode pat_act_list partia
       comp_match_handlers value_kind (compile_flattened ~scopes value_kind repr) partial
         (Context.start size) flat_next flat_nexts
     in
-    List.fold_right2 (bind_with_layout Strict) idl_with_layouts paraml lam, total
+    List.fold_right2 (bind_with_layout Strict) idl_with_layouts (List.map fst paraml) lam, total
   )
 
 (* PR#4828: Believe it or not, the 'paraml' argument below
    may not be side effect free. *)
 
-let param_to_var param =
+let param_to_var (param, layout) =
   match param with
-  | Lvar v -> (v, None)
-  | _ -> (Ident.create_local "*match*", Some param)
+  | Lvar v -> (v, layout, None)
+  | _ -> (Ident.create_local "*match*", layout, Some param)
 
-let bind_opt (v, eo) k =
+let bind_opt (v, layout, eo) k =
   match eo with
   | None -> k
-  | Some e -> Lambda.bind_with_layout Strict (v, Lambda.layout_top) e k
+  | Some e -> Lambda.bind_with_layout Strict (v, layout) e k
 
 let for_multiple_match ~scopes value_kind loc paraml mode pat_act_list partial =
   let v_paraml = List.map param_to_var paraml in
-  let paraml = List.map (fun (v, _) -> Lvar v) v_paraml in
+  let paraml = List.map (fun (v, layout, _) -> (Lvar v, layout)) v_paraml in
   List.fold_right bind_opt v_paraml
     (do_for_multiple_match ~scopes value_kind loc paraml mode pat_act_list partial)

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -2139,7 +2139,7 @@ let get_expr_args_array ~scopes kind head (arg, _mut, _layout) rem =
           (Parrayrefu kind, [ arg; Lconst (Const_base (Const_int pos)) ], loc),
         (match am with
         | Mutable   -> StrictOpt
-        | Immutable -> Alias);
+        | Immutable -> Alias),
         layout_field)
       :: make_args (pos + 1)
   in

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -22,7 +22,7 @@ open Debuginfo.Scoped_location
 (* Entry points to match compiler *)
 val for_function:
         scopes:scopes -> layout -> Location.t ->
-        int ref option -> lambda -> (pattern * lambda) list -> partial ->
+        int ref option -> (lambda * layout) -> (pattern * lambda) list -> partial ->
         lambda
 val for_trywith:
         scopes:scopes -> layout -> Location.t ->
@@ -34,7 +34,7 @@ val for_let:
         lambda
 val for_multiple_match:
         scopes:scopes -> layout -> Location.t ->
-        lambda list -> alloc_mode -> (pattern * lambda) list -> partial ->
+        (lambda * layout) list -> alloc_mode -> (pattern * lambda) list -> partial ->
         lambda
 
 val for_tupled_function:

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -777,8 +777,14 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
         List.iter (fun (id, _) -> if Ident.Set.mem id fv then raise Exit) map;
 
         let inner_id = Ident.create_local (Ident.name fun_id ^ "_inner") in
-        let map_param p = try List.assoc p map with Not_found -> p in
-        let args = List.map (fun (p, _) -> Lvar (map_param p)) params in
+        let map_param p layout =
+          try
+            (* If the param is optional, then it must be a value *)
+            List.assoc p map, Lambda.layout_field
+          with
+            Not_found -> p, layout
+        in
+        let args = List.map (fun (p, layout) -> Lvar (fst (map_param p layout))) params in
         let wrapper_body =
           Lapply {
             ap_func = Lvar inner_id;
@@ -793,10 +799,10 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
             ap_probe=None;
           }
         in
-        let inner_params = List.map map_param (List.map fst params) in
-        let new_ids = List.map Ident.rename inner_params in
+        let inner_params = List.map (fun (param, layout) -> map_param param layout) params in
+        let new_ids = List.map (fun (param, layout) -> (Ident.rename param, layout)) inner_params in
         let subst =
-          List.fold_left2 (fun s id new_id ->
+          List.fold_left2 (fun s (id, _) (new_id, _) ->
             Ident.Map.add id new_id s
           ) Ident.Map.empty inner_params new_ids
         in
@@ -804,7 +810,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
         let body = if add_region then Lregion (body, return) else body in
         let inner_fun =
           lfunction ~kind:(Curried {nlocal=0})
-            ~params:(List.map (fun id -> id, Lambda.layout_top) new_ids)
+            ~params:new_ids
             ~return ~body ~attr ~loc ~mode ~region:true
         in
         (wrapper_body, (inner_id, inner_fun))

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -27,6 +27,16 @@ type error = Tags of label * label
 
 exception Error of Location.t * error
 
+(* Layouts for types defined in camlinternalOO.ml *)
+let layout_label = layout_int
+let layout_label_array = layout_array Pintarray
+let layout_t = layout_any_value
+let layout_obj = layout_array Pgenarray
+let layout_table = layout_block
+let layout_meth = layout_any_value
+let layout_tables = Lambda.Pvalue Pgenval
+
+
 let lfunction ?(kind=Curried {nlocal=0}) ?(region=true) return_layout params body =
   if params = [] then body else
   match kind, body with
@@ -92,12 +102,12 @@ let set_inst_var ~scopes obj id expr =
 
 let transl_val tbl create name =
   mkappl (oo_prim (if create then "new_variable" else "get_variable"),
-          [Lvar tbl; transl_label name], Lambda.layout_int)
+          [Lvar tbl; transl_label name], layout_int)
 
 let transl_vals tbl create strict vals rem =
   List.fold_right
     (fun (name, id) rem ->
-      Llet(strict, Lambda.layout_int, id, transl_val tbl create name, rem))
+      Llet(strict, layout_int, id, transl_val tbl create name, rem))
     vals rem
 
 let meths_super tbl meths inh_meths =
@@ -105,7 +115,7 @@ let meths_super tbl meths inh_meths =
     (fun (nm, id) rem ->
        try
          (nm, id,
-          mkappl(oo_prim "get_method", [Lvar tbl; Lvar (Meths.find nm meths)], Lambda.layout_function))
+          mkappl(oo_prim "get_method", [Lvar tbl; Lvar (Meths.find nm meths)], layout_meth))
          :: rem
        with Not_found -> rem)
     inh_meths []
@@ -113,7 +123,7 @@ let meths_super tbl meths inh_meths =
 let bind_super tbl (vals, meths) cl_init =
   transl_vals tbl false StrictOpt vals
     (List.fold_right (fun (_nm, id, def) rem ->
-         Llet(StrictOpt, Lambda.layout_object, id, def, rem))
+         Llet(StrictOpt, layout_meth, id, def, rem))
        meths cl_init)
 
 let create_object cl obj init =
@@ -123,15 +133,15 @@ let create_object cl obj init =
     (inh_init,
      mkappl (oo_prim (if has_init then "create_object_and_run_initializers"
                       else"create_object_opt"),
-             [obj; Lvar cl], Lambda.layout_object))
+             [obj; Lvar cl], layout_obj))
   else begin
    (inh_init,
-    Llet(Strict, Lambda.layout_object, obj',
-            mkappl (oo_prim "create_object_opt", [obj; Lvar cl], Lambda.layout_object),
+    Llet(Strict, layout_obj, obj',
+            mkappl (oo_prim "create_object_opt", [obj; Lvar cl], layout_obj),
          Lsequence(obj_init,
                    if not has_init then Lvar obj' else
                    mkappl (oo_prim "run_initializers_opt",
-                           [obj; Lvar obj'; Lvar cl], Lambda.layout_object))))
+                           [obj; Lvar obj'; Lvar cl], layout_obj))))
   end
 
 let name_pattern default p =
@@ -155,7 +165,7 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
       let loc = of_location ~scopes cl.cl_loc in
       let path_lam = transl_class_path loc cl.cl_env path in
       ((envs, (path, path_lam, obj_init) :: inh_init),
-       mkappl(Lvar obj_init, env @ [obj], Lambda.layout_object))
+       mkappl(Lvar obj_init, env @ [obj], layout_obj))
   | Tcl_structure str ->
       create_object cl_table obj (fun obj ->
         let (inh_init, obj_init, has_init) =
@@ -194,13 +204,14 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
       (inh_init,
        let build params rem =
          let param = name_pattern "param" pat in
+         let param_layout = Typeopt.layout pat.pat_env pat.pat_type in
          Lambda.lfunction
-                   ~kind:(Curried {nlocal=0}) ~params:((param, Lambda.layout_top)::params)
-                   ~return:Lambda.layout_top
+                   ~kind:(Curried {nlocal=0}) ~params:((param, param_layout)::params)
+                   ~return:layout_obj
                    ~attr:default_function_attribute
                    ~loc:(of_location ~scopes pat.pat_loc)
-                   ~body:(Matching.for_function ~scopes Lambda.layout_top pat.pat_loc
-                             None (Lvar param) [pat, rem] partial)
+                   ~body:(Matching.for_function ~scopes layout_obj pat.pat_loc
+                             None (Lvar param, param_layout) [pat, rem] partial)
                    ~mode:alloc_heap
                    ~region:true
        in
@@ -214,13 +225,13 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
       let (inh_init, obj_init) =
         build_object_init ~scopes cl_table obj params inh_init obj_init cl
       in
-      (inh_init, transl_apply ~result_layout:Lambda.layout_top ~scopes obj_init oexprs Loc_unknown)
+      (inh_init, transl_apply ~scopes ~result_layout:layout_object obj_init oexprs Loc_unknown)
   | Tcl_let (rec_flag, defs, vals, cl) ->
       let (inh_init, obj_init) =
         build_object_init ~scopes cl_table obj (vals @ params)
           inh_init obj_init cl
       in
-      (inh_init, Translcore.transl_let ~scopes rec_flag defs Lambda.layout_top obj_init)
+      (inh_init, Translcore.transl_let ~scopes rec_flag defs layout_obj obj_init)
   | Tcl_open (_, cl)
   | Tcl_constraint (cl, _, _, _, _) ->
       build_object_init ~scopes cl_table obj params inh_init obj_init cl
@@ -239,13 +250,14 @@ let rec build_object_init_0
       let ((_,inh_init), obj_init) =
         build_object_init ~scopes cl_table obj params (envs,[]) copy_env cl in
       let obj_init =
-        if ids = [] then obj_init else lfunction Lambda.layout_top [self, Lambda.layout_top] obj_init in
-      (inh_init, lfunction Lambda.layout_top [env, Lambda.layout_top] (subst_env env inh_init obj_init))
+        if ids = [] then obj_init else lfunction layout_obj [self, layout_obj] obj_init in
+      (inh_init, lfunction (if ids = [] then layout_obj else layout_function)
+         [env, layout_block] (subst_env env inh_init obj_init))
 
 
 let bind_method tbl lab id cl_init =
-  Llet(Strict, Lambda.layout_int, id, mkappl (oo_prim "get_method_label",
-                           [Lvar tbl; transl_label lab], Lambda.layout_int),
+  Llet(Strict, layout_label, id, mkappl (oo_prim "get_method_label",
+                           [Lvar tbl; transl_label lab], layout_label),
        cl_init)
 
 let bind_methods tbl meths vals cl_init =
@@ -259,12 +271,12 @@ let bind_methods tbl meths vals cl_init =
     if nvals = 0 then "get_method_labels", [] else
     "new_methods_variables", [transl_meth_list (List.map fst vals)]
   in
-  Llet(Strict, Lambda.layout_array Pintarray, ids,
+  Llet(Strict, layout_label_array, ids,
        mkappl (oo_prim getter,
                [Lvar tbl; transl_meth_list (List.map fst methl)] @ names,
-              Lambda.layout_array Pintarray),
+              layout_label_array),
        List.fold_right
-         (fun (_lab,id) lam -> decr i; Llet(StrictOpt, Lambda.layout_int, id,
+         (fun (_lab,id) lam -> decr i; Llet(StrictOpt, layout_label, id,
                                            lfield ids !i, lam))
          (methl @ vals) cl_init)
 
@@ -272,13 +284,13 @@ let output_methods tbl methods lam =
   match methods with
     [] -> lam
   | [lab; code] ->
-      lsequence (mkappl(oo_prim "set_method", [Lvar tbl; lab; code], Lambda.layout_unit)) lam
+      lsequence (mkappl(oo_prim "set_method", [Lvar tbl; lab; code], layout_unit)) lam
   | _ ->
       let methods =
         Lprim(Pmakeblock(0,Immutable,None,alloc_heap), methods, Loc_unknown)
       in
       lsequence (mkappl(oo_prim "set_methods",
-                        [Lvar tbl; Lprim (Popaque, [methods], Loc_unknown)], Lambda.layout_unit))
+                        [Lvar tbl; Lprim (Popaque, [methods], Loc_unknown)], layout_unit))
         lam
 
 let rec ignore_cstrs cl =
@@ -302,10 +314,10 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
       begin match inh_init with
       | (_, path_lam, obj_init)::inh_init ->
           (inh_init,
-           Llet (Strict, Lambda.layout_object, obj_init,
+           Llet (Strict, layout_t, obj_init,
                  mkappl(Lprim(class_field 1, [path_lam], Loc_unknown), (Lvar cla ::
                         if top then [Lprim(class_field 3, [path_lam], Loc_unknown)]
-                        else []), Lambda.layout_object),
+                        else []), layout_t),
                  bind_super cla super cl_init))
       | _ ->
           assert false
@@ -340,7 +352,7 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
                   if !Clflags.native_code && List.length met_code = 1 then
                     (* Force correct naming of method for profiles *)
                     let met = Ident.create_local ("method_" ^ name.txt) in
-                    [Llet(Strict, Lambda.layout_top, met, List.hd met_code, Lvar met)]
+                    [Llet(Strict, layout_meth, met, List.hd met_code, Lvar met)]
                   else met_code
                 in
                 (inh_init, cl_init,
@@ -350,7 +362,7 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
                 (inh_init,
                  Lsequence(mkappl (oo_prim "add_initializer",
                                    Lvar cla :: msubst false
-                                                 (transl_exp ~scopes exp), Lambda.layout_unit),
+                                                 (transl_exp ~scopes exp), layout_unit),
                            cl_init),
                  methods, values)
             | Tcf_attribute _ ->
@@ -393,23 +405,23 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
           let cl_init =
             List.fold_left
               (fun init (nm, id, _) ->
-                Llet(StrictOpt, Lambda.layout_top, id,
+                Llet(StrictOpt, layout_meth, id,
                      lfield inh (index nm concr_meths + ofs),
                      init))
               cl_init methids in
           let cl_init =
             List.fold_left
               (fun init (nm, id) ->
-                Llet(StrictOpt, Lambda.layout_top, id,
+                Llet(StrictOpt, layout_meth, id,
                      lfield inh (index nm vals + 1), init))
               cl_init valids in
           (inh_init,
-           Llet (Strict, Lambda.layout_array Pgenarray, inh,
+           Llet (Strict, layout_array Pgenarray, inh,
                  mkappl(oo_prim "inherits", narrow_args @
                         [path_lam;
                          Lconst(const_int (if top then 1 else 0))],
-                       Lambda.layout_array Pgenarray),
-                 Llet(StrictOpt, Lambda.layout_top, obj_init, lfield inh 0, cl_init)))
+                       layout_array Pgenarray),
+                 Llet(StrictOpt, layout_t, obj_init, lfield inh 0, cl_init)))
       | _ ->
           let core cl_init =
             build_class_init
@@ -417,10 +429,10 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
           in
           if cstr then core cl_init else
           let (inh_init, cl_init) =
-            core (Lsequence (mkappl (oo_prim "widen", [Lvar cla], Lambda.layout_unit), cl_init))
+            core (Lsequence (mkappl (oo_prim "widen", [Lvar cla], layout_unit), cl_init))
           in
           (inh_init,
-           Lsequence(mkappl (oo_prim "narrow", narrow_args, Lambda.layout_unit),
+           Lsequence(mkappl (oo_prim "narrow", narrow_args, layout_unit),
                      cl_init))
       end
   | Tcl_open (_, cl) ->
@@ -430,10 +442,10 @@ let rec build_class_lets ~scopes cl =
   match cl.cl_desc with
     Tcl_let (rec_flag, defs, _vals, cl') ->
       let env, wrap = build_class_lets ~scopes cl' in
-      (env, fun x ->
-          Translcore.transl_let ~scopes rec_flag defs Lambda.layout_top (wrap x))
+      (env, fun x_layout x ->
+          Translcore.transl_let ~scopes rec_flag defs x_layout (wrap x_layout x))
   | _ ->
-      (cl.cl_env, fun x -> x)
+      (cl.cl_env, fun _ x -> x)
 
 let rec get_class_meths cl =
   match cl.cl_desc with
@@ -466,13 +478,15 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
         transl_class_rebind ~scopes obj_init cl vf in
       let build params rem =
         let param = name_pattern "param" pat in
+        let param_layout = Typeopt.layout pat.pat_env pat.pat_type in
+        let return_layout = layout_class in
         Lambda.lfunction
-                  ~kind:(Curried {nlocal=0}) ~params:((param, Lambda.layout_top)::params)
-                  ~return:Lambda.layout_top
+                  ~kind:(Curried {nlocal=0}) ~params:((param, param_layout)::params)
+                  ~return:return_layout
                   ~attr:default_function_attribute
                   ~loc:(of_location ~scopes pat.pat_loc)
-                  ~body:(Matching.for_function ~scopes Lambda.layout_top pat.pat_loc
-                            None (Lvar param) [pat, rem] partial)
+                  ~body:(Matching.for_function ~scopes return_layout pat.pat_loc
+                            None (Lvar param, param_layout) [pat, rem] partial)
                   ~mode:alloc_heap
                   ~region:true
       in
@@ -485,11 +499,11 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
   | Tcl_apply (cl, oexprs) ->
       let path, path_lam, obj_init =
         transl_class_rebind ~scopes obj_init cl vf in
-      (path, path_lam, transl_apply ~result_layout:Lambda.layout_top ~scopes obj_init oexprs Loc_unknown)
+      (path, path_lam, transl_apply ~scopes ~result_layout:layout_class obj_init oexprs Loc_unknown)
   | Tcl_let (rec_flag, defs, _vals, cl) ->
       let path, path_lam, obj_init =
         transl_class_rebind ~scopes obj_init cl vf in
-      (path, path_lam, Translcore.transl_let ~scopes rec_flag defs Lambda.layout_top obj_init)
+      (path, path_lam, Translcore.transl_let ~scopes rec_flag defs layout_obj obj_init)
   | Tcl_structure _ -> raise Exit
   | Tcl_constraint (cl', _, _, _, _) ->
       let path, path_lam, obj_init =
@@ -510,11 +524,11 @@ let rec transl_class_rebind_0 ~scopes (self:Ident.t) obj_init cl vf =
       let path, path_lam, obj_init =
         transl_class_rebind_0 ~scopes self obj_init cl vf
       in
-      (path, path_lam, Translcore.transl_let ~scopes rec_flag defs Lambda.layout_top obj_init)
+      (path, path_lam, Translcore.transl_let ~scopes rec_flag defs layout_obj obj_init)
   | _ ->
       let path, path_lam, obj_init =
         transl_class_rebind ~scopes obj_init cl vf in
-      (path, path_lam, lfunction Lambda.layout_top [self, Lambda.layout_top] obj_init)
+      (path, path_lam, lfunction layout_obj [self, layout_obj] obj_init)
 
 let transl_class_rebind ~scopes cl vf =
   try
@@ -525,7 +539,7 @@ let transl_class_rebind ~scopes cl vf =
         ap_loc=Loc_unknown;
         ap_func=Lvar obj_init;
         ap_args=[Lvar self];
-        ap_result_layout=Lambda.layout_object;
+        ap_result_layout=layout_obj;
         ap_region_close=Rc_normal;
         ap_mode=alloc_heap;
         ap_tailcall=Default_tailcall;
@@ -536,7 +550,7 @@ let transl_class_rebind ~scopes cl vf =
     in
     let _, path_lam, obj_init' =
       transl_class_rebind_0 ~scopes self obj_init0 cl vf in
-    let id = (obj_init' = lfunction Lambda.layout_top [self, Lambda.layout_top] obj_init0) in
+    let id = (obj_init' = lfunction layout_obj [self, layout_obj] obj_init0) in
     if id then path_lam else
 
     let cla = Ident.create_local "class"
@@ -545,17 +559,17 @@ let transl_class_rebind ~scopes cl vf =
     and table = Ident.create_local "table"
     and envs = Ident.create_local "envs" in
     Llet(
-    Strict, Lambda.layout_function, new_init, lfunction Lambda.layout_top [obj_init, Lambda.layout_top] obj_init',
+    Strict, layout_function, new_init, lfunction layout_function [obj_init, layout_function] obj_init',
     Llet(
-    Alias, Lambda.layout_class, cla, path_lam,
+    Alias, layout_block, cla, path_lam,
     Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
-          [mkappl(Lvar new_init, [lfield cla 0], Lambda.layout_object);
-           lfunction Lambda.layout_top [table, Lambda.layout_top]
-             (Llet(Strict, Lambda.layout_top, env_init,
-                   mkappl(lfield cla 1, [Lvar table], Lambda.layout_top),
-                   lfunction Lambda.layout_top [envs, Lambda.layout_top]
+          [mkappl(Lvar new_init, [lfield cla 0], layout_function);
+           lfunction layout_function [table, layout_table]
+             (Llet(Strict, layout_function, env_init,
+                   mkappl(lfield cla 1, [Lvar table], layout_function),
+                   lfunction layout_function [envs, layout_block]
                      (mkappl(Lvar new_init,
-                             [mkappl(Lvar env_init, [Lvar envs], Lambda.layout_top)], Lambda.layout_top))));
+                             [mkappl(Lvar env_init, [Lvar envs], layout_obj)], layout_function))));
            lfield cla 2;
            lfield cla 3],
           Loc_unknown)))
@@ -749,7 +763,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   let no_env_update _ _ env = env in
   let msubst arr = function
       Lfunction {kind = Curried _ as kind; region;
-                 params = (self, layout) :: args; body} ->
+                 params = (self, layout) :: args; return; body} ->
         let env = Ident.create_local "env" in
         let body' =
           if new_ids = [] then body else
@@ -758,11 +772,11 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
           (* Doesn't seem to improve size for bytecode *)
           (* if not !Clflags.native_code then raise Not_found; *)
           if not arr || !Clflags.debug then raise Not_found;
-          builtin_meths [self] env env2 (lfunction Lambda.layout_top args body')
+          builtin_meths [self] env env2 (lfunction return args body')
         with Not_found ->
-          [lfunction ~kind ~region Lambda.layout_top ((self, layout) :: args)
+          [lfunction ~kind ~region return ((self, layout) :: args)
              (if not (Ident.Set.mem env (free_variables body')) then body' else
-              Llet(Alias, Lambda.layout_top, env,
+              Llet(Alias, layout_block, env,
                    Lprim(Pfield_computed Reads_vary,
                          [Lvar self; Lvar env2],
                          Loc_unknown),
@@ -781,8 +795,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
     if top then lam else
     (* must be called only once! *)
     let lam = Lambda.subst no_env_update (subst env1 lam 1 new_ids_init) lam in
-    Llet(Alias, Lambda.layout_top, env1, (if l = [] then Lvar envs else lfield envs 0),
-    Llet(Alias, Lambda.layout_top, env1',
+    Llet(Alias, layout_block, env1, (if l = [] then Lvar envs else lfield envs 0),
+    Llet(Alias, layout_block, env1',
          (if !new_ids_init = [] then Lvar env1 else lfield env1 0),
          lam))
   in
@@ -812,40 +826,40 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       if name' <> name then raise(Error(cl.cl_loc, Tags(name, name'))))
     tags pub_meths;
   let ltable table lam =
-    Llet(Strict, Lambda.layout_array Pgenarray, table,
+    Llet(Strict, layout_table, table,
          mkappl (oo_prim "create_table", [transl_meth_list pub_meths],
-                Lambda.layout_array Pgenarray), lam)
+                layout_table), lam)
   and ldirect obj_init =
-    Llet(Strict, Lambda.layout_top, obj_init, cl_init,
-         Lsequence(mkappl (oo_prim "init_class", [Lvar cla], Lambda.layout_unit),
-                   mkappl (Lvar obj_init, [lambda_unit], Lambda.layout_top)))
+    Llet(Strict, layout_function, obj_init, cl_init,
+         Lsequence(mkappl (oo_prim "init_class", [Lvar cla], layout_unit),
+                   mkappl (Lvar obj_init, [lambda_unit], layout_function)))
   in
   (* Simplest case: an object defined at toplevel (ids=[]) *)
-  if top && ids = [] then llets (ltable cla (ldirect obj_init)) else
+  if top && ids = [] then llets layout_table (ltable cla (ldirect obj_init)) else
 
   let concrete = (vflag = Concrete)
   and lclass lam =
-    let cl_init = llets (Lambda.lfunction
+    let cl_init = llets layout_function (Lambda.lfunction
                            ~kind:(Curried {nlocal=0})
                            ~attr:default_function_attribute
                            ~loc:Loc_unknown
-                           ~return:Lambda.layout_top
+                           ~return:layout_function
                            ~mode:alloc_heap
                            ~region:true
-                           ~params:[cla, Lambda.layout_class] ~body:cl_init) in
-    Llet(Strict, Lambda.layout_top, class_init, cl_init, lam (free_variables cl_init))
+                           ~params:[cla, layout_table] ~body:cl_init) in
+    Llet(Strict, layout_function, class_init, cl_init, lam (free_variables cl_init))
   and lbody fv =
     if List.for_all (fun id -> not (Ident.Set.mem id fv)) ids then
       mkappl (oo_prim "make_class",[transl_meth_list pub_meths;
-                                    Lvar class_init], Lambda.layout_class)
+                                    Lvar class_init], layout_block)
     else
       ltable table (
       Llet(
-      Strict, Lambda.layout_top, env_init, mkappl (Lvar class_init, [Lvar table], Lambda.layout_top),
+      Strict, layout_function, env_init, mkappl (Lvar class_init, [Lvar table], layout_function),
       Lsequence(
-      mkappl (oo_prim "init_class", [Lvar table], Lambda.layout_top),
+      mkappl (oo_prim "init_class", [Lvar table], layout_unit),
       Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
-            [mkappl (Lvar env_init, [lambda_unit], Lambda.layout_top);
+            [mkappl (Lvar env_init, [lambda_unit], layout_obj);
              Lvar class_init; Lvar env_init; lambda_unit],
             Loc_unknown))))
   and lbody_virt lenvs =
@@ -854,16 +868,16 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                           ~kind:(Curried {nlocal=0})
                           ~attr:default_function_attribute
                           ~loc:Loc_unknown
-                          ~return:Lambda.layout_top
+                          ~return:layout_function
                           ~mode:alloc_heap
                           ~region:true
-                          ~params:[cla, Lambda.layout_class] ~body:cl_init;
+                          ~params:[cla, layout_table] ~body:cl_init;
            lambda_unit; lenvs],
          Loc_unknown)
   in
   (* Still easy: a class defined at toplevel *)
   if top && concrete then lclass lbody else
-  if top then llets (lbody_virt lambda_unit) else
+  if top then llets layout_block (lbody_virt lambda_unit) else
 
   (* Now for the hard stuff: prepare for table caching *)
   let envs = Ident.create_local "envs"
@@ -888,14 +902,14 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       (List.rev inh_init)
   in
   let make_envs lam =
-    Llet(StrictOpt, Lambda.layout_top, envs,
+    Llet(StrictOpt, layout_block, envs,
          (if linh_envs = [] then lenv else
          Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
                lenv :: linh_envs, Loc_unknown)),
          lam)
   and def_ids cla lam =
-    Llet(StrictOpt, Lambda.layout_int, env2,
-         mkappl (oo_prim "new_variable", [Lvar cla; transl_label ""], Lambda.layout_int),
+    Llet(StrictOpt, layout_int, env2,
+         mkappl (oo_prim "new_variable", [Lvar cla; transl_label ""], layout_int),
          lam)
   in
   let inh_paths =
@@ -909,21 +923,21 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       inh_paths
   in
   let lclass lam =
-    Llet(Strict, Lambda.layout_class, class_init,
+    Llet(Strict, layout_function, class_init,
          Lambda.lfunction
-                   ~kind:(Curried {nlocal=0}) ~params:[cla, Lambda.layout_class]
-                   ~return:Lambda.layout_top
+                   ~kind:(Curried {nlocal=0}) ~params:[cla, layout_table]
+                   ~return:layout_function
                    ~attr:default_function_attribute
                    ~loc:Loc_unknown
                    ~mode:alloc_heap
                    ~region:true
                    ~body:(def_ids cla cl_init), lam)
   and lcache lam =
-    if inh_keys = [] then Llet(Alias, Lambda.layout_top, cached, Lvar tables, lam) else
-    Llet(Strict, Lambda.layout_top, cached,
+    if inh_keys = [] then Llet(Alias, layout_tables, cached, Lvar tables, lam) else
+    Llet(Strict, layout_tables, cached,
          mkappl (oo_prim "lookup_tables",
                 [Lvar tables; Lprim(Pmakearray(Paddrarray, Immutable, alloc_heap),
-                                    inh_keys, Loc_unknown)], Lambda.layout_top),
+                                    inh_keys, Loc_unknown)], layout_tables),
          lam)
   and lset cached i lam =
     Lprim(Psetfield(i, Pointer, Assignment modify_heap),
@@ -931,8 +945,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   in
   let ldirect () =
     ltable cla
-      (Llet(Strict, Lambda.layout_top, env_init, def_ids cla cl_init,
-            Lsequence(mkappl (oo_prim "init_class", [Lvar cla], Lambda.layout_unit),
+      (Llet(Strict, layout_function, env_init, def_ids cla cl_init,
+            Lsequence(mkappl (oo_prim "init_class", [Lvar cla], layout_unit),
                       lset cached 0 (Lvar env_init))))
   and lclass_virt () =
     lset cached 0
@@ -942,8 +956,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
          ~loc:Loc_unknown
          ~mode:alloc_heap
          ~region:true
-         ~return:Lambda.layout_top
-         ~params:[cla, Lambda.layout_class]
+         ~return:layout_function
+         ~params:[cla, layout_table]
          ~body:(def_ids cla cl_init))
   in
   let lupdate_cache =
@@ -952,22 +966,22 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
         lclass (
             mkappl (oo_prim "make_class_store",
                     [transl_meth_list pub_meths;
-                     Lvar class_init; Lvar cached], Lambda.layout_top)) in
+                     Lvar class_init; Lvar cached], layout_unit)) in
   let lcheck_cache =
     if !Clflags.native_code && !Clflags.afl_instrument then
       (* When afl-fuzz instrumentation is enabled, ignore the cache
          so that the program's behaviour does not change between runs *)
       lupdate_cache
     else
-      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache, Lambda.layout_top) in
-  llets (
+      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache, layout_unit) in
+  llets layout_block (
   lcache (
   Lsequence(lcheck_cache,
   make_envs (
-  if ids = [] then mkappl (lfield cached 0, [lenvs], Lambda.layout_top) else
+  if ids = [] then mkappl (lfield cached 0, [lenvs], layout_obj) else
   Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
         (if concrete then
-          [mkappl (lfield cached 0, [lenvs], Lambda.layout_top);
+          [mkappl (lfield cached 0, [lenvs], layout_obj);
            lfield cached 1;
            lfield cached 0;
            lenvs]

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -163,7 +163,7 @@ and wrap_id_pos_list loc id_pos_list get_field lam =
     List.fold_left (fun (lam, s) (id',pos,c) ->
       if Ident.Set.mem id' fv then
         let id'' = Ident.create_local (Ident.name id') in
-        (Llet(Alias, Lambda.layout_field, id'',
+        (Llet(Alias, Lambda.layout_module_field, id'',
              apply_coercion loc Alias c (get_field pos),lam),
          Ident.Map.add id' id'' s)
       else (lam, s))
@@ -1561,7 +1561,7 @@ let toploop_getvalue id =
                   Loc_unknown);
     ap_args=[Lconst(Const_base(
       Const_string (toplevel_name id, Location.none, None)))];
-    ap_result_layout = Lambda.layout_module_field;
+    ap_result_layout = Lambda.layout_any_value;
     ap_region_close=Rc_normal;
     ap_mode=alloc_heap;
     ap_tailcall=Default_tailcall;
@@ -1592,7 +1592,7 @@ let toploop_setvalue id lam =
 let toploop_setvalue_id id = toploop_setvalue id (Lvar id)
 
 let close_toplevel_term (lam, ()) =
-  Ident.Set.fold (fun id l -> Llet(Strict, Lambda.layout_module_field, id,
+  Ident.Set.fold (fun id l -> Llet(Strict, Lambda.layout_any_value, id,
                                   toploop_getvalue id, l))
                 (free_variables lam) lam
 

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -163,7 +163,7 @@ and wrap_id_pos_list loc id_pos_list get_field lam =
     List.fold_left (fun (lam, s) (id',pos,c) ->
       if Ident.Set.mem id' fv then
         let id'' = Ident.create_local (Ident.name id') in
-        (Llet(Alias, Lambda.layout_top, id'',
+        (Llet(Alias, Lambda.layout_field, id'',
              apply_coercion loc Alias c (get_field pos),lam),
          Ident.Map.add id' id'' s)
       else (lam, s))
@@ -426,7 +426,7 @@ let eval_rec_bindings bindings cont =
   | (Ignore_loc loc, None, rhs) :: rem ->
       Lsequence(Lprim(Pignore, [rhs], loc), bind_strict rem)
   | (Id id, None, rhs) :: rem ->
-      Llet(Strict, Lambda.layout_top, id, rhs, bind_strict rem)
+      Llet(Strict, Lambda.layout_module, id, rhs, bind_strict rem)
   | (_id, Some _, _rhs) :: rem ->
       bind_strict rem
   and patch_forwards = function
@@ -1561,7 +1561,7 @@ let toploop_getvalue id =
                   Loc_unknown);
     ap_args=[Lconst(Const_base(
       Const_string (toplevel_name id, Location.none, None)))];
-    ap_result_layout = Lambda.layout_top;
+    ap_result_layout = Lambda.layout_module_field;
     ap_region_close=Rc_normal;
     ap_mode=alloc_heap;
     ap_tailcall=Default_tailcall;
@@ -1580,7 +1580,7 @@ let toploop_setvalue id lam =
       [Lconst(Const_base(
          Const_string(toplevel_name id, Location.none, None)));
        lam];
-    ap_result_layout = Lambda.layout_top;
+    ap_result_layout = Lambda.layout_unit;
     ap_region_close=Rc_normal;
     ap_mode=alloc_heap;
     ap_tailcall=Default_tailcall;
@@ -1592,7 +1592,7 @@ let toploop_setvalue id lam =
 let toploop_setvalue_id id = toploop_setvalue id (Lvar id)
 
 let close_toplevel_term (lam, ()) =
-  Ident.Set.fold (fun id l -> Llet(Strict, Lambda.layout_top, id,
+  Ident.Set.fold (fun id l -> Llet(Strict, Lambda.layout_module_field, id,
                                   toploop_getvalue id, l))
                 (free_variables lam) lam
 

--- a/ocaml/testsuite/tests/basic-modules/anonymous.ocamlc.reference
+++ b/ocaml/testsuite/tests/basic-modules/anonymous.ocamlc.reference
@@ -24,9 +24,9 @@
           (f = (function {nlocal = 0} param : int 0) s = (makemutable 0 ""))
           (seq
             (ignore
-              (let (*match* = (setfield_ptr 0 s "Hello World!"))
+              (let (*match* =[int] (setfield_ptr 0 s "Hello World!"))
                 (makeblock 0)))
             (let
               (drop = (function {nlocal = 0} param : int 0)
-               *match* = (apply drop (field_mut 0 s)))
+               *match* =[int] (apply drop (field_mut 0 s)))
               (makeblock 0 A B f s drop))))))))

--- a/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
+++ b/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
@@ -22,8 +22,9 @@
       (let (f = (function {nlocal = 0} param : int 0) s = (makemutable 0 ""))
         (seq
           (ignore
-            (let (*match* = (setfield_ptr 0 s "Hello World!")) (makeblock 0)))
+            (let (*match* =[int] (setfield_ptr 0 s "Hello World!"))
+              (makeblock 0)))
           (let
             (drop = (function {nlocal = 0} param : int 0)
-             *match* = (apply drop (field_mut 0 s)))
+             *match* =[int] (apply drop (field_mut 0 s)))
             (makeblock 0 A B f s drop)))))))

--- a/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
+++ b/ocaml/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
@@ -25,13 +25,13 @@
         (setfield_ptr(root-init) 3 (global Anonymous!) s))
       (ignore
         (let
-          (*match* =
+          (*match* =[int]
              (setfield_ptr 0 (field 3 (global Anonymous!)) "Hello World!"))
           (makeblock 0)))
       (let (drop = (function {nlocal = 0} param : int 0))
         (setfield_ptr(root-init) 4 (global Anonymous!) drop))
       (let
-        (*match* =
+        (*match* =[int]
            (apply (field 4 (global Anonymous!))
              (field_mut 0 (field 3 (global Anonymous!)))))
         0)

--- a/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -26,14 +26,14 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/277 = 3 *match*/278 = 2 *match*/279 = 1)
+(let (*match*/277 =[int] 3 *match*/278 =[int] 2 *match*/279 =[int] 1)
   (catch
     (catch
       (catch (if (!= *match*/278 3) (exit 3) (exit 1)) with (3)
         (if (!= *match*/277 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
-(let (*match*/277 = 3 *match*/278 = 2 *match*/279 = 1)
+(let (*match*/277 =[int] 3 *match*/278 =[int] 2 *match*/279 =[int] 1)
   (catch (if (!= *match*/278 3) (if (!= *match*/277 1) 0 (exit 1)) (exit 1))
    with (1) 1))
 - : bool = false
@@ -47,7 +47,7 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/282 = 3 *match*/283 = 2 *match*/284 = 1)
+(let (*match*/282 =[int] 3 *match*/283 =[int] 2 *match*/284 =[int] 1)
   (catch
     (catch
       (catch
@@ -65,7 +65,7 @@ match (3, 2, 1) with
      with (5) 0)
    with (4 x/280[(consts ()) (non_consts ([0: [int], [int], [int]]))])
     (seq (ignore x/280) 1)))
-(let (*match*/282 = 3 *match*/283 = 2 *match*/284 = 1)
+(let (*match*/282 =[int] 3 *match*/283 =[int] 2 *match*/284 =[int] 1)
   (catch
     (if (!= *match*/283 3)
       (if (!= *match*/282 1) 0

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -61,7 +61,7 @@ let scrape_poly env ty =
   | d -> d
 
 let is_function_type env ty =
-  match scrape_poly env ty with
+  match scrape env ty with
   | Tarrow (_, lhs, rhs, _) -> Some (lhs, rhs)
   | _ -> None
 

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -61,7 +61,7 @@ let scrape_poly env ty =
   | d -> d
 
 let is_function_type env ty =
-  match scrape env ty with
+  match scrape_poly env ty with
   | Tarrow (_, lhs, rhs, _) -> Some (lhs, rhs)
   | _ -> None
 
@@ -365,7 +365,13 @@ let layout env ty = Lambda.Pvalue (value_kind env ty)
 let function_return_layout env ty =
   match is_function_type env ty with
   | Some (_lhs, rhs) -> layout env rhs
-  | None -> Lambda.layout_top
+  | None -> Misc.fatal_errorf "function_return_layout called on non-function type"
+
+let function2_return_layout env ty =
+  match is_function_type env ty with
+  | Some (_lhs, rhs) -> function_return_layout env rhs
+  | None -> Misc.fatal_errorf "function_return_layout called on non-function type"
+
 
 (** Whether a forward block is needed for a lazy thunk on a value, i.e.
     if the value can be represented as a float/forward/lazy *)

--- a/ocaml/typing/typeopt.mli
+++ b/ocaml/typing/typeopt.mli
@@ -30,6 +30,7 @@ val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
 val layout : Env.t -> Types.type_expr -> Lambda.layout
 val function_return_layout : Env.t -> Types.type_expr -> Lambda.layout
+val function2_return_layout : Env.t -> Types.type_expr -> Lambda.layout
 
 val classify_lazy_argument : Typedtree.expression ->
                              [ `Constant_or_function

--- a/ocaml/typing/typeopt.mli
+++ b/ocaml/typing/typeopt.mli
@@ -30,6 +30,7 @@ val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
 val layout : Env.t -> Types.type_expr -> Lambda.layout
 val function_return_layout : Env.t -> Types.type_expr -> Lambda.layout
+(* Gives the return layout of a function with two arguments. *)
 val function2_return_layout : Env.t -> Types.type_expr -> Lambda.layout
 
 val classify_lazy_argument : Typedtree.expression ->


### PR DESCRIPTION
This PR adds layouts on the parameters in lambda instead of relying on them being Pvalue Pgenval, and then removes a lot of instances of layout_top that still existed in all the files. It also generates layout-dependent caml_curry and caml_apply functions, which become necessary. 