### PR TITLE
Emit CFI sections in the internal assembler

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1954,6 +1954,6 @@ let end_assembly () =
     else
       None
   in
-  Emitaux.Dwarf_helpers.emit_dwarf ();
-  X86_proc.generate_code asm;
-  reset_all ()
+  if not !Flambda_backend_flags.internal_assembler then
+    Emitaux.Dwarf_helpers.emit_dwarf ();
+  X86_proc.generate_code asm

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -141,13 +141,14 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
        avoid errors, emit the beginning of all dwarf sections in advance. *)
     if is_gas () || is_macos ()
     then List.iter switch_to_section (Asm_section.dwarf_sections_in_order ());
-    (* Stop dsymutil complaining about empty __debug_line sections (produces
-       bogus error "line table parameters mismatch") by making sure such
-       sections are never empty. *)
     (* The following line is commented out because it adds a loc directive in a
        section which is not the .text section, which causes issues when the
        debug_line section is being created. *)
-    (* let file_num = A.get_file_num "none" in loc ~file_num ~line:1 ~col:1; *)
+    (* Stop dsymutil complaining about empty __debug_line sections (produces
+       bogus error "line table parameters mismatch") by making sure such
+       sections are never empty.
+
+       let file_num = A.get_file_num "none" in loc ~file_num ~line:1 ~col:1; *)
     D.text ()
 
   let with_comment f ?comment x =

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -244,9 +244,10 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     (* CR poechsel: use the arguments *)
     A.emit_line "label"
 
-  let symbol_plus_offset _sym ~offset_in_bytes:_ =
-    (* CR poechsel: use the arguments *)
-    A.emit_line "symbol_plus_offset"
+  let symbol_plus_offset sym ~offset_in_bytes =
+    let lab = D.const_label (Asm_symbol.encode sym) in
+    let offset = D.const_int64 (Targetint.to_int64 offset_in_bytes) in
+    const_machine_width (D.const_add lab offset)
 
   let new_temp_var () =
     let id = !temp_var_counter in

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -86,14 +86,6 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     | MASM | MacOS -> false
     | GAS_like -> true
 
-  let is_masm () =
-    match Target_system.assembler () with
-    | MASM -> true
-    | GAS_like | MacOS -> false
-
-  let loc ~file_num ~line ~col =
-    if not (is_masm ()) then D.loc ~file_num ~line ~col ()
-
   let new_line () = D.new_line ()
 
   let not_initialized () =
@@ -152,8 +144,10 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     (* Stop dsymutil complaining about empty __debug_line sections (produces
        bogus error "line table parameters mismatch") by making sure such
        sections are never empty. *)
-    let file_num = A.get_file_num "none" in
-    loc ~file_num ~line:1 ~col:1;
+    (* The following line is commented out because it adds a loc directive in a
+       section which is not the .text section, which causes issues when the
+       debug_line section is being created. *)
+    (* let file_num = A.get_file_num "none" in loc ~file_num ~line:1 ~col:1; *)
     D.text ()
 
   let with_comment f ?comment x =

--- a/backend/asm_targets/asm_label.ml
+++ b/backend/asm_targets/asm_label.ml
@@ -111,6 +111,8 @@ let debug_str_label = lazy (create (DWARF Debug_str))
 
 let debug_line_label = lazy (create (DWARF Debug_line))
 
+let debug_frame_label = lazy (create (DWARF Debug_frame))
+
 let for_dwarf_section (dwarf_section : Asm_section.dwarf_section) =
   match dwarf_section with
   | Debug_info -> Lazy.force debug_info_label
@@ -123,6 +125,7 @@ let for_dwarf_section (dwarf_section : Asm_section.dwarf_section) =
   | Debug_rnglists -> Lazy.force debug_rnglists_label
   | Debug_str -> Lazy.force debug_str_label
   | Debug_line -> Lazy.force debug_line_label
+  | Debug_frame -> Lazy.force debug_frame_label
 
 let for_section (section : Asm_section.t) =
   match section with

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -97,7 +97,10 @@ let details t ~first_occurrence =
         | Debug_rnglists -> ".debug_rnglists"
         | Debug_str -> ".debug_str"
         | Debug_line -> ".debug_line"
-        | Debug_frame -> ".debug_frame"
+        | Debug_frame ->
+          if !Dwarf_flags.gdwarf_use_eh_frame
+          then ".eh_frame"
+          else ".debug_frame"
       in
       let flags = if first_occurrence then Some "" else None in
       let args = if first_occurrence then ["%progbits"] else [] in

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -37,6 +37,7 @@ type dwarf_section =
   | Debug_rnglists
   | Debug_str
   | Debug_line
+  | Debug_frame
 
 type t =
   | DWARF of dwarf_section
@@ -54,7 +55,8 @@ let dwarf_sections_in_order () =
       DWARF Debug_abbrev;
       DWARF Debug_aranges;
       DWARF Debug_str;
-      DWARF Debug_line ]
+      DWARF Debug_line;
+      DWARF Debug_frame ]
   in
   let dwarf_version_dependent_sections =
     match !Dwarf_flags.gdwarf_version with
@@ -79,6 +81,7 @@ let details t ~first_occurrence =
         | Debug_rnglists -> "__debug_rnglists"
         | Debug_str -> "__debug_str"
         | Debug_line -> "__debug_line"
+        | Debug_frame -> "__debug_frame"
       in
       ["__DWARF"; name], None, ["regular"; "debug"]
     | DWARF dwarf, _ ->
@@ -94,6 +97,7 @@ let details t ~first_occurrence =
         | Debug_rnglists -> ".debug_rnglists"
         | Debug_str -> ".debug_str"
         | Debug_line -> ".debug_line"
+        | Debug_frame -> ".debug_frame"
       in
       let flags = if first_occurrence then Some "" else None in
       let args = if first_occurrence then ["%progbits"] else [] in
@@ -119,6 +123,7 @@ let print ppf t =
     | DWARF Debug_rnglists -> "(DWARF Debug_rnglists)"
     | DWARF Debug_str -> "(DWARF Debug_str)"
     | DWARF Debug_line -> "(DWARF Debug_line)"
+    | DWARF Debug_frame -> "(DWARF Debug_frame)"
     | Text -> "Text"
   in
   Format.pp_print_string ppf str

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -39,6 +39,7 @@ type dwarf_section =
   | Debug_rnglists
   | Debug_str
   | Debug_line
+  | Debug_frame
 
 type t =
   | DWARF of dwarf_section

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -12,6 +12,7 @@ type debug_thing =
   | Debug_dwarf_vars
   | Debug_dwarf_call_sites
   | Debug_dwarf_cmm
+  | Debug_source_lines
 
 let bytecode_g =
   [ Debug_ocamldebug;

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -137,3 +137,7 @@ let gdwarf_format = ref default_gdwarf_format
 let default_gdwarf_self_tail_calls = true
 
 let gdwarf_self_tail_calls = ref default_gdwarf_self_tail_calls
+
+let default_gdwarf_use_eh_frame = true
+
+let gdwarf_use_eh_frame = ref default_gdwarf_use_eh_frame

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
@@ -12,6 +12,7 @@ type debug_thing =
   | Debug_dwarf_vars
   | Debug_dwarf_call_sites
   | Debug_dwarf_cmm
+  | Debug_source_lines
 
 val debug_thing : debug_thing -> bool
 

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
@@ -65,3 +65,7 @@ val default_gdwarf_format : dwarf_format
 val default_ddebug_invariants : bool
 
 val ddebug_invariants : bool ref
+
+val default_gdwarf_use_eh_frame : bool
+
+val gdwarf_use_eh_frame : bool ref

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.ml
@@ -31,11 +31,12 @@ let emit ~asm_directives ~compilation_unit_proto_die
       ();
   if not !Dwarf_flags.restrict_to_upstream_dwarf
   then
-    (* CR-soon mshinwell: the [compilation_unit_die] member of the record returned
-       from [Assign_abbrevs.run] is now unused *)
+    (* CR-soon mshinwell: the [compilation_unit_die] member of the record
+       returned from [Assign_abbrevs.run] is now unused *)
     let assigned_abbrevs =
       Profile.record "assign_abbrevs"
-        (fun () -> Assign_abbrevs.run ~proto_die_root:compilation_unit_proto_die)
+        (fun () ->
+          Assign_abbrevs.run ~proto_die_root:compilation_unit_proto_die)
         ()
     in
     let debug_abbrev_label = Asm_label.for_section (DWARF Debug_abbrev) in

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.ml
@@ -18,7 +18,7 @@ open Dwarf_low
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 let emit ~asm_directives ~compilation_unit_proto_die
-    ~compilation_unit_header_label ~debug_line =
+    ~compilation_unit_header_label ~debug_line ~debug_frame =
   let module A = (val asm_directives : Asm_directives.S) in
   if Dwarf_flags.debug_thing Dwarf_flags.Debug_source_lines
   then
@@ -28,6 +28,15 @@ let emit ~asm_directives ~compilation_unit_proto_die
         Profile.record "debug_line_section"
           (Debug_line_section.emit ~asm_directives)
           debug_line)
