### PR TITLE
Improved efficiency for guarded right-hand-sides

### DIFF
--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -1664,7 +1664,7 @@ and precompile_or ~arg ~arg_sort (cls : Simple.clause list) ors args def k =
               Typedtree.pat_bound_idents_full arg_sort orp
             in
             (* Optimization: discard pattern vars not bound in orpm actions *)
-            let patbound_action_vars_full =
+            let patbound_idents =
               match pm_free_variables orpm with
               (* Give up on the optimization: there is some action not tracking
                  free variables, so the free variable set is not known. *)
@@ -1680,7 +1680,7 @@ and precompile_or ~arg ~arg_sort (cls : Simple.clause list) ors args def k =
               List.map
                 (fun (id, _, ty, id_sort) ->
                    (id, Typeopt.layout orp.pat_env orp.pat_loc id_sort ty))
-                patbound_action_vars_full
+                patbound_idents
             in
             let or_num = next_raise_count () in
             let new_patl = Patterns.omega_list patl in

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -182,8 +182,8 @@ let bind_rhs_with_layout str (var, layout) exp body =
           let free_variables =
             map_guarded_free_variables
               ~f:(fun free ->
-                    Ident.Set.remove var
-                      (Ident.Set.union (free_variables exp) free))
+                    Ident.Set.union
+                      (free_variables exp) (Ident.Set.remove var free))
               free
           in
           Guarded { patch_guarded; free_variables }
@@ -1167,7 +1167,7 @@ let safe_before ((p, ps), act_p) l =
         (match make_key act1, make_key act2 with
          | Some key1, Some key2 -> key1 = key2
          | None, _ | _, None -> false)
-    (* CR-soon rgodse: Investigate the callsites of this function to determine 
+    (* CR-soon rgodse: Investigate the callsites of this function to determine
        if Guarded rhs's should ever be deemed the same. *)
     | Guarded _, _ | _, Guarded _ -> false
   in

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -1221,7 +1221,7 @@ let pm_free_variables { cases } =
               Known (Ident.Set.union free (free_variables lam))
           | Guarded { free_variables = Precomputed free_variables } ->
               Known (Ident.Set.union free free_variables)
-          | Guarded { free_variables = Uncomputed } -> Known)
+          | Guarded { free_variables = Uncomputed } -> Unknown)
     cases (Known Ident.Set.empty)
 
 (* Basic grouping predicates *)

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -1190,12 +1190,6 @@ let what_is_first_case = what_is_cases ~skip_any:false
 
 let what_is_cases = what_is_cases ~skip_any:true
 
-let pm_free_variables { cases } =
-  List.fold_right
-    (fun (_, act) r ->
-       Ident.Set.union (free_variables_of_rhs act) r)
-    cases Ident.Set.empty
-
 (* Basic grouping predicates *)
 
 let can_group discr pat =
@@ -1632,12 +1626,10 @@ and precompile_or ~arg ~arg_sort (cls : Simple.clause list) ors args def k =
                 default = Default_environment.pop_compat orp def
               }
             in
-            let pm_fv = pm_free_variables orpm in
             let patbound_action_vars =
               (* variables bound in the or-pattern
                  that are used in the orpm actions *)
               Typedtree.pat_bound_idents_full arg_sort orp
-              |> List.filter (fun (id, _, _, _) -> Ident.Set.mem id pm_fv)
               |> List.map (fun (id, _, ty, id_sort) ->
                      (id, Typeopt.layout orp.pat_env orp.pat_loc id_sort ty))
             in

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -182,8 +182,8 @@ let bind_rhs_with_layout str (var, layout) exp body =
           let free_variables =
             map_guarded_free_variables
               ~f:(fun free ->
-                    Ident.Set.union (free_variables exp)
-                      (Ident.Set.remove var free))
+                    Ident.Set.remove var
+                      (Ident.Set.union (free_variables exp) free))
               free
           in
           Guarded { patch_guarded; free_variables }

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -129,7 +129,10 @@ let may_compat = MayCompat.compat
 
 and may_compats = MayCompat.compats
 
-type guarded_free_variables = 
+(* The free variables in a guarded rhs can be precomputed to be used in an
+   optimization, or uncomputed, in which case the optimization is not applied.
+*)
+type guarded_free_variables =
   | Precomputed of Ident.Set.t
   | Uncomputed
 
@@ -155,9 +158,11 @@ type rhs =
   *)
   | Unguarded of lambda
 
-let mk_guarded_rhs ~patch_guarded ~free_variables =
-  Guarded
-    { patch_guarded; free_variables }
+let mk_boolean_guarded_rhs ~patch_guarded ~free_variables =
+  Guarded { patch_guarded; free_variables = Precomputed free_variables }
+
+let mk_pattern_guarded_rhs ~patch_guarded =
+  Guarded { patch_guarded; free_variables = Uncomputed }
 
 let mk_unguarded_rhs action = Unguarded action
 

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -1190,6 +1190,12 @@ let what_is_first_case = what_is_cases ~skip_any:false
 
 let what_is_cases = what_is_cases ~skip_any:true
 
+let pm_free_variables { cases } =
+  List.fold_right
+    (fun (_, act) r ->
+       Ident.Set.union (free_variables_of_rhs act) r)
+    cases Ident.Set.empty
+
 (* Basic grouping predicates *)
 
 let can_group discr pat =
@@ -1626,10 +1632,12 @@ and precompile_or ~arg ~arg_sort (cls : Simple.clause list) ors args def k =
                 default = Default_environment.pop_compat orp def
               }
             in
+            let pm_fv = pm_free_variables orpm in
             let patbound_action_vars =
               (* variables bound in the or-pattern
                  that are used in the orpm actions *)
               Typedtree.pat_bound_idents_full arg_sort orp
+              |> List.filter (fun (id, _, _, _) -> Ident.Set.mem id pm_fv)
               |> List.map (fun (id, _, ty, id_sort) ->
                      (id, Typeopt.layout orp.pat_env orp.pat_loc id_sort ty))
             in

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -27,14 +27,20 @@ type rhs
    If a guard fails, a guarded rhs must fallthrough to the remaining cases.
    To facilitate this, guarded rhs's are constructed using a continuation.
 
-   [mk_guarded ~patch_guarded] produces a guarded rhs with a lambda
-   representation given by [patch_guarded ~patch], where [patch] contains an
-   expression that falls through to the remaining cases.
+   [mk_guarded ~patch_guarded ~free_variables] produces a guarded rhs with a
+   lambda representation given by [patch_guarded ~patch], where [patch] contains
+   an expression that falls through to the remaining cases and [free_variables]
+   contains the free variables in the rhs
 *)
-val mk_guarded_rhs: patch_guarded:(patch:lambda -> lambda) -> rhs
+val mk_guarded_rhs:
+        patch_guarded:(patch:lambda -> lambda) ->
+        free_variables:Ident.Set.t ->
+        rhs
 
 (* Creates an unguarded rhs from its lambda representation. *)
 val mk_unguarded_rhs: lambda -> rhs
+
+val free_variables_of_rhs : rhs -> Ident.Set.t
 
 (* Entry points to match compiler *)
 val for_function:

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -22,6 +22,13 @@ open Debuginfo.Scoped_location
 (* Right-hand side of a case. *)
 type rhs
 
+(* The free variables in a guarded rhs can be precomputed to be used in an
+   optimization, or uncomputed, in which case the optimization is not applied.
+*)
+type guarded_free_variables =
+  | Precomputed of Ident.Set.t
+  | Uncomputed
+
 (* Creates a guarded rhs.
    
    If a guard fails, a guarded rhs must fallthrough to the remaining cases.
@@ -34,13 +41,11 @@ type rhs
 *)
 val mk_guarded_rhs:
         patch_guarded:(patch:lambda -> lambda) ->
-        free_variables:Ident.Set.t ->
+        free_variables:guarded_free_variables ->
         rhs
 
 (* Creates an unguarded rhs from its lambda representation. *)
 val mk_unguarded_rhs: lambda -> rhs
-
-val free_variables_of_rhs : rhs -> Ident.Set.t
 
 (* Entry points to match compiler *)
 val for_function:

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -22,26 +22,25 @@ open Debuginfo.Scoped_location
 (* Right-hand side of a case. *)
 type rhs
 
