### PR TITLE
CFG: relax register allocation postcondition

### DIFF
--- a/backend/cfg/cfg_regalloc_utils.ml
+++ b/backend/cfg/cfg_regalloc_utils.ml
@@ -345,7 +345,11 @@ let postcondition : Cfg_with_layout.t -> allow_stack_operands:bool -> unit =
   in
   let reg_class = ref 0 in
   Array.iter2 max_stack_slots fun_num_stack_slots ~f:(fun max_slot num_slots ->
-      if succ max_slot <> num_slots
+      (* CR-soon xclerc for xclerc: make the condition stricter. The present
+         condition ensure safety: no access out of bounds (i.e. to another
+         frame), but could be made stricter to ensure optimiality (i.e. we use
+         every element from the frame). *)
+      if max_slot >= num_slots
       then
         fatal
           "register class %d has a max slot of %d, but the number of slots is \


### PR DESCRIPTION
This pull request slightly relaxes the postcondition
after register allocation regarding stack slots.

There are two interesting parts to that condition:
- safety: no access out of bounds (that would be
  a miscompilation);
- optimality: no unused elements in the frame.

The present condition is a bit weird in the sense
that it ensures safety, but only very partially
ensures optimality. The issue is that the code
does not guarantee optimality, so the part about
optimality can (admittedly very rarely) fail.

This pull request tweaks the condition to check
safety and say nothing about optimality, with a
CR to revisit the issue later.