### PR TITLE
Add flambda2 -Oclassic and -O3 CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,12 @@ jobs:
           - name: flambda2_nnp_o3
             config: --enable-middle-end=flambda2 --disable-naked-pointers
             os: ubuntu-latest
-            ocamlparam: '_,o3=1'
+            ocamlparam: '_,O3=1'
 
           - name: flambda2_frame_pointers_oclassic
             config: --enable-middle-end=flambda2 --enable-frame-pointers --enable-poll-insertion
             os: ubuntu-latest
-            ocamlparam: '_,oclassic=1'
+            ocamlparam: '_,Oclassic=1'
 
           - name: flambda2_cfg
             config: --enable-middle-end=flambda2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,15 +51,15 @@ jobs:
             use_runtime: d
             ocamlrunparam: "v=0,V=1"
 
-          - name: flambda2_nnp
+          - name: flambda2_nnp_o3
             config: --enable-middle-end=flambda2 --disable-naked-pointers
             os: ubuntu-latest
-            ocamlparam: ''
+            ocamlparam: 'o3=1'
 
-          - name: flambda2_frame_pointers
+          - name: flambda2_frame_pointers_oclassic
             config: --enable-middle-end=flambda2 --enable-frame-pointers --enable-poll-insertion
             os: ubuntu-latest
-            ocamlparam: ''
+            ocamlparam: 'oclassic=1'
 
           - name: flambda2_cfg
             config: --enable-middle-end=flambda2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,12 @@ jobs:
           - name: flambda2_nnp_o3
             config: --enable-middle-end=flambda2 --disable-naked-pointers
             os: ubuntu-latest
-            ocamlparam: 'o3=1'
+            ocamlparam: '_,o3=1'
 
           - name: flambda2_frame_pointers_oclassic
             config: --enable-middle-end=flambda2 --enable-frame-pointers --enable-poll-insertion
             os: ubuntu-latest
-            ocamlparam: 'oclassic=1'
+            ocamlparam: '_,oclassic=1'
 
           - name: flambda2_cfg
             config: --enable-middle-end=flambda2

--- a/ocaml/testsuite/tests/lib-dynlink-init-info/test.ml
+++ b/ocaml/testsuite/tests/lib-dynlink-init-info/test.ml
@@ -2,6 +2,8 @@
    include dynlink
 *)
 
+[@@@ocaml.warning "-58"]
+
 (* Make sure dynlink state info is accurate before any load
    occurs #9338. *)
 

--- a/ocaml/testsuite/tests/lib-dynlink-init-info/test.ml
+++ b/ocaml/testsuite/tests/lib-dynlink-init-info/test.ml
@@ -1,8 +1,7 @@
 (* TEST
+   flags += "-w -58"
    include dynlink
 *)
-
-[@@@ocaml.warning "-58"]
 
 (* Make sure dynlink state info is accurate before any load
    occurs #9338. *)


### PR DESCRIPTION
It turns out that insufficiently many optimization levels were being tested for flambda2.  I've added classic mode and `-O3` to two existing builds whose configuration differences should be orthogonal to the flambda2 optimization level.