### PR TITLE
Disable split preprocessing in flambda2 classic mode

### DIFF
--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -231,6 +231,7 @@ let prelude :
   if Utils.debug
   then Utils.log ~indent:0 "#temporaries(before):%d" num_temporaries;
   if num_temporaries >= threshold_split_live_ranges
+     || Flambda2_ui.Flambda_features.classic_mode ()
   then cfg_infos, Regalloc_stack_slots.make ()
   else if Lazy.force Regalloc_split_utils.split_live_ranges
   then

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -456,7 +456,8 @@ let split_live_ranges : Cfg_with_infos.t -> cfg_infos -> Regalloc_stack_slots.t
   | true, false -> fatal "Regalloc_split: flambda is currently not supported"
   | false, true ->
     (* note: classic mode is not properly supported, but is used in the
-       "tests/backend/frame-too-long" tests. *)
+       "tests/backend/frame-too-long" tests. We now implicitly disable split (in
+       `Regalloc_rewrite.prelude`) if classic mode is enabled. *)
     (* if Flambda2_ui.Flambda_features.classic_mode () then fatal
        "Regalloc_split: classic mode is currently not supported" *)
     ()


### PR DESCRIPTION
(As per title.)