### PR TITLE
Insert Iname_for_debugger operations in Selectgen

### DIFF
--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -250,7 +250,7 @@ method class_of_operation op =
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue -> Op_pure
   | Ispecific _ -> Op_other
-  | Iname_for_debugger _ -> Op_pure
+  | Iname_for_debugger _ -> Op_other
   | Iprobe_is_enabled _ -> Op_other
   | Ibeginregion | Iendregion -> Op_other
 

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -479,7 +479,7 @@ let is_pure_operation : operation -> bool = function
   | Specific s ->
     assert (not (Arch.operation_can_raise s));
     Arch.operation_is_pure s
-  | Name_for_debugger _ -> true
+  | Name_for_debugger _ -> false
 
 let is_pure_basic : basic -> bool = function
   | Op op -> is_pure_operation op

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -255,18 +255,23 @@ let check_operation : location -> Cfg.operation -> Cfg.operation -> unit =
         { ident = left_ident;
           which_parameter = left_which_parameter;
           provenance = left_provenance;
-          is_assignment = left_is_assignment
+          is_assignment = left_is_assignment;
+          regs = left_regs
         },
       Name_for_debugger
         { ident = right_ident;
           which_parameter = right_which_parameter;
           provenance = right_provenance;
-          is_assignment = right_is_assignment
+          is_assignment = right_is_assignment;
+          regs = right_regs
         } )
     when Ident.same left_ident right_ident
          && Option.equal Int.equal left_which_parameter right_which_parameter
-         && Option.equal Unit.equal left_provenance right_provenance
-         && Bool.equal left_is_assignment right_is_assignment ->
+         && Option.equal Backend_var.Provenance.equal left_provenance
+              right_provenance
+         && Bool.equal left_is_assignment right_is_assignment
+         && List.equal Reg.same (Array.to_list left_regs)
+              (Array.to_list right_regs) ->
     ()
   | _ -> different location "operation"
  [@@ocaml.warning "-4"]

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -93,8 +93,9 @@ module S = struct
     | Name_for_debugger of
         { ident : Ident.t;
           which_parameter : int option;
-          provenance : unit option;
-          is_assignment : bool
+          provenance : Backend_var.Provenance.t option;
+          is_assignment : bool;
+          regs : Reg.t array
         }
 
   type bool_test =

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -39,8 +39,9 @@ let from_basic (basic : basic) : Linear.instruction_desc =
       | Specific op -> Ispecific op
       | Begin_region -> Ibeginregion
       | End_region -> Iendregion
-      | Name_for_debugger { ident; which_parameter; provenance; is_assignment }
-        ->
-        Iname_for_debugger { ident; which_parameter; provenance; is_assignment }
+      | Name_for_debugger
+          { ident; which_parameter; provenance; is_assignment; regs } ->
+        Iname_for_debugger
+          { ident; which_parameter; provenance; is_assignment; regs }
     in
     Lop op

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -772,7 +772,7 @@ let fundecl :
     State.make ~fun_name ~tailrec_label ~contains_calls:fun_contains_calls
       cfg.blocks
   in
-  (* XXX run [add_blocks] here but only for Iname_for_debugger instructions *)
+  (* CR run [add_blocks] here but only for Iname_for_debugger instructions *)
   State.add_block state ~label:(Cfg.entry_label cfg)
     ~block:
       { start = Cfg.entry_label cfg;

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -212,10 +212,12 @@ let basic_or_terminator_of_operation :
         (fun label_after -> Specific_can_raise { op; label_after })
     else Basic (Op (Specific op))
   | Iopaque -> Basic (Op Opaque)
-  | Iname_for_debugger _ ->
-    Misc.fatal_error
-      "Cfgize.basic_or_terminator_of_operation: \"the Iname_for_debugger\" \
-       instruction is currently not supported "
+  | Iname_for_debugger
+      { ident; which_parameter; provenance; is_assignment; regs } ->
+    Basic
+      (Op
+         (Name_for_debugger
+            { ident; which_parameter; provenance; is_assignment; regs }))
   | Iprobe { name; handler_code_sym; enabled_at_init } ->
     With_next_label
       (fun label_after ->
@@ -770,6 +772,7 @@ let fundecl :
     State.make ~fun_name ~tailrec_label ~contains_calls:fun_contains_calls
       cfg.blocks
   in
+  (* XXX run [add_blocks] here but only for Iname_for_debugger instructions *)
   State.add_block state ~label:(Cfg.entry_label cfg)
     ~block:
       { start = Cfg.entry_label cfg;
@@ -778,8 +781,7 @@ let fundecl :
           | false -> DLL.make_empty ()
           | true ->
             (* Note: the prologue must come after all `Iname_for_debugger`
-               instructions (this is currently not a concern because we do not
-               support such instructions). *)
+               instructions *)
             let instr = make_instruction state ~desc:Cfg.Prologue in
             instr.dbg <- fun_body.dbg;
             instr.fdo <- Fdo_info.none;

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -629,10 +629,11 @@ let rec create_blocks (t : t) (i : L.instruction) (block : C.basic_block)
     | Iopaque -> basic Opaque
     | Ibeginregion -> basic Begin_region
     | Iendregion -> basic End_region
-    | Iname_for_debugger { ident; which_parameter; provenance; is_assignment }
-      ->
+    | Iname_for_debugger
+        { ident; which_parameter; provenance; is_assignment; regs } ->
       basic
-        (Name_for_debugger { ident; which_parameter; provenance; is_assignment })
+        (Name_for_debugger
+           { ident; which_parameter; provenance; is_assignment; regs })
     | Ispecific op ->
       if Arch.operation_can_raise op
       then

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -941,11 +941,11 @@ end = struct
     | Iintop
         ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor | Ilsl
         | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ )
-    | Icsel _ | Iname_for_debugger _ ->
+    | Icsel _ ->
       assert (Mach.operation_is_pure op);
       assert (not (Mach.operation_can_raise op));
       next
-    | Ivalueofint | Iintofvalue ->
+    | Iname_for_debugger _ | Ivalueofint | Iintofvalue ->
       assert (not (Mach.operation_can_raise op));
       next
     | Istackoffset _ | Iprobe_is_enabled _ | Iopaque | Ibeginregion | Iendregion

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -129,7 +129,7 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         Some (ok Reg_with_debug_info.Set.empty), unreachable
       | Iop
           (Iname_for_debugger
-            { ident; which_parameter; provenance; is_assignment }) ->
+            { ident; which_parameter; provenance; is_assignment; regs }) ->
         (* First forget about any existing debug info to do with [ident] if the
            naming corresponds to an assignment operation. *)
         let forgetting_ident =
