### PR TITLE
Improve layout history error message formatting and wording

### DIFF
--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -144,9 +144,9 @@ end;;
 Line 2, characters 2-31:
 2 |   type t = string [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type string is value, because
+Error: The layout of type string is value, because
          it equals the primitive value type string.
-       But the layout of Type string must be a sublayout of immediate, because
+       But the layout of type string must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}];;
 
@@ -158,9 +158,9 @@ end;;
 Line 2, characters 2-41:
 2 |   type t = Foo of int | Bar [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant.
-       But the layout of Type t must be a sublayout of immediate, because
+       But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
 |}];;
 
@@ -172,9 +172,9 @@ end;;
 Line 2, characters 2-38:
 2 |   type t = { foo : int } [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record.
-       But the layout of Type t must be a sublayout of immediate, because
+       But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/3.
 |}];;
 
@@ -187,9 +187,9 @@ end;;
 Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type t is value, because
-         an abstract type has default layout value.
-       But the layout of Type t must be a sublayout of immediate, because
+Error: The layout of type t is value, because
+         an abstract type has the value layout by default.
+       But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type s.
 |}];;
 
@@ -245,9 +245,9 @@ end;;
 Line 2, characters 2-26:
 2 |   type t = s [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type s is value, because
+Error: The layout of type s is value, because
          it equals the primitive value type string.
-       But the layout of Type s must be a sublayout of immediate, because
+       But the layout of type s must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -148,7 +148,6 @@ Error: The layout of Type string is value, because
          it equals the primitive value type string.
        But the layout of Type string must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (variant) *)
@@ -160,10 +159,9 @@ Line 2, characters 2-41:
 2 |   type t = Foo of int | Bar [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of Type t is value, because
-         a boxed variant.
+         it's a boxed variant.
        But the layout of Type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
-
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (record) *)
@@ -175,10 +173,9 @@ Line 2, characters 2-38:
 2 |   type t = { foo : int } [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of Type t is value, because
-         a boxed record.
+         it's a boxed record.
        But the layout of Type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/3.
-
 |}];;
 
 (* Not guaranteed that t is immediate, so this is an invalid declaration *)
@@ -191,10 +188,9 @@ Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of Type t is value, because
-         the default layout for an abstract type.
+         an abstract type has default layout value.
        But the layout of Type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type s.
-
 |}];;
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
@@ -219,7 +215,6 @@ Error: Signature mismatch:
          it equals the primitive value type string.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 (* Same as above but with explicit signature *)
@@ -239,7 +234,6 @@ Error: Signature mismatch:
          it equals the primitive value type string.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)
@@ -255,7 +249,6 @@ Error: The layout of Type s is value, because
          it equals the primitive value type string.
        But the layout of Type s must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
-
 |}];;
 
 

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -114,7 +114,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         a tuple element.
+         it's a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_float64_id) = x, false;;
@@ -127,7 +127,7 @@ Error: This expression has type 'a t_float64_id = ('a : float64)
        The layout of 'a t_float64_id is float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
        But the layout of 'a t_float64_id must overlap with value, because
-         a tuple element.
+         it's a tuple element.
 |}];;
 
 let f4_3 (x : float#) = x, false;;
@@ -140,7 +140,7 @@ Error: This expression has type float# but an expression was expected of type
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a tuple element.
+         it's a tuple element.
 |}];;
 
 type t4_4 = t_float64 * string;;
@@ -149,11 +149,10 @@ Line 1, characters 12-21:
 1 | type t4_4 = t_float64 * string;;
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
-        The layout of t_float64 is float64, because
-          of the annotation on the declaration of the type t_float64.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         a tuple element.
-
+         it's a tuple element.
 |}];;
 
 type t4_5 = int * float#;;
@@ -162,11 +161,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * float#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-        The layout of float# is float64, because
-          it equals the primitive value type float#.
+       The layout of float# is float64, because
+         it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a tuple element.
-
+         it's a tuple element.
 |}];;
 
 type ('a : float64) t4_6 = 'a * 'a
@@ -178,7 +176,7 @@ Error: This type ('a : value) should be an instance of type ('a0 : float64)
        The layout of 'a is float64, because
          of the annotation on 'a in the declaration of the type t4_6.
        But the layout of 'a must overlap with value, because
-         a tuple element.
+         it's a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -191,7 +189,7 @@ Error: This type ('b : value) should be an instance of type ('a : float64)
        The layout of 'a is float64, because
          of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value, because
-         a tuple element.
+         it's a tuple element.
 |}]
 
 (****************************************************)
@@ -288,8 +286,7 @@ Error: This type signature for x is not a value type.
        The layout of x is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of x must be a sublayout of value, because
-         stored in a module structure.
-
+         it's stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_float64_id end
@@ -301,8 +298,7 @@ Error: This type signature for x is not a value type.
        The layout of x is float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
        But the layout of x must overlap with value, because
-         stored in a module structure.
-
+         it's stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : float# end
@@ -314,8 +310,7 @@ Error: This type signature for x is not a value type.
        The layout of x is float64, because
          it equals the primitive value type float#.
        But the layout of x must be a sublayout of value, because
-         stored in a module structure.
-
+         it's stored in a module structure.
 |}];;
 
 
@@ -331,7 +326,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         a field of a polymorphic variant.
+         it's a field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_float64_id) = `A x;;
@@ -344,7 +339,7 @@ Error: This expression has type 'a t_float64_id = ('a : float64)
        The layout of 'a t_float64_id is float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
        But the layout of 'a t_float64_id must overlap with value, because
-         a field of a polymorphic variant.
+         it's a field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : float#) = `A x;;
@@ -357,7 +352,7 @@ Error: This expression has type float# but an expression was expected of type
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a field of a polymorphic variant.
+         it's a field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_float64 ];;
@@ -366,11 +361,10 @@ Line 1, characters 20-29:
 1 | type f7_4 = [ `A of t_float64 ];;
                         ^^^^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
-        The layout of t_float64 is float64, because
-          of the annotation on the declaration of the type t_float64.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         a field of a polymorphic variant.
-
+         it's a field of a polymorphic variant.
 |}];;
 
 type ('a : float64) f7_5 = [ `A of 'a ];;
@@ -382,7 +376,7 @@ Error: This type ('a : value) should be an instance of type ('a0 : float64)
        The layout of 'a is float64, because
          of the annotation on 'a in the declaration of the type f7_5.
        But the layout of 'a must overlap with value, because
-         a field of a polymorphic variant.
+         it's a field of a polymorphic variant.
 |}];;
 (* CR layouts v2.9: This error could be improved *)
 
@@ -411,7 +405,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         used as a function result.
+         it's used as a function result.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -424,7 +418,7 @@ Error: This expression has type 'a t_float64_id = ('a : float64)
        The layout of 'a t_float64_id is float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
        But the layout of 'a t_float64_id must overlap with value, because
-         used as a function result.
+         it's used as a function result.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -437,7 +431,7 @@ Error: This expression has type float# but an expression was expected of type
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         used as a function result.
+         it's used as a function result.
 |}];;
 
 (*************************************)
@@ -590,11 +584,10 @@ Line 1, characters 15-28:
 1 | type t12_1 = < x : t_float64 >;;
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-        The layout of t_float64 is float64, because
-          of the annotation on the declaration of the type t_float64.
+       The layout of t_float64 is float64, because
+         of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         an object field.
-
+         it's an object field.
 |}];;
 
 type ('a : float64) t12_2 = < x : 'a >;;
@@ -606,7 +599,7 @@ Error: This type ('a : value) should be an instance of type ('a0 : float64)
        The layout of 'a is float64, because
          of the annotation on 'a in the declaration of the type t12_2.
        But the layout of 'a must overlap with value, because
-         an object field.
+         it's an object field.
 |}]
 
 class c12_3 = object method x : t_float64 = assert false end;;
