### PR TITLE
Compute free_vars in to_cmm and use it to filter bindings during flushes

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -94,12 +94,22 @@ let unit0 ~offsets flambda_unit ~all_code =
       ~param_types:(List.map snd return_cont_params)
   in
   (* See comment in [To_cmm_set_of_closures] about binding [my_region] *)
-  let env, _bound_var =
+  let env, toplevel_region_var =
     Env.create_bound_parameter env
       (Flambda_unit.toplevel_my_region flambda_unit)
   in
   let r = R.create ~module_symbol:(Flambda_unit.module_symbol flambda_unit) in
-  let body, res = To_cmm_expr.expr env r (Flambda_unit.body flambda_unit) in
+  let body, body_free_vars, res =
+    To_cmm_expr.expr env r (Flambda_unit.body flambda_unit)
+  in
+  let free_vars =
+    To_cmm_shared.remove_var_with_provenance body_free_vars toplevel_region_var
+  in
+  if not (Backend_var.Set.is_empty free_vars)
+  then
+    Misc.fatal_errorf
+      "Unbound free_vars in module init code when translating to cmm: %a"
+      Backend_var.Set.print free_vars;
   let body =
     let dbg = Debuginfo.none in
     let unit_value = C.targetint ~dbg Targetint_32_64.one in

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -537,6 +537,14 @@ let split_complex_binding ~env ~res (binding : complex binding) =
   match binding.bound_expr with
   | Split _ -> res, Already_split
   | Splittable_prim { dbg; prim; args } ->
+    (* We will be using the free vars of the new cmm args as the free vars for
+       the new cmm expr for the binding (note that the same is done in
+       [To_cmm_primitive]). This is correct because the cmm helpers to build
+       expressions can introduce locally closed variables (through e.g. [bind]),
+       but it will not create new free variables. It might be a slight
+       over-approximation since some primitives may drop some of their
+       arguments, but that should be extremely rare, and should not affect code
+       generation much. *)
     let new_bindings, new_cmm_args, free_vars_of_new_cmm_args =
       new_bindings_for_splitting binding.order args
     in

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -18,6 +18,14 @@ module R = To_cmm_result
 module P = Flambda_primitive
 module Ece = Effects_and_coeffects
 
+type free_vars = Backend_var.Set.t
+
+type expr_with_info =
+  { cmm : Cmm.expression;
+    effs : Effects_and_coeffects.t;
+    free_vars : free_vars
+  }
+
 type cont =
   | Jump of
       { cont : Cmm.label;
@@ -76,12 +84,20 @@ type _ inline =
    The arguments are stored with their effects. This means that if we need to
    split the binding, we can re-bind each argument with its correct effects. *)
 type _ bound_expr =
-  | Simple : { cmm_expr : Cmm.expression } -> simple bound_expr
-  | Split : { cmm_expr : Cmm.expression } -> complex bound_expr
+  | Simple :
+      { cmm_expr : Cmm.expression;
+        free_vars : free_vars
+      }
+      -> simple bound_expr
+  | Split :
+      { cmm_expr : Cmm.expression;
+        free_vars : free_vars
+      }
+      -> complex bound_expr
   | Splittable_prim :
       { dbg : Debuginfo.t;
         prim : Flambda_primitive.Without_args.t;
-        args : (Cmm.expression * Ece.t) list
+        args : expr_with_info list
       }
       -> complex bound_expr
 
@@ -130,7 +146,7 @@ type t =
        handlers. *)
     vars_extra : extra_info Variable.Map.t;
     (* Extra information associated with Flambda variables. *)
-    vars : Cmm.expression Variable.Map.t;
+    vars : (Cmm.expression * free_vars) Variable.Map.t;
     (* Cmm expressions (of the form [Cvar ...]) for all bound variables in
        scope. *)
     bindings : any_binding Variable.Map.t;
@@ -138,6 +154,12 @@ type t =
     inline_once_aliases : Variable.t Variable.Map.t;
     (* Maps for `Must_inline_once` variable that end up aliased. *)
     stages : stage list (* Stages of let-bindings, most recent at the head. *)
+  }
+
+type translation_result =
+  { env : t;
+    res : To_cmm_result.t;
+    expr : expr_with_info
   }
 
 let create offsets functions_info ~trans_prim ~return_continuation
@@ -175,10 +197,15 @@ let [@ocamlformat "disable"] print_inline (type a) ppf (inline : a inline) =
   | Must_inline_once -> Format.fprintf ppf "must_inline_once"
   | Must_inline_and_duplicate -> Format.fprintf ppf "must_inline_and_duplicate"
 
+let print_cmm_expr_with_free_vars ppf (cmm_expr, free_vars) =
+  Format.fprintf ppf
+    "@[<hov 1>(@[<hov 1>(expr@ %a)@]@ @[<hov 1>(free_vars@ %a)@]@ )@]"
+    Printcmm.expression cmm_expr Backend_var.Set.print free_vars
+
 let [@ocamlformat "disable"] print_bound_expr (type a) ppf (b : a bound_expr) =
   match b with
-  | Simple { cmm_expr; } | Split { cmm_expr; } ->
-    Printcmm.expression ppf cmm_expr
+  | Simple { cmm_expr; free_vars; } | Split { cmm_expr; free_vars; } ->
+    print_cmm_expr_with_free_vars ppf (cmm_expr, free_vars)
   | Splittable_prim { prim; args; dbg; } ->
     Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(dbg@ %a)@]@ \
@@ -187,7 +214,8 @@ let [@ocamlformat "disable"] print_bound_expr (type a) ppf (b : a bound_expr) =
       )@]"
       Debuginfo.print_compact dbg
       Flambda_primitive.Without_args.print prim
-      (Format.pp_print_list (fun ppf (cmm, _) -> Printcmm.expression ppf cmm)) args
+      (Format.pp_print_list (fun ppf { cmm; effs = _; free_vars; } ->
+           print_cmm_expr_with_free_vars ppf (cmm, free_vars))) args
 
 let [@ocamlformat "disable"] print_binding (type a) ppf
     ({ order; inline; effs; cmm_var; bound_expr; } : a binding) =
@@ -242,7 +270,8 @@ let gen_variable v =
 
 let add_bound_param env v v' =
   let v'' = Backend_var.With_provenance.var v' in
-  let vars = Variable.Map.add v (C.var v'') env.vars in
+  let free_vars = Backend_var.Set.singleton v'' in
+  let vars = Variable.Map.add v (C.var v'', free_vars) env.vars in
   { env with vars }
 
 let create_bound_parameter env v =
@@ -333,9 +362,9 @@ let get_exn_extra_args env k =
 
 let next_order = ref (-1)
 
-let simple cmm_expr = Simple { cmm_expr }
+let simple cmm_expr free_vars = Simple { cmm_expr; free_vars }
 
-let complex_no_split cmm_expr = Split { cmm_expr }
+let complex_no_split cmm_expr free_vars = Split { cmm_expr; free_vars }
 
 let splittable_primitive dbg prim args = Splittable_prim { dbg; prim; args }
 
@@ -373,12 +402,13 @@ let create_binding (type a) effs var ~(inline : a inline)
      must_inline_and_duplicate (since it basically replaces a variable by either
      another variable, a constant, or a symbol). *)
   match bound_expr with
-  | (Split { cmm_expr } | Simple { cmm_expr }) when is_cmm_simple cmm_expr ->
+  | (Split { cmm_expr; free_vars } | Simple { cmm_expr; free_vars })
+    when is_cmm_simple cmm_expr ->
     (* trivial/simple cmm expression (as decided by [is_cmm_simple]) do not have
        effects and coeffects *)
     let effs = Ece.pure_can_be_duplicated in
     create_binding_aux effs var ~inline:Must_inline_and_duplicate
-      (Split { cmm_expr })
+      (Split { cmm_expr; free_vars })
   | Simple _ | Split _ | Splittable_prim _ ->
     create_binding_aux effs var ~inline bound_expr
 
