### PR TITLE
Use raise-catch control flow to exit guarded right-hand sides

### DIFF
--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -273,7 +273,7 @@ end = struct
       | `Alias (p, id, _, _) ->
           aux
             ( (General.view p, patl),
-                bind_alias p id ~arg ~arg_sort ~action )
+              bind_alias p id ~arg ~arg_sort ~action )
       | `Record ([], _) as view -> stop p view
       | `Record (lbls, closed) ->
           let full_view = `Record (all_record_args lbls, closed) in

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -25,23 +25,12 @@ type rhs
 (* Creates a guarded rhs.
 
    If a guard fails, a guarded rhs must fallthrough to the remaining cases.
-   To facilitate this, guarded rhs's are constructed using a continuation.
 
-   [mk_pattern_guarded_rhs ~patch_guarded] produces a guarded rhs with a
-   lambda representation given by [patch_guarded ~patch], where [patch] contains
-   an expression that falls through to the remaining cases.
-
-   [mk_boolean_guarded_rhs ~patch_guarded ~free_variables] produces a similar
-   rhs where [free_variables] contains the free variables of the rhs.
+   [mk_guarded_rhs ~patch_guarded] produces a guarded rhs with a lambda
+   representation given by [patch_guarded ~patch], where [patch] contains an
+   expression that falls through to the remaining cases.
 *)
-val mk_boolean_guarded_rhs:
-        patch_guarded:(patch:lambda -> lambda) ->
-        free_variables:Ident.Set.t ->
-        rhs
-
-val mk_pattern_guarded_rhs:
-        patch_guarded:(patch:lambda -> lambda) ->
-        rhs
+val mk_guarded_rhs: patch_guarded:(patch:lambda -> lambda) -> rhs
 
 (* Creates an unguarded rhs from its lambda representation. *)
 val mk_unguarded_rhs: lambda -> rhs

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1057,10 +1057,7 @@ and transl_rhs ~scopes rhs_sort rhs =
         event_before
           ~scopes typed_guard (Lifthenelse (guard, body, patch, layout))
       in
-      let free_variables =
-        Ident.Set.union (free_variables guard) (free_variables body)
-      in
-      Matching.mk_boolean_guarded_rhs ~patch_guarded ~free_variables
+      Matching.mk_guarded_rhs ~patch_guarded
   | Pattern_guarded_rhs { scrutinee; scrutinee_sort; cases; partial;
                           loc; env; rhs_type } ->
       match partial with
@@ -1085,7 +1082,7 @@ and transl_rhs ~scopes rhs_sort rhs =
                  ~return_sort:rhs_sort ~return_type:rhs_type ~loc ~env
                  ~extra_cases scrutinee cases partial)
           in
-          Matching.mk_pattern_guarded_rhs ~patch_guarded
+          Matching.mk_guarded_rhs ~patch_guarded
       | Total ->
           (* Total pattern guards are equivalent to nested matches. *)
           let nested_match =


### PR DESCRIPTION
We spent a lot of time doing complicated things to deal with passing pattern-guarded right-hand sides to the pattern match compiler. The main problem was that at the time that pattern-match compilation begins, the fallthrough code is not known. Our best prior try involved representing the right-hand sides as continuations (#1749).

However, as suggested by @lpw25, we can do something a lot simpler. Namely, we may translate a pattern-guarded rhs
```
... when e match (
    | P1 -> rhs1
    ...
    | Pn -> rhsn
)
```

as though it were
```
match e with
| P1 -> rhs1
...
| Pn -> rhsn
| _ -> Lstaticraise (i, [])
```
where `i` is some fresh exception label.

Then, when the code for jumping to the remaining cases (call it `patch`) becomes known, we may wrap the translated pattern-guarded rhs (call it `rhs`) in the following way:
```
Lstaticcatch (rhs, (i, []), patch, return_kind)
```

Naively, this seems to add multiple jumps when one would suffice. When the guarded rhs wishes to fall through, it would seem that it first raises `i`, which is caught and then raises some `i'`, caught by the handler for the next case.

However, these two jumps are optimized into one in `simplif.ml`, as confirmed by examining some dumped lambda. This greatly simplifies the logic around pattern guard translation while also not sacrificing the quality of the produced code.