### PR TITLE
Reduce overhead of CU.Name.t manipulation in Persistent_env

### DIFF
--- a/ocaml/tools/objinfo.ml
+++ b/ocaml/tools/objinfo.ml
@@ -45,6 +45,14 @@ let input_stringlist ic len =
   let sect = really_input_string ic len in
   get_string_list sect len
 
+let sort_intf_imports imports =
+  let imports = Array.copy imports in
+  Array.sort (fun import_info1 import_info2 ->
+      Compilation_unit.Name.compare (Import_info.name import_info2)
+        (Import_info.name import_info1))
+    imports;
+  imports
+
 let dummy_crc = String.make 32 '-'
 let null_crc = String.make 32 '0'
 
@@ -82,7 +90,7 @@ let print_required_global id =
 let print_cmo_infos cu =
   printf "Unit name: %a\n" Compilation_unit.output cu.cu_name;
   print_string "Interfaces imported:\n";
-  Array.iter print_intf_import cu.cu_imports;
+  Array.iter print_intf_import (sort_intf_imports cu.cu_imports);
   print_string "Required globals:\n";
   List.iter print_required_global cu.cu_required_globals;
   printf "Uses unsafe features: ";
@@ -113,7 +121,7 @@ let print_cma_infos (lib : Cmo_format.library) =
 let print_cmi_infos name crcs =
   printf "Unit name: %a\n" Compilation_unit.output name;
   printf "Interfaces imported:\n";
-  Array.iter print_intf_import crcs
+  Array.iter print_intf_import (sort_intf_imports crcs)
 
 let print_cmt_infos cmt =
   let open Cmt_format in
@@ -148,7 +156,7 @@ let print_general_infos name crc defines cmi cmx =
   printf "Globals defined:\n";
   List.iter print_line (List.map linkage_name defines);
   printf "Interfaces imported:\n";
-  Array.iter print_intf_import cmi;
+  Array.iter print_intf_import (sort_intf_imports cmi);
   printf "Implementations imported:\n";
   Array.iter print_impl_import cmx
 

