### PR TITLE
Allow unboxing to detect and delete dead code

### DIFF
--- a/middle_end/flambda2/simplify/apply_cont_rewrite.ml
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.ml
@@ -26,7 +26,7 @@ type used =
 type t =
   { original_params_usage : used list;
     extra_params_usage : used list;
-    extra_args : EA.t list Id.Map.t;
+    extra_args : EA.t list Or_invalid.t Id.Map.t;
     original_params : Bound_parameters.t;
     extra_params : Bound_parameters.t
   }
@@ -54,8 +54,8 @@ let [@ocamlformat "disable"] print ppf
       )@]"
     print_params_used (original_params, original_params_usage)
     print_params_used (extra_params, extra_params_usage)
-    (Id.Map.print
-       (Format.pp_print_list ~pp_sep:Format.pp_print_space EA.print))
+    (Id.Map.print (Or_invalid.print
+       (Format.pp_print_list ~pp_sep:Format.pp_print_space EA.print)))
     extra_args
 
 let does_nothing t =
@@ -145,92 +145,96 @@ let extra_args_list rewrite id =
   try Id.Map.find id rewrite.extra_args
   with Not_found -> (
     match rewrite.extra_params_usage with
-    | [] -> []
+    | [] -> Or_invalid.Ok []
     | _ :: _ ->
       Misc.fatal_errorf
         "Apply_cont_rewrite.extra_args_list:@ Could not find extra args but \
          extra params were not empty")
 
-let make_rewrite rewrite ~ctx id args =
+let make_rewrite rewrite ~ctx id args : _ Or_invalid.t =
   let invariant_args, args =
     partition_used args rewrite.original_params_usage
   in
-  let extra_args_list = extra_args_list rewrite id in
-  let extra_invariant_args_rev, extra_args_rev, extra_lets, _ =
-    List.fold_left2
-      (fun ( extra_invariant_args_rev,
-             extra_args_rev,
-             extra_lets,
-             required_by_other_extra_args ) (arg : EA.t) used ->
-        (* Some extra_args computation can depend on other extra args. But those
-           required extra args might not be needed as argument to the
-           continuation. But we want to keep the let bindings.
-           [required_by_other_extra_args] tracks that dependency. It is the set
-           of free variables of [extra_args_rev] and
-           [extra_invariant_args_rev] *)
-        let extra_arg, extra_let, free_names, defined_names =
-          match arg with
-          | Already_in_scope simple ->
-            simple, [], Simple.free_names simple, Name_occurrences.empty
-          | New_let_binding (temp, prim) ->
-            let extra_let =
-              ( Bound_var.create temp Name_mode.normal,
-                Code_size.prim prim,
-                Flambda.Named.create_prim prim Debuginfo.none )
-            in
-            ( Simple.var temp,
-              [extra_let],
-              Flambda_primitive.free_names prim,
-              Name_occurrences.singleton_variable temp Name_mode.normal )
-          | New_let_binding_with_named_args (temp, gen_prim) ->
-            let prim =
-              match (ctx : rewrite_apply_cont_ctx) with
-              | Apply_expr function_return_values ->
-                gen_prim function_return_values
-              | Apply_cont ->
-                Misc.fatal_errorf
-                  "Apply_cont rewrites should not need to name arguments, \
-                   since they are already named."
-            in
-            let extra_let =
-              ( Bound_var.create temp Name_mode.normal,
-                Code_size.prim prim,
-                Flambda.Named.create_prim prim Debuginfo.none )
-            in
-            ( Simple.var temp,
-              [extra_let],
-              Flambda_primitive.free_names prim,
-              Name_occurrences.singleton_variable temp Name_mode.normal )
-        in
-        let required_let, extra_invariant_args_rev, extra_args_rev =
-          match used with
-          | Used -> true, extra_invariant_args_rev, extra_arg :: extra_args_rev
-          | Used_as_invariant ->
-            true, extra_arg :: extra_invariant_args_rev, extra_args_rev
-          | Unused ->
-            ( Name_occurrences.inter_domain_is_non_empty defined_names
-                required_by_other_extra_args,
-              extra_invariant_args_rev,
-              extra_args_rev )
-        in
-        if required_let
-        then
-          ( extra_invariant_args_rev,
-            extra_args_rev,
-            extra_let @ extra_lets,
-            Name_occurrences.union free_names required_by_other_extra_args )
-        else
-          ( extra_invariant_args_rev,
-            extra_args_rev,
-            extra_lets,
-            required_by_other_extra_args ))
-      ([], [], [], Name_occurrences.empty)
-      extra_args_list rewrite.extra_params_usage
-  in
-  ( extra_lets,
-    invariant_args
-    @ List.rev_append extra_invariant_args_rev args
-    @ List.rev extra_args_rev )
+  match extra_args_list rewrite id with
+  | Or_invalid.Invalid -> Invalid
+  | Or_invalid.Ok extra_args_list ->
+    let extra_invariant_args_rev, extra_args_rev, extra_lets, _ =
+      List.fold_left2
+        (fun ( extra_invariant_args_rev,
+               extra_args_rev,
+               extra_lets,
+               required_by_other_extra_args ) (arg : EA.t) used ->
+          (* Some extra_args computation can depend on other extra args. But
+             those required extra args might not be needed as argument to the
+             continuation. But we want to keep the let bindings.
+             [required_by_other_extra_args] tracks that dependency. It is the
+             set of free variables of [extra_args_rev] and
+             [extra_invariant_args_rev] *)
+          let extra_arg, extra_let, free_names, defined_names =
+            match arg with
+            | Already_in_scope simple ->
+              simple, [], Simple.free_names simple, Name_occurrences.empty
+            | New_let_binding (temp, prim) ->
+              let extra_let =
+                ( Bound_var.create temp Name_mode.normal,
+                  Code_size.prim prim,
+                  Flambda.Named.create_prim prim Debuginfo.none )
+              in
+              ( Simple.var temp,
+                [extra_let],
+                Flambda_primitive.free_names prim,
+                Name_occurrences.singleton_variable temp Name_mode.normal )
+            | New_let_binding_with_named_args (temp, gen_prim) ->
+              let prim =
+                match (ctx : rewrite_apply_cont_ctx) with
+                | Apply_expr function_return_values ->
+                  gen_prim function_return_values
+                | Apply_cont ->
+                  Misc.fatal_errorf
+                    "Apply_cont rewrites should not need to name arguments, \
+                     since they are already named."
+              in
+              let extra_let =
+                ( Bound_var.create temp Name_mode.normal,
+                  Code_size.prim prim,
+                  Flambda.Named.create_prim prim Debuginfo.none )
+              in
+              ( Simple.var temp,
+                [extra_let],
+                Flambda_primitive.free_names prim,
+                Name_occurrences.singleton_variable temp Name_mode.normal )
+          in
+          let required_let, extra_invariant_args_rev, extra_args_rev =
+            match used with
+            | Used ->
+              true, extra_invariant_args_rev, extra_arg :: extra_args_rev
+            | Used_as_invariant ->
+              true, extra_arg :: extra_invariant_args_rev, extra_args_rev
+            | Unused ->
+              ( Name_occurrences.inter_domain_is_non_empty defined_names
+                  required_by_other_extra_args,
+                extra_invariant_args_rev,
+                extra_args_rev )
+          in
+          if required_let
+          then
+            ( extra_invariant_args_rev,
+              extra_args_rev,
+              extra_let @ extra_lets,
+              Name_occurrences.union free_names required_by_other_extra_args )
+          else
+            ( extra_invariant_args_rev,
+              extra_args_rev,
+              extra_lets,
+              required_by_other_extra_args ))
+        ([], [], [], Name_occurrences.empty)
+        extra_args_list rewrite.extra_params_usage
+    in
+    Ok
+      ( extra_lets,
+        invariant_args
+        @ List.rev_append extra_invariant_args_rev args
+        @ List.rev extra_args_rev )
 
 let rewrite_exn_continuation rewrite id exn_cont =
   let exn_cont_arity = Exn_continuation.arity exn_cont in
