### PR TITLE
Better classic unboxing with variable aliasing in to_cmm

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -94,12 +94,24 @@ let unit0 ~offsets flambda_unit ~all_code =
       ~param_types:(List.map snd return_cont_params)
   in
   (* See comment in [To_cmm_set_of_closures] about binding [my_region] *)
-  let env, _bound_var =
+  let env, toplevel_region_var =
     Env.create_bound_parameter env
       (Flambda_unit.toplevel_my_region flambda_unit)
   in
   let r = R.create ~module_symbol:(Flambda_unit.module_symbol flambda_unit) in
-  let body, res = To_cmm_expr.expr env r (Flambda_unit.body flambda_unit) in
+  let body, body_free_names, res =
+    To_cmm_expr.expr env r (Flambda_unit.body flambda_unit)
+  in
+  let free_names =
+    Backend_var.Set.remove
+      (Backend_var.With_provenance.var toplevel_region_var)
+      body_free_names
+  in
+  if not (Backend_var.Set.is_empty free_names)
+  then
+    Misc.fatal_errorf
+      "Unbound free_names in module init code when translating to cmm: %a"
+      Backend_var.Set.print free_names;
   let body =
     let dbg = Debuginfo.none in
     let unit_value = C.targetint ~dbg Targetint_32_64.one in

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -103,9 +103,7 @@ let unit0 ~offsets flambda_unit ~all_code =
     To_cmm_expr.expr env r (Flambda_unit.body flambda_unit)
   in
   let free_names =
-    Backend_var.Set.remove
-      (Backend_var.With_provenance.var toplevel_region_var)
-      body_free_names
+    To_cmm_shared.remove_var_with_provenance body_free_names toplevel_region_var
   in
   if not (Backend_var.Set.is_empty free_names)
   then

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -100,3 +100,4 @@ let classify_continuation_handler k handler ~num_free_occurrences
      && cont_is_known_to_have_exactly_one_occurrence k num_free_occurrences
   then May_inline
   else Regular
+

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -100,4 +100,3 @@ let classify_continuation_handler k handler ~num_free_occurrences
      && cont_is_known_to_have_exactly_one_occurrence k num_free_occurrences
   then May_inline
   else Regular
-

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -617,10 +617,8 @@ and split_in_env ?ensure_in_env env res var binding =
   let res, split_result = split_complex_binding ~env ~res binding in
   match split_result with
   | Already_split ->
-    if debug () then Format.eprintf "split_in_env: Already_split\n%!";
     env, res, binding
   | Split { new_bindings; split_binding } ->
-    if debug () then Format.eprintf "split_in_env: Split\n%!";
     let env =
       (* for duplicated bindings, we need to replace the original splittable
          binding with the new split binding in the bindings map of the env *)
@@ -806,27 +804,21 @@ let inline_variable ?consider_inlining_effectful_expressions env res var =
   | Binding binding -> (
     match binding.inline with
     | Do_not_inline ->
-      if debug () then Format.eprintf "inline_variable: Do_not_inline\n%!";
       will_not_inline_simple env res binding
     | Must_inline_and_duplicate ->
-      if debug () then Format.eprintf "inline_variable: Must_inline_and_dup\n%!";
       split_and_inline env res var binding
     | Must_inline_once -> (
-      if debug () then Format.eprintf "inline_variable: Must_inline_once...\n%!";
       let env = remove_binding env var in
       match To_cmm_effects.classify_by_effects_and_coeffects binding.effs with
       | Pure | Generative_immutable ->
-        if debug () then Format.eprintf "...Pure/Gen_immut\n%!";
         will_inline_complex env res binding
       | Effect | Coeffect_only -> (
         match
           pop_if_in_top_stage ?consider_inlining_effectful_expressions env var
         with
         | None ->
-          if debug () then Format.eprintf "Eff/Coeff_only: None\n%!";
           split_and_inline env res var binding
         | Some env ->
-          if debug () then Format.eprintf "Eff/Coeff_only: Some\n%!";
           will_inline_complex env res binding))
     | May_inline_once -> (
       match To_cmm_effects.classify_by_effects_and_coeffects binding.effs with
@@ -845,12 +837,6 @@ let inline_variable ?consider_inlining_effectful_expressions env res var =
 (* Handling of aliases between variables *)
 
 let add_alias env res ~var ~alias_of ~num_normal_occurrences_of_bound_vars =
-  if debug ()
-  then
-    Format.eprintf "add_alias var=%a (occs %a), alias_of=%a\n%!" Variable.print
-      var
-      (Variable.Map.print Num_occurrences.print)
-      num_normal_occurrences_of_bound_vars Variable.print alias_of;
   let num_occurrences_of_var : Num_occurrences.t =
     match Variable.Map.find var num_normal_occurrences_of_bound_vars with
     | exception Not_found -> More_than_one (* TODO: that should not happen *)

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -63,6 +63,8 @@ type 'env trans_prim =
 
 (* Delayed let-bindings (see the .mli) *)
 
+type free_names = Backend_var.Set.t
+
 (* the binding kinds *)
 type simple = Simple
 
@@ -79,12 +81,20 @@ type _ inline =
    The arguments are stored with their effects. This means that if we need to
    split the binding, we can re-bind each argument with its correct effects. *)
 type _ bound_expr =
-  | Simple : { cmm_expr : Cmm.expression } -> simple bound_expr
-  | Split : { cmm_expr : Cmm.expression } -> complex bound_expr
+  | Simple :
+      { cmm_expr : Cmm.expression;
+        free_names : free_names
+      }
+      -> simple bound_expr
+  | Split :
+      { cmm_expr : Cmm.expression;
+        free_names : free_names
+      }
+      -> complex bound_expr
   | Splittable_prim :
       { dbg : Debuginfo.t;
         prim : Flambda_primitive.Without_args.t;
-        args : (Cmm.expression * Ece.t) list
+        args : (Cmm.expression * Ece.t * free_names) list
       }
       -> complex bound_expr
 
@@ -133,7 +143,7 @@ type t =
        handlers. *)
     vars_extra : extra_info Variable.Map.t;
     (* Extra information associated with Flambda variables. *)
-    vars : Cmm.expression Variable.Map.t;
+    vars : (Cmm.expression * free_names) Variable.Map.t;
     (* Cmm expressions (of the form [Cvar ...]) for all bound variables in
        scope. *)
     bindings : any_binding Variable.Map.t;
@@ -175,10 +185,15 @@ let [@ocamlformat "disable"] print_inline (type a) ppf (inline : a inline) =
   | Must_inline_once -> Format.fprintf ppf "must_inline_once"
   | Must_inline_and_duplicate -> Format.fprintf ppf "must_inline_and_duplicate"
 
+let print_cmm_expr_with_free_names ppf (cmm_expr, free_names) =
+  Format.fprintf ppf
+    "@[<hov 1>(@[<hov 1>(expr@ %a)@]@ @[<hov 1>(free_names@ %a)@]@ )@]"
+    Printcmm.expression cmm_expr Backend_var.Set.print free_names
+
 let [@ocamlformat "disable"] print_bound_expr (type a) ppf (b : a bound_expr) =
   match b with
-  | Simple { cmm_expr; } | Split { cmm_expr; } ->
-    Printcmm.expression ppf cmm_expr
+  | Simple { cmm_expr; free_names; } | Split { cmm_expr; free_names; } ->
+    print_cmm_expr_with_free_names ppf (cmm_expr, free_names)
   | Splittable_prim { prim; args; dbg; } ->
     Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(dbg@ %a)@]@ \
@@ -187,7 +202,8 @@ let [@ocamlformat "disable"] print_bound_expr (type a) ppf (b : a bound_expr) =
       )@]"
       Debuginfo.print_compact dbg
       Flambda_primitive.Without_args.print prim
-      (Format.pp_print_list (fun ppf (cmm, _) -> Printcmm.expression ppf cmm)) args
+      (Format.pp_print_list (fun ppf (cmm, _, free_names) ->
+           print_cmm_expr_with_free_names ppf (cmm, free_names))) args
 
 let [@ocamlformat "disable"] print_binding (type a) ppf
     ({ order; inline; effs; cmm_var; bound_expr; } : a binding) =
@@ -242,7 +258,8 @@ let gen_variable v =
 
 let add_bound_param env v v' =
   let v'' = Backend_var.With_provenance.var v' in
-  let vars = Variable.Map.add v (C.var v'') env.vars in
+  let free_names = Backend_var.Set.singleton v'' in
+  let vars = Variable.Map.add v (C.var v'', free_names) env.vars in
   { env with vars }
 
 let create_bound_parameter env v =
@@ -328,9 +345,9 @@ let get_exn_extra_args env k =
 
 let next_order = ref (-1)
 
-let simple cmm_expr = Simple { cmm_expr }
+let simple cmm_expr free_names = Simple { cmm_expr; free_names }
 
-let complex_no_split cmm_expr = Split { cmm_expr }
+let complex_no_split cmm_expr free_names = Split { cmm_expr; free_names }
 
 let splittable_primitive dbg prim args = Splittable_prim { dbg; prim; args }
 
@@ -368,12 +385,13 @@ let create_binding (type a) effs var ~(inline : a inline)
      must_inline_and_duplicate (since it basically replaces a variable by either
      another variable, a constant, or a symbol). *)
   match bound_expr with
-  | (Split { cmm_expr } | Simple { cmm_expr }) when is_cmm_simple cmm_expr ->
+  | (Split { cmm_expr; free_names } | Simple { cmm_expr; free_names })
+    when is_cmm_simple cmm_expr ->
     (* trivial/simple cmm expression (as decided by [is_cmm_simple]) do not have
        effects and coeffects *)
     let effs = Ece.pure_can_be_duplicated in
     create_binding_aux effs var ~inline:Must_inline_and_duplicate
-      (Split { cmm_expr })
+      (Split { cmm_expr; free_names })
   | Simple _ | Split _ | Splittable_prim _ ->
     create_binding_aux effs var ~inline bound_expr
 
@@ -422,41 +440,49 @@ type split_result =
       }
 
 let new_bindings_for_splitting order args =
