### PR TITLE
Unboxed returns (multiple return values)

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -211,9 +211,11 @@ let loc_parameters arg =
   in
   loc
 
-let loc_results res =
+let loc_results_call res =
+  calling_conventions 0 9 100 109 outgoing (- size_domainstate_args) res
+let loc_results_return res =
   let (loc, _ofs) =
-    calling_conventions 0 0 100 100 not_supported 0 res
+    calling_conventions 0 9 100 109 incoming (- size_domainstate_args) res
   in loc
 
 let max_arguments_for_tailcalls = 10 (* in regs *) + 64 (* in domain state *)

--- a/backend/cfg/tests/check_regalloc_validation.ml
+++ b/backend/cfg/tests/check_regalloc_validation.ml
@@ -248,8 +248,8 @@ let base_templ () : Cfg_desc.t * (unit -> int) =
   in
   let int_arg1 = args.(1) in
   let int_arg2 = args.(2) in
-  let tmp_results, tmp_result_locs = make_locs [| int.(2) |] Proc.loc_results in
-  let results, result_locs = make_locs [| int.(3) |] Proc.loc_results in
+  let tmp_results, tmp_result_locs = make_locs [| int.(2) |] Proc.loc_results_return in
+  let results, result_locs = make_locs [| int.(3) |] Proc.loc_results_return in
   let make_moves src dst =
     Array.map2
       (fun src dst : Basic.t ->
@@ -829,7 +829,7 @@ let make_loop ~loop_loc_first n =
   let extra_regs =
     Array.init n (fun _ -> { (Reg.create Int) with loc = int_arg3.loc })
   in
-  let results, result_locs = make_locs [| int_arg1 |] Proc.loc_results in
+  let results, result_locs = make_locs [| int_arg1 |] Proc.loc_results_return in
   let make_moves src dst =
     Array.map2
       (fun src dst : Basic.t ->

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -31,8 +31,9 @@ val all_phys_regs : Reg.t array
 
 (* Calling conventions *)
 val loc_arguments: Cmm.machtype -> Reg.t array * int
-val loc_results: Cmm.machtype -> Reg.t array
+val loc_results_call: Cmm.machtype -> Reg.t array * int
 val loc_parameters: Cmm.machtype -> Reg.t array
+val loc_results_return: Cmm.machtype -> Reg.t array
 (* For argument number [n] split across multiple registers, the target-specific
    implementation of [loc_external_arguments] must return [regs] such that
    [regs.(n).(0)] is to hold the part of the value at the lowest address. *)

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -98,9 +98,6 @@ let cache_reload_result nfail before handler after_handler env =
   in
   reload_cache := Numbers.Int.Map.add nfail entry !reload_cache
 
-let reset_cache () =
-  reload_cache := Numbers.Int.Map.empty
-
 let spill_reg env r =
   try
     env, Reg.Map.find r env.spill_env
@@ -616,6 +613,10 @@ let rec spill :
         before_body)))
   | Iraise _ ->
       k i env.at_raise
