### PR TITLE
Fixes for arm64

### DIFF
--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -185,6 +185,22 @@ let emit_call_gc gc =
   `{emit_label gc.gc_lbl}:	bl	{emit_symbol "caml_call_gc"}\n`;
   `{emit_label gc.gc_frame_lbl}:	b	{emit_label gc.gc_return_lbl}\n`
 
+(* Record calls to local stack reallocation *)
+
+type local_realloc_call =
+  {  lr_lbl: label;
+     lr_return_lbl: label;
+     lr_dbg: Debuginfo.t
+  }
+
+let local_realloc_sites = ref ([] : local_realloc_call list)
+
+let emit_local_realloc lr =
+  `{emit_label lr.lr_lbl}:\n`;
+  `	{emit_debug_info lr.lr_dbg}\n`;
+  `	bl	{emit_symbol "caml_call_local_realloc"}\n`;
+  `	b	{emit_label lr.lr_return_lbl}\n`
+
 (* Record calls to caml_ml_array_bound_error.
    In debug mode, we maintain one call to caml_ml_array_bound_error
    per bound check site. Otherwise, we can share a single call. *)
@@ -397,7 +413,7 @@ let num_call_gc_and_check_bound_points instr =
   let rec loop instr ((call_gc, check_bound) as totals) =
     match instr.desc with
     | Lend -> totals
-    | Lop (Ialloc _) when !fastcode_flag ->
+    | Lop (Ialloc {mode = Alloc_heap; _}) when !fastcode_flag ->
       loop instr.next (call_gc + 1, check_bound)
     | Lop (Ipoll _) ->
       loop instr.next (call_gc + 1, check_bound)
@@ -523,8 +539,7 @@ module BR = Branch_relaxation.Make (struct
       | _ -> 1 + num_instructions_for_intconst (Nativeint.of_int num_bytes)
       end
     | Lop (Icsel _) -> 4
-    | Lop (Ibeginregion | Iendregion) ->
-       Misc.fatal_error "Local allocations not supported on this architecture"
+    | Lop (Ibeginregion | Iendregion) -> 1
     | Lop (Iintop (Icomp _)) -> 2
     | Lop (Icompf _) -> 2
     | Lop (Iintop_imm (Icomp _, _)) -> 2
@@ -602,44 +617,67 @@ end)
 
 (* Output the assembly code for allocation. *)
 
-let assembly_code_for_allocation i ~n ~far ~dbginfo =
-  let lbl_frame =
-    record_frame_label i.live (Dbg_alloc dbginfo)
-  in
-  if !fastcode_flag then begin
-    let lbl_after_alloc = new_label() in
-    let lbl_call_gc = new_label() in
-    (* n is at most Max_young_whsize * 8, i.e. currently 0x808,
-       so it is reasonable to assume n < 0x1_000.  This makes
-       the generated code simpler. *)
-    assert (16 <= n && n < 0x1_000 && n land 0x7 = 0);
-    let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-    `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`;
-    `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
-    `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp1}\n`;
-    if not far then begin
-      `	b.lo	{emit_label lbl_call_gc}\n`
-    end else begin
-      let lbl = new_label () in
-      `	b.cs	{emit_label lbl}\n`;
-      `	b	{emit_label lbl_call_gc}\n`;
-      `{emit_label lbl}:\n`
-    end;
-    `{emit_label lbl_after_alloc}:`;
-    `	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
-    call_gc_sites :=
-      { gc_lbl = lbl_call_gc;
-        gc_return_lbl = lbl_after_alloc;
-        gc_frame_lbl = lbl_frame } :: !call_gc_sites
+let assembly_code_for_allocation i ~local ~n ~far ~dbginfo =
+  if local then begin
+    let r = i.res.(0) in
+    let domain_local_sp_offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
+    let domain_local_limit_offset = Domainstate.(idx_of_field Domain_local_limit) * 8 in
+    let domain_local_top_offset = Domainstate.(idx_of_field Domain_local_top) * 8 in
+    `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int domain_local_limit_offset}]\n`;
+    `	ldr	{emit_reg r}, [{emit_reg reg_domain_state_ptr}, #{emit_int domain_local_sp_offset}]\n`;
+    `	sub	{emit_reg r}, {emit_reg r}, #{emit_int n}\n`;
+    `	str	{emit_reg r}, [{emit_reg reg_domain_state_ptr}, #{emit_int domain_local_sp_offset}]\n`;
+    `	cmp	{emit_reg r}, {emit_reg reg_tmp1}\n`;
+    let lbl_call = new_label () in
+    `	b.le	{emit_label lbl_call}\n`;
+    let lbl_after_alloc = new_label () in
+    `{emit_label lbl_after_alloc}:\n`;
+    `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int domain_local_top_offset}]\n`;
+    `	add	{emit_reg r}, {emit_reg r}, {emit_reg reg_tmp1}\n`;
+    `	add	{emit_reg r}, {emit_reg r}, #{emit_int 8}\n`;
+    local_realloc_sites :=
+      { lr_lbl = lbl_call;
+        lr_dbg = i.dbg;
+        lr_return_lbl = lbl_after_alloc } :: !local_realloc_sites
   end else begin