@@ -619,7 +612,7 @@ Error: The method x has type t_float64 but is expected to have type
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         an object field.
+         it's an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -631,7 +624,7 @@ Line 2, characters 13-15:
                  ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
 |}];;
@@ -646,8 +639,7 @@ Error: Variables bound in a class must have layout value.
        The layout of x is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of x must be a sublayout of value, because
-         an class field.
-
+         it's an class field.
 |}];;
 
 class type c12_6 = object method x : float# end;;
@@ -659,7 +651,7 @@ Error: The method x has type float# but is expected to have type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         an object field.
+         it's an object field.
 |}];;
 (* CR layouts v2.9: Error could be improved *)
 
@@ -672,8 +664,7 @@ Error: Variables bound in a class must have layout value.
        The layout of x is float64, because
          it equals the primitive value type float#.
        But the layout of x must be a sublayout of value, because
-         an instance variable.
-
+         it's an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -685,7 +676,7 @@ Line 2, characters 10-12:
               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
 |}];;
@@ -726,7 +717,7 @@ Error: This expression has type ('a : value)
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         captured in an object.
+         it's captured in an object.
 |}];;
 
 let f12_14 (m1 : t_float64) (m2 : t_float64) = object
@@ -743,8 +734,7 @@ Error: m1 must have a type of layout value because it is captured by an object.
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         captured in an object.
-
+         it's captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -763,7 +753,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         imported from another compilation unit.
+         it's imported from another compilation unit.
 |}];;
 
 let f13_2 (x : t_float64) = compare x x;;
@@ -776,7 +766,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         imported from another compilation unit.
+         it's imported from another compilation unit.
 |}];;
 
 let f13_3 (x : t_float64) = Marshal.to_bytes x;;
@@ -789,7 +779,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         imported from another compilation unit.
+         it's imported from another compilation unit.
 |}];;
 
 let f13_4 (x : t_float64) = Hashtbl.hash x;;
@@ -802,5 +792,5 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         imported from another compilation unit.
+         it's imported from another compilation unit.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -47,7 +47,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 let f (_ : float# list) = ();;
@@ -59,7 +59,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 type t = C of float# list;;
@@ -71,7 +71,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 type t = C : float# list -> t;;
@@ -83,7 +83,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 (* Syntax: float#c

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -47,7 +47,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 let f (_ : float# list) = ();;
@@ -59,7 +59,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 type t = C of float# list;;
@@ -71,7 +71,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 type t = C : float# list -> t;;
@@ -83,7 +83,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 (* Syntax: float#c
@@ -105,7 +105,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
 |}];;
 
 let f (_ : float#c) = ();;
@@ -117,7 +117,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
 |}];;
 
 type t = C of float#c;;
@@ -129,7 +129,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
 |}];;
 
 type t = C : float#c -> t;;
@@ -141,7 +141,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
 |}];;
 
 (* Syntax: float# c
@@ -156,7 +156,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
 |}];;
 
 let f (_ : float# c) = ();;
@@ -168,7 +168,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
 |}];;
 
 type t = C of float# c;;
@@ -180,7 +180,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
 |}];;
 
 type t = C : float# c -> t;;
@@ -192,7 +192,7 @@ Error: This type float# should be an instance of type ('a : value)
        The layout of float# is float64, because
          it equals the primitive value type float#.
        But the layout of float# must be a sublayout of value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
 |}];;
 
 (* Syntax: float #c

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
@@ -6,4 +6,4 @@ Error: This expression has type t_void -> unit
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         imported from another compilation unit. 
+         it's imported from another compilation unit.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -6,4 +6,4 @@ Error: This expression has type t_void -> unit
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         imported from another compilation unit. 
+         it's imported from another compilation unit.

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -48,7 +48,7 @@ Line 1, characters 12-19:
 Error: This type B.b_value = A.a_value should be an instance of type
          ('a : immediate)
        The layout of B.b_value is value, because
-         imported from another compilation unit.
+         it's imported from another compilation unit.
        But the layout of B.b_value must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type imm_arg.
        No .cmi file found containing A.a_value.

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
@@ -27,9 +27,9 @@ Line 1, characters 40-54:
                                             ^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
-         a missing .cmi file for Function_a.t.
+         the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be a sublayout of '_representable_layout_1, because
-         used as a function argument.
+         it's used as a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -42,9 +42,9 @@ Line 1, characters 34-36:
                                       ^^
 Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
-         a missing .cmi file for Function_a.t.
+         the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be a sublayout of '_representable_layout_2, because
-         used as a function argument.
+         it's used as a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -57,9 +57,9 @@ Line 1, characters 28-56:
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
-         a missing .cmi file for Function_a.t.
+         the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be a sublayout of '_representable_layout_3, because
-         used as a function argument.
+         it's used as a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -72,9 +72,9 @@ Line 1, characters 31-53:
                                    ^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
-         a missing .cmi file for Function_a.t.
+         the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be a sublayout of '_representable_layout_4, because
-         used as a function result.
+         it's used as a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -89,9 +89,9 @@ Line 2, characters 12-28:
                 ^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
-         a missing .cmi file for Function_a.t.
+         the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be a sublayout of '_representable_layout_5, because
-         used as a function argument.
+         it's used as a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -106,9 +106,9 @@ Line 2, characters 12-30:
                 ^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
-         a missing .cmi file for Function_a.t.
+         the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be a sublayout of '_representable_layout_6, because
-         used as a function result.
+         it's used as a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -277,9 +277,9 @@ type ('a : immediate) t_imm
 Line 3, characters 15-39:
 3 | type s = { f : ('a : value). 'a -> 'a u }
                    ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type 'a is value, because
+Error: The layout of type 'a is value, because
          of the annotation on the universal variable a.
-       But the layout of Type 'a must be a sublayout of immediate, because
+       But the layout of type 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t_imm.
 |}]
 (* CR layouts v1.5: the location on that message is wrong. But it's hard

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -57,7 +57,7 @@ Line 1, characters 8-36:
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : immediate)
        The layout of int list is value, because
-         a boxed variant.
+         it's a boxed variant.
        But the layout of int list must be a sublayout of immediate, because
          of the annotation on the type variable a.
 |}]
@@ -261,7 +261,7 @@ Line 2, characters 18-55:
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
        The layout of 'a is value, because
-         an unannotated universal variable.
+         it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on the abstract type declaration for a.
 |}]
@@ -281,7 +281,6 @@ Error: The layout of Type 'a is value, because
          of the annotation on the universal variable a.
        But the layout of Type 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t_imm.
-
 |}]
 (* CR layouts v1.5: the location on that message is wrong. But it's hard
    to improve, because it comes from re-checking typedtree, where we don't
@@ -315,7 +314,7 @@ Error: This pattern matches values of type a
        The layout of a is any, because
          of the annotation on the abstract type declaration for a.
        But the layout of a must be a sublayout of '_representable_layout_1, because
-         used as a function argument.
+         it's used as a function argument.
 |}]
 
 (****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -37,11 +37,10 @@ Line 2, characters 17-22:
 2 |   val f : int -> t_any
                      ^^^^^
 Error: Function return types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_1, because
-         used as a function result.
-
+         it's used as a function result.
 |}];;
 
 module type S1 = sig
