### PR TITLE
Re-enable parallel build of the runtime

### DIFF
--- a/ocaml/dune
+++ b/ocaml/dune
@@ -150,7 +150,7 @@
  (action
  (no-infer
   (progn
-   (chdir yacc (run make -s OCAMLYACC_INCLUDE_PATH=%{ocaml_where}))
+   (chdir yacc (run make -sj8 OCAMLYACC_INCLUDE_PATH=%{ocaml_where}))
    (copy yacc/ocamlyacc ocamlyacc)))))
 
 (install

--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -46,7 +46,7 @@
  (no-infer
    (progn
      (bash "touch .depend") ; hack.
-     (run make -s %{targets} COMPUTE_DEPS=false)
+     (run make -sj8 %{targets} COMPUTE_DEPS=false)
      (bash "rm .depend")))))
 
 (install


### PR DESCRIPTION
It seems like it works to add the `-j8` to sub-makes, so re-add them.