### PR TITLE
Reg_availability_set improvements etc

### DIFF
--- a/backend/debug/is_parameter.ml
+++ b/backend/debug/is_parameter.ml
@@ -24,18 +24,6 @@ let parameter ~index =
   if index < 0 then Misc.fatal_errorf "Bad parameter index %d" index;
   Parameter { index }
 
-let join t1 t2 =
-  match t1, t2 with
-  | Local, Local -> Local
-  | Parameter { index }, Local | Local, Parameter { index } ->
-    Parameter { index }
-  | Parameter { index = index1 }, Parameter { index = index2 } ->
-    if index1 <> index2
-    then
-      Misc.fatal_error
-        "Cannot join [Is_parameter.t] values that disagree on parameter indexes"
-    else Parameter { index = index1 }
-
 include Identifiable.Make (struct
   type nonrec t = t
 

--- a/backend/debug/is_parameter.ml
+++ b/backend/debug/is_parameter.ml
@@ -1,0 +1,61 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Local
+  | Parameter of { index : int }
+
+let local = Local
+
+let parameter ~index =
+  if index < 0 then Misc.fatal_errorf "Bad parameter index %d" index;
+  Parameter { index }
+
+let join t1 t2 =
+  match t1, t2 with
+  | Local, Local -> Local
+  | Parameter { index }, Local | Local, Parameter { index } ->
+    Parameter { index }
+  | Parameter { index = index1 }, Parameter { index = index2 } ->
+    if index1 <> index2
+    then
+      Misc.fatal_error
+        "Cannot join [Is_parameter.t] values that disagree on parameter indexes"
+    else Parameter { index = index1 }
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare t1 t2 =
+    match t1, t2 with
+    | Local, Local -> 0
+    | Parameter { index = index1 }, Parameter { index = index2 } ->
+      Stdlib.compare index1 index2
+    | Local, Parameter _ -> -1
+    | Parameter _, Local -> 1
+
+  let equal t1 t2 = compare t1 t2 = 0
+
+  let hash t = Hashtbl.hash t
+
+  let print ppf t =
+    match t with
+    | Local -> Format.pp_print_string ppf "local"
+    | Parameter { index } ->
+      Format.fprintf ppf "@[(parameter@ (index %d))@]" index
+
+  let output _ _ = Misc.fatal_error "Not yet implemented"
+end)

--- a/backend/debug/is_parameter.mli
+++ b/backend/debug/is_parameter.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2016--2017 Jane Street Group LLC                           *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,33 +12,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Register availability sets. *)
+[@@@ocaml.warning "+a-4-30-40-41-42"]
 
-type t =
-  | Ok of Reg_with_debug_info.Set.t
-  | Unreachable
+(** Whether a variable is a local or a function parameter. *)
 
-(** See comments in the .ml file about these functions. *)
+type t = private
+  | Local
+  | Parameter of { index : int }
 
-val of_list : Reg_with_debug_info.t list -> t
+val local : t
 
-val union : t -> t -> t
+val parameter : index:int -> t
 
-val inter : t -> t -> t
+val join : t -> t -> t
 
-val diff : t -> t -> t
-
-(** This returns the initial value in the [Unreachable] case *)
-val fold : (Reg_with_debug_info.t -> 'a -> 'a) -> t -> 'a -> 'a
-
-(** Return a subset of the given availability set which contains no registers
-    that are not associated with debug info (and holding values of
-    non-persistent identifiers); and where no two registers share the same
-    location. *)
-val canonicalise : t -> t
-
-val equal : t -> t -> bool
-
-(** For debugging purposes only. *)
-val print :
-  print_reg:(Format.formatter -> Reg.t -> unit) -> Format.formatter -> t -> unit
+include Identifiable.S with type t := t

--- a/backend/debug/is_parameter.mli
+++ b/backend/debug/is_parameter.mli
@@ -24,6 +24,4 @@ val local : t
 
 val parameter : index:int -> t
 
-val join : t -> t -> t
-
 include Identifiable.S with type t := t

--- a/backend/debug/reg_availability_set.ml
+++ b/backend/debug/reg_availability_set.ml
@@ -23,6 +23,9 @@ type t =
 
 let of_list rds = Ok (RD.Set.of_list rds)
 