+      ();
+  if Dwarf_flags.debug_thing Dwarf_flags.Debug_dwarf_cfi
+  then
+    Profile.record "dwarf_world_emit"
+      (fun () ->
+        A.switch_to_section (DWARF Debug_frame);
+        Profile.record "debug_frame_section"
+          (Debug_frame_section.emit ~asm_directives)
+          debug_frame)
       ();
   if not !Dwarf_flags.restrict_to_upstream_dwarf
   then

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.ml
@@ -18,33 +18,44 @@ open Dwarf_low
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 let emit ~asm_directives ~compilation_unit_proto_die
-    ~compilation_unit_header_label =
+    ~compilation_unit_header_label ~debug_line =
   let module A = (val asm_directives : Asm_directives.S) in
-  (* CR-soon mshinwell: the [compilation_unit_die] member of the record returned
-     from [Assign_abbrevs.run] is now unused *)
-  let assigned_abbrevs =
-    Profile.record "assign_abbrevs"
-      (fun () -> Assign_abbrevs.run ~proto_die_root:compilation_unit_proto_die)
-      ()
-  in
-  let debug_abbrev_label = Asm_label.for_section (DWARF Debug_abbrev) in
-  let debug_info =
-    Profile.record "debug_info_section"
+  if Dwarf_flags.debug_thing Dwarf_flags.Debug_source_lines
+  then
+    Profile.record "dwarf_world_emit"
       (fun () ->
-        Debug_info_section.create ~dies:assigned_abbrevs.dies
-          ~debug_abbrev_label ~compilation_unit_header_label)
-      ()
-  in
-  Profile.record "dwarf_world_emit"
-    (fun () ->
-      A.switch_to_section (DWARF Debug_info);
+        A.switch_to_section (DWARF Debug_line);
+        Profile.record "debug_line_section"
+          (Debug_line_section.emit ~asm_directives)
+          debug_line)
+      ();
+  if not !Dwarf_flags.restrict_to_upstream_dwarf
+  then
+    (* CR-soon mshinwell: the [compilation_unit_die] member of the record returned
+       from [Assign_abbrevs.run] is now unused *)
+    let assigned_abbrevs =
+      Profile.record "assign_abbrevs"
+        (fun () -> Assign_abbrevs.run ~proto_die_root:compilation_unit_proto_die)
+        ()
+    in
+    let debug_abbrev_label = Asm_label.for_section (DWARF Debug_abbrev) in
+    let debug_info =
       Profile.record "debug_info_section"
-        (Debug_info_section.emit ~asm_directives)
-        debug_info;
-      A.switch_to_section (DWARF Debug_abbrev);
-      Profile.record "abbreviations_table"
-        (Abbreviations_table.emit ~asm_directives)
-        assigned_abbrevs.abbrev_table;
-      A.switch_to_section (DWARF Debug_str);
-      A.emit_cached_strings ())
-    ()
+        (fun () ->
+          Debug_info_section.create ~dies:assigned_abbrevs.dies
+            ~debug_abbrev_label ~compilation_unit_header_label)
+        ()
+    in
+    Profile.record "dwarf_world_emit"
+      (fun () ->
+        A.switch_to_section (DWARF Debug_info);
+        Profile.record "debug_info_section"
+          (Debug_info_section.emit ~asm_directives)
+          debug_info;
+        A.switch_to_section (DWARF Debug_abbrev);
+        Profile.record "abbreviations_table"
+          (Abbreviations_table.emit ~asm_directives)
+          assigned_abbrevs.abbrev_table;
+        A.switch_to_section (DWARF Debug_str);
+        A.emit_cached_strings ())
+      ()

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.mli
@@ -24,4 +24,5 @@ val emit :
   asm_directives:(module Asm_directives.S) ->
   compilation_unit_proto_die:Proto_die.t ->
   compilation_unit_header_label:Asm_label.t ->
+  debug_line:Debug_line_section.t ->
   unit

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.mli
@@ -25,4 +25,5 @@ val emit :
   compilation_unit_proto_die:Proto_die.t ->
   compilation_unit_header_label:Asm_label.t ->
   debug_line:Debug_line_section.t ->
+  debug_frame:Debug_frame_section.t ->
   unit

