### PR TITLE
Uninterruptible regions

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -51,6 +51,7 @@ method! class_of_operation op =
   | Iintop _ | Iintop_imm _ | Iintop_atomic _
   | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _ | Iopaque
   | Ibeginregion | Iendregion | Ipoll _
+  | Ibegin_uninterruptible | Iend_uninterruptible
     -> super#class_of_operation op
 
 end

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -349,7 +349,9 @@ let record_frame_label live dbg =
       | {typ = Val; loc = Stack s} as reg ->
           live_offset := slot_offset s (register_class reg) :: !live_offset
       | {typ = Addr} as r ->
-          Misc.fatal_error ("bad GC root " ^ Reg.name r)
+          Misc.fatal_errorf "bad GC root %s at %a" (Reg.name r)
+            Debuginfo.print_compact
+            (Emitaux.debuginfo_of_frame_debuginfo dbg)
       | _ -> ()
     )
     live;
@@ -1254,6 +1256,7 @@ let emit_instr fallthrough i =
       I.mov (domain_field Domainstate.Domain_local_sp) (res i 0)
   | Lop(Iendregion) ->
       I.mov (arg i 0) (domain_field Domainstate.Domain_local_sp)
+  | Lop (Ibegin_uninterruptible | Iend_uninterruptible) -> ()
   | Lop (Iname_for_debugger _) -> ()
   | Lop (Iprobe { enabled_at_init; _ }) ->
     let probe_label = new_label () in

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -370,7 +370,8 @@ let destroyed_at_oper = function
        | Iname_for_debugger _ | Iprobe _| Iprobe_is_enabled _ | Iopaque)
   | Iend | Ireturn _ | Iifthenelse (_, _, _) | Icatch (_, _, _, _)
   | Iexit _ | Iraise _
-  | Iop(Ibeginregion | Iendregion)
+  | Iop(Ibeginregion | Iendregion | Ibegin_uninterruptible
+      | Iend_uninterruptible)
     ->
     if fp then
 (* prevent any use of the frame pointer ! *)
@@ -421,6 +422,8 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | Opaque
        | Begin_region
        | End_region
+       | Begin_uninterruptible
+       | End_uninterruptible
        | Specific (Ilea _ | Istore_int _ | Ioffset_loc _
                   | Ifloatarithmem _ | Ibswap _ | Isqrtf
                   | Ifloatsqrtf _ | Ifloat_iround
@@ -508,7 +511,7 @@ let safe_register_pressure = function
   | Iintop _ | Iintop_imm (_, _) | Iintop_atomic _
   | Ispecific _ | Iname_for_debugger _
   | Iprobe _ | Iprobe_is_enabled _ | Iopaque
-  | Ibeginregion | Iendregion
+  | Ibeginregion | Iendregion | Ibegin_uninterruptible | Iend_uninterruptible
     -> if fp then 10 else 11
 
 let max_register_pressure =
@@ -552,7 +555,8 @@ let max_register_pressure =
              | Ioffset_loc (_, _) | Ifloatarithmem (_, _)
              | Ibswap _ | Ifloatsqrtf _ | Isqrtf)
   | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _ | Iopaque
-  | Ibeginregion | Iendregion
+  | Ibeginregion | Iendregion | Ibegin_uninterruptible
+  | Iend_uninterruptible
     -> consumes ~int:0 ~float:0
 
 (* Layout of the stack frame *)
@@ -592,6 +596,7 @@ let operation_supported = function
   | Craise _
   | Ccheckbound
   | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cbeginregion | Cendregion
