### PR TITLE
Revert "Only execute caml-apply-split-max-arity on linux"

### DIFF
--- a/tests/backend/caml_apply_split_max_arity/dune
+++ b/tests/backend/caml_apply_split_max_arity/dune
@@ -4,9 +4,7 @@
  (ocamlopt_flags (:standard -linscan -Oclassic)))
 
 (rule
- (enabled_if 
-  (and (= %{context_name} "main")
-       (= %{system} "linux")))
+ (enabled_if (= %{context_name} "main"))
  (target t.output)
  (deps t.exe)
  (action (with-outputs-to t.output (progn
@@ -15,9 +13,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if 
-  (and (= %{context_name} "main")
-       (= %{system} "linux")))
+ (enabled_if (= %{context_name} "main"))
  (action (diff t.expected t.output)))
 
 ;; t.ml was created using cinaps


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#1837