### PR TITLE
Simplify projections in static constants

### DIFF
--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -133,6 +133,64 @@ module Definition = struct
         closure_symbols_with_types Symbol.Map.empty
     | Block_like { symbol; denv; ty; _ } ->
       Symbol.Map.singleton symbol (denv, ty)
+
+  let simplify_projections t denv =
+    let typing_env = DE.typing_env denv in
+    let symbol_projections, vars_to_replace =
+      Variable.Map.fold (fun proj_var projection (symbol_projections, vars_to_replace) ->
+          let keep () =
+            Variable.Map.add proj_var projection symbol_projections, vars_to_replace
+          in
+          let replace simple =
+            symbol_projections, Variable.Map.add proj_var simple vars_to_replace
+          in
+          if T.Typing_env.mem ~min_name_mode:Name_mode.normal typing_env (Name.var proj_var)
+          then
+            (* No need to try to replace it, it is already bound *)
+            keep ()
+          else
+            let symbol = Symbol_projection.symbol projection in
+            let ty = T.alias_type_of Flambda_kind.value (Simple.symbol symbol) in
+            let meet_shortcut =
+              match Symbol_projection.projection projection with
+              | Block_load { index } ->
+                let field_kind =
+                  Symbol_projection.kind projection |> Flambda_kind.With_subkind.kind
+                in
+                T.meet_block_field_simple typing_env ~min_name_mode:Name_mode.normal
+                  ~field_kind ty index
+              | Project_value_slot { project_from = _; value_slot } ->
+                T.meet_project_value_slot_simple typing_env
+                  ~min_name_mode:Name_mode.normal ty value_slot
+            in
+            match meet_shortcut with
+            | Known_result simple -> replace simple
+            | Need_meet -> keep ()
+            | Invalid ->
+              (* Propagating Invalid would be too cumbersome *)
+              keep ())
+        (symbol_projections t) (Variable.Map.empty, Variable.Map.empty)
+    in
+    if Variable.Map.is_empty vars_to_replace then t
+    else
+      match Rebuilt_static_const.to_const t.defining_expr with
+      | None -> t
+      | Some (Code _ | Deleted_code) -> t
+      | Some (Static_const const) ->
+        let defining_expr = Static_const.replace_vars const ~vars_to_replace in
+        let defining_expr =
+          Rebuilt_static_const.from_const
+            (Flambda.Static_const_or_code.create_static_const defining_expr)
+        in
+        let descr =
+          match t.descr with
+          | Code _ -> t.descr
+          | Set_of_closures { denv; closure_symbols_with_types; symbol_projections = _ } ->
+            Set_of_closures { denv; closure_symbols_with_types; symbol_projections }
+          | Block_like { symbol; denv; ty; symbol_projections = _ } ->
+            Block_like { symbol; denv; ty; symbol_projections }
+        in
+        { descr; defining_expr }
 end
 
 type t =
@@ -322,3 +380,10 @@ let apply_projection t proj =
     Misc.fatal_errorf
       "Symbol projection@ %a@ matches more than one constant in:@ %a"
       Symbol_projection.print proj print t
+
+let simplify_projections t denv =
+  concat
+    (List.map
+       (fun definition ->
+          create_definition (Definition.simplify_projections definition denv))
+       t.definitions)

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.mli
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.mli
@@ -114,3 +114,5 @@ val all_defined_symbols : t -> Symbol.Set.t
 val free_names_of_defining_exprs : t -> Name_occurrences.t
 
 val apply_projection : t -> Symbol_projection.t -> Simple.t option
+
+val simplify_projections : t -> Downwards_env.t -> t

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -219,6 +219,9 @@ let to_const t =
     None
   | Normal { const; _ } -> Some const
 
+let from_const (const : Static_const_or_code.t) =
+  Normal { const; free_names = Static_const_or_code.free_names const }
+
 let [@ocamlformat "disable"] print ppf t =
   match t with
   | Normal { const; _ } -> Static_const_or_code.print ppf const

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -98,6 +98,8 @@ val make_code_deleted : t -> if_code_id_is_member_of:Code_id.Set.t -> t
 (** This will return [None] if terms are not being rebuilt. *)
 val to_const : t -> Static_const_or_code.t option
 
