### PR TITLE
Fix `make debug`, yet again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,4 +183,4 @@ ocamlopt:
 
 .ocamldebug: install
 	find _build/main -name '*.cmo' -type f -printf 'directory %h\n' | sort -u > .ocamldebug
-	echo "source ocaml/tools/debug_printers" >> .ocamldebug
+	echo "source _build/main/ocaml/tools/debug_printers" >> .ocamldebug


### PR DESCRIPTION
Going back to the dune setup moved debug_printers. This commit chases it down.