### PR TITLE
Propagates layouts through Flambda1

### DIFF
--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -168,3 +168,5 @@ and raise_kind = Lambda.raise_kind =
   | Raise_notrace
 
 let equal (x: primitive) (y: primitive) = x = y
+
+let result_layout _p = Lambda.layout_any_value

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -171,3 +171,5 @@ and raise_kind = Lambda.raise_kind =
   | Raise_notrace
 
 val equal : primitive -> primitive -> bool
+
+val result_layout : primitive -> Lambda.layout

--- a/middle_end/flambda/augment_specialised_args.ml
+++ b/middle_end/flambda/augment_specialised_args.ml
@@ -470,6 +470,7 @@ module Make (T : S) = struct
           args =
             (Parameter.List.vars wrapper_params) @
             spec_args_bound_in_the_wrapper;
+          result_layout = function_decl.return_layout;
           kind = Direct (Closure_id.wrap new_fun_var);
           dbg = Debuginfo.none;
           reg_close = Rc_normal;

--- a/middle_end/flambda/augment_specialised_args.ml
+++ b/middle_end/flambda/augment_specialised_args.ml
@@ -544,6 +544,7 @@ module Make (T : S) = struct
     let new_function_decl =
       Flambda.create_function_declaration
         ~params:wrapper_params
+        ~return_layout:function_decl.return_layout
         ~alloc_mode
         ~region:function_decl.region
         ~body:wrapper_body
@@ -651,6 +652,7 @@ module Make (T : S) = struct
       let rewritten_function_decl =
         Flambda.create_function_declaration
           ~params:all_params
+          ~return_layout:function_decl.return_layout
           ~alloc_mode:function_decl.alloc_mode
           ~region:function_decl.region
           ~body:function_decl.body

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -531,7 +531,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       List.map (fun (ident, kind) ->
           (Variable.create_with_same_name_as_ident ident, kind)) ids
     in
-    Static_catch (st_exn, List.map fst vars, close t env body,
+    Static_catch (st_exn, vars, close t env body,
       close t (Env.add_vars env (List.map fst ids) vars) handler, kind)
   | Ltrywith (body, id, handler, kind) ->
     let var = Variable.create_with_same_name_as_ident id in

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -41,10 +41,10 @@ let add_default_argument_wrappers lam =
     match lam with
     | Llet (( Strict | Alias | StrictOpt), _k, id,
         Lfunction {kind; params; body = fbody; attr; loc;
-                   mode; region}, body) ->
+                   mode; region; return }, body) ->
       begin match
         Simplif.split_default_wrapper ~id ~kind ~params
-          ~body:fbody ~return:Lambda.layout_top ~attr ~loc ~mode ~region
+          ~body:fbody ~return ~attr ~loc ~mode ~region
       with
       | [fun_id, def] -> Llet (Alias, Lambda.layout_function, fun_id, def, body)
       | [fun_id, def; inner_fun_id, def_inner] ->
@@ -59,9 +59,9 @@ let add_default_argument_wrappers lam =
             (List.map
                (function
                  | (id, Lambda.Lfunction {kind; params; body; attr; loc;
-                                          mode; region}) ->
+                                          mode; region; return }) ->
                    Simplif.split_default_wrapper ~id ~kind ~params ~body
-                     ~return:Lambda.layout_top ~attr ~loc ~mode ~region
+                     ~return ~attr ~loc ~mode ~region
                  | _ -> assert false)
                defs)
         in
