### PR TITLE
Improve debuginfo for for-loops (and conditionals)

### DIFF
--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -202,12 +202,13 @@ let kill_addr_regs n =
 
 (* Prepend a set of moves before [i] to assign [srcs] to [dsts].  *)
 
-let insert_single_move i src dst = instr_cons (Iop Imove) [|src|] [|dst|] i
+let insert_single_move i src dst =
+  instr_cons_debug (Iop Imove) [|src|] [|dst|] i.dbg i
 
 let insert_move srcs dsts i =
   match Array.length srcs with
   | 0 -> i
-  | 1 -> instr_cons (Iop Imove) srcs dsts i
+  | 1 -> instr_cons_debug (Iop Imove) srcs dsts i.dbg i
   | _ -> (* Parallel move: first copy srcs into tmps one by one,
             then copy tmps into dsts one by one *)
          let tmps = Reg.createv_like srcs in

--- a/backend/comballoc.ml
+++ b/backend/comballoc.ml
@@ -103,12 +103,13 @@ let rec combine i allocstate =
       let newifso = combine_restart ifso in
       let newifnot = combine_restart ifnot in
       let newnext = combine_restart i.next in
-      (instr_cons (Iifthenelse(test, newifso, newifnot)) i.arg i.res newnext,
+      (instr_cons_debug (Iifthenelse(test, newifso, newifnot)) i.arg i.res
+         i.dbg newnext,
        allocstate)
   | Iswitch(table, cases) ->
       let newcases = Array.map combine_restart cases in
       let newnext = combine_restart i.next in
-      (instr_cons (Iswitch(table, newcases)) i.arg i.res newnext,
+      (instr_cons_debug (Iswitch(table, newcases)) i.arg i.res i.dbg newnext,
        allocstate)
   | Icatch(rec_flag, ts, handlers, body) ->
       let (newbody, s') = combine body allocstate in
@@ -118,14 +119,14 @@ let rec combine i allocstate =
           handlers
       in
       let newnext = combine_restart i.next in
-      (instr_cons (Icatch(rec_flag, ts, newhandlers, newbody))
-         i.arg i.res newnext, s')
+      (instr_cons_debug (Icatch(rec_flag, ts, newhandlers, newbody))
+         i.arg i.res i.dbg newnext, s')
   | Itrywith(body, kind, (ts, handler)) ->
       let (newbody, s') = combine body allocstate in
       let newhandler = combine_restart handler in
       let newnext = combine_restart i.next in
-      (instr_cons (Itrywith(newbody, kind, (ts, newhandler)))
-         i.arg i.res newnext, s')
+      (instr_cons_debug (Itrywith(newbody, kind, (ts, newhandler)))
+         i.arg i.res i.dbg newnext, s')
 
 and combine_restart i =
   let (newi, _) = combine i No_alloc in newi

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -142,13 +142,6 @@ let end_instr () =
     available_across = None;
   }
 
-let instr_cons d a r n =
-  { desc = d; next = n; arg = a; res = r;
-    dbg = Debuginfo.none; live = Reg.Set.empty;
-    available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
-    available_across = None;
-  }
-
 let instr_cons_debug d a r dbg n =
   { desc = d; next = n; arg = a; res = r; dbg = dbg; live = Reg.Set.empty;
     available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -133,9 +133,6 @@ type fundecl =
 
 val dummy_instr: instruction
 val end_instr: unit -> instruction
-val instr_cons:
-      instruction_desc -> Reg.t array -> Reg.t array -> instruction ->
-        instruction
 val instr_cons_debug:
       instruction_desc -> Reg.t array -> Reg.t array -> Debuginfo.t ->
         instruction -> instruction

--- a/backend/reloadgen.ml
+++ b/backend/reloadgen.ml
@@ -19,16 +19,16 @@ open Misc
 open Reg
 open Mach
 
-let insert_move src dst next =
+let insert_move dbg src dst next =
   if src.loc = dst.loc
   then next
-  else instr_cons (Iop Imove) [|src|] [|dst|] next
+  else instr_cons_debug (Iop Imove) [|src|] [|dst|] dbg next
 
-let insert_moves src dst next =
+let insert_moves dbg src dst next =
   let rec insmoves i =
     if i >= Array.length src
     then next
-    else insert_move src.(i) dst.(i) (insmoves (i+1))
+    else insert_move dbg src.(i) dst.(i) (insmoves (i+1))
   in insmoves 0
 
 class reload_generic = object (self)
@@ -99,51 +99,51 @@ method private reload i k =
     Iend | Ireturn _ | Iop(Itailcall_imm _) | Iraise _ -> k i
   | Iop(Itailcall_ind) ->
       let newarg = self#makereg1 i.arg in
-      k (insert_moves i.arg newarg
+      k (insert_moves i.dbg i.arg newarg
            {i with arg = newarg})
   | Iop(Icall_imm _ | Iextcall _) ->
       self#reload i.next (fun next -> k {i with next; })
   | Iop(Icall_ind) ->
       let newarg = self#makereg1 i.arg in
       self#reload i.next (fun next ->
-        k (insert_moves i.arg newarg
+        k (insert_moves i.dbg i.arg newarg
              {i with arg = newarg; next; }))
   | Iop op ->
       let (newarg, newres) = self#reload_operation op i.arg i.res in
       self#reload i.next (fun next ->
-        k (insert_moves i.arg newarg
+        k (insert_moves i.dbg i.arg newarg
              {i with arg = newarg; res = newres;
-                     next = (insert_moves newres i.res next); }))
+                     next = (insert_moves i.dbg newres i.res next); }))
   | Iifthenelse(tst, ifso, ifnot) ->
       let newarg = self#reload_test tst i.arg in
       self#reload ifso (fun ifso ->
         self#reload ifnot (fun ifnot ->
           self#reload i.next (fun next ->
-            k (insert_moves i.arg newarg
-                 (instr_cons (Iifthenelse(tst, ifso, ifnot))
-                    newarg [||] next)))))
+            k (insert_moves i.dbg i.arg newarg
+                 (instr_cons_debug (Iifthenelse(tst, ifso, ifnot))
+                    newarg [||] i.dbg next)))))
   | Iswitch(index, cases) ->
       let newarg = self#makeregs i.arg in
       let cases = Array.map (fun case -> self#reload case Fun.id) cases in
       self#reload i.next (fun next ->
-        k (insert_moves i.arg newarg
-             (instr_cons (Iswitch(index, cases)) newarg [||] next)))
+        k (insert_moves i.dbg i.arg newarg
+             (instr_cons_debug (Iswitch(index, cases)) newarg [||] i.dbg next)))
   | Icatch(rec_flag, ts, handlers, body) ->
       let new_handlers = List.map
           (fun (nfail, ts, handler, is_cold) -> nfail, ts, self#reload handler Fun.id, is_cold)
           handlers in
       self#reload body (fun body ->
         self#reload i.next (fun next ->
-          k (instr_cons (Icatch(rec_flag, ts, new_handlers, body))
-               [||] [||] next)))
-  | Iexit (i, traps) ->
-      k (instr_cons (Iexit (i, traps)) [||] [||] dummy_instr)
+          k (instr_cons_debug (Icatch(rec_flag, ts, new_handlers, body))
+               [||] [||] i.dbg next)))
+  | Iexit (cont, traps) ->
+      k (instr_cons_debug (Iexit (cont, traps)) [||] [||] i.dbg dummy_instr)
   | Itrywith(body, kind, (ts, handler)) ->
       self#reload body (fun body ->
         self#reload handler (fun handler ->
           self#reload i.next (fun next ->
