### PR TITLE
Pattern guard translation

### DIFF
--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -935,71 +935,8 @@ let next_raise_count () =
   incr raise_count ;
   !raise_count
 
-type action =
-  | Guarded_predicate of lambda
-  | Guarded_pattern of lambda
-  | Unguarded of lambda
-
-let is_guarded = function
-  | Guarded_predicate _ | Guarded_pattern _ -> true
-  | Unguarded _ -> false
-
-let lambda_of_action = function
-  | Guarded_predicate action | Guarded_pattern action | Unguarded action ->
-      action
-
-let map_action ~f = function
-  | Guarded_predicate action -> Guarded_predicate (f action)
-  | Guarded_pattern action -> Guarded_pattern (f action)
-  | Unguarded action -> Unguarded (f action)
-
 (* Anticipated staticraise, for guards *)
 let staticfail = Lstaticraise (0,[])
-
-let value_or_fatal err_msg = function
-  | None -> fatal_error err_msg
-  | Some x -> x
-
-let rec patch_lets_and_events patch_leaf patch = function
-  | Llet (str, k, id, lam, body) ->
-      Option.map (fun patched -> Llet (str, k, id, lam, patched))
-        (patch_lets_and_events patch_leaf patch body)
-  | Levent (lam, ev) ->
-      Option.map (fun patched -> Levent (patched, ev))
-        (patch_lets_and_events patch_leaf patch lam)
-  | lam -> patch_leaf patch lam
-
-let patch_catch patch = function
-  | Lstaticcatch (body, (id, params), Lstaticraise (0,[]), kind) ->
-      Some (Lstaticcatch (body, (id, params), patch, kind))
-  | _ -> None
-
-let patch_catch = patch_lets_and_events patch_catch
-
-let rec patch_pattern patch = function
-  | Lstaticcatch (body, (id, params), Lstaticraise (0,[]), kind) ->
-      Lstaticcatch (body, (id, params), patch, kind)
-  | Lstaticcatch (body, (id, params), handler, kind) ->
-      (match patch_catch patch handler with
-         | None ->
-             let body = patch_pattern patch body in
-             Lstaticcatch (body, (id, params), handler, kind)
-         | Some handler -> Lstaticcatch (body, (id, params), handler, kind))
-  | lam -> value_or_fatal "Lambda.patch_pattern" (patch_catch patch lam)
-
-let patch_predicate patch = function
-  | Lifthenelse (cond, body, Lstaticraise (0,[]), kind) ->
-      Some (Lifthenelse (cond, body, patch, kind))
-  | _ -> None
-
-let patch_predicate patch lam =
-  let patched = patch_lets_and_events patch_predicate patch lam in
-  value_or_fatal "Lambda.patch_predicate" patched
-
-let patch_guarded patch = function
-  | Guarded_pattern lam -> patch_pattern patch lam
-  | Guarded_predicate lam -> patch_predicate patch lam
-  | Unguarded _ -> fatal_error "Lambda.patch_guarded"
 
 (* Translate an access path *)
 

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -935,9 +935,6 @@ let next_raise_count () =
   incr raise_count ;
   !raise_count
 
-(* Anticipated staticraise, for guards *)
-let staticfail = Lstaticraise (0,[])
-
 (* Translate an access path *)
 
 let rec transl_address loc = function

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -661,8 +661,6 @@ val primitive_may_allocate : primitive -> alloc_mode option
 (* Get a new static failure ident *)
 val next_raise_count : unit -> static_label
 
-val staticfail : lambda (* Anticipated static failure *)
-
 val raise_kind: raise_kind -> string
 
 val merge_inline_attributes

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -664,8 +664,18 @@ val next_raise_count : unit -> static_label
 val staticfail : lambda (* Anticipated static failure *)
 
 (* Check anticipated failure, substitute its final value *)
-val is_guarded: lambda -> bool
-val patch_guarded : lambda -> lambda -> lambda
+
+(* Guarded actions must be patched *)
+type action =
+  | Guarded_predicate of lambda
+  | Guarded_pattern of lambda
+  | Unguarded of lambda
+
+val is_guarded : action -> bool
+val lambda_of_action : action -> lambda
+val map_action : f:(lambda -> lambda) -> action -> action
+
+val patch_guarded : lambda -> action -> lambda
 
 val raise_kind: raise_kind -> string
 

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -663,20 +663,6 @@ val next_raise_count : unit -> static_label
 
 val staticfail : lambda (* Anticipated static failure *)
 
-(* Check anticipated failure, substitute its final value *)
-
-(* Guarded actions must be patched *)
-type action =
-  | Guarded_predicate of lambda
-  | Guarded_pattern of lambda
-  | Unguarded of lambda
-
-val is_guarded : action -> bool
-val lambda_of_action : action -> lambda
-val map_action : f:(lambda -> lambda) -> action -> action
-
-val patch_guarded : lambda -> action -> lambda
-
 val raise_kind: raise_kind -> string
 
 val merge_inline_attributes

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -142,13 +142,14 @@ type action =
 
      Some translation functionality requires us to check syntactic properties
      of actions. Rather than recomputing [patch_guarded] at the time of these
-     checks, we keep track of [unpatched], a lambda term which contains
-     [staticfail] in the position to be patched.
+     checks, we keep track of [unpatched], a lambda term which contains a dummy
+     value [Lstaticraise (0,[])] in the position to be patched.
   *)
   | Unguarded of lambda
 
-let mk_guarded ~patch_guarded : action =
-  Guarded { patch_guarded; unpatched = patch_guarded ~patch:staticfail}
+let mk_guarded ~patch_guarded =
+  Guarded
+    { patch_guarded; unpatched = patch_guarded ~patch:(Lstaticraise (0,[])) }
 
 let mk_unguarded action = Unguarded action
 

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -145,6 +145,8 @@ type rhs =
      checks, we keep track of [unpatched], a lambda term which contains a dummy
      value [Lstaticraise (0,[])] in the position to be patched.
   *)
+  (* CR-soon rgodse: This workflow constructs the lambda term twice instead of
+     once. We can be more efficient by only computing the components we need. *)
   | Unguarded of lambda
 
 let mk_guarded_rhs ~patch_guarded =

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -133,10 +133,24 @@ type action =
   | Guarded of
       { patch_guarded: patch:lambda -> lambda
       ; unpatched: lambda }
+  (* Guarded actions must allow for fallthrough if the guard fails.
+
+     When translating a guarded action, the code to execute on fallthrough must
+     be "patched" in. Because the fallthrough code is translated after the
+     action is created, guarded actions carry a function [patch_guarded], which
+     generates a lambda term for the action from the fallthrough code.
+
+     Some translation functionality requires us to check syntactic properties
+     of actions. Rather than recomputing [patch_guarded] at the time of these
+     checks, we keep track of [unpatched], a lambda term which contains
+     [staticfail] in the position to be patched.
+  *)
   | Unguarded of lambda
 
 let mk_guarded ~patch_guarded : action =
   Guarded { patch_guarded; unpatched = patch_guarded ~patch:staticfail}
