### PR TITLE
Centralise warning configuration

### DIFF
--- a/backend/asm_targets/dune
+++ b/backend/asm_targets/dune
@@ -3,6 +3,7 @@
 (library
   (name asm_targets)
   (wrapped true)
-  (flags (:standard -principal))
+  ; FIXME Fix warning 27
+  (flags (:standard -w -27-70))
   (libraries ocamlcommon dwarf_flags)
 )

--- a/backend/debug/dwarf/dwarf_flags/dune
+++ b/backend/debug/dwarf/dwarf_flags/dune
@@ -3,7 +3,6 @@
 (library
   (name dwarf_flags)
   (wrapped true)
-  (flags (:standard -principal))
   (ocamlopt_flags (:standard -O3))
   (libraries ocamlcommon)
 )

--- a/backend/debug/dwarf/dwarf_high/dune
+++ b/backend/debug/dwarf/dwarf_high/dune
@@ -3,7 +3,6 @@
 (library
   (name dwarf_high)
   (wrapped true)
-  (flags (:standard -principal))
   (ocamlopt_flags (:standard -O3))
   (libraries dwarf_low asm_targets)
 )

--- a/backend/debug/dwarf/dwarf_low/dune
+++ b/backend/debug/dwarf/dwarf_low/dune
@@ -3,7 +3,7 @@
 (library
   (name dwarf_low)
   (wrapped true)
-  (flags (:standard -principal))
+  (flags (:standard -w -70))
   (ocamlopt_flags (:standard -O3))
   (libraries asm_targets)
 )

--- a/chamelon/dune.jst
+++ b/chamelon/dune.jst
@@ -10,6 +10,8 @@
 
 (env
   (dev
-    (flags (:standard -warn-error -A))))
+    (flags (:standard -warn-error -A -w -70)))
+  (_
+    (flags (:standard -w -70))))
 
 (include_subdirs unqualified)

--- a/chamelon/dune.upstream
+++ b/chamelon/dune.upstream
@@ -10,6 +10,8 @@
 
 (env
   (dev
-    (flags (:standard -warn-error -A))))
+    (flags (:standard -warn-error -A -w -70)))
+  (_
+    (flags (:standard -w -70))))
 
 (include_subdirs unqualified)

