### PR TITLE
Speed up linking by shrinking symbol and relocation tables

### DIFF
--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -20,8 +20,9 @@ open Cmm
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
-let afl_area_ptr dbg = Cconst_symbol ("caml_afl_area_ptr", dbg)
-let afl_prev_loc dbg = Cconst_symbol ("caml_afl_prev_loc", dbg)
+let sym s = { sym_name = s; sym_global = Global }
+let afl_area_ptr dbg = Cconst_symbol (sym "caml_afl_area_ptr", dbg)
+let afl_prev_loc dbg = Cconst_symbol (sym "caml_afl_prev_loc", dbg)
 let afl_map_size = 1 lsl 16
 
 let rec with_afl_logging b dbg =

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -66,7 +66,7 @@ let command_line_options =
 open Format
 
 type addressing_mode =
-    Ibased of string * int              (* symbol + displ *)
+    Ibased of string * bool * int       (* symbol + displ *)
   | Iindexed of int                     (* reg + displ *)
   | Iindexed2 of int                    (* reg + reg + displ *)
   | Iscaled of int * int                (* reg * scale + displ *)
@@ -140,7 +140,7 @@ let identity_addressing = Iindexed 0
 
 let offset_addressing addr delta =
   match addr with
-    Ibased(s, n) -> Ibased(s, n + delta)
+    Ibased(s, glob, n) -> Ibased(s, glob, n + delta)
   | Iindexed n -> Iindexed(n + delta)
   | Iindexed2 n -> Iindexed2(n + delta)
   | Iscaled(scale, n) -> Iscaled(scale, n + delta)
@@ -175,9 +175,9 @@ let int_of_bswap_bitwidth = function
 
 let print_addressing printreg addr ppf arg =
   match addr with
-  | Ibased(s, 0) ->
+  | Ibased(s, _glob, 0) ->
       fprintf ppf "\"%s\"" s
-  | Ibased(s, n) ->
+  | Ibased(s, _glob, n) ->
       fprintf ppf "\"%s\" + %i" s n
   | Iindexed n ->
       let idx = if n <> 0 then Printf.sprintf " + %i" n else "" in
@@ -305,8 +305,8 @@ let float_cond_and_need_swap cond =
 
 let equal_addressing_mode left right =
   match left, right with
-  | Ibased (left_sym, left_displ), Ibased (right_sym, right_displ) ->
-    String.equal left_sym right_sym && Int.equal left_displ right_displ
+  | Ibased (left_sym, left_glob, left_displ), Ibased (right_sym, right_glob, right_displ) ->
+    String.equal left_sym right_sym && Bool.equal left_glob right_glob && Int.equal left_displ right_displ
   | Iindexed left_displ, Iindexed right_displ ->
     Int.equal left_displ right_displ
   | Iindexed2 left_displ, Iindexed2 right_displ ->

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -65,8 +65,10 @@ let command_line_options =
 
 open Format
 
+type sym_global = Global | Local
+
 type addressing_mode =
-    Ibased of string * bool * int       (* symbol + displ *)
+    Ibased of string * sym_global * int (* symbol + displ *)
   | Iindexed of int                     (* reg + displ *)
   | Iindexed2 of int                    (* reg + reg + displ *)
   | Iscaled of int * int                (* reg * scale + displ *)
@@ -306,7 +308,7 @@ let float_cond_and_need_swap cond =
 let equal_addressing_mode left right =
   match left, right with
   | Ibased (left_sym, left_glob, left_displ), Ibased (right_sym, right_glob, right_displ) ->
-    String.equal left_sym right_sym && Bool.equal left_glob right_glob && Int.equal left_displ right_displ
+    String.equal left_sym right_sym && left_glob = right_glob && Int.equal left_displ right_displ
   | Iindexed left_displ, Iindexed right_displ ->
     Int.equal left_displ right_displ
   | Iindexed2 left_displ, Iindexed2 right_displ ->

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -166,40 +166,56 @@ let mem__imp s =
   let imp_s = get_imp_symbol s in
   mem64_rip QWORD (emit_symbol imp_s)
 
-let rel_plt s =
-  if windows && !Clflags.dlcode then mem__imp s
-  else
-    sym (if use_plt then emit_symbol s ^ "@PLT" else emit_symbol s)
+(* Output a label *)
+
+let label_name lbl =
+  match system with
+  | S_macosx | S_win64 -> "L" ^ lbl
+  | _ -> ".L" ^ lbl
+
+let emit_label lbl =
+  label_name (Int.to_string lbl)
+
+let rel_plt (s : Cmm.symbol) =
+  match s.sym_global with
+  | Local -> sym (label_name (emit_symbol s.sym_name))
+  | Global ->
+    if windows && !Clflags.dlcode then mem__imp s.sym_name
+    else
+      let s = emit_symbol s.sym_name in
+      sym (if use_plt then s ^ "@PLT" else s)
 
 let emit_call s = I.call (rel_plt s)
 
 let emit_jump s = I.jmp (rel_plt s)
 
-let load_symbol_addr s arg =
-  if !Clflags.dlcode then
-    if windows then begin
-      (* I.mov (mem__imp s) arg (\* mov __caml_imp_foo(%rip), ... *\) *)
-      I.mov (sym (emit_symbol s)) arg (* movabsq $foo, ... *)
-    end else I.mov (mem64_rip QWORD (emit_symbol s ^ "@GOTPCREL")) arg
-  else if !Clflags.pic_code then
-    I.lea (mem64_rip NONE (emit_symbol s)) arg
-  else
-    I.mov (sym (emit_symbol s)) arg
-
 let domain_field f =
   mem64 QWORD (Domainstate.idx_of_field f * 8) R14
-
-(* Output a label *)
-
-let emit_label lbl =
-  match system with
-  | S_macosx | S_win64 -> "L" ^ Int.to_string lbl
-  | _ -> ".L" ^ Int.to_string lbl
 
 let label s = sym (emit_label s)
 
 let def_label ?typ s =
   D.label ?typ (emit_label s)
+
+let emit_cmm_symbol (s : Cmm.symbol) =
+  match s.sym_global with
+  | Global -> emit_symbol s.sym_name
+  | Local -> label_name (emit_symbol s.sym_name)
+
+let load_symbol_addr s arg =
+  match s.sym_global with
+  | Local ->
+    I.lea (mem64_rip NONE (label_name (emit_symbol s.sym_name))) arg
+  | Global ->
+    if !Clflags.dlcode then
+      if windows then begin
+        (* I.mov (mem__imp s) arg (\* mov __caml_imp_foo(%rip), ... *\) *)
+        I.mov (sym (emit_symbol s.sym_name)) arg (* movabsq $foo, ... *)
+      end else I.mov (mem64_rip QWORD (emit_symbol s.sym_name ^ "@GOTPCREL")) arg
+    else if !Clflags.pic_code then
+      I.lea (mem64_rip NONE (emit_symbol s.sym_name)) arg
+    else
+      I.mov (sym (emit_symbol s.sym_name)) arg
 
 (* Output .text section directive, or named .text.caml.<name> if enabled and
    supported on the target system. *)
@@ -305,9 +321,10 @@ let res32 i n = emit_subreg reg_low_32_name DWORD i.res.(n)
 
 let addressing addr typ i n =
   match addr with
-  | Ibased(s, ofs) ->
+  | Ibased(s, glob, ofs) ->
       add_used_symbol s;
-      mem64_rip typ (emit_symbol s) ~ofs
+      let s : Cmm.symbol = { sym_name = s; sym_global = if glob then Global else Local } in
+      mem64_rip typ (emit_cmm_symbol s) ~ofs
   | Iindexed d ->
       mem64 typ d (arg64 i n)
   | Iindexed2 d ->
@@ -355,7 +372,7 @@ let call_gc_sites = ref ([] : gc_call list)
 
 let emit_call_gc gc =
   def_label gc.gc_lbl;
-  emit_call "caml_call_gc";
+  emit_call (Cmm.global_symbol "caml_call_gc");
   def_label gc.gc_frame;
   I.jmp (label gc.gc_return_lbl)
 
@@ -369,7 +386,7 @@ let local_realloc_sites = ref ([] : local_realloc_call list)
 
 let emit_local_realloc lr =
   def_label lr.lr_lbl;
-  emit_call "caml_call_local_realloc";
+  emit_call (Cmm.global_symbol "caml_call_local_realloc");
   I.jmp (label lr.lr_return_lbl)
 
 (* Record calls to caml_ml_array_bound_error.
@@ -400,14 +417,14 @@ let bound_error_label dbg =
 
 let emit_call_bound_error bd =
   def_label bd.bd_lbl;
-  emit_call "caml_ml_array_bound_error";
+  emit_call (Cmm.global_symbol "caml_ml_array_bound_error");
   def_label bd.bd_frame
 
 let emit_call_bound_errors () =
   List.iter emit_call_bound_error !bound_error_sites;
   if !bound_error_call > 0 then begin
     def_label !bound_error_call;
-    emit_call "caml_ml_array_bound_error"
+    emit_call (Cmm.global_symbol "caml_ml_array_bound_error")
   end
 
 (* Record jump tables *)
@@ -858,26 +875,26 @@ let emit_instr fallthrough i =
           I.movsd (mem64_rip NONE (emit_label lbl)) (res i 0)
       end
   | Lop(Iconst_symbol s) ->
-      add_used_symbol s;
+      add_used_symbol s.sym_name;
       load_symbol_addr s (res i 0)
   | Lop(Icall_ind) ->
       I.call (arg i 0);
       record_frame i.live (Dbg_other i.dbg)
   | Lop(Icall_imm { func; }) ->
-      add_used_symbol func;
+      add_used_symbol func.sym_name;
       emit_call func;
       record_frame i.live (Dbg_other i.dbg)
   | Lop(Itailcall_ind) ->
       output_epilogue (fun () -> I.jmp (arg i 0))
   | Lop(Itailcall_imm { func; }) ->
       begin
-        if func = !function_name then
+        if func.sym_name = !function_name then
           match !tailrec_entry_point with
           | None -> Misc.fatal_error "jump to missing tailrec entry point"
           | Some tailrec_entry_point -> I.jmp (label tailrec_entry_point)
         else begin
           output_epilogue begin fun () ->
-            add_used_symbol func;
+            add_used_symbol func.sym_name;
             emit_jump func
           end
         end
@@ -885,8 +902,8 @@ let emit_instr fallthrough i =
   | Lop(Iextcall { func; alloc; }) ->
       add_used_symbol func;
       if alloc then begin
-        load_symbol_addr func rax;
-        emit_call "caml_c_call";
+        load_symbol_addr (Cmm.global_symbol func) rax;
+        emit_call (Cmm.global_symbol "caml_c_call");
         record_frame i.live (Dbg_other i.dbg);
         if system <> S_win64 then begin
           (* TODO: investigate why such a diff.
@@ -899,7 +916,7 @@ let emit_instr fallthrough i =
           I.mov (domain_field Domainstate.Domain_young_ptr) r15
         end
       end else begin
-        emit_call func
+        emit_call (Cmm.global_symbol func)
       end
   | Lop(Istackoffset n) ->
       emit_stack_offset n
@@ -960,12 +977,12 @@ let emit_instr fallthrough i =
             gc_frame = lbl_frame; } :: !call_gc_sites
       end else begin
         begin match n with
-        | 16 -> emit_call "caml_alloc1"
-        | 24 -> emit_call "caml_alloc2"
-        | 32 -> emit_call "caml_alloc3"
+        | 16 -> emit_call (Cmm.global_symbol "caml_alloc1")
+        | 24 -> emit_call (Cmm.global_symbol "caml_alloc2")
+        | 32 -> emit_call (Cmm.global_symbol "caml_alloc3")
         | _  ->
             I.sub (int n) r15;
-            emit_call "caml_allocN"
+            emit_call (Cmm.global_symbol "caml_allocN")
         end;
         let label = record_frame_label i.live (Dbg_alloc dbginfo) in
         def_label label;
@@ -1229,7 +1246,7 @@ let emit_instr fallthrough i =
        to control ocaml probe handlers independently from stap probe handlers.
        It is placed immediately after stap semaphore, and is the same
        size - hence offset 2. *)