+
+let mk_unguarded action = Unguarded action
 
 let is_guarded = function
   | Guarded _ -> true

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -99,7 +99,6 @@ open Printpat
 
 module Scoped_location = Debuginfo.Scoped_location
 
-
 type error =
     Non_value_layout of Layout.Violation.t
 

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -19,37 +19,33 @@ open Typedtree
 open Lambda
 open Debuginfo.Scoped_location
 
-(* An action is a right-hand side of a case. *)
-type action
+(* Right-hand side of a case. *)
+type rhs
 
-(* Creates a guarded action.
+(* Creates a guarded rhs.
    
-   If a guard fails, a guarded action must fallthrough to the remaining cases.
-   To facilitate this, guarded actions are constructed using a continuation.
+   If a guard fails, a guarded rhs must fallthrough to the remaining cases.
+   To facilitate this, guarded rhs's are constructed using a continuation.
 
-   [mk_guarded ~patch_guarded] produces a guarded action with a lambda
+   [mk_guarded ~patch_guarded] produces a guarded rhs with a lambda
    representation given by [patch_guarded ~patch], where [patch] contains an
    expression that falls through to the remaining cases.
 *)
-val mk_guarded: patch_guarded:(patch:lambda -> lambda) -> action
+val mk_guarded_rhs: patch_guarded:(patch:lambda -> lambda) -> rhs
 
-(* Creates an unguarded action from its lambda representation. *)
-val mk_unguarded: lambda -> action
-
-val is_guarded: action -> bool
-val lambda_of_action: action -> lambda
-val map_action: f:(lambda -> lambda) -> action -> action
+(* Creates an unguarded rhs from its lambda representation. *)
+val mk_unguarded_rhs: lambda -> rhs
 
 (* Entry points to match compiler *)
 val for_function:
         scopes:scopes ->
         arg_sort:Layouts.sort -> arg_layout:layout -> return_layout:layout ->
-        Location.t -> int ref option -> lambda -> (pattern * action) list ->
+        Location.t -> int ref option -> lambda -> (pattern * rhs) list ->
         partial ->
         lambda
 val for_trywith:
         scopes:scopes -> return_layout:layout -> Location.t ->
-        lambda -> (pattern * action) list ->
+        lambda -> (pattern * rhs) list ->
         lambda
 val for_let:
         scopes:scopes -> arg_sort:Layouts.sort -> return_layout:layout ->
@@ -58,12 +54,12 @@ val for_let:
 val for_multiple_match:
         scopes:scopes -> return_layout:layout -> Location.t ->
         (lambda * Layouts.sort * layout) list -> alloc_mode ->
-        (pattern * action) list -> partial ->
+        (pattern * rhs) list -> partial ->
         lambda
 
 val for_tupled_function:
         scopes:scopes -> return_layout:layout -> Location.t ->
-        Ident.t list -> (pattern list * action) list -> partial ->
+        Ident.t list -> (pattern list * rhs) list -> partial ->
         lambda
 
 exception Cannot_flatten

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -19,26 +19,23 @@ open Typedtree
 open Lambda
 open Debuginfo.Scoped_location
 
-(* An action is a right-hand side of a case (as in a match, function, try) *)
-type action =
-| Guarded of
-    { patch_guarded: patch:lambda -> lambda
-    ; unpatched: lambda }
-(* Guarded actions must allow for fallthrough if the guard fails.
+(* An action is a right-hand side of a case. *)
+type action
 
-   When translating a guarded action, the code to execute on fallthrough must
-   be "patched" in. Because the fallthrough code is translated after the
-   action is created, guarded actions carry a function [patch_guarded], which
-   generates a lambda term for the action from the fallthrough code.
+(* Creates a guarded action.
+   
+   If a guard fails, a guarded action must fallthrough to the remaining cases.
+   To facilitate this, guarded actions are constructed using a continuation.
 
-   Some translation functionality requires us to check syntactic properties
-   of actions. Rather than recomputing [patch_guarded] at the time of these
-   checks, we keep track of [unpatched], a lambda term which contains
-   [staticfail] in the position to be patched.
+   [mk_guarded ~patch_guarded] produces a guarded action with a lambda
+   representation given by [patch_guarded ~patch], where [patch] contains an
+   expression that falls through to the remaining cases.
 *)
-| Unguarded of lambda
-
 val mk_guarded: patch_guarded:(patch:lambda -> lambda) -> action
+
+(* Creates an unguarded action from its lambda representation. *)
+val mk_unguarded: lambda -> action
+
 val is_guarded: action -> bool
 val lambda_of_action: action -> lambda
 val map_action: f:(lambda -> lambda) -> action -> action

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -19,11 +19,6 @@ open Typedtree
 open Lambda
 open Debuginfo.Scoped_location
 
-(* Guarded actions must be patched *)
-type action =
-  | Guarded of lambda
-  | Unguarded of lambda
-
 (* Entry points to match compiler *)
 val for_function:
         scopes:scopes ->

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -19,16 +19,21 @@ open Typedtree
 open Lambda
 open Debuginfo.Scoped_location
 
+(* Guarded actions must be patched *)
+type action =
+  | Guarded of lambda
+  | Unguarded of lambda
+
 (* Entry points to match compiler *)
 val for_function:
         scopes:scopes ->
         arg_sort:Layouts.sort -> arg_layout:layout -> return_layout:layout ->
-        Location.t -> int ref option -> lambda -> (pattern * lambda) list ->
+        Location.t -> int ref option -> lambda -> (pattern * action) list ->
         partial ->
         lambda
 val for_trywith:
         scopes:scopes -> return_layout:layout -> Location.t ->
-        lambda -> (pattern * lambda) list ->
+        lambda -> (pattern * action) list ->
         lambda
 val for_let:
         scopes:scopes -> arg_sort:Layouts.sort -> return_layout:layout ->
@@ -37,12 +42,12 @@ val for_let:
 val for_multiple_match:
         scopes:scopes -> return_layout:layout -> Location.t ->
         (lambda * Layouts.sort * layout) list -> alloc_mode ->
-        (pattern * lambda) list -> partial ->
+        (pattern * action) list -> partial ->
         lambda
 
 val for_tupled_function:
         scopes:scopes -> return_layout:layout -> Location.t ->
-        Ident.t list -> (pattern list * lambda) list -> partial ->
+        Ident.t list -> (pattern list * action) list -> partial ->
         lambda
 
 exception Cannot_flatten

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -213,7 +213,7 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
          let body =
            Matching.for_function ~scopes ~arg_sort ~arg_layout
              ~return_layout:layout_obj pat.pat_loc None (Lvar param)
-             [pat, Matching.mk_unguarded rem] partial
+             [pat, Matching.mk_unguarded_rhs rem] partial
          in
          Lambda.lfunction
                    ~kind:(Curried {nlocal=0})
@@ -501,7 +501,7 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
         let return_layout = layout_class in
         let body =
           Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout pat.pat_loc
-            None (Lvar param) [pat, Matching.mk_unguarded rem] partial
+            None (Lvar param) [pat, Matching.mk_unguarded_rhs rem] partial
         in
         Lambda.lfunction
                   ~kind:(Curried {nlocal=0})

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -213,7 +213,7 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
          let body =
            Matching.for_function ~scopes ~arg_sort ~arg_layout
              ~return_layout:layout_obj pat.pat_loc None (Lvar param)
-             [pat, Unguarded rem] partial
+             [pat, Matching.mk_unguarded rem] partial
          in
          Lambda.lfunction
                    ~kind:(Curried {nlocal=0})
@@ -501,7 +501,7 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
         let return_layout = layout_class in
         let body =
           Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout pat.pat_loc
-            None (Lvar param) [pat, Unguarded rem] partial
+            None (Lvar param) [pat, Matching.mk_unguarded rem] partial
         in
         Lambda.lfunction
                   ~kind:(Curried {nlocal=0})

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -212,8 +212,8 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
          in
          let body =
            Matching.for_function ~scopes ~arg_sort ~arg_layout
-             ~return_layout:layout_obj pat.pat_loc None (Lvar param) [pat, rem]
-             partial
+             ~return_layout:layout_obj pat.pat_loc None (Lvar param)
+             [pat, Unguarded rem] partial
          in
          Lambda.lfunction
                    ~kind:(Curried {nlocal=0})
@@ -501,7 +501,7 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
         let return_layout = layout_class in
         let body =
           Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout pat.pat_loc
-            None (Lvar param) [pat, rem] partial
+            None (Lvar param) [pat, Unguarded rem] partial
         in
         Lambda.lfunction
                   ~kind:(Curried {nlocal=0})

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1049,9 +1049,10 @@ and transl_guard ~scopes guard rhs_sort rhs =
             in
             Matching.mk_guarded_rhs ~patch_guarded
         | Total ->
-            let nested_match = transl_match ~scopes ~arg_sort:pg_scrutinee_sort
-              ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
-              ~env:pg_env ~extra_cases:[] pg_scrutinee [ guard_case ] pg_partial
+            let nested_match =
+              transl_match ~scopes ~arg_sort:pg_scrutinee_sort
+                ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
+                ~env:pg_env ~extra_cases:[] pg_scrutinee [ guard_case ] pg_partial
             in
             Matching.mk_unguarded_rhs
               (event_before ~scopes pg_scrutinee nested_match)

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1009,13 +1009,13 @@ and transl_list_with_shape ~scopes expr_list =
   in
   List.split (List.map transl_with_shape expr_list)
 
-and transl_guard ~scopes guard rhs_sort rhs : Matching.action =
+and transl_guard ~scopes guard rhs_sort rhs : action =
   let layout = layout_exp rhs_sort rhs in
   let expr = event_before ~scopes rhs (transl_exp ~scopes rhs_sort rhs) in
   match guard with
   | None -> Unguarded expr
   | Some (Predicate cond) ->
-      Guarded (
+      Guarded_predicate (
         event_before ~scopes cond
           (Lifthenelse(transl_exp ~scopes Sort.for_predef_value cond,
                        expr, staticfail, layout)))
@@ -1036,12 +1036,12 @@ and transl_guard ~scopes guard rhs_sort rhs : Matching.action =
               ; pat_attributes = []
               }
             in
-            let extra_cases = [ (any_pat, Matching.Unguarded staticfail) ] in
+            let extra_cases = [ (any_pat, Unguarded staticfail) ] in
             let nested_match = transl_match ~scopes ~arg_sort
               ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc ~env
               ~extra_cases arg [ guard_case ] partial
             in
-            Guarded nested_match
+            Guarded_pattern nested_match
         | Total ->
             let nested_match = transl_match ~scopes ~arg_sort
               ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc ~env
@@ -1611,8 +1611,8 @@ and transl_match ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
             ~always:(fun () ->
                 iter_exn_names Translprim.remove_exception_ident pe)
         in
-        (pv, Matching.Unguarded (static_raise vids)) :: val_cases,
-        (pe, Matching.Unguarded (static_raise ids)) :: exn_cases,
+        (pv, Unguarded (static_raise vids)) :: val_cases,
+        (pe, Unguarded (static_raise ids)) :: exn_cases,
         (lbl, ids_kinds, rhs) :: static_handlers
   in
   let val_cases, exn_cases, static_handlers =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1593,7 +1593,7 @@ and transl_match ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
           Lstaticraise (lbl, List.map (fun id -> Lvar id) ids)
         in
         (* Simplif doesn't like it if binders are not uniq, so we make sure to
-            use different names in the value and the exception branches. *)
+           use different names in the value and the exception branches. *)
         let ids_full = Typedtree.pat_bound_idents_full arg_sort pv in
         let ids = List.map (fun (id, _, _, _) -> id) ids_full in
         let ids_kinds =
@@ -1608,7 +1608,7 @@ and transl_match ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
         let rhs =
           Misc.try_finally
             (fun () -> event_before ~scopes c_rhs
-                          (transl_exp ~scopes return_sort c_rhs))
+                         (transl_exp ~scopes return_sort c_rhs))
             ~always:(fun () ->
                 iter_exn_names Translprim.remove_exception_ident pe)
         in
