### PR TITLE
Fix warning 55 semantics

### DIFF
--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -391,7 +391,7 @@ type inline_attribute = Inline_attribute.t =
   | Unroll of int
   | Default_inline
 
-type inlined_attribute = Inlined_attribute.t =
+type inlined_attribute =
   | Always_inlined
   | Hint_inlined
   | Never_inlined

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -964,8 +964,13 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         | None | Some { params_arity = None; ret_arity = _ } ->
           Misc.fatal_errorf "Must specify arities for C call")
     in
-    let inlined =
-      inlined |> Option.value ~default:Inlined_attribute.Default_inlined
+    let inlined : Inlined_attribute.t =
+      match inlined with
+      | None | Some Default_inlined -> Default_inlined
+      | Some Hint_inlined -> Hint_inlined
+      | Some Always_inlined -> Always_inlined Expected_to_be_used
+      | Some (Unroll n) -> Unroll (n, Expected_to_be_used)
+      | Some Never_inlined -> Never_inlined
     in
     let inlining_state =
       match inlining_state with

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -1022,10 +1022,16 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
     | Method _ ->
       None
   in
-  let inlined =
+  let inlined : Fexpr.inlined_attribute option =
     if Flambda2_terms.Inlined_attribute.is_default (Apply_expr.inlined app)
     then None
-    else Some (Apply_expr.inlined app)
+    else
+      match Apply_expr.inlined app with
+      | Default_inlined -> Some Default_inlined
+      | Hint_inlined -> Some Hint_inlined
+      | Always_inlined _ -> Some Always_inlined
+      | Unroll (n, _) -> Some (Unroll n)
+      | Never_inlined -> Some Never_inlined
   in
   let inlining_state = inlining_state (Apply_expr.inlining_state app) in
   let region = Env.find_region_exn env (Apply_expr.region app) in

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -645,7 +645,7 @@ let inline_attribute ~space ppf (i : Inline_attribute.t) =
 let inline_attribute_opt ~space ppf i =
   pp_option ~space (inline_attribute ~space:Neither) ppf i
 
-let inlined_attribute ~space ppf (i : Inlined_attribute.t) =
+let inlined_attribute ~space ppf (i : Fexpr.inlined_attribute) =
   let str =
     match i with
     | Always_inlined -> Some "inlined(always)"

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -187,7 +187,7 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
   let inlined = Apply.inlined apply in
   match inlined with
   | Never_inlined -> Never_inlined_attribute
-  | Default_inlined | Unroll _ | Always_inlined | Hint_inlined -> (
+  | Default_inlined | Unroll _ | Always_inlined _ | Hint_inlined -> (
     let code_or_metadata =
       DE.find_code_exn (DA.denv dacc) (FT.code_id function_type)
     in
@@ -247,7 +247,7 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
             else
               might_inline dacc ~apply ~code_or_metadata ~function_type
                 ~simplify_expr ~return_arity
-          | Unroll unroll_to ->
+          | Unroll (unroll_to, _) ->
             if Simplify_rec_info_expr.can_unroll dacc rec_info
             then
               (* This sets off step 1 in the comment above; see
@@ -255,4 +255,4 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
                  handled. *)
               Attribute_unroll unroll_to
             else Unrolling_depth_exceeded
-          | Always_inlined | Hint_inlined -> Attribute_always))
+          | Always_inlined _ | Hint_inlined -> Attribute_always))

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -100,10 +100,7 @@ let [@ocamlformat "disable"] print ppf t =
       threshold
 
 type can_inline =