+  | Cbegin_uninterruptible | Cend_uninterruptible
     -> true
 
 let trap_size_in_bytes = 16

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -194,7 +194,8 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
   | Op (Intop_atomic _)
   | Op (Move | Spill | Reload | Negf | Absf | Const_float _ | Compf _ | Stackoffset _
        | Load _ | Store _ | Name_for_debugger _ | Probe_is_enabled _
-       | Valueofint | Intofvalue | Opaque | Begin_region | End_region )
+       | Valueofint | Intofvalue | Opaque | Begin_region | End_region
+       | Begin_uninterruptible | End_uninterruptible)
   | Op (Specific (Isqrtf | Isextend32 | Izextend32 | Ilea _
                  | Istore_int (_, _, _)
                  | Ioffset_loc (_, _) | Ifloatarithmem (_, _)

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -184,6 +184,7 @@ method! reload_operation op arg res =
   | Istore (_, _, _)|Ialloc _|Iname_for_debugger _|Iprobe _|Iprobe_is_enabled _
   | Ivalueofint | Iintofvalue | Iopaque
   | Ibeginregion | Iendregion | Ipoll _
+  | Ibegin_uninterruptible | Iend_uninterruptible
     -> (* Other operations: all args and results in registers,
           except moves and probes. *)
       super#reload_operation op arg res

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -175,6 +175,7 @@ let pseudoregs_for_operation op arg res =
   | Iextcall _|Istackoffset _|Iload (_, _, _) | Istore (_, _, _)|Ialloc _
   | Iname_for_debugger _|Iprobe _|Iprobe_is_enabled _ | Iopaque
   | Ibeginregion | Iendregion | Ipoll _
+  | Ibegin_uninterruptible | Iend_uninterruptible
     -> raise Use_default
 
 let select_locality (l : Cmm.prefetch_temporal_locality_hint)

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -272,6 +272,8 @@ let dump_op ppf = function
   | Begin_region -> Format.fprintf ppf "beginregion"
   | End_region -> Format.fprintf ppf "endregion"
   | Name_for_debugger _ -> Format.fprintf ppf "name_for_debugger"
+  | Begin_uninterruptible -> Format.fprintf ppf "begin_uninterruptible"
+  | End_uninterruptible -> Format.fprintf ppf "end_uninterruptible"
 
 let dump_basic ppf (basic : basic) =
   let open Format in
@@ -477,6 +479,8 @@ let is_pure_operation : operation -> bool = function
     assert (not (Arch.operation_can_raise s));
     Arch.operation_is_pure s
   | Name_for_debugger _ -> true
+  | Begin_uninterruptible -> false
+  | End_uninterruptible -> false
 
 let is_pure_basic : basic -> bool = function
   | Op op -> is_pure_operation op
@@ -516,7 +520,8 @@ let is_noop_move instr =
       | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Negf | Absf | Addf
       | Subf | Mulf | Divf | Compf _ | Floatofint | Intoffloat | Opaque
       | Valueofint | Intofvalue | Probe_is_enabled _ | Specific _
-      | Name_for_debugger _ | Begin_region | End_region )
+      | Name_for_debugger _ | Begin_region | End_region | Begin_uninterruptible
+      | End_uninterruptible )
   | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
     false
 

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -95,6 +95,8 @@ module S = struct
           provenance : unit option;
           is_assignment : bool
         }
+    | Begin_uninterruptible
+    | End_uninterruptible
 
   type bool_test =
     { ifso : Label.t;  (** if test is true goto [ifso] label *)

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -38,6 +38,8 @@ let from_basic (basic : basic) : Linear.instruction_desc =
       | Specific op -> Ispecific op
       | Begin_region -> Ibeginregion
       | End_region -> Iendregion
+      | Begin_uninterruptible -> Ibegin_uninterruptible
+      | End_uninterruptible -> Iend_uninterruptible
       | Name_for_debugger { ident; which_parameter; provenance; is_assignment }
         ->
         Iname_for_debugger { ident; which_parameter; provenance; is_assignment }

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -225,6 +225,8 @@ let basic_or_terminator_of_operation :
   | Iprobe_is_enabled { name } -> Basic (Op (Probe_is_enabled { name }))
   | Ibeginregion -> Basic (Op Begin_region)
   | Iendregion -> Basic (Op End_region)
+  | Ibegin_uninterruptible -> Basic (Op Begin_uninterruptible)
+  | Iend_uninterruptible -> Basic (Op End_uninterruptible)
 
 let float_test_of_float_comparison :
     Cmm.float_comparison ->
@@ -673,7 +675,8 @@ module Stack_offset_and_exn = struct
         | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Negf
         | Absf | Addf | Subf | Mulf | Divf | Compf _ | Floatofint | Intoffloat
         | Valueofint | Csel _ | Intofvalue | Probe_is_enabled _ | Opaque
-        | Begin_region | End_region | Specific _ | Name_for_debugger _ )
+        | Begin_region | End_region | Specific _ | Name_for_debugger _
+        | Begin_uninterruptible | End_uninterruptible )
     | Reloadretaddr | Prologue ->
       stack_offset, traps
 

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -637,7 +637,9 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
       then
         terminator_fallthrough (fun label_after ->
             Specific_can_raise { op; label_after })
-      else basic (Specific op))
+      else basic (Specific op)
+    | Ibegin_uninterruptible -> basic Begin_uninterruptible
+    | Iend_uninterruptible -> basic End_uninterruptible)
 
 let run (f : Linear.fundecl) ~preserve_orig_labels =
   let t =

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -944,7 +944,7 @@ end = struct
       assert (not (Mach.operation_can_raise op));
       next
     | Istackoffset _ | Iprobe_is_enabled _ | Iopaque | Ibeginregion | Iendregion
-    | Iintop_atomic _ ->
+    | Ibegin_uninterruptible | Iend_uninterruptible | Iintop_atomic _ ->
       assert (not (Mach.operation_can_raise op));
       next
     | Istore _ ->

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -221,6 +221,7 @@ and operation =
   | Cprobe_is_enabled of { name: string }
   | Copaque
   | Cbeginregion | Cendregion
