### PR TITLE
Ensure that kinds are checked by meet_block_field_simple

### DIFF
--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -533,11 +533,7 @@ let create_let_symbols uacc lifted_constant ~body =
                     then Immediate
                     else Any_value
                   in
-                  Values
-                    { tag = Known Tag.Scannable.zero;
-                      size = Unknown;
-                      field_kind
-                    }
+                  Values { tag = Unknown; size = Unknown; field_kind }
                 | Naked_number Naked_float -> Naked_floats { size = Unknown }
                 | Naked_number
                     ( Naked_immediate | Naked_nativeint | Naked_int32

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -520,18 +520,36 @@ let create_let_symbols uacc lifted_constant ~body =
         | None ->
           let prim : P.t =
             let symbol = Simple.symbol (Symbol_projection.symbol proj) in
+            let kind = Symbol_projection.kind proj in
             match Symbol_projection.projection proj with
             | Block_load { index } ->
               let index = Simple.const_int index in
               let block_access_kind : P.Block_access_kind.t =
-                Values
-                  { tag = Known Tag.Scannable.zero;
-                    size = Unknown;
-                    field_kind = Any_value
-                  }
+                match Flambda_kind.With_subkind.kind kind with
+                | Value ->
+                  let field_kind : P.Block_access_field_kind.t =
+                    if Flambda_kind.With_subkind.equal kind
+                         Flambda_kind.With_subkind.tagged_immediate
+                    then Immediate
+                    else Any_value
+                  in
+                  Values
+                    { tag = Known Tag.Scannable.zero;
+                      size = Unknown;
+                      field_kind
+                    }
+                | Naked_number Naked_float -> Naked_floats { size = Unknown }
+                | Naked_number
+                    ( Naked_immediate | Naked_nativeint | Naked_int32
+                    | Naked_int64 )
+                | Region | Rec_info ->
+                  Misc.fatal_errorf
+                    "Unexpected kind %a for symbol projection: %a"
+                    Flambda_kind.With_subkind.print kind Symbol_projection.print
+                    proj
               in
               Binary (Block_load (block_access_kind, Immutable), symbol, index)
-            | Project_value_slot { project_from; value_slot; kind } ->
+            | Project_value_slot { project_from; value_slot } ->
               Unary
                 (Project_value_slot { project_from; value_slot; kind }, symbol)
           in

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -292,8 +292,8 @@ let apply_projection t proj =
     let meet_shortcut =
       match Symbol_projection.projection proj with
       | Block_load { index } ->
-        T.meet_block_field_simple typing_env ~min_name_mode:Name_mode.normal ty
-          index
+        T.meet_block_field_simple typing_env ~min_name_mode:Name_mode.normal
+          ~field_kind:Flambda_kind.value ty index
       | Project_value_slot { project_from = _; value_slot; kind = _ } ->
         (* CR mshinwell: could use [kind]? *)
         T.meet_project_value_slot_simple typing_env

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -290,16 +290,16 @@ let apply_projection t proj =
     in
     let typing_env = DE.typing_env denv in
     let meet_shortcut =
-      let kind =
-        Symbol_projection.kind proj |> Flambda_kind.With_subkind.kind
-      in
       match Symbol_projection.projection proj with
       | Block_load { index } ->
+        let field_kind =
+          Symbol_projection.kind proj |> Flambda_kind.With_subkind.kind
+        in
         T.meet_block_field_simple typing_env ~min_name_mode:Name_mode.normal
-          ~field_kind:kind ty index
+          ~field_kind ty index
       | Project_value_slot { project_from = _; value_slot } ->
         T.meet_project_value_slot_simple typing_env
-          ~min_name_mode:Name_mode.normal ~value_slot_kind:kind ty value_slot
+          ~min_name_mode:Name_mode.normal ty value_slot
     in
     match meet_shortcut with
     | Known_result simple -> Some simple

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -305,7 +305,7 @@ let apply_projection t proj =
     | Known_result simple -> Some simple
     | Need_meet ->
       (* [Simplify_named], which calls this function, requires [Some] to be
-         returned iff the projection is from a symbol defined in the same
+         returned if the projection is from a symbol defined in the same
          recursive group (see the comment in that module). As such, if the
          projection via the types fails, we currently stop. It seems very
          unlikely that this will happen; we can reconsider in the future if

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -290,14 +290,16 @@ let apply_projection t proj =
     in
     let typing_env = DE.typing_env denv in
     let meet_shortcut =
+      let kind =
+        Symbol_projection.kind proj |> Flambda_kind.With_subkind.kind
+      in
       match Symbol_projection.projection proj with
       | Block_load { index } ->
         T.meet_block_field_simple typing_env ~min_name_mode:Name_mode.normal
-          ~field_kind:Flambda_kind.value ty index
-      | Project_value_slot { project_from = _; value_slot; kind = _ } ->
-        (* CR mshinwell: could use [kind]? *)
+          ~field_kind:kind ty index
+      | Project_value_slot { project_from = _; value_slot } ->
         T.meet_project_value_slot_simple typing_env
-          ~min_name_mode:Name_mode.normal ty value_slot
+          ~min_name_mode:Name_mode.normal ~value_slot_kind:kind ty value_slot
     in
     match meet_shortcut with
     | Known_result simple -> Some simple

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -921,6 +921,7 @@ let simplify_immutable_block_load access_kind ~min_name_mode dacc ~original_term
           Simplify_common.add_symbol_projection result.dacc ~projected_from:arg1
             (Symbol_projection.Projection.block_load ~index)
             ~projection_bound_to:result_var
+            ~kind:Flambda_kind.With_subkind.tagged_immediate
         | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
         | Naked_nativeint _ ->
           Misc.fatal_errorf "Kind error for [Block_load] of %a at index %a"

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -818,11 +818,7 @@ let simplify_phys_equal (op : P.equality_comparison) dacc ~original_term _dbg
 let[@inline always] simplify_immutable_block_load0
     (access_kind : P.Block_access_kind.t) ~min_name_mode dacc ~original_term
     _dbg ~arg1:block ~arg1_ty:block_ty ~arg2:_ ~arg2_ty:index_ty ~result_var =
-  let result_kind =
-    match access_kind with
-    | Values _ -> K.value
-    | Naked_floats _ -> K.naked_float
-  in
+  let result_kind = P.Block_access_kind.element_kind_for_load access_kind in
   let result_var' = Bound_var.var result_var in
   let typing_env = DA.typing_env dacc in
   match T.meet_equals_single_tagged_immediate typing_env index_ty with
@@ -830,7 +826,8 @@ let[@inline always] simplify_immutable_block_load0
   | Need_meet -> SPR.create_unknown dacc ~result_var result_kind ~original_term
   | Known_result index -> (
     match
-      T.meet_block_field_simple typing_env ~min_name_mode block_ty index
+      T.meet_block_field_simple typing_env ~min_name_mode
+        ~field_kind:result_kind block_ty index
     with
     | Invalid -> SPR.create_invalid dacc
     | Known_result simple ->

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -364,7 +364,8 @@ let specialise_array_kind dacc (array_kind : P.Array_kind.t) ~array_ty :
       | Known_result false | Need_meet -> Ok array_kind
       | Known_result true | Invalid -> Bottom))
 
-let add_symbol_projection dacc ~projected_from projection ~projection_bound_to =
+let add_symbol_projection dacc ~projected_from projection ~projection_bound_to
+    ~kind =
   if DE.at_unit_toplevel (DA.denv dacc)
   then dacc
   else
@@ -372,7 +373,7 @@ let add_symbol_projection dacc ~projected_from projection ~projection_bound_to =
     Simple.pattern_match' projected_from
       ~const:(fun _ -> dacc)
       ~symbol:(fun symbol_projected_from ~coercion:_ ->
-        let proj = SP.create symbol_projected_from projection in
+        let proj = SP.create symbol_projected_from projection kind in
         let var = Bound_var.var projection_bound_to in
         DA.map_denv dacc ~f:(fun denv -> DE.add_symbol_projection denv var proj))
       ~var:(fun _ ~coercion:_ -> dacc)

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -164,4 +164,5 @@ val add_symbol_projection :
   projected_from:Simple.t ->
   Symbol_projection.Projection.t ->
   projection_bound_to:Bound_var.t ->
+  kind:Flambda_kind.With_subkind.t ->
   Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -49,6 +49,7 @@ let simplify_project_value_slot function_slot value_slot kind ~min_name_mode
     (* We try a faster method before falling back to [simplify_projection]. *)
     match
       T.meet_project_value_slot_simple (DA.typing_env dacc) ~min_name_mode
+        ~value_slot_kind:(Flambda_kind.With_subkind.kind kind)
         closure_ty value_slot
     with
     | Invalid -> SPR.create_invalid dacc
@@ -84,9 +85,8 @@ let simplify_project_value_slot function_slot value_slot kind ~min_name_mode
   in
   let dacc =
     Simplify_common.add_symbol_projection result.dacc ~projected_from:closure
-      (Symbol_projection.Projection.project_value_slot function_slot value_slot
-         kind)
-      ~projection_bound_to:result_var
+      (Symbol_projection.Projection.project_value_slot function_slot value_slot)
+      ~projection_bound_to:result_var ~kind
   in
   SPR.with_dacc result dacc
 

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -49,7 +49,6 @@ let simplify_project_value_slot function_slot value_slot kind ~min_name_mode
     (* We try a faster method before falling back to [simplify_projection]. *)
     match
       T.meet_project_value_slot_simple (DA.typing_env dacc) ~min_name_mode
-        ~value_slot_kind:(Flambda_kind.With_subkind.kind kind)
         closure_ty value_slot
     with
     | Invalid -> SPR.create_invalid dacc

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -153,6 +153,8 @@ module Closure_field = struct
         (fun closure -> unboxing_prim function_slot ~closure value_slot kind);
       prove_simple =
         (fun tenv ~min_name_mode t ->
-          T.meet_project_value_slot_simple tenv ~min_name_mode t value_slot)
+          T.meet_project_value_slot_simple tenv ~min_name_mode
+            ~value_slot_kind:(Flambda_kind.With_subkind.kind kind)
+            t value_slot)
     }
 end

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -134,7 +134,9 @@ module Field = struct
       unboxing_prim = (fun block -> unboxing_prim bak ~block ~index);
       prove_simple =
         (fun tenv ~min_name_mode t ->
-          T.meet_block_field_simple tenv ~min_name_mode t index)
+          T.meet_block_field_simple tenv ~min_name_mode
+            ~field_kind:(P.Block_access_kind.element_kind_for_load bak)
+            t index)
     }
 end
 

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -153,8 +153,6 @@ module Closure_field = struct
         (fun closure -> unboxing_prim function_slot ~closure value_slot kind);
       prove_simple =
         (fun tenv ~min_name_mode t ->
-          T.meet_project_value_slot_simple tenv ~min_name_mode
-            ~value_slot_kind:(Flambda_kind.With_subkind.kind kind)
-            t value_slot)
+          T.meet_project_value_slot_simple tenv ~min_name_mode t value_slot)
     }
 end

