### PR TITLE
Fix iarray pattern match

### DIFF
--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -2549,6 +2549,14 @@ Line 3, characters 22-23:
 Error: This value escapes its region
 |}]
 
+let f (local_ a : string iarray) =
+  match a with
+  | [: x; _ :] -> x
+  | _ -> "foo"
+[%%expect{|
+val f : local_ string iarray -> local_ string = <fun>
+|}]
+
 (* projecting out of global iarray gives global elements *)
 let f (a : string iarray) =
   match a with

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -2549,6 +2549,19 @@ Line 3, characters 22-23:
 Error: This value escapes its region
 |}]
 
+(* a test that was passing type check *)
+let unsafe_globalize (local_ s : string) : string =
+  match local_ [:s:] with
+  | [:s':] -> s'
+  | _ -> assert false
+[%%expect{|
+Line 3, characters 14-16:
+3 |   | [:s':] -> s'
+                  ^^
+Error: This local value escapes its region
+  Hint: Cannot return local value without an explicit "local_" annotation
+|}]
+
 let f (local_ a : string iarray) =
   match a with
   | [: x; _ :] -> x

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -2275,14 +2275,19 @@ and type_pat_aux
        shouldn't be too bad.  We can inline this when we upstream this code and
        combine the two array pattern constructors. *)
     let ty_elt = solve_Ppat_array ~refine loc env mutability expected_ty in
-      map_fold_cont (fun p -> type_pat ~alloc_mode:(simple_pat_mode Value_mode.global)
-       tps Value p ty_elt) spl (fun pl ->
-        rvp k {
-        pat_desc = Tpat_array (mutability, pl);
-        pat_loc = loc; pat_extra=[];
-        pat_type = instance expected_ty;
-        pat_attributes;
-        pat_env = !env })
+      map_fold_cont (fun p ->
+        let alloc_mode =
+          match mutability with
+          | Mutable -> simple_pat_mode Value_mode.global
+          | Immutable -> alloc_mode
+        in
+        type_pat ~alloc_mode tps Value p ty_elt) spl (fun pl ->
+          rvp k {
+          pat_desc = Tpat_array (mutability, pl);
+          pat_loc = loc; pat_extra=[];
+          pat_type = instance expected_ty;
+          pat_attributes;
+          pat_env = !env })
   in
   match Jane_syntax.Pattern.of_ast sp with
   | Some (jpat, attrs) -> begin


### PR DESCRIPTION
Currently, constructing an `iarray` doesn't require elements to be `global`, but pattern matching on `local iarray` gives `global` elements, which is unsound. This PR fixes this.