### PR TITLE
Count exhaustive pattern guards towards case exhaustivity check

### DIFF
--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -1834,27 +1834,29 @@ let pressure_variants_in_computation_pattern tdefs patl =
 (* Utilities for diagnostics *)
 (*****************************)
 
+let is_guarded_rhs = function
+  (* Total pattern-guarded rhs's should be treated as unguarded, as they will
+     never fail to match. *)
+  | Simple_rhs _ | Pattern_guarded_rhs { pg_partial = Total; _ } -> false
+  | Boolean_guarded_rhs _ | Pattern_guarded_rhs { pg_partial = Partial; _ } ->
+      true
+
 (*
   Build up a working pattern matrix by forgetting
   about guarded patterns
 *)
 
-let rec initial_matrix = function
-    [] -> []
-  | { c_rhs = Simple_rhs _; c_lhs = p } :: rem -> [p] :: initial_matrix rem
-  | { c_rhs = Boolean_guarded_rhs _ | Pattern_guarded_rhs _; _ } :: rem ->
-      initial_matrix rem
+let initial_matrix cases =
+  List.filter (fun case -> not (is_guarded_rhs case.c_rhs)) cases
+  |> List.map (fun case -> [ case.c_lhs ])
 
 (*
    Build up a working pattern matrix by keeping
    only the patterns which are guarded
 *)
-let rec initial_only_guarded = function
-  | [] -> []
-  | { c_rhs = Simple_rhs _; _ } :: rem ->
-      initial_only_guarded rem
-  | { c_lhs = pat; c_rhs = Boolean_guarded_rhs _ | Pattern_guarded_rhs _ }
-    :: rem -> [pat] :: initial_only_guarded rem
+let initial_only_guarded cases =
+  List.filter (fun case -> is_guarded_rhs case.c_rhs) cases
+  |> List.map (fun case -> [ case.c_lhs ])
 
 
 (************************)

--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -1834,9 +1834,8 @@ let pressure_variants_in_computation_pattern tdefs patl =
 (* Utilities for diagnostics *)
 (*****************************)
 
-let is_guarded_rhs = function
-  (* Total pattern-guarded rhs's should be treated as unguarded, as they will
-     never fail to match. *)
+let is_fallthrough_possible = function
+  (* Total pattern-guarded rhs's can never fallthrough, as they always match. *)
   | Simple_rhs _ | Pattern_guarded_rhs { pg_partial = Total; _ } -> false
   | Boolean_guarded_rhs _ | Pattern_guarded_rhs { pg_partial = Partial; _ } ->
       true
@@ -1847,16 +1846,20 @@ let is_guarded_rhs = function
 *)
 
 let initial_matrix cases =
-  List.filter (fun case -> not (is_guarded_rhs case.c_rhs)) cases
-  |> List.map (fun case -> [ case.c_lhs ])
+  List.filter_map
+    (fun case ->
+       if is_fallthrough_possible case.c_rhs then None else Some [ case.c_lhs ])
+    cases
 
 (*
    Build up a working pattern matrix by keeping
    only the patterns which are guarded
 *)
 let initial_only_guarded cases =
-  List.filter (fun case -> is_guarded_rhs case.c_rhs) cases
-  |> List.map (fun case -> [ case.c_lhs ])
+  List.filter_map
+    (fun case ->
+       if is_fallthrough_possible case.c_rhs then Some [ case.c_lhs ] else None)
+    cases
 
 
 (************************)


### PR DESCRIPTION
Pattern guards that exhaustively match can be replaced with nested match expressions, and for this reason, they issue a warning on exhaustive match (warning 73). However, when such pattern guards exist, they should count towards exhaustivity as the guard never fails, i.e. there can be no counterexamples that match the pattern in case.

For example,
```
match x with
| None -> ~-1
| Some b
    when b match (
    | false -> 0
    | true -> 1)
```
would previously trigger warnings 73 and 8 (nonexhaustive match), while it now only triggers the former, as `x : bool option` will never fail to match.