### PR TITLE
Add some checks that the minor GC does not recurse

### DIFF
--- a/ocaml/otherlibs/systhreads/st_stubs.c
+++ b/ocaml/otherlibs/systhreads/st_stubs.c
@@ -247,6 +247,8 @@ static void memprof_ctx_iter(th_ctx_action f, void* data)
 
 CAMLexport void caml_thread_save_runtime_state(void)
 {
+  if (Caml_state->in_minor_collection)
+    caml_fatal_error("Thread switch from inside minor GC");
 #ifdef NATIVE_CODE
   curr_thread->top_of_stack = Caml_state->top_of_stack;
   curr_thread->bottom_of_stack = Caml_state->bottom_of_stack;

--- a/ocaml/runtime/minor_gc.c
+++ b/ocaml/runtime/minor_gc.c
@@ -417,6 +417,8 @@ void caml_empty_minor_heap (void)
 #endif
     if (caml_minor_gc_begin_hook != NULL) (*caml_minor_gc_begin_hook) ();
     prev_alloc_words = caml_allocated_words;
+    if (Caml_state->in_minor_collection)
+      caml_fatal_error("Minor GC triggered recursively");
     Caml_state->in_minor_collection = 1;
     caml_gc_message (0x02, "<");
     CAML_EV_BEGIN(EV_MINOR_LOCAL_ROOTS);


### PR DESCRIPTION
Custom_tag finalisers run during minor GC, at at time when the minor heap is half-collected and generally in a bad state. If they try to allocate or enter a blocking section, then very strange heap corruption occurs: you may recursively enter minor GC, and among other bad things might run custom finalisers twice, or corrupt the heap in essentially arbitrary ways.

This patch adds a couple of checks for this condition, so that the runtime blows up a bit earlier if this occurs. (Had it been there earlier, this patch would have saved me about a week of debugging)