### PR TITLE
Bugfix: do not forget some updates in to_cmm_static

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -77,7 +77,7 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
       let symbol_name = Symbol.linkage_name_as_string symbol in
       let structured_constant = structured (transl c) in
       Cmmgen_state.add_structured_constant symbol_name structured_constant;
-      env, res, None
+      env, res, updates
     | Var (v, dbg) ->
       C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
         ~prev_updates:updates


### PR DESCRIPTION
It seems that in some cases, we could drop some updates during `to_cmm_static`. The bug is likely hard to trigger, since it would require that a boxed number be in the same group as some other static consts which require some udpates (and that we translate the boxed number after the other static consts), but in that case, we would likely silently miscompile things (i.e. not update/initialize some fields of some static consts).

cc @lthls 