@@ -266,19 +270,27 @@ let rewrite_exn_continuation rewrite id exn_cont =
   in
   let _, extra_args1 =
     let extra_args_list =
-      List.map2
-        (fun (arg : EA.t) extra_param ->
-          match arg with
-          | Already_in_scope simple -> simple, Bound_parameter.kind extra_param
-          | New_let_binding _ | New_let_binding_with_named_args _ ->
-            (* Note: this is unsupported for now. If we choose to support it in
-               the future, we must take care of not introducing a wrapper
-               continuation, which would come with its own pushtrap/poptrap. *)
-            Misc.fatal_error
-              "[New_let_binding] are currently forbidden for exn continuation \
-               rewrites")
-        (extra_args_list rewrite id)
-        (Bound_parameters.to_list rewrite.extra_params)
+      match extra_args_list rewrite id with
+      | Invalid ->
+        (* CR gbury: This is not supported for now, but adding support for it
+           should be relatively easy and straight-forward *)
+        Misc.fatal_error "[Invalid]"
+      | Ok extra_args_list ->
+        List.map2
+          (fun (arg : EA.t) extra_param ->
+            match arg with
+            | Already_in_scope simple ->
+              simple, Bound_parameter.kind extra_param
+            | New_let_binding _ | New_let_binding_with_named_args _ ->
+              (* Note: this is unsupported for now. If we choose to support it
+                 in the future, we must take care of not introducing a wrapper
+                 continuation, which would come with its own
+                 pushtrap/poptrap. *)
+              Misc.fatal_error
+                "[New_let_binding] are currently forbidden for exn \
+                 continuation rewrites")
+          extra_args_list
+          (Bound_parameters.to_list rewrite.extra_params)
     in
     partition_used extra_args_list rewrite.extra_params_usage
   in

--- a/middle_end/flambda2/simplify/apply_cont_rewrite.ml
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.ml
@@ -274,7 +274,7 @@ let rewrite_exn_continuation rewrite id exn_cont =
       | Invalid ->
         (* CR gbury: This is not supported for now, but adding support for it
            should be relatively easy and straight-forward *)
-        Misc.fatal_error "[Invalid]"
+        Misc.fatal_error "[Invalid] extra args are currently not allowed for exn continuation rewrites"
       | Ok extra_args_list ->
         List.map2
           (fun (arg : EA.t) extra_param ->

--- a/middle_end/flambda2/simplify/apply_cont_rewrite.ml
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.ml
@@ -274,7 +274,9 @@ let rewrite_exn_continuation rewrite id exn_cont =
       | Invalid ->
         (* CR gbury: This is not supported for now, but adding support for it
            should be relatively easy and straight-forward *)
-        Misc.fatal_error "[Invalid] extra args are currently not allowed for exn continuation rewrites"
+        Misc.fatal_error
+          "[Invalid] extra args are currently not allowed for exn continuation \
+           rewrites"
       | Ok extra_args_list ->
         List.map2
           (fun (arg : EA.t) extra_param ->

--- a/middle_end/flambda2/simplify/apply_cont_rewrite.mli
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.mli
@@ -53,7 +53,8 @@ val make_rewrite :
   ctx:rewrite_apply_cont_ctx ->
   Apply_cont_rewrite_id.t ->
   Simple.t list ->
-  (Bound_var.t * Code_size.t * Flambda.Named.t) list * Simple.t list
+  ((Bound_var.t * Code_size.t * Flambda.Named.t) list * Simple.t list)
+  Or_invalid.t
 
 val rewrite_exn_continuation :
   t -> Apply_cont_rewrite_id.t -> Exn_continuation.t -> Exn_continuation.t

--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -133,31 +133,31 @@ let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
         | Empty -> fun arg -> find_param arg params
         | Non_empty { extra_args; extra_params } -> (
           match RI.Map.find id extra_args with
-            | Invalid -> fun _arg -> None
-            | Ok extra_args ->
-          let rec find_name simple params args =
-            match args, params with
-            | [], [] -> None
-            | [], _ | _, [] ->
-              Misc.fatal_error "Mismatching params and args arity"
-            | arg :: args, param :: params -> (
-              match (arg : EA.t) with
-              | Already_in_scope arg when Simple.equal arg simple ->
-                (* If [param] has an extra equation associated to it, we
-                   shouldn't propagate equations on it as it will mess with the
-                   application of constraints later *)
-                if Name.Map.mem (BP.name param) extra_equations
-                then None
-                else Some (BP.simple param)
-              | Already_in_scope _ | New_let_binding _
-              | New_let_binding_with_named_args _ ->
-                find_name simple params args)
-          in
-          fun arg ->
-            match find_param arg params with
-            | None ->
-              find_name arg (Bound_parameters.to_list extra_params) extra_args
-            | Some _ as r -> r)
+          | Invalid -> fun _arg -> None
+          | Ok extra_args -> (
+            let rec find_name simple params args =
+              match args, params with
+              | [], [] -> None
+              | [], _ | _, [] ->
+                Misc.fatal_error "Mismatching params and args arity"
+              | arg :: args, param :: params -> (
+                match (arg : EA.t) with
+                | Already_in_scope arg when Simple.equal arg simple ->
+                  (* If [param] has an extra equation associated to it, we
+                     shouldn't propagate equations on it as it will mess with
+                     the application of constraints later *)
+                  if Name.Map.mem (BP.name param) extra_equations
+                  then None
+                  else Some (BP.simple param)
+                | Already_in_scope _ | New_let_binding _
+                | New_let_binding_with_named_args _ ->
+                  find_name simple params args)
+            in
+            fun arg ->
+              match find_param arg params with
+              | None ->
+                find_name arg (Bound_parameters.to_list extra_params) extra_args
+              | Some _ as r -> r))
       in
       EP.Map.fold
         (fun prim bound_to eligible ->

--- a/middle_end/flambda2/simplify/continuation_extra_params_and_args.ml
+++ b/middle_end/flambda2/simplify/continuation_extra_params_and_args.ml
@@ -47,7 +47,7 @@ type t =
   | Empty
   | Non_empty of
       { extra_params : Bound_parameters.t;
-        extra_args : Extra_arg.t list Apply_cont_rewrite_id.Map.t
+        extra_args : Extra_arg.t list Or_invalid.t Apply_cont_rewrite_id.Map.t
       }
 
 let [@ocamlformat "disable"] print ppf = function
@@ -58,22 +58,39 @@ let [@ocamlformat "disable"] print ppf = function
         @[<hov 1>(extra_args@ %a)@]\
         )@]"
       Bound_parameters.print extra_params
