### PR TITLE
Fix Icsel reload for test and res.

### DIFF
--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -157,12 +157,10 @@ method! reload_operation op arg res =
         directly, but then in Emit we will have to do Array.sub again
         to call emit_test (unless emit_test takes an index, which is also
         weird). *)
-      if stackp res.(0)
-      then begin
         (* CR-soon gyorsh: [reload_test] may lose some sharing
            between the arguments of the test and the last two arguments
            and the result of the move. *)
-        let r = self#makereg res.(0) in
+        let r = if stackp res.(0) then self#makereg res.(0) else res.(0) in
         let len = Array.length arg in
         let arg' = Array.copy arg in
         let test_arg = self#reload_test tst (Array.sub arg 0 (len - 2)) in
@@ -171,7 +169,6 @@ method! reload_operation op arg res =
         done;
         arg'.(len - 1) <- r;
         (arg', [|r|])
-      end else  (arg, res)
   | Iintop (Ipopcnt | Iclz _| Ictz _)
   | Iintop_atomic _
   | Ispecific  (Isqrtf | Isextend32 | Izextend32 | Ilea _


### PR DESCRIPTION
Fix a bug in reload for `Icsel` that in can result in emitting an illegal assembly instruction `cmp` with two memory operands, for example `cmpq 0(%rsp), 8(%rsp)`.  This can make compilation fail at `assemble` stage, but not silently miscompile. 

The bug is that `reload` of the arguments of `test` part of Icsel is not performed when the result does not need to be reloaded.

It happens with high register pressure, I will try to add a small test case.
