### PR TITLE
Fixed off by one in cached generated function file

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3130,9 +3130,12 @@ module Generic_fns_tbl = struct
         Seq.init (max_tuplify + 1) (fun n -> Lambda.Tupled, arity n, result)
       in
       let curry =
-        Seq.init (Lambda.max_arity () + 1) (fun n ->
-            Seq.init (Lambda.max_arity () + 1) (fun nlocal ->
-                Lambda.Curried { nlocal }, arity n, result))
+        Seq.init
+          (Lambda.max_arity () + 1)
+          (fun n ->
+            Seq.init
+              (Lambda.max_arity () + 1)
+              (fun nlocal -> Lambda.Curried { nlocal }, arity n, result))
         |> Seq.concat
       in
       let send =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3127,23 +3127,23 @@ module Generic_fns_tbl = struct
       let arity n = List.init n (fun _ -> [| Val |]) in
       let result = [| Val |] in
       let tuplify =
-        Seq.init max_tuplify (fun n -> Lambda.Tupled, arity n, result)
+        Seq.init (max_tuplify + 1) (fun n -> Lambda.Tupled, arity n, result)
       in
       let curry =
-        Seq.init (Lambda.max_arity ()) (fun n ->
-            Seq.init (Lambda.max_arity ()) (fun nlocal ->
+        Seq.init (Lambda.max_arity () + 1) (fun n ->
+            Seq.init (Lambda.max_arity () + 1) (fun nlocal ->
                 Lambda.Curried { nlocal }, arity n, result))
         |> Seq.concat
       in
       let send =
-        Seq.init max_send (fun n ->
+        Seq.init (max_send + 1) (fun n ->
             Seq.cons
               (arity n, result, Lambda.alloc_local)
               (Seq.return (arity n, result, Lambda.alloc_heap)))
         |> Seq.concat
       in
       let apply =
-        Seq.init max_apply (fun n ->
+        Seq.init (max_apply + 1) (fun n ->
             Seq.cons
               (arity n, result, Lambda.alloc_local)
               (Seq.return (arity n, result, Lambda.alloc_heap)))


### PR DESCRIPTION
Fix an off-by-one between generation of the cached functions file and filtering of these functions

In the `cached-generic-functions.o` caml_curry are generated using a `Seq.init (Lambda.max_arity()) (fun n -> ...caml_curry{n}...)` - making the largest one to be pre-generated be `caml_curry125`.
However, when linking, all `caml_curry{n}` with `n <= Lambda.max_arity()` are considered to be part of the
pre-generated object file. This mean that `caml_curry126` was believe to be pre-generated, which unfortunately wasn't the case.



