### PR TITLE
Enable layout histories

### DIFF
--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -1,6 +1,7 @@
 (* TEST
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 module type S = sig type t [@@immediate] end;;
 module F (M : S) : S = M;;
@@ -143,7 +144,11 @@ end;;
 Line 2, characters 2-31:
 2 |   type t = string [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type string has layout value, which is not a sublayout of immediate.
+Error: The layout of Type string is value, because
+         it equals the primitive value type string.
+       But the layout of Type string must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (variant) *)
@@ -154,7 +159,11 @@ end;;
 Line 2, characters 2-41:
 2 |   type t = Foo of int | Bar [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type t has layout value, which is not a sublayout of immediate.
+Error: The layout of Type t is value, because
+         a boxed variant.
+       But the layout of Type t must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t/2.
+
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (record) *)
@@ -165,7 +174,11 @@ end;;
 Line 2, characters 2-38:
 2 |   type t = { foo : int } [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type t has layout value, which is not a sublayout of immediate.
+Error: The layout of Type t is value, because
+         a boxed record.
+       But the layout of Type t must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t/3.
+
 |}];;
 
 (* Not guaranteed that t is immediate, so this is an invalid declaration *)
@@ -177,7 +190,11 @@ end;;
 Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type t has layout value, which is not a sublayout of immediate.
+Error: The layout of Type t is value, because
+         the default layout for an abstract type.
+       But the layout of Type t must be a sublayout of immediate, because
+         of the annotation on the declaration of the type s.
+
 |}];;
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
@@ -198,7 +215,11 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it equals the primitive value type string.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 (* Same as above but with explicit signature *)
@@ -214,7 +235,11 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it equals the primitive value type string.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)
@@ -226,7 +251,11 @@ end;;
 Line 2, characters 2-26:
 2 |   type t = s [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type s has layout value, which is not a sublayout of immediate.
+Error: The layout of Type s is value, because
+         it equals the primitive value type string.
+       But the layout of Type s must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t/2.
+
 |}];;
 
 

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -2,6 +2,7 @@
    flags = "-extension layouts_alpha"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 (* This file contains typing tests for the layout [float64].
 
@@ -110,7 +111,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because
+         a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_float64_id) = x, false;;
@@ -120,7 +124,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       'a t_float64_id has layout float64, which does not overlap with value.
+       The layout of 'a t_float64_id is float64, because
+         of the annotation on 'a in the declaration of the type t_float64_id.
+       But the layout of 'a t_float64_id must overlap with value, because
+         a tuple element.
 |}];;
 
 let f4_3 (x : float#) = x, false;;
@@ -130,7 +137,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because
+         a tuple element.
 |}];;
 
 type t4_4 = t_float64 * string;;
@@ -139,7 +149,11 @@ Line 1, characters 12-21:
 1 | type t4_4 = t_float64 * string;;
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+        The layout of t_float64 is float64, because
+          of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because
+         a tuple element.
+
 |}];;
 
 type t4_5 = int * float#;;
@@ -148,7 +162,11 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * float#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-        float# has layout float64, which is not a sublayout of value.
+        The layout of float# is float64, because
+          it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because
+         a tuple element.
+
 |}];;
 
 type ('a : float64) t4_6 = 'a * 'a
@@ -157,7 +175,11 @@ Line 1, characters 27-29:
 1 | type ('a : float64) t4_6 = 'a * 'a
                                ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because all of the following:
+           a tuple element
+           a tuple element
 |}];;
 
 (* check for layout propagation *)
@@ -167,7 +189,13 @@ Line 1, characters 32-34:
 1 | type ('a : float64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because all of the following:
+           used as a function argument
+           a tuple element
+           a tuple element
+           appears as an unannotated type parameter
 |}]
 
 (****************************************************)
@@ -261,7 +289,11 @@ Line 1, characters 31-40:
 1 | module type S6_1 = sig val x : t_float64 end
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout float64, which is not a sublayout of value.
+       The layout of x is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of x must be a sublayout of value, because
+         stored in a module structure.
+
 |}];;
 
 module type S6_2 = sig val x : 'a t_float64_id end
@@ -270,7 +302,11 @@ Line 1, characters 31-46:
 1 | module type S6_2 = sig val x : 'a t_float64_id end
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout float64, which does not overlap with value.
+       The layout of x is float64, because
+         of the annotation on 'a in the declaration of the type t_float64_id.
+       But the layout of x must overlap with value, because
+         stored in a module structure.
+
 |}];;
 
 module type S6_3 = sig val x : float# end
@@ -279,7 +315,11 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : float# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout float64, which is not a sublayout of value.
+       The layout of x is float64, because
+         it equals the primitive value type float#.
+       But the layout of x must be a sublayout of value, because
+         stored in a module structure.
+
 |}];;
 
 
@@ -292,7 +332,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because
+         a field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_float64_id) = `A x;;
@@ -302,7 +345,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       'a t_float64_id has layout float64, which does not overlap with value.
+       The layout of 'a t_float64_id is float64, because
+         of the annotation on 'a in the declaration of the type t_float64_id.
+       But the layout of 'a t_float64_id must overlap with value, because
+         a field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : float#) = `A x;;
@@ -312,7 +358,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because
+         a field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_float64 ];;
@@ -321,7 +370,11 @@ Line 1, characters 20-29:
 1 | type f7_4 = [ `A of t_float64 ];;
                         ^^^^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+        The layout of t_float64 is float64, because
+          of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because
+         a field of a polymorphic variant.
+
 |}];;
 
 type ('a : float64) f7_5 = [ `A of 'a ];;
@@ -330,7 +383,10 @@ Line 1, characters 35-37:
 1 | type ('a : float64) f7_5 = [ `A of 'a ];;
                                        ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         a field of a polymorphic variant.
 |}];;
 (* CR layouts v2.9: This error could be improved *)
 
@@ -356,7 +412,12 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because all of the following:
+           used as a function argument
+           used as a function argument
+           used as a function result
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -366,7 +427,12 @@ Line 1, characters 20-42:
                         ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       'a t_float64_id has layout float64, which does not overlap with value.
+       The layout of 'a t_float64_id is float64, because
+         of the annotation on 'a in the declaration of the type t_float64_id.
+       But the layout of 'a t_float64_id must overlap with value, because all of the following:
+           used as a function argument
+           used as a function argument
+           used as a function result
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -376,7 +442,12 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           used as a function argument
+           used as a function argument
+           used as a function result
 |}];;
 
 (*************************************)
@@ -529,7 +600,11 @@ Line 1, characters 15-28:
 1 | type t12_1 = < x : t_float64 >;;
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+        The layout of t_float64 is float64, because
+          of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because
+         an object field.
+
 |}];;
 
 type ('a : float64) t12_2 = < x : 'a >;;
@@ -538,7 +613,10 @@ Line 1, characters 34-36:
 1 | type ('a : float64) t12_2 = < x : 'a >;;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         an object field.
 |}]
 
 class c12_3 = object method x : t_float64 = assert false end;;
@@ -548,7 +626,10 @@ Line 1, characters 21-56:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_float64 but is expected to have type
          ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because
