### PR TITLE
zero_alloc new warning for unchecked functions

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -171,6 +171,8 @@ end
 module Annotation : sig
   type t
 
+  val get_loc : t -> Location.t
+
   val find : Cmm.codegen_option list -> Cmm.property -> Debuginfo.t -> t option
 
   val expected_value : t -> Value.t
@@ -210,6 +212,8 @@ end = struct
       loc : Location.t
           (** Source location of the annotation, used for error messages. *)
     }
+
+  let get_loc t = t.loc
 
   let expected_value t = if t.strict then Value.safe else Value.relaxed
 
@@ -531,6 +535,8 @@ end = struct
       (match func_info.annotation with
       | None -> ()
       | Some a ->
+        Builtin_attributes.mark_property_checked analysis_name
+          (Annotation.get_loc a);
         if (not (Annotation.is_assume a))
            && not
                 (Value.lessequal func_info.value (Annotation.expected_value a))

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -299,7 +299,13 @@ let get_local_attribute l =
 
 let get_property_attribute l p =
   let attr = find_attribute (is_property_attribute p) l in
-  parse_property_attribute attr p
+  let res = parse_property_attribute attr p in
+  (match attr, res with
+   | None, _ -> ()
+   | _, Default_check -> ()
+   | Some attr, Check _ ->
+     Builtin_attributes.register_property attr.attr_name);
+   res
 
 let get_check_attribute l = get_property_attribute l Zero_alloc
 

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -304,7 +304,8 @@ let get_property_attribute l p =
    | None, _ -> ()
    | _, Default_check -> ()
    | Some attr, Check _ ->
-     Builtin_attributes.register_property attr.attr_name);
+     if !Clflags.zero_alloc_check && !Clflags.native_code then
+       Builtin_attributes.register_property attr.attr_name);
    res
 
 let get_check_attribute l = get_property_attribute l Zero_alloc

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -66,6 +66,13 @@ val register_attr : attr_tracking_time -> string Location.loc -> unit
 val mark_alert_used : Parsetree.attribute -> unit
 val mark_alerts_used : Parsetree.attributes -> unit
 
+(** Properties such as [@zero_alloc] that are checked
+    in late stages of compilation in the backend.
+    Registering them helps detect code that is not checked,
+    because it is optimized away by the middle-end.  *)
+val register_property : string Location.loc -> unit
+val mark_property_checked : string -> Location.t -> unit
+
 (** Marks "warn_on_literal_pattern" attributes used for the purposes of
     misplaced attribute warnings.  Call this when moving things with alert
     attributes into the environment. *)

--- a/ocaml/utils/warnings.ml
+++ b/ocaml/utils/warnings.ml
@@ -107,6 +107,7 @@ type t =
   | Missing_mli                             (* 70 *)
   | Unused_tmc_attribute                    (* 71 *)
   | Tmc_breaks_tailcall                     (* 72 *)
+  | Unchecked_property_attribute of string  (* 199 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -189,9 +190,10 @@ let number = function
   | Missing_mli -> 70
   | Unused_tmc_attribute -> 71
   | Tmc_breaks_tailcall -> 72
+  | Unchecked_property_attribute _ -> 199
 ;;
 
-let last_warning_number = 72
+let last_warning_number = 199
 ;;
 
 type description =
@@ -446,6 +448,10 @@ let descriptions = [
     names = ["tmc-breaks-tailcall"];
     description = "A tail call is turned into a non-tail call \
                    by the @tail_mod_cons transformation." };
+  { number = 199;
+    names = ["unchecked-property-attribute"];
+    description = "A property of a function that was \
+                   optimized away cannot be checked." };
 ]
 ;;
 
@@ -1045,6 +1051,12 @@ let message = function
        Please either mark the called function with the [@tail_mod_cons]\n\
        attribute, or mark this call with the [@tailcall false] attribute\n\
        to make its non-tailness explicit."
