### PR TITLE
Propagate register availability sets to Linear

### DIFF
--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -81,6 +81,7 @@ module Make (T : Branch_relaxation_intf.S) = struct
       | Some l ->
         instr_cons (Lcondbranch (Iinttest_imm (Isigned Cmm.Ceq, n), l))
           arg [||] next
+          ~available_before:None ~available_across:None
     in
     let rec fixup did_fix pc instr =
       match instr.desc with
@@ -114,7 +115,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
             let llabel = Llabel { label = lbl2; section_name = None } in
             let cont =
               instr_cons (Lbranch lbl) [||] [||]
-                (instr_cons llabel [||] [||] instr.next)
+                (instr_cons llabel [||] [||] instr.next
+                  ~available_before:None ~available_across:None)
+                ~available_before:None ~available_across:None
             in
             instr.desc <- Lcondbranch (invert_test test, lbl2);
             instr.next <- cont;

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -390,7 +390,9 @@ let print_basic' ?print_reg ppf (instruction : basic instruction) =
       res = instruction.res;
       dbg = [];
       fdo = None;
-      live = Reg.Set.empty
+      live = Reg.Set.empty;
+      available_before = None;
+      available_across = None
     }
   in
   Printlinear.instr' ?print_reg ppf instruction

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -145,7 +145,9 @@ module S = struct
       mutable stack_offset : int;
       id : int;
       mutable irc_work_list : irc_work_list;
-      mutable ls_order : int
+      mutable ls_order : int;
+      mutable available_before : Reg_availability_set.t option;
+      mutable available_across : Reg_availability_set.t option
     }
 
   (* [basic] instruction cannot raise *)

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -31,12 +31,20 @@ module DLL = Flambda_backend_utils.Doubly_linked_list
 
 let to_linear_instr ?(like : _ Cfg.instruction option) desc ~next :
     L.instruction =
-  let arg, res, dbg, live, fdo =
+  let arg, res, dbg, live, fdo, available_before, available_across =
     match like with
-    | None -> [||], [||], Debuginfo.none, Reg.Set.empty, Fdo_info.none
-    | Some like -> like.arg, like.res, like.dbg, like.live, like.fdo
+    | None ->
+      [||], [||], Debuginfo.none, Reg.Set.empty, Fdo_info.none, None, None
+    | Some like ->
+      ( like.arg,
+        like.res,
+        like.dbg,
+        like.live,
+        like.fdo,
+        like.available_before,
+        like.available_across )
   in
-  { desc; next; arg; res; dbg; live; fdo }
+  { desc; next; arg; res; dbg; live; fdo; available_before; available_across }
 
 let basic_to_linear (i : _ Cfg.instruction) ~next =
   let desc = Cfg_to_linear_desc.from_basic i.desc in

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -313,7 +313,9 @@ let make_instruction : type a. State.t -> desc:a -> a Cfg.instruction =
     id;
     fdo;
     irc_work_list = Unknown_list;
-    ls_order = -1
+    ls_order = -1;
+    available_before = None;
+    available_across = None
   }
 
 let copy_instruction :
@@ -325,8 +327,8 @@ let copy_instruction :
         live;
         desc = _;
         next = _;
-        available_before = _;
-        available_across = _
+        available_before;
+        available_across
       } =
     instr
   in
@@ -342,7 +344,9 @@ let copy_instruction :
     id;
     fdo;
     irc_work_list = Unknown_list;
-    ls_order = -1
+    ls_order = -1;
+    available_before = Some available_before;
+    available_across
   }
 
 let copy_instruction_no_reg :
@@ -354,8 +358,8 @@ let copy_instruction_no_reg :
         live;
         desc = _;
         next = _;
-        available_before = _;
-        available_across = _
+        available_before;
+        available_across
       } =
     instr
   in
@@ -373,7 +377,9 @@ let copy_instruction_no_reg :
     id;
     fdo;
     irc_work_list = Unknown_list;
-    ls_order = -1
+    ls_order = -1;
+    available_before = Some available_before;
+    available_across
   }
 
 let rec get_end : Mach.instruction -> Mach.instruction =

--- a/backend/cfg/linear_to_cfg.ml
+++ b/backend/cfg/linear_to_cfg.ml
@@ -114,7 +114,9 @@ let create_instruction t desc ~stack_offset (i : Linear.instruction) :
     stack_offset;
     id = get_new_linear_id t;
     irc_work_list = Unknown_list;
