### PR TITLE
Improve layout history error message: additional info on value layout defaulting

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -405,7 +405,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         it's used as a function result.
+         it's used as a function result (defaulted to layout value).
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -418,7 +418,7 @@ Error: This expression has type 'a t_float64_id = ('a : float64)
        The layout of 'a t_float64_id is float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
        But the layout of 'a t_float64_id must overlap with value, because
-         it's used as a function result.
+         it's used as a function result (defaulted to layout value).
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -431,7 +431,7 @@ Error: This expression has type float# but an expression was expected of type
        The layout of float# is float64, because
          it is the primitive float64 type float#.
        But the layout of float# must be a sublayout of value, because
-         it's used as a function result.
+         it's used as a function result (defaulted to layout value).
 |}];;
 
 (*************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -405,7 +405,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         it's used as a function result (defaulted to layout value).
+         it's used as a function result, defaulted to layout value.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -418,7 +418,7 @@ Error: This expression has type 'a t_float64_id = ('a : float64)
        The layout of 'a t_float64_id is float64, because
          of the annotation on 'a in the declaration of the type t_float64_id.
        But the layout of 'a t_float64_id must overlap with value, because
-         it's used as a function result (defaulted to layout value).
+         it's used as a function result, defaulted to layout value.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -431,7 +431,7 @@ Error: This expression has type float# but an expression was expected of type
        The layout of float# is float64, because
          it is the primitive float64 type float#.
        But the layout of float# must be a sublayout of value, because
-         it's used as a function result (defaulted to layout value).
+         it's used as a function result, defaulted to layout value.
 |}];;
 
 (*************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -328,3 +328,10 @@ Error: Layout void is used here, but the appropriate layouts extension is not en
 
 (* CR layouts: This test moved to [basics_beta.ml] as it needs an immediate
    type parameter.  Bring back here when we have one enabled by default. *)
+
+
+(****************************************************)
+(* Test 35: unannotated type parameter defaults to layout value *)
+
+(* CR layouts: This test moved to [basics_alpha.ml] as it needs a non-value
+   sort.  Bring back here when we have one enabled by default. *)

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -902,10 +902,13 @@ Line 3, characters 11-12:
                ^
 Error: Variables bound in a class must have layout value.
        The layout of v is void, because
-         it's bound by a `let`.
+         it's bound by a `let`, defaulted to layout void.
        But the layout of v must be a sublayout of value, because
          it's let-bound in a class expression.
 |}];;
+(* CR layouts v2.9: The part about defaulting here is incorrect.
+   It's due to the logic in Pcl_let using sorts directly instead of
+   layouts. *)
 
 (* Hits the Cfk_concrete case of Pcf_val *)
 module M12_2 = struct
@@ -1709,7 +1712,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it's used as a function argument (defaulted to layout value).
+         it's used as a function argument, defaulted to layout value.
 |}]
 
 (**************************************)
@@ -1738,7 +1741,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it's used as a function argument (defaulted to layout value).
+         it's used as a function argument, defaulted to layout value.
 |}]
 
 (**************************************************)
@@ -1817,5 +1820,5 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it appears as an unannotated type parameter (defaulted to layout value).
+         it appears as an unannotated type parameter, defaulted to layout value.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -71,7 +71,7 @@ Error: The type constraints are not consistent.
        The layout of t is any, because
          of the annotation on the declaration of the type t.
        But the layout of t must be a sublayout of '_representable_layout_3, because
-         it appears as an unannotated type parameter.
+         it instantiates an unannotated type parameter.
 |}]
 
 module type S1 = sig
@@ -88,7 +88,7 @@ Error: The type constraints are not consistent.
        The layout of t is any, because
          of the annotation on the declaration of the type t.
        But the layout of t must be a sublayout of '_representable_layout_4, because
-         it appears as an unannotated type parameter.
+         it instantiates an unannotated type parameter.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -1820,5 +1820,5 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it appears as an unannotated type parameter, defaulted to layout value.
+         it instantiates an unannotated type parameter, defaulted to layout value.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -1709,7 +1709,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it's used as a function argument.
+         it's used as a function argument (defaulted to layout value).
 |}]
 
 (**************************************)
@@ -1738,7 +1738,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it's used as a function argument.
+         it's used as a function argument (defaulted to layout value).
 |}]
 
 (**************************************************)
@@ -1801,3 +1801,21 @@ Error: This type signature for foo33 is not a value type.
 (* Test 34: Layout clash in polymorphic record type *)
 
 (* tested elsewhere *)
+
+(****************************************************)
+(* Test 35: unannotated type parameter defaults to layout value *)
+type 'a t35 = 'a
+let f35 (x: t_void): 'a t35 = x
+
+[%%expect{|
+type 'a t35 = 'a
+Line 2, characters 30-31:
+2 | let f35 (x: t_void): 'a t35 = x
+                                  ^
+Error: This expression has type t_void but an expression was expected of type
+         'a t35 = ('a : value)
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must be a sublayout of value, because
+         it appears as an unannotated type parameter (defaulted to layout value).
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -579,3 +579,9 @@ Error: The layout of type 'a is value, because
        But the layout of type 'a must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t2_imm.
 |}]
+
+(****************************************************)
+(* Test 35: unannotated type parameter defaults to layout value *)
+
+(* CR layouts v2.5: This test moved to [basics_alpha.ml] as it needs a non-value
+   sort.  Bring back here when we have one. *)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -90,7 +90,7 @@ Error:
        The layout of 'b t1_constraint' is any, because
          of the annotation on the declaration of the type t_any.
        But the layout of 'b t1_constraint' must be a sublayout of '_representable_layout_4, because
-         it appears as an unannotated type parameter.
+         it instantiates an unannotated type parameter.
 |}]
 (* CR layouts errors: this error is blamed on the wrong piece *)
 

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -854,8 +854,9 @@ module Layout = struct
       | Creation reason ->
         fprintf ppf ", because@ %a" format_creation_reason reason;
         begin match reason, lay with
-        | Concrete_creation _, Const Value ->
-          fprintf ppf " (defaulted to layout value)"
+        | Concrete_creation _, Const _ ->
+          fprintf ppf ", defaulted to layout %a"
+            format_desc lay
         | _ -> ()
         end
       | _ -> assert false

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -659,7 +659,7 @@ module Layout = struct
         fprintf ppf "it's used in the declaration of the record field \"%a\""
           Ident.print lbl
       | Unannotated_type_parameter ->
-        fprintf ppf "it appears as an unannotated type parameter"
+        fprintf ppf "it instantiates an unannotated type parameter"
       | Record_projection ->
         fprintf ppf "it's used as the record in a projection"
       | Record_assignment ->

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -852,7 +852,12 @@ module Layout = struct
         format_desc lay;
       begin match t.history with
       | Creation reason ->
-        fprintf ppf ", because@ %a" format_creation_reason reason
+        fprintf ppf ", because@ %a" format_creation_reason reason;
+        begin match reason, lay with
+        | Concrete_creation _, Const Value ->
+          fprintf ppf " (defaulted to layout value)"
+        | _ -> ()
+        end
       | _ -> assert false
       end;
       fprintf ppf ".@]"


### PR DESCRIPTION
When a concrete layout defaults to value layout, the error message can be a bit confusing. This PR adds an additional message on these cases to explicitly highlight that the value layout is the result of defaulting.