### PR TITLE
Add timestamps to GC logs

### DIFF
--- a/ocaml/runtime/caml/osdeps.h
+++ b/ocaml/runtime/caml/osdeps.h
@@ -108,6 +108,9 @@ extern char_os *caml_secure_getenv(char_os const *var);
    cannot be determined, return -1. */
 extern int caml_num_rows_fd(int fd);
 
+/* Print a timestamp for verbose GC logs */
+extern void caml_print_timestamp(FILE* channel, int formatted);
+
 #ifdef _WIN32
 
 extern int caml_win32_rename(const wchar_t *, const wchar_t *);

--- a/ocaml/runtime/misc.c
+++ b/ocaml/runtime/misc.c
@@ -70,6 +70,9 @@ void caml_gc_message (int level, char *msg, ...)
   if ((caml_verb_gc & level) != 0){
     va_list ap;
     va_start(ap, msg);
+    if (caml_verb_gc & 0x1000) {
+      caml_print_timestamp(stderr, caml_verb_gc & 0x2000);
+    }
     vfprintf (stderr, msg, ap);
     va_end(ap);
     fflush (stderr);

--- a/ocaml/runtime/win32.c
+++ b/ocaml/runtime/win32.c
@@ -1065,6 +1065,11 @@ int caml_num_rows_fd(int fd)
   return -1;
 }
 
+void caml_print_timestamp(FILE* channel, int formatted)
+{
+  /* unimplemented */
+}
+
 /* UCRT clock function returns wall-clock time */
 CAMLexport clock_t caml_win32_clock(void)
 {


### PR DESCRIPTION
This patch uses two more flags in the `caml_verb_gc` bitmask to indicate that the logs should be timestamped: adding `0x1000` to the flag set turns on timestamps, and `0x3000` turns them on and formats them as ISO8601 timestamps:

```
$ TZ='America/St_Johns' OCAMLRUNPARAM=v=0x30f1 _install/bin/ocaml
[2023-03-17 10:01:37.965279-03:30] Initial minor heap size: 1024k words
[2023-03-17 10:01:37.965362-03:30] Initial major heap size: 992k bytes
[2023-03-17 10:01:37.965376-03:30] Initial space overhead: 100%
[2023-03-17 10:01:37.965390-03:30] Initial max overhead: 500%
[2023-03-17 10:01:37.965401-03:30] Initial heap increment: 15%
[2023-03-17 10:01:37.965408-03:30] Initial allocation policy: 2
[2023-03-17 10:01:37.965420-03:30] Initial smoothing window: 1
[2023-03-17 10:01:37.975990-03:30] ordered work = -1 words
[2023-03-17 10:01:37.976012-03:30] allocated_words = 124997
[2023-03-17 10:01:37.976019-03:30] extra_heap_resources = 0u
[2023-03-17 10:01:37.976033-03:30] raw work-to-do = 300000u
[2023-03-17 10:01:37.976045-03:30] work backlog = 2653243u
[2023-03-17 10:01:37.976055-03:30] filtered work-to-do = 300000u
[2023-03-17 10:01:37.976065-03:30] Starting new major GC cycle
[2023-03-17 10:01:37.976076-03:30] work-done = 0u
OCaml version 4.14.1+jst
Enter #help;; for help.

[2023-03-17 10:01:37.982625-03:30] ordered work = -1 words
[2023-03-17 10:01:37.982645-03:30] allocated_words = 125631
[2023-03-17 10:01:37.982657-03:30] extra_heap_resources = 1000000u
[2023-03-17 10:01:37.982665-03:30] raw work-to-do = 300000u
[2023-03-17 10:01:37.982672-03:30] work backlog = 3563965u
[2023-03-17 10:01:37.982687-03:30] filtered work-to-do = 600000u
[2023-03-17 10:01:37.982698-03:30] computed work = 233472 words
[2023-03-17 10:01:37.982705-03:30] Marking 233472 words
[2023-03-17 10:01:37.982721-03:30] Subphase = 10
[2023-03-17 10:01:37.983162-03:30] work-done = 600000u
```

```
$ OCAMLRUNPARAM=v=0x10f1 _install/bin/ocaml
1679056355.720638 Initial minor heap size: 1024k words
1679056355.720680 Initial major heap size: 992k bytes
1679056355.720706 Initial space overhead: 100%
1679056355.720714 Initial max overhead: 500%
1679056355.720732 Initial heap increment: 15%
1679056355.720741 Initial allocation policy: 2
1679056355.720748 Initial smoothing window: 1
1679056355.731116 ordered work = -1 words
1679056355.731137 allocated_words = 124997
1679056355.731143 extra_heap_resources = 0u
1679056355.731154 raw work-to-do = 300000u
1679056355.731165 work backlog = 2653243u
1679056355.731176 filtered work-to-do = 300000u
1679056355.731187 Starting new major GC cycle
1679056355.731196 work-done = 0u
OCaml version 4.14.1+jst
Enter #help;; for help.

1679056355.737826 ordered work = -1 words
1679056355.737843 allocated_words = 125631
1679056355.737850 extra_heap_resources = 1000000u
1679056355.737863 raw work-to-do = 300000u
1679056355.737873 work backlog = 3563965u
1679056355.737892 filtered work-to-do = 600000u
1679056355.737902 computed work = 233472 words
1679056355.737911 Marking 233472 words
1679056355.737917 Subphase = 10
1679056355.738369 work-done = 600000u
# 
```