### PR TITLE
Add mode to `int_as_pointer`

### DIFF
--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -709,7 +709,7 @@ let rec transl env e =
          | Pmulfloat _ | Pdivfloat _ | Pstringlength | Pstringrefu
          | Pstringrefs | Pbyteslength | Pbytesrefu | Pbytessetu
          | Pbytesrefs | Pbytessets | Pisint | Pisout
-         | Pbswap16 | Pint_as_pointer | Popaque | Pfield _
+         | Pbswap16 | Pint_as_pointer _ | Popaque | Pfield _
          | Psetfield (_, _, _) | Psetfield_computed (_, _)
          | Pfloatfield _ | Psetfloatfield (_, _) | Pduprecord (_, _)
          | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _ | Poffsetint _
@@ -976,7 +976,7 @@ and transl_prim_1 env p arg dbg =
   | Pfloatfield (n,mode) ->
       let ptr = transl env arg in
       box_float dbg mode (floatfield n ptr dbg)
-  | Pint_as_pointer ->
+  | Pint_as_pointer _ ->
       int_as_pointer (transl env arg) dbg
   (* Exceptions *)
   | Praise rkind ->
@@ -1222,7 +1222,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
                       transl_unbox_int dbg env bi arg2], dbg)) dbg
   | Pnot | Pnegint | Pintoffloat | Pfloatofint _ | Pnegfloat _
   | Pabsfloat _ | Pstringlength | Pbyteslength | Pbytessetu | Pbytessets
-  | Pisint | Pbswap16 | Pint_as_pointer | Popaque | Pread_symbol _
+  | Pisint | Pbswap16 | Pint_as_pointer _ | Popaque | Pread_symbol _
   | Pmakeblock (_, _, _, _) | Pfield _ | Psetfield_computed (_, _)
   | Pfloatfield _
   | Pduprecord (_, _) | Pccall _ | Praise _ | Poffsetint _ | Poffsetref _
@@ -1279,7 +1279,7 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
   | Pintoffloat | Pfloatofint _ | Pnegfloat _ | Pabsfloat _ | Paddfloat _ | Psubfloat _
   | Pmulfloat _ | Pdivfloat _ | Pstringlength | Pstringrefu | Pstringrefs
   | Pbyteslength | Pbytesrefu | Pbytesrefs | Pisint | Pisout
-  | Pbswap16 | Pint_as_pointer | Popaque | Pread_symbol _
+  | Pbswap16 | Pint_as_pointer _ | Popaque | Pread_symbol _
   | Pmakeblock (_, _, _, _)
   | Pfield _ | Psetfield (_, _, _) | Pfloatfield _ | Psetfloatfield (_, _)
   | Pduprecord (_, _) | Pccall _ | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -119,7 +119,7 @@ type primitive =
   | Pbswap16
   | Pbbswap of boxed_integer * alloc_mode
   (* Integer to external pointer *)
-  | Pint_as_pointer
+  | Pint_as_pointer of alloc_mode
   (* Inhibition of optimisation *)
   | Popaque
   (* Probes *)

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -122,7 +122,7 @@ type primitive =
   | Pbswap16
   | Pbbswap of boxed_integer * alloc_mode
   (* Integer to external pointer *)
-  | Pint_as_pointer
+  | Pint_as_pointer of alloc_mode
   (* Inhibition of optimisation *)
   | Popaque
   (* Probes *)

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -140,7 +140,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       Pbigstring_set (Sixty_four, convert_unsafety is_unsafe)
   | Pbigarraydim dim -> Pbigarraydim dim
   | Pbswap16 -> Pbswap16
-  | Pint_as_pointer -> Pint_as_pointer
+  | Pint_as_pointer m -> Pint_as_pointer m
   | Popaque _ -> Popaque
   | Pprobe_is_enabled {name} -> Pprobe_is_enabled {name}
   | Pobj_dup ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -753,7 +753,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
       | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
       | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _
-      | Pint_as_pointer | Popaque _ | Pprobe_is_enabled _ | Pobj_dup
+      | Pint_as_pointer _ | Popaque _ | Pprobe_is_enabled _ | Pobj_dup
       | Pobj_magic _ | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
         ->
         (* Inconsistent with outer match *)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -989,7 +989,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pbigstring_set_16 true
   | Pbigstring_set_32 true
   | Pbigstring_set_64 true
