### PR TITLE
Add all function and value slots to Closure_approximation

### DIFF
--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -23,6 +23,7 @@ type 'code t =
   | Closure_approximation of
       { code_id : Code_id.t;
         function_slot : Function_slot.t;
+        value_slots : Value_slot.Set.t;
         code : 'code;
         symbol : Symbol.t option
       }

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -23,7 +23,8 @@ type 'code t =
   | Closure_approximation of
       { code_id : Code_id.t;
         function_slot : Function_slot.t;
-        value_slots : Value_slot.Set.t;
+        all_function_slots : Function_slot.Set.t;
+        all_value_slots : Value_slot.Set.t;
         code : 'code;
         symbol : Symbol.t option
       }

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1542,12 +1542,21 @@ let close_functions acc external_env ~current_region function_declarations =
             ~loopify:Never_loopify
         in
         let code = Code_or_metadata.create_metadata_only metadata in
-        let value_slots =
+        let all_function_slots =
+          Ident.Map.data function_slots_from_idents |> Function_slot.Set.of_list
+        in
+        let all_value_slots =
           Ident.Map.data value_slots_from_idents |> Value_slot.Set.of_list
         in
         let approx =
           Value_approximation.Closure_approximation
-            { code_id; function_slot; value_slots; code; symbol = None }
+            { code_id;
+              function_slot;
+              all_function_slots;
+              all_value_slots;
+              code;
+              symbol = None
+            }
         in
         Function_slot.Map.add function_slot approx approx_map)
       Function_slot.Map.empty func_decl_list
@@ -1563,11 +1572,18 @@ let close_functions acc external_env ~current_region function_declarations =
           let approx =
             match Function_slot.Map.find function_slot approx_map with
             | Value_approximation.Closure_approximation
-                { code_id; function_slot; value_slots; code; symbol = _ } ->
+                { code_id;
+                  function_slot;
+                  all_function_slots;
+                  all_value_slots;
+                  code;
+                  symbol = _
+                } ->
               Value_approximation.Closure_approximation
                 { code_id;
                   function_slot;
-                  value_slots;
+                  all_function_slots;
+                  all_value_slots;
                   code;
                   symbol = Some symbol
                 }
@@ -1635,10 +1651,14 @@ let close_functions acc external_env ~current_region function_declarations =
         let code_id =
           Code_metadata.code_id (Code_or_metadata.code_metadata code)
         in
+        let all_function_slots =
+          Function_slot.Lmap.keys funs |> Function_slot.Set.of_list
+        in
         Value_approximation.Closure_approximation
           { code_id;
             function_slot;
-            value_slots = Value_slot.Map.keys value_slots;
+            all_function_slots;
+            all_value_slots = Value_slot.Map.keys value_slots;
             code;
             symbol = None
           })
@@ -1663,9 +1683,21 @@ let close_functions acc external_env ~current_region function_declarations =
           let approx =
             match Function_slot.Map.find function_slot approximations with
             | Value_approximation.Closure_approximation
-                { code_id; function_slot; value_slots; code; symbol = _ } ->
+                { code_id;
+                  function_slot;
+                  all_function_slots;
+                  all_value_slots;
+                  code;
+                  symbol = _
+                } ->
               Value_approximation.Closure_approximation
-                { code_id; function_slot; value_slots; code; symbol = Some sym }
+                { code_id;
+                  function_slot;
+                  all_function_slots;
+                  all_value_slots;
+                  code;
+                  symbol = Some sym
+                }
             | _ -> assert false
             (* see above *)
           in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -370,7 +370,13 @@ module Acc = struct
             let approxs = Array.map filter_inlinable approxs in
             Value_approximation.Block_approximation (approxs, alloc_mode)
           | Closure_approximation
