### PR TITLE
Fix build warning 48

### DIFF
--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -328,7 +328,7 @@ let rec unknown_with_subkind ?(alloc_mode = Alloc_mode.For_types.unknown ())
 let bottom_with_subkind kind = bottom (Flambda_kind.With_subkind.kind kind)
 
 let unknown_types_from_arity arity =
-  List.map unknown_with_subkind (Flambda_arity.to_list arity)
+  List.map (fun kind -> unknown_with_subkind kind) (Flambda_arity.to_list arity)
 
 let bottom_types_from_arity arity =
   List.map bottom_with_subkind (Flambda_arity.to_list arity)


### PR DESCRIPTION
Revert a line from PR #1241 which  causes warning 48 during build.