### PR TITLE
Configure: Add flag to use legacy library layout

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -2,3 +2,4 @@ install_prefix = @prefix@
 dune = @dune@
 middle_end = @middle_end@
 coverage = @coverage@
+legacy_layout = @legacy_layout@

--- a/configure.ac
+++ b/configure.ac
@@ -44,10 +44,18 @@ AC_ARG_ENABLE([coverage],
   [coverage=yes],
   [coverage=no])
 
+AC_ARG_ENABLE([legacy-library-layout],
+  [AS_HELP_STRING([--enable-legacy-library-layout],
+    [Install libraries unix, str, dynlink and bigarray in the toplevel
+     ocaml library directory (Same as upstream OCaml < 5.0)])],
+  [legacy_layout=yes],
+  [legacy_layout=no])
+
 AC_SUBST([prefix])
 AC_SUBST([middle_end])
 AC_SUBST([dune])
 AC_SUBST([coverage])
+AC_SUBST([legacy_layout])
 
 # Don't error on options that this configure script doesn't understand but
 # the ocaml/ one does.

--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -139,6 +139,14 @@ _install: compiler
 	$(cpl) -R _build/install/runtime_stdlib/lib/ocaml_runtime_stdlib/* _install/lib/ocaml/
 	rm -f _install/lib/ocaml/{META,dune-package,Makefile.config,dynlink.cmxa}
 	$(cpl) -R _build/install/main/lib/ocaml/* _install/lib/ocaml/
+	if [ "x$(legacy_layout)" == "xyes" ] ;\
+	then\
+	  echo "Legacy mode";\
+          for libdir in unix str dynlink bigarray ; do\
+	    mv _install/lib/ocaml/$${libdir}/* _install/lib/ocaml/ ;\
+            rmdir _install/lib/ocaml/$${libdir} ;\
+          done;\
+	fi
 	rm -f _install/lib/ocaml/{META,dune-package}
 	rm -f _install/lib/ocaml/compiler-libs/*.cmo
 	$(cpl) {_build/install/main,_install}/lib/ocaml/compiler-libs/topstart.cmo

--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -139,13 +139,12 @@ _install: compiler
 	$(cpl) -R _build/install/runtime_stdlib/lib/ocaml_runtime_stdlib/* _install/lib/ocaml/
 	rm -f _install/lib/ocaml/{META,dune-package,Makefile.config,dynlink.cmxa}
 	$(cpl) -R _build/install/main/lib/ocaml/* _install/lib/ocaml/
-	if [ "x$(legacy_layout)" == "xyes" ] ;\
-	then\
-	  echo "Legacy mode";\
-          for libdir in unix str dynlink bigarray ; do\
-	    mv _install/lib/ocaml/$${libdir}/* _install/lib/ocaml/ ;\
-            rmdir _install/lib/ocaml/$${libdir} ;\
-          done;\
+	if [ "x$(legacy_layout)" == "xyes" ] ; \
+	then \
+          for libdir in unix str dynlink bigarray ; do \
+	    mv _install/lib/ocaml/$${libdir}/* _install/lib/ocaml/ ; \
+            rmdir _install/lib/ocaml/$${libdir} ; \
+          done \
 	fi
 	rm -f _install/lib/ocaml/{META,dune-package}
 	rm -f _install/lib/ocaml/compiler-libs/*.cmo


### PR DESCRIPTION
Follow-up on #1094, restoring the ability to generate a layout compatible with upstream 4.14.
The code follows a suggestion from @mshinwell. Unlike what we discussed elsewhere, by default the new layout is used, only when configured with `--enable-legacy-layout` does the old layout gets used. The opam file used for the compiler will be updated to use this flag when the PR is merged, then we should be able to get opam health checks running again.