### PR TITLE
Call entry functions using a loop

### DIFF
--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -353,7 +353,7 @@ let make_startup_file unix ~ppf_dump ~sourcefile_for_dwarf genfns units =
   let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in
   let name_list =
     List.flatten (List.map (fun u -> u.defines) units) in
-  compile_phrase (Cmm_helpers.entry_point name_list);
+  List.iter compile_phrase (Cmm_helpers.entry_point name_list);
   List.iter compile_phrase
     (Cmm_helpers.emit_preallocated_blocks []
       (Cmm_helpers.generic_functions false genfns));

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3589,9 +3589,9 @@ let make_symbol ?compilation_unit name =
  *   while (true) {
  *     caml_globals_entry_functions[i]();
  *     caml_globals_inited += 1;
- *     int idprev = i;
+ *     int id_prev = i;
  *     id += 1;
- *     if (idprev == len_caml_globals_entry_functions) goto out;
+ *     if (id_prev == len_caml_globals_entry_functions) goto out;
  *   }
  *   out:
  *   return 1;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3667,7 +3667,7 @@ let entry_point namelist =
             create_loop
               (Csequence
                  ( exit_if_last_iteration,
-                   Csequence (call (Cvar (VP.var id)), incr_i )))
+                   Csequence (call (Cvar (VP.var id)), incr_i) ))
               dbg,
             Ctuple [],
             dbg,

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3603,15 +3603,26 @@ let entry_point namelist =
   in
   let table_symbol = global_symbol "caml_globals_entry_functions" in
   let call i =
-    let f = Cop (Cadda, [cconst_symbol table_symbol; Cop (Cmuli, [Cconst_int (Arch.size_addr, dbg ()); i], dbg ())], dbg ()) in
+    let f =
+      Cop
+        ( Cadda,
+          [ cconst_symbol table_symbol;
+            Cop (Cmuli, [Cconst_int (Arch.size_addr, dbg ()); i], dbg ()) ],
+          dbg () )
+    in
     Csequence
-      ( Cop (Capply (typ_void, Rc_normal), [Cop (Cload (Word_int, Immutable), [f], dbg ())], dbg ()),
-        incr_global_inited ())
+      ( Cop
+          ( Capply (typ_void, Rc_normal),
+            [Cop (Cload (Word_int, Immutable), [f], dbg ())],
+            dbg () ),
+        incr_global_inited () )
   in
   let data =
-    List.map (fun name ->
-      Csymbol_address (global_symbol (make_symbol ~compilation_unit:name "entry"))
-    ) namelist
+    List.map
+      (fun name ->
+        Csymbol_address
+          (global_symbol (make_symbol ~compilation_unit:name "entry")))
+      namelist
   in
   let data = Cdefine_symbol table_symbol :: data in
   let raise_num = Lambda.next_raise_count () in
@@ -3621,41 +3632,59 @@ let entry_point namelist =
   let body =
     let dbg = dbg () in
     Clet_mut
-       (id, typ_int, cconst_int 0,
-          ccatch
-            (raise_num, [],
-             Cifthenelse
-               (Cop(Ccmpi Cgt, [Cvar (VP.var id); high], dbg),
-                dbg, Cexit (Lbl raise_num, [], []), dbg,
+      ( id,
+        typ_int,
+        cconst_int 0,
+        ccatch
+          ( raise_num,
+            [],
+            Cifthenelse
+              ( Cop (Ccmpi Cgt, [Cvar (VP.var id); high], dbg),
+                dbg,
+                Cexit (Lbl raise_num, [], []),
+                dbg,
                 create_loop
-                  (Csequence (
-                    call (Cvar (VP.var id)),
-                     Clet(id_prev, Cvar (VP.var id),
-                      Csequence
-                        (Cassign(VP.var id,
-                           Cop(Caddi, [Cvar (VP.var id); Cconst_int (1, dbg)],
-                             dbg)),
-                         Cifthenelse
-                           (Cop(Ccmpi Ceq, [Cvar (VP.var id_prev); high],
-                              dbg),
-                            dbg, Cexit (Lbl raise_num,[],[]),
-                            dbg, Ctuple [],
-                            dbg, Any)))))
+                  (Csequence
+                     ( call (Cvar (VP.var id)),
+                       Clet
+                         ( id_prev,
+                           Cvar (VP.var id),
+                           Csequence
+                             ( Cassign
+                                 ( VP.var id,
+                                   Cop
+                                     ( Caddi,
+                                       [Cvar (VP.var id); Cconst_int (1, dbg)],
+                                       dbg ) ),
+                               Cifthenelse
+                                 ( Cop
+                                     ( Ccmpi Ceq,
+                                       [Cvar (VP.var id_prev); high],
+                                       dbg ),
+                                   dbg,
+                                   Cexit (Lbl raise_num, [], []),
+                                   dbg,
+                                   Ctuple [],
+                                   dbg,
+                                   Any ) ) ) ))
                   dbg,
-               dbg, Any),
-             Ctuple [],
-             dbg, Any))
+                dbg,
+                Any ),
+            Ctuple [],
+            dbg,
+            Any ) )
   in
   let fun_name = global_symbol "caml_program" in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
-  [ Cdata data; Cfunction
-    { fun_name;
-      fun_args = [];
-      fun_body = Csequence(body, cconst_int 1);
-      fun_codegen_options = [Reduce_code_size];
-      fun_dbg;
-      fun_poll = Default_poll
-    }]
+  [ Cdata data;
+    Cfunction
+      { fun_name;
+        fun_args = [];
+        fun_body = Csequence (body, cconst_int 1);
+        fun_codegen_options = [Reduce_code_size];
+        fun_dbg;
+        fun_poll = Default_poll
+      } ]
 
 (* Generate the table of globals *)
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3587,10 +3587,10 @@ let make_symbol ?compilation_unit name =
  * {
  *   int id = 0;
  *   while (true) {
+ *     if (id == len_caml_globals_entry_functions) goto out;
  *     caml_globals_entry_functions[id]();
  *     caml_globals_inited += 1;
  *     id += 1;
- *     if (id == len_caml_globals_entry_functions) goto out;
  *   }
  *   out:
  *   return 1;
@@ -3666,8 +3666,8 @@ let entry_point namelist =
             [],
             create_loop
               (Csequence
-                 ( call (Cvar (VP.var id)),
-                   Csequence (incr_i, exit_if_last_iteration) ))
+                 ( exit_if_last_iteration,
+                   Csequence (call (Cvar (VP.var id)), incr_i )))
               dbg,
             Ctuple [],
             dbg,

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -875,7 +875,7 @@ val placeholder_dbg : unit -> Debuginfo.t
 val placeholder_fun_dbg : human_name:string -> Debuginfo.t
 
 (** Entry point *)
-val entry_point : Compilation_unit.t list -> phrase
+val entry_point : Compilation_unit.t list -> phrase list
 
 (** Generate the caml_globals table *)
 val global_table : Compilation_unit.t list -> phrase


### PR DESCRIPTION
Before this PR `caml_program` was a sequence of function call and variable incrementation. It turns out that when linking large binaries a sizable amount of the linking time was actually spend generating this function (between the register allocation and assembling it).
This PR changes `caml_program` as follow:
- Store the list of entry symbol addresses in `.data`
- Loop other the symbol and call them one after another 