@@ -1622,31 +1622,31 @@ and transl_match ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
   in
   (* In presence of exception patterns, the code we generate for
 
-        match <scrutinees> with
-        | <val-patterns> -> <val-actions>
-        | <exn-patterns> -> <exn-actions>
+       match <scrutinees> with
+       | <val-patterns> -> <val-actions>
+       | <exn-patterns> -> <exn-actions>
 
-      looks like
+     looks like
 
-        staticcatch
-          (try (exit <val-exit> <scrutinees>)
+       staticcatch
+         (try (exit <val-exit> <scrutinees>)
           with <exn-patterns> -> <exn-actions>)
-        with <val-exit> <val-ids> ->
+       with <val-exit> <val-ids> ->
           match <val-ids> with <val-patterns> -> <val-actions>
 
-      In particular, the 'exit' in the value case ensures that the
-      value actions run outside the try..with exception handler.
+     In particular, the 'exit' in the value case ensures that the
+     value actions run outside the try..with exception handler.
   *)
   let static_catch scrutinees val_ids handler =
     let id = Typecore.name_pattern "exn" (List.map fst exn_cases) in
     let static_exception_id = next_raise_count () in
     Lstaticcatch
       (Ltrywith (Lstaticraise (static_exception_id, scrutinees), id,
-                  Matching.for_trywith ~scopes ~return_layout loc (Lvar id)
-                    exn_cases,
-                  return_layout),
-        (static_exception_id, val_ids),
-        handler,
+                 Matching.for_trywith ~scopes ~return_layout loc (Lvar id)
+                   exn_cases,
+                 return_layout),
+       (static_exception_id, val_ids),
+       handler,
       return_layout)
   in
   let classic =
