### PR TITLE
Add `gc-timings` to collect timing information from the GC

### DIFF
--- a/driver/dune
+++ b/driver/dune
@@ -5,5 +5,5 @@
   (:standard -principal))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
- (libraries ocamloptcomp flambda2)
+ (libraries ocamloptcomp flambda2 gc_timings)
  (modules optcompile))

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -83,6 +83,9 @@ let mk_dump_inlining_paths f =
 let mk_internal_assembler f =
   "-internal-assembler", Arg.Unit f, "Write object files directly instead of using the system assembler (x86-64 ELF only)"
 
+let mk_gc_timings f =
+  "-gc-timings", Arg.Unit f, "Output information about time spend in the GC"
+
 module Flambda2 = Flambda_backend_flags.Flambda2
 
 let mk_flambda2_result_types_functors_only f =
@@ -482,6 +485,8 @@ module type Flambda_backend_options = sig
   val caml_apply_inline_fast_path : unit -> unit
   val internal_assembler : unit -> unit
 
+  val gc_timings : unit -> unit
+
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
   val flambda2_result_types_functors_only : unit -> unit
@@ -564,6 +569,8 @@ struct
     mk_caml_apply_inline_fast_path F.caml_apply_inline_fast_path;
 
     mk_internal_assembler F.internal_assembler;
+
+    mk_gc_timings F.gc_timings;
 
     mk_flambda2_join_points F.flambda2_join_points;
     mk_no_flambda2_join_points F.no_flambda2_join_points;
@@ -684,6 +691,8 @@ module Flambda_backend_options_impl = struct
     set' Flambda_backend_flags.caml_apply_inline_fast_path
 
   let internal_assembler = set' Flambda_backend_flags.internal_assembler
+
+  let gc_timings = set' Flambda_backend_flags.gc_timings
 
   let flambda2_join_points = set Flambda2.join_points
   let no_flambda2_join_points = clear Flambda2.join_points
@@ -871,6 +880,7 @@ module Extra_params = struct
     in
     match name with
     | "internal-assembler" -> set' Flambda_backend_flags.internal_assembler
+    | "gc-timings" -> set' Flambda_backend_flags.gc_timings
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
     | "cfg-invariants" -> set' Flambda_backend_flags.cfg_invariants
     | "cfg-equivalence-check" -> set' Flambda_backend_flags.cfg_equivalence_check

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -84,7 +84,7 @@ let mk_internal_assembler f =
   "-internal-assembler", Arg.Unit f, "Write object files directly instead of using the system assembler (x86-64 ELF only)"
 
 let mk_gc_timings f =
-  "-dgc-timings", Arg.Unit f, "Output information about time spend in the GC"
+  "-dgc-timings", Arg.Unit f, "Output information about time spent in the GC"
 
 module Flambda2 = Flambda_backend_flags.Flambda2
 

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -84,7 +84,7 @@ let mk_internal_assembler f =
   "-internal-assembler", Arg.Unit f, "Write object files directly instead of using the system assembler (x86-64 ELF only)"
 
 let mk_gc_timings f =
-  "-gc-timings", Arg.Unit f, "Output information about time spend in the GC"
+  "-dgc-timings", Arg.Unit f, "Output information about time spend in the GC"
 
 module Flambda2 = Flambda_backend_flags.Flambda2
 
@@ -880,7 +880,7 @@ module Extra_params = struct
     in
     match name with
     | "internal-assembler" -> set' Flambda_backend_flags.internal_assembler
-    | "gc-timings" -> set' Flambda_backend_flags.gc_timings
+    | "dgc-timings" -> set' Flambda_backend_flags.gc_timings
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
     | "cfg-invariants" -> set' Flambda_backend_flags.cfg_invariants
     | "cfg-equivalence-check" -> set' Flambda_backend_flags.cfg_equivalence_check

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -46,6 +46,8 @@ module type Flambda_backend_options = sig
   val caml_apply_inline_fast_path : unit -> unit
   val internal_assembler : unit -> unit
 
+  val gc_timings : unit -> unit
+
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
   val flambda2_result_types_functors_only : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -47,6 +47,8 @@ let opt_level = ref Default
 
 let internal_assembler = ref false
 
