### PR TITLE
Zero alloc annotation: assume a function never returns normally

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -419,12 +419,14 @@ end = struct
       List.filter_map
         (fun (c : Cmm.codegen_option) ->
           match c with
-          | Check { property; strict; assume; loc } when property = spec ->
-            Some { strict; assume; loc }
+          | Check { property; strict; loc } when property = spec ->
+            Some { strict; assume = false; loc }
+          | Assume { property; strict; loc; } when property = spec ->
+            Some { strict; assume = true; loc }
           | Ignore_assert_all property when property = spec ->
             ignore_assert_all := true;
             None
-          | Ignore_assert_all _ | Check _ | Reduce_code_size | No_CSE
+          | Ignore_assert_all _ | Check _ | Assume _ | Reduce_code_size | No_CSE
           | Use_linscan_regalloc ->
             None)
         codegen_options

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -403,13 +403,19 @@ end = struct
   type t =
     { strict : bool;  (** strict or relaxed? *)
       assume : bool;
+      never_returns_normally : bool;
       loc : Location.t
           (** Source location of the annotation, used for error messages. *)
     }
 
   let get_loc t = t.loc
 
-  let expected_value t = if t.strict then Value.safe else Value.relaxed
+  let expected_value t =
+    let res = if t.strict then Value.safe else Value.relaxed in
+    if t.never_returns_normally then
+      { res with nor = V.Bot }
+    else
+      res
 
   let is_assume t = t.assume
 
