### PR TITLE
Fix unboxed primitives test

### DIFF
--- a/testsuite/tests/unboxed-primitive-args/gen_test.ml
+++ b/testsuite/tests/unboxed-primitive-args/gen_test.ml
@@ -14,7 +14,7 @@ type native_repr =
   | Unboxed_vector of boxed_vector
 
 (* Generate primitives with up to this number of arguments *)
-let test_all_combination_up_to_n_args = 6
+let test_all_combination_up_to_n_args = 5
 
 (* Generate primitives using all combination of these argument
    representations. No need to test all combination of other

--- a/testsuite/tests/unboxed-primitive-args/test.ml
+++ b/testsuite/tests/unboxed-primitive-args/test.ml
@@ -11,14 +11,10 @@ compiler_output = "stubs.c"
 *** ocaml
 arguments = "ml"
 compiler_output = "main.ml"
-**** script
-script = "${cc} -msse4.2 -c test_common.c -I ../../../../../../../../runtime"
-***** script
-script = "${cc} -msse4.2 -c stubs.c -I ../../../../../../../../runtime"
-****** ocamlopt.opt
-ocamlopt_flags = "-extension simd"
-all_modules = "test_common.o stubs.o common.mli common.ml main.ml"
-******* run
-******** check-program-output
+**** ocamlopt.opt
+ocamlopt_flags = "-extension simd -cc 'gcc -msse4.2'"
+all_modules = "test_common.c stubs.c common.mli common.ml main.ml"
+***** run
+****** check-program-output
 
 *)

--- a/testsuite/tests/unboxed-primitive-args/test.ml
+++ b/testsuite/tests/unboxed-primitive-args/test.ml
@@ -12,7 +12,7 @@ compiler_output = "stubs.c"
 arguments = "ml"
 compiler_output = "main.ml"
 **** ocamlopt.opt
-ocamlopt_flags = "-extension simd -cc 'gcc -msse4.2'"
+ocamlopt_flags = "-extension simd -cc '${cc} -msse4.2'"
 all_modules = "test_common.c stubs.c common.mli common.ml main.ml"
 ***** run
 ****** check-program-output


### PR DESCRIPTION
Running `unboxed-primitive-args/test.ml` locally with `make test-one` ends up compiling it in a different working directory, so this PR removes the hardcoded include path for `gcc`.

Also, compiling the test with closure can run into stack limits (also only locally, seems not to in the CI), so this reduces the number of generated functions from 5^6 to 5^5. 