### PR TITLE
Cold continuation handlers in flambda2

### DIFF
--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -214,16 +214,16 @@ let insert_move srcs dsts i =
          let i1 = array_fold2 insert_single_move i tmps dsts in
          array_fold2 insert_single_move i1 srcs tmps
 
-let rec split3 = function
-    [] -> ([], [], [])
-  | (x,y,z)::l ->
-    let (rx, ry, rz) = split3 l in (x::rx, y::ry, z::rz)
+let rec split4 = function
+    [] -> ([], [], [], [])
+  | (x,y,z,w)::l ->
+    let (rx, ry, rz, rw) = split4 l in (x::rx, y::ry, z::rz, w::rw)
 
-let rec combine3 l1 l2 l3 =
-  match (l1, l2, l3) with
-    ([], [], []) -> []
-  | (a1::l1, a2::l2, a3::l3) -> (a1, a2, a3) :: combine3 l1 l2 l3
-  | (_, _, _) -> invalid_arg "combine3"
+let rec combine4 l1 l2 l3 l4 =
+  match (l1, l2, l3, l4) with
+    ([], [], [], []) -> []
+  | (a1::l1, a2::l2, a3::l3, a4::l4) -> (a1, a2, a3, a4) :: combine4 l1 l2 l3 l4
+  | (_, _, _, _) -> invalid_arg "combine4"
 
 class cse_generic = object (self)
 
@@ -372,9 +372,9 @@ method private cse n i k =
         self#cse empty_numbering i.next (fun next ->
           k { i with desc = Iswitch(index, cases); next; }))
   | Icatch(rec_flag, ts, handlers, body) ->
-      let nfail, t, handler_code = split3 handlers in
+      let nfail, t, handler_code, is_cold = split4 handlers in
       self#cse_list empty_numbering handler_code (fun handler_code ->
-        let handlers = combine3 nfail t handler_code in
+        let handlers = combine4 nfail t handler_code is_cold in
         self#cse n body (fun body ->
           self#cse empty_numbering i.next (fun next ->
             k { i with desc = Icatch(rec_flag, ts, handlers, body); next; })))

--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -84,7 +84,8 @@ and instrument = function
   | Csequence (e1, e2) -> Csequence (instrument e1, instrument e2)
   | Ccatch (isrec, cases, body, kind) ->
      let cases =
-       List.map (fun (nfail, ids, e, dbg) -> nfail, ids, instrument e, dbg)
+       List.map (fun (nfail, ids, e, dbg, is_cold) ->
+           nfail, ids, instrument e, dbg, is_cold)
          cases
      in
      Ccatch (isrec, cases, instrument body, kind)

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -565,7 +565,7 @@ let rec add_blocks :
     | Icatch (_rec, _trap_stack, handlers, body) ->
       let handlers =
         List.map
-          (fun (handler_id, _trap_stack, handler) ->
+          (fun (handler_id, _trap_stack, handler, _is_cold) ->
             let handler_label = State.add_catch_handler state ~handler_id in
             handler_label, handler)
           handlers

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -277,7 +277,7 @@ type expression =
   | Ccatch of
       rec_flag
         * (static_label * (Backend_var.With_provenance.t * machtype) list
-          * expression * Debuginfo.t) list
+          * expression * Debuginfo.t * bool (* is_cold *)) list
         * expression * kind_for_unboxing
   | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
@@ -323,8 +323,8 @@ type phrase =
     Cfunction of fundecl
   | Cdata of data_item list
 
-let ccatch (i, ids, e1, e2, dbg, kind) =
-  Ccatch(Nonrecursive, [i, ids, e2, dbg], e1, kind)
+let ccatch (i, ids, e1, e2, dbg, kind, is_cold) =
+  Ccatch(Nonrecursive, [i, ids, e2, dbg, is_cold], e1, kind)
 
 let reset () =
   label_counter := init_label
@@ -344,7 +344,7 @@ let iter_shallow_tail f = function
       Array.iter (fun (e, _dbg) -> f e) el;
       true
   | Ccatch(_rec_flag, handlers, body, _value_kind) ->
-      List.iter (fun (_, _, h, _dbg) -> f h) handlers;
+      List.iter (fun (_, _, h, _dbg, _) -> f h) handlers;
       f body;
       true
   | Ctrywith(e1, _kind, _id, e2, _dbg, _value_kind) ->
@@ -388,7 +388,9 @@ let map_shallow_tail ?kind f = function
       Cswitch(e, tbl, Array.map (fun (e, dbg) -> f e, dbg) el, dbg',
               Option.value kind ~default:kind_before)
   | Ccatch(rec_flag, handlers, body, kind_before) ->
-      let map_h (n, ids, handler, dbg) = (n, ids, f handler, dbg) in
+      let map_h (n, ids, handler, dbg, is_cold) =
+        (n, ids, f handler, dbg, is_cold)
+      in
       Ccatch(rec_flag, List.map map_h handlers, f body,
              Option.value kind ~default:kind_before)
   | Ctrywith(e1, kind', id, e2, dbg, kind_before) ->
@@ -445,7 +447,7 @@ let iter_shallow f = function
   | Cswitch (_e, _ia, ea, _dbg, _value_kind) ->
       Array.iter (fun (e, _) -> f e) ea
   | Ccatch (_rf, hl, body, _value_kind) ->
-      let iter_h (_n, _ids, handler, _dbg) = f handler in
+      let iter_h (_n, _ids, handler, _dbg, _is_cold) = f handler in
       List.iter iter_h hl; f body
   | Cexit (_n, el, _traps) ->
       List.iter f el
@@ -483,7 +485,9 @@ let map_shallow f = function
   | Cswitch (e, ia, ea, dbg, kind) ->
       Cswitch (e, ia, Array.map (fun (e, dbg) -> f e, dbg) ea, dbg, kind)
   | Ccatch (rf, hl, body, kind) ->
-      let map_h (n, ids, handler, dbg) = (n, ids, f handler, dbg) in
+      let map_h (n, ids, handler, dbg, is_cold) =
+        (n, ids, f handler, dbg, is_cold)
+      in
       Ccatch (rf, List.map map_h hl, f body, kind)
   | Cexit (n, el, traps) ->
       Cexit (n, List.map f el, traps)

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -289,7 +289,7 @@ type expression =
   | Ccatch of
       rec_flag
         * (Lambda.static_label * (Backend_var.With_provenance.t * machtype) list
-          * expression * Debuginfo.t) list
+          * expression * Debuginfo.t * bool (* is_cold *)) list
         * expression
         * kind_for_unboxing
   | Cexit of exit_label * expression list * trap_action list
@@ -340,6 +340,7 @@ type phrase =
 val ccatch :
      label * (Backend_var.With_provenance.t * machtype) list
        * expression * expression * Debuginfo.t * kind_for_unboxing
+       * bool
   -> expression
 
 val reset : unit -> unit

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -774,7 +774,8 @@ let rec remove_unit = function
         kind )
   | Ccatch (rec_flag, handlers, body, kind) ->
     let map_h (n, ids, handler, dbg, is_cold) =
-      n, ids, remove_unit handler, dbg, is_cold in
+      n, ids, remove_unit handler, dbg, is_cold
+    in
     Ccatch (rec_flag, List.map map_h handlers, remove_unit body, kind)
   | Ctrywith (body, kind, exn, handler, dbg, value_kind) ->
     Ctrywith (remove_unit body, kind, exn, remove_unit handler, dbg, value_kind)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -424,7 +424,7 @@ let create_loop body dbg =
   let cont = Lambda.next_raise_count () in
   let call_cont = Cexit (Lbl cont, [], []) in
   let body = Csequence (body, call_cont) in
-  Ccatch (Recursive, [cont, [], body, dbg], call_cont, Any)
+  Ccatch (Recursive, [cont, [], body, dbg, false], call_cont, Any)
 
 (* Turning integer divisions into multiply-high then shift. The
    [division_parameters] function is used in module Emit for those target
@@ -773,7 +773,8 @@ let rec remove_unit = function
         dbg,
         kind )
   | Ccatch (rec_flag, handlers, body, kind) ->
-    let map_h (n, ids, handler, dbg) = n, ids, remove_unit handler, dbg in
+    let map_h (n, ids, handler, dbg, is_cold) =
+      n, ids, remove_unit handler, dbg, is_cold in
     Ccatch (rec_flag, List.map map_h handlers, remove_unit body, kind)
   | Ctrywith (body, kind, exn, handler, dbg, value_kind) ->
     Ctrywith (remove_unit body, kind, exn, remove_unit handler, dbg, value_kind)