+  | Unchecked_property_attribute property ->
+      Printf.sprintf "the %S attribute cannot be checked.\n\
+      The function it is attached to was optimized away. \n\
+      You can try to mark this function as [@inline never] \n\
+      or move the attribute to the relevant callers of this function."
+      property
 ;;
 
 let nerrors = ref 0;;

--- a/ocaml/utils/warnings.mli
+++ b/ocaml/utils/warnings.mli
@@ -109,6 +109,8 @@ type t =
   | Missing_mli                             (* 70 *)
   | Unused_tmc_attribute                    (* 71 *)
   | Tmc_breaks_tailcall                     (* 72 *)
+(* Flambda_backend specific warnings: numbers should go down from 199 *)
+  | Unchecked_property_attribute of string  (* 199 *)
 ;;
 
 type alert = {kind:string; message:string; def:loc; use:loc}

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -269,3 +269,29 @@
  (action
         (diff test_attribute_error_duplicate.output
               test_attribute_error_duplicate.output.corrected)))
+
+;; Closure does not optimize the function away, so the unchecked attribute
+;; warning is only with flambda and flambda2.
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main")
+                  %{ocaml-config:flambda}))
+ (targets test_attr_unused.output.corrected)
+ (deps test_attr_unused.ml)
+ (action
+   (with-outputs-to test_attr_unused.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 0
+     (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -c -zero-alloc-check -O3))
+    (run "./filter.sh")
+  ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main")
+                  %{ocaml-config:flambda}))
+ (deps test_attr_unused.output
+       test_attr_unused.output.corrected)
+ (action
+        (diff test_attr_unused.output
+              test_attr_unused.output.corrected)))

--- a/tests/backend/checkmach/test_attr_unused.ml
+++ b/tests/backend/checkmach/test_attr_unused.ml
@@ -1,0 +1,6 @@
+(* Warn about unused attributes and unchecked zero_alloc annotations. *)
+let[@inline never] f x = if x > 0 then (Printf.eprintf "%d\n%!" x; raise Not_found)
+let[@zero_alloc] g x = f x; (x, x)
+let h x = g x
+[@@@zero_alloc]
+let[@zero_alloc] g x = (x[@zero_alloc])

--- a/tests/backend/checkmach/test_attr_unused.output
+++ b/tests/backend/checkmach/test_attr_unused.output
@@ -1,0 +1,10 @@
+File "test_attr_unused.ml", line 5, characters 0-15:
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+A constant payload of type ident was expected
+File "test_attr_unused.ml", line 3, characters 5-15:
+Warning 199 [unchecked-property-attribute]: the "zero_alloc" attribute cannot be checked.
+The function it is attached to was optimized away. 
+You can try to mark this function as [@inline never] 
+or move the attribute to the relevant callers of this function.
+File "test_attr_unused.ml", line 6, characters 27-37:
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context


### PR DESCRIPTION
A function annotated with `[@zero_alloc]` may be optimized away completely by the middle end. As a result, the static allocation checker in the backend never gets to see and analyze this function, and cannot report a violation of the property, even if the function is allocating.  From the user's point of view, the checker appears to be unsound or at least this behavior is misleading. 

This PR implements a  workaround: give a warning about `[@zero_alloc]` attributes that appear in the source but were not checked. It's not clear how the user can address the problem, other than removing the attribute. In some cases it may be possible to annotate the caller or mark the function as `[@inline never]`. For details see  https://github.com/ocaml-flambda/flambda-backend/issues/1273

I added a new warning, rather than using `Misplaced_attribute` because the hint is different and we can also detect really-misplaced `[@zero_alloc]` attributes separately. The new warning is 199 to avoid conflicts with future changes upstream in warning numbers. This high number will make some operations on Warnings slightly expensive but I don't think it is significantly so. I also propose to number flambda-backend specific warnings from 199 down to avoid changing `Warnings.last_warning_number` every time.

It is not strictly necessary for the code for tracking the unchecked attributes to be in `Builtin_attributes`, next to the existing logic for Misplaced_attribute handling, because unchecked attrbutes are only needed in `Lambda` and the code mostly independent from `Misplaced_attribute` handling (except the use of `Attribute_table` and sorting). 
