### PR TITLE
Improve propagation of Cmm machtypes in To_cmm

### DIFF
--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1984,6 +1984,29 @@ module Without_args = struct
     | Binary prim -> effects_and_coeffects_of_binary_primitive prim
     | Ternary prim -> effects_and_coeffects_of_ternary_primitive prim
     | Variadic prim -> effects_and_coeffects_of_variadic_primitive prim
+
+  let args_kind (t : t) ~args =
+    match t with
+    | Nullary _ -> []
+    | Unary prim -> [arg_kind_of_unary_primitive prim]
+    | Binary prim ->
+      let kind1, kind2 = args_kind_of_binary_primitive prim in
+      [kind1; kind2]
+    | Ternary prim ->
+      let kind1, kind2, kind3 = args_kind_of_ternary_primitive prim in
+      [kind1; kind2; kind3]
+    | Variadic prim -> (
+      match args_kind_of_variadic_primitive prim with
+      | Variadic kinds -> kinds
+      | Variadic_all_of_kind kind -> List.map (fun _ -> kind) args)
+
+  let result_kind (t : t) =
+    match t with
+    | Nullary prim -> result_kind_of_nullary_primitive' prim
+    | Unary prim -> result_kind_of_unary_primitive' prim
+    | Binary prim -> result_kind_of_binary_primitive' prim
+    | Ternary prim -> result_kind_of_ternary_primitive' prim
+    | Variadic prim -> result_kind_of_variadic_primitive' prim
 end
 
 let is_begin_or_end_region t =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -388,6 +388,10 @@ module Without_args : sig
   (** Describe the effects and coeffects that the application of the given
       primitive may have. *)
   val effects_and_coeffects : t -> Effects_and_coeffects.t
+
+  val args_kind : t -> args:_ list -> Flambda_kind.t list
+
+  val result_kind : t -> Flambda_kind.t
 end
 
 (** A description of the kind of values which a unary primitive expects as its

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -96,7 +96,7 @@ let unit0 ~offsets flambda_unit ~all_code =
   (* See comment in [To_cmm_set_of_closures] about binding [my_region] *)
   let env, _bound_var =
     Env.create_bound_parameter env
-      (Flambda_unit.toplevel_my_region flambda_unit)
+      (Flambda_unit.toplevel_my_region flambda_unit, [| Cmm.Int |])
   in
   let r = R.create ~module_symbol:(Flambda_unit.module_symbol flambda_unit) in
   let body, res = To_cmm_expr.expr env r (Flambda_unit.body flambda_unit) in

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -103,11 +103,13 @@ val exported_offsets : t -> Exported_offsets.t
     the new environment and the created variable. Will produce a fatal error if
     the given variable is already bound. *)
 val create_bound_parameter :
-  t -> Variable.t -> t * Backend_var.With_provenance.t
+  t -> Variable.t * Cmm.machtype -> t * Backend_var.With_provenance.t
 
 (** Same as {!create_variable} but for a list of variables. *)
 val create_bound_parameters :
-  t -> Variable.t list -> t * Backend_var.With_provenance.t list
+  t ->
+  (Variable.t * Cmm.machtype) list ->
+  t * Backend_var.With_provenance.t list
 
 (** {2 Delayed let-bindings}
 
@@ -206,6 +208,7 @@ val bind_variable_to_primitive :
   Variable.t ->
   inline:'a inline ->
   defining_expr:'a bound_expr ->
+  machtype_of_defining_expr:Cmm.machtype ->
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
   t * To_cmm_result.t
 
@@ -217,6 +220,7 @@ val bind_variable :
   To_cmm_result.t ->
   Variable.t ->
   defining_expr:Cmm.expression ->
+  machtype_of_defining_expr:Cmm.machtype ->
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
   t * To_cmm_result.t
@@ -227,7 +231,7 @@ val inline_variable :
   t ->
   To_cmm_result.t ->
   Variable.t ->
-  Cmm.expression * t * To_cmm_result.t * Effects_and_coeffects.t
+  Cmm.expression * Cmm.machtype * t * To_cmm_result.t * Effects_and_coeffects.t
 
 type flush_mode =
   | Entering_loop

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -555,7 +555,7 @@ let unary_primitive env res dbg f arg =
     ( None,
       res,
       C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:false
-        ~ty_args:[C.exttype_of_kind K.naked_int64]
+        ~ty_args:[To_cmm_utils.exttype_of_kind K.naked_int64]
         "caml_int64_float_of_bits_unboxed" Cmm.typ_float [arg] )
   | Unbox_number kind -> None, res, unbox_number ~dbg kind arg
   | Untag_immediate -> Some (Env.Untag arg), res, C.untag_int arg dbg
@@ -659,7 +659,10 @@ let variadic_primitive _env dbg f args =
   | Make_array (kind, _mut, alloc_mode) -> make_array ~dbg kind alloc_mode args
 
 let arg ?consider_inlining_effectful_expressions ~dbg env res simple =
-  C.simple ?consider_inlining_effectful_expressions ~dbg env res simple
+  let e, env, res, eff =
+    C.simple ?consider_inlining_effectful_expressions ~dbg env res simple
+  in
+  e, env, res, eff
 
 let arg_list ?consider_inlining_effectful_expressions ~dbg env res l =
   let aux (list, env, res, effs) x =

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -16,10 +16,6 @@
     this module, unlike the ones in [Cmm_helpers], depend on Flambda 2 data
     types. *)
 
