### PR TITLE
`Regalloc_rewrite`: avoid unnecessary array allocations

### DIFF
--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -143,10 +143,8 @@ let rewrite_gen :
       done
     in
     match direction with
-    | Load_before_cell _ | Load_after_list _ ->
-      rewrite_array instr.arg
-    | Store_after_cell _ | Store_before_list _ ->
-      rewrite_array instr.res
+    | Load_before_cell _ | Load_after_list _ -> rewrite_array instr.arg
+    | Store_after_cell _ | Store_before_list _ -> rewrite_array instr.res
   in
   let liveness = Cfg_with_infos.liveness cfg_with_infos in
   Cfg.iter_blocks (Cfg_with_infos.cfg cfg_with_infos) ~f:(fun label block ->


### PR DESCRIPTION
We have been [duplicating](https://github.com/ocaml-flambda/flambda-backend/blob/main/backend/regalloc/regalloc_utils.ml#L132) the `arg` and `res`
arrays when we enter the register allocator
for some time, which makes the `Array.map`
calls in `Regalloc_rewrite` wasteful.

This pull request changes the code to perform
the rewrite in-place.