### PR TITLE
Zero alloc: move checkmach pass before Comballoc and CSE

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -277,14 +277,14 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   ++ Profile.record ~accumulate:true "polling"
        (Polling.instrument_fundecl ~future_funcnames:funcnames)
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_polling
+  ++ Profile.record ~accumulate:true "checkmach"
+       (Checkmach.fundecl ~future_funcnames:funcnames ppf_dump)
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_combine
   ++ pass_dump_if ppf_dump dump_combine "After allocation combining"
   ++ Profile.record ~accumulate:true "cse" CSE.fundecl
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_cse
   ++ pass_dump_if ppf_dump dump_cse "After CSE"
-  ++ Profile.record ~accumulate:true "checkmach"
-       (Checkmach.fundecl ~future_funcnames:funcnames ppf_dump)
   ++ Profile.record ~accumulate:true "regalloc" (fun (fd : Mach.fundecl) ->
     match register_allocator fd with
     | ((IRC | LS) as regalloc) ->

--- a/tests/backend/checkmach/fail19.output
+++ b/tests/backend/checkmach/fail19.output
@@ -1,6 +1,8 @@
 File "fail19.ml", line 7, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail19.foo (camlFail19__foo_HIDE_STAMP)
 File "fail19.ml", line 18, characters 5-26:
+  allocate 48 bytes (fail19.ml:18,5--26;dep19.ml:1,38--52)
+File "fail19.ml", line 18, characters 5-26:
   external call to caml_make_array (fail19.ml:18,5--26;dep19.ml:1,38--52)
 File "fail19.ml", line 10, characters 12-17:
   allocate 24 bytes
@@ -15,10 +17,6 @@ File "fail19.ml", line 14, characters 46-54:
 File "fail19.ml", line 15, characters 11-20:
   allocate 24 bytes
 File "fail19.ml", line 17, characters 10-15:
-  allocate 72 bytes combining 2 allocations below
-File "fail19.ml", line 18, characters 5-26:
-  allocate 6 words
-File "fail19.ml", line 17, characters 10-15:
-  allocate 3 words
+  allocate 24 bytes
 File "fail19.ml", line 18, characters 2-27:
   allocate 24 bytes


### PR DESCRIPTION
As discussed in https://github.com/ocaml-flambda/flambda-backend/pull/1762, CSE and Comballoc interferes with zero_alloc check. Instead of fixing the backend CSE pass to correctly propagate debuginfo with `assume_zero_alloc`, this PR moves `checkmach` pass earlier. This is fine because CSE and Comballoc preserve "zero_alloc" property at function level. This may not remain true if we add other properties in the future, but it is true for all other properties we have considered so far (no indirect calls, no raise, is pure).