### PR TITLE
Simplify integer comparisons that use "compare"

### DIFF
--- a/middle_end/flambda2/simplify/comparison_result.ml
+++ b/middle_end/flambda2/simplify/comparison_result.ml
@@ -1,0 +1,71 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2023 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module P = Flambda_primitive
+
+type comparison_kind =
+  | Int of { kind : Flambda_kind.Standard_int.t; sign : P.signed_or_unsigned }
+  | Float
+
+type t =
+{ lhs : Simple.t;
+  rhs : Simple.t;
+  comp : comparison_kind;
+}
+
+let create ~(prim : P.t) : t option =
+  match[@warning "-fragile-match"] prim with
+  | Binary (Int_comp (kind, Yielding_int_like_compare_functions sign),
+     lhs, rhs)->
+    Some { lhs; rhs; comp = Int { kind; sign } }
+  | Binary (Float_comp (Yielding_int_like_compare_functions ()),
+     lhs, rhs)->
+    Some { lhs; rhs; comp = Float }
+  | _ -> None
+
+let print_kind ppf ckind =
+  match ckind with
+  | Float -> Format.fprintf ppf "float"
+  | Int { kind; sign } ->
+    let prefix = match sign with Signed -> "" | Unsigned -> "u" in
+    Format.fprintf ppf "%s%a"
+      prefix
+      Flambda_kind.Standard_int.print_lowercase kind
+
+let [@ocamlformat "disable"] print ppf { lhs; rhs; comp } =
+  Format.fprintf ppf "@[<hov 1>(\
+      @[<hov 1>(lhs@ %a)@]@ \
+      @[<hov 1>(rhs@ %a)@]@ \
+      @[<hov 1>(kind@ %a)@]@ \
+      )@]"
+    Simple.print lhs
+    Simple.print rhs
+    print_kind comp
+
+let convert_result_compared_to_zero { lhs; rhs; comp } (op : _ P.comparison) : P.t =
+  let fix_sign new_val : _ P.comparison =
+    match op with
+    | Eq -> Eq
+    | Neq -> Neq
+    | Lt _ -> Lt new_val
+    | Gt _ -> Gt new_val
+    | Le _ -> Le new_val
+    | Ge _ -> Ge new_val
+  in
+  let prim : P.binary_primitive=
+    match comp with
+    | Float -> Float_comp (Yielding_bool (fix_sign ()))
+    | Int { kind; sign } -> Int_comp (kind, Yielding_bool (fix_sign sign))
+  in
+  Binary (prim, lhs, rhs)

--- a/middle_end/flambda2/simplify/comparison_result.mli
+++ b/middle_end/flambda2/simplify/comparison_result.mli
@@ -2,11 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                       Vincent Laviron, OCamlPro                        *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2023 OCamlPro SAS                                          *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,19 +12,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Simplification functions on [Simple.t]. *)
+type t
 
-(** This function is guaranteed to return an alias type. *)
-val simplify_simple :
-  Downwards_acc.t -> Simple.t -> min_name_mode:Name_mode.t -> Flambda2_types.t
+val create : prim:Flambda_primitive.t -> t option
 
-val simplify_simple_if_in_scope :
-  Downwards_acc.t -> Simple.t -> min_name_mode:Name_mode.t -> Flambda2_types.t option
+val print : Format.formatter -> t -> unit
 
-type simplify_simples_result = private
-  { simples : Simple.t list;
-    simple_tys : Flambda2_types.t list
-  }
-
-val simplify_simples :
-  Downwards_acc.t -> Simple.t list -> simplify_simples_result
+val convert_result_compared_to_zero :
+  t -> 'a Flambda_primitive.comparison -> Flambda_primitive.t

--- a/middle_end/flambda2/simplify/comparison_result.mli
+++ b/middle_end/flambda2/simplify/comparison_result.mli
@@ -14,9 +14,9 @@
 
 type t
 
-val create : prim:Flambda_primitive.t -> t option
+val create : prim:Flambda_primitive.t -> t Variable.Map.t -> t option
 
 val print : Format.formatter -> t -> unit
 
-val convert_result_compared_to_zero :
+val convert_result_compared_to_tagged_zero :
   t -> 'a Flambda_primitive.comparison -> Flambda_primitive.t

--- a/middle_end/flambda2/simplify/comparison_result.mli
+++ b/middle_end/flambda2/simplify/comparison_result.mli
@@ -14,9 +14,10 @@
 
 type t
 
