### PR TITLE
All-`float#` records

### DIFF
--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -219,7 +219,7 @@ let rec expr_size env = function
       assert false
   | Uprim (Pduprecord (Record_inlined (_, Variant_extensible), sz), _, _) ->
       RHS_block (Lambda.alloc_heap, sz + 1)
-  | Uprim (Pduprecord (Record_float, sz), _, _) ->
+  | Uprim (Pduprecord ((Record_float | Record_ufloat), sz), _, _) ->
       RHS_floatblock (Lambda.alloc_heap, sz)
   | Uprim (Pccall { prim_name; _ }, closure::_, _)
         when prim_name = "caml_check_value_is_closure" ->

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -200,6 +200,8 @@ let rec expr_size env = function
       expr_size env body
   | Uprim(Pmakeblock (_, _, _, mode), args, _) ->
       RHS_block (mode, List.length args)
+  | Uprim(Pmakeufloatblock (_, mode), args, _) ->
+      RHS_floatblock (mode, List.length args)
   | Uprim(Pmakearray((Paddrarray | Pintarray), _, mode), args, _) ->
       RHS_block (mode, List.length args)
   | Uprim(Pmakearray(Pfloatarray, _, mode), args, _) ->

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -617,10 +617,13 @@ let rec transl env e =
       begin match (simplif_primitive prim, args) with
       | (Pread_symbol sym, []) ->
           Cconst_symbol (global_symbol sym, dbg)
-      | (Pmakeblock _, []) ->
+      | ((Pmakeblock _ | Pmakeufloatblock _), []) ->
           assert false
       | (Pmakeblock(tag, _mut, _kind, mode), args) ->
           make_alloc ~mode dbg tag (List.map (transl env) args)
+      | (Pmakeufloatblock(_mut, mode), args) ->
+          make_float_alloc ~mode dbg Obj.double_array_tag
+            (List.map (transl env) args)
       | (Pccall prim, args) ->
           transl_ccall env prim args dbg
       | (Pduparray (kind, _), [Uprim (Pmakearray (kind', _, _), args, _dbg)]) ->
@@ -712,6 +715,7 @@ let rec transl env e =
          | Pbswap16 | Pint_as_pointer _ | Popaque | Pfield _
          | Psetfield (_, _, _) | Psetfield_computed (_, _)
          | Pfloatfield _ | Psetfloatfield (_, _) | Pduprecord (_, _)
+         | Pufloatfield _ | Psetufloatfield (_, _)
          | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _ | Poffsetint _
          | Pcompare_ints | Pcompare_floats | Pcompare_bints _
          | Poffsetref _ | Pfloatcomp _ | Parraylength _
@@ -976,6 +980,8 @@ and transl_prim_1 env p arg dbg =
   | Pfloatfield (n,mode) ->
       let ptr = transl env arg in
       box_float dbg mode (floatfield n ptr dbg)
+  | Pufloatfield n ->
+      get_field env Punboxed_float (transl env arg) n dbg
   | Pint_as_pointer _ ->
       int_as_pointer (transl env arg) dbg
   (* Exceptions *)
@@ -1046,6 +1052,7 @@ and transl_prim_1 env p arg dbg =
     | Pbytesrefs | Pbytessets | Pisout | Pread_symbol _
     | Pmakeblock (_, _, _, _) | Psetfield (_, _, _) | Psetfield_computed (_, _)
     | Psetfloatfield (_, _) | Pduprecord (_, _) | Pccall _ | Pdivint _
+    | Pmakeufloatblock (_, _) | Psetufloatfield (_, _)
     | Pmodint _ | Pintcomp _ | Pfloatcomp _ | Pmakearray (_, _, _)
     | Pcompare_ints | Pcompare_floats | Pcompare_bints _
     | Pduparray (_, _) | Parrayrefu _ | Parraysetu _
@@ -1070,7 +1077,10 @@ and transl_prim_2 env p arg1 arg2 dbg =
       let ptr = transl env arg1 in
       let float_val = transl_unbox_float dbg env arg2 in
       setfloatfield n init ptr float_val dbg
-
+  | Psetufloatfield (n, init) ->
+      let ptr = transl env arg1 in
+      let float_val = transl env arg2 in
+      setfloatfield n init ptr float_val dbg
   (* Boolean operations *)
   | Psequand ->
       let dbg' = Debuginfo.none in
@@ -1226,7 +1236,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   | Pabsfloat _ | Pstringlength | Pbyteslength | Pbytessetu | Pbytessets
   | Pisint | Pbswap16 | Pint_as_pointer _ | Popaque | Pread_symbol _
   | Pmakeblock (_, _, _, _) | Pfield _ | Psetfield_computed (_, _)
-  | Pfloatfield _
+  | Pmakeufloatblock (_, _) | Pfloatfield _ | Pufloatfield _
   | Pduprecord (_, _) | Pccall _ | Praise _ | Poffsetint _ | Poffsetref _
   | Pmakearray (_, _, _) | Pduparray (_, _) | Parraylength _ | Parraysetu _
   | Parraysets _ | Pbintofint _ | Pintofbint _ | Pcvtbint (_, _, _)
@@ -1284,6 +1294,7 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
   | Pbswap16 | Pint_as_pointer _ | Popaque | Pread_symbol _
   | Pmakeblock (_, _, _, _)
   | Pfield _ | Psetfield (_, _, _) | Pfloatfield _ | Psetfloatfield (_, _)
+  | Pmakeufloatblock (_, _) | Pufloatfield _ | Psetufloatfield (_, _)
   | Pduprecord (_, _) | Pccall _ | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _
   | Pcompare_ints | Pcompare_floats | Pcompare_bints _
   | Poffsetint _ | Poffsetref _ | Pfloatcomp _ | Pmakearray (_, _, _)

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -216,4 +216,22 @@ let result_layout (p : primitive) =
   | Pccall {prim_native_repr_res = (_, repr_res); _} ->
     Lambda.layout_of_native_repr repr_res
   | Pufloatfield _ -> Lambda.Punboxed_float
-  | _ -> Lambda.layout_any_value
+  | Pread_symbol _ | Pmakeblock _ | Pmakeufloatblock _ | Pfield _
+  | Pfield_computed | Psetfield _ | Psetfield_computed _ | Pfloatfield _
+  | Psetfloatfield _ | Psetufloatfield _ | Pduprecord _ | Praise _
+  | Psequand | Psequor | Pnot | Pnegint | Paddint | Psubint | Pmulint
+  | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
+  | Pasrint | Pintcomp _ | Pcompare_ints | Pcompare_floats | Pcompare_bints _
+  | Poffsetint _ | Poffsetref _ | Pintoffloat | Pfloatofint _ | Pnegfloat _
+  | Pabsfloat _ | Paddfloat _ | Psubfloat _ | Pmulfloat _ | Pdivfloat _
+  | Pfloatcomp _ | Pstringlength | Pstringrefu  | Pstringrefs
+  | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
+  | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
+  | Parrayrefs _ | Parraysets _ | Pisint | Pisout | Pbintofint _ | Pintofbint _
+  | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _
+  | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
+  | Pasrbint _ | Pbintcomp _ | Pbigarrayref _ | Pbigarrayset _ | Pbigarraydim _
+  | Pstring_load _ | Pbytes_load _ | Pbytes_set _ | Pbigstring_load _
+  | Pbigstring_set _ | Pbswap16 | Pbbswap _ | Pint_as_pointer _ | Popaque
+  | Pprobe_is_enabled _ | Pbox_float _ | Pbox_int _ | Pget_header _
+    -> Lambda.layout_any_value

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -38,12 +38,15 @@ type primitive =
   | Pread_symbol of string
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
+  | Pmakeufloatblock of mutable_flag * alloc_mode
   | Pfield of int * layout
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * alloc_mode
   | Psetfloatfield of int * initialization_or_assignment
+  | Pufloatfield of int
+  | Psetufloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* External call *)
   | Pccall of Primitive.description
@@ -212,4 +215,5 @@ let result_layout (p : primitive) =
   | Punbox_int bi -> Lambda.Punboxed_int bi
   | Pccall {prim_native_repr_res = (_, repr_res); _} ->
     Lambda.layout_of_native_repr repr_res
+  | Pufloatfield _ -> Lambda.Punboxed_float
   | _ -> Lambda.layout_any_value

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -38,12 +38,15 @@ type primitive =
   | Pread_symbol of string
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
+  | Pmakeufloatblock of mutable_flag * alloc_mode
   | Pfield of int * layout
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * alloc_mode
   | Psetfloatfield of int * initialization_or_assignment
+  | Pufloatfield of int
+  | Psetufloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* External call *)
   | Pccall of Primitive.description

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -28,6 +28,8 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       Pmakeblock (tag, mutability, shape, mode)
   | Pmakefloatblock (mutability, mode) ->
       Pmakearray (Pfloatarray, mutability, mode)
+  | Pmakeufloatblock (mutability, mode) ->
+      Pmakeufloatblock (mutability, mode)
   | Pfield (field, _sem) -> Pfield (field, Pvalue Pgenval)
   | Pfield_computed _sem -> Pfield_computed
   | Psetfield (field, imm_or_pointer, init_or_assign) ->
@@ -37,6 +39,9 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pfloatfield (field, _sem, mode) -> Pfloatfield (field, mode)
   | Psetfloatfield (field, init_or_assign) ->
       Psetfloatfield (field, init_or_assign)
+  | Pufloatfield (field, _sem) -> Pufloatfield field
+  | Psetufloatfield (field, init_or_assign) ->
+      Psetufloatfield (field, init_or_assign)
   | Pduprecord (repr, size) -> Pduprecord (repr, size)
   | Pccall prim -> Pccall prim
   | Praise kind -> Praise kind

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -713,7 +713,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Some exn_continuation -> exn_continuation
     in
     close_raise0 acc env ~raise_kind ~arg ~dbg exn_continuation
-  | (Pmakeblock _ | Pmakefloatblock _ | Pmakearray _), [] ->
+  | (Pmakeblock _ | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakearray _),
+    [] ->
     (* Special case for liftable empty block or array *)
     let acc, sym =
       match prim with
@@ -729,12 +730,15 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
             "empty_block"
       | Pmakefloatblock _ ->
         Misc.fatal_error "Unexpected empty float block in [Closure_conversion]"
+      | Pmakeufloatblock _ ->
+        Misc.fatal_error "Unexpected empty float# block in [Closure_conversion]"
       | Pmakearray (_, _, _mode) ->
         register_const0 acc Static_const.empty_array "empty_array"
       | Pbytes_to_string | Pbytes_of_string | Parray_of_iarray
       | Parray_to_iarray | Pignore | Pgetglobal _ | Psetglobal _ | Pgetpredef _
       | Pfield _ | Pfield_computed _ | Psetfield _ | Psetfield_computed _
       | Pfloatfield _ | Psetfloatfield _ | Pduprecord _ | Pccall _ | Praise _
+      | Pufloatfield _ | Psetufloatfield _
       | Psequand | Psequor | Pnot | Pnegint | Paddint | Psubint | Pmulint
       | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
       | Pasrint | Pintcomp _ | Pcompare_ints | Pcompare_floats

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -713,8 +713,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Some exn_continuation -> exn_continuation
     in
     close_raise0 acc env ~raise_kind ~arg ~dbg exn_continuation
-  | (Pmakeblock _ | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakearray _),
-    [] ->
+  | (Pmakeblock _ | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakearray _), []
+    ->
     (* Special case for liftable empty block or array *)
     let acc, sym =
       match prim with
@@ -738,28 +738,27 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Parray_to_iarray | Pignore | Pgetglobal _ | Psetglobal _ | Pgetpredef _
       | Pfield _ | Pfield_computed _ | Psetfield _ | Psetfield_computed _
       | Pfloatfield _ | Psetfloatfield _ | Pduprecord _ | Pccall _ | Praise _
-      | Pufloatfield _ | Psetufloatfield _
-      | Psequand | Psequor | Pnot | Pnegint | Paddint | Psubint | Pmulint
-      | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
-      | Pasrint | Pintcomp _ | Pcompare_ints | Pcompare_floats
-      | Pcompare_bints _ | Poffsetint _ | Poffsetref _ | Pintoffloat
-      | Pfloatofint _ | Pnegfloat _ | Pabsfloat _ | Paddfloat _ | Psubfloat _
-      | Pmulfloat _ | Pdivfloat _ | Pfloatcomp _ | Pstringlength | Pstringrefu
-      | Pstringrefs | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs
-      | Pbytessets | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
-      | Parrayrefs _ | Parraysets _ | Pisint _ | Pisout | Pbintofint _
-      | Pintofbint _ | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _
-      | Pmulbint _ | Pdivbint _ | Pmodbint _ | Pandbint _ | Porbint _
-      | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _ | Pbintcomp _
-      | Pbigarrayref _ | Pbigarrayset _ | Pbigarraydim _ | Pstring_load_16 _
-      | Pstring_load_32 _ | Pstring_load_64 _ | Pbytes_load_16 _
-      | Pbytes_load_32 _ | Pbytes_load_64 _ | Pbytes_set_16 _ | Pbytes_set_32 _
-      | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
-      | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
-      | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _
-      | Pint_as_pointer _ | Popaque _ | Pprobe_is_enabled _ | Pobj_dup
-      | Pobj_magic _ | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
-      | Pget_header _ ->
+      | Pufloatfield _ | Psetufloatfield _ | Psequand | Psequor | Pnot | Pnegint
+      | Paddint | Psubint | Pmulint | Pdivint _ | Pmodint _ | Pandint | Porint
+      | Pxorint | Plslint | Plsrint | Pasrint | Pintcomp _ | Pcompare_ints
+      | Pcompare_floats | Pcompare_bints _ | Poffsetint _ | Poffsetref _
+      | Pintoffloat | Pfloatofint _ | Pnegfloat _ | Pabsfloat _ | Paddfloat _
+      | Psubfloat _ | Pmulfloat _ | Pdivfloat _ | Pfloatcomp _ | Pstringlength
+      | Pstringrefu | Pstringrefs | Pbyteslength | Pbytesrefu | Pbytessetu
+      | Pbytesrefs | Pbytessets | Pduparray _ | Parraylength _ | Parrayrefu _
+      | Parraysetu _ | Parrayrefs _ | Parraysets _ | Pisint _ | Pisout
+      | Pbintofint _ | Pintofbint _ | Pcvtbint _ | Pnegbint _ | Paddbint _
+      | Psubbint _ | Pmulbint _ | Pdivbint _ | Pmodbint _ | Pandbint _
+      | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _
+      | Pbintcomp _ | Pbigarrayref _ | Pbigarrayset _ | Pbigarraydim _
+      | Pstring_load_16 _ | Pstring_load_32 _ | Pstring_load_64 _
+      | Pbytes_load_16 _ | Pbytes_load_32 _ | Pbytes_load_64 _ | Pbytes_set_16 _
+      | Pbytes_set_32 _ | Pbytes_set_64 _ | Pbigstring_load_16 _
+      | Pbigstring_load_32 _ | Pbigstring_load_64 _ | Pbigstring_set_16 _
+      | Pbigstring_set_32 _ | Pbigstring_set_64 _ | Pctconst _ | Pbswap16
+      | Pbbswap _ | Pint_as_pointer _ | Popaque _ | Pprobe_is_enabled _
+      | Pobj_dup | Pobj_magic _ | Punbox_float | Pbox_float _ | Punbox_int _
+      | Pbox_int _ | Pget_header _ ->
         (* Inconsistent with outer match *)
         assert false
     in

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -285,7 +285,8 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
         build_block cl size (Normal runtime_tag) arg letrec
       | Record_inlined (Extension _, Variant_extensible) ->
         build_block cl (size + 1) (Normal 0) arg letrec
-      | Record_float -> build_block cl size Boxed_float arg letrec
+      | Record_float | Record_ufloat ->
+        build_block cl size Boxed_float arg letrec
       | Record_inlined (Extension _, _)
       | Record_inlined (Ordinary _, (Variant_unboxed | Variant_extensible))
       | Record_unboxed ->

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -121,7 +121,7 @@ end
 type block_type =
   | Normal of int
   (* tag *)
-  | Boxed_float
+  | Flat_float_record
 
 type block =
   { block_type : block_type;
@@ -269,7 +269,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
   | Lprim (Pmakefloatblock (_, mode), args, _) -> (
     assert_not_local ~lam mode;
     match current_let with
-    | Some cl -> build_block cl (List.length args) Boxed_float lam letrec
+    | Some cl -> build_block cl (List.length args) Flat_float_record lam letrec
     | None -> dead_code lam letrec)
   | Lprim (Pduprecord (kind, size), args, _) -> (
     match current_let with
@@ -286,7 +286,7 @@ let rec prepare_letrec (recursive_set : Ident.Set.t)
       | Record_inlined (Extension _, Variant_extensible) ->
         build_block cl (size + 1) (Normal 0) arg letrec
       | Record_float | Record_ufloat ->
-        build_block cl size Boxed_float arg letrec
+        build_block cl size Flat_float_record arg letrec
       | Record_inlined (Extension _, _)
       | Record_inlined (Ordinary _, (Variant_unboxed | Variant_extensible))
       | Record_unboxed ->
@@ -569,7 +569,7 @@ let dissect_letrec ~bindings ~body ~free_vars_kind =
         let fn =
           match block_type with
           | Normal _tag -> "caml_alloc_dummy"
-          | Boxed_float -> "caml_alloc_dummy_float"
+          | Flat_float_record -> "caml_alloc_dummy_float"
         in
         let desc = Primitive.simple_on_values ~name:fn ~arity:1 ~alloc:true in
         let size : lambda = Lconst (Const_base (Const_int size)) in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -958,16 +958,16 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pignore | Pgetglobal _ | Psetglobal _ | Pgetpredef _ | Pmakeblock _
   | Pmakefloatblock _ | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
-  | Pmakeufloatblock _ | Pufloatfield _ | Psetufloatfield _
-  | Psequand | Psequor | Pnot | Pnegint | Paddint | Psubint | Pmulint | Pandint
-  | Porint | Pxorint | Plslint | Plsrint | Pasrint | Pintcomp _ | Pcompare_ints
-  | Pcompare_floats | Pcompare_bints _ | Poffsetint _ | Poffsetref _
-  | Pintoffloat | Pfloatofint _ | Pnegfloat _ | Pabsfloat _ | Paddfloat _
-  | Psubfloat _ | Pmulfloat _ | Pdivfloat _ | Pfloatcomp _ | Pstringlength
-  | Pstringrefu | Pbyteslength | Pbytesrefu | Pbytessetu | Pmakearray _
-  | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint _
-  | Pisout | Pbintofint _ | Pintofbint _ | Pcvtbint _ | Pnegbint _ | Paddbint _
-  | Psubbint _ | Pmulbint _
+  | Pmakeufloatblock _ | Pufloatfield _ | Psetufloatfield _ | Psequand | Psequor
+  | Pnot | Pnegint | Paddint | Psubint | Pmulint | Pandint | Porint | Pxorint
+  | Plslint | Plsrint | Pasrint | Pintcomp _ | Pcompare_ints | Pcompare_floats
+  | Pcompare_bints _ | Poffsetint _ | Poffsetref _ | Pintoffloat | Pfloatofint _
+  | Pnegfloat _ | Pabsfloat _ | Paddfloat _ | Psubfloat _ | Pmulfloat _
+  | Pdivfloat _ | Pfloatcomp _ | Pstringlength | Pstringrefu | Pbyteslength
+  | Pbytesrefu | Pbytessetu | Pmakearray _ | Pduparray _ | Parraylength _
+  | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisout | Pbintofint _
+  | Pintofbint _ | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _
+  | Pmulbint _
   | Pdivbint { is_safe = Unsafe; _ }
   | Pmodbint { is_safe = Unsafe; _ }
   | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -958,6 +958,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pignore | Pgetglobal _ | Psetglobal _ | Pgetpredef _ | Pmakeblock _
   | Pmakefloatblock _ | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
+  | Pmakeufloatblock _ | Pufloatfield _ | Psetufloatfield _
   | Psequand | Psequor | Pnot | Pnegint | Paddint | Psubint | Pmulint | Pandint
   | Porint | Pxorint | Plslint | Plsrint | Pasrint | Pintcomp _ | Pcompare_ints
   | Pcompare_floats | Pcompare_bints _ | Poffsetint _ | Poffsetref _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -674,9 +674,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     let args = List.flatten args in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
     let mutability = Mutability.from_lambda mutability in
-    [ Variadic
-        (Make_block (Naked_floats, mutability, mode), args)
-    ]
+    [Variadic (Make_block (Naked_floats, mutability, mode), args)]
   | Pmakearray (array_kind, mutability, mode), _ -> (
     let args = List.flatten args in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
@@ -1014,7 +1012,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     let block_access : P.Block_access_kind.t =
       Naked_floats { size = Unknown }
     in
-    [ Binary (Block_load (block_access, mutability), arg, Simple field) ]
+    [Binary (Block_load (block_access, mutability), arg, Simple field)]
   | ( Psetfield (index, immediate_or_pointer, initialization_or_assignment),
       [[block]; [value]] ) ->
     let field_kind = convert_block_access_field_kind immediate_or_pointer in
@@ -1050,10 +1048,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     in
     let init_or_assign = convert_init_or_assign initialization_or_assignment in
     [ Ternary
-        ( Block_set (block_access, init_or_assign),
-          block,
-          Simple field,
-          value ) ]
+        (Block_set (block_access, init_or_assign), block, Simple field, value)
+    ]
   | Pdivint Unsafe, [[arg1]; [arg2]] ->
     [Binary (Int_arith (I.Tagged_immediate, Div), arg1, arg2)]
   | Pdivint Safe, [[arg1]; [arg2]] ->
@@ -1327,8 +1323,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Pbytes_load_32 _ | Pbytes_load_64 _ | Pisout | Paddbint _ | Psubbint _
       | Pmulbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _
       | Plsrbint _ | Pasrbint _ | Pfield_computed _ | Pdivbint _ | Pmodbint _
-      | Psetfloatfield _ | Psetufloatfield _ | Pbintcomp _ | Pbigstring_load_16 _
-      | Pbigstring_load_32 _ | Pbigstring_load_64 _
+      | Psetfloatfield _ | Psetufloatfield _ | Pbintcomp _
+      | Pbigstring_load_16 _ | Pbigstring_load_32 _ | Pbigstring_load_64 _
       | Parrayrefu
           (Pgenarray_ref _ | Paddrarray_ref | Pintarray_ref | Pfloatarray_ref _)
       | Parrayrefs

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -670,6 +670,13 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [ Variadic
         (Make_block (Naked_floats, mutability, mode), List.map unbox_float args)
     ]
+  | Pmakeufloatblock (mutability, mode), _ ->
+    let args = List.flatten args in
+    let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
+    let mutability = Mutability.from_lambda mutability in
+    [ Variadic
+        (Make_block (Naked_floats, mutability, mode), args)
+    ]
   | Pmakearray (array_kind, mutability, mode), _ -> (
     let args = List.flatten args in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
@@ -714,7 +721,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           { tag = Tag.Scannable.zero;
             length = Targetint_31_63.of_int num_fields
           }
-      | Record_float ->
+      | Record_float | Record_ufloat ->
         Naked_floats { length = Targetint_31_63.of_int num_fields }
       | Record_inlined (Ordinary { runtime_tag; _ }, Variant_boxed _) ->
         Values
@@ -999,6 +1006,15 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [ box_float mode
         (Binary (Block_load (block_access, mutability), arg, Simple field))
         ~current_region ]
+  | Pufloatfield (field, sem), [[arg]] ->
+    let imm = Targetint_31_63.of_int field in
+    check_non_negative_imm imm "Pufloatfield";
+    let field = Simple.const (Reg_width_const.tagged_immediate imm) in
+    let mutability = convert_field_read_semantics sem in
+    let block_access : P.Block_access_kind.t =
+      Naked_floats { size = Unknown }
+    in
+    [ Binary (Block_load (block_access, mutability), arg, Simple field) ]
   | ( Psetfield (index, immediate_or_pointer, initialization_or_assignment),
       [[block]; [value]] ) ->
     let field_kind = convert_block_access_field_kind immediate_or_pointer in
@@ -1025,6 +1041,19 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           block,
           Simple field,
           unbox_float value ) ]
+  | Psetufloatfield (field, initialization_or_assignment), [[block]; [value]] ->
+    let imm = Targetint_31_63.of_int field in
+    check_non_negative_imm imm "Psetufloatfield";
+    let field = Simple.const (Reg_width_const.tagged_immediate imm) in
+    let block_access : P.Block_access_kind.t =
+      Naked_floats { size = Unknown }
+    in
+    let init_or_assign = convert_init_or_assign initialization_or_assignment in
+    [ Ternary
+        ( Block_set (block_access, init_or_assign),
+          block,
+          Simple field,
+          value ) ]
   | Pdivint Unsafe, [[arg1]; [arg2]] ->
     [Binary (Int_arith (I.Tagged_immediate, Div), arg1, arg2)]
   | Pdivint Safe, [[arg1]; [arg2]] ->
@@ -1284,7 +1313,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Pduparray _ | Pfloatfield _ | Pcvtbint _ | Poffsetref _ | Pbswap16
       | Pbbswap _ | Pisint _ | Pint_as_pointer _ | Pbigarraydim _ | Pobj_dup
       | Pobj_magic _ | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
-      | Pget_header _ ),
+      | Pget_header _ | Pufloatfield _ ),
       ([] | _ :: _ :: _ | [([] | _ :: _ :: _)]) ) ->
     Misc.fatal_errorf
       "Closure_conversion.convert_primitive: Wrong arity for unary primitive \
@@ -1298,7 +1327,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Pbytes_load_32 _ | Pbytes_load_64 _ | Pisout | Paddbint _ | Psubbint _
       | Pmulbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _
       | Plsrbint _ | Pasrbint _ | Pfield_computed _ | Pdivbint _ | Pmodbint _
