### PR TITLE
zero_alloc: small cleanup for compiler_hooks

### DIFF
--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -158,10 +158,7 @@ let execute : type a. a pass -> a -> unit =
   | Cfg -> execute_hooks hooks.cfg arg
   | Cmm -> execute_hooks hooks.cmm arg
   | Inlining_tree -> execute_hooks hooks.inlining_tree arg
-  | Check_allocations ->
-    Misc.protect_refs
-      [ Misc.R (Flambda_backend_flags.checkmach_details_cutoff, -1) ]
-      (fun () -> execute_hooks hooks.check_allocations arg)
+  | Check_allocations -> execute_hooks hooks.check_allocations arg
 
 let execute_and_pipe r a = execute r a; a
 


### PR DESCRIPTION
Since witnesses are not always tracked, it is too late to set cutoff here, after checkmach finished. Cutoff will be set externally by the caller of `Compiler_hooks.register Check_allocations`.