### PR TITLE
Regulate access to [Language_extension] from within Jane Syntax

### DIFF
--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -13,6 +13,8 @@ module Language_extension = struct
     : Language_extension_kernel.Language_extension_for_jane_syntax)
 end
 
+(* Suppress the unused module warning so it's easy to keep around the
+   shadowing even if we delete use sites of the module. *)
 module _ = Language_extension
 
 (****************************************)


### PR DESCRIPTION
Along the same lines as #1509: avoid accessing non-exported constructors from `Language_extension_kernel`. The need for this PR was flagged during the import process into `ppxlib_jane`.

**Reviewer:** @antalsz 