-              { code_id; function_slot; value_slots; code; _ } -> (
+              { code_id;
+                function_slot;
+                all_function_slots;
+                all_value_slots;
+                code;
+                _
+              } -> (
             let metadata = Code_or_metadata.code_metadata code in
             if not (Code_or_metadata.code_present code)
             then approx
@@ -387,7 +393,8 @@ module Acc = struct
                 Value_approximation.Closure_approximation
                   { code_id;
                     function_slot;
-                    value_slots;
+                    all_function_slots;
+                    all_value_slots;
                     code = Code_or_metadata.create_metadata_only metadata;
                     symbol = None
                   })

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -369,7 +369,8 @@ module Acc = struct
           | Block_approximation (approxs, alloc_mode) ->
             let approxs = Array.map filter_inlinable approxs in
             Value_approximation.Block_approximation (approxs, alloc_mode)
-          | Closure_approximation { code_id; function_slot; code; _ } -> (
+          | Closure_approximation
+              { code_id; function_slot; value_slots; code; _ } -> (
             let metadata = Code_or_metadata.code_metadata code in
             if not (Code_or_metadata.code_present code)
             then approx
@@ -386,6 +387,7 @@ module Acc = struct
                 Value_approximation.Closure_approximation
                   { code_id;
                     function_slot;
+                    value_slots;
                     code = Code_or_metadata.create_metadata_only metadata;
                     symbol = None
                   })

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1189,19 +1189,35 @@ end = struct
         MTC.immutable_block ~is_unique:false Tag.zero
           ~field_kind:Flambda_kind.value ~fields alloc_mode
       | Closure_approximation
-          { code_id; function_slot; value_slots; code = _; symbol = _ } ->
+          { code_id;
+            function_slot;
+            all_function_slots;
+            all_value_slots;
+            code = _;
+            symbol = _
+          } ->
         (* CR keryan: we should use the associated symbol at some point *)
         let fun_decl =
           TG.Function_type.create code_id
             ~rec_info:(TG.this_rec_info Rec_info_expr.initial)
         in
         let all_function_slots_in_set =
-          Function_slot.Map.singleton function_slot
-            (Or_unknown_or_bottom.Ok fun_decl)
+          Function_slot.Set.fold
+            (fun function_slot' all_function_slots_in_set ->
+              Function_slot.Map.add function_slot'
+                (if Function_slot.equal function_slot function_slot'
+                then Or_unknown_or_bottom.Ok fun_decl
+                else Or_unknown_or_bottom.Unknown)
+                all_function_slots_in_set)
+            all_function_slots Function_slot.Map.empty
         in
         let all_closure_types_in_set =
-          Function_slot.Map.singleton function_slot
-            (MTC.unknown Flambda_kind.value)
+          Function_slot.Set.fold
+            (fun function_slot all_closure_types_in_set ->
+              Function_slot.Map.add function_slot
+                (MTC.unknown Flambda_kind.value)
+                all_closure_types_in_set)
+            all_function_slots Function_slot.Map.empty
         in
         let all_value_slots_in_set =
           Value_slot.Set.fold
@@ -1210,7 +1226,7 @@ end = struct
                 (MTC.unknown
                    (Flambda_kind.With_subkind.kind (Value_slot.kind value_slot)))
                 all_value_slots_in_set)
-            value_slots Value_slot.Map.empty
+            all_value_slots Value_slot.Map.empty
         in
         MTC.exactly_this_closure function_slot ~all_function_slots_in_set
           ~all_closure_types_in_set ~all_value_slots_in_set
@@ -1316,7 +1332,10 @@ end = struct
                 Closure_approximation
                   { code_id;
                     function_slot;
-                    value_slots = Set_of_closures_contents.value_slots contents;
+                    all_function_slots =
+                      Set_of_closures_contents.closures contents;
+                    all_value_slots =
+                      Set_of_closures_contents.value_slots contents;
                     code = code_or_meta;
                     symbol = None
                   }))

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1188,8 +1188,8 @@ end = struct
         let fields = List.map type_from_approx (Array.to_list fields) in
         MTC.immutable_block ~is_unique:false Tag.zero
           ~field_kind:Flambda_kind.value ~fields alloc_mode
-      | Closure_approximation { code_id; function_slot; code = _; symbol = _ }
-        ->
+      | Closure_approximation
+          { code_id; function_slot; value_slots; code = _; symbol = _ } ->
         (* CR keryan: we should use the associated symbol at some point *)
         let fun_decl =
           TG.Function_type.create code_id
@@ -1203,7 +1203,15 @@ end = struct
           Function_slot.Map.singleton function_slot
             (MTC.unknown Flambda_kind.value)
         in
-        let all_value_slots_in_set = Value_slot.Map.empty in
+        let all_value_slots_in_set =
+          Value_slot.Set.fold
+            (fun value_slot all_value_slots_in_set ->
+              Value_slot.Map.add value_slot
+                (MTC.unknown
+                   (Flambda_kind.With_subkind.kind (Value_slot.kind value_slot)))
+                all_value_slots_in_set)
+            value_slots Value_slot.Map.empty
+        in
         MTC.exactly_this_closure function_slot ~all_function_slots_in_set
           ~all_closure_types_in_set ~all_value_slots_in_set
           (Alloc_mode.For_types.unknown ())
@@ -1296,7 +1304,7 @@ end = struct
           | Closures { by_function_slot; alloc_mode = _ } -> (
             match TG.Row_like_for_closures.get_singleton by_function_slot with
             | None -> Value_unknown
-            | Some ((function_slot, _contents), closures_entry) -> (
+            | Some ((function_slot, contents), closures_entry) -> (
               match
                 TG.Closures_entry.find_function_type closures_entry
                   function_slot
@@ -1306,8 +1314,12 @@ end = struct
                 let code_id = TG.Function_type.code_id function_type in
                 let code_or_meta = find_code code_id in
                 Closure_approximation
-                  { code_id; function_slot; code = code_or_meta; symbol = None }
-              ))
+                  { code_id;
+                    function_slot;
+                    value_slots = Set_of_closures_contents.value_slots contents;
+                    code = code_or_meta;
+                    symbol = None
+                  }))
           | Variant { immediates = Unknown; blocks = _; is_unique = _ }
           | Variant { immediates = _; blocks = Unknown; is_unique = _ } ->
             Value_unknown


### PR DESCRIPTION
At present no value slots are exported in classic mode closure approximations.  This can cause failures when inlining a function generated in classic mode into a file being compiled with Simplify.  When any `Project_value_slot` operations are found operating on the closure of the function being inlined, the types will show exactly no value slots are present, causing `Invalid`.  This PR aims to fix that by propagating the set of value slots.