-  | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer | Popaque _
+  | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer _ | Popaque _
   | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _ | Pbox_float _ | Punbox_float
   | Punbox_int _ | Pbox_int _ ->
     false

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1102,7 +1102,9 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [bbswap Naked_int64 Naked_int64 mode arg ~current_region]
   | Pbbswap (Pnativeint, mode), [[arg]] ->
     [bbswap Naked_nativeint Naked_nativeint mode arg ~current_region]
-  | Pint_as_pointer, [[arg]] -> [Unary (Int_as_pointer, arg)]
+  | Pint_as_pointer mode, [[arg]] ->
+    let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
+    [Unary (Int_as_pointer mode, arg)]
   | Pbigarrayref (unsafe, num_dimensions, kind, layout), args -> (
     let args =
       List.map
@@ -1256,7 +1258,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Pnegfloat _ | Pabsfloat _ | Pstringlength | Pbyteslength | Pbintofint _
       | Pintofbint _ | Pnegbint _ | Popaque _ | Pduprecord _ | Parraylength _
       | Pduparray _ | Pfloatfield _ | Pcvtbint _ | Poffsetref _ | Pbswap16
-      | Pbbswap _ | Pisint _ | Pint_as_pointer | Pbigarraydim _ | Pobj_dup
+      | Pbbswap _ | Pisint _ | Pint_as_pointer _ | Pbigarraydim _ | Pobj_dup
       | Pobj_magic _ | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
         ),
       ([] | _ :: _ :: _ | [([] | _ :: _ :: _)]) ) ->

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -538,7 +538,7 @@ let unop env (op : Flambda_primitive.unary_primitive) : Fexpr.unop =
     Project_function_slot { move_from; move_to }
   | String_length string_or_bytes -> String_length string_or_bytes
   | Boolean_not -> Boolean_not
-  | Int_as_pointer | Duplicate_block _ | Duplicate_array _ | Bigarray_length _
+  | Int_as_pointer _ | Duplicate_block _ | Duplicate_array _ | Bigarray_length _
   | Float_arith _ | Reinterpret_int64_as_float | Is_boxed_float | Obj_dup ->
     Misc.fatal_errorf "TODO: Unary primitive: %a"
       Flambda_primitive.Without_args.print

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -485,7 +485,8 @@ let simplify_end_region dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
   let dacc = DA.add_variable dacc result_var ty in
   SPR.create original_term ~try_reify:false dacc
 
-let simplify_int_as_pointer dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
+let simplify_int_as_pointer ~mode:_ dacc ~original_term ~arg:_ ~arg_ty:_
+    ~result_var =
   SPR.create_unknown dacc ~result_var K.value ~original_term
 
 let simplify_bigarray_length ~dimension:_ dacc ~original_term ~arg:_ ~arg_ty:_
@@ -631,7 +632,7 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     | Reinterpret_int64_as_float -> simplify_reinterpret_int64_as_float
     | Is_boxed_float -> simplify_is_boxed_float
     | Is_flat_float_array -> simplify_is_flat_float_array
-    | Int_as_pointer _ -> simplify_int_as_pointer
+    | Int_as_pointer mode -> simplify_int_as_pointer ~mode
     | Bigarray_length { dimension } -> simplify_bigarray_length ~dimension
     | Duplicate_array { kind; source_mutability; destination_mutability } ->
       simplify_duplicate_array ~kind ~source_mutability ~destination_mutability

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -631,7 +631,7 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     | Reinterpret_int64_as_float -> simplify_reinterpret_int64_as_float
     | Is_boxed_float -> simplify_is_boxed_float
     | Is_flat_float_array -> simplify_is_flat_float_array
-    | Int_as_pointer -> simplify_int_as_pointer
+    | Int_as_pointer _ -> simplify_int_as_pointer
     | Bigarray_length { dimension } -> simplify_bigarray_length ~dimension
     | Duplicate_array { kind; source_mutability; destination_mutability } ->
       simplify_duplicate_array ~kind ~source_mutability ~destination_mutability

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -318,7 +318,7 @@ let unary_prim_size prim =
   | Array_length -> array_length_size
   | Bigarray_length _ -> 2 (* cadda + load *)
   | String_length _ -> 5
-  | Int_as_pointer -> 1
+  | Int_as_pointer _ -> 1
   | Opaque_identity _ -> 0
   | Int_arith (kind, op) -> unary_int_prim_size kind op
   | Float_arith _ -> 2

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -997,9 +997,7 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
   | String_length _ -> No_effects, No_coeffects, Strict
   | Int_as_pointer alloc_mode ->
     let coeffects : Coeffects.t =
