### PR TITLE
Improve performance of Available_regs

### DIFF
--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -492,18 +492,7 @@ let all_regs_that_might_be_named instr =
     (fun (instr : Mach.instruction) ->
       match[@ocaml.warning "-4"] instr.desc with
       | Iop (Iname_for_debugger { regs; _ }) ->
-        (* We exclude preassigned registers: the only such registers that should
-           end up in the availability sets are those corresponding to function
-           parameters. However those are added explicitly in [fundecl] below. We
-           should not re-add them here, or else subsequent uses of the same hard
-           registers for different, non-user-visible values might end up in the
-           sets. *)
-        let regs =
-          Reg.Set.filter
-            (fun (reg : Reg.t) -> not (Reg.is_preassigned reg))
-            (Reg.set_of_array regs)
-        in
-        all_regs := Reg.Set.union regs !all_regs
+        all_regs := Reg.Set.union (Reg.set_of_array regs) !all_regs
       | _ -> ())
     instr;
   !all_regs

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -74,25 +74,30 @@ let restore_avail_at_raise kind saved_avail_at_raise =
   | Regular -> avail_at_raise := saved_avail_at_raise
   | Delayed _ -> ()
 
-let check_invariants (instr : M.instruction) ~(avail_before : RAS.t) =
+let check_invariants (instr : M.instruction) ~all_regs_that_might_be_named
+    ~(avail_before : RAS.t) =
   match avail_before with
   | Unreachable -> ()
   | Ok avail_before ->
-    (* Every register that is live across an instruction should also be
-       available before the instruction. *)
-    if not (R.Set.subset instr.live (RD.Set.forget_debug_info avail_before))
+    (* Every register that is live and named across an instruction should also
+       be available before the instruction. *)
+    let live = R.Set.inter instr.live all_regs_that_might_be_named in
+    if not (R.Set.subset live (RD.Set.forget_debug_info avail_before))
     then
       Misc.fatal_errorf
-        "Live registers not a subset of available\n\
-        \       registers: live={%a}  avail_before=%a missing={%a} insn=%a"
-        Printmach.regset instr.live
+        "Named live registers not a subset of available registers: live={%a}  \
+         avail_before=%a missing={%a} insn=%a"
+        Printmach.regset live
         (RAS.print ~print_reg:Printmach.reg)
         (RAS.Ok avail_before) Printmach.regset
-        (R.Set.diff instr.live (RD.Set.forget_debug_info avail_before))
+        (R.Set.diff live (RD.Set.forget_debug_info avail_before))
         Printmach.instr
         { instr with M.next = M.end_instr () };
-    (* Every register that is an input to an instruction should be available. *)
-    let args = R.set_of_array instr.arg in
+    (* Every named register that is an input to an instruction should be
+       available. *)
+    let args =
+      R.Set.inter (R.set_of_array instr.arg) all_regs_that_might_be_named
+    in
     let avail_before_fdi = RD.Set.forget_debug_info avail_before in
     if not (R.Set.subset args avail_before_fdi)
     then
@@ -104,10 +109,13 @@ let check_invariants (instr : M.instruction) ~(avail_before : RAS.t) =
         args Printmach.instr
         { instr with M.next = M.end_instr () }
 