-    begin match n with
-    | 16 -> `	bl	{emit_symbol "caml_alloc1"}\n`
-    | 24 -> `	bl	{emit_symbol "caml_alloc2"}\n`
-    | 32 -> `	bl	{emit_symbol "caml_alloc3"}\n`
-    | _  -> emit_intconst reg_x8 (Nativeint.of_int n);
-            `	bl	{emit_symbol "caml_allocN"}\n`
-    end;
-    `{emit_label lbl_frame}:	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`
+    let lbl_frame =
+      record_frame_label i.live (Dbg_alloc dbginfo)
+    in
+    if !fastcode_flag then begin
+      let lbl_after_alloc = new_label() in
+      let lbl_call_gc = new_label() in
+      (* n is at most Max_young_whsize * 8, i.e. currently 0x808,
+         so it is reasonable to assume n < 0x1_000.  This makes
+         the generated code simpler. *)
+      assert (16 <= n && n < 0x1_000 && n land 0x7 = 0);
+      let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
+      `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`;
+      `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
+      `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp1}\n`;
+      if not far then begin
+        `	b.lo	{emit_label lbl_call_gc}\n`
+      end else begin
+        let lbl = new_label () in
+        `	b.cs	{emit_label lbl}\n`;
+        `	b	{emit_label lbl_call_gc}\n`;
+        `{emit_label lbl}:\n`
+      end;
+      `{emit_label lbl_after_alloc}:`;
+      `	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
+      call_gc_sites :=
+        { gc_lbl = lbl_call_gc;
+          gc_return_lbl = lbl_after_alloc;
+          gc_frame_lbl = lbl_frame } :: !call_gc_sites
+    end else begin
+      begin match n with
+      | 16 -> `	bl	{emit_symbol "caml_alloc1"}\n`
+      | 24 -> `	bl	{emit_symbol "caml_alloc2"}\n`
+      | 32 -> `	bl	{emit_symbol "caml_alloc3"}\n`
+      | _  -> emit_intconst reg_x8 (Nativeint.of_int n);
+              `	bl	{emit_symbol "caml_allocN"}\n`
+      end;
+      `{emit_label lbl_frame}:	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`
+    end
   end
 
 let assembly_code_for_poll i ~far ~return_label =
@@ -852,11 +890,17 @@ let emit_instr i =
         | Onetwentyeight -> fatal_error "arm64: got 128 bit memory chunk"
         end
     | Lop(Ialloc { bytes = n; dbginfo; mode = Alloc_heap }) ->
-        assembly_code_for_allocation i ~n ~far:false ~dbginfo
+        assembly_code_for_allocation i ~n ~local:false ~far:false ~dbginfo
     | Lop(Ispecific (Ifar_alloc { bytes = n; dbginfo })) ->
