### PR TITLE
Generalize `deep_occur` to `deep_occur_list`

### DIFF
--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -264,7 +264,11 @@ val filter_method: Env.t -> string -> type_expr -> type_expr
         (* A special case of unification (with {m : 'a; 'b}).  Raises
            [Filter_method_failed] instead of [Unify]. *)
 val occur_in: Env.t -> type_expr -> type_expr -> bool
+val deep_occur_list: type_expr -> type_expr list -> bool
+        (* Check whether a type occurs structurally within any type from
+           a list of types. *)
 val deep_occur: type_expr -> type_expr -> bool
+        (* Check whether a type occurs structurally within another. *)
 val moregeneral: Env.t -> bool -> type_expr -> type_expr -> unit
         (* Check if the first type scheme is more general than the second. *)
 val is_moregeneral: Env.t -> bool -> type_expr -> type_expr -> bool

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1693,7 +1693,7 @@ let rec prepare_class_type params = function
       let row = Btype.self_type_row cty in
       if List.memq (proxy row) !visited_objects
       || not (List.for_all is_Tvar params)
-      || List.exists (deep_occur row) tyl
+      || deep_occur_list row tyl
       then prepare_class_type params cty
       else List.iter prepare_type tyl
   | Cty_signature sign ->


### PR DESCRIPTION
A pattern that appears a few times is determining whether a type `ty` occurs structurally within any type from a list of types `tyl`.

There are two ways this is currently done. Both use `deep_occur`, which checks whether a type occurs within another (single) type, marking constituent types upon visiting them, and unmarking all upon determining the function's result.

**1.** `List.exists (deep_occur ty) tyl`
  * This potentially does extra work by unmarking each type in `tyl` as it's considered; e.g. if all types in `tyl` are the same, this could multiply the work by the length of the list.

**2.** `deep_occur ty (newgenty (Ttuple tyl))`
  * This avoids extra work by creating a fake `Ttuple`, but is less readable and potentially fragile to changes to tuples. In particular, this becomes messy when [adding labeled tuples](https://github.com/ocaml-flambda/flambda-backend/pull/1502): `deep_occur ty (newgenty (Ttuple (List.map (fun ty -> None, ty) tyl)))`

This change allows both of the above to be replaced with `deep_occur_list ty tyl`, which both avoids the fake `Ttuple` type and prevents duplicate work.