--- a/backend/debug/dwarf/dwarf_low/debug_frame_section.ml
+++ b/backend/debug/dwarf/dwarf_low/debug_frame_section.ml
@@ -1,0 +1,208 @@
+(* Some instructions omitted *)
+type call_frame_instr =
+  | Advance_loc of int
+  | Offset of int * int
+  | Restore of int
+  | Nop
+  | Advance_loc1 of int
+  | Advance_loc2 of int
+  | Advance_loc4 of int
+  | Offset_extended of int * int
+  | Restore_extended of int
+  | Undefined of int
+  | Same_value of int
+  | Register of int * int
+  | Remember_state
+  | Restore_state
+  | Def_cfa of int * int
+  | Def_cfa_register of int
+  | Def_cfa_offset of int
+  | Offset_extended_sf of int * int
+  | Def_cfa_sf of int * int
+  | Def_cfa_offset_sf of int
+  | Val_offset of int * int
+  | Val_offset_sf of int * int
+
+type t = unit
+
+let null_byte = Dwarf_value.uint8 Numbers.Uint8.zero
+
+let cie_id =
+  match !Dwarf_flags.gdwarf_format with
+  | Thirty_two ->
+    Dwarf_value.uint32 (Numbers.Uint32.of_nonnegative_int64_exn 0xffffffffL)
+  | Sixty_four ->
+    Dwarf_value.uint64
+      (Numbers.Uint64.of_nonnegative_int64_exn 0xffffffffffffffffL)
+
+let augmentation = null_byte
+
+let address_size_int =
+  Dwarf_value.absolute_address Targetint.zero
+  |> Dwarf_value.size |> Dwarf_int.to_int64 |> Int64.to_int
+
+let address_size =
+  Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn address_size_int)
+
+let segment_size = null_byte
+
+let code_alignment_factor =
+  Numbers.Uint64.of_nonnegative_int_exn 1 |> Dwarf_value.uleb128
+
+let data_alignment_factor = Dwarf_value.sleb128 (-8L)
+
+let return_address_register =
+  Numbers.Uint64.of_nonnegative_int_exn 16 |> Dwarf_value.uleb128
+
+let initial_instructions = [Def_cfa (7, 8); Offset (16, 1)]
+
+let create () = ()
+
+let encode = function
+  | Advance_loc delta ->
+    [ (0b01 lsl 6) lor (delta land 0b00111111)
+      |> Numbers.Uint8.of_nonnegative_int_exn |> Dwarf_value.uint8 ]
+  | Offset (register, offset) ->
+    [ (0b10 lsl 6) lor (register land 0b00111111)
+      |> Numbers.Uint8.of_nonnegative_int_exn |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn offset |> Dwarf_value.uleb128 ]
+  | Restore register ->
+    [ (0b11 lsl 6) lor (register land 0b00111111)
+      |> Numbers.Uint8.of_nonnegative_int_exn |> Dwarf_value.uint8 ]
+  | Nop -> [null_byte]
+  | Advance_loc1 delta ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x02 |> Dwarf_value.uint8;
+      Numbers.Uint8.of_nonnegative_int_exn delta |> Dwarf_value.uint8 ]
+  | Advance_loc2 delta ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x03 |> Dwarf_value.uint8;
+      Numbers.Uint16.of_nonnegative_int_exn delta |> Dwarf_value.uint16 ]
+  | Advance_loc4 delta ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x04 |> Dwarf_value.uint8;
+      Numbers.Uint32.of_nonnegative_int_exn delta |> Dwarf_value.uint32 ]
+  | Offset_extended (register, offset) ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x05 |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128;
+      Numbers.Uint64.of_nonnegative_int_exn offset |> Dwarf_value.uleb128 ]
+  | Restore_extended register ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x06 |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128 ]
+  | Undefined register ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x07 |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128 ]
+  | Same_value register ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x08 |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128 ]
+  | Register (register1, register2) ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x09 |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register1 |> Dwarf_value.uleb128;
+      Numbers.Uint64.of_nonnegative_int_exn register2 |> Dwarf_value.uleb128 ]
+  | Remember_state ->
+    [Numbers.Uint8.of_nonnegative_int_exn 0x0a |> Dwarf_value.uint8]
+  | Restore_state ->
+    [Numbers.Uint8.of_nonnegative_int_exn 0x0b |> Dwarf_value.uint8]
+  | Def_cfa (register, offset) ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x0c |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128;
+      Numbers.Uint64.of_nonnegative_int_exn offset |> Dwarf_value.uleb128 ]
+  | Def_cfa_register register ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x0d |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128 ]
+  | Def_cfa_offset offset ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x0e |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn offset |> Dwarf_value.uleb128 ]
+  | Offset_extended_sf (register, offset) ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x11 |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128;
+      Numbers.Uint64.of_nonnegative_int_exn offset |> Dwarf_value.uleb128 ]
+  | Def_cfa_sf (register, offset) ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x12 |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128;
+      Int64.of_int offset |> Dwarf_value.sleb128 ]
+  | Def_cfa_offset_sf offset ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x13 |> Dwarf_value.uint8;
+      Int64.of_int offset |> Dwarf_value.sleb128 ]
+  | Val_offset (register, factored_offset) ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x14 |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128;
+      Numbers.Uint64.of_nonnegative_int_exn factored_offset
+      |> Dwarf_value.uleb128 ]
+  | Val_offset_sf (register, factored_offset) ->
+    [ Numbers.Uint8.of_nonnegative_int_exn 0x15 |> Dwarf_value.uint8;
+      Numbers.Uint64.of_nonnegative_int_exn register |> Dwarf_value.uleb128;
+      Int64.of_int factored_offset |> Dwarf_value.sleb128 ]
+
+let instr_size instr =
+  let ( + ) = Dwarf_int.add in
+  List.fold_left
+    (fun size value -> size + Dwarf_value.size value)
+    (Dwarf_int.zero ()) (encode instr)
+
+let program_size program =
+  let ( + ) = Dwarf_int.add in
+  List.fold_left
+    (fun size instr -> size + instr_size instr)
+    (Dwarf_int.zero ()) program
+
+let initial_length_size =
+  Dwarf_int.zero () |> Initial_length.create |> Initial_length.size
+
+let cie_size_without_padding_or_first_word =
+  let ( + ) = Dwarf_int.add in
+  Dwarf_value.size cie_id + Dwarf_version.size Dwarf_version.four
+  + Dwarf_value.size augmentation
+  + Dwarf_value.size address_size
+  + Dwarf_value.size segment_size
+  + Dwarf_value.size code_alignment_factor
+  + Dwarf_value.size data_alignment_factor
+  + Dwarf_value.size return_address_register
+  + program_size initial_instructions
+
+let cie_padding_size =
+  let size_without_padding_or_first_word =
+    Dwarf_int.to_int64 cie_size_without_padding_or_first_word
+  in
+  let size_without_padding =
+    Int64.add size_without_padding_or_first_word
+      (Dwarf_int.to_int64 initial_length_size)
+  in
+  let padding =
+    address_size_int - (Int64.to_int size_without_padding mod address_size_int)
+  in
+  if padding = address_size_int then 0 else padding
+
+let cie_size_without_first_word =
+  Dwarf_int.add cie_size_without_padding_or_first_word
+    (Dwarf_int.of_host_int_exn cie_padding_size)
+
+let cie_size = Dwarf_int.add initial_length_size cie_size_without_first_word
+
+let size t = cie_size
+
+let emit_cie ~asm_directives =
+  let initial_length = Initial_length.create cie_size_without_first_word in
+  Initial_length.emit ~asm_directives initial_length;
+  Dwarf_value.emit ~asm_directives cie_id;
+  Dwarf_version.emit ~asm_directives Dwarf_version.four;
+  Dwarf_value.emit ~asm_directives augmentation;
+  Dwarf_value.emit ~asm_directives address_size;
+  Dwarf_value.emit ~asm_directives segment_size;
+  Dwarf_value.emit ~asm_directives code_alignment_factor;
+  Dwarf_value.emit ~asm_directives data_alignment_factor;
+  Dwarf_value.emit ~asm_directives return_address_register;
+  List.iter (Dwarf_value.emit ~asm_directives) (List.map encode initial_instructions);
+
+
+let emit ~asm_directives t =
+
+  Dwarf_version.emit ~asm_directives Dwarf_version.four;
+  Dwarf_int.emit ~asm_directives (header_length t);
+  Dwarf_value.emit ~asm_directives minimum_instruction_length;
+  Dwarf_value.emit ~asm_directives maximum_operations_per_instruction;
+  Dwarf_value.emit ~asm_directives default_is_stmt;
+  Dwarf_value.emit ~asm_directives line_base;
+  Dwarf_value.emit ~asm_directives line_range;
+  Dwarf_value.emit ~asm_directives opcode_base;
+  List.iter (Dwarf_value.emit ~asm_directives) standard_opcode_lengths;
+  Dwarf_value.emit ~asm_directives null_byte;
+  emit_file_names ~asm_directives t;
+  emit_line_number_program ~asm_directives t

--- a/backend/debug/dwarf/dwarf_low/debug_frame_section.mli
+++ b/backend/debug/dwarf/dwarf_low/debug_frame_section.mli
@@ -4,6 +4,12 @@ open Asm_targets
 
 type t
 
-val create : unit -> t
+val create : code_begin:Asm_symbol.t -> t
+
+val process_cfi_startproc : t -> address:int -> unit
+
+val process_cfi_adjust_cfa_offset : t -> address:int -> offset:int -> unit
+
+val process_cfi_endproc : t -> address:int -> unit
 
 include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/debug_frame_section.mli
+++ b/backend/debug/dwarf/dwarf_low/debug_frame_section.mli
@@ -1,0 +1,9 @@
+(** Representation of the DWARF .debug_frame section. *)
+
+open Asm_targets
+
+type t
+
+val create : unit -> t
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/debug_frame_section.mli
+++ b/backend/debug/dwarf/dwarf_low/debug_frame_section.mli
@@ -12,4 +12,8 @@ val process_cfi_adjust_cfa_offset : t -> address:int -> offset:int -> unit
 
 val process_cfi_endproc : t -> address:int -> unit
 
+val checkpoint : t -> unit
+
+val rollback : t -> unit
+
 include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/debug_line_section.ml
