### PR TITLE
Add arities on Apply_expr

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -903,7 +903,7 @@ let call_kinds env (call_kind1 : Call_kind.t) (call_kind2 : Call_kind.t) :
   match call_kind1, call_kind2 with
   | ( Function { function_call = Direct code_id1; _ },
       Function { function_call = Direct code_id2; _ } ) ->
-    if Code_id.equal code_id1 code_id2
+    if code_ids env code_id1 code_id2 |> Comparison.is_equivalent
     then Equivalent
     else Different { approximant = call_kind1 }
   | ( Function { function_call = Indirect_known_arity; _ },

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2046,7 +2046,6 @@ let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
         ~missing_arity ~arity ~num_trailing_local_params
         ~contains_no_escaping_local_allocs
     | Over_app { full; remaining; remaining_arity } ->
-      (* XXX *)
       let full_args_call apply_continuation ~region acc =
         let mode =
           if contains_no_escaping_local_allocs
@@ -2054,7 +2053,14 @@ let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
           else Lambda.alloc_local
         in
         close_exact_or_unknown_apply acc env
-          { apply with args = full; continuation = apply_continuation; mode }
+          { apply with
+            args = full;
+            continuation = apply_continuation;
+            mode;
+            return_arity =
+              Flambda_arity.With_subkinds.create
+                [Flambda_kind.With_subkind.any_value]
+          }
           (Some approx) ~replace_region:(Some region)
       in
       wrap_over_application acc env full_args_call apply ~remaining

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -64,7 +64,7 @@ module IR = struct
       probe : Lambda.probe;
       mode : Lambda.alloc_mode;
       region : Ident.t;
-      return : Flambda_kind.With_subkind.t
+      return_arity : Flambda_arity.With_subkinds.t
     }
 
   type switch =
@@ -616,7 +616,7 @@ module Function_decls = struct
         function_slot : Function_slot.t;
         kind : Lambda.function_kind;
         params : (Ident.t * Flambda_kind.With_subkind.t) list;
-        return : Flambda_kind.With_subkind.t;
+        return : Flambda_arity.With_subkinds.t;
         return_continuation : Continuation.t;
         exn_continuation : IR.exn_continuation;
         my_region : Ident.t;
@@ -797,9 +797,8 @@ module Expr_with_acc = struct
         match Apply.call_kind apply with
         | Function { function_call = Direct _; _ } -> true
         | Function
-            { function_call = Indirect_unknown_arity | Indirect_known_arity _;
-              _
-            } ->
+            { function_call = Indirect_unknown_arity | Indirect_known_arity; _ }
+          ->
           false
         | Method _ -> false
         | C_call _ -> false)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -68,7 +68,7 @@ module IR : sig
       probe : Lambda.probe;
       mode : Lambda.alloc_mode;
       region : Ident.t;
-      return : Flambda_kind.With_subkind.t
+      return_arity : Flambda_arity.With_subkinds.t
     }
 
   type switch =
@@ -292,7 +292,7 @@ module Function_decls : sig
       function_slot:Function_slot.t ->
       kind:Lambda.function_kind ->
       params:(Ident.t * Flambda_kind.With_subkind.t) list ->
-      return:Flambda_kind.With_subkind.t ->
+      return:Flambda_arity.With_subkinds.t ->
       return_continuation:Continuation.t ->
       exn_continuation:IR.exn_continuation ->
       my_region:Ident.t ->
@@ -314,7 +314,7 @@ module Function_decls : sig
 
     val params : t -> (Ident.t * Flambda_kind.With_subkind.t) list
 
-    val return : t -> Flambda_kind.With_subkind.t
+    val return : t -> Flambda_arity.With_subkinds.t
 
     val return_continuation : t -> Continuation.t
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1308,8 +1308,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                         region = Env.current_region env;
                         return_arity =
                           Flambda_arity.With_subkinds.create
-                            [ Flambda_kind.With_subkind.from_lambda
-                                Lambda.layout_top ]
+                            [Flambda_kind.With_subkind.from_lambda layout]
                       }
                     in
                     wrap_return_continuation acc env ccenv apply))

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -858,8 +858,19 @@ let wrap_return_continuation acc env ccenv (apply : IR.apply) =
         CC.close_apply acc ccenv
           { apply with continuation = wrapper_cont; region }
       in
+      let return_arity =
+        match Flambda_arity.With_subkinds.to_list apply.return_arity with
+        | [return_kind] -> return_kind
+        | _ :: _ ->
+          Misc.fatal_errorf
+            "Multiple return values for application of %a not supported yet"
+            Ident.print apply.func
+        | [] ->
+          Misc.fatal_errorf "Nullary return arity for application of %a"
+            Ident.print apply.func
+      in
       CC.close_let_cont acc ccenv ~name:wrapper_cont ~is_exn_handler:false
-        ~params:[return_value, Not_user_visible, apply.return]
+        ~params:[return_value, Not_user_visible, return_arity]
         ~recursive:Nonrecursive ~body ~handler
   in
   restore_continuation_context acc env ccenv apply.continuation ~close_early
@@ -1295,9 +1306,10 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                         probe = None;
                         mode;
                         region = Env.current_region env;
-                        return =
-                          Flambda_kind.With_subkind.from_lambda
-                            Lambda.layout_top
+                        return_arity =
+                          Flambda_arity.With_subkinds.create
+                            [ Flambda_kind.With_subkind.from_lambda
+                                Lambda.layout_top ]
                       }
                     in
                     wrap_return_continuation acc env ccenv apply))
@@ -1497,7 +1509,9 @@ and cps_tail_apply acc env ccenv ap_func ap_args ap_region_close ap_mode ap_loc
               probe = ap_probe;
               mode = ap_mode;
               region = Env.current_region env;
-              return = Flambda_kind.With_subkind.from_lambda ap_return
+              return_arity =
+                Flambda_arity.With_subkinds.create
+                  [Flambda_kind.With_subkind.from_lambda ap_return]
             }
           in
           wrap_return_continuation acc env ccenv apply)