+let gc_timings = ref false
+
 let flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3 =
   match opt_level with
   | Default -> default

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -44,6 +44,8 @@ val opt_level : opt_level or_default ref
 
 val internal_assembler : bool ref
 
+val gc_timings : bool ref
+
 module Flambda2 : sig
   module Default : sig
     val classic_mode : bool

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -159,6 +159,7 @@ let main unix argv ppf ~flambda2 =
     Location.report_exception ppf x;
     2
   | () ->
-    if !Flambda_backend_flags.gc_timings then Gc_timings.print Format.std_formatter;
+    if !Flambda_backend_flags.gc_timings then
+      Gc_timings.print ~precision:!Clflags.timings_precision Format.std_formatter;
     Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
     0

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -159,7 +159,14 @@ let main unix argv ppf ~flambda2 =
     Location.report_exception ppf x;
     2
   | () ->
-    if !Flambda_backend_flags.gc_timings then
-      Gc_timings.print ~precision:!Clflags.timings_precision Format.std_formatter;
+    if !Flambda_backend_flags.gc_timings then begin
+      let minor = Gc_timings.gc_minor_ns () in
+      let major = Gc_timings.gc_major_ns () in
+      let secs x = x *. 1e-9 in
+      let precision = !Clflags.timings_precision in
+      Format.fprintf ppf "%0.*fs gc\n" precision (secs (minor +. major));
+      Format.fprintf ppf "  %0.*fs minor\n" precision (secs minor);
+      Format.fprintf ppf "  %0.*fs major\n" precision (secs major)
+    end;
     Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
     0

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -37,7 +37,6 @@ module Options = Flambda_backend_args.Make_optcomp_options
         (Flambda_backend_args.Default.Optmain)
 
 let main unix argv ppf ~flambda2 =
-  if !Flambda_backend_flags.gc_timings then Gc_timings.start_collection ();
   native_code := true;
   let columns =
     match Sys.getenv "COLUMNS" with
@@ -67,6 +66,7 @@ let main unix argv ppf ~flambda2 =
     Clflags.Opt_flag_handler.set Flambda_backend_flags.opt_flag_handler;
     Compenv.parse_arguments (ref argv) Compenv.anonymous "ocamlopt";
     Compmisc.read_clflags_from_env ();
+    if !Flambda_backend_flags.gc_timings then Gc_timings.start_collection ();
     if !Clflags.plugin then
       Compenv.fatal "-plugin is only supported up to OCaml 4.08.0";
     begin try

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -37,6 +37,7 @@ module Options = Flambda_backend_args.Make_optcomp_options
         (Flambda_backend_args.Default.Optmain)
 
 let main unix argv ppf ~flambda2 =
+  if !Flambda_backend_flags.gc_timings then Gc_timings.start_collection ();
   native_code := true;
   let columns =
     match Sys.getenv "COLUMNS" with
@@ -158,5 +159,6 @@ let main unix argv ppf ~flambda2 =
     Location.report_exception ppf x;
     2
   | () ->
+    if !Flambda_backend_flags.gc_timings then Gc_timings.print Format.std_formatter;
     Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
     0

--- a/dune
+++ b/dune
@@ -276,7 +276,8 @@
   flambda2_identifiers
   flambda2_cmx
   dwarf_ocaml
-  compiler_owee))
+  compiler_owee
+  gc_timings))
 
 (library
  (name flambda_backend_common)

--- a/external/gc-timings/dune
+++ b/external/gc-timings/dune
@@ -11,6 +11,6 @@
 
 (install
  (files
-  (dllgc_timings_stubs.so as stublibs/gc_timings_stubs.so))
+  (dllgc_timings_stubs.so as stublibs/dllgc_timings_stubs.so))
  (section lib)
  (package ocaml))

