### PR TITLE
Ensure that we always have the slot offsets for all code ids (even non-simplified code)

### DIFF
--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -128,7 +128,11 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename:_ ~keep_symbol_tables
   let run () =
     let cmx_loader = Flambda_cmx.create_loader ~get_module_info in
     let (Mode mode) = Flambda_features.mode () in
-    let raw_flambda, close_program_metadata =
+    let Closure_conversion.
+          { unit = raw_flambda;
+            code_slot_offsets;
+            metadata = close_program_metadata
+          } =
       Profile.record_call "lambda_to_flambda" (fun () ->
           Lambda_to_flambda.lambda_to_flambda ~mode ~big_endian:Arch.big_endian
             ~cmx_loader ~compilation_unit ~module_block_size_in_words
@@ -156,7 +160,7 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename:_ ~keep_symbol_tables
               reachable_names
             } =
           Profile.record_call ~accumulate:true "simplify" (fun () ->
-              Simplify.run ~cmx_loader ~round raw_flambda)
+              Simplify.run ~cmx_loader ~round ~code_slot_offsets raw_flambda)
         in
         (if Flambda_features.inlining_report ()
         then

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2440,7 +2440,7 @@ let bind_code_and_sets_of_closures all_code sets_of_closures acc body =
     Code_id.Lmap.fold
       (fun code_id code (acc, g2c, s2g) ->
         let id = fresh_group_id () in
-        let acc = Acc.add_code_offsets acc code_id in
+        let acc = Acc.add_offsets_from_code acc code_id in
         let bound = Bound_static.Pattern.code code_id in
         let const = Static_const_or_code.create_code code in
         ( acc,

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2626,8 +2626,7 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode) ~big_endian
     Env.add_var_like env toplevel_my_region Not_user_visible
       Flambda_kind.With_subkind.region
   in
-  let slot_offsets = Slot_offsets.empty in
-  let acc = Acc.create ~slot_offsets ~cmx_loader in
+  let acc = Acc.create ~cmx_loader in
   let acc, body =
     wrap_final_module_block acc env ~program ~prog_return_cont
       ~module_block_size_in_words ~return_cont ~module_symbol

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2434,7 +2434,8 @@ let bind_code_and_sets_of_closures all_code sets_of_closures acc body =
   in
   (* CR gbury: We assume that no code_ids are deleted later, but even if that
      were to happen, we would only get an over-approximation of the slot offsets
-     constraints. *)
+     constraints in the [slot_offsets] field of the acc (which is only used in
+     classic mode), and that should be benign. *)
   let acc, group_to_bound_consts, symbol_to_groups =
     Code_id.Lmap.fold
       (fun code_id code (acc, g2c, s2g) ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2433,7 +2433,7 @@ let bind_code_and_sets_of_closures all_code sets_of_closures acc body =
       n
   in
   (* CR gbury: We assume that no code_ids are deleted later, but even if that
-     were to happen, we would onyl get an over-approximation of the slot offsets
+     were to happen, we would only get an over-approximation of the slot offsets
      constraints. *)
   let acc, group_to_bound_consts, symbol_to_groups =
     Code_id.Lmap.fold

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -87,7 +87,11 @@ type 'a close_program_metadata =
       * Exported_offsets.t)
       -> [`Classic] close_program_metadata
 
-type 'a close_program_result = Flambda_unit.t * 'a close_program_metadata
+type 'a close_program_result =
+  { unit : Flambda_unit.t;
+    metadata : 'a close_program_metadata;
+    code_slot_offsets : Slot_offsets.t Code_id.Map.t
+  }
 
 val close_program :
   mode:'mode Flambda_features.mode ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -689,13 +689,14 @@ module Acc = struct
   let push_closure_info t ~return_continuation ~exn_continuation ~my_closure
       ~is_purely_tailrec ~code_id =
     { t with
+      slot_offsets = Slot_offsets.empty;
       closure_infos =
         { code_id;
           return_continuation;
           exn_continuation;
           my_closure;
           is_purely_tailrec;
-          slot_offsets_at_definition = Slot_offsets.empty
+          slot_offsets_at_definition = t.slot_offsets
         }
         :: t.closure_infos
     }

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -341,7 +341,7 @@ module Acc = struct
           (* note: this last field is not a property of the current closure, but
              rather a property of its point of definition (i.e. the state of the
              slot_offsets right before we entered the current closure). It's
-             mainly stored here for eficiency reasons. *)
+             mainly stored here for efficiency reasons. *)
     }
 
   type t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -660,7 +660,7 @@ module Acc = struct
     let cost_metrics = cost_metrics acc in
     cost_metrics, free_names, with_cost_metrics saved_cost_metrics acc, return
 
-  let add_code_offsets t code_id =
+  let add_offsets_from_code t code_id =
     match Code_id.Map.find code_id t.code_slot_offsets with
     | exception Not_found ->
       Misc.fatal_errorf "No slot offsets constraints found for code id %a"

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -210,7 +210,8 @@ module Acc : sig
       return_continuation : Continuation.t;
       exn_continuation : Exn_continuation.t;
       my_closure : Variable.t;
-      is_purely_tailrec : bool
+      is_purely_tailrec : bool;
+      slot_offsets_at_definition : Slot_offsets.t
     }
 
   type t

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -206,7 +206,8 @@ end
 (** Used to pipe some data through closure conversion *)
 module Acc : sig
   type closure_info = private
-    { return_continuation : Continuation.t;
+    { code_id : Code_id.t;
+      return_continuation : Continuation.t;
       exn_continuation : Exn_continuation.t;
       my_closure : Variable.t;
       is_purely_tailrec : bool
@@ -281,6 +282,10 @@ module Acc : sig
 
   val slot_offsets : t -> Slot_offsets.t
 
+  val code_slot_offsets : t -> Slot_offsets.t Code_id.Map.t
+
+  val add_code_offsets : t -> Code_id.t -> t
+
   val add_set_of_closures_offsets :
     is_phantom:bool -> t -> Set_of_closures.t -> t
 
@@ -292,6 +297,7 @@ module Acc : sig
     exn_continuation:Exn_continuation.t ->
     my_closure:Variable.t ->
     is_purely_tailrec:bool ->
+    code_id:Code_id.t ->
     t
 
   val pop_closure_info : t -> closure_info * t

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -284,7 +284,7 @@ module Acc : sig
 
   val code_slot_offsets : t -> Slot_offsets.t Code_id.Map.t
 
-  val add_code_offsets : t -> Code_id.t -> t
+  val add_offsets_from_code : t -> Code_id.t -> t
 
   val add_set_of_closures_offsets :
     is_phantom:bool -> t -> Set_of_closures.t -> t

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -215,7 +215,7 @@ module Acc : sig
 
   type t
 
-  val create : slot_offsets:Slot_offsets.t -> cmx_loader:Flambda_cmx.loader -> t
+  val create : cmx_loader:Flambda_cmx.loader -> t
 
   val manufacture_symbol_short_name : t -> t * Linkage_name.t
 

--- a/middle_end/flambda2/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/downwards_acc.ml
@@ -62,10 +62,10 @@ let [@ocamlformat "disable"] print ppf
     (Code_id.Map.print Slot_offsets.print) slot_offsets
     (Simple.Map.print Debuginfo.print_compact) debuginfo_rewrites
 
-let create denv continuation_uses_env =
+let create denv slot_offsets continuation_uses_env =
   { denv;
     continuation_uses_env;
-    slot_offsets = Code_id.Map.empty;
+    slot_offsets;
     shareable_constants = Static_const.Map.empty;
     used_value_slots = Name_occurrences.empty;
     lifted_constants = LCS.empty;

--- a/middle_end/flambda2/simplify/env/downwards_acc.mli
+++ b/middle_end/flambda2/simplify/env/downwards_acc.mli
@@ -20,7 +20,11 @@ type t
 val print : Format.formatter -> t -> unit
 
 (** Create a downwards accumulator. *)
-val create : Downwards_env.t -> Continuation_uses_env.t -> t
+val create :
+  Downwards_env.t ->
+  Slot_offsets.t Code_id.Map.t ->
+  Continuation_uses_env.t ->
+  t
 
 (** Extract the environment component of the given downwards accumulator. *)
 val denv : t -> Downwards_env.t

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -24,7 +24,7 @@ type simplify_result =
     reachable_names : Name_occurrences.t
   }
 
-let run ~cmx_loader ~round unit =
+let run ~cmx_loader ~round ~code_slot_offsets unit =
   let return_continuation = FU.return_continuation unit in
   let exn_continuation = FU.exn_continuation unit in
   let toplevel_my_region = FU.toplevel_my_region unit in
@@ -40,7 +40,7 @@ let run ~cmx_loader ~round unit =
   in
   (* CR gbury: only compute closure offsets if this is the last round. (same
      remark for the cmx contents) *)
-  let dacc = DA.create denv Continuation_uses_env.empty in
+  let dacc = DA.create denv code_slot_offsets Continuation_uses_env.empty in
   let body, uacc =
     Simplify_expr.simplify_toplevel dacc (FU.body unit) ~return_continuation
       ~return_arity:(Flambda_arity.create_singletons [K.With_subkind.any_value])

--- a/middle_end/flambda2/simplify/simplify.mli
+++ b/middle_end/flambda2/simplify/simplify.mli
@@ -31,5 +31,6 @@ type simplify_result = private
 val run :
   cmx_loader:Flambda_cmx.loader ->
   round:int ->
+  code_slot_offsets:Slot_offsets.t Code_id.Map.t ->
   Flambda_unit.t ->
   simplify_result

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -40,7 +40,7 @@ let run_expect_test ~get_module_info ~extension ~filename
   check_invariants before_fl;
   let cmx_loader = Flambda_cmx.create_loader ~get_module_info in
   (* CR gbury/lmaurer: add a proper traversal to compute the actual
-        code_slot_offsets here (as well as free_names) *)
+     code_slot_offsets here (as well as free_names) *)
   let { Simplify.unit = actual_fl; _ } =
     Simplify.run ~cmx_loader ~round:0 before_fl
       ~code_slot_offsets:Code_id.Map.empty

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -39,6 +39,8 @@ let run_expect_test ~get_module_info ~extension ~filename
   let before_fl = Fexpr_to_flambda.conv comp_unit before in
   check_invariants before_fl;
   let cmx_loader = Flambda_cmx.create_loader ~get_module_info in
+  (* CR gbury/lmaurer: add a proper traversal to compute the actual
+        code_slot_offsets here (as well as free_names) *)
   let { Simplify.unit = actual_fl; _ } =
     Simplify.run ~cmx_loader ~round:0 before_fl
       ~code_slot_offsets:Code_id.Map.empty

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -41,6 +41,7 @@ let run_expect_test ~get_module_info ~extension ~filename
   let cmx_loader = Flambda_cmx.create_loader ~get_module_info in
   let { Simplify.unit = actual_fl; _ } =
     Simplify.run ~cmx_loader ~round:0 before_fl
+      ~code_slot_offsets:Code_id.Map.empty
   in
   let expected_fl = Fexpr_to_flambda.conv comp_unit expected in
   match Compare.flambda_units actual_fl expected_fl with


### PR DESCRIPTION
To ensure that, we compute slot offsets per code_id in from_lambda and use that map to initialise the slot offsets map in the dacc in Simplify.

This should close #1646 