-(* [available_regs ~instr ~avail_before] calculates, given the registers
-   "available before" an instruction [instr], the registers that are available
-   both "across" and immediately after [instr]. This is a forwards dataflow
-   analysis.
+(* [available_regs ~instr ~all_regs_that_might_be_named ~avail_before]
+   calculates, given the registers "available before" an instruction [instr],
+   the registers that are available both "across" and immediately after [instr].
+   This is a forwards dataflow analysis.
+
+   Registers not in [all_regs_that_might_be_named] are ignored, to improve
+   performance.
 
    "available before" can be thought of, at the assembly level, as the set of
    registers available when the program counter is equal to the address of the
@@ -125,8 +133,10 @@ let check_invariants (instr : M.instruction) ~(avail_before : RAS.t) =
 
    The [available_before] and [available_across] fields of each instruction are
    updated by this function. *)
-let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
-  if !Dwarf_flags.ddebug_invariants then check_invariants instr ~avail_before;
+let rec available_regs (instr : M.instruction) ~all_regs_that_might_be_named
+    ~(avail_before : RAS.t) : RAS.t =
+  if !Dwarf_flags.ddebug_invariants
+  then check_invariants instr ~all_regs_that_might_be_named ~avail_before;
   instr.available_before <- avail_before;
   let avail_across, avail_after =
     let ok set = RAS.Ok set in
@@ -203,14 +213,29 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
             (fun arg_reg result_reg ->
               match RD.Set.find_reg_exn avail_before arg_reg with
               | exception Not_found ->
-                assert false (* see second invariant in [check_invariants] *)
+                (* Note that [arg_reg] might not be in
+                   [all_regs_that_might_be_named], meaning it wouldn't be found
+                   in [avail_before]. In that case we shouldn't propagate
+                   anything. *)
+                None
               | arg_reg ->
-                RD.create_copying_debug_info ~reg:result_reg
-                  ~debug_info_from:arg_reg)
+                if Option.is_some (RD.debug_info arg_reg)
+                then
+                  Some
+                    (RD.create_copying_debug_info ~reg:result_reg
+                       ~debug_info_from:arg_reg)
+                else None)
             instr.arg instr.res
         in
         let avail_across = RD.Set.diff avail_before made_unavailable in
