### PR TITLE
Loopify & unrolling

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -194,15 +194,6 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
     in
     if not (Code_or_metadata.code_present code_or_metadata)
     then Missing_code
-    else if Loopify_attribute.was_loopified
-              (Code_metadata.loopify
-                 (Code_or_metadata.code_metadata code_or_metadata))
-            &&
-            match inlined with
-            | Unroll _ -> true
-            | Never_inlined | Default_inlined | Always_inlined | Hint_inlined ->
-              false
-    then Unroll_attribute_used_with_loopified_function
     else
       (* The unrolling process is rather subtle, but it boils down to two steps:
 

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -33,7 +33,6 @@ type t =
   | Max_inlining_depth_exceeded
   | Recursion_depth_exceeded
   | Never_inlined_attribute
-  | Unroll_attribute_used_with_loopified_function
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;
@@ -65,8 +64,6 @@ let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "Recursion_depth_exceeded"
   | Never_inlined_attribute ->
     Format.fprintf ppf "Never_inlined_attribute"
-  | Unroll_attribute_used_with_loopified_function ->
-    Format.fprintf ppf "Unroll_attribute_used_with_loopified_function"
   | Attribute_always ->
     Format.fprintf ppf "Attribute_always"
   | Definition_says_inline { was_inline_always } ->
@@ -129,10 +126,6 @@ let can_inline (t : t) : can_inline =
        attribute when we stop unrolling, which is fine *)
     Do_not_inline
       { warn_if_attribute_ignored = false; because_of_definition = true }
-  | Unroll_attribute_used_with_loopified_function ->
-    (* We have an [@unrolled] attribute, but can't unroll loopified functions *)
-    Do_not_inline
-      { warn_if_attribute_ignored = true; because_of_definition = true }
   | Attribute_unroll unroll_to ->
     Inline { unroll_to = Some unroll_to; was_inline_always = false }
   | Definition_says_inline { was_inline_always } ->
@@ -163,11 +156,6 @@ let report_reason fmt t =
     Format.fprintf fmt "the@ maximum@ recursion@ depth@ has@ been@ exceeded"
   | Never_inlined_attribute ->
     Format.fprintf fmt "the@ call@ has@ an@ attribute@ forbidding@ inlining"
-  | Unroll_attribute_used_with_loopified_function ->
-    Format.fprintf fmt
-      "the@ code@ of@ this@ function@ has@ been@ transformed@ to@ a@ loop,@ \
-       which@ cannot@ be@ unrolled@ yet@ (consider@ adding@ [@loop never]@ to@ \
-       the@ definition)"
   | Attribute_always ->
     Format.fprintf fmt "the@ call@ has@ an@ [@@inline always]@ attribute"
   | Attribute_unroll n ->

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -26,7 +26,6 @@ type t =
   | Max_inlining_depth_exceeded
   | Recursion_depth_exceeded
   | Never_inlined_attribute
-  | Unroll_attribute_used_with_loopified_function
   | Speculatively_not_inline of
       { cost_metrics : Cost_metrics.t;
         evaluated_to : float;


### PR DESCRIPTION
This PR moves the decision for loopification **after** the inlining/unrolling decision, so that we can unroll inside of a function being loopified.

Note: the warning for unroll annotations on loopified functions is removed because it's now unused. We could try and add it back, however, to do that correctly we'd first need to be able to tell whether we are inside or outside of the function being loopified (because only annotations outside of the function are now ignored), and we currently do not warn on unroll annotations used on non-recursive functions. Finally, in any case, the current code actually never unrolls more than once even in there is an annotation, so following a suggestion from @lthls we should first try and specify/formalize the semantics we'd want for unrolling, and then we'll anyway need to fix the code doing decisions as well as warnings.