### PR TITLE
Turn on -warn-error in the compiler

### DIFF
--- a/dune
+++ b/dune
@@ -60,7 +60,7 @@
  ; We should change the code so this "-open" can be removed.
  ; Likewise fix occurrences of warning 9.
  (flags
-  (:standard -principal -w -9-69-70))
+  (:standard -principal -w -9-69-70 -warn-error +A))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
  (instrumentation


### PR DESCRIPTION
This stops compilation on a warning. Inspired by the recent pattern-match warning that slipped in.