### PR TITLE
Add `free_variables_list` and refactor `free_vars*`

### DIFF
--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -570,10 +570,12 @@ let rec free_vars_iter f really_closed real ty =
     | Tobject (ty, _), _ ->
         free_vars_iter f really_closed false ty
     | Tfield (_, _, ty1, ty2), _ ->
-        free_vars_iter f really_closed true ty1; free_vars_iter f really_closed false ty2
+        free_vars_iter f really_closed true ty1;
+        free_vars_iter f really_closed false ty2
     | Tvariant row, _ ->
         iter_row (free_vars_iter f really_closed true) row;
-        if not (static_row row) then free_vars_iter f really_closed false (row_more row)
+        if not (static_row row) then
+          free_vars_iter f really_closed false (row_more row)
     | _    ->
         iter_type_expr (free_vars_iter f really_closed true) ty
 

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -589,10 +589,24 @@ let free_vars ?env ty =
   free_variables := [];
   really_closed := None;
   res
+  
+let free_vars_list ?env tyl =
+  free_variables := [];
+  really_closed := env;
+  List.iter (free_vars_rec true) tyl;
+  let res = !free_variables in
+  free_variables := [];
+  really_closed := None;
+  res
 
 let free_variables ?env ty =
   let tl = List.map fst (free_vars ?env ty) in
   unmark_type ty;
+  tl
+
+let free_variables_list ?env tyl =
+  let tl = List.map fst (free_vars_list ?env tyl) in
+  List.iter unmark_type tyl;
   tl
 
 let closed_type ty =

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -545,9 +545,7 @@ exception Non_closed of type_expr * bool
 
    The functions [free_variables] and [free_variables_list] below receive
    a typing environment as an optional [?env] parameter and set [really_closed]
-   accordingly.
-
-   Both functions also drop the type/row information returns a [variable list].
+   accordingly. Both drop the type/row information, returning a [variable list].
  *)
 let rec free_vars_iter f really_closed real ty =
   if try_mark_node ty then

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -531,25 +531,23 @@ let remove_mode_and_layout_variables ty =
 
 exception Non_closed of type_expr * bool
 
-(* [free_vars_rec] collects the variables of the input type
-   expression into the [free_variables] reference. It is used for
-   several different things in the type-checker, with the following
-   bells and whistles:
+(* [free_vars_iter] iterates over free vars in the input type. It is used for
+   several different things in the type-checker, with the following bells and
+   whistles:
    - If [really_closed] is Some typing environment, types in the environment
      are expanded to check whether the apparently-free variable would vanish
      during expansion.
-   - We collect both type variables and row variables, paired with a boolean
-     that is [true] if we have a row variable.
+   - The iterator function is passed both the type variables and row variables,
+     paired with a boolean that is [true] if we have a row variable.
    - We do not count "virtual" free variables -- free variables stored in
      the abbreviation of an object type that has been expanded (we store
      the abbreviations for use when displaying the type).
 
-   The functions [free_vars] and [free_variables] below receive
-   a typing environment as an optional [?env] parameter and
-   set [really_closed] accordingly.
-   [free_vars] returns a [(variable * bool) list], while
-   [free_variables] drops the type/row information
-   and only returns a [variable list].
+   The functions [free_variables] and [free_variables_list] below receive
+   a typing environment as an optional [?env] parameter and set [really_closed]
+   accordingly.
+
+   Both functions also drop the type/row information returns a [variable list].
  *)
 let rec free_vars_iter f really_closed real ty =
   if try_mark_node ty then

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -435,6 +435,9 @@ val nongen_class_declaration: class_declaration -> bool
 
 val free_variables: ?env:Env.t -> type_expr -> type_expr list
         (* If env present, then check for incomplete definitions too *)
+val free_variables_list: ?env:Env.t -> type_expr list -> type_expr list
+        (* Union of all free variables in a list of types.
+           If env present, then check for incomplete definitions too *)
 val closed_type_decl: type_declaration -> type_expr option
 val closed_extension_constructor: extension_constructor -> type_expr option
 val closed_class:

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1592,9 +1592,7 @@ let transl_extension_constructor ~scope env type_path type_params
         end;
         (* Remove "_" names from parameters used in the constructor *)
         if not cdescr.cstr_generalized then begin
-          let vars =
-            Ctype.free_variables (Btype.newgenty (Ttuple (List.map fst args)))
-          in
+          let vars = Ctype.free_variables_list (List.map fst args) in
           List.iter
             (fun ty ->
               match get_desc ty with

--- a/ocaml/typing/typedecl_variance.ml
+++ b/ocaml/typing/typedecl_variance.ml
@@ -192,8 +192,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
                                                         (c,n,i)))))
       params required;
     (* Check propagation from constrained parameters *)
-    let args = Btype.newgenty (Ttuple params) in
-    let fvl = Ctype.free_variables args in
+    let fvl = Ctype.free_variables_list params in
     let fvl =
       List.filter (fun v -> not (List.exists (eq_type v) params)) fvl in
     (* If there are no extra variables there is nothing to do *)


### PR DESCRIPTION
(Both #1518 and #1519 attempt to fix the same problem. See the last paragraph for how the behavior of this refactor differs)

The motivation for this change is similar to #1503's: we sometimes collect all free variables in a list of types `tyl` by passing a fake `TTuple` to `Ctype.free_variables`, as in `Ctype.free_variables (Btype.newgenty (Ttuple tyl))`.

However, this is fragile to changes in tuples, and in particular, becomes messy when [adding labeled tuples](https://github.com/ocaml-flambda/flambda-backend/pull/1502): the above would become `Ctype.free_variables (Btype.newgenty (Ttuple (List.map (fun t -> None, t) tyl)))`.

This refactor also allows `Ctype.closed_type` to return earlier, raising `Non_closed` for the first free variable found rather than the last (this should be the only externally-noticeable change in behavior - if we want, we could just re-collect the entire list and raise the last instead).