### PR TITLE
Add dune target for `dumpobj`

### DIFF
--- a/ocaml/tools/dune
+++ b/ocaml/tools/dune
@@ -44,6 +44,22 @@
   (section bin)
   (package ocaml))
 
+(rule
+  (target opnames.ml)
+  (deps make_opcodes.exe (universe))
+  (action (system "./make_opcodes.exe -opnames < ../../ocaml/runtime/caml/instruct.h > opnames.ml")))
+
+(library
+  (name opnames)
+  (modes byte)
+  (modules opnames))
+
+(executable
+  (name dumpobj)
+  (modes byte)
+  (modules dumpobj)
+  (libraries ocamlcommon ocamlbytecomp opnames))
+
 (executable
   (name cmpbyt)
   (modes byte)


### PR DESCRIPTION
This just adds a dune target for `dumpobj`.  You can build it from the project root with
```
$ dune build ocaml/tools/dumpobj.exe
```
Or run it with:
```
$ dune exec ocaml/tools/dumpobj.exe ./a.out
```
Perhaps some way already exists to build this with the new build system, in which case this PR is useless, but I couldn't find one.