-  let (new_bindings, _), new_cmm_args =
+  let (new_bindings, _, free_names_of_new_cmm_args), new_cmm_args =
     List.fold_left_map
-      (fun (new_bindings, order) (cmm_arg, arg_effs) ->
+      (fun (new_bindings, order, free_names) (cmm_arg, arg_effs, arg_free_names) ->
         (* CR gbury: here, instead of using [is_cmm_simple], we could instead
            look at [arg_effs] and not create a new binding if it has
            `pure_can_be_duplicated` effects (or any ece that allows
            duplication). *)
         if is_cmm_simple cmm_arg
-        then (new_bindings, order), cmm_arg
+        then
+          ( ( new_bindings,
+              order,
+              Backend_var.Set.union free_names arg_free_names ),
+            cmm_arg )
         else
           (* we need to rebind the argument *)
           (* CR gbury: we should try and store the flambda/cmm variable
              initially associated to this expression when it was built (and
              before it was inlined during the to_cmm translation), instead of
              using a fresh one here. *)
+          let backend_var =
+            Backend_var.create_local (Format.asprintf "to_cmm_split_%d" order)
+          in
           let new_cmm_var =
-            Backend_var.With_provenance.create ?provenance:None
-              (Backend_var.create_local
-                 (Format.asprintf "to_cmm_split_%d" order))
+            Backend_var.With_provenance.create ?provenance:None backend_var
           in
           let binding =
             Binding
               { order;
                 effs = arg_effs;
                 inline = Do_not_inline;
-                bound_expr = Simple { cmm_expr = cmm_arg };
+                bound_expr =
+                  Simple { cmm_expr = cmm_arg; free_names = arg_free_names };
                 cmm_var = new_cmm_var
               }
           in
-          ( (binding :: new_bindings, order - 1),
-            C.var (Backend_var.With_provenance.var new_cmm_var) ))
-      ([], order - 1)
+          ( ( binding :: new_bindings,
+              order - 1,
+              Backend_var.Set.add backend_var free_names ),
+            C.var backend_var ))
+      ([], order - 1, Backend_var.Set.empty)
       args
   in
-  new_bindings, new_cmm_args
+  new_bindings, new_cmm_args, free_names_of_new_cmm_args
 
 let rebuild_prim ~dbg ~env ~res prim args =
   let extra_info, res, cmm =
@@ -495,7 +521,7 @@ let split_complex_binding ~env ~res (binding : complex binding) =
   match binding.bound_expr with
   | Split _ -> res, Already_split
   | Splittable_prim { dbg; prim; args } ->
-    let new_bindings, new_cmm_args =
+    let new_bindings, new_cmm_args, free_names_of_new_cmm_args =
       new_bindings_for_splitting binding.order args
     in
     let new_cmm_expr, res = rebuild_prim ~dbg ~env ~res prim new_cmm_args in
@@ -517,7 +543,9 @@ let split_complex_binding ~env ~res (binding : complex binding) =
       { order = binding.order;
         effs;
         inline = binding.inline;
-        bound_expr = Split { cmm_expr = new_cmm_expr };
+        bound_expr =
+          Split
+            { cmm_expr = new_cmm_expr; free_names = free_names_of_new_cmm_args };
         cmm_var = binding.cmm_var
       }
     in
@@ -528,8 +556,9 @@ let split_complex_binding ~env ~res (binding : complex binding) =
 let rec add_binding_to_env ?extra env res var (Binding binding as b) =
   let env =
     let bindings = Variable.Map.add var b env.bindings in
-    let cmm_expr = C.var (Backend_var.With_provenance.var binding.cmm_var) in
-    let vars = Variable.Map.add var cmm_expr env.vars in
+    let cmm_var = Backend_var.With_provenance.var binding.cmm_var in
+    let free_names = Backend_var.Set.singleton cmm_var in
+    let vars = Variable.Map.add var (C.var cmm_var, free_names) env.vars in
     let vars_extra =
       match extra with
       | None -> env.vars_extra
@@ -660,7 +689,7 @@ let bind_variable_with_decision (type a) ?extra env res var ~inline
   let binding = create_binding ~inline effs var defining_expr in
   add_binding_to_env ?extra env res var binding
 
-let bind_variable ?extra env res var ~defining_expr
+let bind_variable ?extra env res var ~defining_expr ~free_names_of_defining_expr
     ~num_normal_occurrences_of_bound_vars
     ~effects_and_coeffects_of_defining_expr =
   let inline =
@@ -671,22 +700,26 @@ let bind_variable ?extra env res var ~defining_expr
   match inline with
   | Drop_defining_expr -> env, res
   | Regular ->
-    let defining_expr = simple defining_expr in
+    let defining_expr = simple defining_expr free_names_of_defining_expr in
     bind_variable_with_decision ?extra env res var
       ~effects_and_coeffects_of_defining_expr ~defining_expr
       ~inline:Do_not_inline
   | May_inline_once ->
-    let defining_expr = simple defining_expr in
+    let defining_expr = simple defining_expr free_names_of_defining_expr in
     bind_variable_with_decision ?extra env res var
       ~effects_and_coeffects_of_defining_expr ~defining_expr
       ~inline:May_inline_once
   | Must_inline_once ->
-    let defining_expr = complex_no_split defining_expr in
+    let defining_expr =
+      complex_no_split defining_expr free_names_of_defining_expr
+    in
     bind_variable_with_decision ?extra env res var
       ~effects_and_coeffects_of_defining_expr ~defining_expr
       ~inline:Must_inline_once
   | Must_inline_and_duplicate ->
-    let defining_expr = complex_no_split defining_expr in
+    let defining_expr =
+      complex_no_split defining_expr free_names_of_defining_expr
+    in
     bind_variable_with_decision ?extra env res var
       ~effects_and_coeffects_of_defining_expr ~defining_expr
       ~inline:Must_inline_and_duplicate
@@ -695,21 +728,27 @@ let bind_variable_to_primitive = bind_variable_with_decision
 
 (* Variable lookup (for potential inlining) *)
 
-let will_inline_simple env res { effs; bound_expr = Simple { cmm_expr }; _ } =
-  cmm_expr, env, res, effs
+let will_inline_simple env res
+    { effs; bound_expr = Simple { cmm_expr; free_names }; _ } =
+  cmm_expr, free_names, env, res, effs
 
 let will_inline_complex env res { effs; bound_expr; _ } =
   match bound_expr with
-  | Split { cmm_expr } -> cmm_expr, env, res, effs
+  | Split { cmm_expr; free_names } -> cmm_expr, free_names, env, res, effs
   | Splittable_prim { dbg; prim; args } ->
-    let cmm_expr, res = rebuild_prim ~dbg ~env ~res prim (List.map fst args) in
-    cmm_expr, env, res, effs
+    let free_names, cmm_args =
+      List.fold_left_map
+        (fun free_names (cmm_arg, _ece, arg_free_names) ->
+          Backend_var.Set.union free_names arg_free_names, cmm_arg)
+        Backend_var.Set.empty args
+    in
+    let cmm_expr, res = rebuild_prim ~dbg ~env ~res prim cmm_args in
+    cmm_expr, free_names, env, res, effs
 
 let will_not_inline_simple env res { cmm_var; bound_expr = Simple _; _ } =
-  ( C.var (Backend_var.With_provenance.var cmm_var),
-    env,
-    res,
-    Ece.pure_can_be_duplicated )
+  let var = Backend_var.With_provenance.var cmm_var in
+  let free_names = Backend_var.Set.singleton var in
+  C.var var, free_names, env, res, Ece.pure_can_be_duplicated
 
 let split_and_inline env res var binding =
   let env, res, split_binding = split_in_env env res var binding in
@@ -760,10 +799,10 @@ let inline_variable ?consider_inlining_effectful_expressions env res var =
     match Variable.Map.find var env.vars with
     | exception Not_found ->
       Misc.fatal_errorf "Variable %a not found in env" Variable.print var
-    | e ->
+    | e, free_names ->
       (* the env.vars map only contain bindings to expressions of the form
          [Cmm.Cvar _], hence the effects. *)
