### PR TITLE
zero_alloc: improve error message

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -183,6 +183,7 @@ module Annotation : sig
     Invalid of
       { a : t;
         fun_name : string;
+        fun_dbg : Debuginfo.t;
         property : Cmm.property
       }
 end = struct
@@ -235,20 +236,25 @@ end = struct
     Invalid of
       { a : t;
         fun_name : string;
+        fun_dbg : Debuginfo.t;
         property : Cmm.property
       }
 
-  let print_error ppf t ~fun_name ~property =
-    Format.fprintf ppf "Annotation check for %s%s failed on function %s"
+  let print_error ppf t ~fun_name ~fun_dbg ~property =
+    Format.fprintf ppf "Annotation check for %s%s failed on function %s (%s)"
       (Printcmm.property_to_string property)
       (if t.strict then " strict" else "")
+      (fun_dbg
+        |> List.map (fun dbg ->
+          Debuginfo.(Scoped_location.string_of_scopes dbg.dinfo_scopes))
+        |> String.concat ",")
       fun_name
 
   let report_error = function
-    | Invalid { a; fun_name; property } ->
+    | Invalid { a; fun_name; fun_dbg; property } ->
       Some
         (Location.error_of_printer ~loc:a.loc
-           (print_error ~fun_name ~property)
+           (print_error ~fun_name ~fun_dbg ~property)
            a)
     | _ -> None
 end
@@ -259,6 +265,7 @@ module Func_info = struct
      dependencies as the compilation unit is scanned. *)
   type t =
     { name : string;  (** function name *)
+      mutable dbg : Debuginfo.t; (** debug info associated with the function *)
       mutable value : Value.t;  (** the result of the check *)
       mutable annotation : Annotation.t option;
           (** [value] must be lessequal than the expected value
@@ -269,6 +276,7 @@ module Func_info = struct
 
   let create name =
     { name;
+      dbg = Debuginfo.none;
       value = Value.bot;
       annotation = None;
       unresolved_callers = String.Set.empty;
@@ -338,7 +346,7 @@ module Unit_info : sig
   (** [cleanup_deps] remove resolved dependencies starting from [name]. *)
   val cleanup_deps : t -> string -> unit
 
-  val record_annotation : t -> string -> Annotation.t option -> unit
+  val record_annotation : t -> string -> Debuginfo.t -> Annotation.t option -> unit
 
   val resolve_all : t -> unit
 
@@ -405,10 +413,11 @@ end = struct
 
   let join_value t name value = join_and_propagate t name ~value
 
-  let record_annotation t name annotation =
+  let record_annotation t name dbg annotation =
     let func_info = get_or_create t name in
     if Option.is_some func_info.annotation
     then Misc.fatal_errorf "Duplicate symbol %s" name;
+    func_info.dbg <- dbg;
     func_info.annotation <- annotation
 
   let record_deps t ~caller ~callees =
@@ -530,7 +539,8 @@ end = struct
              functions. *)
           raise
             (Annotation.Invalid
-               { a; fun_name = func_info.name; property = S.property }));
+               { a; fun_name = func_info.name; fun_dbg = func_info.dbg;
+                 property = S.property }));
       report_func_info ~msg:"record" ppf func_info;
       S.set_value func_info.name func_info.value
     in
@@ -740,7 +750,7 @@ end = struct
       let fun_name = f.fun_name in
       let t = create ppf fun_name future_funcnames unit_info in
       let a = Annotation.find f.fun_codegen_options S.property f.fun_dbg in
-      Unit_info.record_annotation unit_info fun_name a;
+      Unit_info.record_annotation unit_info fun_name f.fun_dbg a;
       match a with
       | Some a when Annotation.is_assume a ->
         let expected_value = Annotation.expected_value a in

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -245,9 +245,9 @@ end = struct
       (Printcmm.property_to_string property)
       (if t.strict then " strict" else "")
       (fun_dbg
-        |> List.map (fun dbg ->
-          Debuginfo.(Scoped_location.string_of_scopes dbg.dinfo_scopes))
-        |> String.concat ",")
+      |> List.map (fun dbg ->
+             Debuginfo.(Scoped_location.string_of_scopes dbg.dinfo_scopes))
+      |> String.concat ",")
       fun_name
 
   let report_error = function
