### PR TITLE
Use cmx reachability to decide locality of symbols

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -225,6 +225,11 @@ type kind_for_unboxing =
 
 type is_global = Global | Local
 
+let equal_is_global g g' =
+  match g, g' with
+  | Local, Local | Global, Global -> true
+  | Local, Global | Global, Local -> false
+
 type symbol =
   { sym_name : string;
     sym_global : is_global }

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -228,6 +228,7 @@ type kind_for_unboxing =
   | Boxed_float
 
 type is_global = Global | Local
+val equal_is_global : is_global -> is_global -> bool
 
 (* Symbols are marked with whether they are local or global,
    at both definition and use sites.

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4144,7 +4144,7 @@ let gc_root_table syms =
   let table_symbol = make_symbol ?compilation_unit:None "gc_roots" in
   cdata
     (define_symbol { sym_name = table_symbol; sym_global = Global }
-    @ List.map (fun s -> symbol_address (global_symbol s)) syms
+    @ List.map (fun s -> symbol_address s) syms
     @ [cint 0n])
 
 let cmm_arith_size (e : Cmm.expression) =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1209,29 +1209,37 @@ let apply_function_sym arity result mode =
   global_symbol (apply_function_name arity result mode)
 
 let curry_function_sym function_kind arity result =
-  match function_kind with
-  | Lambda.Curried { nlocal } ->
-    Compilenv.need_curry_fun function_kind arity result;
-    "caml_curry"
-    ^ unique_arity_identifier arity
-    ^ (match result with
+  let sym_name =
+    match function_kind with
+    | Lambda.Curried { nlocal } ->
+      Compilenv.need_curry_fun function_kind arity result;
+      "caml_curry"
+      ^ unique_arity_identifier arity
+      ^ (match result with
+        | [| Val |] -> ""
+        | _ -> "_R" ^ machtype_identifier result)
+      ^ if nlocal > 0 then "L" ^ Int.to_string nlocal else ""
+    | Lambda.Tupled -> (
+      if List.exists
+           (function [| Val |] | [| Int |] -> false | _ -> true)
+           arity
+      then
+        Misc.fatal_error
+          "tuplify_function is currently unsupported if arity contains \
+           non-values";
+      (* Always use [Val] to ensure we don't generate duplicate tuplify
+         functions when [Int] machtypes are involved. *)
+      Compilenv.need_curry_fun function_kind
+        (List.map (fun _ -> [| Val |]) arity)
+        result;
+      "caml_tuplify"
+      ^ Int.to_string (List.length arity)
+      ^
+      match result with
       | [| Val |] -> ""
       | _ -> "_R" ^ machtype_identifier result)
-    ^ if nlocal > 0 then "L" ^ Int.to_string nlocal else ""
-  | Lambda.Tupled -> (
-    if List.exists (function [| Val |] | [| Int |] -> false | _ -> true) arity
-    then
-      Misc.fatal_error
-        "tuplify_function is currently unsupported if arity contains non-values";
-    (* Always use [Val] to ensure we don't generate duplicate tuplify functions
-       when [Int] machtypes are involved. *)
-    Compilenv.need_curry_fun function_kind
-      (List.map (fun _ -> [| Val |]) arity)
-      result;
-    "caml_tuplify"
-    ^ Int.to_string (List.length arity)
-    ^
-    match result with [| Val |] -> "" | _ -> "_R" ^ machtype_identifier result)
+  in
+  { sym_name; sym_global = Global }
 
 (* Big arrays *)
 
@@ -2809,8 +2817,8 @@ let final_curry_function nlocal arity result =
   let narity = List.length arity in
   let fun_name =
     global_symbol
-      (curry_function_sym (Lambda.Curried { nlocal }) arity result
-      ^ "_"
+      ((curry_function_sym (Lambda.Curried { nlocal }) arity result).sym_name
+     ^ "_"
       ^ Int.to_string (narity - 1))
   in
   let args_type = List.rev arity in
@@ -2828,7 +2836,9 @@ let final_curry_function nlocal arity result =
     }
 
 let intermediate_curry_functions ~nlocal ~arity result =
-  let name1 = curry_function_sym (Lambda.Curried { nlocal }) arity result in
+  let name1 =
+    (curry_function_sym (Lambda.Curried { nlocal }) arity result).sym_name
+  in
   let narity = List.length arity in
   let dbg = placeholder_dbg in
   let rec loop accumulated_args remaining_args num =
@@ -3756,9 +3766,8 @@ let emit_constant_closure symb fundecls clos_vars cont =
           in
           (Cint (infix_header pos) :: closure_symbol f2)
           @ Csymbol_address
-              (global_symbol
-                 (curry_function_sym arity.function_kind params_machtypes
-                    return_machtype))
+              (curry_function_sym arity.function_kind params_machtypes
+                 return_machtype)
             :: Cint (closure_info ~arity ~startenv:(startenv - pos) ~is_last)
             :: Csymbol_address
                  { sym_name = f2.label; sym_global = symb.sym_global }
@@ -3776,11 +3785,10 @@ let emit_constant_closure symb fundecls clos_vars cont =
       :: emit_others 3 remainder
     | arity ->
       Csymbol_address
-        (global_symbol
-           (curry_function_sym arity.function_kind
-              (List.map machtype_of_layout_changing_tagged_int_to_val
-                 arity.params_layout)
-              (machtype_of_layout_changing_tagged_int_to_val arity.return_layout)))
+        (curry_function_sym arity.function_kind
+           (List.map machtype_of_layout_changing_tagged_int_to_val
+              arity.params_layout)
+           (machtype_of_layout_changing_tagged_int_to_val arity.return_layout))
       :: Cint (closure_info ~arity ~startenv ~is_last)
       :: Csymbol_address { sym_name = f1.label; sym_global = symb.sym_global }
       :: emit_others 4 remainder)
@@ -3844,7 +3852,7 @@ let unit ~dbg = Cconst_int (1, dbg)
 
 let var v = Cvar v
 
-let symbol_from_string ~dbg sym = Cconst_symbol (global_symbol sym, dbg)
+let symbol ~dbg sym = Cconst_symbol (sym, dbg)
 
 let float ~dbg f = Cconst_float (f, dbg)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -475,7 +475,7 @@ val machtype_identifier : machtype -> string
 (** Get the symbol for the generic currying or tuplifying wrapper with [n]
     arguments, and ensure its presence in the set of defined symbols. *)
 val curry_function_sym :
-  Lambda.function_kind -> machtype list -> machtype -> string
+  Lambda.function_kind -> machtype list -> machtype -> Cmm.symbol
 
 (** Bigarrays *)
 
@@ -958,9 +958,8 @@ val unit : dbg:Debuginfo.t -> Cmm.expression
 (** Create an expression from a variable. *)
 val var : Backend_var.t -> Cmm.expression
 
-(** Create an expression that gives the value of an object file symbol, such
-    symbol's name being given by a string. *)
-val symbol_from_string : dbg:Debuginfo.t -> string -> Cmm.expression
+(** Create an expression that gives the value of an object file symbol. *)
+val symbol : dbg:Debuginfo.t -> Cmm.symbol -> Cmm.expression
 
 (** Create a constant float expression. *)
 val float : dbg:Debuginfo.t -> float -> expression
@@ -1244,7 +1243,7 @@ val cfunction : fundecl -> phrase
 val cdata : data_item list -> phrase
 
 (** Create the gc root table from a list of root symbols. *)
-val gc_root_table : string list -> phrase
+val gc_root_table : Cmm.symbol list -> phrase
 
 (* An estimate of the number of arithmetic instructions in a Cmm expression.
    This is currently used in Flambda 2 to determine whether untagging an

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -481,7 +481,7 @@ let rec transl env e =
                 transl_fundecls (pos + 3) rem
               | arity ->
                 Cconst_symbol
-                  (global_symbol (curry_function_sym
+                  ((curry_function_sym
                      arity.function_kind
                      (List.map machtype_of_layout_changing_tagged_int_to_val
                        arity.params_layout)

--- a/backend/cmmgen_state.ml
+++ b/backend/cmmgen_state.ml
@@ -76,6 +76,10 @@ let is_local_function name =
 let clear_function_names () =
   Hashtbl.clear state.function_names
 
+let add_structured_constant (sym : Cmm.symbol) cst =
+  if not (Hashtbl.mem state.structured_constants sym.sym_name) then
+    Hashtbl.replace state.structured_constants sym.sym_name (sym.sym_global, cst)
+
 let set_local_structured_constants l =
   Hashtbl.clear state.structured_constants;
   List.iter

--- a/backend/cmmgen_state.mli
+++ b/backend/cmmgen_state.mli
@@ -41,6 +41,8 @@ val is_local_function : Clambda.function_label -> bool
 
 val clear_function_names : unit -> unit
 
+val add_structured_constant : Cmm.symbol -> Clambda.ustructured_constant -> unit
+
 val set_local_structured_constants : Clambda.preallocated_constant list -> unit
 
 val add_global_structured_constant : string -> Clambda.ustructured_constant -> unit

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -63,6 +63,13 @@ let extcall_signature ppf (ty_res, ty_args) =
       fprintf ppf "->%a" machtype ty_res
   end
 
+let is_global ppf = function
+  | Global -> fprintf ppf "G"
+  | Local -> fprintf ppf "L"
+
+let symbol ppf s =
+  fprintf ppf "%a:\"%s\"" is_global s.sym_global s.sym_name
+
 let integer_comparison = function
   | Ceq -> "=="
   | Cne -> "!="
@@ -230,12 +237,13 @@ let operation d = function
   | Cbeginregion -> "beginregion"
   | Cendregion -> "endregion"
 
+
 let rec expr ppf = function
   | Cconst_int (n, _dbg) -> fprintf ppf "%i" n
   | Cconst_natint (n, _dbg) ->
     fprintf ppf "%s" (Nativeint.to_string n)
   | Cconst_float (n, _dbg) -> fprintf ppf "%F" n
-  | Cconst_symbol (s, _dbg) -> fprintf ppf "\"%s\"" s.sym_name
+  | Cconst_symbol (s, _dbg) -> fprintf ppf "%a:\"%s\"" is_global s.sym_global s.sym_name
   | Cvar id -> V.print ppf id
   | Clet(id, def, (Clet(_, _, _) as body)) ->
       let print_binding id ppf def =
@@ -401,7 +409,7 @@ let data_item ppf = function
   | Cint n -> fprintf ppf "int %s" (Nativeint.to_string n)
   | Csingle f -> fprintf ppf "single %F" f
   | Cdouble f -> fprintf ppf "double %F" f
-  | Csymbol_address s -> fprintf ppf "addr \"%s\"" s.sym_name
+  | Csymbol_address s -> fprintf ppf "addr %a:\"%s\"" is_global s.sym_global s.sym_name
   | Cstring s -> fprintf ppf "string \"%s\"" s
   | Cskip n -> fprintf ppf "skip %i" n
   | Calign n -> fprintf ppf "align %i" n

--- a/backend/printcmm.mli
+++ b/backend/printcmm.mli
@@ -17,6 +17,7 @@
 
 open Format
 
+val symbol : formatter -> Cmm.symbol -> unit
 val rec_flag : formatter -> Cmm.rec_flag -> unit
 val machtype_component : formatter -> Cmm.machtype_component -> unit
 val machtype : formatter -> Cmm.machtype -> unit

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -221,15 +221,19 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
     |> Exported_offsets.reexport_value_slots
          (Name_occurrences.all_value_slots slots_used_in_typing_env)
   in
-  Some
-    (Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets
-       ~used_value_slots)
+  let cmx =
+    Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets
+      ~used_value_slots
+  in
+  reachable_names, Some cmx
 
 let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
     ~exported_offsets all_code =
   match final_typing_env with
-  | None -> None
-  | Some _ when Flambda_features.opaque () -> None
+  | None ->
+    Name_occurrences.singleton_symbol module_symbol Name_mode.normal, None
+  | Some _ when Flambda_features.opaque () ->
+    Name_occurrences.singleton_symbol module_symbol Name_mode.normal, None
   | Some final_typing_env ->
     let typing_env, canonicalise =
       TE.Pre_serializable.create final_typing_env ~used_value_slots
@@ -247,7 +251,7 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
 let prepare_cmx_from_approx ~approxs ~module_symbol ~exported_offsets
     ~used_value_slots all_code =
   if Flambda_features.opaque ()
-  then None
+  then Name_occurrences.singleton_symbol module_symbol Name_mode.normal, None
   else
     let create_typing_env reachable_names =
       let approxs =

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -40,7 +40,7 @@ val prepare_cmx_file_contents :
   used_value_slots:Value_slot.Set.t ->
   exported_offsets:Exported_offsets.t ->
   Exported_code.t ->
-  Flambda_cmx_format.t option
+  Name_occurrences.t * Flambda_cmx_format.t option
 
 val prepare_cmx_from_approx :
   approxs:Code_or_metadata.t Value_approximation.t Symbol.Map.t ->
@@ -48,4 +48,4 @@ val prepare_cmx_from_approx :
   exported_offsets:Exported_offsets.t ->
   used_value_slots:Value_slot.Set.t ->
   Exported_code.t ->
-  Flambda_cmx_format.t option
+  Name_occurrences.t * Flambda_cmx_format.t option

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -136,9 +136,9 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename:_ ~keep_symbol_tables
     in
     Compiler_hooks.execute Raw_flambda2 raw_flambda;
     print_rawflambda ppf raw_flambda;
-    let flambda, offsets, cmx, all_code =
+    let flambda, offsets, reachable_names, cmx, all_code =
       match mode, close_program_metadata with
-      | Classic, Classic (code, cmx, offsets) ->
+      | Classic, Classic (code, reachable_names, cmx, offsets) ->
         (if Flambda_features.inlining_report ()
         then
           let output_prefix = prefixname ^ ".cps_conv" in
@@ -146,10 +146,15 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename:_ ~keep_symbol_tables
             Inlining_report.output_then_forget_decisions ~output_prefix
           in
           Compiler_hooks.execute Inlining_tree inlining_tree);
-        raw_flambda, offsets, cmx, code
+        raw_flambda, offsets, reachable_names, cmx, code
       | Normal, Normal ->
         let round = 0 in
-        let { Simplify.unit = flambda; exported_offsets; cmx; all_code } =
+        let { Simplify.unit = flambda;
+              exported_offsets;
+              cmx;
+              all_code;
+              reachable_names
+            } =
           Profile.record_call ~accumulate:true "simplify" (fun () ->
               Simplify.run ~cmx_loader ~round raw_flambda)
         in
@@ -163,13 +168,15 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename:_ ~keep_symbol_tables
         Compiler_hooks.execute Flambda2 flambda;
         print_flambda "simplify" ppf flambda;
         print_flexpect "simplify" ppf ~raw_flambda flambda;
-        flambda, exported_offsets, cmx, all_code
+        flambda, exported_offsets, reachable_names, cmx, all_code
     in
     (match cmx with
     | None ->
       () (* Either opaque was passed, or there is no need to export offsets *)
     | Some cmx -> Compilenv.flambda2_set_export_info cmx);
-    let cmm = Flambda2_to_cmm.To_cmm.unit flambda ~all_code ~offsets in
+    let cmm =
+      Flambda2_to_cmm.To_cmm.unit flambda ~all_code ~offsets ~reachable_names
+    in
     if not keep_symbol_tables
     then (
       Compilenv.reset_info_tables ();

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -35,7 +35,10 @@ module VB = Bound_var
 type 'a close_program_metadata =
   | Normal : [`Normal] close_program_metadata
   | Classic :
-      (Exported_code.t * Flambda_cmx_format.t option * Exported_offsets.t)
+      (Exported_code.t
+      * Name_occurrences.t
+      * Flambda_cmx_format.t option
+      * Exported_offsets.t)
       -> [`Classic] close_program_metadata
 
 type 'a close_program_result = Flambda_unit.t * 'a close_program_metadata
@@ -2580,7 +2583,7 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode) ~big_endian
       Slot_offsets.finalize_offsets (Acc.slot_offsets acc) ~get_code_metadata
         ~used_slots
     in
-    let cmx =
+    let reachable_names, cmx =
       Flambda_cmx.prepare_cmx_from_approx ~approxs:symbols_approximations
         ~module_symbol ~exported_offsets ~used_value_slots all_code
     in
@@ -2589,4 +2592,4 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode) ~big_endian
         ~toplevel_my_region ~body ~module_symbol
         ~used_value_slots:(Known used_value_slots)
     in
-    unit, Classic (all_code, cmx, exported_offsets)
+    unit, Classic (all_code, reachable_names, cmx, exported_offsets)

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -73,7 +73,10 @@ val close_switch :
 type 'a close_program_metadata =
   | Normal : [`Normal] close_program_metadata
   | Classic :
-      (Exported_code.t * Flambda_cmx_format.t option * Exported_offsets.t)
+      (Exported_code.t
+      * Name_occurrences.t
+      * Flambda_cmx_format.t option
+      * Exported_offsets.t)
       -> [`Classic] close_program_metadata
 
 type 'a close_program_result = Flambda_unit.t * 'a close_program_metadata

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -20,7 +20,8 @@ type simplify_result =
   { cmx : Flambda_cmx_format.t option;
     unit : Flambda_unit.t;
     all_code : Exported_code.t;
-    exported_offsets : Exported_offsets.t
+    exported_offsets : Exported_offsets.t;
+    reachable_names : Name_occurrences.t
   }
 
 let run ~cmx_loader ~round unit =
@@ -97,7 +98,7 @@ let run ~cmx_loader ~round unit =
       in
       Slot_offsets.finalize_offsets slot_offsets ~get_code_metadata ~used_slots
   in
-  let cmx =
+  let reachable_names, cmx =
     Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
       ~used_value_slots ~exported_offsets all_code
   in
@@ -105,4 +106,4 @@ let run ~cmx_loader ~round unit =
     FU.create ~return_continuation ~exn_continuation ~toplevel_my_region
       ~module_symbol ~body ~used_value_slots:(Known used_value_slots)
   in
-  { cmx; unit; all_code; exported_offsets }
+  { cmx; unit; all_code; exported_offsets; reachable_names }

--- a/middle_end/flambda2/simplify/simplify.mli
+++ b/middle_end/flambda2/simplify/simplify.mli
@@ -24,7 +24,8 @@ type simplify_result = private
   { cmx : Flambda_cmx_format.t option;
     unit : Flambda_unit.t;
     all_code : Exported_code.t;
-    exported_offsets : Exported_offsets.t
+    exported_offsets : Exported_offsets.t;
+    reachable_names : Name_occurrences.t
   }
 
 val run :

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -50,8 +50,7 @@ let flush_cmm_helpers_state res =
   match Cmmgen_state.get_and_clear_data_items () with
   | [] ->
     let cst_map = Cmmgen_state.get_and_clear_constants () in
-    let _res, items = Misc.Stdlib.String.Map.fold aux cst_map (res, []) in
-    items
+    Misc.Stdlib.String.Map.fold aux cst_map (res, [])
   | _ ->
     Misc.fatal_errorf
       "There shouldn't be any data items in Cmmgen_state during Flambda 2 to \
@@ -133,7 +132,7 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
     C.cfunction (C.fundecl entry_sym [] body fun_codegen dbg Default_poll)
   in
   let { R.data_items; gc_roots; functions } = R.to_cmm res in
-  let cmm_helpers_data = flush_cmm_helpers_state res in
+  let _res, cmm_helpers_data = flush_cmm_helpers_state res in
   let gc_root_data = C.gc_root_table gc_roots in
   (gc_root_data :: data_items) @ cmm_helpers_data @ functions @ [entry]
 

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -34,7 +34,7 @@ end
    functions from Cmm_helpers which populate some mutable state in
    Cmmgen_state.) *)
 
-let flush_cmm_helpers_state res () =
+let flush_cmm_helpers_state res =
   let aux name cst (res, acc) =
     match (cst : Cmmgen_state.constant) with
     | Const_table (global, l) ->
@@ -50,7 +50,8 @@ let flush_cmm_helpers_state res () =
   match Cmmgen_state.get_and_clear_data_items () with
   | [] ->
     let cst_map = Cmmgen_state.get_and_clear_constants () in
-    Misc.Stdlib.String.Map.fold aux cst_map (res, [])
+    let _res, items = Misc.Stdlib.String.Map.fold aux cst_map (res, []) in
+    items
   | _ ->
     Misc.fatal_errorf
       "There shouldn't be any data items in Cmmgen_state during Flambda 2 to \
@@ -132,7 +133,7 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
     C.cfunction (C.fundecl entry_sym [] body fun_codegen dbg Default_poll)
   in
   let { R.data_items; gc_roots; functions } = R.to_cmm res in
-  let _res, cmm_helpers_data = flush_cmm_helpers_state res () in
+  let cmm_helpers_data = flush_cmm_helpers_state res in
   let gc_root_data = C.gc_root_table gc_roots in
   (gc_root_data :: data_items) @ cmm_helpers_data @ functions @ [entry]
 

--- a/middle_end/flambda2/to_cmm/to_cmm.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm.mli
@@ -17,6 +17,7 @@
 (** Translate a compilation unit. *)
 val unit :
   offsets:Exported_offsets.t ->
-  Flambda_unit.t ->
   all_code:Exported_code.t ->
+  reachable_names:Name_occurrences.t ->
+  Flambda_unit.t ->
   Cmm.phrase list

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -108,22 +108,22 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       then args @ [callee]
       else args
     in
-    let code_linkage_name = Code_id.linkage_name code_id in
+    let code_sym = To_cmm_result.symbol_of_code_id res code_id in
     match Apply.probe_name apply with
     | None ->
       ( C.direct_call ~dbg
           (C.Extended_machtype.to_machtype return_ty)
-          pos
-          (C.symbol_from_linkage_name ~dbg code_linkage_name)
-          args,
+          pos (C.symbol ~dbg code_sym) args,
         free_vars,
         env,
         res,
         Ece.all )
     | Some name ->
-      ( C.probe ~dbg ~name
-          ~handler_code_linkage_name:(Linkage_name.to_string code_linkage_name)
-          ~args
+      (* CR gbury: not sure how probes work, would probes work if the code_id is
+         referred to by a local symbol (i.e. assembler label) and not a global
+         symbol ? *)
+      assert (code_sym.sym_global = Cmm.Global);
+      ( C.probe ~dbg ~name ~handler_code_linkage_name:code_sym.sym_name ~args
         |> C.return_unit dbg,
         free_vars,
         env,
@@ -157,7 +157,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     fail_if_probe apply;
     let callee =
       match Simple.must_be_symbol callee_simple with
-      | Some (sym, _) -> Symbol.linkage_name sym |> Linkage_name.to_string
+      | Some (sym, _) -> (To_cmm_result.symbol res sym).sym_name
       | None ->
         Misc.fatal_errorf "Expected a function symbol instead of:@ %a"
           Simple.print callee_simple

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -26,6 +26,15 @@ type t
 (** Create a result structure. *)
 val create : module_symbol:Symbol.t -> t
 
+(** Create a cmm symbol *)
+val symbol : t -> Symbol.t -> Cmm.symbol
+
+(** TODO *)
+val symbol_of_code_id : t -> Code_id.t -> Cmm.symbol
+
+(** Create a new symbol *)
+val raw_symbol : t -> global:Cmm.is_global -> string -> t * Cmm.symbol
+
 (** Archive the current data into the list of already-translated data. *)
 val archive_data : t -> t
 
@@ -57,7 +66,7 @@ val invalid_message_symbol : t -> message:string -> Symbol.t option
 
 type result = private
   { data_items : Cmm.phrase list;
-    gc_roots : Symbol.t list;
+    gc_roots : Cmm.symbol list;
     functions : Cmm.phrase list
   }
 

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -24,7 +24,7 @@
 type t
 
 (** Create a result structure. *)
-val create : module_symbol:Symbol.t -> t
+val create : module_symbol:Symbol.t -> reachable_names:Name_occurrences.t -> t
 
 (** Create a cmm symbol *)
 val symbol : t -> Symbol.t -> Cmm.symbol

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -23,16 +23,20 @@
     subsequent use. *)
 type t
 
-(** Create a result structure. *)
+(** Create a result structure.
+
+    [reachable_names] specifies which names are reachable from outside the
+    compilation unit (same terminology as used in [Flambda_cmx]).
+*)
 val create : module_symbol:Symbol.t -> reachable_names:Name_occurrences.t -> t
 
-(** Create a cmm symbol *)
+(** Translate an existing [Symbol.t] to a Cmm symbol. *)
 val symbol : t -> Symbol.t -> Cmm.symbol
 
-(** TODO *)
+(** Produce the Cmm function symbol for a piece of code. *)
 val symbol_of_code_id : t -> Code_id.t -> Cmm.symbol
 
-(** Create a new symbol *)
+(** Create a Cmm symbol, not arising from a [Symbol.t]. *)
 val raw_symbol : t -> global:Cmm.is_global -> string -> t * Cmm.symbol
 
 (** Archive the current data into the list of already-translated data. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -103,23 +103,19 @@ let nativeint_of_targetint t =
   | Int32 i -> Nativeint.of_int32 i
   | Int64 i -> Int64.to_nativeint i
 
-let symbol_from_linkage_name ~dbg ln =
-  symbol_from_string ~dbg (Linkage_name.to_string ln)
-
-let symbol ~dbg sym = symbol_from_linkage_name ~dbg (Symbol.linkage_name sym)
-
 let name0 ?consider_inlining_effectful_expressions env res name =
   Name.pattern_match name
     ~var:(fun v ->
       To_cmm_env.inline_variable ?consider_inlining_effectful_expressions env
         res v)
     ~symbol:(fun s ->
+      let sym = To_cmm_result.symbol res s in
       (* CR mshinwell: fix debuginfo? *)
       To_cmm_env.
         { env;
           res;
           expr =
-            { cmm = symbol ~dbg:Debuginfo.none s;
+            { cmm = symbol ~dbg:Debuginfo.none sym;
               free_vars = Backend_var.Set.empty;
               effs = Ece.pure_can_be_duplicated
             }
@@ -152,12 +148,10 @@ let simple ?consider_inlining_effectful_expressions ~dbg env res s =
             }
         })
 
-let symbol_address s = symbol_address (Cmm.global_symbol s)
-
-let name_static name =
+let name_static res name =
   Name.pattern_match name
     ~var:(fun v -> `Var v)
-    ~symbol:(fun s -> `Data [symbol_address (Symbol.linkage_name_as_string s)])
+    ~symbol:(fun s -> `Data [symbol_address (To_cmm_result.symbol res s)])
 
 let const_static cst =
   match Reg_width_const.descr cst with
@@ -172,9 +166,9 @@ let const_static cst =
   | Naked_int64 i -> [cint (Int64.to_nativeint i)]
   | Naked_nativeint t -> [cint (nativeint_of_targetint t)]
 
-let simple_static s =
+let simple_static res s =
   Simple.pattern_match s
-    ~name:(fun n ~coercion:_ -> name_static n)
+    ~name:(fun n ~coercion:_ -> name_static res n)
     ~const:(fun c -> `Data (const_static c))
 
 let simple_list ?consider_inlining_effectful_expressions ~dbg env res l =
@@ -218,9 +212,7 @@ let invalid res ~message =
       in
       let res =
         Cmm_helpers.emit_string_constant
-          { sym_name = Symbol.linkage_name_as_string message_sym;
-            sym_global = Global
-          }
+          (To_cmm_result.symbol res message_sym)
           message []
         |> To_cmm_result.add_archive_data_items res
       in
@@ -233,7 +225,7 @@ let invalid res ~message =
   let call_expr =
     extcall ~dbg ~alloc:false ~is_c_builtin:false ~returns:false ~ty_args:[XInt]
       "caml_flambda2_invalid" Cmm.typ_void
-      [symbol ~dbg message_sym]
+      [symbol ~dbg (To_cmm_result.symbol res message_sym)]
   in
   call_expr, res
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -42,11 +42,6 @@ val tag_targetint : Targetint_32_64.t -> Targetint_32_64.t
 
 val nativeint_of_targetint : Targetint_32_64.t -> Nativeint.t
 
-val symbol_from_linkage_name :
-  dbg:Debuginfo.t -> Linkage_name.t -> Cmm.expression
-
-val symbol : dbg:Debuginfo.t -> Symbol.t -> Cmm.expression
-
 (** This does not inline effectful expressions. *)
 val name :
   To_cmm_env.t -> To_cmm_result.t -> Name.t -> To_cmm_env.translation_result
@@ -65,7 +60,9 @@ val simple :
   To_cmm_env.translation_result
 
 val simple_static :
-  Simple.t -> [`Data of Cmm.data_item list | `Var of Variable.t]
+  To_cmm_result.t ->
+  Simple.t ->
+  [`Data of Cmm.data_item list | `Var of Variable.t]
 
 (** This function translates the [Simple] at the head of the list first.
     Regarding [consider_inlining_effectful_expressions], see [simple] above. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -22,13 +22,9 @@ end
 module SC = Static_const
 module R = To_cmm_result
 
-let to_cmm_symbol sym : Cmm.symbol =
-  { sym_name = Symbol.linkage_name_as_string sym; sym_global = Global }
-
-let static_value v =
+let static_value res v =
   match (v : Field_of_static_block.t) with
-  | Symbol s ->
-    C.symbol_address (Symbol.linkage_name_as_string s |> Cmm.global_symbol)
+  | Symbol s -> C.symbol_address (R.symbol res s)
   | Dynamically_computed _ -> C.cint 1n
   | Tagged_immediate i ->
     C.cint
@@ -67,17 +63,16 @@ let rec static_float_array_updates symb env res acc i = function
 
 let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
     res updates =
-  let aux x cont = emit (to_cmm_symbol symbol) (transl x) cont in
+  let symbol = R.symbol res symbol in
+  let aux x cont = emit symbol (transl x) cont in
   let env, res, updates =
     match (v : _ Or_variable.t) with
     | Const c ->
       (* Add the const to the cmmgen_state structured constants table so that
          functions in cmm_helpers can short-circuit Unboxing of boxed constant
          symbols, particularly in Classic mode. *)
-      let symbol_name = Symbol.linkage_name_as_string symbol in
       let structured_constant = structured (transl c) in
-      Cmmgen_state.add_global_structured_constant symbol_name
-        structured_constant;
+      Cmmgen_state.add_structured_constant symbol structured_constant;
       env, res, updates
     | Var (v, dbg) ->
       C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symbol) v ~index:0
@@ -111,19 +106,19 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     (static_const : Static_const.t) =
   match bound_static, static_const with
   | Block_like s, Block (tag, _mut, fields) ->
+    let sym = R.symbol res s in
     let res = R.check_for_module_symbol res s in
     let tag = Tag.Scannable.to_int tag in
-    let block_name = to_cmm_symbol s in
     let header = C.black_block_header tag (List.length fields) in
     let static_fields =
       List.fold_right
         (fun v static_fields ->
-          let static_field = static_value v in
+          let static_field = static_value res v in
           static_field :: static_fields)
         fields []
     in
-    let block = C.emit_block block_name header static_fields in
-    let env, res, updates = static_block_updates s env res updates 0 fields in
+    let block = C.emit_block sym header static_fields in
+    let env, res, updates = static_block_updates sym env res updates 0 fields in
     env, R.set_data res block, updates
   | Set_of_closures closure_symbols, Set_of_closures set_of_closures ->
     let res, updates, env =
@@ -170,33 +165,32 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
         ~f:Numeric_types.Float_by_bit_pattern.to_float
     in
     let static_fields = List.map aux fields in
-    let float_array =
-      C.emit_float_array_constant (to_cmm_symbol s) static_fields
-    in
-    let env, res, e = static_float_array_updates s env res updates 0 fields in
+    let sym = R.symbol res s in
+    let float_array = C.emit_float_array_constant sym static_fields in
+    let env, res, e = static_float_array_updates sym env res updates 0 fields in
     env, R.update_data res float_array, e
   | Block_like s, Immutable_value_array fields ->
-    let block_name = to_cmm_symbol s in
+    let sym = R.symbol res s in
     let header = C.black_block_header 0 (List.length fields) in
     let static_fields =
       List.fold_right
         (fun v static_fields ->
-          let static_field = static_value v in
+          let static_field = static_value res v in
           static_field :: static_fields)
         fields []
     in
-    let block = C.emit_block block_name header static_fields in
-    let env, res, updates = static_block_updates s env res updates 0 fields in
+    let block = C.emit_block sym header static_fields in
+    let env, res, updates = static_block_updates sym env res updates 0 fields in
     env, R.set_data res block, updates
   | Block_like s, Empty_array ->
     (* Recall: empty arrays have tag zero, even if their kind is naked float. *)
-    let block_name = to_cmm_symbol s in
+    let sym = R.symbol res s in
     let header = C.black_block_header 0 0 in
-    let block = C.emit_block block_name header [] in
+    let block = C.emit_block sym header [] in
     env, R.set_data res block, updates
   | Block_like s, Mutable_string { initial_value = str }
   | Block_like s, Immutable_string str ->
-    let data = C.emit_string_constant (to_cmm_symbol s) str in
+    let data = C.emit_string_constant (R.symbol res s) str in
     env, R.update_data res data, updates
   | Block_like _, Set_of_closures _ ->
     Misc.fatal_errorf


### PR DESCRIPTION
This builds on top of #1222 .

The first commit adds some useful printing functions, as well as prefix all symbols in the cmm output to indicate whether the symbol is global or local (which is extremely helpful for debugging, as most of the bugs I've come across were because the same symbol was declared and used with different "localities").

The second commit centralizes the handling of symbols in `to_cmm`. Basically, after this commit, all cmm symbols are now generated in `to_cmm_result.ml`, and there should not be anywhere that still uses `strings` for symbols (instead using either an flambda `Symbol.t` or a `Cmm.symbol` created by the appropriate function in `to_cmm_result.ml`).

Finally, the third commit uses the name occurrences that are computed during cmx file preparation to decide which symbols should be local. The exact criterion is to use local cmm symbols for symbols from the current compilation unit, and that do not appear in the reachable names.