### PR TITLE
Add specific handling for variable aliasing in To_cmm

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -589,7 +589,7 @@ let rec add_binding_to_env ?extra env res var (Binding binding as b) =
       { env with stages }, res)
 
 (* CR gbury: find a better name for this function *)
-and split_in_env ?ensure_in_env env res var binding =
+and split_in_env env res var binding =
   let res, split_result = split_complex_binding ~env ~res binding in
   match split_result with
   | Already_split -> env, res, binding
@@ -603,8 +603,7 @@ and split_in_env ?ensure_in_env env res var binding =
         }
       in
       match split_binding.inline with
-      | Must_inline_once ->
-        if Option.is_none ensure_in_env then env else update_env ()
+      | Must_inline_once -> env
       | Must_inline_and_duplicate -> update_env ()
     in
     let env, res =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -204,7 +204,7 @@ let [@ocamlformat "disable"] print_binding (type a) ppf
     Backend_var.With_provenance.print cmm_var
     print_bound_expr bound_expr
 
-let print_any_binding ppf (Binding binding) = print_binding ppf binding
+let _print_any_binding ppf (Binding binding) = print_binding ppf binding
 
 let print_stage ppf = function
   | Effect v -> Format.fprintf ppf "(Effect %a)" Variable.print v

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -18,9 +18,6 @@ module R = To_cmm_result
 module P = Flambda_primitive
 module Ece = Effects_and_coeffects
 
-let debug () =
-  match Sys.getenv "DEBUG" with exception Not_found -> false | _ -> true
-
 type cont =
   | Jump of
       { cont : Cmm.label;
@@ -367,7 +364,6 @@ let create_binding_aux (type a) effs var ~(inline : a inline)
   in
   let cmm_var = gen_variable var in
   let binding = Binding { order; inline; effs; cmm_var; bound_expr } in
-  if debug () then Format.eprintf "new binding: %a@." print_any_binding binding;
   binding
 
 let create_binding (type a) effs var ~(inline : a inline)
@@ -460,10 +456,6 @@ let new_bindings_for_splitting order args =
                 cmm_var = new_cmm_var
               }
           in
-          if debug ()
-          then
-            Format.eprintf "new arg binding for split: %a@." print_any_binding
-              binding;
           ( (binding :: new_bindings, order - 1),
             C.var (Backend_var.With_provenance.var new_cmm_var) ))
       ([], order - 1)
@@ -508,8 +500,6 @@ let split_complex_binding ~env ~res (binding : complex binding) =
   match binding.bound_expr with
   | Split _ -> res, Already_split
   | Splittable_prim { dbg; prim; args } ->
-    if debug ()
-    then Format.eprintf "splitting binding: %a@." print_binding binding;
     let new_bindings, new_cmm_args =
       new_bindings_for_splitting binding.order args
     in
@@ -851,10 +841,6 @@ let add_alias env res ~var ~alias_of ~num_normal_occurrences_of_bound_vars =
         Variable.print var Variable.print alias_of
     | num_occurrences -> num_occurrences
   in
