### PR TITLE
Probes test should run only on amd64 linux targets

### DIFF
--- a/tests/backend/probes/dune
+++ b/tests/backend/probes/dune
@@ -1,5 +1,8 @@
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if
+  (and (= %{context_name} "main")
+       (= %{system} "linux")
+       (= %{architecture} "amd64")))
  (deps t1.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -warn-error "+190" -c)))


### PR DESCRIPTION
Fix [this](https://github.com/ocaml-flambda/flambda-backend/actions/runs/4896451933/jobs/8743275894) CI test failure.