@@ -265,7 +265,8 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
   | Lletrec (defs, body) ->
     let env =
       List.fold_right (fun (id,  _) env ->
-          Env.add_var env id (Variable.create_with_same_name_as_ident id) Lambda.layout_top)
+          Env.add_var env id (Variable.create_with_same_name_as_ident id)
+            Lambda.layout_letrec)
         defs env
     in
     let function_declarations =

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -82,6 +82,7 @@ let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
     Apply ({
         func = unboxed_version;
         args = params;
+        result_layout = return_layout;
         (* CR-someday mshinwell for mshinwell: investigate if there is some
            redundancy here (func is also unboxed_version) *)
         kind = Direct (Closure_id.wrap unboxed_version);
@@ -239,7 +240,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     in
     Flambda.create_let set_of_closures_var set_of_closures
       (name_expr (Project_closure (project_closure)) ~name)
-  | Lapply { ap_func; ap_args; ap_loc; ap_region_close; ap_mode;
+  | Lapply { ap_func; ap_args; ap_loc; ap_region_close; ap_mode; ap_result_layout;
              ap_tailcall = _; ap_inlined; ap_specialised; ap_probe; } ->
     Lift_code.lifting_helper (close_list t env ap_args)
       ~evaluation_order:`Right_to_left
@@ -251,6 +252,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
           (Apply ({
               func = func_var;
               args;
+              result_layout = ap_result_layout;
               kind = Indirect;
               dbg = Debuginfo.from_location ap_loc;
               reg_close = ap_region_close;

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -331,7 +331,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       in
       Let_rec (defs, close t env body)
     end
-  | Lsend (kind, meth, obj, args, reg_close, mode, loc, _layout) ->
+  | Lsend (kind, meth, obj, args, reg_close, mode, loc, result_layout) ->
     let meth_var = Variable.create Names.meth in
     let obj_var = Variable.create Names.obj in
     let dbg = Debuginfo.from_location loc in
@@ -342,7 +342,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
           ~name:Names.send_arg
           ~create_body:(fun args ->
               Send { kind; meth = meth_var; obj = obj_var; args;
-                     dbg; reg_close; mode })))
+                     dbg; reg_close; mode; result_layout })))
   | Lprim ((Pdivint Safe | Pmodint Safe
            | Pdivbint { is_safe = Safe } | Pmodbint { is_safe = Safe }) as prim,
            [arg1; arg2], loc)

--- a/middle_end/flambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/closure_conversion_aux.ml
@@ -93,6 +93,7 @@ module Function_decls = struct
       mode : Lambda.alloc_mode;
       region : bool;
       params : (Ident.t * Lambda.layout) list;
+      return_layout : Lambda.layout;
       body : Lambda.lambda;
       free_idents_of_body : Ident.Set.t;
       attr : Lambda.function_attribute;
@@ -100,7 +101,7 @@ module Function_decls = struct
     }
 
     let create ~let_rec_ident ~closure_bound_var ~kind ~mode ~region
-          ~params ~body ~attr ~loc =
+          ~params ~return_layout ~body ~attr ~loc =
       let let_rec_ident =
         match let_rec_ident with
         | None -> Ident.create_local "unnamed_function"
@@ -112,6 +113,7 @@ module Function_decls = struct
         mode;
         region;
         params;
+        return_layout;
         body;
         free_idents_of_body = Lambda.free_variables body;
         attr;
@@ -124,6 +126,7 @@ module Function_decls = struct
     let mode t = t.mode
     let region t = t.region
     let params t = t.params
+    let return_layout t = t.return_layout
     let body t = t.body
     let free_idents t = t.free_idents_of_body
     let inline t = t.attr.inline

--- a/middle_end/flambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/closure_conversion_aux.mli
@@ -61,6 +61,7 @@ module Function_decls : sig
       -> mode:Lambda.alloc_mode
       -> region:bool
       -> params:(Ident.t * Lambda.layout) list
+      -> return_layout:Lambda.layout
       -> body:Lambda.lambda
       -> attr:Lambda.function_attribute
       -> loc:Lambda.scoped_location
@@ -72,6 +73,7 @@ module Function_decls : sig
     val mode : t -> Lambda.alloc_mode
     val region : t -> bool
     val params : t -> (Ident.t * Lambda.layout) list
+    val return_layout : t -> Lambda.layout
     val body : t -> Lambda.lambda
     val inline : t -> Lambda.inline_attribute
     val specialise : t -> Lambda.specialise_attribute

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -76,7 +76,7 @@ type t =
   | String_switch of Variable.t * (string * t) list * t option
                      * Lambda.layout
   | Static_raise of Static_exception.t * Variable.t list
-  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.layout
+  | Static_catch of Static_exception.t * ( Variable.t * Lambda.layout ) list * t * t * Lambda.layout
   | Try_with of t * Variable.t * t * Lambda.layout
   | While of t * t
   | For of for_loop
@@ -338,7 +338,7 @@ let rec lam ppf (flam : t) =
            | [] -> ()
            | _ ->
                List.iter
-                 (fun x -> fprintf ppf " %a" Variable.print x)
+                 (fun (x, _layout) -> fprintf ppf " %a" Variable.print x)
                  vars)
         vars
         lam lhandler
@@ -608,7 +608,7 @@ let rec variables_usage ?ignore_uses_as_callee ?ignore_uses_as_argument
       | Static_raise (_, es) ->
         List.iter free_variable es
       | Static_catch (_, vars, e1, e2, _) ->
-        List.iter bound_variable vars;
+        List.iter (fun (var, _layout) -> bound_variable var) vars;
         aux e1;
         aux e2
       | Try_with (e1, var, e2, _kind) ->

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -28,6 +28,7 @@ type const =
 type apply = {
   func : Variable.t;
   args : Variable.t list;
+  result_layout : Lambda.layout;
   kind : call_kind;
   dbg : Debuginfo.t;
   reg_close : Lambda.region_close;

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -129,6 +129,7 @@ and function_declarations = {
 and function_declaration = {
   closure_origin: Closure_origin.t;
   params : Parameter.t list;
+  return_layout : Lambda.layout;
   alloc_mode : Lambda.alloc_mode;
   region : bool;
   body : t;
@@ -1042,6 +1043,7 @@ let update_body_of_function_declaration (func_decl: function_declaration)
       ~body : function_declaration =
   { closure_origin = func_decl.closure_origin;
     params = func_decl.params;
+    return_layout = func_decl.return_layout;
     alloc_mode = func_decl.alloc_mode;
     region = func_decl.region;
     body;
@@ -1065,6 +1067,7 @@ let rec check_param_modes mode = function
      check_param_modes m params
 
 let create_function_declaration ~params ~alloc_mode ~region ~body ~stub
+      ~(return_layout : Lambda.layout)
       ~(inline : Lambda.inline_attribute)
       ~(specialise : Lambda.specialise_attribute)
       ~(check : Lambda.check_attribute)
@@ -1093,6 +1096,7 @@ let create_function_declaration ~params ~alloc_mode ~region ~body ~stub
   check_param_modes alloc_mode params;
   { closure_origin;
     params;
+    return_layout;
     alloc_mode;
     region;
     body;

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -51,6 +51,7 @@ type send = {
   dbg : Debuginfo.t;
   reg_close : Lambda.region_close;
   mode : Lambda.alloc_mode;
+  result_layout : Lambda.layout;
 }
 
 type project_closure = Projection.project_closure

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -213,7 +213,7 @@ let rec lam ppf (flam : t) =
   match flam with
   | Var (id) ->
       Variable.print ppf id
-  | Apply({func; args; kind; inlined; probe; dbg}) ->
+  | Apply({func; args; kind; inlined; probe; dbg; result_layout}) ->
     let direct ppf () =
       match kind with
       | Indirect -> ()
@@ -232,8 +232,9 @@ let rec lam ppf (flam : t) =
       | None -> ()
       | Some {name} -> fprintf ppf "<probe %s>" name
     in
-    fprintf ppf "@[<2>(apply%a%a%a<%s>@ %a%a)@]" direct () inlined () probe ()
+    fprintf ppf "@[<2>(apply%a%a%a<%s>%a@ %a%a)@]" direct () inlined () probe ()
       (Debuginfo.to_string dbg)
+      Printlambda.layout result_layout
       Variable.print func Variable.print_list args
   | Assign { being_assigned; new_value; } ->
     fprintf ppf "@[<2>(assign@ %a@ %a)@]"

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -313,6 +313,7 @@ and function_declarations = private {
 and function_declaration = private {
   closure_origin: Closure_origin.t;
   params : Parameter.t list;
+  return_layout : Lambda.layout;
   alloc_mode : Lambda.alloc_mode;
   region : bool;
   body : t;
@@ -570,6 +571,7 @@ val create_function_declaration
   -> region:bool
   -> body:t
   -> stub:bool
+  -> return_layout:Lambda.layout
   -> inline:Lambda.inline_attribute
   -> specialise:Lambda.specialise_attribute
   -> check:Lambda.check_attribute

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -112,7 +112,7 @@ type t =
                      * Lambda.layout
   (** Restrictions on [Lambda.Lstringswitch] also apply to [String_switch]. *)
   | Static_raise of Static_exception.t * Variable.t list
-  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.layout
+  | Static_catch of Static_exception.t * ( Variable.t * Lambda.layout ) list * t * t * Lambda.layout
   | Try_with of t * Variable.t * t * Lambda.layout
   | While of t * t
   | For of for_loop

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -36,6 +36,7 @@ type apply = {
      lhs_of_application -> callee *)
   func : Variable.t;
   args : Variable.t list;
+  result_layout : Lambda.layout;
   kind : call_kind;
   dbg : Debuginfo.t;
   reg_close : Lambda.region_close;

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -67,6 +67,7 @@ type send = {
   dbg : Debuginfo.t;
   reg_close : Lambda.region_close;
   mode : Lambda.alloc_mode;
+  result_layout : Lambda.layout;
 }
 
 (** For details on these types, see projection.mli. *)

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -190,14 +190,15 @@ let variable_and_symbol_invariants (program : Flambda.program) =
     | Var var -> check_variable_is_bound env var
     | Apply { func; args; kind; dbg; inlined; specialise; probe;
               reg_close = (Rc_close_at_apply|Rc_normal|Rc_nontail);
-              mode = (Alloc_heap|Alloc_local) } ->
+              mode = (Alloc_heap|Alloc_local); result_layout } ->
       check_variable_is_bound env func;
       check_variables_are_bound env args;
       ignore_call_kind kind;
       ignore_debuginfo dbg;
       ignore_inlined_attribute inlined;
       ignore_specialise_attribute specialise;
-      ignore_probe probe
+      ignore_probe probe;
+      ignore result_layout
     | Assign { being_assigned; new_value; } ->
       check_mutable_variable_is_bound env being_assigned;
       check_variable_is_bound env new_value

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -566,7 +566,7 @@ let used_closure_ids (program:Flambda.program) =
     | Move_within_set_of_closures { closure = _; start_from; move_to; } ->
       used := Closure_id.Set.add start_from !used;
       used := Closure_id.Set.add move_to !used
-    | Project_var { closure = _; closure_id; var = _ } ->
+    | Project_var { closure = _; closure_id; var = _; kind = _ } ->
       used := Closure_id.Set.add closure_id !used
     | Set_of_closures _ | Symbol _ | Const _ | Allocated_const _
     | Prim _ | Expr _ | Read_mutable _ | Read_symbol_field _ -> ()
@@ -580,7 +580,7 @@ let used_vars_within_closures (flam:Flambda.program) =
   let used = ref Var_within_closure.Set.empty in
   let f (flam : Flambda.named) =
     match flam with
-    | Project_var { closure = _; closure_id = _; var; } ->
+    | Project_var { closure = _; closure_id = _; var; kind = _ } ->
       used := Var_within_closure.Set.add var !used
     | _ -> ()
   in

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -204,12 +204,13 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       check_variable_is_bound env new_value
     | Send { kind; meth; obj; args; dbg;
              reg_close = (Rc_normal | Rc_close_at_apply | Rc_nontail);
-             mode = (Alloc_heap | Alloc_local) } ->
+             mode = (Alloc_heap | Alloc_local); result_layout; } ->
       ignore_meth_kind kind;
       check_variable_is_bound env meth;
       check_variable_is_bound env obj;
       check_variables_are_bound env args;
-      ignore_debuginfo dbg
+      ignore_debuginfo dbg;
+      ignore_layout result_layout
     | If_then_else (cond, ifso, ifnot, kind) ->
       check_variable_is_bound env cond;
       ignore_layout kind;

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -181,7 +181,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       ignore_static_exception static_exn;
       ignore_layout kind;
       loop env body;
-      loop (add_binding_occurrences env vars) handler
+      loop (add_binding_occurrences env (List.map fst vars)) handler
     | Try_with (body, var, handler, kind) ->
       loop env body;
       ignore_layout kind;

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -198,7 +198,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       ignore_inlined_attribute inlined;
       ignore_specialise_attribute specialise;
       ignore_probe probe;
-      ignore result_layout
+      ignore_layout result_layout
     | Assign { being_assigned; new_value; } ->
       check_mutable_variable_is_bound env being_assigned;
       check_variable_is_bound env new_value
@@ -263,10 +263,11 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       check_variable_is_bound env closure;
       ignore_closure_id start_from;
       ignore_closure_id move_to;
-    | Project_var { closure; closure_id; var; } ->
+    | Project_var { closure; closure_id; var; kind } ->
       check_variable_is_bound env closure;
       ignore_closure_id closure_id;
-      ignore_var_within_closure var
+      ignore_var_within_closure var;
+      ignore_layout kind
     | Prim (prim, args, dbg) ->
       ignore_primitive prim;
       check_variables_are_bound env args;

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -489,7 +489,7 @@ and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda * Lambd
            (Flambda.Expr (Var set_of_closures)))
         (get_fun_offset t closure_id))
       named,
-    Lambda.layout_any_value
+    Lambda.layout_function
   | Move_within_set_of_closures { closure; start_from; move_to } ->
     let closure_expr, _layout_closure = subst_var env closure in
     check_closure t (build_uoffset
@@ -497,7 +497,7 @@ and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda * Lambd
          (Flambda.Expr (Var closure)))
       ((get_fun_offset t move_to) - (get_fun_offset t start_from)))
       named,
-    Lambda.layout_any_value
+    Lambda.layout_function
   | Project_var { closure; var; closure_id; kind } ->
     let ulam, _closure_layout = subst_var env closure in
     let fun_offset = get_fun_offset t closure_id in
@@ -511,7 +511,7 @@ and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda * Lambd
   | Prim (Pfield index, [block], dbg) ->
     let block, _block_layout = subst_var env block in
     Uprim (Pfield index, [check_field t block index None], dbg),
-    Lambda.layout_any_value
+    Lambda.layout_field
   | Prim (Psetfield (index, maybe_ptr, init), [block; new_value], dbg) ->
     let block, _block_layout = subst_var env block in
     let new_value, _new_value_layout = subst_var env new_value in

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -367,7 +367,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
     let env_handler, ids =
       List.fold_right (fun (var, layout) (env, ids) ->
           let id, env = Env.add_fresh_ident env var layout in
-          env, (VP.create id, Lambda.layout_top) :: ids)
+          env, (VP.create id, layout) :: ids)
         vars (env, [])
     in
     let body, body_layout = to_clambda t env body in

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -423,8 +423,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
     assert(Lambda.compatible_layout id_layout new_value_layout);
     Uassign (id, new_value),
     Lambda.layout_unit
-  | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
-    let result_layout = assert false in
+  | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
     let args, args_layout = List.split (subst_vars env args) in
     let meth, _meth_layout = subst_var env meth in
     let obj, _obj_layout = subst_var env obj in

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -283,7 +283,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
        For an indirect call, we do not need to do anything here; Cmmgen will
        do the equivalent of the previous paragraph when it generates a direct
        call to [caml_apply]. *)
-    to_clambda_direct_apply t func args direct_func probe dbg reg_close mode env,
+    to_clambda_direct_apply t func args direct_func probe dbg reg_close mode result_layout env,
     result_layout
   | Apply { func; args; kind = Indirect; probe = None; dbg; reg_close; mode; result_layout } ->
     let callee, callee_layout = subst_var env func in
@@ -573,7 +573,7 @@ and to_clambda_switch t env cases num_keys default kind =
   | [| |] -> [| |], [| |]  (* May happen when [default] is [None]. *)
   | _ -> index, actions
 
-and to_clambda_direct_apply t func args direct_func probe dbg pos mode env
+and to_clambda_direct_apply t func args direct_func probe dbg pos mode result_layout env
   : Clambda.ulambda =
   let closed = is_function_constant t direct_func in
   let label =
@@ -591,7 +591,6 @@ and to_clambda_direct_apply t func args direct_func probe dbg pos mode env
       assert(Lambda.compatible_layout func_layout Lambda.layout_function);
       uargs @ [func]
   in
-  let result_layout = Lambda.layout_top in
   Udirect_apply (label, uargs, probe, result_layout, (pos, mode), dbg)
 
 (* Describe how to build a runtime closure block that corresponds to the

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -499,17 +499,16 @@ and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda * Lambd
       ((get_fun_offset t move_to) - (get_fun_offset t start_from)))
       named,
     Lambda.layout_any_value
-  | Project_var { closure; var; closure_id } ->
+  | Project_var { closure; var; closure_id; kind } ->
     let ulam, _closure_layout = subst_var env closure in
     let fun_offset = get_fun_offset t closure_id in
     let var_offset = get_fv_offset t var in
     let pos = var_offset - fun_offset in
-    let result_layout = assert false in
     Uprim (Pfield pos,
       [check_field t (check_closure t ulam (Expr (Var closure)))
          pos (Some named)],
       Debuginfo.none),
-    result_layout
+    kind
   | Prim (Pfield index, [block], dbg) ->
     let block, _block_layout = subst_var env block in
     Uprim (Pfield index, [check_field t block index None], dbg),

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -102,7 +102,7 @@ let clambda_arity (func : Flambda.function_declaration) : Clambda.arity =
   {
     function_kind = Curried {nlocal} ;
     params_layout = List.map Parameter.kind func.params ;
-    return_layout = Lambda.layout_top ; (* Need func.return *)
+    return_layout = func.return_layout ;
   }
 
 let check_field t ulam pos named_opt : Clambda.ulambda =

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -131,14 +131,14 @@ module Env : sig
 
   val empty : t
 
-  val add_subst : t -> Variable.t -> Clambda.ulambda -> t
-  val find_subst_exn : t -> Variable.t -> Clambda.ulambda
+  val add_subst : t -> Variable.t -> Clambda.ulambda -> Lambda.layout -> t
+  val find_subst_exn : t -> Variable.t -> Clambda.ulambda * Lambda.layout
 
-  val add_fresh_ident : t -> Variable.t -> V.t * t
-  val ident_for_var_exn : t -> Variable.t -> V.t
+  val add_fresh_ident : t -> Variable.t -> Lambda.layout -> V.t * t
+  val ident_for_var_exn : t -> Variable.t -> V.t * Lambda.layout
 
-  val add_fresh_mutable_ident : t -> Mutable_variable.t -> V.t * t
-  val ident_for_mutable_var_exn : t -> Mutable_variable.t -> V.t
+  val add_fresh_mutable_ident : t -> Mutable_variable.t -> Lambda.layout -> V.t * t
+  val ident_for_mutable_var_exn : t -> Mutable_variable.t -> V.t * Lambda.layout
 
   val add_allocated_const : t -> Symbol.t -> Allocated_const.t -> t
   val allocated_const_for_symbol : t -> Symbol.t -> Allocated_const.t option
@@ -146,9 +146,9 @@ module Env : sig
   val keep_only_symbols : t -> t
 end = struct
   type t =
-    { subst : Clambda.ulambda Variable.Map.t;
-      var : V.t Variable.Map.t;
-      mutable_var : V.t Mutable_variable.Map.t;
+    { subst : (Clambda.ulambda * Lambda.layout) Variable.Map.t;
+      var : (V.t * Lambda.layout) Variable.Map.t;
+      mutable_var : (V.t * Lambda.layout) Mutable_variable.Map.t;
       allocated_constant_for_symbol : Allocated_const.t Symbol.Map.t;
     }
 
@@ -159,23 +159,25 @@ end = struct
       allocated_constant_for_symbol = Symbol.Map.empty;
     }
 
-  let add_subst t id subst =
-    { t with subst = Variable.Map.add id subst t.subst }
+  let add_subst t id subst layout =
+    { t with subst = Variable.Map.add id (subst, layout) t.subst }
 
   let find_subst_exn t id = Variable.Map.find id t.subst
 
   let ident_for_var_exn t id = Variable.Map.find id t.var
 
-  let add_fresh_ident t var =
+  let add_fresh_ident t var layout =
     let id = V.create_local (Variable.name var) in
-    id, { t with var = Variable.Map.add var id t.var }
+    id, { t with var = Variable.Map.add var (id, layout) t.var }
 
   let ident_for_mutable_var_exn t mut_var =
     Mutable_variable.Map.find mut_var t.mutable_var
 
-  let add_fresh_mutable_ident t mut_var =
+  let add_fresh_mutable_ident t mut_var layout =
     let id = V.create_local (Mutable_variable.name mut_var) in
-    let mutable_var = Mutable_variable.Map.add mut_var id t.mutable_var in
+    let mutable_var =
+      Mutable_variable.Map.add mut_var (id, layout) t.mutable_var
+    in
     id, { t with mutable_var; }
 
   let add_allocated_const t sym cons =
@@ -195,10 +197,12 @@ end = struct
     }
 end
 
-let subst_var env var : Clambda.ulambda =
+let subst_var env var : Clambda.ulambda * Lambda.layout =
   try Env.find_subst_exn env var
   with Not_found ->
-    try Uvar (Env.ident_for_var_exn env var)
+    try
+      let v, layout = Env.ident_for_var_exn env var in
+      Uvar v, layout
     with Not_found ->
       Misc.fatal_errorf "Flambda_to_clambda: unbound variable %a@."
         Variable.print var
@@ -240,33 +244,38 @@ let to_clambda_const env (const : Flambda.constant_defining_value_block_field)
   | Const (Int i) -> Uconst_int i
   | Const (Char c) -> Uconst_int (Char.code c)
 
-let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
+let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
   match flam with
   | Var var -> subst_var env var
   | Let { var; defining_expr; body; _ } ->
-    (* TODO: synthesize proper layout *)
-    let id, env_body = Env.add_fresh_ident env var in
-    Ulet (Immutable, Lambda.layout_top, VP.create id,
-      to_clambda_named t env var defining_expr,
-      to_clambda t env_body body)
+    let defining_expr, defining_expr_layout = to_clambda_named t env var defining_expr in
+    let id, env_body = Env.add_fresh_ident env var defining_expr_layout in
+    let body, body_layout = to_clambda t env_body body in
+    Ulet (Immutable, defining_expr_layout, VP.create id, defining_expr, body),
+    body_layout
   | Let_mutable { var = mut_var; initial_value = var; body; contents_kind } ->
-    let id, env_body = Env.add_fresh_mutable_ident env mut_var in
-    let def = subst_var env var in
-    Ulet (Mutable, contents_kind, VP.create id, def, to_clambda t env_body body)
+    let id, env_body = Env.add_fresh_mutable_ident env mut_var contents_kind in
+    let def, def_layout = subst_var env var in
+    assert(Lambda.compatible_layout def_layout contents_kind);
+    let body, body_layout = to_clambda t env_body body in
+    Ulet (Mutable, contents_kind, VP.create id, def, body), body_layout
   | Let_rec (defs, body) ->
     let env, defs =
       List.fold_right (fun (var, def) (env, defs) ->
-          let id, env = Env.add_fresh_ident env var in
+          let id, env = Env.add_fresh_ident env var Lambda.layout_letrec in
           env, (id, var, def) :: defs)
         defs (env, [])
     in
     let defs =
       List.map (fun (id, var, def) ->
-          VP.create id, to_clambda_named t env var def)
+          let def, def_layout = to_clambda_named t env var def in
+          assert(Lambda.compatible_layout def_layout Lambda.layout_letrec);
+          VP.create id, def)
         defs
     in
-    Uletrec (defs, to_clambda t env body)
-  | Apply { func; args; kind = Direct direct_func; probe; dbg; reg_close; mode} ->
+    let body, body_layout = to_clambda t env body in
+    Uletrec (defs, body), body_layout
+  | Apply { func; args; kind = Direct direct_func; probe; dbg; reg_close; mode; result_layout } ->
     (* The closure _parameter_ of the function is added by cmmgen.
        At the call site, for a direct call, the closure argument must be
        explicitly added (by [to_clambda_direct_apply]); there is no special
@@ -274,29 +283,35 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
        For an indirect call, we do not need to do anything here; Cmmgen will
        do the equivalent of the previous paragraph when it generates a direct
        call to [caml_apply]. *)
-    to_clambda_direct_apply t func args direct_func probe dbg reg_close mode env
+    to_clambda_direct_apply t func args direct_func probe dbg reg_close mode env,
+    result_layout
   | Apply { func; args; kind = Indirect; probe = None; dbg; reg_close; mode; result_layout } ->
-    let callee = subst_var env func in
-    let args_layout = assert false in
+    let callee, callee_layout = subst_var env func in
+    assert(Lambda.compatible_layout callee_layout Lambda.layout_function);
+    let args, args_layout = List.split (subst_vars env args) in
     Ugeneric_apply (check_closure t callee (Flambda.Expr (Var func)),
-      subst_vars env args, args_layout, result_layout, (reg_close, mode), dbg)
+      args, args_layout, result_layout, (reg_close, mode), dbg),
+    result_layout
   | Apply { probe = Some {name}; _ } ->
     Misc.fatal_errorf "Cannot apply indirect handler for probe %s" name ()
   | Switch (arg, sw) ->
-    let aux () : Clambda.ulambda =
+    let aux () : Clambda.ulambda * Lambda.layout =
       let const_index, const_actions =
-        to_clambda_switch t env sw.consts sw.numconsts sw.failaction
+        to_clambda_switch t env sw.consts sw.numconsts sw.failaction sw.kind
       in
       let block_index, block_actions =
-        to_clambda_switch t env sw.blocks sw.numblocks sw.failaction
+        to_clambda_switch t env sw.blocks sw.numblocks sw.failaction sw.kind
       in
-      Uswitch (subst_var env arg,
+      let arg, arg_layout = subst_var env arg in
+      assert(Lambda.compatible_layout arg_layout Lambda.layout_any_value);
+      Uswitch (arg,
         { us_index_consts = const_index;
           us_actions_consts = const_actions;
           us_index_blocks = block_index;
           us_actions_blocks = block_actions;
         },
-        Debuginfo.none, sw.kind)  (* debug info will be added by GPR#855 *)
+        Debuginfo.none, sw.kind),  (* debug info will be added by GPR#855 *)
+      sw.kind
     in
     (* Check that the [failaction] may be duplicated.  If this is not the
        case, share it through a static raise / static catch. *)
@@ -320,130 +335,209 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
       to_clambda t env expr
     end
   | String_switch (arg, sw, def, kind) ->
-    let arg = subst_var env arg in
-    let sw = List.map (fun (s, e) -> s, to_clambda t env e) sw in
-    let def = Option.map (to_clambda t env) def in
-    Ustringswitch (arg, sw, def, kind)
+    let arg, arg_layout = subst_var env arg in
+    assert(Lambda.compatible_layout arg_layout Lambda.layout_string);
+    let sw =
+      List.map (fun (s, e) ->
+          let e, layout = to_clambda t env e in
+          assert(Lambda.compatible_layout layout kind);
+          s, e
+        ) sw
+    in
+    let def =
+      Option.map (fun e ->
+          let e, layout = to_clambda t env e in
+          assert(Lambda.compatible_layout layout kind);
+          e
+        ) def
+    in
+    Ustringswitch (arg, sw, def, kind), kind
   | Static_raise (static_exn, args) ->
-    Ustaticfail (Static_exception.to_int static_exn,
-      List.map (subst_var env) args)
+    (* CR pchambart: there probably should be an assertion that the
+       layouts matches the static_catch ones *)
+    let args =
+      List.map (fun arg ->
+          let arg, _layout = subst_var env arg in
+          arg
+        ) args
+    in
+    Ustaticfail (Static_exception.to_int static_exn, args),
+    Lambda.layout_bottom
   | Static_catch (static_exn, vars, body, handler, kind) ->
     let env_handler, ids =
-      List.fold_right (fun var (env, ids) ->
-          let id, env = Env.add_fresh_ident env var in
+      List.fold_right (fun (var, layout) (env, ids) ->
+          let id, env = Env.add_fresh_ident env var layout in
           env, (VP.create id, Lambda.layout_top) :: ids)
         vars (env, [])
     in
+    let body, body_layout = to_clambda t env body in
+    let handler, handler_layout = to_clambda t env_handler handler in
+    assert(Lambda.compatible_layout body_layout kind);
+    assert(Lambda.compatible_layout handler_layout kind);
     Ucatch (Static_exception.to_int static_exn, ids,
-      to_clambda t env body, to_clambda t env_handler handler, kind)
+      body, handler, kind),
+    kind
   | Try_with (body, var, handler, kind) ->
-    let id, env_handler = Env.add_fresh_ident env var in
-    Utrywith (to_clambda t env body, VP.create id,
-      to_clambda t env_handler handler, kind)
+    let id, env_handler = Env.add_fresh_ident env var Lambda.layout_exception in
+    let body, body_layout = to_clambda t env body in
+    let handler, handler_layout = to_clambda t env_handler handler in
+    assert(Lambda.compatible_layout body_layout kind);
+    assert(Lambda.compatible_layout handler_layout kind);
+    Utrywith (body, VP.create id, handler, kind),
+    kind
   | If_then_else (arg, ifso, ifnot, kind) ->
-    Uifthenelse (subst_var env arg, to_clambda t env ifso,
-      to_clambda t env ifnot, kind)
+    let arg, arg_layout = subst_var env arg in
+    let ifso, ifso_layout = to_clambda t env ifso in
+    let ifnot, ifnot_layout = to_clambda t env ifnot in
+    assert(Lambda.compatible_layout arg_layout Lambda.layout_any_value);
+    assert(Lambda.compatible_layout ifso_layout kind);
+    assert(Lambda.compatible_layout ifnot_layout kind);
+    Uifthenelse (arg, ifso, ifnot, kind),
+    kind
   | While (cond, body) ->
-    Uwhile (to_clambda t env cond, to_clambda t env body)
+    let cond, cond_layout = to_clambda t env cond in
+    let body, body_layout = to_clambda t env body in
+    assert(Lambda.compatible_layout cond_layout Lambda.layout_any_value);
+    assert(Lambda.compatible_layout body_layout Lambda.layout_unit);
+    Uwhile (cond, body),
+    Lambda.layout_unit
   | For { bound_var; from_value; to_value; direction; body } ->
-    let id, env_body = Env.add_fresh_ident env bound_var in
-    Ufor (VP.create id, subst_var env from_value, subst_var env to_value,
-      direction, to_clambda t env_body body)
+    let id, env_body = Env.add_fresh_ident env bound_var Lambda.layout_int in
+    let from_value, from_value_layout = subst_var env from_value in
+    let to_value, to_value_layout = subst_var env to_value in
+    let body, body_layout = to_clambda t env_body body in
+    assert(Lambda.compatible_layout from_value_layout Lambda.layout_int);
+    assert(Lambda.compatible_layout to_value_layout Lambda.layout_int);
+    assert(Lambda.compatible_layout body_layout Lambda.layout_unit);
+    Ufor (VP.create id, from_value, to_value, direction, body),
+    Lambda.layout_unit
   | Assign { being_assigned; new_value } ->
-    let id =
+    let id, id_layout =
       try Env.ident_for_mutable_var_exn env being_assigned
       with Not_found ->
         Misc.fatal_errorf "Unbound mutable variable %a in [Assign]: %a"
           Mutable_variable.print being_assigned
           Flambda.print flam
     in
-    Uassign (id, subst_var env new_value)
+    let new_value, new_value_layout = subst_var env new_value in
+    assert(Lambda.compatible_layout id_layout new_value_layout);
+    Uassign (id, new_value),
+    Lambda.layout_unit
   | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
-    let args_layout = List.map (fun _ -> Lambda.layout_top) args in
-    let result_layout = Lambda.layout_top in
-    Usend (kind, subst_var env meth, subst_var env obj,
-      subst_vars env args, args_layout, result_layout, (reg_close,mode), dbg)
+    let result_layout = assert false in
+    let args, args_layout = List.split (subst_vars env args) in
+    let meth, _meth_layout = subst_var env meth in
+    let obj, _obj_layout = subst_var env obj in
+    Usend (kind, meth, obj,
+      args, args_layout, result_layout, (reg_close,mode), dbg),
+    result_layout
   | Region body ->
-      let body = to_clambda t env body in
+      let body, body_layout = to_clambda t env body in
       let is_trivial =
         match body with
         | Uvar _ | Uconst _ -> true
         | _ -> false
       in
-      if is_trivial then body
-      else Uregion body
+      if is_trivial then body, body_layout
+      else Uregion body, body_layout
   | Tail body ->
-      let body = to_clambda t env body in
+      let body, body_layout = to_clambda t env body in
       let is_trivial =
         match body with
         | Uvar _ | Uconst _ -> true
         | _ -> false
       in
-      if is_trivial then body
-      else Utail body
-  | Proved_unreachable -> Uunreachable
+      if is_trivial then body, body_layout
+      else Utail body, body_layout
+  | Proved_unreachable -> Uunreachable, Lambda.layout_bottom
 
-and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda =
+and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda * Lambda.layout =
   match named with
-  | Symbol sym -> to_clambda_symbol env sym
-  | Const (Int n) -> Uconst (Uconst_int n)
-  | Const (Char c) -> Uconst (Uconst_int (Char.code c))
+  | Symbol sym -> to_clambda_symbol env sym, Lambda.layout_any_value
+  | Const (Int n) -> Uconst (Uconst_int n), Lambda.layout_int
+  | Const (Char c) -> Uconst (Uconst_int (Char.code c)), Lambda.layout_int
   | Allocated_const _ ->
     Misc.fatal_errorf "[Allocated_const] should have been lifted to a \
         [Let_symbol] construction before [Flambda_to_clambda]: %a = %a"
       Variable.print var
       Flambda.print_named named
   | Read_mutable mut_var ->
-    begin try Uvar (Env.ident_for_mutable_var_exn env mut_var)
+    begin try
+      let mut_var, layout = Env.ident_for_mutable_var_exn env mut_var in
+      Uvar mut_var, layout
     with Not_found ->
       Misc.fatal_errorf "Unbound mutable variable %a in [Read_mutable]: %a"
         Mutable_variable.print mut_var
         Flambda.print_named named
     end
   | Read_symbol_field (symbol, field) ->
-    Uprim (Pfield field, [to_clambda_symbol env symbol], Debuginfo.none)
+    Uprim (Pfield field, [to_clambda_symbol env symbol], Debuginfo.none),
+    Lambda.layout_any_value
   | Set_of_closures set_of_closures ->
-    to_clambda_set_of_closures t env set_of_closures
+    to_clambda_set_of_closures t env set_of_closures,
+    Lambda.layout_any_value
   | Project_closure { set_of_closures; closure_id } ->
     (* Note that we must use [build_uoffset] to ensure that we do not generate
        a [Uoffset] construction in the event that the offset is zero, otherwise
        we might break pattern matches in Cmmgen (in particular for the
        compilation of "let rec"). *)
+    let set_of_closures_expr, _layout_set_of_closures =
+      subst_var env set_of_closures
+    in
     check_closure t (
       build_uoffset
-        (check_closure t (subst_var env set_of_closures)
+        (check_closure t set_of_closures_expr
            (Flambda.Expr (Var set_of_closures)))
         (get_fun_offset t closure_id))
-      named
+      named,
+    Lambda.layout_any_value
   | Move_within_set_of_closures { closure; start_from; move_to } ->
+    let closure_expr, _layout_closure = subst_var env closure in
     check_closure t (build_uoffset
-      (check_closure t (subst_var env closure)
+      (check_closure t closure_expr
          (Flambda.Expr (Var closure)))
       ((get_fun_offset t move_to) - (get_fun_offset t start_from)))
-      named
+      named,
+    Lambda.layout_any_value
   | Project_var { closure; var; closure_id } ->
-    let ulam = subst_var env closure in
+    let ulam, _closure_layout = subst_var env closure in
     let fun_offset = get_fun_offset t closure_id in
     let var_offset = get_fv_offset t var in
     let pos = var_offset - fun_offset in
+    let result_layout = assert false in
     Uprim (Pfield pos,
       [check_field t (check_closure t ulam (Expr (Var closure)))
          pos (Some named)],
-      Debuginfo.none)
+      Debuginfo.none),
+    result_layout
   | Prim (Pfield index, [block], dbg) ->
-    Uprim (Pfield index, [check_field t (subst_var env block) index None], dbg)
+    let block, _block_layout = subst_var env block in
+    Uprim (Pfield index, [check_field t block index None], dbg),
+    Lambda.layout_any_value
   | Prim (Psetfield (index, maybe_ptr, init), [block; new_value], dbg) ->
+    let block, _block_layout = subst_var env block in
+    let new_value, _new_value_layout = subst_var env new_value in
     Uprim (Psetfield (index, maybe_ptr, init), [
-        check_field t (subst_var env block) index None;
-        subst_var env new_value;
-      ], dbg)
+        check_field t block index None;
+        new_value;
+      ], dbg),
+    Lambda.layout_unit
   | Prim (Popaque, args, dbg) ->
-    Uprim (Popaque, subst_vars env args, dbg)
+    let arg = match args with
+      | [arg] -> arg
+      | [] | _ :: _ :: _ -> assert false
+    in
+    let arg, arg_layout = subst_var env arg in
+    Uprim (Popaque, [arg], dbg),
+    arg_layout
   | Prim (p, args, dbg) ->
-    Uprim (p, subst_vars env args, dbg)
+    let args, _args_layout = List.split (subst_vars env args) in
+    let result_layout = Clambda_primitives.result_layout p in
+    Uprim (p, args, dbg),
+    result_layout
   | Expr expr -> to_clambda t env expr
 
-and to_clambda_switch t env cases num_keys default =
+and to_clambda_switch t env cases num_keys default kind =
   let num_keys =
     if Numbers.Int.Set.cardinal num_keys = 0 then 0
     else Numbers.Int.Set.max_elt num_keys + 1
@@ -470,7 +564,13 @@ and to_clambda_switch t env cases num_keys default =
          if act >= 0 then action := act else index.(i) <- !action)
       index
   end;
-  let actions = Array.map (to_clambda t env) (store.act_get ()) in
+  let actions =
+    Array.map (fun action ->
+        let action, action_layout = to_clambda t env action in
+        assert(Lambda.compatible_layout action_layout kind);
+        action
+      ) (store.act_get ())
+  in
   match actions with
   | [| |] -> [| |], [| |]  (* May happen when [default] is [None]. *)
   | _ -> index, actions
@@ -484,11 +584,14 @@ and to_clambda_direct_apply t func args direct_func probe dbg pos mode env
     |> Linkage_name.to_string
   in
   let uargs =
-    let uargs = subst_vars env args in
+    let uargs, _uargs_layout = List.split (subst_vars env args) in
     (* Remove the closure argument if the closure is closed.  (Note that the
        closure argument is always a variable, so we can be sure we are not
        dropping any side effects.) *)
-    if closed then uargs else uargs @ [subst_var env func]
+    if closed then uargs else
+      let func, func_layout = subst_var env func in
+      assert(Lambda.compatible_layout func_layout Lambda.layout_function);
+      uargs @ [func]
   in
   let result_layout = Lambda.layout_top in
   Udirect_apply (label, uargs, probe, result_layout, (pos, mode), dbg)
@@ -537,7 +640,7 @@ and to_clambda_set_of_closures t env
       let env = Env.keep_only_symbols env in
       (* Add the Clambda expressions for the free variables of the function
          to the environment. *)
-      let add_env_free_variable id _ env =
+      let add_env_free_variable id (spec_to : Flambda.specialised_to) env =
         let var_offset =
           try
             Var_within_closure.Map.find
@@ -551,6 +654,7 @@ and to_clambda_set_of_closures t env
         let pos = var_offset - fun_offset in
         Env.add_subst env id
           (Uprim (Pfield pos, [Clambda.Uvar env_var], Debuginfo.none))
+          spec_to.kind
       in
       let env = Variable.Map.fold add_env_free_variable free_vars env in
       (* Add the Clambda expressions for all functions defined in the current
@@ -563,13 +667,16 @@ and to_clambda_set_of_closures t env
             t.current_unit.fun_offset_table
         in
         let exp : Clambda.ulambda = Uoffset (Uvar env_var, offset - pos) in
-        Env.add_subst env id exp
+        Env.add_subst env id exp Lambda.layout_function
       in
       List.fold_left (add_env_function fun_offset) env all_functions
     in
     let env_body, params =
-      List.fold_right (fun var (env, params) ->
-          let id, env = Env.add_fresh_ident env (Parameter.var var) in
+      List.fold_right (fun param (env, params) ->
+          let id, env =
+            Env.add_fresh_ident env
+              (Parameter.var param) (Parameter.kind param)
+          in
           env, VP.create id :: params)
         function_decl.params (env, [])
     in
@@ -578,10 +685,11 @@ and to_clambda_set_of_closures t env
       |> Symbol.linkage_name
       |> Linkage_name.to_string
     in
+    let body, _body_layout = to_clambda t env_body function_decl.body in
     { label;
       arity = clambda_arity function_decl;
       params = params @ [VP.create env_var];
-      body = to_clambda t env_body function_decl.body;
+      body;
       dbg = function_decl.dbg;
       env = Some env_var;
       poll = function_decl.poll;
@@ -601,7 +709,10 @@ and to_clambda_set_of_closures t env
     List.map snd (
       Variable.Map.bindings (Variable.Map.map (
           fun (free_var : Flambda.specialised_to) ->
-            subst_var env free_var.var) free_vars))
+            let var, var_layout = subst_var env free_var.var in
+            assert(Lambda.compatible_layout var_layout free_var.kind);
+            var
+        ) free_vars))
   in
   Uclosure {
     functions ;
@@ -623,19 +734,24 @@ and to_clambda_closed_set_of_closures t env symbol
       List.fold_left (fun env (var, _) ->
           let closure_id = Closure_id.wrap var in
           let symbol = Symbol_utils.Flambda.for_closure closure_id in
-          Env.add_subst env var (to_clambda_symbol env symbol))
+          Env.add_subst env var (to_clambda_symbol env symbol)
+            Lambda.layout_function)
         (Env.keep_only_symbols env)
         functions
     in
     let env_body, params =
-      List.fold_right (fun var (env, params) ->
-          let id, env = Env.add_fresh_ident env (Parameter.var var) in
+      List.fold_right (fun param (env, params) ->
+          let id, env =
+            Env.add_fresh_ident env
+              (Parameter.var param) (Parameter.kind param)
+          in
           env, VP.create id :: params)
         function_decl.params (env, [])
     in
     let body =
-      Un_anf.apply ~ppf_dump:t.ppf_dump ~what:symbol
-        (to_clambda t env_body function_decl.body)
+      let body, body_layout = to_clambda t env_body function_decl.body in
+      assert(Lambda.compatible_layout body_layout function_decl.return_layout);
+      Un_anf.apply ~ppf_dump:t.ppf_dump ~what:symbol body
     in
     assert (
       Option.equal (fun dbg1 dbg2 -> Debuginfo.compare dbg1 dbg2 = 0)
@@ -662,7 +778,11 @@ and to_clambda_closed_set_of_closures t env symbol
 
 let to_clambda_initialize_symbol t env symbol fields : Clambda.ulambda =
   let fields =
-    List.map (fun (index, expr) -> index, to_clambda t env expr) fields
+    List.map (fun (index, expr) ->
+        let expr, expr_layout = to_clambda t env expr in
+        assert(Lambda.compatible_layout expr_layout Lambda.layout_any_value);
+        index, expr
+      ) fields
   in
   let build_setfield (index, field) : Clambda.ulambda =
     (* Note that this will never cause a write barrier hit, owing to
@@ -760,7 +880,7 @@ let to_clambda_program t env constants (program : Flambda.program) =
       let e2, constants, preallocated_blocks = loop env constants program in
       Usequence (e1, e2), constants, preallocated_block :: preallocated_blocks
     | Effect (expr, program) ->
-      let e1 = to_clambda t env expr in
+      let e1, _e1_layout = to_clambda t env expr in
       let e2, constants, preallocated_blocks = loop env constants program in
       Usequence (e1, e2), constants, preallocated_blocks
     | End _ ->

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -275,10 +275,9 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
        do the equivalent of the previous paragraph when it generates a direct
        call to [caml_apply]. *)
     to_clambda_direct_apply t func args direct_func probe dbg reg_close mode env
-  | Apply { func; args; kind = Indirect; probe = None; dbg; reg_close; mode } ->
+  | Apply { func; args; kind = Indirect; probe = None; dbg; reg_close; mode; result_layout } ->
     let callee = subst_var env func in
-    let args_layout = List.map (fun _ -> Lambda.layout_top) args in
-    let result_layout = Lambda.layout_top in
+    let args_layout = assert false in
     Ugeneric_apply (check_closure t callee (Flambda.Expr (Var func)),
       subst_vars env args, args_layout, result_layout, (reg_close, mode), dbg)
   | Apply { probe = Some {name}; _ } ->

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -263,11 +263,11 @@ let toplevel_substitution sb tree =
       let new_value = sb new_value in
       Assign { being_assigned; new_value; }
     | Apply { func; args; kind; dbg; reg_close; mode;
-              inlined; specialise; probe; } ->
+              inlined; specialise; probe; result_layout; } ->
       let func = sb func in
       let args = List.map sb args in
       Apply { func; args; kind; dbg; reg_close; mode;
-              inlined; specialise; probe; }
+              inlined; specialise; probe; result_layout; }
     | If_then_else (cond, e1, e2, kind) ->
       let cond = sb cond in
       If_then_else (cond, e1, e2, kind)
@@ -717,7 +717,7 @@ let substitute_read_symbol_field_for_variables
       bind_to_value @@
       Flambda.For { bound_var; from_value; to_value; direction; body }
     | Apply { func; args; kind; dbg; reg_close; mode;
-              inlined; specialise; probe } ->
+              inlined; specialise; probe; result_layout } ->
       let func, bind_func = make_var_subst func in
       let args, bind_args =
         List.split (List.map make_var_subst args)
@@ -725,7 +725,7 @@ let substitute_read_symbol_field_for_variables
       bind_func @@
       List.fold_right (fun f expr -> f expr) bind_args @@
       Flambda.Apply { func; args; kind; dbg; reg_close; mode;
-                      inlined; specialise; probe }
+                      inlined; specialise; probe; result_layout }
     | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
       let meth, bind_meth = make_var_subst meth in
       let obj, bind_obj = make_var_subst obj in

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -130,7 +130,9 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
   | Static_raise _, _ | _, Static_raise _ -> false
   | Static_catch (s1, v1, a1, b1, k1), Static_catch (s2, v2, a2, b2, k2) ->
     Static_exception.equal s1 s2
-      && Misc.Stdlib.List.equal Variable.equal v1 v2
+      && Misc.Stdlib.List.equal
+        (fun (v1, l1) (v2, l2) -> Variable.equal v1 v2 && Lambda.equal_layout l1 l2)
+        v1 v2
       && same a1 a2
       && same b1 b2
       && Lambda.equal_layout k1 k2

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -279,11 +279,11 @@ let toplevel_substitution sb tree =
     | String_switch (cond, branches, def, kind) ->
       let cond = sb cond in
       String_switch (cond, branches, def, kind)
-    | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
+    | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
       let meth = sb meth in
       let obj = sb obj in
       let args = List.map sb args in
-      Send { kind; meth; obj; args; dbg; reg_close; mode }
+      Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout }
     | For { bound_var; from_value; to_value; direction; body } ->
       let from_value = sb from_value in
       let to_value = sb to_value in
@@ -728,7 +728,7 @@ let substitute_read_symbol_field_for_variables
       List.fold_right (fun f expr -> f expr) bind_args @@
       Flambda.Apply { func; args; kind; dbg; reg_close; mode;
                       inlined; specialise; probe; result_layout }
-    | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
+    | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
       let meth, bind_meth = make_var_subst meth in
       let obj, bind_obj = make_var_subst obj in
       let args, bind_args =
@@ -737,7 +737,7 @@ let substitute_read_symbol_field_for_variables
       bind_meth @@
       bind_obj @@
       List.fold_right (fun f expr -> f expr) bind_args @@
-      Flambda.Send { kind; meth; obj; args; dbg; reg_close; mode }
+      Flambda.Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout }
     | Proved_unreachable
     | Region _
     | Tail _

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -343,7 +343,7 @@ let toplevel_substitution_named sb named =
   | _ -> assert false
 
 let make_closure_declaration
-      ~is_classic_mode ~id ~alloc_mode ~region ~body ~params ~free_variables : Flambda.t =
+      ~is_classic_mode ~id ~alloc_mode ~region ~body ~params ~return_layout ~free_variables : Flambda.t =
   let param_set = Parameter.Set.vars params in
   let free_variables_set = Variable.Map.keys free_variables in
   if not (Variable.Set.subset param_set free_variables_set) then begin
@@ -363,6 +363,7 @@ let make_closure_declaration
   let function_declaration =
     Flambda.create_function_declaration
       ~params:(List.map subst_param params) ~alloc_mode  ~region
+      ~return_layout
       ~body ~stub:true ~inline:Default_inline
       ~specialise:Default_specialise ~check:Default_check ~is_a_functor:false
       ~closure_origin:(Closure_origin.create (Closure_id.wrap id))

--- a/middle_end/flambda/flambda_utils.mli
+++ b/middle_end/flambda/flambda_utils.mli
@@ -69,6 +69,7 @@ val make_closure_declaration
   -> region:bool
   -> body:Flambda.t
   -> params:Parameter.t list
+  -> return_layout:Lambda.layout
   -> free_variables:Lambda.layout Variable.Map.t
   -> Flambda.t
 

--- a/middle_end/flambda/freshening.ml
+++ b/middle_end/flambda/freshening.ml
@@ -419,11 +419,12 @@ let does_not_freshen t vars =
 let freshen_projection (projection : Projection.t) ~freshening
       ~closure_freshening : Projection.t =
   match projection with
-  | Project_var { closure; closure_id; var; } ->
+  | Project_var { closure; closure_id; var; kind } ->
     Project_var {
       closure = apply_variable freshening closure;
       closure_id = Project_var.apply_closure_id closure_freshening closure_id;
       var = Project_var.apply_var_within_closure closure_freshening var;
+      kind;
     }
   | Project_closure { set_of_closures; closure_id; } ->
     Project_closure {

--- a/middle_end/flambda/freshening.ml
+++ b/middle_end/flambda/freshening.ml
@@ -322,6 +322,7 @@ module Project_var = struct
         let function_decl =
           Flambda.create_function_declaration
             ~params ~alloc_mode:func_decl.alloc_mode ~region:func_decl.region
+            ~return_layout:func_decl.return_layout
             ~body
             ~stub:func_decl.stub
             ~inline:func_decl.inline ~specialise:func_decl.specialise

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -253,7 +253,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_loop ~toplevel [] f1;
       mark_loop ~toplevel [] f2
     | Static_catch (_,ids,f1,f2, _) ->
-      List.iter (fun id -> mark_curr [Var id]) ids;
+      List.iter (fun (id, _layout) -> mark_curr [Var id]) ids;
       mark_curr curr;
       mark_loop ~toplevel [] f1;
       mark_loop ~toplevel [] f2

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -610,6 +610,7 @@ and simplify_set_of_closures original_env r
     let function_decl =
       Flambda.create_function_declaration
         ~params:function_decl.params
+        ~return_layout:function_decl.return_layout
         ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
         ~body ~stub:function_decl.stub
         ~inline:function_decl.inline ~specialise:function_decl.specialise
@@ -880,6 +881,7 @@ and simplify_partial_application env r ~lhs_of_application
       ~alloc_mode:partial_mode
       ~region:function_decl.A.region
       ~params:remaining_args
+      ~return_layout:function_decl.A.return_layout
       ~free_variables
   in
   let with_known_args =
@@ -1509,6 +1511,7 @@ and duplicate_function ~env ~(set_of_closures : Flambda.set_of_closures)
   let function_decl =
     Flambda.create_function_declaration
       ~params:function_decl.params
+      ~return_layout:function_decl.return_layout
       ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
       ~body ~stub:function_decl.stub
       ~inline:function_decl.inline ~specialise:function_decl.specialise

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -468,6 +468,7 @@ let rec simplify_project_var env r ~(project_var : Flambda.project_var)
           closure;
           closure_id;
           var;
+          kind = project_var.kind;
         }
       in
       begin match E.find_projection env ~projection with
@@ -477,7 +478,9 @@ let rec simplify_project_var env r ~(project_var : Flambda.project_var)
           Expr (Var var), ret r var_approx)
       | None ->
         let approx = A.approx_for_bound_var value_set_of_closures var in
-        let expr : Flambda.named = Project_var { closure; closure_id; var; } in
+        let expr : Flambda.named =
+          Project_var { closure; closure_id; var; kind = project_var.kind; }
+        in
         let unwrapped = Var_within_closure.unwrap var in
         let expr =
           if E.mem env unwrapped then

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -1312,12 +1312,12 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
     let cond, r = simplify env r cond in
     let body, r = simplify env r body in
     While (cond, body), ret r (A.value_unknown Other)
-  | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
+  | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
     let dbg = E.add_inlined_debuginfo env ~dbg in
     simplify_free_variable env meth ~f:(fun env meth _meth_approx ->
       simplify_free_variable env obj ~f:(fun env obj _obj_approx ->
         simplify_free_variables env args ~f:(fun _env args _args_approx ->
-          Send { kind; meth; obj; args; dbg; reg_close; mode },
+          Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout },
             ret r (A.value_unknown Other))))
   | For { bound_var; from_value; to_value; direction; body; } ->
     simplify_free_variable env from_value ~f:(fun env from_value _approx ->

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -1256,17 +1256,17 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
           | Static_raise (j, args) ->
             assert (Static_exception.equal i j);
             let handler =
-              List.fold_left2 (fun body var arg ->
+              List.fold_left2 (fun body (var, _layout) arg ->
                   Flambda.create_let var (Expr (Var arg)) body)
                 handler vars args
             in
             let r = R.exit_scope_catch r i in
             simplify env r handler
           | _ ->
-            let vars, sb = Freshening.add_variables' (E.freshening env) vars in
+            let vars, sb = Freshening.add_variables (E.freshening env) vars in
             let approx = R.approx r in
             let env =
-              List.fold_left (fun env id ->
+              List.fold_left (fun env (id, _layout) ->
                   E.add env id (A.value_unknown Other))
                 (E.set_freshening env sb) vars
             in

--- a/middle_end/flambda/inlining_decision.ml
+++ b/middle_end/flambda/inlining_decision.ml
@@ -201,7 +201,7 @@ let inline env r ~lhs_of_application
       Inlining_transforms.inline_by_copying_function_body ~env
         ~r:(R.reset_benefit r) ~lhs_of_application
         ~closure_id_being_applied ~specialise_requested ~inlined_requested
-        ~probe_requested
+        ~probe_requested ~free_vars:value_set_of_closures.A.free_vars
         ~function_decl ~function_body ~fun_vars ~args ~dbg ~reg_close ~mode ~simplify
     in
     let num_direct_applications_seen =
@@ -537,7 +537,7 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
         Inlining_transforms.inline_by_copying_function_body ~env
           ~r ~fun_vars ~lhs_of_application
           ~closure_id_being_applied ~specialise_requested ~inlined_requested
-          ~probe_requested
+          ~probe_requested ~free_vars:value_set_of_closures.free_vars
           ~function_decl ~function_body ~args ~dbg ~reg_close ~mode ~simplify
       in
       simplify env r body
@@ -576,7 +576,7 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
               Inlining_transforms.inline_by_copying_function_body ~env
                 ~r ~function_body ~lhs_of_application
                 ~closure_id_being_applied ~specialise_requested
-                ~probe_requested
+                ~probe_requested ~free_vars:value_set_of_closures.free_vars
                 ~inlined_requested ~function_decl ~fun_vars ~args
                 ~dbg ~reg_close ~mode ~simplify
             in

--- a/middle_end/flambda/inlining_decision.ml
+++ b/middle_end/flambda/inlining_decision.ml
@@ -490,7 +490,7 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
       ~(function_decl : A.function_declaration)
       ~(value_set_of_closures : A.value_set_of_closures)
       ~args ~args_approxs ~dbg ~reg_close ~mode ~simplify ~inlined_requested
-      ~specialise_requested ~probe_requested =
+      ~specialise_requested ~probe_requested ~result_layout =
   if List.length args <> List.length args_approxs then begin
     Misc.fatal_error "Inlining_decision.for_call_site: inconsistent lengths \
         of [args] and [args_approxs]"
@@ -514,6 +514,7 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
     Flambda.Apply {
       func = lhs_of_application;
       args;
+      result_layout;
       kind = Direct closure_id_being_applied;
       dbg;
       reg_close;

--- a/middle_end/flambda/inlining_decision.mli
+++ b/middle_end/flambda/inlining_decision.mli
@@ -38,6 +38,7 @@ val for_call_site
   -> inlined_requested:Lambda.inlined_attribute
   -> specialise_requested:Lambda.specialise_attribute
   -> probe_requested:Lambda.probe
+  -> result_layout:Lambda.layout
   -> Flambda.t * Inline_and_simplify_aux.Result.t
 
 (** When a function declaration is encountered by [for_call_site], the body

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -541,6 +541,7 @@ let rewrite_function ~lhs_of_application ~closure_id_being_applied
     Flambda.create_function_declaration
       ~params ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
       ~body
+      ~return_layout:function_decl.return_layout
       ~stub:function_body.stub
       ~inline:function_body.inline
       ~specialise:function_body.specialise

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -349,7 +349,7 @@ let add_fun_var ~lhs_of_application ~closure_id_being_applied ~state ~fun_var =
     in
     let let_bindings = (outside_var, expr) :: state.let_bindings in
     let spec : Flambda.specialised_to =
-      { var = outside_var; projection = None; kind = Lambda.layout_top }
+      { var = outside_var; projection = None; kind = Lambda.layout_function }
     in
     let new_free_vars_with_old_projections =
       Variable.Map.add inside_var spec state.new_free_vars_with_old_projections

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -674,7 +674,7 @@ let inline_by_copying_function_declaration
       in
       let apply : Flambda.apply =
         { func = closure_var; args; kind = Direct closure_id; dbg;
-          reg_close; mode;
+          reg_close; mode; result_layout = function_decl.return_layout;
           inlined = inlined_requested; specialise = Default_specialise;
           probe = probe_requested;
         }

--- a/middle_end/flambda/inlining_transforms.mli
+++ b/middle_end/flambda/inlining_transforms.mli
@@ -75,6 +75,7 @@ val inline_by_copying_function_body
   -> function_decl:Simple_value_approx.function_declaration
   -> function_body:Simple_value_approx.function_body
   -> fun_vars:Variable.Set.t
+  -> free_vars:Flambda.specialised_to Variable.Map.t
   -> args:Variable.t list
   -> dbg:Debuginfo.t
   -> reg_close:Lambda.region_close

--- a/middle_end/flambda/projection.ml
+++ b/middle_end/flambda/projection.ml
@@ -34,6 +34,7 @@ type project_var = {
   closure : Variable.t;
   closure_id : Closure_id.t;
   var : Var_within_closure.t;
+  kind : Lambda.layout;
 }
 
 let compare_project_var

--- a/middle_end/flambda/projection.mli
+++ b/middle_end/flambda/projection.mli
@@ -41,6 +41,7 @@ type project_var = {
   closure : Variable.t;  (** must yield a closure *)
   closure_id : Closure_id.t;
   var : Var_within_closure.t;
+  kind : Lambda.layout;
 }
 
 val print_project_closure

--- a/middle_end/flambda/remove_unused_arguments.ml
+++ b/middle_end/flambda/remove_unused_arguments.ml
@@ -42,6 +42,7 @@ let remove_params unused (fun_decl: Flambda.function_declaration)
   Flambda.create_function_declaration
     ~params:used_params ~alloc_mode:fun_decl.alloc_mode ~region:fun_decl.region
     ~body
+    ~return_layout:fun_decl.return_layout
     ~stub:fun_decl.stub ~inline:fun_decl.inline
     ~specialise:fun_decl.specialise ~check:fun_decl.check
     ~is_a_functor:fun_decl.is_a_functor
@@ -107,7 +108,7 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
     Flambda.create_function_declaration
       ~params:(List.map snd args')
       ~alloc_mode:fun_decl.alloc_mode ~region:fun_decl.region
-      ~body
+      ~body ~return_layout:fun_decl.return_layout
       ~stub:true ~inline:Default_inline
       ~specialise:Default_specialise
       ~check:Default_check

--- a/middle_end/flambda/remove_unused_arguments.ml
+++ b/middle_end/flambda/remove_unused_arguments.ml
@@ -95,6 +95,7 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
     Apply {
       func = renamed;
       args = Parameter.List.vars args;
+      result_layout = fun_decl.return_layout;
       kind;
       dbg = fun_decl.dbg;
       reg_close = Rc_normal;

--- a/middle_end/flambda/simple_value_approx.ml
+++ b/middle_end/flambda/simple_value_approx.ml
@@ -251,8 +251,7 @@ let augment_with_symbol_field t symbol field =
   | Some _ -> t
 let replace_description t descr = { t with descr }
 
-let augment_with_kind t (layout:Lambda.layout) =
-  let Pvalue kind = layout in
+let augment_with_kind t (kind:Lambda.value_kind) =
   match kind with
   | Pgenval -> t
   | Pfloatval ->
@@ -278,13 +277,13 @@ let augment_with_kind t (layout:Lambda.layout) =
     end
   | _ -> t
 
-let augment_kind_with_approx t (kind:Lambda.layout) : Lambda.layout =
+let augment_kind_with_approx t (kind:Lambda.value_kind) : Lambda.value_kind =
   match t.descr with
-  | Value_float _ -> Pvalue Pfloatval
-  | Value_int _ -> Pvalue Pintval
-  | Value_boxed_int (Int32, _) -> Pvalue (Pboxedintval Pint32)
-  | Value_boxed_int (Int64, _) -> Pvalue (Pboxedintval Pint64)
-  | Value_boxed_int (Nativeint, _) -> Pvalue (Pboxedintval Pnativeint)
+  | Value_float _ -> Pfloatval
+  | Value_int _ -> Pintval
+  | Value_boxed_int (Int32, _) -> Pboxedintval Pint32
+  | Value_boxed_int (Int64, _) -> Pboxedintval Pint64
+  | Value_boxed_int (Nativeint, _) -> Pboxedintval Pnativeint
   | _ -> kind
 
 let value_unknown reason = approx (Value_unknown reason)
@@ -377,7 +376,7 @@ let value_mutable_float_array ~size =
 let value_immutable_float_array (contents:t array) =
   let size = Array.length contents in
   let contents =
-    Array.map (fun t -> augment_with_kind t Lambda.layout_float) contents
+    Array.map (fun t -> augment_with_kind t Pfloatval) contents
   in
   approx (Value_float_array { contents = Contents contents; size; } )
 

--- a/middle_end/flambda/simple_value_approx.ml
+++ b/middle_end/flambda/simple_value_approx.ml
@@ -89,6 +89,7 @@ and function_body = {
 and function_declaration = {
   closure_origin : Closure_origin.t;
   params : Parameter.t list;
+  return_layout : Lambda.layout;
   alloc_mode : Lambda.alloc_mode;
   region : bool;
   function_body : function_body option;
@@ -139,6 +140,11 @@ let print_unresolved_value ppf = function
 let print_function_declaration ppf var (f : function_declaration) =
   let param ppf p = Variable.print ppf (Parameter.var p) in
   let params ppf = List.iter (Format.fprintf ppf "@ %a" param) in
+  let return_layout ppf (layout : Lambda.layout) =
+    match layout with
+    | Pvalue Pgenval -> ()
+    | _ -> Format.fprintf ppf "%a@ " Printlambda.layout layout
+  in
   match f.function_body with
   | None ->
     Format.fprintf ppf "@[<2>(%a@ =@ fun@[<2>%a@])@]@ "
@@ -163,9 +169,10 @@ let print_function_declaration ppf var (f : function_declaration) =
     let print_body ppf _ =
       Format.fprintf ppf "<Function Body>"
     in
-    Format.fprintf ppf "@[<2>(%a%s%s%s%s@ =@ fun@[<2>%a@] ->@ @[<2><%a>@])@]@ "
+    Format.fprintf ppf "@[<2>(%a%s%s%s%s@ =@ fun@[<2>%a@] ->@ %a@[<2><%a>@])@]@ "
       Variable.print var stub is_a_functor inline specialise
       params f.params
+      return_layout f.return_layout
       print_body b
 
 let print_function_declarations ppf (fd : function_declarations) =
@@ -956,6 +963,7 @@ let function_declaration_approx ~keep_body fun_var
   in
   { function_body;
     params = fun_decl.params;
+    return_layout = fun_decl.return_layout;
     alloc_mode = fun_decl.alloc_mode;
     region = fun_decl.region;
     closure_origin = fun_decl.closure_origin; }

--- a/middle_end/flambda/simple_value_approx.mli
+++ b/middle_end/flambda/simple_value_approx.mli
@@ -165,6 +165,7 @@ and function_body = private {
 and function_declaration = private {
   closure_origin : Closure_origin.t;
   params : Parameter.t list;
+  return_layout : Lambda.layout;
   alloc_mode : Lambda.alloc_mode;
   region : bool;
   function_body : function_body option;

--- a/middle_end/flambda/simple_value_approx.mli
+++ b/middle_end/flambda/simple_value_approx.mli
@@ -308,10 +308,10 @@ val augment_with_symbol_field : t -> Symbol.t -> int -> t
 val replace_description : t -> descr -> t
 
 (** Improve the description by taking the kind into account *)
-val augment_with_kind : t -> Lambda.layout -> t
+val augment_with_kind : t -> Lambda.value_kind -> t
 
 (** Improve the kind by taking the description into account *)
-val augment_kind_with_approx : t -> Lambda.layout -> Lambda.layout
+val augment_kind_with_approx : t -> Lambda.value_kind -> Lambda.value_kind
 
 val equal_boxed_int : 'a boxed_int -> 'a -> 'b boxed_int -> 'b -> bool
 

--- a/middle_end/flambda/simplify_primitives.ml
+++ b/middle_end/flambda/simplify_primitives.ml
@@ -111,12 +111,11 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
   | Pmakeblock(tag_int, (Immutable | Immutable_unique), shape, mode) ->
     let tag = Tag.create_exn tag_int in
     let shape = match shape with
-      | None -> List.map (fun _ -> Lambda.layout_top) args
-      | Some shape -> List.map (fun kind -> Lambda.Pvalue kind) shape
+      | None -> List.map (fun _ -> Lambda.Pgenval) args
+      | Some shape -> List.map (fun kind -> kind) shape
     in
     let approxs = List.map2 A.augment_with_kind approxs shape in
     let shape = List.map2 A.augment_kind_with_approx approxs shape in
-    let shape = List.map (fun (Lambda.Pvalue kind) -> kind) shape in
     Prim (Pmakeblock(tag_int, Lambda.Immutable, Some shape, mode), args, dbg),
     A.value_block tag (Array.of_list approxs), C.Benefit.zero
   | Praise _ ->

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -570,6 +570,7 @@ let layout_boxedint bi = Pvalue (Pboxedintval bi)
 let layout_lazy = Pvalue Pgenval
 let layout_lazy_contents = Pvalue Pgenval
 let layout_any_value = Pvalue Pgenval
+let layout_letrec = layout_any_value
 
 let layout_top = Pvalue Pgenval
 let layout_bottom =

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -557,6 +557,7 @@ let layout_block = Pvalue Pgenval
 let layout_list =
   Pvalue (Pvariant { consts = [0] ; non_consts = [0, [Pgenval; Pgenval]] })
 let layout_field = Pvalue Pgenval
+let layout_exception = Pvalue Pgenval
 let layout_function = Pvalue Pgenval
 let layout_object = Pvalue Pgenval
 let layout_class = Pvalue Pgenval

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -291,6 +291,8 @@ let rec equal_value_kind x y =
 
 let equal_layout (Pvalue x) (Pvalue y) = equal_value_kind x y
 
+let compatible_layout (Pvalue _) (Pvalue _) = true
+
 let must_be_value layout =
   match layout with
   | Pvalue v -> v

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -571,6 +571,9 @@ let layout_lazy_contents = Pvalue Pgenval
 let layout_any_value = Pvalue Pgenval
 
 let layout_top = Pvalue Pgenval
+let layout_bottom =
+  (* CR pchambart: this should be an actual bottom *)
+  Pvalue Pgenval
 
 let default_function_attribute = {
   inline = Default_inline;

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -237,6 +237,8 @@ val equal_value_kind : value_kind -> value_kind -> bool
 
 val equal_layout : layout -> layout -> bool
 
+val compatible_layout : layout -> layout -> bool
+
 val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 
 val must_be_value : layout -> value_kind

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -488,6 +488,7 @@ val layout_lazy : layout
 val layout_lazy_contents : layout
 (* A layout that is Pgenval because we are missing layout polymorphism *)
 val layout_any_value : layout
+val layout_letrec : layout
 
 val layout_top : layout
 val layout_bottom : layout

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -489,6 +489,7 @@ val layout_lazy_contents : layout
 val layout_any_value : layout
 
 val layout_top : layout
+val layout_bottom : layout
 
 val name_lambda: let_kind -> lambda -> layout -> (Ident.t -> lambda) -> lambda
 val name_lambda_list: (lambda * layout) list -> (lambda list -> lambda) -> lambda

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -472,6 +472,7 @@ val layout_int : layout
 val layout_array : array_kind -> layout
 val layout_block : layout
 val layout_list : layout
+val layout_exception : layout
 val layout_function : layout
 val layout_object : layout
 val layout_class : layout

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -214,7 +214,7 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
       let (inh_init, obj_init) =
         build_object_init ~scopes cl_table obj params inh_init obj_init cl
       in
-      (inh_init, transl_apply ~scopes obj_init oexprs Loc_unknown)
+      (inh_init, transl_apply ~result_layout:Lambda.layout_top ~scopes obj_init oexprs Loc_unknown)
   | Tcl_let (rec_flag, defs, vals, cl) ->
       let (inh_init, obj_init) =
         build_object_init ~scopes cl_table obj (vals @ params)
@@ -485,7 +485,7 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
   | Tcl_apply (cl, oexprs) ->
       let path, path_lam, obj_init =
         transl_class_rebind ~scopes obj_init cl vf in
-      (path, path_lam, transl_apply ~scopes obj_init oexprs Loc_unknown)
+      (path, path_lam, transl_apply ~result_layout:Lambda.layout_top ~scopes obj_init oexprs Loc_unknown)
   | Tcl_let (rec_flag, defs, _vals, cl) ->
       let path, path_lam, obj_init =
         transl_class_rebind ~scopes obj_init cl vf in

--- a/ocaml/lambda/translcore.mli
+++ b/ocaml/lambda/translcore.mli
@@ -31,6 +31,7 @@ val transl_apply: scopes:scopes
                   -> ?specialised:specialise_attribute
                   -> ?position:region_close
                   -> ?mode:alloc_mode
+                  -> result_layout:Lambda.layout
                   -> lambda
                   -> (arg_label * apply_arg) list
                   -> scoped_location -> lambda

--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -168,3 +168,5 @@ and raise_kind = Lambda.raise_kind =
   | Raise_notrace
 
 let equal (x: primitive) (y: primitive) = x = y
+
+let result_layout _p = Lambda.layout_any_value

--- a/ocaml/middle_end/clambda_primitives.mli
+++ b/ocaml/middle_end/clambda_primitives.mli
@@ -171,3 +171,5 @@ and raise_kind = Lambda.raise_kind =
   | Raise_notrace
 
 val equal : primitive -> primitive -> bool
+
+val result_layout : primitive -> Lambda.layout

--- a/ocaml/middle_end/flambda/augment_specialised_args.ml
+++ b/ocaml/middle_end/flambda/augment_specialised_args.ml
@@ -470,6 +470,7 @@ module Make (T : S) = struct
           args =
             (Parameter.List.vars wrapper_params) @
             spec_args_bound_in_the_wrapper;
+          result_layout = function_decl.return_layout;
           kind = Direct (Closure_id.wrap new_fun_var);
           dbg = Debuginfo.none;
           reg_close = Rc_normal;
@@ -544,6 +545,7 @@ module Make (T : S) = struct
     let new_function_decl =
       Flambda.create_function_declaration
         ~params:wrapper_params
+        ~return_layout:function_decl.return_layout
         ~alloc_mode
         ~region:function_decl.region
         ~body:wrapper_body
@@ -651,6 +653,7 @@ module Make (T : S) = struct
       let rewritten_function_decl =
         Flambda.create_function_declaration
           ~params:all_params
+          ~return_layout:function_decl.return_layout
           ~alloc_mode:function_decl.alloc_mode
           ~region:function_decl.region
           ~body:function_decl.body

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -105,8 +105,8 @@ let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
   let alloc_mode = Lambda.alloc_heap in
   let tuple_param = Parameter.wrap tuple_param_var alloc_mode Lambda.layout_block in
   Flambda.create_function_declaration ~params:[tuple_param] ~alloc_mode ~region
-    ~body ~stub:true dbg:Debuginfo.none ~inline:Default_inline ~return_layout
-    ~specialise:Default_specialise ~check:Default_check ~is_a_functor:false
+    ~body ~stub:true ~dbg:Debuginfo.none ~inline:Default_inline ~return_layout
+    ~specialise:Default_specialise ~is_a_functor:false
     ~closure_origin:(Closure_origin.create (Closure_id.wrap closure_bound_var))
     ~poll:Default_poll (* don't propogate attribute to wrappers *)
 

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -40,10 +40,10 @@ let add_default_argument_wrappers lam =
     match lam with
     | Llet (( Strict | Alias | StrictOpt), _k, id,
         Lfunction {kind; params; body = fbody; attr; loc;
-                   mode; region}, body) ->
+                   mode; region; return }, body) ->
       begin match
         Simplif.split_default_wrapper ~id ~kind ~params
-          ~body:fbody ~return:Lambda.layout_top ~attr ~loc ~mode ~region
+          ~body:fbody ~return ~attr ~loc ~mode ~region
       with
       | [fun_id, def] -> Llet (Alias, Lambda.layout_function, fun_id, def, body)
       | [fun_id, def; inner_fun_id, def_inner] ->
@@ -58,9 +58,9 @@ let add_default_argument_wrappers lam =
             (List.map
                (function
                  | (id, Lambda.Lfunction {kind; params; body; attr; loc;
-                                          mode; region}) ->
+                                          mode; region; return }) ->
                    Simplif.split_default_wrapper ~id ~kind ~params ~body
-                     ~return:Lambda.layout_top ~attr ~loc ~mode ~region
+                     ~return ~attr ~loc ~mode ~region
                  | _ -> assert false)
                defs)
         in
@@ -73,7 +73,7 @@ let add_default_argument_wrappers lam =
 (** Generate a wrapper ("stub") function that accepts a tuple argument and
     calls another function with arguments extracted in the obvious
     manner from the tuple. *)
-let tupled_function_call_stub original_params unboxed_version ~closure_bound_var ~region
+let tupled_function_call_stub original_params unboxed_version ~closure_bound_var ~region ~return_layout
       : Flambda.function_declaration =
   let tuple_param_var = Variable.rename unboxed_version in
   let params = List.map (fun p -> Variable.rename p) original_params in
@@ -81,6 +81,7 @@ let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
     Apply ({
         func = unboxed_version;
         args = params;
+        result_layout = return_layout;
         (* CR-someday mshinwell for mshinwell: investigate if there is some
            redundancy here (func is also unboxed_version) *)
         kind = Direct (Closure_id.wrap unboxed_version);
@@ -104,8 +105,8 @@ let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
   let alloc_mode = Lambda.alloc_heap in
   let tuple_param = Parameter.wrap tuple_param_var alloc_mode Lambda.layout_block in
   Flambda.create_function_declaration ~params:[tuple_param] ~alloc_mode ~region
-    ~body ~stub:true ~dbg:Debuginfo.none ~inline:Default_inline
-    ~specialise:Default_specialise ~is_a_functor:false
+    ~body ~stub:true dbg:Debuginfo.none ~inline:Default_inline ~return_layout
+    ~specialise:Default_specialise ~check:Default_check ~is_a_functor:false
     ~closure_origin:(Closure_origin.create (Closure_id.wrap closure_bound_var))
     ~poll:Default_poll (* don't propogate attribute to wrappers *)
 
@@ -215,7 +216,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
            initial_value = var;
            body;
            contents_kind = block_kind })
-  | Lfunction { kind; params; body; attr; loc; mode; region } ->
+  | Lfunction { kind; params; body; attr; loc; mode; region; return } ->
     let name = Names.anon_fn_with_loc loc in
     let closure_bound_var = Variable.create name in
     (* CR-soon mshinwell: some of this is now very similar to the let rec case
@@ -224,7 +225,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let set_of_closures =
       let decl =
         Function_decl.create ~let_rec_ident:None ~closure_bound_var ~kind ~mode
-          ~region ~params ~body ~attr ~loc
+          ~region ~params ~body ~attr ~loc ~return_layout:return
       in
       close_functions t env (Function_decls.create [decl])
     in
@@ -235,7 +236,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     in
     Flambda.create_let set_of_closures_var set_of_closures
       (name_expr (Project_closure (project_closure)) ~name)
-  | Lapply { ap_func; ap_args; ap_loc; ap_region_close; ap_mode;
+  | Lapply { ap_func; ap_args; ap_loc; ap_region_close; ap_mode; ap_result_layout;
              ap_tailcall = _; ap_inlined; ap_specialised; ap_probe; } ->
     Lift_code.lifting_helper (close_list t env ap_args)
       ~evaluation_order:`Right_to_left
@@ -247,6 +248,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
           (Apply ({
               func = func_var;
               args;
+              result_layout = ap_result_layout;
               kind = Indirect;
               dbg = Debuginfo.from_location ap_loc;
               reg_close = ap_region_close;
@@ -259,7 +261,8 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
   | Lletrec (defs, body) ->
     let env =
       List.fold_right (fun (id,  _) env ->
-          Env.add_var env id (Variable.create_with_same_name_as_ident id) Lambda.layout_top)
+          Env.add_var env id (Variable.create_with_same_name_as_ident id)
+            Lambda.layout_letrec)
         defs env
     in
     let function_declarations =
@@ -267,14 +270,14 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
          will be named after the corresponding identifier in the [let rec]. *)
       List.map (function
           | (let_rec_ident,
-             Lambda.Lfunction { kind; params; body; attr; loc; mode; region }) ->
+             Lambda.Lfunction { kind; params; return; body; attr; loc; mode; region }) ->
             let closure_bound_var =
               Variable.create_with_same_name_as_ident let_rec_ident
             in
             let function_declaration =
               Function_decl.create ~let_rec_ident:(Some let_rec_ident)
                 ~closure_bound_var ~kind ~mode ~region
-                ~params ~body ~attr ~loc
+                ~params ~body ~attr ~loc ~return_layout:return
             in
             Some function_declaration
           | _ -> None)
@@ -324,7 +327,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       in
       Let_rec (defs, close t env body)
     end
-  | Lsend (kind, meth, obj, args, reg_close, mode, loc, _layout) ->
+  | Lsend (kind, meth, obj, args, reg_close, mode, loc, result_layout) ->
     let meth_var = Variable.create Names.meth in
     let obj_var = Variable.create Names.obj in
     let dbg = Debuginfo.from_location loc in
@@ -335,7 +338,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
           ~name:Names.send_arg
           ~create_body:(fun args ->
               Send { kind; meth = meth_var; obj = obj_var; args;
-                     dbg; reg_close; mode })))
+                     dbg; reg_close; mode; result_layout })))
   | Lprim ((Pdivint Safe | Pmodint Safe
            | Pdivbint { is_safe = Safe } | Pmodbint { is_safe = Safe }) as prim,
            [arg1; arg2], loc)
