### PR TITLE
Enable and fix Available_regs

### DIFF
--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*            Mark Shinwell and Thomas Refis, Jane Street Europe          *)
 (*                                                                        *)
-(*   Copyright 2013--2017 Jane Street Group LLC                           *)
+(*   Copyright 2013--2023 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,7 +12,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+[@@@ocaml.warning "+4"]
+
+(* CR mshinwell: We need a Cfg version of this pass. *)
 
 module M = Mach
 module R = Reg
@@ -111,7 +113,7 @@ let check_invariants (instr : M.instruction) ~(avail_before : RAS.t) =
    Recall that some of these may expand into multiple machine instructions
    including clobbers, e.g. for [Ialloc].)
 
-   The [available_before] and [available_across] fields of each instruction is
+   The [available_before] and [available_across] fields of each instruction are
    updated by this function. *)
 let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
   check_invariants instr ~avail_before;
@@ -200,7 +202,14 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         let avail_across = RD.Set.diff avail_before made_unavailable in
         let avail_after = RD.Set.union avail_across (RD.Set.of_array results) in
         Some (ok avail_across), ok avail_after
-      | Iop op ->
+      | Iop
+          (( Icall_ind | Icall_imm _ | Ialloc _ | Ipoll _ | Iprobe _
+           | Iconst_int _ | Iconst_float _ | Iconst_vec128 _ | Iconst_symbol _
+           | Iextcall _ | Istackoffset _ | Iload _ | Istore _ | Iintop _
+           | Iintop_imm _ | Iintop_atomic _ | Icompf _ | Inegf | Iabsf | Iaddf
+           | Isubf | Imulf | Idivf | Icsel _ | Ifloatofint | Iintoffloat
+           | Ivalueofint | Iintofvalue | Iopaque | Ispecific _
+           | Iprobe_is_enabled _ | Ibeginregion | Iendregion ) as op) ->
         (* We split the calculation of registers that become unavailable after a
            call into two parts. First: anything that the target marks as
            destroyed by the operation, combined with any registers that will be
@@ -223,7 +232,7 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
            [Available_ranges.Make_ranges.end_pos_offset]. *)
         let made_unavailable_2 =
           match op with
-          | Icall_ind | Icall_imm _ | Ialloc _ ->
+          | Icall_ind | Icall_imm _ | Ialloc _ | Ipoll _ | Iprobe _ ->
             RD.Set.filter
               (fun reg ->
                 let holds_immediate = RD.holds_non_pointer reg in
@@ -234,7 +243,15 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
                 in
                 not remains_available)
               avail_before
-          | _ -> RD.Set.empty
+          | Imove | Ispill | Ireload | Iconst_int _ | Iconst_float _
+          | Iconst_vec128 _ | Iconst_symbol _ | Itailcall_ind | Itailcall_imm _
+          | Iextcall _ | Istackoffset _ | Iload _ | Istore _ | Iintop _
+          | Iintop_imm _ | Iintop_atomic _ | Icompf _ | Inegf | Iabsf | Iaddf
+          | Isubf | Imulf | Idivf | Icsel _ | Ifloatofint | Iintoffloat
+          | Ivalueofint | Iintofvalue | Iopaque | Ispecific _
+          | Iname_for_debugger _ | Iprobe_is_enabled _ | Ibeginregion
+          | Iendregion ->
+            RD.Set.empty
         in
         let made_unavailable =
           RD.Set.union made_unavailable_1 made_unavailable_2
@@ -318,6 +335,9 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         augment_availability_at_exit nfail avail_before;
         None, unreachable
       | Itrywith (body, kind, (ts, handler)) ->
+        (match kind with
+        | Regular -> ()
+        | Delayed nfail -> Hashtbl.add avail_at_exit nfail unreachable);
         let saved_avail_at_raise = setup_avail_at_raise kind in
         let avail_before = ok avail_before in
         let after_body = available_regs body ~avail_before in
@@ -348,6 +368,9 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
             (available_regs handler ~avail_before:avail_before_handler)
         in
         current_trap_stack := saved_trap_stack;
+        (match kind with
+        | Regular -> ()
+        | Delayed nfail -> Hashtbl.remove avail_at_exit nfail);
         None, avail_after
       | Iraise _ ->
         let avail_before = ok avail_before in
@@ -355,7 +378,7 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         None, unreachable)
   in
   instr.available_across <- avail_across;
-  match instr.desc with
+  match[@ocaml.warning "-4"] instr.desc with
   | Iend -> avail_after
   | _ -> available_regs instr.next ~avail_before:avail_after
 
@@ -370,7 +393,7 @@ and join branches ~avail_before =
   None, avail_after
 
 let fundecl (f : M.fundecl) =
