### PR TITLE
Fix issue caused by effects of gadt expansion in mode cross check

### DIFF
--- a/ocaml/testsuite/tests/typing-local/crossing.ml
+++ b/ocaml/testsuite/tests/typing-local/crossing.ml
@@ -344,3 +344,17 @@ type t2 = { x : int; } [@@unboxed]
 val f : local_ M.t -> M.t = <fun>
 val f : local_ t2 -> t2 = <fun>
 |}]
+
+(* This test needs the snapshotting in is_always_global to prevent a type error
+   from the use of the gadt equation in the inner scope. *)
+type _ t_gadt = Int : int t_gadt
+type 'a t_rec = { fld : 'a }
+
+let f (type a) (x : a t_gadt) (y : a) =
+  match x with
+    Int -> { fld = y }.fld
+[%%expect{|
+type _ t_gadt = Int : int t_gadt
+type 'a t_rec = { fld : 'a; }
+val f : 'a t_gadt -> 'a -> 'a = <fun>
+|}]

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -5747,12 +5747,18 @@ let check_decl_immediate env decl imm =
     | Error _, Some ty -> check_type_immediate env ty imm
 
 let is_always_global env ty =
-  (* We snapshot to keep this pure; see the mode crossing test that mentions
-     snapshotting for an example. *)
-  let snap = Btype.snapshot () in
-  let imm = check_type_immediate env ty Always_on_64bits in
-  Btype.backtrack snap;
-  Result.is_ok imm
+  let perform_check () =
+    Result.is_ok (check_type_immediate env ty Always_on_64bits)
+  in
+  if !Clflags.principal || Env.has_local_constraints env then
+    (* We snapshot to keep this pure; see the mode crossing test that mentions
+       snapshotting for an example. *)
+    let snap = Btype.snapshot () in
+    let result = perform_check () in
+    Btype.backtrack snap;
+    result
+  else
+    perform_check ()
 
 (* For use with ocamldebug *)
 type global_state =

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -5747,7 +5747,12 @@ let check_decl_immediate env decl imm =
     | Error _, Some ty -> check_type_immediate env ty imm
 
 let is_always_global env ty =
-  Result.is_ok (check_type_immediate env ty Always_on_64bits)
+  (* We snapshot to keep this pure; see the mode crossing test that mentions
+     snapshotting for an example. *)
+  let snap = Btype.snapshot () in
+  let imm = check_type_immediate env ty Always_on_64bits in
+  Btype.backtrack snap;
+  Result.is_ok imm
 
 (* For use with ocamldebug *)
 type global_state =


### PR DESCRIPTION
We previously observed the issue that because the improved immediacy system means the mode crossing check may use gadt equations, those equations may appear to escape their scope in benign situations.  I've brought over the fix we used in the unboxed types branch (snapshotting to forget the scope changes), but  moved it from `Typecore.mode_cross` to `Ctype.is_always_global` (to avoid duplication as the latter function now has two callers).

Two things to consider:
- We're sure it's fine to ignore the scope changes resulting from use of equations during the mode cross check?
- Is a similar change needed to `Typeopt.is_always_gc_ignorable` (I think no, because it's too late for the effects to matter).