--- a/middle_end/flambda2/term_basics/symbol_projection.ml
+++ b/middle_end/flambda2/term_basics/symbol_projection.ml
@@ -17,23 +17,19 @@ module Projection = struct
     | Block_load of { index : Targetint_31_63.t }
     | Project_value_slot of
         { project_from : Function_slot.t;
-          value_slot : Value_slot.t;
-          kind : Flambda_kind.With_subkind.t
+          value_slot : Value_slot.t
         }
 
   let block_load ~index = Block_load { index }
 
-  let project_value_slot project_from value_slot kind =
-    Project_value_slot { project_from; value_slot; kind }
+  let project_value_slot project_from value_slot =
+    Project_value_slot { project_from; value_slot }
 
   let hash t =
     match t with
     | Block_load { index } -> Targetint_31_63.hash index
-    | Project_value_slot { project_from; value_slot; kind } ->
-      Hashtbl.hash
-        ( Function_slot.hash project_from,
-          Value_slot.hash value_slot,
-          Flambda_kind.With_subkind.hash kind )
+    | Project_value_slot { project_from; value_slot } ->
+      Hashtbl.hash (Function_slot.hash project_from, Value_slot.hash value_slot)
 
   let [@ocamlformat "disable"] print ppf t =
     match t with
@@ -42,82 +38,81 @@ module Projection = struct
           @[<hov 1>(index@ %a)@]\
           )@]"
         Targetint_31_63.print index
