### PR TITLE
Emit all sections as before except for debug_line and debug_frames which are delayed

### DIFF
--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -137,7 +137,7 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
         Asm_section.details section ~first_occurrence
       in
       if not first_occurrence then new_line ();
-      D.section names flags args;
+      D.section ~delayed:(Asm_section.is_delayed section) names flags args;
       if first_occurrence then define_label (Asm_label.for_section section)
 
   let initialize () =

--- a/backend/asm_targets/asm_directives_intf.ml
+++ b/backend/asm_targets/asm_directives_intf.ml
@@ -57,7 +57,8 @@ module type Arg = sig
 
     val label : ?data_type:data_type -> string -> unit
 
-    val section : ?delayed:bool -> string list -> string option -> string list -> unit
+    val section :
+      ?delayed:bool -> string list -> string option -> string list -> unit
 
     val text : unit -> unit
 

--- a/backend/asm_targets/asm_directives_intf.ml
+++ b/backend/asm_targets/asm_directives_intf.ml
@@ -57,7 +57,7 @@ module type Arg = sig
 
     val label : ?data_type:data_type -> string -> unit
 
-    val section : string list -> string option -> string list -> unit
+    val section : ?delayed:bool -> string list -> string option -> string list -> unit
 
     val text : unit -> unit
 
@@ -92,7 +92,8 @@ module type S = sig
       they are necessary so that references (e.g. DW_FORM_ref_addr /
       DW_FORM_sec_offset when emitting DWARF) to places that are currently at
       the start of these sections get relocated correctly when those places
