### PR TITLE
Remove remaining `layout_top` after #1084

### DIFF
--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1330,7 +1330,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
   | Lprim(Pignore, [arg], _loc) ->
       let expr, approx = make_const_int 0 in
       Usequence(fst (close env arg), expr), approx
-  | Lprim(( Pbytes_to_string | Pbytes_of_string | Pobj_magic),
+  | Lprim(( Pbytes_to_string | Pbytes_of_string | Pobj_magic _),
           [arg], _loc) ->
       close env arg
   | Lprim(Pgetglobal cu, [], loc) ->

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -812,12 +812,12 @@ let bind_params { backend; mutable_vars; _ } loc fdesc params args funct body =
     match (pl, al) with
       ([], []) -> substitute (Debuginfo.from_location loc) (backend, fpc)
                     subst (Some Int.Map.empty) body
-    | (p1 :: pl, a1 :: al) ->
+    | (p1 :: pl, (layout1, a1) :: al) ->
         if is_substituable ~mutable_vars a1 then
           aux (V.Map.add (VP.var p1) a1 subst) pl al body
         else begin
           let p1' = VP.rename p1 in
-          let u1, u2 =
+          let u1, u2, layout =
             match VP.name p1, a1 with
             | "*opt*", Uprim(P.Pmakeblock(0, Immutable, kind, mode), [a], dbg) ->
                 (* This parameter corresponds to an optional parameter,
@@ -826,13 +826,14 @@ let bind_params { backend; mutable_vars; _ } loc fdesc params args funct body =
                    appear once under a Pisint primitive and once under a Pfield
                    primitive (see [simplif_prim_pure]) *)
                 a, Uprim(P.Pmakeblock(0, Immutable, kind, mode),
-                         [Uvar (VP.var p1')], dbg)
+                         [Uvar (VP.var p1')], dbg),
+                Lambda.layout_field
             | _ ->
-                a1, Uvar (VP.var p1')
+                a1, Uvar (VP.var p1'), layout1
           in
           let body' = aux (V.Map.add (VP.var p1) u2 subst) pl al body in
           if occurs_var (VP.var p1) body then
-            Ulet(Immutable, Lambda.layout_top, p1', u1, body')
+            Ulet(Immutable, layout, p1', u1, body')
           else if is_erasable a1 then body'
           else Usequence(a1, body')
         end
@@ -845,7 +846,7 @@ let bind_params { backend; mutable_vars; _ } loc fdesc params args funct body =
     (* Ensure funct is evaluated after args *)
     match params with
     | my_closure :: params when not fdesc.fun_closed ->
-       (params @ [my_closure]), (args @ [funct]), body
+       (params @ [my_closure]), (args @ [Lambda.layout_function, funct]), body
     | _ ->
        params, args, (if is_pure funct then body else Usequence (funct, body))
   in
@@ -882,22 +883,22 @@ let direct_apply env fundesc ufunct uargs pos result_layout mode ~probe ~loc ~at
        fail_if_probe ~probe "Erroneously marked to be inlined"
      end;
      if fundesc.fun_closed && is_pure ufunct then
-       Udirect_apply(fundesc.fun_label, uargs, probe, result_layout, kind, dbg)
+       Udirect_apply(fundesc.fun_label, List.map snd uargs, probe, result_layout, kind, dbg)
      else if not fundesc.fun_closed &&
                is_substituable ~mutable_vars:env.mutable_vars ufunct then
-       Udirect_apply(fundesc.fun_label, uargs @ [ufunct], probe, result_layout, kind, dbg)
+       Udirect_apply(fundesc.fun_label, List.map snd uargs @ [ufunct], probe, result_layout, kind, dbg)
      else begin
-       let args = List.map (fun arg ->
+       let args = List.map (fun (layout, arg) ->
          if is_substituable ~mutable_vars:env.mutable_vars arg then
-           None, arg
+           layout, None, arg
          else
            let id = V.create_local "arg" in
-           Some (VP.create id, arg), Uvar id) uargs in
-       let app_args = List.map snd args in
-       List.fold_left (fun app (binding,_) ->
+           layout, Some (VP.create id, arg), Uvar id) uargs in
+       let app_args = List.map (fun (_, _, arg) -> arg) args in
+       List.fold_left (fun app (layout,binding,_) ->
            match binding with
            | None -> app
-           | Some (v, e) -> Ulet(Immutable, Lambda.layout_top, v, e, app))
+           | Some (v, e) -> Ulet(Immutable, layout, v, e, app))
          (if fundesc.fun_closed then
             Usequence (ufunct,
                        Udirect_apply (fundesc.fun_label, app_args,
@@ -1070,7 +1071,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
          [Uprim(P.Pmakeblock _, uargs, _)])
         when List.length uargs = List.length params_layout ->
           let app =
-            direct_apply env ~loc ~attribute fundesc ufunct uargs
+            direct_apply env ~loc ~attribute fundesc ufunct (List.combine params_layout uargs)
               pos ap_result_layout mode ~probe in
           (app, strengthen_approx app approx_res)
       | ((ufunct, Value_closure(_,
@@ -1080,7 +1081,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
                                 approx_res)), uargs)
         when nargs = List.length params_layout ->
           let app =
-            direct_apply env ~loc ~attribute fundesc ufunct uargs
+            direct_apply env ~loc ~attribute fundesc ufunct (List.combine params_layout uargs)
               pos ap_result_layout mode ~probe in
           (app, strengthen_approx app approx_res)
 
@@ -1172,7 +1173,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
             List.fold_left2 (fun kinds (var, _) kind -> V.Map.add var kind kinds)
               kinds args args_kinds
           in
-          let _, rem_kinds = split_list nparams args_kinds in
+          let first_kinds, rem_kinds = split_list nparams args_kinds in
           let (first_args, rem_args) = split_list nparams args in
           let first_args = List.map (fun (id, _) -> Uvar id) first_args in
           let rem_args = List.map (fun (id, _) -> Uvar id) rem_args in
@@ -1182,7 +1183,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           let mode' = if fundesc.fun_region then alloc_heap else alloc_local in
           let body =
             Ugeneric_apply(direct_apply { env with kinds } ~loc ~attribute
-                              fundesc ufunct first_args
+                              fundesc ufunct (List.combine first_kinds first_args)
                               Rc_normal Lambda.layout_function mode'
                               ~probe,
                            rem_args,
@@ -1295,7 +1296,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
       end else begin
         (* General case: recursive definition of values *)
         let kinds =
-          List.fold_left (fun kinds (id, _) -> V.Map.add id Lambda.layout_top kinds)
+          List.fold_left (fun kinds (id, _) -> V.Map.add id Lambda.layout_letrec kinds)
             kinds defs
         in
         let rec clos_defs = function

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -141,7 +141,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pbigarraydim dim -> Pbigarraydim dim
   | Pbswap16 -> Pbswap16
   | Pint_as_pointer -> Pint_as_pointer
-  | Popaque -> Popaque
+  | Popaque _ -> Popaque
   | Pprobe_is_enabled {name} -> Pprobe_is_enabled {name}
   | Pobj_dup ->
     let module P = Primitive in
@@ -154,7 +154,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       ~native_name:"caml_obj_dup"
       ~native_repr_args:[P.Prim_global, P.Same_as_ocaml_repr]
       ~native_repr_res:(P.Prim_global, P.Same_as_ocaml_repr))
-  | Pobj_magic
+  | Pobj_magic _
   | Pbytes_to_string
   | Pbytes_of_string
   | Pctconst _

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -424,7 +424,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
         (If_then_else (cond, arg2, Var const_false, Lambda.layout_int)))
   | Lprim ((Psequand | Psequor), _, _) ->
     Misc.fatal_error "Psequand / Psequor must have exactly two arguments"
-  | Lprim ((Pbytes_to_string | Pbytes_of_string | Pobj_magic),
+  | Lprim ((Pbytes_to_string | Pbytes_of_string | Pobj_magic _),
            [arg], _) ->
     close t env arg
   | Lprim (Pignore, [arg], _) ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -692,8 +692,8 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
       | Pbytes_set_32 _ | Pbytes_set_64 _ | Pbigstring_load_16 _
       | Pbigstring_load_32 _ | Pbigstring_load_64 _ | Pbigstring_set_16 _
       | Pbigstring_set_32 _ | Pbigstring_set_64 _ | Pctconst _ | Pbswap16
-      | Pbbswap _ | Pint_as_pointer | Popaque | Pprobe_is_enabled _ | Pobj_dup
-      | Pobj_magic ->
+      | Pbbswap _ | Pint_as_pointer | Popaque _ | Pprobe_is_enabled _ | Pobj_dup
+      | Pobj_magic _ ->
         (* Inconsistent with outer match *)
         assert false
     in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1371,9 +1371,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
     let lam = switch_for_if_then_else ~cond ~ifso ~ifnot ~kind in
     cps acc env ccenv lam k k_exn
   | Lsequence (lam1, lam2) ->
-    let k acc env ccenv _value =
-      cps acc env ccenv lam2 k k_exn
-    in
+    let k acc env ccenv _value = cps acc env ccenv lam2 k k_exn in
     cps_non_tail_simple acc env ccenv lam1 k k_exn
   | Lwhile
       { wh_cond = cond; wh_body = body; wh_cond_region = _; wh_body_region = _ }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -952,8 +952,8 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pbigstring_set_16 true
   | Pbigstring_set_32 true
   | Pbigstring_set_64 true
-  | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer | Popaque
-  | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic ->
+  | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer | Popaque _
+  | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _ ->
     false
 
 let primitive_result_kind (prim : Lambda.primitive) :
@@ -1019,8 +1019,12 @@ let primitive_result_kind (prim : Lambda.primitive) :
     | Pint32 -> Flambda_kind.With_subkind.boxed_int32
     | Pint64 -> Flambda_kind.With_subkind.boxed_int64
     | Pnativeint -> Flambda_kind.With_subkind.boxed_nativeint)
+  | Popaque layout | Pobj_magic layout ->
+    Flambda_kind.With_subkind.from_lambda layout
+  | Praise _ ->
+    (* CR ncourant: this should be bottom, but we don't have it *)
+    Flambda_kind.With_subkind.any_value
   | Pccall { prim_native_repr_res = _, Same_as_ocaml_repr; _ }
-  | Praise _
   | Parrayrefs (Pgenarray | Paddrarray)
   | Parrayrefu (Pgenarray | Paddrarray)
   | Pbytes_to_string | Pbytes_of_string | Pgetglobal _ | Psetglobal _
@@ -1029,7 +1033,7 @@ let primitive_result_kind (prim : Lambda.primitive) :
   | Pmakearray _ | Pduparray _ | Pbigarraydim _
   | Pbigarrayref
       (_, _, (Pbigarray_complex32 | Pbigarray_complex64 | Pbigarray_unknown), _)
-  | Pint_as_pointer | Popaque | Pobj_dup | Pobj_magic ->
+  | Pint_as_pointer | Pobj_dup ->
     Flambda_kind.With_subkind.any_value
 
 type cps_continuation =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -630,8 +630,12 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
               ( Make_array (Naked_floats, mutability, mode),
                 List.map unbox_float args ),
             Variadic (Make_array (Values, mutability, mode), args) )))
-  | Popaque _, [arg] -> Unary (Opaque_identity { middle_end_only = false }, arg)
-  | Pobj_magic _, [arg] -> Unary (Opaque_identity { middle_end_only = true }, arg)
+  | Popaque layout, [arg] ->
+    let kind = K.With_subkind.kind (K.With_subkind.from_lambda layout) in
+    Unary (Opaque_identity { middle_end_only = false; kind }, arg)
+  | Pobj_magic layout, [arg] ->
+    let kind = K.With_subkind.kind (K.With_subkind.from_lambda layout) in
+    Unary (Opaque_identity { middle_end_only = true; kind }, arg)
   | Pduprecord (repr, num_fields), [arg] ->
     let kind : P.Duplicate_block_kind.t =
       match repr with

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -630,8 +630,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
               ( Make_array (Naked_floats, mutability, mode),
                 List.map unbox_float args ),
             Variadic (Make_array (Values, mutability, mode), args) )))
-  | Popaque, [arg] -> Unary (Opaque_identity { middle_end_only = false }, arg)
-  | Pobj_magic, [arg] -> Unary (Opaque_identity { middle_end_only = true }, arg)
+  | Popaque _, [arg] -> Unary (Opaque_identity { middle_end_only = false }, arg)
+  | Pobj_magic _, [arg] -> Unary (Opaque_identity { middle_end_only = true }, arg)
   | Pduprecord (repr, num_fields), [arg] ->
     let kind : P.Duplicate_block_kind.t =
       match repr with
@@ -1161,10 +1161,10 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
       Printlambda.primitive prim H.print_list_of_simple_or_prim args
   | ( ( Pfield _ | Pnegint | Pnot | Poffsetint _ | Pintoffloat | Pfloatofint _
       | Pnegfloat _ | Pabsfloat _ | Pstringlength | Pbyteslength | Pbintofint _
-      | Pintofbint _ | Pnegbint _ | Popaque | Pduprecord _ | Parraylength _
+      | Pintofbint _ | Pnegbint _ | Popaque _ | Pduprecord _ | Parraylength _
       | Pduparray _ | Pfloatfield _ | Pcvtbint _ | Poffsetref _ | Pbswap16
       | Pbbswap _ | Pisint _ | Pint_as_pointer | Pbigarraydim _ | Pobj_dup
-      | Pobj_magic ),
+      | Pobj_magic _ ),
       ([] | _ :: _ :: _) ) ->
     Misc.fatal_errorf
       "Closure_conversion.convert_primitive: Wrong arity for unary primitive \

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -350,7 +350,8 @@ let unop env (unop : Fexpr.unop) : Flambda_primitive.unary_primitive =
   | Get_tag -> Get_tag
   | Is_int -> Is_int { variant_only = true } (* CR vlaviron: discuss *)
   | Num_conv { src; dst } -> Num_conv { src; dst }
-  | Opaque_identity -> Opaque_identity { middle_end_only = false }
+  | Opaque_identity ->
+    Opaque_identity { middle_end_only = false; kind = Flambda_kind.value }
   | Project_value_slot { project_from; value_slot } ->
     let value_slot = fresh_or_existing_value_slot env value_slot in
     let project_from = fresh_or_existing_function_slot env project_from in

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -468,8 +468,9 @@ let simplify_is_flat_float_array dacc ~original_term ~arg:_ ~arg_ty ~result_var
     SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
   | Invalid -> SPR.create_invalid dacc
 
-let simplify_opaque_identity dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
-  SPR.create_unknown dacc ~result_var K.value ~original_term
+let simplify_opaque_identity dacc ~kind ~original_term ~arg:_ ~arg_ty:_
+    ~result_var =
+  SPR.create_unknown dacc ~result_var kind ~original_term
 
 let simplify_begin_try_region dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var K.region ~original_term
@@ -595,7 +596,8 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     | Duplicate_array { kind; source_mutability; destination_mutability } ->
       simplify_duplicate_array ~kind ~source_mutability ~destination_mutability
     | Duplicate_block { kind } -> simplify_duplicate_block ~kind
-    | Opaque_identity { middle_end_only = _ } -> simplify_opaque_identity
+    | Opaque_identity { middle_end_only = _; kind } ->
+      simplify_opaque_identity ~kind
     | Begin_try_region -> simplify_begin_try_region
     | End_region -> simplify_end_region
     | Obj_dup -> simplify_obj_dup dbg

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -247,7 +247,10 @@ type unary_primitive =
   (* CR gbury: Invariant check: 0 < dimension <= 3 *)
   | String_length of string_or_bytes
   | Int_as_pointer
-  | Opaque_identity of { middle_end_only : bool }
+  | Opaque_identity of
+      { middle_end_only : bool;
+        kind : Flambda_kind.t
+      }
   | Int_arith of Flambda_kind.Standard_int.t * unary_int_arith_op
   | Float_arith of unary_float_arith_op
   | Num_conv of

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -539,8 +539,9 @@ let unary_primitive env res dbg f arg =
         ~addr:(C.field_address arg (4 + dimension) dbg) )
   | String_length _ -> None, res, C.string_length arg dbg
   | Int_as_pointer -> None, res, C.int_as_pointer arg dbg
-  | Opaque_identity { middle_end_only = true } -> None, res, arg
-  | Opaque_identity { middle_end_only = false } -> None, res, C.opaque arg dbg
+  | Opaque_identity { middle_end_only = true; kind = _ } -> None, res, arg
+  | Opaque_identity { middle_end_only = false; kind = _ } ->
+    None, res, C.opaque arg dbg
   | Int_arith (kind, op) ->
     None, res, unary_int_arith_primitive env dbg kind op arg
   | Float_arith op -> None, res, unary_float_arith_primitive env dbg op arg

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -417,10 +417,10 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbswap16 -> pbswap16
   | Pbbswap _ -> pbbswap
   | Pint_as_pointer -> pint_as_pointer
-  | Popaque -> popaque
+  | Popaque _ -> popaque
   | Pprobe_is_enabled _ -> pprobe_is_enabled
   | Pobj_dup -> pobj_dup
-  | Pobj_magic -> pobj_magic
+  | Pobj_magic _ -> pobj_magic
 
 let of_primitive_arg : Lambda.primitive -> string = function
   | Pbytes_of_string -> pbytes_of_string_arg
@@ -525,7 +525,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbswap16 -> pbswap16_arg
   | Pbbswap _ -> pbbswap_arg
   | Pint_as_pointer -> pint_as_pointer_arg
-  | Popaque -> popaque_arg
+  | Popaque _ -> popaque_arg
   | Pprobe_is_enabled _ -> pprobe_is_enabled_arg
   | Pobj_dup -> pobj_dup_arg
-  | Pobj_magic -> pobj_magic_arg
+  | Pobj_magic _ -> pobj_magic_arg

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -122,7 +122,7 @@ let close_phrase lam =
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in
-    Llet(Strict, Lambda.layout_top, id, glob, l)
+    Llet(Strict, Lambda.layout_module_field, id, glob, l)
   ) (free_variables lam) lam
 
 let toplevel_value id =

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -109,8 +109,8 @@ let rec is_tailcall = function
    from the tail call optimization? *)
 
 let preserve_tailcall_for_prim = function
-    Popaque | Psequor | Psequand
-  | Pobj_magic ->
+    Popaque _ | Psequor | Psequand
+  | Pobj_magic _ ->
       true
   | Pbytes_to_string | Pbytes_of_string | Pignore
   | Pgetglobal _ | Psetglobal _ | Pgetpredef _
@@ -522,7 +522,7 @@ let comp_primitive p args =
   (* The cases below are handled in [comp_expr] before the [comp_primitive] call
      (in the order in which they appear below),
      so they should never be reached in this function. *)
-  | Pignore | Popaque | Pobj_magic
+  | Pignore | Popaque _ | Pobj_magic _
   | Pnot | Psequand | Psequor
   | Praise _
   | Pmakearray _ | Pduparray _
@@ -703,7 +703,7 @@ let rec comp_expr env exp sz cont =
         in
         comp_init env sz decl_size
       end
-  | Lprim((Popaque | Pobj_magic), [arg], _) ->
+  | Lprim((Popaque _ | Pobj_magic _), [arg], _) ->
       comp_expr env arg sz cont
   | Lprim(Pignore, [arg], _) ->
       comp_expr env arg sz (add_const_unit cont)

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1367,4 +1367,58 @@ let structured_constant_layout = function
   | Const_block _ | Const_immstring _ -> Pvalue Pgenval
   | Const_float_array _ | Const_float_block _ -> Pvalue (Parrayval Pfloatarray)
 
-let primitive_result_layout (_p : primitive) = layout_top
+let primitive_result_layout (p : primitive) =
+  match p with
+  | Popaque | Pobj_magic ->
+      (* CR ncourant: these should be parameterized by their layout *)
+      layout_any_value
+  | Pbytes_to_string | Pbytes_of_string -> layout_string
+  | Pignore | Psetfield _ | Psetfield_computed _ | Psetfloatfield _ | Poffsetref _
+  | Pbytessetu | Pbytessets | Parraysetu _ | Parraysets _ | Pbigarrayset _
+    -> layout_unit
+  | Pgetglobal _ | Psetglobal _ | Pgetpredef _ -> layout_module_field
+  | Pmakeblock _ | Pmakefloatblock _ | Pmakearray _ | Pduprecord _
+  | Pduparray _ | Pbigarraydim _ -> layout_block
+  | Pfield _ | Pfield_computed _ -> layout_field
+  | Pfloatfield _ | Pfloatofint _ | Pnegfloat _ | Pabsfloat _
+  | Paddfloat _ | Psubfloat _ | Pmulfloat _ | Pdivfloat _ -> layout_float
+  | Pccall _p ->
+      (* CR ncourant: use native_repr *)
+      layout_any_value
+  | Praise _ -> layout_bottom
+  | Psequor | Psequand | Pnot
+  | Pnegint | Paddint | Psubint | Pmulint
+  | Pdivint _ | Pmodint _
+  | Pandint | Porint | Pxorint
+  | Plslint | Plsrint | Pasrint
+  | Pintcomp _
+  | Pcompare_ints | Pcompare_floats | Pcompare_bints _
+  | Poffsetint _ | Pintoffloat | Pfloatcomp _
+  | Pstringlength | Pstringrefu | Pstringrefs
+  | Pbyteslength | Pbytesrefu | Pbytesrefs
+  | Parraylength _ | Pisint _ | Pisout | Pintofbint _
+  | Pbintcomp _
+    -> layout_int
+  | Parrayrefu array_kind | Parrayrefs array_kind ->
+      (match array_kind with
+       | Pintarray -> layout_int
+       | Pfloatarray -> layout_float
+       | Pgenarray | Paddrarray -> layout_field)
+  | Pbintofint (bi, _) | Pcvtbint (_,bi,_)
+  | Pnegbint (bi, _) | Paddbint (bi, _) | Psubbint (bi, _)
+  | Pmulbint (bi, _) | Pdivbint {size = bi} | Pmodbint {size = bi}
+  | Pandbint (bi, _) | Porbint (bi, _) | Pxorbint (bi, _)
+  | Plslbint (bi, _) | Plsrbint (bi, _) | Pasrbint (bi, _) ->
+      layout_boxedint bi
+  | Pbigarrayref _
+  | Pstring_load_16 _ | Pbytes_load_16 _
+  | Pstring_load_32 _ | Pbytes_load_32 _
+  | Pstring_load_64 _ | Pbytes_load_64 _
+  | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_64 _
+  | Pbigstring_load_16 _
+  | Pbigstring_load_32 _ | Pbigstring_load_64 _
+  | Pbigstring_set_16 _ | Pbigstring_set_32 _ | Pbigstring_set_64 _
+  | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer
+  | Pprobe_is_enabled _ | Pobj_dup
+    -> layout_any_value (* TODO *)
+

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -184,12 +184,12 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer
   (* Inhibition of optimisation *)
-  | Popaque
+  | Popaque of layout
   (* Statically-defined probes *)
   | Pprobe_is_enabled of { name: string }
   (* Primitives for [Obj] *)
   | Pobj_dup
-  | Pobj_magic
+  | Pobj_magic of layout
 
 and integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -437,10 +437,10 @@ let primitive ppf = function
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi,m) -> print_boxed_integer "bswap" ppf bi m
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
-  | Popaque -> fprintf ppf "opaque"
+  | Popaque _ -> fprintf ppf "opaque"
   | Pprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled[%s]" name
   | Pobj_dup -> fprintf ppf "obj_dup"