+         an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -559,7 +640,14 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_float64_id -> 'a t_float64_id = assert false
                  ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with float64.
+       The layout of 'a is value, because all of the following:
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
+       But the layout of 'a must overlap with float64, because all of the following:
+           of the annotation on 'a in the declaration of the type
+                                t_float64_id
+           of the annotation on 'a in the declaration of the type
+                                t_float64_id
 |}];;
 (* CR layouts v2.9: Error could be improved *)
 
@@ -569,7 +657,11 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_float64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       x has layout float64, which is not a sublayout of value.
+       The layout of x is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of x must be a sublayout of value, because
+         an class field.
+
 |}];;
 
 class type c12_6 = object method x : float# end;;
@@ -578,7 +670,11 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : float# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type float# but is expected to have type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           an object field
+           an object field
 |}];;
 (* CR layouts v2.9: Error could be improved *)
 
@@ -588,7 +684,11 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : float# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       x has layout float64, which is not a sublayout of value.
+       The layout of x is float64, because
+         it equals the primitive value type float#.
+       But the layout of x must be a sublayout of value, because
+         an instance variable.
+
 |}];;
 
 class type ['a] c12_8 = object
@@ -599,7 +699,14 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_float64_id -> 'a t_float64_id
               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with float64.
+       The layout of 'a is value, because all of the following:
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
+       But the layout of 'a must overlap with float64, because all of the following:
+           of the annotation on 'a in the declaration of the type
+                                t_float64_id
+           of the annotation on 'a in the declaration of the type
+                                t_float64_id
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -635,7 +742,11 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because all of the following:
+           captured in an object
+           used as a function argument
 |}];;
 
 let f12_14 (m1 : t_float64) (m2 : t_float64) = object
@@ -649,7 +760,11 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because
+         captured in an object.
+
 |}];;
 
 (*********************************************************************)
@@ -665,7 +780,12 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because all of the following:
+           used as a function argument
+           used as a function argument
+           imported from another compilation unit
 |}];;
 
 let f13_2 (x : t_float64) = compare x x;;
@@ -675,7 +795,12 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because all of the following:
+           used as a function argument
+           used as a function argument
+           imported from another compilation unit
 |}];;
 
 let f13_3 (x : t_float64) = Marshal.to_bytes x;;
@@ -685,7 +810,11 @@ Line 1, characters 45-46:
                                                  ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because all of the following:
+           used as a function argument
+           imported from another compilation unit
 |}];;
 
 let f13_4 (x : t_float64) = Hashtbl.hash x;;
@@ -695,5 +824,9 @@ Line 1, characters 41-42:
                                              ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because all of the following:
+           used as a function argument
+           imported from another compilation unit
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -2,6 +2,7 @@
    flags = "-extension layouts_alpha"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 (* These tests show how potential ambiguities are resolved
    between the types #c and float#.
@@ -43,7 +44,10 @@ Line 1, characters 9-15:
 1 | type t = float# list;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 let f (_ : float# list) = ();;
@@ -52,7 +56,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float# list) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 type t = C of float# list;;
@@ -61,7 +68,10 @@ Line 1, characters 14-20:
 1 | type t = C of float# list;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 type t = C : float# list -> t;;
@@ -70,7 +80,10 @@ Line 1, characters 13-19:
 1 | type t = C : float# list -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 (* Syntax: float#c
@@ -89,7 +102,16 @@ Line 1, characters 9-15:
 1 | type t = float#c;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           used as a function result
+           an object
+           an object field
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
 |}];;
 
 let f (_ : float#c) = ();;
@@ -98,7 +120,16 @@ Line 1, characters 11-17:
 1 | let f (_ : float#c) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           used as a function result
+           an object
+           an object field
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
 |}];;
 
 type t = C of float#c;;
@@ -107,7 +138,16 @@ Line 1, characters 14-20:
 1 | type t = C of float#c;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           used as a function result
+           an object
+           an object field
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
 |}];;
 
 type t = C : float#c -> t;;
@@ -116,7 +156,16 @@ Line 1, characters 13-19:
 1 | type t = C : float#c -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           used as a function result
+           an object
+           an object field
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
 |}];;
 
 (* Syntax: float# c
@@ -128,7 +177,16 @@ Line 1, characters 9-15:
 1 | type t = float# c;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           used as a function result
+           an object
+           an object field
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
 |}];;
 
 let f (_ : float# c) = ();;
@@ -137,7 +195,16 @@ Line 1, characters 11-17:
 1 | let f (_ : float# c) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           used as a function result
+           an object
+           an object field
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
 |}];;
 
 type t = C of float# c;;
@@ -146,7 +213,16 @@ Line 1, characters 14-20:
 1 | type t = C of float# c;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           used as a function result
+           an object
+           an object field
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
 |}];;
 
 type t = C : float# c -> t;;
@@ -155,7 +231,16 @@ Line 1, characters 13-19:
 1 | type t = C : float# c -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
+       But the layout of float# must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           used as a function result
+           an object
+           an object field
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
 |}];;
 
 (* Syntax: float #c

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
@@ -3,4 +3,8 @@ File "insert.ml", line 5, characters 47-48:
                                                    ^
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           used as a function result
+           imported from another compilation unit 

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.ml
@@ -12,3 +12,4 @@
    ocamlc_byte_exit_status = "2"
    ***** check-ocamlc.byte-output
 *)
+(* CR layouts v2.9: error message here is unreviewed *)

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -3,4 +3,8 @@ File "insert_extensible.ml", line 5, characters 58-59:
                                                               ^
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           used as a function result
+           imported from another compilation unit 

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.ml
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.ml
@@ -12,3 +12,5 @@
    ocamlc_byte_exit_status = "2"
    ***** check-ocamlc.byte-output
 *)
+
+(* CR layouts v2.9: error message here is unreviewed *)

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -11,7 +11,6 @@ module = "b.ml"
 script = "rm -f a.cmi"
 ***** expect
 *)
-(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 (* CR layouts v2.5: The commented out code in this file uses void, but could
    use any non-value layout. *)
@@ -37,6 +36,8 @@ type foo = B.b_imm imm_arg
 type bar = B.b_value value_arg
 type boz = B.b_imm value_arg
 |}];;
+
+(* CR layouts v2.9: the error message below is unreviewed *)
 
 (* These should not *)
 type err1 = b_value imm_arg;;

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -11,6 +11,7 @@ module = "b.ml"
 script = "rm -f a.cmi"
 ***** expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 (* CR layouts v2.5: The commented out code in this file uses void, but could
    use any non-value layout. *)