--- a/external/gc-timings/dune
+++ b/external/gc-timings/dune
@@ -1,0 +1,16 @@
+(library
+ (name gc_timings)
+ (foreign_stubs
+  (language c)
+  (names gc_timings_stubs)
+  (flags
+   ((:include %{project_root}/oc_cflags.sexp)
+    (:include %{project_root}/sharedlib_cflags.sexp)
+    (:include %{project_root}/oc_cppflags.sexp))))
+ (synopsis "OCaml library to work with DWARF format"))
+
+(install
+ (files
+  (dllgc_timings_stubs.so as stublibs/gc_timings_stubs.so))
+ (section lib)
+ (package ocaml))

--- a/external/gc-timings/dune
+++ b/external/gc-timings/dune
@@ -7,7 +7,7 @@
    ((:include %{project_root}/oc_cflags.sexp)
     (:include %{project_root}/sharedlib_cflags.sexp)
     (:include %{project_root}/oc_cppflags.sexp))))
- (synopsis "OCaml library to work with DWARF format"))
+ (synopsis "OCaml library to extract timing information from the GC"))
 
 (install
  (files

--- a/external/gc-timings/gc_timings.ml
+++ b/external/gc-timings/gc_timings.ml
@@ -1,6 +1,6 @@
 external collect_gc_timings : unit -> unit = "caml_timing_collect_gc" [@@noalloc]
-external gc_minor_ns : unit -> float = "caml_timing_gc_time_spend_minor"
-external gc_major_ns : unit -> float = "caml_timing_gc_time_spend_major"
+external gc_minor_ns : unit -> float = "caml_timing_gc_time_spent_minor"
+external gc_major_ns : unit -> float = "caml_timing_gc_time_spent_major"
 
 let start_collection () =
   collect_gc_timings ()

--- a/external/gc-timings/gc_timings.ml
+++ b/external/gc-timings/gc_timings.ml
@@ -4,11 +4,3 @@ external gc_major_ns : unit -> float = "caml_timing_gc_time_spend_major"
 
 let start_collection () =
   collect_gc_timings ()
-
-let print ?(precision=3) ppf =
-  let minor = gc_minor_ns () in
-  let major = gc_major_ns () in
-  let secs x = x *. 1e-9 in
-  Format.fprintf ppf "%0.*fs gc\n" precision (secs (minor +. major));
-  Format.fprintf ppf "  %0.*fs minor\n" precision (secs minor);
-  Format.fprintf ppf "  %0.*fs major\n" precision (secs major)

--- a/external/gc-timings/gc_timings.ml
+++ b/external/gc-timings/gc_timings.ml
@@ -5,7 +5,6 @@ external gc_major_ns : unit -> float = "caml_timing_gc_time_spend_major"
 let start_collection () =
   collect_gc_timings ()
 
-let print ppf =
-  let precision = 3 in
-  Format.fprintf ppf "minor_ns %0.*f\n" precision (gc_minor_ns () *. 1e-9);
-  Format.fprintf ppf "major_ns %0.*f\n" precision (gc_major_ns () *. 1e-9)
+let print ?(precision=3) ppf =
+  Format.fprintf ppf "minor_s %0.*f\n" precision (gc_minor_ns () *. 1e-9);
+  Format.fprintf ppf "major_s %0.*f\n" precision (gc_major_ns () *. 1e-9)

--- a/external/gc-timings/gc_timings.ml
+++ b/external/gc-timings/gc_timings.ml
@@ -6,5 +6,9 @@ let start_collection () =
   collect_gc_timings ()
 
 let print ?(precision=3) ppf =
-  Format.fprintf ppf "%0.*fs gc_minor\n" precision (gc_minor_ns () *. 1e-9);
-  Format.fprintf ppf "%0.*fs gc_major\n" precision (gc_major_ns () *. 1e-9)
+  let minor = gc_minor_ns () in
+  let major = gc_major_ns () in
+  let secs x = x *. 1e-9 in
+  Format.fprintf ppf "%0.*fs gc\n" precision (secs (minor +. major));
+  Format.fprintf ppf "  %0.*fs minor\n" precision (secs minor);
+  Format.fprintf ppf "  %0.*fs major\n" precision (secs major)

--- a/external/gc-timings/gc_timings.ml
+++ b/external/gc-timings/gc_timings.ml
@@ -6,5 +6,5 @@ let start_collection () =
   collect_gc_timings ()
 
 let print ?(precision=3) ppf =
-  Format.fprintf ppf "minor_s %0.*f\n" precision (gc_minor_ns () *. 1e-9);
-  Format.fprintf ppf "major_s %0.*f\n" precision (gc_major_ns () *. 1e-9)
+  Format.fprintf ppf "%0.*fs gc_minor\n" precision (gc_minor_ns () *. 1e-9);
+  Format.fprintf ppf "%0.*fs gc_major\n" precision (gc_major_ns () *. 1e-9)

--- a/external/gc-timings/gc_timings.ml
+++ b/external/gc-timings/gc_timings.ml
@@ -1,0 +1,11 @@
+external collect_gc_timings : unit -> unit = "caml_timing_collect_gc" [@@noalloc]
+external gc_minor_ns : unit -> float = "caml_timing_gc_time_spend_minor"
+external gc_major_ns : unit -> float = "caml_timing_gc_time_spend_major"
+
+let start_collection () =
+  collect_gc_timings ()
+
+let print ppf =
+  let precision = 3 in
+  Format.fprintf ppf "minor_ns %0.*f\n" precision (gc_minor_ns () *. 1e-9);
+  Format.fprintf ppf "major_ns %0.*f\n" precision (gc_major_ns () *. 1e-9)

--- a/external/gc-timings/gc_timings.mli
+++ b/external/gc-timings/gc_timings.mli
@@ -1,7 +1,7 @@
 val start_collection : unit -> unit
 
-(* Time spend doing a minor collection in nanoseconds *)
+(* Time spent doing a minor collection in nanoseconds *)
 val gc_minor_ns : unit -> float
 
-(* Time spend doing a major collection in nanoseconds *)
+(* Time spent doing a major collection in nanoseconds *)
 val gc_major_ns : unit -> float

--- a/external/gc-timings/gc_timings.mli
+++ b/external/gc-timings/gc_timings.mli
@@ -1,2 +1,7 @@
 val start_collection : unit -> unit
-val print : ?precision:int -> Format.formatter -> unit
+
+(* Time spend doing a minor collection in nanoseconds *)
+val gc_minor_ns : unit -> float
+
+(* Time spend doing a major collection in nanoseconds *)
+val gc_major_ns : unit -> float

--- a/external/gc-timings/gc_timings.mli
+++ b/external/gc-timings/gc_timings.mli
@@ -1,2 +1,2 @@
 val start_collection : unit -> unit
-val print : Format.formatter -> unit
+val print : ?precision:int -> Format.formatter -> unit

--- a/external/gc-timings/gc_timings.mli
+++ b/external/gc-timings/gc_timings.mli
@@ -1,0 +1,2 @@
+val start_collection : unit -> unit
+val print : Format.formatter -> unit

--- a/external/gc-timings/gc_timings_stubs.c
+++ b/external/gc-timings/gc_timings_stubs.c
@@ -89,12 +89,12 @@ CAMLprim value caml_timing_collect_gc(value unit) {
   CAMLreturn (Val_unit);
 }
 
-CAMLprim value caml_timing_gc_time_spend_minor(value unit) {
+CAMLprim value caml_timing_gc_time_spent_minor(value unit) {
   CAMLparam1 (unit);
   CAMLreturn (caml_copy_double (caml_timing_minor_gc));
 }
 
-CAMLprim value caml_timing_gc_time_spend_major(value unit) {
+CAMLprim value caml_timing_gc_time_spent_major(value unit) {
   CAMLparam1 (unit);
   CAMLreturn (caml_copy_double (caml_timing_major_gc));
 }

--- a/external/gc-timings/gc_timings_stubs.c
+++ b/external/gc-timings/gc_timings_stubs.c
@@ -1,0 +1,98 @@
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/gc.h>
+
+#ifdef _WIN32
+#include <wtypes.h>
+#include <process.h>
+#elif defined(HAS_UNISTD)
+#include <unistd.h>
+#endif
+
+#ifdef HAS_MACH_ABSOLUTE_TIME
+#include <mach/mach_time.h>
+#elif HAS_POSIX_MONOTONIC_CLOCK
+#include <time.h>
+#endif
+
+int64_t time_counter(void)
+{
+#ifdef _WIN32
+  static double clock_freq = 0;
+  static LARGE_INTEGER now;
+
+  if (clock_freq == 0) {
+    LARGE_INTEGER f;
+    if (!QueryPerformanceFrequency(&f))
+      return 0;
+    clock_freq = (1000000000.0 / f.QuadPart);
+  };
+
+  if (!QueryPerformanceCounter(&now))
+    return 0;
+  return (int64_t)(now.QuadPart * clock_freq);
+
+#elif defined(HAS_MACH_ABSOLUTE_TIME)
+  static mach_timebase_info_data_t time_base = {0};
+  uint64_t now;
+
+  if (time_base.denom == 0) {
+    if (mach_timebase_info (&time_base) != KERN_SUCCESS)
+      return 0;
+
+    if (time_base.denom == 0)
+      return 0;
+  }
+
+  now = mach_absolute_time ();
+  return (int64_t)((now * time_base.numer) / time_base.denom);
+
+#elif defined(HAS_POSIX_MONOTONIC_CLOCK)
+  struct timespec t;
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  return
+    (int64_t)t.tv_sec  * (int64_t)1000000000 +
+    (int64_t)t.tv_nsec;
+
+
+#endif
+}
+int64_t caml_timing_major_gc = 0.;
+int64_t caml_timing_minor_gc = 0.;
+
+void caml_timing_collect_gc_minor_begin_hook() {
+  caml_timing_minor_gc -= time_counter();
+}
+
+void caml_timing_collect_gc_minor_end_hook() {
+  caml_timing_minor_gc += time_counter();
+}
+
+void caml_timing_collect_gc_major_begin_hook() {
+  caml_timing_major_gc -= time_counter();
+}
+
+void caml_timing_collect_gc_major_end_hook() {
+  caml_timing_major_gc += time_counter();
+}
+
+CAMLprim value caml_timing_collect_gc(value unit) {
+  CAMLparam1 (unit);
+
+  caml_major_slice_begin_hook = caml_timing_collect_gc_major_begin_hook;
+  caml_major_slice_end_hook = caml_timing_collect_gc_major_end_hook;
+
+  caml_minor_gc_begin_hook = caml_timing_collect_gc_minor_begin_hook;
+  caml_minor_gc_end_hook = caml_timing_collect_gc_minor_end_hook;
+  CAMLreturn (Val_unit);
+}
+
+CAMLprim value caml_timing_gc_time_spend_minor(value unit) {
+  CAMLparam1 (unit);
+  CAMLreturn (caml_copy_double (caml_timing_minor_gc));
+}
+
+CAMLprim value caml_timing_gc_time_spend_major(value unit) {
+  CAMLparam1 (unit);
+  CAMLreturn (caml_copy_double (caml_timing_major_gc));
+}

--- a/external/gc-timings/gc_timings_stubs.c
+++ b/external/gc-timings/gc_timings_stubs.c
@@ -15,6 +15,7 @@
 #include <time.h>
 #endif
 
+/* [time_counter] is extracted from ocaml/runtime/eventlog.c */
 int64_t time_counter(void)
 {
 #ifdef _WIN32
@@ -53,10 +54,11 @@ int64_t time_counter(void)
   return
     (int64_t)t.tv_sec  * (int64_t)1000000000 +
     (int64_t)t.tv_nsec;
-
-
+#else
+  return 0;
 #endif
 }
+
 int64_t caml_timing_major_gc = 0.;
 int64_t caml_timing_minor_gc = 0.;
 

--- a/ocaml/runtime/eventlog.c
+++ b/ocaml/runtime/eventlog.c
@@ -115,8 +115,8 @@ static int64_t time_counter(void)
   return
     (int64_t)t.tv_sec  * (int64_t)1000000000 +
     (int64_t)t.tv_nsec;
-
-
+#else
+  return 0;
 #endif
 }
 


### PR DESCRIPTION
Passing `-gc-timings` will print the time spend during the GC minor / major collections.