### PR TITLE
Regalloc: optimize stack slots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,19 +76,19 @@ jobs:
           - name: irc
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
-            build_ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
+            build_ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=STACK_SLOTS_OPTIM:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
             check_arch: true
 
           - name: irc_frame_pointers
             config: --enable-middle-end=flambda2 --enable-frame-pointers
             os: ubuntu-latest
-            build_ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
+            build_ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=STACK_SLOTS_OPTIM:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
             check_arch: true
 
           - name: ls
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
-            build_ocamlparam: '_,w=-46,regalloc=ls,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=LS_ORDER:layout,regalloc-validate=1'
+            build_ocamlparam: '_,w=-46,regalloc=ls,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=STACK_SLOTS_OPTIM:on,regalloc-param=LS_ORDER:layout,regalloc-validate=1'
             check_arch: true
 
           - name: build_upstream_closure

--- a/backend/cfg/cfg_dominators.mli
+++ b/backend/cfg/cfg_dominators.mli
@@ -42,6 +42,7 @@ type dominator_tree =
 
 val iter_breadth_dominator_tree : dominator_tree -> f:(Label.t -> unit) -> unit
 (* [iter_breadth_dominator_tree tree ~f] iterates over [tree] in a breadth-first
+=======
    manner, applying [f] to visited nodes. *)
 
 val compute_dominator_tree : Cfg.t -> immediate_dominators -> dominator_tree

--- a/backend/cfg/cfg_dominators.mli
+++ b/backend/cfg/cfg_dominators.mli
@@ -42,7 +42,6 @@ type dominator_tree =
 
 val iter_breadth_dominator_tree : dominator_tree -> f:(Label.t -> unit) -> unit
 (* [iter_breadth_dominator_tree tree ~f] iterates over [tree] in a breadth-first
-=======
    manner, applying [f] to visited nodes. *)
 
 val compute_dominator_tree : Cfg.t -> immediate_dominators -> dominator_tree

--- a/backend/regalloc/regalloc_irc_state.ml
+++ b/backend/regalloc/regalloc_irc_state.ml
@@ -45,7 +45,7 @@ type t =
     active_moves : InstructionWorkList.t;
     adj_set : RegisterStamp.PairSet.t;
     move_list : Instruction.Set.t Reg.Tbl.t;
-    stack_slots : StackSlots.t;
+    stack_slots : Regalloc_stack_slots.t;
     mutable next_instruction_id : Instruction.id;
     mutable introduced_temporaries : Reg.Set.t
   }

--- a/backend/regalloc/regalloc_irc_state.mli
+++ b/backend/regalloc/regalloc_irc_state.mli
@@ -7,7 +7,7 @@ type t
 
 val make :
   initial:Reg.t list ->
-  stack_slots:StackSlots.t ->
+  stack_slots:Regalloc_stack_slots.t ->
   next_instruction_id:Instruction.id ->
   unit ->
   t
@@ -124,7 +124,7 @@ val find_alias : t -> Reg.t -> Reg.t
 
 val add_alias : t -> Reg.t -> Reg.t -> unit
 
-val stack_slots : t -> StackSlots.t
+val stack_slots : t -> Regalloc_stack_slots.t
 
 val get_and_incr_instruction_id : t -> Instruction.id
 

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -6,7 +6,7 @@ open! Regalloc_ls_utils
 type t =
   { mutable intervals : Interval.t list;
     active : ClassIntervals.t array;
-    stack_slots : StackSlots.t;
+    stack_slots : Regalloc_stack_slots.t;
     mutable next_instruction_id : Instruction.id
   }
 

--- a/backend/regalloc/regalloc_ls_state.mli
+++ b/backend/regalloc/regalloc_ls_state.mli
@@ -7,7 +7,8 @@ type t
 
 val for_fatal : t -> Interval.t list * ClassIntervals.t array
 
-val make : stack_slots:StackSlots.t -> next_instruction_id:Instruction.id -> t
+val make :
+  stack_slots:Regalloc_stack_slots.t -> next_instruction_id:Instruction.id -> t
 
 val update_intervals : t -> Interval.t Reg.Tbl.t -> unit
 
@@ -19,7 +20,7 @@ val release_expired_intervals : t -> pos:int -> unit
 
 val active : t -> reg_class:int -> ClassIntervals.t
 
-val stack_slots : t -> StackSlots.t
+val stack_slots : t -> Regalloc_stack_slots.t
 
 val get_and_incr_instruction_id : t -> Instruction.id
 

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -252,7 +252,8 @@ let postlude :
      cfg_with_liveness ->
   let cfg_with_layout = Cfg_with_liveness.cfg_with_layout cfg_with_liveness in
   (* note: slots need to be updated before prologue removal *)