@@ -52,11 +51,10 @@ Line 2, characters 10-15:
 2 |   val f : t_any -> int
               ^^^^^
 Error: Function argument types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_2, because
-         used as a function argument.
-
+         it's used as a function argument.
 |}];;
 
 module type S1 = sig
@@ -73,7 +71,7 @@ Error: The type constraints are not consistent.
        The layout of t is any, because
          of the annotation on the declaration of the type t.
        But the layout of t must be a sublayout of '_representable_layout_3, because
-         appears as an unannotated type parameter.
+         it appears as an unannotated type parameter.
 |}]
 
 module type S1 = sig
@@ -90,7 +88,7 @@ Error: The type constraints are not consistent.
        The layout of t is any, because
          of the annotation on the declaration of the type t.
        But the layout of t must be a sublayout of '_representable_layout_4, because
-         appears as an unannotated type parameter.
+         it appears as an unannotated type parameter.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -103,7 +101,7 @@ Error: This expression has type t_any but an expression was expected of type
        The layout of t_any is any, because
          of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_5, because
-         used as a function result.
+         it's used as a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -117,7 +115,7 @@ Error: This pattern matches values of type t_any
        The layout of t_any is any, because
          of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_6, because
-         used as a function argument.
+         it's used as a function argument.
 |}];;
 
 (*****************************************************)
@@ -198,8 +196,7 @@ Error: This type signature for x is not a value type.
        The layout of x is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of x must be a sublayout of value, because
-         stored in a module structure.
-
+         it's stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
 
@@ -383,8 +380,7 @@ Error: Non-value detected in [value_kind].
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type void5.
        But the layout of 'a must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}];;
 
 (* disallowed attempts to use f5 and Void5 on non-voids *)
@@ -408,7 +404,7 @@ Line 1, characters 31-32:
 Error: This expression has type int any5
        but an expression was expected of type ('a : void)
        The layout of int any5 is value, because
-         a boxed variant.
+         it's a boxed variant.
        But the layout of int any5 must be a sublayout of void, because
          of the annotation on 'a in the declaration of the type void5.
 |}];;
@@ -427,8 +423,7 @@ Error: Non-value detected in [value_kind].
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type void5.
        But the layout of 'a must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 
 (****************************************)
@@ -455,7 +450,7 @@ Line 2, characters 2-32:
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
        The layout of 'a is value, because
-         an unannotated universal variable.
+         it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
@@ -471,7 +466,7 @@ Line 3, characters 4-34:
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
        The layout of 'a is value, because
-         an unannotated universal variable.
+         it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
@@ -493,7 +488,7 @@ Line 3, characters 12-21:
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
        The layout of int * int is value, because
-         a tuple type.
+         it's a tuple type.
        But the layout of int * int must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t7.
 |}]
@@ -511,11 +506,10 @@ Line 2, characters 40-46:
 2 |   type foo1 = [ `Foo1 of int | `Baz1 of t_void | `Bar1 of string ];;
                                             ^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
-        The layout of t_void is void, because
-          of the annotation on the declaration of the type t_void.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a field of a polymorphic variant.
-
+         it's a field of a polymorphic variant.
 |}];;
 
 module M8_2 = struct
@@ -548,7 +542,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a field of a polymorphic variant.
+         it's a field of a polymorphic variant.
 |}];;
 
 module M8_4 = struct
@@ -563,7 +557,7 @@ Error: The type constraints are not consistent.
        The layout of void_unboxed_record is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of void_unboxed_record must be a sublayout of value, because
-         a field of a polymorphic variant.
+         it's a field of a polymorphic variant.
 |}];;
 
 module type S8_5 = sig
@@ -574,11 +568,10 @@ Line 2, characters 17-23:
 2 |   val x : [`A of t_void]
                      ^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
-        The layout of t_void is void, because
-          of the annotation on the declaration of the type t_void.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a field of a polymorphic variant.
-
+         it's a field of a polymorphic variant.
 |}]
 
 (************************************************)
@@ -593,11 +586,10 @@ Line 2, characters 20-26:
 2 |   type foo1 = int * t_void * [ `Foo1 of int | `Bar1 of string ];;
                         ^^^^^^
 Error: Tuple element types must have layout value.
-        The layout of t_void is void, because
-          of the annotation on the declaration of the type t_void.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a tuple element.
-
+         it's a tuple element.
 |}];;
 
 module M9_2 = struct
@@ -608,11 +600,10 @@ Line 2, characters 31-50:
 2 |   type result = V of (string * void_unboxed_record) | I of int
                                    ^^^^^^^^^^^^^^^^^^^
 Error: Tuple element types must have layout value.
-        The layout of void_unboxed_record is void, because
-          of the annotation on the declaration of the type t_void.
+       The layout of void_unboxed_record is void, because
+         of the annotation on the declaration of the type t_void.
        But the layout of void_unboxed_record must be a sublayout of value, because
-         a tuple element.
-
+         it's a tuple element.
 |}];;
 
 module M9_3 = struct
@@ -632,7 +623,7 @@ Error: This expression has type void_unboxed_record
        The layout of void_unboxed_record is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of void_unboxed_record must be a sublayout of value, because
-         a tuple element.
+         it's a tuple element.
 |}];;
 
 module M9_4 = struct
@@ -649,7 +640,7 @@ Error: The record field vur_void belongs to the type void_unboxed_record
        The layout of void_unboxed_record is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of void_unboxed_record must be a sublayout of value, because
-         a boxed record.
+         it's a boxed record.
 |}];;
 
 module M9_5 = struct
@@ -665,7 +656,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a tuple element.
+         it's a tuple element.
 |}];;
 
 module M9_6 = struct
@@ -680,7 +671,7 @@ Error: The type constraints are not consistent.
        The layout of void_unboxed_record is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of void_unboxed_record must be a sublayout of value, because
-         a tuple element.
+         it's a tuple element.
 |}];;
 
 module type S9_7 = sig
@@ -691,11 +682,10 @@ Line 2, characters 16-22:
 2 |   val x : int * t_void
                     ^^^^^^
 Error: Tuple element types must have layout value.
-        The layout of t_void is void, because
-          of the annotation on the declaration of the type t_void.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a tuple element.
-
+         it's a tuple element.
 |}];;
 
 module M9_9 (X : sig
@@ -714,7 +704,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a tuple element.
+         it's a tuple element.
 |}];;
 
 (*************************************************)
@@ -816,8 +806,7 @@ Error: Methods must have layout value.
        The layout of This expression is void, because
          of the annotation on 'a in the declaration of the type t.
        But the layout of This expression must overlap with value, because
-         an object.
-
+         it's an object.
 |}]
 
 module M11_2 = struct
@@ -832,7 +821,7 @@ Error: This expression has type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         an object field.
+         it's an object field.
 |}];;
 
 module M11_3 = struct
@@ -849,8 +838,7 @@ Error: Non-value detected in [value_kind].
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}];;
 
 module M11_4 = struct
@@ -861,11 +849,10 @@ Line 2, characters 12-22:
 2 |   val x : < l : t_void >
                 ^^^^^^^^^^
 Error: Object field types must have layout value.
-        The layout of t_void is void, because
-          of the annotation on the declaration of the type t_void.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         an object field.
-
+         it's an object field.
 |}];;
 
 module M11_5 = struct
@@ -880,7 +867,7 @@ Error:
        The layout of 'a s is void, because
          of the annotation on 'a in the declaration of the type s.
        But the layout of 'a s must overlap with value, because
