### PR TITLE
Fix arrow printing when closing over unknown mode

### DIFF
--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -337,12 +337,11 @@ and print_out_arg am ppf ty =
 and print_out_ret mode rm ppf ty =
   match mode, rm with
   | Oam_local, Oam_local
-  | Oam_global, Oam_global
-  | Oam_unknown, _
-  | _, Oam_unknown -> print_out_type_1 rm ppf ty
+  | Oam_global, Oam_global -> print_out_type_1 rm ppf ty
   | _, Oam_local ->
-      print_out_type_local rm ppf ty
+    print_out_type_local rm ppf ty
   | _, Oam_global -> print_out_type_2 rm ppf ty
+  | _, Oam_unknown -> print_out_type_1 rm ppf ty
 
 and print_out_type_local m ppf ty =
   if Language_extension.is_enabled Local then begin


### PR DESCRIPTION
Reported by @ncik-roberts . Consider the example:
```
module M : sig
  val f : string -> string -> local_ string
end = struct
  let g x y = local_ "foo"
  let f x = local_ g x
end;;
```
This should error, because f is local-returning, which is not reflected in the signature. However, the error message given is:
```
Lines 3-6, characters 6-3:
Error: Signature mismatch:
...       Values do not match:
         val f : 'a -> 'b -> local_ string
       is not included in
         val f : string -> string -> local_ string
       The type string -> string -> local_ string
       is not compatible with the type string -> string -> local_ string
```
Note that the last two lines are just nonsense.
This is because the first argument of `f` (ie. `x`) is not constrained at all, which translates to `Oam_unknown`, which, in combination with currying, is handled wierdly in `oprint.ml`. 

This PR fixes this particular bug - there are still several places in `oprint.ml` where `Oam_unknown` is treated just like `Oam_global`, which could produce confusing error messages. Maybe this only manifests in convoluted examples, I don't know. But I would to discuss a better solution. 