### PR TITLE
Fix a bug that -no-rebuild introduced in test-one

### DIFF
--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -307,7 +307,8 @@ promote-failed:
 
 runtest-upstream: test
 
-test-one: install_for_test test-one-no-rebuild
+test-one: install_for_test
+	$(MAKE) test-one-no-rebuild
 
 test-one-no-rebuild:
 	(export OCAMLSRCDIR=$$(pwd)/_runtest; \
@@ -317,7 +318,8 @@ test-one-no-rebuild:
 	 fi; \
 	 cd _runtest/testsuite && make one $(if $(TEST),TEST="tests/$(TEST)") $(if $(DIR),DIR="tests/$(DIR)"))
 
-promote-one: install_for_test promote-one-no-rebuild
+promote-one: install_for_test
+	$(MAKE) promote-one-no-rebuild
 
 promote-one-no-rebuild:
 	(export OCAMLSRCDIR=$$(pwd)/_runtest; \


### PR DESCRIPTION
Fix a bug from https://github.com/ocaml-flambda/flambda-backend/pull/1391.

@goldfirere observed that running `make -j test-one` failed because it attempts to run the `install-test` and `test-one-no-rebuild` targets in parallel. I fix that by moving `test-one-no-rebuild` from a dependency to the body of the makefile target.

Testing:
  * `make test-one TEST=typing-local/local.ml -j` works on a clean checkout
  * then `make test-one-no-rebuild TEST=typing-local/local.ml` still works