### PR TITLE
Rename num_trailing_local_params to first_complex_local_param

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -687,14 +687,14 @@ module Function_decls = struct
         loc : Lambda.scoped_location;
         recursive : Recursive.t;
         closure_alloc_mode : Lambda.alloc_mode;
-        num_trailing_local_params : int;
+        first_complex_local_param : int;
         contains_no_escaping_local_allocs : bool
       }
 
     let create ~let_rec_ident ~function_slot ~kind ~params ~return
         ~return_continuation ~exn_continuation ~my_region ~body
         ~(attr : Lambda.function_attribute) ~loc ~free_idents_of_body recursive
-        ~closure_alloc_mode ~num_trailing_local_params
+        ~closure_alloc_mode ~first_complex_local_param
         ~contains_no_escaping_local_allocs =
       let let_rec_ident =
         match let_rec_ident with
@@ -715,7 +715,7 @@ module Function_decls = struct
         loc;
         recursive;
         closure_alloc_mode;
-        num_trailing_local_params;
+        first_complex_local_param;
         contains_no_escaping_local_allocs
       }
 
@@ -759,7 +759,7 @@ module Function_decls = struct
 
     let closure_alloc_mode t = t.closure_alloc_mode
 
-    let num_trailing_local_params t = t.num_trailing_local_params
+    let first_complex_local_param t = t.first_complex_local_param
 
     let contains_no_escaping_local_allocs t =
       t.contains_no_escaping_local_allocs

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -308,7 +308,7 @@ module Function_decls : sig
       free_idents_of_body:Ident.Set.t ->
       Recursive.t ->
       closure_alloc_mode:Lambda.alloc_mode ->
-      num_trailing_local_params:int ->
+      first_complex_local_param:int ->
       contains_no_escaping_local_allocs:bool ->
       t
 
@@ -350,7 +350,7 @@ module Function_decls : sig
 
     val closure_alloc_mode : t -> Lambda.alloc_mode
 
-    val num_trailing_local_params : t -> int
+    val first_complex_local_param : t -> int
 
     val contains_no_escaping_local_allocs : t -> bool
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1600,8 +1600,9 @@ and cps_function_bindings env (bindings : (Ident.t * L.lambda) list) =
 and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     ({ kind; params; return; body; attr; loc; mode; region } : L.lfunction) :
     Function_decl.t =
-  let num_trailing_local_params =
-    match kind with Curried { nlocal } -> nlocal | Tupled -> 0
+  let first_complex_local_param =
+    List.length params
+    - match kind with Curried { nlocal } -> nlocal | Tupled -> 0
   in
   let body_cont = Continuation.create ~sort:Return () in
   let body_exn_cont = Continuation.create () in
@@ -1639,7 +1640,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
   Function_decl.create ~let_rec_ident:(Some fid) ~function_slot ~kind ~params
     ~return ~return_continuation:body_cont ~exn_continuation ~my_region ~body
     ~attr ~loc ~free_idents_of_body recursive ~closure_alloc_mode:mode
-    ~num_trailing_local_params ~contains_no_escaping_local_allocs:region
+    ~first_complex_local_param ~contains_no_escaping_local_allocs:region
 
 and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
     ~scrutinee (k : Continuation.t) (k_exn : Continuation.t) : Expr_with_acc.t =

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -881,7 +881,8 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         let code =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
-            ~newer_version_of ~params_arity ~num_trailing_local_params:0
+            ~newer_version_of ~params_arity
+            ~first_complex_local_param:(Flambda_arity.cardinal params_arity)
             ~result_arity ~result_types:Unknown
             ~contains_no_escaping_local_allocs:false ~stub:false ~inline
             ~check:Default_check

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -324,7 +324,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
     ~callee's_code_id ~callee's_code_metadata ~callee's_function_slot
     ~param_arity ~result_arity ~recursive ~down_to_up ~coming_from_indirect
     ~(closure_alloc_mode_from_type : Alloc_mode.For_types.t) ~current_region
