### PR TITLE
Bugfix for caml_switch_runtime_locking_scheme

### DIFF
--- a/ocaml/otherlibs/systhreads/st_stubs.c
+++ b/ocaml/otherlibs/systhreads/st_stubs.c
@@ -880,6 +880,8 @@ CAMLprim value caml_thread_yield(value unit)        /* ML */
   caml_raise_async_if_exception(caml_process_pending_signals_exn(),
                                 "signal handler");
   caml_thread_save_runtime_state();
+  /* caml_locking_scheme may have changed in caml_process_pending_signals_exn */
+  s = atomic_load(&caml_locking_scheme);
   s->yield(s->context);
   if (atomic_load(&caml_locking_scheme) != s) {
     /* The lock we have is no longer the runtime lock */


### PR DESCRIPTION
The test failures in CI on `swapgil` are due to a bug in the new GIL-swapping logic (#1365): if one thread tries to swap the GIL while another thread is executing an OCaml signal handler during `Thread.yield`, bad things happen.

The source of the badness is caching the value of `caml_locking_scheme` in a local variable for too long (it can go out of date whenever the runtime lock is dropped, so in particular can't be held across `caml_process_pending_signals_exn`), and the fix is to reload it.