### PR TITLE
Loosen ownership of build files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,6 @@
 
 autoconf-aux            @mshinwell @xclerc
 configure.ac            @mshinwell @xclerc
-**/dune                 @mshinwell @xclerc
-**/dune-project         @mshinwell @xclerc
-Makefile.in             @mshinwell @xclerc
 
 flambda_backend.opam    @mshinwell @lthls
 


### PR DESCRIPTION
Having all changes to the `dune` (etc.) files go through @mshinwell and @xclerc is very restrictive, and doesn't seem necessary.  This PR drops that requirement, and leaves them owned by whoever owns the directory they reside in.

This PR was inspired by this requirement delaying #1777.