### PR TITLE
Link can use the internal assembler

### DIFF
--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -483,6 +483,8 @@ let reset () =
 (* Main entry point *)
 
 let link unix ~ppf_dump objfiles output_name =
+  if !Flambda_backend_flags.internal_assembler then
+      Emitaux.binary_backend_available := true;
   Profile.record_call output_name (fun () ->
     let stdlib = "stdlib.cmxa" in
     let stdexit = "std_exit.cmx" in


### PR DESCRIPTION
`link` can now use the internal-assembler.

On preliminary testing it seems like this shaves off a few hundred of milliseconds when linking large binaries