+
+let reset_cache () =
+  reload_cache := Numbers.Int.Map.empty;
+  spill_cache := Numbers.Int.Map.empty
 
 (* Entry point *)
 

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1100,7 +1100,7 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
         (Bound_pattern.singleton untagged_scrutinee')
         untag ~body
 
-let close_one_function acc ~code_id ~external_env ~by_function_slot decl
+let close_one_function acc ~code_id ~external_env ~by_function_slot ~function_code_ids decl
     ~has_lifted_closure ~value_slots_from_idents ~function_slots_from_idents
     ~approx_map function_declarations =
   let acc = Acc.with_free_names Name_occurrences.empty acc in
@@ -1265,6 +1265,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
     |> Bound_parameters.create
   in
   let acc = Acc.with_seen_a_function acc false in
+  let compute_body acc =
   let acc, body =
     (* XXX seems like this needs to know what [my_region] is *)
     try body acc closure_env
@@ -1281,7 +1282,6 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
       (* print body *)
       Printexc.raise_with_backtrace Misc.Fatal_error bt
   in
-  let contains_subfunctions = Acc.seen_a_function acc in
   let my_closure' = Simple.var my_closure in
   let acc, body =
     (* CR mshinwell: These Project_function_slot operations should maybe be
@@ -1322,9 +1322,81 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
   let bound =
     Bound_pattern.singleton (Bound_var.create next_depth Name_mode.normal)
   in
-  let acc, body =
-    Let_with_acc.create acc bound (Named.create_rec_info next_depth_expr) ~body
+  Let_with_acc.create acc bound (Named.create_rec_info next_depth_expr) ~body
   in
+  let acc, body, return_continuation, my_closure =
+    match return with
+    | Single_return _ ->
+      let acc, body = compute_body acc in
+      acc, body, return_continuation, my_closure
+    | Multiple_return (kinds, unboxed_function_slot) ->
+      let kinds =
+        List.map Flambda_kind.With_subkind.from_lambda kinds
+      in
+      let unboxed_return_continuation =
+        Continuation.create ~sort:Return ~name:"unboxed_return" ()
+      in
+      let boxed_variable = Variable.create "boxed_result" in
+      let boxed_return_kind =
+        Flambda_kind.With_subkind.block Tag.zero kinds
+      in
+      let block_access_kind : P.Block_access_kind.t =
+        Values { tag = Known Tag.Scannable.zero;
+                 size = Known (Targetint_31_63.of_int (List.length kinds));
+                 field_kind = Any_value }
+      in
+      let handler_params =
+        Bound_parameters.create
+          [Bound_parameter.create boxed_variable boxed_return_kind]
+      in
+      let handler acc =
+        let field_variables =
+          List.mapi
+            (fun i _kind -> Variable.create ("field_" ^ (Int.to_string i)))
+            kinds
+        in
+        let acc, apply_cont =
+          Apply_cont_with_acc.create acc unboxed_return_continuation
+               ~args:(List.map Simple.var field_variables)
+               ~dbg:Debuginfo.none
+        in
+        let acc, apply_cont =
+          Expr_with_acc.create_apply_cont acc apply_cont
+        in
+        let ((acc, expr), _) =
+          List.fold_left (fun ((acc, expr), i) field_var ->
+              Let_with_acc.create acc
+                (Bound_pattern.singleton (Bound_var.create field_var Name_mode.normal))
+                (Named.create_prim
+                   (Flambda_primitive.Binary
+                      (Block_load (block_access_kind, Immutable),
+                       Simple.var boxed_variable,
+                       Simple.const_int i))
+                      Debuginfo.none)
+                ~body:expr,
+              Targetint_31_63.(add one i))
+            ((acc, apply_cont), Targetint_31_63.zero)
+            field_variables
+        in
+        acc, expr
+      in
+      let acc, unboxed_body =
+        Let_cont_with_acc.build_non_recursive acc return_continuation
+          ~handler_params ~handler ~body:compute_body ~is_exn_handler:false
+      in
+      let my_unboxed_closure = Variable.create "my_unboxed_closure" in
+      let acc, unboxed_body =
+        Let_with_acc.create acc (Bound_pattern.singleton (Bound_var.create my_closure Name_mode.normal))
+          (Named.create_prim
+             (Flambda_primitive.Unary
+                (Project_function_slot { move_from = unboxed_function_slot;
+                                         move_to = function_slot }, Simple.var my_unboxed_closure))
+             Debuginfo.none)
+          ~body:unboxed_body
+      in
+      acc, unboxed_body, unboxed_return_continuation, my_unboxed_closure
+  in
+  let contains_subfunctions = Acc.seen_a_function acc in
   let cost_metrics = Acc.cost_metrics acc in
   let inline : Inline_attribute.t =
     (* We make a decision based on [fallback_inlining_heuristic] here to try to
@@ -1380,39 +1452,19 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
       then Default_loopify_and_tailrec
       else Default_loopify_and_not_tailrec
   in
-  let open struct
-    type multi_return =
-      | Single_return
-      | Multiple_return of Flambda_arity.With_subkinds.t
-  end in
-  let return_kind = K.With_subkind.from_lambda return in
-  let should_unbox =
-    if Function_decl.is_a_functor decl then Single_return else
-    match K.With_subkind.subkind return_kind with
-    | Variant { consts; non_consts } ->
-      if Targetint_31_63.Set.is_empty consts then
-        match Tag.Scannable.Map.get_singleton non_consts with
-        | None -> Single_return
-        | Some (tag, arity) ->
-          if Tag.Scannable.equal tag Tag.Scannable.zero
-          then
-            Multiple_return (Flambda_arity.With_subkinds.create arity)
-          else Single_return
-      else Single_return
-    | Anything | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
-    | Tagged_immediate | Float_block _ | Float_array | Immediate_array | Value_array
-    | Generic_array -> Single_return
-  in
-  let result_arity =
-    match should_unbox with
-    | Single_return -> Flambda_arity.With_subkinds.create [return_kind]
-    | Multiple_return kinds -> kinds
+  let result_arity_main_code, main_code_id =
+    match return with
+    | Single_return kind ->
+      Flambda_arity.With_subkinds.create [K.With_subkind.from_lambda kind], code_id
+    | Multiple_return (kinds, _) ->
+      Flambda_arity.With_subkinds.create (List.map K.With_subkind.from_lambda kinds),
+      Code_id.rename code_id
   in
   let main_code =
-    Code.create code_id ~params_and_body
+    Code.create main_code_id ~params_and_body
       ~free_names_of_params_and_body:(Acc.free_names acc) ~params_arity
       ~num_trailing_local_params:(Function_decl.num_trailing_local_params decl)
-      ~result_arity
+      ~result_arity:result_arity_main_code
       ~result_types:Unknown
       ~contains_no_escaping_local_allocs:
         (Function_decl.contains_no_escaping_local_allocs decl)
@@ -1428,55 +1480,62 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
         (Function_params_and_body.is_my_closure_used params_and_body)
       ~inlining_decision ~absolute_history ~relative_history ~loopify
   in
-  let code, by_function_slot =
-    match should_unbox with
-    | Single_return -> main_code, by_function_slot
-    | Multiple_return kinds ->
-      let wrapper_name = (Function_slot.name function_slot) ^ "_unboxed" in
-      let comp_unit = Compilation_unit.get_current_exn () in
-      let wrapper_code_id = Code_id.create wrapper_name comp_unit in
-      let wrapper_function_slot = Function_slot.create comp_unit ~name:wrapper_name in
-      let wrapper_closure = Variable.create wrapper_name in
+  let code, by_function_slot, function_code_ids, acc =
+    match return with
+    | Single_return _ -> main_code, by_function_slot, function_code_ids, acc
+    | Multiple_return (kinds, unboxed_function_slot) ->
+      (* The outside caller gave us the function slot and code ID meant for
+         the boxed function, which will be a wrapper.
+         So in this branch everything starting with 'main_' refers to the
+         version with unboxed return. *)
+      let boxed_return_kind =
+        Flambda_kind.With_subkind.block Tag.zero (List.map Flambda_kind.With_subkind.from_lambda kinds)
+      in
+      let main_function_slot = unboxed_function_slot in
+      let main_name = Function_slot.name unboxed_function_slot in
+      let main_closure = Variable.create main_name in
       let return_continuation = Continuation.create () in
       let exn_continuation = Continuation.create () in
       let my_closure = Variable.create "my_closure" in
       let my_region = Variable.create "my_region" in
       let my_depth = Variable.create "my_depth" in
-      let body =
+      let body, free_names_of_body =
         let cont = Continuation.create () in
         let main_application =
-          Apply_expr.create ~callee:(Simple.var wrapper_closure) ~continuation:cont
+          Apply_expr.create ~callee:(Simple.var main_closure) ~continuation:(Return cont)
             (Exn_continuation.create ~exn_handler:exn_continuation ~extra_args:[])
             ~args:(Bound_parameters.simples params)
-            ~call_kind:(Call_kind.direct_function_call main_code ~return_arity:kinds
-                          Alloc_mode.For_types.unknown) Debuginfo.none
-            ~inlined:Inlined_attribute.default_inlined
+            ~call_kind:(Call_kind.direct_function_call main_code_id ~return_arity:result_arity_main_code
+                          (Alloc_mode.For_types.unknown ())) Debuginfo.none
+            ~inlined:Inlined_attribute.Default_inlined
             ~inlining_state:(Inlining_state.default ~round:0)
             ~probe_name:None
             ~position:Normal
-            ~relative_history:(Env.relative_history_from_scoped ~loc env)
+            ~relative_history:(Env.relative_history_from_scoped ~loc external_env)
             ~region:my_region
         in
-        let handler =
+        let handler, free_names_of_handler =
           let params =
             Bound_parameters.create
               (List.map (fun kind ->
                    let var = Variable.create "unboxed_return" in
                    Bound_parameter.create var kind)
-                  (Flambda_arity.With_subkinds.to_list kinds))
+                  (Flambda_arity.With_subkinds.to_list result_arity_main_code))
           in
           let handler, free_names_of_handler =
-            let block = Variable.create () in
+            let block = Variable.create "boxed_return" in
             let return_apply_cont =
               Apply_cont.create return_continuation ~args:[Simple.var block] ~dbg:Debuginfo.none
             in
             let make_block =
               Named.create_prim
                 (Flambda_primitive.Variadic
-                   (Make_block (Values, Immutable,
+                   (Make_block (Values (Tag.Scannable.zero,
+                                        Flambda_arity.With_subkinds.to_list result_arity_main_code),
+                                Immutable,
                                 if Function_decl.contains_no_escaping_local_allocs decl
                                 then Alloc_mode.For_allocations.heap
-                                else Alloc_mode.For_allocations.local my_region),
+                                else Alloc_mode.For_allocations.local ~region:my_region),
                     Bound_parameters.simples params))
                 Debuginfo.none
             in
@@ -1485,43 +1544,67 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
                  (Bound_pattern.singleton (Bound_var.create block Name_mode.normal))
                  make_block
                  ~body:(Expr.create_apply_cont return_apply_cont)
-                 ~free_names_of_body:(Apply_cont.free_names return_apply_cont)),
-            Name_occurrences.union (Named.free_names make_block)
-              (Name_occurrences.remove_var (Apply_cont.free_names return_apply_cont) ~var:block)
+                 ~free_names_of_body:(Known (Apply_cont.free_names return_apply_cont))),
+            (Name_occurrences.union (Named.free_names make_block)
+               (Name_occurrences.remove_var (Apply_cont.free_names return_apply_cont) ~var:block))
           in
-          Continuation_handler.create params ~handler ~free_names_of_handler
-            ~is_exn_handler:false
+          Continuation_handler.create params ~handler ~free_names_of_handler:(Known free_names_of_handler)
+            ~is_exn_handler:false,
+          List.fold_left (fun free_names param ->
+              Name_occurrences.remove_var free_names ~var:(Bound_parameter.var param))
+            free_names_of_handler (Bound_parameters.to_list params)
+        in
+        let projection =
+          Named.create_prim
+            (Flambda_primitive.Unary
+               (Project_function_slot { move_from = function_slot;
+                                        move_to = main_function_slot },
+                Simple.var my_closure))
+            Debuginfo.none
         in
         let body =
           Expr.create_let
             (Let_expr.create
-               (Bound_pattern.singleton (Bound_var.create wrapper_closure Name_mode.normal))
-               (Named.create_prim
-                  (Flambda_primitive.Unary (Project_function_slot { move_from: function_slot;
-                                                                    move_to: wrapper_function_slot },
-                                            Simple.var my_closure))
-                    Debuginfo.none)
+               (Bound_pattern.singleton (Bound_var.create main_closure Name_mode.normal))
+               projection
                ~body:(Expr.create_apply main_application)
-               ~free_names_of_body:(Apply_expr.free_names main_application))
+               ~free_names_of_body:(Known (Apply_expr.free_names main_application)))
         in
