### PR TITLE
Minor IRC tweaks

### DIFF
--- a/backend/cfg/cfg_irc_state.ml
+++ b/backend/cfg/cfg_irc_state.ml
@@ -60,6 +60,8 @@ type t =
     mutable introduced_temporaries : Reg.Set.t
   }
 
+let max_capacity = 1024
+
 let[@inline] make ~initial ~next_instruction_id () =
   List.iter (Reg.all_registers ()) ~f:(fun reg ->
       reg.Reg.irc_work_list <- Unknown_list;
@@ -80,7 +82,7 @@ let[@inline] make ~initial ~next_instruction_id () =
       reg.Reg.interf <- [];
       reg.Reg.degree <- Degree.infinite);
   let num_registers = List.length initial in
-  let original_capacity = num_registers in
+  let original_capacity = int_min max_capacity num_registers in
   let simplify_work_list = RegWorkList.make ~original_capacity in
   let freeze_work_list = RegWorkList.make ~original_capacity in
   let spill_work_list = RegWorkList.make ~original_capacity in
@@ -88,7 +90,7 @@ let[@inline] make ~initial ~next_instruction_id () =
   let coalesced_nodes = RegWorkList.make ~original_capacity in
   let colored_nodes = [] in
   let select_stack = [] in
-  let original_capacity = pred next_instruction_id in
+  let original_capacity = int_min max_capacity (pred next_instruction_id) in
   let coalesced_moves = InstructionWorkList.make ~original_capacity in
   let constrained_moves = InstructionWorkList.make ~original_capacity in
   let frozen_moves = InstructionWorkList.make ~original_capacity in

--- a/backend/cfg/cfg_irc_state.ml
+++ b/backend/cfg/cfg_irc_state.ml
@@ -82,7 +82,7 @@ let[@inline] make ~initial ~next_instruction_id () =
       reg.Reg.interf <- [];
       reg.Reg.degree <- Degree.infinite);
   let num_registers = List.length initial in
-  let original_capacity = int_min max_capacity num_registers in
+  let original_capacity = Int.min max_capacity num_registers in
   let simplify_work_list = RegWorkList.make ~original_capacity in
   let freeze_work_list = RegWorkList.make ~original_capacity in
   let spill_work_list = RegWorkList.make ~original_capacity in
@@ -90,7 +90,7 @@ let[@inline] make ~initial ~next_instruction_id () =
   let coalesced_nodes = RegWorkList.make ~original_capacity in
   let colored_nodes = [] in
   let select_stack = [] in
-  let original_capacity = int_min max_capacity (pred next_instruction_id) in
+  let original_capacity = Int.min max_capacity (pred next_instruction_id) in
   let coalesced_moves = InstructionWorkList.make ~original_capacity in
   let constrained_moves = InstructionWorkList.make ~original_capacity in
   let frozen_moves = InstructionWorkList.make ~original_capacity in

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -40,6 +40,9 @@ module Instruction = struct
   module IdMap = MoreLabels.Map.Make (Int)
 end
 
+let[@inline] int_min (left : int) (right : int) =
+  if left <= right then left else right
+
 let[@inline] int_max (left : int) (right : int) =
   if left >= right then left else right
 

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -40,12 +40,6 @@ module Instruction = struct
   module IdMap = MoreLabels.Map.Make (Int)
 end
 
-let[@inline] int_min (left : int) (right : int) =
-  if left <= right then left else right
-
-let[@inline] int_max (left : int) (right : int) =
-  if left >= right then left else right
-
 type cfg_infos =
   { arg : Reg.Set.t;
     res : Reg.Set.t;
@@ -64,7 +58,7 @@ let collect_cfg_infos : Cfg_with_layout.t -> cfg_infos =
         | Reg _ | Stack _ -> ())
   in
   let update_max_id (instr : _ Cfg.instruction) : unit =
-    max_id := int_max !max_id instr.id
+    max_id := Int.max !max_id instr.id
   in
   Cfg_with_layout.iter_instructions
     cfg_with_layout (* CR xclerc for xclerc: use fold *)

--- a/backend/cfg/cfg_regalloc_utils.mli
+++ b/backend/cfg/cfg_regalloc_utils.mli
@@ -12,6 +12,10 @@ val on_fatal : f:(unit -> unit) -> unit
 
 val fatal : ('a, Format.formatter, unit, 'b) format4 -> 'a
 
+val int_min : int -> int -> int
+
+val int_max : int -> int -> int
+
 module Instruction : sig
   type id = int
 

--- a/backend/cfg/cfg_regalloc_utils.mli
+++ b/backend/cfg/cfg_regalloc_utils.mli
@@ -12,10 +12,6 @@ val on_fatal : f:(unit -> unit) -> unit
 
 val fatal : ('a, Format.formatter, unit, 'b) format4 -> 'a
 
-val int_min : int -> int -> int
-
-val int_max : int -> int -> int
-
 module Instruction : sig
   type id = int
 

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -631,7 +631,7 @@ module Stack_offset_and_exn = struct
     check_and_set_stack_offset term ~stack_offset ~traps;
     match term.desc with
     | Tailcall_self _
-      when stack_offset <> 0 || match traps with _ :: _ -> true | [] -> false ->
+      when stack_offset <> 0 || List.compare_length_with traps 0 <> 0 ->
       Misc.fatal_error
         "Cfgize.Stack_offset_and_exn.process_terminator: unexpected handler on \
          self tailcall"

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -630,7 +630,8 @@ module Stack_offset_and_exn = struct
    fun ~stack_offset ~traps term ->
     check_and_set_stack_offset term ~stack_offset ~traps;
     match term.desc with
-    | Tailcall_self _ when List.length traps <> 0 || stack_offset <> 0 ->
+    | Tailcall_self _
+      when stack_offset <> 0 || match traps with _ :: _ -> true | [] -> false ->
       Misc.fatal_error
         "Cfgize.Stack_offset_and_exn.process_terminator: unexpected handler on \
          self tailcall"
@@ -712,8 +713,7 @@ module Stack_offset_and_exn = struct
    fun cfg ->
     update_block cfg cfg.entry_label ~stack_offset:0 ~traps:[];
     Cfg.iter_blocks cfg ~f:(fun _ block ->
-        if block.stack_offset = invalid_stack_offset then block.dead <- true);
-    Cfg.iter_blocks cfg ~f:(fun _ block ->
+        if block.stack_offset = invalid_stack_offset then block.dead <- true;
         assert (not (block.is_trap_handler && block.dead)))
 end
 


### PR DESCRIPTION
This pull requests perform the following minor changes:
- the capacity of work lists (IRC) is capped to avoid allocating huge
  arrays in pathological cases;
- a test of whether a list is empty avoids going through `List.length`;
- two successive iterations over the CFG blocks are merged;
- several assertions are put under a "debug" condition.