### PR TITLE
Remove Lsend and instead use a single Pgetmethod primitive

### DIFF
--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -242,9 +242,7 @@ let build_package_cmx members cmxfile =
         { curry_fun =
             union(List.map (fun info -> info.ui_generic_fns.curry_fun) units);
           apply_fun =
-            union(List.map (fun info -> info.ui_generic_fns.apply_fun) units);
-          send_fun =
-            union(List.map (fun info -> info.ui_generic_fns.send_fun) units) };
+            union(List.map (fun info -> info.ui_generic_fns.apply_fun) units) };
       ui_force_link =
           List.exists (fun info -> info.ui_force_link) units;
       ui_export_info;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2435,6 +2435,21 @@ let apply_function_body arity result (mode : Lambda.alloc_mode) =
           Vval Pgenval (* incorrect but only used for unboxing *) ) )
 
 let get_cached_method obj met cache pos dbg =
+      Cop
+        ( Cextcall
+            { func = "caml_get_cached_public_method";
+              ty = typ_val;
+              builtin = false;
+              returns = true;
+              effects = Arbitrary_effects;
+              coeffects = Has_coeffects;
+              alloc = false;
+              ty_args = []
+            },
+          [obj; met; array_indexing log2_size_addr cache pos dbg],
+          dbg )
+
+(*
   let cconst_int i = Cconst_int (i, dbg) in
   let cache_var = V.create_local "cache" and obj_var = V.create_local "obj" and tag_var = V.create_local "tag" in
   let clos =
@@ -2482,7 +2497,7 @@ let get_cached_method obj met cache pos dbg =
   Clet(VP.create obj_var, obj,
       Clet (VP.create tag_var, met,
             Clet (VP.create cache_var, array_indexing log2_size_addr cache pos dbg, clos)))
-
+*)
 let send_function (arity, result, mode) =
   let dbg = placeholder_dbg in
   let cconst_int i = Cconst_int (i, dbg ()) in

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2446,7 +2446,7 @@ let get_cached_method obj met cache pos dbg =
               alloc = false;
               ty_args = []
             },
-          [obj; met; array_indexing log2_size_addr cache pos dbg],
+          [obj; met; cache; pos],
           dbg )
 
 (*

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2307,19 +2307,19 @@ let apply_function_body arity result (mode : Lambda.alloc_mode) =
           Vval Pgenval (* incorrect but only used for unboxing *) ) )
 
 let get_cached_method obj met cache pos dbg =
-      Cop
-        ( Cextcall
-            { func = "caml_get_cached_public_method";
-              ty = typ_val;
-              builtin = false;
-              returns = true;
-              effects = Arbitrary_effects;
-              coeffects = Has_coeffects;
-              alloc = false;
-              ty_args = []
-            },
-          [obj; met; cache; pos],
-          dbg )
+  Cop
+    ( Cextcall
+        { func = "caml_get_cached_public_method";
+          ty = typ_val;
+          builtin = false;
+          returns = true;
+          effects = Arbitrary_effects;
+          coeffects = Has_coeffects;
+          alloc = false;
+          ty_args = []
+        },
+      [obj; met; cache; pos],
+      dbg )
 
 let apply_function (arity, result, mode) =
   let args, clos, body = apply_function_body arity result mode in
@@ -2613,10 +2613,7 @@ module Generic_fns_tbl = struct
       apply : (machtype list * machtype * Lambda.alloc_mode, unit) Hashtbl.t
     }
 
-  let make () =
-    { curry = Hashtbl.create 10;
-      apply = Hashtbl.create 10
-    }
+  let make () = { curry = Hashtbl.create 10; apply = Hashtbl.create 10 }
 
   let add t Cmx_format.{ curry_fun; apply_fun } =
     List.iter (fun f -> Hashtbl.replace t.curry f ()) curry_fun;
@@ -2632,9 +2629,7 @@ module Generic_fns_tbl = struct
       let keys = Hashtbl.fold (fun k () acc -> k :: acc) tbl [] in
       List.sort compare keys
     in
-    { curry_fun = sorted_keys t.curry;
-      apply_fun = sorted_keys t.apply
-    }
+    { curry_fun = sorted_keys t.curry; apply_fun = sorted_keys t.apply }
 end
 
 let generic_functions shared tbl =
@@ -2642,8 +2637,7 @@ let generic_functions shared tbl =
   let ({ curry_fun; apply_fun } : Cmx_format.generic_fns) =
     Generic_fns_tbl.entries tbl
   in
-  List.concat_map curry_function curry_fun
-  @ List.map apply_function apply_fun
+  List.concat_map curry_function curry_fun @ List.map apply_function apply_fun
 
 (* Primitives *)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -359,7 +359,12 @@ val lookup_tag : expression -> expression -> Debuginfo.t -> expression
 val lookup_label : expression -> expression -> Debuginfo.t -> expression
 
 val get_cached_method :
-  expression -> expression -> expression -> expression -> Debuginfo.t -> expression
+  expression ->
+  expression ->
+  expression ->
+  expression ->
+  Debuginfo.t ->
+  expression
 
 (** Allocations *)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -358,29 +358,6 @@ val lookup_tag : expression -> expression -> Debuginfo.t -> expression
     a tagged integer *)
 val lookup_label : expression -> expression -> Debuginfo.t -> expression
 
-(** Lookup and call a method using the method cache. Arguments:
-
-    - obj : the object from which to lookup
-
-    - tag : the hash of the method name, as a tagged integer
-
-    - cache : the method cache array
-
-    - pos : the position of the cache entry in the cache array
-
-    - args : the additional arguments to the method call *)
-val call_cached_method :
-  expression ->
-  expression ->
-  expression ->
-  expression ->
-  expression list ->
-  machtype list ->
-  machtype ->
-  Clambda.apply_kind ->
-  Debuginfo.t ->
-  expression
-
 val get_cached_method :
   expression -> expression -> expression -> expression -> Debuginfo.t -> expression
 
@@ -775,27 +752,6 @@ val direct_apply :
     closure. *)
 val generic_apply :
   Asttypes.mutable_flag ->
-  expression ->
-  expression list ->
-  machtype list ->
-  machtype ->
-  Clambda.apply_kind ->
-  Debuginfo.t ->
-  expression
-
-(** Method call : [send kind met obj args dbg]
-
-    - [met] is a method identifier, which can be a hashed variant or an index in
-    [obj]'s method table, depending on [kind]
-
-    - [obj] is the object whose method is being called
-
-    - [args] is the extra arguments to the method call (Note: I'm not aware of
-    any way for the frontend to generate any arguments other than the cache and
-    cache position) *)
-val send :
-  Lambda.meth_kind ->
-  expression ->
   expression ->
   expression list ->
   machtype list ->

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -381,6 +381,9 @@ val call_cached_method :
   Debuginfo.t ->
   expression
 
+val get_cached_method :
+  expression -> expression -> expression -> expression -> Debuginfo.t -> expression
+
 (** Allocations *)
 
 (** Allocate a block of regular values with the given tag *)

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -519,13 +519,6 @@ let rec transl env e =
         let args_type = List.map machtype_of_layout args_layout in
         let return = machtype_of_layout result_layout in
         generic_apply (mut_from_env env clos) clos args args_type return kind dbg
-  | Usend(kind, met, obj, args, args_layout, result_layout, pos, dbg) ->
-      let met = transl env met in
-      let obj = transl env obj in
-      let args = List.map (transl env) args in
-      let args_type = List.map machtype_of_layout args_layout in
-      let return = machtype_of_layout result_layout in
-      send kind met obj args args_type return pos dbg
   | Ulet(str, kind, id, exp, body) ->
       transl_let env str kind id exp (fun env -> transl env body)
   | Uphantom_let (var, defining_expr, body) ->

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -631,11 +631,11 @@ let rec transl env e =
                        dbg)) dbg
       | (Pprobe_is_enabled {name}, []) ->
           tag_int (Cop(Cprobe_is_enabled {name}, [], dbg)) dbg
-      | (Pgetmethod ((Self | Public) as k), [obj; tag]) ->
+      | (Pgetmethod ((Self | Public) as k), [tag; obj]) ->
         let obj = transl env obj in
         let tag = transl env tag in
         if k = Self then lookup_label obj tag dbg else lookup_tag obj tag dbg
-      | (Pgetmethod Cached, [obj; tag; cache; pos]) ->
+      | (Pgetmethod Cached, [tag; obj; cache; pos]) ->
         let obj = transl env obj in
         let tag = transl env tag in
         let cache = transl env cache in

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -50,8 +50,7 @@ type apply_fn := machtype list * machtype * Lambda.alloc_mode
 (* Curry/apply/send functions *)
 type generic_fns =
   { curry_fun: (Lambda.function_kind * machtype list * machtype) list;
-    apply_fun: apply_fn list;
-    send_fun: apply_fn list }
+    apply_fun: apply_fn list }
 
 (* Symbols of function that pass certain checks for special properties. *)
 type checks =

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -92,9 +92,6 @@ and ulambda =
   | Ufor of Backend_var.With_provenance.t * ulambda * ulambda
       * direction_flag * ulambda
   | Uassign of Backend_var.t * ulambda
