### PR TITLE
zero_alloc: always compute summaries

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -551,6 +551,7 @@ end = struct
         Builtin_attributes.mark_property_checked analysis_name
           (Annotation.get_loc a);
         if (not (Annotation.is_assume a))
+           && S.enabled ()
            && not
                 (Value.lessequal func_info.value (Annotation.expected_value a))
         then
@@ -570,10 +571,8 @@ end = struct
     Unit_info.iter unit_info ~f:record
 
   let record_unit unit_info ppf =
-    if S.enabled ()
-    then
-      Profile.record_call ~accumulate:true ("record_unit " ^ analysis_name)
-        (fun () -> record_unit unit_info ppf)
+    Profile.record_call ~accumulate:true ("record_unit " ^ analysis_name)
+      (fun () -> record_unit unit_info ppf)
 
   let update_deps t v dep desc dbg =
     match dep with
@@ -802,8 +801,7 @@ end = struct
         Unit_info.cleanup_deps unit_info fun_name;
         report_unit_info ppf unit_info ~msg:"after cleanup_deps"
     in
-    if S.enabled ()
-    then Profile.record_call ~accumulate:true ("check " ^ analysis_name) check
+    Profile.record_call ~accumulate:true ("check " ^ analysis_name) check
 end
 
 (** Check that functions do not allocate on the heap (local allocations are ignored) *)

--- a/backend/checks.ml
+++ b/backend/checks.ml
@@ -14,13 +14,11 @@ let reset t =
   t.enabled <- false
 
 let merge src ~into:dst =
-  if !Clflags.zero_alloc_check
-  then (
-    let join key b1 b2 =
-      Misc.fatal_errorf "Unexpected merge %s %d %d" key b1 b2
-    in
-    dst.zero_alloc <- String.Map.union join dst.zero_alloc src.zero_alloc;
-    dst.enabled <- dst.enabled || src.enabled)
+  let join key b1 b2 =
+    Misc.fatal_errorf "Unexpected merge %s %d %d" key b1 b2
+  in
+  dst.zero_alloc <- String.Map.union join dst.zero_alloc src.zero_alloc;
+  dst.enabled <- dst.enabled || src.enabled
 
 type value = int option
 


### PR DESCRIPTION
Always run  `Checkmach` analysis to compute sumaries needed for checking `zero_alloc` assertions and store the summaries in cmx files.  

Use `Clflags.zero_alloc_check` for assertion checking only, not for computing summaries.   Currently, `-zero-alloc-flag` flag does  both. This PR proposes to change the meaning  of `-zero-alloc-check`  because the overhead of always having summaries is low (to be confirmed on a large build). Having summaries makes it easy to turn the check on for a particular file or library, because there is no need to rebuild its dependencies.