@@ -45,8 +46,10 @@ Line 1, characters 12-19:
                 ^^^^^^^
 Error: This type B.b_value = A.a_value should be an instance of type
          ('a : immediate)
-       B.b_value has an unknown layout,
-         which might not be a sublayout of immediate.
+       The layout of B.b_value is value, because
+         imported from another compilation unit.
+       But the layout of B.b_value must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type imm_arg.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
@@ -10,6 +10,8 @@ module = "function_b.ml"
 script = "rm -f function_a.cmi"
 ***** expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
+
 
 #directory "ocamlc.byte";;
 #load "function_b.cmo";;
@@ -24,7 +26,10 @@ Line 1, characters 40-54:
 1 | let f0 (g : Function_b.fun_t) = g ~arg1:(assert false)
                                             ^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         a missing .cmi file for Function_a.t.
+       But the layout of Function_a.t must be a sublayout of '_representable_layout_1, because
+         used as a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -36,7 +41,10 @@ Line 1, characters 34-36:
 1 | let f1 (g : Function_b.fun_t) = g ()
                                       ^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         a missing .cmi file for Function_a.t.
+       But the layout of Function_a.t must be a sublayout of '_representable_layout_2, because
+         used as a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -48,7 +56,10 @@ Line 1, characters 28-56:
 1 | let f2 : Function_b.fun_t = fun ~arg1:_ ~arg2 () -> arg2
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         a missing .cmi file for Function_a.t.
+       But the layout of Function_a.t must be a sublayout of '_representable_layout_3, because
+         used as a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -60,7 +71,10 @@ Line 1, characters 31-53:
 1 | let f3 : Function_b.return_t = fun () -> assert false
                                    ^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         a missing .cmi file for Function_a.t.
+       But the layout of Function_a.t must be a sublayout of '_representable_layout_4, because
+         used as a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -74,7 +88,10 @@ Line 2, characters 12-28:
 2 | let x1 = f4 Function_b.f_opt
                 ^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         a missing .cmi file for Function_a.t.
+       But the layout of Function_a.t must be a sublayout of '_representable_layout_5, because
+         used as a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -88,7 +105,10 @@ Line 2, characters 12-30:
 2 | let x2 = f5 Function_b.f_opt_2
                 ^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         a missing .cmi file for Function_a.t.
+       But the layout of Function_a.t must be a sublayout of '_representable_layout_6, because
+         used as a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -2,6 +2,7 @@
    flags = "-extension layouts_beta"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 type t_value : value
 type t_imm : immediate
@@ -55,7 +56,10 @@ Line 1, characters 8-36:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : immediate)
-       int list has layout value, which is not a sublayout of immediate.
+       The layout of int list is value, because
+         a boxed variant.
+       But the layout of int list must be a sublayout of immediate, because
+         of the annotation on the type variable a.
 |}]
 (* CR layouts: error message could be phrased better *)
 
@@ -98,7 +102,10 @@ Line 1, characters 9-15:
 1 | type t = string t2_imm
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t2_imm.
 |}]
 
 let f : 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -217,7 +224,10 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on the universal variable a.
 |}]
 
 let r = { field = fun x -> x }
@@ -250,7 +260,12 @@ Line 2, characters 18-55:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because all of the following:
+           used as a function result
+           used as a function argument
+           an unannotated universal variable
+       But the layout of 'a must be a sublayout of immediate, because
+         of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
 
@@ -264,7 +279,13 @@ type ('a : immediate) t_imm
 Line 3, characters 15-39:
 3 | type s = { f : ('a : value). 'a -> 'a u }
                    ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type 'a has layout value, which is not a sublayout of immediate.
+Error: The layout of Type 'a is value, because all of the following:
+           used as a function argument
+           appears as an unannotated type parameter
+           of the annotation on the universal variable a
+       But the layout of Type 'a must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t_imm.
+
 |}]
 (* CR layouts v1.5: the location on that message is wrong. But it's hard
    to improve, because it comes from re-checking typedtree, where we don't
@@ -295,7 +316,10 @@ Line 1, characters 29-36:
 Error: This pattern matches values of type a
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_1)
-       a has layout any, which is not representable.
+       The layout of a is any, because
+         of the annotation on the abstract type declaration for a.
+       But the layout of a must be a sublayout of '_representable_layout_1, because
+         used as a function argument.
 |}]
 
 (****************************************)
@@ -389,7 +413,10 @@ Line 1, characters 43-51:
                                                ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on the universal variable a.
 |}]
 
 (**************************************)
@@ -491,7 +518,12 @@ Line 1, characters 37-53:
                                          ^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because all of the following:
+           used as a function result
+           used as a function argument
+           of the annotation on the universal variable a
+       But the layout of 'a must be a sublayout of immediate, because
+         of the annotation on the universal variable a.
 |}]
 
 type (_ : value) g =

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -2,6 +2,7 @@
    flags = "-extension layouts_alpha"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 type t_any   : any
 type t_value : value
@@ -36,7 +37,11 @@ Line 2, characters 17-22:
 2 |   val f : int -> t_any
                      ^^^^^
 Error: Function return types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_1, because
+         used as a function result.
+
 |}];;
 
 module type S1 = sig
@@ -47,7 +52,11 @@ Line 2, characters 10-15:
 2 |   val f : t_any -> int
               ^^^^^
 Error: Function argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_2, because
+         used as a function argument.
+
 |}];;
 
 module type S1 = sig
@@ -60,8 +69,12 @@ Line 4, characters 35-41:
 4 |   type 'a s = 'a -> int constraint 'a = t
                                        ^^^^^^
 Error: The type constraints are not consistent.
-       Type ('a : '_representable_layout_1) is not compatible with type t
-       t has layout any, which is not representable.
+       Type ('a : '_representable_layout_3) is not compatible with type t
+       The layout of t is any, because
+         of the annotation on the declaration of the type t.
+       But the layout of t must be a sublayout of '_representable_layout_3, because all of the following:
+           used as a function argument
+           appears as an unannotated type parameter
 |}]
 
 module type S1 = sig
@@ -74,8 +87,12 @@ Line 4, characters 35-41:
 4 |   type 'a s = int -> 'a constraint 'a = t
                                        ^^^^^^
 Error: The type constraints are not consistent.
-       Type ('a : '_representable_layout_2) is not compatible with type t
-       t has layout any, which is not representable.
+       Type ('a : '_representable_layout_4) is not compatible with type t
+       The layout of t is any, because
+         of the annotation on the declaration of the type t.
+       But the layout of t must be a sublayout of '_representable_layout_4, because all of the following:
+           used as a function result
+           appears as an unannotated type parameter
 |}]
 
 let f1 () : t_any = assert false;;
@@ -84,8 +101,11 @@ Line 1, characters 20-32:
 1 | let f1 () : t_any = assert false;;
                         ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
-         ('a : '_representable_layout_3)
-       t_any has layout any, which is not representable.
+         ('a : '_representable_layout_5)
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_5, because
+         used as a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -95,8 +115,11 @@ Line 1, characters 7-18:
            ^^^^^^^^^^^
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
-         ('a : '_representable_layout_4)
-       t_any has layout any, which is not representable.
+         ('a : '_representable_layout_6)
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_6, because
+         used as a function argument.
 |}];;
 
 (*****************************************************)
@@ -174,7 +197,11 @@ Line 1, characters 27-33:
 1 | module F2 (X : sig val x : t_void end) = struct
                                ^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout void, which is not a sublayout of value.
