### PR TITLE
Put frametables in .text with relative offsets for return addresses.

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1792,6 +1792,7 @@ let end_assembly () =
   emit_global_label "data_end";
   D.qword (const 0);
 
+  D.text ();
   D.align ~data:true 8;                            (* PR#7591 *)
   emit_global_label "frametable";
 
@@ -1828,6 +1829,7 @@ let end_assembly () =
     D.size frametable (ConstSub (ConstThis, ConstLabel frametable))
   end;
 
+  D.data ();
   emit_probe_notes ();
   emit_trap_notes ();
 

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -219,7 +219,7 @@ let emit_frames a =
   let emit_32 n = n |> Int32.of_int |> a.efa_32 in
   let emit_frame fd =
     let flags = get_flags fd.fd_debuginfo in
-    a.efa_code_label fd.fd_lbl;
+    a.efa_label_rel fd.fd_lbl 0l;
     (* For short format, the size is guaranteed
        to be less than the constant below. *)
     if fd.fd_long then begin

--- a/ocaml/asmcomp/amd64/emit.mlp
+++ b/ocaml/asmcomp/amd64/emit.mlp
@@ -1429,6 +1429,7 @@ let end_assembly() =
   emit_global_label "data_end";
   D.qword (const 0);
 
+  D.text ();
   D.align 8;                            (* PR#7591 *)
   emit_global_label "frametable";
 
@@ -1465,6 +1466,7 @@ let end_assembly() =
     D.size frametable (ConstSub (ConstThis, ConstLabel frametable))
   end;
 
+  D.data ();
   emit_probe_notes ();
 
   if system = S_linux then

--- a/ocaml/asmcomp/emitaux.ml
+++ b/ocaml/asmcomp/emitaux.ml
@@ -203,7 +203,7 @@ let emit_frames a =
              not (Debuginfo.is_none d.Debuginfo.alloc_dbg)) dbgs
         then 3 else 2
     in
-    a.efa_code_label fd.fd_lbl;
+    a.efa_label_rel fd.fd_lbl 0l;
     efa_16_checked (fd.fd_frame_size + flags);
     efa_16_checked (List.length fd.fd_live_offset);
     List.iter efa_16_checked fd.fd_live_offset;

--- a/ocaml/runtime/amd64.S
+++ b/ocaml/runtime/amd64.S
@@ -764,7 +764,7 @@ G(caml_system__code_end):
         .align  EIGHT_ALIGN
 G(caml_system__frametable):
         .quad   1           /* one descriptor */
-        .quad   LBL(107)    /* return address into callback */
+        .4byte   LBL(107) - .    /* return address into callback */
         .value  -1          /* negative frame size => use callback link */
         .value  0           /* no roots here */
         .align  EIGHT_ALIGN

--- a/ocaml/runtime/amd64nt.asm
+++ b/ocaml/runtime/amd64nt.asm
@@ -430,7 +430,7 @@ caml_system__code_end:
         PUBLIC  caml_system__frametable
 caml_system__frametable LABEL QWORD
         QWORD   1           ; one descriptor
-        QWORD   L107        ; return address into callback
+        DWORD   L107 - THIS BYTE ; return address into callback
         WORD    -1          ; negative frame size => use callback link
         WORD    0           ; no roots here
         ALIGN   8

--- a/ocaml/runtime/arm.S
+++ b/ocaml/runtime/arm.S
@@ -436,7 +436,7 @@ caml_system__code_end:
         .globl  caml_system__frametable
 caml_system__frametable:
         .word   1               /* one descriptor */
-        .word   .Lcaml_retaddr  /* return address into callback */
+        .word   .Lcaml_retaddr - .  /* return address into callback */
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots */
         .align  2

--- a/ocaml/runtime/arm64.S
+++ b/ocaml/runtime/arm64.S
@@ -535,7 +535,7 @@ G(caml_system__code_end):
 
 OBJECT(caml_system__frametable)
         .quad   1               /* one descriptor */
-        .quad   L(caml_retaddr) /* return address into callback */
+        .4byte  L(caml_retaddr) - . /* return address into callback */
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots */
         .align  3

--- a/ocaml/runtime/backtrace_nat.c
+++ b/ocaml/runtime/backtrace_nat.c
@@ -41,7 +41,7 @@ frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
     while (1) {
       d = caml_frame_descriptors[h];
       if (d == NULL) return NULL; /* happens if some code compiled without -g */
-      if (d->retaddr == *pc) break;
+      if (Retaddr_frame(d) == *pc) break;
       h = (h+1) & caml_frame_descriptors_mask;
     }
     /* Skip to next frame */

--- a/ocaml/runtime/caml/stack.h
+++ b/ocaml/runtime/caml/stack.h
@@ -87,7 +87,7 @@ struct caml_context {
 
 /* Structure of frame descriptors */
 typedef struct {
-  uintnat retaddr;
+  int32_t retaddr_rel;
   unsigned short frame_size;
   unsigned short num_live;
   unsigned short live_ofs[1 /* num_live */];
@@ -104,7 +104,7 @@ typedef struct {
 } frame_descr;
 
 typedef struct {
-  uintnat retaddr;
+  int32_t retaddr_rel;
   unsigned short marker;        /* LONG_FRAME_MARKER */
   unsigned short _pad;  /* Ensure frame_size is 4-byte aligned */
   uint32_t frame_size;
@@ -142,6 +142,10 @@ extern uintnat caml_frame_descriptors_mask;
 
 #define Hash_retaddr(addr) \
   (((uintnat)(addr) >> 3) & caml_frame_descriptors_mask)
+
+#define Retaddr_frame(d) \
+  ((uintnat)&(d)->retaddr_rel + \
+   (uintnat)(intnat)((d)->retaddr_rel))
 
 extern void caml_init_frame_descriptors(void);
 extern void caml_register_frametable(intnat *);

--- a/ocaml/runtime/i386.S
+++ b/ocaml/runtime/i386.S
@@ -465,7 +465,7 @@ G(caml_system__code_end):
         .globl  G(caml_system__frametable)
 G(caml_system__frametable):
         .long   1               /* one descriptor */
-        .long   LBL(107)        /* return address into callback */
+        .4byte  LBL(107) - .    /* return address into callback */
 #ifndef SYS_solaris
         .word   -1              /* negative frame size => use callback link */
         .word   0               /* no roots here */

--- a/ocaml/runtime/i386nt.asm
+++ b/ocaml/runtime/i386nt.asm
@@ -304,7 +304,7 @@ _caml_system__code_end:
         PUBLIC  _caml_system__frametable
 _caml_system__frametable LABEL DWORD
         DWORD   1               ; one descriptor
-        DWORD   L107            ; return address into callback
+        DWORD   L107 - THIS BYTE            ; return address into callback
         WORD    -1              ; negative frame size => use callback link
         WORD    0               ; no roots here
 

--- a/ocaml/runtime/power.S
+++ b/ocaml/runtime/power.S
@@ -649,7 +649,7 @@ caml_system__code_end:
         .type   caml_system__frametable, @object
 caml_system__frametable:
         datag   1               /* one descriptor */
-        datag   .L105 + 4       /* return address into callback */
+        .long   .L105 + 4 - .   /* return address into callback */
         .short  -1              /* negative size count => use callback link */
         .short  0               /* no roots here */
 

--- a/ocaml/runtime/riscv.S
+++ b/ocaml/runtime/riscv.S
@@ -446,7 +446,7 @@ caml_system__code_end:
         .type   caml_system__frametable, @object
 caml_system__frametable:
         .quad   1               /* one descriptor */
-        .quad   .Lcaml_retaddr  /* return address into callback */
+        .4byte  .Lcaml_retaddr - .  /* return address into callback */
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots */
         .align  3

--- a/ocaml/runtime/roots_nat.c
+++ b/ocaml/runtime/roots_nat.c
@@ -109,7 +109,7 @@ unsigned char * get_end_of_live_ofs (frame_descr *d) {
 static frame_descr * next_frame_descr(frame_descr * d) {
   unsigned char num_allocs = 0, *p;
   uint32_t frame_size;
-  CAMLassert(d->retaddr >= 4096);
+  CAMLassert(Retaddr_frame(d) >= 4096);
   if (d->frame_size != 0xFFFF) {
     frame_size = get_frame_size(d);
     p = get_end_of_live_ofs(d);
@@ -151,7 +151,7 @@ static void fill_hashtable(link *frametables) {
     len = *tbl;
     d = (frame_descr *)(tbl + 1);
     for (j = 0; j < len; j++) {
-      h = Hash_retaddr(d->retaddr);
+      h = Hash_retaddr(Retaddr_frame(d));
       while (caml_frame_descriptors[h] != NULL) {
         h = (h+1) & caml_frame_descriptors_mask;
       }
@@ -220,7 +220,7 @@ static void remove_entry(frame_descr * d) {
   uintnat r;
   uintnat j;
 
-  i = Hash_retaddr(d->retaddr);
+  i = Hash_retaddr(Retaddr_frame(d));
   while (caml_frame_descriptors[i] != d) {
     i = (i+1) & caml_frame_descriptors_mask;
   }
@@ -232,7 +232,7 @@ static void remove_entry(frame_descr * d) {
   i = (i+1) & caml_frame_descriptors_mask;
   // r3
   if(caml_frame_descriptors[i] == NULL) return;
-  r = Hash_retaddr(caml_frame_descriptors[i]->retaddr);
+  r = Hash_retaddr(Retaddr_frame(caml_frame_descriptors[i]));
   /* If r is between i and j (cyclically), i.e. if
      caml_frame_descriptors[i]->retaddr don't need to be moved */
   if(( ( j < r )  && ( r <= i ) ) ||
@@ -657,7 +657,7 @@ void caml_do_local_roots_nat(scanning_action maj, scanning_action min,
       h = Hash_retaddr(retaddr);
       while(1) {
         d = caml_frame_descriptors[h];
-        if (d->retaddr == retaddr) break;
+        if (Retaddr_frame(d) == retaddr) break;
         h = (h+1) & caml_frame_descriptors_mask;
       }
       if (d->frame_size != 0xFFFF) {

--- a/ocaml/runtime/s390x.S
+++ b/ocaml/runtime/s390x.S
@@ -346,7 +346,7 @@ caml_system__code_end:
         .type   caml_system__frametable, @object
 caml_system__frametable:
         .quad   1               /* one descriptor */
-        .quad   .L105           /* return address into callback */
+        .4byte  .L105 - .           /* return address into callback */
         .short  -1              /* negative size count => use callback link */
         .short  0               /* no roots here */
         .align  8

--- a/ocaml/runtime/signals_nat.c
+++ b/ocaml/runtime/signals_nat.c
@@ -68,7 +68,7 @@ void caml_garbage_collection(void)
     uintnat h = Hash_retaddr(Caml_state->last_return_address);
     while (1) {
       d = caml_frame_descriptors[h];
-      if (d->retaddr == Caml_state->last_return_address) break;
+      if (Retaddr_frame(d) == Caml_state->last_return_address) break;
       h = (h + 1) & caml_frame_descriptors_mask;
     }
     /* Must be an allocation frame */


### PR DESCRIPTION
This makes their contents statically known at assemble time, reducing the number of relocations that the linker needs to perform.

This removes approx 25% of the relocations, which should speed up linking.

(This is independent of #1222)