### PR TITLE
Remove a stray character from dynlink Makefile

### DIFF
--- a/ocaml/otherlibs/dynlink/Makefile
+++ b/ocaml/otherlibs/dynlink/Makefile
@@ -254,7 +254,7 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	  "$(INSTALL_LIBDIR_DYNLINK)"
 endif
 
-installopt:g
+installopt:
 ifeq "$(strip $(NATDYNLINK))" "true"
 	$(INSTALL_DATA) \
 	  $(NATOBJS) dynlink.cmxa dynlink.$(A) \


### PR DESCRIPTION
Introduced somehow in #895, in a target that is not used in CI.