### PR TITLE
Remove duplicated creation_reasons from layout history error messages

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -191,7 +191,7 @@ Error: This type ('b : value) should be an instance of type ('a : float64)
        The layout of 'a is float64, because
          of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value, because
-         appears as an unannotated type parameter.
+         a tuple element.
 |}]
 
 (****************************************************)
@@ -726,7 +726,7 @@ Error: This expression has type ('a : value)
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         used as a function argument.
+         captured in an object.
 |}];;
 
 let f12_14 (m1 : t_float64) (m2 : t_float64) = object

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -190,10 +190,8 @@ Line 1, characters 32-34:
 Error: This type ('b : value) should be an instance of type ('a : float64)
        The layout of 'a is float64, because
          of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because all of the following:
-           used as a function argument
-           a tuple element
-           appears as an unannotated type parameter
+       But the layout of 'a must overlap with value, because
+         appears as an unannotated type parameter.
 |}]
 
 (****************************************************)
@@ -412,9 +410,8 @@ Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
-       But the layout of t_float64 must be a sublayout of value, because all of the following:
-           used as a function argument
-           used as a function result
+       But the layout of t_float64 must be a sublayout of value, because
+         used as a function result.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -426,9 +423,8 @@ Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
-       But the layout of 'a t_float64_id must overlap with value, because all of the following:
-           used as a function argument
-           used as a function result
+       But the layout of 'a t_float64_id must overlap with value, because
+         used as a function result.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -440,9 +436,8 @@ Error: This expression has type float# but an expression was expected of type
          ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           used as a function argument
-           used as a function result
+       But the layout of float# must be a sublayout of value, because
+         used as a function result.
 |}];;
 
 (*************************************)
@@ -635,9 +630,8 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_float64_id -> 'a t_float64_id = assert false
                  ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because all of the following:
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       The layout of 'a is value, because
+         a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
 |}];;
@@ -690,9 +684,8 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_float64_id -> 'a t_float64_id
               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because all of the following:
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       The layout of 'a is value, because
+         a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
 |}];;
@@ -732,9 +725,8 @@ Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
-       But the layout of t_float64 must be a sublayout of value, because all of the following:
-           captured in an object
-           used as a function argument
+       But the layout of t_float64 must be a sublayout of value, because
+         used as a function argument.
 |}];;
 
 let f12_14 (m1 : t_float64) (m2 : t_float64) = object
@@ -770,9 +762,8 @@ Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
-       But the layout of t_float64 must be a sublayout of value, because all of the following:
-           used as a function argument
-           imported from another compilation unit
+       But the layout of t_float64 must be a sublayout of value, because
+         imported from another compilation unit.
 |}];;
 
 let f13_2 (x : t_float64) = compare x x;;
@@ -784,9 +775,8 @@ Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
-       But the layout of t_float64 must be a sublayout of value, because all of the following:
-           used as a function argument
-           imported from another compilation unit
+       But the layout of t_float64 must be a sublayout of value, because
+         imported from another compilation unit.
 |}];;
 
 let f13_3 (x : t_float64) = Marshal.to_bytes x;;
@@ -798,9 +788,8 @@ Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
-       But the layout of t_float64 must be a sublayout of value, because all of the following:
-           used as a function argument
-           imported from another compilation unit
+       But the layout of t_float64 must be a sublayout of value, because
+         imported from another compilation unit.
 |}];;
 
 let f13_4 (x : t_float64) = Hashtbl.hash x;;
@@ -812,7 +801,6 @@ Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
-       But the layout of t_float64 must be a sublayout of value, because all of the following:
-           used as a function argument
-           imported from another compilation unit
+       But the layout of t_float64 must be a sublayout of value, because
+         imported from another compilation unit.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -177,9 +177,8 @@ Line 1, characters 27-29:
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
        The layout of 'a is float64, because
          of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value, because all of the following:
-           a tuple element
-           a tuple element
+       But the layout of 'a must overlap with value, because
+         a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -193,7 +192,6 @@ Error: This type ('b : value) should be an instance of type ('a : float64)
          of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value, because all of the following:
            used as a function argument