+++ b/backend/debug/dwarf/dwarf_low/debug_line_section.ml
@@ -1,0 +1,384 @@
+open Asm_targets
+
+type line_number_program_instr =
+  | Special_opcode of Dwarf_value.t
+  | Copy
+  | Advance_pc of Dwarf_value.t
+  | Advance_line of Dwarf_value.t
+  | Set_file of Dwarf_value.t
+  | Set_column of Dwarf_value.t
+  | Const_add_pc
+  | End_sequence
+  | Set_address of Dwarf_value.t
+  | Set_discriminator of Dwarf_value.t
+
+module IntMap = Map.Make (Int)
+
+type line_number_state =
+  { line_number_program : line_number_program_instr list;
+    address_reg : int;
+    file_reg : int;
+    line_reg : int;
+    column_reg : int;
+    discriminator_reg : int;
+    source_files : Dwarf_value.t IntMap.t
+  }
+
+type t = line_number_state ref
+
+let rec range low high =
+  if high < low
+  then []
+  else if low = high
+  then [low]
+  else low :: range (low + 1) high
+
+let default_file_name = Dwarf_value.string "none"
+
+let minimum_instruction_length_int = 1
+
+let minimum_instruction_length =
+  Numbers.Uint8.of_nonnegative_int_exn minimum_instruction_length_int
+  |> Dwarf_value.uint8
+
+let maximum_operations_per_instruction = Numbers.Uint8.one |> Dwarf_value.uint8
+
+let default_is_stmt = Dwarf_value.bool true
+
+let line_base_int = -5
+
+let line_base = Numbers.Int8.of_int_exn line_base_int |> Dwarf_value.int8
+
+let line_range_int = 14
+
+let line_range =
+  Numbers.Uint8.of_nonnegative_int_exn line_range_int |> Dwarf_value.uint8
+
+let opcode_base_int = 13
+
+let opcode_base =
+  Numbers.Uint8.of_nonnegative_int_exn opcode_base_int |> Dwarf_value.uint8
+
+let standard_opcode_lengths =
+  List.map
+    (fun length ->
+      Numbers.Uint8.of_nonnegative_int_exn length |> Dwarf_value.uint8)
+    [0; 1; 1; 1; 1; 0; 0; 0; 1; 0; 0; 1]
+
+let uleb128_zero = Dwarf_value.uleb128 Numbers.Uint64.zero
+
+let null_byte = Dwarf_value.uint8 Numbers.Uint8.zero
+
+let max_special_opcode_operation_advance =
+  (255 - opcode_base_int) / line_range_int
+
+(* Hopefully code_begin is the right symbol to use *)
+let create ~code_begin =
+  ref
+    { line_number_program =
+        [Set_address (Dwarf_value.code_address_from_symbol code_begin)];
+      address_reg = 0;
+      file_reg = 1;
+      line_reg = 1;
+      column_reg = 0;
+      discriminator_reg = 0;
+      source_files = IntMap.empty
+    }
+
+let add_source_file t ~file_name ~file_num =
+  t
+    := { !t with
+         source_files =
+           IntMap.add file_num (Dwarf_value.string file_name) !t.source_files
+       }
+
+let maybe_add_set_column_instr col_int state =
+  if col_int != state.column_reg
+  then
+    let col =
+      Numbers.Uint64.of_nonnegative_int_exn col_int |> Dwarf_value.uleb128
+    in
+    { state with
+      line_number_program = Set_column col :: state.line_number_program;
+      column_reg = col_int
+    }
+  else state
+
+let maybe_add_set_file_instr file_num_int state =
+  if file_num_int != state.file_reg
+  then
+    let file_num =
+      Numbers.Uint64.of_nonnegative_int_exn file_num_int |> Dwarf_value.uleb128
+    in
+    { state with
+      line_number_program = Set_file file_num :: state.line_number_program;
+      file_reg = file_num_int
+    }
+  else state
+
+let maybe_add_set_discriminator_instr discriminator_int state =
+  if discriminator_int != state.discriminator_reg
+  then
+    let discriminator =
+      Numbers.Uint64.of_nonnegative_int_exn discriminator_int
+      |> Dwarf_value.uleb128
+    in
+    { state with
+      line_number_program =
+        Set_discriminator discriminator :: state.line_number_program;
+      discriminator_reg = discriminator_int
+    }
+  else state
+
+let maybe_add_advance_line_instr line state =
+  let line_delta_int = line - state.line_reg in
+  let line_delta_in_special_opcode_range =
+    line_delta_int >= line_base_int
+    && line_delta_int < line_base_int + line_range_int
+  in
+  if (not line_delta_in_special_opcode_range) && line_delta_int <> 0
+  then
+    let line_delta = Int64.of_int line_delta_int |> Dwarf_value.sleb128 in
+    { state with
+      line_number_program = Advance_line line_delta :: state.line_number_program;
+      line_reg = line
+    }
+  else state
+
+let maybe_add_const_add_pc_instr ~instr_address ~line state =
+  let line_delta = line - state.line_reg in
+  let operation_advance =
+    (instr_address - state.address_reg) / minimum_instruction_length_int
+  in
+  let line_delta_in_special_opcode_range =
+    line_delta >= line_base_int && line_delta < line_base_int + line_range_int
+  in
+  if not line_delta_in_special_opcode_range
+  then state
+  else
+    let special_opcode_required_now =
+      line_delta - line_base_int
+      + (line_range_int * operation_advance)
+      + opcode_base_int
+    in
+    let special_opcode_required_after_const_add_pc_instr =
+      special_opcode_required_now
+      - (line_range_int * max_special_opcode_operation_advance)
+    in
+    if special_opcode_required_now > 255
+       && special_opcode_required_after_const_add_pc_instr <= 255
+    then
+      { state with
+        line_number_program = Const_add_pc :: state.line_number_program;
+        address_reg =
+          state.address_reg
+          + max_special_opcode_operation_advance
+            * minimum_instruction_length_int
+      }
+    else state
+
+let maybe_add_advance_pc_instr ~instr_address ~line state =
+  let line_delta = line - state.line_reg in
+  let operation_advance_int =
+    (instr_address - state.address_reg) / minimum_instruction_length_int
+  in
+  let line_delta_in_special_opcode_range =
+    line_delta >= line_base_int && line_delta < line_base_int + line_range_int
+  in
+  let operation_advance_in_special_opcode_range =
+    line_delta - line_base_int
+    + (line_range_int * operation_advance_int)
+    + opcode_base_int
+    <= 255
+  in
+  if ((not line_delta_in_special_opcode_range)
+     || not operation_advance_in_special_opcode_range)
+     && operation_advance_int <> 0
+  then
+    let operation_advance =
+      Numbers.Uint64.of_nonnegative_int_exn operation_advance_int
+      |> Dwarf_value.uleb128
+    in
+    { state with
+      line_number_program =
+        Advance_pc operation_advance :: state.line_number_program;
+      address_reg = instr_address
+    }
+  else state
+
+let add_copy_instr_or_special_opcode_instr ~instr_address ~line state =
+  let line_delta = line - state.line_reg in
+  let operation_advance =
+    (instr_address - state.address_reg) / minimum_instruction_length_int
+  in
+  if operation_advance = 0 && line_delta = 0
+  then
+    { state with
+      line_number_program = Copy :: state.line_number_program;
+      discriminator_reg = 0
+    }
+  else
+    let opcode =
+      line_delta - line_base_int
+      + (line_range_int * operation_advance)
+      + opcode_base_int
+      |> Numbers.Uint8.of_nonnegative_int_exn |> Dwarf_value.uint8
+    in
+    { state with
+      line_number_program = Special_opcode opcode :: state.line_number_program;
+      discriminator_reg = 0;
+      address_reg = instr_address;
+      line_reg = line
+    }
+
+(* If this row is identical to the last row we added, we do nothing: we do not
+   add a duplicate row. *)
+let add_line_number_matrix_row t ~instr_address ~file_num ~line ~col
+    ~discriminator =
+  let desired_discriminator = Option.value discriminator ~default:0 in
+  if instr_address = !t.address_reg
+     && file_num = !t.file_reg && line = !t.line_reg && col = !t.column_reg
+     && desired_discriminator = !t.discriminator_reg
+  then ()
+  else if instr_address < !t.address_reg
+  then
+    failwith
+      "attempt to add line number matrix row with an address lower than the \
+       previous row"
+  else
+    t
+      := maybe_add_set_file_instr file_num !t
+         |> maybe_add_set_column_instr col
+         |> maybe_add_set_discriminator_instr desired_discriminator
+         |> maybe_add_advance_line_instr line
+         |> maybe_add_const_add_pc_instr ~instr_address ~line
+         |> maybe_add_advance_pc_instr ~instr_address ~line
+         |> add_copy_instr_or_special_opcode_instr ~instr_address ~line
+
+let file_names_size t =
+  let ( + ) = Dwarf_int.add in
+  let max_binding = IntMap.max_binding_opt !t.source_files in
+  let max_index_opt = Option.map fst max_binding in
+  let max_index = Option.value max_index_opt ~default:0 in
+  let size =
+    List.fold_left
+      (fun size index ->
+        size
+        + (match IntMap.find_opt index !t.source_files with
+          | None -> Dwarf_value.size default_file_name
+          | Some file_name -> Dwarf_value.size file_name)
+        + Dwarf_value.size uleb128_zero
+        + Dwarf_value.size uleb128_zero
+        + Dwarf_value.size uleb128_zero)
+      (Dwarf_int.zero ()) (range 1 max_index)
+  in
+  size + Dwarf_value.size null_byte
+
+let emit_file_names ~asm_directives t =
+  let max_binding = IntMap.max_binding_opt !t.source_files in
+  let max_index_opt = Option.map fst max_binding in
+  let max_index = Option.value max_index_opt ~default:0 in
+  List.iter
+    (fun index ->
+      (match IntMap.find_opt index !t.source_files with
+      | None -> Dwarf_value.emit ~asm_directives default_file_name
+      | Some file_name -> Dwarf_value.emit ~asm_directives file_name);
+      (* Null terminate string *)
+      Dwarf_value.emit ~asm_directives null_byte;
+      Dwarf_value.emit ~asm_directives uleb128_zero;
+      Dwarf_value.emit ~asm_directives uleb128_zero;
+      Dwarf_value.emit ~asm_directives uleb128_zero)
+    (range 1 max_index);
+  Dwarf_value.emit ~asm_directives null_byte
+
+let encode = function
+  | Special_opcode opcode -> [opcode]
+  | Copy -> [Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn 0x01)]
+  | Advance_pc operation_advance ->
+    [ Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn 0x02);
+      operation_advance ]
+  | Advance_line line_delta ->
+    [Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn 0x03); line_delta]
+  | Set_file file ->
+    [Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn 0x04); file]
+  | Set_column column ->
+    [Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn 0x05); column]
+  | Const_add_pc ->
+    [Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn 0x08)]
+  | End_sequence ->
+    [ null_byte;
+      Dwarf_value.uleb128 (Numbers.Uint64.of_nonnegative_int_exn 1);
+      Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn 0x01) ]
+  | Set_address address ->
+    [ null_byte;
+      Dwarf_value.size address |> Dwarf_int.to_int64 |> Int64.succ
+      |> Numbers.Uint64.of_nonnegative_int64_exn |> Dwarf_value.uleb128;
+      Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn 0x02);
+      address ]
+  | Set_discriminator discriminator ->
+    [ null_byte;
+      Dwarf_value.size discriminator
+      |> Dwarf_int.to_int64 |> Int64.succ
+      |> Numbers.Uint64.of_nonnegative_int64_exn |> Dwarf_value.uleb128;
+      Dwarf_value.uint8 (Numbers.Uint8.of_nonnegative_int_exn 0x04);
+      discriminator ]
+
+let instr_size instr =
+  let ( + ) = Dwarf_int.add in
+  List.fold_left
+    (fun size value -> size + Dwarf_value.size value)
+    (Dwarf_int.zero ()) (encode instr)
+
+let line_number_program_size t =
+  let ( + ) = Dwarf_int.add in
+  List.fold_left
+    (fun size instr -> size + instr_size instr)
+    (Dwarf_int.zero ())
+    (End_sequence :: !t.line_number_program)
+
+let emit_line_number_program ~asm_directives t =
+  List.iter
+    (fun instr -> List.iter (Dwarf_value.emit ~asm_directives) (encode instr))
+    (List.rev (End_sequence :: !t.line_number_program))
+
+(* Value of the header_length field in the header. This is the size of the
+   header minus the first three fields (DWARF-4 standard section 6.2.4)*)
+let header_length t =
+  let ( + ) = Dwarf_int.add in
+  Dwarf_value.size minimum_instruction_length
+  + Dwarf_value.size maximum_operations_per_instruction
+  + Dwarf_value.size default_is_stmt
+  + Dwarf_value.size line_base
+  + Dwarf_value.size line_range
+  + Dwarf_value.size opcode_base
+  + List.fold_left ( + ) (Dwarf_int.zero ())
+      (List.map Dwarf_value.size standard_opcode_lengths)
+  + Dwarf_value.size null_byte + file_names_size t
+
+let size_without_first_word t =
+  let ( + ) = Dwarf_int.add in
+  let header_length = header_length t in
+  Dwarf_version.size Dwarf_version.four
+  + Dwarf_int.size header_length
+  + header_length + line_number_program_size t
+
+let size t =
+  let size_without_first_word = size_without_first_word t in
+  let initial_length = Initial_length.create size_without_first_word in
+  Dwarf_int.add (Initial_length.size initial_length) size_without_first_word
+
+let emit ~asm_directives t =
+  let initial_length = Initial_length.create (size_without_first_word t) in
+  Initial_length.emit ~asm_directives initial_length;
+  Dwarf_version.emit ~asm_directives Dwarf_version.four;
+  Dwarf_int.emit ~asm_directives (header_length t);
+  Dwarf_value.emit ~asm_directives minimum_instruction_length;
+  Dwarf_value.emit ~asm_directives maximum_operations_per_instruction;
+  Dwarf_value.emit ~asm_directives default_is_stmt;
+  Dwarf_value.emit ~asm_directives line_base;
+  Dwarf_value.emit ~asm_directives line_range;
+  Dwarf_value.emit ~asm_directives opcode_base;
+  List.iter (Dwarf_value.emit ~asm_directives) standard_opcode_lengths;
+  Dwarf_value.emit ~asm_directives null_byte;
+  emit_file_names ~asm_directives t;
+  emit_line_number_program ~asm_directives t

