### PR TITLE
Add a proper top and bottom layout

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2654,7 +2654,10 @@ let rec make_curry_apply result narity args_type args clos n =
           :: args)
           newclos (n - 1) )
 
-let machtype_of_layout = function Lambda.Pvalue _ -> typ_val
+let machtype_of_layout (layout : Lambda.layout) =
+  match layout with
+  | Ptop | Pbottom -> Misc.fatal_error "No machtype for layout"
+  | Pvalue _ -> typ_val
 
 let final_curry_function nlocal arity result =
   let last_arg = V.create_local "arg" in
@@ -3989,4 +3992,7 @@ let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
   | Assert p -> [Assert (transl_property p)]
   | Assume p -> [Assume (transl_property p)]
 
-let kind_of_layout (Lambda.Pvalue kind) = Vval kind
+let kind_of_layout (layout : Lambda.layout) =
+  match layout with
+  | Ptop | Pbottom -> Misc.fatal_error "No machtype for layout"
+  | Pvalue kind -> Vval kind

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2656,7 +2656,9 @@ let rec make_curry_apply result narity args_type args clos n =
 
 let machtype_of_layout (layout : Lambda.layout) =
   match layout with
-  | Ptop | Pbottom -> Misc.fatal_error "No machtype for layout"
+  | Ptop -> Misc.fatal_error "No machtype for layout [Ptop]"
+  | Pbottom ->
+    Misc.fatal_error "No unique machtype for layout [Pbottom]"
   | Pvalue _ -> typ_val
 
 let final_curry_function nlocal arity result =
@@ -3994,5 +3996,7 @@ let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
 
 let kind_of_layout (layout : Lambda.layout) =
   match layout with
-  | Ptop | Pbottom -> Misc.fatal_error "No machtype for layout"
+  | Ptop | Pbottom ->
+    (* This is incorrect but only used for unboxing *)
+    Vval Pgenval
   | Pvalue kind -> Vval kind

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2657,8 +2657,7 @@ let rec make_curry_apply result narity args_type args clos n =
 let machtype_of_layout (layout : Lambda.layout) =
   match layout with
   | Ptop -> Misc.fatal_error "No machtype for layout [Ptop]"
-  | Pbottom ->
-    Misc.fatal_error "No unique machtype for layout [Pbottom]"
+  | Pbottom -> Misc.fatal_error "No unique machtype for layout [Pbottom]"
   | Pvalue _ -> typ_val
 
 let final_curry_function nlocal arity result =

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -799,13 +799,17 @@ and transl_catch (kind : Cmm.value_kind) env nfail ids body handler dbg =
     List.iter2
       (fun (id, (layout : Lambda.layout), u) c ->
          match layout with
-         | Ptop | Pbottom ->
-           Misc.fatal_errorf "Variable %a with layout %a can't be compiled"
-             VP.print id Printlambda.layout layout
+         | Ptop ->
+           Misc.fatal_errorf "Variable %a with layout [Ptop] can't be compiled"
+             VP.print id
+         | Pbottom ->
+           Misc.fatal_errorf
+             "Variable %a with layout [Pbottom] can't be compiled"
+             VP.print id
          | Pvalue kind ->
-         let strict = is_strict kind in
-         u := join_unboxed_number_kind ~strict !u
-             (is_unboxed_number_cmm c)
+           let strict = is_strict kind in
+           u := join_unboxed_number_kind ~strict !u
+               (is_unboxed_number_cmm c)
       )
       ids args
   in
@@ -1293,8 +1297,8 @@ and transl_let_value env str (kind : Lambda.value_kind) id exp transl_body =
 and transl_let env str (layout : Lambda.layout) id exp transl_body =
   match layout with
   | Ptop ->
