### PR TITLE
Build dwarf_ocaml/ files as part of ocamloptcomp

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dune
+++ b/backend/debug/dwarf/dwarf_ocaml/dune
@@ -1,9 +1,0 @@
-(include_subdirs unqualified)
-
-(library
-  (name dwarf_ocaml)
-  (wrapped true)
-  (flags (:standard -principal))
-  (ocamlopt_flags (:standard -O3))
-  (libraries dwarf_high dwarf_low asm_targets)
-)

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -434,8 +434,6 @@ let reduce_heap_size ~reset =
   end
 
 module Dwarf_helpers = struct
-  open Dwarf_ocaml
-
   let dwarf = ref None
   let sourcefile_for_dwarf = ref None
 
@@ -481,7 +479,7 @@ module Dwarf_helpers = struct
     | true, _, _
     | false, _, _ -> ()
 
-  let emit_dwarf () = Option.iter Dwarf_ocaml.Dwarf.emit !dwarf
+  let emit_dwarf () = Option.iter Dwarf.emit !dwarf
 
   let record_dwarf_for_fundecl ~fun_name fun_dbg =
     match !dwarf with

--- a/dune
+++ b/dune
@@ -17,6 +17,8 @@
 
 (copy_files# backend/debug/*.ml{,i})
 
+(copy_files# backend/debug/dwarf/dwarf_ocaml/*.ml{,i})
+
 (copy_files# backend/internal_assembler/*.ml{,i})
 
 (copy_files# backend/regalloc/*.ml{,i})
@@ -271,6 +273,13 @@
   available_regs
   reg_with_debug_info
   compute_ranges
+  ;; asmcomp/debug/dwarf/dwarf_ocaml
+  ;; This code has a lot of dependencies into ocamloptcomp, so we just
+  ;; build it as part of that library.
+  dwarf
+  dwarf_compilation_unit
+  dwarf_concrete_instances
+  dwarf_state
   ;; driver/
   opterrors
   optcompile
@@ -288,9 +297,10 @@
   flambda_backend_utils
   flambda2_identifiers
   flambda2_cmx
-  dwarf_ocaml
   compiler_owee
-  gc_timings))
+  gc_timings
+  dwarf_low
+  dwarf_high))
 
 (library
  (name flambda_backend_common)
@@ -348,7 +358,8 @@
   (backend bisect_ppx))
  (flags
   (:standard -principal))
- (ocamlopt_flags (:standard -runtime-variant nnp))
+ (ocamlopt_flags
+  (:standard -runtime-variant nnp))
  (libraries
   flambda_backend_driver
   memtrace
@@ -397,7 +408,6 @@
    %{dep:backend/asm_targets/asm_targets.a}
    %{dep:backend/debug/dwarf/dwarf_low/dwarf_low.a}
    %{dep:backend/debug/dwarf/dwarf_high/dwarf_high.a}
-   %{dep:backend/debug/dwarf/dwarf_ocaml/dwarf_ocaml.a}
    %{dep:flambda_backend_common.a}
    %{dep:utils/flambda_backend_utils.a}
    %{dep:middle_end/flambda2/import/flambda2_import.a}
@@ -434,7 +444,6 @@
    %{dep:backend/asm_targets/asm_targets.cma}
    %{dep:backend/debug/dwarf/dwarf_low/dwarf_low.cma}
    %{dep:backend/debug/dwarf/dwarf_high/dwarf_high.cma}
-   %{dep:backend/debug/dwarf/dwarf_ocaml/dwarf_ocaml.cma}
    %{dep:flambda_backend_common.cma}
    %{dep:utils/flambda_backend_utils.cma}
    %{dep:middle_end/flambda2/import/flambda2_import.cma}
@@ -471,7 +480,6 @@
    %{dep:backend/asm_targets/asm_targets.cmxa}
    %{dep:backend/debug/dwarf/dwarf_low/dwarf_low.cmxa}
    %{dep:backend/debug/dwarf/dwarf_high/dwarf_high.cmxa}
-   %{dep:backend/debug/dwarf/dwarf_ocaml/dwarf_ocaml.cmxa}
    %{dep:flambda_backend_common.cmxa}
    %{dep:utils/flambda_backend_utils.cmxa}
    %{dep:middle_end/flambda2/import/flambda2_import.cmxa}
@@ -519,7 +527,6 @@
   (external/gc-timings/libgc_timings_stubs.a
    as
    compiler-libs/libgc_timings_stubs_native.a)
-
   ; for special_dune compat
   (ocamloptcomp_with_flambda2.cma as compiler-libs/ocamloptcomp.cma)
   (ocamloptcomp_with_flambda2.cmxa as compiler-libs/ocamloptcomp.cmxa)
@@ -541,8 +548,7 @@
    backend/asm_targets/.asm_targets.objs/byte/asm_targets.{cmi,cmo,cmt})
   (glob_files_rec
    backend/asm_targets/.asm_targets.objs/native/asm_targets.cmx)