-           a tuple element
            a tuple element
            appears as an unannotated type parameter
 |}]
@@ -416,7 +414,6 @@ Error: This expression has type t_float64
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because all of the following:
            used as a function argument
-           used as a function argument
            used as a function result
 |}];;
 
@@ -431,7 +428,6 @@ Error: This expression has type 'a t_float64_id = ('a : float64)
          of the annotation on 'a in the declaration of the type t_float64_id.
        But the layout of 'a t_float64_id must overlap with value, because all of the following:
            used as a function argument
-           used as a function argument
            used as a function result
 |}];;
 
@@ -445,7 +441,6 @@ Error: This expression has type float# but an expression was expected of type
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because all of the following:
-           used as a function argument
            used as a function argument
            used as a function result
 |}];;
@@ -643,11 +638,8 @@ Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because all of the following:
            appears as an unannotated type parameter
            a term-level argument to a class constructor
-       But the layout of 'a must overlap with float64, because all of the following:
-           of the annotation on 'a in the declaration of the type
-                                t_float64_id
-           of the annotation on 'a in the declaration of the type
-                                t_float64_id
+       But the layout of 'a must overlap with float64, because
+         of the annotation on 'a in the declaration of the type t_float64_id.
 |}];;
 (* CR layouts v2.9: Error could be improved *)
 
@@ -672,9 +664,8 @@ Line 1, characters 26-43:
 Error: The method x has type float# but is expected to have type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           an object field
-           an object field
+       But the layout of float# must be a sublayout of value, because
+         an object field.
 |}];;
 (* CR layouts v2.9: Error could be improved *)
 
@@ -702,11 +693,8 @@ Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because all of the following:
            appears as an unannotated type parameter
            a term-level argument to a class constructor
-       But the layout of 'a must overlap with float64, because all of the following:
-           of the annotation on 'a in the declaration of the type
-                                t_float64_id
-           of the annotation on 'a in the declaration of the type
-                                t_float64_id
+       But the layout of 'a must overlap with float64, because
+         of the annotation on 'a in the declaration of the type t_float64_id.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -784,7 +772,6 @@ Error: This expression has type t_float64
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because all of the following:
            used as a function argument
-           used as a function argument
            imported from another compilation unit
 |}];;
 
@@ -798,7 +785,6 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because all of the following:
-           used as a function argument
            used as a function argument
            imported from another compilation unit
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -104,13 +104,8 @@ Line 1, characters 9-15:
 Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           used as a function result
-           an object
-           an object field
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       But the layout of float# must be a sublayout of value, because
+         a term-level argument to a class constructor.
 |}];;
 
 let f (_ : float#c) = ();;
@@ -121,13 +116,8 @@ Line 1, characters 11-17:
 Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           used as a function result
-           an object
-           an object field
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       But the layout of float# must be a sublayout of value, because
+         a term-level argument to a class constructor.
 |}];;
 
 type t = C of float#c;;
@@ -138,13 +128,8 @@ Line 1, characters 14-20:
 Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           used as a function result
-           an object
-           an object field
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       But the layout of float# must be a sublayout of value, because
+         a term-level argument to a class constructor.
 |}];;
 
 type t = C : float#c -> t;;
@@ -155,13 +140,8 @@ Line 1, characters 13-19:
 Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           used as a function result
-           an object
-           an object field
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       But the layout of float# must be a sublayout of value, because
+         a term-level argument to a class constructor.
 |}];;
 
 (* Syntax: float# c
@@ -175,13 +155,8 @@ Line 1, characters 9-15:
 Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           used as a function result
-           an object
-           an object field
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       But the layout of float# must be a sublayout of value, because
+         a term-level argument to a class constructor.
 |}];;
 
 let f (_ : float# c) = ();;
@@ -192,13 +167,8 @@ Line 1, characters 11-17:
 Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           used as a function result
-           an object
-           an object field
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       But the layout of float# must be a sublayout of value, because
+         a term-level argument to a class constructor.
 |}];;
 
 type t = C of float# c;;
