### PR TITLE
Statically enabled probes

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -746,10 +746,7 @@ let find_or_add_semaphore name enabled_at_init dbg =
        assert false
      | Some b, Some b' ->
        if not (Bool.equal b b') then
-         Misc.fatal_errorf
-           "Inconsistent use of ~enabled_at_init in [%%probe %s ..] at %a"
-           name
-           Debuginfo.print_compact dbg);
+         raise (Error (Inconsistent_probe_init (name,dbg))));
     label
   | None ->
     let sym = "caml_probes_semaphore_"^name in

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -740,7 +740,7 @@ let find_or_add_semaphore name =
     probe_semaphores := String.Map.add name sym !probe_semaphores;
     sym
 
-let emit_call_probe_handler_wrapper i ~probe_label =
+let emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label =
   assert !frame_required;
   let wrap_label = probe_handler_wrapper_name probe_label in
   (* We emit a cmp instruction that is effectively a nop:
@@ -757,7 +757,10 @@ let emit_call_probe_handler_wrapper i ~probe_label =
        encoding which produces an incorrect relocation and changes the meaning
        of the program. *)
     (* Emit the required encoding of "cmp $0, %eax" directly, using .byte *)
-    D.byte (Const 0x3dL);
+    if enabled_at_init then
+      D.byte (Const 0xe8L)
+    else
+      D.byte (Const 0x3dL);
     D.byte (Const 0L);
     D.byte (Const 0L);
     D.byte (Const 0L);
@@ -1222,7 +1225,7 @@ let emit_instr fallthrough i =
   | Lop(Iendregion) ->
       I.mov (arg i 0) (domain_field Domainstate.Domain_local_sp)
   | Lop (Iname_for_debugger _) -> ()
-  | Lop (Iprobe _) ->
+  | Lop (Iprobe { enabled_at_init; _ }) ->
     let probe_label = new_label () in
     let probe =
       { probe_label;
@@ -1238,7 +1241,7 @@ let emit_instr fallthrough i =
        intervening wrapper that deals with getting the arguments to the probe
        in the correct place and managing the spilling/reloading of live
        registers.  See [emit_probe_handler_wrapper] below. *)
