### PR TITLE
Pattern guards split tests

### DIFF
--- a/ocaml/testsuite/tests/pattern-guards/exn_patterns.ml
+++ b/ocaml/testsuite/tests/pattern-guards/exn_patterns.ml
@@ -1,0 +1,119 @@
+(* TEST
+   * expect *)
+
+(* Test interaction of pattern guards with exception patterns. *)
+
+(* Test behavior of pattern guards that only match exception patterns. *)
+
+let no_value_clauses f x =
+  match x with
+  | Some x when f x match exception e -> Error e
+  | Some x -> Ok (f x)
+  | None -> Error (Failure "x is None")
+;;
+[%%expect{|
+val no_value_clauses : ('a -> 'b) -> 'a option -> ('b, exn) result = <fun>
+|}];;
+
+let f x = 100 / x;;
+[%%expect{|
+val f : int -> int = <fun>
+|}];;
+
+no_value_clauses f None;;
+[%%expect{|
+- : (int, exn) result = Error (Failure "x is None")
+|}];;
+no_value_clauses f (Some 0);;
+[%%expect{|
+- : (int, exn) result = Error Division_by_zero
+|}];;
+no_value_clauses f (Some 5);;
+[%%expect{|
+- : (int, exn) result = Ok 20
+|}];;
+
+(* Test behavior of pattern guards matching empty variants with exception
+   patterns. *)
+
+type void = |;;
+[%%expect{|
+type void = |
+|}];;
+
+let prove_false () : void = failwith "qed";;
+[%%expect{|
+val prove_false : unit -> void = <fun>
+|}];;
+
+let guard_matching_empty_variant = function
+  | None when prove_false () match exception (Failure str) -> "failed: " ^ str
+  | None -> "proved false!"
+  | Some x -> x
+;;
+[%%expect{|
+val guard_matching_empty_variant : string option -> string = <fun>
+|}];;
+
+guard_matching_empty_variant None;;
+[%%expect{|
+- : string = "failed: qed"
+|}];;
+guard_matching_empty_variant (Some "foo");;
+[%%expect{|
+- : string = "foo"
+|}];;
+
+(* Correctness test for pattern guards with mixed value and exception
+   patterns. *)
+
+module M : sig
+  type 'a t
+
+  val empty : 'a t
+  val add : int -> 'a -> 'a t -> 'a t
+  val find : int -> 'a t -> 'a
+end = Map.Make (Int);;
+[%%expect{|
+module M :
+  sig
+    type 'a t
+    val empty : 'a t
+    val add : int -> 'a -> 'a t -> 'a t
+    val find : int -> 'a t -> 'a
+  end
+|}];;
+
+let name_map = M.empty |> M.add 0 "Fred" |> M.add 4 "Barney";;
+[%%expect{|
+val name_map : string M.t = <abstr>
+|}];;
+
+
+let say_hello_catching_exns id name_map =
+  match id with
+  | Some id when M.find id name_map match "Barney" | exception _ ->
+      "Hello, Barney"
+  | None | Some _ -> "Hello, Fred"
+;;
+[%%expect{|
+val say_hello_catching_exns : int option -> string M.t -> string = <fun>
+|}];;
+
+say_hello_catching_exns (Some 0) name_map;;
+[%%expect{|
+- : string = "Hello, Fred"
+|}];;
+say_hello_catching_exns (Some 2) name_map;;
+[%%expect{|
+- : string = "Hello, Barney"
+|}];;
+say_hello_catching_exns (Some 4) name_map;;
+[%%expect{|
+- : string = "Hello, Barney"
+|}];;
+say_hello_catching_exns None name_map;;
+[%%expect{|
+- : string = "Hello, Fred"
+|}];;
+

--- a/ocaml/testsuite/tests/pattern-guards/gadts.ml
+++ b/ocaml/testsuite/tests/pattern-guards/gadts.ml
@@ -1,0 +1,32 @@
+(* TEST
+   * expect *)
+
+(* Test pattern guard inward propagation of GADT type information. *)
+
+type ('a, 'b) eq = Eq : ('a, 'a) eq;;
+[%%expect{|
+type ('a, 'b) eq = Eq : ('a, 'a) eq
+|}];;
+
+let in_pattern_guard (type a b) (eq : (a, b) eq) (compare : a -> a -> int)
+                     (x : a) (y : b) =
+  match eq with
+  | Eq when compare x y match 0 -> true
+  | _ -> false
+;;
+[%%expect{|
+val in_pattern_guard : ('a, 'b) eq -> ('a -> 'a -> int) -> 'a -> 'b -> bool =
+  <fun>
+|}];;
+
+let from_pattern_guard (type a b) (eqs : (a, b) eq option list)
+                       (compare : a -> a -> int) (x : a) (y : b) =
+  match eqs with
+  | eq_opt :: _ when eq_opt match Some Eq -> compare x y
+  | _ -> 0
+;;
+[%%expect{|
+val from_pattern_guard :
+  ('a, 'b) eq option list -> ('a -> 'a -> int) -> 'a -> 'b -> int = <fun>
+|}];;
+

