### PR TITLE
Linear scan: better spilling heuristic (port ocaml#11686)

### DIFF
--- a/backend/linscan.ml
+++ b/backend/linscan.ml
@@ -17,66 +17,111 @@
 (* Linear scan register allocation. *)
 
 open Interval
-open Reg
+
+module IntervalSet = Set.Make (struct
+    type t = Interval.t
+    let compare i j =
+      let c = Int.compare i.iend j.iend in
+      if c = 0 then Int.compare i.reg.stamp j.reg.stamp else c
+  end)
+
+module SlotSet = Set.Make(Int)
 
 (* Live intervals per register class *)
 
 type class_intervals =
   {
-    mutable ci_fixed: Interval.t list;
-    mutable ci_active: Interval.t list;
-    mutable ci_inactive: Interval.t list;
+    mutable ci_fixed: IntervalSet.t;
+    mutable ci_active: IntervalSet.t;
+    mutable ci_inactive: IntervalSet.t;
+    mutable ci_spilled:
+      (* spilled stack slots (reg.loc = Stack (Local n)) still in use *)
+      IntervalSet.t;
+    mutable ci_free_slots:
+      (* expired stack slots available for reuse *)
+      SlotSet.t;
   }
 
 let active = Array.init Proc.num_register_classes (fun _ -> {
-  ci_fixed = [];
-  ci_active = [];
-  ci_inactive = []
+  ci_fixed = IntervalSet.empty;
+  ci_active = IntervalSet.empty;
+  ci_inactive = IntervalSet.empty;
+  ci_spilled = IntervalSet.empty;
+  ci_free_slots = SlotSet.empty;
 })
 
-(* Insert interval into list sorted by end position *)
+let slot_of_spilled i =
+  match i.reg.loc with
+  | Stack(Local ss) -> ss
+  | _ -> invalid_arg "Linscan.slot_of_spilled"
 
-let rec insert_interval_sorted i = function
-    [] -> [i]
-  | j :: _ as il when j.iend <= i.iend -> i :: il
-  | j :: il -> j :: insert_interval_sorted i il
 
-let rec release_expired_fixed pos = function
-    i :: il when i.iend >= pos ->
-      Interval.remove_expired_ranges i pos;
-      i :: release_expired_fixed pos il
-  | _ -> []
+let split_by_pos intervals pos =
+  let divider =
+    (* this interval is strictly above intervals [i] with [i.iend < pos] and
+       strictly below [i] with [i.iend >= pos]. We use a dummy register with a
+       non-existent [stamp] to make sure that it is not "equal" to any of the
+       intervals in the set (according to the equality function of [IntervalSet]
+       above). *)
+    {Interval.reg = {Reg.dummy with stamp = -1};
+     ibegin = pos;
+     iend = pos;
+     ranges = []}
+  in
+  let (before, divider_in_set, after) = IntervalSet.split divider intervals in
+  assert (not divider_in_set);
+  (before, after)
 
-let rec release_expired_active ci pos = function
-    i :: il when i.iend >= pos ->
-      Interval.remove_expired_ranges i pos;
-      if Interval.is_live i pos then
-        i :: release_expired_active ci pos il
-      else begin
-        ci.ci_inactive <- insert_interval_sorted i ci.ci_inactive;
-        release_expired_active ci pos il
-      end
-  | _ -> []
+let remove_expired_ranges intervals pos =
+  IntervalSet.iter (fun i -> Interval.remove_expired_ranges i pos) intervals
 
-let rec release_expired_inactive ci pos = function
-    i :: il when i.iend >= pos ->
-      Interval.remove_expired_ranges i pos;
-      if not (Interval.is_live i pos) then
-        i :: release_expired_inactive ci pos il
-      else begin
-        ci.ci_active <- insert_interval_sorted i ci.ci_active;
-        release_expired_inactive ci pos il
-      end
-  | _ -> []
+let release_expired_spilled ci pos =
+  let (expired, rest) = split_by_pos ci.ci_spilled pos in
+  ci.ci_free_slots <-
+    IntervalSet.fold (fun i free -> SlotSet.add (slot_of_spilled i) free)
+      expired ci.ci_free_slots;
+  ci.ci_spilled <- rest
+
+let release_expired_fixed ci pos =
+  let (_expired, rest) = split_by_pos ci.ci_fixed pos in
+  remove_expired_ranges rest pos;
+  ci.ci_fixed <- rest
+
+let partition_live intervals pos =
+  IntervalSet.partition (fun i -> Interval.is_live i pos) intervals
+
+let release_expired_active ci pos =
+  let (_expired, rest) = split_by_pos ci.ci_active pos in
+  remove_expired_ranges rest pos;
+  let active, inactive = partition_live rest pos in
+  ci.ci_active <- active;
+  ci.ci_inactive <- IntervalSet.union inactive ci.ci_inactive
+
+let release_expired_inactive ci pos =
+  let (_expired, rest) = split_by_pos ci.ci_inactive pos in
+  remove_expired_ranges rest pos;
+  let active, inactive = partition_live rest pos in
+  ci.ci_inactive <- inactive;
+  ci.ci_active <- IntervalSet.union active ci.ci_active
 
 (* Allocate a new stack slot to the interval. *)
 
 let allocate_stack_slot num_stack_slots i =
   let cl = Proc.register_class i.reg in
-  let ss = num_stack_slots.(cl) in
-  num_stack_slots.(cl) <- succ ss;
+  let ci = active.(cl) in
+  let ss =
+    match SlotSet.min_elt_opt ci.ci_free_slots with
+    | Some ss ->
+        ci.ci_free_slots <- SlotSet.remove ss ci.ci_free_slots;
+        ss
+    | None ->
+        let ss = num_stack_slots.(cl) in
+        num_stack_slots.(cl) <- succ ss;
+        ss
+  in
   i.reg.loc <- Stack(Local ss);
-  i.reg.spill <- true
+  i.reg.spill <- true;
+  ci.ci_spilled <- IntervalSet.add i ci.ci_spilled
 
 (* Find a register for the given interval and assigns this register.
    The interval is added to active. Raises Not_found if no free registers
@@ -104,7 +149,7 @@ let allocate_free_register num_stack_slots i =
                    registers) *)
           let regmask = Array.make rn true in
           (* Remove all assigned registers from the register mask *)
