### PR TITLE
zero alloc compiler hooks

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -412,6 +412,8 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduc
          (fun () ->
             gen ();
             Checkmach.record_unit_info ppf_dump;
+            Compiler_hooks.execute Compiler_hooks.Check_allocations
+              Checkmach.iter_witnesses;
             write_ir output_prefix)
          ~always:(fun () ->
              if create_asm then close_out !Emitaux.output_channel)

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -299,7 +299,6 @@ module Value : sig
   val remove_witnesses : t -> t
 
   val get_witnesses : t -> Witnesses.components
-
 end = struct
   (** Lifts V to triples  *)
   type t =

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -128,6 +128,10 @@ module Witnesses : sig
 
   val empty : t
 
+  val is_empty : t -> bool
+
+  val iter : t -> f:(Witness.t -> unit) -> unit
+
   val join : t -> t -> t
 
   val create : Witness.kind -> Debuginfo.t -> t
@@ -152,6 +156,8 @@ end = struct
   let join = union
 
   let create kind dbg = singleton (Witness.create dbg kind)
+
+  let iter t ~f = iter f t
 
   let print ppf t = Format.pp_print_seq Witness.print ppf (to_seq t)
 
@@ -187,6 +193,8 @@ module V : sig
   val replace_witnesses : Witnesses.t -> t -> t
 
   val diff_witnesses : expected:t -> actual:t -> Witnesses.t
+
+  val get_witnesses : t -> Witnesses.t
 
   val is_not_safe : t -> bool
 
@@ -228,6 +236,9 @@ end = struct
     | Top w' -> Top (Witnesses.join w w')
 
   let replace_witnesses w t = match t with Top _ -> Top w | Bot | Safe -> t
+
+  let get_witnesses t =
+    match t with Top w -> w | Bot | Safe -> Witnesses.empty
 
   let diff_witnesses ~expected ~actual =
     if lessequal actual expected
@@ -286,6 +297,9 @@ module Value : sig
   val diff_witnesses : expected:t -> actual:t -> Witnesses.components
 
   val remove_witnesses : t -> t
+
+  val get_witnesses : t -> Witnesses.components
+
 end = struct
   (** Lifts V to triples  *)
   type t =
@@ -325,6 +339,12 @@ end = struct
     }
 
   let remove_witnesses t = replace_witnesses Witnesses.empty t
+
+  let get_witnesses t =
+    { Witnesses.nor = V.get_witnesses t.nor;
+      Witnesses.exn = V.get_witnesses t.exn;
+      Witnesses.div = V.get_witnesses t.div
+    }
 
   let normal_return = { bot with nor = V.Safe }
 
@@ -1132,5 +1152,12 @@ let reset_unit_info () = Unit_info.reset unit_info
 let record_unit_info ppf_dump =
   Check_zero_alloc.record_unit unit_info ppf_dump;
   Compilenv.cache_checks (Compilenv.current_unit_infos ()).ui_checks
+
+type iter_witnesses = (string -> Witnesses.components -> unit) -> unit
+
+let iter_witnesses f =
+  Unit_info.iter unit_info ~f:(fun func_info ->
+      f func_info.name
+        (Value.get_witnesses func_info.value |> Witnesses.simplify))
 
 let () = Location.register_error_of_exn Annotation.report_error

--- a/backend/checkmach.mli
+++ b/backend/checkmach.mli
@@ -62,7 +62,7 @@ module Witness : sig
           handler_code_sym : string
         }
 
- type t =
+  type t =
     { dbg : Debuginfo.t;
       kind : kind
     }

--- a/backend/checkmach.mli
+++ b/backend/checkmach.mli
@@ -40,3 +40,57 @@ val fundecl :
   future_funcnames:Misc.Stdlib.String.Set.t ->
   Mach.fundecl ->
   Mach.fundecl
+
+(** When the check fails, [Witness.t] represents an instruction that does
+    not satisfy the property. *)
+module Witness : sig
+  type kind =
+    | Alloc of
+        { bytes : int;
+          dbginfo : Debuginfo.alloc_dbginfo
+        }
+    | Indirect_call
+    | Indirect_tailcall
+    | Direct_call of { callee : string }
+    | Direct_tailcall of { callee : string }
+    | Missing_summary of { callee : string }
+    | Forward_call of { callee : string }
+    | Extcall of { callee : string }
+    | Arch_specific
+    | Probe of
+        { name : string;
+          handler_code_sym : string
+        }
+
+ type t =
+    { dbg : Debuginfo.t;
+      kind : kind
+    }
+end
+
+module Witnesses : sig
+  type t
+
+  val is_empty : t -> bool
+
+  val iter : t -> f:(Witness.t -> unit) -> unit
+
+  (** The witnesses are classified into which path they may appear on. If a witness
+      appears on both a path to a normal and an excpetional return, it will only appear in
+      [nor] component. *)
+  type components =
+    { nor : t;  (** on a path from function entry to a normal return  *)
+      exn : t;  (** on a path from function entry to an exceptionall return  *)
+      div : t  (** on a path from function entry that may diverge *)
+    }
+end
+
+(**   Iterate over all function symbols with their witnesses. This function can be called
+      at any time, but the complete information is only available after a call to
+      [record_unit_info].  To get all witnesses for all functions, and not only for
+      functions annotated with [@zero_alloc], set
+      [Flambda_backend_flags.checkmach_details_cutoff] to a negative value before calls to
+      [fundecl].  Used by compiler_hooks. *)
+type iter_witnesses = (string -> Witnesses.components -> unit) -> unit
+
+val iter_witnesses : iter_witnesses

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -129,7 +129,6 @@ let register : type a. a pass -> (a -> unit) -> unit =
   | Cmm -> hooks.cmm <- f :: hooks.cmm
   | Inlining_tree -> hooks.inlining_tree <- f :: hooks.inlining_tree
   | Check_allocations ->