@@ -1662,9 +1662,9 @@ and transl_match ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
         let val_ids, lvars =
           List.map
             (fun (arg,s) ->
-                let layout = layout_exp s arg in
-                let id = Typecore.name_pattern "val" [] in
-                (id, layout), (Lvar id, s, layout))
+               let layout = layout_exp s arg in
+               let id = Typecore.name_pattern "val" [] in
+               (id, layout), (Lvar id, s, layout))
             argl
           |> List.split
         in
@@ -1682,7 +1682,7 @@ and transl_match ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
         let arg_layout = layout_exp arg_sort arg in
         static_catch [transl_exp ~scopes arg_sort arg] [val_id, arg_layout]
           (Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
-              loc None (Lvar val_id) val_cases partial)
+             loc None (Lvar val_id) val_cases partial)
   in
   List.fold_left (fun body (static_exception_id, val_ids, handler) ->
     Lstaticcatch (body, (static_exception_id, val_ids), handler, return_layout)

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1009,7 +1009,7 @@ and transl_list_with_shape ~scopes expr_list =
   in
   List.split (List.map transl_with_shape expr_list)
 
-and transl_guard ~scopes guard rhs_sort rhs : action =
+and transl_guard ~scopes guard rhs_sort rhs =
   let layout = layout_exp rhs_sort rhs in
   let expr = event_before ~scopes rhs (transl_exp ~scopes rhs_sort rhs) in
   match guard with
@@ -1194,10 +1194,10 @@ and transl_apply ~scopes
 
 and transl_curried_function
       ~scopes ~arg_sort ~arg_layout ~return_sort ~return_layout loc repr ~region
-      ~curry partial warnings (param:Ident.t) cases : _ * lambda =
+      ~curry partial warnings (param:Ident.t) cases =
   let max_arity = Lambda.max_arity () in
   let rec loop ~scopes ~arg_sort ~arg_layout ~return_sort ~return_layout loc
-            ~arity ~region ~curry partial warnings (param:Ident.t) cases : _ * lambda =
+            ~arity ~region ~curry partial warnings (param:Ident.t) cases =
     match curry, cases with
       More_args {partial_mode},
       [{c_lhs=pat; c_guard=None;

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1019,33 +1019,34 @@ and transl_guard ~scopes guard rhs_sort rhs : action =
         event_before ~scopes cond
           (Lifthenelse(transl_exp ~scopes Sort.for_predef_value cond,
                        expr, staticfail, layout)))
-  | Some (Pattern (arg, arg_sort, pat, partial, loc, env)) ->
+  | Some (Pattern { pg_scrutinee; pg_scrutinee_sort; pg_pattern; pg_partial;
+                    pg_loc; pg_env }) ->
       let guard_case : _ case =
-        { c_lhs = pat
+        { c_lhs = pg_pattern
         ; c_guard = None
         ; c_rhs = rhs }
       in
-      match partial with
+      match pg_partial with
         | Partial -> 
             let any_pat : pattern =
               { pat_desc = Tpat_any
               ; pat_loc = Location.none
               ; pat_extra = []
-              ; pat_type = arg.exp_type
+              ; pat_type = pg_scrutinee.exp_type
               ; pat_env = Env.empty
               ; pat_attributes = []
               }
             in
             let extra_cases = [ (any_pat, Unguarded staticfail) ] in
-            let nested_match = transl_match ~scopes ~arg_sort
-              ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc ~env
-              ~extra_cases arg [ guard_case ] partial
+            let nested_match = transl_match ~scopes ~arg_sort:pg_scrutinee_sort
+              ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
+              ~env:pg_env ~extra_cases pg_scrutinee [ guard_case ] pg_partial
             in
             Guarded_pattern nested_match
         | Total ->
-            let nested_match = transl_match ~scopes ~arg_sort
-              ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc ~env
-              ~extra_cases:[] arg [ guard_case ] partial
+            let nested_match = transl_match ~scopes ~arg_sort:pg_scrutinee_sort
+              ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
+              ~env:pg_env ~extra_cases:[] pg_scrutinee [ guard_case ] pg_partial
             in
             Unguarded nested_match
 

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1040,10 +1040,12 @@ and transl_guard ~scopes guard rhs_sort rhs : Matching.action =
                 ; pat_attributes = []
                 }
               in
-              transl_match ~scopes ~arg_sort:pg_scrutinee_sort
-                ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
-                ~env:pg_env ~extra_cases:[ any_pat, Matching.Unguarded patch ]
-                pg_scrutinee [ guard_case ] pg_partial
+              let extra_cases = [ any_pat, Matching.Unguarded patch ] in
+              event_before ~scopes pg_scrutinee
+                (transl_match ~scopes ~arg_sort:pg_scrutinee_sort
+                   ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
+                   ~env:pg_env ~extra_cases pg_scrutinee [ guard_case ]
+                   pg_partial)
             in
             Matching.mk_guarded ~patch_guarded
         | Total ->
@@ -1051,7 +1053,7 @@ and transl_guard ~scopes guard rhs_sort rhs : Matching.action =
               ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
               ~env:pg_env ~extra_cases:[] pg_scrutinee [ guard_case ] pg_partial
             in
-            Unguarded nested_match
+            Unguarded (event_before ~scopes pg_scrutinee nested_match)
 
 and transl_case ~scopes rhs_sort {c_lhs; c_guard; c_rhs} =
   c_lhs, transl_guard ~scopes c_guard rhs_sort c_rhs

--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -11,21 +11,28 @@ let basic_usage ~f ~default x =
 ;;
 
 let f x = if x > 0 then Some (x - 1) else None;;
-
-basic_usage ~f ~default:~-1 (Some 5);;
-basic_usage ~f ~default:~-1 (Some 0);;
-basic_usage ~f ~default:~-1 (Some ~-5);;
-basic_usage ~f ~default:~-1 None;;
 [%%expect{|
 val basic_usage : f:('a -> 'b option) -> default:'b -> 'a option -> 'b =
   <fun>
 val f : int -> int option = <fun>
+|}];;
+
+basic_usage ~f ~default:~-1 (Some 5);;
+[%%expect{|
 - : int = 4
+|}];;
+basic_usage ~f ~default:~-1 (Some 0);;
+[%%expect{|
 - : int = -1
+|}];;
+basic_usage ~f ~default:~-1 (Some ~-5);;
+[%%expect{|
 - : int = -1
+|}];;
+basic_usage ~f ~default:~-1 None;;
+[%%expect{|
 - : int = -1
-|}]
-;;
+|}];;
 
 let seq_predicate x ~f ~g ~default =
   match x with
@@ -35,20 +42,17 @@ let seq_predicate x ~f ~g ~default =
 [%%expect{|
 val seq_predicate :
   'a option -> f:('a -> 'b) -> g:('a -> bool) -> default:'a -> 'a = <fun>
-|}]
+|}];;
 
 let seq_pattern x ~f ~g ~default =
   match x with
     | Some x when (f x; g x) match Some y -> y
     | _ -> default
+;;
 
 let counter = ref 0;;
 let f () = incr counter;;
 let g () = if !counter > 1 then Some (!counter - 1) else None;;
