### PR TITLE
zero_alloc: more precise treatment of Iexit labels

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -767,9 +767,8 @@ end = struct
        To check divergent loops, the initial value of "div" component of all
        Iexit labels is set to "Safe" instead of "Bot". This is conservative with
        respect to non-recursive Icatch and Itrywith handlers. *)
-    D.analyze ~exnescape:Value.exn_escape ~init_lbl:Value.diverges ~transfer
-      body
-    |> fst
+    let init_lbl ~rc _ = if rc then Value.diverges else Value.bot in
+    D.analyze ~exnescape:Value.exn_escape ~init_lbl ~transfer body |> fst
 
   let fundecl (f : Mach.fundecl) ~future_funcnames unit_info ppf =
     let check () =

--- a/backend/dataflow.ml
+++ b/backend/dataflow.ml
@@ -24,13 +24,19 @@ end
 
 module Backward(D: DOMAIN) = struct
 
-let analyze ?(exnhandler = fun x -> x) ?(exnescape = D.bot) ?(init_lbl = D.bot)
+let analyze ?(exnhandler = fun x -> x) ?(exnescape = D.bot)
+      ?(init_lbl = (fun ~rc:_ _ -> D.bot))
       ~transfer instr =
 
   let lbls =
     (Hashtbl.create 20 : (int, D.t) Hashtbl.t) in
+  let rc_lbls =
+    (Hashtbl.create 1 : (int, unit) Hashtbl.t) in
+  let add_rc_lbl n =
+    if not (Hashtbl.mem rc_lbls n) then Hashtbl.add rc_lbls n () in
+  let init_lbl n = init_lbl ~rc:(Hashtbl.mem rc_lbls n) n in
   let get_lbl n =
-    match Hashtbl.find_opt lbls n with None -> init_lbl | Some b -> b
+    match Hashtbl.find_opt lbls n with None -> init_lbl n | Some b -> b
   and set_lbl n x =
     Hashtbl.replace lbls n x in
 
@@ -72,6 +78,7 @@ let analyze ?(exnhandler = fun x -> x) ?(exnescape = D.bot) ?(init_lbl = D.bot)
                  set_lbl n (before bx exnh h))
             handlers
         | Cmm.Recursive ->
+            List.iter (fun (n, _, _) -> add_rc_lbl n) handlers;
             let update changed (n, trap_stack, h) =
               let b0 = get_lbl n in
               let exnh = exn_from_trap_stack exn trap_stack in

--- a/backend/dataflow.mli
+++ b/backend/dataflow.mli
@@ -29,7 +29,7 @@ module Backward(D: DOMAIN) : sig
 
   val analyze: ?exnhandler: (D.t -> D.t) ->
                ?exnescape: D.t ->
-               ?init_lbl: D.t ->
+               ?init_lbl: (rc:bool -> int -> D.t) ->
                transfer: (Mach.instruction -> next: D.t -> exn: D.t -> D.t) ->
                Mach.instruction ->
                D.t * (int -> D.t)


### PR DESCRIPTION
`Checkmach` is too conservative about the value of `init_lbl` passed to `Dataflow.analyze` to handle loops. The "div" component of `init_lbl` should be initialized to "Safe" only for recursive catch handler labels. It can be initialized to `Bot` for other labels. This PR precomputes the precomputes set of labels, inside Dataflow. 

The parameter  `init_lbl` becomes a function that takes a label and a boolean whether this label is from a recursive catch handler. It's safe because `add_rc_lbl n` is always called before `get_lbl n` for the same label `n`. The overhead of keeping track of `rc` is low. 

An alternative to changing `Dataflow` is to run a preprocessing pass in `Checkmach` to find all `rc` labels before calling `Dataflow.analyze`.  This way, `init_lbl` would be simply `init_lbl : int -> D.t` without the extra `rc` argument, which is nice, but I prefer the other approach to avoid code duplication (traversing the IR to collect the labels).
