### PR TITLE
zero alloc: warning 198 about assume

### DIFF
--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -316,6 +316,7 @@ let get_property_attribute l p ~fun_attr =
               fun_attr.specialise = Never_specialise
            else
               (* closure drops [@specialise never] and never specialises *)
+              (* flambda2 does not have specialisation support yet *)
               true
          in
          if not ((fun_attr.inline = Never_inline) && never_specialise) then

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -314,7 +314,7 @@ let get_property_attribute l p ~fun_attr =
          (* [attr.inline] and [attr.specialise] must be set before the
             check for [Warnings.Misplaced_assume_attribute].
             For attributes from the same list, it's fine because
-            [add_check_attribute] is called before
+            [add_check_attribute] is called after
             [add_inline_attribute] and [add_specialise_attribute].
             The warning will spuriously fire in the following case:
             let[@inline never][@specialise never] f =

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -311,6 +311,15 @@ let get_property_attribute l p ~fun_attr =
           through the [@@@zero_alloc all] top-level annotation rather than through the
           function annotation [@zero_alloc]. *)
        if assume then begin
+         (* [attr.inline] and [attr.specialise] must be set before the
+            check for [Warnings.Misplaced_assume_attribute].
+            For attributes from the same list, it's fine because
+            [add_check_attribute] is called before
+            [add_inline_attribute] and [add_specialise_attribute].
+            The warning will spuriously fire in the following case:
+            let[@inline never][@specialise never] f =
+              fun[@zero_alloc assume] x -> ..
+         *)
          let never_specialise =
            if Config.flambda then
               fun_attr.specialise = Never_specialise

--- a/ocaml/utils/warnings.ml
+++ b/ocaml/utils/warnings.ml
@@ -108,6 +108,7 @@ type t =
   | Unused_tmc_attribute                    (* 71 *)
   | Tmc_breaks_tailcall                     (* 72 *)
   | Probe_name_too_long of string           (* 190 *)
+  | Misplaced_assume_attribute of string    (* 198 *)
   | Unchecked_property_attribute of string  (* 199 *)
 ;;
 
@@ -192,6 +193,7 @@ let number = function
   | Unused_tmc_attribute -> 71
   | Tmc_breaks_tailcall -> 72
   | Probe_name_too_long _ -> 190
+  | Misplaced_assume_attribute _  -> 198
   | Unchecked_property_attribute _ -> 199
 ;;
 
