### PR TITLE
Change unary functions' calling convention

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -131,11 +131,11 @@ let closure_info' ~arity ~startenv ~is_last =
     match arity with
     | Lambda.Tupled, l ->
       let n = List.length l in
-      (* Sanity check: tupled function should not have arity 1/-1,
-         especially considering that unary function have a slightly different
-         call convention. *)
+      (* Sanity check: tupled function should not have arity 1/-1, especially
+         considering that unary function have a slightly different call
+         convention. *)
       assert (n <> 1);
-      - n
+      -n
     | Lambda.Curried _, l -> List.length l
   in
   pack_closure_info ~arity ~startenv ~is_last
@@ -2514,8 +2514,7 @@ let apply_function_body arity result (mode : Lambda.alloc_mode) =
           ( Capply (result, Rc_normal),
             [ get_field_gen Asttypes.Mutable (Cvar clos) 0 (dbg ());
               Cvar clos;
-              Cvar arg;
-            ],
+              Cvar arg ],
             dbg () )
       in
       match region with
@@ -2546,8 +2545,7 @@ let apply_function_body arity result (mode : Lambda.alloc_mode) =
             ( Capply (typ_val, Rc_normal),
               [ get_field_gen Asttypes.Mutable (Cvar clos) 0 (dbg ());
                 Cvar clos;
-                Cvar arg;
-              ],
+                Cvar arg ],
               dbg () ),
           app_fun newclos args )
   in
