### PR TITLE
Only execute caml-apply-split-max-arity on linux

### DIFF
--- a/tests/backend/caml_apply_split_max_arity/dune
+++ b/tests/backend/caml_apply_split_max_arity/dune
@@ -6,8 +6,7 @@
 (rule
  (enabled_if 
   (and (= %{context_name} "main")
-       (= %{system} "linux")
-       (= %{architecture} "amd64")))
+       (= %{system} "linux")))
  (target t.output)
  (deps t.exe)
  (action (with-outputs-to t.output (progn
@@ -18,8 +17,7 @@
  (alias   runtest)
  (enabled_if 
   (and (= %{context_name} "main")
-       (= %{system} "linux")
-       (= %{architecture} "amd64")))
+       (= %{system} "linux")))
  (action (diff t.expected t.output)))
 
 ;; t.ml was created using cinaps

--- a/tests/backend/caml_apply_split_max_arity/dune
+++ b/tests/backend/caml_apply_split_max_arity/dune
@@ -4,7 +4,10 @@
  (ocamlopt_flags (:standard -linscan -Oclassic)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if 
+  (and (= %{context_name} "main")
+       (= %{system} "linux")
+       (= %{architecture} "amd64")))
  (target t.output)
  (deps t.exe)
  (action (with-outputs-to t.output (progn
@@ -13,7 +16,10 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if 
+  (and (= %{context_name} "main")
+       (= %{system} "linux")
+       (= %{architecture} "amd64")))
  (action (diff t.expected t.output)))
 
 ;; t.ml was created using cinaps


### PR DESCRIPTION
This test was failing on macos and relies on having access to binutils so turning it off for non-linux targets