@@ -427,41 +457,48 @@ type split_result =
       }
 
 let new_bindings_for_splitting order args =
-  let (new_bindings, _), new_cmm_args =
+  let (new_bindings, _, free_vars_of_new_cmm_args), new_cmm_args =
     List.fold_left_map
-      (fun (new_bindings, order) (cmm_arg, arg_effs) ->
+      (fun (new_bindings, order, free_vars)
+           { cmm = cmm_arg; effs = arg_effs; free_vars = arg_free_vars } ->
         (* CR gbury: here, instead of using [is_cmm_simple], we could instead
            look at [arg_effs] and not create a new binding if it has
            `pure_can_be_duplicated` effects (or any ece that allows
            duplication). *)
         if is_cmm_simple cmm_arg
-        then (new_bindings, order), cmm_arg
+        then
+          ( (new_bindings, order, Backend_var.Set.union free_vars arg_free_vars),
+            cmm_arg )
         else
           (* we need to rebind the argument *)
           (* CR gbury: we should try and store the flambda/cmm variable
              initially associated to this expression when it was built (and
              before it was inlined during the to_cmm translation), instead of
              using a fresh one here. *)
+          let backend_var =
+            Backend_var.create_local (Format.asprintf "to_cmm_split_%d" order)
+          in
           let new_cmm_var =
-            Backend_var.With_provenance.create ?provenance:None
-              (Backend_var.create_local
-                 (Format.asprintf "to_cmm_split_%d" order))
+            Backend_var.With_provenance.create ?provenance:None backend_var
           in
           let binding =
             Binding
               { order;
                 effs = arg_effs;
                 inline = Do_not_inline;
-                bound_expr = Simple { cmm_expr = cmm_arg };
+                bound_expr =
+                  Simple { cmm_expr = cmm_arg; free_vars = arg_free_vars };
                 cmm_var = new_cmm_var
               }
           in
-          ( (binding :: new_bindings, order - 1),
-            C.var (Backend_var.With_provenance.var new_cmm_var) ))
-      ([], order - 1)
+          ( ( binding :: new_bindings,
+              order - 1,
+              Backend_var.Set.add backend_var free_vars ),
+            C.var backend_var ))
+      ([], order - 1, Backend_var.Set.empty)
       args
   in
-  new_bindings, new_cmm_args
+  new_bindings, new_cmm_args, free_vars_of_new_cmm_args
 
 let rebuild_prim ~dbg ~env ~res prim args =
   let extra_info, res, cmm =
@@ -500,7 +537,7 @@ let split_complex_binding ~env ~res (binding : complex binding) =
   match binding.bound_expr with
   | Split _ -> res, Already_split
   | Splittable_prim { dbg; prim; args } ->
-    let new_bindings, new_cmm_args =
+    let new_bindings, new_cmm_args, free_vars_of_new_cmm_args =
       new_bindings_for_splitting binding.order args
     in
     let new_cmm_expr, res = rebuild_prim ~dbg ~env ~res prim new_cmm_args in
@@ -522,7 +559,9 @@ let split_complex_binding ~env ~res (binding : complex binding) =
       { order = binding.order;
         effs;
         inline = binding.inline;
-        bound_expr = Split { cmm_expr = new_cmm_expr };
+        bound_expr =
+          Split
+            { cmm_expr = new_cmm_expr; free_vars = free_vars_of_new_cmm_args };
         cmm_var = binding.cmm_var
       }
     in
@@ -533,8 +572,9 @@ let split_complex_binding ~env ~res (binding : complex binding) =
 let rec add_binding_to_env ?extra env res var (Binding binding as b) =
   let env =
     let bindings = Variable.Map.add var b env.bindings in
-    let cmm_expr = C.var (Backend_var.With_provenance.var binding.cmm_var) in
-    let vars = Variable.Map.add var cmm_expr env.vars in
+    let cmm_var = Backend_var.With_provenance.var binding.cmm_var in
+    let free_vars = Backend_var.Set.singleton cmm_var in
+    let vars = Variable.Map.add var (C.var cmm_var, free_vars) env.vars in
     let vars_extra =
       match extra with
       | None -> env.vars_extra
@@ -659,7 +699,7 @@ let bind_variable_with_decision (type a) ?extra env res var ~inline
   let binding = create_binding ~inline effs var defining_expr in
   add_binding_to_env ?extra env res var binding
 
-let bind_variable ?extra env res var ~defining_expr
+let bind_variable ?extra env res var ~defining_expr ~free_vars_of_defining_expr
     ~num_normal_occurrences_of_bound_vars
     ~effects_and_coeffects_of_defining_expr =
   let inline =
@@ -670,22 +710,26 @@ let bind_variable ?extra env res var ~defining_expr
   match inline with
   | Drop_defining_expr -> env, res
   | Regular ->
-    let defining_expr = simple defining_expr in
+    let defining_expr = simple defining_expr free_vars_of_defining_expr in
     bind_variable_with_decision ?extra env res var
       ~effects_and_coeffects_of_defining_expr ~defining_expr
       ~inline:Do_not_inline
   | May_inline_once ->
-    let defining_expr = simple defining_expr in
+    let defining_expr = simple defining_expr free_vars_of_defining_expr in
     bind_variable_with_decision ?extra env res var
       ~effects_and_coeffects_of_defining_expr ~defining_expr
       ~inline:May_inline_once
   | Must_inline_once ->
-    let defining_expr = complex_no_split defining_expr in
+    let defining_expr =
+      complex_no_split defining_expr free_vars_of_defining_expr
+    in
     bind_variable_with_decision ?extra env res var
       ~effects_and_coeffects_of_defining_expr ~defining_expr
       ~inline:Must_inline_once
   | Must_inline_and_duplicate ->
-    let defining_expr = complex_no_split defining_expr in
+    let defining_expr =
+      complex_no_split defining_expr free_vars_of_defining_expr
+    in
     bind_variable_with_decision ?extra env res var
       ~effects_and_coeffects_of_defining_expr ~defining_expr
       ~inline:Must_inline_and_duplicate
@@ -694,21 +738,31 @@ let bind_variable_to_primitive = bind_variable_with_decision
 
 (* Variable lookup (for potential inlining) *)
 
-let will_inline_simple env res { effs; bound_expr = Simple { cmm_expr }; _ } =
-  cmm_expr, env, res, effs
+let will_inline_simple env res
+    { effs; bound_expr = Simple { cmm_expr; free_vars }; _ } =
+  { env; res; expr = { cmm = cmm_expr; free_vars; effs } }
 
 let will_inline_complex env res { effs; bound_expr; _ } =
   match bound_expr with
-  | Split { cmm_expr } -> cmm_expr, env, res, effs
+  | Split { cmm_expr; free_vars } ->
+    { env; res; expr = { cmm = cmm_expr; free_vars; effs } }
   | Splittable_prim { dbg; prim; args } ->
-    let cmm_expr, res = rebuild_prim ~dbg ~env ~res prim (List.map fst args) in
-    cmm_expr, env, res, effs
+    let free_vars, cmm_args =
+      List.fold_left_map
+        (fun free_vars { cmm = cmm_arg; effs = _; free_vars = arg_free_vars } ->
+          Backend_var.Set.union free_vars arg_free_vars, cmm_arg)
+        Backend_var.Set.empty args
+    in
+    let cmm_expr, res = rebuild_prim ~dbg ~env ~res prim cmm_args in
+    { env; res; expr = { cmm = cmm_expr; free_vars; effs } }
 
 let will_not_inline_simple env res { cmm_var; bound_expr = Simple _; _ } =
-  ( C.var (Backend_var.With_provenance.var cmm_var),
-    env,
-    res,
-    Ece.pure_can_be_duplicated )
+  let var = Backend_var.With_provenance.var cmm_var in
+  let free_vars = Backend_var.Set.singleton var in
+  { env;
+    res;
+    expr = { cmm = C.var var; free_vars; effs = Ece.pure_can_be_duplicated }
+  }
 
 let split_and_inline env res var binding =
   let env, res, split_binding = split_in_env env res var binding in
