### PR TITLE
Merge Types.* and Subst.Lazy.* types

### DIFF
--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -2356,7 +2356,7 @@ let proj_shape map mod_shape item =
       let shape = Shape.proj mod_shape item in
       Shape.Map.add map item shape, Some shape
 
-module Add_signature(T : Types.S)(M : sig
+module Add_signature(T : Types.Wrapped)(M : sig
   val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool
     -> Ident.t -> module_presence -> T.module_declaration -> t -> t
   val add_modtype: ?shape:Shape.t -> Ident.t -> T.modtype_declaration -> t -> t

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -87,7 +87,7 @@ val without_cmis: ('a -> 'b) -> 'a -> 'b
 val find_value: Path.t -> t -> value_description
 val find_type: Path.t -> t -> type_declaration
 val find_type_descrs: Path.t -> t -> type_descriptions
-val find_module_lazy: Path.t -> t -> Subst.Lazy.module_decl
+val find_module_lazy: Path.t -> t -> Subst.Lazy.module_declaration
 val find_module: Path.t -> t -> module_declaration
 val find_modtype: Path.t -> t -> modtype_declaration
 val find_class: Path.t -> t -> class_declaration
@@ -103,7 +103,7 @@ val find_type_expansion_opt:
 (* Find the manifest type information associated to a type for the sake
    of the compiler's type-based optimisations. *)
 val find_modtype_expansion: Path.t -> t -> module_type
-val find_modtype_expansion_lazy: Path.t -> t -> Subst.Lazy.modtype
+val find_modtype_expansion_lazy: Path.t -> t -> Subst.Lazy.module_type
 
 val find_hash_type: Path.t -> t -> type_declaration
 (* Find the "#t" type given the path for "t" *)
@@ -302,11 +302,11 @@ val add_extension:
 val add_module: ?arg:bool -> ?shape:Shape.t ->
   Ident.t -> module_presence -> module_type -> t -> t
 val add_module_lazy: update_summary:bool ->
-  Ident.t -> module_presence -> Subst.Lazy.modtype -> t -> t
+  Ident.t -> module_presence -> Subst.Lazy.module_type -> t -> t
 val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool ->
   Ident.t -> module_presence -> module_declaration -> t -> t
 val add_module_declaration_lazy: ?arg:bool -> update_summary:bool ->
-  Ident.t -> module_presence -> Subst.Lazy.module_decl -> t -> t
+  Ident.t -> module_presence -> Subst.Lazy.module_declaration -> t -> t
 val add_modtype: Ident.t -> modtype_declaration -> t -> t
 val add_modtype_lazy: update_summary:bool ->
    Ident.t -> Subst.Lazy.modtype_declaration -> t -> t
@@ -482,7 +482,7 @@ val check_well_formed_module:
 val add_delayed_check_forward: ((unit -> unit) -> unit) ref
 (* Forward declaration to break mutual recursion with Mtype. *)
 val scrape_alias:
-    (t -> Subst.Lazy.modtype -> Subst.Lazy.modtype) ref
+    (t -> Subst.Lazy.module_type -> Subst.Lazy.module_type) ref
 (* Forward declaration to break mutual recursion with Ctype. *)
 val same_constr: (t -> type_expr -> type_expr -> bool) ref
 (* Forward declaration to break mutual recursion with Printtyp. *)

--- a/ocaml/typing/mtype.ml
+++ b/ocaml/typing/mtype.ml
@@ -22,7 +22,7 @@ open Types
 let rec scrape_lazy env mty =
   let open Subst.Lazy in
   match mty with
-    MtyL_ident p ->
+    Mty_ident p ->
       begin try
         scrape_lazy env (Env.find_modtype_expansion_lazy p env)
       with Not_found ->
@@ -32,8 +32,8 @@ let rec scrape_lazy env mty =
 
 let scrape env mty =
   match mty with
-    Mty_ident p ->
-     Subst.Lazy.force_modtype (scrape_lazy env (MtyL_ident p))
+    Types.Mty_ident p ->
+     Subst.Lazy.force_modtype (scrape_lazy env (Mty_ident p))
   | _ -> mty
 
 let freshen ~scope mty =
@@ -42,19 +42,19 @@ let freshen ~scope mty =
 let rec strengthen_lazy ~aliasable env mty p =
   let open Subst.Lazy in
   match scrape_lazy env mty with
-    MtyL_signature sg ->
-      MtyL_signature(strengthen_lazy_sig ~aliasable env sg p)
-  | MtyL_functor(Named (Some param, arg), res)
+    Mty_signature sg ->
+      Mty_signature(strengthen_lazy_sig ~aliasable env sg p)
+  | Mty_functor(Named (Some param, arg), res)
     when !Clflags.applicative_functors ->
       let env =
         Env.add_module_lazy ~update_summary:false param Mp_present arg env
       in
-      MtyL_functor(Named (Some param, arg),
+      Mty_functor(Named (Some param, arg),
         strengthen_lazy ~aliasable:false env res (Papply(p, Pident param)))
-  | MtyL_functor(Named (None, arg), res)
+  | Mty_functor(Named (None, arg), res)
     when !Clflags.applicative_functors ->
       let param = Ident.create_scoped ~scope:(Path.scope p) "Arg" in
-      MtyL_functor(Named (Some param, arg),
+      Mty_functor(Named (Some param, arg),
         strengthen_lazy ~aliasable:false env res (Papply(p, Pident param)))
   | mty ->
       mty
@@ -63,12 +63,12 @@ and strengthen_lazy_sig' ~aliasable env sg p =
   let open Subst.Lazy in
   match sg with
     [] -> []
-  | (SigL_value(_, _, _) as sigelt) :: rem ->
+  | (Sig_value(_, _, _) as sigelt) :: rem ->
       sigelt :: strengthen_lazy_sig' ~aliasable env rem p
-  | SigL_type(id, {type_kind=Type_abstract _}, _, _) :: rem
+  | Sig_type(id, {type_kind=Type_abstract _}, _, _) :: rem
     when Btype.is_row_name (Ident.name id) ->
       strengthen_lazy_sig' ~aliasable env rem p
-  | SigL_type(id, decl, rs, vis) :: rem ->
+  | Sig_type(id, decl, rs, vis) :: rem ->
       let newdecl =
         match decl.type_manifest, decl.type_private, decl.type_kind with
           Some _, Public, _ -> decl
@@ -82,36 +82,36 @@ and strengthen_lazy_sig' ~aliasable env sg p =
             else
               { decl with type_manifest = manif }
       in
-      SigL_type(id, newdecl, rs, vis) ::
+      Sig_type(id, newdecl, rs, vis) ::
         strengthen_lazy_sig' ~aliasable env rem p
-  | (SigL_typext _ as sigelt) :: rem ->
+  | (Sig_typext _ as sigelt) :: rem ->
       sigelt :: strengthen_lazy_sig' ~aliasable env rem p
-  | SigL_module(id, pres, md, rs, vis) :: rem ->
+  | Sig_module(id, pres, md, rs, vis) :: rem ->
       let str =
         strengthen_lazy_decl ~aliasable env md (Pdot(p, Ident.name id))
       in
       let env =
         Env.add_module_declaration_lazy ~update_summary:false id pres md env in
-      SigL_module(id, pres, str, rs, vis)
+      Sig_module(id, pres, str, rs, vis)
       :: strengthen_lazy_sig' ~aliasable env rem p
       (* Need to add the module in case it defines manifest module types *)
-  | SigL_modtype(id, decl, vis) :: rem ->
+  | Sig_modtype(id, decl, vis) :: rem ->
       let newdecl =
-        match decl.mtdl_type with
+        match decl.mtd_type with
         | Some _ when not aliasable ->
             (* [not alisable] condition needed because of recursive modules.
                See [Typemod.check_recmodule_inclusion]. *)
             decl
         | _ ->
-            {decl with mtdl_type = Some(MtyL_ident(Pdot(p,Ident.name id)))}
+            {decl with mtd_type = Some(Mty_ident(Pdot(p,Ident.name id)))}
       in
       let env = Env.add_modtype_lazy ~update_summary:false id decl env in
-      SigL_modtype(id, newdecl, vis) ::
+      Sig_modtype(id, newdecl, vis) ::
       strengthen_lazy_sig' ~aliasable env rem p
       (* Need to add the module type in case it is manifest *)
-  | (SigL_class _ as sigelt) :: rem ->
+  | (Sig_class _ as sigelt) :: rem ->
       sigelt :: strengthen_lazy_sig' ~aliasable env rem p
-  | (SigL_class_type _ as sigelt) :: rem ->
+  | (Sig_class_type _ as sigelt) :: rem ->
       sigelt :: strengthen_lazy_sig' ~aliasable env rem p
 
 and strengthen_lazy_sig ~aliasable env sg p =
@@ -121,10 +121,10 @@ and strengthen_lazy_sig ~aliasable env sg p =
 
 and strengthen_lazy_decl ~aliasable env md p =
   let open Subst.Lazy in
-  match md.mdl_type with
-  | MtyL_alias _ -> md
-  | _ when aliasable -> {md with mdl_type = MtyL_alias p}
-  | mty -> {md with mdl_type = strengthen_lazy ~aliasable env mty p}
+  match md.md_type with
+  | Mty_alias _ -> md
+  | _ when aliasable -> {md with md_type = Mty_alias p}
+  | mty -> {md with md_type = strengthen_lazy ~aliasable env mty p}
 
 let strengthen ~aliasable env mty p =
   let mty = strengthen_lazy ~aliasable env (Subst.Lazy.of_modtype mty) p in
@@ -215,15 +215,15 @@ let scrape_for_type_of env pres mty =
 let rec scrape_alias_lazy env ?path mty =
   let open Subst.Lazy in
   match mty, path with
-    MtyL_ident p, _ ->
+    Mty_ident p, _ ->
       begin try
         scrape_alias_lazy env (Env.find_modtype_expansion_lazy p env) ?path
       with Not_found ->
         mty
       end
-  | MtyL_alias path, _ ->
+  | Mty_alias path, _ ->
       begin try
-        scrape_alias_lazy env ((Env.find_module_lazy path env).mdl_type) ~path
+        scrape_alias_lazy env ((Env.find_module_lazy path env).md_type) ~path
       with Not_found ->
         (*Location.prerr_warning Location.none
           (Warnings.No_cmi_file (Path.name path));*)
@@ -244,7 +244,7 @@ let () = Env.scrape_alias := fun env mty -> scrape_alias_lazy env mty
 let find_type_of_module ~strengthen ~aliasable env path =
   if strengthen then
     let md = Env.find_module_lazy path env in
-    let mty = strengthen_lazy ~aliasable env md.mdl_type path in
+    let mty = strengthen_lazy ~aliasable env md.md_type path in
     Subst.Lazy.force_modtype mty
   else
     (Env.find_module path env).md_type

--- a/ocaml/typing/mtype.mli
+++ b/ocaml/typing/mtype.mli
@@ -33,12 +33,13 @@ val scrape_for_type_of:
 val freshen: scope:int -> module_type -> module_type
         (* Return an alpha-equivalent copy of the given module type
            where bound identifiers are fresh. *)
-val strengthen_lazy: aliasable:bool -> Env.t -> Subst.Lazy.modtype -> Path.t -> Subst.Lazy.modtype
+val strengthen_lazy:
+        aliasable:bool -> Env.t -> Subst.Lazy.module_type -> Path.t -> Subst.Lazy.module_type
 val strengthen: aliasable:bool -> Env.t -> module_type -> Path.t -> module_type
         (* Strengthen abstract type components relative to the
            given path. *)
 val strengthen_lazy_decl:
-  aliasable:bool -> Env.t -> Subst.Lazy.module_decl -> Path.t -> Subst.Lazy.module_decl
+  aliasable:bool -> Env.t -> Subst.Lazy.module_declaration -> Path.t -> Subst.Lazy.module_declaration
 val strengthen_decl:
   aliasable:bool -> Env.t -> module_declaration -> Path.t -> module_declaration
 

--- a/ocaml/typing/subst.ml
+++ b/ocaml/typing/subst.ml
@@ -447,53 +447,49 @@ type scoping =
   | Make_local
   | Rescope of int
 
-module Lazy_types = struct
+module Pod : sig
+  type subst = t
+  type 'a t
 
-  type module_decl =
-    {
-      mdl_type: modtype;
-      mdl_attributes: Parsetree.attributes;
-      mdl_loc: Location.t;
-      mdl_uid: Uid.t;
-    }
+  val of_value : 'a -> 'a t
+  val of_lazy : 'a Lazy.t -> 'a t
+  val force : (scoping -> subst -> 'a -> 'a) -> 'a t -> 'a
+  val substitute : compose:(subst -> subst -> subst) -> scoping -> subst -> 'a t -> 'a t
+end = struct
+  type subst = t
 
-  and modtype =
-    | MtyL_ident of Path.t
-    | MtyL_signature of signature
-    | MtyL_functor of functor_parameter * modtype
-    | MtyL_alias of Path.t
+  (* We are lazy twice here - firstly, in converting an underlying type to Subst.Lazy.* and
+     then, in applying the substitution which we try to accumulate. Note that there is a
+     difference between not applying a substitution at all and applying an identity
+     substitution as the latter renames - hence the option. *)
+  type 'a t = ((scoping * subst) option * 'a Lazy.t, 'a) Lazy_backtrack.t
 
-  and modtype_declaration =
-    {
-      mtdl_type: modtype option;
-      mtdl_attributes: Parsetree.attributes;
-      mtdl_loc: Location.t;
-      mtdl_uid: Uid.t;
-    }
+  let of_value = Lazy_backtrack.create_forced
+  let of_lazy x = Lazy_backtrack.create (None, x)
 
-  and signature' =
-    | S_eager of Types.signature
-    | S_lazy of signature_item list
+  let substitute ~compose scoping s x =
+    match Lazy_backtrack.get_contents x with
+    | Left (None, x) ->
+      Lazy_backtrack.create (Some (scoping, s), x)
+    | Left (Some (scoping', s'), x) ->
+        let scoping =
+          match scoping', scoping with
+          | sc, Keep -> sc
+          | _, (Make_local|Rescope _) -> scoping
+        in
+        let s = compose s' s in
+        Lazy_backtrack.create (Some (scoping, s), x)
+    | Right x ->
+        Lazy_backtrack.create (Some (scoping, s), Lazy.from_val x)
 
-  and signature =
-    (scoping * t * signature', signature') Lazy_backtrack.t
-
-  and signature_item =
-      SigL_value of Ident.t * value_description * visibility
-    | SigL_type of Ident.t * type_declaration * rec_status * visibility
-    | SigL_typext of Ident.t * extension_constructor * ext_status * visibility
-    | SigL_module of
-        Ident.t * module_presence * module_decl * rec_status * visibility
-    | SigL_modtype of Ident.t * modtype_declaration * visibility
-    | SigL_class of Ident.t * class_declaration * rec_status * visibility
-    | SigL_class_type of Ident.t * class_type_declaration *
-                           rec_status * visibility
-
-  and functor_parameter =
-    | Unit
-    | Named of Ident.t option * modtype
-
+  let force f = Lazy_backtrack.force (fun (s, x) ->
+    let x = Lazy.force x in
+    match s with
+    | Some (scoping, s) -> f scoping s x
+    | None -> x)
 end
+
+module Lazy_types = Types.Make(Pod)
 open Lazy_types
 
 let rename_bound_idents scoping s sg =
@@ -506,215 +502,136 @@ let rename_bound_idents scoping s sg =
   in
   let rec rename_bound_idents s sg = function
     | [] -> sg, s
-    | SigL_type(id, td, rs, vis) :: rest ->
+    | Sig_type(id, td, rs, vis) :: rest ->
         let id' = rename id in
         rename_bound_idents
           (add_type id (Pident id') s)
-          (SigL_type(id', td, rs, vis) :: sg)
+          (Sig_type(id', td, rs, vis) :: sg)
           rest
-    | SigL_module(id, pres, md, rs, vis) :: rest ->
+    | Sig_module(id, pres, md, rs, vis) :: rest ->
         let id' = rename id in
         rename_bound_idents
           (add_module id (Pident id') s)
-          (SigL_module (id', pres, md, rs, vis) :: sg)
+          (Sig_module (id', pres, md, rs, vis) :: sg)
           rest
-    | SigL_modtype(id, mtd, vis) :: rest ->
+    | Sig_modtype(id, mtd, vis) :: rest ->
         let id' = rename id in
         rename_bound_idents
-          (add_modtype id (Mty_ident(Pident id')) s)
-          (SigL_modtype(id', mtd, vis) :: sg)
+          (add_modtype id (Types.Mty_ident(Pident id')) s)
+          (Sig_modtype(id', mtd, vis) :: sg)
           rest
-    | SigL_class(id, cd, rs, vis) :: rest ->
+    | Sig_class(id, cd, rs, vis) :: rest ->
         (* cheat and pretend they are types cf. PR#6650 *)
         let id' = rename id in
         rename_bound_idents
           (add_type id (Pident id') s)
-          (SigL_class(id', cd, rs, vis) :: sg)
+          (Sig_class(id', cd, rs, vis) :: sg)
           rest
-    | SigL_class_type(id, ctd, rs, vis) :: rest ->
+    | Sig_class_type(id, ctd, rs, vis) :: rest ->
         (* cheat and pretend they are types cf. PR#6650 *)
         let id' = rename id in
         rename_bound_idents
           (add_type id (Pident id') s)
-          (SigL_class_type(id', ctd, rs, vis) :: sg)
+          (Sig_class_type(id', ctd, rs, vis) :: sg)
           rest
-    | SigL_value(id, vd, vis) :: rest ->
+    | Sig_value(id, vd, vis) :: rest ->
         (* scope doesn't matter for value identifiers. *)
         let id' = Ident.rename id in
-        rename_bound_idents s (SigL_value(id', vd, vis) :: sg) rest
-    | SigL_typext(id, ec, es, vis) :: rest ->
+        rename_bound_idents s (Sig_value(id', vd, vis) :: sg) rest
+    | Sig_typext(id, ec, es, vis) :: rest ->
         let id' = rename id in
-        rename_bound_idents s (SigL_typext(id',ec,es,vis) :: sg) rest
+        rename_bound_idents s (Sig_typext(id',ec,es,vis) :: sg) rest
   in
   rename_bound_idents s [] sg
 
-let rec lazy_module_decl md =
-  { mdl_type = lazy_modtype md.md_type;
-    mdl_attributes = md.md_attributes;
-    mdl_loc = md.md_loc;
-    mdl_uid = md.md_uid }
+module To_lazy = Types.Map_pods(Types)(Lazy_types)
 
-and subst_lazy_module_decl scoping s md =
-  let mdl_type = subst_lazy_modtype scoping s md.mdl_type in
-  { mdl_type;
-    mdl_attributes = attrs s md.mdl_attributes;
-    mdl_loc = loc s md.mdl_loc;
-    mdl_uid = md.mdl_uid }
+let to_lazy =
+  let map_signature m sg =
+    lazy (List.map (To_lazy.signature_item m) sg) |> Pod.of_lazy
+  in
+  To_lazy.{map_signature}
 
-and force_module_decl md =
-  let md_type = force_modtype md.mdl_type in
+let lazy_module_decl = To_lazy.module_declaration to_lazy
+let lazy_functor_parameter = To_lazy.functor_parameter to_lazy
+let lazy_modtype = To_lazy.module_type to_lazy
+let lazy_modtype_decl = To_lazy.modtype_declaration to_lazy
+let lazy_signature_item = To_lazy.signature_item to_lazy
+
+module From_lazy = Types.Map_pods(Lazy_types)(Types)
+
+let rec subst_lazy_module_decl scoping s md =
+  let md_type = subst_lazy_modtype scoping s md.md_type in
   { md_type;
-    md_attributes = md.mdl_attributes;
-    md_loc = md.mdl_loc;
-    md_uid = md.mdl_uid }
-
-and lazy_functor_parameter = function
-| Types.Unit -> Unit
-| Types.Named (id, mty) -> Named (id, lazy_modtype mty)
-
-and force_functor_parameter = function
-| Unit -> Types.Unit
-| Named (id, mty) -> Types.Named (id, force_modtype mty)
-
-and lazy_modtype = function
-  | Mty_ident p -> MtyL_ident p
-  | Mty_signature sg ->
-     MtyL_signature (Lazy_backtrack.create_forced (S_eager sg))
-  | Mty_functor (param, mty) ->
-     MtyL_functor (lazy_functor_parameter param, lazy_modtype mty)
-  | Mty_alias p -> MtyL_alias p
+    md_attributes = attrs s md.md_attributes;
+    md_loc = loc s md.md_loc;
+    md_uid = md.md_uid }
 
 and subst_lazy_modtype scoping s = function
-  | MtyL_ident p ->
+  | Mty_ident p ->
       begin match Path.Map.find p s.modtypes with
        | mty -> lazy_modtype mty
        | exception Not_found ->
           begin match p with
-          | Pident _ -> MtyL_ident p
+          | Pident _ -> Mty_ident p
           | Pdot(p, n) ->
-             MtyL_ident(Pdot(module_path s p, n))
+             Mty_ident(Pdot(module_path s p, n))
           | Papply _ ->
              fatal_error "Subst.modtype"
           end
       end
-  | MtyL_signature sg ->
-      MtyL_signature(subst_lazy_signature scoping s sg)
-  | MtyL_functor(Unit, res) ->
-      MtyL_functor(Unit, subst_lazy_modtype scoping s res)
-  | MtyL_functor(Named (None, arg), res) ->
-      MtyL_functor(Named (None, (subst_lazy_modtype scoping s) arg),
+  | Mty_signature sg ->
+      Mty_signature(subst_lazy_signature scoping s sg)
+  | Mty_functor(Unit, res) ->
+      Mty_functor(Unit, subst_lazy_modtype scoping s res)
+  | Mty_functor(Named (None, arg), res) ->
+      Mty_functor(Named (None, (subst_lazy_modtype scoping s) arg),
                    subst_lazy_modtype scoping s res)
-  | MtyL_functor(Named (Some id, arg), res) ->
+  | Mty_functor(Named (Some id, arg), res) ->
       let id' = Ident.rename id in
-      MtyL_functor(Named (Some id', (subst_lazy_modtype scoping s) arg),
+      Mty_functor(Named (Some id', (subst_lazy_modtype scoping s) arg),
                   subst_lazy_modtype scoping (add_module id (Pident id') s) res)
-  | MtyL_alias p ->
-      MtyL_alias (module_path s p)
-
-and force_modtype = function
-  | MtyL_ident p -> Mty_ident p
-  | MtyL_signature sg -> Mty_signature (force_signature sg)
-  | MtyL_functor (param, res) ->
-     Mty_functor (force_functor_parameter param, force_modtype res)
-  | MtyL_alias p -> Mty_alias p
-
-and lazy_modtype_decl mtd =
-  let mtdl_type = Option.map lazy_modtype mtd.mtd_type in
-  { mtdl_type;
-    mtdl_attributes = mtd.mtd_attributes;
-    mtdl_loc = mtd.mtd_loc;
-    mtdl_uid = mtd.mtd_uid }
+  | Mty_alias p ->
+      Mty_alias (module_path s p)
 
 and subst_lazy_modtype_decl scoping s mtd =
-  { mtdl_type = Option.map (subst_lazy_modtype scoping s) mtd.mtdl_type;
-    mtdl_attributes = attrs s mtd.mtdl_attributes;
-    mtdl_loc = loc s mtd.mtdl_loc;
-    mtdl_uid = mtd.mtdl_uid }
-
-and force_modtype_decl mtd =
-  let mtd_type = Option.map force_modtype mtd.mtdl_type in
-  { mtd_type;
-    mtd_attributes = mtd.mtdl_attributes;
-    mtd_loc = mtd.mtdl_loc;
-    mtd_uid = mtd.mtdl_uid }
+  { mtd_type = Option.map (subst_lazy_modtype scoping s) mtd.mtd_type;
+    mtd_attributes = attrs s mtd.mtd_attributes;
+    mtd_loc = loc s mtd.mtd_loc;
+    mtd_uid = mtd.mtd_uid }
 
 and subst_lazy_signature scoping s sg =
-  match Lazy_backtrack.get_contents sg with
-  | Left (scoping', s', sg) ->
-     let scoping =
-       match scoping', scoping with
-       | sc, Keep -> sc
-       | _, (Make_local|Rescope _) -> scoping
-     in
-     let s = compose s' s in
-     Lazy_backtrack.create (scoping, s, sg)
-  | Right sg ->
-     Lazy_backtrack.create (scoping, s, sg)
-
-and force_signature sg =
-  List.map force_signature_item (force_signature_once sg)
+  Pod.substitute ~compose scoping s sg
 
 and force_signature_once sg =
-  lazy_signature' (Lazy_backtrack.force force_signature_once' sg)
+  Pod.force force_signature_once' sg
 
-and lazy_signature' = function
-  | S_lazy sg -> sg
-  | S_eager sg -> List.map lazy_signature_item sg
-
-and force_signature_once' (scoping, s, sg) =
-  let sg = lazy_signature' sg in
+and force_signature_once' scoping s sg =
   (* Components of signature may be mutually recursive (e.g. type declarations
      or class and type declarations), so first build global renaming
      substitution... *)
   let (sg', s') = rename_bound_idents scoping s sg in
   (* ... then apply it to each signature component in turn *)
   For_copy.with_scope (fun copy_scope ->
-    S_lazy (List.rev_map (subst_lazy_signature_item' copy_scope scoping s') sg')
+    List.rev_map (subst_lazy_signature_item' copy_scope scoping s') sg'
   )
-
-and lazy_signature_item = function
-  | Sig_value(id, d, vis) ->
-     SigL_value(id, d, vis)
-  | Sig_type(id, d, rs, vis) ->
-     SigL_type(id, d, rs, vis)
-  | Sig_typext(id, ext, es, vis) ->
-     SigL_typext(id, ext, es, vis)
-  | Sig_module(id, res, d, rs, vis) ->
-     SigL_module(id, res, lazy_module_decl d, rs, vis)
-  | Sig_modtype(id, d, vis) ->
-     SigL_modtype(id, lazy_modtype_decl d, vis)
-  | Sig_class(id, d, rs, vis) ->
-     SigL_class(id, d, rs, vis)
-  | Sig_class_type(id, d, rs, vis) ->
-     SigL_class_type(id, d, rs, vis)
 
 and subst_lazy_signature_item' copy_scope scoping s comp =
   match comp with
-    SigL_value(id, d, vis) ->
-      SigL_value(id, value_description' copy_scope s d, vis)
-  | SigL_type(id, d, rs, vis) ->
-      SigL_type(id, type_declaration' copy_scope s d, rs, vis)
-  | SigL_typext(id, ext, es, vis) ->
-      SigL_typext(id, extension_constructor' copy_scope s ext, es, vis)
-  | SigL_module(id, pres, d, rs, vis) ->
-      SigL_module(id, pres, subst_lazy_module_decl scoping s d, rs, vis)
-  | SigL_modtype(id, d, vis) ->
-      SigL_modtype(id, subst_lazy_modtype_decl scoping s d, vis)
-  | SigL_class(id, d, rs, vis) ->
-      SigL_class(id, class_declaration' copy_scope s d, rs, vis)
-  | SigL_class_type(id, d, rs, vis) ->
-      SigL_class_type(id, cltype_declaration' copy_scope s d, rs, vis)
-
-and force_signature_item = function
-  | SigL_value(id, vd, vis) -> Sig_value(id, vd, vis)
-  | SigL_type(id, d, rs, vis) -> Sig_type(id, d, rs, vis)
-  | SigL_typext(id, ext, es, vis) -> Sig_typext(id, ext, es, vis)
-  | SigL_module(id, pres, d, rs, vis) ->
-     Sig_module(id, pres, force_module_decl d, rs, vis)
-  | SigL_modtype(id, d, vis) ->
-     Sig_modtype (id, force_modtype_decl d, vis)
-  | SigL_class(id, d, rs, vis) -> Sig_class(id, d, rs, vis)
-  | SigL_class_type(id, d, rs, vis) -> Sig_class_type(id, d, rs, vis)
+    Sig_value(id, d, vis) ->
+      Sig_value(id, value_description' copy_scope s d, vis)
+  | Sig_type(id, d, rs, vis) ->
+      Sig_type(id, type_declaration' copy_scope s d, rs, vis)
+  | Sig_typext(id, ext, es, vis) ->
+      Sig_typext(id, extension_constructor' copy_scope s ext, es, vis)
+  | Sig_module(id, pres, d, rs, vis) ->
+      Sig_module(id, pres, subst_lazy_module_decl scoping s d, rs, vis)
+  | Sig_modtype(id, d, vis) ->
+      Sig_modtype(id, subst_lazy_modtype_decl scoping s d, vis)
+  | Sig_class(id, d, rs, vis) ->
+      Sig_class(id, class_declaration' copy_scope s d, rs, vis)
+  | Sig_class_type(id, d, rs, vis) ->
+      Sig_class_type(id, cltype_declaration' copy_scope s d, rs, vis)
 
 and modtype scoping s t =
   t |> lazy_modtype |> subst_lazy_modtype scoping s |> force_modtype
@@ -739,6 +656,19 @@ and compose s1 s2 =
       in
       s2.last_compose <- Some (s1,s); s
 
+and from_lazy =
+  let map_signature m sg =
+    let items = force_signature_once sg in
+    List.map (From_lazy.signature_item m) items
+  in
+  From_lazy.{map_signature}
+
+and force_module_decl d = From_lazy.module_declaration from_lazy d
+and force_functor_parameter x = From_lazy.functor_parameter from_lazy x
+and force_modtype x = From_lazy.module_type from_lazy x
+and force_modtype_decl x = From_lazy.modtype_declaration from_lazy x
+and force_signature_item x = From_lazy.signature_item from_lazy x
+and force_signature x = From_lazy.signature from_lazy x
 
 let subst_lazy_signature_item scoping s comp =
   For_copy.with_scope
@@ -750,8 +680,8 @@ module Lazy = struct
   let of_module_decl = lazy_module_decl
   let of_modtype = lazy_modtype
   let of_modtype_decl = lazy_modtype_decl
-  let of_signature sg = Lazy_backtrack.create_forced (S_eager sg)
-  let of_signature_items sg = Lazy_backtrack.create_forced (S_lazy sg)
+  let of_signature sg = Pod.of_lazy (lazy (List.map lazy_signature_item sg))
+  let of_signature_items sg = Pod.of_value sg
   let of_signature_item = lazy_signature_item
   let of_functor_parameter = lazy_functor_parameter
 

--- a/ocaml/typing/subst.mli
+++ b/ocaml/typing/subst.mli
@@ -90,62 +90,24 @@ val ctype_apply_env_empty:
 
 
 module Lazy : sig
-  type module_decl =
-    {
-      mdl_type: modtype;
-      mdl_attributes: Parsetree.attributes;
-      mdl_loc: Location.t;
-      mdl_uid: Uid.t;
-    }
+  include Types.S
 
-  and modtype =
-    | MtyL_ident of Path.t
-    | MtyL_signature of signature
-    | MtyL_functor of functor_parameter * modtype
-    | MtyL_alias of Path.t
-
-  and modtype_declaration =
-    {
-      mtdl_type: modtype option;  (* Note: abstract *)
-      mtdl_attributes: Parsetree.attributes;
-      mtdl_loc: Location.t;
-      mtdl_uid: Uid.t;
-    }
-
-  and signature
-
-  and signature_item =
-      SigL_value of Ident.t * value_description * visibility
-    | SigL_type of Ident.t * type_declaration * rec_status * visibility
-    | SigL_typext of Ident.t * extension_constructor * ext_status * visibility
-    | SigL_module of
-        Ident.t * module_presence * module_decl * rec_status * visibility
-    | SigL_modtype of Ident.t * modtype_declaration * visibility
-    | SigL_class of Ident.t * class_declaration * rec_status * visibility
-    | SigL_class_type of Ident.t * class_type_declaration *
-                           rec_status * visibility
-
-  and functor_parameter =
-    | Unit
-    | Named of Ident.t option * modtype
-
-
-  val of_module_decl : Types.module_declaration -> module_decl
-  val of_modtype : Types.module_type -> modtype
+  val of_module_decl : Types.module_declaration -> module_declaration
+  val of_modtype : Types.module_type -> module_type
   val of_modtype_decl : Types.modtype_declaration -> modtype_declaration
   val of_signature : Types.signature -> signature
   val of_signature_items : signature_item list -> signature
   val of_signature_item : Types.signature_item -> signature_item
   val of_functor_parameter : Types.functor_parameter -> functor_parameter
 
-  val module_decl : scoping -> t -> module_decl -> module_decl
-  val modtype : scoping -> t -> modtype -> modtype
+  val module_decl : scoping -> t -> module_declaration -> module_declaration
+  val modtype : scoping -> t -> module_type -> module_type
   val modtype_decl : scoping -> t -> modtype_declaration -> modtype_declaration
   val signature : scoping -> t -> signature -> signature
   val signature_item : scoping -> t -> signature_item -> signature_item
 
-  val force_module_decl : module_decl -> Types.module_declaration
-  val force_modtype : modtype -> Types.module_type
+  val force_module_decl : module_declaration -> Types.module_declaration
+  val force_modtype : module_type -> Types.module_type
   val force_modtype_decl : modtype_declaration -> Types.modtype_declaration
   val force_signature : signature -> Types.signature
   val force_signature_once : signature -> signature_item list

--- a/ocaml/typing/subst.mli
+++ b/ocaml/typing/subst.mli
@@ -90,7 +90,7 @@ val ctype_apply_env_empty:
 
 
 module Lazy : sig
-  include Types.S
+  include Types.Wrapped
 
   val of_module_decl : Types.module_declaration -> module_declaration
   val of_modtype : Types.module_type -> module_type

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -342,12 +342,12 @@ type module_presence =
   | Mp_present
   | Mp_absent
 
-module type Pod = sig
+module type Wrap = sig
   type 'a t
 end
 
-module type S = sig
-  type 'a pod
+module type Wrapped = sig
+  type 'a wrapped
 
   type module_type =
     Mty_ident of Path.t
@@ -359,7 +359,7 @@ module type S = sig
   | Unit
   | Named of Ident.t option * module_type
 
-  and signature = signature_item list pod
+  and signature = signature_item list wrapped
 
   and signature_item =
     Sig_value of Ident.t * value_description * visibility
@@ -388,13 +388,13 @@ module type S = sig
   }
 end
 
-module Make(Pod : Pod) = struct
-  (* Avoid repeating everything in S *)
-  module rec M : S with type 'a pod = 'a Pod.t = M
+module Make_wrapped(Wrap : Wrap) = struct
+  (* Avoid repeating everything in Wrapped *)
+  module rec M : Wrapped with type 'a wrapped = 'a Wrap.t = M
   include M
 end
 
-module Map_pods(From : S)(To : S) = struct
+module Map_wrapped(From : Wrapped)(To : Wrapped) = struct
   open From
   type mapper =
     {
@@ -447,7 +447,7 @@ module Map_pods(From : S)(To : S) = struct
         To.Sig_class_type (id,ctd,rs,vis)
 end
 
-include Make(struct type 'a t = 'a end)
+include Make_wrapped(struct type 'a t = 'a end)
 
 (* Constructor and record label descriptions inserted held in typing
    environments *)

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -328,23 +328,40 @@ type visibility =
   | Exported
   | Hidden
 
-type module_type =
+type rec_status =
+  Trec_not                   (* first in a nonrecursive group *)
+| Trec_first                 (* first in a recursive group *)
+| Trec_next                  (* not first in a recursive/nonrecursive group *)
+
+type ext_status =
+  Text_first                     (* first constructor of an extension *)
+| Text_next                      (* not first constructor of an extension *)
+| Text_exception                 (* an exception *)
+
+type module_presence =
+  | Mp_present
+  | Mp_absent
+
+module type Pod = sig
+  type 'a t
+end
+
+module type S = sig
+  type 'a pod
+
+  type module_type =
     Mty_ident of Path.t
   | Mty_signature of signature
   | Mty_functor of functor_parameter * module_type
   | Mty_alias of Path.t
 
-and functor_parameter =
+  and functor_parameter =
   | Unit
   | Named of Ident.t option * module_type
 
-and module_presence =
-  | Mp_present
-  | Mp_absent
+  and signature = signature_item list pod
 
-and signature = signature_item list
-
-and signature_item =
+  and signature_item =
     Sig_value of Ident.t * value_description * visibility
   | Sig_type of Ident.t * type_declaration * rec_status * visibility
   | Sig_typext of Ident.t * extension_constructor * ext_status * visibility
@@ -354,7 +371,7 @@ and signature_item =
   | Sig_class of Ident.t * class_declaration * rec_status * visibility
   | Sig_class_type of Ident.t * class_type_declaration * rec_status * visibility
 
-and module_declaration =
+  and module_declaration =
   {
     md_type: module_type;
     md_attributes: Parsetree.attributes;
@@ -362,24 +379,75 @@ and module_declaration =
     md_uid: Uid.t;
   }
 
-and modtype_declaration =
+  and modtype_declaration =
   {
     mtd_type: module_type option;  (* Note: abstract *)
     mtd_attributes: Parsetree.attributes;
     mtd_loc: Location.t;
     mtd_uid: Uid.t;
   }
+end
 
-and rec_status =
-    Trec_not                   (* first in a nonrecursive group *)
-  | Trec_first                 (* first in a recursive group *)
-  | Trec_next                  (* not first in a recursive/nonrecursive group *)
+module Make(Pod : Pod) = struct
+  (* Avoid repeating everything in S *)
+  module rec M : S with type 'a pod = 'a Pod.t = M
+  include M
+end
 
-and ext_status =
-    Text_first                     (* first constructor of an extension *)
-  | Text_next                      (* not first constructor of an extension *)
-  | Text_exception                 (* an exception *)
+module Map_pods(From : S)(To : S) = struct
+  open From
+  type mapper =
+    {
+      map_signature: mapper -> signature -> To.signature;
+    }
 
+  let signature m = m.map_signature m
+
+  let rec module_type m = function
+    | Mty_ident p -> To.Mty_ident p
+    | Mty_alias p -> To.Mty_alias p
+    | Mty_functor (parm,mty) ->
+        To.Mty_functor (functor_parameter m parm, module_type m mty)
+    | Mty_signature sg -> To.Mty_signature (signature m sg)
+
+  and functor_parameter m = function
+      | Unit -> To.Unit
+      | Named (id,mty) -> To.Named (id, module_type m mty)
+
+  let module_declaration m {md_type; md_attributes; md_loc; md_uid} =
+    To.{
+      md_type = module_type m md_type;
+      md_attributes;
+      md_loc;
+      md_uid;
+    }
+
+  let modtype_declaration m {mtd_type; mtd_attributes; mtd_loc; mtd_uid} =
+    To.{
+      mtd_type = Option.map (module_type m) mtd_type;
+      mtd_attributes;
+      mtd_loc;
+      mtd_uid;
+    }
+
+  let signature_item m = function
+    | Sig_value (id,vd,vis) ->
+        To.Sig_value (id,vd,vis)
+    | Sig_type (id,td,rs,vis) ->
+        To.Sig_type (id,td,rs,vis)
+    | Sig_module (id,pres,md,rs,vis) ->
+        To.Sig_module (id, pres, module_declaration m md, rs, vis)
+    | Sig_modtype (id,mtd,vis) ->
+        To.Sig_modtype (id, modtype_declaration m mtd, vis)
+    | Sig_typext (id,ec,es,vis) ->
+        To.Sig_typext (id,ec,es,vis)
+    | Sig_class (id,cd,rs,vis) ->
+        To.Sig_class (id,cd,rs,vis)
+    | Sig_class_type (id,ctd,rs,vis) ->
+        To.Sig_class_type (id,ctd,rs,vis)
+end
+
+include Make(struct type 'a t = 'a end)
 
 (* Constructor and record label descriptions inserted held in typing
    environments *)

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -687,7 +687,7 @@ module Map_pods(From : S)(To : S) : sig
   val functor_parameter: mapper -> From.functor_parameter -> To.functor_parameter
 end
 
-include module type of Make(struct type 'a t = 'a end)
+include S with type 'a pod = 'a
 
 (* Constructor and record label descriptions inserted held in typing
    environments *)

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -624,13 +624,13 @@ type module_presence =
   | Mp_present
   | Mp_absent
 
-(* A Pod.t encapsulates bits of module types which can be lazy *)
-module type Pod = sig
+(* Wrap.t encapsulates bits of module types which can be lazy *)
+module type Wrap = sig
   type 'a t
 end
 
-module type S = sig
-  type 'a pod
+module type Wrapped = sig
+  type 'a wrapped
 
   type module_type =
     Mty_ident of Path.t
@@ -642,7 +642,7 @@ module type S = sig
   | Unit
   | Named of Ident.t option * module_type
 
-  and signature = signature_item list pod
+  and signature = signature_item list wrapped
 
   and signature_item =
     Sig_value of Ident.t * value_description * visibility
@@ -671,23 +671,26 @@ module type S = sig
   }
 end
 
-module Make(Pod : Pod) : S with type 'a pod = 'a Pod.t
+module Make_wrapped(Wrap : Wrap) : Wrapped with type 'a wrapped = 'a Wrap.t
 
-module Map_pods(From : S)(To : S) : sig
+module Map_wrapped(From : Wrapped)(To : Wrapped) : sig
   type mapper =
     {
       map_signature: mapper -> From.signature -> To.signature;
     }
 
-  val module_declaration: mapper -> From.module_declaration -> To.module_declaration
-  val modtype_declaration: mapper -> From.modtype_declaration -> To.modtype_declaration
-  val module_type: mapper -> From.module_type -> To.module_type
-  val signature: mapper -> From.signature -> To.signature
-  val signature_item: mapper -> From.signature_item -> To.signature_item
-  val functor_parameter: mapper -> From.functor_parameter -> To.functor_parameter
+  val module_declaration :
+    mapper -> From.module_declaration -> To.module_declaration
+  val modtype_declaration :
+    mapper -> From.modtype_declaration -> To.modtype_declaration
+  val module_type : mapper -> From.module_type -> To.module_type
+  val signature : mapper -> From.signature -> To.signature
+  val signature_item : mapper -> From.signature_item -> To.signature_item
+  val functor_parameter :
+    mapper -> From.functor_parameter -> To.functor_parameter
 end
 
-include S with type 'a pod = 'a
+include Wrapped with type 'a wrapped = 'a
 
 (* Constructor and record label descriptions inserted held in typing
    environments *)


### PR DESCRIPTION
This merges the type definitions in `Types` and `Subst.Lazy` by abstracting over the bits of the AST that can be lazy in the new functor in `types.mli` (cg. `Types.Pod`), accompanied by a generic scheme for converting between different kinds of ASTs in `Types.Map_pods`. The conversions to and from lazy ASTs in `Subst` are replaced by this.

The laziness in `Subst` is slightly more generic than what we had before. This is in anticipation of a future PR which will allow us to lazily deserialise .cmi files by piggy-backing on the same mechanism.

There is also a bit of refactoring in `Env` which removes some code duplication and addresses comments in #1228.

I have observed no changes to compile times in my benchmarks. There is a regression when building the compiler with flambda2 *without* optimisations but we shouldn't do that (cf. #1291). 