### PR TITLE
Teach `ocamldep` about all the language extensions

### DIFF
--- a/ocaml/driver/makedepend.ml
+++ b/ocaml/driver/makedepend.ml
@@ -662,6 +662,7 @@ let run_main argv =
     let program = Filename.basename Sys.argv.(0) in
     Compenv.parse_arguments (ref argv)
       (add_dep_arg (fun f -> Src (f, None))) program;
+    List.iter Language_extension.enable Language_extension.all;
     process_dep_args (List.rev !dep_args_rev);
     Compenv.readenv ppf Before_link;
     if !sort_files then sort_files_by_dependencies !files


### PR DESCRIPTION
We want `ocamldep` to be able to parse all files, so have it enable all the language extensions before doing any parsing.