-(* The free variables in a guarded rhs can be precomputed to be used in an
-   optimization, or uncomputed, in which case the optimization is not applied.
-*)
-type guarded_free_variables =
-  | Precomputed of Ident.Set.t
-  | Uncomputed
-
 (* Creates a guarded rhs.
    
    If a guard fails, a guarded rhs must fallthrough to the remaining cases.
    To facilitate this, guarded rhs's are constructed using a continuation.
 
-   [mk_guarded ~patch_guarded ~free_variables] produces a guarded rhs with a
+   [mk_pattern_guarded_rhs ~patch_guarded] produces a guarded rhs with a
    lambda representation given by [patch_guarded ~patch], where [patch] contains
-   an expression that falls through to the remaining cases and [free_variables]
-   contains the free variables in the rhs
+   an expression that falls through to the remaining cases.
+   
+   [mk_boolean_guarded_rhs ~patch_guarded ~free_variables] produces a similar
+   rhs where [free_variables] contains the free variables of the rhs.
 *)
-val mk_guarded_rhs:
+val mk_boolean_guarded_rhs:
         patch_guarded:(patch:lambda -> lambda) ->
-        free_variables:guarded_free_variables ->
+        free_variables:Ident.Set.t ->
+        rhs
+
+val mk_pattern_guarded_rhs:
+        patch_guarded:(patch:lambda -> lambda) ->
         rhs
 
 (* Creates an unguarded rhs from its lambda representation. *)

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1721,31 +1721,31 @@ and transl_match_staged ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
   let static_handlers = List.rev rev_static_handlers in
   (* In presence of exception patterns, the code we generate for
 
-      match <scrutinees> with
-      | <val-patterns> -> <val-actions>
-      | <exn-patterns> -> <exn-actions>
+       match <scrutinees> with
+       | <val-patterns> -> <val-actions>
+       | <exn-patterns> -> <exn-actions>
 
-    looks like
+     looks like
 
-      staticcatch
-        (try (exit <val-exit> <scrutinees>)
+       staticcatch
+         (try (exit <val-exit> <scrutinees>)
           with <exn-patterns> -> <exn-actions>)
-      with <val-exit> <val-ids> ->
+       with <val-exit> <val-ids> ->
           match <val-ids> with <val-patterns> -> <val-actions>
 
-    In particular, the 'exit' in the value case ensures that the
-    value actions run outside the try..with exception handler.
+     In particular, the 'exit' in the value case ensures that the
+     value actions run outside the try..with exception handler.
   *)
   let static_catch scrutinees val_ids handler =
     let id = Typecore.name_pattern "exn" (List.map fst exn_cases) in
     let static_exception_id = next_raise_count () in
     Lstaticcatch
       (Ltrywith (Lstaticraise (static_exception_id, scrutinees), id,
-                Matching.for_trywith ~scopes ~return_layout loc (Lvar id)
-                  exn_cases,
-                return_layout),
-      (static_exception_id, val_ids),
-      handler,
+                 Matching.for_trywith ~scopes ~return_layout loc (Lvar id)
+                   exn_cases,
+                 return_layout),
+       (static_exception_id, val_ids),
+       handler,
       return_layout)
   in
   let scrutinees, classic_staged =
@@ -1766,9 +1766,9 @@ and transl_match_staged ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
         let val_ids, lvars =
           List.map
             (fun (arg,s) ->
-              let layout = layout_exp s arg in
-              let id = Typecore.name_pattern "val" [] in
-              (id, layout), (Lvar id, s, layout))
+               let layout = layout_exp s arg in
+               let id = Typecore.name_pattern "val" [] in
+               (id, layout), (Lvar id, s, layout))
             argl
           |> List.split
         in

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1025,7 +1025,8 @@ and transl_guard ~scopes guard rhs_sort rhs =
         (Lifthenelse (translated_cond, translated_rhs, patch, layout))
     in
     let free_variables =
-      Ident.Set.union (free_variables translated_cond)
+      Ident.Set.union
+        (free_variables translated_cond)
         (free_variables translated_rhs)
     in
     Matching.mk_guarded_rhs ~patch_guarded

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -71,27 +71,26 @@ end = struct
     in
     { scrutinees; cases; handler_data }
   
-  let remove_bound ~bound ~free =
-    List.fold_left (fun s id -> Ident.Set.remove id s) free bound
+  let remove_bound_variables ~bound idents =
+    List.fold_left (fun s id -> Ident.Set.remove id s) idents bound
   
-  let free_case (pat, rhs) =
-    remove_bound
-      ~bound:(pat_bound_idents pat)
-      ~free:(Matching.free_variables_of_rhs rhs)
+  let free_variables_of_case (pat, rhs) =
+    remove_bound_variables ~bound:(pat_bound_idents pat)
+      (Matching.free_variables_of_rhs rhs)
 
-  let free_handler (ids, lam) =
-    remove_bound ~bound:ids ~free:(free_variables lam)
+  let free_variables_of_handler (ids, lam) =
+    remove_bound_variables ~bound:ids (free_variables lam)
 
-  let union_map ~f =
+  let map_union ~f =
     List.fold_left (fun s x -> Ident.Set.union s (f x)) Ident.Set.empty
   
   let union_list = List.fold_left Ident.Set.union Ident.Set.empty
 
   let free_variables (t : t) =
     union_list
