### PR TITLE
Install AFL packages on CI workers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,14 @@ jobs:
       with:
         path: 'flambda_backend'
 
+    - name: Install AFL (for Linux workers)
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install afl++
+
+    - name: Install AFL (for macOS workers)
+      if: matrix.os == 'macos-latest'
+      run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install afl-fuzz
+
     - name: Cache OCaml 4.14 and dune
       uses: actions/cache@v2
       id: cache


### PR DESCRIPTION
This should now cause the AFL tests in the testsuite to fail (until PR1196 is merged) rather than being skipped.