### PR TITLE
Zero alloc: assume that works with inlining - propagate via Scoped_location

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -95,7 +95,7 @@ module Witness = struct
           pp ppf;
           (* Show inlined locations. If dbg has only one item, it will already
              be shown as [loc]. *)
-          if Debuginfo.length t.dbg > 1
+          if Debuginfo.Dbg.length (Debuginfo.get_dbg t.dbg) > 1
           then Format.fprintf ppf " (%a)" Debuginfo.print_compact dbg;
           if not (String.equal "" component)
           then Format.fprintf ppf " on a path to %s" component;
@@ -453,7 +453,7 @@ end = struct
     Format.fprintf ppf "Annotation check for %s%s failed on function %s (%s)"
       (Printcmm.property_to_string property)
       (if t.strict then " strict" else "")
-      (fun_dbg |> Debuginfo.to_list
+      (fun_dbg |> Debuginfo.get_dbg |> Debuginfo.Dbg.to_list
       |> List.map (fun dbg ->
              Debuginfo.(Scoped_location.string_of_scopes dbg.dinfo_scopes))
       |> String.concat ",")

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -915,19 +915,30 @@ end = struct
     let r = Value.join next exn in
     report t r ~msg:"transform join" ~desc dbg;
     let r = transform_diverge ~effect:effect.div r in
-    report t r ~msg:"transform_call result" ~desc dbg;
+    report t r ~msg:"transform result" ~desc dbg;
     check t r desc dbg
+
+  let transform_top t ~next ~exn w desc dbg =
+    let effect =
+      if Debuginfo.assume_zero_alloc dbg then Value.safe else Value.top w
+    in
+    transform t ~next ~exn ~effect desc dbg
 
   let transform_call t ~next ~exn callee w ~desc dbg =
     report t next ~msg:"transform_call next" ~desc dbg;
     report t exn ~msg:"transform_call exn" ~desc dbg;
-    let callee_value, new_dep = find_callee t callee dbg in
-    update_deps t callee_value new_dep w desc dbg;
-    (* Abstract witnesses of a call to the single witness for the callee name.
-       Summary of tailcall self won't be affected because it is set to Safe not
-       Top by [find_callee]. *)
-    let callee_value = Value.replace_witnesses w callee_value in
-    transform t ~next ~exn ~effect:callee_value desc dbg
+    let effect =
+      if Debuginfo.assume_zero_alloc dbg
+      then Value.safe
+      else
+        let callee_value, new_dep = find_callee t callee dbg in
+        update_deps t callee_value new_dep w desc dbg;
+        (* Abstract witnesses of a call to the single witness for the callee
+           name. Summary of tailcall self won't be affected because it is set to
+           Safe not Top by [find_callee]. *)
+        Value.replace_witnesses w callee_value
+    in
+    transform t ~next ~exn ~effect desc dbg
 
   let transform_operation t (op : Mach.operation) ~next ~exn dbg =
     match op with
@@ -968,22 +979,23 @@ end = struct
       next
     | Ialloc { mode = Alloc_heap; bytes; dbginfo } ->
       assert (not (Mach.operation_can_raise op));
-      let w = create_witnesses t (Alloc { bytes; dbginfo }) dbg in
-      let r = Value.transform w next in
-      check t r "heap allocation" dbg
+      if Debuginfo.assume_zero_alloc dbg
+      then next
+      else
+        let w = create_witnesses t (Alloc { bytes; dbginfo }) dbg in
+        let r = Value.transform w next in
+        check t r "heap allocation" dbg
     | Iprobe { name; handler_code_sym; enabled_at_init = __ } ->
       let desc = Printf.sprintf "probe %s handler %s" name handler_code_sym in
       let w = create_witnesses t (Probe { name; handler_code_sym }) dbg in
       transform_call t ~next ~exn handler_code_sym w ~desc dbg
     | Icall_ind ->
       let w = create_witnesses t Indirect_call dbg in
-      let effect = Value.top w in
-      transform t ~next ~exn ~effect "indirect call" dbg
+      transform_top t ~next ~exn w "indirect call" dbg
     | Itailcall_ind ->
       (* Sound to ignore [next] and [exn] because the call never returns. *)
       let w = create_witnesses t Indirect_tailcall dbg in
-      let effect = Value.top w in
-      transform t ~next:Value.normal_return ~exn:Value.exn_escape ~effect
+      transform_top t ~next:Value.normal_return ~exn:Value.exn_escape w
         "indirect tailcall" dbg
     | Icall_imm { func = { sym_name = func; _ } } ->
       let w = create_witnesses t (Direct_call { callee = func }) dbg in
@@ -1004,12 +1016,22 @@ end = struct
       Value.bot
     | Iextcall { func; alloc = true; _ } ->
       let w = create_witnesses t (Extcall { callee = func }) dbg in
-      let effect = Value.top w in
-      transform t ~next ~exn ~effect ("external call to " ^ func) dbg
+      transform_top t ~next ~exn w ("external call to " ^ func) dbg
     | Ispecific s ->
-      let w = create_witnesses t Arch_specific dbg in
-      transform t ~next ~exn ~effect:(S.transform_specific w s)
-        "Arch.specific_operation" dbg
+      let effect =
+        if Debuginfo.assume_zero_alloc dbg
+        then
+          (* Conservatively assume that operation can return normally. *)
+          let nor = V.Safe in
+          let exn = if Arch.operation_can_raise s then V.Safe else V.Bot in
+          (* Assume that the operation does not diverge. *)
+          let div = V.Bot in
+          { Value.nor; exn; div }
+        else
+          let w = create_witnesses t Arch_specific dbg in
+          S.transform_specific w s
+      in
+      transform t ~next ~exn ~effect "Arch.specific_operation" dbg
 
   module D = Dataflow.Backward ((Value : Dataflow.DOMAIN))
 

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -45,7 +45,7 @@ let for_fundecl ~get_file_id state (fundecl : L.fundecl) ~fun_end_label
   let parent = Dwarf_state.compilation_unit_proto_die state in
   let fun_name = fundecl.fun_name in
   let linkage_name =
-    match Debuginfo.to_list fundecl.fun_dbg with
+    match Debuginfo.Dbg.to_list (Debuginfo.get_dbg fundecl.fun_dbg) with
     | [item] ->
       Debuginfo.Scoped_location.string_of_scopes item.dinfo_scopes
       |> remove_double_underscores

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -127,14 +127,16 @@ type frame_descr =
 
 let frame_descriptors = ref([] : frame_descr list)
 
+let is_none_dbg d = Debuginfo.Dbg.is_none (Debuginfo.get_dbg d)
+
 let get_flags debuginfo =
   match debuginfo with
   | Dbg_other d | Dbg_raise d ->
-    if Debuginfo.is_none d then 0 else 1
+    if is_none_dbg d then 0 else 1
   | Dbg_alloc dbgs ->
     if !Clflags.debug &&
        List.exists (fun d ->
-         not (Debuginfo.is_none d.Debuginfo.alloc_dbg)) dbgs
+         not (is_none_dbg d.Debuginfo.alloc_dbg)) dbgs
     then 3 else 2
 
 let is_long n =