-  if debug ()
-  then
-    Format.eprintf "add_alias var=%a (occs %a), alias_of=%a\n%!" Variable.print
-      var Num_occurrences.print num_occurrences_of_var Variable.print alias_of;
   match Variable.Map.find alias_of env.bindings with
   | Binding ({ inline = Must_inline_once; _ } as b) -> (
     match num_occurrences_of_var with

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -221,6 +221,14 @@ val bind_variable :
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
   t * To_cmm_result.t
 
+val add_alias :
+  t ->
+  To_cmm_result.t ->
+  var:Variable.t ->
+  alias_of:Variable.t ->
+  num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
+  t * To_cmm_result.t
+
 (** Try and inline an Flambda variable using the delayed let-bindings. *)
 val inline_variable :
   ?consider_inlining_effectful_expressions:bool ->

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -35,9 +35,9 @@ end
 
 let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
   match Simple.must_be_var s with
-  | Some (alias_of, _coercion) when Flambda_features.classic_mode () ->
+  | Some (alias_of, _coercion) ->
     Env.add_alias env res ~var:v ~num_normal_occurrences_of_bound_vars ~alias_of
-  | Some _ | None ->
+  | None ->
     let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
       C.simple ~dbg env res s
     in

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -34,14 +34,18 @@ end
 (* Bind a Cmm variable to the result of translating a [Simple] into Cmm. *)
 
 let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
-  let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
-    C.simple ~dbg env res s
-  in
-  let env, res =
-    Env.bind_variable env res v ~effects_and_coeffects_of_defining_expr
-      ~defining_expr ~num_normal_occurrences_of_bound_vars
-  in
-  env, res
+  match Simple.must_be_var s with
+  | Some (alias_of, _coercion) when Flambda_features.classic_mode () ->
+    Env.add_alias env res ~var:v ~num_normal_occurrences_of_bound_vars ~alias_of
+  | Some _ | None ->
+    let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
+      C.simple ~dbg env res s
+    in
+    let env, res =
+      Env.bind_variable env res v ~effects_and_coeffects_of_defining_expr
+        ~defining_expr ~num_normal_occurrences_of_bound_vars
+    in
+    env, res
 
 (* Helpers for the translation of [Apply] expressions. *)
 


### PR DESCRIPTION
First part split from #1087 .

This add specific handling for variable aliasing.

Consider the following standalone example extracted from `bigstring` :

```ocaml
let arch_big_endian = Sys.big_endian
let not_on_32bit = Sys.word_size > 32
let mask32_n = Nativeint.(sub (shift_left 1n 32) 1n)

type t =
    ( char
    , Stdlib.Bigarray.int8_unsigned_elt
    , Stdlib.Bigarray.c_layout )
      Stdlib.Bigarray.Array1.t

external swap32 : int32 -> int32 = "%bswap_int32"
external int32_to_int : int32 -> int = "%int32_to_int"
external unsafe_get_32 : t -> int -> int32 = "%caml_bigstring_get32u"

let[@inline always] uint32_of_int32_t n =
  if not_on_32bit
  then
    (* use Caml.Nativeint to ensure inlining even without x-library-inlining *)
    Nativeint.(to_int (logand (of_int32 n) mask32_n))
  else int32_to_int n
;;

let unsafe_read_int32 t ~pos = unsafe_get_32 t pos
let unsafe_read_int32_swap t ~pos = swap32 (unsafe_get_32 t pos)

let unsafe_get_int32_t_be =
  if arch_big_endian then unsafe_read_int32 else unsafe_read_int32_swap
;;

let[@inline] unsafe_get_uint32_be t ~pos =
  uint32_of_int32_t (unsafe_get_int32_t_be t ~pos)
;;
```

We now generate the following cmm code (when in `-Oclassic` mode):
```
(function{/home/guigui/tmp/bigstring.ml:31,34-93}
 camlBigstring__unsafe_get_uint32_be_3_3_code
     (t106/588: val pos107/589: val my_closure105/590: val)
 (let
   (to_cmm_split_12/597
      (let ba_data/594 (load_mut int (+a t106/588 8))
        (load_mut signed int32 (+ ba_data/594 (>>s pos107/589 1))))
    to_cmm_split_16/601
      (>>s (<< (bswap_32 (>>s (<< to_cmm_split_12/597 32) 32)) 32) 32)
    region123/606 (beginregion))
   (catch
     (if (== 1 (load val (+a (load val (+a my_closure105/590 24)) 16)))
       (exit 2 (or (>>s (<< to_cmm_split_16/601 32) 31) 1))
       (let
         Pandbint135/620
           (alloc_local{/home/guigui/tmp/bigstring.ml:20,22-52} 2815
             "caml_nativeint_ops"
             (and (>>s (<< to_cmm_split_16/601 32) 32)
               (load int
                 (+a (load val (+a (load val (+a my_closure105/590 24)) 24))
                   8))))
         (exit 2 (+ (<< (load int (+a Pandbint135/620 8)) 1) 1))))
   with(2 region_return124/607: val)
     (let
       (pos110/592 pos107/589 t111/593 t106/588
        n118/602
          (alloc{/home/guigui/tmp/bigstring.ml:25,36-64} 2303
            "caml_int32_ops" (>>s (<< to_cmm_split_16/601 32) 32))
        my_closure120/603 (load val (+a my_closure105/590 24))
        to_cmm_split_20/609 (load val (+a my_closure105/590 24))
        not_on_32bit121/604 (load val (+a to_cmm_split_20/609 16))
        to_cmm_split_22/608 (load val (+a my_closure105/590 24))
        mask32_n122/605 (load val (+a to_cmm_split_22/608 24))
        unit125/610 (seq (endregion region123/606) 1))
       region_return124/607))))
```

whereas before (i.e. with `main`) we would generate the following (again, when in `-Oclassic` mode):
```(function{/home/guigui/tmp/bigstring.ml:31,34-93}
 camlBigstring__unsafe_get_uint32_be_3_3_code
     (t106/588: val pos107/589: val my_closure105/590: val)
 (let
   (to_cmm_split_12/597
      (let ba_data/594 (load_mut int (+a t106/588 8))
        (load_mut signed int32 (+ ba_data/594 (>>s pos107/589 1))))
    n118/602
      (alloc{/home/guigui/tmp/bigstring.ml:25,36-64} 2303 "caml_int32_ops"
        (>>s (<< (bswap_32 (>>s (<< to_cmm_split_12/597 32) 32)) 32) 32))
    region122/606 (beginregion))
   (catch
     (if (== 1 (load val (+a (load val (+a my_closure105/590 24)) 16)))
       (exit 2 (+ (<< (load signed int32 (+a n118/602 8)) 1) 1))
       (let
         Pandbint134/620
           (alloc_local{/home/guigui/tmp/bigstring.ml:20,22-52} 2815
             "caml_nativeint_ops"
             (and (load signed int32 (+a n118/602 8))
               (load int
                 (+a (load val (+a (load val (+a my_closure105/590 24)) 24))
                   8))))
         (exit 2 (+ (<< (load int (+a Pandbint134/620 8)) 1) 1))))
   with(2 region_return123/607: val)
     (let
       (pos110/592 pos107/589 t111/593 t106/588
        my_closure119/603 (load val (+a my_closure105/590 24))
        to_cmm_split_21/609 (load val (+a my_closure105/590 24))
        not_on_32bit120/604 (load val (+a to_cmm_split_21/609 16))
        to_cmm_split_23/608 (load val (+a my_closure105/590 24))
        mask32_n121/605 (load val (+a to_cmm_split_23/608 24))
        unit124/610 (seq (endregion region122/606) 1))
       region_return123/607))))
```

The main difference is that with this PR, we now currently push down the `Int32` allocation of `n118` down at its use site inside the `catch`. There is still an unneeded flush of the allocation before the `end_region` at the end of the function, but that one will be removed in the upcoming second part of the split of #1087 that computes free_names during `to_cmm`.