### PR TITLE
Remove prefixes from inline record fields for guards

### DIFF
--- a/ocaml/ocamldoc/odoc_ast.ml
+++ b/ocaml/ocamldoc/odoc_ast.ml
@@ -304,7 +304,7 @@ module Analyser =
             match func_body with
             | Pattern_guarded_rhs _ -> parameter, None
             | Simple_rhs func_body
-            | Boolean_guarded_rhs { bg_rhs = func_body; _ } ->
+            | Boolean_guarded_rhs { rhs = func_body; _ } ->
                 match parameter with
                   Simple_name { sn_name = "*opt*" } ->
                     (
@@ -450,7 +450,7 @@ module Analyser =
                    in
                    [ new_param ]
                | {c_rhs=Pattern_guarded_rhs _} :: [] -> []
-               | {c_lhs=pattern_param; c_rhs=Simple_rhs body | Boolean_guarded_rhs {bg_rhs = body}} :: [] ->
+               | {c_lhs=pattern_param; c_rhs=Simple_rhs body | Boolean_guarded_rhs {rhs = body}} :: [] ->
                    (* if this is the first call to the function, this is the first parameter and we skip it *)
                    if not first then
                      (

--- a/ocaml/parsing/ast_helper.ml
+++ b/ocaml/parsing/ast_helper.ml
@@ -237,10 +237,9 @@ end
 
 module Case_rhs = struct
   let simple e = Psimple_rhs e
-  let boolean_guarded ~guard pbg_rhs =
-    Pboolean_guarded_rhs { pbg_guard = guard; pbg_rhs }
-  let pattern_guarded ~loc ppg_scrutinee ppg_cases =
-    Ppattern_guarded_rhs { ppg_scrutinee; ppg_cases; ppg_loc = loc }
+  let boolean_guarded ~guard rhs = Pboolean_guarded_rhs { guard; rhs }
+  let pattern_guarded ~loc scrutinee cases =
+    Ppattern_guarded_rhs { scrutinee; cases; loc }
 end
 
 module Mty = struct

--- a/ocaml/parsing/ast_iterator.ml
+++ b/ocaml/parsing/ast_iterator.ml
@@ -796,13 +796,13 @@ let default_iterator =
     case_rhs =
       (fun this -> function
          | Psimple_rhs e -> this.expr this e
-         | Pboolean_guarded_rhs { pbg_guard; pbg_rhs } ->
-             this.expr this pbg_guard;
-             this.expr this pbg_rhs
-         | Ppattern_guarded_rhs { ppg_scrutinee; ppg_cases; ppg_loc } ->
-             this.expr this ppg_scrutinee;
-             this.cases this ppg_cases;
-             this.location this ppg_loc
+         | Pboolean_guarded_rhs { guard; rhs } ->
+             this.expr this guard;
+             this.expr this rhs
+         | Ppattern_guarded_rhs { scrutinee; cases; loc } ->
+             this.expr this scrutinee;
+             this.cases this cases;
+             this.location this loc
       );
 
     location = (fun _this _l -> ());

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -911,16 +911,16 @@ let default_mapper =
     case_rhs =
       (fun this -> function
          | Psimple_rhs e -> Psimple_rhs (this.expr this e)
-         | Pboolean_guarded_rhs { pbg_guard; pbg_rhs } ->
+         | Pboolean_guarded_rhs { guard; rhs } ->
              Pboolean_guarded_rhs
-               { pbg_guard = this.expr this pbg_guard
-               ; pbg_rhs = this.expr this pbg_rhs
+               { guard = this.expr this guard
+               ; rhs = this.expr this rhs
                }
-         | Ppattern_guarded_rhs { ppg_scrutinee; ppg_cases; ppg_loc } ->
+         | Ppattern_guarded_rhs { scrutinee; cases; loc } ->
              Ppattern_guarded_rhs
-               { ppg_scrutinee = this.expr this ppg_scrutinee
-               ; ppg_cases = this.cases this ppg_cases
-               ; ppg_loc = this.location this ppg_loc
+               { scrutinee = this.expr this scrutinee
+               ; cases = this.cases this cases
+               ; loc = this.location this loc
                }
       );
 

--- a/ocaml/parsing/depend.ml
+++ b/ocaml/parsing/depend.ml
@@ -349,12 +349,12 @@ and add_case bv {pc_lhs; pc_rhs} =
 
 and add_case_rhs bv = function
   | Psimple_rhs e -> add_expr bv e
-  | Pboolean_guarded_rhs { pbg_guard; pbg_rhs } ->
-      add_expr bv pbg_guard;
-      add_expr bv pbg_rhs
-  | Ppattern_guarded_rhs { ppg_scrutinee; ppg_cases } ->
-      add_expr bv ppg_scrutinee;
-      add_cases bv ppg_cases
+  | Pboolean_guarded_rhs { guard; rhs } ->
+      add_expr bv guard;
+      add_expr bv rhs
+  | Ppattern_guarded_rhs { scrutinee; cases } ->
+      add_expr bv scrutinee;
+      add_cases bv cases
 
 and add_bindings recf bv pel =
   let bv' = List.fold_left (fun bv x -> add_pattern bv x.pvb_pat) bv pel in

--- a/ocaml/parsing/parsetree.mli
+++ b/ocaml/parsing/parsetree.mli
@@ -441,12 +441,12 @@ and case =
 and case_rhs =
   | Psimple_rhs of expression
   (** [-> e] *)
-  | Pboolean_guarded_rhs of { pbg_guard : expression; pbg_rhs : expression }
+  | Pboolean_guarded_rhs of { guard : expression; rhs : expression }
   (** [when g -> e] *)
   | Ppattern_guarded_rhs of
-      { ppg_scrutinee : expression
-      ; ppg_cases : case list
-      ; ppg_loc : Location.t
+      { scrutinee : expression
+      ; cases : case list
+      ; loc : Location.t
       }
   (** [when e match (cases) ] *)
 

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -1815,19 +1815,19 @@ and case_list ctxt f l : unit = list (case ctxt) f l ~sep:"@;" ~first:"@;"
 
 and case_rhs ctxt f = function
   | Psimple_rhs e -> pp f "->@;%a" (expression (under_pipe ctxt)) e
-  | Pboolean_guarded_rhs { pbg_guard; pbg_rhs } ->
-      pp f "when@;%a@;->@;%a" (expression ctxt) pbg_guard
-        (expression (under_pipe ctxt)) pbg_rhs
-  | Ppattern_guarded_rhs { ppg_scrutinee; ppg_cases; _ } ->
+  | Pboolean_guarded_rhs { guard; rhs } ->
+      pp f "when@;%a@;->@;%a" (expression ctxt) guard
+        (expression (under_pipe ctxt)) rhs
+  | Ppattern_guarded_rhs { scrutinee; cases; _ } ->
       let singleton_case =
-        match ppg_cases with
+        match cases with
         | [ _ ] -> true
         | _ -> false
       in
       let case_list = list (case ctxt) ~sep:"@;" ~first:"@," ~last:"@," in
       pp f "@[<hv0>@[<hv0>@[<2>when %a@]@ match@] %a@]"
-        (expression reset_ctxt) ppg_scrutinee
-        (paren (not singleton_case) case_list) ppg_cases
+        (expression reset_ctxt) scrutinee
+        (paren (not singleton_case) case_list) cases
 
 and label_x_expression_param ctxt f (l,e) =
   let simple_name = match e with

--- a/ocaml/parsing/printast.ml
+++ b/ocaml/parsing/printast.ml
@@ -918,14 +918,14 @@ and case i ppf { pc_lhs; pc_rhs } =
 
 and case_rhs i ppf = function
   | Psimple_rhs e -> expression i ppf e
-  | Pboolean_guarded_rhs { pbg_guard; pbg_rhs } ->
+  | Pboolean_guarded_rhs { guard; rhs } ->
       line i ppf "<when>\n";
-      expression (i + 1) ppf pbg_guard;
-      expression i ppf pbg_rhs
-  | Ppattern_guarded_rhs { ppg_scrutinee; ppg_cases } ->
+      expression (i + 1) ppf guard;
+      expression i ppf rhs
+  | Ppattern_guarded_rhs { scrutinee; cases } ->
       line i ppf "<when-pattern>\n";
-      expression (i + 1) ppf ppg_scrutinee;
-      list (i + 1) case ppf ppg_cases
+      expression (i + 1) ppf scrutinee;
+      list (i + 1) case ppf cases
 
 and value_binding i ppf x =
   line i ppf "<def>\n";

--- a/ocaml/tools/ocamlprof.ml
+++ b/ocaml/tools/ocamlprof.ml
@@ -158,12 +158,12 @@ and rewrite_cases iflag l =
     (fun pc ->
        match pc.pc_rhs with
        | Psimple_rhs e -> rewrite_exp iflag e
-       | Pboolean_guarded_rhs { pbg_guard; pbg_rhs } ->
-           rewrite_exp iflag pbg_guard;
-           rewrite_exp iflag pbg_rhs
-       | Ppattern_guarded_rhs { ppg_scrutinee; ppg_cases; ppg_loc = _ } ->
-           rewrite_exp iflag ppg_scrutinee;
-           rewrite_cases iflag ppg_cases
+       | Pboolean_guarded_rhs { guard; rhs } ->
+           rewrite_exp iflag guard;
+           rewrite_exp iflag rhs
+       | Ppattern_guarded_rhs { scrutinee; cases; loc = _ } ->
+           rewrite_exp iflag scrutinee;
+           rewrite_cases iflag cases
     )
     l
 
@@ -361,12 +361,12 @@ and rewrite_ifbody iflag ghost sifbody =
 and rewrite_annotate_exp_list l =
   List.iter
     (function
-     | {pc_rhs=Pboolean_guarded_rhs { pbg_guard; pbg_rhs }} ->
-         rewrite_exp true pbg_guard;
-         insert_profile rw_exp pbg_rhs;
-     | {pc_rhs=Ppattern_guarded_rhs { ppg_scrutinee; ppg_cases; _ }} ->
-         rewrite_exp true ppg_scrutinee;
-         rewrite_annotate_exp_list ppg_cases
+     | {pc_rhs=Pboolean_guarded_rhs { guard; rhs }} ->
+         rewrite_exp true guard;
+         insert_profile rw_exp rhs;
+     | {pc_rhs=Ppattern_guarded_rhs { scrutinee; cases; _ }} ->
+         rewrite_exp true scrutinee;
+         rewrite_annotate_exp_list cases
      | {pc_rhs=Psimple_rhs {pexp_desc = Pexp_constraint(sbody, _)}}
        (* let f x : t = e *)
        -> insert_profile rw_exp sbody

--- a/ocaml/typing/cmt2annot.ml
+++ b/ocaml/typing/cmt2annot.ml
@@ -47,9 +47,9 @@ let bind_cases l =
       let loc =
         match c_rhs with
         | Simple_rhs rhs -> rhs.exp_loc
-        | Boolean_guarded_rhs { bg_guard; bg_rhs } ->
-            { bg_rhs.exp_loc with loc_start = bg_guard.exp_loc.loc_start }
-        | Pattern_guarded_rhs { pg_loc; _ } -> pg_loc
+        | Boolean_guarded_rhs { guard; rhs } ->
+            { rhs.exp_loc with loc_start = guard.exp_loc.loc_start }
+        | Pattern_guarded_rhs { loc; _ } -> loc
       in
       bind_variables loc c_lhs
     )

--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -2462,10 +2462,10 @@ let all_guard_idents c_rhs =
   let iterator = {Tast_iterator.default_iterator with expr = expr_iter} in
   let rec rhs_iter = function
     | Simple_rhs _ -> ()
-    | Boolean_guarded_rhs { bg_guard; _ } -> iterator.expr iterator bg_guard
-    | Pattern_guarded_rhs { pg_scrutinee; pg_cases; _ } ->
-        iterator.expr iterator pg_scrutinee;
-        List.iter (fun case -> rhs_iter case.c_rhs) pg_cases
+    | Boolean_guarded_rhs { guard; _ } -> iterator.expr iterator guard
+    | Pattern_guarded_rhs { scrutinee; cases; _ } ->
+        iterator.expr iterator scrutinee;
+        List.iter (fun case -> rhs_iter case.c_rhs) cases
   in
   rhs_iter c_rhs;
   !ids

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -1039,15 +1039,15 @@ and case
 
 and case_rhs i ppf = function
   | Simple_rhs rhs -> expression i ppf rhs
-  | Boolean_guarded_rhs { bg_guard; bg_rhs } ->
+  | Boolean_guarded_rhs { guard; rhs } ->
       line i ppf "<when>\n";
-      expression (i + 1) ppf bg_guard;
-      expression i ppf bg_rhs
-  | Pattern_guarded_rhs { pg_scrutinee; pg_scrutinee_sort; pg_cases } ->
+      expression (i + 1) ppf guard;
+      expression i ppf rhs
+  | Pattern_guarded_rhs { scrutinee; scrutinee_sort; cases } ->
       line i ppf "<when-pattern>\n";
-      expression (i + 1) ppf pg_scrutinee;
-      line (i + 1) ppf "%a\n" Layouts.Sort.format pg_scrutinee_sort;
-      list (i + 1) case ppf pg_cases
+      expression (i + 1) ppf scrutinee;
+      line (i + 1) ppf "%a\n" Layouts.Sort.format scrutinee_sort;
+      list (i + 1) case ppf cases
 
 and value_binding i ppf x =
   line i ppf "<def>\n";

--- a/ocaml/typing/rec_check.ml
+++ b/ocaml/typing/rec_check.ml
@@ -1203,8 +1203,8 @@ and case
            ---------------------------------------
            G - p; m[mp] |- (p when g -> e) : m
         *)
-        | Boolean_guarded_rhs { bg_guard; bg_rhs } ->
-            join [ expression bg_guard << Dereference; expression bg_rhs ]
+        | Boolean_guarded_rhs { guard; rhs } ->
+            join [ expression guard << Dereference; expression rhs ]
         (*
            G |- (match e1 with p2 -> e2) : m
            p1 : mp -| G
@@ -1214,8 +1214,8 @@ and case
            This judgement uses uses the one in [match_expression] as a
            "subroutine."
         *)
-        | Pattern_guarded_rhs { pg_scrutinee; pg_cases; _ } ->
-          match_expression pg_scrutinee pg_cases
+        | Pattern_guarded_rhs { scrutinee; cases; _ } ->
+            match_expression scrutinee cases
       in
       (fun m ->
         let env = judg m in

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -508,14 +508,14 @@ let case sub {c_lhs; c_rhs} =
 
 let case_rhs sub = function
   | Simple_rhs e -> sub.expr sub e
-  | Boolean_guarded_rhs { bg_guard; bg_rhs } ->
-      sub.expr sub bg_guard;
-      sub.expr sub bg_rhs
-  | Pattern_guarded_rhs { pg_scrutinee; pg_scrutinee_sort=_; pg_cases;
-                          pg_partial=_; pg_loc=_; pg_env } ->
-      sub.env sub pg_env;
-      sub.expr sub pg_scrutinee;
-      List.iter (sub.case sub) pg_cases
+  | Boolean_guarded_rhs { guard; rhs } ->
+      sub.expr sub guard;
+      sub.expr sub rhs
+  | Pattern_guarded_rhs { scrutinee; scrutinee_sort=_; cases;
+                          partial=_; loc=_; env } ->
+      sub.env sub env;
+      sub.expr sub scrutinee;
+      List.iter (sub.case sub) cases
 
 let value_binding sub {vb_pat; vb_expr; _} =
   sub.pat sub vb_pat;

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -774,19 +774,19 @@ let case
 
 let case_rhs sub = function
   | Simple_rhs e -> Simple_rhs (sub.expr sub e)
-  | Boolean_guarded_rhs { bg_guard; bg_rhs } ->
+  | Boolean_guarded_rhs { guard; rhs } ->
       Boolean_guarded_rhs
-        { bg_guard = sub.expr sub bg_guard; bg_rhs = sub.expr sub bg_rhs }
-  | Pattern_guarded_rhs { pg_scrutinee; pg_scrutinee_sort; pg_cases; pg_partial;
-                          pg_loc; pg_env; pg_type } ->
+        { guard = sub.expr sub guard; rhs = sub.expr sub rhs }
+  | Pattern_guarded_rhs { scrutinee; scrutinee_sort; cases; partial;
+                          loc; env; rhs_type } ->
       Pattern_guarded_rhs
-        { pg_scrutinee = sub.expr sub pg_scrutinee
-        ; pg_scrutinee_sort
-        ; pg_cases = List.map (sub.case sub) pg_cases
-        ; pg_partial
-        ; pg_loc
-        ; pg_env = sub.env sub pg_env
-        ; pg_type
+        { scrutinee = sub.expr sub scrutinee
+        ; scrutinee_sort
+        ; cases = List.map (sub.case sub) cases
+        ; partial
+        ; loc
+        ; env = sub.env sub env
+        ; rhs_type
         }
 
 let value_binding sub x =

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -221,18 +221,18 @@ and 'k case =
   c_lhs: 'k general_pattern;
   c_rhs: case_rhs;
 }
-  
+
 and case_rhs =
   | Simple_rhs of expression
-  | Boolean_guarded_rhs of { bg_guard : expression; bg_rhs : expression }
+  | Boolean_guarded_rhs of { guard : expression; rhs : expression }
   | Pattern_guarded_rhs of
-      { pg_scrutinee : expression
-      ; pg_scrutinee_sort : Layouts.sort
-      ; pg_cases : computation case list
-      ; pg_partial : partial
-      ; pg_loc : Location.t
-      ; pg_env : Env.t
-      ; pg_type : Types.type_expr
+      { scrutinee : expression
+      ; scrutinee_sort : Layouts.sort
+      ; cases : computation case list
+      ; partial : partial
+      ; loc : Location.t
+      ; env : Env.t
+      ; rhs_type : Types.type_expr
       }
 
 and record_label_definition =

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -403,34 +403,34 @@ and 'k case =
 
 and case_rhs =
   | Simple_rhs of expression
-  | Boolean_guarded_rhs of { bg_guard : expression; bg_rhs : expression }
+  | Boolean_guarded_rhs of { guard : expression; rhs : expression }
   | Pattern_guarded_rhs of
-      { pg_scrutinee : expression
-      ; pg_scrutinee_sort : Layouts.sort
-      ; pg_cases : computation case list
-      ; pg_partial : partial
-      ; pg_loc : Location.t
-      ; pg_env : Env.t
-      ; pg_type : Types.type_expr
+      { scrutinee : expression
+      ; scrutinee_sort : Layouts.sort
+      ; cases : computation case list
+      ; partial : partial
+      ; loc : Location.t
+      ; env : Env.t
+      ; rhs_type : Types.type_expr
       }
-  (* [Pattern_guarded_rhs { pg_scrutinee; pg_scrutinee_sort; pg_cases;
-                            pg_partial; pg_partial; pg_loc; pg_env; pg_type } ]
+  (* [Pattern_guarded_rhs { scrutinee; scrutinee_sort; cases; partial; loc; env;
+                            rhs_type } ]
      represents a pattern guard case right-hand side.
 
-     [pg_env] contains the bindings available prior to the evaluation of the
+     [env] contains the bindings available prior to the evaluation of the
      pattern guard scrutinee, as in a match expression. These bindings are
      available in all pattern guard cases.
 
-     The cases in [pg_cases] are checked in order: a given case will be taken if
-     [pg_scrutinee] evaluates to a value matching the pattern of that case. Each
-     case's rhs has access to the bindings in [pg_env], together with the
+     The cases in [cases] are checked in order: a given case will be taken if
+     [scrutinee] evaluates to a value matching the pattern of that case. Each
+     case's rhs has access to the bindings in [env], together with the
      bindings in its own pattern.
 
-     Like the [Texp_match] constructor, [pg_scrutinee_sort] is the sort of the
-     scrutinee, and [pg_partial] denotes whether the case matches the scrutinee
+     Like the [Texp_match] constructor, [scrutinee_sort] is the sort of the
+     scrutinee, and [partial] denotes whether the case matches the scrutinee
      partially or totally.
-     
-     [pg_loc] contains the source location of the guarded rhs, and [pg_type] is
+
+     [loc] contains the source location of the guarded rhs, and [rhs_type] is
      the type returned by all cases of the pattern guard. *)
 
 and record_label_definition =

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -415,16 +415,16 @@ let case : type k . mapper -> k case -> _ = fun sub {c_lhs; c_rhs} ->
   {
    pc_lhs = sub.pat sub c_lhs;
    pc_rhs =
-     match c_rhs with 
+     match c_rhs with
      | Simple_rhs rhs -> Psimple_rhs (sub.expr sub rhs)
-     | Boolean_guarded_rhs { bg_guard; bg_rhs } ->
+     | Boolean_guarded_rhs { guard; rhs } ->
          Pboolean_guarded_rhs
-           { pbg_guard = sub.expr sub bg_guard; pbg_rhs = sub.expr sub bg_rhs }
-     | Pattern_guarded_rhs { pg_scrutinee; pg_cases; pg_loc; _ } ->
+           { guard = sub.expr sub guard; rhs = sub.expr sub rhs }
+     | Pattern_guarded_rhs { scrutinee; cases; loc; _ } ->
          Ppattern_guarded_rhs
-           { ppg_scrutinee = sub.expr sub pg_scrutinee
-           ; ppg_cases = List.map (sub.case sub) pg_cases
-           ; ppg_loc = sub.location sub pg_loc
+           { scrutinee = sub.expr sub scrutinee
+           ; cases = List.map (sub.case sub) cases
+           ; loc = sub.location sub loc
            }
   }
 
@@ -599,7 +599,7 @@ let expression sub exp =
         let let_ = sub.binding_op sub let_ pat in
         let ands = List.map2 (sub.binding_op sub) ands and_pats in
         let body =
-          match body.c_rhs with 
+          match body.c_rhs with
           | Simple_rhs rhs -> sub.expr sub rhs
           | _ -> Misc.fatal_error "Untypeast.expression: guarded letop body"
         in

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -955,14 +955,14 @@ and case i ppf {pc_lhs; pc_rhs} =
 
 and case_rhs i ppf = function
   | Psimple_rhs e -> expression i ppf e
-  | Pboolean_guarded_rhs { pbg_guard; pbg_rhs } ->
+  | Pboolean_guarded_rhs { guard; rhs } ->
       line i ppf "<when>\n";
-      expression (i + 1) ppf pbg_guard
-  | Ppattern_guarded_rhs { ppg_scrutinee; ppg_cases; _ } ->
+      expression (i + 1) ppf guard
+  | Ppattern_guarded_rhs { scrutinee; cases; _ } ->
       line i ppf "<when>\n";
-      expression (i + 1) ppf ppg_scrutinee;
+      expression (i + 1) ppf scrutinee;
       line (i + 1) ppf "<match>\n";
-      list (i + 1) case ppf ppg_cases
+      list (i + 1) case ppf cases
 
 and value_binding i ppf x =
   line i ppf "<def>\n";


### PR DESCRIPTION
The fields of guard constructs previously were given a prefix signifying whether they were in Parsetree or Typedtree and whether they were pattern or boolean guards.

As these are fields of in-line records used in a variant, there is no ambiguity surrounding these field names. Thus, we can shorten a field like `ppg_scrutinee` to `scrutinee`.

This PR makes these changes, essentially by find-and-replace, fixing indentation where appropriate.