### PR TITLE
Revert "Make Selectgen treat region boundaries more precisely"

### DIFF
--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -28,58 +28,18 @@ type trap_stack_info =
   | Unreachable
   | Reachable of trap_stack
 
-module Region_stack : sig
-  (* A nested set of regions, with the innermost at the head *)
-  type t = Reg.t array list
-
-  val equal : t -> t -> bool
-
-  (* Given two region stacks that are suffixes of the same
-     original stack, return their common suffix.
-
-     (This is always the shorter of the two arguments) *)
-  val common_suffix : t -> t -> t
-
-  (* Given a region stack R and one of its suffixes S,
-     return the prefix P where R = P @ S *)
-  val strip_suffix : suffix:t -> t -> t
-end  = struct
-  type t = Reg.t array list
-
-  let equal a b =
-    (a == b) || List.equal (==) a b
-
-  let common_suffix xs ys =
-    if xs == ys || List.compare_lengths xs ys <= 0
-    then xs
-    else ys
-
-  let strip_suffix ~suffix t =
-    match suffix with
-    | [] -> t
-    | _ when suffix == t -> []
-    | suff ->
-       let pre, suff' =
-         Misc.Stdlib.List.split_at (List.length t - List.length suff) t
-       in
-       assert (equal suff' suff);
-       pre
-end
-
-type static_handler =
-  { regs: Reg.t array list;
-    regions: Region_stack.t;
-    traps_ref : trap_stack_info ref }
+type region_stack = Reg.t array list
 
 type environment =
   { vars : (Reg.t array
             * Backend_var.Provenance.t option
             * Asttypes.mutable_flag) V.Map.t;
-    static_exceptions : static_handler Int.Map.t;
+    static_exceptions : (Reg.t array list * region_stack * trap_stack_info ref) Int.Map.t;
     (** Which registers must be populated when jumping to the given
         handler. *)
     trap_stack : trap_stack;
-    regions : Region_stack.t;
+    regions : region_stack;
+    region_tail : bool;
   }
 
 let env_add ?(mut=Asttypes.Immutable) var regs env =
@@ -89,12 +49,7 @@ let env_add ?(mut=Asttypes.Immutable) var regs env =
 
 let env_add_static_exception id v env =
   let r = ref Unreachable in
-  let s : static_handler =
-    { regs = v;
-      regions = env.regions;
-      traps_ref = r }
-  in
-  { env with static_exceptions = Int.Map.add id s env.static_exceptions }, r
+  { env with static_exceptions = Int.Map.add id (v, env.regions, r) env.static_exceptions }, r
 
 let env_find id env =
   let regs, _provenance, _mut = V.Map.find id env.vars in
@@ -162,7 +117,7 @@ let set_traps_for_raise env =
   | Generic_trap _ -> ()
   | Specific_trap (lbl, _) ->
     begin match env_find_static_exception lbl env with
-    | s -> set_traps lbl s.traps_ref ts [Pop]
+    | (_, _, traps_ref) -> set_traps lbl traps_ref ts [Pop]
     | exception Not_found -> Misc.fatal_errorf "Trap %d not registered in env" lbl
     end
 
@@ -184,7 +139,22 @@ let env_empty = {
   static_exceptions = Int.Map.empty;
   trap_stack = Uncaught;
   regions = [];
+  region_tail = false;
 }
+
+(* Assuming [rs] is equal to or a suffix of [env.regions],
+   return the last region in [env.regions] but not [rs]
+   (or None if they are equal) *)
+let env_close_regions env rs =
+  let rec aux v es rs =
+    match es, rs with
+    | [], [] -> v
+    | (r :: _), (r' :: _) when r == r' -> v
+    | [], _::_ ->
+       Misc.fatal_error "Selectgen.env_close_regions: not a suffix"
+    | r :: es, rs -> aux (Some r) es rs
+  in
+  aux None env.regions rs
 
 let select_mutable_flag : Asttypes.mutable_flag -> Mach.mutable_flag = function
   | Immutable -> Immutable
@@ -307,7 +277,7 @@ let join env opt_r1 seq1 opt_r2 seq2 =
   match (opt_r1, opt_r2) with
     (None, _) -> opt_r2
   | (_, None) -> opt_r1
-  | (Some (r1, uncl1), Some (r2, uncl2)) ->
+  | (Some r1, Some r2) ->
       let l1 = Array.length r1 in
       assert (l1 = Array.length r2);
       let r = Array.make l1 Reg.dummy in
@@ -329,10 +299,7 @@ let join env opt_r1 seq1 opt_r2 seq2 =
           seq2#insert_move env r2.(i) r.(i)
         end
       done;
-      let suffix = Region_stack.common_suffix uncl1 uncl2 in
-      seq1#insert_endregions_until env ~suffix uncl1;
-      seq2#insert_endregions_until env ~suffix uncl2;
-      Some (r, suffix)
+      Some r
 
 (* Same, for N branches *)
 
@@ -342,19 +309,18 @@ let join_array env rs =
     let (r, _) = rs.(i) in
     match r with
     | None -> ()
-    | Some (r, uncl) ->
+    | Some r ->
       match !some_res with
-      | None ->
-        some_res := Some (r, Array.map (fun r -> r.typ) r, uncl)
-      | Some (r', types, uncl') ->
+      | None -> some_res := Some (r, Array.map (fun r -> r.typ) r)
+      | Some (r', types) ->
         let types =
           Array.map2 (fun r typ -> Cmm.lub_component r.typ typ) r types
         in
-        some_res := Some (r', types, Region_stack.common_suffix uncl uncl')
+        some_res := Some (r', types)
   done;
   match !some_res with
     None -> None
-  | Some (template, types, regions) ->
+  | Some (template, types) ->
       let size_res = Array.length template in
       let res = Array.make size_res Reg.dummy in
       for i = 0 to size_res - 1 do
@@ -364,11 +330,9 @@ let join_array env rs =
         let (r, s) = rs.(i) in
         match r with
           None -> ()
-        | Some (r, uncl) ->
-           s#insert_moves env r res;
-           s#insert_endregions_until env ~suffix:regions uncl;
+        | Some r -> s#insert_moves env r res
       done;
-      Some (res, regions)
+      Some res
 
 (* Name of function being compiled *)
 let current_function_name = ref ""
@@ -462,7 +426,7 @@ let select_coeffects (e : Cmm.coeffects) : Coeffect.t =
 
 (* The default instruction selection class *)
 
-class virtual selector_generic = object (self : 'self)
+class virtual selector_generic = object (self)
 
 (* A syntactic criterion used in addition to judgements about (co)effects as
    to whether the evaluation of a given expression may be deferred by
@@ -809,50 +773,23 @@ method insert_op_debug env op dbg rs rd =
 method insert_op env op rs rd =
   self#insert_op_debug env op Debuginfo.none rs rd
 
-method insert_endregions env regions =
-  match regions with
-  | [] -> ()
-  | regions ->
-     (* Coalesce multiple simultaneous Iendregion *)
-     let final_region = List.hd (List.rev regions) in
-     self#insert env (Iop Iendregion) final_region [| |]
+(* Add the instructions for the given expression
+   at the end of the self sequence *)
 
-method insert_endregions_until env ~suffix regions =
-  self#insert_endregions env (Region_stack.strip_suffix ~suffix regions)
-
-(* Emit an expression, which is assumed not to end any regions early.
-   (This holds for any expression not in tail position of Cregion)
-
-   Returns:
-     - [None] if the expression does not finish normally (e.g. raises)
-     - [Some rs] if the expression yields a result in registers [rs] *)
 method emit_expr (env:environment) exp =
-  match self#emit_expr_aux env exp with
-  | None -> None
-  | Some (res, unclosed) ->
-     assert (Region_stack.equal unclosed env.regions);
-     Some res
-
-(* Emit an expression which may end some regions early.
-
-   Returns:
-    - [None] if the expression does not finish normally (e.g. raises)
-    - [Some (rs, unclosed)] if the expression yields a result in [rs],
-      having left [unclosed] (a suffix of env.regions) regions open *)
-method emit_expr_aux (env:environment) exp :
-  (Reg.t array * Region_stack.t) option =
-  (* Normal case of returning a value: no regions are closed *)
-  let ret res = Some (res, env.regions) in
+  (* Environment used in recursive calls not in tail position *)
+  let env' =
+    if env.region_tail then {env with region_tail=false} else env in
   match exp with
     Cconst_int (n, _dbg) ->
       let r = self#regs_for typ_int in
-      ret (self#insert_op env (Iconst_int(Nativeint.of_int n)) [||] r)
+      Some(self#insert_op env (Iconst_int(Nativeint.of_int n)) [||] r)
   | Cconst_natint (n, _dbg) ->
       let r = self#regs_for typ_int in
-      ret (self#insert_op env (Iconst_int n) [||] r)
+      Some(self#insert_op env (Iconst_int n) [||] r)
   | Cconst_float (n, _dbg) ->
       let r = self#regs_for typ_float in
-      ret (self#insert_op env (Iconst_float (Int64.bits_of_float n)) [||] r)
+      Some(self#insert_op env (Iconst_float (Int64.bits_of_float n)) [||] r)
   | Cconst_symbol (n, _dbg) ->
       (* Cconst_symbol _ evaluates to a statically-allocated address, so its
          value fits in a typ_int register and is never changed by the GC.
@@ -862,46 +799,46 @@ method emit_expr_aux (env:environment) exp :
          registered in the compilation unit's global roots structure, so
          adding this register to the frame table would be redundant *)
       let r = self#regs_for typ_int in
-      ret (self#insert_op env (Iconst_symbol n) [||] r)
+      Some(self#insert_op env (Iconst_symbol n) [||] r)
   | Cvar v ->
       begin try
-        ret (env_find v env)
+        Some(env_find v env)
       with Not_found ->
         Misc.fatal_error("Selection.emit_expr: unbound var " ^ V.unique_name v)
       end
   | Clet(v, e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> None
-      | Some r1 -> self#emit_expr_aux (self#bind_let env v r1) e2
+      | Some r1 -> self#emit_expr (self#bind_let env v r1) e2
       end
   | Clet_mut(v, k, e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> None
-      | Some r1 -> self#emit_expr_aux (self#bind_let_mut env v k r1) e2
+      | Some r1 -> self#emit_expr (self#bind_let_mut env v k r1) e2
       end
   | Cphantom_let (_var, _defining_expr, body) ->
-      self#emit_expr_aux env body
+      self#emit_expr env body
   | Cassign(v, e1) ->
       let rv =
         try
           env_find_mut v env
         with Not_found ->
           Misc.fatal_error ("Selection.emit_expr: unbound var " ^ V.name v) in
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> None
       | Some r1 ->
-          self#insert_moves env r1 rv; ret [||]
+          self#insert_moves env r1 rv; Some [||]
       end
   | Ctuple [] ->
-      ret [||]
+      Some [||]
   | Ctuple exp_list ->
-      begin match self#emit_parts_list env exp_list with
+      begin match self#emit_parts_list env' exp_list with
         None -> None
       | Some(simple_list, ext_env) ->
-          ret (self#emit_tuple ext_env simple_list)
+          Some(self#emit_tuple ext_env simple_list)
       end
   | Cop(Craise k, [arg], dbg) ->
-      begin match self#emit_expr env arg with
+      begin match self#emit_expr env' arg with
         None -> None
       | Some r1 ->
           let rd = [|Proc.loc_exn_bucket|] in
@@ -915,25 +852,19 @@ method emit_expr_aux (env:environment) exp :
         None -> None
       | Some (simple_args, env) ->
          let rs = self#emit_tuple env simple_args in
-         ret (self#insert_op_debug env Iopaque dbg rs rs)
+         Some (self#insert_op_debug env Iopaque dbg rs rs)
       end
   | Cop(op, args, dbg) ->
-      begin match self#emit_parts_list env args with
+      begin match self#emit_parts_list env' args with
         None -> None
       | Some(simple_args, env) ->
           let ty = oper_result_type op in
-          let unclosed_regions =
-            match op with
-            | Capply (_, Rc_close_at_apply) -> List.tl env.regions
-            | _ -> env.regions
-          in
           let (new_op, new_args) = self#select_operation op simple_args dbg in
           match new_op with
             Icall_ind ->
               let r1 = self#emit_tuple env new_args in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               let rd = self#regs_for ty in
-              self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
               let loc_res = Proc.loc_results (Reg.typv rd) in
               self#insert_move_args env rarg loc_arg stack_ofs;
@@ -941,18 +872,17 @@ method emit_expr_aux (env:environment) exp :
                           (Array.append [|r1.(0)|] loc_arg) loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
-              Some (rd, unclosed_regions)
+              Some rd
           | Icall_imm _ ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
-              self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
               let loc_res = Proc.loc_results (Reg.typv rd) in
               self#insert_move_args env r1 loc_arg stack_ofs;
               self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
-              Some (rd, unclosed_regions)
+              Some rd
           | Iextcall { ty_args; returns; _} ->
               let (loc_arg, stack_ofs) =
                 self#emit_extcall_args env ty_args new_args in
@@ -962,8 +892,7 @@ method emit_expr_aux (env:environment) exp :
                   loc_arg (Proc.loc_external_results (Reg.typv rd)) in
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
-              assert (Region_stack.equal unclosed_regions env.regions);
-              if returns then ret rd else None
+              if returns then Some rd else None
           | Ialloc { bytes = _; mode } ->
               let rd = self#regs_for typ_val in
               let bytes = size_expr env (Ctuple new_args) in
@@ -977,40 +906,37 @@ method emit_expr_aux (env:environment) exp :
               self#insert_debug env (Iop op) dbg [||] rd;
               self#emit_stores env new_args rd;
               set_traps_for_raise env;
-              assert (Region_stack.equal unclosed_regions env.regions);
-              ret rd
+              Some rd
           | Iprobe _ ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
               let rd = self#insert_op_debug env new_op dbg r1 rd in
               set_traps_for_raise env;
-              assert (Region_stack.equal unclosed_regions env.regions);
-              ret rd
+              Some rd
           | op ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
-              assert (Region_stack.equal unclosed_regions env.regions);
-              ret (self#insert_op_debug env op dbg r1 rd)
+              Some (self#insert_op_debug env op dbg r1 rd)
       end
   | Csequence(e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> None
-      | Some _ -> self#emit_expr_aux env e2
+      | Some _ -> self#emit_expr env e2
       end
   | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, _dbg, _kind) ->
       let (cond, earg) = self#select_condition econd in
-      begin match self#emit_expr env earg with
+      begin match self#emit_expr env' earg with
         None -> None
       | Some rarg ->
-          let (rif, (sif : 'self)) = self#emit_sequence env eif in
-          let (relse, (selse : 'self)) = self#emit_sequence env eelse in
+          let (rif, sif) = self#emit_sequence env eif in
+          let (relse, selse) = self#emit_sequence env eelse in
           let r = join env rif sif relse selse in
           self#insert env (Iifthenelse(cond, sif#extract, selse#extract))
                       rarg [||];
           r
       end
   | Cswitch(esel, index, ecases, _dbg, _kind) ->
-      begin match self#emit_expr env esel with
+      begin match self#emit_expr env' esel with
         None -> None
       | Some rsel ->
           let rscases =
@@ -1023,7 +949,7 @@ method emit_expr_aux (env:environment) exp :
           r
       end
   | Ccatch(_, [], e1, _) ->
-      self#emit_expr_aux env e1
+      self#emit_expr env e1
   | Ccatch(rec_flag, handlers, body, _) ->
       let handlers =
         List.map (fun (nfail, ids, e2, dbg) ->
@@ -1035,6 +961,9 @@ method emit_expr_aux (env:environment) exp :
             (nfail, ids, rs, e2, dbg))
           handlers
       in
+      let env =
+        (* Disable region-fusion on loops *)
+        match rec_flag with Recursive -> env' | Nonrecursive -> env in
       let env, handlers_map =
         (* Since the handlers may be recursive, and called from the body,
            the same environment is used for translating both the handlers and
@@ -1100,13 +1029,13 @@ method emit_expr_aux (env:environment) exp :
         [||] [||];
       r
   | Cexit (lbl,args,traps) ->
-      begin match self#emit_parts_list env args with
+      begin match self#emit_parts_list env' args with
         None -> None
       | Some (simple_list, ext_env) ->
           begin match lbl with
           | Lbl nfail ->
               let src = self#emit_tuple ext_env simple_list in
-              let handler =
+              let dest_args, dest_regions, trap_stack =
                 try env_find_static_exception nfail env
                 with Not_found ->
                   Misc.fatal_error ("Selection.emit_expr: unbound label "^
@@ -1118,10 +1047,13 @@ method emit_expr_aux (env:environment) exp :
               (* Ccatch registers must not contain out of heap pointers *)
               Array.iter (fun reg -> assert(reg.typ <> Addr)) src;
               self#insert_moves env src tmp_regs ;
-              self#insert_moves env tmp_regs (Array.concat handler.regs) ;
-              self#insert_endregions_until env ~suffix:handler.regions env.regions;
+              self#insert_moves env tmp_regs (Array.concat dest_args) ;
+              begin match env_close_regions env dest_regions with
+              | None -> ()
+              | Some regs -> self#insert env (Iop Iendregion) regs [||]
+              end;
               self#insert env (Iexit (nfail, traps)) [||] [||];
-              set_traps nfail handler.traps_ref env.trap_stack traps;
+              set_traps nfail trap_stack env.trap_stack traps;
               None
           | Return_lbl ->
               begin match simple_list with
@@ -1169,9 +1101,9 @@ method emit_expr_aux (env:environment) exp :
       | Regular -> with_handler env e2
       | Delayed lbl ->
         begin match env_find_static_exception lbl env_body with
-        | { traps_ref = { contents = Reachable ts; }; _} ->
+        | (_, _, { contents = Reachable ts; }) ->
           with_handler (env_set_trap_stack env ts) e2
-        | { traps_ref = { contents = Unreachable; }; _ } ->
+        | (_, _, { contents = Unreachable; }) ->
           let unreachable =
             Cmm.(Cop ((Cload (Word_int, Mutable)),
                       [Cconst_int (0, Debuginfo.none)],
@@ -1186,33 +1118,22 @@ method emit_expr_aux (env:environment) exp :
       end
   | Cregion e ->
      assert(Config.stack_allocation);
-     let old_regions = env.regions in
      let reg = self#regs_for typ_int in
      self#insert env (Iop Ibeginregion) [| |] reg;
-     let env = { env with regions = reg :: old_regions } in
-     begin match self#emit_expr_aux env e with
-     | None -> None
-     | Some (rd, reg' :: unclosed) when reg == reg' ->
-        (* Compiling e closed no regions *)
-        assert (Region_stack.equal unclosed old_regions);
-        self#insert_endregions env [reg];
-        Some (rd, unclosed)
-     | Some (rd, unclosed) ->
-        (* Compiling e closed [reg], and possibly other regions too *)
-        assert (List.length unclosed <= List.length old_regions);
-        Some (rd, unclosed)
+     let env = { env with regions = reg::env.regions; region_tail = true } in
+     begin match self#emit_expr env e with
+       None -> None
+     | Some _ as res ->
+        self#insert env (Iop Iendregion) reg [| |];
+        res
      end
   | Ctail e ->
-     begin match env.regions with
-     | [] -> Misc.fatal_error "Selectgen.emit_expr: Ctail but not in tail of a region"
-     | cl :: rest ->
-       self#insert_endregions env [cl];
-       self#emit_expr_aux { env with regions = rest } e
-     end
+      assert env.region_tail;
+      self#emit_expr env e
 
-method private emit_sequence (env:environment) exp : _ * 'self=
-  let s : 'self = {< instr_seq = dummy_instr >} in
-  let r = s#emit_expr_aux env exp in
+method private emit_sequence (env:environment) exp =
+  let s = {< instr_seq = dummy_instr >} in
+  let r = s#emit_expr env exp in
   (r, s)
 
 method private bind_let (env:environment) v r1 =
@@ -1387,54 +1308,49 @@ method emit_stores env data regs_addr =
 method private insert_return (env:environment) r (traps:trap_action list) =
   match r with
     None -> ()
-  | Some (r, unclosed_regions) ->
-      self#insert_endregions env unclosed_regions;
+  | Some r ->
       let loc = Proc.loc_results (Reg.typv r) in
+      if env.region_tail then
+        self#insert env (Iop Iendregion) (List.hd env.regions) [||];
       self#insert_moves env r loc;
       self#insert env (Ireturn traps) loc [||]
 
 method private emit_return (env:environment) exp traps =
-  self#insert_return env (self#emit_expr_aux env exp) traps
+  self#insert_return env (self#emit_expr env exp) traps
 
-method private tail_call_possible (env:environment) (pos:Lambda.region_close) =
-  match pos, env.regions with
-  | (Rc_normal | Rc_nontail), [] -> true
-  | (Rc_normal | Rc_nontail), _ :: _ -> false
-  | Rc_close_at_apply, [] ->
-     Misc.fatal_error "Selectgen: Rc_close_at_apply with no region to close"
-  | Rc_close_at_apply, [_] -> true
-  | Rc_close_at_apply, _ :: _ :: _ -> false
-
-(* Emit an expression in tail position of a function,
-   closing all regions in [env.regions] *)
 method emit_tail (env:environment) exp =
+  let env' =
+    if env.region_tail then {env with region_tail=false} else env in
   match exp with
     Clet(v, e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> ()
       | Some r1 -> self#emit_tail (self#bind_let env v r1) e2
       end
   | Clet_mut (v, k, e1, e2) ->
-     begin match self#emit_expr env e1 with
+     begin match self#emit_expr env' e1 with
        None -> ()
      | Some r1 -> self#emit_tail (self#bind_let_mut env v k r1) e2
      end
   | Cphantom_let (_var, _defining_expr, body) ->
       self#emit_tail env body
   | Cop((Capply(ty, ((Rc_close_at_apply | Rc_normal) as pos))) as op,
-        args, dbg)
-       when self#tail_call_possible env pos ->
-      begin match self#emit_parts_list env args with
+        args, dbg) ->
+      let tail = (pos = Lambda.Rc_close_at_apply) in
+      let endregion = env.region_tail in
+      begin match self#emit_parts_list env' args with
         None -> ()
       | Some(simple_args, env) ->
           let (new_op, new_args) = self#select_operation op simple_args dbg in
           match new_op with
             Icall_ind ->
               let r1 = self#emit_tuple env new_args in
+              if endregion && tail then
+                self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+              let endregion = endregion && not tail in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
-              self#insert_endregions env env.regions;
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
-              if stack_ofs = 0 && trap_stack_is_empty env then begin
+              if stack_ofs = 0 && trap_stack_is_empty env && not endregion then begin
                 let call = Iop (Itailcall_ind) in
                 self#insert_moves env rarg loc_arg;
                 self#insert_debug env call dbg
@@ -1446,18 +1362,26 @@ method emit_tail (env:environment) exp =
                 self#insert_debug env (Iop new_op) dbg
                             (Array.append [|r1.(0)|] loc_arg) loc_res;
                 set_traps_for_raise env;
-                self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
+                if not endregion then begin
+                  self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||]
+                end else begin
+                  self#insert_move_results env loc_res rd stack_ofs;
+                  self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+                  self#insert_moves env rd loc_res
+                end;
                 self#insert env (Ireturn (pop_all_traps env)) loc_res [||]
               end
           | Icall_imm { func; } ->
               let r1 = self#emit_tuple env new_args in
-              self#insert_endregions env env.regions;
+              if endregion && tail then
+                self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+              let endregion = endregion && not tail in
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
-              if stack_ofs = 0 && trap_stack_is_empty env then begin
+              if stack_ofs = 0 && trap_stack_is_empty env && not endregion then begin
                 let call = Iop (Itailcall_imm { func; }) in
                 self#insert_moves env r1 loc_arg;
                 self#insert_debug env call dbg loc_arg [||];
-              end else if func = !current_function_name && trap_stack_is_empty env then begin
+              end else if func = !current_function_name && trap_stack_is_empty env && not endregion then begin
                 let call = Iop (Itailcall_imm { func; }) in
                 let loc_arg' = Proc.loc_parameters (Reg.typv r1) in
                 self#insert_moves env r1 loc_arg';
@@ -1468,19 +1392,25 @@ method emit_tail (env:environment) exp =
                 self#insert_move_args env r1 loc_arg stack_ofs;
                 self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
                 set_traps_for_raise env;
-                self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
+                if not endregion then begin
+                  self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||]
+                end else begin
+                  self#insert_move_results env loc_res rd stack_ofs;
+                  self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+                  self#insert_moves env rd loc_res
+                end;
                 self#insert env (Ireturn (pop_all_traps env)) loc_res [||]
               end
           | _ -> Misc.fatal_error "Selection.emit_tail"
       end
   | Csequence(e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> ()
       | Some _ -> self#emit_tail env e2
       end
   | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, _dbg, _kind) ->
       let (cond, earg) = self#select_condition econd in
-      begin match self#emit_expr env earg with
+      begin match self#emit_expr env' earg with
         None -> ()
       | Some rarg ->
           self#insert env
@@ -1489,7 +1419,7 @@ method emit_tail (env:environment) exp =
                       rarg [||]
       end
   | Cswitch(esel, index, ecases, _dbg, _kind) ->
-      begin match self#emit_expr env esel with
+      begin match self#emit_expr env' esel with
         None -> ()
       | Some rsel ->
           let cases =
@@ -1510,6 +1440,9 @@ method emit_tail (env:environment) exp =
                 ids in
             (nfail, ids, rs, e2, dbg))
           handlers in
+      let env =
+        (* Disable region-fusion on loops *)
+        match rec_flag with Recursive -> env' | Nonrecursive -> env in
       let env, handlers_map =
         List.fold_left (fun (env, map) (nfail, ids, rs, e2, dbg) ->
             let env, r = env_add_static_exception nfail rs env in
@@ -1581,9 +1514,9 @@ method emit_tail (env:environment) exp =
       | Regular -> with_handler env e2
       | Delayed lbl ->
         begin match env_find_static_exception lbl env_body with
-        | { traps_ref = { contents = Reachable ts; }; _} ->
+        | (_, _, { contents = Reachable ts; }) ->
           with_handler (env_set_trap_stack env ts) e2
-        | { traps_ref = { contents = Unreachable; }; _ } ->
+        | (_, _, { contents = Unreachable; }) ->
           let unreachable =
             Cmm.(Cop ((Cload (Word_int, Mutable)),
                       [Cconst_int (0, Debuginfo.none)],
@@ -1597,17 +1530,20 @@ method emit_tail (env:environment) exp =
         end
       end
   | Cregion e ->
-      assert (Config.stack_allocation);
-      let reg = self#regs_for typ_int in
-      self#insert env (Iop Ibeginregion) [| |] reg;
-      self#emit_tail {env with regions = reg::env.regions} e
-  | Ctail e ->
-      begin match env.regions with
-      | [] -> Misc.fatal_error "Selectgen.emit_tail: Ctail not inside Cregion"
-      | reg :: regions ->
-         self#insert_endregions env [reg];
-         self#emit_tail { env with regions } e
+      assert(Config.stack_allocation);
+      if env.region_tail then
+        self#emit_return env exp (pop_all_traps env)
+      else begin
+        let reg = self#regs_for typ_int in
+        self#insert env (Iop Ibeginregion) [| |] reg;
+        let env' = { env with regions = reg::env.regions; region_tail = true } in
+        self#emit_tail env' e
       end
+  | Ctail e ->
+      assert env.region_tail;
+      self#insert env' (Iop Iendregion) (List.hd env.regions) [| |];
+      self#emit_tail { env with regions = List.tl env.regions;
+                                region_tail = false } e
   | Cop _
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
   | Cvar _

--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -31,8 +31,6 @@ val size_expr : environment -> Cmm.expression -> int
 
 val select_mutable_flag : Asttypes.mutable_flag -> Mach.mutable_flag
 
-module Region_stack : sig type t end
-
 module Effect : sig
   type t =
     | None
@@ -164,14 +162,8 @@ class virtual selector_generic : object
   method insert_move_results :
     environment -> Reg.t array -> Reg.t array -> int -> unit
   method insert_moves : environment -> Reg.t array -> Reg.t array -> unit
-  method insert_endregions :
-    environment -> Reg.t array list -> unit
-  method insert_endregions_until :
-    environment -> suffix:Region_stack.t -> Region_stack.t -> unit
   method emit_expr :
     environment -> Cmm.expression -> Reg.t array option
-  method emit_expr_aux :
-    environment -> Cmm.expression -> (Reg.t array * Region_stack.t) option
   method emit_tail : environment -> Cmm.expression -> unit
 
   (* [contains_calls] is declared as a reference instance variable,

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -674,19 +674,18 @@ and simplify_set_of_closures original_env r
   let r = ret r (A.value_set_of_closures value_set_of_closures) in
   set_of_closures, r, value_set_of_closures.freshening
 
-and mark_region_used_for_apply ~(reg_close : Lambda.region_close) ~(mode : Lambda.alloc_mode) r =
-  match reg_close, mode with
-  | (Rc_normal | Rc_nontail), Alloc_heap -> r
-  | Rc_close_at_apply, _
-  | _, Alloc_local -> R.set_region_use r true
-
 and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
   let {
     Flambda. func = lhs_of_application; args; kind = _; dbg; reg_close; mode;
     inlined = inlined_requested; specialise = specialise_requested;
     probe = probe_requested; result_layout
   } = apply in
-  let r = mark_region_used_for_apply ~reg_close ~mode r in
+  let r =
+    match reg_close, mode with
+    | (Rc_normal | Rc_nontail), Alloc_heap -> r
+    | Rc_close_at_apply, _
+    | _, Alloc_local -> R.set_region_use r true
+  in
   let dbg = E.add_inlined_debuginfo env ~dbg in
   simplify_free_variable env lhs_of_application
     ~f:(fun env lhs_of_application lhs_of_application_approx ->
@@ -1314,7 +1313,6 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
     let body, r = simplify env r body in
     While (cond, body), ret r (A.value_unknown Other)
   | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
-    let r = mark_region_used_for_apply ~reg_close ~mode r in
     let dbg = E.add_inlined_debuginfo env ~dbg in
     simplify_free_variable env meth ~f:(fun env meth _meth_approx ->
       simplify_free_variable env obj ~f:(fun env obj _obj_approx ->

--- a/ocaml/asmcomp/selectgen.ml
+++ b/ocaml/asmcomp/selectgen.ml
@@ -24,52 +24,17 @@ module Int = Numbers.Int
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
-module Region_stack : sig
-  (* A nested set of regions, with the innermost at the head *)
-  type t = Reg.t array list
-
-  val equal : t -> t -> bool
-
-  (* Given two region stacks that are suffixes of the same
-     original stack, return their common suffix.
-
-     (This is always the shorter of the two arguments) *)
-  val common_suffix : t -> t -> t
-
-  (* Given a region stack R and one of its suffixes S,
-     return the prefix P where R = P @ S *)
-  val strip_suffix : suffix:t -> t -> t
-end  = struct
-  type t = Reg.t array list
-
-  let equal a b =
-    (a == b) || List.equal (==) a b
-
-  let common_suffix xs ys =
-    if xs == ys || List.compare_lengths xs ys <= 0
-    then xs
-    else ys
-
-  let strip_suffix ~suffix t =
-    match suffix with
-    | [] -> t
-    | _ when suffix == t -> []
-    | suff ->
-       let pre, suff' =
-         Misc.Stdlib.List.split_at (List.length t - List.length suff) t
-       in
-       assert (equal suff' suff);
-       pre
-end
+type region_stack = Reg.t array list
 
 type environment =
   { vars : (Reg.t array
             * Backend_var.Provenance.t option
             * Asttypes.mutable_flag) V.Map.t;
-    static_exceptions : (Reg.t array list * Region_stack.t) Int.Map.t;
+    static_exceptions : (Reg.t array list * region_stack) Int.Map.t;
     (** Which registers must be populated when jumping to the given
         handler. *)
-    regions : Region_stack.t;
+    regions : region_stack;
+    region_tail : bool;
   }
 
 let env_add ?(mut=Asttypes.Immutable) var regs env =
@@ -101,7 +66,22 @@ let env_empty = {
   vars = V.Map.empty;
   static_exceptions = Int.Map.empty;
   regions = [];
+  region_tail = false;
 }
+
+(* Assuming [rs] is equal to or a suffix of [env.regions],
+   return the last region in [env.regions] but not [rs]
+   (or None if they are equal) *)
+let env_close_regions env rs =
+  let rec aux v es rs =
+    match es, rs with
+    | [], [] -> v
+    | (r :: _), (r' :: _) when r == r' -> v
+    | [], _::_ ->
+       Misc.fatal_error "Selectgen.env_close_regions: not a suffix"
+    | r :: es, rs -> aux (Some r) es rs
+  in
+  aux None env.regions rs
 
 (* Infer the type of the result of an operation *)
 
@@ -213,7 +193,7 @@ let join env opt_r1 seq1 opt_r2 seq2 =
   match (opt_r1, opt_r2) with
     (None, _) -> opt_r2
   | (_, None) -> opt_r1
-  | (Some (r1, uncl1), Some (r2, uncl2)) ->
+  | (Some r1, Some r2) ->
       let l1 = Array.length r1 in
       assert (l1 = Array.length r2);
       let r = Array.make l1 Reg.dummy in
@@ -235,10 +215,7 @@ let join env opt_r1 seq1 opt_r2 seq2 =
           seq2#insert_move env r2.(i) r.(i)
         end
       done;
-      let suffix = Region_stack.common_suffix uncl1 uncl2 in
-      seq1#insert_endregions_until env ~suffix uncl1;
-      seq2#insert_endregions_until env ~suffix uncl2;
-      Some (r, suffix)
+      Some r
 
 (* Same, for N branches *)
 
@@ -248,19 +225,18 @@ let join_array env rs =
     let (r, _) = rs.(i) in
     match r with
     | None -> ()
-    | Some (r, uncl) ->
+    | Some r ->
       match !some_res with
-      | None ->
-        some_res := Some (r, Array.map (fun r -> r.typ) r, uncl)
-      | Some (r', types, uncl') ->
+      | None -> some_res := Some (r, Array.map (fun r -> r.typ) r)
+      | Some (r', types) ->
         let types =
           Array.map2 (fun r typ -> Cmm.lub_component r.typ typ) r types
         in
-        some_res := Some (r', types, Region_stack.common_suffix uncl uncl')
+        some_res := Some (r', types)
   done;
   match !some_res with
     None -> None
-  | Some (template, types, regions) ->
+  | Some (template, types) ->
       let size_res = Array.length template in
       let res = Array.make size_res Reg.dummy in
       for i = 0 to size_res - 1 do
@@ -270,11 +246,9 @@ let join_array env rs =
         let (r, s) = rs.(i) in
         match r with
           None -> ()
-        | Some (r, uncl) ->
-           s#insert_moves env r res;
-           s#insert_endregions_until env ~suffix:regions uncl;
+        | Some r -> s#insert_moves env r res
       done;
-      Some (res, regions)
+      Some res
 
 (* Name of function being compiled *)
 let current_function_name = ref ""
@@ -356,7 +330,7 @@ end
 
 (* The default instruction selection class *)
 
-class virtual selector_generic = object (self : 'self)
+class virtual selector_generic = object (self)
 
 (* A syntactic criterion used in addition to judgements about (co)effects as
    to whether the evaluation of a given expression may be deferred by
@@ -667,50 +641,23 @@ method insert_op_debug env op dbg rs rd =
 method insert_op env op rs rd =
   self#insert_op_debug env op Debuginfo.none rs rd
 
-method insert_endregions env regions =
-  match regions with
-  | [] -> ()
-  | regions ->
-     (* Coalesce multiple simultaneous Iendregion *)
-     let final_region = List.hd (List.rev regions) in
-     self#insert env (Iop Iendregion) final_region [| |]
+(* Add the instructions for the given expression
+   at the end of the self sequence *)
 
-method insert_endregions_until env ~suffix regions =
-  self#insert_endregions env (Region_stack.strip_suffix ~suffix regions)
-
-(* Emit an expression, which is assumed not to end any regions early.
-   (This holds for any expression not in tail position of Cregion)
-
-   Returns:
-     - [None] if the expression does not finish normally (e.g. raises)
-     - [Some rs] if the expression yields a result in registers [rs] *)
 method emit_expr (env:environment) exp =
-  match self#emit_expr_aux env exp with
-  | None -> None
-  | Some (res, unclosed) ->
-     assert (Region_stack.equal unclosed env.regions);
-     Some res
-
-(* Emit an expression which may end some regions early.
-
-   Returns:
-    - [None] if the expression does not finish normally (e.g. raises)
-    - [Some (rs, unclosed)] if the expression yields a result in [rs],
-      having left [unclosed] (a suffix of env.regions) regions open *)
-method emit_expr_aux (env:environment) exp :
-  (Reg.t array * Region_stack.t) option =
-  (* Normal case of returning a value: no regions are closed *)
-  let ret res = Some (res, env.regions) in
+  (* Environment used in recursive calls not in tail position *)
+  let env' =
+    if env.region_tail then {env with region_tail=false} else env in
   match exp with
     Cconst_int (n, _dbg) ->
       let r = self#regs_for typ_int in
-      ret (self#insert_op env (Iconst_int(Nativeint.of_int n)) [||] r)
+      Some(self#insert_op env (Iconst_int(Nativeint.of_int n)) [||] r)
   | Cconst_natint (n, _dbg) ->
       let r = self#regs_for typ_int in
-      ret (self#insert_op env (Iconst_int n) [||] r)
+      Some(self#insert_op env (Iconst_int n) [||] r)
   | Cconst_float (n, _dbg) ->
       let r = self#regs_for typ_float in
-      ret (self#insert_op env (Iconst_float (Int64.bits_of_float n)) [||] r)
+      Some(self#insert_op env (Iconst_float (Int64.bits_of_float n)) [||] r)
   | Cconst_symbol (n, _dbg) ->
       (* Cconst_symbol _ evaluates to a statically-allocated address, so its
          value fits in a typ_int register and is never changed by the GC.
@@ -720,46 +667,46 @@ method emit_expr_aux (env:environment) exp :
          registered in the compilation unit's global roots structure, so
          adding this register to the frame table would be redundant *)
       let r = self#regs_for typ_int in
-      ret (self#insert_op env (Iconst_symbol n) [||] r)
+      Some(self#insert_op env (Iconst_symbol n) [||] r)
   | Cvar v ->
       begin try
-        ret (env_find v env)
+        Some(env_find v env)
       with Not_found ->
         Misc.fatal_error("Selection.emit_expr: unbound var " ^ V.unique_name v)
       end
   | Clet(v, e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> None
-      | Some r1 -> self#emit_expr_aux (self#bind_let env v r1) e2
+      | Some r1 -> self#emit_expr (self#bind_let env v r1) e2
       end
   | Clet_mut(v, k, e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> None
-      | Some r1 -> self#emit_expr_aux (self#bind_let_mut env v k r1) e2
+      | Some r1 -> self#emit_expr (self#bind_let_mut env v k r1) e2
       end
   | Cphantom_let (_var, _defining_expr, body) ->
-      self#emit_expr_aux env body
+      self#emit_expr env body
   | Cassign(v, e1) ->
       let rv =
         try
           env_find_mut v env
         with Not_found ->
           Misc.fatal_error ("Selection.emit_expr: unbound var " ^ V.name v) in
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> None
       | Some r1 ->
-          self#insert_moves env r1 rv; ret [||]
+          self#insert_moves env r1 rv; Some [||]
       end
   | Ctuple [] ->
-      ret [||]
+      Some [||]
   | Ctuple exp_list ->
-      begin match self#emit_parts_list env exp_list with
+      begin match self#emit_parts_list env' exp_list with
         None -> None
       | Some(simple_list, ext_env) ->
-          ret (self#emit_tuple ext_env simple_list)
+          Some(self#emit_tuple ext_env simple_list)
       end
   | Cop(Craise k, [arg], dbg) ->
-      begin match self#emit_expr env arg with
+      begin match self#emit_expr env' arg with
         None -> None
       | Some r1 ->
           let rd = [|Proc.loc_exn_bucket|] in
@@ -768,7 +715,7 @@ method emit_expr_aux (env:environment) exp :
           None
       end
   | Cop(Ccmpf _, _, dbg) ->
-      self#emit_expr_aux env
+      self#emit_expr env
         (Cifthenelse (exp,
           dbg, Cconst_int (1, dbg),
           dbg, Cconst_int (0, dbg),
@@ -778,42 +725,35 @@ method emit_expr_aux (env:environment) exp :
         None -> None
       | Some (simple_args, env) ->
          let rs = self#emit_tuple env simple_args in
-         ret (self#insert_op_debug env Iopaque dbg rs rs)
+         Some (self#insert_op_debug env Iopaque dbg rs rs)
       end
   | Cop(op, args, dbg) ->
-      begin match self#emit_parts_list env args with
+      begin match self#emit_parts_list env' args with
         None -> None
       | Some(simple_args, env) ->
           let ty = oper_result_type op in
-          let unclosed_regions =
-            match op with
-            | Capply (_, Rc_close_at_apply) -> List.tl env.regions
-            | _ -> env.regions
-          in
           let (new_op, new_args) = self#select_operation op simple_args dbg in
           match new_op with
             Icall_ind ->
               let r1 = self#emit_tuple env new_args in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               let rd = self#regs_for ty in
-              self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
               let loc_res = Proc.loc_results (Reg.typv rd) in
               self#insert_move_args env rarg loc_arg stack_ofs;
               self#insert_debug env (Iop new_op) dbg
                           (Array.append [|r1.(0)|] loc_arg) loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
-              Some (rd, unclosed_regions)
+              Some rd
           | Icall_imm _ ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
-              self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
               let loc_res = Proc.loc_results (Reg.typv rd) in
               self#insert_move_args env r1 loc_arg stack_ofs;
               self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
-              Some (rd, unclosed_regions)
+              Some rd
           | Iextcall { ty_args; _} ->
               let (loc_arg, stack_ofs) =
                 self#emit_extcall_args env ty_args new_args in
@@ -822,8 +762,7 @@ method emit_expr_aux (env:environment) exp :
                 self#insert_op_debug env new_op dbg
                   loc_arg (Proc.loc_external_results (Reg.typv rd)) in
               self#insert_move_results env loc_res rd stack_ofs;
-              assert (Region_stack.equal unclosed_regions env.regions);
-              ret rd
+              Some rd
           | Ialloc { bytes = _; mode } ->
               let rd = self#regs_for typ_val in
               let bytes = size_expr env (Ctuple new_args) in
@@ -836,33 +775,31 @@ method emit_expr_aux (env:environment) exp :
               in
               self#insert_debug env (Iop op) dbg [||] rd;
               self#emit_stores env new_args rd;
-              assert (Region_stack.equal unclosed_regions env.regions);
-              ret rd
+              Some rd
           | op ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
-              assert (Region_stack.equal unclosed_regions env.regions);
-              ret (self#insert_op_debug env op dbg r1 rd)
+              Some (self#insert_op_debug env op dbg r1 rd)
       end
   | Csequence(e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> None
-      | Some _ -> self#emit_expr_aux env e2
+      | Some _ -> self#emit_expr env e2
       end
   | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, _dbg, _kind) ->
       let (cond, earg) = self#select_condition econd in
-      begin match self#emit_expr env earg with
+      begin match self#emit_expr env' earg with
         None -> None
       | Some rarg ->
-          let (rif, (sif : 'self)) = self#emit_sequence env eif in
-          let (relse, (selse : 'self)) = self#emit_sequence env eelse in
+          let (rif, sif) = self#emit_sequence env eif in
+          let (relse, selse) = self#emit_sequence env eelse in
           let r = join env rif sif relse selse in
           self#insert env (Iifthenelse(cond, sif#extract, selse#extract))
                       rarg [||];
           r
       end
   | Cswitch(esel, index, ecases, _dbg, _kind) ->
-      begin match self#emit_expr env esel with
+      begin match self#emit_expr env' esel with
         None -> None
       | Some rsel ->
           let rscases =
@@ -875,7 +812,7 @@ method emit_expr_aux (env:environment) exp :
           r
       end
   | Ccatch(_, [], e1, _) ->
-      self#emit_expr_aux env e1
+      self#emit_expr env e1
   | Ccatch(rec_flag, handlers, body, _) ->
       let handlers =
         List.map (fun (nfail, ids, e2, dbg) ->
@@ -887,6 +824,9 @@ method emit_expr_aux (env:environment) exp :
             (nfail, ids, rs, e2, dbg))
           handlers
       in
+      let env =
+        (* Disable region-fusion on loops *)
+        match rec_flag with Recursive -> env' | Nonrecursive -> env in
       let env =
         (* Since the handlers may be recursive, and called from the body,
            the same environment is used for translating both the handlers and
@@ -913,7 +853,7 @@ method emit_expr_aux (env:environment) exp :
         [||] [||];
       r
   | Cexit (nfail,args) ->
-      begin match self#emit_parts_list env args with
+      begin match self#emit_parts_list env' args with
         None -> None
       | Some (simple_list, ext_env) ->
           let src = self#emit_tuple ext_env simple_list in
@@ -930,7 +870,10 @@ method emit_expr_aux (env:environment) exp :
           Array.iter (fun reg -> assert(reg.typ <> Addr)) src;
           self#insert_moves env src tmp_regs ;
           self#insert_moves env tmp_regs (Array.concat dest_args) ;
-          self#insert_endregions_until env ~suffix:dest_regions env.regions;
+          begin match env_close_regions env dest_regions with
+          | None -> ()
+          | Some regs -> self#insert env (Iop Iendregion) regs [||]
+          end;
           self#insert env (Iexit nfail) [||] [||];
           None
       end
@@ -956,33 +899,22 @@ method emit_expr_aux (env:environment) exp :
       r
   | Cregion e ->
      assert (Config.stack_allocation);
-     let old_regions = env.regions in
      let reg = self#regs_for typ_int in
      self#insert env (Iop Ibeginregion) [| |] reg;
-     let env = { env with regions = reg :: old_regions } in
-     begin match self#emit_expr_aux env e with
-     | None -> None
-     | Some (rd, reg' :: unclosed) when reg == reg' ->
-        (* Compiling e closed no regions *)
-        assert (Region_stack.equal unclosed old_regions);
-        self#insert_endregions env [reg];
-        Some (rd, unclosed)
-     | Some (rd, unclosed) ->
-        (* Compiling e closed [reg], and possibly other regions too *)
-        assert (List.length unclosed <= List.length old_regions);
-        Some (rd, unclosed)
+     let env = { env with regions = reg::env.regions; region_tail = true } in
+     begin match self#emit_expr env e with
+       None -> None
+     | Some _ as res ->
+        self#insert env (Iop Iendregion) reg [| |];
+        res
      end
   | Ctail e ->
-     begin match env.regions with
-     | [] -> Misc.fatal_error "Selectgen.emit_expr: Ctail but not in tail of a region"
-     | cl :: rest ->
-       self#insert_endregions env [cl];
-       self#emit_expr_aux { env with regions = rest } e
-     end
+      assert env.region_tail;
+      self#emit_expr env e
 
-method private emit_sequence (env:environment) exp : _ * 'self=
-  let s : 'self = {< instr_seq = dummy_instr >} in
-  let r = s#emit_expr_aux env exp in
+method private emit_sequence (env:environment) exp =
+  let s = {< instr_seq = dummy_instr >} in
+  let r = s#emit_expr env exp in
   (r, s)
 
 method private bind_let (env:environment) v r1 =
@@ -1156,54 +1088,49 @@ method emit_stores env data regs_addr =
 method private insert_return (env:environment) r =
   match r with
     None -> ()
-  | Some (r, unclosed_regions) ->
-      self#insert_endregions env unclosed_regions;
+  | Some r ->
       let loc = Proc.loc_results (Reg.typv r) in
+      if env.region_tail then
+        self#insert env (Iop Iendregion) (List.hd env.regions) [||];
       self#insert_moves env r loc;
       self#insert env Ireturn loc [||]
 
 method private emit_return (env:environment) exp =
-  self#insert_return env (self#emit_expr_aux env exp)
+  self#insert_return env (self#emit_expr env exp)
 
-method private tail_call_possible (env:environment) (pos:Lambda.region_close) =
-  match pos, env.regions with
-  | (Rc_normal | Rc_nontail), [] -> true
-  | (Rc_normal | Rc_nontail), _ :: _ -> false
-  | Rc_close_at_apply, [] ->
-     Misc.fatal_error "Selectgen: Rc_close_at_apply with no region to close"
-  | Rc_close_at_apply, [_] -> true
-  | Rc_close_at_apply, _ :: _ :: _ -> false
-
-(* Emit an expression in tail position of a function,
-   closing all regions in [env.regions] *)
 method emit_tail (env:environment) exp =
+  let env' =
+    if env.region_tail then {env with region_tail=false} else env in
   match exp with
     Clet(v, e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> ()
       | Some r1 -> self#emit_tail (self#bind_let env v r1) e2
       end
   | Clet_mut (v, k, e1, e2) ->
-     begin match self#emit_expr env e1 with
+     begin match self#emit_expr env' e1 with
        None -> ()
      | Some r1 -> self#emit_tail (self#bind_let_mut env v k r1) e2
      end
   | Cphantom_let (_var, _defining_expr, body) ->
       self#emit_tail env body
   | Cop((Capply(ty, ((Rc_close_at_apply | Rc_normal) as pos))) as op,
-        args, dbg)
-       when self#tail_call_possible env pos ->
-      begin match self#emit_parts_list env args with
+        args, dbg) ->
+      let tail = (pos = Lambda.Rc_close_at_apply) in
+      let endregion = env.region_tail in
+      begin match self#emit_parts_list env' args with
         None -> ()
       | Some(simple_args, env) ->
           let (new_op, new_args) = self#select_operation op simple_args dbg in
           match new_op with
             Icall_ind ->
               let r1 = self#emit_tuple env new_args in
+              if endregion && tail then
+                self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+              let endregion = endregion && not tail in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
-              self#insert_endregions env env.regions;
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
-              if stack_ofs = 0 then begin
+              if stack_ofs = 0 && not endregion then begin
                 let call = Iop (Itailcall_ind) in
                 self#insert_moves env rarg loc_arg;
                 self#insert_debug env call dbg
@@ -1214,18 +1141,27 @@ method emit_tail (env:environment) exp =
                 self#insert_move_args env rarg loc_arg stack_ofs;
                 self#insert_debug env (Iop new_op) dbg
                             (Array.append [|r1.(0)|] loc_arg) loc_res;
-                self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
+                if not endregion then begin
+                  self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||]
+                end else begin
+                  self#insert_move_results env loc_res rd stack_ofs;
+                  self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+                  self#insert_moves env rd loc_res
+                end;
                 self#insert env Ireturn loc_res [||]
               end
           | Icall_imm { func; } ->
               let r1 = self#emit_tuple env new_args in
-              self#insert_endregions env env.regions;
+              if endregion && tail then
+                self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+              let endregion = endregion && not tail in
               let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
-              if stack_ofs = 0 then begin
+              if stack_ofs = 0 && not endregion then begin
                 let call = Iop (Itailcall_imm { func; }) in
                 self#insert_moves env r1 loc_arg;
                 self#insert_debug env call dbg loc_arg [||];
-              end else if func = !current_function_name then begin
+              end else if func = !current_function_name
+                       && not endregion then begin
                 let call = Iop (Itailcall_imm { func; }) in
                 let loc_arg' = Proc.loc_parameters (Reg.typv r1) in
                 self#insert_moves env r1 loc_arg';
@@ -1235,19 +1171,25 @@ method emit_tail (env:environment) exp =
                 let loc_res = Proc.loc_results (Reg.typv rd) in
                 self#insert_move_args env r1 loc_arg stack_ofs;
                 self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
-                self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
+                if not endregion then begin
+                  self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||]
+                end else begin
+                  self#insert_move_results env loc_res rd stack_ofs;
+                  self#insert env (Iop Iendregion) (List.hd env.regions) [||];
+                  self#insert_moves env rd loc_res
+                end;
                 self#insert env Ireturn loc_res [||]
               end
           | _ -> Misc.fatal_error "Selection.emit_tail"
       end
   | Csequence(e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env' e1 with
         None -> ()
       | Some _ -> self#emit_tail env e2
       end
   | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, _dbg, _kind) ->
       let (cond, earg) = self#select_condition econd in
-      begin match self#emit_expr env earg with
+      begin match self#emit_expr env' earg with
         None -> ()
       | Some rarg ->
           self#insert env
@@ -1256,7 +1198,7 @@ method emit_tail (env:environment) exp =
                       rarg [||]
       end
   | Cswitch(esel, index, ecases, _dbg, _kind) ->
-      begin match self#emit_expr env esel with
+      begin match self#emit_expr env' esel with
         None -> ()
       | Some rsel ->
           let cases =
@@ -1277,6 +1219,9 @@ method emit_tail (env:environment) exp =
                 ids in
             (nfail, ids, rs, e2, dbg))
           handlers in
+      let env =
+        (* Disable region-fusion on loops *)
+        match rec_flag with Recursive -> env' | Nonrecursive -> env in
       let env =
         List.fold_left (fun env (nfail, _ids, rs, _e2, _dbg) ->
             env_add_static_exception nfail rs env)
@@ -1313,16 +1258,19 @@ method emit_tail (env:environment) exp =
       self#insert_return env opt_r1
   | Cregion e ->
       assert (Config.stack_allocation);
-      let reg = self#regs_for typ_int in
-      self#insert env (Iop Ibeginregion) [| |] reg;
-      self#emit_tail {env with regions = reg::env.regions} e
-  | Ctail e ->
-      begin match env.regions with
-      | [] -> Misc.fatal_error "Selectgen.emit_tail: Ctail not inside Cregion"
-      | reg :: regions ->
-         self#insert_endregions env [reg];
-         self#emit_tail { env with regions } e
+      if env.region_tail then
+        self#emit_return env exp
+      else begin
+        let reg = self#regs_for typ_int in
+        self#insert env (Iop Ibeginregion) [| |] reg;
+        let env' = { env with regions = reg::env.regions; region_tail = true } in
+        self#emit_tail env' e
       end
+  | Ctail e ->
+      assert env.region_tail;
+      self#insert env' (Iop Iendregion) (List.hd env.regions) [| |];
+      self#emit_tail { env with regions = List.tl env.regions;
+                                region_tail = false } e
   | Cop _
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
   | Cvar _

--- a/ocaml/asmcomp/selectgen.mli
+++ b/ocaml/asmcomp/selectgen.mli
@@ -29,8 +29,6 @@ val env_find : Backend_var.t -> environment -> Reg.t array
 
 val size_expr : environment -> Cmm.expression -> int
 
-module Region_stack : sig type t end
-
 module Effect : sig
   type t =
     | None
@@ -161,14 +159,8 @@ class virtual selector_generic : object
   method insert_move_results :
     environment -> Reg.t array -> Reg.t array -> int -> unit
   method insert_moves : environment -> Reg.t array -> Reg.t array -> unit
-  method insert_endregions :
-    environment -> Reg.t array list -> unit
-  method insert_endregions_until :
-    environment -> suffix:Region_stack.t -> Region_stack.t -> unit
   method emit_expr :
     environment -> Cmm.expression -> Reg.t array option
-  method emit_expr_aux :
-    environment -> Cmm.expression -> (Reg.t array * Region_stack.t) option
   method emit_tail : environment -> Cmm.expression -> unit
 
   (* [contains_calls] is declared as a reference instance variable,

--- a/ocaml/middle_end/flambda/inline_and_simplify.ml
+++ b/ocaml/middle_end/flambda/inline_and_simplify.ml
@@ -673,19 +673,18 @@ and simplify_set_of_closures original_env r
   let r = ret r (A.value_set_of_closures value_set_of_closures) in
   set_of_closures, r, value_set_of_closures.freshening
 
-and mark_region_used_for_apply ~(reg_close : Lambda.region_close) ~(mode : Lambda.alloc_mode) r =
-  match reg_close, mode with
-  | (Rc_normal | Rc_nontail), Alloc_heap -> r
-  | Rc_close_at_apply, _
-  | _, Alloc_local -> R.set_region_use r true
-
 and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
   let {
     Flambda. func = lhs_of_application; args; kind = _; dbg; reg_close; mode;
     inlined = inlined_requested; specialise = specialise_requested;
     probe = probe_requested; result_layout
   } = apply in
-  let r = mark_region_used_for_apply ~reg_close ~mode r in
+  let r =
+    match reg_close, mode with
+    | (Rc_normal | Rc_nontail), Alloc_heap -> r
+    | Rc_close_at_apply, _
+    | _, Alloc_local -> R.set_region_use r true
+  in
   let dbg = E.add_inlined_debuginfo env ~dbg in
   simplify_free_variable env lhs_of_application
     ~f:(fun env lhs_of_application lhs_of_application_approx ->
@@ -1313,7 +1312,6 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
     let body, r = simplify env r body in
     While (cond, body), ret r (A.value_unknown Other)
   | Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout } ->
-    let r = mark_region_used_for_apply ~reg_close ~mode r in
     let dbg = E.add_inlined_debuginfo env ~dbg in
     simplify_free_variable env meth ~f:(fun env meth _meth_approx ->
       simplify_free_variable env obj ~f:(fun env obj _obj_approx ->

--- a/ocaml/testsuite/tests/typing-local/regions.ml
+++ b/ocaml/testsuite/tests/typing-local/regions.ml
@@ -82,16 +82,6 @@ let () =
   check_empty "after direct overtail"
 
 
-let[@inline always] do_inlined_tailcall g =
-  let local_ r = ref 42 in
-  let _ = opaque_identity r in
-  g ()
-
-let () =
-  do_inlined_tailcall (fun () ->
-    check_empty "during inlined tailcall");
-  check_empty "after inlined tailcall"
-
 
 let[@inline never] local_ret a b = local_ ref (a + b)
 let[@inline never] calls_local_ret () =

--- a/ocaml/testsuite/tests/typing-local/regions.reference
+++ b/ocaml/testsuite/tests/typing-local/regions.reference
@@ -9,8 +9,6 @@
   after indirect overtail: OK
    during direct overtail: OK
     after direct overtail: OK
-  during inlined tailcall: OK
-   after inlined tailcall: OK
             apply merging: OK
          toplevel binding: OK
      toplevel rec binding: OK


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#1131

The assertion on line 833 of `selectgen.ml` is failing on the JS tree.