### PR TITLE
Fix dependencies for regenerating Flambda2 parser, tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,22 +98,22 @@ check-fmt:
 	fi
 
 .PHONY: regen-flambda2-parser
-regen-flambda2-parser:
-	$(dune) build $(ws_main) @middle_end/flambda2/parser/regen --auto-promote || true
+regen-flambda2-parser: $(dune_config_targets)
+	$(dune) build $(ws_boot) @middle_end/flambda2/parser/regen --auto-promote || true
 # Make sure regeneration is idempotent, and also check that the previous step
 # worked (can't tell the difference between failure and successful
 # auto-promotion)
-	$(dune) build $(ws_main) @middle_end/flambda2/parser/regen
+	$(dune) build $(ws_boot) @middle_end/flambda2/parser/regen
 
 .PHONY: regen-flambda2-tests
-regen-flambda2-tests: runtime-stdlib # Need to build this first for some reason
-	$(dune) build $(ws_main) \
+regen-flambda2-tests: boot-compiler regen-flambda2-test-dune-rules
+	$(dune) build $(ws_runstd) \
 	  @middle_end/flambda2/tests/regen --auto-promote || true
-	$(dune) build $(ws_main) \
+	$(dune) build $(ws_runstd) \
 	  @middle_end/flambda2/tests/regen
 
 .PHONY: regen-flambda2-test-dune-rules
-regen-flambda2-test-dune-rules: runtime-stdlib
+regen-flambda2-test-dune-rules: $(dune_config_targets)
 	$(dune) build $(ws_boot) \
 	  @middle_end/flambda2/tests/regen-dune-rules --auto-promote || true
 	$(dune) build $(ws_boot) \

--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -95,11 +95,16 @@ duneconf/%.ws:
 $(ocamldir)/duneconf/dirs-to-ignore.inc:
 	echo "(data_only_dirs yacc $(ocaml_subdirs_to_ignore))" > $@
 
-_build/_bootinstall: Makefile.config duneconf/boot.ws duneconf/runtime_stdlib.ws duneconf/main.ws \
-	$(ocamldir)/duneconf/dirs-to-ignore.inc \
-	$(ocamldir)/duneconf/jst-extra.inc \
-	dune-project
+# Targets that should be prerequisites to any target that runs Dune
+dune_config_targets = \
+  duneconf/boot.ws \
+  duneconf/runtime_stdlib.ws \
+  duneconf/main.ws \
+  $(ocamldir)/duneconf/dirs-to-ignore.inc \
+  $(ocamldir)/duneconf/jst-extra.inc \
+  dune-project
 
+_build/_bootinstall: Makefile.config $(dune_config_targets)
 	echo -n '$(NATDYNLINKOPTS)' > $(ocamldir)/otherlibs/dynlink/natdynlinkops
 
 # flags.sexp


### PR DESCRIPTION
`make regen-flambda2-{parser,tests,test-dune-rules}` now work immediately after `./configure` and have minimal dependencies. Also, `make regen-flambda2-tests` automatically does `make regen-flambda2-test-dune-rules` so that you don't need to run both.