-        assembly_code_for_allocation i ~n ~far:true ~dbginfo
-    | Lop(Ialloc { mode = Alloc_local } | Ibeginregion | Iendregion) ->
-       Misc.fatal_error "Local allocations not supported on this architecture"
+        assembly_code_for_allocation i ~n ~local:false ~far:true ~dbginfo
+    | Lop(Ialloc { bytes = n; dbginfo; mode = Alloc_local }) ->
+        assembly_code_for_allocation i ~n ~local:true ~far:false ~dbginfo
+    | Lop(Ibeginregion) ->
+        let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
+        `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
+    | Lop(Iendregion) ->
+        let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
+        `	str	{emit_reg i.arg.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
     | Lop(Ipoll { return_label }) ->
         assembly_code_for_poll i ~far:false ~return_label
     | Lop(Ispecific (Ifar_poll { return_label })) ->
@@ -1137,6 +1181,7 @@ let fundecl fundecl =
   float_literals := [];
   stack_offset := 0;
   call_gc_sites := [];
+  local_realloc_sites := [];
   bound_error_sites := [];
   for i = 0 to Proc.num_stack_slot_classes - 1 do
     num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
@@ -1160,6 +1205,7 @@ let fundecl fundecl =
   BR.relax fundecl.fun_body ~max_out_of_line_code_offset;
   emit_all fundecl.fun_body;
   List.iter emit_call_gc !call_gc_sites;
+  List.iter emit_local_realloc !local_realloc_sites;
   List.iter emit_call_bound_error !bound_error_sites;
   assert (List.length !call_gc_sites = num_call_gc);
   assert (List.length !bound_error_sites = num_check_bound);

--- a/ocaml/asmcomp/arm64/emit.mlp
+++ b/ocaml/asmcomp/arm64/emit.mlp
@@ -476,8 +476,7 @@ module BR = Branch_relaxation.Make (struct
       | 16 | 24 | 32 -> 1
       | _ -> 1 + num_instructions_for_intconst (Nativeint.of_int num_bytes)
       end
-    | Lop (Ibeginregion | Iendregion) ->
-       Misc.fatal_error "Local allocations not supported on this architecture"
+    | Lop (Ibeginregion | Iendregion) -> 1
     | Lop (Iintop (Icomp _)) -> 2
     | Lop (Iintop_imm (Icomp _, _)) -> 2
     | Lop (Iintop (Icheckbound)) -> 2
@@ -552,7 +551,7 @@ end)
 
 (* Output the assembly code for allocation. *)
 
-let assembly_code_for_allocation env i ~n ~far ~dbginfo =
+let assembly_code_for_allocation env i ~local ~n ~far ~dbginfo =
   let lbl_frame =
     record_frame_label env i.live (Dbg_alloc dbginfo)
   in
@@ -776,11 +775,17 @@ let emit_instr env i =
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         end
     | Lop(Ialloc { bytes = n; dbginfo; mode = Alloc_heap  }) ->
-        assembly_code_for_allocation env i ~n ~far:false ~dbginfo
+        assembly_code_for_allocation env i ~n ~local:false ~far:false ~dbginfo
     | Lop(Ispecific (Ifar_alloc { bytes = n; dbginfo })) ->
-        assembly_code_for_allocation env i ~n ~far:true ~dbginfo
-    | Lop(Ialloc { mode = Alloc_local } | Ibeginregion | Iendregion) ->
-       Misc.fatal_error "Local allocations not supported on this architecture"
+        assembly_code_for_allocation env i ~n ~local:false ~far:true ~dbginfo
+    | Lop(Ialloc { bytes = n; dbginfo; mode = Alloc_local }) ->
+        assembly_code_for_allocation env i ~n ~local:false ~far:false ~dbginfo
+    | Lop(Ibeginregion) ->
+        let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
+        `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
+    | Lop(Iendregion) ->
+        let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
+        `	str	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
     | Lop(Ipoll { return_label }) ->
         assembly_code_for_poll env i ~far:false ~return_label
     | Lop(Ispecific (Ifar_poll { return_label })) ->

--- a/ocaml/asmcomp/arm64/emit.mlp
+++ b/ocaml/asmcomp/arm64/emit.mlp
@@ -160,6 +160,12 @@ let emit_call_gc gc =
   `{emit_label gc.gc_lbl}:	bl	{emit_symbol "caml_call_gc"}\n`;
   `{emit_label gc.gc_frame_lbl}:	b	{emit_label gc.gc_return_lbl}\n`
 
+let emit_local_realloc lr =
+  `{emit_label lr.lr_lbl}:\n`;
+  `	{emit_debug_info lr.lr_dbg}\n`;
+  `	bl	{emit_symbol "caml_call_local_realloc"}\n`;
+  `	b	{emit_label lr.lr_return_lbl}\n`
+
 let bound_error_label env dbg =
   if !Clflags.debug || env.bound_error_sites = [] then begin
     let lbl_bound_error = new_label() in
@@ -357,7 +363,7 @@ let num_call_gc_and_check_bound_points env =
   let rec loop instr ((call_gc, check_bound) as totals) =
     match instr.desc with
     | Lend -> totals
-    | Lop (Ialloc _) when env.f.fun_fast ->
+    | Lop (Ialloc { mode = Alloc_heap }) when env.f.fun_fast ->
       loop instr.next (call_gc + 1, check_bound)
     | Lop (Ipoll _) ->
       loop instr.next (call_gc + 1, check_bound)
@@ -552,43 +558,66 @@ end)
 (* Output the assembly code for allocation. *)
 
 let assembly_code_for_allocation env i ~local ~n ~far ~dbginfo =
