### PR TITLE
Support mode crossing at identifiers

### DIFF
--- a/ocaml/testsuite/tests/typing-local/crossing.ml
+++ b/ocaml/testsuite/tests/typing-local/crossing.ml
@@ -345,7 +345,7 @@ val f : local_ M.t -> M.t = <fun>
 val f : local_ t2 -> t2 = <fun>
 |}]
 
-(* This test needs the snapshotting in is_always_global to prevent a type error
+(* This test needs the snapshotting in [is_immediate] to prevent a type error
    from the use of the gadt equation in the inner scope. *)
 type _ t_gadt = Int : int t_gadt
 type 'a t_rec = { fld : 'a }

--- a/ocaml/testsuite/tests/typing-local/crossing.ml
+++ b/ocaml/testsuite/tests/typing-local/crossing.ml
@@ -437,3 +437,14 @@ Line 1, characters 12-39:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type int -> local_ int is not a subtype of local_ int -> int
 |}]
+
+(* Mode crossing at identifiers - in the following, x and y are added to the
+environment at mode local, but they cross to global when they are refered to
+again. Note that ref is polymorphic and thus doesn't trigger crossing. *)
+let foo () =
+  let x, y = local_ (42, 24) in
+  let _ = ref x, ref y in
+  ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]

--- a/ocaml/testsuite/tests/typing-unique/unique.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique.ml
@@ -147,7 +147,7 @@ Error: Found a shared value where a unique value was expected
 |}]
 
 let f =
-  let unique_ a = 3 in
+  let unique_ a = "hello" in
   let g (unique_ a) = a in
   for i = 0 to 5 do
     let _ = g a in ()

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2132,6 +2132,8 @@ let is_immediate64 env ty =
   else
     perform_check ()
 
+(* We will require Int63 to be [global many unique] on 32-bit platforms, so
+   this is fine *)
 let is_immediate = is_immediate64
 
 let mode_cross env (ty : type_expr) =

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -520,13 +520,14 @@ val check_type_layout :
 val constrain_type_layout :
   Env.t -> type_expr -> layout -> (unit, Layout.Violation.t) result
 
+(* False if running in principal mode and the type is not principal.
+   True otherwise. *)
 val is_principal : type_expr -> bool
 
-(* True if a type is always global (i.e., it mode crosses for local).  This is
-   true for all immediate and immediate64 types.  To make it sound for
-   immediate64, we've disabled stack allocation on 32-bit builds. *)
-val is_always_global : Env.t -> type_expr -> bool
+(* True if a type is immediate. *)
+val is_immediate : Env.t -> type_expr -> bool
 
+(* True if a type can cross to the minimum on all mode axes. *)
 val mode_cross : Env.t -> type_expr -> bool
 
 (* For use with ocamldebug *)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -6026,6 +6026,7 @@ and type_expect_
 
 and type_ident env ?(recarg=Rejected) lid =
   let (path, desc, mode, reason) = Env.lookup_value ~loc:lid.loc lid.txt env in
+  let mode = mode_cross_to_min env desc.val_type mode in
   let is_recarg =
     match get_desc desc.val_type with
     | Tconstr(p, _, _) -> Path.is_constructor_typath p

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -1275,7 +1275,7 @@ and build_as_type_aux ~refine ~mode (env : Env.t ref) p =
       end
   | Tpat_constant _ ->
       let mode =
-        if Ctype.is_always_global !env p.pat_type
+        if Ctype.is_immediate !env p.pat_type
         then Value.newvar ()
         else mode
       in
@@ -6026,6 +6026,9 @@ and type_expect_
 
 and type_ident env ?(recarg=Rejected) lid =
   let (path, desc, mode, reason) = Env.lookup_value ~loc:lid.loc lid.txt env in
+  (* Mode crossing here is needed only because of the strange behaviour of
+  [type_let] - it checks the LHS before RHS. Had it checks the RHS before LHS,
+  identifiers would be mode crossed when being added to the environment. *)
   let mode = mode_cross_to_min env desc.val_type mode in
   let is_recarg =
     match get_desc desc.val_type with

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -441,8 +441,8 @@ let make_constructor
       let args, targs =
         transl_constructor_arguments env univars closed sargs
       in
-      let tret_type = 
-        transl_simple_type env ?univars ~closed Mode.Alloc.Const.legacy sret_type 
+      let tret_type =
+        transl_simple_type env ?univars ~closed Mode.Alloc.Const.legacy sret_type
       in
       let ret_type = tret_type.ctyp_type in
       (* TODO add back type_path as a parameter ? *)
@@ -935,7 +935,7 @@ let check_constraints env sdecl (_, decl) =
    [type_layout] with what we computed.
 
    CR layouts: if easy, factor out the shared backtracking logic from here
-   and is_always_global.
+   and is_immediate.
 *)
 let check_coherence env loc dpath decl =
   match decl with


### PR DESCRIPTION
This PR adds mode crossing at `Texp_ident`. One reason of this is to remedy the counter-intuitive behaviour of `type_let`, which checks the LHS before looking at RHS. See the added test for an example why this is needed. 

Kindly request review from @stedolan or @lpw25 