@@ -198,17 +200,18 @@ let emit_frames a =
   in
   let module Label_table =
     Hashtbl.Make (struct
-      type t = bool * Debuginfo.t
+      type t = bool * Debuginfo.Dbg.t
 
       let equal ((rs1 : bool), dbg1) (rs2, dbg2) =
-        rs1 = rs2 && Debuginfo.compare dbg1 dbg2 = 0
+        rs1 = rs2 && Debuginfo.Dbg.compare dbg1 dbg2 = 0
 
       let hash (rs, dbg) =
-        Hashtbl.hash (rs, Debuginfo.hash dbg)
+        Hashtbl.hash (rs, Debuginfo.Dbg.hash dbg)
     end)
   in
   let debuginfos = Label_table.create 7 in
   let label_debuginfos rs dbg =
+    let dbg = Debuginfo.get_dbg dbg in
     let key = (rs, dbg) in
     try Label_table.find debuginfos key
     with Not_found ->
@@ -253,7 +256,7 @@ let emit_frames a =
       if flags = 3 then begin
         a.efa_align 4;
         List.iter (fun Debuginfo.{alloc_dbg; _} ->
-          if Debuginfo.is_none alloc_dbg then
+          if is_none_dbg alloc_dbg then
             a.efa_32 Int32.zero
           else
             a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero) dbg
