### PR TITLE
Fix a bug in the handling of regions with exclaves

### DIFF
--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -661,7 +661,6 @@ let lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region =
      let nparams = List.length params in
      assert (0 <= nlocal);
      assert (nlocal <= nparams);
-     if not region then assert (nlocal >= 1);
      if is_local_mode mode then assert (nlocal = nparams)
   end;
   Lfunction { kind; params; return; body; attr; loc; mode; region }

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -843,9 +843,8 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
   try
     (* TODO: enable this optimisation even in the presence of local returns *)
     begin match kind with
-    | Curried {nlocal} when nlocal > 0 -> raise Exit
-    | Tupled when not orig_region -> raise Exit
-    | _ -> assert orig_region
+    | Curried {nlocal = 0} | Tupled when orig_region -> ()
+    | _ -> raise Exit
     end;
     let body, inner = aux [] false body in
     let attr = { default_stub_attribute with check = attr.check } in

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -127,14 +127,22 @@ let transl_apply_position position =
     if Config.stack_allocation then Rc_close_at_apply
     else Rc_normal
 
+let iter_exclaves ~f lam =
+  let rec loop ~depth = function
+    | Lregion (body, _layout) ->
+      loop ~depth:(depth + 1) body
+    | Lexclave excl when depth = 0 -> f excl
+    | Lexclave excl ->
+      loop ~depth:(depth - 1) excl
+    | lam ->
+      shallow_iter lam
+        ~tail:(loop ~depth)
+        ~non_tail:ignore (* Exclaves are in tail position *)
+  in
+  loop ~depth:0 lam
+
 let may_allocate_in_region lam =
-  (* loop_region raises, if the lambda might allocate in parent region *)
-  let rec loop_region lam =
-    shallow_iter ~tail:(function
-      | Lexclave body -> loop body
-      | lam -> loop_region lam
-    ) ~non_tail:(fun lam -> loop_region lam) lam
-  and loop = function
+  let rec loop = function
     | Lvar _ | Lmutvar _ | Lconst _ -> ()
 
     | Lfunction {mode=Alloc_heap} -> ()
@@ -152,7 +160,7 @@ let may_allocate_in_region lam =
     | Lregion (body, _layout) ->
        (* [body] might allocate in the parent region because of exclave, and thus
           [Lregion body] might allocate in the current region *)
-      loop_region body
+      iter_exclaves ~f:loop body
     | Lexclave _body ->
       (* [_body] might do local allocations, but not in the current region;
         rather, it's in the parent region *)
@@ -1290,7 +1298,6 @@ and transl_tupled_function
           Matching.for_tupled_function ~scopes ~return_layout loc params
             (transl_tupled_cases ~scopes return_sort pats_expr_list) partial
         in
-        let region = region || not (may_allocate_in_region body) in
         ((Tupled, tparams, return_layout, region), body)
     with Matching.Cannot_flatten ->
       transl_function0 ~scopes ~arg_sort ~arg_layout ~arg_mode ~return_sort ~return_layout
@@ -1306,12 +1313,10 @@ and transl_function0
       Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout loc
         repr (Lvar param) (transl_cases ~scopes return_sort cases) partial
     in
-    let region = region || not (may_allocate_in_region body) in
     let nlocal =
-      if not region then 1
-      else match partial_mode with
-        | Alloc_local -> 1
-        | Alloc_heap -> 0
+      match partial_mode with
+      | Alloc_local -> 1
+      | Alloc_heap -> 0
     in
     let arg_mode = transl_alloc_mode arg_mode in
     ((Curried {nlocal},
@@ -1343,7 +1348,9 @@ and transl_function ~scopes e alloc_mode param arg_mode arg_sort return_sort
   let attr = default_function_attribute in
   let loc = of_location ~scopes e.exp_loc in
   let body = if region then maybe_region_layout return body else body in
-  let lam = lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region in
+  let may_locally_allocate_in_parent = may_allocate_in_region body in
+  let lam = lfunction ~kind ~params ~return ~body ~attr ~loc ~mode
+              ~region:(not may_locally_allocate_in_parent) in
   let attrs =
     (* Collect attributes from the Pexp_newtype node for locally abstract types.
        Otherwise we'd ignore the attribute in, e.g.;

--- a/ocaml/testsuite/tests/typing-local/regions.ml
+++ b/ocaml/testsuite/tests/typing-local/regions.ml
@@ -317,4 +317,15 @@ let () =
      happened in our region instead *)
   check_empty "allocation from exclave"
 
+let exclave_curry x y = exclave_ (fun z -> x + y + z)
+
+let use_exclave_curry () =
+  let f = exclave_curry 1 2 in
+  let n = f 3 in
+  assert (n = 6)
+
+let () =
+  use_exclave_curry ();
+  check_empty "exclave curry"
+
 let () = Gc.compact ()

--- a/ocaml/testsuite/tests/typing-local/regions.reference
+++ b/ocaml/testsuite/tests/typing-local/regions.reference
@@ -30,3 +30,4 @@ dynamic/partial overapply: OK
          method overapply: OK
       mode-crossed region: OK
   allocation from exclave: OK
+            exclave curry: OK


### PR DESCRIPTION
There is a well-named field in `Typedtree.Texp_function` called `region`: it is true if this function has a region.

There is a badly-named field in `Lambda.lfunction` called `region`: it is true if this function cannot allocate locals in its caller's region.

These two ideas used to coincide, but they don't since the addition of exclaves, which allow a function with a region (`Texp_function{region = true}`) to allocate locals in its caller's region inside an `exclave_`. This means it is incorrect to directly initialise the `region` field of `lfunction` with that of `Texp_function`.

This patch fixes the issue by computing the `region` field of lfunction by examining the body. It also weakens the invariants slightly on lfunction: it is no longer the case that `region=false` implies `nlocals>0`. (This only mattered to inhibit a function-merging optimisation in Simplif that is not valid in this case, but that optimisation is already inhibited by `region=false` alone).