### PR TITLE
Don't substitute into an exclave in `un_anf.ml`

### DIFF
--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -248,7 +248,9 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
     | Uregion e ->
       loop ~depth e
     | Uexclave e ->
-      loop ~depth e
+      (* Make sure we don't substitute into a `Uexclave`, which can be bad if the
+         definition reads from a local value *)
+      loop ~depth:(depth + 1) e
   in
   loop ~depth:0 clam;
   let linear_let_bound_vars, used_let_bound_vars, assigned =


### PR DESCRIPTION
In cases like

    let local_ n : nativeint = ... in
    let i = Nativeint.to_int n in
    exclave (
      let local_ a = ... in
      ... i ...
    )

we don't want to substitute `i`, since that would read from `n` outside of its scope. In particular, `a` here will be allocated over `n`, so `Nativeint.to_int` will read garbage.

Simple solution is to treat an `exclave` like a loop during the analysis that decides whether a variable is used linearly.