### PR TITLE
Add documentation for testing targets to HACKING docs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -143,6 +143,23 @@ There is also a `make ci` target which does a full build and test run.
 Some of our tests are expect tests run using a custom tool called `flexpect`.
 Corrected outputs can be promoted using `make promote`.
 
+See `ocaml/HACKING.jst.adoc` for documentation on additional test-related
+targets. When that documentation says to run (say) `make -f Makefile.jst test-one`
+from the `ocaml` subdirectory, you should instead run `make test-one` from the
+root of the repo. Here are some examples of commands you can run:
+
+```
+$ make test-one TEST=typing-local/local.ml
+$ make test-one-no-rebuild TEST=typing-local/local.ml
+$ make promote-one TEST=typing-local/local.ml
+$ make promote-one-no-rebuild TEST=typing-local/local.ml
+# Promote failures from the last run
+$ make promote-failed
+# You can also use the full path from the root of the repo.
+# This interacts better with tab completion.
+$ make test-one TEST=ocaml/testsuite/tests/typing-local/local.ml
+```
+
 ## Running only part of the upstream testsuite
 
 This can be done from the `_runtest` directory after it has been initialised by a previous `make runtest-upstream`.

--- a/ocaml/HACKING.jst.adoc
+++ b/ocaml/HACKING.jst.adoc
@@ -54,6 +54,25 @@ where the test file or test dir are specified with respect to the
     $ make -f Makefile.jst test-one TEST=typing-local/local.ml
     $ make -f Makefile.jst test-one DIR=typing-local
 
+Likewise, you can use `promote-one` to accept the diff from a failed
+test:
+
+    $ make -f Makefile.jst promote-one TEST=typing-local/local.ml
+    $ make -f Makefile.jst promote-one DIR=typing-local
+
+If you've run some series of tests and would like to accept the diff
+from all failed tests in that run, use `promote-failed`:
+
+    $ make -f Makefile.jst promote-failed
+
+To run just one test without running a full dune build, you can use
+`*-no-rebuild` versions of `test-one` and `promote-one`. Note that these
+targets won't pick up changes you've made to compiler code, though they will
+faithfully pick up changes you've made to test files.
+
+    $ make -f Makefile.jst test-one-no-rebuild TEST=typing-local/local.ml
+    $ make -f Makefile.jst promote-one-no-rebuild DIR=typing-local
+
 ## Debugging
 
 We make several custom printers available so that we can print more values in
@@ -97,7 +116,7 @@ Remember to check that the newly installed switch is being used:
         4.14.1     ocaml-base-compiler.4.14.1                       4.14.1
     ->  4.14.1-fp  ocaml-option-fp.1,ocaml-variants.4.14.1+options  4.14.1-fp
 
-Then build the compiler - the following command will build the compiler using the opam switch, then use the newly-built compiler to build itself.
+Then build the compiler &mdash; the following command will build the compiler using the opam switch, then use the newly-built compiler to build itself.
 
     $ make -f Makefile.jst compiler
     


### PR DESCRIPTION
cc @goldfirere as this came out of a conversation we had about missing documentation for some targets. Mark, you're the only approving reviewer &mdash; mind taking a look? (low-priority)