### PR TITLE
Add  flambda_backend_utils to compiler-libs

### DIFF
--- a/utils/dune
+++ b/utils/dune
@@ -5,3 +5,15 @@
  (ocamlopt_flags
   (:standard -O3))
  (libraries ocamlcommon))
+
+(install
+  (files
+    (flambda_backend_utils.a as compiler-libs/flambda_backend_utils.a)
+    (flambda_backend_utils.cma as compiler-libs/flambda_backend_utils.cma)
+    (flambda_backend_utils.cmxa as compiler-libs/flambda_backend_utils.cmxa)
+    (.flambda_backend_utils.objs/byte/flambda_backend_utils.cmi as compiler-libs/flambda_backend_utils.cmi)
+    (doubly_linked_list.mli as compiler-libs/doubly_linked_list.ml)
+    (doubly_linked_list.mli as compiler-libs/doubly_linked_list.mli)
+  )
+  (section lib)
+  (package ocaml))


### PR DESCRIPTION
Motivation: `ocamlfdo` tool needs to be able to access `Doubly_linked_list` which is used to impement CFG layout (after https://github.com/ocaml-flambda/flambda-backend/pull/1146).