-         an object field.
+         it's an object field.
 |}];;
 
 module M11_6 = struct
@@ -895,7 +882,7 @@ Error: The type constraints are not consistent.
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         an object field.
+         it's an object field.
 |}];;
 
 (*******************************************************************)
@@ -915,10 +902,9 @@ Line 3, characters 11-12:
                ^
 Error: Variables bound in a class must have layout value.
        The layout of v is void, because
-         bound by a `let`.
+         it's bound by a `let`.
        But the layout of v must be a sublayout of value, because
-         let-bound in a class expression.
-
+         it's let-bound in a class expression.
 |}];;
 
 (* Hits the Cfk_concrete case of Pcf_val *)
@@ -936,8 +922,7 @@ Error: Variables bound in a class must have layout value.
        The layout of bar is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of bar must be a sublayout of value, because
-         an class field.
-
+         it's an class field.
 |}];;
 
 (* Hits the Cfk_virtual case of Pcf_val *)
@@ -955,8 +940,7 @@ Error: Variables bound in a class must have layout value.
        The layout of bar is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of bar must be a sublayout of value, because
-         an class field.
-
+         it's an class field.
 |}];;
 
 module M12_4 = struct
@@ -973,7 +957,7 @@ Line 6, characters 24-26:
                             ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
          of the annotation on 'a in the declaration of the type t.
 |}];;
@@ -992,7 +976,7 @@ Line 6, characters 29-31:
                                  ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
          of the annotation on 'a in the declaration of the type t.
 |}];;
@@ -1012,7 +996,7 @@ Line 5, characters 4-6:
         ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
-         a term-level argument to a class constructor.
+         it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
          of the annotation on 'a in the declaration of the type t.
 |}];;
@@ -1031,8 +1015,7 @@ Error: Variables bound in a class must have layout value.
        The layout of baz is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of baz must be a sublayout of value, because
-         an instance variable.
-
+         it's an instance variable.
 |}];;
 
 (***********************************************************)
@@ -1048,7 +1031,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         imported from another compilation unit.
+         it's imported from another compilation unit.
 |}];;
 
 let x13 (VV v) = lazy v;;
@@ -1061,7 +1044,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a lazy expression.
+         it's a lazy expression.
 |}];;
 
 let x13 v =
@@ -1076,7 +1059,7 @@ Error: This expression has type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a lazy expression.
+         it's a lazy expression.
 |}];;
 
 (* option *)
@@ -1090,7 +1073,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 let x13 (VV v) = Some v;;
@@ -1103,7 +1086,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 let x13 v =
@@ -1119,7 +1102,7 @@ Error: This expression has type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 (* list *)
@@ -1133,7 +1116,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 let x13 (VV v) = [v];;
@@ -1146,7 +1129,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 let x13 v =
@@ -1162,7 +1145,7 @@ Error: This expression has type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 (* array *)
@@ -1176,7 +1159,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 let x13 (VV v) = [| v |];;
@@ -1189,7 +1172,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         an array element.
+         it's an array element.
 |}];;
 
 let x13 v =
@@ -1205,7 +1188,7 @@ Error: This expression has type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         an array element.
+         it's an array element.
 |}];;
 
 (****************************************************************************)
@@ -1227,7 +1210,7 @@ Error:
        The layout of foo14 is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of foo14 must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 (****************************************************)
@@ -1352,8 +1335,7 @@ Error: Non-value detected in [value_kind].
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type r.
        But the layout of 'a must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}];;
 
 (********************************************************************)
@@ -1426,7 +1408,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}]
 
 (*********************************************************)
@@ -1679,7 +1661,7 @@ Error: This pattern matches values of type t_void
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a tuple element.
+         it's a tuple element.
 |}]
 
 let ( let* ) x f = ()
@@ -1701,7 +1683,7 @@ Error: This pattern matches values of type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         a tuple element.
+         it's a tuple element.
 |}]
 
 
@@ -1727,7 +1709,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         used as a function argument.
+         it's used as a function argument.
 |}]
 
 (**************************************)
@@ -1756,7 +1738,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         used as a function argument.
+         it's used as a function argument.
 |}]
 
 (**************************************************)
@@ -1774,7 +1756,7 @@ Error: This type ('a : value) should be an instance of type ('a0 : void)
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type poly_var.
        But the layout of 'a must overlap with value, because
-         a tuple element.
+         it's a tuple element.
 |}]
 
 (* CR layouts bug: this should be accepted (or maybe we should reject
@@ -1796,7 +1778,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a field of a polymorphic variant.
+         it's a field of a polymorphic variant.
 |}]
 
 (******************************************************)
@@ -1811,8 +1793,7 @@ Error: This type signature for foo33 is not a value type.
        The layout of foo33 is any, because
          of the annotation on the declaration of the type t_any.
        But the layout of foo33 must be a sublayout of value, because
-         stored in a module structure.
-
+         it's stored in a module structure.
 |}]
 
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -1073,7 +1073,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 let x13 (VV v) = Some v;;
@@ -1086,7 +1086,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 let x13 v =
@@ -1102,7 +1102,7 @@ Error: This expression has type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 (* list *)
@@ -1116,7 +1116,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 let x13 (VV v) = [v];;
@@ -1129,7 +1129,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 let x13 v =
@@ -1145,7 +1145,7 @@ Error: This expression has type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 (* array *)
@@ -1159,7 +1159,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 let x13 (VV v) = [| v |];;
@@ -1210,7 +1210,7 @@ Error:
        The layout of foo14 is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of foo14 must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 (****************************************************)
@@ -1408,7 +1408,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}]
 
 (*********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -227,7 +227,7 @@ Line 2, characters 2-32:
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
        The layout of 'a is value, because
-         an unannotated universal variable.
+         it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
@@ -243,7 +243,7 @@ Line 3, characters 4-34:
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
        The layout of 'a is value, because
-         an unannotated universal variable.
+         it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t6_imm.
 |}];;
@@ -264,7 +264,7 @@ Line 3, characters 12-21:
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
        The layout of int * int is value, because
-         a tuple type.
+         it's a tuple type.
        But the layout of int * int must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t7.
 |}]
@@ -578,5 +578,4 @@ Error: The layout of Type 'a is value, because
          of the annotation on the universal variable a.
        But the layout of Type 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t2_imm.
-
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -574,8 +574,8 @@ type ('a : immediate) t2_imm
 Line 3, characters 15-40:
 3 | type s = { f : ('a : value) . 'a -> 'a u }
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type 'a is value, because
+Error: The layout of type 'a is value, because
          of the annotation on the universal variable a.
-       But the layout of Type 'a must be a sublayout of immediate, because
+       But the layout of type 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t2_imm.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -50,11 +50,10 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_1, because
-         used as constructor field 0.
-
+         it's used as constructor field 0.
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -63,11 +62,10 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_2, because
-         used as constructor field 1.
-
+         it's used as constructor field 1.
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -76,11 +74,10 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_3, because
-         used as constructor field 0.
-
+         it's used as constructor field 0.
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -93,7 +90,7 @@ Error:
        The layout of 'b t1_constraint' is any, because
          of the annotation on the declaration of the type t_any.
        But the layout of 'b t1_constraint' must be a sublayout of '_representable_layout_4, because
-         appears as an unannotated type parameter.
+         it appears as an unannotated type parameter.
 |}]
 (* CR layouts errors: this error is blamed on the wrong piece *)
 
@@ -151,11 +148,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_5, because
-         used in the declaration of the record field "x/341".
-
+         it's used in the declaration of the record field "x/341".
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -164,11 +160,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_6, because
-         used in the declaration of the record field "y/344".
-
+         it's used in the declaration of the record field "y/344".
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -177,11 +172,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_7, because
-         used in the declaration of the record field "x/346".
-
+         it's used in the declaration of the record field "x/346".
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -190,11 +184,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_8, because
-         used in the declaration of the record field "x/350".
-
+         it's used in the declaration of the record field "x/350".
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -203,11 +196,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_9, because
-         used in the declaration of the record field "y/354".
-
+         it's used in the declaration of the record field "y/354".
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -216,11 +208,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_10, because
-         used in the declaration of the record field "x/357".
-
+         it's used in the declaration of the record field "x/357".
 |}];;
 
 (*********************************************************)