@@ -265,7 +265,7 @@ module Func_info = struct
      dependencies as the compilation unit is scanned. *)
   type t =
     { name : string;  (** function name *)
-      mutable dbg : Debuginfo.t; (** debug info associated with the function *)
+      mutable dbg : Debuginfo.t;  (** debug info associated with the function *)
       mutable value : Value.t;  (** the result of the check *)
       mutable annotation : Annotation.t option;
           (** [value] must be lessequal than the expected value
@@ -346,7 +346,8 @@ module Unit_info : sig
   (** [cleanup_deps] remove resolved dependencies starting from [name]. *)
   val cleanup_deps : t -> string -> unit
 
-  val record_annotation : t -> string -> Debuginfo.t -> Annotation.t option -> unit
+  val record_annotation :
+    t -> string -> Debuginfo.t -> Annotation.t option -> unit
 
   val resolve_all : t -> unit
 
@@ -539,8 +540,11 @@ end = struct
              functions. *)
           raise
             (Annotation.Invalid
-               { a; fun_name = func_info.name; fun_dbg = func_info.dbg;
-                 property = S.property }));
+               { a;
+                 fun_name = func_info.name;
+                 fun_dbg = func_info.dbg;
+                 property = S.property
+               }));
       report_func_info ~msg:"record" ppf func_info;
       S.set_value func_info.name func_info.value
     in

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -228,7 +228,8 @@
  (action (diff fail11.output fail11.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main")
+                  %{ocaml-config:flambda}))
  (targets fail12.output.corrected)
  (deps (:ml fail12.ml) filter.sh)
  (action
@@ -241,7 +242,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps fail12.output fail12.output.corrected)
  (action (diff fail12.output fail12.output.corrected)))
 

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -226,7 +226,25 @@
  (enabled_if (= %{context_name} "main"))
  (deps fail11.output fail11.output.corrected)
  (action (diff fail11.output fail11.output.corrected)))