-      (Apply_cont_rewrite_id.Map.print Extra_arg.List.print) extra_args
+      (Apply_cont_rewrite_id.Map.print (Or_invalid.print Extra_arg.List.print)) extra_args
 
 let empty = Empty
 
 let is_empty = function Empty -> true | Non_empty _ -> false
 
-let add t ~extra_param ~extra_args =
+let add t ~invalids ~extra_param ~extra_args =
+  if not
+       (Apply_cont_rewrite_id.Set.is_empty
+          (Apply_cont_rewrite_id.Set.inter invalids
+             (Apply_cont_rewrite_id.Map.keys extra_args)))
+  then
+    Misc.fatal_errorf
+      "Broken invariants: when adding an extra param to a continuation, every \
+       Apply_cont_rewrite_id should either have a valid extra arg, or be \
+       invalid, but not both:@ %a@ %a"
+      Apply_cont_rewrite_id.Set.print invalids
+      (Apply_cont_rewrite_id.Map.print Extra_arg.print)
+      extra_args;
   match t with
   | Empty ->
-    Non_empty
-      { extra_params = Bound_parameters.create [extra_param];
-        extra_args =
-          Apply_cont_rewrite_id.Map.map
-            (fun extra_args -> [extra_args])
-            extra_args
-      }
+    let extra_params = Bound_parameters.create [extra_param] in
+    let valid_extra_args =
+      Apply_cont_rewrite_id.Map.map
+        (fun extra_args -> Or_invalid.Ok [extra_args])
+        extra_args
+    in
+    let extra_args =
+      Apply_cont_rewrite_id.Set.fold
+        (fun id map -> Apply_cont_rewrite_id.Map.add id Or_invalid.Invalid map)
+        invalids valid_extra_args
+    in
+    Non_empty { extra_params; extra_args }
   | Non_empty { extra_params; extra_args = already_extra_args } ->
     let extra_params = Bound_parameters.cons extra_param extra_params in
     let extra_args =
@@ -81,12 +98,18 @@ let add t ~extra_param ~extra_args =
         (fun id already_extra_args extra_args ->
           match already_extra_args, extra_args with
           | None, None -> None
-          | Some l, None ->
-            Misc.fatal_errorf "Cannot change domain (1) %a %i"
-              Apply_cont_rewrite_id.print id (List.length l)
-          | None, Some _ -> Misc.fatal_error "Cannot change domain"
-          | Some already_extra_args, Some extra_arg ->
-            Some (extra_arg :: already_extra_args))
+          | None, Some _ ->
+            Misc.fatal_errorf "Cannot change domain: %a"
+              Apply_cont_rewrite_id.print id
+          | Some _, None ->
+            if Apply_cont_rewrite_id.Set.mem id invalids
+            then Some Or_invalid.Invalid
+            else
+              Misc.fatal_errorf "Cannot change domain: %a"
+                Apply_cont_rewrite_id.print id
+          | Some Or_invalid.Invalid, Some _ -> Some Or_invalid.Invalid
+          | Some (Or_invalid.Ok already_extra_args), Some extra_arg ->
+            Some (Or_invalid.Ok (extra_arg :: already_extra_args)))
         already_extra_args extra_args
     in
     Non_empty { extra_params; extra_args }
@@ -108,8 +131,11 @@ let concat ~outer:t1 ~inner:t2 =
           | Some _, None | None, Some _ ->
             Misc.fatal_errorf "concat: mismatching domains on id %a"
               Apply_cont_rewrite_id.print id
-          | Some extra_args1, Some extra_args2 ->
-            Some (extra_args1 @ extra_args2))
+          | Some Or_invalid.Invalid, Some _ | Some _, Some Or_invalid.Invalid ->
+            Some Or_invalid.Invalid
+          | Some (Or_invalid.Ok extra_args1), Some (Or_invalid.Ok extra_args2)
+            ->
+            Some (Or_invalid.Ok (extra_args1 @ extra_args2)))
         t1.extra_args t2.extra_args
     in
     Non_empty

--- a/middle_end/flambda2/simplify/continuation_extra_params_and_args.mli
+++ b/middle_end/flambda2/simplify/continuation_extra_params_and_args.mli
@@ -34,7 +34,7 @@ type t = private
   | Empty
   | Non_empty of
       { extra_params : Bound_parameters.t;
-        extra_args : Extra_arg.t list Apply_cont_rewrite_id.Map.t
+        extra_args : Extra_arg.t list Or_invalid.t Apply_cont_rewrite_id.Map.t
       }
 
 val print : Format.formatter -> t -> unit
@@ -45,14 +45,16 @@ val is_empty : t -> bool
 
 val add :
   t ->
+  invalids:Apply_cont_rewrite_id.Set.t ->
   extra_param:Bound_parameter.t ->
   extra_args:Extra_arg.t Apply_cont_rewrite_id.Map.t ->
   t
 
 val concat : outer:t -> inner:t -> t
 
-val replace_extra_args : t -> Extra_arg.t list Apply_cont_rewrite_id.Map.t -> t
+val replace_extra_args :
+  t -> Extra_arg.t list Or_invalid.t Apply_cont_rewrite_id.Map.t -> t
 
 val extra_params : t -> Bound_parameters.t
 
-val extra_args : t -> Extra_arg.t list Apply_cont_rewrite_id.Map.t
+val extra_args : t -> Extra_arg.t list Or_invalid.t Apply_cont_rewrite_id.Map.t

--- a/middle_end/flambda2/simplify/expr_builder.mli
+++ b/middle_end/flambda2/simplify/expr_builder.mli
@@ -110,6 +110,7 @@ val rebuild_invalid :
 (** Handling of the rewriting of continuation use sites. *)
 
 type rewrite_apply_cont_result = private
+  | Invalid of { message : string }
   | Apply_cont of Apply_cont.t
   | Expr of
       (apply_cont_to_expr:
@@ -117,6 +118,7 @@ type rewrite_apply_cont_result = private
       Rebuilt_expr.t * Cost_metrics.t * Name_occurrences.t)
 
 type rewrite_switch_arm_result = private
+  | Invalid of { message : string }
   | Apply_cont of Apply_cont.t
   | New_wrapper of new_let_cont
 

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
@@ -664,7 +664,8 @@ let add_to_extra_params_and_args result =
             let epa_for_cont =
               List.fold_left2
                 (fun epa_for_cont extra_param extra_args ->
-                  EPA.add epa_for_cont ~extra_param ~extra_args)
+                  EPA.add epa_for_cont ~extra_param ~extra_args
+                    ~invalids:Apply_cont_rewrite_id.Set.empty)
                 epa_for_cont extra_params extra_args
             in
             Some epa_for_cont)

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -34,42 +34,38 @@ let introduce_extra_params_for_join typing_env use_envs_with_ids
       TE.add_definitions_of_params typing_env ~params:extra_params
     in
     let use_envs_with_ids =
