### PR TITLE
Revert "Set better default rec_info in cmx files in classic mode"

### DIFF
--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1193,7 +1193,7 @@ end = struct
         (* CR keryan: we should use the associated symbol at some point *)
         let fun_decl =
           TG.Function_type.create code_id
-            ~rec_info:(TG.this_rec_info Rec_info_expr.initial)
+            ~rec_info:(MTC.unknown Flambda_kind.rec_info)
         in
         let all_function_slots_in_set =
           Function_slot.Map.singleton function_slot


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#1216

I suspect this might be causing problems, reverting for now.