### PR TITLE
Remove Flambda_arity.With_subkinds

### DIFF
--- a/middle_end/flambda2/bound_identifiers/bound_parameters.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameters.ml
@@ -58,12 +58,7 @@ let var_set t = Variable.Set.of_list (vars t)
 
 let rename t = List.map (fun t -> BP.rename t) t
 
-let arity t =
-  List.map (fun t -> Flambda_kind.With_subkind.kind (BP.kind t)) t
-  |> Flambda_arity.create
-
-let arity_with_subkinds t =
-  List.map (fun t -> BP.kind t) t |> Flambda_arity.With_subkinds.create
+let arity t = List.map (fun t -> BP.kind t) t |> Flambda_arity.create
 
 let free_names t =
   List.fold_left

--- a/middle_end/flambda2/bound_identifiers/bound_parameters.mli
+++ b/middle_end/flambda2/bound_identifiers/bound_parameters.mli
@@ -32,8 +32,6 @@ val same_number : t -> t -> bool
 
 val arity : t -> Flambda_arity.t
 
-val arity_with_subkinds : t -> Flambda_arity.With_subkinds.t
-
 val check_no_duplicates : t -> unit
 
 val cardinal : t -> int

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -967,9 +967,9 @@ let apply_exprs env apply1 apply2 : Expr.t Comparison.t =
          (Apply.inlining_state apply1)
          (Apply.inlining_state apply2)
     && Apply.Position.equal (Apply.position apply1) (Apply.position apply2)
-    && Flambda_arity.With_subkinds.equal (Apply.args_arity apply1)
+    && Flambda_arity.equal_exact (Apply.args_arity apply1)
          (Apply.args_arity apply2)
-    && Flambda_arity.With_subkinds.equal
+    && Flambda_arity.equal_exact
          (Apply.return_arity apply1)
          (Apply.return_arity apply2)
   in
@@ -1191,9 +1191,9 @@ and codes env (code1 : Code.t) (code2 : Code.t) =
   |> Comparison.add_condition
        ~approximant:(fun () -> subst_code env code1)
        ~cond:
-         (Flambda_arity.With_subkinds.equal (Code.params_arity code1)
+         (Flambda_arity.equal_exact (Code.params_arity code1)
             (Code.params_arity code2)
-         && Flambda_arity.With_subkinds.equal (Code.result_arity code1)
+         && Flambda_arity.equal_exact (Code.result_arity code1)
               (Code.result_arity code2)
          && Bool.equal (Code.stub code1) (Code.stub code2)
          && Inline_attribute.equal (Code.inline code1) (Code.inline code2)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -238,8 +238,7 @@ module Inlining = struct
     | Some (Closure_approximation { code; _ }) ->
       let metadata = Code_or_metadata.code_metadata code in
       let fun_params_length =
-        Code_metadata.params_arity metadata
-        |> Flambda_arity.With_subkinds.to_arity |> Flambda_arity.length
+        Code_metadata.params_arity metadata |> Flambda_arity.cardinal
       in
       if (not (Code_or_metadata.code_present code))
          || fun_params_length > List.length (Apply_expr.args apply)
@@ -440,11 +439,12 @@ let close_c_call acc env ~loc ~let_bound_var
   in
   let param_arity =
     List.map kind_of_primitive_native_repr prim_native_repr_args
-    |> Flambda_arity.create |> Flambda_arity.With_subkinds.of_arity
+    |> List.map K.With_subkind.anything
+    |> Flambda_arity.create
   in
   let return_kind = kind_of_primitive_native_repr prim_native_repr_res in
   let return_arity =
-    Flambda_arity.create [return_kind] |> Flambda_arity.With_subkinds.of_arity
+    Flambda_arity.create [K.With_subkind.anything return_kind]
   in
   let call_kind =
     Call_kind.c_call ~alloc:prim_alloc ~is_c_builtin:prim_c_builtin
@@ -1132,7 +1132,7 @@ let close_exact_or_unknown_apply acc env
   let apply =
     Apply.create ~callee ~continuation:(Return continuation)
       apply_exn_continuation ~args
-      ~args_arity:(Flambda_arity.With_subkinds.create args_arity)
+      ~args_arity:(Flambda_arity.create args_arity)
       ~return_arity ~call_kind
       (Debuginfo.from_location loc)
       ~inlined:inlined_call
@@ -1536,7 +1536,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
          (Exn_continuation.exn_handler exn_continuation)
   in
   let closure_info, acc = Acc.pop_closure_info acc in
-  let params_arity = Bound_parameters.arity_with_subkinds params in
+  let params_arity = Bound_parameters.arity params in
   let is_tupled =
     match Function_decl.kind decl with Curried _ -> false | Tupled -> true
   in
@@ -1665,8 +1665,7 @@ let close_functions acc external_env ~current_region function_declarations =
         let code_id = Function_slot.Map.find function_slot function_code_ids in
         let params = Function_decl.params decl in
         let params_arity =
-          List.map (fun (_, kind) -> kind) params
-          |> Flambda_arity.With_subkinds.create
+          List.map (fun (_, kind) -> kind) params |> Flambda_arity.create
         in
         let result_arity = Function_decl.return decl in
         let poll_attribute =
@@ -1993,7 +1992,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
       (fun n kind_with_subkind ->
         ( Ident.create_local ("param" ^ string_of_int (num_provided + n)),
           kind_with_subkind ))
-      (Flambda_arity.With_subkinds.to_list missing_arity)
+      (Flambda_arity.to_list missing_arity)
   in
   let return_continuation = Continuation.create ~sort:Return () in
   let exn_continuation =
@@ -2040,7 +2039,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
   in
   let closure_alloc_mode, num_trailing_local_params =
     let num_leading_heap_params =
-      Flambda_arity.With_subkinds.cardinal arity - num_trailing_local_params
+      Flambda_arity.cardinal arity - num_trailing_local_params
     in
     if num_provided <= num_leading_heap_params
     then Lambda.alloc_heap, num_trailing_local_params
@@ -2136,7 +2135,7 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
         List.mapi
           (fun i kind ->
             BP.create (Variable.create ("result" ^ string_of_int i)) kind)
-          (Flambda_arity.With_subkinds.to_list apply.return_arity)
+          (Flambda_arity.to_list apply.return_arity)
       in
       let handler acc =
         let acc, call_return_continuation =
@@ -2179,12 +2178,12 @@ type call_args_split =
   | Exact of IR.simple list
   | Partial_app of
       { provided : IR.simple list;
-        missing_arity : Flambda_arity.With_subkinds.t
+        missing_arity : Flambda_arity.t
       }
   | Over_app of
       { full : IR.simple list;
         remaining : IR.simple list;
-        remaining_arity : Flambda_arity.With_subkinds.t
+        remaining_arity : Flambda_arity.t
       }
 
 let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
@@ -2219,7 +2218,7 @@ let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
     let acc, args_with_arities = find_simples_and_arity acc env apply.args in
     let args_arity = List.map snd args_with_arities in
     let split_args =
-      let arity = Flambda_arity.With_subkinds.to_list arity in
+      let arity = Flambda_arity.to_list arity in
       let split args arity =
         let rec cut n l =
           if n <= 0
@@ -2240,7 +2239,7 @@ let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
           let _provided_arity, missing_arity = cut args_l arity in
           Partial_app
             { provided = args;
-              missing_arity = Flambda_arity.With_subkinds.create missing_arity
+              missing_arity = Flambda_arity.create missing_arity
             }
         else
           let full, remaining = cut arity_l args in
@@ -2248,8 +2247,7 @@ let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
           Over_app
             { full;
               remaining;
-              remaining_arity =
-                Flambda_arity.With_subkinds.create remaining_arity
+              remaining_arity = Flambda_arity.create remaining_arity
             }
       in
       let arity =
@@ -2283,8 +2281,7 @@ let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
             continuation = apply_continuation;
             mode;
             return_arity =
-              Flambda_arity.With_subkinds.create
-                [Flambda_kind.With_subkind.any_value]
+              Flambda_arity.create [Flambda_kind.With_subkind.any_value]
           }
           (Some approx) ~replace_region:(Some region)
       in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -64,7 +64,7 @@ module IR = struct
       probe : Lambda.probe;
       mode : Lambda.alloc_mode;
       region : Ident.t;
-      return_arity : Flambda_arity.With_subkinds.t
+      return_arity : Flambda_arity.t
     }
 
   type switch =
@@ -663,7 +663,7 @@ module Function_decls = struct
         function_slot : Function_slot.t;
         kind : Lambda.function_kind;
         params : (Ident.t * Flambda_kind.With_subkind.t) list;
-        return : Flambda_arity.With_subkinds.t;
+        return : Flambda_arity.t;
         return_continuation : Continuation.t;
         exn_continuation : IR.exn_continuation;
         my_region : Ident.t;
@@ -929,8 +929,7 @@ module Let_with_acc = struct
             ~find_code_characteristics:(fun code_id ->
               let code = Code_id.Map.find code_id code_mapping in
               { cost_metrics = Code.cost_metrics code;
-                params_arity =
-                  Flambda_arity.With_subkinds.cardinal (Code.params_arity code)
+                params_arity = Flambda_arity.cardinal (Code.params_arity code)
               })
             set_of_closures
         | Rec_info _ -> Cost_metrics.zero

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -68,7 +68,7 @@ module IR : sig
       probe : Lambda.probe;
       mode : Lambda.alloc_mode;
       region : Ident.t;
