### PR TITLE
Cmm.value_kind cleanup

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -218,11 +218,10 @@ and operation =
   | Copaque
   | Cbeginregion | Cendregion
 
-type value_kind =
-  | Vval of Lambda.value_kind (* Valid OCaml values *)
-  | Vint (* Untagged integers and off-heap pointers *)
-  | Vaddr (* Derived pointers *)
-  | Vfloat (* Unboxed floating-point numbers *)
+type kind_for_unboxing =
+  | Any
+  | Boxed_integer of Lambda.boxed_integer
+  | Boxed_float
 
 type expression =
     Cconst_int of int * Debuginfo.t
@@ -240,17 +239,17 @@ type expression =
   | Cop of operation * expression list * Debuginfo.t
   | Csequence of expression * expression
   | Cifthenelse of expression * Debuginfo.t * expression
-      * Debuginfo.t * expression * Debuginfo.t * value_kind
+      * Debuginfo.t * expression * Debuginfo.t * kind_for_unboxing
   | Cswitch of expression * int array * (expression * Debuginfo.t) array
-      * Debuginfo.t * value_kind
+      * Debuginfo.t * kind_for_unboxing
   | Ccatch of
       rec_flag
         * (static_label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
-        * expression * value_kind
+        * expression * kind_for_unboxing
   | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
-      * expression * Debuginfo.t * value_kind
+      * expression * Debuginfo.t * kind_for_unboxing
   | Cregion of expression
   | Ctail of expression
 

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -220,11 +220,12 @@ and operation =
   | Copaque (* Sys.opaque_identity *)
   | Cbeginregion | Cendregion
 
-type value_kind =
-  | Vval of Lambda.value_kind (* Valid OCaml values *)
-  | Vint (* Untagged integers and off-heap pointers *)
-  | Vaddr (* Derived pointers *)
-  | Vfloat (* Unboxed floating-point numbers *)
+(* This is information used exclusively during construction of cmm terms by
+   cmmgen, and thus irrelevant for selectgen and flambda2. *)
+type kind_for_unboxing =
+  | Any (* This may contain anything, including non-scannable things *)
+  | Boxed_integer of Lambda.boxed_integer
+  | Boxed_float
 
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)
@@ -245,18 +246,18 @@ type expression =
   | Cop of operation * expression list * Debuginfo.t
   | Csequence of expression * expression
   | Cifthenelse of expression * Debuginfo.t * expression
-      * Debuginfo.t * expression * Debuginfo.t * value_kind
+      * Debuginfo.t * expression * Debuginfo.t * kind_for_unboxing
   | Cswitch of expression * int array * (expression * Debuginfo.t) array
-      * Debuginfo.t * value_kind
+      * Debuginfo.t * kind_for_unboxing
   | Ccatch of
       rec_flag
         * (Lambda.static_label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
         * expression
-        * value_kind
+        * kind_for_unboxing
   | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
-      * expression * Debuginfo.t * value_kind
+      * expression * Debuginfo.t * kind_for_unboxing
   (** Only if the [trywith_kind] is [Regular] will a region be inserted for
       the "try" block. *)
   | Cregion of expression
@@ -300,7 +301,7 @@ type phrase =
 
 val ccatch :
      label * (Backend_var.With_provenance.t * machtype) list
-       * expression * expression * Debuginfo.t * value_kind
+       * expression * expression * Debuginfo.t * kind_for_unboxing
   -> expression
 
 val reset : unit -> unit
@@ -314,12 +315,12 @@ val iter_shallow_tail: (expression -> unit) -> expression -> bool
       considered to be in tail position (because their result become
       the final result for the expression).  *)
 
-val map_shallow_tail: ?kind:value_kind -> (expression -> expression) -> expression -> expression
+val map_shallow_tail: ?kind:kind_for_unboxing -> (expression -> expression) -> expression -> expression
   (** Apply the transformation to those immediate sub-expressions of an
       expression that are in tail position, using the same definition of "tail"
       as [iter_shallow_tail] *)
 
-val map_tail: ?kind:value_kind -> (expression -> expression) -> expression -> expression
+val map_tail: ?kind:kind_for_unboxing -> (expression -> expression) -> expression -> expression
   (** Apply the transformation to an expression, trying to push it
       to all inner sub-expressions that can produce the final result,
       by recursively applying map_shallow_tail *)

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -172,7 +172,7 @@ val safe_mod_bi :
     [ifso], and [ifnot_dbg] to the else branch [ifnot] *)
 val mk_if_then_else :
   Debuginfo.t ->
-  Cmm.value_kind ->
+  Cmm.kind_for_unboxing ->
   expression ->
   Debuginfo.t ->
   expression ->
@@ -768,13 +768,13 @@ val make_switch :
   int array ->
   (expression * Debuginfo.t) array ->
   Debuginfo.t ->
-  Cmm.value_kind ->
+  Cmm.kind_for_unboxing ->
   expression
 
 (** [transl_int_switch loc kind arg low high cases default] *)
 val transl_int_switch :
   Debuginfo.t ->
-  Cmm.value_kind ->
+  Cmm.kind_for_unboxing ->
   expression ->
   int ->
   int ->
@@ -785,7 +785,7 @@ val transl_int_switch :
 (** [transl_switch_clambda loc kind arg index cases] *)
 val transl_switch_clambda :
   Debuginfo.t ->
-  Cmm.value_kind ->
+  Cmm.kind_for_unboxing ->
   expression ->
   int array ->
   expression array ->
@@ -794,7 +794,7 @@ val transl_switch_clambda :
 (** [strmatch_compile dbg arg default cases] *)
 val strmatch_compile :
   Debuginfo.t ->
-  Cmm.value_kind ->
+  Cmm.kind_for_unboxing ->
   expression ->
   expression option ->
   (string * expression) list ->
@@ -1274,7 +1274,7 @@ val transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list
 (* CR lmaurer: Return [Linkage_name.t] instead *)
 val make_symbol : ?compilation_unit:Compilation_unit.t -> string -> string
 
-val kind_of_layout : Lambda.layout -> value_kind
+val kind_of_layout : Lambda.layout -> kind_for_unboxing
 
 val machtype_of_layout : Lambda.layout -> machtype
 

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -355,9 +355,9 @@ let join_unboxed_number_kind ~strict k1 k2 =
       k
   | _, _ -> No_unboxing
 
