### PR TITLE
Add missing vec128 case in cmmgen

### DIFF
--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -52,6 +52,9 @@ val infix_header : int -> nativeint
 (** Header for a boxed float value *)
 val float_header : nativeint
 
+(** Header for a boxed vec128 value *)
+val boxedvec128_header : nativeint
+
 (** Boxed integer headers *)
 val boxedint32_header : nativeint
 

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -410,6 +410,9 @@ let rec is_unboxed_number_cmm = function
     | Cop(Calloc mode, [Cconst_natint (hdr, _); _], dbg)
       when Nativeint.equal hdr float_header ->
       Boxed (Boxed_float (mode, dbg), false)
+    | Cop(Calloc mode, [Cconst_natint (hdr, _); _], dbg)
+      when Nativeint.equal hdr boxedvec128_header ->
+      Boxed (Boxed_vector (Pvec128 Unknown128, mode, dbg), false)
     | Cop(Calloc mode, [Cconst_natint (hdr, _); Cconst_symbol (ops, _); _], dbg) ->
       if Nativeint.equal hdr boxedintnat_header
       && String.equal ops.sym_name caml_nativeint_ops


### PR DESCRIPTION
`is_unboxed_number_cmm` wasn't detecting boxed vec128s, as it was misssing a case that checks for `boxedvec128_header`.

One question - 

Is this case OK given that vec128s use `abstract_tag`? I'm pretty sure they are the only values represented by abstract blocks of size two words; the only other place this occurs is in the runtime at https://github.com/ocaml-flambda/flambda-backend/blob/main/ocaml/runtime/meta.c#L130