### PR TITLE
Remove incorrect invariant for [Apply]

### DIFF
--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -137,7 +137,7 @@ let [@ocamlformat "disable"] print ppf
 
 let invariant
     ({ callee;
-       continuation;
+       continuation = _;
        exn_continuation = _;
        args;
        args_arity;
@@ -171,16 +171,7 @@ let invariant
      <> 0
   then
     Misc.fatal_errorf
-      "Length of argument and arity lists disagree in [Apply]:@ %a" print t;
-  match continuation with
-  | Never_returns ->
-    if not (Flambda_arity.With_subkinds.is_nullary return_arity)
-    then
-      Misc.fatal_errorf
-        "This [Apply] never returns and so should have a nullary return arity, \
-         but instead has a return arity of %a:@ %a"
-        Flambda_arity.With_subkinds.print return_arity print t
-  | Return _ -> ()
+      "Length of argument and arity lists disagree in [Apply]:@ %a" print t
 
 let create ~callee ~continuation exn_continuation ~args ~args_arity
     ~return_arity ~(call_kind : Call_kind.t) dbg ~inlined ~inlining_state

--- a/middle_end/flambda2/tests/mlexamples/function_never_returns.ml
+++ b/middle_end/flambda2/tests/mlexamples/function_never_returns.ml
@@ -1,0 +1,12 @@
+(* compiled with -flambda2-result-types-all-functions this used to trigger a
+   compilation error related to [Never_returns] functions and return arity. *)
+
+let[@inline never] f () : unit = raise Exit
+
+let foo x =
+  let () = f () in
+  x + 1
+
+let bar x =
+  (foo[@inlined]) x
+

--- a/middle_end/flambda2/tests/mlexamples/function_never_returns.ml
+++ b/middle_end/flambda2/tests/mlexamples/function_never_returns.ml
@@ -7,6 +7,4 @@ let foo x =
   let () = f () in
   x + 1
 
-let bar x =
-  (foo[@inlined]) x
-
+let bar x = (foo [@inlined]) x


### PR DESCRIPTION
The check of the arity in the `[Never_returns]` case was not correct.

We can now infer that some applications never return (see the added example, although it requires to use return types and thus the `-flambda2-return-type-all-functions` option), thus the arity check is simply incorrect (it was written at a time where only a few extcalls were marked as `Never_returns` and all those had a nullary arity).