### PR TITLE
Flambda2 layouts: Fix partial application wrapper result arity

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2050,7 +2050,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
         exn_continuation;
         inlined = Lambda.Default_inlined;
         mode = result_mode;
-        return_arity = result_arity;
+        return_arity = result_arity
       }
       (Some approx) ~replace_region:None
   in
@@ -2093,11 +2093,10 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
                  Flambda_arity.cardinal missing_arity
                  - first_complex_local_param
              })
-        ~params ~return:result_arity ~return_continuation
-        ~exn_continuation ~my_region:apply.region ~body:fbody ~attr
-        ~loc:apply.loc ~free_idents_of_body ~closure_alloc_mode
-        ~first_complex_local_param ~contains_no_escaping_local_allocs
-        Recursive.Non_recursive ]
+        ~params ~return:result_arity ~return_continuation ~exn_continuation
+        ~my_region:apply.region ~body:fbody ~attr ~loc:apply.loc
+        ~free_idents_of_body ~closure_alloc_mode ~first_complex_local_param
+        ~contains_no_escaping_local_allocs Recursive.Non_recursive ]
   in
   let body acc env =
     let arg = find_simple_from_id env wrapper_id in


### PR DESCRIPTION
This fixes an issue where an incorrect result arity on a partial application wrapper will trip a couple asserts in flambda2 (and would generate incorrect code without the asserts).  The basic issue is two places where the result arity of a partial application (which is always value) is incorrectly used as the result arity of the fully applied version after wrapping (which might not be value).

I don't think this error can be observed on the current main branch because you need alternate layouts.  But I can see it in #1528 on programs like this:
```ocaml
external of_float : (float[@local_opt]) -> float# = "%unbox_float"

let[@inline never] myapp f (x : float#) = f x

let id_float = myapp (fun x -> x)

let make_pi =
  let x = id_float (of_float 3.14) in ()
```

Both places are in `Closure_conversion.wrap_partial_application` - the rest of this is just plumbing to get the correct result arity to that function.

I haven't added a test here because I'm not sure it's possible without another layout, but I have tested applying this diff to #1528, which gets the tests to pass on flambda2 on my machine.  I've just pushed it there and we'll see if the CI validates that.