### PR TITLE
Unbreak return arities in indirect calls in fexpr->flambda

### DIFF
--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -901,7 +901,8 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           let return_arity =
             (* CR mshinwell: This needs fixing to cope with the fact that the
                arities have moved onto [Apply_expr] *)
-            Flambda_arity.With_subkinds.create []
+            Flambda_arity.With_subkinds.create
+              [Flambda_kind.With_subkind.any_value]
           in
           ( Call_kind.indirect_function_call_unknown_arity
               Alloc_mode.For_types.heap,


### PR DESCRIPTION
There's no syntax for the return arity yet, but the correct fallback is to default to the arity `val` rather than the empty arity.