### PR TITLE
Tail-calling local-returning functions should make the current function local-returning as well

### DIFF
--- a/ocaml/testsuite/tests/typing-local/crossing.ml
+++ b/ocaml/testsuite/tests/typing-local/crossing.ml
@@ -224,7 +224,7 @@ val f : unit -> local_ int = <fun>
 |}]
 
 let g : _ -> _ =
-  fun () -> f ()
+  fun () -> let x = f () in x
 [%%expect{|
 val g : unit -> int = <fun>
 |}]
@@ -236,11 +236,11 @@ val f : unit -> local_ string = <fun>
 |}]
 
 let g : _ -> _ =
-  fun () -> f ()
+  fun () -> let x = f () in x
 [%%expect{|
-Line 2, characters 12-16:
-2 |   fun () -> f ()
-                ^^^^
+Line 2, characters 28-29:
+2 |   fun () -> let x = f () in x
+                                ^
 Error: This value escapes its region
 |}]
 

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -1394,8 +1394,12 @@ val foo : unit -> int = <fun>
 |}]
 
 (* tail-calling local-returning functions make the current function
-   local-returning as well; mode-crossing is irrelavent here. *)
-let foo () = local_ 42
+   local-returning as well; mode-crossing is irrelavent here. Whether or not the
+   function actually allocates in parent-region is also irrelavent here, but we
+   allocate just to demonstrate the potential leaking. *)
+let foo () = local_
+  let _ = local_ (52, 24) in
+  42
 [%%expect{|
 val foo : unit -> local_ int = <fun>
 |}]

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -773,7 +773,7 @@ val baduse : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c lazy_t = <fun>
 Line 2, characters 20-45:
 2 | let result = baduse (fun a b -> local_ (a,b)) 1 2
                         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function is local returning, but was expected otherwise
+Error: This function is local-returning, but was expected otherwise
 |}]
 
 
@@ -1449,7 +1449,7 @@ let foo : unit -> string = fun () -> local_ "hello"
 Line 1, characters 27-51:
 1 | let foo : unit -> string = fun () -> local_ "hello"
                                ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function is local returning, but was expected otherwise
+Error: This function is local-returning, but was expected otherwise
 |}]
 
 (* Unboxed type constructors do not affect regionality *)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -315,7 +315,7 @@ type position_and_mode = {
 
 let position_and_mode_default = {
   apply_position = Default;
-  region = None;
+  region_mode = None;
 }
 
 (** The function produces two values, apply_position and region_mode.

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -313,6 +313,11 @@ type position_and_mode = {
   region_mode : Value_mode.t option;
 }
 
+let position_and_mode_default = {
+  apply_position = Default;
+  region = None;
+}
+
 (** The function produces two values, apply_position and region_mode.
     Invariant: if apply_position = Tail, then region_mode = Some ... *)
 let position_and_mode env (expected_mode : expected_mode) sexp
@@ -6518,11 +6523,7 @@ and type_application env app_loc expected_mode pm
           (Value_mode.regional_to_local_alloc funct_mode) sargs ret_tvar
       in
       let partial_app = is_partial_apply untyped_args in
-      let pm =
-        if partial_app
-          then {apply_position = Default; region_mode = None}
-        else pm
-      in
+      let pm = if partial_app then position_and_mode_default else pm in
       let args =
         List.mapi (fun index arg ->
             type_apply_arg env ~app_loc ~funct ~index

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -262,6 +262,7 @@ type error =
   | Uncurried_function_escapes
   | Local_return_annotation_mismatch of Location.t
   | Function_returns_local
+  | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
   | Optional_poly_param
   | Exclave_in_nontail_position


### PR DESCRIPTION
Example (copied from added tests):
```
let foo () = local_ 42
[%%expect{|
val foo : unit -> local_ int = <fun>
|}]

let bar () =
  let _x = 52 in
  foo ()
[%%expect{|
val bar : unit -> local_ int = <fun>
|}]
```
A function being local-returning means precisely that it might allocate in the parent region. Therefore, a function tail-calling a local-returning function would allocate in parent region as well. 

I also did some renaming of constructors to avoid ambiguition. 

Kindly request @lpw25 for review.