+val from_const : Static_const_or_code.t -> t
+
 module Group : sig
   type t
 

--- a/middle_end/flambda2/terms/static_const.ml
+++ b/middle_end/flambda2/terms/static_const.ml
@@ -423,3 +423,162 @@ let match_against_bound_static_pattern t (pat : Bound_static.Pattern.t)
       (Set_of_closures _ | Code _) ) ->
     Misc.fatal_errorf "Mismatch on variety of [Static_const]:@ %a@ =@ %a"
       Bound_static.Pattern.print pat print t
+
+let replace_field_of_static_block ~vars_to_replace field =
+  let module F = Field_of_static_block in
+  match (field : F.t) with
+  | Symbol _ | Tagged_immediate _ -> field
+  | Dynamically_computed (var, dbg) ->
+    begin match Variable.Map.find_opt var vars_to_replace with
+      | None -> field
+      | Some simple ->
+        Simple.pattern_match' simple
+          ~var:(fun var ~coercion:_ -> F.Dynamically_computed (var, dbg))
+          ~symbol:(fun sym ~coercion:_ -> F.Symbol sym)
+          ~const:(fun const -> match Reg_width_const.descr const with
+              | Tagged_immediate imm -> F.Tagged_immediate imm
+              | Naked_immediate _ | Naked_float _ | Naked_int32 _
+              | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ ->
+                Misc.fatal_errorf "Wrong constant for field of static block %a"
+                  Reg_width_const.print const)
+    end
+
+let replace_or_variable ~vars_to_replace ~from_const or_var =
+  match (or_var : _ Or_variable.t) with
+  | Const _ -> or_var
+  | Var (var, dbg) ->
+    begin match Variable.Map.find_opt var vars_to_replace with
+      | None -> or_var
+      | Some simple ->
+        Simple.pattern_match' simple
+          ~var:(fun var ~coercion:_ -> Or_variable.Var (var, dbg))
+          ~symbol:(fun sym ~coercion:_ ->
+              Misc.fatal_errorf "Unexpected symbol %a for replacing %a"
+                Symbol.print sym Variable.print var)
+          ~const:(fun const -> Or_variable.Const (from_const const))
+    end
+
+let from_float_const (const : Reg_width_const.t) =
+  match Reg_width_const.descr const with
+  | Naked_float f -> f
+  | Naked_immediate _
+  | Tagged_immediate _
+  | Naked_int32 _
+  | Naked_int64 _
+  | Naked_nativeint _
+  | Naked_vec128 _ ->
+    Misc.fatal_errorf "Wrong constant type for %a (expected float)"
+      Reg_width_const.print const
+
+let from_int32_const (const : Reg_width_const.t) =
+  match Reg_width_const.descr const with
+  | Naked_int32 i -> i
+  | Naked_immediate _
+  | Tagged_immediate _
+  | Naked_float _
+  | Naked_int64 _
+  | Naked_nativeint _
+  | Naked_vec128 _ ->
+    Misc.fatal_errorf "Wrong constant type for %a (expected int32)"
+      Reg_width_const.print const
+
+let from_int64_const (const : Reg_width_const.t) =
+  match Reg_width_const.descr const with
+  | Naked_int64 i -> i
+  | Naked_immediate _
+  | Tagged_immediate _
+  | Naked_float _
+  | Naked_int32 _
+  | Naked_nativeint _
+  | Naked_vec128 _ ->
+    Misc.fatal_errorf "Wrong constant type for %a (expected int64)"
+      Reg_width_const.print const
+
+let from_nativeint_const (const : Reg_width_const.t) =
+  match Reg_width_const.descr const with
+  | Naked_nativeint i -> i
+  | Naked_immediate _
+  | Tagged_immediate _
+  | Naked_float _
+  | Naked_int32 _
+  | Naked_int64 _
+  | Naked_vec128 _ ->
+    Misc.fatal_errorf "Wrong constant type for %a (expected nativeint)"
+      Reg_width_const.print const
+
+let from_vec128_const (const : Reg_width_const.t) =
+  match Reg_width_const.descr const with
+  | Naked_vec128 v -> v
+  | Naked_immediate _
+  | Tagged_immediate _
+  | Naked_float _
+  | Naked_int32 _
+  | Naked_int64 _
+  | Naked_nativeint _ ->
+    Misc.fatal_errorf "Wrong constant type for %a (expected vec128)"
+      Reg_width_const.print const
+
+let replace_vars t ~vars_to_replace =
+  match t with
+  | Set_of_closures set ->
+    let value_slots = Set_of_closures.value_slots set in
+    let function_decls = Set_of_closures.function_decls set in
+    let alloc_mode = Set_of_closures.alloc_mode set in
+    let value_slots =
+      Value_slot.Map.map (fun simple ->
+          match Simple.must_be_var simple with
+          | None -> simple
+          | Some (var, coercion) ->
+            begin match Variable.Map.find_opt var vars_to_replace with
+              | None -> simple
+              | Some simple -> Simple.apply_coercion_exn simple coercion
+            end)
+        value_slots
+    in
+    Set_of_closures (Set_of_closures.create ~value_slots alloc_mode function_decls)
+  | Block (tag, mut, fields) ->
+    let fields =
+      List.map (replace_field_of_static_block ~vars_to_replace) fields
+    in
+    Block (tag, mut, fields)
+  | Boxed_float contents ->
+    let contents =
+      replace_or_variable ~vars_to_replace ~from_const:from_float_const contents
+    in
+    Boxed_float contents
+  | Boxed_int32 contents ->
+    let contents =
+      replace_or_variable ~vars_to_replace ~from_const:from_int32_const contents
+    in
+    Boxed_int32 contents
+  | Boxed_int64 contents ->
+    let contents =
+      replace_or_variable ~vars_to_replace ~from_const:from_int64_const contents
+    in
+    Boxed_int64 contents
+  | Boxed_nativeint contents ->
+    let contents =
+      replace_or_variable ~vars_to_replace ~from_const:from_nativeint_const contents
+    in
+    Boxed_nativeint contents
+  | Boxed_vec128 contents ->
+    let contents =
+      replace_or_variable ~vars_to_replace ~from_const:from_vec128_const contents
+    in
+    Boxed_vec128 contents
+  | Immutable_float_block fields ->
+    let fields =
+      List.map (replace_or_variable ~vars_to_replace ~from_const:from_float_const) fields
+    in
+    Immutable_float_block fields
+  | Immutable_float_array fields ->
+    let fields =
+      List.map (replace_or_variable ~vars_to_replace ~from_const:from_float_const) fields
+    in
+    Immutable_float_array fields
+  | Immutable_value_array fields ->
+    let fields =
+      List.map (replace_field_of_static_block ~vars_to_replace) fields
+    in
+    Immutable_value_array fields
+  | Empty_array | Mutable_string _ | Immutable_string _ -> t