@@ -2191,7 +2192,7 @@ module SArgBlocks = struct
         fun body ->
           match body with
           | Cexit (j, _, _) -> if Lbl i = j then handler else body
-          | _ -> ccatch (i, [], body, handler, dbg, kind) ))
+          | _ -> ccatch (i, [], body, handler, dbg, kind, false) ))
 
   let make_exit i = Cexit (Lbl i, [], [])
 end
@@ -2475,7 +2476,8 @@ let cache_public_method meths tag cache dbg =
                     dbg,
                   Ctuple [],
                   dbg,
-                  Any ),
+                  Any,
+                  false ),
               Clet
                 ( VP.create tagged,
                   Cop
@@ -3862,7 +3864,8 @@ let entry_point namelist =
               dbg,
             Ctuple [],
             dbg,
-            Any ) )
+            Any,
+            false ) )
   in
   let fun_name = global_symbol "caml_program" in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
@@ -4151,8 +4154,9 @@ type static_handler =
   * (Backend_var.With_provenance.t * Cmm.machtype) list
   * Cmm.expression
   * Debuginfo.t
+  * bool
 
-let handler ~dbg id vars body = id, vars, body, dbg
+let handler ~dbg id vars body is_cold = id, vars, body, dbg, is_cold
 
 let cexit id args trap_actions = Cmm.Cexit (Cmm.Lbl id, args, trap_actions)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1053,13 +1053,14 @@ val trywith :
 (** Opaque type for static handlers. *)
 type static_handler
 
-(** [handler id vars body] creates a static handler for exit number [id],
+(** [handler id vars body is_cold] creates a static handler for exit number [id],
     binding variables [vars] in [body]. *)
 val handler :
   dbg:Debuginfo.t ->
   Lambda.static_label ->
   (Backend_var.With_provenance.t * Cmm.machtype) list ->
   Cmm.expression ->
+  bool ->
   static_handler
 
 (** [cexit id args] creates the cmm expression for static to a static handler

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -155,7 +155,7 @@ let rec check env (expr : Cmm.expression) =
   | Ccatch (rec_flag, handlers, body, _) ->
     let env_extended =
       List.fold_left
-        (fun env (cont, args, _, _) ->
+        (fun env (cont, args, _, _, _) ->
            Env.handler env ~cont ~arg_num:(List.length args))
         env
         handlers
@@ -166,7 +166,7 @@ let rec check env (expr : Cmm.expression) =
       | Recursive -> env_extended
       | Nonrecursive -> env
     in
-    List.iter (fun (_, _, handler, _) -> check env_handler handler) handlers
+    List.iter (fun (_, _, handler, _, _) -> check env_handler handler) handlers
   | Cexit (exit_label, args, _trap_actions) ->
     Env.jump env ~exit_label ~arg_num:(List.length args)
   | Ctrywith (body, _trywith_kind, _, handler, _, _) ->

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -471,7 +471,7 @@ let rec is_unboxed_number_cmm = function
       List.fold_left
         (join_unboxed_number_kind ~strict)
         (is_unboxed_number_cmm body)
-        (List.map (fun (_, _, e, _) -> is_unboxed_number_cmm e) handlers)
+        (List.map (fun (_, _, e, _, _) -> is_unboxed_number_cmm e) handlers)
 
 (* Translate an expression *)
 
@@ -796,7 +796,7 @@ let rec transl env e =
                     )
               dbg,
             Ctuple [],
-            dbg, Any))
+            dbg, Any, false))
   | Ufor(id, low, high, dir, body) ->
       let dbg = Debuginfo.none in
       let tst = match dir with Upto -> Cgt   | Downto -> Clt in
@@ -831,7 +831,7 @@ let rec transl env e =
                       dbg,
                    dbg, Any),
                  Ctuple [],
-                 dbg, Any))))
+                 dbg, Any, false))))
   | Uassign(id, exp) ->
       let dbg = Debuginfo.none in
       let cexp = transl env exp in
@@ -882,7 +882,7 @@ and transl_catch (kind : Cmm.kind_for_unboxing) env nfail ids body handler dbg =
   in
   if env == new_env then
     (* No unboxing *)
-    ccatch (nfail, ids, body, transl env handler, dbg, kind)
+    ccatch (nfail, ids, body, transl env handler, dbg, kind, false)
   else
     (* allocate new "nfail" to catch errors more easily *)
     let new_nfail = next_raise_count () in
@@ -896,7 +896,7 @@ and transl_catch (kind : Cmm.kind_for_unboxing) env nfail ids body handler dbg =
       in
       aux body
     in
-    ccatch (new_nfail, ids, body, transl new_env handler, dbg, kind)
+    ccatch (new_nfail, ids, body, transl new_env handler, dbg, kind, false)
 
 and transl_make_array dbg env kind mode args =
   match kind with
@@ -1385,7 +1385,7 @@ and transl_let env str (layout : Lambda.layout) id exp transl_body =
 and make_catch (kind : Cmm.kind_for_unboxing) ncatch body handler dbg =
   match body with
   | Cexit (Lbl nexit,[],[]) when nexit=ncatch -> handler
-  | _ ->  ccatch (ncatch, [], body, handler, dbg, kind)
+  | _ ->  ccatch (ncatch, [], body, handler, dbg, kind, false)
 
 and is_shareable_cont exp =
   match exp with

