### PR TITLE
Some support for debugging ocamlopt, plus docs revisions

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -295,24 +295,22 @@ Rather than using our elisp above, you can instead manually invoke the
 ocamldebug emacs mode as follows:
 
 1. Run `M-x camldebug RET`
-2. Choose the `ocamlc` symlink in the root of the repo.
-3. Choose the arguments to pass to `ocamlc`, likely a full path to a test `.ml`
-   file.
+2. Choose the `ocamlc` or `ocamlopt` symlink in the root of the repo.
+3. Choose the arguments to pass to the compiler, likely a full path to a test
+   `.ml` file.
 4. Choose the built `ocamldebug`, in your install directory.
 5. Set any breakpoints you want. The easiest way is to navigate to the line
    where you want the breakpoint and use `C-x C-a C-b` in emacs.
 6. Add relevant directories to `ocamldebug`'s search path.  (If you skip this,
    printing any value may produce `Cannot find module Misc.` or similar
-   errors).  If debugging `ocamlc` compiler, run:
+   errors).  If debugging `ocamlc`, run:
    ```
    (ocd) directory _build/main/ocaml/.ocamlcommon.objs/byte
    ```
-   If debugging the native code compiler, you'll need various additional
-   directories depending on your middle end.  You can find the right directories
-   by searching for cmo files corresponding to the module named in the error
-   message.
+   If debugging `ocamlopt`, you'll need various additional directories depending
+   on your middle end.  You can find the right directories by searching for cmo
+   files corresponding to the module named in the error message.
 7. `run` to your breakpoint.
-
 
 The elisp `ocamldebug-ocaml{c,opt}` functions automate steps 1, 2, 4, 6, and 7,
 above.

--- a/HACKING.md
+++ b/HACKING.md
@@ -206,49 +206,32 @@ something like:
 
 ## Using the OCaml debugger to debug the compiler
 
-Run `make debug`. This completes three steps:
+First, run `make debug`. This completes three steps:
 
 1. `make install`
 2. Sets up the `ocaml/tools/debug_printers` script so that you can `source
    ocaml/tools/debug_printers` during a debugging session to see
-   otherwise-abstract variable values.
-3. Symlinks `./ocamlc` to point to the bytecode compiler. This is convenient for
-   emacs integration, because emacs looks for sources starting in the directory
-   containing the executable.
-   
-To actually run the debugger from emacs (other workflows are possible; just
-tweak these instructions):
+   otherwise-abstract variable values.  This script is automatically loaded by
+   the debugger due to the `.ocamldebug` file at the root of the compiler repo.
+3. Symlinks `./ocamlc` and `./ocamlopt` to point to the bytecode versions of
+   those compilers. This is convenient for emacs integration, because emacs
+   looks for sources starting in the directory containing the executable.
 
-1. Run `M-x camldebug RET`
-2. Choose the `ocamlc` symlink in the root of the repo.
-3. Choose the arguments to pass to `ocamlc`, likely a full path to a test `.ml`
-   file.
-4. Choose the built `ocamldebug`, in your install directory.
-5. Set any breakpoints you want. The easiest way is to navigate to the line
-   where you want the breakpoint and use `C-x C-a C-b` in emacs.
-6. Run `directory _build/main/ocaml/.ocamlcommon.objs/byte` to add the right
-   directory to `ocamldebug`'s search path. (If you skip this, printing any
-   value produces `Cannot find module Misc.`.)
-7. `run` to your breakpoint.
-
-There is already a `.ocamldebug` file that automatically loads the
-`debug_printers` built by `make debug`; no need to load those printers.
-
-In order to make doing this even easier, you may want the following emacs-lisp
-function, which automates steps 1, 2, 4, 6, and 7, above. That is, with
-`ocamldebug-ocaml`, you choose the arguments to the debugger (usually, some
-target `.ml` file), set a breakpoint, and then `run`.
+Then it's time to run the debugger itself.  The recommended workflow is to add
+the elisp below to your emacs init file, and then use the command
+`ocamldebug-ocamlc` to debug `ocamlc` or the command `ocamldebug-ocamlopt` to
+debug `ocamlopt`.
 
 ```
 ;; directly inspired by the ocamldebug implementation in ocamldebug.el
 (require 'ocamldebug)
-(defun ocamldebug-ocaml ()
+(defun ocamldebug-ocaml (cmd)
+  "Runs ocamldebug on the provided command"
   (interactive)
-  "Runs ocamldebug on the ocaml built from the source file in the active buffer"
   (let* ((ocaml-dir (expand-file-name
                      (locate-dominating-file (buffer-file-name) ".git")))
-         (pgm-path (file-name-concat ocaml-dir "ocamlc"))
-         (comint-name "ocamldebug-ocamlc")
+         (pgm-path (file-name-concat ocaml-dir cmd))
+         (comint-name (concat "ocamldebug-" cmd))
          (buffer-name (concat "*" comint-name "*"))
          (ocamldebug-command-name
           (file-name-concat ocaml-dir "_build/install/main/bin/ocamldebug")))
@@ -260,25 +243,79 @@ target `.ml` file), set a breakpoint, and then `run`.
       (setq ocamldebug-debuggee-args
             (read-from-minibuffer (format "Args for ocamlc: ")
                                   ocamldebug-debuggee-args))
-      (let* ((args (split-string-shell-command ocamldebug-debuggee-args)))
-        (apply #'make-comint comint-name
-               ocamldebug-command-name
-               nil
-               "-emacs"
-               "-cd" default-directory
-               "-I" "_build/main/ocaml/.ocamlcommon.objs/byte"
-               pgm-path
-               args)
+      (let* ((cmo-top-dir (file-name-concat ocaml-dir "_build/main"))
+             (find-cmo-cmd (concat "find "
+                                   cmo-top-dir
+                                   " -name '*.cmo' -type f -printf '%h\n' | sort -u"))
+             (cmo-dirs (shell-command-to-string find-cmo-cmd)))
+        (setq cmo-dir-list (split-string cmo-dirs "\n" t)))
+      (let* ((user-args (split-string-shell-command ocamldebug-debuggee-args))
+             (includes (mapcan (lambda (dir) (list "-I" dir)) cmo-dir-list))
+             (args (append (list
+                             comint-name
+                             ocamldebug-command-name
+                             nil
+                             "-emacs"
+                             "-cd" default-directory)
+                           includes
+                           (list pgm-path)
+                           user-args)))
+        (apply #'make-comint args)
         (set-process-filter (get-buffer-process (current-buffer))
                             #'ocamldebug-filter)
         (set-process-sentinel (get-buffer-process (current-buffer))
                               #'ocamldebug-sentinel)
         (ocamldebug-mode)))
     (ocamldebug-set-buffer)))
+(defun ocamldebug-ocamlc ()
+  "Runs ocamldebug on the ocamlc built from the source file in the active buffer"
+  (interactive)
+  (ocamldebug-ocaml "ocamlc"))
+(defun ocamldebug-ocamlopt ()
+  "Runs ocamldebug on the ocamlopt built from the source file in the active buffer"
+  (interactive)
+  (ocamldebug-ocaml "ocamlopt"))
 ```