-let is_strict = function
-  | Pfloatval | Pboxedintval _ -> false
-  | Pintval | Pgenval | Pvariant _ | Parrayval _ -> true
+let is_strict : kind_for_unboxing -> bool = function
+  | Boxed_integer _ | Boxed_float -> false
+  | Any -> true
 
 let rec is_unboxed_number_cmm = function
     | Cop(Calloc mode, [Cconst_natint (hdr, _); _], dbg)
@@ -404,34 +404,24 @@ let rec is_unboxed_number_cmm = function
     | Cassign _
     | Ctuple _
     | Cop _ -> No_unboxing
-    | Cifthenelse (_, _, _, _, _, _, Vval (Pintval | Pvariant _))
-    | Cswitch (_, _,  _, _, Vval (Pintval | Pvariant _))
-    | Ctrywith (_, _, _, _, _, Vval (Pintval | Pvariant _))
-    | Ccatch (_, _, _, Vval (Pintval | Pvariant _)) ->
-      No_unboxing
-    | Cifthenelse (_, _, a, _, b, _, Vval kind) ->
+    | Cifthenelse (_, _, a, _, b, _, kind) ->
       join_unboxed_number_kind ~strict:(is_strict kind)
         (is_unboxed_number_cmm a)
         (is_unboxed_number_cmm b)
-    | Cswitch (_, _,  cases, _, Vval kind) ->
+    | Cswitch (_, _,  cases, _, kind) ->
       let cases = Array.map (fun (x, _) -> is_unboxed_number_cmm x) cases in
       let strict = is_strict kind in
       Array.fold_left (join_unboxed_number_kind ~strict) No_result cases
-    | Ctrywith (a, _, _, b, _, Vval kind) ->
+    | Ctrywith (a, _, _, b, _, kind) ->
       join_unboxed_number_kind ~strict:(is_strict kind)
         (is_unboxed_number_cmm a)
         (is_unboxed_number_cmm b)
-    | Ccatch (_, handlers, body, Vval kind) ->
+    | Ccatch (_, handlers, body, kind) ->
       let strict = is_strict kind in
       List.fold_left
         (join_unboxed_number_kind ~strict)
         (is_unboxed_number_cmm body)
         (List.map (fun (_, _, e, _) -> is_unboxed_number_cmm e) handlers)
-    | Cifthenelse (_, _, _, _, _, _, _)
-    | Cswitch (_, _,  _, _, _)
-    | Ctrywith (_, _, _, _, _, _)
-    | Ccatch (_, _, _, _) ->
-      No_unboxing
 
 (* Translate an expression *)
 
@@ -746,13 +736,13 @@ let rec transl env e =
       return_unit dbg
         (ccatch
            (raise_num, [],
-            create_loop(transl_if env (Vval Pgenval) Unknown dbg cond
+            create_loop(transl_if env Any Unknown dbg cond
                     dbg (remove_unit(transl env body))
                     dbg (Cexit (Lbl raise_num,[],[]))
                     )
               dbg,
             Ctuple [],
-            dbg, Vval Pgenval))
+            dbg, Any))
   | Ufor(id, low, high, dir, body) ->
       let dbg = Debuginfo.none in
       let tst = match dir with Upto -> Cgt   | Downto -> Clt in
@@ -783,11 +773,11 @@ let rec transl env e =
                                   dbg),
                                 dbg, Cexit (Lbl raise_num,[],[]),
                                 dbg, Ctuple [],
-                                dbg, Vint (* unit *))))))
+                                dbg, Any)))))
                       dbg,
-                   dbg, Vint (* unit*)),
+                   dbg, Any),
                  Ctuple [],
-                 dbg, Vint (* unit *)))))
+                 dbg, Any))))
   | Uassign(id, exp) ->
       let dbg = Debuginfo.none in
       let cexp = transl env exp in
@@ -805,27 +795,16 @@ let rec transl env e =
   | Utail e ->
       Ctail (transl env e)
 
-and transl_catch (kind : Cmm.value_kind) env nfail ids body handler dbg =
+and transl_catch (kind : Cmm.kind_for_unboxing) env nfail ids body handler dbg =
   let ids = List.map (fun (id, kind) -> (id, kind, ref No_result)) ids in
   (* Translate the body, and while doing so, collect the "unboxing type" for
      each argument.  *)
   let report args =
     List.iter2
-      (fun (id, (layout : Lambda.layout), u) c ->
-         match layout with
-         | Ptop ->
-           Misc.fatal_errorf "Variable %a with layout [Ptop] can't be compiled"
-             VP.print id
-         | Pbottom ->
-           Misc.fatal_errorf
-             "Variable %a with layout [Pbottom] can't be compiled"
-             VP.print id
-         | Punboxed_float | Punboxed_int _ ->
-           u := No_unboxing
-         | Pvalue kind ->
-           let strict = is_strict kind in
-           u := join_unboxed_number_kind ~strict !u
-               (is_unboxed_number_cmm c)
+      (fun (_id, layout, u) c ->
+         let strict = is_strict (kind_of_layout layout) in
+         u := join_unboxed_number_kind ~strict !u
+             (is_unboxed_number_cmm c)
       )
       ids args
   in
@@ -978,7 +957,7 @@ and transl_prim_1 env p arg dbg =
       arraylength kind (transl env arg) dbg
   (* Boolean operations *)
   | Pnot ->
-      transl_if env Vint Then_false_else_true
+      transl_if env Any Then_false_else_true
         dbg arg
         dbg (Cconst_int (1, dbg))
         dbg (Cconst_int (3, dbg))
@@ -1037,7 +1016,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   (* Boolean operations *)
   | Psequand ->
       let dbg' = Debuginfo.none in
-      transl_sequand env Vint Then_true_else_false
+      transl_sequand env Any Then_true_else_false
         dbg arg1
         dbg' arg2
         dbg (Cconst_int (3, dbg))
@@ -1047,7 +1026,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
            Cifthenelse(test_bool dbg (Cvar id), transl env arg2, Cvar id)) *)
   | Psequor ->
       let dbg' = Debuginfo.none in
-      transl_sequor env Vint Then_true_else_false
+      transl_sequor env Any Then_true_else_false
         dbg arg1
         dbg' arg2
         dbg (Cconst_int (3, dbg))
@@ -1344,7 +1323,7 @@ and transl_let env str (layout : Lambda.layout) id exp transl_body =
   | Pvalue kind ->
     transl_let_value env str kind id exp transl_body
 