-        Let_cont_expr.create_non_recursive cont handler
-          ~body
-          ~free_names_of_body:(Name_occurrences.add_variable
+        let free_names_of_body =
+          Name_occurrences.union (Named.free_names projection)
+            (Name_occurrences.remove_var
+               (Apply_expr.free_names main_application)
+               ~var:main_closure)
+        in
+        Let_cont_expr.create_non_recursive cont handler ~body
+          ~free_names_of_body:(Known free_names_of_body),
+        Name_occurrences.union free_names_of_handler
+          (Name_occurrences.remove_continuation free_names_of_body ~continuation:cont)
       in
       let wrapper_params_and_body =
         Function_params_and_body.create
           ~return_continuation ~exn_continuation params ~body
-          ~free_names_of_body ~my_closure ~my_region ~my_depth
+          ~free_names_of_body:(Known free_names_of_body) ~my_closure ~my_region ~my_depth
+      in
+      let free_names_of_params_and_body =
+        Name_occurrences.remove_continuation ~continuation:return_continuation
+          (Name_occurrences.remove_continuation ~continuation:exn_continuation
+             (Name_occurrences.remove_var ~var:my_closure
+                (Name_occurrences.remove_var ~var:my_region
+                   (Name_occurrences.remove_var ~var:my_depth
+                      (List.fold_left (fun free_names param ->
+                           Name_occurrences.remove_var free_names ~var:(Bound_parameter.var param))
+                          free_names_of_body (Bound_parameters.to_list params))))))
       in
       let wrapper_code =
         Code.create code_id ~params_and_body:wrapper_params_and_body
       ~free_names_of_params_and_body ~params_arity
       ~num_trailing_local_params:(Function_decl.num_trailing_local_params decl)
-      ~result_arity:(Flambda_arity.With_subkinds.create [return_kind])
+      ~result_arity:(Flambda_arity.With_subkinds.create [boxed_return_kind])
       ~result_types:Unknown
       ~contains_no_escaping_local_allocs:
         (Function_decl.contains_no_escaping_local_allocs decl)
-      ~stub:true ~inline
+      ~stub:true ~inline:Inline_attribute.Default_inline
       ~poll_attribute:
         (Poll_attribute.from_lambda (Function_decl.poll_attribute decl))
       ~check:(Check_attribute.from_lambda (Function_decl.check_attribute decl))
@@ -1530,8 +1613,27 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
       ~inlining_arguments:(Inlining_arguments.create ~round:0)
       ~dbg ~is_tupled
       ~is_my_closure_used:true
-      ~inlining_decision ~absolute_history ~relative_history ~loopify
+      ~inlining_decision ~absolute_history ~relative_history ~loopify:Never_loopify
       in
+      let main_approx =
+        let code = Code_or_metadata.create main_code in
+        let meta = Code_or_metadata.remember_only_metadata code in
+        if Flambda_features.classic_mode ()
+        then (
+          Inlining_report.record_decision_at_function_definition ~absolute_history
+            ~code_metadata:(Code_or_metadata.code_metadata meta)
+            ~pass:After_closure_conversion
+            ~are_rebuilding_terms:(Are_rebuilding_terms.of_bool true)
+            inlining_decision;
+          if Function_decl_inlining_decision_type.must_be_inlined inlining_decision
+          then code
+          else meta)
+        else meta
+      in
+      wrapper_code,
+      Function_slot.Map.add main_function_slot main_approx by_function_slot,
+      Function_slot.Map.add main_function_slot main_code_id function_code_ids,
+      Acc.add_code ~code_id:main_code_id ~code:main_code acc
   in
   let approx =
     let code = Code_or_metadata.create code in
@@ -1550,7 +1652,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
   in
   let acc = Acc.add_code ~code_id ~code acc in
   let acc = Acc.with_seen_a_function acc true in
-  acc, Function_slot.Map.add function_slot approx by_function_slot
+  acc, (Function_slot.Map.add function_slot approx by_function_slot, function_code_ids)
 
 let close_functions acc external_env ~current_region function_declarations =
   let compilation_unit = Compilation_unit.get_current_exn () in
@@ -1628,7 +1730,13 @@ let close_functions acc external_env ~current_region function_declarations =
         in
         let return = Function_decl.return decl in
         let result_arity =
-          Flambda_arity.With_subkinds.create [K.With_subkind.from_lambda return]
+          match return with
+          | Single_return return ->
+            Flambda_arity.With_subkinds.create [K.With_subkind.from_lambda return]
+          | Multiple_return (kinds, _) ->
+            Flambda_arity.With_subkinds.create
+              [Flambda_kind.With_subkind.block
+                 Tag.zero (List.map K.With_subkind.from_lambda kinds)]
         in
         let poll_attribute =
           Poll_attribute.from_lambda (Function_decl.poll_attribute decl)
@@ -1693,23 +1801,23 @@ let close_functions acc external_env ~current_region function_declarations =
         (acc, external_env, Function_slot.Map.empty)
     else acc, external_env, Function_slot.Map.empty
   in
-  let acc, approximations =
+  let acc, (approximations, function_code_ids) =
     List.fold_left
-      (fun (acc, by_function_slot) function_decl ->
+      (fun (acc, (by_function_slot, function_code_ids)) function_decl ->
         let code_id =
           Function_slot.Map.find
             (Function_decl.function_slot function_decl)
             function_code_ids
         in
-        let _, _, acc, expr =
+        let _, _, acc, approxs_and_code_ids =
           Acc.measure_cost_metrics acc ~f:(fun acc ->
               close_one_function acc ~code_id ~external_env ~by_function_slot
-                function_decl ~has_lifted_closure:can_be_lifted
+                ~function_code_ids function_decl ~has_lifted_closure:can_be_lifted
                 ~value_slots_from_idents ~function_slots_from_idents ~approx_map
                 function_declarations)
         in
-        acc, expr)
-      (acc, Function_slot.Map.empty)
+        acc, approxs_and_code_ids)
+      (acc, (Function_slot.Map.empty, function_code_ids))
       func_decl_list
   in
   let acc = Acc.with_free_names Name_occurrences.empty acc in
@@ -1966,7 +2074,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
     (* CR keryan: Same as above, better kind for return type *)
     [ Function_decl.create ~let_rec_ident:(Some wrapper_id) ~function_slot
         ~kind:(Lambda.Curried { nlocal = num_trailing_local_params })
-        ~params ~return:Lambda.Pgenval ~return_continuation ~exn_continuation
+        ~params ~return:(Single_return Lambda.Pgenval) ~return_continuation ~exn_continuation
         ~my_region:apply.region ~body:fbody ~attr ~loc:apply.loc
         ~free_idents_of_body ~closure_alloc_mode ~num_trailing_local_params
         ~contains_no_escaping_local_allocs Recursive.Non_recursive ]

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -610,12 +610,16 @@ end
 
 module Function_decls = struct
   module Function_decl = struct
+    type return_kind =
+      | Single_return of Lambda.value_kind
+      | Multiple_return of Lambda.value_kind list * Function_slot.t
+
     type t =
       { let_rec_ident : Ident.t;
         function_slot : Function_slot.t;
         kind : Lambda.function_kind;
         params : (Ident.t * Lambda.value_kind) list;
-        return : Lambda.value_kind;
+        return : return_kind;
         return_continuation : Continuation.t;
         exn_continuation : IR.exn_continuation;
         my_region : Ident.t;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -611,8 +611,10 @@ end
 module Function_decls = struct
   module Function_decl = struct
     type return_kind =
-      | Single_return of Lambda.value_kind
+      | Normal_return of Lambda.value_kind
       | Multiple_return of Lambda.value_kind list * Function_slot.t
+      | Unboxed_float of Function_slot.t
+      | Unboxed_float_record of int * Function_slot.t
 
     type t =
       { let_rec_ident : Ident.t;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -284,6 +284,10 @@ end
     one declaration is when processing "let rec".) *)
 module Function_decls : sig
   module Function_decl : sig
+    type return_kind =
+      | Single_return of Lambda.value_kind
+      | Multiple_return of Lambda.value_kind list * Function_slot.t
+
     type t
 
     val create :
@@ -291,7 +295,7 @@ module Function_decls : sig
       function_slot:Function_slot.t ->
       kind:Lambda.function_kind ->
       params:(Ident.t * Lambda.value_kind) list ->
-      return:Lambda.value_kind ->
+      return:return_kind ->
       return_continuation:Continuation.t ->
       exn_continuation:IR.exn_continuation ->
       my_region:Ident.t ->
@@ -313,7 +317,7 @@ module Function_decls : sig
 
     val params : t -> (Ident.t * Lambda.value_kind) list
 
-    val return : t -> Lambda.value_kind
+    val return : t -> return_kind
 
     val return_continuation : t -> Continuation.t
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -285,8 +285,10 @@ end
 module Function_decls : sig
   module Function_decl : sig
     type return_kind =
-      | Single_return of Lambda.value_kind
+      | Normal_return of Lambda.value_kind
       | Multiple_return of Lambda.value_kind list * Function_slot.t
+      | Unboxed_float of Function_slot.t
+      | Unboxed_float_record of int * Function_slot.t
 
     type t
 

--- a/middle_end/flambda2/identifiers/continuation.ml
+++ b/middle_end/flambda2/identifiers/continuation.ml
@@ -114,9 +114,9 @@ let reset () = initialise ()
 
 let create ?sort ?name () : t =
   let sort = Option.value sort ~default:Sort.Normal_or_exn in
-  let name = Option.value name ~default:"k" in
-  let compilation_unit = Compilation_unit.get_current_exn () in
   let name_stamp = next_stamp () in
+  let name = Option.value name ~default:(Format.asprintf "k_%d" name_stamp) in
+  let compilation_unit = Compilation_unit.get_current_exn () in
   let data : Data.t = { compilation_unit; name; name_stamp; sort } in
   Table.add !grand_table_of_continuations data
 

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -272,13 +272,18 @@ module With_subkind = struct
       | Tagged_immediate
       | Variant of
           { consts : Targetint_31_63.Set.t;
-            non_consts : t list Tag.Scannable.Map.t
+            non_consts : kind_and_subkind list Tag.Scannable.Map.t
           }
       | Float_block of { num_fields : int }
       | Float_array
       | Immediate_array
       | Value_array
       | Generic_array
+
+    and kind_and_subkind =
+    { kind : kind;
+      subkind : t
+    }
 
     let rec compatible (t : t) ~(when_used_at : t) =
       match t, when_used_at with
@@ -313,7 +318,9 @@ module With_subkind = struct
                 then false
                 else
                   List.for_all2
-                    (fun d when_used_at -> compatible d ~when_used_at)
+                    (fun { kind = _; subkind = d }
+                      { kind = _; subkind = when_used_at } ->
+                      compatible d ~when_used_at)
                     fields1 fields2)
               field_lists1 field_lists2
       | ( Float_block { num_fields = num_fields1 },
@@ -361,11 +368,12 @@ module With_subkind = struct
           Format.fprintf ppf "%t=boxed_@<1>\u{2115}@<1>\u{2115}%t" colour
             Flambda_colours.pop
         | Variant { consts; non_consts } ->
+          let print_field ppf { kind = _; subkind } = print ppf subkind in
           Format.fprintf ppf "%t=Variant((consts (%a))@ (non_consts (%a)))%t"
             colour Targetint_31_63.Set.print consts
             (Tag.Scannable.Map.print (fun ppf fields ->
                  Format.fprintf ppf "[%a]"
-                   (Format.pp_print_list ~pp_sep:Format.pp_print_space print)
+                   (Format.pp_print_list ~pp_sep:Format.pp_print_space print_field)
                    fields))
             non_consts Flambda_colours.pop
         | Float_block { num_fields } ->
@@ -388,14 +396,11 @@ module With_subkind = struct
     end)
   end
 
