### PR TITLE
Classic mode hacking for better lifting

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -69,6 +69,7 @@ let register_const0 acc constant name =
     let symbol =
       Symbol.create
         (Compilation_unit.get_current_exn ())
+        (* CR mshinwell: this Variable.rename looks to be redundant *)
         (Linkage_name.of_string (Variable.unique_name (Variable.rename var)))
     in
     let acc = Acc.add_declared_symbol ~symbol ~constant acc in
@@ -708,6 +709,11 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
   | Pmakeblock (tag, Immutable_unique, _, _), [exn_name; exn_id]
     when tag = Obj.object_tag && Env.at_toplevel env ->
     (* Special case to lift toplevel exception declarations *)
+    let symbol =
+      Symbol.create
+        (Compilation_unit.get_current_exn ())
+        (Linkage_name.of_string (Variable.unique_name let_bound_var))
+    in
     let transform_arg arg =
       Simple.pattern_match' arg
         ~var:(fun var ~coercion:_ ->
@@ -718,13 +724,23 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
             Reg_width_const.print const Printlambda.primitive prim
             Debuginfo.print_compact dbg)
     in
-    let acc, sym =
-      register_const0 acc
-        (Static_const.block Tag.Scannable.object_tag Immutable_unique
-           [transform_arg exn_name; transform_arg exn_id])
-        "exn"
+    (* This is an inconstant statically-allocated value, so cannot go through
+       [register_const0]. The definition must be placed right away. *)
+    let static_const =
+      Static_const.block Tag.Scannable.object_tag Immutable_unique
+        [transform_arg exn_name; transform_arg exn_id]
     in
-    k acc (Some (Named.create_simple (Simple.symbol sym)))
+    let static_consts =
+      [Static_const_or_code.create_static_const static_const]
+    in
+    let defining_expr =
+      Static_const_group.create static_consts |> Named.create_static_consts
+    in
+    let acc, body = k acc (Some (Named.create_simple (Simple.symbol symbol))) in
+    Let_with_acc.create acc
+      (Bound_pattern.static
+         (Bound_static.create [Bound_static.Pattern.block_like symbol]))
+      defining_expr ~body
   | prim, args ->
     Lambda_to_flambda_primitives.convert_and_bind acc exn_continuation
       ~big_endian:(Env.big_endian env)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -705,6 +705,26 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
         assert false
     in
     k acc (Some (Named.create_simple (Simple.symbol sym)))
+  | Pmakeblock (tag, Immutable_unique, _, _), [exn_name; exn_id]
+    when tag = Obj.object_tag && Env.at_toplevel env ->
+    (* Special case to lift toplevel exception declarations *)
+    let transform_arg arg =
+      Simple.pattern_match' arg
+        ~var:(fun var ~coercion:_ ->
+          Field_of_static_block.Dynamically_computed (var, dbg))
+        ~symbol:(fun sym ~coercion:_ -> Field_of_static_block.Symbol sym)
+        ~const:(fun const ->
+          Misc.fatal_errorf "Constant %a not expected as argument to %a (%a)"
+            Reg_width_const.print const Printlambda.primitive prim
+            Debuginfo.print_compact dbg)
+    in
+    let acc, sym =
+      register_const0 acc
+        (Static_const.block Tag.Scannable.object_tag Immutable_unique
+           [transform_arg exn_name; transform_arg exn_id])
+        "exn"
+    in
+    k acc (Some (Named.create_simple (Simple.symbol sym)))
   | prim, args ->
     Lambda_to_flambda_primitives.convert_and_bind acc exn_continuation
       ~big_endian:(Env.big_endian env)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -845,7 +845,8 @@ let close_let acc env id user_visible kind defining_expr
                 [exn_name; exn_id] ),
             _ )
         when Tag.Scannable.equal tag Tag.Scannable.object_tag
