### PR TITLE
Backend changes for multiple returns

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -211,9 +211,11 @@ let loc_parameters arg =
   in
   loc
 
-let loc_results res =
+let loc_results_call res =
+  calling_conventions 0 9 100 109 outgoing (- size_domainstate_args) res
+let loc_results_return res =
   let (loc, _ofs) =
-    calling_conventions 0 0 100 100 not_supported 0 res
+    calling_conventions 0 9 100 109 incoming (- size_domainstate_args) res
   in loc
 
 let max_arguments_for_tailcalls = 10 (* in regs *) + 64 (* in domain state *)

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -190,9 +190,11 @@ let loc_parameters arg =
                         incoming (- size_domainstate_args) arg
   in
   loc
-let loc_results res =
+let loc_results_call res =
+  calling_conventions 0 last_int_register 100 115 outgoing (- size_domainstate_args) res
+let loc_results_return res =
   let (loc, _) =
-    calling_conventions 0 last_int_register 100 115 not_supported 0 res
+    calling_conventions 0 last_int_register 100 115 incoming (- size_domainstate_args) res
   in
   loc
 

--- a/backend/cfg/tests/check_regalloc_validation.ml
+++ b/backend/cfg/tests/check_regalloc_validation.ml
@@ -249,8 +249,10 @@ let base_templ () : Cfg_desc.t * (unit -> int) =
   in
   let int_arg1 = args.(1) in
   let int_arg2 = args.(2) in
-  let tmp_results, tmp_result_locs = make_locs [| int.(2) |] Proc.loc_results in
-  let results, result_locs = make_locs [| int.(3) |] Proc.loc_results in
+  let tmp_results, tmp_result_locs =
+    make_locs [| int.(2) |] Proc.loc_results_return
+  in
+  let results, result_locs = make_locs [| int.(3) |] Proc.loc_results_return in
   let make_moves src dst =
     Array.map2
       (fun src dst : Basic.t ->
@@ -830,7 +832,7 @@ let make_loop ~loop_loc_first n =
   let extra_regs =
     Array.init n (fun _ -> { (Reg.create Int) with loc = int_arg3.loc })
   in
-  let results, result_locs = make_locs [| int_arg1 |] Proc.loc_results in
+  let results, result_locs = make_locs [| int_arg1 |] Proc.loc_results_return in
   let make_moves src dst =
     Array.map2
       (fun src dst : Basic.t ->

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4143,3 +4143,5 @@ let kind_of_layout (layout : Lambda.layout) =
   | Punboxed_float -> Vfloat
   | Punboxed_int _ -> Vint
   | Pvalue kind -> Vval kind
+
+let make_tuple l = match l with [e] -> e | _ -> Ctuple l

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1279,3 +1279,5 @@ val kind_of_layout : Lambda.layout -> value_kind
 val machtype_of_layout : Lambda.layout -> machtype
 
 val machtype_of_layout_changing_tagged_int_to_val : Lambda.layout -> machtype
+
+val make_tuple : expression list -> expression

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -31,8 +31,9 @@ val all_phys_regs : Reg.t array
 
 (* Calling conventions *)
 val loc_arguments: Cmm.machtype -> Reg.t array * int
-val loc_results: Cmm.machtype -> Reg.t array
+val loc_results_call: Cmm.machtype -> Reg.t array * int
 val loc_parameters: Cmm.machtype -> Reg.t array
+val loc_results_return: Cmm.machtype -> Reg.t array
 (* For argument number [n] split across multiple registers, the target-specific
    implementation of [loc_external_arguments] must return [regs] such that
    [regs.(n).(0)] is to hold the part of the value at the lowest address. *)

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -793,10 +793,10 @@ method insert_move_args env arg loc stacksize =
   self#insert_moves env arg loc
 
 method insert_move_results env loc res stacksize =
+  self#insert_moves env loc res;
   if stacksize <> 0 then begin
     self#insert env (Iop(Istackoffset(-stacksize))) [||] [||]
-  end;
-  self#insert_moves env loc res
+  end
 
 (* Add an Iop opcode. Can be overridden by processor description
    to insert moves before and after the operation, i.e. for two-address
@@ -934,8 +934,9 @@ method emit_expr_aux (env:environment) exp :
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               let rd = self#regs_for ty in
               self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
-              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
-              let loc_res = Proc.loc_results (Reg.typv rd) in
+              let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv rarg) in
+              let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
+              let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
               self#insert_move_args env rarg loc_arg stack_ofs;
               self#insert_debug env (Iop new_op) dbg
                           (Array.append [|r1.(0)|] loc_arg) loc_res;
@@ -946,8 +947,9 @@ method emit_expr_aux (env:environment) exp :
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
               self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
-              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
-              let loc_res = Proc.loc_results (Reg.typv rd) in
+              let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv r1) in
+              let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
+              let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
               self#insert_move_args env r1 loc_arg stack_ofs;
               self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
@@ -1389,7 +1391,7 @@ method private insert_return (env:environment) r (traps:trap_action list) =
     None -> ()
   | Some (r, unclosed_regions) ->
       self#insert_endregions env unclosed_regions;
-      let loc = Proc.loc_results (Reg.typv r) in
+      let loc = Proc.loc_results_return (Reg.typv r) in
       self#insert_moves env r loc;
       self#insert env (Ireturn traps) loc [||]
 
@@ -1431,17 +1433,18 @@ method emit_tail (env:environment) exp =
           match new_op with
             Icall_ind ->
               let r1 = self#emit_tuple env new_args in
+              let rd = self#regs_for ty in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               self#insert_endregions env env.regions;
-              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
+              let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv rarg) in
+              let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
+              let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
               if stack_ofs = 0 && trap_stack_is_empty env then begin
                 let call = Iop (Itailcall_ind) in
                 self#insert_moves env rarg loc_arg;
                 self#insert_debug env call dbg
                             (Array.append [|r1.(0)|] loc_arg) [||];
               end else begin