-    emit_call_probe_handler_wrapper i ~probe_label
+    emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label
   | Lop (Iprobe_is_enabled { name; }) ->
     let semaphore_sym = find_or_add_semaphore name in
     (* Load unsigned 2-byte integer value of the semaphore.
@@ -1584,7 +1587,8 @@ let emit_probe_handler_wrapper p =
   let wrap_label = probe_handler_wrapper_name p.probe_label in
   let probe_name, handler_code_sym =
     match p.probe_insn.desc with
-    | Lop (Iprobe { name; handler_code_sym; }) -> name, handler_code_sym
+    | Lop (Iprobe { name; handler_code_sym; enabled_at_init = _; }) ->
+      name, handler_code_sym
     | _ -> assert false
   in
   (* Restore stack frame info as it was at the probe site, so we can easily

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -732,12 +732,29 @@ let reset_probes () =
   probes := [];
   probe_semaphores := String.Map.empty
 
-let find_or_add_semaphore name =
+let find_or_add_semaphore name enabled_at_init dbg =
   match String.Map.find_opt name !probe_semaphores with
-  | Some label -> label
+  | Some (label, e) ->
+    (match e, enabled_at_init with
+     | None, None -> ()
+     | None, Some _ ->
+       let d = (label, enabled_at_init) in
+       probe_semaphores :=
+         String.Map.remove name !probe_semaphores |>
+         String.Map.add name d
+     | Some _, None ->
+       assert false
+     | Some b, Some b' ->
+       if not (Bool.equal b b') then
+         Misc.fatal_errorf
+           "Inconsistent use of ~enabled_at_init in [%%probe %s ..] at %a"
+           name
+           Debuginfo.print_compact dbg);
+    label
   | None ->
     let sym = "caml_probes_semaphore_"^name in
-    probe_semaphores := String.Map.add name sym !probe_semaphores;
+    let d = (sym, enabled_at_init) in
+    probe_semaphores := String.Map.add name d !probe_semaphores;
     sym
 
 let emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label =
@@ -1243,7 +1260,7 @@ let emit_instr fallthrough i =
        registers.  See [emit_probe_handler_wrapper] below. *)
     emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label
   | Lop (Iprobe_is_enabled { name; }) ->
-    let semaphore_sym = find_or_add_semaphore name in
+    let semaphore_sym = find_or_add_semaphore name None i.dbg in
     (* Load unsigned 2-byte integer value of the semaphore.
        According to the documentation [1],
        semaphores are of type unsigned short.
@@ -1743,9 +1760,10 @@ let emit_probe_notes0 () =
     Printf.sprintf "%d@%s" (Reg.size_of_contents_in_bytes arg) arg_name
   in
   let describe_one_probe p =
-    let probe_name =
+    let probe_name, enabled_at_init =
       match p.probe_insn.desc with
-      | Lop (Iprobe { name; _; }) -> name
+      | Lop (Iprobe { name; enabled_at_init; handler_code_sym=_; }) ->
+        name, enabled_at_init
       | _ -> assert false
     in
     let args =
@@ -1754,7 +1772,10 @@ let emit_probe_notes0 () =
         []
       |> String.concat " "
     in
-    let semaphore_label = emit_symbol (find_or_add_semaphore probe_name) in
+    let semsym =
+      find_or_add_semaphore probe_name (Some enabled_at_init) p.probe_insn.dbg
+    in
+    let semaphore_label = emit_symbol semsym in
     let emit_desc () =
       D.qword (ConstLabel (emit_label p.probe_label));
       (match is_macosx_system with
@@ -1775,12 +1796,15 @@ let emit_probe_notes0 () =
    | true ->
      D.section ["__TEXT";"__probes"] None ["regular"]);
   D.align ~data:true 2;
-  String.Map.iter (fun _ label ->
+  String.Map.iter (fun _ (label, enabled_at_init) ->
+      (* Unresolved weak symbols have a zero value regardless
+         of the following initialization. *)
+      let enabled_at_init = Option.value enabled_at_init ~default:false in
       D.weak label;
       D.hidden label;
       _label label;
       D.word (const 0); (* for systemtap probes *)
-      D.word (const 0); (* for ocaml probes *)
+      D.word (const (Bool.to_int enabled_at_init)); (* for ocaml probes *)
       add_def_symbol label)
     !probe_semaphores
 

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -368,8 +368,8 @@ let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
       | Alloc { bytes; dbginfo; mode } -> Mach.Ialloc { bytes; dbginfo; mode }
       | Checkbound { immediate = Some x } -> Mach.Iintop_imm (Icheckbound, x)
       | Checkbound { immediate = None } -> Mach.Iintop Icheckbound
-      | Probe { name; handler_code_sym } ->
-        Mach.Iprobe { name; handler_code_sym });
+      | Probe { name; handler_code_sym; enabled_at_init } ->
+        Mach.Iprobe { name; handler_code_sym; enabled_at_init });
     Format.fprintf ppf "%sgoto %d" sep label_after
   | Specific_can_raise { op; label_after } ->
     Format.fprintf ppf "%a" specific_can_raise op;

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -294,12 +294,18 @@ let check_prim_call_operation :
     when Option.equal Int.equal expected_immediate result_immediate ->
     ()
   | ( Probe
-        { name = expected_name; handler_code_sym = expected_handler_code_sym; enabled_at_init = expected_enabled_at_init },
-      Probe { name = result_name; handler_code_sym = result_handler_code_sym; enabled_at_init = result_enabled_at_init } )
+        { name = expected_name;
+          handler_code_sym = expected_handler_code_sym;
+          enabled_at_init = expected_enabled_at_init
+        },
+      Probe
+        { name = result_name;
+          handler_code_sym = result_handler_code_sym;
+          enabled_at_init = result_enabled_at_init
+        } )
     when String.equal expected_name result_name
          && String.equal expected_handler_code_sym result_handler_code_sym
-              && Bool.equal expected_enabled_at_init result_enabled_at_init
-    ->
+         && Bool.equal expected_enabled_at_init result_enabled_at_init ->
     ()
   | _ -> different location "primitive call operation"
  [@@ocaml.warning "-4"]

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -294,10 +294,12 @@ let check_prim_call_operation :
     when Option.equal Int.equal expected_immediate result_immediate ->
     ()
   | ( Probe
-        { name = expected_name; handler_code_sym = expected_handler_code_sym },
-      Probe { name = result_name; handler_code_sym = result_handler_code_sym } )
+        { name = expected_name; handler_code_sym = expected_handler_code_sym; enabled_at_init = expected_enabled_at_init },
+      Probe { name = result_name; handler_code_sym = result_handler_code_sym; enabled_at_init = result_enabled_at_init } )
     when String.equal expected_name result_name