-      become not at the start (e.g. during linking). *)
+      become not at the start (e.g. during linking).
+  *)
   val switch_to_section : Asm_section.t -> unit
 
   (** Called at the beginning of the assembly generation and only if the dwarf

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -63,6 +63,11 @@ let dwarf_sections_in_order () =
   in
   sections @ dwarf_version_dependent_sections
 
+let is_delayed = function
+  | DWARF Debug_line -> true
+  | DWARF (Debug_info | Debug_abbrev | Debug_aranges | Debug_str | Debug_loclists | Debug_rnglists | Debug_addr | Debug_loc | Debug_ranges)
+  | Text -> false
+
 let details t ~first_occurrence =
   let names, flags, args =
     match t, Target_system.derived_system () with

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -65,8 +65,11 @@ let dwarf_sections_in_order () =
 
 let is_delayed = function
   | DWARF Debug_line -> true
-  | DWARF (Debug_info | Debug_abbrev | Debug_aranges | Debug_str | Debug_loclists | Debug_rnglists | Debug_addr | Debug_loc | Debug_ranges)
-  | Text -> false
+  | DWARF
+      ( Debug_info | Debug_abbrev | Debug_aranges | Debug_str | Debug_loclists
+      | Debug_rnglists | Debug_addr | Debug_loc | Debug_ranges )
+  | Text ->
+    false
 
 let details t ~first_occurrence =
   let names, flags, args =

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -54,6 +54,9 @@ type section_details = private
 
 val dwarf_sections_in_order : unit -> t list
 
+(* If [is_delayed] = true the corresponding function will be emitted after text *)
+val is_delayed : t -> bool
+
 (** The necessary information for a section directive. [first_occurrence] should
     be [true] iff the corresponding directive will be the first such in the
     relevant assembly file for the given section. *)

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -54,7 +54,8 @@ type section_details = private
 
 val dwarf_sections_in_order : unit -> t list
 
-(* If [is_delayed] = true the corresponding function will be emitted after text *)
+(* If [is_delayed] = true the corresponding function will be emitted after
+   text *)
 val is_delayed : t -> bool
 
 (** The necessary information for a section directive. [first_occurrence] should

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -54,7 +54,7 @@ type section_details = private
 
 val dwarf_sections_in_order : unit -> t list
 
-(* If [is_delayed] = true the corresponding function will be emitted after
+(* If [is_delayed] = true the corresponding section will be emitted after
    text *)
 val is_delayed : t -> bool
 

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.ml
@@ -17,7 +17,6 @@ open Dwarf_low
 
 let emit0_delayed ~asm_directives:_ = ()
 
-
 let emit0 ~asm_directives ~compilation_unit_proto_die
     ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
     ~address_table ~location_list_table =
@@ -86,11 +85,11 @@ let emit ~asm_directives ~compilation_unit_proto_die
       ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
       ~address_table ~location_list_table
 
-let emit_delayed ~asm_directives ~basic_block_sections ~binary_backend_available =
+let emit_delayed ~asm_directives ~basic_block_sections ~binary_backend_available
+    =
   if (* CR mshinwell: support function sections *)
      !Clflags.function_sections || basic_block_sections
      (* CR mshinwell: support the internal assembler *)
      || binary_backend_available
   then ()
-  else
-    emit0_delayed ~asm_directives
+  else emit0_delayed ~asm_directives

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.ml
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.ml
@@ -15,6 +15,9 @@
 open Asm_targets
 open Dwarf_low
 
+let emit0_delayed ~asm_directives:_ = ()
+
+
 let emit0 ~asm_directives ~compilation_unit_proto_die
     ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
     ~address_table ~location_list_table =
@@ -82,3 +85,12 @@ let emit ~asm_directives ~compilation_unit_proto_die
     emit0 ~asm_directives ~compilation_unit_proto_die
       ~compilation_unit_header_label ~debug_loc_table ~debug_ranges_table
       ~address_table ~location_list_table
+
+let emit_delayed ~asm_directives ~basic_block_sections ~binary_backend_available =
+  if (* CR mshinwell: support function sections *)
+     !Clflags.function_sections || basic_block_sections
+     (* CR mshinwell: support the internal assembler *)
+     || binary_backend_available
+  then ()
+  else
+    emit0_delayed ~asm_directives

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.mli
@@ -29,3 +29,8 @@ val emit :
   basic_block_sections:bool ->
   binary_backend_available:bool ->
   unit
+val emit_delayed :
+  asm_directives:(module Asm_directives.S) ->
+  basic_block_sections:bool ->
+  binary_backend_available:bool ->
+  unit

--- a/backend/debug/dwarf/dwarf_high/dwarf_world.mli
+++ b/backend/debug/dwarf/dwarf_high/dwarf_world.mli
@@ -29,6 +29,7 @@ val emit :
   basic_block_sections:bool ->
   binary_backend_available:bool ->
   unit
+
 val emit_delayed :
   asm_directives:(module Asm_directives.S) ->
   basic_block_sections:bool ->

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -114,8 +114,8 @@ let emit_delayed t ~basic_block_sections ~binary_backend_available =
   if t.emitted_delayed
   then
     Misc.fatal_error
-      "Cannot call [Dwarf.emit] more than once on a given value of type \
-       [Dwarf.t]";
+      "Cannot call [Dwarf.emit_delayed] more than once on a given value of \
+       type [Dwarf.t]";
   t.emitted_delayed <- true;
   Dwarf_world.emit_delayed ~asm_directives:t.asm_directives
     ~basic_block_sections ~binary_backend_available

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -26,7 +26,7 @@ type t =
     asm_directives : (module Asm_directives.S);
     get_file_id : string -> int;
     mutable emitted : bool;
-    mutable emitted_delayed : bool;
+    mutable emitted_delayed : bool
   }
 
 (* CR mshinwell: On OS X 10.11 (El Capitan), dwarfdump doesn't seem to be able
@@ -62,7 +62,12 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_begin
       ~value_type_proto_die ~start_of_code_symbol debug_loc_table
       debug_ranges_table address_table location_list_table
   in
-  { state; asm_directives; emitted = false; emitted_delayed = false; get_file_id }
+  { state;
+    asm_directives;
+    emitted = false;
+    emitted_delayed = false;
+    get_file_id
+  }
 
 type fundecl =
   { fun_end_label : Cmm.label;

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -25,7 +25,8 @@ type t =
   { state : DS.t;
     asm_directives : (module Asm_directives.S);
     get_file_id : string -> int;
-    mutable emitted : bool
+    mutable emitted : bool;
+    mutable emitted_delayed : bool;
   }
 
 (* CR mshinwell: On OS X 10.11 (El Capitan), dwarfdump doesn't seem to be able
@@ -61,7 +62,7 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_begin
       ~value_type_proto_die ~start_of_code_symbol debug_loc_table
       debug_ranges_table address_table location_list_table
   in
-  { state; asm_directives; emitted = false; get_file_id }
+  { state; asm_directives; emitted = false; emitted_delayed = false; get_file_id }
 
 type fundecl =
   { fun_end_label : Cmm.label;
@@ -102,4 +103,19 @@ let emit t ~basic_block_sections ~binary_backend_available =
 let emit t ~basic_block_sections ~binary_backend_available =
   Profile.record "emit_dwarf"
     (emit ~basic_block_sections ~binary_backend_available)
+    t
+
+let emit_delayed t ~basic_block_sections ~binary_backend_available =
+  if t.emitted_delayed
+  then
+    Misc.fatal_error
+      "Cannot call [Dwarf.emit] more than once on a given value of type \
+       [Dwarf.t]";
+  t.emitted_delayed <- true;
+  Dwarf_world.emit_delayed ~asm_directives:t.asm_directives
+    ~basic_block_sections ~binary_backend_available
+
+let emit_delayed t ~basic_block_sections ~binary_backend_available =
+  Profile.record "emit_delayed_dwarf"
+    (emit_delayed ~basic_block_sections ~binary_backend_available)
     t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
@@ -45,5 +45,6 @@ val dwarf_for_fundecl :
     above functions. *)
 val emit :
   t -> basic_block_sections:bool -> binary_backend_available:bool -> unit
+
 val emit_delayed :
   t -> basic_block_sections:bool -> binary_backend_available:bool -> unit

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.mli
@@ -45,3 +45,5 @@ val dwarf_for_fundecl :
     above functions. *)
 val emit :
   t -> basic_block_sections:bool -> binary_backend_available:bool -> unit
+val emit_delayed :
+  t -> basic_block_sections:bool -> binary_backend_available:bool -> unit

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -484,6 +484,12 @@ module Dwarf_helpers = struct
         ~binary_backend_available:!binary_backend_available)
       !dwarf
 
+  let emit_delayed_dwarf () =
+    Option.iter (Dwarf.emit_delayed
+        ~basic_block_sections:!Flambda_backend_flags.basic_block_sections
+        ~binary_backend_available:!binary_backend_available)
+      !dwarf
+
   let record_dwarf_for_fundecl fundecl =
     match !dwarf with
     | None -> None

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -116,6 +116,7 @@ module Dwarf_helpers : sig
     -> unit
 
   val emit_dwarf : unit -> unit
+  val emit_delayed_dwarf : unit -> unit
 
   val record_dwarf_for_fundecl : Linear.fundecl -> Dwarf.fundecl option
 end

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -170,26 +170,11 @@ let assemble_one_section ~name instructions =
       sec_instrs = Array.of_list instructions
     }
 
-
 let get_sections ~delayed sections =
   let get acc sections =
-    List.fold_left
-      (fun acc (name, instructions) ->
-        let align =
-          List.fold_left
-            (fun acc i ->
-              match i with X86_ast.Align (data, n) when n > acc -> n | _ -> acc)
-            0 instructions
-        in
-        Section_name.Map.add name
-          ( align,
-            X86_binary_emitter.assemble_section X64
-              { X86_binary_emitter.sec_name = X86_proc.Section_name.to_string name;
-                sec_instrs = Array.of_list instructions
-              } )
-          acc)
-      acc
-      sections
+    List.fold_left (fun acc (name, instructions) ->
+      Section_name.Map.add name (assemble_one_section ~name instructions) acc)
+      acc sections
   in
   (* DWARF sections must be emitted after .text and .data because they
      contain information that is produced when .text and .data are emitted.

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -188,18 +188,19 @@ let get_sections ~delayed sections =
                 sec_instrs = Array.of_list instructions
               } )
           acc)