@@ -287,7 +290,7 @@ let emit_frames a =
                       (of_int has_next)))))
   in
   let emit_debuginfo (rs, dbg) lbl =
-    let rdbg = dbg |> Debuginfo.to_list |> List.rev in
+    let rdbg = dbg |> Debuginfo.Dbg.to_list |> List.rev in
     (* Due to inlined functions, a single debuginfo may have multiple locations.
        These are represented sequentially in memory (innermost frame first),
        with the low bit of the packed debuginfo being 0 on the last entry. *)
@@ -381,7 +384,7 @@ let get_file_num ~file_emitter file_name =
 (* We only display .file if the file has not been seen before. We
    display .loc for every instruction. *)
 let emit_debug_info_gen ?discriminator dbg file_emitter loc_emitter =
-  let dbg = Debuginfo.to_list dbg in
+  let dbg = Debuginfo.Dbg.to_list (Debuginfo.get_dbg dbg) in
   if is_cfi_enabled () &&
     (!Clflags.debug || Config.with_frame_pointers) then begin
     match List.rev dbg with

--- a/backend/fdo_info.ml
+++ b/backend/fdo_info.ml
@@ -28,7 +28,7 @@ let create ~dbg ~discriminator =
     }
 
 let equal_info left right =
-  Debuginfo.compare left.dbg right.dbg = 0
+  Debuginfo.(Dbg.compare (get_dbg left.dbg) (get_dbg right.dbg) = 0)
   && Int.equal left.discriminator right.discriminator
 
 let equal left right =

--- a/ocaml/asmcomp/emitaux.ml
+++ b/ocaml/asmcomp/emitaux.ml
@@ -166,17 +166,18 @@ let emit_frames a =
   in
   let module Label_table =
     Hashtbl.Make (struct
-      type t = bool * Debuginfo.t
+      type t = bool * Debuginfo.Dbg.t
 
       let equal ((rs1 : bool), dbg1) (rs2, dbg2) =
-        rs1 = rs2 && Debuginfo.compare dbg1 dbg2 = 0
+        rs1 = rs2 && Debuginfo.Dbg.compare dbg1 dbg2 = 0
 
       let hash (rs, dbg) =
-        Hashtbl.hash (rs, Debuginfo.hash dbg)
+        Hashtbl.hash (rs, Debuginfo.Dbg.hash dbg)
     end)
   in
   let debuginfos = Label_table.create 7 in
   let label_debuginfos rs dbg =
+    let dbg = Debuginfo.get_dbg dbg in
     let key = (rs, dbg) in
     try Label_table.find debuginfos key
     with Not_found ->
@@ -190,16 +191,17 @@ let emit_frames a =
     then a.efa_16 n
     else raise (Error(Stack_frame_too_large n))
   in
+  let is_none_dbg d = Debuginfo.Dbg.is_none (Debuginfo.get_dbg d) in
   let emit_frame fd =
     assert (fd.fd_frame_size land 3 = 0);
     let flags =
       match fd.fd_debuginfo with
       | Dbg_other d | Dbg_raise d ->
-        if Debuginfo.is_none d then 0 else 1
+        if is_none_dbg d then 0 else 1
       | Dbg_alloc dbgs ->
         if !Clflags.debug &&
            List.exists (fun d ->
-             not (Debuginfo.is_none d.Debuginfo.alloc_dbg)) dbgs
+             not (is_none_dbg d.Debuginfo.alloc_dbg)) dbgs
         then 3 else 2
     in
     a.efa_label_rel fd.fd_lbl 0l;
