### PR TITLE
Don't pass (unnecessary?) -L flags to `gcc -shared` from opttoplevel

### DIFF
--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -407,8 +407,10 @@ let make_shared_startup_file unix ~ppf_dump ~sourcefile_for_dwarf genfns units =
      might drop some of them (in case of libraries) *)
   Emit.end_assembly ()
 
-let call_linker_shared file_list output_name =
-  let exitcode = Ccomp.call_linker Ccomp.Dll output_name file_list "" in
+let call_linker_shared ?(native_toplevel = false) file_list output_name =
+  let exitcode =
+    Ccomp.call_linker ~native_toplevel Ccomp.Dll output_name file_list ""
+  in
   if not (exitcode = 0)
   then raise(Error(Linking_error exitcode))
 

--- a/backend/asmlink.mli
+++ b/backend/asmlink.mli
@@ -24,7 +24,7 @@ val link: (module Compiler_owee.Unix_intf.S) -> ppf_dump:formatter ->
 val link_shared: (module Compiler_owee.Unix_intf.S) ->
   ppf_dump:formatter -> string list -> string -> unit
 
-val call_linker_shared: string list -> string -> unit
+val call_linker_shared: ?native_toplevel:bool -> string list -> string -> unit
 
 val reset : unit -> unit
 val check_consistency: filepath -> Cmx_format.unit_infos -> Digest.t -> unit

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -294,7 +294,7 @@ let default_load ppf (program : Lambda.program) =
     ~filename ~prefixname:filename
     ~pipeline ~ppf_dump:ppf
     program;
-  Asmlink.call_linker_shared [filename ^ ext_obj] dll;
+  Asmlink.call_linker_shared ~native_toplevel:true [filename ^ ext_obj] dll;
   Sys.remove (filename ^ ext_obj);
   let dll =
     if Filename.is_implicit dll

--- a/ocaml/utils/ccomp.ml
+++ b/ocaml/utils/ccomp.ml
@@ -168,7 +168,7 @@ let remove_Wl cclibs =
                  (String.sub cclib 4 (String.length cclib - 4))
     else cclib)
 
-let call_linker mode output_name files extra =
+let call_linker ?(native_toplevel = false) mode output_name files extra =
   Profile.record_call "c-linker" (fun () ->
     let cmd =
       if mode = Partial then
@@ -194,7 +194,8 @@ let call_linker mode output_name files extra =
           )
           (Filename.quote output_name)
           ""  (*(Clflags.std_include_flag "-I")*)
-          (quote_prefixed "-L" (Load_path.get_paths ()))
+          (if native_toplevel then ""
+           else quote_prefixed "-L" (Load_path.get_paths ()))
           (String.concat " " (List.rev !Clflags.all_ccopts))
           (quote_files files)
           extra

--- a/ocaml/utils/ccomp.mli
+++ b/ocaml/utils/ccomp.mli
@@ -35,6 +35,7 @@ type link_mode =
   | MainDll
   | Partial
 
-val call_linker: link_mode -> string -> string list -> string -> int
+val call_linker:
+  ?native_toplevel:bool -> link_mode -> string -> string list -> string -> int
 
 val linker_is_flexlink : bool

--- a/ocaml/utils/ccomp.mli
+++ b/ocaml/utils/ccomp.mli
@@ -35,6 +35,12 @@ type link_mode =
   | MainDll
   | Partial
 
+(* If the ~native_toplevel flag is true, we don't pass any `-L` flags to gcc.
+   In some cases we observed so many flags being passed that gcc would crash,
+   but they should all be unnecessary as we're compiling with `-shared` in that
+   case. *)
+(* CR-someday ccasinghino: the argument above equally applies to all cases when
+   `link_mode` is `Dll`, but that didn't seem to work.  Understand why. *)
 val call_linker:
   ?native_toplevel:bool -> link_mode -> string -> string list -> string -> int
 


### PR DESCRIPTION
This is a hacky proof-of-concept of a fix for the problem that sometimes we're invoking the native toplevel in a way that causes its call to gcc to fail due to too many -L flags.  My theory is that we don't need those -L flags anyway, because we're calling `gcc -shared`.  (More detail to come via email)