### PR TITLE
Merge ocaml-jst 2023-04-28 (includes Lexclave implementation for flambda2)

### DIFF
--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -216,7 +216,7 @@ let rec expr_size env = function
       | _ -> assert false)
   | Uregion exp ->
       expr_size env exp
-  | Utail exp ->
+  | Uexclave exp ->
       expr_size env exp
   | _ -> RHS_nonrec
 
@@ -805,7 +805,7 @@ let rec transl env e =
       Cop(Cload (Word_int, Mutable), [Cconst_int (0, dbg)], dbg)
   | Uregion e ->
       region (transl env e)
-  | Utail e ->
+  | Uexclave e ->
       Ctail (transl env e)
 
 and transl_catch (kind : Cmm.kind_for_unboxing) env nfail ids body handler dbg =

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -97,7 +97,7 @@ and ulambda =
       * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
-  | Utail of ulambda
+  | Uexclave of ulambda
 
 and ufunction = {
   label  : function_label;

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -108,7 +108,7 @@ and ulambda =
       * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
-  | Utail of ulambda
+  | Uexclave of ulambda
 
 and ufunction = {
   label  : function_label;

--- a/middle_end/flambda/build_export_info.ml
+++ b/middle_end/flambda/build_export_info.ml
@@ -260,7 +260,7 @@ let rec approx_of_expr (env : Env.t) (flam : Flambda.t) : Export_info.approx =
     end
   | Region body ->
     approx_of_expr env body
-  | Tail body ->
+  | Exclave body ->
     approx_of_expr env body
   | Assign _ -> Value_id (Env.new_unit_descr env)
   | For _ -> Value_id (Env.new_unit_descr env)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -583,6 +583,8 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
         [Simplif.simplify_lets]"
   | Lregion (body, _) ->
     Region (close t env body)
+  | Lexclave body ->
+    Exclave (close t env body)
 
 (** Perform closure conversion on a set of function declarations, returning a
     set of closures.  (The set will often only contain a single function;

--- a/middle_end/flambda/effect_analysis.ml
+++ b/middle_end/flambda/effect_analysis.ml
@@ -47,7 +47,7 @@ let rec no_effects (flam : Flambda.t) =
     no_effects body
   | Region body ->
     no_effects body
-  | Tail body ->
+  | Exclave body ->
     no_effects body
   | While _ | For _ | Apply _ | Send _ | Assign _ | Static_raise _ -> false
   | Proved_unreachable -> true

--- a/middle_end/flambda/extract_projections.ml
+++ b/middle_end/flambda/extract_projections.ml
@@ -107,7 +107,7 @@ let rec analyse_expr ~which_variables expr =
       check_free_variable from_value;
       check_free_variable to_value
     | Let _ | Let_rec _ | Static_catch _ | While _ | Try_with _
-    | Region _ | Tail _
+    | Region _ | Exclave _
     | Proved_unreachable -> ()
   in
   let for_named (named : Flambda.named) =

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -82,7 +82,7 @@ type t =
   | While of t * t
   | For of for_loop
   | Region of t
-  | Tail of t
+  | Exclave of t
   | Proved_unreachable
 
 and named =
@@ -361,8 +361,8 @@ let rec lam ppf (flam : t) =
       Variable.print to_value lam body
   | Region body ->
     fprintf ppf "@[<2>(region@ %a)@]" lam body
-  | Tail body ->
-    fprintf ppf "@[<2>(tail@ %a)@]" lam body
+  | Exclave body ->
+    fprintf ppf "@[<2>(exclave@ %a)@]" lam body
 
 and print_named ppf (named : named) =
   match named with
@@ -637,7 +637,7 @@ let rec variables_usage ?ignore_uses_as_callee ?ignore_uses_as_argument
         List.iter free_variable args;
       | Region body ->
         aux body
-      | Tail body ->
+      | Exclave body ->
         aux body
       | Proved_unreachable -> ()
     in
@@ -838,7 +838,7 @@ let iter_general ~toplevel f f_named maybe_named =
         Option.iter aux def
       | Region body ->
         aux body
-      | Tail body ->
+      | Exclave body ->
         aux body
   and aux_named (named : named) =
     f_named named;

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -118,7 +118,7 @@ type t =
   | While of t * t
   | For of for_loop
   | Region of t
-  | Tail of t
+  | Exclave of t
   | Proved_unreachable
 
 (** Values of type [named] will always be [let]-bound to a [Variable.t]. *)

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -242,7 +242,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       loop env e2
     | Region e ->
       loop env e
-    | Tail e ->
+    | Exclave e ->
       loop env e
     | Proved_unreachable -> ()
   and loop_named env (named : Flambda.named) =

--- a/middle_end/flambda/flambda_iterators.ml
+++ b/middle_end/flambda/flambda_iterators.ml
@@ -46,7 +46,7 @@ let apply_on_subexpressions f f_named (flam : Flambda.t) =
     f f1; f f2
   | For { body; _ } -> f body
   | Region body -> f body
-  | Tail body -> f body
+  | Exclave body -> f body
 
 let rec list_map_sharing f l =
   match l with
@@ -167,12 +167,12 @@ let map_subexpressions f f_named (tree:Flambda.t) : Flambda.t =
       tree
     else
       Region new_body
-  | Tail body ->
+  | Exclave body ->
     let new_body = f body in
     if new_body == body then
       tree
     else
-      Tail new_body
+      Exclave new_body
 
 let iter_general = Flambda.iter_general
 
@@ -404,12 +404,12 @@ let map_general ~toplevel f f_named tree =
             tree
           else
             Region new_body
-        | Tail body ->
+        | Exclave body ->
           let new_body = aux body in
           if new_body == body then
             tree
           else
-            Tail new_body
+            Exclave new_body
       in
       f exp
   and aux_done_something expr done_something =

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -439,7 +439,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
       in
       if is_trivial then body, body_layout
       else Uregion body, body_layout
-  | Tail body ->
+  | Exclave body ->
       let body, body_layout = to_clambda t env body in
       let is_trivial =
         match body with
@@ -447,7 +447,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
         | _ -> false
       in
       if is_trivial then body, body_layout
-      else Utail body, body_layout
+      else Uexclave body, body_layout
   | Proved_unreachable -> Uunreachable, Lambda.layout_bottom
 
 and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda * Lambda.layout =

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -78,7 +78,7 @@ let description_of_toplevel_node (expr : Flambda.t) =
   | While _ -> "while"
   | For _ -> "for"
   | Region _ -> "region"
-  | Tail _ -> "tail"
+  | Exclave _ -> "exclave"
 
 let equal_direction_flag
       (x : Asttypes.direction_flag)
@@ -161,9 +161,9 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
   | Region body1, Region body2 ->
     same body1 body2
   | Region _, _ | _, Region _ -> false
-  | Tail body1, Tail body2 ->
+  | Exclave body1, Exclave body2 ->
     same body1 body2
-  | Tail _, _ | _, Tail _ -> false
+  | Exclave _, _ | _, Exclave _ -> false
   | Assign { being_assigned = being_assigned1; new_value = new_value1; },
     Assign { being_assigned = being_assigned2; new_value = new_value2; } ->
     Mutable_variable.equal being_assigned1 being_assigned2
@@ -291,7 +291,7 @@ let toplevel_substitution sb tree =
     | Static_raise (static_exn, args) ->
       let args = List.map sb args in
       Static_raise (static_exn, args)
-    | Static_catch _ | Try_with _ | While _ | Region _ | Tail _
+    | Static_catch _ | Try_with _ | While _ | Region _ | Exclave _
     | Let _ | Let_rec _ | Proved_unreachable -> flam
   in
   let aux_named (named : Flambda.named) : Flambda.named =
@@ -740,7 +740,7 @@ let substitute_read_symbol_field_for_variables
       Flambda.Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout }
     | Proved_unreachable
     | Region _
-    | Tail _
+    | Exclave _
     | While _
     | Try_with _
     | Static_catch _ ->

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -300,7 +300,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
     | Region body ->
       mark_curr curr;
       mark_loop ~toplevel [] body
-    | Tail body ->
+    | Exclave body ->
       mark_curr curr;
       mark_loop ~toplevel [] body
     | Proved_unreachable ->

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -939,7 +939,7 @@ and simplify_over_application env r ~args ~args_approxs ~function_decls
   in
   let expr =
     match reg_close with
-    | Lambda.Rc_close_at_apply -> Flambda.Tail expr
+    | Lambda.Rc_close_at_apply -> Flambda.Exclave expr
     | Lambda.Rc_normal | Lambda.Rc_nontail-> expr
   in
   simplify (E.set_never_inline env) r expr
@@ -1462,10 +1462,10 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
      let r = R.set_region_use r use_outer_region in
      if use_inner_region then Region body, r
      else body, r
-  | Tail body ->
+  | Exclave body ->
      let r = R.set_region_use r true in
      let body, r = simplify env r body in
-     Tail body, r
+     Exclave body, r
   | Proved_unreachable -> tree, ret r A.value_bottom
 
 and simplify_list env r l =

--- a/middle_end/flambda/inlining_cost.ml
+++ b/middle_end/flambda/inlining_cost.ml
@@ -123,7 +123,7 @@ let lambda_smaller' lam ~than:threshold =
       size := !size + 4; lambda_size body
     | Region body ->
       size := !size + 2; lambda_size body
-    | Tail body ->
+    | Exclave body ->
       lambda_size body
   and lambda_named_size (named : Flambda.named) =
     if !size > threshold then raise Exit;
@@ -276,7 +276,7 @@ module Benefit = struct
     | If_then_else _ | While _ | For _ -> b := remove_branch !b
     | Apply _ | Send _ -> b := remove_call !b
     | Let _ | Let_mutable _ | Let_rec _ | Proved_unreachable | Var _
-    | Region _ | Tail _ | Static_catch _ -> ()
+    | Region _ | Exclave _ | Static_catch _ -> ()
 
   let remove_code_helper_named b (named : Flambda.named) =
     match named with

--- a/middle_end/flambda/inlining_transforms.ml
+++ b/middle_end/flambda/inlining_transforms.ml
@@ -133,7 +133,7 @@ let inline_by_copying_function_body ~env ~r
   in
   let body =
     match reg_close with
-    | Lambda.Rc_close_at_apply -> Flambda.Tail body
+    | Lambda.Rc_close_at_apply -> Flambda.Exclave body
     | Lambda.Rc_normal | Lambda.Rc_nontail -> body
   in
   let bindings_for_params_to_args =

--- a/middle_end/flambda/ref_to_variables.ml
+++ b/middle_end/flambda/ref_to_variables.ml
@@ -82,7 +82,7 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
       set := Variable.Set.union (Variable.Set.of_list args) !set
     | Region body ->
       loop body
-    | Tail body ->
+    | Exclave body ->
       loop body
     | Proved_unreachable | Apply _ | Send _ | Assign _ ->
       set := Variable.Set.union !set (Flambda.free_variables flam)
@@ -155,7 +155,7 @@ let eliminate_ref_of_expr flam =
       | Let_rec _ | Switch _ | String_switch _
       | Static_raise _ | Static_catch _
       | Try_with _ | If_then_else _
-      | While _ | For _ | Region _ | Tail _ | Send _ | Proved_unreachable ->
+      | While _ | For _ | Region _ | Exclave _ | Send _ | Proved_unreachable ->
         flam
     and aux_named (named : Flambda.named) : Flambda.named =
       match named with

--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -247,7 +247,7 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
       ()
     | Uregion e ->
       loop ~depth e
-    | Utail e ->
+    | Uexclave e ->
       loop ~depth e
   in
   loop ~depth:0 clam;
@@ -482,7 +482,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
     | Uregion e ->
       let_stack := [];
       loop e
-    | Utail e ->
+    | Uexclave e ->
       let_stack := [];
       loop e
   in
@@ -635,9 +635,9 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
   | Uregion e ->
     let e = substitute_let_moveable is_let_moveable env e in
     Uregion (e)
-  | Utail e ->
+  | Uexclave e ->
     let e = substitute_let_moveable is_let_moveable env e in
-    Utail (e)
+    Uexclave (e)
 
 and substitute_let_moveable_list is_let_moveable env clams =
   List.map (substitute_let_moveable is_let_moveable env) clams
@@ -864,9 +864,9 @@ let rec un_anf_and_moveable var_info env (clam : Clambda.ulambda)
   | Uregion e ->
     let e = un_anf var_info env e in
     Uregion e, Fixed
-  | Utail e ->
+  | Uexclave e ->
     let e = un_anf var_info env e in
-    Utail e, Fixed
+    Uexclave e, Fixed
 
 and un_anf var_info env clam : Clambda.ulambda =
   let clam, _moveable = un_anf_and_moveable var_info env clam in

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -532,6 +532,10 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
   | Lregion (body, _) ->
     let letrec = prepare_letrec recursive_set current_let body letrec in
     { letrec with needs_region = true }
+  | Lexclave _ ->
+    Misc.fatal_errorf
+      "Cannot yet handle Lexclave directly under let rec with Flambda 2:@ %a"
+      Printlambda.lambda lam
   [@@ocaml.warning "-fragile-match"]
 
 let dissect_letrec ~bindings ~body =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1395,9 +1395,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
   | Lsequence (lam1, lam2) ->
     let k acc env ccenv _value = cps acc env ccenv lam2 k k_exn in
     cps_non_tail_simple acc env ccenv lam1 k k_exn
-  | Lwhile
-      { wh_cond = cond; wh_body = body; wh_cond_region = _; wh_body_region = _ }
-    ->
+  | Lwhile { wh_cond = cond; wh_body = body } ->
     (* CR-someday mshinwell: make use of wh_cond_region / wh_body_region? *)
     let env, loop = rec_catch_for_while_loop env cond body in
     cps acc env ccenv loop k k_exn
@@ -1406,8 +1404,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         for_from = start;
         for_to = stop;
         for_dir = dir;
-        for_body = body;
-        for_region = _
+        for_body = body
       } ->
     let env, loop = rec_catch_for_for_loop env ident start stop dir body in
     cps acc env ccenv loop k k_exn

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -290,8 +290,8 @@ and lam ppf = function
       fprintf ppf "unreachable"
   | Uregion e ->
       fprintf ppf "@[<2>(region@ %a)@]" lam e
-  | Utail e ->
-      fprintf ppf "@[<2>(tail@ %a)@]" lam e
+  | Uexclave e ->
+      fprintf ppf "@[<2>(exclave@ %a)@]" lam e
 
 and sequence ppf ulam = match ulam with
   | Usequence(l1, l2) ->

--- a/ocaml/.github/workflows/build.yml
+++ b/ocaml/.github/workflows/build.yml
@@ -21,13 +21,6 @@ jobs:
             use_runtime: d
             ocamlrunparam: "v=0,V=1"
 
-          - name: i386
-            config: --enable-stack-allocation=no CC='cc32' AS='as --32' ASPP='gcc -m32 -c' -host i386-linux PARTIALLD='ld -r -melf_i386'
-            os: ubuntu-20.04
-            ocamlparam: ''
-            boot_config: CC='cc32' AS='as --32' ASPP='gcc -m32 -c' -host i386-linux PARTIALLD='ld -r -melf_i386'
-            boot_cachekey: 32bit
-
     env:
       J: "3"
 
@@ -35,11 +28,6 @@ jobs:
     - name: Install GNU parallel
       if: matrix.os == 'macos-latest'
       run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install parallel
-
-    - name: Install GCC 32-bit libraries
-      if: matrix.name == 'i386'
-      run: |
-        sudo apt-get install gcc-multilib gfortran-multilib
 
     - name: Checkout the ocaml-jst repo
       uses: actions/checkout@master
@@ -60,13 +48,6 @@ jobs:
         repository: 'ocaml/ocaml'
         path: 'ocaml-414'
         ref: '4.14'
-
-    - name: Setup 32-bit C compiler
-      if: matrix.name == 'i386' && steps.cache.outputs.cache-hit != 'true'
-      run: |
-        mkdir -p ocaml-414/_install/bin
-        { echo '#!/bin/sh'; echo 'exec gcc -m32 "$@"'; } > ocaml-414/_install/bin/cc32
-        chmod +x ocaml-414/_install/bin/cc32
 
     - name: Build OCaml 4.14
       if: steps.cache.outputs.cache-hit != 'true'

--- a/ocaml/asmcomp/afl_instrument.ml
+++ b/ocaml/asmcomp/afl_instrument.ml
@@ -88,7 +88,7 @@ and instrument = function
      Ccatch (isrec, cases, instrument body, kind)
   | Cexit (ex, args) -> Cexit (ex, List.map instrument args)
   | Cregion e -> Cregion (instrument e)
-  | Ctail e -> Ctail (instrument e)
+  | Cexclave e -> Cexclave (instrument e)
 
   (* these are base cases and have no logging *)
   | Cconst_int _ | Cconst_natint _ | Cconst_float _

--- a/ocaml/asmcomp/cmm.ml
+++ b/ocaml/asmcomp/cmm.ml
@@ -206,7 +206,7 @@ type expression =
   | Ctrywith of expression * Backend_var.With_provenance.t * expression
       * Debuginfo.t * kind_for_unboxing
   | Cregion of expression
-  | Ctail of expression
+  | Cexclave of expression
 
 type codegen_option =
   | Reduce_code_size
@@ -270,7 +270,7 @@ let iter_shallow_tail f = function
   | Cexit _ | Cop (Craise _, _, _) ->
       true
   | Cregion _
-  | Ctail _
+  | Cexclave _
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float _
@@ -312,7 +312,7 @@ let map_shallow_tail ?kind f = function
   | Cexit _ | Cop (Craise _, _, _) as cmm ->
       cmm
   | Cregion _
-  | Ctail _
+  | Cexclave _
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float _
@@ -325,7 +325,7 @@ let map_shallow_tail ?kind f = function
 let map_tail ?kind f =
   let rec loop = function
     | Cregion _
-    | Ctail _
+    | Cexclave _
     | Cconst_int _
     | Cconst_natint _
     | Cconst_float _
@@ -367,7 +367,7 @@ let iter_shallow f = function
       f e1; f e2
   | Cregion e ->
       f e
-  | Ctail e ->
+  | Cexclave e ->
       f e
   | Cconst_int _
   | Cconst_natint _
@@ -404,8 +404,8 @@ let map_shallow f = function
       Ctrywith (f e1, id, f e2, dbg, value_kind)
   | Cregion e ->
       Cregion (f e)
-  | Ctail e ->
-      Ctail (f e)
+  | Cexclave e ->
+      Cexclave (f e)
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float _

--- a/ocaml/asmcomp/cmm.mli
+++ b/ocaml/asmcomp/cmm.mli
@@ -210,7 +210,7 @@ type expression =
   | Ctrywith of expression * Backend_var.With_provenance.t * expression
       * Debuginfo.t * kind_for_unboxing
   | Cregion of expression
-  | Ctail of expression
+  | Cexclave of expression
 
 type codegen_option =
   | Reduce_code_size

--- a/ocaml/asmcomp/cmm_invariants.ml
+++ b/ocaml/asmcomp/cmm_invariants.ml
@@ -174,7 +174,7 @@ let rec check env (expr : Cmm.expression) =
     check env body;
     check env handler
   | Cregion e -> check env e
-  | Ctail e -> check env e
+  | Cexclave e -> check env e
 
 let run ppf (fundecl : Cmm.fundecl) =
   let env = Env.init () in

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -190,7 +190,7 @@ let rec expr_size env = function
       | _ -> assert false)
   | Uregion exp ->
       expr_size env exp
-  | Utail exp ->
+  | Uexclave exp ->
       expr_size env exp
   | _ -> RHS_nonrec
 
@@ -368,7 +368,7 @@ let is_unboxed_number_cmm ~strict cmm =
         | _ ->
             notify No_unboxing
         end
-    | Cregion e | Ctail e ->
+    | Cregion e ->
         aux e
     | l ->
         if not (Cmm.iter_shallow_tail aux l) then
@@ -748,8 +748,8 @@ let rec transl env e =
       Cop(Cload (Word_int, Mutable), [Cconst_int (0, dbg)], dbg)
   | Uregion e ->
       region (transl env e)
-  | Utail e ->
-      Ctail (transl env e)
+  | Uexclave e ->
+      Cexclave (transl env e)
 
 and transl_catch (kind : Cmm.kind_for_unboxing) env nfail ids body handler dbg =
   let ids = List.map (fun (id, kind) -> (id, kind, ref No_result)) ids in

--- a/ocaml/asmcomp/printcmm.ml
+++ b/ocaml/asmcomp/printcmm.ml
@@ -272,8 +272,8 @@ let rec expr ppf = function
              sequence e1 VP.print id sequence e2
   | Cregion e ->
       fprintf ppf "@[<2>(region@ %a)@]" sequence e
-  | Ctail e ->
-      fprintf ppf "@[<2>(tail@ %a)@]" sequence e
+  | Cexclave e ->
+      fprintf ppf "@[<2>(exclave@ %a)@]" sequence e
 
 and sequence ppf = function
   | Csequence(e1, e2) -> fprintf ppf "%a@ %a" sequence e1 sequence e2

--- a/ocaml/asmcomp/selectgen.ml
+++ b/ocaml/asmcomp/selectgen.ml
@@ -388,7 +388,7 @@ method is_simple_expr = function
       | Ccmpf _ -> List.for_all self#is_simple_expr args
       end
   | Cassign _ | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _
-  | Ctrywith _ | Cregion _ | Ctail _ -> false
+  | Ctrywith _ | Cregion _ | Cexclave _ -> false
 
 (* Analyses the effects and coeffects of an expression.  This is used across
    a whole list of expressions with a view to determining which expressions
@@ -435,7 +435,7 @@ method effects_of exp =
     in
     EC.join from_op (EC.join_list_map args self#effects_of)
   | Cassign _ | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _
-  | Cregion _ | Ctail _ ->
+  | Cregion _ | Cexclave _ ->
     EC.arbitrary
 
 (* Says whether an integer constant is a suitable immediate argument for
@@ -974,9 +974,9 @@ method emit_expr_aux (env:environment) exp :
         assert (List.length unclosed <= List.length old_regions);
         Some (rd, unclosed)
      end
-  | Ctail e ->
+  | Cexclave e ->
      begin match env.regions with
-     | [] -> Misc.fatal_error "Selectgen.emit_expr: Ctail but not in tail of a region"
+     | [] -> Misc.fatal_error "Selectgen.emit_expr: Cexclave but not in tail of a region"
      | cl :: rest ->
        self#insert_endregions env [cl];
        self#emit_expr_aux { env with regions = rest } e
@@ -1320,9 +1320,9 @@ method emit_tail (env:environment) exp =
       let reg = self#regs_for typ_int in
       self#insert env (Iop Ibeginregion) [| |] reg;
       self#emit_tail {env with regions = reg::env.regions} e
-  | Ctail e ->
+  | Cexclave e ->
       begin match env.regions with
-      | [] -> Misc.fatal_error "Selectgen.emit_tail: Ctail not inside Cregion"
+      | [] -> Misc.fatal_error "Selectgen.emit_tail: Cexclave not inside Cregion"
       | reg :: regions ->
          self#insert_endregions env [reg];
          self#emit_tail { env with regions } e

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -1029,6 +1029,8 @@ let rec comp_expr env exp sz cont =
       comp_expr env exp sz cont
   | Lregion (exp, _) ->
       comp_expr env exp sz cont
+  | Lexclave exp ->
+      comp_expr env exp sz cont
 
 (* Compile a list of arguments [e1; ...; eN] to a primitive operation.
    The values of eN ... e2 are pushed on the stack, e2 at top of stack,

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -966,6 +966,9 @@ let mk_afl_inst_ratio f =
   \     (advanced, see afl-fuzz docs for AFL_INST_RATIO)"
 ;;
 
+let mk_alloc_check f =
+  "-zero-alloc-check", Arg.Unit f, "<ignored>"
+
 let mk__ f =
   "-", Arg.String f,
   "<file>  Treat <file> as a file name (even if it starts with `-')"
@@ -1201,6 +1204,7 @@ module type Optcomp_options = sig
   val _save_ir_after : string -> unit
   val _probes : unit -> unit
   val _no_probes : unit -> unit
+  val _alloc_check : unit -> unit
 end;;
 
 module type Opttop_options = sig
@@ -1578,6 +1582,7 @@ struct
     mk_dump_into_file F._dump_into_file;
     mk_dump_dir F._dump_dir;
     mk_dump_pass F._dump_pass;
+    mk_alloc_check F._alloc_check;
 
     mk_args F._args;
     mk_args0 F._args0;
@@ -2069,6 +2074,7 @@ module Default = struct
     let _v () = Compenv.print_version_and_library "native-code compiler"
     let _no_probes = clear probes
     let _probes = set probes
+    let _alloc_check () = ()
   end
 
   module Odoc_args = struct

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -966,9 +966,6 @@ let mk_afl_inst_ratio f =
   \     (advanced, see afl-fuzz docs for AFL_INST_RATIO)"
 ;;
 
-let mk_alloc_check f =
-  "-zero-alloc-check", Arg.Unit f, "<ignored>"
-
 let mk__ f =
   "-", Arg.String f,
   "<file>  Treat <file> as a file name (even if it starts with `-')"
@@ -1204,7 +1201,6 @@ module type Optcomp_options = sig
   val _save_ir_after : string -> unit
   val _probes : unit -> unit
   val _no_probes : unit -> unit
-  val _alloc_check : unit -> unit
 end;;
 
 module type Opttop_options = sig
@@ -1582,7 +1578,6 @@ struct
     mk_dump_into_file F._dump_into_file;
     mk_dump_dir F._dump_dir;
     mk_dump_pass F._dump_pass;
-    mk_alloc_check F._alloc_check;
 
     mk_args F._args;
     mk_args0 F._args0;
@@ -2074,7 +2069,6 @@ module Default = struct
     let _v () = Compenv.print_version_and_library "native-code compiler"
     let _no_probes = clear probes
     let _probes = set probes
-    let _alloc_check () = ()
   end
 
   module Odoc_args = struct

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -246,7 +246,6 @@ module type Optcomp_options = sig
   val _save_ir_after : string -> unit
   val _probes : unit -> unit
   val _no_probes : unit -> unit
-  val _alloc_check : unit -> unit
 end;;
 
 module type Opttop_options = sig

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -246,6 +246,7 @@ module type Optcomp_options = sig
   val _save_ir_after : string -> unit
   val _probes : unit -> unit
   val _no_probes : unit -> unit
+  val _alloc_check : unit -> unit
 end;;
 
 module type Opttop_options = sig

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -25,7 +25,7 @@
    ;; CR gyorsh: it is not clear what the ":standard" flags are, and they
    ;; may change depending on the version of dune.
    ;; Consider hard-coded flags, such as -O3.
-   (:standard -zero-alloc-check -caml-apply-inline-fast-path)))
+   (:standard -zero-alloc-check)))
  (boot
   (flags
    (:standard -warn-error +A))))
