### PR TITLE
Flush the env for invalids in to_cmm

### DIFF
--- a/middle_end/flambda2/tests/mlexamples/invalid.ml
+++ b/middle_end/flambda2/tests/mlexamples/invalid.ml
@@ -1,0 +1,12 @@
+(* This example showed an isntance where [Simplify] produced an invalid, which
+   when translated by `to_cmm`, caused delayed let bindings to be lost because
+   there was a missing flush, see PR#1126 *)
+
+let[@inline never] check t1 t2 =
+  if Array.length t1 <> Array.length t2 then failwith "lengths"
+
+let[@inline] bar t1 t2 =
+  check t1 t2;
+  Array.unsafe_get t2 0 = 0.
+
+let foo () = bar [| 1. |] [||]

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -304,6 +304,14 @@ let translate_jump_to_return_continuation env res apply return_cont args =
        Multiple return values from functions are not yet supported"
       Continuation.print return_cont Apply_cont.print apply
 
+(* Invalid expressions *)
+let invalid env res ~message =
+  let wrap, _empty_env, res =
+    Env.flush_delayed_lets ~mode:Branching_point env res
+  in
+  let cmm_invalid, res = C.invalid res ~message in
+  wrap cmm_invalid, res
+
 (* The main set of translation functions for expressions *)
 
 let rec expr env res e =
@@ -313,7 +321,7 @@ let rec expr env res e =
   | Apply e' -> apply_expr env res e'
   | Apply_cont e' -> apply_cont env res e'
   | Switch e' -> switch env res e'
-  | Invalid { message } -> C.invalid res ~message
+  | Invalid { message } -> invalid env res ~message
 
 and let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body =
   let v = Bound_var.var v in


### PR DESCRIPTION
This fixes a bug where `to_cmm` would simply omit delayed lets when encountering an invalid, which would prevent these expressions from performing effects (in particular raising an exception to not reach the invalid).