-      return_arity : Flambda_arity.With_subkinds.t
+      return_arity : Flambda_arity.t
     }
 
   type switch =
@@ -296,7 +296,7 @@ module Function_decls : sig
       function_slot:Function_slot.t ->
       kind:Lambda.function_kind ->
       params:(Ident.t * Flambda_kind.With_subkind.t) list ->
-      return:Flambda_arity.With_subkinds.t ->
+      return:Flambda_arity.t ->
       return_continuation:Continuation.t ->
       exn_continuation:IR.exn_continuation ->
       my_region:Ident.t ->
@@ -318,7 +318,7 @@ module Function_decls : sig
 
     val params : t -> (Ident.t * Flambda_kind.With_subkind.t) list
 
-    val return : t -> Flambda_arity.With_subkinds.t
+    val return : t -> Flambda_arity.t
 
     val return_continuation : t -> Continuation.t
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -860,7 +860,7 @@ let wrap_return_continuation acc env ccenv (apply : IR.apply) =
           { apply with continuation = wrapper_cont; region }
       in
       let return_arity =
-        match Flambda_arity.With_subkinds.to_list apply.return_arity with
+        match Flambda_arity.to_list apply.return_arity with
         | [return_kind] -> return_kind
         | _ :: _ ->
           Misc.fatal_errorf
@@ -1323,7 +1323,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                         mode;
                         region = Env.current_region env;
                         return_arity =
-                          Flambda_arity.With_subkinds.create
+                          Flambda_arity.create
                             [Flambda_kind.With_subkind.from_lambda layout]
                       }
                     in
@@ -1528,7 +1528,7 @@ and cps_tail_apply acc env ccenv ap_func ap_args ap_region_close ap_mode ap_loc
               mode = ap_mode;
               region = Env.current_region env;
               return_arity =
-                Flambda_arity.With_subkinds.create
+                Flambda_arity.create
                   [Flambda_kind.With_subkind.from_lambda ap_return]
             }
           in
@@ -1666,8 +1666,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
       params
   in
   let return =
-    Flambda_arity.With_subkinds.create
-      [Flambda_kind.With_subkind.from_lambda return]
+    Flambda_arity.create [Flambda_kind.With_subkind.from_lambda return]
   in
   Function_decl.create ~let_rec_ident:(Some fid) ~function_slot ~kind ~params
     ~return ~return_continuation:body_cont ~exn_continuation ~my_region ~body

--- a/middle_end/flambda2/kinds/flambda_arity.ml
+++ b/middle_end/flambda2/kinds/flambda_arity.ml
@@ -5,8 +5,8 @@
 (*                       Pierre Chambart, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2013--2017 OCamlPro SAS                                    *)
-(*   Copyright 2014--2017 Jane Street Group LLC                           *)
+(*   Copyright 2013--2023 OCamlPro SAS                                    *)
+(*   Copyright 2014--2023 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,101 +14,49 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = Flambda_kind.t list
+module Component = struct
+  type t = Singleton of Flambda_kind.With_subkind.t
 
-type arity = t
+  let equal_ignoring_subkinds t1 t2 =
+    match t1, t2 with
+    | Singleton kind1, Singleton kind2 ->
+      Flambda_kind.With_subkind.equal_ignoring_subkind kind1 kind2
+
+  let equal_exact t1 t2 =
+    match t1, t2 with
+    | Singleton kind1, Singleton kind2 ->
+      Flambda_kind.With_subkind.equal kind1 kind2
+
+  let print ~product_above:_ ppf t =
+    match t with Singleton kind -> Flambda_kind.With_subkind.print ppf kind
+end
+
+type t = Component.t list
 
 let nullary = []
 
-let create t = t
+let create t = List.map (fun kind -> Component.Singleton kind) t
 
-let length t = List.length t
+let to_list t = List.map (fun (Component.Singleton kind) -> kind) t
 
-let to_list t = t
+let print ppf t =
+  Format.fprintf ppf "@[%a@]"
+    (Format.pp_print_list (Component.print ~product_above:true)
+       ~pp_sep:(fun ppf () -> Format.fprintf ppf " @<1>\u{2a2f} "))
+    t
 
-include Container_types.Make (struct
-  type nonrec t = t
+let equal_ignoring_subkinds t1 t2 =
+  List.equal Component.equal_ignoring_subkinds t1 t2
 
-  let compare t1 t2 = List.compare Flambda_kind.compare t1 t2
-
-  let equal t1 t2 = compare t1 t2 = 0
-
-  let hash = Hashtbl.hash
-
-  let print ppf t =
-    match t with
-    | [] -> Format.pp_print_string ppf "Nullary"
-    | _ ->
-      Format.fprintf ppf "@[%a@]"
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.fprintf ppf " @<1>\u{2a2f} ")
-           Flambda_kind.print)
-        t
-end)
-
-let is_all_values t = List.for_all Flambda_kind.is_value t
-
-let is_all_naked_floats t = List.for_all Flambda_kind.is_naked_float t
+let equal_exact t1 t2 = List.equal Component.equal_exact t1 t2
 
 let is_singleton_value t =
   match t with
-  | [kind] when Flambda_kind.equal kind Flambda_kind.value -> true
-  | _ -> false
+  | [Component.Singleton kind]
+    when Flambda_kind.equal
+           (Flambda_kind.With_subkind.kind kind)
+           Flambda_kind.value ->
+    true
+  | [] | Component.Singleton _ :: _ -> false
 
-module With_subkinds = struct
-  type t = Flambda_kind.With_subkind.t list
-
-  let create t = t
-
-  let to_list t = t
-
-  include Container_types.Make (struct
-    type nonrec t = t
-
-    let compare t1 t2 = List.compare Flambda_kind.With_subkind.compare t1 t2
-
-    let equal t1 t2 = compare t1 t2 = 0
-
-    let hash = Hashtbl.hash
-
-    let print ppf t =
-      match t with
-      | [] -> Format.pp_print_string ppf "Nullary"
-      | _ ->
-        Format.fprintf ppf "@[%a@]"
-          (Format.pp_print_list
-             ~pp_sep:(fun ppf () -> Format.fprintf ppf " @<1>\u{2a2f} ")
-             Flambda_kind.With_subkind.print)
-          t
-  end)
-
-  let is_singleton_value t =
-    match t with
-    | [kind]
-      when Flambda_kind.equal
-             (Flambda_kind.With_subkind.kind kind)
-             Flambda_kind.value ->
-      true
-    | _ -> false
-
-  let cardinal t = List.length t
-
-  let nullary = []
-
-  let is_nullary t = match t with [] -> true | _ :: _ -> false
-
-  let to_arity t = List.map Flambda_kind.With_subkind.kind t
-
-  let of_arity arity =
-    List.map (fun kind -> Flambda_kind.With_subkind.create kind Anything) arity
-
-  let compatible t ~when_used_at =
-    if List.compare_lengths t when_used_at <> 0
-    then
-      Misc.fatal_errorf "Mismatched arities:@ %a@ and@ %a" print t print
-        when_used_at;
-    List.for_all2
-      (fun kind when_used_at ->
-        Flambda_kind.With_subkind.compatible kind ~when_used_at)
-      t when_used_at
-end
+let cardinal t = List.length t

--- a/middle_end/flambda2/kinds/flambda_arity.mli
+++ b/middle_end/flambda2/kinds/flambda_arity.mli
@@ -5,8 +5,8 @@
 (*                       Pierre Chambart, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2013--2017 OCamlPro SAS                                    *)
-(*   Copyright 2014--2017 Jane Street Group LLC                           *)
+(*   Copyright 2013--2023 OCamlPro SAS                                    *)
+(*   Copyright 2014--2023 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,50 +14,25 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Arities are lists of kinds, sometimes with subkinds, used to describe things
+(** Arities are lists of kinds (with subkinds) used to describe things
     such as the kinding of function and continuation parameter lists. *)
 
 type t
 
-type arity = t
-
-val create : Flambda_kind.t list -> t
-
-val to_list : t -> Flambda_kind.t list
-
 val nullary : t
 
-val length : t -> int
+val create : Flambda_kind.With_subkind.t list -> t
 
-val is_all_values : t -> bool
+val to_list : t -> Flambda_kind.With_subkind.t list
 
-val is_all_naked_floats : t -> bool
+val cardinal : t -> int
 
 val is_singleton_value : t -> bool
 
-include Container_types.S with type t := t
+val print : Format.formatter -> t -> unit
 
-module With_subkinds : sig
-  type t
+val equal_ignoring_subkinds : t -> t -> bool
 
-  val create : Flambda_kind.With_subkind.t list -> t
-
-  val to_list : t -> Flambda_kind.With_subkind.t list
-
-  val nullary : t
-
-  val is_nullary : t -> bool
-
-  val cardinal : t -> int
-
-  val is_singleton_value : t -> bool
-
-  val to_arity : t -> arity
-
-  (** [of_arity] sets the subkind information to [Anything]. *)
-  val of_arity : arity -> t
-
-  val compatible : t -> when_used_at:t -> bool
-
-  include Container_types.S with type t := t
-end
+(* It's usually a mistake to use this function, but it's needed for
+   [Compare]. *)
+val equal_exact : t -> t -> bool

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -414,6 +414,8 @@ module With_subkind = struct
           subkind print kind));
     { kind; subkind }
 
+  let anything kind = create kind Anything
+
   let compatible (t : t) ~(when_used_at : t) =
     equal t.kind when_used_at.kind
     && Subkind.compatible t.subkind ~when_used_at:when_used_at.subkind