-    Flambda_backend_flags.checkmach_details_cutoff := -1;
     hooks.check_allocations <- f :: hooks.check_allocations
 
 let execute : type a. a pass -> a -> unit =
@@ -159,7 +158,10 @@ let execute : type a. a pass -> a -> unit =
   | Cfg -> execute_hooks hooks.cfg arg
   | Cmm -> execute_hooks hooks.cmm arg
   | Inlining_tree -> execute_hooks hooks.inlining_tree arg
-  | Check_allocations -> execute_hooks hooks.check_allocations arg
+  | Check_allocations ->
+    Misc.protect_refs
+      [ Misc.R (Flambda_backend_flags.checkmach_details_cutoff, -1) ]
+      (fun () -> execute_hooks hooks.check_allocations arg)
 
 let execute_and_pipe r a = execute r a; a
 

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -40,6 +40,7 @@ type _ pass =
   | Cmm : Cmm.phrase list pass
 
   | Inlining_tree : Flambda2_simplify_shared.Inlining_report.Inlining_tree.t pass
+  | Check_allocations : Checkmach.iter_witnesses pass
 
 type t = {
   mutable parse_tree_intf : (Parsetree.signature -> unit) list;
@@ -65,7 +66,8 @@ type t = {
   mutable linear : (Linear.fundecl -> unit) list;
   mutable cfg : (Cfg_with_layout.t -> unit) list;
   mutable cmm : (Cmm.phrase list -> unit) list;
-  mutable inlining_tree : (Flambda2_simplify_shared.Inlining_report.Inlining_tree.t -> unit) list
+  mutable inlining_tree : (Flambda2_simplify_shared.Inlining_report.Inlining_tree.t -> unit) list;
+  mutable check_allocations : (Checkmach.iter_witnesses -> unit) list
 }
 let hooks : t = {
   parse_tree_intf = [];
@@ -92,6 +94,7 @@ let hooks : t = {
   cfg = [];
   cmm = [];
   inlining_tree = [];
+  check_allocations = [];
 }
 
 let execute_hooks : type a. (a -> unit) list -> a -> unit = fun hooks arg ->
@@ -125,6 +128,9 @@ let register : type a. a pass -> (a -> unit) -> unit =
   | Cfg -> hooks.cfg <- f :: hooks.cfg
   | Cmm -> hooks.cmm <- f :: hooks.cmm
   | Inlining_tree -> hooks.inlining_tree <- f :: hooks.inlining_tree
+  | Check_allocations ->
+    Flambda_backend_flags.checkmach_details_cutoff := -1;
+    hooks.check_allocations <- f :: hooks.check_allocations
 
 let execute : type a. a pass -> a -> unit =
   fun representation arg ->
@@ -153,6 +159,7 @@ let execute : type a. a pass -> a -> unit =
   | Cfg -> execute_hooks hooks.cfg arg
   | Cmm -> execute_hooks hooks.cmm arg
   | Inlining_tree -> execute_hooks hooks.inlining_tree arg
+  | Check_allocations -> execute_hooks hooks.check_allocations arg
 
 let execute_and_pipe r a = execute r a; a
 
@@ -182,3 +189,4 @@ let clear : type a. a pass -> unit =
   | Cfg -> hooks.cfg <- []
   | Cmm -> hooks.cmm <- []
   | Inlining_tree -> hooks.inlining_tree <- []
+  | Check_allocations -> hooks.check_allocations <- []

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -53,6 +53,7 @@ type _ pass =
   | Cmm : Cmm.phrase list pass
 
   | Inlining_tree : Flambda2_simplify_shared.Inlining_report.Inlining_tree.t pass
+  | Check_allocations : Checkmach.iter_witnesses pass
 
 (* Register a new hook for [pass]. *)
 val register : 'a pass -> ('a -> unit) -> unit


### PR DESCRIPTION
~On top of https://github.com/ocaml-flambda/flambda-backend/pull/1407 starting from [Add Value.get_witnesses](https://github.com/ocaml-flambda/flambda-backend/commit/7ad012ec6122780d67f94f70f94e857dcd286cfb).~ 
Based on PR https://github.com/ocaml-flambda/flambda-backend/pull/858. 
