### PR TITLE
Zero alloc bounded join of witnesses

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -469,17 +469,23 @@ end = struct
     let l =
       List.concat [f div "diverge"; f nor ""; f exn "exceptional return"]
     in
-    let cutoff = !Flambda_backend_flags.checkmach_details_cutoff in
     let len = List.length l in
-    if cutoff < 0 || len < cutoff
-    then l
-    else if cutoff = 0
-    then (* don't even print the dots *)
+    match !Flambda_backend_flags.checkmach_details_cutoff with
+    | Keep_all -> l
+    | No_details ->
+      (* don't even print the dots *)
+      assert (len = 0);
       []
-    else
-      let print_dots = Location.mknoloc (fun ppf -> Format.fprintf ppf "...") in
-      let details, _ = Misc.Stdlib.List.split_at cutoff l in
-      details @ [print_dots]
+    | At_most cutoff ->
+      let print_with_dots l =
+        let dots = Location.mknoloc (fun ppf -> Format.fprintf ppf "...") in
+        l @ [dots]
+      in
+      if len < cutoff
+      then l
+      else
+        let details, _ = Misc.Stdlib.List.split_at cutoff l in
+        print_with_dots details
 
   let report_error = function
     | Invalid { a; fun_name; fun_dbg; property; witnesses } ->
@@ -610,11 +616,10 @@ end = struct
     | Some func_info -> func_info
 
   let should_keep_witnesses keep =
-    if !Flambda_backend_flags.checkmach_details_cutoff < 0
-    then true
-    else if !Flambda_backend_flags.checkmach_details_cutoff = 0
-    then false
-    else keep
+    match !Flambda_backend_flags.checkmach_details_cutoff with
+    | Keep_all -> true
+    | No_details -> false
+    | At_most _ -> keep
 
   (* fixpoint backward propogation of function summaries along the recorded
      dependency edges. *)

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -160,7 +160,8 @@ let execute : type a. a pass -> a -> unit =
   | Inlining_tree -> execute_hooks hooks.inlining_tree arg
   | Check_allocations ->
     Misc.protect_refs
-      [ Misc.R (Flambda_backend_flags.checkmach_details_cutoff, -1) ]
+      [ Misc.R (Flambda_backend_flags.checkmach_details_cutoff,
+                Flambda_backend_flags.Keep_all) ]
       (fun () -> execute_hooks hooks.check_allocations arg)
 
 let execute_and_pipe r a = execute r a; a

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -95,7 +95,10 @@ let mk_checkmach_details_cutoff f =
   Printf.sprintf " Do not show more than this number of error locations \
                   in each function that fails the check \
                   (default %d, negative to show all)"
-  Flambda_backend_flags.default_checkmach_details_cutoff
+    (match Flambda_backend_flags.default_checkmach_details_cutoff with
+     | Keep_all -> (-1)
+     | No_details -> 0
+     | At_most n -> n)
 
 let mk_disable_poll_insertion f =
   "-disable-poll-insertion", Arg.Unit f, " Do not insert poll points"
@@ -755,7 +758,12 @@ module Flambda_backend_options_impl = struct
   let zero_alloc_check = set' Clflags.zero_alloc_check
   let dcheckmach = set' Flambda_backend_flags.dump_checkmach
   let checkmach_details_cutoff n =
-    Flambda_backend_flags.checkmach_details_cutoff := n
+    let c : Flambda_backend_flags.checkmach_details_cutoff =
+      if n < 0 then Keep_all
+      else if n = 0 then No_details
+      else At_most n
+    in
+    Flambda_backend_flags.checkmach_details_cutoff := c
 
   let disable_poll_insertion = set' Flambda_backend_flags.disable_poll_insertion
   let enable_poll_insertion = clear' Flambda_backend_flags.disable_poll_insertion
@@ -987,7 +995,12 @@ module Extra_params = struct
     | "zero-alloc-check" -> set' Clflags.zero_alloc_check
     | "dump-checkmach" -> set' Flambda_backend_flags.dump_checkmach
     | "checkmach-details-cutoff" ->
-      set_int' Flambda_backend_flags.checkmach_details_cutoff
+      begin match Compenv.check_int ppf name v with
+      | Some i ->
+        Flambda_backend_options_impl.checkmach_details_cutoff i
+      | None -> ()
+      end;
+      true
     | "poll-insertion" -> set' Flambda_backend_flags.disable_poll_insertion
     | "long-frames" -> set' Flambda_backend_flags.allow_long_frames
     | "debug-long-frames-threshold" ->

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -29,7 +29,13 @@ let dasm_comments = ref false (* -dasm-comments *)
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)
 let dump_checkmach = ref false          (* -dcheckmach *)
-let default_checkmach_details_cutoff = 20
+
+type checkmach_details_cutoff =
+  | Keep_all
+  | At_most of int
+  | No_details
+
+let default_checkmach_details_cutoff = At_most 20
 let checkmach_details_cutoff = ref default_checkmach_details_cutoff
                                        (* -checkmach-details-cutoff n *)
 

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -30,8 +30,14 @@ val dasm_comments : bool ref
 val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
 val dump_checkmach : bool ref
-val checkmach_details_cutoff : int ref
-val default_checkmach_details_cutoff : int
+
+type checkmach_details_cutoff =
+  | Keep_all
+  | At_most of int  (* n > 0 *)
+  | No_details
+
+val checkmach_details_cutoff : checkmach_details_cutoff ref
+val default_checkmach_details_cutoff : checkmach_details_cutoff
 
 val disable_poll_insertion : bool ref
 val allow_long_frames : bool ref


### PR DESCRIPTION
On top of https://github.com/ocaml-flambda/flambda-backend/pull/1471. Only last two commits are new. Best review commit by commit. 

The analysis keeps track of all witness instructions that lead to `Top` at function entry, even if the flag `-checkmach-details-cutoff n` limits the number of witnesses to be included in error message to some `n > 0`. This PR uses `n` as the apper bound on the size of the set of witnesses to be propagated. 

There are two commits. The first is a simple change to  `join` to implement the above functionality. 
The second commit is refactoring of `Witnesses.t` type to keep track of whether join was in fact bounded or not, and propagate this information to function entry. This information is then used to print "..."  at the end of error messages so the user knows when list of witnesses is partial. I am not entirely sure that the "dots" are worth the extra memory overhead of boolean field to track them. I'd be fine without it but wanted to get feedback first, or maybe there is a cheaper way to track it. I thought about tracking it per function but it breaks the abstractions.