-  let lbl_frame =
-    record_frame_label env i.live (Dbg_alloc dbginfo)
-  in
-  if env.f.fun_fast then begin
-    let lbl_after_alloc = new_label() in
-    let lbl_call_gc = new_label() in
-    (* n is at most Max_young_whsize * 8, i.e. currently 0x808,
-       so it is reasonable to assume n < 0x1_000.  This makes
-       the generated code simpler. *)
-    assert (16 <= n && n < 0x1_000 && n land 0x7 = 0);
-    let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-    `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`;
-    `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
-    `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp1}\n`;
-    if not far then begin
-      `	b.lo	{emit_label lbl_call_gc}\n`
-    end else begin
-      let lbl = new_label () in
-      `	b.cs	{emit_label lbl}\n`;
-      `	b	{emit_label lbl_call_gc}\n`;
-      `{emit_label lbl}:\n`
-    end;
-    `{emit_label lbl_after_alloc}:`;
-    `	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
-    env.call_gc_sites <-
-      { gc_lbl = lbl_call_gc;
-        gc_return_lbl = lbl_after_alloc;
-        gc_frame_lbl = lbl_frame; } :: env.call_gc_sites
+  if local then begin
+    let r = i.res.(0) in
+    let domain_local_sp_offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
+    let domain_local_limit_offset = Domainstate.(idx_of_field Domain_local_limit) * 8 in
+    let domain_local_top_offset = Domainstate.(idx_of_field Domain_local_top) * 8 in
+    `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int domain_local_limit_offset}]\n`;
+    `	ldr	{emit_reg r}, [{emit_reg reg_domain_state_ptr}, #{emit_int domain_local_sp_offset}]\n`;
+    `	sub	{emit_reg r}, {emit_reg r}, #{emit_int n}\n`;
+    `	str	{emit_reg r}, [{emit_reg reg_domain_state_ptr}, #{emit_int domain_local_sp_offset}]\n`;
+    `	cmp	{emit_reg r}, {emit_reg reg_tmp1}\n`;
+    let lbl_call = new_label () in
+    `	b.le	{emit_label lbl_call}\n`;
+    let lbl_after_alloc = new_label () in
+    `{emit_label lbl_after_alloc}:\n`;
+    `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int domain_local_top_offset}]\n`;
+    `	add	{emit_reg r}, {emit_reg r}, {emit_reg reg_tmp1}\n`;
+    `	add	{emit_reg r}, {emit_reg r}, #{emit_int 8}\n`;
+    env.local_realloc_sites <-
+      { lr_lbl = lbl_call;
+        lr_dbg = i.dbg;
+        lr_return_lbl = lbl_after_alloc } :: env.local_realloc_sites
   end else begin