+       The layout of x is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of x must be a sublayout of value, because
+         stored in a module structure.
+
 |}];;
 (* CR layouts v5: the test above should be made to work *)
 
@@ -213,7 +240,10 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type imm_id.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -233,7 +263,10 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type imm_id.
 |}]
 
 (************************************)
@@ -246,7 +279,10 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}];;
 
 type s4 = string t4
@@ -257,7 +293,10 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type s4 = int t4
@@ -287,7 +326,10 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       s5 has layout value, which is not a sublayout of immediate.
+       The layout of s5 is value, because
+         it equals the primitive value type string.
+       But the layout of s5 must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 (* CR layouts v2.9: improve error, which will require layout histories *)
 
@@ -340,7 +382,12 @@ Lines 4-5, characters 33-22:
 5 |   | Void5 x -> Void5 x
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       'a has layout void, which is not a sublayout of value.
+       The layout of 'a is void, because all of the following:
+           used as constructor field 0
+           of the annotation on 'a in the declaration of the type void5
+       But the layout of 'a must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}];;
 
 (* disallowed attempts to use f5 and Void5 on non-voids *)
@@ -350,7 +397,11 @@ Line 1, characters 12-15:
 1 | let h5 (x : int void5) = f5 x
                 ^^^
 Error: This type int should be an instance of type ('a : void)
-       int has layout immediate, which is not a sublayout of void.
+       The layout of int is immediate, because
+         it equals the primitive immediate type int.
+       But the layout of int must be a sublayout of void, because all of the following:
+           used as constructor field 0
+           of the annotation on 'a in the declaration of the type void5
 |}];;
 
 let h5' (x : int any5) = Void5 x
@@ -360,7 +411,11 @@ Line 1, characters 31-32:
                                    ^
 Error: This expression has type int any5
        but an expression was expected of type ('a : void)
-       int any5 has layout value, which is not a sublayout of void.
+       The layout of int any5 is value, because
+         a boxed variant.
+       But the layout of int any5 must be a sublayout of void, because all of the following:
+           used as constructor field 0
+           of the annotation on 'a in the declaration of the type void5
 |}];;
 
 (* disallowed - tries to return void *)
@@ -374,7 +429,12 @@ Lines 1-3, characters 6-16:
 3 |   | Void5 x -> x..
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       'a has layout void, which is not a sublayout of value.
+       The layout of 'a is void, because all of the following:
+           used as constructor field 0
+           of the annotation on 'a in the declaration of the type void5
+       But the layout of 'a must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 
 (****************************************)
@@ -400,7 +460,11 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because all of the following:
+           used as a function argument
+           an unannotated universal variable
+       But the layout of 'a must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
 
 let o6 = object
@@ -413,7 +477,11 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because all of the following:
+           used as a function argument
+           an unannotated universal variable
+       But the layout of 'a must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -432,7 +500,10 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       int * int has layout value, which is not a sublayout of immediate.
+       The layout of int * int is value, because
+         a tuple type.
+       But the layout of int * int must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t7.
 |}]
 
 (**********************************************************)
@@ -448,7 +519,11 @@ Line 2, characters 40-46:
 2 |   type foo1 = [ `Foo1 of int | `Baz1 of t_void | `Bar1 of string ];;
                                             ^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+        The layout of t_void is void, because
+          of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a field of a polymorphic variant.
+
 |}];;
 
 module M8_2 = struct
@@ -478,7 +553,11 @@ Line 4, characters 13-19:
 4 |   type bad = t_void t
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           a field of a polymorphic variant
+           appears as an unannotated type parameter
 |}];;
 
 module M8_4 = struct
@@ -490,8 +569,11 @@ Line 2, characters 54-78:
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
-       void_unboxed_record has layout void,
-         which is not a sublayout of value.
+       The layout of void_unboxed_record is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of void_unboxed_record must be a sublayout of value, because all of the following:
+           a field of a polymorphic variant
+           appears as an unannotated type parameter
 |}];;
 
 module type S8_5 = sig
@@ -502,7 +584,11 @@ Line 2, characters 17-23:
 2 |   val x : [`A of t_void]
                      ^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+        The layout of t_void is void, because
+          of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a field of a polymorphic variant.
+
 |}]
 
 (************************************************)
@@ -517,7 +603,11 @@ Line 2, characters 20-26:
 2 |   type foo1 = int * t_void * [ `Foo1 of int | `Bar1 of string ];;
                         ^^^^^^
 Error: Tuple element types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+        The layout of t_void is void, because
+          of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a tuple element.
+
 |}];;
 
 module M9_2 = struct
@@ -528,8 +618,11 @@ Line 2, characters 31-50:
 2 |   type result = V of (string * void_unboxed_record) | I of int
                                    ^^^^^^^^^^^^^^^^^^^
 Error: Tuple element types must have layout value.
-        void_unboxed_record has layout void,
-          which is not a sublayout of value.
+        The layout of void_unboxed_record is void, because
+          of the annotation on the declaration of the type t_void.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         a tuple element.
+
 |}];;
 
 module M9_3 = struct
@@ -546,8 +639,10 @@ Line 7, characters 13-14:
                  ^
 Error: This expression has type void_unboxed_record
        but an expression was expected of type ('a : value)
-       void_unboxed_record has layout void,
-         which is not a sublayout of value.
+       The layout of void_unboxed_record is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         a tuple element.
 |}];;
 
 module M9_4 = struct
@@ -561,8 +656,10 @@ Line 4, characters 8-16:
             ^^^^^^^^
 Error: The record field vur_void belongs to the type void_unboxed_record
        but is mixed here with fields of type ('a : value)
-       void_unboxed_record has layout void,
-         which is not a sublayout of value.
+       The layout of void_unboxed_record is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         a boxed record.
 |}];;
 
 module M9_5 = struct
@@ -575,7 +672,11 @@ Line 4, characters 13-19:
 4 |   type bad = t_void t
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           a tuple element
+           appears as an unannotated type parameter
 |}];;
 
 module M9_6 = struct
@@ -587,8 +688,11 @@ Line 2, characters 34-58:
                                       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
-       void_unboxed_record has layout void,
-         which is not a sublayout of value.
+       The layout of void_unboxed_record is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of void_unboxed_record must be a sublayout of value, because all of the following:
+           a tuple element
+           appears as an unannotated type parameter
 |}];;
 
 module type S9_7 = sig
@@ -599,7 +703,11 @@ Line 2, characters 16-22:
 2 |   val x : int * t_void
                     ^^^^^^
 Error: Tuple element types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+        The layout of t_void is void, because
+          of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a tuple element.
+
 |}];;
 
 module M9_9 (X : sig
@@ -615,7 +723,10 @@ Line 5, characters 11-23:
                ^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a tuple element.
 |}];;
 
 (*************************************************)
@@ -655,7 +766,11 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type string is not compatible with the type string
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because all of the following:
+           of the annotation on 'a in the declaration of the type t
+           of the annotation on 'a in the declaration of the type t
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -692,7 +807,11 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type string t = string is not compatible with the type string
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because all of the following:
+           of the annotation on 'a in the declaration of the type t
+           of the annotation on 'a in the declaration of the type t
 |}]
 
 (**************************************************************)
