### PR TITLE
Make Selectgen treat region boundaries more precisely

### DIFF
--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1113,10 +1113,15 @@ method emit_expr_aux (env:environment) exp :
               Array.iter (fun reg -> assert(reg.typ <> Addr)) src;
               self#insert_moves env src tmp_regs ;
               self#insert_moves env tmp_regs (Array.concat handler.regs) ;
-              (* FIXME: this assertion should be weakened
-                 env.regions may be longer than handler.regions,
-                 in which case we close the surplus *)
-              assert (env.regions == handler.regions);
+              if handler.regions != env.regions then begin
+                let cl, rest =
+                  cut_region_stack
+                    ~len:(List.length handler.regions)
+                    env.regions
+                in
+                assert (rest == handler.regions);
+                self#insert_endregions env cl;
+              end;
               self#insert env (Iexit (nfail, traps)) [||] [||];
               set_traps nfail handler.traps_ref env.trap_stack traps;
               None

--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -31,7 +31,7 @@ val size_expr : environment -> Cmm.expression -> int
 
 val select_mutable_flag : Asttypes.mutable_flag -> Mach.mutable_flag
 
-type region_stack
+module Region_stack : sig type t end
 
 module Effect : sig
   type t =
@@ -166,10 +166,12 @@ class virtual selector_generic : object
   method insert_moves : environment -> Reg.t array -> Reg.t array -> unit
   method insert_endregions :
     environment -> Reg.t array list -> unit
+  method insert_endregions_until :
+    environment -> suffix:Region_stack.t -> Region_stack.t -> unit
   method emit_expr :
     environment -> Cmm.expression -> Reg.t array option
   method emit_expr_aux :
