### PR TITLE
Refactor stack classes

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -6,6 +6,9 @@ checks.ml
 checks.mli
 checkmach.ml
 checkmach.mli
+stack_class.mli
+stack_class_utils.ml
+stack_class_utils.mli
 cfg/**/*.ml
 cfg/**/*.mli
 asm_targets/**/*.ml

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -98,7 +98,7 @@ let fastcode_flag = ref true
 (* Layout of the stack frame *)
 let stack_offset = ref 0
 
-let num_stack_slots = Array.make Proc.num_stack_slot_classes 0
+let num_stack_slots = Stack_class.Tbl.make 0
 
 let prologue_required = ref false
 
@@ -106,13 +106,10 @@ let frame_required = ref false
 
 let frame_size () =                     (* includes return address *)
   if !frame_required then begin
-    if num_stack_slots.(2) > 0 then assert_simd_enabled ();
     let sz =
       (!stack_offset
        + 8
-       + 8 * num_stack_slots.(0)
-       + 8 * num_stack_slots.(1)
-       + 16 * num_stack_slots.(2)
+       + Stack_class.Tbl.total_size_in_bytes num_stack_slots
        + (if fp then 8 else 0))
     in Misc.align sz 16
   end else
@@ -122,14 +119,11 @@ let slot_offset loc cl =
   match loc with
   | Incoming n -> frame_size() + n
   | Local n ->
-      if num_stack_slots.(2) > 0 || cl >= 2 then assert_simd_enabled ();
-      (!stack_offset +
-        (* Preserves original ordering (int -> float) *)
-        match cl with
-        | 2 -> n * 16
-        | 0 -> num_stack_slots.(2) * 16 + n * 8
-        | 1 -> num_stack_slots.(2) * 16 + num_stack_slots.(0) * 8 + n * 8
-        | _ -> Misc.fatal_error "Unknown register class")
+      !stack_offset +
+       Stack_class.offset_in_bytes
+         num_stack_slots
+         ~stack_class:cl
+         ~slot:n
   | Outgoing n -> n
   | Domainstate _ -> assert false (* not a stack slot *)
 
@@ -311,7 +305,7 @@ let reg = function
       let ofs = n + Domainstate.(idx_of_field Domain_extra_params) * 8 in
       mem64 (x86_data_type_for_stack_slot ty) ofs R14
   | { loc = Stack s; typ = ty } as r ->
-      let ofs = slot_offset s (stack_slot_class r.typ) in
+      let ofs = slot_offset s (Stack_class.of_machtype r.typ) in
       mem64 (x86_data_type_for_stack_slot ty) ofs RSP
   | { loc = Unknown } ->
       assert false
@@ -334,7 +328,7 @@ let reg_low_32_name = Array.map (fun r -> Reg32 r) int_reg_name
 let emit_subreg tbl typ r =
   match r.loc with
   | Reg.Reg r when r < 13 -> tbl.(r)
-  | Stack s -> mem64 typ (slot_offset s (stack_slot_class r.Reg.typ)) RSP
+  | Stack s -> mem64 typ (slot_offset s (Stack_class.of_machtype r.Reg.typ)) RSP
   | _ -> assert false
 
 let arg8 i n = emit_subreg reg_low_8_name BYTE i.arg.(n)
@@ -376,7 +370,7 @@ let record_frame_label live dbg =
       | {typ = Val; loc = Reg r} ->
           live_offset := ((r lsl 1) + 1) :: !live_offset
       | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (stack_slot_class reg.typ) :: !live_offset
+          live_offset := slot_offset s (Stack_class.of_machtype reg.typ) :: !live_offset
       | {typ = Addr} as r ->
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
       | _ -> ()
@@ -795,7 +789,7 @@ let tailrec_entry_point = ref None
 type probe =
   {
     stack_offset: int;
-    num_stack_slots: int array;
+    num_stack_slots: int Stack_class.Tbl.t;
     (* Record frame info held in the corresponding mutable variables. *)
     probe_label: label;
     (* Probe site, recorded in .note.stapsdt section
@@ -1673,7 +1667,7 @@ let emit_instr fallthrough i =
       { probe_label;
         probe_insn = i;
         stack_offset = !stack_offset;
-        num_stack_slots = Array.copy num_stack_slots;
+        num_stack_slots = Stack_class.Tbl.copy num_stack_slots;
       }
     in
     probes := probe :: !probes;
@@ -1836,9 +1830,7 @@ let fundecl fundecl =
   call_gc_sites := [];
   local_realloc_sites := [];
   clear_safety_checks ();
-  for i = 0 to Proc.num_stack_slot_classes - 1 do
-    num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
-  done;
+  Stack_class.Tbl.copy_values ~from:fundecl.fun_num_stack_slots ~to_:num_stack_slots;
   prologue_required := fundecl.fun_prologue_required;
   frame_required := fundecl.fun_frame_required;
   all_functions := fundecl :: !all_functions;
@@ -2117,9 +2109,7 @@ let emit_probe_handler_wrapper p =
      recall that the wrapper does however have its own frame.) *)
   frame_required := true;
   stack_offset := p.stack_offset;
-  for i = 0 to Proc.num_stack_slot_classes - 1 do
-    num_stack_slots.(i) <- p.num_stack_slots.(i);
-  done;
+  Stack_class.Tbl.copy_values ~from:p.num_stack_slots ~to_:num_stack_slots;
   (* Account for the return address that is now pushed on the stack. *)
   stack_offset := !stack_offset + 8;
   (* Emit function entry code *)
@@ -2254,7 +2244,7 @@ let emit_probe_notes0 () =
     let arg_name =
       match arg.loc with
       | Stack s ->
