### PR TITLE
Further refine our debugging infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ _coverage/
 
 # Debugger support
 ocamlc
+ocamlopt
+.ocamldebug

--- a/.ocamldebug
+++ b/.ocamldebug
@@ -1,1 +1,0 @@
-source ocaml/tools/debug_printers

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ coverage: boot-runtest
 
 .PHONY: debug
 .NOTPARALLEL: debug
-debug: install ocaml/tools/debug_printers ocamlc ocamlopt
+debug: install debug-printers ocamlc ocamlopt .ocamldebug
 
 ocamlc:
 	ln -s $(prefix)/bin/ocamlc.byte ocamlc
@@ -171,9 +171,6 @@ ocamlc:
 ocamlopt:
 	ln  -s $(prefix)/bin/ocamlopt.byte ocamlopt
 
-ocaml/tools/debug_printers: ocaml/tools/debug_printers.ml ocaml/tools/debug_printers.cmo
-	echo 'load_printer "ocaml/tools/debug_printers.cmo"' > $@
-	awk '{ print "install_printer Debug_printers." $$2 }' < $< >> $@
-
-ocaml/tools/debug_printers.cmo: ocaml/tools/debug_printers.ml _build/install/main/bin/ocamlc.byte
-	_build/install/main/bin/ocamlc.byte -c -I _build/main/ocaml/.ocamlcommon.objs/byte ocaml/tools/debug_printers.ml
+.ocamldebug: install
+	find _build/main -name '*.cmo' -type f -printf 'directory %h\n' | sort -u > .ocamldebug
+	echo "source ocaml/tools/debug_printers" >> .ocamldebug

--- a/ocaml/tools/dune
+++ b/ocaml/tools/dune
@@ -91,4 +91,16 @@
   (libraries ocamlcommon)
   (modules debug_printers))
 
+(rule
+  (target debug_printers)
+  (deps debug_printers.ml %{cmo:debug_printers})
+  (action
+    (with-stdout-to %{target}
+      (progn
+        ; Resorting to Bash instead of the built-in [echo] action because I
+        ; couldn't find a better way to get an absolute path out of Dune
+        (bash "echo load_printer \\\"$(realpath %{cmo:debug_printers})\\\"")
+        (with-stdin-from debug_printers.ml
+          (run awk "{ print \"install_printer Debug_printers.\" $2 }"))))))
+
 ; ocamlcp, ocamloptp and ocamlprof are not currently supported.


### PR DESCRIPTION
This puts the build-path mangling inside of .ocamldebug for easier use outside of emacs. It also restores the dune-based approach to generating debug_printers, as requested by Luke.