-      e, env, res, Ece.pure_can_be_duplicated)
+      e, free_names, env, res, Ece.pure_can_be_duplicated)
   | Binding binding -> (
     match binding.inline with
     | Do_not_inline ->
@@ -818,14 +857,14 @@ let add_alias env res ~var ~alias_of ~num_normal_occurrences_of_bound_vars =
     | num_occurrences -> num_occurrences
   in
   match Variable.Map.find alias_of env.bindings, num_occurrences_of_var with
-  | Binding ({ inline = Must_inline_once; _ }) as b, One ->
-    (* special case: we do not want to split the binding in this case, but instead
-       just transfer the binding to the new variable, so that we can decide whether
-       to split it at its effective use (and not here where we rebind it to a
-       used-only-once variable).
+  | (Binding { inline = Must_inline_once; _ } as b), One ->
+    (* special case: we do not want to split the binding in this case, but
+       instead just transfer the binding to the new variable, so that we can
+       decide whether to split it at its effective use (and not here where we
+       rebind it to a used-only-once variable).
 
-       Note that vars with `Must_inline_once` bindings are never put on the stages
-       stack, so it's okay to just transfer the binding. *)
+       Note that vars with `Must_inline_once` bindings are never put on the
+       stages stack, so it's okay to just transfer the binding. *)
     let env = remove_binding env alias_of in
     let env =
       match Variable.Map.find alias_of env.vars_extra with
@@ -833,15 +872,17 @@ let add_alias env res ~var ~alias_of ~num_normal_occurrences_of_bound_vars =
       | extra_info ->
         let vars_extra = Variable.Map.remove alias_of env.vars_extra in
         let vars_extra = Variable.Map.add var extra_info vars_extra in
-        { env with vars_extra; }
+        { env with vars_extra }
     in
-    let env = { env with bindings = Variable.Map.add var b env.bindings; } in
+    let env = { env with bindings = Variable.Map.add var b env.bindings } in
     env, res
-  | Binding { inline = (Must_inline_once | Must_inline_and_duplicate); _ }, _ ->
-    (* special case: we want to force splitting of the original binding, and then
-       bind the new variable with a `must_inline` inline status *)
-    let cmm_expr, env, res, ece = inline_variable env res alias_of in
-    let defining_expr : _ bound_expr = Split { cmm_expr } in
+  | Binding { inline = Must_inline_once | Must_inline_and_duplicate; _ }, _ ->
+    (* special case: we want to force splitting of the original binding, and
+       then bind the new variable with a `must_inline` inline status *)
+    let cmm_expr, free_names, env, res, ece =
+      inline_variable env res alias_of
+    in
+    let defining_expr : _ bound_expr = Split { cmm_expr; free_names } in
     let inline =
       match num_occurrences_of_var with
       | Zero | One -> Must_inline_once
@@ -849,11 +890,15 @@ let add_alias env res ~var ~alias_of ~num_normal_occurrences_of_bound_vars =
     in
     bind_variable_with_decision env res var ~inline ~defining_expr
       ~effects_and_coeffects_of_defining_expr:ece
-  | exception Not_found
-  | Binding { inline = (Do_not_inline | May_inline_once); _}, (Zero | One | More_than_one) ->
+  | (exception Not_found)
+  | ( Binding { inline = Do_not_inline | May_inline_once; _ },
+      (Zero | One | More_than_one) ) ->
     (* generic case, we just inline the var/binding, and rebind it *)
-    let cmm_expr, env, res, ece = inline_variable env res alias_of in
+    let cmm_expr, free_names, env, res, ece =
+      inline_variable env res alias_of
+    in
     bind_variable env res var ~defining_expr:cmm_expr
+      ~free_names_of_defining_expr:free_names
       ~effects_and_coeffects_of_defining_expr:ece
       ~num_normal_occurrences_of_bound_vars
 
@@ -873,16 +918,24 @@ type flush_mode =
 
 let flush_delayed_lets ~mode env res =
   (* Generate a wrapper function to introduce the delayed let-bindings. *)
-  let wrap_flush order_map e =
+  let wrap_flush order_map e free_names =
     M.fold
-      (fun _ (Binding b) acc ->
+      (fun _ (Binding b) (acc, acc_free_names) ->
         match b.bound_expr with
         | Splittable_prim _ ->
           Misc.fatal_errorf
             "Complex bindings should have been split prior to being flushed."
-        | Split { cmm_expr } | Simple { cmm_expr } ->
-          Cmm_helpers.letin b.cmm_var ~defining_expr:cmm_expr ~body:acc)
-      order_map e
+        | Split { cmm_expr; free_names } | Simple { cmm_expr; free_names } ->
+          let expr =
+            Cmm_helpers.letin b.cmm_var ~defining_expr:cmm_expr ~body:acc
+          in
+          let v = Backend_var.With_provenance.var b.cmm_var in
+          let free_names =
+            Backend_var.Set.union free_names
+              (Backend_var.Set.remove v acc_free_names)
+          in
+          expr, free_names)
+      order_map (e, free_names)
   in
   (* CR-someday mshinwell: work out a criterion for allowing substitutions into
      loops. CR gbury: this is now done by creating a binding with the inline

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -221,6 +221,14 @@ val bind_variable :
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
   t * To_cmm_result.t
 
+val add_alias :
+  t ->
+  To_cmm_result.t ->
+  var:Variable.t ->
+  alias_of:Variable.t ->
+  num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
+  t * To_cmm_result.t
+
 (** Try and inline an Flambda variable using the delayed let-bindings. *)
 val inline_variable :
   ?consider_inlining_effectful_expressions:bool ->

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -166,6 +166,9 @@ val create_bound_parameters :
     expression, also contains the arguments and a way to re-build the
     expression. *)
 
+(** Free names for cmm expressions *)
+type free_names = Backend_var.Set.t
+
 (** Some uniques and different types *)
 type simple = Simple
 
@@ -184,7 +187,7 @@ type _ inline =
 type _ bound_expr
 
 (** A simple cmm bound expression *)
-val simple : Cmm.expression -> simple bound_expr
+val simple : Cmm.expression -> free_names -> simple bound_expr
 
 (** A bound expr that can be split if needed. This is used for primitives that
     must be inlined, but whose arguments may not be inlinable or duplicable, so
@@ -194,7 +197,7 @@ val simple : Cmm.expression -> simple bound_expr
 val splittable_primitive :
   Debuginfo.t ->
   Flambda_primitive.Without_args.t ->
-  (Cmm.expression * Effects_and_coeffects.t) list ->
+  (Cmm.expression * Effects_and_coeffects.t * free_names) list ->
   complex bound_expr
 
 (** Bind a variable, with support for splitting duplicatable primitives with
@@ -217,6 +220,7 @@ val bind_variable :
   To_cmm_result.t ->
   Variable.t ->
   defining_expr:Cmm.expression ->
+  free_names_of_defining_expr:free_names ->
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
   t * To_cmm_result.t
@@ -235,7 +239,7 @@ val inline_variable :
   t ->
   To_cmm_result.t ->
   Variable.t ->
-  Cmm.expression * t * To_cmm_result.t * Effects_and_coeffects.t
+  Cmm.expression * free_names * t * To_cmm_result.t * Effects_and_coeffects.t
 
 type flush_mode =
   | Entering_loop
@@ -248,7 +252,9 @@ val flush_delayed_lets :
   mode:flush_mode ->
   t ->
   To_cmm_result.t ->
-  (Cmm.expression -> Cmm.expression) * t * To_cmm_result.t
+  (Cmm.expression -> free_names -> Cmm.expression * free_names)
+  * t
+  * To_cmm_result.t
 
 (** Fetch the extra info for a Flambda variable (if any), specified as a
     [Simple]. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -34,14 +34,20 @@ end
 (* Bind a Cmm variable to the result of translating a [Simple] into Cmm. *)
 
 let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
-  let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
-    C.simple ~dbg env res s
-  in
-  let env, res =
-    Env.bind_variable env res v ~effects_and_coeffects_of_defining_expr
-      ~defining_expr ~num_normal_occurrences_of_bound_vars
-  in
-  env, res
+  match Simple.must_be_var s with
+  | Some (alias_of, _coercion) when Flambda_features.classic_mode () ->
+    Env.add_alias env res ~var:v
+      ~num_normal_occurrences_of_bound_vars
+      ~alias_of
+  | Some _ | None ->
+    let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
+      C.simple ~dbg env res s
+    in
+    let env, res =
+      Env.bind_variable env res v ~effects_and_coeffects_of_defining_expr
+        ~defining_expr ~num_normal_occurrences_of_bound_vars
+    in
+    env, res
 
 (* Helpers for the translation of [Apply] expressions. *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -627,11 +627,7 @@ and let_cont_rec env res invariant_params conts body =
           continuation_handler env res handler
         in
         let free_names =
-          List.fold_left
-            (fun acc (cmm_var, _) ->
-              let v = Backend_var.With_provenance.var cmm_var in
-              Backend_var.Set.remove v acc)
-            free_names_of_handler invariant_vars
+          C.remove_vars_with_machtype free_names_of_handler invariant_vars
         in
         ( Continuation.Map.add k
             (invariant_vars @ vars, handler, free_names)
@@ -664,11 +660,7 @@ and continuation_handler env res handler =
       let env, vars = C.bound_parameters env params in
       let expr, free_names_of_handler, res = expr env res handler in
       let free_names =
-        List.fold_left
-          (fun acc (cmm_var, _) ->
-            let v = Backend_var.With_provenance.var cmm_var in
-            Backend_var.Set.remove v acc)
-          free_names_of_handler vars
+        C.remove_vars_with_machtype free_names_of_handler vars
       in
       vars, arity, expr, free_names, res)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -659,9 +659,7 @@ and continuation_handler env res handler =
       let arity = Bound_parameters.arity params in
       let env, vars = C.bound_parameters env params in
       let expr, free_names_of_handler, res = expr env res handler in
-      let free_names =
-        C.remove_vars_with_machtype free_names_of_handler vars
-      in
+      let free_names = C.remove_vars_with_machtype free_names_of_handler vars in
       vars, arity, expr, free_names, res)
 
 and apply_expr env res apply =

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -629,8 +629,8 @@ and let_cont_rec env res invariant_params conts body =
         let free_names =
           List.fold_left
             (fun acc (cmm_var, _) ->
-               let v = Backend_var.With_provenance.var cmm_var in
-               Backend_var.Set.remove v acc)
+              let v = Backend_var.With_provenance.var cmm_var in
+              Backend_var.Set.remove v acc)
             free_names_of_handler invariant_vars
         in
         ( Continuation.Map.add k

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -25,6 +25,9 @@ module C = struct
   include To_cmm_shared
 end
 
+let debug () =
+  match Sys.getenv "DEBUG" with exception Not_found -> false | _ -> true
+
 (* Note about flushing of environments: this module treats the delayed bindings
    in [To_cmm_env] environments (see to_cmm_env.mli for more information) in a
    linear manner. Flushes are inserted to preserve this property. This ensures
@@ -36,16 +39,19 @@ end
 let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
   match Simple.must_be_var s with
   | Some (alias_of, _coercion) when Flambda_features.classic_mode () ->
-    Env.add_alias env res ~var:v
-      ~num_normal_occurrences_of_bound_vars
-      ~alias_of
+    Env.add_alias env res ~var:v ~num_normal_occurrences_of_bound_vars ~alias_of
   | Some _ | None ->
-    let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
+    let ( defining_expr,
+          free_names_of_defining_expr,
+          env,
+          res,
+          effects_and_coeffects_of_defining_expr ) =
       C.simple ~dbg env res s
     in
     let env, res =
       Env.bind_variable env res v ~effects_and_coeffects_of_defining_expr
-        ~defining_expr ~num_normal_occurrences_of_bound_vars
+        ~defining_expr ~free_names_of_defining_expr
+        ~num_normal_occurrences_of_bound_vars
     in
     env, res
 
@@ -60,8 +66,11 @@ let translate_apply0 env res apply =
      effects/coeffects values currently ignored on the following two lines. At
      the moment they can be ignored as we always deem all calls to have
      arbitrary effects and coeffects. *)
-  let callee, env, res, _ = C.simple ~dbg env res callee_simple in
-  let args, env, res, _ = C.simple_list ~dbg env res args in
+  let callee, callee_free_names, env, res, _ =
+    C.simple ~dbg env res callee_simple
+  in
+  let args, args_free_names, env, res, _ = C.simple_list ~dbg env res args in
+  let free_names = Backend_var.Set.union callee_free_names args_free_names in
   let fail_if_probe apply =
     match Apply.probe_name apply with
     | None -> ()
@@ -101,6 +110,7 @@ let translate_apply0 env res apply =
       ( C.direct_call ~dbg ty pos
           (C.symbol_from_linkage_name ~dbg code_linkage_name)
           args,
+        free_names,
         env,
         res,
         Ece.all )
@@ -109,6 +119,7 @@ let translate_apply0 env res apply =
           ~handler_code_linkage_name:(Linkage_name.to_string code_linkage_name)
           ~args
         |> C.return_unit dbg,
+        free_names,
         env,
         res,
         Ece.all ))
@@ -117,6 +128,7 @@ let translate_apply0 env res apply =
     ( C.indirect_call ~dbg Cmm.typ_val pos
         (Alloc_mode.For_types.to_lambda alloc_mode)
         callee args,
+      free_names,
       env,
       res,
       Ece.all )
@@ -138,6 +150,7 @@ let translate_apply0 env res apply =
       ( C.indirect_full_call ~dbg ty pos
           (Alloc_mode.For_types.to_lambda alloc_mode)
           callee args,
+        free_names,
         env,
         res,
         Ece.all )
@@ -176,15 +189,21 @@ let translate_apply0 env res apply =
     in
     ( wrap dbg
         (C.extcall ~dbg ~alloc ~is_c_builtin ~returns ~ty_args callee ty args),
+      free_names,
       env,
       res,
       Ece.all )
   | Call_kind.Method { kind; obj; alloc_mode } ->
     fail_if_probe apply;
-    let obj, env, res, _ = C.simple ~dbg env res obj in
+    let obj, obj_free_names, env, res, _ = C.simple ~dbg env res obj in
+    let free_names = Backend_var.Set.union free_names obj_free_names in
     let kind = Call_kind.Method_kind.to_lambda kind in
     let alloc_mode = Alloc_mode.For_types.to_lambda alloc_mode in
-    C.send kind callee obj args (pos, alloc_mode) dbg, env, res, Ece.all
+    ( C.send kind callee obj args (pos, alloc_mode) dbg,
+      free_names,
+      env,
+      res,
+      Ece.all )
 
 (* Function calls that have an exn continuation with extra arguments must be
    wrapped with assignments for the mutable variables used to pass the extra
@@ -192,7 +211,7 @@ let translate_apply0 env res apply =
 (* CR mshinwell: Add first-class support in Cmm for the concept of an exception
    handler with extra arguments. *)
 let translate_apply env res apply =
-  let call, env, res, effs = translate_apply0 env res apply in
+  let call, free_names, env, res, effs = translate_apply0 env res apply in
   let dbg = Apply.dbg apply in
   let k_exn = Apply.exn_continuation apply in
   let mut_vars =
@@ -205,13 +224,13 @@ let translate_apply env res apply =
        `To_cmm_shared.simple_list`, namely the first simple translated (and
        potentially inlined/substituted) is evaluted last. *)
     let aux (call, env, res) (arg, _k) v =
-      let arg, env, res, _ = C.simple ~dbg env res arg in
+      let arg, _arg_free_names, env, res, _ = C.simple ~dbg env res arg in
       C.sequence (C.assign v arg) call, env, res
     in
     let call, env, res =
       List.fold_left2 aux (call, env, res) extra_args mut_vars
     in
-    call, env, res, effs
+    call, free_names, env, res, effs
   else
     Misc.fatal_errorf
       "Length of [extra_args] in exception continuation %a@ does not match \
@@ -238,8 +257,11 @@ let translate_raise env res apply exn_handler args =
           Apply_cont.print apply
     in
     let dbg = Apply_cont.debuginfo apply in
-    let exn, env, res, _ = C.simple ~dbg env res exn in
-    let extra, env, res, _ = C.simple_list ~dbg env res extra in
+    let exn, exn_free_names, env, res, _ = C.simple ~dbg env res exn in
+    let extra, extra_free_names, env, res, _ =
+      C.simple_list ~dbg env res extra
+    in
+    let free_names = Backend_var.Set.union exn_free_names extra_free_names in
     let mut_vars = Env.get_exn_extra_args env exn_handler in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     let cmm =
@@ -248,7 +270,8 @@ let translate_raise env res apply exn_handler args =
         (C.raise_prim raise_kind exn dbg)
         extra mut_vars
     in
-    wrap cmm, res
+    let cmm, free_names = wrap cmm free_names in
+    cmm, free_names, res
   | [] ->
     Misc.fatal_errorf "Exception continuation %a has no arguments:@ \n%a"
       Continuation.print exn_handler Apply_cont.print apply
@@ -265,9 +288,10 @@ let translate_jump_to_continuation env res apply types cont args =
         [Cmm.Push cont]
     in
     let dbg = Apply_cont.debuginfo apply in
-    let args, env, res, _ = C.simple_list ~dbg env res args in
+    let args, free_names, env, res, _ = C.simple_list ~dbg env res args in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    wrap (C.cexit cont args trap_actions), res
+    let cmm, free_names = wrap (C.cexit cont args trap_actions) free_names in
+    cmm, free_names, res
   else
     Misc.fatal_errorf "Types (%a) do not match arguments of@ %a"
       (Format.pp_print_list ~pp_sep:Format.pp_print_space Printcmm.machtype)
@@ -279,11 +303,19 @@ let translate_jump_to_return_continuation env res apply return_cont args =
   match args with
   | [return_value] -> (
     let dbg = Apply_cont.debuginfo apply in
-    let return_value, env, res, _ = C.simple ~dbg env res return_value in
+    let return_value, free_names, env, res, _ =
+      C.simple ~dbg env res return_value
+    in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     match Apply_cont.trap_action apply with
-    | None -> wrap return_value, res
-    | Some (Pop _) -> wrap (C.trap_return return_value [Cmm.Pop]), res
+    | None ->
+      let cmm, free_names = wrap return_value free_names in
+      cmm, free_names, res
+    | Some (Pop _) ->
+      let cmm, free_names =
+        wrap (C.trap_return return_value [Cmm.Pop]) free_names
+      in
+      cmm, free_names, res
     | Some (Push _) ->
       Misc.fatal_errorf
         "Return continuation %a should not be applied with a Push trap action"
@@ -298,14 +330,16 @@ let translate_jump_to_return_continuation env res apply return_cont args =
 
 (* The main set of translation functions for expressions *)
 
-let rec expr env res e =
+let rec expr env res e : Cmm.expression * Backend_var.Set.t * To_cmm_result.t =
   match Expr.descr e with
   | Let e' -> let_expr env res e'
   | Let_cont e' -> let_cont env res e'
   | Apply e' -> apply_expr env res e'
   | Apply_cont e' -> apply_cont env res e'
   | Switch e' -> switch env res e'
-  | Invalid { message } -> C.invalid res ~message
+  | Invalid { message } ->
+    let cmm, res = C.invalid res ~message in
+    cmm, Backend_var.Set.empty, res
 
 and let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body =
   let v = Bound_var.var v in
@@ -378,30 +412,48 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
     let wrap, env, res =
       Env.flush_delayed_lets ~mode:Flush_everything env res
     in
-    let cmm, res =
+    let cmm, free_names, res =
       let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body
     in
-    wrap cmm, res
+    let cmm, free_names = wrap cmm free_names in
+    cmm, free_names, res
   | Singleton v, Prim (p, dbg) ->
     let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body
   | Set_of_closures bound_vars, Set_of_closures soc ->
     To_cmm_set_of_closures.let_dynamic_set_of_closures env res ~body ~bound_vars
       ~num_normal_occurrences_of_bound_vars soc ~translate_expr:expr
   | Static bound_static, Static_consts consts -> (
-    let env, res, update_opt =
+    let env, res, update_opt, update_free_names =
       To_cmm_static.static_consts env res
         ~params_and_body:
           (To_cmm_set_of_closures.params_and_body ~translate_expr:expr)
         bound_static consts
     in
     match update_opt with
-    | None -> expr env res body
+    | None ->
+      if not (Backend_var.Set.is_empty update_free_names)
+      then Misc.fatal_errorf "Non_empty free_names for an empty update";
+      expr env res body
     | Some update ->
+      if debug ()
+      then
+        Format.eprintf
+          "*** bound_static ***@\n\
+           free_names: %a@\n\
+           updates: %a@\n\
+           consts: %a@\n\
+           @."
+          Backend_var.Set.print update_free_names Printcmm.expression update
+          Flambda.Static_const_group.print consts;
       let wrap, env, res =
         Env.flush_delayed_lets ~mode:Branching_point env res
       in
-      let body, res = expr env res body in
-      wrap (C.sequence update body), res)
+      let body, body_free_names, res = expr env res body in
+      let free_names =
+        Backend_var.Set.union update_free_names body_free_names
+      in
+      let cmm, free_names = wrap (C.sequence update body) free_names in
+      cmm, free_names, res)
   | Singleton _, Rec_info _ -> expr env res body
   | Singleton _, (Set_of_closures _ | Static_consts _)
   | Set_of_closures _, (Simple _ | Prim _ | Static_consts _ | Rec_info _)
@@ -462,11 +514,13 @@ and let_cont_not_inlined env res k handler body =
      expression. *)
   let wrap, env, res = Env.flush_delayed_lets ~mode:Branching_point env res in
   let is_exn_handler = Continuation_handler.is_exn_handler handler in
-  let vars, arity, handler, res = continuation_handler env res handler in
+  let vars, arity, handler, free_names_of_handler, res =
+    continuation_handler env res handler
+  in
   let catch_id, env =
     Env.add_jump_cont env k ~param_types:(List.map snd vars)
   in
-  let cmm, res =
+  let cmm, free_names_of_body, res =
     (* Exception continuations are translated specially -- these will be reached
        via the raising of exceptions, whereas other continuations are reached
        using a normal jump. *)
@@ -474,12 +528,17 @@ and let_cont_not_inlined env res k handler body =
     then let_cont_exn_handler env res k body vars handler ~catch_id arity
     else
       let dbg = Debuginfo.none (* CR mshinwell: fix debuginfo *) in
-      let body, res = expr env res body in
+      let body, free_names, res = expr env res body in
       ( C.create_ccatch ~rec_flag:false ~body
           ~handlers:[C.handler ~dbg catch_id vars handler],
+        free_names,
         res )
   in
-  wrap cmm, res
+  let free_names =
+    Backend_var.Set.union free_names_of_handler free_names_of_body
+  in
+  let cmm, free_names = wrap cmm free_names in
+  cmm, free_names, res
 
 (* Exception continuations are translated using delayed Ctrywith blocks. The
    exception handler parts of these blocks are identified by the [catch_id]s.
@@ -506,7 +565,7 @@ and let_cont_exn_handler env res k body vars handler ~catch_id arity =
         C.letin extra_param ~defining_expr:(C.var mut_var) ~body:handler)
       handler mut_vars extra_params
   in
-  let body, res = expr env_body res body in
+  let body, free_names_of_body, res = expr env_body res body in
   let dbg = Debuginfo.none (* CR mshinwell: fix debuginfo *) in
   let trywith =
     C.trywith ~dbg ~kind:(Delayed catch_id) ~body ~exn_var ~handler ()
@@ -533,7 +592,7 @@ and let_cont_exn_handler env res k body vars handler ~catch_id arity =
         C.letin_mut mut_var (C.machtype_of_kind kind) dummy_value cmm)
       trywith mut_vars
   in
-  cmm, res
+  cmm, free_names_of_body, res
 
 and let_cont_rec env res invariant_params conts body =
   (* Flush the env now to avoid inlining something inside of a recursive
@@ -564,36 +623,57 @@ and let_cont_rec env res invariant_params conts body =
   let conts_to_handlers, res =
     Continuation.Map.fold
       (fun k handler (conts_to_handlers, res) ->
-        let vars, _arity, handler, res = continuation_handler env res handler in
+        let vars, _arity, handler, free_names_of_handler, res =
+          continuation_handler env res handler
+        in
+        let free_names =
+          List.fold_left
+            (fun acc (cmm_var, _) ->
+               let v = Backend_var.With_provenance.var cmm_var in
+               Backend_var.Set.remove v acc)
+            free_names_of_handler invariant_vars
+        in
         ( Continuation.Map.add k
-            (invariant_vars @ vars, handler)
+            (invariant_vars @ vars, handler, free_names)
             conts_to_handlers,
           res ))
       conts_to_handlers
       (Continuation.Map.empty, res)
   in
   let dbg = Debuginfo.none (* CR mshinwell: fix debuginfo *) in
+  let body, free_names_of_body, res = expr env res body in
   (* Setup the Cmm handlers for the Ccatch *)
-  let handlers =
+  let handlers, free_names =
     Continuation.Map.fold
-      (fun k (vars, handler) acc ->
+      (fun k (vars, handler, free_names_of_handler) (handlers, free_names) ->
+        let free_names =
+          Backend_var.Set.union free_names free_names_of_handler
+        in
         let id = Env.get_cmm_continuation env k in
-        C.handler ~dbg id vars handler :: acc)
-      conts_to_handlers []
+        C.handler ~dbg id vars handler :: handlers, free_names)
+      conts_to_handlers ([], free_names_of_body)
   in
-  let body, res = expr env res body in
-  wrap (C.create_ccatch ~rec_flag:true ~body ~handlers), res
+  let cmm = C.create_ccatch ~rec_flag:true ~body ~handlers in
+  let cmm, free_names = wrap cmm free_names in
+  cmm, free_names, res
 
 and continuation_handler env res handler =
   Continuation_handler.pattern_match' handler
     ~f:(fun params ~num_normal_occurrences_of_params:_ ~handler ->
       let arity = Bound_parameters.arity params in
       let env, vars = C.bound_parameters env params in
-      let expr, res = expr env res handler in
-      vars, arity, expr, res)
+      let expr, free_names_of_handler, res = expr env res handler in
+      let free_names =
+        List.fold_left
+          (fun acc (cmm_var, _) ->
+            let v = Backend_var.With_provenance.var cmm_var in
+            Backend_var.Set.remove v acc)
+          free_names_of_handler vars
+      in
+      vars, arity, expr, free_names, res)
 
 and apply_expr env res apply =
-  let call, env, res, effs = translate_apply env res apply in
+  let call, free_names, env, res, effs = translate_apply env res apply in
   (* With respect to flushing the environment we have three cases:
 
      1. The call never returns or jumps to another function
@@ -618,11 +698,13 @@ and apply_expr env res apply =
   | Never_returns ->
     (* Case 1 *)
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    wrap call, res
+    let cmm, free_names = wrap call free_names in
+    cmm, free_names, res
   | Return k when Continuation.equal (Env.return_continuation env) k ->
     (* Case 1 *)
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    wrap call, res
+    let cmm, free_names = wrap call free_names in
+    cmm, free_names, res
   | Return k -> (
     let[@inline always] unsupported () =
       (* CR gbury: add support using unboxed tuples *)
@@ -637,7 +719,8 @@ and apply_expr env res apply =
     | Jump { param_types = [_]; cont } ->
       (* Case 2 *)
       let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-      wrap (C.cexit cont [call] []), res
+      let cmm, free_names = wrap (C.cexit cont [call] []) free_names in
+      cmm, free_names, res
     | Inline { handler_params; handler_body = body; handler_params_occurrences }
       -> (
       (* Case 3 *)
@@ -649,6 +732,7 @@ and apply_expr env res apply =
         let env, res =
           Env.bind_variable env res var
             ~effects_and_coeffects_of_defining_expr:effs ~defining_expr:call
+            ~free_names_of_defining_expr:free_names
             ~num_normal_occurrences_of_bound_vars:handler_params_occurrences
         in
         expr env res body
@@ -697,7 +781,9 @@ and apply_cont env res apply_cont =
 and switch env res switch =
   let scrutinee = Switch.scrutinee switch in
   let dbg = Switch.condition_dbg switch in
-  let untagged_scrutinee_cmm, env, res, _ = C.simple ~dbg env res scrutinee in
+  let untagged_scrutinee_cmm, scrutinee_free_names, env, res, _ =
+    C.simple ~dbg env res scrutinee
+  in
   let arms = Switch.arms switch in
   (* For binary switches, which can be translated to an if-then-else, it can be
      interesting for the scrutinee to be tagged (particularly for switches
@@ -741,8 +827,8 @@ and switch env res switch =
   in
   let make_arm ~must_tag_discriminant env res (d, action) =
     let d = prepare_discriminant ~must_tag:must_tag_discriminant d in
-    let cmm_action, res = apply_cont env res action in
-    (d, cmm_action, Apply_cont.debuginfo action), res
+    let cmm_action, action_free_names, res = apply_cont env res action in
+    (d, cmm_action, action_free_names, Apply_cont.debuginfo action), res
   in
   match Targetint_31_63.Map.cardinal arms with
   (* Binary case: if-then-else *)
@@ -756,19 +842,34 @@ and switch env res switch =
        before creating an if-then-else, introducing an indirection that might
        prevent some optimizations performed by Selectgen/Emit when the condition
        is inlined in the if-then-else. Instead we use [C.ite]. *)
-    | (0, else_, else_dbg), (_, then_, then_dbg)
-    | (_, then_, then_dbg), (0, else_, else_dbg) ->
-      wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_), res
+    | ( (0, else_, else_free_names, else_dbg),
+        (_, then_, then_free_names, then_dbg) )
+    | ( (_, then_, then_free_names, then_dbg),
+        (0, else_, else_free_names, else_dbg) ) ->
+      let free_names =
+        Backend_var.Set.union scrutinee_free_names
+          (Backend_var.Set.union else_free_names then_free_names)
+      in
+      let cmm, free_names =
+        wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_) free_names
+      in
+      cmm, free_names, res
     (* Similar case to the previous but none of the arms match 0, so we have to
        generate an equality test, and make sure it is inside the condition to
        ensure Selectgen and Emit can take advantage of it. *)
-    | (x, if_x, if_x_dbg), (_, if_not, if_not_dbg) ->
+    | ( (x, if_x, if_x_free_names, if_x_dbg),
+        (_, if_not, if_not_free_names, if_not_dbg) ) ->
+      let free_names =
+        Backend_var.Set.union scrutinee_free_names
+          (Backend_var.Set.union if_x_free_names if_not_free_names)
+      in
       let expr =
         C.ite ~dbg
           (C.eq ~dbg (C.int ~dbg x) scrutinee)
           ~then_dbg:if_x_dbg ~then_:if_x ~else_dbg:if_not_dbg ~else_:if_not
       in
-      wrap expr, res)
+      let cmm, free_names = wrap expr free_names in
+      cmm, free_names, res)
   (* General case *)
   | n ->
     (* transl_switch_clambda expects an [index] array such that index.(d) is the
@@ -778,19 +879,22 @@ and switch env res switch =
     let unreachable, res = C.invalid res ~message:"unreachable switch case" in
     let cases = Array.make (n + 1) unreachable in
     let index = Array.make (m + 1) n in
-    let _, res =
+    let _, res, free_names =
       Targetint_31_63.Map.fold
-        (fun discriminant action (i, res) ->
-          let (d, cmm_action, _dbg), res =
+        (fun discriminant action (i, res, free_names) ->
+          let (d, cmm_action, action_free_names, _dbg), res =
             make_arm ~must_tag_discriminant env res (discriminant, action)
           in
+          let free_names = Backend_var.Set.union free_names action_free_names in
           cases.(i) <- cmm_action;
           index.(d) <- i;
-          i + 1, res)
-        arms (0, res)
+          i + 1, res, free_names)
+        arms
+        (0, res, scrutinee_free_names)
     in
     (* CR-someday poechsel: Put a more precise value kind here *)
     let expr =
       C.transl_switch_clambda dbg (Vval Pgenval) scrutinee index cases
     in
-    wrap expr, res
+    let cmm, free_names = wrap expr free_names in
+    cmm, free_names, res

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.mli
@@ -18,4 +18,4 @@ val expr :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Flambda.Expr.t ->
-  Cmm.expression * To_cmm_result.t
+  Cmm.expression * Backend_var.Set.t * To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -662,23 +662,26 @@ let arg ?consider_inlining_effectful_expressions ~dbg env res simple =
   C.simple ?consider_inlining_effectful_expressions ~dbg env res simple
 
 let arg_list ?consider_inlining_effectful_expressions ~dbg env res l =
-  let aux (list, env, res, effs) x =
-    let y, env, res, eff =
+  let aux (list, free_names, env, res, effs) x =
+    let y, y_free_names, env, res, eff =
       arg ?consider_inlining_effectful_expressions ~dbg env res x
     in
-    y :: list, env, res, Ece.join eff effs
+    let free_names = Backend_var.Set.union free_names y_free_names in
+    y :: list, free_names, env, res, Ece.join eff effs
   in
-  let args, env, res, effs =
-    List.fold_left aux ([], env, res, Ece.pure_can_be_duplicated) l
+  let args, free_names, env, res, effs =
+    List.fold_left aux
+      ([], Backend_var.Set.empty, env, res, Ece.pure_can_be_duplicated)
+      l
   in
-  List.rev args, env, res, effs
+  List.rev args, free_names, env, res, effs
 
 let arg_list' ?consider_inlining_effectful_expressions ~dbg env res l =
   let aux (list, env, res, effs) x =
-    let y, env, res, eff =
+    let y, free_names, env, res, eff =
       arg ?consider_inlining_effectful_expressions ~dbg env res x
     in
-    (y, eff) :: list, env, res, Ece.join eff effs
+    (y, eff, free_names) :: list, env, res, Ece.join eff effs
   in
   let args, env, res, effs =
     List.fold_left aux ([], env, res, Ece.pure_can_be_duplicated) l
@@ -730,8 +733,8 @@ let prim_simple env res dbg p =
   let arg = arg ?consider_inlining_effectful_expressions ~dbg in
   (* Somewhat counter-intuitively, the left-to-right translation below (e.g. [x]
      before [y] in the [Binary] case) correctly matches right-to-left evaluation
-     order---ensuring maximal inlining---since [C.simple_list] translates the
-     first [Simple] in the list first. Consider in pseudo-code:
+     order---ensuring maximal inlining---since [arg_list] translates the first
+     [Simple] in the list first. Consider in pseudo-code:
 
      let x = <effect-x> in let y = <effect-y> in Make_block [y; x]
 
@@ -745,31 +748,38 @@ let prim_simple env res dbg p =
      order. This therefore matches the original source code. *)
   match (p : P.t) with
   | Nullary prim ->
+    let free_names = Backend_var.Set.empty in
     let extra, res, expr = nullary_primitive env res dbg prim in
-    Env.simple expr, extra, env, res, Ece.pure
+    Env.simple expr free_names, extra, env, res, Ece.pure
   | Unary (unary, x) ->
-    let x, env, res, eff = arg env res x in
+    let x, free_names, env, res, eff = arg env res x in
     let extra, res, expr = unary_primitive env res dbg unary x in
-    Env.simple expr, extra, env, res, eff
+    Env.simple expr free_names, extra, env, res, eff
   | Binary (binary, x, y) ->
-    let x, env, res, effx = arg env res x in
-    let y, env, res, effy = arg env res y in
+    let x, x_free_names, env, res, effx = arg env res x in
+    let y, y_free_names, env, res, effy = arg env res y in
+    let free_names = Backend_var.Set.union x_free_names y_free_names in
     let effs = Ece.join effx effy in
     let expr = binary_primitive env dbg binary x y in
-    Env.simple expr, None, env, res, effs
+    Env.simple expr free_names, None, env, res, effs
   | Ternary (ternary, x, y, z) ->
-    let x, env, res, effx = arg env res x in
-    let y, env, res, effy = arg env res y in
-    let z, env, res, effz = arg env res z in
+    let x, x_free_names, env, res, effx = arg env res x in
+    let y, y_free_names, env, res, effy = arg env res y in
+    let z, z_free_names, env, res, effz = arg env res z in
+    let free_names =
+      Backend_var.Set.union
+        (Backend_var.Set.union x_free_names y_free_names)
+        z_free_names
+    in
     let effs = Ece.join (Ece.join effx effy) effz in
     let expr = ternary_primitive env dbg ternary x y z in
-    Env.simple expr, None, env, res, effs
+    Env.simple expr free_names, None, env, res, effs
   | Variadic (((Make_block _ | Make_array _) as variadic), l) ->
-    let args, env, res, effs =
+    let args, free_names, env, res, effs =
       arg_list ?consider_inlining_effectful_expressions ~dbg env res l
     in
     let expr = variadic_primitive env dbg variadic args in
-    Env.simple expr, None, env, res, effs
+    Env.simple expr free_names, None, env, res, effs
 
 let prim_complex env res dbg p =
   let consider_inlining_effectful_expressions =
@@ -784,21 +794,25 @@ let prim_complex env res dbg p =
       prim', [], Ece.pure_can_be_duplicated, env, res
     | Unary (unary, x) ->
       let prim' = P.Without_args.Unary unary in
-      let x, env, res, eff = arg env res x in
-      prim', [x, eff], eff, env, res
+      let x, x_free_names, env, res, eff = arg env res x in
+      prim', [x, eff, x_free_names], eff, env, res
     | Binary (binary, x, y) ->
       let prim' = P.Without_args.Binary binary in
-      let x, env, res, effx = arg env res x in
-      let y, env, res, effy = arg env res y in
+      let x, x_free_names, env, res, effx = arg env res x in
+      let y, y_free_names, env, res, effy = arg env res y in
       let effs = Ece.join effx effy in
-      prim', [x, effx; y, effy], effs, env, res
+      prim', [x, effx, x_free_names; y, effy, y_free_names], effs, env, res
     | Ternary (ternary, x, y, z) ->
       let prim' = P.Without_args.Ternary ternary in
-      let x, env, res, effx = arg env res x in
-      let y, env, res, effy = arg env res y in
-      let z, env, res, effz = arg env res z in
+      let x, x_free_names, env, res, effx = arg env res x in
+      let y, y_free_names, env, res, effy = arg env res y in
+      let z, z_free_names, env, res, effz = arg env res z in
       let effs = Ece.join (Ece.join effx effy) effz in
-      prim', [x, effx; y, effy; z, effz], effs, env, res
+      ( prim',
+        [x, effx, x_free_names; y, effy, y_free_names; z, effz, z_free_names],
+        effs,
+        env,
+        res )
     | Variadic (((Make_block _ | Make_array _) as variadic), l) ->
       let prim' = P.Without_args.Variadic variadic in
       let args, env, res, effs =

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -363,8 +363,8 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
   if not (Backend_var.Set.is_empty fun_free_names)
   then
     Misc.fatal_errorf
-      "Unbound free_names in function body when translating to cmm: %a@\nfunction body: %a"
-      Backend_var.Set.print fun_free_names
+      "Unbound free_names in function body when translating to cmm: %a@\n\
+       function body: %a" Backend_var.Set.print fun_free_names
       Printcmm.expression fun_body;
   let fun_flags =
     transl_check_attrib check

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -351,13 +351,8 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
   let env, fun_params = C.bound_parameters env params in
   let fun_body, fun_body_free_names, res = translate_expr env res body in
   let fun_free_names =
-    List.fold_left
-      (fun acc (var, _) ->
-        let v = Backend_var.With_provenance.var var in
-        Backend_var.Set.remove v acc)
-      (Backend_var.Set.remove
-         (Backend_var.With_provenance.var my_region_var)
-         fun_body_free_names)
+    C.remove_vars_with_machtype
+      (C.remove_var_with_provenance fun_body_free_names my_region_var)
       fun_params
   in
   if not (Backend_var.Set.is_empty fun_free_names)

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -17,7 +17,10 @@
 open! Flambda.Import
 
 type translate_expr =
-  To_cmm_env.t -> To_cmm_result.t -> Expr.t -> Cmm.expression * To_cmm_result.t
+  To_cmm_env.t ->
+  To_cmm_result.t ->
+  Expr.t ->
+  Cmm.expression * Backend_var.Set.t * To_cmm_result.t
 
 val let_static_set_of_closures :
   To_cmm_env.t ->
@@ -25,7 +28,11 @@ val let_static_set_of_closures :
   Symbol.t Function_slot.Map.t ->
   Set_of_closures.t ->
   prev_updates:Cmm.expression option ->
-  To_cmm_env.t * To_cmm_result.t * Cmm.data_item list * Cmm.expression option
+  To_cmm_env.t
+  * To_cmm_result.t
+  * Cmm.data_item list
+  * Cmm.expression option
+  * Backend_var.Set.t
 
 val let_dynamic_set_of_closures :
   To_cmm_env.t ->
@@ -35,7 +42,7 @@ val let_dynamic_set_of_closures :
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   Set_of_closures.t ->
   translate_expr:translate_expr ->
-  Cmm.expression * To_cmm_result.t
+  Cmm.expression * Backend_var.Set.t * To_cmm_result.t
 
 val params_and_body :
   To_cmm_env.t ->
@@ -44,9 +51,5 @@ val params_and_body :
   Function_params_and_body.t ->
   fun_dbg:Debuginfo.t ->
   check:Check_attribute.t ->
-  translate_expr:
-    (To_cmm_env.t ->
-    To_cmm_result.t ->
-    Expr.t ->
-    Cmm.expression * To_cmm_result.t) ->
+  translate_expr:translate_expr ->
   Cmm.fundecl * To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -21,9 +21,10 @@ let remove_var_with_provenance free_names var =
   Backend_var.Set.remove v free_names
 
 let remove_vars_with_machtype free_names vars =
-  List.fold_left (fun free_names (cmm_var, _machtype) ->
-      remove_var_with_provenance free_names cmm_var
-    ) free_names vars
+  List.fold_left
+    (fun free_names (cmm_var, _machtype) ->
+      remove_var_with_provenance free_names cmm_var)
+    free_names vars
 
 let exttype_of_kind (k : Flambda_kind.t) : Cmm.exttype =
   match k with

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -16,6 +16,15 @@ open! Cmm_helpers
 open! Cmm_builtins
 module Ece = Effects_and_coeffects
 
+let remove_var_with_provenance free_names var =
+  let v = Backend_var.With_provenance.var var in
+  Backend_var.Set.remove v free_names
+
+let remove_vars_with_machtype free_names vars =
+  List.fold_left (fun free_names (cmm_var, _machtype) ->
+      remove_var_with_provenance free_names cmm_var
+    ) free_names vars
+
 let exttype_of_kind (k : Flambda_kind.t) : Cmm.exttype =
   match k with
   | Value -> XInt

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -67,7 +67,11 @@ let name0 ?consider_inlining_effectful_expressions env res name =
         res v)
     ~symbol:(fun s ->
       (* CR mshinwell: fix debuginfo? *)
-      symbol ~dbg:Debuginfo.none s, env, res, Ece.pure_can_be_duplicated)
+      ( symbol ~dbg:Debuginfo.none s,
+        Backend_var.Set.empty,
+        env,
+        res,
+        Ece.pure_can_be_duplicated ))
 
 let name env name = name0 env name
 
@@ -85,7 +89,8 @@ let simple ?consider_inlining_effectful_expressions ~dbg env res s =
   Simple.pattern_match s
     ~name:(fun n ~coercion:_ ->
       name0 ?consider_inlining_effectful_expressions env res n)
-    ~const:(fun c -> const ~dbg c, env, res, Ece.pure_can_be_duplicated)
+    ~const:(fun c ->
+      const ~dbg c, Backend_var.Set.empty, env, res, Ece.pure_can_be_duplicated)
 
 let name_static name =
   Name.pattern_match name
@@ -113,16 +118,19 @@ let simple_static s =
 let simple_list ?consider_inlining_effectful_expressions ~dbg env res l =
   (* Note that [To_cmm_primitive] relies on this function translating the
      [Simple] at the head of the list first. *)
-  let aux (list, env, res, effs) x =
-    let y, env, res, eff =
+  let aux (list, free_names, env, res, effs) x =
+    let y, y_free_names, env, res, eff =
       simple ?consider_inlining_effectful_expressions ~dbg env res x
     in
-    y :: list, env, res, Ece.join eff effs
+    let free_names = Backend_var.Set.union free_names y_free_names in
+    y :: list, free_names, env, res, Ece.join eff effs
   in
-  let args, env, res, effs =
-    List.fold_left aux ([], env, res, Ece.pure_can_be_duplicated) l
+  let args, free_names, env, res, effs =
+    List.fold_left aux
+      ([], Backend_var.Set.empty, env, res, Ece.pure_can_be_duplicated)
+      l
   in
-  List.rev args, env, res, effs
+  List.rev args, free_names, env, res, effs
 
 let bound_parameters env l =
   let flambda_vars = Bound_parameters.vars l in
@@ -166,12 +174,13 @@ let invalid res ~message =
   call_expr, res
 
 let make_update env res dbg kind ~symbol var ~index ~prev_updates =
-  let e, env, res, _ece = To_cmm_env.inline_variable env res var in
+  let e, free_names, env, res, _ece = To_cmm_env.inline_variable env res var in
   let addr = field_address symbol index dbg in
   let update = store ~dbg kind Initialization ~addr ~new_value:e in
   match prev_updates with
-  | None -> env, res, Some update
-  | Some prev_updates -> env, res, Some (sequence prev_updates update)
+  | None -> env, res, free_names, Some update
+  | Some prev_updates ->
+    env, res, free_names, Some (sequence prev_updates update)
 
 let check_arity arity args =
   Flambda_arity.With_subkinds.cardinal arity = List.length args

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -20,7 +20,9 @@ val remove_var_with_provenance :
   Backend_var.Set.t -> Backend_var.With_provenance.t -> Backend_var.Set.t
 
 val remove_vars_with_machtype :
-  Backend_var.Set.t -> (Backend_var.With_provenance.t * Cmm.machtype) list -> Backend_var.Set.t
+  Backend_var.Set.t ->
+  (Backend_var.With_provenance.t * Cmm.machtype) list ->
+  Backend_var.Set.t
 
 val exttype_of_kind : Flambda_kind.t -> Cmm.exttype
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -40,7 +40,11 @@ val name :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Name.t ->
-  Cmm.expression * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
+  Cmm.expression
+  * Backend_var.Set.t
+  * To_cmm_env.t
+  * To_cmm_result.t
+  * Effects_and_coeffects.t
 
 val const : dbg:Debuginfo.t -> Reg_width_const.t -> Cmm.expression
 
@@ -53,7 +57,11 @@ val simple :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Simple.t ->
-  Cmm.expression * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
+  Cmm.expression
+  * Backend_var.Set.t
+  * To_cmm_env.t
+  * To_cmm_result.t
+  * Effects_and_coeffects.t
 
 val simple_static :
   Simple.t -> [`Data of Cmm.data_item list | `Var of Variable.t]
@@ -66,7 +74,11 @@ val simple_list :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Simple.t list ->
-  Cmm.expression list * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
+  Cmm.expression list
+  * Backend_var.Set.t
+  * To_cmm_env.t
+  * To_cmm_result.t
+  * Effects_and_coeffects.t
 
 val bound_parameters :
   To_cmm_env.t ->
@@ -86,7 +98,7 @@ val make_update :
   Variable.t ->
   index:int ->
   prev_updates:Cmm.expression option ->
-  To_cmm_env.t * To_cmm_result.t * Cmm.expression option
+  To_cmm_env.t * To_cmm_result.t * Backend_var.Set.t * Cmm.expression option
 
 val check_arity : Flambda_arity.With_subkinds.t -> _ list -> bool
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -16,6 +16,12 @@
     this module, unlike the ones in [Cmm_helpers], depend on Flambda 2 data
     types. *)
 