-  if false (* !Clflags.debug && !Clflags.debug_runavail *)
+  if !Clflags.debug && not !Dwarf_flags.restrict_to_upstream_dwarf
   then (
     assert (Hashtbl.length avail_at_exit = 0);
     avail_at_raise := RAS.Unreachable;

--- a/backend/debug/available_regs.mli
+++ b/backend/debug/available_regs.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*            Mark Shinwell and Thomas Refis, Jane Street Europe          *)
 (*                                                                        *)
-(*   Copyright 2013--2017 Jane Street Group LLC                           *)
+(*   Copyright 2013--2023 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -254,8 +254,7 @@ let rec instr ppf i =
     fprintf ppf "@[<1>{%a" regsetaddr i.live;
     if Array.length i.arg > 0 then fprintf ppf "@ +@ %a" regs i.arg;
     fprintf ppf "}@]@,";
-    (* CR-someday mshinwell: to use for gdb work
-    if !Clflags.dump_avail then begin
+    if !Flambda_backend_flags.davail then begin
       let module RAS = Reg_availability_set in
       fprintf ppf "@[<1>AB={%a}" (RAS.print ~print_reg:reg) i.available_before;
       begin match i.available_across with
@@ -264,7 +263,7 @@ let rec instr ppf i =
         fprintf ppf ",AA={%a}" (RAS.print ~print_reg:reg) available_across
       end;
       fprintf ppf "@]@,"
-    end *)
+    end
   end;
   begin match i.desc with
   | Iend -> ()

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -121,6 +121,9 @@ let mk_caml_apply_inline_fast_path f =
 let mk_dump_inlining_paths f =
   "-dump-inlining-paths", Arg.Unit f, " Dump inlining paths when dumping flambda2 terms"
 
+let mk_davail f =
+  "-davail", Arg.Unit f, " Dump register availability information"
+
 let mk_internal_assembler f =
   "-internal-assembler", Arg.Unit f, "Write object files directly instead of using the system assembler (x86-64 ELF only)"
 
@@ -522,6 +525,7 @@ module type Flambda_backend_options = sig
   val ocamlcfg : unit -> unit
   val no_ocamlcfg : unit -> unit
   val dump_inlining_paths : unit -> unit
+  val davail : unit -> unit
   val dcfg : unit -> unit
   val dcfg_invariants : unit -> unit
   val dcfg_equivalence_check : unit -> unit
@@ -616,6 +620,7 @@ module Make_flambda_backend_options (F : Flambda_backend_options) =
 struct
   let list2 = [
     mk_dump_inlining_paths F.dump_inlining_paths;
+    mk_davail F.davail;
     mk_ocamlcfg F.ocamlcfg;
     mk_no_ocamlcfg F.no_ocamlcfg;
     mk_dcfg F.dcfg;
@@ -764,6 +769,8 @@ module Flambda_backend_options_impl = struct
     clear' Flambda_backend_flags.dasm_comments
 
   let dump_inlining_paths = set' Flambda_backend_flags.dump_inlining_paths
+
+  let davail = set' Flambda_backend_flags.davail
 
   let heap_reduction_threshold x =
     Flambda_backend_flags.heap_reduction_threshold := x
@@ -1003,6 +1010,7 @@ module Extra_params = struct
     | "regalloc-param" -> add_string Flambda_backend_flags.regalloc_params
     | "regalloc-validate" -> set' Flambda_backend_flags.regalloc_validate
     | "dump-inlining-paths" -> set' Flambda_backend_flags.dump_inlining_paths
+    | "davail" -> set' Flambda_backend_flags.davail
     | "reorder-blocks-random" ->
        set_int_option' Flambda_backend_flags.reorder_blocks_random
     | "basic-block-sections" -> set' Flambda_backend_flags.basic_block_sections

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -23,6 +23,7 @@ module type Flambda_backend_options = sig
   val ocamlcfg : unit -> unit
   val no_ocamlcfg : unit -> unit
   val dump_inlining_paths : unit -> unit
+  val davail : unit -> unit
   val dcfg : unit -> unit
   val dcfg_invariants : unit -> unit
   val dcfg_equivalence_check : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -54,6 +54,7 @@ type opt_level = Oclassic | O2 | O3
 type 'a or_default = Set of 'a | Default
 
 let dump_inlining_paths = ref false
+let davail = ref false
 
 let opt_level = ref Default
 

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -31,6 +31,8 @@ val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
 val dump_checkmach : bool ref
 
+val davail : bool ref
+
 type checkmach_details_cutoff =
   | Keep_all
   | At_most of int  (* n > 0 *)


### PR DESCRIPTION
Bug fix: delayed `Itrywith` had a couple of small mistakes in `Available_regs`.

Warning 4 has been enabled for this pass.  Polls and probes are now treated in the same way as non-tail function calls for the purposes of availability.

New flag `-davail` for dumping register availability information.

`Available_regs` is now run when in the "non upstream DWARF" mode.

Based on #1651