-             && Env.at_toplevel env ->
+             && Env.at_toplevel env
+             && Flambda_features.classic_mode () ->
         (* Special case to lift toplevel exception declarations *)
         let symbol =
           Symbol.create

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -775,75 +775,118 @@ let close_let acc env id user_visible kind defining_expr
          generated. *)
       body acc body_env
     | Some defining_expr -> (
-      let bound_pattern = Bound_pattern.singleton (VB.create var Name_mode.normal) in
+      let bound_pattern =
+        Bound_pattern.singleton (VB.create var Name_mode.normal)
+      in
       let bind acc env =
         (* CR pchambart: Not tail ! The body function is the recursion *)
         let acc, body = body acc env in
         Let_with_acc.create acc bound_pattern defining_expr ~body
       in
       match defining_expr with
-      | Prim (Variadic (Make_block (_, Immutable, alloc_mode), fields), _) ->
+      | Prim
+          ( Variadic
+              (Make_block (Values (tag, _), Immutable, alloc_mode), fields),
+            _ ) -> (
         let approxs =
           List.map
             (fun field ->
-               match Simple.must_be_symbol field with
-               | None -> find_value_approximation acc body_env field
-               | Some (sym, _) -> Value_approximation.Value_symbol sym)
+              match Simple.must_be_symbol field with
+              | None -> find_value_approximation acc body_env field
+              | Some (sym, _) -> Value_approximation.Value_symbol sym)
             fields
           |> Array.of_list
         in
-        let body_env =
-          Env.add_block_approximation body_env var approxs
-            (Alloc_mode.For_allocations.as_type alloc_mode)
+        let all_fields_static =
+          List.fold_left
+            (fun static_fields f ->
+              match static_fields with
+              | None -> None
+              | Some fields ->
+                Simple.pattern_match'
+                  ~const:(fun c ->
+                    match Reg_width_const.descr c with
+                    | Tagged_immediate imm ->
+                      Some (Field_of_static_block.Tagged_immediate imm :: fields)
+                    | _ -> None)
+                  ~symbol:(fun s ~coercion:_ ->
+                    Some (Field_of_static_block.Symbol s :: fields))
+                  ~var:(fun _v ~coercion:_ -> None)
+                  f)
+            (Some []) fields
+          |> Option.map List.rev
         in
-        bind acc body_env
+        match all_fields_static with
+        | Some static_fields ->
+          let acc, sym =
+            register_const0 acc
+              (Static_const.block tag Immutable static_fields)
+              (Ident.name id)
+          in
+          let body_env =
+            Env.add_simple_to_substitute body_env id (Simple.symbol sym) kind
+          in
+          let acc =
+            Acc.add_symbol_approximation acc sym
+              (Value_approximation.Block_approximation
+                 (approxs,Alloc_mode.For_allocations.as_type alloc_mode))
+          in
+          body acc body_env
+        | None ->
+          let body_env =
+            Env.add_block_approximation body_env var approxs
+              (Alloc_mode.For_allocations.as_type alloc_mode)
+          in
+          bind acc body_env)
       | Prim (Binary (Block_load _, block, field), _) -> (
-          match find_value_approximation acc body_env block with
-          | Value_unknown -> bind acc body_env
-          | Closure_approximation _ | Value_symbol _ | Value_int _ ->
-            (* Here we assume [block] has already been substituted as a known
-               symbol if it exists, and rely on the invariant that the
-               approximation of a symbol is never a symbol. *)
-            if Flambda_features.check_invariants ()
-            then
-              (* CR keryan: This is hidden behind invariants check because it
-                 can appear on correct code using Lazy or GADT. It might warrant
-                 a proper warning at some point. *)
-              Misc.fatal_errorf
-                "Unexpected approximation found when block approximation was \
-                 expected in [Closure_conversion]: %a"
-                Named.print defining_expr
-            else
-              ( acc,
-                Expr.create_invalid
-                  (Defining_expr_of_let (bound_pattern, defining_expr)) )
-          | Block_approximation (approx, _alloc_mode) -> (
-              let approx =
-                Simple.pattern_match field
-                  ~const:(fun const ->
-                      match Reg_width_const.descr const with
-                      | Tagged_immediate i ->
-                        let i = Targetint_31_63.to_int i in
-                        if i >= Array.length approx
-                        then
-                          Misc.fatal_errorf
-                            "Trying to access the %dth field of a block \
-                             approximation of length %d."
-                            i (Array.length approx);
-                        approx.(i)
-                      | _ -> Value_approximation.Value_unknown)
-                  ~name:(fun _ ~coercion:_ -> Value_approximation.Value_unknown)
-              in
-              match approx with
-              | Value_symbol sym ->
-                (* In spirit, this is the same as the simple case but more
-                   cumbersome to detect, we have to remove the now useless
-                   let-binding later. *)
-                let body_env = Env.add_simple_to_substitute env id (Simple.symbol sym) kind in
-                bind acc body_env
-              | _ ->
-                let body_env = Env.add_var_approximation body_env var approx in
-                bind acc body_env))
+        match find_value_approximation acc body_env block with
+        | Value_unknown -> bind acc body_env
+        | Closure_approximation _ | Value_symbol _ | Value_int _ ->
+          (* Here we assume [block] has already been substituted as a known
+             symbol if it exists, and rely on the invariant that the
+             approximation of a symbol is never a symbol. *)
+          if Flambda_features.check_invariants ()
+          then
+            (* CR keryan: This is hidden behind invariants check because it can
+               appear on correct code using Lazy or GADT. It might warrant a
+               proper warning at some point. *)
+            Misc.fatal_errorf
+              "Unexpected approximation found when block approximation was \
+               expected in [Closure_conversion]: %a"
+              Named.print defining_expr
+          else
+            ( acc,
+              Expr.create_invalid
+                (Defining_expr_of_let (bound_pattern, defining_expr)) )
+        | Block_approximation (approx, _alloc_mode) -> (
+          let approx =
+            Simple.pattern_match field
+              ~const:(fun const ->
+                match Reg_width_const.descr const with
+                | Tagged_immediate i ->
+                  let i = Targetint_31_63.to_int i in
+                  if i >= Array.length approx
+                  then
+                    Misc.fatal_errorf
+                      "Trying to access the %dth field of a block \
+                       approximation of length %d."
+                      i (Array.length approx);
+                  approx.(i)
+                | _ -> Value_approximation.Value_unknown)
+              ~name:(fun _ ~coercion:_ -> Value_approximation.Value_unknown)
+          in
+          match approx with
+          | Value_symbol sym ->
+            (* In spirit, this is the same as the simple case but more
+               cumbersome to detect, we have to remove the now useless
+               let-binding later. *)
+            let body_env =
+              Env.add_simple_to_substitute env id (Simple.symbol sym) kind
+            in
+            bind acc body_env
+          | _ ->
+            let body_env = Env.add_var_approximation body_env var approx in
+            bind acc body_env))
       | _ -> bind acc body_env)
   in
   close_named acc env ~let_bound_var:var defining_expr cont

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -706,41 +706,6 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
         assert false
     in
     k acc (Some (Named.create_simple (Simple.symbol sym)))
-  | Pmakeblock (tag, Immutable_unique, _, _), [exn_name; exn_id]
-    when tag = Obj.object_tag && Env.at_toplevel env ->
-    (* Special case to lift toplevel exception declarations *)
-    let symbol =
-      Symbol.create
-        (Compilation_unit.get_current_exn ())
-        (Linkage_name.of_string (Variable.unique_name let_bound_var))
-    in
-    let transform_arg arg =
-      Simple.pattern_match' arg
-        ~var:(fun var ~coercion:_ ->
-          Field_of_static_block.Dynamically_computed (var, dbg))
-        ~symbol:(fun sym ~coercion:_ -> Field_of_static_block.Symbol sym)
-        ~const:(fun const ->
-          Misc.fatal_errorf "Constant %a not expected as argument to %a (%a)"
-            Reg_width_const.print const Printlambda.primitive prim
-            Debuginfo.print_compact dbg)
-    in
-    (* This is an inconstant statically-allocated value, so cannot go through
-       [register_const0]. The definition must be placed right away. *)
-    let static_const =
-      Static_const.block Tag.Scannable.object_tag Immutable_unique
-        [transform_arg exn_name; transform_arg exn_id]
-    in
-    let static_consts =
-      [Static_const_or_code.create_static_const static_const]
-    in
-    let defining_expr =
-      Static_const_group.create static_consts |> Named.create_static_consts
-    in
-    let acc, body = k acc (Some (Named.create_simple (Simple.symbol symbol))) in
-    Let_with_acc.create acc
-      (Bound_pattern.static
-         (Bound_static.create [Bound_static.Pattern.block_like symbol]))
-      defining_expr ~body
   | prim, args ->
     Lambda_to_flambda_primitives.convert_and_bind acc exn_continuation
       ~big_endian:(Env.big_endian env)
@@ -874,6 +839,49 @@ let close_let acc env id user_visible kind defining_expr
               (Alloc_mode.For_allocations.as_type alloc_mode)
           in
           bind acc body_env)