-    environment -> Cmm.expression -> (Reg.t array * region_stack) option
+    environment -> Cmm.expression -> (Reg.t array * Region_stack.t) option
   method emit_tail : environment -> Cmm.expression -> unit
 
   (* [contains_calls] is declared as a reference instance variable,

--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -31,6 +31,8 @@ val size_expr : environment -> Cmm.expression -> int
 
 val select_mutable_flag : Asttypes.mutable_flag -> Mach.mutable_flag
 
+type region_stack
+
 module Effect : sig
   type t =
     | None
@@ -162,8 +164,12 @@ class virtual selector_generic : object
   method insert_move_results :
     environment -> Reg.t array -> Reg.t array -> int -> unit
   method insert_moves : environment -> Reg.t array -> Reg.t array -> unit
+  method insert_endregions :
+    environment -> Reg.t array list -> unit
   method emit_expr :
     environment -> Cmm.expression -> Reg.t array option
+  method emit_expr_aux :
+    environment -> Cmm.expression -> (Reg.t array * region_stack) option
   method emit_tail : environment -> Cmm.expression -> unit
 
   (* [contains_calls] is declared as a reference instance variable,

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -674,18 +674,19 @@ and simplify_set_of_closures original_env r
   let r = ret r (A.value_set_of_closures value_set_of_closures) in
   set_of_closures, r, value_set_of_closures.freshening
 
+and mark_region_used_for_apply ~(reg_close : Lambda.region_close) ~(mode : Lambda.alloc_mode) r =
+  match reg_close, mode with
+  | (Rc_normal | Rc_nontail), Alloc_heap -> r
+  | Rc_close_at_apply, _
+  | _, Alloc_local -> R.set_region_use r true
+
 and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
   let {
     Flambda. func = lhs_of_application; args; kind = _; dbg; reg_close; mode;
     inlined = inlined_requested; specialise = specialise_requested;
     probe = probe_requested; result_layout
   } = apply in
-  let r =
-    match reg_close, mode with
-    | (Rc_normal | Rc_nontail), Alloc_heap -> r
-    | Rc_close_at_apply, _
-    | _, Alloc_local -> R.set_region_use r true
-  in
+  let r = mark_region_used_for_apply ~reg_close ~mode r in
   let dbg = E.add_inlined_debuginfo env ~dbg in
   simplify_free_variable env lhs_of_application
     ~f:(fun env lhs_of_application lhs_of_application_approx ->
@@ -1313,6 +1314,7 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
     let body, r = simplify env r body in
     While (cond, body), ret r (A.value_unknown Other)
   | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
+    let r = mark_region_used_for_apply ~reg_close ~mode r in
     let dbg = E.add_inlined_debuginfo env ~dbg in
     simplify_free_variable env meth ~f:(fun env meth _meth_approx ->
       simplify_free_variable env obj ~f:(fun env obj _obj_approx ->

--- a/ocaml/asmcomp/selectgen.mli
+++ b/ocaml/asmcomp/selectgen.mli
@@ -29,6 +29,8 @@ val env_find : Backend_var.t -> environment -> Reg.t array
 
 val size_expr : environment -> Cmm.expression -> int
 
+module Region_stack : sig type t end
+
 module Effect : sig
   type t =
     | None
@@ -159,8 +161,14 @@ class virtual selector_generic : object
   method insert_move_results :
     environment -> Reg.t array -> Reg.t array -> int -> unit
   method insert_moves : environment -> Reg.t array -> Reg.t array -> unit
+  method insert_endregions :
+    environment -> Reg.t array list -> unit
+  method insert_endregions_until :
+    environment -> suffix:Region_stack.t -> Region_stack.t -> unit
   method emit_expr :
     environment -> Cmm.expression -> Reg.t array option
+  method emit_expr_aux :
+    environment -> Cmm.expression -> (Reg.t array * Region_stack.t) option
   method emit_tail : environment -> Cmm.expression -> unit
 
   (* [contains_calls] is declared as a reference instance variable,

--- a/ocaml/testsuite/tests/typing-local/regions.ml
+++ b/ocaml/testsuite/tests/typing-local/regions.ml
@@ -82,6 +82,16 @@ let () =
   check_empty "after direct overtail"
 
 
+let[@inline always] do_inlined_tailcall g =
+  let local_ r = ref 42 in
+  let _ = opaque_identity r in
+  g ()
+
+let () =
+  do_inlined_tailcall (fun () ->
+    check_empty "during inlined tailcall");
+  check_empty "after inlined tailcall"
+
 
 let[@inline never] local_ret a b = local_ ref (a + b)
 let[@inline never] calls_local_ret () =

--- a/ocaml/testsuite/tests/typing-local/regions.reference
+++ b/ocaml/testsuite/tests/typing-local/regions.reference
@@ -9,6 +9,8 @@
   after indirect overtail: OK
    during direct overtail: OK
     after direct overtail: OK
+  during inlined tailcall: OK
+   after inlined tailcall: OK
             apply merging: OK
          toplevel binding: OK
      toplevel rec binding: OK


### PR DESCRIPTION
Currently, Selectgen treats region boundaries fairly loosely when inlining is involved, allowing regions to extend beyond their specified scope. For instance, consider these functions:
```
let[@inline] f use g x =
  let local_ r = ref 42 in
  if x then (use r; g 42)
  else (Some 42)

let h use g x =
  let local_ r = ref 42 in
  use r;
  let z = f use g x [@nontail] in
  use r;
  z
```
The `use` function is just to prevent the refs being optimised away, and isn't otherwise relevant to the example. The function `h` is currently compiled to (with details removed):
```
h_reg := beginregion;
f_reg := beginregion;
if x then
  v := call g
else
  v := Some 42
endif;
endregion f_reg;
endregion h_reg;
return v
```
Note that both regions are ended *after* the inlined body of `f`. (Actually, the two endregions can be coalesced to a single instruction, but in principle they're ended here). In particular, the region of `f` remains on the stack when `f` tailcalls `g`.

This was a known issue in Selectgen, which resulted in a minor loss of efficiency (possibly offset by improved code size) as some values stayed on the local stack in non-tail position for longer than they should. However, it becomes a soundness issue when combined with various upcoming features and optimisations that rely on precise region boundaries.

So, this patch compiles `h` as follows instead:
```
h_reg := beginregion;
f_reg := beginregion;
if x then
  endregion f_reg;
  v := call g;
  endregion h_reg
  return v
else
  endregion f_reg;
  endregion h_reg;
  v := Some 42
  return v
endif
```
where in particular, the region `f_reg` is ended before the inlined body of `f` tailcalls `g`.

This patch also lifts the assumption in Selectgen that an expression is in tail position of at most one region, which happens to be true at the moment but won't be for long.

The main change is a change to the semantics of `Selectgen.emit_expr` and `Selectgen.emit_expr_tail`:

**Before**:
  - `emit_expr`: emit an expression, without closing any regions (ignoring `Ctail`, etc.)
  - `emit_expr_tail`: emit an expression in tail position, closing the current region (of which there can be at most one)

**After**:
  - `emit_expr_aux`: emit an expression, possibly closing some regions if instructed to by `Ctail`, etc.
  - `emit_expr`: emit an expression with `emit_expr_aux`, verifying that no regions were closed (e.g. for nontail expressions)
  - `emit_expr_tail`: emit an expression in tail position, closing _all_ current regions (of which there can be many)