### PR TITLE
Emit jump tables in the text section to save relocations

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -410,6 +410,25 @@ let emit_call_bound_errors () =
     emit_call "caml_ml_array_bound_error"
   end
 
+(* Record jump tables *)
+type jump_table =
+  { table_lbl: string;
+    elems: Linear.label array }
+
+let jump_tables = ref ([] : jump_table list)
+
+let emit_jump_table t =
+  _label t.table_lbl;
+  for i = 0 to Array.length t.elems - 1 do
+    D.long (ConstSub (ConstLabel(emit_label t.elems.(i)),
+                      ConstLabel t.table_lbl))
+  done
+
+let emit_jump_tables () =
+  D.align ~data:true 4;
+  List.iter emit_jump_table !jump_tables;
+  jump_tables := []
+
 (* Record function info for dwarf and emit label if needed. *)
 let emit_dwarf_for_fundecl fun_name fun_dbg =
   match Emitaux.Dwarf_helpers.record_dwarf_for_fundecl ~fun_name fun_dbg with
@@ -1260,19 +1279,11 @@ let emit_instr fallthrough i =
       I.add (reg tmp2) (reg tmp1);
       I.jmp (reg tmp1);
 
-      begin match system with
-      | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
-      | S_macosx | S_win64 -> ()
-        (* with LLVM/OS X and MASM, use the text segment *)
-      | _ -> D.section [".rodata"] None []
-      end;
-      D.align ~data:true 4;
-      _label lbl;
-      for i = 0 to Array.length jumptbl - 1 do
-        D.long (ConstSub (ConstLabel(emit_label jumptbl.(i)),
-                         ConstLabel lbl))
-      done;
-      emit_function_or_basic_block_section_name ()
+      let table =
+        { table_lbl = lbl;
+          elems = jumptbl }
+      in
+      jump_tables := table :: !jump_tables
   | Lentertrap ->
       if fp then begin
         let delta = frame_size () - 16 (* retaddr + rbp *) in
@@ -1777,6 +1788,9 @@ let end_assembly () =
 
   (* Emit probe handler wrappers *)
   List.iter emit_probe_handler_wrapper !probes;
+
+  emit_named_text_section (Cmm_helpers.make_symbol "jump_tables");
+  emit_jump_tables ();
 
   let code_end = Cmm_helpers.make_symbol "code_end" in
   emit_named_text_section code_end;


### PR DESCRIPTION
This patch moves the jump tables generated by `Lswitch` from `.rodata` to `.text`. This means that the offsets in the tables are known at assemble time, and get compiled by the assembler into constant bytes, instead of leaving relocations to be resolved by the linker.