@@ -524,7 +527,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       List.map (fun (ident, kind) ->
           (Variable.create_with_same_name_as_ident ident, kind)) ids
     in
-    Static_catch (st_exn, List.map fst vars, close t env body,
+    Static_catch (st_exn, vars, close t env body,
       close t (Env.add_vars env (List.map fst ids) vars) handler, kind)
   | Ltrywith (body, id, handler, kind) ->
     let var = Variable.create_with_same_name_as_ident id in
@@ -589,6 +592,7 @@ and close_functions t external_env function_declarations : Flambda.named =
     let dbg = Debuginfo.from_location loc in
     let region = Function_decl.region decl in
     let params = Function_decl.params decl in
+    let return_layout = Function_decl.return_layout decl in
     (* Create fresh variables for the elements of the closure (cf.
        the comment on [Function_decl.closure_env_without_parameters], above).
        This induces a renaming on [Function_decl.free_idents]; the results of
@@ -625,7 +629,7 @@ and close_functions t external_env function_declarations : Flambda.named =
     let fun_decl =
       Flambda.create_function_declaration
         ~params ~alloc_mode:(Function_decl.mode decl) ~region
-        ~body ~stub ~dbg
+        ~body ~stub ~dbg ~return_layout
         ~inline:(Function_decl.inline decl)
         ~specialise:(Function_decl.specialise decl)
         ~is_a_functor:(Function_decl.is_a_functor decl)
@@ -639,7 +643,7 @@ and close_functions t external_env function_declarations : Flambda.named =
       let unboxed_version = Variable.rename closure_bound_var in
       let generic_function_stub =
         tupled_function_call_stub (List.map fst param_vars) unboxed_version
-          ~closure_bound_var ~region
+          ~closure_bound_var ~region ~return_layout
       in
       Variable.Map.add unboxed_version fun_decl
         (Variable.Map.add closure_bound_var generic_function_stub map)
@@ -679,13 +683,13 @@ and close_list t sb l = List.map (close t sb) l
 and close_let_bound_expression t ?let_rec_ident let_bound_var env
       (lam : Lambda.lambda) : Flambda.named =
   match lam with
-  | Lfunction { kind; params; body; attr; loc; mode; region } ->
+  | Lfunction { kind; params; return; body; attr; loc; mode; region } ->
     (* Ensure that [let] and [let rec]-bound functions have appropriate
        names. *)
     let closure_bound_var = Variable.rename let_bound_var in
     let decl =
       Function_decl.create ~let_rec_ident ~closure_bound_var ~kind ~mode ~region
-        ~params ~body ~attr ~loc
+        ~params ~body ~attr ~loc ~return_layout:return
     in
     let set_of_closures_var = Variable.rename let_bound_var in
     let set_of_closures =

--- a/ocaml/middle_end/flambda/closure_conversion_aux.ml
+++ b/ocaml/middle_end/flambda/closure_conversion_aux.ml
@@ -93,6 +93,7 @@ module Function_decls = struct
       mode : Lambda.alloc_mode;
       region : bool;
       params : (Ident.t * Lambda.layout) list;
+      return_layout : Lambda.layout;
       body : Lambda.lambda;
       free_idents_of_body : Ident.Set.t;
       attr : Lambda.function_attribute;
@@ -100,7 +101,7 @@ module Function_decls = struct
     }
 
     let create ~let_rec_ident ~closure_bound_var ~kind ~mode ~region
-          ~params ~body ~attr ~loc =
+          ~params ~return_layout ~body ~attr ~loc =
       let let_rec_ident =
         match let_rec_ident with
         | None -> Ident.create_local "unnamed_function"
@@ -112,6 +113,7 @@ module Function_decls = struct
         mode;
         region;
         params;
+        return_layout;
         body;
         free_idents_of_body = Lambda.free_variables body;
         attr;
@@ -124,6 +126,7 @@ module Function_decls = struct
     let mode t = t.mode
     let region t = t.region
     let params t = t.params
+    let return_layout t = t.return_layout
     let body t = t.body
     let free_idents t = t.free_idents_of_body
     let inline t = t.attr.inline

--- a/ocaml/middle_end/flambda/closure_conversion_aux.mli
+++ b/ocaml/middle_end/flambda/closure_conversion_aux.mli
@@ -61,6 +61,7 @@ module Function_decls : sig
       -> mode:Lambda.alloc_mode
       -> region:bool
       -> params:(Ident.t * Lambda.layout) list
+      -> return_layout:Lambda.layout
       -> body:Lambda.lambda
       -> attr:Lambda.function_attribute
       -> loc:Lambda.scoped_location
@@ -72,6 +73,7 @@ module Function_decls : sig
     val mode : t -> Lambda.alloc_mode
     val region : t -> bool
     val params : t -> (Ident.t * Lambda.layout) list
+    val return_layout : t -> Lambda.layout
     val body : t -> Lambda.lambda
     val inline : t -> Lambda.inline_attribute
     val specialise : t -> Lambda.specialise_attribute

--- a/ocaml/middle_end/flambda/flambda.mli
+++ b/ocaml/middle_end/flambda/flambda.mli
@@ -36,6 +36,7 @@ type apply = {
      lhs_of_application -> callee *)
   func : Variable.t;
   args : Variable.t list;
+  result_layout : Lambda.layout;
   kind : call_kind;
   dbg : Debuginfo.t;
   reg_close : Lambda.region_close;
@@ -66,6 +67,7 @@ type send = {
   dbg : Debuginfo.t;
   reg_close : Lambda.region_close;
   mode : Lambda.alloc_mode;
+  result_layout : Lambda.layout;
 }
 
 (** For details on these types, see projection.mli. *)
@@ -111,7 +113,7 @@ type t =
                      * Lambda.layout
   (** Restrictions on [Lambda.Lstringswitch] also apply to [String_switch]. *)
   | Static_raise of Static_exception.t * Variable.t list
-  | Static_catch of Static_exception.t * Variable.t list * t * t * Lambda.layout
+  | Static_catch of Static_exception.t * ( Variable.t * Lambda.layout ) list * t * t * Lambda.layout
   | Try_with of t * Variable.t * t * Lambda.layout
   | While of t * t
   | For of for_loop
@@ -313,6 +315,7 @@ and function_declarations = private {
 and function_declaration = private {
   closure_origin: Closure_origin.t;
   params : Parameter.t list;
+  return_layout : Lambda.layout;
   alloc_mode : Lambda.alloc_mode;
   region : bool;
   body : t;
@@ -569,6 +572,7 @@ val create_function_declaration
   -> body:t
   -> stub:bool
   -> dbg:Debuginfo.t
+  -> return_layout:Lambda.layout
   -> inline:Lambda.inline_attribute
   -> specialise:Lambda.specialise_attribute
   -> is_a_functor:bool

--- a/ocaml/middle_end/flambda/flambda_to_clambda.ml
+++ b/ocaml/middle_end/flambda/flambda_to_clambda.ml
@@ -529,7 +529,7 @@ and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda * Lambd
     arg_layout
   | Prim (p, args, dbg) ->
     let args, _args_layout = List.split (subst_vars env args) in
-    let result_layout = ocaml/middle_end/clambda_primitives.result_layout p in
+    let result_layout = Clambda_primitives.result_layout p in
     Uprim (p, args, dbg),
     result_layout
   | Expr expr -> to_clambda t env expr

--- a/ocaml/middle_end/flambda/flambda_to_clambda.ml
+++ b/ocaml/middle_end/flambda/flambda_to_clambda.ml
@@ -101,7 +101,7 @@ let clambda_arity (func : Flambda.function_declaration) : Clambda.arity =
   {
     function_kind = Curried {nlocal} ;
     params_layout = List.map Parameter.kind func.params ;
-    return_layout = Lambda.layout_top ; (* Need func.return *)
+    return_layout = func.return_layout ;
   }
 
 let check_field t ulam pos named_opt : Clambda.ulambda =
@@ -130,14 +130,14 @@ module Env : sig
 
   val empty : t
 
-  val add_subst : t -> Variable.t -> Clambda.ulambda -> t
-  val find_subst_exn : t -> Variable.t -> Clambda.ulambda
+  val add_subst : t -> Variable.t -> Clambda.ulambda -> Lambda.layout -> t
+  val find_subst_exn : t -> Variable.t -> Clambda.ulambda * Lambda.layout
 
-  val add_fresh_ident : t -> Variable.t -> V.t * t
-  val ident_for_var_exn : t -> Variable.t -> V.t
+  val add_fresh_ident : t -> Variable.t -> Lambda.layout -> V.t * t
+  val ident_for_var_exn : t -> Variable.t -> V.t * Lambda.layout
 
-  val add_fresh_mutable_ident : t -> Mutable_variable.t -> V.t * t
-  val ident_for_mutable_var_exn : t -> Mutable_variable.t -> V.t
+  val add_fresh_mutable_ident : t -> Mutable_variable.t -> Lambda.layout -> V.t * t
+  val ident_for_mutable_var_exn : t -> Mutable_variable.t -> V.t * Lambda.layout
 
   val add_allocated_const : t -> Symbol.t -> Allocated_const.t -> t
   val allocated_const_for_symbol : t -> Symbol.t -> Allocated_const.t option
@@ -145,9 +145,9 @@ module Env : sig
   val keep_only_symbols : t -> t
 end = struct
   type t =
-    { subst : Clambda.ulambda Variable.Map.t;
-      var : V.t Variable.Map.t;
-      mutable_var : V.t Mutable_variable.Map.t;
+    { subst : (Clambda.ulambda * Lambda.layout) Variable.Map.t;
+      var : (V.t * Lambda.layout) Variable.Map.t;
+      mutable_var : (V.t * Lambda.layout) Mutable_variable.Map.t;
       allocated_constant_for_symbol : Allocated_const.t Symbol.Map.t;
     }
 
@@ -158,23 +158,25 @@ end = struct
       allocated_constant_for_symbol = Symbol.Map.empty;
     }
 
-  let add_subst t id subst =
-    { t with subst = Variable.Map.add id subst t.subst }
+  let add_subst t id subst layout =
+    { t with subst = Variable.Map.add id (subst, layout) t.subst }
 
   let find_subst_exn t id = Variable.Map.find id t.subst
 
   let ident_for_var_exn t id = Variable.Map.find id t.var
 
-  let add_fresh_ident t var =
+  let add_fresh_ident t var layout =
     let id = V.create_local (Variable.name var) in
-    id, { t with var = Variable.Map.add var id t.var }
+    id, { t with var = Variable.Map.add var (id, layout) t.var }
 
   let ident_for_mutable_var_exn t mut_var =
     Mutable_variable.Map.find mut_var t.mutable_var
 
-  let add_fresh_mutable_ident t mut_var =
+  let add_fresh_mutable_ident t mut_var layout =
     let id = V.create_local (Mutable_variable.name mut_var) in
-    let mutable_var = Mutable_variable.Map.add mut_var id t.mutable_var in
+    let mutable_var =
+      Mutable_variable.Map.add mut_var (id, layout) t.mutable_var
+    in
     id, { t with mutable_var; }
 
   let add_allocated_const t sym cons =
@@ -194,10 +196,12 @@ end = struct
     }
 end
 
-let subst_var env var : Clambda.ulambda =
+let subst_var env var : Clambda.ulambda * Lambda.layout =
   try Env.find_subst_exn env var
   with Not_found ->
-    try Uvar (Env.ident_for_var_exn env var)
+    try
+      let v, layout = Env.ident_for_var_exn env var in
+      Uvar v, layout
     with Not_found ->
       Misc.fatal_errorf "Flambda_to_clambda: unbound variable %a@."
         Variable.print var
@@ -239,33 +243,38 @@ let to_clambda_const env (const : Flambda.constant_defining_value_block_field)
   | Const (Int i) -> Uconst_int i
   | Const (Char c) -> Uconst_int (Char.code c)
 
-let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
+let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
   match flam with
   | Var var -> subst_var env var
   | Let { var; defining_expr; body; _ } ->
-    (* TODO: synthesize proper layout *)
-    let id, env_body = Env.add_fresh_ident env var in
-    Ulet (Immutable, Lambda.layout_top, VP.create id,
-      to_clambda_named t env var defining_expr,
-      to_clambda t env_body body)
+    let defining_expr, defining_expr_layout = to_clambda_named t env var defining_expr in
+    let id, env_body = Env.add_fresh_ident env var defining_expr_layout in
+    let body, body_layout = to_clambda t env_body body in
+    Ulet (Immutable, defining_expr_layout, VP.create id, defining_expr, body),
+    body_layout
   | Let_mutable { var = mut_var; initial_value = var; body; contents_kind } ->
-    let id, env_body = Env.add_fresh_mutable_ident env mut_var in
-    let def = subst_var env var in
-    Ulet (Mutable, contents_kind, VP.create id, def, to_clambda t env_body body)
+    let id, env_body = Env.add_fresh_mutable_ident env mut_var contents_kind in
+    let def, def_layout = subst_var env var in
+    assert(Lambda.compatible_layout def_layout contents_kind);
+    let body, body_layout = to_clambda t env_body body in
+    Ulet (Mutable, contents_kind, VP.create id, def, body), body_layout
   | Let_rec (defs, body) ->
     let env, defs =
       List.fold_right (fun (var, def) (env, defs) ->
-          let id, env = Env.add_fresh_ident env var in
+          let id, env = Env.add_fresh_ident env var Lambda.layout_letrec in
           env, (id, var, def) :: defs)
         defs (env, [])
     in
     let defs =
       List.map (fun (id, var, def) ->
-          VP.create id, to_clambda_named t env var def)
+          let def, def_layout = to_clambda_named t env var def in
+          assert(Lambda.compatible_layout def_layout Lambda.layout_letrec);
+          VP.create id, def)
         defs
     in
-    Uletrec (defs, to_clambda t env body)
-  | Apply { func; args; kind = Direct direct_func; probe; dbg; reg_close; mode} ->
+    let body, body_layout = to_clambda t env body in
+    Uletrec (defs, body), body_layout
+  | Apply { func; args; kind = Direct direct_func; probe; dbg; reg_close; mode; result_layout } ->
     (* The closure _parameter_ of the function is added by cmmgen.
        At the call site, for a direct call, the closure argument must be
        explicitly added (by [to_clambda_direct_apply]); there is no special
@@ -273,30 +282,35 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
        For an indirect call, we do not need to do anything here; Cmmgen will
        do the equivalent of the previous paragraph when it generates a direct
        call to [caml_apply]. *)
-    to_clambda_direct_apply t func args direct_func probe dbg reg_close mode env
-  | Apply { func; args; kind = Indirect; probe = None; dbg; reg_close; mode } ->
-    let callee = subst_var env func in
-    let args_layout = List.map (fun _ -> Lambda.layout_top) args in
-    let result_layout = Lambda.layout_top in
+    to_clambda_direct_apply t func args direct_func probe dbg reg_close mode result_layout env,
+    result_layout
+  | Apply { func; args; kind = Indirect; probe = None; dbg; reg_close; mode; result_layout } ->
+    let callee, callee_layout = subst_var env func in
+    assert(Lambda.compatible_layout callee_layout Lambda.layout_function);
+    let args, args_layout = List.split (subst_vars env args) in
     Ugeneric_apply (check_closure t callee (Flambda.Expr (Var func)),
-      subst_vars env args, args_layout, result_layout, (reg_close, mode), dbg)
+      args, args_layout, result_layout, (reg_close, mode), dbg),
+    result_layout
   | Apply { probe = Some {name}; _ } ->
     Misc.fatal_errorf "Cannot apply indirect handler for probe %s" name ()
   | Switch (arg, sw) ->