-         && String.equal expected_handler_code_sym result_handler_code_sym ->
+         && String.equal expected_handler_code_sym result_handler_code_sym
+              && Bool.equal expected_enabled_at_init result_enabled_at_init
+    ->
     ()
   | _ -> different location "primitive call operation"
  [@@ocaml.warning "-4"]

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -52,7 +52,7 @@ module S = struct
     | Probe of
         { name : string;
           handler_code_sym : string;
-          enabled_at_init: bool;
+          enabled_at_init : bool
         }
 
   type operation =

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -51,7 +51,8 @@ module S = struct
     | Checkbound of { immediate : int option }
     | Probe of
         { name : string;
-          handler_code_sym : string
+          handler_code_sym : string;
+          enabled_at_init: bool;
         }
 
   type operation =

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -171,7 +171,7 @@ let linearize_terminator cfg_with_layout (func : string) start
         | Checkbound { immediate = None } -> Iintop Icheckbound
         | Checkbound { immediate = Some i } -> Iintop_imm (Icheckbound, i)
         | Alloc { bytes; dbginfo; mode } -> Ialloc { bytes; dbginfo; mode }
-        | Probe { name; handler_code_sym } -> Iprobe { name; handler_code_sym }
+        | Probe { name; handler_code_sym; enabled_at_init } -> Iprobe { name; handler_code_sym; enabled_at_init }
       in
       branch_or_fallthrough [L.Lop op] label_after, None
     | Specific_can_raise { op; label_after } ->

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -171,7 +171,8 @@ let linearize_terminator cfg_with_layout (func : string) start
         | Checkbound { immediate = None } -> Iintop Icheckbound
         | Checkbound { immediate = Some i } -> Iintop_imm (Icheckbound, i)
         | Alloc { bytes; dbginfo; mode } -> Ialloc { bytes; dbginfo; mode }
-        | Probe { name; handler_code_sym; enabled_at_init } -> Iprobe { name; handler_code_sym; enabled_at_init }
+        | Probe { name; handler_code_sym; enabled_at_init } ->
+          Iprobe { name; handler_code_sym; enabled_at_init }
       in
       branch_or_fallthrough [L.Lop op] label_after, None
     | Specific_can_raise { op; label_after } ->

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -218,7 +218,10 @@ let basic_or_terminator_of_operation :
   | Iprobe { name; handler_code_sym; enabled_at_init } ->
     With_next_label
       (fun label_after ->
-         Prim { op = Probe { name; handler_code_sym; enabled_at_init }; label_after })
+        Prim
+          { op = Probe { name; handler_code_sym; enabled_at_init };
+            label_after
+          })
   | Iprobe_is_enabled { name } -> Basic (Op (Probe_is_enabled { name }))
   | Ibeginregion -> Basic (Op Begin_region)
   | Iendregion -> Basic (Op End_region)

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -215,10 +215,10 @@ let basic_or_terminator_of_operation :
     Misc.fatal_error
       "Cfgize.basic_or_terminator_of_operation: \"the Iname_for_debugger\" \
        instruction is currently not supported "
-  | Iprobe { name; handler_code_sym } ->
+  | Iprobe { name; handler_code_sym; enabled_at_init } ->
     With_next_label
       (fun label_after ->
-        Prim { op = Probe { name; handler_code_sym }; label_after })
+         Prim { op = Probe { name; handler_code_sym; enabled_at_init }; label_after })
   | Iprobe_is_enabled { name } -> Basic (Op (Probe_is_enabled { name }))
   | Ibeginregion -> Basic (Op Begin_region)
   | Iendregion -> Basic (Op End_region)

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -550,8 +550,8 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
       terminator_prim (Checkbound { immediate = Some i })
     | Ialloc { bytes; dbginfo; mode } ->
       terminator_prim (Alloc { bytes; dbginfo; mode })
-    | Iprobe { name; handler_code_sym } ->
-      terminator_prim (Probe { name; handler_code_sym })
+    | Iprobe { name; handler_code_sym; enabled_at_init } ->
+      terminator_prim (Probe { name; handler_code_sym; enabled_at_init })
     | Istackoffset bytes ->
       let desc = C.Op (C.Stackoffset bytes) in
       DLL.add_end block.body (create_instruction t desc i ~stack_offset);

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -699,7 +699,7 @@ end = struct
       assert (not (Mach.operation_can_raise op));
       let r = Value.transform next in
       check t r "heap allocation" dbg