-    Misc.fatal_errorf "Variable %a with layout %a can't be compiled"
-      VP.print id Printlambda.layout layout
+    Misc.fatal_errorf "Variable %a with layout [Ptop] can't be compiled"
+      VP.print id
   | Pbottom ->
     let cexp = transl env exp in
     (* N.B. [body] must still be traversed even if [exp] will never return:

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -506,9 +506,19 @@ let rec transl env e =
   | Ugeneric_apply(clos, args, args_layout, result_layout, kind, dbg) ->
       let clos = transl env clos in
       let args = List.map (transl env) args in
-      let args_type = List.map machtype_of_layout args_layout in
-      let return = machtype_of_layout result_layout in
-      generic_apply (mut_from_env env clos) clos args args_type return kind dbg
+      if List.mem Pbottom args_layout then
+        (* [machtype_of_layout] will fail on Pbottom, convert it to a sequence
+           and remove the call, preserving the execution order. *)
+        List.fold_left2 (fun rest arg arg_layout ->
+            if arg_layout = Pbottom then
+              arg
+            else
+              Csequence(remove_unit arg, rest)
+          ) (Ctuple []) args args_layout
+      else
+        let args_type = List.map machtype_of_layout args_layout in
+        let return = machtype_of_layout result_layout in
+        generic_apply (mut_from_env env clos) clos args args_type return kind dbg
   | Usend(kind, met, obj, args, args_layout, result_layout, pos, dbg) ->
       let met = transl env met in
       let obj = transl env obj in

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1299,7 +1299,7 @@ and transl_let env str (layout : Lambda.layout) id exp transl_body =
     let cexp = transl env exp in
     (* N.B. [body] must still be traversed even if [exp] will never return:
        there may be constant closures inside that need lifting out. *)
-    let _cbody = transl_body env in
+    let _cbody : expression = transl_body env in
     cexp
   | Pvalue kind ->
     transl_let_value env str kind id exp transl_body

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -142,7 +142,9 @@ and value_kind = Lambda.value_kind =
   | Parrayval of array_kind
 
 and layout = Lambda.layout =
+  | Ptop
   | Pvalue of value_kind
+  | Pbottom
 
 and block_shape = Lambda.block_shape
 and boxed_integer = Primitive.boxed_integer =

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -145,7 +145,9 @@ and value_kind = Lambda.value_kind =
   | Parrayval of array_kind
 
 and layout = Lambda.layout =
+  | Ptop
   | Pvalue of value_kind
+  | Pbottom
 
 and block_shape = Lambda.block_shape
 and boxed_integer = Primitive.boxed_integer =

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -59,6 +59,7 @@ let rec add_to_closure_env env_param pos cenv = function
 
 let is_gc_ignorable kind =
   match kind with
+  | Ptop | Pbottom -> Misc.fatal_error "Wrong layout"
   | Pvalue Pintval -> true
   | Pvalue (Pgenval | Pfloatval | Pboxedintval _ | Pvariant _ | Parrayval _) -> false
 

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -59,7 +59,8 @@ let rec add_to_closure_env env_param pos cenv = function
 
 let is_gc_ignorable kind =
   match kind with
-  | Ptop | Pbottom -> Misc.fatal_error "Wrong layout"
+  | Ptop -> Misc.fatal_error "[Ptop] can't be stored in a closure."
+  | Pbottom -> Misc.fatal_error "[Pbottom] should not be stored in a closure."
   | Pvalue Pintval -> true
   | Pvalue (Pgenval | Pfloatval | Pboxedintval _ | Pvariant _ | Parrayval _) -> false
 

--- a/middle_end/flambda/closure_offsets.ml
+++ b/middle_end/flambda/closure_offsets.ml
@@ -70,7 +70,11 @@ let add_closure_offsets
   in
   let gc_invisible_free_vars, gc_visible_free_vars =
     Variable.Map.partition (fun _ (free_var : Flambda.specialised_to) ->
-        match free_var.kind with Pvalue Pintval -> true | Pvalue _ -> false)
+        match free_var.kind with
+        | Ptop | Pbottom ->
+          Misc.fatal_error "Wrong layout in closure"
+        | Pvalue Pintval -> true
+        | Pvalue _ -> false)
       free_vars
   in
   let free_variable_offsets, free_variable_pos =

