### PR TITLE
cached-generate-functions generates an archive

### DIFF
--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -454,38 +454,6 @@ let link_shared unix ~ppf_dump objfiles output_name =
     remove_file startup_obj
   )
 
-let make_cached_generic_functions unix  ~ppf_dump ~sourcefile_for_dwarf =
-  Location.input_name := "caml_cached_generic_functions"; (* set name of "current" input *)
-  let startup_comp_unit =
-    CU.create CU.Prefix.empty (CU.Name.of_string "_cached_generic_functions")
-  in
-  Compilenv.reset startup_comp_unit;
-  Emitaux.Dwarf_helpers.init ~disable_dwarf:(not !Dwarf_flags.dwarf_for_startup_file)
-    sourcefile_for_dwarf;
-  let genfns = Cmm_helpers.Generic_fns_tbl.Precomputed.gen () in
-  Emit.begin_assembly unix;
-  let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in
-  Profile.record_call "genfns" (fun () ->
-  List.iter compile_phrase
-    (Cmm_helpers.emit_preallocated_blocks []
-      (Cmm_helpers.generic_functions false genfns)));
-  Emit.end_assembly ()
-
-let cached_generic_functions unix ~ppf_dump output_name =
-  Profile.record_call output_name (fun () ->
-    let startup = output_name ^ ext_asm in
-    let sourcefile_for_dwarf = sourcefile_for_dwarf ~named_startup_file:true startup in
-    Profile.record_call "compile_unit" (fun () ->
-      Asmgen.compile_unit ~output_prefix:output_name
-        ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
-        ~obj_filename:(output_name ^ ext_obj)
-        ~may_reduce_heap:true
-        ~ppf_dump
-        (fun () ->
-          make_cached_generic_functions unix ~ppf_dump ~sourcefile_for_dwarf)
-    );
-  )
-
 let call_linker file_list_rev startup_file output_name =
   let main_dll = !Clflags.output_c_object
                  && Filename.check_suffix output_name Config.ext_dll

--- a/backend/asmlink.mli
+++ b/backend/asmlink.mli
@@ -26,8 +26,6 @@ val link_shared: (module Compiler_owee.Unix_intf.S) ->
 
 val call_linker_shared: ?native_toplevel:bool -> string list -> string -> unit
 
-val cached_generic_functions : (module Compiler_owee.Unix_intf.S) -> ppf_dump:formatter -> string -> unit
-
 val reset : unit -> unit
 val check_consistency: filepath -> Cmx_format.unit_infos -> Digest.t -> unit
 val extract_crc_interfaces: unit -> Import_info.t list

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -892,7 +892,7 @@ module Generic_fns_tbl : sig
   val entries : t -> Cmx_format.generic_fns
 
   module Precomputed : sig
-    val gen : unit -> t
+    val gen : int -> t list
   end
 end
 

--- a/tools/generate_cached_generic_functions.ml
+++ b/tools/generate_cached_generic_functions.ml
@@ -26,16 +26,55 @@
 
 open Printf
 open Misc
+open Config
 
+module CU = Compilation_unit
+
+let make_cached_generic_functions unix  ~ppf_dump genfns =
+  Location.input_name := "caml_cached_generic_functions"; (* set name of "current" input *)
+  let startup_comp_unit =
+    CU.create CU.Prefix.empty (CU.Name.of_string "_cached_generic_functions")
+  in
+  Compilenv.reset startup_comp_unit;
+  Emit.begin_assembly unix;
+  let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in
+  Profile.record_call "genfns" (fun () ->
+  List.iter compile_phrase
+    (Cmm_helpers.emit_preallocated_blocks []
+      (Cmm_helpers.generic_functions false genfns)));
+  Emit.end_assembly ()
+
+let cached_generic_functions unix ~ppf_dump output_name genfns =
+  Profile.record_call output_name (fun () ->
+    let startup = output_name ^ ext_asm in
+    Profile.record_call "compile_unit" (fun () ->
+      let obj_filename = output_name ^ ext_obj in
+      Asmgen.compile_unit ~output_prefix:output_name
+        ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
+        ~obj_filename
+        ~may_reduce_heap:true
+        ~ppf_dump
+        (fun () ->
+          make_cached_generic_functions unix ~ppf_dump genfns);
+      obj_filename
+    );
+  )
 
 let main filename =
   let unix = (module Unix : Compiler_owee.Unix_intf.S) in
   Clflags.native_code := true;
   Clflags.use_linscan := true;
   Compmisc.init_path ();
-  let file_prefix = Filename.remove_extension filename in
-  Compmisc.with_ppf_dump ~file_prefix (fun ppf_dump ->
-      Asmlink.cached_generic_functions unix ~ppf_dump file_prefix)
+  let file_prefix = Filename.remove_extension filename ^ ext_lib in
+  let genfns_partitions = Cmm_helpers.Generic_fns_tbl.Precomputed.gen 64 in
+  let objects =
+    List.map (fun partition ->
+      let file_prefix = Filename.temp_file "cached-generated" "" in
+      Compmisc.with_ppf_dump ~file_prefix (fun ppf_dump ->
+        cached_generic_functions unix ~ppf_dump file_prefix partition)
+    ) genfns_partitions
+  in
+  ignore (Ccomp.create_archive file_prefix objects : int)
 
 let arg_usage =
   Printf.sprintf "%s FILE : Generate an obj file containing cached generatic functions named FILE" Sys.argv.(0)


### PR DESCRIPTION
Cached generated functions will now be generated as a collection of 64 `.o` files, all gathered in an archive file.

This should hopefully reduce the size of binaries using this feature, as before this change the full object file (~50mb) would be linked.
Now only the `.o` containing the required generated functions will be linked.

All functions considered small (arity <= 20) are put in the same `.o` file. This `.o` file is ~1.7mb. The functions remaining are then distributed more or less equally in the 63 other `.o` files (each around 700kb). 