### PR TITLE
Add debug option for flambda2

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -16,6 +16,12 @@
 let format_default flag = if flag then " (default)" else ""
 let format_not_default flag = if flag then "" else " (default)"
 
+let mk_flambda2_debug f =
+  "-flambda2-debug", Arg.Unit f, " Enable debug output for the Flambda2 pass"
+
+let mk_no_flambda2_debug f =
+  "-no-flambda2-debug", Arg.Unit f, " Disable debug ouput for the flambda2 pass"
+
 let mk_ocamlcfg f =
   "-ocamlcfg", Arg.Unit f, " Use ocamlcfg"
 
@@ -511,6 +517,8 @@ module type Flambda_backend_options = sig
 
   val gc_timings : unit -> unit
 
+  val flambda2_debug : unit -> unit
+  val no_flambda2_debug : unit -> unit
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
   val flambda2_result_types_functors_only : unit -> unit
@@ -599,6 +607,8 @@ struct
 
     mk_gc_timings F.gc_timings;
 
+    mk_flambda2_debug F.flambda2_debug;
+    mk_no_flambda2_debug F.no_flambda2_debug;
     mk_flambda2_join_points F.flambda2_join_points;
     mk_no_flambda2_join_points F.no_flambda2_join_points;
     mk_flambda2_result_types_functors_only
@@ -725,6 +735,8 @@ module Flambda_backend_options_impl = struct
 
   let gc_timings = set' Flambda_backend_flags.gc_timings
 
+  let flambda2_debug = set' Flambda_backend_flags.Flambda2.debug
+  let no_flambda2_debug = clear' Flambda_backend_flags.Flambda2.debug
   let flambda2_join_points = set Flambda2.join_points
   let no_flambda2_join_points = clear Flambda2.join_points
   let flambda2_result_types_functors_only () =
@@ -940,6 +952,7 @@ module Extra_params = struct
     | "dasm-comments" -> set' Flambda_backend_flags.dasm_comments
     | "gupstream-dwarf" -> set' Debugging.restrict_to_upstream_dwarf
     | "gstartup" -> set' Debugging.dwarf_for_startup_file