-      List.map
+      List.filter_map
         (fun (env_at_use, use_id, kind) ->
           let env_at_use =
             TE.add_definitions_of_params env_at_use ~params:extra_params
           in
-          let extra_args =
-            match
-              Apply_cont_rewrite_id.Map.find use_id
-                (EPA.extra_args extra_params_and_args)
-            with
-            | Ok extra_args -> extra_args
-            | Invalid ->
-              (* CR gbury: ask @vlaviron what to do here *)
-              assert false
-            | exception Not_found ->
-              Misc.fatal_errorf
-                "No extra args for rewrite Id %a@.Extra params and args: %a"
-                Apply_cont_rewrite_id.print use_id EPA.print
-                extra_params_and_args
-          in
-          let env_at_use =
-            List.fold_left2
-              (fun env_at_use param (arg : EPA.Extra_arg.t) ->
-                match arg with
-                | Already_in_scope s ->
-                  TE.add_equation env_at_use (BP.name param)
-                    (T.alias_type_of
-                       (BP.kind param |> Flambda_kind.With_subkind.kind)
-                       s)
-                | New_let_binding _ | New_let_binding_with_named_args _ ->
-                  env_at_use)
-              env_at_use
-              (Bound_parameters.to_list extra_params)
-              extra_args
-          in
-          env_at_use, use_id, kind)
+          match
+            Apply_cont_rewrite_id.Map.find use_id
+              (EPA.extra_args extra_params_and_args)
+          with
+          | exception Not_found ->
+            Misc.fatal_errorf
+              "No extra args for rewrite Id %a@.Extra params and args: %a"
+              Apply_cont_rewrite_id.print use_id EPA.print
+              extra_params_and_args
+          | Invalid -> None
+          | Ok extra_args ->
+            let env_at_use =
+              List.fold_left2
+                (fun env_at_use param (arg : EPA.Extra_arg.t) ->
+                   match arg with
+                   | Already_in_scope s ->
+                     TE.add_equation env_at_use (BP.name param)
+                       (T.alias_type_of
+                          (BP.kind param |> Flambda_kind.With_subkind.kind)
+                          s)
+                   | New_let_binding _ | New_let_binding_with_named_args _ ->
+                     env_at_use)
+                env_at_use
+                (Bound_parameters.to_list extra_params)
+                extra_args
+            in
+            Some (env_at_use, use_id, kind))
         use_envs_with_ids
     in
     typing_env, use_envs_with_ids

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -46,21 +46,20 @@ let introduce_extra_params_for_join typing_env use_envs_with_ids
           | exception Not_found ->
             Misc.fatal_errorf
               "No extra args for rewrite Id %a@.Extra params and args: %a"
-              Apply_cont_rewrite_id.print use_id EPA.print
-              extra_params_and_args
+              Apply_cont_rewrite_id.print use_id EPA.print extra_params_and_args
           | Invalid -> None
           | Ok extra_args ->
             let env_at_use =
               List.fold_left2
                 (fun env_at_use param (arg : EPA.Extra_arg.t) ->
-                   match arg with
-                   | Already_in_scope s ->
-                     TE.add_equation env_at_use (BP.name param)
-                       (T.alias_type_of
-                          (BP.kind param |> Flambda_kind.With_subkind.kind)
-                          s)
-                   | New_let_binding _ | New_let_binding_with_named_args _ ->
-                     env_at_use)
+                  match arg with
+                  | Already_in_scope s ->
+                    TE.add_equation env_at_use (BP.name param)
+                      (T.alias_type_of
+                         (BP.kind param |> Flambda_kind.With_subkind.kind)
+                         s)
+                  | New_let_binding _ | New_let_binding_with_named_args _ ->
+                    env_at_use)
                 env_at_use
                 (Bound_parameters.to_list extra_params)
                 extra_args

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -40,10 +40,15 @@ let introduce_extra_params_for_join typing_env use_envs_with_ids
             TE.add_definitions_of_params env_at_use ~params:extra_params
           in
           let extra_args =
-            try
+            match
               Apply_cont_rewrite_id.Map.find use_id
                 (EPA.extra_args extra_params_and_args)
-            with Not_found ->
+            with
+            | Ok extra_args -> extra_args
+            | Invalid ->
+              (* CR gbury: ask @vlaviron what to do here *)
+              assert false
+            | exception Not_found ->
               Misc.fatal_errorf
                 "No extra args for rewrite Id %a@.Extra params and args: %a"
                 Apply_cont_rewrite_id.print use_id EPA.print

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -91,6 +91,10 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
     in
     let expr, cost_metrics, free_names =
       match rewrite_use_result with
+      | Invalid { message } ->
+        ( RE.create_invalid (Message message),
+          Cost_metrics.zero,
+          Name_occurrences.empty )
       | Apply_cont apply_cont -> apply_cont_to_expr apply_cont
       | Expr build_expr -> build_expr ~apply_cont_to_expr
     in

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -220,7 +220,9 @@ let extra_params_for_continuation_param_aliases cont uacc rewrite_ids =
           (Variable.Map.find var aliases_kind)
           Anything
       in
-      EPA.add ~extra_param:(Bound_parameter.create var var_kind) ~extra_args epa)
+      EPA.add
+        ~extra_param:(Bound_parameter.create var var_kind)
+        ~extra_args epa ~invalids:Apply_cont_rewrite_id.Set.empty)
     required_extra_args.extra_args_for_aliases EPA.empty
 
 let add_extra_params_for_mutable_unboxing cont uacc extra_params_and_args =
@@ -847,12 +849,13 @@ let create_handler_to_rebuild
         with
         | extra_args -> extra_args
         | exception Not_found ->
-          List.map
-            (fun param ->
-              EPA.Extra_arg.Already_in_scope
-                (Simple.var (Bound_parameter.var param)))
-            (Bound_parameters.to_list
-               (EPA.extra_params data.invariant_extra_params_and_args)))
+          Or_invalid.Ok
+            (List.map
+               (fun param ->
+                 EPA.Extra_arg.Already_in_scope
+                   (Simple.var (Bound_parameter.var param)))
+               (Bound_parameters.to_list
+                  (EPA.extra_params data.invariant_extra_params_and_args))))
       use_ids
   in
   let invariant_epa =

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -71,6 +71,9 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
       action
   in
   match EB.rewrite_switch_arm uacc action ~use_id arity with
