### PR TITLE
sync dynlink/dune compiler flags

### DIFF
--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -17,7 +17,7 @@
   (wrapped true)
   (modes byte native)
   (flags (
-    -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48
+    -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
     -warn-error A -bin-annot -safe-string -strict-formats
   ))
   (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))


### PR DESCRIPTION
Sync some compiler flags from `dynlink/Makefile` to `dynlink/dune`. In particular, removing warning 70 to allow modules without `.mli` file - which is useful for `*_intf.ml` paradigm. 