-    ls_order = -1
+    ls_order = -1;
+    available_before = i.available_before;
+    available_across = i.available_across
   }
 
 let record_traps t label traps =
@@ -166,7 +168,9 @@ let create_empty_block t start ~stack_offset ~traps =
       stack_offset;
       id = get_new_linear_id t;
       irc_work_list = Unknown_list;
-      ls_order = -1
+      ls_order = -1;
+      available_before = Some Unreachable;
+      available_across = Some Unreachable
     }
   in
   let block : C.basic_block =
@@ -317,7 +321,10 @@ let get_or_make_label t (insn : Linear.instruction) : Linear_utils.labelled_insn
     let label = Cmm.new_label () in
     t.new_labels <- Label.Set.add label t.new_labels;
     let insn =
-      Linear.instr_cons (Llabel { label; section_name = None }) [||] [||] insn
+      Linear.instr_cons
+        (Llabel { label; section_name = None })
+        [||] [||] insn ~available_before:insn.available_before
+        ~available_across:insn.available_across
     in
     { label; insn }
 

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -344,7 +344,9 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
             res = [||];
             dbg = insn.dbg;
             fdo = insn.fdo;
-            live = insn.live
+            live = insn.live;
+            available_before = insn.available_before;
+            available_across = insn.available_across
           }
         in
         used_label := Some (label, label_insn);

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -24,7 +24,10 @@ type instruction =
     res: Reg.t array;
     dbg: Debuginfo.t;
     fdo: Fdo_info.t;
-    live: Reg.Set.t }
+    live: Reg.Set.t;
+    available_before: Reg_availability_set.t option;
+    available_across: Reg_availability_set.t option;
+  }
 
 and instruction_desc =
   | Lprologue
@@ -86,12 +89,16 @@ let rec end_instr =
     res = [||];
     dbg = Debuginfo.none;
     fdo = Fdo_info.none;
-    live = Reg.Set.empty }
+    live = Reg.Set.empty;
+    available_before = Some Unreachable;
+    available_across = None
+  }
 
 (* Cons an instruction (live, debug empty) *)
 
-let instr_cons d a r n =
+let instr_cons d a r n ~available_before ~available_across =
   { desc = d; next = n; arg = a; res = r;
-    dbg = Debuginfo.none; fdo = Fdo_info.none; live = Reg.Set.empty }
+    dbg = Debuginfo.none; fdo = Fdo_info.none; live = Reg.Set.empty;
+    available_before; available_across }
 
 let traps_to_bytes traps = Proc.trap_size_in_bytes * traps

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -24,7 +24,10 @@ type instruction =
     res: Reg.t array;
     dbg: Debuginfo.t;
     fdo: Fdo_info.t;
-    live: Reg.Set.t }
+    live: Reg.Set.t;
+    available_before: Reg_availability_set.t option;
+    available_across: Reg_availability_set.t option;
+  }
 
 and instruction_desc =
   | Lprologue
@@ -46,7 +49,9 @@ and instruction_desc =
 val has_fallthrough :  instruction_desc -> bool
 val end_instr: instruction
 val instr_cons:
-  instruction_desc -> Reg.t array -> Reg.t array -> instruction -> instruction
+  instruction_desc -> Reg.t array -> Reg.t array -> instruction
+  -> available_before:Reg_availability_set.t option
+  -> available_across:Reg_availability_set.t option -> instruction
 val invert_test: Mach.test -> Mach.test
 
 type fundecl =

--- a/backend/linearize.ml
+++ b/backend/linearize.ml
@@ -20,15 +20,20 @@ open Linear
 
 let cons_instr d n =
   { desc = d; next = n; arg = [||]; res = [||];
-    dbg = Debuginfo.none; fdo = Fdo_info.none; live = Reg.Set.empty }
+    dbg = Debuginfo.none; fdo = Fdo_info.none; live = Reg.Set.empty;
+    (* CR mshinwell: this isn't good, but will suffice for now, since we're
+       targetting Cfg anyway *)
+    available_before = None; available_across = None }
 