@@ -227,7 +229,7 @@ let emit_frames a =
       if flags = 3 then begin
         a.efa_align 4;
         List.iter (fun Debuginfo.{alloc_dbg; _} ->
-          if Debuginfo.is_none alloc_dbg then
+          if is_none_dbg alloc_dbg then
             a.efa_32 Int32.zero
           else
             a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero) dbg
@@ -261,7 +263,7 @@ let emit_frames a =
                       (of_int has_next)))))
   in
   let emit_debuginfo (rs, dbg) lbl =
-    let rdbg = dbg |> Debuginfo.to_list |> List.rev in
+    let rdbg = dbg |> Debuginfo.Dbg.to_list |> List.rev in
     (* Due to inlined functions, a single debuginfo may have multiple locations.
        These are represented sequentially in memory (innermost frame first),
        with the low bit of the packed debuginfo being 0 on the last entry. *)
@@ -346,7 +348,7 @@ let reset_debug_info () =
 (* We only display .file if the file has not been seen before. We
    display .loc for every instruction. *)
 let emit_debug_info_gen dbg file_emitter loc_emitter =
-  let dbg = Debuginfo.to_list dbg in
+  let dbg = Debuginfo.Dbg.to_list (Debuginfo.get_dbg dbg) in
   if is_cfi_enabled () &&
     (!Clflags.debug || Config.with_frame_pointers) then begin
     match List.rev dbg with

--- a/ocaml/lambda/debuginfo.ml
+++ b/ocaml/lambda/debuginfo.ml
@@ -273,5 +273,9 @@ let to_list { dbg; } = dbg
 
 let length { dbg; } = List.length dbg
 
+
 let merge ~into:{ dbg = dbg1 } { dbg = _dbg2; } =
   { dbg = dbg1 }
+
+let assume_zero_alloc t = t.assume_zero_alloc
+

--- a/ocaml/lambda/debuginfo.ml
+++ b/ocaml/lambda/debuginfo.ml
@@ -181,21 +181,22 @@ module Dbg = struct
       | _ :: _, [] -> 1
       | [], _ :: _ -> -1
       | d1 :: ds1, d2 :: ds2 ->
-        let c = String.compare d1.dinfo_file d2.dinfo_file in
-        if c <> 0 then c else
-          let c = compare d1.dinfo_line d2.dinfo_line in
-          if c <> 0 then c else
-            let c = compare d1.dinfo_char_end d2.dinfo_char_end in
-            if c <> 0 then c else
-              let c = compare d1.dinfo_char_start d2.dinfo_char_start in
-              if c <> 0 then c else
-                let c = compare d1.dinfo_start_bol d2.dinfo_start_bol in
-                if c <> 0 then c else
-                  let c = compare d1.dinfo_end_bol d2.dinfo_end_bol in
-                  if c <> 0 then c else
-                    let c = compare d1.dinfo_end_line d2.dinfo_end_line in
-                    if c <> 0 then c else
-                      loop ds1 ds2
+
+     let c = String.compare d1.dinfo_file d2.dinfo_file in
+       if c <> 0 then c else
+       let c = Int.compare d1.dinfo_line d2.dinfo_line in
+       if c <> 0 then c else
+       let c = Int.compare d1.dinfo_char_end d2.dinfo_char_end in
+       if c <> 0 then c else
+       let c = Int.compare d1.dinfo_char_start d2.dinfo_char_start in
+       if c <> 0 then c else
+       let c = Int.compare d1.dinfo_start_bol d2.dinfo_start_bol in
+       if c <> 0 then c else
+       let c = Int.compare d1.dinfo_end_bol d2.dinfo_end_bol in
+       if c <> 0 then c else
+       let c = Int.compare d1.dinfo_end_line d2.dinfo_end_line in
+       if c <> 0 then c else
+       loop ds1 ds2
     in
     loop (List.rev dbg1) (List.rev dbg2)
 

--- a/ocaml/lambda/debuginfo.ml
+++ b/ocaml/lambda/debuginfo.ml
@@ -316,8 +316,15 @@ let rec print_compact ppf t =
 
 let print_compact ppf { dbg; } = print_compact ppf dbg
 