-  StackSlots.update_cfg_with_layout (State.stack_slots state) cfg_with_layout;
+  if Lazy.force stack_slots_optim
+  then Regalloc_stack_slots.optimize (State.stack_slots state) cfg_with_liveness;
   Regalloc_stack_slots.update_cfg_with_layout (State.stack_slots state)
     cfg_with_layout;
   if Utils.debug

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -228,7 +228,7 @@ let prelude :
   if Utils.debug
   then Utils.log ~indent:0 "#temporaries(before):%d" num_temporaries;
   if num_temporaries >= threshold_split_live_ranges
-  then cfg_infos, StackSlots.make ()
+  then cfg_infos, Regalloc_stack_slots.make ()
   else if Lazy.force Regalloc_split_utils.split_live_ranges
   then
     let stack_slots =
@@ -238,7 +238,7 @@ let prelude :
     in
     let cfg_infos = collect_cfg_infos cfg_with_layout in
     cfg_infos, stack_slots
-  else cfg_infos, StackSlots.make ()
+  else cfg_infos, Regalloc_stack_slots.make ()
 
 let postlude :
     type s.

--- a/backend/regalloc/regalloc_rewrite.mli
+++ b/backend/regalloc/regalloc_rewrite.mli
@@ -5,7 +5,7 @@ open Regalloc_utils
 module type State = sig
   type t
 
-  val stack_slots : t -> StackSlots.t
+  val stack_slots : t -> Regalloc_stack_slots.t
 
   val get_and_incr_instruction_id : t -> Instruction.id
 end
@@ -50,7 +50,7 @@ val prelude :
   (module Utils) ->
   on_fatal_callback:(unit -> unit) ->
   Cfg_with_liveness.t ->