--- a/backend/debug/dwarf/dwarf_low/debug_line_section.mli
+++ b/backend/debug/dwarf/dwarf_low/debug_line_section.mli
@@ -17,4 +17,8 @@ val add_line_number_matrix_row :
   discriminator:int option ->
   unit
 
+val checkpoint : t -> unit
+
+val rollback : t -> unit
+
 include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/debug_line_section.mli
+++ b/backend/debug/dwarf/dwarf_low/debug_line_section.mli
@@ -1,0 +1,20 @@
+(** Representation of the DWARF .debug_line section. *)
+
+open Asm_targets
+
+type t
+
+val create : code_begin:Asm_symbol.t -> t
+
+val add_source_file : t -> file_name:string -> file_num:int -> unit
+
+val add_line_number_matrix_row :
+  t ->
+  instr_address:int ->
+  file_num:int ->
+  line:int ->
+  col:int ->
+  discriminator:int option ->
+  unit
+
+include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/dwarf_value.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_value.mli
@@ -96,6 +96,8 @@ val offset_into_debug_rnglists : ?comment:string -> Asm_label.t -> t
 
 val offset_into_debug_abbrev : ?comment:string -> Asm_label.t -> t
 
+val offset_into_debug_frame : ?comment:string -> Asm_label.t -> t
+
 val distance_between_labels_16_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> t
 

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -60,6 +60,12 @@ let dwarf_for_line_number_matrix_row t ~instr_address ~file_num ~line ~col
   Debug_line_section.add_line_number_matrix_row debug_line_section
     ~instr_address ~file_num ~line ~col ~discriminator
 
+let debug_line_checkpoint t =
+  Debug_line_section.checkpoint (DS.debug_line_section t.state)
+
+let debug_line_rollback t =
+  Debug_line_section.rollback (DS.debug_line_section t.state)
+
 let emit t =
   if t.emitted
   then

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -60,11 +60,9 @@ let dwarf_for_line_number_matrix_row t ~instr_address ~file_num ~line ~col
   Debug_line_section.add_line_number_matrix_row debug_line_section
     ~instr_address ~file_num ~line ~col ~discriminator
 
-let debug_line_checkpoint t =
-  Debug_line_section.checkpoint (DS.debug_line_section t.state)
+let checkpoint t = Debug_line_section.checkpoint (DS.debug_line_section t.state)
 
-let debug_line_rollback t =
-  Debug_line_section.rollback (DS.debug_line_section t.state)
+let rollback t = Debug_line_section.rollback (DS.debug_line_section t.state)
 
 let emit t =
   if t.emitted

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -74,9 +74,13 @@ let dwarf_for_cfi_endproc t ~address =
   let debug_frame_section = DS.debug_frame_section t.state in
   Debug_frame_section.process_cfi_endproc debug_frame_section ~address
 
-let checkpoint t = Debug_line_section.checkpoint (DS.debug_line_section t.state)
+let checkpoint t =
+  Debug_line_section.checkpoint (DS.debug_line_section t.state);
+  Debug_frame_section.checkpoint (DS.debug_frame_section t.state)
 
-let rollback t = Debug_line_section.rollback (DS.debug_line_section t.state)
+let rollback t =
+  Debug_line_section.rollback (DS.debug_line_section t.state);
+  Debug_frame_section.rollback (DS.debug_frame_section t.state)
 
 let emit t =
   if t.emitted

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -40,9 +40,10 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_begin
   in
   let compilation_unit_header_label = Asm_label.create (DWARF Debug_info) in
   let debug_line_section = Debug_line_section.create ~code_begin in
+  let debug_frame_section = Debug_frame_section.create ~code_begin in
   let state =
     DS.create ~compilation_unit_header_label ~compilation_unit_proto_die
-      ~debug_line_section
+      ~debug_line_section ~debug_frame_section
   in
   { state; asm_directives; emitted = false; get_file_id }
 
@@ -75,5 +76,6 @@ let emit t =
     ~compilation_unit_proto_die:(DS.compilation_unit_proto_die t.state)
     ~compilation_unit_header_label:(DS.compilation_unit_header_label t.state)
     ~debug_line:(DS.debug_line_section t.state)
+    ~debug_frame:(DS.debug_frame_section t.state)
 
 let emit t = Profile.record "emit_dwarf" emit t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -39,14 +39,26 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_begin
       ~code_begin ~code_end
   in
   let compilation_unit_header_label = Asm_label.create (DWARF Debug_info) in
+  let debug_line_section = Debug_line_section.create ~code_begin in
   let state =
     DS.create ~compilation_unit_header_label ~compilation_unit_proto_die
+      ~debug_line_section
   in
   { state; asm_directives; emitted = false; get_file_id }
 
 let dwarf_for_fundecl t fundecl =
   Dwarf_concrete_instances.for_fundecl ~get_file_id:t.get_file_id t.state
     fundecl
+
+let dwarf_for_source_file t ~file_name ~file_num =
+  let debug_line_section = DS.debug_line_section t.state in
+  Debug_line_section.add_source_file debug_line_section ~file_name ~file_num
+
+let dwarf_for_line_number_matrix_row t ~instr_address ~file_num ~line ~col
+    ~discriminator =
+  let debug_line_section = DS.debug_line_section t.state in
+  Debug_line_section.add_line_number_matrix_row debug_line_section
+    ~instr_address ~file_num ~line ~col ~discriminator
 
 let emit t =
   if t.emitted