--- a/ocaml/testsuite/tests/pattern-guards/jane_test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/jane_test.ml
@@ -11,7 +11,7 @@ let pattern_guard_returns_local f x =
     | [] -> 0
     | [ _ ] -> one
     | [ _; _ ] -> 2
-  )
+    )
   | _ -> 3
 ;;
 [%%expect{|
@@ -26,10 +26,10 @@ let pattern_guard_doesnt_return_local f x =
   let local_ one = 1 in
   match x with
   | Some x when one match (
-    | 0 -> 0
-    | 1 -> 1
-    | 2 -> 2
-  )
+      | 0 -> 0
+      | 1 -> 1
+      | 2 -> 2
+    )
   | _ -> 3
 ;;
 [%%expect{|

--- a/ocaml/testsuite/tests/pattern-guards/nested_guards.ml
+++ b/ocaml/testsuite/tests/pattern-guards/nested_guards.ml
@@ -1,0 +1,121 @@
+(* TEST
+   * expect *)
+
+(* Tests behavior of nested pattern guards, i.e. pattern guards whose cases have
+   patterns that are themselves guarded. *)
+
+(* Nested single-way pattern guards. *)
+
+let nested_singleway f g h ~default = function
+  | Some x
+      when f x match Some y
+      when g y match Some z
+      when h z match Some a ->
+      a
+  | _ -> default
+;;
+[%%expect{|
+val nested_singleway :
+  ('a -> 'b option) ->
+  ('b -> 'c option) -> ('c -> 'd option) -> default:'d -> 'a option -> 'd =
+  <fun>
+|}];;
+
+let collatz = function
+  | 1 -> None
+  | n -> if n mod 2 = 0 then Some (n / 2) else Some (3 * n + 1)
+;;
+[%%expect{|
+val collatz : int -> int option = <fun>
+|}];;
+
+nested_singleway collatz collatz collatz ~default:~-1 None;;
+[%%expect{|
+- : int = -1
+|}];;
+nested_singleway collatz collatz collatz ~default:~-1 (Some 1);;
+[%%expect{|
+- : int = -1
+|}];;
+nested_singleway collatz collatz collatz ~default:~-1 (Some 2);;
+[%%expect{|
+- : int = -1
+|}];;
+nested_singleway collatz collatz collatz ~default:~-1 (Some 3);;
+[%%expect{|
+- : int = 16
+|}];;
+nested_singleway collatz collatz collatz ~default:~-1 (Some 4);;
+[%%expect{|
+- : int = -1
+|}];;
+nested_singleway collatz collatz collatz ~default:~-1 (Some 8);;
+[%%expect{|
+- : int = 1
+|}];;
+
+(* Nested multiway pattern guards. *)
+
+let nested_multiway f g h = function
+  | Some x when f x match (
+      | "foo" when h x -> "foo1"
+      | "bar" when g x match (
+          | [] -> "bar empty"
+          | [ y ] -> "bar singleton " ^ y
+        )
+    )
+  | _ -> "not found"
+;;
+[%%expect{|
+val nested_multiway :
+  ('a -> string) ->
+  ('a -> string list) -> ('a -> bool) -> 'a option -> string = <fun>
+|}];;
+
+let f = function
+  | 0 | 1 -> "foo"
+  | 10 | 100 | 1000 -> "bar"
+  | _ -> "neither"
+;;
+[%%expect{|
+val f : int -> string = <fun>
+|}];;
+
+let g = function
+  | 10 -> []
+  | 100 -> [ "one" ]
+  | _ -> [ "more"; "than"; "one" ]
+;;
+[%%expect{|
+val g : int -> string list = <fun>
+|}];;
+
+let h x = x = 1;;
+[%%expect{|
+val h : int -> bool = <fun>
+|}];;
+
+nested_multiway f g h None;;
+[%%expect{|
+- : string = "not found"
+|}];;
+nested_multiway f g h (Some 0);;
+[%%expect{|
+- : string = "not found"
+|}];;
+nested_multiway f g h (Some 1);;
+[%%expect{|
+- : string = "foo1"
+|}];;
+nested_multiway f g h (Some 10);;
+[%%expect{|
+- : string = "bar empty"
+|}];;
+nested_multiway f g h (Some 100);;
+[%%expect{|
+- : string = "bar singleton one"
+|}];;
+nested_multiway f g h (Some 1000);;
+[%%expect{|
+- : string = "not found"
+|}];;

--- a/ocaml/testsuite/tests/pattern-guards/seq.ml
+++ b/ocaml/testsuite/tests/pattern-guards/seq.ml
@@ -1,0 +1,56 @@
+(* TEST
+   * expect *)
+
+(* Demonstrate interaction of sequences [(e1; e2; ..; en)] with pattern
+   guards. *)
+
+(* Demonstrate parsing of sequences in boolean guards. *)
+
+let seq_boolean x ~f ~g ~default =
+  match x with
+    | Some x when f x; g x -> x
+    | _ -> default
+;;
+[%%expect{|
+val seq_boolean :
+  'a option -> f:('a -> 'b) -> g:('a -> bool) -> default:'a -> 'a = <fun>
+|}];;
+
+(* Demonstrate semantics of sequences in pattern guard scrutinees. *)
+
+let seq_pattern x ~f ~g ~default =
+  match x with
+    | Some x when (f x; g x) match Some y -> y
+    | _ -> default
+;;
+[%%expect{|
+val seq_pattern :
+  'a option -> f:('a -> 'b) -> g:('a -> 'c option) -> default:'c -> 'c =
+  <fun>
+|}];;
+
+let counter = ref 0;;
+[%%expect{|
+val counter : int ref = {contents = 0}
+|}];;
+let f () = incr counter;;
+[%%expect{|
+val f : unit -> unit = <fun>
+|}];;
+let g () = if !counter > 1 then Some (!counter - 1) else None;;
+[%%expect{|
+val g : unit -> int option = <fun>
+|}];;
+
+seq_pattern (Some ()) ~f ~g ~default:0;;
+[%%expect{|
+- : int = 0
+|}];;
+seq_pattern (Some ()) ~f ~g ~default:0;;
+[%%expect{|
+- : int = 1
+|}];;
+seq_pattern None ~f ~g ~default:0;;
+[%%expect{|
+- : int = 0
+|}];;

--- a/ocaml/testsuite/tests/pattern-guards/seq_bad.compilers.reference
+++ b/ocaml/testsuite/tests/pattern-guards/seq_bad.compilers.reference
@@ -1,4 +1,4 @@
 File "seq_bad.ml", line 13, characters 25-30:
-13 |   | Some x when f x; g x match Some y -> y 
+13 |   | Some x when f x; g x match Some y -> y
                               ^^^^^
 Error: Syntax error

--- a/ocaml/testsuite/tests/pattern-guards/seq_bad.ml
+++ b/ocaml/testsuite/tests/pattern-guards/seq_bad.ml
@@ -4,12 +4,13 @@
     ocamlopt_opt_exit_status = "2"
   *** check-ocamlopt.opt-output*)
 
-(* One might innocuously write the below code hoping that it parses as
-   [(f x; g x) match ...]. This test demonstrates that this intentionally results in
-   a type error. *)
+(* Demonstrate that [when e1; e2 match P -> e3] is a parse error.
+   One might believe that it parses as [when (e1; e2) match P -> e3], but this
+   is the wrong precedence. *)
 
 let seq_bad x ~f ~g ~default =
   match x with
-  | Some x when f x; g x match Some y -> y 
+  | Some x when f x; g x match Some y -> y
   | _ -> y
+;;
 

--- a/ocaml/testsuite/tests/pattern-guards/test.ml
+++ b/ocaml/testsuite/tests/pattern-guards/test.ml
@@ -1,13 +1,14 @@
 (* TEST
    * expect *)
 
-(* CR-soon rgodse: We expect this output to change soon, but for now it shows
-   that parsing works for multicase patterns. *)
+(* Typical usage of pattern guards *)
 
-(* Test basic usage of pattern guards. *)
+(* Test basic usage of single-case pattern guards. *)
+
 let basic_usage ~f ~default x =
   match x with
-    | Some x when f x match Some y -> y
+    | Some x when f x match
+      | Some y -> y
     | _ -> default
 ;;
 [%%expect{|
@@ -37,286 +38,13 @@ basic_usage ~f ~default:~-1 None;;
 - : int = -1
 |}];;
 
-(* Demonstrate parsing of sequences in boolean predicates. *)
-let seq_predicate x ~f ~g ~default =
-  match x with
-    | Some x when f x; g x -> x
-    | _ -> default
-;;
-[%%expect{|
-val seq_predicate :
-  'a option -> f:('a -> 'b) -> g:('a -> bool) -> default:'a -> 'a = <fun>
-|}];;
-
-(* Demonstrate semantics of sequences in pattern guard scrutinees. *)
-let seq_pattern x ~f ~g ~default =
-  match x with
-    | Some x when (f x; g x) match Some y -> y
-    | _ -> default
-;;
-[%%expect{|
-val seq_pattern :
-  'a option -> f:('a -> 'b) -> g:('a -> 'c option) -> default:'c -> 'c =
-  <fun>
-|}];;
-
-let counter = ref 0;;
-[%%expect{|
-val counter : int ref = {contents = 0}
-|}];;
-let f () = incr counter;;
-[%%expect{|
-val f : unit -> unit = <fun>
-|}];;
-let g () = if !counter > 1 then Some (!counter - 1) else None;;
-[%%expect{|
-val g : unit -> int option = <fun>
-|}];;
-
-seq_pattern (Some ()) ~f ~g ~default:0;;
-[%%expect{|
-- : int = 0
-|}];;
-seq_pattern (Some ()) ~f ~g ~default:0;;
-[%%expect{|
-- : int = 1
-|}];;
-seq_pattern None ~f ~g ~default:0;;
-[%%expect{|
-- : int = 0
-|}];;
-
-let complex_types (x : int list option) : bool =
-  let strs_opt = match x with
-    | Some [ y ] when y + 1 > 5 -> Some ("foo", "bar")
-    | Some ys when List.length ys match 0 -> Some ("baz", "qux")
-    | Some _ | None -> None
-  in
-  match strs_opt with
-    | Some strs when strs match ("foo", s2) -> String.equal s2 "bar"
-    | Some _ | None -> false
-;;
-[%%expect {|
-val complex_types : int list option -> bool = <fun>
-|}];;
-
-(* Check typing of pattern guard patterns. *)
-let ill_typed_pattern (x : int list option) : bool =
-  match x with
-    | Some [ y ] when y match None -> true
-    | _ -> false
-[%%expect{|
-Line 3, characters 30-34:
-3 |     | Some [ y ] when y match None -> true
-                                  ^^^^
-Error: This pattern matches values of type 'a option
-       but a pattern was expected which matches values of type int
-|}]
-
-let typing_no_value_clauses f x =
-  match x with
-    | Some x when f x match exception e -> Error e
-    | Some x -> Ok (f x)
-    | None -> Error (Failure "x is None")
-;;
-
-let f x = 100 / x;;
-[%%expect{|
-val typing_no_value_clauses : ('a -> 'b) -> 'a option -> ('b, exn) result =
-  <fun>
-val f : int -> int = <fun>
-|}];;
-
-typing_no_value_clauses f None;;
-[%%expect{|
-- : (int, exn) result = Error (Failure "x is None")
-|}];;
-typing_no_value_clauses f (Some 0);;
-[%%expect{|
-- : (int, exn) result = Error Division_by_zero
-|}];;
-typing_no_value_clauses f (Some 5);;
-[%%expect{|
-- : (int, exn) result = Ok 20
-|}];;
-
-(* Check typing of pattern guards with no value cases. *)
-let typing_no_value_clauses f x =
-  match x with
-    | Some x when f x match exception e -> Error e
-    | Some x -> Ok (f x)
-    | None -> Error (Failure "x is None")
-;;
-
-let f x = 100 / x;;
-[%%expect{|
-val typing_no_value_clauses : ('a -> 'b) -> 'a option -> ('b, exn) result =
-  <fun>
-val f : int -> int = <fun>
-|}];;
-
-typing_no_value_clauses f None;;
-[%%expect{|
-- : (int, exn) result = Error (Failure "x is None")
-|}];;
-typing_no_value_clauses f (Some 0);;
-[%%expect{|
-- : (int, exn) result = Error Division_by_zero
-|}];;
-typing_no_value_clauses f (Some 5);;
-[%%expect{|
-- : (int, exn) result = Ok 20
-|}];;
-
-(* Check typing of vars bound in pattern guard patterns. *)
-let ill_typed_pattern_var (x : int list option) : bool =
-  match x with
-    | Some xs when xs match [ y ] -> String.equal y "foo"
-    | _ -> false
-[%%expect{|
-Line 3, characters 50-51:
-3 |     | Some xs when xs match [ y ] -> String.equal y "foo"
-                                                      ^
-Error: This expression has type int but an expression was expected of type
-         String.t = string
-|}];;
-
-(* Check that pattern guards can shadow and use outer variables correctly. *)
-let shadow_outer_variables (n : int option) (strs : string list) =
-  match n with
-  | Some n when List.nth_opt strs n match Some s -> s
-  | _ -> "Not found"
-;;
-[%%expect{|
-val shadow_outer_variables : int option -> string list -> string = <fun>
-|}];;
-
-shadow_outer_variables (Some 0) [ "foo"; "bar" ];;
-[%%expect{|
-- : string = "foo"
-|}];;
-shadow_outer_variables (Some 1) [ "foo"; "bar" ];;
-[%%expect{|
-- : string = "bar"
-|}];;
-shadow_outer_variables (Some 2) [ "foo"; "bar" ];;
-[%%expect{|
-- : string = "Not found"
-|}]
-
-(* Test inward propagation of GADT type information. *)
-
-type ('a, 'b) eq = Eq : ('a, 'a) eq
-[%%expect{|
-type ('a, 'b) eq = Eq : ('a, 'a) eq
-|}];;
-
-let in_pattern_guard (type a b) (eq : (a, b) eq) (compare : a -> a -> int)
-                     (x : a) (y : b) =
-  match eq with
-    | Eq when compare x y match 0 -> true
-    | _ -> false
-[%%expect{|
-val in_pattern_guard : ('a, 'b) eq -> ('a -> 'a -> int) -> 'a -> 'b -> bool =
-  <fun>
-|}]
-
-let from_pattern_guard (type a b) (eqs : (a, b) eq option list)
-                       (compare : a -> a -> int) (x : a) (y : b) =
-  match eqs with
-    | eq_opt :: _ when eq_opt match Some Eq -> compare x y
-    | _ -> 0
-[%%expect{|
-val from_pattern_guard :
-  ('a, 'b) eq option list -> ('a -> 'a -> int) -> 'a -> 'b -> int = <fun>
-|}]
-
-type void = |
-[%%expect{|
-type void = |
-|}];;
-
-(* Ensure that warning 73 is appropriately issued. *)
-let exhaustive_pattern_guards (x : (unit, void option) Either.t) : int =
-  match x with
-    | Left u when u match () -> 0
-    | Right v when v match None -> 1
-    | _ -> 2
-;;
-[%%expect{|
-Line 3, characters 13-33:
-3 |     | Left u when u match () -> 0
-                 ^^^^^^^^^^^^^^^^^^^^
-Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
-Line 4, characters 14-36:
-4 |     | Right v when v match None -> 1
-                  ^^^^^^^^^^^^^^^^^^^^^^
-Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
-val exhaustive_pattern_guards : (unit, void option) Either.t -> int = <fun>
-|}];;
-
-exhaustive_pattern_guards (Left ());;
-[%%expect{|
-- : int = 0
-|}];;
-exhaustive_pattern_guards (Right None);;
-[%%expect{|
-- : int = 1
-|}];;
-
-let prove_false () : void = failwith "qed";;
-
-let guard_matching_empty_variant = function
-  | None when prove_false () match exception (Failure str) -> "failed: " ^ str
-  | None -> "proved false!"
-  | Some x -> x
-;;
-[%%expect{|
-val prove_false : unit -> void = <fun>
-val guard_matching_empty_variant : string option -> string = <fun>
-|}];;
-
-guard_matching_empty_variant None;;
-[%%expect{|
-- : string = "failed: qed"
-|}];;
-guard_matching_empty_variant (Some "foo");;
-[%%expect{|
-- : string = "foo"
-|}]
-
-(* Test rejection of pattern guards on mixed exception/value or-patterns *)
-let reject_guarded_val_exn_orp k =
-  match k () with
-  | Some s | exception Failure s when s match "foo" -> s
-  | _ -> "Not foo"
-;;
-[%%expect{|
-Line 3, characters 4-32:
-3 |   | Some s | exception Failure s when s match "foo" -> s
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Mixing value and exception patterns under when-guards is not supported.
-|}];;
-
-(* Test rejection of pattern guards on mixed exception/value or-patterns *)
-let reject_guarded_val_exn_orp k =
-  match k () with
-  | Some s | exception Failure s when s match "foo" -> s
-  | _ -> "Not foo"
-;;
-[%%expect{|
-Line 3, characters 4-32:
-3 |   | Some s | exception Failure s when s match "foo" -> s
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Mixing value and exception patterns under when-guards is not supported.
-|}];;
+(* Correctness test for pattern guard with interesting scrutinee. *)
 
 module M : sig
   type 'a t
 
   val empty : 'a t
   val add : int -> 'a -> 'a t -> 'a t
