### PR TITLE
Zero_alloc: more precise handling of caml_flambda2_invalid

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -724,7 +724,7 @@ end = struct
     | Iextcall { alloc = false; returns = false; _ } ->
       (* Sound to ignore [next] and [exn] because the call never returns or
          raises. *)
-      Value.normal_return
+      Value.bot
     | Iextcall { func; alloc = true; _ } ->
       transform t ~next ~exn ~effect:Value.top ("external call to " ^ func) dbg
     | Ispecific s ->


### PR DESCRIPTION
After `Iextcall { alloc = false; returns = false; _ }`, the execution never reaches normal or exceptional exits, so `Value.normal` is too conservative. It leads to the "relaxed" check failure when compiled with Flambda2 on some functions that only allocate on an exception return (for example, [`Iobuf.fail`](https://github.com/janestreet/core_kernel/blob/master/iobuf/src/iobuf.ml#L56-L65) ).

Looks like the only way to get the above `Iextcall` is with Flambda2 for `caml_flambda2_invalid`.  I don't know how to write a small test that triggers it.