-  type kind = t
+  type with_subkind = Subkind.kind_and_subkind
 
-  type t =
-    { kind : kind;
-      subkind : Subkind.t
-    }
+  type t = with_subkind
 
-  let create (kind : kind) (subkind : Subkind.t) =
+  let create (kind : kind) (subkind : Subkind.t) : t =
     (match kind with
     | Value -> ()
     | Naked_number _ | Region | Rec_info -> (
@@ -408,13 +413,13 @@ module With_subkind = struct
           subkind print kind));
     { kind; subkind }
 
-  let compatible t ~when_used_at =
+  let compatible (t: t) ~(when_used_at : t) =
     equal t.kind when_used_at.kind
     && Subkind.compatible t.subkind ~when_used_at:when_used_at.subkind
 
-  let kind t = t.kind
+  let kind (t : t) = t.kind
 
-  let subkind t = t.subkind
+  let subkind (t : t) = t.subkind
 
   let any_value = create value Anything
 
@@ -451,12 +456,11 @@ module With_subkind = struct
   let generic_array = create value Generic_array
 
   let block tag fields =
-    if List.exists (fun t -> not (equal t.kind Value)) fields
+    if List.exists (fun (t : t) -> not (equal t.kind Value)) fields
     then
       Misc.fatal_error
         "Block with fields of non-Value kind (use \
          [Flambda_kind.With_subkind.float_block] for float records)";