-      match alloc_mode with
-      | Local _ -> Has_coeffects
-      | Heap -> No_coeffects
+      match alloc_mode with Local _ -> Has_coeffects | Heap -> No_coeffects
     in
     No_effects, coeffects, Strict
   | Opaque_identity _ -> Arbitrary_effects, Has_coeffects, Strict
@@ -1092,8 +1090,8 @@ let free_names_unary_primitive p =
          value_slot Name_mode.normal)
       project_from Name_mode.normal
   | Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag | String_length _
-  | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
-  | Reinterpret_int64_as_float | Float_arith _ | Array_length
+  | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _
+  | Boolean_not | Reinterpret_int64_as_float | Float_arith _ | Array_length
   | Bigarray_length _ | Unbox_number _ | Untag_immediate | Tag_immediate
   | Is_boxed_float | Is_flat_float_array | Begin_try_region | End_region
   | Obj_dup ->
@@ -1107,8 +1105,8 @@ let apply_renaming_unary_primitive p renaming =
     in
     if alloc_mode == alloc_mode' then p else Box_number (kind, alloc_mode')
   | Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag | String_length _
-  | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
-  | Reinterpret_int64_as_float | Float_arith _ | Array_length
+  | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _
+  | Boolean_not | Reinterpret_int64_as_float | Float_arith _ | Array_length
   | Bigarray_length _ | Unbox_number _ | Untag_immediate | Tag_immediate
   | Is_boxed_float | Is_flat_float_array | Begin_try_region | End_region
   | Project_function_slot _ | Project_value_slot _ | Obj_dup ->
@@ -1119,8 +1117,8 @@ let ids_for_export_unary_primitive p =
   | Box_number (_kind, alloc_mode) ->
     Alloc_mode.For_allocations.ids_for_export alloc_mode
   | Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag | String_length _
-  | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
-  | Reinterpret_int64_as_float | Float_arith _ | Array_length
+  | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _
+  | Boolean_not | Reinterpret_int64_as_float | Float_arith _ | Array_length
   | Bigarray_length _ | Unbox_number _ | Untag_immediate | Tag_immediate
   | Is_boxed_float | Is_flat_float_array | Begin_try_region | End_region
   | Project_function_slot _ | Project_value_slot _ | Obj_dup ->

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -695,7 +695,7 @@ type unary_primitive =
   | Array_length
   | Bigarray_length of { dimension : int }
   | String_length of string_or_bytes