--- a/ocaml/typing/persistent_env.ml
+++ b/ocaml/typing/persistent_env.ml
@@ -70,7 +70,10 @@ type 'a pers_struct_info =
 type 'a t = {
   persistent_structures :
     (CU.Name.t, 'a pers_struct_info) Hashtbl.t;
-  imported_units: CU.Name.Set.t ref;
+  imported_units: CU.Name.t list ref;
+  (*
+  imported_units_old: CU.Name.Set.t ref;
+  *)
   imported_opaque_units: CU.Name.Set.t ref;
   crc_units: Consistbl.t;
   can_load_cmis: can_load_cmis ref;
@@ -78,7 +81,10 @@ type 'a t = {
 
 let empty () = {
   persistent_structures = Hashtbl.create 17;
-  imported_units = ref CU.Name.Set.empty;
+  imported_units = ref [];
+  (*
+  imported_units_old = ref CU.Name.Set.empty;
+  *)
   imported_opaque_units = ref CU.Name.Set.empty;
   crc_units = Consistbl.create ();
   can_load_cmis = ref Can_load_cmis;
@@ -88,12 +94,18 @@ let clear penv =
   let {
     persistent_structures;
     imported_units;
+    (*
+    imported_units_old;
+    *)
     imported_opaque_units;
     crc_units;
     can_load_cmis;
   } = penv in
   Hashtbl.clear persistent_structures;
-  imported_units := CU.Name.Set.empty;
+  imported_units := [];
+  (*
+  imported_units_old := CU.Name.Set.empty;
+  *)
   imported_opaque_units := CU.Name.Set.empty;
   Consistbl.clear crc_units;
   can_load_cmis := Can_load_cmis;
@@ -107,8 +119,36 @@ let clear_missing {persistent_structures; _} =
   in
   List.iter (Hashtbl.remove persistent_structures) missing_entries
 
-let add_import {imported_units; _} s =
-  imported_units := CU.Name.Set.add s !imported_units
+let add_import {imported_units; (* imported_units_old = _; *) _} s =
+  (*
+  let already_imported =
+    List.exists (fun name' -> CU.Name.equal s name') !imported_units
+  in
+  if already_imported then
+    Format.eprintf "dup trying to add %a: %s\n%!"
+      CU.Name.print s
+      (Printexc.raw_backtrace_to_string (Printexc.get_callstack 5));
+  imported_units_old := CU.Name.Set.add s !imported_units_old
+  *)
+  imported_units := s :: !imported_units
+
+(*
+let add_old_import { imported_units_old; _} s =
+  imported_units_old := CU.Name.Set.add s !imported_units_old
+*)
+
+(*
+let check_imports { imported_units; imported_units_old; _ } =
+  let imported_units = !imported_units in
+  let imported_units_old = !imported_units_old in
+  let imported_units_set = CU.Name.Set.of_list imported_units in
+  if (not (CU.Name.Set.equal imported_units_set imported_units_old))
+    || List.length imported_units <> CU.Name.Set.cardinal imported_units_old
+  then
+    Misc.fatal_errorf "mismatch: new list:@ %a@ old set:@ %a\n%!"
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space CU.Name.print) imported_units
+      CU.Name.Set.print imported_units_old
+*)
 
 let register_import_as_opaque {imported_opaque_units; _} s =
   imported_opaque_units := CU.Name.Set.add s !imported_opaque_units
@@ -126,9 +166,14 @@ let import_crcs penv ~source crcs =
     let crco = Import_info.crc_with_unit import_info in
     match crco with
     | None -> ()
-    | Some (unit, crc) ->
-        add_import penv name;
-        Consistbl.check crc_units name unit crc source
+    | Some (unit, crc) -> (
+      (*
+      Format.eprintf "adding import %a\n%!" CU.Name.print name;
+      *)
+      if not (Consistbl.check_did_exist
+        crc_units name (Some (unit, crc, source)))
+      then add_import penv name
+    )
   in Array.iter import_crc crcs
 
 let check_consistency penv ps =
@@ -222,16 +267,19 @@ let acknowledge_pers_struct penv check modname pers_sig pm =
   ps
 
 let read_pers_struct penv val_of_pers_sig check modname filename =
-  add_import penv modname;
+  (* add_old_import penv modname; *)
   let cmi = read_cmi filename in
   let pers_sig = { Persistent_signature.filename; cmi } in
   let pm = val_of_pers_sig pers_sig in
   let ps = acknowledge_pers_struct penv check modname pers_sig pm in
+  (* check_imports penv; *)
   (ps, pm)
 
 let find_pers_struct penv val_of_pers_sig check name =
+(*  Format.eprintf "FIND_PERS_STRUCT %a\n%!" CU.Name.print name; *)
   let {persistent_structures; _} = penv in
   if CU.Name.equal name CU.Name.predef_exn then raise Not_found;
+  (* check_imports penv; *)
   match Hashtbl.find persistent_structures name with
   | Found (ps, pm) -> (ps, pm)
   | Missing -> raise Not_found
@@ -246,7 +294,7 @@ let find_pers_struct penv val_of_pers_sig check name =
             Hashtbl.add persistent_structures name Missing;
             raise Not_found
         in
-        add_import penv name;
+        (* add_old_import penv name; *)
         let pm = val_of_pers_sig psig in
         let ps = acknowledge_pers_struct penv check name psig pm in
         (ps, pm)
@@ -259,6 +307,7 @@ let describe_prefix ppf prefix =
 
 (* Emits a warning if there is no valid cmi for name *)
 let check_pers_struct penv f ~loc name =
+  (* check_imports penv; *)
   let name_as_string = CU.Name.to_string name in
   try
     ignore (find_pers_struct penv f false name)
@@ -305,12 +354,15 @@ let find penv f name =
   snd (find_pers_struct penv f true name)
 
 let check penv f ~loc name =
-  let {persistent_structures; _} = penv in
+  let { persistent_structures; crc_units } = penv in
   if not (Hashtbl.mem persistent_structures name) then begin
     (* PR#6843: record the weak dependency ([add_import]) regardless of
        whether the check succeeds, to help make builds more
        deterministic. *)
-    add_import penv name;
+    if not (Consistbl.check_did_exist crc_units name None)
+    then
+      add_import penv name;
+    (* add_old_import penv name; *)
     if (Warnings.is_active (Warnings.No_cmi_file("", None))) then
       !add_delayed_check_forward
         (fun () -> check_pers_struct penv f ~loc name)
@@ -343,19 +395,13 @@ let crc_of_unit penv f name =
     | Some crc -> crc
 
 let imports {imported_units; crc_units; _} =
-  let imports =
-    Consistbl.extract (CU.Name.Set.elements !imported_units)
-      crc_units
-  in
+  let imports = Consistbl.extract ~no_dups:() !imported_units crc_units in
   List.map (fun (cu_name, crc_with_unit) ->
       Import_info.create cu_name ~crc_with_unit)
     imports
 
 let looked_up {persistent_structures; _} modname =
   Hashtbl.mem persistent_structures modname
-
-let is_imported {imported_units; _} s =
-  CU.Name.Set.mem s !imported_units
 
 let is_imported_opaque {imported_opaque_units; _} s =
   CU.Name.Set.mem s !imported_opaque_units

--- a/ocaml/typing/persistent_env.mli
+++ b/ocaml/typing/persistent_env.mli
@@ -74,10 +74,6 @@ val check : 'a t -> (Persistent_signature.t -> 'a)
    [penv] (it may have failed) *)
 val looked_up : 'a t -> Compilation_unit.Name.t -> bool
 