-    I.mov (addressing (Ibased(semaphore_sym, 2)) WORD i 0) (res16 i 0);
+    I.mov (addressing (Ibased(semaphore_sym, true, 2)) WORD i 0) (res16 i 0);
     (* If the semaphore is 0, then the result is 0, otherwise 1. *)
     I.cmp (int 0) (res16 i 0);
     I.set (cond (Iunsigned Cne)) (res8 i 0);
@@ -1318,10 +1335,10 @@ let emit_instr fallthrough i =
       begin match k with
       | Lambda.Raise_regular ->
           I.mov (int 0) (domain_field Domainstate.Domain_backtrace_pos);
-          emit_call "caml_raise_exn";
+          emit_call (Cmm.global_symbol "caml_raise_exn");
           record_frame Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_reraise ->
-          emit_call "caml_raise_exn";
+          emit_call (Cmm.global_symbol "caml_raise_exn");
           record_frame Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_notrace ->
           I.mov (domain_field Domainstate.Domain_exception_pointer) rsp;
@@ -1380,6 +1397,7 @@ let fundecl fundecl =
   else
     D.global (emit_symbol fundecl.fun_name);
   D.label (emit_symbol fundecl.fun_name);
+  D.label (label_name (emit_symbol fundecl.fun_name));
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc ();
   emit_all true fundecl.fun_body;
@@ -1400,15 +1418,25 @@ let fundecl fundecl =
 (* Emission of data *)
 
 let emit_item = function
-  | Cglobal_symbol s -> D.global (emit_symbol s)
-  | Cdefine_symbol s -> add_def_symbol s; _label (emit_symbol s)
+  | Cdefine_symbol s ->
+    begin match s.sym_global with
+    | Local ->
+      _label (label_name (emit_symbol s.sym_name))
+    | Global ->
+      D.global (emit_symbol s.sym_name);
+      add_def_symbol s.sym_name;
+      _label (emit_symbol s.sym_name);
+      _label (label_name (emit_symbol s.sym_name))
+    end
   | Cint8 n -> D.byte (const n)
   | Cint16 n -> D.word (const n)
   | Cint32 n -> D.long (const_nat n)
   | Cint n -> D.qword (const_nat n)
   | Csingle f -> D.long  (Const (Int64.of_int32 (Int32.bits_of_float f)))
   | Cdouble f -> D.qword (Const (Int64.bits_of_float f))
-  | Csymbol_address s -> add_used_symbol s; D.qword (ConstLabel (emit_symbol s))
+  | Csymbol_address s ->
+    add_used_symbol s.sym_name;
+    D.qword (ConstLabel (emit_cmm_symbol s))
   | Cstring s -> D.bytes s
   | Cskip n -> if n > 0 then D.space n
   | Calign n -> D.align ~data:true n
@@ -1612,7 +1640,7 @@ let emit_probe_handler_wrapper p =
   I.mov (reg saved_r15) r15;
   (* Emit call to handler *)
   add_used_symbol handler_code_sym;
-  emit_call handler_code_sym;
+  emit_call (Cmm.global_symbol handler_code_sym);
   (* Record a frame description for the wrapper *)
   let label = new_label () in
   let live_offset =

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -370,9 +370,12 @@ type gc_call =
 
 let call_gc_sites = ref ([] : gc_call list)
 
+let call_gc_local_sym : Cmm.symbol =
+  {sym_name = "caml_call_gc_"; sym_global=Local}
+
 let emit_call_gc gc =
   def_label gc.gc_lbl;
-  emit_call (Cmm.global_symbol "caml_call_gc");
+  emit_call call_gc_local_sym;
   def_label gc.gc_frame;
   I.jmp (label gc.gc_return_lbl)
 
@@ -1506,6 +1509,12 @@ let begin_assembly unix =
   emit_named_text_section code_begin;
   emit_global_label_for_symbol code_begin;
   if system = S_macosx then I.nop (); (* PR#4690 *)
+
+  D.label (emit_cmm_symbol call_gc_local_sym);
+  cfi_startproc ();
+  I.jmp (rel_plt (Cmm.global_symbol "caml_call_gc"));
+  cfi_endproc ();
+
   ()
 
 let make_stack_loc ~offset i (r : Reg.t) =

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -321,10 +321,11 @@ let res32 i n = emit_subreg reg_low_32_name DWORD i.res.(n)
 
 let addressing addr typ i n =
   match addr with
-  | Ibased(s, glob, ofs) ->
-      add_used_symbol s;
-      let s : Cmm.symbol = { sym_name = s; sym_global = if glob then Global else Local } in
-      mem64_rip typ (emit_cmm_symbol s) ~ofs
+  | Ibased(sym_name, sym_global, ofs) ->
+      add_used_symbol sym_name;
+      let sym_global : Cmm.is_global =
+        match sym_global with Global -> Global | Local -> Local in
+      mem64_rip typ (emit_cmm_symbol { sym_name ; sym_global }) ~ofs
   | Iindexed d ->
       mem64 typ d (arg64 i n)
   | Iindexed2 d ->
@@ -1249,7 +1250,7 @@ let emit_instr fallthrough i =
        to control ocaml probe handlers independently from stap probe handlers.
        It is placed immediately after stap semaphore, and is the same
        size - hence offset 2. *)
-    I.mov (addressing (Ibased(semaphore_sym, true, 2)) WORD i 0) (res16 i 0);
+    I.mov (addressing (Ibased(semaphore_sym, Global, 2)) WORD i 0) (res16 i 0);
     (* If the semaphore is 0, then the result is 0, otherwise 1. *)
     I.cmp (int 0) (res16 i 0);
     I.set (cond (Iunsigned Cne)) (res8 i 0);
@@ -1399,6 +1400,9 @@ let fundecl fundecl =
     D.private_extern (emit_symbol fundecl.fun_name)
   else
     D.global (emit_symbol fundecl.fun_name);
+  (* Even if the function name is Local, still emit an
+     actual linker symbol for it. This provides symbols
+     for perf, gdb, and similar tools *)
   D.label (emit_symbol fundecl.fun_name);
   D.label (label_name (emit_symbol fundecl.fun_name));
   emit_debug_info fundecl.fun_dbg;

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -24,7 +24,7 @@ open Mach
 (* Auxiliary for recognizing addressing modes *)
 
 type addressing_expr =
-    Asymbol of string
+    Asymbol of Cmm.symbol
   | Alinear of expression
   | Aadd of expression * expression
   | Ascale of expression * int
@@ -245,7 +245,7 @@ method select_addressing _chunk exp =
   then (Iindexed 0, exp)
   else match a with
     | Asymbol s ->
-        (Ibased(s, d), Ctuple [])
+        (Ibased(s.sym_name, s.sym_global = Cmm.Global, d), Ctuple [])
     | Alinear e ->
         (Iindexed d, e)
     | Aadd(e1, e2) ->

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -245,7 +245,9 @@ method select_addressing _chunk exp =
   then (Iindexed 0, exp)
   else match a with
     | Asymbol s ->
-        (Ibased(s.sym_name, s.sym_global = Cmm.Global, d), Ctuple [])
+        let glob : Arch.sym_global =
+          match s.sym_global with Global -> Global | Local -> Local in
+        (Ibased(s.sym_name, glob, d), Ctuple [])
     | Alinear e ->
         (Iindexed d, e)
     | Aadd(e1, e2) ->

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -500,7 +500,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Icall_imm _) -> 1
     | Lop (Itailcall_ind) -> epilogue_size ()
     | Lop (Itailcall_imm { func; _ }) ->
-      if func = !function_name then 1 else epilogue_size ()
+      if func.sym_name = !function_name then 1 else epilogue_size ()
     | Lop (Iextcall { alloc = false; }) -> 1
     | Lop (Iextcall { alloc = true; }) -> 3
     | Lop (Istackoffset _) -> 2
@@ -763,22 +763,22 @@ let emit_instr i =
           emit_load_literal i.res.(0) lbl
         end
     | Lop(Iconst_symbol s) ->
-        emit_load_symbol_addr i.res.(0) s
+        emit_load_symbol_addr i.res.(0) s.sym_name
     | Lop(Icall_ind) ->
         `	blr	{emit_reg i.arg.(0)}\n`;
         `{record_frame i.live (Dbg_other i.dbg)}\n`
     | Lop(Icall_imm { func; }) ->
-        `	bl	{emit_symbol func}\n`;
+        `	bl	{emit_symbol func.sym_name}\n`;
         `{record_frame i.live (Dbg_other i.dbg)}\n`
     | Lop(Itailcall_ind) ->
         output_epilogue (fun () -> `	br	{emit_reg i.arg.(0)}\n`)
     | Lop(Itailcall_imm { func; }) ->
-        if func = !function_name then
+        if func.sym_name = !function_name then
           match !tailrec_entry_point with
           | None -> Misc.fatal_error "jump to missing tailrec entry point"
           | Some tailrec_entry_point -> `	b	{emit_label tailrec_entry_point}\n`
         else
-          output_epilogue (fun () -> `	b	{emit_symbol func}\n`)
+          output_epilogue (fun () -> `	b	{emit_symbol func.sym_name}\n`)
     | Lop(Iextcall { func; alloc = false; }) ->
         `	bl	{emit_symbol func}\n`
     | Lop(Iextcall { func; alloc = true; }) ->
@@ -1163,23 +1163,22 @@ let fundecl fundecl =
 (* Emission of data *)
 
 let emit_item = function
-  | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
   | Cdefine_symbol s ->
-    if !Clflags.dlcode then begin
+    if !Clflags.dlcode || s.sym_global = Cmm.Global then begin
       (* GOT relocations against non-global symbols don't seem to work
          properly: GOT entries are not created for the symbols and the
          relocations evaluate to random other GOT entries.  For the moment
          force all symbols to be global. *)
-      `	.globl	{emit_symbol s}\n`;
+      `	.globl	{emit_symbol s.sym_name}\n`;
     end;
-    `{emit_symbol s}:\n`
+    `{emit_symbol s.sym_name}:\n`
   | Cint8 n -> `	.byte	{emit_int n}\n`
   | Cint16 n -> `	.short	{emit_int n}\n`
   | Cint32 n -> `	.long	{emit_nativeint n}\n`
   | Cint n -> `	.quad	{emit_nativeint n}\n`
   | Csingle f -> emit_float32_directive ".long" (Int32.bits_of_float f)
   | Cdouble f -> emit_float64_directive ".quad" (Int64.bits_of_float f)
-  | Csymbol_address s -> `	.quad	{emit_symbol s}\n`
+  | Csymbol_address s -> `	.quad	{emit_symbol s.sym_name}\n`
   | Cstring s -> emit_string_directive "	.ascii  " s
   | Cskip n -> if n > 0 then `	.space	{emit_int n}\n`
   | Calign n -> `	.align	{emit_int(Misc.log2 n)}\n`

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -49,6 +49,8 @@ let emit_label lbl =
 
 (* Symbols *)
 
+(* CR sdolan: Support local symbol definitions & references on arm64 *)
+
 let emit_symbol s =
   if macosx then emit_string "_";
   Emitaux.emit_symbol '$' s

--- a/backend/arm64/selection.ml
+++ b/backend/arm64/selection.ml
@@ -95,7 +95,7 @@ method! effects_of e =
 method select_addressing chunk = function
   | Cop((Caddv | Cadda), [Cconst_symbol (s, _); Cconst_int (n, _)], _)
     when use_direct_addressing s ->
-      (Ibased(s, n), Ctuple [])
+      (Ibased(s.sym_name, n), Ctuple [])
   | Cop((Caddv | Cadda), [arg; Cconst_int (n, _)], _)
     when is_offset chunk n ->
       (Iindexed n, arg)