-    let aux () : Clambda.ulambda =
+    let aux () : Clambda.ulambda * Lambda.layout =
       let const_index, const_actions =
-        to_clambda_switch t env sw.consts sw.numconsts sw.failaction
+        to_clambda_switch t env sw.consts sw.numconsts sw.failaction sw.kind
       in
       let block_index, block_actions =
-        to_clambda_switch t env sw.blocks sw.numblocks sw.failaction
+        to_clambda_switch t env sw.blocks sw.numblocks sw.failaction sw.kind
       in
-      Uswitch (subst_var env arg,
+      let arg, arg_layout = subst_var env arg in
+      assert(Lambda.compatible_layout arg_layout Lambda.layout_any_value);
+      Uswitch (arg,
         { us_index_consts = const_index;
           us_actions_consts = const_actions;
           us_index_blocks = block_index;
           us_actions_blocks = block_actions;
         },
-        Debuginfo.none, sw.kind)  (* debug info will be added by GPR#855 *)
+        Debuginfo.none, sw.kind),  (* debug info will be added by GPR#855 *)
+      sw.kind
     in
     (* Check that the [failaction] may be duplicated.  If this is not the
        case, share it through a static raise / static catch. *)
@@ -320,130 +334,207 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
       to_clambda t env expr
     end
   | String_switch (arg, sw, def, kind) ->
-    let arg = subst_var env arg in
-    let sw = List.map (fun (s, e) -> s, to_clambda t env e) sw in
-    let def = Option.map (to_clambda t env) def in
-    Ustringswitch (arg, sw, def, kind)
+    let arg, arg_layout = subst_var env arg in
+    assert(Lambda.compatible_layout arg_layout Lambda.layout_string);
+    let sw =
+      List.map (fun (s, e) ->
+          let e, layout = to_clambda t env e in
+          assert(Lambda.compatible_layout layout kind);
+          s, e
+        ) sw
+    in
+    let def =
+      Option.map (fun e ->
+          let e, layout = to_clambda t env e in
+          assert(Lambda.compatible_layout layout kind);
+          e
+        ) def
+    in
+    Ustringswitch (arg, sw, def, kind), kind
   | Static_raise (static_exn, args) ->
-    Ustaticfail (Static_exception.to_int static_exn,
-      List.map (subst_var env) args)
+    (* CR pchambart: there probably should be an assertion that the
+       layouts matches the static_catch ones *)
+    let args =
+      List.map (fun arg ->
+          let arg, _layout = subst_var env arg in
+          arg
+        ) args
+    in
+    Ustaticfail (Static_exception.to_int static_exn, args),
+    Lambda.layout_bottom
   | Static_catch (static_exn, vars, body, handler, kind) ->
     let env_handler, ids =
-      List.fold_right (fun var (env, ids) ->
-          let id, env = Env.add_fresh_ident env var in
-          env, (VP.create id, Lambda.layout_top) :: ids)
+      List.fold_right (fun (var, layout) (env, ids) ->
+          let id, env = Env.add_fresh_ident env var layout in
+          env, (VP.create id, layout) :: ids)
         vars (env, [])
     in
+    let body, body_layout = to_clambda t env body in
+    let handler, handler_layout = to_clambda t env_handler handler in
+    assert(Lambda.compatible_layout body_layout kind);
+    assert(Lambda.compatible_layout handler_layout kind);
     Ucatch (Static_exception.to_int static_exn, ids,
-      to_clambda t env body, to_clambda t env_handler handler, kind)
+      body, handler, kind),
+    kind
   | Try_with (body, var, handler, kind) ->
-    let id, env_handler = Env.add_fresh_ident env var in
-    Utrywith (to_clambda t env body, VP.create id,
-      to_clambda t env_handler handler, kind)
+    let id, env_handler = Env.add_fresh_ident env var Lambda.layout_exception in
+    let body, body_layout = to_clambda t env body in
+    let handler, handler_layout = to_clambda t env_handler handler in
+    assert(Lambda.compatible_layout body_layout kind);
+    assert(Lambda.compatible_layout handler_layout kind);
+    Utrywith (body, VP.create id, handler, kind),
+    kind
   | If_then_else (arg, ifso, ifnot, kind) ->
-    Uifthenelse (subst_var env arg, to_clambda t env ifso,
-      to_clambda t env ifnot, kind)
+    let arg, arg_layout = subst_var env arg in
+    let ifso, ifso_layout = to_clambda t env ifso in
+    let ifnot, ifnot_layout = to_clambda t env ifnot in
+    assert(Lambda.compatible_layout arg_layout Lambda.layout_any_value);
+    assert(Lambda.compatible_layout ifso_layout kind);
+    assert(Lambda.compatible_layout ifnot_layout kind);
+    Uifthenelse (arg, ifso, ifnot, kind),
+    kind
   | While (cond, body) ->
-    Uwhile (to_clambda t env cond, to_clambda t env body)
+    let cond, cond_layout = to_clambda t env cond in
+    let body, body_layout = to_clambda t env body in
+    assert(Lambda.compatible_layout cond_layout Lambda.layout_any_value);
+    assert(Lambda.compatible_layout body_layout Lambda.layout_unit);
+    Uwhile (cond, body),
+    Lambda.layout_unit
   | For { bound_var; from_value; to_value; direction; body } ->
-    let id, env_body = Env.add_fresh_ident env bound_var in
-    Ufor (VP.create id, subst_var env from_value, subst_var env to_value,
-      direction, to_clambda t env_body body)
+    let id, env_body = Env.add_fresh_ident env bound_var Lambda.layout_int in
+    let from_value, from_value_layout = subst_var env from_value in
+    let to_value, to_value_layout = subst_var env to_value in
+    let body, body_layout = to_clambda t env_body body in
+    assert(Lambda.compatible_layout from_value_layout Lambda.layout_int);
+    assert(Lambda.compatible_layout to_value_layout Lambda.layout_int);
+    assert(Lambda.compatible_layout body_layout Lambda.layout_unit);
+    Ufor (VP.create id, from_value, to_value, direction, body),
+    Lambda.layout_unit
   | Assign { being_assigned; new_value } ->
-    let id =
+    let id, id_layout =
       try Env.ident_for_mutable_var_exn env being_assigned
       with Not_found ->
         Misc.fatal_errorf "Unbound mutable variable %a in [Assign]: %a"
           Mutable_variable.print being_assigned
           Flambda.print flam
     in
-    Uassign (id, subst_var env new_value)
-  | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
-    let args_layout = List.map (fun _ -> Lambda.layout_top) args in
-    let result_layout = Lambda.layout_top in
-    Usend (kind, subst_var env meth, subst_var env obj,
-      subst_vars env args, args_layout, result_layout, (reg_close,mode), dbg)
+    let new_value, new_value_layout = subst_var env new_value in
+    assert(Lambda.compatible_layout id_layout new_value_layout);
+    Uassign (id, new_value),
+    Lambda.layout_unit
+  | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
+    let args, args_layout = List.split (subst_vars env args) in
+    let meth, _meth_layout = subst_var env meth in
+    let obj, _obj_layout = subst_var env obj in
+    Usend (kind, meth, obj,
+      args, args_layout, result_layout, (reg_close,mode), dbg),
+    result_layout
   | Region body ->
-      let body = to_clambda t env body in
+      let body, body_layout = to_clambda t env body in
       let is_trivial =
         match body with
         | Uvar _ | Uconst _ -> true
         | _ -> false
       in
-      if is_trivial then body
-      else Uregion body
+      if is_trivial then body, body_layout
+      else Uregion body, body_layout
   | Tail body ->
-      let body = to_clambda t env body in
+      let body, body_layout = to_clambda t env body in
       let is_trivial =
         match body with
         | Uvar _ | Uconst _ -> true
         | _ -> false
       in
-      if is_trivial then body
-      else Utail body
-  | Proved_unreachable -> Uunreachable
+      if is_trivial then body, body_layout
+      else Utail body, body_layout
+  | Proved_unreachable -> Uunreachable, Lambda.layout_bottom
 
-and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda =
+and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda * Lambda.layout =
   match named with
-  | Symbol sym -> to_clambda_symbol env sym
-  | Const (Int n) -> Uconst (Uconst_int n)
-  | Const (Char c) -> Uconst (Uconst_int (Char.code c))
+  | Symbol sym -> to_clambda_symbol env sym, Lambda.layout_any_value
+  | Const (Int n) -> Uconst (Uconst_int n), Lambda.layout_int
+  | Const (Char c) -> Uconst (Uconst_int (Char.code c)), Lambda.layout_int
   | Allocated_const _ ->
     Misc.fatal_errorf "[Allocated_const] should have been lifted to a \
         [Let_symbol] construction before [Flambda_to_clambda]: %a = %a"
       Variable.print var
       Flambda.print_named named
   | Read_mutable mut_var ->
-    begin try Uvar (Env.ident_for_mutable_var_exn env mut_var)
+    begin try
+      let mut_var, layout = Env.ident_for_mutable_var_exn env mut_var in
+      Uvar mut_var, layout
     with Not_found ->
       Misc.fatal_errorf "Unbound mutable variable %a in [Read_mutable]: %a"
         Mutable_variable.print mut_var
         Flambda.print_named named
     end
   | Read_symbol_field (symbol, field) ->
-    Uprim (Pfield field, [to_clambda_symbol env symbol], Debuginfo.none)
+    Uprim (Pfield field, [to_clambda_symbol env symbol], Debuginfo.none),
+    Lambda.layout_any_value
   | Set_of_closures set_of_closures ->
-    to_clambda_set_of_closures t env set_of_closures
+    to_clambda_set_of_closures t env set_of_closures,
+    Lambda.layout_any_value
   | Project_closure { set_of_closures; closure_id } ->
     (* Note that we must use [build_uoffset] to ensure that we do not generate
        a [Uoffset] construction in the event that the offset is zero, otherwise
        we might break pattern matches in Cmmgen (in particular for the
        compilation of "let rec"). *)
+    let set_of_closures_expr, _layout_set_of_closures =
+      subst_var env set_of_closures
+    in
     check_closure t (
       build_uoffset
-        (check_closure t (subst_var env set_of_closures)
+        (check_closure t set_of_closures_expr
            (Flambda.Expr (Var set_of_closures)))
         (get_fun_offset t closure_id))
-      named
+      named,
+    Lambda.layout_function
   | Move_within_set_of_closures { closure; start_from; move_to } ->
+    let closure_expr, _layout_closure = subst_var env closure in
     check_closure t (build_uoffset
-      (check_closure t (subst_var env closure)
+      (check_closure t closure_expr
          (Flambda.Expr (Var closure)))
       ((get_fun_offset t move_to) - (get_fun_offset t start_from)))
-      named
-  | Project_var { closure; var; closure_id } ->
-    let ulam = subst_var env closure in
+      named,
+    Lambda.layout_function
+  | Project_var { closure; var; closure_id; kind } ->
+    let ulam, _closure_layout = subst_var env closure in
     let fun_offset = get_fun_offset t closure_id in
     let var_offset = get_fv_offset t var in
     let pos = var_offset - fun_offset in
     Uprim (Pfield pos,
       [check_field t (check_closure t ulam (Expr (Var closure)))
          pos (Some named)],
-      Debuginfo.none)
+      Debuginfo.none),
+    kind
   | Prim (Pfield index, [block], dbg) ->
-    Uprim (Pfield index, [check_field t (subst_var env block) index None], dbg)
+    let block, _block_layout = subst_var env block in
+    Uprim (Pfield index, [check_field t block index None], dbg),
+    Lambda.layout_field
   | Prim (Psetfield (index, maybe_ptr, init), [block; new_value], dbg) ->
+    let block, _block_layout = subst_var env block in
+    let new_value, _new_value_layout = subst_var env new_value in
     Uprim (Psetfield (index, maybe_ptr, init), [
-        check_field t (subst_var env block) index None;
-        subst_var env new_value;
-      ], dbg)
+        check_field t block index None;
+        new_value;
+      ], dbg),
+    Lambda.layout_unit
   | Prim (Popaque, args, dbg) ->