-
-seq_pattern (Some ()) ~f ~g ~default:0;;
-seq_pattern (Some ()) ~f ~g ~default:0;;
-seq_pattern None ~f ~g ~default:0;;
 [%%expect{|
 val seq_pattern :
   'a option -> f:('a -> 'b) -> g:('a -> 'c option) -> default:'c -> 'c =
@@ -56,8 +60,18 @@ val seq_pattern :
 val counter : int ref = {contents = 0}
 val f : unit -> unit = <fun>
 val g : unit -> int option = <fun>
+|}];;
+
+seq_pattern (Some ()) ~f ~g ~default:0;;
+[%%expect{|
 - : int = 0
+|}];;
+seq_pattern (Some ()) ~f ~g ~default:0;;
+[%%expect{|
 - : int = 1
+|}];;
+seq_pattern None ~f ~g ~default:0;;
+[%%expect{|
 - : int = 0
 |}]
 
@@ -70,6 +84,7 @@ let complex_types (x : int list option) : bool =
   match strs_opt with
     | Some strs when strs match ("foo", s2) -> String.equal s2 "bar"
     | Some _ | None -> false
+;;
 [%%expect {|
 val complex_types : int list option -> bool = <fun>
 |}]
@@ -103,14 +118,20 @@ let shadow_outer_variables (n : int option) (strs : string list) =
   | Some n when List.nth_opt strs n match Some s -> s
   | _ -> "Not found"
 ;;
-
-shadow_outer_variables (Some 0) [ "foo"; "bar" ];;
-shadow_outer_variables (Some 1) [ "foo"; "bar" ];;
-shadow_outer_variables (Some 2) [ "foo"; "bar" ];;
 [%%expect{|
 val shadow_outer_variables : int option -> string list -> string = <fun>
+|}];;
+
+shadow_outer_variables (Some 0) [ "foo"; "bar" ];;
+[%%expect{|
 - : string = "foo"
+|}];;
+shadow_outer_variables (Some 1) [ "foo"; "bar" ];;
+[%%expect{|
 - : string = "bar"
+|}];;
+shadow_outer_variables (Some 2) [ "foo"; "bar" ];;
+[%%expect{|
 - : string = "Not found"
 |}]
 
@@ -145,25 +166,36 @@ let exhaustive_pattern_guards (x : (unit, void option) Either.t) : int =
     | Right v when v match None -> 1
     | _ -> 2
 ;;
-
-exhaustive_pattern_guards (Left ());;
-exhaustive_pattern_guards (Right None);;
 [%%expect{|
 type void = |
-Line 144, characters 13-28:
-144 |     | Left u when u match () -> 0
+Line 165, characters 13-28:
+165 |     | Left u when u match () -> 0
                    ^^^^^^^^^^^^^^^
 Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
-Line 145, characters 14-31:
-145 |     | Right v when v match None -> 1
+Line 166, characters 14-31:
+166 |     | Right v when v match None -> 1
                     ^^^^^^^^^^^^^^^^^
 Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
 val exhaustive_pattern_guards : (unit, void option) Either.t -> int = <fun>
+|}];;
+
+exhaustive_pattern_guards (Left ());;
+[%%expect{|
 - : int = 0
+|}];;
+exhaustive_pattern_guards (Right None);;
+[%%expect{|
 - : int = 1
 |}]
 
-module M = Map.Make (Int);;
+module M : sig
+  type 'a t
+
+  val empty : 'a t
+  val add : int -> 'a -> 'a t -> 'a t
+  val find : int -> 'a t -> 'a
+  val find_opt : int -> 'a t -> 'a option
+end = Map.Make (Int);;
 
 let say_hello (id : int option) (name_map : string M.t) =
   match id with
@@ -172,62 +204,33 @@ let say_hello (id : int option) (name_map : string M.t) =
 ;;
 
 let name_map = M.empty |> M.add 0 "Fred" |> M.add 4 "Barney";;
-say_hello (Some 0) name_map;;
-say_hello (Some 2) name_map;;
-say_hello (Some 4) name_map;;
-say_hello None name_map;;
 [%%expect{|
 module M :
   sig
-    type key = Int.t
-    type 'a t = 'a Map.Make(Int).t
+    type 'a t
     val empty : 'a t
-    val is_empty : 'a t -> bool
-    val mem : key -> 'a t -> bool
-    val add : key -> 'a -> 'a t -> 'a t
-    val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
-    val singleton : key -> 'a -> 'a t
-    val remove : key -> 'a t -> 'a t
-    val merge :
-      (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
-    val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
-    val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
-    val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
-    val iter : (key -> 'a -> unit) -> 'a t -> unit
-    val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
-    val for_all : (key -> 'a -> bool) -> 'a t -> bool
-    val exists : (key -> 'a -> bool) -> 'a t -> bool
-    val filter : (key -> 'a -> bool) -> 'a t -> 'a t
-    val filter_map : (key -> 'a -> 'b option) -> 'a t -> 'b t
-    val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
-    val cardinal : 'a t -> int
-    val bindings : 'a t -> (key * 'a) list
-    val min_binding : 'a t -> key * 'a
-    val min_binding_opt : 'a t -> (key * 'a) option
-    val max_binding : 'a t -> key * 'a
-    val max_binding_opt : 'a t -> (key * 'a) option
-    val choose : 'a t -> key * 'a
-    val choose_opt : 'a t -> (key * 'a) option
-    val split : key -> 'a t -> 'a t * 'a option * 'a t
-    val find : key -> 'a t -> 'a
-    val find_opt : key -> 'a t -> 'a option
-    val find_first : (key -> bool) -> 'a t -> key * 'a
-    val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
-    val find_last : (key -> bool) -> 'a t -> key * 'a
-    val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
-    val map : ('a -> 'b) -> 'a t -> 'b t
-    val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
-    val to_seq : 'a t -> (key * 'a) Seq.t
-    val to_rev_seq : 'a t -> (key * 'a) Seq.t
-    val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
-    val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
-    val of_seq : (key * 'a) Seq.t -> 'a t
+    val add : int -> 'a -> 'a t -> 'a t
+    val find : int -> 'a t -> 'a
+    val find_opt : int -> 'a t -> 'a option
   end
 val say_hello : int option -> string M.t -> string = <fun>
 val name_map : string M.t = <abstr>
+|}];;
+
+say_hello (Some 0) name_map;;
+[%%expect{|
 - : string = "Hello, Fred"
+|}];;
+say_hello (Some 2) name_map;;
+[%%expect{|
 - : string = "Hello, stranger"
+|}];;
+say_hello (Some 4) name_map;;
+[%%expect{|
 - : string = "Hello, Barney"
+|}];;
+say_hello None name_map;;
+[%%expect{|
 - : string = "Hello, stranger"
 |}]
 
@@ -237,14 +240,23 @@ let say_hello_catching_exns id name_map =
         "Hello, Barney"
     | None | Some _ -> "Hello, Fred"
 ;;
