### PR TITLE
Add `arg_label` to `Otyp_arrow`

### DIFF
--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -305,7 +305,10 @@ and print_out_type_1 mode ppf =
   function
   | Otyp_arrow (lab, am, ty1, rm, ty2) ->
       pp_open_box ppf 0;
-      if lab <> "" then (pp_print_string ppf lab; pp_print_char ppf ':');
+      (match lab with
+      | Nolabel -> ()
+      | Labelled l -> pp_print_string ppf l; pp_print_char ppf ':'
+      | Optional l -> pp_print_string ppf ("?"^l); pp_print_char ppf ':');
       print_out_arg am ppf ty1;
       pp_print_string ppf " ->";
       pp_print_space ppf ();

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -75,11 +75,16 @@ type out_global =
   | Ogf_global
   | Ogf_unrestricted
 
+type arg_label =
+  | Nolabel
+  | Labelled of string (** [label:T -> ...] *)
+  | Optional of string (*** [?label:T -> ...] *)
+
 type out_type =
   | Otyp_abstract
   | Otyp_open
   | Otyp_alias of out_type * string
-  | Otyp_arrow of string * out_alloc_mode * out_type * out_alloc_mode * out_type
+  | Otyp_arrow of arg_label * out_alloc_mode * out_type * out_alloc_mode * out_type
   | Otyp_class of bool * out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -75,6 +75,7 @@ type out_global =
   | Ogf_global
   | Ogf_unrestricted
 
+(** This definition avoids a cyclic dependency between Outcometree and Types. *)
 type arg_label =
   | Nolabel
   | Labelled of string (** [label:T -> ...] *)

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -509,9 +509,9 @@ let print_name ppf = function
   | Some name -> fprintf ppf "\"%s\"" name
 
 let string_of_label = function
-    Nolabel -> ""
-  | Labelled s -> s
-  | Optional s -> "?"^s
+    Asttypes.Nolabel -> ""
+  | Asttypes.Labelled s -> s
+  | Asttypes.Optional s -> "?"^s
 
 let visited = ref []
 let rec raw_type ppf ty =
@@ -1117,7 +1117,12 @@ let rec tree_of_typexp mode ty =
         Otyp_var (non_gen, Names.name_of_type name_gen tty)
     | Tarrow ((l, marg, mret), ty1, ty2, _) ->
         let lab =
-          if !print_labels || is_optional l then string_of_label l else ""
+          if !print_labels || is_optional l then
+            match l with
+            | Nolabel -> Nolabel
+            | Labelled l -> Labelled l
+            | Optional l -> Optional l
+          else Nolabel
         in
         let t1 =
           if is_optional l then


### PR DESCRIPTION
Rather than storing a string to represent a label in the `Outcometree` (which may contain a hard-coded "?" to represent optional arguments), store a label value.
This will be particularly helpful for printing Position arguments in the future.