-    | Iprobe { name; handler_code_sym } ->
+    | Iprobe { name; handler_code_sym; enabled_at_init=__ } ->
       let desc = Printf.sprintf "probe %s handler %s" name handler_code_sym in
       transform_call t ~next ~exn handler_code_sym ~desc dbg
     | Icall_ind -> transform t ~next ~exn ~effect:Value.top "indirect call" dbg

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -699,7 +699,7 @@ end = struct
       assert (not (Mach.operation_can_raise op));
       let r = Value.transform next in
       check t r "heap allocation" dbg
-    | Iprobe { name; handler_code_sym; enabled_at_init=__ } ->
+    | Iprobe { name; handler_code_sym; enabled_at_init = __ } ->
       let desc = Printf.sprintf "probe %s handler %s" name handler_code_sym in
       transform_call t ~next ~exn handler_code_sym ~desc dbg
     | Icall_ind -> transform t ~next ~exn ~effect:Value.top "indirect call" dbg

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -213,7 +213,7 @@ and operation =
   | Ccmpf of float_comparison
   | Craise of Lambda.raise_kind
   | Ccheckbound
-  | Cprobe of { name: string; handler_code_sym: string; }
+  | Cprobe of { name: string; handler_code_sym: string; enabled_at_init: bool }
   | Cprobe_is_enabled of { name: string }
   | Copaque
   | Cbeginregion | Cendregion

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -215,7 +215,7 @@ and operation =
                    then the index.
                    It results in a bounds error if the index is greater than
                    or equal to the bound. *)
-  | Cprobe of { name: string; handler_code_sym: string; }
+  | Cprobe of { name: string; handler_code_sym: string; enabled_at_init: bool }
   | Cprobe_is_enabled of { name: string }
   | Copaque (* Sys.opaque_identity *)
   | Cbeginregion | Cendregion

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4029,7 +4029,11 @@ let beginregion ~dbg = Cop (Cbeginregion, [], dbg)
 let endregion ~dbg region = Cop (Cendregion, [region], dbg)
 
 let probe ~dbg ~name ~handler_code_linkage_name ~enabled_at_init ~args =
-  Cop (Cprobe { name; handler_code_sym = handler_code_linkage_name; enabled_at_init; }, args, dbg)
+  Cop
+    ( Cprobe
+        { name; handler_code_sym = handler_code_linkage_name; enabled_at_init },
+      args,
+      dbg )
 
 let load ~dbg kind mut ~addr = Cop (Cload (kind, mut), [addr], dbg)
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4028,8 +4028,8 @@ let beginregion ~dbg = Cop (Cbeginregion, [], dbg)
 
 let endregion ~dbg region = Cop (Cendregion, [region], dbg)
 
-let probe ~dbg ~name ~handler_code_linkage_name ~args =
-  Cop (Cprobe { name; handler_code_sym = handler_code_linkage_name }, args, dbg)
+let probe ~dbg ~name ~handler_code_linkage_name ~enabled_at_init ~args =
+  Cop (Cprobe { name; handler_code_sym = handler_code_linkage_name; enabled_at_init; }, args, dbg)
 
 let load ~dbg kind mut ~addr = Cop (Cload (kind, mut), [addr], dbg)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1131,6 +1131,7 @@ val probe :
   dbg:Debuginfo.t ->
   name:string ->
   handler_code_linkage_name:string ->
+  enabled_at_init:bool ->
   args:expression list ->
   expression
 

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -511,10 +511,10 @@ let rec transl env e =
       let ptr = transl env arg in
       let dbg = Debuginfo.none in
       ptr_offset ptr offset dbg
-  | Udirect_apply(handler_code_sym, args, Some { name; }, _, _, dbg) ->
+  | Udirect_apply(handler_code_sym, args, Some { name; enabled_at_init }, _, _, dbg) ->
       let args = List.map (transl env) args in
       return_unit dbg
-        (Cop(Cprobe { name; handler_code_sym; }, args, dbg))
+        (Cop(Cprobe { name; handler_code_sym; enabled_at_init }, args, dbg))
   | Udirect_apply(lbl, args, None, result_layout, kind, dbg) ->
     let args = List.map (transl env) args in
     let sym =

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -18,6 +18,7 @@
 type error =
   | Stack_frame_too_large of int
   | Stack_frame_way_too_large of int
+  | Inconsistent_probe_init of string * Debuginfo.t
 
 exception Error of error
 
