### PR TITLE
IRC: fix for frame pointers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,15 @@ jobs:
             irc_split: off
             irc_spilling_heuristics: flat_uses
 
+          - name: irc_frame_pointers
+            config: --enable-middle-end=flambda2 --enable-frame-pointers
+            os: ubuntu-latest
+            ocamlparam: ''
+            check_arch: true
+            register_allocator: irc
+            irc_split: off
+            irc_spilling_heuristics: flat_uses
+
           - name: build_upstream_closure
             config: --enable-middle-end=closure
             os: ubuntu-20.04

--- a/backend/cfg/cfg_irc.ml
+++ b/backend/cfg/cfg_irc.ml
@@ -6,12 +6,44 @@ open! Cfg_irc_split
 module State = Cfg_irc_state
 module DLL = Flambda_backend_utils.Doubly_linked_list
 
+(* Remove the frame pointer from the passed array if present, returning the
+   passed array otherwise *)
+let filter_fp : Reg.t array -> Reg.t array =
+ fun regs ->
+  let is_fp (reg : Reg.t) : bool =
+    match reg.loc with
+    | Unknown -> false
+    | Reg r ->
+      let reg_class = Proc.register_class reg in
+      r - Proc.first_available_register.(reg_class)
+      >= Proc.num_available_registers.(reg_class)
+    | Stack _ -> false
+  in
+  let len = Array.length regs in
+  let idx = ref 0 in
+  while !idx < len && not (is_fp regs.(!idx)) do
+    incr idx
+  done;
+  if !idx >= len
+  then regs
+  else if len = 1
+  then [||]
+  else
+    let new_regs = Array.make (pred len) regs.(0) in
+    Array.blit ~src:regs ~src_pos:0 ~dst:new_regs ~dst_pos:0 ~len:!idx;
+    Array.blit ~src:regs ~src_pos:(succ !idx) ~dst:new_regs ~dst_pos:!idx
+      ~len:(len - !idx - 1);
+    new_regs
+
+let filter_fp regs = if Config.with_frame_pointers then filter_fp regs else regs
+
 let build : State.t -> Cfg_with_liveness.t -> unit =
  fun state cfg_with_liveness ->
   if irc_debug then log ~indent:1 "build";
   let liveness = Cfg_with_liveness.liveness cfg_with_liveness in
   let add_edges_live (id : Instruction.id) ~(def : Reg.t array)
       ~(move_src : Reg.t) ~(destroyed : Reg.t array) : unit =
+    let destroyed = filter_fp destroyed in
     let live = Cfg_dataflow.Instr.Tbl.find liveness id in
     if Array.length def > 0
     then
@@ -59,7 +91,7 @@ let build : State.t -> Cfg_with_liveness.t -> unit =
         let live = Cfg_dataflow.Instr.Tbl.find liveness first_id in
         Reg.Set.iter
           (fun reg1 ->
-            Array.iter Proc.destroyed_at_raise ~f:(fun reg2 ->
+            Array.iter (filter_fp Proc.destroyed_at_raise) ~f:(fun reg2 ->
                 State.add_edge state reg1 reg2))
           (Reg.Set.remove Proc.loc_exn_bucket live.before))
 

--- a/backend/cfg/cfg_irc_utils.ml
+++ b/backend/cfg/cfg_irc_utils.ml
@@ -159,7 +159,22 @@ let is_move_basic : Cfg.basic -> bool =
 let is_move_instruction : Cfg.basic Cfg.instruction -> bool =
  fun instr -> is_move_basic instr.desc
 
-let all_precolored_regs : Reg.t array = Proc.all_phys_regs
+let all_precolored_regs : Reg.t array =
+  Proc.init ();
+  let num_available_registers =
+    Array.fold_left Proc.num_available_registers ~f:( + ) ~init:0
+  in
+  let res = Array.make num_available_registers Reg.dummy in
+  let i = ref 0 in
+  for reg_class = 0 to pred Proc.num_register_classes do
+    let first_available_register = Proc.first_available_register.(reg_class) in
+    let num_available_registers = Proc.num_available_registers.(reg_class) in
+    for reg_idx = 0 to pred num_available_registers do
+      res.(!i) <- Proc.phys_reg (first_available_register + reg_idx);
+      incr i
+    done
+  done;
+  res
 
 let k reg = Proc.num_available_registers.(Proc.register_class reg)
 

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -345,8 +345,6 @@ let postcondition : Cfg_with_layout.t -> allow_stack_operands:bool -> unit =
   in
   let reg_class = ref 0 in
   Array.iter2 max_stack_slots fun_num_stack_slots ~f:(fun max_slot num_slots ->
-      (* CR-soon xclerc for xclerc: make the condition stricter if max_slot >=
-         num_slots *)
       if succ max_slot <> num_slots
       then
         fatal

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -345,8 +345,9 @@ let postcondition : Cfg_with_layout.t -> allow_stack_operands:bool -> unit =
   in
   let reg_class = ref 0 in
   Array.iter2 max_stack_slots fun_num_stack_slots ~f:(fun max_slot num_slots ->
-      (* CR-soon xclerc for xclerc: make the condition stricter *)
-      if max_slot >= num_slots
+      (* CR-soon xclerc for xclerc: make the condition stricter if max_slot >=
+         num_slots *)
+      if succ max_slot <> num_slots
       then
         fatal
           "register class %d has a max slot of %d, but the number of slots is \

--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -345,7 +345,8 @@ let postcondition : Cfg_with_layout.t -> allow_stack_operands:bool -> unit =
   in
   let reg_class = ref 0 in
   Array.iter2 max_stack_slots fun_num_stack_slots ~f:(fun max_slot num_slots ->
-      if succ max_slot <> num_slots
+      (* CR-soon xclerc for xclerc: make the condition stricter *)
+      if max_slot >= num_slots
       then
         fatal
           "register class %d has a max slot of %d, but the number of slots is \


### PR DESCRIPTION
The IRC algorithm relies on the fact that the precolored registers
are the hardware registers that can be assigned.

(extracted from https://github.com/ocaml-flambda/flambda-backend/pull/1183)