@@ -209,13 +179,8 @@ Line 1, characters 14-20:
 Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           used as a function result
-           an object
-           an object field
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       But the layout of float# must be a sublayout of value, because
+         a term-level argument to a class constructor.
 |}];;
 
 type t = C : float# c -> t;;
@@ -226,13 +191,8 @@ Line 1, characters 13-19:
 Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
-       But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           used as a function result
-           an object
-           an object field
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       But the layout of float# must be a sublayout of value, because
+         a term-level argument to a class constructor.
 |}];;
 
 (* Syntax: float #c

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -106,7 +106,6 @@ Error: This type float# should be an instance of type ('a : value)
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because all of the following:
            a type argument defaulted to have layout value
-           a type argument defaulted to have layout value
            used as a function result
            an object
            an object field
@@ -123,7 +122,6 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
            a type argument defaulted to have layout value
            used as a function result
            an object
@@ -142,7 +140,6 @@ Error: This type float# should be an instance of type ('a : value)
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because all of the following:
            a type argument defaulted to have layout value
-           a type argument defaulted to have layout value
            used as a function result
            an object
            an object field
@@ -159,7 +156,6 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
            a type argument defaulted to have layout value
            used as a function result
            an object
@@ -181,7 +177,6 @@ Error: This type float# should be an instance of type ('a : value)
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because all of the following:
            a type argument defaulted to have layout value
-           a type argument defaulted to have layout value
            used as a function result
            an object
            an object field
@@ -198,7 +193,6 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
            a type argument defaulted to have layout value
            used as a function result
            an object
@@ -217,7 +211,6 @@ Error: This type float# should be an instance of type ('a : value)
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because all of the following:
            a type argument defaulted to have layout value
-           a type argument defaulted to have layout value
            used as a function result
            an object
            an object field
@@ -234,7 +227,6 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
            a type argument defaulted to have layout value
            used as a function result
            an object

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
@@ -5,6 +5,5 @@ Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           used as a function result
-           imported from another compilation unit 
+       But the layout of t_void must be a sublayout of value, because
+         imported from another compilation unit. 

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -5,6 +5,5 @@ Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           used as a function result
-           imported from another compilation unit 
+       But the layout of t_void must be a sublayout of value, because
+         imported from another compilation unit. 

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -260,10 +260,8 @@ Line 2, characters 18-55:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The layout of 'a is value, because all of the following:
-           used as a function result
-           used as a function argument
-           an unannotated universal variable
+       The layout of 'a is value, because
+         an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on the abstract type declaration for a.
 |}]
@@ -279,10 +277,8 @@ type ('a : immediate) t_imm
 Line 3, characters 15-39:
 3 | type s = { f : ('a : value). 'a -> 'a u }
                    ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type 'a is value, because all of the following:
-           used as a function argument
-           appears as an unannotated type parameter
-           of the annotation on the universal variable a
+Error: The layout of Type 'a is value, because
+         of the annotation on the universal variable a.
        But the layout of Type 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t_imm.
 
@@ -518,10 +514,8 @@ Line 1, characters 37-53:
                                          ^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The layout of 'a is value, because all of the following:
-           used as a function result
-           used as a function argument
-           of the annotation on the universal variable a
+       The layout of 'a is value, because
+         of the annotation on the universal variable a.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on the universal variable a.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -548,7 +548,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         appears as an unannotated type parameter.
+         a field of a polymorphic variant.
 |}];;
 
 module M8_4 = struct
@@ -563,7 +563,7 @@ Error: The type constraints are not consistent.
        The layout of void_unboxed_record is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of void_unboxed_record must be a sublayout of value, because
-         appears as an unannotated type parameter.
+         a field of a polymorphic variant.
 |}];;
 
 module type S8_5 = sig
@@ -665,7 +665,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         appears as an unannotated type parameter.
+         a tuple element.
 |}];;
 
 module M9_6 = struct
