### PR TITLE
Jane-syntax support for extension constructors

### DIFF
--- a/ocaml/parsing/ast_iterator.ml
+++ b/ocaml/parsing/ast_iterator.ml
@@ -204,14 +204,23 @@ module T = struct
     | Pext_rebind li ->
         iter_loc sub li
 
+  let iter_extension_constructor_jst _sub :
+    Jane_syntax.Extension_constructor.t -> _ = function
+    | _ -> .
+
   let iter_extension_constructor sub
-      {pext_name;
+     ({pext_name;
        pext_kind;
        pext_loc;
-       pext_attributes} =
+       pext_attributes} as ext) =
     iter_loc sub pext_name;
-    iter_extension_constructor_kind sub pext_kind;
     sub.location sub pext_loc;
+    match Jane_syntax.Extension_constructor.of_ast ext with
+    | Some (jext, attrs) ->
+      sub.attributes sub attrs;
+      iter_extension_constructor_jst sub jext
+    | None ->
+    iter_extension_constructor_kind sub pext_kind;
     sub.attributes sub pext_attributes
 
 end

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -149,7 +149,7 @@ module T = struct
     match Jane_syntax.Core_type.of_ast typ with
     | Some (jtyp, attrs) -> begin
         let attrs = sub.attributes sub attrs in
-        Jane_syntax_parsing.Core_type.wrap_desc ~loc ~attrs @@
+        Jane_syntax_parsing.Core_type.wrap_desc ~loc ~info:attrs @@
         match sub.typ_jane_syntax sub jtyp with
         | _ -> .
     end
@@ -302,7 +302,7 @@ module MT = struct
     match Jane_syntax.Module_type.of_ast mty with
     | Some (jmty, attrs) -> begin
         let attrs = sub.attributes sub attrs in
-        Jane_syntax_parsing.Module_type.wrap_desc ~loc ~attrs @@
+        Jane_syntax_parsing.Module_type.wrap_desc ~loc ~info:attrs @@
         match sub.module_type_jane_syntax sub jmty with
         | Jmty_strengthen smty -> Jane_syntax.Strengthen.mty_of ~loc smty
       end
@@ -354,7 +354,7 @@ module MT = struct
     let loc = sub.location sub loc in
     match Jane_syntax.Signature_item.of_ast sigi with
     | Some jsigi -> begin
-        Jane_syntax_parsing.Signature_item.wrap_desc ~loc ~attrs:[] @@
+        Jane_syntax_parsing.Signature_item.wrap_desc ~loc ~info:() @@
         match sub.signature_item_jane_syntax sub jsigi with
         | Jsig_include_functor incl ->
             Jane_syntax.Include_functor.sig_item_of ~loc incl
@@ -434,7 +434,7 @@ module M = struct
     let loc = sub.location sub loc in
     match Jane_syntax.Structure_item.of_ast stri with
     | Some jstri -> begin
-        Jane_syntax_parsing.Structure_item.wrap_desc ~loc ~attrs:[] @@
+        Jane_syntax_parsing.Structure_item.wrap_desc ~loc ~info:() @@
         match sub.structure_item_jane_syntax sub jstri with
         | Jstr_include_functor incl ->
             Jane_syntax.Include_functor.str_item_of ~loc incl
@@ -512,7 +512,7 @@ module E = struct
     match Jane_syntax.Expression.of_ast exp with
     | Some (jexp, attrs) -> begin
         let attrs = sub.attributes sub attrs in
-        Jane_syntax_parsing.Expression.wrap_desc ~loc ~attrs @@
+        Jane_syntax_parsing.Expression.wrap_desc ~loc ~info:attrs @@
         match sub.expr_jane_syntax sub jexp with
         | Jexp_comprehension   c -> Jane_syntax.Comprehensions.expr_of   ~loc c
         | Jexp_immutable_array i -> Jane_syntax.Immutable_arrays.expr_of ~loc i
@@ -623,7 +623,7 @@ module P = struct
     match Jane_syntax.Pattern.of_ast pat with
     | Some (jpat, attrs) -> begin
         let attrs = sub.attributes sub attrs in
