### PR TITLE
mode crossing of LHS of arrow types by coercing

### DIFF
--- a/ocaml/testsuite/tests/typing-local/crossing.ml
+++ b/ocaml/testsuite/tests/typing-local/crossing.ml
@@ -397,7 +397,6 @@ let _ = bar (foo : int -> int :> local_ int -> int)
 - : int = 42
 |}]
 
-
 (* Only the RHS type of :> is looked at for mode crossing *)
 let _ = bar (foo : int -> int :> local_ _ -> _)
 [%%expect{|
@@ -405,6 +404,29 @@ Line 1, characters 12-47:
 1 | let _ = bar (foo : int -> int :> local_ _ -> _)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type int -> int is not a subtype of local_ 'a -> 'b
+|}]
+
+
+(* An example: the RHS allows mode crossing but the LHS doesn't *)
+let foo = function
+  | `A -> ()
+  | `B (s : string) -> ()
+[%%expect{|
+val foo : [< `A | `B of string ] -> unit = <fun>
+|}]
+
+let foo_ = (foo : [`A | `B of string] -> unit :> local_ [`A] -> unit)
+[%%expect{|
+val foo_ : local_ [ `A ] -> unit = <fun>
+|}]
+
+let foo_ = (foo : [`A | `B of string] -> unit :> local_ [`B of string] -> unit)
+[%%expect{|
+Line 1, characters 11-79:
+1 | let foo_ = (foo : [`A | `B of string] -> unit :> local_ [`B of string] -> unit)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type [ `A | `B of string ] -> unit is not a subtype of
+         local_ [ `B of string ] -> unit
 |}]
 
 (* You can't erase the info that a function might allocate in parent region *)

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -5348,6 +5348,11 @@ let rec build_subtype env (visited : transient_expr list)
       let (t2', c2) = build_subtype env visited loops posi level t2 in
       let (a', c3) =
         if level > 2 then begin
+          (* If posi, then t1' >= t1, and we pick t1; otherwise we pick t1'. In
+            either case we pick the smaller type which is the "real" type of
+            runtime values, and easier to cross modes (and thus making the
+            mode-crossing more complete). *)
+          let t1 = if posi then t1 else t1' in
           if is_always_global env t1 then
             Mode.Alloc.newvar (), Changed
           else

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -5347,7 +5347,12 @@ let rec build_subtype env (visited : transient_expr list)
       let (t1', c1) = build_subtype env visited loops (not posi) level t1 in
       let (t2', c2) = build_subtype env visited loops posi level t2 in
       let (a', c3) =
-        if level > 2 then build_submode (not posi) a else a, Unchanged
+        if level > 2 then begin
+          if is_always_global env t1 then
+            Alloc_mode.newvar (), Changed
+          else
+            build_submode (not posi) a
+          end else a, Unchanged
       in
       let (r', c4) =
         if level > 2 then build_submode posi r else r, Unchanged

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -5349,7 +5349,7 @@ let rec build_subtype env (visited : transient_expr list)
       let (a', c3) =
         if level > 2 then begin
           if is_always_global env t1 then
-            Alloc_mode.newvar (), Changed
+            Mode.Alloc.newvar (), Changed
           else
             build_submode (not posi) a
           end else a, Unchanged

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -520,10 +520,14 @@ val check_type_layout :
 val constrain_type_layout :
   Env.t -> type_expr -> layout -> (unit, Layout.Violation.t) result
 
+val is_principal : type_expr -> bool
+
 (* True if a type is always global (i.e., it mode crosses for local).  This is
    true for all immediate and immediate64 types.  To make it sound for
    immediate64, we've disabled stack allocation on 32-bit builds. *)
 val is_always_global : Env.t -> type_expr -> bool
+
+val mode_cross : Env.t -> type_expr -> bool
 
 (* For use with ocamldebug *)
 type global_state

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -709,9 +709,6 @@ let extract_label_names env ty =
   | Record_type (_, _,fields, _) -> List.map (fun l -> l.Types.ld_id) fields
   | Not_a_record_type | Maybe_a_record_type -> assert false
 
-let is_principal ty =
-  not !Clflags.principal || get_level ty = generic_level
-
 let has_local_attr loc attrs =
   match Builtin_attributes.has_local attrs with
   | Ok l -> l
@@ -732,9 +729,6 @@ let has_poly_constraint spat =
       | _ -> false
     end
   | _ -> false
-
-let mode_cross env (ty : type_expr) =
-  is_principal ty && is_always_global env ty
 
 let mode_cross_to_min env ty mode =
   if mode_cross env ty then


### PR DESCRIPTION
This PR allows you to strenghthen functions by making its argument mode `local_`, if the argument type is immediate. 
```
f : int -> int :> local_ int -> int
```
Request review from @stedolan . Please note that I didn't check the principality of the argument type, because it seems that the types passed to `subtype` are always instances.