@@ -147,11 +147,11 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
               avail_before
         in
         let avail_after = ref forgetting_ident in
-        let num_parts_of_value = Array.length instr.arg in
+        let num_parts_of_value = Array.length regs in
         (* Add debug info about [ident], but only for registers that are known
            to be available. *)
         for part_of_value = 0 to num_parts_of_value - 1 do
-          let reg = instr.arg.(part_of_value) in
+          let reg = regs.(part_of_value) in
           if RD.Set.mem_reg forgetting_ident reg
           then
             let regd =

--- a/backend/debug/reg_with_debug_info.ml
+++ b/backend/debug/reg_with_debug_info.ml
@@ -22,7 +22,7 @@ module Debug_info = struct
       part_of_value : int;
       num_parts_of_value : int;
       which_parameter : int option;
-      provenance : unit option
+      provenance : Backend_var.Provenance.t option
     }
 
   let compare t1 t2 =

--- a/backend/debug/reg_with_debug_info.mli
+++ b/backend/debug/reg_with_debug_info.mli
@@ -31,7 +31,7 @@ module Debug_info : sig
       the zero-based index of said parameter; otherwise it is [None]. *)
   val which_parameter : t -> int option
 
-  val provenance : t -> unit option
+  val provenance : t -> Backend_var.Provenance.t option
 end
 
 type t
@@ -44,7 +44,7 @@ val create :
   part_of_value:int ->
   num_parts_of_value:int ->
   which_parameter:int option ->
-  provenance:unit option ->
+  provenance:Backend_var.Provenance.t option ->
   t
 
 val create_with_debug_info : reg:Reg.t -> debug_info:Debug_info.t option -> t

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -79,7 +79,8 @@ type operation =
   | Ispecific of Arch.specific_operation
   | Ipoll of { return_label: Cmm.label option }
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
-      provenance : unit option; is_assignment : bool; }
+      provenance : Backend_var.Provenance.t option; is_assignment : bool;
+      regs : Reg.t array }
   | Iprobe of { name: string; handler_code_sym: string; enabled_at_init: bool; }
   | Iprobe_is_enabled of { name: string }
   | Ibeginregion | Iendregion
