### PR TITLE
Set better default rec_info in cmx files in classic mode

### DIFF
--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1193,7 +1193,7 @@ end = struct
         (* CR keryan: we should use the associated symbol at some point *)
         let fun_decl =
           TG.Function_type.create code_id
-            ~rec_info:(MTC.unknown Flambda_kind.rec_info)
+            ~rec_info:(TG.this_rec_info Rec_info_expr.initial)
         in
         let all_function_slots_in_set =
           Function_slot.Map.singleton function_slot


### PR DESCRIPTION
Should fix #1199 

This PR changes the rec_info of functions as exported in the classic mode cmx files, to be the initial (`depth=0`) rec_info, rather than the unknown one (`depth=infinity`).

This follows what is done in regular mode, here :
https://github.com/ocaml-flambda/flambda-backend/blob/5d0923daea0a30d7919a2f781b19b0643dcfb9be/middle_end/flambda2/simplify/simplify_set_of_closures.ml#L519-L525

where the default rec_info to use for a function declaration (outside of its own body), is `Rec_info_expr.initial` rather than `unknown`.