@@ -506,3 +507,7 @@ let report_error ppf = function
                         Use -long-frames compiler flag." n
   | Stack_frame_way_too_large n ->
     Format.fprintf ppf "stack frame too large (%d bytes)." n
+  | Inconsistent_probe_init (name, dbg) ->
+    Format.fprintf ppf "Inconsistent use of ~enabled_at_init in [%%probe %s ..] at %a"
+      name Debuginfo.print_compact dbg
+

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -106,6 +106,7 @@ val reduce_heap_size : reset:(unit -> unit) -> unit
 type error =
   | Stack_frame_too_large of int
   | Stack_frame_way_too_large of int
+  | Inconsistent_probe_init of string * Debuginfo.t
 
 module Dwarf_helpers : sig
   val init: disable_dwarf:bool -> string -> unit

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -79,7 +79,7 @@ type operation =
   | Ipoll of { return_label: Cmm.label option }
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
       provenance : unit option; is_assignment : bool; }
-  | Iprobe of { name: string; handler_code_sym: string; }
+  | Iprobe of { name: string; handler_code_sym: string; enabled_at_init: bool; }
   | Iprobe_is_enabled of { name: string }
   | Ibeginregion | Iendregion
 

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -89,7 +89,7 @@ type operation =
         (b) If [is_assignment] is [true], any information about other [Reg.t]s
             that have been previously deemed to hold the value of that
             identifier is forgotten. *)
-  | Iprobe of { name: string; handler_code_sym: string; }
+  | Iprobe of { name: string; handler_code_sym: string; enabled_at_init: bool; }
   | Iprobe_is_enabled of { name: string }
   | Ibeginregion | Iendregion
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -226,8 +226,9 @@ let operation d = function
   | Ccmpf c -> Printf.sprintf "%sf" (float_comparison c)
   | Craise k -> Lambda.raise_kind k ^ location d
   | Ccheckbound -> "checkbound" ^ location d
-  | Cprobe { name; handler_code_sym } ->
-    Printf.sprintf "probe[%s %s]" name handler_code_sym
+  | Cprobe { name; handler_code_sym; enabled_at_init; } ->
+    Printf.sprintf "probe[%s %s%s]" name handler_code_sym
+      (if enabled_at_init then " enabled_at_init" else "")
   | Cprobe_is_enabled {name} -> Printf.sprintf "probe_is_enabled[%s]" name
   | Cprefetch { is_write; locality; } ->
     Printf.sprintf "prefetch is_write=%b prefetch_temporal_locality_hint=%s"

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -690,8 +690,8 @@ method select_operation op args _dbg =
     (Iintop_atomic { op = Compare_and_swap; size; addr }, [compare_with; set_to; eloc])
   | (Ccheckbound, _) ->
     self#select_arith Icheckbound args
-  | (Cprobe { name; handler_code_sym; }, _) ->
-    Iprobe { name; handler_code_sym; }, args
+  | (Cprobe { name; handler_code_sym; enabled_at_init; }, _) ->
+    Iprobe { name; handler_code_sym; enabled_at_init; }, args
   | (Cprobe_is_enabled {name}, _) -> Iprobe_is_enabled {name}, []
   | (Cbeginregion, _) -> Ibeginregion, []
   | (Cendregion, _) -> Iendregion, args

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1125,7 +1125,9 @@ let close_exact_or_unknown_apply acc env
   let args, args_arity = List.split args_with_arity in
   let inlined_call = Inlined_attribute.from_lambda inlined in
   let probe_name =
-    match probe with None -> None | Some { name } -> Some name
+    match probe with
+    | None -> None
+    | Some { name; enabled_at_init } -> Some (name, enabled_at_init)
   in
   let position =
     match region_close with
@@ -2106,7 +2108,9 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
     let inlined = Inlined_attribute.from_lambda apply.inlined in
     (* Keeping the inlining attributes matches the behaviour of simplify *)
     let probe_name =
-      match apply.probe with None -> None | Some { name } -> Some name
+      match apply.probe with
+      | None -> None
+      | Some { name; enabled_at_init } -> Some (name, enabled_at_init)
     in
     let position =
       match apply.region_close with

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -79,7 +79,7 @@ type t =
     dbg : Debuginfo.t;
     inlined : Inlined_attribute.t;
     inlining_state : Inlining_state.t;