+      | Prim
+          ( Variadic
+              ( Make_block (Values (tag, _), Immutable_unique, _alloc_mode),
+                [exn_name; exn_id] ),
+            _ )
+        when Tag.Scannable.equal tag Tag.Scannable.object_tag
+             && Env.at_toplevel env ->
+        (* Special case to lift toplevel exception declarations *)
+        let symbol =
+          Symbol.create
+            (Compilation_unit.get_current_exn ())
+            (Linkage_name.of_string (Variable.unique_name var))
+        in
+        let transform_arg arg =
+          Simple.pattern_match' arg
+            ~var:(fun var ~coercion:_ ->
+              Field_of_static_block.Dynamically_computed (var, Debuginfo.none))
+            ~symbol:(fun sym ~coercion:_ -> Field_of_static_block.Symbol sym)
+            ~const:(fun const ->
+              Misc.fatal_errorf "Constant %a not expected as argument in %a"
+                Reg_width_const.print const Named.print defining_expr)
+        in
+        (* This is an inconstant statically-allocated value, so cannot go
+           through [register_const0]. The definition must be placed right
+           away. *)
+        let static_const =
+          Static_const.block Tag.Scannable.object_tag Immutable_unique
+            [transform_arg exn_name; transform_arg exn_id]
+        in
+        let static_consts =
+          [Static_const_or_code.create_static_const static_const]
+        in
+        let defining_expr =
+          Static_const_group.create static_consts |> Named.create_static_consts
+        in
+        let body_env =
+          Env.add_simple_to_substitute body_env id (Simple.symbol symbol) kind
+        in
+        let acc, body = body acc body_env in
+        Let_with_acc.create acc
+          (Bound_pattern.static
+             (Bound_static.create [Bound_static.Pattern.block_like symbol]))
+          defining_expr ~body
       | Prim (Binary (Block_load _, block, field), _) -> (
         match find_value_approximation_through_symbol acc body_env block with
         | Value_unknown -> bind acc body_env

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -32,6 +32,8 @@ module K = Flambda_kind
 module P = Flambda_primitive
 module VB = Bound_var
 
+let inconstant_approxs = ref []
+
 type 'a close_program_metadata =
   | Normal : [`Normal] close_program_metadata
   | Classic :
@@ -766,6 +768,38 @@ let close_named acc env ~let_bound_var (named : IR.named)
       ~current_region:(fst (Env.find_var env region))
       k
 
+type simplified_block_load =
+  | Unknown
+  | Not_a_block
+  | Block_but_cannot_simplify of Code_or_metadata.t Value_approximation.t
+  | Field_contents of Symbol.t
+
+let simplify_block_load acc body_env ~block ~field : simplified_block_load =
+  match find_value_approximation_through_symbol acc body_env block with
+  | Value_unknown -> Unknown
+  | Closure_approximation _ | Value_symbol _ | Value_int _ -> Not_a_block
+  | Block_approximation (approx, _alloc_mode) -> (
+    (* Format.eprintf "...block approx found\n%!"; *)
+    let approx =
+      Simple.pattern_match field
+        ~const:(fun const ->
+          match Reg_width_const.descr const with
+          | Tagged_immediate i ->
+            let i = Targetint_31_63.to_int i in
+            if i >= Array.length approx
+            then
+              Misc.fatal_errorf
+                "Trying to access the %dth field of a block approximation of \
+                 length %d."
+                i (Array.length approx);
+            approx.(i)
+          | _ -> Value_approximation.Value_unknown)
+        ~name:(fun _ ~coercion:_ -> Value_approximation.Value_unknown)
+    in
+    match approx with
+    | Value_symbol sym -> Field_contents sym
+    | _ -> Block_but_cannot_simplify approx)
+
 let close_let acc env id user_visible kind defining_expr
     ~(body : Acc.t -> Env.t -> Expr_with_acc.t) : Expr_with_acc.t =
   let body_env, var = Env.add_var_like env id user_visible kind in
@@ -798,6 +832,9 @@ let close_let acc env id user_visible kind defining_expr
         let approxs =
           List.map (find_value_approximation body_env) fields |> Array.of_list
         in
+        let is_local =
+          match alloc_mode with Local _ -> true | Heap -> false
+        in
         let all_fields_static =
           List.fold_left
             (fun static_fields f ->
@@ -812,27 +849,76 @@ let close_let acc env id user_visible kind defining_expr
                     | _ -> None)
                   ~symbol:(fun s ~coercion:_ ->
                     Some (Field_of_static_block.Symbol s :: fields))
-                  ~var:(fun _v ~coercion:_ -> None)
+                  ~var:(fun v ~coercion:_ ->
+                    if Env.at_toplevel env
+                       && Flambda_features.classic_mode ()
+                       && not is_local
+                    then
+                      Some
+                        (Field_of_static_block.Dynamically_computed
+                           (v, Debuginfo.none)
+                        :: fields)
+                    else None)
                   f)
             (Some []) fields
           |> Option.map List.rev
         in
         match all_fields_static with
         | Some static_fields ->
-          let acc, sym =
-            register_const0 acc
-              (Static_const.block tag Immutable static_fields)
-              (Ident.name id)
-          in
-          let body_env =
-            Env.add_simple_to_substitute body_env id (Simple.symbol sym) kind
-          in
-          let acc =
-            Acc.add_symbol_approximation acc sym
-              (Value_approximation.Block_approximation
-                 (approxs, Alloc_mode.For_allocations.as_type alloc_mode))
-          in
-          body acc body_env
+          if (not (Flambda_features.classic_mode ()))
+             || not (Env.at_toplevel env)
+          then
+            let acc, sym =
+              register_const0 acc
+                (Static_const.block tag Immutable static_fields)
+                (Ident.name id)
+            in
+            let body_env =
+              Env.add_simple_to_substitute body_env id (Simple.symbol sym) kind
+            in
+            let acc =
+              Acc.add_symbol_approximation acc sym
+                (Value_approximation.Block_approximation
+                   (approxs, Alloc_mode.For_allocations.as_type alloc_mode))
+            in
+            body acc body_env
+          else
+            (* This is a possibly-inconstant statically-allocated value, so
+               cannot go through [register_const0]. The definition must be
+               placed right away. *)
+            let symbol =
+              Symbol.create
+                (Compilation_unit.get_current_exn ())
+                (Linkage_name.of_string (Variable.unique_name var))
+            in
+            let static_const = Static_const.block tag Immutable static_fields in
+            let static_consts =
+              [Static_const_or_code.create_static_const static_const]
+            in
+            let defining_expr =
+              Static_const_group.create static_consts
+              |> Named.create_static_consts
+            in
+            let body_env =
+              Env.add_simple_to_substitute body_env id (Simple.symbol symbol)
+                kind
+            in
+            let approx =
+              Value_approximation.Block_approximation
+                (approxs, Alloc_mode.For_allocations.as_type alloc_mode)
+            in
+            let acc = Acc.add_symbol_approximation acc symbol approx in
+            inconstant_approxs := (symbol, approx) :: !inconstant_approxs;
+            (* unsure this is needed let body_env = Env.add_block_approximation
+               body_env var approxs (Alloc_mode.For_allocations.as_type
+               alloc_mode) in *)
+            (* let () = Format.eprintf "symbol %a approx: %a\n%!" Symbol.print
+               symbol Value_approximation.print approx in *)
+            let acc, body = body acc body_env in
+            Let_with_acc.create acc
+              (Bound_pattern.static
+                 (Bound_static.create [Bound_static.Pattern.block_like symbol]))
+              defining_expr ~body
         | None ->
           let body_env =
             Env.add_block_approximation body_env var approxs
@@ -878,15 +964,17 @@ let close_let acc env id user_visible kind defining_expr
         let body_env =
           Env.add_simple_to_substitute body_env id (Simple.symbol symbol) kind
         in
+        inconstant_approxs
+          := (symbol, Value_approximation.Value_unknown) :: !inconstant_approxs;
         let acc, body = body acc body_env in
         Let_with_acc.create acc
           (Bound_pattern.static
              (Bound_static.create [Bound_static.Pattern.block_like symbol]))
           defining_expr ~body
       | Prim (Binary (Block_load _, block, field), _) -> (
-        match find_value_approximation_through_symbol acc body_env block with
-        | Value_unknown -> bind acc body_env
-        | Closure_approximation _ | Value_symbol _ | Value_int _ ->
+        match simplify_block_load acc body_env ~block ~field with
+        | Unknown -> bind acc body_env
+        | Not_a_block ->
           (* Here we assume [block] has already been substituted as a known
              symbol if it exists, and rely on the invariant that the
              approximation of a symbol is never a symbol. *)
@@ -903,32 +991,14 @@ let close_let acc env id user_visible kind defining_expr
             ( acc,
               Expr.create_invalid
                 (Defining_expr_of_let (bound_pattern, defining_expr)) )
-        | Block_approximation (approx, _alloc_mode) -> (
-          let approx =
-            Simple.pattern_match field
-              ~const:(fun const ->
-                match Reg_width_const.descr const with
-                | Tagged_immediate i ->
-                  let i = Targetint_31_63.to_int i in
-                  if i >= Array.length approx
-                  then
-                    Misc.fatal_errorf
-                      "Trying to access the %dth field of a block \
-                       approximation of length %d."
-                      i (Array.length approx);
-                  approx.(i)
-                | _ -> Value_approximation.Value_unknown)
-              ~name:(fun _ ~coercion:_ -> Value_approximation.Value_unknown)
+        | Field_contents sym ->
+          let body_env =
+            Env.add_simple_to_substitute env id (Simple.symbol sym) kind
           in
-          match approx with
-          | Value_symbol sym ->
-            let body_env =
-              Env.add_simple_to_substitute env id (Simple.symbol sym) kind
-            in
-            body acc body_env
-          | _ ->
-            let body_env = Env.add_var_approximation body_env var approx in
-            bind acc body_env))
+          body acc body_env
+        | Block_but_cannot_simplify approx ->
+          let body_env = Env.add_var_approximation body_env var approx in
+          bind acc body_env)
       | _ -> bind acc body_env)
   in
   close_named acc env ~let_bound_var:var defining_expr cont
@@ -2263,6 +2333,15 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode) ~big_endian
   let slot_offsets = Slot_offsets.empty in
   let acc = Acc.create ~slot_offsets ~cmx_loader in
   let load_fields_body acc =
+    let env =
+      match Acc.continuation_known_arguments ~cont:prog_return_cont acc with
+      | Some [approx] ->
+        (* Format.eprintf "got approx for prog_return_cont\n%!"; *)
+        Env.add_var_approximation env module_block_var approx
+      | None | Some ([] | _ :: _) ->
+        (* Format.eprintf "no approx for prog_return_cont\n%!"; *)
+        env
+    in
     let field_vars =
       List.init module_block_size_in_words (fun pos ->
           let pos_str = string_of_int pos in
@@ -2309,16 +2388,25 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode) ~big_endian
     List.fold_left
       (fun (acc, body) (pos, var) ->
         let var = VB.create var Name_mode.normal in
+        let pat = Bound_pattern.singleton var in
         let pos = Targetint_31_63.of_int pos in
-        let named =
-          Named.create_prim
-            (Binary
-               ( Block_load (block_access, Immutable),
-                 Simple.var module_block_var,
-                 Simple.const (Reg_width_const.tagged_immediate pos) ))
-            Debuginfo.none
-        in
-        Let_with_acc.create acc (Bound_pattern.singleton var) named ~body)
+        let block = Simple.var module_block_var in
+        let field = Simple.const (Reg_width_const.tagged_immediate pos) in
+        (* Format.eprintf "module block field: block=%a, field=%a ... "
+           Simple.print block Simple.print field; *)
+        match simplify_block_load acc env ~block ~field with
+        | Unknown | Not_a_block | Block_but_cannot_simplify _ ->
+          (* Format.eprintf "unknown\n%!"; *)
+          let named =
+            Named.create_prim
+              (Binary (Block_load (block_access, Immutable), block, field))
+              Debuginfo.none
+          in
+          Let_with_acc.create acc pat named ~body
+        | Field_contents sym ->
+          (* Format.eprintf "contents %a\n%!" Symbol.print sym; *)
+          let named = Named.create_simple (Simple.symbol sym) in
+          Let_with_acc.create acc pat named ~body)
       (acc, body) (List.rev field_vars)
   in
   let load_fields_handler_param =
@@ -2373,6 +2461,11 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode) ~big_endian
           Symbol.Map.add symbol Value_approximation.Value_unknown sa)
         (Symbol.Map.singleton module_symbol module_block_approximation)
         (Acc.declared_symbols acc)
+    in
+    let symbol_approxs =
+      List.fold_left
+        (fun sa (symbol, approx) -> Symbol.Map.add symbol approx sa)
+        symbol_approxs !inconstant_approxs
     in
     List.fold_left
       (fun sa (closure_map, _) ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -141,7 +141,8 @@ module Env = struct
       value_approximations : value_approximation Variable.Map.t;
       big_endian : bool;
       path_to_root : Debuginfo.Scoped_location.t;
-      inlining_history_tracker : Inlining_history.Tracker.t
+      inlining_history_tracker : Inlining_history.Tracker.t;
+      at_toplevel : bool
     }
 
   let current_unit t = t.current_unit
@@ -160,8 +161,13 @@ module Env = struct
       value_approximations = Variable.Map.empty;
       big_endian;
       path_to_root = Debuginfo.Scoped_location.Loc_unknown;
-      inlining_history_tracker = Inlining_history.Tracker.empty current_unit
+      inlining_history_tracker = Inlining_history.Tracker.empty current_unit;
+      at_toplevel = true
     }
+
+  let set_not_at_toplevel t = { t with at_toplevel = false }
+
+  let at_toplevel t = t.at_toplevel
 
   let clear_local_bindings
       { variables = _;
@@ -172,7 +178,8 @@ module Env = struct
         value_approximations;
         big_endian;
         path_to_root;
-        inlining_history_tracker
+        inlining_history_tracker;
+        at_toplevel
       } =
     let simples_to_substitute =
       Ident.Map.filter
@@ -187,7 +194,8 @@ module Env = struct
       value_approximations;
       big_endian;
       path_to_root;
-      inlining_history_tracker
+      inlining_history_tracker;
+      at_toplevel
     }
 
   let with_depth t depth_var = { t with current_depth = Some depth_var }

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -358,49 +358,57 @@ module Acc = struct
     fun symbol ->
       match Symbol.Map.find symbol !externals with
       | approx -> approx
-      | exception Not_found ->
-        let approx = Flambda_cmx.load_symbol_approx loader symbol in
-        (if Flambda_features.check_invariants ()
-        then
-          match approx with
-          | Value_symbol sym ->
-            Misc.fatal_errorf
-              "Closure_conversion: approximation loader returned a Symbol \
-               approximation (%a) for symbol %a"
-              Symbol.print sym Symbol.print symbol
-          | Value_unknown | Value_int _ | Closure_approximation _
-          | Block_approximation _ ->
-            ());
-        let rec filter_inlinable approx =
-          match (approx : Env.value_approximation) with
-          | Value_unknown | Value_symbol _ | Value_int _ -> approx
-          | Block_approximation (approxs, alloc_mode) ->
-            let approxs = Array.map filter_inlinable approxs in
-            Value_approximation.Block_approximation (approxs, alloc_mode)
-          | Closure_approximation { code_id; function_slot; code; _ } -> (
-            let metadata = Code_or_metadata.code_metadata code in
-            if not (Code_or_metadata.code_present code)
-            then approx
-            else
-              match
-                Inlining.definition_inlining_decision
-                  (Code_metadata.inline metadata)
-                  (Code_metadata.cost_metrics metadata)
-              with
-              | Attribute_inline | Small_function _ -> approx
-              | Not_yet_decided | Never_inline_attribute | Stub | Recursive
-              | Function_body_too_large _ | Speculatively_inlinable _
-              | Functor _ ->
-                Value_approximation.Closure_approximation
-                  { code_id;
-                    function_slot;
-                    code = Code_or_metadata.create_metadata_only metadata;
-                    symbol = None
-                  })
+      | exception Not_found -> (
+        let approx =
+          try Some (Flambda_cmx.load_symbol_approx loader symbol)
+          with _exn -> None
+          (* Misc.fatal_error (Format.asprintf "load_symbol_approx for %a
+             failed: %s" Symbol.print symbol (Printexc.to_string exn)) *)
         in
-        let approx = filter_inlinable approx in
-        externals := Symbol.Map.add symbol approx !externals;
-        approx
+        match approx with
+        | None -> Value_approximation.Value_unknown
+        | Some approx ->
+          (if Flambda_features.check_invariants ()
+          then
+            match approx with
+            | Value_symbol sym ->
+              Misc.fatal_errorf
+                "Closure_conversion: approximation loader returned a Symbol \
+                 approximation (%a) for symbol %a"
+                Symbol.print sym Symbol.print symbol
+            | Value_unknown | Value_int _ | Closure_approximation _
+            | Block_approximation _ ->
+              ());
+          let rec filter_inlinable approx =
+            match (approx : Env.value_approximation) with
+            | Value_unknown | Value_symbol _ | Value_int _ -> approx
+            | Block_approximation (approxs, alloc_mode) ->
+              let approxs = Array.map filter_inlinable approxs in
+              Value_approximation.Block_approximation (approxs, alloc_mode)
+            | Closure_approximation { code_id; function_slot; code; _ } -> (
+              let metadata = Code_or_metadata.code_metadata code in
+              if not (Code_or_metadata.code_present code)
+              then approx
+              else
+                match
+                  Inlining.definition_inlining_decision
+                    (Code_metadata.inline metadata)
+                    (Code_metadata.cost_metrics metadata)
+                with
+                | Attribute_inline | Small_function _ -> approx
+                | Not_yet_decided | Never_inline_attribute | Stub | Recursive
+                | Function_body_too_large _ | Speculatively_inlinable _
+                | Functor _ ->
+                  Value_approximation.Closure_approximation
+                    { code_id;
+                      function_slot;
+                      code = Code_or_metadata.create_metadata_only metadata;
+                      symbol = None
+                    })
+          in
+          let approx = filter_inlinable approx in
+          externals := Symbol.Map.add symbol approx !externals;
+          approx)
 
   let create ~slot_offsets ~cmx_loader =
     { declared_symbols = [];

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -101,7 +101,12 @@ module Env : sig
 
   type t
 
+  (** Create an environment marked as being at toplevel. *)
   val create : big_endian:bool -> t
+
+  val set_not_at_toplevel : t -> t
+
+  val at_toplevel : t -> bool
 
   val clear_local_bindings : t -> t
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1253,10 +1253,12 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
           ~condition_dbg:(Debuginfo.from_location loc)
           ~scrutinee k k_exn)
   | Lstringswitch (scrutinee, cases, default, loc, kind) ->
+    let ccenv = CCenv.set_not_at_toplevel ccenv in
     cps acc env ccenv
       (Matching.expand_stringswitch loc kind scrutinee cases default)
       k k_exn
   | Lstaticraise (static_exn, args) ->
+    let ccenv = CCenv.set_not_at_toplevel ccenv in
     let continuation = Env.get_static_exn_continuation env static_exn in
     cps_non_tail_list acc env ccenv args
       (fun acc env ccenv args ->
@@ -1268,6 +1270,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         compile_staticfail acc env ccenv ~continuation ~args:(args @ extra_args))
       k_exn
   | Lstaticcatch (body, (static_exn, args), handler, layout) ->
+    let ccenv = CCenv.set_not_at_toplevel ccenv in
     maybe_insert_let_cont "staticcatch_result" layout k acc env ccenv
       (fun acc env ccenv k ->
         let continuation = Continuation.create () in
@@ -1344,6 +1347,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
        [Begin_region] with its parent region. This use of the parent region will
        ensure that the parent does not get deleted unless the try region is
        unused. *)
+    let ccenv = CCenv.set_not_at_toplevel ccenv in
     CC.close_let acc ccenv region Not_user_visible
       Flambda_kind.With_subkind.region
       (Begin_region { try_region_parent = Some (Env.current_region env) })
@@ -1389,6 +1393,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
   | Lwhile
       { wh_cond = cond; wh_body = body; wh_cond_region = _; wh_body_region = _ }
     ->
+    let ccenv = CCenv.set_not_at_toplevel ccenv in
     (* CR-someday mshinwell: make use of wh_cond_region / wh_body_region? *)
     let env, loop = rec_catch_for_while_loop env cond body in
     cps acc env ccenv loop k k_exn
@@ -1400,6 +1405,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         for_body = body;
         for_region = _
       } ->
+    let ccenv = CCenv.set_not_at_toplevel ccenv in
     let env, loop = rec_catch_for_for_loop env ident start stop dir body in
     cps acc env ccenv loop k k_exn
   | Lassign (being_assigned, new_value) ->
@@ -1648,6 +1654,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
   in
   let body acc ccenv =
     let ccenv = CCenv.set_path_to_root ccenv loc in
+    let ccenv = CCenv.set_not_at_toplevel ccenv in
     cps_tail acc new_env ccenv body body_cont body_exn_cont
   in
   let params =
@@ -1735,6 +1742,7 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
   cps_non_tail_var "scrutinee" acc env ccenv scrutinee
     Flambda_kind.With_subkind.any_value
     (fun acc env ccenv scrutinee ->
+      let ccenv = CCenv.set_not_at_toplevel ccenv in
       let consts_rev, wrappers = convert_arms_rev env switch.sw_consts [] in
       let blocks_rev, wrappers =
         convert_arms_rev env (List.combine block_nums sw_blocks) wrappers
@@ -1825,9 +1833,9 @@ let lambda_to_flambda ~mode ~big_endian ~cmx_loader ~compilation_unit
     Env.create ~current_unit:compilation_unit ~return_continuation
       ~exn_continuation ~my_region:toplevel_my_region
   in
-  let toplevel acc ccenv =
+  let program acc ccenv =
     cps_tail acc env ccenv lam return_continuation exn_continuation
   in
   CC.close_program ~mode ~big_endian ~cmx_loader ~compilation_unit
-    ~module_block_size_in_words ~program:toplevel
-    ~prog_return_cont:return_continuation ~exn_continuation ~toplevel_my_region
+    ~module_block_size_in_words ~program ~prog_return_cont:return_continuation
+    ~exn_continuation ~toplevel_my_region

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -500,7 +500,7 @@ let init_or_assign env (ia : Flambda_primitive.Init_or_assign.t) :
 let nullop _env (op : Flambda_primitive.nullary_primitive) : Fexpr.nullop =
   match op with
   | Begin_region -> Begin_region
-  | Invalid _ | Optimised_out _ | Probe_is_enabled _ ->
+  | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _ ->
     Misc.fatal_errorf "TODO: Nullary primitive: %a" Flambda_primitive.print
       (Flambda_primitive.Nullary op)
 

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -40,3 +40,12 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     let ty = T.any_region in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
+  | Enter_inlined_apply { dbg } ->
+    let dacc =
+      DA.map_denv dacc ~f:(fun denv ->
+          DE.set_inlined_debuginfo denv (DE.add_inlined_debuginfo denv dbg))
+    in
+    let named = Named.create_simple Simple.const_unit in
+    let ty = T.this_tagged_immediate Targetint_31_63.zero in
+    let dacc = DA.add_variable dacc result_var ty in
+    Simplify_primitive_result.create named ~try_reify:false dacc

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -309,6 +309,7 @@ let nullary_prim_size prim =
   | Optimised_out _ -> 0
   | Probe_is_enabled { name = _ } -> 4
   | Begin_region -> 1
+  | Enter_inlined_apply _ -> 0
 
 let unary_prim_size prim =
   match (prim : Flambda_primitive.unary_primitive) with

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -208,6 +208,9 @@ type nullary_primitive =
       (** Starting delimiter of local allocation region, returning a region
           name. For regions for the "try" part of a "try...with", use
           [Begin_try_region] (below) instead. *)
+  | Enter_inlined_apply of { dbg : Debuginfo.t }
+      (** Used in classic mode to denote the start of an inlined function body.
+          This is then used in to_cmm to correctly add inlined debuginfo. *)
 
 (** Untagged binary integer arithmetic operations.
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -93,6 +93,19 @@ val enter_function_body :
   exn_continuation:Continuation.t ->
   t
 
+(** {2 Debuginfo} *)
+
+(** Add the inlined debuginfo from the env to the debuginfo provided,
+    in order to get the correct debuginfo to attach. *)
+val add_inlined_debuginfo : t -> Debuginfo.t -> Debuginfo.t
+
+(** Adjust the inlined debuginfo in the env to represent the fact
+    that we entered the inlined body of a function. *)
+val enter_inlined_apply : t -> Debuginfo.t -> t
+
+(** Set the inlined debuginfo. *)
+val set_inlined_debuginfo : t -> Debuginfo.t -> t
+
 (** {2 Continuations} *)
 
 (** Returns the return continuation of the environment. *)
@@ -286,7 +299,8 @@ type cont = private
   | Inline of
       { handler_params : Bound_parameters.t;
         handler_params_occurrences : Num_occurrences.t Variable.Map.t;
-        handler_body : Flambda.Expr.t
+        handler_body : Flambda.Expr.t;
+        handler_body_inlined_debuginfo : Debuginfo.t
       }
 
 (** Record that the given continuation should be compiled to a jump, creating a

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -33,7 +33,8 @@ end
 
 (* Bind a Cmm variable to the result of translating a [Simple] into Cmm. *)
 
-let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
+let bind_var_to_simple ~dbg_with_inlined:dbg env res v
+    ~num_normal_occurrences_of_bound_vars s =
   match Simple.must_be_var s with
   | Some (alias_of, _coercion) ->
     Env.add_alias env res ~var:v ~num_normal_occurrences_of_bound_vars ~alias_of
@@ -58,10 +59,9 @@ let bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s =
 
 (* Helpers for the translation of [Apply] expressions. *)
 
-let translate_apply0 env res apply =
+let translate_apply0 ~dbg_with_inlined:dbg env res apply =
   let callee_simple = Apply.callee apply in
   let args = Apply.args apply in
-  let dbg = Apply.dbg apply in
   (* CR mshinwell: When we fix the problem that [prim_effects] and
      [prim_coeffects] are ignored for C calls, we need to take into account the
      effects/coeffects values currently ignored on the following two lines. At
@@ -221,8 +221,10 @@ let translate_apply0 env res apply =
 (* CR mshinwell: Add first-class support in Cmm for the concept of an exception
    handler with extra arguments. *)
 let translate_apply env res apply =
-  let call, free_vars, env, res, effs = translate_apply0 env res apply in
-  let dbg = Apply.dbg apply in
+  let dbg = Env.add_inlined_debuginfo env (Apply.dbg apply) in
+  let call, free_vars, env, res, effs =
+    translate_apply0 ~dbg_with_inlined:dbg env res apply
+  in
   let k_exn = Apply.exn_continuation apply in
   let mut_vars =
     Exn_continuation.exn_handler k_exn |> Env.get_exn_extra_args env
@@ -261,7 +263,7 @@ let translate_apply env res apply =
 (* Exception continuations always receive the exception value in their first
    argument. Additionally, they may have extra arguments that are passed to the
    handler via mutable variables (expected to be spilled to the stack). *)
-let translate_raise env res apply exn_handler args =
+let translate_raise ~dbg_with_inlined:dbg env res apply exn_handler args =
   match args with
   | exn :: extra ->
     let raise_kind =
@@ -273,7 +275,6 @@ let translate_raise env res apply exn_handler args =
           "Apply_cont calls an exception handler without a Pop trap action:@ %a"
           Apply_cont.print apply
     in
-    let dbg = Apply_cont.debuginfo apply in
     let To_cmm_env.
           { env;
             res;
@@ -299,7 +300,8 @@ let translate_raise env res apply exn_handler args =
     Misc.fatal_errorf "Exception continuation %a has no arguments:@ \n%a"
       Continuation.print exn_handler Apply_cont.print apply
 
-let translate_jump_to_continuation env res apply types cont args =
+let translate_jump_to_continuation ~dbg_with_inlined:dbg env res apply types
+    cont args =
   if List.compare_lengths types args = 0
   then
     let trap_actions =
@@ -310,7 +312,6 @@ let translate_jump_to_continuation env res apply types cont args =
         let cont = Env.get_cmm_continuation env exn_handler in
         [Cmm.Push cont]
     in
-    let dbg = Apply_cont.debuginfo apply in
     let args, free_vars, env, res, _ = C.simple_list ~dbg env res args in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     let cmm, free_vars = wrap (C.cexit cont args trap_actions) free_vars in
@@ -322,10 +323,10 @@ let translate_jump_to_continuation env res apply types cont args =
 
 (* A call to the return continuation of the current block simply is the return
    value for the current block being translated. *)
-let translate_jump_to_return_continuation env res apply return_cont args =
+let translate_jump_to_return_continuation ~dbg_with_inlined:dbg env res apply
+    return_cont args =
   match args with
   | [return_value] -> (
-    let dbg = Apply_cont.debuginfo apply in
     let To_cmm_env.
           { env; res; expr = { cmm = return_value; free_vars; effs = _ } } =
       C.simple ~dbg env res return_value
@@ -373,6 +374,7 @@ let rec expr env res e : Cmm.expression * Backend_var.Set.t * To_cmm_result.t =
   | Invalid { message } -> invalid env res ~message
 
 and let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body =
+  let dbg = Env.add_inlined_debuginfo env dbg in
   let v = Bound_var.var v in
   let effects_and_coeffects_of_prim =
     Flambda_primitive.effects_and_coeffects p
@@ -422,14 +424,20 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
     let v = Bound_var.var v in
     (* CR mshinwell: Try to get a proper [dbg] here (although the majority of
        these bindings should have been substituted out). *)
-    let dbg = Debuginfo.none in
+    (* CR gbury: once we get proper debuginfo here, remember to apply
+       Env.add_inlined_debuginfo to it *)
+    let dbg_with_inlined = Debuginfo.none in
     let env, res =
-      bind_var_to_simple ~dbg env res v ~num_normal_occurrences_of_bound_vars s
+      bind_var_to_simple ~dbg_with_inlined env res v
+        ~num_normal_occurrences_of_bound_vars s
     in
     expr env res body
   | Singleton _, Prim (p, _)
     when (not (Flambda_features.stack_allocation_enabled ()))
          && Flambda_primitive.is_begin_or_end_region p ->
+    expr env res body
+  | Singleton _, Prim (Nullary (Enter_inlined_apply { dbg }), _) ->
+    let env = Env.enter_inlined_apply env dbg in
     expr env res body
   | Singleton v, Prim ((Unary (End_region, _) as p), dbg) ->
     (* CR gbury: this is a hack to prevent moving of expressions past an
@@ -545,7 +553,10 @@ and let_cont_not_inlined env res k handler body =
       let_cont_exn_handler env res k body vars handler free_vars_of_handler
         ~catch_id arity
     else
-      let dbg = Debuginfo.none (* CR mshinwell: fix debuginfo *) in
+      (* CR mshinwell: fix debuginfo *)
+      (* CR gbury: once we get proper debuginfo here, remember to apply
+         Env.add_inlined_debuginfo to it *)
+      let dbg = Debuginfo.none in
       let body, free_vars_of_body, res = expr env res body in
       let free_vars =
         Backend_var.Set.union free_vars_of_body
@@ -593,7 +604,10 @@ and let_cont_exn_handler env res k body vars handler free_vars_of_handler
     Backend_var.Set.union free_vars_of_body
       (C.remove_vars_with_machtype free_vars_of_handler vars)
   in
-  let dbg = Debuginfo.none (* CR mshinwell: fix debuginfo *) in
+  (* CR mshinwell: fix debuginfo *)
+  (* CR gbury: once we get proper debuginfo here, remember to apply
+     Env.add_inlined_debuginfo to it *)
+  let dbg = Debuginfo.none in
   let trywith =
     C.trywith ~dbg ~kind:(Delayed catch_id) ~body ~exn_var ~handler ()
   in
@@ -660,7 +674,10 @@ and let_cont_rec env res invariant_params conts body =
       conts_to_handlers
       (Continuation.Map.empty, res)
   in
-  let dbg = Debuginfo.none (* CR mshinwell: fix debuginfo *) in
+  (* CR mshinwell: fix debuginfo *)
+  (* CR gbury: once we get proper debuginfo here, remember to apply
+     Env.add_inlined_debuginfo to it *)
+  let dbg = Debuginfo.none in
   let body, free_vars_of_body, res = expr env res body in
   (* Setup the Cmm handlers for the Ccatch *)
   let handlers, free_vars =
@@ -735,8 +752,12 @@ and apply_expr env res apply =
       let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
       let cmm, free_vars = wrap (C.cexit cont [call] []) free_vars in
       cmm, free_vars, res
-    | Inline { handler_params; handler_body = body; handler_params_occurrences }
-      -> (
+    | Inline
+        { handler_params;
+          handler_body = body;
+          handler_params_occurrences;
+          handler_body_inlined_debuginfo
+        } -> (
       (* Case 3 *)
       let handler_params = Bound_parameters.to_list handler_params in
       match handler_params with
@@ -749,22 +770,36 @@ and apply_expr env res apply =
             ~free_vars_of_defining_expr:free_vars
             ~num_normal_occurrences_of_bound_vars:handler_params_occurrences
         in
+        let env =
+          Env.set_inlined_debuginfo env handler_body_inlined_debuginfo
+        in
         expr env res body
       | _ :: _ -> unsupported ())
     | Jump _ -> unsupported ())
 
 and apply_cont env res apply_cont =
+  let dbg_with_inlined =
+    Env.add_inlined_debuginfo env (Apply_cont.debuginfo apply_cont)
+  in
   let k = Apply_cont.continuation apply_cont in
   let args = Apply_cont.args apply_cont in
   if Env.is_exn_handler env k
-  then translate_raise env res apply_cont k args
+  then translate_raise ~dbg_with_inlined env res apply_cont k args
   else if Continuation.equal (Env.return_continuation env) k
-  then translate_jump_to_return_continuation env res apply_cont k args
+  then
+    translate_jump_to_return_continuation ~dbg_with_inlined env res apply_cont k
+      args
   else
     match Env.get_continuation env k with
     | Jump { param_types; cont } ->
-      translate_jump_to_continuation env res apply_cont param_types cont args
-    | Inline { handler_params; handler_body; handler_params_occurrences } ->
+      translate_jump_to_continuation ~dbg_with_inlined env res apply_cont
+        param_types cont args
+    | Inline
+        { handler_params;
+          handler_body;
+          handler_params_occurrences;
+          handler_body_inlined_debuginfo
+        } ->
       if Option.is_some (Apply_cont.trap_action apply_cont)
       then
         Misc.fatal_errorf "This [Apply_cont] should not have a trap action:@ %a"
@@ -777,12 +812,13 @@ and apply_cont env res apply_cont =
         let env, res =
           List.fold_left2
             (fun (env, res) param ->
-              bind_var_to_simple
-                ~dbg:(Apply_cont.debuginfo apply_cont)
-                env res
+              bind_var_to_simple ~dbg_with_inlined env res
                 (Bound_parameter.var param)
                 ~num_normal_occurrences_of_bound_vars:handler_params_occurrences)
             (env, res) handler_params args
+        in
+        let env =
+          Env.set_inlined_debuginfo env handler_body_inlined_debuginfo
         in
         expr env res handler_body
       else
@@ -794,7 +830,7 @@ and apply_cont env res apply_cont =
 
 and switch env res switch =
   let scrutinee = Switch.scrutinee switch in
-  let dbg = Switch.condition_dbg switch in
+  let dbg = Env.add_inlined_debuginfo env (Switch.condition_dbg switch) in
   let To_cmm_env.
         { env;
           res;

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -521,6 +521,11 @@ let nullary_primitive _env res dbg prim =
     let expr = Cmm.Cop (Cprobe_is_enabled { name }, [], dbg) in
     None, res, expr
   | Begin_region -> None, res, C.beginregion ~dbg
+  | Enter_inlined_apply _ ->
+    Misc.fatal_errorf
+      "The primitive [Enter_inlined_apply] should not be translated by \
+       [to_cmm_primitive] but should instead be handled in [to_cmm_expr] to \
+       correctly adjust the inlined debuginfo in the env."
 
 let unary_primitive env res dbg f arg =
   match (f : P.unary_primitive) with

--- a/ocaml/testsuite/tests/backtrace-multifiles/foo.ml
+++ b/ocaml/testsuite/tests/backtrace-multifiles/foo.ml
@@ -1,0 +1,22 @@
+
+let[@inline never] print s = (print_endline[@inlined never]) s
+
+let[@inline] print_stack () =
+  let st = Printexc.get_callstack 100 in
+  (Printexc.print_raw_backtrace[@inlined never]) stdout st
+
+let[@inline] f s =
+  print_stack ();
+  print s
+
+let[@inline] g s =
+  let s = (String.cat[@inlined never]) s " !" in
+  f s;
+  print_stack ();
+  print "end of g"
+
+let[@inline] h s =
+  g s;
+  print_stack ();
+  print "end of h"
+

--- a/ocaml/testsuite/tests/backtrace-multifiles/main.ml
+++ b/ocaml/testsuite/tests/backtrace-multifiles/main.ml
@@ -1,0 +1,82 @@
+(* TEST_BELOW *)
+
+let[@inline never] test s =
+  let s' = (String.cat[@inlined never]) "! " s in
+  (Foo.h[@inlined]) s'; (* CR gbury: remove [@inlined], cf #1199 *)
+  (Foo.print_stack[@inlined]) (); (* CR gbury: remove [@inlined], cf #1199  *)
+  (print_endline[@inlined never]) "end of test"
+
+let () =
+  Printexc.record_backtrace true;
+  test "foobar"
+
+(* This test aims at checking that backtraces are correct after inlining,
+   particularly after inlining of functions from other files, and
+   furthermore from other files compiled with different optimization options.
+   We therefore define quite a few functions (in `foo.ml`) that use one
+   another (with a lot of inlining). Additionally, we also print
+   stack/backtraces after an inlined function (in the `test` function above),
+   to ensure that we do not wrongly propagate debuginfos past the function
+   call. *)
+
+(* TEST
+
+   readonly_files ="foo.ml"
+
+   * setup-ocamlopt.opt-build-env
+     compiler_directory_suffix = ".O3"
+   ** ocamlopt.opt
+      module = "foo.ml"
+      flags = "-g -O3"
+   *** ocamlopt.opt
+       module = "main.ml"
+       flags = "-g -O3"
+   **** ocamlopt.opt
+        module = ""
+        all_modules = "foo.cmx main.cmx"
+   ***** run
+   ****** check-program-output
+
+   * setup-ocamlopt.opt-build-env
+     compiler_directory_suffix = ".Oclassic"
+   ** ocamlopt.opt
+      module = "foo.ml"
+      flags = "-g -Oclassic"
+   *** ocamlopt.opt
+       module = "main.ml"
+       flags = "-g -Oclassic"
+   **** ocamlopt.opt
+        module = ""
+        all_modules = "foo.cmx main.cmx"
+   ***** run
+   ****** check-program-output
+
+   * setup-ocamlopt.opt-build-env
+     compiler_directory_suffix = ".O3-Oclassic"
+   ** ocamlopt.opt
+      module = "foo.ml"
+      flags = "-g -O3"
+   *** ocamlopt.opt
+       module = "main.ml"
+       flags = "-g -Oclassic"
+   **** ocamlopt.opt
+        module = ""
+        all_modules = "foo.cmx main.cmx"
+   ***** run
+   ****** check-program-output
+
+   * setup-ocamlopt.opt-build-env
+     compiler_directory_suffix = ".Oclassic-O3"
+   ** ocamlopt.opt
+      module = "foo.ml"
+      flags = "-g -Oclassic"
+   *** ocamlopt.opt
+       module = "main.ml"
+       flags = "-g -O3"
+   **** ocamlopt.opt
+        module = ""
+        all_modules = "foo.cmx main.cmx"
+   ***** run
+   ****** check-program-output
+
+*)

--- a/ocaml/testsuite/tests/backtrace-multifiles/main.reference
+++ b/ocaml/testsuite/tests/backtrace-multifiles/main.reference
@@ -1,0 +1,22 @@
+Raised by primitive operation at Foo.print_stack in file "foo.ml" (inlined), line 5, characters 11-37
+Called from Foo.f in file "foo.ml" (inlined), line 9, characters 2-16
+Called from Foo.g in file "foo.ml" (inlined), line 14, characters 2-5
+Called from Foo.h in file "foo.ml" (inlined), line 19, characters 2-5
+Called from Main.test in file "main.ml", line 5, characters 2-22
+Called from Main in file "main.ml", line 11, characters 2-15
+! foobar !
+Raised by primitive operation at Foo.print_stack in file "foo.ml" (inlined), line 5, characters 11-37
+Called from Foo.g in file "foo.ml" (inlined), line 15, characters 2-16
+Called from Foo.h in file "foo.ml" (inlined), line 19, characters 2-5
+Called from Main.test in file "main.ml", line 5, characters 2-22
+Called from Main in file "main.ml", line 11, characters 2-15
+end of g
+Raised by primitive operation at Foo.print_stack in file "foo.ml" (inlined), line 5, characters 11-37
+Called from Foo.h in file "foo.ml" (inlined), line 20, characters 2-16
+Called from Main.test in file "main.ml", line 5, characters 2-22
+Called from Main in file "main.ml", line 11, characters 2-15
+end of h
+Raised by primitive operation at Foo.print_stack in file "foo.ml" (inlined), line 5, characters 11-37
+Called from Main.test in file "main.ml", line 6, characters 2-32
+Called from Main in file "main.ml", line 11, characters 2-15
+end of test

--- a/ocaml/testsuite/tests/backtrace/inline_test.ml
+++ b/ocaml/testsuite/tests/backtrace/inline_test.ml
@@ -6,6 +6,9 @@
    * native
      ocamlopt_flags = "-O3"
      compiler_directory_suffix = ".O3"
+   * native
+     ocamlopt_flags = "-Oclassic"
+     compiler_directory_suffix = ".Oclassic"
 *)
 
 (* A test for inlined stack backtraces *)

--- a/ocaml/testsuite/tests/backtrace/inline_test.reference
+++ b/ocaml/testsuite/tests/backtrace/inline_test.reference
@@ -1,5 +1,5 @@
-File "inline_test.ml", line 14, characters 2-24
-File "inline_test.ml", line 17, characters 2-5
-File "inline_test.ml", line 20, characters 12-17
-File "inline_test.ml", line 23, characters 5-8
-File "inline_test.ml", line 26, characters 2-6
+File "inline_test.ml", line 17, characters 2-24
+File "inline_test.ml", line 20, characters 2-5
+File "inline_test.ml", line 23, characters 12-17
+File "inline_test.ml", line 26, characters 5-8
+File "inline_test.ml", line 29, characters 2-6

--- a/ocaml/testsuite/tests/backtrace/inline_traversal_test.ml
+++ b/ocaml/testsuite/tests/backtrace/inline_traversal_test.ml
@@ -6,6 +6,9 @@
    * native
      ocamlopt_flags = "-O3"
      compiler_directory_suffix = ".O3"
+   * native
+     ocamlopt_flags = "-Oclassic"
+     compiler_directory_suffix = ".Oclassic"
 *)
 
 (* A test for inlined stack backtraces *)

--- a/ocaml/testsuite/tests/backtrace/inline_traversal_test.reference
+++ b/ocaml/testsuite/tests/backtrace/inline_traversal_test.reference
@@ -1,5 +1,5 @@
-File inline_traversal_test.ml:14, raise
-File inline_traversal_test.ml:17
+File inline_traversal_test.ml:17, raise
 File inline_traversal_test.ml:20
 File inline_traversal_test.ml:23
-File inline_traversal_test.ml:27
+File inline_traversal_test.ml:26
+File inline_traversal_test.ml:30


### PR DESCRIPTION
This needs tidying up/redoing, but shows what's necessary to get the (main part of the) Core testsuite to pass:

1. Do a lot more lifting by generating inconstant let-symbol expressions for things other than exception declarations.
2. Ensure that symbols are correctly propagated through into module block approximations.  (If you run `ocamlobjinfo` on the `.cmx` files for `Import0` and `Import` in `Base` for example, you should see the difference before and after this PR.)

Based on #1151 , only the most recent changeset is new.