-      [ union_map ~f:free_variables t.scrutinees
-      ; union_map ~f:free_case t.cases
-      ; union_map ~f:free_handler t.handler_data
+      [ map_union ~f:free_variables t.scrutinees
+      ; map_union ~f:free_variables_of_case t.cases
+      ; map_union ~f:free_variables_of_handler t.handler_data
       ]
   
   let to_rhs t ~patch_guarded =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -36,67 +36,6 @@ type error =
 
 exception Error of Location.t * error
 
-(* Produces rhs's guarded by pattern guards *)
-module Pattern_guarded_rhs_factory : sig
-  type t
-
-  (* Generates a factory from the relevant data *)
-  val of_data
-  :  scrutinees:lambda list
-  -> cases:(pattern * Matching.rhs) list
-  -> handlers:(static_label * (Ident.t * Lambda.layout) list * lambda) list
-  -> t
-  
-  (* Produces a pattern-guarded rhs
-     
-     [patch_guarded ~patch] should be a valid translation of the rhs given that
-     patch is an expression that correctly falls through to the next case.
-  *)
-  val to_rhs:
-        t -> patch_guarded:(patch:lambda -> lambda) -> Matching.rhs
-end = struct
-  type t =
-    { scrutinees: lambda list
-    ; cases: (pattern * Matching.rhs) list
-    ; handler_data: (Ident.t list * lambda) list
-    }
-
-  let of_data ~scrutinees ~cases ~handlers =
-    let to_idents = List.map (fun (ident, _layout) -> ident) in
-    let handler_data =
-      List.map
-        (fun (_label, idents_and_layouts, handler) ->
-           to_idents idents_and_layouts, handler)
-        handlers
-    in
-    { scrutinees; cases; handler_data }
-  
-  let remove_bound_variables ~bound idents =
-    List.fold_left (fun s id -> Ident.Set.remove id s) idents bound
-  
-  let free_variables_of_case (pat, rhs) =
-    remove_bound_variables ~bound:(pat_bound_idents pat)
-      (Matching.free_variables_of_rhs rhs)
-
-  let free_variables_of_handler (ids, lam) =
-    remove_bound_variables ~bound:ids (free_variables lam)
-
-  let map_union ~f =
-    List.fold_left (fun s x -> Ident.Set.union s (f x)) Ident.Set.empty
-  
-  let union_list = List.fold_left Ident.Set.union Ident.Set.empty
-
-  let free_variables (t : t) =
-    union_list
-      [ map_union ~f:free_variables t.scrutinees
-      ; map_union ~f:free_variables_of_case t.cases
-      ; map_union ~f:free_variables_of_handler t.handler_data
-      ]
-  
-  let to_rhs t ~patch_guarded =
-    Matching.mk_guarded_rhs ~patch_guarded ~free_variables:(free_variables t)
-end
-
 let use_dup_for_constant_mutable_arrays_bigger_than = 4
 
 let layout_must_be_value loc layout =
@@ -499,7 +438,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
            oargs (of_location ~scopes e.exp_loc))
   | Texp_match(arg, arg_sort, pat_expr_list, partial) ->
       transl_match ~scopes ~arg_sort ~return_sort:sort ~return_type:e.exp_type
-        ~loc:e.exp_loc ~env:e.exp_env arg pat_expr_list partial
+        ~loc:e.exp_loc ~env:e.exp_env ~extra_cases:[] arg pat_expr_list partial
   | Texp_try(body, pat_expr_list) ->
       let id = Typecore.name_cases "exn" pat_expr_list in
       let return_layout = layout_exp sort e in
@@ -1072,19 +1011,25 @@ and transl_list_with_shape ~scopes expr_list =
 
 and transl_guard ~scopes guard rhs_sort rhs =
   let layout = layout_exp rhs_sort rhs in
-  let expr = event_before ~scopes rhs (transl_exp ~scopes rhs_sort rhs) in
   match guard with
-  | None -> Matching.mk_unguarded_rhs expr
+  | None ->
+      Matching.mk_unguarded_rhs
+        (event_before ~scopes rhs (transl_exp ~scopes rhs_sort rhs))
   | Some (Predicate cond) ->
-      let translated_cond = transl_exp ~scopes Sort.for_predef_value cond in
-      let patch_guarded ~patch =
-        event_before ~scopes cond
-          (Lifthenelse (translated_cond, expr, patch, layout))
-      in
-      let free_variables =
-        Ident.Set.union (free_variables translated_cond) (free_variables expr)
-      in
-      Matching.mk_guarded_rhs ~patch_guarded ~free_variables
+    let translated_cond = transl_exp ~scopes Sort.for_predef_value cond in
+    let translated_rhs =
+      event_before ~scopes rhs (transl_exp ~scopes rhs_sort rhs)
+    in
+    let patch_guarded ~patch =
+      event_before ~scopes cond
+        (Lifthenelse (translated_cond, translated_rhs, patch, layout))
+    in
+    let free_variables =
+      Ident.Set.union (free_variables translated_cond)
+        (free_variables translated_rhs)
+    in
+    Matching.mk_guarded_rhs ~patch_guarded
+      ~free_variables:(Precomputed free_variables)
   | Some (Pattern { pg_scrutinee; pg_scrutinee_sort; pg_pattern; pg_partial;
                     pg_loc; pg_env }) ->
       let guard_case : _ case =
@@ -1098,11 +1043,6 @@ and transl_guard ~scopes guard rhs_sort rhs =
              guarded rhs from a continuation that patches in the code to execute
              on match failure.
           *)
-          let factory, staged =
-            transl_match_staged ~scopes ~arg_sort:pg_scrutinee_sort
-              ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
-              ~env:pg_env pg_scrutinee [ guard_case ] pg_partial
-          in
           let patch_guarded ~patch =
             let any_pat : pattern =
               { pat_desc = Tpat_any
@@ -1114,15 +1054,19 @@ and transl_guard ~scopes guard rhs_sort rhs =
               }
             in
             let extra_cases = [ any_pat, Matching.mk_unguarded_rhs patch ] in
-            event_before ~scopes pg_scrutinee (staged ~extra_cases)
+            event_before ~scopes pg_scrutinee
+              (transl_match ~scopes ~arg_sort:pg_scrutinee_sort
+                 ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
+                 ~env:pg_env ~extra_cases pg_scrutinee [ guard_case ]
+                 pg_partial)
           in
-          Pattern_guarded_rhs_factory.to_rhs factory ~patch_guarded
+          Matching.mk_guarded_rhs ~patch_guarded ~free_variables:Uncomputed
       | Total ->
           (* Total pattern guards are equivalent to nested matches. *)
           let nested_match =
             transl_match ~scopes ~arg_sort:pg_scrutinee_sort
               ~return_sort:rhs_sort ~return_type:rhs.exp_type ~loc:pg_loc
-              ~env:pg_env pg_scrutinee [ guard_case ] pg_partial
+              ~env:pg_env ~extra_cases:[] pg_scrutinee [ guard_case ] pg_partial
           in
           Matching.mk_unguarded_rhs
             (event_before ~scopes pg_scrutinee nested_match)
@@ -1644,28 +1588,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     end
   end
 
-(* Translate a match-like expression
-   
-   This function is applied for two different expressions: proper match
-   expressions, and pattern guarded rhs's.
-
-   Guarded rhs's are translated lazily, but their free variables must be
-   computed eagerly (as the pattern match compiler is interested in knowing the
-   free variables of an rhs during compilation).
-   
-   For this reason, this function produces a "factory" that can construct
-   guarded rhs's, together with a continuation that takes [extra_cases], a list
-   of value cases to add to those in the match.
-   
-   When translating guarded rhs's, the continuation should be evaluated with 
-   [extra_cases=[_ -> patch]], where patch is a lambda expression that falls
-   through to the remaining cases.
-   
-   When translating match expressions, the factory can be ignored and the
-   continuation should be evaluated with [extra_cases=[]].
-*)
-and transl_match_staged ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
-      arg pat_expr_list partial =
+and transl_match ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
+      ~extra_cases arg pat_expr_list partial =
   let return_layout = layout env loc arg_sort return_type in
   let rewrite_case (val_cases, exn_cases, static_handlers as acc)
         ({ c_lhs; c_guard; c_rhs } as case) =
@@ -1713,11 +1637,10 @@ and transl_match_staged ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
         (pe, Matching.mk_unguarded_rhs (static_raise ids)) :: exn_cases,
         (lbl, ids_kinds, rhs) :: static_handlers
   in
-  let rev_val_cases, rev_exn_cases, rev_static_handlers =
-    List.fold_left rewrite_case ([], [], []) pat_expr_list
+  let val_cases, exn_cases, static_handlers =
+    let x, y, z = List.fold_left rewrite_case ([], [], []) pat_expr_list in
+    List.rev_append x extra_cases, List.rev y, List.rev z
   in
-  let exn_cases = List.rev rev_exn_cases in
-  let static_handlers = List.rev rev_static_handlers in
   (* In presence of exception patterns, the code we generate for
 
        match <scrutinees> with
@@ -1747,19 +1670,14 @@ and transl_match_staged ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
        handler,
       return_layout)
   in
-  let scrutinees, classic_staged =
+  let classic =
     match arg, exn_cases with
     | {exp_desc = Texp_tuple (argl, alloc_mode)}, [] ->
       assert (static_handlers = []);
       let mode = transl_alloc_mode alloc_mode in
       let argl = List.map (fun a -> (a, Sort.for_tuple_element)) argl in
-      let argl = transl_list_with_layout ~scopes argl in
-      let scrutinees = List.map (fun (lam, _, _) -> lam) argl in
-      let staged ~val_cases = 
-        Matching.for_multiple_match ~scopes ~return_layout loc argl mode
-          val_cases partial
-      in
-      scrutinees, staged
+      Matching.for_multiple_match ~scopes ~return_layout loc
+        (transl_list_with_layout ~scopes argl) mode val_cases partial
     | {exp_desc = Texp_tuple (argl, alloc_mode)}, _ :: _ ->
         let argl = List.map (fun a -> (a, Sort.for_tuple_element)) argl in
         let val_ids, lvars =
@@ -1772,58 +1690,24 @@ and transl_match_staged ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
           |> List.split
         in
         let mode = transl_alloc_mode alloc_mode in
-        let argl = transl_list ~scopes argl in
-        let staged ~val_cases = 
-          static_catch argl val_ids
-            (Matching.for_multiple_match ~scopes ~return_layout loc lvars mode
-              val_cases partial)
-        in
-        argl, staged
+        static_catch (transl_list ~scopes argl) val_ids
+          (Matching.for_multiple_match ~scopes ~return_layout loc lvars mode
+             val_cases partial)
     | arg, [] ->
       assert (static_handlers = []);
       let arg_layout = layout_exp arg_sort arg in
