### PR TITLE
Check that layout variables aren't unconstrained when writing `cmi`s

### DIFF
--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -761,7 +761,7 @@ let mk_directive ~loc name arg =
 let check_layout loc id =
   begin
     match id with
-    | ("any" | "value" | "void" | "immediate64" | "immediate") -> ()
+    | ("any" | "value" | "void" | "immediate64" | "immediate" | "float64") -> ()
     | _ -> expecting loc "layout"
   end;
   let loc = make_loc loc in

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -761,7 +761,7 @@ let mk_directive ~loc name arg =
 let check_layout loc id =
   begin
     match id with
-    | ("any" | "value" | "void" | "immediate64" | "immediate" | "float64") -> ()
+    | ("any" | "value" | "void" | "immediate64" | "immediate") -> ()
     | _ -> expecting loc "layout"
   end;
   let loc = make_loc loc in

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/extract_extensible.ml
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/extract_extensible.ml
@@ -1,0 +1,6 @@
+(* Disable warning 8 as it's unrelated to this test: It's the inexhaustive
+   match warning when you don't have a wildcard case for extensible variants.
+*)
+let[@ocaml.warning "-8"] f (Gadt_extensible.Mk (produce, consume)) =
+  let (surely_is_a_value, _) = (produce (), 5) in
+  consume surely_is_a_value

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/gadt_extensible.ml
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/gadt_extensible.ml
@@ -1,0 +1,4 @@
+type t_ext = ..
+
+type t_ext +=
+| Mk : (unit -> 'a) * ('a -> unit) -> t_ext

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/insert_extensible.ml
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/insert_extensible.ml
@@ -1,0 +1,5 @@
+type t_void [@@void]
+
+let rec g (_ : t_void) = ()
+
+and packed = Gadt_extensible.Mk ((fun _ -> assert false), g)

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -1,0 +1,6 @@
+File "insert_extensible.ml", line 5, characters 58-59:
+5 | and packed = Gadt_extensible.Mk ((fun _ -> assert false), g)
+                                                              ^
+Error: This expression has type t_void -> unit
+       but an expression was expected of type 'a -> unit
+       t_void has layout void, which is not a sublayout of value.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.ml
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.ml
@@ -1,0 +1,14 @@
+(* TEST
+
+   readonly_files = "gadt_extensible.ml insert_extensible.ml extract_extensible.ml"
+   flags = "-extension layouts_alpha"
+   * setup-ocamlc.byte-build-env
+   ** ocamlc.byte
+   module = "gadt_extensible.ml"
+   *** ocamlc.byte
+   module = "extract_extensible.ml"
+   **** ocamlc.byte
+   module = "insert_extensible.ml"
+   ocamlc_byte_exit_status = "2"
+   ***** check-ocamlc.byte-output
+*)

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -655,8 +655,14 @@ let closed_extension_constructor ext =
   try
     List.iter mark_type ext.ext_type_params;
     begin match ext.ext_ret_type with
-    | Some _ -> ()
-    | None -> iter_type_expr_cstr_args closed_type ext.ext_args
+    | Some res_ty ->
+        (* gadts cannot have free type variables, but they might
+           have undefaulted layout variables; these lines default
+           them. Test case: typing-layouts-gadt-sort-var/test_extensible.ml *)
+        iter_type_expr_cstr_args remove_mode_and_layout_variables ext.ext_args;
+        remove_mode_and_layout_variables res_ty
+    | None ->
+        iter_type_expr_cstr_args closed_type ext.ext_args
     end;
     unmark_extension_constructor ext;
     None

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -2654,9 +2654,10 @@ let persistent_structures_of_dir dir =
 (* Save a signature to a file *)
 let save_signature_with_transform cmi_transform ~alerts sg modname filename =
   Btype.cleanup_abbrev ();
-  Subst.reset_for_saving ();
+  Subst.reset_additional_action_type_id ();
   let sg = Subst.Lazy.of_signature sg
-    |> Subst.Lazy.signature Make_local (Subst.for_saving Subst.identity)
+    |> Subst.Lazy.signature Make_local
+        (Subst.with_additional_action Prepare_for_saving Subst.identity)
   in
   let cmi =
     Persistent_env.make_cmi !persistent_env modname sg alerts

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -167,7 +167,7 @@ module Sort = struct
     | Void -> "void"
 
   let to_string s = match get s with