-  | Int_as_pointer
+  | Int_as_pointer of Alloc_mode.For_allocations.t
   | Opaque_identity of
       { middle_end_only : bool;
         kind : K.t
@@ -737,7 +737,7 @@ let unary_primitive_eligible_for_cse p ~arg =
   | Array_length -> true
   | Bigarray_length _ -> false
   | String_length _ -> true
-  | Int_as_pointer -> true
+  | Int_as_pointer _ -> true
   | Opaque_identity _ -> false
   | Int_arith _ -> true
   | Float_arith _ ->
@@ -768,7 +768,7 @@ let compare_unary_primitive p1 p2 =
     | Array_length -> 4
     | Bigarray_length _ -> 5
     | String_length _ -> 6
-    | Int_as_pointer -> 7
+    | Int_as_pointer _ -> 7
     | Opaque_identity _ -> 8
     | Int_arith _ -> 9
     | Float_arith _ -> 10
@@ -858,7 +858,7 @@ let compare_unary_primitive p1 p2 =
     let c = Bool.compare middle_end_only1 middle_end_only2 in
     if c <> 0 then c else K.compare kind1 kind2
   | ( ( Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag
-      | String_length _ | Int_as_pointer | Opaque_identity _ | Int_arith _
+      | String_length _ | Int_as_pointer _ | Opaque_identity _ | Int_arith _
       | Num_conv _ | Boolean_not | Reinterpret_int64_as_float | Float_arith _
       | Array_length | Bigarray_length _ | Unbox_number _ | Box_number _
       | Untag_immediate | Tag_immediate | Project_function_slot _
@@ -883,7 +883,7 @@ let print_unary_primitive ppf p =
     if variant_only then fprintf ppf "Is_int" else fprintf ppf "Is_int_generic"
   | Get_tag -> fprintf ppf "Get_tag"
   | String_length _ -> fprintf ppf "String_length"
-  | Int_as_pointer -> fprintf ppf "Int_as_pointer"
+  | Int_as_pointer _ -> fprintf ppf "Int_as_pointer"
   | Opaque_identity { middle_end_only; kind } ->
     fprintf ppf "@[(Opaque_identity@ (middle_end_only %b) (kind %a))@]"
       middle_end_only K.print kind
@@ -924,7 +924,7 @@ let arg_kind_of_unary_primitive p =
   | Is_int _ -> K.value
   | Get_tag -> K.value
   | String_length _ -> K.value
-  | Int_as_pointer -> K.value
+  | Int_as_pointer _ -> K.value
   | Opaque_identity { middle_end_only = _; kind } -> kind
   | Int_arith (kind, _) -> K.Standard_int.to_kind kind
   | Num_conv { src; dst = _ } -> K.Standard_int_or_float.to_kind src
@@ -947,7 +947,7 @@ let result_kind_of_unary_primitive p : result_kind =
   | Duplicate_array _ | Duplicate_block _ -> Singleton K.value
   | Is_int _ | Get_tag -> Singleton K.naked_immediate
   | String_length _ -> Singleton K.naked_immediate
-  | Int_as_pointer ->
+  | Int_as_pointer _ ->
     (* This primitive is *only* to be used when the resulting pointer points at
        something which is a valid OCaml value (even if outside of the heap). *)
     Singleton K.value
@@ -995,7 +995,13 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
     (* [Obj.truncate] has now been removed. *)
     No_effects, No_coeffects, Strict
   | String_length _ -> No_effects, No_coeffects, Strict
-  | Int_as_pointer -> No_effects, No_coeffects, Strict
+  | Int_as_pointer alloc_mode ->
+    let coeffects : Coeffects.t =
+      match alloc_mode with
+      | Local _ -> Has_coeffects
+      | Heap -> No_coeffects
+    in
+    No_effects, coeffects, Strict
   | Opaque_identity _ -> Arbitrary_effects, Has_coeffects, Strict
   | Int_arith (_, (Neg | Swap_byte_endianness))
   | Num_conv _ | Boolean_not | Reinterpret_int64_as_float ->
@@ -1061,7 +1067,7 @@ let unary_classify_for_printing p =
   match p with
   | Duplicate_array _ | Duplicate_block _ | Obj_dup -> Constructive
   | String_length _ | Get_tag -> Destructive
-  | Is_int _ | Int_as_pointer | Opaque_identity _ | Int_arith _ | Num_conv _
+  | Is_int _ | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _
   | Boolean_not | Reinterpret_int64_as_float | Float_arith _ ->
     Neither
   | Array_length | Bigarray_length _ | Unbox_number _ | Untag_immediate ->
@@ -1086,7 +1092,7 @@ let free_names_unary_primitive p =
          value_slot Name_mode.normal)
       project_from Name_mode.normal
   | Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag | String_length _
-  | Int_as_pointer | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
+  | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
   | Reinterpret_int64_as_float | Float_arith _ | Array_length
   | Bigarray_length _ | Unbox_number _ | Untag_immediate | Tag_immediate
   | Is_boxed_float | Is_flat_float_array | Begin_try_region | End_region
@@ -1101,7 +1107,7 @@ let apply_renaming_unary_primitive p renaming =
     in
     if alloc_mode == alloc_mode' then p else Box_number (kind, alloc_mode')
   | Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag | String_length _
-  | Int_as_pointer | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
+  | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
   | Reinterpret_int64_as_float | Float_arith _ | Array_length
   | Bigarray_length _ | Unbox_number _ | Untag_immediate | Tag_immediate
   | Is_boxed_float | Is_flat_float_array | Begin_try_region | End_region
@@ -1113,7 +1119,7 @@ let ids_for_export_unary_primitive p =
   | Box_number (_kind, alloc_mode) ->
     Alloc_mode.For_allocations.ids_for_export alloc_mode
   | Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag | String_length _
-  | Int_as_pointer | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
+  | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
   | Reinterpret_int64_as_float | Float_arith _ | Array_length
   | Bigarray_length _ | Unbox_number _ | Untag_immediate | Tag_immediate
   | Is_boxed_float | Is_flat_float_array | Begin_try_region | End_region

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -270,7 +270,7 @@ type unary_primitive =
   (* CR mshinwell/xclerc: Invariant check: dimension >= 0 *)
   (* CR gbury: Invariant check: 0 < dimension <= 3 *)
   | String_length of string_or_bytes
-  | Int_as_pointer
+  | Int_as_pointer of Alloc_mode.For_allocations.t
   | Opaque_identity of
       { middle_end_only : bool;
         kind : Flambda_kind.t

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -544,7 +544,7 @@ let unary_primitive env res dbg f arg =
       C.load ~dbg Word_int Mutable
         ~addr:(C.field_address arg (4 + dimension) dbg) )
   | String_length _ -> None, res, C.string_length arg dbg
-  | Int_as_pointer -> None, res, C.int_as_pointer arg dbg
+  | Int_as_pointer _ -> None, res, C.int_as_pointer arg dbg
   | Opaque_identity { middle_end_only = true; kind = _ } -> None, res, arg
   | Opaque_identity { middle_end_only = false; kind = _ } ->
     None, res, C.opaque arg dbg

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -433,7 +433,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbigstring_set_64 _ -> pbigstring_set_64
   | Pbswap16 -> pbswap16
   | Pbbswap _ -> pbbswap
-  | Pint_as_pointer -> pint_as_pointer
+  | Pint_as_pointer _ -> pint_as_pointer
   | Popaque _ -> popaque
   | Pprobe_is_enabled _ -> pprobe_is_enabled
   | Pobj_dup -> pobj_dup
@@ -547,7 +547,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbigstring_set_64 _ -> pbigstring_set_64_arg
   | Pbswap16 -> pbswap16_arg
   | Pbbswap _ -> pbbswap_arg
-  | Pint_as_pointer -> pint_as_pointer_arg
+  | Pint_as_pointer _ -> pint_as_pointer_arg
   | Popaque _ -> popaque_arg
   | Pprobe_is_enabled _ -> pprobe_is_enabled_arg
   | Pobj_dup -> pobj_dup_arg

--- a/middle_end/printclambda_primitives.ml
+++ b/middle_end/printclambda_primitives.ml
@@ -251,7 +251,7 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
         (access_safety safety) (access_size size)
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi,m) -> print_boxed_integer "bswap" ppf bi m
-  | Pint_as_pointer -> fprintf ppf "int_as_pointer"
+  | Pint_as_pointer m -> fprintf ppf "int_as_pointer.%s" (alloc_kind m)
   | Popaque -> fprintf ppf "opaque"
   | Pprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled[%s]" name
   | Pbox_float m -> fprintf ppf "box_float.%s" (alloc_kind m)

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -150,7 +150,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
       Arbitrary_effects, No_coeffects
   | Pbswap16 -> No_effects, No_coeffects
   | Pbbswap (_,m) -> No_effects, coeffects_of m
