### PR TITLE
Split generated functions cache according to arity

### DIFF
--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -454,38 +454,6 @@ let link_shared unix ~ppf_dump objfiles output_name =
     remove_file startup_obj
   )
 
-let make_cached_generic_functions unix  ~ppf_dump ~sourcefile_for_dwarf =
-  Location.input_name := "caml_cached_generic_functions"; (* set name of "current" input *)
-  let startup_comp_unit =
-    CU.create CU.Prefix.empty (CU.Name.of_string "_cached_generic_functions")
-  in
-  Compilenv.reset startup_comp_unit;
-  Emitaux.Dwarf_helpers.init ~disable_dwarf:(not !Dwarf_flags.dwarf_for_startup_file)
-    sourcefile_for_dwarf;
-  let genfns = Cmm_helpers.Generic_fns_tbl.Precomputed.gen () in
-  Emit.begin_assembly unix;
-  let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in
-  Profile.record_call "genfns" (fun () ->
-  List.iter compile_phrase
-    (Cmm_helpers.emit_preallocated_blocks []
-      (Cmm_helpers.generic_functions false genfns)));
-  Emit.end_assembly ()
-
-let cached_generic_functions unix ~ppf_dump output_name =
-  Profile.record_call output_name (fun () ->
-    let startup = output_name ^ ext_asm in
-    let sourcefile_for_dwarf = sourcefile_for_dwarf ~named_startup_file:true startup in
-    Profile.record_call "compile_unit" (fun () ->
-      Asmgen.compile_unit ~output_prefix:output_name
-        ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
-        ~obj_filename:(output_name ^ ext_obj)
-        ~may_reduce_heap:true
-        ~ppf_dump
-        (fun () ->
-          make_cached_generic_functions unix ~ppf_dump ~sourcefile_for_dwarf)
-    );
-  )
-
 let call_linker file_list_rev startup_file output_name =
   let main_dll = !Clflags.output_c_object
                  && Filename.check_suffix output_name Config.ext_dll

--- a/backend/asmlink.mli
+++ b/backend/asmlink.mli
@@ -26,8 +26,6 @@ val link_shared: (module Compiler_owee.Unix_intf.S) ->
 
 val call_linker_shared: ?native_toplevel:bool -> string list -> string -> unit
 
-val cached_generic_functions : (module Compiler_owee.Unix_intf.S) -> ppf_dump:formatter -> string -> unit
-
 val reset : unit -> unit
 val check_consistency: filepath -> Cmx_format.unit_infos -> Digest.t -> unit
 val extract_crc_interfaces: unit -> Import_info.t list

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3076,7 +3076,7 @@ module Generic_fns_tbl = struct
     let considered_as_small_threshold = 20
 
     let is_curry (kind, arity, result) =
