### PR TITLE
Don't treat an "empty" import map as equivalent to `None`

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -99,7 +99,7 @@ let ids_for_export t =
     t Ids_for_export.empty
 
 let apply_renaming code_id_map renaming t =
-  if Renaming.is_empty renaming && Code_id.Map.is_empty code_id_map
+  if Renaming.is_identity renaming && Code_id.Map.is_empty code_id_map
   then t
   else
     Code_id.Map.fold

--- a/middle_end/flambda2/nominal/name_abstraction.ml
+++ b/middle_end/flambda2/nominal/name_abstraction.ml
@@ -55,7 +55,7 @@ let[@inline always] pattern_match_pair (type bindable)
 let apply_renaming (type bindable)
     (module Bindable : Bindable.S with type t = bindable)
     ((bindable, term) as t) renaming ~apply_renaming_to_term =
-  if Renaming.is_empty renaming
+  if Renaming.is_identity renaming
   then t
   else
     let bindable' = Bindable.apply_renaming bindable renaming in

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -1038,7 +1038,7 @@ let apply_renaming
        code_ids;
        newer_version_of_code_ids
      } as t) renaming =
-  if Renaming.is_empty renaming
+  if Renaming.is_identity renaming
   then t
   else
     let names = For_names.apply_renaming names renaming in

--- a/middle_end/flambda2/nominal/renaming.ml
+++ b/middle_end/flambda2/nominal/renaming.ml
@@ -36,8 +36,6 @@ module Import_map : sig
     original_compilation_unit:Compilation_unit.t ->
     t
 
-  val is_empty : t -> bool
-
   val const : t -> Const.t -> Const.t
 
   val variable : t -> Variable.t -> Variable.t
@@ -75,24 +73,6 @@ end = struct
              allowed for variables that are not used in the compilation unit
              they are defined in. *)
     }
-
-  let is_empty
-      { symbols;
-        variables;
-        simples;
-        consts;
-        code_ids;
-        continuations;
-        used_value_slots;
-        original_compilation_unit = _
-      } =
-    Symbol.Map.is_empty symbols
-    && Variable.Map.is_empty variables
-    && Simple.Map.is_empty simples
-    && Const.Map.is_empty consts
-    && Code_id.Map.is_empty code_ids
-    && Continuation.Map.is_empty continuations
-    && Value_slot.Set.is_empty used_value_slots
 
   let create ~symbols ~variables ~simples ~consts ~code_ids ~continuations
       ~used_value_slots ~original_compilation_unit =
@@ -154,9 +134,10 @@ let create_import_map ~symbols ~variables ~simples ~consts ~code_ids
     Import_map.create ~symbols ~variables ~simples ~consts ~code_ids
       ~continuations ~used_value_slots ~original_compilation_unit
   in
-  if Import_map.is_empty import_map
-  then empty
-  else { empty with import_map = Some import_map }
+  (* It's tempting to set [import_map] to [None] if everything is empty, but
+     this is incorrect: an import map of [None] is equivalent to having _all_
+     value slots used, not none (see [value_slot_is_used]). *)
+  { empty with import_map = Some import_map }
 
 let has_import_map t = Option.is_some t.import_map
 
@@ -180,7 +161,11 @@ let is_empty { continuations; variables; code_ids; symbols; import_map } =
   &&
   match import_map with
   | None -> true
-  | Some import_map -> Import_map.is_empty import_map
+  | Some _ ->
+    (* If there is any import map at all, then this renaming is not necessarily
+       the identity: any value slots _not_ present in [used_value_slots] will
+       cause value slots to be removed. *)
+    false
 
 let compose0
     ~second:

--- a/middle_end/flambda2/nominal/renaming.mli
+++ b/middle_end/flambda2/nominal/renaming.mli
@@ -31,7 +31,7 @@ val empty : t
 
 val print : Format.formatter -> t -> unit
 
-val is_empty : t -> bool
+val is_identity : t -> bool
 
 val create_import_map :
   symbols:Symbol.t Symbol.Map.t ->

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -47,7 +47,7 @@ end = struct
     { t with delayed_renaming }
 
   let[@inline always] descr t ~apply_renaming_descr =
-    if Renaming.is_empty t.delayed_renaming
+    if Renaming.is_identity t.delayed_renaming
     then t.descr
     else
       let descr = apply_renaming_descr t.descr t.delayed_renaming in
@@ -309,7 +309,7 @@ and apply_renaming_function_params_and_body ({ abst; is_my_closure_used } as t)
 and apply_renaming_static_const_or_code
     (static_const_or_code : static_const_or_code) renaming :
     static_const_or_code =
-  if Renaming.is_empty renaming
+  if Renaming.is_identity renaming
   then static_const_or_code
   else
     match static_const_or_code with

--- a/middle_end/flambda2/terms/static_const.ml
+++ b/middle_end/flambda2/terms/static_const.ml
@@ -230,7 +230,7 @@ let free_names t =
   | Immutable_value_array fields -> free_names_of_fields fields
 
 let apply_renaming t renaming =
-  if Renaming.is_empty renaming
+  if Renaming.is_identity renaming
   then t
   else
     match t with

--- a/middle_end/flambda2/types/grammar/type_descr.ml
+++ b/middle_end/flambda2/types/grammar/type_descr.ml
@@ -109,7 +109,7 @@ end = struct
           Flambda_colours.pop Simple.print simple
 
     let[@inline always] apply_renaming ~apply_renaming_head t renaming =
-      if Renaming.is_empty renaming
+      if Renaming.is_identity renaming
       then t
       else
         match t with

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -406,7 +406,7 @@ let free_names_head_of_kind_naked_immediate t =
   free_names_head_of_kind_naked_immediate0 ~follow_value_slots:true t
 
 let rec apply_renaming t renaming =
-  if Renaming.is_empty renaming
+  if Renaming.is_identity renaming
   then t
   else
     match t with


### PR DESCRIPTION
An import map with only empty sets does _not_ act as the identity function: it causes all value slots to be removed. Therefore `Renaming.create_import_map` must not set `import_map` to `None` if `used_value_slots` is empty, since then `value_slot_is_used` returns _true_ for all value slots rather than false. Similarly, `Renaming.is_empty` (which is taken to mean that the renaming is the identity function) should return false whenever there is _any_ import map.

I've removed `Import_map.is_empty` entirely, since the value it returns is meaningless.

In principle, this could cause a performance hit, since `Exported_code.apply_renaming` will never shortcut out when importing. However, the status quo is not much better, since `Exported_code.apply_renaming` currently _fails_ to shortcut out whenever there is a _single_ used value slot anywhere in the entire compilation unit.

Possible additions/alternatives:

1. We could instead change `Import_map.t` to store the value slots that are _not_ used rather than the ones that _are_, since then the empty set once again means that nothing will change. (Basically, `used_value_slots` is the only field in all of `rewriting.ml` that is _smaller_ when the renaming changes _more_ things.)
2. We could make this change and also rename `Rewriting.is_empty` as `Rewriting.is_identity` for clarity.