### PR TITLE
Annotate Cmm.Pop with the exception handler label

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -325,7 +325,7 @@ let destroyed_at_pushtrap =
   [| r11 |]
 
 let has_pushtrap traps =
-  List.exists (function Cmm.Push _ -> true | Pop -> false) traps
+  List.exists (function Cmm.Push _ -> true | Pop _ -> false) traps
 
 (* note: keep this function in sync with `destroyed_at_{basic,terminator}` below. *)
 let destroyed_at_oper = function

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -458,7 +458,7 @@ let rec add_blocks :
           | Cmm.Push handler_id ->
             let lbl_handler = State.get_catch_handler state ~handler_id in
             make_instruction state ~desc:(Cfg.Pushtrap { lbl_handler })
-          | Cmm.Pop -> make_instruction state ~desc:Cfg.Poptrap
+          | Cmm.Pop _ -> make_instruction state ~desc:Cfg.Poptrap
         in
         DLL.add_end body instr)
       trap_actions;
@@ -524,7 +524,9 @@ let rec add_blocks :
       else
         terminate_block
           ~trap_actions:
-            (if State.is_iend_with_poptrap state last then [Cmm.Pop] else [])
+            (if State.is_iend_with_poptrap state last
+            then [Cmm.Pop Pop_generic]
+            else [])
           (copy_instruction_no_reg state last ~desc:(Cfg.Always next))
     | Ireturn trap_actions ->
       terminate_block ~trap_actions

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -153,9 +153,13 @@ type phantom_defining_expr =
 
 type trywith_shared_label = int
 
+type pop_action =
+  | Pop_generic
+  | Pop_specific of trywith_shared_label
+
 type trap_action =
   | Push of trywith_shared_label
-  | Pop
+  | Pop of pop_action
 
 type trywith_kind =
   | Regular

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -140,10 +140,14 @@ type phantom_defining_expr =
 
 type trywith_shared_label = Lambda.static_label (* Same as Ccatch handlers *)
 
+type pop_action =
+  | Pop_generic
+  | Pop_specific of trywith_shared_label
+
 type trap_action =
   | Push of trywith_shared_label
   (** Add the corresponding handler to the trap stack. *)
-  | Pop
+  | Pop of pop_action
   (** Remove the last handler from the trap stack. *)
 
 type trywith_kind =

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -108,9 +108,8 @@ let enter_catch_body env nfail =
 let mk_traps env nfail =
   let catch_trywith_depths_inverse =
     env.catch_trywith_depths
-    |> IntMap.bindings
-    |> List.map (fun (nfail, depth) -> depth, nfail)
-    |> List.to_seq
+    |> IntMap.to_seq
+    |> Seq.map (fun (nfail, depth) -> depth, nfail)
     |> IntMap.of_seq
   in
   let handler_depth =

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -145,7 +145,7 @@ let is_next_catch env n = match env.exit_label with
 let rec add_traps env i traps =
   match traps with
   | [] -> i
-  | Cmm.Pop :: traps ->
+  | Cmm.Pop _ :: traps ->
     add_traps env (cons_instr Lpoptrap i) traps
   | Cmm.Push handler :: traps ->
     let lbl_handler = find_exit_label env handler in
@@ -156,7 +156,7 @@ let delta_traps_diff traps =
     List.fold_left
       (fun delta trap ->
          match trap with
-         | Cmm.Pop -> delta - 1
+         | Cmm.Pop _ -> delta - 1
          | Cmm.Push _ -> delta + 1)
       0 traps in
   -delta

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -151,7 +151,8 @@ let exit_label ppf = function
 let trap_action ppf ta =
   match ta with
   | Push i -> fprintf ppf "push(%d)" i
-  | Pop -> fprintf ppf "pop"
+  | Pop Pop_generic -> fprintf ppf "pop"
+  | Pop (Pop_specific i) -> fprintf ppf "pop(%d)" i
 
 let trap_action_list ppf traps =
   match traps with

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -210,7 +210,7 @@ componentlist:
   | componentlist STAR component { $3 :: $1 }
 ;
 traps:
-    LPAREN INTCONST RPAREN       { List.init $2 (fun _ -> Pop) }
+    LPAREN INTCONST RPAREN       { List.init $2 (fun _ -> Pop Pop_generic) }
   | /**/                         { [] }
 expr:
     INTCONST    { Cconst_int ($1, debuginfo ()) }


### PR DESCRIPTION
As per request in #1380 

cc @xclerc does this work?  I had to add a "generic pop" case as sometimes there isn't a handler label; is this ok?