-  cfg_infos * StackSlots.t
+  cfg_infos * Regalloc_stack_slots.t
 
 (* Runs the last steps common to register allocators, updating the CFG (stack
    slots, live fields, and prologue), running [f], and checking

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -76,9 +76,9 @@ let compute_substitutions : State.t -> Cfg_with_liveness.t -> Substitution.map =
       Reg.Set.iter
         (fun old_reg ->
           let slots = State.stack_slots state in
-          let (_ : int) = StackSlots.get_or_create slots old_reg in
+          let (_ : int) = Regalloc_stack_slots.get_or_create slots old_reg in
           let new_reg = Reg.clone old_reg in
-          StackSlots.use_same_slot_or_fatal slots new_reg ~existing:old_reg;
+          Regalloc_stack_slots.use_same_slot_or_fatal slots new_reg ~existing:old_reg;
           if split_debug
           then
             log ~indent:2 "renaming %a to %a" Printmach.reg old_reg

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -78,7 +78,8 @@ let compute_substitutions : State.t -> Cfg_with_liveness.t -> Substitution.map =
           let slots = State.stack_slots state in
           let (_ : int) = Regalloc_stack_slots.get_or_create slots old_reg in
           let new_reg = Reg.clone old_reg in
-          Regalloc_stack_slots.use_same_slot_or_fatal slots new_reg ~existing:old_reg;
+          Regalloc_stack_slots.use_same_slot_or_fatal slots new_reg
+            ~existing:old_reg;
           if split_debug
           then
             log ~indent:2 "renaming %a to %a" Printmach.reg old_reg

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -117,12 +117,13 @@ let insert_spills :
             | Some stack_reg -> stack_reg
             | None ->
               let slots = State.stack_slots state in
-              let slot : int = StackSlots.get_or_fatal slots reg in
+              let slot : int = Regalloc_stack_slots.get_or_fatal slots reg in
               let stack : Reg.t =
                 make_temporary ~same_class_and_base_name_as:reg
                   ~name_prefix:"stack"
               in
-              StackSlots.use_same_slot_or_fatal slots stack ~existing:reg;
+              Regalloc_stack_slots.use_same_slot_or_fatal slots stack
+                ~existing:reg;
               stack.Reg.loc <- Reg.(Stack (Local slot));
               Reg.Tbl.replace res reg stack;
               stack
@@ -162,13 +163,15 @@ let insert_reloads :
             | Some stack_reg -> stack_reg
             | None ->
               let slots = State.stack_slots state in
-              let slot = StackSlots.get_or_create slots old_reg in
+              let slot = Regalloc_stack_slots.get_or_create slots old_reg in
               let stack =
                 make_temporary ~same_class_and_base_name_as:old_reg
                   ~name_prefix:"stack"
               in
-              StackSlots.use_same_slot_or_fatal slots stack ~existing:old_reg;
-              StackSlots.use_same_slot_or_fatal slots stack ~existing:new_reg;
+              Regalloc_stack_slots.use_same_slot_or_fatal slots stack
+                ~existing:old_reg;
+              Regalloc_stack_slots.use_same_slot_or_fatal slots stack
+                ~existing:new_reg;
               stack.Reg.loc <- Reg.(Stack (Local slot));
               stack
           in
@@ -287,7 +290,7 @@ let insert_phi_moves :
     (State.phi_at_beginning state)
 
 let split_at_destruction_points :
-    Cfg_with_liveness.t -> cfg_infos -> StackSlots.t option =
+    Cfg_with_liveness.t -> cfg_infos -> Regalloc_stack_slots.t option =
  fun cfg_with_liveness cfg_infos ->
   if split_debug
   then (
@@ -336,7 +339,8 @@ let split_at_destruction_points :
     then Regalloc_irc_utils.log_cfg_with_liveness ~indent:1 cfg_with_liveness;
     Some (State.stack_slots state)
 
-let split_live_ranges : Cfg_with_liveness.t -> cfg_infos -> StackSlots.t =
+let split_live_ranges :
+    Cfg_with_liveness.t -> cfg_infos -> Regalloc_stack_slots.t =
  fun cfg_with_liveness cfg_infos ->
   (* CR-soon xclerc for xclerc: support closure, flambda, and
      flambda2/classic *)
@@ -351,7 +355,7 @@ let split_live_ranges : Cfg_with_liveness.t -> cfg_infos -> StackSlots.t =
     ()
   | true, true -> assert false);
   match split_at_destruction_points cfg_with_liveness cfg_infos with
-  | None -> StackSlots.make ()
+  | None -> Regalloc_stack_slots.make ()
   | Some stack_slots ->
     Cfg_with_liveness.invalidate_liveness cfg_with_liveness;
     let (_ : Cfg_with_liveness.t) =

--- a/backend/regalloc/regalloc_split.mli
+++ b/backend/regalloc/regalloc_split.mli
@@ -15,4 +15,5 @@ open Regalloc_utils
     The algorithm is an adaptation of the one rewriting a CFG to put it in
     SSA form: we simply consider that new names are introduced at destruction
     points. *)
-val split_live_ranges : Cfg_with_liveness.t -> cfg_infos -> StackSlots.t
+val split_live_ranges :
+  Cfg_with_liveness.t -> cfg_infos -> Regalloc_stack_slots.t

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -15,7 +15,7 @@ type t =
     destructions_at_end : destructions_at_end;
     definitions_at_beginning : definitions_at_beginning;
     phi_at_beginning : phi_at_beginning;
-    stack_slots : StackSlots.t;
+    stack_slots : Regalloc_stack_slots.t;
     mutable next_instruction_id : Instruction.id
   }
 
@@ -481,7 +481,7 @@ let make cfg_with_liveness ~next_instruction_id =
     RemoveDominatedSpillsForConstants.optimize cfg_with_liveness dominators
       ~destructions_at_end
   in
