### PR TITLE
Refactor primitive handling in Lambda_to_flambda

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -601,9 +601,32 @@ let close_exn_continuation acc env (exn_continuation : IR.exn_continuation) =
     Exn_continuation.create ~exn_handler:exn_continuation.exn_handler
       ~extra_args )
 
+let close_raise acc env ~raise_kind ~arg loc exn_continuation =
+  let acc, exn_cont = close_exn_continuation acc env exn_continuation in
+  let exn_handler = Exn_continuation.exn_handler exn_cont in
+  let acc, arg = find_simple acc env arg in
+  let args =
+    (* CR mshinwell: Share with [Lambda_to_flambda_primitives_helpers] *)
+    let extra_args =
+      List.map
+        (fun (simple, _kind) -> simple)
+        (Exn_continuation.extra_args exn_cont)
+    in
+    arg :: extra_args
+  in
+  let raise_kind = Some (Trap_action.Raise_kind.from_lambda raise_kind) in
+  let trap_action = Trap_action.Pop { exn_handler; raise_kind } in
+  let dbg = Debuginfo.from_location loc in
+  let acc, apply_cont =
+    Apply_cont_with_acc.create acc ~trap_action exn_handler ~args ~dbg
+  in
+  (* Since raising of an exception doesn't terminate, we don't call [k]. *)
+  Expr_with_acc.create_apply_cont acc apply_cont
+
 let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
     loc (exn_continuation : IR.exn_continuation option) ~current_region
     (k : Acc.t -> Named.t option -> Expr_with_acc.t) : Expr_with_acc.t =
+  let orig_exn_continuation = exn_continuation in
   let acc, exn_continuation =
     match exn_continuation with
     | None -> acc, None
@@ -611,6 +634,7 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
       let acc, cont = close_exn_continuation acc env exn_continuation in
       acc, Some cont
   in
+  let orig_args = args in
   let acc, args = find_simples acc env args in
   let dbg = Debuginfo.from_location loc in
   match prim, args with
@@ -642,29 +666,14 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
     k acc (Some named)
   | Praise raise_kind, [_] ->
     let exn_continuation =
-      match exn_continuation with
+      match orig_exn_continuation with
       | None ->
         Misc.fatal_errorf "Praise is missing exception continuation: %a"
           IR.print_named named
       | Some exn_continuation -> exn_continuation
     in
-    let exn_handler = Exn_continuation.exn_handler exn_continuation in
-    let args =
-      (* CR mshinwell: Share with [Lambda_to_flambda_primitives_helpers] *)
-      let extra_args =
-        List.map
-          (fun (simple, _kind) -> simple)
-          (Exn_continuation.extra_args exn_continuation)
-      in
-      args @ extra_args
-    in
-    let raise_kind = Some (Trap_action.Raise_kind.from_lambda raise_kind) in
-    let trap_action = Trap_action.Pop { exn_handler; raise_kind } in
-    let acc, apply_cont =
-      Apply_cont_with_acc.create acc ~trap_action exn_handler ~args ~dbg
-    in
-    (* Since raising of an exception doesn't terminate, we don't call [k]. *)
-    Expr_with_acc.create_apply_cont acc apply_cont
+    close_raise acc env ~raise_kind ~arg:(List.hd orig_args) loc
+      exn_continuation
   | (Pmakeblock _ | Pmakefloatblock _ | Pmakearray _), [] ->
     (* Special case for liftable empty block or array *)
     let acc, sym =

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -70,6 +70,15 @@ val close_switch :
   IR.switch ->
   Expr_with_acc.t
 
+val close_raise :
+  Acc.t ->
+  Env.t ->
+  raise_kind:Lambda.raise_kind ->
+  arg:IR.simple ->
+  Lambda.scoped_location ->
+  IR.exn_continuation ->
+  Expr_with_acc.t
+
 type 'a close_program_metadata =
   | Normal : [`Normal] close_program_metadata
   | Classic :

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1430,9 +1430,12 @@ let primitive_result_layout (p : primitive) =
   | Paddfloat _ | Psubfloat _ | Pmulfloat _ | Pdivfloat _
   | Pbox_float _ -> layout_float
   | Punbox_float -> Punboxed_float
-  | Pccall _p ->
-      (* CR ncourant: use native_repr *)
+  | Pccall { prim_native_repr_res = _, Untagged_int; _} ->layout_int
+  | Pccall { prim_native_repr_res = _, Unboxed_float; _} -> layout_float
+  | Pccall { prim_native_repr_res = _, Same_as_ocaml_repr; _} ->
       layout_any_value
+  | Pccall { prim_native_repr_res = _, Unboxed_integer bi; _} ->
+      layout_boxedint bi
   | Praise _ -> layout_bottom
   | Psequor | Psequand | Pnot
   | Pnegint | Paddint | Psubint | Pmulint


### PR DESCRIPTION
This allows us to remove the `primitive_result_kind` function together with some duplicate code (calling `transform_primitive`).