### PR TITLE
zero alloc: don't propagate witnesses unnecessarily

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -909,7 +909,7 @@ end = struct
     let callee_value = Value.replace_witnesses w callee_value in
     transform t ~next ~exn ~effect:callee_value desc dbg
 
-  let create_witnesses t kind dbg =
+  let[@inline always] create_witnesses t kind dbg =
     if t.keep_witnesses then Witnesses.create kind dbg else Witnesses.empty
 
   let transform_operation t (op : Mach.operation) ~next ~exn dbg =

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -610,10 +610,10 @@ end = struct
     | Some func_info -> func_info
 
   let should_keep_witnesses keep =
-    if !Flambda_backend_flags.checkmach_details_cutoff < 0 then
-      true
-    else if !Flambda_backend_flags.checkmach_details_cutoff = 0 then
-      false
+    if !Flambda_backend_flags.checkmach_details_cutoff < 0
+    then true
+    else if !Flambda_backend_flags.checkmach_details_cutoff = 0
+    then false
     else keep
 
   (* fixpoint backward propogation of function summaries along the recorded


### PR DESCRIPTION
In some pathological cases, keeping all witnesses has orders of magnitude overhead on compilation time and memory of checkmach pass, even when the witnesses are thrown away at the end of the pass. This PR partly addresses it by keeping witnesses only for function that are checked. In one degenerate example, checkmach pass goes from 8 min back down to under 1 second with this PR.

