### PR TITLE
Bump buffer size to avoid gcc warning

### DIFF
--- a/ocaml/runtime/unix.c
+++ b/ocaml/runtime/unix.c
@@ -445,7 +445,7 @@ void caml_print_timestamp(FILE* channel, int formatted)
     fprintf(channel, "%ld.%06d ", (long)tv.tv_sec, (int)tv.tv_usec);
   } else {
     struct tm tm;
-    char tz[10] = "Z";
+    char tz[64] = "Z";
     localtime_r(&tv.tv_sec, &tm);
     if (tm.tm_gmtoff != 0) {
       long tzhour = tm.tm_gmtoff / 60 / 60;


### PR DESCRIPTION
Recent GCC warns about the small buffer size used to format the timezone offset in #1229. This patch makes it big enough to avoid the warning.