-    begin match n with
-    | 16 -> `	bl	{emit_symbol "caml_alloc1"}\n`
-    | 24 -> `	bl	{emit_symbol "caml_alloc2"}\n`
-    | 32 -> `	bl	{emit_symbol "caml_alloc3"}\n`
-    | _  -> emit_intconst reg_x8 (Nativeint.of_int n);
-            `	bl	{emit_symbol "caml_allocN"}\n`
-    end;
-    `{emit_label lbl_frame}:	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`
+    let lbl_frame =
+      record_frame_label env i.live (Dbg_alloc dbginfo)
+    in
+    if env.f.fun_fast then begin
+      let lbl_after_alloc = new_label() in
+      let lbl_call_gc = new_label() in
+      (* n is at most Max_young_whsize * 8, i.e. currently 0x808,
+         so it is reasonable to assume n < 0x1_000.  This makes
+         the generated code simpler. *)
+      assert (16 <= n && n < 0x1_000 && n land 0x7 = 0);
+      let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
+      `	ldr	{emit_reg reg_tmp1}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`;
+      `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
+      `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp1}\n`;
+      if not far then begin
+        `	b.lo	{emit_label lbl_call_gc}\n`
+      end else begin
+        let lbl = new_label () in
+        `	b.cs	{emit_label lbl}\n`;
+        `	b	{emit_label lbl_call_gc}\n`;
+        `{emit_label lbl}:\n`
+      end;
+      `{emit_label lbl_after_alloc}:`;
+      `	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
+      env.call_gc_sites <-
+        { gc_lbl = lbl_call_gc;
+          gc_return_lbl = lbl_after_alloc;
+          gc_frame_lbl = lbl_frame; } :: env.call_gc_sites
+    end else begin
+      begin match n with
+      | 16 -> `	bl	{emit_symbol "caml_alloc1"}\n`
+      | 24 -> `	bl	{emit_symbol "caml_alloc2"}\n`
+      | 32 -> `	bl	{emit_symbol "caml_alloc3"}\n`
+      | _  -> emit_intconst reg_x8 (Nativeint.of_int n);
+              `	bl	{emit_symbol "caml_allocN"}\n`
+      end;
+      `{emit_label lbl_frame}:	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`
+    end
   end
 
 let assembly_code_for_poll env i ~far ~return_label =
@@ -779,13 +808,13 @@ let emit_instr env i =
     | Lop(Ispecific (Ifar_alloc { bytes = n; dbginfo })) ->
         assembly_code_for_allocation env i ~n ~local:false ~far:true ~dbginfo
     | Lop(Ialloc { bytes = n; dbginfo; mode = Alloc_local }) ->