-    | Project_value_slot { project_from; value_slot; kind } ->
+    | Project_value_slot { project_from; value_slot; } ->
       Format.fprintf ppf "@[<hov 1>(Project_value_slot@ \
           @[<hov 1>(project_from@ %a)@]@ \
-          @[<hov 1>(var@ %a)@]@ \
-          @[<hov 1>(kind@ %a)@]\
+          @[<hov 1>(var@ %a)@]\
           )@]"
         Function_slot.print project_from
         Value_slot.print value_slot
-        Flambda_kind.With_subkind.print kind
 
   let compare t1 t2 =
     match t1, t2 with
     | Block_load { index = index1 }, Block_load { index = index2 } ->
       Targetint_31_63.compare index1 index2
     | ( Project_value_slot
-          { project_from = project_from1;
-            value_slot = value_slot1;
-            kind = kind1
-          },
+          { project_from = project_from1; value_slot = value_slot1 },
         Project_value_slot
-          { project_from = project_from2;
-            value_slot = value_slot2;
-            kind = kind2
-          } ) ->
+          { project_from = project_from2; value_slot = value_slot2 } ) ->
       let c = Function_slot.compare project_from1 project_from2 in
-      if c <> 0
-      then c
-      else
-        let c = Value_slot.compare value_slot1 value_slot2 in
-        if c <> 0 then c else Flambda_kind.With_subkind.compare kind1 kind2
+      if c <> 0 then c else Value_slot.compare value_slot1 value_slot2
     | Block_load _, Project_value_slot _ -> -1
     | Project_value_slot _, Block_load _ -> 1
 end
 
 type t =
   { symbol : Symbol.t;
-    projection : Projection.t
+    projection : Projection.t;
+    kind : Flambda_kind.With_subkind.t
   }
 
