### PR TITLE
Improvements for closure types

### DIFF
--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -23,8 +23,6 @@ type 'code t =
   | Closure_approximation of
       { code_id : Code_id.t;
         function_slot : Function_slot.t;
-        all_function_slots : Function_slot.Set.t;
-        all_value_slots : Value_slot.Set.t;
         code : 'code;
         symbol : Symbol.t option
       }
@@ -67,14 +65,7 @@ let rec free_names ~code_free_names approx =
       (fun names approx ->
         Name_occurrences.union names (free_names ~code_free_names approx))
       Name_occurrences.empty approxs
-  | Closure_approximation
-      { code_id;
-        function_slot;
-        all_function_slots;
-        all_value_slots;
-        code;
-        symbol
-      } ->
+  | Closure_approximation { code_id; function_slot; code; symbol } ->
     let free_names = code_free_names code in
     let free_names =
       match symbol with
@@ -84,16 +75,4 @@ let rec free_names ~code_free_names approx =
     let free_names =
       Name_occurrences.add_code_id free_names code_id Name_mode.normal
     in
-    let free_names =
-      Name_occurrences.add_function_slot_in_types free_names function_slot
-    in
-    let free_names =
-      Function_slot.Set.fold
-        (fun function_slot free_names ->
-          Name_occurrences.add_function_slot_in_types free_names function_slot)
-        all_function_slots free_names
-    in
-    Value_slot.Set.fold
-      (fun value_slot free_names ->
-        Name_occurrences.add_value_slot_in_types free_names value_slot)
-      all_value_slots free_names
+    Name_occurrences.add_function_slot_in_types free_names function_slot

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -23,8 +23,6 @@ type 'code t =
   | Closure_approximation of
       { code_id : Code_id.t;
         function_slot : Function_slot.t;
-        all_function_slots : Function_slot.Set.t;
-        all_value_slots : Value_slot.Set.t;
         code : 'code;
         symbol : Symbol.t option
       }

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2626,23 +2626,9 @@ let close_functions acc external_env ~current_region function_declarations =
             ~loopify:Never_loopify
         in
         let code = Code_or_metadata.create_metadata_only metadata in
-        (* CR ncourant: do we need to add the unboxed function slot to the
-           approx map? *)
-        let all_function_slots =
-          Ident.Map.data function_slots_from_idents |> Function_slot.Set.of_list
-        in
-        let all_value_slots =
-          Ident.Map.data value_slots_from_idents |> Value_slot.Set.of_list
-        in
         let approx =
           Value_approximation.Closure_approximation
-            { code_id;
-              function_slot;
-              all_function_slots;
-              all_value_slots;
-              code;
-              symbol = None
-            }
+            { code_id; function_slot; code; symbol = None }
         in
         Function_slot.Map.add function_slot approx approx_map)
       Function_slot.Map.empty func_decl_list
@@ -2658,21 +2644,9 @@ let close_functions acc external_env ~current_region function_declarations =
           let approx =
             match Function_slot.Map.find function_slot approx_map with
             | Value_approximation.Closure_approximation
-                { code_id;
-                  function_slot;
-                  all_function_slots;
-                  all_value_slots;
-                  code;
-                  symbol = _
-                } ->
+                { code_id; function_slot; code; symbol = _ } ->
               Value_approximation.Closure_approximation
-                { code_id;
-                  function_slot;
-                  all_function_slots;
-                  all_value_slots;
-                  code;
-                  symbol = Some symbol
-                }
+                { code_id; function_slot; code; symbol = Some symbol }
             | _ -> assert false
             (* see above *)
           in
@@ -2733,17 +2707,8 @@ let close_functions acc external_env ~current_region function_declarations =
         let code_id =
           Code_metadata.code_id (Code_or_metadata.code_metadata code)
         in
-        let all_function_slots =
-          Function_slot.Lmap.keys funs |> Function_slot.Set.of_list
-        in
         Value_approximation.Closure_approximation
-          { code_id;
-            function_slot;
-            all_function_slots;
-            all_value_slots = Value_slot.Map.keys value_slots;
-            code;
-            symbol = None
-          })
+          { code_id; function_slot; code; symbol = None })
       approximations
   in
   let set_of_closures =
@@ -2765,21 +2730,9 @@ let close_functions acc external_env ~current_region function_declarations =
           let approx =
             match Function_slot.Map.find function_slot approximations with
             | Value_approximation.Closure_approximation
-                { code_id;
-                  function_slot;
-                  all_function_slots;
-                  all_value_slots;
-                  code;
-                  symbol = _
-                } ->
+                { code_id; function_slot; code; symbol = _ } ->
               Value_approximation.Closure_approximation