-  | Do_not_inline of
-      { warn_if_attribute_ignored : bool;
-        because_of_definition : bool
-      }
+  | Do_not_inline of { erase_attribute_if_ignored : bool }
   | Inline of
       { unroll_to : int option;
         was_inline_always : bool
@@ -115,17 +112,14 @@ let can_inline (t : t) : can_inline =
   | Recursion_depth_exceeded | Speculatively_not_inline _
   | Definition_says_not_to_inline | Argument_types_not_useful ->
     (* If there's an [@inlined] attribute on this, something's gone wrong *)
-    Do_not_inline
-      { warn_if_attribute_ignored = true; because_of_definition = true }
+    Do_not_inline { erase_attribute_if_ignored = false }
   | Never_inlined_attribute ->
     (* If there's an [@inlined] attribute on this, something's gone wrong *)
-    Do_not_inline
-      { warn_if_attribute_ignored = true; because_of_definition = true }
+    Do_not_inline { erase_attribute_if_ignored = false }
   | Unrolling_depth_exceeded ->
     (* If there's an [@unrolled] attribute on this, then we'll ignore the
        attribute when we stop unrolling, which is fine *)
-    Do_not_inline
-      { warn_if_attribute_ignored = false; because_of_definition = true }
+    Do_not_inline { erase_attribute_if_ignored = true }
   | Attribute_unroll unroll_to ->
     Inline { unroll_to = Some unroll_to; was_inline_always = false }
   | Definition_says_inline { was_inline_always } ->

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -45,10 +45,7 @@ val print : Format.formatter -> t -> unit
 val report : Format.formatter -> t -> unit
 
 type can_inline = private
-  | Do_not_inline of
-      { warn_if_attribute_ignored : bool;
-        because_of_definition : bool
-      }
+  | Do_not_inline of { erase_attribute_if_ignored : bool }
   | Inline of
       { unroll_to : int option;
         was_inline_always : bool

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -373,3 +373,5 @@ let region t = t.region
 let args_arity t = t.args_arity
 
 let return_arity t = t.return_arity
+
+let with_inlined_attribute t inlined = { t with inlined }

--- a/middle_end/flambda2/terms/apply_expr.mli
+++ b/middle_end/flambda2/terms/apply_expr.mli
@@ -129,3 +129,5 @@ val returns : t -> bool
 
 (** The local allocation region for this application. *)
 val region : t -> Variable.t
+
+val with_inlined_attribute : t -> Inlined_attribute.t -> t

--- a/middle_end/flambda2/terms/inlined_attribute.ml
+++ b/middle_end/flambda2/terms/inlined_attribute.ml
@@ -30,7 +30,12 @@ module Use_info = struct
         "the optimizer decided not to inline the function given its \
          definition, or because its definition was not visible"
     | Unused_because_function_unknown ->
-      Some "the optimizer did not know what function was being applied"
+      Some
+        ("the optimizer did not know what function was being applied"
+        ^
+        if Flambda_features.classic_mode ()
+        then " (is it marked [@inline never]?)"
+        else "")
 end
 
 type t =

--- a/middle_end/flambda2/terms/inlined_attribute.ml
+++ b/middle_end/flambda2/terms/inlined_attribute.ml
@@ -14,31 +14,52 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Use_info = struct
+  type t =
+    | Expected_to_be_used
+    | Unused_because_of_call_site_decision
+    | Unused_because_function_unknown
+
+  let equal t1 t2 = t1 = t2
+
+  let explanation t =
+    match t with
+    | Expected_to_be_used -> None
+    | Unused_because_of_call_site_decision ->
+      Some
+        "the optimizer decided not to inline the function given its \
+         definition, or because its definition was not visible"
+    | Unused_because_function_unknown ->
+      Some "the optimizer did not know what function was being applied"
+end
+
 type t =
-  | Always_inlined
+  | Always_inlined of Use_info.t
   | Hint_inlined
   | Never_inlined
-  | Unroll of int
+  | Unroll of int * Use_info.t
   | Default_inlined
 
-let [@ocamlformat "disable"] print ppf t =
+let print ppf t =
   let fprintf = Format.fprintf in
   match t with
-  | Always_inlined -> fprintf ppf "Always_inlined"
+  | Always_inlined _ -> fprintf ppf "Always_inlined"
   | Hint_inlined -> fprintf ppf "Hint_inlined"
   | Never_inlined -> fprintf ppf "Never_inlined"
-  | Unroll n -> fprintf ppf "@[(Unroll %d)@]" n
+  | Unroll (n, _) -> fprintf ppf "@[(Unroll %d)@]" n
   | Default_inlined -> fprintf ppf "Default_inlined"
 
 let equal t1 t2 =
   match t1, t2 with
-  | Always_inlined, Always_inlined
+  | Always_inlined use_info1, Always_inlined use_info2 ->
+    Use_info.equal use_info1 use_info2
   | Hint_inlined, Hint_inlined
   | Never_inlined, Never_inlined
   | Default_inlined, Default_inlined ->
     true
-  | Unroll n1, Unroll n2 -> n1 = n2
-  | ( ( Always_inlined | Hint_inlined | Never_inlined | Unroll _
+  | Unroll (n1, use_info1), Unroll (n2, use_info2) ->
+    n1 = n2 && Use_info.equal use_info1 use_info2
+  | ( ( Always_inlined _ | Hint_inlined | Never_inlined | Unroll _
       | Default_inlined ),
       _ ) ->
     false
@@ -46,12 +67,23 @@ let equal t1 t2 =
 let is_default t =
   match t with
   | Default_inlined -> true
-  | Always_inlined | Hint_inlined | Never_inlined | Unroll _ -> false
+  | Always_inlined _ | Hint_inlined | Never_inlined | Unroll _ -> false
 
 let from_lambda (attr : Lambda.inlined_attribute) =
   match attr with
-  | Always_inlined -> Always_inlined
+  | Always_inlined -> Always_inlined Expected_to_be_used
   | Never_inlined -> Never_inlined
   | Hint_inlined -> Hint_inlined
-  | Unroll i -> Unroll i
+  | Unroll i -> Unroll (i, Expected_to_be_used)
   | Default_inlined -> Default_inlined
+
+let with_use_info t use_info =
+  match t with
+  | Always_inlined _ -> Always_inlined use_info
+  | Unroll (n, _) -> Unroll (n, use_info)
+  | Never_inlined | Hint_inlined | Default_inlined -> t
+
+let use_info t =
+  match t with
+  | Always_inlined use_info | Unroll (_, use_info) -> Some use_info
+  | Never_inlined | Hint_inlined | Default_inlined -> None

--- a/middle_end/flambda2/terms/inlined_attribute.mli
+++ b/middle_end/flambda2/terms/inlined_attribute.mli
@@ -16,11 +16,20 @@
 
 (** Call site (not function declaration) inlining annotations. *)
 
+module Use_info : sig
+  type t =
+    | Expected_to_be_used
+    | Unused_because_of_call_site_decision
+    | Unused_because_function_unknown
+
+  val explanation : t -> string option
+end
+
 type t =
-  | Always_inlined
+  | Always_inlined of Use_info.t
   | Hint_inlined
   | Never_inlined
-  | Unroll of int
+  | Unroll of int * Use_info.t
   | Default_inlined
 
 val print : Format.formatter -> t -> unit
@@ -30,3 +39,7 @@ val equal : t -> t -> bool
 val is_default : t -> bool
 
 val from_lambda : Lambda.inlined_attribute -> t
+
+val with_use_info : t -> Use_info.t -> t
+
+val use_info : t -> Use_info.t option


### PR DESCRIPTION
The warning 55 (inlining impossible) semantics in flambda2 is wrong at present.  Some cases of this warning are correct, when there is an "obvious error", e.g. an inlining attribute on a partial application.  However in the more usual cases, where the compiler doesn't know what function is being applied, or a call site attribute conflicts with the definition's inlining decision, the warnings are emitted too early.  This means that if the code in question is subsequently removed, e.g. fully inlined out everywhere, a warning may still be emitted.  This doesn't match flambda1 and is very unhelpful.  For example this produces a warning:
```
module S : sig
  val bar : int -> int
end = struct
  let[@inline] foo f x =
    (f [@inlined]) x

  let bar x =
    foo (fun x -> x) x
end
```
This patch aims to rectify that by checking for unused attributes during `To_cmm`.  The `Inlined_attribute` type is enhanced so that the reason for an inlining failure can be easily propagated in the cases where it is required (always-inline or unrolling attributes).  As far as I can see this seems to work well.

In classic mode, the above now triggers two warnings, rather than one (because inlined bodies are not simplified, and `To_cmm` will see all copies of the original attribute).  I think this is probably fine, from what I've seen people wouldn't be writing code like this for classic mode anyway (typically `[@inline hint]` would be used).

There is one corner case where, at the point of hitting an unrolling depth limit, the old code suppressed subsequent warnings about the corresponding attribute.  This code erases the attribute, which seems maybe better.  We could also add a new `Inlined_attribute.Use_info` case which would cause the code in `To_cmm` to just ignore the attribute rather than issuing a warning.

One niggle I have noticed is that in Classic mode, trying to inline a function marked `inline never` causes the error about function information being unavailable - instead of saying that the definition says "never inline".  See the following example.  Under Simplify this is let through without warning, I'm unsure that is correct either.
```
let[@inline never] never_inline x = x + 1

let baz x = (never_inline[@inlined]) x
```

A couple of cleanups happened along the way: the `because_of_definition` field in `Call_site_inlining_decision_type` was always set to `true`, so has been removed.  The warnings are now consistent between classic mode and Simplify.