-            k (instr_cons (Itrywith(body, kind, (ts, handler)))
-                 [||] [||] next))))
+            k (instr_cons_debug (Itrywith(body, kind, (ts, handler)))
+                 [||] [||] i.dbg next))))
 
 method fundecl f num_stack_slots =
   redo_regalloc <- false;

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -805,7 +805,8 @@ method insert_debug _env desc dbg arg res =
   instr_seq <- instr_cons_debug desc arg res dbg instr_seq
 
 method insert _env desc arg res =
-  instr_seq <- instr_cons desc arg res instr_seq
+  (* CR mshinwell: fix debuginfo *)
+  instr_seq <- instr_cons_debug desc arg res Debuginfo.none instr_seq
 
 method extract_onto o =
   let rec extract res i =
@@ -1107,7 +1108,7 @@ method emit_expr_aux (env:environment) exp ~bound_name :
         None -> None
       | Some _ -> self#emit_expr_aux env e2 ~bound_name
       end
-  | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, _dbg, _kind) ->
+  | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, dbg, _kind) ->
       let (cond, earg) = self#select_condition econd in
       begin match self#emit_expr env earg ~bound_name:None with
         None -> None
@@ -1119,11 +1120,11 @@ method emit_expr_aux (env:environment) exp ~bound_name :
             self#emit_sequence env eelse ~bound_name
           in
           let r = join env rif sif relse selse ~bound_name in
-          self#insert env (Iifthenelse(cond, sif#extract, selse#extract))
-                      rarg [||];
+          self#insert_debug env (Iifthenelse(cond, sif#extract, selse#extract))
+            dbg rarg [||];
           r
       end
-  | Cswitch(esel, index, ecases, _dbg, _kind) ->
+  | Cswitch(esel, index, ecases, dbg, _kind) ->
       begin match self#emit_expr env esel ~bound_name:None with
         None -> None
       | Some rsel ->
@@ -1133,9 +1134,9 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               ecases
           in
           let r = join_array env rscases ~bound_name in