+  | Invalid _ ->
+    (* The destination is unreachable; delete the [Switch] arm. *)
+    new_let_conts, arms, mergeable_arms, identity_arms, not_arms
   | Apply_cont action -> (
     let action =
       let cont = Apply_cont.continuation action in

--- a/middle_end/flambda2/simplify/unboxing/unbox_continuation_params.ml
+++ b/middle_end/flambda2/simplify/unboxing/unbox_continuation_params.ml
@@ -18,31 +18,39 @@ open! Simplify_import
 module U = Unboxing_types
 module Decisions = U.Decisions
 
-let refine_decision_based_on_arg_types_at_uses ~pass ~rewrite_ids_seen nth_arg
-    arg_type_by_use_id (decision : U.decision) =
+let refine_decision_based_on_arg_types_at_uses ~pass ~rewrite_ids_seen
+    ~rewrite_ids_invalid nth_arg arg_type_by_use_id (decision : U.decision) =
   match decision with
-  | Do_not_unbox _ as decision -> decision
+  | Do_not_unbox _ as decision -> decision, Apply_cont_rewrite_id.Set.empty
   | Unbox _ as decision ->
     Apply_cont_rewrite_id.Map.fold
-      (fun rewrite_id (arg_at_use : Continuation_uses.arg_at_use) decision ->
+      (fun rewrite_id (arg_at_use : Continuation_uses.arg_at_use)
+           (decision, invalids) ->
         if Apply_cont_rewrite_id.Set.mem rewrite_id rewrite_ids_seen
-        then decision
+           || Apply_cont_rewrite_id.Set.mem rewrite_id rewrite_ids_invalid
+        then decision, invalids
         else
           let typing_env_at_use = arg_at_use.typing_env in
           let arg_type_at_use = arg_at_use.arg_type in
-          match
-            TE.get_alias_then_canonical_simple_exn typing_env_at_use
-              ~min_name_mode:Name_mode.normal arg_type_at_use
-          with
-          | simple ->
-            Unboxing_epa.compute_extra_args_for_one_decision_and_use ~pass
-              rewrite_id ~typing_env_at_use (Available simple) decision
-          | exception Not_found ->
-            Unboxing_epa.compute_extra_args_for_one_decision_and_use ~pass
-              rewrite_id ~typing_env_at_use
-              (Added_by_wrapper_at_rewrite_use { nth_arg })
-              decision)
-      arg_type_by_use_id decision
+          let unboxed_arg =
+            match
+              TE.get_alias_then_canonical_simple_exn typing_env_at_use
+                ~min_name_mode:Name_mode.normal arg_type_at_use
+            with
+            | simple -> Unboxing_epa.Available simple
+            | exception Not_found ->
+              Unboxing_epa.Added_by_wrapper_at_rewrite_use { nth_arg }
+          in
+          try
+            let decision =
+              Unboxing_epa.compute_extra_args_for_one_decision_and_use ~pass
+                rewrite_id ~typing_env_at_use unboxed_arg decision
+            in
+            decision, invalids
+          with Unboxing_epa.Invalid_apply_cont ->
+            decision, Apply_cont_rewrite_id.Set.add rewrite_id invalids)
+      arg_type_by_use_id
+      (decision, rewrite_ids_invalid)
 
 module List = struct
   include List
@@ -60,7 +68,10 @@ let make_do_not_unbox_decisions params : Decisions.t =
       (fun param -> param, U.Do_not_unbox Unboxing_not_requested)
       (Bound_parameters.to_list params)
   in
-  { decisions; rewrite_ids_seen = Apply_cont_rewrite_id.Set.empty }
+  { decisions;
+    rewrite_ids_seen = Apply_cont_rewrite_id.Set.empty;
+    rewrite_ids_invalid = Apply_cont_rewrite_id.Set.empty
+  }
 
 type continuation_arg_types =
   | Recursive
@@ -76,9 +87,10 @@ let make_decisions ~continuation_arg_types denv params params_types :
     | Non_recursive arg_types_by_use_id -> false, arg_types_by_use_id
   in
   let empty = Apply_cont_rewrite_id.Set.empty in
-  let _, denv, rev_decisions, seen =
+  let _, denv, rev_decisions, seen, invalids =
     List.fold_left3
-      (fun (nth, denv, rev_decisions, seen) param param_type arg_type_by_use_id ->
+      (fun (nth, denv, rev_decisions, seen, invalids) param param_type
+           arg_type_by_use_id ->
         (* Make an optimistic decision, filter it based on the arg types at the
            use sites (to prevent decisions that would be detrimental), and
            compute the necessary denv. *)
@@ -87,7 +99,7 @@ let make_decisions ~continuation_arg_types denv params params_types :
             ~recursive:continuation_is_recursive (DE.typing_env denv)
             ~param_type
         in
-        let decision =
+        let decision, invalids =
           if continuation_is_recursive
           then
             (* For recursive continuation whether unboxing is beneficial or not
@@ -96,11 +108,17 @@ let make_decisions ~continuation_arg_types denv params params_types :
                recursive continuation risk introducing an allocation when
                leaving the loop if the value is unused, while the benefit might
                be great most of the time. *)
-            decision
+            decision, invalids
           else
-            refine_decision_based_on_arg_types_at_uses ~rewrite_ids_seen:empty
-              nth arg_type_by_use_id ~pass:Filter decision
-            |> Is_unboxing_beneficial.filter_non_beneficial_decisions
+            let decision, invalids =
+              refine_decision_based_on_arg_types_at_uses ~rewrite_ids_seen:empty
+                ~rewrite_ids_invalid:invalids nth arg_type_by_use_id
+                ~pass:Filter decision
+            in
+            let decision =
+              Is_unboxing_beneficial.filter_non_beneficial_decisions decision
+            in
+            decision, invalids
         in
         let denv =
           Build_unboxing_denv.denv_of_decision denv ~param_var:(BP.var param)
@@ -122,29 +140,32 @@ let make_decisions ~continuation_arg_types denv params params_types :
               (fun id _ acc -> Apply_cont_rewrite_id.Set.add id acc)
               arg_type_by_use_id empty
         in
-        nth + 1, denv, decision :: rev_decisions, Some seen)
-      (0, denv, [], None) params params_types arg_types_by_use_id
+        nth + 1, denv, decision :: rev_decisions, Some seen, invalids)
+      (0, denv, [], None, Apply_cont_rewrite_id.Set.empty)
+      params params_types arg_types_by_use_id
   in
   let rewrite_ids_seen = match seen with None -> empty | Some s -> s in
   let decisions = List.combine params (List.rev rev_decisions) in
-  denv, { decisions; rewrite_ids_seen }
+  denv, { decisions; rewrite_ids_seen; rewrite_ids_invalid = invalids }
 
 let compute_extra_params_and_args
-    ({ decisions; rewrite_ids_seen } : Decisions.t) ~arg_types_by_use_id
-    existing_extra_params_and_args =
-  let _, extra_params_and_args =
+    ({ decisions; rewrite_ids_seen; rewrite_ids_invalid } : Decisions.t)
+    ~arg_types_by_use_id existing_extra_params_and_args =
+  let _, extra_params_and_args, _ =
     List.fold_left2
-      (fun (nth, extra_params_and_args) arg_type_by_use_id (_, decision) ->
-        let decision =
+      (fun (nth, extra_params_and_args, invalids) arg_type_by_use_id
+           (_, decision) ->
+        let decision, invalids =
           refine_decision_based_on_arg_types_at_uses
-            ~pass:Compute_all_extra_args ~rewrite_ids_seen nth
-            arg_type_by_use_id decision
+            ~pass:Compute_all_extra_args ~rewrite_ids_seen
+            ~rewrite_ids_invalid:invalids nth arg_type_by_use_id decision
         in
         let extra_params_and_args =
-          Unboxing_epa.add_extra_params_and_args extra_params_and_args decision
+          Unboxing_epa.add_extra_params_and_args extra_params_and_args ~invalids
+            decision
         in
-        nth + 1, extra_params_and_args)
-      (0, existing_extra_params_and_args)
+        nth + 1, extra_params_and_args, invalids)
+      (0, existing_extra_params_and_args, rewrite_ids_invalid)
       arg_types_by_use_id decisions
   in
   extra_params_and_args

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -66,7 +66,7 @@ module Float32 = struct
 
   let unboxer =
     { var_name = "unboxed_float32";
-      invalid_const =
+      poison_const =
         Const.naked_float32 Numeric_types.Float32_by_bit_pattern.zero;
       unboxing_prim;
       prove_simple = T.meet_boxed_float32_containing_simple

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -24,7 +24,7 @@ type number_decider =
 
 type unboxer =
   { var_name : string;
-    invalid_const : Const.t;
+    poison_const : Const.t;
     unboxing_prim : Simple.t -> P.t;
     prove_simple :
       TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.meet_shortcut
@@ -49,7 +49,7 @@ module Immediate = struct
 
   let unboxer =
     { var_name = "naked_immediate";
-      invalid_const = Const.naked_immediate (Targetint_31_63.of_int 0xabcd);
+      poison_const = Const.naked_immediate (Targetint_31_63.of_int 0xabcd);
       unboxing_prim;
       prove_simple = T.meet_tagging_of_simple
     }
@@ -84,7 +84,7 @@ module Float = struct
 
   let unboxer =
     { var_name = "unboxed_float";
-      invalid_const = Const.naked_float Numeric_types.Float_by_bit_pattern.zero;
+      poison_const = Const.naked_float Numeric_types.Float_by_bit_pattern.zero;
       unboxing_prim;
       prove_simple = T.meet_boxed_float_containing_simple
     }
@@ -101,7 +101,7 @@ module Int32 = struct
 
   let unboxer =
     { var_name = "unboxed_int32";
-      invalid_const = Const.naked_int32 Int32.(div 0xabcd0l 2l);
+      poison_const = Const.naked_int32 Int32.(div 0xabcd0l 2l);
       unboxing_prim;
       prove_simple = T.meet_boxed_int32_containing_simple
     }
@@ -118,7 +118,7 @@ module Int64 = struct
 
   let unboxer =
     { var_name = "unboxed_int64";
-      invalid_const = Const.naked_int64 Int64.(div 0xdcba0L 2L);
+      poison_const = Const.naked_int64 Int64.(div 0xdcba0L 2L);
       unboxing_prim;
       prove_simple = T.meet_boxed_int64_containing_simple
     }
@@ -135,7 +135,7 @@ module Nativeint = struct
 
   let unboxer =
     { var_name = "unboxed_nativeint";
-      invalid_const = Const.naked_nativeint Targetint_32_64.zero;
+      poison_const = Const.naked_nativeint Targetint_32_64.zero;
       unboxing_prim;
       prove_simple = T.meet_boxed_nativeint_containing_simple
     }
@@ -152,7 +152,7 @@ module Vec128 = struct
 
   let unboxer =
     { var_name = "unboxed_vec128";
-      invalid_const = Const.naked_vec128 Vector_types.Vec128.Bit_pattern.zero;
+      poison_const = Const.naked_vec128 Vector_types.Vec128.Bit_pattern.zero;
       unboxing_prim;
       prove_simple = T.meet_boxed_vec128_containing_simple
     }
@@ -163,9 +163,9 @@ module Field = struct
     let field_const = Simple.const (Const.tagged_immediate index) in
     P.Binary (Block_load (bak, Immutable), block, field_const)
 
-  let unboxer ~invalid_const bak ~index =
+  let unboxer ~poison_const bak ~index =
     { var_name = "field_at_use";
-      invalid_const;
+      poison_const;
       unboxing_prim = (fun block -> unboxing_prim bak ~block ~index);
       prove_simple =
         (fun tenv ~min_name_mode t ->
@@ -182,7 +182,7 @@ module Closure_field = struct
 
   let unboxer function_slot value_slot =
     { var_name = "closure_field_at_use";
-      invalid_const = Const.const_zero;
+      poison_const = Const.const_zero;
       unboxing_prim =
         (fun closure -> unboxing_prim function_slot ~closure value_slot);
       prove_simple =

--- a/middle_end/flambda2/simplify/unboxing/unboxers.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.mli
@@ -24,7 +24,7 @@ type number_decider =
 
 type unboxer =
   { var_name : string;
-    invalid_const : Const.t;
+    poison_const : Const.t;
     unboxing_prim : Simple.t -> P.t;
     prove_simple :
       TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.meet_shortcut
@@ -57,7 +57,7 @@ module Field : sig
     P.Block_access_kind.t -> block:Simple.t -> index:Targetint_31_63.t -> P.t
 
   val unboxer :
-    invalid_const:Const.t ->
+    poison_const:Const.t ->
     P.Block_access_kind.t ->
     index:Targetint_31_63.t ->
     unboxer

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -18,6 +18,8 @@ open! Simplify_import
 module U = Unboxing_types
 module Extra_param_and_args = U.Extra_param_and_args
 
+exception Invalid_apply_cont
+
 exception Prevent_current_unboxing
 
 let prevent_current_unboxing () = raise Prevent_current_unboxing
@@ -47,7 +49,7 @@ let unbox_arg (unboxer : Unboxers.unboxer) ~typing_env_at_use arg_being_unboxed
   match arg_being_unboxed with
   | Poison ->
     let extra_arg =
-      EPA.Extra_arg.Already_in_scope (Simple.const unboxer.invalid_const)
+      EPA.Extra_arg.Already_in_scope (Simple.const unboxer.poison_const)
     in
     extra_arg, Poison
   | Available arg_at_use -> (
@@ -56,13 +58,9 @@ let unbox_arg (unboxer : Unboxers.unboxer) ~typing_env_at_use arg_being_unboxed
       unboxer.prove_simple typing_env_at_use arg_type
         ~min_name_mode:Name_mode.normal
     with
+    | Invalid -> raise Invalid_apply_cont
     | Known_result simple ->
       EPA.Extra_arg.Already_in_scope simple, Available simple
-    | Invalid ->
-      let extra_arg =
-        EPA.Extra_arg.Already_in_scope (Simple.const unboxer.invalid_const)
-      in
-      extra_arg, Poison
     | Need_meet ->
       let var = Variable.create unboxer.var_name in
       let prim = unboxer.unboxing_prim arg_at_use in
@@ -115,18 +113,16 @@ let extra_arg_for_ctor ~typing_env_at_use = function
       with
       | Known_result simple -> EPA.Extra_arg.Already_in_scope simple
       | Need_meet -> prevent_current_unboxing ()
-      | Invalid ->
-        (* [Invalid] this means that we are in an impossible-to-reach case, and
-           thus as in other cases, we only need to provide well-kinded
-           values. *)
-        EPA.Extra_arg.Already_in_scope
-          (Simple.untagged_const_int (Targetint_31_63.of_int 0))))
+      | Invalid -> raise Invalid_apply_cont))
 
 let extra_args_for_const_ctor_of_variant
     (const_ctors_decision : U.const_ctors_decision) ~typing_env_at_use
     rewrite_id variant_arg : U.const_ctors_decision =
   match const_ctors_decision with
-  | Zero -> const_ctors_decision
+  | Zero -> (
+    match variant_arg with
+    | Not_a_constant_constructor -> const_ctors_decision
+    | Maybe_constant_constructor _ -> raise Invalid_apply_cont)
   | At_least_one { ctor = Do_not_unbox reason; is_int } ->
     let is_int =
       Extra_param_and_args.update_param_args is_int rewrite_id
@@ -198,22 +194,17 @@ and compute_extra_args_for_one_decision_and_use_aux ~(pass : U.pass) rewrite_id
   | Unbox
       (Variant { tag; const_ctors = const_ctors_from_decision; fields_by_tag })
     -> (
-    let invalid () =
-      (* Invalid here means that the Apply_cont is unreachable, i.e. the args we
-         generated will never be actually used at runtime, so the values of the
-         args do not matter, they are here to make the kind checker happy. *)
+    match type_of_arg_being_unboxed arg_being_unboxed with
+    | None ->
       compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
         arg_being_unboxed ~tag_from_decision:tag ~const_ctors_from_decision
         ~fields_by_tag_from_decision:fields_by_tag
         ~const_ctors_at_use:(Or_unknown.Known Targetint_31_63.Set.empty)
         ~non_const_ctors_with_sizes_at_use:Tag.Scannable.Map.empty
-    in
-    match type_of_arg_being_unboxed arg_being_unboxed with
-    | None -> invalid ()
     | Some arg_type -> (
       match T.meet_variant_like typing_env_at_use arg_type with
       | Need_meet -> prevent_current_unboxing ()
-      | Invalid -> invalid ()
+      | Invalid -> raise Invalid_apply_cont
       | Known_result { const_ctors; non_const_ctors_with_sizes } ->
         compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
           arg_being_unboxed ~tag_from_decision:tag ~const_ctors_from_decision
@@ -245,7 +236,7 @@ and compute_extra_args_for_one_decision_and_use_aux ~(pass : U.pass) rewrite_id
 and compute_extra_args_for_block ~pass rewrite_id ~typing_env_at_use
     arg_being_unboxed tag fields : U.decision =
   let size = Or_unknown.Known (Targetint_31_63.of_int (List.length fields)) in
-  let bak, invalid_const =
+  let bak, poison_const =
     if Tag.equal tag Tag.double_array_tag
     then
       ( P.Block_access_kind.Naked_floats { size },
@@ -263,7 +254,7 @@ and compute_extra_args_for_block ~pass rewrite_id ~typing_env_at_use
       (fun field_nth ({ epa; decision; kind } : U.field_decision) :
            (_ * U.field_decision) ->
         let unboxer =
-          Unboxers.Field.unboxer ~invalid_const bak ~index:field_nth
+          Unboxers.Field.unboxer ~poison_const bak ~index:field_nth
         in
         let new_extra_arg, new_arg_being_unboxed =
           unbox_arg unboxer ~typing_env_at_use arg_being_unboxed
@@ -354,7 +345,7 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
       (fun tag_decision block_fields ->
         let size = List.length block_fields in
         (* See doc/unboxing.md about invalid constants, poison and aliases. *)
-        let invalid_const = Const.const_int (Targetint_31_63.of_int 0xbaba) in
+        let poison_const = Const.const_int (Targetint_31_63.of_int 0xbaba) in
         let bak : Flambda_primitive.Block_access_kind.t =
           Values
             { size = Known (Targetint_31_63.of_int size);
@@ -371,11 +362,11 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
                    && Tag.Scannable.equal tag_at_use_site tag_decision
                 then
                   let unboxer =
-                    Unboxers.Field.unboxer ~invalid_const bak ~index:field_nth
+                    Unboxers.Field.unboxer ~poison_const bak ~index:field_nth
                   in
                   unbox_arg unboxer ~typing_env_at_use arg_being_unboxed
                 else
-                  ( EPA.Extra_arg.Already_in_scope (Simple.const invalid_const),
+                  ( EPA.Extra_arg.Already_in_scope (Simple.const poison_const),
                     Poison )
               in
               let epa =
@@ -396,7 +387,7 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
   in
   Unbox (Variant { tag; const_ctors; fields_by_tag })
 
-let add_extra_params_and_args extra_params_and_args decision =
+let add_extra_params_and_args extra_params_and_args ~invalids decision =
   let rec aux extra_params_and_args (decision : U.decision) =
     match decision with
     | Do_not_unbox _ -> extra_params_and_args
@@ -405,7 +396,8 @@ let add_extra_params_and_args extra_params_and_args decision =
         (fun extra_params_and_args ({ epa; decision; kind } : U.field_decision) ->
           let extra_param = BP.create epa.param kind in
           let extra_params_and_args =
-            EPA.add extra_params_and_args ~extra_param ~extra_args:epa.args
+            EPA.add extra_params_and_args ~invalids ~extra_param
+              ~extra_args:epa.args
           in
           aux extra_params_and_args decision)
         extra_params_and_args fields
@@ -415,7 +407,8 @@ let add_extra_params_and_args extra_params_and_args decision =
              extra_params_and_args ->
           let extra_param = BP.create epa.param kind in
           let extra_params_and_args =
-            EPA.add extra_params_and_args ~extra_param ~extra_args:epa.args
+            EPA.add extra_params_and_args ~invalids ~extra_param
+              ~extra_args:epa.args
           in
           aux extra_params_and_args decision)
         vars_within_closure extra_params_and_args
@@ -428,7 +421,7 @@ let add_extra_params_and_args extra_params_and_args decision =
                    ({ epa; decision; kind } : U.field_decision) ->
                 let extra_param = BP.create epa.param kind in
                 let extra_params_and_args =
-                  EPA.add extra_params_and_args ~extra_param
+                  EPA.add extra_params_and_args ~invalids ~extra_param
                     ~extra_args:epa.args
                 in
                 aux extra_params_and_args decision)
@@ -442,19 +435,22 @@ let add_extra_params_and_args extra_params_and_args decision =
           let extra_param =
             BP.create is_int.param K.With_subkind.naked_immediate
           in
-          EPA.add extra_params_and_args ~extra_param ~extra_args:is_int.args
+          EPA.add extra_params_and_args ~invalids ~extra_param
+            ~extra_args:is_int.args
         | At_least_one { is_int; ctor = Unbox (Number (Naked_immediate, ctor)) }
           ->
           let extra_param =
             BP.create is_int.param K.With_subkind.naked_immediate
           in
           let extra_params_and_args =
-            EPA.add extra_params_and_args ~extra_param ~extra_args:is_int.args
+            EPA.add extra_params_and_args ~invalids ~extra_param
+              ~extra_args:is_int.args
           in
           let extra_param =
             BP.create ctor.param K.With_subkind.naked_immediate
           in
-          EPA.add extra_params_and_args ~extra_param ~extra_args:ctor.args
+          EPA.add extra_params_and_args ~invalids ~extra_param
+            ~extra_args:ctor.args
         | At_least_one
             { ctor =
                 Unbox
@@ -470,12 +466,12 @@ let add_extra_params_and_args extra_params_and_args decision =
              other than Naked_immediate."
       in
       let extra_param = BP.create tag.param K.With_subkind.naked_immediate in
-      EPA.add extra_params_and_args ~extra_param ~extra_args:tag.args
+      EPA.add extra_params_and_args ~invalids ~extra_param ~extra_args:tag.args
     | Unbox (Number (naked_number_kind, epa)) ->
       let kind_with_subkind =
         K.With_subkind.of_naked_number_kind naked_number_kind
       in
       let extra_param = BP.create epa.param kind_with_subkind in
-      EPA.add extra_params_and_args ~extra_param ~extra_args:epa.args
+      EPA.add extra_params_and_args ~invalids ~extra_param ~extra_args:epa.args
   in
   aux extra_params_and_args decision

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.mli
@@ -17,6 +17,8 @@
 (** Handling of the extra params and args required for the unboxing of a
     continuation's parameter(s). *)
 
+exception Invalid_apply_cont
+
 type unboxed_arg =
   | Poison (* used for recursive calls *)
   | Available of Simple.t
@@ -33,5 +35,6 @@ val compute_extra_args_for_one_decision_and_use :
 
 val add_extra_params_and_args :
   Continuation_extra_params_and_args.t ->
+  invalids:Apply_cont_rewrite_id.Set.t ->
   Unboxing_types.decision ->
   Continuation_extra_params_and_args.t

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
@@ -87,7 +87,7 @@ and decision =
 type decisions =
   { decisions : (BP.t * decision) list;
     rewrite_ids_seen : Apply_cont_rewrite_id.Set.t;
-    rewrite_ids_invalid : Apply_cont_rewrite_id.Set.t
+    rewrites_ids_known_as_invalid : Apply_cont_rewrite_id.Set.t
   }
 
 type pass =
@@ -152,7 +152,7 @@ and print_const_ctor_num ppf = function
       "@[<hov 1>(const_ctors@ @[<hov 1>(is_int@ %a)@]@ @[<hov 1>(ctor@ %a)@])@]"
       Extra_param_and_args.print is_int print_decision ctor
 
-let [@ocamlformat "disable"] print ppf { decisions; rewrite_ids_seen; rewrite_ids_invalid; } =
+let [@ocamlformat "disable"] print ppf { decisions; rewrite_ids_seen; rewrites_ids_known_as_invalid; } =
   let pp_sep = Format.pp_print_space in
   let aux ppf (param, decision) =
     Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
@@ -161,17 +161,17 @@ let [@ocamlformat "disable"] print ppf { decisions; rewrite_ids_seen; rewrite_id
   Format.fprintf ppf "@[<hov 1>(\
     @[<hov 1>(decisions@ %a)@]@ \
     @[<hov 1>(rewrite_ids_seen@ %a)@]@ \
-    @[<hov 1>(rewrite_ids_invalid@ %a)@]\
+    @[<hov 1>(rewrites_ids_known_as_invalid@ %a)@]\
     )@]"
     (Format.pp_print_list ~pp_sep aux) decisions
     Apply_cont_rewrite_id.Set.print rewrite_ids_seen
-    Apply_cont_rewrite_id.Set.print rewrite_ids_invalid
+    Apply_cont_rewrite_id.Set.print rewrites_ids_known_as_invalid
 
 module Decisions = struct
   type t = decisions =
     { decisions : (BP.t * decision) list;
       rewrite_ids_seen : Apply_cont_rewrite_id.Set.t;
-      rewrite_ids_invalid : Apply_cont_rewrite_id.Set.t
+      rewrites_ids_known_as_invalid : Apply_cont_rewrite_id.Set.t
     }
 
   let print = print

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
@@ -86,7 +86,8 @@ and decision =
 
 type decisions =
   { decisions : (BP.t * decision) list;
-    rewrite_ids_seen : Apply_cont_rewrite_id.Set.t
+    rewrite_ids_seen : Apply_cont_rewrite_id.Set.t;
+    rewrite_ids_invalid : Apply_cont_rewrite_id.Set.t
   }
 
 type pass =
@@ -151,7 +152,7 @@ and print_const_ctor_num ppf = function
       "@[<hov 1>(const_ctors@ @[<hov 1>(is_int@ %a)@]@ @[<hov 1>(ctor@ %a)@])@]"
       Extra_param_and_args.print is_int print_decision ctor
 
-let [@ocamlformat "disable"] print ppf { decisions; rewrite_ids_seen; } =
+let [@ocamlformat "disable"] print ppf { decisions; rewrite_ids_seen; rewrite_ids_invalid; } =
   let pp_sep = Format.pp_print_space in
   let aux ppf (param, decision) =
     Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
@@ -159,15 +160,18 @@ let [@ocamlformat "disable"] print ppf { decisions; rewrite_ids_seen; } =
   in
   Format.fprintf ppf "@[<hov 1>(\
     @[<hov 1>(decisions@ %a)@]@ \
-    @[<hov 1>(rewrite_ids_seen@ %a)@]\
+    @[<hov 1>(rewrite_ids_seen@ %a)@]@ \
+    @[<hov 1>(rewrite_ids_invalid@ %a)@]\
     )@]"
     (Format.pp_print_list ~pp_sep aux) decisions
     Apply_cont_rewrite_id.Set.print rewrite_ids_seen
+    Apply_cont_rewrite_id.Set.print rewrite_ids_invalid
 
 module Decisions = struct
   type t = decisions =
     { decisions : (BP.t * decision) list;
-      rewrite_ids_seen : Apply_cont_rewrite_id.Set.t
+      rewrite_ids_seen : Apply_cont_rewrite_id.Set.t;
+      rewrite_ids_invalid : Apply_cont_rewrite_id.Set.t
     }
 
   let print = print

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
@@ -81,7 +81,7 @@ module Decisions : sig
   type t =
     { decisions : (BP.t * decision) list;
       rewrite_ids_seen : Apply_cont_rewrite_id.Set.t;
-      rewrite_ids_invalid : Apply_cont_rewrite_id.Set.t
+      rewrites_ids_known_as_invalid : Apply_cont_rewrite_id.Set.t
     }
 
   val print : Format.formatter -> t -> unit

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
@@ -80,7 +80,8 @@ val print_decision : Format.formatter -> decision -> unit
 module Decisions : sig
   type t =
     { decisions : (BP.t * decision) list;
-      rewrite_ids_seen : Apply_cont_rewrite_id.Set.t
+      rewrite_ids_seen : Apply_cont_rewrite_id.Set.t;
+      rewrite_ids_invalid : Apply_cont_rewrite_id.Set.t
     }
 
   val print : Format.formatter -> t -> unit


### PR DESCRIPTION
This PR contains two changes:
- continuation extra params and args can now record that some apply conts are invalid, and should be thus turned into an `Invalid` when rewriting it (instead of adding params/args)
- the unboxing pass makes use of that new feature to mark some apply_conts as invalid, when unboxing discovers that it is actually invalid, cc @lthls for why and how this happens. Previously, in such cases we would just generate poison values.

This improves on the example from #1578 , and flambda2 is now able to eliminate the dead code of the gadt pattern match after inlining.

@chambart should review to ensure that all of the invalids encountered during unboxing are indeed invalids and not poison situations (and a round of testing on opam packages before merging would be useful).