+val remove_var_with_provenance :
+  Backend_var.Set.t -> Backend_var.With_provenance.t -> Backend_var.Set.t
+
+val remove_vars_with_machtype :
+  Backend_var.Set.t -> (Backend_var.With_provenance.t * Cmm.machtype) list -> Backend_var.Set.t
+
 val exttype_of_kind : Flambda_kind.t -> Cmm.exttype
 
 val machtype_of_kind : Flambda_kind.t -> Cmm.machtype_component array

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -36,39 +36,42 @@ let or_variable f default v cont =
   | Const c -> f c cont
   | Var _ -> f default cont
 
-let rec static_block_updates symb env res acc i = function
-  | [] -> env, res, acc
+let rec static_block_updates symb env res acc free_names i = function
+  | [] -> env, res, acc, free_names
   | sv :: r -> (
     match (sv : Field_of_static_block.t) with
     | Symbol _ | Tagged_immediate _ ->
-      static_block_updates symb env res acc (i + 1) r
+      static_block_updates symb env res acc free_names (i + 1) r
     | Dynamically_computed (var, dbg) ->
-      let env, res, acc =
+      let env, res, field_free_names, acc =
         C.make_update env res dbg Word_val ~symbol:(C.symbol ~dbg symb) var
           ~index:i ~prev_updates:acc
       in
-      static_block_updates symb env res acc (i + 1) r)
+      let free_names = Backend_var.Set.union free_names field_free_names in
+      static_block_updates symb env res acc free_names (i + 1) r)
 