-          acc sections
-      in
-      (* DWARF sections must be emitted after .text and .data because they
-         contain information that is produced when .text and .data are emitted.
-         For example, DWARF sections need to know the offset of some instructions
-         from the start of the .text section.
-         Additionally, DWARF sections may add relocations to the object file's
-         relocation table. *)
-      let acc = Section_name.Map.empty in
-      let acc = get acc sections in
-      Emitaux.Dwarf_helpers.emit_delayed_dwarf ();
-      get acc (delayed ())
+      acc
+      sections
+  in
+  (* DWARF sections must be emitted after .text and .data because they
+     contain information that is produced when .text and .data are emitted.
+     For example, DWARF sections need to know the offset of some instructions
+     from the start of the .text section.
+     Additionally, DWARF sections may add relocations to the object file's
+     relocation table. *)
+  let acc = Section_name.Map.empty in
+  let acc = get acc sections in
+  Emitaux.Dwarf_helpers.emit_delayed_dwarf ();
+  get acc (delayed ())
 
 let make_compiler_sections section_table compiler_sections symbol_table
     sh_string_table =

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -190,6 +190,12 @@ let get_sections ~delayed sections =
           acc)
           acc sections
       in
+      (* DWARF sections must be emitted after .text and .data because they
+         contain information that is produced when .text and .data are emitted.
+         For example, DWARF sections need to know the offset of some instructions
+         from the start of the .text section.
+         Additionally, DWARF sections may add relocations to the object file's
+         relocation table. *)
       let acc = Section_name.Map.empty in
       let acc = get acc sections in
       Emitaux.Dwarf_helpers.emit_delayed_dwarf ();