-        Jane_syntax_parsing.Pattern.wrap_desc ~loc ~attrs @@
+        Jane_syntax_parsing.Pattern.wrap_desc ~loc ~info:attrs @@
         match sub.pat_jane_syntax sub jpat with
         | Jpat_immutable_array i -> Jane_syntax.Immutable_arrays.pat_of ~loc i
     end

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -46,8 +46,6 @@ type mapper = {
   constructor_declaration: mapper -> constructor_declaration
                            -> constructor_declaration;
   expr: mapper -> expression -> expression;
-  expr_jane_syntax:
-    mapper -> Jane_syntax.Expression.t -> Jane_syntax.Expression.t;
   extension: mapper -> extension -> extension;
   extension_constructor: mapper -> extension_constructor
                          -> extension_constructor;
@@ -62,23 +60,15 @@ type mapper = {
   module_type: mapper -> module_type -> module_type;
   module_type_declaration: mapper -> module_type_declaration
                            -> module_type_declaration;
-  module_type_jane_syntax: mapper
-    -> Jane_syntax.Module_type.t -> Jane_syntax.Module_type.t;
   open_declaration: mapper -> open_declaration -> open_declaration;
   open_description: mapper -> open_description -> open_description;
   pat: mapper -> pattern -> pattern;
-  pat_jane_syntax: mapper -> Jane_syntax.Pattern.t -> Jane_syntax.Pattern.t;
   payload: mapper -> payload -> payload;
   signature: mapper -> signature -> signature;
   signature_item: mapper -> signature_item -> signature_item;
-  signature_item_jane_syntax: mapper ->
-    Jane_syntax.Signature_item.t -> Jane_syntax.Signature_item.t;
   structure: mapper -> structure -> structure;
   structure_item: mapper -> structure_item -> structure_item;
-  structure_item_jane_syntax: mapper ->
-    Jane_syntax.Structure_item.t -> Jane_syntax.Structure_item.t;
   typ: mapper -> core_type -> core_type;
-  typ_jane_syntax: mapper -> Jane_syntax.Core_type.t -> Jane_syntax.Core_type.t;
   type_declaration: mapper -> type_declaration -> type_declaration;
   type_extension: mapper -> type_extension -> type_extension;
   type_exception: mapper -> type_exception -> type_exception;
@@ -86,6 +76,21 @@ type mapper = {
   value_binding: mapper -> value_binding -> value_binding;
   value_description: mapper -> value_description -> value_description;
   with_constraint: mapper -> with_constraint -> with_constraint;
+
+  expr_jane_syntax:
+    mapper -> Jane_syntax.Expression.t -> Jane_syntax.Expression.t;
+  extension_constructor_jane_syntax:
+    mapper ->
+    Jane_syntax.Extension_constructor.t -> Jane_syntax.Extension_constructor.t;
+  module_type_jane_syntax: mapper
+    -> Jane_syntax.Module_type.t -> Jane_syntax.Module_type.t;
+  pat_jane_syntax: mapper -> Jane_syntax.Pattern.t -> Jane_syntax.Pattern.t;
+  signature_item_jane_syntax: mapper ->
+    Jane_syntax.Signature_item.t -> Jane_syntax.Signature_item.t;
+  structure_item_jane_syntax: mapper ->
+    Jane_syntax.Structure_item.t -> Jane_syntax.Structure_item.t;
+  typ_jane_syntax: mapper -> Jane_syntax.Core_type.t -> Jane_syntax.Core_type.t;
+
 }
 
 let map_fst f (x, y) = (f x, y)
@@ -228,6 +233,10 @@ module T = struct
     Te.mk_exception ~loc ~attrs
       (sub.extension_constructor sub ptyexn_constructor)
 
+  let map_extension_constructor_jst _sub :
+    Jane_syntax.Extension_constructor.t -> _ = function
+    | _ -> .
+
   let map_extension_constructor_kind sub = function
       Pext_decl(vars, ctl, cto) ->
         Pext_decl(List.map (map_loc sub) vars,
@@ -237,11 +246,21 @@ module T = struct
         Pext_rebind (map_loc sub li)
 
   let map_extension_constructor sub
-      {pext_name;
+     ({pext_name;
        pext_kind;
        pext_loc;
-       pext_attributes} =
+       pext_attributes} as ext) =
     let loc = sub.location sub pext_loc in
+    let name = map_loc sub pext_name in
+    match Jane_syntax.Extension_constructor.of_ast ext with
+    | Some (jext, attrs) -> begin
+      let attrs = sub.attributes sub attrs in
+      Jane_syntax_parsing.Extension_constructor.wrap_desc
+        ~loc ~info:(attrs, name) @@
+      match sub.extension_constructor_jane_syntax sub jext with
+      | _ -> .
+    end
+    | None ->
     let attrs = sub.attributes sub pext_attributes in
     Te.constructor ~loc ~attrs
       (map_loc sub pext_name)
@@ -734,13 +753,10 @@ let default_mapper =
     constant = C.map;
     structure = (fun this l -> List.map (this.structure_item this) l);
     structure_item = M.map_structure_item;
-    structure_item_jane_syntax = M.map_structure_item_jst;
     module_expr = M.map;
     signature = (fun this l -> List.map (this.signature_item this) l);
     signature_item = MT.map_signature_item;
-    signature_item_jane_syntax = MT.map_signature_item_jst;
     module_type = MT.map;
-    module_type_jane_syntax = MT.map_jane_syntax;
     with_constraint = MT.map_with_constraint;
     class_declaration =
       (fun this -> CE.class_infos this (this.class_expr this));
@@ -757,7 +773,6 @@ let default_mapper =
     type_declaration = T.map_type_declaration;
     type_kind = T.map_type_kind;
     typ = T.map;
-    typ_jane_syntax = T.map_jst;
     type_extension = T.map_type_extension;
     type_exception = T.map_type_exception;
     extension_constructor = T.map_extension_constructor;
@@ -773,9 +788,7 @@ let default_mapper =
       );
 
     pat = P.map;
-    pat_jane_syntax = P.map_jst;
     expr = E.map;
-    expr_jane_syntax = E.map_jst;
     binding_op = E.map_binding_op;
 
     module_declaration =
@@ -906,6 +919,15 @@ let default_mapper =
          | PTyp x -> PTyp (this.typ this x)
          | PPat (x, g) -> PPat (this.pat this x, map_opt (this.expr this) g)
       );
+
+    expr_jane_syntax = E.map_jst;
+    extension_constructor_jane_syntax = T.map_extension_constructor_jst;
+    module_type_jane_syntax = MT.map_jane_syntax;
+    pat_jane_syntax = P.map_jst;
+    signature_item_jane_syntax = MT.map_signature_item_jst;
+    structure_item_jane_syntax = M.map_structure_item_jst;
+    typ_jane_syntax = T.map_jst;
+
   }
 
 let extension_of_error {kind; main; sub} =