-    Uprim (Popaque, subst_vars env args, dbg)
+    let arg = match args with
+      | [arg] -> arg
+      | [] | _ :: _ :: _ -> assert false
+    in
+    let arg, arg_layout = subst_var env arg in
+    Uprim (Popaque, [arg], dbg),
+    arg_layout
   | Prim (p, args, dbg) ->
-    Uprim (p, subst_vars env args, dbg)
+    let args, _args_layout = List.split (subst_vars env args) in
+    let result_layout = ocaml/middle_end/clambda_primitives.result_layout p in
+    Uprim (p, args, dbg),
+    result_layout
   | Expr expr -> to_clambda t env expr
 
-and to_clambda_switch t env cases num_keys default =
+and to_clambda_switch t env cases num_keys default kind =
   let num_keys =
     if Numbers.Int.Set.cardinal num_keys = 0 then 0
     else Numbers.Int.Set.max_elt num_keys + 1
@@ -470,12 +561,18 @@ and to_clambda_switch t env cases num_keys default =
          if act >= 0 then action := act else index.(i) <- !action)
       index
   end;
-  let actions = Array.map (to_clambda t env) (store.act_get ()) in
+  let actions =
+    Array.map (fun action ->
+        let action, action_layout = to_clambda t env action in
+        assert(Lambda.compatible_layout action_layout kind);
+        action
+      ) (store.act_get ())
+  in
   match actions with
   | [| |] -> [| |], [| |]  (* May happen when [default] is [None]. *)
   | _ -> index, actions
 