-(* Build an instruction with arg, res, dbg, live taken from
+(* Build an instruction with arg, res, dbg, live and availability taken from
    the given Mach.instruction *)
 
 let copy_instr d i n =
   { desc = d; next = n;
     arg = i.Mach.arg; res = i.Mach.res;
-    dbg = i.Mach.dbg; fdo = Fdo_info.none; live = i.Mach.live }
+    dbg = i.Mach.dbg; fdo = Fdo_info.none; live = i.Mach.live;
+    available_before = Some i.Mach.available_before;
+    available_across = i.Mach.available_across }
 
 (*
    Label the beginning of the given instruction sequence.
@@ -355,6 +360,8 @@ let add_prologue first_insn prologue_required =
           dbg = insn.dbg;
           fdo = insn.fdo;
           live = insn.live;
+          available_before = None;
+          available_across = None;
         }
       in
       (* We expect [Lprologue] to expand to at least one instruction---as such,
@@ -389,6 +396,8 @@ let add_prologue first_insn prologue_required =
             dbg = tailrec_entry_point.dbg;
             fdo = tailrec_entry_point.fdo;
             live = Reg.Set.empty;  (* will not be used *)
+            available_before = None;
+            available_across = None;
           }
         in
         tailrec_entry_point_label, prologue

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -102,6 +102,7 @@ type instruction =
     res: Reg.t array;
     dbg: Debuginfo.t;
     mutable live: Reg.Set.t;
+    (* CR mshinwell: maybe this should be [option]: *)
     mutable available_before: Reg_availability_set.t;
     mutable available_across: Reg_availability_set.t option;
   }

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -87,7 +87,9 @@ module Instruction = struct
       stack_offset = -1;
       id = -1;
       irc_work_list = Unknown_list;
-      ls_order = -1
+      ls_order = -1;
+      available_before = None;
+      available_across = None
     }
 
   let compare (left : t) (right : t) : int = Int.compare left.id right.id
@@ -240,7 +242,9 @@ module Move = struct
       stack_offset = instr.stack_offset;
       id;
       irc_work_list = Unknown_list;
-      ls_order = -1
+      ls_order = -1;
+      available_before = instr.available_before;
+      available_across = instr.available_across
     }
 
   let to_string = function Plain -> "move" | Load -> "load" | Store -> "store"
@@ -482,14 +486,19 @@ let insert_block :
     Misc.fatal_errorf
       "Cannot insert a block after block %a: it has no successors" Label.print
       predecessor_block.start;
-  let dbg, fdo, live, stack_offset =
+  let dbg, fdo, live, stack_offset, available_before, available_across =
     match DLL.last body with
     | None ->
       ( Debuginfo.none,
         Fdo_info.none,
         Reg.Set.empty,
-        predecessor_block.stack_offset )
-    | Some { dbg; fdo; live; stack_offset; _ } -> dbg, fdo, live, stack_offset
+        predecessor_block.stack_offset,
+        None,
+        None )
+    | Some
+        { dbg; fdo; live; stack_offset; available_before; available_across; _ }
+      ->
+      dbg, fdo, live, stack_offset, available_before, available_across
   in
   let copy (i : Cfg.basic Cfg.instruction) : Cfg.basic Cfg.instruction =
     { i with id = next_instruction_id () }
@@ -524,7 +533,9 @@ let insert_block :
               stack_offset;
               id = next_instruction_id ();
               irc_work_list = Unknown_list;
-              ls_order = -1
+              ls_order = -1;
+              available_before;
+              available_across
             };
           (* The [predecessor_block] is the only predecessor. *)
           predecessors = Label.Set.singleton predecessor_block.start;

--- a/tests/backend/regalloc_validator/check_regalloc_validation.ml
+++ b/tests/backend/regalloc_validator/check_regalloc_validation.ml
@@ -30,7 +30,9 @@ module Instruction = struct
       irc_work_list = Unknown_list;
       live = Reg.Set.empty;
       stack_offset = 0;
-      ls_order = -1
+      ls_order = -1;
+      available_before = None;
+      available_across = None;
     }
 end
 


### PR DESCRIPTION
This propagates the register availability sets from `Mach` instructions to `Linear` instructions, after which point they will be used by the analysis pass that computes available ranges.

The old `Linearize` pass requires significant alterations to get the availability information accurate.  We can probably avoid this since we're moving to `Cfg` anyway in the near term.