--- a/middle_end/flambda/closure_offsets.ml
+++ b/middle_end/flambda/closure_offsets.ml
@@ -71,8 +71,12 @@ let add_closure_offsets
   let gc_invisible_free_vars, gc_visible_free_vars =
     Variable.Map.partition (fun _ (free_var : Flambda.specialised_to) ->
         match free_var.kind with
-        | Ptop | Pbottom ->
-          Misc.fatal_error "Wrong layout in closure"
+        | Ptop ->
+          Misc.fatal_error "[Ptop] can't be stored in a closure."
+        | Pbottom ->
+          Misc.fatal_error
+            "[Pbottom] should have been eliminated as dead code \
+             and not stored in a closure."
         | Pvalue Pintval -> true
         | Pvalue _ -> false)
       free_vars

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -698,8 +698,11 @@ and to_clambda_set_of_closures t env
   let not_scanned_fv, scanned_fv =
     Variable.Map.partition (fun _ (free_var : Flambda.specialised_to) ->
         match free_var.kind with
-        | Ptop -> Misc.fatal_error "Layout top in a closure"
-        | Pbottom -> Misc.fatal_error "Layout bottom in a closure"
+        | Ptop -> Misc.fatal_error "[Ptop] can't be stored in a closure."
+        | Pbottom ->
+          Misc.fatal_error
+            "[Pbottom] should have been eliminated as dead code \
+             and not stored in a closure."
         | Pvalue Pintval -> true
         | Pvalue _ -> false)
       free_vars

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -698,6 +698,8 @@ and to_clambda_set_of_closures t env
   let not_scanned_fv, scanned_fv =
     Variable.Map.partition (fun _ (free_var : Flambda.specialised_to) ->
         match free_var.kind with
+        | Ptop -> Misc.fatal_error "Layout top in a closure"
+        | Pbottom -> Misc.fatal_error "Layout bottom in a closure"
         | Pvalue Pintval -> true
         | Pvalue _ -> false)
       free_vars

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -519,8 +519,9 @@ module With_subkind = struct
   let from_lambda (layout : Lambda.layout) =
     match layout with
     | Pvalue vk -> from_lambda_value_kind vk
-    | Ptop -> Misc.fatal_error "Can't convert layout top to flambda kind"
-    | Pbottom -> Misc.fatal_error "Can't convert layout bottom to flambda kind"
+    | Ptop -> Misc.fatal_error "Can't convert layout [Ptop] to flambda kind"
+    | Pbottom ->
+      Misc.fatal_error "Can't convert layout [Pbottom] to flambda kind"
 
   include Container_types.Make (struct
     type nonrec t = t

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -516,7 +516,11 @@ module With_subkind = struct
     | Parrayval Paddrarray -> value_array
     | Parrayval Pgenarray -> generic_array
 
-  let from_lambda (Pvalue vk : Lambda.layout) = from_lambda_value_kind vk
+  let from_lambda (layout : Lambda.layout) =
+    match layout with
+    | Pvalue vk -> from_lambda_value_kind vk
+    | Ptop -> Misc.fatal_error "Can't convert layout top to flambda kind"
+    | Pbottom -> Misc.fatal_error "Can't convert layout bottom to flambda kind"
 
   include Container_types.Make (struct
     type nonrec t = t

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -54,8 +54,8 @@ let value_kind kind = Format.asprintf "%a" value_kind0 kind
 let layout (layout : Lambda.layout) =
   match layout with
   | Pvalue kind -> value_kind kind
-  | Ptop -> "top"
-  | Pbottom -> "bottom"
+  | Ptop -> ":top"
+  | Pbottom -> ":bottom"
 
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -51,7 +51,11 @@ let rec value_kind0 ppf kind =
       non_consts
 
 let value_kind kind = Format.asprintf "%a" value_kind0 kind
-let layout (Lambda.Pvalue kind) = value_kind kind
+let layout (layout : Lambda.layout) =
+  match layout with
+  | Pvalue kind -> value_kind kind
+  | Ptop -> "top"
+  | Pbottom -> "bottom"
 
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -2239,7 +2239,11 @@ let rec make_curry_apply result narity args_type args clos n =
           :: args)
           newclos (n - 1) )
 
-let machtype_of_layout = function Lambda.Pvalue _ -> typ_val
+let machtype_of_layout (layout : Lambda.layout) =
+  match layout with
+  | Ptop -> Misc.fatal_error "No machtype for layout [Ptop]"
+  | Pbottom -> Misc.fatal_error "No unique machtype for layout [Pbottom]"
+  | Pvalue _ -> typ_val
 
 let final_curry_function nlocal arity result =
   let last_arg = V.create_local "arg" in
@@ -3140,5 +3144,9 @@ let emit_preallocated_blocks preallocated_blocks cont =
   let c1 = emit_gc_roots_table ~symbols cont in
   List.fold_left preallocate_block c1 preallocated_blocks
 
-let kind_of_layout (Lambda.Pvalue kind) = Vval kind
-
+let kind_of_layout (layout : Lambda.layout) =
+  match layout with
+  | Ptop | Pbottom ->
+    (* This is incorrect but only used for unboxing *)
+    Vval Pgenval
+  | Pvalue kind -> Vval kind

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -751,7 +751,11 @@ and transl_catch (kind : Cmm.value_kind) env nfail ids body handler dbg =
              "Variable %a with layout [Pbottom] can't be compiled"
              VP.print id
          | Pvalue kind ->