-  val find : int -> 'a t -> 'a
   val find_opt : int -> 'a t -> 'a option
 end = Map.Make (Int);;
 [%%expect{|
@@ -325,12 +53,10 @@ module M :
     type 'a t
     val empty : 'a t
     val add : int -> 'a -> 'a t -> 'a t
-    val find : int -> 'a t -> 'a
     val find_opt : int -> 'a t -> 'a option
   end
 |}];;
 
-(* Correctness test for pattern guard matching and failure. *)
 let say_hello (id : int option) (name_map : string M.t) =
   match id with
     | Some id when M.find_opt id name_map match Some name -> "Hello, " ^ name
@@ -362,198 +88,7 @@ say_hello None name_map;;
 - : string = "Hello, stranger"
 |}]
 
-(* Correctness test for pattern guards with mixed value and exception
-   patterns. *)
-let say_hello_catching_exns id name_map =
-  match id with
-    | Some id when M.find id name_map match "Barney" | exception _ ->
-        "Hello, Barney"
-    | None | Some _ -> "Hello, Fred"
-;;
-[%%expect{|
-val say_hello_catching_exns : int option -> string M.t -> string = <fun>
-|}];;
-
-say_hello_catching_exns (Some 0) name_map;;
-[%%expect{|
-- : string = "Hello, Fred"
-|}];;
-say_hello_catching_exns (Some 2) name_map;;
-[%%expect{|
-- : string = "Hello, Barney"
-|}];;
-say_hello_catching_exns (Some 4) name_map;;
-[%%expect{|
-- : string = "Hello, Barney"
-|}];;
-say_hello_catching_exns None name_map;;
-[%%expect{|
-- : string = "Hello, Fred"
-|}]
-
-(* Ensure that Match_failure is raised when all cases, including pattern-guarded
-   ones, fail to match. *)
-let patch_to_match_failure f default x =
-  match x with
-  | None -> default
-  | Some x when f x match Some y -> y
-;;
-[%%expect{|
-Lines 2-4, characters 2-37:
-2 | ..match x with
-3 |   | None -> default
-4 |   | Some x when f x match Some y -> y
-Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some _
-(However, some guarded clause may match this value.)
-val patch_to_match_failure : ('a -> 'b option) -> 'b -> 'a option -> 'b =
-  <fun>
-|}];;
-
-let exact_half n = if n mod 2 = 0 then Some (n / 2) else None;;
-[%%expect{|
-val exact_half : int -> int option = <fun>
-|}];;
-
-patch_to_match_failure exact_half ~-1 None;;
-[%%expect{|
-- : int = -1
-|}];;
-patch_to_match_failure exact_half ~-1 (Some 42);;
-[%%expect{|
-- : int = 21
-|}];;
-patch_to_match_failure exact_half ~-1 (Some 41);;
-[%%expect{|
-Exception: Match_failure ("", 2, 2).
-|}];;
-
-(* Ensure that warning 8 is issued appropriately in the presence of pattern
-   guards. *)
-let warn_partial = function
-  | [] -> 0
-  | xs when List.hd xs match Some y -> y
-;;
-[%%expect{|
-Lines 1-3, characters 19-40:
-1 | ...................function
-2 |   | [] -> 0
-3 |   | xs when List.hd xs match Some y -> y
-Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-_::_
-(However, some guarded clause may match this value.)
-val warn_partial : int option list -> int = <fun>
-|}];;
-
-(* Ensure that warning 57 is appropriately issued for pattern guards. *)
-let warn_ambiguous = function
-  | ([ x ], _) | (_, [ x ]) when (let one = 1 in Int.abs x + one) match 2 -> 1
-  | _ -> 0
-;;
-[%%expect{|
-Line 2, characters 4-27:
-2 |   | ([ x ], _) | (_, [ x ]) when (let one = 1 in Int.abs x + one) match 2 -> 1
-        ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
-variable x appears in different places in different or-pattern alternatives.
-Only the first match will be used to evaluate the guard expression.
-(See manual section 11.5)
-val warn_ambiguous : int list * int list -> int = <fun>
-|}];;
-
-(* Ensure that warning 57 is not extraneously issued for pattern guards. *)
-let dont_warn_ambiguous = function
-  | ([ x ], _) | (_, [ x ]) when (let one = 1 in one + one) match 2 -> x
-  | _ -> 0
-;;
-[%%expect{|
-val dont_warn_ambiguous : int list * int list -> int = <fun>
-|}]
-
-let single_bar_syntax x =
-  match x with
-  | Some x when x match | Some y -> y
-  | _ -> 0
-;;
-[%%expect{|
-val single_bar_syntax : int option option -> int = <fun>
-|}];;
-
-single_bar_syntax (Some (Some 5));;
-[%%expect{|
-- : int = 5
-|}];;
-single_bar_syntax (Some None);;
-[%%expect{|
-- : int = 0
-|}];;
-single_bar_syntax None;;
-[%%expect{|
-- : int = 0
-|}];;
-
-single_bar_syntax (Some (Some 5));;
-[%%expect{|
-- : int = 5
-|}];;
-single_bar_syntax (Some None);;
-[%%expect{|
-- : int = 0
-|}];;
-single_bar_syntax None;;
-[%%expect{|
-- : int = 0
-|}];;
-
-let nested_singleway f g h ~default = function
-  | Some x
-      when f x match Some y
-      when g y match Some z
-      when h z match Some a ->
-      a
-  | _ -> default
-;;
-
-let collatz = function
-  | 1 -> None
-  | n -> if n mod 2 = 0 then Some (n / 2) else Some (3 * n + 1)
-;;
-
-[%%expect{|
-val nested_singleway :
-  ('a -> 'b option) ->
-  ('b -> 'c option) -> ('c -> 'd option) -> default:'d -> 'a option -> 'd =
-  <fun>
-val collatz : int -> int option = <fun>
-|}];;
-
-nested_singleway collatz collatz collatz ~default:~-1 None;;
-[%%expect{|
-- : int = -1
-|}];;
-nested_singleway collatz collatz collatz ~default:~-1 (Some 1);;
-[%%expect{|
-- : int = -1
-|}];;
-nested_singleway collatz collatz collatz ~default:~-1 (Some 2);;
-[%%expect{|
-- : int = -1
-|}];;
-nested_singleway collatz collatz collatz ~default:~-1 (Some 3);;
-[%%expect{|
-- : int = 16
-|}];;
-nested_singleway collatz collatz collatz ~default:~-1 (Some 4);;
-[%%expect{|
-- : int = -1
-|}];;
-nested_singleway collatz collatz collatz ~default:~-1 (Some 8);;
-[%%expect{|
-- : int = 1
-|}];;
-
+(* Test behavior of typical multiway pattern guard. *)
 let find_multiway ~eq ~flag ~finish ~default = function
   | x :: xs when List.find_opt (fun y -> eq flag y || eq x y) xs match (
       | Some y when eq flag y -> finish flag
@@ -568,13 +103,19 @@ val find_multiway :
 |}];;
 
 let eq n m = (n - m) mod 100 = 0;;
