### PR TITLE
Fix a typo in language extension parsing/serializing

### DIFF
--- a/ocaml/testsuite/tests/language-extensions/language_extensions.ml
+++ b/ocaml/testsuite/tests/language-extensions/language_extensions.ml
@@ -216,4 +216,16 @@ report
   ~text:("\"" ^ extension_name ^ "\" is " ^
          if Language_extension.is_enabled extension
          then "INCORRECTLY enabled"
-         else "correctly disabled")
+         else "correctly disabled");
+
+(* Test that language extensions round-trip via string *)
+List.iter
+  (fun (Language_extension.Exist.Pack x) ->
+     let str = Language_extension.to_string x in
+     let Pack x' =
+       match Language_extension.of_string str with
+       | None -> failwith str
+       | Some x' -> x'
+     in
+     if not (Language_extension.equal x x') then failwith str)
+  Language_extension.Exist.all;

--- a/ocaml/utils/language_extension.ml
+++ b/ocaml/utils/language_extension.ml
@@ -98,7 +98,7 @@ let pair_of_string extn_name : extn_pair option =
   | "include_functor" -> Some (Pair (Include_functor, ()))
   | "polymorphic_parameters" -> Some (Pair (Polymorphic_parameters, ()))
   | "immutable_arrays" -> Some (Pair (Immutable_arrays, ()))
-  | "strengthening" -> Some (Pair (Module_strengthening, ()))
+  | "module_strengthening" -> Some (Pair (Module_strengthening, ()))
   | "layouts" -> Some (Pair (Layouts, (Stable : Maturity.t)))
   | "layouts_beta" -> Some (Pair (Layouts, (Beta : Maturity.t)))
   | "layouts_alpha" -> Some (Pair (Layouts, (Alpha : Maturity.t)))


### PR DESCRIPTION
Fix a typo that prevented the `Module_strengthening` language extension from round-tripping via a string. (And add a test so we don't run into this again.)

Reviewer: @goldfirere please! (@antalsz is out.)