-          self#insert env (Iswitch(index,
-                                   Array.map (fun (_, s) -> s#extract) rscases))
-                      rsel [||];
+          self#insert_debug env
+            (Iswitch(index, Array.map (fun (_, s) -> s#extract) rscases))
+            dbg rsel [||];
           r
       end
   | Ccatch(_, [], e1, _) ->
@@ -1270,7 +1271,7 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               end
           end
       end
-  | Ctrywith(e1, kind, v, e2, _dbg, _value_kind) ->
+  | Ctrywith(e1, kind, v, e2, dbg, _value_kind) ->
       (* This region is used only to clean up local allocations in the
          exceptional path. It must not be ended in the non-exception case
          as local allocations may be returned from the body of the "try". *)
@@ -1280,7 +1281,8 @@ method emit_expr_aux (env:environment) exp ~bound_name :
         then begin
           let reg = self#regs_for typ_int in
           self#insert env (Iop Ibeginregion) [| |] reg;
-          fun handler_instruction -> instr_cons (Iop Iendregion) reg [| |] handler_instruction
+          fun handler_instruction ->
+            instr_cons_debug (Iop Iendregion) reg [| |] dbg handler_instruction
         end
         else
           fun handler_instruction -> handler_instruction
@@ -1311,7 +1313,8 @@ method emit_expr_aux (env:environment) exp ~bound_name :
         self#insert env
           (Itrywith(s1#extract, kind,
                     (env_handler.trap_stack,
-                     instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv
+                     instr_cons_debug (Iop Imove) [|Proc.loc_exn_bucket|] rv
+                       dbg
                        (end_region s2#extract))))
           [||] [||];
         r
@@ -1670,17 +1673,17 @@ method emit_tail (env:environment) exp =
         None -> ()
       | Some _ -> self#emit_tail env e2
       end
-  | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, _dbg, _kind) ->
+  | Cifthenelse(econd, _ifso_dbg, eif, _ifnot_dbg, eelse, dbg, _kind) ->
       let (cond, earg) = self#select_condition econd in
       begin match self#emit_expr env earg ~bound_name:None with
         None -> ()
       | Some rarg ->
-          self#insert env
+          self#insert_debug env
                       (Iifthenelse(cond, self#emit_tail_sequence env eif,
                                          self#emit_tail_sequence env eelse))
-                      rarg [||]
+                      dbg rarg [||]
       end
-  | Cswitch(esel, index, ecases, _dbg, _kind) ->
+  | Cswitch(esel, index, ecases, dbg, _kind) ->
       begin match self#emit_expr env esel ~bound_name:None with
         None -> ()
       | Some rsel ->
@@ -1688,7 +1691,7 @@ method emit_tail (env:environment) exp =
             Array.map (fun (case, _dbg) -> self#emit_tail_sequence env case)
               ecases
           in
-          self#insert env (Iswitch (index, cases)) rsel [||]
+          self#insert_debug env (Iswitch (index, cases)) dbg rsel [||]
       end
   | Ccatch(_, [], e1, _) ->
       self#emit_tail env e1
@@ -1765,14 +1768,15 @@ method emit_tail (env:environment) exp =
       (* The final trap stack doesn't matter, as it's not reachable. *)
       self#insert env (Icatch(rec_flag, env.trap_stack, new_handlers, s_body))
         [||] [||]
-  | Ctrywith(e1, kind, v, e2, _dbg, _value_kind) ->
+  | Ctrywith(e1, kind, v, e2, dbg, _value_kind) ->
       (* This region is used only to clean up local allocations in the
          exceptional path. It need not be ended in the non-exception case. *)
       let end_region =
         if Config.stack_allocation then begin
           let reg = self#regs_for typ_int in
           self#insert env (Iop Ibeginregion) [| |] reg;
-          fun handler_instruction -> instr_cons (Iop Iendregion) reg [| |] handler_instruction
+          fun handler_instruction ->
+            instr_cons_debug (Iop Iendregion) reg [| |] dbg handler_instruction
         end
         else
           fun handler_instruction -> handler_instruction
@@ -1803,7 +1807,7 @@ method emit_tail (env:environment) exp =
         self#insert env
           (Itrywith(s1, kind,
                     (env_handler.trap_stack,
-                     instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv
+                     instr_cons_debug (Iop Imove) [|Proc.loc_exn_bucket|] rv dbg
                        (end_region s2))))
           [||] [||]
       in

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -179,7 +179,7 @@ let add_reloads env regset i =
     (fun r (env, i) ->
        let env, r' = spill_reg env r in
        env,
-       instr_cons (Iop Ireload) [|r'|] [|r|] i)
+       instr_cons_debug (Iop Ireload) [|r'|] [|r|] i.dbg i)
     regset (env, i)
 
 let find_reload_at_exit env k =
@@ -249,8 +249,8 @@ let rec reload env i before =
       let (new_next, finally, env) =
         reload env i.next (Reg.Set.union after_ifso after_ifnot) in
       let new_i =
-        instr_cons (Iifthenelse(test, new_ifso, new_ifnot))
-        i.arg i.res new_next in
+        instr_cons_debug (Iifthenelse(test, new_ifso, new_ifnot))
+        i.arg i.res i.dbg new_next in
       let env =
         { env with destroyed_at_fork =
                      (new_i, at_fork) :: env.destroyed_at_fork;
@@ -280,8 +280,8 @@ let rec reload env i before =
       let (new_next, finally, env) = reload env i.next after_cases in
       let env, i =
         add_reloads env (Reg.inter_set_array before i.arg)
-          (instr_cons (Iswitch(index, new_cases))
-             i.arg i.res new_next)
+          (instr_cons_debug (Iswitch(index, new_cases))
+             i.arg i.res i.dbg new_next)
       in
       (i, finally, env)
   | Icatch(rec_flag, ts, handlers, body) ->
@@ -344,8 +344,9 @@ let rec reload env i before =
       in
       let env = { env with reload_at_exit; } in
       let (new_next, finally, env) = reload env i.next after_union in
-      (instr_cons
-         (Icatch(rec_flag, ts, new_handlers, new_body)) i.arg i.res new_next,
+      (instr_cons_debug
+         (Icatch(rec_flag, ts, new_handlers, new_body)) i.arg i.res i.dbg
+         new_next,
        finally,
        env)
   | Iexit (nfail, _traps) ->
@@ -369,7 +370,8 @@ let rec reload env i before =
       in
       let (new_next, finally, env) =
         reload env i.next (Reg.Set.union after_body after_handler) in
-      (instr_cons (Itrywith(new_body, kind, (ts, new_handler))) i.arg i.res new_next,
+      (instr_cons_debug (Itrywith(new_body, kind, (ts, new_handler))) i.arg
+         i.res i.dbg new_next,
        finally,
        env)
   | Iraise _ ->
@@ -491,7 +493,8 @@ let add_spills env regset i =
       { i with next; }
     | _ ->
       List.fold_left (fun i r ->
-          instr_cons (Iop Ispill) [|r|] [|spill_reg_no_add env r|] i)
+          instr_cons_debug (Iop Ispill) [|r|] [|spill_reg_no_add env r|]
+            i.dbg i)
         i regset
   in
   add_spills i
@@ -508,7 +511,7 @@ let rec spill :
   | Iop Ireload ->
     spill env i.next finally (fun new_next after ->
       let before1 = Reg.diff_set_array after i.res in
-      k (instr_cons i.desc i.arg i.res new_next)
+      k (instr_cons_debug i.desc i.arg i.res i.dbg new_next)
         (Reg.add_set_array before1 i.res))
   | Iop op ->
     spill env i.next finally (fun new_next after ->
@@ -527,8 +530,8 @@ let rec spill :
       if
         env.loop || env.arm || env.catch
       then
-        k (instr_cons (Iifthenelse(test, new_ifso, new_ifnot))
-                     i.arg i.res new_next)
+        k (instr_cons_debug (Iifthenelse(test, new_ifso, new_ifnot))
+                     i.arg i.res i.dbg new_next)
           (Reg.Set.union before_ifso before_ifnot)
       else begin
         let destroyed = List.assq i env.destroyed_at_fork in
@@ -536,10 +539,10 @@ let rec spill :
           Reg.Set.diff (Reg.Set.diff before_ifso before_ifnot) destroyed
         and spill_ifnot_branch =
           Reg.Set.diff (Reg.Set.diff before_ifnot before_ifso) destroyed in
-        k (instr_cons
+        k (instr_cons_debug
             (Iifthenelse(test, add_spills env spill_ifso_branch new_ifso,
                                add_spills env spill_ifnot_branch new_ifnot))
-            i.arg i.res new_next)
+            i.arg i.res i.dbg new_next)
           (Reg.Set.diff (Reg.Set.diff (Reg.Set.union before_ifso before_ifnot)
                                     spill_ifso_branch)
                        spill_ifnot_branch)
@@ -555,7 +558,8 @@ let rec spill :
             before := Reg.Set.union !before before_c;
             new_c))
           cases in
-      k (instr_cons (Iswitch(index, new_cases)) i.arg i.res new_next)
+      k (instr_cons_debug (Iswitch(index, new_cases)) i.arg i.res i.dbg
+          new_next)
         !before)
   | Icatch(rec_flag, ts, handlers, body) ->
     let next_env = { env with at_raise = at_raise_from_trap_stack env ts } in
@@ -604,8 +608,8 @@ let rec spill :
       let new_handlers = List.map2
           (fun (nfail, ts, _, is_cold) (handler, _) -> nfail, ts, handler, is_cold)
           handlers res in
-      k (instr_cons (Icatch(rec_flag, ts, new_handlers, new_body))
-         i.arg i.res new_next)
+      k (instr_cons_debug (Icatch(rec_flag, ts, new_handlers, new_body))
+         i.arg i.res i.dbg new_next)
         before))
   | Iexit (nfail, _traps) ->
       k i (find_spill_at_exit env nfail)
@@ -627,8 +631,8 @@ let rec spill :
             }
       in
       spill env_body body at_join (fun new_body before_body ->
-      k (instr_cons (Itrywith(new_body, kind, (ts, new_handler)))
-         i.arg i.res new_next)
+      k (instr_cons_debug (Itrywith(new_body, kind, (ts, new_handler)))
+         i.arg i.res i.dbg new_next)
         before_body)))
   | Iraise _ ->
       k i env.at_raise

--- a/backend/split.ml
+++ b/backend/split.ml
@@ -136,7 +136,7 @@ let rec rename i sub =
           let newr = Reg.clone i.res.(0) in
           let (new_next, sub_next) =
             rename i.next (Some(Reg.Map.add oldr newr s)) in
-          (instr_cons i.desc i.arg [|newr|] new_next,
+          (instr_cons_debug i.desc i.arg [|newr|] i.dbg new_next,
            sub_next)
       end
   | Iop (Iname_for_debugger {
@@ -157,16 +157,17 @@ let rec rename i sub =
       let (new_ifnot, sub_ifnot) = rename ifnot sub in
       let (new_next, sub_next) =
         rename i.next (merge_substs sub_ifso sub_ifnot i.next) in
-      (instr_cons (Iifthenelse(tst, new_ifso, new_ifnot))
-                  (subst_regs i.arg sub) [||] new_next,
+      (instr_cons_debug (Iifthenelse(tst, new_ifso, new_ifnot))
+                  (subst_regs i.arg sub) [||] i.dbg new_next,
        sub_next)
   | Iswitch(index, cases) ->
       let new_sub_cases = Array.map (fun c -> rename c sub) cases in
       let sub_merge =
         merge_subst_array (Array.map (fun (_n, s) -> s) new_sub_cases) i.next in
       let (new_next, sub_next) = rename i.next sub_merge in
-      (instr_cons (Iswitch(index, Array.map (fun (n, _s) -> n) new_sub_cases))
-                  (subst_regs i.arg sub) [||] new_next,
+      (instr_cons_debug
+        (Iswitch(index, Array.map (fun (n, _s) -> n) new_sub_cases))
+        (subst_regs i.arg sub) [||] i.dbg new_next,
        sub_next)
   | Icatch(rec_flag, ts, handlers, body) ->
       let new_subst =
@@ -188,8 +189,9 @@ let rec rename i sub =
       let (new_next, sub_next) = rename i.next merged_subst in
       let new_handlers = List.map2 (fun (nfail, ts, _, is_cold) (handler, _) ->
           (nfail, ts, handler, is_cold)) handlers res in
-      (instr_cons
-         (Icatch(rec_flag, ts, new_handlers, new_body)) [||] [||] new_next,
+      (instr_cons_debug
+         (Icatch(rec_flag, ts, new_handlers, new_body)) [||] [||]
+         i.dbg new_next,
        sub_next)
   | Iexit (nfail, _traps) ->
       let r = find_exit_subst nfail in
@@ -200,8 +202,8 @@ let rec rename i sub =
       let (new_handler, sub_handler) = rename handler sub in
       let (new_next, sub_next) =
         rename i.next (merge_substs sub_body sub_handler i.next) in
-      (instr_cons (Itrywith(new_body, kind, (ts, new_handler)))
-         [||] [||] new_next,
+      (instr_cons_debug (Itrywith(new_body, kind, (ts, new_handler)))
+         [||] [||] i.dbg new_next,
        sub_next)
   | Iraise k ->
       (instr_cons_debug (Iraise k) (subst_regs i.arg sub) [||] i.dbg i.next,

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -70,8 +70,11 @@ module IR = struct
 
   type switch =
     { numconsts : int;
-      consts : (int * Continuation.t * trap_action option * simple list) list;
-      failaction : (Continuation.t * trap_action option * simple list) option
+      consts :
+        (int * Continuation.t * Debuginfo.t * trap_action option * simple list)
+        list;
+      failaction :
+        (Continuation.t * Debuginfo.t * trap_action option * simple list) option
     }
 
   let fprintf = Format.fprintf

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -74,8 +74,11 @@ module IR : sig
 
   type switch =
     { numconsts : int;
-      consts : (int * Continuation.t * trap_action option * simple list) list;
-      failaction : (Continuation.t * trap_action option * simple list) option
+      consts :
+        (int * Continuation.t * Debuginfo.t * trap_action option * simple list)
+        list;
+      failaction :
+        (Continuation.t * Debuginfo.t * trap_action option * simple list) option
     }
 
   val print_simple : Format.formatter -> simple -> unit

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -74,6 +74,7 @@ module IR : sig
 
   type switch =
     { numconsts : int;
+      (* CR mshinwell: use record types *)
       consts :
         (int * Continuation.t * Debuginfo.t * trap_action option * simple list)
         list;

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -167,6 +167,39 @@ let compile_staticfail acc env ccenv ~(continuation : Continuation.t) ~args :
         acc ccenv)
     acc ccenv
 
+let rec try_to_find_location (lam : L.lambda) =
+  (* This is very much best-effort and may overshoot, but will still likely be
+     better than nothing. *)
+  match lam with
+  | Lprim (_, _, loc)
+  | Lfunction { loc; _ }
+  | Lapply { ap_loc = loc; _ }
+  | Lfor { for_loc = loc; _ }
+  | Lswitch (_, _, loc, _)
+  | Lstringswitch (_, _, _, loc, _)
+  | Lsend (_, _, _, _, _, _, loc, _)
+  | Levent (_, { lev_loc = loc; _ }) ->
+    loc
+  | Llet (_, _, _, lam, _)
+  | Lmutlet (_, _, lam, _)
+  | Lletrec ((_, lam) :: _, _)
+  | Lifthenelse (lam, _, _, _)
+  | Lstaticcatch (lam, _, _, _)
+  | Lstaticraise (_, lam :: _)
+  | Lwhile { wh_cond = lam; _ }
+  | Lsequence (lam, _)
+  | Lassign (_, lam)
+  | Lifused (_, lam)
+  | Lregion (lam, _)
+  | Lexclave lam
+  | Ltrywith (lam, _, _, _) ->
+    try_to_find_location lam
+  | Lvar _ | Lmutvar _ | Lconst _ | Lletrec _ | Lstaticraise (_, []) ->
+    Debuginfo.Scoped_location.Loc_unknown
+
+let try_to_find_debuginfo lam =
+  Debuginfo.from_location (try_to_find_location lam)
+
 let switch_for_if_then_else ~cond ~ifso ~ifnot ~kind =
   let switch : Lambda.lambda_switch =
     { sw_numconsts = 2;
@@ -176,7 +209,7 @@ let switch_for_if_then_else ~cond ~ifso ~ifnot ~kind =
       sw_failaction = None
     }
   in
-  L.Lswitch (cond, switch, Loc_unknown, kind)
+  L.Lswitch (cond, switch, try_to_find_location cond, kind)
 
 let transform_primitive env (prim : L.primitive) args loc =
   match prim, args with
@@ -306,27 +339,26 @@ let rec_catch_for_while_loop env cond body =
   in
   env, lam
 
-let rec_catch_for_for_loop env ident start stop (dir : Asttypes.direction_flag)
-    body =
+let rec_catch_for_for_loop env loc ident start stop
+    (dir : Asttypes.direction_flag) body =
   let cont = L.next_raise_count () in
   let env = Env.mark_as_recursive_static_catch env cont in
   let start_ident = Ident.create_local "for_start" in
   let stop_ident = Ident.create_local "for_stop" in
   let first_test : L.lambda =
     match dir with
-    | Upto ->
-      Lprim (Pintcomp Cle, [L.Lvar start_ident; L.Lvar stop_ident], Loc_unknown)
+    | Upto -> Lprim (Pintcomp Cle, [L.Lvar start_ident; L.Lvar stop_ident], loc)
     | Downto ->
-      Lprim (Pintcomp Cge, [L.Lvar start_ident; L.Lvar stop_ident], Loc_unknown)
+      Lprim (Pintcomp Cge, [L.Lvar start_ident; L.Lvar stop_ident], loc)
   in
   let subsequent_test : L.lambda =
-    Lprim (Pintcomp Cne, [L.Lvar ident; L.Lvar stop_ident], Loc_unknown)
+    Lprim (Pintcomp Cne, [L.Lvar ident; L.Lvar stop_ident], loc)
   in
   let one : L.lambda = Lconst (Const_base (Const_int 1)) in
   let next_value_of_counter =
     match dir with
-    | Upto -> L.Lprim (Paddint, [L.Lvar ident; one], Loc_unknown)
-    | Downto -> L.Lprim (Psubint, [L.Lvar ident; one], Loc_unknown)
+    | Upto -> L.Lprim (Paddint, [L.Lvar ident; one], loc)
+    | Downto -> L.Lprim (Psubint, [L.Lvar ident; one], loc)
   in
   let lam : L.lambda =
     (* Care needs to be taken here not to cause overflow if, for an incrementing
@@ -1108,12 +1140,13 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
     cps acc env ccenv loop k k_exn
   | Lfor
       { for_id = ident;
+        for_loc = loc;
         for_from = start;
         for_to = stop;
         for_dir = dir;
         for_body = body
       } ->
-    let env, loop = rec_catch_for_for_loop env ident start stop dir body in
+    let env, loop = rec_catch_for_for_loop env loc ident start stop dir body in
     cps acc env ccenv loop k k_exn
   | Lassign (being_assigned, new_value) ->
     if not (Env.is_mutable env being_assigned)
@@ -1509,7 +1542,8 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
           in
           let k = restore_continuation_context_for_switch_arm env k in
           let consts_rev =
-            (arm, k, None, IR.Var var :: extra_args) :: consts_rev
+            (arm, k, Debuginfo.none, None, IR.Var var :: extra_args)
+            :: consts_rev
           in
           consts_rev, wrappers
         | Lconst cst ->
@@ -1520,7 +1554,8 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
           in
           let k = restore_continuation_context_for_switch_arm env k in
           let consts_rev =
-            (arm, k, None, IR.Const cst :: extra_args) :: consts_rev
+            (arm, k, Debuginfo.none, None, IR.Const cst :: extra_args)
+            :: consts_rev
           in
           consts_rev, wrappers
         | Lmutvar _ | Lapply _ | Lfunction _ | Llet _ | Lmutlet _ | Lletrec _
@@ -1533,8 +1568,9 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
              it is safe to exclude them from passing along the extra arguments
              for mutable values. *)
           let cont = Continuation.create () in
+          let dbg = try_to_find_debuginfo action in
           let action acc ccenv = cps_tail acc env ccenv action k k_exn in
-          let consts_rev = (arm, cont, None, []) :: consts_rev in
+          let consts_rev = (arm, cont, dbg, None, []) :: consts_rev in
           let wrappers = (cont, action) :: wrappers in
           consts_rev, wrappers)
       ([], wrappers) cases
@@ -1554,9 +1590,10 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
         | None -> None, wrappers
         | Some action ->
           let cont = Continuation.create () in
+          let dbg = try_to_find_debuginfo action in
           let action acc ccenv = cps_tail acc env ccenv action k k_exn in
           let wrappers = (cont, action) :: wrappers in
-          Some (cont, None, []), wrappers
+          Some (cont, dbg, None, []), wrappers
       in
       let const_switch : IR.switch =
         { numconsts = switch.sw_numconsts; consts; failaction }
@@ -1586,7 +1623,9 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
           let block_cont = Continuation.create () in
           let isint_switch : IR.switch =
             { numconsts = 2;
-              consts = [0, block_cont, None, []; 1, const_cont, None, []];
+              consts =
+                [ 0, block_cont, condition_dbg, None, [];
+                  1, const_cont, condition_dbg, None, [] ];
               failaction = None
             }
           in

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -86,8 +86,8 @@ include Container_types.Make (struct
 
   let hash _ = Misc.fatal_error "Not yet implemented"
 
-  let compare { k = k1; args = args1; trap_action = trap_action1; dbg = _ }
-      { k = k2; args = args2; trap_action = trap_action2; dbg = _ } =
+  let compare { k = k1; args = args1; trap_action = trap_action1; dbg = dbg1 }
+      { k = k2; args = args2; trap_action = trap_action2; dbg = dbg2 } =
     let c = Continuation.compare k1 k2 in
     if c <> 0
     then c
@@ -95,7 +95,9 @@ include Container_types.Make (struct
       let c = Misc.Stdlib.List.compare Simple.compare args1 args2 in
       if c <> 0
       then c
-      else Option.compare Trap_action.compare trap_action1 trap_action2
+      else
+        let c = Option.compare Trap_action.compare trap_action1 trap_action2 in
+        if c <> 0 then c else Debuginfo.compare dbg1 dbg2
 
   let equal t1 t2 = compare t1 t2 = 0
 end)

--- a/middle_end/flambda2/terms/switch_expr.ml
+++ b/middle_end/flambda2/terms/switch_expr.ml
@@ -62,10 +62,12 @@ let print_arms ppf arms =
         action)
     arms
 
-let print ppf { condition_dbg = _; scrutinee; arms } =
-  fprintf ppf "@[<v 0>(%tswitch%t %a@ @[<v 0>%a@])@]"
+let print ppf { condition_dbg; scrutinee; arms } =
+  fprintf ppf "@[<v 0>(%tswitch%t %a%s%t%a%t@ @[<v 0>%a@])@]"
     Flambda_colours.expr_keyword Flambda_colours.pop Simple.print scrutinee
-    print_arms arms
+    (if Debuginfo.is_none condition_dbg then "" else " ")
+    Flambda_colours.debuginfo Debuginfo.print_compact condition_dbg
+    Flambda_colours.pop print_arms arms
 
 let create ~condition_dbg ~scrutinee ~arms = { condition_dbg; scrutinee; arms }
 

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -923,7 +923,11 @@ and switch env res switch =
   let make_arm ~must_tag_discriminant env res (d, action) =
     let d = prepare_discriminant ~must_tag:must_tag_discriminant d in
     let cmm_action, action_free_vars, res = apply_cont env res action in
-    (d, cmm_action, action_free_vars, Apply_cont.debuginfo action), res
+    ( ( d,
+        cmm_action,
+        action_free_vars,
+        Env.add_inlined_debuginfo env (Apply_cont.debuginfo action) ),
+      res )
   in
   match Targetint_31_63.Map.cardinal arms with
   (* Binary case: if-then-else *)
@@ -945,6 +949,13 @@ and switch env res switch =
           (Backend_var.Set.union else_free_vars then_free_vars)
       in
       let cmm, free_vars =
+        let then_dbg, else_dbg =
+          if Debuginfo.is_none then_dbg
+          then else_dbg, else_dbg
+          else if Debuginfo.is_none else_dbg
+          then then_dbg, then_dbg
+          else then_dbg, else_dbg
+        in
         wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_) free_vars
       in
       cmm, free_vars, res
@@ -956,6 +967,13 @@ and switch env res switch =
       let free_vars =
         Backend_var.Set.union scrutinee_free_vars
           (Backend_var.Set.union if_x_free_vars if_not_free_vars)
+      in
+      let if_x_dbg, if_not_dbg =
+        if Debuginfo.is_none if_x_dbg
+        then if_not_dbg, if_not_dbg
+        else if Debuginfo.is_none if_not_dbg
+        then if_x_dbg, if_x_dbg
+        else if_x_dbg, if_not_dbg
       in
       let expr =
         C.ite ~dbg

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -949,13 +949,6 @@ and switch env res switch =
           (Backend_var.Set.union else_free_vars then_free_vars)
       in
       let cmm, free_vars =
-        let then_dbg, else_dbg =
-          if Debuginfo.is_none then_dbg
-          then else_dbg, else_dbg
-          else if Debuginfo.is_none else_dbg
-          then then_dbg, then_dbg
-          else then_dbg, else_dbg
-        in
         wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_) free_vars
       in
       cmm, free_vars, res
@@ -967,13 +960,6 @@ and switch env res switch =
       let free_vars =
         Backend_var.Set.union scrutinee_free_vars
           (Backend_var.Set.union if_x_free_vars if_not_free_vars)
-      in
-      let if_x_dbg, if_not_dbg =
-        if Debuginfo.is_none if_x_dbg
-        then if_not_dbg, if_not_dbg
-        else if Debuginfo.is_none if_not_dbg
-        then if_x_dbg, if_x_dbg
-        else if_x_dbg, if_not_dbg
       in
       let expr =
         C.ite ~dbg

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -603,6 +603,7 @@ and lambda_while =
 
 and lambda_for =
   { for_id : Ident.t;
+    for_loc : scoped_location;
     for_from : lambda;
     for_to : lambda;
     for_dir : direction_flag;

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -507,6 +507,7 @@ and lambda_while =
 
 and lambda_for =
   { for_id : Ident.t;
+    for_loc : scoped_location;
     for_from : lambda;
     for_to : lambda;
     for_dir : direction_flag;

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -868,7 +868,7 @@ let rec lam ppf = function
   | Lwhile {wh_cond; wh_body} ->
       fprintf ppf "@[<2>(while@ %a@ %a)@]"
         lam wh_cond lam wh_body
-  | Lfor {for_id; for_from; for_to; for_dir; for_body} ->
+  | Lfor {for_id; for_loc = _; for_from; for_to; for_dir; for_body} ->
       fprintf ppf "@[<2>(for %a@ %a@ %s@ %a@ %a)@]"
        Ident.print for_id lam for_from
        (match for_dir with Upto -> "to" | Downto -> "downto")

--- a/ocaml/lambda/transl_array_comprehension.ml
+++ b/ocaml/lambda/transl_array_comprehension.ml
@@ -456,6 +456,7 @@ let iterator ~transl_exp ~scopes ~loc
       let stop  = bound "stop"  stop  in
       let mk_iterator body =
         Lfor { for_id     = ident
+             ; for_loc    = loc
              ; for_from   = start.var
              ; for_to     = stop.var
              ; for_dir    = direction
@@ -483,6 +484,7 @@ let iterator ~transl_exp ~scopes ~loc
         (* for iter_ix = 0 to Array.length iter_arr - 1 ... *)
         (* CR layouts v4: will need updating when we allow non-values in arrays. *)
         Lfor { for_id     = iter_ix
+             ; for_loc    = loc
              ; for_from   = l0
              ; for_to     = iter_len.var - l1
              ; for_dir    = Upto

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -691,6 +691,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let body = transl_exp ~scopes for_body_sort for_body in
       Lfor {
         for_id;
+        for_loc = of_location ~scopes e.exp_loc;
         for_from = transl_exp ~scopes Jkind.Sort.for_predef_value for_from;
         for_to = transl_exp ~scopes Jkind.Sort.for_predef_value for_to;
         for_dir;


### PR DESCRIPTION
This started out as an attempt to improve the debuginfo on `for`-loops in flambda2, which currently don't have any location information, and about which there have (quite reasonably) been complaints.

For example in the following fragment, there is no debuginfo on either the conditional immediately prior to the first iteration or on the conditional at each iteration!  This means that, for example, this latter conditional will end up adopting the last debuginfo that happens to come from the body of the loop.
```
let[@inline] poke buf ~pos c = Bigarray.Array1.unsafe_set buf pos c

let fill buf len c =
  for i = 0 to len do
    poke buf ~pos:i c
  done
```

This patch fixes this.  In order to do that, I've had to fix many places in the backend where debuginfo was just getting dropped, although the changes are almost all individually trivial.  In addition I added some extra debug info propagation for spills and reloads.  So in fact, this should pretty much improve debuginfo across the board.  It is only intended to work with flambda2.

This also fixes what appears to be a bug where we were failing to add the inlined debuginfo during `To_cmm`'s processing of `Switch` expressions.

Linearized code after this PR for the above example:
```
camlFor_loc__fill_1_3_code: {for_loc.ml:3,9-71}
  prologue
  buf/45[%rax] := R/0[%rax]
  len/46[%rbx] := R/1[%rbx]
  c/47[%rdi] := R/2[%rdi]
  if len/46[%rbx] <s 1 goto L107 {for_loc.ml:4,2-50}   <-- important debuginfo
  spilled-c/58[s[i:1]] := c/47[%rdi] (spill)
  spilled-len/56[s[i:3]] := len/46[%rbx] (spill)
  spilled-buf/59[s[i:0]] := buf/45[%rax] (spill)
  I/50[%rsi] := 1
  I/51[%rsi] := I/50[%rsi]
  i/49[%rsi] := I/51[%rsi]
  spilled-i/57[s[i:2]] := i/49[%rsi] (spill)
  L108:
  buf/60[%rdi] := spilled-buf/59[s[i:0]] (reload)
  R/2[%rdi] := buf/60[%rdi]
  R/3[%rsi] := i/49[%rsi]
  c/61[%rdx] := spilled-c/58[s[i:1]] (reload)
  R/4[%rdx] := c/61[%rdx]
  {spilled-len/56[s[i:3]] spilled-i/57[s[i:2]] spilled-c/58[s[i:1]]* spilled-buf/59[s[i:0]]*}
  R/0[%rax] := extcall "caml_ba_set_1" R/2[%rdi] R/3[%rsi] R/4[%rdx] {for_loc.ml:5,4-21;for_loc.ml:1,31-67}
  i/49[%rsi] := spilled-i/57[s[i:2]] (reload) {for_loc.ml:4,2-50}   <-- important debuginfo
  len/63[%rax] := spilled-len/56[s[i:3]] (reload) {for_loc.ml:4,2-50}
  if i/49[%rsi] ==s len/63[%rax] goto L112 {for_loc.ml:4,2-50}
  I/54[%rsi] := i/49[%rsi]
  I/54[%rsi] := I/54[%rsi] + 2 {for_loc.ml:4,2-50}
  I/55[%rsi] := I/54[%rsi]
  i/49[%rsi] := I/55[%rsi]
  spilled-i/57[s[i:2]] := i/49[%rsi] (spill)
  goto L108
  L112:
  I/53[%rax] := 1
  R/0[%rax] := I/53[%rax]
  reload retaddr
  return R/0[%rax]
  L107:
  I/48[%rax] := 1
  R/0[%rax] := I/48[%rax]
  reload retaddr
  return R/0[%rax]
```