-                { code_id;
-                  function_slot;
-                  all_function_slots;
-                  all_value_slots;
-                  code;
-                  symbol = Some sym
-                }
+                { code_id; function_slot; code; symbol = Some sym }
             | _ -> assert false
             (* see above *)
           in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -414,14 +414,7 @@ module Acc = struct
             let approxs = Array.map filter_inlinable approxs in
             Value_approximation.Block_approximation
               (tag, shape, approxs, alloc_mode)
-          | Closure_approximation
-              { code_id;
-                function_slot;
-                all_function_slots;
-                all_value_slots;
-                code;
-                _
-              } -> (
+          | Closure_approximation { code_id; function_slot; code; _ } -> (
             let metadata = Code_or_metadata.code_metadata code in
             if not (Code_or_metadata.code_present code)
             then approx
@@ -438,8 +431,6 @@ module Acc = struct
                 Value_approximation.Closure_approximation
                   { code_id;
                     function_slot;
-                    all_function_slots;
-                    all_value_slots;
                     code = Code_or_metadata.create_metadata_only metadata;
                     symbol = None
                   })

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -216,6 +216,38 @@ let exactly_this_closure function_slot ~all_function_slots_in_set:function_types
   in
   TG.create_closures alloc_mode by_function_slot
 
+let static_closure_with_this_code ~this_function_slot ~closure_symbol ~code_id =
+  let function_types =
+    let function_type =
+      TG.Function_type.create code_id ~rec_info:(unknown K.rec_info)
+    in
+    Function_slot.Map.singleton this_function_slot
+      (Or_unknown_or_bottom.Ok function_type)
+  in
+  let closure_types =
+    let closure_type =
+      match closure_symbol with
+      | Some symbol -> TG.alias_type_of K.value (Simple.symbol symbol)
+      | None -> unknown K.value
+    in
+    TG.Product.Function_slot_indexed.create
+      (Function_slot.Map.singleton this_function_slot closure_type)
+  in
+  let closures_entry =
+    TG.Closures_entry.create ~function_types ~closure_types
+      ~value_slot_types:TG.Product.Value_slot_indexed.top
+  in
+  let by_function_slot =
+    let set_of_closures_contents =
+      Set_of_closures_contents.create
+        (Function_slot.Set.singleton this_function_slot)
+        Value_slot.Set.empty
+    in
+    TG.Row_like_for_closures.create_at_least this_function_slot
+      set_of_closures_contents closures_entry
+  in
+  TG.create_closures (Alloc_mode.For_types.unknown ()) by_function_slot
+
 let closure_with_at_least_these_function_slots ~this_function_slot
     function_slots_and_bindings =
   let function_slot_components_by_index =

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -142,6 +142,12 @@ val closure_with_at_least_these_function_slots :
   Simple.t Function_slot.Map.t ->
   Type_grammar.t
 
+val static_closure_with_this_code :
+  this_function_slot:Function_slot.t ->
+  closure_symbol:Symbol.t option ->
+  code_id:Code_id.t ->
+  Type_grammar.t
+
 val closure_with_at_least_these_value_slots :
   this_function_slot:Function_slot.t ->
   (Variable.t * Flambda_kind.With_subkind.t) Value_slot.Map.t ->

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -2503,9 +2503,9 @@ module Closures_entry = struct
   let create ~function_types ~closure_types ~value_slot_types =
     { function_types; closure_types; value_slot_types }
 
-  let find_function_type t function_slot : _ Or_unknown_or_bottom.t =
+  let find_function_type t ~exact function_slot : _ Or_unknown_or_bottom.t =
     match Function_slot.Map.find function_slot t.function_types with
-    | exception Not_found -> Bottom
+    | exception Not_found -> if exact then Bottom else Unknown
     | func_decl -> func_decl
 
   let value_slot_types { value_slot_types; _ } =
@@ -2836,62 +2836,56 @@ module Row_like_for_closures = struct
     (* CR-someday mshinwell: add invariant check? *)
     { known_closures; other_closures }
 
-  let get_singleton { known_closures; other_closures } =
+  type get_single_tag_result =
+    | No_singleton
+    | Exact_closure of Function_slot.t * closures_entry
+    | Incomplete_closure of Function_slot.t * closures_entry
+
+  let get_single_tag { known_closures; other_closures } : get_single_tag_result
+      =
     match other_closures with
-    | Ok _ -> None
+    | Ok _ -> No_singleton
     | Bottom -> (
       match Function_slot.Map.get_singleton known_closures with
-      | None -> None
+      | None -> No_singleton
       | Some (tag, { maps_to; index; env_extension = _ }) -> (
         (* If this is a singleton all the information from the env_extension is
            already part of the environment *)
         match index.domain with
-        | At_least _ -> None
-        | Known index -> Some ((tag, index), maps_to)))
+        | At_least index ->
+          if Function_slot.Set.mem tag (Set_of_closures_contents.closures index)
+          then Incomplete_closure (tag, maps_to)
+          else No_singleton
+        | Known index ->
+          if Function_slot.Set.mem tag (Set_of_closures_contents.closures index)
+          then Exact_closure (tag, maps_to)
+          else
+            Misc.fatal_errorf
+              "Function slot %a not bound in Known closure type with contents \
+               %a"
+              Function_slot.print tag Set_of_closures_contents.print index))
 
   let get_closure t function_slot : _ Or_unknown.t =