-and make_catch (kind : Cmm.value_kind) ncatch body handler dbg =
+and make_catch (kind : Cmm.kind_for_unboxing) ncatch body handler dbg =
   match body with
   | Cexit (Lbl nexit,[],[]) when nexit=ncatch -> handler
   | _ ->  ccatch (ncatch, [], body, handler, dbg, kind)
@@ -1354,7 +1333,7 @@ and is_shareable_cont exp =
   | Cexit (_,[],[]) -> true
   | _ -> false
 
-and make_shareable_cont (kind : Cmm.value_kind) dbg mk exp =
+and make_shareable_cont (kind : Cmm.kind_for_unboxing) dbg mk exp =
   if is_shareable_cont exp then mk exp
   else begin
     let nfail = next_raise_count () in
@@ -1366,7 +1345,7 @@ and make_shareable_cont (kind : Cmm.value_kind) dbg mk exp =
       dbg
   end
 
-and transl_if env (kind : Cmm.value_kind) (approx : then_else)
+and transl_if env (kind : Cmm.kind_for_unboxing) (approx : then_else)
       (dbg : Debuginfo.t) cond
       (then_dbg : Debuginfo.t) then_
       (else_dbg : Debuginfo.t) else_ =
@@ -1455,7 +1434,7 @@ and transl_if env (kind : Cmm.value_kind) (approx : then_else)
             else_dbg else_
     end
 
-and transl_sequand env (kind : Cmm.value_kind) (approx : then_else)
+and transl_sequand env (kind : Cmm.kind_for_unboxing) (approx : then_else)
       (arg1_dbg : Debuginfo.t) arg1
       (arg2_dbg : Debuginfo.t) arg2
       (then_dbg : Debuginfo.t) then_
@@ -1471,7 +1450,7 @@ and transl_sequand env (kind : Cmm.value_kind) (approx : then_else)
          else_dbg shareable_else)
     else_
 
-and transl_sequor env (kind : Cmm.value_kind) (approx : then_else)
+and transl_sequor env (kind : Cmm.kind_for_unboxing) (approx : then_else)
       (arg1_dbg : Debuginfo.t) arg1
       (arg2_dbg : Debuginfo.t) arg2
       (then_dbg : Debuginfo.t) then_
@@ -1488,7 +1467,7 @@ and transl_sequor env (kind : Cmm.value_kind) (approx : then_else)
     then_
 
 (* This assumes that [arg] can be safely discarded if it is not used. *)
-and transl_switch dbg (kind : Cmm.value_kind) env arg index cases = match Array.length cases with
+and transl_switch dbg (kind : Cmm.kind_for_unboxing) env arg index cases = match Array.length cases with
 | 0 -> fatal_error "Cmmgen.transl_switch"
 | 1 -> transl env cases.(0)
 | _ ->

--- a/backend/strmatch.ml
+++ b/backend/strmatch.ml
@@ -24,7 +24,7 @@ module VP = Backend_var.With_provenance
 module type I = sig
   val string_block_length : Cmm.expression -> Cmm.expression
   val transl_switch :
-      Debuginfo.t -> Cmm.value_kind -> Cmm.expression -> int -> int ->
+      Debuginfo.t -> Cmm.kind_for_unboxing -> Cmm.expression -> int -> int ->
         (int * Cmm.expression) list -> Cmm.expression ->
           Cmm.expression
 end
@@ -380,7 +380,7 @@ module Make(I:I) = struct
     | Cexit (_e,[],_traps) ->  k arg
     | _ ->
         let e = next_raise_count () in
-        ccatch (e,[],k (Cexit (Lbl e,[],[])),arg,dbg, Vval Pgenval)
+        ccatch (e,[],k (Cexit (Lbl e,[],[])),arg,dbg, Any)
 
     let compile dbg value_kind str default cases =
 (* We do not attempt to really optimise default=None *)

--- a/backend/strmatch.mli
+++ b/backend/strmatch.mli
@@ -18,7 +18,7 @@
 module type I = sig
   val string_block_length : Cmm.expression -> Cmm.expression
   val transl_switch :
-      Debuginfo.t -> Cmm.value_kind -> Cmm.expression -> int -> int ->
+      Debuginfo.t -> Cmm.kind_for_unboxing -> Cmm.expression -> int -> int ->
         (int * Cmm.expression) list -> Cmm.expression ->
           Cmm.expression
 end
@@ -26,7 +26,7 @@ end
 module Make(_:I) : sig
   (* Compile stringswitch (arg,cases,d)
      Note: cases should not contain string duplicates *)
-  val compile : Debuginfo.t -> Cmm.value_kind
+  val compile : Debuginfo.t -> Cmm.kind_for_unboxing
     -> Cmm.expression (* arg *)
     -> Cmm.expression option (* d *) ->
     (string * Cmm.expression) list (* cases *)-> Cmm.expression

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -950,8 +950,6 @@ and switch env res switch =
         (0, res, scrutinee_free_vars)
     in
     (* CR-someday poechsel: Put a more precise value kind here *)
-    let expr =
-      C.transl_switch_clambda dbg (Vval Pgenval) scrutinee index cases
-    in
+    let expr = C.transl_switch_clambda dbg Any scrutinee index cases in
     let cmm, free_vars = wrap expr free_vars in
     cmm, free_vars, res

--- a/ocaml/asmcomp/cmm.ml
+++ b/ocaml/asmcomp/cmm.ml
@@ -173,11 +173,10 @@ and operation =
   | Copaque
   | Cbeginregion | Cendregion
 
-type value_kind =
-  | Vval of Lambda.value_kind (* Valid OCaml values *)
-  | Vint (* Untagged integers and off-heap pointers *)
-  | Vaddr (* Derived pointers *)
-  | Vfloat (* Unboxed floating-point numbers *)
+type kind_for_unboxing =
+  | Any
+  | Boxed_integer of Lambda.boxed_integer
+  | Boxed_float
 
 type expression =
     Cconst_int of int * Debuginfo.t
@@ -195,17 +194,17 @@ type expression =
   | Cop of operation * expression list * Debuginfo.t
   | Csequence of expression * expression
   | Cifthenelse of expression * Debuginfo.t * expression
-      * Debuginfo.t * expression * Debuginfo.t * value_kind
+      * Debuginfo.t * expression * Debuginfo.t * kind_for_unboxing
   | Cswitch of expression * int array * (expression * Debuginfo.t) array