+
+These commands will prompt you for the arguments to be passed to the compiler.
+Usually this includes the location of a test `.ml` file to be compiled (note
+that `~` will not be expanded, so using a full path is often necessary).
+Compiler command line flags may also be passed this way (e.g., `-extension`
+flags).
+
+Once at the ocamldebugger's `(ocd)` prompt, you are ready to set breakpoints
+in relevant compiler source files with `C-x C-a C-b` and `run` the debugger.
 
 See [the manual section](https://v2.ocaml.org/manual/debugger.html) for more
 information about the debugger.
+
+### Alternative debugger workflow
+
+Rather than using our elisp above, you can instead manually invoke the
+ocamldebug emacs mode as follows:
+
+1. Run `M-x camldebug RET`
+2. Choose the `ocamlc` symlink in the root of the repo.
+3. Choose the arguments to pass to `ocamlc`, likely a full path to a test `.ml`
+   file.
+4. Choose the built `ocamldebug`, in your install directory.
+5. Set any breakpoints you want. The easiest way is to navigate to the line
+   where you want the breakpoint and use `C-x C-a C-b` in emacs.
+6. Add relevant directories to `ocamldebug`'s search path.  (If you skip this,
+   printing any value may produce `Cannot find module Misc.` or similar
+   errors).  If debugging `ocamlc` compiler, run:
+   ```
+   (ocd) directory _build/main/ocaml/.ocamlcommon.objs/byte
+   ```
+   If debugging the native code compiler, you'll need various additional
+   directories depending on your middle end.  You can find the right directories
+   by searching for cmo files corresponding to the module named in the error
+   message.
+7. `run` to your breakpoint.
+
+
+The elisp `ocamldebug-ocaml{c,opt}` functions automate steps 1, 2, 4, 6, and 7,
+above.
 
 ## Getting the compilation command for a stdlib file
 

--- a/Makefile
+++ b/Makefile
@@ -163,10 +163,13 @@ coverage: boot-runtest
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: install ocaml/tools/debug_printers ocamlc
+debug: install ocaml/tools/debug_printers ocamlc ocamlopt
 
 ocamlc:
 	ln -s $(prefix)/bin/ocamlc.byte ocamlc
+
+ocamlopt:
+	ln  -s $(prefix)/bin/ocamlopt.byte ocamlopt
 
 ocaml/tools/debug_printers: ocaml/tools/debug_printers.ml ocaml/tools/debug_printers.cmo
 	echo 'load_printer "ocaml/tools/debug_printers.cmo"' > $@


### PR DESCRIPTION
This makes four small improvements to the debugging story:

- The `debug` target now also provides a symlink to `ocamlopt.byte`
- `HACKING.md` is revised to put the nice workflow first, and explicitly recommend it over the old manual workflow.
- The recommended elisp is revised to have two commands (`ocamldebug-ocamlc` and `ocamldebug-ocamlopt`, for debugging the indicated compiler).
- The handling of `-I` arguments in the recommended elisp is revised (these are the things that end up in the ocamldebug "`directories`" search path).  I found that to effectively debug `ocamlopt`, it is necessary to add a dozen or more directories to this list, and they vary depending on what middle-end you have configured for.  Rather than listing them out manually, the elisp now just uses `find` to locate all directories under `_build/main` that contain a `.cmo` file, and adds them to the list.  This seems to work, and has the advantage of being robust when we add or rename directories in the compiler source (at least, I think it is).

Review: @goldfirere wrote the previous version of this documentation, but I suppose anybody can review.