### PR TITLE
Cfg-based register allocators: remove debug info from introduced moves

### DIFF
--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -233,7 +233,7 @@ module Move = struct
     { desc = Op (op_of_move move);
       arg = [| from |];
       res = [| to_ |];
-      dbg = instr.dbg;
+      dbg = Debuginfo.none;
       fdo = instr.fdo;
       live = instr.live;
       (* note: recomputed anyway *)


### PR DESCRIPTION
While looking at the differences between upstream's
allocators and the CFG-based ones, I noticed that
we emit more `.loc` directives. We indeed (sometimes)
emit such directives for `mov` instructions introduced
by the register allocator (for spills, reloads, or phi
functions). This pull request simply sets the debug
info of such `mov` instructions to `none`.