@@ -565,4 +567,6 @@ module With_subkind = struct
       true
 
   let erase_subkind (t : t) : t = { t with subkind = Anything }
+
+  let equal_ignoring_subkind t1 t2 = equal (erase_subkind t1) (erase_subkind t2)
 end

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -150,6 +150,8 @@ module With_subkind : sig
 
   val create : kind -> Subkind.t -> t
 
+  val anything : kind -> t
+
   val kind : t -> kind
 
   val subkind : t -> Subkind.t
@@ -205,4 +207,6 @@ module With_subkind : sig
   val erase_subkind : t -> t
 
   include Container_types.S with type t := t
+
+  val equal_ignoring_subkind : t -> t -> bool
 end

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -283,8 +283,7 @@ let value_kind_with_subkind_opt :
   | Some kind -> value_kind_with_subkind kind
   | None -> Flambda_kind.With_subkind.any_value
 
-let arity a =
-  Flambda_arity.With_subkinds.create (List.map value_kind_with_subkind a)
+let arity a = Flambda_arity.create (List.map value_kind_with_subkind a)
 
 let const (c : Fexpr.const) : Reg_width_const.t =
   match c with
@@ -801,13 +800,11 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
               (fun ({ kind; _ } : Fexpr.kinded_parameter) ->
                 value_kind_with_subkind_opt kind)
               params_and_body.params
-            |> Flambda_arity.With_subkinds.create
+            |> Flambda_arity.create
         in
         let result_arity =
           match ret_arity with
-          | None ->
-            Flambda_arity.With_subkinds.create
-              [Flambda_kind.With_subkind.any_value]
+          | None -> Flambda_arity.create [Flambda_kind.With_subkind.any_value]
           | Some ar -> arity ar
         in
         let ( _params,
@@ -839,7 +836,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           let my_depth, env = fresh_var env depth_var in
           let return_continuation, env =
             fresh_cont env ret_cont ~sort:Return
-              ~arity:(Flambda_arity.With_subkinds.cardinal result_arity)
+              ~arity:(Flambda_arity.cardinal result_arity)
           in
           let exn_continuation, env = fresh_exn_cont env exn_cont in
           assert (
@@ -923,14 +920,12 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         let params_arity =
           (* CR mshinwell: This needs fixing to cope with the fact that the
              arities have moved onto [Apply_expr] *)
-          Flambda_arity.With_subkinds.create
+          Flambda_arity.create
             (List.map (fun _ -> Flambda_kind.With_subkind.any_value) args)
         in
         let return_arity =
           match arities with
-          | None ->
-            Flambda_arity.With_subkinds.create
-              [Flambda_kind.With_subkind.any_value]
+          | None -> Flambda_arity.create [Flambda_kind.With_subkind.any_value]
           | Some { ret_arity; _ } -> arity ret_arity
         in
         let alloc = alloc_mode_for_types alloc in
@@ -948,14 +943,13 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           let params_arity =
             (* CR mshinwell: This needs fixing to cope with the fact that the
                arities have moved onto [Apply_expr] *)
-            Flambda_arity.With_subkinds.create
+            Flambda_arity.create
               (List.map (fun _ -> Flambda_kind.With_subkind.any_value) args)
           in
           let return_arity =
             (* CR mshinwell: This needs fixing to cope with the fact that the
                arities have moved onto [Apply_expr] *)
-            Flambda_arity.With_subkinds.create
-              [Flambda_kind.With_subkind.any_value]
+            Flambda_arity.create [Flambda_kind.With_subkind.any_value]
           in
           ( Call_kind.indirect_function_call_unknown_arity alloc,
             params_arity,

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -452,15 +452,15 @@ let kind_with_subkind_opt (k : Flambda_kind.With_subkind.t) :
     Fexpr.kind_with_subkind option =
   if is_default_kind_with_subkind k then None else Some (k |> kind_with_subkind)
 
-let is_default_arity (a : Flambda_arity.With_subkinds.t) =
-  match Flambda_arity.With_subkinds.to_list a with
+let is_default_arity (a : Flambda_arity.t) =
+  match Flambda_arity.to_list a with
   | [k] -> is_default_kind_with_subkind k
   | _ -> false
 
-let arity (a : Flambda_arity.With_subkinds.t) : Fexpr.arity =
-  Flambda_arity.With_subkinds.to_list a |> List.map kind_with_subkind
+let arity (a : Flambda_arity.t) : Fexpr.arity =
+  Flambda_arity.to_list a |> List.map kind_with_subkind
 
-let arity_opt (a : Flambda_arity.With_subkinds.t) : Fexpr.arity option =
+let arity_opt (a : Flambda_arity.t) : Fexpr.arity option =
   if is_default_arity a then None else Some (arity a)
 
 let kinded_parameter env (kp : Bound_parameter.t) :

--- a/middle_end/flambda2/simplify/apply_cont_rewrite.ml
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.ml
@@ -84,8 +84,7 @@ let create ~original_params ~extra_params_and_args ~decide_param_usage =
     extra_params
   }
 
-let original_params_arity t =
-  Bound_parameters.arity_with_subkinds t.original_params
+let original_params_arity t = Bound_parameters.arity t.original_params
 
 let rec partition_used l usage =
   match l, usage with
@@ -236,7 +235,7 @@ let make_rewrite rewrite ~ctx id args =
 let rewrite_exn_continuation rewrite id exn_cont =
   let exn_cont_arity = Exn_continuation.arity exn_cont in
   if not
-       (Flambda_arity.With_subkinds.equal exn_cont_arity
+       (Flambda_arity.equal_ignoring_subkinds exn_cont_arity
           (original_params_arity rewrite))
   then
     Misc.fatal_errorf
@@ -244,7 +243,7 @@ let rewrite_exn_continuation rewrite id exn_cont =
        (%a)"
       Exn_continuation.print exn_cont Bound_parameters.print
       rewrite.original_params;
-  assert (Flambda_arity.With_subkinds.cardinal exn_cont_arity >= 1);
+  assert (Flambda_arity.cardinal exn_cont_arity >= 1);
   if List.hd rewrite.original_params_usage <> Used
   then
     Misc.fatal_errorf

--- a/middle_end/flambda2/simplify/apply_cont_rewrite.mli
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.mli
@@ -42,7 +42,7 @@ val get_used_params : t -> Bound_parameters.t * Bound_parameters.t
 
 val get_unused_params : t -> Bound_parameters.t
 
-val original_params_arity : t -> Flambda_arity.With_subkinds.t
+val original_params_arity : t -> Flambda_arity.t
 
 type rewrite_apply_cont_ctx =
   | Apply_cont

--- a/middle_end/flambda2/simplify/continuation_in_env.ml
+++ b/middle_end/flambda2/simplify/continuation_in_env.ml
@@ -22,10 +22,10 @@ type t =
         cost_metrics_of_handler : Cost_metrics.t
       }
   | Non_inlinable_zero_arity of { handler : Rebuilt_expr.t Or_unknown.t }
-  | Non_inlinable_non_zero_arity of { arity : Flambda_arity.With_subkinds.t }
+  | Non_inlinable_non_zero_arity of { arity : Flambda_arity.t }
   | Toplevel_or_function_return_or_exn_continuation of
-      { arity : Flambda_arity.With_subkinds.t }
-  | Invalid of { arity : Flambda_arity.With_subkinds.t }
+      { arity : Flambda_arity.t }
+  | Invalid of { arity : Flambda_arity.t }
 
 let [@ocamlformat "disable"] print are_rebuilding_terms ppf t =
   match t with
@@ -50,18 +50,18 @@ let [@ocamlformat "disable"] print are_rebuilding_terms ppf t =
     Format.fprintf ppf "@[<hov 1>(Non_inlinable_non_zero_arity@ \
         @[<hov 1>(arity@ %a)@]\
         )@]"
-      Flambda_arity.With_subkinds.print arity
+      Flambda_arity.print arity
   | Toplevel_or_function_return_or_exn_continuation { arity } ->
     Format.fprintf ppf
       "@[<hov 1>(Toplevel_or_function_return_or_exn_continuation@ \
         @[<hov 1>(arity@ %a)@]\
         )@]"
-      Flambda_arity.With_subkinds.print arity
+      Flambda_arity.print arity
   | Invalid { arity } ->
     Format.fprintf ppf "@[<hov 1>(Invalid@ \
         @[<hov 1>(arity@ %a)@]\
         )@]"
-      Flambda_arity.With_subkinds.print arity
+      Flambda_arity.print arity
 
 let arity t =
   match t with
@@ -71,8 +71,8 @@ let arity t =
         free_names_of_handler = _;
         cost_metrics_of_handler = _
       } ->
-    Bound_parameters.arity_with_subkinds params
-  | Non_inlinable_zero_arity _ -> Flambda_arity.With_subkinds.nullary
+    Bound_parameters.arity params
+  | Non_inlinable_zero_arity _ -> Flambda_arity.nullary
   | Non_inlinable_non_zero_arity { arity }
   | Toplevel_or_function_return_or_exn_continuation { arity }
   | Invalid { arity } ->

--- a/middle_end/flambda2/simplify/continuation_in_env.mli
+++ b/middle_end/flambda2/simplify/continuation_in_env.mli
@@ -30,13 +30,13 @@ type t =
             (** The handler, if available, is stored for
                 [Simplify_switch_expr]. *)
       }
-  | Non_inlinable_non_zero_arity of { arity : Flambda_arity.With_subkinds.t }
+  | Non_inlinable_non_zero_arity of { arity : Flambda_arity.t }
   | Toplevel_or_function_return_or_exn_continuation of