+(* CR mshinwell: The implementations below probably aren't really adequate, but
+   will suffice for now. We should aim to improve them soon *)
+
 let union t1 t2 =
   (* Since [RD.Set]'s comparison function just looks at the [Reg.t] values, this
      will arbitrarily pick between debug info values in the case where [t1] and

--- a/backend/debug/reg_availability_set.ml
+++ b/backend/debug/reg_availability_set.ml
@@ -21,10 +21,22 @@ type t =
   | Ok of RD.Set.t
   | Unreachable
 
-let inter regs1 regs2 =
-  match regs1, regs2 with
-  | Unreachable, _ -> regs2
-  | _, Unreachable -> regs1
+let of_list rds = Ok (RD.Set.of_list rds)
+
+let union t1 t2 =
+  (* Since [RD.Set]'s comparison function just looks at the [Reg.t] values, this
+     will arbitrarily pick between debug info values in the case where [t1] and
+     [t2] both contain the same [Reg.t]. That seems ok, at least for now. *)
+  match t1, t2 with
+  | Ok avail1, Ok avail2 -> Ok (RD.Set.union avail1 avail2)
+  | Unreachable, _ | _, Unreachable -> Unreachable
+
+(* This is intersection on the [Reg.t] values with the additional semantics that
+   conflicting debug info values are erased (see comment below). *)
+let inter t1 t2 =
+  match t1, t2 with
+  | Unreachable, _ -> t2
+  | _, Unreachable -> t1
   | Ok avail1, Ok avail2 ->
     let result =
       RD.Set.fold
@@ -57,11 +69,17 @@ let inter regs1 regs2 =
     in
     Ok result
 
-let equal t1 t2 =
+(* This ignores the debug info values completely. *)
+let diff t1 t2 =
   match t1, t2 with
-  | Unreachable, Unreachable -> true
-  | Unreachable, Ok _ | Ok _, Unreachable -> false
-  | Ok regs1, Ok regs2 -> RD.Set.equal regs1 regs2
+  | Unreachable, (Ok _ | Unreachable) -> Unreachable
+  | Ok avail1, Ok avail2 -> Ok (RD.Set.diff avail1 avail2)
+  | Ok _, Unreachable -> Ok RD.Set.empty
+
+let fold f t init =
+  match t with
+  | Unreachable -> init
+  | Ok availability -> RD.Set.fold f availability init
 
 let canonicalise availability =
   match availability with
@@ -99,6 +117,13 @@ let canonicalise availability =
         regs_by_ident RD.Set.empty
     in
     Ok result
+
+(* This ignores the debug info values. *)
+let equal t1 t2 =
+  match t1, t2 with
+  | Unreachable, Unreachable -> true
+  | Unreachable, Ok _ | Ok _, Unreachable -> false
+  | Ok regs1, Ok regs2 -> RD.Set.equal regs1 regs2
 
 let print ~print_reg ppf = function
   | Unreachable -> Format.fprintf ppf "<unreachable>"

--- a/backend/debug/reg_with_debug_info.ml
+++ b/backend/debug/reg_with_debug_info.ml
@@ -21,6 +21,7 @@ module Debug_info = struct
     { holds_value_of : V.t;
       part_of_value : int;
       num_parts_of_value : int;
+      (* CR mshinwell: use [Is_parameter] *)
       which_parameter : int option;
       provenance : Backend_var.Provenance.t option
     }
@@ -51,6 +52,11 @@ module Debug_info = struct
     match t.which_parameter with
     | None -> ()
     | Some index -> Format.fprintf ppf "[P%d]" index
+
+  let is_parameter t =
+    match t.which_parameter with
+    | None -> Is_parameter.local
+    | Some index -> Is_parameter.parameter ~index
 end
 
 module T = struct

--- a/backend/debug/reg_with_debug_info.mli
+++ b/backend/debug/reg_with_debug_info.mli
@@ -32,6 +32,8 @@ module Debug_info : sig
   val which_parameter : t -> int option
 
   val provenance : t -> Backend_var.Provenance.t option
+
+  val is_parameter : t -> Is_parameter.t
 end
 
 type t
@@ -112,3 +114,5 @@ end
 
 val print :
   print_reg:(Format.formatter -> Reg.t -> unit) -> Format.formatter -> t -> unit
+
+val compare : t -> t -> int

--- a/dune
+++ b/dune
@@ -273,6 +273,7 @@
   available_regs
   reg_with_debug_info
   compute_ranges
+  is_parameter
   ;; asmcomp/debug/dwarf/dwarf_ocaml
   ;; This code has a lot of dependencies into ocamloptcomp, so we just
   ;; build it as part of that library.


### PR DESCRIPTION
This fills in the missing functionality in `Reg_availability_set` and `Reg_with_debug_info`.  A new `Is_parameter` module is used to provide information about whether variables are locals or function parameters.