@@ -760,10 +814,11 @@ let inline_variable ?consider_inlining_effectful_expressions env res var =
     match Variable.Map.find var env.vars with
     | exception Not_found ->
       Misc.fatal_errorf "Variable %a not found in env" Variable.print var
-    | e ->
+    | cmm, free_vars ->
       (* the env.vars map only contain bindings to expressions of the form
          [Cmm.Cvar _], hence the effects. *)
-      e, env, res, Ece.pure_can_be_duplicated)
+      { env; res; expr = { cmm; free_vars; effs = Ece.pure_can_be_duplicated } }
+    )
   | Binding binding -> (
     match binding.inline with
     | Do_not_inline -> will_not_inline_simple env res binding
@@ -818,15 +873,17 @@ let make_alias env res var alias_of =
    bind the new variable with a `must_inline` inline status *)
 let split_binding_and_rebind ~num_occurrences_of_var env res ~var ~alias_of
     binding =
-  let cmm_expr, env, res, ece = split_and_inline env res alias_of binding in
-  let defining_expr : _ bound_expr = Split { cmm_expr } in
+  let { env; res; expr = { cmm; free_vars; effs } } =
+    split_and_inline env res alias_of binding
+  in
+  let defining_expr : _ bound_expr = Split { cmm_expr = cmm; free_vars } in
   let inline =
     match (num_occurrences_of_var : Num_occurrences.t) with
     | Zero | One -> Must_inline_once
     | More_than_one -> Must_inline_and_duplicate
   in
   bind_variable_with_decision env res var ~inline ~defining_expr
-    ~effects_and_coeffects_of_defining_expr:ece
+    ~effects_and_coeffects_of_defining_expr:effs
 
 let add_alias env res ~var ~alias_of ~num_normal_occurrences_of_bound_vars =
   let alias_of = resolve_alias env alias_of in
@@ -853,9 +910,12 @@ let add_alias env res ~var ~alias_of ~num_normal_occurrences_of_bound_vars =
   | (exception Not_found)
   | Binding { inline = Do_not_inline | May_inline_once; _ } ->
     (* generic case, we just inline the var/binding, and rebind it *)
-    let cmm_expr, env, res, ece = inline_variable env res alias_of in
-    bind_variable env res var ~defining_expr:cmm_expr
-      ~effects_and_coeffects_of_defining_expr:ece
+    let { env; res; expr = { cmm; free_vars; effs } } =
+      inline_variable env res alias_of
+    in
+    bind_variable env res var ~defining_expr:cmm
+      ~free_vars_of_defining_expr:free_vars
+      ~effects_and_coeffects_of_defining_expr:effs
       ~num_normal_occurrences_of_bound_vars
 
 (* Flushing delayed bindings *)
@@ -872,18 +932,35 @@ type flush_mode =
   | Branching_point
   | Flush_everything
 
+let can_be_removed effs =
+  match (effs : Effects_and_coeffects.t) with
+  | Arbitrary_effects, _, _ -> false
+  | (Only_generative_effects _ | No_effects), _, _ -> true
+
 let flush_delayed_lets ~mode env res =
   (* Generate a wrapper function to introduce the delayed let-bindings. *)
-  let wrap_flush order_map e =
+  let wrap_flush order_map e free_vars =
     M.fold