-let [@ocamlformat "disable"] print ppf { symbol; projection; } =
+let [@ocamlformat "disable"] print ppf { symbol; projection;kind } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(symbol@ %a)@]@ \
-      @[<hov 1>(projection@ %a)@]\
+      @[<hov 1>(projection@ %a)@] \
+      @[<hov 1>(kind@ %a)@]\
       )@]"
     Symbol.print symbol
-    Projection.print projection
+    Projection.print projection Flambda_kind.With_subkind.print kind
 
-let create symbol projection = { symbol; projection }
+let create symbol projection kind = { symbol; projection; kind }
 
 let symbol t = t.symbol
 
 let projection t = t.projection
 
-let compare { symbol = symbol1; projection = projection1 }
-    { symbol = symbol2; projection = projection2 } =
+let kind t = t.kind
+
+let compare { symbol = symbol1; projection = projection1; kind = kind1 }
+    { symbol = symbol2; projection = projection2; kind = kind2 } =
   let c = Symbol.compare symbol1 symbol2 in
-  if c <> 0 then c else Projection.compare projection1 projection2
+  if c <> 0
+  then c
+  else
+    let c = Projection.compare projection1 projection2 in
+    if c <> 0 then c else Flambda_kind.With_subkind.compare kind1 kind2
 
 let equal t1 t2 = compare t1 t2 = 0
 
-let hash { symbol; projection } =
-  Hashtbl.hash (Symbol.hash symbol, Projection.hash projection)
+let hash { symbol; projection; kind } =
+  Hashtbl.hash
+    ( Symbol.hash symbol,
+      Hashtbl.hash
+        (Projection.hash projection, Flambda_kind.With_subkind.hash kind) )
 
-let apply_renaming ({ symbol; projection = _ } as t) renaming =
+let apply_renaming ({ symbol; projection = _; kind = _ } as t) renaming =
   let symbol' = Renaming.apply_symbol renaming symbol in
   if symbol == symbol' then t else { t with symbol = symbol' }
 
-let free_names { symbol; projection } =
+let free_names { symbol; projection; kind = _ } =
   let free_names = Name_occurrences.singleton_symbol symbol Name_mode.normal in
   match projection with
   | Block_load _ -> free_names
-  | Project_value_slot { project_from; value_slot; kind = _ } ->
+  | Project_value_slot { project_from; value_slot } ->
     Name_occurrences.add_function_slot_in_projection
       (Name_occurrences.add_value_slot_in_projection free_names value_slot
          Name_mode.normal)
       project_from Name_mode.normal
 
-let ids_for_export { symbol; projection = _ } =
+let ids_for_export { symbol; projection = _; kind = _ } =
   Ids_for_export.singleton_symbol symbol

--- a/middle_end/flambda2/term_basics/symbol_projection.mli
+++ b/middle_end/flambda2/term_basics/symbol_projection.mli
@@ -17,21 +17,21 @@ module Projection : sig
     | Block_load of { index : Targetint_31_63.t }
     | Project_value_slot of
         { project_from : Function_slot.t;
-          value_slot : Value_slot.t;
-          kind : Flambda_kind.With_subkind.t
+          value_slot : Value_slot.t
         }
 
   val block_load : index:Targetint_31_63.t -> t
 
-  val project_value_slot :
-    Function_slot.t -> Value_slot.t -> Flambda_kind.With_subkind.t -> t
+  val project_value_slot : Function_slot.t -> Value_slot.t -> t
 end
 
 type t
 
 val print : Format.formatter -> t -> unit
 
