### PR TITLE
Build all boot targets in `make hacking`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ci-coverage: boot-runtest coverage
 
 .PHONY: hacking-runtest
 hacking-runtest: _build/_bootinstall
-	$(dune) build $(ws_boot) $(coverage_dune_flags) -w boot_ocamlopt.exe @runtest
+	$(dune) build $(ws_boot) $(coverage_dune_flags) -w $(boot_targets) @runtest
 
 # Only needed for running the test tools by hand; runtest will take care of
 # building them using Dune

--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -51,13 +51,15 @@ endef
 .DEFAULT_GOAL := compiler
 .PHONY: boot-compiler boot-runtest runtime-stdlib compiler runtest
 
+boot_targets = \
+  $(boot_ocamlc) \
+  $(boot_ocamlopt) \
+  $(boot_ocamlmklib) \
+  $(boot_ocamldep) \
+  $(boot_ocamlobjinfo)
+
 boot-compiler: _build/_bootinstall
-	$(dune) build $(ws_boot) $(coverage_dune_flags) \
-	  $(boot_ocamlc) \
-	  $(boot_ocamlopt) \
-	  $(boot_ocamlmklib) \
-	  $(boot_ocamldep) \
-          $(boot_ocamlobjinfo)
+	$(dune) build $(ws_boot) $(coverage_dune_flags) $(boot_targets)
 
 boot-runtest: boot-compiler
 	$(dune) runtest $(ws_boot) $(coverage_dune_flags) --force
@@ -303,4 +305,4 @@ test-one: install_for_test
 # This target is like a polling version of upstream "make ocamlopt"
 .PHONY: hacking
 hacking: _build/_bootinstall
-	$(dune) build $(ws_boot) -w $(boot_ocamlopt)
+	$(dune) build $(ws_boot) -w $(boot_targets)


### PR DESCRIPTION
Currently, `make hacking` builds only `ocamlopt` (the boot version). Adding the other targets doesn't add much compile time and makes life easier if you're making changes that will propagate out to them - for instance, changes to file formats usually break `ocamlobjinfo`.