-val create : prim:Flambda_primitive.t -> t Variable.Map.t -> t option
+val create :
+  prim:Flambda_primitive.t -> comparison_results:t Variable.Map.t -> t option
 
 val print : Format.formatter -> t -> unit
 
 val convert_result_compared_to_tagged_zero :
-  t -> 'a Flambda_primitive.comparison -> Flambda_primitive.t
+  t -> _ Flambda_primitive.comparison -> Flambda_primitive.t

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -477,7 +477,7 @@ let add_cse t prim ~bound_to =
   let comparison_results =
     let prim = Flambda_primitive.Eligible_for_cse.to_primitive prim in
     match
-      ( Comparison_result.create ~prim t.comparison_results,
+      ( Comparison_result.create ~prim ~comparison_results:t.comparison_results,
         Simple.must_be_var bound_to )
     with
     | None, _ | _, None -> t.comparison_results

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -40,6 +40,7 @@ type t =
     unit_toplevel_exn_continuation : Continuation.t;
     variables_defined_at_toplevel : Variable.Set.t;
     cse : CSE.t;
+    comparison_results : Comparison_result.t Variable.Map.t;
     do_not_rebuild_terms : bool;
     closure_info : Closure_info.t;
     get_imported_code : unit -> Exported_code.t;
@@ -57,7 +58,7 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
                 inlined_debuginfo; can_inline;
                 inlining_state; propagating_float_consts;
                 at_unit_toplevel; unit_toplevel_exn_continuation;
-                variables_defined_at_toplevel; cse;
+                variables_defined_at_toplevel; cse; comparison_results;
                 do_not_rebuild_terms; closure_info;
                 unit_toplevel_return_continuation; all_code;
                 get_imported_code = _; inlining_history_tracker = _;
@@ -75,6 +76,7 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
       @[<hov 1>(unit_toplevel_exn_continuation@ %a)@]@ \
       @[<hov 1>(variables_defined_at_toplevel@ %a)@]@ \
       @[<hov 1>(cse@ @[<hov 1>%a@])@]@ \
+      @[<hov 1>(comparison_results@ @[<hov 1>%a@])@]@ \
       @[<hov 1>(do_not_rebuild_terms@ %b)@]@ \
       @[<hov 1>(closure_info@ %a)@]@ \
       @[<hov 1>(all_code@ %a)@]@ \
@@ -91,6 +93,7 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
     Continuation.print unit_toplevel_exn_continuation
     Variable.Set.print variables_defined_at_toplevel
     CSE.print cse
+    (Variable.Map.print Comparison_result.print) comparison_results
     do_not_rebuild_terms
     Closure_info.print closure_info
     (Code_id.Map.print Code.print) all_code
@@ -118,6 +121,7 @@ let create ~round ~(resolver : resolver)
     unit_toplevel_exn_continuation;
     variables_defined_at_toplevel = Variable.Set.empty;
     cse = CSE.empty;
+    comparison_results = Variable.Map.empty;
     do_not_rebuild_terms = false;
     closure_info = Closure_info.not_in_a_closure;
     all_code = Code_id.Map.empty;
@@ -179,6 +183,7 @@ let enter_set_of_closures
       unit_toplevel_exn_continuation;
       variables_defined_at_toplevel;
       cse = _;
+      comparison_results = _;
       do_not_rebuild_terms;
       closure_info = _;
       get_imported_code;
@@ -197,6 +202,7 @@ let enter_set_of_closures
     unit_toplevel_exn_continuation;
     variables_defined_at_toplevel;
     cse = CSE.empty;
+    comparison_results = Variable.Map.empty;
     do_not_rebuild_terms;
     closure_info = Closure_info.in_a_set_of_closures;
     get_imported_code;
@@ -463,12 +469,22 @@ let add_inlined_debuginfo t dbg = Debuginfo.inline t.inlined_debuginfo dbg
 
 let cse t = t.cse
 
+let comparison_results t = t.comparison_results
+
 let add_cse t prim ~bound_to =
   let scope = get_continuation_scope t in
   let cse = CSE.add t.cse prim ~bound_to scope in
-  { t with cse }
+  let comparison_results =
+    let prim = Flambda_primitive.Eligible_for_cse.to_primitive prim in
+    match Comparison_result.create ~prim, Simple.must_be_var bound_to with
+    | None, _ | _, None -> t.comparison_results
+    | Some comp, Some (var, _) -> Variable.Map.add var comp t.comparison_results
+  in
+  { t with cse; comparison_results }
 
 let find_cse t prim = CSE.find t.cse prim
+
+let find_comparison_result t var = Variable.Map.find_opt var t.comparison_results
 
 let with_cse t cse = { t with cse }
 

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -476,7 +476,10 @@ let add_cse t prim ~bound_to =
   let cse = CSE.add t.cse prim ~bound_to scope in
   let comparison_results =
     let prim = Flambda_primitive.Eligible_for_cse.to_primitive prim in
-    match Comparison_result.create ~prim, Simple.must_be_var bound_to with
+    match
+      ( Comparison_result.create ~prim t.comparison_results,
+        Simple.must_be_var bound_to )
+    with
     | None, _ | _, None -> t.comparison_results
     | Some comp, Some (var, _) -> Variable.Map.add var comp t.comparison_results
   in
@@ -484,7 +487,8 @@ let add_cse t prim ~bound_to =
 
 let find_cse t prim = CSE.find t.cse prim
 
-let find_comparison_result t var = Variable.Map.find_opt var t.comparison_results
+let find_comparison_result t var =
+  Variable.Map.find_opt var t.comparison_results
 
 let with_cse t cse = { t with cse }
 

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -166,7 +166,11 @@ val add_cse :
 
 val find_cse : t -> Flambda_primitive.Eligible_for_cse.t -> Simple.t option
 
+val find_comparison_result : t -> Variable.t -> Comparison_result.t option
+
 val cse : t -> Common_subexpression_elimination.t
+
+val comparison_results : t -> Comparison_result.t Variable.Map.t
 
 val with_cse : t -> Common_subexpression_elimination.t -> t
 

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1034,69 +1034,74 @@ let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
 
 let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
   match prim with
-  | Block_load _
-  | Array_load _
-  | Int_arith _
-  | Int_shift _
+  | Block_load _ | Array_load _ | Int_arith _ | Int_shift _
   | Int_comp (_, Yielding_int_like_compare_functions _)
-  | Float_arith _
-  | Float_comp _
-  | Phys_equal _
-  | String_or_bigstring_load _
-  | Bigarray_load _
-  | Bigarray_get_alignment _ ->
+  | Float_arith _ | Float_comp _ | Phys_equal _ | String_or_bigstring_load _
+  | Bigarray_load _ | Bigarray_get_alignment _ ->
     None
   | Int_comp (kind, Yielding_bool op) -> (
-      match kind with
-      | Naked_immediate
-      | Naked_int32
-      | Naked_int64
-      | Naked_nativeint -> None
-      | Tagged_immediate ->
-        let try_one_direction left right op =
-          Simple.pattern_match right ~name:(fun _ ~coercion:_ -> None)
-            ~const:(fun const ->
-                match[@warning "-fragile-match"] Const.descr const with
-                | Tagged_immediate i when Targetint_31_63.(equal i zero) ->
-                  Simple.pattern_match' left ~const:(fun _ -> None)
-                    ~symbol:(fun _ ~coercion:_ -> None)
-                    ~var:(fun var ~coercion:_ ->
-                        match DE.find_comparison_result (DA.denv dacc) var with
-                        | None -> None
-                        | Some comp ->
-                          Some (Comparison_result.convert_result_compared_to_zero comp op))
-                | _ -> None)
+    match kind with
+    | Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint -> None
+    | Tagged_immediate -> (
+      let try_one_direction left right op =
+        Simple.pattern_match right
+          ~name:(fun _ ~coercion:_ -> None)
+          ~const:(fun const ->
+            match[@warning "-fragile-match"] Const.descr const with
+            | Tagged_immediate i when Targetint_31_63.(equal i zero) ->
+              Simple.pattern_match' left
+                ~const:(fun _ -> None)
+                ~symbol:(fun _ ~coercion:_ -> None)
+                ~var:(fun var ~coercion:_ ->
+                  match DE.find_comparison_result (DA.denv dacc) var with
+                  | None -> None
+                  | Some comp ->
+                    Some
+                      (Comparison_result.convert_result_compared_to_tagged_zero
+                         comp op))
+            | _ -> None)
+      in
+      match try_one_direction arg1 arg2 op with
+      | Some p -> Some p
+      | None ->
+        let op : _ P.comparison =
+          match op with
+          | Eq -> Eq
+          | Neq -> Neq
+          | Lt s -> Gt s
+          | Gt s -> Lt s
+          | Le s -> Ge s
+          | Ge s -> Le s
         in
-        match try_one_direction arg1 arg2 op with
-        | Some p -> Some p
-        | None ->
-          let op : _ P.comparison = match op with
-            | Eq -> Eq
-            | Neq -> Neq
-            | Lt s -> Gt s
-            | Gt s -> Lt s
-            | Le s -> Ge s
-            | Ge s -> Le s
-          in
-          try_one_direction arg2 arg1 op)
+        try_one_direction arg2 arg1 op))
 
 let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var =
   let original_prim, prim, arg1, arg1_ty, arg2, arg2_ty =