-    probe_name : string option;
+    probe_name : (string * bool) option;
     position : Position.t;
     relative_history : Inlining_history.Relative.t;
     region : Variable.t
@@ -127,7 +127,10 @@ let [@ocamlformat "disable"] print ppf
     (fun ppf probe_name ->
       match probe_name with
       | None -> Format.pp_print_string ppf "()"
-      | Some probe_name -> Format.pp_print_string ppf probe_name)
+      | Some (probe_name, enable_at_init) ->
+        Format.pp_print_string ppf probe_name;
+        if enable_at_init then Format.pp_print_string ppf "enable_at_init";
+    )
     probe_name
     (fun ppf position ->
        match position with

--- a/middle_end/flambda2/terms/apply_expr.mli
+++ b/middle_end/flambda2/terms/apply_expr.mli
@@ -57,7 +57,7 @@ val create :
   Debuginfo.t ->
   inlined:Inlined_attribute.t ->
   inlining_state:Inlining_state.t ->
-  probe_name:string option ->
+  probe_name:(string * bool) option ->
   position:Position.t ->
   relative_history:Inlining_history.Relative.t ->
   region:Variable.t ->
@@ -119,7 +119,7 @@ val inlining_state : t -> Inlining_state.t
 
 val inlining_arguments : t -> Inlining_arguments.t
 
-val probe_name : t -> string option
+val probe_name : t -> (string * bool) option
 
 val relative_history : t -> Inlining_history.Relative.t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -118,8 +118,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         env,
         res,
         Ece.all )
-    | Some name ->
-      ( C.probe ~dbg ~name ~handler_code_linkage_name:code_sym.sym_name ~args
+    | Some (name, enabled_at_init) ->
+      ( C.probe ~dbg ~name ~handler_code_linkage_name:code_sym.sym_name ~args ~enabled_at_init
         |> C.return_unit dbg,
         free_vars,
         env,

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -119,7 +119,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         res,
         Ece.all )
     | Some (name, enabled_at_init) ->
-      ( C.probe ~dbg ~name ~handler_code_linkage_name:code_sym.sym_name ~args ~enabled_at_init
+      ( C.probe ~dbg ~name ~handler_code_linkage_name:code_sym.sym_name ~args
+          ~enabled_at_init
         |> C.return_unit dbg,
         free_vars,
         env,

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -411,7 +411,7 @@ let equal_inlined_attribute (x : inlined_attribute) (y : inlined_attribute) =
     | Hint_inlined | Unroll _ | Default_inlined), _ ->
     false
 
-type probe_desc = { name: string }
+type probe_desc = { name: string; enabled_at_init: bool; }
 type probe = probe_desc option
 
 type specialise_attribute =

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -298,7 +298,7 @@ type inlined_attribute =
 val equal_inline_attribute : inline_attribute -> inline_attribute -> bool
 val equal_inlined_attribute : inlined_attribute -> inlined_attribute -> bool
 
-type probe_desc = { name: string }
+type probe_desc = { name: string; enabled_at_init: bool; }
 type probe = probe_desc option
 
 type specialise_attribute =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -863,7 +863,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           Llet(pure, Lambda.layout_module, oid,
                !transl_module ~scopes Tcoerce_none None od.open_expr, body)
       end
-  | Texp_probe {name; handler=exp} ->
+  | Texp_probe {name; handler=exp; enabled_at_init} ->
     if !Clflags.native_code && !Clflags.probes then begin
       let lam = transl_exp ~scopes exp in
       let map =
@@ -946,7 +946,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           ap_tailcall = Default_tailcall;
           ap_inlined = Never_inlined;
           ap_specialised = Always_specialise;
-          ap_probe = Some {name};
+          ap_probe = Some {name; enabled_at_init};
         }
       in
       begin match Config.flambda || Config.flambda2 with

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -439,8 +439,8 @@ let expr sub x =
         e
     | Texp_open (od, e) ->
         Texp_open (sub.open_declaration sub od, sub.expr sub e)
-    | Texp_probe {name; handler} ->
-      Texp_probe {name; handler = sub.expr sub handler }
+    | Texp_probe {name; handler; enabled_at_init;} ->
+      Texp_probe {name; handler = sub.expr sub handler; enabled_at_init}
     | Texp_probe_is_enabled _ as e -> e
     | Texp_exclave exp ->
         Texp_exclave (sub.expr sub exp)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -5498,6 +5498,19 @@ and type_expect_
           raise (Error (loc, env, Invalid_extension_constructor_payload))
       end
   | Pexp_extension ({ txt = ("probe" | "ocaml.probe"); _ }, payload) ->
+      let mk_probe ~enabled_at_init name name_loc arg =
+        check_probe_name name name_loc env;
+        let env = Env.add_lock Alloc_mode.global env in
+        Env.add_probe name;
+        let exp = type_expect env mode_global arg
+                    (mk_expected Predef.type_unit) in
+        rue {
+          exp_desc = Texp_probe {name; handler=exp; enabled_at_init};
+          exp_loc = loc; exp_extra = [];
+          exp_type = instance Predef.type_unit;
+          exp_attributes = sexp.pexp_attributes;
+          exp_env = env }
+      in
       begin match payload with
       | PStr
           ([{ pstr_desc =
@@ -5508,20 +5521,33 @@ and type_expect_
                                (Pexp_constant (Pconst_string(name,_,None)));
                              pexp_loc = name_loc;
                              _ }
-                          , [Nolabel, arg]))
+                          , ([Nolabel, arg]|
+                             [Labelled "enabled_at_init",
+                              { pexp_desc =
+                                  Pexp_construct({ txt = Longident.Lident "false"; _ },
+                                                 None); _ };
+                              Nolabel, arg])))
                    ; _ }
                   , _)}]) ->