-let merge ~into:{ dbg = dbg1 } { dbg = _dbg2; } =
-  { dbg = dbg1 }
+let merge ~into:{ dbg = dbg1; assume_zero_alloc = a1; }
+      { dbg = dbg2; assume_zero_alloc = a2 } =
+  (* Keep the first [dbg] info to match existing behavior.
+     When assume_zero_alloc is only on one of the inputs but not both, keep [dbg]
+     from the other.
+  *)
+  { dbg = if a1 && not a2 then dbg2 else dbg1;
+    assume_zero_alloc = a1 && a2
+  }
 
 let assume_zero_alloc t = t.assume_zero_alloc
 

--- a/ocaml/lambda/debuginfo.ml
+++ b/ocaml/lambda/debuginfo.ml
@@ -29,7 +29,8 @@ module Scoped_location = struct
 
   type scopes =
     | Empty
-    | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes}
+    | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes;
+               assume_zero_alloc: bool}
 
   let str = function
     | Empty -> ""
@@ -39,8 +40,9 @@ module Scoped_location = struct
     | Empty -> "(fun)"
     | Cons r -> r.str_fun
 
-  let cons scopes item str name =
-    Cons {item; str; str_fun = str ^ ".(fun)"; name; prev = scopes}
+  let cons scopes item str name ~assume_zero_alloc =
+    Cons {item; str; str_fun = str ^ ".(fun)"; name; prev = scopes;
+          assume_zero_alloc}
 
   let empty_scopes = Empty
 
@@ -61,22 +63,27 @@ module Scoped_location = struct
     | Empty -> s
     | Cons {str; _} -> str ^ sep ^ s
 
-  let enter_anonymous_function ~scopes =
+  let enter_anonymous_function ~scopes ~assume_zero_alloc =
     let str = str_fun scopes in
-    Cons {item = Sc_anonymous_function; str; str_fun = str; name = ""; prev = scopes}
+    Cons {item = Sc_anonymous_function; str; str_fun = str; name = ""; prev = scopes;
+          assume_zero_alloc }
 
-  let enter_value_definition ~scopes id =
+  let enter_value_definition ~scopes ~assume_zero_alloc id =
     cons scopes Sc_value_definition (dot scopes (Ident.name id)) (Ident.name id)
+      ~assume_zero_alloc
 
   let enter_compilation_unit ~scopes cu =
     let name = Compilation_unit.name_as_string cu in
     cons scopes Sc_module_definition (dot scopes name) name
+      ~assume_zero_alloc:false
 
   let enter_module_definition ~scopes id =
     cons scopes Sc_module_definition (dot scopes (Ident.name id)) (Ident.name id)
+      ~assume_zero_alloc:false
 
   let enter_class_definition ~scopes id =
     cons scopes Sc_class_definition (dot scopes (Ident.name id)) (Ident.name id)
+      ~assume_zero_alloc:false
 
   let enter_method_definition ~scopes (s : Asttypes.label) =
     let str =
@@ -84,16 +91,32 @@ module Scoped_location = struct
       | Cons {item = Sc_class_definition; _} -> dot ~sep:"#" scopes s
       | _ -> dot scopes s
     in
-    cons scopes Sc_method_definition str s
+    cons scopes Sc_method_definition str s ~assume_zero_alloc:false
 
   let enter_lazy ~scopes = cons scopes Sc_lazy (str scopes) ""
+                             ~assume_zero_alloc:false
 
   let enter_partial_or_eta_wrapper ~scopes =
     cons scopes Sc_partial_or_eta_wrapper (dot ~no_parens:() scopes "(partial)") ""
+      ~assume_zero_alloc:false
+
+  let set_assume_zero_alloc ~scopes =
+    match scopes with
+    | Empty -> Empty
+    | Cons { assume_zero_alloc = true } -> scopes
+    | Cons { item; str; str_fun; name; prev; assume_zero_alloc = false; } ->
+      Cons { item; str; str_fun; name; prev; assume_zero_alloc = true; }
+
+  let get_assume_zero_alloc ~scopes =
+    match scopes with
+    | Empty -> false
+    | Cons { assume_zero_alloc; _ } -> assume_zero_alloc
 
   let string_of_scopes = function
     | Empty -> "<unknown>"
