### PR TITLE
Provide an AST-like view of modular extension extension node names

### DIFF
--- a/ocaml/parsing/extensions.ml
+++ b/ocaml/parsing/extensions.ml
@@ -151,26 +151,27 @@ module Comprehensions = struct
 
   module Desugaring_error = struct
     type error =
-      | Non_comprehension_extension_point of string list
+      | Non_comprehension_extension_point of Extension_node_name.t
       | Non_extension
       | Bad_comprehension_extension_point of string list
       | No_clauses
 
     let report_error ~loc = function
-      | Non_comprehension_extension_point name ->
+      | Non_comprehension_extension_point ext_name ->
           Location.errorf ~loc
-            "Tried to desugar the non-comprehension extension point \
-             \"extension.%s\" as part of a comprehension expression"
-            (String.concat "." name)
+            "Tried to desugar the non-comprehension extension point %a@ \
+             as part of a comprehension expression"
+            Extension_node_name.pp_quoted_name ext_name
       | Non_extension ->
           Location.errorf ~loc
-            "Tried to desugar a non-extension expression as part of a \
-             comprehension expression"
-      | Bad_comprehension_extension_point name ->
+            "Tried to desugar a non-extension expression@ \
+             as part of a comprehension expression"
+      | Bad_comprehension_extension_point subparts ->
           Location.errorf ~loc
-            "Unknown, unexpected, or malformed comprehension extension point \
-             \"extension.comprehension.%s\""
-            (String.concat "." name)
+            "Unknown, unexpected, or malformed@ \
+             comprehension extension point %a"
+            Extension_node_name.pp_quoted_name
+            Extension_node_name.(extension_string :: subparts)
       | No_clauses ->
           Location.errorf ~loc
             "Tried to desugar a comprehension with no clauses"
@@ -191,8 +192,8 @@ module Comprehensions = struct
     | Some (comprehensions :: names, expr)
       when String.equal comprehensions extension_string ->
         names, expr
-    | Some (name, _) ->
-        Desugaring_error.raise expr (Non_comprehension_extension_point name)
+    | Some (ext_name, _) ->
+        Desugaring_error.raise expr (Non_comprehension_extension_point ext_name)
     | None ->
         Desugaring_error.raise expr Non_extension
 

--- a/ocaml/testsuite/tests/jst-modular-extensions/user_error3.compilers.reference
+++ b/ocaml/testsuite/tests/jst-modular-extensions/user_error3.compilers.reference
@@ -1,5 +1,5 @@
 File "user_error3.ml", line 21, characters 25-69:
 21 | let _unknown_extension = [%extension.this_extension_doesn't_exist] ();;
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Unknown extension "this_extension_doesn't_exist" referenced via an
-       [%extension.this_extension_doesn't_exist] extension node
+Error: Unknown extension "this_extension_doesn't_exist" referenced via
+       an [%extension.this_extension_doesn't_exist] extension node

--- a/ocaml/testsuite/tests/jst-modular-extensions/user_error5.compilers.reference
+++ b/ocaml/testsuite/tests/jst-modular-extensions/user_error5.compilers.reference
@@ -1,4 +1,4 @@
-File "user_error5.ml", line 21, characters 25-40:
+File "user_error5.ml", line 21, characters 27-36:
 21 | let _unnamed_extension = [%extension] ();;
-                              ^^^^^^^^^^^^^^^
+                                ^^^^^^^^^
 Error: Cannot have an extension node named [%extension]

--- a/ocaml/testsuite/tests/jst-modular-extensions/user_error6.compilers.reference
+++ b/ocaml/testsuite/tests/jst-modular-extensions/user_error6.compilers.reference
@@ -1,6 +1,6 @@
 File "user_error6.ml", line 21, characters 24-56:
 21 | let _bad_introduction = [%extension.something.nested] ();;
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The extension "something" was referenced improperly; it started with an
-       [%extension.something.nested] extension node,
+Error: The extension "something" was referenced improperly; it started with
+       an [%extension.something.nested] extension node,
        not an [%extension.something] one


### PR DESCRIPTION
That is: if you have `[%extension.comprehensions.for.in]`, this will be represented in OCaml as
`Extensions_parsing.Extension_node_name.("comprehensions" :: ["for"; "in"])`; we're guaranteed to have it be nonempty, we can pass it around as a unit, and most importantly we can change the representation in a single place (e.g., to `[%jst.comprehensions.for.in]`, or to `[%extension'comprehensions'for'in]`, etc.).

Some minor error changes come along as well, either around spacing (due to printing changes) or the locations in errors that the user will never see.