+[%%expect{|
+val say_hello_catching_exns : int option -> string M.t -> string = <fun>
+|}];;
+
 say_hello_catching_exns (Some 0) name_map;;
+[%%expect{|
+- : string = "Hello, Fred"
+|}];;
 say_hello_catching_exns (Some 2) name_map;;
+[%%expect{|
+- : string = "Hello, Barney"
+|}];;
 say_hello_catching_exns (Some 4) name_map;;
+[%%expect{|
+- : string = "Hello, Barney"
+|}];;
 say_hello_catching_exns None name_map;;
 [%%expect{|
-val say_hello_catching_exns : M.key option -> string M.t -> string = <fun>
-- : string = "Hello, Fred"
-- : string = "Hello, Barney"
-- : string = "Hello, Barney"
 - : string = "Hello, Fred"
 |}]

--- a/ocaml/typing/cmt2annot.ml
+++ b/ocaml/typing/cmt2annot.ml
@@ -52,7 +52,7 @@ let bind_cases l =
           let gexp =
             match g with
             | Predicate pred -> pred
-            | Pattern (exp, _, pat, _) ->
+            | Pattern (exp, _, pat, _, _, _) ->
                 bind_variables c_rhs.exp_loc pat;
                 exp
               in

--- a/ocaml/typing/cmt2annot.ml
+++ b/ocaml/typing/cmt2annot.ml
@@ -52,9 +52,9 @@ let bind_cases l =
           let gexp =
             match g with
             | Predicate pred -> pred
-            | Pattern (exp, _, pat, _, _, _) ->
-                bind_variables c_rhs.exp_loc pat;
-                exp
+            | Pattern { pg_scrutinee; pg_pattern; _ } ->
+                bind_variables c_rhs.exp_loc pg_pattern;
+                pg_scrutinee
               in
           {c_rhs.exp_loc with loc_start=gexp.exp_loc.loc_start}
       in

--- a/ocaml/typing/cmt2annot.ml
+++ b/ocaml/typing/cmt2annot.ml
@@ -52,7 +52,7 @@ let bind_cases l =
           let gexp =
             match g with
             | Predicate pred -> pred
-            | Pattern (exp, _, pat) ->
+            | Pattern (exp, _, pat, _) ->
                 bind_variables c_rhs.exp_loc pat;
                 exp
               in

--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -2446,7 +2446,7 @@ let pattern_stable_vars ns p =
 let all_rhs_idents guard =
   let exp = match guard with
     | Predicate p -> p
-    | Pattern (e, _, _, _) -> e
+    | Pattern (e, _, _, _, _, _) -> e
   in
   let ids = ref Ident.Set.empty in
   let open Tast_iterator in

--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -2446,7 +2446,7 @@ let pattern_stable_vars ns p =
 let all_rhs_idents guard =
   let exp = match guard with
     | Predicate p -> p
-    | Pattern (e, _, _) -> e
+    | Pattern (e, _, _, _) -> e
   in
   let ids = ref Ident.Set.empty in
   let open Tast_iterator in

--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -2446,7 +2446,7 @@ let pattern_stable_vars ns p =
 let all_rhs_idents guard =
   let exp = match guard with
     | Predicate p -> p
-    | Pattern (e, _, _, _, _, _) -> e
+    | Pattern { pg_scrutinee; _ } -> pg_scrutinee
   in
   let ids = ref Ident.Set.empty in
   let open Tast_iterator in

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -1043,7 +1043,7 @@ and case
 
 and guard i ppf = function
   | Predicate p -> expression i ppf p
-  | Pattern (e, s, pat, _partial) ->
+  | Pattern (e, s, pat, _partial, _loc, _env) ->
       expression i ppf e;
       line i ppf "%a " Layouts.Sort.format s;
       pattern i ppf pat

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -1043,7 +1043,7 @@ and case
 
 and guard i ppf = function
   | Predicate p -> expression i ppf p
-  | Pattern (e, s, pat, _partial, _loc, _env) ->
+  | Pattern { pg_scrutinee = e; pg_scrutinee_sort = s; pg_pattern = pat; _ } ->
       expression i ppf e;
       line i ppf "%a " Layouts.Sort.format s;
       pattern i ppf pat

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -1043,7 +1043,7 @@ and case
 
 and guard i ppf = function
   | Predicate p -> expression i ppf p
-  | Pattern (e, s, pat) ->
+  | Pattern (e, s, pat, _partial) ->
       expression i ppf e;
       line i ppf "%a " Layouts.Sort.format s;
       pattern i ppf pat

--- a/ocaml/typing/rec_check.ml
+++ b/ocaml/typing/rec_check.ml
@@ -1214,7 +1214,7 @@ and case
            This judgement uses uses the one in [match_expression] as a
            "subroutine."
         *)
-        | Some (Pattern (e, _, pat, _)) ->
+        | Some (Pattern (e, _, pat, _, _, _)) ->
           let cases = [ { c_lhs = pat; c_guard = None; c_rhs } ] in
           match_expression e cases
       in

--- a/ocaml/typing/rec_check.ml
+++ b/ocaml/typing/rec_check.ml
@@ -1214,7 +1214,7 @@ and case
            This judgement uses uses the one in [match_expression] as a
            "subroutine."
         *)
-        | Some (Pattern (e, _, pat)) ->
+        | Some (Pattern (e, _, pat, _)) ->
           let cases = [ { c_lhs = pat; c_guard = None; c_rhs } ] in
           match_expression e cases
       in

--- a/ocaml/typing/rec_check.ml
+++ b/ocaml/typing/rec_check.ml
@@ -1214,7 +1214,7 @@ and case
            This judgement uses uses the one in [match_expression] as a
            "subroutine."
         *)
-        | Some (Pattern (e, _, pat, _, _, _)) ->
+        | Some (Pattern { pg_scrutinee = e; pg_pattern = pat; _ }) ->
           let cases = [ { c_lhs = pat; c_guard = None; c_rhs } ] in
           match_expression e cases
       in

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -509,7 +509,7 @@ let case sub {c_lhs; c_guard; c_rhs} =
 
 let guard sub = function
   | Predicate p -> sub.expr sub p
-  | Pattern (e, _, pat) -> sub.expr sub e; sub.pat sub pat
+  | Pattern (e, _, pat, _) -> sub.expr sub e; sub.pat sub pat
 
 let value_binding sub {vb_pat; vb_expr; _} =
   sub.pat sub vb_pat;

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -509,7 +509,9 @@ let case sub {c_lhs; c_guard; c_rhs} =
 
 let guard sub = function
   | Predicate p -> sub.expr sub p
-  | Pattern (e, _, pat, _, _, _) -> sub.expr sub e; sub.pat sub pat
+  | Pattern { pg_scrutinee = e; pg_pattern = pat; _ } ->
+      sub.expr sub e;
+      sub.pat sub pat
 
 let value_binding sub {vb_pat; vb_expr; _} =
   sub.pat sub vb_pat;

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -509,7 +509,8 @@ let case sub {c_lhs; c_guard; c_rhs} =
 
 let guard sub = function
   | Predicate p -> sub.expr sub p