-        check_probe_name name name_loc env;
-        let env = Env.add_lock Alloc_mode.global env in
-        Env.add_probe name;
-        let exp = type_expect env mode_global arg
-                    (mk_expected Predef.type_unit) in
-        rue {
-          exp_desc = Texp_probe {name; handler=exp};
-          exp_loc = loc; exp_extra = [];
-          exp_type = instance Predef.type_unit;
-          exp_attributes = sexp.pexp_attributes;
-          exp_env = env }
+        mk_probe ~enabled_at_init:false name name_loc arg
+      | PStr
+          ([{ pstr_desc =
+                Pstr_eval
+                  ({ pexp_desc =
+                       (Pexp_apply
+                          ({ pexp_desc=
+                               (Pexp_constant (Pconst_string(name,_,None)));
+                             pexp_loc = name_loc;
+                             _ }
+                          , [Labelled "enabled_at_init",
+                             { pexp_desc =
+                                 Pexp_construct({ txt = Longident.Lident "true"; _ },
+                                                None);
+                               _ };
+                             Nolabel, arg]))
+                   ; _ }
+                  , _)}]) ->
+        mk_probe ~enabled_at_init:true name name_loc arg
       | _ -> raise (Error (loc, env, Probe_format))
     end
   | Pexp_extension ({ txt = ("probe_is_enabled"
@@ -8041,8 +8067,9 @@ let report_error ~loc env = function
         name name
   | Probe_format ->
       Location.errorf ~loc
-        "Probe points must consist of a name, as a string \
-         literal, followed by a single expression of type unit."
+        "Probe points must consist of a name, as a string literal, \
+         optionally followed by ~enabled_at_init:true or ~enabled_at_init:false, \
+         followed by a single expression of type unit."
   | Probe_is_enabled_format ->
       Location.errorf ~loc
         "%%probe_is_enabled points must specify a single probe name as a \

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -174,7 +174,7 @@ and expression_desc =
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
   | Texp_open of open_declaration * expression
-  | Texp_probe of { name:string; handler:expression; }
+  | Texp_probe of { name:string; handler:expression; enabled_at_init:bool; }
   | Texp_probe_is_enabled of { name:string }
   | Texp_exclave of expression
 

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -351,7 +351,7 @@ and expression_desc =
   | Texp_extension_constructor of Longident.t loc * Path.t
   | Texp_open of open_declaration * expression
         (** let open[!] M in e *)
-  | Texp_probe of { name:string; handler:expression; }
+  | Texp_probe of { name:string; handler:expression; enabled_at_init:bool }
   | Texp_probe_is_enabled of { name:string }
   | Texp_exclave of expression
 

--- a/tests/backend/probes/dune
+++ b/tests/backend/probes/dune
@@ -24,3 +24,24 @@
  (target t2.output)
  (deps t2.exe)
  (action (with-outputs-to %{target} (run %{deps}))))
+
+
+(rule
+ (enabled_if
+  (and (= %{context_name} "main")
+       (= %{system} "linux")
+       (= %{architecture} "amd64")))
+ (target t3.output)
+ (deps t3.ml)
+ (action (with-outputs-to %{target}
+         (with-accepted-exit-codes 2
+         (run %{bin:ocamlopt.opt} %{deps} -color never -error-style short -warn-error "+190" -c)))))
+
+(rule
+ (alias   runtest)
+ (enabled_if
+  (and (= %{context_name} "main")
+       (= %{system} "linux")
+       (= %{architecture} "amd64")))
+ (deps t3.expected t3.output)
+ (action (diff t3.expected t3.output)))

--- a/tests/backend/probes/dune
+++ b/tests/backend/probes/dune
@@ -6,3 +6,21 @@
        (= %{architecture} "amd64")))
  (deps t1.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -warn-error "+190" -c)))