-    match[@warning "-fragile-match"] recover_comparison_primitive dacc prim ~arg1 ~arg2 with
+    match[@warning "-fragile-match"]
+      recover_comparison_primitive dacc prim ~arg1 ~arg2
+    with
     | None -> original_prim, prim, arg1, arg1_ty, arg2, arg2_ty
-    | Some (Binary (new_prim, new_arg1, new_arg2) as new_original_prim) ->
+    | Some (Binary (new_prim, new_arg1, new_arg2) as new_original_prim) -> (
       let min_name_mode = Bound_var.name_mode result_var in
-      let arg1_ty_opt = S.simplify_simple_if_in_scope dacc arg1 ~min_name_mode in
-      let arg2_ty_opt = S.simplify_simple_if_in_scope dacc arg2 ~min_name_mode in
-      (match arg1_ty_opt, arg2_ty_opt with
+      let arg1_ty_opt =
+        S.simplify_simple_if_in_scope dacc arg1 ~min_name_mode
+      in
+      let arg2_ty_opt =
+        S.simplify_simple_if_in_scope dacc arg2 ~min_name_mode
+      in
+      match arg1_ty_opt, arg2_ty_opt with
       | Some new_arg1_ty, Some new_arg2_ty ->
-        new_original_prim, new_prim, new_arg1, new_arg1_ty, new_arg2, new_arg2_ty
-      | None, _ | _, None ->
-        original_prim, prim, arg1, arg1_ty, arg2, arg2_ty)
+        ( new_original_prim,
+          new_prim,
+          new_arg1,
+          new_arg1_ty,
+          new_arg2,
+          new_arg2_ty )
+      | None, _ | _, None -> original_prim, prim, arg1, arg1_ty, arg2, arg2_ty)
     | Some other_prim ->
       Misc.fatal_errorf "Recovered primitive %a is not a comparison"
         Flambda_primitive.print other_prim
   in
