### PR TITLE
Add hint for `#float`

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -250,3 +250,14 @@ Line 1, characters 9-26:
 Error: The type constructor float# expects 0 argument(s),
        but is here applied to 2 argument(s)
 |}];;
+
+(*******************)
+(* Hint for #float *)
+type t = #float;;
+[%%expect {|
+Line 1, characters 10-15:
+1 | type t = #float;;
+              ^^^^^
+Error: Unbound class type float
+Hint: Did you mean float#?
+|}]

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -3889,7 +3889,12 @@ let report_lookup_error _loc env ppf = function
     end
   | Unbound_cltype lid ->
       fprintf ppf "Unbound class type %a" !print_longident lid;
-      spellcheck ppf extract_cltypes env lid;
+      begin match lid with
+      | Lident "float" ->
+        Misc.did_you_mean ppf (fun () -> ["float#"])
+      | Lident _ | Ldot _ | Lapply _ ->
+        spellcheck ppf extract_cltypes env lid
+      end;
   | Unbound_instance_variable s ->
       fprintf ppf "Unbound instance variable %s" s;
       spellcheck_name ppf extract_instance_variables env s;


### PR DESCRIPTION
This adds a hint if you forget where the hash goes and type `#float` instead of `float#`:
```ocaml
# type t = #float;;
Error: Unbound class type float
Hint: Did you mean float#?
```
Our first user requested this.  I'm not totally sure we want it, or that this is the best way to do it, but it seems reasonable.

Review: @goldfirere 