### PR TITLE
Fix layouts in flambda1 partial application simplification

### DIFF
--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -780,7 +780,7 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
             else if nargs > 0 && nargs < arity then
               simplify_partial_application env r ~lhs_of_application
                 ~closure_id_being_applied ~function_decl ~args ~mode ~dbg
-                ~inlined_requested ~specialise_requested ~result_layout
+                ~inlined_requested ~specialise_requested
             else
               Misc.fatal_errorf "Function with arity %d when simplifying \
                   application expression: %a"
@@ -809,7 +809,7 @@ and simplify_full_application env r ~function_decls ~lhs_of_application
 
 and simplify_partial_application env r ~lhs_of_application
       ~closure_id_being_applied ~function_decl ~args ~mode ~dbg
-      ~inlined_requested ~specialise_requested ~result_layout
+      ~inlined_requested ~specialise_requested
   =
   let arity = A.function_arity function_decl in
   assert (arity > List.length args);
@@ -867,10 +867,9 @@ and simplify_partial_application env r ~lhs_of_application
         inlined = Default_inlined;
         specialise = Default_specialise;
         probe = None;
-        result_layout;
+        result_layout = function_decl.A.return_layout;
       }
     in
-    assert(Lambda.compatible_layout function_decl.A.return_layout result_layout);
     let closure_variable =
       Variable.rename ~debug_info:(Closure_id.debug_info closure_id_being_applied)
         (Closure_id.unwrap closure_id_being_applied)

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -777,10 +777,13 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
                 ~function_decls ~lhs_of_application ~closure_id_being_applied
                 ~function_decl ~value_set_of_closures ~dbg ~reg_close ~mode
                 ~inlined_requested ~specialise_requested ~result_layout
-            else if nargs > 0 && nargs < arity then
+            else if nargs > 0 && nargs < arity then begin
+              assert(Lambda.compatible_layout Lambda.layout_function
+                       result_layout);
               simplify_partial_application env r ~lhs_of_application
                 ~closure_id_being_applied ~function_decl ~args ~mode ~dbg
                 ~inlined_requested ~specialise_requested
+            end
             else
               Misc.fatal_errorf "Function with arity %d when simplifying \
                   application expression: %a"


### PR DESCRIPTION
~~(I'm not confident this is correct, and if it is other problems remain.)~~

This addresses an flambda1-specific failure I'm seeing over in #1528, which adds unboxed floats to the front-end.  In that PR, this program trips [an assert](https://github.com/ocaml-flambda/flambda-backend/blob/f951994b019c8314a8c95626d1c1a98d69f4e541/middle_end/flambda/inline_and_simplify.ml#L873) in `Inline_and_simplify.simplify_partial_application`:
```ocaml
let id_float (x : float#) = x

let app f (x : float#) = f x

let id_float' = app id_float
```
The assert tripped is:
```ocaml
    assert(Lambda.compatible_layout function_decl.A.return_layout result_layout);
```
This assert is surprising to me.  As far as I can tell, `result_layout` is the result of the application.  Since we're looking at a partial application, the result type is a function and the result layout will always be value.  On the other hand, the `return_layout` of the function being partially applied may not be value.

This PR attempts to fix this by dropping the assert and correcting a layout in the resulting function.  I can't test it here since there are no other layouts allowed by the front-end.  I have tested it in #1528, and it seems to work.  ~~But I'm also seeing other flambda1 problems that I'm less sure how to fix, so I don't feel confident - I'll write a slack message about those.~~

Edit: The things that worried me in the original message did turn out to be a distinct issue, now addressed in #1557 