-and to_clambda_direct_apply t func args direct_func probe dbg pos mode env
+and to_clambda_direct_apply t func args direct_func probe dbg pos mode result_layout env
   : Clambda.ulambda =
   let closed = is_function_constant t direct_func in
   let label =
@@ -484,13 +581,15 @@ and to_clambda_direct_apply t func args direct_func probe dbg pos mode env
     |> Linkage_name.to_string
   in
   let uargs =
-    let uargs = subst_vars env args in
+    let uargs, _uargs_layout = List.split (subst_vars env args) in
     (* Remove the closure argument if the closure is closed.  (Note that the
        closure argument is always a variable, so we can be sure we are not
        dropping any side effects.) *)
-    if closed then uargs else uargs @ [subst_var env func]
+    if closed then uargs else
+      let func, func_layout = subst_var env func in
+      assert(Lambda.compatible_layout func_layout Lambda.layout_function);
+      uargs @ [func]
   in
-  let result_layout = Lambda.layout_top in
   Udirect_apply (label, uargs, probe, result_layout, (pos, mode), dbg)
 
 (* Describe how to build a runtime closure block that corresponds to the
@@ -537,7 +636,7 @@ and to_clambda_set_of_closures t env
       let env = Env.keep_only_symbols env in
       (* Add the Clambda expressions for the free variables of the function
          to the environment. *)
-      let add_env_free_variable id _ env =
+      let add_env_free_variable id (spec_to : Flambda.specialised_to) env =
         let var_offset =
           try
             Var_within_closure.Map.find
@@ -551,6 +650,7 @@ and to_clambda_set_of_closures t env
         let pos = var_offset - fun_offset in
         Env.add_subst env id
           (Uprim (Pfield pos, [Clambda.Uvar env_var], Debuginfo.none))
+          spec_to.kind
       in
       let env = Variable.Map.fold add_env_free_variable free_vars env in
       (* Add the Clambda expressions for all functions defined in the current
@@ -563,13 +663,16 @@ and to_clambda_set_of_closures t env
             t.current_unit.fun_offset_table
         in
         let exp : Clambda.ulambda = Uoffset (Uvar env_var, offset - pos) in
-        Env.add_subst env id exp
+        Env.add_subst env id exp Lambda.layout_function
       in
       List.fold_left (add_env_function fun_offset) env all_functions
     in
     let env_body, params =
-      List.fold_right (fun var (env, params) ->
-          let id, env = Env.add_fresh_ident env (Parameter.var var) in
+      List.fold_right (fun param (env, params) ->
+          let id, env =
+            Env.add_fresh_ident env
+              (Parameter.var param) (Parameter.kind param)
+          in
           env, VP.create id :: params)
         function_decl.params (env, [])
     in
@@ -578,10 +681,11 @@ and to_clambda_set_of_closures t env
       |> Symbol.linkage_name
       |> Linkage_name.to_string
     in
+    let body, _body_layout = to_clambda t env_body function_decl.body in
     { label;
       arity = clambda_arity function_decl;
       params = params @ [VP.create env_var];
-      body = to_clambda t env_body function_decl.body;
+      body;
       dbg = function_decl.dbg;
       env = Some env_var;
       mode = set_of_closures.alloc_mode;
@@ -600,7 +704,10 @@ and to_clambda_set_of_closures t env
     List.map snd (
       Variable.Map.bindings (Variable.Map.map (
           fun (free_var : Flambda.specialised_to) ->
-            subst_var env free_var.var) free_vars))
+            let var, var_layout = subst_var env free_var.var in
+            assert(Lambda.compatible_layout var_layout free_var.kind);
+            var
+        ) free_vars))
   in
   Uclosure {
     functions ;
@@ -622,19 +729,24 @@ and to_clambda_closed_set_of_closures t env symbol
       List.fold_left (fun env (var, _) ->
           let closure_id = Closure_id.wrap var in
           let symbol = Symbol_utils.Flambda.for_closure closure_id in
-          Env.add_subst env var (to_clambda_symbol env symbol))
+          Env.add_subst env var (to_clambda_symbol env symbol)
+            Lambda.layout_function)
         (Env.keep_only_symbols env)
         functions
     in
     let env_body, params =
-      List.fold_right (fun var (env, params) ->
-          let id, env = Env.add_fresh_ident env (Parameter.var var) in
+      List.fold_right (fun param (env, params) ->
+          let id, env =
+            Env.add_fresh_ident env
+              (Parameter.var param) (Parameter.kind param)
+          in
           env, VP.create id :: params)
         function_decl.params (env, [])
     in
     let body =
-      Un_anf.apply ~ppf_dump:t.ppf_dump ~what:symbol
-        (to_clambda t env_body function_decl.body)
+      let body, body_layout = to_clambda t env_body function_decl.body in
+      assert(Lambda.compatible_layout body_layout function_decl.return_layout);
+      Un_anf.apply ~ppf_dump:t.ppf_dump ~what:symbol body
     in
     let label =
       Symbol_utils.Flambda.for_code_of_closure (Closure_id.wrap id)
@@ -657,7 +769,11 @@ and to_clambda_closed_set_of_closures t env symbol
 
 let to_clambda_initialize_symbol t env symbol fields : Clambda.ulambda =
   let fields =
-    List.map (fun (index, expr) -> index, to_clambda t env expr) fields
+    List.map (fun (index, expr) ->
+        let expr, expr_layout = to_clambda t env expr in
+        assert(Lambda.compatible_layout expr_layout Lambda.layout_any_value);
+        index, expr
+      ) fields
   in
   let build_setfield (index, field) : Clambda.ulambda =
     (* Note that this will never cause a write barrier hit, owing to
@@ -755,7 +871,7 @@ let to_clambda_program t env constants (program : Flambda.program) =
       let e2, constants, preallocated_blocks = loop env constants program in
       Usequence (e1, e2), constants, preallocated_block :: preallocated_blocks
     | Effect (expr, program) ->
-      let e1 = to_clambda t env expr in
+      let e1, _e1_layout = to_clambda t env expr in
       let e2, constants, preallocated_blocks = loop env constants program in
       Usequence (e1, e2), constants, preallocated_blocks
     | End _ ->

--- a/ocaml/middle_end/flambda/flambda_utils.ml
+++ b/ocaml/middle_end/flambda/flambda_utils.ml
@@ -367,7 +367,7 @@ let make_closure_declaration
       ~params:(List.map subst_param params) ~alloc_mode  ~region
       ~return_layout
       ~body ~stub:true ~dbg:Debuginfo.none ~inline:Default_inline
-      ~specialise:Default_specialise ~check:Default_check ~is_a_functor:false
+      ~specialise:Default_specialise ~is_a_functor:false
       ~closure_origin:(Closure_origin.create (Closure_id.wrap id))
       ~poll:Default_poll
   in

--- a/ocaml/middle_end/flambda/flambda_utils.mli
+++ b/ocaml/middle_end/flambda/flambda_utils.mli
@@ -69,6 +69,7 @@ val make_closure_declaration
   -> region:bool
   -> body:Flambda.t
   -> params:Parameter.t list
+  -> return_layout:Lambda.layout
   -> free_variables:Lambda.layout Variable.Map.t
   -> Flambda.t
 

--- a/ocaml/middle_end/flambda/freshening.ml
+++ b/ocaml/middle_end/flambda/freshening.ml
@@ -322,6 +322,7 @@ module Project_var = struct
         let function_decl =
           Flambda.create_function_declaration
             ~params ~alloc_mode:func_decl.alloc_mode ~region:func_decl.region
+            ~return_layout:func_decl.return_layout
             ~body
             ~stub:func_decl.stub ~dbg:func_decl.dbg
             ~inline:func_decl.inline ~specialise:func_decl.specialise
@@ -417,11 +418,12 @@ let does_not_freshen t vars =
 let freshen_projection (projection : Projection.t) ~freshening
       ~closure_freshening : Projection.t =
   match projection with
-  | Project_var { closure; closure_id; var; } ->
+  | Project_var { closure; closure_id; var; kind } ->
     Project_var {
       closure = apply_variable freshening closure;
       closure_id = Project_var.apply_closure_id closure_freshening closure_id;
       var = Project_var.apply_var_within_closure closure_freshening var;
+      kind;
     }
   | Project_closure { set_of_closures; closure_id; } ->
     Project_closure {

--- a/ocaml/middle_end/flambda/inconstant_idents.ml
+++ b/ocaml/middle_end/flambda/inconstant_idents.ml
@@ -253,7 +253,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_loop ~toplevel [] f1;
       mark_loop ~toplevel [] f2
     | Static_catch (_,ids,f1,f2, _) ->
-      List.iter (fun id -> mark_curr [Var id]) ids;
+      List.iter (fun (id, _layout) -> mark_curr [Var id]) ids;
       mark_curr curr;
       mark_loop ~toplevel [] f1;
       mark_loop ~toplevel [] f2

--- a/ocaml/middle_end/flambda/inline_and_simplify.ml
+++ b/ocaml/middle_end/flambda/inline_and_simplify.ml
@@ -468,6 +468,7 @@ let rec simplify_project_var env r ~(project_var : Flambda.project_var)
           closure;
           closure_id;
           var;
+          kind = project_var.kind;
         }
       in
       begin match E.find_projection env ~projection with
@@ -477,7 +478,9 @@ let rec simplify_project_var env r ~(project_var : Flambda.project_var)
           Expr (Var var), ret r var_approx)
       | None ->
         let approx = A.approx_for_bound_var value_set_of_closures var in
-        let expr : Flambda.named = Project_var { closure; closure_id; var; } in
+        let expr : Flambda.named =
+          Project_var { closure; closure_id; var; kind = project_var.kind; }
+        in
         let unwrapped = Var_within_closure.unwrap var in
         let expr =
           if E.mem env unwrapped then
@@ -610,6 +613,7 @@ and simplify_set_of_closures original_env r
     let function_decl =
       Flambda.create_function_declaration
         ~params:function_decl.params
+        ~return_layout:function_decl.return_layout
         ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
         ~body ~stub:function_decl.stub ~dbg:function_decl.dbg
         ~inline:function_decl.inline ~specialise:function_decl.specialise
@@ -673,7 +677,7 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
   let {
     Flambda. func = lhs_of_application; args; kind = _; dbg; reg_close; mode;
     inlined = inlined_requested; specialise = specialise_requested;
-    probe = probe_requested;
+    probe = probe_requested; result_layout
   } = apply in
   let r =
     match reg_close, mode with
@@ -762,7 +766,7 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
           end;
           let result, r =
             if nargs = arity then
-              simplify_full_application env r ~function_decls
+              simplify_full_application env r ~function_decls ~result_layout
                 ~lhs_of_application ~closure_id_being_applied ~function_decl
                 ~value_set_of_closures ~args ~args_approxs ~dbg ~reg_close ~mode
                 ~inlined_requested ~specialise_requested ~probe_requested
@@ -770,11 +774,11 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
               simplify_over_application env r ~args ~args_approxs
                 ~function_decls ~lhs_of_application ~closure_id_being_applied
                 ~function_decl ~value_set_of_closures ~dbg ~reg_close ~mode
-                ~inlined_requested ~specialise_requested
+                ~inlined_requested ~specialise_requested ~result_layout
             else if nargs > 0 && nargs < arity then
               simplify_partial_application env r ~lhs_of_application
                 ~closure_id_being_applied ~function_decl ~args ~mode ~dbg
-                ~inlined_requested ~specialise_requested
+                ~inlined_requested ~specialise_requested ~result_layout
             else
               Misc.fatal_errorf "Function with arity %d when simplifying \
                   application expression: %a"
@@ -787,22 +791,23 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
                    inlined = inlined_requested;
                    specialise = specialise_requested;
                    probe = probe_requested;
+                   result_layout;
                  }),
             ret r (A.value_unknown Other)))
 
 and simplify_full_application env r ~function_decls ~lhs_of_application
       ~closure_id_being_applied ~function_decl ~value_set_of_closures ~args
