### PR TITLE
Extensions in variants

### DIFF
--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1425,10 +1425,16 @@ end = struct
                 blocks = Unknown;
                 extensions = _;
                 is_unique = _
+              }
+          | Variant
+              { immediates = Unknown;
+                blocks = _;
+                extensions = _;
+                is_unique = _
               } ->
             Value_unknown
           | Variant
-              { immediates = imms;
+              { immediates = Known imms;
                 blocks = Known blocks;
                 extensions = _;
                 is_unique = _

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1420,12 +1420,19 @@ end = struct
             | Incomplete_closure (function_slot, closures_entry) ->
               approx_of_closures_entry ~exact:false function_slot closures_entry
             )
-          | Variant { immediates = Unknown; blocks = _; is_unique = _ }
-          | Variant { immediates = _; blocks = Unknown; is_unique = _ } ->
+          | Variant
+              { immediates = _;
+                blocks = Unknown;
+                extensions = _;
+                is_unique = _
+              } ->
             Value_unknown
           | Variant
-              { immediates = Known imms; blocks = Known blocks; is_unique = _ }
-            ->
+              { immediates = imms;
+                blocks = Known blocks;
+                extensions = _;
+                is_unique = _
+              } ->
             if TG.is_obviously_bottom imms
             then
               match TG.Row_like_for_blocks.get_singleton blocks with

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -66,7 +66,7 @@ let these_naked_nativeints is = TG.these_naked_nativeints is
 let these_naked_vec128s vs = TG.these_naked_vec128s vs
 
 let any_tagged_immediate =
-  TG.create_variant ~is_unique:false ~immediates:TG.any_naked_immediate
+  TG.create_variant ~is_unique:false ~immediates:Unknown
     ~blocks:(Known TG.Row_like_for_blocks.bottom) ~extensions:No_extensions
 
 let these_tagged_immediates0 imms =
@@ -77,7 +77,7 @@ let these_tagged_immediates0 imms =
     then TG.bottom_value
     else
       TG.create_variant ~is_unique:false
-        ~immediates:(these_naked_immediates imms)
+        ~immediates:(Known (these_naked_immediates imms))
         ~blocks:(Known TG.Row_like_for_blocks.bottom) ~extensions:No_extensions
 
 let these_tagged_immediates imms = these_tagged_immediates0 imms
@@ -138,8 +138,9 @@ let any_boxed_vec128 =
   TG.box_vec128 TG.any_naked_vec128 (Alloc_mode.For_types.unknown ())
 
 let any_block =
-  TG.create_variant ~is_unique:false ~immediates:TG.bottom_naked_immediate
-    ~blocks:Unknown ~extensions:No_extensions
+  TG.create_variant ~is_unique:false
+    ~immediates:(Known TG.bottom_naked_immediate) ~blocks:Unknown
+    ~extensions:No_extensions
 
 let blocks_with_these_tags tags alloc_mode : _ Or_unknown.t =
   if not (Tag.Set.for_all Tag.is_structured_block tags)
@@ -150,8 +151,9 @@ let blocks_with_these_tags tags alloc_mode : _ Or_unknown.t =
       TG.Row_like_for_blocks.create_blocks_with_these_tags tags alloc_mode
     in
     Known
-      (TG.create_variant ~is_unique:false ~immediates:TG.bottom_naked_immediate
-         ~blocks:(Known blocks) ~extensions:No_extensions)
+      (TG.create_variant ~is_unique:false
+         ~immediates:(Known TG.bottom_naked_immediate) ~blocks:(Known blocks)
+         ~extensions:No_extensions)
 
 let immutable_block ~is_unique tag ~shape alloc_mode ~fields =
   match Targetint_31_63.of_int_option (List.length fields) with
@@ -159,7 +161,7 @@ let immutable_block ~is_unique tag ~shape alloc_mode ~fields =
     (* CR-someday mshinwell: This should be a special kind of error. *)
     Misc.fatal_error "Block too long for target"
   | Some _size ->
-    TG.create_variant ~is_unique ~immediates:TG.bottom_naked_immediate
+    TG.create_variant ~is_unique ~immediates:(Known TG.bottom_naked_immediate)
       ~blocks:
         (Known
            (TG.Row_like_for_blocks.create ~shape ~field_tys:fields (Closed tag)
@@ -175,7 +177,8 @@ let immutable_block_with_size_at_least ~tag ~n ~shape ~field_n_minus_one =
         then unknown field_kind
         else TG.alias_type_of field_kind (Simple.var field_n_minus_one))
   in
-  TG.create_variant ~is_unique:false ~immediates:TG.bottom_naked_immediate
+  TG.create_variant ~is_unique:false
+    ~immediates:(Known TG.bottom_naked_immediate)
     ~blocks:
       (Known
          (TG.Row_like_for_blocks.create ~shape ~field_tys (Open tag)
@@ -193,7 +196,7 @@ let variant ~const_ctors ~non_const_ctors alloc_mode =
     TG.Row_like_for_blocks.create_exactly_multiple ~shape_and_field_tys_by_tag
       alloc_mode
   in
-  TG.create_variant ~is_unique:false ~immediates:const_ctors
+  TG.create_variant ~is_unique:false ~immediates:(Known const_ctors)
     ~blocks:(Known blocks) ~extensions:No_extensions
 
 let exactly_this_closure function_slot ~all_function_slots_in_set:function_types

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -66,8 +66,8 @@ let these_naked_nativeints is = TG.these_naked_nativeints is
 let these_naked_vec128s vs = TG.these_naked_vec128s vs
 
 let any_tagged_immediate =
-  TG.create_variant ~is_unique:false ~immediates:Unknown
-    ~blocks:(Known TG.Row_like_for_blocks.bottom)
+  TG.create_variant ~is_unique:false ~immediates:TG.any_naked_immediate
+    ~blocks:(Known TG.Row_like_for_blocks.bottom) ~extensions:No_extensions
 
 let these_tagged_immediates0 imms =
   match Targetint_31_63.Set.get_singleton imms with
@@ -77,8 +77,8 @@ let these_tagged_immediates0 imms =
     then TG.bottom_value
     else
       TG.create_variant ~is_unique:false
-        ~immediates:(Known (these_naked_immediates imms))
-        ~blocks:(Known TG.Row_like_for_blocks.bottom)
+        ~immediates:(these_naked_immediates imms)
+        ~blocks:(Known TG.Row_like_for_blocks.bottom) ~extensions:No_extensions
 
 let these_tagged_immediates imms = these_tagged_immediates0 imms
 
@@ -138,8 +138,8 @@ let any_boxed_vec128 =
   TG.box_vec128 TG.any_naked_vec128 (Alloc_mode.For_types.unknown ())
 
 let any_block =
-  TG.create_variant ~is_unique:false
-    ~immediates:(Known TG.bottom_naked_immediate) ~blocks:Unknown
+  TG.create_variant ~is_unique:false ~immediates:TG.bottom_naked_immediate
+    ~blocks:Unknown ~extensions:No_extensions
 
 let blocks_with_these_tags tags alloc_mode : _ Or_unknown.t =
   if not (Tag.Set.for_all Tag.is_structured_block tags)
@@ -150,8 +150,8 @@ let blocks_with_these_tags tags alloc_mode : _ Or_unknown.t =
       TG.Row_like_for_blocks.create_blocks_with_these_tags tags alloc_mode
     in
     Known
-      (TG.create_variant ~is_unique:false
-         ~immediates:(Known TG.bottom_naked_immediate) ~blocks:(Known blocks))
+      (TG.create_variant ~is_unique:false ~immediates:TG.bottom_naked_immediate
+         ~blocks:(Known blocks) ~extensions:No_extensions)
 
 let immutable_block ~is_unique tag ~shape alloc_mode ~fields =
   match Targetint_31_63.of_int_option (List.length fields) with
@@ -159,11 +159,12 @@ let immutable_block ~is_unique tag ~shape alloc_mode ~fields =
     (* CR-someday mshinwell: This should be a special kind of error. *)
     Misc.fatal_error "Block too long for target"
   | Some _size ->
-    TG.create_variant ~is_unique ~immediates:(Known TG.bottom_naked_immediate)
+    TG.create_variant ~is_unique ~immediates:TG.bottom_naked_immediate
       ~blocks:
         (Known
            (TG.Row_like_for_blocks.create ~shape ~field_tys:fields (Closed tag)
               alloc_mode))
+      ~extensions:No_extensions
 
 let immutable_block_with_size_at_least ~tag ~n ~shape ~field_n_minus_one =
   let n = Targetint_31_63.to_int n in
@@ -174,12 +175,12 @@ let immutable_block_with_size_at_least ~tag ~n ~shape ~field_n_minus_one =
         then unknown field_kind
         else TG.alias_type_of field_kind (Simple.var field_n_minus_one))
   in
-  TG.create_variant ~is_unique:false
-    ~immediates:(Known (bottom K.naked_immediate))
+  TG.create_variant ~is_unique:false ~immediates:TG.bottom_naked_immediate
     ~blocks:
       (Known
          (TG.Row_like_for_blocks.create ~shape ~field_tys (Open tag)
             (Alloc_mode.For_types.unknown ())))
+    ~extensions:No_extensions
 
 let variant ~const_ctors ~non_const_ctors alloc_mode =
   let blocks =
@@ -192,8 +193,8 @@ let variant ~const_ctors ~non_const_ctors alloc_mode =
     TG.Row_like_for_blocks.create_exactly_multiple ~shape_and_field_tys_by_tag
       alloc_mode
   in
-  TG.create_variant ~is_unique:false ~immediates:(Known const_ctors)
-    ~blocks:(Known blocks)
+  TG.create_variant ~is_unique:false ~immediates:const_ctors
+    ~blocks:(Known blocks) ~extensions:No_extensions
 
 let exactly_this_closure function_slot ~all_function_slots_in_set:function_types
     ~all_closure_types_in_set:closure_types

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -3501,14 +3501,16 @@ let rec recover_some_aliases t =
                   ~const:(fun const ->
                     match Reg_width_const.descr const with
                     | Naked_immediate i -> this_tagged_immediate i
-                    | Tagged_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
-                    | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ ->
+                    | Tagged_immediate _ | Naked_float _ | Naked_float32 _
+                    | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
+                    | Naked_vec128 _ ->
                       Misc.fatal_errorf
                         "Immediates case returned wrong kind of constant:@ %a"
                         Reg_width_const.print const)
               | Unknown | Bottom | Ok (No_alias _) -> t)
-            | Value _ | Naked_float _ | Naked_float32 _ | Naked_int32 _ | Naked_int64 _
-            | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _ ->
+            | Value _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
+            | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _
+            | Region _ ->
               Misc.fatal_errorf "Immediates case returned wrong kind:@ %a" print
                 t' ()))))
   | Naked_immediate ty -> (

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -53,8 +53,9 @@ type t =
 
 and head_of_kind_value =
   | Variant of
-      { immediates : t Or_unknown.t;
+      { immediates : t;
         blocks : row_like_for_blocks Or_unknown.t;
+        extensions : variant_extensions;
         is_unique : bool
       }
   | Mutable_block of { alloc_mode : Alloc_mode.For_types.t }
@@ -196,6 +197,13 @@ and array_contents =
 
 and env_extension = { equations : t Name.Map.t } [@@unboxed]
 
+and variant_extensions =
+  | No_extensions
+  | Ext of
+      { when_immediate : env_extension;
+        when_block : env_extension
+      }
+
 type flambda_type = t
 
 let get_alias_exn t =
@@ -258,12 +266,13 @@ let rec free_names0 ~follow_value_slots t =
 
 and free_names_head_of_kind_value0 ~follow_value_slots head =
   match head with
-  | Variant { blocks; immediates; is_unique = _ } ->
-    Name_occurrences.union
-      (Or_unknown.free_names
-         (free_names_row_like_for_blocks ~follow_value_slots)
-         blocks)
-      (Or_unknown.free_names (free_names0 ~follow_value_slots) immediates)
+  | Variant { blocks; immediates; extensions; is_unique = _ } ->
+    Name_occurrences.union_list
+      [ Or_unknown.free_names
+          (free_names_row_like_for_blocks ~follow_value_slots)
+          blocks;
+        free_names0 ~follow_value_slots immediates;
+        free_names_variant_extensions ~follow_value_slots extensions ]
   | Mutable_block { alloc_mode = _ } -> Name_occurrences.empty
   | Boxed_float32 (ty, _alloc_mode) -> free_names0 ~follow_value_slots ty
   | Boxed_float (ty, _alloc_mode) -> free_names0 ~follow_value_slots ty
@@ -445,6 +454,15 @@ and free_names_env_extension ~follow_value_slots { equations } =
       Name_occurrences.add_name acc name Name_mode.in_types)
     equations Name_occurrences.empty
 
+and free_names_variant_extensions ~follow_value_slots
+    (extensions : variant_extensions) =
+  match extensions with
+  | No_extensions -> Name_occurrences.empty
+  | Ext { when_immediate; when_block } ->
+    Name_occurrences.union
+      (free_names_env_extension ~follow_value_slots when_immediate)
+      (free_names_env_extension ~follow_value_slots when_block)
+
 let free_names_except_through_value_slots t =
   free_names0 ~follow_value_slots:false t
 
@@ -533,18 +551,23 @@ let rec apply_renaming t renaming =
 
 and apply_renaming_head_of_kind_value head renaming =
   match head with
-  | Variant { blocks; immediates; is_unique } ->
-    let immediates' =
-      let>+$ immediates = immediates in
-      apply_renaming immediates renaming
-    in
+  | Variant { blocks; immediates; extensions; is_unique } ->
+    let immediates' = apply_renaming immediates renaming in
     let blocks' =
       let>+$ blocks = blocks in
       apply_renaming_row_like_for_blocks blocks renaming
     in
+    let extensions' = apply_renaming_variant_extensions extensions renaming in
     if immediates == immediates' && blocks == blocks'
+       && extensions == extensions'
     then head
-    else Variant { is_unique; blocks = blocks'; immediates = immediates' }
+    else
+      Variant
+        { is_unique;
+          blocks = blocks';
+          immediates = immediates';
+          extensions = extensions'
+        }
   | Mutable_block { alloc_mode = _ } -> head
   | Boxed_float32 (ty, alloc_mode) ->
     let ty' = apply_renaming ty renaming in
@@ -768,6 +791,18 @@ and apply_renaming_env_extension ({ equations } as env_extension) renaming =
   in
   if !changed then { equations = equations' } else env_extension
 
+and apply_renaming_variant_extensions extensions renaming =
+  match extensions with
+  | No_extensions -> extensions
+  | Ext { when_immediate; when_block } ->
+    let when_immediate' =
+      apply_renaming_env_extension when_immediate renaming
+    in
+    let when_block' = apply_renaming_env_extension when_block renaming in
+    if when_immediate == when_immediate' && when_block == when_block'
+    then extensions
+    else Ext { when_immediate = when_immediate'; when_block = when_block' }
+
 let rec print ppf t =
   match t with
   | Value ty ->
@@ -813,15 +848,15 @@ let rec print ppf t =
 
 and print_head_of_kind_value ppf head =
   match head with
-  | Variant { blocks; immediates; is_unique } ->
+  | Variant { blocks; immediates; extensions; is_unique } ->
     (* CR-someday mshinwell: Improve so that we elide blocks and/or immediates
        when they're empty. *)
     Format.fprintf ppf
       "@[<hov 1>(Variant%s@ @[<hov 1>(blocks@ %a)@]@ @[<hov 1>(tagged_imms@ \
-       %a)@])@]"
+       %a)@]%a)@]"
       (if is_unique then " unique" else "")
       (Or_unknown.print print_row_like_for_blocks)
-      blocks (Or_unknown.print print) immediates
+      blocks print immediates print_variant_extensions extensions
   | Mutable_block { alloc_mode } ->
     Format.fprintf ppf "@[<hov 1>(Mutable_block@ %a)@]"
       Alloc_mode.For_types.print alloc_mode
@@ -1030,6 +1065,14 @@ and print_env_extension ppf { equations } =
   Format.fprintf ppf "@[<hov 1>(equations@ @[<v 1>%a@])@]" print_equations
     equations
 
+and print_variant_extensions ppf (extensions : variant_extensions) =
+  match extensions with
+  | No_extensions -> ()
+  | Ext { when_immediate; when_block } ->
+    Format.fprintf ppf
+      "@ @[<hov 1>(when_immediate@ %a)@]@ @[<hov 1>(when_block@ %a)@]"
+      print_env_extension when_immediate print_env_extension when_block
+
 let rec ids_for_export t =
   match t with
   | Value ty ->
@@ -1063,10 +1106,11 @@ let rec ids_for_export t =
 
 and ids_for_export_head_of_kind_value head =
   match head with
-  | Variant { blocks; immediates; is_unique = _ } ->
-    Ids_for_export.union
-      (Or_unknown.ids_for_export ids_for_export_row_like_for_blocks blocks)
-      (Or_unknown.ids_for_export ids_for_export immediates)
+  | Variant { blocks; immediates; extensions; is_unique = _ } ->
+    Ids_for_export.union_list
+      [ Or_unknown.ids_for_export ids_for_export_row_like_for_blocks blocks;
+        ids_for_export immediates;
+        ids_for_export_variant_extensions extensions ]
   | Mutable_block { alloc_mode = _ } -> Ids_for_export.empty
   | Boxed_float (t, _alloc_mode) -> ids_for_export t
   | Boxed_float32 (t, _alloc_mode) -> ids_for_export t
@@ -1210,6 +1254,14 @@ and ids_for_export_env_extension { equations } =
     (fun name t ids ->
       Ids_for_export.add_name (Ids_for_export.union ids (ids_for_export t)) name)
     equations Ids_for_export.empty
+
+and ids_for_export_variant_extensions ext =
+  match ext with
+  | No_extensions -> Ids_for_export.empty
+  | Ext { when_immediate; when_block } ->
+    Ids_for_export.union
+      (ids_for_export_env_extension when_immediate)
+      (ids_for_export_env_extension when_block)
 
 (* We need to be very careful here. A non-trivial coercion expects to be dealing
    with some very specific type. As of this writing, the only non-trivial
@@ -1646,9 +1698,8 @@ let rec remove_unused_value_slots_and_shortcut_aliases t ~used_value_slots
 and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value head
     ~used_value_slots ~canonicalise =
   match head with
-  | Variant { blocks; immediates; is_unique } ->
+  | Variant { blocks; immediates; extensions; is_unique } ->
     let immediates' =
-      let>+$ immediates = immediates in
       remove_unused_value_slots_and_shortcut_aliases immediates
         ~used_value_slots ~canonicalise
     in
@@ -1657,9 +1708,20 @@ and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value head
       remove_unused_value_slots_and_shortcut_aliases_row_like_for_blocks blocks
         ~used_value_slots ~canonicalise
     in
+    let extensions' =
+      remove_unused_value_slots_and_shortcut_aliases_variant_extensions
+        extensions ~used_value_slots ~canonicalise
+    in
     if immediates == immediates' && blocks == blocks'
+       && extensions == extensions'
     then head
-    else Variant { is_unique; blocks = blocks'; immediates = immediates' }
+    else
+      Variant
+        { is_unique;
+          blocks = blocks';
+          immediates = immediates';
+          extensions = extensions'
+        }
   | Mutable_block { alloc_mode = _ } -> head
   | Boxed_float32 (ty, alloc_mode) ->
     let ty' =
@@ -2004,6 +2066,23 @@ and remove_unused_value_slots_and_shortcut_aliases_env_extension { equations }
   in
   { equations }
 
+and remove_unused_value_slots_and_shortcut_aliases_variant_extensions
+    (extensions : variant_extensions) ~used_value_slots ~canonicalise =
+  match extensions with
+  | No_extensions -> extensions
+  | Ext { when_immediate; when_block } ->
+    let when_immediate' =
+      remove_unused_value_slots_and_shortcut_aliases_env_extension
+        when_immediate ~used_value_slots ~canonicalise
+    in
+    let when_block' =
+      remove_unused_value_slots_and_shortcut_aliases_env_extension when_block
+        ~used_value_slots ~canonicalise
+    in
+    if when_immediate == when_immediate' && when_block == when_block'
+    then extensions
+    else Ext { when_immediate = when_immediate'; when_block = when_block' }
+
 let rec project_variables_out ~to_project ~expand t =
   match t with
   | Value ty ->
@@ -2198,18 +2277,25 @@ let rec project_variables_out ~to_project ~expand t =
 
 and project_head_of_kind_value ~to_project ~expand head =
   match head with
-  | Variant { blocks; immediates; is_unique } ->
-    let immediates' =
-      let>+$ immediates = immediates in
-      project_variables_out ~to_project ~expand immediates
-    in
+  | Variant { blocks; immediates; extensions; is_unique } ->
+    let immediates' = project_variables_out ~to_project ~expand immediates in
     let blocks' =
       let>+$ blocks = blocks in
       project_row_like_for_blocks ~to_project ~expand blocks
     in
+    let extensions' =
+      project_variant_extensions ~to_project ~expand extensions
+    in
     if immediates == immediates' && blocks == blocks'
+       && extensions == extensions'
     then head
-    else Variant { is_unique; blocks = blocks'; immediates = immediates' }
+    else
+      Variant
+        { is_unique;
+          blocks = blocks';
+          immediates = immediates';
+          extensions = extensions'
+        }
   | Mutable_block _ -> head
   | Boxed_float32 (ty, alloc_mode) ->
     let ty' = project_variables_out ~to_project ~expand ty in
@@ -2457,6 +2543,19 @@ and project_env_extension ~to_project ~expand ({ equations } as env_extension) =
   in
   if !changed then { equations = equations' } else env_extension
 
+and project_variant_extensions ~to_project ~expand
+    (extensions : variant_extensions) =
+  match extensions with
+  | No_extensions -> extensions
+  | Ext { when_immediate; when_block } ->
+    let when_immediate' =
+      project_env_extension ~to_project ~expand when_immediate
+    in
+    let when_block' = project_env_extension ~to_project ~expand when_block in
+    if when_immediate == when_immediate' && when_block == when_block'
+    then extensions
+    else Ext { when_immediate = when_immediate'; when_block = when_block' }
+
 let kind t =
   match t with
   | Value _ -> K.value
@@ -2470,17 +2569,14 @@ let kind t =
   | Rec_info _ -> K.rec_info
   | Region _ -> K.region
 
-let create_variant ~is_unique ~(immediates : _ Or_unknown.t) ~blocks =
-  (match immediates with
-  | Unknown -> ()
-  | Known immediates ->
-    if not (K.equal (kind immediates) K.naked_immediate)
-    then
-      Misc.fatal_errorf
-        "Cannot create [immediates] with type that is not of kind \
-         [Naked_immediate]:@ %a"
-        print immediates);
-  Value (TD.create (Variant { immediates; blocks; is_unique }))
+let create_variant ~is_unique ~immediates ~blocks ~extensions =
+  if not (K.equal (kind immediates) K.naked_immediate)
+  then
+    Misc.fatal_errorf
+      "Cannot create [immediates] with type that is not of kind \
+       [Naked_immediate]:@ %a"
+      print immediates;
+  Value (TD.create (Variant { immediates; blocks; extensions; is_unique }))
 
 let mutable_block alloc_mode = Value (TD.create (Mutable_block { alloc_mode }))
 
@@ -3117,7 +3213,8 @@ let tag_immediate t : t =
       (TD.create
          (Variant
             { is_unique = false;
-              immediates = Known t;
+              immediates = t;
+              extensions = No_extensions;
               blocks = Known Row_like_for_blocks.bottom
             }))
   | Value _ | Naked_float _ | Naked_float32 _ | Naked_int32 _ | Naked_int64 _
@@ -3249,8 +3346,8 @@ let create_from_head_region head = Region (TD.create head)
 module Head_of_kind_value = struct
   type t = head_of_kind_value
 
-  let create_variant ~is_unique ~blocks ~immediates =
-    Variant { is_unique; blocks; immediates }
+  let create_variant ~is_unique ~blocks ~immediates ~extensions =
+    Variant { is_unique; blocks; immediates; extensions }
 
   let create_mutable_block alloc_mode = Mutable_block { alloc_mode }
 
@@ -3269,8 +3366,9 @@ module Head_of_kind_value = struct
   let create_tagged_immediate imm : t =
     Variant
       { is_unique = false;
-        immediates = Known (this_naked_immediate imm);
-        blocks = Known Row_like_for_blocks.bottom
+        immediates = this_naked_immediate imm;
+        blocks = Known Row_like_for_blocks.bottom;
+        extensions = No_extensions
       }
 
   let create_closures by_function_slot alloc_mode =
@@ -3368,39 +3466,36 @@ let rec recover_some_aliases t =
           | Boxed_int64 _ | Boxed_vec128 _ | Boxed_nativeint _ | String _
           | Closures _ | Array _ )) ->
       t
-    | Ok (No_alias (Variant { immediates; blocks; is_unique = _ })) -> (
+    | Ok
+        (No_alias
+          (Variant { immediates; blocks; extensions = _; is_unique = _ })) -> (
       match blocks with
       | Unknown -> t
       | Known blocks -> (
         if not (Row_like_for_blocks.is_bottom blocks)
         then t
         else
-          match immediates with
-          | Unknown -> t
-          | Known immediates -> (
-            let t' = recover_some_aliases immediates in
-            match t' with
-            | Naked_immediate ty -> (
-              match TD.descr ty with
-              | Ok (Equals alias) ->
-                Simple.pattern_match' alias
-                  ~var:(fun _ ~coercion:_ -> t)
-                  ~symbol:(fun _ ~coercion:_ -> t)
-                  ~const:(fun const ->
-                    match Reg_width_const.descr const with
-                    | Naked_immediate i -> this_tagged_immediate i
-                    | Tagged_immediate _ | Naked_float _ | Naked_float32 _
-                    | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
-                    | Naked_vec128 _ ->
-                      Misc.fatal_errorf
-                        "Immediates case returned wrong kind of constant:@ %a"
-                        Reg_width_const.print const)
-              | Unknown | Bottom | Ok (No_alias _) -> t)
-            | Value _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
-            | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _
-            | Region _ ->
-              Misc.fatal_errorf "Immediates case returned wrong kind:@ %a" print
-                t' ()))))
+          let t' = recover_some_aliases immediates in
+          match t' with
+          | Naked_immediate ty -> (
+            match TD.descr ty with
+            | Ok (Equals alias) ->
+              Simple.pattern_match' alias
+                ~var:(fun _ ~coercion:_ -> t)
+                ~symbol:(fun _ ~coercion:_ -> t)
+                ~const:(fun const ->
+                  match Reg_width_const.descr const with
+                  | Naked_immediate i -> this_tagged_immediate i
+                  | Tagged_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
+                  | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ ->
+                    Misc.fatal_errorf
+                      "Immediates case returned wrong kind of constant:@ %a"
+                      Reg_width_const.print const)
+            | Unknown | Bottom | Ok (No_alias _) -> t)
+          | Value _ | Naked_float _ | Naked_float32 _ | Naked_int32 _ | Naked_int64 _
+          | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _ ->
+            Misc.fatal_errorf "Immediates case returned wrong kind:@ %a" print
+              t' ())))
   | Naked_immediate ty -> (
     match TD.descr ty with
     | Unknown | Bottom | Ok (Equals _) | Ok (No_alias (Is_int _ | Get_tag _)) ->

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -43,7 +43,7 @@ type t = private
 
 and head_of_kind_value = private
   | Variant of
-      { immediates : t;
+      { immediates : t Or_unknown.t;
         blocks : row_like_for_blocks Or_unknown.t;
         extensions : variant_extensions;
         is_unique : bool
@@ -301,7 +301,7 @@ val get_tag_for_block : block:Simple.t -> t
 
 val create_variant :
   is_unique:bool ->
-  immediates:t ->
+  immediates:t Or_unknown.t ->
   blocks:row_like_for_blocks Or_unknown.t ->
   extensions:variant_extensions ->
   t
@@ -646,7 +646,7 @@ module Head_of_kind_value : sig
   val create_variant :
     is_unique:bool ->
     blocks:Row_like_for_blocks.t Or_unknown.t ->
-    immediates:flambda_type ->
+    immediates:flambda_type Or_unknown.t ->
     extensions:variant_extensions ->
     t
 

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -43,8 +43,9 @@ type t = private
 
 and head_of_kind_value = private
   | Variant of
-      { immediates : t Or_unknown.t;
+      { immediates : t;
         blocks : row_like_for_blocks Or_unknown.t;
+        extensions : variant_extensions;
         is_unique : bool
       }
   (* CR mshinwell: It would be better to track per-field mutability. *)
@@ -148,6 +149,13 @@ and array_contents =
   | Mutable
 
 and env_extension = private { equations : t Name.Map.t } [@@unboxed]
+
+and variant_extensions =
+  | No_extensions
+  | Ext of
+      { when_immediate : env_extension;
+        when_block : env_extension
+      }
 
 type flambda_type = t
 
@@ -293,8 +301,9 @@ val get_tag_for_block : block:Simple.t -> t
 
 val create_variant :
   is_unique:bool ->
-  immediates:t Or_unknown.t ->
+  immediates:t ->
   blocks:row_like_for_blocks Or_unknown.t ->
+  extensions:variant_extensions ->
   t
 
 val mutable_block : Alloc_mode.For_types.t -> t
@@ -637,7 +646,8 @@ module Head_of_kind_value : sig
   val create_variant :
     is_unique:bool ->
     blocks:Row_like_for_blocks.t Or_unknown.t ->
-    immediates:flambda_type Or_unknown.t ->
+    immediates:flambda_type ->
+    extensions:variant_extensions ->
     t
 
   val create_mutable_block : Alloc_mode.For_types.t -> t

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -179,10 +179,15 @@ and meet0 env (t1 : TG.t) (t2 : TG.t) : TG.t * TEE.t =
     | Some simple2 -> (
       match meet_expanded_head env expanded1 expanded2 with
       | Left_head_unchanged ->
+        let ty =
+          if ET.is_bottom expanded1
+          then MTC.bottom kind
+          else TG.alias_type_of kind simple2
+        in
         let env_extension =
           add_equation simple2 (ET.to_type expanded1) TEE.empty
         in
-        TG.alias_type_of kind simple2, env_extension
+        ty, env_extension
       | Right_head_unchanged -> TG.alias_type_of kind simple2, TEE.empty
       | New_head (expanded, env_extension) ->
         (* It makes things easier (to check if the result of [meet] was bottom)
@@ -214,10 +219,15 @@ and meet0 env (t1 : TG.t) (t2 : TG.t) : TG.t * TEE.t =
       match meet_expanded_head env expanded1 expanded2 with
       | Left_head_unchanged -> TG.alias_type_of kind simple1, TEE.empty
       | Right_head_unchanged ->
+        let ty =
+          if ET.is_bottom expanded2
+          then MTC.bottom kind
+          else TG.alias_type_of kind simple1
+        in
         let env_extension =
           add_equation simple1 (ET.to_type expanded2) TEE.empty
         in
-        TG.alias_type_of kind simple1, env_extension
+        ty, env_extension
       | New_head (expanded, env_extension) ->
         let ty =
           if ET.is_bottom expanded

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -532,7 +532,7 @@ let prove_unique_tag_and_size0 env t :
           | None -> Unknown
           | Some (tag, shape, size, product, alloc_mode) ->
             Proved (tag, shape, size, product, alloc_mode))
-    else Unknown)
+      else Unknown)
   | Value (Ok (Mutable_block _)) | Value (Ok _) | Value Unknown | Value Bottom
     ->
     Unknown
@@ -1063,12 +1063,12 @@ let prove_physical_equality env t1 t2 =
               extensions = _;
               is_unique = _
             },
-          ( Mutable_block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _ | Boxed_int64 _
-          | Boxed_vec128 _ | Boxed_nativeint _ | Closures _ | String _ | Array _
-            ) )
-      | ( ( Mutable_block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _ | Boxed_int64 _
-          | Boxed_vec128 _ | Boxed_nativeint _ | Closures _ | String _ | Array _
-            ),
+          ( Mutable_block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _
+          | Boxed_int64 _ | Boxed_vec128 _ | Boxed_nativeint _ | Closures _
+          | String _ | Array _ ) )
+      | ( ( Mutable_block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _
+          | Boxed_int64 _ | Boxed_vec128 _ | Boxed_nativeint _ | Closures _
+          | String _ | Array _ ),
           Variant
             { immediates = _;
               blocks = Known blocks;

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -82,10 +82,13 @@ let prove_equals_to_simple_of_kind env t kind : Simple.t proof_of_property =
 let prove_is_int_generic ~variant_only env t : bool generic_proof =
   match expand_head env t with
   | Value (Ok (Variant blocks_imms)) -> (
-    let imms = blocks_imms.immediates in
-    match blocks_imms.blocks with
-    | Unknown -> if is_bottom env imms then Proved false else Unknown
-    | Known blocks ->
+    match blocks_imms.blocks, blocks_imms.immediates with
+    | Unknown, Unknown -> Unknown
+    | Unknown, Known imms ->
+      if is_bottom env imms then Proved false else Unknown
+    | Known blocks, Unknown ->
+      if TG.Row_like_for_blocks.is_bottom blocks then Proved true else Unknown
+    | Known blocks, Known imms ->
       if TG.Row_like_for_blocks.is_bottom blocks
       then if is_bottom env imms then Invalid else Proved true
       else if is_bottom env imms
@@ -119,18 +122,21 @@ let meet_is_int_variant_only env t =
 let prove_get_tag_generic env t : Tag.Set.t generic_proof =
   match expand_head env t with
   | Value (Ok (Variant blocks_imms)) -> (
-    let imms = blocks_imms.immediates in
-    if not (is_bottom env imms)
-    then Unknown
-    else
-      match blocks_imms.blocks with
-      | Unknown -> Unknown
-      | Known blocks -> (
-        (* CR mshinwell: maybe [all_tags] should return the [Invalid] case
-           directly? *)
-        match TG.Row_like_for_blocks.all_tags blocks with
+    match blocks_imms.immediates with
+    | Unknown -> Unknown
+    | Known imms -> (
+      if not (is_bottom env imms)
+      then Unknown
+      else
+        match blocks_imms.blocks with
         | Unknown -> Unknown
-        | Known tags -> if Tag.Set.is_empty tags then Invalid else Proved tags))
+        | Known blocks -> (
+          (* CR mshinwell: maybe [all_tags] should return the [Invalid] case
+             directly? *)
+          match TG.Row_like_for_blocks.all_tags blocks with
+          | Unknown -> Unknown
+          | Known tags -> if Tag.Set.is_empty tags then Invalid else Proved tags
+          )))
   | Value
       (Ok
         ( Boxed_float _ | Boxed_float32 _ | Boxed_int32 _ | Boxed_int64 _
@@ -191,10 +197,13 @@ let prove_equals_tagged_immediates env t : _ proof_of_property =
     | Known blocks ->
       if TG.Row_like_for_blocks.is_bottom blocks
       then
-        match prove_naked_immediates_generic env immediates with
-        | Proved imms -> Proved imms
-        | Invalid -> Proved Targetint_31_63.Set.empty
+        match immediates with
         | Unknown -> Unknown
+        | Known imms -> (
+          match prove_naked_immediates_generic env imms with
+          | Proved imms -> Proved imms
+          | Invalid -> Proved Targetint_31_63.Set.empty
+          | Unknown -> Unknown)
       else Unknown)
   | Value (Ok _ | Unknown | Bottom) -> Unknown
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
@@ -206,8 +215,10 @@ let meet_equals_tagged_immediates env t : _ meet_shortcut =
   match expand_head env t with
   | Value
       (Ok (Variant { immediates; blocks = _; extensions = _; is_unique = _ }))
-    ->
-    meet_naked_immediates env immediates
+    -> (
+    match immediates with
+    | Unknown -> Need_meet
+    | Known imms -> meet_naked_immediates env imms)
   | Value
       (Ok
         ( Mutable_block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _
@@ -356,11 +367,13 @@ let prove_variant_like_generic env t : variant_like_proof generic_proof =
         | Unknown -> Unknown
         | Known non_const_ctors_with_sizes ->
           let const_ctors : _ Or_unknown.t =
-            let imms = blocks_imms.immediates in
-            match prove_naked_immediates_generic env imms with
+            match blocks_imms.immediates with
             | Unknown -> Unknown
-            | Invalid -> Known Targetint_31_63.Set.empty
-            | Proved const_ctors -> Known const_ctors
+            | Known imms -> (
+              match prove_naked_immediates_generic env imms with
+              | Unknown -> Unknown
+              | Invalid -> Known Targetint_31_63.Set.empty
+              | Proved const_ctors -> Known const_ctors)
           in
           Proved { const_ctors; non_const_ctors_with_sizes })))
   | Value (Ok (Mutable_block _)) -> Unknown
@@ -506,18 +519,20 @@ let prove_unique_tag_and_size0 env t :
     * Alloc_mode.For_types.t)
     proof_of_property =
   match expand_head env t with
-  | Value (Ok (Variant blocks_imms)) ->
-    let immediates = blocks_imms.immediates in
-    if is_bottom env immediates
-    then
-      match blocks_imms.blocks with
-      | Unknown -> Unknown
-      | Known blocks -> (
-        match TG.Row_like_for_blocks.get_singleton blocks with
-        | None -> Unknown
-        | Some (tag, shape, size, product, alloc_mode) ->
-          Proved (tag, shape, size, product, alloc_mode))
-    else Unknown
+  | Value (Ok (Variant blocks_imms)) -> (
+    match blocks_imms.immediates with
+    | Unknown -> Unknown
+    | Known immediates ->
+      if is_bottom env immediates
+      then
+        match blocks_imms.blocks with
+        | Unknown -> Unknown
+        | Known blocks -> (
+          match TG.Row_like_for_blocks.get_singleton blocks with
+          | None -> Unknown
+          | Some (tag, shape, size, product, alloc_mode) ->
+            Proved (tag, shape, size, product, alloc_mode))
+    else Unknown)
   | Value (Ok (Mutable_block _)) | Value (Ok _) | Value Unknown | Value Bottom
     ->
     Unknown
@@ -706,25 +721,27 @@ let[@inline always] inspect_tagging_of_simple proof_kind env ~min_name_mode t :
   | Value (Ok (Variant { immediates; blocks; extensions = _; is_unique = _ }))
     -> (
     let inspect_immediates () =
-      let from_alias =
-        match
-          TE.get_canonical_simple_exn env ~min_name_mode
-            (TG.get_alias_exn immediates)
-        with
-        | simple -> Some simple
-        | exception Not_found -> None
-      in
-      match from_alias with
-      | Some simple -> Proved simple
-      | None -> (
-        match meet_naked_immediates env immediates with
-        | Need_meet -> Unknown
-        | Invalid -> Invalid
-        | Known_result imms -> (
-          match Targetint_31_63.Set.get_singleton imms with
-          | Some imm ->
-            Proved (Simple.const (Reg_width_const.naked_immediate imm))
-          | None -> Unknown))
+      match immediates with
+      | Unknown -> Unknown
+      | Known t -> (
+        let from_alias =
+          match
+            TE.get_canonical_simple_exn env ~min_name_mode (TG.get_alias_exn t)
+          with
+          | simple -> Some simple
+          | exception Not_found -> None
+        in
+        match from_alias with
+        | Some simple -> Proved simple
+        | None -> (
+          match meet_naked_immediates env t with
+          | Need_meet -> Unknown
+          | Invalid -> Invalid
+          | Known_result imms -> (
+            match Targetint_31_63.Set.get_singleton imms with
+            | Some imm ->
+              Proved (Simple.const (Reg_width_const.naked_immediate imm))
+            | None -> Unknown)))
     in
     match proof_kind, blocks with
     | Prove, Unknown -> Unknown
@@ -1076,16 +1093,16 @@ let prove_physical_equality env t1 t2 =
               extensions = _;
               is_unique = _
             } ) -> (
-        match blocks1, blocks2 with
-        | _, Known blocks
-          when TG.is_obviously_bottom immediates1
+        match immediates1, immediates2, blocks1, blocks2 with
+        | Known imms, _, _, Known blocks
+          when TG.is_obviously_bottom imms
                && TG.Row_like_for_blocks.is_bottom blocks ->
           Proved false
-        | Known blocks, _
-          when TG.is_obviously_bottom immediates2
+        | _, Known imms, Known blocks, _
+          when TG.is_obviously_bottom imms
                && TG.Row_like_for_blocks.is_bottom blocks ->
           Proved false
-        | Known blocks1, Known blocks2 -> (
+        | Known imms1, Known imms2, Known blocks1, Known blocks2 -> (
           let immediates_equality : _ generic_proof =
             (* Note: the proof we're returning here has slightly unusual
                semantics. [Invalid] is only returned if neither input can be an
@@ -1096,8 +1113,8 @@ let prove_physical_equality env t1 t2 =
                This is what allows us to combine correctly with the property on
                blocks to return a precise enough result. *)
             match
-              ( prove_naked_immediates_generic env immediates1,
-                prove_naked_immediates_generic env immediates2 )
+              ( prove_naked_immediates_generic env imms1,
+                prove_naked_immediates_generic env imms2 )
             with
             | Invalid, Invalid -> Invalid
             | Invalid, _ | _, Invalid -> Proved false
@@ -1150,7 +1167,7 @@ let prove_physical_equality env t1 t2 =
           | Proved b, Invalid | Invalid, Proved b -> Proved b
           | Proved false, Proved false -> Proved false
           | _, _ -> Unknown)
-        | _, _ -> Unknown)
+        | _, _, _, _ -> Unknown)
       (* Boxed numbers with non-numbers or different kinds -> Proved *)
       | ( Boxed_float _,
           ( Variant _ | Mutable_block _ | Boxed_float32 _ | Boxed_int32 _

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -207,10 +207,11 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
     match
       Expand_head.expand_head env t |> Expand_head.Expanded_type.descr_oub
     with
-    | Value (Ok (Variant { is_unique; blocks; immediates })) -> (
-      match blocks, immediates with
-      | Known blocks, Known imms ->
-        if Expand_head.is_bottom env imms
+    | Value (Ok (Variant { is_unique; blocks; immediates; extensions = _ }))
+      -> (
+      match blocks with
+      | Known blocks ->
+        if Expand_head.is_bottom env immediates
         then
           match TG.Row_like_for_blocks.get_singleton blocks with
           | None ->
@@ -255,7 +256,7 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
               | None -> try_canonical_simple ()))
         else if TG.Row_like_for_blocks.is_bottom blocks
         then
-          match Provers.meet_naked_immediates env imms with
+          match Provers.meet_naked_immediates env immediates with
           | Known_result imms -> (
             match Targetint_31_63.Set.get_singleton imms with
             | None -> try_canonical_simple ()
@@ -264,8 +265,7 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
           | Need_meet -> try_canonical_simple ()
           | Invalid -> Invalid
         else try_canonical_simple ()
-      | Known _, Unknown | Unknown, Known _ | Unknown, Unknown ->
-        try_canonical_simple ())
+      | Unknown -> try_canonical_simple ())
     | Value (Ok (Mutable_block _)) -> try_canonical_simple ()
     | Value (Ok (Closures { by_function_slot = _; alloc_mode = _ })) ->
       try_canonical_simple ()

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -209,9 +209,9 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
     with
     | Value (Ok (Variant { is_unique; blocks; immediates; extensions = _ }))
       -> (
-      match blocks with
-      | Known blocks ->
-        if Expand_head.is_bottom env immediates
+      match blocks, immediates with
+      | Known blocks, Known imms ->
+        if Expand_head.is_bottom env imms
         then
           match TG.Row_like_for_blocks.get_singleton blocks with
           | None ->
@@ -256,7 +256,7 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
               | None -> try_canonical_simple ()))
         else if TG.Row_like_for_blocks.is_bottom blocks
         then
-          match Provers.meet_naked_immediates env immediates with
+          match Provers.meet_naked_immediates env imms with
           | Known_result imms -> (
             match Targetint_31_63.Set.get_singleton imms with
             | None -> try_canonical_simple ()
@@ -265,7 +265,8 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
           | Need_meet -> try_canonical_simple ()
           | Invalid -> Invalid
         else try_canonical_simple ()
-      | Unknown -> try_canonical_simple ())
+      | Known _, Unknown | Unknown, Known _ | Unknown, Unknown ->
+        try_canonical_simple ())
     | Value (Ok (Mutable_block _)) -> try_canonical_simple ()
     | Value (Ok (Closures { by_function_slot = _; alloc_mode = _ })) ->
       try_canonical_simple ()


### PR DESCRIPTION
Based on #406.
This PR fixes a hole in variant unboxing, which would work as long as there was at least two non-constant constructors (in which case the row-like structure would contain the extension) but fail in the single non-constant constructor case because row-like would not store the extension.

It allows us to remove all allocations in the following code:
```ocaml
module Seq = struct

  type _ t = State : ('s * ('s -> ('a * 's) option)) -> 'a t

  let rec fold_left f acc (State (s, next)) =
    match next s with
    | None -> acc
    | Some (x, s') -> fold_left f (f acc x) (State (s', next))

  let rec map f (State (s, next)) =
    State (s, fun s -> match next s with
        | None -> None | Some (x, s') -> Some (f x, s'))

  let rec unfold f acc =
    State (acc, f)

end

let square x = x * x

let ints lo hi =
  Seq.unfold (fun i -> if i > hi then None else Some (i, i + 1)) lo

let[@inline] sum s =
  Seq.fold_left (+) 0 s

let foo () =
  sum (Seq.map square (ints 0 11))
```
The resulting code is still not optimal, as there remain a number of intermediate branches in the loop, but these branches would be trivially removed once we introduce match-in-match optimisations.

@Gbury and I will be also trying to find good examples to add to the flexpect tests to verify that we don't introduce regressions in the future.