### PR TITLE
Add `toplevel` keyword to fexpr lexer

### DIFF
--- a/middle_end/flambda2/parser/flambda_lex.mll
+++ b/middle_end/flambda2/parser/flambda_lex.mll
@@ -88,6 +88,7 @@ let keyword_table =
     "switch", KWD_SWITCH;
     "tag", KWD_TAG;
     "tagged", KWD_TAGGED;
+    "toplevel", KWD_TOPLEVEL;
     "tupled", KWD_TUPLED;
     "unit", KWD_UNIT;
     "unreachable", KWD_UNREACHABLE;


### PR DESCRIPTION
Managed to forget this when writing #1168.