### PR TITLE
Better error when using a float64 library without extension

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -22,3 +22,18 @@ Line 1, characters 15-26:
 Error: Layout float64 is used here, but the appropriate layouts extension is not enabled
 |}]
 
+(* CR layouts: The below test checks that we give an acceptable error for cases
+   where a float64 was used from a library in a file where the user forgot to
+   enable the relevant extension.  It can be deleted when float64 is on by
+   default (though at that time we should add tests for explicitly disabling the
+   layouts extension). *)
+let f x = Stdlib__Float_u.sin x
+[%%expect{|
+Line 1, characters 6-31:
+1 | let f x = Stdlib__Float_u.sin x
+          ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Non-value layout float64 detected as sort for type float#,
+       but this requires extension layouts_beta, which is not enabled.
+       If you intended to use this layout, please add this flag to your build file.
+       Otherwise, please report this error to the Jane Street compilers team.
+|}]


### PR DESCRIPTION
Users observed during testing that it's easy to hit the scary "please contact us" error by using a float# from a library but forgetting to update the current file's build script.  This improves the error to suggest adding the extension flag (but still says to contact us if they weren't intentionally using an unboxed float).

I'm open to bikeshedding on the wording.