-    let fields = List.map (fun t -> t.subkind) fields in
     match Tag.Scannable.of_tag tag with
     | Some tag ->
       create value
@@ -502,7 +506,7 @@ module With_subkind = struct
               match Tag.Scannable.create tag with
               | Some tag ->
                 Tag.Scannable.Map.add tag
-                  (List.map (fun vk -> subkind (from_lambda vk)) fields)
+                  (List.map from_lambda fields)
                   non_consts
               | None ->
                 Misc.fatal_errorf "Non-scannable tag %d in [Pvariant]" tag)
@@ -517,7 +521,7 @@ module With_subkind = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf { kind; subkind } =
+    let print ppf ({ kind; subkind } : t) =
       match kind, subkind with
       | _, Anything -> print ppf kind
       | Value, subkind ->
@@ -529,17 +533,17 @@ module With_subkind = struct
         assert false
     (* see [create] *)
 
-    let compare { kind = kind1; subkind = subkind1 }
-        { kind = kind2; subkind = subkind2 } =
+    let compare ({ kind = kind1; subkind = subkind1 } : t)
+        ({ kind = kind2; subkind = subkind2 } : t) =
       let c = compare kind1 kind2 in
       if c <> 0 then c else Subkind.compare subkind1 subkind2
 
     let equal t1 t2 = compare t1 t2 = 0
 
