### PR TITLE
Change default major GC window size to 3

### DIFF
--- a/ocaml/runtime/caml/config.h
+++ b/ocaml/runtime/caml/config.h
@@ -245,10 +245,9 @@ typedef uint64_t uintnat;
  */
 #define Max_percent_free_def 500
 
-/* Default setting for the major GC slice smoothing window: 1
-   (i.e. no smoothing)
+/* Default setting for the major GC slice smoothing window
 */
-#define Major_window_def 1
+#define Major_window_def 3
 
 /* Maximum size of the major GC slice smoothing window. */
 #define Max_major_window 50

--- a/ocaml/runtime/major_gc.c
+++ b/ocaml/runtime/major_gc.c
@@ -115,7 +115,7 @@ int caml_ephe_list_pure;
 static value *ephes_checked_if_pure;
 static value *ephes_to_check;
 
-int caml_major_window = 1;
+int caml_major_window = Major_window_def;
 double caml_major_ring[Max_major_window] = { 0. };
 int caml_major_ring_index = 0;
 double caml_major_work_credit = 0.0;


### PR DESCRIPTION
The major GC has a smoothing facility that allows long slices to be spread out over adjacent slices, but it's almost unused. This patch turns it on by default.

cc @lpw25 