### PR TITLE
Delete unused continuations in to_cmm

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -82,13 +82,18 @@ type continuation_handler_classification =
   | Regular
   | May_inline
 
-let classify_continuation_handler _k handler
+let classify_continuation_handler k handler
     ~(num_free_occurrences : Num_occurrences.t Or_unknown.t)
     ~is_applied_with_traps : continuation_handler_classification =
   let is_exn_handler = Continuation_handler.is_exn_handler handler in
   match[@warning "-4"]
     num_free_occurrences, is_exn_handler, is_applied_with_traps
   with
+  | Known Zero, false, false ->
+    (* CR gbury: not sure we still need this case *)
+    Misc.fatal_errorf
+      "Found unused let-bound continuation %a, this should not happen"
+      Continuation.print k
   | Known Zero, _, _ -> Drop (* this can happen in classic mode *)
   | Known One, false, false -> May_inline
   | _ -> Regular

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.mli
@@ -66,6 +66,7 @@ val classify_let_binding :
 (** Classification of continuations, indicating what may be done with the
     handler expression. *)
 type continuation_handler_classification = private
+  | Drop
   | Regular
   | May_inline
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -292,6 +292,7 @@ val extra_info : t -> Simple.t -> extra_info option
     translated as a static jump to a Cmm continuation (represented as a Cmm
     label), or inlined at any unique use site. *)
 type cont = private
+  | Dropped
   | Jump of
       { cont : Lambda.static_label;
         param_types : Cmm.machtype list
@@ -302,6 +303,10 @@ type cont = private
         handler_body : Flambda.Expr.t;
         handler_body_inlined_debuginfo : Debuginfo.t
       }
+
+(** Record that the given continuation should be dropped because it is unused,
+    and that its uses in push/pop traps can be erased *)
+val add_dropped_cont : t -> Continuation.t -> t
 
 (** Record that the given continuation should be compiled to a jump, creating a
     fresh Cmm continuation identifier for it. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -519,7 +519,7 @@ and let_cont env res (let_cont : Flambda.Let_cont.t) =
             Let_cont.print let_cont;
         let_cont_rec env res invariant_params conts body)
 
-(* The bound continuation [k] is never used, **but** cna appear in push/pop
+(* The bound continuation [k] is never used, **but** can appear in push/pop
    trap, in which cases the push/pops should be removed. *)
 and let_cont_dropped env res k body =
   let env = Env.add_dropped_cont env k in


### PR DESCRIPTION
This PR adds some simplification of unused continuations in to_cmm. This particularly happens in classic mode, which can generate continuations with zero uses for unused exn handlers, for isntance in the following program:

```ocaml
let f x = try () with _ -> x
```

With this PR we can now eliminate the unneeded exn handler, which simplifies the generated code quite a bit.