-  let stack_slots = StackSlots.make () in
+  let stack_slots = Regalloc_stack_slots.make () in
   { dominators;
     destructions_at_end;
     definitions_at_beginning;

--- a/backend/regalloc/regalloc_split_state.mli
+++ b/backend/regalloc/regalloc_split_state.mli
@@ -36,6 +36,6 @@ val definitions_at_beginning : t -> definitions_at_beginning
 
 val phi_at_beginning : t -> phi_at_beginning
 
-val stack_slots : t -> StackSlots.t
+val stack_slots : t -> Regalloc_stack_slots.t
 
 val get_and_incr_instruction_id : t -> Instruction.id

--- a/backend/regalloc/regalloc_stack_slots.ml
+++ b/backend/regalloc/regalloc_stack_slots.ml
@@ -1,0 +1,46 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open! Regalloc_utils
+
+type slot = int
+
+type t =
+  { stack_slots : int Reg.Tbl.t;
+    num_stack_slots : int array
+  }
+
+let[@inline] make () =
+  let stack_slots = Reg.Tbl.create 128 in
+  let num_stack_slots = Array.make Proc.num_register_classes 0 in
+  { stack_slots; num_stack_slots }
+
+let[@inline] get_and_incr t ~reg_class =
+  let res = t.num_stack_slots.(reg_class) in
+  t.num_stack_slots.(reg_class) <- succ res;
+  res
+
+let[@inline] get_or_create t reg =
+  match Reg.Tbl.find_opt t.stack_slots reg with
+  | Some slot -> slot
+  | None ->
+    let res = get_and_incr t ~reg_class:(Proc.register_class reg) in
+    Reg.Tbl.replace t.stack_slots reg res;
+    res
+
+let[@inline] get_or_fatal t reg =
+  match Reg.Tbl.find_opt t.stack_slots reg with
+  | None -> fatal "register %a has no associated slot" Printmach.reg reg
+  | Some slot -> slot
+
+let[@inline] use_same_slot_or_fatal t reg ~existing =
+  match Reg.Tbl.find_opt t.stack_slots existing with
+  | None -> fatal "register %a has no associated slot" Printmach.reg existing
+  | Some slot -> Reg.Tbl.replace t.stack_slots reg slot
+
+let[@inline] update_cfg_with_layout t cfg_with_layout =
+  let fun_num_stack_slots =
+    (Cfg_with_layout.cfg cfg_with_layout).fun_num_stack_slots
+  in
+  for reg_class = 0 to pred Proc.num_register_classes do
+    fun_num_stack_slots.(reg_class) <- t.num_stack_slots.(reg_class)
+  done

--- a/backend/regalloc/regalloc_stack_slots.ml
+++ b/backend/regalloc/regalloc_stack_slots.ml
@@ -1,6 +1,9 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 open! Regalloc_utils
+module DLL = Flambda_backend_utils.Doubly_linked_list
+
+let debug = false
 
 type slot = int
 
@@ -13,6 +16,9 @@ let[@inline] make () =
   let stack_slots = Reg.Tbl.create 128 in
   let num_stack_slots = Array.make Proc.num_register_classes 0 in
   { stack_slots; num_stack_slots }
+
+let[@inline] size_for_all_reg_classes t =
+  Array.fold_left t.num_stack_slots ~f:( + ) ~init:0
 
 let[@inline] get_and_incr t ~reg_class =
   let res = t.num_stack_slots.(reg_class) in
@@ -44,3 +50,280 @@ let[@inline] update_cfg_with_layout t cfg_with_layout =
   for reg_class = 0 to pred Proc.num_register_classes do
     fun_num_stack_slots.(reg_class) <- t.num_stack_slots.(reg_class)
   done
+
+(** The optimization below is conceptually fairly close to what linscan does:
+   - for each register class / stack slot couple, we compute the interval of
+     uses;
+   - we re-assign slots by putting in the same "bucket" slots whose
+     intervals do not overlap.
+
+   It is also considerably simpler than linscan:
+   - we do not distinguish the different kinds of uses (arg/res/live);
+   - we do not track "holes" in the intervals;
+   - we know that, by definition, we have enough slots to store
+     everything and hence have no need to "restart" the computation. *)
+
+(* CR-someday xclerc for xclerc: see whether parts could actually be shared with
+   linscan. *)
+
+let apply_reg_stack_local (reg : Reg.t) ~(f : slot -> unit) : unit =
+  match reg.loc with
+  | Unknown -> ()
+  | Reg _ -> ()
+  | Stack stack_loc -> (
+    match stack_loc with
+    | Local slot_index -> f slot_index
+    | Incoming _ -> ()
+    | Outgoing _ -> ()
+    | Domainstate _ -> ())
+
+module Point : sig
+  type t =
+    { layout_index : int;
+      instruction_index : int
+    }
+
+  val dummy : t
+
+  val compare : t -> t -> int
+
+  val print : Format.formatter -> t -> unit
+end = struct
+  type t =
+    { layout_index : int;
+      instruction_index : int
+    }
+
+  let dummy = { layout_index = -1; instruction_index = -1 }
+
+  let compare
+      { layout_index = left_layout_index;
+        instruction_index = left_instruction_index
+      }
+      { layout_index = right_layout_index;
+        instruction_index = right_instruction_index
+      } : int =
+    match Int.compare left_layout_index right_layout_index with
+    | 0 -> Int.compare left_instruction_index right_instruction_index
+    | c -> c
+
+  let print ppf t =
+    Format.fprintf ppf "%d:%d" t.layout_index t.instruction_index
+end
+
+module Interval : sig
+  type t =
+    { mutable start : Point.t; (* inclusive *)
+      mutable end_ : Point.t (* inclusive *)
+    }
+
+  val overlap : t -> t -> bool
+
+  val print : Format.formatter -> t -> unit
+end = struct
+  type t =
+    { mutable start : Point.t;
+      mutable end_ : Point.t
+    }
+
+  let overlap left right =
+    Point.compare left.start right.end_ <= 0
+    && Point.compare left.end_ right.start >= 0
+
+  let print ppf t =
+    Format.fprintf ppf "[%a..%a]" Point.print t.start Point.print t.end_
+end
+
+module Intervals : sig
+  type slots = t
+
+  type t = Interval.t array array
+  (* first index is register class, second index is slot index *)
+
+  val build_from_cfg : slots -> Cfg_with_liveness.t -> t
+
+  val print : Format.formatter -> t -> unit
+end
+with type slots := t = struct
+  type t = Interval.t array array
+
+  let make slots =
+    Array.init Proc.num_register_classes ~f:(fun reg_class ->
+        Array.init slots.num_stack_slots.(reg_class) ~f:(fun _ ->
+            { Interval.start = Point.dummy; end_ = Point.dummy }))
+
+  let visit_reg (t : t) (point : Point.t) (reg : Reg.t) : unit =
+    apply_reg_stack_local reg ~f:(fun slot_index ->
+        let reg_class = Proc.register_class reg in
+        let interval = t.(reg_class).(slot_index) in
+        if interval.start == Point.dummy then interval.start <- point;
+        interval.end_ <- point)
+
+  let visit_array (t : t) (point : Point.t) (regs : Reg.t array) : unit =
+    Array.iter regs ~f:(fun reg -> visit_reg t point reg)
+
+  let visit_set (t : t) (point : Point.t) (regs : Reg.Set.t) : unit =
+    Reg.Set.iter (fun reg -> visit_reg t point reg) regs
+
+  (* CR-someday xclerc for xclerc: since we are only interested in the very
+     first and the very last occurrences and are working on a doubly-linked
+     list, the computation could start from both ends. *)
+  let build_from_cfg slots cfg_with_liveness =
+    let intervals = make slots in
+    let live_across (id : Instruction.id) : Reg.Set.t =
+      match Cfg_with_liveness.liveness_find_opt cfg_with_liveness id with
+      | None -> fatal "missing liveness information for instruction %d" id
+      | Some { before = _; across } -> across
+    in
+    let cfg_with_layout = Cfg_with_liveness.cfg_with_layout cfg_with_liveness in
+    let cfg = Cfg_with_layout.cfg cfg_with_layout in
+    let visit_instr (type a) (point : Point.t) (instr : a Cfg.instruction) :
+        unit =
+      visit_array intervals point instr.arg;
+      visit_array intervals point instr.res;
+      visit_set intervals point (live_across instr.id)
+    in
+    DLL.iteri (Cfg_with_layout.layout cfg_with_layout)
+      ~f:(fun layout_index label ->
+        let block = Cfg.get_block_exn cfg label in
+        DLL.iteri block.body ~f:(fun instruction_index instr ->
+            visit_instr { Point.layout_index; instruction_index } instr);
+        visit_instr
+          { Point.layout_index; instruction_index = DLL.length block.body }
+          block.terminator);
+    intervals
+
+  let print ppf t =
+    Array.iteri t ~f:(fun reg_class intervals ->
+        Array.iteri intervals ~f:(fun slot_index interval ->
+            Format.fprintf ppf "reg_class=%d slot_index=%d -> %a\n" reg_class
+              slot_index Interval.print interval))
+end
+
+module Int = Numbers.Int
+
+module Buckets : sig
+  type slots = t
+
+  type t
+
+  val build_from_intervals : slots -> Intervals.t -> t
+
+  val contains_empty : t -> bool
+
+  val find_bucket : t -> reg_class:int -> slot_index:slot -> int option
+
+  val print : Format.formatter -> t -> unit
+end
+with type slots := t = struct
+  type t = Interval.t Int.Tbl.t array array
+  (* first index is register class, second index is bucket index *)
+
+  let does_not_fit (bucket : Interval.t Int.Tbl.t) (interval : Interval.t) :
+      bool =
+    try
+      Int.Tbl.iter
+        (fun _ bucket_interval ->
+          if Interval.overlap bucket_interval interval then raise Exit)
+        bucket;
+      false
+    with Exit -> true
+
+  let build_from_intervals slots intervals =
+    let buckets =
+      Array.init Proc.num_register_classes ~f:(fun reg_class ->
+          let num_slots = slots.num_stack_slots.(reg_class) in
+          Array.init num_slots ~f:(fun _ -> Int.Tbl.create num_slots))
+    in
+    Array.iteri intervals ~f:(fun reg_class intervals ->
+        Array.iteri intervals ~f:(fun slot_index interval ->
+            let buckets = buckets.(reg_class) in
+            let bucket_index = ref 0 in
+            while
+              !bucket_index < Array.length buckets
+              && does_not_fit buckets.(!bucket_index) interval
+            do
+              incr bucket_index
+            done;
+            assert (!bucket_index < Array.length buckets);
+            Int.Tbl.replace buckets.(!bucket_index) slot_index interval));
+    buckets
+
+  let contains_empty t =
+    (* Given how we add slots to buckets, empty buckets are at the end *)
+    Array.exists t ~f:(fun (buckets : Interval.t Int.Tbl.t array) ->
+        match Array.length buckets with
+        | 0 -> false
+        | len ->
+          let last_bucket = buckets.(len - 1) in
+          Int.Tbl.length last_bucket = 0)
+
+  let find_bucket t ~reg_class ~slot_index =
+    let buckets = t.(reg_class) in
+    let len = Array.length buckets in
+    let bucket_index = ref 0 in
+    while
+      !bucket_index < len
+      && not (Int.Tbl.mem buckets.(!bucket_index) slot_index)
+    do
+      incr bucket_index
+    done;
+    if !bucket_index < len then Some !bucket_index else None
+
+  let print ppf t =
+    Array.iteri t ~f:(fun reg_class buckets ->
+        Array.iteri buckets ~f:(fun bucket_index bucket ->
+            Format.fprintf ppf "reg_class=%d bucket_index=%d\n" reg_class
+              bucket_index;
+            Int.Tbl.iter
+              (fun slot_index interval ->
+                Format.fprintf ppf "  . slot_index=%d %a\n" slot_index
+                  Interval.print interval)
+              bucket))
+end
+
+let optimize (t : t) (cfg_with_liveness : Cfg_with_liveness.t) : unit =
+  if size_for_all_reg_classes t > 0
+  then (
+    (* First, compute the intervals for all stack slots *)
+    let intervals = Intervals.build_from_cfg t cfg_with_liveness in
+    if debug then Format.eprintf "intervals:\n%a%!" Intervals.print intervals;
+    (* Second, put the intervals into buckets *)
+    let buckets = Buckets.build_from_intervals t intervals in
+    if debug then Format.eprintf "buckets:\n%a%!" Buckets.print buckets;
+    (* Third, check whether we have less non-empty buckets than original
+       slots *)
+    let optimized = Buckets.contains_empty buckets in
+    if debug then Format.eprintf "optimized=%B\n%!" optimized;
+    (* Finally, if so, reassign the slot indices *)
+    if optimized
+    then (
+      let max_bucket_indices = Array.make Proc.num_register_classes (-1) in
+      List.iter (Reg.all_registers ()) ~f:(fun (reg : Reg.t) ->
+          apply_reg_stack_local reg ~f:(fun slot_index ->
+              let reg_class = Proc.register_class reg in
+              match Buckets.find_bucket buckets ~reg_class ~slot_index with
+              | None ->
+                fatal "slot %d (reg_class=%d) has in not in any of the buckets"
+                  slot_index reg_class
+              | Some bucket_index ->
+                if debug
+                then
+                  Format.eprintf
+                    "changing the slot index of %a (class %d): %d ~> %d\n%!"
+                    Printmach.reg reg reg_class slot_index bucket_index;
+                reg.loc <- Stack (Local bucket_index);
+                max_bucket_indices.(reg_class)
+                  <- Stdlib.Int.max max_bucket_indices.(reg_class) bucket_index;
+                if Reg.Tbl.mem t.stack_slots reg
+                then Reg.Tbl.replace t.stack_slots reg bucket_index));
+      for reg_class = 0 to pred Proc.num_register_classes do
+        let old_value = t.num_stack_slots.(reg_class) in
+        let new_value = succ max_bucket_indices.(reg_class) in
+        if debug
+        then
+          Format.eprintf "reg_class %d has %d fewer slots (%d ~> %d)\n%!"
+            reg_class (old_value - new_value) old_value new_value;
+        t.num_stack_slots.(reg_class) <- new_value
+      done;
+      Cfg_with_liveness.invalidate_liveness cfg_with_liveness))

--- a/backend/regalloc/regalloc_stack_slots.ml
+++ b/backend/regalloc/regalloc_stack_slots.ml
@@ -217,8 +217,8 @@ module Buckets : sig
 end
 with type slots := t = struct
   type t = Interval.t Int.Tbl.t array array
-  (* first index is register class, second index is bucket index,
-     table key is slot index *)
+  (* first index is register class, second index is bucket index, table key is
+     slot index *)
 
   let does_not_fit (bucket : Interval.t Int.Tbl.t) (interval : Interval.t) :
       bool =
@@ -321,11 +321,10 @@ let optimize (t : t) (cfg_with_liveness : Cfg_with_liveness.t) : unit =
       for reg_class = 0 to pred Proc.num_register_classes do
         let old_value = t.num_stack_slots.(reg_class) in
         let new_value = succ max_bucket_indices.(reg_class) in
-        if new_value > old_value then
+        if new_value > old_value
+        then
           fatal "more slots are now used for class %d (before: %d, after: %d)"
-            reg_class
-            old_value
-            new_value;
+            reg_class old_value new_value;
         if debug
         then
           Format.eprintf "reg_class %d has %d fewer slots (%d ~> %d)\n%!"

--- a/backend/regalloc/regalloc_stack_slots.mli
+++ b/backend/regalloc/regalloc_stack_slots.mli
@@ -6,6 +6,8 @@ type t
 
 val make : unit -> t
 
+val size_for_all_reg_classes : t -> int
+
 val get_and_incr : t -> reg_class:int -> slot
 
 val get_or_create : t -> Reg.t -> slot
@@ -15,3 +17,9 @@ val get_or_fatal : t -> Reg.t -> slot
 val use_same_slot_or_fatal : t -> Reg.t -> existing:Reg.t -> unit
 
 val update_cfg_with_layout : t -> Cfg_with_layout.t -> unit
+
+(** Reduces the number of slots, by merging slots whose use
+    intervals do not overlap. If a reduction occurs, registers
+    are modified and liveness is invalidated, but the CFG is
+    left untouched. *)
+val optimize : t -> Cfg_with_liveness.t -> unit

--- a/backend/regalloc/regalloc_stack_slots.mli
+++ b/backend/regalloc/regalloc_stack_slots.mli
@@ -1,0 +1,17 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type slot = int
+
+type t
+
+val make : unit -> t
+
+val get_and_incr : t -> reg_class:int -> slot
+
+val get_or_create : t -> Reg.t -> slot
+
+val get_or_fatal : t -> Reg.t -> slot
+
+val use_same_slot_or_fatal : t -> Reg.t -> existing:Reg.t -> unit
+
+val update_cfg_with_layout : t -> Cfg_with_layout.t -> unit

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -46,6 +46,8 @@ let bool_of_param ?guard param_name =
          then fatal "%s is set but %s is not" param_name guard_name);
      res)
 