@@ -1632,7 +1646,10 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
       (fun (param, kind) -> param, Flambda_kind.With_subkind.from_lambda kind)
       params
   in
-  let return = Flambda_kind.With_subkind.from_lambda return in
+  let return =
+    Flambda_arity.With_subkinds.create
+      [Flambda_kind.With_subkind.from_lambda return]
+  in
   Function_decl.create ~let_rec_ident:(Some fid) ~function_slot ~kind ~params
     ~return ~return_continuation:body_cont ~exn_continuation ~my_region ~body
     ~attr ~loc ~free_idents_of_body recursive ~closure_alloc_mode:mode

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -868,7 +868,8 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         let params_arity =
           (* CR mshinwell: This needs fixing to cope with the fact that the
              arities have moved onto [Apply_expr] *)
-          Flambda_arity.With_subkinds.create []
+          Flambda_arity.With_subkinds.create
+            (List.map (fun _ -> Flambda_kind.With_subkind.any_value) args)
         in
         let return_arity =
           match arities with
@@ -893,7 +894,8 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           let params_arity =
             (* CR mshinwell: This needs fixing to cope with the fact that the
                arities have moved onto [Apply_expr] *)
-            Flambda_arity.With_subkinds.create []
+            Flambda_arity.With_subkinds.create
+              (List.map (fun _ -> Flambda_kind.With_subkind.any_value) args)
           in
           let return_arity =
             (* CR mshinwell: This needs fixing to cope with the fact that the

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -56,7 +56,7 @@ let record_free_names_of_apply_as_used dacc ~use_id ~exn_cont_use_id apply =
   DA.map_flow_acc dacc
     ~f:(record_free_names_of_apply_as_used0 ~use_id ~exn_cont_use_id apply)
 
-let simplify_direct_tuple_application ~simplify_expr dacc apply ~result_arity
+let simplify_direct_tuple_application ~simplify_expr dacc apply
     ~apply_alloc_mode ~current_region ~callee's_code_id ~callee's_code_metadata
     ~down_to_up =
   let dbg = Apply.dbg apply in
@@ -70,6 +70,9 @@ let simplify_direct_tuple_application ~simplify_expr dacc apply ~result_arity
     | tuple :: others -> tuple, others
     | _ -> Misc.fatal_errorf "Empty argument list for direct application"
   in
+  let over_application_arity =
+    List.tl (Flambda_arity.With_subkinds.to_list (Apply.args_arity apply))
+  in
   (* Create the list of variables and projections *)
   let vars_and_fields =
     List.init n (fun i ->
@@ -79,9 +82,17 @@ let simplify_direct_tuple_application ~simplify_expr dacc apply ~result_arity
   in
   (* Change the application to operate on the fields of the tuple *)
   let apply =
+    let args_arity =
+      (* The components of the tuple must always be of kind [Value] (in Lambda,
+         [layout_field]). *)
+      Flambda_arity.With_subkinds.create
+        (List.init n (fun _ -> K.With_subkind.any_value)
+        @ over_application_arity)
+    in
     Apply.with_args apply
       (List.map (fun (v, _) -> Simple.var v) vars_and_fields
       @ over_application_args)
+      ~args_arity
   in
   (* Immediately simplify over_applications to avoid having direct applications
      with the wrong arity. *)
@@ -92,9 +103,8 @@ let simplify_direct_tuple_application ~simplify_expr dacc apply ~result_arity
       (* [apply] already got a correct relative_history and
          [split_direct_over_application] infers the relative history from the
          one on [apply] so there's nothing to do here. *)
-      Simplify_common.split_direct_over_application apply ~result_arity
-        ~apply_alloc_mode ~current_region ~callee's_code_id
-        ~callee's_code_metadata
+      Simplify_common.split_direct_over_application apply ~apply_alloc_mode
+        ~current_region ~callee's_code_id ~callee's_code_metadata
   in
   (* Insert the projections and simplify the new expression, to allow field
      projections to be simplified, and over-application/full_application
@@ -438,8 +448,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
       |> Bound_parameters.create
     in
     let call_kind =
-      Call_kind.direct_function_call callee's_code_id ~return_arity:result_arity
-        apply_alloc_mode
+      Call_kind.direct_function_call callee's_code_id apply_alloc_mode
     in
     let open struct
       (* An argument or the callee, with information about its entry in the
@@ -512,7 +521,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
       in
       let full_application =
         Apply.create ~callee ~continuation:(Return return_continuation)
-          exn_continuation ~args ~call_kind dbg ~inlined:Default_inlined
+          exn_continuation ~args ~args_arity:param_arity
+          ~return_arity:result_arity ~call_kind dbg ~inlined:Default_inlined
           ~inlining_state:(Apply.inlining_state apply)
           ~position:Normal ~probe_name:None
           ~relative_history:Inlining_history.Relative.empty ~region:my_region
@@ -656,14 +666,13 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
   in
   simplify_expr dacc expr ~down_to_up
 
-let simplify_direct_over_application ~simplify_expr dacc apply ~result_arity
-    ~down_to_up ~coming_from_indirect ~apply_alloc_mode ~current_region
-    ~callee's_code_id ~callee's_code_metadata =
+let simplify_direct_over_application ~simplify_expr dacc apply ~down_to_up
+    ~coming_from_indirect ~apply_alloc_mode ~current_region ~callee's_code_id
+    ~callee's_code_metadata =
   fail_if_probe apply;
   let expr =
-    Simplify_common.split_direct_over_application apply ~result_arity
-      ~apply_alloc_mode ~current_region ~callee's_code_id
-      ~callee's_code_metadata
+    Simplify_common.split_direct_over_application apply ~apply_alloc_mode
+      ~current_region ~callee's_code_id ~callee's_code_metadata
   in
   let down_to_up dacc ~rebuild =
     let rebuild uacc ~after_rebuild =
@@ -685,7 +694,7 @@ let simplify_direct_over_application ~simplify_expr dacc apply ~result_arity
 
 let simplify_direct_function_call ~simplify_expr dacc apply
     ~callee's_code_id_from_type ~callee's_code_id_from_call_kind
-    ~callee's_function_slot ~result_arity ~result_types ~recursive ~arg_types:_
+    ~callee's_function_slot ~result_arity ~result_types ~recursive
     ~must_be_detupled ~closure_alloc_mode_from_type ~apply_alloc_mode
     ~current_region function_decl ~down_to_up =
   (match Apply.probe_name apply, Apply.inlined apply with
@@ -695,12 +704,11 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       "[Apply] terms with a [probe_name] (i.e. that call a tracing probe) must \
        always be marked as [Never_inline]:@ %a"
       Apply.print apply);
-  let result_arity_of_application =
-    Call_kind.return_arity (Apply.call_kind apply)
-  in
+  let result_arity_of_application = Apply.return_arity apply in
   if not
-       (Flambda_arity.With_subkinds.compatible result_arity
-          ~when_used_at:result_arity_of_application)
+       (Flambda_arity.equal
+          (Flambda_arity.With_subkinds.to_arity result_arity)
+          (Flambda_arity.With_subkinds.to_arity result_arity_of_application))
   then
     Misc.fatal_errorf
       "Wrong return arity for direct OCaml function call (expected %a, found \
@@ -726,8 +734,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
         EB.rebuild_invalid uacc (Closure_type_was_invalid apply) ~after_rebuild)
   | Ok callee's_code_id ->
     let call_kind =
-      Call_kind.direct_function_call callee's_code_id ~return_arity:result_arity
-        apply_alloc_mode
+      Call_kind.direct_function_call callee's_code_id apply_alloc_mode
     in
     let apply = Apply.with_call_kind apply call_kind in
     let callee's_code_or_metadata =
@@ -746,7 +753,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
        tuple argument, irrespective of what [Code.params_arity] says. *)
     if must_be_detupled
     then
-      simplify_direct_tuple_application ~simplify_expr dacc apply ~result_arity
+      simplify_direct_tuple_application ~simplify_expr dacc apply
         ~apply_alloc_mode ~current_region ~callee's_code_id
         ~callee's_code_metadata ~down_to_up
     else
@@ -760,8 +767,8 @@ let simplify_direct_function_call ~simplify_expr dacc apply
           ~coming_from_indirect ~callee's_code_metadata
       else if provided_num_args > num_params
       then
-        simplify_direct_over_application ~simplify_expr dacc apply ~result_arity
-          ~down_to_up ~coming_from_indirect ~apply_alloc_mode ~current_region
+        simplify_direct_over_application ~simplify_expr dacc apply ~down_to_up
+          ~coming_from_indirect ~apply_alloc_mode ~current_region
           ~callee's_code_id ~callee's_code_metadata
       else if provided_num_args > 0 && provided_num_args < num_params
       then
@@ -784,15 +791,12 @@ let rebuild_function_call_where_callee's_type_unavailable apply call_kind
     |> Simplify_common.update_exn_continuation_extra_args uacc ~exn_cont_use_id
   in
   let uacc, expr =
-    EB.rewrite_fixed_arity_apply uacc ~use_id
-      (Call_kind.return_arity call_kind)
-      apply
+    EB.rewrite_fixed_arity_apply uacc ~use_id (Apply.return_arity apply) apply
   in
   after_rebuild expr uacc
 
 let simplify_function_call_where_callee's_type_unavailable dacc apply
-    (call : Call_kind.Function_call.t) ~apply_alloc_mode ~args:_ ~arg_types
-    ~down_to_up =
+    (call : Call_kind.Function_call.t) ~apply_alloc_mode ~down_to_up =
   fail_if_probe apply;
   let cont =
     match Apply.continuation apply with
@@ -817,55 +821,24 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
         (T.unknown_types_from_arity_with_subkinds
            (Exn_continuation.arity (Apply.exn_continuation apply)))
   in
-  let record_return_cont_use ~return_arity =
+  let dacc, use_id =
     DA.record_continuation_use dacc cont
       (Non_inlinable { escaping = true })
       ~env_at_use
-      ~arg_types:(T.unknown_types_from_arity_with_subkinds return_arity)
+      ~arg_types:
+        (T.unknown_types_from_arity_with_subkinds (Apply.return_arity apply))
   in
-  let call_kind, use_id, dacc =
+  let call_kind =
     match call with
     | Indirect_unknown_arity ->
-      let dacc, use_id =
-        DA.record_continuation_use dacc cont
-          (Non_inlinable { escaping = true })
-          ~env_at_use ~arg_types:[T.any_value]
-      in
-      ( Call_kind.indirect_function_call_unknown_arity apply_alloc_mode,
-        use_id,
-        dacc )
-    | Indirect_known_arity { param_arity; return_arity } ->
-      let args_arity =
-        T.arity_of_list arg_types |> Flambda_arity.With_subkinds.of_arity
-      in
-      if not
-           (Flambda_arity.With_subkinds.compatible args_arity
-              ~when_used_at:param_arity)
-      then
-        Misc.fatal_errorf
-          "Argument arity on indirect-known-arity application doesn't match \
-           [Call_kind] (expected %a, found %a):@ %a"
-          Flambda_arity.With_subkinds.print param_arity
-          Flambda_arity.With_subkinds.print args_arity Apply.print apply;
-      let dacc, use_id = record_return_cont_use ~return_arity in
-      let call_kind =
-        Call_kind.indirect_function_call_known_arity ~param_arity ~return_arity
-          apply_alloc_mode
-      in
-      call_kind, use_id, dacc
-    | Direct { return_arity; _ } ->
-      let param_arity =
-        T.arity_of_list arg_types |> Flambda_arity.With_subkinds.of_arity
-      in
+      Call_kind.indirect_function_call_unknown_arity apply_alloc_mode
+    | Indirect_known_arity ->
+      Call_kind.indirect_function_call_known_arity apply_alloc_mode
+    | Direct _code_id ->
       (* Some types have regressed in precision. Since this used to be a direct
          call, however, we know the function's arity even though we don't know
          which function it is. *)
-      let dacc, use_id = record_return_cont_use ~return_arity in
-      let call_kind =
-        Call_kind.indirect_function_call_known_arity ~param_arity ~return_arity
-          apply_alloc_mode
-      in
-      call_kind, use_id, dacc
+      Call_kind.indirect_function_call_known_arity apply_alloc_mode
   in
   let dacc =
     record_free_names_of_apply_as_used ~use_id:(Some use_id) ~exn_cont_use_id
@@ -877,9 +850,7 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
          ~use_id ~exn_cont_use_id)
 
 let simplify_function_call ~simplify_expr dacc apply ~callee_ty
-    (call : Call_kind.Function_call.t) ~apply_alloc_mode ~arg_types ~down_to_up
-    =
-  let args = Apply.args apply in
+    (call : Call_kind.Function_call.t) ~apply_alloc_mode ~down_to_up =
   (* Function declarations and params and body might not have the same calling
      convention. Currently the only case when it happens is for tupled
      functions. For such functions, the function_declaration declares a
@@ -894,7 +865,7 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
      call in order to correctly adapt to the change in calling convention. *)
   let call_must_be_detupled is_function_decl_tupled =
     match call with
-    | Direct _ | Indirect_known_arity _ ->
+    | Direct _ | Indirect_known_arity ->
       (* In these cases, the calling convention already used in the application
          being simplified is that of the code actually called. Thus we must not
          detuple the function. *)
@@ -911,7 +882,7 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
         "[@inlined] attribute was not used on this function application (the \
          optimizer did not know what function was being applied)";
     simplify_function_call_where_callee's_type_unavailable dacc apply call
-      ~apply_alloc_mode ~args ~arg_types ~down_to_up
+      ~apply_alloc_mode ~down_to_up
   in
   (* CR-someday mshinwell: Should this be using [meet_shape], like for
      primitives? *)
@@ -924,8 +895,8 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
         func_decl_type ) ->
     let callee's_code_id_from_call_kind =
       match call with
-      | Direct { code_id; _ } -> Some code_id
-      | Indirect_unknown_arity | Indirect_known_arity _ -> None
+      | Direct code_id -> Some code_id
+      | Indirect_unknown_arity | Indirect_known_arity -> None
     in
     let callee's_code_id_from_type = T.Function_type.code_id func_decl_type in
     let callee's_code_or_metadata =
@@ -940,7 +911,7 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
     let current_region = Apply.region apply in
     simplify_direct_function_call ~simplify_expr dacc apply
       ~callee's_code_id_from_type ~callee's_code_id_from_call_kind
-      ~callee's_function_slot ~arg_types
+      ~callee's_function_slot
       ~result_arity:(Code_metadata.result_arity callee's_code_metadata)
       ~result_types:(Code_metadata.result_types callee's_code_metadata)
       ~recursive:(Code_metadata.recursive callee's_code_metadata)
@@ -962,6 +933,17 @@ let simplify_apply_shared dacc apply =
   let { S.simples = args; simple_tys = arg_types } =
     S.simplify_simples dacc (Apply.args apply)
   in
+  List.iter2
+    (fun kind_with_subkind arg_type ->
+      let kind = K.With_subkind.kind kind_with_subkind in
+      if not (K.equal kind (T.kind arg_type))
+      then
+        Misc.fatal_errorf
+          "Argument kind %a from arity does not match kind from type %a for \
+           application:@ %a"
+          K.print kind T.print arg_type Apply.print apply)
+    (Flambda_arity.With_subkinds.to_list (Apply.args_arity apply))
+    arg_types;
   let inlining_state =
     Inlining_state.meet
       (DE.get_inlining_state (DA.denv dacc))
@@ -971,7 +953,9 @@ let simplify_apply_shared dacc apply =
     Apply.create ~callee:simplified_callee
       ~continuation:(Apply.continuation apply)
       (Apply.exn_continuation apply)
-      ~args ~call_kind:(Apply.call_kind apply)
+      ~args ~args_arity:(Apply.args_arity apply)
+      ~return_arity:(Apply.return_arity apply)
+      ~call_kind:(Apply.call_kind apply)
       (DE.add_inlined_debuginfo (DA.denv dacc) (Apply.dbg apply))
       ~inlined:(Apply.inlined apply) ~inlining_state
       ~probe_name:(Apply.probe_name apply) ~position:(Apply.position apply)
@@ -1061,25 +1045,30 @@ let rebuild_c_call apply ~use_id ~exn_cont_use_id ~return_arity uacc
   in
   after_rebuild expr uacc
 
-let simplify_c_call ~simplify_expr dacc apply ~callee_ty ~param_arity
-    ~return_arity ~arg_types ~down_to_up =
+let simplify_c_call ~simplify_expr dacc apply ~callee_ty ~arg_types ~down_to_up
+    =
   fail_if_probe apply;
+  let args_arity =
+    Apply.args_arity apply |> Flambda_arity.With_subkinds.to_arity
+  in
+  let return_arity =
+    Apply.return_arity apply |> Flambda_arity.With_subkinds.to_arity
+  in
   let callee_kind = T.kind callee_ty in
   if not (K.is_value callee_kind)
   then
     Misc.fatal_errorf "C callees must be of kind [Value], not %a: %a" K.print
       callee_kind T.print callee_ty;
-  let args_arity = T.arity_of_list arg_types in
-  if not (Flambda_arity.equal args_arity param_arity)
+  let args_arity_from_types = T.arity_of_list arg_types in
+  if not (Flambda_arity.equal args_arity_from_types args_arity)
   then
     Misc.fatal_errorf
       "Arity %a of [Apply] arguments doesn't match parameter arity %a of C \
        callee:@ %a"
-      Flambda_arity.print args_arity Flambda_arity.print param_arity Apply.print
+      Flambda_arity.print args_arity Flambda_arity.print args_arity Apply.print
       apply;
   let simplified =
-    Simplify_extcall.simplify_extcall dacc apply ~callee_ty ~param_arity
-      ~return_arity ~arg_types
+    Simplify_extcall.simplify_extcall dacc apply ~callee_ty ~arg_types
   in
   match simplified with
   | Specialised (dacc, expr, operation) ->
@@ -1137,9 +1126,8 @@ let simplify_apply ~simplify_expr dacc apply ~down_to_up =
   match Apply.call_kind apply with
   | Function { function_call; alloc_mode = apply_alloc_mode } ->
     simplify_function_call ~simplify_expr dacc apply ~callee_ty function_call
-      ~apply_alloc_mode ~arg_types ~down_to_up
+      ~apply_alloc_mode ~down_to_up
   | Method { kind; obj; alloc_mode = _ } ->
     simplify_method_call dacc apply ~callee_ty ~kind ~obj ~arg_types ~down_to_up
-  | C_call { alloc = _; param_arity; return_arity; is_c_builtin = _ } ->
-    simplify_c_call ~simplify_expr dacc apply ~callee_ty ~param_arity
-      ~return_arity ~arg_types ~down_to_up
+  | C_call { alloc = _; is_c_builtin = _ } ->
+    simplify_c_call ~simplify_expr dacc apply ~callee_ty ~arg_types ~down_to_up

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -90,16 +90,21 @@ let project_tuple ~dbg ~size ~field tuple =
   let prim = P.Binary (Block_load (bak, mutability), tuple, index) in
   Named.create_prim prim dbg
 
-let split_direct_over_application apply ~result_arity
+let split_direct_over_application apply
     ~(apply_alloc_mode : Alloc_mode.For_types.t) ~current_region
     ~callee's_code_id ~callee's_code_metadata =
-  let arity =
-    Flambda_arity.With_subkinds.cardinal
-      (Code_metadata.params_arity callee's_code_metadata)
+  let callee's_params_arity =
+    Code_metadata.params_arity callee's_code_metadata
   in
+  let arity = Flambda_arity.With_subkinds.cardinal callee's_params_arity in
   let args = Apply.args apply in
   assert (arity < List.length args);
   let first_args, remaining_args = Misc.Stdlib.List.split_at arity args in
+  let _, remaining_arity =
+    Misc.Stdlib.List.split_at arity
+      (Apply.args_arity apply |> Flambda_arity.With_subkinds.to_list)
+  in
+  assert (List.compare_lengths remaining_args remaining_arity = 0);
   let func_var = Variable.create "full_apply" in
   let contains_no_escaping_local_allocs =
     Code_metadata.contains_no_escaping_local_allocs callee's_code_metadata
@@ -137,6 +142,8 @@ let split_direct_over_application apply ~result_arity
     Apply.create ~callee:(Simple.var func_var) ~continuation
       (Apply.exn_continuation apply)
       ~args:remaining_args
+      ~args_arity:(Flambda_arity.With_subkinds.create remaining_arity)
+      ~return_arity:(Apply.return_arity apply)
       ~call_kind:
         (Call_kind.indirect_function_call_unknown_arity apply_alloc_mode)
       (Apply.dbg apply) ~inlined:(Apply.inlined apply)
@@ -163,7 +170,7 @@ let split_direct_over_application apply ~result_arity
         List.mapi
           (fun i kind ->
             BP.create (Variable.create ("result" ^ string_of_int i)) kind)
-          (Flambda_arity.With_subkinds.to_list result_arity)
+          (Flambda_arity.With_subkinds.to_list (Apply.return_arity apply))
       in
       let call_return_continuation, call_return_continuation_free_names =
         match Apply.continuation apply with
@@ -223,11 +230,9 @@ let split_direct_over_application apply ~result_arity
     Apply.create ~callee:(Apply.callee apply)
       ~continuation:(Return after_full_application)
       (Apply.exn_continuation apply)
-      ~args:first_args
-      ~call_kind:
-        (Call_kind.direct_function_call callee's_code_id
-           ~return_arity:(Code_metadata.result_arity callee's_code_metadata)
-           alloc_mode)
+      ~args:first_args ~args_arity:callee's_params_arity
+      ~return_arity:(Code_metadata.result_arity callee's_code_metadata)
+      ~call_kind:(Call_kind.direct_function_call callee's_code_id alloc_mode)
       (Apply.dbg apply) ~inlined:(Apply.inlined apply)
       ~inlining_state:(Apply.inlining_state apply)
       ~probe_name:(Apply.probe_name apply) ~position:(Apply.position apply)

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -115,7 +115,6 @@ val project_tuple :
     application of the leftover arguments. *)
 val split_direct_over_application :
   Apply_expr.t ->
-  result_arity:Flambda_arity.With_subkinds.t ->
   apply_alloc_mode:Alloc_mode.For_types.t ->
   current_region:Variable.t ->
   callee's_code_id:Code_id.t ->

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -194,8 +194,7 @@ let simplify_returning_extcall ~dbg ~cont ~exn_cont:_ dacc fun_name args
 (* Exported simplification function *)
 (* ******************************** *)
 
-let simplify_extcall dacc apply ~callee_ty:_ ~param_arity:_ ~return_arity:_
-    ~arg_types =
+let simplify_extcall dacc apply ~callee_ty:_ ~arg_types =
   let dbg = Apply.dbg apply in
   let args = Apply.args apply in
   let exn_cont = Apply.exn_continuation apply in

--- a/middle_end/flambda2/simplify/simplify_extcall.mli
+++ b/middle_end/flambda2/simplify/simplify_extcall.mli
@@ -24,7 +24,5 @@ val simplify_extcall :
   Downwards_acc.t ->
   Flambda.Apply.t ->
   callee_ty:Flambda2_types.t ->
-  param_arity:Flambda_arity.t ->
-  return_arity:Flambda_arity.t ->
   arg_types:Flambda2_types.t list ->
   t

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -73,6 +73,8 @@ type t =
     continuation : Result_continuation.t;
     exn_continuation : Exn_continuation.t;
     args : Simple.t list;
+    args_arity : Flambda_arity.With_subkinds.t;
+    return_arity : Flambda_arity.With_subkinds.t;
     call_kind : Call_kind.t;
     dbg : Debuginfo.t;
     inlined : Inlined_attribute.t;
@@ -89,12 +91,15 @@ let [@ocamlformat "disable"] print_inlining_paths ppf relative_history =
       Inlining_history.Relative.print relative_history
 
 let [@ocamlformat "disable"] print ppf
-    { callee; continuation; exn_continuation; args; call_kind;
-      dbg; inlined; inlining_state; probe_name; position; relative_history; region } =
+    { callee; continuation; exn_continuation; args; args_arity;
+      return_arity; call_kind; dbg; inlined; inlining_state; probe_name;
+      position; relative_history; region } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(%a\u{3008}%a\u{3009}\u{300a}%a\u{300b}\
       \u{27c5}%t%a%t\u{27c6}@ \
       (%a))@]@ \
+      @[<hov 1>(args_arity@ %a)@]@ \
+      @[<hov 1>(return_arity@ %a)@]@ \
       @[<hov 1>(call_kind@ %a)@]@ \
       @[<hov 1>%t(dbg@ %a)%t@]@ \
       @[<hov 1>(inline@ %a)@]@ \
@@ -110,6 +115,8 @@ let [@ocamlformat "disable"] print ppf
     Variable.print region
     Flambda_colours.pop
     Simple.List.print args
+    Flambda_arity.With_subkinds.print args_arity
+    Flambda_arity.With_subkinds.print return_arity
     Call_kind.print call_kind
     Flambda_colours.debuginfo
     Debuginfo.print_compact dbg
@@ -132,7 +139,9 @@ let invariant
     ({ callee;
        continuation;
        exn_continuation = _;
-       args = _;
+       args;
+       args_arity;
+       return_arity;
        call_kind;
        dbg = _;
        inlined = _;
@@ -144,7 +153,7 @@ let invariant
      } as t) =
   (match call_kind with
   | Function _ | Method _ -> ()
-  | C_call { alloc = _; param_arity = _; return_arity = _; is_c_builtin = _ } ->
+  | C_call _ -> (
     if not (Simple.is_symbol callee)
     then
       (* CR-someday mshinwell: We could expose indirect C calls at the source
@@ -152,10 +161,19 @@ let invariant
       Misc.fatal_errorf
         "For [C_call] applications the callee must be directly specified as a \
          [Symbol]:@ %a"
-        print t);
+        print t;
+    match Flambda_arity.With_subkinds.to_list return_arity with
+    | [] | [_] -> ()
+    | _ :: _ :: _ ->
+      Misc.fatal_errorf "Illegal return arity for C call:@ %a"
+        Flambda_arity.With_subkinds.print return_arity));
+  if List.compare_lengths args (Flambda_arity.With_subkinds.to_list args_arity)
+     <> 0
+  then
+    Misc.fatal_errorf
+      "Length of argument and arity lists disagree in [Apply]:@ %a" print t;
   match continuation with
   | Never_returns ->
-    let return_arity = Call_kind.return_arity call_kind in
     if not (Flambda_arity.With_subkinds.is_nullary return_arity)
     then
       Misc.fatal_errorf
@@ -164,13 +182,16 @@ let invariant
         Flambda_arity.With_subkinds.print return_arity print t
   | Return _ -> ()
 
-let create ~callee ~continuation exn_continuation ~args ~call_kind dbg ~inlined
-    ~inlining_state ~probe_name ~position ~relative_history ~region =
+let create ~callee ~continuation exn_continuation ~args ~args_arity
+    ~return_arity ~(call_kind : Call_kind.t) dbg ~inlined ~inlining_state
+    ~probe_name ~position ~relative_history ~region =
   let t =
     { callee;
       continuation;
       exn_continuation;
       args;
+      args_arity;
+      return_arity;
       call_kind;
       dbg;
       inlined;
@@ -209,6 +230,8 @@ let free_names_without_exn_continuation
       continuation;
       exn_continuation = _;
       args;
+      args_arity = _;
+      return_arity = _;
       call_kind;
       dbg = _;
       inlined = _;
@@ -230,6 +253,8 @@ let free_names_except_callee
       continuation;
       exn_continuation;
       args;
+      args_arity = _;
+      return_arity = _;
       call_kind;
       dbg = _;
       inlined = _;
@@ -256,6 +281,8 @@ let apply_renaming
        continuation;
        exn_continuation;
        args;
+       args_arity;
+       return_arity;
        call_kind;
        dbg;
        inlined;
@@ -285,6 +312,8 @@ let apply_renaming
       continuation = continuation';
       exn_continuation = exn_continuation';
       args = args';
+      args_arity;
+      return_arity;
       call_kind = call_kind';
       dbg;
       inlined;
@@ -300,6 +329,8 @@ let ids_for_export
       continuation;
       exn_continuation;
       args;
+      args_arity = _;
+      return_arity = _;
       call_kind;
       dbg = _;
       inlined = _;
@@ -338,7 +369,7 @@ let with_call_kind t call_kind =
   invariant t;
   t
 
-let with_args t args = { t with args }
+let with_args t args ~args_arity = { t with args; args_arity }
 
 let inlining_arguments t = inlining_state t |> Inlining_state.arguments
 
@@ -348,3 +379,7 @@ let returns t =
   match continuation t with Return _ -> true | Never_returns -> false
 
 let region t = t.region
+
+let args_arity t = t.args_arity
+
+let return_arity t = t.return_arity

--- a/middle_end/flambda2/terms/apply_expr.mli
+++ b/middle_end/flambda2/terms/apply_expr.mli
@@ -51,6 +51,8 @@ val create :
   continuation:Result_continuation.t ->
   Exn_continuation.t ->
   args:Simple.t list ->
+  args_arity:Flambda_arity.With_subkinds.t ->
+  return_arity:Flambda_arity.With_subkinds.t ->
   call_kind:Call_kind.t ->
   Debuginfo.t ->
   inlined:Inlined_attribute.t ->
@@ -73,6 +75,12 @@ val callee : t -> Simple.t
 
 (** The arguments of the function or method being applied. *)
 val args : t -> Simple.t list
+
+(** The arity of the arguments being applied. *)
+val args_arity : t -> Flambda_arity.With_subkinds.t
+
+(** The arity of the result(s) of the application. *)
+val return_arity : t -> Flambda_arity.With_subkinds.t
 
 (** Information about what kind of call is involved (direct function call,
     method call, etc). *)
@@ -102,7 +110,8 @@ val with_continuations : t -> Result_continuation.t -> Exn_continuation.t -> t
 val with_exn_continuation : t -> Exn_continuation.t -> t
 
 (** Change the arguments of an application *)
-val with_args : t -> Simple.t list -> t
+val with_args :
+  t -> Simple.t list -> args_arity:Flambda_arity.With_subkinds.t -> t
 
 (** Change the call kind of an application. *)
 val with_call_kind : t -> Call_kind.t -> t

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -14,46 +14,20 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let check_arity arity =
-  if Flambda_arity.With_subkinds.is_nullary arity
-  then Misc.fatal_error "Invalid nullary arity"
-
 let fprintf = Format.fprintf
 
 module Function_call = struct
   type t =
-    | Direct of
-        { code_id : Code_id.t;
-          return_arity : Flambda_arity.With_subkinds.t
-        }
+    | Direct of Code_id.t
     | Indirect_unknown_arity
-    | Indirect_known_arity of
-        { param_arity : Flambda_arity.With_subkinds.t;
-          return_arity : Flambda_arity.With_subkinds.t
-        }
+    | Indirect_known_arity
 
-  let [@ocamlformat "disable"] print ppf call =
+  let print ppf call =
     match call with
-    | Direct { code_id; return_arity; } ->
-      fprintf ppf "@[<hov 1>(Direct@ \
-          @[<hov 1>(code_id@ %a)@]@ \
-          @[<hov 1>(return_arity@ %a)@]\
-          )@]"
-        Code_id.print code_id
-        Flambda_arity.With_subkinds.print return_arity
-    | Indirect_unknown_arity ->
-      fprintf ppf "Indirect_unknown_arity"
-    | Indirect_known_arity { param_arity; return_arity; } ->
-      fprintf ppf "@[<hov 1>(Indirect_known_arity %a \u{2192} %a)@]"
-        Flambda_arity.With_subkinds.print param_arity
-        Flambda_arity.With_subkinds.print return_arity
-
-  let return_arity call =
-    match call with
-    | Direct { return_arity; _ } | Indirect_known_arity { return_arity; _ } ->
-      return_arity
-    | Indirect_unknown_arity ->
-      Flambda_arity.With_subkinds.create [Flambda_kind.With_subkind.any_value]
+    | Direct code_id ->
+      fprintf ppf "@[<hov 1>(Direct %a)@]" Code_id.print code_id
+    | Indirect_unknown_arity -> fprintf ppf "Indirect_unknown_arity"
+    | Indirect_known_arity -> fprintf ppf "Indirect_known_arity"
 end
 
 module Method_kind = struct
@@ -87,8 +61,6 @@ type t =
       }
   | C_call of
       { alloc : bool;
-        param_arity : Flambda_arity.t;
-        return_arity : Flambda_arity.t;
         is_c_builtin : bool
       }
 
@@ -110,82 +82,47 @@ let [@ocamlformat "disable"] print ppf t =
       Simple.print obj
       Method_kind.print kind
       Alloc_mode.For_types.print alloc_mode
-  | C_call { alloc; param_arity; return_arity; is_c_builtin; } ->
-    fprintf ppf "@[(C@ @[(alloc %b)@]@ @[(is_c_builtin %b)@]@ \
-        %t@<1>\u{2237}%t %a @<1>\u{2192} %a)@]"
+  | C_call { alloc; is_c_builtin; } ->
+    fprintf ppf "@[<hov 1>(C@ \
+        @[<hov 1>(alloc %b)@]@ \
+        @[<hov 1>(is_c_builtin %b)@]\
+        )@]"
       alloc
       is_c_builtin
-      Flambda_colours.elide
-      Flambda_colours.pop
-      Flambda_arity.print param_arity
-      Flambda_arity.print return_arity
 
-let direct_function_call code_id ~return_arity alloc_mode =
-  check_arity return_arity;
-  Function { function_call = Direct { code_id; return_arity }; alloc_mode }
+let direct_function_call code_id alloc_mode =
+  Function { function_call = Direct code_id; alloc_mode }
 
 let indirect_function_call_unknown_arity alloc_mode =
   Function { function_call = Indirect_unknown_arity; alloc_mode }
 
-let indirect_function_call_known_arity ~param_arity ~return_arity alloc_mode =
-  check_arity return_arity;
-  Function
-    { function_call = Indirect_known_arity { param_arity; return_arity };
-      alloc_mode
-    }
+let indirect_function_call_known_arity alloc_mode =
+  Function { function_call = Indirect_known_arity; alloc_mode }
 
 let method_call kind ~obj alloc_mode = Method { kind; obj; alloc_mode }
 
-let c_call ~alloc ~param_arity ~return_arity ~is_c_builtin =
-  (match Flambda_arity.to_list return_arity with
-  | [] | [_] -> ()
-  | _ :: _ :: _ ->
-    Misc.fatal_errorf "Illegal return arity for C call: %a" Flambda_arity.print
-      return_arity);
-  C_call { alloc; param_arity; return_arity; is_c_builtin }
-
-let return_arity t =
-  match t with
-  | Function { function_call; _ } -> Function_call.return_arity function_call
-  | Method _ ->
-    Flambda_arity.With_subkinds.create [Flambda_kind.With_subkind.any_value]
-  | C_call { return_arity; _ } ->
-    Flambda_arity.With_subkinds.of_arity return_arity
+let c_call ~alloc ~is_c_builtin = C_call { alloc; is_c_builtin }
 
 let free_names t =
   match t with
-  | Function
-      { function_call = Direct { code_id; return_arity = _ }; alloc_mode = _ }
-    ->
+  | Function { function_call = Direct code_id; alloc_mode = _ } ->
     Name_occurrences.singleton_code_id code_id Name_mode.normal
   | Function { function_call = Indirect_unknown_arity; alloc_mode = _ }
-  | Function
-      { function_call =
-          Indirect_known_arity { param_arity = _; return_arity = _ };
-        alloc_mode = _
-      }
-  | C_call { alloc = _; param_arity = _; return_arity = _; is_c_builtin = _ } ->
+  | Function { function_call = Indirect_known_arity; alloc_mode = _ }
+  | C_call { alloc = _; is_c_builtin = _ } ->
     Name_occurrences.empty
   | Method { kind = _; obj; alloc_mode = _ } -> Simple.free_names obj
 
 let apply_renaming t renaming =
   match t with
-  | Function { function_call = Direct { code_id; return_arity }; alloc_mode } ->
+  | Function { function_call = Direct code_id; alloc_mode } ->
     let code_id' = Renaming.apply_code_id renaming code_id in
     if code_id == code_id'
     then t
-    else
-      Function
-        { function_call = Direct { code_id = code_id'; return_arity };
-          alloc_mode
-        }
+    else Function { function_call = Direct code_id'; alloc_mode }
   | Function { function_call = Indirect_unknown_arity; alloc_mode = _ }
-  | Function
-      { function_call =
-          Indirect_known_arity { param_arity = _; return_arity = _ };
-        alloc_mode = _
-      }
-  | C_call { alloc = _; param_arity = _; return_arity = _; is_c_builtin = _ } ->
+  | Function { function_call = Indirect_known_arity; alloc_mode = _ }
+  | C_call { alloc = _; is_c_builtin = _ } ->
     t
   | Method { kind; obj; alloc_mode } ->
     let obj' = Simple.apply_renaming obj renaming in
@@ -193,16 +130,10 @@ let apply_renaming t renaming =
 
 let ids_for_export t =
   match t with
-  | Function
-      { function_call = Direct { code_id; return_arity = _ }; alloc_mode = _ }
-    ->
+  | Function { function_call = Direct code_id; alloc_mode = _ } ->
     Ids_for_export.add_code_id Ids_for_export.empty code_id
   | Function { function_call = Indirect_unknown_arity; alloc_mode = _ }
-  | Function
-      { function_call =
-          Indirect_known_arity { param_arity = _; return_arity = _ };
-        alloc_mode = _
-      }
-  | C_call { alloc = _; param_arity = _; return_arity = _; is_c_builtin = _ } ->
+  | Function { function_call = Indirect_known_arity; alloc_mode = _ }
+  | C_call { alloc = _; is_c_builtin = _ } ->
     Ids_for_export.empty
   | Method { kind = _; obj; alloc_mode = _ } -> Ids_for_export.from_simple obj

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -18,20 +18,11 @@
 
 module Function_call : sig
   type t = private
-    | Direct of
-        { code_id : Code_id.t;
-              (** The [code_id] uniquely determines the function symbol that
-                  must be called. *)
-          return_arity : Flambda_arity.With_subkinds.t
-              (** [return_arity] describes what the callee returns. It matches
-                  up with the arity of [continuation] in the enclosing [Apply.t]
-                  record. *)
-        }
+    | Direct of Code_id.t
+        (** The [code_id] uniquely determines the function symbol that
+            must be called. *)
     | Indirect_unknown_arity
-    | Indirect_known_arity of
-        { param_arity : Flambda_arity.With_subkinds.t;
-          return_arity : Flambda_arity.With_subkinds.t
-        }
+    | Indirect_known_arity
 end
 
 module Method_kind : sig
@@ -59,8 +50,6 @@ type t = private
       }
   | C_call of
       { alloc : bool;
-        param_arity : Flambda_arity.t;
-        return_arity : Flambda_arity.t;
         is_c_builtin : bool
             (* CR mshinwell: This should have the effects and coeffects
                fields *)
@@ -70,27 +59,12 @@ include Expr_std.S with type t := t
 
 include Contains_ids.S with type t := t
 
-val direct_function_call :
-  Code_id.t ->
-  return_arity:Flambda_arity.With_subkinds.t ->
-  Alloc_mode.For_types.t ->
-  t
+val direct_function_call : Code_id.t -> Alloc_mode.For_types.t -> t
 
 val indirect_function_call_unknown_arity : Alloc_mode.For_types.t -> t
 
-val indirect_function_call_known_arity :
-  param_arity:Flambda_arity.With_subkinds.t ->
-  return_arity:Flambda_arity.With_subkinds.t ->
-  Alloc_mode.For_types.t ->
-  t
+val indirect_function_call_known_arity : Alloc_mode.For_types.t -> t
 
 val method_call : Method_kind.t -> obj:Simple.t -> Alloc_mode.For_types.t -> t
 
-val c_call :
-  alloc:bool ->
-  param_arity:Flambda_arity.t ->
-  return_arity:Flambda_arity.t ->
-  is_c_builtin:bool ->
-  t
-
-val return_arity : t -> Flambda_arity.With_subkinds.t
+val c_call : alloc:bool -> is_c_builtin:bool -> t

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -394,7 +394,7 @@ let apply apply =
   (* CR mshinwell: Check / fix these numbers *)
   | Function { function_call = Indirect_unknown_arity; alloc_mode = _ } ->
     indirect_call_size
-  | Function { function_call = Indirect_known_arity _; alloc_mode = _ } ->
+  | Function { function_call = Indirect_known_arity; alloc_mode = _ } ->
     indirect_call_size
   | C_call { alloc = true; _ } -> alloc_extcall_size
   | C_call { alloc = false; _ } -> nonalloc_extcall_size


### PR DESCRIPTION
As discussed, whilst these could be inferred during `To_cmm` at the present time, we think it's going to be necessary to have these for propagation of information about complex layouts.

After this PR I'll do the renaming of the indirect call constructors so their meaning is more clear.