### PR TITLE
Fix closure marshalling when not in NNP mode

### DIFF
--- a/ocaml/runtime/extern.c
+++ b/ocaml/runtime/extern.c
@@ -663,7 +663,6 @@ static void extern_code_pointer(char * codeptr)
 
 /* Marshaling the non-scanned-environment part of closures */
 
-#ifdef NO_NAKED_POINTERS
 Caml_inline mlsize_t extern_closure_up_to_env(value v)
 {
   mlsize_t startenv, i;
@@ -691,7 +690,6 @@ Caml_inline mlsize_t extern_closure_up_to_env(value v)
   }
   return startenv;
 }
-#endif
 
 /* Marshal the given value in the output buffer */
 
@@ -789,7 +787,6 @@ static void extern_rec(value v)
       extern_record_location(v, h);
       break;
     }
-#ifdef NO_NAKED_POINTERS
     case Closure_tag: {
       mlsize_t i;
       extern_header(sz, tag);
@@ -809,7 +806,6 @@ static void extern_rec(value v)
       v = Field(v, i);
       continue;
     }
-#endif
     default: {
       extern_header(sz, tag);
       size_32 += 1 + sz;


### PR DESCRIPTION
The unboxed part of the environment was being treated as containing GC-scannable values when not in NNP mode.  This should be fixed simply by using the NNP code for marshalling closures all the time.