### PR TITLE
Revert "Give `my_closure` accurate rec info"

### DIFF
--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -69,19 +69,9 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
           closure_bound_names_inside_function
       | name ->
         let name = Bound_name.name name in
-        let coercion =
-          (* The name at its binding site always has empty rec info by
-             definition. Since [my_closure] does have rec info (namely
-             [my_depth]), [my_closure] and the bound name are aliases only up to
-             a coercion. This is particularly important when lifting so that we
-             rewrite [my_closure] to the coerced symbol. *)
-          Coercion.change_depth ~from:Rec_info_expr.initial
-            ~to_:(Rec_info_expr.var my_depth)
-        in
-        let aliased = Simple.with_coercion (Simple.name name) coercion in
         DE.add_variable denv
           (Bound_var.create my_closure NM.normal)
-          (T.alias_type_of K.value aliased))
+          (T.alias_type_of K.value (Simple.name name)))
   in
   let denv =
     let my_region = Bound_var.create my_region Name_mode.normal in

--- a/middle_end/flambda2/tests/mlexamples/tests11.flt
+++ b/middle_end/flambda2/tests/mlexamples/tests11.flt
@@ -179,7 +179,7 @@ and code rec loopify(never) size(69) newer_version_of(map_foo_4)
                      @`anon-fn[tests11.ml:15,2--70]`
                  with {
                    map_foo =
-                     $camlTests11__map_foo_8 ~ depth 0 -> succ my_depth
+                     $camlTests11__map_foo_8 ~ depth my_depth -> succ my_depth
                  }
                  in
                  cont k2 (`anon-fn[tests11.ml:15,2--70]`)
@@ -189,7 +189,7 @@ and code rec loopify(never) size(69) newer_version_of(map_foo_4)
                      @`anon-fn[tests11.ml:15,2--70]`
                  with {
                    map_foo =
-                     $camlTests11__map_foo_8 ~ depth 0 -> succ my_depth
+                     $camlTests11__map_foo_8 ~ depth my_depth -> succ my_depth
                  }
                  in
                  cont k2 (`anon-fn[tests11.ml:15,2--70]`))

--- a/middle_end/flambda2/tests/mlexamples/tests11_out.fl
+++ b/middle_end/flambda2/tests/mlexamples/tests11_out.fl
@@ -85,7 +85,7 @@ and code rec loopify(never) size(69) newer_version_of(map_foo_4)
                      @`anon-fn[tests11.ml:15,2--70]`
                  with {
                    map_foo =
-                     $camlTests11__map_foo_8 ~ depth 0 -> succ my_depth
+                     $camlTests11__map_foo_8 ~ depth my_depth -> succ my_depth
                  }
                  in
                  cont k2 (`anon-fn[tests11.ml:15,2--70]`)
@@ -95,7 +95,7 @@ and code rec loopify(never) size(69) newer_version_of(map_foo_4)
                      @`anon-fn[tests11.ml:15,2--70]`
                  with {
                    map_foo =
-                     $camlTests11__map_foo_8 ~ depth 0 -> succ my_depth
+                     $camlTests11__map_foo_8 ~ depth my_depth -> succ my_depth
                  }
                  in
                  cont k2 (`anon-fn[tests11.ml:15,2--70]`))


### PR DESCRIPTION
One or both of #1318 and #1319 contains a bug.  @lukemaurer please test these PRs on the JS tree individually.

Reverts ocaml-flambda/flambda-backend#1318