### PR TITLE
Propagation of kinds in Lambda -> Flambda2 translation

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -900,7 +900,8 @@ let close_exact_or_unknown_apply acc env
        probe;
        mode;
        region_close;
-       region
+       region;
+       return = _;
      } :
       IR.apply) callee_approx ~replace_region : Expr_with_acc.t =
   let callee = find_simple_from_id env func in

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -45,7 +45,7 @@ val close_let_cont :
   Env.t ->
   name:Continuation.t ->
   is_exn_handler:bool ->
-  params:(Ident.t * IR.user_visible * Lambda.layout) list ->
+  params:(Ident.t * IR.user_visible * Flambda_kind.With_subkind.t) list ->
   recursive:Asttypes.rec_flag ->
   handler:(Acc.t -> Env.t -> Expr_with_acc.t) ->
   body:(Acc.t -> Env.t -> Expr_with_acc.t) ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -63,7 +63,8 @@ module IR = struct
       inlined : Lambda.inlined_attribute;
       probe : Lambda.probe;
       mode : Lambda.alloc_mode;
-      region : Ident.t
+      region : Ident.t;
+      return : Lambda.layout;
     }
 
   type switch =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -21,7 +21,7 @@ module IR = struct
 
   type exn_continuation =
     { exn_handler : Continuation.t;
-      extra_args : (simple * Lambda.layout) list
+      extra_args : (simple * Flambda_kind.With_subkind.t) list
     }
 
   type trap_action =
@@ -64,7 +64,7 @@ module IR = struct
       probe : Lambda.probe;
       mode : Lambda.alloc_mode;
       region : Ident.t;
-      return : Lambda.layout;
+      return : Flambda_kind.With_subkind.t;
     }
 
   type switch =
@@ -615,8 +615,8 @@ module Function_decls = struct
       { let_rec_ident : Ident.t;
         function_slot : Function_slot.t;
         kind : Lambda.function_kind;
-        params : (Ident.t * Lambda.layout) list;
-        return : Lambda.layout;
+        params : (Ident.t * Flambda_kind.With_subkind.t) list;
+        return : Flambda_kind.With_subkind.t;
         return_continuation : Continuation.t;
         exn_continuation : IR.exn_continuation;
         my_region : Ident.t;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -23,7 +23,7 @@ module IR : sig
 
   type exn_continuation =
     { exn_handler : Continuation.t;
-      extra_args : (simple * Lambda.layout) list
+      extra_args : (simple * Flambda_kind.With_subkind.t) list
     }
 
   type trap_action =
@@ -68,7 +68,7 @@ module IR : sig
       probe : Lambda.probe;
       mode : Lambda.alloc_mode;
       region : Ident.t;
-      return : Lambda.layout;
+      return : Flambda_kind.With_subkind.t;
     }
 
   type switch =
@@ -291,8 +291,8 @@ module Function_decls : sig
       let_rec_ident:Ident.t option ->
       function_slot:Function_slot.t ->
       kind:Lambda.function_kind ->
-      params:(Ident.t * Lambda.layout) list ->
-      return:Lambda.layout ->
+      params:(Ident.t * Flambda_kind.With_subkind.t) list ->
+      return:Flambda_kind.With_subkind.t ->
       return_continuation:Continuation.t ->
       exn_continuation:IR.exn_continuation ->
       my_region:Ident.t ->
@@ -312,9 +312,9 @@ module Function_decls : sig
 
     val kind : t -> Lambda.function_kind
 
-    val params : t -> (Ident.t * Lambda.layout) list
+    val params : t -> (Ident.t * Flambda_kind.With_subkind.t) list
 
-    val return : t -> Lambda.layout
+    val return : t -> Flambda_kind.With_subkind.t
 
     val return_continuation : t -> Continuation.t
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -67,7 +67,8 @@ module IR : sig
       inlined : Lambda.inlined_attribute;
       probe : Lambda.probe;
       mode : Lambda.alloc_mode;
-      region : Ident.t
+      region : Ident.t;
+      return : Lambda.layout;
     }
 
   type switch =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -457,7 +457,7 @@ let extra_args_for_exn_continuation env exn_handler =
   let more_extra_args =
     Env.extra_args_for_continuation_with_kinds env exn_handler
   in
-  List.map (fun (arg, kind) : (IR.simple * _) -> Var arg, kind) more_extra_args
+  List.map (fun (arg, kind) : (IR.simple * _) -> Var arg, Flambda_kind.With_subkind.from_lambda kind) more_extra_args
 
 let _print_stack ppf stack =
   Format.fprintf ppf "%a"
@@ -761,8 +761,9 @@ let let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler
   let { Env.body_env; handler_env; extra_params } =
     Env.add_continuation env cont ~push_to_try_stack:is_exn_handler Nonrecursive
   in
+  let params = List.map (fun (id, visible, kind) -> (id, visible, Flambda_kind.With_subkind.from_lambda kind)) params in
   let extra_params =
-    List.map (fun (id, kind) -> id, IR.User_visible, kind) extra_params
+    List.map (fun (id, kind) -> id, IR.User_visible, Flambda_kind.With_subkind.from_lambda kind) extra_params
   in
   let handler acc ccenv = handler acc handler_env ccenv in
   let body acc ccenv = body acc body_env ccenv cont in
@@ -1246,7 +1247,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         in
         let params =
           List.map
-            (fun (arg, kind) -> arg, IR.User_visible, kind)
+            (fun (arg, kind) -> arg, IR.User_visible, Flambda_kind.With_subkind.from_lambda kind)
             (args @ extra_params)
         in
         let handler acc ccenv =
@@ -1282,7 +1283,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                         probe = None;
                         mode;
                         region = Env.current_region env;
-                        return = Lambda.layout_top;
+                        return = Flambda_kind.With_subkind.from_lambda Lambda.layout_top;
                       }
                     in
                     wrap_return_continuation acc env ccenv apply))
@@ -1482,7 +1483,7 @@ and cps_tail_apply acc env ccenv ap_func ap_args ap_region_close ap_mode ap_loc
               probe = ap_probe;
               mode = ap_mode;
               region = Env.current_region env;
-              return = ap_return;
+              return = Flambda_kind.With_subkind.from_lambda ap_return;
             }
           in
           wrap_return_continuation acc env ccenv apply)
@@ -1612,6 +1613,8 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     let ccenv = CCenv.set_path_to_root ccenv loc in
     cps_tail acc new_env ccenv body body_cont body_exn_cont
   in
+  let params = List.map (fun (param, kind) -> param, Flambda_kind.With_subkind.from_lambda kind) params in
+  let return = Flambda_kind.With_subkind.from_lambda return in
   Function_decl.create ~let_rec_ident:(Some fid) ~function_slot ~kind ~params
     ~return ~return_continuation:body_cont ~exn_continuation ~my_region ~body
     ~attr ~loc ~free_idents_of_body recursive ~closure_alloc_mode:mode


### PR DESCRIPTION
This makes sure we propagate kinds correctly inside `closure_conversion` and `closure_conversion_aux`.