--- a/ocaml/parsing/ast_mapper.mli
+++ b/ocaml/parsing/ast_mapper.mli
@@ -75,8 +75,6 @@ type mapper = {
   constructor_declaration: mapper -> constructor_declaration
                            -> constructor_declaration;
   expr: mapper -> expression -> expression;
-  expr_jane_syntax:
-    mapper -> Jane_syntax.Expression.t -> Jane_syntax.Expression.t;
   extension: mapper -> extension -> extension;
   extension_constructor: mapper -> extension_constructor
                          -> extension_constructor;
@@ -100,23 +98,15 @@ type mapper = {
   module_type: mapper -> module_type -> module_type;
   module_type_declaration: mapper -> module_type_declaration
                            -> module_type_declaration;
-  module_type_jane_syntax: mapper ->
-    Jane_syntax.Module_type.t -> Jane_syntax.Module_type.t;
   open_declaration: mapper -> open_declaration -> open_declaration;
   open_description: mapper -> open_description -> open_description;
   pat: mapper -> pattern -> pattern;
-  pat_jane_syntax: mapper -> Jane_syntax.Pattern.t -> Jane_syntax.Pattern.t;
   payload: mapper -> payload -> payload;
   signature: mapper -> signature -> signature;
   signature_item: mapper -> signature_item -> signature_item;
-  signature_item_jane_syntax: mapper ->
-    Jane_syntax.Signature_item.t -> Jane_syntax.Signature_item.t;
   structure: mapper -> structure -> structure;
   structure_item: mapper -> structure_item -> structure_item;
-  structure_item_jane_syntax: mapper ->
-    Jane_syntax.Structure_item.t -> Jane_syntax.Structure_item.t;
   typ: mapper -> core_type -> core_type;
-  typ_jane_syntax: mapper -> Jane_syntax.Core_type.t -> Jane_syntax.Core_type.t;
   type_declaration: mapper -> type_declaration -> type_declaration;
   type_extension: mapper -> type_extension -> type_extension;
   type_exception: mapper -> type_exception -> type_exception;
@@ -124,6 +114,21 @@ type mapper = {
   value_binding: mapper -> value_binding -> value_binding;
   value_description: mapper -> value_description -> value_description;
   with_constraint: mapper -> with_constraint -> with_constraint;
+
+  expr_jane_syntax:
+    mapper -> Jane_syntax.Expression.t -> Jane_syntax.Expression.t;
+  extension_constructor_jane_syntax:
+    mapper ->
+    Jane_syntax.Extension_constructor.t -> Jane_syntax.Extension_constructor.t;
+  module_type_jane_syntax: mapper ->
+    Jane_syntax.Module_type.t -> Jane_syntax.Module_type.t;
+  pat_jane_syntax: mapper -> Jane_syntax.Pattern.t -> Jane_syntax.Pattern.t;
+  signature_item_jane_syntax: mapper ->
+    Jane_syntax.Signature_item.t -> Jane_syntax.Signature_item.t;
+  structure_item_jane_syntax: mapper ->
+    Jane_syntax.Structure_item.t -> Jane_syntax.Structure_item.t;
+  typ_jane_syntax: mapper -> Jane_syntax.Core_type.t -> Jane_syntax.Core_type.t;
+
 }
 (** A mapper record implements one "method" per syntactic category,
     using an open recursion style: each method takes as its first

--- a/ocaml/parsing/depend.ml
+++ b/ocaml/parsing/depend.ml
@@ -155,7 +155,14 @@ let add_type_declaration bv td =
   | Ptype_open -> () in
   add_tkind td.ptype_kind
 
+let add_extension_constructor_jst _bv _attrs :
+  Jane_syntax.Extension_constructor.t -> _ = function
+  | _ -> .
+
 let add_extension_constructor bv ext =
+  match Jane_syntax.Extension_constructor.of_ast ext with
+  | Some (jext, attrs) -> add_extension_constructor_jst bv attrs jext
+  | None ->
   match ext.pext_kind with
     Pext_decl(_, args, rty) ->
       add_constructor_arguments bv args;

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -95,7 +95,7 @@ module Comprehensions = struct
   *)
 
   let comprehension_expr names x =
-    Expression.wrap_desc ~attrs:[] ~loc:x.pexp_loc @@
+    Expression.wrap_desc ~info:[] ~loc:x.pexp_loc @@
     Expression.make_jane_syntax feature names x
 
   (** First, we define how to go from the nice AST to the OCaml AST; this is

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -460,3 +460,12 @@ module Structure_item = struct
 
   let of_ast = Structure_item.make_of_ast ~of_ast_internal
 end
+
+module Extension_constructor = struct
+  type t = |
+
+  let of_ast_internal (feat : Feature.t) _ext = match feat with
+    | _ -> None
+
+  let of_ast = Extension_constructor.make_of_ast ~of_ast_internal
+end

--- a/ocaml/parsing/jane_syntax.mli
+++ b/ocaml/parsing/jane_syntax.mli
@@ -262,3 +262,10 @@ module Structure_item : sig
 
   include AST with type t := t and type ast := Parsetree.structure_item
 end
+
+module Extension_constructor : sig
+  type t = |
+
+  include AST with type t := t * Parsetree.attributes
+               and type ast := Parsetree.extension_constructor
+end

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -448,6 +448,10 @@ module type AST_syntactic_category = sig
       [Parsetree.expression_desc]) *)
   type ast_desc
 
+  (** The bits stored in an [ast] but missing from an [ast_desc], other than
+      location *)
+  type ast_info
+
   (** The name for this syntactic category in the plural form; used for error
       messages (e.g., "expressions") *)
   val plural : string
@@ -461,7 +465,7 @@ module type AST_syntactic_category = sig
       be omitted; in this case, it will default to [!Ast_helper.default_loc],
       which should be [ghost]. *)
   val wrap_desc :
