### PR TITLE
Use only `.ocamlformat*` to enable or disable ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,4 @@
+# Please make a pull request to change this file.
+# Each directory that enables ocamlformat sets its own options, so here we just
+# disable it by default.
+disable=true

--- a/Makefile
+++ b/Makefile
@@ -77,66 +77,17 @@ promote:
 
 .PHONY: fmt
 fmt:
-	ocamlformat -i \
-	  $$(find middle_end/flambda2 \
-	    \( -name "*.ml" -or -name "*.mli" \) \
-	    -and \! \( -name "flambda_parser.*" -or -name "flambda_lex.*" \))
-	ocamlformat -i \
-	  $$(find backend/cfg \
-	    \( -name "*.ml" -or -name "*.mli" \))
-	ocamlformat -i middle_end/mangling.ml
-	ocamlformat -i middle_end/mangling.mli
-	ocamlformat -i \
-	  $$(find backend/asm_targets \
-	    \( -name "*.ml" -or -name "*.mli" \))
-	ocamlformat -i \
-	  $$(find backend/debug \
-	    \( -name "*.ml" -or -name "*.mli" \))
-	ocamlformat -i backend/cmm_helpers.ml{,i}
-	ocamlformat -i backend/cmm_builtins.ml{,i}
-	ocamlformat -i backend/checkmach.ml{,i}
-	ocamlformat -i tools/merge_archives.ml
-	ocamlformat -i \
-	  $$(find backend/debug/dwarf \
-	    \( -name "*.ml" -or -name "*.mli" \))
-	ocamlformat -i \
-	  $$(find utils \
-	    \( -name "*.ml" -or -name "*.mli" \))
-	ocamlformat -i \
-	  $$(find ocaml/utils \
-	    \( -name "*.ml" -or -name "*.mli" \))
+	ocamlformat -i $$(find . \( -name "*.ml" -or -name "*.mli" \))
 
 .PHONY: check-fmt
 check-fmt:
-	@if [ "$$(git status --porcelain middle_end/flambda2)" != "" ] || \
-           [ "$$(git status --porcelain backend/cfg)" != "" ] || \
-           [ "$$(git status --porcelain middle_end/mangling.ml)" != "" ] || \
-           [ "$$(git status --porcelain middle_end/mangling.mli)" != "" ] || \
-           [ "$$(git status --porcelain backend/asm_targets)" != "" ] || \
-           [ "$$(git status --porcelain backend/debug)" != "" ] || \
-           [ "$$(git status --porcelain backend/cmm_helpers.ml{,i})" != "" ] || \
-           [ "$$(git status --porcelain backend/cmm_builtins.ml{,i})" != "" ] || \
-           [ "$$(git status --porcelain backend/checkmach.ml{,i})" != "" ] || \
-           [ "$$(git status --porcelain tools/merge_archives.ml)" != "" ] || \
-           [ "$$(git status --porcelain ocaml/utils)" != "" ] || \
-           [ "$$(git status --porcelain utils)" != "" ]; then \
+	@if [ "$$(git status --porcelain)" != "" ]; then \
 	  echo; \
 	  echo "Tree must be clean before running 'make check-fmt'"; \
 	  exit 1; \
 	fi
 	$(MAKE) fmt
-	@if [ "$$(git diff middle_end/flambda2)" != "" ] || \
-           [ "$$(git diff backend/cfg)" != "" ] || \
-           [ "$$(git diff middle_end/mangling.ml)" != "" ] || \
-           [ "$$(git diff middle_end/mangling.mli)" != "" ] || \
-           [ "$$(git diff backend/asm_targets)" != "" ] || \
-           [ "$$(git diff backend/debug)" != "" ] || \
-           [ "$$(git diff backend/cmm_helpers.ml{,i})" != "" ] || \
-           [ "$$(git diff backend/cmm_builtins.ml{,i})" != "" ] || \
-           [ "$$(git diff backend/checkmach.ml{,i})" != "" ] || \
-           [ "$$(git diff tools/merge_archives.ml)" != "" ] || \
-           [ "$$(git diff ocaml/utils)" != "" ] || \
-           [ "$$(git diff utils)" != "" ]; then \
+	@if [ "$$(git diff)" != "" ]; then \
 	  echo; \
 	  echo "The following code was not formatted correctly:"; \
 	  echo "(the + side of the diff is how it should be formatted)"; \

--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -2,8 +2,6 @@ cmm_helpers.ml
 cmm_helpers.mli
 cmm_builtins.ml
 cmm_builtins.mli
-internal_assembler/*.ml
-internal_assembler/*.mli
 checkmach.ml
 checkmach.mli
 cfg/**/*.ml

--- a/middle_end/.ocamlformat-enable
+++ b/middle_end/.ocamlformat-enable
@@ -1,4 +1,2 @@
 mangling.ml
 mangling.mli
-flambda2/**/*.ml
-flambda2/**/*.mli

--- a/middle_end/flambda2/.ocamlformat
+++ b/middle_end/flambda2/.ocamlformat
@@ -1,5 +1,6 @@
 # Please make a pull request to change this file.
 # Keep this file in sync with other .ocamlformat files in this repo.
+disable=false
 assignment-operator=begin-line
 cases-exp-indent=2
 doc-comments=before

--- a/middle_end/flambda2/parser/.ocamlformat-ignore
+++ b/middle_end/flambda2/parser/.ocamlformat-ignore
@@ -1,0 +1,2 @@
+flambda_lex.*
+flambda_parser.*

--- a/ocaml/lambda/.ocamlformat-enable
+++ b/ocaml/lambda/.ocamlformat-enable
@@ -1,1 +1,0 @@
-matching.ml

--- a/ocaml/manual/src/html_processing/.ocamlformat
+++ b/ocaml/manual/src/html_processing/.ocamlformat
@@ -1,0 +1,1 @@
+disable=true

--- a/tools/.ocamlformat-ignore
+++ b/tools/.ocamlformat-ignore
@@ -1,0 +1,1 @@
+flambda_backend_objinfo.ml


### PR DESCRIPTION
Currently, we have two ways of expressing which files are ocamlformatted: ocamlformat's own configuration files, and the logic hardcoded into the `make fmt` implementation. Editors use `.ocamlformat` and friends to see which files to format, and CI uses `make fmt` to check that things are formatted. Unfortunately, these mechanisms have gone out of sync - there are several files that are formatted according to `.ocamlformat` or `.ocamlformat-enable` but are missing from `make fmt`, so the only effect of enabling ocamlformat on them is a fun surprise when you go and save a file.

Notably, ocamlformat's behaviour is to take a list of files and format only the ones it's configured to. So `make fmt` can only go wrong by passing _too few_ files, not too many.

This PR changes `make fmt` so that it just passes every last `.ml` and `.mli` file in the repo to the `ocamlformat` command line, making `.ocamlformat`, `.ocamlformat-ignore`, and `.ocamlformat-enable` files the source of truth about which files get formatted. I've adjusted these files to reflect the status quo, so the only immediate impact here is that editors behave predictably.

(Note that some changes reflect a subtle fact about ocamlformat: Once a file is listed in `.ocamlformat-enable`, it cannot be `.ocamlformat-ignore`d. Thus adding a deeper `.ocamlformat` with `disable=false` is preferable to using a wildcard match in `.ocamlformat-enable`.)