### PR TITLE
Changes to arity in clambda

### DIFF
--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -61,13 +61,19 @@ val boxedintnat_header : nativeint
 
 (** Closure info for a closure of given arity and distance to environment *)
 val closure_info :
-  arity:Lambda.function_kind * int -> startenv:int -> is_last:bool -> nativeint
+  arity:Clambda.arity -> startenv:int -> is_last:bool -> nativeint
+
+val closure_info' :
+  arity:(Lambda.function_kind * 'a list) ->
+  startenv:int ->
+  is_last:bool ->
+  nativeint
 
 (** Wrappers *)
 val alloc_infix_header : int -> Debuginfo.t -> expression
 
 val alloc_closure_info :
-  arity:Lambda.function_kind * int ->
+  arity:Clambda.arity ->
   startenv:int ->
   is_last:bool ->
   Debuginfo.t ->

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -61,7 +61,7 @@ val boxedintnat_header : nativeint
 
 (** Closure info for a closure of given arity and distance to environment *)
 val closure_info :
-  arity:Clambda.arity -> startenv:int -> is_last:bool -> nativeint
+  arity:Lambda.function_kind * int -> startenv:int -> is_last:bool -> nativeint
 
 (** Wrappers *)
 val alloc_infix_header : int -> Debuginfo.t -> expression

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -64,7 +64,7 @@ val closure_info :
   arity:Clambda.arity -> startenv:int -> is_last:bool -> nativeint
 
 val closure_info' :
-  arity:(Lambda.function_kind * 'a list) ->
+  arity:Lambda.function_kind * 'a list ->
   startenv:int ->
   is_last:bool ->
   nativeint

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -465,7 +465,12 @@ let rec transl env e =
                                    ~startenv:(startenv - pos) ~is_last dbg ::
                 transl_fundecls (pos + 3) rem
               | arity ->
-                Cconst_symbol (curry_function_sym arity.function_kind (List.map machtype_of_layout arity.params_layout) (machtype_of_layout arity.return_layout), dbg) ::
+                Cconst_symbol
+                  (curry_function_sym
+                     arity.function_kind
+                     (List.map machtype_of_layout arity.params_layout)
+                     (machtype_of_layout arity.return_layout),
+                   dbg) ::
                 alloc_closure_info ~arity
                                    ~startenv:(startenv - pos) ~is_last dbg ::
                 Cconst_symbol (f.label, dbg) ::
@@ -1491,7 +1496,8 @@ let transl_function f =
       f.arity.params_layout @ [Lambda.layout_function]
   in
   Cfunction {fun_name = f.label;
-             fun_args = List.map2 (fun id ty -> (id, machtype_of_layout ty)) f.params params_layout;
+             fun_args = List.map2 (fun id ty -> (id, machtype_of_layout ty))
+                 f.params params_layout;
              fun_body = cmm_body;
              fun_codegen_options;
              fun_poll = f.poll;

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -461,12 +461,12 @@ let rec transl env e =
               match f.arity with
               | { function_kind = Curried _ ; params_layout = ([] | [_]) } as arity ->
                 Cconst_symbol (f.label, dbg) ::
-                alloc_closure_info ~arity:(arity.function_kind, List.length arity.params_layout)
+                alloc_closure_info ~arity
                                    ~startenv:(startenv - pos) ~is_last dbg ::
                 transl_fundecls (pos + 3) rem
               | arity ->
                 Cconst_symbol (curry_function_sym arity.function_kind (List.map machtype_of_layout arity.params_layout) (machtype_of_layout arity.return_layout), dbg) ::
-                alloc_closure_info ~arity:(arity.function_kind, List.length arity.params_layout)
+                alloc_closure_info ~arity
                                    ~startenv:(startenv - pos) ~is_last dbg ::
                 Cconst_symbol (f.label, dbg) ::
                 transl_fundecls (pos + 4) rem

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -494,11 +494,11 @@ let rec transl env e =
       let args = List.map (transl env) args in
       let return = typ_val in
       direct_apply lbl return args kind dbg
-  | Ugeneric_apply(clos, args, kind, dbg) ->
+  | Ugeneric_apply(clos, args, args_layout, result_layout, kind, dbg) ->
       let clos = transl env clos in
       let args = List.map (transl env) args in
-      let args_type = List.map (fun _ -> typ_val) args in
-      let return = typ_val in
+      let args_type = List.map machtype_of_layout args_layout in
+      let return = machtype_of_layout result_layout in
       generic_apply (mut_from_env env clos) clos args args_type return kind dbg
   | Usend(kind, met, obj, args, pos, dbg) ->
       let met = transl env met in

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -486,14 +486,13 @@ let rec transl env e =
       let ptr = transl env arg in
       let dbg = Debuginfo.none in
       ptr_offset ptr offset dbg
-  | Udirect_apply(handler_code_sym, args, Some { name; }, _, dbg) ->
+  | Udirect_apply(handler_code_sym, args, Some { name; }, _, _, dbg) ->
       let args = List.map (transl env) args in
       return_unit dbg
         (Cop(Cprobe { name; handler_code_sym; }, args, dbg))
-  | Udirect_apply(lbl, args, None, kind, dbg) ->
+  | Udirect_apply(lbl, args, None, result_layout, kind, dbg) ->
       let args = List.map (transl env) args in
-      let return = typ_val in
-      direct_apply lbl return args kind dbg
+      direct_apply lbl (machtype_of_layout result_layout) args kind dbg
   | Ugeneric_apply(clos, args, args_layout, result_layout, kind, dbg) ->
       let clos = transl env clos in
       let args = List.map (transl env) args in

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -500,12 +500,12 @@ let rec transl env e =
       let args_type = List.map machtype_of_layout args_layout in
       let return = machtype_of_layout result_layout in
       generic_apply (mut_from_env env clos) clos args args_type return kind dbg
-  | Usend(kind, met, obj, args, pos, dbg) ->
+  | Usend(kind, met, obj, args, args_layout, result_layout, pos, dbg) ->
       let met = transl env met in
       let obj = transl env obj in
       let args = List.map (transl env) args in
-      let args_type = List.map (fun _ -> typ_val) args in
-      let return = typ_val in
+      let args_type = List.map machtype_of_layout args_layout in
+      let return = machtype_of_layout result_layout in
       send kind met obj args args_type return pos dbg
   | Ulet(str, kind, id, exp, body) ->
       transl_let env str kind id exp (fun env -> transl env body)

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -94,7 +94,7 @@ and ulambda =
   | Uassign of Backend_var.t * ulambda
   | Usend of
       meth_kind * ulambda * ulambda * ulambda list
-      * apply_kind * Debuginfo.t
+      * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
   | Utail of ulambda

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -55,7 +55,7 @@ and ulambda =
   | Udirect_apply of
       function_label * ulambda list * Lambda.probe * apply_kind * Debuginfo.t
   | Ugeneric_apply of
-      ulambda * ulambda list * apply_kind * Debuginfo.t
+      ulambda * ulambda list * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uclosure of {
       functions : ufunction list ;
       not_scanned_slots : ulambda list ;

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -20,7 +20,11 @@ open Asttypes
 open Lambda
 
 type function_label = string
-type arity = Lambda.function_kind * int
+type arity = {
+  function_kind : Lambda.function_kind ;
+  params_layout : Lambda.layout list ;
+  return_layout : Lambda.layout ;
+}
 type apply_kind = Lambda.region_close * Lambda.alloc_mode
 
 type ustructured_constant =
@@ -98,8 +102,7 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : arity;
-  params : (Backend_var.With_provenance.t * layout) list;
-  return : layout;
+  params : Backend_var.With_provenance.t list;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -53,7 +53,7 @@ and ulambda =
     Uvar of Backend_var.t
   | Uconst of uconstant
   | Udirect_apply of
-      function_label * ulambda list * Lambda.probe * apply_kind * Debuginfo.t
+      function_label * ulambda list * Lambda.probe * Lambda.layout * apply_kind * Debuginfo.t
   | Ugeneric_apply of
       ulambda * ulambda list * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uclosure of {

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -66,7 +66,7 @@ and ulambda =
   | Udirect_apply of
       function_label * ulambda list * Lambda.probe * apply_kind * Debuginfo.t
   | Ugeneric_apply of
-      ulambda * ulambda list * apply_kind * Debuginfo.t
+      ulambda * ulambda list * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uclosure of {
       functions : ufunction list ;
       not_scanned_slots : ulambda list ;

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -20,7 +20,11 @@ open Asttypes
 open Lambda
 
 type function_label = string
-type arity = Lambda.function_kind * int
+type arity = {
+  function_kind : Lambda.function_kind ;
+  params_layout : Lambda.layout list ;
+  return_layout : Lambda.layout ;
+}
 type apply_kind = Lambda.region_close * Lambda.alloc_mode
 
 type ustructured_constant =
@@ -109,8 +113,7 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : arity;
-  params : (Backend_var.With_provenance.t * layout) list;
-  return : layout;
+  params : Backend_var.With_provenance.t list;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -105,7 +105,7 @@ and ulambda =
   | Uassign of Backend_var.t * ulambda
   | Usend of
       meth_kind * ulambda * ulambda * ulambda list
-      * apply_kind * Debuginfo.t
+      * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
   | Utail of ulambda

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -64,7 +64,7 @@ and ulambda =
     Uvar of Backend_var.t
   | Uconst of uconstant
   | Udirect_apply of
-      function_label * ulambda list * Lambda.probe * apply_kind * Debuginfo.t
+      function_label * ulambda list * Lambda.probe * Lambda.layout * apply_kind * Debuginfo.t
   | Ugeneric_apply of
       ulambda * ulambda list * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uclosure of {

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1173,12 +1173,11 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           fail_if_probe ~probe "Unknown function";
           (Ugeneric_apply(ufunct, uargs, List.map (fun _ -> Lambda.layout_top) uargs, ap_result_layout, (pos, mode), dbg), Value_unknown)
       end
-  | Lsend(kind, met, obj, args, pos, mode, loc, _result_layout) ->
+  | Lsend(kind, met, obj, args, pos, mode, loc, result_layout) ->
       let (umet, _) = close env met in
       let (uobj, _) = close env obj in
       let dbg = Debuginfo.from_location loc in
-      let args_layout = assert false in
-      let result_layout = assert false in
+      let args_layout = List.map (fun _ -> Lambda.layout_top) args in
       (Usend(kind, umet, uobj, close_list env args, args_layout, result_layout, (pos,mode), dbg),
        Value_unknown)
   | Llet(str, kind, id, lam, body) ->

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1030,7 +1030,9 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           Location.print_loc (Debuginfo.Scoped_location.to_location loc);
       begin match (close env funct, close_list env args) with
         ((ufunct, Value_closure(_,
-                                ({fun_arity={function_kind = Tupled ; params_layout = params_layout; _}} as fundesc),
+                                ({fun_arity={
+                                     function_kind = Tupled ;
+                                     params_layout; _}} as fundesc),
                                 approx_res)),
          [Uprim(P.Pmakeblock _, uargs, _)])
         when List.length uargs = List.length params_layout ->
@@ -1039,7 +1041,9 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
               pos ap_result_layout mode ~probe in
           (app, strengthen_approx app approx_res)
       | ((ufunct, Value_closure(_,
-                                ({fun_arity={function_kind = Curried _ ; params_layout ; _}} as fundesc),
+                                ({fun_arity={
+                                     function_kind = Curried _ ;
+                                     params_layout ; _}} as fundesc),
                                 approx_res)), uargs)
         when nargs = List.length params_layout ->
           let app =
@@ -1049,7 +1053,8 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
 
       | ((ufunct, (Value_closure(
             clos_mode,
-            ({fun_arity={ function_kind = Curried {nlocal} ; params_layout ; _ }} as fundesc),
+            ({fun_arity={ function_kind = Curried {nlocal} ;
+                          params_layout ; _ }} as fundesc),
             _) as fapprox)), uargs)
           when nargs < List.length params_layout ->
         let nparams = List.length params_layout in
@@ -1122,7 +1127,8 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
         fail_if_probe ~probe "Partial application";
         (new_fun, approx)
 
-      | ((ufunct, Value_closure(_, ({fun_arity = { function_kind = Curried _; params_layout ; _}} as fundesc),
+      | ((ufunct, Value_closure(_, ({fun_arity = {
+          function_kind = Curried _; params_layout ; _}} as fundesc),
                                 _approx_res)), uargs)
         when nargs > List.length params_layout ->
           let nparams = List.length params_layout in
@@ -1494,7 +1500,11 @@ and close_functions { backend; fenv; cenv; mutable_vars; kinds; catch_env } fun_
             in
             let fundesc =
               {fun_label = label;
-               fun_arity = { function_kind = kind ; params_layout = List.map snd params ; return_layout = return };
+               fun_arity = {
+                 function_kind = kind ;
+                 params_layout = List.map snd params ;
+                 return_layout = return
+               };
                fun_closed = initially_closed;
                fun_inline = None;
                fun_float_const_prop = !Clflags.float_const_prop;
@@ -1523,7 +1533,9 @@ and close_functions { backend; fenv; cenv; mutable_vars; kinds; catch_env } fun_
       (fun (_id, _params, _return, _body, _mode, _attrib, fundesc, _dbg) ->
         let pos = !env_pos + 1 in
         env_pos := !env_pos + 1 +
-          (match fundesc.fun_arity with { function_kind = Curried _; params_layout = ([] | [_]); _} -> 2 | _ -> 3);
+          (match fundesc.fun_arity with
+            | { function_kind = Curried _; params_layout = ([] | [_]); _} -> 2
+            | _ -> 3);
         pos)
       uncurried_defs in
   let fv_pos = !env_pos in

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -104,7 +104,7 @@ let occurs_var var u =
   let rec occurs = function
       Uvar v -> v = var
     | Uconst _ -> false
-    | Udirect_apply(_lbl, args, _, _, _) -> List.exists occurs args
+    | Udirect_apply(_lbl, args, _, _, _, _) -> List.exists occurs args
     | Ugeneric_apply(funct, args, _, _, _, _) ->
         occurs funct || List.exists occurs args
     | Uclosure { functions = _ ; not_scanned_slots ; scanned_slots } ->
@@ -192,7 +192,7 @@ let lambda_smaller lam threshold =
     match lam with
       Uvar _ -> ()
     | Uconst _ -> incr size
-    | Udirect_apply(_, args, None, _, _) ->
+    | Udirect_apply(_, args, None, _, _, _) ->
         size := !size + 4; lambda_list_size args
     | Udirect_apply _ -> ()
     (* We aim for probe points to not affect inlining decisions.
@@ -605,10 +605,10 @@ let rec substitute loc ((backend, fpc) as st) sb rn ulam =
     Uvar v ->
       begin try V.Map.find v sb with Not_found -> ulam end
   | Uconst _ -> ulam
-  | Udirect_apply(lbl, args, probe, kind, dbg) ->
+  | Udirect_apply(lbl, args, probe, return_layout, kind, dbg) ->
       let dbg = subst_debuginfo loc dbg in
       Udirect_apply(lbl, List.map (substitute loc st sb rn) args,
-                    probe, kind, dbg)
+                    probe, return_layout, kind, dbg)
   | Ugeneric_apply(fn, args, args_layout, return_layout, kind, dbg) ->
       let dbg = subst_debuginfo loc dbg in
       Ugeneric_apply(substitute loc st sb rn fn,
@@ -864,7 +864,7 @@ let fail_if_probe ~probe msg =
 
 (* Generate a direct application *)
 
-let direct_apply env fundesc ufunct uargs pos mode ~probe ~loc ~attribute =
+let direct_apply env fundesc ufunct uargs pos result_layout mode ~probe ~loc ~attribute =
   match fundesc.fun_inline, attribute with
   | _, Never_inlined
   | None, _ ->
@@ -882,10 +882,10 @@ let direct_apply env fundesc ufunct uargs pos mode ~probe ~loc ~attribute =
        fail_if_probe ~probe "Erroneously marked to be inlined"
      end;
      if fundesc.fun_closed && is_pure ufunct then
-       Udirect_apply(fundesc.fun_label, uargs, probe, kind, dbg)
+       Udirect_apply(fundesc.fun_label, uargs, probe, result_layout, kind, dbg)
      else if not fundesc.fun_closed &&
                is_substituable ~mutable_vars:env.mutable_vars ufunct then
-       Udirect_apply(fundesc.fun_label, uargs @ [ufunct], probe, kind, dbg)
+       Udirect_apply(fundesc.fun_label, uargs @ [ufunct], probe, result_layout, kind, dbg)
      else begin
        let args = List.map (fun arg ->
          if is_substituable ~mutable_vars:env.mutable_vars arg then
@@ -901,12 +901,12 @@ let direct_apply env fundesc ufunct uargs pos mode ~probe ~loc ~attribute =
          (if fundesc.fun_closed then
             Usequence (ufunct,
                        Udirect_apply (fundesc.fun_label, app_args,
-                                      probe, kind, dbg))
+                                      probe, result_layout, kind, dbg))
           else
             let clos = V.create_local "clos" in
             Ulet(Immutable, Lambda.layout_function, VP.create clos, ufunct,
                  Udirect_apply(fundesc.fun_label, app_args @ [Uvar clos],
-                               probe, kind, dbg)))
+                               probe, result_layout, kind, dbg)))
          args
        end
   | Some(params, body), _  ->
@@ -1036,7 +1036,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
         when List.length uargs = List.length params_layout ->
           let app =
             direct_apply env ~loc ~attribute fundesc ufunct uargs
-              pos mode ~probe in
+              pos ap_result_layout mode ~probe in
           (app, strengthen_approx app approx_res)
       | ((ufunct, Value_closure(_,
                                 ({fun_arity={function_kind = Curried _ ; params_layout ; _}} as fundesc),
@@ -1044,7 +1044,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
         when nargs = List.length params_layout ->
           let app =
             direct_apply env ~loc ~attribute fundesc ufunct uargs
-              pos mode ~probe in
+              pos ap_result_layout mode ~probe in
           (app, strengthen_approx app approx_res)
 
       | ((ufunct, (Value_closure(
@@ -1142,7 +1142,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           let body =
             Ugeneric_apply(direct_apply { env with kinds } ~loc ~attribute
                               fundesc ufunct first_args
-                              Rc_normal mode'
+                              Rc_normal Lambda.layout_function mode'
                               ~probe,
                            rem_args,
                            List.map (fun _ -> Lambda.layout_top) rem_args,
@@ -1730,7 +1730,7 @@ let collect_exported_structured_constants a =
   and ulam = function
     | Uvar _ -> ()
     | Uconst c -> const c
-    | Udirect_apply (_, ul, _, _, _) -> List.iter ulam ul
+    | Udirect_apply (_, ul, _, _, _, _) -> List.iter ulam ul
     | Ugeneric_apply (u, ul, _, _, _, _) -> ulam u; List.iter ulam ul
     | Uclosure { functions ; not_scanned_slots ; scanned_slots } ->
         List.iter (fun f -> ulam f.body) functions;

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -277,8 +277,10 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
     to_clambda_direct_apply t func args direct_func probe dbg reg_close mode env
   | Apply { func; args; kind = Indirect; probe = None; dbg; reg_close; mode } ->
     let callee = subst_var env func in
+    let args_layout = assert false in
+    let result_layout = assert false in
     Ugeneric_apply (check_closure t callee (Flambda.Expr (Var func)),
-      subst_vars env args, (reg_close, mode), dbg)
+      subst_vars env args, args_layout, result_layout, (reg_close, mode), dbg)
   | Apply { probe = Some {name}; _ } ->
     Misc.fatal_errorf "Cannot apply indirect handler for probe %s" name ()
   | Switch (arg, sw) ->

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -360,8 +360,10 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
     in
     Uassign (id, subst_var env new_value)
   | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
+    let args_layout = assert false in
+    let result_layout = assert false in
     Usend (kind, subst_var env meth, subst_var env obj,
-      subst_vars env args, (reg_close,mode), dbg)
+      subst_vars env args, args_layout, result_layout, (reg_close,mode), dbg)
   | Region body ->
       let body = to_clambda t env body in
       let is_trivial =

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -491,7 +491,8 @@ and to_clambda_direct_apply t func args direct_func probe dbg pos mode env
        dropping any side effects.) *)
     if closed then uargs else uargs @ [subst_var env func]
   in
-  Udirect_apply (label, uargs, probe, (pos, mode), dbg)
+  let result_layout = Lambda.layout_top in
+  Udirect_apply (label, uargs, probe, result_layout, (pos, mode), dbg)
 
 (* Describe how to build a runtime closure block that corresponds to the
    given Flambda set of closures.

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -102,7 +102,7 @@ let clambda_arity (func : Flambda.function_declaration) : Clambda.arity =
   {
     function_kind = Curried {nlocal} ;
     params_layout = List.map Parameter.kind func.params ;
-    return_layout = assert false ; (* Need func.return *)
+    return_layout = Lambda.layout_top ; (* Need func.return *)
   }
 
 let check_field t ulam pos named_opt : Clambda.ulambda =
@@ -277,8 +277,8 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
     to_clambda_direct_apply t func args direct_func probe dbg reg_close mode env
   | Apply { func; args; kind = Indirect; probe = None; dbg; reg_close; mode } ->
     let callee = subst_var env func in
-    let args_layout = assert false in
-    let result_layout = assert false in
+    let args_layout = List.map (fun _ -> Lambda.layout_top) args in
+    let result_layout = Lambda.layout_top in
     Ugeneric_apply (check_closure t callee (Flambda.Expr (Var func)),
       subst_vars env args, args_layout, result_layout, (reg_close, mode), dbg)
   | Apply { probe = Some {name}; _ } ->
@@ -360,8 +360,8 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
     in
     Uassign (id, subst_var env new_value)
   | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
-    let args_layout = assert false in
-    let result_layout = assert false in
+    let args_layout = List.map (fun _ -> Lambda.layout_top) args in
+    let result_layout = Lambda.layout_top in
     Usend (kind, subst_var env meth, subst_var env obj,
       subst_vars env args, args_layout, result_layout, (reg_close,mode), dbg)
   | Region body ->

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -157,8 +157,7 @@ end = struct
         get_func_decl_params_arity env code_id
       in
       let closure_info =
-        C.closure_info'
-          ~arity:(kind, params_ty)
+        C.closure_info' ~arity:(kind, params_ty)
           ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
       in
       let acc =

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -157,8 +157,8 @@ end = struct
         get_func_decl_params_arity env code_id
       in
       let closure_info =
-        C.closure_info
-          ~arity:(kind, List.length params_ty)
+        C.closure_info'
+          ~arity:(kind, params_ty)
           ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
       in
       let acc =

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -263,7 +263,7 @@ and lam ppf = function
        lam hi lam body
   | Uassign(id, expr) ->
       fprintf ppf "@[<2>(assign@ %a@ %a)@]" V.print id lam expr
-  | Usend (k, met, obj, largs, (pos,_) , _) ->
+  | Usend (k, met, obj, largs, _, _, (pos,_) , _) ->
       let form =
         match pos with
         | Rc_normal | Rc_nontail -> "send"

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -140,7 +140,7 @@ and lam ppf = function
         | Some {name} -> fprintf ppf " (probe %s)" name
       in
       fprintf ppf "@[<2>(%a*@ %s %a%a)@]" apply_kind kind f lams largs pr probe
-  | Ugeneric_apply(lfun, largs, kind, _) ->
+  | Ugeneric_apply(lfun, largs, _, _, kind, _) ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       fprintf ppf "@[<2>(%a@ %a%a)@]" apply_kind kind lam lfun lams largs

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -298,9 +298,15 @@ let rec approx ppf = function
       Format.fprintf ppf "@[<2>function %s"
         fundesc.fun_label;
       begin match fundesc.fun_arity.function_kind with
-      | Tupled -> Format.fprintf ppf "@ arity -%i" (List.length fundesc.fun_arity.params_layout)
-      | Curried {nlocal=0} -> Format.fprintf ppf "@ arity %i" (List.length fundesc.fun_arity.params_layout)
-      | Curried {nlocal=k} -> Format.fprintf ppf "@ arity %i(%i L)" (List.length fundesc.fun_arity.params_layout) k
+      | Tupled ->
+        Format.fprintf ppf "@ arity -%i"
+          (List.length fundesc.fun_arity.params_layout)
+      | Curried {nlocal=0} ->
+        Format.fprintf ppf "@ arity %i"
+          (List.length fundesc.fun_arity.params_layout)
+      | Curried {nlocal=k} ->
+        Format.fprintf ppf "@ arity %i(%i L)"
+          (List.length fundesc.fun_arity.params_layout) k
       end;
       if fundesc.fun_closed then begin
         Format.fprintf ppf "@ (closed)"

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -86,7 +86,8 @@ and one_fun ppf f =
           VP.print param Printlambda.layout Lambda.layout_function
       | param :: params, layout :: layouts ->
         fprintf ppf "@ %a%a"
-          VP.print param Printlambda.layout layout
+          VP.print param Printlambda.layout layout;
+        iter params layouts
       | _ -> Misc.fatal_error "arity inconsistent with params"
     in
     iter f.params f.arity.params_layout

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -131,7 +131,7 @@ and lam ppf = function
   | Uvar id ->
       V.print ppf id
   | Uconst c -> uconstant ppf c
-  | Udirect_apply(f, largs, probe, kind, _) ->
+  | Udirect_apply(f, largs, probe, _, kind, _) ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       let pr ppf (probe : Lambda.probe) =

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -297,16 +297,11 @@ let rec approx ppf = function
     Value_closure(_, fundesc, a) ->
       Format.fprintf ppf "@[<2>function %s"
         fundesc.fun_label;
+      let n = List.length fundesc.fun_arity.params_layout in
       begin match fundesc.fun_arity.function_kind with
-      | Tupled ->
-        Format.fprintf ppf "@ arity -%i"
-          (List.length fundesc.fun_arity.params_layout)
-      | Curried {nlocal=0} ->
-        Format.fprintf ppf "@ arity %i"
-          (List.length fundesc.fun_arity.params_layout)
-      | Curried {nlocal=k} ->
-        Format.fprintf ppf "@ arity %i(%i L)"
-          (List.length fundesc.fun_arity.params_layout) k
+      | Tupled -> Format.fprintf ppf "@ arity -%i" n
+      | Curried {nlocal=0} -> Format.fprintf ppf "@ arity %i" n
+      | Curried {nlocal=k} -> Format.fprintf ppf "@ arity %i(%i L)" n k
       end;
       if fundesc.fun_closed then begin
         Format.fprintf ppf "@ (closed)"

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -80,12 +80,7 @@ let caml_int64_ops = "caml_int64_ops"
 let pos_arity_in_closinfo = 8 * size_addr - 8
        (* arity = the top 8 bits of the closinfo word *)
 
-let closure_info ~arity ~startenv ~is_last =
-  let arity =
-    match arity with
-    | Lambda.Tupled, n -> -n
-    | Lambda.Curried _, n -> n
-  in
+let pack_closure_info ~arity ~startenv ~is_last =
   assert (-128 <= arity && arity <= 127);
   assert (0 <= startenv && startenv < 1 lsl (pos_arity_in_closinfo - 2));
   Nativeint.(add (shift_left (of_int arity) pos_arity_in_closinfo)
@@ -94,6 +89,19 @@ let closure_info ~arity ~startenv ~is_last =
           (Bool.to_int is_last |> Nativeint.of_int)
           (pos_arity_in_closinfo - 1))
       (add (shift_left (of_int startenv) 1) 1n)))
+
+let closure_info' ~arity ~startenv ~is_last =
+  let arity =
+    match arity with
+    | Lambda.Tupled, l -> -List.length l
+    | Lambda.Curried _, l -> List.length l
+  in
+  pack_closure_info ~arity ~startenv ~is_last
+
+let closure_info ~(arity : Clambda.arity) ~startenv ~is_last =
+  closure_info'
+    ~arity:(arity.function_kind, arity.params_layout)
+    ~startenv ~is_last
 
 let alloc_float_header mode dbg =
   match mode with
@@ -2271,7 +2279,6 @@ let intermediate_curry_functions ~nlocal ~arity result =
       let mode : Lambda.alloc_mode =
         if num >= narity - nlocal then Lambda.alloc_local else Lambda.alloc_heap
       in
-      let curried n = Lambda.Curried { nlocal = min nlocal n }, n in
       let has_nary = curry_clos_has_nary_application ~narity (num + 1) in
       let function_slot_size = if has_nary then 3 else 2 in
       Cfunction
@@ -2284,11 +2291,14 @@ let intermediate_curry_functions ~nlocal ~arity result =
                     (function_slot_size + machtype_stored_size arg_type + 1)
                     (dbg ());
                   Cconst_symbol (name1 ^ "_" ^ Int.to_string (num + 1), dbg ());
-                  alloc_closure_info
-                    ~arity:(curried (if has_nary then narity - num - 1 else 1))
-                    ~startenv:
-                      (function_slot_size + machtype_non_scanned_size arg_type)
-                    (dbg ()) ~is_last:true ]
+                  Cconst_natint
+                    ( pack_closure_info
+                        ~arity:(if has_nary then narity - num - 1 else 1)
+                        ~startenv:
+                          (function_slot_size
+                          + machtype_non_scanned_size arg_type)
+                        ~is_last:true,
+                      dbg () ) ]
                 @ (if has_nary
                   then
                     [ Cconst_symbol
@@ -3018,7 +3028,7 @@ let fundecls_size fundecls =
     (fun (f : Clambda.ufunction) ->
        let indirect_call_code_pointer_size =
          match f.arity with
-         | Curried _, (0 | 1) -> 0
+         | { function_kind = Curried _; params_layout = [] | [_]; _ } -> 0
            (* arity 1 does not need an indirect call handler.
               arity 0 cannot be indirect called *)
          | _ -> 1
@@ -3053,7 +3063,7 @@ let emit_constant_closure ((_, global_symb) as symb) fundecls clos_vars cont =
       | (f2 : Clambda.ufunction) :: rem -> (
         let is_last = match rem with [] -> true | _ :: _ -> false in
         match f2.arity with
-        | (Curried _, (0 | 1)) as arity ->
+        | { function_kind = Curried _; params_layout = [] | [_]; _ } as arity ->
           (Cint (infix_header pos) :: closure_symbol f2)
           @ Csymbol_address f2.label
             :: Cint (closure_info ~arity ~startenv:(startenv - pos) ~is_last)
@@ -3061,9 +3071,9 @@ let emit_constant_closure ((_, global_symb) as symb) fundecls clos_vars cont =
         | arity ->
           (Cint (infix_header pos) :: closure_symbol f2)
           @ Csymbol_address
-              (curry_function_sym (fst arity)
-                 (List.init (snd arity) (fun _ -> typ_val))
-                 typ_val)
+              (curry_function_sym arity.function_kind
+                 (List.map machtype_of_layout arity.params_layout)
+                 (machtype_of_layout arity.return_layout))
             :: Cint (closure_info ~arity ~startenv:(startenv - pos) ~is_last)
             :: Csymbol_address f2.label
             :: emit_others (pos + 4) rem)
@@ -3074,15 +3084,15 @@ let emit_constant_closure ((_, global_symb) as symb) fundecls clos_vars cont =
     @ closure_symbol f1
     @
     match f1.arity with
-    | (Curried _, (0 | 1)) as arity ->
+    | { function_kind = Curried _; params_layout = [] | [_]; _ } as arity ->
       Csymbol_address f1.label
       :: Cint (closure_info ~arity ~startenv ~is_last)
       :: emit_others 3 remainder
     | arity ->
       Csymbol_address
-        (curry_function_sym (fst arity)
-           (List.init (snd arity) (fun _ -> typ_val))
-           typ_val)
+        (curry_function_sym arity.function_kind
+           (List.map machtype_of_layout arity.params_layout)
+           (machtype_of_layout arity.return_layout))
       :: Cint (closure_info ~arity ~startenv ~is_last)
       :: Csymbol_address f1.label :: emit_others 4 remainder)
 

--- a/ocaml/asmcomp/cmm_helpers.mli
+++ b/ocaml/asmcomp/cmm_helpers.mli
@@ -62,11 +62,20 @@ val boxedintnat_header : nativeint
 val closure_info : arity:Clambda.arity -> startenv:int -> is_last:bool
   -> nativeint
 
+val closure_info' :
+  arity:Lambda.function_kind * 'a list ->
+  startenv:int ->
+  is_last:bool ->
+  nativeint
+
 (** Wrappers *)
 val alloc_infix_header : int -> Debuginfo.t -> expression
 val alloc_closure_info :
-      arity:(Lambda.function_kind * int) -> startenv:int -> is_last:bool ->
-      Debuginfo.t -> expression
+  arity:Clambda.arity ->
+  startenv:int ->
+  is_last:bool ->
+  Debuginfo.t ->
+  expression
 
 (** Integers *)
 

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -401,15 +401,18 @@ let rec transl env e =
             let dbg = f.dbg in
             let without_header =
               match f.arity with
-              | Curried _, (1|0) as arity ->
+              | { function_kind = Curried _ ; params_layout = ([] | [_]) } as arity ->
                 Cconst_symbol (f.label, dbg) ::
                 alloc_closure_info ~arity
                                    ~startenv:(startenv - pos) ~is_last dbg ::
                 transl_fundecls (pos + 3) rem
               | arity ->
-                Cconst_symbol (
-                  curry_function_sym (fst arity)
-                    (List.init (snd arity) (fun _ -> typ_val)) typ_val, dbg) ::
+                Cconst_symbol
+                  (curry_function_sym
+                     arity.function_kind
+                     (List.map machtype_of_layout arity.params_layout)
+                     (machtype_of_layout arity.return_layout),
+                   dbg) ::
                 alloc_closure_info ~arity
                                    ~startenv:(startenv - pos) ~is_last dbg ::
                 Cconst_symbol (f.label, dbg) ::
@@ -430,26 +433,25 @@ let rec transl env e =
       let ptr = transl env arg in
       let dbg = Debuginfo.none in
       ptr_offset ptr offset dbg
-  | Udirect_apply(handler_code_sym, args, Some { name; }, _, dbg) ->
+  | Udirect_apply(handler_code_sym, args, Some { name; }, _, _, dbg) ->
       let args = List.map (transl env) args in
       return_unit dbg
         (Cop(Cprobe { name; handler_code_sym; }, args, dbg))
-  | Udirect_apply(lbl, args, None, kind, dbg) ->
+  | Udirect_apply(lbl, args, None, result_layout, kind, dbg) ->
       let args = List.map (transl env) args in
-      let return = typ_val in
-      direct_apply lbl return args kind dbg
-  | Ugeneric_apply(clos, args, kind, dbg) ->
+      direct_apply lbl (machtype_of_layout result_layout) args kind dbg
+  | Ugeneric_apply(clos, args, args_layout, result_layout, kind, dbg) ->
       let clos = transl env clos in
       let args = List.map (transl env) args in
-      let args_type = List.map (fun _ -> typ_val) args in
-      let return = typ_val in
+      let args_type = List.map machtype_of_layout args_layout in
+      let return = machtype_of_layout result_layout in
       generic_apply (mut_from_env env clos) clos args args_type return kind dbg
-  | Usend(kind, met, obj, args, pos, dbg) ->
+  | Usend(kind, met, obj, args, args_layout, result_layout, pos, dbg) ->
       let met = transl env met in
       let obj = transl env obj in
       let args = List.map (transl env) args in
-      let args_type = List.map (fun _ -> typ_val) args in
-      let return = typ_val in
+      let args_type = List.map machtype_of_layout args_layout in
+      let return = machtype_of_layout result_layout in
       send kind met obj args args_type return pos dbg
   | Ulet(str, kind, id, exp, body) ->
       transl_let env str kind id exp (fun env -> transl env body)
@@ -1432,8 +1434,15 @@ let transl_function f =
     else
       [ Reduce_code_size ]
   in
+  let params_layout =
+    if List.length f.params = List.length f.arity.params_layout then
+      f.arity.params_layout
+    else
+      f.arity.params_layout @ [Lambda.layout_function]
+  in
   Cfunction {fun_name = f.label;
-             fun_args = List.map (fun (id, _) -> (id, typ_val)) f.params;
+             fun_args = List.map2 (fun id ty -> (id, machtype_of_layout ty))
+                 f.params params_layout;
              fun_body = cmm_body;
              fun_codegen_options;
              fun_poll = f.poll;

--- a/ocaml/middle_end/clambda.ml
+++ b/ocaml/middle_end/clambda.ml
@@ -20,7 +20,11 @@ open Asttypes
 open Lambda
 
 type function_label = string
-type arity = Lambda.function_kind * int
+type arity = {
+  function_kind : Lambda.function_kind ;
+  params_layout : Lambda.layout list ;
+  return_layout : Lambda.layout ;
+}
 type apply_kind = Lambda.region_close * Lambda.alloc_mode
 
 type ustructured_constant =
@@ -49,9 +53,9 @@ and ulambda =
     Uvar of Backend_var.t
   | Uconst of uconstant
   | Udirect_apply of
-      function_label * ulambda list * Lambda.probe * apply_kind * Debuginfo.t
+      function_label * ulambda list * Lambda.probe * Lambda.layout * apply_kind * Debuginfo.t
   | Ugeneric_apply of
-      ulambda * ulambda list * apply_kind * Debuginfo.t
+      ulambda * ulambda list * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uclosure of {
       functions : ufunction list ;
       not_scanned_slots : ulambda list ;
@@ -90,7 +94,7 @@ and ulambda =
   | Uassign of Backend_var.t * ulambda
   | Usend of
       meth_kind * ulambda * ulambda * ulambda list
-      * apply_kind * Debuginfo.t
+      * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
   | Utail of ulambda
@@ -98,8 +102,7 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : arity;
-  params : (Backend_var.With_provenance.t * layout) list;
-  return : layout;
+  params : Backend_var.With_provenance.t list;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;

--- a/ocaml/middle_end/clambda.mli
+++ b/ocaml/middle_end/clambda.mli
@@ -20,7 +20,11 @@ open Asttypes
 open Lambda
 
 type function_label = string
-type arity = Lambda.function_kind * int
+type arity = {
+  function_kind : Lambda.function_kind ;
+  params_layout : Lambda.layout list ;
+  return_layout : Lambda.layout ;
+}
 type apply_kind = Lambda.region_close * Lambda.alloc_mode
 
 type ustructured_constant =
@@ -60,9 +64,9 @@ and ulambda =
     Uvar of Backend_var.t
   | Uconst of uconstant
   | Udirect_apply of
-      function_label * ulambda list * Lambda.probe * apply_kind * Debuginfo.t
+      function_label * ulambda list * Lambda.probe * Lambda.layout * apply_kind * Debuginfo.t
   | Ugeneric_apply of
-      ulambda * ulambda list * apply_kind * Debuginfo.t
+      ulambda * ulambda list * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uclosure of {
       functions : ufunction list ;
       not_scanned_slots : ulambda list ;
@@ -101,7 +105,7 @@ and ulambda =
   | Uassign of Backend_var.t * ulambda
   | Usend of
       meth_kind * ulambda * ulambda * ulambda list
-      * apply_kind * Debuginfo.t
+      * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
   | Utail of ulambda
@@ -109,8 +113,7 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : arity;
-  params : (Backend_var.With_provenance.t * layout) list;
-  return : layout;
+  params : Backend_var.With_provenance.t list;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -1533,7 +1533,7 @@ and close_functions { backend; fenv; cenv; mutable_vars; kinds; catch_env } fun_
      does not use its environment parameter is invalidated. *)
   let useless_env = ref initially_closed in
   (* Translate each function definition *)
-  let clos_fundef (id, params, return, body, mode, fundesc, dbg) env_pos =
+  let clos_fundef (id, params, _return, body, mode, fundesc, dbg) env_pos =
     let env_param = V.create_local "env" in
     let cenv_fv =
       add_to_closure_env env_param

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -104,8 +104,8 @@ let occurs_var var u =
   let rec occurs = function
       Uvar v -> v = var
     | Uconst _ -> false
-    | Udirect_apply(_lbl, args, _, _, _) -> List.exists occurs args
-    | Ugeneric_apply(funct, args, _, _) ->
+    | Udirect_apply(_lbl, args, _, _, _, _) -> List.exists occurs args
+    | Ugeneric_apply(funct, args, _, _, _, _) ->
         occurs funct || List.exists occurs args
     | Uclosure { functions = _ ; not_scanned_slots ; scanned_slots } ->
       List.exists occurs not_scanned_slots || List.exists occurs scanned_slots
@@ -131,7 +131,7 @@ let occurs_var var u =
     | Uwhile(cond, body) -> occurs cond || occurs body
     | Ufor(_id, lo, hi, _dir, body) -> occurs lo || occurs hi || occurs body
     | Uassign(id, u) -> id = var || occurs u
-    | Usend(_, met, obj, args, _, _) ->
+    | Usend(_, met, obj, args, _, _, _, _) ->
         occurs met || occurs obj || List.exists occurs args
     | Uunreachable -> false
     | Uregion e -> occurs e
@@ -192,13 +192,13 @@ let lambda_smaller lam threshold =
     match lam with
       Uvar _ -> ()
     | Uconst _ -> incr size
-    | Udirect_apply(_, args, None, _, _) ->
+    | Udirect_apply(_, args, None, _, _, _) ->
         size := !size + 4; lambda_list_size args
     | Udirect_apply _ -> ()
     (* We aim for probe points to not affect inlining decisions.
        Actual cost is either 1, 5 or 6 bytes, depending on their kind,
        on x86-64. *)
-    | Ugeneric_apply(fn, args, _, _) ->
+    | Ugeneric_apply(fn, args, _, _, _, _) ->
         size := !size + 6; lambda_size fn; lambda_list_size args
     | Uclosure _ ->
         raise Exit (* inlining would duplicate function definitions *)
@@ -243,7 +243,7 @@ let lambda_smaller lam threshold =
         size := !size + 4; lambda_size low; lambda_size high; lambda_size body
     | Uassign(_id, lam) ->
         incr size;  lambda_size lam
-    | Usend(_, met, obj, args, _, _) ->
+    | Usend(_, met, obj, args, _, _, _, _) ->
         size := !size + 8;
         lambda_size met; lambda_size obj; lambda_list_size args
     | Uunreachable -> ()
@@ -605,14 +605,15 @@ let rec substitute loc ((backend, fpc) as st) sb rn ulam =
     Uvar v ->
       begin try V.Map.find v sb with Not_found -> ulam end
   | Uconst _ -> ulam
-  | Udirect_apply(lbl, args, probe, kind, dbg) ->
+  | Udirect_apply(lbl, args, probe, return_layout, kind, dbg) ->
       let dbg = subst_debuginfo loc dbg in
       Udirect_apply(lbl, List.map (substitute loc st sb rn) args,
-                    probe, kind, dbg)
-  | Ugeneric_apply(fn, args, kind, dbg) ->
+                    probe, return_layout, kind, dbg)
+  | Ugeneric_apply(fn, args, args_layout, return_layout, kind, dbg) ->
       let dbg = subst_debuginfo loc dbg in
       Ugeneric_apply(substitute loc st sb rn fn,
-                     List.map (substitute loc st sb rn) args, kind, dbg)
+                     List.map (substitute loc st sb rn) args,
+                     args_layout, return_layout, kind, dbg)
   | Uclosure { functions ; not_scanned_slots ; scanned_slots } ->
       (* Question: should we rename function labels as well?  Otherwise,
          there is a risk that function labels are not globally unique.
@@ -752,10 +753,10 @@ let rec substitute loc ((backend, fpc) as st) sb rn ulam =
         with Not_found ->
           id in
       Uassign(id', substitute loc st sb rn u)
-  | Usend(k, u1, u2, ul, pos, dbg) ->
+  | Usend(k, u1, u2, ul, args_layout, result_layout, pos, dbg) ->
       let dbg = subst_debuginfo loc dbg in
       Usend(k, substitute loc st sb rn u1, substitute loc st sb rn u2,
-            List.map (substitute loc st sb rn) ul, pos, dbg)
+            List.map (substitute loc st sb rn) ul, args_layout, result_layout, pos, dbg)
   | Uunreachable ->
       Uunreachable
   | Uregion e ->
@@ -863,7 +864,7 @@ let fail_if_probe ~probe msg =
 
 (* Generate a direct application *)
 
-let direct_apply env fundesc ufunct uargs pos mode ~probe ~loc ~attribute =
+let direct_apply env fundesc ufunct uargs pos result_layout mode ~probe ~loc ~attribute =
   match fundesc.fun_inline, attribute with
   | _, Never_inlined
   | None, _ ->
@@ -881,10 +882,10 @@ let direct_apply env fundesc ufunct uargs pos mode ~probe ~loc ~attribute =
        fail_if_probe ~probe "Erroneously marked to be inlined"
      end;
      if fundesc.fun_closed && is_pure ufunct then
-       Udirect_apply(fundesc.fun_label, uargs, probe, kind, dbg)
+       Udirect_apply(fundesc.fun_label, uargs, probe, result_layout, kind, dbg)
      else if not fundesc.fun_closed &&
                is_substituable ~mutable_vars:env.mutable_vars ufunct then
-       Udirect_apply(fundesc.fun_label, uargs @ [ufunct], probe, kind, dbg)
+       Udirect_apply(fundesc.fun_label, uargs @ [ufunct], probe, result_layout, kind, dbg)
      else begin
        let args = List.map (fun arg ->
          if is_substituable ~mutable_vars:env.mutable_vars arg then
@@ -900,12 +901,12 @@ let direct_apply env fundesc ufunct uargs pos mode ~probe ~loc ~attribute =
          (if fundesc.fun_closed then
             Usequence (ufunct,
                        Udirect_apply (fundesc.fun_label, app_args,
-                                      probe, kind, dbg))
+                                      probe, result_layout, kind, dbg))
           else
             let clos = V.create_local "clos" in
             Ulet(Immutable, Lambda.layout_function, VP.create clos, ufunct,
                  Udirect_apply(fundesc.fun_label, app_args @ [Uvar clos],
-                               probe, kind, dbg)))
+                               probe, result_layout, kind, dbg)))
          args
        end
   | Some(params, body), _  ->
@@ -1023,7 +1024,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
        when fun_arity > nargs *)
   | Lapply{ap_func = funct; ap_args = args; ap_region_close=pos; ap_mode=mode;
            ap_probe = probe; ap_loc = loc;
-           ap_inlined = attribute} ->
+           ap_inlined = attribute; ap_result_layout} ->
       let nargs = List.length args in
       if nargs = 0 && probe = None then
         Misc.fatal_errorf "Closure: 0-ary application at %a"
@@ -1031,28 +1032,34 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
       assert (nargs > 0);
       begin match (close env funct, close_list env args) with
         ((ufunct, Value_closure(_,
-                                ({fun_arity=(Tupled, nparams)} as fundesc),
+                                ({fun_arity={
+                                     function_kind = Tupled ;
+                                     params_layout; _}} as fundesc),
                                 approx_res)),
          [Uprim(P.Pmakeblock _, uargs, _)])
-        when List.length uargs = nparams ->
+        when List.length uargs = List.length params_layout ->
           let app =
             direct_apply env ~loc ~attribute fundesc ufunct uargs
-              pos mode ~probe in
+              pos ap_result_layout mode ~probe in
           (app, strengthen_approx app approx_res)
       | ((ufunct, Value_closure(_,
-                                ({fun_arity=(Curried _, nparams)} as fundesc),
+                                ({fun_arity={
+                                     function_kind = Curried _ ;
+                                     params_layout ; _}} as fundesc),
                                 approx_res)), uargs)
-        when nargs = nparams ->
+        when nargs = List.length params_layout ->
           let app =
             direct_apply env ~loc ~attribute fundesc ufunct uargs
-              pos mode ~probe in
+              pos ap_result_layout mode ~probe in
           (app, strengthen_approx app approx_res)
 
       | ((ufunct, (Value_closure(
             clos_mode,
-            ({fun_arity=(Curried {nlocal}, nparams)} as fundesc),
+            ({fun_arity={ function_kind = Curried {nlocal} ;
+                          params_layout ; _ }} as fundesc),
             _) as fapprox)), uargs)
-          when nargs < nparams ->
+          when nargs < List.length params_layout ->
+        let nparams = List.length params_layout in
         let first_args = List.map (fun arg ->
           (V.create_local "arg", arg) ) uargs in
         (* CR mshinwell: Edit when Lapply has kinds *)
@@ -1125,9 +1132,11 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
         fail_if_probe ~probe "Partial application";
         (new_fun, approx)
 
-      | ((ufunct, Value_closure(_, ({fun_arity = (Curried _, nparams)} as fundesc),
+      | ((ufunct, Value_closure(_, ({fun_arity = {
+          function_kind = Curried _; params_layout ; _}} as fundesc),
                                 _approx_res)), uargs)
-        when nargs > nparams ->
+        when nargs > List.length params_layout ->
+          let nparams = List.length params_layout in
           let args = List.map (fun arg -> V.create_local "arg", arg) uargs in
           (* CR mshinwell: Edit when Lapply has kinds *)
           let kinds =
@@ -1144,9 +1153,12 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           let body =
             Ugeneric_apply(direct_apply { env with kinds } ~loc ~attribute
                               fundesc ufunct first_args
-                              Rc_normal mode'
+                              Rc_normal Lambda.layout_function mode'
                               ~probe,
-                           rem_args, (Rc_normal, mode), dbg)
+                           rem_args,
+                           List.map (fun _ -> Lambda.layout_top) rem_args,
+                           ap_result_layout,
+                           (Rc_normal, mode), dbg)
           in
           let body =
             match mode, fundesc.fun_region with
@@ -1160,6 +1172,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           in
           let result =
             List.fold_left (fun body (id, defining_expr) ->
+                (* CR ncourant: we need to know the layout of defining_expr here, this is hard *)
                 Ulet (Immutable, Lambda.layout_top, VP.create id, defining_expr, body))
               body
               args
@@ -1169,13 +1182,14 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           let dbg = Debuginfo.from_location loc in
           warning_if_forced_inlined ~loc ~attribute "Unknown function";
           fail_if_probe ~probe "Unknown function";
-          (Ugeneric_apply(ufunct, uargs, (pos, mode), dbg), Value_unknown)
+          (Ugeneric_apply(ufunct, uargs, List.map (fun _ -> Lambda.layout_top) uargs, ap_result_layout, (pos, mode), dbg), Value_unknown)
       end
-  | Lsend(kind, met, obj, args, pos, mode, loc, _result_layout) ->
+  | Lsend(kind, met, obj, args, pos, mode, loc, result_layout) ->
       let (umet, _) = close env met in
       let (uobj, _) = close env obj in
       let dbg = Debuginfo.from_location loc in
-      (Usend(kind, umet, uobj, close_list env args, (pos,mode), dbg),
+      let args_layout = List.map (fun _ -> Lambda.layout_top) args in
+      (Usend(kind, umet, uobj, close_list env args, args_layout, result_layout, (pos,mode), dbg),
        Value_unknown)
   | Llet(str, kind, id, lam, body) ->
       let (ulam, alam) = close_named env id lam in
@@ -1269,7 +1283,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
       in
       let arg, _approx = close env arg in
       let id = Ident.create_local "dummy" in
-      Ulet(Immutable, Lambda.layout_top, VP.create id, arg, cst), approx
+      Ulet(Immutable, Lambda.layout_unit, VP.create id, arg, cst), approx
   | Lprim(Pignore, [arg], _loc) ->
       let expr, approx = make_const_int 0 in
       Usequence(fst (close env arg), expr), approx
@@ -1474,10 +1488,13 @@ and close_functions { backend; fenv; cenv; mutable_vars; kinds; catch_env } fun_
               |> Symbol.linkage_name
               |> Linkage_name.to_string
             in
-            let arity = List.length params in
             let fundesc =
               {fun_label = label;
-               fun_arity = (kind, arity);
+               fun_arity = {
+                 function_kind = kind ;
+                 params_layout = List.map snd params ;
+                 return_layout = return
+               };
                fun_closed = initially_closed;
                fun_inline = None;
                fun_float_const_prop = !Clflags.float_const_prop;
@@ -1506,7 +1523,9 @@ and close_functions { backend; fenv; cenv; mutable_vars; kinds; catch_env } fun_
       (fun (_id, _params, _return, _body, _mode, fundesc, _dbg) ->
         let pos = !env_pos + 1 in
         env_pos := !env_pos + 1 +
-          (match fundesc.fun_arity with (Curried _, (0|1)) -> 2 | _ -> 3);
+          (match fundesc.fun_arity with
+            | { function_kind = Curried _; params_layout = ([] | [_]); _} -> 2
+            | _ -> 3);
         pos)
       uncurried_defs in
   let fv_pos = !env_pos in
@@ -1556,8 +1575,7 @@ and close_functions { backend; fenv; cenv; mutable_vars; kinds; catch_env } fun_
       {
         label  = fundesc.fun_label;
         arity  = fundesc.fun_arity;
-        params = List.map (fun (var, kind) -> VP.create var, kind) fun_params;
-        return;
+        params = List.map (fun (var, _) -> VP.create var) fun_params;
         body   = ubody;
         dbg;
         env = Some env_param;
@@ -1713,8 +1731,8 @@ let collect_exported_structured_constants a =
   and ulam = function
     | Uvar _ -> ()
     | Uconst c -> const c
-    | Udirect_apply (_, ul, _, _, _) -> List.iter ulam ul
-    | Ugeneric_apply (u, ul, _, _) -> ulam u; List.iter ulam ul
+    | Udirect_apply (_, ul, _, _, _, _) -> List.iter ulam ul
+    | Ugeneric_apply (u, ul, _, _, _, _) -> ulam u; List.iter ulam ul
     | Uclosure { functions ; not_scanned_slots ; scanned_slots } ->
         List.iter (fun f -> ulam f.body) functions;
         List.iter ulam not_scanned_slots;
@@ -1740,7 +1758,7 @@ let collect_exported_structured_constants a =
     | Uifthenelse (u1, u2, u3, _)
     | Ufor (_, u1, u2, _, u3) -> ulam u1; ulam u2; ulam u3
     | Uassign (_, u) -> ulam u
-    | Usend (_, u1, u2, ul, _, _) -> ulam u1; ulam u2; List.iter ulam ul
+    | Usend (_, u1, u2, ul, _, _, _, _) -> ulam u1; ulam u2; List.iter ulam ul
     | Uunreachable -> ()
     | Uregion u -> ulam u
     | Utail u -> ulam u

--- a/ocaml/middle_end/printclambda.ml
+++ b/ocaml/middle_end/printclambda.ml
@@ -86,7 +86,8 @@ and one_fun ppf f =
           VP.print param Printlambda.layout Lambda.layout_function
       | param :: params, layout :: layouts ->
         fprintf ppf "@ %a%a"
-          VP.print param Printlambda.layout layout
+          VP.print param Printlambda.layout layout;
+        iter params layouts
       | _ -> Misc.fatal_error "arity inconsistent with params"
     in
     iter f.params f.arity.params_layout

--- a/ocaml/middle_end/printclambda.ml
+++ b/ocaml/middle_end/printclambda.ml
@@ -78,15 +78,22 @@ let rec structured_constant ppf = function
 
 and one_fun ppf f =
   let idents ppf =
-    List.iter
-      (fun (x, k) ->
-         fprintf ppf "@ %a%a"
-           VP.print x
-           Printlambda.layout k
-      )
+    let rec iter params layouts =
+      match params, layouts with
+      | [], [] -> ()
+      | [param], [] ->
+        fprintf ppf "@ %a%a"
+          VP.print param Printlambda.layout Lambda.layout_function
+      | param :: params, layout :: layouts ->
+        fprintf ppf "@ %a%a"
+          VP.print param Printlambda.layout layout
+      | _ -> Misc.fatal_error "arity inconsistent with params"
+    in
+    iter f.params f.arity.params_layout
   in
-  fprintf ppf "(fun@ %s%s@ %d@ @[<2>%a@]@ @[<2>%a@])"
-    f.label (layout f.return) (snd f.arity) idents f.params lam f.body
+  fprintf ppf "(fun@ %s%s@ %d@ @[<2>%t@]@ @[<2>%a@])"
+    f.label (layout f.arity.return_layout) (List.length f.arity.params_layout)
+    idents lam f.body
 
 and phantom_defining_expr ppf = function
   | Uphantom_const const -> uconstant ppf const
@@ -124,7 +131,7 @@ and lam ppf = function
   | Uvar id ->
       V.print ppf id
   | Uconst c -> uconstant ppf c
-  | Udirect_apply(f, largs, probe, kind, _) ->
+  | Udirect_apply(f, largs, probe, _, kind, _) ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       let pr ppf (probe : Lambda.probe) =
@@ -133,7 +140,7 @@ and lam ppf = function
         | Some {name} -> fprintf ppf " (probe %s)" name
       in
       fprintf ppf "@[<2>(%a*@ %s %a%a)@]" apply_kind kind f lams largs pr probe
-  | Ugeneric_apply(lfun, largs, kind, _) ->
+  | Ugeneric_apply(lfun, largs, _, _, kind, _) ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       fprintf ppf "@[<2>(%a@ %a%a)@]" apply_kind kind lam lfun lams largs
@@ -256,7 +263,7 @@ and lam ppf = function
        lam hi lam body
   | Uassign(id, expr) ->
       fprintf ppf "@[<2>(assign@ %a@ %a)@]" V.print id lam expr
-  | Usend (k, met, obj, largs, (pos,_) , _) ->
+  | Usend (k, met, obj, largs, _, _, (pos,_) , _) ->
       let form =
         match pos with
         | Rc_normal | Rc_nontail -> "send"
@@ -290,10 +297,11 @@ let rec approx ppf = function
     Value_closure(_, fundesc, a) ->
       Format.fprintf ppf "@[<2>function %s"
         fundesc.fun_label;
-      begin match fundesc.fun_arity with
-      | Tupled, n -> Format.fprintf ppf "@ arity -%i" n
-      | Curried {nlocal=0}, n -> Format.fprintf ppf "@ arity %i" n
-      | Curried {nlocal=k}, n -> Format.fprintf ppf "@ arity %i(%i L)" n k
+      let n = List.length fundesc.fun_arity.params_layout in
+      begin match fundesc.fun_arity.function_kind with
+      | Tupled -> Format.fprintf ppf "@ arity -%i" n
+      | Curried {nlocal=0} -> Format.fprintf ppf "@ arity %i" n
+      | Curried {nlocal=k} -> Format.fprintf ppf "@ arity %i(%i L)" n k
       end;
       if fundesc.fun_closed then begin
         Format.fprintf ppf "@ (closed)"


### PR DESCRIPTION
These were split off #1104.
These changes the `arity` type of Clambda to include the type of the arguments and of the return value of the function, as well as adding the types of arguments and return to `Ugeneric_apply` and `Usend`.