-    | Var v -> var_name (v :> var)
+    | Var v -> var_name v
     | Const c -> string_of_const c
 
   let format ppf t = Format.fprintf ppf "%s" (to_string t)

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -64,7 +64,21 @@ module Sort = struct
           if result != s then r := Some result; (* path compression *)
           result
         end
-    end
+      end
+
+  (* This is constant-time if [var] was just returned from a previous call to
+     [get]. That's because [var] will always be [None] in that case.
+  *)
+  let var_constraint : var -> const option = fun r ->
+    match !r with
+    | None -> None
+    | Some t -> begin
+        match get t with
+        | Const const -> Some const
+        | Var { contents = None } -> None
+        | Var _ ->
+            Misc.fatal_error "[get] should return [Const _] or [Var None]"
+      end
 
   let default_value : t option = Some (Const Value)
   let default_void : t option = Some (Const Void)
@@ -153,7 +167,7 @@ module Sort = struct
     | Void -> "void"
 
   let to_string s = match get s with
-    | Var v -> var_name v
+    | Var v -> var_name (v :> var)
     | Const c -> string_of_const c
 
   let format ppf t = Format.fprintf ppf "%s" (to_string t)

--- a/ocaml/typing/layouts.mli
+++ b/ocaml/typing/layouts.mli
@@ -297,9 +297,6 @@ module Layout : sig
   type desc =
     | Const of const
     | Var of Sort.var
-      (** The [var] of [Var var] enjoys a constant-time
-          [Sort.var_is_unconstrained]
-      *)
 
   (** Extract the [desc] from a [Layout.t], looking through unified
       sort variables. Returns [Var] if the final, non-variable layout has not

--- a/ocaml/typing/layouts.mli
+++ b/ocaml/typing/layouts.mli
@@ -28,6 +28,11 @@ module Sort : sig
   (** A sort variable that can be unified during type-checking. *)
   type var
 
+  (** Return the concrete constraint placed on the variable. This check is
+      constant-time if [var] was just returned from [Layout.get].
+  *)
+  val var_constraint : var -> const option
+
   (** Create a new sort variable that can be unified. *)
   val new_var : unit -> t
 
@@ -292,6 +297,9 @@ module Layout : sig
   type desc =
     | Const of const
     | Var of Sort.var
+      (** The [var] of [Var var] enjoys a constant-time
+          [Sort.var_is_unconstrained]
+      *)
 
   (** Extract the [desc] from a [Layout.t], looking through unified
       sort variables. Returns [Var] if the final, non-variable layout has not

--- a/ocaml/typing/subst.mli
+++ b/ocaml/typing/subst.mli
@@ -42,8 +42,14 @@ val add_module_path: Path.t -> Path.t -> t -> t
 val add_modtype: Ident.t -> module_type -> t -> t
 val add_modtype_path: Path.t -> module_type -> t -> t
 
-val for_saving: t -> t
-val reset_for_saving: unit -> unit
+type additional_action_config =
+   | Prepare_for_saving
+   | Copy_type_variables
+
+(* CR nroberts: comment *)
+val with_additional_action: additional_action_config -> t -> t
+val reset_additional_action_type_id: unit -> unit
+
 val change_locs: t -> Location.t -> t
 
 val module_path: t -> Path.t -> Path.t

--- a/ocaml/typing/subst.mli
+++ b/ocaml/typing/subst.mli
@@ -43,13 +43,14 @@ val add_modtype: Ident.t -> module_type -> t -> t
 val add_modtype_path: Path.t -> module_type -> t -> t
 
 type additional_action_config =
-   | Copy_types
-   (* CR nroberts: I have low confidence in this comment. *)
-   (* [Copy_types] makes it so any substitution will replace all types
-      with copies unrelated to the original type. *)
+   | Duplicate_variables
+   (* [Duplicate_variables] makes it so that any substitution will duplicate
+      variable nodes. Substitution already duplicates non-variable nodes;
+      refer to the comment at the top of [subst.mli].
+   *)
    | Prepare_for_saving
    (* [Prepare_for_saving] performs all actions associated with
-      [Copy_types] and additionally prepares layouts for saving by
+      [Duplicate_variables] and additionally prepares layouts for saving by
       commoning them up, truncating their histories, and performing
       a check that all unconstrained layouts have been defaulted to value.
    *)

--- a/ocaml/typing/subst.mli
+++ b/ocaml/typing/subst.mli
@@ -43,11 +43,26 @@ val add_modtype: Ident.t -> module_type -> t -> t
 val add_modtype_path: Path.t -> module_type -> t -> t
 
 type additional_action_config =
+   | Copy_types
+   (* CR nroberts: I have low confidence in this comment. *)
+   (* [Copy_types] makes it so any substitution will replace all types
+      with copies unrelated to the original type. *)
    | Prepare_for_saving
-   | Copy_type_variables
+   (* [Prepare_for_saving] performs all actions associated with
+      [Copy_types] and additionally prepares layouts for saving by
+      commoning them up, truncating their histories, and performing
+      a check that all unconstrained layouts have been defaulted to value.
+   *)
 
-(* CR nroberts: comment *)
+(* Sets the additional action that runs along with any substitution.
+   See the documentation on [additional_action_config].
+*)
 val with_additional_action: additional_action_config -> t -> t
+
+(* Any of the additional actions involve copying type variables. Calling
+   [reset_additional_action_type_id] resets the id counter used when the copying
+   of type variables needs to mint new type variable ids.
+*)
 val reset_additional_action_type_id: unit -> unit
 
 val change_locs: t -> Location.t -> t

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -6849,12 +6849,12 @@ and type_cases
       (* Hack: use the [Subst] machinery to copy types, even though
          we don't intend on persisting the type to disk.
 
-         We added a new [Copy_types] variant specifically for this
-         callsite, but it's still a bit of a hack (e.g. the type
-         IDs are all negative, like they are in cmi files).
+         We added a new [Duplicate_variables] variant specifically for this
+         callsite, but it's still a bit of a hack (e.g. the type IDs produced
+         for duplicated nodes are all negative, like they are in cmi files).
       *)
       Subst.type_expr
