### PR TITLE
Add hint for common misplaced [@unboxed] attribute

### DIFF
--- a/ocaml/testsuite/tests/typing-unboxed-types/test.ml
+++ b/ocaml/testsuite/tests/typing-unboxed-types/test.ml
@@ -128,6 +128,30 @@ Error: Signature mismatch:
        the first declaration uses unboxed representation.
 |}];;
 
+module M' : sig
+  type t = A of string [@ocaml.unboxed]
+end = struct
+  type t = A of string [@@ocaml.unboxed]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = A of string [@@ocaml.unboxed]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = A of string [@@unboxed] end
+       is not included in
+         sig type t = A of string end
+       Type declarations do not match:
+         type t = A of string [@@unboxed]
+       is not included in
+         type t = A of string
+       Their internal representations differ:
+       the first declaration uses unboxed representation.
+       Hint: the second declaration has [@unboxed]. Did you mean [@@unboxed]?
+|}];;
+
 module N : sig
   type t = A of string [@@ocaml.unboxed]
 end = struct

--- a/ocaml/typing/includecore.mli
+++ b/ocaml/typing/includecore.mli
@@ -104,7 +104,7 @@ type type_mismatch =
   | Variance
   | Record_mismatch of record_mismatch
   | Variant_mismatch of variant_change list
-  | Unboxed_representation of position
+  | Unboxed_representation of position * attributes
   | Immediate of Type_immediacy.Violation.t
 
 val value_descriptions:


### PR DESCRIPTION
@mshinwell observed that it's surprisingly common for people trying to unbox a variant to accidentally write `[@@unboxed]` in the mli and `[@unboxed]` in the ml (or the opposite).  This error message is potentially very confusing if you don't spot the different number of `@`s, so this just adds a hint.