-    let hash { kind; subkind } = Hashtbl.hash (hash kind, Subkind.hash subkind)
+    let hash ({ kind; subkind } : t) = Hashtbl.hash (hash kind, Subkind.hash subkind)
   end)
 
-  let has_useful_subkind_info t =
+  let has_useful_subkind_info (t : t) =
     match t.subkind with
     | Anything -> false
     | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
@@ -547,5 +551,5 @@ module With_subkind = struct
     | Immediate_array | Value_array | Generic_array ->
       true
 
-  let erase_subkind t = { t with subkind = Anything }
+  let erase_subkind (t : t) : t = { t with subkind = Anything }
 end

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -123,6 +123,8 @@ module Boxable_number : sig
 end
 
 module With_subkind : sig
+  type with_subkind
+
   module Subkind : sig
     type t =
       | Anything
@@ -133,7 +135,7 @@ module With_subkind : sig
       | Tagged_immediate
       | Variant of
           { consts : Targetint_31_63.Set.t;
-            non_consts : t list Tag.Scannable.Map.t
+            non_consts : with_subkind list Tag.Scannable.Map.t
           }
       | Float_block of { num_fields : int }
       | Float_array
@@ -144,9 +146,7 @@ module With_subkind : sig
     include Container_types.S with type t := t
   end
 