-      (fun _ (Binding b) acc ->
+      (fun _ (Binding b) (acc, acc_free_vars) ->
         match b.bound_expr with
         | Splittable_prim _ ->
           Misc.fatal_errorf
             "Complex bindings should have been split prior to being flushed."
-        | Split { cmm_expr } | Simple { cmm_expr } ->
-          Cmm_helpers.letin b.cmm_var ~defining_expr:cmm_expr ~body:acc)
-      order_map e
+        | Split { cmm_expr; free_vars } | Simple { cmm_expr; free_vars } ->
+          let v = Backend_var.With_provenance.var b.cmm_var in
+          if (not (Backend_var.Set.mem v acc_free_vars))
+             && can_be_removed b.effs
+          then acc, acc_free_vars
+          else
+            let expr =
+              Cmm_helpers.letin b.cmm_var ~defining_expr:cmm_expr ~body:acc
+            in
+            let free_vars =
+              Backend_var.Set.union free_vars
+                (Backend_var.Set.remove v acc_free_vars)
+            in
+            expr, free_vars)
+      order_map (e, free_vars)
   in
   (* CR-someday mshinwell: work out a criterion for allowing substitutions into
      loops. CR gbury: this is now done by creating a binding with the inline

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -18,6 +18,22 @@
 (** Environment for Flambda to Cmm translation *)
 type t
 
+(** Free names for cmm expressions *)
+type free_vars = Backend_var.Set.t
+
+(** A cmm expression along with extra information *)
+type expr_with_info =
+  { cmm : Cmm.expression;
+    effs : Effects_and_coeffects.t;
+    free_vars : free_vars
+  }
+
+type translation_result =
+  { env : t;
+    res : To_cmm_result.t;
+    expr : expr_with_info
+  }
+
 (** Printing function *)
 val print : Format.formatter -> t -> unit
 
@@ -184,7 +200,7 @@ type _ inline =
 type _ bound_expr
 
 (** A simple cmm bound expression *)
-val simple : Cmm.expression -> simple bound_expr
+val simple : Cmm.expression -> free_vars -> simple bound_expr
 
 (** A bound expr that can be split if needed. This is used for primitives that
     must be inlined, but whose arguments may not be inlinable or duplicable, so
@@ -194,7 +210,7 @@ val simple : Cmm.expression -> simple bound_expr
 val splittable_primitive :
   Debuginfo.t ->
   Flambda_primitive.Without_args.t ->
-  (Cmm.expression * Effects_and_coeffects.t) list ->
+  expr_with_info list ->
   complex bound_expr
 
 (** Bind a variable, with support for splitting duplicatable primitives with
@@ -217,6 +233,7 @@ val bind_variable :
   To_cmm_result.t ->
   Variable.t ->
   defining_expr:Cmm.expression ->
+  free_vars_of_defining_expr:free_vars ->
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
   t * To_cmm_result.t
@@ -235,7 +252,7 @@ val inline_variable :
   t ->
   To_cmm_result.t ->
   Variable.t ->
-  Cmm.expression * t * To_cmm_result.t * Effects_and_coeffects.t
+  translation_result
 
 type flush_mode =
   | Entering_loop
@@ -248,7 +265,9 @@ val flush_delayed_lets :
   mode:flush_mode ->
   t ->
   To_cmm_result.t ->
-  (Cmm.expression -> Cmm.expression) * t * To_cmm_result.t
+  (Cmm.expression -> free_vars -> Cmm.expression * free_vars)
+  * t
+  * To_cmm_result.t
 
 (** Fetch the extra info for a Flambda variable (if any), specified as a
     [Simple]. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -38,12 +38,21 @@ let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
   | Some (alias_of, _coercion) ->
     Env.add_alias env res ~var:v ~num_normal_occurrences_of_bound_vars ~alias_of
   | None ->
-    let defining_expr, env, res, effects_and_coeffects_of_defining_expr =
+    let To_cmm_env.
+          { env;
+            res;
+            expr =
+              { cmm = defining_expr;
+                free_vars = free_vars_of_defining_expr;
+                effs = effects_and_coeffects_of_defining_expr
+              }
+          } =
       C.simple ~dbg env res s
     in
     let env, res =
       Env.bind_variable env res v ~effects_and_coeffects_of_defining_expr
-        ~defining_expr ~num_normal_occurrences_of_bound_vars
+        ~defining_expr ~free_vars_of_defining_expr
+        ~num_normal_occurrences_of_bound_vars
     in
     env, res
 
@@ -58,8 +67,15 @@ let translate_apply0 env res apply =
      effects/coeffects values currently ignored on the following two lines. At
      the moment they can be ignored as we always deem all calls to have
      arbitrary effects and coeffects. *)
-  let callee, env, res, _ = C.simple ~dbg env res callee_simple in
-  let args, env, res, _ = C.simple_list ~dbg env res args in
+  let To_cmm_env.
+        { env;
+          res;
+          expr = { cmm = callee; free_vars = callee_free_vars; effs = _ }
+        } =
+    C.simple ~dbg env res callee_simple
+  in
+  let args, args_free_vars, env, res, _ = C.simple_list ~dbg env res args in
+  let free_vars = Backend_var.Set.union callee_free_vars args_free_vars in
   let fail_if_probe apply =
     match Apply.probe_name apply with
     | None -> ()
@@ -99,6 +115,7 @@ let translate_apply0 env res apply =
       ( C.direct_call ~dbg ty pos
           (C.symbol_from_linkage_name ~dbg code_linkage_name)
           args,
+        free_vars,
         env,
         res,
         Ece.all )
@@ -107,6 +124,7 @@ let translate_apply0 env res apply =
           ~handler_code_linkage_name:(Linkage_name.to_string code_linkage_name)
           ~args
         |> C.return_unit dbg,
+        free_vars,
         env,
         res,
         Ece.all ))
@@ -116,6 +134,7 @@ let translate_apply0 env res apply =
     ( C.indirect_call ~dbg ty pos
         (Alloc_mode.For_types.to_lambda alloc_mode)
         callee args_ty args,
+      free_vars,
       env,
       res,
       Ece.all )
@@ -142,6 +161,7 @@ let translate_apply0 env res apply =
       ( C.indirect_full_call ~dbg ty pos
           (Alloc_mode.For_types.to_lambda alloc_mode)
           callee args_ty args,
+        free_vars,
         env,
         res,
         Ece.all )
@@ -180,16 +200,25 @@ let translate_apply0 env res apply =
     in
     ( wrap dbg
         (C.extcall ~dbg ~alloc ~is_c_builtin ~returns ~ty_args callee ty args),
+      free_vars,
       env,
       res,
       Ece.all )
   | Call_kind.Method { kind; obj; alloc_mode } ->
     fail_if_probe apply;
     let args_ty, ty = Cmm.(List.map (fun _ -> [| Val |]) args, [| Val |]) in
-    let obj, env, res, _ = C.simple ~dbg env res obj in
+    let To_cmm_env.
+          { env;
+            res;
+            expr = { cmm = obj; free_vars = obj_free_vars; effs = _ }
+          } =
+      C.simple ~dbg env res obj
+    in
+    let free_vars = Backend_var.Set.union free_vars obj_free_vars in
     let kind = Call_kind.Method_kind.to_lambda kind in
     let alloc_mode = Alloc_mode.For_types.to_lambda alloc_mode in
     ( C.send kind callee obj args args_ty ty (pos, alloc_mode) dbg,
+      free_vars,
       env,
       res,
       Ece.all )
@@ -200,7 +229,7 @@ let translate_apply0 env res apply =
 (* CR mshinwell: Add first-class support in Cmm for the concept of an exception
    handler with extra arguments. *)
 let translate_apply env res apply =
-  let call, env, res, effs = translate_apply0 env res apply in
+  let call, free_vars, env, res, effs = translate_apply0 env res apply in
   let dbg = Apply.dbg apply in
   let k_exn = Apply.exn_continuation apply in
   let mut_vars =
@@ -212,14 +241,21 @@ let translate_apply env res apply =
     (* Note wrt evaluation order: this is correct for the same reason as
        `To_cmm_shared.simple_list`, namely the first simple translated (and
        potentially inlined/substituted) is evaluted last. *)
-    let aux (call, env, res) (arg, _k) v =
-      let arg, env, res, _ = C.simple ~dbg env res arg in
-      C.sequence (C.assign v arg) call, env, res
+    let aux (call, env, res, free_vars) (arg, _k) v =
+      let To_cmm_env.
+            { env;
+              res;
+              expr = { cmm = arg; free_vars = arg_free_vars; effs = _ }
+            } =
+        C.simple ~dbg env res arg
+      in
+      let free_vars = Backend_var.Set.union free_vars arg_free_vars in
+      C.sequence (C.assign v arg) call, env, res, free_vars
     in
-    let call, env, res =
-      List.fold_left2 aux (call, env, res) extra_args mut_vars
+    let call, env, res, free_vars =
+      List.fold_left2 aux (call, env, res, free_vars) extra_args mut_vars
     in
-    call, env, res, effs
+    call, free_vars, env, res, effs
   else
     Misc.fatal_errorf
       "Length of [extra_args] in exception continuation %a@ does not match \
@@ -246,8 +282,17 @@ let translate_raise env res apply exn_handler args =
           Apply_cont.print apply
     in
     let dbg = Apply_cont.debuginfo apply in
-    let exn, env, res, _ = C.simple ~dbg env res exn in
-    let extra, env, res, _ = C.simple_list ~dbg env res extra in
+    let To_cmm_env.
+          { env;
+            res;
+            expr = { cmm = exn; free_vars = exn_free_vars; effs = _ }
+          } =
+      C.simple ~dbg env res exn
+    in
+    let extra, extra_free_vars, env, res, _ =
+      C.simple_list ~dbg env res extra
+    in
+    let free_vars = Backend_var.Set.union exn_free_vars extra_free_vars in
     let mut_vars = Env.get_exn_extra_args env exn_handler in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     let cmm =
@@ -256,7 +301,8 @@ let translate_raise env res apply exn_handler args =
         (C.raise_prim raise_kind exn dbg)
         extra mut_vars
     in
-    wrap cmm, res
+    let cmm, free_vars = wrap cmm free_vars in
+    cmm, free_vars, res
   | [] ->
     Misc.fatal_errorf "Exception continuation %a has no arguments:@ \n%a"
       Continuation.print exn_handler Apply_cont.print apply
@@ -273,9 +319,10 @@ let translate_jump_to_continuation env res apply types cont args =
         [Cmm.Push cont]
     in
     let dbg = Apply_cont.debuginfo apply in
-    let args, env, res, _ = C.simple_list ~dbg env res args in
+    let args, free_vars, env, res, _ = C.simple_list ~dbg env res args in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    wrap (C.cexit cont args trap_actions), res
+    let cmm, free_vars = wrap (C.cexit cont args trap_actions) free_vars in
+    cmm, free_vars, res
   else
     Misc.fatal_errorf "Types (%a) do not match arguments of@ %a"
       (Format.pp_print_list ~pp_sep:Format.pp_print_space Printcmm.machtype)
@@ -287,11 +334,20 @@ let translate_jump_to_return_continuation env res apply return_cont args =
   match args with
   | [return_value] -> (
     let dbg = Apply_cont.debuginfo apply in
-    let return_value, env, res, _ = C.simple ~dbg env res return_value in
+    let To_cmm_env.
+          { env; res; expr = { cmm = return_value; free_vars; effs = _ } } =
+      C.simple ~dbg env res return_value
+    in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     match Apply_cont.trap_action apply with
-    | None -> wrap return_value, res
-    | Some (Pop _) -> wrap (C.trap_return return_value [Cmm.Pop]), res
+    | None ->
+      let cmm, free_vars = wrap return_value free_vars in
+      cmm, free_vars, res
+    | Some (Pop _) ->
+      let cmm, free_vars =
+        wrap (C.trap_return return_value [Cmm.Pop]) free_vars
+      in
+      cmm, free_vars, res
     | Some (Push _) ->
       Misc.fatal_errorf
         "Return continuation %a should not be applied with a Push trap action"
@@ -310,11 +366,12 @@ let invalid env res ~message =
     Env.flush_delayed_lets ~mode:Branching_point env res
   in
   let cmm_invalid, res = C.invalid res ~message in
-  wrap cmm_invalid, res
+  let cmm, free_vars = wrap cmm_invalid Backend_var.Set.empty in
+  cmm, free_vars, res
 
 (* The main set of translation functions for expressions *)
 
-let rec expr env res e =
+let rec expr env res e : Cmm.expression * Backend_var.Set.t * To_cmm_result.t =
   match Expr.descr e with
   | Let e' -> let_expr env res e'
   | Let_cont e' -> let_cont env res e'
@@ -394,10 +451,11 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
     let wrap, env, res =
       Env.flush_delayed_lets ~mode:Flush_everything env res
     in
-    let cmm, res =
+    let cmm, free_vars, res =
       let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body
     in
-    wrap cmm, res
+    let cmm, free_vars = wrap cmm free_vars in
+    cmm, free_vars, res
   | Singleton v, Prim (p, dbg) ->
     let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body
   | Set_of_closures bound_vars, Set_of_closures soc ->
@@ -416,8 +474,10 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
       let wrap, env, res =
         Env.flush_delayed_lets ~mode:Branching_point env res
       in
-      let body, res = expr env res body in
-      wrap (C.sequence update body), res)
+      let body, body_free_vars, res = expr env res body in
+      let free_vars = Backend_var.Set.union update.free_vars body_free_vars in
+      let cmm, free_vars = wrap (C.sequence update.cmm body) free_vars in
+      cmm, free_vars, res)
   | Singleton _, Rec_info _ -> expr env res body
   | Singleton _, (Set_of_closures _ | Static_consts _)
   | Set_of_closures _, (Simple _ | Prim _ | Static_consts _ | Rec_info _)
