### PR TITLE
Remove `-absname` to improve dune build errors

### DIFF
--- a/dune
+++ b/dune
@@ -287,7 +287,6 @@
  (flags
   (-strict-sequence
    -principal
-   -absname
    -w
    +a-4-9-40-41-42-44-45-48-66
    -warn-error

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -48,7 +48,7 @@
  (name ocamlcommon)
  (wrapped false)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
+   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
    -warn-error A -bin-annot -safe-string -strict-formats
    -w -67
    ; remove -w -67 by adding the camlinternalMenhirLib hack like the Makefile
@@ -105,7 +105,7 @@
  (name ocamlbytecomp)
  (wrapped false)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
+   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
@@ -123,7 +123,7 @@
  (name main)
  (modes byte)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
+   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
  (libraries ocamlbytecomp ocamlcommon)
@@ -133,7 +133,7 @@
  (name main_native)
  (modes native)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
+   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
    -warn-error A -bin-annot -safe-string -strict-formats
  ))
  (libraries ocamlbytecomp ocamlcommon)


### PR DESCRIPTION
A companion to https://github.com/ocaml-flambda/ocaml-jst/pull/151. (I'm less familiar with flambda-backend so I didn't know how to test this.)