-      * Debuginfo.t * value_kind
+      * Debuginfo.t * kind_for_unboxing
   | Ccatch of
       rec_flag
         * (int * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
-        * expression * value_kind
+        * expression * kind_for_unboxing
   | Cexit of int * expression list
   | Ctrywith of expression * Backend_var.With_provenance.t * expression
-      * Debuginfo.t * value_kind
+      * Debuginfo.t * kind_for_unboxing
   | Cregion of expression
   | Ctail of expression
 

--- a/ocaml/asmcomp/cmm.mli
+++ b/ocaml/asmcomp/cmm.mli
@@ -171,11 +171,12 @@ and operation =
   | Copaque (* Sys.opaque_identity *)
   | Cbeginregion | Cendregion
 
-type value_kind =
-  | Vval of Lambda.value_kind (* Valid OCaml values *)
-  | Vint (* Untagged integers and off-heap pointers *)
-  | Vaddr (* Derived pointers *)
-  | Vfloat (* Unboxed floating-point numbers *)
+(* This is information used exclusively during construction of cmm terms by
+   cmmgen, and thus irrelevant for selectgen. *)
+type kind_for_unboxing =
+  | Any (* This may contain anything, including non-scannable things *)
+  | Boxed_integer of Lambda.boxed_integer
+  | Boxed_float
 
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)
@@ -196,18 +197,18 @@ type expression =
   | Cop of operation * expression list * Debuginfo.t
   | Csequence of expression * expression
   | Cifthenelse of expression * Debuginfo.t * expression
-      * Debuginfo.t * expression * Debuginfo.t * value_kind
+      * Debuginfo.t * expression * Debuginfo.t * kind_for_unboxing
   | Cswitch of expression * int array * (expression * Debuginfo.t) array
-      * Debuginfo.t * value_kind
+      * Debuginfo.t * kind_for_unboxing
   | Ccatch of
       rec_flag
         * (int * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
         * expression
-        * value_kind
+        * kind_for_unboxing
   | Cexit of int * expression list
   | Ctrywith of expression * Backend_var.With_provenance.t * expression
-      * Debuginfo.t * value_kind
+      * Debuginfo.t * kind_for_unboxing
   | Cregion of expression
   | Ctail of expression
 
@@ -244,7 +245,7 @@ type phrase =
 
 val ccatch :
      int * (Backend_var.With_provenance.t * machtype) list
-       * expression * expression * Debuginfo.t * value_kind
+       * expression * expression * Debuginfo.t * kind_for_unboxing
   -> expression
 
 val reset : unit -> unit
@@ -258,12 +259,12 @@ val iter_shallow_tail: (expression -> unit) -> expression -> bool
       considered to be in tail position (because their result become
       the final result for the expression).  *)
 
-val map_shallow_tail: ?kind:value_kind -> (expression -> expression) -> expression -> expression
+val map_shallow_tail: ?kind:kind_for_unboxing -> (expression -> expression) -> expression -> expression
   (** Apply the transformation to those immediate sub-expressions of an
       expression that are in tail position, using the same definition of "tail"
       as [iter_shallow_tail] *)
 
-val map_tail: ?kind:value_kind -> (expression -> expression) -> expression -> expression
+val map_tail: ?kind:kind_for_unboxing -> (expression -> expression) -> expression -> expression
   (** Apply the transformation to an expression, trying to push it
       to all inner sub-expressions that can produce the final result,
       by recursively applying map_shallow_tail *)

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -359,7 +359,7 @@ let create_loop body dbg =
   let cont = Lambda.next_raise_count () in
   let call_cont = Cexit (cont, []) in
   let body = Csequence (body, call_cont) in
-  Ccatch (Recursive, [cont, [], body, dbg], call_cont, Vval Pgenval)
+  Ccatch (Recursive, [cont, [], body, dbg], call_cont, Any)
 
 (* Turning integer divisions into multiply-high then shift.
    The [division_parameters] function is used in module Emit for
@@ -508,7 +508,7 @@ let rec div_int c1 c2 is_safe dbg =
                       Cop(Cdivi, [c1; c2], dbg),
                       dbg,
                       raise_symbol dbg "caml_exn_Division_by_zero",
-                      dbg, Vint)))
+                      dbg, Any)))
 
 let mod_int c1 c2 is_safe dbg =
   match (c1, c2) with
@@ -549,7 +549,7 @@ let mod_int c1 c2 is_safe dbg =
                       Cop(Cmodi, [c1; c2], dbg),
                       dbg,
                       raise_symbol dbg "caml_exn_Division_by_zero",
-                      dbg, Vint)))
+                      dbg, Any)))
 
 (* Division or modulo on boxed integers.  The overflow case min_int / -1
    can occur, in which case we force x / -1 = -x and x mod -1 = 0. (PR#5513). *)
@@ -575,11 +575,11 @@ let safe_divmod_bi mkop kind is_safe mkm1 c1 c2 bi dbg =
       c))
 
 let safe_div_bi is_safe =
-  safe_divmod_bi div_int Vint is_safe
+  safe_divmod_bi div_int Any is_safe
     (fun c1 dbg -> Cop(Csubi, [Cconst_int (0, dbg); c1], dbg))
 
 let safe_mod_bi is_safe =
-  safe_divmod_bi mod_int Vint is_safe (fun _ dbg -> Cconst_int (0, dbg))
+  safe_divmod_bi mod_int Any is_safe (fun _ dbg -> Cconst_int (0, dbg))
 
 (* Bool *)
 
@@ -600,7 +600,7 @@ let box_float dbg m c = Cop(Calloc m, [alloc_float_header m dbg; c], dbg)
 
 let rec unbox_float dbg =
   map_tail
