### PR TITLE
Reenable backtrace testsuite folder for flambda2

### DIFF
--- a/ocaml/testsuite/tests/backtrace/backtrace.reference
+++ b/ocaml/testsuite/tests/backtrace/backtrace.reference
@@ -23,4 +23,4 @@ Called from Backtrace.f in file "backtrace.ml", line 11, characters 42-53
 Called from Backtrace.g in file "backtrace.ml", line 15, characters 4-11
 Called from Backtrace in file "backtrace.ml", line 21, characters 9-25
 Fatal error: exception Invalid_argument("index out of bounds")
-Raised by primitive operation at Backtrace in file "backtrace.ml", line 21, characters 12-24
+Raised at Backtrace in file "backtrace.ml", line 21, characters 12-24

--- a/ocaml/testsuite/tests/backtrace/backtrace.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace.run
@@ -4,6 +4,6 @@
 exec > "${output}" 2>&1
 
 for arg in a b c d ''; do
-  ("${program}" ${arg} || true) |& \
+  ("${program}" ${arg} || true) 2>&1 | \
     ${test_source_directory}/sanitize-backtrace.sh
 done

--- a/ocaml/testsuite/tests/backtrace/backtrace.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace.run
@@ -4,5 +4,6 @@
 exec > "${output}" 2>&1
 
 for arg in a b c d ''; do
-  "${program}" ${arg} || true
+  ("${program}" ${arg} || true) |& \
+    ${test_source_directory}/sanitize-backtrace.sh
 done

--- a/ocaml/testsuite/tests/backtrace/backtrace2.reference
+++ b/ocaml/testsuite/tests/backtrace/backtrace2.reference
@@ -32,7 +32,7 @@ Uncaught exception Backtrace2.Error("f")
 Raised at Backtrace2.test_Error in file "backtrace2.ml", line 32, characters 62-71
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Invalid_argument("index out of bounds")
-Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
+Raised at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
 Raised at Backtrace2.test_Not_found.aux in file "backtrace2.ml", line 36, characters 18-33

--- a/ocaml/testsuite/tests/backtrace/backtrace2.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace2.run
@@ -1,3 +1,3 @@
 #!/bin/sh
-(${program} 2>&1 || true) |& \
+(${program} 2>&1 || true) 2>&1 | \
   ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/backtrace2.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace2.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+(${program} 2>&1 || true) |& \
+  ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/backtrace3.reference
+++ b/ocaml/testsuite/tests/backtrace/backtrace3.reference
@@ -70,4 +70,4 @@ Called from Backtrace3.g in file "backtrace3.ml", line 15, characters 4-11
 Re-raised at Backtrace3.g in file "backtrace3.ml", line 45, characters 10-17
 Called from Backtrace3.run in file "backtrace3.ml", line 49, characters 11-23
 Uncaught exception Invalid_argument("index out of bounds")
-Raised by primitive operation at Backtrace3.run in file "backtrace3.ml", line 49, characters 14-22
+Raised at Backtrace3.run in file "backtrace3.ml", line 49, characters 14-22

--- a/ocaml/testsuite/tests/backtrace/backtrace3.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace3.run
@@ -1,3 +1,3 @@
 #!/bin/sh
-(${program} 2>&1 || true) |& \
+(${program} 2>&1 || true) 2>&1 | \
   ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/backtrace3.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace3.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+(${program} 2>&1 || true) |& \
+  ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/backtrace_deprecated.reference
+++ b/ocaml/testsuite/tests/backtrace/backtrace_deprecated.reference
@@ -24,4 +24,4 @@ Called from Backtrace_deprecated.f in file "backtrace_deprecated.ml", line 14, c
 Called from Backtrace_deprecated.g in file "backtrace_deprecated.ml", line 18, characters 4-11
 Called from Backtrace_deprecated.run in file "backtrace_deprecated.ml", line 25, characters 11-23
 Uncaught exception Invalid_argument("index out of bounds")
-Raised by primitive operation at Backtrace_deprecated.run in file "backtrace_deprecated.ml", line 25, characters 14-22
+Raised at Backtrace_deprecated.run in file "backtrace_deprecated.ml", line 25, characters 14-22

--- a/ocaml/testsuite/tests/backtrace/backtrace_deprecated.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace_deprecated.run
@@ -1,3 +1,3 @@
 #!/bin/sh
-(${program} 2>&1 || true) |& \
+(${program} 2>&1 || true) 2>&1 | \
   ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/backtrace_deprecated.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace_deprecated.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+(${program} 2>&1 || true) |& \
+  ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/backtrace_slots.reference
+++ b/ocaml/testsuite/tests/backtrace/backtrace_slots.reference
@@ -24,4 +24,4 @@ Called from Backtrace_slots.f in file "backtrace_slots.ml", line 40, characters 
 Called from Backtrace_slots.g in file "backtrace_slots.ml", line 44, characters 4-11
 Called from Backtrace_slots.run in file "backtrace_slots.ml", line 51, characters 11-23
 Uncaught exception Invalid_argument("index out of bounds")
-Raised by primitive operation at Backtrace_slots.run in file "backtrace_slots.ml", line 51, characters 14-22
+Raised at Backtrace_slots.run in file "backtrace_slots.ml", line 51, characters 14-22

--- a/ocaml/testsuite/tests/backtrace/backtrace_slots.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace_slots.run
@@ -1,3 +1,3 @@
 #!/bin/sh
-(${program} 2>&1 || true) |& \
+(${program} 2>&1 || true) 2>&1 | \
   ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/backtrace_slots.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace_slots.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+(${program} 2>&1 || true) |& \