@@ -478,11 +538,13 @@ and let_cont_not_inlined env res k handler body =
      expression. *)
   let wrap, env, res = Env.flush_delayed_lets ~mode:Branching_point env res in
   let is_exn_handler = Continuation_handler.is_exn_handler handler in
-  let vars, arity, handler, res = continuation_handler env res handler in
+  let vars, arity, handler, free_vars_of_handler, res =
+    continuation_handler env res handler
+  in
   let catch_id, env =
     Env.add_jump_cont env k ~param_types:(List.map snd vars)
   in
-  let cmm, res =
+  let cmm, free_vars_of_body, res =
     (* Exception continuations are translated specially -- these will be reached
        via the raising of exceptions, whereas other continuations are reached
        using a normal jump. *)
@@ -490,12 +552,17 @@ and let_cont_not_inlined env res k handler body =
     then let_cont_exn_handler env res k body vars handler ~catch_id arity
     else
       let dbg = Debuginfo.none (* CR mshinwell: fix debuginfo *) in
-      let body, res = expr env res body in
+      let body, free_vars, res = expr env res body in
       ( C.create_ccatch ~rec_flag:false ~body
           ~handlers:[C.handler ~dbg catch_id vars handler],
+        free_vars,
         res )
   in
-  wrap cmm, res
+  let free_vars =
+    Backend_var.Set.union free_vars_of_handler free_vars_of_body
+  in
+  let cmm, free_vars = wrap cmm free_vars in
+  cmm, free_vars, res
 
 (* Exception continuations are translated using delayed Ctrywith blocks. The
    exception handler parts of these blocks are identified by the [catch_id]s.
@@ -522,7 +589,7 @@ and let_cont_exn_handler env res k body vars handler ~catch_id arity =
         C.letin extra_param ~defining_expr:(C.var mut_var) ~body:handler)
       handler mut_vars extra_params
   in
-  let body, res = expr env_body res body in
+  let body, free_vars_of_body, res = expr env_body res body in
   let dbg = Debuginfo.none (* CR mshinwell: fix debuginfo *) in
   let trywith =
     C.trywith ~dbg ~kind:(Delayed catch_id) ~body ~exn_var ~handler ()
@@ -549,7 +616,7 @@ and let_cont_exn_handler env res k body vars handler ~catch_id arity =
         C.letin_mut mut_var (C.machtype_of_kind kind) dummy_value cmm)
       trywith mut_vars
   in
-  cmm, res
+  cmm, free_vars_of_body, res
 
 and let_cont_rec env res invariant_params conts body =
   (* Flush the env now to avoid inlining something inside of a recursive
@@ -580,36 +647,45 @@ and let_cont_rec env res invariant_params conts body =
   let conts_to_handlers, res =
     Continuation.Map.fold
       (fun k handler (conts_to_handlers, res) ->
-        let vars, _arity, handler, res = continuation_handler env res handler in
+        let vars, _arity, handler, free_vars_of_handler, res =
+          continuation_handler env res handler
+        in
+        let free_vars =
+          C.remove_vars_with_machtype free_vars_of_handler invariant_vars
+        in
         ( Continuation.Map.add k
-            (invariant_vars @ vars, handler)
+            (invariant_vars @ vars, handler, free_vars)
             conts_to_handlers,
           res ))
       conts_to_handlers
       (Continuation.Map.empty, res)
   in
   let dbg = Debuginfo.none (* CR mshinwell: fix debuginfo *) in
+  let body, free_vars_of_body, res = expr env res body in
   (* Setup the Cmm handlers for the Ccatch *)
-  let handlers =
+  let handlers, free_vars =
     Continuation.Map.fold
-      (fun k (vars, handler) acc ->
+      (fun k (vars, handler, free_vars_of_handler) (handlers, free_vars) ->
+        let free_vars = Backend_var.Set.union free_vars free_vars_of_handler in
         let id = Env.get_cmm_continuation env k in
-        C.handler ~dbg id vars handler :: acc)
-      conts_to_handlers []
+        C.handler ~dbg id vars handler :: handlers, free_vars)
+      conts_to_handlers ([], free_vars_of_body)
   in
-  let body, res = expr env res body in
-  wrap (C.create_ccatch ~rec_flag:true ~body ~handlers), res
+  let cmm = C.create_ccatch ~rec_flag:true ~body ~handlers in
+  let cmm, free_vars = wrap cmm free_vars in
+  cmm, free_vars, res
 
 and continuation_handler env res handler =
   Continuation_handler.pattern_match' handler
     ~f:(fun params ~num_normal_occurrences_of_params:_ ~handler ->
       let arity = Bound_parameters.arity params in
       let env, vars = C.bound_parameters env params in
-      let expr, res = expr env res handler in
-      vars, arity, expr, res)
+      let expr, free_vars_of_handler, res = expr env res handler in
+      let free_vars = C.remove_vars_with_machtype free_vars_of_handler vars in
+      vars, arity, expr, free_vars, res)
 
 and apply_expr env res apply =