--- a/backend/internal_assembler/internal_assembler.mli
+++ b/backend/internal_assembler/internal_assembler.mli
@@ -23,6 +23,7 @@
 (** Create .o file. **)
 val assemble :
   (module Compiler_owee.Unix_intf.S) ->
-  X86_ast.asm_program ref X86_proc.Section_name.Tbl.t ->
+  delayed:(unit -> (X86_proc.Section_name.t * X86_ast.asm_line list) list) ->
+  (X86_proc.Section_name.t * X86_ast.asm_line list) list ->
   string ->
   unit

--- a/backend/x86_ast.mli
+++ b/backend/x86_ast.mli
@@ -207,7 +207,7 @@ type asm_line =
   | NewLabel of string * data_type
   | NewLine
   | Quad of constant
-  | Section of string list * string option * string list
+  | Section of string list * string option * string list * bool
   | Sleb128 of constant
   | Space of int
   | Uleb128 of constant

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -75,7 +75,7 @@ let mem64_rip typ ?(ofs = 0) s =
   Mem64_RIP (typ, s, ofs)
 
 module D = struct
-  let section segment flags args = directive (Section (segment, flags, args))
+  let section ?(delayed=false) segment flags args = directive (Section (segment, flags, args, delayed))
   let align ~data n = directive (Align (data, n))
   let byte n = directive (Byte n)
   let bytes s = directive (Bytes s)

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -92,7 +92,7 @@ module D : sig
   val private_extern: string -> unit
   val qword: constant -> unit
   val reloc: offset:constant -> name:reloc_type -> expr:constant -> unit
-  val section: string list -> string option -> string list -> unit
+  val section: ?delayed:bool -> string list -> string option -> string list -> unit
   val setvar: string * constant -> unit
   val size: string -> constant -> unit
   val sleb128 : constant -> unit

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -266,9 +266,9 @@ let print_line b = function
   | NewLabel (s, _) -> bprintf b "%s:" s
   | NewLine -> ()
   | Quad n -> bprintf b "\t.quad\t%a" cst n
-  | Section ([".data" ], _, _) -> bprintf b "\t.data"
-  | Section ([".text" ], _, _) -> bprintf b "\t.text"
-  | Section (name, flags, args) ->
+  | Section ([".data" ], _, _, _) -> bprintf b "\t.data"
+  | Section ([".text" ], _, _, _) -> bprintf b "\t.text"
+  | Section (name, flags, args, _delayed) ->
       bprintf b "\t.section %s" (String.concat "," name);
       begin match flags with
       | None -> ()

--- a/backend/x86_masm.ml
+++ b/backend/x86_masm.ml
@@ -218,8 +218,8 @@ let print_line b = function
   | NewLabel (s, ptr) -> bprintf b "%s LABEL %s" s (string_of_datatype ptr)
   | NewLine -> ()
   | Quad n -> bprintf b "\tQWORD\t%a" cst n