-        Printf.sprintf "%d(%%rsp)" (slot_offset s (stack_slot_class arg.Reg.typ))
+        Printf.sprintf "%d(%%rsp)" (slot_offset s (Stack_class.of_machtype arg.Reg.typ))
       | Reg reg -> Proc.register_name arg.Reg.typ reg
       | Unknown ->
         Misc.fatal_errorf "Cannot create probe: illegal argument: %a"

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -228,4 +228,4 @@ method! reload_test tst arg =
 end
 
 let fundecl f num_stack_slots =
-  (new reload)#fundecl f num_stack_slots
+  (new reload)#fundecl f ~num_stack_slots

--- a/backend/amd64/stack_class.ml
+++ b/backend/amd64/stack_class.ml
@@ -1,0 +1,90 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+module T = struct
+
+  type t =
+    | Int64
+    | Float64
+    | Vector128
+
+  let all = [
+    Int64;
+    Float64;
+    Vector128;
+  ]
+
+  let equal
+    : t -> t -> bool
+    = fun left right ->
+      match left, right with
+      | Int64, Int64 -> true
+      | Float64, Float64 -> true
+      | Vector128, Vector128 -> true
+      | (Int64 | Float64 | Vector128), _ -> false
+
+  let hash : t -> int = function
+    | Int64 -> 0
+    | Float64 -> 1
+    | Vector128 -> 2
+
+  let tag
+    : t -> string
+    = function
+      | Int64 -> "i"
+      | Float64 -> "f"
+      | Vector128 ->
+        Arch.assert_simd_enabled ();
+        "x"
+
+  let print
+    : Format.formatter -> t -> unit
+    = fun ppf stack_class ->
+      Format.fprintf ppf "%s"
+        (match stack_class with
+         | Int64 -> "int64"
+         | Float64 -> "float64"
+         | Vector128 -> "vector128")
+
+  let size_in_bytes
+    : t -> int
+    = function
+      | Int64 -> 8
+      | Float64 -> 8
+      | Vector128 -> 16
+
+  let of_machtype
+    : Cmm.machtype_component -> t
+    = function
+      | Val | Addr | Int -> Int64
+      | Float -> Float64
+      | Vec128 ->
+        Arch.assert_simd_enabled ();
+        Vector128
+
+end
+
+include T
+module Tbl = Stack_class_utils.Make_tbl (T)
+
+let offset_in_bytes_for_class
+  : stack_class:t -> slot:int -> int
+  = fun ~stack_class ~slot ->
+    (match stack_class with
+     | Int64 | Float64 -> ()
+     | Vector128 ->
+       Arch.assert_simd_enabled ());
+    slot * size_in_bytes stack_class
+
+let offset_in_bytes
+  : int Tbl.t -> stack_class:t -> slot:int -> int
+  = fun tbl ~stack_class ~slot ->
+    match stack_class with
+    | Vector128 ->
+      offset_in_bytes_for_class ~stack_class:Vector128 ~slot
+    | Int64 ->
+      Tbl.total_size_in_bytes_for_class tbl ~stack_class:Vector128
+      + offset_in_bytes_for_class ~stack_class:Int64 ~slot
+    | Float64 ->
+      Tbl.total_size_in_bytes_for_class tbl ~stack_class:Vector128
+      + Tbl.total_size_in_bytes_for_class tbl ~stack_class:Int64
+      + offset_in_bytes_for_class ~stack_class:Float64 ~slot

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -93,15 +93,14 @@ let emit_wreg = function
 
 let stack_offset = ref 0
 
-let num_stack_slots = Array.make Proc.num_stack_slot_classes 0
+let num_stack_slots = Stack_class.Tbl.make 0
 
 let prologue_required = ref false
 
 let contains_calls = ref false
 
 let initial_stack_offset () =
-    8 * num_stack_slots.(0) +
-    8 * num_stack_slots.(1) +
+    Stack_class.Tbl.total_size_in_bytes num_stack_slots +
     (if !contains_calls then 8 else 0)
 
 let frame_size () =
@@ -116,14 +115,12 @@ let slot_offset loc cl =
       assert (n >= 0);
       frame_size() + n
   | Local n ->
-      !stack_offset +
-      (if cl = 0
-       then n * 8
-       else num_stack_slots.(0) * 8 + n * 8)
+    !stack_offset
+    + Stack_class.offset_in_bytes num_stack_slots ~stack_class:cl ~slot:n
   | Outgoing n ->
       assert (n >= 0);
       n
-  | Domainstate _ -> assert false (* not a satck slot *)
+  | Domainstate _ -> assert false (* not a stack slot *)
 
 (* Output a stack reference *)
 
@@ -133,7 +130,7 @@ let emit_stack r =
       let ofs = n + Domainstate.(idx_of_field Domain_extra_params) * 8 in
       `[{emit_reg reg_domain_state_ptr}, #{emit_int ofs}]`
   | Stack s ->
-      let ofs = slot_offset s (stack_slot_class r.typ) in
+      let ofs = slot_offset s (Stack_class.of_machtype r.typ) in
       `[sp, #{emit_int ofs}]`
   | _ -> fatal_error "Emit.emit_stack"
 
@@ -163,7 +160,7 @@ let record_frame_label live dbg =
       | {typ = Val; loc = Reg r} ->
           live_offset := ((r lsl 1) + 1) :: !live_offset
       | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (stack_slot_class reg.typ) :: !live_offset
+          live_offset := slot_offset s (Stack_class.of_machtype reg.typ) :: !live_offset
       | {typ = Addr} as r ->
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
       | _ -> ())
@@ -1109,9 +1106,7 @@ let fundecl fundecl =
   float_literals := [];
   stack_offset := 0;
   call_gc_sites := [];