-  let call, env, res, effs = translate_apply env res apply in
+  let call, free_vars, env, res, effs = translate_apply env res apply in
   (* With respect to flushing the environment we have three cases:
 
      1. The call never returns or jumps to another function
@@ -634,11 +710,13 @@ and apply_expr env res apply =
   | Never_returns ->
     (* Case 1 *)
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    wrap call, res
+    let cmm, free_vars = wrap call free_vars in
+    cmm, free_vars, res
   | Return k when Continuation.equal (Env.return_continuation env) k ->
     (* Case 1 *)
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    wrap call, res
+    let cmm, free_vars = wrap call free_vars in
+    cmm, free_vars, res
   | Return k -> (
     let[@inline always] unsupported () =
       (* CR gbury: add support using unboxed tuples *)
@@ -653,7 +731,8 @@ and apply_expr env res apply =
     | Jump { param_types = [_]; cont } ->
       (* Case 2 *)
       let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-      wrap (C.cexit cont [call] []), res
+      let cmm, free_vars = wrap (C.cexit cont [call] []) free_vars in
+      cmm, free_vars, res
     | Inline { handler_params; handler_body = body; handler_params_occurrences }
       -> (
       (* Case 3 *)
@@ -665,6 +744,7 @@ and apply_expr env res apply =
         let env, res =
           Env.bind_variable env res var
             ~effects_and_coeffects_of_defining_expr:effs ~defining_expr:call
+            ~free_vars_of_defining_expr:free_vars
             ~num_normal_occurrences_of_bound_vars:handler_params_occurrences
         in
         expr env res body
@@ -713,7 +793,17 @@ and apply_cont env res apply_cont =
 and switch env res switch =
   let scrutinee = Switch.scrutinee switch in
   let dbg = Switch.condition_dbg switch in
-  let untagged_scrutinee_cmm, env, res, _ = C.simple ~dbg env res scrutinee in
+  let To_cmm_env.
+        { env;
+          res;
+          expr =
+            { cmm = untagged_scrutinee_cmm;
+              free_vars = scrutinee_free_vars;
+              effs = _
+            }
+        } =
+    C.simple ~dbg env res scrutinee
+  in
   let arms = Switch.arms switch in
   (* For binary switches, which can be translated to an if-then-else, it can be
      interesting for the scrutinee to be tagged (particularly for switches
@@ -757,8 +847,8 @@ and switch env res switch =
   in
   let make_arm ~must_tag_discriminant env res (d, action) =
     let d = prepare_discriminant ~must_tag:must_tag_discriminant d in
-    let cmm_action, res = apply_cont env res action in
-    (d, cmm_action, Apply_cont.debuginfo action), res
+    let cmm_action, action_free_vars, res = apply_cont env res action in
+    (d, cmm_action, action_free_vars, Apply_cont.debuginfo action), res
   in
   match Targetint_31_63.Map.cardinal arms with
   (* Binary case: if-then-else *)
@@ -772,19 +862,33 @@ and switch env res switch =
        before creating an if-then-else, introducing an indirection that might
        prevent some optimizations performed by Selectgen/Emit when the condition
        is inlined in the if-then-else. Instead we use [C.ite]. *)
-    | (0, else_, else_dbg), (_, then_, then_dbg)
-    | (_, then_, then_dbg), (0, else_, else_dbg) ->
-      wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_), res
+    | (0, else_, else_free_vars, else_dbg), (_, then_, then_free_vars, then_dbg)
+    | (_, then_, then_free_vars, then_dbg), (0, else_, else_free_vars, else_dbg)
+      ->
+      let free_vars =
+        Backend_var.Set.union scrutinee_free_vars
+          (Backend_var.Set.union else_free_vars then_free_vars)
+      in
+      let cmm, free_vars =
+        wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_) free_vars
+      in
+      cmm, free_vars, res
     (* Similar case to the previous but none of the arms match 0, so we have to
        generate an equality test, and make sure it is inside the condition to
        ensure Selectgen and Emit can take advantage of it. *)
-    | (x, if_x, if_x_dbg), (_, if_not, if_not_dbg) ->
+    | ( (x, if_x, if_x_free_vars, if_x_dbg),
+        (_, if_not, if_not_free_vars, if_not_dbg) ) ->
+      let free_vars =
+        Backend_var.Set.union scrutinee_free_vars
+          (Backend_var.Set.union if_x_free_vars if_not_free_vars)
+      in
       let expr =
         C.ite ~dbg
           (C.eq ~dbg (C.int ~dbg x) scrutinee)
           ~then_dbg:if_x_dbg ~then_:if_x ~else_dbg:if_not_dbg ~else_:if_not
       in
-      wrap expr, res)
+      let cmm, free_vars = wrap expr free_vars in
+      cmm, free_vars, res)
   (* General case *)
   | n ->
     (* transl_switch_clambda expects an [index] array such that index.(d) is the
@@ -794,19 +898,22 @@ and switch env res switch =
     let unreachable, res = C.invalid res ~message:"unreachable switch case" in
     let cases = Array.make (n + 1) unreachable in
     let index = Array.make (m + 1) n in
-    let _, res =
+    let _, res, free_vars =
       Targetint_31_63.Map.fold
-        (fun discriminant action (i, res) ->
-          let (d, cmm_action, _dbg), res =
+        (fun discriminant action (i, res, free_vars) ->
+          let (d, cmm_action, action_free_vars, _dbg), res =
             make_arm ~must_tag_discriminant env res (discriminant, action)
           in
+          let free_vars = Backend_var.Set.union free_vars action_free_vars in
           cases.(i) <- cmm_action;
           index.(d) <- i;
-          i + 1, res)
-        arms (0, res)
+          i + 1, res, free_vars)
+        arms
+        (0, res, scrutinee_free_vars)
     in
     (* CR-someday poechsel: Put a more precise value kind here *)
     let expr =
       C.transl_switch_clambda dbg (Vval Pgenval) scrutinee index cases
     in
-    wrap expr, res
+    let cmm, free_vars = wrap expr free_vars in
+    cmm, free_vars, res

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.mli
@@ -18,4 +18,4 @@ val expr :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Flambda.Expr.t ->
-  Cmm.expression * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -470,7 +470,7 @@ let let_static_set_of_closures0 env res closure_symbols
   if not (Backend_var.Set.is_empty free_vars)
   then
     Misc.fatal_errorf
-      "Non-empty set of free_vars for a statis set of closures (*not* \
+      "Non-empty set of free_vars for a static set of closures (*not* \
        including updates):@ %a"
       Backend_var.Set.print free_vars;
   let block =

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -24,7 +24,10 @@ module C = struct
 end
 
 type translate_expr =
-  To_cmm_env.t -> To_cmm_result.t -> Expr.t -> Cmm.expression * To_cmm_result.t
+  To_cmm_env.t ->
+  To_cmm_result.t ->
+  Expr.t ->
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_result.t
 
 (* Filling of closure blocks *)
 
@@ -81,6 +84,7 @@ module Make_layout_filler (P : sig
     To_cmm_result.t ->
     Simple.t ->
     [`Data of cmm_term list | `Var of Variable.t]
+    * To_cmm_env.free_vars
     * To_cmm_env.t
     * To_cmm_result.t
     * Ece.t
@@ -100,14 +104,15 @@ end) : sig
     Env.t ->
     To_cmm_result.t ->
     Ece.t ->
-    prev_updates:Cmm.expression option ->
+    prev_updates:To_cmm_env.expr_with_info option ->
     (int * Slot_offsets.Layout.slot) list ->
     P.cmm_term list
+    * To_cmm_env.free_vars
     * int
     * Env.t
     * To_cmm_result.t
     * Ece.t
-    * Cmm.expression option
+    * To_cmm_env.expr_with_info option
 end = struct
   (* The [offset]s here are measured in units of words. *)
   let fill_slot for_static_sets decls dbg ~startenv value_slots env res acc
@@ -115,7 +120,13 @@ end = struct
     match (slot : Slot_offsets.Layout.slot) with
     | Infix_header ->
       let field = P.infix_header ~function_slot_offset:(slot_offset + 1) ~dbg in
-      field :: acc, slot_offset + 1, env, res, Ece.pure, updates
+      ( field :: acc,
+        Backend_var.Set.empty,
+        slot_offset + 1,
+        env,
+        res,
+        Ece.pure,
+        updates )
     | Value_slot { value_slot; is_scanned; size = _ } ->
       let simple, kind = Value_slot.Map.find value_slot value_slots in
       if (not
@@ -127,7 +138,7 @@ end = struct
         Misc.fatal_errorf
           "Value slot %a not of kind Value (%a) but is visible by GC"
           Simple.print simple Debuginfo.print_compact dbg;
-      let contents, env, res, eff = P.simple ~dbg env res simple in
+      let contents, free_vars, env, res, eff = P.simple ~dbg env res simple in
       let env, res, fields, updates =
         match contents with
         | `Data fields -> env, res, fields, updates
@@ -149,7 +160,13 @@ end = struct
             in
             env, res, [P.int ~dbg 1n], updates)
       in
-      List.rev_append fields acc, slot_offset + 1, env, res, eff, updates
+      ( List.rev_append fields acc,
+        free_vars,
+        slot_offset + 1,
+        env,
+        res,
+        eff,
+        updates )
     | Function_slot { size; function_slot; last_function_slot } -> (
       let code_id = Function_slot.Map.find function_slot decls in
       let code_linkage_name = Code_id.linkage_name code_id in
@@ -187,7 +204,13 @@ end = struct
           :: P.symbol_from_linkage_name ~dbg code_linkage_name
           :: acc
         in
-        acc, slot_offset + size, env, res, Ece.pure, updates
+        ( acc,
+          Backend_var.Set.empty,
+          slot_offset + size,
+          env,
+          res,
+          Ece.pure,
+          updates )
       | Full_and_partial_application ->
         if size <> 3
         then
@@ -204,12 +227,18 @@ end = struct
                   (C.curry_function_sym kind params_ty result_ty))
           :: acc
         in
-        acc, slot_offset + size, env, res, Ece.pure, updates)
+        ( acc,
+          Backend_var.Set.empty,
+          slot_offset + size,
+          env,
+          res,
+          Ece.pure,
+          updates ))
 
   let rec fill_layout0 for_static_sets decls dbg ~startenv value_slots env res
-      effs acc updates ~starting_offset slots =
+      effs acc updates ~free_vars ~starting_offset slots =
     match slots with
-    | [] -> List.rev acc, starting_offset, env, res, effs, updates
+    | [] -> List.rev acc, free_vars, starting_offset, env, res, effs, updates
     | (slot_offset, slot) :: slots ->
       let acc =
         if starting_offset > slot_offset
@@ -222,18 +251,19 @@ end = struct
           List.init (slot_offset - starting_offset) (fun _ -> P.int ~dbg 1n)
           @ acc
       in
-      let acc, next_offset, env, res, eff, updates =
+      let acc, slot_free_vars, next_offset, env, res, eff, updates =
         fill_slot for_static_sets decls dbg ~startenv value_slots env res acc
           ~slot_offset updates slot
       in
+      let free_vars = Backend_var.Set.union free_vars slot_free_vars in
       let effs = Ece.join eff effs in
       fill_layout0 for_static_sets decls dbg ~startenv value_slots env res effs
-        acc updates ~starting_offset:next_offset slots
+        acc updates ~free_vars ~starting_offset:next_offset slots
 
   let fill_layout for_static_sets decls dbg ~startenv value_slots env res effs
       ~prev_updates slots =
     fill_layout0 for_static_sets decls dbg ~startenv value_slots env res effs []
-      prev_updates ~starting_offset:0 slots
+      prev_updates ~free_vars:Backend_var.Set.empty ~starting_offset:0 slots
 end
 
 (* Filling-up of dynamically-allocated sets of closures. *)
@@ -250,8 +280,10 @@ module Dynamic = Make_layout_filler (struct
      left-to-right order, so that the first translated field is actually
      evaluated last. *)
   let simple ~dbg env res simple =
-    let term, env, res, eff = C.simple ~dbg env res simple in
-    `Data [term], env, res, eff
+    let To_cmm_env.{ env; res; expr = { cmm; free_vars; effs } } =
+      C.simple ~dbg env res simple
+    in
+    `Data [cmm], free_vars, env, res, effs
 
   let infix_header ~dbg ~function_slot_offset =
     C.alloc_infix_header function_slot_offset dbg
@@ -270,7 +302,7 @@ module Static = Make_layout_filler (struct
 
   let simple ~dbg:_ env res simple =
     let contents = C.simple_static simple in
-    contents, env, res, Ece.pure
+    contents, Backend_var.Set.empty, env, res, Ece.pure
 
   let infix_header ~dbg:_ ~function_slot_offset =
     C.cint (C.infix_header function_slot_offset)
@@ -322,10 +354,21 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
      code, so we don't need any binder for it (this is why we can ignore
      [_bound_var]). If it does end up in generated code, Selection will complain
      and refuse to compile the code. *)
-  let env, _bound_var = Env.create_bound_parameter env my_region in
+  let env, my_region_var = Env.create_bound_parameter env my_region in
   (* Translate the arg list and body *)
-  let env, fun_args = C.bound_parameters env params in
-  let fun_body, res = translate_expr env res body in
+  let env, fun_params = C.bound_parameters env params in
+  let fun_body, fun_body_free_vars, res = translate_expr env res body in
+  let fun_free_vars =
+    C.remove_vars_with_machtype
+      (C.remove_var_with_provenance fun_body_free_vars my_region_var)
+      fun_params
+  in
+  if not (Backend_var.Set.is_empty fun_free_vars)
+  then
+    Misc.fatal_errorf
+      "Unbound free_vars in function body when translating to cmm: %a@\n\
+       function body: %a" Backend_var.Set.print fun_free_vars
+      Printcmm.expression fun_body;
   let fun_flags =
     transl_check_attrib check
     @
@@ -336,7 +379,7 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
     Env.get_code_metadata env code_id
     |> Code_metadata.poll_attribute |> Poll_attribute.to_lambda
   in
-  C.fundecl linkage_name fun_args fun_body fun_flags fun_dbg fun_poll, res
+  C.fundecl linkage_name fun_params fun_body fun_flags fun_dbg fun_poll, res
 
 let params_and_body env res code_id p ~fun_dbg ~check ~translate_expr =
   Function_params_and_body.pattern_match p
@@ -419,11 +462,17 @@ let let_static_set_of_closures0 env res closure_symbols
       closure_symbol_for_updates
     }
   in
-  let l, length, env, res, _effs, updates =
+  let l, free_vars, length, env, res, _effs, updates =
     Static.fill_layout (Some for_static_sets) decls dbg
       ~startenv:layout.startenv value_slots env res Ece.pure ~prev_updates
       layout.slots
   in
+  if not (Backend_var.Set.is_empty free_vars)
+  then
+    Misc.fatal_errorf
+      "Non-empty set of free_vars for a statis set of closures (*not* \
+       including updates):@ %a"
+      Backend_var.Set.print free_vars;
   let block =
     match l with
     | _ :: _ ->
@@ -489,6 +538,7 @@ let lift_set_of_closures env res ~body ~bound_vars layout set ~translate_expr
         let v = Bound_var.var v in
         let sym = C.symbol ~dbg (Function_slot.Map.find cid closure_symbols) in
         Env.bind_variable env res v ~defining_expr:sym
+          ~free_vars_of_defining_expr:Backend_var.Set.empty
           ~num_normal_occurrences_of_bound_vars
           ~effects_and_coeffects_of_defining_expr:Ece.pure_can_be_duplicated)
       (env, res) cids bound_vars
@@ -512,7 +562,7 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   let decl_map =
     decls |> Function_slot.Lmap.bindings |> Function_slot.Map.of_list
   in
-  let l, _offset, env, res, effs, updates =
+  let l, free_vars, _offset, env, res, effs, updates =
     Dynamic.fill_layout None decl_map dbg ~startenv:layout.startenv value_slots
       env res effs ~prev_updates:None layout.slots
   in
@@ -525,26 +575,33 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
       dbg tag l
   in
   let soc_var = Variable.create "*set_of_closures*" in
-  let defining_expr = Env.simple csoc in
+  let defining_expr = Env.simple csoc free_vars in
   let env, res =
     Env.bind_variable_to_primitive env res soc_var ~inline:Env.Do_not_inline
       ~defining_expr ~effects_and_coeffects_of_defining_expr:effs
   in
   (* Get from the env the cmm variable that was created and bound to the
      compiled set of closures. *)
-  let soc_cmm_var, env, res, peff = Env.inline_variable env res soc_var in
+  let To_cmm_env.
+        { env;
+          res;
+          expr = { cmm = soc_cmm_var; free_vars = s_free_vars; effs = peff }
+        } =
+    Env.inline_variable env res soc_var
+  in
   assert (
     match To_cmm_effects.classify_by_effects_and_coeffects peff with
     | Pure -> true
     | Generative_immutable | Effect | Coeffect_only -> false);
   (* Helper function to get the cmm expr for a closure offset *)
-  let get_closure_by_offset env set_cmm function_slot =
+  let get_closure_by_offset env function_slot =
     match
       Exported_offsets.function_slot_offset (Env.exported_offsets env)
         function_slot
     with
     | Some (Live_function_slot { offset; _ }) ->
-      Some (C.infix_field_address ~dbg:Debuginfo.none set_cmm offset, Ece.pure)
+      Some
+        (C.infix_field_address ~dbg:Debuginfo.none soc_cmm_var offset, Ece.pure)
     | Some Dead_function_slot -> None
     | None ->
       Misc.fatal_errorf "Missing offset for function slot %a"
@@ -554,11 +611,12 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   let env, res =
     List.fold_left2
       (fun (env, res) cid v ->
-        match get_closure_by_offset env soc_cmm_var cid with
+        match get_closure_by_offset env cid with
         | None -> env, res
         | Some (defining_expr, effects_and_coeffects_of_defining_expr) ->
           let v = Bound_var.var v in
           Env.bind_variable env res v ~defining_expr
+            ~free_vars_of_defining_expr:s_free_vars
             ~num_normal_occurrences_of_bound_vars
             ~effects_and_coeffects_of_defining_expr)
       (env, res)

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -17,15 +17,21 @@
 open! Flambda.Import
 
 type translate_expr =
-  To_cmm_env.t -> To_cmm_result.t -> Expr.t -> Cmm.expression * To_cmm_result.t
+  To_cmm_env.t ->
+  To_cmm_result.t ->
+  Expr.t ->
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_result.t
 
 val let_static_set_of_closures :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Symbol.t Function_slot.Map.t ->
   Set_of_closures.t ->
-  prev_updates:Cmm.expression option ->
-  To_cmm_env.t * To_cmm_result.t * Cmm.data_item list * Cmm.expression option
+  prev_updates:To_cmm_env.expr_with_info option ->
+  To_cmm_env.t
+  * To_cmm_result.t
+  * Cmm.data_item list
+  * To_cmm_env.expr_with_info option
 
 val let_dynamic_set_of_closures :
   To_cmm_env.t ->
@@ -35,7 +41,7 @@ val let_dynamic_set_of_closures :
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   Set_of_closures.t ->
   translate_expr:translate_expr ->
-  Cmm.expression * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_result.t
 
 val params_and_body :
   To_cmm_env.t ->
@@ -44,9 +50,5 @@ val params_and_body :
   Function_params_and_body.t ->
   fun_dbg:Debuginfo.t ->
   check:Check_attribute.t ->
-  translate_expr:
-    (To_cmm_env.t ->
-    To_cmm_result.t ->
-    Expr.t ->
-    Cmm.expression * To_cmm_result.t) ->
+  translate_expr:translate_expr ->
   Cmm.fundecl * To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -16,6 +16,14 @@
     this module, unlike the ones in [Cmm_helpers], depend on Flambda 2 data
     types. *)
 
+val remove_var_with_provenance :
+  To_cmm_env.free_vars -> Backend_var.With_provenance.t -> To_cmm_env.free_vars
+
+val remove_vars_with_machtype :
+  To_cmm_env.free_vars ->
+  (Backend_var.With_provenance.t * Cmm.machtype) list ->
+  To_cmm_env.free_vars
+
 val exttype_of_kind : Flambda_kind.t -> Cmm.exttype
 
 val machtype_of_kind : Flambda_kind.t -> Cmm.machtype_component array
@@ -37,10 +45,7 @@ val symbol : dbg:Debuginfo.t -> Symbol.t -> Cmm.expression
 
 (** This does not inline effectful expressions. *)
 val name :
-  To_cmm_env.t ->
-  To_cmm_result.t ->
-  Name.t ->
-  Cmm.expression * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
+  To_cmm_env.t -> To_cmm_result.t -> Name.t -> To_cmm_env.translation_result
 
 val const : dbg:Debuginfo.t -> Reg_width_const.t -> Cmm.expression
 
@@ -53,7 +58,7 @@ val simple :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Simple.t ->
-  Cmm.expression * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
+  To_cmm_env.translation_result
 
 val simple_static :
   Simple.t -> [`Data of Cmm.data_item list | `Var of Variable.t]
@@ -66,7 +71,11 @@ val simple_list :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Simple.t list ->
-  Cmm.expression list * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
+  Cmm.expression list
+  * To_cmm_env.free_vars
+  * To_cmm_env.t
+  * To_cmm_result.t
+  * Effects_and_coeffects.t
 
 val bound_parameters :
   To_cmm_env.t ->
@@ -85,8 +94,8 @@ val make_update :
   symbol:Cmm.expression ->
   Variable.t ->
   index:int ->
-  prev_updates:Cmm.expression option ->
-  To_cmm_env.t * To_cmm_result.t * Cmm.expression option
+  prev_updates:To_cmm_env.expr_with_info option ->
+  To_cmm_env.t * To_cmm_result.t * To_cmm_env.expr_with_info option
 
 val check_arity : Flambda_arity.With_subkinds.t -> _ list -> bool
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -79,11 +79,8 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
       Cmmgen_state.add_structured_constant symbol_name structured_constant;
       env, res, updates
     | Var (v, dbg) ->
-      let env, res, updates =
-        C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
-          ~prev_updates:updates
-      in
-      env, res, updates
+      C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
+        ~prev_updates:updates
   in
   R.update_data res (or_variable aux default v), env, updates
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -79,8 +79,11 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
       Cmmgen_state.add_structured_constant symbol_name structured_constant;
       env, res, updates
     | Var (v, dbg) ->
-      C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
-        ~prev_updates:updates
+      let env, res, updates =
+        C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
+          ~prev_updates:updates
+      in
+      env, res, updates
   in
   R.update_data res (or_variable aux default v), env, updates
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.mli
@@ -29,4 +29,4 @@ val static_consts :
     Cmm.fundecl * To_cmm_result.t) ->
   Bound_static.t ->
   Static_const_group.t ->
-  To_cmm_env.t * To_cmm_result.t * Cmm.expression option
+  To_cmm_env.t * To_cmm_result.t * To_cmm_env.expr_with_info option


### PR DESCRIPTION
This is the second part of the split of #1087 , and is based on top of #1099 .

This adds free_names computation on the way up during to_cmm translation, and then use that set of free_names to filter out uneeded bindings when we flush. In particular, this is useful when flushing everything because of an end_region, where before this PR we were forced to flush `must_inline_and_duplicate` binding to be safe and correct, even if there was no use of the bound vars after the end_region.

On the example mentionned in #1099 , the cmm now looks like this (in `-Oclassic` mode):
```
(function{/home/guigui/tmp/bigstring.ml:31,34-93}
 camlBigstring__unsafe_get_uint32_be_3_3_code
     (t106/588: val pos107/589: val my_closure105/590: val)
 (let
   (to_cmm_split_12/597
      (let ba_data/594 (load_mut int (+a t106/588 8))
        (load_mut signed int32 (+ ba_data/594 (>>s pos107/589 1))))
    to_cmm_split_16/601
      (>>s (<< (bswap_32 (>>s (<< to_cmm_split_12/597 32) 32)) 32) 32)
    region123/606 (beginregion))
   (catch
     (if (== 1 (load val (+a (load val (+a my_closure105/590 24)) 16)))
       (exit 2 (or (>>s (<< to_cmm_split_16/601 32) 31) 1))
       (let
         Pandbint135/620
           (alloc_local{/home/guigui/tmp/bigstring.ml:20,22-52} 2815
             "caml_nativeint_ops"
             (and (>>s (<< to_cmm_split_16/601 32) 32)
               (load int
                 (+a (load val (+a (load val (+a my_closure105/590 24)) 24))
                   8))))
         (exit 2 (+ (<< (load int (+a Pandbint135/620 8)) 1) 1))))
   with(2 region_return124/607: val)
     (let unit125/610 (seq (endregion region123/606) 1) region_return124/607))))
```

where all of the useless let_binding before the end_region at the end of the function have now disappeared. Most importantly, the allocation disapeared (the other bindings could already be removed by deadcode, but not the allocation).

This PR works, but there are still style changes to do (mostly, introduce record types and type aliases to avoid using 5/6-tuples).