### PR TITLE
Don't substitute into exclaves in `simplif.ml`

### DIFF
--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -187,7 +187,7 @@ let simplify_exits lam =
   | Levent(l, _) -> count ~try_depth l
   | Lifused(_v, l) -> count ~try_depth l
   | Lregion (l, _) -> count ~try_depth:(try_depth+1) l
-  | Lexclave l -> count ~try_depth:(try_depth+1) l
+  | Lexclave l -> count ~try_depth:(try_depth-1) l
 
   and count_default ~try_depth sw = match sw.sw_failaction with
   | None -> ()

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -187,7 +187,7 @@ let simplify_exits lam =
   | Levent(l, _) -> count ~try_depth l
   | Lifused(_v, l) -> count ~try_depth l
   | Lregion (l, _) -> count ~try_depth:(try_depth+1) l
-  | Lexclave l -> count ~try_depth:(try_depth-1) l
+  | Lexclave l -> count ~try_depth:(try_depth+1) l
 
   and count_default ~try_depth sw = match sw.sw_failaction with
   | None -> ()

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -492,7 +492,10 @@ let simplify_lets lam =
   | Lregion (l, _) ->
       count bv l
   | Lexclave l ->
-      count bv l
+      (* Not safe in general to move code into an exclave, so block
+         single-use optimizations by treating them the same as lambdas
+         and loops *)
+      count Ident.Map.empty l
 
   and count_default bv sw = match sw.sw_failaction with
   | None -> ()

--- a/ocaml/testsuite/tests/typing-local/exclave.ml
+++ b/ocaml/testsuite/tests/typing-local/exclave.ml
@@ -211,5 +211,10 @@ let f () =
      assert (x = 1))
 ;;
 f ();;
-[%%expect{||}]
+[%%expect{|
+type 'a glob = Glob of global_ 'a
+val return_local : 'a -> local_ 'a glob = <fun>
+val f : unit -> local_ unit = <fun>
+- : unit = ()
+|}]
 

--- a/ocaml/testsuite/tests/typing-local/exclave.ml
+++ b/ocaml/testsuite/tests/typing-local/exclave.ml
@@ -199,3 +199,17 @@ val bar : 'a -> string = <fun>
 - : string = "Some of 5"
 |}]
 
+(* Ensure that Alias bindings are not substituted by Simplif (PR1448) *)
+type 'a glob = Glob of ('a[@global])
+
+let[@inline never] return_local a = [%local] (Glob a)
+
+let f () =
+  let (Glob x) = return_local 1 in
+  [%exclave]
+    (let (_ : _) = return_local 99 in
+     assert (x <> 99))
+
+f ();
+[%%expect{||}]
+

--- a/ocaml/testsuite/tests/typing-local/exclave.ml
+++ b/ocaml/testsuite/tests/typing-local/exclave.ml
@@ -208,8 +208,8 @@ let f () =
   let (Glob x) = return_local 1 in
   [%exclave]
     (let (_ : _) = return_local 99 in
-     assert (x <> 99))
-
-f ();
+     assert (x = 1))
+;;
+f ();;
 [%%expect{||}]
 


### PR DESCRIPTION
The current behavior in the lambda-to-lambda optimizer substitutes away certain `let` bindings that are used only once and not under a lambda or inside a loop. We need to add `exclave` to this list of provisos, to avoid cases like:

```
type 'a glob = Glob of ('a[@global])

let[@inline never] return_local a = [%local] (Glob a)

let f () =
  let (Glob x) = return_local 1 in
  [%exclave]
    (let (_ : _) = return_local 99 in
     assert (x <> 99))
;;
```

Here the lambda code generated is something like

```
let *match* = apply return_local 1 in
let x = field 0 *match* in
exclave (
  let _ = apply return_local 99 in
  assert (x <> 99)
)
```

If we read `field 0 *match*` inside the exclave, we'll get 99 rather than 1, since the exclave decrements the local stack pointer, meaning the `Glob 99` block gets allocated on top of the `Glob 1`, clobbering the 1 with a 99. Therefore we have to keep the binding of `x` where it is. Conservatively, we assume that _any_ `let` binding could be unsafe to move into the `exclave`, so we treat `exclave` like a loop body and never substitute into it.