### PR TITLE
Binary emitter understands relocations emitted for probes

### DIFF
--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1023,8 +1023,8 @@ let emit_SHR b dst src = emit_shift 5 b dst src
 
 let emit_SAR b dst src = emit_shift 7 b dst src
 
-let record_local_reloc b local_reloc =
-  local_relocs := (Buffer.length b.buf, local_reloc) :: !local_relocs
+let record_local_reloc b ?(offset=0) local_reloc =
+  local_relocs := (Buffer.length b.buf + offset, local_reloc) :: !local_relocs
 
 let emit_reloc_jump near_opcodes far_opcodes b loc symbol =
   if String.Tbl.mem local_labels symbol then
@@ -1682,7 +1682,14 @@ let assemble_line b loc ins =
         for _ = 1 to n do
           buf_int8 b 0
         done
-    | Hidden _ | Weak _ | Reloc _ | NewLine | Sleb128 _ | Uleb128 _ | Direct_assignment _ -> ()
+    | Hidden _ | Weak _ | NewLine | Sleb128 _ | Uleb128 _ | Direct_assignment _ -> ()
+    | Reloc { name = R_X86_64_PLT32;
+              expr = ConstSub (ConstLabel wrap_label, Const 4L);
+              offset = ConstSub (ConstThis, Const 4L);
+            }  when String.Tbl.mem local_labels wrap_label ->
+      record_local_reloc b ~offset:(-4) (RelocCall wrap_label)
+    | Reloc { name = R_X86_64_PLT32; expr=_; offset=_ }  ->
+      failwith "Unsupported: Reloc R_X86_64_PLT32"
   with e ->
     Printf.eprintf "Exception %s:\n%!" (Printexc.to_string e);
     (*


### PR DESCRIPTION
and produces an error on other important instructions it does not yet understand, instead of silently miscompiling.