-val exttype_of_kind : Flambda_kind.t -> Cmm.exttype
-
-val machtype_of_kind : Flambda_kind.t -> Cmm.machtype_component array
-
 val machtype_of_kinded_parameter :
   Bound_parameter.t -> Cmm.machtype_component array
 
@@ -40,7 +36,11 @@ val name :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Name.t ->
-  Cmm.expression * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
+  Cmm.expression
+  * Cmm.machtype
+  * To_cmm_env.t
+  * To_cmm_result.t
+  * Effects_and_coeffects.t
 
 val const : dbg:Debuginfo.t -> Reg_width_const.t -> Cmm.expression
 
@@ -55,6 +55,18 @@ val simple :
   Simple.t ->
   Cmm.expression * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
 
+val simple_with_machtype :
+  ?consider_inlining_effectful_expressions:bool ->
+  dbg:Debuginfo.t ->
+  To_cmm_env.t ->
+  To_cmm_result.t ->
+  Simple.t ->
+  Cmm.expression
+  * Cmm.machtype
+  * To_cmm_env.t
+  * To_cmm_result.t
+  * Effects_and_coeffects.t
+
 val simple_static :
   Simple.t -> [`Data of Cmm.data_item list | `Var of Variable.t]
 
@@ -67,6 +79,17 @@ val simple_list :
   To_cmm_result.t ->
   Simple.t list ->
   Cmm.expression list * To_cmm_env.t * To_cmm_result.t * Effects_and_coeffects.t
+
+val simple_with_machtype_list :
+  ?consider_inlining_effectful_expressions:bool ->
+  dbg:Debuginfo.t ->
+  To_cmm_env.t ->
+  To_cmm_result.t ->
+  Simple.t list ->
+  (Cmm.expression * Cmm.machtype) list
+  * To_cmm_env.t
+  * To_cmm_result.t
+  * Effects_and_coeffects.t
 
 val bound_parameters :
   To_cmm_env.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_utils.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_utils.ml
@@ -1,0 +1,43 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                        Guillaume Bury, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2019--2022 OCamlPro SAS                                    *)
+(*   Copyright 2022 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+let typ_region = Cmm.typ_int
+
+(* The following two functions are here instead of [To_cmm_shared] to avoid a
+   circularity. They can't go in [Flambda_kind] as that module does not depend
+   on the backend. *)
+
+let exttype_of_kind (k : Flambda_kind.t) : Cmm.exttype =
+  match k with
+  | Value -> XInt
+  | Naked_number Naked_float -> XFloat
+  | Naked_number Naked_int64 -> XInt64
+  | Naked_number Naked_int32 -> XInt32
+  | Naked_number (Naked_immediate | Naked_nativeint) -> (
+    match Targetint_32_64.num_bits with
+    | Thirty_two -> XInt32
+    | Sixty_four -> XInt64)
+  | Region -> Misc.fatal_error "[Region] kind not expected here"
+  | Rec_info -> Misc.fatal_error "[Rec_info] kind not expected here"
+
+let machtype_of_kind (k : Flambda_kind.t) =
+  match k with
+  | Value -> Cmm.typ_val
+  | Naked_number Naked_float -> Cmm.typ_float
+  | Naked_number Naked_int64 -> Cmm_helpers.typ_int64
+  | Naked_number (Naked_immediate | Naked_int32 | Naked_nativeint) ->
+    Cmm.typ_int
+  | Region -> (* See comments elsewhere about these bindings. *) typ_region
+  | Rec_info -> assert false

--- a/middle_end/flambda2/to_cmm/to_cmm_utils.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_utils.mli
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                        Guillaume Bury, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2019--2022 OCamlPro SAS                                    *)
+(*   Copyright 2022 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val typ_region : Cmm.machtype
+
+val exttype_of_kind : Flambda_kind.t -> Cmm.exttype
+
+val machtype_of_kind : Flambda_kind.t -> Cmm.machtype


### PR DESCRIPTION
This patch brings Cmm `machtype`s for arguments of applications to the correct places in `To_cmm_expr.simplify_apply0` where they will be needed for functions like `C.indirect_call` (so that e.g. the correct `caml_apply` functions can be selected).  A separate PR will make the change to the relevant `Cmm_helpers` functions themselves.

@Gbury has already reviewed a first version of this patch.