@@ -208,8 +209,8 @@ let operation_is_pure = function
   | Icsel _
   | Ifloatofint | Iintoffloat
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _ | Iconst_vec128 _
-  | Iload (_, _, _) | Iname_for_debugger _
-    -> true
+  | Iload (_, _, _) -> true
+  | Iname_for_debugger _ -> false
 
 
 let operation_can_raise op =

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -83,7 +83,8 @@ type operation =
   | Ispecific of Arch.specific_operation
   | Ipoll of { return_label: Cmm.label option }
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
-      provenance : unit option; is_assignment : bool; }
+      provenance : Backend_var.Provenance.t option; is_assignment : bool;
+      regs : Reg.t array }
     (** [Iname_for_debugger] has the following semantics:
         (a) The argument register(s) is/are deemed to contain the value of the
             given identifier.

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -226,13 +226,13 @@ let operation' ?(print_reg = reg) op arg ppf res =
   | Ivalueofint -> fprintf ppf "valueofint %a" reg arg.(0)
   | Iintofvalue -> fprintf ppf "intofvalue %a" reg arg.(0)
   | Iopaque -> fprintf ppf "opaque %a" reg arg.(0)
-  | Iname_for_debugger { ident; which_parameter; } ->
-    fprintf ppf "name_for_debugger %a%s=%a"
+  | Iname_for_debugger { ident; which_parameter; regs = r } ->
+    fprintf ppf "%a holds the value of %a%s"
+      regs r
       V.print ident
       (match which_parameter with
         | None -> ""
         | Some index -> sprintf "[P%d]" index)
-      reg arg.(0)
   | Ibeginregion -> fprintf ppf "beginregion"
   | Iendregion -> fprintf ppf "endregion %a" reg arg.(0)
   | Ispecific op ->

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -99,6 +99,8 @@ let apply_substitutions : Cfg_with_infos.t -> Substitution.map -> unit =
   Substitution.apply_cfg_in_place substs (Cfg_with_infos.cfg cfg_with_infos)
 
 (* Inserts spills at the end of blocks, before destruction points. *)
+(* CR mshinwell: Add special handling for [Iname_for_debugger] (see
+   [Spill.add_spills]). *)
 let insert_spills :
     State.t -> Cfg_with_infos.t -> Substitution.map -> Substitution.t =
  fun state cfg_with_infos substs ->

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -316,6 +316,7 @@ module Substitution = struct
   let apply_set : t -> Reg.Set.t -> Reg.Set.t =
    fun subst set -> Reg.Set.map (fun reg -> apply_reg subst reg) set
 
+  (* CR mshinwell: Apply substitution to [Iname_for_debugger] registers. *)
   let apply_instruction_in_place : t -> _ Cfg.instruction -> unit =
    fun subst instr ->
     apply_array_in_place subst instr.arg;

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -483,7 +483,10 @@ end = struct
           id old_successor_id successor_id;
       (* CR-someday azewierzejew: Avoid using polymrphic compare. *)
       (match instr.desc, old_instr.desc with
-      | Op (Name_for_debugger _), Op (Name_for_debugger _) -> ()
+      | Op (Name_for_debugger _), Op (Name_for_debugger _) ->
+        (* IRC uses `Reg.interf` to represent the adjacency lists for the
+           interference graph, which can lead to cycles. *)
+        ()
       | _ ->
         if instr.desc <> old_instr.desc
         then

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -482,8 +482,12 @@ end = struct
            allocation): %d."
           id old_successor_id successor_id;
       (* CR-someday azewierzejew: Avoid using polymrphic compare. *)
-      if instr.desc <> old_instr.desc
-      then Regalloc_utils.fatal "The desc of instruction with id %d changed" id;
+      (match instr.desc, old_instr.desc with
+      | Op (Name_for_debugger _), Op (Name_for_debugger _) -> ()
+      | _ ->
+        if instr.desc <> old_instr.desc
+        then
+          Regalloc_utils.fatal "The desc of instruction with id %d changed" id);
       verify_reg_arrays ~id instr old_instr;
       (* Return new successor id which is the id of the current instruction. *)
       id

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -101,7 +101,7 @@ let env_find id env =
   regs
 
 let env_find_mut id env =
-  let regs, _provenance, mut = V.Map.find id env.vars in
+  let regs, provenance, mut = V.Map.find id env.vars in
   begin match mut with
   | Asttypes.Mutable -> ()
   | Asttypes.Immutable ->
@@ -109,7 +109,10 @@ let env_find_mut id env =
       "Selectgen.env_find_mut: %a is not mutable"
       V.print id
   end;
-  regs
+  regs, provenance
+
+let env_find_with_provenance id env =
+  V.Map.find id env.vars
 
 let env_find_static_exception id env =
   Int.Map.find id env.static_exceptions
@@ -303,10 +306,28 @@ let name_regs id rv =
       rv.(i).part <- Some i
     done
 
+let maybe_emit_naming_op env ~bound_name seq regs =
+  match bound_name with
+  | None -> ()
+  | Some bound_name ->
+    let provenance = VP.provenance bound_name in
+    let bound_name = VP.var bound_name in
+    let naming_op =
+      Iname_for_debugger {
+        ident = bound_name;
+        provenance;
+        which_parameter = None;
+        is_assignment = false;
+        regs = regs;
+      }
+    in
+    seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+
 (* "Join" two instruction sequences, making sure they return their results
    in the same registers. *)
 
-let join env opt_r1 seq1 opt_r2 seq2 =
+let join env opt_r1 seq1 opt_r2 seq2 ~bound_name =
+  let maybe_emit_naming_op = maybe_emit_naming_op env ~bound_name in
   match (opt_r1, opt_r2) with
     (None, _) -> opt_r2
   | (_, None) -> opt_r1
@@ -319,17 +340,21 @@ let join env opt_r1 seq1 opt_r2 seq2 =
           && Cmm.ge_component r1.(i).typ r2.(i).typ
         then begin
           r.(i) <- r1.(i);
-          seq2#insert_move env r2.(i) r1.(i)
+          seq2#insert_move env r2.(i) r1.(i);
+          maybe_emit_naming_op seq2 [| r1.(i) |]
         end else if Reg.anonymous r2.(i)
           && Cmm.ge_component r2.(i).typ r1.(i).typ
         then begin
           r.(i) <- r2.(i);
-          seq1#insert_move env r1.(i) r2.(i)
+          seq1#insert_move env r1.(i) r2.(i);
+          maybe_emit_naming_op seq1 [| r2.(i) |]
         end else begin
           let typ = Cmm.lub_component r1.(i).typ r2.(i).typ in
           r.(i) <- Reg.create typ;
           seq1#insert_move env r1.(i) r.(i);
-          seq2#insert_move env r2.(i) r.(i)
+          maybe_emit_naming_op seq1 [| r.(i) |];
+          seq2#insert_move env r2.(i) r.(i);
+          maybe_emit_naming_op seq2 [| r.(i) |]
         end
       done;
       let suffix = Region_stack.common_suffix uncl1 uncl2 in
@@ -339,7 +364,8 @@ let join env opt_r1 seq1 opt_r2 seq2 =
 
 (* Same, for N branches *)
 
-let join_array env rs =
+let join_array env rs ~bound_name =
+  let maybe_emit_naming_op = maybe_emit_naming_op env ~bound_name in
   let some_res = ref None in
   for i = 0 to Array.length rs - 1 do
     let (r, _) = rs.(i) in
@@ -369,6 +395,7 @@ let join_array env rs =
           None -> ()
         | Some (r, uncl) ->
            s#insert_moves env r res;
+           maybe_emit_naming_op s res;
            s#insert_endregions_until env ~suffix:regions uncl;
       done;
       Some (res, regions)
@@ -827,11 +854,15 @@ method insert_endregions_until env ~suffix regions =
 (* Emit an expression, which is assumed not to end any regions early.
    (This holds for any expression not in tail position of Cregion)
 
+   [bound_name] is the name that will be bound to the result of evaluating
+   the expression, if such exists.  This is used for emitting debugging
+   info.
+
    Returns:
      - [None] if the expression does not finish normally (e.g. raises)
      - [Some rs] if the expression yields a result in registers [rs] *)
-method emit_expr (env:environment) exp =
-  match self#emit_expr_aux env exp with
+method emit_expr (env:environment) exp ~bound_name =
+  match self#emit_expr_aux env exp ~bound_name with
   | None -> None
   | Some (res, unclosed) ->
      assert (Region_stack.equal unclosed env.regions);
@@ -843,7 +874,7 @@ method emit_expr (env:environment) exp =
     - [None] if the expression does not finish normally (e.g. raises)
     - [Some (rs, unclosed)] if the expression yields a result in [rs],
       having left [unclosed] (a suffix of env.regions) regions open *)
