### PR TITLE
Backport #10364

### DIFF
--- a/ocaml/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/ocaml/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -11,6 +11,8 @@ type (_, _) eq = Refl : ('a, 'a) eq
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let Refl = w1 in let Refl = w2 in g 3;;
 [%%expect{|
+val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> 'b = <fun>
+|}, Principal{|
 Line 2, characters 37-40:
 2 |    let Refl = w1 in let Refl = w2 in g 3;;
                                          ^^^

--- a/ocaml/testsuite/tests/typing-gadts/didier.ml
+++ b/ocaml/testsuite/tests/typing-gadts/didier.ml
@@ -52,7 +52,10 @@ val f : 't -> 't ty -> bool = <fun>
 Line 4, characters 12-13:
 4 |   | Bool -> x
                 ^
-Error: This expression has type t but an expression was expected of type bool
+Error: This expression has type t = bool
+       but an expression was expected of type bool
+       This instance of bool is ambiguous:
+       it would escape the scope of its equation
 |}];;
 (* val f : 'a -> 'a ty -> bool = <fun> *)
 
@@ -72,7 +75,10 @@ Error: This expression has type bool but an expression was expected of type
 Line 4, characters 11-16:
 4 |   | Int -> x > 0
                ^^^^^
-Error: This expression has type bool but an expression was expected of type t
+Error: This expression has type bool but an expression was expected of type
+         t = int
+       This instance of int is ambiguous:
+       it would escape the scope of its equation
 |}];;
 (* Error: This expression has type bool but an expression was expected of type
 t = int *)

--- a/ocaml/testsuite/tests/typing-gadts/test.ml
+++ b/ocaml/testsuite/tests/typing-gadts/test.ml
@@ -370,7 +370,10 @@ module Propagation :
 Line 13, characters 19-20:
 13 |     | BoolLit b -> b
                         ^
-Error: This expression has type bool but an expression was expected of type s
+Error: This expression has type bool but an expression was expected of type
+         s = bool
+       This instance of bool is ambiguous:
+       it would escape the scope of its equation
 |}];;
 
 module Normal_constrs = struct
@@ -782,13 +785,6 @@ Error: This expression has type [> `A of a ]
        Type a is not compatible with type b = a
        This instance of a is ambiguous:
        it would escape the scope of its equation
-|}, Principal{|
-Line 2, characters 9-15:
-2 |   fun Eq o -> o ;; (* fail *)
-             ^^^^^^
-Error: This expression has type ([> `A of b ] as 'a) -> 'a
-       but an expression was expected of type [> `A of a ] -> [> `A of b ]
-       Types for tag `A are incompatible
 |}];;
 
 let f (type a b) (eq : (a,b) eq) (v : [> `A of a]) : [> `A of b] =

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -464,13 +464,6 @@ Line 8, characters 16-21:
 8 |     | `Bar v -> { v }
                     ^^^^^
 Error: This expression should not be a record, the expected type is result
-|}, Principal{|
-Line 8, characters 18-19:
-8 |     | `Bar v -> { v }
-                      ^
-Error: This expression has type ('a : value)
-       but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
 |}];;
 
 module M8_3 = struct

--- a/ocaml/testsuite/tests/typing-poly/poly.ml
+++ b/ocaml/testsuite/tests/typing-poly/poly.ml
@@ -1542,15 +1542,6 @@ Error: This expression has type < m : 'x. [< `Foo of 'x ] -> 'x >
        but an expression was expected of type
          < m : 'a. [< `Foo of int ] -> 'a >
        The universal variable 'x would escape its scope
-|}, Principal{|
-Line 2, characters 2-72:
-2 |   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type < m : 'x. [< `Foo of 'x ] -> 'x >
-       but an expression was expected of type < m : 'a. 'b -> 'a >
-       The method m has type 'x. [< `Foo of 'x ] -> 'x,
-       but the expected method type was 'a. 'b -> 'a
-       The universal variable 'x would escape its scope
 |}];;
 (* ok *)
 let f (n : < m : 'a 'r. [< `Foo of 'a & int | `Bar] as 'r >) =

--- a/ocaml/testsuite/tests/typing-polyvariants-bugs/pr8575.ml
+++ b/ocaml/testsuite/tests/typing-polyvariants-bugs/pr8575.ml
@@ -18,7 +18,8 @@ val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 Line 5, characters 49-50:
 5 |   | B -> if Random.bool () then `Onoes else `A_t B;;
                                                      ^
-Error: Unbound constructor B
+Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 |}]
 
 let test () =
@@ -32,5 +33,6 @@ val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 Line 5, characters 49-50:
 5 |   | B -> if Random.bool () then `Onoes else `A_t B;;
                                                      ^
-Error: Unbound constructor B
+Warning 18 [not-principal]: this type-based constructor disambiguation is not principal.
+val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
 |}]


### PR DESCRIPTION
This backports ocaml/ocaml#10364 on top of flambda-backend. I'm backporting this because it makes backport syntactic arity slightly easier.

I don't understand the code deeply but backporting it was fairly straightforward and tests changed in the same way, with some easily-explainable exceptions:
  * Tests for internal features like layouts: The error printed in principal mode for these is now the same as the error in non-principal mode.
  * `ocaml/testsuite/tests/typing-poly/poly.ml`: this PR just removes the diff that was inserted in https://github.com/ocaml-flambda/ocaml-jst/pull/14. (It again changes the error in principal mode to be the same as the error in non-principal mode.) This also seems fine.

Run this command from the cloned  to get the diff between this PR's diff and the upstream PR's diff:

```
patdiff <(curl https://patch-diff.githubusercontent.com/raw/ocaml-flambda/flambda-backend/pull/1788.diff) <(curl https://patch-diff.githubusercontent.com/raw/ocaml/ocaml/pull/10364.diff)
```

The two thorny-looking sections of the diff-of-diffs are the testsuite changes (already explained) and the fact that the body of `type_unknown_args` is different, but that is easy enough to review on its own.