-    match get_singleton t with
-    | None -> Unknown
-    | Some ((_tag, index), maps_to) ->
-      if not
-           (Function_slot.Set.mem function_slot
-              (Set_of_closures_contents.closures index))
-      then Unknown
-      else
-        let closure_ty =
-          try
-            Function_slot.Map.find function_slot
-              maps_to.closure_types.function_slot_components_by_index
-          with Not_found ->
-            Misc.fatal_errorf
-              "Function slot %a is bound in index but not in maps_to@.Index:@ \
-               %a@.Maps_to:@ %a"
-              Function_slot.print function_slot Set_of_closures_contents.print
-              index print_closures_entry maps_to
-        in
-        Known closure_ty
+    match get_single_tag t with
+    | No_singleton -> Unknown
+    | Exact_closure (_tag, maps_to) | Incomplete_closure (_tag, maps_to) -> (
+      match
+        Function_slot.Map.find_opt function_slot
+          maps_to.closure_types.function_slot_components_by_index
+      with
+      | None -> Unknown
+      | Some closure_ty -> Known closure_ty)
 
   let get_env_var t env_var : _ Or_unknown.t =
-    match get_singleton t with
-    | None -> Unknown
-    | Some ((_tag, index), maps_to) ->
-      if not
-           (Value_slot.Set.mem env_var
-              (Set_of_closures_contents.value_slots index))
-      then Unknown
-      else
-        let env_var_ty =
-          try
-            Value_slot.Map.find env_var
-              maps_to.value_slot_types.value_slot_components_by_index
-          with Not_found ->
-            Misc.fatal_errorf
-              "Environment variable %a is bound in index but not in \
-               maps_to@.Index:@ %a@.Maps_to:@ %a"
-              Value_slot.print env_var Set_of_closures_contents.print index
-              print_closures_entry maps_to
-        in
-        Known env_var_ty
+    match get_single_tag t with
+    | No_singleton -> Unknown
+    | Exact_closure (_tag, maps_to) | Incomplete_closure (_tag, maps_to) -> (
+      match
+        Value_slot.Map.find_opt env_var
+          maps_to.value_slot_types.value_slot_components_by_index
+      with
+      | None -> Unknown
+      | Some env_var_ty -> Known env_var_ty)
 end
 
 module Env_extension = struct

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -380,7 +380,7 @@ module Closures_entry : sig
     t
 
   val find_function_type :
-    t -> Function_slot.t -> Function_type.t Or_unknown_or_bottom.t
+    t -> exact:bool -> Function_slot.t -> Function_type.t Or_unknown_or_bottom.t
 
   val value_slot_types : t -> flambda_type Value_slot.Map.t
 end
@@ -451,6 +451,8 @@ module Row_like_for_blocks : sig
   val all_tags_and_sizes :
     t -> (Targetint_31_63.t * Flambda_kind.Block_shape.t) Tag.Map.t Or_unknown.t
 
+  (** If the type corresponds to a single block of known size (as created by
+      [create_exactly_multiple]) then return it. *)
   val get_singleton :
     t ->
     (Tag.t
@@ -516,9 +518,12 @@ module Row_like_for_closures : sig
       Or_bottom.t ->
     t
 
-  val get_singleton :
-    t ->
-    ((Function_slot.t * Set_of_closures_contents.t) * Closures_entry.t) option
+  type get_single_tag_result =
+    | No_singleton
+    | Exact_closure of Function_slot.t * Closures_entry.t
+    | Incomplete_closure of Function_slot.t * Closures_entry.t
+
+  val get_single_tag : t -> get_single_tag_result
 
   (** Same as For_blocks.get_field: attempt to find the type associated to the
       given environment variable without an expensive meet. *)


### PR DESCRIPTION
The first commit improves the handling of At_least closure types. The second one builds on that to provide an alternative solution to #1253. The third commit cleans up the additional code introduced for #1253 that is now irrelevant.

I think the first commit should be looked at anyway, the others are mostly here to show what we can do with it.