-  | Usend of
-      meth_kind * ulambda * ulambda * ulambda list
-      * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
   | Utail of ulambda

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -103,9 +103,6 @@ and ulambda =
   | Ufor of Backend_var.With_provenance.t * ulambda * ulambda
       * direction_flag * ulambda
   | Uassign of Backend_var.t * ulambda
-  | Usend of
-      meth_kind * ulambda * ulambda * ulambda list
-      * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
   | Utail of ulambda

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -126,6 +126,7 @@ type primitive =
   | Pbox_float of alloc_mode
   | Punbox_int of boxed_integer
   | Pbox_int of boxed_integer * alloc_mode
+  | Pgetmethod of Lambda.meth_kind
 
 and integer_comparison = Lambda.integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -129,6 +129,7 @@ type primitive =
   | Pbox_float of alloc_mode
   | Punbox_int of boxed_integer
   | Pbox_int of boxed_integer * alloc_mode
+  | Pgetmethod of Lambda.meth_kind
 
 and integer_comparison = Lambda.integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -135,8 +135,6 @@ let occurs_var var u =
     | Uwhile(cond, body) -> occurs cond || occurs body
     | Ufor(_id, lo, hi, _dir, body) -> occurs lo || occurs hi || occurs body
     | Uassign(id, u) -> id = var || occurs u
-    | Usend(_, met, obj, args, _, _, _, _) ->
-        occurs met || occurs obj || List.exists occurs args
     | Uunreachable -> false
     | Uregion e -> occurs e
     | Utail e -> occurs e
@@ -247,9 +245,6 @@ let lambda_smaller lam threshold =
         size := !size + 4; lambda_size low; lambda_size high; lambda_size body
     | Uassign(_id, lam) ->
         incr size;  lambda_size lam
-    | Usend(_, met, obj, args, _, _, _, _) ->
-        size := !size + 8;
-        lambda_size met; lambda_size obj; lambda_list_size args
     | Uunreachable -> ()
     | Uregion e ->
         size := !size + 2;
@@ -757,10 +752,6 @@ let rec substitute loc ((backend, fpc) as st) sb rn ulam =
         with Not_found ->
           id in
       Uassign(id', substitute loc st sb rn u)
-  | Usend(k, u1, u2, ul, args_layout, result_layout, pos, dbg) ->
-      let dbg = subst_debuginfo loc dbg in
-      Usend(k, substitute loc st sb rn u1, substitute loc st sb rn u2,
-            List.map (substitute loc st sb rn) ul, args_layout, result_layout, pos, dbg)
   | Uunreachable ->
       Uunreachable
   | Uregion e ->
@@ -1770,7 +1761,6 @@ let collect_exported_structured_constants a =
     | Uifthenelse (u1, u2, u3, _)
     | Ufor (_, u1, u2, _, u3) -> ulam u1; ulam u2; ulam u3
     | Uassign (_, u) -> ulam u
-    | Usend (_, u1, u2, ul, _, _, _, _) -> ulam u1; ulam u2; List.iter ulam ul
     | Uunreachable -> ()
     | Uregion u -> ulam u
     | Utail u -> ulam u

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1187,13 +1187,6 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
                           List.map (Lambda.compute_expr_layout kinds) args,
                           ap_result_layout, (pos, mode), dbg), Value_unknown)
       end
-  | Lsend(kind, met, obj, args, pos, mode, loc, result_layout) ->
-      let (umet, _) = close env met in
-      let (uobj, _) = close env obj in
-      let dbg = Debuginfo.from_location loc in
-      let args_layout = List.map (Lambda.compute_expr_layout kinds) args in
-      (Usend(kind, umet, uobj, close_list env args, args_layout, result_layout, (pos,mode), dbg),
-       Value_unknown)
   | Llet(str, kind, id, lam, body) ->
       let (ulam, alam) = close_named env id lam in
       let kinds = V.Map.add id kind kinds in

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -123,7 +123,7 @@ let current_unit =
     ui_defines = [];
     ui_imports_cmi = [];
     ui_imports_cmx = [];
-    ui_generic_fns = { curry_fun = []; apply_fun = []; send_fun = [] };
+    ui_generic_fns = { curry_fun = []; apply_fun = [] };
     ui_force_link = false;
     ui_checks = Checks.create ();
     ui_export_info = default_ui_export_info }
@@ -138,7 +138,7 @@ let reset compilation_unit =
   current_unit.ui_imports_cmi <- [];
   current_unit.ui_imports_cmx <- [];
   current_unit.ui_generic_fns <-
-    { curry_fun = []; apply_fun = []; send_fun = [] };
+    { curry_fun = []; apply_fun = [] };
   current_unit.ui_force_link <- !Clflags.link_everything;
   Checks.reset current_unit.ui_checks;
   Hashtbl.clear exported_constants;
@@ -335,12 +335,6 @@ let need_apply_fun arity result mode =
   if not (List.mem (arity, result, mode) fns.apply_fun) then
     current_unit.ui_generic_fns <-
       { fns with apply_fun = (arity, result, mode) :: fns.apply_fun }
-
-let need_send_fun arity result mode =
-  let fns = current_unit.ui_generic_fns in
-  if not (List.mem (arity, result, mode) fns.send_fun) then
-    current_unit.ui_generic_fns <-
-      { fns with send_fun = (arity, result, mode) :: fns.send_fun }
 
 (* Write the description of the current unit *)
 

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -72,10 +72,8 @@ val need_curry_fun:
   Lambda.function_kind -> Cmm.machtype list -> Cmm.machtype -> unit
 val need_apply_fun:
   Cmm.machtype list -> Cmm.machtype -> Lambda.alloc_mode -> unit
-val need_send_fun:
-  Cmm.machtype list -> Cmm.machtype -> Lambda.alloc_mode -> unit
-        (* Record the need of a currying (resp. application,
-           message sending) function with the given arity *)
+        (* Record the need of a currying (resp. application)
+           function with the given arity *)
 
 module Checks : sig
   type t = Cmx_format.checks  (* mutable state *)

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -158,6 +158,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pbox_float m -> Pbox_float m
   | Punbox_int bi -> Punbox_int bi
   | Pbox_int (bi, m) -> Pbox_int (bi, m)
+  | Pgetmethod k -> Pgetmethod k
   | Pobj_magic _
   | Pbytes_to_string
   | Pbytes_of_string

--- a/middle_end/flambda/build_export_info.ml
+++ b/middle_end/flambda/build_export_info.ml
@@ -266,7 +266,7 @@ let rec approx_of_expr (env : Env.t) (flam : Flambda.t) : Export_info.approx =
   | For _ -> Value_id (Env.new_unit_descr env)
   | While _ -> Value_id (Env.new_unit_descr env)
   | Static_raise _ | Static_catch _ | Try_with _ | If_then_else _
-  | Switch _ | String_switch _ | Send _ | Proved_unreachable ->
+  | Switch _ | String_switch _ | Proved_unreachable ->
     Value_unknown
 
 and descr_of_named (env : Env.t) (named : Flambda.named)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -332,18 +332,6 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       in
       Let_rec (defs, close t env body)
     end
