### PR TITLE
Improve warning 55 diagnostic under Flambda 2

### DIFF
--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -30,8 +30,13 @@ let warn_not_inlined_if_needed apply reason =
   match Apply.inlined apply with
   | Hint_inlined | Never_inlined | Default_inlined -> ()
   | Always_inlined | Unroll _ ->
+    let dbg = Apply.dbg apply in
+    let reason =
+      Format.asprintf "%s@ (the full inlining stack was:@ %a)" reason
+        Debuginfo.print_compact dbg
+    in
     Location.prerr_warning
-      (Debuginfo.to_location (Apply.dbg apply))
+      (Debuginfo.to_location dbg)
       (Warnings.Inlining_impossible reason)
 
 let record_free_names_of_apply_as_used0 apply ~use_id ~exn_cont_use_id data_flow


### PR DESCRIPTION
The warning 55 diagnostic isn't helpful at present when there are inlined frames, as it only prints the outermost location.  This PR just improves the message a bit.