-  simplify_binary_primitive0 dacc original_prim prim
-    ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var
+  simplify_binary_primitive0 dacc original_prim prim ~arg1 ~arg1_ty ~arg2
+    ~arg2_ty dbg ~result_var

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -985,7 +985,7 @@ let simplify_bigarray_get_alignment _align ~original_prim dacc ~original_term
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
+let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var =
   let min_name_mode = Bound_var.name_mode result_var in
   let original_term = Named.create_prim original_prim dbg in
@@ -1031,3 +1031,72 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
       simplify_bigarray_get_alignment align ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var
+
+let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
+  match prim with
+  | Block_load _
+  | Array_load _
+  | Int_arith _
+  | Int_shift _
+  | Int_comp (_, Yielding_int_like_compare_functions _)
+  | Float_arith _
+  | Float_comp _
+  | Phys_equal _
+  | String_or_bigstring_load _
+  | Bigarray_load _
+  | Bigarray_get_alignment _ ->
+    None
+  | Int_comp (kind, Yielding_bool op) -> (
+      match kind with
+      | Naked_immediate
+      | Naked_int32
+      | Naked_int64
+      | Naked_nativeint -> None
+      | Tagged_immediate ->
+        let try_one_direction left right op =
+          Simple.pattern_match right ~name:(fun _ ~coercion:_ -> None)
+            ~const:(fun const ->
+                match[@warning "-fragile-match"] Const.descr const with
+                | Tagged_immediate i when Targetint_31_63.(equal i zero) ->
+                  Simple.pattern_match' left ~const:(fun _ -> None)
+                    ~symbol:(fun _ ~coercion:_ -> None)
+                    ~var:(fun var ~coercion:_ ->
+                        match DE.find_comparison_result (DA.denv dacc) var with
+                        | None -> None
+                        | Some comp ->
+                          Some (Comparison_result.convert_result_compared_to_zero comp op))
+                | _ -> None)
+        in
+        match try_one_direction arg1 arg2 op with
+        | Some p -> Some p
+        | None ->
+          let op : _ P.comparison = match op with
+            | Eq -> Eq
+            | Neq -> Neq
+            | Lt s -> Gt s
+            | Gt s -> Lt s
+            | Le s -> Ge s
+            | Ge s -> Le s
+          in
+          try_one_direction arg2 arg1 op)
+
+let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
+    ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var =
+  let original_prim, prim, arg1, arg1_ty, arg2, arg2_ty =
+    match[@warning "-fragile-match"] recover_comparison_primitive dacc prim ~arg1 ~arg2 with
+    | None -> original_prim, prim, arg1, arg1_ty, arg2, arg2_ty
+    | Some (Binary (new_prim, new_arg1, new_arg2) as new_original_prim) ->
+      let min_name_mode = Bound_var.name_mode result_var in
+      let arg1_ty_opt = S.simplify_simple_if_in_scope dacc arg1 ~min_name_mode in
+      let arg2_ty_opt = S.simplify_simple_if_in_scope dacc arg2 ~min_name_mode in
+      (match arg1_ty_opt, arg2_ty_opt with
+      | Some new_arg1_ty, Some new_arg2_ty ->
+        new_original_prim, new_prim, new_arg1, new_arg1_ty, new_arg2, new_arg2_ty
+      | None, _ | _, None ->
+        original_prim, prim, arg1, arg1_ty, arg2, arg2_ty)
+    | Some other_prim ->
+      Misc.fatal_errorf "Recovered primitive %a is not a comparison"
+        Flambda_primitive.print other_prim
+  in
+  simplify_binary_primitive0 dacc original_prim prim
+    ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1068,6 +1068,9 @@ let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
           match op with
           | Eq -> Eq
           | Neq -> Neq
