### PR TITLE
Linscan (CFG): unconditionally use DFS

### DIFF
--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -86,7 +86,7 @@ let build_intervals : State.t -> Cfg_with_infos.t -> unit =
   in
   let pos = ref 0 in
   (* Equivalent to [walk_instruction] in "backend/interval.ml".*)
-  iter_instructions_order cfg_with_layout (Lazy.force Order.value)
+  iter_instructions_dfs cfg_with_layout
     ~instruction:(fun ~trap_handler instr ->
       incr pos;
       update_instr !pos instr ~trap_handler
@@ -105,7 +105,7 @@ let build_intervals : State.t -> Cfg_with_infos.t -> unit =
     past_ranges;
   if ls_debug && Lazy.force ls_verbose
   then
-    iter_cfg_order cfg_with_layout (Lazy.force Order.value) ~f:(fun block ->
+    iter_cfg_dfs (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun block ->
         log ~indent:2 "(block %d)" block.start;
         log_body_and_terminator ~indent:2 block.body block.terminator liveness);
   State.update_intervals state past_ranges
@@ -279,7 +279,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
       if ls_debug && Lazy.force ls_verbose
       then
         let liveness = Cfg_with_infos.liveness cfg_with_infos in
-        iter_cfg_order cfg_with_layout (Lazy.force Order.value) ~f:(fun block ->
+        iter_cfg_dfs (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun block ->
             log ~indent:2 "(block %d)" block.start;
             log_body_and_terminator ~indent:2 block.body block.terminator
               liveness))

--- a/backend/regalloc/regalloc_ls_utils.mli
+++ b/backend/regalloc/regalloc_ls_utils.mli
@@ -20,27 +20,13 @@ val log_body_and_terminator :
 
 val log_cfg_with_infos : indent:int -> Cfg_with_infos.t -> unit
 
-module Order : sig
-  type t =
-    | Layout (* Order given by iterating over the CFG layout. *)
-    | DFS (* Order computed by a depth-first search from the entry point. *)
-
-  val all : t list
-
-  val to_string : t -> string
-
-  val value : t Lazy.t
-end
-
-val iter_cfg_order :
-  Cfg_with_layout.t -> Order.t -> f:(Cfg.basic_block -> unit) -> unit
+val iter_cfg_dfs : Cfg.t -> f:(Cfg.basic_block -> unit) -> unit
 
 (* The [trap_handler] parameter to the [instruction] and [terminator] functions
    is set to [true] iff the instruction is the first one of a block which is a
    trap handler. *)
-val iter_instructions_order :
+val iter_instructions_dfs :
   Cfg_with_layout.t ->
-  Order.t ->
   instruction:(trap_handler:bool -> Cfg.basic Cfg.instruction -> unit) ->
   terminator:(trap_handler:bool -> Cfg.terminator Cfg.instruction -> unit) ->
   unit


### PR DESCRIPTION
The way we compute intervals in linscan relies
upon the order in which we see the various
blocks. For instance, the algorithm expects to
see a set before a read for a given register.
We lost this property in https://github.com/ocaml-flambda/flambda-backend/pull/1576, so this pull
request change the order to unconditionally
use DFS rather than rely on the layout.