-        assembly_code_for_allocation env i ~n ~local:false ~far:false ~dbginfo
+        assembly_code_for_allocation env i ~n ~local:true ~far:false ~dbginfo
     | Lop(Ibeginregion) ->
         let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
         `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
     | Lop(Iendregion) ->
         let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
-        `	str	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
+        `	str	{emit_reg i.arg.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
     | Lop(Ipoll { return_label }) ->
         assembly_code_for_poll env i ~far:false ~return_label
     | Lop(Ispecific (Ifar_poll { return_label })) ->
@@ -1041,6 +1070,7 @@ let fundecl fundecl =
   BR.relax fundecl ~max_out_of_line_code_offset;
   emit_all env fundecl.fun_body;
   List.iter emit_call_gc env.call_gc_sites;
+  List.iter emit_local_realloc env.local_realloc_sites;
   List.iter emit_call_bound_error env.bound_error_sites;
   assert (List.length env.call_gc_sites = num_call_gc);
   assert (List.length env.bound_error_sites = num_check_bound);

--- a/ocaml/asmcomp/emitenv.mli
+++ b/ocaml/asmcomp/emitenv.mli
@@ -25,7 +25,9 @@ type gc_call =
 (* Record calls to local stack reallocation *)
 type local_realloc_call =
   { lr_lbl: label;
-    lr_return_lbl: label; }
+    lr_return_lbl: label;
+    lr_dbg: Debuginfo.t
+  }
 
 (* Record calls to caml_ml_array_bound_error.
    In -g mode, we maintain one call to caml_ml_array_bound_error

--- a/ocaml/runtime/arm64.S
+++ b/ocaml/runtime/arm64.S
@@ -280,6 +280,91 @@ FUNCTION(caml_allocN)
         CFI_ENDPROC
         END_FUNCTION(caml_allocN)
 
+FUNCTION(caml_call_local_realloc)
+L(caml_call_local_realloc):
+        CFI_STARTPROC
+    /* Set up stack space, saving return address and frame pointer */
+    /* Store return address and frame pointer */
+    /* (2 RA/GP, 24 allocatable int regs, 24 caller-saved float regs) * 8 */
+        CFI_OFFSET(29,-400)
+        CFI_OFFSET(30,-392)
+        stp     x29, x30, [sp,-400]! /* pre-indexing stp */
+        CFI_ADJUST(400)
+        add     x29, sp, #0
+
+    /* Save allocatable integer registers on the stack, using order in proc.ml */
+        stp     x0, x1, [sp, 16]
+        stp     x2, x3, [sp, 32]
+        stp     x4, x5, [sp, 48]
+        stp     x6, x7, [sp, 64]
+        stp     x8, x9, [sp, 80]
+        stp     x10, x11, [sp, 96]
+        stp     x12, x13, [sp, 112]
+        stp     x14, x15, [sp, 128]
+        stp     x19, x20, [sp, 144]
+        stp     x21, x22, [sp, 160]
+        stp     x23, x24, [sp, 176]
+        str     x25, [sp, 192]
+
+    /* Save caller saved floating-point registers on the stack */
+        stp     d0, d1, [sp, 208]
+        stp     d2, d3, [sp, 224]
+        stp     d4, d5, [sp, 240]
+        stp     d6, d7, [sp, 256]
+        stp     d16, d17, [sp, 272]
+        stp     d18, d19, [sp, 288]
+        stp     d20, d21, [sp, 304]
+        stp     d22, d23, [sp, 320]
+        stp     d24, d25, [sp, 336]
+        stp     d26, d27, [sp, 352]
+        stp     d28, d29, [sp, 368]
+        stp     d30, d31, [sp, 384]
+
+    /* Store pointer to saved integer registers in Caml_state->gc_regs */
+        add     TMP, sp, #16
+        str     TMP, Caml_state(gc_regs)
+
+    /* Save current allocation pointer for debugging purposes */
+        str     ALLOC_PTR, Caml_state(young_ptr)
+
+    /* Call the realloc function */
+        bl      G(caml_local_realloc)
+
+    /* Restore registers */
+        ldp     x0, x1, [sp, 16]
+        ldp     x2, x3, [sp, 32]
+        ldp     x4, x5, [sp, 48]
+        ldp     x6, x7, [sp, 64]
+        ldp     x8, x9, [sp, 80]
+        ldp     x10, x11, [sp, 96]
+        ldp     x12, x13, [sp, 112]
+        ldp     x14, x15, [sp, 128]
+        ldp     x19, x20, [sp, 144]
+        ldp     x21, x22, [sp, 160]
+        ldp     x23, x24, [sp, 176]
+        ldr     x25, [sp, 192]
+        ldp     d0, d1, [sp, 208]
+        ldp     d2, d3, [sp, 224]
+        ldp     d4, d5, [sp, 240]
+        ldp     d6, d7, [sp, 256]
+        ldp     d16, d17, [sp, 272]
+        ldp     d18, d19, [sp, 288]
+        ldp     d20, d21, [sp, 304]
+        ldp     d22, d23, [sp, 320]
+        ldp     d24, d25, [sp, 336]
+        ldp     d26, d27, [sp, 352]
+        ldp     d28, d29, [sp, 368]
+        ldp     d30, d31, [sp, 384]
+
+    /* Reload new allocation pointer */
+        ldr     ALLOC_PTR, Caml_state(young_ptr)
+
+    /* Free stack space and return to caller */
+        ldp     x29, x30, [sp], 400
+        ret
+        CFI_ENDPROC
+        END_FUNCTION(caml_call_local_realloc)
+
 /* Call a C function from OCaml */
 /* Function to call is in ADDITIONAL_ARG */
 

--- a/ocaml/runtime/arm64.S
+++ b/ocaml/runtime/arm64.S
@@ -338,15 +338,19 @@ L(jump_to_caml):
         ldr     x8, Caml_state(bottom_of_stack)
         ldr     x9, Caml_state(last_return_address)
         ldr     x10, Caml_state(gc_regs)
+        ldr     x11, Caml_state(async_exception_pointer)
         stp     x8, x9, [sp, -32]!     /* 16-byte alignment */
         CFI_ADJUST(32)
         str     x10, [sp, 16]
+        str     x11, [sp, 24]
     /* Setup a trap frame to catch exceptions escaping the OCaml code */
         ldr     x8, Caml_state(exception_pointer)
         adr     x9, L(trap_handler)
         stp     x8, x9, [sp, -16]!
         CFI_ADJUST(16)
         add     TRAP_PTR, sp, #0
+    /* Store the async exception pointer */
+        str     TRAP_PTR, Caml_state(async_exception_pointer)
     /* Reload allocation pointer */
         ldr     ALLOC_PTR, Caml_state(young_ptr)
     /* Call the OCaml code */
@@ -358,12 +362,14 @@ L(caml_retaddr):
         str     x8, Caml_state(exception_pointer)
     /* Pop the callback link, restoring the global variables */
 L(return_result):
+        ldr     x11, [sp, 24]
         ldr     x10, [sp, 16]
         ldp     x8, x9, [sp], 32
         CFI_ADJUST(-32)
         str     x8, Caml_state(bottom_of_stack)
         str     x9, Caml_state(last_return_address)
         str     x10, Caml_state(gc_regs)
+        str     x11, Caml_state(async_exception_pointer)
     /* Update allocation pointer */
         str     ALLOC_PTR, Caml_state(young_ptr)
     /* Reload callee-save registers and return address */

--- a/ocaml/testsuite/tests/unboxed-primitive-args/test.ml
+++ b/ocaml/testsuite/tests/unboxed-primitive-args/test.ml
@@ -2,18 +2,19 @@
 
 readonly_files = "common.mli common.ml test_common.c test_common.h"
 
-* setup-ocamlopt.opt-build-env
-** ocaml
+* arch_amd64
+** setup-ocamlopt.opt-build-env
+*** ocaml
 test_file = "${test_source_directory}/gen_test.ml"
 ocaml_script_as_argument = "true"
 arguments = "c"
 compiler_output = "stubs.c"
-*** ocaml
+**** ocaml
 arguments = "ml"
 compiler_output = "main.ml"
-**** ocamlopt.opt
+***** ocamlopt.opt
 all_modules = "test_common.c stubs.c common.mli common.ml main.ml"
-***** run
-****** check-program-output
+****** run
+******* check-program-output
 
 *)

--- a/ocaml/testsuite/tests/unboxed-primitive-args/test.ml
+++ b/ocaml/testsuite/tests/unboxed-primitive-args/test.ml
@@ -2,19 +2,18 @@
 
 readonly_files = "common.mli common.ml test_common.c test_common.h"
 
-* arch_amd64
-** setup-ocamlopt.opt-build-env
-*** ocaml
+* setup-ocamlopt.opt-build-env
+** ocaml
 test_file = "${test_source_directory}/gen_test.ml"
 ocaml_script_as_argument = "true"
 arguments = "c"
 compiler_output = "stubs.c"
-**** ocaml
+*** ocaml
 arguments = "ml"
 compiler_output = "main.ml"
-***** ocamlopt.opt
+**** ocamlopt.opt
 all_modules = "test_common.c stubs.c common.mli common.ml main.ml"
-****** run
-******* check-program-output
+***** run
+****** check-program-output
 
 *)

--- a/tests/backend/regalloc_validator/check_regalloc_validation.ml
+++ b/tests/backend/regalloc_validator/check_regalloc_validation.ml
@@ -550,8 +550,12 @@ let () =
       cfg1, cfg2)
     ~exp_std:"fatal exception raised when validating description"
     ~exp_err:
-      ">> Fatal error: In function arguments: changed preassigned register's \
-       location from %rax to %rbx"
+      (Printf.sprintf
+        ">> Fatal error: In function arguments: changed preassigned register's \
+         location from %s to %s"
+         (Proc.register_name Cmm.Int 0)
+         (Proc.register_name Cmm.Int 1))
+
 
 let () =
   check "Location can't be unknown after allocation"
@@ -574,8 +578,11 @@ let () =
       cfg1, cfg2)
     ~exp_std:"fatal exception raised when validating description"
     ~exp_err:
-      ">> Fatal error: In instruction's no 17 results: changed preassigned \
-       register's location from %rdi to %rbx"
+      (Printf.sprintf
+        ">> Fatal error: In instruction's no 17 results: changed preassigned \
+         register's location from %s to %s"
+         (Proc.register_name Cmm.Int 2)
+         (Proc.register_name Cmm.Int 1))
 
 let () =
   check "Duplicate instruction found when validating description"
@@ -1024,15 +1031,32 @@ let test_loop ~loop_loc_first n =
     (Printf.sprintf "Check loop with %d locations" n)
     (fun () -> make_loop ~loop_loc_first n)
     ~exp_std:
-      "Validation failed: Bad equations at entry point, reason: Unsatisfiable \
-       equations when removing result equations.\n\
-       Existing equation has to agree on 0 or 2 sides (cannot be exactly 1) \
-       with the removed equation.\n\
-       Existing equation R[%rdi]=%rbx.\n\
-       Removed equation: R[%rbx]=%rbx.\n\
-       Equations: R[%rax]=%rax R[%rdi]=%rbx R[%rdi]=%rdi\n\
-       Function argument descriptions: R[%rax], R[%rbx], R[%rdi]\n\
-       Function argument locations: %rax, %rbx, %rdi"
+      (Printf.sprintf
+        "Validation failed: Bad equations at entry point, reason: Unsatisfiable \
+         equations when removing result equations.\n\
+         Existing equation has to agree on 0 or 2 sides (cannot be exactly 1) \
+         with the removed equation.\n\
+         Existing equation R[%s]=%s.\n\
+         Removed equation: R[%s]=%s.\n\
+         Equations: R[%s]=%s R[%s]=%s R[%s]=%s\n\
+         Function argument descriptions: R[%s], R[%s], R[%s]\n\
+         Function argument locations: %s, %s, %s"
+         (Proc.register_name Cmm.Int 2)
+         (Proc.register_name Cmm.Int 1)
+         (Proc.register_name Cmm.Int 1)
+         (Proc.register_name Cmm.Int 1)
+         (Proc.register_name Cmm.Int 0)
+         (Proc.register_name Cmm.Int 0)
+         (Proc.register_name Cmm.Int 2)
+         (Proc.register_name Cmm.Int 1)
+         (Proc.register_name Cmm.Int 2)
+         (Proc.register_name Cmm.Int 2)
+         (Proc.register_name Cmm.Int 0)
+         (Proc.register_name Cmm.Int 1)
+         (Proc.register_name Cmm.Int 2)
+         (Proc.register_name Cmm.Int 0)
+         (Proc.register_name Cmm.Int 1)
+         (Proc.register_name Cmm.Int 2))
     ~exp_err:"";
   let end_time = Sys.time () in
   Format.printf "  Time of loop test: %fs\n" (end_time -. start_time);

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -30,7 +30,8 @@
 (rule
  (alias runtest)
  (enabled_if
-  (= %{context_name} "main"))
+  (and (= %{context_name} "main")
+       (= %{architecture} amd64)))
  (action
   (progn
    (diff empty.expected basic.out))))

--- a/testsuite/tests/unboxed-primitive-args/test.ml
+++ b/testsuite/tests/unboxed-primitive-args/test.ml
@@ -2,13 +2,14 @@
 
 readonly_files = "common.mli common.ml test_common.c test_common.h"
 
-* setup-ocamlopt.opt-build-env
-** ocaml
+* arch_amd64
+** setup-ocamlopt.opt-build-env
+*** ocaml
 test_file = "${test_source_directory}/gen_test.ml"
 ocaml_script_as_argument = "true"
 arguments = "c"
 compiler_output = "stubs.c"
-*** ocaml
+**** ocaml
 arguments = "ml"
 compiler_output = "main.ml"
 **** ocamlopt.opt


### PR DESCRIPTION
This PR proposes patches that enable the main branch to be compiled and tested on arm64 machines.

Summary of changes -

1. Fixed async exceptions
2. Implemented local allocations
3. Fixed failing test cases - regalloc_validator

Notes - 

1. The regalloc_validator test case "Location can't be unknown after allocation" is failing on arm64 because the unknown register is different from amd64 "V/68" instead of "V/53". Still investigating this error.
2. Disabled simd and unboxed-primitive-args tests on arm64 as the `-msse4.2` flag causes compilation errors for the stubs.
3. I am not aware of the CI process so I haven't updated any CI related files for arm64.

Apologies if I am not adhering to general PR guidelines. It's my first PR and I am open to feedback! 