### PR TITLE
Enable ocamlformat for Jane Syntax / language extensions code

### DIFF
--- a/ocaml/parsing/.ocamlformat
+++ b/ocaml/parsing/.ocamlformat
@@ -1,0 +1,17 @@
+# Please make a pull request to change this file.
+disable=true
+# There is an .ocamlformat-enable file in this directory.
+# Keep the remainder of this file in sync with other .ocamlformat files in this repo.
+assignment-operator=begin-line
+cases-exp-indent=2
+doc-comments=before
+dock-collection-brackets=false
+if-then-else=keyword-first
+module-item-spacing=sparse
+parens-tuple=multi-line-only
+sequence-blank-line=compact
+space-around-lists=false
+space-around-variants=false
+type-decl=sparse
+wrap-comments=false
+version=0.24.1

--- a/ocaml/parsing/.ocamlformat
+++ b/ocaml/parsing/.ocamlformat
@@ -13,5 +13,9 @@ sequence-blank-line=compact
 space-around-lists=false
 space-around-variants=false
 type-decl=sparse
-wrap-comments=false
 version=0.24.1
+
+# The existing comments are hand-formatted and lose a lot of readability
+# if we wrap them. We should either convert the comments we care about to
+# doc comments, or make this same setting change everywhere.
+wrap-comments=false

--- a/ocaml/parsing/.ocamlformat-enable
+++ b/ocaml/parsing/.ocamlformat-enable
@@ -1,0 +1,5 @@
+jane_syntax.ml
+jane_syntax.mli
+jane_syntax_parsing.ml
+jane_syntax_parsing.mli
+jane_asttypes.mli

--- a/ocaml/parsing/jane_asttypes.mli
+++ b/ocaml/parsing/jane_asttypes.mli
@@ -25,7 +25,6 @@
 
 *)
 
-
 open Asttypes
 
 type global_flag =

--- a/ocaml/parsing/jane_syntax.mli
+++ b/ocaml/parsing/jane_syntax.mli
@@ -44,38 +44,40 @@
 (** The ASTs for list and array comprehensions *)
 module Comprehensions : sig
   type iterator =