-  | Pint_as_pointer -> No_effects, No_coeffects
+  | Pint_as_pointer m -> No_effects, coeffects_of m
   | Popaque -> Arbitrary_effects, Has_coeffects
   | Psequand
   | Psequor ->
@@ -276,7 +276,7 @@ let may_locally_allocate (prim:Clambda_primitives.primitive) : bool =
       false
   | Pbswap16 -> false
   | Pbbswap (_,m) -> is_local_alloc m
-  | Pint_as_pointer -> false
+  | Pint_as_pointer m -> is_local_alloc m
   | Popaque -> false
   | Psequand
   | Psequor ->

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -629,7 +629,7 @@ let rec transl env e =
          | Pmulfloat _ | Pdivfloat _ | Pstringlength | Pstringrefu
          | Pstringrefs | Pbyteslength | Pbytesrefu | Pbytessetu
          | Pbytesrefs | Pbytessets | Pisint | Pisout
-         | Pbswap16 | Pint_as_pointer | Popaque | Pfield _
+         | Pbswap16 | Pint_as_pointer _ | Popaque | Pfield _
          | Psetfield (_, _, _) | Psetfield_computed (_, _)
          | Pfloatfield _ | Psetfloatfield (_, _) | Pduprecord (_, _)
          | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _ | Poffsetint _
@@ -900,7 +900,7 @@ and transl_prim_1 env p arg dbg =
   | Pfloatfield (n,mode) ->
       let ptr = transl env arg in
       box_float dbg mode (floatfield n ptr dbg)
-  | Pint_as_pointer ->
+  | Pint_as_pointer _ ->
       int_as_pointer (transl env arg) dbg
   (* Exceptions *)
   | Praise rkind ->
