### PR TITLE
Add kind to Function_slot.t and Value_slot.t + fix join

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -270,8 +270,8 @@ let subst_set_of_closures env set =
   let value_slots =
     Set_of_closures.value_slots set
     |> Value_slot.Map.bindings
-    |> List.map (fun (var, (simple, kind)) ->
-           subst_value_slot env var, (subst_simple env simple, kind))
+    |> List.map (fun (var, simple) ->
+           subst_value_slot env var, subst_simple env simple)
     |> Value_slot.Map.of_list
   in
   let alloc = Set_of_closures.alloc_mode set in
@@ -756,7 +756,8 @@ let sets_of_closures env set1 set2 : Set_of_closures.t Comparison.t =
    * similar (and less worrisome) with function slots. *)
   let value_slots_by_value set =
     Value_slot.Map.bindings (Set_of_closures.value_slots set)
-    |> List.map (fun (var, (value, kind)) -> kind, subst_simple env value, var)
+    |> List.map (fun (var, value) ->
+           Value_slot.kind var, subst_simple env value, var)
   in
   (* We want to process the whole map to find new correspondences between
    * value slots, so we need to remember whether we've found any mismatches *)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1644,7 +1644,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
   let function_slot =
     Function_slot.create
       (Compilation_unit.get_current_exn ())
-      ~name:(Ident.name fid)
+      ~name:(Ident.name fid) Flambda_kind.With_subkind.any_value
   in
   let body acc ccenv =
     let ccenv = CCenv.set_path_to_root ccenv loc in

--- a/middle_end/flambda2/identifiers/slot.mli
+++ b/middle_end/flambda2/identifiers/slot.mli
@@ -19,7 +19,8 @@ module type S = sig
 
   module Lmap : Lmap.S with type key = t
 
-  val create : Compilation_unit.t -> name:string -> t
+  val create :
+    Compilation_unit.t -> name:string -> Flambda_kind.With_subkind.t -> t
 
   val get_compilation_unit : t -> Compilation_unit.t
 
@@ -30,6 +31,8 @@ module type S = sig
   val to_string : t -> string
 
   val name : t -> string
+
+  val kind : t -> Flambda_kind.With_subkind.t
 
   val rename : t -> t
 end

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -133,7 +133,11 @@ let fresh_code_id env { Fexpr.txt = name; loc = _ } =
   c, { env with code_ids = DM.add name c env.code_ids }
 
 let fresh_function_slot env { Fexpr.txt = name; loc = _ } =
-  let c = Function_slot.create (Compilation_unit.get_current_exn ()) ~name in
+  let c =
+    Function_slot.create
+      (Compilation_unit.get_current_exn ())
+      ~name Flambda_kind.With_subkind.any_value
+  in
   UT.add env.function_slots name c;
   c
 
@@ -142,14 +146,14 @@ let fresh_or_existing_function_slot env ({ Fexpr.txt = name; loc = _ } as id) =
   | None -> fresh_function_slot env id
   | Some function_slot -> function_slot
 
-let fresh_value_slot env { Fexpr.txt = name; loc = _ } =
-  let c = Value_slot.create (Compilation_unit.get_current_exn ()) ~name in
+let fresh_value_slot env { Fexpr.txt = name; loc = _ } kind =
+  let c = Value_slot.create (Compilation_unit.get_current_exn ()) ~name kind in
   WT.add env.vars_within_closures name c;
   c
 
-let fresh_or_existing_value_slot env ({ Fexpr.txt = name; _ } as id) =
+let fresh_or_existing_value_slot env ({ Fexpr.txt = name; _ } as id) kind =
   match WT.find_opt env.vars_within_closures name with
-  | None -> fresh_value_slot env id
+  | None -> fresh_value_slot env id kind
   | Some value_slot -> value_slot
 
 let print_scoped_location ppf loc =
@@ -385,10 +389,11 @@ let unop env (unop : Fexpr.unop) : Flambda_primitive.unary_primitive =
   | Opaque_identity ->
     Opaque_identity { middle_end_only = false; kind = Flambda_kind.value }
   | Project_value_slot { project_from; value_slot } ->
-    let value_slot = fresh_or_existing_value_slot env value_slot in
+    (* CR mshinwell: support non-value kinds *)
+    let kind = Flambda_kind.With_subkind.any_value in
+    let value_slot = fresh_or_existing_value_slot env value_slot kind in
     let project_from = fresh_or_existing_function_slot env project_from in
-    Project_value_slot
-      { project_from; value_slot; kind = Flambda_kind.With_subkind.any_value }
+    Project_value_slot { project_from; value_slot; kind }
   | Project_function_slot { move_from; move_to } ->
     let move_from = fresh_or_existing_function_slot env move_from in
     let move_to = fresh_or_existing_function_slot env move_to in
@@ -490,10 +495,11 @@ let set_of_closures env fun_decls value_slots alloc =
     |> Function_slot.Lmap.of_list |> Function_declarations.create
   in
   let value_slots = Option.value value_slots ~default:[] in
-  let value_slots : (Simple.t * Flambda_kind.With_subkind.t) Value_slot.Map.t =
+  let value_slots : Simple.t Value_slot.Map.t =
     let convert ({ var; value } : Fexpr.one_value_slot) =
-      ( fresh_or_existing_value_slot env var,
-        (simple env value, Flambda_kind.With_subkind.any_value) )
+      (* CR mshinwell: support non-value kinds *)
+      ( fresh_or_existing_value_slot env var Flambda_kind.With_subkind.any_value,
+        simple env value )
     in
     List.map convert value_slots |> Value_slot.Map.of_list
   in

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -601,7 +601,8 @@ let prim env (p : Flambda_primitive.t) : Fexpr.prim =
 
 let value_slots env map =
   List.map
-    (fun (var, (value, kind)) ->
+    (fun (var, value) ->
+      let kind = Value_slot.kind var in
       if not
            (Flambda_kind.equal
               (Flambda_kind.With_subkind.kind kind)

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -151,8 +151,7 @@ let rebuild_let simplify_named_result removed_operations ~rewrite_id
     in
     after_rebuild body uacc
 
-let record_one_value_slot_for_data_flow symbol value_slot (simple, _kind)
-    data_flow =
+let record_one_value_slot_for_data_flow symbol value_slot simple data_flow =
   Flow.Acc.record_value_slot (Name.symbol symbol) value_slot
     (Simple.free_names simple) data_flow
 

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -610,18 +610,18 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
     Function_slot.Map.map Bound_name.create_symbol closure_symbols_map
   in
   let value_slot_types =
-    Value_slot.Map.map
-      (fun (value_slot, kind_with_subkind) ->
-        let kind = K.With_subkind.kind kind_with_subkind in
-        Simple.pattern_match value_slot
-          ~const:(fun _ -> T.alias_type_of kind value_slot)
+    Value_slot.Map.mapi
+      (fun value_slot in_slot ->
+        let kind = K.With_subkind.kind (Value_slot.kind value_slot) in
+        Simple.pattern_match in_slot
+          ~const:(fun _ -> T.alias_type_of kind in_slot)
           ~name:(fun name ~coercion ->
             Name.pattern_match name
               ~var:(fun var ->
                 match Variable.Map.find var closure_bound_vars_inverse with
                 | exception Not_found ->
                   assert (DE.mem_variable (DA.denv dacc) var);
-                  T.alias_type_of kind value_slot
+                  T.alias_type_of kind in_slot
                 | function_slot ->
                   let closure_symbol =
                     Function_slot.Map.find function_slot closure_symbols_map
@@ -630,7 +630,7 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
                     Simple.with_coercion (Simple.symbol closure_symbol) coercion
                   in
                   T.alias_type_of kind simple)
-              ~symbol:(fun _sym -> T.alias_type_of kind value_slot)))
+              ~symbol:(fun _sym -> T.alias_type_of kind in_slot)))
       value_slots
   in
   let context =
@@ -735,7 +735,7 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
 
 type lifting_decision_result =
   { can_lift : bool;
-    value_slots : (Simple.t * K.With_subkind.t) Value_slot.Map.t;
+    value_slots : Simple.t Value_slot.Map.t;
     value_slot_types : T.t Value_slot.Map.t;
     symbol_projections : Symbol_projection.t Variable.Map.t
   }
@@ -753,7 +753,7 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
      available.) *)
   let value_slots, value_slot_types, symbol_projections =
     Value_slot.Map.fold
-      (fun value_slot (env_entry, kind)
+      (fun value_slot env_entry
            (value_slots, value_slot_types, symbol_projections) ->
         let env_entry, ty, symbol_projections =
           let ty =
@@ -777,9 +777,7 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
           in
           simple, ty, symbol_projections
         in
-        let value_slots =
-          Value_slot.Map.add value_slot (env_entry, kind) value_slots
-        in
+        let value_slots = Value_slot.Map.add value_slot env_entry value_slots in
         let value_slot_types =
           Value_slot.Map.add value_slot ty value_slot_types
         in
@@ -822,7 +820,7 @@ let type_value_slots_and_make_lifting_decision_for_one_set dacc
          | Unknown -> false)
        | Heap -> true
   in
-  let value_slot_permits_lifting _value_slot (simple, _kind) =
+  let value_slot_permits_lifting _value_slot simple =
     can_lift_coercion (Simple.coercion simple)
     && Simple.pattern_match' simple
          ~const:(fun _ -> true)

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -866,7 +866,8 @@ end = struct
       closure_map;
     (* Fill value slot slots *)
     Value_slot.Map.iter
-      (fun value_slot (_, kind) ->
+      (fun value_slot _ ->
+        let kind = Value_slot.kind value_slot in
         let size, is_unboxed =
           match Flambda_kind.With_subkind.kind kind with
           | Region | Rec_info ->

--- a/middle_end/flambda2/terms/set_of_closures.ml
+++ b/middle_end/flambda2/terms/set_of_closures.ml
@@ -16,13 +16,9 @@
 
 type t =
   { function_decls : Function_declarations.t;
-    value_slots : (Simple.t * Flambda_kind.With_subkind.t) Value_slot.Map.t;
+    value_slots : Simple.t Value_slot.Map.t;
     alloc_mode : Alloc_mode.For_allocations.t
   }
-
-let print_value_slot ppf (simple, kind) =
-  Format.fprintf ppf "@[(%a @<1>\u{2237} %a)@]" Simple.print simple
-    Flambda_kind.With_subkind.print kind
 
 let [@ocamlformat "disable"] print ppf
       { function_decls;
@@ -37,7 +33,7 @@ let [@ocamlformat "disable"] print ppf
     Flambda_colours.prim_constructive
     Flambda_colours.pop
     (Function_declarations.print) function_decls
-    (Value_slot.Map.print print_value_slot) value_slots
+    (Value_slot.Map.print Simple.print) value_slots
     Alloc_mode.For_allocations.print alloc_mode
 
 include Container_types.Make (struct
@@ -60,13 +56,7 @@ include Container_types.Make (struct
     if c <> 0
     then c
     else
-      let compare_value_slot (simple1, kind1) (simple2, kind2) =
-        let c = Simple.compare simple1 simple2 in
-        if c <> 0 then c else Flambda_kind.With_subkind.compare kind1 kind2
-      in
-      let c =
-        Value_slot.Map.compare compare_value_slot value_slots1 value_slots2
-      in
+      let c = Value_slot.Map.compare Simple.compare value_slots1 value_slots2 in
       if c <> 0
       then c
       else Alloc_mode.For_allocations.compare alloc_mode1 alloc_mode2
@@ -111,12 +101,12 @@ let [@ocamlformat "disable"] print ppf
       Flambda_colours.pop
       Alloc_mode.For_allocations.print alloc_mode
       Function_declarations.print function_decls
-      (Value_slot.Map.print print_value_slot) value_slots
+      (Value_slot.Map.print Simple.print) value_slots
 
 let free_names { function_decls; value_slots; alloc_mode = _ } =
   let free_names_of_value_slots =
     Value_slot.Map.fold
-      (fun value_slot (simple, _kind) free_names ->
+      (fun value_slot simple free_names ->
         Name_occurrences.union free_names
           (Name_occurrences.add_value_slot_in_declaration
              (Simple.free_names simple) value_slot Name_mode.normal))
@@ -135,12 +125,12 @@ let apply_renaming ({ function_decls; value_slots; alloc_mode } as t) renaming =
   let changed = ref false in
   let value_slots' =
     Value_slot.Map.filter_map
-      (fun var (simple, kind) ->
+      (fun var simple ->
         if Renaming.value_slot_is_used renaming var
         then (
           let simple' = Simple.apply_renaming simple renaming in
           if not (simple == simple') then changed := true;
-          Some (simple', kind))
+          Some simple')
         else (
           changed := true;
           None))
@@ -162,8 +152,7 @@ let ids_for_export { function_decls; value_slots; alloc_mode } =
   in
   Ids_for_export.union
     (Value_slot.Map.fold
-       (fun _value_slot (simple, _kind) ids ->
-         Ids_for_export.add_simple ids simple)
+       (fun _value_slot simple ids -> Ids_for_export.add_simple ids simple)
        value_slots function_decls_ids)
     (Alloc_mode.For_allocations.ids_for_export alloc_mode)
 

--- a/middle_end/flambda2/terms/set_of_closures.mli
+++ b/middle_end/flambda2/terms/set_of_closures.mli
@@ -25,7 +25,7 @@ val is_empty : t -> bool
 (** Create a set of closures given the code for its functions and the closure
     variables. *)
 val create :
-  value_slots:(Simple.t * Flambda_kind.With_subkind.t) Value_slot.Map.t ->
+  value_slots:Simple.t Value_slot.Map.t ->
   Alloc_mode.For_allocations.t ->
   Function_declarations.t ->
   t
@@ -34,7 +34,7 @@ val create :
 val function_decls : t -> Function_declarations.t
 
 (** The values of each value slot (the environment, or captured variables). *)
-val value_slots : t -> (Simple.t * Flambda_kind.With_subkind.t) Value_slot.Map.t
+val value_slots : t -> Simple.t Value_slot.Map.t
 
 (** Returns true iff the given set of closures has no value slots. *)
 val is_closed : t -> bool

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -99,7 +99,7 @@ end) : sig
     Code_id.t Function_slot.Map.t ->
     Debuginfo.t ->
     startenv:int ->
-    (Simple.t * Flambda_kind.With_subkind.t) Value_slot.Map.t ->
+    Simple.t Value_slot.Map.t ->
     Env.t ->
     To_cmm_result.t ->
     Ece.t ->
@@ -127,7 +127,8 @@ end = struct
         Ece.pure,
         updates )
     | Value_slot { value_slot; is_scanned; size = _ } ->
-      let simple, kind = Value_slot.Map.find value_slot value_slots in
+      let simple = Value_slot.Map.find value_slot value_slots in
+      let kind = Value_slot.kind value_slot in
       if (not
             (Flambda_kind.equal
                (Flambda_kind.With_subkind.kind kind)

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -1306,7 +1306,7 @@ and join_head_of_kind_region _env () () : _ Or_unknown.t = Known ()
 and join_row_like :
       'index 'maps_to 'row_tag 'known.
       join_maps_to:(Join_env.t -> 'maps_to -> 'maps_to -> 'maps_to) ->
-      maps_to_field_kind:('maps_to -> K.t option) ->
+      maps_to_field_kind:('maps_to -> K.t) option ->
       equal_index:('index -> 'index -> bool) ->
       inter_index:('index -> 'index -> 'index) ->
       merge_map_known:
@@ -1342,14 +1342,12 @@ and join_row_like :
   in
   let matching_kinds (case1 : ('index, 'maps_to) TG.Row_like_case.t)
       (case2 : ('index, 'maps_to) TG.Row_like_case.t) =
-    match
-      maps_to_field_kind case1.maps_to, maps_to_field_kind case2.maps_to
-    with
-    | None, None -> true
-    | Some kind1, Some kind2 -> K.equal kind1 kind2
-    | None, Some _ | Some _, None ->
-      (* See call sites below. *)
-      assert false
+    match maps_to_field_kind with
+    | None -> true
+    | Some maps_to_field_kind ->
+      K.equal
+        (maps_to_field_kind case1.maps_to)
+        (maps_to_field_kind case2.maps_to)
   in
   let join_case join_env (case1 : ('index, 'maps_to) TG.Row_like_case.t)
       (case2 : ('index, 'maps_to) TG.Row_like_case.t) =
@@ -1446,8 +1444,7 @@ and join_row_like_for_blocks env
       TG.Row_like_for_blocks.t) =
   let known_tags, other_tags =
     join_row_like ~join_maps_to:join_int_indexed_product
-      ~maps_to_field_kind:(fun product ->
-        Some (TG.Product.Int_indexed.field_kind product))
+      ~maps_to_field_kind:(Some TG.Product.Int_indexed.field_kind)
       ~equal_index:TG.Block_size.equal ~inter_index:TG.Block_size.inter
       ~merge_map_known:Tag.Map.merge env ~known1 ~known2 ~other1 ~other2
   in
@@ -1460,8 +1457,7 @@ and join_row_like_for_closures env
     ({ known_closures = known2; other_closures = other2 } :
       TG.Row_like_for_closures.t) : TG.Row_like_for_closures.t =
   let known_closures, other_closures =
-    join_row_like ~join_maps_to:join_closures_entry
-      ~maps_to_field_kind:(fun _ -> None)
+    join_row_like ~join_maps_to:join_closures_entry ~maps_to_field_kind:None
       ~equal_index:Set_of_closures_contents.equal
       ~inter_index:Set_of_closures_contents.inter
       ~merge_map_known:Function_slot.Map.merge env ~known1 ~known2 ~other1

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -1306,7 +1306,7 @@ and join_head_of_kind_region _env () () : _ Or_unknown.t = Known ()
 and join_row_like :
       'index 'maps_to 'row_tag 'known.
       join_maps_to:(Join_env.t -> 'maps_to -> 'maps_to -> 'maps_to) ->
-      maps_to_field_kind:('maps_to -> K.t) ->
+      maps_to_field_kind:('maps_to -> K.t option) ->
       equal_index:('index -> 'index -> bool) ->
       inter_index:('index -> 'index -> 'index) ->
       merge_map_known:
@@ -1342,9 +1342,14 @@ and join_row_like :
   in
   let matching_kinds (case1 : ('index, 'maps_to) TG.Row_like_case.t)
       (case2 : ('index, 'maps_to) TG.Row_like_case.t) =
-    K.equal
-      (maps_to_field_kind case1.maps_to)
-      (maps_to_field_kind case2.maps_to)
+    match
+      maps_to_field_kind case1.maps_to, maps_to_field_kind case2.maps_to
+    with
+    | None, None -> true
+    | Some kind1, Some kind2 -> K.equal kind1 kind2
+    | None, Some _ | Some _, None ->
+      (* See call sites below. *)
+      assert false
   in
   let join_case join_env (case1 : ('index, 'maps_to) TG.Row_like_case.t)
       (case2 : ('index, 'maps_to) TG.Row_like_case.t) =
@@ -1441,7 +1446,8 @@ and join_row_like_for_blocks env
       TG.Row_like_for_blocks.t) =
   let known_tags, other_tags =
     join_row_like ~join_maps_to:join_int_indexed_product
-      ~maps_to_field_kind:TG.Product.Int_indexed.field_kind
+      ~maps_to_field_kind:(fun product ->
+        Some (TG.Product.Int_indexed.field_kind product))
       ~equal_index:TG.Block_size.equal ~inter_index:TG.Block_size.inter
       ~merge_map_known:Tag.Map.merge env ~known1 ~known2 ~other1 ~other2
   in
@@ -1455,7 +1461,7 @@ and join_row_like_for_closures env
       TG.Row_like_for_closures.t) : TG.Row_like_for_closures.t =
   let known_closures, other_closures =
     join_row_like ~join_maps_to:join_closures_entry
-      ~maps_to_field_kind:(fun _ -> K.value)
+      ~maps_to_field_kind:(fun _ -> None)
       ~equal_index:Set_of_closures_contents.equal
       ~inter_index:Set_of_closures_contents.inter
       ~merge_map_known:Function_slot.Map.merge env ~known1 ~known2 ~other1


### PR DESCRIPTION
The change to add the kind to slots both cleans up existing code and should ensure correct operation in the join.  The `maps_to_field_kind` comparison is now only done for blocks; for closures field kind equality is enforced by equality on value slots.