@@ -708,7 +827,12 @@ Line 5, characters 4-7:
 5 |     t.v # baz11
         ^^^
 Error: Methods must have layout value.
-       This expression has layout void, which does not overlap with value.
+       The layout of This expression is void, because all of the following:
+           used in the declaration of the record field "v/447"
+           of the annotation on 'a in the declaration of the type t
+       But the layout of This expression must overlap with value, because
+         an object.
+
 |}]
 
 module M11_2 = struct
@@ -720,7 +844,11 @@ Line 2, characters 17-30:
                      ^^^^^^^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           an object field
+           an object field
 |}];;
 
 module M11_3 = struct
@@ -734,7 +862,12 @@ Line 4, characters 12-33:
                 ^^^^^^^^^^^^^^^^^^^^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       'a has layout void, which is not a sublayout of value.
+       The layout of 'a is void, because all of the following:
+           used as constructor field 0
+           of the annotation on 'a in the declaration of the type t
+       But the layout of 'a must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}];;
 
 module M11_4 = struct
@@ -745,7 +878,11 @@ Line 2, characters 12-22:
 2 |   val x : < l : t_void >
                 ^^^^^^^^^^
 Error: Object field types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+        The layout of t_void is void, because
+          of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         an object field.
+
 |}];;
 
 module M11_5 = struct
@@ -757,7 +894,10 @@ Line 3, characters 2-24:
 3 |   and ('a : void) s = 'a
       ^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       'a s has layout void, which does not overlap with value.
+       The layout of 'a s is void, because
+         of the annotation on 'a in the declaration of the type s.
+       But the layout of 'a s must overlap with value, because
+         an object field.
 |}];;
 
 module M11_6 = struct
@@ -769,7 +909,11 @@ Line 2, characters 36-47:
                                         ^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           an object field
+           appears as an unannotated type parameter
 |}];;
 
 (*******************************************************************)
@@ -788,7 +932,11 @@ Line 3, characters 11-12:
 3 |     let VV v = v in
                ^
 Error: Variables bound in a class must have layout value.
-       v has layout void, which is not a sublayout of value.
+       The layout of v is void, because
+         bound by a `let`.
+       But the layout of v must be a sublayout of value, because
+         let-bound in a class expression.
+
 |}];;
 
 (* Hits the Cfk_concrete case of Pcf_val *)
@@ -803,7 +951,11 @@ Line 4, characters 10-13:
 4 |       val bar = v.vr_void
               ^^^
 Error: Variables bound in a class must have layout value.
-       bar has layout void, which is not a sublayout of value.
+       The layout of bar is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of bar must be a sublayout of value, because
+         an class field.
+
 |}];;
 
 (* Hits the Cfk_virtual case of Pcf_val *)
@@ -818,7 +970,11 @@ Line 4, characters 18-21:
 4 |       val virtual bar : t_void
                       ^^^
 Error: Variables bound in a class must have layout value.
-       bar has layout void, which is not a sublayout of value.
+       The layout of bar is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of bar must be a sublayout of value, because
+         an class field.
+
 |}];;
 
 module M12_4 = struct
@@ -834,7 +990,11 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with void.
+       The layout of 'a is value, because all of the following:
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
+       But the layout of 'a must overlap with void, because
+         of the annotation on 'a in the declaration of the type t.
 |}];;
 
 module M12_5 = struct
@@ -850,7 +1010,12 @@ Line 6, characters 29-31:
 6 |       method void_id (A a) : 'a t = a
                                  ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with void.
+       The layout of 'a is value, because all of the following:
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
+       But the layout of 'a must overlap with void, because all of the following:
+           used as constructor field 0
+           of the annotation on 'a in the declaration of the type t
 |}];;
 
 module type S12_6 = sig
@@ -867,7 +1032,12 @@ Line 5, characters 4-6:
 5 |     'a t ->
         ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with void.
+       The layout of 'a is value, because all of the following:
+           appears as an unannotated type parameter
+           a term-level argument to a class constructor
+       But the layout of 'a must overlap with void, because all of the following:
+           used as constructor field 0
+           of the annotation on 'a in the declaration of the type t
 |}];;
 
 module type S12_7 = sig
@@ -881,7 +1051,11 @@ Line 4, characters 6-22:
 4 |       val baz : t_void
           ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       baz has layout void, which is not a sublayout of value.
+       The layout of baz is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of baz must be a sublayout of value, because
+         an instance variable.
+
 |}];;
 
 (***********************************************************)
@@ -894,7 +1068,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void Lazy.t;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         imported from another compilation unit.
 |}];;
 
 let x13 (VV v) = lazy v;;
@@ -904,7 +1081,10 @@ Line 1, characters 22-23:
                           ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a lazy expression.
 |}];;
 
 let x13 v =
@@ -916,7 +1096,10 @@ Line 3, characters 17-18:
                      ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a lazy expression.
 |}];;
 
 (* option *)
@@ -927,7 +1110,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void option;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 let x13 (VV v) = Some v;;
@@ -937,7 +1123,10 @@ Line 1, characters 22-23:
                           ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 let x13 v =
@@ -950,7 +1139,11 @@ Line 3, characters 17-18:
                      ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
 |}];;
 
 (* list *)
@@ -961,7 +1154,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void list;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 let x13 (VV v) = [v];;
@@ -971,7 +1167,10 @@ Line 1, characters 18-19:
                       ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 let x13 v =
@@ -984,7 +1183,11 @@ Line 3, characters 14-15:
                   ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
 |}];;
 
 (* array *)
@@ -995,7 +1198,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void array;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 let x13 (VV v) = [| v |];;
@@ -1005,7 +1211,10 @@ Line 1, characters 20-21:
                         ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         an array element.
 |}];;
 
 let x13 v =
@@ -1018,7 +1227,10 @@ Line 3, characters 18-19:
                       ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         an array element.
 |}];;
 
 (****************************************************************************)
@@ -1037,7 +1249,10 @@ Line 2, characters 0-18:
 2 | and foo14 = t_void;;
     ^^^^^^^^^^^^^^^^^^
 Error:
-       foo14 has layout void, which is not a sublayout of value.
+       The layout of foo14 is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of foo14 must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 (****************************************************)
@@ -1159,7 +1374,27 @@ Lines 5-7, characters 6-20:
 7 |   g (failwith "foo")..
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       'a has layout void, which is not a sublayout of value.
+       The layout of 'a is void, because all of the following:
+           used in the declaration of the record field "y/607"
+           of the annotation on 'a in the declaration of the type r
+       But the layout of 'a must be a sublayout of value, because
+         to be value for the V1 safety check.
+
+|}, Principal{|
+type t_void : void
+type ('a : void) r = { x : int; y : 'a; }
+Lines 5-7, characters 6-20:
+5 | ......() =
+6 |   let rec g { x = x ; y = y } : _ r = g { x; y } in
+7 |   g (failwith "foo")..
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of 'a is void, because all of the following:
+           used in the declaration of the record field "y/609"
+           of the annotation on 'a in the declaration of the type r
+       But the layout of 'a must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}];;
 
 (********************************************************************)
@@ -1190,7 +1425,10 @@ Line 15, characters 4-8:
 Error: This pattern matches values of type (M.t_void, M.t_void) eq
        but a pattern was expected which matches values of type
          (M.t_void, M.t_imm) eq
-       M.t_void has layout void, which does not overlap with immediate.
+       The layout of M.t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of M.t_void must overlap with immediate, because
+         of the annotation on the declaration of the type t_imm.
 |}]
 (* CR layouts v2.9: error message is OK, but it could probably be better.
    But a similar case without layouts is already pretty bad, so try
@@ -1226,7 +1464,13 @@ Line 2, characters 15-16:
                    ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           a type argument defaulted to have layout value
+           bound by a `let`
 |}]
 
 (*********************************************************)
