### PR TITLE
Disable `beat.ml` on macOS

### DIFF
--- a/ocaml/ocamltest/builtin_actions.ml
+++ b/ocaml/ocamltest/builtin_actions.ml
@@ -133,6 +133,12 @@ let macos = make
     "on a MacOS system"
     "not on a MacOS system")
 
+let not_macos = make
+  "not-macos"
+  (Actions_helpers.pass_or_skip (not (Ocamltest_config.system = macos_system))
+    "not on a MacOS system"
+    "on a MacOS system")
+
 let arch32 = make
   "arch32"
   (Actions_helpers.pass_or_skip (Sys.word_size = 32)
@@ -300,6 +306,7 @@ let _ =
     bsd;
     not_bsd;
     macos;
+    not_macos;
     arch32;
     arch64;
     has_symlink;

--- a/ocaml/testsuite/tests/lib-threads/beat.ml
+++ b/ocaml/testsuite/tests/lib-threads/beat.ml
@@ -2,8 +2,9 @@
 
 * hassysthreads
 include systhreads
-** bytecode
-** native
+** not-macos
+*** bytecode
+*** native
 
 *)
 


### PR DESCRIPTION
I am pretty sure this is not what we want,
but maybe as a temporary measure...