### PR TITLE
tmc: Remove close-on-apply flag when producing a call in non-tail position

### DIFF
--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -749,6 +749,14 @@ let rec choice ctx t =
           | other -> other
         in
         { apply with ap_tailcall } in
+      (* The call will not be in tail position, so the close-on-apply flag must
+         not be set. *)
+      let ap_region_close =
+        match apply.ap_region_close with
+        | Rc_close_at_apply -> Rc_normal
+        | (Rc_normal | Rc_nontail) as reg_close -> reg_close
+      in
+      let apply = { apply with ap_region_close } in
       { (Choice.lambda (Lapply apply)) with
         direct = (fun () -> Lapply apply_no_bailout);
       }

--- a/ocaml/testsuite/tests/tmc/region_close.ml
+++ b/ocaml/testsuite/tests/tmc/region_close.ml
@@ -1,0 +1,15 @@
+(* TEST
+   * bytecode
+   * native
+*)
+
+(* This was producing an error in ocamlopt because the call to [failwith] had
+   the close-at-apply flag on, which wasn't cleared when tmc rewrote the call to
+   one not in tail position. *)
+
+let[@tail_mod_cons] rec map2_exn l0 l1 ~f =
+  match l0, l1 with
+  | [], [] -> []
+  | h0 :: t0, h1 :: t1 -> f h0 h1 :: map2_exn t0 t1 ~f
+  | _ -> failwith (let message () = "urk" in message ())
+;;


### PR DESCRIPTION
The close-on-apply flag is invalid on a function call in non-tail position, and recent flambda1 changes cause us to notice this.