### PR TITLE
Clarify the types used for static jump/catch

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -107,11 +107,8 @@ type float_comparison = Lambda.float_comparison =
 let negate_float_comparison = Lambda.negate_float_comparison
 
 let swap_float_comparison = Lambda.swap_float_comparison
-type label = int
 
-type exit_label =
-  | Return_lbl
-  | Lbl of label
+type label = int
 
 let init_label = 99
 
@@ -127,6 +124,12 @@ let set_label l =
 let cur_label () = !label_counter
 
 let new_label() = incr label_counter; !label_counter
+
+type static_label = Lambda.static_label
+
+type exit_label =
+  | Return_lbl
+  | Lbl of static_label
 
 type rec_flag = Nonrecursive | Recursive
 
@@ -242,7 +245,7 @@ type expression =
       * Debuginfo.t * value_kind
   | Ccatch of
       rec_flag
-        * (label * (Backend_var.With_provenance.t * machtype) list
+        * (static_label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
         * expression * value_kind
   | Cexit of exit_label * expression list * trap_action list

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -138,7 +138,7 @@ type phantom_defining_expr =
   (** The phantom-let-bound variable points at a block with the given
       structure. *)
 
-type trywith_shared_label = int (* Same as Ccatch handlers *)
+type trywith_shared_label = Lambda.static_label (* Same as Ccatch handlers *)
 
 type trap_action =
   | Push of trywith_shared_label

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -98,7 +98,7 @@ val cur_label: unit -> label
 
 type exit_label =
   | Return_lbl
-  | Lbl of label
+  | Lbl of Lambda.static_label
 
 type rec_flag = Nonrecursive | Recursive
 
@@ -250,7 +250,7 @@ type expression =
       * Debuginfo.t * value_kind
   | Ccatch of
       rec_flag
-        * (label * (Backend_var.With_provenance.t * machtype) list
+        * (Lambda.static_label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
         * expression
         * value_kind

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -994,14 +994,18 @@ type static_handler
     binding variables [vars] in [body]. *)
 val handler :
   dbg:Debuginfo.t ->
-  int ->
+  Lambda.static_label ->
   (Backend_var.With_provenance.t * Cmm.machtype) list ->
   Cmm.expression ->
   static_handler
 
 (** [cexit id args] creates the cmm expression for static to a static handler
     with exit number [id], with arguments [args]. *)
-val cexit : int -> Cmm.expression list -> Cmm.trap_action list -> Cmm.expression
+val cexit :
+  Lambda.static_label ->
+  Cmm.expression list ->
+  Cmm.trap_action list ->
+  Cmm.expression
 
 (** [trap_return res traps] creates the cmm expression for returning [res] after
     applying the trap actions in [traps]. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -28,7 +28,7 @@ type expr_with_info =
 
 type cont =
   | Jump of
-      { cont : Cmm.label;
+      { cont : Lambda.static_label;
         param_types : Cmm.machtype list
       }
   | Inline of
@@ -317,10 +317,8 @@ let get_continuation env k =
       Continuation.print k
   | res -> res
 
-let new_cmm_continuation = Lambda.next_raise_count
-
 let add_jump_cont env k ~param_types =
-  let cont = new_cmm_continuation () in
+  let cont = Lambda.next_raise_count () in
   let conts = Continuation.Map.add k (Jump { param_types; cont }) env.conts in
   cont, { env with conts }
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -280,7 +280,7 @@ val extra_info : t -> Simple.t -> extra_info option
     label), or inlined at any unique use site. *)
 type cont = private
   | Jump of
-      { cont : Cmm.label;
+      { cont : Lambda.static_label;
         param_types : Cmm.machtype list
       }
   | Inline of
@@ -292,7 +292,10 @@ type cont = private
 (** Record that the given continuation should be compiled to a jump, creating a
     fresh Cmm continuation identifier for it. *)
 val add_jump_cont :
-  t -> Continuation.t -> param_types:Cmm.machtype list -> Cmm.label * t
+  t ->
+  Continuation.t ->
+  param_types:Cmm.machtype list ->
+  Lambda.static_label * t
 
 (** Record that the given continuation should be inlined. *)
 val add_inline_cont :
@@ -327,4 +330,4 @@ val get_continuation : t -> Continuation.t -> cont
 (** Returns the Cmm continuation identifier bound to a continuation. Produces a
     fatal error if given an unbound continuation, or a continuation that was
     registered (using [add_inline_cont]) to be inlined. *)
-val get_cmm_continuation : t -> Continuation.t -> Cmm.label
+val get_cmm_continuation : t -> Continuation.t -> Lambda.static_label

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -434,6 +434,8 @@ let equal_meth_kind x y =
 
 type shared_code = (int * int) list
 
+type static_label = int
+
 type function_attribute = {
   inline : inline_attribute;
   specialise : specialise_attribute;
@@ -461,8 +463,8 @@ type lambda =
   | Lswitch of lambda * lambda_switch * scoped_location * layout
   | Lstringswitch of
       lambda * (string * lambda) list * lambda option * scoped_location * layout
-  | Lstaticraise of int * lambda list
-  | Lstaticcatch of lambda * (int * (Ident.t * layout) list) * lambda * layout
+  | Lstaticraise of static_label * lambda list
+  | Lstaticcatch of lambda * (static_label * (Ident.t * layout) list) * lambda * layout
   | Ltrywith of lambda * Ident.t * lambda * layout
   | Lifthenelse of lambda * lambda * lambda * layout
   | Lsequence of lambda * lambda

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -340,6 +340,8 @@ val equal_meth_kind : meth_kind -> meth_kind -> bool
 
 type shared_code = (int * int) list     (* stack size -> code label *)
 
+type static_label = int
+
 type function_attribute = {
   inline : inline_attribute;
   specialise : specialise_attribute;
@@ -369,8 +371,8 @@ type lambda =
    strings are pairwise distinct *)
   | Lstringswitch of
       lambda * (string * lambda) list * lambda option * scoped_location * layout
-  | Lstaticraise of int * lambda list
-  | Lstaticcatch of lambda * (int * (Ident.t * layout) list) * lambda * layout
+  | Lstaticraise of static_label * lambda list
+  | Lstaticcatch of lambda * (static_label * (Ident.t * layout) list) * lambda * layout
   | Ltrywith of lambda * Ident.t * lambda * layout
 (* Lifthenelse (e, t, f, layout) evaluates t if e evaluates to 0, and evaluates f if
    e evaluates to any other value; layout must be the layout of [t] and [f] *)
@@ -618,7 +620,7 @@ val primitive_may_allocate : primitive -> alloc_mode option
 (***********************)
 
 (* Get a new static failure ident *)
-val next_raise_count : unit -> int
+val next_raise_count : unit -> static_label
 
 val staticfail : lambda (* Anticipated static failure *)
 


### PR DESCRIPTION
This is a small PR to clarify a very confusing situation that we have currently.

Currently, static jumps catches are present from lambda onwards, and are identified by a integer. Since that integer must be unique for each static handler, these integers are generated using counters, and there are two such counters in the compiler: one in `lambda.ml` (`Lambda.next_raise_count`) and one in `cmm.ml` (`Cmm.new_label`). In order to not use the same integers for two different handlers, one must be careful to always use the same counter for each pass, which is not easy right now.

For instance, up to (and including) `cmm`, the `lambda` counter is used (see e.g. occurrences of `Lambda.next_raise_count` in `cmm_helpers.ml`), whereas the `Cmm` counter is used starting from the linearize pass. This is **extremely** confusing, considering that `Cmm` defines `type label = int` and uses it in the type declaration for static jumps and catches, even though one should use `Lambda.next_raise_count` and not `Cmm.new_label`, since all code currently generating cmm code uses the `lambda` counter.

This PR is a first step in cleaning up this situation, by at least clarifying the situation and using the appropriate type abbreviations in order to suggest which counter to use. If there is an agreement, I'd also propose to make the type types incompatible (using e.g. `private`, or opaque types) in order to ensure that the same counter is always used for a given type and AST (however, that would result in quite a big diff).