+let stack_slots_optim = bool_of_param "STACK_SLOTS_OPTIM"
+
 let validator_debug = bool_of_param "VALIDATOR_DEBUG"
 
 type liveness = Cfg_with_liveness.liveness

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -285,51 +285,6 @@ let save_cfg : string -> Cfg_with_layout.t -> unit =
       Printf.sprintf "label:%d stack_offset:%d" label block.stack_offset)
     ~annotate_succ:(Printf.sprintf "%d->%d") str
 
-module StackSlots = struct
-  type slot = int
-
-  type t =
-    { stack_slots : int Reg.Tbl.t;
-      num_stack_slots : int array
-    }
-
-  let[@inline] make () =
-    let stack_slots = Reg.Tbl.create 128 in
-    let num_stack_slots = Array.make Proc.num_register_classes 0 in
-    { stack_slots; num_stack_slots }
-
-  let[@inline] get_and_incr t ~reg_class =
-    let res = t.num_stack_slots.(reg_class) in
-    t.num_stack_slots.(reg_class) <- succ res;
-    res
-
-  let[@inline] get_or_create t reg =
-    match Reg.Tbl.find_opt t.stack_slots reg with
-    | Some slot -> slot
-    | None ->
-      let res = get_and_incr t ~reg_class:(Proc.register_class reg) in
-      Reg.Tbl.replace t.stack_slots reg res;
-      res
-
-  let[@inline] get_or_fatal t reg =
-    match Reg.Tbl.find_opt t.stack_slots reg with
-    | None -> fatal "register %a has no associated slot" Printmach.reg reg
-    | Some slot -> slot
-
-  let[@inline] use_same_slot_or_fatal t reg ~existing =
-    match Reg.Tbl.find_opt t.stack_slots existing with
-    | None -> fatal "register %a has no associated slot" Printmach.reg existing
-    | Some slot -> Reg.Tbl.replace t.stack_slots reg slot
-
-  let[@inline] update_cfg_with_layout t cfg_with_layout =
-    let fun_num_stack_slots =
-      (Cfg_with_layout.cfg cfg_with_layout).fun_num_stack_slots
-    in
-    for reg_class = 0 to pred Proc.num_register_classes do
-      fun_num_stack_slots.(reg_class) <- t.num_stack_slots.(reg_class)
-    done
-end
-
 module Substitution = struct
   type t = Reg.t Reg.Tbl.t
 

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -99,24 +99,6 @@ val simplify_cfg : Cfg_with_layout.t -> Cfg_with_layout.t
 
 val save_cfg : string -> Cfg_with_layout.t -> unit
 
