### PR TITLE
exclave_ implies strictly local

### DIFF
--- a/ocaml/testsuite/tests/typing-local/exclave.ml
+++ b/ocaml/testsuite/tests/typing-local/exclave.ml
@@ -200,3 +200,15 @@ val f : unit -> local_ unit = <fun>
 - : unit = ()
 |}]
 
+(* exclave means the inner body must be exactly at local; cannot be global *)
+let f () =
+  exclave_ (
+    (fun x y -> ()) : (string -> string -> unit)
+  )
+[%%expect{|
+Line 3, characters 4-19:
+3 |     (fun x y -> ()) : (string -> string -> unit)
+        ^^^^^^^^^^^^^^^
+Error: This function or one of its parameters escape their region
+       when it is partially applied
+|}]

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -4454,7 +4454,7 @@ and type_expect_
         | RTail (mode, _) ->
           (* mode' is RNontail, because currently our language cannot construct
              region in the tail of another region.*)
-          let mode' = mode_default mode in
+          let mode' = mode_exact mode in
           (* The middle-end relies on all functions which allocate into their
              parent's region having a return mode of local. *)
           submode ~loc ~env ~reason:Other Value_mode.local mode';


### PR DESCRIPTION
This PR makes `exclave_ exp` requiring `exp` to be strictly `local`, in accordance to the existing behaviour of `local_`. 

Request review from @lpw25 