### PR TITLE
Replaces calls to raise by calls to raise_notrace

### DIFF
--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -58,9 +58,9 @@ module Equations = struct
   let find op_class op m =
     match op_class with
     | Op_load Mutable ->
-      Rhs_map.find op m.mutable_load_equations
+      Rhs_map.find_opt op m.mutable_load_equations
     | _ ->
-      Rhs_map.find op m.other_equations
+      Rhs_map.find_opt op m.other_equations
 
   let remove_mutable_loads m =
     { mutable_load_equations = Rhs_map.empty;
@@ -106,10 +106,9 @@ let fresh_valnum_regs n rs =
   registers. *)
 
 let valnum_reg n r =
-  try
-    (n, Reg.Map.find r n.num_reg)
-  with Not_found ->
-    fresh_valnum_reg n r
+  match Reg.Map.find_opt r n.num_reg with
+  | Some s -> n, s
+  | None -> fresh_valnum_reg n r
 
 let valnum_regs n rs =
   array_fold_transf valnum_reg n rs
@@ -118,10 +117,7 @@ let valnum_regs n rs =
    Return [Some res] if there is one, where [res] is the lhs. *)
 
 let find_equation op_class n rhs =
-  try
-    Some(Equations.find op_class rhs n.num_eqs)
-  with Not_found ->
-    None
+  Equations.find op_class rhs n.num_eqs
 
 (* Find a register containing the given value number. *)
 

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -77,9 +77,7 @@ let create_env ~environment_param =
     environment_param;
   }
 
-let is_unboxed_id id env =
-  try Some (V.find_same id env.unboxed_ids)
-  with Not_found -> None
+let is_unboxed_id id env = V.find_same_opt id env.unboxed_ids
 
 let add_unboxed_id id unboxed_id bn env =
   { env with

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -178,18 +178,18 @@ type emit_frame_actions =
 let emit_frames a =
   let filenames = Hashtbl.create 7 in
   let label_filename name =
-    try
-      Hashtbl.find filenames name
-    with Not_found ->
+    match Hashtbl.find_opt filenames name with
+    | Some s -> s
+    | None ->
       let lbl = Cmm.new_label () in
       Hashtbl.add filenames name lbl;
       lbl
   in
   let defnames = Hashtbl.create 7 in
   let label_defname filename defname =
-    try
-      snd (Hashtbl.find defnames (filename, defname))
-    with Not_found ->
+    match Hashtbl.find_opt defnames (filename, defname) with
+    | Some x -> snd x
+    | None ->
       let file_lbl = label_filename filename in
       let def_lbl = Cmm.new_label () in
       Hashtbl.add defnames (filename, defname) (file_lbl, def_lbl);

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -52,8 +52,9 @@ let env_add_static_exception id v env =
   { env with static_exceptions = Int.Map.add id (v, env.regions, r) env.static_exceptions }, r
 
 let env_find id env =
-  let regs, _provenance, _mut = V.Map.find id env.vars in
-  regs
+  match V.Map.find_opt id env.vars with
+  | None -> raise_notrace Not_found
+  | Some (regs, _provenance, _mut) -> regs
 
 let env_find_mut id env =
   let regs, _provenance, mut = V.Map.find id env.vars in

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -187,9 +187,7 @@ end = struct
     }
 
   let allocated_const_for_symbol t sym =
