### PR TITLE
Add tag to Block_approximation

### DIFF
--- a/middle_end/flambda2/classic_mode_types/dune
+++ b/middle_end/flambda2/classic_mode_types/dune
@@ -9,6 +9,8 @@
    -open
    Flambda2_identifiers
    -open
+   Flambda2_kinds
+   -open
    Flambda2_nominal
    -open
    Flambda2_numbers
@@ -19,6 +21,7 @@
  (libraries
   ocamlcommon
   flambda2_identifiers
+  flambda2_kinds
   flambda2_nominal
   flambda2_numbers
   flambda2_term_basics))

--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -28,7 +28,7 @@ type 'code t =
         code : 'code;
         symbol : Symbol.t option
       }
-  | Block_approximation of 'code t array * Alloc_mode.For_types.t
+  | Block_approximation of Tag.t * 'code t array * Alloc_mode.For_types.t
 
 let rec print fmt = function
   | Value_unknown -> Format.fprintf fmt "?"
@@ -36,12 +36,12 @@ let rec print fmt = function
   | Value_int i -> Targetint_31_63.print fmt i
   | Closure_approximation { code_id; _ } ->
     Format.fprintf fmt "[%a]" Code_id.print code_id
-  | Block_approximation (fields, _) ->
+  | Block_approximation (tag, fields, _) ->
     let len = Array.length fields in
     if len < 1
     then Format.fprintf fmt "{}"
     else (
-      Format.fprintf fmt "@[<hov 2>{%a" print fields.(0);
+      Format.fprintf fmt "@[<hov 2>{%a:%a" Tag.print tag print fields.(0);
       for i = 1 to len - 1 do
         Format.fprintf fmt "@ %a" print fields.(i)
       done;
@@ -57,7 +57,7 @@ let rec free_names ~code_free_names approx =
   match approx with
   | Value_unknown | Value_int _ -> Name_occurrences.empty
   | Value_symbol sym -> Name_occurrences.singleton_symbol sym Name_mode.normal
-  | Block_approximation (approxs, _) ->
+  | Block_approximation (_tag, approxs, _) ->
     Array.fold_left
       (fun names approx ->
         Name_occurrences.union names (free_names ~code_free_names approx))

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -28,7 +28,7 @@ type 'code t =
         code : 'code;
         symbol : Symbol.t option
       }
-  | Block_approximation of 'code t array * Alloc_mode.For_types.t
+  | Block_approximation of Tag.t * 'code t array * Alloc_mode.For_types.t
 
 val print : Format.formatter -> 'a t -> unit
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -157,7 +157,12 @@ module Env : sig
   val add_var_approximation : t -> Variable.t -> value_approximation -> t
 
   val add_block_approximation :
-    t -> Variable.t -> value_approximation array -> Alloc_mode.For_types.t -> t
+    t ->
+    Variable.t ->
+    Tag.t ->
+    value_approximation array ->
+    Alloc_mode.For_types.t ->
+    t
 
   val find_var_approximation : t -> Variable.t -> value_approximation
 

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1184,10 +1184,10 @@ end = struct
       | Value_int i -> TG.this_tagged_immediate i
       | Value_symbol symbol ->
         TG.alias_type_of Flambda_kind.value (Simple.symbol symbol)
-      | Block_approximation (fields, alloc_mode) ->
+      | Block_approximation (tag, fields, alloc_mode) ->
         let fields = List.map type_from_approx (Array.to_list fields) in
-        MTC.immutable_block ~is_unique:false Tag.zero
-          ~field_kind:Flambda_kind.value ~fields alloc_mode
+        MTC.immutable_block ~is_unique:false tag ~field_kind:Flambda_kind.value
+          ~fields alloc_mode
       | Closure_approximation
           { code_id;
             function_slot;
@@ -1349,12 +1349,12 @@ end = struct
             then
               match TG.Row_like_for_blocks.get_singleton blocks with
               | None -> Value_unknown
-              | Some ((_tag, _size), fields, alloc_mode) ->
+              | Some ((tag, _size), fields, alloc_mode) ->
                 let fields =
                   List.map type_to_approx
                     (TG.Product.Int_indexed.components fields)
                 in
-                Block_approximation (Array.of_list fields, alloc_mode)
+                Block_approximation (tag, Array.of_list fields, alloc_mode)
             else Value_unknown))
       | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
       | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _ ->


### PR DESCRIPTION
This fixes a bug where all block types reconstructed for Simplify from the classic mode approximations would be given tag zero.