-  for i = 0 to Proc.num_stack_slot_classes - 1 do
-    num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
-  done;
+  Stack_class.Tbl.copy_values ~from:fundecl.fun_num_stack_slots ~to_:num_stack_slots;
   prologue_required := fundecl.fun_prologue_required;
   contains_calls := fundecl.fun_contains_calls;
   emit_named_text_section !function_name;

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -69,21 +69,6 @@ let register_class r =
   (* CR mslater: (SIMD) arm64 *)
   | Vec128 -> fatal_error "arm64: got vec128 register"
 
-let num_stack_slot_classes = 2
-
-let stack_slot_class typ =
-  match typ with
-  | Val | Int | Addr  -> 0
-  | Float -> 1
-  (* CR mslater: (SIMD) arm64 *)
-  | Vec128 -> fatal_error "arm64: got vec128 register"
-
-let stack_class_tag c =
-  match c with
-  | 0 -> "i"
-  | 1 -> "f"
-  | c -> Misc.fatal_errorf "Unspecified stack slot class %d" c
-
 let num_available_registers =
   [| 23; 32 |] (* first 23 int regs allocatable; all float regs allocatable *)
 
@@ -398,8 +383,8 @@ let trap_frame_size_in_bytes = 16
 
 let frame_required ~fun_contains_calls ~fun_num_stack_slots =
   fun_contains_calls
-    || fun_num_stack_slots.(0) > 0
-    || fun_num_stack_slots.(1) > 0
+  || Stack_class.Tbl.exists fun_num_stack_slots ~f:(fun _stack_class num ->
+        num > 0)
 
 let prologue_required ~fun_contains_calls ~fun_num_stack_slots =
   frame_required ~fun_contains_calls ~fun_num_stack_slots

--- a/backend/arm64/reload.ml
+++ b/backend/arm64/reload.ml
@@ -38,4 +38,4 @@ method! reload_operation op arg res =
 end
 
 let fundecl f num_stack_slots =
-  (new reload)#fundecl f num_stack_slots
+  (new reload)#fundecl f ~num_stack_slots

--- a/backend/arm64/stack_class.ml
+++ b/backend/arm64/stack_class.ml
@@ -1,0 +1,75 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+let fatal_vec128 () =
+  Misc.fatal_error "arm64: got vec128 register"
+
+module T = struct
+
+  type t =
+    | Int64
+    | Float64
+
+  let all = [
+    Int64;
+    Float64;
+  ]
+
+  let equal
+    : t -> t -> bool
+    = fun left right ->
+      match left, right with
+      | Int64, Int64 -> true
+      | Float64, Float64 -> true
+      | (Int64 | Float64), _ -> false
+
+  let hash : t -> int = function
+    | Int64 -> 0
+    | Float64 -> 1
+
+  let tag
+    : t -> string
+    = function
+      | Int64 -> "i"
+      | Float64 -> "f"
+
+  let print
+    : Format.formatter -> t -> unit
+    = fun ppf stack_class ->
+      Format.fprintf ppf "%s"
+        (match stack_class with
+         | Int64 -> "int64"
+         | Float64 -> "float64")
+
+  let size_in_bytes
+    : t -> int
+    = function
+      | Int64 -> 8
+      | Float64 -> 8
+
+  let of_machtype
+    : Cmm.machtype_component -> t
+    = function
+      | Val | Int | Addr  -> Int64
+      | Float -> Float64
+      (* CR mslater: (SIMD) arm64 *)
+      | Vec128 -> fatal_vec128 ()
+
+end
+
+include T
+module Tbl = Stack_class_utils.Make_tbl (T)
+
+let offset_in_bytes_for_class
+  : stack_class:t -> slot:int -> int
+  = fun ~stack_class ~slot ->
+    slot * size_in_bytes stack_class
+
+let offset_in_bytes
+  : int Tbl.t -> stack_class:t -> slot:int -> int
+  = fun tbl ~stack_class ~slot ->
+    match stack_class with
+    | Int64 ->
+      offset_in_bytes_for_class ~stack_class:Int64 ~slot
+    | Float64 ->
+      Tbl.total_size_in_bytes_for_class tbl ~stack_class:Int64
+      + offset_in_bytes_for_class ~stack_class:Float64 ~slot

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -361,7 +361,7 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
             (* Skip DWARF variable range generation for complicated functions
                to avoid high compilation speed penalties *)
             let total_num_stack_slots =
-              Array.fold_left (+) 0 fundecl.fun_num_stack_slots
+              Stack_class.Tbl.total_size_in_slots fundecl.fun_num_stack_slots
             in
             if total_num_stack_slots
                > !Dwarf_flags.dwarf_max_function_complexity

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -70,7 +70,7 @@ type t =
     entry_label : Label.t;
     fun_contains_calls : bool;
     (* CR-someday gyorsh: compute locally. *)
-    fun_num_stack_slots : int array
+    fun_num_stack_slots : int Stack_class.Tbl.t
   }
 
 let create ~fun_name ~fun_args ~fun_codegen_options ~fun_dbg ~fun_contains_calls
@@ -530,7 +530,8 @@ let same_location (r1 : Reg.t) (r2 : Reg.t) =
   match r1.loc with
   | Unknown -> Misc.fatal_errorf "Cfg got unknown register location."
   | Reg _ -> Proc.register_class r1 = Proc.register_class r2
-  | Stack _ -> Proc.stack_slot_class r1.typ = Proc.stack_slot_class r2.typ
+  | Stack _ ->
+    Stack_class.Tbl.equal_machtype r1 r2
 
 let is_noop_move instr =
   match instr.desc with

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -90,7 +90,7 @@ type t = private
     entry_label : Label.t;
         (** This label must be the first in all layouts of this cfg. *)
     fun_contains_calls : bool;  (** Precomputed at selection time. *)
