### PR TITLE
Adjust the location on `as` pattern vars for better errors/warnings

### DIFF
--- a/ocaml/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/ocaml/testsuite/tests/typing-gadts/or_patterns.ml
@@ -217,9 +217,9 @@ let simple_merged_annotated_return (type a) (t : a t) (a : a) =
 ;;
 
 [%%expect{|
-Line 3, characters 12-20:
+Line 3, characters 18-19:
 3 |   | IntLit, (3 as x)
-                ^^^^^^^^
+                      ^
 Error: This pattern matches values of type a
        This instance of a is ambiguous:
        it would escape the scope of its equation

--- a/ocaml/testsuite/tests/warnings/w26_alias.ml
+++ b/ocaml/testsuite/tests/warnings/w26_alias.ml
@@ -1,0 +1,19 @@
+(* TEST
+   * expect
+*)
+type t =
+  { x : int
+  ; y : int
+  }
+
+let sum ({ x; y } as t) = x + y
+
+[%%expect{|
+type t = { x : int; y : int; }
+Line 6, characters 21-22:
+6 | let sum ({ x; y } as t) = x + y
+                         ^
+Warning 26 [unused-var]: unused variable t.
+val sum : t -> int = <fun>
+|}]
+

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -2540,7 +2540,7 @@ and type_pat_aux
         let ty_var, mode = solve_Ppat_alias ~refine ~mode:alloc_mode.mode env q in
         let mode = mode_cross_to_min !env expected_ty mode in
         let id =
-          enter_variable ~is_as_variable:true tps loc name mode
+          enter_variable ~is_as_variable:true tps name.loc name mode
             ty_var sp.ppat_attributes
         in
         rvp k {


### PR DESCRIPTION
This program has an unused pattern variable:
```ocaml
type t =
  { x : int
  ; y : int
  }

let sum ({ x; y } as t) = x + y
```
Previously, it gave this warning:
```
File "/home/ccasinghino/tmp/milo.ml", line 6, characters 8-23:
6 | let sum ({ x; y } as t) = x + y
            ^^^^^^^^^^^^^^^
Warning 26 [unused-var]: unused variable t.
```
But the location here is unhelpful, and it's worse if the pattern is bigger.

After this PR, we instead give:
```
File "/home/ccasinghino/tmp/milo.ml", line 6, characters 21-22:
6 | let sum ({ x; y } as t) = x + y
                         ^
Warning 26 [unused-var]: unused variable t.
```
Better!

This location shows up once in the testsuite for a different error. I think it's an improvement there too.