### PR TITLE
Fix code to look for allocations in exclaves

### DIFF
--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -145,8 +145,8 @@ let may_allocate_in_region lam =
   let rec loop_region lam =
     shallow_iter ~tail:(function
       | Lexclave body -> loop body
-      | _ -> ()
-    ) ~non_tail:(fun _ -> ()) lam
+      | lam -> loop_region lam
+    ) ~non_tail:(fun lam -> loop_region lam) lam
   and loop = function
     | Lvar _ | Lmutvar _ | Lconst _ -> ()
 


### PR DESCRIPTION
The code in `translcore.ml` to decide whether to create a region was failing to find allocations that occur within exclaves, as it was failing to recurse manually when calling `shallow_iter` (which, naturally, performs a shallow traversal).