-(* [is_imported penv md] checks if [md] has been successfully
-   imported in the environment [penv] *)
-val is_imported : 'a t -> Compilation_unit.Name.t -> bool
-
 (* [is_imported_opaque penv md] checks if [md] has been imported
    in [penv] as an opaque module *)
 val is_imported_opaque : 'a t -> Compilation_unit.Name.t -> bool

--- a/ocaml/utils/consistbl.ml
+++ b/ocaml/utils/consistbl.ml
@@ -26,7 +26,7 @@ module Make (Module_name : sig
 end) (Data : sig
   type t
 end) = struct
-  type t = (Data.t * Digest.t * filepath) Module_name.Tbl.t
+  type t = (Data.t * Digest.t * filepath) option Module_name.Tbl.t
 
   let create () = Module_name.Tbl.create 13
 
@@ -42,38 +42,72 @@ end) = struct
 
   exception Not_available of Module_name.t
 
-  let check_ tbl name data crc source =
-    let (old_data, old_crc, old_source) = Module_name.Tbl.find tbl name in
-    if not (Digest.equal crc old_crc)
-    then raise(Inconsistency {
-        unit_name = name;
-        inconsistent_source = source;
-        original_source = old_source;
-        inconsistent_data = data;
-        original_data = old_data;
-      })
+  external raise_notrace : exn -> _ = "%raise_notrace"
+  exception Weak_dep
+
+  let check_ tbl name data_crc_source =
+    match Module_name.Tbl.find tbl name with
+    | None ->
+      (* Note this isn't the case where the module isn't in the table.
+         It's the case where the module is in the table, but the CRC etc
+         is [None], i.e. it's currently a weak dependency. *)
+      raise_notrace Weak_dep
+    | Some (old_data, old_crc, old_source) ->
+      match data_crc_source with
+      | None ->
+        (* Module in the table but an attempt has been made to re-add it as
+           a weak dependency, which is fine. *)
+        ()
+      | Some (data, crc, source) ->
+        if not (Digest.equal crc old_crc)
+        then raise(Inconsistency {
+            unit_name = name;
+            inconsistent_source = source;
+            original_source = old_source;
+            inconsistent_data = data;
+            original_data = old_data;
+          })
 
   let check tbl name data crc source =
-    try check_ tbl name data crc source
-    with Not_found ->
-      Module_name.Tbl.add tbl name (data, crc, source)
+    let data_crc_source = Some (data, crc, source) in
+    try check_ tbl name data_crc_source
+    with Not_found | Weak_dep ->
+      Module_name.Tbl.replace tbl name data_crc_source
+
+  let check_did_exist tbl name data_crc_source =
+    try check_ tbl name data_crc_source; true
+    with
+    | Not_found ->
+      Module_name.Tbl.replace tbl name data_crc_source;
+      false
+    | Weak_dep ->
+      Module_name.Tbl.replace tbl name data_crc_source;
+      true
 
   let check_noadd tbl name data crc source =
-    try check_ tbl name data crc source
-    with Not_found ->
+    try check_ tbl name (Some (data, crc, source))
+    with Not_found | Weak_dep ->
       raise (Not_available name)
 
-  let set tbl name data crc source = Module_name.Tbl.add tbl name (data, crc, source)
+  let set tbl name data crc source =
+    Module_name.Tbl.replace tbl name (Some (data, crc, source))
 
-  let source tbl name = thd3 (Module_name.Tbl.find tbl name)
+  let source tbl name =
+    match Module_name.Tbl.find tbl name with
+    | None -> raise Not_found
+    | Some (_, _, source) -> source
 
   let find t name =
     match Module_name.Tbl.find t name with
-    | exception Not_found -> None
-    | (data, crc, _) -> Some (data, crc)
+    | exception Not_found | None -> None
+    | Some (data, crc, _) -> Some (data, crc)
 
-  let extract l tbl =
-    let l = List.sort_uniq Module_name.compare l in
+  let extract ?no_dups l tbl =
+    let l =
+      match no_dups with
+      | Some () -> l
+      | None -> List.sort_uniq Module_name.compare l
+    in
     List.fold_left (fun assc name -> (name, find tbl name) :: assc) [] l
 
   let extract_map mod_names tbl =

--- a/ocaml/utils/consistbl.mli
+++ b/ocaml/utils/consistbl.mli
@@ -45,6 +45,14 @@ end) : sig
              [source] is the name of the file from which the information
              comes from.  This is used for error reporting. *)
 