-method emit_expr_aux (env:environment) exp :
+method emit_expr_aux (env:environment) exp ~bound_name :
   (Reg.t array * Region_stack.t) option =
   (* Normal case of returning a value: no regions are closed *)
   let ret res = Some (res, env.regions) in
@@ -877,26 +908,37 @@ method emit_expr_aux (env:environment) exp :
         Misc.fatal_error("Selection.emit_expr: unbound var " ^ V.unique_name v)
       end
   | Clet(v, e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env e1 ~bound_name:(Some v) with
         None -> None
-      | Some r1 -> self#emit_expr_aux (self#bind_let env v r1) e2
+      | Some r1 -> self#emit_expr_aux (self#bind_let env v r1) e2 ~bound_name
       end
   | Clet_mut(v, k, e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env e1 ~bound_name:(Some v) with
         None -> None
-      | Some r1 -> self#emit_expr_aux (self#bind_let_mut env v k r1) e2
+      | Some r1 ->
+          self#emit_expr_aux (self#bind_let_mut env v k r1) e2 ~bound_name
       end
   | Cphantom_let (_var, _defining_expr, body) ->
-      self#emit_expr_aux env body
+      self#emit_expr_aux env body ~bound_name
   | Cassign(v, e1) ->
-      let rv =
+      let rv, provenance =
         try
           env_find_mut v env
         with Not_found ->
           Misc.fatal_error ("Selection.emit_expr: unbound var " ^ V.name v) in
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env e1 ~bound_name:None with
         None -> None
       | Some r1 ->
+          let naming_op =
+            Iname_for_debugger {
+              ident = v;
+              provenance;
+              which_parameter = None;
+              is_assignment = true;
+              regs = r1;
+            }
+          in
+          self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |];
           self#insert_moves env r1 rv; ret [||]
       end
   | Ctuple [] ->
@@ -908,7 +950,7 @@ method emit_expr_aux (env:environment) exp :
           ret (self#emit_tuple ext_env simple_list)
       end
   | Cop(Craise k, [arg], dbg) ->
-      begin match self#emit_expr env arg with
+      begin match self#emit_expr env arg ~bound_name:None with
         None -> None
       | Some r1 ->
           let rd = [|Proc.loc_exn_bucket|] in
@@ -928,6 +970,23 @@ method emit_expr_aux (env:environment) exp :
       begin match self#emit_parts_list env args with
         None -> None
       | Some(simple_args, env) ->
+          let add_naming_op_for_bound_name regs =
+            match bound_name with
+            | None -> ()
+            | Some bound_name ->
+              let provenance = VP.provenance bound_name in
+              let bound_name = VP.var bound_name in
+              let naming_op =
+                Iname_for_debugger {
+                  ident = bound_name;
+                  provenance;
+                  which_parameter = None;
+                  is_assignment = false;
+                  regs = regs;
+                }
+              in
+              self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+          in
           let ty = oper_result_type op in
           let unclosed_regions =
             match op with
@@ -947,6 +1006,11 @@ method emit_expr_aux (env:environment) exp :
               self#insert_move_args env rarg loc_arg stack_ofs;
               self#insert_debug env (Iop new_op) dbg
                           (Array.append [|r1.(0)|] loc_arg) loc_res;
+              (* The destination registers (as per the procedure calling
+                 convention) need to be named right now, otherwise the result
+                 of the function call may be unavailable in the debugger
+                 immediately after the call.  *)
+              add_naming_op_for_bound_name loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
               Some (rd, unclosed_regions)
@@ -959,6 +1023,7 @@ method emit_expr_aux (env:environment) exp :
               let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
               self#insert_move_args env r1 loc_arg stack_ofs;
               self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
+              add_naming_op_for_bound_name loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
               Some (rd, unclosed_regions)
@@ -969,6 +1034,7 @@ method emit_expr_aux (env:environment) exp :
               let loc_res =
                 self#insert_op_debug env new_op dbg
                   loc_arg (Proc.loc_external_results (Reg.typv rd)) in
+              add_naming_op_for_bound_name loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
               assert (Region_stack.equal unclosed_regions env.regions);
@@ -984,6 +1050,7 @@ method emit_expr_aux (env:environment) exp :
                          mode }
               in
               self#insert_debug env (Iop op) dbg [||] rd;
+              add_naming_op_for_bound_name rd;
               self#emit_stores env new_args rd;
               set_traps_for_raise env;
               assert (Region_stack.equal unclosed_regions env.regions);
@@ -999,40 +1066,47 @@ method emit_expr_aux (env:environment) exp :
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
               assert (Region_stack.equal unclosed_regions env.regions);
+              add_naming_op_for_bound_name rd;
               ret (self#insert_op_debug env op dbg r1 rd)
       end
   | Csequence(e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env e1 ~bound_name:None with
         None -> None
-      | Some _ -> self#emit_expr_aux env e2
+      | Some _ -> self#emit_expr_aux env e2 ~bound_name
       end
   | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, _dbg, _kind) ->
       let (cond, earg) = self#select_condition econd in
-      begin match self#emit_expr env earg with
+      begin match self#emit_expr env earg ~bound_name:None with
         None -> None
       | Some rarg ->
-          let (rif, (sif : 'self)) = self#emit_sequence env eif in
-          let (relse, (selse : 'self)) = self#emit_sequence env eelse in
-          let r = join env rif sif relse selse in
+          let (rif, (sif : 'self)) =
+            self#emit_sequence env eif ~bound_name
+          in
+          let (relse, (selse : 'self)) =
+            self#emit_sequence env eelse ~bound_name
+          in
+          let r = join env rif sif relse selse ~bound_name in
           self#insert env (Iifthenelse(cond, sif#extract, selse#extract))
                       rarg [||];
           r
       end
   | Cswitch(esel, index, ecases, _dbg, _kind) ->
-      begin match self#emit_expr env esel with
+      begin match self#emit_expr env esel ~bound_name:None with
         None -> None
       | Some rsel ->
           let rscases =
-            Array.map (fun (case, _dbg) -> self#emit_sequence env case) ecases
+            Array.map (fun (case, _dbg) ->
+                self#emit_sequence env case ~bound_name)
+              ecases
           in
-          let r = join_array env rscases in
+          let r = join_array env rscases ~bound_name in
           self#insert env (Iswitch(index,
                                    Array.map (fun (_, s) -> s#extract) rscases))
                       rsel [||];
           r
       end
   | Ccatch(_, [], e1, _) ->
-      self#emit_expr_aux env e1
+      self#emit_expr_aux env e1 ~bound_name
   | Ccatch(rec_flag, handlers, body, _) ->
       let handlers =
         List.map (fun (nfail, ids, e2, dbg) ->
@@ -1053,7 +1127,7 @@ method emit_expr_aux (env:environment) exp :
             env, Int.Map.add nfail (r, (ids, rs, e2, dbg)) map)
           (env, Int.Map.empty) handlers
       in
-      let (r_body, s_body) = self#emit_sequence env body in
+      let (r_body, s_body) = self#emit_sequence env body ~bound_name in
       let translate_one_handler nfail (traps_info, (ids, rs, e2, _dbg)) =
         assert(List.length ids = List.length rs);
         let trap_stack =
@@ -1061,11 +1135,28 @@ method emit_expr_aux (env:environment) exp :
           | Unreachable -> assert false
           | Reachable t -> t
         in
+      let ids_and_rs = List.combine ids rs in
         let new_env =
           List.fold_left (fun env ((id, _typ), r) -> env_add id r env)
-            (env_set_trap_stack env trap_stack) (List.combine ids rs)
+            (env_set_trap_stack env trap_stack) ids_and_rs
         in
-        let (r, s) = self#emit_sequence new_env e2 in
+        let (r, s) =
+          self#emit_sequence new_env e2 ~bound_name:None ~at_start:(fun seq ->
+            List.iter (fun ((var, _typ), r) ->
+                let provenance = VP.provenance var in
+                let var = VP.var var in
+                let naming_op =
+                  Iname_for_debugger {
+                    ident = var;
+                    provenance;
+                    which_parameter = None;
+                    is_assignment = false;
+                    regs = r;
+                  }
+                in
+                seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |])
+              ids_and_rs)
+        in
         ((nfail, trap_stack), (r, s))
       in
       let rec build_all_reachable_handlers ~already_built ~not_built =
@@ -1088,7 +1179,7 @@ method emit_expr_aux (env:environment) exp :
         (* Note: we're dropping unreachable handlers here *)
       in
       let a = Array.of_list ((r_body, s_body) :: List.map snd l) in
-      let r = join_array env a in
+      let r = join_array env a ~bound_name in
       let aux ((nfail, ts), (_r, s)) = (nfail, ts, s#extract) in
       let final_trap_stack =
         match r_body with
@@ -1160,11 +1251,26 @@ method emit_expr_aux (env:environment) exp :
           fun handler_instruction -> handler_instruction
       in
       let env_body = env_enter_trywith env kind in
-      let (r1, s1) = self#emit_sequence env_body e1 in
+      let (r1, s1) = self#emit_sequence env_body e1 ~bound_name in
       let rv = self#regs_for typ_val in
       let with_handler env_handler e2 =
-        let (r2, s2) = self#emit_sequence env_handler e2 in
-        let r = join env r1 s1 r2 s2 in
+        let (r2, s2) =
+          self#emit_sequence env_handler e2 ~bound_name
+            ~at_start:(fun seq ->
+              let provenance = VP.provenance v in
+              let var = VP.var v in
+              let naming_op =
+                Iname_for_debugger {
+                  ident = var;
+                  provenance;
+                  which_parameter = None;
+                  is_assignment = false;
+                  regs = rv;
+                }
+              in
+              seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |])
+        in
+        let r = join env r1 s1 r2 s2 ~bound_name in
         self#insert env
           (Itrywith(s1#extract, kind,
                     (env_handler.trap_stack,
@@ -1199,7 +1305,7 @@ method emit_expr_aux (env:environment) exp :
      let reg = self#regs_for typ_int in
      self#insert env (Iop Ibeginregion) [| |] reg;
      let env = { env with regions = reg :: old_regions } in
-     begin match self#emit_expr_aux env e with
+     begin match self#emit_expr_aux env e ~bound_name with
      | None -> None
      | Some (rd, reg' :: unclosed) when reg == reg' ->
         (* Compiling e closed no regions *)
@@ -1216,29 +1322,57 @@ method emit_expr_aux (env:environment) exp :
      | [] -> Misc.fatal_error "Selectgen.emit_expr: Ctail but not in tail of a region"
      | cl :: rest ->
        self#insert_endregions env [cl];
-       self#emit_expr_aux { env with regions = rest } e
+       self#emit_expr_aux { env with regions = rest } e ~bound_name
      end
 
-method private emit_sequence (env:environment) exp : _ * 'self=
+method private emit_sequence ?at_start (env:environment) exp ~bound_name
+    : _ * 'self =
   let s : 'self = {< instr_seq = dummy_instr >} in
-  let r = s#emit_expr_aux env exp in
+  begin match at_start with
+  | None -> ()
+  | Some f -> f s
+  end;
+  let r = s#emit_expr_aux env exp ~bound_name in
   (r, s)
 
 method private bind_let (env:environment) v r1 =
-  if all_regs_anonymous r1 then begin
-    name_regs v r1;
-    env_add v r1 env
-  end else begin
-    let rv = Reg.createv_like r1 in
-    name_regs v rv;
-    self#insert_moves env r1 rv;
-    env_add v rv env
-  end
+  let env =
+    if all_regs_anonymous r1 then begin
+      name_regs v r1;
+      env_add v r1 env
+    end else begin
+      let rv = Reg.createv_like r1 in
+      name_regs v rv;
+      self#insert_moves env r1 rv;
+      env_add v rv env
+    end
+  in
+  let naming_op =
+    Iname_for_debugger {
+      ident = VP.var v;
+      which_parameter = None;
+      provenance = VP.provenance v;
+      is_assignment = false;
+      regs = r1;
+    }
+  in
+  self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |];
+  env
 
 method private bind_let_mut (env:environment) v k r1 =
   let rv = self#regs_for k in
   name_regs v rv;
   self#insert_moves env r1 rv;
+  let naming_op =
+    Iname_for_debugger {
+      ident = VP.var v;
+      which_parameter = None;
+      provenance = VP.provenance v;
+      is_assignment = false;
+      regs = r1;
+    }
+  in
+  self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |];
   env_add ~mut:Mutable v rv env
 
 (* The following two functions, [emit_parts] and [emit_parts_list], force
@@ -1288,7 +1422,7 @@ method private emit_parts (env:environment) ~effects_after exp =
   if may_defer_evaluation && self#is_simple_expr exp then
     Some (exp, env)
   else begin
-    match self#emit_expr env exp with
+    match self#emit_expr env exp ~bound_name:None with
       None -> None
     | Some r ->
         if Array.length r = 0 then
@@ -1336,7 +1470,7 @@ method private emit_tuple_not_flattened env exp_list =
   | exp :: rem ->
       (* Again, force right-to-left evaluation *)
       let loc_rem = emit_list rem in
-      match self#emit_expr env exp with
+      match self#emit_expr env exp ~bound_name:None with
         None -> assert false  (* should have been caught in emit_parts *)
       | Some loc_exp -> loc_exp :: loc_rem
   in
@@ -1372,7 +1506,7 @@ method emit_stores env data regs_addr =
   List.iter
     (fun e ->
       let (op, arg) = self#select_store false !a e in
-      match self#emit_expr env arg with
+      match self#emit_expr env arg ~bound_name:None with
         None -> assert false
       | Some regs ->
           match op with
@@ -1407,7 +1541,7 @@ method private insert_return (env:environment) r (traps:trap_action list) =
       self#insert env (Ireturn traps) loc [||]
 
 method private emit_return (env:environment) exp traps =
-  self#insert_return env (self#emit_expr_aux env exp) traps
+  self#insert_return env (self#emit_expr_aux env exp ~bound_name:None) traps
 
 method private tail_call_possible (env:environment) (pos:Lambda.region_close) =
   match pos, env.regions with
@@ -1423,12 +1557,12 @@ method private tail_call_possible (env:environment) (pos:Lambda.region_close) =
 method emit_tail (env:environment) exp =
   match exp with
     Clet(v, e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env e1 ~bound_name:None with
         None -> ()
       | Some r1 -> self#emit_tail (self#bind_let env v r1) e2
       end
   | Clet_mut (v, k, e1, e2) ->
-     begin match self#emit_expr env e1 with
+     begin match self#emit_expr env e1 ~bound_name:None with
        None -> ()
      | Some r1 -> self#emit_tail (self#bind_let_mut env v k r1) e2
      end
@@ -1489,13 +1623,13 @@ method emit_tail (env:environment) exp =
           | _ -> Misc.fatal_error "Selection.emit_tail"
       end
   | Csequence(e1, e2) ->
-      begin match self#emit_expr env e1 with
+      begin match self#emit_expr env e1 ~bound_name:None with
         None -> ()
       | Some _ -> self#emit_tail env e2
       end
   | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, _dbg, _kind) ->
       let (cond, earg) = self#select_condition econd in
-      begin match self#emit_expr env earg with
+      begin match self#emit_expr env earg ~bound_name:None with
         None -> ()
       | Some rarg ->
           self#insert env
@@ -1504,7 +1638,7 @@ method emit_tail (env:environment) exp =
                       rarg [||]
       end
   | Cswitch(esel, index, ecases, _dbg, _kind) ->
-      begin match self#emit_expr env esel with
+      begin match self#emit_expr env esel ~bound_name:None with
         None -> ()
       | Some rsel ->
           let cases =
@@ -1538,12 +1672,31 @@ method emit_tail (env:environment) exp =
           | Unreachable -> assert false
           | Reachable t -> t
         in
+        let ids_and_rs = List.combine ids rs in
         let new_env =
           List.fold_left
             (fun env ((id, _typ),r) -> env_add id r env)
-            (env_set_trap_stack env trap_stack) (List.combine ids rs)
+            (env_set_trap_stack env trap_stack) ids_and_rs
         in
-        nfail, trap_stack, self#emit_tail_sequence new_env e2
+        let seq =
+          self#emit_tail_sequence new_env e2 ~at_start:(fun seq ->
+            List.iter (fun ((var, _typ), r) ->
+                let provenance = VP.provenance var in
+                let var = VP.var var in
+                let naming_op =
+                  Iname_for_debugger {
+                    ident = var;
+                    provenance;
+                    which_parameter = None;
+                    is_assignment = false;
+                    regs = r;
+                  }
+                in
+               seq#insert_debug new_env (Iop naming_op) Debuginfo.none
+                 [| |] [| |])
+               ids_and_rs)
+        in
+        nfail, trap_stack, seq
       in
       let rec build_all_reachable_handlers ~already_built ~not_built =
         let not_built, to_build =
@@ -1583,7 +1736,23 @@ method emit_tail (env:environment) exp =
       let s1 = self#emit_tail_sequence env_body e1 in
       let rv = self#regs_for typ_val in
       let with_handler env_handler e2 =
-        let s2 = self#emit_tail_sequence env_handler e2 in
+        let s2 =
+          self#emit_tail_sequence env_handler e2
+            ~at_start:(fun seq ->
+              let provenance = VP.provenance v in
+              let var = VP.var v in
+              let naming_op =
+                Iname_for_debugger {
+                  ident = var;
+                  provenance;
+                  which_parameter = None;
+                  is_assignment = false;
+                  regs = rv;
+                }
+              in
+              seq#insert_debug env_handler (Iop naming_op)
+                Debuginfo.none [| |] [| |])
+        in
         self#insert env
           (Itrywith(s1, kind,
                     (env_handler.trap_stack,
@@ -1631,8 +1800,12 @@ method emit_tail (env:environment) exp =
   | Cexit _ ->
     self#emit_return env exp (pop_all_traps env)
 
-method private emit_tail_sequence env exp =
+method private emit_tail_sequence ?at_start env exp =
   let s = {< instr_seq = dummy_instr >} in
+  begin match at_start with
+  | None -> ()
+  | Some f -> f s
+  end;
   s#emit_tail env exp;
   s#extract
 
@@ -1640,9 +1813,14 @@ method private emit_tail_sequence env exp =
 
 method emit_fundecl ~future_funcnames f =
   current_function_name := f.Cmm.fun_name.sym_name;
+  let num_regs_per_arg = Array.make (List.length f.Cmm.fun_args) 0 in
   let rargs =
-    List.map
-      (fun (id, ty) -> let r = self#regs_for ty in name_regs id r; r)
+    List.mapi
+      (fun arg_index (var, ty) ->
+        let r = self#regs_for ty in
+        name_regs var r;
+        num_regs_per_arg.(arg_index) <- Array.length r;
+        r)
       f.Cmm.fun_args in
   let rarg = Array.concat rargs in
   let loc_arg = Proc.loc_parameters (Reg.typv rarg) in
@@ -1653,6 +1831,28 @@ method emit_fundecl ~future_funcnames f =
   self#emit_tail env f.Cmm.fun_body;
   let body = self#extract in
   instr_seq <- dummy_instr;
+  let loc_arg_index = ref 0 in
+  List.iteri (fun param_index (var, _ty) ->
+      let provenance = VP.provenance var in
+      let var = VP.var var in
+      let num_regs_for_arg = num_regs_per_arg.(param_index) in
+      let hard_regs_for_arg =
+        Array.init num_regs_for_arg (fun index ->
+          loc_arg.(!loc_arg_index + index))
+      in
+      let naming_op =
+        Iname_for_debugger {
+          ident = var;
+          provenance;
+          which_parameter = Some param_index;
+          is_assignment = false;
+          regs = hard_regs_for_arg;
+        }
+      in
+      loc_arg_index := !loc_arg_index + num_regs_for_arg;
+      self#insert_debug env (Iop naming_op) Debuginfo.none
+        hard_regs_for_arg [| |])
+    f.Cmm.fun_args;
   self#insert_moves env loc_arg rarg;
   let polled_body =
     if Polling.requires_prologue_poll ~future_funcnames

--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -168,10 +168,16 @@ class virtual selector_generic : object
     environment -> Reg.t array list -> unit
   method insert_endregions_until :
     environment -> suffix:Region_stack.t -> Region_stack.t -> unit
-  method emit_expr :
-    environment -> Cmm.expression -> Reg.t array option
-  method emit_expr_aux :
-    environment -> Cmm.expression -> (Reg.t array * Region_stack.t) option
+  method emit_expr
+     : environment
+    -> Cmm.expression
+    -> bound_name:Backend_var.With_provenance.t option
+    -> Reg.t array option
+  method emit_expr_aux
+     : environment
+    -> Cmm.expression
+    -> bound_name:Backend_var.With_provenance.t option
+    -> (Reg.t array * Region_stack.t) option
   method emit_tail : environment -> Cmm.expression -> unit
 
   (* [contains_calls] is declared as a reference instance variable,

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -482,7 +482,8 @@ let add_spills env regset i =
      spill between a move into a register and the operation naming that
      register.  (Such a situation would cause the spilled register to be
      unnamed). *)
-  (* CR mshinwell: this probably needs implementing for Cfg regalloc *)
+  (* CR mshinwell: this probably needs implementing for Cfg regalloc
+     (see Regalloc_split.insert_spills). *)
   let rec add_spills i =
     match i.desc with
     | Iop (Iname_for_debugger _) ->

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -477,9 +477,23 @@ let find_in_spill_cache nfail at_join env =
   with Not_found -> None
 
 let add_spills env regset i =
-  Reg.Set.fold
-    (fun r i -> instr_cons (Iop Ispill) [|r|] [|spill_reg_no_add env r|] i)
-    regset i
+  let regset = Reg.Set.elements regset in
+  (* Skip over any [Iname_for_debugger] operations so that we don't put a
+     spill between a move into a register and the operation naming that
+     register.  (Such a situation would cause the spilled register to be
+     unnamed). *)
+  (* CR mshinwell: this probably needs implementing for Cfg regalloc *)
+  let rec add_spills i =
+    match i.desc with
+    | Iop (Iname_for_debugger _) ->
+      let next = add_spills i.next in
+      { i with next; }
+    | _ ->
+      List.fold_left (fun i r ->
+          instr_cons (Iop Ispill) [|r|] [|spill_reg_no_add env r|] i)
+        i regset
+  in
+  add_spills i
 
 let rec spill :
   type a. spill_env -> Mach.instruction -> Reg.Set.t ->

--- a/backend/split.ml
+++ b/backend/split.ml
@@ -139,6 +139,14 @@ let rec rename i sub =
           (instr_cons i.desc i.arg [|newr|] new_next,
            sub_next)
       end
+  | Iop (Iname_for_debugger {
+        ident; which_parameter; provenance; is_assignment; regs }) ->
+      let (new_next, sub_next) = rename i.next sub in
+      let regs = subst_regs regs sub in
+      (instr_cons_debug (Iop (Iname_for_debugger {
+          ident; which_parameter; provenance; is_assignment; regs }))
+         [| |] [||] i.dbg new_next,
+       sub_next)
   | Iop _ ->
       let (new_next, sub_next) = rename i.next sub in
       (instr_cons_debug i.desc (subst_regs i.arg sub) (subst_regs i.res sub)

--- a/middle_end/backend_var.ml
+++ b/middle_end/backend_var.ml
@@ -46,6 +46,8 @@ module Provenance = struct
   let module_path t = t.module_path
   let location t = t.location
   let original_ident t = t.original_ident
+
+  let equal t1 t2 = Stdlib.compare t1 t2 = 0
 end
 
 module With_provenance = struct

--- a/middle_end/backend_var.mli
+++ b/middle_end/backend_var.mli
@@ -35,6 +35,8 @@ module Provenance : sig
   val original_ident : t -> Ident.t
 
   val print : Format.formatter -> t -> unit
+
+  val equal : t -> t -> bool
 end
 
 module With_provenance : sig


### PR DESCRIPTION
This is a port of https://github.com/ocaml/ocaml/pull/2063 to flambda-backend.  It causes the pseudo-operation that provides the names of registers, for the purposes of generating debugging information, to be inserted during instruction selection.  These operations are then picked up later by `Available_regs` to determine the names of values in the various available registers.