### PR TITLE
Add simd-regalloc flag to x86 backend

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -31,6 +31,9 @@ let prefetchwt1_support = ref false
 (* Emit elf notes with trap handling information. *)
 let trap_notes = ref true
 
+(* Enable SIMD register allocation features. *)
+let simd_regalloc = ref false
+
 (* Machine-specific command-line options *)
 
 let command_line_options =
@@ -58,7 +61,11 @@ let command_line_options =
     "-ftrap-notes", Arg.Set trap_notes,
       " Emit .note.ocaml_eh section with trap handling information (default)";
     "-fno-trap-notes", Arg.Clear trap_notes,
-      " Do not emit .note.ocaml_eh section with trap handling information"
+      " Do not emit .note.ocaml_eh section with trap handling information";
+    "-fsimd-regalloc", Arg.Set simd_regalloc,
+      " Enable SIMD register allocation (implied by -extension SIMD)";
+    "-fno-simd-regalloc", Arg.Clear simd_regalloc,
+      " Disable SIMD register allocation (overridden by -extension SIMD) (default)";
   ]
 
 (* Specific operations for the AMD64 processor *)

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -41,7 +41,7 @@ let _label s = D.label ~typ:QWORD s
 
 (* Override proc.ml *)
 
-let simd_regalloc_disabled () = not (Language_extension.is_enabled SIMD)
+let simd_frontend_disabled () = not (Language_extension.is_enabled SIMD)
 
 let int_reg_name =
   [| RAX; RBX; RDI; RSI; RDX; RCX; R8; R9;
@@ -54,8 +54,8 @@ let register_name typ r =
   | Int | Val | Addr -> Reg64 (int_reg_name.(r))
   | Float -> Regf (float_reg_name.(r - 100))
   | Vec128 ->
-    if simd_regalloc_disabled () then
-      Misc.fatal_error "SIMD register allocation is not enabled.";
+    if simd_frontend_disabled ()
+    then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 register.";
     Regf (float_reg_name.(r - 100))
 
 (* CFI directives *)
@@ -95,7 +95,8 @@ let frame_required = ref false
 
 let frame_size () =                     (* includes return address *)
   if !frame_required then begin
-    if simd_regalloc_disabled () then assert (num_stack_slots.(2) = 0);
+    if simd_frontend_disabled () && (num_stack_slots.(2) > 0)
+    then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 stack slot.";
     let sz =
       (!stack_offset
        + 8
@@ -111,7 +112,8 @@ let slot_offset loc cl =
   match loc with
   | Incoming n -> frame_size() + n
   | Local n ->
-      if simd_regalloc_disabled () then assert (num_stack_slots.(2) = 0 && cl < 2);
+      if simd_frontend_disabled () && (num_stack_slots.(2) > 0 || cl >= 2)
+      then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 stack slot.";
       (!stack_offset +
         (* Preserves original ordering (int -> float) *)
         match cl with
@@ -1632,8 +1634,8 @@ let make_stack_loc ~offset n (r : Reg.t) =
   (match r.typ with
    | Int | Val | Addr | Float -> ()
    | Vec128 ->
-    if simd_regalloc_disabled () then
-      Misc.fatal_error "SIMD register allocation is not enabled.");
+     if simd_frontend_disabled ()
+     then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 register.");
   Reg.at_location r.typ loc
 
 (* CR mshinwell: Not now, but after code review, it would be better to

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -23,7 +23,7 @@ open Cmm
 open Reg
 open Mach
 
-let simd_regalloc_disabled () = not (Language_extension.is_enabled SIMD)
+let simd_regalloc_disabled () = not (Language_extension.is_enabled SIMD || !simd_regalloc)
 
 let fp = Config.with_frame_pointers
 
@@ -106,8 +106,8 @@ let register_class r =
   | Val | Int | Addr -> 0
   | Float -> 1
   | Vec128 ->
-    if simd_regalloc_disabled () then
-      Misc.fatal_error "SIMD register allocation is not enabled.";
+    if simd_regalloc_disabled ()
+    then Misc.fatal_error "SIMD register allocation is not enabled.";
     1
 
 let num_stack_slot_classes = 3
@@ -117,8 +117,8 @@ let stack_slot_class typ =
   | Val | Addr | Int -> 0
   | Float -> 1
   | Vec128 ->
-    if simd_regalloc_disabled () then
-      Misc.fatal_error "SIMD register allocation is not enabled.";
+    if simd_regalloc_disabled ()
+    then Misc.fatal_error "SIMD register allocation is not enabled.";
     2
 
 let stack_class_tag c =
@@ -126,8 +126,8 @@ let stack_class_tag c =
   | 0 -> "i"
   | 1 -> "f"
   | 2 ->
-    if simd_regalloc_disabled () then
-      Misc.fatal_error "SIMD register allocation is not enabled.";
+    if simd_regalloc_disabled ()
+    then Misc.fatal_error "SIMD register allocation is not enabled.";
     "x"
   | c -> Misc.fatal_errorf "Unspecified stack slot class %d" c
 
@@ -143,8 +143,8 @@ let register_name ty r =
   | Float ->
     float_reg_name.(r - first_available_register.(1))
   | Vec128 ->
-    if simd_regalloc_disabled () then
-      Misc.fatal_error "SIMD register allocation is not enabled.";
+    if simd_regalloc_disabled ()
+    then Misc.fatal_error "SIMD register allocation is not enabled.";
     float_reg_name.(r - first_available_register.(1))
 
 (* Pack registers starting at %rax so as to reduce the number of REX
@@ -204,8 +204,9 @@ let destroyed_by_plt_stub_set = Reg.set_of_array destroyed_by_plt_stub
 let stack_slot slot ty =
   (match ty with
    | Float | Int | Addr | Val -> ()
-   | Vec128 -> if simd_regalloc_disabled () then
-     Misc.fatal_error "SIMD register allocation is not enabled.");
+   | Vec128 ->
+     if simd_regalloc_disabled ()
+     then Misc.fatal_error "SIMD register allocation is not enabled.");
   Reg.at_location ty (Stack slot)
 
 (* Instruction selection *)


### PR DESCRIPTION
This flag allows us to enable the SIMD-related register allocation changes without the full SIMD language extension.
When the extension is enabled, the register allocation features are automatically enabled as well.