### PR TITLE
Emit dwarf debug information after it has been collected

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1954,6 +1954,6 @@ let end_assembly () =
     else
       None
   in
-  Emitaux.Dwarf_helpers.emit_dwarf ();
-  X86_proc.generate_code asm;
-  reset_all ()
+  if not !Flambda_backend_flags.internal_assembler then
+    Emitaux.Dwarf_helpers.emit_dwarf ();
+  X86_proc.generate_code asm

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1956,4 +1956,7 @@ let end_assembly () =
   in
   if not !Flambda_backend_flags.internal_assembler then
     Emitaux.Dwarf_helpers.emit_dwarf ();
-  X86_proc.generate_code asm
+  X86_proc.generate_code asm;
+  (* The internal assembler does not work if reset_all is called here *)
+  if not !Flambda_backend_flags.internal_assembler then
+    reset_all ()

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -183,6 +183,12 @@ let get_sections sections =
       Section_name.Map.add name (assemble_one_section ~name instructions) acc)
       acc sections
   in
+  (* DWARF sections must be emitted after .text and .data because they
+     contain information that is produced when .text and .data are emitted.
+     For example, DWARF sections need to know the offset of some instructions
+     from the start of the .text section.
+     Additionally, DWARF sections may add relocations to the object file's
+     relocation table. *)
   let acc = aux text_data Section_name.Map.empty in
   Emitaux.Dwarf_helpers.emit_dwarf ();
   aux others acc

--- a/backend/internal_assembler/internal_assembler.mli
+++ b/backend/internal_assembler/internal_assembler.mli
@@ -23,6 +23,6 @@
 (** Create .o file. **)
 val assemble :
   (module Compiler_owee.Unix_intf.S) ->
-  (X86_proc.Section_name.t * X86_ast.asm_line list) list ->
+  X86_ast.asm_program ref X86_proc.Section_name.Tbl.t ->
   string ->
   unit

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -48,6 +48,13 @@ module Section_name = struct
         | [hd] -> Option.value ~default:0L (Int64.of_string_opt hd)
         | hd :: tl -> align tl
       in align t.args
+
+    let isprefix s1 s2 =
+      String.length s1 <= String.length s2
+      && String.equal (String.sub s2 0 (String.length s1)) s1
+
+    let is_text_like t = isprefix ".text" t.name_str
+    let is_data_like t = isprefix ".data" t.name_str
   end
   include S
   module Map = Map.Make (S)
@@ -357,10 +364,10 @@ let generate_code asm =
   end;
   begin match !internal_assembler with
     | Some f ->
-      let instrs = Section_name.Tbl.fold (fun name instrs acc ->
+      (* let instrs = Section_name.Tbl.fold (fun name instrs acc ->
           (name, List.rev !instrs) :: acc)
           asm_code_by_section []
-      in
-      binary_content := Some (f instrs)
+      in *)
+      binary_content := Some (f asm_code_by_section)
   | None -> binary_content := None
   end

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -364,10 +364,6 @@ let generate_code asm =
   end;
   begin match !internal_assembler with
     | Some f ->
-      (* let instrs = Section_name.Tbl.fold (fun name instrs acc ->
-          (name, List.rev !instrs) :: acc)
-          asm_code_by_section []
-      in *)
       binary_content := Some (f asm_code_by_section)
   | None -> binary_content := None
   end

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -49,12 +49,8 @@ module Section_name = struct
         | hd :: tl -> align tl
       in align t.args
 
-    let isprefix s1 s2 =
-      String.length s1 <= String.length s2
-      && String.equal (String.sub s2 0 (String.length s1)) s1
-
-    let is_text_like t = isprefix ".text" t.name_str
-    let is_data_like t = isprefix ".data" t.name_str
+    let is_text_like t = String.starts_with ~prefix:".text" t.name_str
+    let is_data_like t = String.starts_with ~prefix:".data" t.name_str
   end
   include S
   module Map = Map.Make (S)

--- a/backend/x86_proc.mli
+++ b/backend/x86_proc.mli
@@ -90,7 +90,7 @@ val windows:bool
 val use_plt : bool
 
 module Section_name : sig
-  type t 
+  type t
   val equal : t -> t -> bool
   val hash : t -> int
   val compare : t -> t -> int
@@ -99,6 +99,8 @@ module Section_name : sig
   val to_string : t -> string
   val flags : t -> string option
   val alignment : t -> int64
+  val is_text_like : t -> bool
+  val is_data_like : t -> bool
 
   module Map : Map.S with type key = t
   module Tbl : Hashtbl.S with type key = t
@@ -107,7 +109,7 @@ end
 (** Support for plumbing a binary code emitter *)
 
 val internal_assembler :
-  ((Section_name.t * X86_ast.asm_program) list -> string -> unit) option ref
+  (X86_ast.asm_program ref Section_name.Tbl.t -> string -> unit) option ref
 
 val register_internal_assembler :
-  ((Section_name.t * X86_ast.asm_program) list -> string -> unit) -> unit
+  (X86_ast.asm_program ref Section_name.Tbl.t -> string -> unit) -> unit


### PR DESCRIPTION
Previously dwarf was emitted before all the debug information could be collected. The line number information requires addresses of instructions emitted by the internal assembler, which are only known after the text and data sections have been emitted.