@@ -453,6 +455,10 @@ let descriptions = [
   { number = 190;
     names = ["probe-name-too-long"];
     description = "Probe name must be at most 100 characters long." };
+  { number = 198;
+    names = ["misplaced-assume-attribute"];
+    description = "Assume of a property is ignored \
+                   if the function is inlined or specialised." };
   { number = 199;
     names = ["unchecked-property-attribute"];
     description = "A property of a function that was \
@@ -1060,6 +1066,12 @@ let message = function
       Printf.sprintf
         "This probe name is too long: `%s'. \
          Probe names must be at most 100 characters long." name
+  | Misplaced_assume_attribute property ->
+      Printf.sprintf
+        "the \"%s assume\" attribute will be ignored by the check \
+         when the function is inlined or specialised.\n\
+         Mark this function as [@inline never][@specialise never]."
+      property
   | Unchecked_property_attribute property ->
       Printf.sprintf "the %S attribute cannot be checked.\n\
       The function it is attached to was optimized away. \n\

--- a/ocaml/utils/warnings.mli
+++ b/ocaml/utils/warnings.mli
@@ -111,6 +111,7 @@ type t =
   | Tmc_breaks_tailcall                     (* 72 *)
 (* Flambda_backend specific warnings: numbers should go down from 199 *)
   | Probe_name_too_long of string           (* 190 *)
+  | Misplaced_assume_attribute of string    (* 198 *)
   | Unchecked_property_attribute of string  (* 199 *)
 ;;
 

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -3,19 +3,19 @@
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps s.ml t.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
 
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps t5.ml test_assume.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
 
 (rule
  (alias   runtest)
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps test_flambda.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
 
 (rule
  (enabled_if (= %{context_name} "main"))
@@ -26,7 +26,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -45,7 +45,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -64,7 +64,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -83,7 +83,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -102,7 +102,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -121,7 +121,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -140,7 +140,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -159,7 +159,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -178,7 +178,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -197,7 +197,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -216,7 +216,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -235,7 +235,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -254,7 +254,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -273,7 +273,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -292,7 +292,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -311,7 +311,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -330,7 +330,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -349,7 +349,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -368,7 +368,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -387,7 +387,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -406,7 +406,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -425,7 +425,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 0
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -444,7 +444,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 0
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -458,16 +458,54 @@
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps t7.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
 
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps test_stub_dep.ml test_stub.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
 
 (rule
  (alias   runtest)
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps t1.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_warning198.output.corrected)
+ (deps (:ml test_warning198.ml) filter.sh)
+ (action
+   (with-outputs-to test_warning198.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 0
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_warning198.output test_warning198.output.corrected)
+ (action (diff test_warning198.output test_warning198.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (targets test_warning199.output.corrected)
+ (deps (:ml test_warning199.mli test_warning199.ml) filter.sh)
+ (action
+   (with-outputs-to test_warning199.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 0
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (deps test_warning199.output test_warning199.output.corrected)
+ (action (diff test_warning199.output test_warning199.output.corrected)))

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -3,19 +3,19 @@
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps s.ml t.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps t5.ml test_assume.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps test_flambda.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (enabled_if (= %{context_name} "main"))
@@ -26,7 +26,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -45,7 +45,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -64,7 +64,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -83,7 +83,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -102,7 +102,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -121,7 +121,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -140,7 +140,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -159,7 +159,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -178,7 +178,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -197,7 +197,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -216,7 +216,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -235,7 +235,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -254,7 +254,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -273,7 +273,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -292,7 +292,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -311,7 +311,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -330,7 +330,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -349,7 +349,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -368,7 +368,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -387,7 +387,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -406,7 +406,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -425,7 +425,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 0
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -444,7 +444,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 0
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -458,19 +458,19 @@
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps t7.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps test_stub_dep.ml test_stub.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps t1.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (enabled_if (= %{context_name} "main"))
@@ -481,7 +481,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 0
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -500,7 +500,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 0
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -22,7 +22,7 @@ let () =
  (alias   runtest)
  ${enabled_if}
  (deps ${deps})
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
@@ -56,7 +56,7 @@ let () =
     (pipe-outputs
     (with-accepted-exit-codes ${exit_code}
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff ${cutoff} -O3))
+          -zero-alloc-check -checkmach-details-cutoff ${cutoff} -O3 -w +199+198))
     (run "./filter.sh")
    ))))
 
@@ -114,3 +114,7 @@ let () =
   (* flambda2 generates an indirect call but we don't yet have a way to exclude it
      without excluding closure. *)
   print_test ~flambda_only:true ~deps:"t1.ml";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:0
+    "test_warning198";
+  (* closure does not delete dead functions *)
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:(Some "test_warning199.mli") ~exit_code:0 "test_warning199";

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -22,7 +22,7 @@ let () =
  (alias   runtest)
  ${enabled_if}
  (deps ${deps})
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3 -w +199+198)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
@@ -56,7 +56,7 @@ let () =
     (pipe-outputs
     (with-accepted-exit-codes ${exit_code}
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff ${cutoff} -O3 -w +199+198))
+          -zero-alloc-check -checkmach-details-cutoff ${cutoff} -O3))
     (run "./filter.sh")
    ))))
 

--- a/tests/backend/checkmach/t5.ml
+++ b/tests/backend/checkmach/t5.ml
@@ -1,9 +1,9 @@
-let[@zero_alloc strict assume][@inline never] test x = [x;x+1]
+let[@zero_alloc strict assume][@inline never][@specialise never] test x = [x;x+1]
 (* The test below to make sure "noalloc" on external is still handled correctly. *)
 external external_test_noalloc : unit -> unit = "test" [@@noalloc]
 external external_test : unit -> unit = "test"
 
-let[@zero_alloc assume][@inline never] test4 x =
+let[@zero_alloc assume][@inline never][@specialise never] test4 x =
   if x > (-100)
   then x
   else raise (Failure ("don't be so negative, "^(string_of_int x)))

--- a/tests/backend/checkmach/t6.ml
+++ b/tests/backend/checkmach/t6.ml
@@ -12,16 +12,16 @@ let[@zero_alloc strict] pass3 x y = x + y
 let[@zero_alloc ignore] test1 x = (x, x)
 
 (* assume still works *)
-let[@zero_alloc assume][@inline never] fail_loud x = [ x; x+1 ]
+let[@zero_alloc assume][@inline never][@specialise never] fail_loud x = [ x; x+1 ]
 
 let call_loud x = fail_loud (x*2)
 
 (* assume strict still works *)
