### PR TITLE
Fix unboxed-primitive-args stack overflow under closure

### DIFF
--- a/testsuite/tests/unboxed-primitive-args/test.ml
+++ b/testsuite/tests/unboxed-primitive-args/test.ml
@@ -10,10 +10,10 @@ arguments = "c"
 compiler_output = "stubs.c"
 *** ocaml
 arguments = "ml"
-compiler_output = "main.ml"
+compiler_output = "ignore_stdout.ml"
 **** ocamlopt.opt
 ocamlopt_flags = "-extension simd -cc '${cc} -msse4.2'"
-all_modules = "test_common.c stubs.c common.mli common.ml main.ml"
+all_modules = "test_common.c stubs.c common.mli common.ml test0.ml test1.ml"
 ***** run
 ****** check-program-output
 


### PR DESCRIPTION
Updates the `unboxed-primitive-args` test to write multiple output files instead of a single monolithic file.
The single file was causing the the compiler to stack overflow when configured with closure.