-    ~kind:Vfloat
+    ~kind:Any
     (function
       | Cop(Calloc _, [Cconst_natint (hdr, _); c], _)
         when Nativeint.equal hdr float_header ->
@@ -616,7 +616,7 @@ let rec unbox_float dbg =
         (* It is valid to push unboxing inside a Cregion except when the extra
            unboxing logic pushes a tail call out of tail position *)
         match
-          map_tail ~kind:Vfloat
+          map_tail ~kind:Any
             (function
               | Cop (Capply (_, Rc_close_at_apply), _, _) -> raise Exit
               | Ctail e -> Ctail (unbox_float dbg e)
@@ -1261,7 +1261,7 @@ let rec unbox_int dbg bi =
         [Cop(Cadda, [arg; Cconst_int (size_addr, dbg)], dbg)], dbg)
   in
   map_tail
-    ~kind:Vint
+    ~kind:Any
     (function
       | Cop(Calloc _,
             [hdr; ops;
@@ -1306,7 +1306,7 @@ let rec unbox_int dbg bi =
         (* It is valid to push unboxing inside a Cregion except when the extra
            unboxing logic pushes a tail call out of tail position *)
         match
-          map_tail ~kind:Vint
+          map_tail ~kind:Any
             (function
               | Cop (Capply (_, Rc_close_at_apply), _, _) -> raise Exit
               | Ctail e -> Ctail (unbox_int dbg bi e)
@@ -1739,7 +1739,7 @@ struct
   type test = expression
   type act = expression
 
-  type layout = value_kind
+  type layout = kind_for_unboxing
 
   (* CR mshinwell: GPR#2294 will fix the Debuginfo here *)
 
@@ -1998,15 +1998,15 @@ let cache_public_method meths tag cache dbg =
                      dbg)], dbg),
            dbg, Cassign(hi, Cop(Csubi, [Cvar mi; cconst_int 2], dbg)),
            dbg, Cassign(li, Cvar mi),
-           dbg, Vint (* unit *)),
+           dbg, Any),
         Cifthenelse
           (Cop(Ccmpi Cge, [Cvar li; Cvar hi], dbg),
            dbg, Cexit (raise_num, []),
            dbg, Ctuple [],
-           dbg, Vint (* unit *)))))
+           dbg, Any))))
        dbg,
      Ctuple [],
-     dbg, Vint (* unit *)),
+     dbg, Any),
   Clet (
     VP.create tagged,
       Cop(Caddi, [lsl_const (Cvar li) log2_size_addr dbg;
@@ -2120,7 +2120,7 @@ let apply_function_body arity result (mode : Lambda.alloc_mode) =
                  Csequence (Cop (Cendregion, [Cvar region], dbg ()), Cvar res)
                )),
             dbg (),
-            Vval Pgenval (* Incorrect but only used for unboxing *) ))
+            Any ))
     | arg :: args ->
       let newclos = V.create_local "clos" in
       Clet
@@ -2164,7 +2164,7 @@ let apply_function_body arity result (mode : Lambda.alloc_mode) =
           dbg (),
           code,
           dbg (),
-          Vval Pgenval (* incorrect but only used for unboxing *) ) )
+          Any ) )
 
 let send_function (arity, result, mode) =
   let dbg = placeholder_dbg in
@@ -2195,7 +2195,7 @@ let send_function (arity, result, mode) =
                 cache_public_method (Cvar meths) tag cache (dbg ()),
                 dbg (),
                 cached_pos,
-                dbg (), Vval Pgenval),
+                dbg (), Any),
     Cop(Cload (Word_val, Mutable),
       [Cop(Cadda, [Cop (Cadda, [Cvar real; Cvar meths], dbg ());
        cconst_int(2*size_addr-1)], dbg ())], dbg ()))))
@@ -2575,7 +2575,7 @@ let arraylength kind arg dbg =
                           dbg,
                           Cop(Clsr,
                             [hdr; Cconst_int (numfloat_shift, dbg)], dbg),
-                          dbg, Vint))
+                          dbg, Any))
       in
       Cop(Cor, [len; Cconst_int (1, dbg)], dbg)
   | Paddrarray | Pintarray ->
@@ -2762,7 +2762,7 @@ let arrayref_unsafe kind arg1 arg2 dbg =
                       addr_array_ref arr idx dbg,
                       dbg,
                       float_array_ref arr idx dbg,
-                      dbg, Vval Pgenval)))
+                      dbg, Any)))
   | Paddrarray ->
       addr_array_ref arg1 arg2 dbg
   | Pintarray ->
@@ -2785,7 +2785,7 @@ let arrayref_safe kind arg1 arg2 dbg =
                         addr_array_ref arr idx dbg,
                         dbg,
                         float_array_ref arr idx dbg,
-                        dbg, Vval Pgenval))
+                        dbg, Any))
         else
           Cifthenelse(is_addr_array_hdr hdr dbg,
             dbg,
@@ -2796,7 +2796,7 @@ let arrayref_safe kind arg1 arg2 dbg =
             Csequence(
               make_checkbound dbg [float_array_length_shifted hdr dbg; idx],
               float_array_ref arr idx dbg),
-            dbg, Vval Pgenval))))
+            dbg, Any))))
       | Paddrarray ->
           bind "index" arg2 (fun idx ->
           bind "arr" arg1 (fun arr ->
@@ -2866,7 +2866,7 @@ let arrayset_unsafe kind arg1 arg2 arg3 dbg =
                         dbg,
                         float_array_set arr index (unbox_float dbg newval)
                           dbg,
-                        dbg, Vint (* unit *)))))
+                        dbg, Any))))
   | Paddrarray ->
       addr_array_set arg1 arg2 arg3 dbg
   | Pintarray ->
@@ -2892,7 +2892,7 @@ let arrayset_safe kind arg1 arg2 arg3 dbg =
                         float_array_set arr idx
                           (unbox_float dbg newval)
                           dbg,
-                        dbg, Vint (* unit *)))
+                        dbg, Any))
         else
           Cifthenelse(
             is_addr_array_hdr hdr dbg,
@@ -2905,7 +2905,7 @@ let arrayset_safe kind arg1 arg2 arg3 dbg =
               make_checkbound dbg [float_array_length_shifted hdr dbg; idx],
               float_array_set arr idx
                 (unbox_float dbg newval) dbg),
