### PR TITLE
Split long strings when emitting assembly

### DIFF
--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -97,10 +97,10 @@ let windows =
   | S_mingw64 | S_cygwin | S_win64 -> true
   | _ -> false
 
-let string_of_string_literal s =
-  let b = Buffer.create (String.length s + 2) in
+let string_of_substring_literal k n s =
+  let b = Buffer.create (n + 2) in
   let last_was_escape = ref false in
-  for i = 0 to String.length s - 1 do
+  for i = k to k + n - 1 do
     let c = s.[i] in
     if c >= '0' && c <= '9' then
       if !last_was_escape
@@ -115,6 +115,9 @@ let string_of_string_literal s =
     end
   done;
   Buffer.contents b
+
+let string_of_string_literal s =
+  string_of_substring_literal 0 (String.length s) s
 
 let string_of_symbol prefix s =
   let spec = ref false in

--- a/backend/x86_proc.mli
+++ b/backend/x86_proc.mli
@@ -26,6 +26,7 @@ val string_of_reg16: reg64 -> string
 val string_of_reg32: reg64 -> string
 val string_of_reg64: reg64 -> string
 val string_of_registerf: registerf -> string
+val string_of_substring_literal: int -> int -> string -> string
 val string_of_string_literal: string -> string
 val string_of_condition: condition -> string
 val string_of_float_condition: float_condition -> string


### PR DESCRIPTION
It turns out that gas can be extremely slow with very long (multi-MB) lines and some of our generated source code actually runs into this. Let's split up long string literals to avoid this. See comments in code for details.