### PR TITLE
Add more owners of the upstream tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,8 +65,8 @@ native_toplevel/                @mshinwell
 
 ocaml/asmcomp/                  @gretay-js @xclerc
 ocaml/runtime/                  @stedolan
-ocaml/typing/                   @lpw25 @antalsz @ccasin @goldfirere @rqian @ncik-roberts @stedolan
-ocaml/testsuite/tests/          @lpw25 @antalsz @ccasin @goldfirere @rqian @ncik-roberts @stedolan @mshinwell @poechsel @gretay-js @xclerc @lukemaurer
+ocaml/typing/                   @lpw25 @antalsz @ccasin @goldfirere @riaqn @ncik-roberts @stedolan
+ocaml/testsuite/tests/          @lpw25 @antalsz @ccasin @goldfirere @riaqn @ncik-roberts @stedolan @mshinwell @poechsel @gretay-js @xclerc @lukemaurer
 
 scripts/                        @mshinwell
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,7 @@ native_toplevel/                @mshinwell
 ocaml/asmcomp/                  @gretay-js @xclerc
 ocaml/runtime/                  @stedolan
 ocaml/typing/                   @lpw25 @antalsz @ccasin @goldfirere @rqian @ncik-roberts @stedolan
+ocaml/testsuite/tests/          @lpw25 @antalsz @ccasin @goldfirere @rqian @ncik-roberts @stedolan @mshinwell @poechsel @gretay-js @xclerc @lukemaurer
 
 scripts/                        @mshinwell
 


### PR DESCRIPTION
This makes every Jane Street employee who owns any part of the compiler also own the upstream tests.  Currently Mark has to approve every change there, which is silly, and this is the easiest solution.