-    ?loc:Location.t -> attrs:attributes -> ast_desc -> ast
+    ?loc:Location.t -> info:ast_info -> ast_desc -> ast
 end
 
 module type AST_internal = sig
@@ -539,6 +543,7 @@ module Make_with_attribute
     (AST_syntactic_category : sig
        include AST_syntactic_category
 
+       val prepend_attributes : attributes -> ast_info -> ast_info
        val desc : ast -> ast_desc
        val attributes : ast -> attributes
        val with_attributes : ast -> attributes -> ast
@@ -546,6 +551,7 @@ module Make_with_attribute
     AST_internal with type ast      = AST_syntactic_category.ast
                   and type ast_desc =
                         AST_syntactic_category.ast_desc With_attributes.t
+                  and type ast_info = AST_syntactic_category.ast_info
 = struct
     include AST_syntactic_category
 
@@ -553,11 +559,12 @@ module Make_with_attribute
 
     type nonrec ast_desc = ast_desc With_attributes.t
 
-    let wrap_desc ?loc ~attrs:extra_attrs with_attributes =
+    let wrap_desc ?loc ~info with_attributes =
       let { desc; jane_syntax_attributes } : _ With_attributes.t =
         with_attributes
       in
-      wrap_desc ?loc ~attrs:(jane_syntax_attributes @ extra_attrs) desc
+      let info = prepend_attributes jane_syntax_attributes info in
+      wrap_desc ?loc ~info desc
 
     let make_jane_syntax name ast : _ With_attributes.t =
       let original_attributes = attributes ast in
@@ -578,12 +585,17 @@ module Make_with_attribute
       | Some (name, attrs) -> Some (name, with_attributes ast attrs)
 end
 
+(* common case for [Make_with_attribute], when [ast_info] = [attributes] *)
+let prepend_attributes_info attrs1 attrs2 = attrs1 @ attrs2
+
 (** For a syntactic category, produce translations into and out of
     our novel syntax, using extension nodes as the encoding.
 *)
 module Make_with_extension_node
     (AST_syntactic_category : sig
        include AST_syntactic_category
+         with type ast_info = unit (* [Make_with_extension_node] is for
+                                      categories without attributes. *)
 
       (** How to construct an extension node for this AST (something of the
           shape [[%name]]). Should just be [Ast_helper.CAT.extension] for the
@@ -607,7 +619,8 @@ module Make_with_extension_node
       val match_extension_use : ast -> (extension * ast) option
      end) :
     AST_internal with type ast      = AST_syntactic_category.ast
-                  and type ast_desc = AST_syntactic_category.ast_desc =
+                  and type ast_desc = AST_syntactic_category.ast_desc
+                  and type ast_info = unit =
   struct
     include AST_syntactic_category
 
@@ -642,12 +655,15 @@ end
 module Type_AST_syntactic_category = struct
   type ast = core_type
   type ast_desc = core_type_desc
+  type ast_info = attributes
 
   (* Missing [plural] *)
 
+  let prepend_attributes = prepend_attributes_info
+
   let location typ = typ.ptyp_loc
 
-  let wrap_desc ?loc ~attrs = Ast_helper.Typ.mk ?loc ~attrs
+  let wrap_desc ?loc ~info:attrs = Ast_helper.Typ.mk ?loc ~attrs
 
   let attributes typ = typ.ptyp_attributes
   let with_attributes typ ptyp_attributes = { typ with ptyp_attributes }
@@ -672,12 +688,13 @@ end)
 module Expression0 = Make_with_attribute (struct
   type ast = expression
   type ast_desc = expression_desc
+  type ast_info = attributes
 
   let plural = "expressions"
-
+  let prepend_attributes = prepend_attributes_info
   let location expr = expr.pexp_loc
 
-  let wrap_desc ?loc ~attrs = Ast_helper.Exp.mk ?loc ~attrs
+  let wrap_desc ?loc ~info:attrs = Ast_helper.Exp.mk ?loc ~attrs
 
   let desc expr = expr.pexp_desc
   let attributes expr = expr.pexp_attributes
@@ -688,12 +705,13 @@ end)
 module Pattern0 = Make_with_attribute (struct
   type ast = pattern
   type ast_desc = pattern_desc
+  type ast_info = attributes
 
   let plural = "patterns"
-
+  let prepend_attributes = prepend_attributes_info
   let location pat = pat.ppat_loc
 
-  let wrap_desc ?loc ~attrs = Ast_helper.Pat.mk ?loc ~attrs
+  let wrap_desc ?loc ~info:attrs = Ast_helper.Pat.mk ?loc ~attrs
 
   let desc pat = pat.ppat_desc
   let attributes pat = pat.ppat_attributes
@@ -704,12 +722,13 @@ end)
 module Module_type0 = Make_with_attribute (struct
     type ast = module_type
     type ast_desc = module_type_desc
+    type ast_info = attributes
 
     let plural = "module types"
-
+    let prepend_attributes = prepend_attributes_info
     let location mty = mty.pmty_loc
 
-    let wrap_desc ?loc ~attrs = Ast_helper.Mty.mk ?loc ~attrs
+    let wrap_desc ?loc ~info:attrs = Ast_helper.Mty.mk ?loc ~attrs
 
     let desc mty = mty.pmty_desc
     let attributes mty = mty.pmty_attributes
@@ -723,19 +742,13 @@ end)
 module Signature_item0 = Make_with_extension_node (struct
     type ast = signature_item
     type ast_desc = signature_item_desc
+    type ast_info = unit
 
     let plural = "signature items"
 
     let location sigi = sigi.psig_loc
 
-    (* The attributes are only set in [ast_mapper], so requiring them to be
-       empty here is fine, as there won't be any to set in that case. *)
-    let wrap_desc ?loc ~attrs =
-      match attrs with
-      | [] -> Ast_helper.Sig.mk ?loc
-      | _ :: _ ->
-          Misc.fatal_errorf
-            "Jane syntax: Cannot put attributes on a signature item"
+    let wrap_desc ?loc ~info:() = Ast_helper.Sig.mk ?loc
 
     let make_extension_node = Ast_helper.Sig.extension
 
@@ -766,19 +779,13 @@ end)
 module Structure_item0 = Make_with_extension_node (struct
     type ast = structure_item
     type ast_desc = structure_item_desc
+    type ast_info = unit
 
     let plural = "structure items"
 
     let location stri = stri.pstr_loc
 
-    (* The attributes are only set in [ast_mapper], so requiring them to be
-       empty here is fine, as there won't be any to set in that case. *)
-    let wrap_desc ?loc ~attrs =
-      match attrs with
-      | [] -> Ast_helper.Str.mk ?loc
-      | _ :: _ ->
-          Misc.fatal_errorf
-            "Jane syntax: Cannot put attributes on a structure item"
+    let wrap_desc ?loc ~info:() = Ast_helper.Str.mk ?loc
 
     let make_extension_node = Ast_helper.Str.extension
 
@@ -808,9 +815,10 @@ end)
 module type AST = sig
   type ast
   type ast_desc
+  type ast_info
 
   val wrap_desc :
-    ?loc:Location.t -> attrs:Parsetree.attributes -> ast_desc -> ast
+    ?loc:Location.t -> info:ast_info -> ast_desc -> ast
   val make_jane_syntax : Feature.t -> string list -> ast -> ast_desc
   val make_entire_jane_syntax :
     loc:Location.t -> Feature.t -> (unit -> ast) -> ast_desc
@@ -820,6 +828,7 @@ end
 
 module Make_ast (AST : AST_internal) : AST with type ast = AST.ast
                                             and type ast_desc = AST.ast_desc
+                                            and type ast_info = AST.ast_info
   = struct
   include AST
 

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -735,6 +735,24 @@ module Module_type0 = Make_with_attribute (struct
     let with_attributes mty pmty_attributes = { mty with pmty_attributes }
 end)
 
+(** Extension constructors; embedded using an attribute. *)
+module Extension_constructor0 = Make_with_attribute (struct
+    type ast = extension_constructor
+    type ast_desc = extension_constructor_kind
+    type ast_info = attributes * string Location.loc
+
+    let plural = "extension constructors"
+    let prepend_attributes attrs1 (attrs2, name) = (attrs1 @ attrs2, name)
+    let location ext = ext.pext_loc
+
+    let wrap_desc ?loc ~info:(attrs, name) =
+      Ast_helper.Te.constructor ?loc ~attrs name
+
+    let desc ext = ext.pext_kind
+    let attributes ext = ext.pext_attributes
+    let with_attributes ext pext_attributes = { ext with pext_attributes }
+end)
+
 (** Signature items; embedded as
     [include sig [%%extension.EXTNAME];; BODY end]. Signature items don't have
     attributes or we'd use them instead.
@@ -876,3 +894,4 @@ module Signature_item = Make_ast(Signature_item0)
 module Structure_item = Make_ast(Structure_item0)
 module Core_type = Make_ast(Core_type0)
 module Constructor_argument = Make_ast(Constructor_argument0)
+module Extension_constructor = Make_ast(Extension_constructor0)

--- a/ocaml/parsing/jane_syntax_parsing.mli
+++ b/ocaml/parsing/jane_syntax_parsing.mli
@@ -262,6 +262,7 @@ module Extension_constructor :
        and type ast_desc =
              Parsetree.extension_constructor_kind With_attributes.t
        and type ast_info = Parsetree.attributes * string Location.loc
+       (* the [string Location.loc] is the name of the constructor *)
 
 (** Require that an extension is enabled for at least the provided level, or
     else throw an exception (of an abstract type) at the provided location

--- a/ocaml/parsing/jane_syntax_parsing.mli
+++ b/ocaml/parsing/jane_syntax_parsing.mli
@@ -162,13 +162,17 @@ module type AST = sig
       attributes (e.g., [Parsetree.expression_desc]) *)
   type ast_desc
 
+  (** Information which is part of the [ast] but missing from [ast_desc], other
+      than location. We need this to get from an [ast_desc] to an [ast]. *)
+  type ast_info
+
   (** Turn an [ast_desc] into an [ast] by adding the appropriate metadata.  When
       creating [ast] nodes afresh to embed our novel syntax, the location should
       be omitted; in this case, it will default to [!Ast_helper.default_loc],
       which should be [ghost]. *)
   val wrap_desc
     :  ?loc:Location.t
-    -> attrs:Parsetree.attributes
+    -> info:ast_info
     -> ast_desc
     -> ast
 
@@ -221,30 +225,37 @@ end
 module Expression :
   AST with type ast = Parsetree.expression
        and type ast_desc = Parsetree.expression_desc With_attributes.t
+       and type ast_info = Parsetree.attributes
 
 module Pattern :
   AST with type ast = Parsetree.pattern
        and type ast_desc = Parsetree.pattern_desc With_attributes.t
+       and type ast_info = Parsetree.attributes
 
 module Module_type :
   AST with type ast = Parsetree.module_type
        and type ast_desc = Parsetree.module_type_desc With_attributes.t
+       and type ast_info = Parsetree.attributes
 
 module Signature_item :
   AST with type ast = Parsetree.signature_item
        and type ast_desc = Parsetree.signature_item_desc
+       and type ast_info = unit
 
 module Structure_item :
   AST with type ast = Parsetree.structure_item
        and type ast_desc = Parsetree.structure_item_desc
+       and type ast_info = unit
 
 module Core_type :
   AST with type ast = Parsetree.core_type
        and type ast_desc = Parsetree.core_type_desc With_attributes.t
+       and type ast_info = Parsetree.attributes
 
 module Constructor_argument :
   AST with type ast = Parsetree.core_type
        and type ast_desc = Parsetree.core_type_desc With_attributes.t
+       and type ast_info = Parsetree.attributes
 
 (** Require that an extension is enabled for at least the provided level, or
     else throw an exception (of an abstract type) at the provided location

--- a/ocaml/parsing/jane_syntax_parsing.mli
+++ b/ocaml/parsing/jane_syntax_parsing.mli
@@ -257,6 +257,12 @@ module Constructor_argument :
        and type ast_desc = Parsetree.core_type_desc With_attributes.t
        and type ast_info = Parsetree.attributes
 
+module Extension_constructor :
+  AST with type ast = Parsetree.extension_constructor
+       and type ast_desc =
+             Parsetree.extension_constructor_kind With_attributes.t
+       and type ast_info = Parsetree.attributes * string Location.loc
+
 (** Require that an extension is enabled for at least the provided level, or
     else throw an exception (of an abstract type) at the provided location
     saying otherwise.  This is intended to be used in [jane_syntax.ml] when a

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -1790,6 +1790,9 @@ and constructor_declaration ctxt f (name, vars, args, res, attrs) =
 
 and extension_constructor ctxt f x =
   (* Cf: #7200 *)
+  match Jane_syntax.Extension_constructor.of_ast x with
+  | Some (jext, attrs) -> extension_constructor_jst ctxt f attrs jext
+  | None ->
   match x.pext_kind with
   | Pext_decl(v, l, r) ->
       constructor_declaration ctxt f
@@ -1798,6 +1801,10 @@ and extension_constructor ctxt f x =
       pp f "%s@;=@;%a%a" x.pext_name.txt
         longident_loc li
         (attributes ctxt) x.pext_attributes
+
+and extension_constructor_jst _ctxt _f _attrs :
+  Jane_syntax.Extension_constructor.t -> _ = function
+  | _ -> .
 
 and case_list ctxt f l : unit =
   let aux f {pc_lhs; pc_guard; pc_rhs} =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1538,11 +1538,20 @@ let transl_type_decl env rec_flag sdecl_list =
   (final_decls, final_env)
 
 (* Translating type extensions *)
+let transl_extension_constructor_jst ~scope:_ _env _type_path _type_params
+      _typext_params _priv _id _attrs : Jane_syntax.Extension_constructor.t -> _ =
+  function
+  | _ -> .
 
 let transl_extension_constructor ~scope env type_path type_params
                                  typext_params priv sext =
   let id = Ident.create_scoped ~scope sext.pext_name.txt in
   let args, arg_layouts, constant, ret_type, kind =
+    match Jane_syntax.Extension_constructor.of_ast sext with
+    | Some (jext, attrs) ->
+      transl_extension_constructor_jst
+        ~scope env type_path type_params typext_params priv id attrs jext
+    | None ->
     match sext.pext_kind with
       Pext_decl(svars, sargs, sret_type) ->
         let targs, tret_type, args, ret_type =


### PR DESCRIPTION
Motivation: To support `type t += Mk : ('a : immediate) ('b : float64) 'c 'd. ...`

This is in two commits, reviewable independently. The first adds some infrastructure used in the second.

There are no tests, because there is no actual jane-syntax for extension constructors. Doing that will be part of #1417.

@ncik-roberts and @antalsz are good reviewers.