-    | Range of { start     : Parsetree.expression
-               ; stop      : Parsetree.expression
-               ; direction : Asttypes.direction_flag }
-    (** "= START to STOP" (direction = Upto)
+    | Range of
+        { start : Parsetree.expression;
+          stop : Parsetree.expression;
+          direction : Asttypes.direction_flag
+        }
+        (** "= START to STOP" (direction = Upto)
         "= START downto STOP" (direction = Downto) *)
-    | In of Parsetree.expression
-    (** "in EXPR" *)
+    | In of Parsetree.expression  (** "in EXPR" *)
 
   (* In [Typedtree], the [pattern] moves into the [iterator]. *)
+
+  (** [@...] PAT (in/=) ... *)
   type clause_binding =
-    { pattern    : Parsetree.pattern
-    ; iterator   : iterator
-    ; attributes : Parsetree.attribute list }
-    (** [@...] PAT (in/=) ... *)
+    { pattern : Parsetree.pattern;
+      iterator : iterator;
+      attributes : Parsetree.attribute list
+    }
 
   type clause =
     | For of clause_binding list
-    (** "for PAT (in/=) ... and PAT (in/=) ... and ..."; must be nonempty *)
-    | When of Parsetree.expression
-    (** "when EXPR" *)
+        (** "for PAT (in/=) ... and PAT (in/=) ... and ..."; must be nonempty *)
+    | When of Parsetree.expression  (** "when EXPR" *)
 
   type comprehension =
-    { body : Parsetree.expression
-    (** The body/generator of the comprehension *)
-    ; clauses : clause list
-    (** The clauses of the comprehension; must be nonempty *) }
+    { body : Parsetree.expression;
+          (** The body/generator of the comprehension *)
+      clauses : clause list
+          (** The clauses of the comprehension; must be nonempty *)
+    }
 
   type expression =
-    | Cexp_list_comprehension  of comprehension
-    (** [BODY ...CLAUSES...] *)
+    | Cexp_list_comprehension of comprehension  (** [BODY ...CLAUSES...] *)
     | Cexp_array_comprehension of Asttypes.mutable_flag * comprehension
-    (** [|BODY ...CLAUSES...|] (flag = Mutable)
+        (** [|BODY ...CLAUSES...|] (flag = Mutable)
         [:BODY ...CLAUSES...:] (flag = Immutable)
           (only allowed with [-extension immutable_arrays]) *)
 
@@ -88,18 +90,17 @@ end
 module Immutable_arrays : sig
   type expression =
     | Iaexp_immutable_array of Parsetree.expression list
-    (** [: E1; ...; En :] *)
+        (** [: E1; ...; En :] *)
 
   type pattern =
-    | Iapat_immutable_array of Parsetree.pattern list
-    (** [: P1; ...; Pn :] **)
+    | Iapat_immutable_array of Parsetree.pattern list  (** [: P1; ...; Pn :] **)
 
   val expr_of : loc:Location.t -> expression -> Parsetree.expression
+
   val pat_of : loc:Location.t -> pattern -> Parsetree.pattern
 end
 
 module N_ary_functions : sig
-
   (** These types use the [P] prefix to match how they are represented in the
       upstream compiler *)
 
@@ -107,7 +108,7 @@ module N_ary_functions : sig
   type function_body =
     | Pfunction_body of Parsetree.expression
     | Pfunction_cases of Parsetree.case list * Location.t * Parsetree.attributes
-    (** In [Pfunction_cases (_, loc, attrs)], the location extends from the
+        (** In [Pfunction_cases (_, loc, attrs)], the location extends from the
         start of the [function] keyword to the end of the last case. The
         compiler will only use typechecking-related attributes from [attrs],
         e.g. enabling or disabling a warning.
@@ -116,7 +117,7 @@ module N_ary_functions : sig
   type function_param_desc =
     | Pparam_val of
         Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern
-    (** [Pparam_val (lbl, exp0, P)] represents the parameter:
+        (** [Pparam_val (lbl, exp0, P)] represents the parameter:
         - [P]
           when [lbl] is {{!Asttypes.arg_label.Nolabel}[Nolabel]}
           and [exp0] is [None]
@@ -135,7 +136,7 @@ module N_ary_functions : sig
     *)
     | Pparam_newtype of
         string Asttypes.loc * Jane_asttypes.layout_annotation option
-    (** [Pparam_newtype (x, layout)] represents the parameter [(type x)].
+        (** [Pparam_newtype (x, layout)] represents the parameter [(type x)].
         [x] carries the location of the identifier, whereas [pparam_loc] is
         the location of the [(type x)] as a whole.
 
@@ -156,8 +157,8 @@ module N_ary_functions : sig
     *)
 
   type function_param =
-    { pparam_desc : function_param_desc
-    ; pparam_loc : Location.t
+    { pparam_desc : function_param_desc;
+      pparam_loc : Location.t
     }
 
   type type_constraint =
@@ -174,8 +175,8 @@ module N_ary_functions : sig
     | Once
 
   type function_constraint =
-    { mode_annotations: mode_annotation Location.loc list;
-      type_constraint: type_constraint;
+    { mode_annotations : mode_annotation Location.loc list;
+      type_constraint : type_constraint
     }
 
   (** [([P1; ...; Pn], C, body)] represents any construct
@@ -202,20 +203,21 @@ end
     these into the existing [P{sig,str}_include] constructors (similar to what
     we did with [T{sig,str}_include], but without depending on typechecking). *)
 module Include_functor : sig
-  type signature_item =
-    | Ifsig_include_functor of Parsetree.include_description
+  type signature_item = Ifsig_include_functor of Parsetree.include_description
 
-  type structure_item =
-    | Ifstr_include_functor of Parsetree.include_declaration
+  type structure_item = Ifstr_include_functor of Parsetree.include_declaration
 
   val sig_item_of : loc:Location.t -> signature_item -> Parsetree.signature_item
+
   val str_item_of : loc:Location.t -> structure_item -> Parsetree.structure_item
 end
 
 (** The ASTs for module type strengthening. *)
 module Strengthen : sig
   type module_type =
-    { mty : Parsetree.module_type; mod_id : Longident.t Location.loc }
+    { mty : Parsetree.module_type;
+      mod_id : Longident.t Location.loc
+    }
 
   val mty_of : loc:Location.t -> module_type -> Parsetree.module_type
 end
@@ -230,13 +232,12 @@ module Layouts : sig
     (* examples: [ #2.0 ] or [ #42L ] *)
     (* This is represented as an attribute wrapping a [Pexp_constant] node. *)
     | Lexp_constant of constant
-
     (* [fun (type a : immediate) -> ...] *)
     (* This is represented as an attribute wrapping a [Pexp_newtype] node. *)
     | Lexp_newtype of
-        string Location.loc *
-        Jane_asttypes.layout_annotation *
-        Parsetree.expression
+        string Location.loc
+        * Jane_asttypes.layout_annotation
+        * Parsetree.expression
 
   type nonrec pattern =
     (* examples: [ #2.0 ] or [ #42L ] *)
@@ -247,9 +248,10 @@ module Layouts : sig
     (* ['a : immediate] or [_ : float64] *)
     (* This is represented by an attribute wrapping either a [Ptyp_any] or
        a [Ptyp_var] node. *)
-    | Ltyp_var of { name : string option
-                  ; layout : Jane_asttypes.layout_annotation }
-
+    | Ltyp_var of
+        { name : string option;
+          layout : Jane_asttypes.layout_annotation
+        }
     (* [('a : immediate) 'b 'c ('d : value). 'a -> 'b -> 'c -> 'd] *)
     (* This is represented by an attribute wrapping a [Ptyp_poly] node. *)
     (* This is used instead of [Ptyp_poly] only where there is at least one
@@ -257,17 +259,20 @@ module Layouts : sig
        annotations at all, [Ptyp_poly] is used instead. This saves space in the
        parsed representation and guarantees that we don't accidentally try to
        require the layouts extension. *)
-    | Ltyp_poly of { bound_vars : (string Location.loc *
-                                   Jane_asttypes.layout_annotation option) list
-                   ; inner_type : Parsetree.core_type }
-
+    | Ltyp_poly of
+        { bound_vars :
+            (string Location.loc * Jane_asttypes.layout_annotation option) list;
+          inner_type : Parsetree.core_type
+        }
     (* [ty as ('a : immediate)] *)
     (* This is represented by an attribute wrapping either a [Ptyp_alias] node
        or, in the [ty as (_ : layout)] case, the annotated type itself, with no
        intervening [type_desc]. *)
-    | Ltyp_alias of { aliased_type : Parsetree.core_type
-                    ; name : string option
-                    ; layout : Jane_asttypes.layout_annotation }
+    | Ltyp_alias of
+        { aliased_type : Parsetree.core_type;
+          name : string option;
+          layout : Jane_asttypes.layout_annotation
+        }
 
   type nonrec extension_constructor =
     (* [ 'a ('b : immediate) ('c : float64). 'a * 'b * 'c -> exception ] *)
@@ -275,13 +280,12 @@ module Layouts : sig
     (* Like [Ltyp_poly], this is used only when there is at least one layout
        annotation. Otherwise, we will have a [Pext_decl]. *)
     | Lext_decl of
-        (string Location.loc * Jane_asttypes.layout_annotation option) list *
-        Parsetree.constructor_arguments *
-        Parsetree.core_type option
+        (string Location.loc * Jane_asttypes.layout_annotation option) list
+        * Parsetree.constructor_arguments
+        * Parsetree.core_type option
 
   module Pprint : sig
-    val const_layout :
-      Format.formatter -> Jane_asttypes.const_layout -> unit
+    val const_layout : Format.formatter -> Jane_asttypes.const_layout -> unit
 
     val layout_annotation :
       Format.formatter -> Jane_asttypes.layout_annotation -> unit
@@ -304,11 +308,15 @@ module Layouts : sig
   (** See also [Ast_helper.Type.constructor], which is a direct inspiration for
       the interface here. It's meant to be able to be a drop-in replacement.  *)
   val constructor_declaration_of :
-    loc:Location.t -> attrs:Parsetree.attributes -> info:Docstrings.info ->
-    vars_layouts:(string Location.loc *
-                  Jane_asttypes.layout_annotation option) list ->
-    args:Parsetree.constructor_arguments -> res:Parsetree.core_type option ->
-    string Location.loc -> Parsetree.constructor_declaration
+    loc:Location.t ->
+    attrs:Parsetree.attributes ->
+    info:Docstrings.info ->
+    vars_layouts:
+      (string Location.loc * Jane_asttypes.layout_annotation option) list ->
+    args:Parsetree.constructor_arguments ->
+    res:Parsetree.core_type option ->
+    string Location.loc ->
+    Parsetree.constructor_declaration
 
   (** Extract the layouts from a [constructor_declaration]; returns leftover
       attributes along with the annotated variables. Unlike other pieces
@@ -316,8 +324,9 @@ module Layouts : sig
       the remaining pieces of the original [constructor_declaration]. *)
   val of_constructor_declaration :
     Parsetree.constructor_declaration ->
-    ((string Location.loc * Jane_asttypes.layout_annotation option) list *
-     Parsetree.attributes) option
+    ((string Location.loc * Jane_asttypes.layout_annotation option) list
+    * Parsetree.attributes)
+    option
 end
 
 (******************************************)
@@ -398,12 +407,12 @@ end
 
 (** Novel syntax in types *)
 module Core_type : sig
-  type t =
-    | Jtyp_layout of Layouts.core_type
+  type t = Jtyp_layout of Layouts.core_type
 
-  include AST
-    with type t := t * Parsetree.attributes
-     and type ast := Parsetree.core_type
+  include
+    AST
+      with type t := t * Parsetree.attributes
+       and type ast := Parsetree.core_type
 
   val core_type_of :
     loc:Location.t -> attrs:Parsetree.attributes -> t -> Parsetree.core_type
@@ -414,9 +423,10 @@ end
 module Constructor_argument : sig
   type t = |
 
-  include AST
-    with type t := t * Parsetree.attributes
-     and type ast := Parsetree.core_type
+  include
+    AST
+      with type t := t * Parsetree.attributes
+       and type ast := Parsetree.core_type
 end
 
 (** Novel syntax in expressions *)
@@ -427,9 +437,10 @@ module Expression : sig
     | Jexp_layout of Layouts.expression
     | Jexp_n_ary_function of N_ary_functions.expression
 
-  include AST
-    with type t := t * Parsetree.attributes
-     and type ast := Parsetree.expression
+  include
+    AST
+      with type t := t * Parsetree.attributes
+       and type ast := Parsetree.expression
 
   val expr_of :
     loc:Location.t -> attrs:Parsetree.attributes -> t -> Parsetree.expression
@@ -441,9 +452,10 @@ module Pattern : sig
     | Jpat_immutable_array of Immutable_arrays.pattern
     | Jpat_layout of Layouts.pattern
 
-  include AST
-    with type t := t * Parsetree.attributes
-     and type ast := Parsetree.pattern
+  include
+    AST
+      with type t := t * Parsetree.attributes
+       and type ast := Parsetree.pattern
 
   val pat_of :
     loc:Location.t -> attrs:Parsetree.attributes -> t -> Parsetree.pattern
@@ -451,12 +463,12 @@ end
 
 (** Novel syntax in module types *)
 module Module_type : sig
-  type t =
-    | Jmty_strengthen of Strengthen.module_type
+  type t = Jmty_strengthen of Strengthen.module_type
 
-  include AST
-    with type t := t * Parsetree.attributes
-     and type ast := Parsetree.module_type
+  include
+    AST
+      with type t := t * Parsetree.attributes
+       and type ast := Parsetree.module_type
 
   val mty_of :
     loc:Location.t -> attrs:Parsetree.attributes -> t -> Parsetree.module_type
@@ -464,30 +476,33 @@ end
 
 (** Novel syntax in signature items *)
 module Signature_item : sig
-  type t =
-    | Jsig_include_functor of Include_functor.signature_item
+  type t = Jsig_include_functor of Include_functor.signature_item
 
   include AST with type t := t and type ast := Parsetree.signature_item
 end
 
 (** Novel syntax in structure items *)
 module Structure_item : sig
-  type t =
-    | Jstr_include_functor of Include_functor.structure_item
+  type t = Jstr_include_functor of Include_functor.structure_item
 
   include AST with type t := t and type ast := Parsetree.structure_item
 end
 
 (** Novel syntax in extension constructors *)
 module Extension_constructor : sig
-  type t =
-    | Jext_layout of Layouts.extension_constructor
+  type t = Jext_layout of Layouts.extension_constructor
 
-  include AST with type t := t * Parsetree.attributes
-               and type ast := Parsetree.extension_constructor
+  include
+    AST
+      with type t := t * Parsetree.attributes
+       and type ast := Parsetree.extension_constructor
 
   val extension_constructor_of :
-    loc:Location.t -> name:string Location.loc -> attrs:Parsetree.attributes ->
-    ?info:Docstrings.info -> ?docs:Docstrings.docs -> t ->
+    loc:Location.t ->
+    name:string Location.loc ->
+    attrs:Parsetree.attributes ->
+    ?info:Docstrings.info ->
+    ?docs:Docstrings.docs ->
+    t ->
     Parsetree.extension_constructor
 end

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -85,9 +85,10 @@ open Parsetree
 *)
 module Language_extension = struct
   include Language_extension_kernel
+
   include (
-    Language_extension
-      : Language_extension_kernel.Language_extension_for_jane_syntax)
+    Language_extension :
+      Language_extension_kernel.Language_extension_for_jane_syntax)
 end
 
 (******************************************************************************)
@@ -109,8 +110,9 @@ module Feature : sig
 
   val is_erasable : t -> bool
 end = struct
-  type t = Language_extension : _ Language_extension.t -> t
-         | Builtin
+  type t =
+    | Language_extension : _ Language_extension.t -> t
+    | Builtin
 
   type error =
     | Disabled_extension : _ Language_extension.t -> error
@@ -120,25 +122,23 @@ end = struct
 
   let describe_uppercase = function
     | Language_extension ext ->
-        "The extension \"" ^ Language_extension.to_string ext ^ "\""
-    | Builtin ->
-        "Built-in syntax"
+      "The extension \"" ^ Language_extension.to_string ext ^ "\""
+    | Builtin -> "Built-in syntax"
 
   let extension_component = function
     | Language_extension ext -> Language_extension.to_string ext
     | Builtin -> builtin_component
 
   let of_component str =
-    if String.equal str builtin_component then
-      Ok Builtin
+    if String.equal str builtin_component
+    then Ok Builtin
     else
       match Language_extension.of_string str with
       | Some (Pack ext) ->
-          if Language_extension.is_enabled ext
-          then Ok (Language_extension ext)
-          else Error (Disabled_extension ext)
-      | None ->
-          Error (Unknown_extension str)
+        if Language_extension.is_enabled ext
+        then Ok (Language_extension ext)
+        else Error (Disabled_extension ext)
+      | None -> Error (Unknown_extension str)
 
   let is_erasable = function
     | Language_extension ext -> Language_extension.is_erasable ext
@@ -168,10 +168,7 @@ module Embedding_syntax = struct
     | Attribute -> "attributes"
 
   let pp ppf (t, name) =
-    let sigil = match t with
-      | Extension_node -> "%"
-      | Attribute -> "@"
-    in
+    let sigil = match t with Extension_node -> "%" | Attribute -> "@" in
     Format.fprintf ppf "[%s%s]" sigil name
 end
 
@@ -187,9 +184,8 @@ module Misnamed_embedding_error = struct
     | No_erasability -> "Missing erasability and feature components"
     | No_feature -> "Missing a feature component"
     | Unknown_erasability str ->
-        Printf.sprintf
-          "Unrecognized component where erasability was expected: `%s'"
-          str
+      Printf.sprintf
+        "Unrecognized component where erasability was expected: `%s'" str
 end
 
 (** The component of an attribute or extension name that identifies whether or
@@ -231,7 +227,6 @@ end
     nodes or attributes for modular syntax; see the .mli file for more
     details. *)
 module Embedded_name : sig
-
   (** A nonempty list of name components, without the first two components.
       (That is, without the leading root component that identifies it as part of
       the modular syntax mechanism, and without the next component that
@@ -239,8 +234,8 @@ module Embedded_name : sig
   type components = ( :: ) of string * string list
 
   type t =
-    { erasability : Erasability.t
-    ; components : components
+    { erasability : Erasability.t;
+      components : components
     }
 
   (** See the mli. *)
@@ -294,8 +289,8 @@ end = struct
   type components = ( :: ) of string * string list
 
   type t =
-    { erasability : Erasability.t
-    ; components : components
+    { erasability : Erasability.t;
+      components : components
     }
 
   let of_feature feature trailing_components =
@@ -308,23 +303,20 @@ end = struct
   let components t = t.components
 
   let to_string { erasability; components = feat :: subparts } =
-    String.concat
-      separator_str
+    String.concat separator_str
       (root :: Erasability.to_string erasability :: feat :: subparts)
 
   let of_string str : (t, Misnamed_embedding_error.t) result option =
     match String.split_on_char separator str with
-    | root' :: parts when String.equal root root' -> begin
-        match parts with
-        | [] -> Some (Error No_erasability)
-        | [_] -> Some (Error No_feature)
-        | erasability :: feat :: subparts -> begin
-            match Erasability.of_string erasability with
-            | Ok erasability ->
-                Some (Ok { erasability; components = feat :: subparts })
-            | Error () -> Some (Error (Unknown_erasability erasability))
-         end
-      end
+    | root' :: parts when String.equal root root' -> (
+      match parts with
+      | [] -> Some (Error No_erasability)
+      | [_] -> Some (Error No_feature)
+      | erasability :: feat :: subparts -> (
+        match Erasability.of_string erasability with
+        | Ok erasability ->
+          Some (Ok { erasability; components = feat :: subparts })
+        | Error () -> Some (Error (Unknown_erasability erasability))))
     | _ :: _ | [] -> None
 
   let pp_quoted_name ppf t = Format.fprintf ppf "\"%s\"" (to_string t)
@@ -338,13 +330,13 @@ module Error = struct
   (** An error triggered when desugaring a language extension from an OCaml
       AST; should always be fatal *)
   type error =
-    | Introduction_has_payload of
-        Embedding_syntax.t * Embedded_name.t * payload
+    | Introduction_has_payload of Embedding_syntax.t * Embedded_name.t * payload
     | Unknown_extension of Embedding_syntax.t * Erasability.t * string
     | Disabled_extension :
-        { ext : _ Language_extension.t
-        ; maturity : Language_extension.maturity option
-        } -> error
+        { ext : _ Language_extension.t;
+          maturity : Language_extension.maturity option
+        }
+        -> error
     | Wrong_syntactic_category of Feature.t * string
     | Misnamed_embedding of
         Misnamed_embedding_error.t * string * Embedding_syntax.t
@@ -357,81 +349,65 @@ end
 
 open Error
 
-let assert_extension_enabled
-    (type a) ~loc (ext : a Language_extension.t) (setting : a)
-  =
-  if not (Language_extension.is_at_least ext setting) then
+let assert_extension_enabled (type a) ~loc (ext : a Language_extension.t)
+    (setting : a) =
+  if not (Language_extension.is_at_least ext setting)
+  then
     let maturity : Language_extension.maturity option =
       match ext with
       | Layouts -> Some (setting : Language_extension.maturity)
       | _ -> None
     in
-    raise (Error(loc, Disabled_extension { ext; maturity }))
-;;
+    raise (Error (loc, Disabled_extension { ext; maturity }))
 
 let report_error ~loc = function
   | Introduction_has_payload (what, name, _payload) ->
-       Location.errorf
-            ~loc
-            "@[Modular syntax %s are not allowed to have a payload,@ \
-             but %a does@]"
-          (Embedding_syntax.name_plural what)
-          Embedded_name.pp_quoted_name name
+    Location.errorf ~loc
+      "@[Modular syntax %s are not allowed to have a payload,@ but %a does@]"
+      (Embedding_syntax.name_plural what)
+      Embedded_name.pp_quoted_name name
   | Unknown_extension (what, erasability, name) ->
-      let embedded_name = { Embedded_name.erasability; components = [name] } in
-      Location.errorf
-        ~loc
-        "@[Unknown extension \"%s\" referenced via@ %a %s@]"
-        name
-        Embedded_name.pp_a_term (what, embedded_name)
-        (Embedding_syntax.name what)
-  | Disabled_extension { ext; maturity } -> begin
-      (* CR layouts: The [maturity] special case is a bit ad-hoc, but the
-         layouts error message would be much worse without it. It also
-         would be nice to mention the language construct in the error message.
-      *)
-      match maturity with
-      | None ->
-          Location.errorf
-            ~loc
-            "The extension \"%s\" is disabled and cannot be used"
-            (Language_extension.to_string ext)
-      | Some maturity ->
-          Location.errorf
-            ~loc
-            "This construct requires the %s version of the extension \"%s\", \
-             which is disabled and cannot be used"
-            (Language_extension.maturity_to_string maturity)
-            (Language_extension.to_string ext)
-    end
-  | Wrong_syntactic_category(feat, cat) ->
-      Location.errorf
-        ~loc
-        "%s cannot appear in %s"
-        (Feature.describe_uppercase feat)
-        cat
+    let embedded_name = { Embedded_name.erasability; components = [name] } in
+    Location.errorf ~loc "@[Unknown extension \"%s\" referenced via@ %a %s@]"
+      name Embedded_name.pp_a_term (what, embedded_name)
+      (Embedding_syntax.name what)
+  | Disabled_extension { ext; maturity } -> (
+    (* CR layouts: The [maturity] special case is a bit ad-hoc, but the
+       layouts error message would be much worse without it. It also
+       would be nice to mention the language construct in the error message.
+    *)
+    match maturity with
+    | None ->
+      Location.errorf ~loc "The extension \"%s\" is disabled and cannot be used"
+        (Language_extension.to_string ext)
+    | Some maturity ->
+      Location.errorf ~loc
+        "This construct requires the %s version of the extension \"%s\", which \
+         is disabled and cannot be used"
+        (Language_extension.maturity_to_string maturity)
+        (Language_extension.to_string ext))
+  | Wrong_syntactic_category (feat, cat) ->
+    Location.errorf ~loc "%s cannot appear in %s"
+      (Feature.describe_uppercase feat)
+      cat
   | Misnamed_embedding (err, name, what) ->
-      Location.errorf
-        ~loc
-        "Cannot have %s named %a: %s"
-        (Embedding_syntax.name_indefinite what)
-        Embedding_syntax.pp (what, name)
-        (Misnamed_embedding_error.to_string err)
-  | Bad_introduction(what, ({ components = ext :: _; _ } as name)) ->
-      Location.errorf
-        ~loc
-        "@[The extension \"%s\" was referenced improperly; it started with@ \
-         %a %s,@ not %a one@]"
-        ext
-        Embedded_name.pp_a_term (what, name)
-        (Embedding_syntax.name what)
-        Embedded_name.pp_a_term (what, { name with components = [ext] })
+    Location.errorf ~loc "Cannot have %s named %a: %s"
+      (Embedding_syntax.name_indefinite what)
+      Embedding_syntax.pp (what, name)
+      (Misnamed_embedding_error.to_string err)
+  | Bad_introduction (what, ({ components = ext :: _; _ } as name)) ->
+    Location.errorf ~loc
+      "@[The extension \"%s\" was referenced improperly; it started with@ %a \
+       %s,@ not %a one@]"
+      ext Embedded_name.pp_a_term (what, name)
+      (Embedding_syntax.name what)
+      Embedded_name.pp_a_term
+      (what, { name with components = [ext] })
 
 let () =
-  Location.register_error_of_exn
-    (function
-      | Error(loc, err) -> Some (report_error ~loc err)
-      | _ -> None)
+  Location.register_error_of_exn (function
+    | Error (loc, err) -> Some (report_error ~loc err)
+    | _ -> None)
 
 (******************************************************************************)
 (** Generically find and create the OCaml AST syntax used to encode one of our
@@ -465,8 +441,7 @@ module type AST_internal = sig
 
   val embedding_syntax : Embedding_syntax.t
 
-  val make_jane_syntax :
-    Embedded_name.t -> ?payload:payload -> ast -> ast
+  val make_jane_syntax : Embedded_name.t -> ?payload:payload -> ast -> ast
 
   (** Given an AST node, check if it's a representation of a term from one of
       our novel syntactic features; if it is, split it back up into its name,
@@ -486,7 +461,8 @@ let parse_embedding_exn ~loc ~name ~embedding_syntax =
   let raise_error err = raise (Error (loc, err)) in
   match Embedded_name.of_string name with
   | Some (Ok name) -> Some name
-  | Some (Error err) -> raise_error (Misnamed_embedding (err, name, embedding_syntax))
+  | Some (Error err) ->
+    raise_error (Misnamed_embedding (err, name, embedding_syntax))
   | None -> None
 
 let find_and_remove_jane_syntax_attribute =
@@ -494,113 +470,98 @@ let find_and_remove_jane_syntax_attribute =
   let rec loop ~rev_prefix ~suffix =
     match rev_prefix with
     | [] -> None
-    | attr :: rev_prefix ->
-        let { attr_name = { txt = name; loc = attr_loc }; attr_payload } =
-          attr
-        in
-        begin
-          match
-            parse_embedding_exn ~loc:attr_loc ~name ~embedding_syntax:Attribute
-          with
-          | None -> loop ~rev_prefix ~suffix:(attr :: suffix)
-          | Some name ->
-              let unconsumed_attributes = List.rev_append rev_prefix suffix in
-              Some (name, attr_loc, attr_payload, unconsumed_attributes)
-        end
+    | attr :: rev_prefix -> (
+      let { attr_name = { txt = name; loc = attr_loc }; attr_payload } = attr in
+      match
+        parse_embedding_exn ~loc:attr_loc ~name ~embedding_syntax:Attribute
+      with
+      | None -> loop ~rev_prefix ~suffix:(attr :: suffix)
+      | Some name ->
+        let unconsumed_attributes = List.rev_append rev_prefix suffix in
+        Some (name, attr_loc, attr_payload, unconsumed_attributes))
   in
   fun attributes -> loop ~rev_prefix:(List.rev attributes) ~suffix:[]
-;;
 
 let make_jane_syntax_attribute name payload =
   { attr_name =
-      { txt = Embedded_name.to_string name
-      ; loc = !Ast_helper.default_loc
-      }
-  ; attr_loc = !Ast_helper.default_loc
-  ; attr_payload = payload
+      { txt = Embedded_name.to_string name; loc = !Ast_helper.default_loc };
+    attr_loc = !Ast_helper.default_loc;
+    attr_payload = payload
   }
 
 (** For a syntactic category, produce translations into and out of
     our novel syntax, using parsetree attributes as the encoding.
 *)
-module Make_with_attribute
-    (AST_syntactic_category : sig
-       include AST_syntactic_category
+module Make_with_attribute (AST_syntactic_category : sig
+  include AST_syntactic_category
 
-       val attributes : ast -> attributes
-       val with_attributes : ast -> attributes -> ast
-     end) : AST_internal with type ast = AST_syntactic_category.ast
-= struct
-    include AST_syntactic_category
+  val attributes : ast -> attributes
 
-    let embedding_syntax = Embedding_syntax.Attribute
+  val with_attributes : ast -> attributes -> ast
+end) : AST_internal with type ast = AST_syntactic_category.ast = struct
+  include AST_syntactic_category
 
-    let make_jane_syntax name ?(payload = PStr []) ast =
-      let attr = make_jane_syntax_attribute name payload in
-      (* See Note [Outer attributes at end] in jane_syntax.ml *)
-      with_attributes ast (attributes ast @ [ attr ])
+  let embedding_syntax = Embedding_syntax.Attribute
 
-    let match_jane_syntax ast =
-      match find_and_remove_jane_syntax_attribute (attributes ast) with
-      | None -> None
-      | Some (name, loc, payload, attrs) ->
-        Some (name, loc, payload, with_attributes ast attrs)
+  let make_jane_syntax name ?(payload = PStr []) ast =
+    let attr = make_jane_syntax_attribute name payload in
+    (* See Note [Outer attributes at end] in jane_syntax.ml *)
+    with_attributes ast (attributes ast @ [attr])
+
+  let match_jane_syntax ast =
+    match find_and_remove_jane_syntax_attribute (attributes ast) with
+    | None -> None
+    | Some (name, loc, payload, attrs) ->
+      Some (name, loc, payload, with_attributes ast attrs)
 end
 
 (** For a syntactic category, produce translations into and out of
     our novel syntax, using extension nodes as the encoding.
 *)
-module Make_with_extension_node
-    (AST_syntactic_category : sig
-       include AST_syntactic_category
+module Make_with_extension_node (AST_syntactic_category : sig
+  include AST_syntactic_category
 
-       (** How to construct an extension node for this AST (something of the
+  (** How to construct an extension node for this AST (something of the
           shape [[%name]]). Should just be [Ast_helper.CAT.extension] for the
           appropriate syntactic category [CAT]. (This means that [?loc] should
           default to [!Ast_helper.default_loc.].) *)
-      val make_extension_node :
-        ?loc:Location.t -> ?attrs:attributes -> extension -> ast
+  val make_extension_node :
+    ?loc:Location.t -> ?attrs:attributes -> extension -> ast
 
-      (** Given an extension node (as created by [make_extension_node]) with an
+  (** Given an extension node (as created by [make_extension_node]) with an
           appropriately-formed name and a body, combine them into the special
           syntactic form we use for novel syntactic features in this syntactic
           category. Partial inverse of [match_extension_use]. *)
-      val make_extension_use  : extension_node:ast -> ast -> ast
+  val make_extension_use : extension_node:ast -> ast -> ast
 
-      (** Given an AST node, check if it's of the special syntactic form
+  (** Given an AST node, check if it's of the special syntactic form
           indicating that this is one of our novel syntactic features (as
           created by [make_extension_node]), split it back up into the extension
           node and the possible body. Doesn't do any checking about the
           name/format of the extension or the possible body terms (for which see
           [AST.match_extension]). Partial inverse of [make_extension_use]. *)
-      val match_extension_use : ast -> (extension * ast) option
-     end) : AST_internal with type ast = AST_syntactic_category.ast =
-  struct
-    include AST_syntactic_category
+  val match_extension_use : ast -> (extension * ast) option
+end) : AST_internal with type ast = AST_syntactic_category.ast = struct
+  include AST_syntactic_category
 
-    let embedding_syntax = Embedding_syntax.Extension_node
+  let embedding_syntax = Embedding_syntax.Extension_node
 
-    let make_jane_syntax name ?(payload = PStr []) ast =
-      make_extension_use
-        ast
-        ~extension_node:
-          (make_extension_node
-             ({ txt = Embedded_name.to_string name
-              ; loc = !Ast_helper.default_loc },
-              payload))
+  let make_jane_syntax name ?(payload = PStr []) ast =
+    make_extension_use ast
+      ~extension_node:
+        (make_extension_node
+           ( { txt = Embedded_name.to_string name;
+               loc = !Ast_helper.default_loc
+             },
+             payload ))
 
-    let match_jane_syntax ast =
-      match match_extension_use ast with
+  let match_jane_syntax ast =
+    match match_extension_use ast with
+    | None -> None
+    | Some (({ txt = name; loc = ext_loc }, ext_payload), body) -> (
+      match parse_embedding_exn ~loc:ext_loc ~name ~embedding_syntax with
       | None -> None
-      | Some (({txt = name; loc = ext_loc}, ext_payload), body) ->
-        match
-          parse_embedding_exn
-            ~loc:ext_loc
-            ~name
-            ~embedding_syntax
-        with
-        | None -> None
-        | Some name -> Some (name, ext_loc, ext_payload, body)
+      | Some name -> Some (name, ext_loc, ext_payload, body))
 end
 
 (********************************************************)
@@ -623,17 +584,19 @@ module Type_AST_syntactic_category = struct
   (* Missing [plural] *)
 
   let location typ = typ.ptyp_loc
+
   let with_location typ l = { typ with ptyp_loc = l }
 
   let attributes typ = typ.ptyp_attributes
+
   let with_attributes typ ptyp_attributes = { typ with ptyp_attributes }
 end
 
 (** Types; embedded with attributes. *)
 module Core_type0 = Make_with_attribute (struct
-    include Type_AST_syntactic_category
+  include Type_AST_syntactic_category
 
-    let plural = "types"
+  let plural = "types"
 end)
 
 (** Constructor arguments; the same as types, but used in fewer places *)
@@ -648,10 +611,13 @@ module Expression0 = Make_with_attribute (struct
   type ast = expression
 
   let plural = "expressions"
+
   let location expr = expr.pexp_loc
+
   let with_location expr l = { expr with pexp_loc = l }
 
   let attributes expr = expr.pexp_attributes
+
   let with_attributes expr pexp_attributes = { expr with pexp_attributes }
 end)
 
@@ -660,35 +626,44 @@ module Pattern0 = Make_with_attribute (struct
   type ast = pattern
 
   let plural = "patterns"
+
   let location pat = pat.ppat_loc
+
   let with_location pat l = { pat with ppat_loc = l }
 
   let attributes pat = pat.ppat_attributes
+
   let with_attributes pat ppat_attributes = { pat with ppat_attributes }
 end)
 
 (** Module types; embedded using an attribute on the module type. *)
 module Module_type0 = Make_with_attribute (struct
-    type ast = module_type
+  type ast = module_type
 
-    let plural = "module types"
-    let location mty = mty.pmty_loc
-    let with_location mty l = { mty with pmty_loc = l }
+  let plural = "module types"
 
-    let attributes mty = mty.pmty_attributes
-    let with_attributes mty pmty_attributes = { mty with pmty_attributes }
+  let location mty = mty.pmty_loc
+
+  let with_location mty l = { mty with pmty_loc = l }
+
+  let attributes mty = mty.pmty_attributes
+
+  let with_attributes mty pmty_attributes = { mty with pmty_attributes }
 end)
 
 (** Extension constructors; embedded using an attribute. *)
 module Extension_constructor0 = Make_with_attribute (struct
-    type ast = extension_constructor
+  type ast = extension_constructor
 
-    let plural = "extension constructors"
-    let location ext = ext.pext_loc
-    let with_location ext l = { ext with pext_loc = l }
+  let plural = "extension constructors"
 
-    let attributes ext = ext.pext_attributes
-    let with_attributes ext pext_attributes = { ext with pext_attributes }
+  let location ext = ext.pext_loc
+
+  let with_location ext l = { ext with pext_loc = l }
+
+  let attributes ext = ext.pext_attributes
+
+  let with_attributes ext pext_attributes = { ext with pext_attributes }
 end)
 
 (** Signature items; embedded as
@@ -696,34 +671,36 @@ end)
     attributes or we'd use them instead.
 *)
 module Signature_item0 = Make_with_extension_node (struct
-    type ast = signature_item
+  type ast = signature_item
 
-    let plural = "signature items"
+  let plural = "signature items"
 
-    let location sigi = sigi.psig_loc
-    let with_location sigi l = { sigi with psig_loc = l }
+  let location sigi = sigi.psig_loc
 
-    let make_extension_node = Ast_helper.Sig.extension
+  let with_location sigi l = { sigi with psig_loc = l }
 
-    let make_extension_use ~extension_node sigi =
-      Ast_helper.Sig.include_
-        { pincl_mod = Ast_helper.Mty.signature [extension_node; sigi]
-        ; pincl_loc = !Ast_helper.default_loc
-        ; pincl_attributes = [] }
+  let make_extension_node = Ast_helper.Sig.extension
 
-    let match_extension_use sigi =
-      match sigi.psig_desc with
-      | Psig_include
-          { pincl_mod =
-              { pmty_desc =
-                  Pmty_signature
-                    [ { psig_desc = Psig_extension (ext, []); _ }
-                    ; sigi ]
-              ; _}
-          ; _}
-        ->
-          Some (ext, sigi)
-      | _ -> None
+  let make_extension_use ~extension_node sigi =
+    Ast_helper.Sig.include_
+      { pincl_mod = Ast_helper.Mty.signature [extension_node; sigi];
+        pincl_loc = !Ast_helper.default_loc;
+        pincl_attributes = []
+      }
+
+  let match_extension_use sigi =
+    match sigi.psig_desc with
+    | Psig_include
+        { pincl_mod =
+            { pmty_desc =
+                Pmty_signature
+                  [{ psig_desc = Psig_extension (ext, []); _ }; sigi];
+              _
+            };
+          _
+        } ->
+      Some (ext, sigi)
+    | _ -> None
 end)
 
 (** Structure items; embedded as
@@ -731,46 +708,50 @@ end)
     have attributes or we'd use them instead.
 *)
 module Structure_item0 = Make_with_extension_node (struct
-    type ast = structure_item
+  type ast = structure_item
 
-    let plural = "structure items"
+  let plural = "structure items"
 
-    let location stri = stri.pstr_loc
-    let with_location stri l = { stri with pstr_loc = l }
+  let location stri = stri.pstr_loc
 
-    let make_extension_node = Ast_helper.Str.extension
+  let with_location stri l = { stri with pstr_loc = l }
 
-    let make_extension_use ~extension_node stri =
-      Ast_helper.Str.include_
-        { pincl_mod = Ast_helper.Mod.structure [extension_node; stri]
-        ; pincl_loc = !Ast_helper.default_loc
-        ; pincl_attributes = [] }
+  let make_extension_node = Ast_helper.Str.extension
 
-    let match_extension_use stri =
-      match stri.pstr_desc with
-      | Pstr_include
-          { pincl_mod =
-              { pmod_desc =
-                  Pmod_structure
-                    [ { pstr_desc = Pstr_extension (ext, []); _ }
-                    ; stri ]
-              ; _}
-          ; _}
-        ->
-          Some (ext, stri)
-      | _ -> None
+  let make_extension_use ~extension_node stri =
+    Ast_helper.Str.include_
+      { pincl_mod = Ast_helper.Mod.structure [extension_node; stri];
+        pincl_loc = !Ast_helper.default_loc;
+        pincl_attributes = []
+      }
+
+  let match_extension_use stri =
+    match stri.pstr_desc with
+    | Pstr_include
+        { pincl_mod =
+            { pmod_desc =
+                Pmod_structure
+                  [{ pstr_desc = Pstr_extension (ext, []); _ }; stri];
+              _
+            };
+          _
+        } ->
+      Some (ext, stri)
+    | _ -> None
 end)
 
-
 (** Constructor declarations; embedded with attributes. *)
-module Constructor_declaration0 = Make_with_attribute(struct
+module Constructor_declaration0 = Make_with_attribute (struct
   type ast = Parsetree.constructor_declaration
 
   let plural = "constructor declarations"
+
   let location pcd = pcd.pcd_loc
+
   let with_location pcd loc = { pcd with pcd_loc = loc }
 
   let attributes pcd = pcd.pcd_attributes
+
   let with_attributes pcd pcd_attributes = { pcd with pcd_attributes }
 end)
 
@@ -782,10 +763,12 @@ module type AST = sig
 
   val make_jane_syntax :
     Feature.t -> string list -> ?payload:payload -> ast -> ast
+
   val make_entire_jane_syntax :
     loc:Location.t -> Feature.t -> (unit -> ast) -> ast
+
   val make_of_ast :
-    of_ast_internal:(Feature.t -> ast -> 'a option) -> (ast -> 'a option)
+    of_ast_internal:(Feature.t -> ast -> 'a option) -> ast -> 'a option
 end
 
 (* See Note [Hiding internal details] *)
@@ -795,8 +778,7 @@ module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
   let make_jane_syntax feature trailing_components ?payload ast =
     AST.make_jane_syntax
       (Embedded_name.of_feature feature trailing_components)
-      ?payload
-      ast
+      ?payload ast
 
   let make_entire_jane_syntax ~loc feature ast =
     AST.with_location
@@ -804,7 +786,7 @@ module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
          [jane_syntax_parsing.ml] to build with the upstream compiler; see
          Note [Buildable with upstream] in jane_syntax.mli for details. *)
       (Ast_helper.with_default_loc { loc with loc_ghost = true } (fun () ->
-        make_jane_syntax feature [] (ast ())))
+           make_jane_syntax feature [] (ast ())))
       loc
 
   (** Generically lift our custom ASTs for our novel syntax from OCaml ASTs. *)
@@ -813,29 +795,32 @@ module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
       let loc = AST.location ast in
       let raise_error loc err = raise (Error (loc, err)) in
       match AST.match_jane_syntax ast with
-      | Some ({ erasability; components = [name] } as embedded_name, syntax_loc, payload, ast) -> begin
-          begin match payload with
-          | PStr [] -> ()
-          | _ -> raise_error syntax_loc
-                   (Introduction_has_payload
-                      (AST.embedding_syntax, embedded_name, payload))
-          end;
-          match Feature.of_component name with
-          | Ok feat -> begin
-              match of_ast_internal feat ast with
-              | Some ext_ast -> Some ext_ast
-              | None ->
-                  raise_error loc (Wrong_syntactic_category(feat, AST.plural))
-            end
-          | Error err -> raise_error loc begin match err with
+      | Some
+          ( ({ erasability; components = [name] } as embedded_name),
+            syntax_loc,
+            payload,
+            ast ) -> (
+        (match payload with
+        | PStr [] -> ()
+        | _ ->
+          raise_error syntax_loc
+            (Introduction_has_payload
+               (AST.embedding_syntax, embedded_name, payload)));
+        match Feature.of_component name with
+        | Ok feat -> (
+          match of_ast_internal feat ast with
+          | Some ext_ast -> Some ext_ast
+          | None ->
+            raise_error loc (Wrong_syntactic_category (feat, AST.plural)))
+        | Error err ->
+          raise_error loc
+            (match err with
             | Disabled_extension ext ->
-                Disabled_extension { ext; maturity = None }
+              Disabled_extension { ext; maturity = None }
             | Unknown_extension name ->
-                Unknown_extension (AST.embedding_syntax, erasability, name)
-          end
-        end
-      | Some ({ components = _ :: _ :: _; _ } as name, _, _, _) ->
-          raise_error loc (Bad_introduction(AST.embedding_syntax, name))
+              Unknown_extension (AST.embedding_syntax, erasability, name)))
+      | Some (({ components = _ :: _ :: _; _ } as name), _, _, _) ->
+        raise_error loc (Bad_introduction (AST.embedding_syntax, name))
       | None -> None
     in
     of_ast
@@ -847,12 +832,12 @@ let make_jane_syntax_attribute feature trailing_components payload =
     payload
 
 (* See Note [Hiding internal details] *)
-module Expression = Make_ast(Expression0)
-module Pattern = Make_ast(Pattern0)
-module Module_type = Make_ast(Module_type0)
-module Signature_item = Make_ast(Signature_item0)
-module Structure_item = Make_ast(Structure_item0)
-module Core_type = Make_ast(Core_type0)
-module Constructor_argument = Make_ast(Constructor_argument0)
-module Extension_constructor = Make_ast(Extension_constructor0)
-module Constructor_declaration = Make_ast(Constructor_declaration0)
+module Expression = Make_ast (Expression0)
+module Pattern = Make_ast (Pattern0)
+module Module_type = Make_ast (Module_type0)
+module Signature_item = Make_ast (Signature_item0)
+module Structure_item = Make_ast (Structure_item0)
+module Core_type = Make_ast (Core_type0)
+module Constructor_argument = Make_ast (Constructor_argument0)
+module Extension_constructor = Make_ast (Extension_constructor0)
+module Constructor_declaration = Make_ast (Constructor_declaration0)

--- a/ocaml/parsing/jane_syntax_parsing.mli
+++ b/ocaml/parsing/jane_syntax_parsing.mli
@@ -110,7 +110,6 @@ end
     also why we don't expose any functions for rendering or parsing these names;
     that's all handled internally. *)
 module Embedded_name : sig
-
   (** A nonempty list of name components, without the first two components.
       (That is, without the leading root component that identifies it as part of
       the modular syntax mechanism, and without the next component that
@@ -150,12 +149,8 @@ module type AST = sig
       given name (in the [Feature.t]) and body (the [ast]).  Any locations in
       the generated AST will be set to [!Ast_helper.default_loc], which should
       be [ghost]. *)
-  val make_jane_syntax
-    :  Feature.t
-    -> string list
-    -> ?payload:Parsetree.payload
-    -> ast
-    -> ast
+  val make_jane_syntax :
+    Feature.t -> string list -> ?payload:Parsetree.payload -> ast -> ast
 
   (** As [make_jane_syntax], but specifically for the AST node corresponding to
       the entire piece of novel syntax (e.g., for a list comprehension, the
@@ -163,11 +158,8 @@ module type AST = sig
       sets [Ast_helper.default_loc] locally to the [ghost] version of the
       provided location, which is why the [ast] is generated from a function
       call; it is during this call that the location is so set. *)
-  val make_entire_jane_syntax
-    :  loc:Location.t
-    -> Feature.t
-    -> (unit -> ast)
-    -> ast
+  val make_entire_jane_syntax :
+    loc:Location.t -> Feature.t -> (unit -> ast) -> ast
 
   (** Build an [of_ast] function. The return value of this function should be
       used to implement [of_ast] in modules satisfying the signature
@@ -178,9 +170,9 @@ module type AST = sig
       It raises an error if it finds a term from a disabled extension or if the
       embedding is malformed.
   *)
-  val make_of_ast
-    :  of_ast_internal:(Feature.t -> ast -> 'a option)
-    (** A function to convert [Parsetree]'s AST to our novel extended one.  The
+  val make_of_ast :
+    of_ast_internal:(Feature.t -> ast -> 'a option)
+      (** A function to convert [Parsetree]'s AST to our novel extended one.  The
         choice of feature and the piece of syntax will both be extracted from
         the embedding by the first argument.
 
@@ -189,30 +181,24 @@ module type AST = sig
         example: There are no pattern comprehensions, so when building the
         extended pattern AST, this function will return [None] if it spots an
         embedding that claims to be from [Language_extension Comprehensions].)
-    *)
-    -> (ast -> 'a option)
+    *) ->
+    ast ->
+    'a option
 end
 
-module Expression :
-  AST with type ast = Parsetree.expression
+module Expression : AST with type ast = Parsetree.expression
 
-module Pattern :
-  AST with type ast = Parsetree.pattern
+module Pattern : AST with type ast = Parsetree.pattern
 
-module Module_type :
-  AST with type ast = Parsetree.module_type
+module Module_type : AST with type ast = Parsetree.module_type
 
-module Signature_item :
-  AST with type ast = Parsetree.signature_item
+module Signature_item : AST with type ast = Parsetree.signature_item
 
-module Structure_item :
-  AST with type ast = Parsetree.structure_item
+module Structure_item : AST with type ast = Parsetree.structure_item
 
-module Core_type :
-  AST with type ast = Parsetree.core_type
+module Core_type : AST with type ast = Parsetree.core_type
 
-module Constructor_argument :
-  AST with type ast = Parsetree.core_type
+module Constructor_argument : AST with type ast = Parsetree.core_type
 
 module Extension_constructor :
   AST with type ast = Parsetree.extension_constructor
@@ -239,6 +225,7 @@ val assert_extension_enabled :
    approach for now, but we could revisit this decision if we use it more
    often.
 *)
+
 (** Extracts the last attribute (in list order) that was inserted by the
     Jane Syntax framework, and returns the rest of the attributes in the
     same relative order as was input, along with the location of the removed
@@ -250,8 +237,8 @@ val assert_extension_enabled :
 *)
 val find_and_remove_jane_syntax_attribute :
   Parsetree.attributes ->
-  (Embedded_name.t * Location.t *
-   Parsetree.payload * Parsetree.attributes) option
+  (Embedded_name.t * Location.t * Parsetree.payload * Parsetree.attributes)
+  option
 
 (** Creates an attribute used for encoding syntax from the given [Feature.t] *)
 val make_jane_syntax_attribute :

--- a/ocaml/utils/.ocamlformat-enable
+++ b/ocaml/utils/.ocamlformat-enable
@@ -2,3 +2,5 @@ compilation_unit.ml
 compilation_unit.mli
 import_info.ml
 import_info.mli
+language_extension.ml
+language_extension.mli

--- a/ocaml/utils/language_extension.ml
+++ b/ocaml/utils/language_extension.ml
@@ -3,37 +3,47 @@ include Language_extension_kernel
 (* operations we want on every extension level *)
 module type Extension_level = sig
   type t
+
   val compare : t -> t -> int
+
   val max : t -> t -> t
+
   val max_value : t
+
   val all : t list
+
   val to_command_line_suffix : t -> string
 end
 
 module Unit = struct
   type t = unit
+
   let compare = Unit.compare
+
   let max _ _ = ()
+
   let max_value = ()
+
   let all = [()]
+
   let to_command_line_suffix () = ""
 end
 
 module Maturity = struct
-  type t = maturity = Stable | Beta | Alpha
+  type t = maturity =
+    | Stable
+    | Beta
+    | Alpha
 
   let compare t1 t2 =
-    let rank = function
-      | Stable -> 1
-      | Beta -> 2
-      | Alpha -> 3
-    in
+    let rank = function Stable -> 1 | Beta -> 2 | Alpha -> 3 in
     compare (rank t1) (rank t2)
 
   let max t1 t2 = if compare t1 t2 >= 0 then t1 else t2
+
   let max_value = Alpha
 
-  let all = [ Stable; Beta; Alpha ]
+  let all = [Stable; Beta; Alpha]
 
   let to_command_line_suffix = function
     | Stable -> ""
@@ -54,24 +64,28 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
   | SIMD -> (module Unit)
 
 type extn_pair = Exist_pair.t = Pair : 'a t * 'a -> extn_pair
+
 type exist = Exist.t = Pack : _ t -> exist
 
 (**********************************)
 (* string conversions *)
 
-let to_command_line_string : type a. a t -> a -> string = fun extn level ->
+let to_command_line_string : type a. a t -> a -> string =
+ fun extn level ->
   let (module Ops) = get_level_ops extn in
   to_string extn ^ Ops.to_command_line_suffix level
 
-let pair_of_string_exn extn_name = match pair_of_string extn_name with
+let pair_of_string_exn extn_name =
+  match pair_of_string extn_name with
   | Some pair -> pair
   | None ->
-    raise (Arg.Bad(Printf.sprintf "Extension %s is not known" extn_name))
+    raise (Arg.Bad (Printf.sprintf "Extension %s is not known" extn_name))
 
 (************************************)
 (* equality *)
 
-let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option = match a, b with
+let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
+  match a, b with
   | Comprehensions, Comprehensions -> Some Refl
   | Local, Local -> Some Refl
   | Unique, Unique -> Some Refl
@@ -81,8 +95,11 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option = match a, b 
   | Module_strengthening, Module_strengthening -> Some Refl
   | Layouts, Layouts -> Some Refl
   | SIMD, SIMD -> Some Refl
-  | (Comprehensions | Local | Unique | Include_functor | Polymorphic_parameters |
-     Immutable_arrays | Module_strengthening | Layouts | SIMD), _ -> None
+  | ( ( Comprehensions | Local | Unique | Include_functor
+      | Polymorphic_parameters | Immutable_arrays | Module_strengthening
+      | Layouts | SIMD ),
+      _ ) ->
+    None
 
 let equal a b = Option.is_some (equal_t a b)
 
@@ -91,7 +108,9 @@ let equal a b = Option.is_some (equal_t a b)
 
 module Universe : sig
   val is_allowed : 'a t -> bool
+
   val check : 'a t -> unit
+
   val check_maximal : unit -> unit
 
   type t =
@@ -108,11 +127,7 @@ end = struct
     | Any
 
   let compare t1 t2 =
-    let rank = function
-      | No_extensions -> 1
-      | Only_erasable -> 2
-      | Any -> 3
-    in
+    let rank = function No_extensions -> 1 | Only_erasable -> 2 | Any -> 3 in
     compare (rank t1) (rank t2)
 
   let universe = ref Any
@@ -120,65 +135,65 @@ end = struct
   let compiler_options = function
     | No_extensions -> "flag -disable-all-extensions"
     | Only_erasable -> "flag -only-erasable-extensions"
-    | Any           -> "default options"
+    | Any -> "default options"
 
-  let is_allowed ext = match !universe with
+  let is_allowed ext =
+    match !universe with
     | No_extensions -> false
     | Only_erasable -> is_erasable ext
-    | Any           -> true
+    | Any -> true
 
   (* are _all_ extensions allowed? *)
-  let all_allowed () = match !universe with
-    | Any -> true
-    | No_extensions | Only_erasable -> false
+  let all_allowed () =
+    match !universe with Any -> true | No_extensions | Only_erasable -> false
 
   (* The terminating [()] argument helps protect against ignored arguments. See
      the documentation for [Base.failwithf]. *)
-  let fail fmt =
-    Format.ksprintf (fun str () -> raise (Arg.Bad str)) fmt
+  let fail fmt = Format.ksprintf (fun str () -> raise (Arg.Bad str)) fmt
 
   let check extn =
     if not (is_allowed extn)
-    then fail "Cannot enable extension %s: incompatible with %s"
-           (to_string extn)
-           (compiler_options !universe)
-           ()
+    then
+      fail "Cannot enable extension %s: incompatible with %s" (to_string extn)
+        (compiler_options !universe)
+        ()
 
   let check_maximal () =
     if not (all_allowed ())
-    then fail "Cannot enable all extensions: incompatible with %s"
-           (compiler_options !universe)
-           ()
+    then
+      fail "Cannot enable all extensions: incompatible with %s"
+        (compiler_options !universe)
+        ()
 
   (* returns whether or not a change was actually made *)
   let set new_universe =
     let cmp = compare new_universe !universe in
     if cmp > 0
-    then fail "Cannot specify %s: incompatible with %s"
-           (compiler_options new_universe)
-           (compiler_options !universe)
-           ();
-   universe := new_universe;
+    then
+      fail "Cannot specify %s: incompatible with %s"
+        (compiler_options new_universe)
+        (compiler_options !universe)
+        ();
+    universe := new_universe;
     cmp <> 0
 end
 
 (*****************************************)
 (* enabling / disabling *)
 
-(* Mutable state.  Invariants:
+(* Mutable state. Invariants:
 
    (1) [!extensions] contains at most one copy of each extension.
 
-   (2) Every member of [!extensions] satisfies [Universe.is_allowed].
-       (For instance, [!universe = No_extensions] implies
-       [!extensions = []]). *)
+   (2) Every member of [!extensions] satisfies [Universe.is_allowed]. (For
+   instance, [!universe = No_extensions] implies [!extensions = []]). *)
 
 let default_extensions : extn_pair list =
-  [ Pair (Local, ())
-  ; Pair (Include_functor, ())
-  ; Pair (Polymorphic_parameters, ())
-  ; Pair (Immutable_arrays, ())
-  ]
+  [ Pair (Local, ());
+    Pair (Include_functor, ());
+    Pair (Polymorphic_parameters, ());
+    Pair (Immutable_arrays, ()) ]
+
 let extensions : extn_pair list ref = ref default_extensions
 
 let set_worker (type a) (extn : a t) = function
@@ -188,21 +203,23 @@ let set_worker (type a) (extn : a t) = function
     let rec update_extensions already_seen : extn_pair list -> extn_pair list =
       function
       | [] -> Pair (extn, value) :: already_seen
-      | ((Pair (extn', v) as e) :: es) ->
-         match equal_t extn extn' with
-         | None -> update_extensions (e :: already_seen) es
-         | Some Refl ->
-            Pair (extn, Ops.max v value) :: List.rev_append already_seen es
+      | (Pair (extn', v) as e) :: es -> (
+        match equal_t extn extn' with
+        | None -> update_extensions (e :: already_seen) es
+        | Some Refl ->
+          Pair (extn, Ops.max v value) :: List.rev_append already_seen es)
     in
     extensions := update_extensions [] !extensions
   | None ->
-    extensions :=
-      List.filter (fun (Pair (extn', _) : extn_pair) -> not (equal extn extn'))
-        !extensions
+    extensions
+      := List.filter
+           (fun (Pair (extn', _) : extn_pair) -> not (equal extn extn'))
+           !extensions
 
-let set extn ~enabled =
-  set_worker extn (if enabled then Some () else None)
+let set extn ~enabled = set_worker extn (if enabled then Some () else None)
+
 let enable extn value = set_worker extn (Some value)
+
 let disable extn = set_worker extn None
 
 (* This is similar to [Misc.protect_refs], but we don't have values to set
@@ -215,21 +232,25 @@ let with_temporary_extensions f =
    [only_erasable_extensions], and [disallow_extensions] inside [f], but it's
    not clear that it's worth the hassle *)
 let with_set_worker extn value f =
-  with_temporary_extensions (fun () -> set_worker extn value; f ())
+  with_temporary_extensions (fun () ->
+      set_worker extn value;
+      f ())
 
 let with_set extn ~enabled =
   with_set_worker extn (if enabled then Some () else None)
+
 let with_enabled extn value = with_set_worker extn (Some value)
+
 let with_disabled extn = with_set_worker extn None
 
-let enable_of_string_exn extn_name = match pair_of_string_exn extn_name with
+let enable_of_string_exn extn_name =
+  match pair_of_string_exn extn_name with
   | Pair (extn, setting) -> enable extn setting
 
-let disable_of_string_exn extn_name = match pair_of_string_exn extn_name with
-  | Pair (extn, _) -> disable extn
+let disable_of_string_exn extn_name =
+  match pair_of_string_exn extn_name with Pair (extn, _) -> disable extn
 
-let disable_all () =
-  extensions := []
+let disable_all () = extensions := []
 
 let unconditionally_enable_maximal_without_checks () =
   let maximal_pair (Pack extn) =
@@ -246,8 +267,11 @@ let enable_maximal () =
 let restrict_to_erasable_extensions () =
   let changed = Universe.set Only_erasable in
   if changed
-  then extensions :=
-      List.filter (fun (Pair (extn, _)) -> Universe.is_allowed extn) !extensions
+  then
+    extensions
+      := List.filter
+           (fun (Pair (extn, _)) -> Universe.is_allowed extn)
+           !extensions
 
 let disallow_extensions () =
   ignore (Universe.set No_extensions : bool);
@@ -259,27 +283,27 @@ let disallow_extensions () =
 let is_at_least (type a) (extn : a t) (value : a) =
   let rec check : extn_pair list -> bool = function
     | [] -> false
-    | (Pair (e, v) :: es) ->
+    | Pair (e, v) :: es -> (
       let (module Ops) = get_level_ops e in
       match equal_t e extn with
       | Some Refl -> Ops.compare v value >= 0
-      | None -> check es
+      | None -> check es)
   in
   check !extensions
 
 let is_enabled extn =
   let rec check : extn_pair list -> bool = function
     | [] -> false
-    | (Pair (e, _) :: _) when equal e extn -> true
-    | (_ :: es) -> check es
+    | Pair (e, _) :: _ when equal e extn -> true
+    | _ :: es -> check es
   in
   check !extensions
 
 let get_command_line_string_if_enabled extn =
   let rec find = function
     | [] -> None
-    | (Pair (e, v) :: _) when equal e extn -> Some (to_command_line_string e v)
-    | (_ :: es) -> find es
+    | Pair (e, v) :: _ when equal e extn -> Some (to_command_line_string e v)
+    | _ :: es -> find es
   in
   find !extensions
 
@@ -293,14 +317,11 @@ module Exist = struct
     let (module Ops) = get_level_ops extn in
     List.map (to_command_line_string extn) Ops.all
 
-  let to_string : t -> string = function
-    | Pack extn -> to_string extn
+  let to_string : t -> string = function Pack extn -> to_string extn
 
-  let is_enabled : t -> bool = function
-    | Pack extn -> is_enabled extn
+  let is_enabled : t -> bool = function Pack extn -> is_enabled extn
 
-  let is_erasable : t -> bool = function
-    | Pack extn -> is_erasable extn
+  let is_erasable : t -> bool = function Pack extn -> is_erasable extn
 end
 
 (********************************************)
@@ -309,23 +330,25 @@ end
 module For_pprintast = struct
   type printer_exporter =
     { print_with_maximal_extensions :
-        'a. (Format.formatter -> 'a -> unit) -> (Format.formatter -> 'a -> unit)
+        'a. (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a -> unit
     }
 
   let can_still_define_printers = ref true
 
   let make_printer_exporter () =
-    if !can_still_define_printers then begin
+    if !can_still_define_printers
+    then (
       can_still_define_printers := false;
-      { print_with_maximal_extensions = fun pp fmt item ->
-          with_temporary_extensions (fun () ->
-            (* It's safe to call this here without validating that the
-               extensions are enabled, because the [Pprintast] printers should
-               always print Jane syntax. *)
-            unconditionally_enable_maximal_without_checks ();
-            pp fmt item)
-      }
-    end else
+      { print_with_maximal_extensions =
+          (fun pp fmt item ->
+            with_temporary_extensions (fun () ->
+                (* It's safe to call this here without validating that the
+                   extensions are enabled, because the [Pprintast] printers
+                   should always print Jane syntax. *)
+                unconditionally_enable_maximal_without_checks ();
+                pp fmt item))
+      })
+    else
       Misc.fatal_error
         "Only Pprintast may use [Language_extension.For_pprintast]"
 end

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -3,7 +3,10 @@
 *)
 
 (** A setting for extensions that track multiple maturity levels *)
-type maturity = Language_extension_kernel.maturity = Stable | Beta | Alpha
+type maturity = Language_extension_kernel.maturity =
+  | Stable
+  | Beta
+  | Alpha
 
 (** The type of language extensions. An ['a t] is an extension that can either
     be off or be set to have any value in ['a], so a [unit t] can be either on
@@ -21,13 +24,16 @@ type 'a t = 'a Language_extension_kernel.t =
 
 (** Existentially packed language extension *)
 module Exist : sig
-  type 'a extn = 'a t (* this is removed from the sig by the [with] below;
-                         ocamldoc doesn't like [:=] in sigs *)
-  type t = Language_extension_kernel.Exist.t =
-    | Pack : 'a extn -> t
+  type 'a extn = 'a t
+  (* this is removed from the sig by the [with] below; ocamldoc doesn't like
+     [:=] in sigs *)
+
+  type t = Language_extension_kernel.Exist.t = Pack : 'a extn -> t
 
   val to_string : t -> string
+
   val is_enabled : t -> bool
+
   val is_erasable : t -> bool
 
   (** Returns a list of all strings, like ["layouts_beta"], that
@@ -35,7 +41,8 @@ module Exist : sig
   val to_command_line_strings : t -> string list
 
   val all : t list
-end with type 'a extn := 'a t
+end
+with type 'a extn := 'a t
 
 (** Equality on language extensions *)
 val equal : 'a t -> 'b t -> bool
@@ -54,7 +61,9 @@ val is_erasable : 'a t -> bool
 
 (** Print and parse language extensions; parsing is case-insensitive *)
 val to_string : 'a t -> string
+
 val to_command_line_string : 'a t -> 'a -> string
+
 val of_string : string -> Exist.t option
 
 val maturity_to_string : maturity -> string
@@ -66,11 +75,14 @@ val get_command_line_string_if_enabled : 'a t -> string option
 (** Enable and disable according to command-line strings; these raise
     an exception if the input string is invalid. *)
 val enable_of_string_exn : string -> unit
+
 val disable_of_string_exn : string -> unit
 
 (** Enable and disable language extensions; these operations are idempotent *)
 val set : unit t -> enabled:bool -> unit
+
 val enable : 'a t -> 'a -> unit
+
 val disable : 'a t -> unit
 
 (** Check if a language extension is currently enabled (at any maturity level)
@@ -86,7 +98,9 @@ val is_at_least : 'a t -> 'a -> bool
     be rolled back when the function finishes, but this behavior may change;
     nest multiple [with_*] functions instead.  *)
 val with_set : unit t -> enabled:bool -> (unit -> unit) -> unit
+
 val with_enabled : 'a t -> 'a -> (unit -> unit) -> unit
+
 val with_disabled : 'a t -> (unit -> unit) -> unit
 
 (** Permanently restrict the allowable extensions to those that are
@@ -121,7 +135,7 @@ module For_pprintast : sig
       trying to print syntax from disabled extensions. *)
   type printer_exporter =
     { print_with_maximal_extensions :
-        'a. (Format.formatter -> 'a -> unit) -> (Format.formatter -> 'a -> unit)
+        'a. (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a -> unit
     }
 
   (** Raises if called more than once ever. *)


### PR DESCRIPTION
Enable ocamlformat for these files:
  * `ocaml/parsing/jane_syntax.{ml,mli}`
  * `ocaml/parsing/jane_asttypes.mli`
  * `ocaml/parsing/jane_syntax_parsing.{ml,mli}`
  * `ocaml/utils/language_extension.{ml,mli}`

Keep the same settings as other places ocamlformat is used in the repo, except disable comment wrapping (because it mangles lots of the existing comments in `jane_syntax.ml`).

This PR makes it so we can make changes to these files without carefully hand-formatting the resulting code. These files don't exist upstream yet (or probably ever, for these particular ones) so this doesn't introduce more surface area for merge conflicts.

You run `make fmt` to format all files in the repo. CI will complain if you forget to do this.

**Review:** probably worth glancing to make sure this doesn't make things appreciably worse, but this one should be pretty straightforward. Maybe @goldfirere can do that glancing?