-      ~args_approxs ~dbg ~reg_close ~mode
+      ~args_approxs ~dbg ~reg_close ~mode ~result_layout
       ~inlined_requested ~specialise_requested ~probe_requested
   =
   Inlining_decision.for_call_site ~env ~r ~function_decls
     ~lhs_of_application ~closure_id_being_applied ~function_decl
     ~value_set_of_closures ~args ~args_approxs ~dbg ~reg_close ~mode ~simplify
-    ~inlined_requested ~specialise_requested ~probe_requested
+    ~inlined_requested ~specialise_requested ~probe_requested ~result_layout
 
 and simplify_partial_application env r ~lhs_of_application
       ~closure_id_being_applied ~function_decl ~args ~mode ~dbg
-      ~inlined_requested ~specialise_requested
+      ~inlined_requested ~specialise_requested ~result_layout
   =
   let arity = A.function_arity function_decl in
   assert (arity > List.length args);
@@ -860,8 +865,10 @@ and simplify_partial_application env r ~lhs_of_application
         inlined = Default_inlined;
         specialise = Default_specialise;
         probe = None;
+        result_layout;
       }
     in
+    assert(Lambda.compatible_layout function_decl.A.return_layout result_layout);
     let closure_variable =
       Variable.rename
         (Closure_id.unwrap closure_id_being_applied)
