### PR TITLE
Add tail_mod_const to builtin_attrs

### DIFF
--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -423,7 +423,7 @@ let add_poll_attribute expr loc attributes =
       | Default_poll -> ()
       | Error_poll ->
           Location.prerr_warning loc
-            (Warnings.Duplicated_attribute "error_poll")
+            (Warnings.Duplicated_attribute "poll error")
       end;
       let attr = { attr with poll } in
       check_poll_inline loc attr;

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -86,7 +86,6 @@ let builtin_attrs =
   ; "noalloc"; "ocaml.noalloc"
   ; "untagged"; "ocaml.untagged"
   ; "poll"; "ocaml.poll"
-  ; "error_poll"; "ocaml.error_poll"
   ; "loop"; "ocaml.loop"
   ; "tail_mod_cons"; "ocaml.tail_mod_cons"
   ]

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -86,7 +86,9 @@ let builtin_attrs =
   ; "noalloc"; "ocaml.noalloc"
   ; "untagged"; "ocaml.untagged"
   ; "poll"; "ocaml.poll"
+  ; "error_poll"; "ocaml.error_poll"
   ; "loop"; "ocaml.loop"
+  ; "tail_mod_cons"; "ocaml.tail_mod_cons"
   ]
 
 let builtin_attrs =


### PR DESCRIPTION
These attributes where added upstream in 4.14 but we forgot to update the table used for warnings about misplaced attributes.