-            dbg, Vint (* unit*))))))
+            dbg, Any)))))
   | Paddrarray ->
       bind "newval" arg3 (fun newval ->
       bind "index" arg2 (fun idx ->
@@ -3277,11 +3277,9 @@ let emit_preallocated_blocks preallocated_blocks cont =
 
 let kind_of_layout (layout : Lambda.layout) =
   match layout with
-  | Ptop | Pbottom ->
-    (* This is incorrect but only used for unboxing *)
-    Vval Pgenval
-  | Punboxed_float -> Vfloat
-  | Punboxed_int _ -> Vint
-  | Pvalue kind -> Vval kind
+  | Pvalue Pfloatval -> Boxed_float
+  | Pvalue (Pboxedintval bi) -> Boxed_integer bi
+  | Pvalue (Pgenval | Pintval | Pvariant _ | Parrayval _)
+  | Ptop | Pbottom | Punboxed_float | Punboxed_int _ -> Any
 
 let make_tuple l = match l with [e] -> e | _ -> Ctuple l

--- a/ocaml/asmcomp/cmm_helpers.mli
+++ b/ocaml/asmcomp/cmm_helpers.mli
@@ -149,7 +149,7 @@ val safe_mod_bi :
     then branch [ifso], and [ifnot_dbg] to the else branch [ifnot] *)
 val mk_if_then_else :
   Debuginfo.t ->
-  Cmm.value_kind ->
+  Cmm.kind_for_unboxing ->
   expression ->
   Debuginfo.t -> expression ->
   Debuginfo.t -> expression ->
@@ -599,20 +599,20 @@ val transl_isout : expression -> expression -> Debuginfo.t -> expression
     or optimize as a static table lookup when possible. *)
 val make_switch :
   expression -> int array -> (expression * Debuginfo.t) array -> Debuginfo.t ->
-  Cmm.value_kind -> expression
+  Cmm.kind_for_unboxing -> expression
 
 (** [transl_int_switch loc kind arg low high cases default] *)
 val transl_int_switch :
-  Debuginfo.t -> Cmm.value_kind -> expression -> int -> int ->
+  Debuginfo.t -> Cmm.kind_for_unboxing -> expression -> int -> int ->
   (int * expression) list -> expression -> expression
 
 (** [transl_switch_clambda loc kind arg index cases] *)
 val transl_switch_clambda :
-  Debuginfo.t -> Cmm.value_kind -> expression -> int array -> expression array -> expression
+  Debuginfo.t -> Cmm.kind_for_unboxing -> expression -> int array -> expression array -> expression
 
 (** [strmatch_compile dbg arg default cases] *)
 val strmatch_compile :
-  Debuginfo.t -> Cmm.value_kind -> expression -> expression option ->
+  Debuginfo.t -> Cmm.kind_for_unboxing -> expression -> expression option ->
   (string * expression) list -> expression
 
 (** Closures and function applications *)
@@ -744,7 +744,7 @@ val emit_preallocated_blocks :
 
 val make_symbol : ?compilation_unit:Compilation_unit.t -> string -> string
 
-val kind_of_layout : Lambda.layout -> value_kind
+val kind_of_layout : Lambda.layout -> kind_for_unboxing
 
 val machtype_of_layout : Lambda.layout -> machtype
 

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -693,12 +693,12 @@ let rec transl env e =
       return_unit dbg
         (ccatch
            (raise_num, [],
-            create_loop(transl_if env (Vval Pgenval) Unknown dbg cond
+            create_loop(transl_if env Any Unknown dbg cond
                     dbg (remove_unit(transl env body))
                     dbg (Cexit (raise_num,[])))
               dbg,
             Ctuple [],
-            dbg, Vval Pgenval))
+            dbg, Any))
   | Ufor(id, low, high, dir, body) ->
       let dbg = Debuginfo.none in
       let tst = match dir with Upto -> Cgt   | Downto -> Clt in
@@ -729,11 +729,11 @@ let rec transl env e =
                                   dbg),
                                 dbg, Cexit (raise_num,[]),
                                 dbg, Ctuple [],
-                                dbg, Vint (* unit *))))))
+                                dbg, Any)))))
                       dbg,
-                   dbg, Vint (* unit*)),
+                   dbg, Any),
                  Ctuple [],
-                 dbg, Vint (* unit *)))))
+                 dbg, Any))))
   | Uassign(id, exp) ->
       let dbg = Debuginfo.none in
       let cexp = transl env exp in
@@ -751,31 +751,19 @@ let rec transl env e =
   | Utail e ->
       Ctail (transl env e)
 
-and transl_catch (kind : Cmm.value_kind) env nfail ids body handler dbg =
+and transl_catch (kind : Cmm.kind_for_unboxing) env nfail ids body handler dbg =
   let ids = List.map (fun (id, kind) -> (id, kind, ref No_result)) ids in
   (* Translate the body, and while doing so, collect the "unboxing type" for
      each argument.  *)
   let report args =
     List.iter2
-      (fun (id, (layout : Lambda.layout), u) c ->
-         match layout with
-         | Ptop ->
-           Misc.fatal_errorf "Variable %a with layout [Ptop] can't be compiled"
-             VP.print id
-         | Pbottom ->
-           Misc.fatal_errorf
-             "Variable %a with layout [Pbottom] can't be compiled"
-             VP.print id
-         | Punboxed_float | Punboxed_int _ ->
-           u := No_unboxing
-         | Pvalue kind ->
-           let strict =
-             match kind with
-             | Pfloatval | Pboxedintval _ -> false
-             | Pintval | Pgenval | Pvariant _ | Parrayval _ -> true
-           in
-           u := join_unboxed_number_kind ~strict !u
-               (is_unboxed_number_cmm ~strict c)
+      (fun (_id, layout, u) c ->
+         let strict = match kind_of_layout layout with
+           | Boxed_integer _ | Boxed_float -> false
+           | Any -> true
+         in
+         u := join_unboxed_number_kind ~strict !u
+             (is_unboxed_number_cmm ~strict c)
       )
       ids args
   in
@@ -926,7 +914,7 @@ and transl_prim_1 env p arg dbg =
       arraylength kind (transl env arg) dbg
   (* Boolean operations *)
   | Pnot ->
-      transl_if env Vint Then_false_else_true
+      transl_if env Any Then_false_else_true
         dbg arg
         dbg (Cconst_int (1, dbg))
         dbg (Cconst_int (3, dbg))
@@ -985,7 +973,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   (* Boolean operations *)
   | Psequand ->
       let dbg' = Debuginfo.none in
-      transl_sequand env Vint Then_true_else_false
+      transl_sequand env Any Then_true_else_false
         dbg arg1
         dbg' arg2
         dbg (Cconst_int (3, dbg))
@@ -995,7 +983,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
            Cifthenelse(test_bool dbg (Cvar id), transl env arg2, Cvar id)) *)
   | Psequor ->
       let dbg' = Debuginfo.none in
-      transl_sequor env Vint Then_true_else_false
+      transl_sequor env Any Then_true_else_false
         dbg arg1
         dbg' arg2
         dbg (Cconst_int (3, dbg))