-        let avail_after = RD.Set.union avail_across (RD.Set.of_array results) in
+        let avail_after =
+          Array.fold_left
+            (fun avail_after reg_opt ->
+              match reg_opt with
+              | None -> avail_after
+              | Some reg -> RD.Set.add reg avail_after)
+            avail_across results
+        in
         Some (ok avail_across), ok avail_after
       | Iop
           (( Icall_ind | Icall_imm _ | Ialloc _ | Ipoll _ | Iprobe _
@@ -291,13 +316,23 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         if M.operation_can_raise op
         then augment_availability_at_raise (ok avail_across);
         let avail_after =
-          RD.Set.union
-            (RD.Set.without_debug_info (Reg.set_of_array instr.res))
-            avail_across
+          (* If a result register will never be named, we can forget about it
+             for the purposes of this analysis. *)
+          let res =
+            Reg.inter_set_array all_regs_that_might_be_named instr.res
+          in
+          RD.Set.union (RD.Set.without_debug_info res) avail_across
         in
         Some (ok avail_across), ok avail_after
-      | Iifthenelse (_, ifso, ifnot) -> join [ifso; ifnot] ~avail_before
-      | Iswitch (_, cases) -> join (Array.to_list cases) ~avail_before
+      | Iifthenelse (_, ifso, ifnot) ->
+        join [ifso; ifnot] ~all_regs_that_might_be_named ~avail_before
+      | Iswitch (_, cases) ->
+        (* CR mshinwell: Proc.destroyed_at_oper actually applies to all
+           instructions, so we need to call it in more cases. We're only going
+           to implement this on the Cfg version of this pass though as these are
+           probably mostly corner cases, it's easier to implement on Cfg, and
+           we'll be switching to that soon. *)
+        join (Array.to_list cases) ~all_regs_that_might_be_named ~avail_before
       | Icatch (recursive, ts, handlers, body) ->
         let old_disable_extend_live = !disable_extend_live in
         (match recursive with
@@ -313,14 +348,16 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
             Hashtbl.add avail_at_exit nfail unreachable)
           handlers;
         let avail_after_body =
-          available_regs body ~avail_before:(ok avail_before)
+          available_regs body ~all_regs_that_might_be_named
+            ~avail_before:(ok avail_before)
         in
         (* CR-someday mshinwell: Consider potential efficiency speedups (see
            suggestions from @chambart on GPR#856). *)
         let aux (nfail, ts, handler, _) (nfail', avail_at_top_of_handler) =
           assert (nfail = nfail');
           current_trap_stack := ts;
-          available_regs handler ~avail_before:avail_at_top_of_handler
+          available_regs handler ~all_regs_that_might_be_named
+            ~avail_before:avail_at_top_of_handler
         in
         let aux_equal (nfail, avail_before_handler)
             (nfail', avail_before_handler') =
@@ -388,7 +425,9 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         | Delayed nfail -> Hashtbl.add avail_at_exit nfail unreachable);
         let saved_avail_at_raise = setup_avail_at_raise kind in
         let avail_before = ok avail_before in
-        let after_body = available_regs body ~avail_before in
+        let after_body =
+          available_regs body ~all_regs_that_might_be_named ~avail_before
+        in
         let avail_before_handler =
           let with_exn_bucket =
             match kind with
@@ -413,7 +452,8 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
         current_trap_stack := ts;
         let avail_after =
           RAS.inter after_body
-            (available_regs handler ~avail_before:avail_before_handler)
+            (available_regs handler ~all_regs_that_might_be_named
+               ~avail_before:avail_before_handler)
         in
         current_trap_stack := saved_trap_stack;
         (match kind with
@@ -428,17 +468,45 @@ let rec available_regs (instr : M.instruction) ~(avail_before : RAS.t) : RAS.t =
   instr.available_across <- avail_across;
   match[@ocaml.warning "-4"] instr.desc with
   | Iend -> avail_after
-  | _ -> available_regs instr.next ~avail_before:avail_after
+  | _ ->
+    available_regs instr.next ~all_regs_that_might_be_named
+      ~avail_before:avail_after
 
-and join branches ~avail_before =
+and join branches ~all_regs_that_might_be_named ~avail_before =
   let avail_before = RAS.Ok avail_before in
-  let avails = List.map (available_regs ~avail_before) branches in
+  let avails =
+    List.map
+      (available_regs ~all_regs_that_might_be_named ~avail_before)
+      branches
+  in
   let avail_after =
     match avails with
     | [] -> avail_before
     | avail :: avails -> List.fold_left RAS.inter avail avails
   in
   None, avail_after
+
+let all_regs_that_might_be_named instr =
+  let all_regs = ref Reg.Set.empty in
+  Mach.instr_iter
+    (fun (instr : Mach.instruction) ->
+      match[@ocaml.warning "-4"] instr.desc with
+      | Iop (Iname_for_debugger { regs; _ }) ->
+        (* We exclude preassigned registers: the only such registers that should
+           end up in the availability sets are those corresponding to function
+           parameters. However those are added explicitly in [fundecl] below. We
+           should not re-add them here, or else subsequent uses of the same hard
+           registers for different, non-user-visible values might end up in the
+           sets. *)
+        let regs =
+          Reg.Set.filter
+            (fun (reg : Reg.t) -> not (Reg.is_preassigned reg))
+            (Reg.set_of_array regs)
+        in
+        all_regs := Reg.Set.union regs !all_regs
+      | _ -> ())
+    instr;
+  !all_regs
 
 let fundecl (f : M.fundecl) =
   if !Clflags.debug && not !Dwarf_flags.restrict_to_upstream_dwarf
@@ -449,5 +517,10 @@ let fundecl (f : M.fundecl) =
     disable_extend_live := false;
     let fun_args = R.set_of_array f.fun_args in
     let avail_before = RAS.Ok (RD.Set.without_debug_info fun_args) in
-    ignore (available_regs f.fun_body ~avail_before : RAS.t));
+    let all_regs_that_might_be_named =
+      all_regs_that_might_be_named f.fun_body
+    in
+    ignore
+      (available_regs f.fun_body ~all_regs_that_might_be_named ~avail_before
+        : RAS.t));
   f


### PR DESCRIPTION
As discussed with @xclerc , this traverses the Mach terms prior to the analysis, collecting which registers might ever be named.  Then during the analysis, approximately only registers in this set are considered.

There is also a bug fix in `Printmach` and an added comment following an in-person discussion earlier this week.