### PR TITLE
Use a forest rather than a tree for dominators

### DIFF
--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -48,15 +48,12 @@ let invariant_doms : Cfg.t -> doms -> unit =
     cfg.blocks;
   (* Check that (i) the immediate dominator is a strict dominator, and (ii)
      there is no other intermediate strict dominator - except for the entry
-     block. *)
+     block and unreachable blocks, which all have (by convention) themselves as
+     immediate dominators. *)
   Label.Tbl.iter
     (fun n idom_n ->
-      if Label.equal n cfg.entry_label
+      if not (Label.equal n idom_n)
       then (
-        if not (Label.equal idom_n cfg.entry_label)
-        then
-          fatal "Cfg_dominators.invariant_doms: invalid binding for entry label")
-      else (
         if not (is_strictly_dominating doms idom_n n)
         then
           fatal

--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -23,7 +23,7 @@ type dominator_tree =
 type t =
   { doms : doms;
     dominance_frontiers : dominance_frontiers;
-    dominator_tree : dominator_tree
+    dominator_forest : dominator_tree list
   }
 
 let rec is_dominating (doms : doms) left right =
@@ -169,18 +169,18 @@ let compute_doms : Cfg.t -> doms =
                   new_idom
                     := Some
                          (intersect doms order predecessor_label new_idom_pred)));
-          match !new_idom with
-          | None -> assert false
-          | Some new_idom -> (
-            match Label.Tbl.find_opt doms label with
-            | None ->
+          let new_idom =
+            match !new_idom with None -> label | Some new_idom -> new_idom
+          in
+          match Label.Tbl.find_opt doms label with
+          | None ->
+            Label.Tbl.replace doms label new_idom;
+            changed := true
+          | Some dom_label ->
+            if not (Label.equal dom_label new_idom)
+            then (
               Label.Tbl.replace doms label new_idom;
-              changed := true
-            | Some dom_label ->
-              if not (Label.equal dom_label new_idom)
-              then (
-                Label.Tbl.replace doms label new_idom;
-                changed := true))))
+              changed := true)))
   done;
   if debug then invariant_doms cfg doms;
   doms
@@ -253,11 +253,12 @@ let iter_breadth_dominator_tree : dominator_tree -> f:(Label.t -> unit) -> unit
     List.iter dom_tree.children ~f:(fun child -> Queue.add child queue)
   done
 
-let invariant_dominator_tree : Cfg.t -> doms -> dominator_tree -> unit =
- fun cfg doms dominator_tree ->
+let invariant_dominator_forest : Cfg.t -> doms -> dominator_tree list -> unit =
+ fun cfg doms dominator_forest ->
   let seen_by_iter = ref Label.Set.empty in
-  iter_breadth_dominator_tree dominator_tree ~f:(fun label ->
-      seen_by_iter := Label.Set.add label !seen_by_iter);
+  List.iter dominator_forest ~f:(fun dominator_tree ->
+      iter_breadth_dominator_tree dominator_tree ~f:(fun label ->
+          seen_by_iter := Label.Set.add label !seen_by_iter));
   let seen_by_cfg =
     Cfg.fold_blocks cfg ~init:Label.Set.empty
       ~f:(fun label _block seen_by_cfg -> Label.Set.add label seen_by_cfg)
@@ -265,7 +266,8 @@ let invariant_dominator_tree : Cfg.t -> doms -> dominator_tree -> unit =
   if not (Label.Set.equal !seen_by_iter seen_by_cfg)
   then
     fatal
-      "Cfg_dominators.invariant_dominator_tree: iterator did not see all blocks";
+      "Cfg_dominators.invariant_dominator_forest: iterator did not see all \
+       blocks";
   let rec check_parent ~parent tree =
     let immediate_dominator : Label.t option =
       match Label.Tbl.find_opt doms tree.label with
@@ -275,16 +277,17 @@ let invariant_dominator_tree : Cfg.t -> doms -> dominator_tree -> unit =
     if not (Option.equal Label.equal immediate_dominator parent)
     then
       fatal
-        "Cfg_dominators.invariant_dominator_tree: unexpected parent (%s) for \
+        "Cfg_dominators.invariant_dominator_forest: unexpected parent (%s) for \
          label %d"
         (Option.fold ~none:"none" ~some:string_of_int parent)
         tree.label;
     List.iter tree.children ~f:(fun child ->
         check_parent ~parent:(Some tree.label) child)
   in
-  check_parent ~parent:None dominator_tree
+  List.iter dominator_forest ~f:(fun dominator_tree ->
+      check_parent ~parent:None dominator_tree)
 
-let compute_dominator_tree : Cfg.t -> doms -> dominator_tree =
+let compute_dominator_forest : Cfg.t -> doms -> dominator_tree list =
  fun cfg doms ->
   let rec children_of parent =
     Label.Tbl.fold
@@ -296,17 +299,23 @@ let compute_dominator_tree : Cfg.t -> doms -> dominator_tree =
       doms []
   in
   let res =
-    { label = cfg.entry_label; children = children_of cfg.entry_label }
+    Cfg.fold_blocks cfg ~init:[] ~f:(fun label _block acc ->
+        match Label.Tbl.find_opt doms label with
+        | None -> assert false
+        | Some immediate_dominator ->
+          if Label.equal label immediate_dominator
+          then { label; children = children_of label } :: acc
+          else acc)
   in