-      | Psetfloatfield _ | Pbintcomp _ | Pbigstring_load_16 _
+      | Psetfloatfield _ | Psetufloatfield _ | Pbintcomp _ | Pbigstring_load_16 _
       | Pbigstring_load_32 _ | Pbigstring_load_64 _
       | Parrayrefu
           (Pgenarray_ref _ | Paddrarray_ref | Pintarray_ref | Pfloatarray_ref _)

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -120,6 +120,7 @@ let pfield = "Pfield"
 let pfield_computed = "Pfield_computed"
 let pfloatcomp = "Pfloatcomp"
 let pfloatfield = "Pfloatfield"
+let pufloatfield = "Pufloatfield"
 let pfloatofint = "Pfloatofint"
 let pgetglobal = "Pgetglobal"
 let pgetpredef = "Pgetpredef"
@@ -142,6 +143,7 @@ let plsrint = "Plsrint"
 let pmakearray = "Pmakearray"
 let pmakeblock = "Pmakeblock"
 let pmakefloatblock = "Pmakefloatblock"
+let pmakeufloatblock = "Pmakeufloatblock"
 let pmodbint = "Pmodbint"
 let pmodint = "Pmodint"
 let pmulbint = "Pmulbint"
@@ -165,6 +167,7 @@ let psequor = "Psequor"
 let psetfield = "Psetfield"
 let psetfield_computed = "Psetfield_computed"
 let psetfloatfield = "Psetfloatfield"
+let psetufloatfield = "Psetufloatfield"
 let psetglobal = "Psetglobal"
 let pstring_load_16 = "Pstring_load_16"
 let pstring_load_32 = "Pstring_load_32"
@@ -227,6 +230,7 @@ let pfield_arg = "Pfield_arg"
 let pfield_computed_arg = "Pfield_computed_arg"
 let pfloatcomp_arg = "Pfloatcomp_arg"
 let pfloatfield_arg = "Pfloatfield_arg"
+let pufloatfield_arg = "Pufloatfield_arg"
 let pfloatofint_arg = "Pfloatofint_arg"
 let pgetglobal_arg = "Pgetglobal_arg"
 let pgetpredef_arg = "Pgetpredef_arg"
@@ -249,6 +253,7 @@ let plsrint_arg = "Plsrint_arg"
 let pmakearray_arg = "Pmakearray_arg"
 let pmakeblock_arg = "Pmakeblock_arg"
 let pmakefloatblock_arg = "Pmakefloatblock_arg"
+let pmakeufloatblock_arg = "Pmakeufloatblock_arg"
 let pmodbint_arg = "Pmodbint_arg"
 let pmodint_arg = "Pmodint_arg"
 let pmulbint_arg = "Pmulbint_arg"
@@ -269,6 +274,7 @@ let psequor_arg = "Psequor_arg"
 let psetfield_arg = "Psetfield_arg"
 let psetfield_computed_arg = "Psetfield_computed_arg"
 let psetfloatfield_arg = "Psetfloatfield_arg"
+let psetufloatfield_arg = "Psetufloatfield_arg"
 let psetglobal_arg = "Psetglobal_arg"
 let pstring_load_16_arg = "Pstring_load_16_arg"
 let pstring_load_32_arg = "Pstring_load_32_arg"
@@ -342,12 +348,15 @@ let of_primitive : Lambda.primitive -> string = function
   | Pgetpredef _ -> pgetpredef
   | Pmakeblock _ -> pmakeblock
   | Pmakefloatblock _ -> pmakefloatblock
