### PR TITLE
Restore Cmm unboxing behaviour inside regions

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -672,7 +672,7 @@ let test_bool dbg cmm =
 
 let box_float dbg m c = Cop (Calloc m, [alloc_float_header m dbg; c], dbg)
 
-let unbox_float dbg =
+let rec unbox_float dbg =
   map_tail ~kind:Vfloat (function
     | Cop (Calloc _, [Cconst_natint (hdr, _); c], _)
       when Nativeint.equal hdr float_header
@@ -682,6 +682,19 @@ let unbox_float dbg =
       match Cmmgen_state.structured_constant_of_sym s with
       | Some (Uconst_float x) -> Cconst_float (x, dbg) (* or keep _dbg? *)
       | _ -> Cop (Cload (Double, Immutable), [cmm], dbg))
+    | Cregion e as cmm -> (
+      (* It is valid to push unboxing inside a Cregion except when the extra
+         unboxing logic pushes a tail call out of tail position *)
+      match
+        map_tail ~kind:Vfloat
+          (function
+            | Cop (Capply (_, Rc_close_at_apply), _, _) -> raise Exit
+            | Ctail e -> Ctail (unbox_float dbg e)
+            | e -> unbox_float dbg e)
+          e
+      with
+      | e -> Cregion e
+      | exception Exit -> Cop (Cload (Double, Immutable), [cmm], dbg))
     | cmm -> Cop (Cload (Double, Immutable), [cmm], dbg))
 
 (* Complex *)
@@ -1409,7 +1422,7 @@ let alloc_matches_boxed_int bi ~hdr ~ops =
     && String.equal sym caml_int64_ops
   | (Pnativeint | Pint32 | Pint64), _, _ -> false
 
-let unbox_int dbg bi =
+let rec unbox_int dbg bi =
   let default arg =
     if size_int = 4 && bi = Primitive.Pint64
     then split_int64_for_32bit_target arg dbg
@@ -1458,6 +1471,19 @@ let unbox_int dbg bi =
             Ctuple
               [natint_const_untagged dbg low; natint_const_untagged dbg high]
       | _ -> default cmm)
+    | Cregion e as cmm -> (
+      (* It is valid to push unboxing inside a Cregion except when the extra
+         unboxing logic pushes a tail call out of tail position *)
+      match
+        map_tail ~kind:Vint
+          (function
+            | Cop (Capply (_, Rc_close_at_apply), _, _) -> raise Exit
+            | Ctail e -> Ctail (unbox_int dbg bi e)
+            | e -> unbox_int dbg bi e)
+          e
+      with
+      | e -> Cregion e
+      | exception Exit -> default cmm)
     | cmm -> default cmm)
 
 let make_unsigned_int bi arg dbg =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -695,6 +695,7 @@ let rec unbox_float dbg =
       with
       | e -> Cregion e
       | exception Exit -> Cop (Cload (Double, Immutable), [cmm], dbg))
+    | Ctail e -> Ctail (unbox_float dbg e)
     | cmm -> Cop (Cload (Double, Immutable), [cmm], dbg))
 
 (* Complex *)
@@ -1484,6 +1485,7 @@ let rec unbox_int dbg bi =
       with
       | e -> Cregion e
       | exception Exit -> default cmm)
+    | Ctail e -> Ctail (unbox_int dbg bi e)
     | cmm -> default cmm)
 
 let make_unsigned_int bi arg dbg =

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -394,8 +394,7 @@ let rec is_unboxed_number_cmm = function
           No_unboxing
       end
     | Cexit _ | Cop (Craise _, _, _) -> No_result
-    | Cregion _ | Ctail _ -> No_unboxing
-    | Csequence (_, a)
+    | Csequence (_, a) | Cregion a | Ctail a
     | Clet (_, _, a) | Cphantom_let (_, _, a) | Clet_mut (_, _, _, a) ->
       is_unboxed_number_cmm a
     | Cconst_int _

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -368,6 +368,8 @@ let is_unboxed_number_cmm ~strict cmm =
         | _ ->
             notify No_unboxing
         end
+    | Cregion e | Ctail e ->
+        aux e
     | l ->
         if not (Cmm.iter_shallow_tail aux l) then
           notify No_unboxing

--- a/ocaml/testsuite/tests/typing-local/regression_cmm_unboxing.ml
+++ b/ocaml/testsuite/tests/typing-local/regression_cmm_unboxing.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+   * native
+*)
 
 (* Regression test for a bad interaction between Cmm unboxing
    and regions present after inlining *)
@@ -21,3 +23,43 @@ let () =
   Printf.printf "%Ld %Ld\n"
     (h 42L false f)
     (h 42L true f)
+
+
+let[@inline always] f a b =
+  let _ = opaque_local (local_ ref 42) in
+  if a < b then
+    a +. (a *. b)
+  else
+    a *. b
+
+let[@inline never] g a b =
+  let n = f a b in
+  assert (n = 3.)
+
+let () =
+  let prebefore = Gc.minor_words () in
+  let before = Gc.minor_words () in
+  g 1. 2.;
+  let after = Gc.minor_words () in
+  Printf.printf "%.0f words\n"
+    (after -. before -. (before -. prebefore))
+
+
+let[@inline always] f a b =
+  let _ = opaque_local (local_ ref 42) in
+  if a < b then
+    Int64.add a (Int64.mul a b)
+  else
+    Int64.mul a b
+
+let[@inline never] g a b =
+  let n = f a b in
+  assert (n = 3L)
+
+let () =
+  let prebefore = Gc.minor_words () in
+  let before = Gc.minor_words () in
+  g 1L 2L;
+  let after = Gc.minor_words () in
+  Printf.printf "%.0f words\n"
+    (after -. before -. (before -. prebefore));

--- a/ocaml/testsuite/tests/typing-local/regression_cmm_unboxing.reference
+++ b/ocaml/testsuite/tests/typing-local/regression_cmm_unboxing.reference
@@ -1,1 +1,3 @@
 44 3
+0 words
+0 words


### PR DESCRIPTION
PR #1284 fixed a Cmm unboxing bug, in which Cmmgen would generate invalid Cmm by pushing unboxing operations inside `Cregion`, potentially moving tail calls out of tail position.

However, the fix was overly broad, making Cmm unboxing weaker in a way that broke some tests. So, this patch restores the Cmm unboxing in cases where it is safe to push the unboxing into a region (i.e. when there are no tail calls to disrupt).

(A more advanced implementation might convert the tail calls to use the `Ctail` constructor, but that doesn't seem to be necessary in the cases of interest)