-  (glob_files
-   middle_end/flambda2/.flambda2objs/byte/flambda2.{cmi,cmt})
+  (glob_files middle_end/flambda2/.flambda2objs/byte/flambda2.{cmi,cmt})
   (glob_files
    middle_end/flambda2/to_cmm/.flambda2_to_cmm.objs/byte/flambda2_to_cmm{,__To_cmm}.{cmi,cmt})
   (glob_files
@@ -555,28 +561,23 @@
   backend/debug/dwarf/dwarf_flags/.dwarf_flags.objs/native/dwarf_flags.cmx
   (glob_files
    backend/debug/dwarf/dwarf_low/.dwarf_low.objs/byte/*.{cmi,cmo,cmt})
-  (glob_files
-   backend/debug/dwarf/dwarf_low/.dwarf_low.objs/native/*.cmx)
+  (glob_files backend/debug/dwarf/dwarf_low/.dwarf_low.objs/native/*.cmx)
   (glob_files
    backend/debug/dwarf/dwarf_high/.dwarf_high.objs/byte/*.{cmi,cmo,cmt})
-  (glob_files
-   backend/debug/dwarf/dwarf_high/.dwarf_high.objs/native/*.cmx)
-  (glob_files
-   backend/debug/dwarf/dwarf_ocaml/.dwarf_ocaml.objs/byte/*.{cmi,cmo,cmt})
-  (glob_files
-   backend/debug/dwarf/dwarf_ocaml/.dwarf_ocaml.objs/native/*.cmx)
-  (glob_files
-   external/owee/.compiler_owee.objs/byte/*.{cmi,cmo,cmt,cmti})
-  (glob_files
-   external/owee/.compiler_owee.objs/native/*.cmx)
+  (glob_files backend/debug/dwarf/dwarf_high/.dwarf_high.objs/native/*.cmx)
+  (glob_files backend/debug/dwarf/dwarf_ocaml/.dwarf_ocaml.objs/native/*.cmx)
+  (glob_files external/owee/.compiler_owee.objs/byte/*.{cmi,cmo,cmt,cmti})
+  (glob_files external/owee/.compiler_owee.objs/native/*.cmx)
   (glob_files
    external/gc-timings/.gc_timings.objs/byte/gc_timings.{cmi,cmti})
   external/gc-timings/.gc_timings.objs/native/gc_timings.cmx)
  (action
-  (with-stdout-to compiler-libs-installation.sexp
+  (with-stdout-to
+   compiler-libs-installation.sexp
    (run tools/gen_compiler_libs_installation.exe %{deps}))))
 
 (install
  (section lib)
  (package ocaml)
- (files (include compiler-libs-installation.sexp)))
+ (files
+  (include compiler-libs-installation.sexp)))


### PR DESCRIPTION
As discussed with @poechsel .  These files (and some more coming soon) have a lot of dependencies into `ocamloptcomp` and the easiest thing is to build them together with that library.