### PR TITLE
Make environment lazy in preparation for simd extension

### DIFF
--- a/ocaml/debugger/loadprinter.ml
+++ b/ocaml/debugger/loadprinter.ml
@@ -105,7 +105,7 @@ let match_printer_type desc typename =
   let printer_type =
     match
       Env.find_type_by_name
-        (Ldot(Lident "Topdirs", typename)) Env.initial_safe_string
+        (Ldot(Lident "Topdirs", typename)) (Lazy.force Env.initial_safe_string)
     with
     | path, _ -> path
     | exception Not_found ->
@@ -113,7 +113,7 @@ let match_printer_type desc typename =
   in
   Ctype.begin_def();
   let ty_arg = Ctype.newvar Layout.(value ~why:Debug_printer_argument) in
-  Ctype.unify Env.initial_safe_string
+  Ctype.unify (Lazy.force Env.initial_safe_string)
     (Ctype.newconstr printer_type [ty_arg])
     (Ctype.instance desc.val_type);
   Ctype.end_def();

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -1898,7 +1898,8 @@ let get_mod_field modname field =
   lazy
     (let mod_ident = Ident.create_persistent modname in
      let env =
-       Env.add_persistent_structure mod_ident Env.initial_safe_string
+       Env.add_persistent_structure mod_ident
+         (Lazy.force Env.initial_safe_string)
      in
      match Env.open_pers_signature modname env with
      | Error `Not_found ->
@@ -3580,7 +3581,7 @@ let failure_handler ~scopes loc ~failer () =
     let sloc = Scoped_location.of_location ~scopes loc in
     let slot =
       transl_extension_path sloc
-        Env.initial_safe_string Predef.path_match_failure
+        (Lazy.force Env.initial_safe_string) Predef.path_match_failure
     in
     let fname, line, char =
       Location.get_pos_info loc.Location.loc_start in

--- a/ocaml/lambda/transl_array_comprehension.ml
+++ b/ocaml/lambda/transl_array_comprehension.ml
@@ -210,7 +210,7 @@ end = struct
     let slot =
       transl_extension_path
         loc
-        Env.initial_safe_string
+        (Lazy.force Env.initial_safe_string)
         Predef.path_invalid_argument
     in
     (* CR-someday aspectorzabusky: We might want to raise an event here for

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -297,7 +297,7 @@ let event_function ~scopes exp lam =
 let assert_failed ~scopes exp =
   let slot =
     transl_extension_path Loc_unknown
-      Env.initial_safe_string Predef.path_assert_failure
+      (Lazy.force Env.initial_safe_string) Predef.path_assert_failure
   in
   let loc = exp.exp_loc in
   let (fname, line, char) =

--- a/ocaml/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/ocaml/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -9,7 +9,7 @@
 let res =
   let s = {| match None with Some (Some _) -> () | _ -> () |} in
   let pe = Parse.expression (Lexing.from_string s) in
-  let te = Typecore.type_expression (Env.initial_safe_string) pe in
+  let te = Typecore.type_expression (Lazy.force Env.initial_safe_string) pe in
   let ute = Untypeast.untype_expression te in
   Format.asprintf "%a" Pprintast.expression ute
 

--- a/ocaml/testsuite/tests/language-extensions/language_extensions.ml
+++ b/ocaml/testsuite/tests/language-extensions/language_extensions.ml
@@ -22,7 +22,7 @@ let report ~name ~text =
 
 let typecheck_with_extension ?(full_name = false) name =
   let success =
-    match Typecore.type_expression Env.initial_safe_string
+    match Typecore.type_expression (Lazy.force Env.initial_safe_string)
             extension_parsed_expression
     with
     | _ -> true

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -373,7 +373,7 @@ let in_current_module = function
 
 let in_pervasives p =
   in_current_module p &&
-  try ignore (Env.find_type p Env.initial_safe_string); true
+  try ignore (Env.find_type p (Lazy.force Env.initial_safe_string)); true
   with Not_found -> false
 
 let is_datatype decl=

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -2697,7 +2697,7 @@ let add_language_extension_types env =
    been parsed yet. So, we make the initial environment lazy.
 
    If language extensions are adjusted after [initial_safe_string] and
-   [initial_unsafe_string] are forced, these environment may be inaccurate.
+   [initial_unsafe_string] are forced, these environments may be inaccurate.
 *)
 let initial_safe_string = add_language_extension_types initial_safe_string
 let initial_unsafe_string = add_language_extension_types initial_unsafe_string

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -2696,8 +2696,8 @@ let add_language_extension_types env =
    turned on.  We can't do this at startup because command line flags haven't
    been parsed yet. So, we make the initial environment lazy.
 
-   It is important that [initial_safe_string] and [initial_unsafe_string] are
-   not forced until after the command line flags have been processed.
+   If language extensions are adjusted after [initial_safe_string] and
+   [initial_unsafe_string] are forced, these environment may be inaccurate.
 *)
 let initial_safe_string = add_language_extension_types initial_safe_string
 let initial_unsafe_string = add_language_extension_types initial_unsafe_string

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -59,8 +59,13 @@ type address =
 type t
 
 val empty: t
-val initial_safe_string: t
-val initial_unsafe_string: t
+
+(* Lazy: these should be forced only after command-line flags are parsed, as
+   construction consults the enabled language extensions.
+ *)
+val initial_safe_string: t Lazy.t
+val initial_unsafe_string: t Lazy.t
+
 val diff: t -> t -> Ident.t list
 
 type type_descr_kind =

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -60,9 +60,11 @@ type t
 
 val empty: t
 
-(* Lazy: these should be forced only after command-line flags are parsed, as
-   construction consults the enabled language extensions.
- *)
+(* These environments are lazy so that they may depend on the enabled
+   extensions, typically adjusted via command line flags.  If extensions are
+   changed after these environments are forced, they may be inaccurate.  This
+   could happen, for example, if extensions are adjusted via the
+   compiler-libs. *)
 val initial_safe_string: t Lazy.t
 val initial_unsafe_string: t Lazy.t
 

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -291,6 +291,12 @@ let build_initial_env add_type add_exception empty_env =
   let unsafe_string = add_type ident_bytes ~manifest:type_string common in
   (safe_string, unsafe_string)
 
+let add_simd_extension_types add_type env =
+  let add_type = mk_add_type add_type in
+  (* CR ccasinghino for mslater: Change the line below to [add_type ident_vec128
+     env]. *)
+  ignore add_type; env
+
 let builtin_values =
   List.map (fun id -> (Ident.name id, id)) all_predef_exns
 

--- a/ocaml/typing/predef.mli
+++ b/ocaml/typing/predef.mli
@@ -78,6 +78,13 @@ val build_initial_env:
   (Ident.t -> extension_constructor -> 'a -> 'a) ->
   'a -> 'a * 'a
 
+(* Add simd types to an environment.  We can't do this in [build_initial_env]
+   because we'd like to only do it if the simd extension is on, and the initial
+   environment is constructed at startup before command-line flags can be
+   consulted. *)
+val add_simd_extension_types :
+  (Ident.t -> type_declaration -> 'a -> 'a) -> 'a -> 'a
+
 (* To initialize linker tables *)
 
 val builtin_values: (string * Ident.t) list

--- a/ocaml/typing/predef.mli
+++ b/ocaml/typing/predef.mli
@@ -78,10 +78,8 @@ val build_initial_env:
   (Ident.t -> extension_constructor -> 'a -> 'a) ->
   'a -> 'a * 'a
 
-(* Add simd types to an environment.  We can't do this in [build_initial_env]
-   because we'd like to only do it if the simd extension is on, and the initial
-   environment is constructed at startup before command-line flags can be
-   consulted. *)
+(* Add simd types to an environment.  This is separate from [build_initial_env]
+   because we'd like to only do it if the simd extension is on. *)
 val add_simd_extension_types :
   (Ident.t -> type_declaration -> 'a -> 'a) -> 'a -> 'a
 

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -193,9 +193,9 @@ let initial_env ~loc ~safe_string ~initially_opened_module
     ~open_implicit_modules =
   let env =
     if safe_string then
-      Env.initial_safe_string
+      Lazy.force Env.initial_safe_string
     else
-      Env.initial_unsafe_string
+      Lazy.force Env.initial_unsafe_string
   in
   let open_module env m =
     let open Asttypes in
@@ -3382,7 +3382,8 @@ let package_units initial_env objfiles cmifile modulename =
          let modname = Compilation_unit.create_child modulename unit in
          let sg = Env.read_signature modname (pref ^ ".cmi") in
          if Filename.check_suffix f ".cmi" &&
-            not(Mtype.no_code_needed_sig Env.initial_safe_string sg)
+            not(Mtype.no_code_needed_sig (Lazy.force Env.initial_safe_string)
+                  sg)
          then raise(Error(Location.none, Env.empty,
                           Implementation_is_required f));
          Compilation_unit.name modname,


### PR DESCRIPTION
This makes the initial environment lazy so that we can add types conditionally based on the presence of language extensions.  It also adds some stubs for that simd logic to be filled in in the simd PR.

This is just refresh of @ncik-roberts previous version [here](https://github.com/ocaml-flambda/flambda-backend/commit/fb093a3b75388f7494f0cb6e2629f916c466f407).  He did it for unboxed floats, but we eventually went a different way there.

Review: @goldfirere 