--- a/driver/dune
+++ b/driver/dune
@@ -1,8 +1,6 @@
 (library
  (name flambda_backend_driver)
  (modes byte native)
- (flags
-  (:standard -principal))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
  (libraries ocamloptcomp flambda2 gc_timings)

--- a/dune
+++ b/dune
@@ -8,6 +8,12 @@
 ;*                                                                        *
 ;**************************************************************************
 
+
+(env
+ (_
+  (flags
+   (:standard -principal -warn-error +A -w +a-4-9-40-41-42-44-45-48-66))))
+
 ; Since upstream has the middle end code inside ocamloptcomp, we do the
 ; same for the moment.
 
@@ -62,9 +68,9 @@
  (wrapped false) ; for compatibility with existing code
  (modes byte native)
  ; We should change the code so this "-open" can be removed.
- ; Likewise fix occurrences of warning 9.
+ ; Likewise fix occurrences of warnings 9, 27, 32, 33, 34, 37, 39, and 60.
  (flags
-  (:standard -principal -w -9-69-70))
+  (:standard -w -27-32-33-34-37-39-60-69-70))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
  (instrumentation
@@ -322,11 +328,6 @@
  ; same flags as for ocamlcommon library
  (flags
   (-strict-sequence
-   -principal
-   -w
-   +a-4-9-40-41-42-44-45-48-66
-   -warn-error
-   A
    -bin-annot
    -safe-string
    -strict-formats
@@ -346,8 +347,6 @@
  (modes byte)
  (instrumentation
   (backend bisect_ppx))
- (flags
-  (:standard -principal))
  (libraries
   flambda_backend_driver
   memtrace
@@ -369,8 +368,6 @@
  (modes native)
  (instrumentation
   (backend bisect_ppx))
- (flags
-  (:standard -principal))
  (ocamlopt_flags
   (:standard -runtime-variant nnp))
  (libraries
@@ -396,8 +393,6 @@
  (modes native)
  (instrumentation
   (backend bisect_ppx))
- (flags
-  (:standard -principal))
  (libraries
   flambda_backend_driver
   flambda2

--- a/external/dune
+++ b/external/dune
@@ -1,0 +1,2 @@
+(env
+ (_ (flags (:standard -no-principal -w -69-70))))

--- a/middle_end/flambda2/algorithms/dune
+++ b/middle_end/flambda2/algorithms/dune
@@ -4,8 +4,6 @@
  (name flambda2_algorithms)
  (wrapped true)
  (instrumentation (backend bisect_ppx))
- (flags
-  (:standard -principal))
  (ocamlopt_flags
   (:standard -O3))
  (libraries ocamlcommon))

--- a/middle_end/flambda2/bound_identifiers/dune
+++ b/middle_end/flambda2/bound_identifiers/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/classic_mode_types/dune
+++ b/middle_end/flambda2/classic_mode_types/dune
@@ -5,7 +5,6 @@
  (wrapped true)
  (flags
   (:standard
-   -principal
    -open
    Flambda2_identifiers
    -open

--- a/middle_end/flambda2/cmx/dune
+++ b/middle_end/flambda2/cmx/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/compare/dune
+++ b/middle_end/flambda2/compare/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/dune
+++ b/middle_end/flambda2/dune
@@ -3,7 +3,7 @@
 (env
  (_
   (flags
-   (:standard -w +a-30-40-41-42-69-70))))
+   (:standard -w +4+9-30+44+45+48-69-70))))
 
 (library
  (name flambda2)
@@ -12,7 +12,6 @@
   (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_lattices
    -open

--- a/middle_end/flambda2/from_lambda/dune
+++ b/middle_end/flambda2/from_lambda/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/identifiers/dune
+++ b/middle_end/flambda2/identifiers/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/kinds/dune
+++ b/middle_end/flambda2/kinds/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/lattices/dune
+++ b/middle_end/flambda2/lattices/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/nominal/dune
+++ b/middle_end/flambda2/nominal/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/numbers/dune
+++ b/middle_end/flambda2/numbers/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/parser/dune
+++ b/middle_end/flambda2/parser/dune
@@ -103,7 +103,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_bound_identifiers
    -open

--- a/middle_end/flambda2/simplify/dune
+++ b/middle_end/flambda2/simplify/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/simplify_shared/dune
+++ b/middle_end/flambda2/simplify_shared/dune
@@ -5,7 +5,6 @@
  (wrapped true)
  (flags
   (:standard
-   -principal
    -open
    Flambda2_identifiers
    -open

--- a/middle_end/flambda2/term_basics/dune
+++ b/middle_end/flambda2/term_basics/dune
@@ -9,7 +9,6 @@
   (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/terms/dune
+++ b/middle_end/flambda2/terms/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/tests/algorithms/dune
+++ b/middle_end/flambda2/tests/algorithms/dune
@@ -2,5 +2,4 @@
  (names patricia_tree_tests)
  (modes native)
  (instrumentation (backend bisect_ppx))
- (flags (:standard -principal))
  (libraries minicheck flambda2_algorithms flambda2_nominal))

--- a/middle_end/flambda2/tests/dune
+++ b/middle_end/flambda2/tests/dune
@@ -2,7 +2,6 @@
  (names meet_test)
  (modes native)
  (instrumentation (backend bisect_ppx))
- (flags (:standard -principal))
  (libraries
   ocamloptcomp ocamlcommon
   flambda2_bound_identifiers flambda2_cmx flambda2_identifiers flambda2_kinds

--- a/middle_end/flambda2/tests/tools/dune
+++ b/middle_end/flambda2/tests/tools/dune
@@ -1,7 +1,6 @@
 (executables
   (names flexpect fldiff parseflambda roundtrip)
   (modes native)
-  (flags (:standard -principal))
   (libraries
    ocamlcommon ocamloptcomp
    flambda2 flambda2_compare flambda2_parser flambda2_terms flambda2_cmx))

--- a/middle_end/flambda2/to_cmm/dune
+++ b/middle_end/flambda2/to_cmm/dune
@@ -6,7 +6,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_bound_identifiers
    -open

--- a/middle_end/flambda2/types/dune
+++ b/middle_end/flambda2/types/dune
@@ -8,7 +8,6 @@
  (instrumentation (backend bisect_ppx))
  (flags
   (:standard
-   -principal
    -open
    Flambda2_algorithms
    -open

--- a/middle_end/flambda2/ui/dune
+++ b/middle_end/flambda2/ui/dune
@@ -4,8 +4,6 @@
  (name flambda2_ui)
  (wrapped true)
  (instrumentation (backend bisect_ppx))
- (flags
-  (:standard -principal))
  (ocamlopt_flags
   (:standard -O3))
  (libraries ocamlcommon flambda_backend_common))

--- a/native_toplevel/dune
+++ b/native_toplevel/dune
@@ -18,7 +18,7 @@
  (name ocamlopttoplevel)
  (modes native)
  (wrapped false)
- (flags (:standard -principal -w -9))
+ (flags (:standard -w -70))
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (libraries ocamlcommon ocamlbytecomp ocamloptcomp
    flambda_backend_common
@@ -34,7 +34,6 @@
 (executable
  (name opttopstart)
  (modes native)
- (flags (:standard -principal))
  (libraries ocamlopttoplevel)
  (modules opttopstart))
 

--- a/ocaml/debugger/dune
+++ b/ocaml/debugger/dune
@@ -17,7 +17,6 @@
 
 (library
  (name ocamldebug)
- (flags (:standard -principal -w -9))
  (modules (:standard \ ocamldebug_entry pattern_matching))
  (modules_without_implementation parser_aux)
  (libraries ocamlcommon ocamltoplevel unix dynlink_internal))

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -15,15 +15,15 @@
 
 ; set warning as error in release profile
 (env
- (dev     (flags (:standard -w +a-4-9-40-41-42-44-45-48-66-67-70)))
- (release (flags (:standard -w +a-4-9-40-41-42-44-45-48-66-67-70)))
+ (dev     (flags (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70)))
+ (release (flags (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70)))
 
  (main
   (flags
-   (:standard -warn-error +A)))
+   (:standard -principal -warn-error +A -w +a-4-9-40-41-42-44-45-48-66-67-70)))
  (boot
   (flags
-   (:standard -warn-error +A))))
+   (:standard -principal -warn-error +A -w +a-4-9-40-41-42-44-45-48-66-67-70))))
 
 (copy_files# utils/*.ml{,i})
 (copy_files# parsing/*.ml{,i})
@@ -43,8 +43,9 @@
  (name ocamlcommon)
  (wrapped false)
  (flags (
-   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
-   -warn-error A -bin-annot -safe-string -strict-formats
+   :standard
+   -strict-sequence
+   -bin-annot -safe-string -strict-formats
    -w -67
    ; remove -w -67 by adding the camlinternalMenhirLib hack like the Makefile
  ))
@@ -100,8 +101,9 @@
  (name ocamlbytecomp)
  (wrapped false)
  (flags (
-   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
-   -warn-error A -bin-annot -safe-string -strict-formats
+   :standard
+   -strict-sequence -w +67
+   -bin-annot -safe-string -strict-formats
  ))
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (libraries ocamlcommon)
@@ -118,8 +120,9 @@
  (name main)
  (modes byte)
  (flags (
-   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
-   -warn-error A -bin-annot -safe-string -strict-formats
+   :standard
+   -strict-sequence -w +67
+   -bin-annot -safe-string -strict-formats
  ))
  (libraries ocamlbytecomp ocamlcommon)
  (modules main))
@@ -128,8 +131,9 @@
  (name main_native)
  (modes native)
  (flags (
-   -strict-sequence -principal -w +a-4-9-40-41-42-44-45-48-66-70
-   -warn-error A -bin-annot -safe-string -strict-formats
+   :standard
+   -strict-sequence -w +67
+   -bin-annot -safe-string -strict-formats
  ))
  (libraries ocamlbytecomp ocamlcommon)
  (modules main_native))

--- a/ocaml/jst.dune
+++ b/ocaml/jst.dune
@@ -7,7 +7,6 @@
 ; (library
 ;  (name ocamlmiddleend)
 ;  (wrapped false)
-;  (flags (:standard -principal))
 ;  (libraries ocamlcommon)
 ;  (modules_without_implementation
 ;    cmx_format cmxs_format backend_intf inlining_decision_intf
@@ -19,7 +18,6 @@
 (library
  (name ocamloptcomp)
  (wrapped false)
- (flags (:standard -principal))
  (libraries ocamlcommon)
  (modules_without_implementation x86_ast emitenv
    cmx_format cmxs_format backend_intf inlining_decision_intf
@@ -85,8 +83,9 @@
  (name optmain_native)
  (modes byte native)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
-   -warn-error A -bin-annot -safe-string -strict-formats
+   :standard
+   -strict-sequence -absname -w +67
+   -bin-annot -safe-string -strict-formats
  ))
  (libraries ocamloptcomp ocamlcommon)
  (modules optmain_native))

--- a/ocaml/lex/dune
+++ b/ocaml/lex/dune
@@ -15,7 +15,6 @@
   (name ocamllex_lib)
   (wrapped false)
   (modes byte native)
-  (flags (:standard -principal))
   (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
   (modules
     common
@@ -32,7 +31,6 @@
 (executable
   (name main)
   (modes byte)
-  (flags (:standard -principal))
   (libraries ocamllex_lib)
   (modules main))
 
@@ -43,7 +41,6 @@
 (executable
   (name main_native)
   (modes native)
-  (flags (:standard -principal))
   (libraries ocamllex_lib)
   (modules main_native))
 

--- a/ocaml/ocamltest/dune
+++ b/ocaml/ocamltest/dune
@@ -58,7 +58,7 @@
 (executable
  (name main)
  (modes byte)
- (flags (:standard -principal
+ (flags (:standard
    -cclib "-I../runtime"))
  (modules options main)
  (libraries ocamltest_core_and_plugin))

--- a/ocaml/otherlibs/bigarray/dune
+++ b/ocaml/otherlibs/bigarray/dune
@@ -17,8 +17,9 @@
  (wrapped false)
  (modes byte native)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66
-   -warn-error A -bin-annot -safe-string -strict-formats
+   :standard
+   -strict-sequence -absname -w +67+70
+   -bin-annot -safe-string -strict-formats
  ))
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall)))

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -17,8 +17,9 @@
   (wrapped true)
   (modes byte native)
   (flags (
-    -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66-70
-    -warn-error A -bin-annot -safe-string -strict-formats
+    :standard
+    -strict-sequence -absname -w +67
+    -bin-annot -safe-string -strict-formats
   ))
   (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
   (modules
@@ -409,7 +410,6 @@
 (executable
  (name extract_crc)
  (modes byte)
- (flags (:standard -principal))
  (libraries
    dynlink_internal
  )

--- a/ocaml/otherlibs/str/dune
+++ b/ocaml/otherlibs/str/dune
@@ -17,8 +17,9 @@
  (wrapped false)
  (modes byte native)
  (flags (
-   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66
-   -warn-error A -bin-annot -safe-string -strict-formats
+   :standard
+   -strict-sequence -absname -w +67+70
+   -bin-annot -safe-string -strict-formats
  ))
  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags (:standard -linkall))

--- a/ocaml/tools/dune
+++ b/ocaml/tools/dune
@@ -54,6 +54,8 @@
   (name ocamlmklib)
   (modes byte native)
   (modules ocamlmklib)
+  ; FIXME Fix warning 32
+  (flags (:standard -w -32))
   (libraries ocamlcommon ocamlbytecomp))
 
 (install

--- a/ocaml/toplevel/byte/dune
+++ b/ocaml/toplevel/byte/dune
@@ -18,7 +18,6 @@
  (name ocamltoplevel)
  (wrapped false)
  (modes byte)
- (flags (:standard -principal))
  (libraries ocamlcommon ocamlbytecomp)
  (modules :standard \ topstart expunge))
 

--- a/ocaml/toplevel/dune
+++ b/ocaml/toplevel/dune
@@ -15,14 +15,13 @@
 (executable
  (name topstart)
  (modes byte)
- (flags (:standard -principal -linkall))
+ (flags (:standard -linkall))
  (libraries ocamlbytecomp ocamlcommon ocamltoplevel)
  (modules topstart))
 
 (executable
  (name expunge)
  (modes byte)
- (flags (:standard -principal))
  (libraries ocamlbytecomp ocamlcommon)
  (modules expunge))
 

--- a/ocaml/toplevel/native/dune
+++ b/ocaml/toplevel/native/dune
@@ -18,14 +18,12 @@
 ;  (name ocamltoplevel_native)
 ;  (wrapped false)
 ;  (modes native)
-;  (flags (:standard -principal))
 ;  (libraries ocamlcommon ocamloptcomp dynlink_internal)
 ;  (modules :standard \ topstart expunge))
 ; 
 ; (executable
 ;  (name topstart)
 ;  (modes native)
-;  (flags (:standard -principal))
 ;  (modules topstart)
 ;  (libraries ocamltoplevel_native))
 ; 

--- a/tests/backend/regalloc_validator/dune
+++ b/tests/backend/regalloc_validator/dune
@@ -1,3 +1,5 @@
 (tests
  (names check_regalloc_validation)
+ ; FIXME Fix warnings
+ (flags (:standard -no-principal -w -27-32))
  (libraries ocamloptcomp))

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -1,3 +1,9 @@
+(env
+ (_
+  ; FIXME Fix warnings or suppress them more finely
+  (flags
+   (:standard -w -32-33-35-60))))
+
 ; Stubs
 
 (foreign_library

--- a/tools/dune
+++ b/tools/dune
@@ -22,8 +22,8 @@
  (name generate_cached_generic_functions)
  (modes byte native)
  (modules generate_cached_generic_functions)
- (flags
-  (:standard -principal -w -9-69-70-33-27))
+ ; FIXME Fix warnings 27 and 33
+ (flags (:standard -w -27-33-69-70))
  (libraries ocamlcommon ocamloptcomp unix memtrace))
 
 (install
@@ -38,6 +38,8 @@
  (name merge_archives)
  (modes native)
  (modules merge_archives)
+ ; FIXME Fix warning 27
+ (flags (:standard -w -27))
  (libraries ocamlcommon ocamlbytecomp ocamloptcomp))
 
 (executable

--- a/utils/dune
+++ b/utils/dune
@@ -2,6 +2,8 @@
 
 (library
  (name flambda_backend_utils)
+ ; FIXME Fix warning 27
+ (flags (:standard -w -27))
  (ocamlopt_flags
   (:standard -O3))
  (libraries ocamlcommon))


### PR DESCRIPTION
There's a lot of warning boilerplate in our Dune files (thankfully not in our source files anymore). This makes it very easy to leave off warning flags, and in fact it turns out we've been compiling all of `backend/` and `tools/` with only default warnings on (which is to say, practically no warnings enabled).

I've chosen to keep this PR to Dune files, so I haven't fixed any warnings, but it did turn up several that should be easy to fix.

Principles at play here:

1. All `flags` clauses should include `:standard`, and none should include `-w +a` except the topmost declaration possible. (The exception is `ocaml/dune`, which has to be self-sufficient.) Also, `-principal` should be set early on and `-no-principal` used to override it.

2. All modules that already had reasonable warnings set should be compiled with exactly the same warnings enabled as before. Further simplifications are probably possible here, since there are quite a few random-looking differences that may not have been intended.

3. All modules that were being compiled with the default warnings now explicitly disable enough warnings that they currently compile. I've left comments for the warnings that we probably want to fix.

CI can't really tell us what warnings should be enabled but aren't, so reviewers please make sure I haven't left anything important out.