-  | Pattern { pg_scrutinee = e; pg_pattern = pat; _ } ->
+  | Pattern { pg_scrutinee = e; pg_scrutinee_sort = _; pg_pattern = pat;
+              pg_partial = _; pg_env = _; pg_loc = _; } ->
       sub.expr sub e;
       sub.pat sub pat
 

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -509,7 +509,7 @@ let case sub {c_lhs; c_guard; c_rhs} =
 
 let guard sub = function
   | Predicate p -> sub.expr sub p
-  | Pattern (e, _, pat, _) -> sub.expr sub e; sub.pat sub pat
+  | Pattern (e, _, pat, _, _, _) -> sub.expr sub e; sub.pat sub pat
 
 let value_binding sub {vb_pat; vb_expr; _} =
   sub.pat sub vb_pat;

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -775,8 +775,8 @@ let case
 
 let guard sub = function
   | Predicate p -> Predicate (sub.expr sub p)
-  | Pattern (e, s, pat, partial) ->
-      Pattern (sub.expr sub e, s, sub.pat sub pat, partial)
+  | Pattern (e, s, pat, partial, loc, env) ->
+      Pattern (sub.expr sub e, s, sub.pat sub pat, partial, loc, env)
 
 let value_binding sub x =
   let vb_pat = sub.pat sub x.vb_pat in

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -775,7 +775,8 @@ let case
 
 let guard sub = function
   | Predicate p -> Predicate (sub.expr sub p)
-  | Pattern (e, s, pat) -> Pattern (sub.expr sub e, s, sub.pat sub pat)
+  | Pattern (e, s, pat, partial) ->
+      Pattern (sub.expr sub e, s, sub.pat sub pat, partial)
 
 let value_binding sub x =
   let vb_pat = sub.pat sub x.vb_pat in

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -775,9 +775,15 @@ let case
 
 let guard sub = function
   | Predicate p -> Predicate (sub.expr sub p)
-  | Pattern pg ->
-      Pattern { pg with pg_scrutinee = sub.expr sub pg.pg_scrutinee;
-                        pg_pattern = sub.pat sub pg.pg_pattern }
+  | Pattern { pg_scrutinee; pg_scrutinee_sort; pg_pattern; pg_partial; pg_env;
+              pg_loc; } ->
+      Pattern
+        { pg_scrutinee = sub.expr sub pg_scrutinee
+        ; pg_scrutinee_sort
+        ; pg_pattern = sub.pat sub pg_pattern
+        ; pg_partial
+        ; pg_env
+        ; pg_loc }
 
 let value_binding sub x =
   let vb_pat = sub.pat sub x.vb_pat in

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -775,8 +775,9 @@ let case
 
 let guard sub = function
   | Predicate p -> Predicate (sub.expr sub p)
-  | Pattern (e, s, pat, partial, loc, env) ->
-      Pattern (sub.expr sub e, s, sub.pat sub pat, partial, loc, env)
+  | Pattern pg ->
+      Pattern { pg with pg_scrutinee = sub.expr sub pg.pg_scrutinee;
+                        pg_pattern = sub.pat sub pg.pg_pattern }
 
 let value_binding sub x =
   let vb_pat = sub.pat sub x.vb_pat in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -3369,7 +3369,7 @@ let rec is_nonexpansive exp =
            let is_guard_nonexpansive = match c_guard with
              | None -> true
              | Some (Typedtree.Predicate p) -> is_nonexpansive p
-             | Some (Typedtree.Pattern (e, _, pat, _)) ->
+             | Some (Typedtree.Pattern (e, _, pat, _, _, _)) ->
                  is_nonexpansive e && not (contains_exception_pat pat)
            in
            is_guard_nonexpansive && is_nonexpansive c_rhs
@@ -6986,7 +6986,11 @@ and type_cases
                 in
                 (match cases with
                   | [ { c_lhs = pat; c_guard = None; c_rhs = exp } ] ->
-                    Some (Typedtree.Pattern (arg, sort, pat, partial)), exp
+                      let pattern_guard =
+                        (Typedtree.Pattern
+                           (arg, sort, pat, partial, loc, ext_env))
+                      in
+                      Some pattern_guard, exp
                   | _ ->
                       Misc.fatal_error "type_cases invariant violated")
         in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -3369,7 +3369,7 @@ let rec is_nonexpansive exp =
            let is_guard_nonexpansive = match c_guard with
              | None -> true
              | Some (Typedtree.Predicate p) -> is_nonexpansive p
-             | Some (Typedtree.Pattern (e, _, pat)) ->
+             | Some (Typedtree.Pattern (e, _, pat, _)) ->
                  is_nonexpansive e && not (contains_exception_pat pat)
            in
            is_guard_nonexpansive && is_nonexpansive c_rhs
@@ -6978,9 +6978,7 @@ and type_cases
             | Some
                 (Guard_pattern 
                   { pgp_scrutinee = e; pgp_pattern = pat; pgp_loc = loc }) ->
