### PR TITLE
Don't add a module to the environment when saving it

### DIFF
--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -972,8 +972,6 @@ let sign_of_cmi ~freshen { Persistent_env.Persistent_signature.cmi; _ } =
 
 let read_sign_of_cmi = sign_of_cmi ~freshen:true
 
-let save_sign_of_cmi = sign_of_cmi ~freshen:false
-
 let persistent_env : module_data Persistent_env.t ref =
   s_table Persistent_env.empty ()
 
@@ -2670,10 +2668,8 @@ let save_signature_with_transform cmi_transform ~alerts sg modname filename =
   let cmi =
     Persistent_env.make_cmi !persistent_env modname sg alerts
     |> cmi_transform in
-  let pm = save_sign_of_cmi
-      { Persistent_env.Persistent_signature.cmi; filename } in
   Persistent_env.save_cmi !persistent_env
-    { Persistent_env.Persistent_signature.filename; cmi } pm;
+    { Persistent_env.Persistent_signature.filename; cmi };
   cmi
 
 let save_signature ~alerts sg modname filename =

--- a/ocaml/typing/persistent_env.mli
+++ b/ocaml/typing/persistent_env.mli
@@ -89,7 +89,7 @@ val register_import_as_opaque : 'a t -> Compilation_unit.Name.t -> unit
 val make_cmi : 'a t -> Compilation_unit.t -> Subst.Lazy.signature -> alerts
   -> Cmi_format.cmi_infos_lazy
 
-val save_cmi : 'a t -> Persistent_signature.t -> 'a -> unit
+val save_cmi : 'a t -> Persistent_signature.t -> unit
 
 val can_load_cmis : 'a t -> can_load_cmis
 val set_can_load_cmis : 'a t -> can_load_cmis -> unit


### PR DESCRIPTION
When saving a .cmi, we produce all the same data we would if we were importing it and add this data to the environment. This is done only so that the CRC for the module is added to our CRCs and we can look up the CRC later. This is wholly unnecessary, however: we can just add the CRC to the `Consistbl`. Removing the extra steps
  * gets rid of a decidedly awkward code path,
  * keeps the environment clean (we currently never observe the fact that a saved .cmi is treated as bound in the environment, but it's not good!), and
  * will also enable further simplification, since `sign_of_cmi` now freshens unconditionally (the only call with `~freshen:false` is gone).

This patch removes the saved .cmi from the persistent environment, and also changes `crc_of_unit` to look up in the global `crc_units` table first so that it bypasses `find_pers_struct` for a saved .cmi.