@@ -58,5 +70,6 @@ let emit t =
   Dwarf_world.emit ~asm_directives:t.asm_directives
     ~compilation_unit_proto_die:(DS.compilation_unit_proto_die t.state)
     ~compilation_unit_header_label:(DS.compilation_unit_header_label t.state)
+    ~debug_line:(DS.debug_line_section t.state)
 
 let emit t = Profile.record "emit_dwarf" emit t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -61,6 +61,19 @@ let dwarf_for_line_number_matrix_row t ~instr_address ~file_num ~line ~col
   Debug_line_section.add_line_number_matrix_row debug_line_section
     ~instr_address ~file_num ~line ~col ~discriminator
 
+let dwarf_for_cfi_startproc t ~address =
+  let debug_frame_section = DS.debug_frame_section t.state in
+  Debug_frame_section.process_cfi_startproc debug_frame_section ~address
+
+let dwarf_for_cfi_adjust_cfa_offset t ~address ~offset =
+  let debug_frame_section = DS.debug_frame_section t.state in
+  Debug_frame_section.process_cfi_adjust_cfa_offset debug_frame_section ~address
+    ~offset
+
+let dwarf_for_cfi_endproc t ~address =
+  let debug_frame_section = DS.debug_frame_section t.state in
+  Debug_frame_section.process_cfi_endproc debug_frame_section ~address
+
 let checkpoint t = Debug_line_section.checkpoint (DS.debug_line_section t.state)
 
 let rollback t = Debug_line_section.rollback (DS.debug_line_section t.state)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
@@ -45,6 +45,10 @@ val dwarf_for_line_number_matrix_row :
   discriminator:int option ->
   unit
 
+val debug_line_checkpoint : t -> unit
+
+val debug_line_rollback : t -> unit
+
 (** Write the DWARF information to the assembly file. This should only be called
     once all (in)constants and function declarations have been passed to the
     above functions. *)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
@@ -45,6 +45,12 @@ val dwarf_for_line_number_matrix_row :
   discriminator:int option ->
   unit
 
+val dwarf_for_cfi_startproc : t -> address:int -> unit
+
+val dwarf_for_cfi_adjust_cfa_offset : t -> address:int -> offset:int -> unit
+
+val dwarf_for_cfi_endproc : t -> address:int -> unit
+
 val checkpoint : t -> unit
 
 val rollback : t -> unit

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
@@ -45,9 +45,9 @@ val dwarf_for_line_number_matrix_row :
   discriminator:int option ->
   unit
 
-val debug_line_checkpoint : t -> unit
+val checkpoint : t -> unit
 
