### PR TITLE
zero_alloc attribute payload "assert all" and "ignore"

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -230,19 +230,17 @@ end = struct
           | Ignore_assert_all property when property = spec ->
             ignore_assert_all := true;
             None
-          | Ignore_assert_all _
-          | Check _ | Reduce_code_size | No_CSE | Use_linscan_regalloc ->
+          | Ignore_assert_all _ | Check _ | Reduce_code_size | No_CSE
+          | Use_linscan_regalloc ->
             None)
         codegen_options
     in
     match a with
     | [] ->
-      if !Clflags.zero_alloc_check_assert_all
-      && not !ignore_assert_all
+      if !Clflags.zero_alloc_check_assert_all && not !ignore_assert_all
       then
         Some { strict = false; assume = false; loc = Debuginfo.to_location dbg }
-      else
-        None
+      else None
     | [p] -> Some p
     | _ :: _ ->
       Misc.fatal_errorf "Unexpected duplicate annotation %a"

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -230,7 +230,12 @@ end = struct
         codegen_options
     in
     match a with
-    | [] -> None
+    | [] ->
+      if !Clflags.zero_alloc_check_assert_all
+      then
+        Some { strict = false; assume = false; loc = Debuginfo.to_location dbg }
+      else
+        None
     | [p] -> Some p
     | _ :: _ ->
       Misc.fatal_errorf "Unexpected duplicate annotation %a"

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -260,6 +260,7 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
+  | Ignore_assert_all of property
   | Check of { property: property; strict: bool; assume: bool;
                loc : Location.t; }
 

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -270,6 +270,7 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
+  | Ignore_assert_all of property
   | Check of { property: property; strict: bool; assume: bool; loc: Location.t }
 
 type fundecl =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4123,6 +4123,7 @@ let transl_property : Lambda.property -> Cmm.property = function
 
 let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
   | Default_check -> []
+  | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
   | Check { property; strict; assume; loc } ->
     [Check { property = transl_property property; strict; assume; loc }]
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -368,6 +368,8 @@ let codegen_option = function
   | Reduce_code_size -> "reduce_code_size"
   | No_CSE -> "no_cse"
   | Use_linscan_regalloc -> "linscan"
+  | Ignore_assert_all property ->
+    Printf.sprintf "ignore %s" (property_to_string property)
   | Check { property; strict; assume; loc = _ } ->
     Printf.sprintf "%s %s%s"
       (if assume then "assume" else "assert")

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -22,6 +22,7 @@ end
 
 type t =
   | Default_check