-  type kind = t
-
-  type t
+  type t = with_subkind
 
   val create : kind -> Subkind.t -> t
 

--- a/middle_end/flambda2/simplify/flow/flow.mli
+++ b/middle_end/flambda2/simplify/flow/flow.mli
@@ -82,6 +82,7 @@ module Acc : sig
   val add_apply_conts :
     result_cont:(Apply_cont_rewrite_id.t * Continuation.t) option ->
     exn_cont:Apply_cont_rewrite_id.t * Exn_continuation.t ->
+    result_arity:Flambda_arity.With_subkinds.t ->
     t ->
     t
 

--- a/middle_end/flambda2/simplify/flow/flow_acc.mli
+++ b/middle_end/flambda2/simplify/flow/flow_acc.mli
@@ -97,6 +97,7 @@ val add_used_in_current_handler : Name_occurrences.t -> t -> t
 val add_apply_conts :
   result_cont:(Apply_cont_rewrite_id.t * Continuation.t) option ->
   exn_cont:Apply_cont_rewrite_id.t * Exn_continuation.t ->
+  result_arity:Flambda_arity.With_subkinds.t ->
   t ->
   t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -184,6 +184,15 @@ let machtype_of_return_arity arity =
   | [] -> Cmm.typ_void
   (* Regular functions with a single return value *)
   | [k] -> machtype_of_kind k