--- a/middle_end/flambda2/terms/static_const.mli
+++ b/middle_end/flambda2/terms/static_const.mli
@@ -100,3 +100,5 @@ val match_against_bound_static_pattern :
     (closure_symbols:Symbol.t Function_slot.Lmap.t -> Set_of_closures.t -> 'a) ->
   block_like:(Symbol.t -> t -> 'a) ->
   'a
+
+val replace_vars : t -> vars_to_replace:Simple.t Variable.Map.t -> t


### PR DESCRIPTION
While working on ideas to remove more unused value slots, @Ekdohibs discovered a default in our current code for symbol projections: when we introduce lifted constants at a point where they can be placed, we don't simplify the projections right away which means can lead to unnecessary let bindings, and more importantly the value slots in projections will not be removed even if they don't end up used.

Here is an example:
```ocaml
external __dummy2__ : unit -> 'a = "%opaque"
let transl_label_init_flambda =
  let e = (__dummy2__ ()) (__dummy2__ ()) in
  let transl_label_init_flambda () =
    (__dummy2__ ()) (fun () -> e)
  in
  transl_label_init_flambda
```
There are two nested functions, and since they're both going to be lifted only the inner one needs to store `e` in its closure.
Without this patch we end up with both closures storing `e`, with this patch only the inner one does.