@@ -251,11 +242,10 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_11, because
-         used as constructor field 0.
-
+         it's used as constructor field 0.
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -264,11 +254,10 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_12, because
-         used as constructor field 1.
-
+         it's used as constructor field 1.
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -277,11 +266,10 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_13, because
-         used as constructor field 0.
-
+         it's used as constructor field 0.
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -312,11 +300,10 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        The layout of t_any is any, because
-          of the annotation on the declaration of the type t_any.
+       The layout of t_any is any, because
+         of the annotation on the declaration of the type t_any.
        But the layout of t_any must be a sublayout of '_representable_layout_14, because
-         used in the declaration of the record field "y/387".
-
+         it's used in the declaration of the record field "y/387".
 |}];;
 
 (**************************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -133,9 +133,9 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type Bar3.t is value, because
+Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
-       But the layout of Type Bar3.t must be a sublayout of immediate, because
+       But the layout of type Bar3.t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
 |}];;
 
@@ -182,9 +182,9 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The layout of Type string is value, because
+Error: The layout of type string is value, because
          it equals the primitive value type string.
-       But the layout of Type string must be a sublayout of immediate, because
+       But the layout of type string must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -137,7 +137,6 @@ Error: The layout of Type Bar3.t is value, because
          of the annotation on the declaration of the type t.
        But the layout of Type Bar3.t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
-
 |}];;
 
 module rec Foo3 : sig
@@ -187,7 +186,6 @@ Error: The layout of Type string is value, because
          it equals the primitive value type string.
        But the layout of Type string must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}]
 
 (*****************************************)
@@ -226,10 +224,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : immediate
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 module type S6_6' = sig
@@ -247,10 +244,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : immediate
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 (* CR layouts: this is broken because of the package with-type hack.  It was
@@ -272,10 +268,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : immediate
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -41,7 +41,7 @@ Error: The type constraints are not consistent.
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must overlap with value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 module type S1'' = S1 with type s = t_void;;
@@ -50,10 +50,10 @@ module type S1'' = S1 with type s = t_void;;
 Line 1, characters 27-42:
 1 | module type S1'' = S1 with type s = t_void;;
                                ^^^^^^^^^^^^^^^
-Error: The layout of Type t_void is void, because
+Error: The layout of type t_void is void, because
          of the annotation on the declaration of the type t_void.
-       But the layout of Type t_void must be a sublayout of value, because
-         an abstract type has default layout value.
+       But the layout of type t_void must be a sublayout of value, because
+         an abstract type has the value layout by default.
 |}]
 
 module type S1_2 = sig
@@ -95,7 +95,7 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
        The layout of 'a is immediate, because
          of the annotation on 'a in the declaration of the type t.
 |}]
@@ -196,9 +196,9 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type Bar3.t is value, because
+Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
-       But the layout of Type Bar3.t must be a sublayout of immediate, because
+       But the layout of type Bar3.t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
 |}];;
 
@@ -237,7 +237,7 @@ Error: This type ('a : void) should be an instance of type ('b : value)
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must overlap with value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 |}];;
 
 (* One downside of the current approach - this could be allowed, but isn't.  You
@@ -266,7 +266,7 @@ Line 12, characters 11-17:
                 ^^^^^^
 Error: This type Foo3.t should be an instance of type ('a : void)
        The layout of Foo3.t is value, because
-         an abstract type has default layout value.
+         an abstract type has the value layout by default.
        But the layout of Foo3.t must be a sublayout of void, because
          of the annotation on 'a in the declaration of the type t.
 |}];;
@@ -397,9 +397,9 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The layout of Type string is value, because
+Error: The layout of type string is value, because
          it equals the primitive value type string.
-       But the layout of Type string must be a sublayout of immediate, because
+       But the layout of type string must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -41,7 +41,7 @@ Error: The type constraints are not consistent.
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must overlap with value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 module type S1'' = S1 with type s = t_void;;
@@ -53,8 +53,7 @@ Line 1, characters 27-42:
 Error: The layout of Type t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of Type t_void must be a sublayout of value, because
-         the default layout for an abstract type.
-
+         an abstract type has default layout value.
 |}]
 
 module type S1_2 = sig
@@ -94,13 +93,11 @@ Error: Signature mismatch:
        is not included in
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
-       because their layouts are different.'a value, because
-                                             a type argument defaulted to have layout value.
-                                           'a immediate, because
-                                             of the annotation on 'a
-                                                                  in the declaration of the type
-                                                                  t.
-
+       because their layouts are different.
+       The layout of 'a is value, because
+         a type argument default to layout value.
+       The layout of 'a is immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}]
 
 (************************************************************************)
@@ -203,7 +200,6 @@ Error: The layout of Type Bar3.t is value, because
          of the annotation on the declaration of the type t.
        But the layout of Type Bar3.t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
-
 |}];;
 
 module rec Foo3 : sig
@@ -241,7 +237,7 @@ Error: This type ('a : void) should be an instance of type ('b : value)
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must overlap with value, because
-         a type argument defaulted to have layout value.
+         a type argument default to layout value.
 |}];;
 
 (* One downside of the current approach - this could be allowed, but isn't.  You
@@ -270,7 +266,7 @@ Line 12, characters 11-17:
                 ^^^^^^
 Error: This type Foo3.t should be an instance of type ('a : void)
        The layout of Foo3.t is value, because
-         the default layout for an abstract type.
+         an abstract type has default layout value.
        But the layout of Foo3.t must be a sublayout of void, because
          of the annotation on 'a in the declaration of the type t.
 |}];;
@@ -323,7 +319,7 @@ Line 1, characters 11-15:
                ^^^^
 Error: This type M4.s should be an instance of type ('a : void)
        The layout of M4.s is value, because
-         a boxed variant.
+         it's a boxed variant.
        But the layout of M4.s must be a sublayout of void, because
          of the annotation on 'a in the declaration of the type t4_void.
 |}]
@@ -405,7 +401,6 @@ Error: The layout of Type string is value, because
          it equals the primitive value type string.
        But the layout of Type string must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}]
 
 (*****************************************)
@@ -429,10 +424,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : void
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of void, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 module type S6_3 = sig
@@ -448,11 +442,10 @@ Line 6, characters 33-34:
 6 |   val m : (module S6_3 with type t = t_void)
                                      ^
 Error: Signature package constraint types must have layout value.
-        The layout of t_void is void, because
-          of the annotation on the declaration of the type t_void.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         used as an element in a first-class module.
-
+         it's used as an element in a first-class module.
 |}];;
 
 module type S6_5 = sig