-  | _ ->
-    (* CR gbury: update when unboxed tuples are used *)
-    Misc.fatal_errorf "Functions are currently limited to a single return value"
+  | arity ->
+    let machtypes = List.map machtype_of_kind arity in
+    let len = List.fold_left (fun acc mtype -> acc + Array.length mtype) 0 machtypes in
+    let res = Array.make len Cmm.Addr (* not used *) in
+    let _ =
+      List.fold_left (fun acc mtype ->
+          let len = Array.length mtype in
+          Array.blit mtype 0 res acc len;
+          acc + len)
+        0 machtypes
+    in
+    res

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -302,9 +302,7 @@ let rec unknown_with_subkind ?(alloc_mode = Alloc_mode.For_types.unknown ())
       Tag.Scannable.Map.map
         (fun fields ->
           List.map
-            (fun subkind ->
-              unknown_with_subkind
-                (Flambda_kind.With_subkind.create Flambda_kind.value subkind))
+            (fun subkind -> unknown_with_subkind subkind)
             fields)
         non_consts
     in

--- a/ocaml/utils/compilation_unit.ml
+++ b/ocaml/utils/compilation_unit.ml
@@ -138,14 +138,10 @@ end = struct
   end)
 
   let is_valid_character first_char c =
-    let code = Char.code c in
-    if first_char
-    then code >= 65 && code <= 90 (* [A-Z] *)
-    else
-      Char.equal c '_'
-      || (code >= 48 && 57 <= 90 (* [0-9] *))
-      || (code >= 65 && code <= 90 (* [A-Z] *))
-      || (code >= 97 && code <= 122 (* [a-z] *))
+    match c with
+    | 'A' .. 'Z' -> true
+    | '_' | '0' .. '9' | 'a' .. 'z' -> not first_char
+    | _ -> false
 
   let parse_for_pack pack =
     let prefix = String.split_on_char '.' pack in


### PR DESCRIPTION
Proof-of-concept PR for unboxed returns.
Functions returning tuple-like types get unboxed automatically by flambda 2, providing a few cases for testing the rest of the backend changes.

TODO: cleanup, extract independent parts.