-    try
-      Some (Symbol.Map.find sym t.allocated_constant_for_symbol)
-    with Not_found -> None
+    Symbol.Map.find_opt sym t.allocated_constant_for_symbol
 
   let keep_only_symbols t =
     { empty with

--- a/ocaml/asmcomp/CSEgen.ml
+++ b/ocaml/asmcomp/CSEgen.ml
@@ -58,9 +58,9 @@ module Equations = struct
   let find op_class op m =
     match op_class with
     | Op_load Mutable ->
-      Rhs_map.find op m.mutable_load_equations
+      Rhs_map.find_opt op m.mutable_load_equations
     | _ ->
-      Rhs_map.find op m.other_equations
+      Rhs_map.find_opt op m.other_equations
 
   let remove_mutable_loads m =
     { mutable_load_equations = Rhs_map.empty;
@@ -117,11 +117,7 @@ let valnum_regs n rs =
 (* Look up the set of equations for an equation with the given rhs.
    Return [Some res] if there is one, where [res] is the lhs. *)
 
-let find_equation op_class n rhs =
-  try
-    Some(Equations.find op_class rhs n.num_eqs)
-  with Not_found ->
-    None
+let find_equation op_class n rhs = Equations.find op_class rhs n.num_eqs
 
 (* Find a register containing the given value number. *)
 

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -73,8 +73,7 @@ let create_env ~environment_param =
   }
 
 let is_unboxed_id id env =
-  try Some (V.find_same id env.unboxed_ids)
-  with Not_found -> None
+  V.find_same_opt id env.unboxed_ids
 
 let add_unboxed_id id unboxed_id bn env =
   { env with

--- a/ocaml/middle_end/flambda/flambda_to_clambda.ml
+++ b/ocaml/middle_end/flambda/flambda_to_clambda.ml
@@ -186,9 +186,7 @@ end = struct
     }
 
   let allocated_const_for_symbol t sym =
-    try
-      Some (Symbol.Map.find sym t.allocated_constant_for_symbol)
-    with Not_found -> None
+    Symbol.Map.find_opt sym t.allocated_constant_for_symbol
 
   let keep_only_symbols t =
     { empty with

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -835,8 +835,7 @@ let attribute_of_warning loc s =
 let cookies = ref String.Map.empty
 
 let get_cookie k =
-  try Some (String.Map.find k !cookies)
-  with Not_found -> None
+  String.Map.find_opt k !cookies
 
 let set_cookie k v =
   cookies := String.Map.add k v !cookies

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -1685,14 +1685,14 @@ let safe_abbrev env ty =
 let try_expand_once env ty =
   match get_desc ty with
     Tconstr _ -> expand_abbrev env ty
-  | _ -> raise Cannot_expand
+  | _ -> raise_notrace Cannot_expand
 
 (* This one only raises Cannot_expand *)
 let try_expand_safe env ty =
   let snap = Btype.snapshot () in
   try try_expand_once env ty
   with Escape _ ->
-    Btype.backtrack snap; cleanup_abbrev (); raise Cannot_expand
+    Btype.backtrack snap; cleanup_abbrev (); raise_notrace Cannot_expand
 
 (* Fully expand the head of a type. *)
 let rec try_expand_head

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -1197,14 +1197,14 @@ let type_of_cstr path = function
 let find_type_data path env =
   match Path.constructor_typath path with
   | Regular p -> begin
-      match Path.Map.find p env.local_constraints with
-      | decl ->
+      match Path.Map.find_opt p env.local_constraints with
+      | Some decl ->
           {
             tda_declaration = decl;
             tda_descriptions = Type_abstract;
             tda_shape = Shape.leaf decl.type_uid;
           }
-      | exception Not_found -> find_type_full p env
+      | None -> find_type_full p env
     end
   | Cstr (ty_path, s) ->
       (* This case corresponds to an inlined record *)
@@ -1235,8 +1235,9 @@ let find_type_data path env =
         with Not_found -> assert false
       in
       let cstrs =
-        try NameMap.find s comps.comp_constrs
-        with Not_found -> assert false
+        match NameMap.find_opt s comps.comp_constrs with
+        | Some s -> s
+        | None -> assert false
       in
       let exts = List.filter is_ext cstrs in
       match exts with
@@ -1463,7 +1464,7 @@ let find_type_expansion path env =
      private row are still considered unknown to the type system.
      Hence, this case is caught by the following clause that also handles
      purely abstract data types without manifest type definition. *)
-  | _ -> raise Not_found
+  | _ -> raise_notrace Not_found
 
 (* Find the manifest type information associated to a type, i.e.
    the necessary information for the compiler's type-based optimisations.

--- a/ocaml/typing/ident.ml
+++ b/ocaml/typing/ident.ml
@@ -239,7 +239,7 @@ let rec add id data = function
         balance l k (add id data r)
 
 let rec min_binding = function
-    Empty -> raise Not_found
+    Empty -> raise_notrace Not_found
   | Node (Empty, d, _, _) -> d
   | Node (l, _, _, _) -> min_binding l
 
@@ -272,13 +272,13 @@ let rec remove id = function
 
 let rec find_previous id = function
     None ->
-      raise Not_found
+      raise_notrace Not_found
   | Some k ->
       if same id k.ident then k.data else find_previous id k.previous
 
 let rec find_same id = function
     Empty ->
-      raise Not_found
+      raise_notrace Not_found
   | Node(l, k, r, _) ->
       let c = String.compare (name id) (name k.ident) in
       if c = 0 then
@@ -288,9 +288,12 @@ let rec find_same id = function
       else
         find_same id (if c < 0 then l else r)
 
+let find_same_opt id ids =
+  try Some (find_same id ids) with Not_found -> None
+
 let rec find_name n = function
     Empty ->
-      raise Not_found
+      raise_notrace Not_found
   | Node(l, k, r, _) ->
       let c = String.compare n (name k.ident) in
       if c = 0 then

--- a/ocaml/typing/ident.mli
+++ b/ocaml/typing/ident.mli
@@ -72,6 +72,7 @@ type 'a tbl
 val empty: 'a tbl
 val add: t -> 'a -> 'a tbl -> 'a tbl
 val find_same: t -> 'a tbl -> 'a
+val find_same_opt: t -> 'a tbl -> 'a option
 val find_name: string -> 'a tbl -> t * 'a
 val find_all: string -> 'a tbl -> (t * 'a) list
 val fold_name: (t -> 'a -> 'b -> 'b) -> 'a tbl -> 'b -> 'b

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -228,9 +228,9 @@ end = struct
 
   (* throws Not_found if the variable is not in scope *)
   let lookup_local name =
-    try
-      List.assoc name !univars
-    with Not_found ->
+    match List.assoc_opt name !univars with
+    | Some s -> s
+    | None ->
       instance (fst (TyVarMap.find name !used_variables))
       (* This call to instance might be redundant; all variables
          inserted into [used_variables] are non-generic, but some


### PR DESCRIPTION
This PR replaces a few occurrences of `raise` by calls to `raise_notrace`. It turned out
that constructing backtraces is costly, and that the `raise` in `ident.ml` were responsible for ~1.5% of the
runtime of the compiler.

Not all calls to `raise` have been replaced by calls to `raise_notrace` as it's still desirable to get the backtrace when something gets wrong.