-let rec static_float_array_updates symb env res acc i = function
-  | [] -> env, res, acc
+let rec static_float_array_updates symb env res acc free_names i = function
+  | [] -> env, res, acc, free_names
   | sv :: r -> (
     match (sv : _ Or_variable.t) with
-    | Const _ -> static_float_array_updates symb env res acc (i + 1) r
+    | Const _ ->
+      static_float_array_updates symb env res acc free_names (i + 1) r
     | Var (var, dbg) ->
-      let env, res, acc =
+      let env, res, cell_free_names, acc =
         C.make_update env res dbg Double ~symbol:(C.symbol ~dbg symb) var
           ~index:i ~prev_updates:acc
       in
-      static_float_array_updates symb env res acc (i + 1) r)
+      let free_names = Backend_var.Set.union free_names cell_free_names in
+      static_float_array_updates symb env res acc free_names (i + 1) r)
 
 let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
-    res updates =
+    res updates free_names =
   let aux x cont =
     emit
       (Symbol.linkage_name_as_string symbol, Cmmgen_state.Global)
       (transl x) cont
   in
-  let env, res, updates =
+  let env, res, updates, free_names =
     match (v : _ Or_variable.t) with
     | Const c ->
       (* Add the const to the cmmgen_state structured constants table so that
@@ -77,12 +80,16 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
       let symbol_name = Symbol.linkage_name_as_string symbol in
       let structured_constant = structured (transl c) in
       Cmmgen_state.add_structured_constant symbol_name structured_constant;
-      env, res, None
+      env, res, None, free_names
     | Var (v, dbg) ->
-      C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
-        ~prev_updates:updates
+      let env, res, var_free_names, updates =
+        C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
+          ~prev_updates:updates
+      in
+      let free_names = Backend_var.Set.union free_names var_free_names in
+      env, res, updates, free_names
   in
-  R.update_data res (or_variable aux default v), env, updates
+  R.update_data res (or_variable aux default v), env, updates, free_names
 
 let add_function env res ~params_and_body code_id p ~fun_dbg ~check =
   let fundecl, res = params_and_body env res code_id p ~fun_dbg ~check in
@@ -95,7 +102,7 @@ let add_functions env ~params_and_body res (code : Code.t) =
 
 let preallocate_set_of_closures (res, updates, env) ~closure_symbols
     set_of_closures =
-  let env, res, data, updates =
+  let env, res, data, updates, free_names =
     let closure_symbols =
       closure_symbols |> Function_slot.Lmap.bindings
       |> Function_slot.Map.of_list
@@ -104,10 +111,10 @@ let preallocate_set_of_closures (res, updates, env) ~closure_symbols
       set_of_closures ~prev_updates:updates
   in
   let res = R.set_data res data in
-  res, updates, env
+  res, updates, env, free_names
 
-let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
-    (static_const : Static_const.t) =
+let static_const0 env res ~updates ~free_names
+    (bound_static : Bound_static.Pattern.t) (static_const : Static_const.t) =
   match bound_static, static_const with
   | Block_like s, Block (tag, _mut, fields) ->
     let res = R.check_for_module_symbol res s in
@@ -122,46 +129,52 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
         fields []
     in
     let block = C.emit_block block_name header static_fields in
-    let env, res, updates = static_block_updates s env res updates 0 fields in
-    env, R.set_data res block, updates
+    let env, res, updates, free_names =
+      static_block_updates s env res updates free_names 0 fields
+    in
+    env, R.set_data res block, updates, free_names
   | Set_of_closures closure_symbols, Set_of_closures set_of_closures ->
-    let res, updates, env =
+    let res, updates, env, soc_free_names =
       preallocate_set_of_closures (res, updates, env) ~closure_symbols
         set_of_closures
     in
-    env, res, updates
+    let free_names = Backend_var.Set.union free_names soc_free_names in
+    env, res, updates, free_names
   | Block_like symbol, Boxed_float v ->
     let default = Numeric_types.Float_by_bit_pattern.zero in
     let transl = Numeric_types.Float_by_bit_pattern.to_float in
     let structured f = Clambda.Uconst_float f in
-    let res, env, updates =
+    let res, env, updates, free_names =
       static_boxed_number ~kind:Double ~env ~symbol ~default
-        ~emit:C.emit_float_constant ~transl ~structured v res updates
+        ~emit:C.emit_float_constant ~transl ~structured v res updates free_names
     in
-    env, res, updates
+    env, res, updates, free_names
   | Block_like symbol, Boxed_int32 v ->
     let structured i = Clambda.Uconst_int32 i in
-    let res, env, updates =
+    let res, env, updates, free_names =
       static_boxed_number ~kind:Word_int ~env ~symbol ~default:0l
         ~emit:C.emit_int32_constant ~transl:Fun.id ~structured v res updates
+        free_names
     in
-    env, res, updates
+    env, res, updates, free_names
   | Block_like symbol, Boxed_int64 v ->
     let structured i = Clambda.Uconst_int64 i in
-    let res, env, updates =
+    let res, env, updates, free_names =
       static_boxed_number ~kind:Word_int ~env ~symbol ~default:0L
         ~emit:C.emit_int64_constant ~transl:Fun.id ~structured v res updates
+        free_names
     in
-    env, res, updates
+    env, res, updates, free_names
   | Block_like symbol, Boxed_nativeint v ->
     let default = Targetint_32_64.zero in
     let transl = C.nativeint_of_targetint in
     let structured i = Clambda.Uconst_nativeint i in
-    let res, env, updates =
+    let res, env, updates, free_names =
       static_boxed_number ~kind:Word_int ~env ~symbol ~default
         ~emit:C.emit_nativeint_constant ~transl ~structured v res updates
+        free_names
     in
-    env, res, updates
+    env, res, updates, free_names
   | Block_like s, (Immutable_float_block fields | Immutable_float_array fields)
     ->
     let aux =
@@ -174,8 +187,10 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
         (Symbol.linkage_name_as_string s, Cmmgen_state.Global)
         static_fields
     in
-    let env, res, e = static_float_array_updates s env res updates 0 fields in
-    env, R.update_data res float_array, e
+    let env, res, e, free_names =
+      static_float_array_updates s env res updates free_names 0 fields
+    in
+    env, R.update_data res float_array, e, free_names
   | Block_like s, Immutable_value_array fields ->
     let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
     let header = C.black_block_header 0 (List.length fields) in
@@ -187,19 +202,21 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
         fields []
     in
     let block = C.emit_block block_name header static_fields in
-    let env, res, updates = static_block_updates s env res updates 0 fields in
-    env, R.set_data res block, updates
+    let env, res, updates, free_names =
+      static_block_updates s env res updates free_names 0 fields
+    in
+    env, R.set_data res block, updates, free_names
   | Block_like s, Empty_array ->
     (* Recall: empty arrays have tag zero, even if their kind is naked float. *)
     let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
     let header = C.black_block_header 0 0 in
     let block = C.emit_block block_name header [] in
-    env, R.set_data res block, updates
+    env, R.set_data res block, updates, free_names
   | Block_like s, Mutable_string { initial_value = str }
   | Block_like s, Immutable_string str ->
     let name = Symbol.linkage_name_as_string s in
     let data = C.emit_string_constant (name, Cmmgen_state.Global) str in
-    env, R.update_data res data, updates
+    env, R.update_data res data, updates, free_names
   | Block_like _, Set_of_closures _ ->
     Misc.fatal_errorf
       "[Set_of_closures] values cannot be bound by [Block_like] bindings:@ %a"
@@ -217,12 +234,13 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     Misc.fatal_errorf "Sets of closures cannot be bound by [Code] bindings:@ %a"
       SC.print static_const
 
-let static_const_or_code env r ~updates (bound_static : Bound_static.Pattern.t)
+let static_const_or_code env r ~updates ~free_names
+    (bound_static : Bound_static.Pattern.t)
     (static_const_or_code : Static_const_or_code.t) =
-  let env, r, updates =
+  let env, r, updates, free_names =
     match bound_static, static_const_or_code with
     | (Block_like _ | Set_of_closures _), Static_const static_const ->
-      static_const0 env r ~updates bound_static static_const
+      static_const0 env r ~updates ~free_names bound_static static_const
     | Code code_id, Code code ->
       if not (Code_id.equal code_id (Code.code_id code))
       then
@@ -230,8 +248,8 @@ let static_const_or_code env r ~updates (bound_static : Bound_static.Pattern.t)
           Bound_static.Pattern.print bound_static Code.print code;
       (* Nothing needs doing here as we've already added the code to the
          environment. *)
-      env, r, updates
-    | Code _, Deleted_code -> env, r, updates
+      env, r, updates, free_names
+    | Code _, Deleted_code -> env, r, updates, free_names
     | Code _, Static_const static_const ->
       Misc.fatal_errorf "Only code can be bound by [Code] bindings:@ %a@ =@ %a"
         Bound_static.Pattern.print bound_static SC.print static_const
@@ -246,7 +264,7 @@ let static_const_or_code env r ~updates (bound_static : Bound_static.Pattern.t)
          bindings:@ %a@ =@ <deleted code>"
         Bound_static.Pattern.print bound_static
   in
-  env, R.archive_data r, updates
+  env, R.archive_data r, updates, free_names
 
 let static_consts0 env r ~params_and_body bound_static static_consts =
   (* We cannot both build the environment and compile any functions in one
@@ -265,9 +283,10 @@ let static_consts0 env r ~params_and_body bound_static static_consts =
         | None -> r
         | Some code -> add_functions env ~params_and_body r code)
   in
-  ListLabels.fold_left2 bound_static' static_consts' ~init:(env, r, None)
-    ~f:(fun (env, r, updates) bound_symbol_pat const ->
-      static_const_or_code env r ~updates bound_symbol_pat const)
+  ListLabels.fold_left2 bound_static' static_consts'
+    ~init:(env, r, None, Backend_var.Set.empty)
+    ~f:(fun (env, r, updates, free_names) bound_symbol_pat const ->
+      static_const_or_code env r ~updates ~free_names bound_symbol_pat const)
 
 let static_consts env r ~params_and_body bound_static static_consts =
   try

--- a/middle_end/flambda2/to_cmm/to_cmm_static.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.mli
@@ -29,4 +29,4 @@ val static_consts :
     Cmm.fundecl * To_cmm_result.t) ->
   Bound_static.t ->
   Static_const_group.t ->
