### PR TITLE
Allowing pattern guards with only exception patterns

### DIFF
--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -101,6 +101,17 @@ Error: This pattern matches values of type 'a option
        but a pattern was expected which matches values of type int
 |}]
 
+let typing_no_value_clauses f x =
+  match x with
+    | Some x when f x match exception e -> Error e
+    | Some x -> Ok (f x)
+    | None -> Error (Failure "x is None")
+;;
+[%%expect{|
+Uncaught exception: Failure("guard pattern translation unimplemented")
+
+|}];;
+
 let ill_typed_pattern_var (x : int list option) : bool =
   match x with
     | Some xs when xs match [ y ] -> String.equal y "foo"

--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -199,7 +199,28 @@ exhaustive_pattern_guards (Left ());;
 exhaustive_pattern_guards (Right None);;
 [%%expect{|
 - : int = 1
-|}]
+|}];;
+
+let prove_false () : void = failwith "qed";;
+
+let guard_matching_empty_variant = function
+  | None when prove_false () match exception (Failure str) -> "failed: " ^ str
+  | None -> "proved false!"
+  | Some x -> x
+;;
+[%%expect{|
+val prove_false : unit -> void = <fun>
+val guard_matching_empty_variant : string option -> string = <fun>
+|}];;
+
+guard_matching_empty_variant None;;
+[%%expect{|
+- : string = "failed: qed"
+|}];;
+guard_matching_empty_variant (Some "foo");;
+[%%expect{|
+- : string = "foo"
+|}];;
 
 module M : sig
   type 'a t

--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -110,8 +110,22 @@ let typing_no_value_clauses f x =
 
 let f x = 100 / x;;
 [%%expect{|
-Uncaught exception: Failure("guard pattern translation unimplemented")
+val typing_no_value_clauses : ('a -> 'b) -> 'a option -> ('b, exn) result =
+  <fun>
+val f : int -> int = <fun>
+|}];;
 
+typing_no_value_clauses f None;;
+[%%expect{|
+- : (int, exn) result = Error (Failure "x is None")
+|}];;
+typing_no_value_clauses f (Some 0);;
+[%%expect{|
+- : (int, exn) result = Error Division_by_zero
+|}];;
+typing_no_value_clauses f (Some 5);;
+[%%expect{|
+- : (int, exn) result = Ok 20
 |}];;
 
 let ill_typed_pattern_var (x : int list option) : bool =