@@ -1304,7 +1292,7 @@ and transl_let env str (layout : Lambda.layout) id exp transl_body =
   | Pvalue kind ->
       transl_let_value env str kind id exp transl_body
 
-and make_catch (kind : Cmm.value_kind) ncatch body handler dbg = match body with
+and make_catch (kind : Cmm.kind_for_unboxing) ncatch body handler dbg = match body with
 | Cexit (nexit,[]) when nexit=ncatch -> handler
 | _ ->  ccatch (ncatch, [], body, handler, dbg, kind)
 
@@ -1313,7 +1301,7 @@ and is_shareable_cont exp =
   | Cexit (_,[]) -> true
   | _ -> false
 
-and make_shareable_cont (kind : Cmm.value_kind) dbg mk exp =
+and make_shareable_cont (kind : Cmm.kind_for_unboxing) dbg mk exp =
   if is_shareable_cont exp then mk exp
   else begin
     let nfail = next_raise_count () in
@@ -1325,7 +1313,7 @@ and make_shareable_cont (kind : Cmm.value_kind) dbg mk exp =
       dbg
   end
 
-and transl_if env (kind : Cmm.value_kind) (approx : then_else)
+and transl_if env (kind : Cmm.kind_for_unboxing) (approx : then_else)
       (dbg : Debuginfo.t) cond
       (then_dbg : Debuginfo.t) then_
       (else_dbg : Debuginfo.t) else_ =
@@ -1414,7 +1402,7 @@ and transl_if env (kind : Cmm.value_kind) (approx : then_else)
             else_dbg else_
     end
 
-and transl_sequand env (kind : Cmm.value_kind) (approx : then_else)
+and transl_sequand env (kind : Cmm.kind_for_unboxing) (approx : then_else)
       (arg1_dbg : Debuginfo.t) arg1
       (arg2_dbg : Debuginfo.t) arg2
       (then_dbg : Debuginfo.t) then_
@@ -1430,7 +1418,7 @@ and transl_sequand env (kind : Cmm.value_kind) (approx : then_else)
          else_dbg shareable_else)
     else_
 
-and transl_sequor env (kind : Cmm.value_kind) (approx : then_else)
+and transl_sequor env (kind : Cmm.kind_for_unboxing) (approx : then_else)
       (arg1_dbg : Debuginfo.t) arg1
       (arg2_dbg : Debuginfo.t) arg2
       (then_dbg : Debuginfo.t) then_
@@ -1447,7 +1435,7 @@ and transl_sequor env (kind : Cmm.value_kind) (approx : then_else)
     then_
 
 (* This assumes that [arg] can be safely discarded if it is not used. *)
-and transl_switch dbg (kind : Cmm.value_kind) env arg index cases = match Array.length cases with
+and transl_switch dbg (kind : Cmm.kind_for_unboxing) env arg index cases = match Array.length cases with
 | 0 -> fatal_error "Cmmgen.transl_switch"
 | 1 -> transl env cases.(0)
 | _ ->

--- a/ocaml/asmcomp/selectgen.ml
+++ b/ocaml/asmcomp/selectgen.ml
@@ -772,7 +772,7 @@ method emit_expr_aux (env:environment) exp :
         (Cifthenelse (exp,
           dbg, Cconst_int (1, dbg),
           dbg, Cconst_int (0, dbg),
-          dbg, Vint))
+          dbg, Any))
   | Cop(Copaque, args, dbg) ->
       begin match self#emit_parts_list env args with
         None -> None

--- a/ocaml/asmcomp/strmatch.ml
+++ b/ocaml/asmcomp/strmatch.ml
@@ -24,7 +24,7 @@ module VP = Backend_var.With_provenance
 module type I = sig
   val string_block_length : Cmm.expression -> Cmm.expression
   val transl_switch :
-      Debuginfo.t -> Cmm.value_kind -> Cmm.expression -> int -> int ->
+      Debuginfo.t -> Cmm.kind_for_unboxing -> Cmm.expression -> int -> int ->
         (int * Cmm.expression) list -> Cmm.expression ->
           Cmm.expression
 end
@@ -380,7 +380,7 @@ module Make(I:I) = struct
     | Cexit (_e,[]) ->  k arg
     | _ ->
         let e =  next_raise_count () in
-        ccatch (e,[],k (Cexit (e,[])),arg,dbg, Vval Pgenval)
+        ccatch (e,[],k (Cexit (e,[])),arg,dbg, Any)
 
     let compile dbg value_kind str default cases =
 (* We do not attempt to really optimise default=None *)

--- a/ocaml/asmcomp/strmatch.mli
+++ b/ocaml/asmcomp/strmatch.mli
@@ -18,7 +18,7 @@
 module type I = sig
   val string_block_length : Cmm.expression -> Cmm.expression
   val transl_switch :
-      Debuginfo.t -> Cmm.value_kind -> Cmm.expression -> int -> int ->
+      Debuginfo.t -> Cmm.kind_for_unboxing -> Cmm.expression -> int -> int ->
         (int * Cmm.expression) list -> Cmm.expression ->
           Cmm.expression
 end
@@ -26,7 +26,7 @@ end
 module Make(_:I) : sig
   (* Compile stringswitch (arg,cases,d)
      Note: cases should not contain string duplicates *)
-  val compile : Debuginfo.t -> Cmm.value_kind
+  val compile : Debuginfo.t -> Cmm.kind_for_unboxing
     -> Cmm.expression (* arg *)
     -> Cmm.expression option (* d *) ->
     (string * Cmm.expression) list (* cases *)-> Cmm.expression

--- a/ocaml/testsuite/tools/parsecmm.mly
+++ b/ocaml/testsuite/tools/parsecmm.mly
@@ -43,7 +43,7 @@ let make_switch n selector caselist =
     List.iter (fun pos -> index.(pos) <- i) posl;
     actv.(i) <- (e, dbg)
   done;
-  Cswitch(selector, index, actv, dbg, value_kind ())
+  Cswitch(selector, index, actv, dbg, Any)
 
 let access_array base numelt size =
   match numelt with
