### PR TITLE
Provide a no-naked-pointers runtime and use it for the compiler

### DIFF
--- a/dune
+++ b/dune
@@ -336,6 +336,7 @@
   (backend bisect_ppx))
  (flags
   (:standard -principal))
+ (ocamlopt_flags (:standard -runtime-variant nnp))
  (libraries
   flambda_backend_driver
   memtrace

--- a/ocaml/runtime/Makefile
+++ b/ocaml/runtime/Makefile
@@ -76,6 +76,7 @@ ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
 BYTECODE_STATIC_LIBRARIES += libcamlrun_pic.$(A)
 BYTECODE_SHARED_LIBRARIES += libcamlrun_shared.$(SO)
 NATIVE_STATIC_LIBRARIES += libasmrun_pic.$(A)
+NATIVE_STATIC_LIBRARIES += libasmrunnnp.$(A)
 NATIVE_SHARED_LIBRARIES += libasmrun_shared.$(SO)
 endif
 endif
@@ -105,6 +106,8 @@ libasmruni_OBJECTS := $(NATIVE_C_SOURCES:.c=.ni.$(O)) $(ASM_OBJECTS)
 
 libasmrunpic_OBJECTS := $(NATIVE_C_SOURCES:.c=.npic.$(O)) \
   $(ASM_OBJECTS:.$(O)=_libasmrunpic.$(O))
+
+libasmrunnnp_OBJECTS := $(NATIVE_C_SOURCES:.c=.nnp.$(O)) $(ASM_OBJECTS)
 
 # General (non target-specific) assembler and compiler flags
 
@@ -310,6 +313,9 @@ libasmruni.$(A): $(libasmruni_OBJECTS)
 libasmrun_pic.$(A): $(libasmrunpic_OBJECTS)
 	$(call MKLIB,$@, $^)
 
+libasmrunnnp.$(A): $(libasmrunnnp_OBJECTS)
+	$(call MKLIB,$@, $^)
+
 libasmrun_shared.$(SO): $(libasmrunpic_OBJECTS)
 	$(MKDLL) -o $@ $^ $(NATIVECCLIBS)
 
@@ -335,6 +341,9 @@ libasmrun_shared.$(SO): $(libasmrunpic_OBJECTS)
 %.npic.$(O): OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 %.npic.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
 %.npic.$(D): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
+
+%.nnp.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) -DNO_NAKED_POINTERS
+%.nnp.$(D): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) -DNO_NAKED_POINTERS
 
 # The major GC performs better with this flag on Intel processors
 # This is a workaround for an Intel CPU bug:
@@ -369,7 +378,7 @@ endef
 
 object_types := % %.b %.bd %.bi %.bpic
 ifneq "$(NATIVE_COMPILER)" "false"
-object_types += %.n %.nd %.ni %.np %.npic
+object_types += %.n %.nnp %.nd %.ni %.np %.npic
 endif
 
 $(foreach object_type, $(object_types), \
@@ -414,6 +423,7 @@ i386nt.obj: i386nt.asm domain_state32.inc
 DEP_FILES := $(addsuffix .b, $(basename $(BYTECODE_C_SOURCES) instrtrace))
 ifneq "$(NATIVE_COMPILER)" "false"
 DEP_FILES += $(addsuffix .n, $(basename $(NATIVE_C_SOURCES)))
+DEP_FILES += $(addsuffix .nnp, $(basename $(NATIVE_C_SOURCES)))
 endif
 DEP_FILES += $(addsuffix d, $(DEP_FILES)) \
              $(addsuffix i, $(DEP_FILES)) \

--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -27,7 +27,7 @@
  (action  (with-stdout-to %{targets} (run %{dep:gen_primitives.sh}))))
 
 (rule
- (targets libasmrun.a libasmrund.a libasmruni.a libasmrun_pic.a
+ (targets libasmrun.a libasmrund.a libasmruni.a libasmrun_pic.a libasmrunnnp.a
     libasmrun_shared.so libcamlrun.a libcamlrund.a libcamlruni.a libcamlrun_pic.a
     libcamlrun_shared.so ocamlrun ocamlrund ocamlruni ld.conf
     sak)
@@ -77,6 +77,7 @@
     libasmrund.a
     libasmruni.a
     libasmrun_pic.a
+    libasmrunnnp.a
     libasmrun_shared.so
   )
   (section lib)

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -90,6 +90,14 @@ static struct page_table caml_page_table;
 
 int caml_page_table_lookup(void * addr)
 {
+#ifdef NO_NAKED_POINTERS
+  /* This case should only be hit if C stubs compiled without
+     NO_NAKED_POINTERS are linked into an executable using
+     "-runtime-variant nnp".  The return value here should cause the
+     macros in address_class.h to give the same results as when they
+     are compiled with NO_NAKED_POINTERS defined. */
+  return In_heap | In_young;
+#else
   uintnat h, e;
 
   h = Hash(Page(addr));
@@ -102,6 +110,7 @@ int caml_page_table_lookup(void * addr)
     e = caml_page_table.entries[h];
     if (Page_entry_matches(e, (uintnat)addr)) return e & 0xFF;
   }
+#endif
 }
 
 int caml_page_table_initialize(mlsize_t bytesize)


### PR DESCRIPTION
Banishes `caml_page_table_lookup` from your `perf` profiles and might make things faster too.

This currently only applies to the Flambda backend compiler binary (no changes yet for compilers built in the `ocaml-jst` part of the world).