### PR TITLE
Remove check for probe code symbols being global

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -119,15 +119,6 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         res,
         Ece.all )
     | Some name ->
-      (* To be on the safe side, insist that code symbols for probes are
-         global. *)
-      (match code_sym.sym_global with
-      | Global -> ()
-      | Local ->
-        Misc.fatal_errorf
-          "Code symbol %s for code ID %a, being used to call a probe, is not \
-           global"
-          code_sym.sym_name Code_id.print code_id);
       ( C.probe ~dbg ~name ~handler_code_linkage_name:code_sym.sym_name ~args
         |> C.return_unit dbg,
         free_vars,


### PR DESCRIPTION
This check is going off and blocking a lot of testing.  Having thought about this some more, I'm unsure it matters if the code symbol is actually local here, since it's the location of the probe itself which is e.g. referenced in the ELF notes.