+  | Cbegin_uninterruptible | Cend_uninterruptible
 
 type kind_for_unboxing =
   | Any

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -223,6 +223,7 @@ and operation =
   | Cprobe_is_enabled of { name: string }
   | Copaque (* Sys.opaque_identity *)
   | Cbeginregion | Cendregion
+  | Cbegin_uninterruptible | Cend_uninterruptible
 
 (* This is information used exclusively during construction of cmm terms by
    cmmgen, and thus irrelevant for selectgen and flambda2. *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4377,3 +4377,7 @@ let kind_of_layout (layout : Lambda.layout) =
   | Pvalue (Pgenval | Pintval | Pvariant _ | Parrayval _)
   | Ptop | Pbottom | Punboxed_float | Punboxed_int _ ->
     Any
+
+let begin_uninterruptible ~dbg = Cop (Cbegin_uninterruptible, [], dbg)
+
+let end_uninterruptible ~dbg e = Cop (Cend_uninterruptible, [e], dbg)

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1282,3 +1282,7 @@ val machtype_of_layout : Lambda.layout -> machtype
 val machtype_of_layout_changing_tagged_int_to_val : Lambda.layout -> machtype
 
 val make_tuple : expression list -> expression
+
+val begin_uninterruptible : dbg:Debuginfo.t -> expression
+
+val end_uninterruptible : dbg:Debuginfo.t -> expression -> expression

--- a/backend/comballoc.ml
+++ b/backend/comballoc.ml
@@ -72,6 +72,7 @@ let rec combine i allocstate =
       end
   | Iop(Icall_ind | Icall_imm _ | Iextcall _ |
         Itailcall_ind | Itailcall_imm _ | Ipoll _ | Iprobe _ |
+        Ibegin_uninterruptible | Iend_uninterruptible |
         Iintop Icheckbound | Iintop_imm (Icheckbound, _)) ->
       let newnext = combine_restart i.next in
       (instr_cons_debug i.desc i.arg i.res i.dbg newnext,

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -117,6 +117,12 @@ type frame_debuginfo =
   | Dbg_raise of Debuginfo.t
   | Dbg_other of Debuginfo.t
 
+let debuginfo_of_frame_debuginfo frame_dbg =
+  match frame_dbg with
+  | Dbg_alloc [] -> Debuginfo.none
+  | Dbg_alloc ({ alloc_dbg; _} :: _) -> alloc_dbg
+  | Dbg_raise dbg | Dbg_other dbg -> dbg
+
 type frame_descr =
   { fd_lbl: int;                        (* Return address *)
     fd_frame_size: int;                 (* Size of stack frame *)

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -51,6 +51,8 @@ type frame_debuginfo =
   | Dbg_raise of Debuginfo.t
   | Dbg_other of Debuginfo.t
 
+val debuginfo_of_frame_debuginfo : frame_debuginfo -> Debuginfo.t
+
 val record_frame_descr :
   label:int ->              (* Return address *)
   frame_size:int ->         (* Size of stack frame *)

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -82,6 +82,7 @@ type operation =
   | Iprobe of { name: string; handler_code_sym: string; enabled_at_init: bool; }
   | Iprobe_is_enabled of { name: string }
   | Ibeginregion | Iendregion
+  | Ibegin_uninterruptible | Iend_uninterruptible
 
 type instruction =
   { desc: instruction_desc;
@@ -185,7 +186,8 @@ let rec instr_iter f i =
             | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue
             | Ispecific _ | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _
             | Iopaque
-            | Ibeginregion | Iendregion | Ipoll _) ->
+            | Ibeginregion | Iendregion | Ipoll _
+            | Ibegin_uninterruptible | Iend_uninterruptible) ->
         instr_iter f i.next
 
 let operation_is_pure = function
@@ -195,6 +197,7 @@ let operation_is_pure = function
   (* Conservative to ensure valueofint/intofvalue are not eliminated before emit. *)
   | Ivalueofint | Iintofvalue | Iintop_atomic _ -> false
   | Ibeginregion | Iendregion -> false
+  | Ibegin_uninterruptible | Iend_uninterruptible -> false
   | Iprobe _ -> false
   | Iprobe_is_enabled _-> true
   | Ispecific sop -> Arch.operation_is_pure sop
@@ -230,6 +233,7 @@ let operation_can_raise op =
   | Istackoffset _ | Istore _  | Iload (_, _, _) | Iname_for_debugger _
   | Itailcall_imm _ | Itailcall_ind
   | Iopaque | Ibeginregion | Iendregion
+  | Ibegin_uninterruptible | Iend_uninterruptible
   | Iprobe_is_enabled _ | Ialloc _ | Ipoll _
     -> false
 

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -92,6 +92,7 @@ type operation =
   | Iprobe of { name: string; handler_code_sym: string; enabled_at_init: bool; }
   | Iprobe_is_enabled of { name: string }
   | Ibeginregion | Iendregion
+  | Ibegin_uninterruptible | Iend_uninterruptible
 
 type instruction =
   { desc: instruction_desc;

--- a/backend/polling.ml
+++ b/backend/polling.ml
@@ -247,7 +247,8 @@ let find_poll_alloc_or_calls instr =
             Ifloatofint | Iintoffloat | Inegf | Iabsf | Iaddf | Isubf |
             Imulf | Idivf | Iopaque | Ispecific _ | Ibeginregion | Iendregion |
             Icsel _ | Icompf _ | Iname_for_debugger _ | Iprobe _ |
-            Iprobe_is_enabled _ | Ivalueofint | Iintofvalue)-> None
+            Iprobe_is_enabled _ | Ivalueofint | Iintofvalue |
+            Ibegin_uninterruptible | Iend_uninterruptible)-> None
       | Iend | Ireturn _ | Iifthenelse _ | Iswitch _ | Icatch _ | Iexit _ |
         Itrywith _ | Iraise _ -> None
     in

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -238,6 +238,8 @@ let operation d = function
   | Copaque -> "opaque"
   | Cbeginregion -> "beginregion"
   | Cendregion -> "endregion"
+  | Cbegin_uninterruptible -> "begin_uninterruptible"
+  | Cend_uninterruptible -> "end_uninterruptible"
 
 
 let rec expr ppf = function

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -240,6 +240,8 @@ let operation' ?(print_reg = reg) op arg ppf res =
   | Iprobe {name;handler_code_sym} ->
     fprintf ppf "probe \"%s\" %s %a" name handler_code_sym regs arg
   | Iprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled \"%s\"" name
+  | Ibegin_uninterruptible -> fprintf ppf "begin_uninterruptible"
+  | Iend_uninterruptible -> fprintf ppf "end_uninterruptible"
 
 let operation op arg ppf res = operation' op arg ppf res
 

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -39,6 +39,8 @@ let precondition : Cfg_with_layout.t -> unit =
       | Opaque -> ()
       | Begin_region -> ()
       | End_region -> ()
+      | Begin_uninterruptible -> ()
+      | End_uninterruptible -> ()
       | Specific op ->
         if Arch.operation_can_raise op
         then

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -133,6 +133,8 @@ let is_move_basic : Cfg.basic -> bool =
     | Opaque -> false
     | Begin_region -> false
     | End_region -> false
+    | Begin_uninterruptible -> false
+    | End_uninterruptible -> false
     | Specific _ -> false
     | Name_for_debugger _ -> false)
   | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> false

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -168,6 +168,8 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pgetpredef _
   | Parray_to_iarray
   | Parray_of_iarray