@@ -474,10 +467,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : immediate
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 module type S6_6' = sig
@@ -495,10 +487,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : immediate
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -517,10 +508,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : immediate
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 (*****************************************)
@@ -549,6 +539,5 @@ Error: This type signature for x is not a value type.
        The layout of x is any, because
          of the annotation on the declaration of the type t_any.
        But the layout of x must be a sublayout of value, because
-         stored in a module structure.
-
+         it's stored in a module structure.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -83,13 +83,11 @@ Error: Signature mismatch:
        is not included in
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
-       because their layouts are different.'a value, because
-                                             a type argument defaulted to have layout value.
-                                           'a immediate, because
-                                             of the annotation on 'a
-                                                                  in the declaration of the type
-                                                                  t.
-
+       because their layouts are different.
+       The layout of 'a is value, because
+         a type argument default to layout value.
+       The layout of 'a is immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}]
 
 module M1_2''' : S1_2 = struct
@@ -111,13 +109,11 @@ Error: Signature mismatch:
          type ('a : immediate) t
        Their parameters differ:
        The type ('a : value) is not equal to the type ('a0 : immediate)
-       because their layouts are different.'a value, because
-                                             a type argument defaulted to have layout value.
-                                           'a immediate, because
-                                             of the annotation on 'a
-                                                                  in the declaration of the type
-                                                                  t.
-
+       because their layouts are different.
+       The layout of 'a is value, because
+         a type argument default to layout value.
+       The layout of 'a is immediate, because
+         of the annotation on 'a in the declaration of the type t.
 |}]
 
 (************************************************************************)
@@ -221,7 +217,6 @@ Error: The layout of Type Bar3.t is value, because
          of the annotation on the declaration of the type t.
        But the layout of Type Bar3.t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
-
 |}];;
 
 module rec Foo3 : sig
@@ -352,7 +347,6 @@ Error: The layout of Type string is value, because
          it equals the primitive value type string.
        But the layout of Type string must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}]
 
 (*****************************************)
@@ -390,10 +384,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : immediate
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 module type S6_6' = sig
@@ -411,10 +404,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : immediate
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -433,10 +425,9 @@ Error: In this `with' constraint, the new definition of t
        is not included in
          type t : immediate
        The layout of the first is value, because
-         used as an element in a first-class module.
+         it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
-
 |}];;
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -85,7 +85,7 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
        The layout of 'a is immediate, because
          of the annotation on 'a in the declaration of the type t.
 |}]
@@ -111,7 +111,7 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
        The layout of 'a is immediate, because
          of the annotation on 'a in the declaration of the type t.
 |}]
@@ -213,9 +213,9 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of Type Bar3.t is value, because
+Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
-       But the layout of Type Bar3.t must be a sublayout of immediate, because
+       But the layout of type Bar3.t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t/2.
 |}];;
 
@@ -343,9 +343,9 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The layout of Type string is value, because
+Error: The layout of type string is value, because
          it equals the primitive value type string.
-       But the layout of Type string must be a sublayout of immediate, because
+       But the layout of type string must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
@@ -7,7 +7,7 @@ Error: This type ('a : value) should be an instance of type ('a0 : void)
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type t0.
        But the layout of 'a must overlap with value, because
-         a type argument defaulted to have layout value. 
+         a type argument default to layout value.
 Line 2, characters 11-15:
 2 | type ('a : valu) t0 = 'a list;;
                ^^^^

--- a/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
@@ -7,7 +7,7 @@ Error: This type ('a : value) should be an instance of type ('a0 : void)
        The layout of 'a is void, because
          of the annotation on 'a in the declaration of the type t0.
        But the layout of 'a must overlap with value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
 Line 2, characters 11-15:
 2 | type ('a : valu) t0 = 'a list;;
                ^^^^

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -79,8 +79,7 @@ Error: Non-value detected in [value_kind].
        The layout of void_rec is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of void_rec must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -143,8 +142,7 @@ Error: Non-value detected in [value_kind].
        The layout of void_rec is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of void_rec must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -233,8 +231,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -448,8 +445,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -496,8 +492,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -527,8 +522,7 @@ Error: Non-value detected in [value_kind].
        The layout of void_rec is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of void_rec must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -640,8 +634,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -683,8 +676,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -725,8 +717,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -767,8 +758,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -850,8 +840,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -901,8 +890,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -971,8 +959,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -1017,8 +1004,7 @@ Error: Non-value detected in [value_kind].
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         to be value for the V1 safety check.
-
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after

--- a/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
@@ -4,7 +4,8 @@ File "baz.ml", line 1, characters 8-18:
 Error: This expression has type 'a Foo.t
        but an expression was expected of type ('b : '_representable_layout_1)
        The layout of 'a Foo.t is any, because
-         a missing .cmi file for Foo.t.
+         the .cmi file for Foo.t is missing.
        But the layout of 'a Foo.t must be a sublayout of '_representable_layout_1, because
-         bound by a `let`. No .cmi file found containing Foo.t.
+         it's bound by a `let`.
+       No .cmi file found containing Foo.t.
        Hint: Adding "foo" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
@@ -3,8 +3,8 @@ File "client.ml", line 2, characters 0-19:
     ^^^^^^^^^^^^^^^^^^^
 Error: 
        The layout of alias is any, because
-         a dummy layout used in checking mutually recursive datatypes.
+         a dummy layout of any is used to check mutually recursive datatypes.
        But the layout of alias must be a sublayout of value, because
-         a type argument defaulted to have layout value. 
+         a type argument default to layout value.
        No .cmi file found containing Missing.t.
        Hint: Adding "missing" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
@@ -5,6 +5,6 @@ Error:
        The layout of alias is any, because
          a dummy layout of any is used to check mutually recursive datatypes.
        But the layout of alias must be a sublayout of value, because
-         a type argument default to layout value.
+         a type argument defaults to layout value.
        No .cmi file found containing Missing.t.
        Hint: Adding "missing" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -4,8 +4,8 @@ File "main.ml", line 1, characters 8-11:
 Error: This expression has type M.a but an expression was expected of type
          ('a : value)
        The layout of M.a is any, because
-         a missing .cmi file for M.a.
+         the .cmi file for M.a is missing.
        But the layout of M.a must be a sublayout of value, because
-         imported from another compilation unit. 
+         it's imported from another compilation unit.
        No .cmi file found containing M.a.
        Hint: Adding "m" to your dependencies might help.

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -744,7 +744,7 @@ module Layout = struct
       | Extensible_variant -> fprintf ppf "it's an extensible variant"
       | Primitive id ->
         fprintf ppf "it equals the primitive value type %s" (Ident.name id)
-      | Type_argument -> fprintf ppf "a type argument default to layout value"
+      | Type_argument -> fprintf ppf "a type argument defaults to layout value"
       | Tuple -> fprintf ppf "it's a tuple type"
       | Row_variable -> fprintf ppf "it's a row variable"
       | Polymorphic_variant -> fprintf ppf "it's a polymorphic variant"
@@ -757,7 +757,7 @@ module Layout = struct
       | Univar -> fprintf ppf "it's an unannotated universal variable"
       | Polymorphic_variant_field -> fprintf ppf "it's a field of a polymorphic variant"
       | Default_type_layout ->
-        fprintf ppf "an abstract type has default layout value"
+        fprintf ppf "an abstract type has the value layout by default"
       | Float_record_field ->
         fprintf ppf "it's a field of a float record"
       | Existential_type_variable ->

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -634,34 +634,34 @@ module Layout = struct
     let format_concrete_layout_reason ppf : concrete_layout_reason -> unit =
       function
       | Match ->
-        fprintf ppf "matched on"
+        fprintf ppf "it's pattern matched on"
       | Constructor_declaration idx ->
-        fprintf ppf "used as constructor field %d" idx
+        fprintf ppf "it's used as constructor field %d" idx
       | Label_declaration lbl ->
-        fprintf ppf "used in the declaration of the record field \"%a\""
+        fprintf ppf "it's used in the declaration of the record field \"%a\""
           Ident.print lbl
       | Unannotated_type_parameter ->
-        fprintf ppf "appears as an unannotated type parameter"
+        fprintf ppf "it appears as an unannotated type parameter"
       | Record_projection ->
-        fprintf ppf "used as the record in a projection"
+        fprintf ppf "it's used as the record in a projection"
       | Record_assignment ->
-        fprintf ppf "used as the record in an assignment"
+        fprintf ppf "it's used as the record in an assignment"
       | Let_binding ->
-        fprintf ppf "bound by a `let`"
+        fprintf ppf "it's bound by a `let`"
       | Function_argument ->
-        fprintf ppf "used as a function argument"
+        fprintf ppf "it's used as a function argument"
       | Function_result ->
-        fprintf ppf "used as a function result"
+        fprintf ppf "it's used as a function result"
       | Structure_item_expression ->
-        fprintf ppf "used in an expression in a structure"
+        fprintf ppf "it's used in an expression in a structure"
       | V1_safety_check ->
-        fprintf ppf "part of the v1 safety check"
+        fprintf ppf "it's part of the v1 safety check"
       | External_argument ->
-        fprintf ppf "used as an argument in an external declaration"
+        fprintf ppf "it's used as an argument in an external declaration"
       | External_result ->
-        fprintf ppf "used as the result of an external declaration"
+        fprintf ppf "it's used as the result of an external declaration"
       | Statement ->
-        fprintf ppf "used as a statement"
+        fprintf ppf "it's used as a statement"
 
     let format_annotation_context ppf : annotation_context -> unit = function
       | Type_declaration p ->
@@ -691,30 +691,30 @@ module Layout = struct
 
     let format_any_creation_reason ppf : any_creation_reason -> unit = function
       | Missing_cmi p ->
-         fprintf ppf "a missing .cmi file for %a" !printtyp_path p
+         fprintf ppf "the .cmi file for %a is missing" !printtyp_path p
       | Wildcard ->
-         fprintf ppf "a _ in a type"
+        fprintf ppf "there's a _ in the type"
       | Unification_var ->
-         fprintf ppf "a fresh unification variable"
+         fprintf ppf "it's a fresh unification variable"
       | Initial_typedecl_env ->
-         fprintf ppf "a dummy layout used in checking mutually recursive datatypes"
+         fprintf ppf "a dummy layout of any is used to check mutually recursive datatypes"
       | Dummy_layout ->
-         fprintf ppf "@[a dummy layout that should have been overwritten;@ \
-                      Please notify the Jane Street compilers group if you see this output."
+         fprintf ppf "@[it's assigned a dummy layout that should have been overwritten;@ \
+                      Please notify the Jane Street compilers group if you see this output.@]"
       (* CR layouts: Improve output or remove this constructor ^^ *)
       | Type_expression_call ->
-         fprintf ppf "a call to [type_expression] via the ocaml API"
+         fprintf ppf "there's a call to [type_expression] via the ocaml API"
 
     let format_immediate_creation_reason ppf : immediate_creation_reason -> _ =
       function
       | Empty_record ->
-         fprintf ppf "a record containing all void elements"
+         fprintf ppf "it's a record containing all void elements"
       | Enumeration ->
-         fprintf ppf "an enumeration variant (all constructors are constant)"
+         fprintf ppf "it's an enumeration variant (all constructors are constant)"
       | Primitive id ->
          fprintf ppf "it equals the primitive immediate type %s" (Ident.name id)
       | Immediate_polymorphic_variant ->
-         fprintf ppf "an immediate polymorphic variant"
+         fprintf ppf "it's an immediate polymorphic variant"
       | Gc_ignorable_check ->
          fprintf ppf "the check to see whether a value can be ignored by GC"
       | Value_kind ->
@@ -730,56 +730,56 @@ module Layout = struct
          fprintf ppf "the check that a type is definitely not `float`"
 
     let format_value_creation_reason ppf : value_creation_reason -> _ = function
-      | Class_let_binding -> fprintf ppf "let-bound in a class expression"
-      | Tuple_element -> fprintf ppf "a tuple element"
-      | Probe -> fprintf ppf "a probe"
-      | Package_hack -> fprintf ppf "used as an element in a first-class module"
-      | Object -> fprintf ppf "an object"
-      | Instance_variable -> fprintf ppf "an instance variable"
-      | Object_field -> fprintf ppf "an object field"
-      | Class_field -> fprintf ppf "an class field"
-      | Boxed_record -> fprintf ppf "a boxed record"
-      | Boxed_variant -> fprintf ppf "a boxed variant"
-      | Extensible_variant -> fprintf ppf "an extensible variant"
+      | Class_let_binding -> fprintf ppf "it's let-bound in a class expression"
+      | Tuple_element -> fprintf ppf "it's a tuple element"
+      | Probe -> fprintf ppf "it's a probe"
+      | Package_hack -> fprintf ppf "it's used as an element in a first-class module"
+      | Object -> fprintf ppf "it's an object"
+      | Instance_variable -> fprintf ppf "it's an instance variable"
+      | Object_field -> fprintf ppf "it's an object field"
+      | Class_field -> fprintf ppf "it's an class field"
+      | Boxed_record -> fprintf ppf "it's a boxed record"
+      | Boxed_variant -> fprintf ppf "it's a boxed variant"
+      | Extensible_variant -> fprintf ppf "it's an extensible variant"
       | Primitive id ->
         fprintf ppf "it equals the primitive value type %s" (Ident.name id)
-      | Type_argument -> fprintf ppf "a type argument defaulted to have layout value"
-      | Tuple -> fprintf ppf "a tuple type"
-      | Row_variable -> fprintf ppf "a row variable"
-      | Polymorphic_variant -> fprintf ppf "a polymorphic variant"
-      | Arrow -> fprintf ppf "a function type"
-      | Tfield -> fprintf ppf "an internal Tfield type (you shouldn't see this)"
-      | Tnil -> fprintf ppf "an internal Tnil type (you shouldn't see this)"
-      | First_class_module -> fprintf ppf "a first-class module type"
+      | Type_argument -> fprintf ppf "a type argument default to layout value"
+      | Tuple -> fprintf ppf "it's a tuple type"
+      | Row_variable -> fprintf ppf "it's a row variable"
+      | Polymorphic_variant -> fprintf ppf "it's a polymorphic variant"
+      | Arrow -> fprintf ppf "it's a function type"
+      | Tfield -> fprintf ppf "it's an internal Tfield type (you shouldn't see this)"
+      | Tnil -> fprintf ppf "it's an internal Tnil type (you shouldn't see this)"
+      | First_class_module -> fprintf ppf "it's a first-class module type"
       | Separability_check ->
         fprintf ppf "the check that a type is definitely not `float`"
-      | Univar -> fprintf ppf "an unannotated universal variable"
-      | Polymorphic_variant_field -> fprintf ppf "a field of a polymorphic variant"
+      | Univar -> fprintf ppf "it's an unannotated universal variable"
+      | Polymorphic_variant_field -> fprintf ppf "it's a field of a polymorphic variant"
       | Default_type_layout ->
-        fprintf ppf "the default layout for an abstract type"
+        fprintf ppf "an abstract type has default layout value"
       | Float_record_field ->
-        fprintf ppf "a field of a float record"
+        fprintf ppf "it's a field of a float record"
       | Existential_type_variable ->
-        fprintf ppf "an unannotated existential type variable"
+        fprintf ppf "it's an unannotated existential type variable"
       | Array_element ->
-        fprintf ppf "an array element"
+        fprintf ppf "it's an array element"
       | Lazy_expression ->
-        fprintf ppf "a lazy expression"
+        fprintf ppf "it's a lazy expression"
       | Class_argument ->
-        fprintf ppf "a term-level argument to a class constructor"
+        fprintf ppf "it's a term-level argument to a class constructor"
       | Structure_element ->
-         fprintf ppf "stored in a module structure"
+         fprintf ppf "it's stored in a module structure"
       | Debug_printer_argument ->
-         fprintf ppf "used as the argument to a debugger printer function"
+         fprintf ppf "it's used as the argument to a debugger printer function"
       | V1_safety_check ->
-          fprintf ppf "to be value for the V1 safety check"
-      | Captured_in_object -> fprintf ppf "captured in an object"
+          fprintf ppf "it has to be value for the V1 safety check"
+      | Captured_in_object -> fprintf ppf "it's captured in an object"
       | Unknown s -> fprintf ppf "unknown @[(please alert the Jane Street@;\
                        compilers team with this message: %s)@]" s
 
 
     let format_void_creation_reason ppf : void_creation_reason -> _ = function
-      | V1_safety_check -> fprintf ppf "check to make sure there are no voids"
+      | V1_safety_check -> fprintf ppf "the check to make sure there are no voids"
         (* CR layouts: remove this when we remove its uses *)
 
     let format_float64_creation_reason ppf : float64_creation_reason -> _ = function
@@ -804,7 +804,7 @@ module Layout = struct
       | Concrete_creation concrete ->
          format_concrete_layout_reason ppf concrete
       | Imported ->
-         fprintf ppf "imported from another compilation unit"
+         fprintf ppf "it's imported from another compilation unit"
 
     let format_interact_reason ppf = function
       | Gadt_equation name ->

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -602,8 +602,9 @@ module Layout = struct
 
     let report_missing_cmi ppf = function
       | Some p ->
-        fprintf ppf "@,No .cmi file found containing %a." !printtyp_path p;
-        missing_cmi_hint ppf p
+        fprintf ppf "@,@[No .cmi file found containing %a.%a@]"
+          !printtyp_path p
+          missing_cmi_hint p
       | None -> ()
   end
 
@@ -830,7 +831,7 @@ module Layout = struct
         fprintf ppf ", because@ %a" format_creation_reason reason
       | _ -> assert false
       end;
-      fprintf ppf ".@]@;"
+      fprintf ppf ".@]"
 
 
     (* this isn't really formatted for user consumption *)
@@ -911,7 +912,7 @@ module Layout = struct
           | Not_a_sublayout _ -> "be a sublayout of"
           | No_intersection _ -> "overlap with"
         in
-        fprintf ppf "%a%a"
+        fprintf ppf "@[<v>%a@;%a@]"
           (format_history ~intro:(dprintf "The layout of %a is" pp_former former)) l1
           (format_history ~intro:(dprintf "But the layout of %a must %s" pp_former former connective)) l2;
       end else begin

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -2607,7 +2607,7 @@ let explanation (type variety) intro prev env
       let fmt_history t =
         Layout.format_history ~intro:(dprintf "The layout of %t is" (fun ppf -> type_expr ppf t))
       in
-      Some (dprintf "@ because their layouts are different.@ @[<v>%a%a@]"
+      Some (dprintf "@ because their layouts are different.@ @[<v>%a@;%a@]"
               (fmt_history t1) l1 (fmt_history t2) l2)
 
 let mismatch intro env trace =

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -2605,9 +2605,9 @@ let explanation (type variety) intro prev env
                  ~offender:(fun ppf -> type_expr ppf t)) e)
   | Errortrace.Unequal_var_layouts (t1,l1,t2,l2) ->
       let fmt_history t =
-        Layout.format_history ~intro:(fun ppf -> type_expr ppf t)
+        Layout.format_history ~intro:(dprintf "The layout of %t is" (fun ppf -> type_expr ppf t))
       in
-      Some (dprintf "@ because their layouts are different.@[<v>%a%a@]"
+      Some (dprintf "@ because their layouts are different.@ @[<v>%a%a@]"
               (fmt_history t1) l1 (fmt_history t2) l2)
 
 let mismatch intro env trace =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2530,10 +2530,10 @@ let report_error ppf = function
   | Layout_mismatch_of_path (dpath,v) ->
     (* the type is always printed just above, so print out just the head of the
        path instead of something like [t/3] *)
-    let offender ppf = fprintf ppf "Type %s" (Ident.name (Path.head dpath)) in
+    let offender ppf = fprintf ppf "type %s" (Ident.name (Path.head dpath)) in
     Layout.Violation.report_with_offender ~offender ppf v
   | Layout_mismatch_of_type (ty,v) ->
-    let offender ppf = fprintf ppf "Type %a" Printtyp.type_expr ty in
+    let offender ppf = fprintf ppf "type %a" Printtyp.type_expr ty in
     Layout.Violation.report_with_offender ~offender ppf v
   | Layout_sort {lloc; typ; err} ->
     let s =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -441,8 +441,8 @@ let make_constructor
       let args, targs =
         transl_constructor_arguments env univars closed sargs
       in
-      let tret_type = 
-        transl_simple_type env ?univars ~closed Mode.Alloc.Const.legacy sret_type 
+      let tret_type =
+        transl_simple_type env ?univars ~closed Mode.Alloc.Const.legacy sret_type
       in
       let ret_type = tret_type.ctyp_type in
       (* TODO add back type_path as a parameter ? *)
@@ -2542,7 +2542,7 @@ let report_error ppf = function
       | Record -> "Record element"
       | External -> "External"
     in
-    fprintf ppf "@[%s types must have a representable layout.@ \ %a@]" s
+    fprintf ppf "@[%s types must have a representable layout.@ %a@]" s
       (Layout.Violation.report_with_offender
          ~offender:(fun ppf -> Printtyp.type_expr ppf typ)) err
   | Layout_empty_record ->

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -1373,7 +1373,7 @@ let report_error env ppf = function
       | Package_constraint -> "Signature package constraint"
       | Object_field -> "Object field"
     in
-    fprintf ppf "@[%s types must have layout value.@ \ %a@]"
+    fprintf ppf "@[%s types must have layout value.@ %a@]"
       s (Layout.Violation.report_with_offender
            ~offender:(fun ppf -> Printtyp.type_expr ppf typ)) err
   | Non_sort {vloc; typ; err} ->
@@ -1382,7 +1382,7 @@ let report_error env ppf = function
       | Fun_arg -> "Function argument"
       | Fun_ret -> "Function return"
     in
-    fprintf ppf "@[%s types must have a representable layout.@ \ %a@]"
+    fprintf ppf "@[%s types must have a representable layout.@ %a@]"
       s (Layout.Violation.report_with_offender
            ~offender:(fun ppf -> Printtyp.type_expr ppf typ)) err
   | Bad_layout_annot(ty, violation) ->


### PR DESCRIPTION
Improve the wording and formatting (spacing, alignment, etc) of layout history error messages