-          List.iter
+          IntervalSet.iter
             (function
               {reg = {loc = Reg r}} ->
                 if r - r0 < rn then regmask.(r - r0) <- false
@@ -117,8 +162,8 @@ let allocate_free_register num_stack_slots i =
                    && Interval.overlap j i then
                 regmask.(r - r0) <- false
             | _ -> () in
-          List.iter remove_bound_overlapping ci.ci_inactive;
-          List.iter remove_bound_overlapping ci.ci_fixed;
+          IntervalSet.iter remove_bound_overlapping ci.ci_inactive;
+          IntervalSet.iter remove_bound_overlapping ci.ci_fixed;
           (* Assign the first free register (if any) *)
           let rec assign r =
             if r = rn then
@@ -128,7 +173,7 @@ let allocate_free_register num_stack_slots i =
                  current interval into the active list *)
               i.reg.loc <- Reg (r0 + r);
               i.reg.spill <- false;
-              ci.ci_active <- insert_interval_sorted i ci.ci_active
+              ci.ci_active <- IntervalSet.add i ci.ci_active
             end else
               assign (succ r) in
           assign 0
@@ -139,20 +184,22 @@ let allocate_free_register num_stack_slots i =
 let allocate_blocked_register num_stack_slots i =
   let cl = Proc.register_class i.reg in
   let ci = active.(cl) in
-  match ci.ci_active with
-  | ilast :: il when
+  match IntervalSet.max_elt_opt ci.ci_active with
+  | Some ilast when
       ilast.iend > i.iend &&
       (* Last interval in active is the last interval, so spill it. *)
       let chk r = r.reg.loc = ilast.reg.loc && Interval.overlap r i in
       (* But only if its physical register is admissible for the current
          interval. *)
-      not (List.exists chk ci.ci_fixed || List.exists chk ci.ci_inactive)
+      not (IntervalSet.exists chk ci.ci_fixed ||
+           IntervalSet.exists chk ci.ci_inactive)
     ->
+      let il = IntervalSet.remove ilast ci.ci_active in
       begin match ilast.reg.loc with Reg _ -> () | _ -> assert false end;
       (* Use register from last interval for current interval *)
       i.reg.loc <- ilast.reg.loc;
       (* Remove the last interval from active and insert the current *)
-      ci.ci_active <- insert_interval_sorted i il;
+      ci.ci_active <- IntervalSet.add i il;
       (* Now get a new stack slot for the spilled register *)
       allocate_stack_slot num_stack_slots ilast
   | _ ->
@@ -166,9 +213,10 @@ let walk_interval num_stack_slots i =
   (* Release all intervals that have been expired at the current position *)
   Array.iter
     (fun ci ->
-      ci.ci_fixed <- release_expired_fixed pos ci.ci_fixed;
-      ci.ci_active <- release_expired_active ci pos ci.ci_active;
-      ci.ci_inactive <- release_expired_inactive ci pos ci.ci_inactive)
+      release_expired_fixed ci pos;
+      release_expired_active ci pos;
+      release_expired_inactive ci pos;
+      release_expired_spilled ci pos)
     active;
   try
     (* Allocate free register (if any) *)
@@ -183,9 +231,11 @@ let allocate_registers() =
   for cl = 0 to Proc.num_register_classes - 1 do
     (* Start with empty interval lists *)
     active.(cl) <- {
-      ci_fixed = [];
-      ci_active = [];
-      ci_inactive = []
+      ci_fixed = IntervalSet.empty;
+      ci_active = IntervalSet.empty;
+      ci_inactive = IntervalSet.empty;
+      ci_spilled = IntervalSet.empty;
+      ci_free_slots = SlotSet.empty;
     };
   done;
   (* Reset the stack slot counts *)
@@ -194,7 +244,7 @@ let allocate_registers() =
   List.iter
     (fun i ->
       let ci = active.(Proc.register_class i.reg) in
-      ci.ci_fixed <- insert_interval_sorted i ci.ci_fixed)
+      ci.ci_fixed <- IntervalSet.add i ci.ci_fixed)
     (Interval.all_fixed_intervals());
   (* Walk all the intervals within the list *)
   List.iter (walk_interval num_stack_slots) (Interval.all_intervals());


### PR DESCRIPTION
Port https://github.com/ocaml/ocaml/pull/11686 to `backend/linscan.ml` only, for its benefits for linscan performance and output. 
Porting to `asmcomp` and `cfg` can be done in separate PRs.

For example, it takes frame size from `41304` down to `8296` bytes when building `owl_lapacke_bindings` from  https://github.com/owlbarn/owl/  with `-linscan`  with `flambda2` classic mode and the file can be built without `-long-frames`. 