### PR TITLE
Erasability namespace for Jane Syntax attributes/extensions

### DIFF
--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -108,12 +108,42 @@ let builtin_attrs =
   ; "tail_mod_cons"; "ocaml.tail_mod_cons"
   ]
 
-let builtin_attrs =
-  let tbl = Hashtbl.create 128 in
-  List.iter (fun attr -> Hashtbl.add tbl attr ()) builtin_attrs;
-  tbl
+(* nroberts: When we upstream the builtin-attribute whitelisting, we shouldn't
+   upstream the "jane" prefix.
+     - Internally, we use "jane.*" to encode our changes to the parsetree,
+       and our compiler should not drop these attributes.
+     - Upstream, ppxes may produce attributes with the "jane.*" prefix.
+       The upstream compiler does not use these attributes. We want it to be
+       able to drop these attributes without a warning.
 
-let is_builtin_attr s = Hashtbl.mem builtin_attrs s
+   It's an error for an upstream ppx to create an attribute that corresponds to
+   a *non-erasable* Jane language extension, like list comprehensions, which
+   should never reach the upstream compiler. So, we distinguish that in the
+   attribute prefix: upstream ppxlib will error out if it sees a ppx creating a
+   "jane.non_erasable" attribute and be happy to accept a "jane.erasable"
+   attribute. Meanwhile, an internal patched version of ppxlib will be happy for
+   a ppx to produce either of these attributes.
+*)
+let builtin_attr_prefixes =
+  [ "jane"
+  ]
+
+let is_builtin_attr =
+  let builtin_attrs =
+    let tbl = Hashtbl.create 128 in
+    List.iter
+      (fun attr -> Hashtbl.add tbl attr ())
+      (builtin_attr_prefixes @ builtin_attrs);
+    tbl
+  in
+  let builtin_attr_prefixes_with_trailing_dot =
+    List.map (fun x -> x ^ ".") builtin_attr_prefixes
+  in
+  fun s ->
+    Hashtbl.mem builtin_attrs s
+    || List.exists
+        (fun prefix -> String.starts_with ~prefix s)
+        builtin_attr_prefixes_with_trailing_dot
 
 type attr_tracking_time = Parser | Invariant_check
 

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -166,17 +166,17 @@ module Comprehensions = struct
   let expr_of ~loc cexpr =
     (* See Note [Wrapping with make_entire_jane_syntax] *)
     AST.make_entire_jane_syntax Expression ~loc erasability feature (fun () ->
-        match cexpr with
-        | Cexp_list_comprehension comp ->
-            expr_of_comprehension ~type_:["list"] comp
-        | Cexp_array_comprehension (amut, comp) ->
-            expr_of_comprehension
-              ~type_:[ "array"
-                    ; match amut with
-                      | Mutable   -> "mutable"
-                      | Immutable -> "immutable"
-                    ]
-              comp)
+      match cexpr with
+      | Cexp_list_comprehension comp ->
+          expr_of_comprehension ~type_:["list"] comp
+      | Cexp_array_comprehension (amut, comp) ->
+          expr_of_comprehension
+            ~type_:[ "array"
+                  ; match amut with
+                    | Mutable   -> "mutable"
+                    | Immutable -> "immutable"
+                  ]
+            comp)
 
   (** Then, we define how to go from the OCaml AST to the nice AST; this is
       the [..._of_expr] family of expressions, culminating in

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -12,23 +12,25 @@ open Jane_syntax_parsing
    that both [comprehensions] and [immutable_arrays] are enabled.  But our
    general mechanism for checking for enabled extensions (in [of_ast]) won't
    work well here: it triggers when converting from
-   e.g. [[%jane.*.comprehensions.array] ...] to the comprehensions-specific AST.
-   But if we spot a [[%jane.*.comprehensions.immutable]], there is no
-   expression to translate.  So we just check for the immutable arrays extension
-   when processing a comprehension expression for an immutable array.
+   e.g. [[%jane.non_erasable.comprehensions.array] ...] to the
+   comprehensions-specific AST. But if we spot a
+   [[%jane.non_erasable.comprehensions.immutable]], there is no expression to
+   translate. So we just check for the immutable arrays extension when
+   processing a comprehension expression for an immutable array.
 
    Note [Wrapping with make_entire_jane_syntax]
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    The topmost node in the encoded AST must always look like e.g.
-   [%jane.*.comprehensions]. This allows the decoding machinery to know what
-   extension is being used and what function to call to do the decoding.
-   Accordingly, during encoding, after doing the hard work of converting the
-   extension syntax tree into e.g. Parsetree.expression, we need to make a final
-   step of wrapping the result in a [%jane.*.xyz] node. Ideally, this
-   step would be done by part of our general structure, like we separate
-   [of_ast] and [of_ast_internal] in the decode structure; this design would
-   make it structurally impossible/hard to forget taking this final step.
+   [%jane.non_erasable.comprehensions]. (More generally,
+   [%jane.ERASABILITY.FEATURE] or [@jane.ERASABILITY.FEATURE].) This allows the
+   decoding machinery to know what extension is being used and what function to
+   call to do the decoding. Accordingly, during encoding, after doing the hard
+   work of converting the extension syntax tree into e.g. Parsetree.expression,
+   we need to make a final step of wrapping the result in a [%jane.*.xyz] node.
+   Ideally, this step would be done by part of our general structure, like we
+   separate [of_ast] and [of_ast_internal] in the decode structure; this design
+   would make it structurally impossible/hard to forget taking this final step.
 
    However, the final step is only one line of code (a call to
    [make_entire_jane_syntax]), but yet the name of the feature varies, as does

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -25,7 +25,7 @@ open Jane_syntax_parsing
    extension is being used and what function to call to do the decoding.
    Accordingly, during encoding, after doing the hard work of converting the
    extension syntax tree into e.g. Parsetree.expression, we need to make a final
-   step of wrapping the result in an [%jane.*.xyz] node. Ideally, this
+   step of wrapping the result in a [%jane.*.xyz] node. Ideally, this
    step would be done by part of our general structure, like we separate
    [of_ast] and [of_ast_internal] in the decode structure; this design would
    make it structurally impossible/hard to forget taking this final step.

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -172,10 +172,10 @@ module Comprehensions = struct
       | Cexp_array_comprehension (amut, comp) ->
           expr_of_comprehension
             ~type_:[ "array"
-                  ; match amut with
-                    | Mutable   -> "mutable"
-                    | Immutable -> "immutable"
-                  ]
+                   ; match amut with
+                     | Mutable   -> "mutable"
+                     | Immutable -> "immutable"
+                   ]
             comp)
 
   (** Then, we define how to go from the OCaml AST to the nice AST; this is

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -374,7 +374,7 @@ module Strengthen = struct
   let mty_of ~loc { mty; mod_id } =
     (* See Note [Wrapping with make_entire_jane_syntax] *)
     AST.make_entire_jane_syntax Module_type ~loc erasability feature (fun () ->
-        Ast_helper.Mty.functor_ (Named (Location.mknoloc None, mty))
+      Ast_helper.Mty.functor_ (Named (Location.mknoloc None, mty))
         (Ast_helper.Mty.alias mod_id))
 
   (* Returns remaining unconsumed attributes *)

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -8,7 +8,7 @@
     2. As a pair of an extension node and an AST item that serves as the "body".
        Here, the "pair" is embedded as a pair-like construct in the relevant AST
        category, e.g. [include sig [%jane.ERASABILITY.EXTNAME];; BODY end] for
-    signature items.
+       signature items.
 
     In particular, for an language extension named [EXTNAME] (i.e., one that is
     enabled by [-extension EXTNAME] on the command line), the attribute (if
@@ -243,7 +243,7 @@ end = struct
     (** The separator between name components *)
     let separator = '.'
 
-    (** The leading erasability that identifies this extension node or attribute
+    (** The leading namespace that identifies this extension node or attribute
         as reserved for a piece of modular syntax *)
     let root = "jane"
 
@@ -305,8 +305,7 @@ end
 
 (******************************************************************************)
 module Error = struct
-  (** Someone used [[%jane.ERASABILITY.FEATNAME]]/[[@jane.ERASABILITY.FEATNAME]]
-      wrong *)
+  (** Someone used [[%jane.*.FEATNAME]]/[[@jane.*.FEATNAME]] wrong *)
   type malformed_embedding =
     | Has_payload of payload
 
@@ -392,9 +391,9 @@ let () =
     novel syntactic features.  One module per variety of AST (expressions,
     patterns, etc.). *)
 
-(** The parameters that define how to look for [[%jane.ERASABILITY.FEATNAME]] and
-    [[@jane.ERASABILITY.FEATNAME]] inside ASTs of a certain syntactic category.
-    This module type describes the input to the [Make_with_attribute] and
+(** The parameters that define how to look for [[%jane.*.FEATNAME]] and
+    [[@jane.*.FEATNAME]] inside ASTs of a certain syntactic category. This
+    module type describes the input to the [Make_with_attribute] and
     [Make_with_extension_node] functors (though they stipulate additional
     requirements for their inputs).
 *)

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -181,6 +181,26 @@ module Misnamed_embedding_error = struct
           str
 end
 
+(** The component of an attribute or extension name that identifies whether or
+    not the embedded syntax is *erasable*; that is, whether or not the
+    upstream OCaml compiler can safely interpret the AST while ignoring the
+    attribute or extension.  (This means that syntax encoded as extension
+    nodes should always be non-erasable.)  Tools that consume the parse tree
+    we generate can make use of this information; for instance, ocamlformat
+    will use it to guide how we present code that can be run with both our
+    compiler and the upstream compiler, and ppxlib can use it to decide
+    whether it's ok to allow ppxes to construct syntax that uses this
+    emedding.  In particular, the upstream version of ppxlib will allow ppxes
+    to produce [[@jane.erasable.*]] attributes, but will report an error if a
+    ppx produces a [[@jane.non_erasable.*]] attribute.
+
+    As mentioned above, unlike for attributes, the erasable/non-erasable
+    distinction is not meaningful for extension nodes, as the compiler will
+    always error if it sees an uninterpreted extension node. So, for purposes
+    of tools in the wider OCaml ecosystem, it is irrelevant whether embeddings
+    that use extension nodes indicate [Erasable] or [Non_erasable] for this
+    component, but the semantically correct choice and the one we've settled
+    on is to use [Non_erasable]. *)
 module Erasability = struct
   type t =
     | Erasable

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -24,13 +24,13 @@
     In the below example, we use attributes an examples, but it applies equally
     to extensions. We also provide utilities for further desugaring similar
     applications where the embeddings have the longer form
-    [[@jane.ERASABILITY.FEATNAME.ID1.ID2.….IDn]] (with the outermost one being the
-    [n = 0] case), as these might be used inside the [EXPR]. (For example,
-    within the outermost [[@jane.ERASABILITY.comprehensions]] term for list and
+    [[@jane.ERASABILITY.FEATNAME.ID1.ID2.….IDn]] (with the outermost one being
+    the [n = 0] case), as these might be used inside the [EXPR]. (For example,
+    within the outermost [[@jane.non_erasable.comprehensions]] term for list and
     array comprehensions, we can also use
-    [[@jane.ERASABILITY.comprehensions.list]],
-    [[@jane.ERASABILITY.comprehensions.array]],
-    [[@jane.ERASABILITY.comprehensions.for.in]], etc.).
+    [[@jane.non_erasable.comprehensions.list]],
+    [[@jane.non_erasable.comprehensions.array]],
+    [[@jane.non_erasable.comprehensions.for.in]], etc.).
 
     As mentioned, we represent terms as a "pair" and don't use the extension
     node or attribute payload; this is so that ppxen can see inside these

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -791,8 +791,9 @@ module AST = struct
     let (module AST) = to_module t in
     AST.make_jane_syntax
 
-  let make_entire_jane_syntax t ~loc erasability name ast =
-    make_jane_syntax t { erasability; components = [name] }
+  let make_entire_jane_syntax t ~loc erasability feature ast =
+    let feature_component = Feature.extension_component feature in
+    make_jane_syntax t { erasability; components = [feature_component] }
       (Ast_helper.with_default_loc (Location.ghostify loc) ast)
 
   (** Generically lift our custom ASTs for our novel syntax from OCaml ASTs. *)

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -16,9 +16,10 @@
     used) must be [[%jane.ERASABILITY.EXTNAME]]. For built-in syntax, we use
     [_builtin] instead of an language extension name.
 
-    The [ERASABILITY] component indicates to tools, like ppxlib, whether the
-    attribute is erasable or not. See the documentation of [Erasability] for
-    more information on how tools make use of this information.
+    The [ERASABILITY] component indicates to tools such as ocamlformat and
+    ppxlib whether or not the attribute is erasable. See the documentation of
+    [Erasability] for more information on how tools make use of this
+    information.
 
     In the below example, we use attributes an examples, but it applies equally
     to extensions. We also provide utilities for further desugaring similar
@@ -180,21 +181,26 @@ end
     details. *)
 module Embedded_name : sig
 
-  (** The component that identifies whether the embedding attribute is erasable
-      -- i.e. the upstream OCaml compiler can safely interpret the AST ignoring
-      the attribute -- or not. Tools like ppxlib use this component to decide
+  (** The component of an attribute or extension name that identifies whether or
+      not the embedded syntax is *erasable*; that is, whether or not the
+      upstream OCaml compiler can safely interpret the AST while ignoring the
+      attribute or extension.  (This means that syntax encoded as extension
+      nodes should always be non-erasable.)  Tools that consume the parse tree
+      we generate can make use of this information; for instance, ocamlformat
+      will use it to guide how we present code that can be run with both our
+      compiler and the upstream compiler, and ppxlib can use it to decide
       whether it's ok to allow ppxes to construct syntax that uses this
-      emedding. In particular, the upstream version of ppxlib allows ppxes to
-      produce [[@jane.erasable.*]] attributes, but indicates errors if a ppx
-      produces [[@jane.non_erasable.*]] attributes.
+      emedding.  In particular, the upstream version of ppxlib will allow ppxes
+      to produce [[@jane.erasable.*]] attributes, but will report an error if a
+      ppx produces a [[@jane.non_erasable.*]] attribute.
 
-      Unlike for attributes, the distinction is not meaningful for an extension
-      node. The upstream compiler will always error if it sees an uninterpreted
-      extension node. So, for purposes of tools in the OCaml ecosystem, it is
-      irrelevant whether embeddings that use extension nodes indicate [Erasable]
-      or [Non_erasable] for this component, but the convention we've settled on
-      is to use [Non_erasable].
-  *)
+      As mentioned above, unlike for attributes, the erasable/non-erasable
+      distinction is not meaningful for extension nodes, as the compiler will
+      always error if it sees an uninterpreted extension node. So, for purposes
+      of tools in the wider OCaml ecosystem, it is irrelevant whether embeddings
+      that use extension nodes indicate [Erasable] or [Non_erasable] for this
+      component, but the semantically correct choice and the one we've settled
+      on is to use [Non_erasable]. *)
   module Erasability : sig
     type t =
       | Erasable

--- a/ocaml/parsing/jane_syntax_parsing.mli
+++ b/ocaml/parsing/jane_syntax_parsing.mli
@@ -103,32 +103,6 @@ module Feature : sig
   val extension_component : t -> string
 end
 
-(** The component of an attribute or extension name that identifies whether or
-    not the embedded syntax is *erasable*; that is, whether or not the
-    upstream OCaml compiler can safely interpret the AST while ignoring the
-    attribute or extension.  (This means that syntax encoded as extension
-    nodes should always be non-erasable.)  Tools that consume the parse tree
-    we generate can make use of this information; for instance, ocamlformat
-    will use it to guide how we present code that can be run with both our
-    compiler and the upstream compiler, and ppxlib can use it to decide
-    whether it's ok to allow ppxes to construct syntax that uses this
-    emedding.  In particular, the upstream version of ppxlib will allow ppxes
-    to produce [[@jane.erasable.*]] attributes, but will report an error if a
-    ppx produces a [[@jane.non_erasable.*]] attribute.
-
-    As mentioned above, unlike for attributes, the erasable/non-erasable
-    distinction is not meaningful for extension nodes, as the compiler will
-    always error if it sees an uninterpreted extension node. So, for purposes
-    of tools in the wider OCaml ecosystem, it is irrelevant whether embeddings
-    that use extension nodes indicate [Erasable] or [Non_erasable] for this
-    component, but the semantically correct choice and the one we've settled
-    on is to use [Non_erasable]. *)
-module Erasability : sig
-  type t =
-    | Erasable
-    | Non_erasable
-end
-
 (** An AST-style representation of the names used when generating extension
     nodes or attributes for modular syntax.  We use this to abstract over the
     details of how they're encoded, so we have some flexibility in changing them

--- a/ocaml/parsing/jane_syntax_parsing.mli
+++ b/ocaml/parsing/jane_syntax_parsing.mli
@@ -105,11 +105,19 @@ end
     also why we don't expose any functions for rendering or parsing these names;
     that's all handled internally. *)
 module Embedded_name : sig
+  module Namespace : sig
+    type t =
+      | Erasable
+      | Non_erasable
+  end
+
   (** A nonempty list of name components, without the leading root component
       that identifies it as part of the modular syntax mechanism.  This is a
       nonempty list corresponding to the different components of the name: first
       the feature, and then any subparts. *)
-  type t = ( :: ) of string * string list
+  type components = ( :: ) of string * string list
+
+  type t = { namespace : Namespace.t; components : components }
 
   (** Print out the embedded form of a Jane-syntax name, in quotes; for use in
       error messages. *)
@@ -180,6 +188,7 @@ module AST : sig
   val make_entire_jane_syntax
     :  ('ast, 'ast_desc) t
     -> loc:Location.t
+    -> Embedded_name.Namespace.t
     -> string
     -> (unit -> 'ast)
     -> 'ast_desc

--- a/ocaml/parsing/jane_syntax_parsing.mli
+++ b/ocaml/parsing/jane_syntax_parsing.mli
@@ -196,7 +196,7 @@ module AST : sig
     :  ('ast, 'ast_desc) t
     -> loc:Location.t
     -> Embedded_name.Erasability.t
-    -> string
+    -> Feature.t
     -> (unit -> 'ast)
     -> 'ast_desc
 

--- a/ocaml/parsing/jane_syntax_parsing.mli
+++ b/ocaml/parsing/jane_syntax_parsing.mli
@@ -105,19 +105,26 @@ end
     also why we don't expose any functions for rendering or parsing these names;
     that's all handled internally. *)
 module Embedded_name : sig
-  module Namespace : sig
+  module Erasability : sig
     type t =
       | Erasable
       | Non_erasable
   end
 
-  (** A nonempty list of name components, without the leading root component
-      that identifies it as part of the modular syntax mechanism.  This is a
-      nonempty list corresponding to the different components of the name: first
-      the feature, and then any subparts. *)
+  (** A nonempty list of name components, without the first two components.
+      (That is, without the leading root component that identifies it as part of
+      the modular syntax mechanism, and without the next component that
+      identifies the erasability.)
+
+      This is a nonempty list corresponding to the different components of the
+      name: first the feature, and then any subparts.
+  *)
   type components = ( :: ) of string * string list
 
-  type t = { namespace : Namespace.t; components : components }
+  (** The trailing components together with the erasability. The erasability is
+      the second component of the literal name that appears in the parsetree.
+  *)
+  type t = { erasability : Erasability.t; components : components }
 
   (** Print out the embedded form of a Jane-syntax name, in quotes; for use in
       error messages. *)
@@ -188,7 +195,7 @@ module AST : sig
   val make_entire_jane_syntax
     :  ('ast, 'ast_desc) t
     -> loc:Location.t
-    -> Embedded_name.Namespace.t
+    -> Embedded_name.Erasability.t
     -> string
     -> (unit -> 'ast)
     -> 'ast_desc

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error1.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error1.compilers.reference
@@ -1,5 +1,5 @@
-File "user_error1.ml", line 21, characters 44-58:
-21 | let _malformed_extension_has_payload = () [@jane.something "no payloads"];;
-                                                 ^^^^^^^^^^^^^^
+File "user_error1.ml", line 21, characters 44-67:
+21 | let _malformed_extension_has_payload = () [@jane.erasable.something "no payloads"];;
+                                                 ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Modular syntax attributes are not allowed to have a payload,
-       but "jane.something" does
+       but "jane.erasable.something" does

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error1.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error1.ml
@@ -18,5 +18,5 @@
    like it in separate files, because the "compile and test output"
    infrastructure reports only one error at a time. *)
 
-let _malformed_extension_has_payload = () [@jane.something "no payloads"];;
+let _malformed_extension_has_payload = () [@jane.erasable.something "no payloads"];;
 

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error2.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error2.compilers.reference
@@ -1,4 +1,4 @@
-File "user_error2.ml", line 21, characters 46-60:
-21 | let _malformed_extensions_wrong_arguments = [%jane.something] "two" "arguments";;
-                                                   ^^^^^^^^^^^^^^
-Error: Uninterpreted extension 'jane.something'.
+File "user_error2.ml", line 21, characters 46-69:
+21 | let _malformed_extensions_wrong_arguments = [%jane.erasable.something] "two" "arguments";;
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Uninterpreted extension 'jane.erasable.something'.

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error2.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error2.ml
@@ -18,4 +18,4 @@
    like it in separate files, because the "compile and test output"
    infrastructure reports only one error at a time. *)
 
-let _malformed_extensions_wrong_arguments = [%jane.something] "two" "arguments";;
+let _malformed_extensions_wrong_arguments = [%jane.erasable.something] "two" "arguments";;

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3.compilers.reference
@@ -1,5 +1,5 @@
-File "user_error3.ml", line 21, characters 25-27:
-21 | let _unknown_extension = () [@jane.this_extension_doesn't_exist];;
-                              ^^
+File "user_error3.ml", line 21, characters 26-28:
+21 | let _misnamed_extension = () [@jane.erasable.this_extension_doesn't_exist];;
+                               ^^
 Error: Unknown extension "this_extension_doesn't_exist" referenced via
-       a [@jane.this_extension_doesn't_exist] attribute
+       a [@jane.erasable.this_extension_doesn't_exist] attribute

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3.ml
@@ -6,7 +6,7 @@
 *)
 
 (* What happens if the user tries to write one of the pieces of Jane Street
-   syntax in concrete syntax but messes up?  In practice we don't
+   syntax in terms of extension nodes but messes up?  In practice we don't
    expect to ever see these errors, but one never knows (and a bug in our
    desugaring could cause them).  The let-binding is named after the constructor
    in [jane_syntax_parsing.ml] representing this particular error. *)
@@ -18,4 +18,4 @@
    like it in separate files, because the "compile and test output"
    infrastructure reports only one error at a time. *)
 
-let _unknown_extension = () [@jane.this_extension_doesn't_exist];;
+let _misnamed_extension = () [@jane.erasable.this_extension_doesn't_exist];;

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3.ml
@@ -6,7 +6,7 @@
 *)
 
 (* What happens if the user tries to write one of the pieces of Jane Street
-   syntax in terms of extension nodes but messes up?  In practice we don't
+   syntax in concrete syntax but messes up?  In practice we don't
    expect to ever see these errors, but one never knows (and a bug in our
    desugaring could cause them).  The let-binding is named after the constructor
    in [jane_syntax_parsing.ml] representing this particular error. *)

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_1.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_1.compilers.reference
@@ -1,4 +1,4 @@
-File "user_error3_1.ml", line 9, characters 31-64:
-9 | let _misnamed_extension = () [@jane.this_extension_doesn't_exist];;
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Cannot have an attribute named [@jane.this_extension_doesn't_exist]: Missing a feature component
+File "user_error3_1.ml", line 9, characters 31-55:
+9 | let _misnamed_extension = () [@jane.invalid_erasability];;
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Cannot have an attribute named [@jane.invalid_erasability]: Missing a feature component

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_1.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_1.compilers.reference
@@ -1,0 +1,4 @@
+File "user_error3_1.ml", line 9, characters 31-64:
+9 | let _misnamed_extension = () [@jane.this_extension_doesn't_exist];;
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Cannot have an attribute named [@jane.this_extension_doesn't_exist]: Missing a feature component

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_1.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_1.ml
@@ -6,4 +6,4 @@
 *)
 
 (* See the comment in user_error3.ml *)
-let _misnamed_extension = () [@jane.this_extension_doesn't_exist];;
+let _misnamed_extension = () [@jane.invalid_erasability];;

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_1.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_1.ml
@@ -1,0 +1,9 @@
+(* TEST
+   ocamlc_byte_exit_status = "2"
+   * setup-ocamlc.byte-build-env
+   ** ocamlc.byte
+   *** check-ocamlc.byte-output
+*)
+
+(* See the comment in user_error3.ml *)
+let _misnamed_extension = () [@jane.this_extension_doesn't_exist];;

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_2.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_2.compilers.reference
@@ -1,0 +1,4 @@
+File "user_error3_2.ml", line 9, characters 31-48:
+9 | let _misnamed_extension = () [@jane.non_erasable];;
+                                   ^^^^^^^^^^^^^^^^^
+Error: Cannot have an attribute named [@jane.non_erasable]: Missing a feature component

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_2.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_2.ml
@@ -1,0 +1,9 @@
+(* TEST
+   ocamlc_byte_exit_status = "2"
+   * setup-ocamlc.byte-build-env
+   ** ocamlc.byte
+   *** check-ocamlc.byte-output
+*)
+
+(* See the comment in user_error3.ml *)
+let _misnamed_extension = () [@jane.non_erasable];;

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.compilers.reference
@@ -1,4 +1,4 @@
 File "user_error3_3.ml", line 9, characters 31-57:
 9 | let _misnamed_extension = () [@jane.non_namespace.feature];;
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Cannot have an attribute named [@jane.non_namespace.feature]: Unrecognized namespace `non_namespace'
+Error: Cannot have an attribute named [@jane.non_namespace.feature]: Unrecognized component where erasability was expected: `non_namespace'

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.compilers.reference
@@ -1,0 +1,4 @@
+File "user_error3_3.ml", line 9, characters 31-57:
+9 | let _misnamed_extension = () [@jane.non_namespace.feature];;
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Cannot have an attribute named [@jane.non_namespace.feature]: Unrecognized namespace `non_namespace'

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.compilers.reference
@@ -1,4 +1,4 @@
-File "user_error3_3.ml", line 9, characters 31-57:
-9 | let _misnamed_extension = () [@jane.non_namespace.feature];;
-                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Cannot have an attribute named [@jane.non_namespace.feature]: Unrecognized component where erasability was expected: `non_namespace'
+File "user_error3_3.ml", line 9, characters 31-63:
+9 | let _misnamed_extension = () [@jane.invalid_erasability.feature];;
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Cannot have an attribute named [@jane.invalid_erasability.feature]: Unrecognized component where erasability was expected: `invalid_erasability'

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.ml
@@ -1,0 +1,9 @@
+(* TEST
+   ocamlc_byte_exit_status = "2"
+   * setup-ocamlc.byte-build-env
+   ** ocamlc.byte
+   *** check-ocamlc.byte-output
+*)
+
+(* See the comment in user_error3.ml *)
+let _misnamed_extension = () [@jane.non_namespace.feature];;

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error3_3.ml
@@ -6,4 +6,4 @@
 *)
 
 (* See the comment in user_error3.ml *)
-let _misnamed_extension = () [@jane.non_namespace.feature];;
+let _misnamed_extension = () [@jane.invalid_erasability.feature];;

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error4.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error4.compilers.reference
@@ -1,4 +1,4 @@
 File "user_error4.ml", line 21, characters 26-28:
-21 | let _disabled_extension = () [@jane.comprehensions];;
+21 | let _disabled_extension = () [@jane.non_erasable.comprehensions];;
                                ^^
 Error: The extension "comprehensions" is disabled and cannot be used

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error4.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error4.ml
@@ -18,4 +18,4 @@
    like it in separate files, because the "compile and test output"
    infrastructure reports only one error at a time. *)
 
-let _disabled_extension = () [@jane.comprehensions];;
+let _disabled_extension = () [@jane.non_erasable.comprehensions];;

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error5.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error5.compilers.reference
@@ -1,4 +1,4 @@
 File "user_error5.ml", line 21, characters 30-34:
 21 | let _unnamed_extension = () [@jane];;
                                    ^^^^
-Error: Cannot have an attribute named [@jane]: Missing namespace and feature components
+Error: Cannot have an attribute named [@jane]: Missing erasability and feature components

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error5.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error5.compilers.reference
@@ -1,4 +1,4 @@
 File "user_error5.ml", line 21, characters 30-34:
 21 | let _unnamed_extension = () [@jane];;
                                    ^^^^
-Error: Cannot have an attribute named [@jane]
+Error: Cannot have an attribute named [@jane]: Missing namespace and feature components

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error6.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error6.compilers.reference
@@ -1,5 +1,6 @@
 File "user_error6.ml", line 21, characters 24-26:
-21 | let _bad_introduction = () [@jane.something.nested];;
+21 | let _bad_introduction = () [@jane.erasable.something.nested];;
                              ^^
 Error: The extension "something" was referenced improperly; it started with
-       a [@jane.something.nested] attribute, not a [@jane.something] one
+       a [@jane.erasable.something.nested] attribute,
+       not a [@jane.erasable.something] one

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error6.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error6.ml
@@ -18,4 +18,4 @@
    like it in separate files, because the "compile and test output"
    infrastructure reports only one error at a time. *)
 
-let _bad_introduction = () [@jane.something.nested];;
+let _bad_introduction = () [@jane.erasable.something.nested];;

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error7_attributes.compilers.reference
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error7_attributes.compilers.reference
@@ -1,0 +1,4 @@
+File "user_error7_attributes.ml", line 21, characters 5-9:
+21 | let[@jane] f () = ();;
+          ^^^^
+Warning 53 [misplaced-attribute]: the "jane" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error7_attributes.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error7_attributes.ml
@@ -1,0 +1,25 @@
+(* TEST
+
+   flags = "-w +A-60-70"
+
+ * setup-ocamlc.byte-build-env
+ ** ocamlc.byte
+   compile_only = "true"
+ *** check-ocamlc.byte-output
+
+*)
+
+(*
+ If we use attributes on a syntactic category not handled by modular syntax,
+ they aren't interpreted by the modular syntax machinery and fail with a normal
+ OCaml error.
+
+ We may some day run out of such syntactic categories, in which case we should
+ delete this test and leave a comment saying that we can't write such a test for
+ attributes because the modular syntax machinery always interprets them.
+*)
+let[@jane] f () = ();;
+
+(* We can't use expect test here because warning 53 is only raised by ocamlc,
+   not the toplevel. This is probably a bug.
+*)

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error7_extensions.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error7_extensions.ml
@@ -4,7 +4,8 @@
 
 (* If we use extension nodes outside of the context they are expected,
    they aren't interpreted by the modular syntax machinery and fail with
-   a normal OCaml error *)
+   a normal OCaml error
+*)
 
 (* Extension node in an interpreted context would be:
 

--- a/ocaml/testsuite/tests/jane-modular-syntax/user_error7_extensions.ml
+++ b/ocaml/testsuite/tests/jane-modular-syntax/user_error7_extensions.ml
@@ -4,8 +4,7 @@
 
 (* If we use extension nodes outside of the context they are expected,
    they aren't interpreted by the modular syntax machinery and fail with
-   a normal OCaml error
-*)
+   a normal OCaml error *)
 
 (* Extension node in an interpreted context would be:
 


### PR DESCRIPTION
This PR changes Jane Syntax attributes from looking like `[@jane.comprehensions]` to instead like `[@jane.non_erasable.comprehensions]`. The second component can be `erasable`/`non_erasable`.
  * `erasable` indicates that the attribute can be dropped by, e.g., the upstream compiler
  * `non_erasable` indicates that it isn't safe to drop the attribute
 
This PR makes the same change to extension nodes, but this is less notable, as the upstream compiler will always fail upon seeing an uninterpreted extension node (regardless of the text we put in the name).

This allows us to switch over ppxes in the wild to construct Jane Syntax, as long as the attributes are erasable. We'll want ppxlib to complain if a ppx constructs a non-erasable attribute. I plan on making an (upstream) PR for this once this PR is reviewed.

It's an error for an upstream ppx to create an attribute that corresponds to a *non-erasable* Jane language extension, like list comprehensions, which should never reach the upstream compiler. So, we distinguish that in the attribute prefix: upstream ppxlib will error out if it sees a ppx creating a "jane.non_erasable" attribute and be happy to accept a "jane.erasable" attribute. Meanwhile, an internal patched version of ppxlib will be happy for a ppx to produce either of these attributes.

The current internal patched version of ppxlib is *already* happy for a ppx to produce either of these attributes, so it's just a matter of submitting a PR to get the upstream ppxlib in the right state.

### Review

@antalsz please!