### PR TITLE
Change Includemod to work on lazy modtypes

### DIFF
--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -336,6 +336,7 @@ val filter_non_loaded_persistent : (Ident.t -> bool) -> t -> t
 (* Insertion of all fields of a signature. *)
 
 val add_signature: signature -> t -> t
+val add_signature_lazy: Subst.Lazy.signature_item list -> t -> t
 
 (* Insertion of all fields of a signature, relative to the given path.
    Used to implement open. Returns None if the path refers to a functor,

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -305,7 +305,7 @@ val add_module_lazy: update_summary:bool ->
   Ident.t -> module_presence -> Subst.Lazy.modtype -> t -> t
 val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool ->
   Ident.t -> module_presence -> module_declaration -> t -> t
-val add_module_declaration_lazy: update_summary:bool ->
+val add_module_declaration_lazy: ?arg:bool -> update_summary:bool ->
   Ident.t -> module_presence -> Subst.Lazy.module_decl -> t -> t
 val add_modtype: Ident.t -> modtype_declaration -> t -> t
 val add_modtype_lazy: update_summary:bool ->

--- a/ocaml/typing/envaux.ml
+++ b/ocaml/typing/envaux.ml
@@ -48,12 +48,17 @@ let rec env_from_summary sum subst =
             (Subst.extension_constructor subst desc)
             (env_from_summary s subst)
       | Env_module(s, id, pres, desc) ->
-          Env.add_module_declaration ~check:false id pres
-            (Subst.module_declaration Keep subst desc)
+          let desc =
+            Subst.Lazy.module_decl Keep subst (Subst.Lazy.of_module_decl desc)
+          in
+          Env.add_module_declaration_lazy ~update_summary:true id pres desc
             (env_from_summary s subst)
       | Env_modtype(s, id, desc) ->
-          Env.add_modtype id (Subst.modtype_declaration Keep subst desc)
-                          (env_from_summary s subst)
+          let desc = 
+            Subst.Lazy.modtype_decl Keep subst (Subst.Lazy.of_modtype_decl desc)
+          in
+          Env.add_modtype_lazy ~update_summary:true id desc
+            (env_from_summary s subst)
       | Env_class(s, id, desc) ->
           Env.add_class id (Subst.class_declaration subst desc)
                         (env_from_summary s subst)
@@ -70,8 +75,10 @@ let rec env_from_summary sum subst =
           end
       | Env_functor_arg(Env_module(s, id, pres, desc), id')
             when Ident.same id id' ->
-          Env.add_module_declaration ~check:false
-            id pres (Subst.module_declaration Keep subst desc)
+          let desc =
+            Subst.Lazy.module_decl Keep subst (Subst.Lazy.of_module_decl desc)
+          in
+          Env.add_module_declaration_lazy ~update_summary:true id pres desc
             ~arg:true (env_from_summary s subst)
       | Env_functor_arg _ -> assert false
       | Env_constraints(s, map) ->

--- a/ocaml/typing/includemod.ml
+++ b/ocaml/typing/includemod.ml
@@ -654,14 +654,14 @@ and functor_param ~in_eq ~loc env ~mark subst param1 param2 =
       let env, subst =
         match name1, name2 with
         | Some id1, Some id2 ->
-            Env.add_module_lazy ~update_summary:true id1 Mp_present arg2' env,
+            Env.add_module_lazy ~update_summary:false id1 Mp_present arg2' env,
             Subst.add_module id2 (Path.Pident id1) subst
         | None, Some id2 ->
             let id1 = Ident.rename id2 in
-            Env.add_module_lazy ~update_summary:true id1 Mp_present arg2' env,
+            Env.add_module_lazy ~update_summary:false id1 Mp_present arg2' env,
             Subst.add_module id2 (Path.Pident id1) subst
         | Some id1, None ->
-            Env.add_module_lazy ~update_summary:true id1 Mp_present arg2' env, subst
+            Env.add_module_lazy ~update_summary:false id1 Mp_present arg2' env, subst
         | None, None ->
             env, subst
       in

--- a/ocaml/typing/mtype.mli
+++ b/ocaml/typing/mtype.mli
@@ -37,6 +37,8 @@ val strengthen_lazy: aliasable:bool -> Env.t -> Subst.Lazy.modtype -> Path.t -> 
 val strengthen: aliasable:bool -> Env.t -> module_type -> Path.t -> module_type
         (* Strengthen abstract type components relative to the
            given path. *)
+val strengthen_lazy_decl:
+  aliasable:bool -> Env.t -> Subst.Lazy.module_decl -> Path.t -> Subst.Lazy.module_decl
 val strengthen_decl:
   aliasable:bool -> Env.t -> module_declaration -> Path.t -> module_declaration
 

--- a/ocaml/typing/subst.mli
+++ b/ocaml/typing/subst.mli
@@ -136,6 +136,7 @@ module Lazy : sig
   val of_signature : Types.signature -> signature
   val of_signature_items : signature_item list -> signature
   val of_signature_item : Types.signature_item -> signature_item
+  val of_functor_parameter : Types.functor_parameter -> functor_parameter
 
   val module_decl : scoping -> t -> module_decl -> module_decl
   val modtype : scoping -> t -> modtype -> modtype
@@ -149,4 +150,5 @@ module Lazy : sig
   val force_signature : signature -> Types.signature
   val force_signature_once : signature -> signature_item list
   val force_signature_item : signature_item -> Types.signature_item
+  val force_functor_parameter : functor_parameter -> Types.functor_parameter
 end

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -426,14 +426,6 @@ let may_equal_constr c1 c2 =
      | tag1, tag2 ->
          equal_tag tag1 tag2)
 
-let item_visibility = function
-  | Sig_value (_, _, vis)
-  | Sig_type (_, _, _, vis)
-  | Sig_typext (_, _, _, vis)
-  | Sig_module (_, _, _, _, vis)
-  | Sig_modtype (_, _, vis)
-  | Sig_class (_, _, _, vis)
-  | Sig_class_type (_, _, _, vis) -> vis
 
 let kind_abstract = Type_abstract { immediate = Unknown }
 

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -662,8 +662,6 @@ and ext_status =
   | Text_next                      (* not first constructor in an extension *)
   | Text_exception
 
-val item_visibility : signature_item -> visibility
-
 (* Constructor and record label descriptions inserted held in typing
    environments *)
 


### PR DESCRIPTION
Includemod now works directly on lazy modtypes & friends. The main
benefits are now longer having to force when getting module types from
Env.t, not having to copy things when storing them in Env.t and not
having to convert back and forth when strengthening.

This is a prerequisite for a subsequent change which will introduce lazy
value_descriptions.

There is some slight code duplication here in Env but it seems that the right fix for this is to unify strict and lazy types which is beyond the scope of this PR.