### PR TITLE
Fix failure of `check_all_arches` on RISCV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ build_and_test_upstream: build_upstream
 	      echo "Running testsuite sequentially"; \
               make --no-print-directory all; \
             fi
+	cd _build_upstream && $(MAKE) check_all_arches
 
 .PHONY: coverage
 coverage: boot-runtest

--- a/ocaml/asmcomp/riscv/emit.mlp
+++ b/ocaml/asmcomp/riscv/emit.mlp
@@ -650,7 +650,7 @@ let end_assembly() =
   `	.quad	0\n`;
   (* Emit the frame descriptors *)
   `	{emit_string data_space}\n`; (* not rodata because relocations inside *)
-  let lbl = Compilenv.make_symbol (Some "frametable") in
+  let lbl = Cmm_helpers.make_symbol "frametable" in
   declare_global_data lbl;
   `{emit_symbol lbl}:\n`;
   emit_frames


### PR DESCRIPTION
This was broken by the ocaml-jst merge on October 31st.