@@ -150,7 +150,7 @@
  (action
  (no-infer
   (progn
-   (chdir yacc (run make -sj8 OCAMLYACC_INCLUDE_PATH=%{ocaml_where}))
+   (chdir yacc (run make -s OCAMLYACC_INCLUDE_PATH=%{ocaml_where}))
    (copy yacc/ocamlyacc ocamlyacc)))))
 
 (install

--- a/ocaml/jane/doc/local-reference.md
+++ b/ocaml/jane/doc/local-reference.md
@@ -441,7 +441,103 @@ function is a local-returning function, then the nearest enclosing region will
 be the caller's (or that of the caller's caller, etc., if the caller is also
 local-returning).
 
+## Exclave
+In the previous section, we discussed that a function can return local values
+without having its own region. Consequently, it operates within the caller's
+region. This approach, however, has certain disadvantages. Consider the
+following example:
 
+```
+let f (local_ x) = local_
+  let local_ y = (complex computation on x) in
+  if y then local_ None
+  else local_ (Some x)
+```
+
+The function `f` allocates memory within the caller's region to store
+intermediate and temporary data for the complex computation. This allocation
+remains in the region even after `f` returns and is released only when the
+program exits the caller's region. To allow temporary allocations to be released
+upon the function's return, we can rewrite the example as follows:
+
+
+```
+let f (local_ x) =
+  let local_ y = (complex computation on x) in
+  if y then [%exclave] (local_ None)
+  else [%exclave] (local_ (Some x))
+```
+
+The new primitive `[%exclave]` terminates the current region early and executes
+the subsequent code in the outer region. In this example, the function `f`
+retains its own region where the allocation for the complex computation occurs.
+This region is terminated by `[%exclave]`, releasing all temporary allocations.
+Both `local_ None` and `local_ (Some x)` are considered "local" relative to the
+outer region and are allowed to escape. In summary, we have temporary
+allocations on the stack that are promptly released and result allocations on
+the stack that can escape.
+
+
+Here is another example in which the stack usage can be improved asymptotically
+by applying `[%exclave]`:
+
+
+```
+let rec maybe_length p l = local_
+  match l with
+  | [] -> Ok { res = 0 }
+  | x :: xs ->
+      match p x with
+      | false -> None
+      | true ->
+          match count_result f xs with
+          | None as r -> r
+          | Some { res = count } ->
+              Some { res = count + 1 }
+```
+
+The function is intended to have the type:
+
+```
+val maybe_length : ('a -> bool) -> 'a list -> local_ int option
+```
+
+This function computes the length of the list. The predicate can return `false`,
+in which case the result of the entire function would be `None`. It is designed
+not to allocate heap memory, instead using the stack for all `Some` allocations.
+However, it will currently use O(N) stack space because all allocations occur in
+the original caller's stack frame. To improve its space usage, we remove the
+`local_` annotation (so the function has its own region), and wrap `Some {res =
+count + 1}` inside `[%exclave]` to release the region before the allocation.
+After the revision, the function should use O(1) stack space.
+
+
+`[%exclave]` terminates the current region, so local values from that region
+cannot be used inside `[%exclave]`. For example, the following code produces an
+error because `x` would escape its region:
+
+
+```
+  let local_ x = "hello" in
+  [%exclave] (
+    let local_ y = "world" in
+    local_ (x ^ y)
+  )
+```
+
+Similarly, `[%exclave]` can only appear at the tail position of a region since
+one cannot re-enter a terminated region. The following code is an error for this
+reason:
+
+
+```
+  let local_ x = "hello" in
+  [%exclave] (
+    let local_ y = "world" in
+    ()
+  );
+  local_ (x ^ "world")
+```
 ## Records and mutability
 
 For any given variable, the typechecker checks only whether that variable is
@@ -481,18 +577,18 @@ itself local.
 In particular, by defining:
 
     type 'a glob = { global_ contents: 'a } [@@unboxed]
-    
+
 then a variable `local_ x` of type `string glob list` is a local list
 of global strings, and while the list itself cannot be returned out of
 a region, the `contents` field of any of its elements can.
 
-The same overriding can be used on constructor arguments. To imitate the example 
+The same overriding can be used on constructor arguments. To imitate the example
 for record fields:
 
     type ('a, 'b) t = Foo of global_ 'a * 'b
 
-    let f () = 
-      let local_ packed = Foo (x, y) in 
+    let f () =
+      let local_ packed = Foo (x, y) in
       match packed with
       | Foo (foo, bar) -> foo
 