-  To_cmm_env.t * To_cmm_result.t * Cmm.expression option
+  To_cmm_env.t * To_cmm_result.t * Cmm.expression option * Backend_var.Set.t


### PR DESCRIPTION
This is an upgraded version of the to_cmm parts of #1031 . This PR contains two main changes: better handling of aliasing, and a way to avoid introducing unneeded binding when flushing. This PR is probably best reviewed commit by commit. In particular, a careful review of the second commit is welcomed to make sure no `free_names` is accidentally dropped.

# Variable aliasing in to_cmm

When translating to cmm a variable alias, i.e. `let x = y in ...`, we take care of propagating the inline status of `y` to `x`. So that if e.g. `y` was bound to a must_inline_and_duplicate primitive, we do the same for `x`. Before this PR, we would lose that information and uses of `x` would not inline the primitive bound to `y`, thus limiting the opportunities for unboxing.
This is done by the first commit (which is a more concise version of what PR#1031 was doing).

# Unneeded binding when flushing

One current problem of the substitution/inlining process in to_cmm is that it interacts badly with the forced flushs at end_regions. The common case is that there is a binding such as `let x = box_float ... in ...` which gets translated to a must_inline_and_duplicate binding. This binding gets correctly inlined at every use. However, when we reach an end_region, the binding is still in the env, and we do not know whether there are any use of `x` after the end_region, so to be correct, we need to create a binding when flushing an end_region (so that any potential use after the end_region can access `x`); note that we cannot not flush `x` because the expression bound to `x` might interact with regions, and thus become invalid if moved after an end_region (that can happen e.g. for project_value primitives).

To solve that problem, this PR introduces a not-so-minor change to cmm generation: when building cmm expressions, we also build the set of free_names in that expression and return it along the expression (and the `To_cmm_result.t` which holds all static data). This is done in the second commit.

Once we have that information, we can use the free_names information when flushing in order to determine whether a binding is actually needed.