-let flag = 0;;
-let finish n = Int.to_string n;;
-let default = "No match found";;
 [%%expect{|
 val eq : int -> int -> bool = <fun>
+|}];;
+let flag = 0;;
+[%%expect{|
 val flag : int = 0
+|}];;
+let finish n = Int.to_string n;;
+[%%expect{|
 val finish : int -> string = <fun>
+|}];;
+let default = "No match found";;
+[%%expect{|
 val default : string = "No match found"
 |}];;
 
@@ -595,68 +136,9 @@ find_multiway ~eq ~flag ~finish ~default [ 0; 100 ];;
 - : string = "0"
 |}];;
 
-let nested_multiway f g h = function
-  | Some x when f x match (
-      | "foo" when h x -> "foo1"
-      | "bar" when g x match (
-          | [] -> "bar empty"
-          | [ y ] -> "bar singleton " ^ y
-        )
-    )
-  | _ -> "not found"
-;;
-[%%expect{|
-val nested_multiway :
-  ('a -> string) ->
-  ('a -> string list) -> ('a -> bool) -> 'a option -> string = <fun>
-|}];;
-
-let f = function
-  | 0 | 1 -> "foo"
-  | 10 | 100 | 1000 -> "bar"
-  | _ -> "neither"
-;;
-
-let g = function
-  | 10 -> []
-  | 100 -> [ "one" ]
-  | _ -> [ "more"; "than"; "one" ]
-;;
-
-let h x = x = 1;;
-[%%expect{|
-val f : int -> string = <fun>
-val g : int -> string list = <fun>
-val h : int -> bool = <fun>
-|}];;
-
-nested_multiway f g h None;;
-[%%expect{|
-- : string = "not found"
-|}];;
-nested_multiway f g h (Some 0);;
-[%%expect{|
-- : string = "not found"
-|}];;
-nested_multiway f g h (Some 1);;
-[%%expect{|
-- : string = "foo1"
-|}];;
-nested_multiway f g h (Some 10);;
-[%%expect{|
-- : string = "bar empty"
-|}];;
-nested_multiway f g h (Some 100);;
-[%%expect{|
-- : string = "bar singleton one"
-|}];;
-nested_multiway f g h (Some 1000);;
-[%%expect{|
-- : string = "not found"
-|}];;
-
-(* Checks that optional arguments with defaults are correclty bound in the
+(* Checks that optional arguments with defaults are correctly bound in the
    presence of pattern guards. *)
+
 let check_push_defaults g ?(s="hello") = function
   | x when g s match Some t -> t ^ ", " ^ x
   | x -> x

--- a/ocaml/testsuite/tests/pattern-guards/typing.ml
+++ b/ocaml/testsuite/tests/pattern-guards/typing.ml
@@ -1,0 +1,62 @@
+(* TEST
+   * expect *)
+
+(* Test pattern guard typechecking. *)
+
+(* Well-typed pattern guard with complex types. *)
+
+let complex_types (x : int list option) : bool =
+  let strs_opt = match x with
+    | Some [ y ] when y + 1 > 5 -> Some ("foo", "bar")
+    | Some ys when List.length ys match 0 -> Some ("baz", "qux")
+    | Some _ | None -> None
+  in
+  match strs_opt with
+    | Some strs when strs match ("foo", s2) -> String.equal s2 "bar"
+    | Some _ | None -> false
+;;
+[%%expect {|
+val complex_types : int list option -> bool = <fun>
+|}];;
+
+(* Ill-typed pattern in pattern guard. *)
+
+let ill_typed_pattern (x : int list option) : bool =
+  match x with
+    | Some [ y ] when y match None -> true
+    | _ -> false
+[%%expect{|
+Line 3, characters 30-34:
+3 |     | Some [ y ] when y match None -> true
+                                  ^^^^
+Error: This pattern matches values of type 'a option
+       but a pattern was expected which matches values of type int
+|}]
+
+(* Ill-typed usage of pattern guard-bound variables. *)
+
+let ill_typed_pattern_var (x : int list option) : bool =
+  match x with
+    | Some xs when xs match [ y ] -> String.equal y "foo"
+    | _ -> false
+[%%expect{|
+Line 3, characters 50-51:
+3 |     | Some xs when xs match [ y ] -> String.equal y "foo"
+                                                      ^
+Error: This expression has type int but an expression was expected of type
+         String.t = string
+|}];;
+
+(* Test rejection of pattern guards on mixed exception/value or-patterns *)
+
+let reject_guarded_val_exn_orp k =
+  match k () with
+  | Some s | exception Failure s when s match "foo" -> s
+  | _ -> "Not foo"
+;;
+[%%expect{|
+Line 3, characters 4-32:
+3 |   | Some s | exception Failure s when s match "foo" -> s
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Mixing value and exception patterns under when-guards is not supported.
+|}];;

--- a/ocaml/testsuite/tests/pattern-guards/warn.ml
+++ b/ocaml/testsuite/tests/pattern-guards/warn.ml
@@ -70,7 +70,7 @@ warn_ambiguous ([], []);;
 - : int = 0
 |}];;
 
