### PR TITLE
Delete IRC split mode module.

### DIFF
--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -164,34 +164,6 @@ let update_register_locations : unit -> unit =
           then log ~indent:1 "updating %a to %d" Printmach.reg reg color;
           reg.Reg.loc <- Reg color))
 
-module Split_mode = struct
-  type t =
-    | Off
-    | Naive
-
-  let all = [Off; Naive]
-
-  let to_string = function Off -> "off" | Naive -> "naive"
-
-  let value =
-    let available_modes () =
-      String.concat ", "
-        (all |> List.map ~f:to_string |> List.map ~f:(Printf.sprintf "%S"))
-    in
-    lazy
-      (match find_param_value "IRC_SPLIT" with
-      | None ->
-        fatal "the IRC_SPLIT parameter is not set (possible values: %s)"
-          (available_modes ())
-      | Some id -> (
-        match String.lowercase_ascii id with
-        | "off" -> Off
-        | "naive" -> Naive
-        | _ ->
-          fatal "unknown split mode %S (possible values: %s)" id
-            (available_modes ())))
-end
-
 module Spilling_heuristics = struct
   type t =
     | Set_choose

--- a/backend/regalloc/regalloc_irc_utils.mli
+++ b/backend/regalloc/regalloc_irc_utils.mli
@@ -70,19 +70,6 @@ val k : Reg.t -> int
 
 val update_register_locations : unit -> unit
 
-(* CR-soon xclerc for xclerc: remove this module. *)
-module Split_mode : sig
-  type t =
-    | Off
-    | Naive
-
-  val all : t list
-
-  val to_string : t -> string
-
-  val value : t Lazy.t
-end
-
 module Spilling_heuristics : sig
   type t =
     | Set_choose


### PR DESCRIPTION
This module was effectively useless since we
remove the IRC-specific split preprocessing
in https://github.com/ocaml-flambda/flambda-backend/pull/1445.