### PR TITLE
Hardcode the use of the CFG allocators, and do not force linscan on flambda2/classic

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -252,16 +252,10 @@ type register_allocator =
   | IRC
   | LS
 
-let default_allocator = Upstream
+let _default_allocator = Upstream
 
 let register_allocator fd : register_allocator =
-  match String.lowercase_ascii !Flambda_backend_flags.regalloc with
-  | "cfg" -> if should_use_linscan fd then LS else IRC
-  | "irc" -> IRC
-  | "ls" -> LS
-  | "upstream" -> Upstream
-  | "" -> default_allocator
-  | other -> Misc.fatal_errorf "unknown register allocator (%S)" other
+  if should_use_linscan fd then LS else IRC
 
 let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   Proc.init ();

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -186,22 +186,11 @@ module Split_mode = struct
   let to_string = function Off -> "off" | Naive -> "naive"
 
   let value =
-    let available_modes () =
+    let _available_modes () =
       String.concat ", "
         (all |> List.map ~f:to_string |> List.map ~f:(Printf.sprintf "%S"))
     in
-    lazy
-      (match find_param_value "IRC_SPLIT" with
-      | None ->
-        fatal "the IRC_SPLIT parameter is not set (possible values: %s)"
-          (available_modes ())
-      | Some id -> (
-        match String.lowercase_ascii id with
-        | "off" -> Off
-        | "naive" -> Naive
-        | _ ->
-          fatal "unknown split mode %S (possible values: %s)" id
-            (available_modes ())))
+    lazy Off
 end
 
 module Spilling_heuristics = struct
@@ -218,25 +207,11 @@ module Spilling_heuristics = struct
     | Hierarchical_uses -> "hierarchical_uses"
 
   let value =
-    let available_heuristics () =
+    let _available_heuristics () =
       String.concat ", "
         (all |> List.map ~f:to_string |> List.map ~f:(Printf.sprintf "%S"))
     in
-    lazy
-      (match find_param_value "IRC_SPILLING_HEURISTICS" with
-      | None ->
-        fatal
-          "the IRC_SPILLING_HEURISTICS parameter is not set (possible values: \
-           %s)"
-          (available_heuristics ())
-      | Some id -> (
-        match String.lowercase_ascii id with
-        | "set_choose" | "set-choose" -> Set_choose
-        | "flat_uses" | "flat-uses" -> Flat_uses
-        | "hierarchical_uses" | "hierarchical-uses" -> Hierarchical_uses
-        | _ ->
-          fatal "unknown heuristics %S (possible values: %s)" id
-            (available_heuristics ())))
+    lazy Flat_uses
 end
 
 module ArraySet = struct

--- a/backend/regalloc/regalloc_ls_utils.ml
+++ b/backend/regalloc/regalloc_ls_utils.ml
@@ -51,22 +51,11 @@ module Order = struct
   let to_string = function Layout -> "layout" | DFS -> "dfs"
 
   let value =
-    let available_orders () =
+    let _available_orders () =
       String.concat ", "
         (all |> List.map ~f:to_string |> List.map ~f:(Printf.sprintf "%S"))
     in
-    lazy
-      (match find_param_value "LS_ORDER" with
-      | None ->
-        fatal "the LS_ORDER parameter is not set (possible values: %s)"
-          (available_orders ())
-      | Some id -> (
-        match String.lowercase_ascii id with
-        | "layout" -> Layout
-        | "dfs" -> DFS
-        | _ ->
-          fatal "unknown order %S (possible values: %s)" id
-            (available_orders ())))
+    lazy Layout
 end
 
 let iter_blocks_dfs : Cfg.t -> f:(Cfg.basic_block -> unit) -> unit =

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -102,11 +102,6 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename:_ ~keep_symbol_tables
   let compilation_unit = program.compilation_unit in
   let module_block_size_in_words = program.main_module_block_size in
   let module_initializer = program.code in
-  (* Make sure -linscan is enabled in classic mode. Doing this here to be sure
-     it happens exactly when -Oclassic is in effect, which we don't know at CLI
-     processing time because there may be an [@@@flambda_oclassic] or
-     [@@@flambda_o3] attribute. *)
-  if Flambda_features.classic_mode () then Clflags.use_linscan := true;
   Misc.Color.setup (Flambda_features.colour ());
   (* CR-someday mshinwell: Note for future WebAssembly work: this thing about
      the length of arrays will need fixing, I don't think it only applies to the


### PR DESCRIPTION
(for testing)