### PR TITLE
Prevent fatal compiler error with unboxing code and GADTs

### DIFF
--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -126,8 +126,7 @@ let extra_args_for_const_ctor_of_variant
     (const_ctors_decision : U.const_ctors_decision) ~typing_env_at_use
     rewrite_id variant_arg : U.const_ctors_decision =
   match const_ctors_decision with
-  | Zero ->
-    const_ctors_decision
+  | Zero -> const_ctors_decision
   | At_least_one { ctor = Do_not_unbox reason; is_int } ->
     let is_int =
       Extra_param_and_args.update_param_args is_int rewrite_id

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -126,14 +126,8 @@ let extra_args_for_const_ctor_of_variant
     (const_ctors_decision : U.const_ctors_decision) ~typing_env_at_use
     rewrite_id variant_arg : U.const_ctors_decision =
   match const_ctors_decision with
-  | Zero -> (
-    match variant_arg with
-    | Not_a_constant_constructor -> const_ctors_decision
-    | Maybe_constant_constructor _ ->
-      Misc.fatal_errorf
-        "The unboxed variant parameter was determined to have no constant \
-         cases when deciding to unbox it (using the parameter type), but at \
-         the use site, it is a constant constructor.")
+  | Zero ->
+    const_ctors_decision
   | At_least_one { ctor = Do_not_unbox reason; is_int } ->
     let is_int =
       Extra_param_and_args.update_param_args is_int rewrite_id

--- a/middle_end/flambda2/tests/mlexamples/unboxing_gadt.ml
+++ b/middle_end/flambda2/tests/mlexamples/unboxing_gadt.ml
@@ -1,0 +1,15 @@
+type foo =
+  | A of float
+  | B of int
+
+type bar = Other
+
+type 'a t =
+  | Foo : foo -> foo t
+  | Bar : bar t
+
+let f (type a) : a t -> a = function Foo x -> x | Bar -> Other
+
+let baz p x z =
+  let a = if p then f x else B z in
+  Sys.opaque_identity a


### PR DESCRIPTION
This prevents a crash on this example:
```ocaml
type foo =
  | A of float
  | B of int

type bar = Other

type 'a t =
  | Foo : foo -> foo t
  | Bar : bar t


let f (type a) : a t -> a = function
  | Foo x -> x
  | Bar -> Other


let baz p x z =
  let a =
    if p then (f x)
    else B z
  in
  Sys.opaque_identity a
```

I think we could also rewrite the code to `Invalid` in this case, but I'm not sure how to do that.