-module StackSlots : sig
-  type slot = int
-
-  type t
-
-  val make : unit -> t
-
-  val get_and_incr : t -> reg_class:int -> slot
-
-  val get_or_create : t -> Reg.t -> slot
-
-  val get_or_fatal : t -> Reg.t -> slot
-
-  val use_same_slot_or_fatal : t -> Reg.t -> existing:Reg.t -> unit
-
-  val update_cfg_with_layout : t -> Cfg_with_layout.t -> unit
-end
-
 module Substitution : sig
   type t = Reg.t Reg.Tbl.t
 

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -12,6 +12,8 @@ val find_param_value : string -> string option
 
 val bool_of_param : ?guard:bool * string -> string -> bool Lazy.t
 
+val stack_slots_optim : bool Lazy.t
+
 val validator_debug : bool Lazy.t
 
 type liveness = Cfg_with_liveness.liveness

--- a/dune
+++ b/dune
@@ -255,6 +255,7 @@
   regalloc_ls_state
   regalloc_ls_utils
   regalloc_rewrite
+  regalloc_stack_slots
   regalloc_split
   regalloc_split_state
   regalloc_split_utils
@@ -787,6 +788,7 @@
   (regalloc_ls_state.mli as compiler-libs/regalloc_ls_state.mli)
   (regalloc_ls_utils.mli as compiler-libs/regalloc_ls_utils.mli)
   (regalloc_rewrite.mli as compiler-libs/regalloc_rewrite.mli)