-val create : Symbol.t -> Projection.t -> t
+val create : Symbol.t -> Projection.t -> Flambda_kind.With_subkind.t -> t
+
+val kind : t -> Flambda_kind.With_subkind.t
 
 val symbol : t -> Symbol.t
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -678,6 +678,7 @@ val meet_boxed_nativeint_containing_simple :
 val meet_block_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
+  field_kind:Flambda_kind.t ->
   t ->
   Targetint_31_63.t ->
   Simple.t meet_shortcut

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -686,6 +686,7 @@ val meet_block_field_simple :
 val meet_project_value_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
+  value_slot_kind:Flambda_kind.t ->
   t ->
   Value_slot.t ->
   Simple.t meet_shortcut

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -686,7 +686,6 @@ val meet_block_field_simple :
 val meet_project_value_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
-  value_slot_kind:Flambda_kind.t ->
   t ->
   Value_slot.t ->
   Simple.t meet_shortcut

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -776,16 +776,18 @@ let meet_project_function_slot_simple env ~min_name_mode t function_slot :
   | Naked_nativeint _ | Rec_info _ | Region _ ->
     wrong_kind "Value" t
 
-let meet_project_value_slot_simple env ~min_name_mode ~value_slot_kind t env_var
-    : Simple.t meet_shortcut =
+let meet_project_value_slot_simple env ~min_name_mode t value_slot :
+    Simple.t meet_shortcut =
   match expand_head env t with
   | Value (Ok (Closures { by_function_slot; alloc_mode = _ })) -> (
-    match TG.Row_like_for_closures.get_env_var by_function_slot env_var with
+    match TG.Row_like_for_closures.get_env_var by_function_slot value_slot with
     | Unknown -> Need_meet
     | Known ty -> (
       if (* It's more straightforward to check the kind of [ty] instead of
             examining the row-like structure directly. *)
-         not (Flambda_kind.equal (TG.kind ty) value_slot_kind)
+         not
+           (Flambda_kind.equal (TG.kind ty)
+              (Value_slot.kind value_slot |> Flambda_kind.With_subkind.kind))
       then Invalid
       else
         match TG.get_alias_exn ty with

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -735,7 +735,9 @@ let meet_block_field_simple env ~min_name_mode ~field_kind t field_index :
         | Bottom -> Invalid
         | Unknown -> Need_meet
         | Ok ty -> (
-          if not (Flambda_kind.equal (TG.kind ty) field_kind)
+          if (* It's more straightforward to check the kind of [ty] instead of
+                examining the row-like structure directly. *)
+             not (Flambda_kind.equal (TG.kind ty) field_kind)
           then Invalid
           else
             match TG.get_alias_exn ty with
@@ -781,7 +783,9 @@ let meet_project_value_slot_simple env ~min_name_mode ~value_slot_kind t env_var
     match TG.Row_like_for_closures.get_env_var by_function_slot env_var with
     | Unknown -> Need_meet
     | Known ty -> (
-      if not (Flambda_kind.equal (TG.kind ty) value_slot_kind)
+      if (* It's more straightforward to check the kind of [ty] instead of
+            examining the row-like structure directly. *)
+         not (Flambda_kind.equal (TG.kind ty) value_slot_kind)
       then Invalid
       else
         match TG.get_alias_exn ty with

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -201,7 +201,6 @@ val meet_block_field_simple :
 val meet_project_value_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
-  value_slot_kind:Flambda_kind.t ->
   Type_grammar.t ->
   Value_slot.t ->
   Simple.t meet_shortcut

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -193,6 +193,7 @@ val meet_boxed_nativeint_containing_simple :
 val meet_block_field_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
+  field_kind:Flambda_kind.t ->
   Type_grammar.t ->
   Targetint_31_63.t ->
   Simple.t meet_shortcut

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -201,6 +201,7 @@ val meet_block_field_simple :
 val meet_project_value_slot_simple :
   Typing_env.t ->
   min_name_mode:Name_mode.t ->
+  value_slot_kind:Flambda_kind.t ->
   Type_grammar.t ->
   Value_slot.t ->
   Simple.t meet_shortcut


### PR DESCRIPTION
The fast path in `simplify_immutable_block_load`, which uses `T.meet_block_field_simple`, is not currently checking the kind of any `Simple` found in the corresponding field against the required kind.  This can cause `Simple`s of the wrong kind to be returned with corresponding wrong equations added to the environment.