@@ -181,12 +195,12 @@ let exhaustive_pattern_guards (x : (unit, void option) Either.t) : int =
 ;;
 [%%expect{|
 type void = |
-Line 165, characters 13-28:
-165 |     | Left u when u match () -> 0
+Line 192, characters 13-28:
+192 |     | Left u when u match () -> 0
                    ^^^^^^^^^^^^^^^
 Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
-Line 166, characters 14-31:
-166 |     | Right v when v match None -> 1
+Line 193, characters 14-31:
+193 |     | Right v when v match None -> 1
                     ^^^^^^^^^^^^^^^^^
 Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
 val exhaustive_pattern_guards : (unit, void option) Either.t -> int = <fun>

--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -107,6 +107,8 @@ let typing_no_value_clauses f x =
     | Some x -> Ok (f x)
     | None -> Error (Failure "x is None")
 ;;
+
+let f x = 100 / x;;
 [%%expect{|
 Uncaught exception: Failure("guard pattern translation unimplemented")
 

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -4577,8 +4577,9 @@ and type_expect_
         exp_env = env }
   | Pexp_match(sarg, caselist) ->
     let { arg; sort; cases; partial } =
-      type_match sarg caselist env loc Check_and_warn_if_partial
-                  ty_expected_explained expected_mode
+      type_match
+        ~require_value_clause:true sarg caselist env loc
+        Check_and_warn_if_partial ty_expected_explained expected_mode
     in
     re {
       exp_desc = Texp_match(arg, sort, cases, partial);
@@ -4594,7 +4595,7 @@ and type_expect_
       in
       let arg_mode = simple_pat_mode Value_mode.global in
       let cases, _ =
-        type_cases Value env arg_mode expected_mode
+        type_cases Value ~require_value_clause:true env arg_mode expected_mode
           Predef.type_exn ty_expected_explained Assume_partial loc caselist in
       re {
         exp_desc = Texp_try(body, cases);
@@ -5595,7 +5596,7 @@ and type_expect_
       let body_env = Env.add_lock Alloc_mode.global env in
       let scase = Ast_helper.Exp.case spat_params sbody in
       let cases, partial =
-        type_cases Value body_env
+        type_cases Value ~require_value_clause:true body_env
           (simple_pat_mode Value_mode.global)
           (mode_return Value_mode.global)
           ty_params (mk_expected ty_func_result)
@@ -5731,6 +5732,8 @@ and type_expect_
     pattern guard. See the comments on [match_info] for the meaning of the
     returned type.
 
+   [require_value_clause]: should [No_value_clauses] be raised if no value
+    clauses are encountered?
    [sarg]: scrutinee to match against
    [caselist]: list of cases to match
    [loc]: location of the entire match-like construct
@@ -5738,8 +5741,8 @@ and type_expect_
     so, what is the desired result? of type [partiality_constraint]
    [ty_expected_explained], [expected_mode]: as in [type_expect]
  *)
-and type_match sarg caselist env loc partiality_constraint ty_expected_explained
-               expected_mode =
+and type_match ~require_value_clause sarg caselist env loc partiality_constraint
+               ty_expected_explained expected_mode =
   let arg_pat_mode, arg_expected_mode =
     match cases_tuple_arity caselist with
       | Not_local_tuple | Maybe_local_tuple ->
@@ -5760,7 +5763,7 @@ and type_match sarg caselist env loc partiality_constraint ty_expected_explained
   if maybe_expansive arg then lower_contravariant env arg.exp_type;
   generalize arg.exp_type;
   let cases, partial =
-    type_cases Computation env arg_pat_mode expected_mode
+    type_cases ~require_value_clause Computation env arg_pat_mode expected_mode
       arg.exp_type ty_expected_explained partiality_constraint loc caselist
   in
   { arg;
@@ -5957,9 +5960,9 @@ and type_function ?in_function loc attrs env (expected_mode : expected_mode)
     end
   in
   let cases, partial =
-    type_cases Value ?in_function env (simple_pat_mode arg_value_mode)
-      cases_expected_mode ty_arg_mono (mk_expected ty_ret)
-      Check_and_warn_if_partial loc caselist in
+    type_cases Value ~require_value_clause:true ?in_function env
+      (simple_pat_mode arg_value_mode) cases_expected_mode ty_arg_mono
+      (mk_expected ty_ret) Check_and_warn_if_partial loc caselist in
   let not_nolabel_function ty =
     let ls, tvar = list_labels env ty in
     List.for_all ((<>) Nolabel) ls && not tvar
@@ -6808,9 +6811,9 @@ and type_statement ?explanation ?(position=RNontail) env sexp =
 (* Typing of match cases *)
 and type_cases
     : type k . k pattern_category ->
-           ?in_function:_ -> _ -> _ -> _ -> _ -> _ -> _ -> _ -> Parsetree.case list ->
-           k case list * partial
-  = fun category ?in_function env pmode emode
+           ?in_function:_ -> require_value_clause:_ -> _ -> _ -> _ -> _ -> _ ->
+           _ -> _ -> Parsetree.case list -> k case list * partial
+  = fun category ?in_function ~require_value_clause env pmode emode
         ty_arg ty_res_explained partiality_constraint loc caselist ->
   (* ty_arg is _fully_ generalized *)
   let { ty = ty_res; explanation } = ty_res_explained in
@@ -6981,7 +6984,8 @@ and type_cases
                   { pgp_scrutinee = e; pgp_pattern = pat; pgp_loc = loc }) ->
                 let { arg; sort; cases; partial; } =
                   type_match
-                    e [ { pc_lhs = pat; pc_guard = None; pc_rhs } ] ext_env loc
+                    ~require_value_clause:false e
+                    [ { pc_lhs = pat; pc_guard = None; pc_rhs } ] ext_env loc
                     Check_and_warn_if_total (mk_expected ?explanation ty_res')
                     emode
                 in
@@ -7031,7 +7035,7 @@ and type_cases
     match category with
       | Value -> (cases : value case list), []
       | Computation -> split_cases env cases in
-  if val_cases = [] && exn_cases <> [] then
+  if require_value_clause && val_cases = [] && exn_cases <> [] then
     raise (Error (loc, env, No_value_clauses));
   let partial = match partiality_constraint with
     | Assume_partial -> Partial


### PR DESCRIPTION
Currently, the typechecker rejects cases that only contain exception patterns. This behavior is not necessary for cases of pattern guards, so this PR modifies the typechecker to accept pattern guards with no value patterns.

This shouldn't lead to issues in translation, as when translating a pattern guard with only exception patterns, a value clause is inserted, i.e.
`match e with p when e' match exception ex -> ...` maps to
`match e with p -> (match e' with exception ex -> ... | _ -> patch)`