-      let scrutinee = transl_exp ~scopes arg_sort arg in
-      let staged ~val_cases = 
-        Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout loc
-          None scrutinee val_cases partial
-      in
-      [ scrutinee ], staged
+      Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
+        loc None (transl_exp ~scopes arg_sort arg) val_cases partial
     | arg, _ :: _ ->
+        let val_id = Typecore.name_pattern "val" (List.map fst val_cases) in
         let arg_layout = layout_exp arg_sort arg in
-        let scrutinee = transl_exp ~scopes arg_sort arg in
-        let staged ~val_cases =
-          let val_id = Typecore.name_pattern "val" (List.map fst val_cases) in
-          static_catch [ scrutinee ] [ val_id, arg_layout ]
-            (Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
-               loc None (Lvar val_id) val_cases partial)
-        in
-        [ scrutinee ], staged
+        static_catch [transl_exp ~scopes arg_sort arg] [val_id, arg_layout]
+          (Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
+             loc None (Lvar val_id) val_cases partial)
   in
-  let factory =
-    Pattern_guarded_rhs_factory.of_data
-      ~scrutinees
-      ~cases:(rev_val_cases @ exn_cases)
-      ~handlers:static_handlers
-  in
-  let staged ~extra_cases =
-    let val_cases = List.rev_append rev_val_cases extra_cases in
-    let classic = classic_staged ~val_cases in
-    List.fold_left
-      (fun body (static_exception_id, val_ids, handler) ->
-         Lstaticcatch
-          (body, (static_exception_id, val_ids), handler, return_layout))
-      classic
-      static_handlers
-  in
-  factory, staged
-
-and transl_match ~scopes ~arg_sort ~return_sort ~return_type ~loc ~env
-      arg pat_expr_list partial =
-  let (_ : Pattern_guarded_rhs_factory.t), staged =
-    transl_match_staged ~scopes ~arg_sort ~return_sort ~return_type ~loc
-      ~env arg pat_expr_list partial
-  in
-  staged ~extra_cases:[]
+  List.fold_left (fun body (static_exception_id, val_ids, handler) ->
+    Lstaticcatch (body, (static_exception_id, val_ids), handler, return_layout)
+  ) classic static_handlers
 
 and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
       partial warnings =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1029,8 +1029,7 @@ and transl_guard ~scopes guard rhs_sort rhs =
         (free_variables translated_cond)
         (free_variables translated_rhs)
     in
-    Matching.mk_guarded_rhs ~patch_guarded
-      ~free_variables:(Precomputed free_variables)
+    Matching.mk_boolean_guarded_rhs ~patch_guarded ~free_variables
   | Some (Pattern { pg_scrutinee; pg_scrutinee_sort; pg_pattern; pg_partial;
                     pg_loc; pg_env }) ->
       let guard_case : _ case =
@@ -1061,7 +1060,7 @@ and transl_guard ~scopes guard rhs_sort rhs =
                  ~env:pg_env ~extra_cases pg_scrutinee [ guard_case ]
                  pg_partial)
           in
-          Matching.mk_guarded_rhs ~patch_guarded ~free_variables:Uncomputed
+          Matching.mk_pattern_guarded_rhs ~patch_guarded
       | Total ->
           (* Total pattern guards are equivalent to nested matches. *)
           let nested_match =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1650,13 +1650,17 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
    This function is applied for two different expressions: proper match
    expressions, and pattern guarded rhs's.
 
-   Guarded rhs's are translated lazily, but they also require the eager
-   computation of their free variables.
+   Guarded rhs's are translated lazily, but their free variables must be
+   computed eagerly (as the pattern match compiler is interested in knowing the
+   free variables of an rhs during compilation).
    
    For this reason, this function produces a "factory" that can construct
-   guarded rhs's, together with a continuation that translates the lambda given
-   [extra_cases] that reroute the expression to a patch corresponding to
-   fallthrough.
+   guarded rhs's, together with a continuation that takes [extra_cases], a list
+   of value cases to add to those in the match.
+   
+   When translating guarded rhs's, the continuation should be evaluated with 
+   [extra_cases=[_ -> patch]], where patch is a lambda expression that falls
+   through to the remaining cases.
    
    When translating match expressions, the factory can be ignored and the
    continuation should be evaluated with [extra_cases=[]].