+  | Pbegin_uninterruptible
+  | Pend_uninterruptible
     ->
       Misc.fatal_errorf "lambda primitive %a can't be converted to \
                          clambda primitive"

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -750,7 +750,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _
       | Pint_as_pointer | Popaque _ | Pprobe_is_enabled _ | Pobj_dup
       | Pobj_magic _ | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
-        ->
+      | Pbegin_uninterruptible | Pend_uninterruptible ->
         (* Inconsistent with outer match *)
         assert false
     in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -983,7 +983,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pbigstring_set_64 true
   | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer | Popaque _
   | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _ | Pbox_float _ | Punbox_float
-  | Punbox_int _ | Pbox_int _ ->
+  | Punbox_int _ | Pbox_int _ | Pbegin_uninterruptible | Pend_uninterruptible ->
     false
 
 type cps_continuation =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1232,6 +1232,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Pprobe_is_enabled { name }, [] ->
     [tag_int (Nullary (Probe_is_enabled { name }))]
   | Pobj_dup, [[v]] -> [Unary (Obj_dup, v)]
+  | Pbegin_uninterruptible, [[_unit]] -> [Nullary Begin_uninterruptible]
+  | Pend_uninterruptible, [[v]] -> [Unary (End_uninterruptible, v)]
   | ( ( Pmodint Unsafe
       | Pdivbint { is_safe = Unsafe; size = _; mode = _ }
       | Pmodbint { is_safe = Unsafe; size = _; mode = _ }
@@ -1248,13 +1250,19 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
        %a (%a)"
       Printlambda.primitive prim H.print_list_of_simple_or_prim
       (List.flatten args)
+  | Pbegin_uninterruptible, ([] | [[]] | [_ :: _] | _ :: _) ->
+    Misc.fatal_errorf
+      "Closure_conversion.convert_primitive: Wrong arity for nullary primitive \
+       %a (%a)"
+      Printlambda.primitive prim H.print_list_of_simple_or_prim
+      (List.flatten args)
   | ( ( Pfield _ | Pnegint | Pnot | Poffsetint _ | Pintoffloat | Pfloatofint _
       | Pnegfloat _ | Pabsfloat _ | Pstringlength | Pbyteslength | Pbintofint _
       | Pintofbint _ | Pnegbint _ | Popaque _ | Pduprecord _ | Parraylength _
       | Pduparray _ | Pfloatfield _ | Pcvtbint _ | Poffsetref _ | Pbswap16
       | Pbbswap _ | Pisint _ | Pint_as_pointer | Pbigarraydim _ | Pobj_dup
       | Pobj_magic _ | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
-        ),
+      | Pend_uninterruptible ),
       ([] | _ :: _ :: _ | [([] | _ :: _ :: _)]) ) ->
     Misc.fatal_errorf
       "Closure_conversion.convert_primitive: Wrong arity for unary primitive \

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -503,7 +503,8 @@ let init_or_assign env (ia : Flambda_primitive.Init_or_assign.t) :
 let nullop _env (op : Flambda_primitive.nullary_primitive) : Fexpr.nullop =
   match op with
   | Begin_region -> Begin_region
-  | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _ ->
+  | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _
+  | Begin_uninterruptible ->
     Misc.fatal_errorf "TODO: Nullary primitive: %a" Flambda_primitive.print
       (Flambda_primitive.Nullary op)
 
@@ -534,7 +535,8 @@ let unop env (op : Flambda_primitive.unary_primitive) : Fexpr.unop =
   | String_length string_or_bytes -> String_length string_or_bytes
   | Boolean_not -> Boolean_not
   | Int_as_pointer | Duplicate_block _ | Duplicate_array _ | Bigarray_length _
-  | Float_arith _ | Reinterpret_int64_as_float | Is_boxed_float | Obj_dup ->
+  | Float_arith _ | Reinterpret_int64_as_float | Is_boxed_float | Obj_dup
+  | End_uninterruptible ->
     Misc.fatal_errorf "TODO: Unary primitive: %a"
       Flambda_primitive.Without_args.print
       (Flambda_primitive.Without_args.Unary op)

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -49,3 +49,8 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     let ty = T.this_tagged_immediate Targetint_31_63.zero in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
+  | Begin_uninterruptible ->
+    let named = Named.create_prim original_prim dbg in
+    let ty = T.any_value in
+    let dacc = DA.add_variable dacc result_var ty in
+    Simplify_primitive_result.create named ~try_reify:false dacc

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -480,6 +480,12 @@ let simplify_end_region dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
   let dacc = DA.add_variable dacc result_var ty in
   SPR.create original_term ~try_reify:false dacc
 
+let simplify_end_uninterruptible dacc ~original_term ~arg:_ ~arg_ty:_
+    ~result_var =
+  let ty = T.this_tagged_immediate Targetint_31_63.zero in
+  let dacc = DA.add_variable dacc result_var ty in
+  SPR.create original_term ~try_reify:false dacc
+
 let simplify_int_as_pointer dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var K.value ~original_term
 
@@ -635,5 +641,6 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     | Begin_try_region -> simplify_begin_try_region
     | End_region -> simplify_end_region
     | Obj_dup -> simplify_obj_dup dbg
+    | End_uninterruptible -> simplify_end_uninterruptible
   in
   simplifier dacc ~original_term ~arg ~arg_ty ~result_var

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -309,6 +309,7 @@ let nullary_prim_size prim =
   | Probe_is_enabled { name = _ } -> 4
   | Begin_region -> 1
   | Enter_inlined_apply _ -> 0
+  | Begin_uninterruptible -> 0
 
 let unary_prim_size prim =
   match (prim : Flambda_primitive.unary_primitive) with
@@ -336,6 +337,7 @@ let unary_prim_size prim =
   | Begin_try_region -> 1
   | End_region -> 1
   | Obj_dup -> alloc_extcall_size + 1
+  | End_uninterruptible -> 0
 
 let binary_prim_size prim =
   match (prim : Flambda_primitive.binary_primitive) with

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -232,6 +232,7 @@ type nullary_primitive =
   | Enter_inlined_apply of { dbg : Debuginfo.t }
       (** Used in classic mode to denote the start of an inlined function body.
           This is then used in to_cmm to correctly add inlined debuginfo. *)
+  | Begin_uninterruptible
 
 (** Untagged binary integer arithmetic operations.
 
@@ -323,6 +324,7 @@ type unary_primitive =
   | End_region
       (** Ending delimiter of local allocation region, accepting a region name. *)
   | Obj_dup  (** Corresponds to [Obj.dup]; see the documentation in obj.mli. *)
+  | End_uninterruptible
 
 (** Whether a comparison is to yield a boolean result, as given by a particular
     comparison operator, or whether it is to behave in the manner of "compare"

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -442,7 +442,8 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
   | Singleton _, Prim (Nullary (Enter_inlined_apply { dbg }), _) ->
     let env = Env.enter_inlined_apply env dbg in
     expr env res body
-  | Singleton v, Prim ((Unary (End_region, _) as p), dbg) ->
+  | Singleton v, Prim ((Unary (End_region, _) as p), dbg)
+  | Singleton v, Prim ((Nullary Begin_uninterruptible as p), dbg) ->
     (* CR gbury: this is a hack to prevent moving of expressions past an
        End_region. We have to do this manually because we currently have effects
        and coeffects that are not precise enough. Particularly, an immutable
@@ -451,6 +452,7 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
        including must_inline bindings, particularly projections that may project
        from locally allocated closures (and that must not be moved past an
        end_region). *)
+    (* The hack now applies for [Begin_uninterruptible] too. *)
     let wrap, env, res =
       Env.flush_delayed_lets ~mode:Flush_everything env res
     in

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -520,6 +520,7 @@ let nullary_primitive _env res dbg prim =
     let expr = Cmm.Cop (Cprobe_is_enabled { name }, [], dbg) in
     None, res, expr
   | Begin_region -> None, res, C.beginregion ~dbg
+  | Begin_uninterruptible -> None, res, C.begin_uninterruptible ~dbg
   | Enter_inlined_apply _ ->
     Misc.fatal_errorf
       "The primitive [Enter_inlined_apply] should not be translated by \
@@ -630,6 +631,8 @@ let unary_primitive env res dbg f arg =
     None, res, C.eq ~dbg (C.get_tag arg dbg) (C.floatarray_tag dbg)
   | Begin_try_region -> None, res, C.beginregion ~dbg
   | End_region -> None, res, C.return_unit dbg (C.endregion ~dbg arg)
+  | End_uninterruptible ->
+    None, res, C.return_unit dbg (C.end_uninterruptible ~dbg arg)
 
 let binary_primitive env dbg f x y =
   match (f : P.binary_primitive) with

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -314,6 +314,10 @@ let punbox_int = "Punbox_int"
 let pbox_int = "Pbox_int"
 let punbox_int_arg = "Punbox_int_arg"
 let pbox_int_arg = "Pbox_int_arg"
+let pbegin_uninterruptible = "Pbegin_uninterruptible"
+let pend_uninterruptible = "Pend_uninterruptible"
+let pbegin_uninterruptible_arg = "Pbegin_uninterruptible_arg"
+let pend_uninterruptible_arg = "Pend_uninterruptible_arg"
 
 let anon_fn_with_loc (sloc: Lambda.scoped_location) =
   let loc = Debuginfo.Scoped_location.to_location sloc in
@@ -439,6 +443,8 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbox_int _ -> pbox_int
   | Parray_of_iarray -> parray_of_iarray
   | Parray_to_iarray -> parray_to_iarray
+  | Pbegin_uninterruptible -> pbegin_uninterruptible
+  | Pend_uninterruptible -> pend_uninterruptible
 
 let of_primitive_arg : Lambda.primitive -> string = function
   | Pbytes_of_string -> pbytes_of_string_arg
@@ -553,3 +559,5 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbox_int _ -> pbox_int_arg
   | Parray_of_iarray -> parray_of_iarray_arg
   | Parray_to_iarray -> parray_to_iarray_arg
+| Pbegin_uninterruptible -> pbegin_uninterruptible_arg
+| Pend_uninterruptible -> pend_uninterruptible_arg

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -137,7 +137,8 @@ let preserve_tailcall_for_prim = function
   | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
   | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
   | Pprobe_is_enabled _ | Pobj_dup
-  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer ->
+  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer
+  | Pbegin_uninterruptible | Pend_uninterruptible ->
       false
 
 (* Add a Kpop N instruction in front of a continuation *)
@@ -544,6 +545,7 @@ let comp_primitive p args =
   | Pmakefloatblock _
   | Pprobe_is_enabled _
   | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
+  | Pbegin_uninterruptible | Pend_uninterruptible
     ->
       fatal_error "Bytegen.comp_primitive"
 
@@ -718,6 +720,8 @@ let rec comp_expr env exp sz cont =
         comp_init env sz decl_size
       end
   | Lprim((Popaque _ | Pobj_magic _), [arg], _) ->
+      comp_expr env arg sz cont
+  | Lprim((Pbegin_uninterruptible | Pend_uninterruptible), [arg], _) ->
       comp_expr env arg sz cont
   | Lprim((Pbox_float _ | Punbox_float), [arg], _) ->
       comp_expr env arg sz cont

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -246,6 +246,8 @@ type primitive =
   (* Jane Street extensions *)
   | Parray_to_iarray
   | Parray_of_iarray
+  | Pbegin_uninterruptible
+  | Pend_uninterruptible
 
 and integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge
@@ -1409,6 +1411,7 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pobj_magic _ -> None
   | Punbox_float | Punbox_int _ -> None
   | Pbox_float m | Pbox_int (_, m) -> Some m
+  | Pbegin_uninterruptible | Pend_uninterruptible -> None
 
 let constant_layout = function
   | Const_int _ | Const_char _ -> Pvalue Pintval
@@ -1503,6 +1506,7 @@ let primitive_result_layout (p : primitive) =
       (* CR ncourant: use an unboxed int64 here when it exists *)
       layout_any_value
   | (Parray_to_iarray | Parray_of_iarray) -> layout_any_value
+  | Pbegin_uninterruptible | Pend_uninterruptible -> layout_any_value
 
 let compute_expr_layout free_vars_kind lam =
   let rec compute_expr_layout kinds = function

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -199,6 +199,8 @@ type primitive =
                         one; O(1) *)
   | Parray_of_iarray (* Unsafely reinterpret an immutable array as a mutable
                         one; O(1) *)
+  | Pbegin_uninterruptible
+  | Pend_uninterruptible
 
 and integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -477,6 +477,8 @@ let primitive ppf = function
 
   | Parray_to_iarray -> fprintf ppf "array_to_iarray"
   | Parray_of_iarray -> fprintf ppf "array_of_iarray"
+  | Pbegin_uninterruptible -> fprintf ppf "begin_uninterruptible"
+  | Pend_uninterruptible -> fprintf ppf "end_uninterruptible"
 
 let name_of_primitive = function
   | Pbytes_of_string -> "Pbytes_of_string"
@@ -591,6 +593,8 @@ let name_of_primitive = function
   | Pbox_int _ -> "Pbox_int"
   | Parray_of_iarray -> "Parray_of_iarray"
   | Parray_to_iarray -> "Parray_to_iarray"
+  | Pbegin_uninterruptible -> "Pbegin_uninterruptible"
+  | Pend_uninterruptible -> "Pend_uninterruptible"
 
 let check_attribute ppf check =
   let check_property = function

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -921,6 +921,7 @@ let rec choice ctx t =
     | Pbswap16
     | Pbbswap _
     | Pint_as_pointer
+    | Pbegin_uninterruptible | Pend_uninterruptible
       ->
         let primargs = traverse_list ctx primargs in
         Choice.lambda (Lprim (prim, primargs, loc))

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -415,6 +415,8 @@ let lookup_primitive loc poly pos p =
     | "%obj_magic" -> Primitive(Pobj_magic Lambda.layout_any_value, 1)
     | "%array_to_iarray" -> Primitive (Parray_to_iarray, 1)
     | "%array_of_iarray" -> Primitive (Parray_of_iarray, 1)
+    | "%begin_uninterruptible" -> Primitive (Pbegin_uninterruptible, 1)
+    | "%end_uninterruptible" -> Primitive (Pend_uninterruptible, 1)
     | s when String.length s > 0 && s.[0] = '%' ->
        raise(Error(loc, Unknown_builtin_primitive s))
     | _ -> External p
@@ -962,7 +964,8 @@ let lambda_primitive_needs_event_after = function
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisout
   | Pprobe_is_enabled _
   | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque _
-  | Pobj_magic _ | Punbox_float | Punbox_int _  -> false
+  | Pobj_magic _ | Punbox_float | Punbox_int _
+  | Pbegin_uninterruptible | Pend_uninterruptible -> false
 
 (* Determine if a primitive should be surrounded by an "after" debug event *)
 let primitive_needs_event_after = function


### PR DESCRIPTION
This has arisen from discussions about the recent change to allow more code motion of allocations in flambda2 (#1435), which allows better placement of boxing operations without complicated compiler changes.  We think some kind of barrier should be provided so that code involving non-interruptible "atomic" sections can be guaranteed not to contain safepoints, in particular those potentially introduced by this code motion.  There are various places in the JS tree which involve these sections and we've had to check them carefully following the flambda2 change.  Instead of having a block-structured construct, which is complicated to translate in the middle end, and also inadequate for certain use cases (in particular where the atomic section starts prior to a conditional but only extends into one of the branches) we propose instead having separate primitives.  (This work may also help with the safepoints transition.)

The idea is that `%begin_uninterruptible` will return a variable of a new kind, analogous to the way that in flambda2, the begin-region primitive returns a variable of `Region` kind.  (This front- and middle-end kinding is not yet implemented in this PR, but should be easy to write in flambda-backend based on the unboxed types work.)  The user's code then passes the variable to `%end_uninterruptible`.  All code in between (including the whole body of a loop if e.g. the begin primitive is prior to a loop and the end primitive is inside) will be checked to ensure there are no safe points.  Furthermore, any code motion optimisations are blocked.  In flambda2 the new `Begin_interruptible` barrier is as strong as `End_region` currently is.

We can probably allow function parameters of the new kind as well, which might be useful for passing witnesses of non-interruptability around in some way.

The checking is done using a trick: the return value of the begin primitive is given machtype `Addr`.  This ensures that the existing check when emitting frametables will catch any cases where a safe point occurs inside one of these regions.  We could do something like emitting a proper error instead of a fatal error if we have seen that the primitives have been used in the current function or file.

There is no implementation here for Closure or flambda1 yet, but this will be straightforward.

One problem relates to publicly-released JS code that might start relying on these barriers.  They can't just be erased in the way that we do for e.g. `%obj_magic` (as this would mean that building the code with flambda-backend could produce incorrect results).  Furthermore, upstreaming the compiler patch will be problematic for a while, as it's going to end up relying on the new kinding support introduced for unboxed types.  However we could probably use the "builtin" mechanisms, that recognise external calls to C functions, instead.  Identity C stubs could be provided, but if the code were compiled with an flambda-backend compiler, the barriers would come into effect.  This does make us wonder whether the recognition of builtins should be moved before the middle end (this would allow other optimizations as well).

Here is an example:
```
type uninterruptible  (* eventually of a new kind *)

external begin_uninterruptible : unit -> uninterruptible
  = "%begin_uninterruptible"

external end_uninterruptible : uninterruptible -> unit
  = "%end_uninterruptible"

type t = { mutable i : int option }

let[@inline] atomic t n i =
  if n < 0 then (
    t.i <- i
  )
  else (
    t.i <- Some n
  )

let foo n =
  let t = { i = None; } in
  let i = Some (n + 1) in (* sinking will be blocked by begin_uninterruptible *)
  atomic t n i;
  t
```
With flambda2, the `Some (n + 1)` will be sunk down all the way to the `t.i <- i` line; it goes past the conditional because `i` is linearly used (across both branches of the conditional):
```
(function{i.ml:23,8-139} camlI__foo_1_3_code (n99/312: int)
 (let t100/313 (alloc{i.ml:24,10-23} 1024 1)
   (catch
     (if (< n99/312 1)
       (let
         Psetfield106/319
           (seq
             (extcall "caml_modify"{i.ml:26,2-14;i.ml:13,16-67} t100/313
               (alloc{i.ml:25,10-22} 1024 (+ n99/312 2)) ->unit)  ; allocation sunk down
             1 1)
         (exit 2))
       (let
         Psetfield105/318
           (seq
             (extcall "caml_modify"{i.ml:26,2-14;i.ml:17,7-108} t100/313
               (alloc{i.ml:26,2-14;i.ml:19,11-17} 1024 n99/312) ->unit)
             1 1)
         (exit 2)))
   with(2) t100/313)))
```
Adding a non-interruptible section stops this:
```
let[@inline] atomic t n i =
  let id = begin_uninterruptible () in
  if n < 0 then (
    t.i <- i;
    end_uninterruptible id
  )
  else (
    t.i <- Some n
  )

let foo n =
  let t = { i = None; } in
  let i = Some (n + 1) in
  atomic t n i;
  t
```
by compiling to:
```
(function{i.ml:23,8-139} camlI__foo_1_3_code (n107/316: int)
 (let t108/317 (alloc{i.ml:24,10-23} 1024 1)
   (catch
     (let
       (i110/319 (alloc{i.ml:25,10-22} 1024 (+ n107/316 2))   ; allocation stays here
        id111/320 (begin_uninterruptable))
       (if (< n107/316 1)
         (let
           (Psetfield115/324
              (seq
                (extcall "caml_modify"{i.ml:26,2-14;i.ml:14,4-12} t108/317
                  i110/319 ->unit)
                1 1)
            Pend_uninterruptable116/325
              (seq (end_uninterruptable id111/320) 1))
           (exit 2))
         (let
           Psetfield114/323
             (seq
               (extcall "caml_modify"{i.ml:26,2-14;i.ml:17,7-108} t108/317
                 (alloc{i.ml:26,2-14;i.ml:19,11-17} 1024 n107/316) ->unit)
               1 1)
           (exit 2))))
   with(2) t108/317)))
```
We can then test the check itself by changing the code thus:
```
let[@inline] atomic t n i =
  let id = begin_uninterruptible () in
  if n < 0 then (
    t.i <- i;
    end_uninterruptible id
  )
  else (
    let id = begin_uninterruptible () in
    t.i <- Some n;  (* not allowed! *)
    end_uninterruptible id
  )

let foo n =
  let t = { i = None; } in
  let i = Some (n + 1) in
  atomic t n i;
  t
```
which produces:
```
(function{i.ml:11,20-229} camlI__atomic_0_2_code
     (t101/308: val n102/309: int i103/310: val)
 (let id104/311 (begin_uninterruptable)
   (if (< n102/309 1)
     (let
       (Psetfield110/317
          (seq (extcall "caml_modify"{i.ml:14,4-12} t101/308 i103/310 ->unit)
            1 1)
        Pend_uninterruptable111/318 (seq (end_uninterruptable id104/311) 1))
       1)
     (let
       (id106/313 (begin_uninterruptable)
        Psetfield108/315
          (seq
            (extcall "caml_modify"{i.ml:19,4-17} t101/308
              (alloc{i.ml:19,11-17} 1024 n102/309) ->unit)
            1 1)
        Pend_uninterruptable109/316 (seq (end_uninterruptable id106/313) 1))
       1))))

>> Fatal error: bad GC root id106 at i.ml:19,11--17
```