@@ -1146,7 +1146,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
                       transl_unbox_int dbg env bi arg2], dbg)) dbg
   | Pnot | Pnegint | Pintoffloat | Pfloatofint _ | Pnegfloat _
   | Pabsfloat _ | Pstringlength | Pbyteslength | Pbytessetu | Pbytessets
-  | Pisint | Pbswap16 | Pint_as_pointer | Popaque | Pread_symbol _
+  | Pisint | Pbswap16 | Pint_as_pointer _ | Popaque | Pread_symbol _
   | Pmakeblock (_, _, _, _) | Pfield _ | Psetfield_computed (_, _)
   | Pfloatfield _
   | Pduprecord (_, _) | Pccall _ | Praise _ | Poffsetint _ | Poffsetref _
@@ -1203,7 +1203,7 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
   | Pintoffloat | Pfloatofint _ | Pnegfloat _ | Pabsfloat _ | Paddfloat _ | Psubfloat _
   | Pmulfloat _ | Pdivfloat _ | Pstringlength | Pstringrefu | Pstringrefs
   | Pbyteslength | Pbytesrefu | Pbytesrefs | Pisint | Pisout
-  | Pbswap16 | Pint_as_pointer | Popaque | Pread_symbol _
+  | Pbswap16 | Pint_as_pointer _ | Popaque | Pread_symbol _
   | Pmakeblock (_, _, _, _)
   | Pfield _ | Psetfield (_, _, _) | Pfloatfield _ | Psetfloatfield (_, _)
   | Pduprecord (_, _) | Pccall _ | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -137,7 +137,7 @@ let preserve_tailcall_for_prim = function
   | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
   | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
   | Pprobe_is_enabled _ | Pobj_dup
-  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer ->
+  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer _ ->
       false
 
 (* Add a Kpop N instruction in front of a continuation *)
@@ -526,7 +526,7 @@ let comp_primitive p args =
   | Pbigstring_set_64(_) -> Kccall("caml_ba_uint8_set64", 3)
   | Pbswap16 -> Kccall("caml_bswap16", 1)
   | Pbbswap(bi,_) -> comp_bint_primitive bi "bswap" args
-  | Pint_as_pointer -> Kccall("caml_int_as_pointer", 1)
+  | Pint_as_pointer _ -> Kccall("caml_int_as_pointer", 1)
   | Pbytes_to_string -> Kccall("caml_string_of_bytes", 1)
   | Pbytes_of_string -> Kccall("caml_bytes_of_string", 1)
   | Parray_to_iarray -> Kccall("caml_iarray_of_array", 1)

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -231,7 +231,7 @@ type primitive =
   | Pbswap16
   | Pbbswap of boxed_integer * alloc_mode
   (* Integer to external pointer *)
-  | Pint_as_pointer
+  | Pint_as_pointer of alloc_mode
   (* Inhibition of optimisation *)
   | Popaque of layout
   (* Statically-defined probes *)
@@ -1470,7 +1470,7 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pctconst _ -> None
   | Pbswap16 -> None
   | Pbbswap (_, m) -> Some m
-  | Pint_as_pointer -> None
+  | Pint_as_pointer m -> Some m
   | Popaque _ -> None
   | Pprobe_is_enabled _ -> None
   | Pobj_dup -> Some alloc_heap
@@ -1572,7 +1572,7 @@ let primitive_result_layout (p : primitive) =
       (* Compile-time constants only ever return ints for now,
          enumerate them all to be sure to modify this if it becomes wrong. *)
       layout_int
-  | Pint_as_pointer ->
+  | Pint_as_pointer _ ->
       (* CR ncourant: use an unboxed int64 here when it exists *)
       layout_any_value
   | (Parray_to_iarray | Parray_of_iarray) -> layout_any_value

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -182,7 +182,7 @@ type primitive =
   | Pbswap16
   | Pbbswap of boxed_integer * alloc_mode
   (* Integer to external pointer *)
-  | Pint_as_pointer
+  | Pint_as_pointer of alloc_mode
   (* Inhibition of optimisation *)
   | Popaque of layout
   (* Statically-defined probes *)

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -471,7 +471,7 @@ let primitive ppf = function
      else fprintf ppf "bigarray.array1.set64"
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi,m) -> print_boxed_integer "bswap" ppf bi m
-  | Pint_as_pointer -> fprintf ppf "int_as_pointer"
+  | Pint_as_pointer m -> fprintf ppf "int_as_pointer%s" (alloc_kind m)
   | Popaque _ -> fprintf ppf "opaque"
   | Pprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled[%s]" name
   | Pobj_dup -> fprintf ppf "obj_dup"