-    fun_num_stack_slots : int array
+    fun_num_stack_slots : int Stack_class.Tbl.t
         (** Precomputed at register allocation time *)
   }
 
@@ -100,7 +100,7 @@ val create :
   fun_codegen_options:codegen_option list ->
   fun_dbg:Debuginfo.t ->
   fun_contains_calls:bool ->
-  fun_num_stack_slots:int array ->
+  fun_num_stack_slots:int Stack_class.Tbl.t ->
   t
 
 val fun_name : t -> string

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -451,7 +451,7 @@ let print_assembly (blocks : Cfg.basic_block list) =
   let fun_name = "_fun_start_" in
   let cfg =
     Cfg.create ~fun_name ~fun_args:[||] ~fun_codegen_options:[]
-      ~fun_dbg:Debuginfo.none ~fun_contains_calls:true ~fun_num_stack_slots:[||]
+      ~fun_dbg:Debuginfo.none ~fun_contains_calls:true ~fun_num_stack_slots:(Stack_class.Tbl.make 0)
   in
   List.iter
     (fun (block : Cfg.basic_block) ->

--- a/backend/coloring.ml
+++ b/backend/coloring.ml
@@ -44,28 +44,29 @@ let allocate_registers() =
   let unconstrained = ref [] in
 
   (* Reset the stack slot counts *)
-  let num_stack_slots = Array.make Proc.num_stack_slot_classes 0 in
+  let num_stack_slots = Stack_class.Tbl.make 0 in
 
   (* Preallocate the spilled registers in the stack.
      Split the remaining registers into constrained and unconstrained. *)
   let remove_reg reg =
     let cl = Proc.register_class reg in
-    let stack_cl = Proc.stack_slot_class reg.typ in
+    let stack_cl = Stack_class.of_machtype reg.typ in
     if reg.spill then begin
       (* Preallocate the registers in the stack *)
-      let nslots = num_stack_slots.(stack_cl) in
+      let nslots = Stack_class.Tbl.find num_stack_slots stack_cl in
       let conflict = Array.make nslots false in
       List.iter
         (fun r ->
           match r.loc with
             Stack(Local n) ->
-              if Proc.stack_slot_class r.typ = stack_cl then conflict.(n) <- true
+              if Stack_class.equal (Stack_class.of_machtype r.typ) stack_cl then
+                conflict.(n) <- true
           | _ -> ())
         reg.interf;
       let slot = ref 0 in
       while !slot < nslots && conflict.(!slot) do incr slot done;
       reg.loc <- Stack(Local !slot);
-      if !slot >= nslots then num_stack_slots.(stack_cl) <- !slot + 1
+      if !slot >= nslots then Stack_class.Tbl.replace num_stack_slots stack_cl (!slot + 1)
     end else if reg.degree < Proc.num_available_registers.(cl) then
       unconstrained := reg :: !unconstrained
     else begin
@@ -91,7 +92,7 @@ let allocate_registers() =
   (* Assign a location to a register, the best we can. *)
   let assign_location reg =
     let cl = Proc.register_class reg in
-    let stack_cl = Proc.stack_slot_class reg.typ in
+    let stack_cl = Stack_class.of_machtype reg.typ in
     let first_reg = Proc.first_available_register.(cl) in
     let num_regs = Proc.num_available_registers.(cl) in
     let score = Array.make num_regs 0 in
@@ -163,7 +164,7 @@ let allocate_registers() =
                                 if start >= num_regs then 0 else start)
     end else begin
       (* Sorry, we must put the pseudoreg in a stack location *)
-      let nslots = num_stack_slots.(stack_cl) in
+      let nslots = Stack_class.Tbl.find num_stack_slots stack_cl in
       let score = Array.make nslots 0 in
       (* Compute the scores as for registers *)
       List.iter
@@ -209,7 +210,7 @@ let allocate_registers() =
       else begin
         (* Allocate a new stack slot *)
         reg.loc <- Stack(Local nslots);