-                (* CR-soon rgodse: This `partial` is needed by the pattern
-                   match compiler, thread it through into typedtree. *)
-                let { arg; sort; cases; partial = _ } =
+                let { arg; sort; cases; partial; } =
                   type_match
                     e [ { pc_lhs = pat; pc_guard = None; pc_rhs } ] ext_env loc
                     Check_and_warn_if_total (mk_expected ?explanation ty_res')
@@ -6988,7 +6986,7 @@ and type_cases
                 in
                 (match cases with
                   | [ { c_lhs = pat; c_guard = None; c_rhs = exp } ] ->
-                    Some (Typedtree.Pattern (arg, sort, pat)), exp
+                    Some (Typedtree.Pattern (arg, sort, pat, partial)), exp
                   | _ ->
                       Misc.fatal_error "type_cases invariant violated")
         in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -6988,13 +6988,13 @@ and type_cases
                 (match cases with
                   | [ { c_lhs = pat; c_guard = None; c_rhs = exp } ] ->
                       let pattern_guard =
-                        (Typedtree.Pattern
+                        Pattern
                            { pg_scrutinee = arg
                            ; pg_scrutinee_sort = sort
                            ; pg_pattern = pat
                            ; pg_partial = partial
                            ; pg_loc = loc
-                           ; pg_env = ext_env })
+                           ; pg_env = ext_env }
                       in
                       Some pattern_guard, exp
                   | _ ->

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -6987,7 +6987,7 @@ and type_cases
                 in
                 (match cases with
                   | [ { c_lhs = pat; c_guard = None; c_rhs = exp } ] ->
-                      let pattern_guard =
+                      let pattern_guard : Typedtree.guard =
                         Pattern
                            { pg_scrutinee = arg
                            ; pg_scrutinee_sort = sort

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -3369,8 +3369,9 @@ let rec is_nonexpansive exp =
            let is_guard_nonexpansive = match c_guard with
              | None -> true
              | Some (Typedtree.Predicate p) -> is_nonexpansive p
-             | Some (Typedtree.Pattern (e, _, pat, _, _, _)) ->
-                 is_nonexpansive e && not (contains_exception_pat pat)
+             | Some (Typedtree.Pattern { pg_scrutinee; pg_pattern; _ }) ->
+                 is_nonexpansive pg_scrutinee
+                 && not (contains_exception_pat pg_pattern)
            in
            is_guard_nonexpansive && is_nonexpansive c_rhs
            && not (contains_exception_pat c_lhs)
@@ -6988,7 +6989,12 @@ and type_cases
                   | [ { c_lhs = pat; c_guard = None; c_rhs = exp } ] ->
                       let pattern_guard =
                         (Typedtree.Pattern
-                           (arg, sort, pat, partial, loc, ext_env))
+                           { pg_scrutinee = arg
+                           ; pg_scrutinee_sort = sort
+                           ; pg_pattern = pat
+                           ; pg_partial = partial
+                           ; pg_loc = loc
+                           ; pg_env = ext_env })
                       in
                       Some pattern_guard, exp
                   | _ ->

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -225,7 +225,7 @@ and 'k case =
   
 and guard =
   | Predicate of expression
-  | Pattern of expression * Layouts.sort * computation general_pattern
+  | Pattern of expression * Layouts.sort * computation general_pattern * partial
 
 and record_label_definition =
   | Kept of Types.type_expr

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -226,6 +226,7 @@ and 'k case =
 and guard =
   | Predicate of expression
   | Pattern of expression * Layouts.sort * computation general_pattern * partial
+                * Location.t * Env.t
 
 and record_label_definition =
   | Kept of Types.type_expr

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -225,8 +225,16 @@ and 'k case =
   
 and guard =
   | Predicate of expression
-  | Pattern of expression * Layouts.sort * computation general_pattern * partial
-                * Location.t * Env.t
+  | Pattern of pattern_guard
+
+and pattern_guard =
+  { pg_scrutinee      : expression
+  ; pg_scrutinee_sort : Layouts.sort
+  ; pg_pattern        : computation general_pattern
+  ; pg_partial        : partial
+  ; pg_loc            : Location.t
+  ; pg_env            : Env.t
+  }
 
 and record_label_definition =
   | Kept of Types.type_expr

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -406,14 +406,22 @@ and 'k case =
    [Guard_pattern] *)
 and guard =
   | Predicate of expression
-  | Pattern of expression * Layouts.sort * computation general_pattern * partial
-                * Location.t * Env.t
+  | Pattern of pattern_guard
   (* [Pattern (scrutinee, sort, pattern, partial)] represents a pattern guard.
      The case will be taken if [scrutinee] evaluates to a value matching
      [pattern]. Variables bound by the pattern match are available on the RHS of
      the case. Like the [Texp_match] constructor, [sort] is the sort of the
      scrutinee, and [partial] denotes whether the case matches the scrutinee
      partially or totally. *)
+
+and pattern_guard =
+  { pg_scrutinee      : expression
+  ; pg_scrutinee_sort : Layouts.sort
+  ; pg_pattern        : computation general_pattern
+  ; pg_partial        : partial
+  ; pg_loc            : Location.t
+  ; pg_env            : Env.t
+  }
 
 and record_label_definition =
   | Kept of Types.type_expr

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -407,6 +407,7 @@ and 'k case =
 and guard =
   | Predicate of expression
   | Pattern of expression * Layouts.sort * computation general_pattern * partial
+                * Location.t * Env.t
   (* [Pattern (scrutinee, sort, pattern, partial)] represents a pattern guard.
      The case will be taken if [scrutinee] evaluates to a value matching
      [pattern]. Variables bound by the pattern match are available on the RHS of

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -406,11 +406,13 @@ and 'k case =
    [Guard_pattern] *)
 and guard =
   | Predicate of expression
-  | Pattern of expression * Layouts.sort * computation general_pattern
-  (* [Pattern (scrutinee, sort, pattern)] represents a pattern guard. The case
-     will be taken if [scrutinee] evaluates to a value matching [pattern].
-     Variables bound by the pattern match are available on the RHS of the case.
-     Like the [Pexp_match] constructor, [sort] is the sort of the scrutinee. *)
+  | Pattern of expression * Layouts.sort * computation general_pattern * partial
+  (* [Pattern (scrutinee, sort, pattern, partial)] represents a pattern guard.
+     The case will be taken if [scrutinee] evaluates to a value matching
+     [pattern]. Variables bound by the pattern match are available on the RHS of
+     the case. Like the [Texp_match] constructor, [sort] is the sort of the
+     scrutinee, and [partial] denotes whether the case matches the scrutinee
+     partially or totally. *)
 
 and record_label_definition =
   | Kept of Types.type_expr

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -413,7 +413,7 @@ let exp_extra sub (extra, loc, attrs) sexp =
 
 let guard sub = function 
   | Predicate p -> Guard_predicate (sub.expr sub p)
-  | Pattern (e, _, pat, _, _, _) ->
+  | Pattern { pg_scrutinee = e; pg_pattern = pat; _ } ->
       Guard_pattern {
         pgp_scrutinee = sub.expr sub e;
         pgp_pattern = sub.pat sub pat;

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -413,7 +413,7 @@ let exp_extra sub (extra, loc, attrs) sexp =
 
 let guard sub = function 
   | Predicate p -> Guard_predicate (sub.expr sub p)
-  | Pattern (e, _, pat) ->
+  | Pattern (e, _, pat, _) ->
       Guard_pattern {
         pgp_scrutinee = sub.expr sub e;
         pgp_pattern = sub.pat sub pat;

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -413,7 +413,7 @@ let exp_extra sub (extra, loc, attrs) sexp =
 
 let guard sub = function 
   | Predicate p -> Guard_predicate (sub.expr sub p)
-  | Pattern (e, _, pat, _) ->
+  | Pattern (e, _, pat, _, _, _) ->
       Guard_pattern {
         pgp_scrutinee = sub.expr sub e;
         pgp_pattern = sub.pat sub pat;


### PR DESCRIPTION
Implements translation for pattern guards

Pattern guards are translated as though they were nested matches, with a catch-all case that returns `staticfail` if the guard fails to match, i.e.
`| p1 when e1 match p2 -> e2`
is translated as
`| p1 -> match e1 with p2 -> e2 | _ -> staticfail`

This has the benefit of being able to use the existing machinery for match translation in translcore. 

Of course, the resulting lambda term must be "patched:" `staticfail` is replaced with the remaining cases in the pattern. This "patching" logic is already used for boolean guards.

Unlike in the case of boolean guards, it is not clear where in the lambda term the patched term should live. This had two main consequences:
1. When patching pattern guards, we must carefully traverse the lambda term looking for the `staticfail` which must exist. Each node is touched at most once, so this process is amortized linear in the size of the emitted lambda term.
2. We mark each case RHS to indicate whether it has a guard. This provides a quality-of-life improvement over the previous implementation of `is_guarded`, which had to look into the lambda term to infer guardedness.