@@ -587,7 +587,7 @@ let name_of_primitive = function
   | Pbigstring_set_64 _ -> "Pbigstring_set_64"
   | Pbswap16 -> "Pbswap16"
   | Pbbswap _ -> "Pbbswap"
-  | Pint_as_pointer -> "Pint_as_pointer"
+  | Pint_as_pointer _ -> "Pint_as_pointer"
   | Popaque _ -> "Popaque"
   | Pprobe_is_enabled _ -> "Pprobe_is_enabled"
   | Pobj_dup -> "Pobj_dup"

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -924,7 +924,7 @@ let rec choice ctx t =
     | Pctconst _
     | Pbswap16
     | Pbbswap _
-    | Pint_as_pointer
+    | Pint_as_pointer _
       ->
         let primargs = traverse_list ctx primargs in
         Choice.lambda (Lprim (prim, primargs, loc))

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -399,7 +399,7 @@ let lookup_primitive loc poly pos p =
     | "%bswap_int32" -> Primitive ((Pbbswap(Pint32, mode)), 1)
     | "%bswap_int64" -> Primitive ((Pbbswap(Pint64, mode)), 1)
     | "%bswap_native" -> Primitive ((Pbbswap(Pnativeint, mode)), 1)
-    | "%int_as_pointer" -> Primitive (Pint_as_pointer, 1)
+    | "%int_as_pointer" -> Primitive (Pint_as_pointer mode, 1)
     | "%opaque" -> Primitive (Popaque Lambda.layout_any_value, 1)
     | "%sys_argv" -> Sys_argv
     | "%send" -> Send (pos, Lambda.layout_any_value)
@@ -982,7 +982,7 @@ let lambda_primitive_needs_event_after = function
   | Pbytessetu | Pmakearray ((Pintarray | Paddrarray | Pfloatarray), _, _)
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisout
   | Pprobe_is_enabled _
-  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque _
+  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer _ | Popaque _
   | Pobj_magic _ | Punbox_float | Punbox_int _  -> false
 
 (* Determine if a primitive should be surrounded by an "after" debug event *)

--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -119,7 +119,7 @@ type primitive =
   | Pbswap16
   | Pbbswap of boxed_integer * alloc_mode
   (* Integer to external pointer *)
-  | Pint_as_pointer
+  | Pint_as_pointer of alloc_mode
   (* Inhibition of optimisation *)
   | Popaque
   (* Probes *)

--- a/ocaml/middle_end/clambda_primitives.mli
+++ b/ocaml/middle_end/clambda_primitives.mli
@@ -122,7 +122,7 @@ type primitive =
   | Pbswap16
   | Pbbswap of boxed_integer * alloc_mode
   (* Integer to external pointer *)
-  | Pint_as_pointer
+  | Pint_as_pointer of alloc_mode
   (* Inhibition of optimisation *)
   | Popaque
   (* Probes *)

--- a/ocaml/middle_end/convert_primitives.ml
+++ b/ocaml/middle_end/convert_primitives.ml
@@ -140,7 +140,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       Pbigstring_set (Sixty_four, convert_unsafety is_unsafe)
   | Pbigarraydim dim -> Pbigarraydim dim
   | Pbswap16 -> Pbswap16
-  | Pint_as_pointer -> Pint_as_pointer
+  | Pint_as_pointer m -> Pint_as_pointer m
   | Popaque _ -> Popaque
   | Pprobe_is_enabled {name} -> Pprobe_is_enabled {name}
   | Pobj_dup ->

--- a/ocaml/middle_end/internal_variable_names.ml
+++ b/ocaml/middle_end/internal_variable_names.ml
@@ -428,7 +428,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbigstring_set_64 _ -> pbigstring_set_64
   | Pbswap16 -> pbswap16
   | Pbbswap _ -> pbbswap
-  | Pint_as_pointer -> pint_as_pointer
+  | Pint_as_pointer _ -> pint_as_pointer
   | Popaque _ -> popaque
   | Pprobe_is_enabled _ -> pprobe_is_enabled
   | Pobj_dup -> pobj_dup