-           let strict = is_strict kind in
+           let strict =
+             match kind with
+             | Pfloatval | Pboxedintval _ -> false
+             | Pintval | Pgenval | Pvariant _ | Parrayval _ -> true
+           in
            u := join_unboxed_number_kind ~strict !u
                (is_unboxed_number_cmm c)
       )

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -448,9 +448,19 @@ let rec transl env e =
   | Ugeneric_apply(clos, args, args_layout, result_layout, kind, dbg) ->
       let clos = transl env clos in
       let args = List.map (transl env) args in
-      let args_type = List.map machtype_of_layout args_layout in
-      let return = machtype_of_layout result_layout in
-      generic_apply (mut_from_env env clos) clos args args_type return kind dbg
+      if List.mem Pbottom args_layout then
+        (* [machtype_of_layout] will fail on Pbottom, convert it to a sequence
+           and remove the call, preserving the execution order. *)
+        List.fold_left2 (fun rest arg arg_layout ->
+            if arg_layout = Pbottom then
+              arg
+            else
+              Csequence(remove_unit arg, rest)
+          ) (Ctuple []) args args_layout
+      else
+        let args_type = List.map machtype_of_layout args_layout in
+        let return = machtype_of_layout result_layout in
+        generic_apply (mut_from_env env clos) clos args args_type return kind dbg
   | Usend(kind, met, obj, args, args_layout, result_layout, pos, dbg) ->
       let met = transl env met in
       let obj = transl env obj in
@@ -731,14 +741,19 @@ and transl_catch (kind : Cmm.value_kind) env nfail ids body handler dbg =
      each argument.  *)
   let report args =
     List.iter2
-      (fun (_id, Pvalue kind, u) c ->
-         let strict =
-           match kind with
-           | Pfloatval | Pboxedintval _ -> false
-           | Pintval | Pgenval | Pvariant _ | Parrayval _ -> true
-         in
-         u := join_unboxed_number_kind ~strict !u
-             (is_unboxed_number_cmm ~strict c)
+      (fun (id, (layout : Lambda.layout), u) c ->
+         match layout with
+         | Ptop ->
+           Misc.fatal_errorf "Variable %a with layout [Ptop] can't be compiled"
+             VP.print id
+         | Pbottom ->
+           Misc.fatal_errorf
+             "Variable %a with layout [Pbottom] can't be compiled"
+             VP.print id
+         | Pvalue kind ->
+           let strict = is_strict kind in
+           u := join_unboxed_number_kind ~strict !u
+               (is_unboxed_number_cmm c)
       )
       ids args
   in
@@ -1181,7 +1196,7 @@ and transl_unbox_sized size dbg env exp =
   | Thirty_two -> transl_unbox_int dbg env Pint32 exp
   | Sixty_four -> transl_unbox_int dbg env Pint64 exp
 
-and transl_let env str (Pvalue kind : Lambda.layout) id exp transl_body =
+and transl_let_value env str (kind : Lambda.value_kind) id exp transl_body =
   let dbg = Debuginfo.none in
   let cexp = transl env exp in
   let unboxing =
@@ -1232,6 +1247,20 @@ and transl_let env str (Pvalue kind : Lambda.layout) id exp transl_body =
       | (Immutable | Immutable_unique), _ -> Clet (v, cexp, body)
       | Mutable, bn -> Clet_mut (v, typ_of_boxed_number bn, cexp, body)
       end
+
+and transl_let env str (layout : Lambda.layout) id exp transl_body =
+  match layout with
+  | Ptop ->
+      Misc.fatal_errorf "Variable %a with layout [Ptop] can't be compiled"
+        VP.print id
+  | Pbottom ->
+      let cexp = transl env exp in
+      (* N.B. [body] must still be traversed even if [exp] will never return:
+         there may be constant closures inside that need lifting out. *)
+      let _cbody : expression = transl_body env in
+      cexp
+  | Pvalue kind ->
+      transl_let_value env str kind id exp transl_body
 
 and make_catch (kind : Cmm.value_kind) ncatch body handler dbg = match body with
 | Cexit (nexit,[]) when nexit=ncatch -> handler

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -757,7 +757,7 @@ and transl_catch (kind : Cmm.value_kind) env nfail ids body handler dbg =
              | Pintval | Pgenval | Pvariant _ | Parrayval _ -> true
            in
            u := join_unboxed_number_kind ~strict !u
-               (is_unboxed_number_cmm c)
+               (is_unboxed_number_cmm ~strict c)
       )
       ids args
   in

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -612,6 +612,7 @@ let layout_lazy_contents = Pvalue Pgenval
 let layout_any_value = Pvalue Pgenval
 let layout_letrec = layout_any_value
 