+  | Pmakeufloatblock _ -> pmakeufloatblock
   | Pfield _ -> pfield
   | Pfield_computed _ -> pfield_computed
   | Psetfield _ -> psetfield
   | Psetfield_computed _ -> psetfield_computed
   | Pfloatfield _ -> pfloatfield
   | Psetfloatfield _ -> psetfloatfield
+  | Pufloatfield _ -> pufloatfield
+  | Psetufloatfield _ -> psetufloatfield
   | Pduprecord _ -> pduprecord
   | Pccall _ -> pccall
   | Praise _ -> praise
@@ -457,12 +466,15 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pgetpredef _ -> pgetpredef_arg
   | Pmakeblock _ -> pmakeblock_arg
   | Pmakefloatblock _ -> pmakefloatblock_arg
+  | Pmakeufloatblock _ -> pmakeufloatblock_arg
   | Pfield _ -> pfield_arg
   | Pfield_computed _ -> pfield_computed_arg
   | Psetfield _ -> psetfield_arg
   | Psetfield_computed _ -> psetfield_computed_arg
   | Pfloatfield _ -> pfloatfield_arg
   | Psetfloatfield _ -> psetfloatfield_arg
+  | Pufloatfield _ -> pufloatfield_arg
+  | Psetufloatfield _ -> psetufloatfield_arg
   | Pduprecord _ -> pduprecord_arg
   | Pccall _ -> pccall_arg
   | Praise _ -> praise_arg

--- a/middle_end/printclambda_primitives.ml
+++ b/middle_end/printclambda_primitives.ml
@@ -96,6 +96,18 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
       in
       let name = "make" ^ mode ^ mut in
       fprintf ppf "%s %i%a" name tag Printlambda.block_shape shape
+  | Pmakeufloatblock(mut, mode) ->
+      let mode = match mode with
+        | Alloc_heap -> ""
+        | Alloc_local -> "local"
+      in
+      let mut = match mut with
+        | Immutable -> "block"
+        | Immutable_unique -> "block_unique"
+        | Mutable -> "mutable"
+      in
+      let name = "make" ^ mode ^ "ufloat" ^ mut in
+      fprintf ppf "%s" name
   | Pfield (n, layout) -> fprintf ppf "field%a %i" Printlambda.layout layout n
   | Pfield_computed -> fprintf ppf "field_computed"
   | Psetfield(n, ptr, init) ->
@@ -128,6 +140,7 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
       fprintf ppf "setfield_%s%s_computed" instr init
   | Pfloatfield (n, Alloc_heap) -> fprintf ppf "floatfield %i" n
   | Pfloatfield (n, Alloc_local) -> fprintf ppf "floatfieldlocal %i" n
+  | Pufloatfield n -> fprintf ppf "ufloatfield %i" n
   | Psetfloatfield (n, init) ->
       let init =
         match init with
@@ -137,6 +150,15 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
         | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setfloatfield%s %i" init n
+  | Psetufloatfield (n, init) ->
+      let init =
+        match init with
+        | Heap_initialization -> "(heap-init)"
+        | Root_initialization -> "(root-init)"
+        | Assignment Modify_heap -> ""
+        | Assignment Modify_maybe_stack -> "(maybe-stack)"
+      in
+      fprintf ppf "setufloatfield%s %i" init n
   | Pduprecord (rep, size) ->
       fprintf ppf "duprecord %a %i" Printlambda.record_rep rep size
   | Pccall p -> fprintf ppf "%s" p.Primitive.prim_name

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -29,6 +29,7 @@ let coeffects_of : Lambda.alloc_mode -> coeffects = function
 let for_primitive (prim : Clambda_primitives.primitive) =
   match prim with
   | Pmakeblock (_, _, _, m)
+  | Pmakeufloatblock (_, m)
   | Pmakearray (_, Mutable, m) -> Only_generative_effects, coeffects_of m
   | Pmakearray (_, (Immutable | Immutable_unique), m) ->
      No_effects, coeffects_of m
@@ -118,6 +119,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Pfield _
   | Pfield_computed
   | Pfloatfield _
+  | Pufloatfield _
   | Parrayrefu _
   | Pstringrefu
   | Pbytesrefu
@@ -138,6 +140,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Psetfield _
   | Psetfield_computed _
   | Psetfloatfield _
+  | Psetufloatfield _
   | Parraysetu _
   | Parraysets _
   | Pbytessetu
@@ -185,6 +188,7 @@ let is_local_alloc = function
 let may_locally_allocate (prim:Clambda_primitives.primitive) : bool =
   match prim with
   | Pmakeblock (_, _, _, m)
+  | Pmakeufloatblock (_, m)
   | Pmakearray (_, _, m) -> is_local_alloc m
   | Pduparray (_, _)
   | Pduprecord (_,_) -> false
@@ -257,6 +261,7 @@ let may_locally_allocate (prim:Clambda_primitives.primitive) : bool =
   | Pbigstring_load (_, Unsafe, _) ->
       false
   | Pfloatfield (_, m) -> is_local_alloc m
+  | Pufloatfield _ -> false
   | Pstring_load (_, Safe, m)
   | Pbytes_load (_, Safe, m)
   | Pbigstring_load (_, Safe, m) -> is_local_alloc m
@@ -267,6 +272,7 @@ let may_locally_allocate (prim:Clambda_primitives.primitive) : bool =
   | Psetfield _
   | Psetfield_computed _
   | Psetfloatfield _
+  | Psetufloatfield _
   | Parraysetu _
   | Parraysets _
   | Pbytessetu

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -181,7 +181,7 @@ let rec expr_size env = function
       assert false
   | Uprim (Pduprecord (Record_inlined (_, Variant_extensible), sz), _, _) ->
       RHS_block (Lambda.alloc_heap, sz + 1)
-  | Uprim (Pduprecord (Record_float, sz), _, _) ->
+  | Uprim (Pduprecord ((Record_float | Record_ufloat), sz), _, _) ->
       RHS_floatblock (Lambda.alloc_heap, sz)
   | Uprim (Pccall { prim_name; _ }, closure::_, _)
         when prim_name = "caml_check_value_is_closure" ->

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -162,6 +162,8 @@ let rec expr_size env = function
       expr_size env body
   | Uprim(Pmakeblock (_, _, _, mode), args, _) ->
       RHS_block (mode, List.length args)
+  | Uprim(Pmakeufloatblock (_, mode), args, _) ->
+      RHS_floatblock (mode, List.length args)
   | Uprim(Pmakearray((Paddrarray | Pintarray), _, mode), args, _) ->
       RHS_block (mode, List.length args)
   | Uprim(Pmakearray(Pfloatarray, _, mode), args, _) ->

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -537,10 +537,13 @@ let rec transl env e =
       begin match (simplif_primitive prim, args) with
       | (Pread_symbol sym, []) ->
           Cconst_symbol (sym, dbg)
-      | (Pmakeblock _, []) ->
+      | ((Pmakeblock _ | Pmakeufloatblock _), []) ->
           assert false
       | (Pmakeblock(tag, _mut, _kind, mode), args) ->
           make_alloc ~mode dbg tag (List.map (transl env) args)