-    ~num_trailing_local_params =
+    ~first_complex_local_param =
   (* Partial-applications are converted in full applications. Let's assume that
      [foo] takes 6 arguments. Then [foo a b c] gets transformed into:
 
@@ -377,17 +377,13 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
     Function_slot.create compilation_unit ~name:"partial_app_closure"
       K.With_subkind.any_value
   in
-  let new_closure_alloc_mode, num_trailing_local_params =
+  let new_closure_alloc_mode, first_complex_local_param =
     (* If the closure has a local suffix, and we've supplied enough args to hit
        it, then the closure must be local (because the args or closure might
        be). *)
-    let num_leading_heap_params = arity - num_trailing_local_params in
-    if args_arity <= num_leading_heap_params
-    then Alloc_mode.For_allocations.heap, num_trailing_local_params
-    else
-      let num_supplied_local_args = args_arity - num_leading_heap_params in
-      ( Alloc_mode.For_allocations.local ~region:current_region,
-        num_trailing_local_params - num_supplied_local_args )
+    if args_arity <= first_complex_local_param
+    then Alloc_mode.For_allocations.heap, first_complex_local_param - args_arity
+    else Alloc_mode.For_allocations.local ~region:current_region, 0
   in
   (match closure_alloc_mode_from_type with
   | Heap_or_local -> ()
@@ -570,7 +566,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         Code.create code_id ~params_and_body
           ~free_names_of_params_and_body:free_names ~newer_version_of:None
           ~params_arity:(Bound_parameters.arity remaining_params)
-          ~num_trailing_local_params ~result_arity ~result_types:Unknown
+          ~first_complex_local_param ~result_arity ~result_types:Unknown
           ~contains_no_escaping_local_allocs ~stub:true ~inline:Default_inline
           ~poll_attribute:Default ~check:Check_attribute.Default_check
           ~is_a_functor:false ~recursive ~cost_metrics:cost_metrics_of_body
@@ -777,8 +773,8 @@ let simplify_direct_function_call ~simplify_expr dacc apply
           ~callee's_code_id ~callee's_code_metadata ~callee's_function_slot
           ~param_arity:params_arity ~result_arity ~recursive ~down_to_up
           ~coming_from_indirect ~closure_alloc_mode_from_type ~current_region
-          ~num_trailing_local_params:
-            (Code_metadata.num_trailing_local_params callee's_code_metadata))
+          ~first_complex_local_param:
+            (Code_metadata.first_complex_local_param callee's_code_metadata))
       else
         Misc.fatal_errorf
           "Function with %d params when simplifying direct OCaml function call \

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -31,13 +31,13 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
     ~inlining_arguments ~absolute_history code_id ~return_continuation
     ~exn_continuation ~loopify_state code_metadata =
   let dacc = C.dacc_inside_functions context in
-  let num_leading_heap_params =
-    Code_metadata.num_leading_heap_params code_metadata
+  let first_complex_local_param =
+    Code_metadata.first_complex_local_param code_metadata
   in
   let alloc_modes =
     List.mapi
       (fun index _ : Alloc_mode.For_types.t ->
-        if index < num_leading_heap_params
+        if index < first_complex_local_param
         then Alloc_mode.For_types.heap
         else Alloc_mode.For_types.unknown ())
       (Bound_parameters.to_list params)
@@ -434,7 +434,7 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       (DA.are_rebuilding_terms dacc_after_body)
       code_id ~params_and_body ~free_names_of_params_and_body:free_names_of_code
       ~newer_version_of ~params_arity:(Code.params_arity code)
-      ~num_trailing_local_params:(Code.num_trailing_local_params code)
+      ~first_complex_local_param:(Code.first_complex_local_param code)
       ~result_arity ~result_types
       ~contains_no_escaping_local_allocs:
         (Code.contains_no_escaping_local_allocs code)

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -18,7 +18,7 @@ type t =
   { code_id : Code_id.t;
     newer_version_of : Code_id.t option;
     params_arity : Flambda_arity.t;
-    num_trailing_local_params : int;
+    first_complex_local_param : int;
     result_arity : Flambda_arity.t;
     result_types : Result_types.t Or_unknown_or_bottom.t;
     contains_no_escaping_local_allocs : bool;
@@ -56,14 +56,7 @@ module Code_metadata_accessors (X : Metadata_view_type) = struct
 
   let params_arity t = (metadata t).params_arity
 
-  let num_leading_heap_params t =
-    let { params_arity; num_trailing_local_params; _ } = metadata t in
-    let n = Flambda_arity.cardinal params_arity - num_trailing_local_params in
-    assert (n >= 0);
-    (* see [create] *)
-    n
-
-  let num_trailing_local_params t = (metadata t).num_trailing_local_params
+  let first_complex_local_param t = (metadata t).first_complex_local_param
 
   let result_arity t = (metadata t).result_arity
 
@@ -125,7 +118,7 @@ type 'a create_type =
   Code_id.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.t ->
-  num_trailing_local_params:int ->
+  first_complex_local_param:int ->
   result_arity:Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   contains_no_escaping_local_allocs:bool ->
@@ -146,7 +139,7 @@ type 'a create_type =
   loopify:Loopify_attribute.t ->
   'a
 
-let createk k code_id ~newer_version_of ~params_arity ~num_trailing_local_params
+let createk k code_id ~newer_version_of ~params_arity ~first_complex_local_param
     ~result_arity ~result_types ~contains_no_escaping_local_allocs ~stub
     ~(inline : Inline_attribute.t) ~check ~poll_attribute ~is_a_functor
     ~recursive ~cost_metrics ~inlining_arguments ~dbg ~is_tupled
@@ -160,17 +153,17 @@ let createk k code_id ~newer_version_of ~params_arity ~num_trailing_local_params
     ()
   | true, (Always_inline | Unroll _) ->
     Misc.fatal_error "Stubs may not be annotated as [Always_inline] or [Unroll]");
-  if num_trailing_local_params < 0
-     || num_trailing_local_params > Flambda_arity.cardinal params_arity
+  if first_complex_local_param < 0
+     || first_complex_local_param > Flambda_arity.cardinal params_arity
   then
     Misc.fatal_errorf
-      "Illegal num_trailing_local_params=%d for params arity: %a"
-      num_trailing_local_params Flambda_arity.print params_arity;
+      "Illegal first_complex_local_param=%d for params arity: %a"
+      first_complex_local_param Flambda_arity.print params_arity;
   k
     { code_id;
       newer_version_of;
       params_arity;
-      num_trailing_local_params;
+      first_complex_local_param;
       result_arity;
       result_types;
       contains_no_escaping_local_allocs;
@@ -219,7 +212,7 @@ let [@ocamlformat "disable"] print_inlining_paths ppf
 
 let [@ocamlformat "disable"] print ppf
        { code_id = _; newer_version_of; stub; inline; check; poll_attribute;
-         is_a_functor; params_arity; num_trailing_local_params; result_arity;
+         is_a_functor; params_arity; first_complex_local_param; result_arity;
          result_types; contains_no_escaping_local_allocs;
          recursive; cost_metrics; inlining_arguments;
          dbg; is_tupled; is_my_closure_used; inlining_decision;
@@ -233,7 +226,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>%t(poll_attribute@ %a)%t@]@ \
       @[<hov 1>%t(is_a_functor@ %b)%t@]@ \
       @[<hov 1>%t(params_arity@ %t%a%t)%t@]@ \
-      @[<hov 1>(num_trailing_local_params@ %d)@]@ \
+      @[<hov 1>(first_complex_local_param@ %d)@]@ \
       @[<hov 1>%t(result_arity@ %t%a%t)%t@]@ \
       @[<hov 1>(result_types@ @[<hov 1>(%a)@])@]@ \
       @[<hov 1>(contains_no_escaping_local_allocs@ %b)@]@ \
@@ -279,7 +272,7 @@ let [@ocamlformat "disable"] print ppf
     then Flambda_colours.elide
     else Flambda_colours.none)
     Flambda_colours.pop
-    num_trailing_local_params
+    first_complex_local_param
     (if Flambda_arity.is_singleton_value result_arity
     then Flambda_colours.elide
     else Flambda_colours.none)
@@ -315,7 +308,7 @@ let free_names
     { code_id = _;
       newer_version_of;
       params_arity = _;
-      num_trailing_local_params = _;
+      first_complex_local_param = _;
       result_arity = _;
       result_types;
       contains_no_escaping_local_allocs = _;
@@ -355,7 +348,7 @@ let apply_renaming
     ({ code_id;
        newer_version_of;
        params_arity = _;
-       num_trailing_local_params = _;
+       first_complex_local_param = _;
        result_arity = _;
        result_types;
        contains_no_escaping_local_allocs = _;
@@ -406,7 +399,7 @@ let ids_for_export
     { code_id;
       newer_version_of;
       params_arity = _;
-      num_trailing_local_params = _;
+      first_complex_local_param = _;
       result_arity = _;
       result_types;
       contains_no_escaping_local_allocs = _;
@@ -443,7 +436,7 @@ let approx_equal
     { code_id = code_id1;
       newer_version_of = newer_version_of1;
       params_arity = params_arity1;
-      num_trailing_local_params = num_trailing_local_params1;
+      first_complex_local_param = first_complex_local_param1;
       result_arity = result_arity1;
       result_types = _;
       contains_no_escaping_local_allocs = contains_no_escaping_local_allocs1;
@@ -466,7 +459,7 @@ let approx_equal
     { code_id = code_id2;
       newer_version_of = newer_version_of2;
       params_arity = params_arity2;
-      num_trailing_local_params = num_trailing_local_params2;
+      first_complex_local_param = first_complex_local_param2;
       result_arity = result_arity2;
       result_types = _;
       contains_no_escaping_local_allocs = contains_no_escaping_local_allocs2;
@@ -489,7 +482,7 @@ let approx_equal
   Code_id.equal code_id1 code_id2
   && (Option.equal Code_id.equal) newer_version_of1 newer_version_of2
   && Flambda_arity.equal_ignoring_subkinds params_arity1 params_arity2
-  && Int.equal num_trailing_local_params1 num_trailing_local_params2
+  && Int.equal first_complex_local_param1 first_complex_local_param2
   && Flambda_arity.equal_ignoring_subkinds result_arity1 result_arity2
   && Bool.equal contains_no_escaping_local_allocs1
        contains_no_escaping_local_allocs2

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -33,8 +33,9 @@ module type Code_metadata_accessors_result_type = sig
 
   val params_arity : 'a t -> Flambda_arity.t
 
-  (* val num_leading_heap_params : 'a t -> int *)
-
+  (* Zero-indexed position of the first local param, to be able to determine the
+     allocation modes of partial applications. If there is no local parameter,
+     equal to the number of (complex) parameters. *)
   val first_complex_local_param : 'a t -> int
 
   val result_arity : 'a t -> Flambda_arity.t

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -33,9 +33,9 @@ module type Code_metadata_accessors_result_type = sig
 
   val params_arity : 'a t -> Flambda_arity.t
 
-  val num_leading_heap_params : 'a t -> int
+  (* val num_leading_heap_params : 'a t -> int *)
 
-  val num_trailing_local_params : 'a t -> int
+  val first_complex_local_param : 'a t -> int
 
   val result_arity : 'a t -> Flambda_arity.t
 
@@ -83,7 +83,7 @@ type 'a create_type =
   Code_id.t ->
   newer_version_of:Code_id.t option ->
   params_arity:Flambda_arity.t ->
-  num_trailing_local_params:int ->
+  first_complex_local_param:int ->
   result_arity:Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   contains_no_escaping_local_allocs:bool ->

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -55,7 +55,11 @@ let get_func_decl_params_arity t code_id =
     if Code_metadata.is_tupled info
     then Lambda.Tupled
     else
-      Lambda.Curried { nlocal = Code_metadata.num_trailing_local_params info }
+      let nlocal =
+        Flambda_arity.cardinal (Code_metadata.params_arity info)
+        - Code_metadata.first_complex_local_param info
+      in
+      Lambda.Curried { nlocal }
   in
   let closure_code_pointers =
     match kind, params_ty with


### PR DESCRIPTION
`num_trailing_local_params` was misleading, as it was counting all params after the first local params, not only local ones. We considered naming this field `num_trailing_local_closures`, but since full application does not yield a closure in general, this is confusing and easily leads to off-by-one errors. 
This name seems better, now counting the position of the first local param instead. It looks like it simplifies the code as well, which is always a win.
I used `first_complex_local_param` instead of `first_local_param` to prepare for the upcoming unarization changes.