--- a/ocaml/jane/doc/proposals/data-race-freedom.md
+++ b/ocaml/jane/doc/proposals/data-race-freedom.md
@@ -1,0 +1,1349 @@
+# Data races are bad
+
+We would like to provide a programming model for shared-memory
+parallelism in OCaml that is less terrifying than the free-for-all you
+get in languages like Java, C, C++ and Go. In particular, we intend to
+statically prevent data races. We define a data race as two or more
+threads concurrently accessing a non-atomic memory location where at
+least one of the accesses is a write.
+
+Data races are bad because their behavior is under-specified and hard
+to reason about. They are generally a mistake caused by the programmer
+accidentally sharing mutable state in a way they did not intend.
+
+OCaml has unrestricted mutable state. Controlling that mutability is
+at the heart of preventing data-races. We take a two-pronged approach:
+
+- We place restrictions on how mutable state can be shared between
+  threads. In general mutable state cannot be shared between
+  threads. However, we also provide mechanisms to wrap mutable data up
+  into isolated *capsules* allowing them to be shared between threads.
+
+- We provide support for new restricted forms of mutation that cannot
+  cause data-races:
+
+  * We support reusing the space from one *immutable* value to create a
+    second *immutable* value if there are no aliases remaining to the
+    original value. Semantically this behaves as creating a fresh value
+    however, unlike allocating fresh immutable values, it does not incur
+    the cost of actually allocating.
+
+  * We provide support for data that can only be mutated if there are
+    no other active aliases to that data. Since there are no other
+    active aliases, the mutation cannot cause a data race.
+
+  * We add some mutable types that can only be mutated if you have
+    exclusive access to an associated *key* value. Since the key is held
+    uniquely there cannot be any data-races from these mutations. Keys
+    can be managed using traditional methods of mutual exclusion e.g.
+    locks.
+
+These approaches rely on the ability to reason about whether a value
+is held uniquely and whether it contains mutable state. We rely on
+a system of *modes* to track these properties of values.
+
+# Modes are good
+
+Our support for stack allocation in OCaml is based around tracking
+locality in the type system. We can generalize this tracking of
+locality to a general concept of *mode*.
+
+A mode is a property of value that is independent of its type. The
+type system tracks the modes of variable bindings and expressions in
+addition to their types.
+
+We will use several axes of modes to support data-race freedom, in
+addition to the existing axis of locality modes. Each axis describes
+one aspect of a value; for example, the locality axis describes
+whether the value can escape a region.
+
+By default, a mode applies deeply to all the values reachable from the
+original value. For example, a local `string list` is a local `list`
+of local `string`s. Modes *do not* apply deeply through function
+types. A `global` function's closure will only contain `global` values,
+but a `global` function may accept `local` parameters or return `local`
+results.
+
+Since modes do not apply deeply through functions types, they are
+annotated with the modes of their parameters and results. For example:
+```ocaml
+val foo : local 'a -> 'b -> local 'c
+```
+
+Record and constructor fields can be annotated with *modalities* that
+allow a value at one mode to contain a value at a different mode. For
+example, record fields can be annotated with `global`:
+```ocaml
+type t = { a : string; global b : string }
+```
+which means that the value in the field is always `global` --
+even when the record itself is `local`.
+
+Modes in each axis are ordered by their "strictness". For example,
+`global` is more strict than `local` because the former requires the
+the data to be allocated in heap, while the latter allows heap or
+stack allocation. Values of one mode can always be used as values of a
+less strict mode. For example, a `global` value can always be used as
+a `local` value.
+
+All modes can be inferred. Mode annotations are only required when
+writing function types e.g. in `.mli` files. Explicit mode annotation
+can still be used to ensure a specific mode, similar to explicit type
+annotation.
+
+As a preview, we are going to describing 5 mode axes in this document,
+which have the following modes ordered by increasing strictness.
+
+| Locality | Sync   | Uniqueness | Linearity  | Readonly  |
+| -------- | ------ | ---------- | ---------- | --------- |
+| Local    | Unsync | Shared     | Once       | Readonly  |
+| Global   | Sync   | Exclusive  | Separate   | Readwrite |
+|          |        | Unique     | Many       |           |
+
+The *locality* axis tracks which values can leave regions. The *sync*
+axis tracks which values are allowed to be shared with other
+threads. The *uniqueness* axis tracks which values have aliases. The
+*linearity* axis tracks functions that can only be run at most once. The
+*readonly* axis tracks which values can have their mutable parts
+mutated.
+
+# Modal kinds and mutable fields
+
+For any modality there are types which are unaffected by it. For
+example, a global `int` is equivalent to a local `int`, because an
+integer is immediately available and does not need extra allocation
+on the stack or heap. We can use *kinds* to track such types and then
+allow values of those types to freely change between the compatible
+modes. For example, a function expecting a global `int` can be
+passed a local `int` instead.
+
+For each mode `m` there is a kind `always(m)` of types that can always
+be considered to have that mode. `m` is an upper bound on the mode of
+values of types with kind `always(m)`.
+
+A value of a type of kind `always(m)` can be used at mode `m` regardless
+of the original mode the value. This *mode-crossing* requires that the
+type of the value be known at the point where the value is used --
+similar to how record field disambiguation and constructor
+disambiguation work.
+
+We also use these modal kinds to allow records with mutable fields to
+be created at different modes. For example, given the type definition:
+```ocaml
+type 'a t =
+  { name : string;
+    mutable data : 'a; }
+```
+an expression creating a `t`:
+```ocaml
+{ name = n; data = d }
+```
+creates a value at mode `m` if:
+
+1. The mode of `n` is less than `m`.
+
+2. The type of `d` is of kind `always(m)`.
+
+This ensures that, not only is `d` of mode `m` but so is any value
+that it might be replaced by through mutation. Key here is that, for
+mutable fields, we examine only the kind of the type of the field,
+not the mode on any expression we use to initialize the field.
+
+# Mode polymorphism & new mode syntax
+
+Already with just two modes (`local` and `global`) you sometimes need
+to duplicate functions to get versions that work on values at either
+mode. For example, `List.fold` could be given the following four
+types:
+```ocaml
+val fold :
+  'a list
+  -> init:'b
+  -> f:local ('b -> 'a -> 'b)
+  -> 'b
+
+val fold :
+  local 'a list
+  -> init:'b
+  -> f:local ('b -> local 'a -> 'b)
+  -> 'b
+
+val fold :
+  'a list
+  -> init:local 'b
+  -> f:local (local 'b -> 'a -> 'b)
+  -> local 'b
+
+val fold :
+  local 'a list
+  -> init:local 'b
+  -> f:local (local 'b -> local 'a -> 'b)
+  -> local 'b
+```
+
+This problem obviously gets worse as we add further modes. To address
+this we intend to add support for mode polymorphism. Allowing
+`List.fold` to be given a single general type of which all the above
+types are instances.
+
+Adding more modes and mode polymorphism starts to risk making the type
+syntax over-complicated, especially for beginners that shouldn't have
+to worry about modes initially. We intend to address this by making
+two changes to our mode syntax. First, we are going to switch from
+writing modes in front of types on arguments and returns:
+```ocaml
+val map : local 'a -> local 'b
+```
+to writing them after the type separated by an `@`:
+```ocaml
+val foo : 'a @ local -> ('b @ local)
+```
+Second we are going to allow the mode parts of a type to be
+"unzipped", writing first the type without any modes and then a
+skeleton of the type holding the modes:
+```ocaml
+val foo : 'a -> 'b @ local -> local
+```
+
+This allows the general type of `List.fold` to be written as something
+like:
+```ocaml
+val fold :
+  'a list
+  -> init:'b
+  -> f:('b -> 'a -> 'b)
+  -> 'b
+  @
+    'm
+    -> init:'n
+    -> f:local ('n -> 'm -> global 'n)
+    -> 'n
+```
+We write `.` to stand for the default mode.
+
+The precise details of mode polymorphism are not yet worked out --
+there are a number of design decisions still to be made -- but we
+don't expect there to be any fundamental difficulties.
+
+# Don't share mutable data
+
+The root cause of potential data races in OCaml is mutability. In
+particular, `mutable` record fields and mutable arrays. To prevent
+data races we need to place restrictions on this mutable data. To do
+this we add a new `sync` mode. A value is `sync` if **it can be passed
+between threads without risking introducing data races**. Values that
+are not `sync` are at mode `unsync`. An array or record with mutable
+fields is always `unsync`.
+
+Naturally `sync` can be relaxed into `unsync`: one can always forget
+that a value can be safely passed between threads.
+
+A function is `sync` if it only closes over other `sync` values. This
+ensures that it can be safely sent to another thread. Note that a
+`sync` function can still receive `unsync` values via parameters and
+return them as results. For example, `Array.concat` is a `sync`
+function even though it manipulates mutable data: since it doesn't
+close over `unsync` values it is safe for it to be called in two
+threads simultaneously.
+
+We use `sync` to ensure that two threads never share raw mutable
+state.  When spawning a new thread, we require the thread body to be
+`sync`, so that no `unsync` value is passed from the spawning thread
+to the spawned thread:
+
+```ocaml
+val spawn : (unit -> 'a) -> 'a t
+          @ sync (. -> .) -> .
+
+val join : 'a t -> 'a
+         @ . -> .
+```
+
+Similarly, any mechanism for communicating between threads,
+e.g. channels, requires the transferred data to be `sync`:
+```ocaml
+val send : 'a channel -> 'a   -> unit
+         @ . -> sync -> .
+
+val recv : 'a channel -> 'a
+         @ . -> sync
+```
+
+Note that any deeply immutable type is of kind `always(sync)` allowing
+any value of such types to be passed between threads.
+
+We allow a `sync` modality on record fields so that the fields will be
+`sync` even if the record is `unsync`. We obviously cannot allow a
+`unsync` modality, because a record with `unsync` fields cannot itself
+be `sync`.
+
+The majority of toplevel functions will already be `sync` since people
+try to avoid using global mutable state. Most others will become `sync`
+by the addition of e.g. locking to allow them to be called from multiple
+threads.  As such, it would be better in the long run to have `sync` be
+the default mode for things in modules and require people to specify
+which functions are `unsync`. Since this would be a backward
+incompatible change, and only affects the meaning of the default syntax,
+we'll let the user choose the default via a command-line flag, with the
+aim being to make the new state the default and eventually deprecate the
+flag.
+
+# Uniqueness
+
+A motivating example for uniqueness mode is the following:
+```ocaml
+let r = {x = 3; y = 5} in
+...
+let s = {r with x = 7} in
+...
+```
+This allocates fresh space for `s`. However, it is common that `r` will
+never be referred to again after `s` is created, in which case we can
+optimize the machine code so that `s` will skip allocating and
+copying from `r`, but instead just reuse the space of `r`.
+
+To support this optimization we add the following in-place record update
+operation:
+```ocaml
+{overwrite r with x = 7}
+```
+that behaves as `{r with x = 7}` but reuses the space of `r`.  To
+ensure that this operation is only used when it is safe, we introduce
+the `unique` mode as part of a new *uniqueness* mode axis.
+
+A value is `unique` if **it is not aliased with any other value in the
+whole system**. More precisely:
+```ocaml
+e == f
+```
+is always `false` if the expression `e` returns a unique value. Note
+that in the expression `x == x`, `x` cannot be given the unique mode
+because it is used twice. Values which aren't `unique` are at mode
+`shared`.
+
+Only values at mode `unique` can be used with in-place record
+update.  Consider the following example:
+```ocaml
+let r = {x = 3; y = 5} in
+let s = {overwrite r with x = 7} in
+r
+```
+which gives a type error:
+```ocaml
+Line 2, characters 22-23:
+2 | let s = {overwrite r with x = 7} in
+                       ^
+Error: r is used uniquely here so cannot be used twice. It will be used
+  again at:
+Line 3, characters 3-4:
+3 | r
+    ^
+```
+There are two occurrences of `r`, so `r` will be a `shared` value at
+these occurrences. As a result, `r` cannot be used with in-place record
+update. It would be unsafe in the sense that `r.x` is observed to be
+mutated while being an immutable field.
+
+Note that while the updated value reuses the space of the old value,
+semantically they are still two distinct values. In particular, they
+could have different types. Consider the following example:
+```ocaml
+type 'a foo = {x : int; y : 'a}
+
+let r = {x = 3; y = "foo"} in
+let s = {overwrite r with y = 5} in
+...
+```
+where `r` is of type `string foo` and `s` of type `int foo`, while
+sharing the same memory space. Such an update that changes not only
+the value but also the type is called a *strong update*. It is
+obviously only safe if `r` is never used again after the update,
+otherwise `r.y` might be read as `string` while actually being an
+`int`.
+
+A useful example of strong update is the in-place version of
+`List.map` (using a list type defined as a record type):
+```ocaml
+type 'a list =
+  | Cons of { hd : 'a; tl : 'a list }
+  | Nil
+
+let rec map f (unique_ xs) =
+  match xs with
+  | Nil -> xs
+  | Cons ({hd;tl} as xs) -> Cons { overwrite xs with hd = f hd; tl = map f tl }
+```
+
+Note that using the `overwrite` syntax also requires that any values
+being written into the record are global. For instance,
+```ocaml
+{ overwrite r with s = msg }
+```
+requires that `msg` be `global`. This is because, even if `r` is
+`local`, it's possible that it was allocated on the heap, and the
+runtime does not support pointers from the heap to the stack.
+
+By default a value being unique means that everything reachable from
+it is also unique. For example, the following is an error because the
+explicit annotation enforces the tuple to be `unique`, which means
+everything reachable from the tuple must be `unique`. However, the
+first element of the tuple is not `unique` because it is aliased with
+another value (namely in the second component of the tuple), and
+similar for the second component.
+
+```ocaml
+let dup x = unique (x, x)
+
+[%%expect{|
+Line 1, characters 24-25:
+1 | let dup x = unique (x, x)
+                            ^
+Error: x is used uniquely here so cannot be used twice. It will be used again at:
+Line 1, characters 21-22:
+1 | let dup x = unique (x, x)
+                         ^
+|}]
+```
+
+A `shared` modality can be applied to record fields, so that the field
+will be `shared` regardless of the mode of the record. One particular
+application is the following, where `'a shrd` would represent some
+`shared` `'a` regardless of the mode of the `'a shrd`.
+```ocaml
+type 'a shrd = {shared foo : 'a } [@@unboxed]
+```
+
+Note that a `unique` modality on record fields is not permitted as it
+breaches mode safety. The result of reading from such a field could
+not be unique because the value would still be aliased in the shared
+record from which it was read.
+
+`unique` is more strict than `shared` as it restricts the number of
+aliases.  One can always forget this extra bit of information about a
+value, and relax a value of `unique` into a value of `shared`.  In the
+following, `x` is `unique` but relaxed to `shared` which allows it to
+be aliased twice (by the tuple); the resulting tuple is `shared` as
+well of course.
+```ocaml
+let dup (unique x) = (x, x)
+```
+
+# Borrowing
+
+One might wish to use a `unique` value as `shared` for a short
+duration. For example,
+```ocaml
+type point = { x : float; y : float }
+
+let total p = p.x +. p.y
+
+let averagize p =
+  let avg = (total p) /. 2.0 in
+  { overwrite p with x = avg; y = avg }
+```
+This would be an error because `p` has two occurrences but the second
+occurrence requires that it be unique. However, it is clear that by
+the time of the second occurrence `p` will in fact be unique again.
+
+To support such code we introduce *borrowing*. Borrowing allows
+`unique` values to be `shared` for the duration of a region, and
+recovers them to `unique` afterwards. To borrow the variable `x` you
+use the syntax `&x`. So that `averagize` becomes:
+```ocaml
+let averagize p =
+  let avg = (total &p) /. 2.0 in
+  { overwrite p with x = avg; y = avg }
+```
+
+The `&x` syntax creates an implicit region and treats `&x` as `shared`
+and `local` for the duration of this region. The `local` mode prevents
+the value from escaping the region, which allows `x` to be considered
+`unique` again after the region has ended.
+
+The implicit regions take one of the following forms -- using `{...}` to
+indicate where the implicit region would be:
+
+- Surrounding a function call:
+```ocaml
+ let foo x =
+    let y = {bar &x} in
+    unique x
+ ```
+
+- Around a `let` binding:
+```ocaml
+let foo x =
+   {let y = &x in
+   bar y y
+   }
+```
+
+The implicit region for a use of `&x` will be the nearest enclosing potential
+region. For example,
+```ocaml
+let foo x y =
+    let z = bar x ({baz &y}) in
+    unique y
+```
+
+Since a borrowed value is `shared`, there may be multiple borrows
+within the same (implicit) region. In the following example, `x` is
+borrowed twice in the same region, both of which would be used as
+`shared` by `bar`.
+```ocaml
+let foo x =
+  let y = {bar &x &x} in
+  unique x
+```
+
+The original unique value is not accessible uniquely in the borrowing
+region. The following example is an error because `x` is borrowed as `y`
+for the whole `let` binding, and would not be accessible uniquely for
+the call to `baz`.
+```ocaml
+let foo x =
+  let y = &x in
+  let z = bar y in
+  baz (unique x)
+```
+
+# Exclusivity
+
+Consider the following program:
+```ocaml
+let foo x =
+  ...
+  let x = {overwrite x with a = "hello"} in
+  ...
+  x
+
+let bar x =
+  ...
+  let x = {overwrite x with b = "goodbye"} in
+  ...
+  x
+
+let process x =
+  ...
+  let x = foo x in
+  ...
+  let x =
+    if p then begin
+      ...
+      let x = bar x in
+      ...
+    end else begin
+      x
+    end
+  in
+  ...
+  unique x
+```
+The `process` function operates on a unique value `x`, using `foo`
+and `bar` which update `x` in place. Since these in place updates
+require `x` to be unique, `x` must be threaded through the body of `process`
+passing it in and getting it out of each call that modifies it. This passing
+around of `x` can become cumbersome for large programs.
+
+As an alternative we propose `exclusively mutable` record fields:
+```ocaml
+type t =
+  { exclusively mutable a : string
+  ; exclusively mutable b : string }
+```
+
+Such fields can be mutated using the usual syntax
+```ocaml
+x.a <- "hello"
+```
+but only if the value being mutated (`x`) is *exclusive*. Unlike
+ordinary `mutable` fields, records with `exclusively mutable` fields can
+be `sync`.
+
+The `exclusive` mode is closely related to the `unique` mode. They both
+restrict how values can be used to limit how they can be aliased. The
+difference comes in how they treat borrowing. Values can be borrowed as
+`exclusive` but values can never be borrowed as `unique`.
+
+More precisely, a value being `exclusive` requires that **it is not
+aliased with other values that are active in the current region**. It
+might be aliased with other values, but those values will not be used in
+the current region.
+
+For instance, our example above can be rewritten as:
+```ocaml
+let foo x =
+  ...
+  x.a <- "hello";
+  ...
+
+let bar x =
+  ...
+  x.b <- "goodbye";
+  ...
+
+let process x =
+  ...
+  foo &x;
+  ...
+  if p then begin
+    ...
+    bar &x;
+    ...
+  end;
+  ...
+  unique x
+```
+Here, the `foo` and `bar` functions require that their parameter be
+`exclusive`.
+
+Note that the `&x` passed to `foo` and the `&x` passed to `bar` are
+aliases to each other; however, the first `x` is active only during
+the region around the call to `foo`, whilst the second `x` is active
+only during the region around the call to `bar`. This means that,
+whilst they aren't `unique`, these borrowed values are `exclusive`.
+
+Having a value exclusively is not a strong enough condition to
+`overwrite` it with another value -- you might have borrowed the value
+from elsewhere and when your borrow ends the original owner will reclaim
+it and continue to use it. This is why we need to have both `exclusive`
+and `unique` modes.
+
+Much like `unique` values, the compiler checks values used as
+`exclusive` are not aliased. For example, the following code:
+```ocaml
+let dup x = exclusive (x, x)
+```
+is an error:
+```ocaml
+Line 1, characters 27-28:
+1 | let dup x = exclusive (x, x)
+                              ^
+Error: x is used exclusively here so cannot be used twice. It will be used
+  again at:
+Line 1, characters 24-25:
+1 | let dup x = exclusive (x, x)
+                           ^
+```
+
+A borrowed value is `exclusive` as long as the following conditions
+hold:
+1. The original value is `unique` or `exclusive`.
+2. The original value is not borrowed or used elsewhere in the implicit
+   region of the borrow.
+
+For example, the following is an error:
+```ocaml
+let foo (exclusive x) y =
+  x.a <- y.a;
+
+let bar x =
+  ...;
+  foo &x &x
+```
+because `foo` requires its first parameter exclusively, but it is
+borrowed twice within the same implicit region.
+
+Unlike ordinary `mutable` fields, there is no possibility of data races
+when mutating `exclusively mutable` fields. There is also no possibility
+of unexpected aliasing: if you are reading the value of an `exclusively
+mutable` field then no other piece of code can be updating it. Combined
+with the fact that borrows are syntactically explicit (thus signalling
+the possibility of mutation), you get much of the same benefits as
+immutability when reasoning about your code.
+
+# Closures
+
+## Accessing unique values from closures
+
+Consider the following code:
+```ocaml
+let foo x =
+  let bar () =
+    if String.equal x.a "foo" then
+      { overwrite x with a = 42 }
+    else
+      { overwrite x with a = 24 }
+  in
+  bar
+```
+The function `bar` clearly cannot run more than once. It strongly
+updates `x`, and running it the second time would be reading the
+integer `x.a` as a string, which is unsafe. To be safe, we forbid any
+function closing over unique values to be called more than once.
+
+To this end, we introduce the `once` mode. This mode **prevents
+additional aliases of the value from being created**. For example, the
+following is an error, because the value `x` while being `once` is
+referred to twice.
+```ocaml
+let dup (once x) = (x, x)
+```
+This ensures that, for example, a `once` function can only be called a
+single time.
+
+Values that are not `once` will be at mode `many`. `many` is stricter
+than `once`: it is safe to forget that a value can be used multiple
+times, and instead use it only once.
+
+In addition, a `many` modality can apply to record fields, so that the
+fields will be `many` regardless of the mode of the record.
+
+`once` and `unique` are closely related: a value being `once` means it
+cannot have more aliases created in the *future*, a value being
+`unique` means it has had no aliases created in the *past*. In
+particular, a function parameter being `unique` is a restriction on
+the caller, whilst a function parameter being `once` is a restriction
+on the callee.
+
+Putting all of this together, we would infer the following type for
+`foo`:
+
+```ocaml
+val foo : t -> (unit -> t)
+          @ unique -> once
+```
+
+This says that `foo` takes a `t` it is allowed to destroy and returns
+a function that can be called at most once.
+
+As another example, `Deferred.bind` could probably have the following type
+to indicate that the `f` parameter will be called only once:
+```ocaml
+val bind : 'a t -> f:('a -> 'b t) -> 'b t
+          @ . -> once -> .
+```
+which means `f` can close over `unique` values and strongly update
+them. By making a stricter requirement on `bind` -- that it can call
+`f` at most once -- we give its caller the freedom to pass in more
+possible functions.
+
+Functions that close over `once` variables are themselves at mode
+`once`. In the following example, `bar` must be called at most
+once to ensure that `f` is called at most once.
+```ocaml
+let foo (once f) =
+  let bar () =
+    f 42
+  in
+  bar
+```
+
+Since `once` is about restricting functions, concrete data types
+that don't contain functions are `always(many)`.
+
+## Accessing exclusive values from closures
+
+There are three different ways that a local function can access an
+exclusive value from its surrounding environment.
+
+1. Putting the value in the function's closure, and then using the
+   value directly from the closure in the body of the function. We
+   shall refer to this as *consuming* the value.
+
+2. Borrowing the value, putting the borrowed value in the closure, and
+   then re-borrowing the value whenever it is used in the body of the
+   function. We shall refer to this as *borrowing* the value.
+
+3. Putting the value in the function's closure, and then borrowing the
+   value whenever it is used in the body of the function. We shall
+   refer to this as *moving* the value.
+
+Each of these ways places different restrictions on the function and
+on the uses of the value inside the function.
+
+### Consuming the value
+
+Consider the following code:
+```ocaml
+type t =
+  { exclusively mutable a : int }
+
+let set t x = t.a <- x
+
+let updater t =
+  (fun x -> set t x)
+```
+The `updater` function returns a closure that uses `t` exclusively
+without borrowing it. That can only be done once and so this closure
+will be created at mode `once`, much like a function that uses a value
+from its closure uniquely.
+
+The types of these functions will be:
+```ocaml
+val set : t -> int -> unit
+         @ local exclusive -> . -> .
+
+val updater : t -> (int -> unit)
+             @ unique -> once
+```
+
+### Borrowing the value
+
+Consider the following example,
+```ocaml
+type t =
+  { exclusively mutable a : int }
+
+let get t = t.a
+
+let set t x = t.a <- x
+
+let foo t g =
+  let () =
+    let bar f =
+      let old = get &t in
+      set &t (old + 1);
+      f ();
+      assert (get &t = old + 1)
+    in
+    g bar
+  in
+  unique t
+```
+The `bar` function closes over the `t` value exclusively. The
+assertion should be guaranteed to pass: since `t` is exclusive there
+should be no other aliases to it, so the call to `f ()` should not be
+able to change `t`'s value.
+
+Since each use of `t` within `bar` is a borrow, we also consider the
+definition of `bar` itself to borrow `t`. That means that `bar` must
+be local.  This condition is not sufficient to ensure that `t` can be
+used exclusively in `bar`. Consider the following potential use of
+`foo`:
+```ocaml
+let bad t =
+  foo t (fun bar -> bar (fun () -> bar (fun () -> ())))
+```
+This code would cause the assertion in `bar` to fail, because the
+`f()` call in `bar` would in fact call `bar` itself, resulting in `t`
+being unexpectedly mutated.
+
+To be safe, at most one instance of `bar` can be running
+simultaneously. To ensure this we add a `separate` mode that sits
+between `once` and `many`. A value being at mode `separate` **prevents
+additional aliases that are active in the current region from being
+created**. This is ensured by preventing the creation of new aliases
+to `separate` values, whilst still allowing `separate` values to be
+borrowed.
+
+A `separate` value can be borrowed as long as the following conditions
+hold:
+
+1. The borrowed value is `separate` or `once`.
+
+2. The original value is not used elsewhere in the implicit region of
+   the borrow.
+
+This prevents the `bad` example from passing type-checking: the `bar`
+parameter is `separate` and so it cannot be passed to itself. Whereas,
+the following use of `foo` would be fine:
+```ocaml
+let good t =
+  foo t
+    (fun bar ->
+       &bar (fun () -> ());
+       &bar (fun () -> ()))
+```
+because the implicit regions of the two borrows do not overlap.
+
+Pulling this all together, we get these inferred types from this example:
+```ocaml
+val bar : (unit -> unit) -> unit
+         @ local separate (local once (. -> .) -> .)
+
+val foo : t -> (((unit -> unit) -> unit) -> unit) -> t
+         @ unique
+           -> local once (local separate (local once (. -> .) -> .) -> .)
+           -> unique
+
+val good : t -> t
+          @ unique -> unique
+```
+
+Similar to the relationship between `once` and `unique`, `separate` is
+dual to `exclusive` in that a value being `separate` poses a restriction
+on code *using* the value, while a value being `exclusive` poses
+restriction on code *providing* the value. For example, `List.iter`
+could have type:
+```ocaml
+val iter : 'a t -> f:('a -> unit) -> unit
+          @ . -> local separate -> .
+```
+to indicate that the `f` parameter is only run one-at-a-time and
+doesn't escape. This allows `f` to close over some `exclusive` values
+By posing stricter requirements on `iter`, we give more freedom to
+`f`.
+
+Note that functions closing over `separate` values are themselves
+`separate`.
+
+### Moving the value
+
+Consider the following example:
+```ocaml
+type t =
+  { exclusively mutable a : int }
+
+let get t = t.a
+
+let set t x = t.a <- x
+
+let foo t =
+  let global bar f =
+    let old = get &t in
+    set &t (old + 1);
+    f ();
+    assert (get &t = old + 1)
+  in
+  bar
+```
+This is similar to the example from the previous section, except
+here `bar` is returned from `foo` and `t` is not used outside of
+`bar` again. This requires that we *move* `t` into `bar`, which
+is indicated by the user by the `global` annotation on the definition
+of `bar`.
+
+We get the following inferred types for `bar` and `foo`:
+```ocaml
+val bar : (unit -> unit) -> unit
+          @ separate (local once (. -> .) -> .)
+
+val foo : t -> ((unit -> unit) -> unit)
+          unique t -> separate (local once (. -> .) -> .)
+```
+
+Moving an exclusive value into a closure produces a closure at mode
+`separate`, since at most one instance of the function can be run
+simultaneously. This prevents code like the following:
+```ocaml
+let bad t =
+  let bar = foo t in
+  bar (fun () -> bar (fun () -> ()))
+```
+
+# Keys and locks
+
+Uniqueness and exclusivity provide forms of mutation that cannot race,
+allowing the data that is mutated to be safely shared between
+threads. However, they require the user to carefully manage aliases
+to all the mutated data and to convey that information to the type
+checker.  This could quickly become cumbersome as one needs to
+carefully keep the `exclusive`/`unique` mode when passing around
+values.
+
+Moreover, some programs fundamentally cannot be directly expressed
+using just exclusive and unique. Consider the following example of
+constructing a circular graph:
+```ocaml
+type node =
+  { data : int;
+    mutable next : node option }
+
+let create_loop () =
+  let n0 = {data = 42; next = None} in
+  let n1 = {data = 24; next = Some n0} in
+  n0.next <- n1;
+  n0
+```
+The above would not work if we rely on `exclusively mutable` instead of
+`mutable`.  When performing `n0.next <- n1`, `n0` cannot be `exclusive`
+because it is aliased as `n1.next`.
+
+However, we can provide some additional APIs built around `exclusive`
+and `unique` that enable data-race free mutation without requiring the
+mutated data itself to be `exclusive` or `unique`.
+
+The core of these APIs is the `Key.t` type:
+```ocaml
+module Key : sig
+
+  type 'k t : void & always(sync)
+
+  type packed = Key : 'k t -> packed [@@unboxed]
+
+  val create : unit -> unique packed
+
+end
+```
+
+The essential invariant that the above API ensures is that for each type
+`k` there is at most one value of type `k Key.t`. This property is
+maintained by the `create` function returning an existential type. That
+means that each call to `create` returns a key for a fresh `k` type.
+
+A *key* is a form of capability. For a given `k`, there can be only one
+`k Key.t` at `exclusive` mode at any point in time. If there is a `k
+Key.t` at `shared` mode then there are no `k Key.t`s at mode `exclusive`
+simultaneously.
+
+`'k t` is of the `void` layout, which means it consumes no space and
+contains no information at run-time. It is also `always(sync)` so can
+always be safely passed to another thread.
+
+## Safe boxes
+
+The first API using keys is `Safe_box`. A `Safe_box.t` is a piece of
+mutable state guarded by a key. It can only be written to if you have
+the key exclusively. That prevents data races without requiring the user
+to keep track of aliases to the `Safe_box.t` itself.
+
+The core of its API is as follows:
+```ocaml
+module Safe_box : sig
+
+  type ('a, 'k) t : always(sync)
+
+  val create : 'a -> ('a, 'k) t
+               @ sync -> .
+
+  val read : ('a, 'k) t -> 'k Key.t -> 'a
+             @ . -> local -> sync
+
+  val write : ('a, 'k) t -> 'k Key.t -> 'a -> unit
+              @ . -> local exclusive -> sync -> .
+
+end
+```
+
+To `read` the safe-box one must provide the associated key. To `write`
+to the safe-box, one must provide the key exclusively. They both only
+require the key locally, which allows one to use borrowed keys to
+access safe-boxes.
+
+The `create_loop` example can now be rewritten as
+```ocaml
+type 'k node =
+  { data : int;
+    next : ('k node option, 'k) Safe_box.t }
+
+let create_loop key =
+  let n0 = {data = 42; next = Safe_box.create None} in
+  let n1 = {data = 24; next = Safe_box.create (Some n0)} in
+  Safe_box.write n0.next key n1;
+  n0
+```
+Note that the keys for `n0.next` and `n1.next` are not specified at
+`create` but later inferred upon `read`/`write`. In practice, we would
+protect the whole graph with a single key, by which all `Safe_box.t`s
+within are parameterized.
+
+## Unique safe boxes
+
+We can also have a data-race free reference type that holds unique
+values:
+```ocaml
+module Unique_safebox : sig
+
+  type ('a, 'k) t : always(sync)
+
+  val create : 'a -> ('a, 'k) t
+               @ unique sync -> .
+
+  val exchange : ('a, 'k) t -> 'k Key.t -> 'a -> 'a
+                 @ . -> local exclusive -> unique sync -> unique sync
+
+end
+```
+This interface is guaranteed to preserve the uniqueness of the value
+because you can only swap the value out of the box, you cannot read
+it. It is also guaranteed to be data-race free because you can only
+swap out the contents if you have exclusive access to the key that
+protects the safebox.
+
+## Unique atomic
+
+OCaml comes with an atomic reference type `Atomic.t`. This type will
+be considered `sync` since racing on an atomic reference is not
+considered a data-race. We can additionally add a `Unique_atomic.t`
+that holds unique values:
+```ocaml
+module Unique_atomic : sig
+
+  type 'a t : always(sync)
+
+  val make : 'a -> 'a t
+             @ sync unique -> .
+
+  val exchange : 'a t -> 'a -> 'a
+                @ . -> sync unique -> sync unique
+
+end
+```
+There is no `get` operation, since that would allow the unique value
+to become aliased. Note that the `exchange` operation must be atomic
+to ensure the uniqueness of the result.
+
+## Mutex
+
+We can rely on mutual exclusion to ensure uniqueness. The following
+mutex interface is a convenient way to support this:
+```ocaml
+module Mutex : sig
+
+  type 'k t
+
+  val create : unit -> 'k t
+
+  val acquire : 'k t -> 'k Key.t
+               @ . -> unique
+
+  val release : 'k t -> 'k Key.t -> unit
+               @ . -> unique -> .
+
+end
+```
+
+The idea is that a mutex protects a `unique` key. One can `acquire` the
+protected `unique` key, and then perform actions enabled by that key
+(e.g. write to a `Safe_box.t`). When one is finished with the key, they
+can `release` it back into the protection of the `Mutex`. Note that
+`create` creates the mutex in the acquired state.
+
+The `Mutex.t` is associated with a particular key type `'k`. That means
+to `acquire` the intended `'k Key.t` one must be using the corresponding
+`Mutex.t`, and this is ensured by the type checker.  This is a helpful
+improvement over the traditional mutex interface where one can easily
+acquire and release the wrong mutex without being warned by type system
+at all.
+
+We can give a spinlock-based implementation of `Mutex` using
+`Unique_atomic.t`:
+```ocaml
+type 'k t = 'k Key.t option Atomic_unique_ref.t
+
+let create () =
+  Unique_atomic.create None
+
+let rec acquire t =
+  match Unique_atomic.exchange k None with
+  | None -> acquire t
+  | Some key -> key
+
+let release t key =
+  ignore (Unique_atomic.exchange t (Some key))
+```
+which shows that `Mutex` doesn't add any additional expressivity. In
+practice however we would implement `Mutex.t` on top of a traditional
+mutex implementation.
+
+As a side-note, recall that `'k Key.t` is of `void` layout and so
+consumes no space at runtime. As a result, `'k Key.t option` is simply
+`bool` at runtime just like a traditional mutex: the extra safety
+brought by `'k Key.t` is free.
+
+We can define a useful `with_` combinator as:
+```ocaml
+let with_ t f =
+  let key = acquire t in
+  let res = f &key in
+  release t key
+  res
+```
+which has type:
+```ocaml
+val with_ : 'k t -> ('k Key.t -> 'a) -> 'a
+            @ . -> local once (local exclusive -> .) -> .
+```
+
+# Capsules
+The requirement that values shared between threads be `sync` essentially
+forbids threads from sharing mutable (i.e. `unsync`) values. This improves
+safety at the cost of expressivity. To restore the expressivity of shared
+mutable values but in a safe manner, we introduce capsules.
+
+A *capsule* is a container holding some, possibly `unsync`, data. Only
+`sync` data is allowed to pass into or out of a capsule. This ensures
+that any `unsync` data within the capsule is entirely isolated from the
+world outside the capsule. There is one capsule associated with each
+key, and access to the capsule is guarded by that key. This ensures that
+any `unsync` data inside the capsule can only be accessed while holding
+that key . That means it is safe to pass capsules between threads
+without risking data-races.
+
+Capsules are accessed via `Capsule.t`s. These are pointers into a capsule
+from the outside world. They have the following interface:
+```ocaml
+module Capsule : sig
+
+  type (+'a, 'k) t : always(sync)
+
+  val pure : 'a -> ('a, 'k) t
+            @ sync -> .
+
+  val apply : 'k Key.t -> ('a -> 'b, 'k) t -> ('a, 'k) t -> ('b, 'k) t
+              @ local exclusive -> . -> . -> .
+
+  val extract : 'k Key.t -> ('a, 'k) t -> ('a -> 'b) -> 'b
+               @ local exclusive -> . -> local once sync (. -> sync) -> sync
+
+  val destroy : 'k Key.t -> ('a, 'k) t -> 'a
+               @ unique -> . -> .
+
+end
+```
+
+`sync` data can move freely between capsules, so all `sync` data can be
+ thought of as being in all capsules simultaneously. `pure` makes such
+ data available as a `Capsule.t`.
+
+`apply` takes a `Capsule.t` pointing to a function and a `Capsule.t`
+pointing to a value within the same capsule and runs the function on
+that value returning a `Capsule.t` pointing to the result.
+
+`extract` takes a `sync` function that returns a `sync` value, and a
+`Capsule.t` pointing to some data, and runs the function on the data and
+returns the result. Since the result must be `sync` it does not need to
+be wrapped in a `Capsule.t`. This allows the user take `sync` data out
+of a capsule.
+
+`destroy` consumes a `key`, destroying the associated capsule. A
+`Capsule.t` is also provided and the data from it is returned,
+essentially moving it from the destroyed capsule to the outside world.
+
+Note that `apply` and `extract` both require exclusive access to the key
+associated with the capsule. This ensures that only one thread can be
+accessing the mutable data in a capsule at any one time.
+
+We can define a few more useful combinators:
+```ocaml
+let map k f x =
+  apply k (pure f) x
+
+let inject k f x =
+  map k f (pure x)
+
+let iter k f x =
+  ignore (map k f x)
+```
+with signatures:
+```ocaml
+val map : 'k Key.t -> ('a -> 'b) -> ('a, 'k) t -> ('b, 'k) t
+           @ local exclusive -> sync -> . -> .
+
+val inject : 'k Key.t -> ('a -> 'b) -> 'a -> ('b, 'k) t
+              @ local exclusive -> sync -> sync -> .
+
+val iter : 'k Key.t -> ('a -> unit) -> ('a, 'k) t -> unit
+            @ local exclusive -> sync -> . -> .
+```
+
+As an example, below we encapsulate a mutable `Hashtbl.t`. The resulting
+`'k Capsule_table.t` is `sync` so can be passed between threads.
+
+```ocaml
+module Capsule_table : sig
+
+  type 'k t : always(sync)
+
+  val create : 'k Key.t -> 'k t
+              @ local exclusive -> .
+
+  val add_exn : 'k Key.t -> 'k t -> int -> string -> unit
+               @ local exclusive -> . -> . -> . -> .
+
+  val find : 'k Key.t -> 'k t -> int -> string
+               @ local exclusive -> . -> . -> .
+
+end = struct
+
+  type 'k t = ((int, string) Hashtbl.t, 'k) Capsule.t
+
+  let create key =
+    Capsule.inject key (fun () -> Hashtbl.create ()) ()
+
+  let add_exn key t i data =
+    Capsule.iter key (fun t -> Hashtbl.add t ~key:i ~data) t
+
+  let find key t i =
+    Capsule.extract key (fun t -> Hashtbl.find t i) t
+
+end
+```
+
+Recall that we can use a mutex to dynamically protect a key. Below we extend
+the above example to a type for a hash table protected by a lock:
+```ocaml
+module Locked_table = struct
+
+  type t =
+    Table :
+      { table : 'k Capsule_table.t;
+        mutex : 'k Mutex.t; } -> t
+
+  let create () =
+    let Key key = Key.create () in
+    let table = Capsule_table.create &key in
+    let mutex = Mutex.create () in
+    Mutex.release mutex key;
+    { table; mutex }
+
+  let add_exn { table; mutex } i data =
+    Mutex.with_ mutex (fun key ->
+      Capsule_table.add_exn key table i data)
+
+  let find { table; mutex } i =
+    Mutex.with_ mutex (fun key ->
+      Capsule_table.find key table i)
+
+end
+```
+
+# Read-only capsule access
+
+Capsules allow us to wrap mutable data and ensure that it is only
+accessed by one thread at a time. However, this is stricter than is
+necessary to avoid data races. Multiple threads can safely read from the
+mutable state in a capsule as long as no thread can be simultaneously
+writing to it.
+
+To support this kind of access we add another mode: `readonly`. A `readonly`
+value can contain mutable state, but that state cannot be written to. A
+value that is not `readonly` is at mode `readwrite`. `readwrite` is more
+strict than `readonly`.
+
+There are two restrictions on `readonly` values:
+
+1. Writing to a `mutable` record field requires that the record
+   being written to be `readwrite`.
+
+2. Functions can only be applied at mode `readwrite`.
+
+For example, the following:
+```ocaml
+let set t =
+  (readonly t).contents <- 5
+```
+is an error:
+```ocaml
+Line 2, characters 6-32:
+1 |   (readonly t).contents <- 5
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Cannot mutate readonly value
+```
+
+There is a `readonly` modality that allows `readwrite` data to point to
+`readonly` data. Since `sync` values contain no mutable data, the `sync`
+modality on record fields also gives `readwrite` values even if the
+record is `readonly`. Similarly, `always(sync)` implies
+`always(readwrite)`.
+
+With this mode we can add the following additional operations to the
+`Capsule` API:
+```ocaml
+val map_readonly : 'k Key.t -> ('a -> 'b) -> ('a, 'k) t -> ('b, 'k) t
+           @ local -> sync (readonly -> .) -> . -> .
+
+val read : 'k Key.t -> ('a, 'k) t -> ('a -> 'b) -> 'b
+             @ local -> . -> sync (readonly -> sync) -> sync
+
+val freeze : 'k Key.t -> ('a, 'k) t -> 'a
+             @ . -> . -> readonly
+```
+which require the capsule's key, but do not require it exclusively.
+
+Using these it is possible to create a version of `Locked_hashtbl` that
+uses a multiple-reader-single-writer lock to allow multiple threads to
+read from the hash table simultaneously. However, it does require
+changing the interface of the underlying `Hashtbl` module to indicate
+which operations only read from the mutable state in the hash table.

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -512,6 +512,7 @@ type lambda =
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
   | Lregion of lambda * layout