-                let rd = self#regs_for ty in
-                let loc_res = Proc.loc_results (Reg.typv rd) in
                 self#insert_move_args env rarg loc_arg stack_ofs;
                 self#insert_debug env (Iop new_op) dbg
                             (Array.append [|r1.(0)|] loc_arg) loc_res;
@@ -1451,8 +1454,11 @@ method emit_tail (env:environment) exp =
               end
           | Icall_imm { func; } ->
               let r1 = self#emit_tuple env new_args in
+              let rd = self#regs_for ty in
               self#insert_endregions env env.regions;
-              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
+              let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv r1) in
+              let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
+              let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
               if stack_ofs = 0 && trap_stack_is_empty env then begin
                 let call = Iop (Itailcall_imm { func; }) in
                 self#insert_moves env r1 loc_arg;
@@ -1463,8 +1469,6 @@ method emit_tail (env:environment) exp =
                 self#insert_moves env r1 loc_arg';
                 self#insert_debug env call dbg loc_arg' [||];
               end else begin
-                let rd = self#regs_for ty in
-                let loc_res = Proc.loc_results (Reg.typv rd) in
                 self#insert_move_args env r1 loc_arg stack_ofs;
                 self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
                 set_traps_for_raise env;

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -98,6 +98,9 @@ let cache_reload_result nfail before handler after_handler env =
   in
   reload_cache := Numbers.Int.Map.add nfail entry !reload_cache
 
+let reset_cache () =
+  reload_cache := Numbers.Int.Map.empty
+
 let spill_reg env r =
   try
     env, Reg.Map.find r env.spill_env
@@ -613,10 +616,6 @@ let rec spill :
         before_body)))
   | Iraise _ ->
       k i env.at_raise