-  | Section ([".data"], None, []) -> bprintf b "\t.DATA"
-  | Section ([".text"], None, []) -> bprintf b "\t.CODE"
+  | Section ([".data"], None, [], _) -> bprintf b "\t.DATA"
+  | Section ([".text"], None, [], _) -> bprintf b "\t.CODE"
   | Section _ -> assert false
   | Space n -> bprintf b "\tBYTE\t%d DUP (?)" n
   | Word n -> bprintf b "\tWORD\t%a" cst n

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -354,7 +354,6 @@ let emit ins = directive (Ins ins)
 let reset_asm_code () =
   asm_code := [];
   asm_code_current_section := ref [];
-  (* Section_name.Tbl.clear delayed_sections; *)
   Section_name.Tbl.clear asm_code_by_section
 
 let generate_code asm =

--- a/backend/x86_proc.ml
+++ b/backend/x86_proc.ml
@@ -330,6 +330,7 @@ let assemble_file infile outfile =
 let asm_code = ref []
 let asm_code_current_section = ref (ref [])
 let asm_code_by_section = Section_name.Tbl.create 100
+let delayed_sections = Section_name.Tbl.create 100
 
 (* Cannot use Emitaux directly here or there would be a circular dep *)
 let create_asm_file = ref true
@@ -338,13 +339,14 @@ let directive dir =
   (if !create_asm_file then
      asm_code := dir :: !asm_code);
   match dir with
-  | Section (name, flags, args) -> (
+  | Section (name, flags, args, is_delayed) -> (
       let name = Section_name.make name flags args in
-      match Section_name.Tbl.find_opt asm_code_by_section name with
+      let where = if is_delayed then delayed_sections else asm_code_by_section in
+      match Section_name.Tbl.find_opt where name with
       | Some x -> asm_code_current_section := x
       | None ->
         asm_code_current_section := ref [];
-        Section_name.Tbl.add asm_code_by_section name !asm_code_current_section)
+        Section_name.Tbl.add where name !asm_code_current_section)
   | dir -> !asm_code_current_section := dir :: !(!asm_code_current_section)
 
 let emit ins = directive (Ins ins)
@@ -352,6 +354,7 @@ let emit ins = directive (Ins ins)
 let reset_asm_code () =
   asm_code := [];
   asm_code_current_section := ref [];
+  (* Section_name.Tbl.clear delayed_sections; *)
   Section_name.Tbl.clear asm_code_by_section
 
 let generate_code asm =
@@ -361,6 +364,13 @@ let generate_code asm =
   end;
   begin match !internal_assembler with
     | Some f ->
-      binary_content := Some (f asm_code_by_section)
+      let get sections =
+         Section_name.Tbl.fold (fun name instrs acc ->
+            (name, List.rev !instrs) :: acc)
+          sections []
+      in
+      let instrs = get asm_code_by_section in
+      let delayed () = get delayed_sections in
+      binary_content := Some (f ~delayed instrs)
   | None -> binary_content := None
   end

--- a/backend/x86_proc.mli
+++ b/backend/x86_proc.mli
@@ -111,7 +111,10 @@ end
 (** Support for plumbing a binary code emitter *)
 
 val internal_assembler :
-  (X86_ast.asm_program ref Section_name.Tbl.t -> string -> unit) option ref
+  (delayed:(unit -> (Section_name.t * X86_ast.asm_program) list)
+    -> (Section_name.t * X86_ast.asm_program) list
+    -> string -> unit) option ref
 
 val register_internal_assembler :
-  (X86_ast.asm_program ref Section_name.Tbl.t -> string -> unit) -> unit
+  (delayed:(unit -> (Section_name.t * X86_ast.asm_program) list)
+   -> (Section_name.t * X86_ast.asm_program) list -> string -> unit) -> unit


### PR DESCRIPTION
#1643 caused problem with mdx as it's involved a big changed in signatures.

This PR does the same but explicitly. All sections - but .debug_line, and later .debug_frames are emitted directly. .debug_line and .debug_frames are now considered as "delayed" and will only be emitted once [Dwarf.emit_delayed] is called.