+  (regalloc_stack_slots.mli as compiler-libs/regalloc_stack_slots.mli)
   (regalloc_split.mli as compiler-libs/regalloc_split.mli)
   (regalloc_split_state.mli as compiler-libs/regalloc_split_state.mli)
   (regalloc_split_utils.mli as compiler-libs/regalloc_split_utils.mli)
@@ -1355,6 +1357,21 @@
   (.ocamloptcomp.objs/native/regalloc_rewrite.cmx
     as
     compiler-libs/regalloc_rewrite.cmx)
+  (.ocamloptcomp.objs/byte/regalloc_stack_slots.cmi
+    as
+    compiler-libs/regalloc_stack_slots.cmi)
+  (.ocamloptcomp.objs/byte/regalloc_stack_slots.cmo
+    as
+    compiler-libs/regalloc_stack_slots.cmo)
+  (.ocamloptcomp.objs/byte/regalloc_stack_slots.cmt
+    as
+    compiler-libs/regalloc_stack_slots.cmt)
+  (.ocamloptcomp.objs/byte/regalloc_stack_slots.cmti
+    as
+    compiler-libs/regalloc_stack_slots.cmti)
+  (.ocamloptcomp.objs/native/regalloc_stack_slots.cmx
+    as
+    compiler-libs/regalloc_stack_slots.cmx)
   (.ocamloptcomp.objs/byte/regalloc_split.cmi
     as
     compiler-libs/regalloc_split.cmi)


### PR DESCRIPTION
This pull request adds a post-processing pass to
the register allocation, whose goal is to try and
reduce the number of stack slots.

The basic idea is that, within the same register
class, it is possible to use the very same slot for
several registers if their use intervals do not
overlap.

The new pass is essentially a simplified version
of linscan; the main differences are that:
- we are interested in stack slots rather than
  registers;
- we do not distinguish the different kinds of uses
  (arg/res/live) when computing the intervals;
- we do not track potential "holes" in the intervals;
- we know that, at worst, we do not save any slots but
  there is never a reason to restart the computation.

The new pass is guarded by a new "regalloc-param",
namely `STACK_SLOTS_OPTIM`, to ease testing, but the
pass is expected to be cheap enough (in particular
because the number of slots is often fairly low) to
be always enabled once we are confident it is correct.
On that topic, the pass is technically part of the
register allocation and hence covered by the validator.

The effect of this pull request has been measured by
counting the total number of slots in all the functions
of the compiler distribution. When comparing to upstream:
- when the optimization is disabled, the IRC allocator
  uses 40% more slots;
- when the optimization is enabled, the IRC allocator
  uses 6% fewer slots.