@@ -680,7 +680,7 @@ Error: The type constraints are not consistent.
        The layout of void_unboxed_record is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of void_unboxed_record must be a sublayout of value, because
-         appears as an unannotated type parameter.
+         a tuple element.
 |}];;
 
 module type S9_7 = sig
@@ -895,7 +895,7 @@ Error: The type constraints are not consistent.
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         appears as an unannotated type parameter.
+         an object field.
 |}];;
 
 (*******************************************************************)
@@ -1426,7 +1426,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         bound by a `let`.
+         a type argument defaulted to have layout value.
 |}]
 
 (*********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -768,9 +768,8 @@ Error: Signature mismatch:
        The type string is not compatible with the type string
        The layout of string is value, because
          it equals the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because all of the following:
-           of the annotation on 'a in the declaration of the type t
-           of the annotation on 'a in the declaration of the type t
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -809,9 +808,8 @@ Error: Signature mismatch:
        The type string t = string is not compatible with the type string
        The layout of string is value, because
          it equals the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because all of the following:
-           of the annotation on 'a in the declaration of the type t
-           of the annotation on 'a in the declaration of the type t
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}]
 
 (**************************************************************)
@@ -846,9 +844,8 @@ Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           an object field
-           an object field
+       But the layout of t_void must be a sublayout of value, because
+         an object field.
 |}];;
 
 module M11_3 = struct
@@ -1141,9 +1138,8 @@ Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           a type argument defaulted to have layout value
+       But the layout of t_void must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 (* list *)
@@ -1185,9 +1181,8 @@ Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           a type argument defaulted to have layout value
+       But the layout of t_void must be a sublayout of value, because
+         a type argument defaulted to have layout value.
 |}];;
 
 (* array *)
@@ -1468,8 +1463,6 @@ Error: This expression has type t_void but an expression was expected of type
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because all of the following:
            a type argument defaulted to have layout value
-           a type argument defaulted to have layout value
-           a type argument defaulted to have layout value
            bound by a `let`
 |}]
 
@@ -1722,9 +1715,8 @@ Error: This pattern matches values of type t_void
        but a pattern was expected which matches values of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           a tuple element
-           a tuple element
+       But the layout of t_void must be a sublayout of value, because
+         a tuple element.
 |}]
 
 let ( let* ) x f = ()
@@ -1745,9 +1737,8 @@ Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
-       But the layout of t_float64 must be a sublayout of value, because all of the following:
-           a tuple element
-           a tuple element
+       But the layout of t_float64 must be a sublayout of value, because
+         a tuple element.
 |}]
 
 
@@ -1773,11 +1764,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because all of the following:
-           used as a function argument
-           used as a function argument
            used as an argument in an external declaration
-           used as an argument in an external declaration
-           used as a function argument
            used as a function argument
 |}]
 
@@ -1807,7 +1794,6 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because all of the following:
-           used as a function argument
            used as a function result
            used as a function argument
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -72,9 +72,8 @@ Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_3) is not compatible with type t
        The layout of t is any, because
          of the annotation on the declaration of the type t.
-       But the layout of t must be a sublayout of '_representable_layout_3, because all of the following:
-           used as a function argument
-           appears as an unannotated type parameter
+       But the layout of t must be a sublayout of '_representable_layout_3, because
+         appears as an unannotated type parameter.
 |}]
 
 module type S1 = sig
@@ -90,9 +89,8 @@ Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_4) is not compatible with type t
        The layout of t is any, because
          of the annotation on the declaration of the type t.
-       But the layout of t must be a sublayout of '_representable_layout_4, because all of the following:
-           used as a function result
-           appears as an unannotated type parameter
+       But the layout of t must be a sublayout of '_representable_layout_4, because
+         appears as an unannotated type parameter.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -382,9 +380,8 @@ Lines 4-5, characters 33-22:
 5 |   | Void5 x -> Void5 x
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of 'a is void, because all of the following:
-           used as constructor field 0
-           of the annotation on 'a in the declaration of the type void5
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type void5.
        But the layout of 'a must be a sublayout of value, because
          to be value for the V1 safety check.
 