-        (Subst.with_additional_action Copy_types Subst.identity)
+        (Subst.with_additional_action Duplicate_variables Subst.identity)
         ty_arg'
     else ty_arg'
   in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -6846,8 +6846,15 @@ and type_cases
   let do_init = may_contain_gadts || needs_exhaust_check in
   let ty_arg_check =
     if do_init then
+      (* Hack: use the [Subst] machinery to copy types, even though
+         we don't intend on persisting the type to disk.
+
+         We added a new [Copy_types] variant specifically for this
+         callsite, but it's still a bit of a hack (e.g. the type
+         IDs are all negative, like they are in cmi files).
+      *)
       Subst.type_expr
-        (Subst.with_additional_action Copy_type_variables Subst.identity)
+        (Subst.with_additional_action Copy_types Subst.identity)
         ty_arg'
     else ty_arg'
   in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -6846,8 +6846,9 @@ and type_cases
   let do_init = may_contain_gadts || needs_exhaust_check in
   let ty_arg_check =
     if do_init then
-      (* Hack: use for_saving to copy variables too *)
-      Subst.type_expr (Subst.for_saving Subst.identity) ty_arg'
+      Subst.type_expr
+        (Subst.with_additional_action Copy_type_variables Subst.identity)
+        ty_arg'
     else ty_arg'
   in
   let val_cases, exn_cases =


### PR DESCRIPTION
**Reviewer: @ccasin**

Raise an error if the compiler tries to write out a cmi that mentions an unconstrained layout variable.

The error looks like this:

```
File "external/owee/owee_marker.mli", line 36, characters 3-65:
36 |    | Traverse : ((Obj.t -> 'acc -> 'acc) -> 'acc -> 'acc) service
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unconstrained layout variable detected when saving artifacts of compilation to disk.
       Please report this error to the Jane Street compilers team. 
```

This immediately found one bug where layout variables of some existential type variables in GADT constructors of extensible type declarations weren't being defaulted. I fix that bug in this PR and add a regression test.

### Implementation

I check whether the layout variable is `None` or not. For the existing callsite, this is a constant-time check because the sort was just returned from `get`, which can only return `Const _` or `Var None`.

Other things to note:
  * There are two callsites to `for_saving`. I distinguish them with a two-value variant. One of them does the layout variable check, the other doesn't.
  * In order to show a location with the error, I plumb a location through `Subst.typexp`. This ends up being rather noisy in the diff. I could just set global mutable state instead if the reviewer thinks we should be worried about rebase conflicts (but I also don't like global mutable state).
  
### Doubts

I stopped commoning-up layout values and truncating histories at the call to `Subst.with_additional_action` that *isn't* just before saving the cmi file. My guess is that this is ok, but it's possible to keep doing the commoning-up and truncation without also doing the layout check, if the reviewer thinks this is a good idea.