### PR TITLE
Fix programmatically enabling and disabling the same layouts extension

### DIFF
--- a/ocaml/testsuite/tests/language-extensions/language_extensions.ml
+++ b/ocaml/testsuite/tests/language-extensions/language_extensions.ml
@@ -60,19 +60,37 @@ let try_disallowing_extensions name =
 
 type goal = Fail | Succeed
 
+let with_goal goal ~name ~what test = match goal with
+  | Fail    -> should_fail    name      test
+  | Succeed -> should_succeed name what test
+
+let with_two_layouts goal first second ~enabled =
+  let verb ending =
+    "enabl" ^ ending ^ (if enabled then "" else " and disabl" ^ ending)
+  in
+  let comparison, plural =
+    if first = second then "the same", "" else "two different", "s"
+  in
+  let description ending =
+    verb ending ^ " " ^ comparison ^ " layouts extension" ^ plural
+  in
+  Language_extension.with_enabled (Layouts first) (fun () ->
+    with_goal goal
+      ~name:(description "e")
+      ~what:(description "ing")
+      (fun () ->
+         Language_extension.with_set (Layouts second) ~enabled (fun () -> ())))
+
 let when_disallowed goal f_str f =
   let can_or_can't = match goal with
     | Fail    -> "can't"
     | Succeed -> "can"
   in
   let f_code = "[" ^ f_str ^ "]" in
-  let name =
-    can_or_can't ^ " call " ^ f_code ^ " when extensions are disallowed"
-  in
-  let action () = f extension in
-  match goal with
-  | Fail    -> should_fail    name                                   action
-  | Succeed -> should_succeed name ("redundantly calling " ^ f_code) action
+  with_goal goal
+    ~name:(can_or_can't ^ " call " ^ f_code ^ " when extensions are disallowed")
+    ~what:("redundantly calling " ^ f_code)
+    (fun () -> f extension)
 ;;
 
 let lift_with with_fn extension = with_fn extension Fun.id;;
@@ -147,16 +165,13 @@ Language_extension.with_set extension ~enabled:false (fun () ->
 Language_extension.with_set extension ~enabled:true (fun () ->
   typecheck_with_extension "disabled locally via [with_set] and also globally");
 
-(* Test that we only allow you to pass one layouts extension flag *)
-should_fail "Enable two layouts"
-  (fun () ->
-     Language_extension.(enable (Layouts Alpha));
-     Language_extension.(enable (Layouts Beta)));
+(* Test that we only allow you to pass one distinct layouts extension flag*)
 
-should_fail "Enable and disable layouts"
-  (fun () ->
-     Language_extension.(enable (Layouts Alpha));
-     Language_extension.(disable (Layouts Beta)));
+with_two_layouts Succeed Alpha Alpha ~enabled:false;
+
+with_two_layouts Fail    Alpha Beta  ~enabled:false;
+
+with_two_layouts Fail    Alpha Beta  ~enabled:true;
 
 (* Test disallowing extensions *)
 

--- a/ocaml/testsuite/tests/language-extensions/reference.txt
+++ b/ocaml/testsuite/tests/language-extensions/reference.txt
@@ -52,11 +52,15 @@ Successfully typechecked "[x for x = 1 to 10]"
 # "comprehensions" extension disabled locally via [with_set] and also globally [comprehensions enabled]:
 Successfully typechecked "[x for x = 1 to 10]"
 
-# Enable two layouts [comprehensions enabled]:
-Failed as expected: Invalid extensions: Please enable at most one of 'layouts', 'layouts_beta', and 'layouts_alpha'.
+# enable and disable the same layouts extension [comprehensions enabled]:
+FAILED at enabling and disabling the same layouts extension, with the following error
+:Cannot disable extension layouts_alpha because extension layouts_alpha is enabled. Please enable or disable at most one of the layouts extensions.
 
-# Enable and disable layouts [comprehensions enabled]:
+# enable and disable two different layouts extensions [comprehensions enabled]:
 Failed as expected: Cannot disable extension layouts_beta because extension layouts_alpha is enabled. Please enable or disable at most one of the layouts extensions.
+
+# enable two different layouts extensions [comprehensions enabled]:
+Failed as expected: Invalid extensions: Please enable at most one of 'layouts', 'layouts_beta', and 'layouts_alpha'.
 
 # can disallow extensions while extensions are enabled [comprehensions disabled]:
 Succeeded at disallowing all extensions

--- a/ocaml/testsuite/tests/language-extensions/reference.txt
+++ b/ocaml/testsuite/tests/language-extensions/reference.txt
@@ -53,8 +53,7 @@ Successfully typechecked "[x for x = 1 to 10]"
 Successfully typechecked "[x for x = 1 to 10]"
 
 # enable and disable the same layouts extension [comprehensions enabled]:
-FAILED at enabling and disabling the same layouts extension, with the following error
-:Cannot disable extension layouts_alpha because extension layouts_alpha is enabled. Please enable or disable at most one of the layouts extensions.
+Succeeded at enabling and disabling the same layouts extension
 
 # enable and disable two different layouts extensions [comprehensions enabled]:
 Failed as expected: Cannot disable extension layouts_beta because extension layouts_alpha is enabled. Please enable or disable at most one of the layouts extensions.


### PR DESCRIPTION
When we introduced logic to avoid accidentally specifying both `-layouts_beta` and `-layouts_stable`, we had a bug in the programmatic API, where it was impossible to ever switch off a layouts extension that had been switched on.  This PR fixes that; see the first commit for a test where things are in the broken state, which is fixed by the second commit.