### PR TITLE
Remove closure from Array.for_all

### DIFF
--- a/ocaml/stdlib/array.ml
+++ b/ocaml/stdlib/array.ml
@@ -199,12 +199,12 @@ let exists p a =
   loop 0
 
 let for_all p a =
-  let n = length a in
+  (* take [n], [p], and [a] as parameters to avoid a closure allocation *)
   let rec loop n p a i =
     if i = n then true
     else if p (unsafe_get a i) then loop n p a (succ i)
     else false in
-  loop n p a 0
+  loop (length a) p a 0
 
 let for_all2 p l1 l2 =
   let n1 = length l1

--- a/ocaml/stdlib/array.ml
+++ b/ocaml/stdlib/array.ml
@@ -200,11 +200,11 @@ let exists p a =
 
 let for_all p a =
   let n = length a in
-  let rec loop i =
+  let rec loop n p a i =
     if i = n then true
-    else if p (unsafe_get a i) then loop (succ i)
+    else if p (unsafe_get a i) then loop n p a (succ i)
     else false in
-  loop 0
+  loop n p a 0
 
 let for_all2 p l1 l2 =
   let n1 = length l1


### PR DESCRIPTION
This leads to a 7.4% (!) reduction in allocations in one test.

This is surely a good thing, but I'm not sure that this commit is really the right way to fix the problem.

* There are many stdlib functions, and this commit optimizes only one. It turns out that this one makes a very big difference, but it's awkward to have a stdlib that is normally happy to allocate closures except in this one case.
* What's the upstreaming story? Do we want to remove closures from the stdlib for everyone?
* Maybe we should just have our own for_all in e.g. Misc.Stdlib.Array. That would work. But it would be easy not to know about that and use the stdlib one.
* It's a small shame the optimizer doesn't fix this on its own.

So I don't really know what's best here. Of course, we can merge this commit (there's nothing wrong with it, and it's a big improvement!) while we debate.