+          (* Note that this is not handling a negation of an inequality, it is
+             simply a pattern match for when the inequality appears the other
+             way around. So e.g. [Lt] maps to [Gt], not [Ge]. *)
           | Lt s -> Gt s
           | Gt s -> Lt s
           | Le s -> Ge s

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1085,10 +1085,10 @@ let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     | Some (Binary (new_prim, new_arg1, new_arg2) as new_original_prim) -> (
       let min_name_mode = Bound_var.name_mode result_var in
       let arg1_ty_opt =
-        S.simplify_simple_if_in_scope dacc arg1 ~min_name_mode
+        S.simplify_simple_if_in_scope dacc new_arg1 ~min_name_mode
       in
       let arg2_ty_opt =
-        S.simplify_simple_if_in_scope dacc arg2 ~min_name_mode
+        S.simplify_simple_if_in_scope dacc new_arg2 ~min_name_mode
       in
       match arg1_ty_opt, arg2_ty_opt with
       | Some new_arg1_ty, Some new_arg2_ty ->

--- a/middle_end/flambda2/simplify/simplify_simple.mli
+++ b/middle_end/flambda2/simplify/simplify_simple.mli
@@ -21,7 +21,10 @@ val simplify_simple :
   Downwards_acc.t -> Simple.t -> min_name_mode:Name_mode.t -> Flambda2_types.t
 
 val simplify_simple_if_in_scope :
-  Downwards_acc.t -> Simple.t -> min_name_mode:Name_mode.t -> Flambda2_types.t option
+  Downwards_acc.t ->
+  Simple.t ->
+  min_name_mode:Name_mode.t ->
+  Flambda2_types.t option
 
 type simplify_simples_result = private
   { simples : Simple.t list;

--- a/ocaml/testsuite/tests/translprim/comparison_optim.ml
+++ b/ocaml/testsuite/tests/translprim/comparison_optim.ml
@@ -1,0 +1,103 @@
+(* TEST *)
+
+let check_list name list =
+  Printf.printf "testing %S...\n" name;
+    List.iteri
+    (fun i (x, y) ->
+       Printf.printf "  #%d: %s\n"
+         i
+         (if x = y then "OK" else "KO"))
+    list;
+  Printf.printf "\n%!"
+
+let check_int () = check_list "int" [
+  compare (Sys.opaque_identity 1)       2       <= 0, true;
+  compare (Sys.opaque_identity 3)       3       <= 0, true;
+  compare (Sys.opaque_identity 1)       min_int <= 0, false;
+  compare (Sys.opaque_identity 1)       2       <  0, true;
+  compare (Sys.opaque_identity 3)       3       <  0, false;
+  compare (Sys.opaque_identity 1)       min_int <  0, false;
+  compare (Sys.opaque_identity max_int) (-1)    >= 0, true;
+  compare (Sys.opaque_identity 3)       3       >= 0, true;
+  compare (Sys.opaque_identity 2)       min_int >= 0, true;
+  compare (Sys.opaque_identity max_int) (-1)    >  0, true;
+  compare (Sys.opaque_identity 3)       3       >  0, false;
+  compare (Sys.opaque_identity 2)       min_int >  0, true;
+  compare (Sys.opaque_identity min_int) min_int =  0, true;
+  compare (Sys.opaque_identity max_int) max_int =  0, true;
+  compare (Sys.opaque_identity 1)       2       =  0, false;
+  compare (Sys.opaque_identity min_int) min_int <> 0, false;
+  compare (Sys.opaque_identity max_int) max_int <> 0, false;
+  compare (Sys.opaque_identity 1)       2       <> 0, true;
+]
+
+let () = check_int ()
+
+let check_int32 () = check_list "int32" [
+  compare (Sys.opaque_identity 1l)            2l            <= 0, true;
+  compare (Sys.opaque_identity 3l)            3l            <= 0, true;
+  compare (Sys.opaque_identity 1l)            Int32.min_int <= 0, false;
+  compare (Sys.opaque_identity 1l)            2l            <  0, true;
+  compare (Sys.opaque_identity 3l)            3l            <  0, false;
+  compare (Sys.opaque_identity 1l)            Int32.min_int <  0, false;
+  compare (Sys.opaque_identity Int32.max_int) (-1l)         >= 0, true;
+  compare (Sys.opaque_identity 3l)            3l            >= 0, true;
+  compare (Sys.opaque_identity 2l)            Int32.min_int >= 0, true;
+  compare (Sys.opaque_identity Int32.max_int) (-1l)         >  0, true;
+  compare (Sys.opaque_identity 3l)            3l            >  0, false;
+  compare (Sys.opaque_identity 2l)            Int32.min_int >  0, true;
+  compare (Sys.opaque_identity Int32.min_int) Int32.min_int =  0, true;
+  compare (Sys.opaque_identity Int32.max_int) Int32.max_int =  0, true;
+  compare (Sys.opaque_identity 1l)            2l            =  0, false;
+  compare (Sys.opaque_identity Int32.min_int) Int32.min_int <> 0, false;
+  compare (Sys.opaque_identity Int32.max_int) Int32.max_int <> 0, false;
+  compare (Sys.opaque_identity 1l)            2l            <> 0, true;
+]
+
+let () = check_int32 ()
+
+let check_int64 () = check_list "int64" [
+  compare (Sys.opaque_identity 1L)            2L            <= 0, true;
+  compare (Sys.opaque_identity 3L)            3L            <= 0, true;
+  compare (Sys.opaque_identity 1L)            Int64.min_int <= 0, false;
+  compare (Sys.opaque_identity 1L)            2L            <  0, true;
+  compare (Sys.opaque_identity 3L)            3L            <  0, false;
+  compare (Sys.opaque_identity 1L)            Int64.min_int <  0, false;
+  compare (Sys.opaque_identity Int64.max_int) (-1L)         >= 0, true;
+  compare (Sys.opaque_identity 3L)            3L            >= 0, true;
+  compare (Sys.opaque_identity 2L)            Int64.min_int >= 0, true;
+  compare (Sys.opaque_identity Int64.max_int) (-1L)         >  0, true;
+  compare (Sys.opaque_identity 3L)            3L            >  0, false;
+  compare (Sys.opaque_identity 2L)            Int64.min_int >  0, true;
+  compare (Sys.opaque_identity Int64.min_int) Int64.min_int =  0, true;
+  compare (Sys.opaque_identity Int64.max_int) Int64.max_int =  0, true;
+  compare (Sys.opaque_identity 1L)            2L            =  0, false;
+  compare (Sys.opaque_identity Int64.min_int) Int64.min_int <> 0, false;
+  compare (Sys.opaque_identity Int64.max_int) Int64.max_int <> 0, false;
+  compare (Sys.opaque_identity 1L)            2L            <> 0, true;
+]
+
+let () = check_int64 ()
+
+let check_nativeint () = check_list "nativeint" [
+  compare (Sys.opaque_identity 1n)                2n                <= 0, true;
+  compare (Sys.opaque_identity 3n)                3n                <= 0, true;
+  compare (Sys.opaque_identity 1n)                Nativeint.min_int <= 0, false;
+  compare (Sys.opaque_identity 1n)                2n                <  0, true;
+  compare (Sys.opaque_identity 3n)                3n                <  0, false;
+  compare (Sys.opaque_identity 1n)                Nativeint.min_int <  0, false;
+  compare (Sys.opaque_identity Nativeint.max_int) (-1n)             >= 0, true;
+  compare (Sys.opaque_identity 3n)                3n                >= 0, true;
+  compare (Sys.opaque_identity 2n)                Nativeint.min_int >= 0, true;
+  compare (Sys.opaque_identity Nativeint.max_int) (-1n)             >  0, true;
+  compare (Sys.opaque_identity 3n)                3n                >  0, false;
+  compare (Sys.opaque_identity 2n)                Nativeint.min_int >  0, true;
+  compare (Sys.opaque_identity Nativeint.min_int) Nativeint.min_int =  0, true;
+  compare (Sys.opaque_identity Nativeint.max_int) Nativeint.max_int =  0, true;
+  compare (Sys.opaque_identity 1n)                2n                =  0, false;
+  compare (Sys.opaque_identity Nativeint.min_int) Nativeint.min_int <> 0, false;
+  compare (Sys.opaque_identity Nativeint.max_int) Nativeint.max_int <> 0, false;
+  compare (Sys.opaque_identity 1n)                2n                <> 0, true;
+]
+
+let () = check_nativeint ()

--- a/ocaml/testsuite/tests/translprim/comparison_optim.reference
+++ b/ocaml/testsuite/tests/translprim/comparison_optim.reference
@@ -1,0 +1,79 @@
+testing "int"...
+  #0: OK
+  #1: OK
+  #2: OK
+  #3: OK
+  #4: OK
+  #5: OK
+  #6: OK
+  #7: OK
+  #8: OK
+  #9: OK
+  #10: OK
+  #11: OK
+  #12: OK
+  #13: OK
+  #14: OK
+  #15: OK
+  #16: OK
+  #17: OK
+
+testing "int32"...
+  #0: OK
+  #1: OK
+  #2: OK
+  #3: OK
+  #4: OK
+  #5: OK
+  #6: OK
+  #7: OK
+  #8: OK
+  #9: OK
+  #10: OK
+  #11: OK
+  #12: OK
+  #13: OK
+  #14: OK
+  #15: OK
+  #16: OK
+  #17: OK
+
+testing "int64"...
+  #0: OK
+  #1: OK
+  #2: OK
+  #3: OK
+  #4: OK
+  #5: OK
+  #6: OK
+  #7: OK
+  #8: OK
+  #9: OK
+  #10: OK
+  #11: OK
+  #12: OK
+  #13: OK
+  #14: OK
+  #15: OK
+  #16: OK
+  #17: OK
+
+testing "nativeint"...
+  #0: OK
+  #1: OK
+  #2: OK
+  #3: OK
+  #4: OK
+  #5: OK
+  #6: OK
+  #7: OK
+  #8: OK
+  #9: OK
+  #10: OK
+  #11: OK
+  #12: OK
+  #13: OK
+  #14: OK
+  #15: OK
+  #16: OK
+  #17: OK

--- a/ocaml/testsuite/tests/translprim/comparison_optim.reference
+++ b/ocaml/testsuite/tests/translprim/comparison_optim.reference
@@ -77,3 +77,4 @@ testing "nativeint"...
   #15: OK
   #16: OK
   #17: OK
+


### PR DESCRIPTION
This PR provides support for simplifying the common pattern `(compare x y) op 0` (where `op` is a comparison operator) into `x op y`. It is only implemented for the integer types as it is incorrect on floats (for non-regular values) and not obviously correct on non-numerical types.

I have only tested it on a simple example, other examples that should be simplified are welcome.