@@ -879,6 +886,7 @@ and simplify_partial_application env r ~lhs_of_application
       ~alloc_mode:partial_mode
       ~region:function_decl.A.region
       ~params:remaining_args
+      ~return_layout:function_decl.A.return_layout
       ~free_variables
   in
   let with_known_args =
@@ -891,7 +899,7 @@ and simplify_partial_application env r ~lhs_of_application
 
 and simplify_over_application env r ~args ~args_approxs ~function_decls
       ~lhs_of_application ~closure_id_being_applied ~function_decl
-      ~value_set_of_closures ~dbg ~reg_close ~mode
+      ~value_set_of_closures ~dbg ~reg_close ~mode ~result_layout
       ~inlined_requested ~specialise_requested =
   let arity = A.function_arity function_decl in
   assert (arity < List.length args);
@@ -910,13 +918,14 @@ and simplify_over_application env r ~args ~args_approxs ~function_decls
       ~closure_id_being_applied ~function_decl ~value_set_of_closures
       ~args:full_app_args ~args_approxs:full_app_approxs ~dbg
       ~reg_close:Lambda.Rc_normal ~mode:mode'
+      ~result_layout:Lambda.layout_function
       ~inlined_requested ~specialise_requested ~probe_requested:None
   in
   let func_var = Variable.create Internal_variable_names.full_apply in
   let expr : Flambda.t =
     Flambda.create_let func_var (Expr expr)
       (Apply { func = func_var; args = remaining_args; kind = Indirect; dbg;
-               reg_close = Rc_normal; mode;
+               reg_close = Rc_normal; mode; result_layout;
                inlined = inlined_requested; specialise = specialise_requested;
                probe = None})
   in
@@ -1249,17 +1258,17 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
           | Static_raise (j, args) ->
             assert (Static_exception.equal i j);
             let handler =
-              List.fold_left2 (fun body var arg ->
+              List.fold_left2 (fun body (var, _layout) arg ->
                   Flambda.create_let var (Expr (Var arg)) body)
                 handler vars args
             in
             let r = R.exit_scope_catch r i in
             simplify env r handler
           | _ ->
-            let vars, sb = Freshening.add_variables' (E.freshening env) vars in
+            let vars, sb = Freshening.add_variables (E.freshening env) vars in
             let approx = R.approx r in
             let env =
-              List.fold_left (fun env id ->
+              List.fold_left (fun env (id, _layout) ->
                   E.add env id (A.value_unknown Other))
                 (E.set_freshening env sb) vars
             in
@@ -1302,12 +1311,12 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
     let cond, r = simplify env r cond in
     let body, r = simplify env r body in
     While (cond, body), ret r (A.value_unknown Other)
-  | Send { kind; meth; obj; args; dbg; reg_close; mode } ->
+  | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
     let dbg = E.add_inlined_debuginfo env ~dbg in
     simplify_free_variable env meth ~f:(fun env meth _meth_approx ->
       simplify_free_variable env obj ~f:(fun env obj _obj_approx ->
         simplify_free_variables env args ~f:(fun _env args _args_approx ->
-          Send { kind; meth; obj; args; dbg; reg_close; mode },
+          Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout },
             ret r (A.value_unknown Other))))
   | For { bound_var; from_value; to_value; direction; body; } ->
     simplify_free_variable env from_value ~f:(fun env from_value _approx ->
@@ -1508,6 +1517,7 @@ and duplicate_function ~env ~(set_of_closures : Flambda.set_of_closures)
   let function_decl =
     Flambda.create_function_declaration
       ~params:function_decl.params
+      ~return_layout:function_decl.return_layout
       ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
       ~body ~stub:function_decl.stub ~dbg:function_decl.dbg
       ~inline:function_decl.inline ~specialise:function_decl.specialise

--- a/ocaml/middle_end/flambda/inlining_decision.ml
+++ b/ocaml/middle_end/flambda/inlining_decision.ml
@@ -201,7 +201,7 @@ let inline env r ~lhs_of_application
       Inlining_transforms.inline_by_copying_function_body ~env
         ~r:(R.reset_benefit r) ~lhs_of_application
         ~closure_id_being_applied ~specialise_requested ~inlined_requested
-        ~probe_requested
+        ~probe_requested ~free_vars:value_set_of_closures.A.free_vars
         ~function_decl ~function_body ~fun_vars ~args ~dbg ~reg_close ~mode ~simplify
     in
     let num_direct_applications_seen =
@@ -490,7 +490,7 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
       ~(function_decl : A.function_declaration)
       ~(value_set_of_closures : A.value_set_of_closures)
       ~args ~args_approxs ~dbg ~reg_close ~mode ~simplify ~inlined_requested
-      ~specialise_requested ~probe_requested =
+      ~specialise_requested ~probe_requested ~result_layout =
   if List.length args <> List.length args_approxs then begin
     Misc.fatal_error "Inlining_decision.for_call_site: inconsistent lengths \
         of [args] and [args_approxs]"
@@ -514,6 +514,7 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
     Flambda.Apply {
       func = lhs_of_application;
       args;
+      result_layout;
       kind = Direct closure_id_being_applied;
       dbg;
       reg_close;
@@ -536,7 +537,7 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
         Inlining_transforms.inline_by_copying_function_body ~env
           ~r ~fun_vars ~lhs_of_application
           ~closure_id_being_applied ~specialise_requested ~inlined_requested
-          ~probe_requested
+          ~probe_requested ~free_vars:value_set_of_closures.free_vars
           ~function_decl ~function_body ~args ~dbg ~reg_close ~mode ~simplify
       in
       simplify env r body
@@ -575,7 +576,7 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
               Inlining_transforms.inline_by_copying_function_body ~env
                 ~r ~function_body ~lhs_of_application
                 ~closure_id_being_applied ~specialise_requested
-                ~probe_requested
+                ~probe_requested ~free_vars:value_set_of_closures.free_vars
                 ~inlined_requested ~function_decl ~fun_vars ~args
                 ~dbg ~reg_close ~mode ~simplify
             in

--- a/ocaml/middle_end/flambda/inlining_decision.mli
+++ b/ocaml/middle_end/flambda/inlining_decision.mli
@@ -38,6 +38,7 @@ val for_call_site
   -> inlined_requested:Lambda.inlined_attribute
   -> specialise_requested:Lambda.specialise_attribute
   -> probe_requested:Lambda.probe
+  -> result_layout:Lambda.layout
   -> Flambda.t * Inline_and_simplify_aux.Result.t
 
 (** When a function declaration is encountered by [for_call_site], the body

--- a/ocaml/middle_end/flambda/inlining_transforms.ml
+++ b/ocaml/middle_end/flambda/inlining_transforms.ml
@@ -32,13 +32,15 @@ let new_var name =
     user-specified function as an [Flambda.named] value that projects the
     variable from its closure. *)
 let fold_over_projections_of_vars_bound_by_closure ~closure_id_being_applied
-      ~lhs_of_application ~bound_variables ~init ~f =
+      ~lhs_of_application ~bound_variables
+      ~(free_vars : Flambda.specialised_to Variable.Map.t) ~init ~f =
   Variable.Set.fold (fun var acc ->
       let expr : Flambda.named =
         Project_var {
           closure = lhs_of_application;
           closure_id = closure_id_being_applied;
           var = Var_within_closure.wrap var;
+          kind = (Variable.Map.find var free_vars).kind;
         }
       in
       f ~acc ~var ~expr)
@@ -97,6 +99,7 @@ let inline_by_copying_function_body ~env ~r
       ~(function_decl : A.function_declaration)
       ~(function_body : A.function_body)
       ~fun_vars
+      ~(free_vars : Flambda.specialised_to Variable.Map.t)
       ~args ~dbg ~reg_close ~mode:_ ~simplify =
   assert (E.mem env lhs_of_application);
   assert (List.for_all (E.mem env) args);
@@ -150,6 +153,7 @@ let inline_by_copying_function_body ~env ~r
     fold_over_projections_of_vars_bound_by_closure ~closure_id_being_applied
       ~lhs_of_application ~bound_variables ~init:bindings_for_params_to_args
       ~f:(fun ~acc:body ~var ~expr -> Flambda.create_let var expr body)
+      ~free_vars
   in
   (* Add bindings for variables corresponding to the functions introduced by
      the whole set of closures.  Each such variable will be bound to a closure;
@@ -231,6 +235,7 @@ let bind_free_vars ~lhs_of_application ~closure_id_being_applied
            closure = lhs_of_application;
            closure_id = closure_id_being_applied;
            var = Var_within_closure.wrap free_var;
+           kind = spec.kind;
          }
        in
        let let_bindings = (var_clos, expr) :: state.let_bindings in
@@ -344,7 +349,7 @@ let add_fun_var ~lhs_of_application ~closure_id_being_applied ~state ~fun_var =
     in
     let let_bindings = (outside_var, expr) :: state.let_bindings in
     let spec : Flambda.specialised_to =
-      { var = outside_var; projection = None; kind = Lambda.layout_top }
+      { var = outside_var; projection = None; kind = Lambda.layout_function }
     in
     let new_free_vars_with_old_projections =
       Variable.Map.add inside_var spec state.new_free_vars_with_old_projections
@@ -541,6 +546,7 @@ let rewrite_function ~lhs_of_application ~closure_id_being_applied
     Flambda.create_function_declaration
       ~params ~alloc_mode:function_decl.alloc_mode ~region:function_decl.region
       ~body
+      ~return_layout:function_decl.return_layout
       ~stub:function_body.stub
       ~dbg:function_body.dbg
       ~inline:function_body.inline
@@ -673,7 +679,7 @@ let inline_by_copying_function_declaration
       in
       let apply : Flambda.apply =
         { func = closure_var; args; kind = Direct closure_id; dbg;
-          reg_close; mode;
+          reg_close; mode; result_layout = function_decl.return_layout;
           inlined = inlined_requested; specialise = Default_specialise;
           probe = probe_requested;
         }

--- a/ocaml/middle_end/flambda/inlining_transforms.mli
+++ b/ocaml/middle_end/flambda/inlining_transforms.mli
@@ -75,6 +75,7 @@ val inline_by_copying_function_body
   -> function_decl:Simple_value_approx.function_declaration
   -> function_body:Simple_value_approx.function_body
   -> fun_vars:Variable.Set.t
+  -> free_vars:Flambda.specialised_to Variable.Map.t
   -> args:Variable.t list
   -> dbg:Debuginfo.t
   -> reg_close:Lambda.region_close

--- a/ocaml/middle_end/flambda/projection.ml
+++ b/ocaml/middle_end/flambda/projection.ml
@@ -34,6 +34,7 @@ type project_var = {
   closure : Variable.t;
   closure_id : Closure_id.t;
   var : Var_within_closure.t;
+  kind : Lambda.layout;
 }
 
 let compare_project_var

--- a/ocaml/middle_end/flambda/projection.mli
+++ b/ocaml/middle_end/flambda/projection.mli
@@ -41,6 +41,7 @@ type project_var = {
   closure : Variable.t;  (** must yield a closure *)
   closure_id : Closure_id.t;
   var : Var_within_closure.t;
+  kind : Lambda.layout;
 }
 
 val print_project_closure

--- a/ocaml/middle_end/flambda/remove_unused_arguments.ml
+++ b/ocaml/middle_end/flambda/remove_unused_arguments.ml
@@ -42,6 +42,7 @@ let remove_params unused (fun_decl: Flambda.function_declaration)
   Flambda.create_function_declaration
     ~params:used_params ~alloc_mode:fun_decl.alloc_mode ~region:fun_decl.region
     ~body
+    ~return_layout:fun_decl.return_layout
     ~stub:fun_decl.stub ~dbg:fun_decl.dbg ~inline:fun_decl.inline
     ~specialise:fun_decl.specialise ~is_a_functor:fun_decl.is_a_functor
     ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
@@ -93,6 +94,7 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
     Apply {
       func = renamed;
       args = Parameter.List.vars args;
+      result_layout = fun_decl.return_layout;
       kind;
       dbg = fun_decl.dbg;
       reg_close = Rc_normal;
@@ -106,7 +108,7 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
     Flambda.create_function_declaration
       ~params:(List.map snd args')
       ~alloc_mode:fun_decl.alloc_mode ~region:fun_decl.region
-      ~body
+      ~body ~return_layout:fun_decl.return_layout
       ~stub:true ~dbg:fun_decl.dbg ~inline:Default_inline
       ~specialise:Default_specialise ~is_a_functor:fun_decl.is_a_functor
       ~closure_origin:fun_decl.closure_origin

--- a/ocaml/middle_end/flambda/simple_value_approx.mli
+++ b/ocaml/middle_end/flambda/simple_value_approx.mli
@@ -164,6 +164,7 @@ and function_body = private {
 and function_declaration = private {
   closure_origin : Closure_origin.t;
   params : Parameter.t list;
+  return_layout : Lambda.layout;
   alloc_mode : Lambda.alloc_mode;
   region : bool;
   function_body : function_body option;
@@ -306,10 +307,10 @@ val augment_with_symbol_field : t -> Symbol.t -> int -> t
 val replace_description : t -> descr -> t
 
 (** Improve the description by taking the kind into account *)
-val augment_with_kind : t -> Lambda.layout -> t
+val augment_with_kind : t -> Lambda.value_kind -> t
 
 (** Improve the kind by taking the description into account *)
-val augment_kind_with_approx : t -> Lambda.layout -> Lambda.layout
+val augment_kind_with_approx : t -> Lambda.value_kind -> Lambda.value_kind
 
 val equal_boxed_int : 'a boxed_int -> 'a -> 'b boxed_int -> 'b -> bool
 

--- a/ocaml/middle_end/flambda/simplify_primitives.ml
+++ b/ocaml/middle_end/flambda/simplify_primitives.ml
@@ -111,12 +111,11 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
   | Pmakeblock(tag_int, (Immutable | Immutable_unique), shape, mode) ->
     let tag = Tag.create_exn tag_int in
     let shape = match shape with
-      | None -> List.map (fun _ -> Lambda.layout_top) args
-      | Some shape -> List.map (fun kind -> Lambda.Pvalue kind) shape
+      | None -> List.map (fun _ -> Lambda.Pgenval) args
+      | Some shape -> List.map (fun kind -> kind) shape
     in
     let approxs = List.map2 A.augment_with_kind approxs shape in
     let shape = List.map2 A.augment_kind_with_approx approxs shape in
-    let shape = List.map (fun (Lambda.Pvalue kind) -> kind) shape in
     Prim (Pmakeblock(tag_int, Lambda.Immutable, Some shape, mode), args, dbg),
     A.value_block tag (Array.of_list approxs), C.Benefit.zero
   | Praise _ ->


### PR DESCRIPTION
This builds on #1106 to propagates layout where it is needed in Flambda1:
* Adds layout information in return of apply and send
* In return information of functions
* In parameters of static_catch
* In var projections
* In return information of function value approximation

Apply/Send parameters are not annotated: the information is rebuilded through flambda_to_clambda