### PR TITLE
Build Jane Syntax with upstream OCaml in CI

### DIFF
--- a/.github/workflows/jane_syntax.yml
+++ b/.github/workflows/jane_syntax.yml
@@ -1,0 +1,42 @@
+name: jane-syntax-upstream-build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        ocaml-compiler:
+          - "4.14.0"
+
+    steps:
+    - name: Checkout the Flambda backend repo
+      uses: actions/checkout@master
+      with:
+        path: 'flambda_backend'
+
+    - name: Setup OCaml ${{ matrix.ocaml-compiler }}
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+    - name: Try building Jane_syntax and its dependencies with upstream OCaml
+      working-directory: flambda_backend
+      run: |
+        # Stub [Language_extension] in the same way we do internally.
+        echo "include Language_extension_kernel let is_enabled _ = true let is_at_least _ _ = true" > language_extension.ml
+        if ! \
+          opam exec -- ocamlc -stop-after typing \
+            -I +compiler-libs -I ocaml/utils -I ocaml/parsing \
+            ocaml/utils/language_extension_kernel.{mli,ml} \
+            language_extension.ml \
+            ocaml/parsing/jane_asttypes.mli \
+            ocaml/parsing/{jane_syntax_parsing,jane_syntax}.{mli,ml}
+        then
+          echo "Jane Syntax files failed to build with upstream OCaml"
+          echo "See Note [Buildable with upstream] in ocaml/parsing/jane_syntax.mli"
+          exit 2
+        fi

--- a/.github/workflows/jane_syntax.yml
+++ b/.github/workflows/jane_syntax.yml
@@ -25,18 +25,4 @@ jobs:
 
     - name: Try building Jane_syntax and its dependencies with upstream OCaml
       working-directory: flambda_backend
-      run: |
-        # Stub [Language_extension] in the same way we do internally.
-        echo "include Language_extension_kernel let is_enabled _ = true let is_at_least _ _ = true" > language_extension.ml
-        if ! \
-          opam exec -- ocamlc -stop-after typing \
-            -I +compiler-libs -I ocaml/utils -I ocaml/parsing \
-            ocaml/utils/language_extension_kernel.{mli,ml} \
-            language_extension.ml \
-            ocaml/parsing/jane_asttypes.mli \
-            ocaml/parsing/{jane_syntax_parsing,jane_syntax}.{mli,ml}
-        then
-          echo "Jane Syntax files failed to build with upstream OCaml"
-          echo "See Note [Buildable with upstream] in ocaml/parsing/jane_syntax.mli"
-          exit 2
-        fi
+      run: opam exec -- ocaml/tools/build_jane_syntax_with_active_opam_switch.sh

--- a/ocaml/tools/build_jane_syntax_with_active_opam_switch.sh
+++ b/ocaml/tools/build_jane_syntax_with_active_opam_switch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/ocaml/tools/build_jane_syntax_with_active_opam_switch.sh
+++ b/ocaml/tools/build_jane_syntax_with_active_opam_switch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Build Jane Syntax files with the opam switch's OCaml. This verifies
 # that they can be put into public release with minimal changes;
 # see Note [Buildable with upstream] in ocaml/parsing/jane_syntax.mli
@@ -14,13 +16,19 @@ files_in_dependency_order=(
 )
 
 function basenames_in_dependency_order() {
-  echo "${files_in_dependency_order[@]}" | xargs -n 1 basename
+  printf "%s\n" "${files_in_dependency_order[@]}" | xargs -n 1 basename
+}
+
+# language_extension.ml is stubbed later, so we don't copy anything
+# from ocaml/ for it.
+function source_files_in_ocaml_dir() {
+  printf "%s\n" "${files_in_dependency_order[@]}" | grep -v '^language_extension.ml$'
 }
 
 # Copy files to another directory before compiling so we're confident
 # we're not using the build artifacts of an earlier build.
 tmp=$(mktemp -d)
-cp "${files_in_dependency_order[@]}" "$tmp" 2>/dev/null || true
+cp $(source_files_in_ocaml_dir) "$tmp"
 
 cd "$tmp"
 

--- a/ocaml/tools/build_jane_syntax_with_active_opam_switch.sh
+++ b/ocaml/tools/build_jane_syntax_with_active_opam_switch.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Build Jane Syntax files with the opam switch's OCaml. This verifies
+# that they can be put into public release with minimal changes;
+# see Note [Buildable with upstream] in ocaml/parsing/jane_syntax.mli
+
+cd $(git rev-parse --show-toplevel)/ocaml
+
+files_in_dependency_order=(
+  utils/language_extension_kernel.{mli,ml}
+  language_extension.ml
+  parsing/jane_asttypes.mli
+  parsing/{jane_syntax_parsing,jane_syntax}.{mli,ml}
+)
+
+function basenames_in_dependency_order() {
+  echo "${files_in_dependency_order[@]}" | xargs -n 1 basename
+}
+
+# Copy files to another directory before compiling so we're confident
+# we're not using the build artifacts of an earlier build.
+tmp=$(mktemp -d)
+cp "${files_in_dependency_order[@]}" "$tmp" 2>/dev/null || true
+
+cd "$tmp"
+
+# Stub [Language_extension] in the same way we do internally.
+cat > language_extension.ml <<EOF
+include Language_extension_kernel
+let is_enabled _ = true
+let is_at_least _ _ = true
+EOF
+
+if ! ocamlc -stop-after typing -I +compiler-libs \
+  $(basenames_in_dependency_order)
+then
+  echo "Jane Syntax files failed to build with upstream OCaml"
+  echo "See Note [Buildable with upstream] in ocaml/parsing/jane_syntax.mli"
+  exit 2
+else
+  # Print the typechecked interfaces to support the assertion that this check
+  # is actually checking anything.
+  echo "Jane Syntax files built with upstream OCaml:"
+  ocamlc -i -I +compiler-libs $(basenames_in_dependency_order)
+fi


### PR DESCRIPTION
Add a new CI to check that Jane Syntax files are buildable with upstream OCaml. Our public release process of `ppxlib_jane`, which includes Jane Syntax files, goes much more smoothly if this is the case &mdash; we like importing Jane Syntax files with minimal changes.

This CI will fail when the PR author has made a change to Jane Syntax files that makes it depend on bindings that aren't present in upstream OCaml. As such, the only people who should be affected by this CI are people making changes to Jane Syntax who should already have quite a bit of context on it &mdash; people who work primarily on the middle and back-ends should not be affected.

Example output when the test fails:
```
File "ocaml/parsing/jane_syntax.mli", line 137, characters 30-61:
137 |         string Asttypes.loc * Jane_asttypes.layout_annotation option
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Jane_asttypes
Jane Syntax files failed to build with upstream OCaml
See Note [Buildable with upstream] in ocaml/parsing/jane_syntax.mli
Error: Process completed with exit code 2.
```
See also [this job output](https://github.com/ocaml-flambda/flambda-backend/actions/runs/6025772263/job/16347227073), which shows what this failure looks like in the context of CI. (Though I've added extra detail to the error message since this job ran.)

**Reviewers**: @antalsz for making sure the check accomplishes what I've described above; @mshinwell or @xclerc for making sure the CI-related parts look OK before merging.