+  | Lexclave of lambda
 
 and lfunction =
   { kind: function_kind;
@@ -525,9 +526,7 @@ and lfunction =
 
 and lambda_while =
   { wh_cond : lambda;
-    wh_cond_region : bool;
     wh_body : lambda;
-    wh_body_region : bool
   }
 
 and lambda_for =
@@ -536,7 +535,6 @@ and lambda_for =
     for_to : lambda;
     for_dir : direction_flag;
     for_body : lambda;
-    for_region : bool;
   }
 
 and lambda_apply =
@@ -725,6 +723,7 @@ let make_key e =
         Lsend (m,tr_rec env e1,tr_rec env e2,tr_recs env es,pos,mo,Loc_unknown,layout)
     | Lifused (id,e) -> Lifused (id,tr_rec env e)
     | Lregion (e,layout) -> Lregion (tr_rec env e,layout)
+    | Lexclave e -> Lexclave (tr_rec env e)
     | Lletrec _|Lfunction _
     | Lfor _ | Lwhile _
 (* Beware: (PR#6412) the event argument to Levent
@@ -825,6 +824,8 @@ let shallow_iter ~tail ~non_tail:f = function
       tail e
   | Lregion (e, _) ->
       f e
+  | Lexclave e ->
+      tail e
 
 let iter_head_constructor f l =
   shallow_iter ~tail:f ~non_tail:f l
@@ -906,6 +907,8 @@ let rec free_variables = function
       (* Shouldn't v be considered a free variable ? *)
       free_variables e
   | Lregion (e, _) ->
+      free_variables e
+  | Lexclave e ->
       free_variables e
 
 and free_variables_list set exprs =
@@ -1066,8 +1069,8 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
     | Lifthenelse(e1, e2, e3,kind) ->
         Lifthenelse(subst s l e1, subst s l e2, subst s l e3,kind)
     | Lsequence(e1, e2) -> Lsequence(subst s l e1, subst s l e2)
-    | Lwhile lw -> Lwhile {lw with wh_cond = subst s l lw.wh_cond;
-                                   wh_body = subst s l lw.wh_body}
+    | Lwhile lw -> Lwhile { wh_cond = subst s l lw.wh_cond;
+                            wh_body = subst s l lw.wh_body}
     | Lfor lf ->
         let for_id, l' = bind lf.for_id l in
         Lfor {lf with for_id;
@@ -1112,6 +1115,8 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
         Lifused (id, subst s l e)
     | Lregion (e, layout) ->
         Lregion (subst s l e, layout)
+    | Lexclave e ->
+        Lexclave (subst s l e)
   and subst_list s l li = List.map (subst s l) li
   and subst_decl s l (id, exp) = (id, subst s l exp)
   and subst_case s l (key, case) = (key, subst s l case)
@@ -1195,8 +1200,8 @@ let shallow_map ~tail ~non_tail:f = function
   | Lsequence (e1, e2) ->
       Lsequence (f e1, tail e2)
   | Lwhile lw ->
-      Lwhile { lw with wh_cond = f lw.wh_cond;
-                       wh_body = f lw.wh_body }
+      Lwhile { wh_cond = f lw.wh_cond;
+               wh_body = f lw.wh_body }
   | Lfor lf ->
       Lfor { lf with for_from = f lf.for_from;
                      for_to = f lf.for_to;
@@ -1211,6 +1216,8 @@ let shallow_map ~tail ~non_tail:f = function
       Lifused (v, tail e)
   | Lregion (e, layout) ->
       Lregion (f e, layout)
+  | Lexclave e ->
+      Lexclave (tail e)
 
 let map f =
   let rec g lam = f (shallow_map ~tail:g ~non_tail:g lam) in
@@ -1516,4 +1523,5 @@ let rec compute_expr_layout kinds lam =
   | Lwhile _ | Lfor _ | Lassign _ -> layout_unit
   | Lifused _ ->
       assert false
+  | Lexclave e -> compute_expr_layout kinds e
 

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -411,6 +411,7 @@ type lambda =
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
   | Lregion of lambda * layout
+  | Lexclave of lambda
 
 and lfunction = private
   { kind: function_kind;
@@ -426,11 +427,7 @@ and lfunction = private
 
 and lambda_while =
   { wh_cond : lambda;
-    wh_cond_region : bool; (* false if the condition may locally allocate in
-                              the region containing the loop *)
     wh_body : lambda;
-    wh_body_region : bool  (* false if the body may locally allocate in
-                              the region containing the loop *)
   }
 
 and lambda_for =
@@ -439,8 +436,6 @@ and lambda_for =
     for_to : lambda;
     for_dir : direction_flag;
     for_body : lambda;
-    for_region : bool;     (* false if the body may locally allocate in the
-                              region containing the loop *)
   }
 
 and lambda_apply =

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -3668,6 +3668,7 @@ let rec map_return f = function
     | Lwhile _ | Lfor _ | Lassign _ | Lifused _ ) as l ->
       f l
   | Lregion (l, layout) -> Lregion (map_return f l, layout)
+  | Lexclave l -> Lexclave (map_return f l)
 
 (* The 'opt' reference indicates if the optimization is worthy.
 

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -788,17 +788,14 @@ let rec lam ppf = function
       fprintf ppf "@[<2>(if@ %a@ %a@ %a)@]" lam lcond lam lif lam lelse
   | Lsequence(l1, l2) ->
       fprintf ppf "@[<2>(seq@ %a@ %a)@]" lam l1 sequence l2
-  | Lwhile {wh_cond; wh_cond_region; wh_body; wh_body_region} ->
-      let cond_mode = if wh_cond_region then alloc_heap else alloc_local in
-      let body_mode = if wh_body_region then alloc_heap else alloc_local in
-      fprintf ppf "@[<2>(while@ %s %a@ %s %a)@]"
-        (alloc_mode cond_mode) lam wh_cond (alloc_mode body_mode) lam wh_body
-  | Lfor {for_id; for_from; for_to; for_dir; for_body; for_region} ->
-      let mode = if for_region then alloc_heap else alloc_local in
-      fprintf ppf "@[<2>(for %a@ %a@ %s@ %a@ %s %a)@]"
+  | Lwhile {wh_cond; wh_body} ->
+      fprintf ppf "@[<2>(while@ %a@ %a)@]"
+        lam wh_cond lam wh_body
+  | Lfor {for_id; for_from; for_to; for_dir; for_body} ->
+      fprintf ppf "@[<2>(for %a@ %a@ %s@ %a@ %a)@]"
        Ident.print for_id lam for_from
        (match for_dir with Upto -> "to" | Downto -> "downto")
-       lam for_to (alloc_mode mode) lam for_body
+       lam for_to lam for_body
   | Lassign(id, expr) ->
       fprintf ppf "@[<2>(assign@ %a@ %a)@]" Ident.print id lam expr
   | Lsend (k, met, obj, largs, pos, reg, _, _) ->
@@ -838,6 +835,8 @@ let rec lam ppf = function
       fprintf ppf "@[<2>(ifused@ %a@ %a)@]" Ident.print id lam expr
   | Lregion (expr, _) ->
       fprintf ppf "@[<2>(region@ %a)@]" lam expr
+  | Lexclave expr ->
+      fprintf ppf "@[<2>(exclave@ %a)@]" lam expr
 
 and sequence ppf = function
   | Lsequence(l1, l2) ->

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -668,6 +668,9 @@ let rec choice ctx t =
     | Lregion (lam, layout) ->
         let+ lam = choice ctx ~tail lam in
         Lregion (lam, layout)
+    | Lexclave lam ->
+        let+ lam = choice ctx ~tail lam in
+        Lexclave lam
 
   and choice_apply ctx ~tail apply =
     let exception No_tmc in

--- a/ocaml/lambda/transl_array_comprehension.ml
+++ b/ocaml/lambda/transl_array_comprehension.ml
@@ -459,8 +459,7 @@ let iterator ~transl_exp ~scopes ~loc
              ; for_from   = start.var
              ; for_to     = stop.var
              ; for_dir    = direction
-             ; for_body   = body
-             ; for_region = true }
+             ; for_body   = body }
       in
       mk_iterator, Range { start
                          ; stop
@@ -486,7 +485,6 @@ let iterator ~transl_exp ~scopes ~loc
              ; for_from   = l0
              ; for_to     = iter_len.var - l1
              ; for_dir    = Upto
-             ; for_region = true
              ; for_body   =
                  Matching.for_let
                    ~scopes

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -721,7 +721,7 @@ let free_methods l =
     | Lvar _ | Lmutvar _ | Lconst _ | Lapply _
     | Lprim _ | Lswitch _ | Lstringswitch _ | Lstaticraise _
     | Lifthenelse _ | Lsequence _ | Lwhile _
-    | Levent _ | Lifused _ | Lregion _ -> ()
+    | Levent _ | Lifused _ | Lregion _ | Lexclave _ -> ()
   in free l; !fv
 
 let transl_class ~scopes ids cl_id pub_meths cl vflag =

--- a/ocaml/middle_end/clambda.ml
+++ b/ocaml/middle_end/clambda.ml
@@ -97,7 +97,7 @@ and ulambda =
       * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
-  | Utail of ulambda
+  | Uexclave of ulambda
 
 and ufunction = {
   label  : function_label;

--- a/ocaml/middle_end/clambda.mli
+++ b/ocaml/middle_end/clambda.mli
@@ -108,7 +108,7 @@ and ulambda =
       * Lambda.layout list * Lambda.layout * apply_kind * Debuginfo.t
   | Uunreachable
   | Uregion of ulambda
-  | Utail of ulambda
+  | Uexclave of ulambda
 
 and ufunction = {
   label  : function_label;

--- a/ocaml/middle_end/closure/closure.ml
+++ b/ocaml/middle_end/closure/closure.ml
@@ -98,14 +98,14 @@ let region ulam =
   if is_trivial then ulam
   else Uregion ulam
 
-let tail ulam =
+let exclave ulam =
   let is_trivial =
     match ulam with
     | Uvar _ | Uconst _ -> true
     | _ -> false
   in
   if is_trivial then ulam
-  else Utail ulam
+  else Uexclave ulam
 
 (* Check if a variable occurs in a [clambda] term. *)
 
@@ -144,7 +144,7 @@ let occurs_var var u =
         occurs met || occurs obj || List.exists occurs args
     | Uunreachable -> false
     | Uregion e -> occurs e
-    | Utail e -> occurs e
+    | Uexclave e -> occurs e
   and occurs_array a =
     try
       for i = 0 to Array.length a - 1 do
@@ -259,7 +259,7 @@ let lambda_smaller lam threshold =
     | Uregion e ->
         size := !size + 2;
         lambda_size e
-    | Utail e ->
+    | Uexclave e ->
         lambda_size e
   and lambda_list_size l = List.iter lambda_size l
   and lambda_array_size a = Array.iter lambda_size a in
@@ -286,7 +286,7 @@ let rec is_pure = function
   | Ulet(Immutable, _, _var, def, body) ->
       is_pure def && is_pure body
   | Uregion body -> is_pure body
-  | Utail body -> is_pure body
+  | Uexclave body -> is_pure body
   | _ -> false
 
 (* Simplify primitive operations on known arguments *)
@@ -770,8 +770,8 @@ let rec substitute loc ((backend, fpc) as st) sb rn ulam =
       Uunreachable
   | Uregion e ->
       region (substitute loc st sb rn e)
-  | Utail e ->
-      tail (substitute loc st sb rn e)
+  | Uexclave e ->
+      exclave (substitute loc st sb rn e)
 
 type env = {
   backend : (module Backend_intf.S);
@@ -923,7 +923,7 @@ let direct_apply env fundesc ufunct uargs pos result_layout mode ~probe ~loc ~at
      let body =
        match pos with
        | Rc_normal | Rc_nontail -> body
-       | Rc_close_at_apply -> tail body
+       | Rc_close_at_apply -> exclave body
      in
      bind_params env loc fundesc params uargs ufunct body
 
@@ -1180,7 +1180,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
           let body =
             match pos with
             | Rc_normal | Rc_nontail -> body
-            | Rc_close_at_apply -> tail body
+            | Rc_close_at_apply -> exclave body
           in
           let result =
             List.fold_left2 (fun body (id, defining_expr) kind ->
@@ -1443,6 +1443,9 @@ let rec close ({ backend; fenv; cenv ; mutable_vars; kinds; catch_env } as env) 
   | Lregion (lam, _) ->
       let ulam, approx = close env lam in
       region ulam, approx
+  | Lexclave lam ->
+      let ulam, approx = close env lam in
+      exclave ulam, approx
 
 and close_list env = function
     [] -> []
@@ -1776,7 +1779,7 @@ let collect_exported_structured_constants a =
     | Usend (_, u1, u2, ul, _, _, _, _) -> ulam u1; ulam u2; List.iter ulam ul
     | Uunreachable -> ()
     | Uregion u -> ulam u
-    | Utail u -> ulam u
+    | Uexclave u -> ulam u
   in
   approx a
 

--- a/ocaml/middle_end/flambda/build_export_info.ml
+++ b/ocaml/middle_end/flambda/build_export_info.ml
@@ -260,7 +260,7 @@ let rec approx_of_expr (env : Env.t) (flam : Flambda.t) : Export_info.approx =
     end
   | Region body ->
     approx_of_expr env body
-  | Tail body ->
+  | Exclave body ->
     approx_of_expr env body
   | Assign _ -> Value_id (Env.new_unit_descr env)
   | For _ -> Value_id (Env.new_unit_descr env)

--- a/ocaml/middle_end/flambda/closure_conversion.ml
+++ b/ocaml/middle_end/flambda/closure_conversion.ml
@@ -578,6 +578,8 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
         [Simplif.simplify_lets]"
   | Lregion (body, _) ->
     Region (close t env body)
+  | Lexclave body ->
+    Exclave (close t env body)
 
 (** Perform closure conversion on a set of function declarations, returning a
     set of closures.  (The set will often only contain a single function;

--- a/ocaml/middle_end/flambda/effect_analysis.ml
+++ b/ocaml/middle_end/flambda/effect_analysis.ml
@@ -47,7 +47,7 @@ let rec no_effects (flam : Flambda.t) =
     no_effects body
   | Region body ->
     no_effects body
-  | Tail body ->
+  | Exclave body ->
     no_effects body
   | While _ | For _ | Apply _ | Send _ | Assign _ | Static_raise _ -> false
   | Proved_unreachable -> true

--- a/ocaml/middle_end/flambda/extract_projections.ml
+++ b/ocaml/middle_end/flambda/extract_projections.ml
@@ -107,7 +107,7 @@ let rec analyse_expr ~which_variables expr =
       check_free_variable from_value;
       check_free_variable to_value
     | Let _ | Let_rec _ | Static_catch _ | While _ | Try_with _
-    | Region _ | Tail _
+    | Region _ | Exclave _
     | Proved_unreachable -> ()
   in
   let for_named (named : Flambda.named) =

--- a/ocaml/middle_end/flambda/flambda.ml
+++ b/ocaml/middle_end/flambda/flambda.ml
@@ -82,7 +82,7 @@ type t =
   | While of t * t
   | For of for_loop
   | Region of t
-  | Tail of t
+  | Exclave of t
   | Proved_unreachable
 
 and named =
@@ -360,8 +360,8 @@ let rec lam ppf (flam : t) =
       Variable.print to_value lam body
   | Region body ->
     fprintf ppf "@[<2>(region@ %a)@]" lam body
-  | Tail body ->
-    fprintf ppf "@[<2>(tail@ %a)@]" lam body
+  | Exclave body ->
+    fprintf ppf "@[<2>(exclave@ %a)@]" lam body
 
 and print_named ppf (named : named) =
   match named with
@@ -635,7 +635,7 @@ let rec variables_usage ?ignore_uses_as_callee ?ignore_uses_as_argument
         List.iter free_variable args;
       | Region body ->
         aux body
-      | Tail body ->
+      | Exclave body ->
         aux body
       | Proved_unreachable -> ()
     in
@@ -836,7 +836,7 @@ let iter_general ~toplevel f f_named maybe_named =
         Option.iter aux def
       | Region body ->
         aux body
-      | Tail body ->
+      | Exclave body ->
         aux body
   and aux_named (named : named) =
     f_named named;

--- a/ocaml/middle_end/flambda/flambda.mli
+++ b/ocaml/middle_end/flambda/flambda.mli
@@ -118,7 +118,7 @@ type t =
   | While of t * t
   | For of for_loop
   | Region of t
-  | Tail of t
+  | Exclave of t
   | Proved_unreachable
 
 (** Values of type [named] will always be [let]-bound to a [Variable.t]. *)

--- a/ocaml/middle_end/flambda/flambda_invariants.ml
+++ b/ocaml/middle_end/flambda/flambda_invariants.ml
@@ -242,7 +242,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       loop env e2
     | Region e ->
       loop env e
-    | Tail e ->
+    | Exclave e ->
       loop env e
     | Proved_unreachable -> ()
   and loop_named env (named : Flambda.named) =

--- a/ocaml/middle_end/flambda/flambda_iterators.ml
+++ b/ocaml/middle_end/flambda/flambda_iterators.ml
@@ -46,7 +46,7 @@ let apply_on_subexpressions f f_named (flam : Flambda.t) =
     f f1; f f2
   | For { body; _ } -> f body
   | Region body -> f body
-  | Tail body -> f body
+  | Exclave body -> f body
 
 let rec list_map_sharing f l =
   match l with
@@ -167,12 +167,12 @@ let map_subexpressions f f_named (tree:Flambda.t) : Flambda.t =
       tree
     else
       Region new_body
-  | Tail body ->
+  | Exclave body ->
     let new_body = f body in
     if new_body == body then
       tree
     else
-      Tail new_body
+      Exclave new_body
 
 let iter_general = Flambda.iter_general
 
@@ -404,12 +404,12 @@ let map_general ~toplevel f f_named tree =
             tree
           else
             Region new_body
-        | Tail body ->
+        | Exclave body ->
           let new_body = aux body in
           if new_body == body then
             tree
           else
-            Tail new_body
+            Exclave new_body
       in
       f exp
   and aux_done_something expr done_something =

--- a/ocaml/middle_end/flambda/flambda_to_clambda.ml
+++ b/ocaml/middle_end/flambda/flambda_to_clambda.ml
@@ -438,7 +438,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
       in
       if is_trivial then body, body_layout
       else Uregion body, body_layout
-  | Tail body ->
+  | Exclave body ->
       let body, body_layout = to_clambda t env body in
       let is_trivial =
         match body with
@@ -446,7 +446,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda * Lambda.layout =
         | _ -> false
       in
       if is_trivial then body, body_layout
-      else Utail body, body_layout
+      else Uexclave body, body_layout
   | Proved_unreachable -> Uunreachable, Lambda.layout_bottom
 
 and to_clambda_named t env var (named : Flambda.named) : Clambda.ulambda * Lambda.layout =

--- a/ocaml/middle_end/flambda/flambda_utils.ml
+++ b/ocaml/middle_end/flambda/flambda_utils.ml
@@ -78,7 +78,7 @@ let description_of_toplevel_node (expr : Flambda.t) =
   | While _ -> "while"
   | For _ -> "for"
   | Region _ -> "region"
-  | Tail _ -> "tail"
+  | Exclave _ -> "exclave"
 
 let equal_direction_flag
       (x : Asttypes.direction_flag)
@@ -161,9 +161,9 @@ let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
   | Region body1, Region body2 ->
     same body1 body2
   | Region _, _ | _, Region _ -> false
-  | Tail body1, Tail body2 ->
+  | Exclave body1, Exclave body2 ->
     same body1 body2
-  | Tail _, _ | _, Tail _ -> false
+  | Exclave _, _ | _, Exclave _ -> false
   | Assign { being_assigned = being_assigned1; new_value = new_value1; },
     Assign { being_assigned = being_assigned2; new_value = new_value2; } ->
     Mutable_variable.equal being_assigned1 being_assigned2
@@ -291,7 +291,7 @@ let toplevel_substitution sb tree =
     | Static_raise (static_exn, args) ->
       let args = List.map sb args in
       Static_raise (static_exn, args)
-    | Static_catch _ | Try_with _ | While _ | Region _ | Tail _
+    | Static_catch _ | Try_with _ | While _ | Region _ | Exclave _
     | Let _ | Let_rec _ | Proved_unreachable -> flam
   in
   let aux_named (named : Flambda.named) : Flambda.named =
@@ -742,7 +742,7 @@ let substitute_read_symbol_field_for_variables
       Flambda.Send { kind; meth; obj; args; dbg; reg_close; mode; result_layout }
     | Proved_unreachable
     | Region _
-    | Tail _
+    | Exclave _
     | While _
     | Try_with _
     | Static_catch _ ->

--- a/ocaml/middle_end/flambda/inconstant_idents.ml
+++ b/ocaml/middle_end/flambda/inconstant_idents.ml
@@ -300,7 +300,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
     | Region body ->
       mark_curr curr;
       mark_loop ~toplevel [] body
-    | Tail body ->
+    | Exclave body ->
       mark_curr curr;
       mark_loop ~toplevel [] body
     | Proved_unreachable ->

--- a/ocaml/middle_end/flambda/inline_and_simplify.ml
+++ b/ocaml/middle_end/flambda/inline_and_simplify.ml
@@ -938,7 +938,7 @@ and simplify_over_application env r ~args ~args_approxs ~function_decls
   in
   let expr =
     match reg_close with
-    | Lambda.Rc_close_at_apply -> Flambda.Tail expr
+    | Lambda.Rc_close_at_apply -> Flambda.Exclave expr
     | Lambda.Rc_normal | Lambda.Rc_nontail -> expr
   in
   simplify (E.set_never_inline env) r expr
@@ -1461,10 +1461,10 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
      let r = R.set_region_use r use_outer_region in
      if use_inner_region then Region body, r
      else body, r
-  | Tail body ->
+  | Exclave body ->
      let r = R.set_region_use r true in
      let body, r = simplify env r body in
-     Tail body, r
+     Exclave body, r
   | Proved_unreachable -> tree, ret r A.value_bottom
 
 and simplify_list env r l =

--- a/ocaml/middle_end/flambda/inlining_cost.ml
+++ b/ocaml/middle_end/flambda/inlining_cost.ml
@@ -123,7 +123,7 @@ let lambda_smaller' lam ~than:threshold =
       size := !size + 4; lambda_size body
     | Region body ->
       size := !size + 2; lambda_size body
-    | Tail body ->
+    | Exclave body ->
       lambda_size body
   and lambda_named_size (named : Flambda.named) =
     if !size > threshold then raise Exit;
@@ -276,7 +276,7 @@ module Benefit = struct
     | If_then_else _ | While _ | For _ -> b := remove_branch !b
     | Apply _ | Send _ -> b := remove_call !b
     | Let _ | Let_mutable _ | Let_rec _ | Proved_unreachable | Var _
-    | Region _ | Tail _ | Static_catch _ -> ()
+    | Region _ | Exclave _ | Static_catch _ -> ()
 
   let remove_code_helper_named b (named : Flambda.named) =
     match named with

--- a/ocaml/middle_end/flambda/inlining_transforms.ml
+++ b/ocaml/middle_end/flambda/inlining_transforms.ml
@@ -133,7 +133,7 @@ let inline_by_copying_function_body ~env ~r
   in
   let body =
     match reg_close with
-    | Lambda.Rc_close_at_apply -> Flambda.Tail body
+    | Lambda.Rc_close_at_apply -> Flambda.Exclave body
     | Lambda.Rc_normal | Lambda.Rc_nontail -> body
   in
   let bindings_for_params_to_args =

--- a/ocaml/middle_end/flambda/ref_to_variables.ml
+++ b/ocaml/middle_end/flambda/ref_to_variables.ml
@@ -82,7 +82,7 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
       set := Variable.Set.union (Variable.Set.of_list args) !set
     | Region body ->
       loop body
-    | Tail body ->
+    | Exclave body ->
       loop body
     | Proved_unreachable | Apply _ | Send _ | Assign _ ->
       set := Variable.Set.union !set (Flambda.free_variables flam)
@@ -155,7 +155,7 @@ let eliminate_ref_of_expr flam =
       | Let_rec _ | Switch _ | String_switch _
       | Static_raise _ | Static_catch _
       | Try_with _ | If_then_else _
-      | While _ | For _ | Region _ | Tail _ | Send _ | Proved_unreachable ->
+      | While _ | For _ | Region _ | Exclave _ | Send _ | Proved_unreachable ->
         flam
     and aux_named (named : Flambda.named) : Flambda.named =
       match named with

--- a/ocaml/middle_end/flambda/un_anf.ml
+++ b/ocaml/middle_end/flambda/un_anf.ml
@@ -245,7 +245,7 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
       ()
     | Uregion e ->
       loop ~depth e
-    | Utail e ->
+    | Uexclave e ->
       loop ~depth e
   in
   loop ~depth:0 clam;
@@ -478,7 +478,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
     | Uregion e ->
       let_stack := [];
       loop e
-    | Utail e ->
+    | Uexclave e ->
       let_stack := [];
       loop e
   in
@@ -631,9 +631,9 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
   | Uregion e ->
     let e = substitute_let_moveable is_let_moveable env e in
     Uregion (e)
-  | Utail e ->
+  | Uexclave e ->
     let e = substitute_let_moveable is_let_moveable env e in
-    Utail (e)
+    Uexclave (e)
 
 and substitute_let_moveable_list is_let_moveable env clams =
   List.map (substitute_let_moveable is_let_moveable env) clams
@@ -860,9 +860,9 @@ let rec un_anf_and_moveable var_info env (clam : Clambda.ulambda)
   | Uregion e ->
     let e = un_anf var_info env e in
     Uregion e, Fixed
-  | Utail e ->
+  | Uexclave e ->
     let e = un_anf var_info env e in
-    Utail e, Fixed
+    Uexclave e, Fixed
 
 and un_anf var_info env clam : Clambda.ulambda =
   let clam, _moveable = un_anf_and_moveable var_info env clam in

--- a/ocaml/middle_end/printclambda.ml
+++ b/ocaml/middle_end/printclambda.ml
@@ -290,8 +290,8 @@ and lam ppf = function
       fprintf ppf "unreachable"
   | Uregion e ->
       fprintf ppf "@[<2>(region@ %a)@]" lam e
-  | Utail e ->
-      fprintf ppf "@[<2>(tail@ %a)@]" lam e
+  | Uexclave e ->
+      fprintf ppf "@[<2>(exclave@ %a)@]" lam e
 
 and sequence ppf ulam = match ulam with
   | Usequence(l1, l2) ->

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -66,7 +66,7 @@ val register_attr : attr_tracking_time -> string Location.loc -> unit
 val mark_alert_used : Parsetree.attribute -> unit
 val mark_alerts_used : Parsetree.attributes -> unit
 
-(** Properties such as [@zero_alloc] that are checked
+(** Properties such as the zero_alloc attribute that are checked
     in late stages of compilation in the backend.
     Registering them helps detect code that is not checked,
     because it is optimized away by the middle-end.  *)

--- a/ocaml/testsuite/tests/typing-local/exclave.ml
+++ b/ocaml/testsuite/tests/typing-local/exclave.ml
@@ -1,0 +1,201 @@
+(* TEST
+ * expect *)
+
+(* typing tests *)
+
+let escape x =
+  let _ = ref x in
+  ()
+[%%expect{|
+val escape : 'a -> unit = <fun>
+|}]  
+
+(* Any function ending with exclave is always typed to 
+   return local value. 
+  This is to accomadate some code in compiler that relies 
+  on the function's type to know if it allocates in caller's 
+  region. *)
+let foo () = 
+  [%exclave] (
+    let local_ y = Some 42 in 
+    y
+  )
+[%%expect{|
+val foo : unit -> local_ int option = <fun>
+|}]
+(* sidenote: in the above, 
+   y escapes the function even though local_
+   - indeed y is in the outer region!
+   *)
+
+(* Of course this applies even when the exclave returns a global value,
+  because it might still allocate in outer region
+    *)
+let foo () = 
+  [%exclave] (
+    let local_ _y = Some 42 in 
+    let x = Some 42 in 
+    let _ = escape x in 
+    x
+  )
+[%%expect{|
+val foo : unit -> local_ int option = <fun>
+|}]
+
+(* this still applies even when the exclave doesn't allocate in outer region at all,
+  because I don't know any reliable mechanisms in type checker to do that. 
+  So it's better to be safe and say that "it might allocate in outer region". *)
+let foo x =
+  [%exclave] (
+    let x = Some 42 in 
+    let _ = escape x in
+    x
+  )
+[%%expect{|
+val foo : 'a -> local_ int option = <fun>
+|}]
+
+
+(* Below we do some usual testing  *)
+let foo x =
+  [%exclave] (
+    let local_ y = None in
+    (* y is not global *)
+    ref y
+  )
+[%%expect{|
+Line 5, characters 8-9:
+5 |     ref y
+            ^
+Error: This value escapes its region
+|}]
+
+(* following we check error detection *)
+let foo x =
+  let local_ y = "foo" in
+  [%exclave] (Some y)
+[%%expect{|
+Line 3, characters 19-20:
+3 |   [%exclave] (Some y)
+                       ^
+Error: The value y is local, so cannot be used inside exclave
+|}]
+
+let foo x =
+  let local_ y = "foo" in
+  let z = [%exclave] (Some y) in
+  z
+[%%expect{|
+Line 3, characters 10-29:
+3 |   let z = [%exclave] (Some y) in
+              ^^^^^^^^^^^^^^^^^^^
+Error: Exclave expression should only be in tail position of the current region
+|}]
+
+(* following we test WHILE loop *)
+(* exclave in loop is allowed*)
+let foo () =
+  while true do
+    [%exclave] ()
+  done
+
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+(* we also require tail position *)
+let foo () =
+  while true do
+    [%exclave] ();
+    ()
+  done
+[%%expect{|
+Line 3, characters 4-17:
+3 |     [%exclave] ();
+        ^^^^^^^^^^^^^
+Error: Exclave expression should only be in tail position of the current region
+|}]
+
+(* following we test FOR loop *)
+let foo () =
+  for i = 1 to 42 do
+    [%exclave] ()
+  done
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let foo () =
+  for i = 1 to 42 do
+    [%exclave] ();
+    ()
+  done
+[%%expect{|
+Line 3, characters 4-17:
+3 |     [%exclave] ();
+        ^^^^^^^^^^^^^
+Error: Exclave expression should only be in tail position of the current region
+|}]
+
+type t = { nonlocal_ x : int option }
+
+let foo (local_ x) =
+  let __ = { x } in
+  [%exclave] x
+
+[%%expect{|
+type t = { nonlocal_ x : int option; }
+val foo : local_ int option -> local_ int option = <fun>
+|}]
+
+let foo (local_ x) =
+  let _ = { x } in
+  [%exclave] { x }
+
+[%%expect{|
+Line 3, characters 15-16:
+3 |   [%exclave] { x }
+                   ^
+Error: This local value escapes its region
+|}]
+
+(* semantics tests *)
+
+type data = {mutable a : string}
+
+let foo () =
+  let local_ x : data = {a  = "foo"} in
+  let local_ z = "hello" in
+  x.a <- z;
+  while true do
+    [%exclave] (
+      let local_ y = "hello" in
+      x.a <- y
+    )
+  done
+
+[%%expect{|
+type data = { mutable a : string; }
+Line 6, characters 9-10:
+6 |   x.a <- z;
+             ^
+Error: This value escapes its region
+|}]
+
+let foo x =
+  [%exclave] (
+    let local_ y = Some x in
+    y
+  );;
+
+let bar _ =
+  match foo 5 with
+  | None -> "None!"
+  | Some x -> "Some of " ^ (string_of_int (x + 0)) ;;
+bar ();;
+[%%expect{|
+val foo : 'a -> local_ 'a option = <fun>
+val bar : 'a -> string = <fun>
+- : string = "Some of 5"
+|}]
+

--- a/ocaml/testsuite/tests/typing-local/loop_regions.ml
+++ b/ocaml/testsuite/tests/typing-local/loop_regions.ml
@@ -20,10 +20,11 @@ let print_offsets (name,allocs) =
 let loc_for () =
   let offset_loop = ref (-1) in
   let offset1 = local_stack_offset () in
-  for i = 0 to 0 do local_
+  for i = 0 to 0 do [%exclave] (
     let z = local_ (Some (Sys.opaque_identity 42)) in
     let _ = (opaque_local z) in
     offset_loop := local_stack_offset ()
+  )
   done;
   let offset2 = local_stack_offset () in
   [offset1; !offset_loop; offset2]
@@ -45,11 +46,12 @@ let loc_while_body () =
   let offset_loop = ref (-1) in
   let offset1 = local_stack_offset () in
   let cond = ref true in
-  while !cond do local_
+  while !cond do [%exclave] (
     let z = local_ (Some (Sys.opaque_identity 42)) in
     let _ = (opaque_local z) in
     offset_loop := local_stack_offset ();
     cond := false
+  )
   done;
   let offset2 = local_stack_offset () in
   [offset1; !offset_loop; offset2]
@@ -72,11 +74,12 @@ let nonloc_while_body () =
 let loc_while_cond () =
   let offset_loop = ref (-1) in
   let offset1 = local_stack_offset () in
-  while local_
+  while [%exclave] (
     let z = local_ (Some (Sys.opaque_identity 42)) in
     let _ = (opaque_local z) in
     offset_loop := local_stack_offset ();
     false
+  )
   do
     ()
   done;
@@ -98,6 +101,33 @@ let nonloc_while_cond () =
   let offset2 = local_stack_offset () in
   [offset1; !offset_loop; offset2]
 
+
+let loc_func () =
+  let offset_func = ref (-1) in
+  let fun_exclave r =
+    [%exclave] (
+        let z = local_ (Some (Sys.opaque_identity 42)) in
+        let _ = (opaque_local z) in
+        r := local_stack_offset ()
+    ) in
+  let offset1 = local_stack_offset () in
+  fun_exclave offset_func;
+  let offset2 = local_stack_offset () in
+  [offset1; !offset_func; offset2]
+
+
+let nonloc_func () =
+  let offset_func = ref (-1) in
+  let fun_nonexclave r =
+    let z = local_ (Some (Sys.opaque_identity 42)) in
+    let _ = (opaque_local z) in
+    r := local_stack_offset ()
+  in
+  let offset1 = local_stack_offset () in
+  fun_nonexclave offset_func;
+  let offset2 = local_stack_offset () in
+  [offset1; !offset_func; offset2]
+
 let () =
   List.iter print_offsets [
     "local for",           loc_for ();
@@ -105,5 +135,7 @@ let () =
     "local while body",    loc_while_body ();
     "nonlocal while body", nonloc_while_body ();
     "local while cond",    loc_while_cond ();
-    "nonlocal while cond", nonloc_while_cond ()
+    "nonlocal while cond", nonloc_while_cond ();
+    "local func",          loc_func ();
+    "nonlocal func",       nonloc_func ();
   ]

--- a/ocaml/testsuite/tests/typing-local/loop_regions.stack.reference
+++ b/ocaml/testsuite/tests/typing-local/loop_regions.stack.reference
@@ -4,3 +4,5 @@
       nonlocal while body: [0; 2; 0]
          local while cond: [0; 2; 2]
       nonlocal while cond: [0; 2; 0]
+               local func: [0; 2; 2]
+            nonlocal func: [0; 2; 0]

--- a/ocaml/testsuite/tests/typing-local/regions.ml
+++ b/ocaml/testsuite/tests/typing-local/regions.ml
@@ -25,6 +25,16 @@ let () =
   uses_local 42;
   check_empty "function call"
 
+let[@inline never] uses_exclave x =
+  let local_ r = ref x in
+  let _ = opaque_identity r in
+  [%exclave] (
+    check_empty "cleanup upon exclave"
+  )
+let () =
+  uses_exclave 42
+
+
 let[@inline never] uses_local_try x =
   try
     let r = local_ ref x in

--- a/ocaml/testsuite/tests/typing-local/regions.reference
+++ b/ocaml/testsuite/tests/typing-local/regions.reference
@@ -1,5 +1,6 @@
                   startup: OK
             function call: OK
+     cleanup upon exclave: OK
         exn function call: OK
  during indirect tailcall: OK
   after indirect tailcall: OK

--- a/ocaml/toplevel/native/dune
+++ b/ocaml/toplevel/native/dune
@@ -12,31 +12,31 @@
 ;*                                                                        *
 ;**************************************************************************
 
-(copy_files# ../*.ml*)
-
-(library
- (name ocamltoplevel_native)
- (wrapped false)
- (modes native)
- (flags (:standard -principal))
- (libraries ocamlcommon ocamloptcomp dynlink_internal)
- (modules :standard \ topstart expunge))
-
-(executable
- (name topstart)
- (modes native)
- (flags (:standard -principal))
- (modules topstart)
- (libraries ocamltoplevel_native))
-
-(install
-  (files
-    (topstart.exe as ocamlnat)
-  )
-  (section bin)
-  (package ocaml))
-
-;
+; (copy_files# ../*.ml*)
+; 
+; (library
+;  (name ocamltoplevel_native)
+;  (wrapped false)
+;  (modes native)
+;  (flags (:standard -principal))
+;  (libraries ocamlcommon ocamloptcomp dynlink_internal)
+;  (modules :standard \ topstart expunge))
+; 
+; (executable
+;  (name topstart)
+;  (modes native)
+;  (flags (:standard -principal))
+;  (modules topstart)
+;  (libraries ocamltoplevel_native))
+; 
+; (install
+;   (files
+;     (topstart.exe as ocamlnat)
+;   )
+;   (section bin)
+;   (package ocaml))
+; 
+; 
 ; (install
 ;   (files
 ;     (ocamltoplevel.cma as compiler-libs/ocamltoplevel.cma)
@@ -63,4 +63,4 @@
 ;   )
 ;   (section lib)
 ;   (package ocaml))
-;
+; 

--- a/ocaml/toplevel/native/dune
+++ b/ocaml/toplevel/native/dune
@@ -12,31 +12,31 @@
 ;*                                                                        *
 ;**************************************************************************
 
-; (copy_files# ../*.ml*)
-; 
-; (library
-;  (name ocamltoplevel_native)
-;  (wrapped false)
-;  (modes native)
-;  (flags (:standard -principal))
-;  (libraries ocamlcommon ocamloptcomp dynlink_internal)
-;  (modules :standard \ topstart expunge))
-; 
-; (executable
-;  (name topstart)
-;  (modes native)
-;  (flags (:standard -principal))
-;  (modules topstart)
-;  (libraries ocamltoplevel_native))
-; 
-; (install
-;   (files
-;     (topstart.exe as ocamlnat)
-;   )
-;   (section bin)
-;   (package ocaml))
-; 
-; 
+(copy_files# ../*.ml*)
+
+(library
+ (name ocamltoplevel_native)
+ (wrapped false)
+ (modes native)
+ (flags (:standard -principal))
+ (libraries ocamlcommon ocamloptcomp dynlink_internal)
+ (modules :standard \ topstart expunge))
+
+(executable
+ (name topstart)
+ (modes native)
+ (flags (:standard -principal))
+ (modules topstart)
+ (libraries ocamltoplevel_native))
+
+(install
+  (files
+    (topstart.exe as ocamlnat)
+  )
+  (section bin)
+  (package ocaml))
+
+;
 ; (install
 ;   (files
 ;     (ocamltoplevel.cma as compiler-libs/ocamltoplevel.cma)
@@ -63,4 +63,4 @@
 ;   )
 ;   (section lib)
 ;   (package ocaml))
-; 
+;

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -154,7 +154,7 @@ type module_unbound_reason =
 
 type summary =
     Env_empty
-  | Env_value of summary * Ident.t * value_description
+  | Env_value of summary * Ident.t * value_description * Types.value_mode
   | Env_type of summary * Ident.t * type_declaration
   | Env_extension of summary * Ident.t * extension_constructor
   | Env_module of summary * Ident.t * module_presence * module_declaration
@@ -171,7 +171,7 @@ type summary =
 
 let map_summary f = function
     Env_empty -> Env_empty
-  | Env_value (s, id, d) -> Env_value (f s, id, d)
+  | Env_value (s, id, d, m) -> Env_value (f s, id, d, m)
   | Env_type (s, id, d) -> Env_type (f s, id, d)
   | Env_extension (s, id, d) -> Env_extension (f s, id, d)
   | Env_module (s, id, p, d) -> Env_module (f s, id, p, d)
@@ -323,6 +323,7 @@ type escaping_context =
 type value_lock =
   | Lock of { mode : Alloc_mode.t; escaping_context : escaping_context option }
   | Region_lock
+  | Exclave_lock
 
 module IdTbl =
   struct
@@ -691,6 +692,7 @@ type lookup_error =
   | Illegal_reference_to_recursive_module
   | Cannot_scrape_alias of Longident.t * Path.t
   | Local_value_used_in_closure of Longident.t * escaping_context option
+  | Local_value_used_in_exclave of Longident.t
 
 type error =
   | Missing_module of Location.t * Path.t * Path.t
@@ -1974,7 +1976,8 @@ and store_value ?check mode id addr decl shape env =
   { env with
     values = IdTbl.add id (Val_bound vda) env.values;
     summary =
-      Env_value(env.summary, id, Subst.Lazy.force_value_description decl) }
+      Env_value(env.summary, id, Subst.Lazy.force_value_description decl,
+        mode) }
 
 and store_constructor ~check type_decl type_id cstr_id cstr env =
   if check && not type_decl.type_loc.Location.loc_ghost
@@ -2351,6 +2354,9 @@ let add_lock ?escaping_context mode env =
 let add_region_lock env =
   { env with values = IdTbl.add_lock Region_lock env.values }
 
+let add_exclave_lock env =
+  { env with values = IdTbl.add_lock Exclave_lock env.values }
+
 (* Insertion of all components of a signature *)
 
 let proj_shape map mod_shape item =
@@ -2391,7 +2397,7 @@ end) = struct
     | Sig_class_type(id, decl, _, _) ->
         let map, shape = proj_shape map mod_shape (Shape.Item.class_type id) in
         map, add_cltype ?shape id decl env
-  
+
   let rec add_signature map mod_shape sg env =
     match sg with
         [] -> map, env
@@ -2400,7 +2406,7 @@ end) = struct
         add_signature map mod_shape rem env
 end
 
-let add_signature = 
+let add_signature =
   let module M = Add_signature(Types)(struct
     let add_value ?shape id vd =
       add_value_lazy ?shape id (Subst.Lazy.of_value_description vd)
@@ -2899,11 +2905,20 @@ let lock_mode ~errors ~loc env id vmode locks =
       match lock with
       | Region_lock -> Value_mode.local_to_regional vmode
       | Lock {mode; escaping_context} ->
+        begin
           match Value_mode.submode vmode (Value_mode.of_alloc mode) with
           | Ok () -> vmode
           | Error _ ->
               may_lookup_error errors loc env
-                (Local_value_used_in_closure (id, escaping_context)))
+                (Local_value_used_in_closure (id, escaping_context))
+        end
+      | Exclave_lock ->
+        match Value_mode.submode vmode Value_mode.regional with
+        | Ok () -> Value_mode.regional_to_local vmode
+        | Error _ ->
+          may_lookup_error errors loc env
+            (Local_value_used_in_exclave id);
+    )
     vmode locks
 
 let lookup_ident_value ~errors ~use ~loc name env =
@@ -3784,6 +3799,10 @@ let report_lookup_error _loc env ppf = function
                           is an argument to a tail call@]"
       | _ -> ()
       end
+  | Local_value_used_in_exclave lid ->
+    fprintf ppf "@[The value %a is local, so cannot be used \
+                 inside exclave @]"
+      !print_longident lid
 
 let report_error ppf = function
   | Missing_module(_, path1, path2) ->

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -34,7 +34,7 @@ type module_unbound_reason =
 
 type summary =
     Env_empty
-  | Env_value of summary * Ident.t * value_description
+  | Env_value of summary * Ident.t * value_description * Types.value_mode
   | Env_type of summary * Ident.t * type_declaration
   | Env_extension of summary * Ident.t * extension_constructor
   | Env_module of summary * Ident.t * module_presence * module_declaration
@@ -198,6 +198,7 @@ type lookup_error =
   | Illegal_reference_to_recursive_module
   | Cannot_scrape_alias of Longident.t * Path.t
   | Local_value_used_in_closure of Longident.t * escaping_context option
+  | Local_value_used_in_exclave of Longident.t
 
 val lookup_error: Location.t -> t -> lookup_error -> 'a
 
@@ -395,6 +396,7 @@ val enter_unbound_module : string -> module_unbound_reason -> t -> t
 
 val add_lock : ?escaping_context:escaping_context -> Types.alloc_mode -> t -> t
 val add_region_lock : t -> t
+val add_exclave_lock : t -> t
 
 (* Initialize the cache of in-core module interfaces. *)
 val reset_cache: preserve_persistent_env:bool -> unit

--- a/ocaml/typing/envaux.ml
+++ b/ocaml/typing/envaux.ml
@@ -36,12 +36,12 @@ let rec env_from_summary sum subst =
       match sum with
         Env_empty ->
           Env.empty
-      | Env_value(s, id, desc) ->
+      | Env_value(s, id, desc, mode) ->
           let desc =
             Subst.Lazy.of_value_description desc
             |> Subst.Lazy.value_description subst
           in
-          Env.add_value_lazy id desc (env_from_summary s subst)
+          Env.add_value_lazy ~mode id desc (env_from_summary s subst)
       | Env_type(s, id, desc) ->
           Env.add_type ~check:false id
             (Subst.type_declaration subst desc)
@@ -57,7 +57,7 @@ let rec env_from_summary sum subst =
           Env.add_module_declaration_lazy ~update_summary:true id pres desc
             (env_from_summary s subst)
       | Env_modtype(s, id, desc) ->
-          let desc = 
+          let desc =
             Subst.Lazy.modtype_decl Keep subst (Subst.Lazy.of_modtype_decl desc)
           in
           Env.add_modtype_lazy ~update_summary:true id desc

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -436,18 +436,15 @@ and expression i ppf x =
       line i ppf "Texp_sequence\n";
       expression i ppf e1;
       expression i ppf e2;
-  | Texp_while {wh_cond; wh_cond_region; wh_body; wh_body_region} ->
+  | Texp_while {wh_cond; wh_body} ->
       line i ppf "Texp_while\n";
-      line i ppf "cond_region %b\n" wh_cond_region;
       expression i ppf wh_cond;
-      line i ppf "body_region %b\n" wh_body_region;
       expression i ppf wh_body;
-  | Texp_for {for_id; for_from; for_to; for_dir; for_body; for_region} ->
+  | Texp_for {for_id; for_from; for_to; for_dir; for_body} ->
       line i ppf "Texp_for \"%a\" %a\n"
         fmt_ident for_id fmt_direction_flag for_dir;
       expression i ppf for_from;
       expression i ppf for_to;
-      line i ppf "region %b\n" for_region;
       expression i ppf for_body
   | Texp_send (e, Tmeth_name s, _, am) ->
       line i ppf "Texp_send \"%s\"\n" s;
@@ -508,6 +505,9 @@ and expression i ppf x =
       expression i ppf handler;
   | Texp_probe_is_enabled {name} ->
       line i ppf "Texp_probe_is_enabled \"%s\"\n" name;
+  | Texp_exclave (e) ->
+      line i ppf "Texp_exclave";
+      expression i ppf e;
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_ident x.val_id fmt_location

--- a/ocaml/typing/rec_check.ml
+++ b/ocaml/typing/rec_check.ml
@@ -154,7 +154,8 @@ let classify_expression : Typedtree.expression -> sd =
     | Texp_open (_, e)
     | Texp_letmodule (_, _, _, _, e)
     | Texp_sequence (_, e)
-    | Texp_letexception (_, e) ->
+    | Texp_letexception (_, e)
+    | Texp_exclave e ->
         classify_expression env e
 
     | Texp_construct (_, {cstr_tag = Cstr_unboxed}, [e], _) ->
@@ -836,6 +837,7 @@ let rec expression : Typedtree.expression -> term_judg =
     | Texp_probe {handler} ->
       expression handler << Dereference
     | Texp_probe_is_enabled _ -> empty
+    | Texp_exclave e -> expression e
 
 and comprehension_clauses clauses =
   List.concat_map

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -295,6 +295,7 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
       sub.expr sub e
   | Texp_probe {handler;_} -> sub.expr sub handler
   | Texp_probe_is_enabled _ -> ()
+  | Texp_exclave exp -> sub.expr sub exp
 
 
 let package_type sub {pack_fields; _} =

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -370,8 +370,8 @@ let expr sub x =
           sub.expr sub exp2
         )
     | Texp_while wh ->
-        Texp_while { wh with wh_cond = sub.expr sub wh.wh_cond;
-                             wh_body = sub.expr sub wh.wh_body
+        Texp_while { wh_cond = sub.expr sub wh.wh_cond;
+                     wh_body = sub.expr sub wh.wh_body
                    }
     | Texp_for tf ->
         Texp_for {tf with for_from = sub.expr sub tf.for_from;
@@ -438,6 +438,8 @@ let expr sub x =
     | Texp_probe {name; handler} ->
       Texp_probe {name; handler = sub.expr sub handler }
     | Texp_probe_is_enabled _ as e -> e
+    | Texp_exclave exp ->
+        Texp_exclave (sub.expr sub exp)
   in
   {x with exp_extra; exp_desc; exp_env}
 

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -186,6 +186,7 @@ type error =
   | Function_returns_local
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
   | Optional_poly_param
+  | Exclave_in_nontail_position
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -273,10 +274,20 @@ let mk_expected ?explanation ty = { ty; explanation; }
 let case lhs rhs =
   {c_lhs = lhs; c_guard = None; c_rhs = rhs}
 
-type mode_position = Tail | Nontail
+type function_position = Tail | Nontail
+
+
+type region_position =
+  (* not the tail of a region*)
+  | RNontail
+  (* tail of a region,
+     together with the mode of that region,
+     and whether it is also the tail of a function
+     (for tail call escape detection) *)
+  | RTail of Value_mode.t * function_position
 
 type expected_mode =
-  { position : mode_position;
+  { position : region_position;
     escaping_context : Env.escaping_context option;
     (* the upper bound of mode*)
     mode : Value_mode.t;
@@ -301,35 +312,51 @@ type expected_mode =
     (* for t in tuple_modes, t <= regional_to_global mode *)
   }
 
+let tail_call_escape = function
+  | RTail (_, Tail) -> true
+  | _ -> false
+
 let apply_position env (expected_mode : expected_mode) sexp : apply_position =
   let fail err =
     raise (Error (sexp.pexp_loc, env, Bad_tail_annotation err))
   in
   match
     Builtin_attributes.tailcall sexp.pexp_attributes,
-    expected_mode.position
+    tail_call_escape expected_mode.position
   with
-  | Ok (None | Some `Tail_if_possible), Nontail -> Default
-  | Ok (None | Some `Tail | Some `Tail_if_possible), Tail -> Tail
+  | Ok (None | Some `Tail_if_possible), false  -> Default
+  | Ok (None | Some `Tail | Some `Tail_if_possible), true -> Tail
   | Ok (Some `Nontail), _ -> Nontail
-  | Ok (Some `Tail), Nontail -> fail `Not_a_tailcall
+  | Ok (Some `Tail), false -> fail `Not_a_tailcall
   | Error `Conflict, _ -> fail `Conflict
 
 let mode_default mode =
-  { position = Nontail;
+  { position = RNontail;
     escaping_context = None;
     mode = mode;
     exact = false;
     tuple_modes = [] }
 
+(* used when entering a function;
+mode is the mode of the function region *)
 let mode_return mode =
-  { (mode_default mode) with
-    position = Tail;
+  { (mode_default (Value_mode.local_to_regional mode)) with
+    position = RTail (mode, Tail);
     escaping_context = Some Return;
+  }
+
+(* used when entering a region.*)
+let mode_region mode =
+  { (mode_default (Value_mode.local_to_regional mode)) with
+    position = RTail (mode, Nontail);
+    escaping_context = None;
   }
 
 let mode_local =
   mode_default Value_mode.local
+
+let mode_local_with_position position =
+  { mode_local with position }
 
 let mode_global =
   mode_default Value_mode.global
@@ -361,7 +388,7 @@ let mode_partial_application expected_mode =
 
 
 let mode_trywith expected_mode =
-  { expected_mode with position = Nontail }
+  { expected_mode with position = RNontail }
 
 let mode_tuple mode tuple_modes =
   { (mode_default mode) with
@@ -380,7 +407,8 @@ let mode_argument ~funct ~index ~position ~partial_app alloc_mode =
                 Id_prim _), 1, Tail ->
      (* The second argument to (&&) and (||) is in
         tail position if the call is *)
-     mode_return (Value_mode.local_to_regional vmode)
+      (* vmode is wrong; fine because of mode crossing on boolean *)
+     mode_return vmode
   | Texp_ident (_, _, _, Id_prim _), _, _ ->
      (* Other primitives cannot be tail-called *)
      mode_default vmode
@@ -391,7 +419,7 @@ let mode_argument ~funct ~index ~position ~partial_app alloc_mode =
 
 let mode_lazy =
   { mode_global with
-    position = Tail }
+    position = RTail (Value_mode.global, Tail) }
 
 
 let submode ~loc ~env ~reason mode expected_mode =
@@ -3185,6 +3213,7 @@ let rec is_nonexpansive exp =
   | Texp_letop _
   | Texp_extension_constructor _ ->
     false
+  | Texp_exclave e -> is_nonexpansive e
 
 and is_nonexpansive_mod mexp =
   match mexp.mod_desc with
@@ -3614,7 +3643,8 @@ let check_partial_application ~statement exp =
             | Texp_ifthenelse (_, e1, Some e2) ->
                 check e1; check e2
             | Texp_let (_, _, e) | Texp_sequence (_, e) | Texp_open (_, e)
-            | Texp_letexception (_, e) | Texp_letmodule (_, _, _, _, e) ->
+            | Texp_letexception (_, e) | Texp_letmodule (_, _, _, _, e)
+            | Texp_exclave e ->
                 check e
             | Texp_apply _ | Texp_send _ | Texp_new _ | Texp_letop _ ->
                 Location.prerr_warning exp_loc
@@ -4143,6 +4173,36 @@ and type_expect_
           ty_expected_explained
       in
       { exp with exp_loc = loc }
+  | Pexp_apply
+      ({ pexp_desc = Pexp_extension({
+         txt = "extension.exclave" | "ocaml.exclave" | "exclave" as txt}, PStr []) },
+       [Nolabel, sbody]) ->
+      if (txt = "extension.exclave") && not (Language_extension.is_enabled Local) then
+          raise (Typetexp.Error (loc, Env.empty, Unsupported_extension Local));
+      begin
+        match expected_mode.position with
+        | RNontail ->
+          raise (Error (loc, env, Exclave_in_nontail_position))
+        | RTail (mode, _) ->
+          (* mode' is RNontail, because currently our language cannot construct
+             region in the tail of another region.*)
+          let mode' = mode_default mode in
+          (* The middle-end relies on all functions which allocate into their
+             parent's region having a return mode of local. *)
+          submode ~loc ~env ~reason:Other Value_mode.local mode';
+          let new_env = Env.add_exclave_lock env in
+          let exp =
+            type_expect ?in_function ~recarg new_env mode' sbody ty_expected_explained
+          in
+          submode ~loc ~env ~reason:Other Value_mode.regional expected_mode;
+          { exp_desc = Texp_exclave exp;
+            exp_loc = loc;
+            exp_extra = [];
+            exp_type = exp.exp_type;
+            exp_env = env;
+            exp_attributes = sexp.pexp_attributes;
+          }
+      end
   | Pexp_apply(sfunct, sargs) ->
       assert (sargs <> []);
       let position = apply_position env expected_mode sexp in
@@ -4613,50 +4673,45 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_while(scond, sbody) ->
-      let cond_env,wh_cond_region =
-        if is_local_returning_expr scond then env, false
-        else Env.add_region_lock env, true
-      in
+      let cond_env = Env.add_region_lock env in
+      let mode = mode_region Value_mode.local in
       let wh_cond =
-        type_expect cond_env mode_local scond
+        type_expect cond_env mode scond
           (mk_expected ~explanation:While_loop_conditional Predef.type_bool)
       in
-      let body_env,wh_body_region =
-        if is_local_returning_expr sbody then env, false
-        else Env.add_region_lock env, true
-      in
+      let body_env = Env.add_region_lock env in
+      let position = RTail (Value_mode.local, Nontail) in
       let wh_body =
-        type_statement ~explanation:While_loop_body body_env sbody
+        type_statement ~explanation:While_loop_body
+          ~position body_env sbody
       in
       rue {
         exp_desc =
-          Texp_while {wh_cond; wh_cond_region; wh_body; wh_body_region};
+          Texp_while {wh_cond; wh_body};
         exp_loc = loc; exp_extra = [];
         exp_type = instance Predef.type_unit;
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_for(param, slow, shigh, dir, sbody) ->
       let for_from =
-        type_expect env mode_local slow
+        type_expect env (mode_region Value_mode.local) slow
           (mk_expected ~explanation:For_loop_start_index Predef.type_int)
       in
       let for_to =
-        type_expect env mode_local shigh
+        type_expect env (mode_region Value_mode.local) shigh
           (mk_expected ~explanation:For_loop_stop_index Predef.type_int)
       in
       let for_id, new_env =
         type_for_loop_index ~loc ~env ~param
       in
-      let new_env, for_region =
-        if is_local_returning_expr sbody then new_env, false
-        else Env.add_region_lock new_env, true
-      in
+      let new_env = Env.add_region_lock new_env in
+      let position = RTail (Value_mode.local, Nontail) in
       let for_body =
-        type_statement ~explanation:For_loop_body new_env sbody
+        type_statement ~explanation:For_loop_body ~position new_env sbody
       in
       rue {
         exp_desc = Texp_for {for_id; for_pat = param; for_from; for_to;
-                             for_dir = dir; for_body; for_region};
+                             for_dir = dir; for_body};
         exp_loc = loc; exp_extra = [];
         exp_type = instance Predef.type_unit;
         exp_attributes = sexp.pexp_attributes;
@@ -5497,7 +5552,7 @@ and type_function ?in_function loc attrs env (expected_mode : expected_mode)
     else begin
       let ret_value_mode = Value_mode.of_alloc ret_mode in
       let ret_value_mode =
-        if region_locked then mode_return (Value_mode.local_to_regional ret_value_mode)
+        if region_locked then mode_return ret_value_mode
         else begin
           match Alloc_mode.submode Alloc_mode.local ret_mode with
           | Ok () -> mode_local
@@ -6329,9 +6384,9 @@ and type_construct env (expected_mode : expected_mode) loc lid sarg
 
 (* Typing of statements (expressions whose values are discarded) *)
 
-and type_statement ?explanation env sexp =
+and type_statement ?explanation ?(position=RNontail) env sexp =
   begin_def();
-  let exp = type_exp env mode_local sexp in
+  let exp = type_exp env (mode_local_with_position position) sexp in
   end_def();
   let ty = expand_head env exp.exp_type and tv = newvar() in
   if is_Tvar ty && get_level ty > get_level tv then
@@ -7929,6 +7984,9 @@ let report_error ~loc env = function
         (match err with
          | `Conflict -> "is contradictory"
          | `Not_a_tailcall -> "is not on a tail call")
+  | Exclave_in_nontail_position ->
+    Location.errorf ~loc
+        "Exclave expression should only be in tail position of the current region"
   | Optional_poly_param ->
       Location.errorf ~loc
         "Optional parameters cannot be polymorphic"

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -264,6 +264,7 @@ type error =
   | Function_returns_local
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
   | Optional_poly_param
+  | Exclave_in_nontail_position
 
 
 exception Error of Location.t * Env.t * error

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -136,9 +136,7 @@ and expression_desc =
   | Texp_sequence of expression * expression
   | Texp_while of {
       wh_cond : expression;
-      wh_cond_region : bool;
       wh_body : expression;
-      wh_body_region : bool
     }
   | Texp_for of {
       for_id  : Ident.t;
@@ -147,7 +145,6 @@ and expression_desc =
       for_to   : expression;
       for_dir  : direction_flag;
       for_body : expression;
-      for_region : bool;
     }
   | Texp_send of expression * meth * apply_position * Types.alloc_mode
   | Texp_new of
@@ -176,6 +173,7 @@ and expression_desc =
   | Texp_open of open_declaration * expression
   | Texp_probe of { name:string; handler:expression; }
   | Texp_probe_is_enabled of { name:string }
+  | Texp_exclave of expression
 
 and ident_kind = Id_value | Id_prim of Types.alloc_mode option
 

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -293,9 +293,7 @@ and expression_desc =
   | Texp_sequence of expression * expression
   | Texp_while of {
       wh_cond : expression;
-      wh_cond_region : bool; (* False means allocates in outer region *)
       wh_body : expression;
-      wh_body_region : bool  (* False means allocates in outer region *)
     }
   | Texp_for of {
       for_id  : Ident.t;
@@ -304,9 +302,6 @@ and expression_desc =
       for_to   : expression;
       for_dir  : direction_flag;
       for_body : expression;
-      for_region : bool;
-      (* for_region = true means we create a region for the body.  false means
-         it may allocated in the containing region *)
     }
   | Texp_send of expression * meth * apply_position * Types.alloc_mode
     (** [alloc_mode] is the allocation mode of the result *)
@@ -337,6 +332,7 @@ and expression_desc =
         (** let open[!] M in e *)
   | Texp_probe of { name:string; handler:expression; }
   | Texp_probe_is_enabled of { name:string }
+  | Texp_exclave of expression
 
 and ident_kind = Id_value | Id_prim of Types.alloc_mode option
 

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -604,6 +604,16 @@ let expression sub exp =
                      , [])
                ; pstr_loc = loc
                }]))
+    | Texp_exclave exp ->
+        Pexp_apply ({
+        pexp_desc =
+          Pexp_extension
+            ({ txt = "ocaml.exclave"; loc}
+            , PStr []);
+        pexp_loc = loc;
+        pexp_loc_stack = [];
+        pexp_attributes = [];
+      }, [Nolabel, sub.expr sub exp])
   in
   List.fold_right (exp_extra sub) exp.exp_extra
     (Exp.mk ~loc ~attrs desc)


### PR DESCRIPTION
I took the `Lexclave` implementation for flambda2 from #1313 , but I've left out the support for this construct directly under a `let rec` for now.  That can be done subsequently in a rebased version of the above PR.