### PR TITLE
Reinstate previous API for Env.lookup_value

### DIFF
--- a/ocaml/toplevel/topdirs.ml
+++ b/ocaml/toplevel/topdirs.ml
@@ -416,7 +416,7 @@ let () =
   reg_show_prim "show_val"
     (fun env loc id lid ->
        let _path, desc, _ = Env.lookup_value ~loc lid env in
-       [ Sig_value (id, Subst.Lazy.force_value_description desc, Exported) ]
+       [ Sig_value (id, desc, Exported) ]
     )
     "Print the signature of the corresponding value."
 

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -3183,7 +3183,7 @@ let lookup_module_path ~errors ~use ~loc ~load lid env : Path.t =
       let path_f, _comp_f, path_arg = lookup_apply ~errors ~use ~loc lid env in
       Papply(path_f, path_arg)
 
-let lookup_value ~errors ~use ~loc lid env =
+let lookup_value_lazy ~errors ~use ~loc lid env =
   match lid with
   | Lident s -> lookup_ident_value ~errors ~use ~loc s env
   | Ldot(l, s) ->
@@ -3280,7 +3280,7 @@ let find_module_by_name lid env =
 
 let find_value_by_name lid env =
   let loc = Location.(in_file !input_name) in
-  let path, desc, _ = lookup_value ~errors:false ~use:false ~loc lid env in
+  let path, desc, _ = lookup_value_lazy ~errors:false ~use:false ~loc lid env in
   path, Subst.Lazy.force_value_description desc
 
 let find_type_by_name lid env =
@@ -3317,7 +3317,8 @@ let lookup_module ?(use=true) ~loc lid env =
 
 let lookup_value ?(use=true) ~loc lid env =
   check_value_name (Longident.last lid) loc;
-  lookup_value ~errors:true ~use ~loc lid env
+  let path, desc, mode = lookup_value_lazy ~errors:true ~use ~loc lid env in
+  path, Subst.Lazy.force_value_description desc, mode
 
 let lookup_type ?(use=true) ~loc lid env =
   lookup_type ~errors:true ~use ~loc lid env

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -215,7 +215,7 @@ val lookup_error: Location.t -> t -> lookup_error -> 'a
 
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
-  Path.t * Subst.Lazy.value_description * Types.value_mode
+  Path.t * value_description * Types.value_mode
 val lookup_type:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * type_declaration

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -5336,7 +5336,6 @@ and type_expect_
 
 and type_ident env ?(recarg=Rejected) lid =
   let (path, desc, mode) = Env.lookup_value ~loc:lid.loc lid.txt env in
-  let desc = Subst.Lazy.force_value_description desc in
   let is_recarg =
     match get_desc desc.val_type with
     | Tconstr(p, _, _) -> Path.is_constructor_typath p
@@ -7279,7 +7278,6 @@ let type_expression env sexp =
       let (_path, desc, _mode) =
         Env.lookup_value ~use:false ~loc lid.txt env
       in
-      let desc = Subst.Lazy.force_value_description desc in
       {exp with exp_type = desc.val_type}
   | _ -> exp
 


### PR DESCRIPTION
PR #1320 changed it to return a lazy `value_description` for no real reason which broke some external clients. This reinstates the previous interface, mostly by undoing some of the ill-advised changes in #1320.