-  if debug then invariant_dominator_tree cfg doms res;
+  if debug then invariant_dominator_forest cfg doms res;
   res
 
 let build : Cfg.t -> t =
  fun cfg ->
   let doms = compute_doms cfg in
   let dominance_frontiers = compute_dominance_frontiers cfg doms in
-  let dominator_tree = compute_dominator_tree cfg doms in
-  { doms; dominance_frontiers; dominator_tree }
+  let dominator_forest = compute_dominator_forest cfg doms in
+  { doms; dominance_frontiers; dominator_forest }
 
 let is_dominating t left right = is_dominating t.doms left right
 
@@ -320,7 +329,8 @@ let find_dominance_frontier t label =
     fatal "Cfg_dominators.find_dominance_frontier: no frontier for label %d"
       label
 
-let dominator_tree t = t.dominator_tree
+let dominator_forest t = t.dominator_forest
 
-let iter_breadth_dominator_tree t ~f =
-  iter_breadth_dominator_tree t.dominator_tree ~f
+let iter_breadth_dominator_forest t ~f =
+  List.iter t.dominator_forest ~f:(fun dominator_tree ->
+      iter_breadth_dominator_tree dominator_tree ~f)

--- a/backend/cfg/cfg_dominators.mli
+++ b/backend/cfg/cfg_dominators.mli
@@ -11,7 +11,7 @@ type t
 
 val build : Cfg.t -> t
 (* Computes all dominator-related information, in particular immediate
-   dominators, dominance frontiers, and dominator tree for the passed CFG. *)
+   dominators, dominance frontiers, and dominator forest for the passed CFG. *)
 
 val is_dominating : t -> Label.t -> Label.t -> bool
 (* [is_dominating doms x y] is [true] iff [x] is dominating [y] according to
@@ -29,8 +29,9 @@ val find_dominance_frontier : t -> Label.t -> Label.Set.t
    dominance frontier of a node n is the set of all nodes m such that n
    dominates a predecessor of m, but does not strictly dominate m itself". *)
 
-val dominator_tree : t -> dominator_tree
+val dominator_forest : t -> dominator_tree list
 
-val iter_breadth_dominator_tree : t -> f:(Label.t -> unit) -> unit
-(* [iter_breadth_dominator_tree doms ~f] iterates over the dominator tree from
-   [doms] in a breadth-first manner, applying [f] to visited nodes. *)
+val iter_breadth_dominator_forest : t -> f:(Label.t -> unit) -> unit
+(* [iter_breadth_dominator_forest doms ~f] iterates over the dominator forest
+   from [doms] in a breadth-first manner (iterating over a whole tree of the
+   forest before moving to the next tree), applying [f] to visited nodes. *)

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -89,7 +89,7 @@ let compute_substitutions : State.t -> Cfg_with_infos.t -> Substitution.map =
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
       propagate_substitution state cfg substs block subst
   in
-  Cfg_dominators.iter_breadth_dominator_tree
+  Cfg_dominators.iter_breadth_dominator_forest
     (Cfg_with_infos.dominators cfg_with_infos)
     ~f:compute_substitution_for_block;
   substs
@@ -412,7 +412,7 @@ let split_at_destruction_points :
   then (
     let doms = Cfg_with_infos.dominators cfg_with_infos in
     log_dominance_frontier ~indent:1 (Cfg_with_infos.cfg cfg_with_infos) doms;
-    log_dominator_tree ~indent:1 (Cfg_dominators.dominator_tree doms));
+    log_dominator_forest ~indent:1 (Cfg_dominators.dominator_forest doms));
   match Label.Map.is_empty (State.definitions_at_beginning state) with
   | true ->
     log ~indent:1 "renaming_infos is empty (no new names introduced)";

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -44,6 +44,11 @@ let log_dominator_tree : indent:int -> Cfg_dominators.dominator_tree -> unit =
   in
   ldt ~indent dom_tree
 
+let log_dominator_forest :
+    indent:int -> Cfg_dominators.dominator_tree list -> unit =
+ fun ~indent dom_forest ->
+  List.iter dom_forest ~f:(fun dom_tree -> log_dominator_tree ~indent dom_tree)
+
 let log_substitution : indent:int -> Substitution.t -> unit =
  fun ~indent subst ->
   Reg.Tbl.iter

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -17,6 +17,9 @@ val log_dominance_frontier : indent:int -> Cfg.t -> Cfg_dominators.t -> unit
 
 val log_dominator_tree : indent:int -> Cfg_dominators.dominator_tree -> unit
 
+val log_dominator_forest :
+  indent:int -> Cfg_dominators.dominator_tree list -> unit
+
 val log_substitution : indent:int -> Substitution.t -> unit
 
 val log_substitutions : indent:int -> Substitution.map -> unit


### PR DESCRIPTION
Because some CFG blocks may be unreachable,
it is not always possible to build a dominator tree.
Since there are possibly several roots, this pull
request changes the representation to a forest.

(When a function would induce several roots, the
build would fail with an `assert false` being
raised by `Cfg_dominators.compute_doms`.)