### PR TITLE
zero alloc check: ignore functors and entry functions

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -238,9 +238,7 @@ end = struct
     in
     match a with
     | [] ->
-      if !Clflags.zero_alloc_check_assert_all
-         && (not !ignore_assert_all)
-         && not (String.ends_with ~suffix:"__entry" fun_name)
+      if !Clflags.zero_alloc_check_assert_all && not !ignore_assert_all
       then
         Some { strict = false; assume = false; loc = Debuginfo.to_location dbg }
       else None

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -1676,8 +1676,12 @@ let compunit (ulam, preallocated_blocks, constants) =
                            Reduce_code_size;
                            No_CSE;
                            Use_linscan_regalloc;
+                           Ignore_assert_all Zero_alloc;
                          ]
-                         else [ Reduce_code_size; Use_linscan_regalloc ];
+                         else [ Reduce_code_size;
+                                Use_linscan_regalloc;
+                                Ignore_assert_all Zero_alloc;
+                              ];
                        fun_dbg  = Debuginfo.none;
                        fun_poll = Default_poll }] in
   let c2 = transl_clambda_constants constants c1 in

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -124,7 +124,11 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
     (* CR mshinwell: This should at least be given a source file location. *)
     let dbg = Debuginfo.none in
     let fun_codegen =
-      let fun_codegen = [Cmm.Reduce_code_size; Cmm.Use_linscan_regalloc] in
+      let fun_codegen =
+        [ Cmm.Reduce_code_size;
+          Cmm.Use_linscan_regalloc;
+          Cmm.Ignore_assert_all Cmm.Zero_alloc ]
+      in
       if Flambda_features.backend_cse_at_toplevel ()
       then fun_codegen
       else Cmm.No_CSE :: fun_codegen

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -147,6 +147,7 @@ and apply_coercion_result loc strict funct params args cc_res =
              ~return:Lambda.layout_module
              ~attr:{ default_function_attribute with
                         is_a_functor = true;
+                        check = Ignore_assert_all Zero_alloc;
                         stub = true; }
              ~loc
              ~mode:alloc_heap
@@ -560,10 +561,10 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
       inline = inline_attribute;
       specialise = Default_specialise;
       local = Default_local;
-      check = Default_check;
       poll = Default_poll;
       loop = Never_loop;
       is_a_functor = true;
+      check = Ignore_assert_all Zero_alloc;
       stub = false;
       tmc_candidate = false;
     }

--- a/ocaml/testsuite/tests/functors/functors.compilers.reference
+++ b/ocaml/testsuite/tests/functors/functors.compilers.reference
@@ -1,13 +1,15 @@
 (setglobal Functors!
   (let
     (O =
-       (function {nlocal = 0} X is_a_functor always_inline never_loop
+       (function {nlocal = 0} X is_a_functor always_inline
+         ignore assert all zero_alloc never_loop
          (let
            (cow = (function {nlocal = 0} x[int] : int (apply (field 0 X) x))
             sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
            (makeblock 0 cow sheep)))
      F =
-       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+       (function {nlocal = 0} X Y is_a_functor always_inline
+         ignore assert all zero_alloc never_loop
          (let
            (cow =
               (function {nlocal = 0} x[int] : int
@@ -15,7 +17,8 @@
             sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
            (makeblock 0 cow sheep)))
      F1 =
-       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+       (function {nlocal = 0} X Y is_a_functor always_inline
+         ignore assert all zero_alloc never_loop
          (let
            (cow =
               (function {nlocal = 0} x[int] : int
@@ -23,7 +26,8 @@
             sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
            (makeblock 0 sheep)))
      F2 =
-       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+       (function {nlocal = 0} X Y is_a_functor always_inline
+         ignore assert all zero_alloc never_loop
          (let
            (X =a (makeblock 0 (field 1 X))
             Y =a (makeblock 0 (field 1 Y))
@@ -35,7 +39,8 @@
      M =
        (let
          (F =
-            (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+            (function {nlocal = 0} X Y is_a_functor always_inline
+              ignore assert all zero_alloc never_loop
               (let
                 (cow =
                    (function {nlocal = 0} x[int] : int
@@ -45,6 +50,7 @@
                 (makeblock 0 cow sheep))))
          (makeblock 0
            (function {nlocal = 0} funarg funarg is_a_functor stub
+             ignore assert all zero_alloc
              (let
                (let =
                   (apply F (makeblock 0 (field 1 funarg))

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -340,3 +340,9 @@
  (enabled_if (= %{context_name} "main"))
  (deps t6.output t6.output.corrected)
  (action (diff t6.output t6.output.corrected)))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps t7.ml)
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -81,4 +81,6 @@ let () =
     ~exit_code:0 "test_attr_unused";
   (* Checks that the warning is printed and compilation is successful. *)
   print_test_expected_output ~flambda_only:false ~extra_dep:None
-    ~exit_code:0 "t6"
+    ~exit_code:0 "t6";
+  (* Check that entry function and functors are ignored with  [@@@zero_alloc all] *)
+  print_test ~flambda_only:false ~deps:"t7.ml"

--- a/tests/backend/checkmach/t7.ml
+++ b/tests/backend/checkmach/t7.ml
@@ -1,0 +1,22 @@
+(* Check that entry function and functors are ignored with  [@@@zero_alloc all] *)
+[@@@zero_alloc all]
+
+let[@zero_alloc ignore] foo x = (x,x)
+
+let[@inline never][@zero_alloc ignore] print x =
+  print_int (fst x)
+
+let () =
+  print (Sys.opaque_identity (foo (Sys.opaque_identity 5)))
+
+module type A = sig
+  type t
+  val foo : t -> int
+end
+
+module Make (A : A) = struct
+  include A
+  let f _t = ()
+  let g _t = ()
+end
+[@@inline always]


### PR DESCRIPTION
Check of `[@@@zero_alloc all]` annotation already ignores compiler-generated `_entry` functions. It should similarly ignore  compiler-generated functions for functors (see example in the new test). 

There are two changes in this PR:
- In Lambda, adds the attribute `Ignore_assert_all Zero_alloc`  to all functions annotated with attribute `is_a_functor`.
- Similarly, replace the ad-hoc detection of entry functions with `Ignore_assert_all Zero_alloc` at the time the entry function is generated. 