-      { arity : Flambda_arity.With_subkinds.t }
-  | Invalid of { arity : Flambda_arity.With_subkinds.t }
+      { arity : Flambda_arity.t }
+  | Invalid of { arity : Flambda_arity.t }
       (** [Invalid] means that the code of the continuation handler is invalid,
           not that the continuation has zero uses. *)
 
 val print : Are_rebuilding_terms.t -> Format.formatter -> t -> unit
 
-val arity : t -> Flambda_arity.With_subkinds.t
+val arity : t -> Flambda_arity.t

--- a/middle_end/flambda2/simplify/env/continuation_uses.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses.ml
@@ -39,7 +39,7 @@ let [@ocamlformat "disable"] print ppf { continuation; arity; uses; } =
 let add_use t kind ~env_at_use id ~arg_types =
   try
     let arity = T.arity_of_list arg_types in
-    if not (Flambda_arity.equal arity t.arity)
+    if not (Flambda_arity.equal_ignoring_subkinds arity t.arity)
     then
       Misc.fatal_errorf
         "Arity of use (%a) doesn't match continuation's arity (%a)"
@@ -60,7 +60,7 @@ let add_use t kind ~env_at_use id ~arg_types =
 
 let union t1 t2 =
   assert (Continuation.equal t1.continuation t2.continuation);
-  assert (Flambda_arity.equal t1.arity t2.arity);
+  assert (Flambda_arity.equal_ignoring_subkinds t1.arity t2.arity);
   { continuation = t1.continuation; arity = t1.arity; uses = t1.uses @ t2.uses }
 
 let number_of_uses t = List.length t.uses
