### PR TITLE
Small improvement to layout inference for mutually recursive type decl parameters

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -327,3 +327,10 @@ and t2 = Mk1 of t_void t | Mk2
 type ('b : void) t = 'b void_t * t2
 and t2 = Mk1 of t_void t | Mk2
 |}]
+
+type 'a t8_5 = { x : 'a t8_6; y : string}
+and 'a t8_6 = 'a void_t;;
+[%%expect {|
+type ('a : void) t8_5 = { x : 'a t8_6; y : string; }
+and ('a : void) t8_6 = 'a void_t
+|}]

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1499,6 +1499,8 @@ let transl_type_decl env rec_flag sdecl_list =
         raise (Error (loc, Type_clash (new_env, err))))
       checks)
     delayed_layout_checks;
+  (* Check that constraints are enforced *)
+  List.iter2 (check_constraints new_env) sdecl_list decls;
   (* Check that all type variables are closed; this also defaults any remaining
      sort variables. Defaulting must happen before update_decls_layout,
      Typedecl_seperability.update_decls, and add_types_to_env, all of which need
@@ -1512,8 +1514,6 @@ let transl_type_decl env rec_flag sdecl_list =
          Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
        | None   -> ())
     sdecl_list tdecls;
-  (* Check that constraints are enforced *)
-  List.iter2 (check_constraints new_env) sdecl_list decls;
   (* Add type properties to declarations *)
   let decls =
     try


### PR DESCRIPTION
This PR allows the following definition, which is otherwise unnecessarily rejected:

```ocaml
type ('a : void) t_void_id = 'a

type 'a t = { x : 'a s; y : string }
and 'a s = 'a t_void_id
```

It's currently rejected because we default sort variables in type declarations to `value` before checking constraints, which then fails because `t`'s parameter should be `void` to satisfy the constraints imposed by `s`.  The fix is just to swap the order of defaulting and checking constraints, so that we check constraints first, which result in inferring `void` for `t`'s parameter.

I don't see any reason we should need to default sort variables before checking constraints.

(Obviously we don't particularly care about void.  In reality I observed this while writing tests for all-unboxed-float records.)