### PR TITLE
Make -extension immutable_arrays on by default

### DIFF
--- a/ocaml/testsuite/tests/array-functions/test_iarray.ml
+++ b/ocaml/testsuite/tests/array-functions/test_iarray.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension immutable_arrays"
 *)
 
 module Iarray = Stdlib__Iarray

--- a/ocaml/testsuite/tests/comprehensions/comprehensions_from_quickcheck.ml
+++ b/ocaml/testsuite/tests/comprehensions/comprehensions_from_quickcheck.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-extension comprehensions -extension immutable_arrays"
+   flags = "-extension comprehensions"
    * expect
 *)
 

--- a/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_pure.ml
+++ b/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_pure.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-extension comprehensions -extension immutable_arrays"
+   flags = "-extension comprehensions"
    * expect
 *)
 

--- a/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_require_immutable_arrays.compilers.reference
+++ b/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_require_immutable_arrays.compilers.reference
@@ -1,4 +1,0 @@
-File "iarray_comprehensions_require_immutable_arrays.ml", line 9, characters 0-21:
-9 | [:x for x = 1 to 10:];;
-    ^^^^^^^^^^^^^^^^^^^^^
-Error: The extension "immutable_arrays" is disabled and cannot be used

--- a/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_require_immutable_arrays.ml
+++ b/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_require_immutable_arrays.ml
@@ -1,9 +1,0 @@
-(* TEST
-   flags = "-extension comprehensions"
-   ocamlc_byte_exit_status = "2"
-   * setup-ocamlc.byte-build-env
-   ** ocamlc.byte
-   *** check-ocamlc.byte-output
-*)
-
-[:x for x = 1 to 10:];;

--- a/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_side_effects.ml
+++ b/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_side_effects.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-extension comprehensions -extension immutable_arrays"
+   flags = "-extension comprehensions"
 *)
 
 module Iarray = Stdlib__Iarray

--- a/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_special.ml
+++ b/ocaml/testsuite/tests/comprehensions/iarray_comprehensions_special.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-extension comprehensions -extension immutable_arrays"
+   flags = "-extension comprehensions"
    * expect
 *)
 

--- a/ocaml/testsuite/tests/comprehensions/quickcheck_lists_arrays_haskell_python.ml
+++ b/ocaml/testsuite/tests/comprehensions/quickcheck_lists_arrays_haskell_python.ml
@@ -1128,7 +1128,6 @@ module Interactive_command = struct
     command
       "../../../ocaml"
       [ "-extension"; "comprehensions"
-      ; "-extension"; "immutable_arrays"
       ; "-noprompt"; "-no-version"
       ; "-w"; "no-unused-var" ]
       ~setup:(fun output ->
@@ -1165,7 +1164,7 @@ module Log_test_cases = struct
     try
       output_string oc
 {|(* TEST
-   flags = "-extension comprehensions -extension immutable_arrays"
+   flags = "-extension comprehensions"
    * expect
 *)
 

--- a/ocaml/testsuite/tests/lib-array/iarray_singleton.ml
+++ b/ocaml/testsuite/tests/lib-array/iarray_singleton.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension immutable_arrays"
    * native
    *)
 

--- a/ocaml/testsuite/tests/lib-array/iarrays_with_variables.ml
+++ b/ocaml/testsuite/tests/lib-array/iarrays_with_variables.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension immutable_arrays"
    * expect
 *)
 

--- a/ocaml/testsuite/tests/lib-array/test_iarray.ml
+++ b/ocaml/testsuite/tests/lib-array/test_iarray.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension immutable_arrays"
    * expect
 *)
 

--- a/ocaml/testsuite/tests/typing-local/float_iarray.ml
+++ b/ocaml/testsuite/tests/typing-local/float_iarray.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension immutable_arrays"
    * bytecode
      reference = "${test_source_directory}/float_iarray.heap.reference"
    * stack-allocation

--- a/ocaml/testsuite/tests/typing-local/iarray.ml
+++ b/ocaml/testsuite/tests/typing-local/iarray.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension immutable_arrays"
    * bytecode
      reference = "${test_source_directory}/iarray.heap.reference"
    * stack-allocation

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension immutable_arrays"
    * expect *)
 
 let leak n =

--- a/ocaml/utils/language_extension.ml
+++ b/ocaml/utils/language_extension.ml
@@ -177,6 +177,7 @@ let default_extensions : extn_pair list =
   [ Pair (Local, ())
   ; Pair (Include_functor, ())
   ; Pair (Polymorphic_parameters, ())
+  ; Pair (Immutable_arrays, ())
   ]
 let extensions : extn_pair list ref = ref default_extensions
 


### PR DESCRIPTION
Now that they're available in foundation, I see little reason to keep these guarded behind a flag.