### PR TITLE
Make -O2 the default for Flambda 2

### DIFF
--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -350,3 +350,6 @@ let set_o3 () =
 
 let opt_flag_handler : Clflags.Opt_flag_handler.t =
   { set_oclassic; set_o2; set_o3 }
+
+let () =
+  if Clflags.is_flambda2 () then set_o2 ()


### PR DESCRIPTION
This will avoid the current situation where the default is a weird in-between state, which uses Simplify, but without doing very much inlining etc.

This should also make the compiler faster, one hopes.