--- a/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -82,13 +82,8 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function {nlocal = 0} a/284[int] b/285 : int
-  (region
-    (let
-      (_g/286 =a[(consts ()) (non_consts ([0: [int], *]))]
-         (makelocalblock 0 a/284 b/285))
-      0)))
-(function {nlocal = 0} a/284[int] b/285 : int (region 0))
+(function {nlocal = 0} a/284[int] b/285 : int 0)
+(function {nlocal = 0} a/284[int] b/285 : int 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -107,15 +102,15 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function {nlocal = 0} a/290[int] b/291
+(function {nlocal = 0} a/288[int] b/289
   [(consts ()) (non_consts ([0: [int], *]))](let
-                                              (p/292 =a[(consts ())
+                                              (p/290 =a[(consts ())
                                                         (non_consts (
                                                         [0: [int], *]))]
-                                                 (makeblock 0 a/290 b/291))
-                                              p/292))
-(function {nlocal = 0} a/290[int] b/291
-  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/290 b/291))
+                                                 (makeblock 0 a/288 b/289))
+                                              p/290))
+(function {nlocal = 0} a/288[int] b/289
+  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/288 b/289))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -124,15 +119,15 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function {nlocal = 0} a/294[int] b/295
+(function {nlocal = 0} a/292[int] b/293
   [(consts ()) (non_consts ([0: [int], *]))](let
-                                              (p/296 =a[(consts ())
+                                              (p/294 =a[(consts ())
                                                         (non_consts (
                                                         [0: [int], *]))]
-                                                 (makeblock 0 a/294 b/295))
-                                              p/296))
-(function {nlocal = 0} a/294[int] b/295
-  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/294 b/295))
+                                                 (makeblock 0 a/292 b/293))
+                                              p/294))
+(function {nlocal = 0} a/292[int] b/293
+  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/292 b/293))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -141,20 +136,20 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function {nlocal = 0} a/300[int] b/301
+(function {nlocal = 0} a/298[int] b/299
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/302 =a[int] a/300
-     p/303 =a[(consts ()) (non_consts ([0: [int], *]))]
-       (makeblock 0 a/300 b/301))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/302
-      p/303)))
-(function {nlocal = 0} a/300[int] b/301
+    (x/300 =a[int] a/298
+     p/301 =a[(consts ()) (non_consts ([0: [int], *]))]
+       (makeblock 0 a/298 b/299))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/300
+      p/301)))
+(function {nlocal = 0} a/298[int] b/299
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/300
-    (makeblock 0 a/300 b/301)))
+  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/298
+    (makeblock 0 a/298 b/299)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -163,20 +158,20 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function {nlocal = 0} a/306[int] b/307
+(function {nlocal = 0} a/304[int] b/305
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/308 =a[int] a/306
-     p/309 =a[(consts ()) (non_consts ([0: [int], *]))]
-       (makeblock 0 a/306 b/307))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/308
-      p/309)))
-(function {nlocal = 0} a/306[int] b/307
+    (x/306 =a[int] a/304
+     p/307 =a[(consts ()) (non_consts ([0: [int], *]))]
+       (makeblock 0 a/304 b/305))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/306
+      p/307)))
+(function {nlocal = 0} a/304[int] b/305
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/306
-    (makeblock 0 a/306 b/307)))
+  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/304
+    (makeblock 0 a/304 b/305)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -185,30 +180,30 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function {nlocal = 0} a/316[int] b/317[int]
+(function {nlocal = 0} a/314[int] b/315[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/316
+  (if a/314
     (let
-      (x/318 =a[int] a/316
+      (x/316 =a[int] a/314
+       p/317 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/314 b/315))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/316
+        p/317))
+    (let
+      (x/318 =a[(consts ()) (non_consts ([0: ]))] b/315
        p/319 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/316 b/317))
+         (makeblock 0 a/314 b/315))
       (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/318
-        p/319))
-    (let
-      (x/320 =a[(consts ()) (non_consts ([0: ]))] b/317
-       p/321 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/316 b/317))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/320
-        p/321))))
-(function {nlocal = 0} a/316[int] b/317[int]
+        p/319))))
+(function {nlocal = 0} a/314[int] b/315[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/316
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/316
-      (makeblock 0 a/316 b/317))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) b/317
-      (makeblock 0 a/316 b/317))))
+  (if a/314
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/314
+      (makeblock 0 a/314 b/315))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) b/315
+      (makeblock 0 a/314 b/315))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -218,33 +213,33 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function {nlocal = 0} a/322[int] b/323[int]
+(function {nlocal = 0} a/320[int] b/321[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (catch
-    (if a/322
+    (if a/320
       (let
-        (x/330 =a[int] a/322
-         p/331 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-           (makeblock 0 a/322 b/323))
-        (exit 10 x/330 p/331))
-      (let
-        (x/328 =a[(consts ()) (non_consts ([0: ]))] b/323
+        (x/328 =a[int] a/320
          p/329 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-           (makeblock 0 a/322 b/323))
-        (exit 10 x/328 p/329)))
-   with (10 x/324[int] p/325[(consts ()) (non_consts ([0: [int], [int]]))])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/324
-      p/325)))
-(function {nlocal = 0} a/322[int] b/323[int]
+           (makeblock 0 a/320 b/321))
+        (exit 10 x/328 p/329))
+      (let
+        (x/326 =a[(consts ()) (non_consts ([0: ]))] b/321
+         p/327 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+           (makeblock 0 a/320 b/321))
+        (exit 10 x/326 p/327)))
+   with (10 x/322[int] p/323[(consts ()) (non_consts ([0: [int], [int]]))])
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/322
+      p/323)))
+(function {nlocal = 0} a/320[int] b/321[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (catch
-    (if a/322 (exit 10 a/322 (makeblock 0 a/322 b/323))
-      (exit 10 b/323 (makeblock 0 a/322 b/323)))
-   with (10 x/324[int] p/325[(consts ()) (non_consts ([0: [int], [int]]))])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/324
-      p/325)))
+    (if a/320 (exit 10 a/320 (makeblock 0 a/320 b/321))
+      (exit 10 b/321 (makeblock 0 a/320 b/321)))
+   with (10 x/322[int] p/323[(consts ()) (non_consts ([0: [int], [int]]))])
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/322
+      p/323)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -257,30 +252,30 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function {nlocal = 0} a/332[int] b/333[int]
+(function {nlocal = 0} a/330[int] b/331[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/332
+  (if a/330
     (let
-      (x/334 =a[int] a/332
-       _p/335 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/332 b/333))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/334
+      (x/332 =a[int] a/330
+       _p/333 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/330 b/331))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/332
         [0: 1 1]))
     (let
-      (x/336 =a[int] a/332
-       p/337 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/332 b/333))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/336
-        p/337))))
-(function {nlocal = 0} a/332[int] b/333[int]
+      (x/334 =a[int] a/330
+       p/335 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/330 b/331))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/334
+        p/335))))
+(function {nlocal = 0} a/330[int] b/331[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/332
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/332
+  (if a/330
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/330
       [0: 1 1])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/332
-      (makeblock 0 a/332 b/333))))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/330
+      (makeblock 0 a/330 b/331))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -289,20 +284,20 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function {nlocal = 0} a/338[int] b/339
+(function {nlocal = 0} a/336[int] b/337
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/340 =a[int] a/338
-     p/341 =a[(consts ()) (non_consts ([0: [int], *]))]
-       (makeblock 0 a/338 b/339))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/340
-      p/341)))
-(function {nlocal = 0} a/338[int] b/339
+    (x/338 =a[int] a/336
+     p/339 =a[(consts ()) (non_consts ([0: [int], *]))]
+       (makeblock 0 a/336 b/337))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/338
+      p/339)))
+(function {nlocal = 0} a/336[int] b/337
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/338
-    (makeblock 0 a/338 b/339)))
+  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/336
+    (makeblock 0 a/336 b/337)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -319,23 +314,23 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function {nlocal = 0} a/351[int]
-  b/352[(consts (0))
+(function {nlocal = 0} a/349[int]
+  b/350[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (if a/351
-                                                                    (if b/352
+                                                                    (if a/349
+                                                                    (if b/350
                                                                     (let
-                                                                    (p/353 =a
+                                                                    (p/351 =a
                                                                     (field 0
-                                                                    b/352))
-                                                                    p/353)
+                                                                    b/350))
+                                                                    p/351)
                                                                     (exit 12))
                                                                     (exit 12))
                                                                     with (12)
                                                                     (let
-                                                                    (p/354 =a
+                                                                    (p/352 =a
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -344,24 +339,24 @@ let _ =fun a b -> match a, b with
                                                                     (non_consts (
                                                                     [0: *]))]]))]
                                                                     (makeblock 0
-                                                                    a/351
-                                                                    b/352))
-                                                                    p/354)))
-(function {nlocal = 0} a/351[int]
-  b/352[(consts (0))
+                                                                    a/349
+                                                                    b/350))
+                                                                    p/352)))
+(function {nlocal = 0} a/349[int]
+  b/350[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (if a/351
-                                                                    (if b/352
+                                                                    (if a/349
+                                                                    (if b/350
                                                                     (field 0
-                                                                    b/352)
+                                                                    b/350)
                                                                     (exit 12))
                                                                     (exit 12))
                                                                     with (12)
                                                                     (makeblock 0
-                                                                    a/351
-                                                                    b/352)))
+                                                                    a/349
+                                                                    b/350)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -370,25 +365,25 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function {nlocal = 0} a/355[int]
-  b/356[(consts (0))
+(function {nlocal = 0} a/353[int]
+  b/354[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
                                                                     (catch
-                                                                    (if a/355
-                                                                    (if b/356
+                                                                    (if a/353
+                                                                    (if b/354
                                                                     (let
-                                                                    (p/360 =a
+                                                                    (p/358 =a
                                                                     (field 0
-                                                                    b/356))
+                                                                    b/354))
                                                                     (exit 13
-                                                                    p/360))
+                                                                    p/358))
                                                                     (exit 14))
                                                                     (exit 14))
                                                                     with (14)
                                                                     (let
-                                                                    (p/359 =a
+                                                                    (p/357 =a
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -397,11 +392,11 @@ let _ = fun a b -> match a, b with
                                                                     (non_consts (
                                                                     [0: *]))]]))]
                                                                     (makeblock 0
-                                                                    a/355
-                                                                    b/356))
+                                                                    a/353
+                                                                    b/354))
                                                                     (exit 13
-                                                                    p/359)))
-                                                                    with (13 p/357
+                                                                    p/357)))
+                                                                    with (13 p/355
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -409,26 +404,26 @@ let _ = fun a b -> match a, b with
                                                                     [(consts (0))
                                                                     (non_consts (
                                                                     [0: *]))]]))])
-                                                                    p/357))
-(function {nlocal = 0} a/355[int]
-  b/356[(consts (0))
+                                                                    p/355))
+(function {nlocal = 0} a/353[int]
+  b/354[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
                                                                     (catch
-                                                                    (if a/355
-                                                                    (if b/356
+                                                                    (if a/353
+                                                                    (if b/354
                                                                     (exit 13
                                                                     (field 0
-                                                                    b/356))
+                                                                    b/354))
                                                                     (exit 14))
                                                                     (exit 14))
                                                                     with (14)
                                                                     (exit 13
                                                                     (makeblock 0
-                                                                    a/355
-                                                                    b/356)))
-                                                                    with (13 p/357
+                                                                    a/353
+                                                                    b/354)))
+                                                                    with (13 p/355
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -436,6 +431,6 @@ let _ = fun a b -> match a, b with
                                                                     [(consts (0))
                                                                     (non_consts (
                                                                     [0: *]))]]))])