@@ -107,7 +107,8 @@ let get_arg_types_by_use_id_for_invariant_params arity l =
   List.fold_left
     (fun arg_maps t ->
       if not
-           (Misc.Stdlib.List.is_prefix ~equal:Flambda_kind.equal
+           (Misc.Stdlib.List.is_prefix
+              ~equal:Flambda_kind.With_subkind.equal_ignoring_subkind
               (Flambda_arity.to_list arity)
               ~of_:(Flambda_arity.to_list t.arity))
       then

--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -87,19 +87,16 @@ let add_non_inlinable_continuation t cont ~params ~handler =
   if Bound_parameters.is_empty params
   then add_continuation0 t cont (Non_inlinable_zero_arity { handler })
   else
-    let arity = Bound_parameters.arity_with_subkinds params in
+    let arity = Bound_parameters.arity params in
     add_continuation0 t cont (Non_inlinable_non_zero_arity { arity })
 
 let add_invalid_continuation t cont arity =
   add_continuation0 t cont (Invalid { arity })
 
 let add_continuation_alias t cont arity ~alias_for =
-  let arity = Flambda_arity.With_subkinds.to_arity arity in
   let alias_for = resolve_continuation_aliases t alias_for in
-  let alias_for_arity =
-    continuation_arity t alias_for |> Flambda_arity.With_subkinds.to_arity
-  in
-  if not (Flambda_arity.equal arity alias_for_arity)
+  let alias_for_arity = continuation_arity t alias_for in
+  if not (Flambda_arity.equal_ignoring_subkinds arity alias_for_arity)
   then
     Misc.fatal_errorf
       "%a (arity %a) cannot be an alias for %a (arity %a) since the two \

--- a/middle_end/flambda2/simplify/env/upwards_env.mli
+++ b/middle_end/flambda2/simplify/env/upwards_env.mli
@@ -29,15 +29,10 @@ val add_non_inlinable_continuation :
   handler:Rebuilt_expr.t Or_unknown.t ->
   t
 
-val add_invalid_continuation :
-  t -> Continuation.t -> Flambda_arity.With_subkinds.t -> t
+val add_invalid_continuation : t -> Continuation.t -> Flambda_arity.t -> t
 
 val add_continuation_alias :
-  t ->
-  Continuation.t ->
-  Flambda_arity.With_subkinds.t ->
-  alias_for:Continuation.t ->
-  t
+  t -> Continuation.t -> Flambda_arity.t -> alias_for:Continuation.t -> t
 
 val add_linearly_used_inlinable_continuation :
   t ->
@@ -49,7 +44,7 @@ val add_linearly_used_inlinable_continuation :
   t
 
 val add_function_return_or_exn_continuation :
-  t -> Continuation.t -> Flambda_arity.With_subkinds.t -> t
+  t -> Continuation.t -> Flambda_arity.t -> t
 
 val find_continuation : t -> Continuation.t -> Continuation_in_env.t
 

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -705,12 +705,8 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
   match UE.find_apply_cont_rewrite uenv original_cont with
   | None -> This_continuation cont
   | Some rewrite when Apply_cont_rewrite.does_nothing rewrite ->
-    let arity = Flambda_arity.With_subkinds.to_arity arity in
-    let arity_in_rewrite =
-      Apply_cont_rewrite.original_params_arity rewrite
-      |> Flambda_arity.With_subkinds.to_arity
-    in
-    if not (Flambda_arity.equal arity arity_in_rewrite)
+    let arity_in_rewrite = Apply_cont_rewrite.original_params_arity rewrite in
+    if not (Flambda_arity.equal_ignoring_subkinds arity arity_in_rewrite)
     then
       Misc.fatal_errorf
         "Arity %a provided to fixed-arity-wrapper addition function does not \
@@ -744,11 +740,9 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
       let params =
         List.map
           (fun _kind -> Variable.create "param")
-          (Flambda_arity.With_subkinds.to_list arity)
+          (Flambda_arity.to_list arity)
       in
-      let params =
-        List.map2 BP.create params (Flambda_arity.With_subkinds.to_list arity)
-      in
+      let params = List.map2 BP.create params (Flambda_arity.to_list arity) in
       let args = List.map BP.simple params in
       let params = Bound_parameters.create params in
       let apply_cont = Apply_cont.create cont ~args ~dbg:Debuginfo.none in

--- a/middle_end/flambda2/simplify/expr_builder.mli
+++ b/middle_end/flambda2/simplify/expr_builder.mli
@@ -127,13 +127,13 @@ val rewrite_switch_arm :
   Upwards_acc.t ->
   Apply_cont.t ->
   use_id:Apply_cont_rewrite_id.t ->
-  Flambda_arity.With_subkinds.t ->
+  Flambda_arity.t ->
   rewrite_switch_arm_result
 
 val rewrite_fixed_arity_apply :
   Upwards_acc.t ->
   use_id:Apply_cont_rewrite_id.t ->
-  Flambda_arity.With_subkinds.t ->
+  Flambda_arity.t ->
   Apply.t ->
   Upwards_acc.t * Rebuilt_expr.t
 

--- a/middle_end/flambda2/simplify/flow/flow.mli
+++ b/middle_end/flambda2/simplify/flow/flow.mli
@@ -82,7 +82,7 @@ module Acc : sig
   val add_apply_conts :
     result_cont:(Apply_cont_rewrite_id.t * Continuation.t) option ->
     exn_cont:Apply_cont_rewrite_id.t * Exn_continuation.t ->
-    result_arity:Flambda_arity.With_subkinds.t ->
+    result_arity:Flambda_arity.t ->
     t ->
     t
 

--- a/middle_end/flambda2/simplify/flow/flow_acc.ml
+++ b/middle_end/flambda2/simplify/flow/flow_acc.ml
@@ -277,7 +277,7 @@ let add_apply_conts ~result_cont ~exn_cont ~result_arity t =
         | None -> apply_cont_args
         | Some (rewrite_id, result_cont) ->
           add_func_result result_cont rewrite_id
-            ~result_arity:(Flambda_arity.With_subkinds.cardinal result_arity)
+            ~result_arity:(Flambda_arity.cardinal result_arity)
             ~extra_args:[] apply_cont_args
       in
       { elt with apply_cont_args })

--- a/middle_end/flambda2/simplify/flow/flow_acc.mli
+++ b/middle_end/flambda2/simplify/flow/flow_acc.mli
@@ -97,7 +97,7 @@ val add_used_in_current_handler : Name_occurrences.t -> t -> t
 val add_apply_conts :
   result_cont:(Apply_cont_rewrite_id.t * Continuation.t) option ->
   exn_cont:Apply_cont_rewrite_id.t * Exn_continuation.t ->
-  result_arity:Flambda_arity.With_subkinds.t ->
+  result_arity:Flambda_arity.t ->
   t ->
   t
 

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -106,8 +106,7 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
           UE.add_function_return_or_exn_continuation
             (UE.create (DA.are_rebuilding_terms dacc))
             (Exn_continuation.exn_handler exn_continuation)
-            (Flambda_arity.With_subkinds.create
-               [Flambda_kind.With_subkind.any_value])
+            (Flambda_arity.create [Flambda_kind.With_subkind.any_value])
         in
         let uenv =
           match Apply.continuation apply with

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.mli
@@ -21,7 +21,7 @@ val make_decision :
   simplify_expr:Expr.t Simplify_common.expr_simplifier ->
   function_type:Flambda2_types.Function_type.t ->
   apply:Apply.t ->
-  return_arity:Flambda_arity.With_subkinds.t ->
+  return_arity:Flambda_arity.t ->
   Call_site_inlining_decision_type.t
 
 val get_rec_info :

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -42,8 +42,7 @@ let run ~cmx_loader ~round unit =
   let dacc = DA.create denv Continuation_uses_env.empty in
   let body, uacc =
     Simplify_expr.simplify_toplevel dacc (FU.body unit) ~return_continuation
-      ~return_arity:
-        (Flambda_arity.With_subkinds.create [K.With_subkind.any_value])
+      ~return_arity:(Flambda_arity.create [K.With_subkind.any_value])
       ~exn_continuation
   in
   let body = Rebuilt_expr.to_expr body (UA.are_rebuilding_terms uacc) in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -96,8 +96,7 @@ let simplify_direct_tuple_application ~simplify_expr dacc apply
     ~down_to_up =
   let dbg = Apply.dbg apply in
   let n =
-    Flambda_arity.With_subkinds.cardinal
-      (Code_metadata.params_arity callee's_code_metadata)
+    Flambda_arity.cardinal (Code_metadata.params_arity callee's_code_metadata)
   in
   (* Split the tuple argument from other potential over application arguments *)
   let tuple, over_application_args =
@@ -106,7 +105,7 @@ let simplify_direct_tuple_application ~simplify_expr dacc apply
     | _ -> Misc.fatal_errorf "Empty argument list for direct application"
   in
   let over_application_arity =
-    List.tl (Flambda_arity.With_subkinds.to_list (Apply.args_arity apply))
+    List.tl (Flambda_arity.to_list (Apply.args_arity apply))
   in
   (* Create the list of variables and projections *)
   let vars_and_fields =
@@ -120,7 +119,7 @@ let simplify_direct_tuple_application ~simplify_expr dacc apply
     let args_arity =
       (* The components of the tuple must always be of kind [Value] (in Lambda,
          [layout_field]). *)
-      Flambda_arity.With_subkinds.create
+      Flambda_arity.create
         (List.init n (fun _ -> K.With_subkind.any_value)
         @ over_application_arity)
     in
@@ -247,28 +246,28 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
             DA.record_continuation_use dacc apply_return_continuation
               (Non_inlinable { escaping = true })
               ~env_at_use:(DA.denv dacc)
-              ~arg_types:(T.unknown_types_from_arity_with_subkinds result_arity)
+              ~arg_types:(T.unknown_types_from_arity result_arity)
           in
           dacc, Some use_id, result_continuation
         | Return apply_return_continuation, Ok result_types ->
           Result_types.pattern_match result_types
             ~f:(fun ~params ~results env_extension ->
-              if Flambda_arity.With_subkinds.cardinal params_arity
+              if Flambda_arity.cardinal params_arity
                  <> Bound_parameters.cardinal params
               then
                 Misc.fatal_errorf
                   "Params arity %a does not match up with params in the result \
                    types structure:@ %a@ for application:@ %a"
-                  Flambda_arity.With_subkinds.print params_arity
-                  Result_types.print result_types Apply.print apply;
-              if Flambda_arity.With_subkinds.cardinal result_arity
+                  Flambda_arity.print params_arity Result_types.print
+                  result_types Apply.print apply;
+              if Flambda_arity.cardinal result_arity
                  <> Bound_parameters.cardinal results
               then
                 Misc.fatal_errorf
                   "Result arity %a does not match up with the result types \
                    structure:@ %a@ for application:@ %a"
-                  Flambda_arity.With_subkinds.print params_arity
-                  Result_types.print result_types Apply.print apply;
+                  Flambda_arity.print params_arity Result_types.print
+                  result_types Apply.print apply;
               let denv = DA.denv dacc in
               let denv =
                 DE.add_parameters_with_unknown_types
@@ -287,9 +286,7 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
                          arg))
                   denv params args
               in
-              let result_arity =
-                Flambda_arity.With_subkinds.to_list result_arity
-              in
+              let result_arity = Flambda_arity.to_list result_arity in
               let denv =
                 List.fold_left2
                   (fun denv kind result ->
@@ -324,7 +321,7 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
           (Non_inlinable { escaping = true })
           ~env_at_use:(DA.denv dacc)
           ~arg_types:
-            (T.unknown_types_from_arity_with_subkinds
+            (T.unknown_types_from_arity
                (Exn_continuation.arity (Apply.exn_continuation apply)))
       in
       let apply = Apply.with_continuation apply result_continuation in
@@ -381,14 +378,14 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
          Inlining_helpers.(
            inlined_attribute_on_partial_application_msg Unrolled))
   | Default_inlined | Hint_inlined -> ());
-  let arity = Flambda_arity.With_subkinds.cardinal param_arity in
+  let arity = Flambda_arity.cardinal param_arity in
   let args_arity = List.length args in
   assert (arity > args_arity);
   let applied_args, remaining_param_arity =
     Misc.Stdlib.List.map2_prefix
       (fun arg kind -> arg, kind)
       args
-      (Flambda_arity.With_subkinds.to_list param_arity)
+      (Flambda_arity.to_list param_arity)
   in
   let wrapper_var = Variable.create "partial_app" in
   let compilation_unit = Compilation_unit.get_current_exn () in
@@ -588,7 +585,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
       let code =
         Code.create code_id ~params_and_body
           ~free_names_of_params_and_body:free_names ~newer_version_of:None
-          ~params_arity:(Bound_parameters.arity_with_subkinds remaining_params)
+          ~params_arity:(Bound_parameters.arity remaining_params)
           ~num_trailing_local_params ~result_arity ~result_types:Unknown
           ~contains_no_escaping_local_allocs ~stub:true ~inline:Default_inline
           ~poll_attribute:Default ~check:Check_attribute.Default_check
@@ -745,7 +742,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
     else
       let args = Apply.args apply in
       let provided_num_args = List.length args in
-      let num_params = Flambda_arity.With_subkinds.cardinal params_arity in
+      let num_params = Flambda_arity.cardinal params_arity in
       let result_arity_of_application = Apply.return_arity apply in
       if provided_num_args = num_params
       then (
@@ -760,16 +757,13 @@ let simplify_direct_function_call ~simplify_expr dacc apply
            present on the application expression, so all we can do is check that
            the function being overapplied returns kind Value. *)
         if not
-             (Flambda_arity.equal
-                (Flambda_arity.With_subkinds.to_arity result_arity)
-                (Flambda_arity.With_subkinds.to_arity
-                   result_arity_of_application))
+             (Flambda_arity.equal_ignoring_subkinds result_arity
+                result_arity_of_application)
         then
           Misc.fatal_errorf
             "Wrong return arity for direct OCaml function call\n\
-            \     (expected %a, found  %a):@ %a"
-            Flambda_arity.With_subkinds.print result_arity
-            Flambda_arity.With_subkinds.print result_arity_of_application
+            \     (expected %a, found  %a):@ %a" Flambda_arity.print
+            result_arity Flambda_arity.print result_arity_of_application
             Apply.print apply;
         simplify_direct_full_application ~simplify_expr dacc apply function_decl
           ~params_arity ~result_arity ~result_types ~down_to_up
@@ -777,9 +771,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       else if provided_num_args > num_params
       then (
         (* See comment above. *)
-        if not
-             (Flambda_arity.is_singleton_value
-                (Flambda_arity.With_subkinds.to_arity result_arity))
+        if not (Flambda_arity.is_singleton_value result_arity)
         then
           Misc.fatal_errorf
             "Non-singleton-value return arity for overapplied OCaml function:@ \
@@ -791,10 +783,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       else if provided_num_args > 0 && provided_num_args < num_params
       then (
         (* See comment above. *)
-        if not
-             (Flambda_arity.is_singleton_value
-                (Flambda_arity.With_subkinds.to_arity
-                   result_arity_of_application))
+        if not (Flambda_arity.is_singleton_value result_arity_of_application)
         then
           Misc.fatal_errorf
             "Non-singleton-value return arity for partially-applied OCaml \
@@ -846,15 +835,14 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
       (Non_inlinable { escaping = true })
       ~env_at_use:(DA.denv dacc)
       ~arg_types:
-        (T.unknown_types_from_arity_with_subkinds
+        (T.unknown_types_from_arity
            (Exn_continuation.arity (Apply.exn_continuation apply)))
   in
   let dacc, use_id =
     DA.record_continuation_use dacc cont
       (Non_inlinable { escaping = true })
       ~env_at_use
-      ~arg_types:
-        (T.unknown_types_from_arity_with_subkinds (Apply.return_arity apply))
+      ~arg_types:(T.unknown_types_from_arity (Apply.return_arity apply))
   in
   let call_kind =
     match call with
@@ -970,7 +958,7 @@ let simplify_apply_shared dacc apply =
           "Argument kind %a from arity does not match kind from type %a for \
            application:@ %a"
           K.print kind T.print arg_type Apply.print apply)
-    (Flambda_arity.With_subkinds.to_list (Apply.args_arity apply))
+    (Flambda_arity.to_list (Apply.args_arity apply))
     arg_types;
   let inlining_state =
     Inlining_state.meet
@@ -1021,11 +1009,10 @@ let simplify_method_call dacc apply ~callee_ty ~kind:_ ~obj ~arg_types
   in
   let denv = DA.denv dacc in
   DE.check_simple_is_bound denv obj;
-  let args_arity =
-    Apply.args_arity apply |> Flambda_arity.With_subkinds.to_arity
-  in
+  let args_arity = Apply.args_arity apply in
   let args_arity_from_types = T.arity_of_list arg_types in
-  if not (Flambda_arity.equal args_arity_from_types args_arity)
+  if not
+       (Flambda_arity.equal_ignoring_subkinds args_arity_from_types args_arity)
   then
     Misc.fatal_errorf
       "Arity %a of [Apply] arguments doesn't match parameter arity %a of \
@@ -1036,8 +1023,7 @@ let simplify_method_call dacc apply ~callee_ty ~kind:_ ~obj ~arg_types
     DA.record_continuation_use dacc apply_cont
       (Non_inlinable { escaping = true })
       ~env_at_use:denv
-      ~arg_types:
-        (T.unknown_types_from_arity_with_subkinds (Apply.return_arity apply))
+      ~arg_types:(T.unknown_types_from_arity (Apply.return_arity apply))
   in
   let dacc, exn_cont_use_id =
     DA.record_continuation_use dacc
@@ -1045,7 +1031,7 @@ let simplify_method_call dacc apply ~callee_ty ~kind:_ ~obj ~arg_types
       (Non_inlinable { escaping = true })
       ~env_at_use:(DA.denv dacc)
       ~arg_types:
-        (T.unknown_types_from_arity_with_subkinds
+        (T.unknown_types_from_arity
            (Exn_continuation.arity (Apply.exn_continuation apply)))
   in
   let dacc =
@@ -1063,9 +1049,7 @@ let rebuild_c_call apply ~use_id ~exn_cont_use_id ~return_arity uacc
   let uacc, expr =
     match use_id with
     | Some use_id ->
-      EB.rewrite_fixed_arity_apply uacc ~use_id
-        (Flambda_arity.With_subkinds.of_arity return_arity)
-        apply
+      EB.rewrite_fixed_arity_apply uacc ~use_id return_arity apply
     | None ->
       let uacc =
         UA.add_free_names uacc (Apply.free_names apply)
@@ -1078,19 +1062,16 @@ let rebuild_c_call apply ~use_id ~exn_cont_use_id ~return_arity uacc
 let simplify_c_call ~simplify_expr dacc apply ~callee_ty ~arg_types ~down_to_up
     =
   fail_if_probe apply;
-  let args_arity =
-    Apply.args_arity apply |> Flambda_arity.With_subkinds.to_arity
-  in
-  let return_arity =
-    Apply.return_arity apply |> Flambda_arity.With_subkinds.to_arity
-  in
+  let args_arity = Apply.args_arity apply in
+  let return_arity = Apply.return_arity apply in
   let callee_kind = T.kind callee_ty in
   if not (K.is_value callee_kind)
   then
     Misc.fatal_errorf "C callees must be of kind [Value], not %a: %a" K.print
       callee_kind T.print callee_ty;
   let args_arity_from_types = T.arity_of_list arg_types in
-  if not (Flambda_arity.equal args_arity_from_types args_arity)
+  if not
+       (Flambda_arity.equal_ignoring_subkinds args_arity_from_types args_arity)
   then
     Misc.fatal_errorf
       "Arity %a of [Apply] arguments doesn't match parameter arity %a of C \
@@ -1136,7 +1117,7 @@ let simplify_c_call ~simplify_expr dacc apply ~callee_ty ~arg_types ~down_to_up
         (Non_inlinable { escaping = true })
         ~env_at_use:(DA.denv dacc)
         ~arg_types:
-          (T.unknown_types_from_arity_with_subkinds
+          (T.unknown_types_from_arity
              (Exn_continuation.arity (Apply.exn_continuation apply)))
     in
     let dacc =

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -33,7 +33,7 @@ type simplify_toplevel =
   Downwards_acc.t ->
   Expr.t ->
   return_continuation:Continuation.t ->
-  return_arity:Flambda_arity.With_subkinds.t ->
+  return_arity:Flambda_arity.t ->
   exn_continuation:Continuation.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
@@ -41,7 +41,7 @@ type simplify_function_body =
   Downwards_acc.t ->
   Expr.t ->
   return_continuation:Continuation.t ->
-  return_arity:Flambda_arity.With_subkinds.t ->
+  return_arity:Flambda_arity.t ->
   exn_continuation:Continuation.t ->
   loopify_state:Loopify_state.t ->
   params:Bound_parameters.t ->
@@ -96,13 +96,13 @@ let split_direct_over_application apply
   let callee's_params_arity =
     Code_metadata.params_arity callee's_code_metadata
   in
-  let arity = Flambda_arity.With_subkinds.cardinal callee's_params_arity in
+  let arity = Flambda_arity.cardinal callee's_params_arity in
   let args = Apply.args apply in
   assert (arity < List.length args);
   let first_args, remaining_args = Misc.Stdlib.List.split_at arity args in
   let _, remaining_arity =
     Misc.Stdlib.List.split_at arity
-      (Apply.args_arity apply |> Flambda_arity.With_subkinds.to_list)
+      (Apply.args_arity apply |> Flambda_arity.to_list)
   in
   assert (List.compare_lengths remaining_args remaining_arity = 0);
   let func_var = Variable.create "full_apply" in
@@ -142,7 +142,7 @@ let split_direct_over_application apply
     Apply.create ~callee:(Simple.var func_var) ~continuation
       (Apply.exn_continuation apply)
       ~args:remaining_args
-      ~args_arity:(Flambda_arity.With_subkinds.create remaining_arity)
+      ~args_arity:(Flambda_arity.create remaining_arity)
       ~return_arity:(Apply.return_arity apply)
       ~call_kind:
         (Call_kind.indirect_function_call_unknown_arity apply_alloc_mode)
@@ -170,7 +170,7 @@ let split_direct_over_application apply
         List.mapi
           (fun i kind ->
             BP.create (Variable.create ("result" ^ string_of_int i)) kind)
-          (Flambda_arity.With_subkinds.to_list (Apply.return_arity apply))
+          (Flambda_arity.to_list (Apply.return_arity apply))
       in
       let call_return_continuation, call_return_continuation_free_names =
         match Apply.continuation apply with

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -76,7 +76,7 @@ type simplify_toplevel =
   Downwards_acc.t ->
   Expr.t ->
   return_continuation:Continuation.t ->
-  return_arity:Flambda_arity.With_subkinds.t ->
+  return_arity:Flambda_arity.t ->
   exn_continuation:Continuation.t ->
   Rebuilt_expr.t * Upwards_acc.t
 
@@ -84,7 +84,7 @@ type simplify_function_body =
   Downwards_acc.t ->
   Expr.t ->
   return_continuation:Continuation.t ->
-  return_arity:Flambda_arity.With_subkinds.t ->
+  return_arity:Flambda_arity.t ->
   exn_continuation:Continuation.t ->
   loopify_state:Loopify_state.t ->
   params:Bound_parameters.t ->

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -66,7 +66,7 @@ let simplify_toplevel_common dacc simplify ~params ~implicit_params
         in
         let uenv =
           UE.add_function_return_or_exn_continuation uenv exn_continuation
-            (Flambda_arity.With_subkinds.create [K.With_subkind.any_value])
+            (Flambda_arity.create [K.With_subkind.any_value])
         in
         let uacc =
           UA.create ~flow_result ~compute_slot_offsets:true uenv dacc

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -628,10 +628,10 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
           in
           match behaviour with
           | Invalid ->
-            let arity = Bound_parameters.arity_with_subkinds params in
+            let arity = Bound_parameters.arity params in
             UE.add_invalid_continuation uenv cont arity
           | Alias_for alias_for ->
-            let arity = Bound_parameters.arity_with_subkinds params in
+            let arity = Bound_parameters.arity params in
             UE.add_continuation_alias uenv cont arity ~alias_for
           | Unknown ->
             UE.add_non_inlinable_continuation uenv cont ~params

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -342,7 +342,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
         BP.create
           (Variable.create ("result" ^ string_of_int i))
           kind_with_subkind)
-      (Flambda_arity.With_subkinds.to_list result_arity)
+      (Flambda_arity.to_list result_arity)
     |> Bound_parameters.create
   in
   let { params;
@@ -721,8 +721,7 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
       Cost_metrics.
         { cost_metrics = Code_metadata.cost_metrics code_metadata;
           params_arity =
-            Flambda_arity.With_subkinds.cardinal
-              (Code_metadata.params_arity code_metadata)
+            Flambda_arity.cardinal (Code_metadata.params_arity code_metadata)
         }
     in
     Simplified_named.create_with_known_free_names ~find_code_characteristics

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -71,10 +71,7 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
     Simplify_common.clear_demoted_trap_action_and_patch_unused_exn_bucket uacc
       action
   in
-  match
-    EB.rewrite_switch_arm uacc action ~use_id
-      (Flambda_arity.With_subkinds.of_arity arity)
-  with
+  match EB.rewrite_switch_arm uacc action ~use_id arity with
   | Apply_cont action -> (
     let action =
       let cont = Apply_cont.continuation action in
@@ -377,7 +374,11 @@ let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
       DA.record_continuation_use dacc (AC.continuation action) use_kind
         ~env_at_use:denv_at_use ~arg_types
     in
-    let arity = List.map T.kind arg_types |> Flambda_arity.create in
+    let arity =
+      arg_types
+      |> List.map (fun ty -> K.With_subkind.anything (T.kind ty))
+      |> Flambda_arity.create
+    in
     let action = Apply_cont.update_args action ~args in
     let dacc =
       DA.map_flow_acc dacc

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -72,7 +72,7 @@ let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation
       let kinded_params =
         List.map
           (fun k -> Bound_parameter.create (Variable.create "wrapper_return") k)
-          (Flambda_arity.With_subkinds.to_list result_arity)
+          (Flambda_arity.to_list result_arity)
       in
       let trap_action =
         Trap_action.Pop { exn_handler = wrapper; raise_kind = None }

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.mli
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.mli
@@ -46,7 +46,7 @@ val wrap_inlined_body_for_exn_extra_args :
   extra_args:(Simple.t * Flambda_kind.With_subkind.t) list ->
   apply_exn_continuation:Exn_continuation.t ->
   apply_return_continuation:Flambda.Apply.Result_continuation.t ->
-  result_arity:Flambda_arity.With_subkinds.t ->
+  result_arity:Flambda_arity.t ->
   make_inlined_body:
     ('acc ->
     apply_exn_continuation:Continuation.t ->

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -727,7 +727,7 @@ end = struct
         let module CM = Code_metadata in
         let is_tupled = CM.is_tupled code_metadata in
         let params_arity = CM.params_arity code_metadata in
-        let arity = Flambda_arity.With_subkinds.cardinal params_arity in
+        let arity = Flambda_arity.cardinal params_arity in
         if (arity = 0 || arity = 1) && not is_tupled then 2 else 3
       in
       let s = create_slot ~size (Function_slot function_slot) Unassigned in

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -73,8 +73,8 @@ type t =
     continuation : Result_continuation.t;
     exn_continuation : Exn_continuation.t;
     args : Simple.t list;
-    args_arity : Flambda_arity.With_subkinds.t;
-    return_arity : Flambda_arity.With_subkinds.t;
+    args_arity : Flambda_arity.t;
+    return_arity : Flambda_arity.t;
     call_kind : Call_kind.t;
     dbg : Debuginfo.t;
     inlined : Inlined_attribute.t;
@@ -115,8 +115,8 @@ let [@ocamlformat "disable"] print ppf
     Variable.print region
     Flambda_colours.pop
     Simple.List.print args
-    Flambda_arity.With_subkinds.print args_arity
-    Flambda_arity.With_subkinds.print return_arity
+    Flambda_arity.print args_arity
+    Flambda_arity.print return_arity
     Call_kind.print call_kind
     Flambda_colours.debuginfo
     Debuginfo.print_compact dbg
@@ -162,13 +162,12 @@ let invariant
         "For [C_call] applications the callee must be directly specified as a \
          [Symbol]:@ %a"
         print t;
-    match Flambda_arity.With_subkinds.to_list return_arity with
+    match Flambda_arity.to_list return_arity with
     | [] | [_] -> ()
     | _ :: _ :: _ ->
       Misc.fatal_errorf "Illegal return arity for C call:@ %a"
-        Flambda_arity.With_subkinds.print return_arity));
-  if List.compare_lengths args (Flambda_arity.With_subkinds.to_list args_arity)
-     <> 0
+        Flambda_arity.print return_arity));
+  if List.compare_lengths args (Flambda_arity.to_list args_arity) <> 0
   then
     Misc.fatal_errorf
       "Length of argument and arity lists disagree in [Apply]:@ %a" print t

--- a/middle_end/flambda2/terms/apply_expr.mli
+++ b/middle_end/flambda2/terms/apply_expr.mli
@@ -51,8 +51,8 @@ val create :
   continuation:Result_continuation.t ->
   Exn_continuation.t ->
   args:Simple.t list ->
-  args_arity:Flambda_arity.With_subkinds.t ->
-  return_arity:Flambda_arity.With_subkinds.t ->
+  args_arity:Flambda_arity.t ->
+  return_arity:Flambda_arity.t ->
   call_kind:Call_kind.t ->
   Debuginfo.t ->
   inlined:Inlined_attribute.t ->
@@ -77,10 +77,10 @@ val callee : t -> Simple.t
 val args : t -> Simple.t list
 
 (** The arity of the arguments being applied. *)
-val args_arity : t -> Flambda_arity.With_subkinds.t
+val args_arity : t -> Flambda_arity.t
 
 (** The arity of the result(s) of the application. *)
-val return_arity : t -> Flambda_arity.With_subkinds.t
+val return_arity : t -> Flambda_arity.t
 
 (** Information about what kind of call is involved (direct function call,
     method call, etc). *)
@@ -110,8 +110,7 @@ val with_continuations : t -> Result_continuation.t -> Exn_continuation.t -> t
 val with_exn_continuation : t -> Exn_continuation.t -> t
 
 (** Change the arguments of an application *)
-val with_args :
-  t -> Simple.t list -> args_arity:Flambda_arity.With_subkinds.t -> t
+val with_args : t -> Simple.t list -> args_arity:Flambda_arity.t -> t
 
 (** Change the call kind of an application. *)
 val with_call_kind : t -> Call_kind.t -> t

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -17,9 +17,9 @@
 type t =
   { code_id : Code_id.t;
     newer_version_of : Code_id.t option;
-    params_arity : Flambda_arity.With_subkinds.t;
+    params_arity : Flambda_arity.t;
     num_trailing_local_params : int;
-    result_arity : Flambda_arity.With_subkinds.t;
+    result_arity : Flambda_arity.t;
     result_types : Result_types.t Or_unknown_or_bottom.t;
     contains_no_escaping_local_allocs : bool;
     stub : bool;
@@ -58,10 +58,7 @@ module Code_metadata_accessors (X : Metadata_view_type) = struct
 
   let num_leading_heap_params t =
     let { params_arity; num_trailing_local_params; _ } = metadata t in
-    let n =
-      Flambda_arity.With_subkinds.cardinal params_arity
-      - num_trailing_local_params
-    in
+    let n = Flambda_arity.cardinal params_arity - num_trailing_local_params in
     assert (n >= 0);
     (* see [create] *)
     n
@@ -127,9 +124,9 @@ include Code_metadata_accessors [@inlined hint] (Metadata_view)
 type 'a create_type =
   Code_id.t ->
   newer_version_of:Code_id.t option ->
-  params_arity:Flambda_arity.With_subkinds.t ->
+  params_arity:Flambda_arity.t ->
   num_trailing_local_params:int ->
-  result_arity:Flambda_arity.With_subkinds.t ->
+  result_arity:Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   contains_no_escaping_local_allocs:bool ->
   stub:bool ->
@@ -164,12 +161,11 @@ let createk k code_id ~newer_version_of ~params_arity ~num_trailing_local_params
   | true, (Always_inline | Unroll _) ->
     Misc.fatal_error "Stubs may not be annotated as [Always_inline] or [Unroll]");
   if num_trailing_local_params < 0
-     || num_trailing_local_params
-        > Flambda_arity.With_subkinds.cardinal params_arity
+     || num_trailing_local_params > Flambda_arity.cardinal params_arity
   then
     Misc.fatal_errorf
       "Illegal num_trailing_local_params=%d for params arity: %a"
-      num_trailing_local_params Flambda_arity.With_subkinds.print params_arity;
+      num_trailing_local_params Flambda_arity.print params_arity;
   k
     { code_id;
       newer_version_of;
@@ -274,22 +270,22 @@ let [@ocamlformat "disable"] print ppf
     (if not is_a_functor then Flambda_colours.elide else C.none)
     is_a_functor
     Flambda_colours.pop
-    (if Flambda_arity.With_subkinds.is_singleton_value params_arity
+    (if Flambda_arity.is_singleton_value params_arity
     then Flambda_colours.elide
     else Flambda_colours.none)
     Flambda_colours.pop
-    Flambda_arity.With_subkinds.print params_arity
-    (if Flambda_arity.With_subkinds.is_singleton_value params_arity
+    Flambda_arity.print params_arity
+    (if Flambda_arity.is_singleton_value params_arity
     then Flambda_colours.elide
     else Flambda_colours.none)
     Flambda_colours.pop
     num_trailing_local_params
-    (if Flambda_arity.With_subkinds.is_singleton_value result_arity
+    (if Flambda_arity.is_singleton_value result_arity
     then Flambda_colours.elide
     else Flambda_colours.none)
     Flambda_colours.pop
-    Flambda_arity.With_subkinds.print result_arity
-    (if Flambda_arity.With_subkinds.is_singleton_value result_arity
+    Flambda_arity.print result_arity
+    (if Flambda_arity.is_singleton_value result_arity
     then Flambda_colours.elide
     else Flambda_colours.none)
     Flambda_colours.pop
@@ -492,9 +488,9 @@ let approx_equal
     } =
   Code_id.equal code_id1 code_id2
   && (Option.equal Code_id.equal) newer_version_of1 newer_version_of2
-  && Flambda_arity.With_subkinds.equal params_arity1 params_arity2
+  && Flambda_arity.equal_ignoring_subkinds params_arity1 params_arity2
   && Int.equal num_trailing_local_params1 num_trailing_local_params2
-  && Flambda_arity.With_subkinds.equal result_arity1 result_arity2
+  && Flambda_arity.equal_ignoring_subkinds result_arity1 result_arity2
   && Bool.equal contains_no_escaping_local_allocs1
        contains_no_escaping_local_allocs2
   && Bool.equal stub1 stub2

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -31,13 +31,13 @@ module type Code_metadata_accessors_result_type = sig
 
   val newer_version_of : 'a t -> Code_id.t option
 
-  val params_arity : 'a t -> Flambda_arity.With_subkinds.t
+  val params_arity : 'a t -> Flambda_arity.t
 
   val num_leading_heap_params : 'a t -> int
 
   val num_trailing_local_params : 'a t -> int
 
-  val result_arity : 'a t -> Flambda_arity.With_subkinds.t
+  val result_arity : 'a t -> Flambda_arity.t
 
   val result_types : 'a t -> Result_types.t Or_unknown_or_bottom.t
 
@@ -82,9 +82,9 @@ include Code_metadata_accessors_result_type with type 'a t := t
 type 'a create_type =
   Code_id.t ->
   newer_version_of:Code_id.t option ->
-  params_arity:Flambda_arity.With_subkinds.t ->
+  params_arity:Flambda_arity.t ->
   num_trailing_local_params:int ->
-  result_arity:Flambda_arity.With_subkinds.t ->
+  result_arity:Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   contains_no_escaping_local_allocs:bool ->
   stub:bool ->

--- a/middle_end/flambda2/terms/exn_continuation.ml
+++ b/middle_end/flambda2/terms/exn_continuation.ml
@@ -108,7 +108,7 @@ let arity t =
   let exn_bucket_kind =
     Flambda_kind.With_subkind.create Flambda_kind.value Anything
   in
-  Flambda_arity.With_subkinds.create (exn_bucket_kind :: extra_args)
+  Flambda_arity.create (exn_bucket_kind :: extra_args)
 
 let with_exn_handler t exn_handler = { t with exn_handler }
 

--- a/middle_end/flambda2/terms/exn_continuation.mli
+++ b/middle_end/flambda2/terms/exn_continuation.mli
@@ -46,7 +46,7 @@ val extra_args : t -> (Simple.t * Flambda_kind.With_subkind.t) list
 
 (** The arity of the given exception continuation, taking into account both the
     exception bucket argument and any [extra_args]. *)
-val arity : t -> Flambda_arity.With_subkinds.t
+val arity : t -> Flambda_arity.t
 
 val with_exn_handler : t -> Continuation.t -> t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -360,7 +360,7 @@ let add_exn_handler env k arity =
   let env =
     { env with exn_handlers = Continuation.Set.add k env.exn_handlers }
   in
-  match Flambda_arity.With_subkinds.to_list arity with
+  match Flambda_arity.to_list arity with
   | [] -> Misc.fatal_error "Exception handlers must have at least one parameter"
   | [_] -> env, []
   | _ :: extra_args ->

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -325,7 +325,7 @@ val add_inline_cont :
 val add_exn_handler :
   t ->
   Continuation.t ->
-  Flambda_arity.With_subkinds.t ->
+  Flambda_arity.t ->
   t * (Backend_var.t * Flambda_kind.With_subkind.t) list
 
 (** Return whether the given continuation has been registered as an exception

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -93,9 +93,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       Lambda.Rc_normal
     | Nontail -> Lambda.Rc_nontail
   in
-  let args_arity =
-    Apply.args_arity apply |> Flambda_arity.With_subkinds.to_list
-  in
+  let args_arity = Apply.args_arity apply |> Flambda_arity.to_list in
   let return_arity = Apply.return_arity apply in
   let args_ty = List.map C.extended_machtype_of_kind args_arity in
   let return_ty = C.extended_machtype_of_return_arity return_arity in
@@ -166,7 +164,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     in
     let returns = Apply.returns apply in
     let wrap =
-      match Flambda_arity.With_subkinds.to_list return_arity with
+      match Flambda_arity.to_list return_arity with
       (* Returned int32 values need to be sign_extended because it's not clear
          whether C code that returns an int32 returns one that is sign extended
          or not. There is no need to wrap other return arities. Note that
@@ -186,8 +184,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     in
     let ty_args =
       List.map C.exttype_of_kind
-        (Flambda_arity.to_list
-           (Flambda_arity.With_subkinds.to_arity (Apply.args_arity apply)))
+        (Flambda_arity.to_list (Apply.args_arity apply)
+        |> List.map K.With_subkind.kind)
     in
     ( wrap dbg
         (C.extcall ~dbg ~alloc ~is_c_builtin ~returns ~ty_args callee
@@ -687,7 +685,7 @@ and let_cont_rec env res invariant_params conts body =
 and continuation_handler env res handler =
   Continuation_handler.pattern_match' handler
     ~f:(fun params ~num_normal_occurrences_of_params:_ ~handler ->
-      let arity = Bound_parameters.arity_with_subkinds params in
+      let arity = Bound_parameters.arity params in
       let env, vars = C.bound_parameters env params in
       let expr, free_vars_of_handler, res = expr env res handler in
       vars, arity, expr, free_vars_of_handler, res)

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -45,7 +45,7 @@ let get_func_decl_params_arity t code_id =
       (fun k ->
         C.extended_machtype_of_kind k
         |> C.Extended_machtype.change_tagged_int_to_val)
-      (Flambda_arity.With_subkinds.to_list (Code_metadata.params_arity info))
+      (Flambda_arity.to_list (Code_metadata.params_arity info))
   in
   let result_machtype =
     C.extended_machtype_of_return_arity (Code_metadata.result_arity info)

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -250,11 +250,10 @@ let make_update env res dbg kind ~symbol var ~index ~prev_updates =
   in
   env, res, Some update
 
-let check_arity arity args =
-  Flambda_arity.With_subkinds.cardinal arity = List.length args
+let check_arity arity args = Flambda_arity.cardinal arity = List.length args
 
 let extended_machtype_of_return_arity arity =
-  match Flambda_arity.With_subkinds.to_list arity with
+  match Flambda_arity.to_list arity with
   | [] ->
     (* Functions that never return have arity 0. In that case, we use the most
        restrictive machtype to ensure that the return value of the function is

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -101,7 +101,7 @@ val make_update :
   prev_updates:To_cmm_env.expr_with_info option ->
   To_cmm_env.t * To_cmm_result.t * To_cmm_env.expr_with_info option
 
-val check_arity : Flambda_arity.With_subkinds.t -> _ list -> bool
+val check_arity : Flambda_arity.t -> _ list -> bool
 
 val extended_machtype_of_return_arity :
-  Flambda_arity.With_subkinds.t -> Cmm_helpers.Extended_machtype.t
+  Flambda_arity.t -> Cmm_helpers.Extended_machtype.t

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -517,9 +517,6 @@ val get_alias_exn : t -> Simple.t
 (** For each of the kinds in an arity, create an "unknown" type. *)
 val unknown_types_from_arity : Flambda_arity.t -> t list
 
-val unknown_types_from_arity_with_subkinds :
-  Flambda_arity.With_subkinds.t -> t list
-
 (** For each of the kinds in an arity, create an "bottom" type. *)
 val bottom_types_from_arity : Flambda_arity.t -> t list
 

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -274,10 +274,9 @@ let check_equation name ty =
       Misc.fatal_errorf "Directly recursive equation@ %a = %a@ disallowed"
         Name.print name TG.print ty
 
-let arity_of_list ts = Flambda_arity.create (List.map TG.kind ts)
-
-let unknown_types_from_arity arity =
-  List.map (fun kind -> unknown kind) (Flambda_arity.to_list arity)
+let arity_of_list ts =
+  Flambda_arity.create
+    (List.map (fun ty -> Flambda_kind.With_subkind.anything (TG.kind ty)) ts)
 
 let rec unknown_with_subkind ?(alloc_mode = Alloc_mode.For_types.unknown ())
     (kind : Flambda_kind.With_subkind.t) =
@@ -326,10 +325,10 @@ let rec unknown_with_subkind ?(alloc_mode = Alloc_mode.For_types.unknown ())
     TG.mutable_array ~element_kind:Unknown ~length:any_tagged_immediate
       alloc_mode
 
-let unknown_types_from_arity_with_subkinds arity =
-  List.map
-    (fun kind -> unknown_with_subkind kind)
-    (Flambda_arity.With_subkinds.to_list arity)
+let unknown_types_from_arity arity =
+  List.map (fun kind -> unknown_with_subkind kind) (Flambda_arity.to_list arity)
 
 let bottom_types_from_arity arity =
-  List.map (fun kind -> bottom kind) (Flambda_arity.to_list arity)
+  List.map
+    (fun kind -> bottom kind)
+    (Flambda_arity.to_list arity |> List.map Flambda_kind.With_subkind.kind)

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -325,10 +325,10 @@ let rec unknown_with_subkind ?(alloc_mode = Alloc_mode.For_types.unknown ())
     TG.mutable_array ~element_kind:Unknown ~length:any_tagged_immediate
       alloc_mode
 
+let bottom_with_subkind kind = bottom (Flambda_kind.With_subkind.kind kind)
+
 let unknown_types_from_arity arity =
-  List.map (fun kind -> unknown_with_subkind kind) (Flambda_arity.to_list arity)
+  List.map unknown_with_subkind (Flambda_arity.to_list arity)
 
 let bottom_types_from_arity arity =
-  List.map
-    (fun kind -> bottom kind)
-    (Flambda_arity.to_list arity |> List.map Flambda_kind.With_subkind.kind)
+  List.map bottom_with_subkind (Flambda_arity.to_list arity)

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -151,8 +151,5 @@ val unknown_with_subkind :
 (** For each of the kinds in an arity, create an "unknown" type. *)
 val unknown_types_from_arity : Flambda_arity.t -> Type_grammar.t list
 
-val unknown_types_from_arity_with_subkinds :
-  Flambda_arity.With_subkinds.t -> Type_grammar.t list
-
 (** For each of the kinds in an arity, create an "bottom" type. *)
 val bottom_types_from_arity : Flambda_arity.t -> Type_grammar.t list


### PR DESCRIPTION
As discussed, it seemed like this could be removed - and indeed its removal would make the forthcoming unarization work more straightforward.  Actually removing it was unproblematic; arities now always have subkind info.  Some unused functions have also been removed, so the interface to `Flambda_arity` is now much smaller.