### PR TITLE
Reduce allocations through a few tricks

### DIFF
--- a/ocaml/typing/btype.ml
+++ b/ocaml/typing/btype.ml
@@ -471,7 +471,7 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
 
-  val with_scope: (copy_scope -> 'a) -> 'a
+  val with_scope: ((copy_scope -> 'a)[@local]) -> 'a
 end = struct
   type copy_scope = {
     mutable saved_desc : (transient_expr * type_desc) list;

--- a/ocaml/typing/btype.ml
+++ b/ocaml/typing/btype.ml
@@ -290,7 +290,9 @@ let fold_type_expr f init ty =
     List.fold_left (fun result (_n, ty) -> f result ty) init fl
 
 let iter_type_expr f ty =
-  fold_type_expr (fun () v -> f v) () ty
+  ignore (fold_type_expr (fun f v -> f v; f) f ty : type_expr -> unit)
+    (* written to avoid allocating a closure; the type annotation is to
+       suppress warning 5 *)
 
 let rec iter_abbrev f = function
     Mnil                   -> ()

--- a/ocaml/typing/btype.mli
+++ b/ocaml/typing/btype.mli
@@ -185,7 +185,7 @@ module For_copy : sig
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
         (* Temporarily change a type description *)
 
-  val with_scope: (copy_scope -> 'a) -> 'a
+  val with_scope: ((copy_scope -> 'a)[@local]) -> 'a
         (* [with_scope f] calls [f] and restores saved type descriptions
            before returning its result. *)
 end


### PR DESCRIPTION
Guided by memtrace, I identified spots with lots of allocations and fixed them, all in separate commits. Taken together, these commits lead to a 2.8% reduction in allocations. (That's quite different than what you get if you sum up the individual commits, but it's what I got when I remeasured at the end.)

Note that one of these commits introduces `[@local]` into the compiler source. I think that's OK. But maybe you disagree.