### PR TITLE
Flambda1: Simplify `Region (Exclave e)` to `e`

### DIFF
--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -1454,6 +1454,8 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
         in
         let branch, r = simplify env r branch in
         branch, R.map_benefit r B.remove_branch)
+  | Region (Exclave body) ->
+     simplify env r body
   | Region body ->
      let use_outer_region = R.may_use_region r in
      let r = R.set_region_use r false in

--- a/ocaml/middle_end/flambda/inline_and_simplify.ml
+++ b/ocaml/middle_end/flambda/inline_and_simplify.ml
@@ -1453,6 +1453,8 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
         in
         let branch, r = simplify env r branch in
         branch, R.map_benefit r B.remove_branch)
+  | Region (Exclave body) ->
+     simplify env r body
   | Region body ->
      let use_outer_region = R.may_use_region r in
      let r = R.set_region_use r false in


### PR DESCRIPTION
This is an easy case that does seem to come up if enough things are inlined. Notably, if we _don't_ make this change, there's currently no other way to remove this empty region until after flambda is done, since flambda doesn't remove any region with an exclave.