+    | "flambda2-debug" -> set' Flambda_backend_flags.Flambda2.debug
     | "flambda2-join-points" -> set Flambda2.join_points
     | "flambda2-result-types" ->
       (match String.lowercase_ascii v with

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -20,7 +20,7 @@ let mk_flambda2_debug f =
   "-flambda2-debug", Arg.Unit f, " Enable debug output for the Flambda2 pass"
 
 let mk_no_flambda2_debug f =
-  "-no-flambda2-debug", Arg.Unit f, " Disable debug ouput for the flambda2 pass"
+  "-no-flambda2-debug", Arg.Unit f, " Disable debug ouput for the Flambda2 pass"
 
 let mk_ocamlcfg f =
   "-ocamlcfg", Arg.Unit f, " Use ocamlcfg"

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -20,7 +20,7 @@ let mk_flambda2_debug f =
   "-flambda2-debug", Arg.Unit f, " Enable debug output for the Flambda2 pass"
 
 let mk_no_flambda2_debug f =
-  "-no-flambda2-debug", Arg.Unit f, " Disable debug ouput for the Flambda2 pass"
+  "-no-flambda2-debug", Arg.Unit f, " Disable debug output for the Flambda2 pass"
 
 let mk_ocamlcfg f =
   "-ocamlcfg", Arg.Unit f, " Use ocamlcfg"

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -49,6 +49,8 @@ module type Flambda_backend_options = sig
 
   val gc_timings : unit -> unit
 
+  val flambda2_debug : unit -> unit
+  val no_flambda2_debug : unit -> unit
   val flambda2_join_points : unit -> unit
   val no_flambda2_join_points : unit -> unit
   val flambda2_result_types_functors_only : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -58,6 +58,16 @@ let flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3 =
   | Set O3 -> o3
 
 module Flambda2 = struct
+  let debug = (* -flambda2-debug *)
+    let default =
+      match Sys.getenv "FLAMBDA2_DEBUG" with
+      | exception Not_found -> false
+      | "n" | "no" | "false" | "0" -> false
+      | "y" | "yes" | "true" | "1" -> true
+      | _ -> (* CR gbury: error out ? *) true
+    in
+    ref default
+
   module Default = struct
     let classic_mode = false
     let join_points = false

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -58,15 +58,7 @@ let flags_by_opt_level ~opt_level ~default ~oclassic ~o2 ~o3 =
   | Set O3 -> o3
 
 module Flambda2 = struct
-  let debug = (* -flambda2-debug *)
-    let default =
-      match Sys.getenv "FLAMBDA2_DEBUG" with
-      | exception Not_found -> false
-      | "n" | "no" | "false" | "0" -> false
-      | "y" | "yes" | "true" | "1" -> true
-      | _ -> (* CR gbury: error out ? *) true
-    in
-    ref default
+  let debug = ref false (* -flambda2-debug *)
 
   module Default = struct
     let classic_mode = false

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -48,6 +48,8 @@ val internal_assembler : bool ref
 val gc_timings : bool ref
 
 module Flambda2 : sig
+  val debug : bool ref
+
   module Default : sig
     val classic_mode : bool
     val join_points : bool

--- a/middle_end/flambda2/identifiers/continuation.ml
+++ b/middle_end/flambda2/identifiers/continuation.ml
@@ -114,9 +114,16 @@ let reset () = initialise ()
 
 let create ?sort ?name () : t =
   let sort = Option.value sort ~default:Sort.Normal_or_exn in
-  let name = Option.value name ~default:"k" in
   let compilation_unit = Compilation_unit.get_current_exn () in
   let name_stamp = next_stamp () in
+  let name =
+    let default =
+      if Flambda_features.debug_flambda2 ()
+      then Format.asprintf "k%d" name_stamp
+      else "k"
+    in
+    Option.value name ~default
+  in
   let data : Data.t = { compilation_unit; name; name_stamp; sort } in
   Table.add !grand_table_of_continuations data
 

--- a/middle_end/flambda2/simplify/simplify_import.ml
+++ b/middle_end/flambda2/simplify/simplify_import.ml
@@ -14,6 +14,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+let debug = Flambda_features.debug_flambda2
+
 module Apply = Flambda.Apply
 module Apply_cont = Flambda.Apply_cont
 module Code = Code

--- a/middle_end/flambda2/simplify/simplify_import.mli
+++ b/middle_end/flambda2/simplify/simplify_import.mli
@@ -14,6 +14,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+val debug : unit -> bool
+
 module Apply = Flambda.Apply
 module Apply_cont = Flambda.Apply_cont
 module Code = Code

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -14,6 +14,8 @@
 
 let flambda2_is_enabled () = Clflags.is_flambda2 ()
 
+let debug_flambda2 () = !Flambda_backend_flags.Flambda2.debug
+
 let with_default (r : 'a Flambda_backend_flags.or_default)
     ~(f : Flambda_backend_flags.Flambda2.flags -> 'a) =
   match r with

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -14,6 +14,8 @@
 
 val flambda2_is_enabled : unit -> bool
 
+val debug_flambda2 : unit -> bool
+
 type 'a mode =
   | Normal : [`Normal] mode
   | Classic : [`Classic] mode


### PR DESCRIPTION
This PR adds a debug option for flambda2. This option can be used either via a CLI flag `-flamdba2-debug` or via en env variable `FLAMBDA2_DEBUG`.

Currently, setting this to `true` only gives unique names to every continuation, which makes it a lot easier to follow what happens to which continuation.

Additionally, `Simplify_import` now defines the `debug ()` function, that can be used in code to add debugging statements such as `if debug () then Format.eprintf ....`, which happens quite a lot in my experience.