-val debug_line_rollback : t -> unit
+val rollback : t -> unit
 
 (** Write the DWARF information to the assembly file. This should only be called
     once all (in)constants and function declarations have been passed to the

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
@@ -34,6 +34,17 @@ val create :
 
 val dwarf_for_fundecl : t -> Dwarf_concrete_instances.fundecl -> unit
 
+val dwarf_for_source_file : t -> file_name:string -> file_num:int -> unit
+
+val dwarf_for_line_number_matrix_row :
+  t ->
+  instr_address:int ->
+  file_num:int ->
+  line:int ->
+  col:int ->
+  discriminator:int option ->
+  unit
+
 (** Write the DWARF information to the assembly file. This should only be called
     once all (in)constants and function declarations have been passed to the
     above functions. *)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
@@ -19,12 +19,19 @@ open Dwarf_high
 
 type t =
   { compilation_unit_header_label : Asm_label.t;
-    compilation_unit_proto_die : Proto_die.t
+    compilation_unit_proto_die : Proto_die.t;
+    debug_line_section : Dwarf_low.Debug_line_section.t
   }
 
-let create ~compilation_unit_header_label ~compilation_unit_proto_die =
-  { compilation_unit_header_label; compilation_unit_proto_die }
+let create ~compilation_unit_header_label ~compilation_unit_proto_die
+    ~debug_line_section =
+  { compilation_unit_header_label;
+    compilation_unit_proto_die;
+    debug_line_section
+  }
 
 let compilation_unit_header_label t = t.compilation_unit_header_label
 
 let compilation_unit_proto_die t = t.compilation_unit_proto_die
+
+let debug_line_section t = t.debug_line_section

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
@@ -16,18 +16,21 @@
 
 open Asm_targets
 open Dwarf_high
+open Dwarf_low
 
 type t =
   { compilation_unit_header_label : Asm_label.t;
     compilation_unit_proto_die : Proto_die.t;
-    debug_line_section : Dwarf_low.Debug_line_section.t
+    debug_line_section : Debug_line_section.t;
+    debug_frame_section : Debug_frame_section.t
   }
 
 let create ~compilation_unit_header_label ~compilation_unit_proto_die
-    ~debug_line_section =
+    ~debug_line_section ~debug_frame_section =
   { compilation_unit_header_label;
     compilation_unit_proto_die;
-    debug_line_section
+    debug_line_section;
+    debug_frame_section
   }
 
 let compilation_unit_header_label t = t.compilation_unit_header_label
@@ -35,3 +38,5 @@ let compilation_unit_header_label t = t.compilation_unit_header_label
 let compilation_unit_proto_die t = t.compilation_unit_proto_die
 
 let debug_line_section t = t.debug_line_section
+
+let debug_frame_section t = t.debug_frame_section

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
@@ -18,14 +18,18 @@
 
 open Asm_targets
 open Dwarf_high
+open Dwarf_low
 
 type t
 
 val create :
   compilation_unit_header_label:Asm_label.t ->
   compilation_unit_proto_die:Proto_die.t ->
+  debug_line_section:Debug_line_section.t ->
   t
 
 val compilation_unit_header_label : t -> Asm_label.t
 
 val compilation_unit_proto_die : t -> Proto_die.t
+
+val debug_line_section : t -> Dwarf_low.Debug_line_section.t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
@@ -26,10 +26,13 @@ val create :
   compilation_unit_header_label:Asm_label.t ->
   compilation_unit_proto_die:Proto_die.t ->
   debug_line_section:Debug_line_section.t ->
+  debug_frame_section:Debug_frame_section.t ->
   t
 
 val compilation_unit_header_label : t -> Asm_label.t
 
 val compilation_unit_proto_die : t -> Proto_die.t
 
-val debug_line_section : t -> Dwarf_low.Debug_line_section.t
+val debug_line_section : t -> Debug_line_section.t
+
+val debug_frame_section : t -> Debug_frame_section.t

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -512,6 +512,16 @@ module Dwarf_helpers = struct
     | None -> ()
     | Some dwarf -> Dwarf.dwarf_for_line_number_matrix_row dwarf ~instr_address
       ~file_num ~line ~col ~discriminator
+
+  let debug_line_checkpoint () =
+    match !dwarf with
+    | None -> ()
+    | Some dwarf -> Dwarf.debug_line_checkpoint dwarf
+
+  let debug_line_rollback () =
+    match !dwarf with
+    | None -> ()
+    | Some dwarf -> Dwarf.debug_line_rollback dwarf
 end
 
 let report_error ppf = function

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -514,6 +514,21 @@ module Dwarf_helpers = struct
     | Some dwarf -> Dwarf.dwarf_for_line_number_matrix_row dwarf ~instr_address
       ~file_num ~line ~col ~discriminator
 
+  let record_dwarf_for_cfi_startproc ~address =
+    match !dwarf with
+    | None -> ()
+    | Some dwarf -> Dwarf.dwarf_for_cfi_startproc dwarf ~address
+
+  let record_dwarf_for_cfi_adjust_cfa_offset ~address ~offset =
+    match !dwarf with
+    | None -> ()
+    | Some dwarf -> Dwarf.dwarf_for_cfi_adjust_cfa_offset dwarf ~address ~offset
+
+  let record_dwarf_for_cfi_endproc ~address =
+    match !dwarf with
+    | None -> ()
+    | Some dwarf -> Dwarf.dwarf_for_cfi_endproc dwarf ~address
+
   let checkpoint () =
     match !dwarf with
     | None -> ()

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -513,15 +513,15 @@ module Dwarf_helpers = struct
     | Some dwarf -> Dwarf.dwarf_for_line_number_matrix_row dwarf ~instr_address
       ~file_num ~line ~col ~discriminator
 
-  let debug_line_checkpoint () =
+  let checkpoint () =
     match !dwarf with
     | None -> ()
-    | Some dwarf -> Dwarf.debug_line_checkpoint dwarf
+    | Some dwarf -> Dwarf.checkpoint dwarf
 
-  let debug_line_rollback () =
+  let rollback () =
     match !dwarf with
     | None -> ()
-    | Some dwarf -> Dwarf.debug_line_rollback dwarf
+    | Some dwarf -> Dwarf.rollback dwarf
 end
 
 let report_error ppf = function

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -471,9 +471,10 @@ module Dwarf_helpers = struct
     reset_dwarf ();
     let can_emit_dwarf =
       !Clflags.debug
-      && not !Dwarf_flags.restrict_to_upstream_dwarf
       && not disable_dwarf
     in
+    if !Flambda_backend_flags.internal_assembler then
+      Dwarf_flags.set_debug_thing Dwarf_flags.Debug_source_lines;
     match can_emit_dwarf,
           Target_system.architecture (),
           Target_system.derived_system () with
@@ -499,6 +500,18 @@ module Dwarf_helpers = struct
       in
       Dwarf.dwarf_for_fundecl dwarf fundecl;
       Some label
+
+  let record_dwarf_for_source_file ~file_name ~file_num =
+    match !dwarf with
+    | None -> ()
+    | Some dwarf -> Dwarf.dwarf_for_source_file dwarf ~file_name ~file_num
+
+  let record_dwarf_for_line_number_matrix_row ~instr_address ~file_num ~line ~col
+      ~discriminator =
+    match !dwarf with
+    | None -> ()
+    | Some dwarf -> Dwarf.dwarf_for_line_number_matrix_row dwarf ~instr_address
+      ~file_num ~line ~col ~discriminator
 end
 
 let report_error ppf = function

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -473,8 +473,9 @@ module Dwarf_helpers = struct
       !Clflags.debug
       && not disable_dwarf
     in
-    if !Flambda_backend_flags.internal_assembler then
+    if !Flambda_backend_flags.internal_assembler then (
       Dwarf_flags.set_debug_thing Dwarf_flags.Debug_source_lines;
+      Dwarf_flags.set_debug_thing Dwarf_flags.Debug_dwarf_cfi);
     match can_emit_dwarf,
           Target_system.architecture (),
           Target_system.derived_system () with

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -132,6 +132,10 @@ module Dwarf_helpers : sig
     -> col : int
     -> discriminator : int option
     -> unit
+
+  val debug_line_checkpoint : unit -> unit
+  
+  val debug_line_rollback : unit -> unit
 end
 
 exception Error of error

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -133,6 +133,12 @@ module Dwarf_helpers : sig
     -> discriminator : int option
     -> unit
 
+  val record_dwarf_for_cfi_startproc : address:int -> unit
+
+  val record_dwarf_for_cfi_adjust_cfa_offset : address:int -> offset:int -> unit
+
+  val record_dwarf_for_cfi_endproc : address:int -> unit
+
   val checkpoint : unit -> unit
   
   val rollback : unit -> unit
@@ -140,4 +146,3 @@ end
 
 exception Error of error
 val report_error: Format.formatter -> error -> unit
-

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -133,9 +133,9 @@ module Dwarf_helpers : sig
     -> discriminator : int option
     -> unit
 
-  val debug_line_checkpoint : unit -> unit
+  val checkpoint : unit -> unit
   
-  val debug_line_rollback : unit -> unit
+  val rollback : unit -> unit
 end
 
 exception Error of error

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -121,6 +121,17 @@ module Dwarf_helpers : sig
   val emit_dwarf : unit -> unit
 
   val record_dwarf_for_fundecl : fun_name:string -> Debuginfo.t -> Cmm.label option
+
+  val record_dwarf_for_source_file :
+    file_name:string -> file_num:int -> unit
+
+  val record_dwarf_for_line_number_matrix_row
+    : instr_address : int
+    -> file_num : int
+    -> line : int
+    -> col : int
+    -> discriminator : int option
+    -> unit
 end
 
 exception Error of error

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -158,7 +158,6 @@ let make_relocation_section sections ~sym_tbl_idx relocation_table
     ~align:8L ~sh_info:idx
 
 let assemble_one_section ~name instructions =
-  print_endline (X86_proc.Section_name.to_string name);
   let align =
     List.fold_left
       (fun acc i ->

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -157,34 +157,47 @@ let make_relocation_section sections ~sym_tbl_idx relocation_table
     ~flags:0x40L (* SHF_INFO_LINK *) ~sh_link:sym_tbl_idx sh_string_table
     ~align:8L ~sh_info:idx
 
+let assemble_one_section ~name instructions =
+  print_endline (X86_proc.Section_name.to_string name);
+  let align =
+    List.fold_left
+      (fun acc i ->
+        match i with X86_ast.Align (data, n) when n > acc -> n | _ -> acc)
+      0 instructions
+  in
+  align,
+  X86_binary_emitter.assemble_section X64
+    { X86_binary_emitter.sec_name = X86_proc.Section_name.to_string name;
+      sec_instrs = Array.of_list instructions
+    }
+
 let get_sections sections =
-  List.fold_left
-    (fun acc (name, instructions) ->
-      let align =
-        List.fold_left
-          (fun acc i ->
-            match i with X86_ast.Align (data, n) when n > acc -> n | _ -> acc)
-          0 instructions
-      in
-      Section_name.Map.add name
-        ( align,
-          X86_binary_emitter.assemble_section X64
-            { X86_binary_emitter.sec_name = X86_proc.Section_name.to_string name;
-              sec_instrs = Array.of_list instructions
-            } )
-        acc)
-    Section_name.Map.empty sections
+  let sections = Section_name.Tbl.to_seq sections |> List.of_seq in
+  let text_data, others =
+    List.partition
+      (fun (name, _) -> Section_name.is_text_like name || Section_name.is_data_like name)
+      sections
+  in
+  let aux sections acc =
+    List.fold_left (fun acc (name, instructions) ->
+      let instructions = List.rev !instructions in
+      Section_name.Map.add name (assemble_one_section ~name instructions) acc)
+      acc sections
+  in
+  let acc = aux text_data Section_name.Map.empty in
+  Emitaux.Dwarf_helpers.emit_dwarf ();
+  aux others acc
 
 let make_compiler_sections section_table compiler_sections symbol_table
     sh_string_table =
   let section_symbols = Section_name.Tbl.create 100 in
   Section_name.Map.iter
     (fun name (align, raw_section) ->
-      if isprefix ".text" (X86_proc.Section_name.to_string name)
+      if Section_name.is_text_like name
       then
         make_text section_table name raw_section ~align:(Int64.of_int align)
           sh_string_table
-      else if isprefix ".data" (X86_proc.Section_name.to_string name)
+      else if Section_name.is_data_like name
       then
         make_data section_table name raw_section ~align:(Int64.of_int align)
           sh_string_table

--- a/backend/internal_assembler/internal_assembler.mli
+++ b/backend/internal_assembler/internal_assembler.mli
@@ -23,6 +23,6 @@
 (** Create .o file. **)
 val assemble :
   (module Compiler_owee.Unix_intf.S) ->
-  (X86_proc.Section_name.t * X86_ast.asm_line list) list ->
+  X86_ast.asm_program ref X86_proc.Section_name.Tbl.t ->
   string ->
   unit

--- a/backend/internal_assembler/relocation_entry.ml
+++ b/backend/internal_assembler/relocation_entry.ml
@@ -57,7 +57,10 @@ let create_relocation (relocation : X86_binary_emitter.Relocation.t)
       (get_reloc_info ~relocation_type:1 (* R_X86_64_64 *) ~addend name
          symbol_table)
         string_table
-    | DIR32 (_, _) -> failwith "cannot generate dir32"
+    | DIR32 (name, addend) ->
+      (get_reloc_info ~relocation_type:10 (* R_X86_64_32 *) ~addend name
+         symbol_table)
+        string_table
     | REL32 (name, addend) -> (
       match String.split_on_char '@' name with
       | [name; "GOTPCREL"] ->

--- a/backend/internal_assembler/relocation_table.ml
+++ b/backend/internal_assembler/relocation_table.ml
@@ -52,5 +52,5 @@ let write t section_table buf =
         (* 24 is the size of each relocation entry *)
         let idx = (i * 24) + Int64.to_int table.sh_offset in
         Relocation_entry.write relocation (cursor buf ~at:idx))
-      t.relocations
+      (List.rev t.relocations)
   | None -> ()

--- a/backend/internal_assembler/symbol_table.ml
+++ b/backend/internal_assembler/symbol_table.ml
@@ -80,17 +80,17 @@ let get_label t name = String.Tbl.find t.labels_tbl name
 
 let get_label_idx t name =
   let label, symbol = get_label t name in
-  let idx = IntTbl.find t.section_symbol_tbl (Symbol_entry.get_shndx symbol) in
+  let idx = (IntTbl.find t.section_symbol_tbl (Symbol_entry.get_shndx symbol)) + 1 in
   label, idx
 
 let get_symbol_idx_opt t name =
   match String.Tbl.find_opt t.global_symbols_tbl name with
-  | Some idx -> Some (t.local_num_symbols + idx)
-  | None -> String.Tbl.find_opt t.local_symbols_tbl name
+  | Some idx -> Some (t.local_num_symbols + idx + 1)
+  | None -> String.Tbl.find_opt t.local_symbols_tbl name |> Option.map succ
 
-let num_symbols t = t.local_num_symbols + t.global_num_symbols
+let num_symbols t = t.local_num_symbols + t.global_num_symbols + 1
 
-let num_locals t = t.local_num_symbols
+let num_locals t = t.local_num_symbols + 1
 
 let make_undef_symbol t name string_table =
   add_symbol t (Symbol_entry.create_undef_symbol name string_table)
@@ -106,9 +106,18 @@ let make_symbol t symbol sections string_table =
   in
   add_symbol t symbol_entry
 
+open Compiler_owee.Owee_buf
+
 let write t sh_offset buf =
+  let cursor = Compiler_owee.Owee_buf.cursor buf ~at:(Int64.to_int sh_offset) in
+  Write.u32 cursor 0;
+  Write.u8 cursor 0;
+  Write.u8 cursor 0;
+  Write.u16 cursor 0;
+  Write.u64 cursor 0L;
+  Write.u64 cursor 0L;
   List.iteri
     (fun i symbol ->
-      let idx = (i * 24) + Int64.to_int sh_offset in
+      let idx = ((i + 1) * 24) + Int64.to_int sh_offset in
       Symbol_entry.write symbol (Compiler_owee.Owee_buf.cursor buf ~at:idx))
     (List.rev t.local_symbols @ List.rev t.global_symbols)

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1745,6 +1745,7 @@ let assemble_section arch section =
     (*     if !passes >= 2 then Printf.eprintf "[binary backend] pass %i\n%!" !passes; *)
     let b = new_buffer section in
     local_relocs := [];
+    Emitaux.Dwarf_helpers.debug_line_checkpoint ();
 
     let loc = ref 0 in
     ArrayLabels.iter ~f:(assemble_line b loc) section.sec_instrs;
@@ -1796,7 +1797,9 @@ let assemble_section arch section =
     ListLabels.iter !local_relocs ~f:(fun (pos, local_reloc) ->
         do_local_reloc pos local_reloc);
 
-    if !retry then iter_assemble () else b
+    if !retry 
+    then let _ = Emitaux.Dwarf_helpers.debug_line_rollback () in iter_assemble () 
+    else b
   in
   iter_assemble ()
 

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1745,7 +1745,7 @@ let assemble_section arch section =
     (*     if !passes >= 2 then Printf.eprintf "[binary backend] pass %i\n%!" !passes; *)
     let b = new_buffer section in
     local_relocs := [];
-    Emitaux.Dwarf_helpers.debug_line_checkpoint ();
+    Emitaux.Dwarf_helpers.checkpoint ();
 
     let loc = ref 0 in
     ArrayLabels.iter ~f:(assemble_line b loc) section.sec_instrs;
@@ -1798,7 +1798,7 @@ let assemble_section arch section =
         do_local_reloc pos local_reloc);
 
     if !retry 
-    then let _ = Emitaux.Dwarf_helpers.debug_line_rollback () in iter_assemble () 
+    then let _ = Emitaux.Dwarf_helpers.rollback () in iter_assemble () 
     else b
   in
   iter_assemble ()

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1651,9 +1651,9 @@ let assemble_line b loc ins =
     | Section _ -> assert false
     | Mode386 -> assert (system = S_win32)
     | Model _ -> assert (system = S_win32)
-    | Cfi_startproc -> ()
-    | Cfi_endproc -> ()
-    | Cfi_adjust_cfa_offset _ -> ()
+    | Cfi_startproc -> print_endline "Cfi_startproc"
+    | Cfi_endproc -> print_endline "Cfi_endproc"
+    | Cfi_adjust_cfa_offset offset -> print_endline ("Cfi_adjust_cfa_offset " ^ Int.to_string offset)
     | File (file_num, file_name) ->
         Emitaux.Dwarf_helpers.record_dwarf_for_source_file ~file_name ~file_num
     | Loc { file_num; line; col; discriminator } ->

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1651,9 +1651,15 @@ let assemble_line b loc ins =
     | Section _ -> assert false
     | Mode386 -> assert (system = S_win32)
     | Model _ -> assert (system = S_win32)
-    | Cfi_startproc -> print_endline "Cfi_startproc"
-    | Cfi_endproc -> print_endline "Cfi_endproc"
-    | Cfi_adjust_cfa_offset offset -> print_endline ("Cfi_adjust_cfa_offset " ^ Int.to_string offset)
+    | Cfi_startproc ->
+      let address = Buffer.length b.buf in
+      Emitaux.Dwarf_helpers.record_dwarf_for_cfi_startproc ~address
+    | Cfi_endproc ->
+      let address = Buffer.length b.buf in
+      Emitaux.Dwarf_helpers.record_dwarf_for_cfi_endproc ~address
+    | Cfi_adjust_cfa_offset offset ->
+      let address = Buffer.length b.buf in
+      Emitaux.Dwarf_helpers.record_dwarf_for_cfi_adjust_cfa_offset ~address ~offset
     | File (file_num, file_name) ->
         Emitaux.Dwarf_helpers.record_dwarf_for_source_file ~file_name ~file_num
     | Loc { file_num; line; col; discriminator } ->

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -48,6 +48,13 @@ module Section_name = struct
         | [hd] -> Option.value ~default:0L (Int64.of_string_opt hd)
         | hd :: tl -> align tl
       in align t.args
+
+    let isprefix s1 s2 =
+      String.length s1 <= String.length s2
+      && String.equal (String.sub s2 0 (String.length s1)) s1
+
+    let is_text_like t = isprefix ".text" t.name_str
+    let is_data_like t = isprefix ".data" t.name_str
   end
   include S
   module Map = Map.Make (S)
@@ -357,10 +364,6 @@ let generate_code asm =
   end;
   begin match !internal_assembler with
     | Some f ->
-      let instrs = Section_name.Tbl.fold (fun name instrs acc ->
-          (name, List.rev !instrs) :: acc)
-          asm_code_by_section []
-      in
-      binary_content := Some (f instrs)
+      binary_content := Some (f asm_code_by_section)
   | None -> binary_content := None
   end

--- a/backend/x86_proc.mli
+++ b/backend/x86_proc.mli
@@ -90,7 +90,7 @@ val windows:bool
 val use_plt : bool
 
 module Section_name : sig
-  type t 
+  type t
   val equal : t -> t -> bool
   val hash : t -> int
   val compare : t -> t -> int
@@ -99,6 +99,8 @@ module Section_name : sig
   val to_string : t -> string
   val flags : t -> string option
   val alignment : t -> int64
+  val is_text_like : t -> bool
+  val is_data_like : t -> bool
 
   module Map : Map.S with type key = t
   module Tbl : Hashtbl.S with type key = t
@@ -107,7 +109,7 @@ end
 (** Support for plumbing a binary code emitter *)
 
 val internal_assembler :
-  ((Section_name.t * X86_ast.asm_program) list -> string -> unit) option ref
+  (X86_ast.asm_program ref Section_name.Tbl.t -> string -> unit) option ref
 
 val register_internal_assembler :
-  ((Section_name.t * X86_ast.asm_program) list -> string -> unit) -> unit
+  (X86_ast.asm_program ref Section_name.Tbl.t -> string -> unit) -> unit

--- a/ocaml/parsing/location.ml
+++ b/ocaml/parsing/location.ml
@@ -25,6 +25,7 @@ let in_file name =
 
 let none = in_file "_none_";;
 let is_none l = (l = none);;
+let is_dummy_filename name = name = "_none_";;
 
 let curr lexbuf = {
   loc_start = lexbuf.lex_start_p;

--- a/ocaml/parsing/location.mli
+++ b/ocaml/parsing/location.mli
@@ -58,6 +58,8 @@ val none : t
 val is_none : t -> bool
 (** True for [Location.none], false any other location *)
 
+val is_dummy_filename : string -> bool
+
 val in_file : string -> t
 (** Return an empty ghost range located in a given file. *)
 


### PR DESCRIPTION
The internal assembler did not support generating call frame information. The new functionality was tested by comparing the .eh_frame section generated by the internal assembler to the .eh_frame information generated by the external assembler for some binaries.

Only the last 6 commits are related to CFI information; the first 8 commits are part of PR #1669 (DWARF line number information).