@@ -229,7 +229,7 @@ expr:
   | LPAREN SEQ sequence RPAREN { $3 }
   | LPAREN IF expr expr expr RPAREN
       { Cifthenelse($3, debuginfo (), $4, debuginfo (), $5, debuginfo (),
-                   value_kind ()) }
+                   Any) }
   | LPAREN SWITCH INTCONST expr caselist RPAREN { make_switch $3 $4 $5 }
   | LPAREN WHILE expr sequence RPAREN
       {
@@ -240,21 +240,21 @@ expr:
             Cconst_int (x, _) when x <> 0 -> $4
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
                              (Cexit(lbl0,[])),
-                             debuginfo (), value_kind ()) in
+                             debuginfo (), Any) in
         Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
           Ccatch(Recursive,
             [lbl1, [], Csequence(body, Cexit(lbl1, [])), debuginfo ()],
-            Cexit(lbl1, []), value_kind ()), value_kind ()) }
+            Cexit(lbl1, []), Any), Any) }
   | LPAREN EXIT IDENT exprlist RPAREN
     { Cexit(find_label $3, List.rev $4) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
       List.iter (fun (_, l, _, _) ->
         List.iter (fun (x, _) -> unbind_ident x) l) handlers;
-      Ccatch(Recursive, handlers, $3, value_kind ()) }
+      Ccatch(Recursive, handlers, $3, Any) }
   | EXIT        { Cexit(0,[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
-                { unbind_ident $5; Ctrywith($3, $5, $6, debuginfo (), value_kind ()) }
+                { unbind_ident $5; Ctrywith($3, $5, $6, debuginfo (), Any) }
   | LPAREN VAL expr expr RPAREN
       { let open Asttypes in
         Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],

--- a/ocaml/testsuite/tools/parsecmmaux.ml
+++ b/ocaml/testsuite/tools/parsecmmaux.ml
@@ -60,11 +60,3 @@ let debuginfo ?(loc=Location.symbol_rloc ()) () =
                   ~scopes:Scoped_location.empty_scopes loc
                )
             )
-
-let value_kind () =
-  (* CR-someday poechsel: As the value_kind is only used when building cmm
-     for the first time, its precise value is not important afterward.
-     For now we can say that the cmm code read by parsecmm will only contain
-     Pgenval and it should make no difference, but this should probably be
-     fixed. *)
-  Cmm.Vval Lambda.Pgenval

--- a/ocaml/testsuite/tools/parsecmmaux.mli
+++ b/ocaml/testsuite/tools/parsecmmaux.mli
@@ -29,5 +29,3 @@ type error =
 exception Error of error
 
 val report_error: error -> unit
-
-val value_kind : unit -> Cmm.value_kind

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -43,7 +43,7 @@ let make_switch n selector caselist =
     List.iter (fun pos -> index.(pos) <- i) posl;
     actv.(i) <- (e, dbg)
   done;
-  Cswitch(selector, index, actv, dbg, value_kind ())
+  Cswitch(selector, index, actv, dbg, Any)
 
 let access_array base numelt size =
   match numelt with
@@ -240,7 +240,7 @@ expr:
   | LPAREN SEQ sequence RPAREN { $3 }
   | LPAREN IF expr expr expr RPAREN
       { Cifthenelse($3, debuginfo (), $4, debuginfo (), $5, debuginfo (),
-                    value_kind ()) }
+                    Any) }
   | LPAREN SWITCH INTCONST expr caselist RPAREN { make_switch $3 $4 $5 }
   | LPAREN WHILE expr sequence RPAREN
       {
@@ -251,22 +251,22 @@ expr:
             Cconst_int (x, _) when x <> 0 -> $4
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
                              (Cexit(Cmm.Lbl lbl0,[],[])),
-                             debuginfo (), value_kind ()) in
+                             debuginfo (), Any) in
         Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
           Ccatch(Recursive,
             [lbl1, [], Csequence(body, Cexit(Cmm.Lbl lbl1, [], [])), debuginfo ()],
-            Cexit(Cmm.Lbl lbl1, [], []), value_kind ()), value_kind ()) }
+            Cexit(Cmm.Lbl lbl1, [], []), Any), Any) }
   | LPAREN EXIT traps IDENT exprlist RPAREN
     { Cexit(Cmm.Lbl (find_label $4), List.rev $5, $3) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
       List.iter (fun (_, l, _, _) ->
         List.iter (fun (x, _) -> unbind_ident x) l) handlers;
-      Ccatch(Recursive, handlers, $3, value_kind ()) }
+      Ccatch(Recursive, handlers, $3, Any) }
   | EXIT        { Cexit(Cmm.Lbl 0,[],[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
       { unbind_ident $5; Ctrywith($3, Regular, $5, $6, debuginfo (),
-                                  value_kind ()) }
+                                  Any) }
   | LPAREN VAL expr expr RPAREN
       { let open Asttypes in
         Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],

--- a/testsuite/tools/parsecmmaux.ml
+++ b/testsuite/tools/parsecmmaux.ml
@@ -60,11 +60,3 @@ let debuginfo ?(loc=Location.symbol_rloc ()) () =
                   ~scopes:Scoped_location.empty_scopes loc
                )
             )
-
-let value_kind () =
-  (* CR-someday poechsel: As the value_kind is only used when building cmm
-     for the first time, its precise value is not important afterward.
-     For now we can say that the cmm code read by parsecmm will only contain
-     Pgenval and it should make no difference, but this should probably be
-     fixed. *)
-  Cmm.Vval Lambda.Pgenval

--- a/testsuite/tools/parsecmmaux.mli
+++ b/testsuite/tools/parsecmmaux.mli
@@ -23,8 +23,6 @@ val find_label: string -> int
 
 val debuginfo: ?loc:Location.t -> unit -> Debuginfo.t
 
-val value_kind : unit -> Cmm.value_kind
-
 type error =
     Unbound of string
 


### PR DESCRIPTION
Currently, `Cmm.value_kind` is used only for unboxing code, when creating the Cmm. Besides, it adds a lot of information which is redundant (with the `machtype`) and sometimes simply incorrect (when it puts `Vval Pgenval` as a default value).
This is a first possibility for removing it without sacrificing optimisations, by replacing it with a simpler type that either says we have a value with `Lambda.value_kind`, or that it can be anything.
However, I still do not like this idea of having these `value_kind` nodes everywhere in the AST while they are used only for building the Cmm and never after. Another option would be to change the code building the Cmm to keep the information about unboxing, but it might be a far larger change. 
Perhaps the simplest option would be to revert #295, but instead add kind annotations on Flambda lets (which are increasingly needed due to the layouts changes), and get unboxing to work as with closure.