-  | Pobj_magic -> fprintf ppf "obj_magic"
+  | Pobj_magic _ -> fprintf ppf "obj_magic"
 
 let name_of_primitive = function
   | Pbytes_of_string -> "Pbytes_of_string"
@@ -545,10 +545,10 @@ let name_of_primitive = function
   | Pbswap16 -> "Pbswap16"
   | Pbbswap _ -> "Pbbswap"
   | Pint_as_pointer -> "Pint_as_pointer"
-  | Popaque -> "Popaque"
+  | Popaque _ -> "Popaque"
   | Pprobe_is_enabled _ -> "Pprobe_is_enabled"
   | Pobj_dup -> "Pobj_dup"
-  | Pobj_magic -> "Pobj_magic"
+  | Pobj_magic _ -> "Pobj_magic"
 
 let check_attribute ppf check =
   let check_property = function

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -842,12 +842,12 @@ let rec choice ctx t =
         choice_makeblock ctx ~tail (tag, flag, shape, mode) primargs loc
 
     (* Some primitives have arguments in tail-position *)
-    | Popaque ->
+    | Popaque layout ->
         let l1 = match primargs with
           |  [l1] -> l1
           | _ -> invalid_arg "choice_prim" in
         let+ l1 = choice ctx ~tail l1 in