@@ -420,9 +426,9 @@ end = struct
         (fun (c : Cmm.codegen_option) ->
           match c with
           | Check { property; strict; loc } when property = spec ->
-            Some { strict; assume = false; loc }
-          | Assume { property; strict; loc; } when property = spec ->
-            Some { strict; assume = true; loc }
+            Some { strict; assume = false; never_returns_normally = false; loc }
+          | Assume { property; strict; never_returns_normally; loc; } when property = spec ->
+            Some { strict; assume = true; never_returns_normally; loc }
           | Ignore_assert_all property when property = spec ->
             ignore_assert_all := true;
             None
@@ -435,7 +441,8 @@ end = struct
     | [] ->
       if !Clflags.zero_alloc_check_assert_all && not !ignore_assert_all
       then
-        Some { strict = false; assume = false; loc = Debuginfo.to_location dbg }
+        Some { strict = false; assume = false; never_returns_normally = false;
+               loc = Debuginfo.to_location dbg }
       else None
     | [p] -> Some p
     | _ :: _ ->

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -412,10 +412,7 @@ end = struct
 
   let expected_value t =
     let res = if t.strict then Value.safe else Value.relaxed in
-    if t.never_returns_normally then
-      { res with nor = V.Bot }
-    else
-      res
+    if t.never_returns_normally then { res with nor = V.Bot } else res
 
   let is_assume t = t.assume
 
@@ -427,7 +424,8 @@ end = struct
           match c with
           | Check { property; strict; loc } when property = spec ->
             Some { strict; assume = false; never_returns_normally = false; loc }
-          | Assume { property; strict; never_returns_normally; loc; } when property = spec ->
+          | Assume { property; strict; never_returns_normally; loc }
+            when property = spec ->
             Some { strict; assume = true; never_returns_normally; loc }
           | Ignore_assert_all property when property = spec ->
             ignore_assert_all := true;
@@ -441,8 +439,12 @@ end = struct
     | [] ->
       if !Clflags.zero_alloc_check_assert_all && not !ignore_assert_all
       then
-        Some { strict = false; assume = false; never_returns_normally = false;
-               loc = Debuginfo.to_location dbg }
+        Some
+          { strict = false;
+            assume = false;
+            never_returns_normally = false;
+            loc = Debuginfo.to_location dbg
+          }
       else None
     | [p] -> Some p
     | _ :: _ ->

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -302,8 +302,8 @@ type codegen_option =
   | No_CSE
   | Use_linscan_regalloc
   | Ignore_assert_all of property
-  | Check of { property: property; strict: bool; assume: bool;
-               loc : Location.t; }
+  | Assume of { property: property; strict: bool; loc: Location.t }
+  | Check of { property: property; strict: bool; loc : Location.t; }
 
 type fundecl =
   { fun_name: symbol;

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -302,7 +302,8 @@ type codegen_option =
   | No_CSE
   | Use_linscan_regalloc
   | Ignore_assert_all of property
-  | Assume of { property: property; strict: bool; loc: Location.t }
+  | Assume of { property: property; strict: bool; never_returns_normally: bool;
+                loc: Location.t }
   | Check of { property: property; strict: bool; loc : Location.t; }
 
 type fundecl =

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -317,7 +317,8 @@ type codegen_option =
   | No_CSE
   | Use_linscan_regalloc
   | Ignore_assert_all of property
-  | Check of { property: property; strict: bool; assume: bool; loc: Location.t }
+  | Assume of { property: property; strict: bool; loc: Location.t }
+  | Check of { property: property; strict: bool; loc: Location.t }
 
 type fundecl =
   { fun_name: symbol;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -317,7 +317,8 @@ type codegen_option =
   | No_CSE
   | Use_linscan_regalloc
   | Ignore_assert_all of property
-  | Assume of { property: property; strict: bool; loc: Location.t }
+  | Assume of { property: property; strict: bool; never_returns_normally: bool;
+                loc: Location.t }
   | Check of { property: property; strict: bool; loc: Location.t }
 
 type fundecl =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4513,7 +4513,12 @@ let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
   | Default_check -> []
   | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
   | Assume { property; strict; never_returns_normally; loc } ->
-    [Assume { property = transl_property property; strict; never_returns_normally; loc }]
+    [ Assume
+        { property = transl_property property;
+          strict;
+          never_returns_normally;
+          loc
+        } ]
   | Check { property; strict; loc } ->
     [Check { property = transl_property property; strict; loc }]
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4512,8 +4512,10 @@ let transl_property : Lambda.property -> Cmm.property = function
 let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
   | Default_check -> []
   | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
-  | Check { property; strict; assume; loc } ->
-    [Check { property = transl_property property; strict; assume; loc }]
+  | Assume { property; strict; loc } ->
+    [Assume { property = transl_property property; strict; loc }]
+  | Check { property; strict; loc } ->
+    [Check { property = transl_property property; strict; loc }]
 
 let kind_of_layout (layout : Lambda.layout) =
   match layout with

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4512,8 +4512,8 @@ let transl_property : Lambda.property -> Cmm.property = function
 let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
   | Default_check -> []
   | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
-  | Assume { property; strict; loc } ->
-    [Assume { property = transl_property property; strict; loc }]
+  | Assume { property; strict; never_returns_normally; loc } ->
+    [Assume { property = transl_property property; strict; never_returns_normally; loc }]
   | Check { property; strict; loc } ->
     [Check { property = transl_property property; strict; loc }]
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -391,13 +391,13 @@ let codegen_option = function
   | Ignore_assert_all property ->
     Printf.sprintf "ignore %s" (property_to_string property)
   | Assume { property; strict; loc = _ } ->
-    Printf.sprintf "assume %s%s"
+    Printf.sprintf "assume_%s%s"
       (property_to_string property)
-      (if strict then " strict" else "")
+      (if strict then "_strict" else "")
   | Check { property; strict; loc = _ } ->
-    Printf.sprintf "assert %s%s"
+    Printf.sprintf "assert_%s%s"
       (property_to_string property)
-      (if strict then " strict" else "")
+      (if strict then "_strict" else "")
 
 let print_codegen_options ppf l =
   List.iter (fun c -> fprintf ppf " %s" (codegen_option c)) l

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -390,9 +390,12 @@ let codegen_option = function
   | Use_linscan_regalloc -> "linscan"
   | Ignore_assert_all property ->
     Printf.sprintf "ignore %s" (property_to_string property)
-  | Check { property; strict; assume; loc = _ } ->
-    Printf.sprintf "%s %s%s"
-      (if assume then "assume" else "assert")
+  | Assume { property; strict; loc = _ } ->
+    Printf.sprintf "assume %s%s"
+      (property_to_string property)
+      (if strict then " strict" else "")
+  | Check { property; strict; loc = _ } ->
+    Printf.sprintf "assert %s%s"
       (property_to_string property)
       (if strict then " strict" else "")
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -390,10 +390,11 @@ let codegen_option = function
   | Use_linscan_regalloc -> "linscan"
   | Ignore_assert_all property ->
     Printf.sprintf "ignore %s" (property_to_string property)
-  | Assume { property; strict; loc = _ } ->
-    Printf.sprintf "assume_%s%s"
+  | Assume { property; strict; never_returns_normally; loc = _ } ->
+    Printf.sprintf "assume_%s%s%s"
       (property_to_string property)
       (if strict then "_strict" else "")
+      (if strict then "_never_returns_normally" else "")
   | Check { property; strict; loc = _ } ->
     Printf.sprintf "assert_%s%s"
       (property_to_string property)

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -493,6 +493,7 @@ let simplify_function context ~outer_dacc function_slot code_id
       match Code_metadata.check code_metadata with
       | Default_check -> !Clflags.zero_alloc_check_assert_all
       | Ignore_assert_all Zero_alloc -> false
+      | Assume { property = Zero_alloc; _ } -> false
       | Check { property = Zero_alloc; _ } -> true
     in
     if never_delete then Code_id.Set.singleton code_id else Code_id.Set.empty

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -40,13 +40,13 @@ let print ppf t =
   | Ignore_assert_all property ->
     Format.fprintf ppf "@[ignore %a@]" Property.print property
   | Assume { property; strict; loc = _ } ->
-    Format.fprintf ppf "@[assume%s %a@]"
-      (if strict then " strict" else "")
+    Format.fprintf ppf "@[assume_%a%s@]"
       Property.print property
+      (if strict then "_strict" else "")
   | Check { property; strict; loc = _ } ->
-    Format.fprintf ppf "@[assert%s %a@]"
-      (if strict then " strict" else "")
+    Format.fprintf ppf "@[assert_%a%s@]"
       Property.print property
+      (if strict then "_strict" else "")
 
 let from_lambda : Lambda.check_attribute -> t = function
   | Default_check -> Default_check

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -41,20 +41,23 @@ let print ppf t =
   | Ignore_assert_all property ->
     Format.fprintf ppf "@[ignore %a@]" Property.print property
   | Assume { property; strict; never_returns_normally; loc = _ } ->
-    Format.fprintf ppf "@[assume_%a%s%s@]"
-      Property.print property
+    Format.fprintf ppf "@[assume_%a%s%s@]" Property.print property
       (if strict then "_strict" else "")
       (if never_returns_normally then "_never_returns_normally" else "")
   | Check { property; strict; loc = _ } ->
-    Format.fprintf ppf "@[assert_%a%s@]"
-      Property.print property
+    Format.fprintf ppf "@[assert_%a%s@]" Property.print property
       (if strict then "_strict" else "")
 
 let from_lambda : Lambda.check_attribute -> t = function
   | Default_check -> Default_check
   | Ignore_assert_all p -> Ignore_assert_all (Property.from_lambda p)
   | Assume { property; strict; never_returns_normally; loc } ->
-    Assume { property = Property.from_lambda property; strict; never_returns_normally; loc }
+    Assume
+      { property = Property.from_lambda property;
+        strict;
+        never_returns_normally;
+        loc
+      }
   | Check { property; strict; loc } ->
     Check { property = Property.from_lambda property; strict; loc }
 
@@ -65,11 +68,14 @@ let equal x y =
   | ( Check { property = p1; strict = s1; loc = loc1 },
       Check { property = p2; strict = s2; loc = loc2 } ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && loc1 = loc2
-  | ( Assume { property = p1; strict = s1; never_returns_normally = n1; loc = loc1 },
-      Assume { property = p2; strict = s2; never_returns_normally = n2; loc = loc2 } ) ->
+  | ( Assume
+        { property = p1; strict = s1; never_returns_normally = n1; loc = loc1 },
+      Assume
+        { property = p2; strict = s2; never_returns_normally = n2; loc = loc2 }
+    ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && Bool.equal n1 n2 && loc1 = loc2
   | (Default_check | Ignore_assert_all _ | Check _ | Assume _), _ -> false
 
 let is_default : t -> bool = function
   | Default_check -> true
-  | Ignore_assert_all _ | Check _ | Assume _  -> false
+  | Ignore_assert_all _ | Check _ | Assume _ -> false

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -23,10 +23,14 @@ end
 type t =
   | Default_check
   | Ignore_assert_all of Property.t
+  | Assume of
+      { property : Property.t;
+        strict : bool;
+        loc : Location.t
+      }
   | Check of
       { property : Property.t;
         strict : bool;
-        assume : bool;
         loc : Location.t
       }
 
@@ -35,27 +39,35 @@ let print ppf t =
   | Default_check -> ()
   | Ignore_assert_all property ->
     Format.fprintf ppf "@[ignore %a@]" Property.print property
-  | Check { property; strict; assume; loc = _ } ->
-    Format.fprintf ppf "@[%s%s %a@]"
-      (if assume then "assume" else "assert")
+  | Assume { property; strict; loc = _ } ->
+    Format.fprintf ppf "@[assume%s %a@]"
+      (if strict then " strict" else "")
+      Property.print property
+  | Check { property; strict; loc = _ } ->
+    Format.fprintf ppf "@[assert%s %a@]"
       (if strict then " strict" else "")
       Property.print property
 
 let from_lambda : Lambda.check_attribute -> t = function
   | Default_check -> Default_check
   | Ignore_assert_all p -> Ignore_assert_all (Property.from_lambda p)
-  | Check { property; strict; assume; loc } ->
-    Check { property = Property.from_lambda property; strict; assume; loc }
+  | Assume { property; strict; loc } ->
+    Assume { property = Property.from_lambda property; strict; loc }
+  | Check { property; strict; loc } ->
+    Check { property = Property.from_lambda property; strict; loc }
 
 let equal x y =
   match x, y with
   | Default_check, Default_check -> true
   | Ignore_assert_all p1, Ignore_assert_all p2 -> Property.equal p1 p2
-  | ( Check { property = p1; strict = s1; assume = a1; loc = loc1 },
-      Check { property = p2; strict = s2; assume = a2; loc = loc2 } ) ->
-    Property.equal p1 p2 && Bool.equal s1 s2 && Bool.equal a1 a2 && loc1 = loc2
-  | (Default_check | Ignore_assert_all _ | Check _), _ -> false
+  | ( Check { property = p1; strict = s1; loc = loc1 },
+      Check { property = p2; strict = s2; loc = loc2 } ) ->
+    Property.equal p1 p2 && Bool.equal s1 s2 && loc1 = loc2
+  | ( Assume { property = p1; strict = s1; loc = loc1 },
+      Assume { property = p2; strict = s2; loc = loc2 } ) ->
+    Property.equal p1 p2 && Bool.equal s1 s2 && loc1 = loc2
+  | (Default_check | Ignore_assert_all _ | Check _ | Assume _), _ -> false
 
 let is_default : t -> bool = function
   | Default_check -> true
-  | Ignore_assert_all _ | Check _ -> false
+  | Ignore_assert_all _ | Check _ | Assume _  -> false

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -67,13 +67,14 @@ let equal x y =
   | Ignore_assert_all p1, Ignore_assert_all p2 -> Property.equal p1 p2
   | ( Check { property = p1; strict = s1; loc = loc1 },
       Check { property = p2; strict = s2; loc = loc2 } ) ->
-    Property.equal p1 p2 && Bool.equal s1 s2 && loc1 = loc2
+    Property.equal p1 p2 && Bool.equal s1 s2 && Location.compare loc1 loc2 = 0
   | ( Assume
         { property = p1; strict = s1; never_returns_normally = n1; loc = loc1 },
       Assume
         { property = p2; strict = s2; never_returns_normally = n2; loc = loc2 }
     ) ->
-    Property.equal p1 p2 && Bool.equal s1 s2 && Bool.equal n1 n2 && loc1 = loc2
+    Property.equal p1 p2 && Bool.equal s1 s2 && Bool.equal n1 n2
+    && Location.compare loc1 loc2 = 0
   | (Default_check | Ignore_assert_all _ | Check _ | Assume _), _ -> false
 
 let is_default : t -> bool = function

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -20,6 +20,7 @@ type t =
   | Assume of
       { property : Property.t;
         strict : bool;
+        never_returns_normally : bool;
         loc : Location.t
       }
   | Check of

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -17,10 +17,14 @@ end
 type t =
   | Default_check
   | Ignore_assert_all of Property.t
+  | Assume of
+      { property : Property.t;
+        strict : bool;
+        loc : Location.t
+      }
   | Check of
       { property : Property.t;
         strict : bool;
-        assume : bool;
         loc : Location.t
       }
 

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -324,8 +324,10 @@ let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list =
   function
   | Default_check -> []
   | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
-  | Check { property; strict; assume; loc } ->
-    [Check { property = transl_property property; strict; assume; loc }]
+  | Assume { property; strict; loc } ->
+    [Assume { property = transl_property property; strict; loc }]
+  | Check { property; strict; loc } ->
+    [Check { property = transl_property property; strict; loc }]
 
 (* Translation of the bodies of functions. *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -324,8 +324,8 @@ let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list =
   function
   | Default_check -> []
   | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
-  | Assume { property; strict; loc } ->
-    [Assume { property = transl_property property; strict; loc }]
+  | Assume { property; strict; never_returns_normally; loc } ->
+    [Assume { property = transl_property property; strict; never_returns_normally; loc }]
   | Check { property; strict; loc } ->
     [Check { property = transl_property property; strict; loc }]
 

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -325,7 +325,12 @@ let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list =
   | Default_check -> []
   | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
   | Assume { property; strict; never_returns_normally; loc } ->
-    [Assume { property = transl_property property; strict; never_returns_normally; loc }]
+    [ Assume
+        { property = transl_property property;
+          strict;
+          never_returns_normally;
+          loc
+        } ]
   | Check { property; strict; loc } ->
     [Check { property = transl_property property; strict; loc }]
 

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -105,7 +105,7 @@ and one_fun ppf f =
     in
     iter f.params f.arity.params_layout
   in
-  fprintf ppf "(fun@ %s%s%a@ %d@ @[<2>%t@]@ @[<2>%a@])"
+  fprintf ppf "(fun@ %s%s@ %a@ %d@ @[<2>%t@]@ @[<2>%a@])"
     f.label (layout f.arity.return_layout) Printlambda.check_attribute f.check
     (List.length f.arity.params_layout) idents lam f.body
 

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -496,9 +496,12 @@ type check_attribute =
   | Ignore_assert_all of property
   | Check of { property: property;
                strict: bool;
-               assume: bool;
                loc: Location.t;
              }
+  | Assume of { property: property;
+                strict: bool;
+                loc: Location.t;
+              }
 
 type loop_attribute =
   | Always_loop (* [@loop] or [@loop always] *)

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -501,6 +501,7 @@ type check_attribute =
   | Assume of { property: property;
                 strict: bool;
                 loc: Location.t;
+                never_returns_normally: bool;
               }
 
 type loop_attribute =

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -396,6 +396,7 @@ type check_attribute =
   | Assume of { property: property;
                 strict: bool;
                 loc: Location.t;
+                never_returns_normally: bool;
               }
 
 type loop_attribute =

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -391,11 +391,12 @@ type check_attribute =
                   then the property holds (but property violations on
                   exceptional returns or divering loops are ignored).
                   This definition may not be applicable to new properties. *)
-               assume: bool;
-               (* [assume=true] assume without checking that the
-                  property holds *)
                loc: Location.t;
              }
+  | Assume of { property: property;
+                strict: bool;
+                loc: Location.t;
+              }
 
 type loop_attribute =
   | Always_loop (* [@loop] or [@loop always] *)

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -634,10 +634,11 @@ let check_attribute ppf check =
   | Default_check -> ()
   | Ignore_assert_all p ->
     fprintf ppf "ignore assert all %s@ " (check_property p)
-  | Assume {property=p; strict; loc = _} ->
-    fprintf ppf "assume_%s%s@ "
+  | Assume {property=p; strict; never_returns_normally; loc = _} ->
+    fprintf ppf "assume_%s%s%s@ "
       (check_property p)
       (if strict then "_strict" else "")
+      (if never_returns_normally then "_never_returns_normally" else "")
   | Check {property=p; strict; loc = _} ->
     fprintf ppf "assert_%s%s@ "
       (check_property p)

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -634,9 +634,12 @@ let check_attribute ppf check =
   | Default_check -> ()
   | Ignore_assert_all p ->
     fprintf ppf "ignore assert all %s@ " (check_property p)
-  | Check {property=p; assume; strict; loc = _} ->
-    fprintf ppf "%s %s%s@ "
-      (if assume then "assume" else "assert")
+  | Assume {property=p; strict; loc = _} ->
+    fprintf ppf "assume %s%s@ "
+      (check_property p)
+      (if strict then " strict" else "")
+  | Check {property=p; strict; loc = _} ->
+    fprintf ppf "assert %s%s@ "
       (check_property p)
       (if strict then " strict" else "")
 

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -635,13 +635,13 @@ let check_attribute ppf check =
   | Ignore_assert_all p ->
     fprintf ppf "ignore assert all %s@ " (check_property p)
   | Assume {property=p; strict; loc = _} ->
-    fprintf ppf "assume %s%s@ "
+    fprintf ppf "assume_%s%s@ "
       (check_property p)
-      (if strict then " strict" else "")
+      (if strict then "_strict" else "")
   | Check {property=p; strict; loc = _} ->
-    fprintf ppf "assert %s%s@ "
+    fprintf ppf "assert_%s%s@ "
       (check_property p)
-      (if strict then " strict" else "")
+      (if strict then "_strict" else "")
 
 let function_attribute ppf t =
   if t.is_a_functor then

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -251,11 +251,11 @@ let parse_property_attribute attr property =
   | Some {Parsetree.attr_name = {txt; loc}; attr_payload = payload}->
       parse_ids_payload txt loc
         ~default:Default_check
-        ~empty:(Check { property; strict = false; assume = false; loc; } )
+        ~empty:(Check { property; strict = false; loc; } )
         [
-          ["assume"], Check { property; strict = false; assume = true; loc; };
-          ["strict"], Check { property; strict = true; assume = false; loc; };
-          ["assume"; "strict"], Check { property; strict = true; assume = true; loc; };
+          ["assume"], Assume { property; strict = false; loc; };
+          ["strict"], Check { property; strict = true; loc; };
+          ["assume"; "strict"], Assume { property; strict = true; loc; };
           ["ignore"], Ignore_assert_all property
         ]
         payload
@@ -303,15 +303,15 @@ let get_property_attribute l p =
   (match attr, res with
    | None, Default_check -> ()
    | _, Default_check -> ()
-   | None, (Check _ | Ignore_assert_all _ ) -> assert false
+   | None, (Check _ | Assume _ | Ignore_assert_all _) -> assert false
    | Some _, Ignore_assert_all _ -> ()
-   | Some attr, Check { assume; _ } ->
+   | Some _, Assume _ -> ()
+   | Some attr, Check _ ->
      if !Clflags.zero_alloc_check && !Clflags.native_code then
        (* The warning for unchecked functions will not trigger if the check is requested
           through the [@@@zero_alloc all] top-level annotation rather than through the
           function annotation [@zero_alloc]. *)
-       if not assume then
-         Builtin_attributes.register_property attr.attr_name);
+       Builtin_attributes.register_property attr.attr_name);
    res
 
 let get_poll_attribute l =
@@ -414,7 +414,8 @@ let assume_zero_alloc attributes =
   match parse_property_attribute attr p with
   | Default_check -> false
   | Ignore_assert_all _ -> false
-  | Check { property = Zero_alloc; assume } -> assume
+  | Assume { property = Zero_alloc; _ } -> true
+  | Check { property = Zero_alloc; _ } -> false
 
 let assume_zero_alloc attributes =
   (* This function is used for "look-ahead" to find attributes
@@ -428,9 +429,12 @@ let add_check_attribute expr loc attributes =
     | Zero_alloc -> "zero_alloc"
   in
   let to_string = function
-    | Check { property; strict; assume; loc = _} ->
-      Printf.sprintf "%s %s%s"
-        (if assume then "assume" else "assert")
+    | Check { property; strict; loc = _} ->
+      Printf.sprintf "assert %s%s"
+        (to_string property)
+        (if strict then " strict" else "")
+    | Assume { property; strict; loc = _} ->
+      Printf.sprintf "assume %s%s"
         (to_string property)
         (if strict then " strict" else "")
     | Ignore_assert_all property ->
@@ -441,11 +445,13 @@ let add_check_attribute expr loc attributes =
   | Lfunction({ attr = { stub = false } as attr; } as funct) ->
     begin match get_property_attribute attributes Zero_alloc with
     | Default_check -> expr
-    | (Ignore_assert_all p | Check { property = p; _ }) as check ->
+    | (Ignore_assert_all p | Check { property = p; _ } | Assume { property = p; _ })
+      as check ->
       begin match attr.check with
       | Default_check -> ()
       | Ignore_assert_all p'
-      | Check { property = p'; strict = _; assume = _; loc = _; } ->
+      | Assume { property = p'; strict = _; loc = _; }
+      | Check { property = p'; strict = _; loc = _; } ->
         if p = p' then
           Location.prerr_warning loc
             (Warnings.Duplicated_attribute (to_string check));

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -253,9 +253,15 @@ let parse_property_attribute attr property =
         ~default:Default_check
         ~empty:(Check { property; strict = false; loc; } )
         [
-          ["assume"], Assume { property; strict = false; loc; };
+          ["assume"],
+          Assume { property; strict = false; never_returns_normally = false; loc; };
           ["strict"], Check { property; strict = true; loc; };
-          ["assume"; "strict"], Assume { property; strict = true; loc; };
+          ["assume"; "strict"],
+          Assume { property; strict = true; never_returns_normally = false; loc; };
+          ["assume"; "never_returns_normally"],
+          Assume { property; strict = false; never_returns_normally = true; loc; };
+          ["assume"; "strict"; "never_returns_normally"],
+          Assume { property; strict = true; never_returns_normally = true; loc; };
           ["ignore"], Ignore_assert_all property
         ]
         payload

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -511,7 +511,7 @@
  (action (diff test_warning199.output test_warning199.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (targets test_never_returns_normally.output.corrected)
  (deps (:ml test_never_returns_normally.ml) filter.sh)
  (action
@@ -525,6 +525,6 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps test_never_returns_normally.output test_never_returns_normally.output.corrected)
  (action (diff test_never_returns_normally.output test_never_returns_normally.output.corrected)))

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -509,3 +509,22 @@
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps test_warning199.output test_warning199.output.corrected)
  (action (diff test_warning199.output test_warning199.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_never_returns_normally.output.corrected)
+ (deps (:ml test_never_returns_normally.ml) filter.sh)
+ (action
+   (with-outputs-to test_never_returns_normally.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_never_returns_normally.output test_never_returns_normally.output.corrected)
+ (action (diff test_never_returns_normally.output test_never_returns_normally.output.corrected)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -117,4 +117,5 @@ let () =
   print_test ~flambda_only:true ~deps:"t1.ml";
   (* closure does not delete dead functions *)
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:(Some "test_warning199.mli") ~exit_code:0 "test_warning199";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_never_returns_normally";
   ()

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -117,5 +117,5 @@ let () =
   print_test ~flambda_only:true ~deps:"t1.ml";
   (* closure does not delete dead functions *)
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:(Some "test_warning199.mli") ~exit_code:0 "test_warning199";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_never_returns_normally";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "test_never_returns_normally";
   ()

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -239,3 +239,15 @@ let[@zero_alloc assume][@inline always] test40 x = (x,x)
 
 let[@zero_alloc] test41 b x =
   if b then test40 (x+1) else test40 (x*2)
+
+
+module Never_returns_normally = struct
+  let[@inline never][@zero_alloc assume never_returns_normally] failwithf fmt =
+   Printf.ksprintf (fun s () -> failwith s) fmt
+
+  let[@inline never][@zero_alloc assume never_returns_normally] invalid_argf fmt =
+    Printf.ksprintf (fun s () -> invalid_arg s) fmt
+
+ let[@zero_alloc] foo x = failwithf "%d" x
+ let[@zero_alloc] bar x y = invalid_argf "%d" (x+y)
+end

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -4,12 +4,12 @@ File "test_attribute_error_duplicate.ml", line 2, characters 66-76:
 Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
 File "test_attribute_error_duplicate.ml", line 3, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'assume strict', 'ignore' or empty
+It must be either 'assume', 'strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 4, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'assume strict', 'ignore' or empty
+It must be either 'assume', 'strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 5, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'assume strict', 'ignore' or empty
+It must be either 'assume', 'strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate__test1_HIDE_STAMP)

--- a/tests/backend/checkmach/test_never_returns_normally.ml
+++ b/tests/backend/checkmach/test_never_returns_normally.ml
@@ -1,0 +1,11 @@
+(* CR gyorsh: Does not work without [@inline]. Fix by propagating never_returns_normally
+   to check_mach as an extra annotation on [Debuginfo.t]. *)
+let[@zero_alloc assume never_returns_normally] failwithf fmt =
+  Printf.ksprintf (fun s () -> failwith s) fmt
+
+let[@zero_alloc assume never_returns_normally] invalid_argf fmt =
+  Printf.ksprintf (fun s () -> invalid_arg s) fmt
+
+let[@zero_alloc] foo x = failwithf "%d" x
+let[@zero_alloc] bar x y = invalid_argf "%d" (x+y)
+

--- a/tests/backend/checkmach/test_never_returns_normally.output
+++ b/tests/backend/checkmach/test_never_returns_normally.output
@@ -1,0 +1,4 @@
+File "test_never_returns_normally.ml", line 9, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.foo (camlTest_never_returns_normally__foo_HIDE_STAMP)
+File "test_never_returns_normally.ml", line 9, characters 25-41:
+  indirect tailcall


### PR DESCRIPTION
Support for `[@zero_alloc assume never_returns_normally]` function annotation. The intended use is for situations in which the analysis cannot figure out statically that a function does not return normally, for example:

```
let[@inline never][@zero_alloc assume never_returns_normally] failwithf fmt =
  Printf.ksprintf (fun s () -> failwith s) fmt

let[@inline never][@zero_alloc assume never_returns_normally] invalid_argf fmt =
  Printf.ksprintf (fun s () -> invalid_arg s) fmt

let[@zero_alloc] foo x = failwithf "%d" x
let[@zero_alloc] bar x y = invalid_argf "%d" (x+y)
```

The first commit refactors `Lambda.check_attribute`: instead of `Check { assume=true; ...}` use a separate constructor for `Assume` to make it easier to add a new field to only one of `Check` or `Assume`.  Then, we add a the field `never_returns_normally` to `Assume`. (A subsequent PR will also add an `opt` field to `Check`. ) 
The new field is used in `checkmach` to set `nor` field to `Bot` instead of the current value of `Safe` that is used to express `assume` annotation on a function.  

The above example currently doesn't work without `[@inline never]` because `never_returns_normally` annotation is not propagated as part of  `Debuginfo.t` in the same was `assume_zero_alloc`. I am planning to make a separate PR to  fix it but in the meantime the current PR is sufficient to handle the [common use case from Base](https://github.com/janestreet/base/blob/fbb560c9fe1e3d82c7ecca18a4b56eac9ad86886/src/printf.ml#L6-L7). 

