### PR TITLE
Remove stack slot optim parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,19 +76,19 @@ jobs:
           - name: irc
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
-            build_ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=STACK_SLOTS_OPTIM:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
+            build_ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
             check_arch: true
 
           - name: irc_frame_pointers
             config: --enable-middle-end=flambda2 --enable-frame-pointers
             os: ubuntu-latest
-            build_ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=STACK_SLOTS_OPTIM:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
+            build_ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
             check_arch: true
 
           - name: ls
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
-            build_ocamlparam: '_,w=-46,regalloc=ls,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=STACK_SLOTS_OPTIM:on,regalloc-param=LS_ORDER:layout,regalloc-validate=1'
+            build_ocamlparam: '_,w=-46,regalloc=ls,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=LS_ORDER:layout,regalloc-validate=1'
             check_arch: true
 
           - name: build_upstream_closure

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -252,12 +252,10 @@ let postlude :
      cfg_with_infos ->
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
   (* note: slots need to be updated before prologue removal *)
-  if Lazy.force stack_slots_optim
-  then
-    Profile.record ~accumulate:true "stack_slots_optimize"
-      (fun () ->
-        Regalloc_stack_slots.optimize (State.stack_slots state) cfg_with_infos)
-      ();
+  Profile.record ~accumulate:true "stack_slots_optimize"
+    (fun () ->
+      Regalloc_stack_slots.optimize (State.stack_slots state) cfg_with_infos)
+    ();
   Regalloc_stack_slots.update_cfg_with_layout (State.stack_slots state)
     cfg_with_layout;
   if Utils.debug

--- a/backend/regalloc/regalloc_stack_slots.ml
+++ b/backend/regalloc/regalloc_stack_slots.ml
@@ -305,7 +305,7 @@ let optimize (t : t) (cfg_with_infos : Cfg_with_infos.t) : unit =
               let reg_class = Proc.register_class reg in
               match Buckets.find_bucket buckets ~reg_class ~slot_index with
               | None ->
-                fatal "slot %d (reg_class=%d) has in not in any of the buckets"
+                fatal "slot %d (reg_class=%d) is not in any of the buckets"
                   slot_index reg_class
               | Some bucket_index ->
                 if debug

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -46,8 +46,6 @@ let bool_of_param ?guard param_name =
          then fatal "%s is set but %s is not" param_name guard_name);
      res)
 
-let stack_slots_optim = bool_of_param "STACK_SLOTS_OPTIM"
-
 let validator_debug = bool_of_param "VALIDATOR_DEBUG"
 
 type liveness = Cfg_with_infos.liveness

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -12,8 +12,6 @@ val find_param_value : string -> string option
 
 val bool_of_param : ?guard:bool * string -> string -> bool Lazy.t
 
-val stack_slots_optim : bool Lazy.t
-
 val validator_debug : bool Lazy.t
 
 type liveness = Cfg_with_infos.liveness


### PR DESCRIPTION
This pull request removes the stack
slots optimization parameter, to have
the optimization always enabled.

The optimization was measured on
large builds to take about 7% of
total register allocation time when
using IRC, and about 13% when using
LS.

While this is not particularly cheap,
the optimization has a dramatic effect
on stack usage so it feels important
to have it always enabled. It is also
noteworthy that the numbers are
driven by outliers with huge CFGs;
indeed this pass iterates over the
whole graph to build the intervals.