+  | Ignore_assert_all of Property.t
   | Check of
       { property : Property.t;
         strict : bool;
@@ -32,6 +33,8 @@ type t =
 let print ppf t =
   match t with
   | Default_check -> ()
+  | Ignore_assert_all property ->
+    Format.fprintf ppf "@[ignore %a@]" Property.print property
   | Check { property; strict; assume; loc = _ } ->
     Format.fprintf ppf "@[%s%s %a@]"
       (if assume then "assume" else "assert")
@@ -40,15 +43,20 @@ let print ppf t =
 
 let from_lambda : Lambda.check_attribute -> t = function
   | Default_check -> Default_check
+  | Ignore_assert_all p -> Ignore_assert_all (Property.from_lambda p)
   | Check { property; strict; assume; loc } ->
     Check { property = Property.from_lambda property; strict; assume; loc }
 
 let equal x y =
   match x, y with
   | Default_check, Default_check -> true
+  | Ignore_assert_all p1, Ignore_assert_all p2 ->
+    Property.equal p1 p2
   | ( Check { property = p1; strict = s1; assume = a1; loc = loc1 },
       Check { property = p2; strict = s2; assume = a2; loc = loc2 } ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && Bool.equal a1 a2 && loc1 = loc2
-  | (Default_check | Check _), _ -> false
+  | (Default_check | Ignore_assert_all _ | Check _), _ -> false
 
-let is_default : t -> bool = function Default_check -> true | Check _ -> false
+let is_default : t -> bool = function
+  | Default_check -> true
+  | Ignore_assert_all _ | Check _ -> false

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -50,8 +50,7 @@ let from_lambda : Lambda.check_attribute -> t = function
 let equal x y =
   match x, y with
   | Default_check, Default_check -> true
-  | Ignore_assert_all p1, Ignore_assert_all p2 ->
-    Property.equal p1 p2
+  | Ignore_assert_all p1, Ignore_assert_all p2 -> Property.equal p1 p2
   | ( Check { property = p1; strict = s1; assume = a1; loc = loc1 },
       Check { property = p2; strict = s2; assume = a2; loc = loc2 } ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && Bool.equal a1 a2 && loc1 = loc2

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -16,6 +16,7 @@ end
 
 type t =
   | Default_check
+  | Ignore_assert_all of Property.t
   | Check of
       { property : Property.t;
         strict : bool;

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -327,6 +327,7 @@ let transl_property : Check_attribute.Property.t -> Cmm.property = function
 let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list =
   function
   | Default_check -> []
+  | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
   | Check { property; strict; assume; loc } ->
     [Check { property = transl_property property; strict; assume; loc }]
 

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -442,6 +442,7 @@ type poll_attribute =
 
 type check_attribute =
   | Default_check
+  | Ignore_assert_all of property
   | Check of { property: property;
                strict: bool;
                assume: bool;

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -332,7 +332,7 @@ type check_attribute =
                   exceptional returns or divering loops are ignored).
                   This definition may not be applicable to new properties. *)
                assume: bool;
-               (* [assume=false] assume without checking that the
+               (* [assume=true] assume without checking that the
                   property holds *)
                loc: Location.t;
              }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -323,6 +323,7 @@ type poll_attribute =
 
 type check_attribute =
   | Default_check
+  | Ignore_assert_all of property
   | Check of { property: property;
                strict: bool;
                (* [strict=true] property holds on all paths.

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -580,6 +580,8 @@ let check_attribute ppf check =
   in
   match check with
   | Default_check -> ()
+  | Ignore_assert_all p ->
+    fprintf ppf "ignore assert all %s@ " (check_property p)
   | Check {property=p; assume; strict; loc = _} ->
     fprintf ppf "%s %s%s@ "
       (if assume then "assume" else "assert")

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -309,6 +309,9 @@ let get_property_attribute l p =
    | Some _, Ignore_assert_all _ -> ()
    | Some attr, Check _ ->
      if !Clflags.zero_alloc_check && !Clflags.native_code then
+       (* The warning for unchecked functions will not trigger if the check is requested
+          through the [@@@zero_alloc all] top-level annotation rather than through the
+          function annotation [@zero_alloc]. *)
        Builtin_attributes.register_property attr.attr_name);
    res
 

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -303,8 +303,10 @@ let get_property_attribute l p =
   let attr = find_attribute (is_property_attribute p) l in
   let res = parse_property_attribute attr p in
   (match attr, res with
-   | None, _ -> ()
+   | None, Default_check -> ()
    | _, Default_check -> ()
+   | None, (Check _ | Ignore_assert_all _ ) -> assert false
+   | Some _, Ignore_assert_all _ -> ()
    | Some attr, Check _ ->
      if !Clflags.zero_alloc_check && !Clflags.native_code then
        Builtin_attributes.register_property attr.attr_name);

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -254,9 +254,7 @@ let parse_property_attribute attr property =
         ~empty:(Check { property; strict = false; assume = false; loc; } )
         [
           ["assume"], Check { property; strict = false; assume = true; loc; };
-          ["assert"], Check { property; strict = false; assume = false; loc; };
           ["strict"], Check { property; strict = true; assume = false; loc; };
-          ["assert"; "strict"], Check { property; strict = true; assume = false; loc; };
           ["assume"; "strict"], Check { property; strict = true; assume = true; loc; };
           ["ignore"], Ignore_assert_all property
         ]

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -523,7 +523,7 @@ let zero_alloc_attribute (attr : Parsetree.attribute)  =
   parse_attribute_with_ident_payload attr
     ~name:"zero_alloc" ~f:(function
       | "check" -> Clflags.zero_alloc_check := true
-      | "assert-all" | "assert" | "assert_all" | "all" ->
+      | "all" ->
         Clflags.zero_alloc_check_assert_all := true
       | _ ->
         warn_payload attr.attr_loc attr.attr_name.txt

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -523,9 +523,11 @@ let zero_alloc_attribute (attr : Parsetree.attribute)  =
   parse_attribute_with_ident_payload attr
     ~name:"zero_alloc" ~f:(function
       | "check" -> Clflags.zero_alloc_check := true
+      | "assert-all" | "assert" | "assert_all" | "all" ->
+        Clflags.zero_alloc_check_assert_all := true
       | _ ->
         warn_payload attr.attr_loc attr.attr_name.txt
-          "Only 'check' is supported")
+          "Only 'check' and 'all' are supported")
 
 let afl_inst_ratio_attribute attr =
   clflags_attribute_with_int_payload attr

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -633,4 +633,5 @@ let create_usage_msg program =
 let print_arguments program =
   Arg.usage !arg_spec (create_usage_msg program)
 
-let zero_alloc_check = ref false                   (* -zero-alloc-check *)
+let zero_alloc_check = ref false            (* -zero-alloc-check *)
+let zero_alloc_check_assert_all = ref false (* -zero-alloc-check-assert-all *)

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -285,3 +285,5 @@ val print_arguments : string -> unit
 val reset_arguments : unit -> unit
 
 val zero_alloc_check : bool ref
+val zero_alloc_check_assert_all : bool ref
+

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -4,7 +4,7 @@
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
- (deps s.ml t.ml)
+ (deps s.ml t.ml t6.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
@@ -245,6 +245,61 @@
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps fail12.output fail12.output.corrected)
  (action (diff fail12.output fail12.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail13.output.corrected)
+ (deps (:ml fail13.ml) filter.sh)
+ (action
+   (with-outputs-to fail13.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c -zero-alloc-check -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail13.output fail13.output.corrected)
+ (action (diff fail13.output fail13.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail14.output.corrected)
+ (deps (:ml fail14.ml) filter.sh)
+ (action
+   (with-outputs-to fail14.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c -zero-alloc-check -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail14.output fail14.output.corrected)
+ (action (diff fail14.output fail14.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail15.output.corrected)
+ (deps (:ml fail15.ml) filter.sh)
+ (action
+   (with-outputs-to fail15.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c -zero-alloc-check -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail15.output fail15.output.corrected)
+ (action (diff fail15.output fail15.output.corrected)))
+
 
 ;; test for expected compilation errors
 

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -4,7 +4,7 @@
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
- (deps s.ml t.ml t6.ml)
+ (deps s.ml t.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
@@ -350,3 +350,25 @@
  (action
         (diff test_attr_unused.output
               test_attr_unused.output.corrected)))
+
+
+;;; Check that the warning is printed and compilation is successful.
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (targets t6.output.corrected)
+ (deps t6.ml)
+ (action
+   (with-outputs-to t6.output.corrected
+    (with-accepted-exit-codes 0
+     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -zero-alloc-check -g -O3))
+  )))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps t6.output
+       t6.output.corrected)
+ (action
+        (diff t6.output
+              t6.output.corrected)))

--- a/tests/backend/checkmach/fail13.ml
+++ b/tests/backend/checkmach/fail13.ml
@@ -1,0 +1,3 @@
+[@@@zero_alloc all]
+
+let fail_loud2 x = [ x; x+1 ]

--- a/tests/backend/checkmach/fail13.output
+++ b/tests/backend/checkmach/fail13.output
@@ -1,0 +1,2 @@
+File "fail13.ml", line 3, characters 15-29:
+Error: Annotation check for zero_alloc failed on function Fail13.fail_loud2 (camlFail13__fail_loud2_HIDE_STAMP)

--- a/tests/backend/checkmach/fail14.ml
+++ b/tests/backend/checkmach/fail14.ml
@@ -1,0 +1,9 @@
+exception Exn of (int * int)
+
+let pass x = raise (Exn (x,x))
+
+(* function attributes still work *)
+let[@zero_alloc strict] foo x = if x>0 then pass (x+1) else x+2
+
+(* doesn't matter where in the file it appears *)
+[@@@zero_alloc all]

--- a/tests/backend/checkmach/fail14.output
+++ b/tests/backend/checkmach/fail14.output
@@ -1,0 +1,2 @@
+File "fail14.ml", line 6, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Fail14.foo (camlFail14__foo_HIDE_STAMP)

--- a/tests/backend/checkmach/fail15.ml
+++ b/tests/backend/checkmach/fail15.ml
@@ -1,0 +1,8 @@
+[@@@zero_alloc all]
+
+(* For duplicate attributes we get a warning and the first one takes effect, so the
+   following function, which passes the relaxed test but not the strict, triggers
+   failure of the check of [call_loud1]. *)
+let[@inline never][@zero_alloc ignore][@zero_alloc assume] fails x = (x,x)
+
+let[@zero_alloc strict] call x = fails (x+1)

--- a/tests/backend/checkmach/fail15.output
+++ b/tests/backend/checkmach/fail15.output
@@ -1,0 +1,4 @@
+File "fail15.ml", line 6, characters 40-50:
+Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
+File "fail15.ml", line 8, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Fail15.call (camlFail15__call_HIDE_STAMP)

--- a/tests/backend/checkmach/t6.ml
+++ b/tests/backend/checkmach/t6.ml
@@ -1,0 +1,29 @@
+[@@@zero_alloc all]
+
+let pass1 x = x + 1
+
+exception Exn of (int * int)
+let pass2 x = raise (Exn (x,x))
+
+(* can be combined with strict payload *)
+let[@zero_alloc strict] pass3 x y = x + y
+
+(* test for ignore  *)
+let[@zero_alloc ignore] test1 x = (x, x)
+
+(* assume still works *)
+let[@zero_alloc assume] fail_loud x = [ x; x+1 ]
+
+(* assume strict still works *)
+let[@inline never][@zero_alloc strict assume] fail_loud2 x = raise (Exn (x,x))
+
+let[@zero_alloc strict] call_loud2 x = fail_loud2 (x+1)
+
+(* For duplicate attributes we get a warning and the first one takes effect *)
+let[@inline never][@zero_alloc strict assume][@zero_alloc ignore] fail_loud1 x = raise (Exn (x,x))
+
+let[@zero_alloc strict] call_loud1 x = fail_loud1 (x+1)
+
+
+
+

--- a/tests/backend/checkmach/t6.ml
+++ b/tests/backend/checkmach/t6.ml
@@ -12,18 +12,16 @@ let[@zero_alloc strict] pass3 x y = x + y
 let[@zero_alloc ignore] test1 x = (x, x)
 
 (* assume still works *)
-let[@zero_alloc assume] fail_loud x = [ x; x+1 ]
+let[@zero_alloc assume][@inline never] fail_loud x = [ x; x+1 ]
+
+let call_loud x = fail_loud (x*2)
 
 (* assume strict still works *)
 let[@inline never][@zero_alloc strict assume] fail_loud2 x = raise (Exn (x,x))
 
 let[@zero_alloc strict] call_loud2 x = fail_loud2 (x+1)
 
-(* For duplicate attributes we get a warning and the first one takes effect *)
+(* For duplicate attributes we get a warning and the first one takes effect. *)
 let[@inline never][@zero_alloc strict assume][@zero_alloc ignore] fail_loud1 x = raise (Exn (x,x))
 
 let[@zero_alloc strict] call_loud1 x = fail_loud1 (x+1)
-
-
-
-

--- a/tests/backend/checkmach/t6.output
+++ b/tests/backend/checkmach/t6.output
@@ -1,0 +1,2 @@
+File "t6.ml", line 25, characters 47-57:
+Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression

--- a/tests/backend/checkmach/test_attribute_error_duplicate.ml
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.ml
@@ -1,3 +1,5 @@
 let[@zero_alloc strict][@zero_alloc strict] test1 x = x,x
 let[@zero_alloc strict assume][@zero_alloc strict] test2 x = x,x
 let[@zero_alloc strict check] test3 x = x,x
+let[@zero_alloc check] test4 x = x,x
+let[@zero_alloc all] test5 x = x,x

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -5,5 +5,11 @@ Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than 
 File "test_attribute_error_duplicate.ml", line 3, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 It must be either 'assume', 'assert', 'strict', 'assert strict', 'assume strict', 'ignore' or empty
+File "test_attribute_error_duplicate.ml", line 4, characters 5-15:
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+It must be either 'assume', 'assert', 'strict', 'assert strict', 'assume strict', 'ignore' or empty
+File "test_attribute_error_duplicate.ml", line 5, characters 5-15:
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+It must be either 'assume', 'assert', 'strict', 'assert strict', 'assume strict', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate__test1_HIDE_STAMP)

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -4,6 +4,6 @@ File "test_attribute_error_duplicate.ml", line 2, characters 32-42:
 Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
 File "test_attribute_error_duplicate.ml", line 3, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'assume strict', 'strict assume' or empty
+It must be either 'assume', 'assert', 'strict', 'assert strict', 'assume strict', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate__test1_HIDE_STAMP)

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -4,12 +4,12 @@ File "test_attribute_error_duplicate.ml", line 2, characters 32-42:
 Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
 File "test_attribute_error_duplicate.ml", line 3, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assert', 'strict', 'assert strict', 'assume strict', 'ignore' or empty
+It must be either 'assume', 'strict', 'assume strict', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 4, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assert', 'strict', 'assert strict', 'assume strict', 'ignore' or empty
+It must be either 'assume', 'strict', 'assume strict', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 5, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'assert', 'strict', 'assert strict', 'assume strict', 'ignore' or empty
+It must be either 'assume', 'strict', 'assume strict', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate__test1_HIDE_STAMP)


### PR DESCRIPTION
on top of #1294, only the last 3 commits are new.

This is somewhat experimental. The attributes make it easier to annotate entire files that are mostly not allocating.

* `[@@@zero_alloc assert all]` at top-level of a compilation unit is the same as annotating all functions in the file with `[@zero_alloc]`. Note that it performs a relaxed check, and there is no corresponding attribute for strict check yet.
* `[@zero_alloc ignore]` on a function cancels the effect of `[@@@zero_alloc all]` for that function. That is, compute the summary of this function, but don't check/assert that the function is not allocating. Note that `[@zero_alloc ignore]` is not the same as `[@zero_alloc assume]` which does not check the function but sets it's summary is as non-allocating ).  If the file is not annotated with `[@@@zero_alloc assert all]`  then `[@zero_alloc ignore]` on a function in that file does not do anything.

Ideally, these annotations should be resolved in `Translattribute` and `Builtin_attr` into `Lambda.check_attribute.Default_check` or `Lambda.check_attribute.Check _`  but I couldn't figure how to do it for `ignore` payload. The problem is when an attribute is parsed in `Translattribute`, it is not clear whether it is the only `zero_alloc` attribute on the function or not. The proposed implementation just adds another constructor for it `Lambda.check_attribute.Ignore_assert_all` and resolves it in the backend. The downside is that it needs to be propagated all the way down. An alternative would be to resolve it during the translation from `lambda` in the middle-end, which would result in some code duplication and changes in the middle-end in places that should not care about this check.