@@ -105,7 +105,7 @@ method select_addressing chunk = function
       (Iindexed n, Cop(op, [arg1; arg2], dbg))
   | Cconst_symbol (s, _)
     when use_direct_addressing s ->
-      (Ibased(s, 0), Ctuple [])
+      (Ibased(s.sym_name, 0), Ctuple [])
   | arg ->
       (Iindexed 0, arg)
 

--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -309,7 +309,7 @@ let named_startup_file () =
 
 let force_linking_of_startup ~ppf_dump =
   Asmgen.compile_phrase ~ppf_dump
-    (Cmm.Cdata ([Cmm.Csymbol_address "caml_startup"]))
+    (Cmm.Cdata ([Cmm.Csymbol_address (Cmm.global_symbol "caml_startup")]))
 
 let make_globals_map units_list =
   (* The order in which entries appear in the globals map does not matter

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -343,7 +343,12 @@ let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
   | Raise _ -> fprintf ppf "Raise%a" print_args args
   | Tailcall_self { destination } ->
     dump_mach_op ppf
-      (Mach.Itailcall_imm { func = { sym_name = Printf.sprintf "self(%d)" destination; sym_global = Local } })
+      (Mach.Itailcall_imm
+         { func =
+             { sym_name = Printf.sprintf "self(%d)" destination;
+               sym_global = Local
+             }
+         })
   | Tailcall_func call ->
     dump_mach_op ppf
       (match call with
@@ -359,7 +364,8 @@ let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
     Format.fprintf ppf "%t%a" print_res dump_mach_op
       (match prim with
       | External { func_symbol = func; ty_res; ty_args; alloc } ->
-        Mach.Iextcall { func = func.sym_name; ty_res; ty_args; returns = true; alloc }
+        Mach.Iextcall
+          { func = func.sym_name; ty_res; ty_args; returns = true; alloc }
       | Alloc { bytes; dbginfo; mode } -> Mach.Ialloc { bytes; dbginfo; mode }
       | Checkbound { immediate = Some x } -> Mach.Iintop_imm (Icheckbound, x)
       | Checkbound { immediate = None } -> Mach.Iintop Icheckbound

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -364,8 +364,7 @@ let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
     Format.fprintf ppf "%t%a" print_res dump_mach_op
       (match prim with
       | External { func_symbol = func; ty_res; ty_args; alloc } ->
-        Mach.Iextcall
-          { func = func; ty_res; ty_args; returns = true; alloc }
+        Mach.Iextcall { func; ty_res; ty_args; returns = true; alloc }
       | Alloc { bytes; dbginfo; mode } -> Mach.Ialloc { bytes; dbginfo; mode }
       | Checkbound { immediate = Some x } -> Mach.Iintop_imm (Icheckbound, x)
       | Checkbound { immediate = None } -> Mach.Iintop Icheckbound

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -337,8 +337,8 @@ let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
       done;
       let i = label_count - 1 in
       fprintf ppf "case %d: goto %d" i labels.(i))
-  | Call_no_return { func_symbol : Cmm.symbol; _ } ->
-    fprintf ppf "Call_no_return %s%a" func_symbol.sym_name print_args args
+  | Call_no_return { func_symbol; _ } ->
+    fprintf ppf "Call_no_return %s%a" func_symbol print_args args
   | Return -> fprintf ppf "Return%a" print_args args
   | Raise _ -> fprintf ppf "Raise%a" print_args args
   | Tailcall_self { destination } ->
@@ -365,7 +365,7 @@ let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
       (match prim with
       | External { func_symbol = func; ty_res; ty_args; alloc } ->
         Mach.Iextcall
-          { func = func.sym_name; ty_res; ty_args; returns = true; alloc }
+          { func = func; ty_res; ty_args; returns = true; alloc }
       | Alloc { bytes; dbginfo; mode } -> Mach.Ialloc { bytes; dbginfo; mode }
       | Checkbound { immediate = Some x } -> Mach.Iintop_imm (Icheckbound, x)
       | Checkbound { immediate = None } -> Mach.Iintop Icheckbound

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -184,7 +184,8 @@ let check_external_call_operation :
     Cfg.external_call_operation ->
     unit =
  fun location expected result ->
-  if not (String.equal expected.func_symbol.sym_name result.func_symbol.sym_name)
+  if not
+       (String.equal expected.func_symbol.sym_name result.func_symbol.sym_name)
   then different location "function symbol";
   if not (Bool.equal expected.alloc result.alloc)
   then different location "allocating";
@@ -204,8 +205,8 @@ let check_operation : location -> Cfg.operation -> Cfg.operation -> unit =
     ()
   | Const_float expected, Const_float result when Int64.equal expected result ->
     ()
-  | Const_symbol expected, Const_symbol result when String.equal expected.sym_name result.sym_name
-    ->
+  | Const_symbol expected, Const_symbol result
+    when String.equal expected.sym_name result.sym_name ->
     ()
   | Stackoffset expected, Stackoffset result when Int.equal expected result ->
     ()
@@ -307,8 +308,9 @@ let check_func_call_operation :
  fun location expected result ->
   match expected, result with
   | Indirect, Indirect -> ()
-  | ( Direct expected_func_symbol, Direct result_func_symbol )
-    when String.equal expected_func_symbol.sym_name result_func_symbol.sym_name ->
+  | Direct expected_func_symbol, Direct result_func_symbol
+    when String.equal expected_func_symbol.sym_name result_func_symbol.sym_name
+    ->
     ()
   | _ -> different location "function call operation"
  [@@ocaml.warning "-4"]

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -184,7 +184,7 @@ let check_external_call_operation :
     Cfg.external_call_operation ->
     unit =
  fun location expected result ->
-  if not (String.equal expected.func_symbol result.func_symbol)
+  if not (String.equal expected.func_symbol.sym_name result.func_symbol.sym_name)
   then different location "function symbol";
   if not (Bool.equal expected.alloc result.alloc)
   then different location "allocating";
@@ -204,7 +204,7 @@ let check_operation : location -> Cfg.operation -> Cfg.operation -> unit =
     ()
   | Const_float expected, Const_float result when Int64.equal expected result ->
     ()
-  | Const_symbol expected, Const_symbol result when String.equal expected result
+  | Const_symbol expected, Const_symbol result when String.equal expected.sym_name result.sym_name
     ->
     ()
   | Stackoffset expected, Stackoffset result when Int.equal expected result ->
@@ -307,9 +307,8 @@ let check_func_call_operation :
  fun location expected result ->
   match expected, result with
   | Indirect, Indirect -> ()
-  | ( Direct { func_symbol = expected_func_symbol },
-      Direct { func_symbol = result_func_symbol } )
-    when String.equal expected_func_symbol result_func_symbol ->
+  | ( Direct expected_func_symbol, Direct result_func_symbol )
+    when String.equal expected_func_symbol.sym_name result_func_symbol.sym_name ->
     ()
   | _ -> different location "function call operation"
  [@@ocaml.warning "-4"]

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -184,8 +184,7 @@ let check_external_call_operation :
     Cfg.external_call_operation ->
     unit =
  fun location expected result ->
-  if not
-       (String.equal expected.func_symbol result.func_symbol)
+  if not (String.equal expected.func_symbol result.func_symbol)
   then different location "function symbol";
   if not (Bool.equal expected.alloc result.alloc)
   then different location "allocating";

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -185,7 +185,7 @@ let check_external_call_operation :
     unit =
  fun location expected result ->
   if not
-       (String.equal expected.func_symbol.sym_name result.func_symbol.sym_name)
+       (String.equal expected.func_symbol result.func_symbol)
   then different location "function symbol";
   if not (Bool.equal expected.alloc result.alloc)
   then different location "allocating";

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -32,10 +32,10 @@
 module S = struct
   type func_call_operation =
     | Indirect
-    | Direct of { func_symbol : string }
+    | Direct of Cmm.symbol
 
   type external_call_operation =
-    { func_symbol : string;
+    { func_symbol : Cmm.symbol;
       alloc : bool;
       ty_res : Cmm.machtype;
       ty_args : Cmm.exttype list
@@ -60,7 +60,7 @@ module S = struct
     | Reload
     | Const_int of nativeint (* CR-someday xclerc: change to `Targetint.t` *)
     | Const_float of int64
-    | Const_symbol of string
+    | Const_symbol of Cmm.symbol
     | Stackoffset of int
     | Load of Cmm.memory_chunk * Arch.addressing_mode * Mach.mutable_flag
     | Store of Cmm.memory_chunk * Arch.addressing_mode * bool

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -35,7 +35,7 @@ module S = struct
     | Direct of Cmm.symbol
 
   type external_call_operation =
-    { func_symbol : Cmm.symbol;
+    { func_symbol : string;
       alloc : bool;
       ty_res : Cmm.machtype;
       ty_args : Cmm.exttype list

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -146,12 +146,18 @@ let linearize_terminator cfg_with_layout (func : string) start
     | Tailcall_func (Direct func_symbol) ->
       [L.Lop (Itailcall_imm { func = func_symbol })], None
     | Tailcall_self { destination } ->
-      [L.Lop (Itailcall_imm { func = Cmm.global_symbol func })], Some destination
+      ( [L.Lop (Itailcall_imm { func = Cmm.global_symbol func })],
+        Some destination )
     | Call_no_return { func_symbol; alloc; ty_args; ty_res } ->
       single
         (L.Lop
            (Iextcall
-              { func = func_symbol.sym_name; alloc; ty_args; ty_res; returns = false }))
+              { func = func_symbol.sym_name;
+                alloc;
+                ty_args;
+                ty_res;
+                returns = false
+              }))
     | Call { op; label_after } ->
       let op : Mach.operation =
         match op with
@@ -164,7 +170,12 @@ let linearize_terminator cfg_with_layout (func : string) start
         match op with
         | External { func_symbol; alloc; ty_args; ty_res } ->
           Iextcall
-            { func = func_symbol.sym_name; alloc; ty_args; ty_res; returns = true }
+            { func = func_symbol.sym_name;
+              alloc;
+              ty_args;
+              ty_res;
+              returns = true
+            }
         | Checkbound { immediate = None } -> Iintop Icheckbound
         | Checkbound { immediate = Some i } -> Iintop_imm (Icheckbound, i)
         | Alloc { bytes; dbginfo; mode } -> Ialloc { bytes; dbginfo; mode }

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -146,13 +146,13 @@ let linearize_terminator cfg_with_layout (func : string) start
     | Tailcall_func (Direct func_symbol) ->
       [L.Lop (Itailcall_imm { func = func_symbol })], None
     | Tailcall_self { destination } ->
-      ( [L.Lop (Itailcall_imm { func = Cmm.global_symbol func })],
+      ( [L.Lop (Itailcall_imm { func = { sym_name = func; sym_global = Local } })],
         Some destination )
     | Call_no_return { func_symbol; alloc; ty_args; ty_res } ->
       single
         (L.Lop
            (Iextcall
-              { func = func_symbol.sym_name;
+              { func = func_symbol;
                 alloc;
                 ty_args;
                 ty_res;
@@ -170,7 +170,7 @@ let linearize_terminator cfg_with_layout (func : string) start
         match op with
         | External { func_symbol; alloc; ty_args; ty_res } ->
           Iextcall
-            { func = func_symbol.sym_name;
+            { func = func_symbol;
               alloc;
               ty_args;
               ty_res;

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -146,18 +146,15 @@ let linearize_terminator cfg_with_layout (func : string) start
     | Tailcall_func (Direct func_symbol) ->
       [L.Lop (Itailcall_imm { func = func_symbol })], None
     | Tailcall_self { destination } ->
-      ( [L.Lop (Itailcall_imm { func = { sym_name = func; sym_global = Local } })],
+      ( [ L.Lop
+            (Itailcall_imm { func = { sym_name = func; sym_global = Local } })
+        ],
         Some destination )
     | Call_no_return { func_symbol; alloc; ty_args; ty_res } ->
       single
         (L.Lop
            (Iextcall
-              { func = func_symbol;
-                alloc;
-                ty_args;
-                ty_res;
-                returns = false
-              }))
+              { func = func_symbol; alloc; ty_args; ty_res; returns = false }))
     | Call { op; label_after } ->
       let op : Mach.operation =
         match op with
@@ -170,12 +167,7 @@ let linearize_terminator cfg_with_layout (func : string) start
         match op with
         | External { func_symbol; alloc; ty_args; ty_res } ->
           Iextcall
-            { func = func_symbol;
-              alloc;
-              ty_args;
-              ty_res;
-              returns = true
-            }
+            { func = func_symbol; alloc; ty_args; ty_res; returns = true }
         | Checkbound { immediate = None } -> Iintop Icheckbound
         | Checkbound { immediate = Some i } -> Iintop_imm (Icheckbound, i)
         | Alloc { bytes; dbginfo; mode } -> Ialloc { bytes; dbginfo; mode }

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -149,15 +149,15 @@ let basic_or_terminator_of_operation :
   | Icall_imm { func } ->
     With_next_label
       (fun label_after ->
-        Call { op = Direct { func_symbol = func }; label_after })
+         Call { op = Direct func; label_after })
   | Itailcall_ind -> Terminator (Tailcall_func Indirect)
   | Itailcall_imm { func } ->
     Terminator
-      (if String.equal (State.get_fun_name state) func
+      (if String.equal (State.get_fun_name state) func.sym_name
       then Tailcall_self { destination = State.get_tailrec_label state }
-      else Tailcall_func (Direct { func_symbol = func }))
+      else Tailcall_func (Direct func))
   | Iextcall { func; ty_res; ty_args; alloc; returns } ->
-    let external_call = { Cfg.func_symbol = func; alloc; ty_res; ty_args } in
+    let external_call = { Cfg.func_symbol = { sym_name = func; sym_global = Global }; alloc; ty_res; ty_args } in
     if returns
     then
       With_next_label

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -147,9 +147,7 @@ let basic_or_terminator_of_operation :
   | Icall_ind ->
     With_next_label (fun label_after -> Call { op = Indirect; label_after })
   | Icall_imm { func } ->
-    With_next_label
-      (fun label_after ->
-         Call { op = Direct func; label_after })
+    With_next_label (fun label_after -> Call { op = Direct func; label_after })
   | Itailcall_ind -> Terminator (Tailcall_func Indirect)
   | Itailcall_imm { func } ->
     Terminator
@@ -157,7 +155,13 @@ let basic_or_terminator_of_operation :
       then Tailcall_self { destination = State.get_tailrec_label state }
       else Tailcall_func (Direct func))
   | Iextcall { func; ty_res; ty_args; alloc; returns } ->
-    let external_call = { Cfg.func_symbol = { sym_name = func; sym_global = Global }; alloc; ty_res; ty_args } in
+    let external_call =
+      { Cfg.func_symbol = { sym_name = func; sym_global = Global };
+        alloc;
+        ty_res;
+        ty_args
+      }
+    in
     if returns
     then
       With_next_label

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -155,13 +155,7 @@ let basic_or_terminator_of_operation :
       then Tailcall_self { destination = State.get_tailrec_label state }
       else Tailcall_func (Direct func))
   | Iextcall { func; ty_res; ty_args; alloc; returns } ->
-    let external_call =
-      { Cfg.func_symbol = func;
-        alloc;
-        ty_res;
-        ty_args
-      }
-    in
+    let external_call = { Cfg.func_symbol = func; alloc; ty_res; ty_args } in
     if returns
     then
       With_next_label

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -156,7 +156,7 @@ let basic_or_terminator_of_operation :
       else Tailcall_func (Direct func))
   | Iextcall { func; ty_res; ty_args; alloc; returns } ->
     let external_call =
-      { Cfg.func_symbol = { sym_name = func; sym_global = Global };
+      { Cfg.func_symbol = func;
         alloc;
         ty_res;
         ty_args

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -530,21 +530,21 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     | Itailcall_ind -> terminator (C.Tailcall_func Indirect)
     | Itailcall_imm { func = func_symbol } ->
       let desc =
-        if String.equal func_symbol (C.fun_name t.cfg)
+        if String.equal func_symbol.sym_name (C.fun_name t.cfg)
         then
           match t.tailrec_label with
           | None -> Misc.fatal_error "tail call to missing tailrec entry point"
           | Some destination -> C.Tailcall_self { destination }
-        else C.Tailcall_func (Direct { func_symbol })
+        else C.Tailcall_func (Direct func_symbol)
       in
       terminator desc
     | Iextcall { func; alloc; ty_args; ty_res; returns = false } ->
       terminator
-        (C.Call_no_return { func_symbol = func; alloc; ty_args; ty_res })
+        (C.Call_no_return { func_symbol = { sym_name = func; sym_global = Global }; alloc; ty_args; ty_res })
     | Icall_ind -> terminator_call Indirect
-    | Icall_imm { func } -> terminator_call (Direct { func_symbol = func })
+    | Icall_imm { func } -> terminator_call (Direct func)
     | Iextcall { func; alloc; ty_args; ty_res; returns = true } ->
-      terminator_prim (External { func_symbol = func; alloc; ty_args; ty_res })
+      terminator_prim (External { func_symbol = { sym_name = func; sym_global = Global }; alloc; ty_args; ty_res })
     | Iintop Icheckbound -> terminator_prim (Checkbound { immediate = None })
     | Iintop_imm (Icheckbound, i) ->
       terminator_prim (Checkbound { immediate = Some i })

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -540,22 +540,11 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
       terminator desc
     | Iextcall { func; alloc; ty_args; ty_res; returns = false } ->
       terminator
-        (C.Call_no_return
-           { func_symbol = func;
-             alloc;
-             ty_args;
-             ty_res
-           })
+        (C.Call_no_return { func_symbol = func; alloc; ty_args; ty_res })
     | Icall_ind -> terminator_call Indirect
     | Icall_imm { func } -> terminator_call (Direct func)
     | Iextcall { func; alloc; ty_args; ty_res; returns = true } ->
-      terminator_prim
-        (External
-           { func_symbol = func;
-             alloc;
-             ty_args;
-             ty_res
-           })
+      terminator_prim (External { func_symbol = func; alloc; ty_args; ty_res })
     | Iintop Icheckbound -> terminator_prim (Checkbound { immediate = None })
     | Iintop_imm (Icheckbound, i) ->
       terminator_prim (Checkbound { immediate = Some i })

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -541,7 +541,7 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     | Iextcall { func; alloc; ty_args; ty_res; returns = false } ->
       terminator
         (C.Call_no_return
-           { func_symbol = { sym_name = func; sym_global = Global };
+           { func_symbol = func;
              alloc;
              ty_args;
              ty_res
@@ -551,7 +551,7 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     | Iextcall { func; alloc; ty_args; ty_res; returns = true } ->
       terminator_prim
         (External
-           { func_symbol = { sym_name = func; sym_global = Global };
+           { func_symbol = func;
              alloc;
              ty_args;
              ty_res

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -540,11 +540,22 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
       terminator desc
     | Iextcall { func; alloc; ty_args; ty_res; returns = false } ->
       terminator
-        (C.Call_no_return { func_symbol = { sym_name = func; sym_global = Global }; alloc; ty_args; ty_res })
+        (C.Call_no_return
+           { func_symbol = { sym_name = func; sym_global = Global };
+             alloc;
+             ty_args;
+             ty_res
+           })
     | Icall_ind -> terminator_call Indirect
     | Icall_imm { func } -> terminator_call (Direct func)
     | Iextcall { func; alloc; ty_args; ty_res; returns = true } ->
-      terminator_prim (External { func_symbol = { sym_name = func; sym_global = Global }; alloc; ty_args; ty_res })
+      terminator_prim
+        (External
+           { func_symbol = { sym_name = func; sym_global = Global };
+             alloc;
+             ty_args;
+             ty_res
+           })
     | Iintop Icheckbound -> terminator_prim (Checkbound { immediate = None })
     | Iintop_imm (Icheckbound, i) ->
       terminator_prim (Checkbound { immediate = Some i })

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -707,9 +707,9 @@ end = struct
       (* Sound to ignore [next] and [exn] because the call never returns. *)
       transform t ~next:Value.normal_return ~exn:Value.exn_escape
         ~effect:Value.top "indirect tailcall" dbg
-    | Icall_imm { func } ->
+    | Icall_imm { func = { sym_name = func; _ } } ->
       transform_call t ~next ~exn func ~desc:("direct call to " ^ func) dbg
-    | Itailcall_imm { func } ->
+    | Itailcall_imm { func = { sym_name = func; _ } } ->
       (* Sound to ignore [next] and [exn] because the call never returns. *)
       transform_call t ~next:Value.normal_return ~exn:Value.exn_escape func
         ~desc:("direct tailcall to " ^ func)

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -229,11 +229,13 @@ type symbol =
   { sym_name : string;
     sym_global : is_global }
 
+let global_symbol sym_name = { sym_name; sym_global = Global }
+
 type expression =
     Cconst_int of int * Debuginfo.t
   | Cconst_natint of nativeint * Debuginfo.t
   | Cconst_float of float * Debuginfo.t
-  | Cconst_symbol of string * Debuginfo.t
+  | Cconst_symbol of symbol * Debuginfo.t
   | Cvar of Backend_var.t
   | Clet of Backend_var.With_provenance.t * expression * expression
   | Clet_mut of Backend_var.With_provenance.t * machtype
@@ -271,7 +273,7 @@ type codegen_option =
                loc : Location.t; }
 
 type fundecl =
-  { fun_name: string;
+  { fun_name: symbol;
     fun_args: (Backend_var.With_provenance.t * machtype) list;
     fun_body: expression;
     fun_codegen_options : codegen_option list;
@@ -280,15 +282,14 @@ type fundecl =
   }
 
 type data_item =
-    Cdefine_symbol of string
-  | Cglobal_symbol of string
+    Cdefine_symbol of symbol
   | Cint8 of int
   | Cint16 of int
   | Cint32 of nativeint
   | Cint of nativeint
   | Csingle of float
   | Cdouble of float
-  | Csymbol_address of string
+  | Csymbol_address of symbol
   | Cstring of string
   | Cskip of int
   | Calign of int

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -223,6 +223,10 @@ type kind_for_unboxing =
   | Boxed_integer of Lambda.boxed_integer
   | Boxed_float
 
+type is_global = Global | Local
+
+type symbol = string * is_global
+
 type expression =
     Cconst_int of int * Debuginfo.t
   | Cconst_natint of nativeint * Debuginfo.t

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -225,7 +225,9 @@ type kind_for_unboxing =
 
 type is_global = Global | Local
 
-type symbol = string * is_global
+type symbol =
+  { sym_name : string;
+    sym_global : is_global }
 
 type expression =
     Cconst_int of int * Debuginfo.t

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -245,13 +245,15 @@ type symbol =
   { sym_name : string;
     sym_global : is_global }
 
+val global_symbol : string -> symbol
+
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)
 type expression =
     Cconst_int of int * Debuginfo.t
   | Cconst_natint of nativeint * Debuginfo.t
   | Cconst_float of float * Debuginfo.t
-  | Cconst_symbol of string * Debuginfo.t
+  | Cconst_symbol of symbol * Debuginfo.t
   | Cvar of Backend_var.t
   | Clet of Backend_var.With_provenance.t * expression * expression
   | Clet_mut of Backend_var.With_provenance.t * machtype
@@ -292,7 +294,7 @@ type codegen_option =
   | Check of { property: property; strict: bool; assume: bool; loc: Location.t }
 
 type fundecl =
-  { fun_name: string;
+  { fun_name: symbol;
     fun_args: (Backend_var.With_provenance.t * machtype) list;
     fun_body: expression;
     fun_codegen_options : codegen_option list;
@@ -301,15 +303,14 @@ type fundecl =
   }
 
 type data_item =
-    Cdefine_symbol of string
-  | Cglobal_symbol of string
+    Cdefine_symbol of symbol
   | Cint8 of int
   | Cint16 of int
   | Cint32 of nativeint
   | Cint of nativeint
   | Csingle of float
   | Cdouble of float
-  | Csymbol_address of string
+  | Csymbol_address of symbol
   | Cstring of string
   | Cskip of int
   | Calign of int

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -229,7 +229,21 @@ type kind_for_unboxing =
 
 type is_global = Global | Local
 
-type symbol = string * is_global
+(* Symbols are marked with whether they are local or global,
+   at both definition and use sites.
+
+   Symbols defined as [Local] may only be referenced within the same file,
+   and all such references must also be [Local].
+
+   Symbols defined as [Global] may be referenced from other files.
+   References from other files must be [Global], but references from the
+   same file may be [Local].
+
+   (Marking symbols in this way speeds up linking, as many references can
+   then be resolved early) *)
+type symbol =
+  { sym_name : string;
+    sym_global : is_global }
 
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -227,6 +227,10 @@ type kind_for_unboxing =
   | Boxed_integer of Lambda.boxed_integer
   | Boxed_float
 
+type is_global = Global | Local
+
+type symbol = string * is_global
+
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)
 type expression =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3739,7 +3739,6 @@ let emit_constant_closure symb fundecls clos_vars cont =
         let is_last = match rem with [] -> true | _ :: _ -> false in
         match f2.arity with
         | { function_kind = Curried _; params_layout = [] | [_]; _ } as arity ->
-          (* FIXME: is sym_global correct here? *)
           (Cint (infix_header pos) :: closure_symbol f2)
           @ Csymbol_address
               { sym_name = f2.label; sym_global = symb.sym_global }
@@ -3824,8 +3823,8 @@ let preallocate_block cont { Clambda.symbol; exported; tag; fields } =
 let emit_preallocated_blocks preallocated_blocks cont =
   let symbols =
     List.map
-      (fun ({ Clambda.symbol } : Clambda.preallocated_block) ->
-        global_symbol symbol)
+      (fun ({ Clambda.symbol; exported } : Clambda.preallocated_block) ->
+        { sym_name = symbol; sym_global = (if exported then Global else Local) })
       preallocated_blocks
   in
   let c1 = emit_gc_roots_table ~symbols cont in

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -509,7 +509,8 @@ let divimm_parameters d =
  *)
 
 let raise_symbol dbg symb =
-  Cop (Craise Lambda.Raise_regular, [Cconst_symbol (global_symbol symb, dbg)], dbg)
+  Cop
+    (Craise Lambda.Raise_regular, [Cconst_symbol (global_symbol symb, dbg)], dbg)
 
 let rec div_int c1 c2 is_safe dbg =
   match c1, c2 with
@@ -1460,7 +1461,8 @@ let xor_int e1 e2 dbg = Cop (Cxor, [e1; e2], dbg)
 (* Boxed integers *)
 
 let operations_boxed_int (bi : Primitive.boxed_integer) =
-  let sym_name = match bi with
+  let sym_name =
+    match bi with
     | Pnativeint -> caml_nativeint_ops
     | Pint32 -> caml_int32_ops
     | Pint64 -> caml_int64_ops
@@ -2673,7 +2675,9 @@ let tuplify_function arity return =
     global_symbol
       ("caml_tuplify" ^ Int.to_string arity
       ^
-      match return with [| Val |] -> "" | _ -> "_R" ^ machtype_identifier return)
+      match return with
+      | [| Val |] -> ""
+      | _ -> "_R" ^ machtype_identifier return)
   in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
   Cfunction
@@ -2806,8 +2810,8 @@ let final_curry_function nlocal arity result =
   let fun_name =
     global_symbol
       (curry_function_sym (Lambda.Curried { nlocal }) arity result
-       ^ "_"
-       ^ Int.to_string (narity - 1))
+      ^ "_"
+      ^ Int.to_string (narity - 1))
   in
   let args_type = List.rev arity in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
@@ -2855,8 +2859,9 @@ let intermediate_curry_functions ~nlocal ~arity result =
                 [ alloc_closure_header ~mode
                     (function_slot_size + machtype_stored_size arg_type + 1)
                     (dbg ());
-                  Cconst_symbol (global_symbol (name1 ^ "_" ^ Int.to_string (num + 1)),
-                                 dbg ());
+                  Cconst_symbol
+                    ( global_symbol (name1 ^ "_" ^ Int.to_string (num + 1)),
+                      dbg () );
                   Cconst_natint
                     ( pack_closure_info
                         ~arity:(if has_nary then narity - num - 1 else 1)
@@ -2868,9 +2873,9 @@ let intermediate_curry_functions ~nlocal ~arity result =
                 @ (if has_nary
                   then
                     [ Cconst_symbol
-                        (global_symbol (name1 ^ "_" ^ Int.to_string (num + 1) ^ "_app"),
-                         dbg ())
-                    ]
+                        ( global_symbol
+                            (name1 ^ "_" ^ Int.to_string (num + 1) ^ "_app"),
+                          dbg () ) ]
                   else [])
                 @ value_slot_given_machtype args
                 @ [Cvar clos],
@@ -2893,7 +2898,9 @@ let intermediate_curry_functions ~nlocal ~arity result =
             (fun (arg, ty) -> VP.create arg, ty)
             (direct_args @ [clos, typ_val])
         in
-        let fun_name = global_symbol (name1 ^ "_" ^ Int.to_string (num + 1) ^ "_app") in
+        let fun_name =
+          global_symbol (name1 ^ "_" ^ Int.to_string (num + 1) ^ "_app")
+        in
         let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
         let cf =
           Cfunction
@@ -3513,7 +3520,9 @@ let emit_string_constant_fields s cont =
 let emit_boxed_int32_constant_fields n cont =
   let n = Nativeint.of_int32 n in
   if size_int = 8
-  then Csymbol_address (global_symbol caml_int32_ops) :: Cint32 n :: Cint32 0n :: cont
+  then
+    Csymbol_address (global_symbol caml_int32_ops)
+    :: Cint32 n :: Cint32 0n :: cont
   else Csymbol_address (global_symbol caml_int32_ops) :: Cint n :: cont
 
 let emit_boxed_int64_constant_fields n cont =
@@ -3523,8 +3532,12 @@ let emit_boxed_int64_constant_fields n cont =
   else
     let hi = Int64.to_nativeint (Int64.shift_right n 32) in
     if big_endian
-    then Csymbol_address (global_symbol caml_int64_ops) :: Cint hi :: Cint lo :: cont
-    else Csymbol_address (global_symbol caml_int64_ops) :: Cint lo :: Cint hi :: cont
+    then
+      Csymbol_address (global_symbol caml_int64_ops)
+      :: Cint hi :: Cint lo :: cont
+    else
+      Csymbol_address (global_symbol caml_int64_ops)
+      :: Cint lo :: Cint hi :: cont
 
 let emit_boxed_nativeint_constant_fields n cont =
   Csymbol_address (global_symbol caml_nativeint_ops) :: Cint n :: cont
@@ -3585,7 +3598,8 @@ let entry_point namelist =
     List.fold_right
       (fun name next ->
         let entry_sym =
-          global_symbol (make_symbol ~compilation_unit:name "entry") in
+          global_symbol (make_symbol ~compilation_unit:name "entry")
+        in
         Csequence
           ( Cop (Capply (typ_void, Rc_normal), [cconst_symbol entry_sym], dbg ()),
             Csequence (incr_global_inited (), next) ))
@@ -3608,11 +3622,11 @@ let cint_zero = Cint 0n
 
 let global_table namelist =
   let mksym name =
-    Csymbol_address (global_symbol (make_symbol ~compilation_unit:name "gc_roots"))
+    Csymbol_address
+      (global_symbol (make_symbol ~compilation_unit:name "gc_roots"))
   in
   Cdata
-    (Cdefine_symbol (global_symbol "caml_globals")
-     :: List.map mksym namelist
+    ((Cdefine_symbol (global_symbol "caml_globals") :: List.map mksym namelist)
     @ [cint_zero])
 
 let reference_symbols namelist =
@@ -3629,7 +3643,8 @@ let globals_map v = global_data "caml_globals_map" v
 
 let frame_table namelist =
   let mksym name =
-    Csymbol_address (global_symbol (make_symbol ~compilation_unit:name "frametable"))
+    Csymbol_address
+      (global_symbol (make_symbol ~compilation_unit:name "frametable"))
   in
   Cdata
     (Cdefine_symbol (global_symbol "caml_frametable")
@@ -3641,7 +3656,8 @@ let frame_table namelist =
 let segment_table namelist symbol begname endname =
   let addsyms name lst =
     Csymbol_address (global_symbol (make_symbol ~compilation_unit:name begname))
-    :: Csymbol_address (global_symbol (make_symbol ~compilation_unit:name endname))
+    :: Csymbol_address
+         (global_symbol (make_symbol ~compilation_unit:name endname))
     :: lst
   in
   Cdata
@@ -3658,17 +3674,14 @@ let code_segment_table namelist =
 
 let predef_exception i name =
   let name_sym =
-    { sym_name = Compilenv.new_const_symbol ();
-      sym_global = Local }
+    { sym_name = Compilenv.new_const_symbol (); sym_global = Local }
   in
   let data_items = emit_string_constant name_sym name [] in
   let exn_sym = global_symbol ("caml_exn_" ^ name) in
   let tag = Obj.object_tag in
   let size = 2 in
   let fields = Csymbol_address name_sym :: cint_const (-i - 1) :: data_items in
-  let data_items =
-    emit_block exn_sym (block_header tag size) fields
-  in
+  let data_items = emit_block exn_sym (block_header tag size) fields in
   Cdata data_items
 
 (* Header for a plugin *)
@@ -3728,7 +3741,8 @@ let emit_constant_closure symb fundecls clos_vars cont =
         | { function_kind = Curried _; params_layout = [] | [_]; _ } as arity ->
           (* FIXME: is sym_global correct here? *)
           (Cint (infix_header pos) :: closure_symbol f2)
-          @ Csymbol_address { sym_name = f2.label; sym_global = symb.sym_global }
+          @ Csymbol_address
+              { sym_name = f2.label; sym_global = symb.sym_global }
             :: Cint (closure_info ~arity ~startenv:(startenv - pos) ~is_last)
             :: emit_others (pos + 3) rem
         | arity ->
@@ -3747,7 +3761,8 @@ let emit_constant_closure symb fundecls clos_vars cont =
                  (curry_function_sym arity.function_kind params_machtypes
                     return_machtype))
             :: Cint (closure_info ~arity ~startenv:(startenv - pos) ~is_last)
-            :: Csymbol_address { sym_name = f2.label; sym_global = symb.sym_global }
+            :: Csymbol_address
+                 { sym_name = f2.label; sym_global = symb.sym_global }
             :: emit_others (pos + 4) rem)
     in
     let is_last = match remainder with [] -> true | _ :: _ -> false in
@@ -3768,7 +3783,7 @@ let emit_constant_closure symb fundecls clos_vars cont =
               arity.params_layout)
            (machtype_of_layout_changing_tagged_int_to_val arity.return_layout)))
       :: Cint (closure_info ~arity ~startenv ~is_last)
-      :: Csymbol_address { sym_name = f1.label; sym_global = symb.sym_global}
+      :: Csymbol_address { sym_name = f1.label; sym_global = symb.sym_global }
       :: emit_others 4 remainder)
 
 (* Build the NULL terminated array of gc roots *)
@@ -3786,8 +3801,7 @@ let emit_gc_roots_table ~symbols cont =
 
 let preallocate_block cont { Clambda.symbol; exported; tag; fields } =
   let mksym sym_name =
-    { sym_name;
-      sym_global = if exported then Global else Local }
+    { sym_name; sym_global = (if exported then Global else Local) }
   in
   let space =
     (* These words will be registered as roots and as such must contain valid
@@ -3802,14 +3816,16 @@ let preallocate_block cont { Clambda.symbol; exported; tag; fields } =
         | Some (Clambda.Uconst_field_ref label) -> Csymbol_address (mksym label))
       fields
   in
-  let data = emit_block (mksym symbol) (block_header tag (List.length fields)) space in
+  let data =
+    emit_block (mksym symbol) (block_header tag (List.length fields)) space
+  in
   Cdata data :: cont
 
 let emit_preallocated_blocks preallocated_blocks cont =
   let symbols =
     List.map
       (fun ({ Clambda.symbol } : Clambda.preallocated_block) ->
-         global_symbol symbol)
+        global_symbol symbol)
       preallocated_blocks
   in
   let c1 = emit_gc_roots_table ~symbols cont in
@@ -4105,8 +4121,7 @@ let cfloat f = Cmm.Cdouble f
 let symbol_address s = Cmm.Csymbol_address s
 
 let define_symbol ~global sym_name =
-  [Cdefine_symbol { sym_name;
-                    sym_global = if global then Global else Local }]
+  [Cdefine_symbol { sym_name; sym_global = (if global then Global else Local) }]
 
 (* Cmm phrases *)
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3491,7 +3491,7 @@ let bigstring_set size unsafe arg1 arg2 arg3 dbg =
 
 (* Symbols *)
 
-let cdefine_symbol (symb, (global : Cmmgen_state.is_global)) =
+let cdefine_symbol (symb, (global : is_global)) =
   match global with
   | Global -> [Cglobal_symbol symb; Cdefine_symbol symb]
   | Local -> [Cdefine_symbol symb]
@@ -3783,7 +3783,7 @@ let preallocate_block cont { Clambda.symbol; exported; tag; fields } =
         | Some (Clambda.Uconst_field_ref label) -> Csymbol_address label)
       fields
   in
-  let global = Cmmgen_state.(if exported then Global else Local) in
+  let global = if exported then Global else Local in
   let symb = symbol, global in
   let data = emit_block symb (block_header tag (List.length fields)) space in
   Cdata data :: cont

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4119,8 +4119,8 @@ let cfloat f = Cmm.Cdouble f
 
 let symbol_address s = Cmm.Csymbol_address s
 
-let define_symbol ~global sym_name =
-  [Cdefine_symbol { sym_name; sym_global = (if global then Global else Local) }]
+let define_symbol symbol =
+  [Cdefine_symbol symbol]
 
 (* Cmm phrases *)
 
@@ -4136,7 +4136,7 @@ let fundecl fun_name fun_args fun_body fun_codegen_options fun_dbg fun_poll =
 let gc_root_table syms =
   let table_symbol = make_symbol ?compilation_unit:None "gc_roots" in
   cdata
-    (define_symbol ~global:true table_symbol
+    (define_symbol { sym_name = table_symbol; sym_global = Global }
     @ List.map (fun s -> symbol_address (global_symbol s)) syms
     @ [cint 0n])
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3777,10 +3777,10 @@ let emit_constant_closure symb fundecls clos_vars cont =
     | arity ->
       Csymbol_address
         (global_symbol
-          (curry_function_sym arity.function_kind
-           (List.map machtype_of_layout_changing_tagged_int_to_val
-              arity.params_layout)
-           (machtype_of_layout_changing_tagged_int_to_val arity.return_layout)))
+           (curry_function_sym arity.function_kind
+              (List.map machtype_of_layout_changing_tagged_int_to_val
+                 arity.params_layout)
+              (machtype_of_layout_changing_tagged_int_to_val arity.return_layout)))
       :: Cint (closure_info ~arity ~startenv ~is_last)
       :: Csymbol_address { sym_name = f1.label; sym_global = symb.sym_global }
       :: emit_others 4 remainder)
@@ -4119,8 +4119,7 @@ let cfloat f = Cmm.Cdouble f
 
 let symbol_address s = Cmm.Csymbol_address s
 
-let define_symbol symbol =
-  [Cdefine_symbol symbol]
+let define_symbol symbol = [Cdefine_symbol symbol]
 
 (* Cmm phrases *)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -908,38 +908,38 @@ val plugin_header : Cmxs_format.dynunit list -> phrase
 (** Emit constant symbols *)
 
 (** Produce the data_item list corresponding to a symbol definition *)
-val cdefine_symbol : string * Cmmgen_state.is_global -> data_item list
+val cdefine_symbol : symbol -> data_item list
 
 (** [emit_block symb white_header cont] prepends to [cont] the header and symbol
     for the block. [cont] must already contain the fields of the block (and may
     contain additional data items afterwards). *)
 val emit_block :
-  string * Cmmgen_state.is_global ->
+  symbol ->
   nativeint ->
   data_item list ->
   data_item list
 
 (** Emit specific kinds of constant blocks as data items *)
 val emit_float_constant :
-  string * Cmmgen_state.is_global -> float -> data_item list -> data_item list
+  symbol -> float -> data_item list -> data_item list
 
 val emit_string_constant :
-  string * Cmmgen_state.is_global -> string -> data_item list -> data_item list
+  symbol -> string -> data_item list -> data_item list
 
 val emit_int32_constant :
-  string * Cmmgen_state.is_global -> int32 -> data_item list -> data_item list
+  symbol -> int32 -> data_item list -> data_item list
 
 val emit_int64_constant :
-  string * Cmmgen_state.is_global -> int64 -> data_item list -> data_item list
+  symbol -> int64 -> data_item list -> data_item list
 
 val emit_nativeint_constant :
-  string * Cmmgen_state.is_global ->
+  symbol ->
   nativeint ->
   data_item list ->
   data_item list
 
 val emit_float_array_constant :
-  string * Cmmgen_state.is_global ->
+  symbol ->
   float list ->
   data_item list ->
   data_item list
@@ -947,7 +947,7 @@ val emit_float_array_constant :
 val fundecls_size : Clambda.ufunction list -> int
 
 val emit_constant_closure :
-  string * Cmmgen_state.is_global ->
+  symbol ->
   Clambda.ufunction list ->
   data_item list ->
   data_item list ->

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -913,36 +913,22 @@ val cdefine_symbol : symbol -> data_item list
 (** [emit_block symb white_header cont] prepends to [cont] the header and symbol
     for the block. [cont] must already contain the fields of the block (and may
     contain additional data items afterwards). *)
-val emit_block :
-  symbol ->
-  nativeint ->
-  data_item list ->
-  data_item list
+val emit_block : symbol -> nativeint -> data_item list -> data_item list
 
 (** Emit specific kinds of constant blocks as data items *)
-val emit_float_constant :
-  symbol -> float -> data_item list -> data_item list
+val emit_float_constant : symbol -> float -> data_item list -> data_item list
 
-val emit_string_constant :
-  symbol -> string -> data_item list -> data_item list
+val emit_string_constant : symbol -> string -> data_item list -> data_item list
 
-val emit_int32_constant :
-  symbol -> int32 -> data_item list -> data_item list
+val emit_int32_constant : symbol -> int32 -> data_item list -> data_item list
 
-val emit_int64_constant :
-  symbol -> int64 -> data_item list -> data_item list
+val emit_int64_constant : symbol -> int64 -> data_item list -> data_item list
 
 val emit_nativeint_constant :
-  symbol ->
-  nativeint ->
-  data_item list ->
-  data_item list
+  symbol -> nativeint -> data_item list -> data_item list
 
 val emit_float_array_constant :
-  symbol ->
-  float list ->
-  data_item list ->
-  data_item list
+  symbol -> float list -> data_item list -> data_item list
 
 val fundecls_size : Clambda.ufunction list -> int
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1222,7 +1222,7 @@ val cfloat : float -> data_item
 val symbol_address : symbol -> data_item
 
 (** Definition for a static symbol. *)
-val define_symbol : global:bool -> string -> data_item list
+val define_symbol : symbol -> data_item list
 
 (** {2 Static structure helpers} *)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -807,7 +807,7 @@ val ptr_offset : expression -> int -> Debuginfo.t -> expression
 
 (** Direct application of a function via a symbol *)
 val direct_apply :
-  string ->
+  symbol ->
   machtype ->
   expression list ->
   Clambda.apply_kind ->
@@ -881,7 +881,7 @@ val entry_point : Compilation_unit.t list -> phrase
 val global_table : Compilation_unit.t list -> phrase
 
 (** Add references to the given symbols *)
-val reference_symbols : string list -> phrase
+val reference_symbols : symbol list -> phrase
 
 (** Generate the caml_globals_map structure, as a marshalled string constant.
     The runtime representation of the type here must match that of [type
@@ -1233,7 +1233,7 @@ val cint : nativeint -> data_item
 val cfloat : float -> data_item
 
 (** Static symbol. *)
-val symbol_address : string -> data_item
+val symbol_address : symbol -> data_item
 
 (** Definition for a static symbol. *)
 val define_symbol : global:bool -> string -> data_item list
@@ -1243,7 +1243,7 @@ val define_symbol : global:bool -> string -> data_item list
 (** [fundecl name args body codegen_options dbg] creates a cmm function
     declaration for a function [name] with binding [args] over [body]. *)
 val fundecl :
-  string ->
+  symbol ->
   (Backend_var.With_provenance.t * machtype) list ->
   expression ->
   codegen_option list ->

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1593,7 +1593,7 @@ let transl_clambda_constants (constants : Clambda.preallocated_constant list)
   in
   List.iter
     (fun { symbol; exported; definition = cst; provenance = _; } ->
-       let global : Cmmgen_state.is_global =
+       let global : is_global =
          if exported then Global else Local
        in
        emit_clambda_constant symbol global cst)

--- a/backend/cmmgen_state.ml
+++ b/backend/cmmgen_state.ml
@@ -29,6 +29,7 @@ type t = {
   structured_constants :
     (string, Cmm.is_global * Clambda.ustructured_constant) Hashtbl.t;
   functions : Clambda.ufunction Queue.t;
+  function_names : (Clambda.function_label, unit) Hashtbl.t;
 }
 
 let empty = {
@@ -36,6 +37,7 @@ let empty = {
   data_items = [];
   functions = Queue.create ();
   structured_constants = Hashtbl.create 16;
+  function_names = Hashtbl.create 16;
 }
 
 let state = empty
@@ -46,8 +48,9 @@ let add_constant sym cst =
 let add_data_items items =
   state.data_items <- items :: state.data_items
 
-let add_function func =
-  Queue.add func state.functions
+let add_function (func : Clambda.ufunction) =
+  Queue.add func state.functions;
+  Hashtbl.add state.function_names func.label ()
 
 let get_and_clear_constants () =
   let constants = state.constants in
@@ -66,6 +69,12 @@ let next_function () =
 
 let no_more_functions () =
   Queue.is_empty state.functions
+
+let is_local_function name =
+  Hashtbl.mem state.function_names name
+
+let clear_function_names () =
+  Hashtbl.clear state.function_names
 
 let set_local_structured_constants l =
   Hashtbl.clear state.structured_constants;

--- a/backend/cmmgen_state.ml
+++ b/backend/cmmgen_state.ml
@@ -19,11 +19,9 @@
 
 module S = Misc.Stdlib.String
 
-type is_global = Global | Local
-
 type constant =
-  | Const_closure of is_global * Clambda.ufunction list * Clambda.uconstant list
-  | Const_table of is_global * Cmm.data_item list
+  | Const_closure of Cmm.is_global * Clambda.ufunction list * Clambda.uconstant list
+  | Const_table of Cmm.is_global * Cmm.data_item list
 
 type t = {
   mutable constants : constant S.Map.t;

--- a/backend/cmmgen_state.mli
+++ b/backend/cmmgen_state.mli
@@ -37,6 +37,10 @@ val next_function : unit -> Clambda.ufunction option
 
 val no_more_functions : unit -> bool
 
+val is_local_function : Clambda.function_label -> bool
+
+val clear_function_names : unit -> unit
+
 val set_local_structured_constants : Clambda.preallocated_constant list -> unit
 
 val add_global_structured_constant : string -> Clambda.ustructured_constant -> unit

--- a/backend/cmmgen_state.mli
+++ b/backend/cmmgen_state.mli
@@ -19,11 +19,9 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-type is_global = Global | Local
-
 type constant =
-  | Const_closure of is_global * Clambda.ufunction list * Clambda.uconstant list
-  | Const_table of is_global * Cmm.data_item list
+  | Const_closure of Cmm.is_global * Clambda.ufunction list * Clambda.uconstant list
+  | Const_table of Cmm.is_global * Cmm.data_item list
 
 val add_constant : Misc.Stdlib.String.t -> constant -> unit
 

--- a/backend/cmmgen_state.mli
+++ b/backend/cmmgen_state.mli
@@ -37,9 +37,11 @@ val next_function : unit -> Clambda.ufunction option
 
 val no_more_functions : unit -> bool
 
-val set_structured_constants : Clambda.preallocated_constant list -> unit
+val set_local_structured_constants : Clambda.preallocated_constant list -> unit
 
-val add_structured_constant : string -> Clambda.ustructured_constant -> unit
+val add_global_structured_constant : string -> Clambda.ustructured_constant -> unit
+
+val get_structured_constant : string -> (Cmm.is_global * Clambda.ustructured_constant) option
 
 (* Also looks up using Compilenv.structured_constant_of_symbol *)
 val structured_constant_of_sym : string -> Clambda.ustructured_constant option

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -52,11 +52,11 @@ type operation =
   | Ireload
   | Iconst_int of nativeint
   | Iconst_float of int64
-  | Iconst_symbol of string
+  | Iconst_symbol of Cmm.symbol
   | Icall_ind
-  | Icall_imm of { func : string; }
+  | Icall_imm of { func : Cmm.symbol; }
   | Itailcall_ind
-  | Itailcall_imm of { func : string; }
+  | Itailcall_imm of { func : Cmm.symbol; }
   | Iextcall of { func : string;
                   ty_res : Cmm.machtype; ty_args : Cmm.exttype list;
                   alloc : bool; returns : bool; }

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -55,11 +55,11 @@ type operation =
   | Ireload
   | Iconst_int of nativeint
   | Iconst_float of int64
-  | Iconst_symbol of string
+  | Iconst_symbol of Cmm.symbol
   | Icall_ind
-  | Icall_imm of { func : string; }
+  | Icall_imm of { func : Cmm.symbol; }
   | Itailcall_ind
-  | Itailcall_imm of { func : string; }
+  | Itailcall_imm of { func : Cmm.symbol; }
   | Iextcall of { func : string;
                   ty_res : Cmm.machtype; ty_args : Cmm.exttype list;
                   alloc : bool; returns : bool; }

--- a/backend/polling.ml
+++ b/backend/polling.ml
@@ -149,8 +149,8 @@ let potentially_recursive_tailcall ~future_funcnames funbody =
          So, every such infinite sequence must contain many forward-referencing
          tail calls, so polling only on those suffices.  This is checked using
          the set [future_funcnames]. *)
-      if String.Set.mem func future_funcnames
-         || function_is_assumed_to_never_poll func
+      if String.Set.mem func.sym_name future_funcnames
+         || function_is_assumed_to_never_poll func.sym_name
       then Might_not_poll
       else Always_polls
     | Iop op ->

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -235,7 +235,7 @@ let rec expr ppf = function
   | Cconst_natint (n, _dbg) ->
     fprintf ppf "%s" (Nativeint.to_string n)
   | Cconst_float (n, _dbg) -> fprintf ppf "%F" n
-  | Cconst_symbol (s, _dbg) -> fprintf ppf "\"%s\"" s
+  | Cconst_symbol (s, _dbg) -> fprintf ppf "\"%s\"" s.sym_name
   | Cvar id -> V.print ppf id
   | Clet(id, def, (Clet(_, _, _) as body)) ->
       let print_binding id ppf def =
@@ -389,19 +389,18 @@ let fundecl ppf f =
      cases in
   with_location_mapping ~label:"Function" ~dbg:f.fun_dbg ppf (fun () ->
   fprintf ppf "@[<1>(function%s%a@ %s@;<1 4>@[<1>(%a)@]@ @[%a@])@]@."
-         (location f.fun_dbg) print_codegen_options f.fun_codegen_options f.fun_name
+         (location f.fun_dbg) print_codegen_options f.fun_codegen_options f.fun_name.sym_name
          print_cases f.fun_args sequence f.fun_body)
 
 let data_item ppf = function
-  | Cdefine_symbol s -> fprintf ppf "\"%s\":" s
-  | Cglobal_symbol s -> fprintf ppf "global \"%s\"" s
+  | Cdefine_symbol s -> fprintf ppf "\"%s\":" s.sym_name
   | Cint8 n -> fprintf ppf "byte %i" n
   | Cint16 n -> fprintf ppf "int16 %i" n
   | Cint32 n -> fprintf ppf "int32 %s" (Nativeint.to_string n)
   | Cint n -> fprintf ppf "int %s" (Nativeint.to_string n)
   | Csingle f -> fprintf ppf "single %F" f
   | Cdouble f -> fprintf ppf "double %F" f
-  | Csymbol_address s -> fprintf ppf "addr \"%s\"" s
+  | Csymbol_address s -> fprintf ppf "addr \"%s\"" s.sym_name
   | Cstring s -> fprintf ppf "string \"%s\"" s
   | Cskip n -> fprintf ppf "skip %i" n
   | Calign n -> fprintf ppf "align %i" n

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -393,7 +393,8 @@ let fundecl ppf f =
          print_cases f.fun_args sequence f.fun_body)
 
 let data_item ppf = function
-  | Cdefine_symbol s -> fprintf ppf "\"%s\":" s.sym_name
+  | Cdefine_symbol {sym_name; sym_global = Local} -> fprintf ppf "\"%s\":" sym_name
+  | Cdefine_symbol {sym_name; sym_global = Global} -> fprintf ppf "global \"%s\":" sym_name
   | Cint8 n -> fprintf ppf "byte %i" n
   | Cint16 n -> fprintf ppf "int16 %i" n
   | Cint32 n -> fprintf ppf "int32 %s" (Nativeint.to_string n)

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -158,11 +158,11 @@ let operation' ?(print_reg = reg) op arg ppf res =
   | Ireload -> fprintf ppf "%a (reload)" regs arg
   | Iconst_int n -> fprintf ppf "%s" (Nativeint.to_string n)
   | Iconst_float f -> fprintf ppf "%F" (Int64.float_of_bits f)
-  | Iconst_symbol s -> fprintf ppf "\"%s\"" s
+  | Iconst_symbol s -> fprintf ppf "\"%s\"" s.sym_name
   | Icall_ind -> fprintf ppf "call %a" regs arg
-  | Icall_imm { func; } -> fprintf ppf "call \"%s\" %a" func regs arg
+  | Icall_imm { func; } -> fprintf ppf "call \"%s\" %a" func.sym_name regs arg
   | Itailcall_ind -> fprintf ppf "tailcall %a" regs arg
-  | Itailcall_imm { func; } -> fprintf ppf "tailcall \"%s\" %a" func regs arg
+  | Itailcall_imm { func; } -> fprintf ppf "tailcall \"%s\" %a" func.sym_name regs arg
   | Iextcall { func; alloc; _ } ->
       fprintf ppf "extcall \"%s\" %a%s" func regs arg
       (if alloc then "" else " (noalloc)")

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -126,7 +126,10 @@ let unit0 ~offsets flambda_unit ~all_code =
       then fun_codegen
       else Cmm.No_CSE :: fun_codegen
     in
-    C.cfunction (C.fundecl (Cmm.global_symbol fun_name) [] body fun_codegen dbg Default_poll)
+    C.cfunction
+      (C.fundecl
+         (Cmm.global_symbol fun_name)
+         [] body fun_codegen dbg Default_poll)
   in
   let { R.data_items; gc_roots; functions } = R.to_cmm res in
   let cmm_helpers_data = flush_cmm_helpers_state () in

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -47,7 +47,7 @@ let flush_cmm_helpers_state () =
          Cmm translation"
   in
   (* reset the structured constants, just in case *)
-  Cmmgen_state.set_structured_constants [];
+  Cmmgen_state.set_local_structured_constants [];
   match Cmmgen_state.get_and_clear_data_items () with
   | [] ->
     let cst_map = Cmmgen_state.get_and_clear_constants () in
@@ -126,7 +126,7 @@ let unit0 ~offsets flambda_unit ~all_code =
       then fun_codegen
       else Cmm.No_CSE :: fun_codegen
     in
-    C.cfunction (C.fundecl fun_name [] body fun_codegen dbg Default_poll)
+    C.cfunction (C.fundecl (Cmm.global_symbol fun_name) [] body fun_codegen dbg Default_poll)
   in
   let { R.data_items; gc_roots; functions } = R.to_cmm res in
   let cmm_helpers_data = flush_cmm_helpers_state () in

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -38,7 +38,7 @@ let flush_cmm_helpers_state () =
   let aux name cst acc =
     match (cst : Cmmgen_state.constant) with
     | Const_table (sym_global, l) ->
-      C.cdata (C.define_symbol {sym_name = name; sym_global} @ l) :: acc
+      C.cdata (C.define_symbol { sym_name = name; sym_global } @ l) :: acc
     | Const_closure _ ->
       Misc.fatal_errorf
         "There shouldn't be any closures in Cmmgen_state during Flambda 2 to \

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -37,10 +37,8 @@ end
 let flush_cmm_helpers_state () =
   let aux name cst acc =
     match (cst : Cmmgen_state.constant) with
-    | Const_table (Local, l) ->
-      C.cdata (C.define_symbol ~global:false name @ l) :: acc
-    | Const_table (Global, l) ->
-      C.cdata (C.define_symbol ~global:true name @ l) :: acc
+    | Const_table (sym_global, l) ->
+      C.cdata (C.define_symbol {sym_name = name; sym_global} @ l) :: acc
     | Const_closure _ ->
       Misc.fatal_errorf
         "There shouldn't be any closures in Cmmgen_state during Flambda 2 to \

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -100,7 +100,11 @@ let define_module_symbol_if_missing r =
     let linkage_name =
       Linkage_name.to_string (Symbol.linkage_name r.module_symbol)
     in
-    let l = C.emit_block (linkage_name, Global) (C.black_block_header 0 0) [] in
+    let sym : Cmm.symbol =
+      { sym_name = linkage_name;
+        sym_global = Global }
+    in
+    let l = C.emit_block sym (C.black_block_header 0 0) [] in
     set_data r l
 
 let add_invalid_message_symbol t symbol ~message =

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -49,7 +49,7 @@ let check_for_module_symbol t symbol =
 let defines_a_symbol data =
   match (data : Cmm.data_item) with
   | Cdefine_symbol _ -> true
-  | Cglobal_symbol _ | Cint8 _ | Cint16 _ | Cint32 _ | Cint _ | Csingle _
+  | Cint8 _ | Cint16 _ | Cint32 _ | Cint _ | Csingle _
   | Cdouble _ | Csymbol_address _ | Cstring _ | Cskip _ | Calign _ ->
     false
 

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -49,8 +49,8 @@ let check_for_module_symbol t symbol =
 let defines_a_symbol data =
   match (data : Cmm.data_item) with
   | Cdefine_symbol _ -> true
-  | Cint8 _ | Cint16 _ | Cint32 _ | Cint _ | Csingle _
-  | Cdouble _ | Csymbol_address _ | Cstring _ | Cskip _ | Calign _ ->
+  | Cint8 _ | Cint16 _ | Cint32 _ | Cint _ | Csingle _ | Cdouble _
+  | Csymbol_address _ | Cstring _ | Cskip _ | Calign _ ->
     false
 
 let add_to_data_list x l =
@@ -100,10 +100,7 @@ let define_module_symbol_if_missing r =
     let linkage_name =
       Linkage_name.to_string (Symbol.linkage_name r.module_symbol)
     in
-    let sym : Cmm.symbol =
-      { sym_name = linkage_name;
-        sym_global = Global }
-    in
+    let sym : Cmm.symbol = { sym_name = linkage_name; sym_global = Global } in
     let l = C.emit_block sym (C.black_block_header 0 0) [] in
     set_data r l
 

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -381,7 +381,9 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
     @
     if Flambda_features.optimize_for_speed () then [] else [Cmm.Reduce_code_size]
   in
-  let linkage_name = Linkage_name.to_string (Code_id.linkage_name code_id) |> Cmm.global_symbol in
+  let linkage_name =
+    Linkage_name.to_string (Code_id.linkage_name code_id) |> Cmm.global_symbol
+  in
   let fun_poll =
     Env.get_code_metadata env code_id
     |> Code_metadata.poll_attribute |> Poll_attribute.to_lambda

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -314,7 +314,7 @@ module Static = Make_layout_filler (struct
     C.cint (C.infix_header function_slot_offset)
 
   let symbol_from_linkage_name ~dbg:_ linkage_name =
-    C.symbol_address (Linkage_name.to_string linkage_name)
+    C.symbol_address (Cmm.global_symbol (Linkage_name.to_string linkage_name))
 
   let define_global_symbol sym = C.define_symbol ~global:true sym
 end)
@@ -381,7 +381,7 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
     @
     if Flambda_features.optimize_for_speed () then [] else [Cmm.Reduce_code_size]
   in
-  let linkage_name = Linkage_name.to_string (Code_id.linkage_name code_id) in
+  let linkage_name = Linkage_name.to_string (Code_id.linkage_name code_id) |> Cmm.global_symbol in
   let fun_poll =
     Env.get_code_metadata env code_id
     |> Code_metadata.poll_attribute |> Poll_attribute.to_lambda

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -316,7 +316,7 @@ module Static = Make_layout_filler (struct
   let symbol_from_linkage_name ~dbg:_ linkage_name =
     C.symbol_address (Cmm.global_symbol (Linkage_name.to_string linkage_name))
 
-  let define_global_symbol sym = C.define_symbol ~global:true sym
+  let define_global_symbol sym = C.define_symbol (Cmm.global_symbol sym)
 end)
 
 (* Translation of "check" attributes on functions. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -152,6 +152,8 @@ let simple ?consider_inlining_effectful_expressions ~dbg env res s =
             }
         })
 
+let symbol_address s = symbol_address (Cmm.global_symbol s)
+
 let name_static name =
   Name.pattern_match name
     ~var:(fun v -> `Var v)

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -219,7 +219,8 @@ let invalid res ~message =
       let res =
         Cmm_helpers.emit_string_constant
           { sym_name = Symbol.linkage_name_as_string message_sym;
-            sym_global = Global }
+            sym_global = Global
+          }
           message []
         |> To_cmm_result.add_archive_data_items res
       in

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -216,7 +216,8 @@ let invalid res ~message =
       in
       let res =
         Cmm_helpers.emit_string_constant
-          (Symbol.linkage_name_as_string message_sym, Global)
+          { sym_name = Symbol.linkage_name_as_string message_sym;
+            sym_global = Global }
           message []
         |> To_cmm_result.add_archive_data_items res
       in

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -28,7 +28,7 @@ let to_cmm_symbol sym : Cmm.symbol =
 
 let static_value v =
   match (v : Field_of_static_block.t) with
-  | Symbol s -> C.symbol_address (Symbol.linkage_name_as_string s)
+  | Symbol s -> C.symbol_address (Symbol.linkage_name_as_string s |> Cmm.global_symbol)
   | Dynamically_computed _ -> C.cint 1n
   | Tagged_immediate i ->
     C.cint
@@ -78,7 +78,7 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
          symbols, particularly in Classic mode. *)
       let symbol_name = Symbol.linkage_name_as_string symbol in
       let structured_constant = structured (transl c) in
-      Cmmgen_state.add_structured_constant symbol_name structured_constant;
+      Cmmgen_state.add_global_structured_constant symbol_name structured_constant;
       env, res, updates
     | Var (v, dbg) ->
       C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -65,7 +65,7 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
     res updates =
   let aux x cont =
     emit
-      (Symbol.linkage_name_as_string symbol, Cmmgen_state.Global)
+      (Symbol.linkage_name_as_string symbol, Cmm.Global)
       (transl x) cont
   in
   let env, res, updates =
@@ -112,7 +112,7 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
   | Block_like s, Block (tag, _mut, fields) ->
     let res = R.check_for_module_symbol res s in
     let tag = Tag.Scannable.to_int tag in
-    let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
+    let block_name = Symbol.linkage_name_as_string s, Cmm.Global in
     let header = C.black_block_header tag (List.length fields) in
     let static_fields =
       List.fold_right
@@ -171,13 +171,13 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let static_fields = List.map aux fields in
     let float_array =
       C.emit_float_array_constant
-        (Symbol.linkage_name_as_string s, Cmmgen_state.Global)
+        (Symbol.linkage_name_as_string s, Cmm.Global)
         static_fields
     in
     let env, res, e = static_float_array_updates s env res updates 0 fields in
     env, R.update_data res float_array, e
   | Block_like s, Immutable_value_array fields ->
-    let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
+    let block_name = Symbol.linkage_name_as_string s, Cmm.Global in
     let header = C.black_block_header 0 (List.length fields) in
     let static_fields =
       List.fold_right
@@ -191,14 +191,14 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     env, R.set_data res block, updates
   | Block_like s, Empty_array ->
     (* Recall: empty arrays have tag zero, even if their kind is naked float. *)
-    let block_name = Symbol.linkage_name_as_string s, Cmmgen_state.Global in
+    let block_name = Symbol.linkage_name_as_string s, Cmm.Global in
     let header = C.black_block_header 0 0 in
     let block = C.emit_block block_name header [] in
     env, R.set_data res block, updates
   | Block_like s, Mutable_string { initial_value = str }
   | Block_like s, Immutable_string str ->
     let name = Symbol.linkage_name_as_string s in
-    let data = C.emit_string_constant (name, Cmmgen_state.Global) str in
+    let data = C.emit_string_constant (name, Cmm.Global) str in
     env, R.update_data res data, updates
   | Block_like _, Set_of_closures _ ->
     Misc.fatal_errorf

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -23,12 +23,12 @@ module SC = Static_const
 module R = To_cmm_result
 
 let to_cmm_symbol sym : Cmm.symbol =
-  { sym_name = Symbol.linkage_name_as_string sym;
-    sym_global = Global }
+  { sym_name = Symbol.linkage_name_as_string sym; sym_global = Global }
 
 let static_value v =
   match (v : Field_of_static_block.t) with
-  | Symbol s -> C.symbol_address (Symbol.linkage_name_as_string s |> Cmm.global_symbol)
+  | Symbol s ->
+    C.symbol_address (Symbol.linkage_name_as_string s |> Cmm.global_symbol)
   | Dynamically_computed _ -> C.cint 1n
   | Tagged_immediate i ->
     C.cint
@@ -67,9 +67,7 @@ let rec static_float_array_updates symb env res acc i = function
 
 let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
     res updates =
-  let aux x cont =
-    emit (to_cmm_symbol symbol) (transl x) cont
-  in
+  let aux x cont = emit (to_cmm_symbol symbol) (transl x) cont in
   let env, res, updates =
     match (v : _ Or_variable.t) with
     | Const c ->
@@ -78,7 +76,8 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
          symbols, particularly in Classic mode. *)
       let symbol_name = Symbol.linkage_name_as_string symbol in
       let structured_constant = structured (transl c) in
-      Cmmgen_state.add_global_structured_constant symbol_name structured_constant;
+      Cmmgen_state.add_global_structured_constant symbol_name
+        structured_constant;
       env, res, updates
     | Var (v, dbg) ->
       C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
@@ -172,9 +171,7 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     in
     let static_fields = List.map aux fields in
     let float_array =
-      C.emit_float_array_constant
-        (to_cmm_symbol s)
-        static_fields
+      C.emit_float_array_constant (to_cmm_symbol s) static_fields
     in
     let env, res, e = static_float_array_updates s env res updates 0 fields in
     env, R.update_data res float_array, e

--- a/testsuite/tools/asmgen_amd64.S
+++ b/testsuite/tools/asmgen_amd64.S
@@ -31,6 +31,11 @@
 #define CAML_ABSF_MASK caml_absf_mask
 #endif
 
+        .globl caml_call_gc
+        .weak caml_call_gc
+caml_call_gc:
+        int3
+
         .globl  CALL_GEN_CODE
         .align  ALIGN
 CALL_GEN_CODE:

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -186,8 +186,8 @@ fundecl:
          fun_dbg = debuginfo ()} }
 ;
 fun_name:
-    STRING              { $1 }
-  | IDENT               { $1 }
+    STRING              { Cmm.global_symbol $1 }
+  | IDENT               { Cmm.global_symbol $1 }
 params:
     oneparam params     { $1 :: $2 }
   | /**/                { [] }
@@ -215,7 +215,7 @@ traps:
 expr:
     INTCONST    { Cconst_int ($1, debuginfo ()) }
   | FLOATCONST  { Cconst_float (float_of_string $1, debuginfo ()) }
-  | STRING      { Cconst_symbol ($1, debuginfo ()) }
+  | STRING      { Cconst_symbol (Cmm.global_symbol $1, debuginfo ()) }
   | IDENT       { Cvar(find_ident $1) }
   | LBRACKET RBRACKET { Ctuple [] }
   | LPAREN LET letdef sequence RPAREN { make_letdef $3 $4 }
@@ -413,17 +413,16 @@ datalist:
   | /**/                        { [] }
 ;
 dataitem:
-    STRING COLON                { Cdefine_symbol $1 }
+    STRING COLON                { Cdefine_symbol (Cmm.global_symbol $1) }
   | BYTE INTCONST               { Cint8 $2 }
   | HALF INTCONST               { Cint16 $2 }
   | INT INTCONST                { Cint(Nativeint.of_int $2) }
   | FLOAT FLOATCONST            { Cdouble (float_of_string $2) }
-  | ADDR STRING                 { Csymbol_address $2 }
-  | VAL STRING                 { Csymbol_address $2 }
+  | ADDR STRING                 { Csymbol_address (Cmm.global_symbol $2) }
+  | VAL STRING                 { Csymbol_address (Cmm.global_symbol $2) }
   | KSTRING STRING              { Cstring $2 }
   | SKIP INTCONST               { Cskip $2 }
   | ALIGN INTCONST              { Calign $2 }
-  | GLOBAL STRING               { Cglobal_symbol $2 }
 ;
 catch_handlers:
   | catch_handler


### PR DESCRIPTION
Linking currently takes a long time because many symbol references (in particular, to statically allocated data) are not resolved until link time, despite many of these references being to data defined in the same file.

So far, this patch removes about half the symbols in compiler-libs, mostly unexported data. (The benefit applies only to Closure builds at the moment).

The major change is to use the following type for symbols in Cmm onwards, instead of `string`:
```ocaml
type is_global = Global | Local

(* Symbols are marked with whether they are local or global,
   at both definition and use sites.
   Symbols defined as [Local] may only be referenced within the same file,
   and all such references must also be [Local].
   Symbols defined as [Global] may be referenced from other files.
   References from other files must be [Global], but references from the
   same file may be [Local].
   (Marking symbols in this way speeds up linking, as many references can
   then be resolved early) *)
type symbol =
  { sym_name : string;
    sym_global : is_global }
```

At assembly time, `Local` symbols are generated as assembler labels rather than ELF symbols, so references can be resolved eagerly. `Global` symbols are generated as _both_ an ELF symbol and an assembler label, so that `Local` references within the same file can use the label form.

There is quite a lot of low-hanging fruit here. The last commit here removes another ~8% of symbol references by wrapping `caml_call_gc` once per file. We should also be able to turn references to functions in the same file into assembler label references, and to improve the encoding of debug info and frame tables to generate fewer relocations.