@@ -1476,7 +1720,11 @@ Line 4, characters 9-19:
              ^^^^^^^^^^
 Error: This pattern matches values of type t_void
        but a pattern was expected which matches values of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           a tuple element
+           a tuple element
 |}]
 
 let ( let* ) x f = ()
@@ -1495,7 +1743,11 @@ Line 4, characters 9-22:
              ^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
+       But the layout of t_float64 must be a sublayout of value, because all of the following:
+           a tuple element
+           a tuple element
 |}]
 
 
@@ -1518,7 +1770,15 @@ Line 4, characters 16-28:
                     ^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           used as a function argument
+           used as a function argument
+           used as an argument in an external declaration
+           used as an argument in an external declaration
+           used as a function argument
+           used as a function argument
 |}]
 
 (**************************************)
@@ -1544,7 +1804,12 @@ Line 8, characters 27-28:
                                ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because all of the following:
+           used as a function argument
+           used as a function result
+           used as a function argument
 |}]
 
 (**************************************************)
@@ -1559,7 +1824,10 @@ Line 1, characters 41-43:
 1 | type ('a : void) poly_var = [`A of int * 'a | `B]
                                              ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       'a has layout void, which does not overlap with value.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type poly_var.
+       But the layout of 'a must overlap with value, because
+         a tuple element.
 |}]
 
 (* CR layouts bug: this should be accepted (or maybe we should reject
@@ -1578,7 +1846,10 @@ Line 1, characters 14-37:
                   ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         a field of a polymorphic variant.
 |}]
 
 (******************************************************)
@@ -1590,7 +1861,11 @@ Line 1, characters 17-22:
 1 | external foo33 : t_any = "foo33";;
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
-       foo33 has layout any, which is not a sublayout of value.
+       The layout of foo33 is any, because
+         of the annotation on the declaration of the type t_any.
+       But the layout of foo33 must be a sublayout of value, because
+         stored in a module structure.
+
 |}]
 
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -2,6 +2,7 @@
    flags = "-extension layouts_beta"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 type t_value : value
 type t_imm   : immediate
@@ -73,7 +74,10 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type imm_id.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -93,7 +97,10 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type imm_id.
 |}]
 
 (************************************)
@@ -106,7 +113,10 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}];;
 
 type s4 = string t4
@@ -117,7 +127,10 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type s4 = int t4
@@ -147,7 +160,10 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       s5 has layout value, which is not a sublayout of immediate.
+       The layout of s5 is value, because
+         it equals the primitive value type string.
+       But the layout of s5 must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 (* CR layouts v2.9: improve error, which requires layout histories *)
 
@@ -210,7 +226,11 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because all of the following:
+           used as a function argument
+           an unannotated universal variable
+       But the layout of 'a must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
 
 let o6 = object
@@ -223,7 +243,11 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because all of the following:
+           used as a function argument
+           an unannotated universal variable
+       But the layout of 'a must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -241,7 +265,10 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       int * int has layout value, which is not a sublayout of immediate.
+       The layout of int * int is value, because
+         a tuple type.
+       But the layout of int * int must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t7.
 |}]
 
 (**********************************************************)
@@ -296,7 +323,11 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type string is not compatible with the type string
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because all of the following:
+           of the annotation on 'a in the declaration of the type t
+           of the annotation on 'a in the declaration of the type t
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -333,7 +364,11 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type string t = string is not compatible with the type string
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because all of the following:
+           of the annotation on 'a in the declaration of the type t
+           of the annotation on 'a in the declaration of the type t
 |}]
 
 (**************************************************************)
@@ -543,5 +578,11 @@ type ('a : immediate) t2_imm
 Line 3, characters 15-40:
 3 | type s = { f : ('a : value) . 'a -> 'a u }
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type 'a has layout value, which is not a sublayout of immediate.
+Error: The layout of Type 'a is value, because all of the following:
+           used as a function argument
+           appears as an unannotated type parameter
+           of the annotation on the universal variable a
+       But the layout of Type 'a must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t2_imm.
+
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -2,6 +2,7 @@
    flags = "-extension layouts_alpha"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 (* Tests for layouts in algebraic datatypes *)
 
@@ -49,7 +50,11 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_1, because
+         used as constructor field 0.
+
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -58,7 +63,11 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_2, because
+         used as constructor field 1.
+
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -67,7 +76,11 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_3, because
+         used as constructor field 0.
+
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -77,7 +90,10 @@ Line 2, characters 0-29:
 2 | and 'b t1_constraint' = t_any
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       'b t1_constraint' has layout any, which is not representable.
+       The layout of 'b t1_constraint' is any, because
+         of the annotation on the declaration of the type t_any.
+       But the layout of 'b t1_constraint' must be a sublayout of '_representable_layout_4, because
+         appears as an unannotated type parameter.
 |}]
 (* CR layouts errors: this error is blamed on the wrong piece *)
 
@@ -135,7 +151,11 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_5, because
+         used in the declaration of the record field "x/341".
+
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -144,7 +164,11 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_6, because
+         used in the declaration of the record field "y/344".
+
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -153,7 +177,11 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_7, because
+         used in the declaration of the record field "x/346".
+
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -162,7 +190,11 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_8, because
+         used in the declaration of the record field "x/350".
+
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -171,7 +203,11 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_9, because
+         used in the declaration of the record field "y/354".
+
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -180,7 +216,11 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_10, because
+         used in the declaration of the record field "x/357".
+
 |}];;
 
 (*********************************************************)
@@ -211,7 +251,11 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_11, because
+         used as constructor field 0.
+
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -220,7 +264,11 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_12, because
+         used as constructor field 1.
+
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -229,7 +277,11 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_13, because
+         used as constructor field 0.
+
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -260,7 +312,11 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+        The layout of t_any is any, because
+          of the annotation on the declaration of the type t_any.
+       But the layout of t_any must be a sublayout of '_representable_layout_14, because
+         used in the declaration of the record field "y/387".
+
 |}];;
 
 (**************************************************************************)
@@ -283,7 +339,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       float has layout value, which is not a sublayout of immediate.
+       The layout of float is value, because
+         it equals the primitive value type float.
+       But the layout of float must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type s6.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_beta.ml
@@ -2,6 +2,7 @@
    flags = "-extension layouts_beta"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 (* Tests for layouts in algebraic datatypes *)
 
@@ -79,7 +80,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       float has layout value, which is not a sublayout of immediate.
+       The layout of float is value, because
+         it equals the primitive value type float.
+       But the layout of float must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type s6.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -2,6 +2,7 @@
    * expect
    flags = "-extension layouts"
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 type t_value : value
 type t_imm   : immediate
@@ -132,7 +133,11 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type Bar3.t has layout value, which is not a sublayout of immediate.
+Error: The layout of Type Bar3.t is value, because
+         of the annotation on the declaration of the type t.
+       But the layout of Type Bar3.t must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t/2.
+
 |}];;
 
 module rec Foo3 : sig
@@ -178,7 +183,11 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: Type string has layout value, which is not a sublayout of immediate.
+Error: The layout of Type string is value, because
+         it equals the primitive value type string.
+       But the layout of Type string must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}]
 
 (*****************************************)
@@ -216,7 +225,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 module type S6_6' = sig
@@ -233,7 +246,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 (* CR layouts: this is broken because of the package with-type hack.  It was
@@ -254,7 +271,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -2,6 +2,7 @@
    flags = "-extension layouts_alpha"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 type t_any   : any
 type t_value : value
@@ -37,7 +38,11 @@ Line 1, characters 32-34:
                                     ^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : void)
-       'a has layout void, which does not overlap with value.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value, because all of the following:
+           a type argument defaulted to have layout value
+           appears as an unannotated type parameter
 |}];;
 
 module type S1'' = S1 with type s = t_void;;
@@ -46,7 +51,11 @@ module type S1'' = S1 with type s = t_void;;
 Line 1, characters 27-42:
 1 | module type S1'' = S1 with type s = t_void;;
                                ^^^^^^^^^^^^^^^
-Error: Type t_void has layout void, which is not a sublayout of value.
+Error: The layout of Type t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of Type t_void must be a sublayout of value, because
+         the default layout for an abstract type.
+
 |}]
 
 module type S1_2 = sig
@@ -86,7 +95,14 @@ Error: Signature mismatch:
        is not included in
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
-       because their layouts are different.
+       because their layouts are different.'a value, because all of the following:
+                                               a type argument defaulted to have layout value
+                                               appears as an unannotated type parameter
+                                           'a immediate, because
+                                             of the annotation on 'a
+                                                                  in the declaration of the type
+                                                                  t.
+
 |}]
 
 (************************************************************************)
@@ -127,7 +143,11 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because all of the following:
+           of the annotation on 'a in the declaration of the type s2'
+           of the annotation on 'a in the declaration of the type t
 |}]
 
 (******************************************************************)
@@ -182,7 +202,11 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type Bar3.t has layout value, which is not a sublayout of immediate.
+Error: The layout of Type Bar3.t is value, because
+         of the annotation on the declaration of the type t.
+       But the layout of Type Bar3.t must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t/2.
+
 |}];;
 
 module rec Foo3 : sig
@@ -217,7 +241,10 @@ Line 2, characters 26-28:
 2 |   type 'a t = 'a Bar3.t * 'a list
                               ^^
 Error: This type ('a : void) should be an instance of type ('b : value)
-       'a has layout void, which does not overlap with value.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 (* One downside of the current approach - this could be allowed, but isn't.  You
@@ -245,7 +272,10 @@ Line 12, characters 11-17:
 12 |   type s = Foo3.t t
                 ^^^^^^
 Error: This type Foo3.t should be an instance of type ('a : void)
-       Foo3.t has layout value, which is not a sublayout of void.
+       The layout of Foo3.t is value, because
+         the default layout for an abstract type.
+       But the layout of Foo3.t must be a sublayout of void, because
+         of the annotation on 'a in the declaration of the type t.
 |}];;
 
 (* Previous example works with annotation *)
@@ -295,7 +325,10 @@ Line 1, characters 11-15:
 1 | type t4' = M4.s t4_void;;
                ^^^^
 Error: This type M4.s should be an instance of type ('a : void)
-       M4.s has layout value, which is not a sublayout of void.
+       The layout of M4.s is value, because
+         a boxed variant.
+       But the layout of M4.s must be a sublayout of void, because
+         of the annotation on 'a in the declaration of the type t4_void.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -322,7 +355,10 @@ Line 1, characters 10-15:
 1 | type t4 = M4'.s t4_void;;
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : void)
-       M4'.s has layout immediate, which is not a sublayout of void.
+       The layout of M4'.s is immediate, because
+         of the annotation on the declaration of the type t.
+       But the layout of M4'.s must be a sublayout of void, because
+         of the annotation on 'a in the declaration of the type t4_void.
 |}];;
 
 (************************************)
@@ -352,7 +388,10 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}]
 
 module type S3_2 = sig
@@ -365,7 +404,11 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: Type string has layout value, which is not a sublayout of immediate.
+Error: The layout of Type string is value, because
+         it equals the primitive value type string.
+       But the layout of Type string must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}]
 
 (*****************************************)
@@ -388,7 +431,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : void
-       the first has layout value, which is not a sublayout of void.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of void, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 module type S6_3 = sig
@@ -404,7 +451,11 @@ Line 6, characters 33-34:
 6 |   val m : (module S6_3 with type t = t_void)
                                      ^
 Error: Signature package constraint types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+        The layout of t_void is void, because
+          of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         used as an element in a first-class module.
+
 |}];;
 
 module type S6_5 = sig
@@ -425,7 +476,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 module type S6_6' = sig
@@ -442,7 +497,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -460,7 +519,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 (*****************************************)
@@ -486,5 +549,9 @@ Line 1, characters 28-33:
 1 | module type S = sig val x : t_any end
                                 ^^^^^
 Error: This type signature for x is not a value type.
-       x has layout any, which is not a sublayout of value.
+       The layout of x is any, because
+         of the annotation on the declaration of the type t_any.
+       But the layout of x must be a sublayout of value, because
+         stored in a module structure.
+
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -2,6 +2,7 @@
    flags = "-extension layouts_beta"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
 
 type t_value : value
 type t_imm   : immediate
@@ -82,7 +83,14 @@ Error: Signature mismatch:
        is not included in
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
-       because their layouts are different.
+       because their layouts are different.'a value, because all of the following:
+                                               a type argument defaulted to have layout value
+                                               appears as an unannotated type parameter
+                                           'a immediate, because
+                                             of the annotation on 'a
+                                                                  in the declaration of the type
+                                                                  t.
+
 |}]
 
 module M1_2''' : S1_2 = struct
@@ -104,7 +112,14 @@ Error: Signature mismatch:
          type ('a : immediate) t
        Their parameters differ:
        The type ('a : value) is not equal to the type ('a0 : immediate)
-       because their layouts are different.
+       because their layouts are different.'a value, because all of the following:
+                                               a type argument defaulted to have layout value
+                                               appears as an unannotated type parameter
+                                           'a immediate, because
+                                             of the annotation on 'a
+                                                                  in the declaration of the type
+                                                                  t.
+
 |}]
 
 (************************************************************************)
@@ -145,7 +160,11 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because all of the following:
+           of the annotation on 'a in the declaration of the type s2'
+           of the annotation on 'a in the declaration of the type t
 |}]
 
 (******************************************************************)
@@ -201,7 +220,11 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type Bar3.t has layout value, which is not a sublayout of immediate.
+Error: The layout of Type Bar3.t is value, because
+         of the annotation on the declaration of the type t.
+       But the layout of Type Bar3.t must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t/2.
+
 |}];;
 
 module rec Foo3 : sig
@@ -312,7 +335,10 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it equals the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}]
 
 module type S3_2 = sig
@@ -325,7 +351,11 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: Type string has layout value, which is not a sublayout of immediate.
+Error: The layout of Type string is value, because
+         it equals the primitive value type string.
+       But the layout of Type string must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}]
 
 (*****************************************)
@@ -362,7 +392,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 module type S6_6' = sig
@@ -379,7 +413,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -397,7 +435,11 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         used as an element in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
+
 |}];;
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
@@ -4,7 +4,10 @@ Line 2, characters 22-24:
 2 | type ('a : void) t0 = 'a list;;
                           ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       'a has layout void, which does not overlap with value.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t0.
+       But the layout of 'a must overlap with value, because
+         a type argument defaulted to have layout value. 
 Line 2, characters 11-15:
 2 | type ('a : valu) t0 = 'a list;;
                ^^^^

--- a/ocaml/testsuite/tests/typing-layouts/parsing_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/parsing_alpha.ml
@@ -3,6 +3,8 @@
    * toplevel
 *)
 
+(* CR layouts v2.9: error message here is unreviewed *)
+
 type ('a : value) t0 = 'a list;;
 
 type ('a : immediate) t0 = 'a list;;

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -2,6 +2,8 @@
    flags = "-extension layouts_alpha"
    * expect
 *)
+(* CR layouts v2.9: all error messages below here are unreviewed *)
+
 (* CR layouts v5: when we add the ability to make actual void types, eliminate
    the uses of Obj.magic from this file *)
 
@@ -74,7 +76,11 @@ Lines 13-21, characters 8-3:
 21 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       void_rec has layout void, which is not a sublayout of value.
+       The layout of void_rec is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of void_rec must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -134,7 +140,11 @@ Lines 3-11, characters 9-3:
 11 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       void_rec has layout void, which is not a sublayout of value.
+       The layout of void_rec is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of void_rec must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -220,7 +230,11 @@ Lines 17-35, characters 10-27:
 35 |        b2 = (cons_r 1; b2)}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -431,7 +445,11 @@ Line 5, characters 4-6:
         ^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -475,7 +493,11 @@ Lines 3-11, characters 26-24:
 11 |    b2 = (cons_r 2; {v})}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -502,7 +524,11 @@ Lines 1-3, characters 26-32:
 3 |   (x, V b2.v, V b1.v, z, V a1.v)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       void_rec has layout void, which is not a sublayout of value.
+       The layout of void_rec is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of void_rec must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -611,7 +637,11 @@ Lines 1-13, characters 31-24:
 13 |   | exception Ex3 _ -> 6
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -650,7 +680,11 @@ Lines 1-13, characters 31-24:
 13 |   | exception Ex3 _ -> 6
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -688,7 +722,11 @@ Lines 1-12, characters 31-24:
 12 |   | exception Ex3 _ -> 6
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -726,7 +764,11 @@ Lines 1-12, characters 31-24:
 12 |   | exception Ex3 _ -> 6
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -805,7 +847,11 @@ Lines 8-18, characters 21-29:
 18 |   cons_r uivrh.uivrh_x; uivrh
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -852,7 +898,11 @@ Lines 5-11, characters 10-7:
 11 |     end
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -918,7 +968,11 @@ Lines 3-11, characters 22-11:
 11 |   (y, V v')
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -960,7 +1014,11 @@ Lines 3-12, characters 22-23:
 12 |   (x, V v1, V v2, V v3)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         to be value for the V1 safety check.
+
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after

--- a/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
@@ -3,6 +3,8 @@ File "baz.ml", line 1, characters 8-18:
             ^^^^^^^^^^
 Error: This expression has type 'a Foo.t
        but an expression was expected of type ('b : '_representable_layout_1)
-       'a Foo.t has an unknown layout, which might not be representable.
-       No .cmi file found containing Foo.t.
+       The layout of 'a Foo.t is any, because
+         a missing .cmi file for Foo.t.
+       But the layout of 'a Foo.t must be a sublayout of '_representable_layout_1, because
+         bound by a `let`. No .cmi file found containing Foo.t.
        Hint: Adding "foo" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi-2/test.ml
+++ b/ocaml/testsuite/tests/typing-missing-cmi-2/test.ml
@@ -13,3 +13,5 @@ module = "baz.ml"
 ocamlc_byte_exit_status = "2"
 ****** check-ocamlc.byte-output
 *)
+
+(* CR layouts v2.9: error message here is unreviewed *)

--- a/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
@@ -2,6 +2,9 @@ File "client.ml", line 2, characters 0-19:
 2 | and alias = missing
     ^^^^^^^^^^^^^^^^^^^
 Error: 
-       alias has an unknown layout, which might not be a sublayout of value.
+       The layout of alias is any, because
+         a dummy layout used in checking mutually recursive datatypes.
+       But the layout of alias must be a sublayout of value, because
+         a type argument defaulted to have layout value. 
        No .cmi file found containing Missing.t.
        Hint: Adding "missing" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.ml
+++ b/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.ml
@@ -14,3 +14,5 @@ module = "client.ml"
 ocamlc_byte_exit_status = "2"
 ****** check-ocamlc.byte-output
 *)
+
+(* CR layouts v2.9: error message here is unreviewed *)

--- a/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -3,6 +3,11 @@ File "main.ml", line 1, characters 8-11:
             ^^^
 Error: This expression has type M.a but an expression was expected of type
          ('a : value)
-       M.a has an unknown layout, which might not be a sublayout of value.
+       The layout of M.a is any, because
+         a missing .cmi file for M.a.
+       But the layout of M.a must be a sublayout of value, because all of the following:
+           used as a function argument
+           used as a function argument
+           imported from another compilation unit 
        No .cmi file found containing M.a.
        Hint: Adding "m" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi/test.ml
+++ b/ocaml/testsuite/tests/typing-missing-cmi/test.ml
@@ -19,3 +19,5 @@ module = "main.ml"
 ocamlc_byte_exit_status = "2"
 ******** check-ocamlc.byte-output
 *)
+
+(* CR layouts v2.9: error message here is unreviewed *)

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -613,7 +613,7 @@ module Layout = struct
      may want to change these to experiment / debug. *)
 
   (* should we print histories at all? *)
-  let display_histories = false
+  let display_histories = true
 
   (* should we print histories in a way users can understand?
      The alternative is to print out all the data, which may be useful


### PR DESCRIPTION
This PR enables layout histories inside error messages in the `layout-histories` feature branch.

Test changes are accepted and marked as unreviewed.