### PR TITLE
Disable one of the minimizers which seems to cause non-termination

### DIFF
--- a/chamelon/chamelon.ml
+++ b/chamelon/chamelon.ml
@@ -79,7 +79,7 @@ let default_iteration =
     "simplify-application";
     "simplify-match";
     "flatten-modules";
-    "remove-attributes";
+    (* "remove-attributes"; *)
     "simplify-types";
     "remove-cons-fields";
   ]


### PR DESCRIPTION
It seems to cause of non-termination of the minimizer, so we disable it by default so that the default configuration remains usable.