-let[@inline never][@zero_alloc strict assume] fail_loud2 x = raise (Exn (x,x))
+let[@inline never][@specialise never][@zero_alloc strict assume] fail_loud2 x = raise (Exn (x,x))
 
 let[@zero_alloc strict] call_loud2 x = fail_loud2 (x+1)
 
 (* For duplicate attributes we get a warning and the first one takes effect. *)
-let[@inline never][@zero_alloc strict assume][@zero_alloc ignore] fail_loud1 x = raise (Exn (x,x))
+let[@inline never][@specialise never][@zero_alloc strict assume][@zero_alloc ignore] fail_loud1 x = raise (Exn (x,x))
 
 let[@zero_alloc strict] call_loud1 x = fail_loud1 (x+1)

--- a/tests/backend/checkmach/t6.output
+++ b/tests/backend/checkmach/t6.output
@@ -1,2 +1,2 @@
-File "t6.ml", line 25, characters 47-57:
+File "t6.ml", line 25, characters 66-76:
 Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression

--- a/tests/backend/checkmach/test_assume.ml
+++ b/tests/backend/checkmach/test_assume.ml
@@ -1,4 +1,4 @@
-let[@zero_alloc strict assume][@inline never] test1 n = (n,n)
+let[@zero_alloc strict assume][@inline never][@specialise never] test1 n = (n,n)
 let[@zero_alloc strict] test2 n = test1 (n+1)
 let[@zero_alloc strict] test3 n = T5.test n
 let no_annotations x y = x * y

--- a/tests/backend/checkmach/test_attribute_error_duplicate.ml
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.ml
@@ -1,5 +1,5 @@
 let[@zero_alloc strict][@zero_alloc strict] test1 x = x,x
-let[@zero_alloc strict assume][@zero_alloc strict] test2 x = x,x
+let[@inline never][@specialise never][@zero_alloc strict assume][@zero_alloc strict] test2 x = x,x
 let[@zero_alloc strict check] test3 x = x,x
 let[@zero_alloc check] test4 x = x,x
 let[@zero_alloc all] test5 x = x,x

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -1,6 +1,6 @@
 File "test_attribute_error_duplicate.ml", line 1, characters 25-35:
 Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
-File "test_attribute_error_duplicate.ml", line 2, characters 32-42:
+File "test_attribute_error_duplicate.ml", line 2, characters 66-76:
 Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
 File "test_attribute_error_duplicate.ml", line 3, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.

--- a/tests/backend/checkmach/test_warning198.ml
+++ b/tests/backend/checkmach/test_warning198.ml
@@ -1,0 +1,2 @@
+let[@zero_alloc assume] bar y = (y+1,y)
+

--- a/tests/backend/checkmach/test_warning198.output
+++ b/tests/backend/checkmach/test_warning198.output
@@ -1,0 +1,3 @@
+File "test_warning198.ml", line 1, characters 5-15:
+Warning 198 [misplaced-assume-attribute]: the "zero_alloc assume" attribute will be ignored by the check when the function is inlined or specialised.
+Mark this function as [@inline never][@specialise never].

--- a/tests/backend/checkmach/test_warning199.ml
+++ b/tests/backend/checkmach/test_warning199.ml
@@ -1,0 +1,3 @@
+let[@zero_alloc][@inline always] baz y = snd y
+
+let[@zero_alloc] foo x = baz (x-1,x)

--- a/tests/backend/checkmach/test_warning199.mli
+++ b/tests/backend/checkmach/test_warning199.mli
@@ -1,0 +1,1 @@
+val foo : int -> int

--- a/tests/backend/checkmach/test_warning199.output
+++ b/tests/backend/checkmach/test_warning199.output
@@ -1,0 +1,5 @@
+File "test_warning199.ml", line 1, characters 5-15:
+Warning 199 [unchecked-property-attribute]: the "zero_alloc" attribute cannot be checked.
+The function it is attached to was optimized away. 
+You can try to mark this function as [@inline never] 
+or move the attribute to the relevant callers of this function.


### PR DESCRIPTION
Warn if a function annotated with `[@zero_alloc assume]` is not annotated with `[@inline never]` and `[@specialise never]`. If such a function is inlined, the "assume" annotation won't be propagated to the caller and therefore won't be in affect for the purpose of the check.  The current behavior when assume is silently ignored is misleading for the users.

A proper fix (propagate the annotation from the function to subexpressions) will take a little longer to implement. In the meantime, it is worth just to have warning and is not hard to implement.