### PR TITLE
Fix handling of recursive tailcalls by `Cfg_loop_infos`

### DIFF
--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -34,19 +34,26 @@ val compute_loop_of_back_edge : Cfg.t -> Edge.t -> loop
 (* Assumes the passed edge is a back edge. *)
 
 type loops = loop EdgeMap.t
+(* Map from back edge to loop. *)
 
 val compute_loops_of_back_edges : Cfg.t -> Edge.t list -> loops
 (* Assumes the passed edges are back edges. *)
 
+type header_map = loop list Label.Map.t
+(* Map from loop header to loops. *)
+
+val compute_header_map : loops -> header_map
+
 type loop_depths = int Label.Map.t
 (* Maps labels to the number of nested loops it is part of. *)
 
-val compute_loop_depths : Cfg.t -> loops -> loop_depths
+val compute_loop_depths : Cfg.t -> header_map -> loop_depths
 
 type t =
   { dominators : dominators;
     back_edges : Edge.t list;
     loops : loops;
+    header_map : header_map;
     loop_depths : loop_depths
   }
 


### PR DESCRIPTION
This pull request fixes a bug in `Cfg_loop_infos` related
to recursive tailcalls. While testing https://github.com/ocaml-flambda/flambda-backend/pull/1080, I used only
simple examples of recursive tailcalls and missed an
embarrassing issue with the the current implementation:
- recursive tailcalls are back edges;
- if there are several such calls in the function,
  each one will define a loop;
- the computation of loop depths will essentially
  see these loops as nested, computing weird depths.

This pull requests addresses this issue in a slightly
hackish way, by:
- computing a map from loop headers to sets of
  labels in the loop;
- for a given header, merging the loops which are
  not properly nested.

As a result, even when there are multiple recursive
tailcalls, they will essentially be seen as part of the
same loop when computing the depths.

I have manually tested, on all 3 middle-ends, that
the handling of proper (nested) loops is not affected,
and that loops arising from recursive tailcalls are
properly merged so that ultimately the depth is 1.