### PR TITLE
Restructure LIBDIR: Move Dynlink, Str and Unix to sub-directories (port part of ocaml/PR11198)

### DIFF
--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -202,11 +202,12 @@ install_for_test: _install
 	 done; \
 	 ln -s . lex; ln -s . yacc; \
 	 ln -s _install/lib/ocaml/compiler-libs compilerlibs; \
-	 mkdir -p otherlibs/{unix,dynlink/native,str}; \
+	 mkdir -p otherlibs/{unix,dynlink/native,str,bigarray}; \
 	 ln -s ../stdlib/threads otherlibs/systhreads; \
-	 $(cpl) stdlib/{lib,}unix* otherlibs/unix; \
-	 $(cpl) stdlib/dynlink* otherlibs/dynlink; \
-	 $(cpl) stdlib/{lib,}str* otherlibs/str; \
+         $(cpl) stdlib/unix/{lib,}unix* otherlibs/unix; \
+         $(cpl) stdlib/dynlink/dynlink* otherlibs/dynlink; \
+         $(cpl) stdlib/str/{lib,}str* otherlibs/str; \
+         ${cpl} stdlib/bigarray/bigarray* otherlibs/bigarray; \
 	 ln -s ../_build/main/$(ocamldir)/toplevel/byte/.ocamltoplevel.objs/byte toplevel; \
 	)
 
