### PR TITLE
Factor out duplicated code in `cmm_helpers`

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1164,10 +1164,11 @@ let unique_arity_identifier (arity : Cmm.machtype list) =
   then Int.to_string (List.length arity)
   else String.concat "_" (List.map machtype_identifier arity)
 
+let result_layout_suffix result =
+  match result with [| Val |] -> "" | _ -> "_R" ^ machtype_identifier result
+
 let send_function_name arity result (mode : Lambda.alloc_mode) =
-  let res =
-    match result with [| Val |] -> "" | _ -> "_R" ^ machtype_identifier result
-  in
+  let res = result_layout_suffix result in
   let suff = match mode with Alloc_heap -> "" | Alloc_local -> "L" in
   global_symbol ("caml_send" ^ unique_arity_identifier arity ^ res ^ suff)
 
@@ -1263,9 +1264,7 @@ let make_checkbound dbg = function
 (* Record application and currying functions *)
 
 let apply_function_name arity result (mode : Lambda.alloc_mode) =
-  let res =
-    match result with [| Val |] -> "" | _ -> "_R" ^ machtype_identifier result
-  in
+  let res = result_layout_suffix result in
   let suff = match mode with Alloc_heap -> "" | Alloc_local -> "L" in
   "caml_apply" ^ unique_arity_identifier arity ^ res ^ suff
 
@@ -1282,9 +1281,7 @@ let curry_function_sym_name function_kind arity result =
     Compilenv.need_curry_fun function_kind arity result;
     "caml_curry"
     ^ unique_arity_identifier arity
-    ^ (match result with
-      | [| Val |] -> ""
-      | _ -> "_R" ^ machtype_identifier result)
+    ^ result_layout_suffix result
     ^ if nlocal > 0 then "L" ^ Int.to_string nlocal else ""
   | Lambda.Tupled -> (
     if List.exists (function [| Val |] | [| Int |] -> false | _ -> true) arity
@@ -1298,8 +1295,7 @@ let curry_function_sym_name function_kind arity result =
       result;
     "caml_tuplify"
     ^ Int.to_string (List.length arity)
-    ^
-    match result with [| Val |] -> "" | _ -> "_R" ^ machtype_identifier result)
+    ^ result_layout_suffix result)
 
 let curry_function_sym function_kind arity result =
   { sym_name = curry_function_sym_name function_kind arity result;
@@ -2748,10 +2744,7 @@ let tuplify_function arity return =
   let fun_name =
     global_symbol
       ("caml_tuplify" ^ Int.to_string arity
-      ^
-      match return with
-      | [| Val |] -> ""
-      | _ -> "_R" ^ machtype_identifier return)
+      ^ result_layout_suffix return)
   in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
   Cfunction

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1283,7 +1283,7 @@ let curry_function_sym_name function_kind arity result =
     ^ unique_arity_identifier arity
     ^ result_layout_suffix result
     ^ if nlocal > 0 then "L" ^ Int.to_string nlocal else ""
-  | Lambda.Tupled -> (
+  | Lambda.Tupled ->
     if List.exists (function [| Val |] | [| Int |] -> false | _ -> true) arity
     then
       Misc.fatal_error
@@ -1295,7 +1295,7 @@ let curry_function_sym_name function_kind arity result =
       result;
     "caml_tuplify"
     ^ Int.to_string (List.length arity)
-    ^ result_layout_suffix result)
+    ^ result_layout_suffix result
 
 let curry_function_sym function_kind arity result =
   { sym_name = curry_function_sym_name function_kind arity result;
@@ -2743,8 +2743,7 @@ let tuplify_function arity return =
   in
   let fun_name =
     global_symbol
-      ("caml_tuplify" ^ Int.to_string arity
-      ^ result_layout_suffix return)
+      ("caml_tuplify" ^ Int.to_string arity ^ result_layout_suffix return)
   in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
   Cfunction

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1275,6 +1275,9 @@ let apply_function_sym arity result mode =
   Compilenv.need_apply_fun arity result mode;
   global_symbol (apply_function_name arity result mode)
 
+let tuplify_function_name arity result =
+  "caml_tuplify" ^ Int.to_string arity ^ result_layout_suffix result
+
 let curry_function_sym_name function_kind arity result =
   match function_kind with
   | Lambda.Curried { nlocal } ->
@@ -1293,9 +1296,7 @@ let curry_function_sym_name function_kind arity result =
     Compilenv.need_curry_fun function_kind
       (List.map (fun _ -> [| Val |]) arity)
       result;
-    "caml_tuplify"
-    ^ Int.to_string (List.length arity)
-    ^ result_layout_suffix result
+    tuplify_function_name (List.length arity) result
 
 let curry_function_sym function_kind arity result =
   { sym_name = curry_function_sym_name function_kind arity result;
@@ -2741,10 +2742,7 @@ let tuplify_function arity return =
       get_field_gen Asttypes.Mutable (Cvar arg) i (dbg ())
       :: access_components (i + 1)
   in
-  let fun_name =
-    global_symbol
-      ("caml_tuplify" ^ Int.to_string arity ^ result_layout_suffix return)
-  in
+  let fun_name = global_symbol (tuplify_function_name arity return) in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
   Cfunction
     { fun_name;

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -1030,6 +1030,9 @@ let apply_function_sym arity result mode =
   Compilenv.need_apply_fun arity result mode;
   apply_function_name arity result mode
 
+let tuplify_function_name arity result =
+  "caml_tuplify" ^ Int.to_string arity ^ result_layout_suffix result
+
 let curry_function_sym function_kind arity result =
   Compilenv.need_curry_fun function_kind arity result;
   match function_kind with
@@ -1043,9 +1046,7 @@ let curry_function_sym function_kind arity result =
     then
       Misc.fatal_error
         "tuplify_function is currently unsupported if arity contains non-values";
-    "caml_tuplify"
-    ^ Int.to_string (List.length arity)
-    ^ result_layout_suffix result
+    tuplify_function_name (List.length arity) result
 
 (* Big arrays *)
 
@@ -2250,10 +2251,7 @@ let tuplify_function arity return =
     else get_field_gen Asttypes.Mutable (Cvar arg) i (dbg ())
          :: access_components(i+1)
   in
-  let fun_name =
-    "caml_tuplify" ^ Int.to_string arity
-    ^ result_layout_suffix return
-  in
+  let fun_name = tuplify_function_name arity return in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
   Cfunction
    {fun_name;

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -1038,14 +1038,14 @@ let curry_function_sym function_kind arity result =
     ^ unique_arity_identifier arity
     ^ result_layout_suffix result
     ^ if nlocal > 0 then "L" ^ Int.to_string nlocal else ""
-  | Lambda.Tupled -> (
+  | Lambda.Tupled ->
     if List.exists (function [| Val |] -> false | _ -> true) arity
     then
       Misc.fatal_error
         "tuplify_function is currently unsupported if arity contains non-values";
     "caml_tuplify"
     ^ Int.to_string (List.length arity)
-    ^ result_layout_suffix result)
+    ^ result_layout_suffix result
 
 (* Big arrays *)
 


### PR DESCRIPTION
@xclerc pointed out in #1793 that we should factor out this little bit of code duplication.