-                                                                    p/357))
+                                                                    p/355))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -82,8 +82,13 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function {nlocal = 0} a/284[int] b/285 : int 0)
-(function {nlocal = 0} a/284[int] b/285 : int 0)
+(function {nlocal = 0} a/284[int] b/285 : int
+  (region
+    (let
+      (_g/286 =a[(consts ()) (non_consts ([0: [int], *]))]
+         (makelocalblock 0 a/284 b/285))
+      0)))
+(function {nlocal = 0} a/284[int] b/285 : int (region 0))
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -102,15 +107,15 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function {nlocal = 0} a/288[int] b/289
+(function {nlocal = 0} a/290[int] b/291
   [(consts ()) (non_consts ([0: [int], *]))](let
-                                              (p/290 =a[(consts ())
+                                              (p/292 =a[(consts ())
                                                         (non_consts (
                                                         [0: [int], *]))]
-                                                 (makeblock 0 a/288 b/289))
-                                              p/290))
-(function {nlocal = 0} a/288[int] b/289
-  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/288 b/289))
+                                                 (makeblock 0 a/290 b/291))
+                                              p/292))
+(function {nlocal = 0} a/290[int] b/291
+  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/290 b/291))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -119,15 +124,15 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function {nlocal = 0} a/292[int] b/293
+(function {nlocal = 0} a/294[int] b/295
   [(consts ()) (non_consts ([0: [int], *]))](let
-                                              (p/294 =a[(consts ())
+                                              (p/296 =a[(consts ())
                                                         (non_consts (
                                                         [0: [int], *]))]
-                                                 (makeblock 0 a/292 b/293))
-                                              p/294))
-(function {nlocal = 0} a/292[int] b/293
-  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/292 b/293))
+                                                 (makeblock 0 a/294 b/295))
+                                              p/296))
+(function {nlocal = 0} a/294[int] b/295
+  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/294 b/295))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -136,20 +141,20 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function {nlocal = 0} a/298[int] b/299
+(function {nlocal = 0} a/300[int] b/301
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/300 =a[int] a/298
-     p/301 =a[(consts ()) (non_consts ([0: [int], *]))]
-       (makeblock 0 a/298 b/299))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/300
-      p/301)))
-(function {nlocal = 0} a/298[int] b/299
+    (x/302 =a[int] a/300
+     p/303 =a[(consts ()) (non_consts ([0: [int], *]))]
+       (makeblock 0 a/300 b/301))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/302
+      p/303)))
+(function {nlocal = 0} a/300[int] b/301
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/298
-    (makeblock 0 a/298 b/299)))
+  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/300
+    (makeblock 0 a/300 b/301)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -158,20 +163,20 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function {nlocal = 0} a/304[int] b/305
+(function {nlocal = 0} a/306[int] b/307
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/306 =a[int] a/304
-     p/307 =a[(consts ()) (non_consts ([0: [int], *]))]
-       (makeblock 0 a/304 b/305))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/306
-      p/307)))
-(function {nlocal = 0} a/304[int] b/305
+    (x/308 =a[int] a/306
+     p/309 =a[(consts ()) (non_consts ([0: [int], *]))]
+       (makeblock 0 a/306 b/307))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/308
+      p/309)))
+(function {nlocal = 0} a/306[int] b/307
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/304
-    (makeblock 0 a/304 b/305)))
+  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/306
+    (makeblock 0 a/306 b/307)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -180,30 +185,30 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function {nlocal = 0} a/314[int] b/315[int]
+(function {nlocal = 0} a/316[int] b/317[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/314
+  (if a/316
     (let
-      (x/316 =a[int] a/314
-       p/317 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/314 b/315))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/316
-        p/317))
-    (let
-      (x/318 =a[(consts ()) (non_consts ([0: ]))] b/315
+      (x/318 =a[int] a/316
        p/319 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/314 b/315))
+         (makeblock 0 a/316 b/317))
       (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/318
-        p/319))))
-(function {nlocal = 0} a/314[int] b/315[int]
+        p/319))
+    (let
+      (x/320 =a[(consts ()) (non_consts ([0: ]))] b/317
+       p/321 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/316 b/317))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/320
+        p/321))))
+(function {nlocal = 0} a/316[int] b/317[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/314
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/314
-      (makeblock 0 a/314 b/315))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) b/315
-      (makeblock 0 a/314 b/315))))
+  (if a/316
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/316
+      (makeblock 0 a/316 b/317))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) b/317
+      (makeblock 0 a/316 b/317))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -213,33 +218,33 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function {nlocal = 0} a/320[int] b/321[int]
+(function {nlocal = 0} a/322[int] b/323[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (catch
-    (if a/320
+    (if a/322
       (let
-        (x/328 =a[int] a/320
+        (x/330 =a[int] a/322
+         p/331 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+           (makeblock 0 a/322 b/323))
+        (exit 10 x/330 p/331))
+      (let
+        (x/328 =a[(consts ()) (non_consts ([0: ]))] b/323
          p/329 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-           (makeblock 0 a/320 b/321))
-        (exit 10 x/328 p/329))
-      (let
-        (x/326 =a[(consts ()) (non_consts ([0: ]))] b/321
-         p/327 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-           (makeblock 0 a/320 b/321))
-        (exit 10 x/326 p/327)))
-   with (10 x/322[int] p/323[(consts ()) (non_consts ([0: [int], [int]]))])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/322
-      p/323)))
-(function {nlocal = 0} a/320[int] b/321[int]
+           (makeblock 0 a/322 b/323))
+        (exit 10 x/328 p/329)))
+   with (10 x/324[int] p/325[(consts ()) (non_consts ([0: [int], [int]]))])
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/324
+      p/325)))
+(function {nlocal = 0} a/322[int] b/323[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
   (catch
-    (if a/320 (exit 10 a/320 (makeblock 0 a/320 b/321))
-      (exit 10 b/321 (makeblock 0 a/320 b/321)))
-   with (10 x/322[int] p/323[(consts ()) (non_consts ([0: [int], [int]]))])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/322
-      p/323)))
+    (if a/322 (exit 10 a/322 (makeblock 0 a/322 b/323))
+      (exit 10 b/323 (makeblock 0 a/322 b/323)))
+   with (10 x/324[int] p/325[(consts ()) (non_consts ([0: [int], [int]]))])
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/324
+      p/325)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -252,30 +257,30 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function {nlocal = 0} a/330[int] b/331[int]
+(function {nlocal = 0} a/332[int] b/333[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/330
+  (if a/332
     (let
-      (x/332 =a[int] a/330
-       _p/333 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/330 b/331))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/332
+      (x/334 =a[int] a/332
+       _p/335 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/332 b/333))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/334
         [0: 1 1]))
     (let
-      (x/334 =a[int] a/330
-       p/335 =a[(consts ()) (non_consts ([0: [int], [int]]))]
-         (makeblock 0 a/330 b/331))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/334
-        p/335))))
-(function {nlocal = 0} a/330[int] b/331[int]
+      (x/336 =a[int] a/332
+       p/337 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+         (makeblock 0 a/332 b/333))
+      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/336
+        p/337))))
+(function {nlocal = 0} a/332[int] b/333[int]
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
-  (if a/330
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/330
+  (if a/332
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/332
       [0: 1 1])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/330
-      (makeblock 0 a/330 b/331))))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/332
+      (makeblock 0 a/332 b/333))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -284,20 +289,20 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function {nlocal = 0} a/336[int] b/337
+(function {nlocal = 0} a/338[int] b/339
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/338 =a[int] a/336
-     p/339 =a[(consts ()) (non_consts ([0: [int], *]))]
-       (makeblock 0 a/336 b/337))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/338
-      p/339)))
-(function {nlocal = 0} a/336[int] b/337
+    (x/340 =a[int] a/338
+     p/341 =a[(consts ()) (non_consts ([0: [int], *]))]
+       (makeblock 0 a/338 b/339))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/340
+      p/341)))
+(function {nlocal = 0} a/338[int] b/339
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/336
-    (makeblock 0 a/336 b/337)))
+  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/338
+    (makeblock 0 a/338 b/339)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -314,23 +319,23 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function {nlocal = 0} a/349[int]
-  b/350[(consts (0))
+(function {nlocal = 0} a/351[int]
+  b/352[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (if a/349
-                                                                    (if b/350
+                                                                    (if a/351
+                                                                    (if b/352
                                                                     (let
-                                                                    (p/351 =a
+                                                                    (p/353 =a
                                                                     (field 0
-                                                                    b/350))
-                                                                    p/351)
+                                                                    b/352))
+                                                                    p/353)
                                                                     (exit 12))
                                                                     (exit 12))
                                                                     with (12)
                                                                     (let
-                                                                    (p/352 =a
+                                                                    (p/354 =a
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -339,24 +344,24 @@ let _ =fun a b -> match a, b with
                                                                     (non_consts (
                                                                     [0: *]))]]))]
                                                                     (makeblock 0
-                                                                    a/349
-                                                                    b/350))
-                                                                    p/352)))
-(function {nlocal = 0} a/349[int]
-  b/350[(consts (0))
+                                                                    a/351
+                                                                    b/352))
+                                                                    p/354)))
+(function {nlocal = 0} a/351[int]
+  b/352[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (if a/349
-                                                                    (if b/350
+                                                                    (if a/351
+                                                                    (if b/352
                                                                     (field 0
-                                                                    b/350)
+                                                                    b/352)
                                                                     (exit 12))
                                                                     (exit 12))
                                                                     with (12)
                                                                     (makeblock 0
-                                                                    a/349
-                                                                    b/350)))
+                                                                    a/351
+                                                                    b/352)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -365,25 +370,25 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function {nlocal = 0} a/353[int]
-  b/354[(consts (0))
+(function {nlocal = 0} a/355[int]
+  b/356[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
                                                                     (catch
-                                                                    (if a/353
-                                                                    (if b/354
+                                                                    (if a/355
+                                                                    (if b/356
                                                                     (let
-                                                                    (p/358 =a
+                                                                    (p/360 =a
                                                                     (field 0
-                                                                    b/354))
+                                                                    b/356))
                                                                     (exit 13
-                                                                    p/358))
+                                                                    p/360))
                                                                     (exit 14))
                                                                     (exit 14))
                                                                     with (14)
                                                                     (let
-                                                                    (p/357 =a
+                                                                    (p/359 =a
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -392,11 +397,11 @@ let _ = fun a b -> match a, b with
                                                                     (non_consts (
                                                                     [0: *]))]]))]
                                                                     (makeblock 0
-                                                                    a/353
-                                                                    b/354))
+                                                                    a/355
+                                                                    b/356))
                                                                     (exit 13
-                                                                    p/357)))
-                                                                    with (13 p/355
+                                                                    p/359)))
+                                                                    with (13 p/357
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -404,26 +409,26 @@ let _ = fun a b -> match a, b with
                                                                     [(consts (0))
                                                                     (non_consts (
                                                                     [0: *]))]]))])