- 
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail12.output.corrected)
+ (deps (:ml fail12.ml) filter.sh)
+ (action
+   (with-outputs-to fail12.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c -zero-alloc-check -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail12.output fail12.output.corrected)
+ (action (diff fail12.output fail12.output.corrected)))
+
 ;; test for expected compilation errors
 
 (rule

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
 File "fail1.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function camlFail1__test15_HIDE_STAMP
+Error: Annotation check for zero_alloc strict failed on function Fail1.test15 (camlFail1__test15_HIDE_STAMP)

--- a/tests/backend/checkmach/fail10.output
+++ b/tests/backend/checkmach/fail10.output
@@ -1,2 +1,2 @@
 File "fail10.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function camlFail10__test7_HIDE_STAMP
+Error: Annotation check for zero_alloc failed on function Fail10.test7 (camlFail10__test7_HIDE_STAMP)

--- a/tests/backend/checkmach/fail11.output
+++ b/tests/backend/checkmach/fail11.output
@@ -1,2 +1,2 @@
 File "fail11.ml", line 14, characters 5-15:
-Error: Annotation check for zero_alloc failed on function camlFail11__f_HIDE_STAMP
+Error: Annotation check for zero_alloc failed on function Fail11.f (camlFail11__f_HIDE_STAMP)

--- a/tests/backend/checkmach/fail12.ml
+++ b/tests/backend/checkmach/fail12.ml
@@ -1,0 +1,6 @@
+(* Test error message with anonymous function and module names *)
+let[@inline never] foo x f = f x
+
+module Inner = struct
+  let bar = foo (Sys.opaque_identity 1) (fun [@zero_alloc] x -> (x,x))
+end

--- a/tests/backend/checkmach/fail12.output
+++ b/tests/backend/checkmach/fail12.output
@@ -1,0 +1,2 @@
+File "fail12.ml", line 5, characters 47-57:
+Error: Annotation check for zero_alloc failed on function Fail12.Inner.bar.(fun) (camlFail12__anon_fn[fail12.ml:5,40--70]_HIDE_STAMP)

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
 File "fail2.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function camlFail2__test_HIDE_STAMP
+Error: Annotation check for zero_alloc strict failed on function Fail2.test (camlFail2__test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
 File "fail3.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function camlFail3__test_HIDE_STAMP
+Error: Annotation check for zero_alloc strict failed on function Fail3.test (camlFail3__test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
 File "fail4.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function camlFail4__test_HIDE_STAMP
+Error: Annotation check for zero_alloc strict failed on function Fail4.test (camlFail4__test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail5.output
+++ b/tests/backend/checkmach/fail5.output
@@ -1,2 +1,2 @@
 File "fail5.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc failed on function camlFail5__test_HIDE_STAMP
+Error: Annotation check for zero_alloc failed on function Fail5.test (camlFail5__test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail6.output
+++ b/tests/backend/checkmach/fail6.output
@@ -1,2 +1,2 @@
 File "fail6.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc failed on function camlFail6__test3_HIDE_STAMP
+Error: Annotation check for zero_alloc failed on function Fail6.test3 (camlFail6__test3_HIDE_STAMP)

--- a/tests/backend/checkmach/fail7.output
+++ b/tests/backend/checkmach/fail7.output
@@ -1,2 +1,2 @@
 File "fail7.ml", line 7, characters 5-15:
-Error: Annotation check for zero_alloc failed on function camlFail7__test_HIDE_STAMP
+Error: Annotation check for zero_alloc failed on function Fail7.test (camlFail7__test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail8.output
+++ b/tests/backend/checkmach/fail8.output
@@ -1,2 +1,2 @@
 File "fail8.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function camlFail8__f_HIDE_STAMP
+Error: Annotation check for zero_alloc failed on function Fail8.f (camlFail8__f_HIDE_STAMP)

--- a/tests/backend/checkmach/fail9.output
+++ b/tests/backend/checkmach/fail9.output
@@ -1,2 +1,2 @@
 File "fail9.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc failed on function camlFail9__g_HIDE_STAMP
+Error: Annotation check for zero_alloc failed on function Fail9.g (camlFail9__g_HIDE_STAMP)

--- a/tests/backend/checkmach/filter.sh
+++ b/tests/backend/checkmach/filter.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-sed -r 's/Error: Annotation check for zero_alloc( strict | )failed on function caml(.*)_[0-9]+(_[0-9]+_code)?$/Error: Annotation check for zero_alloc\1failed on function caml\2_HIDE_STAMP/'
+sed -r 's/Error: Annotation check for zero_alloc( strict | )failed on function ([^ ]*) \(caml(.*)_[0-9]+(_[0-9]+_code)?\)$/Error: Annotation check for zero_alloc\1failed on function \2 \(caml\3_HIDE_STAMP\)/'

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -6,4 +6,4 @@ File "test_attribute_error_duplicate.ml", line 3, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 It must be either 'assume', 'strict', 'assume strict', 'strict assume' or empty
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function camlTest_attribute_error_duplicate__test1_HIDE_STAMP
+Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate__test1_HIDE_STAMP)


### PR DESCRIPTION
Error message now includes source level function name and not only the function symbol. The name can be extracted from the scope of `Mach.fundecl.fun_dbg`  field.  Keeping the function symbol in the error message to aid debugging when the check fails.  

Anonymous functions are also printed. Testing them is tricky (different symbol name depending on the middle-end) so the test is only enabled in flambda.