+
+(executable
+ (name t2)
+ (modules t2))
+
+(rule
+ (alias   runtest)
+ (enabled_if
+  (and (= %{context_name} "main")
+       (= %{system} "linux")
+       (= %{architecture} "amd64")))
+ (deps t2.expected t2.output)
+ (action (diff t2.expected t2.output)))
+
+(rule
+ (target t2.output)
+ (deps t2.exe)
+ (action (with-outputs-to %{target} (run %{deps}))))

--- a/tests/backend/probes/t2.expected
+++ b/tests/backend/probes/t2.expected
@@ -1,0 +1,1 @@
+enabled at init

--- a/tests/backend/probes/t2.ml
+++ b/tests/backend/probes/t2.ml
@@ -1,0 +1,5 @@
+let () =
+  [%probe "name" (Printf.printf "default\n")];
+  [%probe "name" ~enabled_at_init:true (Printf.printf "enabled at init\n")];
+  [%probe "name" ~enabled_at_init:false (Printf.printf "not enabled at init\n")];
+  ()

--- a/tests/backend/probes/t2.ml
+++ b/tests/backend/probes/t2.ml
@@ -1,5 +1,5 @@
 let () =
-  [%probe "name" (Printf.printf "default\n")];
-  [%probe "name" ~enabled_at_init:true (Printf.printf "enabled at init\n")];
-  [%probe "name" ~enabled_at_init:false (Printf.printf "not enabled at init\n")];
+  [%probe "a" (Printf.printf "default\n")];
+  [%probe "b" ~enabled_at_init:true (Printf.printf "enabled at init\n")];
+  [%probe "c" ~enabled_at_init:false (Printf.printf "not enabled at init\n")];
   ()

--- a/tests/backend/probes/t3.expected
+++ b/tests/backend/probes/t3.expected
@@ -1,0 +1,2 @@
+File "t3.ml", line 1:
+Error: Error producing assembly code for t3.ml: Inconsistent use of ~enabled_at_init in [%probe name ..] at t3.ml:3,2--75

--- a/tests/backend/probes/t3.ml
+++ b/tests/backend/probes/t3.ml
@@ -1,0 +1,5 @@
+let () =
+  [%probe "name" (Printf.printf "default\n")];
+  [%probe "name" ~enabled_at_init:true (Printf.printf "enabled at init\n")];
+  [%probe "name" ~enabled_at_init:false (Printf.printf "not enabled at init\n")];
+  ()


### PR DESCRIPTION
Initially, %probes are disabled. This PR adds `~enabled_at_init` argument to `%probe` to emit probes that are enabled at startup.

The following new constructs are accepted:
`[%probe "name" ~enabled_at_init:true handler]`
`[%probe "name" ~enabled_at_init:false handler]`

The default construct `[%probe "name" handler]` implies `~enabled_at_init:false`

Motivation: when probes are used for logging, it can be convenient in some situations to always have logging enabled in specific libraries by default. Currently, it is possible to enable probes on startup of a program but easy to forget and hard to enforce on clients of the library. It is possible to enable the relevant probes as a top-level effect of the library, but it can be slow.

The implementation is straightforward propagation of an extra field throughout the compiler. It is easy to emit `call` instead of `jmp` and set the initial state of relevant semaphores to 1 instead of 0.

This in general can lead to inconsistency with semaphores, which are associated with probe names, not individual `%probe` expressions. If a program has more than one probe with the same name in multiple compilation units, some are enabled at init and others are not, then it won't be possible to disable the sites that were enabled at init, without first enabling all the other sites of the same probe name. `enabled_at_init` should be used consistently for all `%probe` with the same name. This PR checks it at the current compilation unit level only. Separately, [ocaml-probes](https://github.com/janestreet/ocaml-probes) tool will be updated to check consistency between semaphore value and probe sites.