-                                                                    p/355))
-(function {nlocal = 0} a/353[int]
-  b/354[(consts (0))
+                                                                    p/357))
+(function {nlocal = 0} a/355[int]
+  b/356[(consts (0))
         (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
   [(consts ())
    (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
                                                                     (catch
-                                                                    (if a/353
-                                                                    (if b/354
+                                                                    (if a/355
+                                                                    (if b/356
                                                                     (exit 13
                                                                     (field 0
-                                                                    b/354))
+                                                                    b/356))
                                                                     (exit 14))
                                                                     (exit 14))
                                                                     with (14)
                                                                     (exit 13
                                                                     (makeblock 0
-                                                                    a/353
-                                                                    b/354)))
-                                                                    with (13 p/355
+                                                                    a/355
+                                                                    b/356)))
+                                                                    with (13 p/357
                                                                     [(consts ())
                                                                     (non_consts (
                                                                     [0:
@@ -431,6 +436,6 @@ let _ = fun a b -> match a, b with
                                                                     [(consts (0))
                                                                     (non_consts (
                                                                     [0: *]))]]))])
-                                                                    p/355))
+                                                                    p/357))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -437,3 +437,12 @@ Only the first match will be used to evaluate the guard expression.
 val warn_ambiguous : int list * int list -> int = <fun>
 |}];;
 
+(* Ensure that warning 57 is not extraneously issued for pattern guards. *)
+let dont_warn_ambiguous = function
+  | ([ x ], _) | (_, [ x ]) when (let one = 1 in one + one) match 2 -> x
+  | _ -> 0
+;;
+[%%expect{|
+val dont_warn_ambiguous : int list * int list -> int = <fun>
+|}];;
+

--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -243,13 +243,12 @@ let exhaustive_pattern_guards (x : (unit, void option) Either.t) : int =
     | _ -> 2
 ;;
 [%%expect{|
-type void = |
-Line 192, characters 13-28:
-192 |     | Left u when u match () -> 0
+Line 241, characters 13-28:
+241 |     | Left u when u match () -> 0
                    ^^^^^^^^^^^^^^^
 Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
-Line 193, characters 14-31:
-193 |     | Right v when v match None -> 1
+Line 242, characters 14-31:
+242 |     | Right v when v match None -> 1
                     ^^^^^^^^^^^^^^^^^
 Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
 val exhaustive_pattern_guards : (unit, void option) Either.t -> int = <fun>

--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -343,3 +343,34 @@ patch_to_match_failure exact_half ~-1 (Some 41);;
 Exception: Match_failure ("", 2, 2).
 |}];;
 
+let warn_partial = function
+  | [] -> 0
+  | xs when List.hd xs match Some y -> y
+;;
+[%%expect{|
+Lines 1-3, characters 19-40:
+1 | ...................function
+2 |   | [] -> 0
+3 |   | xs when List.hd xs match Some y -> y
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+_::_
+(However, some guarded clause may match this value.)
+val warn_partial : int option list -> int = <fun>
+|}];;
+
+let warn_ambiguous = function
+  | ([ x ], _) | (_, [ x ]) when (let one = 1 in Int.abs x + one) match 2 -> 1
+  | _ -> 0
+;;
+[%%expect{|
+Line 2, characters 4-27:
+2 |   | ([ x ], _) | (_, [ x ]) when (let one = 1 in Int.abs x + one) match 2 -> 1
+        ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
+variable x appears in different places in different or-pattern alternatives.
+Only the first match will be used to evaluate the guard expression.
+(See manual section 11.5)
+val warn_ambiguous : int list * int list -> int = <fun>
+|}]
+

--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -4,16 +4,19 @@
 (* CR-soon rgodse: We expect this output to change soon, but for now it shows
    that parsing and typechecking work (as the compiler fails at translation). *)
 
+(* Test basic usage of pattern guards. *)
 let basic_usage ~f ~default x =
-  match x with 
+  match x with
     | Some x when f x match Some y -> y
     | _ -> default
 ;;
-
-let f x = if x > 0 then Some (x - 1) else None;;
 [%%expect{|
 val basic_usage : f:('a -> 'b option) -> default:'b -> 'a option -> 'b =
   <fun>
+|}];;
+
+let f x = if x > 0 then Some (x - 1) else None;;
+[%%expect{|
 val f : int -> int option = <fun>
 |}];;
 
@@ -34,6 +37,7 @@ basic_usage ~f ~default:~-1 None;;
 - : int = -1
 |}];;
 
+(* Demonstrate parsing of sequences in boolean predicates. *)
 let seq_predicate x ~f ~g ~default =
   match x with
     | Some x when f x; g x -> x
@@ -44,21 +48,28 @@ val seq_predicate :
   'a option -> f:('a -> 'b) -> g:('a -> bool) -> default:'a -> 'a = <fun>
 |}];;
 
+(* Demonstrate semantics of sequences in pattern guard scrutinees. *)
 let seq_pattern x ~f ~g ~default =
   match x with
     | Some x when (f x; g x) match Some y -> y
     | _ -> default
 ;;
-
-let counter = ref 0;;
-let f () = incr counter;;
-let g () = if !counter > 1 then Some (!counter - 1) else None;;
 [%%expect{|
 val seq_pattern :
   'a option -> f:('a -> 'b) -> g:('a -> 'c option) -> default:'c -> 'c =
   <fun>
+|}];;
+
+let counter = ref 0;;
+[%%expect{|
 val counter : int ref = {contents = 0}
+|}];;
+let f () = incr counter;;
+[%%expect{|
 val f : unit -> unit = <fun>
+|}];;
+let g () = if !counter > 1 then Some (!counter - 1) else None;;
+[%%expect{|
 val g : unit -> int option = <fun>
 |}];;
 
