### PR TITLE
Dune lang 3.5

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.8)
+(lang dune 3.5)
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 

--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -15,7 +15,7 @@ else
 endif
 
 define dune_boot_context
-(lang dune 2.8)
+(lang dune 3.5)
 ; We need to call the boot context "default" so that dune selects it for merlin
 (context (default
   (name default)
@@ -24,7 +24,7 @@ define dune_boot_context
 endef
 
 define dune_runtime_stdlib_context
-(lang dune 2.8)
+(lang dune 3.5)
 (context (default
   (name runtime_stdlib)
   (profile main)
@@ -36,7 +36,7 @@ define dune_runtime_stdlib_context
 endef
 
 define dune_main_context
-(lang dune 2.8)
+(lang dune 3.5)
 (context (default
   (name main)
   (profile main)

--- a/ocaml/dune-project.jst
+++ b/ocaml/dune-project.jst
@@ -1,4 +1,4 @@
-(lang dune 2.8)
+(lang dune 3.5)
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 

--- a/tests/backend/frame-too-long/t.expected
+++ b/tests/backend/frame-too-long/t.expected
@@ -1,1 +1,1 @@
-i=10000 len=2 name=Raised at T.break in file "tests/backend/frame-too-long/t.ml", line 5, characters 2-15
+i=10000 name=Raised at T.break in file "tests/backend/frame-too-long/t.ml", line 5, characters 2-15

--- a/tests/backend/frame-too-long/t.ml
+++ b/tests/backend/frame-too-long/t.ml
@@ -15,7 +15,7 @@ let[@inline never] check_backtrace n =
     let slot = Printexc.get_raw_backtrace_slot raw_backtrace 0
                |> Printexc.convert_raw_backtrace_slot  in
     let name = Printexc.Slot.format 0 slot |> Option.get in
-    Printf.printf "i=%d len=%d name=%s\n" i len name;
+    Printf.printf "i=%d name=%s\n" i name;
     ()
 
 let test n =


### PR DESCRIPTION
Can we move dune lang from 2.8 to 3.5? I'd like to use "include" in the "files" filed of "install" stanza, available from dune 3.5?

This caused a surprising change in backtrace in one of the tests, only in flambda mode and dune 3.5 the backtrace is short and seems to be missing an entry:
```
Raised at T.break in file "tests/backend/frame-too-long/t.ml", line 5, characters 2-15
```
whereis with closure or with dune 2.8 the backtrace is normal:
```
Raised at T.break in file "tests/backend/frame-too-long/t.ml", line 5, characters 2-15
Called from T.check_backtrace in file "tests/backend/frame-too-long/t.ml", line 9, characters 4-11
```
I know I shouldn't have backtraces in tests, so I fixed the test in this PR in a separate commit, but I don't undertand the cause of this change.