-        Lprim (Popaque, [l1], loc)
+        Lprim (Popaque layout, [l1], loc)
     | (Psequand | Psequor) as shortcutop ->
         let l1, l2 = match primargs with
           |  [l1; l2] -> l1, l2
@@ -891,7 +891,7 @@ let rec choice ctx t =
     | Pmakefloatblock _
 
     | Pobj_dup
-    | Pobj_magic
+    | Pobj_magic _
     | Pprobe_is_enabled _
 
     (* operations returning boxed values could be considered

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -68,7 +68,7 @@ let lapply ap =
 
 let mkappl (func, args, layout) =
   Lprim
-    (Popaque,
+    (Popaque layout,
      [Lapply {
          ap_loc=Loc_unknown;
          ap_func=func;
@@ -290,7 +290,8 @@ let output_methods tbl methods lam =
         Lprim(Pmakeblock(0,Immutable,None,alloc_heap), methods, Loc_unknown)
       in
       lsequence (mkappl(oo_prim "set_methods",
-                        [Lvar tbl; Lprim (Popaque, [methods], Loc_unknown)], layout_unit))
+                        [Lvar tbl; Lprim (Popaque layout_block,
+                                          [methods], Loc_unknown)], layout_unit))
         lam
 
 let rec ignore_cstrs cl =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -770,7 +770,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
             optimisation in Flambda, but the concept of a mutable
             block doesn't really match what is going on here.  This
             value may subsequently turn into an immediate... *)
-         Lprim (Popaque,
+         Lprim (Popaque Lambda.layout_lazy,
                 [Lprim(Pmakeblock(Obj.forward_tag, Immutable, None,
                                   alloc_heap),
                        [transl_exp ~scopes e],

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1006,7 +1006,7 @@ and transl_apply ~scopes
         }
   in
   let rec build_apply lam args loc pos ap_mode = function
-    | Omitted { mode_closure; mode_arg; mode_ret } :: l ->
+    | Omitted { mode_closure; mode_arg; mode_ret; ty_arg; ty_env } :: l ->
         assert (pos = Rc_normal);
         let defs = ref [] in
         let protect name (lam, layout) =
@@ -1049,8 +1049,8 @@ and transl_apply ~scopes
             | Alloc_local -> false
             | Alloc_heap -> true
           in
-          (* CR ncourant: need layout of the omitted parameter *)
-          lfunction ~kind:(Curried {nlocal}) ~params:[id_arg, Lambda.layout_top]
+          let layout_arg = Typeopt.layout ty_env ty_arg in
+          lfunction ~kind:(Curried {nlocal}) ~params:[id_arg, layout_arg]
                     ~return:result_layout ~body ~mode ~region
                     ~attr:default_stub_attribute ~loc
         in

--- a/ocaml/lambda/translobj.ml
+++ b/ocaml/lambda/translobj.ml
@@ -92,13 +92,14 @@ let transl_label_init_general f =
   let expr =
     Hashtbl.fold
       (fun c id expr ->
+         let layout = Lambda.structured_constant_layout c in
          let const =
-           Lprim (Popaque, [Lconst c], Debuginfo.Scoped_location.Loc_unknown)
+           Lprim (Popaque layout, [Lconst c], Debuginfo.Scoped_location.Loc_unknown)
          in
          (* CR ncourant: this *should* not be too precise for the moment,
             but we should take care, or fix the underlying cause that led
             us to using [Popaque]. *)
-         Llet(Alias, Lambda.structured_constant_layout c, id, const, expr))
+         Llet(Alias, layout, id, const, expr))
       consts expr
   in
   (*let expr =
@@ -190,7 +191,7 @@ let oo_wrap env req f x =
                         Loc_unknown)
                 in
                 Llet(StrictOpt, Lambda.layout_class, id,
-                     Lprim (Popaque, [cl], Loc_unknown),
+                     Lprim (Popaque Lambda.layout_class, [cl], Loc_unknown),
                      lambda))
              lambda !classes
          in

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -77,9 +77,6 @@ type loc_kind =
   | Loc_POS
   | Loc_FUNCTION
 
-(* CR ncourant: the result layout of these should probably be an option, filled
-   by specialise_primitive and the rest of the code should fail if it
-   encounters it? *)
 type prim =
   | Primitive of Lambda.primitive * int
   | External of Primitive.description
@@ -388,7 +385,7 @@ let lookup_primitive loc poly pos p =
     | "%bswap_int64" -> Primitive ((Pbbswap(Pint64, mode)), 1)
     | "%bswap_native" -> Primitive ((Pbbswap(Pnativeint, mode)), 1)
     | "%int_as_pointer" -> Primitive (Pint_as_pointer, 1)
-    | "%opaque" -> Primitive (Popaque, 1)
+    | "%opaque" -> Primitive (Popaque Lambda.layout_any_value, 1)
     | "%sys_argv" -> Sys_argv
     | "%send" -> Send (pos, Lambda.layout_any_value)
     | "%sendself" -> Send_self (pos, Lambda.layout_any_value)
@@ -401,7 +398,7 @@ let lookup_primitive loc poly pos p =
     | "%greaterthan" -> Comparison(Greater_than, Compare_generic)
     | "%compare" -> Comparison(Compare, Compare_generic)
     | "%obj_dup" -> Primitive(Pobj_dup, 1)
-    | "%obj_magic" -> Primitive(Pobj_magic, 1)
+    | "%obj_magic" -> Primitive(Pobj_magic Lambda.layout_any_value, 1)
     | s when String.length s > 0 && s.[0] = '%' ->
        raise(Error(loc, Unknown_builtin_primitive s))
     | _ -> External p
@@ -885,8 +882,8 @@ let lambda_primitive_needs_event_after = function
   | Pbytessetu | Pmakearray ((Pintarray | Paddrarray | Pfloatarray), _, _)
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisout
   | Pprobe_is_enabled _
-  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque
-  | Pobj_magic -> false
+  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque _
+  | Pobj_magic _ -> false
 
 (* Determine if a primitive should be surrounded by an "after" debug event *)
 let primitive_needs_event_after = function

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -812,12 +812,12 @@ let bind_params { backend; mutable_vars; _ } loc fdesc params args funct body =
     match (pl, al) with
       ([], []) -> substitute (Debuginfo.from_location loc) (backend, fpc)
                     subst (Some Int.Map.empty) body
-    | (p1 :: pl, a1 :: al) ->
+    | (p1 :: pl, (layout1, a1) :: al) ->
         if is_substituable ~mutable_vars a1 then
           aux (V.Map.add (VP.var p1) a1 subst) pl al body
         else begin
           let p1' = VP.rename p1 in
-          let u1, u2 =
+          let u1, u2, layout =
             match VP.name p1, a1 with
             | "*opt*", Uprim(P.Pmakeblock(0, Immutable, kind, mode), [a], dbg) ->
                 (* This parameter corresponds to an optional parameter,
@@ -826,13 +826,14 @@ let bind_params { backend; mutable_vars; _ } loc fdesc params args funct body =
                    appear once under a Pisint primitive and once under a Pfield
                    primitive (see [simplif_prim_pure]) *)
                 a, Uprim(P.Pmakeblock(0, Immutable, kind, mode),
-                         [Uvar (VP.var p1')], dbg)
+                         [Uvar (VP.var p1')], dbg),
+                Lambda.layout_field
             | _ ->
-                a1, Uvar (VP.var p1')
+                a1, Uvar (VP.var p1'), layout1
           in
           let body' = aux (V.Map.add (VP.var p1) u2 subst) pl al body in
           if occurs_var (VP.var p1) body then
-            Ulet(Immutable, Lambda.layout_top, p1', u1, body')
+            Ulet(Immutable, layout, p1', u1, body')
           else if is_erasable a1 then body'
           else Usequence(a1, body')
         end
@@ -845,7 +846,7 @@ let bind_params { backend; mutable_vars; _ } loc fdesc params args funct body =
     (* Ensure funct is evaluated after args *)
     match params with
     | my_closure :: params when not fdesc.fun_closed ->
-       (params @ [my_closure]), (args @ [funct]), body
+       (params @ [my_closure]), (args @ [Lambda.layout_function, funct]), body
     | _ ->
        params, args, (if is_pure funct then body else Usequence (funct, body))
   in
@@ -882,22 +883,22 @@ let direct_apply env fundesc ufunct uargs pos result_layout mode ~probe ~loc ~at
        fail_if_probe ~probe "Erroneously marked to be inlined"
      end;
      if fundesc.fun_closed && is_pure ufunct then
-       Udirect_apply(fundesc.fun_label, uargs, probe, result_layout, kind, dbg)
+       Udirect_apply(fundesc.fun_label, List.map snd uargs, probe, result_layout, kind, dbg)
      else if not fundesc.fun_closed &&
                is_substituable ~mutable_vars:env.mutable_vars ufunct then
-       Udirect_apply(fundesc.fun_label, uargs @ [ufunct], probe, result_layout, kind, dbg)
+       Udirect_apply(fundesc.fun_label, List.map snd uargs @ [ufunct], probe, result_layout, kind, dbg)
      else begin
-       let args = List.map (fun arg ->
+       let args = List.map (fun (layout, arg) ->
          if is_substituable ~mutable_vars:env.mutable_vars arg then
-           None, arg
+           layout, None, arg
          else
            let id = V.create_local "arg" in
-           Some (VP.create id, arg), Uvar id) uargs in
-       let app_args = List.map snd args in
-       List.fold_left (fun app (binding,_) ->
+           layout, Some (VP.create id, arg), Uvar id) uargs in
+       let app_args = List.map (fun (_, _, arg) -> arg) args in
+       List.fold_left (fun app (layout,binding,_) ->
            match binding with
            | None -> app
-           | Some (v, e) -> Ulet(Immutable, Lambda.layout_top, v, e, app))
+           | Some (v, e) -> Ulet(Immutable, layout, v, e, app))
          (if fundesc.fun_closed then
             Usequence (ufunct,
                        Udirect_apply (fundesc.fun_label, app_args,
@@ -1072,7 +1073,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
          [Uprim(P.Pmakeblock _, uargs, _)])
         when List.length uargs = List.length params_layout ->
           let app =
-            direct_apply env ~loc ~attribute fundesc ufunct uargs
+            direct_apply env ~loc ~attribute fundesc ufunct (List.combine params_layout uargs)
               pos ap_result_layout mode ~probe in
           (app, strengthen_approx app approx_res)
       | ((ufunct, Value_closure(_,
@@ -1082,7 +1083,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
                                 approx_res)), uargs)
         when nargs = List.length params_layout ->
           let app =
-            direct_apply env ~loc ~attribute fundesc ufunct uargs
+            direct_apply env ~loc ~attribute fundesc ufunct (List.combine params_layout uargs)
               pos ap_result_layout mode ~probe in
           (app, strengthen_approx app approx_res)
 
@@ -1177,7 +1178,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
             List.fold_left2 (fun kinds (var, _) kind -> V.Map.add var kind kinds)
               kinds args args_kinds
           in
-          let _, rem_kinds = split_list nparams args_kinds in
+          let first_kinds, rem_kinds = split_list nparams args_kinds in
           let (first_args, rem_args) = split_list nparams args in
           let first_args = List.map (fun (id, _) -> Uvar id) first_args in
           let rem_args = List.map (fun (id, _) -> Uvar id) rem_args in
@@ -1187,7 +1188,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           let mode' = if fundesc.fun_region then alloc_heap else alloc_local in
           let body =
             Ugeneric_apply(direct_apply { env with kinds } ~loc ~attribute
-                              fundesc ufunct first_args
+                              fundesc ufunct (List.combine first_kinds first_args)
                               Rc_normal Lambda.layout_function mode'
                               ~probe,
                            rem_args,
@@ -1287,7 +1288,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
       end else begin
         (* General case: recursive definition of values *)
         let kinds =
-          List.fold_left (fun kinds (id, _) -> V.Map.add id Lambda.layout_top kinds)
+          List.fold_left (fun kinds (id, _) -> V.Map.add id Lambda.layout_letrec kinds)
             kinds defs
         in
         let rec clos_defs = function

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -1322,7 +1322,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
   | Lprim(Pignore, [arg], _loc) ->
       let expr, approx = make_const_int 0 in
       Usequence(fst (close env arg), expr), approx
-  | Lprim((Pbytes_to_string | Pbytes_of_string | Pobj_magic),
+  | Lprim((Pbytes_to_string | Pbytes_of_string | Pobj_magic _),
           [arg], _loc) ->
       close env arg
   | Lprim(Pgetglobal cu, [], loc) ->

--- a/ocaml/middle_end/convert_primitives.ml
+++ b/ocaml/middle_end/convert_primitives.ml
@@ -141,7 +141,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pbigarraydim dim -> Pbigarraydim dim
   | Pbswap16 -> Pbswap16
   | Pint_as_pointer -> Pint_as_pointer
-  | Popaque -> Popaque
+  | Popaque _ -> Popaque
   | Pprobe_is_enabled {name} -> Pprobe_is_enabled {name}
   | Pobj_dup ->
     let module P = Primitive in
@@ -154,7 +154,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       ~native_name:"caml_obj_dup"
       ~native_repr_args:[P.Prim_global, P.Same_as_ocaml_repr]
       ~native_repr_res:(P.Prim_global, P.Same_as_ocaml_repr))
-  | Pobj_magic
+  | Pobj_magic _
   | Pbytes_to_string
   | Pbytes_of_string
   | Pctconst _

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -419,7 +419,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
         (If_then_else (cond, arg2, Var const_false, Lambda.layout_int)))
   | Lprim ((Psequand | Psequor), _, _) ->
     Misc.fatal_error "Psequand / Psequor must have exactly two arguments"
-  | Lprim ((Pbytes_to_string | Pbytes_of_string | Pobj_magic),
+  | Lprim ((Pbytes_to_string | Pbytes_of_string | Pobj_magic _),
            [arg], _) ->
     close t env arg
   | Lprim (Pignore, [arg], _) ->

--- a/ocaml/middle_end/internal_variable_names.ml
+++ b/ocaml/middle_end/internal_variable_names.ml
@@ -417,10 +417,10 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbswap16 -> pbswap16
   | Pbbswap _ -> pbbswap
   | Pint_as_pointer -> pint_as_pointer
-  | Popaque -> popaque
+  | Popaque _ -> popaque
   | Pprobe_is_enabled _ -> pprobe_is_enabled
   | Pobj_dup -> pobj_dup
-  | Pobj_magic -> pobj_magic
+  | Pobj_magic _ -> pobj_magic
 
 let of_primitive_arg : Lambda.primitive -> string = function
   | Pbytes_of_string -> pbytes_of_string_arg
@@ -525,7 +525,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbswap16 -> pbswap16_arg
   | Pbbswap _ -> pbbswap_arg
   | Pint_as_pointer -> pint_as_pointer_arg
-  | Popaque -> popaque_arg
+  | Popaque _ -> popaque_arg
   | Pprobe_is_enabled _ -> pprobe_is_enabled_arg
   | Pobj_dup -> pobj_dup_arg
-  | Pobj_magic -> pobj_magic_arg
+  | Pobj_magic _ -> pobj_magic_arg

--- a/ocaml/testsuite/tests/translprim/array_spec.compilers.flat.reference
+++ b/ocaml/testsuite/tests/translprim/array_spec.compilers.flat.reference
@@ -46,11 +46,11 @@
            (function {nlocal = 0} prim[intarray] prim[int] stub : int
              (array.unsafe_get[int] prim prim))
          eta_int_safe_set =
-           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
-             (array.set[int] prim prim prim))
+           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+             : int (array.set[int] prim prim prim))
          eta_int_unsafe_set =
-           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
-             (array.unsafe_set[int] prim prim prim))
+           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+             : int (array.unsafe_set[int] prim prim prim))
          eta_float_len =
            (function {nlocal = 0} prim[floatarray] stub : int
              (array.length[float] prim))
@@ -61,11 +61,11 @@
            (function {nlocal = 0} prim[floatarray] prim[int] stub : float
              (array.unsafe_get[float] prim prim))
          eta_float_safe_set =
-           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub : int
-             (array.set[float] prim prim prim))
+           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+             : int (array.set[float] prim prim prim))
          eta_float_unsafe_set =
-           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub : int
-             (array.unsafe_set[float] prim prim prim))
+           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+             : int (array.unsafe_set[float] prim prim prim))
          eta_addr_len =
            (function {nlocal = 0} prim[addrarray] stub : int
              (array.length[addr] prim))

--- a/ocaml/testsuite/tests/translprim/array_spec.compilers.flat.reference
+++ b/ocaml/testsuite/tests/translprim/array_spec.compilers.flat.reference
@@ -22,7 +22,7 @@
         (array.unsafe_set[gen] a 0 x))
       (let
         (eta_gen_len =
-           (function {nlocal = 0} prim[genarray] stub
+           (function {nlocal = 0} prim[genarray] stub : int
              (array.length[gen] prim))
          eta_gen_safe_get =
            (function {nlocal = 0} prim[genarray] prim[int] stub
@@ -31,43 +31,43 @@
            (function {nlocal = 0} prim[genarray] prim[int] stub
              (array.unsafe_get[gen] prim prim))
          eta_gen_safe_set =
-           (function {nlocal = 0} prim[genarray] prim[int] prim stub
+           (function {nlocal = 0} prim[genarray] prim[int] prim stub : int
              (array.set[gen] prim prim prim))
          eta_gen_unsafe_set =
-           (function {nlocal = 0} prim[genarray] prim[int] prim stub
+           (function {nlocal = 0} prim[genarray] prim[int] prim stub : int
              (array.unsafe_set[gen] prim prim prim))
          eta_int_len =
-           (function {nlocal = 0} prim[intarray] stub
+           (function {nlocal = 0} prim[intarray] stub : int
              (array.length[int] prim))
          eta_int_safe_get =
-           (function {nlocal = 0} prim[intarray] prim[int] stub
+           (function {nlocal = 0} prim[intarray] prim[int] stub : int
              (array.get[int] prim prim))
          eta_int_unsafe_get =
-           (function {nlocal = 0} prim[intarray] prim[int] stub
+           (function {nlocal = 0} prim[intarray] prim[int] stub : int
              (array.unsafe_get[int] prim prim))
          eta_int_safe_set =
-           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
              (array.set[int] prim prim prim))
          eta_int_unsafe_set =
-           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
              (array.unsafe_set[int] prim prim prim))
          eta_float_len =
-           (function {nlocal = 0} prim[floatarray] stub
+           (function {nlocal = 0} prim[floatarray] stub : int
              (array.length[float] prim))
          eta_float_safe_get =
-           (function {nlocal = 0} prim[floatarray] prim[int] stub
+           (function {nlocal = 0} prim[floatarray] prim[int] stub : float
              (array.get[float] prim prim))
          eta_float_unsafe_get =
-           (function {nlocal = 0} prim[floatarray] prim[int] stub
+           (function {nlocal = 0} prim[floatarray] prim[int] stub : float
              (array.unsafe_get[float] prim prim))
          eta_float_safe_set =
-           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub : int
              (array.set[float] prim prim prim))
          eta_float_unsafe_set =
-           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub : int
              (array.unsafe_set[float] prim prim prim))
          eta_addr_len =
-           (function {nlocal = 0} prim[addrarray] stub
+           (function {nlocal = 0} prim[addrarray] stub : int
              (array.length[addr] prim))
          eta_addr_safe_get =
            (function {nlocal = 0} prim[addrarray] prim[int] stub
@@ -76,10 +76,10 @@
            (function {nlocal = 0} prim[addrarray] prim[int] stub
              (array.unsafe_get[addr] prim prim))
          eta_addr_safe_set =
-           (function {nlocal = 0} prim[addrarray] prim[int] prim stub
+           (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
              (array.set[addr] prim prim prim))
          eta_addr_unsafe_set =
-           (function {nlocal = 0} prim[addrarray] prim[int] prim stub
+           (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
              (array.unsafe_set[addr] prim prim prim)))
         (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
           eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len

--- a/ocaml/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/ocaml/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -96,160 +96,160 @@
        (function {nlocal = 0} x[nativeint] y[nativeint] : int
          (Nativeint.>= x y))
      eta_gen_cmp =
-       (function {nlocal = 0} prim prim stub (caml_compare prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_compare prim prim))
      eta_int_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub
+       (function {nlocal = 0} prim[int] prim[int] stub : int
          (compare_ints prim prim))
      eta_bool_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub
+       (function {nlocal = 0} prim[int] prim[int] stub : int
          (compare_ints prim prim))
      eta_intlike_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub
+       (function {nlocal = 0} prim[int] prim[int] stub : int
          (compare_ints prim prim))
      eta_float_cmp =
-       (function {nlocal = 0} prim[float] prim[float] stub
+       (function {nlocal = 0} prim[float] prim[float] stub : int
          (compare_floats prim prim))
      eta_string_cmp =
-       (function {nlocal = 0} prim prim stub (caml_string_compare prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_string_compare prim prim))
      eta_int32_cmp =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
          (compare_bints int32 prim prim))
      eta_int64_cmp =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
          (compare_bints int64 prim prim))
      eta_nativeint_cmp =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (compare_bints nativeint prim prim))
      eta_gen_eq =
-       (function {nlocal = 0} prim prim stub (caml_equal prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_equal prim prim))
      eta_int_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub (== prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_bool_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub (== prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_intlike_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub (== prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_float_eq =
-       (function {nlocal = 0} prim[float] prim[float] stub (==. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int (==. prim prim))
      eta_string_eq =
-       (function {nlocal = 0} prim prim stub (caml_string_equal prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_string_equal prim prim))
      eta_int32_eq =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
          (Int32.== prim prim))
      eta_int64_eq =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
          (Int64.== prim prim))
      eta_nativeint_eq =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (Nativeint.== prim prim))
      eta_gen_ne =
-       (function {nlocal = 0} prim prim stub (caml_notequal prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_notequal prim prim))
      eta_int_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub (!= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_bool_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub (!= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_intlike_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub (!= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_float_ne =
-       (function {nlocal = 0} prim[float] prim[float] stub (!=. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int (!=. prim prim))
      eta_string_ne =
-       (function {nlocal = 0} prim prim stub
+       (function {nlocal = 0} prim prim stub : int
          (caml_string_notequal prim prim))
      eta_int32_ne =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
          (Int32.!= prim prim))
      eta_int64_ne =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
          (Int64.!= prim prim))
      eta_nativeint_ne =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (Nativeint.!= prim prim))
      eta_gen_lt =
-       (function {nlocal = 0} prim prim stub (caml_lessthan prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_lessthan prim prim))
      eta_int_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub (< prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_bool_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub (< prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_intlike_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub (< prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_float_lt =
-       (function {nlocal = 0} prim[float] prim[float] stub (<. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int (<. prim prim))
      eta_string_lt =
-       (function {nlocal = 0} prim prim stub
+       (function {nlocal = 0} prim prim stub : int
          (caml_string_lessthan prim prim))
      eta_int32_lt =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
          (Int32.< prim prim))
      eta_int64_lt =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
          (Int64.< prim prim))
      eta_nativeint_lt =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (Nativeint.< prim prim))
      eta_gen_gt =
-       (function {nlocal = 0} prim prim stub (caml_greaterthan prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_greaterthan prim prim))
      eta_int_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub (> prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_bool_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub (> prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_intlike_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub (> prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_float_gt =
-       (function {nlocal = 0} prim[float] prim[float] stub (>. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int (>. prim prim))
      eta_string_gt =
-       (function {nlocal = 0} prim prim stub
+       (function {nlocal = 0} prim prim stub : int
          (caml_string_greaterthan prim prim))
      eta_int32_gt =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
          (Int32.> prim prim))
      eta_int64_gt =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
          (Int64.> prim prim))
      eta_nativeint_gt =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (Nativeint.> prim prim))
      eta_gen_le =
-       (function {nlocal = 0} prim prim stub (caml_lessequal prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_lessequal prim prim))
      eta_int_le =
-       (function {nlocal = 0} prim[int] prim[int] stub (<= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_bool_le =
-       (function {nlocal = 0} prim[int] prim[int] stub (<= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_intlike_le =
-       (function {nlocal = 0} prim[int] prim[int] stub (<= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_float_le =
-       (function {nlocal = 0} prim[float] prim[float] stub (<=. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int (<=. prim prim))
      eta_string_le =
-       (function {nlocal = 0} prim prim stub
+       (function {nlocal = 0} prim prim stub : int
          (caml_string_lessequal prim prim))
      eta_int32_le =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
          (Int32.<= prim prim))
      eta_int64_le =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
          (Int64.<= prim prim))
      eta_nativeint_le =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (Nativeint.<= prim prim))
      eta_gen_ge =
-       (function {nlocal = 0} prim prim stub (caml_greaterequal prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_greaterequal prim prim))
      eta_int_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub (>= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_bool_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub (>= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_intlike_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub (>= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_float_ge =
-       (function {nlocal = 0} prim[float] prim[float] stub (>=. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int (>=. prim prim))
      eta_string_ge =
-       (function {nlocal = 0} prim prim stub
+       (function {nlocal = 0} prim prim stub : int
          (caml_string_greaterequal prim prim))
      eta_int32_ge =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
          (Int32.>= prim prim))
      eta_int64_ge =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
          (Int64.>= prim prim))
      eta_nativeint_ge =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (Nativeint.>= prim prim))
      int_vec =[(consts (0))
                (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]

--- a/ocaml/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/ocaml/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -110,7 +110,8 @@
        (function {nlocal = 0} prim[float] prim[float] stub : int
          (compare_floats prim prim))
      eta_string_cmp =
-       (function {nlocal = 0} prim prim stub : int (caml_string_compare prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_compare prim prim))
      eta_int32_cmp =
        (function {nlocal = 0} prim[int32] prim[int32] stub : int
          (compare_bints int32 prim prim))
@@ -129,9 +130,11 @@
      eta_intlike_eq =
        (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_float_eq =
-       (function {nlocal = 0} prim[float] prim[float] stub : int (==. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (==. prim prim))
      eta_string_eq =
-       (function {nlocal = 0} prim prim stub : int (caml_string_equal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_equal prim prim))
      eta_int32_eq =
        (function {nlocal = 0} prim[int32] prim[int32] stub : int
          (Int32.== prim prim))
@@ -150,7 +153,8 @@
      eta_intlike_ne =
        (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_float_ne =
-       (function {nlocal = 0} prim[float] prim[float] stub : int (!=. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (!=. prim prim))
      eta_string_ne =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_notequal prim prim))
@@ -172,7 +176,8 @@
      eta_intlike_lt =
        (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_float_lt =
-       (function {nlocal = 0} prim[float] prim[float] stub : int (<. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (<. prim prim))
      eta_string_lt =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_lessthan prim prim))
@@ -186,7 +191,8 @@
        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (Nativeint.< prim prim))
      eta_gen_gt =
-       (function {nlocal = 0} prim prim stub : int (caml_greaterthan prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_greaterthan prim prim))
      eta_int_gt =
        (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_bool_gt =
@@ -194,7 +200,8 @@
      eta_intlike_gt =
        (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_float_gt =
-       (function {nlocal = 0} prim[float] prim[float] stub : int (>. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (>. prim prim))
      eta_string_gt =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_greaterthan prim prim))
@@ -208,7 +215,8 @@
        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (Nativeint.> prim prim))
      eta_gen_le =
-       (function {nlocal = 0} prim prim stub : int (caml_lessequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_lessequal prim prim))
      eta_int_le =
        (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_bool_le =
@@ -216,7 +224,8 @@
      eta_intlike_le =
        (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_float_le =
-       (function {nlocal = 0} prim[float] prim[float] stub : int (<=. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (<=. prim prim))
      eta_string_le =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_lessequal prim prim))
@@ -230,7 +239,8 @@
        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (Nativeint.<= prim prim))
      eta_gen_ge =
-       (function {nlocal = 0} prim prim stub : int (caml_greaterequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_greaterequal prim prim))
      eta_int_ge =
        (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_bool_ge =
@@ -238,7 +248,8 @@
      eta_intlike_ge =
        (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_float_ge =
-       (function {nlocal = 0} prim[float] prim[float] stub : int (>=. prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (>=. prim prim))
      eta_string_ge =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_greaterequal prim prim))

--- a/ocaml/testsuite/tests/translprim/module_coercion.compilers.flat.reference
+++ b/ocaml/testsuite/tests/translprim/module_coercion.compilers.flat.reference
@@ -12,38 +12,46 @@
             (array.get[int] prim prim))
           (function {nlocal = 0} prim[intarray] prim[int] stub : int
             (array.unsafe_get[int] prim prim))
-          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
-            (array.set[int] prim prim prim))
-          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
-            (array.unsafe_set[int] prim prim prim))
+          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+            : int (array.set[int] prim prim prim))
+          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+            : int (array.unsafe_set[int] prim prim prim))
           (function {nlocal = 0} prim[int] prim[int] stub : int
             (compare_ints prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))))
+          (function {nlocal = 0} prim[int] prim[int] stub : int
+            (== prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int
+            (!= prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int
+            (< prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int
+            (> prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int
+            (<= prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int
+            (>= prim prim))))
       (module-defn(M_float) Module_coercion module_coercion.ml(47):1594-1637
         (makeblock 0
           (function {nlocal = 0} prim[floatarray] stub : int
             (array.length[float] prim))
-          (function {nlocal = 0} prim[floatarray] prim[int] stub : int
+          (function {nlocal = 0} prim[floatarray] prim[int] stub : float
             (array.get[float] prim prim))
-          (function {nlocal = 0} prim[floatarray] prim[int] stub : int
+          (function {nlocal = 0} prim[floatarray] prim[int] stub : float
             (array.unsafe_get[float] prim prim))
-          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub : int
-            (array.set[float] prim prim prim))
-          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub : int
-            (array.unsafe_set[float] prim prim prim))
+          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+            : int (array.set[float] prim prim prim))
+          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+            : int (array.unsafe_set[float] prim prim prim))
           (function {nlocal = 0} prim[float] prim[float] stub : int
             (compare_floats prim prim))
           (function {nlocal = 0} prim[float] prim[float] stub : int
             (==. prim prim))
           (function {nlocal = 0} prim[float] prim[float] stub : int
             (!=. prim prim))
-          (function {nlocal = 0} prim[float] prim[float] stub : int (<. prim prim))
-          (function {nlocal = 0} prim[float] prim[float] stub : int (>. prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub : int
+            (<. prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub : int
+            (>. prim prim))
           (function {nlocal = 0} prim[float] prim[float] stub : int
             (<=. prim prim))
           (function {nlocal = 0} prim[float] prim[float] stub : int
@@ -52,9 +60,9 @@
         (makeblock 0
           (function {nlocal = 0} prim[addrarray] stub : int
             (array.length[addr] prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub : float
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
             (array.get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub : float
+          (function {nlocal = 0} prim[addrarray] prim[int] stub
             (array.unsafe_get[addr] prim prim))
           (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
             (array.set[addr] prim prim prim))
@@ -82,10 +90,10 @@
             (array.get[addr] prim prim))
           (function {nlocal = 0} prim[addrarray] prim[int] stub : int32
             (array.unsafe_get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub : int
-            (array.set[addr] prim prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub : int
-            (array.unsafe_set[addr] prim prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
+            : int (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
+            : int (array.unsafe_set[addr] prim prim prim))
           (function {nlocal = 0} prim[int32] prim[int32] stub : int
             (compare_bints int32 prim prim))
           (function {nlocal = 0} prim[int32] prim[int32] stub : int
@@ -108,10 +116,10 @@
             (array.get[addr] prim prim))
           (function {nlocal = 0} prim[addrarray] prim[int] stub : int64
             (array.unsafe_get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub : int
-            (array.set[addr] prim prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub : int
-            (array.unsafe_set[addr] prim prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
+            : int (array.set[addr] prim prim prim))
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
+            : int (array.unsafe_set[addr] prim prim prim))
           (function {nlocal = 0} prim[int64] prim[int64] stub : int
             (compare_bints int64 prim prim))
           (function {nlocal = 0} prim[int64] prim[int64] stub : int

--- a/ocaml/testsuite/tests/translprim/module_coercion.compilers.flat.reference
+++ b/ocaml/testsuite/tests/translprim/module_coercion.compilers.flat.reference
@@ -6,149 +6,149 @@
     (makeblock 0 M
       (module-defn(M_int) Module_coercion module_coercion.ml(46):1552-1591
         (makeblock 0
-          (function {nlocal = 0} prim[intarray] stub
+          (function {nlocal = 0} prim[intarray] stub : int
             (array.length[int] prim))
-          (function {nlocal = 0} prim[intarray] prim[int] stub
+          (function {nlocal = 0} prim[intarray] prim[int] stub : int
             (array.get[int] prim prim))
-          (function {nlocal = 0} prim[intarray] prim[int] stub
+          (function {nlocal = 0} prim[intarray] prim[int] stub : int
             (array.unsafe_get[int] prim prim))
-          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
             (array.set[int] prim prim prim))
-          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
+          (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
             (array.unsafe_set[int] prim prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub
+          (function {nlocal = 0} prim[int] prim[int] stub : int
             (compare_ints prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub (== prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub (!= prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub (< prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub (> prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub (<= prim prim))
-          (function {nlocal = 0} prim[int] prim[int] stub (>= prim prim))))
+          (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
+          (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))))
       (module-defn(M_float) Module_coercion module_coercion.ml(47):1594-1637
         (makeblock 0
-          (function {nlocal = 0} prim[floatarray] stub
+          (function {nlocal = 0} prim[floatarray] stub : int
             (array.length[float] prim))
-          (function {nlocal = 0} prim[floatarray] prim[int] stub
+          (function {nlocal = 0} prim[floatarray] prim[int] stub : int
             (array.get[float] prim prim))
-          (function {nlocal = 0} prim[floatarray] prim[int] stub
+          (function {nlocal = 0} prim[floatarray] prim[int] stub : int
             (array.unsafe_get[float] prim prim))
-          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub : int
             (array.set[float] prim prim prim))
-          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
+          (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub : int
             (array.unsafe_set[float] prim prim prim))
-          (function {nlocal = 0} prim[float] prim[float] stub
+          (function {nlocal = 0} prim[float] prim[float] stub : int
             (compare_floats prim prim))
-          (function {nlocal = 0} prim[float] prim[float] stub
+          (function {nlocal = 0} prim[float] prim[float] stub : int
             (==. prim prim))
-          (function {nlocal = 0} prim[float] prim[float] stub
+          (function {nlocal = 0} prim[float] prim[float] stub : int
             (!=. prim prim))
-          (function {nlocal = 0} prim[float] prim[float] stub (<. prim prim))
-          (function {nlocal = 0} prim[float] prim[float] stub (>. prim prim))
-          (function {nlocal = 0} prim[float] prim[float] stub
+          (function {nlocal = 0} prim[float] prim[float] stub : int (<. prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub : int (>. prim prim))
+          (function {nlocal = 0} prim[float] prim[float] stub : int
             (<=. prim prim))
-          (function {nlocal = 0} prim[float] prim[float] stub
+          (function {nlocal = 0} prim[float] prim[float] stub : int
             (>=. prim prim))))
       (module-defn(M_string) Module_coercion module_coercion.ml(48):1640-1685
         (makeblock 0
-          (function {nlocal = 0} prim[addrarray] stub
+          (function {nlocal = 0} prim[addrarray] stub : int
             (array.length[addr] prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] stub : float
             (array.get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] stub : float
             (array.unsafe_get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim stub
+          (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
             (array.set[addr] prim prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim stub
+          (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
             (array.unsafe_set[addr] prim prim prim))
-          (function {nlocal = 0} prim prim stub
+          (function {nlocal = 0} prim prim stub : int
             (caml_string_compare prim prim))
-          (function {nlocal = 0} prim prim stub
+          (function {nlocal = 0} prim prim stub : int
             (caml_string_equal prim prim))
-          (function {nlocal = 0} prim prim stub
+          (function {nlocal = 0} prim prim stub : int
             (caml_string_notequal prim prim))
-          (function {nlocal = 0} prim prim stub
+          (function {nlocal = 0} prim prim stub : int
             (caml_string_lessthan prim prim))
-          (function {nlocal = 0} prim prim stub
+          (function {nlocal = 0} prim prim stub : int
             (caml_string_greaterthan prim prim))
-          (function {nlocal = 0} prim prim stub
+          (function {nlocal = 0} prim prim stub : int
             (caml_string_lessequal prim prim))
-          (function {nlocal = 0} prim prim stub
+          (function {nlocal = 0} prim prim stub : int
             (caml_string_greaterequal prim prim))))
       (module-defn(M_int32) Module_coercion module_coercion.ml(49):1688-1731
         (makeblock 0
-          (function {nlocal = 0} prim[addrarray] stub
+          (function {nlocal = 0} prim[addrarray] stub : int
             (array.length[addr] prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] stub : int32
             (array.get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] stub : int32
             (array.unsafe_get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub : int
             (array.set[addr] prim prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub : int
             (array.unsafe_set[addr] prim prim prim))
-          (function {nlocal = 0} prim[int32] prim[int32] stub
+          (function {nlocal = 0} prim[int32] prim[int32] stub : int
             (compare_bints int32 prim prim))
-          (function {nlocal = 0} prim[int32] prim[int32] stub
+          (function {nlocal = 0} prim[int32] prim[int32] stub : int
             (Int32.== prim prim))
-          (function {nlocal = 0} prim[int32] prim[int32] stub
+          (function {nlocal = 0} prim[int32] prim[int32] stub : int
             (Int32.!= prim prim))
-          (function {nlocal = 0} prim[int32] prim[int32] stub
+          (function {nlocal = 0} prim[int32] prim[int32] stub : int
             (Int32.< prim prim))
-          (function {nlocal = 0} prim[int32] prim[int32] stub
+          (function {nlocal = 0} prim[int32] prim[int32] stub : int
             (Int32.> prim prim))
-          (function {nlocal = 0} prim[int32] prim[int32] stub
+          (function {nlocal = 0} prim[int32] prim[int32] stub : int
             (Int32.<= prim prim))
-          (function {nlocal = 0} prim[int32] prim[int32] stub
+          (function {nlocal = 0} prim[int32] prim[int32] stub : int
             (Int32.>= prim prim))))
       (module-defn(M_int64) Module_coercion module_coercion.ml(50):1734-1777
         (makeblock 0
-          (function {nlocal = 0} prim[addrarray] stub
+          (function {nlocal = 0} prim[addrarray] stub : int
             (array.length[addr] prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] stub : int64
             (array.get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] stub : int64
             (array.unsafe_get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub : int
             (array.set[addr] prim prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub : int
             (array.unsafe_set[addr] prim prim prim))
-          (function {nlocal = 0} prim[int64] prim[int64] stub
+          (function {nlocal = 0} prim[int64] prim[int64] stub : int
             (compare_bints int64 prim prim))
-          (function {nlocal = 0} prim[int64] prim[int64] stub
+          (function {nlocal = 0} prim[int64] prim[int64] stub : int
             (Int64.== prim prim))
-          (function {nlocal = 0} prim[int64] prim[int64] stub
+          (function {nlocal = 0} prim[int64] prim[int64] stub : int
             (Int64.!= prim prim))
-          (function {nlocal = 0} prim[int64] prim[int64] stub
+          (function {nlocal = 0} prim[int64] prim[int64] stub : int
             (Int64.< prim prim))
-          (function {nlocal = 0} prim[int64] prim[int64] stub
+          (function {nlocal = 0} prim[int64] prim[int64] stub : int
             (Int64.> prim prim))
-          (function {nlocal = 0} prim[int64] prim[int64] stub
+          (function {nlocal = 0} prim[int64] prim[int64] stub : int
             (Int64.<= prim prim))
-          (function {nlocal = 0} prim[int64] prim[int64] stub
+          (function {nlocal = 0} prim[int64] prim[int64] stub : int
             (Int64.>= prim prim))))
       (module-defn(M_nativeint) Module_coercion module_coercion.ml(51):1780-1831
         (makeblock 0
-          (function {nlocal = 0} prim[addrarray] stub
+          (function {nlocal = 0} prim[addrarray] stub : int
             (array.length[addr] prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] stub : nativeint
             (array.get[addr] prim prim))
-          (function {nlocal = 0} prim[addrarray] prim[int] stub
+          (function {nlocal = 0} prim[addrarray] prim[int] stub : nativeint
             (array.unsafe_get[addr] prim prim))
           (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint]
-            stub (array.set[addr] prim prim prim))
+            stub : int (array.set[addr] prim prim prim))
           (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint]
-            stub (array.unsafe_set[addr] prim prim prim))
-          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+            stub : int (array.unsafe_set[addr] prim prim prim))
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
             (compare_bints nativeint prim prim))
-          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
             (Nativeint.== prim prim))
-          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
             (Nativeint.!= prim prim))
-          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
             (Nativeint.< prim prim))
-          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
             (Nativeint.> prim prim))
-          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
             (Nativeint.<= prim prim))
-          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
+          (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
             (Nativeint.>= prim prim)))))))

--- a/ocaml/toplevel/native/topeval.ml
+++ b/ocaml/toplevel/native/topeval.ml
@@ -62,7 +62,7 @@ let close_phrase lam =
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in
-    Llet(Strict, Lambda.layout_top, id, glob, l)
+    Llet(Strict, Lambda.layout_module_field, id, glob, l)
   ) (free_variables lam) lam
 
 let toplevel_value id =

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -416,7 +416,7 @@ let class_expr sub {cl_desc; cl_env; _} =
       sub.class_expr sub cl;
       List.iter (function
         | (_, Arg exp) -> sub.expr sub exp
-        | (_, Omitted _) -> ())
+        | (_, Omitted o) -> sub.env sub o.ty_env)
         args
   | Tcl_let (rec_flag, value_bindings, ivars, cl) ->
       sub.value_bindings sub (rec_flag, value_bindings);

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -307,7 +307,9 @@ let expr sub x =
           sub.expr sub exp,
           List.map (function
             | (lbl, Arg exp) -> (lbl, Arg (sub.expr sub exp))
-            | (lbl, Omitted o) -> (lbl, Omitted o))
+            | (lbl, Omitted o) ->
+                let o' = { o with ty_env = sub.env sub o.ty_env } in
+                (lbl, Omitted o'))
             list,
           pos, am
         )

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1290,7 +1290,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                       let mode_closure = Alloc_mode.global in
                       let mode_arg = Alloc_mode.global in
                       let mode_ret = Alloc_mode.global in
-                      Omitted { mode_closure; mode_arg; mode_ret }
+                      Omitted { mode_closure; mode_arg; mode_ret; ty_arg = ty; ty_env = val_env }
                     end
             in
             let omitted =

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -3019,7 +3019,7 @@ let type_omitted_parameters expected_mode env ty_ret mode_ret args =
              let open_args = [] in
              let mode_closure = Alloc_mode.join (mode_fun :: closed_args) in
              register_allocation_mode mode_closure;
-             let arg = Omitted { mode_closure; mode_arg; mode_ret } in
+             let arg = Omitted { mode_closure; mode_arg; mode_ret; ty_arg; ty_env = env } in
              let args = (lbl, arg) :: args in
              (ty_ret, mode_closure, open_args, closed_args, args))
       (ty_ret, mode_ret, [], [], []) (List.rev args)

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -239,7 +239,9 @@ and ('a, 'b) arg_or_omitted =
 and omitted_parameter =
   { mode_closure : alloc_mode;
     mode_arg : alloc_mode;
-    mode_ret : alloc_mode }
+    mode_ret : alloc_mode;
+    ty_arg : Types.type_expr;
+    ty_env : Env.t }
 
 and apply_arg = (expression, omitted_parameter) arg_or_omitted
 

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -404,6 +404,8 @@ and omitted_parameter =
   { mode_closure : Types.alloc_mode;
     mode_arg : Types.alloc_mode;
     mode_ret : Types.alloc_mode;
+    (* CR ncourant: actually, we only need this to be able to compute the layout
+       in [Translcore], change this when merging with the front-end. *)
     ty_arg : Types.type_expr;
     ty_env : Env.t}
 

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -403,7 +403,9 @@ and ('a, 'b) arg_or_omitted =
 and omitted_parameter =
   { mode_closure : Types.alloc_mode;
     mode_arg : Types.alloc_mode;
-    mode_ret : Types.alloc_mode }
+    mode_ret : Types.alloc_mode;
+    ty_arg : Types.type_expr;
+    ty_env : Env.t}
 
 and apply_arg = (expression, omitted_parameter) arg_or_omitted
 


### PR DESCRIPTION
This removes _almost_ all remaining `layout_top` which remain after #1084. There are still two places where `layout_top` remains:

- In dissect-let-rec, when the letrec contains a region, we need the layout of the body of the letrec. Unfortunately, there is no easy way to compute this. However, @lthls and @chambart want to rewrite the region handling of dissect-let-rec anyway, so we will see after those changes.
- In the construction of probes in translcore, we need to transform the free variables of the generated lambda code into function arguments, thus needing their kinds. At this point, it is not obvious how we could compute the kinds however, since we do not dispose of a mapping of lambda variables to their kinds.