### PR TITLE
Only insert regions when stack allocations is on

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2299,9 +2299,12 @@ let apply_function_body (arity, (mode : Lambda.alloc_mode)) =
   (* In the slowpath, a region is necessary in case the initial applications do
      local allocations *)
   let region =
-    match mode with
-    | Alloc_heap -> Some (V.create_local "region")
-    | Alloc_local -> None
+    if not Config.stack_allocation
+    then None
+    else
+      match mode with
+      | Alloc_heap -> Some (V.create_local "region")
+      | Alloc_local -> None
   in
   let rec app_fun clos n =
     if n = arity - 1

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1117,6 +1117,7 @@ method emit_expr (env:environment) exp =
         end
       end
   | Cregion e ->
+     assert(Config.stack_allocation);
      let reg = self#regs_for typ_int in
      self#insert env (Iop Ibeginregion) [| |] reg;
      let env = { env with regions = reg::env.regions; region_tail = true } in
@@ -1529,6 +1530,7 @@ method emit_tail (env:environment) exp =
         end
       end
   | Cregion e ->
+      assert(Config.stack_allocation);
       if env.region_tail then
         self#emit_return env exp (pop_all_traps env)
       else begin


### PR DESCRIPTION
When rebasing ocaml/ some checks for local allocations have been dropped, resulting in flambda-backend not working for architecture not supporting local allocations.
