### PR TITLE
Fix linear_to_cfg trap stack reconstruction bug

### DIFF
--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -391,21 +391,53 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
   let add_terminator (desc : C.terminator) ~(next : Linear.instruction) =
     (* All terminators are followed by a label, except branches we created for
        fallthroughs in Linear. *)
-    (match desc with
-    | Never -> Misc.fatal_error "Cannot add terminator: Never"
-    | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-    | Poll_and_jump _ | Call _ | Prim _ | Specific_can_raise _ | Switch _ ->
-      ()
-    | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Call_no_return _ ->
-      if not (Linear_utils.defines_label i.next)
-      then
-        Misc.fatal_errorf "Linear instruction not followed by label:@ %a"
-          Printlinear.instr
-          { i with Linear.next = L.end_instr });
+    let new_traps =
+      match desc with
+      | Never -> Misc.fatal_error "Cannot add terminator: Never"
+      | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+      | Poll_and_jump _ | Call _ | Prim _ | Specific_can_raise _ | Switch _ ->
+        traps
+      | Always successor_label -> (
+        (* If it is not fallthrough, do not propagate traps, only
+           stack_offsets. *)
+        let next_label =
+          match i.next.desc with
+          | Llabel { label; _ } -> Some label
+          | Ladjust_stack_offset _ ->
+            (* No need for special case: traps will be set to T.unknown in
+               [adjust_traps i.next]. *)
+            None
+          | Lend | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Lbranch _
+          | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap
+          | Lpushtrap _ | Lpoptrap | Lraise _ ->
+            None
+        in
+        match next_label with
+        | None -> traps
+        | Some next_label ->
+          if not (Label.equal successor_label next_label)
+          then (
+            if !C.verbose
+            then
+              Printf.printf
+                "No fallthrough detected: block.start=%d, successor_label=%d \
+                 next_label=%d\n"
+                block.start successor_label next_label;
+            T.unknown ())
+          else traps)
+      | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Call_no_return _
+        ->
+        if not (Linear_utils.defines_label i.next)
+        then
+          Misc.fatal_errorf "Linear instruction not followed by label:@ %a"
+            Printlinear.instr
+            { i with Linear.next = L.end_instr };
+        traps
+    in
     block.terminator <- create_instruction t desc ~stack_offset i;
     if Cfg.can_raise_terminator desc then record_exn t block traps;
     register_block t block traps;
-    create_blocks t next block ~stack_offset ~traps
+    create_blocks t next block ~stack_offset ~traps:new_traps
   in
   let terminator desc = add_terminator desc ~next:i.next in
   let terminator_fallthrough (mk_desc : Label.t -> C.terminator) =


### PR DESCRIPTION
Linear to cfg pass reconstructs trap stacks (to determine exceptional successors of blocks) from push and pop traps. 
There is a bug that causes compilation failure on an assertion `Trap_stacks.unify` because when handlers disagree.

It does not happen in normal builds with `-ocamlcfg` flag, which bypasses `linear_to_cfg`, but the assertion failure can be triggered by a build with FDO. Prior to [PR#1041](https://github.com/ocaml-flambda/flambda-backend/pull/1041), FDO builds took as input `linear` produced by `linearize` (and not by `cfgize`). It looks like `linearize` produced layouts that didn't trigger the assertion.

The bug is that trap stacks are propagated from one block to the next in the layout even when there is no flow of control possible between these blocks. The fix is to set  traps to `Unknown` in such cases (similarly to `adjust_trap_stacks`). Note that `stack_offset` is propagated linearly based on the layout, not control flow.

It is easy to reproduce even on the compiler itself, for example the function `[expand_head](https://github.com/ocaml-flambda/flambda-backend/blob/bc7f2d7f34529a115c3c3f635a514bfb9538123a/middle_end/flambda2/types/expand_head.ml#L330-L345 
)` in `Flambda2`, if we force the the compiler to run `Linear_to_cfg`  after [this line](https://github.com/ocaml-flambda/flambda-backend/blob/bc7f2d7f34529a115c3c3f635a514bfb9538123a/backend/asmgen.ml#L346) and set `BUILD_OCAMLPARAM="_,ocamlcfg=1"`.

It was a bit hard to come up with a small example. If we compile the following function while carefully reordering the CFG to get the layout below, the assertion will be triggered with flambda.

```
let foo p get l l' f g g' g'' =
  match p l with
  | exception Not_found -> g l
  | x -> (
    let y = get l in
    match
      f l
    with
    | exception Not_found ->
      g' y
    | x ->
      g'' l' y)
```

Layout:

```

1:
prologue
goto 101

101:
...
push trap L105
...
goto 106

114:
pop trap
...
tailcall "caml_apply2" R/0[%rax] R/1[%rbx] R/2[%rdi]

106:
pop trap
...
goto 109

109:
..
push trap L113
...
goto 114

113:
...
if V/53[%rax] < s I/54[%rbx] goto 116
if V/53[%rax] = s I/54[%rbx] goto 115
if V/53[%rax] > s I/54[%rbx] goto 116

105:
...
if V/42[%rax] < s I/43[%rbx] goto 108
if V/42[%rax] = s I/43[%rbx] goto 107
if V/42[%rax] > s I/43[%rbx] goto 108

115:
...
tailcall V/55[%rdi] R/0[%rax] R/1[%rbx]

116:
..
Raise R/0[%rax]

107:
...
tailcall V/44[%rdi] R/0[%rax] R/1[%rbx]

108:
...
Raise R/0[%rax]
```

The culprit is propagation of the irrelevant trap stack that consists of `L105` from `L101` to `L114` and then the actual control flow to `L114` from `L109` propagates the trap stack `L113` to `L114`. The assertion fails because `L105` and `L113` cannot be unified.

[camlT__foo_5.dot.pdf](https://github.com/ocaml-flambda/flambda-backend/files/11435277/camlT__foo_5.dot.pdf)