@@ -399,9 +396,8 @@ Line 1, characters 12-15:
 Error: This type int should be an instance of type ('a : void)
        The layout of int is immediate, because
          it equals the primitive immediate type int.
-       But the layout of int must be a sublayout of void, because all of the following:
-           used as constructor field 0
-           of the annotation on 'a in the declaration of the type void5
+       But the layout of int must be a sublayout of void, because
+         of the annotation on 'a in the declaration of the type void5.
 |}];;
 
 let h5' (x : int any5) = Void5 x
@@ -413,9 +409,8 @@ Error: This expression has type int any5
        but an expression was expected of type ('a : void)
        The layout of int any5 is value, because
          a boxed variant.
-       But the layout of int any5 must be a sublayout of void, because all of the following:
-           used as constructor field 0
-           of the annotation on 'a in the declaration of the type void5
+       But the layout of int any5 must be a sublayout of void, because
+         of the annotation on 'a in the declaration of the type void5.
 |}];;
 
 (* disallowed - tries to return void *)
@@ -429,9 +424,8 @@ Lines 1-3, characters 6-16:
 3 |   | Void5 x -> x..
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of 'a is void, because all of the following:
-           used as constructor field 0
-           of the annotation on 'a in the declaration of the type void5
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type void5.
        But the layout of 'a must be a sublayout of value, because
          to be value for the V1 safety check.
 
@@ -460,9 +454,8 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because all of the following:
-           used as a function argument
-           an unannotated universal variable
+       The layout of 'a is value, because
+         an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
@@ -477,9 +470,8 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because all of the following:
-           used as a function argument
-           an unannotated universal variable
+       The layout of 'a is value, because
+         an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
@@ -555,9 +547,8 @@ Line 4, characters 13-19:
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           a field of a polymorphic variant
-           appears as an unannotated type parameter
+       But the layout of t_void must be a sublayout of value, because
+         appears as an unannotated type parameter.
 |}];;
 
 module M8_4 = struct
@@ -571,9 +562,8 @@ Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
        The layout of void_unboxed_record is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of void_unboxed_record must be a sublayout of value, because all of the following:
-           a field of a polymorphic variant
-           appears as an unannotated type parameter
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         appears as an unannotated type parameter.
 |}];;
 
 module type S8_5 = sig
@@ -674,9 +664,8 @@ Line 4, characters 13-19:
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           a tuple element
-           appears as an unannotated type parameter
+       But the layout of t_void must be a sublayout of value, because
+         appears as an unannotated type parameter.
 |}];;
 
 module M9_6 = struct
@@ -690,9 +679,8 @@ Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
        The layout of void_unboxed_record is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of void_unboxed_record must be a sublayout of value, because all of the following:
-           a tuple element
-           appears as an unannotated type parameter
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         appears as an unannotated type parameter.
 |}];;
 
 module type S9_7 = sig
@@ -825,9 +813,8 @@ Line 5, characters 4-7:
 5 |     t.v # baz11
         ^^^
 Error: Methods must have layout value.
-       The layout of This expression is void, because all of the following:
-           used in the declaration of the record field "v/447"
-           of the annotation on 'a in the declaration of the type t
+       The layout of This expression is void, because
+         of the annotation on 'a in the declaration of the type t.
        But the layout of This expression must overlap with value, because
          an object.
 
@@ -859,9 +846,8 @@ Line 4, characters 12-33:
                 ^^^^^^^^^^^^^^^^^^^^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of 'a is void, because all of the following:
-           used as constructor field 0
-           of the annotation on 'a in the declaration of the type t
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must be a sublayout of value, because
          to be value for the V1 safety check.
 
@@ -908,9 +894,8 @@ Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_void
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           an object field
-           appears as an unannotated type parameter
+       But the layout of t_void must be a sublayout of value, because
+         appears as an unannotated type parameter.
 |}];;
 
 (*******************************************************************)
@@ -987,9 +972,8 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because all of the following:
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
+       The layout of 'a is value, because
+         a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
          of the annotation on 'a in the declaration of the type t.
 |}];;
