### PR TITLE
Flambda1: Tolerate removing all closures from a set

### DIFF
--- a/middle_end/flambda/remove_unused_closure_vars.ml
+++ b/middle_end/flambda/remove_unused_closure_vars.ml
@@ -115,11 +115,18 @@ let remove_unused_closure_variables ~remove_direct_call_surrogates program =
           set_of_closures.direct_call_surrogates
           Variable.Map.empty
       in
-      let set_of_closures =
-        Flambda.create_set_of_closures ~function_decls
-          ~free_vars ~specialised_args ~direct_call_surrogates
-      in
-      Set_of_closures set_of_closures
+      if Variable.Map.is_empty function_decls.funs then
+        (* All of the closure ids are dead. The whole set _should_ be dead, but
+           sometimes in odd cases we don't manage to kill it (for example, if
+           it's the value of an [initialize_symbol]). In any event, no one is
+           projecting anything out so we can just swap in the unit value. *)
+        Const (Int 0)
+      else
+        let set_of_closures =
+          Flambda.create_set_of_closures ~function_decls
+            ~free_vars ~specialised_args ~direct_call_surrogates
+        in
+        Set_of_closures set_of_closures
     | e -> e
   in
   Flambda_iterators.map_named_of_program ~f:aux_named program


### PR DESCRIPTION
In rare circumstances, we lift a set of closures into a symbol and later find that none of its closures is actually used. Since we don't remove dead `Initialize_symbol`s, the symbol will remain, but since all the closure ids are dead, we'll try to remove _all_ of the closures from the set. This crashes, since we don't actually allow an empty set of closures. However, we know that all the closure ids are dead, which means that no one is actually observing that the symbol is bound to a set of closures. Therefore we can simply bind the symbol to a constant zero instead.