+  val check_did_exist: t -> Module_name.t
+     -> (Data.t * Digest.t * filepath) option
+     -> bool
+        (* Same as [check], but:
+           1. allows the addition of weak dependencies;
+           2. returns whether the module name was already known by the table
+              (whether as a weak or strong dependency) or not. *)
+
   val check_noadd: t -> Module_name.t -> Data.t -> Digest.t -> filepath -> unit
         (* Same as [check], but raise [Not_available] if no CRC was previously
              associated with [name]. *)
@@ -61,11 +69,13 @@ end) : sig
 
   val find: t -> Module_name.t -> (Data.t * Digest.t) option
 
-  val extract:
+  val extract: ?no_dups:unit ->
     Module_name.t list -> t -> (Module_name.t * (Data.t * Digest.t) option) list
         (* [extract tbl names] returns an associative list mapping each string
            in [names] to the data and CRC associated with it in [tbl]. If no CRC
-           is associated with a name then it is mapped to [None]. *)
+           is associated with a name then it is mapped to [None].
+           If [no_dups] is provided then the list of module names won't be
+           deduped by this function. *)
 
   val extract_map :
     Module_name.Set.t -> t -> (Data.t * Digest.t) option Module_name.Map.t

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -54,6 +54,14 @@ let input_stringlist ic len =
   let sect = really_input_string ic len in
   get_string_list sect len
 