+(* CR ncourant: use [Ptop] or remove this as soon as possible. *)
 let layout_top = layout_any_value
 let layout_bottom = Pbottom
 

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -255,7 +255,9 @@ and value_kind =
   | Parrayval of array_kind
 
 and layout =
+  | Ptop
   | Pvalue of value_kind
+  | Pbottom
 
 and block_shape =
   value_kind list option
@@ -316,14 +318,25 @@ let rec equal_value_kind x y =
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval | Pvariant _
       | Parrayval _), _ -> false
 
-let equal_layout (Pvalue x) (Pvalue y) = equal_value_kind x y
+let equal_layout x y =
+  match x, y with
+  | Pvalue x, Pvalue y -> equal_value_kind x y
+  | Ptop, Ptop -> true
+  | Pbottom, Pbottom -> true
+  | _, _ -> false
 
-let compatible_layout (Pvalue _) (Pvalue _) = true
+let compatible_layout x y =
+  match x, y with
+  | Pbottom, _
+  | _, Pbottom -> true
+  | Pvalue _, Pvalue _ -> true
+  | Ptop, Ptop -> true
+  | Ptop, _ | _, Ptop -> false
 
 let must_be_value layout =
   match layout with
   | Pvalue v -> v
-  (* | _ -> Misc.fatal_error "Layout is not a value" *)
+  | _ -> Misc.fatal_error "Layout is not a value"
 
 type structured_constant =
     Const_base of constant
@@ -599,10 +612,8 @@ let layout_lazy_contents = Pvalue Pgenval
 let layout_any_value = Pvalue Pgenval
 let layout_letrec = layout_any_value
 
-let layout_top = Pvalue Pgenval
-let layout_bottom =
-  (* CR pchambart: this should be an actual bottom *)
-  Pvalue Pgenval
+let layout_top = layout_any_value
+let layout_bottom = Pbottom
 
 let default_function_attribute = {
   inline = Default_inline;

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -336,6 +336,11 @@ let compatible_layout x y =
 let must_be_value layout =
   match layout with
   | Pvalue v -> v
+  | Pbottom ->
+      (* Here, we want to get the [value_kind] corresponding to
+         a [Pbottom] layout. Anything will do, we return [Pgenval]
+         as a default. *)
+      Pgenval
   | _ -> Misc.fatal_error "Layout is not a value"
 
 type structured_constant =

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -212,7 +212,9 @@ and value_kind =
   | Parrayval of array_kind
 
 and layout =
+  | Ptop
   | Pvalue of value_kind
+  | Pbottom
 
 and block_shape =
   value_kind list option

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -95,7 +95,11 @@ and value_kind' ppf = function
   | Pvariant { consts; non_consts; } ->
     variant_kind value_kind' ppf ~consts ~non_consts
 
-let layout ppf (Pvalue k) = value_kind ppf k
+let layout ppf layout =
+  match layout with
+  | Pvalue k -> value_kind ppf k
+  | Ptop -> fprintf ppf "top"
+  | Pbottom -> fprintf ppf "bottom"
 
 let return_kind ppf (mode, kind) =
   let smode = alloc_mode mode in
@@ -109,6 +113,8 @@ let return_kind ppf (mode, kind) =
   | Pvalue (Pboxedintval bi) -> fprintf ppf ": %s%s@ " smode (boxed_integer_name bi)
   | Pvalue (Pvariant { consts; non_consts; }) ->
     variant_kind value_kind' ppf ~consts ~non_consts
+  | Ptop -> fprintf ppf ": top@ "
+  | Pbottom -> fprintf ppf ": bottom@ "
 
 let field_kind ppf = function
   | Pgenval -> pp_print_string ppf "*"

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -98,8 +98,8 @@ and value_kind' ppf = function
 let layout ppf layout =
   match layout with
   | Pvalue k -> value_kind ppf k
-  | Ptop -> fprintf ppf "top"
-  | Pbottom -> fprintf ppf "bottom"
+  | Ptop -> fprintf ppf "[top]"
+  | Pbottom -> fprintf ppf "[bottom]"
 
 let return_kind ppf (mode, kind) =
   let smode = alloc_mode mode in

--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -142,7 +142,9 @@ and value_kind = Lambda.value_kind =
   | Parrayval of array_kind
 
 and layout = Lambda.layout =
+  | Ptop
   | Pvalue of value_kind
+  | Pbottom
 
 and block_shape = Lambda.block_shape
 and boxed_integer = Primitive.boxed_integer =

--- a/ocaml/middle_end/clambda_primitives.mli
+++ b/ocaml/middle_end/clambda_primitives.mli
@@ -145,7 +145,9 @@ and value_kind = Lambda.value_kind =
   | Parrayval of array_kind
 
 and layout = Lambda.layout =
+  | Ptop
   | Pvalue of value_kind
+  | Pbottom
 
 and block_shape = Lambda.block_shape
 and boxed_integer = Primitive.boxed_integer =

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -59,6 +59,8 @@ let rec add_to_closure_env env_param pos cenv = function
 
 let is_gc_ignorable kind =
   match kind with
+  | Ptop -> Misc.fatal_error "[Ptop] can't be stored in a closure."
+  | Pbottom -> Misc.fatal_error "[Pbottom] should not be stored in a closure."
   | Pvalue Pintval -> true
   | Pvalue (Pgenval | Pfloatval | Pboxedintval _ | Pvariant _ | Parrayval _) -> false
 

--- a/ocaml/middle_end/flambda/closure_offsets.ml
+++ b/ocaml/middle_end/flambda/closure_offsets.ml
@@ -70,7 +70,15 @@ let add_closure_offsets
   in
   let gc_invisible_free_vars, gc_visible_free_vars =
     Variable.Map.partition (fun _ (free_var : Flambda.specialised_to) ->
-        match free_var.kind with Pvalue Pintval -> true | Pvalue _ -> false)
+        match free_var.kind with
+        | Ptop ->
+          Misc.fatal_error "[Ptop] can't be stored in a closure."
+        | Pbottom ->
+          Misc.fatal_error
+            "[Pbottom] should have been eliminated as dead code \
+             and not stored in a closure."
+        | Pvalue Pintval -> true
+        | Pvalue _ -> false)
       free_vars
   in
   let free_variable_offsets, free_variable_pos =

