### PR TITLE
Remove the `type float# = float` hack

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/unboxed_floats.ml
+++ b/ocaml/testsuite/tests/typing-layouts/unboxed_floats.ml
@@ -3,10 +3,11 @@
    * expect
 *)
 
-(* CR layouts: These tests will change when we remove the obvious inaccuracy
-   where float# is aliased to float.
+(* CR layouts: We should start running these tests soon when
+   we have proper typechecking for unboxed float literals.
 *)
 
+(*
 let id : float# -> float# = fun x -> x;;
 
 id #4.0;;
@@ -32,3 +33,4 @@ val apply : (float# -> float# -> float#) -> float# -> float# -> float# =
   <fun>
 - : float# = 9.
 |}];;
+*)

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -227,15 +227,7 @@ let common_initial_env add_type add_extension empty_env =
        ~layout:(Layout.value ~why:Extensible_variant)
   |> add_type ident_extension_constructor
   |> add_type ident_float
-  (* CR layouts: Adding the alias float#=float is a convenient hack so
-     we can write tests for float#, but this is obviously something we'll
-     want to change.
-  *)
   |> add_type ident_float_unboxed
-       ?manifest:
-         (if Language_extension.is_at_least Layouts Language_extension.Alpha
-          then Some type_float
-          else None)
   |> add_type ident_floatarray
   |> add_type ident_int ~layout:(Layout.immediate ~why:(Primitive ident_int))
   |> add_type ident_int32

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -231,7 +231,11 @@ let common_initial_env add_type add_extension empty_env =
      we can write tests for float#, but this is obviously something we'll
      want to change.
   *)
-  |> add_type ident_float_unboxed ~manifest:type_float
+  |> add_type ident_float_unboxed
+       ?manifest:
+         (if Language_extension.is_at_least Layouts Language_extension.Alpha
+          then Some type_float
+          else None)
   |> add_type ident_floatarray
   |> add_type ident_int ~layout:(Layout.immediate ~why:(Primitive ident_int))
   |> add_type ident_int32


### PR DESCRIPTION
@ccasin: could you review?

It was convenient to alias `float# = float`, as it allowed us to write some tests in the compiler.

This PR removes that alias.

That's because, if this alias is available, it's possible that the type printer will choose to print `float#` for the type of a float even if the code makes no reference to unboxed anything.

It would have been nice to instead only add this alias if we were in layouts alpha, but this would require making the environment dynamic (in particular, consulting command line flags for layout extensions, which hasn't yet been done when constructing a top-level value). Instead, I just disable the test that relied on this behavior &mdash; we'll add it back soon anyway.

### Testing

The place that was printing `float#` before now prints `float`.