-    | Cons {str; _} -> str
+    | Cons {str; assume_zero_alloc; _} ->
+      if assume_zero_alloc then str^"(assume zero_alloc)"
+      else str
 
   let string_of_scopes =
     let module StringSet = Set.Make (String) in
@@ -199,7 +222,8 @@ let from_location = function
   | Scoped_location.Loc_unknown -> { dbg = []; assume_zero_alloc = false; }
   | Scoped_location.Loc_known {scopes; loc} ->
     assert (not (Location.is_none loc));
-    { dbg = [item_from_location ~scopes loc]; assume_zero_alloc = false; }
+    let assume_zero_alloc = Scoped_location.get_assume_zero_alloc ~scopes in
+    { dbg = [item_from_location ~scopes loc]; assume_zero_alloc; }
 
 let to_location { dbg; assume_zero_alloc=_ } =
   match dbg with

--- a/ocaml/lambda/debuginfo.mli
+++ b/ocaml/lambda/debuginfo.mli
@@ -25,19 +25,22 @@ module Scoped_location : sig
 
   type scopes = private
     | Empty
-    | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes}
+    | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes;
+               assume_zero_alloc: bool}
 
   val string_of_scopes : scopes -> string
 
   val empty_scopes : scopes
-  val enter_anonymous_function : scopes:scopes -> scopes
-  val enter_value_definition : scopes:scopes -> Ident.t -> scopes
+  val enter_anonymous_function : scopes:scopes -> assume_zero_alloc:bool -> scopes
+  val enter_value_definition : scopes:scopes -> assume_zero_alloc:bool -> Ident.t -> scopes
   val enter_compilation_unit : scopes:scopes -> Compilation_unit.t -> scopes
   val enter_module_definition : scopes:scopes -> Ident.t -> scopes
   val enter_class_definition : scopes:scopes -> Ident.t -> scopes
   val enter_method_definition : scopes:scopes -> Asttypes.label -> scopes
   val enter_lazy : scopes:scopes -> scopes
   val enter_partial_or_eta_wrapper : scopes:scopes -> scopes
+  val set_assume_zero_alloc : scopes:scopes -> scopes
+  val get_assume_zero_alloc : scopes:scopes -> bool
 
   type t =
     | Loc_unknown

--- a/ocaml/lambda/debuginfo.mli
+++ b/ocaml/lambda/debuginfo.mli
@@ -93,15 +93,23 @@ val inline : t -> t -> t
 
 val compare : t -> t -> int
 
-val hash : t -> int
-
 val print_compact : Format.formatter -> t -> unit
-
-val to_list : t -> item list
-
-val length : t -> int
 
 val merge : into:t -> t -> t
 
 val assume_zero_alloc : t -> bool
+
+module Dbg : sig
+  type t
+
+  (** [compare] and [hash] ignore [dinfo_scopes] field of item *)
+
+  val is_none : t -> bool
+  val compare : t -> t -> int
+  val hash : t -> int
+  val to_list : t -> item list
+  val length : t -> int
+end
+
+val get_dbg : t -> Dbg.t
 

--- a/ocaml/lambda/debuginfo.mli
+++ b/ocaml/lambda/debuginfo.mli
@@ -99,3 +99,6 @@ val to_list : t -> item list
 val length : t -> int
 
 val merge : into:t -> t -> t
+
+val assume_zero_alloc : t -> bool
+

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -297,7 +297,7 @@ let get_local_attribute l =
   let attr = find_attribute is_local_attribute l in
   parse_local_attribute attr
 