--- a/ocaml/middle_end/flambda/flambda_to_clambda.ml
+++ b/ocaml/middle_end/flambda/flambda_to_clambda.ml
@@ -696,6 +696,11 @@ and to_clambda_set_of_closures t env
   let not_scanned_fv, scanned_fv =
     Variable.Map.partition (fun _ (free_var : Flambda.specialised_to) ->
         match free_var.kind with
+        | Ptop -> Misc.fatal_error "[Ptop] can't be stored in a closure."
+        | Pbottom ->
+          Misc.fatal_error
+            "[Pbottom] should have been eliminated as dead code \
+             and not stored in a closure."
         | Pvalue Pintval -> true
         | Pvalue _ -> false)
       free_vars

--- a/ocaml/middle_end/printclambda.ml
+++ b/ocaml/middle_end/printclambda.ml
@@ -51,7 +51,11 @@ let rec value_kind0 ppf kind =
       non_consts
 
 let value_kind kind = Format.asprintf "%a" value_kind0 kind
-let layout (Lambda.Pvalue kind) = value_kind kind
+let layout (layout : Lambda.layout) =
+  match layout with
+  | Pvalue kind -> value_kind kind
+  | Ptop -> ":top"
+  | Pbottom -> ":bottom"
 
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -411,5 +411,10 @@ let value_kind_union (k1 : Lambda.value_kind) (k2 : Lambda.value_kind) =
   if Lambda.equal_value_kind k1 k2 then k1
   else Pgenval
 
-let layout_union (Pvalue layout1) (Pvalue layout2) =
-  Pvalue (value_kind_union layout1 layout2)
+let layout_union l1 l2 =
+  match l1, l2 with
+  | Pbottom, l
+  | l, Pbottom -> l
+  | Pvalue layout1, Pvalue layout2 ->
+      Pvalue (value_kind_union layout1 layout2)
+  | Ptop, _ | _, Ptop -> Ptop


### PR DESCRIPTION
This is extracted from Pierre's PR with test layouts. Note that for now, `layout_top` is defined as `layout_any_value` and not `Ptop`: otherwise, three tests fail, related to dissect-let-rec and regions.

There is a question as to whether we want to add `Ptop` in the first place, or if this PR should only add `Pbottom` (which is needed, because in some places we really need a `Pbottom` compatible with all layouts).