+      | (Pmakeufloatblock(_mut, mode), args) ->
+          make_float_alloc ~mode dbg Obj.double_array_tag
+            (List.map (transl env) args)
       | (Pccall prim, args) ->
           transl_ccall env prim args dbg
       | (Pduparray (kind, _), [Uprim (Pmakearray (kind', _, _), args, _dbg)]) ->
@@ -632,6 +635,7 @@ let rec transl env e =
          | Pbswap16 | Pint_as_pointer _ | Popaque | Pfield _
          | Psetfield (_, _, _) | Psetfield_computed (_, _)
          | Pfloatfield _ | Psetfloatfield (_, _) | Pduprecord (_, _)
+         | Pufloatfield _ | Psetufloatfield (_, _)
          | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _ | Poffsetint _
          | Pcompare_ints | Pcompare_floats | Pcompare_bints _
          | Poffsetref _ | Pfloatcomp _ | Parraylength _
@@ -900,6 +904,8 @@ and transl_prim_1 env p arg dbg =
   | Pfloatfield (n,mode) ->
       let ptr = transl env arg in
       box_float dbg mode (floatfield n ptr dbg)
+  | Pufloatfield n ->
+      get_field env Punboxed_float (transl env arg) n dbg
   | Pint_as_pointer _ ->
       int_as_pointer (transl env arg) dbg
   (* Exceptions *)
@@ -969,7 +975,9 @@ and transl_prim_1 env p arg dbg =
     | Pstringrefu | Pstringrefs | Pbytesrefu | Pbytessetu
     | Pbytesrefs | Pbytessets | Pisout | Pread_symbol _
     | Pmakeblock (_, _, _, _) | Psetfield (_, _, _) | Psetfield_computed (_, _)
+    | Pmakeufloatblock (_, _)
     | Psetfloatfield (_, _) | Pduprecord (_, _) | Pccall _ | Pdivint _
+    | Psetufloatfield (_, _)
     | Pmodint _ | Pintcomp _ | Pfloatcomp _ | Pmakearray (_, _, _)
     | Pcompare_ints | Pcompare_floats | Pcompare_bints _
     | Pduparray (_, _) | Parrayrefu _ | Parraysetu _
@@ -994,7 +1002,10 @@ and transl_prim_2 env p arg1 arg2 dbg =
       let ptr = transl env arg1 in
       let float_val = transl_unbox_float dbg env arg2 in
       setfloatfield n init ptr float_val dbg
-
+  | Psetufloatfield (n, init) ->
+      let ptr = transl env arg1 in
+      let float_val = transl env arg2 in
+      setfloatfield n init ptr float_val dbg
   (* Boolean operations *)
   | Psequand ->
       let dbg' = Debuginfo.none in
@@ -1150,7 +1161,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   | Pabsfloat _ | Pstringlength | Pbyteslength | Pbytessetu | Pbytessets
   | Pisint | Pbswap16 | Pint_as_pointer _ | Popaque | Pread_symbol _
   | Pmakeblock (_, _, _, _) | Pfield _ | Psetfield_computed (_, _)
-  | Pfloatfield _
+  | Pmakeufloatblock (_, _) | Pfloatfield _ | Pufloatfield _
   | Pduprecord (_, _) | Pccall _ | Praise _ | Poffsetint _ | Poffsetref _
   | Pmakearray (_, _, _) | Pduparray (_, _) | Parraylength _ | Parraysetu _
   | Parraysets _ | Pbintofint _ | Pintofbint _ | Pcvtbint (_, _, _)
@@ -1208,6 +1219,7 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
   | Pbswap16 | Pint_as_pointer _ | Popaque | Pread_symbol _
   | Pmakeblock (_, _, _, _)
   | Pfield _ | Psetfield (_, _, _) | Pfloatfield _ | Psetfloatfield (_, _)
+  | Pmakeufloatblock (_, _) | Pufloatfield _ | Psetufloatfield (_, _)
   | Pduprecord (_, _) | Pccall _ | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _
   | Pcompare_ints | Pcompare_floats | Pcompare_bints _
   | Poffsetint _ | Poffsetref _ | Pfloatcomp _ | Pmakearray (_, _, _)

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -117,9 +117,10 @@ let preserve_tailcall_for_prim = function
   | Pget_header _
   | Pignore
   | Pgetglobal _ | Psetglobal _ | Pgetpredef _
-  | Pmakeblock _ | Pmakefloatblock _
+  | Pmakeblock _ | Pmakefloatblock _ | Pmakeufloatblock _
   | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
+  | Pufloatfield _ | Psetufloatfield _
   | Pccall _ | Praise _ | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
   | Pasrint | Pintcomp _ | Poffsetint _ | Poffsetref _ | Pintoffloat
@@ -191,7 +192,7 @@ let rec size_of_lambda env = function
       begin match kind with
       | Record_boxed _ | Record_inlined (_, Variant_boxed _) -> RHS_block size
       | Record_unboxed | Record_inlined (_, Variant_unboxed) -> assert false
-      | Record_float -> RHS_floatblock size
+      | Record_float | Record_ufloat -> RHS_floatblock size
       | Record_inlined (_, Variant_extensible) -> RHS_block (size + 1)
       end
   | Llet(_str, _k, id, arg, body) ->
@@ -413,6 +414,10 @@ let comp_primitive p args =
   | Psetfield_computed(_ptr, _init) -> Ksetvectitem
   | Pfloatfield (n, _sem, _mode) -> Kgetfloatfield n
   | Psetfloatfield (n, _init) -> Ksetfloatfield n
+  (* In bytecode, float#s are boxed.  So, we can use the existing float
+     instructions for the ufloat primitives. *)
+  | Pufloatfield (n, _sem) -> Kgetfloatfield n
+  | Psetufloatfield (n, _init) -> Ksetfloatfield n
   | Pduprecord _ -> Kccall("caml_obj_dup", 1)
   | Pccall p -> Kccall(p.prim_name, p.prim_arity)
   | Pnegint -> Knegint
@@ -544,6 +549,7 @@ let comp_primitive p args =
   | Pfloatcomp _
   | Pmakeblock _
   | Pmakefloatblock _
+  | Pmakeufloatblock _
   | Pprobe_is_enabled _
   | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
     ->
@@ -776,7 +782,9 @@ let rec comp_expr env exp sz cont =
         (Kpush::
          Kconst (Const_base (Const_int n))::
          Kaddint::cont)
-  | Lprim (Pmakefloatblock _, args, loc) ->
+  | Lprim ((Pmakefloatblock _ | Pmakeufloatblock _), args, loc) ->
+      (* In bytecode, float# is boxed, so we can treat these two primitives the
+         same. *)
       let cont = add_pseudo_event loc !compunit_name cont in
       comp_args env args sz (Kmakefloatblock (List.length args) :: cont)
   | Lprim(Pmakearray (kind, _, _), args, loc) ->

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1395,6 +1395,12 @@ let mod_field ?(read_semantics=Reads_agree) pos =
 let mod_setfield pos =
   Psetfield (pos, Pointer, Root_initialization)
 
+(* [primitive_may_allocate] treats projecting an unboxed float from a float
+   record as non-allocating, which is a lie for the bytecode backend (where
+   unboxed floats are boxed).  But it's only used for stack allocation, which
+   doesn't happen in bytecode.  If that changes, or if we want to use this for
+   another purpose in bytecode, it will need to be revised.
+*)
 let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pbytes_to_string | Pbytes_of_string
   | Parray_to_iarray | Parray_of_iarray

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1395,12 +1395,6 @@ let mod_field ?(read_semantics=Reads_agree) pos =
 let mod_setfield pos =
   Psetfield (pos, Pointer, Root_initialization)
 
-(* [primitive_may_allocate] treats projecting an unboxed float from a float
-   record as non-allocating, which is a lie for the bytecode backend (where
-   unboxed floats are boxed).  But it's only used for stack allocation, which
-   doesn't happen in bytecode.  If that changes, or if we want to use this for
-   another purpose in bytecode, it will need to be revised.
-*)
 let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pbytes_to_string | Pbytes_of_string
   | Parray_to_iarray | Parray_of_iarray

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -38,7 +38,7 @@ type locality_mode = private
   | Alloc_heap
   | Alloc_local
 
-(** For now we don't have strong update, and thus uniqueness is irrelavent in 
+(** For now we don't have strong update, and thus uniqueness is irrelavent in
     middle and back-end; in the future this will be extended with uniqueness *)
 type alloc_mode = locality_mode
 
@@ -92,12 +92,15 @@ type primitive =
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
   | Pmakefloatblock of mutable_flag * alloc_mode
+  | Pmakeufloatblock of mutable_flag * alloc_mode
   | Pfield of int * field_read_semantics
   | Pfield_computed of field_read_semantics
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * field_read_semantics * alloc_mode
+  | Pufloatfield of int * field_read_semantics
   | Psetfloatfield of int * initialization_or_assignment
+  | Psetufloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* External call *)
   | Pccall of Primitive.description

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -38,7 +38,7 @@ type locality_mode = private
   | Alloc_heap
   | Alloc_local
 
-(** For now we don't have strong update, and thus uniqueness is irrelevent in
+(** For now we don't have strong update, and thus uniqueness is irrelevant in
     middle and back-end; in the future this will be extended with uniqueness *)
 type alloc_mode = locality_mode
 
@@ -705,7 +705,15 @@ val is_heap_mode : alloc_mode -> bool
 val primitive_may_allocate : primitive -> alloc_mode option
   (** Whether and where a primitive may allocate.
       [Some Alloc_local] permits both options: that is, primitives that
-      may allocate on both the GC heap and locally report this value. *)
+      may allocate on both the GC heap and locally report this value.
+
+      This treats projecting an unboxed float from a float record as
+      non-allocating, which is a lie for the bytecode backend (where unboxed
+      floats are boxed).  Presently this function is only used for stack
+      allocation, which doesn't happen in bytecode.  If that changes, or if we
+      want to use this for another purpose in bytecode, it will need to be
+      revised.
+  *)
 
 (***********************)
 (* For static failures *)

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -38,7 +38,7 @@ type locality_mode = private
   | Alloc_heap
   | Alloc_local
 
-(** For now we don't have strong update, and thus uniqueness is irrelavent in
+(** For now we don't have strong update, and thus uniqueness is irrelevent in
     middle and back-end; in the future this will be extended with uniqueness *)
 type alloc_mode = locality_mode
 
@@ -81,11 +81,15 @@ type region_close =
   | Rc_nontail        (* do not close region, must not TCO *)
   | Rc_close_at_apply (* close region and tail call *)
 
+(* CR layouts v5: When we add more blocks of non-scannable values, consider
+   whether some of the primitives specific to ufloat records
+   ([Pmakeufloatblock], [Pufloatfield], and [Psetufloatfield]) can/should be
+   generalized, rather than just adding new primitives. *)
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
   | Pignore
-    (* Globals *)
+  (* Globals *)
   | Pgetglobal of Compilation_unit.t
   | Psetglobal of Compilation_unit.t
   | Pgetpredef of Ident.t

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -3823,14 +3823,14 @@ let for_let ~scopes ~arg_sort ~return_layout loc param pat body =
   | _ ->
       let opt = ref false in
       let nraise = next_raise_count () in
-      let catch_ids = pat_bound_idents_with_types pat in
+      let catch_ids = pat_bound_idents_full arg_sort pat in
       let ids_with_kinds =
         List.map
-          (fun (id, typ) ->
-             (id, Typeopt.layout pat.pat_env pat.pat_loc arg_sort typ))
+          (fun (id, _, typ, sort) ->
+             (id, Typeopt.layout pat.pat_env pat.pat_loc sort typ))
           catch_ids
       in
-      let ids = List.map (fun (id, _) -> id) catch_ids in
+      let ids = List.map (fun (id, _, _, _) -> id) catch_ids in
       let bind =
         map_return (assign_pat ~scopes return_layout opt nraise ids loc pat
                       arg_sort)

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -114,6 +114,9 @@ let layout_must_be_value loc layout =
   | Ok _ -> ()
   | Error e -> raise (Error (loc, Non_value_layout e))
 
+(* CR layouts v5: This function is only used for sanity checking the
+   typechecker.  When we allow arbitrary layouts in structures, it will have
+   outlived its usefulness and should be deleted. *)
 let check_record_field_layout lbl =
   match Layout.(get_default_value lbl.lbl_layout), lbl.lbl_repres with
   | (Value | Immediate | Immediate64), _ -> ()

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -101,6 +101,7 @@ module Scoped_location = Debuginfo.Scoped_location
 
 type error =
     Non_value_layout of Layout.Violation.t
+  | Illegal_record_field of Layout.const
 
 exception Error of Location.t * error
 
@@ -112,6 +113,15 @@ let layout_must_be_value loc layout =
   match Layout.(sub layout (value ~why:V1_safety_check)) with
   | Ok _ -> ()
   | Error e -> raise (Error (loc, Non_value_layout e))
+
+let check_record_field_layout lbl =
+  match Layout.(get_default_value lbl.lbl_layout), lbl.lbl_repres with
+  | (Value | Immediate | Immediate64), _ -> ()
+  | Float64, Record_ufloat -> ()
+  | Float64, (Record_boxed _ | Record_inlined _
+             | Record_unboxed | Record_float) ->
+    raise (Error (lbl.lbl_loc, Illegal_record_field Float64))
+  | (Any | Void) as c, _ -> raise (Error (lbl.lbl_loc, Illegal_record_field c))
 
 (*
    Compatibility predicate that considers potential rebindings of constructors
@@ -2084,7 +2094,7 @@ let record_matching_line num_fields lbl_pat_list =
   List.iter (fun (_, lbl, pat) ->
     (* CR layouts v5: This void sanity check can be removed when we add proper
        void support (or whenever we remove `lbl_pos_void`) *)
-    layout_must_be_value lbl.lbl_loc lbl.lbl_layout;
+    check_record_field_layout lbl;
     patv.(lbl.lbl_pos) <- pat)
     lbl_pat_list;
   Array.to_list patv
@@ -2111,35 +2121,34 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
       rem
     else
       let lbl = all_labels.(pos) in
-      layout_must_be_value lbl.lbl_loc lbl.lbl_layout;
+      check_record_field_layout lbl;
+      let lbl_sort = Layout.sort_of_layout lbl.lbl_layout in
+      let lbl_layout = Typeopt.layout_of_sort lbl.lbl_loc lbl_sort in
       let sem =
         match lbl.lbl_mut with
         | Immutable -> Reads_agree
         | Mutable -> Reads_vary
       in
       let access, sort, layout =
-        (* CR layouts v5: Here we'll need to get the layout from the
-           record_representation and translate it to `Lambda.layout`, rather
-           than just using layout_field everywhere.  (Though layout_field is
-           safe for now, particularly after checking for void above.)  I think
-           only the sort information matters here, so when we make that change
-           we may want to use `Typeopt.layout_of_sort` rather than
-           `Typeopt.layout`.  *)
         match lbl.lbl_repres with
         | Record_boxed _
         | Record_inlined (_, Variant_boxed _) ->
             Lprim (Pfield (lbl.lbl_pos, sem), [ arg ], loc),
-            Sort.for_record_field, layout_field
+            lbl_sort, lbl_layout
         | Record_unboxed
         | Record_inlined (_, Variant_unboxed) -> arg, sort, layout
         | Record_float ->
            (* TODO: could optimise to Alloc_local sometimes *)
            Lprim (Pfloatfield (lbl.lbl_pos, sem, alloc_heap), [ arg ], loc),
            (* Here we are projecting a boxed float from a float record. *)
-           Sort.for_predef_value, layout_boxed_float
+           lbl_sort, lbl_layout
+        | Record_ufloat ->
+           Lprim (Pufloatfield (lbl.lbl_pos, sem), [ arg ], loc),
+           (* Here we are projecting an unboxed float from a float record. *)
+           lbl_sort, lbl_layout
         | Record_inlined (_, Variant_extensible) ->
             Lprim (Pfield (lbl.lbl_pos + 1, sem), [ arg ], loc),
-            Sort.for_record_field, layout_field
+            lbl_sort, lbl_layout
       in
       let str =
         match lbl.lbl_mut with
@@ -4010,6 +4019,11 @@ let report_error ppf = function
         "Non-value detected in translation:@ Please report this error to \
          the Jane Street compilers team.@ %a"
         (Layout.Violation.report_with_name ~name:"This expression") err
+  | Illegal_record_field c ->
+      fprintf ppf
+        "Sort %s detected where value was expected in a record field:@ Please \
+         report this error to the Jane Street compilers team."
+        (Layout.string_of_const c)
 
 let () =
   Location.register_error_of_exn

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -212,6 +212,7 @@ let record_rep ppf r = match r with
   | Record_boxed _ -> fprintf ppf "boxed"
   | Record_inlined _ -> fprintf ppf "inlined"
   | Record_float -> fprintf ppf "float"
+  | Record_ufloat -> fprintf ppf "ufloat"
 
 let block_shape ppf shape = match shape with
   | None | Some [] -> ()
@@ -275,6 +276,15 @@ let primitive ppf = function
   | Pmakefloatblock (Mutable, mode) ->
      fprintf ppf "make%sfloatblock Mutable"
         (alloc_mode mode)
+  | Pmakeufloatblock (Immutable, mode) ->
+      fprintf ppf "make%sufloatblock Immutable"
+        (alloc_mode mode)
+  | Pmakeufloatblock (Immutable_unique, mode) ->
+     fprintf ppf "make%sufloatblock Immutable_unique"
+        (alloc_mode mode)
+  | Pmakeufloatblock (Mutable, mode) ->
+     fprintf ppf "make%sufloatblock Mutable"
+        (alloc_mode mode)
   | Pfield (n, sem) ->
       fprintf ppf "field%a %i" field_read_semantics sem n
   | Pfield_computed sem ->
@@ -310,6 +320,9 @@ let primitive ppf = function
   | Pfloatfield (n, sem, mode) ->
       fprintf ppf "floatfield%a%s %i"
         field_read_semantics sem (alloc_mode mode) n
+  | Pufloatfield (n, sem) ->
+      fprintf ppf "ufloatfield%a %i"
+        field_read_semantics sem n
   | Psetfloatfield (n, init) ->
       let init =
         match init with
@@ -319,6 +332,15 @@ let primitive ppf = function
         | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setfloatfield%s %i" init n
+  | Psetufloatfield (n, init) ->
+      let init =
+        match init with
+        | Heap_initialization -> "(heap-init)"
+        | Root_initialization -> "(root-init)"
+        | Assignment Modify_heap -> ""
+        | Assignment Modify_maybe_stack -> "(maybe-stack)"
+      in
+      fprintf ppf "setufloatfield%s %i" init n
   | Pduprecord (rep, size) -> fprintf ppf "duprecord %a %i" record_rep rep size
   | Pccall p -> fprintf ppf "%s" p.prim_name
   | Praise k -> fprintf ppf "%s" (Lambda.raise_kind k)
@@ -495,12 +517,15 @@ let name_of_primitive = function
   | Pgetpredef _ -> "Pgetpredef"
   | Pmakeblock _ -> "Pmakeblock"
   | Pmakefloatblock _ -> "Pmakefloatblock"
+  | Pmakeufloatblock _ -> "Pmakeufloatblock"
   | Pfield _ -> "Pfield"
   | Pfield_computed _ -> "Pfield_computed"
   | Psetfield _ -> "Psetfield"
   | Psetfield_computed _ -> "Psetfield_computed"
   | Pfloatfield _ -> "Pfloatfield"
   | Psetfloatfield _ -> "Psetfloatfield"
+  | Pufloatfield _ -> "Pufloatfield"
+  | Psetufloatfield _ -> "Psetufloatfield"
   | Pduprecord _ -> "Pduprecord"
   | Pccall _ -> "Pccall"
   | Praise _ -> "Praise"

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -878,6 +878,7 @@ let rec choice ctx t =
     | Pfield _ | Pfield_computed _
     | Psetfield _ | Psetfield_computed _
     | Pfloatfield _ | Psetfloatfield _
+    | Pufloatfield _ | Psetufloatfield _
     | Pccall _
     | Praise _
     | Pnot
@@ -907,6 +908,7 @@ let rec choice ctx t =
 
     (* we don't handle all-float records *)
     | Pmakefloatblock _
+    | Pmakeufloatblock _
 
     | Pobj_dup
     | Pobj_magic _

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1574,7 +1574,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
   end
 
 and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
-  let return_layout = layout_exp arg_sort e in
+  let return_layout = layout_exp return_sort e in
   let rewrite_case (val_cases, exn_cases, static_handlers as acc)
         ({ c_lhs; c_guard; c_rhs } as case) =
     if c_rhs.exp_desc = Texp_unreachable then acc else

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -31,17 +31,12 @@ type error =
     Free_super_var
   | Unreachable_reached
   | Bad_probe_layout of Ident.t
-  | Non_value_layout of Layout.Violation.t
+  | Illegal_record_field of Sort.const
   | Void_sort of type_expr
 
 exception Error of Location.t * error
 
 let use_dup_for_constant_mutable_arrays_bigger_than = 4
-
-let layout_must_be_value loc layout =
-  match Layout.(sub layout (value ~why:V1_safety_check)) with
-  | Ok _ -> ()
-  | Error e -> raise (Error (loc, Non_value_layout e))
 
 (* CR layouts v7: In the places where this is used, we will want to allow
    float#, but not void yet (e.g., the left of a semicolon and loop bodies).  we
@@ -57,6 +52,28 @@ let sort_must_not_be_void loc ty sort =
   if Sort.is_void_defaulting sort then raise (Error (loc, Void_sort ty))
 
 let layout_exp sort e = layout e.exp_env e.exp_loc sort e.exp_type
+
+(* This is `Lambda.must_be_value` for the special case of record fields, where
+   we allow the unboxed float layout and pretend it's a normal `Pvalue
+   Pfloatval`.  The compiler already has legacy support for that using
+   (incorrect) value kind `Pfloatval` for their fields.
+
+   CR layouts v5: eliminate this hack.
+*)
+let record_field_kind l =
+  match l with
+  | Punboxed_float -> Pfloatval
+  | _ -> must_be_value l
+
+let check_record_field_sort loc sort repres =
+  match Sort.get_default_value sort, repres with
+  | Value, _ -> ()
+  | Float64, Record_ufloat -> ()
+  | Float64, (Record_boxed _ | Record_inlined _
+             | Record_unboxed | Record_float) ->
+    raise (Error (loc, Illegal_record_field Float64))
+  | Void, _ ->
+    raise (Error (loc, Illegal_record_field Void))
 
 (* Forward declaration -- to be filled in by Translmod.transl_module *)
 let transl_module =
@@ -516,13 +533,15 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       transl_record ~scopes e.exp_loc e.exp_env
         (Option.map transl_alloc_mode alloc_mode)
         fields representation extended_expression
-  | Texp_field(arg, _, lbl, _, alloc_mode) ->
+  | Texp_field(arg, id, lbl, _, alloc_mode) ->
       let targ = transl_exp ~scopes Sort.for_record arg in
       let sem =
         match lbl.lbl_mut with
         | Immutable -> Reads_agree
         | Mutable -> Reads_vary
       in
+      let lbl_sort = Layout.sort_of_layout lbl.lbl_layout in
+      check_record_field_sort id.loc lbl_sort lbl.lbl_repres;
       begin match lbl.lbl_repres with
           Record_boxed _ | Record_inlined (_, Variant_boxed _) ->
           Lprim (Pfield (lbl.lbl_pos, sem), [targ],
@@ -532,12 +551,20 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           let mode = transl_alloc_mode (Option.get alloc_mode) in
           Lprim (Pfloatfield (lbl.lbl_pos, sem, mode), [targ],
                  of_location ~scopes e.exp_loc)
+        | Record_ufloat ->
+          Lprim (Pufloatfield (lbl.lbl_pos, sem), [targ],
+                 of_location ~scopes e.exp_loc)
         | Record_inlined (_, Variant_extensible) ->
           Lprim (Pfield (lbl.lbl_pos + 1, sem), [targ],
                  of_location ~scopes e.exp_loc)
       end
   | Texp_setfield(arg, arg_mode, id, lbl, newval) ->
-      layout_must_be_value id.loc lbl.lbl_layout;
+      (* CR layouts v2.5: When we allow `any` in record fields and check
+         representability on construction, [sort_of_layout] will be unsafe here.
+         Probably we should add a sort to `Texp_setfield` in the typed tree,
+         then. *)
+      let lbl_sort = Layout.sort_of_layout lbl.lbl_layout in
+      check_record_field_sort id.loc lbl_sort lbl.lbl_repres;
       let mode =
         Assignment (transl_modify_mode arg_mode)
       in
@@ -549,11 +576,12 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         | Record_unboxed | Record_inlined (_, Variant_unboxed) ->
           assert false
         | Record_float -> Psetfloatfield (lbl.lbl_pos, mode)
+        | Record_ufloat -> Psetufloatfield (lbl.lbl_pos, mode)
         | Record_inlined (_, Variant_extensible) ->
           Psetfield (lbl.lbl_pos + 1, maybe_pointer newval, mode)
       in
       Lprim(access, [transl_exp ~scopes Sort.for_record arg;
-                     transl_exp ~scopes Sort.for_record_field newval],
+                     transl_exp ~scopes lbl_sort newval],
             of_location ~scopes e.exp_loc)
   | Texp_array (amut, expr_list, alloc_mode) ->
       let mode = transl_alloc_mode alloc_mode in
@@ -1448,16 +1476,20 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
   then begin
     (* Allocate new record with given fields (and remaining fields
        taken from init_expr if any *)
-    (* CR layouts v5: currently we raise if a non-value field is detected.
-       relax that. *)
+    (* CR layouts v5: allow non-value fields beyond just float# *)
     let init_id = Ident.create_local "init" in
     let lv =
       Array.mapi
         (fun i (lbl, definition) ->
+           (* CR layouts v2.5: When we allow `any` in record fields and check
+              representability on construction, [sort_of_layout] will be unsafe
+              here.  Probably we should add sorts to record construction in the
+              typed tree, then. *)
+           let lbl_sort = Layout.sort_of_layout lbl.lbl_layout in
            match definition with
            | Kept (typ, _) ->
                let field_kind =
-                 must_be_value (layout env lbl.lbl_loc Sort.for_record_field typ)
+                 record_field_kind (layout env lbl.lbl_loc lbl_sort typ)
                in
                let sem =
                  match lbl.lbl_mut with
@@ -1474,15 +1506,15 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                  | Record_float ->
                     (* This allocation is always deleted,
                        so it's simpler to leave it Alloc_heap *)
-                    Pfloatfield (i, sem, alloc_heap) in
+                    Pfloatfield (i, sem, alloc_heap)
+                 | Record_ufloat -> Pufloatfield (i, sem)
+               in
                Lprim(access, [Lvar init_id],
                      of_location ~scopes loc),
                field_kind
            | Overridden (_lid, expr) ->
-               let field_kind =
-                 must_be_value (layout_exp Sort.for_record_field expr)
-               in
-               transl_exp ~scopes Sort.for_record_field expr, field_kind)
+               let field_kind = record_field_kind (layout_exp lbl_sort expr) in
+               transl_exp ~scopes lbl_sort expr, field_kind)
         fields
     in
     let ll, shape = List.split (Array.to_list lv) in
@@ -1502,6 +1534,12 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             Lconst(match cl with [v] -> v | _ -> assert false)
         | Record_float ->
             Lconst(Const_float_block(List.map extract_float cl))
+        | Record_ufloat ->
+            (* CR layouts v2.5: When we add unboxed float literals, we may need
+               to do something here.  (Currrently this case isn't reachable for
+               `float#` records because `extact_constant` will have raised
+               `Not_constant`.) *)
+            raise Not_constant
         | Record_inlined (_, Variant_extensible)
         | Record_inlined (Extension _, _) ->
             raise Not_constant
@@ -1517,6 +1555,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             (match ll with [v] -> v | _ -> assert false)
         | Record_float ->
             Lprim(Pmakefloatblock (mut, Option.get mode), ll, loc)
+        | Record_ufloat ->
+            Lprim(Pmakeufloatblock (mut, Option.get mode), ll, loc)
         | Record_inlined (Extension (path, _), Variant_extensible) ->
             let slot = transl_extension_path loc env path in
             Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape), Option.get mode),
@@ -1535,10 +1575,9 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
        of the copy *)
     let copy_id = Ident.create_local "newrecord" in
     let update_field cont (lbl, definition) =
-      (* CR layouts v5: remove this check to allow non-value fields.  Even
-         in the current version we can reasonably skip it because if we built
-         the init record, we must have already checked for void. *)
-      layout_must_be_value lbl.lbl_loc lbl.lbl_layout;
+      (* CR layouts v5: allow more unboxed types here. *)
+      let lbl_sort = Layout.sort_of_layout lbl.lbl_layout in
+      check_record_field_sort lbl.lbl_loc lbl_sort lbl.lbl_repres;
       match definition with
       | Kept (_type, _uu) -> cont
       | Overridden (_lid, expr) ->
@@ -1551,13 +1590,15 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                 assert false
             | Record_float ->
                 Psetfloatfield (lbl.lbl_pos, Assignment modify_heap)
+            | Record_ufloat ->
+                Psetufloatfield (lbl.lbl_pos, Assignment modify_heap)
             | Record_inlined (_, Variant_extensible) ->
                 let pos = lbl.lbl_pos + 1 in
                 let ptr = maybe_pointer expr in
                 Psetfield(pos, ptr, Assignment modify_heap)
           in
           Lsequence(Lprim(upd, [Lvar copy_id;
-                                transl_exp ~scopes Sort.for_record_field expr],
+                                transl_exp ~scopes lbl_sort expr],
                           of_location ~scopes loc),
                     cont)
     in
@@ -1810,11 +1851,11 @@ let report_error ppf = function
   | Bad_probe_layout id ->
       fprintf ppf "Variables in probe handlers must have layout value, \
                    but %s in this handler does not." (Ident.name id)
-  | Non_value_layout err ->
+  | Illegal_record_field c ->
       fprintf ppf
-        "Non-value detected in translation:@ Please report this error to \
-         the Jane Street compilers team.@ %a"
-        (Layout.Violation.report_with_name ~name:"This expression") err
+        "Sort %a detected where value was expected in a record field:@ Please \
+         report this error to the Jane Street compilers team."
+        Sort.format (Sort.of_const c)
   | Void_sort ty ->
       fprintf ppf
         "Void detected in translation for type %a:@ Please report this error \

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -54,17 +54,17 @@ let sort_must_not_be_void loc ty sort =
 let layout_exp sort e = layout e.exp_env e.exp_loc sort e.exp_type
 
 (* This is `Lambda.must_be_value` for the special case of record fields, where
-   we allow the unboxed float layout and pretend it's a normal `Pvalue
-   Pfloatval`.  The compiler already has legacy support for that using
-   (incorrect) value kind `Pfloatval` for their fields.
-
-   CR layouts v5: eliminate this hack.
+   we allow the unboxed float layout.  Its result is never actually used in that
+   case - it would be fine to return garbage.
 *)
 let record_field_kind l =
   match l with
   | Punboxed_float -> Pfloatval
   | _ -> must_be_value l
 
+(* CR layouts v5: This function is only used for sanity checking the
+   typechecker.  When we allow arbitrary layouts in structures, it will have
+   outlived its usefulness and should be deleted. *)
 let check_record_field_sort loc sort repres =
   match Sort.get_default_value sort, repres with
   | Value, _ -> ()

--- a/ocaml/lambda/translcore.mli
+++ b/ocaml/lambda/translcore.mli
@@ -48,7 +48,7 @@ type error =
     Free_super_var
   | Unreachable_reached
   | Bad_probe_layout of Ident.t
-  | Non_value_layout of Layouts.Layout.Violation.t
+  | Illegal_record_field of Layouts.Sort.const
   | Void_sort of Types.type_expr
 
 exception Error of Location.t * error

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -973,9 +973,10 @@ let lambda_primitive_needs_event_after = function
   | Parray_to_iarray | Parray_of_iarray
   | Pignore | Psetglobal _
   | Pgetglobal _ | Pgetpredef _ | Pmakeblock _ | Pmakefloatblock _
+  | Pmakeufloatblock _
   | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Praise _
-  | Pmakeufloatblock _ | Pufloatfield _ | Psetufloatfield _
+  | Pufloatfield _ | Psetufloatfield _
   | Psequor | Psequand | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
   | Pasrint | Pintcomp _ | Poffsetint _ | Poffsetref _ | Pintoffloat

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -975,6 +975,7 @@ let lambda_primitive_needs_event_after = function
   | Pgetglobal _ | Pgetpredef _ | Pmakeblock _ | Pmakefloatblock _
   | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Praise _
+  | Pmakeufloatblock _ | Pufloatfield _ | Psetufloatfield _
   | Psequor | Psequand | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
   | Pasrint | Pintcomp _ | Poffsetint _ | Poffsetref _ | Pintoffloat

--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -217,4 +217,22 @@ let result_layout (p : primitive) =
   | Pccall {prim_native_repr_res = (_, repr_res); _} ->
     Lambda.layout_of_native_repr repr_res
   | Pufloatfield _ -> Lambda.Punboxed_float
-  | _ -> Lambda.layout_any_value
+  | Pread_symbol _ | Pmakeblock _ | Pmakeufloatblock _ | Pfield _
+  | Pfield_computed | Psetfield _ | Psetfield_computed _ | Pfloatfield _
+  | Psetfloatfield _ | Psetufloatfield _ | Pduprecord _ | Praise _
+  | Psequand | Psequor | Pnot | Pnegint | Paddint | Psubint | Pmulint
+  | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
+  | Pasrint | Pintcomp _ | Pcompare_ints | Pcompare_floats | Pcompare_bints _
+  | Poffsetint _ | Poffsetref _ | Pintoffloat | Pfloatofint _ | Pnegfloat _
+  | Pabsfloat _ | Paddfloat _ | Psubfloat _ | Pmulfloat _ | Pdivfloat _
+  | Pfloatcomp _ | Pstringlength | Pstringrefu  | Pstringrefs
+  | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
+  | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
+  | Parrayrefs _ | Parraysets _ | Pisint | Pisout | Pbintofint _ | Pintofbint _
+  | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _
+  | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
+  | Pasrbint _ | Pbintcomp _ | Pbigarrayref _ | Pbigarrayset _ | Pbigarraydim _
+  | Pstring_load _ | Pbytes_load _ | Pbytes_set _ | Pbigstring_load _
+  | Pbigstring_set _ | Pbswap16 | Pbbswap _ | Pint_as_pointer _ | Popaque
+  | Pprobe_is_enabled _ | Pbox_float _ | Pbox_int _ | Pget_header _
+    -> Lambda.layout_any_value

--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -38,12 +38,15 @@ type primitive =
   | Pread_symbol of string
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
+  | Pmakeufloatblock of mutable_flag * alloc_mode
   | Pfield of int * layout
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * alloc_mode
   | Psetfloatfield of int * initialization_or_assignment
+  | Pufloatfield of int
+  | Psetufloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* External call *)
   | Pccall of Primitive.description
@@ -213,4 +216,5 @@ let result_layout (p : primitive) =
   | Punbox_int bi -> Lambda.Punboxed_int bi
   | Pccall {prim_native_repr_res = (_, repr_res); _} ->
     Lambda.layout_of_native_repr repr_res
+  | Pufloatfield _ -> Lambda.Punboxed_float
   | _ -> Lambda.layout_any_value

--- a/ocaml/middle_end/clambda_primitives.mli
+++ b/ocaml/middle_end/clambda_primitives.mli
@@ -38,12 +38,15 @@ type primitive =
   | Pread_symbol of string
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
+  | Pmakeufloatblock of mutable_flag * alloc_mode
   | Pfield of int * layout
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * alloc_mode
   | Psetfloatfield of int * initialization_or_assignment
+  | Pufloatfield of int
+  | Psetufloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* External call *)
   | Pccall of Primitive.description

--- a/ocaml/middle_end/convert_primitives.ml
+++ b/ocaml/middle_end/convert_primitives.ml
@@ -28,6 +28,8 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       Pmakeblock (tag, mutability, shape, mode)
   | Pmakefloatblock (mutability, mode) ->
       Pmakearray (Pfloatarray, mutability, mode)
+  | Pmakeufloatblock (mutability, mode) ->
+      Pmakeufloatblock (mutability, mode)
   | Pfield (field, _sem) -> Pfield (field, Pvalue Pgenval)
   | Pfield_computed _sem -> Pfield_computed
   | Psetfield (field, imm_or_pointer, init_or_assign) ->
@@ -37,6 +39,9 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pfloatfield (field, _sem, mode) -> Pfloatfield (field, mode)
   | Psetfloatfield (field, init_or_assign) ->
       Psetfloatfield (field, init_or_assign)
+  | Pufloatfield (field, _sem) -> Pufloatfield field
+  | Psetufloatfield (field, init_or_assign) ->
+      Psetufloatfield (field, init_or_assign)
   | Pduprecord (repr, size) -> Pduprecord (repr, size)
   | Pccall prim -> Pccall prim
   | Praise kind -> Praise kind

--- a/ocaml/middle_end/internal_variable_names.ml
+++ b/ocaml/middle_end/internal_variable_names.ml
@@ -116,6 +116,7 @@ let pfield = "Pfield"
 let pfield_computed = "Pfield_computed"
 let pfloatcomp = "Pfloatcomp"
 let pfloatfield = "Pfloatfield"
+let pufloatfield = "Pufloatfield"
 let pfloatofint = "Pfloatofint"
 let pgetglobal = "Pgetglobal"
 let pgetpredef = "Pgetpredef"
@@ -138,6 +139,7 @@ let plsrint = "Plsrint"
 let pmakearray = "Pmakearray"
 let pmakeblock = "Pmakeblock"
 let pmakefloatblock = "Pmakefloatblock"
+let pmakeufloatblock = "Pmakeufloatblock"
 let pmodbint = "Pmodbint"
 let pmodint = "Pmodint"
 let pmulbint = "Pmulbint"
@@ -161,6 +163,7 @@ let psequor = "Psequor"
 let psetfield = "Psetfield"
 let psetfield_computed = "Psetfield_computed"
 let psetfloatfield = "Psetfloatfield"
+let psetufloatfield = "Psetufloatfield"
 let psetglobal = "Psetglobal"
 let pstring_load_16 = "Pstring_load_16"
 let pstring_load_32 = "Pstring_load_32"
@@ -223,6 +226,7 @@ let pfield_arg = "Pfield_arg"
 let pfield_computed_arg = "Pfield_computed_arg"
 let pfloatcomp_arg = "Pfloatcomp_arg"
 let pfloatfield_arg = "Pfloatfield_arg"
+let pufloatfield_arg = "Pufloatfield_arg"
 let pfloatofint_arg = "Pfloatofint_arg"
 let pgetglobal_arg = "Pgetglobal_arg"
 let pgetpredef_arg = "Pgetpredef_arg"
@@ -245,6 +249,7 @@ let plsrint_arg = "Plsrint_arg"
 let pmakearray_arg = "Pmakearray_arg"
 let pmakeblock_arg = "Pmakeblock_arg"
 let pmakefloatblock_arg = "Pmakefloatblock_arg"
+let pmakeufloatblock_arg = "Pmakeufloatblock_arg"
 let pmodbint_arg = "Pmodbint_arg"
 let pmodint_arg = "Pmodint_arg"
 let pmulbint_arg = "Pmulbint_arg"
@@ -265,6 +270,7 @@ let psequor_arg = "Psequor_arg"
 let psetfield_arg = "Psetfield_arg"
 let psetfield_computed_arg = "Psetfield_computed_arg"
 let psetfloatfield_arg = "Psetfloatfield_arg"
+let psetufloatfield_arg = "Psetufloatfield_arg"
 let psetglobal_arg = "Psetglobal_arg"
 let pstring_load_16_arg = "Pstring_load_16_arg"
 let pstring_load_32_arg = "Pstring_load_32_arg"
@@ -337,12 +343,15 @@ let of_primitive : Lambda.primitive -> string = function
   | Pgetpredef _ -> pgetpredef
   | Pmakeblock _ -> pmakeblock
   | Pmakefloatblock _ -> pmakefloatblock
+  | Pmakeufloatblock _ -> pmakeufloatblock
   | Pfield _ -> pfield
   | Pfield_computed _ -> pfield_computed
   | Psetfield _ -> psetfield
   | Psetfield_computed _ -> psetfield_computed
   | Pfloatfield _ -> pfloatfield
   | Psetfloatfield _ -> psetfloatfield
+  | Pufloatfield _ -> pufloatfield
+  | Psetufloatfield _ -> psetufloatfield
   | Pduprecord _ -> pduprecord
   | Pccall _ -> pccall
   | Praise _ -> praise
@@ -452,12 +461,15 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pgetpredef _ -> pgetpredef_arg
   | Pmakeblock _ -> pmakeblock_arg
   | Pmakefloatblock _ -> pmakefloatblock_arg
+  | Pmakeufloatblock _ -> pmakeufloatblock_arg
   | Pfield _ -> pfield_arg
   | Pfield_computed _ -> pfield_computed_arg
   | Psetfield _ -> psetfield_arg
   | Psetfield_computed _ -> psetfield_computed_arg
   | Pfloatfield _ -> pfloatfield_arg
   | Psetfloatfield _ -> psetfloatfield_arg
+  | Pufloatfield _ -> pufloatfield_arg
+  | Psetufloatfield _ -> psetufloatfield_arg
   | Pduprecord _ -> pduprecord_arg
   | Pccall _ -> pccall_arg
   | Praise _ -> praise_arg

--- a/ocaml/middle_end/printclambda_primitives.ml
+++ b/ocaml/middle_end/printclambda_primitives.ml
@@ -96,6 +96,18 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
       in
       let name = "make" ^ mode ^ mut in
       fprintf ppf "%s %i%a" name tag Printlambda.block_shape shape
+  | Pmakeufloatblock(mut, mode) ->
+      let mode = match mode with
+        | Alloc_heap -> ""
+        | Alloc_local -> "local"
+      in
+      let mut = match mut with
+        | Immutable -> "block"
+        | Immutable_unique -> "block_unique"
+        | Mutable -> "mutable"
+      in
+      let name = "make" ^ mode ^ "ufloat" ^ mut in
+      fprintf ppf "%s" name
   | Pfield (n, layout) -> fprintf ppf "field%a %i" Printlambda.layout layout n
   | Pfield_computed -> fprintf ppf "field_computed"
   | Psetfield(n, ptr, init) ->
@@ -128,6 +140,7 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
       fprintf ppf "setfield_%s%s_computed" instr init
   | Pfloatfield (n, Alloc_heap) -> fprintf ppf "floatfield %i" n
   | Pfloatfield (n, Alloc_local) -> fprintf ppf "floatfieldlocal %i" n
+  | Pufloatfield n -> fprintf ppf "ufloatfield %i" n
   | Psetfloatfield (n, init) ->
       let init =
         match init with
@@ -137,6 +150,15 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
         | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setfloatfield%s %i" init n
+  | Psetufloatfield (n, init) ->
+      let init =
+        match init with
+        | Heap_initialization -> "(heap-init)"
+        | Root_initialization -> "(root-init)"
+        | Assignment Modify_heap -> ""
+        | Assignment Modify_maybe_stack -> "(maybe-stack)"
+      in
+      fprintf ppf "setufloatfield%s %i" init n
   | Pduprecord (rep, size) ->
       fprintf ppf "duprecord %a %i" Printlambda.record_rep rep size
   | Pccall p -> fprintf ppf "%s" p.Primitive.prim_name

--- a/ocaml/middle_end/semantics_of_primitives.ml
+++ b/ocaml/middle_end/semantics_of_primitives.ml
@@ -29,6 +29,7 @@ let coeffects_of : Lambda.alloc_mode -> coeffects = function
 let for_primitive (prim : Clambda_primitives.primitive) =
   match prim with
   | Pmakeblock (_, _, _, m)
+  | Pmakeufloatblock (_, m)
   | Pmakearray (_, Mutable, m) -> Only_generative_effects, coeffects_of m
   | Pmakearray (_, (Immutable | Immutable_unique), m) ->
      No_effects, coeffects_of m
@@ -106,6 +107,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Pfield _
   | Pfield_computed
   | Pfloatfield _
+  | Pufloatfield _
   | Parrayrefu _
   | Pstringrefu
   | Pbytesrefu
@@ -126,6 +128,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Psetfield _
   | Psetfield_computed _
   | Psetfloatfield _
+  | Psetufloatfield _
   | Parraysetu _
   | Parraysets _
   | Pbytessetu
@@ -173,6 +176,7 @@ let is_local_alloc = function
 let may_locally_allocate (prim:Clambda_primitives.primitive) : bool =
   match prim with
   | Pmakeblock (_, _, _, m)
+  | Pmakeufloatblock (_, m)
   | Pmakearray (_, _, m) -> is_local_alloc m
   | Pduparray (_, _)
   | Pduprecord (_,_) -> false
@@ -245,6 +249,7 @@ let may_locally_allocate (prim:Clambda_primitives.primitive) : bool =
   | Pbigstring_load (_, Unsafe, _) ->
       false
   | Pfloatfield (_, m) -> is_local_alloc m
+  | Pufloatfield _ -> false
   | Pstring_load (_, Safe, m)
   | Pbytes_load (_, Safe, m)
   | Pbigstring_load (_, Safe, m) -> is_local_alloc m
@@ -255,6 +260,7 @@ let may_locally_allocate (prim:Clambda_primitives.primitive) : bool =
   | Psetfield _
   | Psetfield_computed _
   | Psetfloatfield _
+  | Psetufloatfield _
   | Parraysetu _
   | Parraysets _
   | Pbytessetu

--- a/ocaml/testsuite/tests/typing-layouts-float64/alloc.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/alloc.ml
@@ -19,7 +19,16 @@ end
 
 let alloc = ref 0.0
 
-let measure_alloc f =
+let measure_alloc f : float# =
+  (* NB: right-to-left evaluation order gets this right *)
+  let baseline_allocation = Gc.allocated_bytes() -. Gc.allocated_bytes() in
+  let before = Gc.allocated_bytes () in
+  let result = (f[@inlined never]) () in
+  let after = Gc.allocated_bytes () in
+  alloc := (after -. before) -. baseline_allocation;
+  result
+
+let measure_alloc_value f : 'a =
   (* NB: right-to-left evaluation order gets this right *)
   let baseline_allocation = Gc.allocated_bytes() -. Gc.allocated_bytes() in
   let before = Gc.allocated_bytes () in
@@ -38,6 +47,11 @@ let measure_alloc f =
 
 let get_allocations () =
   let result = if !alloc > 0. then "Allocated" else "Did not allocate" in
+  alloc := 0.0;
+  result
+
+let get_exact_allocations () =
+  let result = !alloc in
   alloc := 0.0;
   result
 
@@ -84,3 +98,67 @@ end
 
 let _ = Pi_unboxed.estimate ()
 let _ = Pi_boxed.estimate ()
+
+(**********************************)
+(* float# record allocation tests *)
+let[@inline never] consumer x y = Float_u.(x + y)
+
+type t8 = { a : float#;
+            mutable b : float#;
+            c : float#;
+            mutable d : float# }
+
+let print_record_and_allocs s r =
+  let allocs = get_exact_allocations () in
+  Printf.printf
+    "%s:\n  allocated bytes: %.2f\n  a: %.2f\n  b: %.2f\n  c: %.2f\n  d: %.2f\n"
+    s allocs (Float_u.to_float r.a) (Float_u.to_float r.b)
+    (Float_u.to_float r.c) (Float_u.to_float r.d)
+
+(* Building a record should only allocate the box *)
+let[@inline never] build x =
+  { a = x;
+    b = Float_u.of_float 42.0;
+    c = consumer x x;
+    d = consumer x (Float_u.of_float 1.0) }
+
+let[@inline never] project_a r = r.a
+let[@inline never] update_d r x = r.d <- x
+
+(* We should be able to get floats out, do math on them, pass them to functions,
+   etc, without allocating. *)
+let[@inline never] manipulate ({c; _} as r) =
+  match r with
+  | { b; _ } ->
+    update_d r (consumer b (project_a r));
+    r.b <- Float_u.sub c (Float_u.of_float 21.1);
+    r.a
+
+let _ =
+  let r = measure_alloc_value (fun () -> build (Float_u.of_float 3.14)) in
+  print_record_and_allocs "Construction (40 bytes for record)" r;
+  let _ = measure_alloc (fun () -> manipulate r) in
+  print_record_and_allocs "Manipulation (0 bytes)" r
+
+
+(* There was some concern the below would allocate when passed `false` due to
+   CSE.  The idea is:
+   - Projections like `r.a` were initially implemented as
+     `unbox (box ( *(r+offset) ))`.  This box is supposed to be erased by the
+     middle-end, but...
+   - The boxes from the `true` branch could get lifted out of the `if` to be
+     combined with the box from the projection, preventing it from being erased.
+   Projections are no longer implemented that way, so there's no common
+   subexpression to be eliminated, but I've kept the test.  *)
+let[@inline never] cse_test b r =
+  let (x : float#) = r.a in
+  if b then
+    (Float_u.to_float x, Float_u.to_float x)
+  else
+    (0., 0.)
+
+let _ =
+  let r = build (Float_u.of_float 3.14) in
+  let _ = measure_alloc_value (fun () -> cse_test false r) in
+  let allocs = get_exact_allocations () in
+  Printf.printf "CSE test (0 bytes):\n  allocated bytes: %.2f\n" allocs

--- a/ocaml/testsuite/tests/typing-layouts-float64/alloc.reference
+++ b/ocaml/testsuite/tests/typing-layouts-float64/alloc.reference
@@ -4,3 +4,17 @@ Unboxed:
 Boxed:
   estimate: 3.141693
   allocations: Allocated
+Construction (40 bytes for record):
+  allocated bytes: 40.00
+  a: 3.14
+  b: 42.00
+  c: 6.28
+  d: 4.14
+Manipulation (0 bytes):
+  allocated bytes: 0.00
+  a: 3.14
+  b: -14.82
+  c: 6.28
+  d: 45.14
+CSE test (0 bytes):
+  allocated bytes: 0.00

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
@@ -172,37 +172,31 @@ Error: This type ('b : value) should be an instance of type ('a : float64)
        'a has layout float64, which does not overlap with value.
 |}]
 
-(****************************************************)
-(* Test 5: Can't be put in structures in typedecls. *)
+(******************************************************************************)
+(* Test 5: Can't be put in structures in typedecls, except all-float records. *)
 
 type t5_1 = { x : t_float64 };;
 [%%expect{|
-Line 1, characters 14-27:
-1 | type t5_1 = { x : t_float64 };;
-                  ^^^^^^^^^^^^^
-Error: Type t_float64 has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+type t5_1 = { x : t_float64; }
 |}];;
 
 (* CR layouts v5: this should work *)
 type t5_2 = { y : int; x : t_float64 };;
 [%%expect{|
-Line 1, characters 23-36:
+Line 1, characters 0-38:
 1 | type t5_2 = { y : int; x : t_float64 };;
-                           ^^^^^^^^^^^^^
-Error: Type t_float64 has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Records may not contain both unboxed floats and normal values.
 |}];;
 
 (* CR layouts: this runs afoul of the mixed block restriction, but should work
    once we relax that. *)
 type t5_2' = { y : string; x : t_float64 };;
 [%%expect{|
-Line 1, characters 27-40:
+Line 1, characters 0-42:
 1 | type t5_2' = { y : string; x : t_float64 };;
-                               ^^^^^^^^^^^^^
-Error: Type t_float64 has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Records may not contain both unboxed floats and normal values.
 |}];;
 
 (* CR layouts 2.5: allow this *)
@@ -212,7 +206,7 @@ Line 1, characters 14-27:
 1 | type t5_3 = { x : t_float64 } [@@unboxed];;
                   ^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}];;
 
 type t5_4 = A of t_float64;;
@@ -221,7 +215,7 @@ Line 1, characters 12-26:
 1 | type t5_4 = A of t_float64;;
                 ^^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}];;
 
 type t5_5 = A of int * t_float64;;
@@ -230,7 +224,7 @@ Line 1, characters 12-32:
 1 | type t5_5 = A of int * t_float64;;
                 ^^^^^^^^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}];;
 
 type t5_6 = A of t_float64 [@@unboxed];;
@@ -239,7 +233,7 @@ Line 1, characters 12-26:
 1 | type t5_6 = A of t_float64 [@@unboxed];;
                 ^^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}];;
 
 type ('a : float64) t5_7 = A of int
@@ -250,8 +244,39 @@ Line 2, characters 27-34:
 2 | type ('a : float64) t5_8 = A of 'a;;
                                ^^^^^^^
 Error: Type 'a has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}]
+
+type ('a : float64, 'b : float64) t5_9 = {x : 'a; y : 'b; z : 'a}
+
+type 'a t5_10 = 'a t_float64_id
+and 'a t5_11 = {x : 'a t5_10; y : 'a}
+
+type ('a : float64) t5_12 = {x : 'a; y : float#};;
+[%%expect{|
+type ('a : float64, 'b : float64) t5_9 = { x : 'a; y : 'b; z : 'a; }
+type ('a : float64) t5_10 = 'a t_float64_id
+and ('a : float64) t5_11 = { x : 'a t5_10; y : 'a; }
+type ('a : float64) t5_12 = { x : 'a; y : float#; }
+|}];;
+
+type ('a : float64) t5_13 = {x : 'a; y : float#};;
+[%%expect{|
+type ('a : float64) t5_13 = { x : 'a; y : float#; }
+|}];;
+
+type 'a t5_14 = {x : 'a; y : float#};;
+[%%expect{|
+Line 1, characters 0-36:
+1 | type 'a t5_14 = {x : 'a; y : float#};;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Records may not contain both unboxed floats and normal values.
+|}];;
+
+type ufref = { mutable contents : float# };;
+[%%expect{|
+type ufref = { mutable contents : float#; }
+|}];;
 
 (****************************************************)
 (* Test 6: Can't be put at top level of signatures. *)
@@ -493,7 +518,7 @@ Line 3, characters 14-28:
 3 | type t11_1 += A of t_float64;;
                   ^^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}]
 
 type t11_1 += B of float#;;
@@ -502,7 +527,7 @@ Line 1, characters 14-25:
 1 | type t11_1 += B of float#;;
                   ^^^^^^^^^^^
 Error: Type float# has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}]
 
 type ('a : float64) t11_2 = ..
@@ -518,7 +543,7 @@ Line 5, characters 17-24:
 5 | type 'a t11_2 += B of 'a;;
                      ^^^^^^^
 Error: Type 'a has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}]
 
 (***************************************)
@@ -699,3 +724,62 @@ Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        t_float64 has layout float64, which is not a sublayout of value.
 |}];;
+
+(***********************************************************)
+(* Test 14: unboxed float records work like normal records *)
+
+module FU = Stdlib__Float_u
+
+type t14_1 = { x : float#; y : float# }
+
+(* pattern matching *)
+let f14_1 {x;y} = FU.sub x y
+
+(* construction *)
+let r14 = { x = FU.of_float 3.14; y = FU.of_float 2.72 }
+
+let sum14_1 = FU.to_float (f14_1 r14)
+
+(* projection *)
+let f14_2 ({y;_} as r) = FU.sub r.x y
+
+let sum14_2 = FU.to_float (f14_1 r14)
+
+type t14_2 = { mutable a : float#; b : float#; mutable c : float# }
+
+let f14_3 ({b; c; _} as r) =
+  (* pure record update *)
+  let r' = { r with b = FU.of_float 20.0; c = r.a } in
+  (* mutation *)
+  r.a <- FU.sub r.a r'.b;
+  r'.a <- FU.of_float 42.0;
+  r'
+
+let a, b, c, a', b', c' =
+  let r = {a = FU.of_float 3.1; b = FU.of_float (-0.42); c = FU.of_float 27.7 } in
+  let r' = f14_3 r in
+  FU.to_float r.a,
+  FU.to_float r.b,
+  FU.to_float r.c,
+  FU.to_float r'.a,
+  FU.to_float r'.b,
+  FU.to_float r'.c
+
+
+[%%expect{|
+module FU = Stdlib__Float_u
+type t14_1 = { x : float#; y : float#; }
+val f14_1 : t14_1 -> float# = <fun>
+val r14 : t14_1 = {x = <abstr>; y = <abstr>}
+val sum14_1 : float = 0.419999999999999929
+val f14_2 : t14_1 -> float# = <fun>
+val sum14_2 : float = 0.419999999999999929
+type t14_2 = { mutable a : float#; b : float#; mutable c : float#; }
+val f14_3 : t14_2 -> t14_2 = <fun>
+val a : float = -16.9
+val b : float = -0.42
+val c : float = 27.7
+val a' : float = 42.
+val b' : float = 20.
+val c' : float = 3.1
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
@@ -206,7 +206,7 @@ Line 1, characters 14-27:
 1 | type t5_3 = { x : t_float64 } [@@unboxed];;
                   ^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Unboxed records may not yet contain types of this layout.
 |}];;
 
 type t5_4 = A of t_float64;;
@@ -215,7 +215,7 @@ Line 1, characters 12-26:
 1 | type t5_4 = A of t_float64;;
                 ^^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Variants may not yet contain types of this layout.
 |}];;
 
 type t5_5 = A of int * t_float64;;
@@ -224,7 +224,7 @@ Line 1, characters 12-32:
 1 | type t5_5 = A of int * t_float64;;
                 ^^^^^^^^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Variants may not yet contain types of this layout.
 |}];;
 
 type t5_6 = A of t_float64 [@@unboxed];;
@@ -233,7 +233,7 @@ Line 1, characters 12-26:
 1 | type t5_6 = A of t_float64 [@@unboxed];;
                 ^^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Variants may not yet contain types of this layout.
 |}];;
 
 type ('a : float64) t5_7 = A of int
@@ -244,7 +244,7 @@ Line 2, characters 27-34:
 2 | type ('a : float64) t5_8 = A of 'a;;
                                ^^^^^^^
 Error: Type 'a has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Variants may not yet contain types of this layout.
 |}]
 
 type ('a : float64, 'b : float64) t5_9 = {x : 'a; y : 'b; z : 'a}
@@ -518,7 +518,7 @@ Line 3, characters 14-28:
 3 | type t11_1 += A of t_float64;;
                   ^^^^^^^^^^^^^^
 Error: Type t_float64 has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Variants may not yet contain types of this layout.
 |}]
 
 type t11_1 += B of float#;;
@@ -527,7 +527,7 @@ Line 1, characters 14-25:
 1 | type t11_1 += B of float#;;
                   ^^^^^^^^^^^
 Error: Type float# has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Variants may not yet contain types of this layout.
 |}]
 
 type ('a : float64) t11_2 = ..
@@ -543,7 +543,7 @@ Line 5, characters 17-24:
 5 | type 'a t11_2 += B of 'a;;
                      ^^^^^^^
 Error: Type 'a has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Variants may not yet contain types of this layout.
 |}]
 
 (***************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
@@ -765,6 +765,10 @@ let a, b, c, a', b', c' =
   FU.to_float r'.b,
   FU.to_float r'.c
 
+let f14_4 r =
+  let {x; y} = r in
+  FU.add x y
+
 
 [%%expect{|
 module FU = Stdlib__Float_u
@@ -782,4 +786,5 @@ val c : float = 27.7
 val a' : float = 42.
 val b' : float = 20.
 val c' : float = 3.1
+val f14_4 : t14_1 -> float# = <fun>
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -23,7 +23,7 @@ Line 1, characters 9-20:
 1 | type t = C of float#;;
              ^^^^^^^^^^^
 Error: Type float# has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}];;
 
 type t = C : float# -> t;;
@@ -32,7 +32,7 @@ Line 1, characters 9-24:
 1 | type t = C : float# -> t;;
              ^^^^^^^^^^^^^^^
 Error: Type float# has layout float64.
-       Types of this layout are not yet allowed in blocks (like records or variants).
+       This layout is not yet allowed in blocks (except for all-float64 records).
 |}];;
 
 (* float# works as an argument to normal type constructors, not just classes,

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -23,7 +23,7 @@ Line 1, characters 9-20:
 1 | type t = C of float#;;
              ^^^^^^^^^^^
 Error: Type float# has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Variants may not yet contain types of this layout.
 |}];;
 
 type t = C : float# -> t;;
@@ -32,7 +32,7 @@ Line 1, characters 9-24:
 1 | type t = C : float# -> t;;
              ^^^^^^^^^^^^^^^
 Error: Type float# has layout float64.
-       This layout is not yet allowed in blocks (except for all-float64 records).
+       Variants may not yet contain types of this layout.
 |}];;
 
 (* float# works as an argument to normal type constructors, not just classes,

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
@@ -459,4 +459,19 @@ let _ =
   print_t9 t10_1;
   print_t9 t10_2
 
+(***********************************************)
+(* Test 11: Heterogeneous polymorphic equality *)
 
+type ex = Ex : 'a -> ex
+
+type t11_u = { xu : float#; yu : float# }
+type t11_b = { xb : float; yb : float }
+
+let ru = { xu = Float_u.of_float 3.14; yu = Float_u.of_float 42.0 }
+let rb = { xb = 3.14; yb = 42.0 }
+let rb' = { xb = 3.14; yb = 42.1 }
+
+let _ =
+  Printf.printf "Test 11, heterogeneous polymorphic equality.\n";
+  Printf.printf "  equal: %b\n" (Ex ru = Ex rb);
+  Printf.printf "  unequal: %b\n" (Ex ru = Ex rb');

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.reference
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.reference
@@ -88,3 +88,59 @@ Test 6, 34.00: 34.00
 Test 6, -46.88: -46.88
 Test 7, 36.50: 36.50
 Test 7, 32.20: 32.20
+Test 8, 610.68: : 610.68
+  Test 8, step 0: 0.00
+  Test 8, step 1: 0.00
+  Test 8, step 2: 0.00
+  Test 8, step 3: 0.00
+  Test 8, step 4: 458.01
+  Test 8, step 5: 305.34
+  Test 8, step 6: 152.67
+  Test 8, step 7: 0.00
+  Test 8, step 8: 0.00
+  Test 8, step 9: 0.00
+Test 9, construction:
+  a: 3.14
+  b: 2.72
+  c: 1.62
+  d: 1.41
+  a: -3.14
+  b: -2.72
+  c: -1.62
+  d: -1.41
+Test 9, matching and projection:
+  a: 1.62
+  b: -4.55
+  c: 0.00
+  d: 4.13
+Test 9, record update and mutation:
+  a: 3.14
+  b: 2.72
+  c: 1.62
+  d: 42.00
+  a: -3.14
+  b: 17.00
+  c: -1.62
+  d: -1.41
+  a: -3.14
+  b: 4.55
+  c: 42.00
+  d: 25.00
+Test 10, float# records in recursive groups.
+  a: 1.10
+  b: 2.20
+  c: 3.20
+  d: 4.40
+  a: -5.10
+  b: -6.20
+  c: -7.30
+  d: -8.40
+  result (-4.00): -4.00
+  a: 1.10
+  b: 2.20
+  c: 3.20
+  d: 2.20
+  a: -5.10
+  b: 42.00
+  c: -7.30
+  d: -8.40

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.reference
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.reference
@@ -144,3 +144,6 @@ Test 10, float# records in recursive groups.
   b: 42.00
   c: -7.30
   d: -8.40
+Test 11, heterogeneous polymorphic equality.
+  equal: true
+  unequal: false

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -187,6 +187,7 @@ type record_mismatch =
   | Label_mismatch of record_change list
   | Inlined_representation of position
   | Float_representation of position
+  | Ufloat_representation of position
 
 type constructor_mismatch =
   | Type of Errortrace.equality_error
@@ -360,6 +361,10 @@ let report_record_mismatch first second decl env ppf err =
       pr "@[<hv>Their internal representations differ:@ %s %s %s.@]"
         (choose ord first second) decl
         "uses unboxed float representation"
+  | Ufloat_representation ord ->
+      pr "@[<hv>Their internal representations differ:@ %s %s %s.@]"
+        (choose ord first second) decl
+        "uses float# representation"
 
 let report_constructor_mismatch first second decl env ppf err =
   let pr fmt  = Format.fprintf ppf fmt in
@@ -633,6 +638,12 @@ module Record_diffing = struct
         Some (Record_mismatch (Float_representation First))
      | _, Record_float ->
         Some (Record_mismatch (Float_representation Second))
+
+     | Record_ufloat, Record_ufloat -> None
+     | Record_ufloat, _ ->
+        Some (Record_mismatch (Ufloat_representation First))
+     | _, Record_ufloat ->
+        Some (Record_mismatch (Ufloat_representation Second))
 
      | Record_boxed _, Record_boxed _ -> None
 

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -362,6 +362,10 @@ let report_record_mismatch first second decl env ppf err =
         (choose ord first second) decl
         "uses unboxed float representation"
   | Ufloat_representation ord ->
+      (* CR layouts: This case should unreachable now.  But it may be reachable
+         when we allow [any] types in structure declarations, using an example
+         like the "unboxed float representation" one in
+         [typing-unboxed-types/test.ml].  Add a test then. *)
       pr "@[<hv>Their internal representations differ:@ %s %s %s.@]"
         (choose ord first second) decl
         "uses float# representation"

--- a/ocaml/typing/includecore.mli
+++ b/ocaml/typing/includecore.mli
@@ -61,6 +61,7 @@ type record_mismatch =
   | Label_mismatch of record_change list
   | Inlined_representation of position
   | Float_representation of position
+  | Ufloat_representation of position
 
 type constructor_mismatch =
   | Type of Errortrace.equality_error

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -213,7 +213,6 @@ module Sort = struct
   let for_probe_body = value
   let for_poly_variant = value
   let for_record = value
-  let for_record_field = value
   let for_constructor_arg = value
   let for_object = value
   let for_lazy_body = value

--- a/ocaml/typing/layouts.mli
+++ b/ocaml/typing/layouts.mli
@@ -85,7 +85,6 @@ module Sort : sig
   val for_lazy_body : t
   val for_tuple_element : t
   val for_record : t
-  val for_record_field : t
   val for_constructor_arg : t
   val for_block_element : t
   val for_array_get_result : t

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -196,6 +196,7 @@ let record_representation i ppf = let open Types in function
   | Record_inlined (t,v) ->
     line i ppf "Record_inlined (%a, %a)\n" tag t (variant_representation i) v
   | Record_float -> line i ppf "Record_float\n"
+  | Record_ufloat -> line i ppf "Record_ufloat\n"
 
 let attribute i ppf k a =
   line i ppf "%s \"%s\"\n" k a.Parsetree.attr_name.txt;

--- a/ocaml/typing/rec_check.ml
+++ b/ocaml/typing/rec_check.ml
@@ -642,7 +642,7 @@ let rec expression : Typedtree.expression -> term_judg =
     | Texp_record { fields = es; extended_expression = eo;
                     representation = rep } ->
         let field_mode = match rep with
-          | Record_float -> Dereference
+          | Record_float | Record_ufloat -> Dereference
           | Record_unboxed | Record_inlined (_,Variant_unboxed) -> Return
           | Record_boxed _ | Record_inlined _ -> Guard
         in

--- a/ocaml/typing/subst.ml
+++ b/ocaml/typing/subst.ml
@@ -439,6 +439,7 @@ let record_representation ~prepare_layout loc = function
   | Record_boxed lays ->
       Record_boxed (Array.map (prepare_layout loc) lays)
   | Record_float -> Record_float
+  | Record_ufloat -> Record_ufloat
 
 let type_declaration' copy_scope s decl =
   { type_params = List.map (typexp copy_scope s decl.type_loc) decl.type_params;

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -1910,7 +1910,7 @@ module Label = NameChoice (struct
     Env.lookup_all_labels_from_type ~loc usage path env
   let in_env lbl =
     match lbl.lbl_repres with
-    | Record_boxed _ | Record_float | Record_unboxed -> true
+    | Record_boxed _ | Record_float | Record_ufloat | Record_unboxed -> true
     | Record_inlined _ -> false
 end)
 

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1030,8 +1030,8 @@ let check_representable ~why ~allow_float env loc lloc typ =
 (* [update_label_layouts] additionally returns whether all the layouts
    were void *)
 let update_label_layouts env loc lbls named =
-  (* "named" distinguishes between top-level records (for which we need to
-     update the kind with the layouts) and inlined records *)
+  (* [named] is [Some layouts] for top-level records (we will update the
+     layouts) and [None] for inlined records. *)
   (* CR layouts v5: it wouldn't be too hard to support records that are all
      void.  just needs a bit of refactoring in translcore *)
   let update =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -73,6 +73,7 @@ type error =
   | Layout_empty_record
   | Non_value_in_sig of Layout.Violation.t * string
   | Float64_in_block of type_expr
+  | Mixed_block
   | Separability of Typedecl_separability.error
   | Bad_unboxed_attribute of string
   | Boxed_and_unboxed
@@ -1003,7 +1004,7 @@ let check_abbrev env sdecl (id, decl) =
    should be replaced with checks at the places where values of those types are
    constructed.  We've been conservative here in the first version. This is the
    same issue as with arrows. *)
-let check_representable ~why env loc lloc typ =
+let check_representable ~why ~allow_float env loc lloc typ =
   match Ctype.type_sort ~why env typ with
   (* CR layouts v3: This is a convenient place to rule out [float#] in
      structures for now, as it is called on all the types in declared blocks in
@@ -1017,6 +1018,7 @@ let check_representable ~why env loc lloc typ =
          all the defaulting, so we don't expect this actually defaults the
          sort - we just want the [const]. *)
       | Void | Value -> ()
+      | Float64 when allow_float -> ()
       | Float64 -> raise (Error (loc, Float64_in_block typ))
     end
   | Error err -> raise (Error (loc,Layout_sort {lloc; typ; err}))
@@ -1040,7 +1042,7 @@ let update_label_layouts env loc lbls named =
   let lbls =
     List.mapi (fun idx (Types.{ld_type; ld_id; ld_loc} as lbl) ->
       check_representable ~why:(Label_declaration ld_id)
-        env ld_loc Record ld_type;
+        ~allow_float:(Option.is_some named) env ld_loc Record ld_type;
       let ld_layout = Ctype.type_layout env ld_type in
       update idx ld_layout;
       {lbl with ld_layout}
@@ -1058,7 +1060,7 @@ let update_constructor_arguments_layouts env loc cd_args layouts =
   match cd_args with
   | Types.Cstr_tuple tys ->
     List.iteri (fun idx (ty,_) ->
-      check_representable ~why:(Constructor_declaration idx)
+      check_representable ~why:(Constructor_declaration idx) ~allow_float:false
         env loc Cstr_tuple ty;
       layouts.(idx) <- Ctype.type_layout env ty) tys;
     cd_args, Array.for_all Layout.is_void_defaulting layouts
@@ -1066,6 +1068,10 @@ let update_constructor_arguments_layouts env loc cd_args layouts =
     let lbls, all_void = update_label_layouts env loc lbls None in
     layouts.(0) <- Layout.value ~why:Boxed_record;
     Types.Cstr_record lbls, all_void
+
+(* For tracking what types appear in record blocks. *)
+type has_values = Has_values | No_values
+type has_float64s = Has_float64s | No_float64s
 
 (* This function updates layout stored in kinds with more accurate layouts.
    It is called after the circularity checks and the delayed layout checks
@@ -1081,13 +1087,31 @@ let update_decl_layout env dpath decl =
   let update_record_kind loc lbls rep =
     match lbls, rep with
     | [Types.{ld_type; ld_id; ld_loc} as lbl], Record_unboxed ->
-      check_representable ~why:(Label_declaration ld_id)
+      check_representable ~why:(Label_declaration ld_id) ~allow_float:false
         env ld_loc Record ld_type;
       let ld_layout = Ctype.type_layout env ld_type in
       [{lbl with ld_layout}], Record_unboxed, ld_layout
     | _, Record_boxed layouts ->
       let lbls, all_void = update_label_layouts env loc lbls (Some layouts) in
       let layout = Layout.for_boxed_record ~all_void in
+      let has_values, has_floats =
+        Array.fold_left
+          (fun (values, floats) layout ->
+             match Layout.get_default_value layout with
+             | Value | Immediate64 | Immediate -> (Has_values, floats)
+             | Float64 -> (values, Has_float64s)
+             | Void -> (values, floats)
+             | Any -> assert false)
+          (No_values, No_float64s) layouts
+      in
+      let rep =
+        match has_values, has_floats with
+        | Has_values, Has_float64s -> raise (Error (loc, Mixed_block))
+        | Has_values, No_float64s -> rep
+        | No_values, Has_float64s -> Record_ufloat
+        | No_values, No_float64s ->
+          Misc.fatal_error "Typedecl.update_record_kind: empty record"
+      in
       lbls, rep, layout
     | _, Record_float ->
       (* CR layouts v2.5: When we have an unboxed float layout, does it make
@@ -1099,7 +1123,8 @@ let update_decl_layout env dpath decl =
           lbls
       in
       lbls, rep, Layout.value ~why:Boxed_record
-    | (([] | (_ :: _)), Record_unboxed | _, Record_inlined _) -> assert false
+    | (([] | (_ :: _)), Record_unboxed
+      | _, (Record_inlined _ | Record_ufloat)) -> assert false
   in
 
   (* returns updated constructors, updated rep, and updated layout *)
@@ -1110,13 +1135,13 @@ let update_decl_layout env dpath decl =
         match cd_args with
         | Cstr_tuple [ty,_] -> begin
             check_representable ~why:(Constructor_declaration 0)
-              env cd_loc Cstr_tuple ty;
+              ~allow_float:false env cd_loc Cstr_tuple ty;
             let layout = Ctype.type_layout env ty in
             cstrs, Variant_unboxed, layout
           end
         | Cstr_record [{ld_type; ld_id; ld_loc} as lbl] -> begin
             check_representable ~why:(Label_declaration ld_id)
-              env ld_loc Record ld_type;
+              ~allow_float:false env ld_loc Record ld_type;
             let ld_layout = Ctype.type_layout env ld_type in
             [{ cstr with Types.cd_args =
                            Cstr_record [{ lbl with ld_layout }] }],
@@ -2552,9 +2577,12 @@ let report_error ppf = function
       val_name (Layout.Violation.report_with_name ~name:val_name) err
   | Float64_in_block typ ->
     fprintf ppf
-      "@[Type %a has layout float64.@ Types of this layout are not yet \
-       allowed in blocks (like records or variants).@]"
+      "@[Type %a has layout float64.@ This layout is not yet allowed in blocks \
+       (except for all-float64 records).@]"
       Printtyp.type_expr typ
+  | Mixed_block  ->
+    fprintf ppf
+      "@[Records may not contain both unboxed floats and normal values.@]"
   | Bad_unboxed_attribute msg ->
       fprintf ppf "@[This type cannot be unboxed because@ %s.@]" msg
   | Separability (Typedecl_separability.Non_separable_evar evar) ->

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -111,6 +111,7 @@ type error =
   | Layout_empty_record
   | Non_value_in_sig of Layout.Violation.t * string
   | Float64_in_block of type_expr
+  | Mixed_block
   | Separability of Typedecl_separability.error
   | Bad_unboxed_attribute of string
   | Boxed_and_unboxed

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -110,7 +110,7 @@ type error =
       }
   | Layout_empty_record
   | Non_value_in_sig of Layout.Violation.t * string
-  | Float64_in_block of type_expr
+  | Float64_in_block of type_expr * layout_sort_loc
   | Mixed_block
   | Separability of Typedecl_separability.error
   | Bad_unboxed_attribute of string

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -518,8 +518,16 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
                  sort (we can get this info from the label.ld_layout).  For now
                  we rely on the layout check at the top of value_kind to rule
                  out void. *)
-              value_kind env ~loc ~visited ~depth ~num_nodes_visited
-                label.ld_type
+              match rep with
+              | Record_float | Record_ufloat ->
+                (* We're using the `Pfloatval` value kind for unboxed floats.
+                   This is kind of a lie (there are unboxed floats in here, not
+                   boxed floats), but that was already happening here due to the
+                   float record optimization. *)
+                num_nodes_visited, Pfloatval
+              | Record_boxed _ | Record_inlined _ | Record_unboxed ->
+                value_kind env ~loc ~visited ~depth ~num_nodes_visited
+                  label.ld_type
             in
             (is_mutable, num_nodes_visited), field)
           (false, num_nodes_visited) labels
@@ -531,9 +539,8 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
           match rep with
           | Record_inlined (Ordinary {runtime_tag}, _) ->
             [runtime_tag, fields]
-          | Record_float ->
-            [ Obj.double_array_tag,
-              List.map (fun _ -> Pfloatval) fields ]
+          | Record_float | Record_ufloat ->
+            [ Obj.double_array_tag, fields ]
           | Record_boxed _ ->
             [0, fields]
           | Record_inlined (Extension _, _) ->

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -226,6 +226,7 @@ and record_representation =
   | Record_inlined of tag * variant_representation
   | Record_boxed of layout array
   | Record_float
+  | Record_ufloat
 
 and variant_representation =
   | Variant_unboxed
@@ -520,7 +521,10 @@ let equal_record_representation r1 r2 = match r1, r2 with
       Misc.Stdlib.Array.equal Layout.equal lays1 lays2
   | Record_float, Record_float ->
       true
-  | (Record_unboxed | Record_inlined _ | Record_boxed _ | Record_float), _ ->
+  | Record_ufloat, Record_ufloat ->
+      true
+  | (Record_unboxed | Record_inlined _ | Record_boxed _ | Record_float
+    | Record_ufloat ), _ ->
       false
 
 let may_equal_constr c1 c2 =
@@ -546,7 +550,7 @@ let find_unboxed_type decl =
                   Variant_unboxed) ->
     Some arg
   | Type_record (_, ( Record_inlined _ | Record_unboxed
-                    | Record_boxed _ | Record_float ))
+                    | Record_boxed _ | Record_float | Record_ufloat ))
   | Type_variant (_, ( Variant_boxed _ | Variant_unboxed
                      | Variant_extensible ))
   | Type_abstract | Type_open ->

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -523,7 +523,10 @@ and record_representation =
      contains it and the tag of the relevant constructor of that variant. *)
   | Record_boxed of layout array
   | Record_float (* All fields are floats *)
-
+  | Record_ufloat
+  (* All fields are [float#]s.  Same runtime representation as [Record_float],
+     but operations on these (e.g., projection, update) work with unboxed floats
+     rather than boxed floats. *)
 
 (* For unboxed variants, we record the layout of the mandatory single argument.
    For boxed variants, we record the layouts for the arguments of each

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -785,6 +785,9 @@ type label_description =
     lbl_attributes: Parsetree.attributes;
     lbl_uid: Uid.t;
   }
+(* CR layouts v5: once we allow [any] in record fields, change [lbl_layout] to
+   be a [sort option].  This will allow a fast path for representability checks
+   at record construction, and currently only the sort is used anyway. *)
 
 (** The special value we assign to lbl_pos for label descriptions corresponding
     to void types, because they can't sensibly be projected.


### PR DESCRIPTION
This adds support for records with only `float#`s in them, building on the existing float record optimization.

There are three commits.  The first fixes a small but rather bad bug that has been sitting in transl for a while, but was hard to reach until now.  The second has the actual record stuff. The third fixes another bug.

This PR takes a couple shortcuts in its approach (both of which I think are the right thing in the short term, but I'm open to debate):

**When to check what records to allow:**  Currently, we do this while checking type declarations, even though I know we'll eventually want to move it to where we typecheck record construction.  I think that should be done with all the similar restrictions after the modal kinds work.

**How to handle float# records in lambda and beyond:**  Currently, the compiler has a bunch of primitives for working with optimized float records.  They all do both a record manipulation _and_ a step of boxing or unboxing.  For example `Pfloatfield` gets a float from such a record, and boxes it.  But, obviously, if we're projecting from a `float#` record, the result shouldn't be boxed.

I can imagine three ways to to deal with that:
- Just use the float record primitives anyway and then add extra boxing/unboxing where appropriate, and hope the middle-end will erase the extra steps.  ~~This is what I've done.  I added allocation tests to check the extra work gets erased.~~
- Just use the normal record primitives, rather than the float record primitives, for `float#` records.  After all, we just want to project or update without any extra boxing or unboxing, and that's what they do.  I tried this and it causes segfaults which I did not investigate - presumably later stages of the compiler make assumptions about what types those primitives can work on.
- Add new primitives that work on unboxed types.  This is probably the right thing in the long term, but obviously more work. ~~I suggest we plan to do it when we solve the mixed block restriction and allow more general records.~~

Update: This PR now adds the new primitives.  A previous version took approach 1 instead, but see the discussion below for a case where the middle-end can't remove the extra steps.