+let sort_intf_imports imports =
+  let imports = Array.copy imports in
+  Array.sort (fun import_info1 import_info2 ->
+      Compilation_unit.Name.compare (Import_info.name import_info2)
+        (Import_info.name import_info1))
+    imports;
+  imports
+
 let dummy_crc = String.make 32 '-'
 
 let null_crc = String.make 32 '0'
@@ -88,7 +96,7 @@ let print_required_global id = printf "\t%a\n" Compilation_unit.output id
 let print_cmo_infos cu =
   printf "Unit name: %a\n" Compilation_unit.output cu.cu_name;
   print_string "Interfaces imported:\n";
-  Array.iter print_intf_import cu.cu_imports;
+  Array.iter print_intf_import (sort_intf_imports cu.cu_imports);
   print_string "Required globals:\n";
   List.iter print_required_global cu.cu_required_globals;
   printf "Uses unsafe features: ";
@@ -118,7 +126,7 @@ let print_cma_infos (lib : Cmo_format.library) =
 let print_cmi_infos name crcs =
   printf "Unit name: %a\n" Compilation_unit.output name;
   printf "Interfaces imported:\n";
-  Array.iter print_intf_import crcs
+  Array.iter print_intf_import (sort_intf_imports crcs)
 
 let print_cmt_infos cmt =
   let open Cmt_format in
@@ -190,7 +198,7 @@ let print_generic_fns gfns =
 
 let print_cmx_infos (uir, sections, crc) =
   print_general_infos Compilation_unit.output uir.uir_unit crc uir.uir_defines
-    (fun f -> Array.iter f uir.uir_imports_cmi)
+    (fun f -> Array.iter f (sort_intf_imports uir.uir_imports_cmi))
     (fun f -> Array.iter f uir.uir_imports_cmx);
   begin
     match uir.uir_export_info with
@@ -252,7 +260,7 @@ let print_cmxs_infos header =
     (fun ui ->
       print_general_infos Compilation_unit.output ui.dynu_name ui.dynu_crc
         ui.dynu_defines
-        (fun f -> Array.iter f ui.dynu_imports_cmi)
+        (fun f -> Array.iter f (sort_intf_imports ui.dynu_imports_cmi))
         (fun f -> Array.iter f ui.dynu_imports_cmx))
     header.dynu_units
 


### PR DESCRIPTION
I noticed today in a perf profile that a lot of time is being spent manipulating `CU.Name.t` values in `Persistent_env`.  I think the problem is especially bad on the JS tree as there are a very large number of `.cmi` files being read in any particular compilation.

Specifically:
1. The `imported_units` member of the `penv` values is a set, necessitating string comparisons for its operations.
2. The contents of this set are converted to a list prior to `Consistbl.extract`.
3. This list is then deduped (and sorted) inside `Consistbl.extract`.

I wanted to see if it was possible to just use a list for `imported_units` and ensure that it never contained a duplicate.  For the moment, I haven't worried about the sorting; it isn't clear to me why that's required.  Arranging that duplicates do not arise turns out to be tricky.  First of all I observed something I think is correct which is that we currently end up adding duplicates because the CRCs list for a unit ends up containing the CRC for that unit itself.  That seems easy enough to fix.  The harder part relates to the "weak dependency" cases in the `check` function.  I experimented with having a separate set of these but in the end decided it was better to fix `Consistbl`, which semantically I've done, but the code could probably be cleaned up.  After this change, the `Consistbl` keeps track not only of units with normal dependencies, but also those with weak dependencies.  This allows a reasonably fast test to ensure that `imported_units` stays deduplicated when `check` is called.

I tried this on a large file which spends a lot of time in the type checker.  I didn't have access to all of the counters on the particular machine I used but the number of perf events recorded dropped by 15% after this patch, and I think the compiler run was 10% faster.

I've left debugging code in comments in the diff which includes a check to try to ensure this patch is preserving the existing semantics.