@@ -2700,10 +2698,7 @@ let tuplify_function arity return =
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
   Cfunction
     { fun_name;
-      fun_args = [
-        VP.create clos, typ_val;
-        VP.create arg, typ_val;
-      ];
+      fun_args = [VP.create clos, typ_val; VP.create arg, typ_val];
       fun_body =
         Cop
           ( Capply (return, Rc_normal),
@@ -2839,10 +2834,7 @@ let final_curry_function nlocal arity result =
   Cfunction
     { fun_name;
       fun_args =
-        [
-          VP.create last_clos, typ_val;
-          VP.create last_arg, List.hd args_type;
-        ];
+        [VP.create last_clos, typ_val; VP.create last_arg, List.hd args_type];
       fun_body =
         make_curry_apply result narity (List.tl args_type) [Cvar last_arg]
           last_clos (narity - 1);
@@ -2877,11 +2869,10 @@ let intermediate_curry_functions ~nlocal ~arity result =
       Cfunction
         { fun_name = global_symbol name2;
           fun_args =
-            (* These are actually 1-argument functions that directly
-               deconstruct their only argument *)
-            (VP.create clos, typ_val) ::
-            List.map (fun (arg, t) -> VP.create arg, [| t |]) args
-        ;
+            (* These are actually 1-argument functions that directly deconstruct
+               their only argument *)
+            (VP.create clos, typ_val)
+            :: List.map (fun (arg, t) -> VP.create arg, [| t |]) args;
           fun_body =
             Cop
               ( Calloc mode,
@@ -2915,7 +2906,7 @@ let intermediate_curry_functions ~nlocal ~arity result =
         }
       ::
       (if has_nary
-      then
+      then (
         let direct_args =
           List.mapi
             (fun i ty ->
@@ -2946,7 +2937,7 @@ let intermediate_curry_functions ~nlocal ~arity result =
               fun_poll = Default_poll
             }
         in
-        [cf]
+        [cf])
       else [])
       @ loop (arg_type :: accumulated_args) remaining_args (num + 1)
   in
@@ -4076,7 +4067,8 @@ let indirect_call ~dbg ty pos alloc_mode f args_type args =
       ~body:
         (Cop
            ( Capply (Extended_machtype.to_machtype ty, pos),
-             (* Note: unary functions (and only them) take their closure as first argument *)
+             (* Note: unary functions (and only them) take their closure as
+                first argument *)
              [load ~dbg Word_int Asttypes.Mutable ~addr:(Cvar v); Cvar v; arg],
              dbg ))
   | args ->

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2274,6 +2274,7 @@ let direct_apply lbl ty args (pos, _mode) dbg =
   Cop (Capply (ty, pos), Cconst_symbol (lbl, dbg) :: args, dbg)
 
 let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
+  assert (List.length args <> 1);
   (* Treat tagged int arguments and results as [typ_val], to avoid generating
      excessive numbers of caml_apply functions. *)
   let ty = Extended_machtype.to_machtype extended_ty in
@@ -2323,7 +2324,7 @@ let generic_apply mut clos args args_type result (pos, mode) dbg =
     bind "fun" clos (fun clos ->
         Cop
           ( Capply (Extended_machtype.to_machtype result, pos),
-            [get_field_gen mut clos 0 dbg; arg; clos],
+            [get_field_gen mut clos 0 dbg; clos; arg],
             dbg ))
   | _ -> call_caml_apply result args_type mut clos args pos mode dbg
 
@@ -2921,7 +2922,7 @@ let intermediate_curry_functions ~nlocal ~arity result =
               V.create_local (Printf.sprintf "arg%d" (i + num + 2)), ty)
             remaining_args
         in
-        (* CR gbury: put closure first if there is 1 remaining_arg ? *)
+        assert (List.length remaining_args > 1);
         let fun_args =
           List.map
             (fun (arg, ty) -> VP.create arg, ty)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2876,8 +2876,11 @@ let intermediate_curry_functions ~nlocal ~arity result =
       Cfunction
         { fun_name = global_symbol name2;
           fun_args =
+            (* These are actually 1-argument functions that directly
+               deconstruct their only argument *)
+            (VP.create clos, typ_val) ::
             List.map (fun (arg, t) -> VP.create arg, [| t |]) args
-            @ [VP.create clos, typ_val];
+        ;
           fun_body =
             Cop
               ( Calloc mode,
@@ -2918,6 +2921,7 @@ let intermediate_curry_functions ~nlocal ~arity result =
               V.create_local (Printf.sprintf "arg%d" (i + num + 2)), ty)
             remaining_args
         in
+        (* CR gbury: put closure first if there is 1 remaining_arg ? *)
         let fun_args =
           List.map
             (fun (arg, ty) -> VP.create arg, ty)

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -512,6 +512,8 @@ let rec transl env e =
       let dbg = Debuginfo.none in
       ptr_offset ptr offset dbg
   | Udirect_apply(handler_code_sym, args, Some { name; enabled_at_init }, _, _, dbg) ->
+      (* CR gbury: is the call convention for probes compatible with the one for
+         unary caml function where we put the closure first ? *)
       let args = List.map (transl env) args in
       return_unit dbg
         (Cop(Cprobe { name; handler_code_sym; enabled_at_init }, args, dbg))

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -119,9 +119,9 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     if not (C.check_arity params_arity args)
     then Misc.fatal_errorf "Wrong arity for direct call";
     let args =
-      (* Note on call convention: in order to have a caml_apply/curry
-         that is generic wrt layouts, we need unary functions to take
-         their closures as first arguments. *)
+      (* Note on call convention: in order to have a caml_apply/curry that is
+         generic wrt layouts, we need unary functions to take their closures as
+         first arguments. *)
       match args with
       | [_] ->
         (* CR gbury: use a gap/dummy argument when the closure is unused *)

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -334,20 +334,22 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
       | Unknown -> true
       | Known is_my_closure_used -> is_my_closure_used
     in
-    (* Note: unary functions (and only them) take their closure as first argument *)
-    if Bound_parameters.cardinal params = 1 then
+    (* Note: unary functions (and only them) take their closure as first
+       argument *)
+    if Bound_parameters.cardinal params = 1
+    then
       let my_closure_param =
         Bound_parameter.create my_closure Flambda_kind.With_subkind.any_value
       in
       Bound_parameters.cons my_closure_param params
-    else if is_my_closure_used then
+    else if is_my_closure_used
+    then
       let my_closure_param =
         Bound_parameter.create my_closure Flambda_kind.With_subkind.any_value
       in
       Bound_parameters.append params
         (Bound_parameters.create [my_closure_param])
-    else
-      params
+    else params
   in
   (* Init the env and create a jump id for the return continuation in case a
      trap action is attached to one of its calls *)

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -334,14 +334,20 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
       | Unknown -> true
       | Known is_my_closure_used -> is_my_closure_used
     in
-    if not is_my_closure_used
-    then params
-    else
+    (* Note: unary functions (and only them) take their closure as first argument *)
+    if Bound_parameters.cardinal params = 1 then
+      let my_closure_param =
+        Bound_parameter.create my_closure Flambda_kind.With_subkind.any_value
+      in
+      Bound_parameters.cons my_closure_param params
+    else if is_my_closure_used then
       let my_closure_param =
         Bound_parameter.create my_closure Flambda_kind.With_subkind.any_value
       in
       Bound_parameters.append params
         (Bound_parameters.create [my_closure_param])
+    else
+      params
   in
   (* Init the env and create a jump id for the return continuation in case a
      trap action is attached to one of its calls *)

--- a/ocaml/runtime/amd64.S
+++ b/ocaml/runtime/amd64.S
@@ -712,9 +712,9 @@ CFI_STARTPROC
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
         movq    C_ARG_1, %r14      /* Caml_state */
-        movq    C_ARG_2, %rbx      /* closure */
-        movq    0(C_ARG_3), %rax   /* argument */
-        movq    0(%rbx), %r12      /* code pointer */
+        movq    C_ARG_2, %rax      /* closure */
+        movq    0(C_ARG_3), %rbx   /* argument */
+        movq    0(%rax), %r12      /* code pointer */
         jmp     LBL(caml_start_program)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_callback_asm))


### PR DESCRIPTION
This PR changes the call convention for unary functions, that is functions/closures that take 1 argument (at the source level, i.e. one argument as an ocaml function).

This should work for flambda2 on amd64, but other backends (and other archs) still need to be updated.