### PR TITLE
Fix uncaught Unify exception in filter_arrow

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -652,7 +652,7 @@ Error: Signature mismatch:
          val x : ('a : immediate). 'a
        is not included in
          val x : string
-       The type string is not compatible with the type string
+       The type ('a : immediate) is not compatible with the type string
        string has layout value, which is not a sublayout of immediate.
 |}];;
 
@@ -689,7 +689,8 @@ Error: Signature mismatch:
          val x : ('a : immediate). 'a t
        is not included in
          val x : string
-       The type string t = string is not compatible with the type string
+       The type 'a t = ('a : immediate) is not compatible with the type
+         string
        string has layout value, which is not a sublayout of immediate.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -295,7 +295,7 @@ Error: Signature mismatch:
          val x : ('a : immediate). 'a
        is not included in
          val x : string
-       The type string is not compatible with the type string
+       The type ('a : immediate) is not compatible with the type string
        string has layout value, which is not a sublayout of immediate.
 |}];;
 
@@ -332,7 +332,8 @@ Error: Signature mismatch:
          val x : ('a : immediate). 'a t
        is not included in
          val x : string
-       The type string t = string is not compatible with the type string
+       The type 'a t = ('a : immediate) is not compatible with the type
+         string
        string has layout value, which is not a sublayout of immediate.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -545,3 +545,26 @@ Line 3, characters 15-40:
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type 'a has layout value, which is not a sublayout of immediate.
 |}]
+
+(****************************************************)
+(* Test 35: check bad layout error in filter_arrow *)
+
+module M35_1 : sig
+  val x : string
+end = struct
+  type ('a : immediate) t = 'a
+
+  let f : 'a t -> 'a = fun x y z -> x
+
+  let x = f (assert false)
+
+end;;
+
+[%%expect {|
+Line 6, characters 23-37:
+6 |   let f : 'a t -> 'a = fun x y z -> x
+                           ^^^^^^^^^^^^^^
+Error: This expression has type 'a -> 'b
+       but an expression was expected of type 'a -> 'b
+       'a -> 'b has layout value, which is not a sublayout of immediate.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -549,21 +549,15 @@ Error: Type 'a has layout value, which is not a sublayout of immediate.
 (****************************************************)
 (* Test 35: check bad layout error in filter_arrow *)
 
-module M35_1 : sig
-  val x : string
-end = struct
-  type ('a : immediate) t = 'a
 
-  let f : 'a t -> 'a = fun x y z -> x
-
-  let x = f (assert false)
-
-end;;
+type ('a : immediate) t35 = 'a
+let f : 'a t35 -> 'a = fun x y -> ()
 
 [%%expect {|
-Line 6, characters 23-37:
-6 |   let f : 'a t -> 'a = fun x y z -> x
-                           ^^^^^^^^^^^^^^
+type ('a : immediate) t35 = 'a
+Line 2, characters 23-36:
+2 | let f : 'a t35 -> 'a = fun x y -> ()
+                           ^^^^^^^^^^^^^
 Error: This expression has type 'a -> 'b
        but an expression was expected of type 'a -> 'b
        'a -> 'b has layout value, which is not a sublayout of immediate.

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -549,16 +549,15 @@ Error: Type 'a has layout value, which is not a sublayout of immediate.
 (****************************************************)
 (* Test 35: check bad layout error in filter_arrow *)
 
-
 type ('a : immediate) t35 = 'a
-let f : 'a t35 -> 'a = fun x y -> ()
+let f35 : 'a t35 = fun () -> ()
 
 [%%expect {|
 type ('a : immediate) t35 = 'a
-Line 2, characters 23-36:
-2 | let f : 'a t35 -> 'a = fun x y -> ()
-                           ^^^^^^^^^^^^^
-Error: This expression has type 'a -> 'b
-       but an expression was expected of type 'a -> 'b
+Line 2, characters 19-31:
+2 | let f35 : 'a t35 = fun () -> ()
+                       ^^^^^^^^^^^^
+Error: This expression has type 'b -> 'c
+       but an expression was expected of type ('a : immediate)
        'a -> 'b has layout value, which is not a sublayout of immediate.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -557,7 +557,6 @@ type ('a : immediate) t35 = 'a
 Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
-Error: This expression has type 'b -> 'c
-       but an expression was expected of type ('a : immediate)
+Error:
        'a -> 'b has layout value, which is not a sublayout of immediate.
 |}]

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -4371,8 +4371,8 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
         moregen_occur env (get_level t1) t2;
         update_scope_for Moregen (get_scope t1) t2;
         occur_for Moregen env t1 t2;
-        link_type t1 t2;
-        constrain_type_layout_exn env Moregen t2 layout
+        constrain_type_layout_exn env Moregen t2 layout;
+        link_type t1 t2
     | (Tconstr (p1, [], _), Tconstr (p2, [], _)) when Path.same p1 p2 ->
         ()
     | _ ->
@@ -4387,8 +4387,8 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
             (Tvar { layout }, _) when may_instantiate inst_nongen t1' ->
               moregen_occur env (get_level t1') t2;
               update_scope_for Moregen (get_scope t1') t2;
-              link_type t1' t2;
-              constrain_type_layout_exn env Moregen t2 layout
+              constrain_type_layout_exn env Moregen t2 layout;
+              link_type t1' t2
           | (Tarrow ((l1,a1,r1), t1, u1, _),
              Tarrow ((l2,a2,r2), t2, u2, _)) when
                (l1 = l2

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -3864,7 +3864,7 @@ let filter_arrow env t l ~force_tpoly =
                  (Unification_error
                     (expand_to_unification_error
                        env
-                       [Diff {got = t'; expected = t}; Bad_layout (t',err)])))
+                       [Bad_layout (t',err)])))
       end;
       link_type t t';
       arrow_desc

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -3857,8 +3857,6 @@ let filter_arrow env t l ~force_tpoly =
   match get_desc t with
     Tvar { layout } ->
       let t', arrow_desc = function_type (get_level t) in
-      link_type t t';
-
       begin match constrain_type_layout env t' layout with
       | Ok _ -> ()
       | Error err ->
@@ -3868,7 +3866,7 @@ let filter_arrow env t l ~force_tpoly =
                        env
                        [Diff {got = t'; expected = t}; Bad_layout (t',err)])))
       end;
-
+      link_type t t';
       arrow_desc
   | Tarrow((l', arg_mode, ret_mode), ty_arg, ty_ret, _) ->
       if l = l' || !Clflags.classic && l = Nolabel && not (is_optional l')


### PR DESCRIPTION
The included testcase current results in an uncaught exception:

```
Fatal error: exception Ctype.Unify_trace(_)
Raised at Ctype.raise_trace_for in file "ocaml/typing/ctype.ml", line 99, characters 16-41
Called from Ctype.filter_arrow in file "ocaml/typing/ctype.ml", line 3861, characters 6-51
Called from Typecore.type_function in file "ocaml/typing/typecore.ml", line 6133, characters 8-60
Called from Builtin_attributes.warning_scope in file "ocaml/parsing/builtin_attributes.ml", line 415, characters 14-18
Re-raised at Builtin_attributes.warning_scope in file "ocaml/parsing/builtin_attributes.ml", line 420, characters 4-13
Called from Typecore.type_expect in file "ocaml/typing/typecore.ml", line 4476, characters 4-181
Called from Typecore.type_cases.(fun) in file "ocaml/typing/typecore.ml", line 7235, characters 10-106
...
```

This PR seeks to fix this by wrapping the error as a proper `Filter_arrow_failed` exception before raising.