### PR TITLE
Fixes for user-visible variable flags

### DIFF
--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -311,17 +311,19 @@ let maybe_emit_naming_op env ~bound_name seq regs =
   | None -> ()
   | Some bound_name ->
     let provenance = VP.provenance bound_name in
-    let bound_name = VP.var bound_name in
-    let naming_op =
-      Iname_for_debugger {
-        ident = bound_name;
-        provenance;
-        which_parameter = None;
-        is_assignment = false;
-        regs = regs;
-      }
-    in
-    seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+    if Option.is_some provenance then (
+      let bound_name = VP.var bound_name in
+      let naming_op =
+        Iname_for_debugger {
+          ident = bound_name;
+          provenance;
+          which_parameter = None;
+          is_assignment = false;
+          regs = regs;
+        }
+      in
+      seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+    )
 
 (* "Join" two instruction sequences, making sure they return their results
    in the same registers. *)
@@ -928,18 +930,21 @@ method emit_expr_aux (env:environment) exp ~bound_name :
           Misc.fatal_error ("Selection.emit_expr: unbound var " ^ V.name v) in
       begin match self#emit_expr env e1 ~bound_name:None with
         None -> None
-      | Some r1 ->
-          let naming_op =
-            Iname_for_debugger {
-              ident = v;
-              provenance;
-              which_parameter = None;
-              is_assignment = true;
-              regs = r1;
-            }
-          in
-          self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |];
+      | Some r1 -> (
+          if Option.is_some provenance then (
+            let naming_op =
+              Iname_for_debugger {
+                ident = v;
+                provenance;
+                which_parameter = None;
+                is_assignment = true;
+                regs = r1;
+              }
+            in
+            self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+          );
           self#insert_moves env r1 rv; ret [||]
+        )
       end
   | Ctuple [] ->
       ret [||]
@@ -975,17 +980,19 @@ method emit_expr_aux (env:environment) exp ~bound_name :
             | None -> ()
             | Some bound_name ->
               let provenance = VP.provenance bound_name in
-              let bound_name = VP.var bound_name in
-              let naming_op =
-                Iname_for_debugger {
-                  ident = bound_name;
-                  provenance;
-                  which_parameter = None;
-                  is_assignment = false;
-                  regs = regs;
-                }
-              in
-              self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+              if Option.is_some provenance then (
+                let bound_name = VP.var bound_name in
+                let naming_op =
+                  Iname_for_debugger {
+                    ident = bound_name;
+                    provenance;
+                    which_parameter = None;
+                    is_assignment = false;
+                    regs = regs;
+                  }
+                in
+                self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+              )
           in
           let ty = oper_result_type op in
           let unclosed_regions =
@@ -1144,17 +1151,19 @@ method emit_expr_aux (env:environment) exp ~bound_name :
           self#emit_sequence new_env e2 ~bound_name:None ~at_start:(fun seq ->
             List.iter (fun ((var, _typ), r) ->
                 let provenance = VP.provenance var in
-                let var = VP.var var in
-                let naming_op =
-                  Iname_for_debugger {
-                    ident = var;
-                    provenance;
-                    which_parameter = None;
-                    is_assignment = false;
-                    regs = r;
-                  }
-                in
-                seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |])
+                if Option.is_some provenance then (
+                  let var = VP.var var in
+                  let naming_op =
+                    Iname_for_debugger {
+                      ident = var;
+                      provenance;
+                      which_parameter = None;
+                      is_assignment = false;
+                      regs = r;
+                    }
+                  in
+                  seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+                ))
               ids_and_rs)
         in
         ((nfail, trap_stack, is_cold), (r, s))
@@ -1258,17 +1267,19 @@ method emit_expr_aux (env:environment) exp ~bound_name :
           self#emit_sequence env_handler e2 ~bound_name
             ~at_start:(fun seq ->
               let provenance = VP.provenance v in
-              let var = VP.var v in
-              let naming_op =
-                Iname_for_debugger {
-                  ident = var;
-                  provenance;
-                  which_parameter = None;
-                  is_assignment = false;
-                  regs = rv;
-                }
-              in
-              seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |])
+              if Option.is_some provenance then (
+                let var = VP.var v in
+                let naming_op =
+                  Iname_for_debugger {
+                    ident = var;
+                    provenance;
+                    which_parameter = None;
+                    is_assignment = false;
+                    regs = rv;
+                  }
+                in
+                seq#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+              ))
         in
         let r = join env r1 s1 r2 s2 ~bound_name in
         self#insert env
@@ -1347,32 +1358,38 @@ method private bind_let (env:environment) v r1 =
       env_add v rv env
     end
   in
-  let naming_op =
-    Iname_for_debugger {
-      ident = VP.var v;
-      which_parameter = None;
-      provenance = VP.provenance v;
-      is_assignment = false;
-      regs = r1;
-    }
-  in
-  self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |];
+  let provenance = VP.provenance v in
+  (if Option.is_some provenance then (
+    let naming_op =
+      Iname_for_debugger {
+        ident = VP.var v;
+        which_parameter = None;
+        provenance;
+        is_assignment = false;
+        regs = r1;
+      }
+    in
+    self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+  ));
   env
 
 method private bind_let_mut (env:environment) v k r1 =
   let rv = self#regs_for k in
   name_regs v rv;
   self#insert_moves env r1 rv;