-let get_property_attribute l p ~fun_attr =
+let get_property_attribute l p ~fun_attr:_ =
   let attr = find_attribute (is_property_attribute p) l in
   let res = parse_property_attribute attr p in
   (match attr, res with
@@ -310,29 +310,7 @@ let get_property_attribute l p ~fun_attr =
        (* The warning for unchecked functions will not trigger if the check is requested
           through the [@@@zero_alloc all] top-level annotation rather than through the
           function annotation [@zero_alloc]. *)
-       if assume then begin
-         (* [attr.inline] and [attr.specialise] must be set before the
-            check for [Warnings.Misplaced_assume_attribute].
-            For attributes from the same list, it's fine because
-            [add_check_attribute] is called after
-            [add_inline_attribute] and [add_specialise_attribute].
-            The warning will spuriously fire in the following case:
-            let[@inline never][@specialise never] f =
-              fun[@zero_alloc assume] x -> ..
-         *)
-         let never_specialise =
-           if Config.flambda then
-              fun_attr.specialise = Never_specialise
-           else
-              (* closure drops [@specialise never] and never specialises *)
-              (* flambda2 does not have specialisation support yet *)
-              true
-         in
-         if not ((fun_attr.inline = Never_inline) && never_specialise) then
-          Location.prerr_warning attr.attr_name.loc
-            (Warnings.Misplaced_assume_attribute attr.attr_name.txt)
-       end
-       else
+       if not assume then
          Builtin_attributes.register_property attr.attr_name);
    res
 

--- a/ocaml/lambda/translattribute.mli
+++ b/ocaml/lambda/translattribute.mli
@@ -64,3 +64,5 @@ val add_function_attributes
   -> Location.t
   -> Parsetree.attributes
   -> Lambda.lambda
+
+val assume_zero_alloc : Parsetree.attributes -> bool

--- a/ocaml/utils/warnings.ml
+++ b/ocaml/utils/warnings.ml
@@ -108,7 +108,6 @@ type t =
   | Unused_tmc_attribute                    (* 71 *)
   | Tmc_breaks_tailcall                     (* 72 *)
   | Probe_name_too_long of string           (* 190 *)
-  | Misplaced_assume_attribute of string    (* 198 *)
   | Unchecked_property_attribute of string  (* 199 *)
 ;;
 
@@ -193,7 +192,6 @@ let number = function
   | Unused_tmc_attribute -> 71
   | Tmc_breaks_tailcall -> 72
   | Probe_name_too_long _ -> 190
-  | Misplaced_assume_attribute _  -> 198
   | Unchecked_property_attribute _ -> 199
 ;;
 