@@ -1007,12 +991,10 @@ Line 6, characters 29-31:
 6 |       method void_id (A a) : 'a t = a
                                  ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because all of the following:
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
-       But the layout of 'a must overlap with void, because all of the following:
-           used as constructor field 0
-           of the annotation on 'a in the declaration of the type t
+       The layout of 'a is value, because
+         a term-level argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the annotation on 'a in the declaration of the type t.
 |}];;
 
 module type S12_6 = sig
@@ -1029,12 +1011,10 @@ Line 5, characters 4-6:
 5 |     'a t ->
         ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because all of the following:
-           appears as an unannotated type parameter
-           a term-level argument to a class constructor
-       But the layout of 'a must overlap with void, because all of the following:
-           used as constructor field 0
-           of the annotation on 'a in the declaration of the type t
+       The layout of 'a is value, because
+         a term-level argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the annotation on 'a in the declaration of the type t.
 |}];;
 
 module type S12_7 = sig
@@ -1369,24 +1349,8 @@ Lines 5-7, characters 6-20:
 7 |   g (failwith "foo")..
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of 'a is void, because all of the following:
-           used in the declaration of the record field "y/607"
-           of the annotation on 'a in the declaration of the type r
-       But the layout of 'a must be a sublayout of value, because
-         to be value for the V1 safety check.
-
-|}, Principal{|
-type t_void : void
-type ('a : void) r = { x : int; y : 'a; }
-Lines 5-7, characters 6-20:
-5 | ......() =
-6 |   let rec g { x = x ; y = y } : _ r = g { x; y } in
-7 |   g (failwith "foo")..
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of 'a is void, because all of the following:
-           used in the declaration of the record field "y/609"
-           of the annotation on 'a in the declaration of the type r
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type r.
        But the layout of 'a must be a sublayout of value, because
          to be value for the V1 safety check.
 
@@ -1461,9 +1425,8 @@ Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           a type argument defaulted to have layout value
-           bound by a `let`
+       But the layout of t_void must be a sublayout of value, because
+         bound by a `let`.
 |}]
 
 (*********************************************************)
@@ -1763,9 +1726,8 @@ Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           used as an argument in an external declaration
-           used as a function argument
+       But the layout of t_void must be a sublayout of value, because
+         used as a function argument.
 |}]
 
 (**************************************)
@@ -1793,9 +1755,8 @@ Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of t_void must be a sublayout of value, because all of the following:
-           used as a function result
-           used as a function argument
+       But the layout of t_void must be a sublayout of value, because
+         used as a function argument.
 |}]
 
 (**************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -325,9 +325,8 @@ Error: Signature mismatch:
        The type string is not compatible with the type string
        The layout of string is value, because
          it equals the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because all of the following:
-           of the annotation on 'a in the declaration of the type t
-           of the annotation on 'a in the declaration of the type t
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -366,9 +365,8 @@ Error: Signature mismatch:
        The type string t = string is not compatible with the type string
        The layout of string is value, because
          it equals the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because all of the following:
-           of the annotation on 'a in the declaration of the type t
-           of the annotation on 'a in the declaration of the type t
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}]
 
 (**************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -226,9 +226,8 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because all of the following:
-           used as a function argument
-           an unannotated universal variable
+       The layout of 'a is value, because
+         an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
@@ -243,9 +242,8 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because all of the following:
-           used as a function argument
-           an unannotated universal variable
+       The layout of 'a is value, because
+         an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
@@ -576,10 +574,8 @@ type ('a : immediate) t2_imm
 Line 3, characters 15-40:
 3 | type s = { f : ('a : value) . 'a -> 'a u }
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type 'a is value, because all of the following:
-           used as a function argument
-           appears as an unannotated type parameter
-           of the annotation on the universal variable a
+Error: The layout of Type 'a is value, because
+         of the annotation on the universal variable a.
        But the layout of Type 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t2_imm.
 

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -40,9 +40,8 @@ Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : void)
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with value, because all of the following:
-           a type argument defaulted to have layout value
-           appears as an unannotated type parameter
+       But the layout of 'a must overlap with value, because
+         appears as an unannotated type parameter.
 |}];;
 
 module type S1'' = S1 with type s = t_void;;
@@ -95,9 +94,8 @@ Error: Signature mismatch:
        is not included in
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
-       because their layouts are different.'a value, because all of the following:
-                                               a type argument defaulted to have layout value
-                                               appears as an unannotated type parameter
+       because their layouts are different.'a value, because
+                                             appears as an unannotated type parameter.
                                            'a immediate, because
                                              of the annotation on 'a
                                                                   in the declaration of the type
@@ -145,9 +143,8 @@ Error: This expression has type string but an expression was expected of type
          ('a : immediate)
        The layout of string is value, because
          it equals the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because all of the following:
-           of the annotation on 'a in the declaration of the type s2'
-           of the annotation on 'a in the declaration of the type t
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}]
 
 (******************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -41,7 +41,7 @@ Error: The type constraints are not consistent.
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must overlap with value, because
-         appears as an unannotated type parameter.
+         a type argument defaulted to have layout value.
 |}];;
 
 module type S1'' = S1 with type s = t_void;;
