### PR TITLE
Attribute [@@@zero_alloc check] to turn the check on

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -772,7 +772,7 @@ end
 module Spec_zero_alloc : Spec = struct
   let property = Cmm.Zero_alloc
 
-  let enabled () = !Flambda_backend_flags.zero_alloc_check
+  let enabled () = !Clflags.zero_alloc_check
 
   (* Compact the mapping from function name to Value.t to reduce size of Checks
      in cmx and memory consumption Compilenv. Different components have

--- a/backend/checks.ml
+++ b/backend/checks.ml
@@ -24,7 +24,7 @@ let reset t =
   t.enabled <- false
 
 let merge src ~into:dst =
-  if !Flambda_backend_flags.zero_alloc_check
+  if !Clflags.zero_alloc_check
   then (
     let join _key b1 b2 = Some (b1 || b2) in
     dst.nor <- String.Map.union join dst.nor src.nor;

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -718,7 +718,8 @@ module Flambda_backend_options_impl = struct
 
   let heap_reduction_threshold x =
     Flambda_backend_flags.heap_reduction_threshold := x
-  let zero_alloc_check = set' Flambda_backend_flags.zero_alloc_check
+
+  let zero_alloc_check = set' Clflags.zero_alloc_check
   let dcheckmach = set' Flambda_backend_flags.dump_checkmach
 
   let disable_poll_insertion = set' Flambda_backend_flags.disable_poll_insertion
@@ -934,7 +935,7 @@ module Extra_params = struct
        set_int_option' Flambda_backend_flags.reorder_blocks_random
     | "basic-block-sections" -> set' Flambda_backend_flags.basic_block_sections
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
-    | "zero-alloc-check" -> set' Flambda_backend_flags.zero_alloc_check
+    | "zero-alloc-check" -> set' Clflags.zero_alloc_check
     | "dump-checkmach" -> set' Flambda_backend_flags.dump_checkmach
     | "poll-insertion" -> set' Flambda_backend_flags.disable_poll_insertion
     | "long-frames" -> set' Flambda_backend_flags.allow_long_frames

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -25,7 +25,6 @@ let dasm_comments = ref false (* -dasm-comments *)
 
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)
-let zero_alloc_check = ref false        (* -zero-alloc-check *)
 let dump_checkmach = ref false          (* -dcheckmach *)
 
 let disable_poll_insertion = ref (not Config.poll_insertion)

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -26,7 +26,6 @@ val dasm_comments : bool ref
 
 val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
-val zero_alloc_check : bool ref
 val dump_checkmach : bool ref
 
 val disable_poll_insertion : bool ref

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -507,7 +507,7 @@ let parse_attribute_with_ident_payload attr ~name ~f =
 let zero_alloc_attribute (attr : Parsetree.attribute)  =
   parse_attribute_with_ident_payload attr
     ~name:"zero_alloc" ~f:(function
-      | "check" -> Clflags.alloc_check := true
+      | "check" -> Clflags.zero_alloc_check := true
       | _ ->
         warn_payload attr.attr_loc attr.attr_name.txt
           "Only 'check' is supported")

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -435,6 +435,14 @@ let parse_int_payload attr =
       "A constant payload of type int was expected";
     None
 
+let parse_ident_payload attr =
+  match ident_of_payload attr.attr_payload with
+  | Some i -> Some i
+  | None ->
+    warn_payload attr.attr_loc attr.attr_name.txt
+      "A constant payload of type ident was expected";
+    None
+
 let clflags_attribute_without_payload attr ~name clflags_ref =
   when_attribute_is [name; "ocaml." ^ name] attr ~f:(fun () ->
     match parse_empty_payload attr with
@@ -490,6 +498,20 @@ let inline_attribute attr =
         Clflags.Float_arg_helper.parse s err_msg Clflags.inline_threshold
       | None -> warn_payload attr.attr_loc attr.attr_name.txt err_msg)
 
+let parse_attribute_with_ident_payload attr ~name ~f =
+  when_attribute_is [name; "ocaml." ^ name] attr ~f:(fun () ->
+    match parse_ident_payload attr with
+    | Some i -> f i
+    | None -> ())
+
+let zero_alloc_attribute (attr : Parsetree.attribute)  =
+  parse_attribute_with_ident_payload attr
+    ~name:"zero_alloc" ~f:(function
+      | "check" -> Clflags.alloc_check := true
+      | _ ->
+        warn_payload attr.attr_loc attr.attr_name.txt
+          "Only 'check' is supported")
+
 let afl_inst_ratio_attribute attr =
   clflags_attribute_with_int_payload attr
     ~name:"afl_inst_ratio" Clflags.afl_inst_ratio
@@ -508,7 +530,8 @@ let parse_standard_implementation_attributes attr =
   inline_attribute attr;
   afl_inst_ratio_attribute attr;
   flambda_o3_attribute attr;
-  flambda_oclassic_attribute attr
+  flambda_oclassic_attribute attr;
+  zero_alloc_attribute attr
 
 let has_local_opt attrs =
   has_attribute ["ocaml.local_opt"; "local_opt"] attrs

--- a/ocaml/stdlib/camlinternalAtomic.ml
+++ b/ocaml/stdlib/camlinternalAtomic.ml
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 [@@@ocaml.flambda_o3]
+[@@@zero_alloc check]
 
 (* CamlinternalAtomic is a dependency of Stdlib, so it is compiled with
    -nopervasives. *)

--- a/ocaml/stdlib/std_exit.ml
+++ b/ocaml/stdlib/std_exit.ml
@@ -17,6 +17,7 @@
 open! Stdlib
 
 [@@@ocaml.flambda_o3]
+[@@@zero_alloc check]
 
 (* Ensure that [at_exit] functions are called at the end of every program *)
 

--- a/ocaml/stdlib/stdlib.ml
+++ b/ocaml/stdlib/stdlib.ml
@@ -16,6 +16,7 @@
 
 [@@@ocaml.warning "-49"]
 [@@@ocaml.flambda_o3]
+[@@@zero_alloc check]
 
 (* Exceptions *)
 

--- a/ocaml/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/ocaml/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
-Raised at Stdlib.open_in_gen in file "stdlib.ml", line 408, characters 28-54
+Raised at Stdlib.open_in_gen in file "stdlib.ml", line 409, characters 28-54
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/ocaml/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/ocaml/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised at Stdlib.open_in_gen in file "stdlib.ml", line 408, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml", line 413, characters 2-45
+Raised at Stdlib.open_in_gen in file "stdlib.ml", line 409, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml", line 414, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -1,5 +1,5 @@
 Error: Failure("Plugin error")
-Raised at Stdlib.failwith in file "stdlib.ml", line 32, characters 17-33
+Raised at Stdlib.failwith in file "stdlib.ml", line 33, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml", line 3, characters 2-21
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6

--- a/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/ocaml/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,5 +1,5 @@
 Error: Failure("Plugin error")
-Raised at Stdlib.failwith in file "stdlib.ml", line 32, characters 17-33
+Raised at Stdlib.failwith in file "stdlib.ml", line 33, characters 17-33
 Called from Test10_plugin.g in file "test10_plugin.ml" (inlined), line 2, characters 15-38
 Called from Test10_plugin.f in file "test10_plugin.ml", line 6, characters 2-6
 Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -632,3 +632,5 @@ let create_usage_msg program =
 
 let print_arguments program =
   Arg.usage !arg_spec (create_usage_msg program)
+
+let zero_alloc_check = ref false                   (* -zero-alloc-check *)

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -283,3 +283,5 @@ val print_arguments : string -> unit
 
 (* [reset_arguments ()] clear all declared arguments *)
 val reset_arguments : unit -> unit
+
+val zero_alloc_check : bool ref


### PR DESCRIPTION
The new attribtue [@@@zero_alloc check] has the same effect as `-zero-alloc-check` command line flag. It just turns on the computation of summaries and checking of `[@zero_alloc]` function annotations on individual files.

The attribute is used for `stdlib.ml` and other files involved in the special dune compilation rule for stdlib (similarly to `[@@@ocaml.flambda_o3]`).  The rule doesn't take into account `ocamlopt_flags` specified in `stdlib` library stanza in `ocamll/stdlib/dune` file. This due probles is fixed with dune 3.7 but we haven't got it yet. 

This attribute is not very useful for user code (except perhaps in small tests), because it won't be able to prove anything about functions with callees in other compilation units not compiled with the check.

To support this new top-level attribute in the usual way, we need access to the flag `zero_alloc_check` early on from `Builtin_attributes` which does not know about `Flambda_backend_flags`. The simplest way to fix it seems to be moving `zero_alloc_check` to  `Clflags`.