### PR TITLE
Generalize `Ctype.free_variables` to `Ctype.free_variables_list`

### DIFF
--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -589,10 +589,24 @@ let free_vars ?env ty =
   free_variables := [];
   really_closed := None;
   res
+  
+let free_vars_list ?env tyl =
+  free_variables := [];
+  really_closed := env;
+  List.iter (free_vars_rec true) tyl;
+  let res = !free_variables in
+  free_variables := [];
+  really_closed := None;
+  res
 
 let free_variables ?env ty =
   let tl = List.map fst (free_vars ?env ty) in
   unmark_type ty;
+  tl
+
+let free_variables_list ?env tyl =
+  let tl = List.map fst (free_vars_list ?env tyl) in
+  List.iter unmark_type tyl;
   tl
 
 let closed_type ty =

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -435,6 +435,9 @@ val nongen_class_declaration: class_declaration -> bool
 
 val free_variables: ?env:Env.t -> type_expr -> type_expr list
         (* If env present, then check for incomplete definitions too *)
+val free_variables_list: ?env:Env.t -> type_expr list -> type_expr list
+        (* Union of all free variables in a list of types.
+           If env present, then check for incomplete definitions too *)
 val closed_type_decl: type_declaration -> type_expr option
 val closed_extension_constructor: extension_constructor -> type_expr option
 val closed_class:

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1592,9 +1592,7 @@ let transl_extension_constructor ~scope env type_path type_params
         end;
         (* Remove "_" names from parameters used in the constructor *)
         if not cdescr.cstr_generalized then begin
-          let vars =
-            Ctype.free_variables (Btype.newgenty (Ttuple (List.map fst args)))
-          in
+          let vars = Ctype.free_variables_list (List.map fst args) in
           List.iter
             (fun ty ->
               match get_desc ty with

--- a/ocaml/typing/typedecl_variance.ml
+++ b/ocaml/typing/typedecl_variance.ml
@@ -192,8 +192,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
                                                         (c,n,i)))))
       params required;
     (* Check propagation from constrained parameters *)
-    let args = Btype.newgenty (Ttuple params) in
-    let fvl = Ctype.free_variables args in
+    let fvl = Ctype.free_variables_list params in
     let fvl =
       List.filter (fun v -> not (List.exists (eq_type v) params)) fvl in
     (* If there are no extra variables there is nothing to do *)


### PR DESCRIPTION
(See also #1519, which attempts to fix the same problem)

The motivation for this change is similar to #1503's: we sometimes collect all free variables in a list of types `tyl` by passing a fake `TTuple` to `Ctype.free_variables`, as in `Ctype.free_variables (Btype.newgenty (Ttuple tyl))`.

However, this is fragile to changes in tuples, and in particular, becomes messy when [adding labeled tuples](https://github.com/ocaml-flambda/flambda-backend/pull/1502): the above would become `Ctype.free_variables (Btype.newgenty (Ttuple (List.map (fun t -> None, t) tyl)))`.