@@ -542,7 +542,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbigstring_set_64 _ -> pbigstring_set_64_arg
   | Pbswap16 -> pbswap16_arg
   | Pbbswap _ -> pbbswap_arg
-  | Pint_as_pointer -> pint_as_pointer_arg
+  | Pint_as_pointer _ -> pint_as_pointer_arg
   | Popaque _ -> popaque_arg
   | Pprobe_is_enabled _ -> pprobe_is_enabled_arg
   | Pobj_dup -> pobj_dup_arg

--- a/ocaml/middle_end/printclambda_primitives.ml
+++ b/ocaml/middle_end/printclambda_primitives.ml
@@ -251,7 +251,7 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
         (access_safety safety) (access_size size)
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi,m) -> print_boxed_integer "bswap" ppf bi m
-  | Pint_as_pointer -> fprintf ppf "int_as_pointer"
+  | Pint_as_pointer m -> fprintf ppf "int_as_pointer.%s" (alloc_kind m)
   | Popaque -> fprintf ppf "opaque"
   | Pprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled[%s]" name
   | Pbox_float m -> fprintf ppf "box_float.%s" (alloc_kind m)

--- a/ocaml/middle_end/semantics_of_primitives.ml
+++ b/ocaml/middle_end/semantics_of_primitives.ml
@@ -138,7 +138,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
       Arbitrary_effects, No_coeffects
   | Pbswap16 -> No_effects, No_coeffects
   | Pbbswap (_,m) -> No_effects, coeffects_of m
-  | Pint_as_pointer -> No_effects, No_coeffects
+  | Pint_as_pointer m -> No_effects, coeffects_of m
   | Popaque -> Arbitrary_effects, Has_coeffects
   | Psequand
   | Psequor ->
@@ -264,7 +264,7 @@ let may_locally_allocate (prim:Clambda_primitives.primitive) : bool =
       false
   | Pbswap16 -> false
   | Pbbswap (_,m) -> is_local_alloc m
-  | Pint_as_pointer -> false
+  | Pint_as_pointer m -> is_local_alloc m
   | Popaque -> false
   | Psequand
   | Psequor ->

--- a/ocaml/testsuite/tests/typing-local/cstubs.c
+++ b/ocaml/testsuite/tests/typing-local/cstubs.c
@@ -5,6 +5,6 @@
 value make_dumb_external_block(value unit)
 {
     value *p = caml_stat_alloc(sizeof(value));
-    *p = Make_header(0, 0, Caml_black);
+    *p = Caml_out_of_heap_header(0, 0);
     return Val_int(((intnat)p) + 1);
 }

--- a/ocaml/testsuite/tests/typing-local/cstubs.c
+++ b/ocaml/testsuite/tests/typing-local/cstubs.c
@@ -1,0 +1,10 @@
+#include "caml/mlvalues.h"
+#include "caml/gc.h"
+#include "caml/memory.h"
+
+value make_dumb_external_block(value unit)
+{
+    value *p = caml_stat_alloc(sizeof(value));
+    *p = Make_header(0, 0, Caml_black);
+    return Val_int(((intnat)p) + 1);
+}

--- a/ocaml/testsuite/tests/typing-local/regions.reference
+++ b/ocaml/testsuite/tests/typing-local/regions.reference
@@ -1,5 +1,5 @@
                   startup: OK
-  int_as_pointer (global): 16 bytes leaked
+  int_as_pointer (global): OK
    int_as_pointer (local): OK
             function call: OK
      cleanup upon exclave: OK

--- a/ocaml/testsuite/tests/typing-local/regions.reference
+++ b/ocaml/testsuite/tests/typing-local/regions.reference
@@ -1,4 +1,6 @@
                   startup: OK
+  int_as_pointer (global): 16 bytes leaked
+   int_as_pointer (local): OK
             function call: OK
      cleanup upon exclave: OK
         exn function call: OK


### PR DESCRIPTION
This PR adds a mode parameter to the `int_as_pointer` primitive, so that when you write:
```
external follow : int -> ('a [@local_opt]) = "%int_as_pointer"
```
that parameter will reflect the mode of `'a`.  If the mode is `local`, `follow` is understood to be allocating in the current region, and the current region must be preserved by optimizations. This PR changes the behaviours around `int_as_pointer` to reflect that. The behaviours of `int_as_pointer` itself is not changed. 

Request review from @mshinwell or @lpw25 