+  ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/filter-locations.sh
+++ b/ocaml/testsuite/tests/backtrace/filter-locations.sh
@@ -2,4 +2,4 @@
 # This location filter is erasing information from the backtrace
 # to be robust to different inlining choices made by different compiler settings.
 # It checks that the expected locations occur (in the expected order).
-sed -e "s/^.*in file/File/" -e 's/ (inlined)//' | grep ^File
+sed -e "s/^.*in file/File/" -e 's/ (inlined)//' -e 's/ by primitive operation//' | grep ^File

--- a/ocaml/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/ocaml/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 408, characters 28-54
+Raised at Stdlib.open_in_gen in file "stdlib.ml", line 408, characters 28-54
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/ocaml/testsuite/tests/backtrace/pr2195-nolocs.byte.reference
+++ b/ocaml/testsuite/tests/backtrace/pr2195-nolocs.byte.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at unknown location
+Raised at unknown location
 Called from unknown location
 (Cannot print locations:
  bytecode executable program file cannot be opened;

--- a/ocaml/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/ocaml/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 408, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 413, characters 2-45
+Raised at Stdlib.open_in_gen in file "stdlib.ml", line 408, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml", line 413, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/ocaml/testsuite/tests/backtrace/pr2195.run
+++ b/ocaml/testsuite/tests/backtrace/pr2195.run
@@ -5,5 +5,5 @@
 # is limited to 8192 open files (including the standard handles).
 ulimit -n 32
 
-${program} > ${output} 2>&1
+${program} |& ${test_source_directory}/sanitize-backtrace.sh > ${output}
 echo 'exit_status="'$?'"' > ${ocamltest_response}

--- a/ocaml/testsuite/tests/backtrace/pr2195.run
+++ b/ocaml/testsuite/tests/backtrace/pr2195.run
@@ -5,5 +5,5 @@
 # is limited to 8192 open files (including the standard handles).
 ulimit -n 32
 
-${program} |& ${test_source_directory}/sanitize-backtrace.sh > ${output}
+${program} 2>&1 | ${test_source_directory}/sanitize-backtrace.sh > ${output}
 echo 'exit_status="'$?'"' > ${ocamltest_response}

--- a/ocaml/testsuite/tests/backtrace/raw_backtrace.reference
+++ b/ocaml/testsuite/tests/backtrace/raw_backtrace.reference
@@ -46,4 +46,4 @@ Called from Raw_backtrace.g in file "raw_backtrace.ml", line 20, characters 4-11
 Re-raised at Raw_backtrace.g in file "raw_backtrace.ml", line 33, characters 9-57
 Called from Raw_backtrace.backtrace in file "raw_backtrace.ml", line 37, characters 11-23
 Uncaught exception Invalid_argument("index out of bounds")
-Raised by primitive operation at Raw_backtrace.backtrace in file "raw_backtrace.ml", line 37, characters 14-22
+Raised at Raw_backtrace.backtrace in file "raw_backtrace.ml", line 37, characters 14-22

--- a/ocaml/testsuite/tests/backtrace/raw_backtrace.run
+++ b/ocaml/testsuite/tests/backtrace/raw_backtrace.run
@@ -1,3 +1,3 @@
 #!/bin/sh
-(${program} 2>&1 || true) |& \
+(${program} 2>&1 || true) 2>&1 | \
   ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/raw_backtrace.run
+++ b/ocaml/testsuite/tests/backtrace/raw_backtrace.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+(${program} 2>&1 || true) |& \
+  ${test_source_directory}/sanitize-backtrace.sh > ${output}

--- a/ocaml/testsuite/tests/backtrace/sanitize-backtrace.sh
+++ b/ocaml/testsuite/tests/backtrace/sanitize-backtrace.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# This location filter is normalizing backtraces so that
+# closure and flambda backtrace can be compared more easily
+# It runs two transformations:
+# - remove "(inlined)" annotations
+# - remove "by primitive operations" because flambda2 handles
+#   array primitives a bit differently and thus does not emit
+#   this "by primitive operation" for e.g. array accesses
+sed -e 's/ (inlined)//' -e 's/ by primitive operation//'

--- a/testsuite/flambda2-test-list
+++ b/testsuite/flambda2-test-list
@@ -1,7 +1,6 @@
 # excluded test                  | status      | reason for not running / failure
 # ------------------------------------------------------------------------------------------------
   tests/asmcomp                    FAIL
-  tests/backtrace                  FAIL (FIXME)  there is practically no backtrace info
   tests/float-unboxing             FAIL (FIXME)  'float_subst_boxed_number.ml' see flambdatest/mlexamples/float_unboxing.ml for a simplified error example. Should be fixed with unboxing in to_cmm
   tests/statmemprof                FAIL          Stack traces differ
   tests/warnings                   FAIL          'w55.ml' (@inline attribute), 'w59.ml' (missing warnings when using Obj functions)


### PR DESCRIPTION
This PR re-enables the `backtrace` folder of the upstream testsuite.

In order to make the tests pass, a bit of work was needed. More specifically, backtraces generated with flambda2 can differ from other backends on two points:
- some functions may be inlined with flambda2, resulting in an additional `(inlined)` in a backtrace slot (this is not specific to flambda2, but also affects flambda1 in principle)
- array accesses are not flagged as primitive operations by flambda2 (presumably because we do not compile the exception to an extcall but rather a direct raise) (this is specific to flambda2).
This PR thus introduces a script (based on `sed`) that removes these differences before comparing with the reference result. Note that this new script is quite similar to an already present script called `filter-locations.sh` (which is also adapted by this PR), so it's not that big a change.

I looked into completely removing the `filter-locations.sh` script, but there is one major difference in that on the two tests that use the script, in bytecode, we have slots that start with `Called from ...` whereas with ocamlopt we have slots that start with `Raised by primitive operation at ...`, and I'm not sure exactly why there is this difference, so I didn't change those yet.