-  let naming_op =
-    Iname_for_debugger {
-      ident = VP.var v;
-      which_parameter = None;
-      provenance = VP.provenance v;
-      is_assignment = false;
-      regs = r1;
-    }
-  in
-  self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |];
+  let provenance = VP.provenance v in
+  (if Option.is_some provenance then (
+    let naming_op =
+      Iname_for_debugger {
+        ident = VP.var v;
+        which_parameter = None;
+        provenance = VP.provenance v;
+        is_assignment = false;
+        regs = r1;
+      }
+    in
+    self#insert_debug env (Iop naming_op) Debuginfo.none [| |] [| |]
+  ));
   env_add ~mut:Mutable v rv env
 
 (* The following two functions, [emit_parts] and [emit_parts_list], force
@@ -1682,19 +1699,21 @@ method emit_tail (env:environment) exp =
           self#emit_tail_sequence new_env e2 ~at_start:(fun seq ->
             List.iter (fun ((var, _typ), r) ->
                 let provenance = VP.provenance var in
-                let var = VP.var var in
-                let naming_op =
-                  Iname_for_debugger {
-                    ident = var;
-                    provenance;
-                    which_parameter = None;
-                    is_assignment = false;
-                    regs = r;
-                  }
-                in
-               seq#insert_debug new_env (Iop naming_op) Debuginfo.none
-                 [| |] [| |])
-               ids_and_rs)
+                if Option.is_some provenance then (
+                  let var = VP.var var in
+                  let naming_op =
+                    Iname_for_debugger {
+                      ident = var;
+                      provenance;
+                      which_parameter = None;
+                      is_assignment = false;
+                      regs = r;
+                    }
+                  in
+                  seq#insert_debug new_env (Iop naming_op) Debuginfo.none
+                    [| |] [| |]
+                ))
+                ids_and_rs)
         in
         nfail, trap_stack, seq, is_cold
       in
@@ -1740,18 +1759,20 @@ method emit_tail (env:environment) exp =
           self#emit_tail_sequence env_handler e2
             ~at_start:(fun seq ->
               let provenance = VP.provenance v in
-              let var = VP.var v in
-              let naming_op =
-                Iname_for_debugger {
-                  ident = var;
-                  provenance;
-                  which_parameter = None;
-                  is_assignment = false;
-                  regs = rv;
-                }
-              in
-              seq#insert_debug env_handler (Iop naming_op)
-                Debuginfo.none [| |] [| |])
+              if Option.is_some provenance then (
+                let var = VP.var v in
+                let naming_op =
+                  Iname_for_debugger {
+                    ident = var;
+                    provenance;
+                    which_parameter = None;
+                    is_assignment = false;
+                    regs = rv;
+                  }
+                in
+                seq#insert_debug env_handler (Iop naming_op)
+                  Debuginfo.none [| |] [| |]
+              ))
         in
         self#insert env
           (Itrywith(s1, kind,
@@ -1840,18 +1861,20 @@ method emit_fundecl ~future_funcnames f =
         Array.init num_regs_for_arg (fun index ->
           loc_arg.(!loc_arg_index + index))
       in
-      let naming_op =
-        Iname_for_debugger {
-          ident = var;
-          provenance;
-          which_parameter = Some param_index;
-          is_assignment = false;
-          regs = hard_regs_for_arg;
-        }
-      in
       loc_arg_index := !loc_arg_index + num_regs_for_arg;
-      self#insert_debug env (Iop naming_op) Debuginfo.none
-        hard_regs_for_arg [| |])
+      if Option.is_some provenance then (
+        let naming_op =
+          Iname_for_debugger {
+            ident = var;
+            provenance;
+            which_parameter = Some param_index;
+            is_assignment = false;
+            regs = hard_regs_for_arg;
+          }
+        in
+        self#insert_debug env (Iop naming_op) Debuginfo.none
+          hard_regs_for_arg [| |]
+      ))
     f.Cmm.fun_args;
   self#insert_moves env loc_arg rarg;
   let polled_body =

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -380,10 +380,13 @@ module Variable = struct
     let print ppf t =
       let cu = compilation_unit t in
       if Compilation_unit.equal cu (Compilation_unit.get_current_exn ())
-      then Format.fprintf ppf "%s/%d" (name t) (name_stamp t)
+      then
+        Format.fprintf ppf "%s/%d%s" (name t) (name_stamp t)
+          (if user_visible t then "UV" else "N")
       else
-        Format.fprintf ppf "%a.%s/%d" Compilation_unit.print cu (name t)
+        Format.fprintf ppf "%a.%s/%d%s" Compilation_unit.print cu (name t)
           (name_stamp t)
+          (if user_visible t then "UV" else "N")
   end
 
   include T0


### PR DESCRIPTION
Some variables that were not user-visible were slipping through.  This patch seems to fix things effectively on the example I was looking at.

This updates the Flambda 2 variable printer to identify whether a variable is user-visible.  This seems fairly unobtrusive since the annotation is at the end of the stamp, and is a great help for debugging.

Something still needs doing about `*opt*` which is user-visible and probably should be, I'll investigate this in due course.