@@ -218,6 +219,7 @@ install_for_test: _install
 	cp $(main_build)/$(ocamldir)/.ocamlcommon.objs/byte/*.cmo _runtest/utils
 	rm -f _runtest/utils/{topdirs,opttopdirs}.cmi
 	cp _install/lib/ocaml/*.{cmi,cma,a,cmxa} _runtest/utils
+	cp _install/lib/ocaml/{unix,str,dynlink,bigarray}/*.{cmi,cma,a,cmxa} _runtest/utils
 	cp $(main_build)/$(ocamldir)/.ocamlcommon.objs/native/config.o _runtest/utils
 	# Needed for tests/warnings
 	cp $(ocamldir)/utils/warnings.ml _runtest/utils

--- a/ocaml/compilerlibs/Makefile.compilerlibs
+++ b/ocaml/compilerlibs/Makefile.compilerlibs
@@ -31,10 +31,10 @@ UTILS = \
   utils/identifiable.cmo \
   utils/numbers.cmo \
   utils/arg_helper.cmo \
-  utils/clflags.cmo \
-  utils/profile.cmo \
   utils/local_store.cmo \
   utils/load_path.cmo \
+  utils/clflags.cmo \
+  utils/profile.cmo \
   utils/terminfo.cmo \
   utils/ccomp.cmo \
   utils/warnings.cmo \

--- a/ocaml/otherlibs/Makefile.otherlibs.common
+++ b/ocaml/otherlibs/Makefile.otherlibs.common
@@ -88,6 +88,8 @@ $(LIBNAME).cmxs: $(LIBNAME).cmxa $(STUBSLIB)
 lib$(CLIBNAME).$(A): $(COBJS)
 	$(MKLIB_CMD) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)
 
+INSTALL_LIBDIR_LIBNAME = $(INSTALL_LIBDIR)/$(LIBNAME)
+
 install::
 	if test -f dll$(CLIBNAME)$(EXT_DLL); then \
 	  $(INSTALL_PROG) \
@@ -96,15 +98,21 @@ install::
 ifneq "$(STUBSLIB)" ""
 	$(INSTALL_DATA) $(STUBSLIB) "$(INSTALL_LIBDIR)/"
 endif
-
+# If installing over a previous OCaml version, ensure the library is removed
+# from the previous installation.
+	rm -f $(addprefix "$(INSTALL_LIBDIR)"/, \
+          $(LIBNAME).cma $(CMIFILES) \
+          $(CMIFILES:.cmi=.mli) $(CMIFILES:.cmi=.cmti) \
+          $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).cmxs $(LIBNAME).$(A))
+	$(MKDIR) "$(INSTALL_LIBDIR_LIBNAME)"
 	$(INSTALL_DATA) \
 	  $(LIBNAME).cma $(CMIFILES) \
-	  "$(INSTALL_LIBDIR)/"
+	  "$(INSTALL_LIBDIR_LIBNAME)/"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	  $(CMIFILES:.cmi=.mli) \
           $(CMIFILES:.cmi=.cmti) \
-	  "$(INSTALL_LIBDIR)/"
+	  "$(INSTALL_LIBDIR_LIBNAME)/"
 endif
 	if test -n "$(HEADERS)"; then \
 	  $(INSTALL_DATA) $(HEADERS) "$(INSTALL_LIBDIR)/caml/"; \
@@ -113,9 +121,9 @@ endif
 installopt:
 	$(INSTALL_DATA) \
 	   $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).$(A) \
-	   "$(INSTALL_LIBDIR)/"
+	   "$(INSTALL_LIBDIR_LIBNAME)/"
 	if test -f $(LIBNAME).cmxs; then \
-	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR)"; \
+	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR_LIBNAME)"; \
 	fi
 
 partialclean:

--- a/ocaml/otherlibs/bigarray/dune
+++ b/ocaml/otherlibs/bigarray/dune
@@ -25,14 +25,14 @@
 
 (install
   (files
-    .bigarray.objs/native/bigarray.cmx
-    bigarray.cmxa
-    bigarray.a
-    bigarray.cmxs
-    bigarray.cma
-    .bigarray.objs/byte/bigarray.cmi
-    .bigarray.objs/byte/bigarray.cmti
-    bigarray.mli
+    (.bigarray.objs/native/bigarray.cmx as bigarray/bigarray.cmx)
+    (bigarray.cmxa as bigarray/bigarray.cmxa)
+    (bigarray.a as bigarray/bigarray.a)
+    (bigarray.cmxs as bigarray/bigarray.cmxs)
+    (bigarray.cma as bigarray/bigarray.cma)
+    (.bigarray.objs/byte/bigarray.cmi as bigarray/bigarray.cmi)
+    (.bigarray.objs/byte/bigarray.cmti as bigarray/bigarray.cmti)
+    (bigarray.mli as bigarray/bigarray.mli)
   )
   (section lib)
   (package ocaml))

--- a/ocaml/otherlibs/dynlink/Makefile
+++ b/ocaml/otherlibs/dynlink/Makefile
@@ -77,13 +77,13 @@ COMPILERLIBS_SOURCES=\
   utils/identifiable.ml \
   utils/numbers.ml \
   utils/arg_helper.ml \
+  utils/local_store.ml \
+  utils/load_path.ml \
   utils/clflags.ml \
   utils/profile.ml \
   utils/consistbl.ml \
   utils/terminfo.ml \
   utils/warnings.ml \
-  utils/local_store.ml \
-  utils/load_path.ml \
   utils/int_replace_polymorphic_compare.ml \
   typing/ident.ml \
   utils/compilation_unit.ml \
@@ -236,21 +236,29 @@ $(eval $(call PROGRAM_SYNONYM,extract_crc))
 $(extract_crc): dynlink.cma dynlink_compilerlibs.cmo extract_crc.cmo
 	$(OCAMLC) -o $@ $^
 
+INSTALL_LIBDIR_DYNLINK = $(INSTALL_LIBDIR)/dynlink
+
 install:
+# If installing over a previous OCaml version, ensure dynlink is removed from
+# the previous installation.
+	rm -f "$(INSTALL_LIBDIR)"/dynlink.cm* "$(INSTALL_LIBDIR)/dynlink.mli" \
+        "$(INSTALL_LIBDIR)/dynlink.$(A)" \
+        $(addprefix "$(INSTALL_LIBDIR)/", $(notdir $(NATOBJS)))
+	$(MKDIR) "$(INSTALL_LIBDIR_DYNLINK)"
 	$(INSTALL_DATA) \
 	  dynlink.cmi dynlink.cma \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR_DYNLINK)"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	  dynlink.cmti dynlink.mli \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR_DYNLINK)"
 endif
 
 installopt:
 ifeq "$(strip $(NATDYNLINK))" "true"
 	$(INSTALL_DATA) \
 	  $(NATOBJS) dynlink.cmxa dynlink.$(A) \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR_DYNLINK)"
 endif
 
 partialclean:

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -374,18 +374,18 @@
 
 (install
   (files
-    .dynlink_internal.objs/native/dynlink_common.cmx
-    .dynlink_internal.objs/native/dynlink_platform_intf.cmx
-    .dynlink_internal.objs/native/dynlink_types.cmx
-    .dynlink_internal.objs/native/dynlink.cmx
-    dynlink.cma
-    dynlink.cmxa
-    dynlink.a
-;    dynlink.cmxs
-    dynlink.mli
-    dynlink.cmi
-    (.dynlink_internal.objs/byte/dynlink.cmti as dynlink.cmti)
-    (extract_crc.bc as extract_crc)
+    (.dynlink_internal.objs/native/dynlink_common.cmx as dynlink/dynlink_common.cmx)
+    (.dynlink_internal.objs/native/dynlink_platform_intf.cmx as dynlink/dynlink_platform_intf.cmx)
+    (.dynlink_internal.objs/native/dynlink_types.cmx as dynlink/dynlink_types.cmx)
+    (.dynlink_internal.objs/native/dynlink.cmx as dynlink/dynlink.cmx)
+    (dynlink.cma as dynlink/dynlink.cma)
+    (dynlink.cmxa as dynlink/dynlink.cmxa)
+    (dynlink.a as dynlink/dynlink.a)
+;    (dynlink.cmxs as dynlink/dynlink.cmxs)
+    (dynlink.mli as dynlink/dynlink.mli)
+    (dynlink.cmi as dynlink/dynlink.cmi)
+    (.dynlink_internal.objs/byte/dynlink.cmti as dynlink/dynlink.cmti)
+    (extract_crc.bc as dynlink/extract_crc)
 
     .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Misc.cmx
   )

--- a/ocaml/otherlibs/str/dune
+++ b/ocaml/otherlibs/str/dune
@@ -29,17 +29,17 @@
 
 (install
   (files
-    .str.objs/native/str.cmx
-    libstr_stubs.a
+    (.str.objs/native/str.cmx as str/str.cmx)
+    (libstr_stubs.a as str/libstr_stubs.a)
     (libstr_stubs.a as libstr_stubs_native.a) ; for special_dune compat
     (dllstr_stubs.so as stublibs/dllstr_stubs.so)
-    str.cmxa
-    str.a
-    str.cmxs
-    str.cma
-    str.mli
-    .str.objs/byte/str.cmi
-    .str.objs/byte/str.cmti
+    (str.cmxa as str/str.cmxa)
+    (str.a as str/str.a)
+    (str.cmxs as str/str.cmxs)
+    (str.cma as str/str.cma)
+    (str.mli as str/str.mli)
+    (.str.objs/byte/str.cmi as str/str.cmi)
+    (.str.objs/byte/str.cmti as str/str.cmti)
   )
   (section lib)
   (package ocaml))

--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -42,19 +42,19 @@
 
 (install
   (files
-    .unix.objs/native/unix.cmx
-    .unix.objs/native/unixLabels.cmx
-    unix.cmxa
-    unix.a
-    unix.cma
-    .unix.objs/byte/unix.cmi
-    .unix.objs/byte/unix.cmti
-    .unix.objs/byte/unixLabels.cmi
-    .unix.objs/byte/unixLabels.cmti
-    unix.cmxs
-    unix.mli
-    unixLabels.mli
-    libunix_stubs.a
+    (.unix.objs/native/unix.cmx as unix/unix.cmx)
+    (.unix.objs/native/unixLabels.cmx as unix/unixLabels.cmx)
+    (unix.cmxa as unix/unix.cmxa)
+    (unix.a as unix/unix.a)
+    (unix.cma as unix/unix.cma)
+    (.unix.objs/byte/unix.cmi as unix/unix.cmi)
+    (.unix.objs/byte/unix.cmti as unix/unix.cmti)
+    (.unix.objs/byte/unixLabels.cmi as unix/unixLabels.cmi)
+    (.unix.objs/byte/unixLabels.cmti as unix/unixLabels.cmti)
+    (unix.cmxs as unix/unix.cmxs)
+    (unix.mli as unix/unix.mli)
+    (unixLabels.mli as unix/unixLabel.mli)
+    (libunix_stubs.a as unix/libunix_stubs.a)
     (libunix_stubs.a as libunix_stubs_native.a) ; for special_dune compat
     (dllunix_stubs.so as stublibs/dllunix_stubs.so)
     (socketaddr.h as caml/socketaddr.h)


### PR DESCRIPTION
This is a simpler verison of #895. 
Only changes the layout of `ocaml/otherlibs` and the corresponding build files.
Does not add missing libraries automatically and no alerts. No changes to `Load_path.init`. 