-(* Ensure that warning 57 is not extraneously issued for pattern guards. *)
+(* Ensure that warning 57 is not spuriously issued for pattern guards. *)
 
 let dont_warn_ambiguous = function
   | ([ x ], _) | (_, [ x ]) when (let one = 1 in one + one) match 2 -> x

--- a/ocaml/testsuite/tests/pattern-guards/warn.ml
+++ b/ocaml/testsuite/tests/pattern-guards/warn.ml
@@ -1,0 +1,173 @@
+(* TEST
+   * expect *)
+
+(* Tests that warnings related to pattern guards are appropriately issued. *)
+
+(* Ensure that warning 8 is issued appropriately in the presence of pattern
+   guards. *)
+
+let warn_partial = function
+  | [] -> 0
+  | xs when List.hd xs match Some y -> y
+;;
+[%%expect{|
+Lines 1-3, characters 19-40:
+1 | ...................function
+2 |   | [] -> 0
+3 |   | xs when List.hd xs match Some y -> y
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+_::_
+(However, some guarded clause may match this value.)
+val warn_partial : int option list -> int = <fun>
+|}];;
+
+warn_partial [];;
+[%%expect{|
+- : int = 0
+|}];;
+warn_partial [ Some 1; Some 2; Some 3 ];;
+[%%expect{|
+- : int = 1
+|}];;
+warn_partial [ None; Some 1 ];;
+[%%expect{|
+Exception: Match_failure ("", 1, 19).
+|}];;
+
+(* Ensure that warning 57 is issued when a pattern guard uses an ambiguously
+   bound variable. *)
+
+let warn_ambiguous = function
+  | ([ x ], _) | (_, [ x ]) when (let one = 1 in Int.abs x + one) match 2 -> 1
+  | _ -> 0
+;;
+[%%expect{|
+Line 2, characters 4-27:
+2 |   | ([ x ], _) | (_, [ x ]) when (let one = 1 in Int.abs x + one) match 2 -> 1
+        ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
+variable x appears in different places in different or-pattern alternatives.
+Only the first match will be used to evaluate the guard expression.
+(See manual section 11.5)
+val warn_ambiguous : int list * int list -> int = <fun>
+|}];;
+
+warn_ambiguous ([ 1 ], [ 0 ]);;
+[%%expect{|
+- : int = 1
+|}];;
+warn_ambiguous ([ 0 ], [ 1 ]);;
+[%%expect{|
+- : int = 0
+|}];;
+warn_ambiguous ([], [ 1 ]);;
+[%%expect{|
+- : int = 1
+|}];;
+warn_ambiguous ([], []);;
+[%%expect{|
+- : int = 0
+|}];;
+
+(* Ensure that warning 57 is not extraneously issued for pattern guards. *)
+
+let dont_warn_ambiguous = function
+  | ([ x ], _) | (_, [ x ]) when (let one = 1 in one + one) match 2 -> x
+  | _ -> 0
+;;
+[%%expect{|
+val dont_warn_ambiguous : int list * int list -> int = <fun>
+|}];;
+
+dont_warn_ambiguous ([ 10 ], [ 20 ]);;
+[%%expect{|
+- : int = 10
+|}];;
+dont_warn_ambiguous ([], [ 20 ]);;
+[%%expect{|
+- : int = 20
+|}];;
+dont_warn_ambiguous ([], []);;
+[%%expect{|
+- : int = 0
+|}];;
+
+(* Ensure that warning 57 is issued for nested guards. *)
+
+let warn_ambiguous_nested = function
+  | ([ x ], _, y) | (_, [ x ], y)
+      when y match Some y
+      when x + y match 0 ->
+      1
+  | _ -> 0
+;;
+[%%expect{|
+Line 2, characters 4-33:
+2 |   | ([ x ], _, y) | (_, [ x ], y)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57 [ambiguous-var-in-pattern-guard]: Ambiguous or-pattern variables under guard;
+variable x appears in different places in different or-pattern alternatives.
+Only the first match will be used to evaluate the guard expression.
+(See manual section 11.5)
+val warn_ambiguous_nested : int list * int list * int option -> int = <fun>
+|}];;
+
+warn_ambiguous_nested ([ 1 ], [ 2 ], Some ~-1);;
+[%%expect{|
+- : int = 1
+|}];;
+warn_ambiguous_nested ([ 1 ], [ 2 ], Some ~-2);;
+[%%expect{|
+- : int = 0
+|}];;
+warn_ambiguous_nested ([], [ 2 ], Some ~-2);;
+[%%expect{|
+- : int = 1
+|}];;
+warn_ambiguous_nested ([ 1 ], [ 2 ], None);;
+[%%expect{|
+- : int = 0
+|}];;
+warn_ambiguous_nested ([], [], Some ~-1);;
+[%%expect{|
+- : int = 0
+|}];;
+
+(* Ensure that warning 73 is issued whenever a pattern guard matches totally. *)
+
+let warn_total_guards (x : (unit, int option) Either.t) : int =
+  match x with
+    | Left u when u match () -> 0
+    | Right v when v match (
+        | None -> 1
+        | Some n -> ~-n
+        )
+    | _ -> 2
+;;
+[%%expect{|
+Line 3, characters 13-33:
+3 |     | Left u when u match () -> 0
+                 ^^^^^^^^^^^^^^^^^^^^
+Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
+Lines 4-7, characters 14-9:
+4 | ..............when v match (
+5 |         | None -> 1
+6 |         | Some n -> ~-n
+7 |         )
+Warning 73 [total-match-in-pattern-guard]: This pattern guard matches exhaustively. Consider rewriting the guard as a nested match.
+val warn_total_guards : (unit, int option) Either.t -> int = <fun>
+|}];;
+
+warn_total_guards (Left ());;
+[%%expect{|
+- : int = 0
+|}];;
+warn_total_guards (Right None);;
+[%%expect{|
+- : int = 1
+|}];;
+warn_total_guards (Right (Some 1));;
+[%%expect{|
+- : int = -1
+|}];;


### PR DESCRIPTION
Splits up and documents the tests for pattern guards.

The pattern guard tests were getting too big to be kept in one file, and their intent wasn't always clear.

This PR makes the test suite clearer by splitting into multiple files, grouping tests by what features they test. It also adds top-level and per-test comments in these files to show the purpose of each test. Some tests were found to be duplicated, which were removed.