### PR TITLE
Flambda2 alignment check primitive

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1035,10 +1035,7 @@ let bigstring_length ba dbg =
 let bigstring_data ba dbg =
   Cop (Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg)
 
-let string_alignment str idx align dbg =
-  Cop (Cand, [Cconst_int (align - 1, dbg); Cop (Caddi, [str; idx], dbg)], dbg)
-
-let bigstring_alignment ba idx align dbg =
+let bigstring_alignment_test ba idx align dbg =
   Cop
     ( Cand,
       [ Cconst_int (align - 1, dbg);

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1035,13 +1035,14 @@ let bigstring_length ba dbg =
 let bigstring_data ba dbg =
   Cop (Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg)
 
-let string_alignment str idx dbg =
-  Cop (Cctz { arg_is_non_zero = true }, [Cop (Caddi, [str; idx], dbg)], dbg)
+let string_alignment str idx align dbg =
+  Cop (Cand, [Cconst_int (align - 1, dbg); Cop (Caddi, [str; idx], dbg)], dbg)
 
-let bigstring_alignment ba idx dbg =
+let bigstring_alignment ba idx align dbg =
   Cop
-    ( Cctz { arg_is_non_zero = true },
-      [Cop (Caddi, [bigstring_data ba dbg; idx], dbg)],
+    ( Cand,
+      [ Cconst_int (align - 1, dbg);
+        Cop (Caddi, [bigstring_data ba dbg; idx], dbg) ],
       dbg )
 
 (* Message sending *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1035,7 +1035,7 @@ let bigstring_length ba dbg =
 let bigstring_data ba dbg =
   Cop (Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg)
 
-let bigstring_alignment_test ba idx align dbg =
+let bigstring_get_alignment ba idx align dbg =
   Cop
     ( Cand,
       [ Cconst_int (align - 1, dbg);

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1032,6 +1032,18 @@ let string_length exp dbg =
 let bigstring_length ba dbg =
   Cop (Cload (Word_int, Mutable), [field_address ba 5 dbg], dbg)
 
+let bigstring_data ba dbg =
+  Cop (Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg)
+
+let string_alignment str idx dbg =
+  Cop (Cctz { arg_is_non_zero = true }, [Cop (Caddi, [str; idx], dbg)], dbg)
+
+let bigstring_alignment ba idx dbg =
+  Cop
+    ( Cctz { arg_is_non_zero = true },
+      [Cop (Caddi, [bigstring_data ba dbg; idx], dbg)],
+      dbg )
+
 (* Message sending *)
 
 let lookup_tag obj tag dbg =

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -367,7 +367,7 @@ val bigstring_length : expression -> Debuginfo.t -> expression
 
 val bigstring_data : expression -> Debuginfo.t -> expression
 
-val bigstring_alignment_test :
+val bigstring_get_alignment :
   expression -> expression -> int -> Debuginfo.t -> expression
 
 module Extended_machtype_component : sig

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -365,6 +365,10 @@ val string_length : expression -> Debuginfo.t -> expression
 
 val bigstring_length : expression -> Debuginfo.t -> expression
 
+val string_alignment : expression -> expression -> Debuginfo.t -> expression
+
+val bigstring_alignment : expression -> expression -> Debuginfo.t -> expression
+
 module Extended_machtype_component : sig
   (** Like [Cmm.machtype_component] but has a case explicitly for tagged
       integers.  This enables caml_apply functions to be insensitive to whether

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -365,10 +365,9 @@ val string_length : expression -> Debuginfo.t -> expression
 
 val bigstring_length : expression -> Debuginfo.t -> expression
 
-val string_alignment :
-  expression -> expression -> int -> Debuginfo.t -> expression
+val bigstring_data : expression -> Debuginfo.t -> expression
 
-val bigstring_alignment :
+val bigstring_alignment_test :
   expression -> expression -> int -> Debuginfo.t -> expression
 
 module Extended_machtype_component : sig

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -365,9 +365,11 @@ val string_length : expression -> Debuginfo.t -> expression
 
 val bigstring_length : expression -> Debuginfo.t -> expression
 
-val string_alignment : expression -> expression -> Debuginfo.t -> expression
+val string_alignment :
+  expression -> expression -> int -> Debuginfo.t -> expression
 
-val bigstring_alignment : expression -> expression -> Debuginfo.t -> expression
+val bigstring_alignment :
+  expression -> expression -> int -> Debuginfo.t -> expression
 
 module Extended_machtype_component : sig
   (** Like [Cmm.machtype_component] but has a case explicitly for tagged

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -352,18 +352,16 @@ let bigstring_access_validity_condition ~size_int big_str access_size index :
 let string_like_alignment_validity_condition str kind alignment tagged_index :
     H.expr_primitive =
   Binary
-    ( Int_comp (I.Naked_immediate, Yielding_bool (Ge Unsigned)),
-      Prim (Binary (Get_alignment kind, str, untag_int tagged_index)),
-      Simple (Simple.untagged_const_int alignment) )
+    ( Int_comp (I.Naked_immediate, Yielding_bool Eq),
+      Prim
+        (Binary (Check_alignment (kind, alignment), str, untag_int tagged_index)),
+      Simple Simple.untagged_const_zero )
 
 let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind
     string index =
   (* TODO(mslater): check alignment based on access size *)
-  (* let string_like_value_kind : P.string_like_value = match (kind :
-     P.string_or_bytes) with String -> String | Bytes -> Bytes in let primitive
-     = checked_alignment ~dbg ~primitive ~conditions: [
-     string_like_alignment_validity_condition string string_like_value_kind
-     alignment index ] in *)
+  ignore checked_alignment;
+  ignore string_like_alignment_validity_condition;
   checked_access ~dbg ~primitive
     ~conditions:
       [ string_or_bytes_access_validity_condition ~size_int string kind
@@ -371,9 +369,8 @@ let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind
 
 let checked_bigstring_access ~dbg ~size_int ~access_size ~primitive arg1 arg2 =
   (* TODO(mslater): check alignment based on access size *)
-  (* let primitive = checked_alignment ~dbg ~primitive ~conditions:
-     [string_like_alignment_validity_condition arg1 Bigstring alignment arg2]
-     in *)
+  ignore checked_alignment;
+  ignore string_like_alignment_validity_condition;
   checked_access ~dbg ~primitive
     ~conditions:
       [bigstring_access_validity_condition ~size_int arg1 access_size arg2]

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -349,19 +349,17 @@ let bigstring_access_validity_condition ~size_int big_str access_size index :
   string_like_access_validity_condition index ~size_int ~access_size
     ~length:(bigarray_dim_bound big_str 1)
 
-let string_like_alignment_validity_condition str kind alignment tagged_index :
+let bigstring_alignment_validity_condition bstr alignment tagged_index :
     H.expr_primitive =
   Binary
     ( Int_comp (I.Naked_immediate, Yielding_bool Eq),
       Prim
-        (Binary (Check_alignment (kind, alignment), str, untag_int tagged_index)),
+        (Binary
+           (Bigarray_check_alignment alignment, bstr, untag_int tagged_index)),
       Simple Simple.untagged_const_zero )
 
 let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind
     string index =
-  (* TODO(mslater): check alignment based on access size *)
-  ignore checked_alignment;
-  ignore string_like_alignment_validity_condition;
   checked_access ~dbg ~primitive
     ~conditions:
       [ string_or_bytes_access_validity_condition ~size_int string kind
@@ -370,7 +368,7 @@ let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind
 let checked_bigstring_access ~dbg ~size_int ~access_size ~primitive arg1 arg2 =
   (* TODO(mslater): check alignment based on access size *)
   ignore checked_alignment;
-  ignore string_like_alignment_validity_condition;
+  ignore bigstring_alignment_validity_condition;
   checked_access ~dbg ~primitive
     ~conditions:
       [bigstring_access_validity_condition ~size_int arg1 access_size arg2]

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -249,6 +249,14 @@ let checked_access ~dbg ~primitive ~conditions : H.expr_primitive =
       dbg
     }
 
+let checked_alignment ~dbg ~primitive ~conditions : H.expr_primitive =
+  Checked
+    { primitive;
+      validity_conditions = conditions;
+      failure = Address_was_misaligned;
+      dbg
+    }
+
 let check_bound_tagged tagged_index bound : H.expr_primitive =
   Binary
     ( Int_comp (I.Naked_immediate, Yielding_bool (Lt Unsigned)),
@@ -341,14 +349,31 @@ let bigstring_access_validity_condition ~size_int big_str access_size index :
   string_like_access_validity_condition index ~size_int ~access_size
     ~length:(bigarray_dim_bound big_str 1)
 
+let string_like_alignment_validity_condition str kind alignment tagged_index :
+    H.expr_primitive =
+  Binary
+    ( Int_comp (I.Naked_immediate, Yielding_bool (Ge Unsigned)),
+      Prim (Binary (Get_alignment kind, str, untag_int tagged_index)),
+      Simple (Simple.untagged_const_int alignment) )
+
 let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind
     string index =
+  (* TODO(mslater): check alignment based on access size *)
+  (* let string_like_value_kind : P.string_like_value = match (kind :
+     P.string_or_bytes) with String -> String | Bytes -> Bytes in let primitive
+     = checked_alignment ~dbg ~primitive ~conditions: [
+     string_like_alignment_validity_condition string string_like_value_kind
+     alignment index ] in *)
   checked_access ~dbg ~primitive
     ~conditions:
       [ string_or_bytes_access_validity_condition ~size_int string kind
           access_size index ]
 
 let checked_bigstring_access ~dbg ~size_int ~access_size ~primitive arg1 arg2 =
+  (* TODO(mslater): check alignment based on access size *)
+  (* let primitive = checked_alignment ~dbg ~primitive ~conditions:
+     [string_like_alignment_validity_condition arg1 Bigstring alignment arg2]
+     in *)
   checked_access ~dbg ~primitive
     ~conditions:
       [bigstring_access_validity_condition ~size_int arg1 access_size arg2]

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -354,8 +354,7 @@ let bigstring_alignment_validity_condition bstr alignment tagged_index :
   Binary
     ( Int_comp (I.Naked_immediate, Yielding_bool Eq),
       Prim
-        (Binary
-           (Bigarray_check_alignment alignment, bstr, untag_int tagged_index)),
+        (Binary (Bigarray_get_alignment alignment, bstr, untag_int tagged_index)),
       Simple Simple.untagged_const_zero )
 
 let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -17,6 +17,7 @@
 type failure =
   | Division_by_zero
   | Index_out_of_bounds
+  | Address_was_misaligned
 
 type expr_primitive =
   | Simple of Simple.t

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -345,7 +345,7 @@ type binop =
   | Int_shift of standard_int * int_shift_op
   | Infix of infix_binop
   | String_or_bigstring_load of string_like_value * string_accessor_width
-  | Check_alignment of string_like_value * int
+  | Bigarray_check_alignment of int
 
 type ternop =
   | Array_set of array_kind * init_or_assign

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -345,6 +345,7 @@ type binop =
   | Int_shift of standard_int * int_shift_op
   | Infix of infix_binop
   | String_or_bigstring_load of string_like_value * string_accessor_width
+  | Get_alignment of string_like_value
 
 type ternop =
   | Array_set of array_kind * init_or_assign

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -345,7 +345,7 @@ type binop =
   | Int_shift of standard_int * int_shift_op
   | Infix of infix_binop
   | String_or_bigstring_load of string_like_value * string_accessor_width
-  | Bigarray_check_alignment of int
+  | Bigarray_get_alignment of int
 
 type ternop =
   | Array_set of array_kind * init_or_assign

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -345,7 +345,7 @@ type binop =
   | Int_shift of standard_int * int_shift_op
   | Infix of infix_binop
   | String_or_bigstring_load of string_like_value * string_accessor_width
-  | Get_alignment of string_like_value
+  | Check_alignment of string_like_value * int
 
 type ternop =
   | Array_set of array_kind * init_or_assign

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -443,7 +443,7 @@ let binop (binop : Fexpr.binop) : Flambda_primitive.binary_primitive =
   | Int_comp (i, c) -> Int_comp (i, c)
   | Int_shift (i, s) -> Int_shift (i, s)
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
-  | Check_alignment (slv, align) -> Check_alignment (slv, align)
+  | Bigarray_check_alignment align -> Bigarray_check_alignment align
 
 let ternop env (ternop : Fexpr.ternop) : Flambda_primitive.ternary_primitive =
   match ternop with

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -443,6 +443,7 @@ let binop (binop : Fexpr.binop) : Flambda_primitive.binary_primitive =
   | Int_comp (i, c) -> Int_comp (i, c)
   | Int_shift (i, s) -> Int_shift (i, s)
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
+  | Check_alignment (slv, align) -> Check_alignment (slv, align)
 
 let ternop env (ternop : Fexpr.ternop) : Flambda_primitive.ternary_primitive =
   match ternop with

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -443,7 +443,7 @@ let binop (binop : Fexpr.binop) : Flambda_primitive.binary_primitive =
   | Int_comp (i, c) -> Int_comp (i, c)
   | Int_shift (i, s) -> Int_shift (i, s)
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
-  | Bigarray_check_alignment align -> Bigarray_check_alignment align
+  | Bigarray_get_alignment align -> Bigarray_get_alignment align
 
 let ternop env (ternop : Fexpr.ternop) : Flambda_primitive.ternary_primitive =
   match ternop with

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -580,7 +580,7 @@ let binop (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   | Float_arith o -> Infix (Float_arith o)
   | Float_comp c -> Infix (Float_comp c)
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
-  | Bigarray_check_alignment align -> Bigarray_check_alignment align
+  | Bigarray_get_alignment align -> Bigarray_get_alignment align
   | Bigarray_load _ ->
     Misc.fatal_errorf "TODO: Binary primitive: %a"
       Flambda_primitive.Without_args.print

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -580,6 +580,7 @@ let binop (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   | Float_arith o -> Infix (Float_arith o)
   | Float_comp c -> Infix (Float_comp c)
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
+  | Get_alignment slv -> Get_alignment slv
   | Bigarray_load _ ->
     Misc.fatal_errorf "TODO: Binary primitive: %a"
       Flambda_primitive.Without_args.print

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -580,7 +580,7 @@ let binop (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   | Float_arith o -> Infix (Float_arith o)
   | Float_comp c -> Infix (Float_comp c)
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
-  | Get_alignment slv -> Get_alignment slv
+  | Check_alignment (slv, align) -> Check_alignment (slv, align)
   | Bigarray_load _ ->
     Misc.fatal_errorf "TODO: Binary primitive: %a"
       Flambda_primitive.Without_args.print

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -580,7 +580,7 @@ let binop (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   | Float_arith o -> Infix (Float_arith o)
   | Float_comp c -> Infix (Float_comp c)
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
-  | Check_alignment (slv, align) -> Check_alignment (slv, align)
+  | Bigarray_check_alignment align -> Bigarray_check_alignment align
   | Bigarray_load _ ->
     Misc.fatal_errorf "TODO: Binary primitive: %a"
       Flambda_primitive.Without_args.print

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -488,6 +488,15 @@ let binop ppf binop a b =
     Format.fprintf ppf "@[<2>%%int_shift %a%a@ %a@ %a@]"
       (standard_int ~space:After)
       i simple a int_shift_op s simple b
+  | Check_alignment (slv, align) ->
+    let prim =
+      match slv with
+      | String -> "string"
+      | Bytes -> "bytes"
+      | Bigstring -> "bigstring"
+    in
+    Format.fprintf ppf "@[<2>%%check_alignment[%d] %s@ %a@ %a@]" align prim
+      simple a simple b
 
 let unary_int_arith_op ppf (o : unary_int_arith_op) =
   Format.pp_print_string ppf

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -488,14 +488,8 @@ let binop ppf binop a b =
     Format.fprintf ppf "@[<2>%%int_shift %a%a@ %a@ %a@]"
       (standard_int ~space:After)
       i simple a int_shift_op s simple b
-  | Check_alignment (slv, align) ->
-    let prim =
-      match slv with
-      | String -> "string"
-      | Bytes -> "bytes"
-      | Bigstring -> "bigstring"
-    in
-    Format.fprintf ppf "@[<2>%%check_alignment[%d] %s@ %a@ %a@]" align prim
+  | Bigarray_check_alignment align ->
+    Format.fprintf ppf "@[<2>%%bigarray_check_alignment[%d] %a@ %a@]" align
       simple a simple b
 
 let unary_int_arith_op ppf (o : unary_int_arith_op) =

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -488,9 +488,9 @@ let binop ppf binop a b =
     Format.fprintf ppf "@[<2>%%int_shift %a%a@ %a@ %a@]"
       (standard_int ~space:After)
       i simple a int_shift_op s simple b
-  | Bigarray_check_alignment align ->
-    Format.fprintf ppf "@[<2>%%bigarray_check_alignment[%d] %a@ %a@]" align
-      simple a simple b
+  | Bigarray_get_alignment align ->
+    Format.fprintf ppf "@[<2>%%bigarray_get_alignment[%d] %a@ %a@]" align simple
+      a simple b
 
 let unary_int_arith_op ppf (o : unary_int_arith_op) =
   Format.pp_print_string ppf

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -979,8 +979,8 @@ let simplify_bigarray_load _num_dimensions _bigarray_kind _bigarray_layout
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_get_alignment _kind ~original_prim dacc ~original_term _dbg ~arg1:_
-    ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
+let simplify_get_alignment _kind _align ~original_prim dacc ~original_term _dbg
+    ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var
     (P.result_kind' original_prim)
     ~original_term
@@ -1027,7 +1027,7 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     | Bigarray_load (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_load num_dimensions bigarray_kind bigarray_layout
         ~original_prim
-    | Get_alignment string_like_value ->
-      simplify_get_alignment string_like_value ~original_prim
+    | Check_alignment (string_like_value, align) ->
+      simplify_get_alignment string_like_value align ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -979,6 +979,12 @@ let simplify_bigarray_load _num_dimensions _bigarray_kind _bigarray_layout
     (P.result_kind' original_prim)
     ~original_term
 
+let simplify_get_alignment _kind ~original_prim dacc ~original_term _dbg ~arg1:_
+    ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
+  SPR.create_unknown dacc ~result_var
+    (P.result_kind' original_prim)
+    ~original_term
+
 let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var =
   let min_name_mode = Bound_var.name_mode result_var in
@@ -1021,5 +1027,7 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     | Bigarray_load (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_load num_dimensions bigarray_kind bigarray_layout
         ~original_prim
+    | Get_alignment string_like_value ->
+      simplify_get_alignment string_like_value ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -979,7 +979,7 @@ let simplify_bigarray_load _num_dimensions _bigarray_kind _bigarray_layout
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_bigarray_check_alignment _align ~original_prim dacc ~original_term
+let simplify_bigarray_get_alignment _align ~original_prim dacc ~original_term
     _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var
     (P.result_kind' original_prim)
@@ -1027,7 +1027,7 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     | Bigarray_load (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_load num_dimensions bigarray_kind bigarray_layout
         ~original_prim
-    | Bigarray_check_alignment align ->
-      simplify_bigarray_check_alignment align ~original_prim
+    | Bigarray_get_alignment align ->
+      simplify_bigarray_get_alignment align ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -979,8 +979,8 @@ let simplify_bigarray_load _num_dimensions _bigarray_kind _bigarray_layout
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_get_alignment _kind _align ~original_prim dacc ~original_term _dbg
-    ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
+let simplify_bigarray_check_alignment _align ~original_prim dacc ~original_term
+    _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var
     (P.result_kind' original_prim)
     ~original_term
@@ -1027,7 +1027,7 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     | Bigarray_load (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_load num_dimensions bigarray_kind bigarray_layout
         ~original_prim
-    | Check_alignment (string_like_value, align) ->
-      simplify_get_alignment string_like_value align ~original_prim
+    | Bigarray_check_alignment align ->
+      simplify_bigarray_check_alignment align ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -355,6 +355,8 @@ let binary_prim_size prim =
   | Float_arith op -> binary_float_arith_primitive op
   | Float_comp (Yielding_bool cmp) -> binary_float_comp_primitive cmp
   | Float_comp (Yielding_int_like_compare_functions ()) -> 8
+  | Get_alignment (String | Bytes) -> 2 (* add index + tzcnt *)
+  | Get_alignment Bigstring -> 3 (* load data + add index + tzcnt *)
 
 let ternary_prim_size prim =
   match (prim : Flambda_primitive.ternary_primitive) with

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -355,8 +355,7 @@ let binary_prim_size prim =
   | Float_arith op -> binary_float_arith_primitive op
   | Float_comp (Yielding_bool cmp) -> binary_float_comp_primitive cmp
   | Float_comp (Yielding_int_like_compare_functions ()) -> 8
-  | Check_alignment ((String | Bytes), _) -> 2 (* add index + and *)
-  | Check_alignment (Bigstring, _) -> 3 (* load data + add index + and *)
+  | Bigarray_check_alignment _ -> 3 (* load data + add index + and *)
 
 let ternary_prim_size prim =
   match (prim : Flambda_primitive.ternary_primitive) with

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -355,8 +355,8 @@ let binary_prim_size prim =
   | Float_arith op -> binary_float_arith_primitive op
   | Float_comp (Yielding_bool cmp) -> binary_float_comp_primitive cmp
   | Float_comp (Yielding_int_like_compare_functions ()) -> 8
-  | Get_alignment (String | Bytes) -> 2 (* add index + tzcnt *)
-  | Get_alignment Bigstring -> 3 (* load data + add index + tzcnt *)
+  | Check_alignment ((String | Bytes), _) -> 2 (* add index + and *)
+  | Check_alignment (Bigstring, _) -> 3 (* load data + add index + and *)
 
 let ternary_prim_size prim =
   match (prim : Flambda_primitive.ternary_primitive) with

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -355,7 +355,7 @@ let binary_prim_size prim =
   | Float_arith op -> binary_float_arith_primitive op
   | Float_comp (Yielding_bool cmp) -> binary_float_comp_primitive cmp
   | Float_comp (Yielding_int_like_compare_functions ()) -> 8
-  | Bigarray_check_alignment _ -> 3 (* load data + add index + and *)
+  | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
 
 let ternary_prim_size prim =
   match (prim : Flambda_primitive.ternary_primitive) with

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1347,8 +1347,7 @@ let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
     if Flambda_features.float_const_prop ()
     then No_effects, No_coeffects, Strict
     else No_effects, Has_coeffects, Strict
-  | Bigarray_check_alignment _ ->
-    Only_generative_effects Mutable, Has_coeffects, Strict
+  | Bigarray_check_alignment _ -> No_effects, Has_coeffects, Strict
 
 let binary_classify_for_printing p =
   match p with

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1182,14 +1182,14 @@ type binary_primitive =
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
   | Float_arith of binary_float_arith_op
   | Float_comp of unit comparison_behaviour
-  | Bigarray_check_alignment of int
+  | Bigarray_get_alignment of int
 
 let binary_primitive_eligible_for_cse p =
   match p with
   | Array_load _ | Block_load _ -> false
   | String_or_bigstring_load _ -> false (* CR mshinwell: review *)
   | Bigarray_load _ -> false
-  | Bigarray_check_alignment _ -> true
+  | Bigarray_get_alignment _ -> true
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ -> true
   | Float_arith _ | Float_comp _ ->
     (* We believe that under the IEEE standard it is correct to CSE
@@ -1214,7 +1214,7 @@ let compare_binary_primitive p1 p2 =
     | Int_comp _ -> 7
     | Float_arith _ -> 8
     | Float_comp _ -> 9
-    | Bigarray_check_alignment _ -> 10
+    | Bigarray_get_alignment _ -> 10
   in
   match p1, p2 with
   | Block_load (kind1, mut1), Block_load (kind2, mut2) ->
@@ -1247,11 +1247,11 @@ let compare_binary_primitive p1 p2 =
     if c <> 0 then c else Stdlib.compare comp_behaviour1 comp_behaviour2
   | Float_arith op1, Float_arith op2 -> Stdlib.compare op1 op2
   | Float_comp comp1, Float_comp comp2 -> Stdlib.compare comp1 comp2
-  | Bigarray_check_alignment align1, Bigarray_check_alignment align2 ->
+  | Bigarray_get_alignment align1, Bigarray_get_alignment align2 ->
     Int.compare align1 align2
   | ( ( Block_load _ | Array_load _ | String_or_bigstring_load _
       | Bigarray_load _ | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _
-      | Float_arith _ | Float_comp _ | Bigarray_check_alignment _ ),
+      | Float_arith _ | Float_comp _ | Bigarray_get_alignment _ ),
       _ ) ->
     Stdlib.compare
       (binary_primitive_numbering p1)
@@ -1285,8 +1285,8 @@ let print_binary_primitive ppf p =
   | Float_comp comp_behaviour ->
     print_comparison_and_behaviour (fun _ppf () -> ()) ppf comp_behaviour;
     fprintf ppf "."
-  | Bigarray_check_alignment align ->
-    fprintf ppf "@[(Bigarray_check_alignment[%d])@]" align
+  | Bigarray_get_alignment align ->
+    fprintf ppf "@[(Bigarray_get_alignment[%d])@]" align
 
 let args_kind_of_binary_primitive p =
   match p with
@@ -1306,7 +1306,7 @@ let args_kind_of_binary_primitive p =
     let kind = K.Standard_int.to_kind kind in
     kind, kind
   | Float_arith _ | Float_comp _ -> K.naked_float, K.naked_float
-  | Bigarray_check_alignment _ -> bigstring_kind, K.naked_immediate
+  | Bigarray_get_alignment _ -> bigstring_kind, K.naked_immediate
 
 let result_kind_of_binary_primitive p : result_kind =
   match p with
@@ -1322,7 +1322,7 @@ let result_kind_of_binary_primitive p : result_kind =
     Singleton (K.Standard_int.to_kind kind)
   | Float_arith _ -> Singleton K.naked_float
   | Phys_equal _ | Int_comp _ | Float_comp _ -> Singleton K.naked_immediate
-  | Bigarray_check_alignment _ -> Singleton K.naked_immediate
+  | Bigarray_get_alignment _ -> Singleton K.naked_immediate
 
 let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
   match p with
@@ -1348,35 +1348,35 @@ let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
     if Flambda_features.float_const_prop ()
     then No_effects, No_coeffects, Strict
     else No_effects, Has_coeffects, Strict
-  | Bigarray_check_alignment _ -> No_effects, No_coeffects, Strict
+  | Bigarray_get_alignment _ -> No_effects, No_coeffects, Strict
 
 let binary_classify_for_printing p =
   match p with
   | Block_load _ | Array_load _ -> Destructive
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
   | Float_comp _ | Bigarray_load _ | String_or_bigstring_load _
-  | Bigarray_check_alignment _ ->
+  | Bigarray_get_alignment _ ->
     Neither
 
 let free_names_binary_primitive p =
   match p with
   | Block_load _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Bigarray_check_alignment _ ->
+  | Float_comp _ | Bigarray_get_alignment _ ->
     Name_occurrences.empty
 
 let apply_renaming_binary_primitive p _renaming =
   match p with
   | Block_load _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Bigarray_check_alignment _ ->
+  | Float_comp _ | Bigarray_get_alignment _ ->
     p
 
 let ids_for_export_binary_primitive p =
   match p with
   | Block_load _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Bigarray_check_alignment _ ->
+  | Float_comp _ | Bigarray_get_alignment _ ->
     Ids_for_export.empty
 
 type ternary_primitive =

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1188,7 +1188,8 @@ let binary_primitive_eligible_for_cse p =
   match p with
   | Array_load _ | Block_load _ -> false
   | String_or_bigstring_load _ -> false (* CR mshinwell: review *)
-  | Bigarray_load _ | Bigarray_check_alignment _ -> false
+  | Bigarray_load _ -> false
+  | Bigarray_check_alignment _ -> true
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ -> true
   | Float_arith _ | Float_comp _ ->
     (* We believe that under the IEEE standard it is correct to CSE
@@ -1347,7 +1348,7 @@ let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
     if Flambda_features.float_const_prop ()
     then No_effects, No_coeffects, Strict
     else No_effects, Has_coeffects, Strict
-  | Bigarray_check_alignment _ -> No_effects, Has_coeffects, Strict
+  | Bigarray_check_alignment _ -> No_effects, No_coeffects, Strict
 
 let binary_classify_for_printing p =
   match p with

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1182,14 +1182,14 @@ type binary_primitive =
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
   | Float_arith of binary_float_arith_op
   | Float_comp of unit comparison_behaviour
-  | Check_alignment of string_like_value * int
+  | Bigarray_check_alignment of int
 
 let binary_primitive_eligible_for_cse p =
   match p with
   | Array_load _ | Block_load _ -> false
   | String_or_bigstring_load _ -> false (* CR mshinwell: review *)
   | Bigarray_load _ -> false
-  | Check_alignment _ -> false (* CR mshinwell: review *)
+  | Bigarray_check_alignment _ -> true
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ -> true
   | Float_arith _ | Float_comp _ ->
     (* We believe that under the IEEE standard it is correct to CSE
@@ -1214,7 +1214,7 @@ let compare_binary_primitive p1 p2 =
     | Int_comp _ -> 7
     | Float_arith _ -> 8
     | Float_comp _ -> 9
-    | Check_alignment _ -> 10
+    | Bigarray_check_alignment _ -> 10
   in
   match p1, p2 with
   | Block_load (kind1, mut1), Block_load (kind2, mut2) ->
@@ -1247,13 +1247,11 @@ let compare_binary_primitive p1 p2 =
     if c <> 0 then c else Stdlib.compare comp_behaviour1 comp_behaviour2
   | Float_arith op1, Float_arith op2 -> Stdlib.compare op1 op2
   | Float_comp comp1, Float_comp comp2 -> Stdlib.compare comp1 comp2
-  | ( Check_alignment (string_like1, align1),
-      Check_alignment (string_like2, align2) ) ->
-    let c = Stdlib.compare string_like1 string_like2 in
-    if c <> 0 then c else Stdlib.compare align1 align2
+  | Bigarray_check_alignment align1, Bigarray_check_alignment align2 ->
+    Int.compare align1 align2
   | ( ( Block_load _ | Array_load _ | String_or_bigstring_load _
       | Bigarray_load _ | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _
-      | Float_arith _ | Float_comp _ | Check_alignment _ ),
+      | Float_arith _ | Float_comp _ | Bigarray_check_alignment _ ),
       _ ) ->
     Stdlib.compare
       (binary_primitive_numbering p1)
@@ -1287,9 +1285,8 @@ let print_binary_primitive ppf p =
   | Float_comp comp_behaviour ->
     print_comparison_and_behaviour (fun _ppf () -> ()) ppf comp_behaviour;
     fprintf ppf "."
-  | Check_alignment (string_like, align) ->
-    fprintf ppf "@[(Check_alignment[%d] %a)@]" align print_string_like_value
-      string_like
+  | Bigarray_check_alignment align ->
+    fprintf ppf "@[(Bigarray_check_alignment[%d])@]" align
 
 let args_kind_of_binary_primitive p =
   match p with
@@ -1309,9 +1306,7 @@ let args_kind_of_binary_primitive p =
     let kind = K.Standard_int.to_kind kind in
     kind, kind
   | Float_arith _ | Float_comp _ -> K.naked_float, K.naked_float
-  | Check_alignment ((String | Bytes), _) ->
-    string_or_bytes_kind, K.naked_immediate
-  | Check_alignment (Bigstring, _) -> bigstring_kind, K.naked_immediate
+  | Bigarray_check_alignment _ -> bigstring_kind, K.naked_immediate
 
 let result_kind_of_binary_primitive p : result_kind =
   match p with
@@ -1327,7 +1322,7 @@ let result_kind_of_binary_primitive p : result_kind =
     Singleton (K.Standard_int.to_kind kind)
   | Float_arith _ -> Singleton K.naked_float
   | Phys_equal _ | Int_comp _ | Float_comp _ -> Singleton K.naked_immediate
-  | Check_alignment _ -> Singleton K.naked_immediate
+  | Bigarray_check_alignment _ -> Singleton K.naked_immediate
 
 let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
   match p with
@@ -1353,35 +1348,36 @@ let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
     if Flambda_features.float_const_prop ()
     then No_effects, No_coeffects, Strict
     else No_effects, Has_coeffects, Strict
-  | Check_alignment _ -> Only_generative_effects Mutable, Has_coeffects, Strict
+  | Bigarray_check_alignment _ ->
+    Only_generative_effects Mutable, Has_coeffects, Strict
 
 let binary_classify_for_printing p =
   match p with
   | Block_load _ | Array_load _ -> Destructive
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
   | Float_comp _ | Bigarray_load _ | String_or_bigstring_load _
-  | Check_alignment _ ->
+  | Bigarray_check_alignment _ ->
     Neither
 
 let free_names_binary_primitive p =
   match p with
   | Block_load _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Check_alignment _ ->
+  | Float_comp _ | Bigarray_check_alignment _ ->
     Name_occurrences.empty
 
 let apply_renaming_binary_primitive p _renaming =
   match p with
   | Block_load _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Check_alignment _ ->
+  | Float_comp _ | Bigarray_check_alignment _ ->
     p
 
 let ids_for_export_binary_primitive p =
   match p with
   | Block_load _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Check_alignment _ ->
+  | Float_comp _ | Bigarray_check_alignment _ ->
     Ids_for_export.empty
 
 type ternary_primitive =

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1188,8 +1188,7 @@ let binary_primitive_eligible_for_cse p =
   match p with
   | Array_load _ | Block_load _ -> false
   | String_or_bigstring_load _ -> false (* CR mshinwell: review *)
-  | Bigarray_load _ -> false
-  | Bigarray_check_alignment _ -> true
+  | Bigarray_load _ | Bigarray_check_alignment _ -> false
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ -> true
   | Float_arith _ | Float_comp _ ->
     (* We believe that under the IEEE standard it is correct to CSE

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -369,6 +369,7 @@ type binary_primitive =
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
   | Float_arith of binary_float_arith_op
   | Float_comp of unit comparison_behaviour
+  | Get_alignment of string_like_value
 
 (** Primitives taking exactly three arguments. *)
 type ternary_primitive =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -369,7 +369,7 @@ type binary_primitive =
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
   | Float_arith of binary_float_arith_op
   | Float_comp of unit comparison_behaviour
-  | Bigarray_check_alignment of int
+  | Bigarray_get_alignment of int
 
 (** Primitives taking exactly three arguments. *)
 type ternary_primitive =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -369,7 +369,7 @@ type binary_primitive =
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
   | Float_arith of binary_float_arith_op
   | Float_comp of unit comparison_behaviour
-  | Check_alignment of string_like_value * int
+  | Bigarray_check_alignment of int
 
 (** Primitives taking exactly three arguments. *)
 type ternary_primitive =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -369,7 +369,7 @@ type binary_primitive =
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
   | Float_arith of binary_float_arith_op
   | Float_comp of unit comparison_behaviour
-  | Get_alignment of string_like_value
+  | Check_alignment of string_like_value * int
 
 (** Primitives taking exactly three arguments. *)
 type ternary_primitive =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -653,9 +653,7 @@ let binary_primitive env dbg f x y =
     binary_float_comp_primitive env dbg cmp x y
   | Float_comp (Yielding_int_like_compare_functions ()) ->
     binary_float_comp_primitive_yielding_int env dbg x y
-  | Check_alignment ((String | Bytes), align) ->
-    C.string_alignment x y align dbg
-  | Check_alignment (Bigstring, align) -> C.bigstring_alignment x y align dbg
+  | Bigarray_check_alignment align -> C.bigstring_alignment_test x y align dbg
 
 let ternary_primitive _env dbg f x y z =
   match (f : P.ternary_primitive) with

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -653,6 +653,8 @@ let binary_primitive env dbg f x y =
     binary_float_comp_primitive env dbg cmp x y
   | Float_comp (Yielding_int_like_compare_functions ()) ->
     binary_float_comp_primitive_yielding_int env dbg x y
+  | Get_alignment (String | Bytes) -> C.string_alignment x y dbg
+  | Get_alignment Bigstring -> C.bigstring_alignment x y dbg
 
 let ternary_primitive _env dbg f x y z =
   match (f : P.ternary_primitive) with

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -653,7 +653,7 @@ let binary_primitive env dbg f x y =
     binary_float_comp_primitive env dbg cmp x y
   | Float_comp (Yielding_int_like_compare_functions ()) ->
     binary_float_comp_primitive_yielding_int env dbg x y
-  | Bigarray_check_alignment align -> C.bigstring_alignment_test x y align dbg
+  | Bigarray_get_alignment align -> C.bigstring_get_alignment x y align dbg
 
 let ternary_primitive _env dbg f x y z =
   match (f : P.ternary_primitive) with

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -653,8 +653,9 @@ let binary_primitive env dbg f x y =
     binary_float_comp_primitive env dbg cmp x y
   | Float_comp (Yielding_int_like_compare_functions ()) ->
     binary_float_comp_primitive_yielding_int env dbg x y
-  | Get_alignment (String | Bytes) -> C.string_alignment x y dbg
-  | Get_alignment Bigstring -> C.bigstring_alignment x y dbg
+  | Check_alignment ((String | Bytes), align) ->
+    C.string_alignment x y align dbg
+  | Check_alignment (Bigstring, align) -> C.bigstring_alignment x y align dbg
 
 let ternary_primitive _env dbg f x y z =
   match (f : P.ternary_primitive) with


### PR DESCRIPTION
Adds a flambda2 primitive for checking whether indexing a string/bytes/bigstring would access an address with a particular alignment. This will be necessary for #1682, and is tested in that PR. 