### PR TITLE
Access the current unit's module block via a Cmm variable

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -153,7 +153,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     fail_if_probe apply;
     let callee =
       match Simple.must_be_symbol callee_simple with
-      | Some (sym, _) -> (To_cmm_result.symbol res sym).sym_name
+      | Some (sym, _) -> (To_cmm_result.symbol_definition res sym).sym_name
       | None ->
         Misc.fatal_errorf "Expected a function symbol instead of:@ %a"
           Simple.print callee_simple

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -31,7 +31,10 @@ type t
 val create : module_symbol:Symbol.t -> reachable_names:Name_occurrences.t -> t
 
 (** Translate an existing [Symbol.t] to a Cmm symbol. *)
-val symbol : t -> Symbol.t -> Cmm.symbol
+val symbol_definition : t -> Symbol.t -> Cmm.symbol
+
+(** Translate a reference to an existing [Symbol.t] to Cmm. *)
+val symbol : t -> Debuginfo.t -> Symbol.t -> Cmm.expression
 
 (** Produce the Cmm function symbol for a piece of code. *)
 val symbol_of_code_id : t -> Code_id.t -> Cmm.symbol
@@ -60,8 +63,13 @@ val add_gc_roots : t -> Symbol.t list -> t
 val add_function : t -> Cmm.fundecl -> t
 
 (** Record the given symbol as having been defined. This is used to keep track
-    of whether the module block symbol for the current unit has been defined. *)
+    of whether the module block symbol for the current unit has been defined.
+    If this function is supplied with the module block symbol then it will
+    return [Some global_sym] where [global_sym] is the global alias to the
+    module block.  Other calls to [symbol] will return the local alias. *)
 val check_for_module_symbol : t -> Symbol.t -> t
+
+val module_block_var : t -> Backend_var.t
 
 (** Caching of symbols associated with [Invalid] messages. *)
 val add_invalid_message_symbol : t -> Symbol.t -> message:string -> t

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -190,7 +190,9 @@ end = struct
           let function_symbol =
             Function_slot.Map.find function_slot closure_symbols
           in
-          List.rev_append (P.define_symbol (R.symbol res function_symbol)) acc
+          List.rev_append
+            (P.define_symbol (R.symbol_definition res function_symbol))
+            acc
       in
       (* We build here the **reverse** list of fields for the function slot *)
       match closure_code_pointers with
@@ -448,7 +450,8 @@ let let_static_set_of_closures0 env res closure_symbols
     with
     | Some (function_slot_offset, function_slot) -> (
       match Function_slot.Map.find function_slot closure_symbols with
-      | closure_symbol -> function_slot_offset, R.symbol res closure_symbol
+      | closure_symbol ->
+        function_slot_offset, R.symbol_definition res closure_symbol
       | exception Not_found ->
         Misc.fatal_errorf "No closure symbol for function slot %a"
           Function_slot.print function_slot)
@@ -537,7 +540,8 @@ let lift_set_of_closures env res ~body ~bound_vars layout set ~translate_expr
         let v = Bound_var.var v in
         let sym =
           C.symbol ~dbg
-            (R.symbol res (Function_slot.Map.find cid closure_symbols))
+            (R.symbol_definition res
+               (Function_slot.Map.find cid closure_symbols))
         in
         Env.bind_variable env res v ~defining_expr:sym
           ~free_vars_of_defining_expr:Backend_var.Set.empty

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -109,13 +109,13 @@ let name0 ?consider_inlining_effectful_expressions env res name =
       To_cmm_env.inline_variable ?consider_inlining_effectful_expressions env
         res v)
     ~symbol:(fun s ->
-      let sym = To_cmm_result.symbol res s in
+      let cmm = To_cmm_result.symbol res Debuginfo.none s in
       (* CR mshinwell: fix debuginfo? *)
       To_cmm_env.
         { env;
           res;
           expr =
-            { cmm = symbol ~dbg:Debuginfo.none sym;
+            { cmm;
               free_vars = Backend_var.Set.empty;
               effs = Ece.pure_can_be_duplicated
             }
@@ -151,7 +151,8 @@ let simple ?consider_inlining_effectful_expressions ~dbg env res s =
 let name_static res name =
   Name.pattern_match name
     ~var:(fun v -> `Var v)
-    ~symbol:(fun s -> `Data [symbol_address (To_cmm_result.symbol res s)])
+    ~symbol:(fun s ->
+      `Data [symbol_address (To_cmm_result.symbol_definition res s)])
 
 let const_static cst =
   match Reg_width_const.descr cst with
@@ -212,7 +213,7 @@ let invalid res ~message =
       in
       let res =
         Cmm_helpers.emit_string_constant
-          (To_cmm_result.symbol res message_sym)
+          (To_cmm_result.symbol_definition res message_sym)
           message []
         |> To_cmm_result.add_archive_data_items res
       in
@@ -225,7 +226,7 @@ let invalid res ~message =
   let call_expr =
     extcall ~dbg ~alloc:false ~is_c_builtin:false ~returns:false ~ty_args:[XInt]
       "caml_flambda2_invalid" Cmm.typ_void
-      [symbol ~dbg (To_cmm_result.symbol res message_sym)]
+      [symbol ~dbg (To_cmm_result.symbol_definition res message_sym)]
   in
   call_expr, res
 


### PR DESCRIPTION
We've noted that disabling CSE for module initialisers causes a large increase in the number of relocations, which is likely to adversely affect linking times.  This was spotted in the context of #1325 on Closure builds.  The problem arises because every reference (via `Cconst_symbol`) to the module block results in a relocation.  Changing the symbols to local or something like that won't help, because these are accesses across sections.

Flambda 2 was disabling CSE for these entry functions even prior to the above PR.  Here is an idea to improve the situation: when accessing the current module block, do so via a Cmm variable, which is bound at the top of the entry function.  This produces only one relocation.  It probably won't do as well as CSE since it doesn't deal with repeated accesses to other module blocks that might occur during an entry function, but it might produce a decent improvement.  We'll do some benchmarking.