@@ -95,7 +95,7 @@ Error: Signature mismatch:
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.'a value, because
-                                             appears as an unannotated type parameter.
+                                             a type argument defaulted to have layout value.
                                            'a immediate, because
                                              of the annotation on 'a
                                                                   in the declaration of the type

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -83,9 +83,8 @@ Error: Signature mismatch:
        is not included in
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
-       because their layouts are different.'a value, because all of the following:
-                                               a type argument defaulted to have layout value
-                                               appears as an unannotated type parameter
+       because their layouts are different.'a value, because
+                                             appears as an unannotated type parameter.
                                            'a immediate, because
                                              of the annotation on 'a
                                                                   in the declaration of the type
@@ -112,9 +111,8 @@ Error: Signature mismatch:
          type ('a : immediate) t
        Their parameters differ:
        The type ('a : value) is not equal to the type ('a0 : immediate)
-       because their layouts are different.'a value, because all of the following:
-                                               a type argument defaulted to have layout value
-                                               appears as an unannotated type parameter
+       because their layouts are different.'a value, because
+                                             appears as an unannotated type parameter.
                                            'a immediate, because
                                              of the annotation on 'a
                                                                   in the declaration of the type
@@ -162,9 +160,8 @@ Error: This expression has type string but an expression was expected of type
          ('a : immediate)
        The layout of string is value, because
          it equals the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because all of the following:
-           of the annotation on 'a in the declaration of the type s2'
-           of the annotation on 'a in the declaration of the type t
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}]
 
 (******************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -84,7 +84,7 @@ Error: Signature mismatch:
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.'a value, because
-                                             appears as an unannotated type parameter.
+                                             a type argument defaulted to have layout value.
                                            'a immediate, because
                                              of the annotation on 'a
                                                                   in the declaration of the type
@@ -112,7 +112,7 @@ Error: Signature mismatch:
        Their parameters differ:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.'a value, because
-                                             appears as an unannotated type parameter.
+                                             a type argument defaulted to have layout value.
                                            'a immediate, because
                                              of the annotation on 'a
                                                                   in the declaration of the type

--- a/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -5,8 +5,7 @@ Error: This expression has type M.a but an expression was expected of type
          ('a : value)
        The layout of M.a is any, because
          a missing .cmi file for M.a.
-       But the layout of M.a must be a sublayout of value, because all of the following:
-           used as a function argument
-           imported from another compilation unit 
+       But the layout of M.a must be a sublayout of value, because
+         imported from another compilation unit. 
        No .cmi file found containing M.a.
        Hint: Adding "m" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -7,7 +7,6 @@ Error: This expression has type M.a but an expression was expected of type
          a missing .cmi file for M.a.
        But the layout of M.a must be a sublayout of value, because all of the following:
            used as a function argument
-           used as a function argument
            imported from another compilation unit 
        No .cmi file found containing M.a.
        Hint: Adding "m" to your dependencies might help.

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -814,7 +814,7 @@ module Layout = struct
       | Sublayout ->
         fprintf ppf "sublayout check"
 
-    (* CR layouts v2.9: An older implementation of format_flattened_history existed
+    (* CR layouts: An older implementation of format_flattened_history existed
        which displays more information not limited to one layout and one creation_reason
        around commit 66a832d70bf61d9af3b0ec6f781dcf0a188b324d in main.
 

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -823,6 +823,7 @@ module Layout = struct
 
        INVARIANT: the creation_reasons within a list all are reasons for
        the layout they are paired with.
+       INVARIANT: the creation_reasons do not store duplicates
        INVARIANT: L is a sublayout of all the Li in a flattened_history.
        INVARIANT: If Li and Lj are stored in different entries in a
        flattened_history, then not (Li <= Lj) and not (Lj <= Li).
@@ -846,9 +847,11 @@ module Layout = struct
         let layout_desc = get_internal layout in
         let rec go acc = function
           | ((key, value) as row) :: rest ->
+            let is_unseen reason = List.fold_left (fun acc r -> acc && not (r = reason)) true value in
             begin match sub_desc layout_desc key with
             | Sub -> go acc rest
-            | Equal -> (key, reason :: value) :: acc @ rest
+            | Equal when is_unseen reason -> (key, reason :: value) :: acc @ rest
+            | Equal -> row :: acc @ rest
             | Not_sub -> go (row :: acc) rest
             end
           | [] -> (layout_desc, [reason]) :: acc

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -963,7 +963,7 @@ module Layout = struct
     if flattened_histories
     then begin match sub_desc (get_internal lhs.layout) (get_internal rhs.layout) with
       | Sub -> lhs.history
-      | Not_sub -> rhs.history
+      | Not_sub -> rhs.history  (* CR layouts: this will be wrong if we ever have a non-trivial meet in the layout lattice *)
       | Equal -> begin match lhs.history, rhs.history with
         (* Prefer other creation_reasons over Concrete_creation *)
         | h, Creation (Concrete_creation _)

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -827,9 +827,15 @@ module Layout = struct
                    ; lhs_history
                    ; rhs_layout
                    ; rhs_history } ->
-          begin match history key lhs_layout lhs_history with
-          | Some _ as r -> r
-          | None -> history key rhs_layout rhs_history
+          let lhs_reason = history key lhs_layout lhs_history in
+          let rhs_reason = history key rhs_layout rhs_history in
+          begin match lhs_reason, rhs_reason with
+          | None, r
+          | r, None -> r
+          (* Prefer other creation_reasons over Concrete_creation *)
+          | r, Some (Concrete_creation _)
+          | Some (Concrete_creation _), r -> r
+          | r, _ -> r
           end
         | Creation reason ->
           let layout_desc = get_internal internal in


### PR DESCRIPTION
This PR aims to improve layout history error messages by removing duplicated `creation_reason`s. For example:

```
module M11_2 = struct
  let foo x = VV (x # getvoid)
end;;
[%%expect{|
Line 2, characters 17-30:
2 |   let foo x = VV (x # getvoid)
                     ^^^^^^^^^^^^^
Error: This expression has type ('a : value)
       but an expression was expected of type t_void
       The layout of t_void is void, because
         of the annotation on the declaration of the type t_void.
       But the layout of t_void must be a sublayout of value, because all of the following:
           an object field
           an object field
|}];;
```

will turn into

```
...
Error: This expression has type ('a : value)
       but an expression was expected of type t_void
       The layout of t_void is void, because
         of the annotation on the declaration of the type t_void.
       But the layout of t_void must be a sublayout of value, because
         an object field.
|}];;
```

This is currently implemented using polymorphic equal checks. An alternative will be to define `compare`/`equal` functions for all `*_creation_reason` types. Would love some input on whether it will be worth it to do that.