### PR TITLE
Remove kind constraint on T.never_holds_locally_allocated_values

### DIFF
--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -795,7 +795,7 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
      the case where we are considering lifting a set that has not been lifted
      before, there are never any other mutually-recursive sets ([Named.t] does
      not allow them). *)
-  let[@inline] variable_permits_lifting var kind =
+  let[@inline] variable_permits_lifting var =
     (* Variables (excluding ones bound to symbol projections; see below) in the
        definition of the set of closures will currently prevent lifting if the
        allocation mode is [Local] and we cannot show that such variables never
@@ -817,18 +817,17 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
        | Local _ -> (
          match
            T.never_holds_locally_allocated_values (DA.typing_env dacc) var
-             (K.With_subkind.kind kind)
          with
          | Proved () -> true
          | Unknown -> false)
        | Heap -> true
   in
-  let value_slot_permits_lifting _value_slot (simple, kind) =
+  let value_slot_permits_lifting _value_slot (simple, _kind) =
     can_lift_coercion (Simple.coercion simple)
     && Simple.pattern_match' simple
          ~const:(fun _ -> true)
          ~symbol:(fun _ ~coercion:_ -> true)
-         ~var:(fun var ~coercion:_ -> variable_permits_lifting var kind)
+         ~var:(fun var ~coercion:_ -> variable_permits_lifting var)
   in
   let can_lift =
     Name_mode.is_normal name_mode_of_bound_vars

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -736,6 +736,6 @@ val reify :
   reification_result
 
 val never_holds_locally_allocated_values :
-  Typing_env.t -> Variable.t -> Flambda_kind.t -> unit proof_of_property
+  Typing_env.t -> Variable.t -> unit proof_of_property
 
 val remove_outermost_alias : Typing_env.t -> t -> t

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -218,7 +218,7 @@ val prove_alloc_mode_of_boxed_number :
   Typing_env.t -> Type_grammar.t -> Alloc_mode.For_types.t proof_of_property
 
 val never_holds_locally_allocated_values :
-  Typing_env.t -> Variable.t -> Flambda_kind.t -> unit proof_of_property
+  Typing_env.t -> Variable.t -> unit proof_of_property
 
 val prove_physical_equality :
   Typing_env.t -> Type_grammar.t -> Type_grammar.t -> bool proof_of_property

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -96,10 +96,7 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
           match alloc_mode with
           | Heap -> true
           | Heap_or_local | Local -> (
-            match
-              Provers.never_holds_locally_allocated_values env var
-                Flambda_kind.value
-            with
+            match Provers.never_holds_locally_allocated_values env var with
             | Proved () -> true
             | Unknown -> false))
   in


### PR DESCRIPTION
This could otherwise cause a fatal error.