### PR TITLE
Add -no-rebuild options for test-one and promote-one

### DIFF
--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -307,7 +307,9 @@ promote-failed:
 
 runtest-upstream: test
 
-test-one: install_for_test
+test-one: install_for_test test-one-no-rebuild
+
+test-one-no-rebuild:
 	(export OCAMLSRCDIR=$$(pwd)/_runtest; \
 	 export CAML_LD_LIBRARY_PATH=$$(pwd)/_runtest/lib/ocaml/stublibs; \
 	 if $$(which gfortran > /dev/null 2>&1); then \
@@ -315,7 +317,9 @@ test-one: install_for_test
 	 fi; \
 	 cd _runtest/testsuite && make one $(if $(TEST),TEST="tests/$(TEST)") $(if $(DIR),DIR="tests/$(DIR)"))
 
-promote-one: install_for_test
+promote-one: install_for_test promote-one-no-rebuild
+
+promote-one-no-rebuild:
 	(export OCAMLSRCDIR=$$(pwd)/_runtest; \
 	 export CAML_LD_LIBRARY_PATH=$$(pwd)/_runtest/lib/ocaml/stublibs; \
 	 if $$(which gfortran > /dev/null 2>&1); then \


### PR DESCRIPTION
Add these targets for running a single test without incurring the cost of a dune build:

```
make test-one-no-rebuild TEST=...
make promote-one-no-rebuild TEST=...
```

This allows tests to run ~instantly rather than waiting for upward of a minute for `make test-one`. You need to build the tree before you can run `make test-one-no-rebuild`.

There is surely a more principled way to do this (like, `make test-one` shouldn't take that long if no files change), but this is a quick fix that improves my workflow by a lot.