### PR TITLE
Revert "Add flambda2 -Oclassic and -O3 CI jobs"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,15 +51,15 @@ jobs:
             use_runtime: d
             ocamlrunparam: "v=0,V=1"
 
-          - name: flambda2_nnp_o3
+          - name: flambda2_nnp
             config: --enable-middle-end=flambda2 --disable-naked-pointers
             os: ubuntu-latest
-            ocamlparam: '_,O3=1'
+            ocamlparam: ''
 
-          - name: flambda2_frame_pointers_oclassic
+          - name: flambda2_frame_pointers
             config: --enable-middle-end=flambda2 --enable-frame-pointers --enable-poll-insertion
             os: ubuntu-latest
-            ocamlparam: '_,Oclassic=1'
+            ocamlparam: ''
 
           - name: flambda2_cfg
             config: --enable-middle-end=flambda2

--- a/ocaml/testsuite/tests/lib-dynlink-init-info/test.ml
+++ b/ocaml/testsuite/tests/lib-dynlink-init-info/test.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags += "-w -58"
    include dynlink
 *)
 


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#1459

I think this is wrong actually, it's setting `BUILD_OCAMLPARAM` not `OCAMLPARAM`.