### PR TITLE
zero_alloc check: smaller encoding of summaries for storing in cmx

### DIFF
--- a/backend/checks.ml
+++ b/backend/checks.ml
@@ -1,48 +1,30 @@
 module String = Misc.Stdlib.String
 
-(* CR gyorsh: refactor repetititve code. *)
 (* CR gyorsh: Add [t] per analysis when at least one more analysis is
    implemented *)
 type t =
-  { mutable nor : bool String.Map.t;
-    mutable exn : bool String.Map.t;
-    mutable div : bool String.Map.t;
+  { mutable zero_alloc : int String.Map.t;
     mutable enabled : bool
   }
 
-let create () =
-  { nor = String.Map.empty;
-    exn = String.Map.empty;
-    div = String.Map.empty;
-    enabled = false
-  }
+let create () = { zero_alloc = String.Map.empty; enabled = false }
 
 let reset t =
-  t.nor <- String.Map.empty;
-  t.exn <- String.Map.empty;
-  t.div <- String.Map.empty;
+  t.zero_alloc <- String.Map.empty;
   t.enabled <- false
 
 let merge src ~into:dst =
   if !Clflags.zero_alloc_check
   then (
-    let join _key b1 b2 = Some (b1 || b2) in
-    dst.nor <- String.Map.union join dst.nor src.nor;
-    dst.exn <- String.Map.union join dst.exn src.exn;
-    dst.div <- String.Map.union join dst.div src.div;
+    let join key b1 b2 =
+      Misc.fatal_errorf "Unexpected merge %s %d %d" key b1 b2
+    in
+    dst.zero_alloc <- String.Map.union join dst.zero_alloc src.zero_alloc;
     dst.enabled <- dst.enabled || src.enabled)
 
-type value =
-  { nor : bool option;
-    exn : bool option;
-    div : bool option
-  }
+type value = int option
 
-let get_value (t : t) s : value =
-  { nor = String.Map.find_opt s t.nor;
-    exn = String.Map.find_opt s t.exn;
-    div = String.Map.find_opt s t.div
-  }
+let get_value (t : t) s : value = String.Map.find_opt s t.zero_alloc
 
 let get_value (t : t) s : value option =
   match t.enabled with false -> None | true -> Some (get_value t s)
@@ -53,19 +35,13 @@ let set_value (t : t) s (v : value) =
     then Misc.fatal_errorf "Value of %s is already set" s;
     new_
   in
-  t.nor <- String.Map.update s (f v.nor) t.nor;
-  t.exn <- String.Map.update s (f v.exn) t.exn;
-  t.div <- String.Map.update s (f v.div) t.div;
+  t.zero_alloc <- String.Map.update s (f v) t.zero_alloc;
   t.enabled <- true
 
 module Raw = struct
-  type entries = (string * bool) list
+  type entries = (string * int) list
 
-  type r =
-    { nor : entries;
-      exn : entries;
-      div : entries
-    }
+  type r = { zero_alloc : entries }
 
   type t = r option
 
@@ -73,28 +49,15 @@ module Raw = struct
     List.fold_left (fun acc (k, v) -> String.Map.add k v acc) String.Map.empty e
 
   let print t =
-    let print (name, b) = Printf.printf "\t\t%s = %b\n" name b in
-    let print_component c title =
-      match c with
-      | [] -> ()
-      | _ ->
-        Printf.printf "\t%s:\n" title;
-        List.iter print c
-    in
+    let print (name, v) = Printf.printf "\t\t%s = %#x\n" name v in
     (* CR gyorsh: move encode/decode here somehow for noalloc *)
     Printf.printf "Function summaries for static checks:\n";
-    print_component t.nor "Normal return";
-    print_component t.exn "Exceptional return";
-    print_component t.div "Diverging"
+    List.iter print t.zero_alloc
 
   let print = function None -> () | Some t -> print t
 end
 
-let to_raw (t : t) : Raw.r =
-  { nor = String.Map.bindings t.nor;
-    exn = String.Map.bindings t.exn;
-    div = String.Map.bindings t.div
-  }
+let to_raw (t : t) : Raw.r = { zero_alloc = String.Map.bindings t.zero_alloc }
 
 let to_raw (t : t) : Raw.t =
   match t.enabled with false -> None | true -> Some (to_raw t)
@@ -102,9 +65,4 @@ let to_raw (t : t) : Raw.t =
 let of_raw (t : Raw.t) : t =
   match t with
   | None -> create ()
-  | Some t ->
-    { nor = Raw.entries_to_map t.nor;
-      exn = Raw.entries_to_map t.exn;
-      div = Raw.entries_to_map t.div;
-      enabled = true
-    }
+  | Some t -> { zero_alloc = Raw.entries_to_map t.zero_alloc; enabled = true }

--- a/backend/checks.mli
+++ b/backend/checks.mli
@@ -1,10 +1,6 @@
 (** Symbols of function that pass certain checks for special properties. *)
 
-type value =
-  { nor : bool option;
-    exn : bool option;
-    div : bool option
-  }
+type value = int option
 
 type t
 


### PR DESCRIPTION
Storing summaries in cmx has some overhead in terms of size when the check is enabled. The check is disabled by default in user's code, but enabled in stdlib and the compiler. This PR is a small improvement in size. 

- Don't store a summary when it is `Value.top`.
- Otherwise, encode a summary as an integer (each component of `Value.{nor;exn;div}` has  only 3 possible values, so takes only 2 bits).
- Instead of storing each component of the abstract value in a separate map, use a single map. This should slightly reduce memory overhead of zero_alloc checks during compilation. 
- Removing `div` altogether will be considered separately. 

On `_build/main` of the compiler itself, the overhead on size of cmx files is below 2.4% with closure (down from 5.7%) and below 0.5% for flambda and flambda2 (down from around 2.7%). I haven't measured it yet on a larger code base.