-  | Lsend (kind, meth, obj, args, reg_close, mode, loc, result_layout) ->
-    let meth_var = Variable.create Names.meth in
-    let obj_var = Variable.create Names.obj in
-    let dbg = Debuginfo.from_location loc in
-    Flambda.create_let meth_var (Expr (close t env meth))
-      (Flambda.create_let obj_var (Expr (close t env obj))
-        (Lift_code.lifting_helper (close_list t env args)
-          ~evaluation_order:`Right_to_left
-          ~name:Names.send_arg
-          ~create_body:(fun args ->
-              Send { kind; meth = meth_var; obj = obj_var; args;
-                     dbg; reg_close; mode; result_layout })))
   | Lprim ((Pdivint Safe | Pmodint Safe
            | Pdivbint { is_safe = Safe } | Pmodbint { is_safe = Safe }) as prim,
            [arg1; arg2], loc)

--- a/middle_end/flambda/effect_analysis.ml
+++ b/middle_end/flambda/effect_analysis.ml
@@ -49,7 +49,7 @@ let rec no_effects (flam : Flambda.t) =
     no_effects body
   | Tail body ->
     no_effects body
-  | While _ | For _ | Apply _ | Send _ | Assign _ | Static_raise _ -> false
+  | While _ | For _ | Apply _ | Assign _ | Static_raise _ -> false
   | Proved_unreachable -> true
 
 and no_effects_named (named : Flambda.named) =

--- a/middle_end/flambda/extract_projections.ml
+++ b/middle_end/flambda/extract_projections.ml
@@ -91,10 +91,6 @@ let rec analyse_expr ~which_variables expr =
        call.  We should improve this analysis.  Leo says this can be
        done by a similar thing to the unused argument analysis. *)
     | Apply _ -> ()
-    | Send { meth; obj; args; _ } ->
-      check_free_variable meth;
-      check_free_variable obj;
-      List.iter check_free_variable args
     | Assign { new_value; _ } ->
       check_free_variable new_value
     | If_then_else (var, _, _, _)

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -58,18 +58,6 @@ type assign = {
   new_value : Variable.t;
 }
 
-(** The invocation of a method. *)
-type send = {
-  kind : Lambda.meth_kind;
-  meth : Variable.t;
-  obj : Variable.t;
-  args : Variable.t list;
-  dbg : Debuginfo.t;
-  reg_close : Lambda.region_close;
-  mode : Lambda.alloc_mode;
-  result_layout : Lambda.layout;
-}
-
 (** For details on these types, see projection.mli. *)
 type project_closure = Projection.project_closure
 type move_within_set_of_closures = Projection.move_within_set_of_closures
@@ -105,7 +93,6 @@ type t =
   | Let_rec of (Variable.t * named) list * t
   (** CR-someday lwhite: give Let_rec the same fields as Let. *)
   | Apply of apply
-  | Send of send
   | Assign of assign
   | If_then_else of Variable.t * t * t * Lambda.layout
   | Switch of Variable.t * switch

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -34,7 +34,6 @@ let will_traverse_named_expression_later (_ : Flambda.named) = ()
 let ignore_variable (_ : Variable.t) = ()
 let ignore_call_kind (_ : Flambda.call_kind) = ()
 let ignore_debuginfo (_ : Debuginfo.t) = ()
-let ignore_meth_kind (_ : Lambda.meth_kind) = ()
 let ignore_int (_ : int) = ()
 let ignore_int_set (_ : Numbers.Int.Set.t) = ()
 let ignore_bool (_ : bool) = ()
@@ -202,15 +201,6 @@ let variable_and_symbol_invariants (program : Flambda.program) =
     | Assign { being_assigned; new_value; } ->
       check_mutable_variable_is_bound env being_assigned;
       check_variable_is_bound env new_value
-    | Send { kind; meth; obj; args; dbg;
-             reg_close = (Rc_normal | Rc_close_at_apply | Rc_nontail);
-             mode = (Alloc_heap | Alloc_local); result_layout; } ->
-      ignore_meth_kind kind;
-      check_variable_is_bound env meth;
-      check_variable_is_bound env obj;
-      check_variables_are_bound env args;
-      ignore_debuginfo dbg;
-      ignore_layout result_layout
     | If_then_else (cond, ifso, ifnot, kind) ->
       check_variable_is_bound env cond;
       ignore_layout kind;

--- a/middle_end/flambda/flambda_iterators.ml
+++ b/middle_end/flambda/flambda_iterators.ml
@@ -19,7 +19,7 @@ open! Int_replace_polymorphic_compare
 
 let apply_on_subexpressions f f_named (flam : Flambda.t) =
   match flam with
-  | Var _ | Apply _ | Assign _ | Send _ | Proved_unreachable
+  | Var _ | Apply _ | Assign _ | Proved_unreachable
   | Static_raise _ -> ()
   | Let { defining_expr; body; _ } ->
     f_named defining_expr;
@@ -78,7 +78,7 @@ let map_snd_sharing f ((a, b) as cpl) =
 
 let map_subexpressions f f_named (tree:Flambda.t) : Flambda.t =
   match tree with
-  | Var _ | Apply _ | Assign _ | Send _ | Proved_unreachable
+  | Var _ | Apply _ | Assign _ | Proved_unreachable
   | Static_raise _ -> tree
   | Let { var; defining_expr; body; _ } ->
     let new_named = f_named var defining_expr in
@@ -304,7 +304,7 @@ let map_general ~toplevel f f_named tree =
     | _ ->
       let exp : Flambda.t =
         match tree with
-        | Var _ | Apply _ | Assign _ | Send _ | Proved_unreachable
+        | Var _ | Apply _ | Assign _ | Proved_unreachable
         | Static_raise _ -> tree
         | Let _ -> assert false
         | Let_mutable mutable_let ->

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -423,13 +423,6 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
     assert(Lambda.compatible_layout id_layout new_value_layout);
     Uassign (id, new_value),
     Lambda.layout_unit
-  | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
-    let args, args_layout = List.split (subst_vars env args) in
-    let meth, _meth_layout = subst_var env meth in
-    let obj, _obj_layout = subst_var env obj in
-    Usend (kind, meth, obj,
-      args, args_layout, result_layout, (reg_close,mode), dbg),
-    result_layout
   | Region body ->
       let body, body_layout = to_clambda t env body in
       let is_trivial =

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -292,11 +292,6 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_var arg curr;
       List.iter (fun (_,l) -> mark_loop ~toplevel [] l) sw;
       Option.iter (fun l -> mark_loop ~toplevel [] l) def
-    | Send { kind = _; meth; obj; args; dbg = _; } ->
-      mark_curr curr;
-      mark_var meth curr;
-      mark_var obj curr;
-      List.iter (fun arg -> mark_var arg curr) args
     | Region body ->
       mark_curr curr;
       mark_loop ~toplevel [] body

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -1312,13 +1312,6 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
     let cond, r = simplify env r cond in
     let body, r = simplify env r body in
     While (cond, body), ret r (A.value_unknown Other)
-  | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
-    let dbg = E.add_inlined_debuginfo env ~dbg in
-    simplify_free_variable env meth ~f:(fun env meth _meth_approx ->
-      simplify_free_variable env obj ~f:(fun env obj _obj_approx ->
-        simplify_free_variables env args ~f:(fun _env args _args_approx ->
-          Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout },
-            ret r (A.value_unknown Other))))
   | For { bound_var; from_value; to_value; direction; body; } ->
     simplify_free_variable env from_value ~f:(fun env from_value _approx ->
       simplify_free_variable env to_value ~f:(fun env to_value _approx ->

--- a/middle_end/flambda/inlining_cost.ml
+++ b/middle_end/flambda/inlining_cost.ml
@@ -84,7 +84,6 @@ let lambda_smaller' lam ~than:threshold =
     (* Do not affect inlining decision.
        Actual cost is either 1, 5 or 6 bytes, depending on their kind. *)
     | Assign _ -> incr size
-    | Send _ -> size := !size + 8
     | Proved_unreachable -> ()
     | Let { defining_expr; body; _ } ->
       lambda_named_size defining_expr;
@@ -274,7 +273,7 @@ module Benefit = struct
     | Assign _ -> b := remove_prim !b
     | Switch _ | String_switch _ | Static_raise _ | Try_with _
     | If_then_else _ | While _ | For _ -> b := remove_branch !b
-    | Apply _ | Send _ -> b := remove_call !b
+    | Apply _ -> b := remove_call !b
     | Let _ | Let_mutable _ | Let_rec _ | Proved_unreachable | Var _
     | Region _ | Tail _ | Static_catch _ -> ()
 

--- a/middle_end/flambda/ref_to_variables.ml
+++ b/middle_end/flambda/ref_to_variables.ml
@@ -84,7 +84,7 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
       loop body
     | Tail body ->
       loop body
-    | Proved_unreachable | Apply _ | Send _ | Assign _ ->
+    | Proved_unreachable | Apply _ | Assign _ ->
       set := Variable.Set.union !set (Flambda.free_variables flam)
   in
   loop tree;
@@ -155,7 +155,7 @@ let eliminate_ref_of_expr flam =
       | Let_rec _ | Switch _ | String_switch _
       | Static_raise _ | Static_catch _
       | Try_with _ | If_then_else _
-      | While _ | For _ | Region _ | Tail _ | Send _ | Proved_unreachable ->
+      | While _ | For _ | Region _ | Tail _ | Proved_unreachable ->
         flam
     and aux_named (named : Flambda.named) : Flambda.named =
       match named with

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -896,7 +896,6 @@ let blocks env block1 block2 =
     ~subst3:(fun env -> List.map (subst_field env))
     env block1 block2
 
-
 let call_kinds env (call_kind1 : Call_kind.t) (call_kind2 : Call_kind.t) :
     Call_kind.t Comparison.t =
   let compare_alloc_modes_then alloc_mode1 alloc_mode2 ~f : _ Comparison.t =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -909,8 +909,7 @@ let close_let_cont acc env ~name ~is_exn_handler ~params
       ~invariant_params:Bound_parameters.empty ~handlers ~body
 
 let close_exact_or_unknown_apply acc env
-    ({ kind;
-       func;
+    ({ func;
        args;
        continuation;
        exn_continuation;
@@ -930,10 +929,7 @@ let close_exact_or_unknown_apply acc env
     | Some region -> region
   in
   let mode = Alloc_mode.For_types.from_lambda mode in
-  let acc, call_kind =
-    match kind with
-    | Function -> (
-      ( acc,
+  let call_kind =
         match (callee_approx : Env.value_approximation option) with
         | Some (Closure_approximation { code_id; code = code_or_meta; _ }) ->
           let is_tupled =
@@ -952,12 +948,7 @@ let close_exact_or_unknown_apply acc env
             ( Value_unknown | Value_symbol _ | Value_int _
             | Block_approximation _ ) ->
           assert false
-        (* See [close_apply] *) ))
-    | Method { kind; obj } ->
-      let acc, obj = find_simple acc env obj in
-      ( acc,
-        Call_kind.method_call (Call_kind.Method_kind.from_lambda kind) ~obj mode
-      )
+        (* See [close_apply] *)
   in
   let acc, apply_exn_continuation =
     close_exn_continuation acc env exn_continuation
@@ -1797,7 +1788,6 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
   let fbody acc env =
     close_exact_or_unknown_apply acc env
       { apply with
-        kind = Function;
         args = all_args;
         continuation = return_continuation;
         exn_continuation;

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -704,6 +704,7 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
       | Pbigstring_set_32 _ | Pbigstring_set_64 _ | Pctconst _ | Pbswap16
       | Pbbswap _ | Pint_as_pointer | Popaque _ | Pprobe_is_enabled _ | Pobj_dup
       | Pobj_magic _ | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
+      | Pgetmethod _
         ->
         (* Inconsistent with outer match *)
         assert false

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -45,16 +45,8 @@ module IR = struct
           region : Ident.t
         }
 
-  type apply_kind =
-    | Function
-    | Method of
-        { kind : Lambda.meth_kind;
-          obj : simple
-        }
-
   type apply =
-    { kind : apply_kind;
-      func : Ident.t;
+    { func : Ident.t;
       args : simple list;
       continuation : Continuation.t;
       exn_continuation : exn_continuation;
@@ -800,7 +792,6 @@ module Expr_with_acc = struct
             { function_call = Indirect_unknown_arity | Indirect_known_arity; _ }
           ->
           false
-        | Method _ -> false
         | C_call _ -> false)
     in
     let acc =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -49,16 +49,8 @@ module IR : sig
           region : Ident.t
         }
 
-  type apply_kind =
-    | Function
-    | Method of
-        { kind : Lambda.meth_kind;
-          obj : simple
-        }
-
   type apply =
-    { kind : apply_kind;
-      func : Ident.t;
+    { func : Ident.t;
       args : simple list;
       continuation : Continuation.t;
       exn_continuation : exn_continuation;

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -493,7 +493,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
   | Lstaticcatch (_, _, _, _)
   | Ltrywith (_, _, _, _)
   | Lifthenelse (_, _, _, _)
-  | Lsend _ | Lvar _ | Lmutvar _
+  | Lvar _ | Lmutvar _
   | Lprim (_, _, _) ->
     (* This cannot be recursive, otherwise it should have been caught by the
        well formedness check. Hence it is ok to evaluate it before anything
@@ -507,7 +507,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
       | Lstringswitch (lam1, _, _, _, _)
       | Lifthenelse (lam1, _, _, _) ->
         Some lam1
-      | Lapply _ | Lstaticraise _ | Lsend _ | Lvar _ | Lmutvar _ | Lprim _ ->
+      | Lapply _ | Lstaticraise _ | Lvar _ | Lmutvar _ | Lprim _ ->
         Some lam
       | _ -> assert false
     in

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -507,8 +507,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
       | Lstringswitch (lam1, _, _, _, _)
       | Lifthenelse (lam1, _, _, _) ->
         Some lam1
-      | Lapply _ | Lstaticraise _ | Lvar _ | Lmutvar _ | Lprim _ ->
-        Some lam
+      | Lapply _ | Lstaticraise _ | Lvar _ | Lmutvar _ | Lprim _ -> Some lam
       | _ -> assert false
     in
     Option.iter

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1472,8 +1472,7 @@ and cps_tail_apply acc env ccenv ap_func ap_args ap_region_close ap_mode ap_loc
             }
           in
           let apply : IR.apply =
-            { kind = Function;
-              func;
+            { func;
               continuation = k;
               exn_continuation;
               args;

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1209,7 +1209,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
       | Pbigstring_load_32 _ | Pbigstring_load_64 _
       | Parrayrefu (Pgenarray | Paddrarray | Pintarray | Pfloatarray)
       | Parrayrefs (Pgenarray | Paddrarray | Pintarray | Pfloatarray)
-      | Pcompare_ints | Pcompare_floats | Pcompare_bints _ | Pgetmethod (Self | Public)),
+      | Pcompare_ints | Pcompare_floats | Pcompare_bints _
+      | Pgetmethod (Self | Public) ),
       ([] | [_] | _ :: _ :: _ :: _) ) ->
     Misc.fatal_errorf
       "Closure_conversion.convert_primitive: Wrong arity for binary primitive \
@@ -1225,10 +1226,11 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list)
       "Closure_conversion.convert_primitive: Wrong arity for ternary primitive \
        %a (%a)"
       Printlambda.primitive prim H.print_list_of_simple_or_prim args
-  | Pgetmethod Cached, ([] | [_] | [_; _] | [_; _; _] | _ :: _ :: _ :: _ :: _ :: _) ->
+  | ( Pgetmethod Cached,
+      ([] | [_] | [_; _] | [_; _; _] | _ :: _ :: _ :: _ :: _ :: _) ) ->
     Misc.fatal_errorf
-      "Closure_conversion.convert_primitive: Wrong arity for quaternary primitive \
-       %a (%a)"
+      "Closure_conversion.convert_primitive: Wrong arity for quaternary \
+       primitive %a (%a)"
       Printlambda.primitive prim H.print_list_of_simple_or_prim args
   | (Pignore | Psequand | Psequor | Pbytes_of_string | Pbytes_to_string), _ ->
     Misc.fatal_errorf

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -31,7 +31,11 @@ type expr_primitive =
   | Ternary of
       P.ternary_primitive * simple_or_prim * simple_or_prim * simple_or_prim
   | Quaternary of
-      P.quaternary_primitive * simple_or_prim * simple_or_prim * simple_or_prim * simple_or_prim
+      P.quaternary_primitive
+      * simple_or_prim
+      * simple_or_prim
+      * simple_or_prim
+      * simple_or_prim
   | Variadic of P.variadic_primitive * simple_or_prim list
   | Checked of
       { validity_conditions : expr_primitive list;

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -29,6 +29,12 @@ type expr_primitive =
       * simple_or_prim
       * simple_or_prim
       * simple_or_prim
+  | Quaternary of
+      Flambda_primitive.quaternary_primitive
+      * simple_or_prim
+      * simple_or_prim
+      * simple_or_prim
+      * simple_or_prim
   | Variadic of Flambda_primitive.variadic_primitive * simple_or_prim list
   | Checked of
       { validity_conditions : expr_primitive list;

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -567,7 +567,7 @@ let binop (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   | Int_shift (i, s) -> Int_shift (i, s)
   | Float_arith o -> Infix (Float_arith o)
   | Float_comp c -> Infix (Float_comp c)
-  | String_or_bigstring_load _ | Bigarray_load _ ->
+  | String_or_bigstring_load _ | Bigarray_load _ | Get_method _ ->
     Misc.fatal_errorf "TODO: Binary primitive: %a"
       Flambda_primitive.Without_args.print
       (Flambda_primitive.Without_args.Binary op)
@@ -599,6 +599,7 @@ let prim env (p : Flambda_primitive.t) : Fexpr.prim =
     Binary (binop op, simple env arg1, simple env arg2)
   | Ternary (op, arg1, arg2, arg3) ->
     Ternary (ternop env op, simple env arg1, simple env arg2, simple env arg3)
+  | Quaternary _ -> failwith "TODO"
   | Variadic (op, args) -> Variadic (varop env op, List.map (simple env) args)
 
 let value_slots env map =

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -990,7 +990,6 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
       let alloc = alloc_mode_for_types alloc_mode in
       Function (Indirect alloc)
     | C_call { alloc; _ } -> C_call { alloc }
-    | Method _ -> Misc.fatal_error "TODO: Method call kind"
   in
   let param_arity = Apply_expr.args_arity app in
   let return_arity = Apply_expr.return_arity app in
@@ -1014,8 +1013,7 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
       let params_arity = Some (arity param_arity) in
       let ret_arity = arity return_arity in
       Some { params_arity; ret_arity }
-    | Function { function_call = Indirect_unknown_arity; alloc_mode = _ }
-    | Method _ ->
+    | Function { function_call = Indirect_unknown_arity; alloc_mode = _ } ->
       None
   in
   let inlined =

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -981,6 +981,12 @@ let simplify_bigarray_load _num_dimensions _bigarray_kind _bigarray_layout
     (P.result_kind' original_prim)
     ~original_term
 
+let simplify_get_method _is_self ~original_prim dacc ~original_term _dbg
+    ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
+  SPR.create_unknown dacc ~result_var
+    (P.result_kind' original_prim)
+    ~original_term
+
 let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var =
   let min_name_mode = Bound_var.name_mode result_var in
@@ -1023,5 +1029,7 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     | Bigarray_load (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_load num_dimensions bigarray_kind bigarray_layout
         ~original_prim
+    | Get_method { is_self } ->
+      simplify_get_method is_self ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -981,8 +981,8 @@ let simplify_bigarray_load _num_dimensions _bigarray_kind _bigarray_layout
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_get_method _is_self ~original_prim dacc ~original_term _dbg
-    ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
+let simplify_get_method _is_self ~original_prim dacc ~original_term _dbg ~arg1:_
+    ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var
     (P.result_kind' original_prim)
     ~original_term
@@ -1029,7 +1029,6 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     | Bigarray_load (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_load num_dimensions bigarray_kind bigarray_layout
         ~original_prim
-    | Get_method { is_self } ->
-      simplify_get_method is_self ~original_prim
+    | Get_method { is_self } -> simplify_get_method is_self ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -152,7 +152,8 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
       Simplify_ternary_primitive.simplify_ternary_primitive dacc original_prim
         ternary_prim ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty dbg
         ~result_var)
-  | Quaternary (quaternary_prim, orig_arg1, orig_arg2, orig_arg3, orig_arg4) -> (
+  | Quaternary (quaternary_prim, orig_arg1, orig_arg2, orig_arg3, orig_arg4)
+    -> (
     let arg1_ty = S.simplify_simple dacc orig_arg1 ~min_name_mode in
     let arg1 = T.get_alias_exn arg1_ty in
     let arg2_ty = S.simplify_simple dacc orig_arg2 ~min_name_mode in
@@ -167,18 +168,22 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
         P.args_kind_of_quaternary_primitive quaternary_prim
       in
       check_arg_kinds prim
-        [arg1_ty, arg1_kind; arg2_ty, arg2_kind; arg3_ty, arg3_kind; arg4_ty, arg4_kind]);
+        [ arg1_ty, arg1_kind;
+          arg2_ty, arg2_kind;
+          arg3_ty, arg3_kind;
+          arg4_ty, arg4_kind ]);
     let original_prim : P.t =
-      if orig_arg1 == arg1 && orig_arg2 == arg2 && orig_arg3 = arg3 && orig_arg4 == arg4
+      if orig_arg1 == arg1 && orig_arg2 == arg2 && orig_arg3 = arg3
+         && orig_arg4 == arg4
       then prim
       else Quaternary (quaternary_prim, arg1, arg2, arg3, arg4)
     in
     match try_cse dacc ~original_prim ~min_name_mode ~result_var with
     | Applied result -> result
     | Not_applied dacc ->
-      Simplify_quaternary_primitive.simplify_quaternary_primitive dacc original_prim
-        quaternary_prim ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty ~arg4 ~arg4_ty dbg
-        ~result_var)
+      Simplify_quaternary_primitive.simplify_quaternary_primitive dacc
+        original_prim quaternary_prim ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3
+        ~arg3_ty ~arg4 ~arg4_ty dbg ~result_var)
   | Variadic (variadic_prim, orig_args) -> (
     let args_with_tys =
       ListLabels.fold_right orig_args ~init:[] ~f:(fun arg args_rev ->

--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -152,6 +152,33 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
       Simplify_ternary_primitive.simplify_ternary_primitive dacc original_prim
         ternary_prim ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty dbg
         ~result_var)
+  | Quaternary (quaternary_prim, orig_arg1, orig_arg2, orig_arg3, orig_arg4) -> (
+    let arg1_ty = S.simplify_simple dacc orig_arg1 ~min_name_mode in
+    let arg1 = T.get_alias_exn arg1_ty in
+    let arg2_ty = S.simplify_simple dacc orig_arg2 ~min_name_mode in
+    let arg2 = T.get_alias_exn arg2_ty in
+    let arg3_ty = S.simplify_simple dacc orig_arg3 ~min_name_mode in
+    let arg3 = T.get_alias_exn arg3_ty in
+    let arg4_ty = S.simplify_simple dacc orig_arg4 ~min_name_mode in
+    let arg4 = T.get_alias_exn arg4_ty in
+    (if Flambda_features.check_invariants ()
+    then
+      let arg1_kind, arg2_kind, arg3_kind, arg4_kind =
+        P.args_kind_of_quaternary_primitive quaternary_prim
+      in
+      check_arg_kinds prim
+        [arg1_ty, arg1_kind; arg2_ty, arg2_kind; arg3_ty, arg3_kind; arg4_ty, arg4_kind]);
+    let original_prim : P.t =
+      if orig_arg1 == arg1 && orig_arg2 == arg2 && orig_arg3 = arg3 && orig_arg4 == arg4
+      then prim
+      else Quaternary (quaternary_prim, arg1, arg2, arg3, arg4)
+    in
+    match try_cse dacc ~original_prim ~min_name_mode ~result_var with
+    | Applied result -> result
+    | Not_applied dacc ->
+      Simplify_quaternary_primitive.simplify_quaternary_primitive dacc original_prim
+        quaternary_prim ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty ~arg4 ~arg4_ty dbg
+        ~result_var)
   | Variadic (variadic_prim, orig_args) -> (
     let args_with_tys =
       ListLabels.fold_right orig_args ~init:[] ~f:(fun arg args_rev ->

--- a/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
@@ -1,0 +1,35 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2019 OCamlPro SAS                                    *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open! Simplify_import
+
+let simplify_get_cached_method dacc ~original_prim
+    ~original_term _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_ ~arg4:_ ~arg4_ty:_
+    ~result_var =
+  SPR.create_unknown dacc ~result_var
+    (P.result_kind' original_prim)
+    ~original_term
+
+let simplify_quaternary_primitive dacc original_prim (prim : P.quaternary_primitive)
+    ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty ~arg4 ~arg4_ty dbg ~result_var =
+  let original_term = Named.create_prim original_prim dbg in
+  let simplifier =
+    match prim with
+    | Get_cached_method ->
+      simplify_get_cached_method ~original_prim
+  in
+  simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3
+    ~arg3_ty ~arg4 ~arg4_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
@@ -16,20 +16,20 @@
 
 open! Simplify_import
 
-let simplify_get_cached_method dacc ~original_prim
-    ~original_term _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_ ~arg4:_ ~arg4_ty:_
+let simplify_get_cached_method dacc ~original_prim ~original_term _dbg ~arg1:_
+    ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_ ~arg4:_ ~arg4_ty:_
     ~result_var =
   SPR.create_unknown dacc ~result_var
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_quaternary_primitive dacc original_prim (prim : P.quaternary_primitive)
-    ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty ~arg4 ~arg4_ty dbg ~result_var =
+let simplify_quaternary_primitive dacc original_prim
+    (prim : P.quaternary_primitive) ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty
+    ~arg4 ~arg4_ty dbg ~result_var =
   let original_term = Named.create_prim original_prim dbg in
   let simplifier =
     match prim with
-    | Get_cached_method ->
-      simplify_get_cached_method ~original_prim
+    | Get_cached_method -> simplify_get_cached_method ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3
     ~arg3_ty ~arg4 ~arg4_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_quaternary_primitive.mli
+++ b/middle_end/flambda2/simplify/simplify_quaternary_primitive.mli
@@ -1,0 +1,33 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2019 OCamlPro SAS                                    *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Simplification of primitives taking four arguments. *)
+
+val simplify_quaternary_primitive :
+  Downwards_acc.t ->
+  Flambda_primitive.t ->
+  Flambda_primitive.quaternary_primitive ->
+  arg1:Simple.t ->
+  arg1_ty:Flambda2_types.t ->
+  arg2:Simple.t ->
+  arg2_ty:Flambda2_types.t ->
+  arg3:Simple.t ->
+  arg3_ty:Flambda2_types.t ->
+  arg4:Simple.t ->
+  arg4_ty:Flambda2_types.t ->
+  Debuginfo.t ->
+  result_var:Bound_var.t ->
+  Simplify_primitive_result.t

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -152,7 +152,7 @@ let invariant
        region = _
      } as t) =
   (match call_kind with
-  | Function _ | Method _ -> ()
+  | Function _ -> ()
   | C_call _ -> (
     if not (Simple.is_symbol callee)
     then

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -97,4 +97,3 @@ let ids_for_export t =
   | Function { function_call = Indirect_known_arity; alloc_mode = _ }
   | C_call { alloc = _; is_c_builtin = _ } ->
     Ids_for_export.empty
-

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -25,27 +25,11 @@ module Function_call : sig
     | Indirect_known_arity
 end
 
-module Method_kind : sig
-  type t = private
-    | Self
-    | Public
-    | Cached
-
-  val from_lambda : Lambda.meth_kind -> t
-
-  val to_lambda : t -> Lambda.meth_kind
-end
-
 (** Whether an application expression corresponds to an OCaml function
     invocation, an OCaml method invocation, or an external call. *)
 type t = private
   | Function of
       { function_call : Function_call.t;
-        alloc_mode : Alloc_mode.For_types.t
-      }
-  | Method of
-      { kind : Method_kind.t;
-        obj : Simple.t;
         alloc_mode : Alloc_mode.For_types.t
       }
   | C_call of
@@ -64,7 +48,5 @@ val direct_function_call : Code_id.t -> Alloc_mode.For_types.t -> t
 val indirect_function_call_unknown_arity : Alloc_mode.For_types.t -> t
 
 val indirect_function_call_known_arity : Alloc_mode.For_types.t -> t
-
-val method_call : Method_kind.t -> obj:Simple.t -> Alloc_mode.For_types.t -> t
 
 val c_call : alloc:bool -> is_c_builtin:bool -> t

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -370,7 +370,8 @@ let ternary_prim_size prim =
 
 let quaternary_prim_size prim =
   match (prim : Flambda_primitive.quaternary_primitive) with
-  | Get_cached_method -> direct_call_size (* CR ncourant: is this a good estimate? *)
+  | Get_cached_method ->
+    direct_call_size (* CR ncourant: is this a good estimate? *)
 
 let variadic_prim_size prim args =
   match (prim : Flambda_primitive.variadic_primitive) with

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -405,7 +405,6 @@ let apply apply =
     indirect_call_size
   | C_call { alloc = true; _ } -> alloc_extcall_size
   | C_call { alloc = false; _ } -> nonalloc_extcall_size
-  | Method _ -> 8
 (* from flambda/inlining_cost.ml *)
 
 let apply_cont apply_cont =

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -356,6 +356,7 @@ let binary_prim_size prim =
   | Float_arith op -> binary_float_arith_primitive op
   | Float_comp (Yielding_bool cmp) -> binary_float_comp_primitive cmp
   | Float_comp (Yielding_int_like_compare_functions ()) -> 8
+  | Get_method _ -> direct_call_size (* CR ncourant: is this good? *)
 
 let ternary_prim_size prim =
   match (prim : Flambda_primitive.ternary_primitive) with
@@ -366,6 +367,10 @@ let ternary_prim_size prim =
     5 (* ~ 3 block_load + 2 block_set *)
   | Bigarray_set (_dims, _kind, _layout) -> 2
 (* ~ 1 block_load + 1 block_set *)
+
+let quaternary_prim_size prim =
+  match (prim : Flambda_primitive.quaternary_primitive) with
+  | Get_cached_method -> direct_call_size (* CR ncourant: is this a good estimate? *)
 
 let variadic_prim_size prim args =
   match (prim : Flambda_primitive.variadic_primitive) with
@@ -381,6 +386,7 @@ let prim (prim : Flambda_primitive.t) =
   | Unary (p, _) -> unary_prim_size p
   | Binary (p, _, _) -> binary_prim_size p
   | Ternary (p, _, _, _) -> ternary_prim_size p
+  | Quaternary (p, _, _, _, _) -> quaternary_prim_size p
   | Variadic (p, args) -> variadic_prim_size p args
 
 let simple simple =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -348,7 +348,7 @@ type binary_primitive =
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
   | Float_arith of binary_float_arith_op
   | Float_comp of unit comparison_behaviour
-  | Get_method of { is_self: bool }
+  | Get_method of { is_self : bool }
 
 (** Primitives taking exactly three arguments. *)
 type ternary_primitive =
@@ -358,8 +358,7 @@ type ternary_primitive =
   | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
 
 (** Primitives taking exactly four arguments. *)
-type quaternary_primitive =
-  | Get_cached_method
+type quaternary_primitive = Get_cached_method
 
 (** Primitives taking zero or more arguments. *)
 type variadic_primitive =
@@ -374,7 +373,8 @@ type t =
   | Unary of unary_primitive * Simple.t
   | Binary of binary_primitive * Simple.t * Simple.t
   | Ternary of ternary_primitive * Simple.t * Simple.t * Simple.t
-  | Quaternary of quaternary_primitive * Simple.t * Simple.t * Simple.t * Simple.t
+  | Quaternary of
+      quaternary_primitive * Simple.t * Simple.t * Simple.t * Simple.t
   | Variadic of variadic_primitive * Simple.t list
 
 type primitive_application = t
@@ -414,7 +414,8 @@ val args_kind_of_ternary_primitive :
   ternary_primitive -> Flambda_kind.t * Flambda_kind.t * Flambda_kind.t
 
 val args_kind_of_quaternary_primitive :
-  quaternary_primitive -> Flambda_kind.t * Flambda_kind.t * Flambda_kind.t * Flambda_kind.t
+  quaternary_primitive ->
+  Flambda_kind.t * Flambda_kind.t * Flambda_kind.t * Flambda_kind.t
 
 type arg_kinds =
   | Variadic of Flambda_kind.t list
@@ -453,7 +454,8 @@ val result_kind_of_binary_primitive' : binary_primitive -> Flambda_kind.t
 
 val result_kind_of_ternary_primitive' : ternary_primitive -> Flambda_kind.t
 
-val result_kind_of_quaternary_primitive' : quaternary_primitive -> Flambda_kind.t
+val result_kind_of_quaternary_primitive' :
+  quaternary_primitive -> Flambda_kind.t
 
 val result_kind_of_variadic_primitive' : variadic_primitive -> Flambda_kind.t
 
@@ -512,7 +514,8 @@ val equal_binary_primitive : binary_primitive -> binary_primitive -> bool
 
 val equal_ternary_primitive : ternary_primitive -> ternary_primitive -> bool
 
-val equal_quaternary_primitive : quaternary_primitive -> quaternary_primitive -> bool
+val equal_quaternary_primitive :
+  quaternary_primitive -> quaternary_primitive -> bool
 
 val equal_variadic_primitive : variadic_primitive -> variadic_primitive -> bool
 

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -348,6 +348,7 @@ type binary_primitive =
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
   | Float_arith of binary_float_arith_op
   | Float_comp of unit comparison_behaviour
+  | Get_method of { is_self: bool }
 
 (** Primitives taking exactly three arguments. *)
 type ternary_primitive =
@@ -355,6 +356,10 @@ type ternary_primitive =
   | Array_set of Array_kind.t * Init_or_assign.t
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
   | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
+
+(** Primitives taking exactly four arguments. *)
+type quaternary_primitive =
+  | Get_cached_method
 
 (** Primitives taking zero or more arguments. *)
 type variadic_primitive =
@@ -369,6 +374,7 @@ type t =
   | Unary of unary_primitive * Simple.t
   | Binary of binary_primitive * Simple.t * Simple.t
   | Ternary of ternary_primitive * Simple.t * Simple.t * Simple.t
+  | Quaternary of quaternary_primitive * Simple.t * Simple.t * Simple.t * Simple.t
   | Variadic of variadic_primitive * Simple.t list
 
 type primitive_application = t
@@ -387,6 +393,7 @@ module Without_args : sig
     | Unary of unary_primitive
     | Binary of binary_primitive
     | Ternary of ternary_primitive
+    | Quaternary of quaternary_primitive
     | Variadic of variadic_primitive
 
   val print : Format.formatter -> t -> unit
@@ -405,6 +412,9 @@ val args_kind_of_binary_primitive :
 
 val args_kind_of_ternary_primitive :
   ternary_primitive -> Flambda_kind.t * Flambda_kind.t * Flambda_kind.t
+
+val args_kind_of_quaternary_primitive :
+  quaternary_primitive -> Flambda_kind.t * Flambda_kind.t * Flambda_kind.t * Flambda_kind.t
 
 type arg_kinds =
   | Variadic of Flambda_kind.t list
@@ -427,6 +437,8 @@ val result_kind_of_binary_primitive : binary_primitive -> result_kind
 
 val result_kind_of_ternary_primitive : ternary_primitive -> result_kind
 
+val result_kind_of_quaternary_primitive : quaternary_primitive -> result_kind
+
 val result_kind_of_variadic_primitive : variadic_primitive -> result_kind
 
 (** Describe the kind of the result of the given primitive. *)
@@ -440,6 +452,8 @@ val result_kind_of_unary_primitive' : unary_primitive -> Flambda_kind.t
 val result_kind_of_binary_primitive' : binary_primitive -> Flambda_kind.t
 
 val result_kind_of_ternary_primitive' : ternary_primitive -> Flambda_kind.t
+
+val result_kind_of_quaternary_primitive' : quaternary_primitive -> Flambda_kind.t
 
 val result_kind_of_variadic_primitive' : variadic_primitive -> Flambda_kind.t
 
@@ -497,6 +511,8 @@ val equal_unary_primitive : unary_primitive -> unary_primitive -> bool
 val equal_binary_primitive : binary_primitive -> binary_primitive -> bool
 
 val equal_ternary_primitive : ternary_primitive -> ternary_primitive -> bool
+
+val equal_quaternary_primitive : quaternary_primitive -> quaternary_primitive -> bool
 
 val equal_variadic_primitive : variadic_primitive -> variadic_primitive -> bool
 

--- a/middle_end/flambda2/terms/removed_operations.ml
+++ b/middle_end/flambda2/terms/removed_operations.ml
@@ -54,7 +54,9 @@ let prim (prim : Flambda_primitive.t) =
          example) are not counted here. *)
       { zero with prim = 1 })
   | Nullary _ -> zero
-  | Binary (_, _, _) | Ternary (_, _, _, _) -> { zero with prim = 1 }
+    (* CR ncourant: get_method maybe removes a call? *)
+  | Binary (_, _, _) | Ternary (_, _, _, _) | Quaternary (_, _, _, _, _) ->
+    { zero with prim = 1 }
   | Variadic (prim, _) -> (
     match prim with Make_block _ | Make_array _ -> alloc)
   [@@ocaml.warning "-fragile-match"]

--- a/middle_end/flambda2/terms/removed_operations.ml
+++ b/middle_end/flambda2/terms/removed_operations.ml
@@ -53,8 +53,7 @@ let prim (prim : Flambda_primitive.t) =
       (* Some allocating primitives ([Num_conv] to naked_int64 on arch32 for
          example) are not counted here. *)
       { zero with prim = 1 })
-  | Nullary _ -> zero
-    (* CR ncourant: get_method maybe removes a call? *)
+  | Nullary _ -> zero (* CR ncourant: get_method maybe removes a call? *)
   | Binary (_, _, _) | Ternary (_, _, _, _) | Quaternary (_, _, _, _, _) ->
     { zero with prim = 1 }
   | Variadic (prim, _) -> (

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -66,8 +66,12 @@ type 'env trans_prim =
     quaternary :
       ( 'env,
         P.quaternary_primitive,
-        Cmm.expression -> Cmm.expression -> Cmm.expression -> Cmm.expression -> prim_res )
-        prim_helper;
+        Cmm.expression ->
+        Cmm.expression ->
+        Cmm.expression ->
+        Cmm.expression ->
+        prim_res )
+      prim_helper;
     variadic :
       ('env, P.variadic_primitive, Cmm.expression list -> prim_res) prim_helper
   }

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -63,6 +63,11 @@ type 'env trans_prim =
         P.ternary_primitive,
         Cmm.expression -> Cmm.expression -> Cmm.expression -> prim_res )
       prim_helper;
+    quaternary :
+      ( 'env,
+        P.quaternary_primitive,
+        Cmm.expression -> Cmm.expression -> Cmm.expression -> Cmm.expression -> prim_res )
+        prim_helper;
     variadic :
       ('env, P.variadic_primitive, Cmm.expression list -> prim_res) prim_helper
   }
@@ -532,9 +537,11 @@ let rebuild_prim ~dbg ~env ~res prim args =
     | Binary binary, [x; y] -> env.trans_prim.binary env res dbg binary x y
     | Ternary ternary, [x; y; z] ->
       env.trans_prim.ternary env res dbg ternary x y z
+    | Quaternary quaternary, [x; y; z; w] ->
+      env.trans_prim.quaternary env res dbg quaternary x y z w
     | Variadic variadic, args ->
       env.trans_prim.variadic env res dbg variadic args
-    | (Nullary _ | Unary _ | Binary _ | Ternary _), _ ->
+    | (Nullary _ | Unary _ | Binary _ | Ternary _ | Quaternary _), _ ->
       Misc.fatal_errorf
         "Mismatched arity when splitting a binding in to_cmm_env:@\n%a@\n%a"
         Flambda_primitive.Without_args.print prim

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -68,6 +68,11 @@ type 'env trans_prim =
         Flambda_primitive.ternary_primitive,
         Cmm.expression -> Cmm.expression -> Cmm.expression -> prim_res )
       prim_helper;
+    quaternary :
+      ( 'env,
+        Flambda_primitive.quaternary_primitive,
+        Cmm.expression -> Cmm.expression -> Cmm.expression -> Cmm.expression -> prim_res )
+        prim_helper;
     variadic :
       ( 'env,
         Flambda_primitive.variadic_primitive,

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -71,8 +71,12 @@ type 'env trans_prim =
     quaternary :
       ( 'env,
         Flambda_primitive.quaternary_primitive,
-        Cmm.expression -> Cmm.expression -> Cmm.expression -> Cmm.expression -> prim_res )
-        prim_helper;
+        Cmm.expression ->
+        Cmm.expression ->
+        Cmm.expression ->
+        Cmm.expression ->
+        prim_res )
+      prim_helper;
     variadic :
       ( 'env,
         Flambda_primitive.variadic_primitive,

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -197,7 +197,6 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       env,
       res,
       Ece.all )
-  | Call_kind.Method _ -> assert false
 
 (* Function calls that have an exn continuation with extra arguments must be
    wrapped with assignments for the mutable variables used to pass the extra

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -197,23 +197,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       env,
       res,
       Ece.all )
-  | Call_kind.Method { kind; obj; alloc_mode } ->
-    fail_if_probe apply;
-    let To_cmm_env.
-          { env;
-            res;
-            expr = { cmm = obj; free_vars = obj_free_vars; effs = _ }
-          } =
-      C.simple ~dbg env res obj
-    in
-    let free_vars = Backend_var.Set.union free_vars obj_free_vars in
-    let kind = Call_kind.Method_kind.to_lambda kind in
-    let alloc_mode = Alloc_mode.For_types.to_lambda alloc_mode in
-    ( C.send kind callee obj args args_ty return_ty (pos, alloc_mode) dbg,
-      free_vars,
-      env,
-      res,
-      Ece.all )
+  | Call_kind.Method _ -> assert false
 
 (* Function calls that have an exn continuation with extra arguments must be
    wrapped with assignments for the mutable variables used to pass the extra

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -506,10 +506,7 @@ let binary_float_comp_primitive_yielding_int _env dbg x y =
   C.mk_compare_floats_untagged dbg x y
 
 let get_method dbg is_self obj met =
-  if is_self then
-    C.lookup_label obj met dbg
-  else
-    C.lookup_tag obj met dbg
+  if is_self then C.lookup_label obj met dbg else C.lookup_tag obj met dbg
 
 let get_cached_method dbg obj met cache pos =
   C.get_cached_method obj met cache pos dbg
@@ -656,8 +653,7 @@ let binary_primitive env dbg f x y =
     binary_float_comp_primitive env dbg cmp x y
   | Float_comp (Yielding_int_like_compare_functions ()) ->
     binary_float_comp_primitive_yielding_int env dbg x y
-  | Get_method { is_self } ->
-    get_method dbg is_self x y
+  | Get_method { is_self } -> get_method dbg is_self x y
 
 let ternary_primitive _env dbg f x y z =
   match (f : P.ternary_primitive) with
@@ -722,8 +718,8 @@ let trans_prim : To_cmm_env.t To_cmm_env.trans_prim =
         None, res, cmm);
     quaternary =
       (fun env res dbg prim x y z w ->
-         let cmm = quaternary_primitive env dbg prim x y z w in
-         None, res, cmm);
+        let cmm = quaternary_primitive env dbg prim x y z w in
+        None, res, cmm);
     variadic =
       (fun env res dbg prim args ->
         let cmm = variadic_primitive env dbg prim args in
@@ -812,7 +808,9 @@ let prim_simple env res dbg p =
         w.free_vars
     in
     let effs = Ece.join (Ece.join (Ece.join x.effs y.effs) z.effs) w.effs in
-    let expr = quaternary_primitive env dbg quaternary x.cmm y.cmm z.cmm w.cmm in
+    let expr =
+      quaternary_primitive env dbg quaternary x.cmm y.cmm z.cmm w.cmm
+    in
     Env.simple expr free_vars, None, env, res, effs
   | Variadic (((Make_block _ | Make_array _) as variadic), l) ->
     let args, free_vars, env, res, effs =

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -310,7 +310,9 @@ let punbox_int = "Punbox_int"
 let pbox_int = "Pbox_int"
 let punbox_int_arg = "Punbox_int_arg"
 let pbox_int_arg = "Pbox_int_arg"
-
+let pgetmethod = "Pgetmethod"
+let pgetmethod_arg = "Pgetmethod_arg"
+  
 let anon_fn_with_loc (sloc: Lambda.scoped_location) =
   let loc = Debuginfo.Scoped_location.to_location sloc in
   let (file, line, startchar) = Location.get_pos_info loc.loc_start in
@@ -433,6 +435,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbox_float _ -> pbox_float
   | Punbox_int _ -> punbox_int
   | Pbox_int _ -> pbox_int
+  | Pgetmethod _ -> pgetmethod
 
 let of_primitive_arg : Lambda.primitive -> string = function
   | Pbytes_of_string -> pbytes_of_string_arg
@@ -545,3 +548,4 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbox_float _ -> pbox_float_arg
   | Punbox_int _ -> punbox_int_arg
   | Pbox_int _ -> pbox_int_arg
+  | Pgetmethod _ -> pgetmethod_arg

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -272,20 +272,6 @@ and lam ppf = function
        lam hi lam body
   | Uassign(id, expr) ->
       fprintf ppf "@[<2>(assign@ %a@ %a)@]" V.print id lam expr
-  | Usend (k, met, obj, largs, _, _, (pos,_) , _) ->
-      let form =
-        match pos with
-        | Rc_normal | Rc_nontail -> "send"
-        | Rc_close_at_apply -> "send[end_region]"
-      in
-      let args ppf largs =
-        List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
-      let kind =
-        if k = Lambda.Self then "self"
-        else if k = Lambda.Cached then "cache"
-        else "" in
-      fprintf ppf "@[<2>(%s%s@ %a@ %a%a)@]"
-        form kind lam obj lam met args largs
   | Uunreachable ->
       fprintf ppf "unreachable"
   | Uregion e ->

--- a/middle_end/printclambda_primitives.ml
+++ b/middle_end/printclambda_primitives.ml
@@ -235,3 +235,6 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
   | Pbox_int (bi, m) ->
     fprintf ppf "box_%s.%s" (boxed_integer_name bi) (alloc_kind m)
   | Punbox_int bi -> fprintf ppf "unbox_%s" (boxed_integer_name bi)
+  | Pgetmethod k ->
+    fprintf ppf "getmethod%s"
+      (match k with Self -> "self" | Cached -> "cached" | Public -> "")

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -156,6 +156,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Psequor ->
       (* Removed by [Closure_conversion] in the flambda pipeline. *)
       No_effects, No_coeffects
+  | Pgetmethod _ -> No_effects, No_coeffects
 
 type return_type =
   | Float
@@ -281,4 +282,5 @@ let may_locally_allocate (prim:Clambda_primitives.primitive) : bool =
   | Psequand
   | Psequor ->
       false
-  | Pprobe_is_enabled _ -> false
+  | Pprobe_is_enabled _
+  | Pgetmethod _ -> false

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -77,6 +77,8 @@ type region_close =
   | Rc_nontail        (* do not close region, must not TCO *)
   | Rc_close_at_apply (* close region and tail call *)
 
+type meth_kind = Self | Public | Cached
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -95,6 +97,8 @@ type primitive =
   | Pfloatfield of int * field_read_semantics * alloc_mode
   | Psetfloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
+  (* Get methods of objects *)
+  | Pgetmethod of meth_kind
   (* External call *)
   | Pccall of Primitive.description
   (* Exceptions *)
@@ -342,8 +346,6 @@ type let_kind = Strict | Alias | StrictOpt
       we can discard e if x does not appear in e'
  *)
 
-type meth_kind = Self | Public | Cached
-
 val equal_meth_kind : meth_kind -> meth_kind -> bool
 
 type shared_code = (int * int) list     (* stack size -> code label *)
@@ -389,8 +391,6 @@ type lambda =
   | Lwhile of lambda_while
   | Lfor of lambda_for
   | Lassign of Ident.t * lambda
-  | Lsend of meth_kind * lambda * lambda * lambda list
-             * region_close * alloc_mode * scoped_location * layout
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
   | Lregion of lambda * layout

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -3664,7 +3664,7 @@ let rec map_return f = function
           Option.map (map_return f) def,
           loc, k )
   | (Lstaticraise _ | Lprim (Praise _, _, _)) as l -> l
-  | ( Lvar _ | Lmutvar _ | Lconst _ | Lapply _ | Lfunction _ | Lsend _ | Lprim _
+  | ( Lvar _ | Lmutvar _ | Lconst _ | Lapply _ | Lfunction _  | Lprim _
     | Lwhile _ | Lfor _ | Lassign _ | Lifused _ ) as l ->
       f l
   | Lregion (l, layout) -> Lregion (map_return f l, layout)

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -456,6 +456,11 @@ let primitive ppf = function
   | Punbox_int bi -> fprintf ppf "unbox_%s" (boxed_integer_name bi)
   | Pbox_int (bi, m) ->
       fprintf ppf "box_%s%s" (boxed_integer_name bi) (alloc_kind m)
+  | Pgetmethod k ->
+      let kind =
+        if k = Self then "self" else if k = Cached then "cache" else "" in
+      fprintf ppf "getmethod%s" kind
+
 
 let name_of_primitive = function
   | Pbytes_of_string -> "Pbytes_of_string"
@@ -568,6 +573,7 @@ let name_of_primitive = function
   | Pbox_float _ -> "Pbox_float"
   | Punbox_int _ -> "Punbox_int"
   | Pbox_int _ -> "Pbox_int"
+  | Pgetmethod _ -> "Pgetmethod"
 
 let check_attribute ppf check =
   let check_property = function
@@ -791,13 +797,6 @@ let rec lam ppf = function
        lam for_to (alloc_mode mode) lam for_body
   | Lassign(id, expr) ->
       fprintf ppf "@[<2>(assign@ %a@ %a)@]" Ident.print id lam expr
-  | Lsend (k, met, obj, largs, pos, reg, _, _) ->
-      let args ppf largs =
-        List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
-      let kind =
-        if k = Self then "self" else if k = Cached then "cache" else "" in
-      let form = apply_kind "send" pos reg in
-      fprintf ppf "@[<2>(%s%s@ %a@ %a%a)@]" form kind lam obj lam met args largs
   | Levent(expr, ev) ->
       let kind =
        match ev.lev_kind with

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -579,7 +579,7 @@ let declare_binding ctx (var, def) =
 let rec choice ctx t =
   let rec choice ctx ~tail t =
     match t with
-    | (Lvar _ | Lmutvar _ | Lconst _ | Lfunction _ | Lsend _
+    | (Lvar _ | Lmutvar _ | Lconst _ | Lfunction _
       | Lassign _ | Lfor _ | Lwhile _) ->
         let t = traverse ctx t in
         Choice.lambda t
@@ -882,6 +882,7 @@ let rec choice ctx t =
     | Pcompare_ints | Pcompare_floats | Pcompare_bints _
     | Punbox_float | Pbox_float _
     | Punbox_int _ | Pbox_int _
+    | Pgetmethod _
 
     (* we don't handle array indices as destinations yet *)
     | (Pmakearray _ | Pduparray _)

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -999,20 +999,13 @@ and transl_apply ~scopes
       ~result_layout
       lam sargs loc
   =
-  let rec lapply funct args loc pos mode result_layout =
+  let lapply funct args loc pos mode result_layout =
     match funct, pos with
     | Lapply ({ ap_region_close = (Rc_normal | Rc_nontail) } as ap),
-      (Rc_normal | Rc_nontail)
-    | Levent (Lapply ({ ap_region_close = (Rc_normal | Rc_nontail) } as ap), _),
       (Rc_normal | Rc_nontail) ->
         Lapply
           {ap with ap_args = ap.ap_args @ args; ap_loc = loc;
                    ap_region_close = pos; ap_mode = mode}
-    | Llet (kind, layout, name, value, body), pos ->
-        (* The function of an application is evaluated first, so it is safe to
-           push the application under the [Llet]. *)
-        Llet (kind, layout, name, value,
-             lapply body args loc pos mode result_layout)
     | lexp, _ ->
         Lapply {
           ap_loc=loc;

--- a/ocaml/runtime/interp.c
+++ b/ocaml/runtime/interp.c
@@ -1115,6 +1115,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(GETMETHOD):
       accu = Lookup(sp[0], accu);
+      sp++;
       Next;
 
 #define CAML_METHOD_CACHE
@@ -1152,6 +1153,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         accu = Field (meths, li-1);
       }
       pc++;
+      sp++;
       Next;
     }
 #else
@@ -1171,6 +1173,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         else li = mi;
       }
       accu = Field (meths, li-1);
+      sp++;
       Next;
     }
 

--- a/ocaml/runtime/obj.c
+++ b/ocaml/runtime/obj.c
@@ -261,9 +261,10 @@ CAMLprim value caml_get_public_method (value obj, value tag)
   return (tag == Field(meths,li) ? Field (meths, li-1) : 0);
 }
 
-CAMLprim value caml_get_cached_public_method (value obj, value tag, value *cache)
+CAMLprim value caml_get_cached_public_method (value obj, value tag, value cache_, value pos)
 {
   value meths = Field(obj, 0);
+  value* cache = &Field(cache_, Val_long(pos));
   int tag_pos = (*cache) & Field(meths,1);
   int li = 3, hi = Field(meths,0), mi;
   if (Field(meths, tag_pos) == tag) {

--- a/ocaml/runtime/obj.c
+++ b/ocaml/runtime/obj.c
@@ -261,15 +261,20 @@ CAMLprim value caml_get_public_method (value obj, value tag)
   return (tag == Field(meths,li) ? Field (meths, li-1) : 0);
 }
 
-CAMLprim value caml_cache_public_method (value meths, value tag, value *cache)
+CAMLprim value caml_get_cached_public_method (value obj, value tag, value *cache)
 {
+  value meths = Field(obj, 0);
+  int tag_pos = (*cache) & Field(meths,1);
   int li = 3, hi = Field(meths,0), mi;
+  if (Field(meths, tag_pos) == tag) {
+    return Field(meths, tag_pos - 1);
+  }
   while (li < hi) { // no need to check the 1st time
     mi = ((li+hi) >> 1) | 1;
     if (tag < Field(meths,mi)) hi = mi-2;
     else li = mi;
   }
-  *cache = (li-3)*sizeof(value)+1;
+  *cache = li; // Always odd
   return Field (meths, li-1);
 }
 

--- a/ocaml/runtime/obj.c
+++ b/ocaml/runtime/obj.c
@@ -264,7 +264,7 @@ CAMLprim value caml_get_public_method (value obj, value tag)
 CAMLprim value caml_get_cached_public_method (value obj, value tag, value cache_, value pos)
 {
   value meths = Field(obj, 0);
-  value* cache = &Field(cache_, Val_long(pos));
+  value* cache = &Field(cache_, Long_val(pos));
   int tag_pos = (*cache) & Field(meths,1);
   int li = 3, hi = Field(meths,0), mi;
   if (Field(meths, tag_pos) == tag) {

--- a/ocaml/runtime/obj.c
+++ b/ocaml/runtime/obj.c
@@ -261,6 +261,19 @@ CAMLprim value caml_get_public_method (value obj, value tag)
   return (tag == Field(meths,li) ? Field (meths, li-1) : 0);
 }
 
+CAMLprim value caml_cache_public_method (value meths, value tag, value *cache)
+{
+  int li = 3, hi = Field(meths,0), mi;
+  while (li < hi) { // no need to check the 1st time
+    mi = ((li+hi) >> 1) | 1;
+    if (tag < Field(meths,mi)) hi = mi-2;
+    else li = mi;
+  }
+  *cache = (li-3)*sizeof(value)+1;
+  return Field (meths, li-1);
+}
+
+
 static value oo_last_id = Val_int(0);
 
 CAMLprim value caml_set_oo_id (value obj) {

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -185,8 +185,7 @@ let print_generic_fns gfns =
           (unique_arity_identifier arity)
           (return_arity_identifier result)) fns in
   printf "Currying functions:%a\n" pr_cfuns gfns.curry_fun;
-  printf "Apply functions:%a\n" pr_afuns gfns.apply_fun;
-  printf "Send functions:%a\n" pr_afuns gfns.send_fun
+  printf "Apply functions:%a\n" pr_afuns gfns.apply_fun
 
 let print_cmx_infos (uir, sections, crc) =
   print_general_infos Compilation_unit.output uir.uir_unit crc uir.uir_defines


### PR DESCRIPTION
A lot of code is still there that will need to be removed as well. The objective of this is to greatly simplify the treatment of calls to methods, by handling them like all other applications.