-        num_stack_slots.(stack_cl) <- nslots + 1
+        Stack_class.Tbl.replace num_stack_slots stack_cl (nslots + 1)
       end
     end;
     (* Cancel the preferences of this register so that they don't influence

--- a/backend/coloring.mli
+++ b/backend/coloring.mli
@@ -15,4 +15,4 @@
 
 (* Register allocation by coloring of the interference graph *)
 
-val allocate_registers: unit -> int array
+val allocate_registers: unit -> int Stack_class.Tbl.t

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -109,7 +109,7 @@ module Vars = struct
           in
           let slot_offset =
             Proc.slot_offset loc
-              ~stack_class:(Proc.stack_slot_class reg.typ)
+              ~stack_class:(Stack_class.of_machtype reg.typ)
               ~stack_offset ~fun_contains_calls ~fun_num_stack_slots
           in
           let offset : Stack_reg_offset.t =

--- a/backend/debug/available_ranges_vars.mli
+++ b/backend/debug/available_ranges_vars.mli
@@ -44,7 +44,7 @@ module Subrange_info : sig
     Reg_with_debug_info.t ->
     Subrange_state.t ->
     fun_contains_calls:bool ->
-    fun_num_stack_slots:int array ->
+    fun_num_stack_slots:int Stack_class.Tbl.t ->
     t
 
   val reg : t -> Reg.t

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -189,7 +189,7 @@ let rec available_regs (instr : M.instruction) ~all_regs_that_might_be_named
           else
             RD.Set.made_unavailable_by_clobber avail_before
               ~regs_clobbered:instr.res ~register_class:Proc.register_class
-              ~stack_class:(fun r -> Proc.stack_slot_class r.typ)
+              ~stack_class:(fun r -> Stack_class.of_machtype r.typ)
         in
         let results =
           Array.map2
@@ -239,7 +239,7 @@ let rec available_regs (instr : M.instruction) ~all_regs_that_might_be_named
           in
           RD.Set.made_unavailable_by_clobber avail_before ~regs_clobbered
             ~register_class:Proc.register_class ~stack_class:(fun r ->
-              Proc.stack_slot_class r.typ)
+              Stack_class.of_machtype r.typ)
         in
         (* Second: the cases of (a) allocations, (b) other polling points, (c)
            OCaml to OCaml function calls and (d) end-region operations. In these

--- a/backend/debug/compute_ranges_intf.ml
+++ b/backend/debug/compute_ranges_intf.ml
@@ -93,7 +93,7 @@ module type S_subrange_info = sig
     key ->
     subrange_state ->
     fun_contains_calls:bool ->
-    fun_num_stack_slots:int array ->
+    fun_num_stack_slots:int Stack_class.Tbl.t ->
     t
 
   val print : Format.formatter -> t -> unit

--- a/backend/debug/reg_with_debug_info.mli
+++ b/backend/debug/reg_with_debug_info.mli
@@ -69,7 +69,7 @@ val at_same_location :
   t ->
   Reg.t ->
   register_class:(Reg.t -> int) ->
-  stack_class:(Reg.t -> int) ->
+  stack_class:(Reg.t -> Stack_class.t) ->
   bool
 
 val holds_pointer : t -> bool
@@ -109,7 +109,7 @@ module Set : sig
     t ->
     regs_clobbered:Reg.t array ->
     register_class:(Reg.t -> int) ->
-    stack_class:(Reg.t -> int) ->
+    stack_class:(Reg.t -> Stack_class.t) ->
     t
 end
 

--- a/backend/dune
+++ b/backend/dune
@@ -14,7 +14,7 @@
 
 (rule
  (targets arch.ml arch.mli CSE.ml proc.ml regalloc_stack_operands.ml reload.ml scheduling.ml selection.ml
-          simd.ml simd_selection.ml simd_reload.ml)
+          simd.ml simd_selection.ml simd_reload.ml stack_class.ml)
  (mode    fallback)
  (deps    (glob_files amd64/*.ml)
           (glob_files amd64/*.mli)

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -60,7 +60,7 @@ type fundecl =
     fun_dbg : Debuginfo.t;
     fun_tailrec_entry_point_label : label option;
     fun_contains_calls: bool;
-    fun_num_stack_slots: int array;
+    fun_num_stack_slots: int Stack_class.Tbl.t;
     fun_frame_required: bool;
     fun_prologue_required: bool;
     fun_section_name: string option;

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -62,7 +62,7 @@ type fundecl =
     fun_dbg : Debuginfo.t;
     fun_tailrec_entry_point_label : label option;
     fun_contains_calls: bool;
-    fun_num_stack_slots: int array;
+    fun_num_stack_slots: int Stack_class.Tbl.t;
     fun_frame_required: bool;
     fun_prologue_required: bool;
     fun_section_name: string option;

--- a/backend/linscan.ml
+++ b/backend/linscan.ml
@@ -72,9 +72,9 @@ let rec release_expired_inactive ci pos = function
 (* Allocate a new stack slot to the interval. *)
 
 let allocate_stack_slot num_stack_slots i =
-  let cl = Proc.stack_slot_class i.reg.typ in
-  let ss = num_stack_slots.(cl) in
-  num_stack_slots.(cl) <- succ ss;
+  let cl = Stack_class.of_machtype i.reg.typ in
+  let ss = Stack_class.Tbl.find num_stack_slots cl in
+  Stack_class.Tbl.replace num_stack_slots cl (succ ss);
   i.reg.loc <- Stack(Local ss);
   i.reg.spill <- true
 
@@ -189,7 +189,7 @@ let allocate_registers() =
     };
   done;
   (* Reset the stack slot counts *)
-  let num_stack_slots = Array.make Proc.num_stack_slot_classes 0 in
+  let num_stack_slots = Stack_class.Tbl.make 0 in
   (* Add all fixed intervals (sorted by end position) *)
   List.iter
     (fun i ->

--- a/backend/linscan.mli
+++ b/backend/linscan.mli
@@ -16,4 +16,4 @@
 
 (* Linear scan register allocation. *)
 
-val allocate_registers: unit -> int array
+val allocate_registers: unit -> int Stack_class.Tbl.t

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -132,7 +132,7 @@ type fundecl =
     fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
     fun_poll: Lambda.poll_attribute;
-    fun_num_stack_slots: int array;
+    fun_num_stack_slots: int Stack_class.Tbl.t;
     fun_contains_calls: bool;
   }
 

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -133,7 +133,7 @@ type fundecl =
     fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
     fun_poll: Lambda.poll_attribute;
-    fun_num_stack_slots: int array;
+    fun_num_stack_slots: int Stack_class.Tbl.t;
     fun_contains_calls: bool;
   }
 

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -30,7 +30,7 @@ let loc ?(wrap_out = fun ppf f -> f ppf) ~unknown ppf loc typ =
       wrap_out ppf (fun ppf -> fprintf ppf "%s" (Proc.register_name typ r))
   | Stack(Local s) ->
       wrap_out ppf (fun ppf ->
-        fprintf ppf "s[%s:%i]" (Proc.stack_class_tag (Proc.stack_slot_class typ)) s)
+        fprintf ppf "s[%s:%i]" (Stack_class.tag (Stack_class.of_machtype typ)) s)
   | Stack(Incoming s) ->
       wrap_out ppf (fun ppf -> fprintf ppf "par[%i]" s)
   | Stack(Outgoing s) ->

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -28,13 +28,6 @@ val phys_reg: Cmm.machtype_component -> int -> Reg.t
 val rotate_registers: bool
 val precolored_regs : unit -> Reg.Set.t
 
-(* The number of stack slot classes may differ from the number of register classes.
-   On x86, we use the same class for floating point and SIMD vector registers,
-   but they take up different amounts of space on the stack. *)
-val num_stack_slot_classes: int
-val stack_slot_class: Cmm.machtype_component -> int
-val stack_class_tag: int -> string
-
 (* Calling conventions *)
 val loc_arguments: Cmm.machtype -> Reg.t array * int
 val loc_results_call: Cmm.machtype -> Reg.t array * int
@@ -75,13 +68,13 @@ val trap_frame_size_in_bytes : int
 
 val frame_required :
   fun_contains_calls:bool ->
-  fun_num_stack_slots:int array ->
+  fun_num_stack_slots:int Stack_class.Tbl.t ->
   bool
 
 val frame_size :
   stack_offset:int ->
   fun_contains_calls:bool ->
-  fun_num_stack_slots:int array ->
+  fun_num_stack_slots:int Stack_class.Tbl.t ->
   int
 
 type slot_offset = private
@@ -90,16 +83,16 @@ type slot_offset = private
 
 val slot_offset :
   Reg.stack_location ->
-  stack_class:int ->
+  stack_class:Stack_class.t ->
   stack_offset:int ->
   fun_contains_calls:bool ->
-  fun_num_stack_slots:int array ->
+  fun_num_stack_slots:int Stack_class.Tbl.t ->
   slot_offset
 
 (* Function prologues *)
 val prologue_required :
   fun_contains_calls : bool ->
-  fun_num_stack_slots : int array ->
+  fun_num_stack_slots : int Stack_class.Tbl.t ->
   bool
 
 (** For a given register class, the DWARF register numbering for that class.

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -264,9 +264,11 @@ let postlude :
     cfg_with_layout;
   if Utils.debug
   then
-    Array.iteri (Cfg_with_layout.cfg cfg_with_layout).fun_num_stack_slots
+    Stack_class.Tbl.iter
+      (Cfg_with_layout.cfg cfg_with_layout).fun_num_stack_slots
       ~f:(fun stack_class num_stack_slots ->
-        Utils.log ~indent:1 "stack_slots[%d]=%d" stack_class num_stack_slots);
+        Utils.log ~indent:1 "stack_slots[%a]=%d" Stack_class.print stack_class
+          num_stack_slots);
   remove_prologue_if_not_required cfg_with_layout;
   update_live_fields cfg_with_layout (Cfg_with_infos.liveness cfg_with_infos);
   f ();

--- a/backend/regalloc/regalloc_stack_slots.mli
+++ b/backend/regalloc/regalloc_stack_slots.mli
@@ -8,9 +8,9 @@ val make : unit -> t
 
 val iter : t -> f:(Reg.Tbl.key -> int -> unit) -> unit
 
-val size_for_all_stack_classes : t -> int
+val total_size_in_slots : t -> int
 
-val get_and_incr : t -> stack_class:int -> slot
+val get_and_incr : t -> stack_class:Stack_class.t -> slot
 
 val get_or_create : t -> Reg.t -> slot
 

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -256,7 +256,7 @@ let same_reg_class : Reg.t -> Reg.t -> bool =
 
 let same_stack_class : Reg.t -> Reg.t -> bool =
  fun reg1 reg2 ->
-  Int.equal (Proc.stack_slot_class reg1.typ) (Proc.stack_slot_class reg2.typ)
+  Stack_class.Tbl.equal_machtype reg1 reg2
 
 let make_temporary :
     same_class_and_base_name_as:Reg.t -> name_prefix:string -> Reg.t =

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -43,7 +43,7 @@ end = struct
     type t =
       | Local of
           { index : int;
-            stack_class : int
+            stack_class : Stack_class.t
           }
       | Incoming of { index : int }
       | Outgoing of { index : int }
@@ -115,7 +115,7 @@ end = struct
       Some
         (Stack
            (Stack.of_stack_loc
-              ~stack_class:(Proc.stack_slot_class reg.Reg.typ)
+              ~stack_class:(Stack_class.of_machtype reg.Reg.typ)
               stack))
 
   let of_reg_exn reg = of_reg reg |> Option.get

--- a/backend/reload.mli
+++ b/backend/reload.mli
@@ -15,4 +15,4 @@
 
 (* Insert load/stores for pseudoregs that got assigned to stack locations. *)
 
-val fundecl: Mach.fundecl -> int array -> Mach.fundecl * bool
+val fundecl: Mach.fundecl -> int Stack_class.Tbl.t -> Mach.fundecl * bool

--- a/backend/reloadgen.ml
+++ b/backend/reloadgen.ml
@@ -67,7 +67,7 @@ method reload_operation op arg res =
       begin match arg.(0), res.(0) with
         {loc = Stack s1}, {loc = Stack s2} ->
           if s1 = s2
-          && Proc.stack_slot_class arg.(0).typ = Proc.stack_slot_class res.(0).typ then
+          && Stack_class.Tbl.equal_machtype arg.(0) res.(0) then
             (* nothing will be emitted later,
                not necessary to apply constraints *)
             (arg, res)
@@ -145,7 +145,7 @@ method private reload i k =
             k (instr_cons_debug (Itrywith(body, kind, (ts, handler)))
                  [||] [||] i.dbg next))))
 
-method fundecl f num_stack_slots =
+method fundecl f ~num_stack_slots =
   redo_regalloc <- false;
   let new_body = self#reload f.fun_body Fun.id in
   ({fun_name = f.fun_name; fun_args = f.fun_args;
@@ -153,7 +153,7 @@ method fundecl f num_stack_slots =
     fun_dbg  = f.fun_dbg;
     fun_poll = f.fun_poll;
     fun_contains_calls = f.fun_contains_calls;
-    fun_num_stack_slots = Array.copy num_stack_slots;
+    fun_num_stack_slots = Stack_class.Tbl.copy num_stack_slots;
    },
    redo_regalloc)
 end

--- a/backend/reloadgen.mli
+++ b/backend/reloadgen.mli
@@ -22,6 +22,6 @@ class reload_generic : object
   method makereg : Reg.t -> Reg.t
     (* Can be overridden to avoid creating new registers of some class
        (i.e. if all "registers" of that class are actually on stack) *)
-  method fundecl : Mach.fundecl -> int array -> Mach.fundecl * bool
+  method fundecl : Mach.fundecl -> num_stack_slots:int Stack_class.Tbl.t -> Mach.fundecl * bool
     (* The entry point *)
 end

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1795,7 +1795,7 @@ method emit_fundecl ~future_funcnames f =
     fun_codegen_options = f.Cmm.fun_codegen_options;
     fun_dbg  = f.Cmm.fun_dbg;
     fun_poll = f.Cmm.fun_poll;
-    fun_num_stack_slots = Array.make Proc.num_stack_slot_classes 0;
+    fun_num_stack_slots = Stack_class.Tbl.make 0;
     fun_contains_calls = !contains_calls;
   }
 

--- a/backend/stack_class.mli
+++ b/backend/stack_class.mli
@@ -1,0 +1,7 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+include Stack_class_utils.T
+
+module Tbl : Stack_class_utils.Tbl with type stack_class = t
+
+val offset_in_bytes : int Tbl.t -> stack_class:t -> slot:int -> int

--- a/backend/stack_class_utils.ml
+++ b/backend/stack_class_utils.ml
@@ -1,0 +1,127 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+module List = ListLabels
+
+module type T = sig
+  type t
+
+  val all : t list
+
+  val equal : t -> t -> bool
+
+  val hash : t -> int
+
+  val tag : t -> string
+
+  val print : Format.formatter -> t -> unit
+
+  val size_in_bytes : t -> int
+
+  val of_machtype : Cmm.machtype_component -> t
+end
+
+module type Tbl = sig
+  type stack_class
+
+  type 'a t
+
+  val make : 'a -> 'a t
+
+  val init : f:(stack_class -> 'a) -> 'a t
+
+  val copy : 'a t -> 'a t
+
+  val copy_values : from:'a t -> to_:'a t -> unit
+
+  val find : 'a t -> stack_class -> 'a
+
+  val replace : 'a t -> stack_class -> 'a -> unit
+
+  val update : 'a t -> stack_class -> f:('a -> 'a) -> unit
+
+  val iter : 'a t -> f:(stack_class -> 'a -> unit) -> unit
+
+  val fold : 'a t -> f:(stack_class -> 'a -> 'b -> 'b) -> init:'b -> 'b
+
+  val exists : 'a t -> f:(stack_class -> 'a -> bool) -> bool
+
+  val total_size_in_bytes_for_class : int t -> stack_class:stack_class -> int
+
+  val total_size_in_bytes : int t -> int
+
+  val total_size_in_slots : int t -> int
+
+  val equal_machtype : Reg.t -> Reg.t -> bool
+end
+
+module Make_tbl (SC : T) : Tbl with type stack_class = SC.t = struct
+  module Tbl = Hashtbl.Make (SC)
+
+  type stack_class = SC.t
+
+  type 'a t = 'a Tbl.t
+
+  let init : f:(stack_class -> 'a) -> 'a t =
+   fun ~f ->
+    let res = Tbl.create (List.length SC.all) in
+    List.iter SC.all ~f:(fun stack_class ->
+        Tbl.replace res stack_class (f stack_class));
+    res
+
+  let make : 'a -> 'a t = fun x -> init ~f:(fun _stack_class -> x)
+
+  let copy : 'a t -> 'a t = fun tbl -> Tbl.copy tbl
+
+  let copy_values : from:'a t -> to_:'a t -> unit =
+   fun ~from ~to_ ->
+    assert (Tbl.length from = Tbl.length to_);
+    List.iter SC.all ~f:(fun stack_class ->
+        Tbl.replace to_ stack_class (Tbl.find from stack_class))
+
+  let find : 'a t -> stack_class -> 'a =
+   fun tbl stack_class ->
+    match Tbl.find_opt tbl stack_class with
+    | None ->
+      Misc.fatal_errorf "stack class %a missing from table" SC.print stack_class
+    | Some x -> x
+
+  let replace : 'a t -> stack_class -> 'a -> unit =
+   fun tbl stack_class x -> Tbl.replace tbl stack_class x
+
+  let update : 'a t -> stack_class -> f:('a -> 'a) -> unit =
+   fun tbl stack_class ~f ->
+    let curr = find tbl stack_class in
+    replace tbl stack_class (f curr)
+
+  let iter : 'a t -> f:(stack_class -> 'a -> unit) -> unit =
+   fun tbl ~f -> Tbl.iter f tbl
+
+  let fold : 'a t -> f:(stack_class -> 'a -> 'b -> 'b) -> init:'b -> 'b =
+   fun tbl ~f ~init -> Tbl.fold f tbl init
+
+  exception Found
+
+  let exists : 'a t -> f:(stack_class -> 'a -> bool) -> bool =
+   fun tbl ~f ->
+    try
+      Tbl.iter (fun stack_class v -> if f stack_class v then raise Found) tbl;
+      false
+    with Found -> true
+
+  let total_size_in_bytes_for_class :
+      int Tbl.t -> stack_class:stack_class -> int =
+   fun tbl ~stack_class ->
+    let num = Tbl.find tbl stack_class in
+    num * SC.size_in_bytes stack_class
+
+  let total_size_in_bytes : int Tbl.t -> int =
+   fun tbl ->
+    List.fold_left SC.all ~init:0 ~f:(fun acc stack_class ->
+        acc + total_size_in_bytes_for_class tbl ~stack_class)
+
+  let total_size_in_slots : int Tbl.t -> int =
+    fun tbl -> fold tbl ~init:0 ~f:(fun _stack_class num acc -> num + acc)
+
+  let equal_machtype : Reg.t -> Reg.t -> bool = fun left right ->
+    SC.equal (SC.of_machtype left.typ) (SC.of_machtype right.typ)
+end

--- a/backend/stack_class_utils.mli
+++ b/backend/stack_class_utils.mli
@@ -1,0 +1,67 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+(** Definition of stack classes for a given backend.
+
+    The number of stack slot classes may differ from the number of register classes.
+    On x86, we use the same register class for floating point and SIMD vector registers,
+    but they take up different amounts of space on the stack. *)
+module type T = sig
+  (** The "enum" representing the different classes. *)
+  type t
+
+  (** The list of all classes. *)
+  val all : t list
+
+  val equal : t -> t -> bool
+
+  val hash : t -> int
+
+  val tag : t -> string
+
+  val print : Format.formatter -> t -> unit
+
+  val size_in_bytes : t -> int
+
+  val of_machtype : Cmm.machtype_component -> t
+end
+
+(** Definition of tables with register classes as keys. All registers classes
+    are always bound. *)
+module type Tbl = sig
+  type stack_class
+
+  type 'a t
+
+  (** Creates a table with all register classes set to the passed value. *)
+  val make : 'a -> 'a t
+
+  (** Creates a table by calling [f] on each and every register class to
+      get the initial value for that class. *)
+  val init : f:(stack_class -> 'a) -> 'a t
+
+  val copy : 'a t -> 'a t
+
+  val copy_values : from:'a t -> to_:'a t -> unit
+
+  val find : 'a t -> stack_class -> 'a
+
+  val replace : 'a t -> stack_class -> 'a -> unit
+
+  val update : 'a t -> stack_class -> f:('a -> 'a) -> unit
+
+  val iter : 'a t -> f:(stack_class -> 'a -> unit) -> unit
+
+  val fold : 'a t -> f:(stack_class -> 'a -> 'b -> 'b) -> init:'b -> 'b
+
+  val exists : 'a t -> f:(stack_class -> 'a -> bool) -> bool
+
+  val total_size_in_bytes_for_class : int t -> stack_class:stack_class -> int
+
+  val total_size_in_bytes : int t -> int
+
+  val total_size_in_slots : int t -> int
+
+  val equal_machtype : Reg.t -> Reg.t -> bool
+end
+
+module Make_tbl (SC : T) : Tbl with type stack_class = SC.t

--- a/dune
+++ b/dune
@@ -133,6 +133,8 @@
   selection
   spill
   split
+  stack_class
+  stack_class_utils
   string_table
   symbol_entry
   symbol_table

--- a/ocaml/utils/config.common.ml
+++ b/ocaml/utils/config.common.ml
@@ -51,8 +51,8 @@ and ast_intf_magic_number = "Caml1999N033"
 and cmxs_magic_number = "Caml1999D524"
 and cmt_magic_number = "Caml1999T524"
 and cms_magic_number = "Caml1999S524"
-and linear_magic_number = "Caml1999L524"
-and cfg_magic_number = "Caml2021G524"
+and linear_magic_number = "Caml1999L525"
+and cfg_magic_number = "Caml2021G525"
 
 let safe_string = true
 let default_safe_string = true

--- a/tests/backend/regalloc_validator/check_regalloc_validation.ml
+++ b/tests/backend/regalloc_validator/check_regalloc_validation.ml
@@ -93,8 +93,8 @@ module Cfg_desc = struct
     let cfg =
       Cfg.create ~fun_name:"foo" ~fun_args:(Array.copy fun_args) ~fun_dbg:Debuginfo.none
         ~fun_codegen_options:[]
-         ~fun_contains_calls
-        ~fun_num_stack_slots:(Array.make Proc.num_stack_slot_classes 0)
+        ~fun_contains_calls
+        ~fun_num_stack_slots:(Stack_class.Tbl.make 0)
     in
     List.iter
       (fun (block : Block.t) ->
@@ -124,10 +124,12 @@ module Cfg_desc = struct
          count. *)
       let update_stack_slots i =
         let update_slot (r : Reg.t) =
-          match r.loc, Proc.stack_slot_class r.typ with
+          match r.loc, Stack_class.of_machtype r.typ with
           | Stack (Local idx), stack_class ->
-            cfg.fun_num_stack_slots.(stack_class)
-              <- max cfg.fun_num_stack_slots.(stack_class) (idx + 1)
+            Stack_class.Tbl.update
+              cfg.fun_num_stack_slots
+              stack_class
+              ~f:(fun curr -> max curr (idx + 1))
           | _ -> ()
         in
         Array.iter update_slot i.arg;


### PR DESCRIPTION
This pull request refactors the handling of
stack classes. Since the introduction of
vector types (#1499), we distinguish
between register and stack classes.

Having both encoded as mere ints is
error-prone, so this pull request introduces
a proper and abstract type for stack
classes (a similar refactoring will be
performed on register classes, but it is
slightly more complex).

This pull request introduces the following
modules:

- `Stack_class_utils` which defines what
  stack classes and tables with stack classes
  as keys are;
- `Stack_class` which defines backend-dependent
  stack classes.

As of 23c812461b7d1293b267ffe18b452ebe74cd6cca, tables are implemented
as hash tables instead of arrays. If this causes
a performance or marshalling issue, it is
easy to use a bare array as the underlying
representation of the table.
