### PR TITLE
Ask user to add `exclave_` instead of `local_`

### DIFF
--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -9,7 +9,7 @@ Line 3, characters 2-3:
 3 |   r
       ^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 external idint : local_ int -> int = "%identity"
@@ -40,7 +40,7 @@ Line 3, characters 2-3:
 3 |   r
       ^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 let leak n =
@@ -51,7 +51,7 @@ Line 3, characters 2-3:
 3 |   r
       ^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 let leak n =
@@ -62,7 +62,7 @@ Line 3, characters 2-3:
 3 |   f
       ^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 let leak n =
@@ -73,7 +73,7 @@ Line 3, characters 2-3:
 3 |   f
       ^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 (* If both type and mode are wrong, complain about type *)
@@ -268,7 +268,7 @@ Line 1, characters 15-21:
 1 | let apply2 x = f4 x x
                    ^^^^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
   Hint: This is a partial application
         Adding 2 more arguments will make the value non-local
 |}]
@@ -278,7 +278,7 @@ Line 1, characters 15-23:
 1 | let apply3 x = f4 x x x
                    ^^^^^^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -316,7 +316,7 @@ Line 1, characters 15-18:
 1 | let apply1 x = g x
                    ^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -339,7 +339,7 @@ Line 1, characters 23-32:
 1 | let apply3_wrapped x = (g x x) x
                            ^^^^^^^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -476,7 +476,7 @@ Line 1, characters 52-65:
 1 | let app4' (f : b:local_ int ref -> a:int -> unit) = f ~b:(ref 42)
                                                         ^^^^^^^^^^^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -531,7 +531,7 @@ Line 1, characters 50-59:
 1 | let rapp3 (f : a:int -> unit -> local_ int ref) = f ~a:1 ()
                                                       ^^^^^^^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 let bug1 () =
@@ -546,7 +546,7 @@ Line 7, characters 2-5:
 7 |   res
       ^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 let bug2 () =
   let foo : a:local_ string -> (b:local_ string -> (c:int -> unit)) =
@@ -655,7 +655,7 @@ Line 3, characters 25-31:
 3 |   let local_ perm ~foo = f ~foo in
                              ^^^^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
   Hint: This is a partial application
         Adding 1 more argument may make the value non-local
 |}]
@@ -677,7 +677,7 @@ Line 3, characters 2-5:
 3 |   res
       ^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 (* In principle. it would be sound to allow this one:
@@ -690,7 +690,7 @@ Line 3, characters 2-5:
 3 |   res
       ^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 let optret1 (f : ?x:int -> local_ (y:unit -> unit -> int)) = f ()
@@ -699,7 +699,7 @@ Line 1, characters 61-65:
 1 | let optret1 (f : ?x:int -> local_ (y:unit -> unit -> int)) = f ()
                                                                  ^^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -1334,7 +1334,7 @@ Line 3, characters 2-3:
 3 |   r
       ^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 let foo x =
@@ -1488,7 +1488,7 @@ Line 3, characters 2-7:
 3 |   x.imm
       ^^^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 let foo (local_ x) = x.mut
 [%%expect{|
@@ -1523,7 +1523,7 @@ Line 3, characters 2-5:
 3 |   imm
       ^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 let foo (local_ { mut }) = mut
 [%%expect{|
@@ -2494,7 +2494,7 @@ Line 4, characters 20-22:
 4 |   | GFoo (_, s') -> s'
                         ^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 (* and regional gives regional *)
@@ -2558,7 +2558,7 @@ Line 3, characters 14-16:
 3 |   | [:s':] -> s'
                   ^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
 |}]
 
 let f (local_ a : string iarray) =
@@ -2625,7 +2625,7 @@ Line 11, characters 13-59:
 11 |   let f () = fold_until [] ~init:0 ~f:(fun _ _ -> Right ())
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This local value escapes its region
-  Hint: Cannot return local value without an explicit "local_" annotation
+  Hint: Cannot return local value without an "exclave_" annotation
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -8370,8 +8370,8 @@ let escaping_hint failure_reason submode_reason
   begin match failure_reason, context with
   | `Locality, Some Return ->
       [ Location.msg
-          "@[Hint: Cannot return local value without an explicit@ \
-           \"local_\" annotation@]" ]
+          "@[Hint: Cannot return local value without an@ \
+           \"exclave_\" annotation@]" ]
   | `Locality, Some Tailcall_argument ->
       [ Location.msg
           "@[Hint: This argument cannot be local, because this is a tail call@]" ]


### PR DESCRIPTION
Since we plan to gradually transition from tail-poition `local_` to `exclave_`, we should also change the error message to reflect that transition. 

Request review from @ncik-roberts 