### PR TITLE
clean up `expected_mode` related stuff

### DIFF
--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1285,7 +1285,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                 else
                   let ty' = extract_option_type val_env ty
                   and ty0' = extract_option_type val_env ty0 in
-                  option_some val_env Value_mode.global sarg ty' ty0',
+                  type_optional_argument val_env Value_mode.global sarg ty' ty0',
                   (* CR layouts v5: Change the sort when options can hold
                      non-values. *)
                   Sort.value

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1285,8 +1285,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                 else
                   let ty' = extract_option_type val_env ty
                   and ty0' = extract_option_type val_env ty0 in
-                  let arg = type_argument val_env sarg ty' ty0' in
-                  option_some val_env arg Value_mode.global,
+                  option_some val_env Value_mode.global sarg ty' ty0',
                   (* CR layouts v5: Change the sort when options can hold
                      non-values. *)
                   Sort.value

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -389,10 +389,11 @@ let mode_max = mode_default Value_mode.max_mode
 (** Same as [mode_max] but set [position] *)
 let mode_max_with_position position = { mode_max with position }
 
-(** used when entering a region whose type must cross modes *)
+(** For typing subexpressions while entering a region, where the
+    subexpression has a fixed type that crosses all mode axes *)
 let mode_max_with_region =
-  { (mode_default Value_mode.local) with
-    position = RTail (Value_mode.local, FNontail);
+  { mode_max with
+    position = RTail (Value_mode.max_mode, FNontail);
   }
 
 (** Used for several cases; all non-tail *)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -294,7 +294,6 @@ type position_in_region =
 
 type expected_mode =
   { position : position_in_region;
-
     escaping_context : Env.escaping_context option;
     (** explains why [mode] is low. Better be empty if [mode] is max *)
 
@@ -316,7 +315,6 @@ type expected_mode =
 
 type position_and_mode = {
   apply_position : apply_position;
-
   region_mode : Value_mode.t option;
   (** [Some m] if [position] is [Tail], where m is the mode of the surrounding
      function's return mode *)

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -145,7 +145,7 @@ val type_argument:
         Env.t -> Parsetree.expression ->
         type_expr -> type_expr -> Typedtree.expression
 
-val option_some:
+val type_optional_argument:
   Env.t -> value_mode -> Parsetree.expression -> type_expr -> type_expr
   -> Typedtree.expression
 val option_none:

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -146,7 +146,8 @@ val type_argument:
         type_expr -> type_expr -> Typedtree.expression
 
 val option_some:
-  Env.t -> Typedtree.expression -> value_mode -> Typedtree.expression
+  Env.t -> value_mode -> Parsetree.expression -> type_expr -> type_expr
+  -> Typedtree.expression
 val option_none:
   Env.t -> type_expr -> Location.t -> Typedtree.expression
 val extract_option_type: Env.t -> type_expr -> type_expr


### PR DESCRIPTION
Clean up comments and codes around the `expected_mode` stuff. I don't think any behaviour is changed. 

In particular, I reduced the usage of `mode_subcomponent`. I almost eliminated it, but  in `Pexp_record` there is some circular logic that still requires it.

Request review from @lpw25 