@@ -73,7 +84,7 @@ seq_pattern (Some ()) ~f ~g ~default:0;;
 seq_pattern None ~f ~g ~default:0;;
 [%%expect{|
 - : int = 0
-|}]
+|}];;
 
 let complex_types (x : int list option) : bool =
   let strs_opt = match x with
@@ -87,8 +98,9 @@ let complex_types (x : int list option) : bool =
 ;;
 [%%expect {|
 val complex_types : int list option -> bool = <fun>
-|}]
+|}];;
 
+(* Check typing of pattern guard patterns. *)
 let ill_typed_pattern (x : int list option) : bool =
   match x with
     | Some [ y ] when y match None -> true
@@ -128,6 +140,34 @@ typing_no_value_clauses f (Some 5);;
 - : (int, exn) result = Ok 20
 |}];;
 
+let typing_no_value_clauses f x =
+  match x with
+    | Some x when f x match exception e -> Error e
+    | Some x -> Ok (f x)
+    | None -> Error (Failure "x is None")
+;;
+
+let f x = 100 / x;;
+[%%expect{|
+val typing_no_value_clauses : ('a -> 'b) -> 'a option -> ('b, exn) result =
+  <fun>
+val f : int -> int = <fun>
+|}];;
+
+typing_no_value_clauses f None;;
+[%%expect{|
+- : (int, exn) result = Error (Failure "x is None")
+|}];;
+typing_no_value_clauses f (Some 0);;
+[%%expect{|
+- : (int, exn) result = Error Division_by_zero
+|}];;
+typing_no_value_clauses f (Some 5);;
+[%%expect{|
+- : (int, exn) result = Ok 20
+|}];;
+
+(* Check typing of vars bound in pattern guard patterns. *)
 let ill_typed_pattern_var (x : int list option) : bool =
   match x with
     | Some xs when xs match [ y ] -> String.equal y "foo"
@@ -138,8 +178,9 @@ Line 3, characters 50-51:
                                                       ^
 Error: This expression has type int but an expression was expected of type
          String.t = string
-|}]
+|}];;
 
+(* Check that pattern guards can shadow and use outer variables correctly. *)
 let shadow_outer_variables (n : int option) (strs : string list) =
   match n with
   | Some n when List.nth_opt strs n match Some s -> s
@@ -162,7 +203,12 @@ shadow_outer_variables (Some 2) [ "foo"; "bar" ];;
 - : string = "Not found"
 |}]
 
+(* Test inward propagation of GADT type information. *)
+
 type ('a, 'b) eq = Eq : ('a, 'a) eq
+[%%expect{|
+type ('a, 'b) eq = Eq : ('a, 'a) eq
+|}];;
 
 let in_pattern_guard (type a b) (eq : (a, b) eq) (compare : a -> a -> int)
                      (x : a) (y : b) =
@@ -170,7 +216,6 @@ let in_pattern_guard (type a b) (eq : (a, b) eq) (compare : a -> a -> int)
     | Eq when compare x y match 0 -> true
     | _ -> false
 [%%expect{|
-type ('a, 'b) eq = Eq : ('a, 'a) eq
 val in_pattern_guard : ('a, 'b) eq -> ('a -> 'a -> int) -> 'a -> 'b -> bool =
   <fun>
 |}]
@@ -186,7 +231,11 @@ val from_pattern_guard :
 |}]
 
 type void = |
+[%%expect{|
+type void = |
+|}];;
 
+(* Ensure that warning 73 is appropriately issued. *)
 let exhaustive_pattern_guards (x : (unit, void option) Either.t) : int =
   match x with
     | Left u when u match () -> 0
@@ -244,14 +293,6 @@ module M : sig
   val find : int -> 'a t -> 'a
   val find_opt : int -> 'a t -> 'a option
 end = Map.Make (Int);;
-
-let say_hello (id : int option) (name_map : string M.t) =
-  match id with
-    | Some id when M.find_opt id name_map match Some name -> "Hello, " ^ name
-    | None | Some _ -> "Hello, stranger"
-;;
-
-let name_map = M.empty |> M.add 0 "Fred" |> M.add 4 "Barney";;
 [%%expect{|
 module M :
   sig
@@ -261,7 +302,20 @@ module M :
     val find : int -> 'a t -> 'a
     val find_opt : int -> 'a t -> 'a option
   end
+|}];;
+
+(* Correctness test for pattern guard matching and failure. *)
+let say_hello (id : int option) (name_map : string M.t) =
+  match id with
+    | Some id when M.find_opt id name_map match Some name -> "Hello, " ^ name
+    | None | Some _ -> "Hello, stranger"
+;;
+[%%expect{|
 val say_hello : int option -> string M.t -> string = <fun>
+|}];;
+
+let name_map = M.empty |> M.add 0 "Fred" |> M.add 4 "Barney";;
+[%%expect{|
 val name_map : string M.t = <abstr>
 |}];;
 
@@ -282,6 +336,8 @@ say_hello None name_map;;
 - : string = "Hello, stranger"
 |}]
 
+(* Correctness test for pattern guards with mixed value and exception
+   patterns. *)
 let say_hello_catching_exns id name_map =
   match id with
     | Some id when M.find id name_map match "Barney" | exception _ ->
@@ -309,13 +365,13 @@ say_hello_catching_exns None name_map;;
 - : string = "Hello, Fred"
 |}]
 
+(* Ensure that Match_failure is raised when all cases, including pattern-guarded
+   ones, fail to match. *)
 let patch_to_match_failure f default x =
   match x with
   | None -> default
   | Some x when f x match Some y -> y
 ;;
-
-let exact_half n = if n mod 2 = 0 then Some (n / 2) else None;;
 [%%expect{|
 Lines 2-4, characters 2-37:
 2 | ..match x with
@@ -327,6 +383,10 @@ Some _
 (However, some guarded clause may match this value.)
 val patch_to_match_failure : ('a -> 'b option) -> 'b -> 'a option -> 'b =
   <fun>
+|}];;
+
+let exact_half n = if n mod 2 = 0 then Some (n / 2) else None;;
+[%%expect{|
 val exact_half : int -> int option = <fun>
 |}];;
 
@@ -343,6 +403,8 @@ patch_to_match_failure exact_half ~-1 (Some 41);;
 Exception: Match_failure ("", 2, 2).
 |}];;
 
+(* Ensure that warning 8 is issued appropriately in the presence of pattern
+   guards. *)
 let warn_partial = function
   | [] -> 0
   | xs when List.hd xs match Some y -> y
@@ -359,6 +421,7 @@ _::_
 val warn_partial : int option list -> int = <fun>
 |}];;
 
+(* Ensure that warning 57 is appropriately issued for pattern guards. *)
 let warn_ambiguous = function
   | ([ x ], _) | (_, [ x ]) when (let one = 1 in Int.abs x + one) match 2 -> 1
   | _ -> 0
@@ -372,5 +435,5 @@ variable x appears in different places in different or-pattern alternatives.
 Only the first match will be used to evaluate the guard expression.
 (See manual section 11.5)
 val warn_ambiguous : int list * int list -> int = <fun>
-|}]
+|}];;
 


### PR DESCRIPTION
The current strategy for translating guarded rhs's is to construct a continuation to be evaluated lazily and a lambda term that evaluates the continuation on [staticfail]. This allows us to more elegantly patch the rhs while also being able to examine its structure. However, this design leads to the evaluation of all translation functions twice, which is less than desirable.

This PR improves on efficiency by precomputing (and updating) the parts of the translated rhs that the pattern match compiler cares about instead of the translated rhs itself.

Prior to this PR, there were two sites in the pattern match compiler which cared about the structure of the translated rhs.
1. `Matching.safe_before`: The callsite checks for equality between rhs's using structural equality of their translations. This requires greater investigation, but we posit that guarded rhs's should never be equal to another rhs in this way: for that reason, we return false if either operand is guarded, obviating the need to track the structure of the lambda.
2. `Matching.pm_free_variables`: The callsite determines the free variables in a pattern match by unioning the free variables in each rhs. Here, we precompute this information for guarded rhs's.