### PR TITLE
Use the type of primitive declarations to make their layout

### DIFF
--- a/ocaml/testsuite/tests/translprim/array_spec.compilers.flat.reference
+++ b/ocaml/testsuite/tests/translprim/array_spec.compilers.flat.reference
@@ -19,45 +19,61 @@
       (array.unsafe_set[addr] addr_a 0 "a")
       (function a[genarray] x : int (array.unsafe_set[gen] a 0 x))
       (let
-        (eta_gen_len = (function prim stub (array.length[gen] prim))
+        (eta_gen_len =
+           (function prim[genarray] stub (array.length[gen] prim))
          eta_gen_safe_get =
-           (function prim prim stub (array.get[gen] prim prim))
+           (function prim[genarray] prim[int] stub
+             (array.get[gen] prim prim))
          eta_gen_unsafe_get =
-           (function prim prim stub (array.unsafe_get[gen] prim prim))
+           (function prim[genarray] prim[int] stub
+             (array.unsafe_get[gen] prim prim))
          eta_gen_safe_set =
-           (function prim prim prim stub (array.set[gen] prim prim prim))
+           (function prim[genarray] prim[int] prim stub
+             (array.set[gen] prim prim prim))
          eta_gen_unsafe_set =
-           (function prim prim prim stub
+           (function prim[genarray] prim[int] prim stub
              (array.unsafe_set[gen] prim prim prim))
-         eta_int_len = (function prim stub (array.length[int] prim))
+         eta_int_len =
+           (function prim[intarray] stub (array.length[int] prim))
          eta_int_safe_get =
-           (function prim prim stub (array.get[int] prim prim))
+           (function prim[intarray] prim[int] stub
+             (array.get[int] prim prim))
          eta_int_unsafe_get =
-           (function prim prim stub (array.unsafe_get[int] prim prim))
+           (function prim[intarray] prim[int] stub
+             (array.unsafe_get[int] prim prim))
          eta_int_safe_set =
-           (function prim prim prim stub (array.set[int] prim prim prim))
+           (function prim[intarray] prim[int] prim[int] stub
+             (array.set[int] prim prim prim))
          eta_int_unsafe_set =
-           (function prim prim prim stub
+           (function prim[intarray] prim[int] prim[int] stub
              (array.unsafe_set[int] prim prim prim))
-         eta_float_len = (function prim stub (array.length[float] prim))
+         eta_float_len =
+           (function prim[floatarray] stub (array.length[float] prim))
          eta_float_safe_get =
-           (function prim prim stub (array.get[float] prim prim))
+           (function prim[floatarray] prim[int] stub
+             (array.get[float] prim prim))
          eta_float_unsafe_get =
-           (function prim prim stub (array.unsafe_get[float] prim prim))
+           (function prim[floatarray] prim[int] stub
+             (array.unsafe_get[float] prim prim))
          eta_float_safe_set =
-           (function prim prim prim stub (array.set[float] prim prim prim))
+           (function prim[floatarray] prim[int] prim[float] stub
+             (array.set[float] prim prim prim))
          eta_float_unsafe_set =
-           (function prim prim prim stub
+           (function prim[floatarray] prim[int] prim[float] stub
              (array.unsafe_set[float] prim prim prim))
-         eta_addr_len = (function prim stub (array.length[addr] prim))
+         eta_addr_len =
+           (function prim[addrarray] stub (array.length[addr] prim))
          eta_addr_safe_get =
-           (function prim prim stub (array.get[addr] prim prim))
+           (function prim[addrarray] prim[int] stub
+             (array.get[addr] prim prim))
          eta_addr_unsafe_get =
-           (function prim prim stub (array.unsafe_get[addr] prim prim))
+           (function prim[addrarray] prim[int] stub
+             (array.unsafe_get[addr] prim prim))
          eta_addr_safe_set =
-           (function prim prim prim stub (array.set[addr] prim prim prim))
+           (function prim[addrarray] prim[int] prim stub
+             (array.set[addr] prim prim prim))
          eta_addr_unsafe_set =
-           (function prim prim prim stub
+           (function prim[addrarray] prim[int] prim stub
              (array.unsafe_set[addr] prim prim prim)))
         (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
           eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len

--- a/ocaml/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/ocaml/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -72,77 +72,108 @@
      nativeint_ge =
        (function x[nativeint] y[nativeint] : int (Nativeint.>= x y))
      eta_gen_cmp = (function prim prim stub (caml_compare prim prim))
-     eta_int_cmp = (function prim prim stub (compare_ints prim prim))
-     eta_bool_cmp = (function prim prim stub (compare_ints prim prim))
-     eta_intlike_cmp = (function prim prim stub (compare_ints prim prim))
-     eta_float_cmp = (function prim prim stub (compare_floats prim prim))
+     eta_int_cmp =
+       (function prim[int] prim[int] stub (compare_ints prim prim))
+     eta_bool_cmp =
+       (function prim[int] prim[int] stub (compare_ints prim prim))
+     eta_intlike_cmp =
+       (function prim[int] prim[int] stub (compare_ints prim prim))
+     eta_float_cmp =
+       (function prim[float] prim[float] stub (compare_floats prim prim))
      eta_string_cmp =
        (function prim prim stub (caml_string_compare prim prim))
      eta_int32_cmp =
-       (function prim prim stub (compare_bints int32 prim prim))
+       (function prim[int32] prim[int32] stub
+         (compare_bints int32 prim prim))
      eta_int64_cmp =
-       (function prim prim stub (compare_bints int64 prim prim))
+       (function prim[int64] prim[int64] stub
+         (compare_bints int64 prim prim))
      eta_nativeint_cmp =
-       (function prim prim stub (compare_bints nativeint prim prim))
+       (function prim[nativeint] prim[nativeint] stub
+         (compare_bints nativeint prim prim))
      eta_gen_eq = (function prim prim stub (caml_equal prim prim))
-     eta_int_eq = (function prim prim stub (== prim prim))
-     eta_bool_eq = (function prim prim stub (== prim prim))
-     eta_intlike_eq = (function prim prim stub (== prim prim))
-     eta_float_eq = (function prim prim stub (==. prim prim))
+     eta_int_eq = (function prim[int] prim[int] stub (== prim prim))
+     eta_bool_eq = (function prim[int] prim[int] stub (== prim prim))
+     eta_intlike_eq = (function prim[int] prim[int] stub (== prim prim))
+     eta_float_eq = (function prim[float] prim[float] stub (==. prim prim))
      eta_string_eq = (function prim prim stub (caml_string_equal prim prim))
-     eta_int32_eq = (function prim prim stub (Int32.== prim prim))
-     eta_int64_eq = (function prim prim stub (Int64.== prim prim))
-     eta_nativeint_eq = (function prim prim stub (Nativeint.== prim prim))
+     eta_int32_eq =
+       (function prim[int32] prim[int32] stub (Int32.== prim prim))
+     eta_int64_eq =
+       (function prim[int64] prim[int64] stub (Int64.== prim prim))
+     eta_nativeint_eq =
+       (function prim[nativeint] prim[nativeint] stub
+         (Nativeint.== prim prim))
      eta_gen_ne = (function prim prim stub (caml_notequal prim prim))
-     eta_int_ne = (function prim prim stub (!= prim prim))
-     eta_bool_ne = (function prim prim stub (!= prim prim))
-     eta_intlike_ne = (function prim prim stub (!= prim prim))
-     eta_float_ne = (function prim prim stub (!=. prim prim))
+     eta_int_ne = (function prim[int] prim[int] stub (!= prim prim))
+     eta_bool_ne = (function prim[int] prim[int] stub (!= prim prim))
+     eta_intlike_ne = (function prim[int] prim[int] stub (!= prim prim))
+     eta_float_ne = (function prim[float] prim[float] stub (!=. prim prim))
      eta_string_ne =
        (function prim prim stub (caml_string_notequal prim prim))
-     eta_int32_ne = (function prim prim stub (Int32.!= prim prim))
-     eta_int64_ne = (function prim prim stub (Int64.!= prim prim))
-     eta_nativeint_ne = (function prim prim stub (Nativeint.!= prim prim))
+     eta_int32_ne =
+       (function prim[int32] prim[int32] stub (Int32.!= prim prim))
+     eta_int64_ne =
+       (function prim[int64] prim[int64] stub (Int64.!= prim prim))
+     eta_nativeint_ne =
+       (function prim[nativeint] prim[nativeint] stub
+         (Nativeint.!= prim prim))
      eta_gen_lt = (function prim prim stub (caml_lessthan prim prim))
-     eta_int_lt = (function prim prim stub (< prim prim))
-     eta_bool_lt = (function prim prim stub (< prim prim))
-     eta_intlike_lt = (function prim prim stub (< prim prim))
-     eta_float_lt = (function prim prim stub (<. prim prim))
+     eta_int_lt = (function prim[int] prim[int] stub (< prim prim))
+     eta_bool_lt = (function prim[int] prim[int] stub (< prim prim))
+     eta_intlike_lt = (function prim[int] prim[int] stub (< prim prim))
+     eta_float_lt = (function prim[float] prim[float] stub (<. prim prim))
      eta_string_lt =
        (function prim prim stub (caml_string_lessthan prim prim))
-     eta_int32_lt = (function prim prim stub (Int32.< prim prim))
-     eta_int64_lt = (function prim prim stub (Int64.< prim prim))
-     eta_nativeint_lt = (function prim prim stub (Nativeint.< prim prim))
+     eta_int32_lt =
+       (function prim[int32] prim[int32] stub (Int32.< prim prim))
+     eta_int64_lt =
+       (function prim[int64] prim[int64] stub (Int64.< prim prim))
+     eta_nativeint_lt =
+       (function prim[nativeint] prim[nativeint] stub
+         (Nativeint.< prim prim))
      eta_gen_gt = (function prim prim stub (caml_greaterthan prim prim))
-     eta_int_gt = (function prim prim stub (> prim prim))
-     eta_bool_gt = (function prim prim stub (> prim prim))
-     eta_intlike_gt = (function prim prim stub (> prim prim))
-     eta_float_gt = (function prim prim stub (>. prim prim))
+     eta_int_gt = (function prim[int] prim[int] stub (> prim prim))
+     eta_bool_gt = (function prim[int] prim[int] stub (> prim prim))
+     eta_intlike_gt = (function prim[int] prim[int] stub (> prim prim))
+     eta_float_gt = (function prim[float] prim[float] stub (>. prim prim))
      eta_string_gt =
        (function prim prim stub (caml_string_greaterthan prim prim))
-     eta_int32_gt = (function prim prim stub (Int32.> prim prim))
-     eta_int64_gt = (function prim prim stub (Int64.> prim prim))
-     eta_nativeint_gt = (function prim prim stub (Nativeint.> prim prim))
+     eta_int32_gt =
+       (function prim[int32] prim[int32] stub (Int32.> prim prim))
+     eta_int64_gt =
+       (function prim[int64] prim[int64] stub (Int64.> prim prim))
+     eta_nativeint_gt =
+       (function prim[nativeint] prim[nativeint] stub
+         (Nativeint.> prim prim))
      eta_gen_le = (function prim prim stub (caml_lessequal prim prim))
-     eta_int_le = (function prim prim stub (<= prim prim))
-     eta_bool_le = (function prim prim stub (<= prim prim))
-     eta_intlike_le = (function prim prim stub (<= prim prim))
-     eta_float_le = (function prim prim stub (<=. prim prim))
+     eta_int_le = (function prim[int] prim[int] stub (<= prim prim))
+     eta_bool_le = (function prim[int] prim[int] stub (<= prim prim))
+     eta_intlike_le = (function prim[int] prim[int] stub (<= prim prim))
+     eta_float_le = (function prim[float] prim[float] stub (<=. prim prim))
      eta_string_le =
        (function prim prim stub (caml_string_lessequal prim prim))
-     eta_int32_le = (function prim prim stub (Int32.<= prim prim))
-     eta_int64_le = (function prim prim stub (Int64.<= prim prim))
-     eta_nativeint_le = (function prim prim stub (Nativeint.<= prim prim))
+     eta_int32_le =
+       (function prim[int32] prim[int32] stub (Int32.<= prim prim))
+     eta_int64_le =
+       (function prim[int64] prim[int64] stub (Int64.<= prim prim))
+     eta_nativeint_le =
+       (function prim[nativeint] prim[nativeint] stub
+         (Nativeint.<= prim prim))
      eta_gen_ge = (function prim prim stub (caml_greaterequal prim prim))
-     eta_int_ge = (function prim prim stub (>= prim prim))
-     eta_bool_ge = (function prim prim stub (>= prim prim))
-     eta_intlike_ge = (function prim prim stub (>= prim prim))
-     eta_float_ge = (function prim prim stub (>=. prim prim))
+     eta_int_ge = (function prim[int] prim[int] stub (>= prim prim))
+     eta_bool_ge = (function prim[int] prim[int] stub (>= prim prim))
+     eta_intlike_ge = (function prim[int] prim[int] stub (>= prim prim))
+     eta_float_ge = (function prim[float] prim[float] stub (>=. prim prim))
      eta_string_ge =
        (function prim prim stub (caml_string_greaterequal prim prim))
-     eta_int32_ge = (function prim prim stub (Int32.>= prim prim))
-     eta_int64_ge = (function prim prim stub (Int64.>= prim prim))
-     eta_nativeint_ge = (function prim prim stub (Nativeint.>= prim prim))
+     eta_int32_ge =
+       (function prim[int32] prim[int32] stub (Int32.>= prim prim))
+     eta_int64_ge =
+       (function prim[int64] prim[int64] stub (Int64.>= prim prim))
+     eta_nativeint_ge =
+       (function prim[nativeint] prim[nativeint] stub
+         (Nativeint.>= prim prim))
      int_vec =[(consts (0))
                (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
        [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]

--- a/ocaml/testsuite/tests/translprim/module_coercion.compilers.flat.reference
+++ b/ocaml/testsuite/tests/translprim/module_coercion.compilers.flat.reference
@@ -5,39 +5,49 @@
          (makeblock 0)))
     (makeblock 0 M
       (module-defn(M_int) Module_coercion module_coercion.ml(46):1552-1591
-        (makeblock 0 (function prim stub (array.length[int] prim))
-          (function prim prim stub (array.get[int] prim prim))
-          (function prim prim stub (array.unsafe_get[int] prim prim))
-          (function prim prim prim stub (array.set[int] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0 (function prim[intarray] stub (array.length[int] prim))
+          (function prim[intarray] prim[int] stub (array.get[int] prim prim))
+          (function prim[intarray] prim[int] stub
+            (array.unsafe_get[int] prim prim))
+          (function prim[intarray] prim[int] prim[int] stub
+            (array.set[int] prim prim prim))
+          (function prim[intarray] prim[int] prim[int] stub
             (array.unsafe_set[int] prim prim prim))
-          (function prim prim stub (compare_ints prim prim))
-          (function prim prim stub (== prim prim))
-          (function prim prim stub (!= prim prim))
-          (function prim prim stub (< prim prim))
-          (function prim prim stub (> prim prim))
-          (function prim prim stub (<= prim prim))
-          (function prim prim stub (>= prim prim))))
+          (function prim[int] prim[int] stub (compare_ints prim prim))
+          (function prim[int] prim[int] stub (== prim prim))
+          (function prim[int] prim[int] stub (!= prim prim))
+          (function prim[int] prim[int] stub (< prim prim))
+          (function prim[int] prim[int] stub (> prim prim))
+          (function prim[int] prim[int] stub (<= prim prim))
+          (function prim[int] prim[int] stub (>= prim prim))))
       (module-defn(M_float) Module_coercion module_coercion.ml(47):1594-1637
-        (makeblock 0 (function prim stub (array.length[float] prim))
-          (function prim prim stub (array.get[float] prim prim))
-          (function prim prim stub (array.unsafe_get[float] prim prim))
-          (function prim prim prim stub (array.set[float] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function prim[floatarray] stub (array.length[float] prim))
+          (function prim[floatarray] prim[int] stub
+            (array.get[float] prim prim))
+          (function prim[floatarray] prim[int] stub
+            (array.unsafe_get[float] prim prim))
+          (function prim[floatarray] prim[int] prim[float] stub
+            (array.set[float] prim prim prim))
+          (function prim[floatarray] prim[int] prim[float] stub
             (array.unsafe_set[float] prim prim prim))
-          (function prim prim stub (compare_floats prim prim))
-          (function prim prim stub (==. prim prim))
-          (function prim prim stub (!=. prim prim))
-          (function prim prim stub (<. prim prim))
-          (function prim prim stub (>. prim prim))
-          (function prim prim stub (<=. prim prim))
-          (function prim prim stub (>=. prim prim))))
+          (function prim[float] prim[float] stub (compare_floats prim prim))
+          (function prim[float] prim[float] stub (==. prim prim))
+          (function prim[float] prim[float] stub (!=. prim prim))
+          (function prim[float] prim[float] stub (<. prim prim))
+          (function prim[float] prim[float] stub (>. prim prim))
+          (function prim[float] prim[float] stub (<=. prim prim))
+          (function prim[float] prim[float] stub (>=. prim prim))))
       (module-defn(M_string) Module_coercion module_coercion.ml(48):1640-1685
-        (makeblock 0 (function prim stub (array.length[addr] prim))
-          (function prim prim stub (array.get[addr] prim prim))
-          (function prim prim stub (array.unsafe_get[addr] prim prim))
-          (function prim prim prim stub (array.set[addr] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function prim[addrarray] stub (array.length[addr] prim))
+          (function prim[addrarray] prim[int] stub
+            (array.get[addr] prim prim))
+          (function prim[addrarray] prim[int] stub
+            (array.unsafe_get[addr] prim prim))
+          (function prim[addrarray] prim[int] prim stub
+            (array.set[addr] prim prim prim))
+          (function prim[addrarray] prim[int] prim stub
             (array.unsafe_set[addr] prim prim prim))
           (function prim prim stub (caml_string_compare prim prim))
           (function prim prim stub (caml_string_equal prim prim))
@@ -47,44 +57,65 @@
           (function prim prim stub (caml_string_lessequal prim prim))
           (function prim prim stub (caml_string_greaterequal prim prim))))
       (module-defn(M_int32) Module_coercion module_coercion.ml(49):1688-1731
-        (makeblock 0 (function prim stub (array.length[addr] prim))
-          (function prim prim stub (array.get[addr] prim prim))
-          (function prim prim stub (array.unsafe_get[addr] prim prim))
-          (function prim prim prim stub (array.set[addr] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function prim[addrarray] stub (array.length[addr] prim))
+          (function prim[addrarray] prim[int] stub
+            (array.get[addr] prim prim))
+          (function prim[addrarray] prim[int] stub
+            (array.unsafe_get[addr] prim prim))
+          (function prim[addrarray] prim[int] prim[int32] stub
+            (array.set[addr] prim prim prim))
+          (function prim[addrarray] prim[int] prim[int32] stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (compare_bints int32 prim prim))
-          (function prim prim stub (Int32.== prim prim))
-          (function prim prim stub (Int32.!= prim prim))
-          (function prim prim stub (Int32.< prim prim))
-          (function prim prim stub (Int32.> prim prim))
-          (function prim prim stub (Int32.<= prim prim))
-          (function prim prim stub (Int32.>= prim prim))))
+          (function prim[int32] prim[int32] stub
+            (compare_bints int32 prim prim))
+          (function prim[int32] prim[int32] stub (Int32.== prim prim))
+          (function prim[int32] prim[int32] stub (Int32.!= prim prim))
+          (function prim[int32] prim[int32] stub (Int32.< prim prim))
+          (function prim[int32] prim[int32] stub (Int32.> prim prim))
+          (function prim[int32] prim[int32] stub (Int32.<= prim prim))
+          (function prim[int32] prim[int32] stub (Int32.>= prim prim))))
       (module-defn(M_int64) Module_coercion module_coercion.ml(50):1734-1777
-        (makeblock 0 (function prim stub (array.length[addr] prim))
-          (function prim prim stub (array.get[addr] prim prim))
-          (function prim prim stub (array.unsafe_get[addr] prim prim))
-          (function prim prim prim stub (array.set[addr] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function prim[addrarray] stub (array.length[addr] prim))
+          (function prim[addrarray] prim[int] stub
+            (array.get[addr] prim prim))
+          (function prim[addrarray] prim[int] stub
+            (array.unsafe_get[addr] prim prim))
+          (function prim[addrarray] prim[int] prim[int64] stub
+            (array.set[addr] prim prim prim))
+          (function prim[addrarray] prim[int] prim[int64] stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (compare_bints int64 prim prim))
-          (function prim prim stub (Int64.== prim prim))
-          (function prim prim stub (Int64.!= prim prim))
-          (function prim prim stub (Int64.< prim prim))
-          (function prim prim stub (Int64.> prim prim))
-          (function prim prim stub (Int64.<= prim prim))
-          (function prim prim stub (Int64.>= prim prim))))
+          (function prim[int64] prim[int64] stub
+            (compare_bints int64 prim prim))
+          (function prim[int64] prim[int64] stub (Int64.== prim prim))
+          (function prim[int64] prim[int64] stub (Int64.!= prim prim))
+          (function prim[int64] prim[int64] stub (Int64.< prim prim))
+          (function prim[int64] prim[int64] stub (Int64.> prim prim))
+          (function prim[int64] prim[int64] stub (Int64.<= prim prim))
+          (function prim[int64] prim[int64] stub (Int64.>= prim prim))))
       (module-defn(M_nativeint) Module_coercion module_coercion.ml(51):1780-1831
-        (makeblock 0 (function prim stub (array.length[addr] prim))
-          (function prim prim stub (array.get[addr] prim prim))
-          (function prim prim stub (array.unsafe_get[addr] prim prim))
-          (function prim prim prim stub (array.set[addr] prim prim prim))
-          (function prim prim prim stub
+        (makeblock 0
+          (function prim[addrarray] stub (array.length[addr] prim))
+          (function prim[addrarray] prim[int] stub
+            (array.get[addr] prim prim))
+          (function prim[addrarray] prim[int] stub
+            (array.unsafe_get[addr] prim prim))
+          (function prim[addrarray] prim[int] prim[nativeint] stub
+            (array.set[addr] prim prim prim))
+          (function prim[addrarray] prim[int] prim[nativeint] stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (compare_bints nativeint prim prim))
-          (function prim prim stub (Nativeint.== prim prim))
-          (function prim prim stub (Nativeint.!= prim prim))
-          (function prim prim stub (Nativeint.< prim prim))
-          (function prim prim stub (Nativeint.> prim prim))
-          (function prim prim stub (Nativeint.<= prim prim))
-          (function prim prim stub (Nativeint.>= prim prim)))))))
+          (function prim[nativeint] prim[nativeint] stub
+            (compare_bints nativeint prim prim))
+          (function prim[nativeint] prim[nativeint] stub
+            (Nativeint.== prim prim))
+          (function prim[nativeint] prim[nativeint] stub
+            (Nativeint.!= prim prim))
+          (function prim[nativeint] prim[nativeint] stub
+            (Nativeint.< prim prim))
+          (function prim[nativeint] prim[nativeint] stub
+            (Nativeint.> prim prim))
+          (function prim[nativeint] prim[nativeint] stub
+            (Nativeint.<= prim prim))
+          (function prim[nativeint] prim[nativeint] stub
+            (Nativeint.>= prim prim)))))))


### PR DESCRIPTION
The fatal error can't be reached by the user because there is already another check for primitive arrity.