### PR TITLE
Fix AFL test in flambda2

### DIFF
--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -2024,7 +2024,7 @@ let inline_lazy_force arg pos loc =
         ap_result_layout = Lambda.layout_lazy_contents;
         ap_region_close = pos;
         ap_mode = alloc_heap;
-        ap_inlined = Default_inlined;
+        ap_inlined = Never_inlined;
         ap_specialised = Default_specialise;
         ap_probe=None;
       }


### PR DESCRIPTION
This PR fixes a test failure that's been around since #1196, when we added AFL support for flambda2. It's a more principled version of #1789, which you can refer to to see what test is failing.

We fix the test failure by preventing a call to `CamlinternalLazy.force` from being inlined by flambda2 when `-afl-instrument` is in force. It's desirable to avoid this inlining because:
  * If the code is inlined, then AFL instrumentation will be inserted in all the branches.
  * `CamlinternalLazy.force` branches on whether the object header is `Forward_tag`, `Lazy_tag`, or something else.
  * When a lazy object with `Forward_tag` is traversed by the GC, the lazy object will silently be replaced by its contents, changing its tag.

In short, the current state of the world violates @stedolan's manifesto from the original PR that tries to fix this problem, ocaml/ocaml#1754:
> code that does the same thing twice should produce exactly the same instrumentation output both times

and this violation makes the `laziness` test in `ocaml/testsuite/tests/afl-instrumentation/test.ml` fail in flambda2.

This is small change on top of ocaml/ocaml#1754, which is the original attempt to prevent this problem. Flambda2 would actually go ahead and inline this attempted fix, though, and closure/flambda would not &mdash; that's why we haven't run into this problem until now.