### PR TITLE
Add jane street merlin support files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ _coverage/
 /oc_cflags.sexp
 /oc_cppflags.sexp
 /sharedlib_cflags.sexp
+
+# Jane Street Merlin support
+/.local-merlin-binaries
+/.local-ocaml-lib


### PR DESCRIPTION
similarly to [ocaml/.gitignore](https://github.com/ocaml-flambda/flambda-backend/blob/f78e39a28af40aeb21871581d37bbb7ee960f740/ocaml/.gitignore#L295-L297)