--- a/backend/comballoc.ml
+++ b/backend/comballoc.ml
@@ -113,7 +113,7 @@ let rec combine i allocstate =
       let (newbody, s') = combine body allocstate in
       let newhandlers =
         List.map
-          (fun (io, ts, handler) -> io, ts, combine_restart handler)
+          (fun (io, ts, handler, is_cold) -> io, ts, combine_restart handler, is_cold)
           handlers
       in
       let newnext = combine_restart i.next in

--- a/backend/dataflow.ml
+++ b/backend/dataflow.ml
@@ -74,19 +74,19 @@ let analyze ?(exnhandler = fun x -> x) ?(exnescape = D.bot)
         begin match rc with
         | Cmm.Nonrecursive ->
             List.iter
-              (fun (n, trap_stack, h) ->
+              (fun (n, trap_stack, h, _) ->
                  let exnh = exn_from_trap_stack exn trap_stack in
                  set_lbl n (before bx exnh h))
             handlers
         | Cmm.Recursive ->
-            List.iter (fun (n, _, _) -> add_rc_lbl n) handlers;
+            List.iter (fun (n, _, _, _) -> add_rc_lbl n) handlers;
             (* If [transfer] is monotonic and [D.t] satisfies
                the finite ascending chains condition,
                then the [while] loop below is guaranteed to terminate
                with [lbls] at the least fixed point of [before bx exnh h].
                Labels that retain their initial value at fixed point
                may be implicitly represented and absent from [lbls]. *)
-            let update changed (n, trap_stack, h) =
+            let update changed (n, trap_stack, h, _) =
               let b0 = get_lbl n in
               let exnh = exn_from_trap_stack exn trap_stack in
               let b1 = before bx exnh h in

--- a/backend/deadcode.ml
+++ b/backend/deadcode.ml
@@ -79,8 +79,8 @@ let rec deadcode i =
     let s = deadcode i.next in
     let handlers' =
       List.fold_left
-        (fun map (nfail, ts, handler) ->
-           Int.Map.add nfail (ts, deadcode handler) map)
+        (fun map (nfail, ts, handler, is_cold) ->
+           Int.Map.add nfail (ts, deadcode handler, is_cold) map)
         Int.Map.empty handlers
     in
     (* Previous passes guarantee that indexes of handlers are unique
@@ -94,8 +94,8 @@ let rec deadcode i =
         let live_exits = Int.Set.add nfail live_exits in
         match Int.Map.find_opt nfail handlers' with
         | None -> (live_exits, used_handlers)
-        | Some (ts, handler) ->
-          let used_handlers = (nfail, ts, handler) :: used_handlers in
+        | Some (ts, handler, is_cold) ->
+          let used_handlers = (nfail, ts, handler, is_cold) :: used_handlers in
           match rec_flag with
           | Cmm.Nonrecursive -> (live_exits, used_handlers)
           | Cmm.Recursive ->
@@ -106,7 +106,7 @@ let rec deadcode i =
     in
     (* Remove exits that are going out of scope. *)
     let used_handler_indexes =
-      List.fold_left (fun acc (n, _, _) -> Int.Set.add n acc)
+      List.fold_left (fun acc (n, _, _, _) -> Int.Set.add n acc)
         Int.Set.empty used_handlers
     in
     let live_exits = Int.Set.diff live_exits used_handler_indexes in
@@ -115,7 +115,7 @@ let rec deadcode i =
       match rec_flag with
       | Cmm.Recursive -> live_exits
       | Cmm.Nonrecursive ->
-        List.fold_left (fun exits (_,_,h) -> Int.Set.union h.exits exits)
+        List.fold_left (fun exits (_,_,h,_) -> Int.Set.union h.exits exits)
           live_exits
           used_handlers
     in
@@ -127,7 +127,7 @@ let rec deadcode i =
         exits;
       }
     | _ ->
-      let handlers = List.map (fun (n,ts,h) -> (n,ts,h.i)) used_handlers in
+      let handlers = List.map (fun (n,ts,h,is_cold) -> (n,ts,h.i,is_cold)) used_handlers in
       { i = { i with desc = Icatch(rec_flag, ts, handlers, body'.i);
                      next = s.i };
         regs = i.live;

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -269,7 +269,7 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
       | Iswitch (_, cases) -> join (Array.to_list cases) ~avail_before
       | Icatch (recursive, ts, handlers, body) ->
         List.iter
-          (fun (nfail, _ts, _handler) ->
+          (fun (nfail, _ts, _handler, _) ->
             (* In case there are nested [Icatch] expressions with the same
                handler numbers, we rely on the [Hashtbl] shadowing semantics. *)
             Hashtbl.add avail_at_exit nfail unreachable)
@@ -279,7 +279,7 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         in
         (* CR-someday mshinwell: Consider potential efficiency speedups (see
            suggestions from @chambart on GPR#856). *)
-        let aux (nfail, ts, handler) (nfail', avail_at_top_of_handler) =
+        let aux (nfail, ts, handler, _) (nfail', avail_at_top_of_handler) =
           assert (nfail = nfail');
           current_trap_stack := ts;
           available_regs handler ~avail_before:avail_at_top_of_handler
@@ -296,7 +296,7 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
           in
           let avail_at_top_of_handlers' =
             List.map
-              (fun (nfail, _ts, _handler) ->
+              (fun (nfail, _ts, _handler, _) ->
                 match Hashtbl.find avail_at_exit nfail with
                 | exception Not_found -> assert false (* see above *)
                 | avail_at_top_of_handler -> nfail, avail_at_top_of_handler)
@@ -312,7 +312,7 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         in
         let init_avail_at_top_of_handlers =
           List.map
-            (fun (nfail, _ts, _handler) ->
+            (fun (nfail, _ts, _handler, _) ->
               match Hashtbl.find avail_at_exit nfail with
               | exception Not_found -> assert false (* see above *)
               | avail_at_top_of_handler -> nfail, avail_at_top_of_handler)
@@ -320,7 +320,7 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         in
         let avail_after_handlers = fixpoint init_avail_at_top_of_handlers in
         List.iter
-          (fun (nfail, _ts, _handler) -> Hashtbl.remove avail_at_exit nfail)
+          (fun (nfail, _ts, _handler, _) -> Hashtbl.remove avail_at_exit nfail)
           handlers;
         current_trap_stack := ts;
         let avail_after =

--- a/backend/interf.ml
+++ b/backend/interf.ml
@@ -109,7 +109,7 @@ let build_graph fundecl =
         interf i.next
     | Icatch(_rec_flag, _ts, handlers, body) ->
         interf body;
-        List.iter (fun (_, _, handler) -> interf handler) handlers;
+        List.iter (fun (_, _, handler, _) -> interf handler) handlers;
         interf i.next
     | Iexit _ ->
         ()
@@ -186,7 +186,7 @@ let build_graph fundecl =
               if weight < 1000 then 8 * weight else weight
           | Cmm.Nonrecursive ->
               weight in
-        List.iter (fun (_nfail, _ts, handler) -> prefer weight_h handler) handlers;
+        List.iter (fun (_nfail, _ts, handler, _) -> prefer weight_h handler) handlers;
         prefer weight i.next
     | Iexit _ ->
         ()

--- a/backend/interval.ml
+++ b/backend/interval.ml
@@ -150,7 +150,7 @@ let build_intervals fd =
         walk_instruction i.next
     | Icatch(_, _ts, handlers, body) ->
         insert_destroyed_at_oper intervals i !pos;
-        List.iter (fun (_, _, i) -> walk_instruction i) handlers;
+        List.iter (fun (_, _, i, _) -> walk_instruction i) handlers;
         walk_instruction body;
         walk_instruction i.next
     | Iexit _ ->

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -275,17 +275,17 @@ let linear i n contains_calls =
         (* CR mshinwell for pchambart:
            1. rename "io"
            2. Make sure the test cases cover the "Iend" cases too *)
-        let labels_at_entry_to_handlers = List.map (fun (_n, _ts, handler) ->
+        let labels_at_entry_to_handlers = List.map (fun (_n, _ts, handler, _) ->
             match handler.Mach.desc with
             | Iend -> lbl_end
             | _ -> Cmm.new_label ())
             handlers in
         let exit_label_add = List.map2
-            (fun (nfail, _ts, _) lbl -> (nfail, lbl))
+            (fun (nfail, _ts, _, _) lbl -> (nfail, lbl))
             handlers labels_at_entry_to_handlers in
         let env = { env with exit_label = exit_label_add @ env.exit_label; } in
         let (n2, ts_n2) =
-          List.fold_left2 (fun (n, ts_next) (_nfail, ts, handler) lbl_handler ->
+          List.fold_left2 (fun (n, ts_next) (_nfail, ts, handler, _) lbl_handler ->
             match handler.Mach.desc with
             | Iend -> n, ts_next
             | _ ->

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -113,7 +113,7 @@ and instruction_desc =
   | Ireturn of Cmm.trap_action list
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
-  | Icatch of Cmm.rec_flag * trap_stack * (int * trap_stack * instruction) list * instruction
+  | Icatch of Cmm.rec_flag * trap_stack * (int * trap_stack * instruction * bool) list * instruction
   | Iexit of int * Cmm.trap_action list
   | Itrywith of instruction * Cmm.trywith_kind * (trap_stack * instruction)
   | Iraise of Lambda.raise_kind

--- a/backend/polling.ml
+++ b/backend/polling.ml
@@ -179,7 +179,7 @@ let add_poll i =
   Mach.instr_cons_debug (Iop (Ipoll { return_label = None })) [||] [||] i.dbg i
 
 let instr_body handler_safe i =
-  let add_unsafe_handler ube (k, _trap_stack, _) =
+  let add_unsafe_handler ube (k, _trap_stack, _, _) =
     match handler_safe k with
     | Safe -> ube
     | Unsafe -> Int.Set.add k ube
@@ -201,9 +201,9 @@ let instr_body handler_safe i =
         match rc with
         | Cmm.Recursive -> List.fold_left add_unsafe_handler ube hdl
         | Cmm.Nonrecursive -> ube in
-      let instr_handler (k, trap_stack, i0) =
+      let instr_handler (k, trap_stack, i0, is_cold) =
         let i1 = instr ube' i0 in
-        (k, trap_stack, i1) in
+        (k, trap_stack, i1, is_cold) in
       (* Since we are only interested in unguarded _back_ edges, we don't
          use [ube'] for instrumenting [body], but just [ube] instead. *)
       let body = instr ube body in

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -335,9 +335,9 @@ let rec expr ppf = function
        done in
       fprintf ppf "@[<v 0>@[<2>(switch@ %a@ @]%t)@]" expr e1 print_cases)
   | Ccatch(flag, handlers, e1, _kind) ->
-      let print_handler ppf (i, ids, e2, dbg) =
+      let print_handler ppf (i, ids, e2, dbg, is_cold) =
         with_location_mapping ~label:"Ccatch-handler" ~dbg ppf (fun () ->
-        fprintf ppf "(%d%a)@ %a"
+        fprintf ppf "(%d%a)%s@ %a"
           i
           (fun ppf ids ->
              List.iter
@@ -345,6 +345,7 @@ let rec expr ppf = function
                  fprintf ppf "@ %a: %a"
                    VP.print id machtype ty)
                ids) ids
+          (if is_cold then "(cold)" else "")
           sequence e2)
       in
       let print_handlers ppf l =

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -291,8 +291,8 @@ let rec instr ppf i =
   | Icatch(flag, ts, handlers, body) ->
       fprintf ppf "@[<v 2>catch%a%a@,%a@;<0 -2>with"
         Printcmm.rec_flag flag trap_stack ts instr body;
-      let h (nfail, ts, handler) =
-        fprintf ppf "(%d)%a@,%a@;" nfail trap_stack ts instr handler in
+      let h (nfail, ts, handler, is_cold) =
+        fprintf ppf "(%d)%s%a@,%a@;" nfail (if is_cold then "(cold)" else "") trap_stack ts instr handler in
       let rec aux = function
         | [] -> ()
         | [v] -> h v

--- a/backend/reloadgen.ml
+++ b/backend/reloadgen.ml
@@ -131,7 +131,7 @@ method private reload i k =
              (instr_cons (Iswitch(index, cases)) newarg [||] next)))
   | Icatch(rec_flag, ts, handlers, body) ->
       let new_handlers = List.map
-          (fun (nfail, ts, handler) -> nfail, ts, self#reload handler Fun.id)
+          (fun (nfail, ts, handler, is_cold) -> nfail, ts, self#reload handler Fun.id, is_cold)
           handlers in
       self#reload body (fun body ->
         self#reload i.next (fun next ->

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1157,12 +1157,7 @@ method emit_expr_aux (env:environment) exp ~bound_name :
                 seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |])
               ids_and_rs)
         in
-<<<<<<< HEAD
-        ((nfail, trap_stack), (r, s))
-=======
-        let (r, s) = self#emit_sequence new_env e2 in
         ((nfail, trap_stack, is_cold), (r, s))
->>>>>>> c4926ad7f (is_cold in Cmm & Mach)
       in
       let rec build_all_reachable_handlers ~already_built ~not_built =
         let not_built, to_build =
@@ -1184,13 +1179,8 @@ method emit_expr_aux (env:environment) exp ~bound_name :
         (* Note: we're dropping unreachable handlers here *)
       in
       let a = Array.of_list ((r_body, s_body) :: List.map snd l) in
-<<<<<<< HEAD
       let r = join_array env a ~bound_name in
-      let aux ((nfail, ts), (_r, s)) = (nfail, ts, s#extract) in
-=======
-      let r = join_array env a in
       let aux ((nfail, ts, is_cold), (_r, s)) = (nfail, ts, s#extract, is_cold) in
->>>>>>> c4926ad7f (is_cold in Cmm & Mach)
       let final_trap_stack =
         match r_body with
         | Some _ -> env.trap_stack
@@ -1688,7 +1678,6 @@ method emit_tail (env:environment) exp =
             (fun env ((id, _typ),r) -> env_add id r env)
             (env_set_trap_stack env trap_stack) ids_and_rs
         in
-<<<<<<< HEAD
         let seq =
           self#emit_tail_sequence new_env e2 ~at_start:(fun seq ->
             List.iter (fun ((var, _typ), r) ->
@@ -1707,10 +1696,7 @@ method emit_tail (env:environment) exp =
                  [| |] [| |])
                ids_and_rs)
         in
-        nfail, trap_stack, seq
-=======
-        nfail, trap_stack, self#emit_tail_sequence new_env e2, is_cold
->>>>>>> c4926ad7f (is_cold in Cmm & Mach)
+        nfail, trap_stack, seq, is_cold
       in
       let rec build_all_reachable_handlers ~already_built ~not_built =
         let not_built, to_build =

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -286,7 +286,7 @@ let rec reload env i before =
       (i, finally, env)
   | Icatch(rec_flag, ts, handlers, body) ->
       let reload_at_exit = List.fold_left
-          (fun reload_at_exit (nfail, _, _) ->
+          (fun reload_at_exit (nfail, _, _, _) ->
             Numbers.Int.Map.add nfail Reg.Set.empty reload_at_exit)
           env.reload_at_exit
           handlers
@@ -296,7 +296,7 @@ let rec reload env i before =
       let rec fixpoint env_fix =
         let new_handlers, after_union, env =
           List.fold_right
-            (fun (nfail, ts, handler) (handlers, after_union, env) ->
+            (fun (nfail, ts, handler, is_cold) (handlers, after_union, env) ->
                let handler, after_handler, env =
                  match find_in_reload_cache nfail env with
                  | None ->
@@ -316,7 +316,7 @@ let rec reload env i before =
                    in
                    handler, after_handler, { env with reload_at_exit }
                in
-               ((nfail, ts, handler) :: handlers,
+               ((nfail, ts, handler, is_cold) :: handlers,
                 Reg.Set.union after_union after_handler,
                 env))
             handlers ([], after_body, env_fix)
@@ -326,7 +326,7 @@ let rec reload env i before =
             new_handlers, after_union, env
         | Cmm.Recursive ->
             let equal =
-              List.for_all (fun (nfail, _ts, _handler) ->
+              List.for_all (fun (nfail, _ts, _handler, _) ->
                 Reg.Set.equal
                   (find_reload_at_exit env_fix nfail)
                   (find_reload_at_exit env nfail))
@@ -338,7 +338,7 @@ let rec reload env i before =
       in
       let new_handlers, after_union, env = fixpoint env in
       let reload_at_exit =
-        List.fold_left (fun reload_at_exit (nfail, _, _) ->
+        List.fold_left (fun reload_at_exit (nfail, _, _, _) ->
             Numbers.Int.Map.remove nfail reload_at_exit)
           env.reload_at_exit handlers
       in
@@ -561,7 +561,7 @@ let rec spill :
     let next_env = { env with at_raise = at_raise_from_trap_stack env ts } in
     spill next_env i.next finally (fun new_next at_join ->
       let spill_at_exit_add at_exits = List.map2
-          (fun (nfail,_,_) at_exit -> nfail, at_exit)
+          (fun (nfail,_,_,_) at_exit -> nfail, at_exit)
           handlers at_exits
       in
       let rec fixpoint at_exits =
@@ -569,7 +569,7 @@ let rec spill :
         let new_at_exit = spill_at_exit_add @ env.at_exit in
         let res =
           List.map
-            (fun (nfail, ts, handler) ->
+            (fun (nfail, ts, handler, _) ->
                let env =
                  { env with at_exit = new_at_exit;
                             at_raise = at_raise_from_trap_stack env ts;
@@ -602,7 +602,7 @@ let rec spill :
       let env_body = { env with at_exit = spill_at_exit_add @ env.at_exit; } in
       spill env_body body at_join (fun new_body before ->
       let new_handlers = List.map2
-          (fun (nfail, ts, _) (handler, _) -> nfail, ts, handler)
+          (fun (nfail, ts, _, is_cold) (handler, _) -> nfail, ts, handler, is_cold)
           handlers res in
       k (instr_cons (Icatch(rec_flag, ts, new_handlers, new_body))
          i.arg i.res new_next)

--- a/backend/split.ml
+++ b/backend/split.ml
@@ -170,14 +170,14 @@ let rec rename i sub =
        sub_next)
   | Icatch(rec_flag, ts, handlers, body) ->
       let new_subst =
-        List.map (fun (nfail, _, _) -> nfail, ref None) handlers
+        List.map (fun (nfail, _, _, _) -> nfail, ref None) handlers
       in
       let previous_exit_subst = !exit_subst in
       exit_subst := new_subst @ !exit_subst;
       let (new_body, sub_body) = rename body sub in
       let res =
         List.map2
-          (fun (_, _, handler) (_, new_subst) -> rename handler !new_subst)
+          (fun (_, _, handler, _) (_, new_subst) -> rename handler !new_subst)
           handlers new_subst
       in
       exit_subst := previous_exit_subst;
@@ -186,8 +186,8 @@ let rec rename i sub =
             merge_substs acc sub_handler i.next)
           sub_body res in
       let (new_next, sub_next) = rename i.next merged_subst in
-      let new_handlers = List.map2 (fun (nfail, ts, _) (handler, _) ->
-          (nfail, ts, handler)) handlers res in
+      let new_handlers = List.map2 (fun (nfail, ts, _, is_cold) (handler, _) ->
+          (nfail, ts, handler, is_cold)) handlers res in
       (instr_cons
          (Icatch(rec_flag, ts, new_handlers, new_body)) [||] [||] new_next,
        sub_next)

--- a/backend/strmatch.ml
+++ b/backend/strmatch.ml
@@ -380,7 +380,7 @@ module Make(I:I) = struct
     | Cexit (_e,[],_traps) ->  k arg
     | _ ->
         let e = next_raise_count () in
-        ccatch (e,[],k (Cexit (Lbl e,[],[])),arg,dbg, Any)
+        ccatch (e,[],k (Cexit (Lbl e,[],[])),arg,dbg, Any, false)
 
     let compile dbg value_kind str default cases =
 (* We do not attempt to really optimise default=None *)

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -1287,7 +1287,7 @@ and cont_handlers env handler1 handler2 =
                 (Continuation_handler.is_cold handler1)
                 (Continuation_handler.is_cold handler2))
            ~approximant:(fun () -> subst_cont_handler env handler1))
-|> function
+  |> function
   | Ok comp -> comp
   | Error _ ->
     Comparison.Different { approximant = subst_cont_handler env handler1 }

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -421,7 +421,8 @@ and subst_cont_handler env cont_handler =
   Continuation_handler.pattern_match cont_handler ~f:(fun params ~handler ->
       let handler = subst_expr env handler in
       Continuation_handler.create params ~handler ~free_names_of_handler:Unknown
-        ~is_exn_handler:(Continuation_handler.is_exn_handler cont_handler))
+        ~is_exn_handler:(Continuation_handler.is_exn_handler cont_handler)
+        ~is_cold:(Continuation_handler.is_cold cont_handler))
 
 and subst_apply env apply =
   let callee = subst_simple env (Apply_expr.callee apply) in
@@ -1272,14 +1273,21 @@ and cont_handlers env handler1 handler2 =
       |> Comparison.map ~f:(fun handler ->
              Continuation_handler.create params ~handler
                ~free_names_of_handler:Unknown
-               ~is_exn_handler:(Continuation_handler.is_exn_handler handler2))
+               ~is_exn_handler:(Continuation_handler.is_exn_handler handler2)
+               ~is_cold:(Continuation_handler.is_cold handler2))
       |> Comparison.add_condition
            ~cond:
              (Bool.equal
                 (Continuation_handler.is_exn_handler handler1)
                 (Continuation_handler.is_exn_handler handler2))
+           ~approximant:(fun () -> subst_cont_handler env handler1)
+      |> Comparison.add_condition
+           ~cond:
+             (Bool.equal
+                (Continuation_handler.is_cold handler1)
+                (Continuation_handler.is_cold handler2))
            ~approximant:(fun () -> subst_cont_handler env handler1))
-  |> function
+|> function
   | Ok comp -> comp
   | Error _ ->
     Comparison.Different { approximant = subst_cont_handler env handler1 }

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -326,8 +326,8 @@ module Inlining = struct
       in
       Expr_with_acc.create_apply_cont acc apply_cont
     in
-    let let_cont_create acc cont ~handler_params ~handler ~body ~is_exn_handler ~is_cold
-        =
+    let let_cont_create acc cont ~handler_params ~handler ~body ~is_exn_handler
+        ~is_cold =
       Let_cont_with_acc.build_non_recursive acc cont ~handler_params ~handler
         ~body ~is_exn_handler ~is_cold
     in
@@ -1101,7 +1101,8 @@ let close_let_cont acc env ~name ~is_exn_handler ~params
   | Recursive ->
     (* CR ncourant: from lambda *)
     let handlers =
-      Continuation.Map.singleton name (handler, handler_params, is_exn_handler, false)
+      Continuation.Map.singleton name
+        (handler, handler_params, is_exn_handler, false)
     in
     (* CR ncourant: If we could somehow detect the syntactically invariant
        parameters here, we could be able to improve the results of [Simplify] in
@@ -2213,8 +2214,7 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
         ~handler_params:(Bound_parameters.create over_application_results)
         ~handler
         ~body:(fun acc -> Expr_with_acc.create_apply acc over_application)
-        ~is_exn_handler:false
-        ~is_cold:false
+        ~is_exn_handler:false ~is_cold:false
   in
   let body = full_call wrapper_cont ~region:apply_region in
   let acc, both_applications =
@@ -2222,7 +2222,8 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
       ~handler_params:
         ([BP.create returned_func K.With_subkind.any_value]
         |> Bound_parameters.create)
-      ~handler:perform_over_application ~body ~is_exn_handler:false ~is_cold:false
+      ~handler:perform_over_application ~body ~is_exn_handler:false
+      ~is_cold:false
   in
   match needs_region with
   | None -> acc, both_applications
@@ -2547,8 +2548,7 @@ let wrap_final_module_block acc env ~program ~prog_return_cont
   let body acc = program acc env in
   Let_cont_with_acc.build_non_recursive acc prog_return_cont
     ~handler_params:load_fields_handler_param ~handler:load_fields_body ~body
-    ~is_exn_handler:false
-    ~is_cold:false
+    ~is_exn_handler:false ~is_cold:false
 
 let close_program (type mode) ~(mode : mode Flambda_features.mode) ~big_endian
     ~cmx_loader ~compilation_unit ~module_block_size_in_words ~program

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -415,7 +415,7 @@ module Let_cont_with_acc : sig
     Acc.t ->
     invariant_params:Bound_parameters.t ->
     handlers:
-      ((Acc.t -> Expr_with_acc.t) * Bound_parameters.t * bool)
+      ((Acc.t -> Expr_with_acc.t) * Bound_parameters.t * bool * bool)
       Continuation.Map.t ->
     body:(Acc.t -> Expr_with_acc.t) ->
     Expr_with_acc.t
@@ -427,5 +427,6 @@ module Let_cont_with_acc : sig
     handler:(Acc.t -> Expr_with_acc.t) ->
     body:(Acc.t -> Expr_with_acc.t) ->
     is_exn_handler:bool ->
+    is_cold:bool ->
     Expr_with_acc.t
 end

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -227,17 +227,17 @@ let rec bind_rec acc exn_cont ~register_const0 (prim : expr_primitive)
           in
           Let_cont_with_acc.build_non_recursive acc condition_passed_cont
             ~handler_params:Bound_parameters.empty
-            ~handler:condition_passed_expr ~body ~is_exn_handler:false)
+            ~handler:condition_passed_expr ~body ~is_exn_handler:false ~is_cold:false)
         prim_apply_cont validity_conditions
     in
     let body acc =
       Let_cont_with_acc.build_non_recursive acc failure_cont
         ~handler_params:Bound_parameters.empty ~handler:failure_handler_expr
-        ~body:check_validity_conditions ~is_exn_handler:false
+        ~body:check_validity_conditions ~is_exn_handler:false ~is_cold:true
     in
     Let_cont_with_acc.build_non_recursive acc primitive_cont
       ~handler_params:Bound_parameters.empty ~handler:primitive_handler_expr
-      ~body ~is_exn_handler:false
+      ~body ~is_exn_handler:false ~is_cold:false
   | If_then_else (cond, ifso, ifnot) ->
     let cond_result = Variable.create "cond_result" in
     let cond_result_pat = Bound_var.create cond_result Name_mode.normal in
@@ -298,16 +298,16 @@ let rec bind_rec acc exn_cont ~register_const0 (prim : expr_primitive)
     let body acc =
       Let_cont_with_acc.build_non_recursive acc ifnot_cont
         ~handler_params:Bound_parameters.empty ~handler:ifnot_handler_expr
-        ~body:compute_cond_and_switch ~is_exn_handler:false
+        ~body:compute_cond_and_switch ~is_exn_handler:false ~is_cold:false
     in
     let body acc =
       Let_cont_with_acc.build_non_recursive acc ifso_cont
         ~handler_params:Bound_parameters.empty ~handler:ifso_handler_expr ~body
-        ~is_exn_handler:false
+        ~is_exn_handler:false ~is_cold:false
     in
     Let_cont_with_acc.build_non_recursive acc join_point_cont
       ~handler_params:(Bound_parameters.create [result_param])
-      ~handler:join_handler_expr ~body ~is_exn_handler:false
+      ~handler:join_handler_expr ~body ~is_exn_handler:false ~is_cold:false
 
 and bind_rec_primitive acc exn_cont ~register_const0 (prim : simple_or_prim)
     (dbg : Debuginfo.t) (cont : Acc.t -> Simple.t -> Expr_with_acc.t) :

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -227,7 +227,8 @@ let rec bind_rec acc exn_cont ~register_const0 (prim : expr_primitive)
           in
           Let_cont_with_acc.build_non_recursive acc condition_passed_cont
             ~handler_params:Bound_parameters.empty
-            ~handler:condition_passed_expr ~body ~is_exn_handler:false ~is_cold:false)
+            ~handler:condition_passed_expr ~body ~is_exn_handler:false
+            ~is_cold:false)
         prim_apply_cont validity_conditions
     in
     let body acc =

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -640,7 +640,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
     let handler =
       Flambda.Continuation_handler.create
         (Bound_parameters.create params)
-        ~handler ~free_names_of_handler:Unknown ~is_exn_handler
+        ~handler ~free_names_of_handler:Unknown ~is_exn_handler ~is_cold:false
     in
     match recursive with
     | Nonrecursive ->

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -740,7 +740,9 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
           (UA.are_rebuilding_terms uacc)
           params ~handler:expr ~free_names_of_handler:free_names
           ~is_exn_handler:false ~is_cold:false
-        (* CR ncourant: this should maybe be same as original cont? *)
+        (* This is only a wrapper that will immediately call the continuation,
+           so we set [is_cold] to false so that this wrapper can be inlined by
+           [to_cmm]. *)
       in
       let free_names_of_handler =
         ListLabels.fold_left (Bound_parameters.to_list params) ~init:free_names

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -739,7 +739,7 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
         RE.Continuation_handler.create
           (UA.are_rebuilding_terms uacc)
           params ~handler:expr ~free_names_of_handler:free_names
-          ~is_exn_handler:false
+          ~is_exn_handler:false ~is_cold:false (* CR ncourant: this should maybe be same as original cont? *)
       in
       let free_names_of_handler =
         ListLabels.fold_left (Bound_parameters.to_list params) ~init:free_names

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -739,7 +739,8 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
         RE.Continuation_handler.create
           (UA.are_rebuilding_terms uacc)
           params ~handler:expr ~free_names_of_handler:free_names
-          ~is_exn_handler:false ~is_cold:false (* CR ncourant: this should maybe be same as original cont? *)
+          ~is_exn_handler:false ~is_cold:false
+        (* CR ncourant: this should maybe be same as original cont? *)
       in
       let free_names_of_handler =
         ListLabels.fold_left (Bound_parameters.to_list params) ~init:free_names

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -71,10 +71,10 @@ let wrap_inlined_body_for_exn_extra_args ~extra_args ~apply_exn_continuation
   let apply_cont_create () ~trap_action cont ~args ~dbg =
     Apply_cont.create ~trap_action cont ~args ~dbg |> Expr.create_apply_cont
   in
-  let let_cont_create () cont ~handler_params ~handler ~body ~is_exn_handler =
+  let let_cont_create () cont ~handler_params ~handler ~body ~is_exn_handler ~is_cold =
     let handler =
       Continuation_handler.create handler_params ~handler:(handler ())
-        ~free_names_of_handler:Unknown ~is_exn_handler
+        ~free_names_of_handler:Unknown ~is_exn_handler ~is_cold
     in
     Let_cont.create_non_recursive cont handler ~body:(body ())
       ~free_names_of_body:Unknown

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -71,7 +71,8 @@ let wrap_inlined_body_for_exn_extra_args ~extra_args ~apply_exn_continuation
   let apply_cont_create () ~trap_action cont ~args ~dbg =
     Apply_cont.create ~trap_action cont ~args ~dbg |> Expr.create_apply_cont
   in
-  let let_cont_create () cont ~handler_params ~handler ~body ~is_exn_handler ~is_cold =
+  let let_cont_create () cont ~handler_params ~handler ~body ~is_exn_handler
+      ~is_cold =
     let handler =
       Continuation_handler.create handler_params ~handler:(handler ())
         ~free_names_of_handler:Unknown ~is_exn_handler ~is_cold

--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -92,22 +92,22 @@ module Continuation_handler = struct
 
   let dummy =
     Continuation_handler.create Bound_parameters.empty ~handler:term_not_rebuilt
-      ~free_names_of_handler:Unknown ~is_exn_handler:false
+      ~free_names_of_handler:Unknown ~is_exn_handler:false ~is_cold:false
 
   let create are_rebuilding params ~handler ~free_names_of_handler
-      ~is_exn_handler =
+      ~is_exn_handler ~is_cold =
     if ART.do_not_rebuild_terms are_rebuilding
     then dummy
     else
       Continuation_handler.create params ~handler
-        ~free_names_of_handler:(Known free_names_of_handler) ~is_exn_handler
+        ~free_names_of_handler:(Known free_names_of_handler) ~is_exn_handler ~is_cold
 
-  let create' are_rebuilding params ~handler ~is_exn_handler =
+  let create' are_rebuilding params ~handler ~is_exn_handler ~is_cold =
     if ART.do_not_rebuild_terms are_rebuilding
     then dummy
     else
       Continuation_handler.create params ~handler ~free_names_of_handler:Unknown
-        ~is_exn_handler
+        ~is_exn_handler ~is_cold
 end
 
 let create_non_recursive_let_cont are_rebuilding cont handler ~body

--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -100,7 +100,8 @@ module Continuation_handler = struct
     then dummy
     else
       Continuation_handler.create params ~handler
-        ~free_names_of_handler:(Known free_names_of_handler) ~is_exn_handler ~is_cold
+        ~free_names_of_handler:(Known free_names_of_handler) ~is_exn_handler
+        ~is_cold
 
   let create' are_rebuilding params ~handler ~is_exn_handler ~is_cold =
     if ART.do_not_rebuild_terms are_rebuilding

--- a/middle_end/flambda2/simplify/rebuilt_expr.mli
+++ b/middle_end/flambda2/simplify/rebuilt_expr.mli
@@ -93,6 +93,7 @@ module Continuation_handler : sig
     handler:rebuilt_expr ->
     free_names_of_handler:Name_occurrences.t ->
     is_exn_handler:bool ->
+    is_cold:bool ->
     t
 
   val create' :
@@ -100,6 +101,7 @@ module Continuation_handler : sig
     Bound_parameters.t ->
     handler:rebuilt_expr ->
     is_exn_handler:bool ->
+    is_cold:bool ->
     t
 end
 

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -219,7 +219,7 @@ let split_direct_over_application apply
       (Bound_parameters.create [func_param])
       ~handler:perform_over_application
       ~free_names_of_handler:(Known perform_over_application_free_names)
-      ~is_exn_handler:false ~is_cold:false (* CR ncourant: check *)
+      ~is_exn_handler:false ~is_cold:false
   in
   let full_apply =
     let alloc_mode =

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -207,6 +207,7 @@ let split_direct_over_application apply
           ~handler:handler_expr
           ~free_names_of_handler:(Known handler_expr_free_names)
           ~is_exn_handler:false
+          ~is_cold:false (* CR ncourant: check *)
       in
       Let_cont.create_non_recursive after_over_application handler
         ~body:(Expr.create_apply perform_over_application)
@@ -220,6 +221,7 @@ let split_direct_over_application apply
       ~handler:perform_over_application
       ~free_names_of_handler:(Known perform_over_application_free_names)
       ~is_exn_handler:false
+      ~is_cold:false (* CR ncourant: check *)
   in
   let full_apply =
     let alloc_mode =

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -206,7 +206,7 @@ let split_direct_over_application apply
           (Bound_parameters.create over_application_results)
           ~handler:handler_expr
           ~free_names_of_handler:(Known handler_expr_free_names)
-          ~is_exn_handler:false ~is_cold:false (* CR ncourant: check *)
+          ~is_exn_handler:false ~is_cold:false
       in
       Let_cont.create_non_recursive after_over_application handler
         ~body:(Expr.create_apply perform_over_application)

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -206,8 +206,7 @@ let split_direct_over_application apply
           (Bound_parameters.create over_application_results)
           ~handler:handler_expr
           ~free_names_of_handler:(Known handler_expr_free_names)
-          ~is_exn_handler:false
-          ~is_cold:false (* CR ncourant: check *)
+          ~is_exn_handler:false ~is_cold:false (* CR ncourant: check *)
       in
       Let_cont.create_non_recursive after_over_application handler
         ~body:(Expr.create_apply perform_over_application)
@@ -220,8 +219,7 @@ let split_direct_over_application apply
       (Bound_parameters.create [func_param])
       ~handler:perform_over_application
       ~free_names_of_handler:(Known perform_over_application_free_names)
-      ~is_exn_handler:false
-      ~is_cold:false (* CR ncourant: check *)
+      ~is_exn_handler:false ~is_cold:false (* CR ncourant: check *)
   in
   let full_apply =
     let alloc_mode =

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -138,7 +138,7 @@ and simplify_function_body dacc expr ~return_continuation ~return_arity
     let handlers =
       Continuation.Map.singleton cont
         (Continuation_handler.create params ~handler:expr
-           ~free_names_of_handler:Unknown ~is_exn_handler:false)
+           ~free_names_of_handler:Unknown ~is_exn_handler:false ~is_cold:false)
     in
     simplify_toplevel_common dacc
       (fun dacc ->

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -46,13 +46,14 @@ open! Simplify_import
 type original_handlers =
   | Recursive of
       { invariant_params : Bound_parameters.t;
-        continuation_handlers : (Bound_parameters.t * Expr.t) Continuation.Map.t
+        continuation_handlers : (Bound_parameters.t * Expr.t * bool) Continuation.Map.t
       }
   | Non_recursive of
       { cont : Continuation.t;
         params : Bound_parameters.t;
         handler : Expr.t;
-        is_exn_handler : bool
+        is_exn_handler : bool;
+        is_cold : bool;
       }
 
 type simplify_let_cont_data =
@@ -72,6 +73,7 @@ type handler_after_downwards_traversal =
   { params : Bound_parameters.t;
     rebuild_handler : expr_to_rebuild;
     is_exn_handler : bool;
+    is_cold : bool;
     (* continuations_used is the set of which continuations from this block of
        mutually recursive continuations is used inside the handler *)
     continuations_used : Continuation.Set.t;
@@ -93,6 +95,7 @@ type handler_to_rebuild =
   { params : Bound_parameters.t;
     rebuild_handler : expr_to_rebuild;
     is_exn_handler : bool;
+    is_cold : bool;
     extra_params_and_args : EPA.t;
     (* Note: EPA.extra_params invariant_extra_params_and_args should always be
        equal to invariant_extra_params in stage4 *)
@@ -518,6 +521,7 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
   (* Clear existing name occurrences & cost metrics *)
   let uacc = UA.clear_name_occurrences (UA.clear_cost_metrics uacc) in
   let { is_exn_handler;
+        is_cold;
         rewrite_ids;
         params;
         rebuild_handler;
@@ -577,7 +581,7 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
       let cont_handler =
         RE.Continuation_handler.create
           (UA.are_rebuilding_terms uacc)
-          params ~handler ~free_names_of_handler:free_names ~is_exn_handler
+          params ~handler ~free_names_of_handler:free_names ~is_exn_handler ~is_cold
       in
       let uacc =
         UA.map_uenv uacc ~f:(fun uenv ->
@@ -683,7 +687,7 @@ let rebuild_single_recursive_handler cont
         RE.Continuation_handler.create
           (UA.are_rebuilding_terms uacc)
           variant_params ~handler ~free_names_of_handler:free_names
-          ~is_exn_handler:false
+          ~is_exn_handler:false ~is_cold:false
       in
       let free_names =
         remove_params invariant_params (remove_params variant_params free_names)
@@ -861,6 +865,7 @@ let create_handler_to_rebuild
   { params = handler.params;
     rebuild_handler = handler.rebuild_handler;
     is_exn_handler = handler.is_exn_handler;
+    is_cold = handler.is_cold;
     extra_params_and_args;
     invariant_extra_params_and_args = invariant_epa;
     rewrite_ids = Continuation_uses.get_use_ids uses
@@ -898,7 +903,7 @@ let sort_handlers data handlers =
             | [] | _ :: _ :: _ -> false
             | [use] -> (
               match One_continuation_use.use_kind use with
-              | Inlinable -> true
+              | Inlinable -> not handler.is_cold
               | Non_inlinable _ -> false)
           in
           Non_recursive { cont; handler; is_single_inlinable_use }
@@ -1040,7 +1045,7 @@ let simplify_handler ~simplify_expr ~is_recursive ~is_exn_handler
 
 let simplify_single_recursive_handler ~simplify_expr cont_uses_env_so_far
     ~invariant_params consts_lifted_during_body all_handlers_set denv_to_reset
-    dacc cont (params, handler) k =
+    dacc cont (params, handler, is_cold) k =
   (* Here we perform the downwards traversal on a single handler.
 
      We also make unboxing decisions at this step, which are necessary to
@@ -1081,6 +1086,7 @@ let simplify_single_recursive_handler ~simplify_expr cont_uses_env_so_far
         { params;
           rebuild_handler;
           is_exn_handler = false;
+          is_cold;
           continuations_used;
           unbox_decisions;
           extra_params_and_args_for_cse = EPA.empty
@@ -1157,7 +1163,7 @@ let after_downwards_traversal_of_body ~simplify_expr
     DA.add_to_lifted_constant_accumulator dacc data.prior_lifted_constants
   in
   match data.handlers with
-  | Non_recursive { cont; params; handler; is_exn_handler } -> (
+  | Non_recursive { cont; params; handler; is_exn_handler; is_cold } -> (
     match
       Continuation_uses_env.get_continuation_uses body_continuation_uses_env
         cont
@@ -1209,6 +1215,7 @@ let after_downwards_traversal_of_body ~simplify_expr
             { params;
               rebuild_handler;
               is_exn_handler;
+              is_cold;
               continuations_used;
               unbox_decisions;
               extra_params_and_args_for_cse
@@ -1299,12 +1306,13 @@ let simplify_let_cont ~simplify_expr dacc (let_cont : Let_cont.t) ~down_to_up =
       in
       let cont_handler = Non_recursive_let_cont_handler.handler handler in
       let is_exn_handler = CH.is_exn_handler cont_handler in
+      let is_cold = CH.is_cold cont_handler in
       let params, handler =
         CH.pattern_match cont_handler ~f:(fun params ~handler ->
             params, handler)
       in
       { body;
-        handlers = Non_recursive { cont; params; handler; is_exn_handler }
+        handlers = Non_recursive { cont; params; handler; is_exn_handler; is_cold }
       }
     | Recursive handlers ->
       let invariant_params, body, rec_handlers =
@@ -1317,7 +1325,8 @@ let simplify_let_cont ~simplify_expr dacc (let_cont : Let_cont.t) ~down_to_up =
       let continuation_handlers =
         Continuation.Map.map
           (fun handler ->
-            CH.pattern_match handler ~f:(fun params ~handler -> params, handler))
+             let is_cold = CH.is_cold handler in
+             CH.pattern_match handler ~f:(fun params ~handler -> params, handler, is_cold))
           handlers
       in
       { body; handlers = Recursive { invariant_params; continuation_handlers } }
@@ -1333,7 +1342,8 @@ let simplify_as_recursive_let_cont ~simplify_expr dacc (body, handlers)
   let continuation_handlers =
     Continuation.Map.map
       (fun handler ->
-        CH.pattern_match handler ~f:(fun params ~handler -> params, handler))
+         let is_cold = CH.is_cold handler in
+         CH.pattern_match handler ~f:(fun params ~handler -> params, handler, is_cold))
       handlers
   in
   let data : simplify_let_cont_data =

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -641,7 +641,7 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
             UE.add_continuation_alias uenv cont arity ~alias_for
           | Unknown ->
             UE.add_non_inlinable_continuation uenv cont ~params
-              ~handler:(Known handler)
+              ~handler:(if is_cold then Unknown else Known handler)
       in
       let uacc = UA.with_uenv uacc uenv in
       (* The parameters are removed from the free name information as they are

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -46,14 +46,15 @@ open! Simplify_import
 type original_handlers =
   | Recursive of
       { invariant_params : Bound_parameters.t;
-        continuation_handlers : (Bound_parameters.t * Expr.t * bool) Continuation.Map.t
+        continuation_handlers :
+          (Bound_parameters.t * Expr.t * bool) Continuation.Map.t
       }
   | Non_recursive of
       { cont : Continuation.t;
         params : Bound_parameters.t;
         handler : Expr.t;
         is_exn_handler : bool;
-        is_cold : bool;
+        is_cold : bool
       }
 
 type simplify_let_cont_data =
@@ -581,7 +582,8 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
       let cont_handler =
         RE.Continuation_handler.create
           (UA.are_rebuilding_terms uacc)
-          params ~handler ~free_names_of_handler:free_names ~is_exn_handler ~is_cold
+          params ~handler ~free_names_of_handler:free_names ~is_exn_handler
+          ~is_cold
       in
       let uacc =
         UA.map_uenv uacc ~f:(fun uenv ->
@@ -1312,7 +1314,8 @@ let simplify_let_cont ~simplify_expr dacc (let_cont : Let_cont.t) ~down_to_up =
             params, handler)
       in
       { body;
-        handlers = Non_recursive { cont; params; handler; is_exn_handler; is_cold }
+        handlers =
+          Non_recursive { cont; params; handler; is_exn_handler; is_cold }
       }
     | Recursive handlers ->
       let invariant_params, body, rec_handlers =
@@ -1325,8 +1328,9 @@ let simplify_let_cont ~simplify_expr dacc (let_cont : Let_cont.t) ~down_to_up =
       let continuation_handlers =
         Continuation.Map.map
           (fun handler ->
-             let is_cold = CH.is_cold handler in
-             CH.pattern_match handler ~f:(fun params ~handler -> params, handler, is_cold))
+            let is_cold = CH.is_cold handler in
+            CH.pattern_match handler ~f:(fun params ~handler ->
+                params, handler, is_cold))
           handlers
       in
       { body; handlers = Recursive { invariant_params; continuation_handlers } }
@@ -1342,8 +1346,9 @@ let simplify_as_recursive_let_cont ~simplify_expr dacc (body, handlers)
   let continuation_handlers =
     Continuation.Map.map
       (fun handler ->
-         let is_cold = CH.is_cold handler in
-         CH.pattern_match handler ~f:(fun params ~handler -> params, handler, is_cold))
+        let is_cold = CH.is_cold handler in
+        CH.pattern_match handler ~f:(fun params ~handler ->
+            params, handler, is_cold))
       handlers
   in
   let data : simplify_let_cont_data =

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -114,7 +114,8 @@ let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation
       ~handler:push_wrapper_handler ~body ~is_exn_handler:false ~is_cold:false
   in
   let_cont_create acc wrapper ~handler_params:wrapper_handler_params
-    ~handler:wrapper_handler ~body:body_with_push ~is_exn_handler:true ~is_cold:false
+    ~handler:wrapper_handler ~body:body_with_push ~is_exn_handler:true
+    ~is_cold:false
 
 type attribute_kind =
   | Inlined

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -84,7 +84,7 @@ let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation
       in
       let_cont_create acc pop_wrapper_cont
         ~handler_params:(Bound_parameters.create kinded_params)
-        ~handler ~body ~is_exn_handler:false
+        ~handler ~body ~is_exn_handler:false ~is_cold:false
   in
   let param = Variable.create "exn" in
   let wrapper_handler_params =
@@ -111,10 +111,10 @@ let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation
         ~dbg:Debuginfo.none
     in
     let_cont_create acc push_wrapper_cont ~handler_params:Bound_parameters.empty
-      ~handler:push_wrapper_handler ~body ~is_exn_handler:false
+      ~handler:push_wrapper_handler ~body ~is_exn_handler:false ~is_cold:false
   in
   let_cont_create acc wrapper ~handler_params:wrapper_handler_params
-    ~handler:wrapper_handler ~body:body_with_push ~is_exn_handler:true
+    ~handler:wrapper_handler ~body:body_with_push ~is_exn_handler:true ~is_cold:false
 
 type attribute_kind =
   | Inlined

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.mli
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.mli
@@ -66,6 +66,7 @@ val wrap_inlined_body_for_exn_extra_args :
     handler:('acc -> 'expr_with_acc) ->
     body:('acc -> 'expr_with_acc) ->
     is_exn_handler:bool ->
+    is_cold:bool ->
     'expr_with_acc) ->
   'expr_with_acc
 

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -536,7 +536,8 @@ and print ppf (t : expr) =
       Flambda_colours.invalid_keyword Flambda_colours.pop message
 
 and print_continuation_handler (recursive : Recursive.t) invariant_params ppf k
-    ({ cont_handler_abst = _; is_exn_handler; is_cold } as t) occurrences ~first =
+    ({ cont_handler_abst = _; is_exn_handler; is_cold } as t) occurrences ~first
+    =
   let fprintf = Format.fprintf in
   if not first then fprintf ppf "@ ";
   let print params ~handler =

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -273,6 +273,7 @@ module Continuation_handler : sig
     handler:expr ->
     free_names_of_handler:Name_occurrences.t Or_unknown.t ->
     is_exn_handler:bool ->
+    is_cold:bool ->
     t
 
   (** Choose a member of the alpha-equivalence class to enable examination of
@@ -316,6 +317,8 @@ module Continuation_handler : sig
       simultaneously-defined continuations when one or more of them is an
       exception handler.) *)
   val is_exn_handler : t -> bool
+
+  val is_cold : t -> bool
 end
 
 module Continuation_handlers : sig

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -117,7 +117,7 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
   let body =
     let unit_value = C.targetint ~dbg Targetint_32_64.one in
     C.create_ccatch ~rec_flag:false ~body
-      ~handlers:[C.handler ~dbg return_cont return_cont_params unit_value]
+      ~handlers:[C.handler ~dbg return_cont return_cont_params unit_value false]
   in
   let body =
     if !Clflags.afl_instrument

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -96,6 +96,7 @@ let cont_is_known_to_have_exactly_one_occurrence k (num : _ Or_unknown.t) =
 let classify_continuation_handler k handler ~num_free_occurrences
     ~is_applied_with_traps : continuation_handler_classification =
   if (not (Continuation_handler.is_exn_handler handler))
+     && (not (Continuation_handler.is_cold handler))
      && (not is_applied_with_traps)
      && cont_is_known_to_have_exactly_one_occurrence k num_free_occurrences
   then May_inline

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -542,6 +542,7 @@ and let_cont_not_inlined env res k handler body =
      expression. *)
   let wrap, env, res = Env.flush_delayed_lets ~mode:Branching_point env res in
   let is_exn_handler = Continuation_handler.is_exn_handler handler in
+  let is_cold = Continuation_handler.is_cold handler in
   let vars, arity, handler, free_vars_of_handler, res =
     continuation_handler env res handler
   in
@@ -567,7 +568,7 @@ and let_cont_not_inlined env res k handler body =
           (C.remove_vars_with_machtype free_vars_of_handler vars)
       in
       ( C.create_ccatch ~rec_flag:false ~body
-          ~handlers:[C.handler ~dbg catch_id vars handler],
+          ~handlers:[C.handler ~dbg catch_id vars handler is_cold],
         free_vars,
         res )
   in
@@ -693,7 +694,7 @@ and let_cont_rec env res invariant_params conts body =
             (C.remove_vars_with_machtype free_vars_of_handler vars)
         in
         let id = Env.get_cmm_continuation env k in
-        C.handler ~dbg id vars handler :: handlers, free_vars)
+        C.handler ~dbg id vars handler false :: handlers, free_vars)
       conts_to_handlers ([], free_vars_of_body)
   in
   let cmm = C.create_ccatch ~rec_flag:true ~body ~handlers in
@@ -790,8 +791,9 @@ and apply_expr env res apply =
           Env.set_inlined_debuginfo env handler_body_inlined_debuginfo
         in
         let expr, free_vars_of_handler, res = expr env res body in
+        (* we know the handler can't be cold, or it wouldn't have been inlined. *)
         let handler =
-          C.handler ~dbg:(Apply.dbg apply) label params_with_machtype expr
+          C.handler ~dbg:(Apply.dbg apply) label params_with_machtype expr false
         in
         let expr =
           C.create_ccatch ~rec_flag:false ~handlers:[handler]

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -791,7 +791,8 @@ and apply_expr env res apply =
           Env.set_inlined_debuginfo env handler_body_inlined_debuginfo
         in
         let expr, free_vars_of_handler, res = expr env res body in
-        (* we know the handler can't be cold, or it wouldn't have been inlined. *)
+        (* we know the handler can't be cold, or it wouldn't have been
+           inlined. *)
         let handler =
           C.handler ~dbg:(Apply.dbg apply) label params_with_machtype expr false
         in

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -252,15 +252,15 @@ expr:
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
                              (Cexit(Cmm.Lbl lbl0,[],[])),
                              debuginfo (), Any) in
-        Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
+        Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo (), false],
           Ccatch(Recursive,
-            [lbl1, [], Csequence(body, Cexit(Cmm.Lbl lbl1, [], [])), debuginfo ()],
+            [lbl1, [], Csequence(body, Cexit(Cmm.Lbl lbl1, [], [])), debuginfo (), false],
             Cexit(Cmm.Lbl lbl1, [], []), Any), Any) }
   | LPAREN EXIT traps IDENT exprlist RPAREN
     { Cexit(Cmm.Lbl (find_label $4), List.rev $5, $3) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
-      List.iter (fun (_, l, _, _) ->
+      List.iter (fun (_, l, _, _, _) ->
         List.iter (fun (x, _) -> unbind_ident x) l) handlers;
       Ccatch(Recursive, handlers, $3, Any) }
   | EXIT        { Cexit(Cmm.Lbl 0,[],[]) }
@@ -432,9 +432,9 @@ catch_handlers:
 
 catch_handler:
   | sequence
-    { 0, [], $1, debuginfo () }
+    { 0, [], $1, debuginfo (), false }
   | LPAREN IDENT params RPAREN sequence
-    { find_label $2, $3, $5, debuginfo () }
+    { find_label $2, $3, $5, debuginfo (), false }
 
 location:
     /**/                        { None }


### PR DESCRIPTION
Cold continuation handlers will not be inlined, neither by simplify, nor by to_cmm. For now, they are generated only in from_lambda for the exception handlers of checked operations, but the plan is to add then in lambda as well and propagate the information. The backend parts seem more complex however: while it seems to be easy enough to propagate the information into Cmm code, it's unclear how to represent it inside Mach and Linear if we want to be able to put cold continuation handlers at the end of the function.