@@ -455,10 +453,6 @@ let descriptions = [
   { number = 190;
     names = ["probe-name-too-long"];
     description = "Probe name must be at most 100 characters long." };
-  { number = 198;
-    names = ["misplaced-assume-attribute"];
-    description = "Assume of a property is ignored \
-                   if the function is inlined or specialised." };
   { number = 199;
     names = ["unchecked-property-attribute"];
     description = "A property of a function that was \
@@ -1066,12 +1060,6 @@ let message = function
       Printf.sprintf
         "This probe name is too long: `%s'. \
          Probe names must be at most 100 characters long." name
-  | Misplaced_assume_attribute property ->
-      Printf.sprintf
-        "the \"%s assume\" attribute will be ignored by the check \
-         when the function is inlined or specialised.\n\
-         Mark this function as [@inline never][@specialise never]."
-      property
   | Unchecked_property_attribute property ->
       Printf.sprintf "the %S attribute cannot be checked.\n\
       The function it is attached to was optimized away. \n\

--- a/ocaml/utils/warnings.mli
+++ b/ocaml/utils/warnings.mli
@@ -111,7 +111,6 @@ type t =
   | Tmc_breaks_tailcall                     (* 72 *)
 (* Flambda_backend specific warnings: numbers should go down from 199 *)
   | Probe_name_too_long of string           (* 190 *)
-  | Misplaced_assume_attribute of string    (* 198 *)
   | Unchecked_property_attribute of string  (* 199 *)
 ;;
 

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -398,6 +398,25 @@
  (action (diff fail20.output fail20.output.corrected)))
 
 (rule
+ (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (targets fail21.output.corrected)
+ (deps (:ml fail21.ml) filter.sh)
+ (action
+   (with-outputs-to fail21.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (deps fail21.output fail21.output.corrected)
+ (action (diff fail21.output fail21.output.corrected)))
+
+(rule
  (enabled_if (= %{context_name} "main"))
  (targets test_attribute_error_duplicate.output.corrected)
  (deps (:ml test_attribute_error_duplicate.ml) filter.sh)

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -473,25 +473,6 @@
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
- (targets test_warning198.output.corrected)
- (deps (:ml test_warning198.ml) filter.sh)
- (action
-   (with-outputs-to test_warning198.output.corrected
-    (pipe-outputs
-    (with-accepted-exit-codes 0
-     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
-    (run "./filter.sh")
-   ))))
-
-(rule
- (alias   runtest)
- (enabled_if (= %{context_name} "main"))
- (deps test_warning198.output test_warning198.output.corrected)
- (action (diff test_warning198.output test_warning198.output.corrected)))
-
-(rule
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (targets test_warning199.output.corrected)
  (deps (:ml test_warning199.mli test_warning199.ml) filter.sh)

--- a/tests/backend/checkmach/fail21.ml
+++ b/tests/backend/checkmach/fail21.ml
@@ -1,0 +1,12 @@
+let[@zero_alloc assume][@inline always] test1 x = (x,x)
+
+let[@inline always] test2 x = (x,x)
+
+(* passes *)
+let[@zero_alloc] test3 b x =
+  if b then test1 (x+1) else test1 (x*2)
+
+(* fails *)
+let[@zero_alloc] test4 b x =
+  let y = if b then test1 (x+1) else test1 (x*2) in
+  test2 y

--- a/tests/backend/checkmach/fail21.output
+++ b/tests/backend/checkmach/fail21.output
@@ -1,0 +1,4 @@
+File "fail21.ml", line 10, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Fail21.test4 (camlFail21__test4_HIDE_STAMP)
+File "fail21.ml", line 12, characters 2-9:
+  allocate 24 bytes (fail21.ml:12,2--9;fail21.ml:3,30--35)

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -97,6 +97,7 @@ let () =
      on optimization level. *)
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:(Some "dep19.ml") ~exit_code:2 "fail19";
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "fail20";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "fail21";
 
   print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None
     ~exit_code:2 "test_attribute_error_duplicate";

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -114,7 +114,6 @@ let () =
   (* flambda2 generates an indirect call but we don't yet have a way to exclude it
      without excluding closure. *)
   print_test ~flambda_only:true ~deps:"t1.ml";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:0
-    "test_warning198";
   (* closure does not delete dead functions *)
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:(Some "test_warning199.mli") ~exit_code:0 "test_warning199";
+  ()

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -234,3 +234,8 @@ module Params = struct
   let[@zero_alloc] test13 () =
     test12 ~d:42 ()
 end
+
+let[@zero_alloc assume][@inline always] test40 x = (x,x)
+
+let[@zero_alloc] test41 b x =
+  if b then test40 (x+1) else test40 (x*2)

--- a/tests/backend/checkmach/test_warning198.ml
+++ b/tests/backend/checkmach/test_warning198.ml
@@ -1,2 +1,0 @@
-let[@zero_alloc assume] bar y = (y+1,y)
-

--- a/tests/backend/checkmach/test_warning198.output
+++ b/tests/backend/checkmach/test_warning198.output
@@ -1,3 +1,0 @@
-File "test_warning198.ml", line 1, characters 5-15:
-Warning 198 [misplaced-assume-attribute]: the "zero_alloc assume" attribute will be ignored by the check when the function is inlined or specialised.
-Mark this function as [@inline never][@specialise never].


### PR DESCRIPTION
A new version of #1714. Instead of changing the middle-end translation from `Lambda`, this PR changes `Translcore` to parse `[@zero_alloc assume]` function attributes a little earler than before and propagate it as part of the `scopes` to the body of the function. Other changes are:

- Add field `assume_zero_alloc` to `Debuginfo.Scoped_location.scopes.Cons` 
- Propagate `assume_zero_alloc` from `Scoped_location.t` to Debuginfo.t`
- Use `assume_zero_alloc` in `Checkmach`
- Remove warning 198 and related tests
- Add tests

Best reviewed commit by commit.
Still needs testing on large examples.