### PR TITLE
Reduce memory usage of cached-generic-functions

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3117,32 +3117,34 @@ module Generic_fns_tbl = struct
       let arity n = List.init n (fun _ -> [| Val |]) in
       let result = [| Val |] in
       let tuplify =
-        List.init max_tuplify (fun n -> Lambda.Tupled, arity n, result)
+        Seq.init max_tuplify (fun n -> Lambda.Tupled, arity n, result)
       in
       let curry =
-        List.init (Lambda.max_arity ()) (fun n ->
-            List.init (Lambda.max_arity ()) (fun nlocal ->
+        Seq.init (Lambda.max_arity ()) (fun n ->
+            Seq.init (Lambda.max_arity ()) (fun nlocal ->
                 Lambda.Curried { nlocal }, arity n, result))
-        |> List.concat
+        |> Seq.concat
       in
       let send =
-        List.init max_send (fun n ->
-            [ arity n, result, Lambda.alloc_local;
-              arity n, result, Lambda.alloc_heap ])
-        |> List.concat
+        Seq.init max_send (fun n ->
+          Seq.cons
+              (arity n, result, Lambda.alloc_local)
+              (Seq.return (arity n, result, Lambda.alloc_heap)))
+        |> Seq.concat
       in
       let apply =
-        List.init max_apply (fun n ->
-            [ arity n, result, Lambda.alloc_local;
-              arity n, result, Lambda.alloc_heap ])
-        |> List.concat
+        Seq.init max_apply (fun n ->
+           Seq.cons
+              (arity n, result, Lambda.alloc_local)
+              (Seq.return (arity n, result, Lambda.alloc_heap)))
+        |> Seq.concat
       in
       let t = make () in
       add_uncached t
         Cmx_format.
-          { curry_fun = List.filter is_curry (tuplify @ curry);
-            send_fun = List.filter is_send send;
-            apply_fun = List.filter is_apply apply
+          { curry_fun = Seq.filter is_curry (Seq.append tuplify curry) |> List.of_seq;
+            send_fun = Seq.filter is_send send |> List.of_seq;
+            apply_fun = Seq.filter is_apply apply |> List.of_seq
           };
       t
   end

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3127,14 +3127,14 @@ module Generic_fns_tbl = struct
       in
       let send =
         Seq.init max_send (fun n ->
-          Seq.cons
+            Seq.cons
               (arity n, result, Lambda.alloc_local)
               (Seq.return (arity n, result, Lambda.alloc_heap)))
         |> Seq.concat
       in
       let apply =
         Seq.init max_apply (fun n ->
-           Seq.cons
+            Seq.cons
               (arity n, result, Lambda.alloc_local)
               (Seq.return (arity n, result, Lambda.alloc_heap)))
         |> Seq.concat
@@ -3142,7 +3142,8 @@ module Generic_fns_tbl = struct
       let t = make () in
       add_uncached t
         Cmx_format.
-          { curry_fun = Seq.filter is_curry (Seq.append tuplify curry) |> List.of_seq;
+          { curry_fun =
+              Seq.filter is_curry (Seq.append tuplify curry) |> List.of_seq;
             send_fun = Seq.filter is_send send |> List.of_seq;
             apply_fun = Seq.filter is_apply apply |> List.of_seq
           };

--- a/tools/dune
+++ b/tools/dune
@@ -13,35 +13,34 @@
 ;**************************************************************************
 
 (executable
-  (name flambda_backend_objinfo)
-  (modes byte native)
-  (modules flambda_backend_objinfo)
-  (libraries ocamlcommon ocamlbytecomp ocamloptcomp))
+ (name flambda_backend_objinfo)
+ (modes byte native)
+ (modules flambda_backend_objinfo)
+ (libraries ocamlcommon ocamlbytecomp ocamloptcomp))
 
 (executable
-  (name generate_cached_generic_functions)
-  (modes byte native)
-  (modules generate_cached_generic_functions)
+ (name generate_cached_generic_functions)
+ (modes byte native)
+ (modules generate_cached_generic_functions)
  (flags
   (:standard -principal -w -9-69-70-33-27))
-  (libraries ocamlcommon ocamloptcomp unix))
+ (libraries ocamlcommon ocamloptcomp unix memtrace))
 
 (install
-  (files
-    (flambda_backend_objinfo.bc as ocamlobjinfo.byte)
-    (flambda_backend_objinfo.exe as ocamlobjinfo.opt)
-    generate_cached_generic_functions.exe
-  )
-  (section bin)
-  (package ocaml))
+ (files
+  (flambda_backend_objinfo.bc as ocamlobjinfo.byte)
+  (flambda_backend_objinfo.exe as ocamlobjinfo.opt)
+  generate_cached_generic_functions.exe)
+ (section bin)
+ (package ocaml))
 
 (executable
-  (name merge_archives)
-  (modes native)
-  (modules merge_archives)
-  (libraries ocamlcommon ocamlbytecomp ocamloptcomp))
+ (name merge_archives)
+ (modes native)
+ (modules merge_archives)
+ (libraries ocamlcommon ocamlbytecomp ocamloptcomp))
 
 (executable
-  (name gen_compiler_libs_installation)
-  (modes native)
-  (modules gen_compiler_libs_installation))
+ (name gen_compiler_libs_installation)
+ (modes native)
+ (modules gen_compiler_libs_installation))

--- a/tools/generate_cached_generic_functions.ml
+++ b/tools/generate_cached_generic_functions.ml
@@ -31,6 +31,7 @@ open Misc
 let main filename =
   let unix = (module Unix : Compiler_owee.Unix_intf.S) in
   Clflags.native_code := true;
+  Clflags.use_linscan := true;
   Compmisc.init_path ();
   let file_prefix = Filename.remove_extension filename in
   Compmisc.with_ppf_dump ~file_prefix (fun ppf_dump ->
@@ -40,6 +41,7 @@ let arg_usage =
   Printf.sprintf "%s FILE : Generate an obj file containing cached generatic functions named FILE" Sys.argv.(0)
 
 let main () =
+  Memtrace.trace_if_requested ~context:"ocamlopt" ();
   Arg.parse_expand [] main arg_usage;
   exit 0
 


### PR DESCRIPTION
Generated the list of cached generated functions was eating up a lot of ram and could OOM. This PR fixes it by doing two things:

- When generating the list of candidate it now uses `Seq` instead of `List`, as there's no need for them to be materialized all of the time
- It switches the register allocator to linscan instead of regalloc. 

On my machine regalloc was using up to 10Go of RAM, against 2Go for linscan and IRC. The main difference between linscan and IRC is runtime: `tools/generate_cached_generic_functions.exe` takes ~1min for the former, 5min for the later (and regalloc was around 2min)