-
-let reset_cache () =
-  reload_cache := Numbers.Int.Map.empty;
-  spill_cache := Numbers.Int.Map.empty
 
 (* Entry point *)
 

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -98,9 +98,6 @@ let cache_reload_result nfail before handler after_handler env =
   in
   reload_cache := Numbers.Int.Map.add nfail entry !reload_cache
 
-let reset_cache () =
-  reload_cache := Numbers.Int.Map.empty
-
 let spill_reg env r =
   try
     env, Reg.Map.find r env.spill_env
@@ -616,6 +613,10 @@ let rec spill :
         before_body)))
   | Iraise _ ->
       k i env.at_raise
+
+let reset_cache () =
+  reload_cache := Numbers.Int.Map.empty;
+  spill_cache := Numbers.Int.Map.empty
 
 (* Entry point *)
 

--- a/ocaml/asmcomp/amd64/proc.ml
+++ b/ocaml/asmcomp/amd64/proc.ml
@@ -202,8 +202,11 @@ let loc_parameters arg =
   let (loc, _ofs) =
     calling_conventions 0 9 100 109 incoming (- size_domainstate_args) arg
   in loc
-let loc_results res =
-  let (loc, _ofs) = calling_conventions 0 0 100 100 not_supported 0 res
+let loc_results_call res =
+  calling_conventions 0 9 100 109 outgoing (- size_domainstate_args) res
+let loc_results_return res =
+  let (loc, _ofs) =
+    calling_conventions 0 9 100 109 incoming (- size_domainstate_args) res
   in loc
 
 let max_arguments_for_tailcalls = 10 (* in regs *) + 64 (* in domain state *)

--- a/ocaml/asmcomp/arm/proc.ml
+++ b/ocaml/asmcomp/arm/proc.ml
@@ -192,8 +192,13 @@ let loc_parameters arg =
     calling_conventions 0 7 100 115 incoming (- size_domainstate_args) arg
   in loc
 
