### PR TITLE
Remove check about coercions in Simplify_static_const

### DIFF
--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -26,22 +26,9 @@ let simplify_field_of_block dacc (field : Field_of_static_block.t) =
     let ty = S.simplify_simple dacc (Simple.var var) ~min_name_mode in
     let simple = T.get_alias_exn ty in
     Simple.pattern_match simple
-      ~name:(fun name ~coercion ->
-        (* CR lmaurer for lmaurer: This will break if you try and put a coerced
-           thing in a block
-
-           mshinwell: is that guaranteed not to occur? It isn't obvious to me
-           why this would be the case. (Update: this won't happen at the moment,
-           since [Lambda_to_flambda] doesn't generate these and let-symbol
-           bindings cannot occur under lambdas, so we may be able to wait until
-           attempting to convert coercions to use some kind of primitive
-           mechanism instead of being attached to [Simple]s.) *)
-        if not (Coercion.is_id coercion)
-        then
-          Misc.fatal_errorf
-            "Coercion in field of static block is not the identity: %a, \
-             field:@ %a"
-            Coercion.print coercion Field_of_static_block.print field;
+      ~name:(fun name ~coercion:_ ->
+        (* CR mshinwell: It's safe to drop the coercion, but perhaps not
+           ideal. *)
         Name.pattern_match name
           ~var:(fun var ->
             Field_of_static_block.Dynamically_computed (var, dbg), ty)

--- a/middle_end/flambda2/terms/static_const.mli
+++ b/middle_end/flambda2/terms/static_const.mli
@@ -17,6 +17,9 @@
 (** Language terms that represent statically-allocated values, bound to
     symbols. *)
 
+(* CR mshinwell: Store coercions so the CR in Simplify_static_const can be
+   removed. *)
+
 (** The static structure of a symbol, possibly with holes, ready to be filled
     with values computed at runtime. *)
 type t = private


### PR DESCRIPTION
This check is triggering on a testcase in #1470 .  For the moment it seems like we can just drop the coercion here.  It maybe isn't ideal, but there are more important things to fix first.