### PR TITLE
`Cfg.can_raise_terminator`: allocations no longer raise

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -413,7 +413,10 @@ let print_instruction ppf i = print_instruction' ppf i
 
 let can_raise_terminator (i : terminator) =
   match i with
-  | Raise _ | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ -> true
+  | Raise _ | Tailcall_func _ | Call_no_return _ | Call _
+  | Prim { op = External _ | Checkbound _ | Probe _; label_after = _ } ->
+    true
+  | Prim { op = Alloc _; label_after = _ } -> false
   | Specific_can_raise { op; _ } ->
     assert (Arch.operation_can_raise op);
     true


### PR DESCRIPTION
Allocations no longer raise since https://github.com/ocaml-flambda/flambda-backend/pull/802;
the change was probably lost dut to
a rebase / concurrency of https://github.com/ocaml-flambda/flambda-backend/pull/785.