-let loc_results res =
-  let (loc, _) = calling_conventions 0 7 100 115 not_supported 0 res in loc
+let loc_results_call res =
+  calling_conventions 0 7 100 115 outgoing (- size_domainstate_args) res
+
+let loc_results_return res =
+  let (loc, _) =
+    calling_conventions 0 7 100 115 incoming (- size_domainstate_args) res
+  in loc
 
 (* C calling convention:
      first integer args in r0...r3

--- a/ocaml/asmcomp/arm64/proc.ml
+++ b/ocaml/asmcomp/arm64/proc.ml
@@ -183,9 +183,13 @@ let loc_parameters arg =
                         incoming (- size_domainstate_args) arg
   in
   loc
-let loc_results res =
+let loc_results_call res =
+  calling_conventions 0 last_int_register 100 115
+                      outgoing (- size_domainstate_args) res
+let loc_results_return res =
   let (loc, _) =
-    calling_conventions 0 last_int_register 100 115 not_supported 0 res
+    calling_conventions 0 last_int_register 100 115
+                        incoming (- size_domainstate_args) res
   in
   loc
 

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -3283,3 +3283,5 @@ let kind_of_layout (layout : Lambda.layout) =
   | Punboxed_float -> Vfloat
   | Punboxed_int _ -> Vint
   | Pvalue kind -> Vval kind
+
+let make_tuple l = match l with [e] -> e | _ -> Ctuple l

--- a/ocaml/asmcomp/cmm_helpers.mli
+++ b/ocaml/asmcomp/cmm_helpers.mli
@@ -749,3 +749,5 @@ val kind_of_layout : Lambda.layout -> value_kind
 val machtype_of_layout : Lambda.layout -> machtype
 
 val machtype_of_layout_changing_tagged_int_to_val : Lambda.layout -> machtype
+
+val make_tuple : expression list -> expression

--- a/ocaml/asmcomp/i386/proc.ml
+++ b/ocaml/asmcomp/i386/proc.ml
@@ -144,8 +144,16 @@ let loc_arguments arg =
   calling_conventions 0 5 100 99 outgoing arg
 let loc_parameters arg =
   let (loc, _ofs) = calling_conventions 0 5 100 99 incoming arg in loc
-let loc_results res =
-  let (loc, _ofs) = calling_conventions 0 5 100 100 not_supported res in loc
+
+(* CR vlaviron: The old code used to allow a single float register for
+   the return registers (even though the case was never used). I've
+   chosen to forbid it to match the convention for parameters.
+   Unboxed float return values will thus end up either on the reserved
+   region of the domain state or on the stack. *)
+let loc_results_call res =
+  calling_conventions 0 5 100 99 outgoing res
+let loc_results_return res =
+  let (loc, _ofs) = calling_conventions 0 5 100 99 incoming res in loc
 
 let max_arguments_for_tailcalls =
   6 (* in registers *) + 64 (* in domain state *)

--- a/ocaml/asmcomp/power/proc.ml
+++ b/ocaml/asmcomp/power/proc.ml
@@ -173,8 +173,12 @@ let loc_parameters arg =
     calling_conventions 0 15 100 112 incoming (- size_domainstate_args) arg
   in loc
 
-let loc_results res =
-  let (loc, _ofs) = calling_conventions 0 15 100 112 not_supported 0 res
+let loc_results_call res =
+    calling_conventions 0 15 100 112 outgoing (- size_domainstate_args) res
+
+let loc_results_return res =
+  let (loc, _ofs) =
+    calling_conventions 0 15 100 112 incoming (- size_domainstate_args) res
   in loc
 
 (* C calling conventions for ELF32:

--- a/ocaml/asmcomp/proc.mli
+++ b/ocaml/asmcomp/proc.mli
@@ -29,8 +29,9 @@ val rotate_registers: bool
 
 (* Calling conventions *)
 val loc_arguments: Cmm.machtype -> Reg.t array * int
-val loc_results: Cmm.machtype -> Reg.t array
+val loc_results_call: Cmm.machtype -> Reg.t array * int
 val loc_parameters: Cmm.machtype -> Reg.t array
+val loc_results_return: Cmm.machtype -> Reg.t array
 (* For argument number [n] split across multiple registers, the target-specific
    implementation of [loc_external_arguments] must return [regs] such that
    [regs.(n).(0)] is to hold the part of the value at the lowest address. *)

--- a/ocaml/asmcomp/riscv/proc.ml
+++ b/ocaml/asmcomp/riscv/proc.ml
@@ -178,9 +178,12 @@ let loc_parameters arg =
   in
   loc
 
-let loc_results res =
+let loc_results_call res =
+  calling_conventions 0 15 110 125 outgoing (- size_domainstate_args) res
+
+let loc_results_return res =
   let (loc, _ofs) =
-    calling_conventions 0 15 110 125 not_supported 0 res
+    calling_conventions 0 15 110 125 incoming (- size_domainstate_args) res
   in
   loc
 

--- a/ocaml/asmcomp/s390x/proc.ml
+++ b/ocaml/asmcomp/s390x/proc.ml
@@ -143,8 +143,12 @@ let loc_parameters arg =
   let (loc, _ofs) =
     calling_conventions 0 7 100 103 incoming (- size_domainstate_args) arg
   in loc
-let loc_results res =
-  let (loc, _ofs) = calling_conventions 0 7 100 103 not_supported 0 res in loc
+let loc_results_call res =
+  calling_conventions 0 7 100 103 outgoing (- size_domainstate_args) res
+let loc_results_return res =
+  let (loc, _ofs) =
+    calling_conventions 0 7 100 103 incoming (- size_domainstate_args) res
+  in loc
 
 (*   C calling conventions under SVR4:
      use GPR 2-6 and FPR 0,2,4,6 just like ML calling conventions.

--- a/ocaml/asmcomp/selectgen.ml
+++ b/ocaml/asmcomp/selectgen.ml
@@ -651,10 +651,10 @@ method insert_move_args env arg loc stacksize =
   self#insert_moves env arg loc
 
 method insert_move_results env loc res stacksize =
+  self#insert_moves env loc res;
   if stacksize <> 0 then begin
     self#insert env (Iop(Istackoffset(-stacksize))) [||] [||]
-  end;
-  self#insert_moves env loc res
+  end
 
 (* Add an Iop opcode. Can be overridden by processor description
    to insert moves before and after the operation, i.e. for two-address
@@ -797,8 +797,9 @@ method emit_expr_aux (env:environment) exp :
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               let rd = self#regs_for ty in
               self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
-              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
-              let loc_res = Proc.loc_results (Reg.typv rd) in
+              let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv rarg) in
+              let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
+              let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
               self#insert_move_args env rarg loc_arg stack_ofs;
               self#insert_debug env (Iop new_op) dbg
                           (Array.append [|r1.(0)|] loc_arg) loc_res;
@@ -808,8 +809,9 @@ method emit_expr_aux (env:environment) exp :
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
               self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
-              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
-              let loc_res = Proc.loc_results (Reg.typv rd) in
+              let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv r1) in
+              let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
+              let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
               self#insert_move_args env r1 loc_arg stack_ofs;
               self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
@@ -1158,7 +1160,7 @@ method private insert_return (env:environment) r =
     None -> ()
   | Some (r, unclosed_regions) ->
       self#insert_endregions env unclosed_regions;
-      let loc = Proc.loc_results (Reg.typv r) in
+      let loc = Proc.loc_results_return (Reg.typv r) in
       self#insert_moves env r loc;
       self#insert env Ireturn loc [||]
 
@@ -1200,17 +1202,18 @@ method emit_tail (env:environment) exp =
           match new_op with
             Icall_ind ->
               let r1 = self#emit_tuple env new_args in
+              let rd = self#regs_for ty in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               self#insert_endregions env env.regions;
-              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
+              let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv rarg) in
+              let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
+              let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
               if stack_ofs = 0 then begin
                 let call = Iop (Itailcall_ind) in
                 self#insert_moves env rarg loc_arg;
                 self#insert_debug env call dbg
                             (Array.append [|r1.(0)|] loc_arg) [||];
               end else begin
-                let rd = self#regs_for ty in
-                let loc_res = Proc.loc_results (Reg.typv rd) in
                 self#insert_move_args env rarg loc_arg stack_ofs;
                 self#insert_debug env (Iop new_op) dbg
                             (Array.append [|r1.(0)|] loc_arg) loc_res;
@@ -1219,8 +1222,11 @@ method emit_tail (env:environment) exp =
               end
           | Icall_imm { func; } ->
               let r1 = self#emit_tuple env new_args in
+              let rd = self#regs_for ty in
               self#insert_endregions env env.regions;
-              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
+              let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv r1) in
+              let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
+              let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
               if stack_ofs = 0 then begin
                 let call = Iop (Itailcall_imm { func; }) in
                 self#insert_moves env r1 loc_arg;
@@ -1231,8 +1237,6 @@ method emit_tail (env:environment) exp =
                 self#insert_moves env r1 loc_arg';
                 self#insert_debug env call dbg loc_arg' [||];
               end else begin
-                let rd = self#regs_for ty in
-                let loc_res = Proc.loc_results (Reg.typv rd) in
                 self#insert_move_args env r1 loc_arg stack_ofs;
                 self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
                 self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];


### PR DESCRIPTION
Extracted from #1248.
Two changes are not strictly necessary:
- The patch to `spill.ml` is just an unrelated bug fix that I made while debugging the code.
- The addition of `Cmm_helpers.make_tuple` is useful for generating Cmm code with multiple returns, but could be kept as part of the middle-end patches instead.

I chose to integrate them anyway because it was simpler to extract everything in the `backend/` folder, and they're short and easy to review.

I haven't backported those changes to the `ocaml/` directory, I couls probably do it as part of this PR too.