-      (* For now we don't cache generic functions involving unboxed typs *)
+      (* For now we don't cache generic functions involving unboxed types *)
       if not (only_concerns_values ~arity ~result)
       then false
       else
@@ -3100,7 +3100,7 @@ module Generic_fns_tbl = struct
           else false
 
     let is_send (arity, result, alloc) =
-      (* For now we don't cache generic functions involving unboxed typs *)
+      (* For now we don't cache generic functions involving unboxed types *)
       if not (only_concerns_values ~arity ~result)
       then false
       else
@@ -3109,7 +3109,7 @@ module Generic_fns_tbl = struct
         | Lambda.Alloc_heap -> len_arity arity <= max_send
 
     let is_apply (arity, result, alloc) =
-      (* For now we don't cache generic functions involving unboxed typs *)
+      (* For now we don't cache generic functions involving unboxed types *)
       if not (only_concerns_values ~arity ~result)
       then false
       else

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3059,10 +3059,11 @@ module Generic_fns_tbl = struct
     }
 
   module Precomputed = struct
-    let has_layout_value = function [| Val |] -> true | _ -> false
+    let has_singleton_layout_value = function [| Val |] -> true | _ -> false
 
     let only_concerns_values ~arity ~result =
-      has_layout_value result && List.for_all has_layout_value arity
+      has_singleton_layout_value result
+      && List.for_all has_singleton_layout_value arity
 
     let len_arity arity =
       List.fold_left
@@ -3159,9 +3160,7 @@ module Generic_fns_tbl = struct
         |> Seq.concat
       in
       let apply =
-        Seq.init
-          (max_apply + 1)
-          (fun n ->
+        Seq.init (max_apply + 1) (fun n ->
             Seq.cons
               (arity n, result, Lambda.alloc_local)
               (Seq.return (arity n, result, Lambda.alloc_heap)))

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3071,6 +3071,8 @@ module Generic_fns_tbl = struct
 
     let max_send = 20
 
+    let max_apply = 404
+
     let max_tuplify = 100
 
     let considered_as_small_threshold = 20
@@ -3132,7 +3134,7 @@ module Generic_fns_tbl = struct
          automatically derive a good search space in the future as the filters
          might become more complexed with unboxed types. *)
       assert (considered_as_small_threshold <= max_tuplify);
-      assert (considered_as_small_threshold <= Lambda.max_arity ());
+      assert (considered_as_small_threshold <= max_apply);
       assert (considered_as_small_threshold <= max_send);
       assert (considered_as_small_threshold <= Lambda.max_arity ());
       let arity n = List.init n (fun _ -> [| Val |]) in
@@ -3158,7 +3160,7 @@ module Generic_fns_tbl = struct
       in
       let apply =
         Seq.init
-          (Lambda.max_arity () + 1)
+          (max_apply + 1)
           (fun n ->
             Seq.cons
               (arity n, result, Lambda.alloc_local)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3059,11 +3059,7 @@ module Generic_fns_tbl = struct
     }
 
   module Precomputed = struct
-    let has_singleton_layout_value = function [| Val |] -> true | _ -> false
-
-    let only_concerns_values ~arity ~result =
-      has_singleton_layout_value result
-      && List.for_all has_singleton_layout_value arity
+    let check_result = function [| Val |] -> true | _ -> false
 
     let len_arity arity =
       List.fold_left
@@ -3079,8 +3075,7 @@ module Generic_fns_tbl = struct
     let considered_as_small_threshold = 20
 
     let is_curry (kind, arity, result) =
-      (* For now we don't cache generic functions involving unboxed types *)
-      if not (only_concerns_values ~arity ~result)
+      if not (check_result result)
       then false
       else
         match kind with
@@ -3103,8 +3098,7 @@ module Generic_fns_tbl = struct
           else false
 
     let is_send (arity, result, alloc) =
-      (* For now we don't cache generic functions involving unboxed types *)
-      if not (only_concerns_values ~arity ~result)
+      if not (check_result result)
       then false
       else
         match alloc with
@@ -3112,8 +3106,7 @@ module Generic_fns_tbl = struct
         | Lambda.Alloc_heap -> len_arity arity <= max_send
 
     let is_apply (arity, result, alloc) =
-      (* For now we don't cache generic functions involving unboxed types *)
-      if not (only_concerns_values ~arity ~result)
+      if not (check_result result)
       then false
       else
         match alloc with

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3115,7 +3115,7 @@ module Generic_fns_tbl = struct
           2 <= l && l <= considered_as_small_threshold
         | Lambda.Alloc_heap ->
           let l = len_arity arity in
-          2 <= l && l <= Lambda.max_arity ()
+          2 <= l && l <= max_apply
 
     let gen () =
       (* [is_curry], [is_send] and [is_apply] are also used to determine if a

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3157,7 +3157,9 @@ module Generic_fns_tbl = struct
         |> Seq.concat
       in
       let apply =
-        Seq.init (Lambda.max_arity () + 1) (fun n ->
+        Seq.init
+          (Lambda.max_arity () + 1)
+          (fun n ->
             Seq.cons
               (arity n, result, Lambda.alloc_local)
               (Seq.return (arity n, result, Lambda.alloc_heap)))

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3170,7 +3170,7 @@ module Generic_fns_tbl = struct
       let category prefix arity =
         let l = len_arity arity in
         if l <= considered_as_small_threshold
-        then "common"
+        then "small"
         else prefix ^ string_of_int l
       in
       let module SMap = Misc.Stdlib.String.Map in

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -892,7 +892,7 @@ module Generic_fns_tbl : sig
   val entries : t -> Cmx_format.generic_fns
 
   module Precomputed : sig
-    val gen : unit -> t
+    val gen : unit -> (string, t) Hashtbl.t
   end
 end
 

--- a/tools/generate_cached_generic_functions.ml
+++ b/tools/generate_cached_generic_functions.ml
@@ -26,16 +26,56 @@
 
 open Printf
 open Misc
+open Config
 
+module CU = Compilation_unit
+
+let make_cached_generic_functions unix ~ppf_dump genfns =
+  Location.input_name := "caml_cached_generic_functions"; (* set name of "current" input *)
+  let startup_comp_unit =
+    CU.create CU.Prefix.empty (CU.Name.of_string "_cached_generic_functions")
+  in
+  Compilenv.reset startup_comp_unit;
+  Emit.begin_assembly unix;
+  let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in
+  Profile.record_call "genfns" (fun () ->
+  List.iter compile_phrase
+    (Cmm_helpers.emit_preallocated_blocks []
+      (Cmm_helpers.generic_functions false genfns)));
+  Emit.end_assembly ()
+
+let cached_generic_functions unix ~ppf_dump output_name genfns =
+  Profile.record_call output_name (fun () ->
+    let startup = output_name ^ ext_asm in
+    Profile.record_call "compile_unit" (fun () ->
+      let obj_filename = output_name ^ ext_obj in
+      Asmgen.compile_unit ~output_prefix:output_name
+        ~asm_filename:startup ~keep_asm:false
+        ~obj_filename
+        ~may_reduce_heap:true
+        ~ppf_dump
+        (fun () ->
+          make_cached_generic_functions unix ~ppf_dump genfns);
+      obj_filename
+    );
+  )
 
 let main filename =
   let unix = (module Unix : Compiler_owee.Unix_intf.S) in
   Clflags.native_code := true;
   Clflags.use_linscan := true;
   Compmisc.init_path ();
-  let file_prefix = Filename.remove_extension filename in
-  Compmisc.with_ppf_dump ~file_prefix (fun ppf_dump ->
-      Asmlink.cached_generic_functions unix ~ppf_dump file_prefix)
+  let file_prefix = Filename.remove_extension filename ^ ext_lib in
+  let genfns_partitions = Cmm_helpers.Generic_fns_tbl.Precomputed.gen () in
+  let objects =
+    Hashtbl.fold (fun name partition objs ->
+      let output_name = Filename.temp_file ("cached-generated-" ^ name) "" in
+      cached_generic_functions unix ~ppf_dump:Format.std_formatter output_name partition
+      :: objs
+    ) genfns_partitions []
+  in
+  ignore (Ccomp.create_archive file_prefix objects : int);
+  List.iter remove_file objects
 
 let arg_usage =
   Printf.sprintf "%s FILE : Generate an obj file containing cached generatic functions named FILE" Sys.argv.(0)


### PR DESCRIPTION
Superseeds #1755

Once #1826 goes in this will split the generated function cache in one object file per generated function and arity. Overall this creates 200 different object files. The generated archive is ~20mb in size.

This is possible since after #1826 we don't need to generate any caml_apply with an arity greater than 126 - so it cuts down on the number of items quite a lot