### PR TITLE
Added a hook on imported units

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -6,6 +6,8 @@ checks.ml
 checks.mli
 checkmach.ml
 checkmach.mli
+checkmach_types.ml
+checkmach_types.mli
 cfg/**/*.ml
 cfg/**/*.mli
 asm_targets/**/*.ml

--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -205,6 +205,7 @@ let build_package_cmx members cmxfile =
           List.exists (fun info -> info.ui_force_link) units;
       ui_export_info;
       ui_checks;
+      ui_impl_filename = ui.ui_impl_filename;
     } in
   Compilenv.write_unit_info pkg_infos cmxfile
 

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -25,122 +25,8 @@
  **********************************************************************************)
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+include Checkmach_types
 module String = Misc.Stdlib.String
-
-module Witness = struct
-  type kind =
-    | Alloc of
-        { bytes : int;
-          dbginfo : Debuginfo.alloc_dbginfo
-        }
-    | Indirect_call
-    | Indirect_tailcall
-    | Direct_call of { callee : string }
-    | Direct_tailcall of { callee : string }
-    | Missing_summary of { callee : string }
-    | Forward_call of { callee : string }
-    | Extcall of { callee : string }
-    | Arch_specific
-    | Probe of
-        { name : string;
-          handler_code_sym : string
-        }
-
-  type t =
-    { dbg : Debuginfo.t;
-      kind : kind
-    }
-
-  let create dbg kind = { dbg; kind }
-
-  let compare { dbg = dbg1; kind = kind1 } { dbg = dbg2; kind = kind2 } =
-    (* compare by [dbg] first to print the errors in the order they appear in
-       the source file. *)
-    let c = Debuginfo.compare dbg1 dbg2 in
-    if c <> 0 then c else Stdlib.compare kind1 kind2
-
-  let print_kind ppf kind =
-    let open Format in
-    match kind with
-    | Alloc { bytes; dbginfo = _ } -> fprintf ppf "allocation of %d bytes" bytes
-    | Indirect_call -> fprintf ppf "indirect call"
-    | Indirect_tailcall -> fprintf ppf "indirect tailcall"
-    | Direct_call { callee } -> fprintf ppf "direct call %s" callee
-    | Direct_tailcall { callee : string } ->
-      fprintf ppf "direct tailcall %s" callee
-    | Missing_summary { callee } -> fprintf ppf "missing summary for %s" callee
-    | Forward_call { callee } ->
-      fprintf ppf "foward call or tailcall (conservatively handled) %s" callee
-    | Extcall { callee } -> fprintf ppf "external call to %s" callee
-    | Arch_specific -> fprintf ppf "arch specific operation"
-    | Probe { name; handler_code_sym } ->
-      fprintf ppf "probe %s handler %s" name handler_code_sym
-
-  let get_alloc_dbginfo kind =
-    match kind with
-    | Alloc { bytes = _; dbginfo } -> Some dbginfo
-    | Indirect_call | Indirect_tailcall | Direct_call _ | Direct_tailcall _
-    | Missing_summary _ | Forward_call _ | Extcall _ | Arch_specific | Probe _
-      ->
-      None
-
-  let print ppf { kind; dbg } =
-    Format.fprintf ppf "%a %a" print_kind kind Debuginfo.print_compact dbg
-end
-
-module Witnesses : sig
-  type t
-
-  val empty : t
-
-  val is_empty : t -> bool
-
-  val iter : t -> f:(Witness.t -> unit) -> unit
-
-  val join : t -> t -> t
-
-  val create : Witness.kind -> Debuginfo.t -> t
-
-  val print : Format.formatter -> t -> unit
-
-  val elements : t -> Witness.t list
-
-  type components =
-    { nor : t;
-      exn : t;
-      div : t
-    }
-
-  val simplify : components -> components
-end = struct
-  include Set.Make (Witness)
-
-  (* CR gyorsh: consider using Flambda_backend_flags.checkmach_details_cutoff to
-     limit the size of this set. The downside is that it won't get tested as
-     much. Only keep witnesses for functions that need checking. *)
-  let join = union
-
-  let create kind dbg = singleton (Witness.create dbg kind)
-
-  let iter t ~f = iter f t
-
-  let print ppf t = Format.pp_print_seq Witness.print ppf (to_seq t)
-
-  type components =
-    { nor : t;
-      exn : t;
-      div : t
-    }
-
-  let simplify { nor; exn; div } =
-    { div =
-        (* don't print diverge witnesses unless they are the only ones. *)
-        (if is_empty nor && is_empty exn then div else empty);
-      nor;
-      (* only print the exn witnesses that are not also nor witnesses. *)
-      exn = diff exn nor
-    }
-end
 
 (** Abstract value for each component of the domain. *)
 module V : sig
@@ -1256,8 +1142,6 @@ let reset_unit_info () = Unit_info.reset unit_info
 let record_unit_info ppf_dump =
   Check_zero_alloc.record_unit unit_info ppf_dump;
   Compilenv.cache_checks (Compilenv.current_unit_infos ()).ui_checks
-
-type iter_witnesses = (string -> Witnesses.components -> unit) -> unit
 
 let iter_witnesses f =
   Unit_info.iter unit_info ~f:(fun func_info ->

--- a/backend/checkmach_types.ml
+++ b/backend/checkmach_types.ml
@@ -1,0 +1,143 @@
+(**********************************************************************************
+ *                             MIT License                                        *
+ *                                                                                *
+ *                                                                                *
+ * Copyright (c) 2022-2022 Jane Street Group LLC                                  *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ *                                                                                *
+ **********************************************************************************)
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+module Witness = struct
+  type kind =
+    | Alloc of
+        { bytes : int;
+          dbginfo : Debuginfo.alloc_dbginfo
+        }
+    | Indirect_call
+    | Indirect_tailcall
+    | Direct_call of { callee : string }
+    | Direct_tailcall of { callee : string }
+    | Missing_summary of { callee : string }
+    | Forward_call of { callee : string }
+    | Extcall of { callee : string }
+    | Arch_specific
+    | Probe of
+        { name : string;
+          handler_code_sym : string
+        }
+
+  type t =
+    { dbg : Debuginfo.t;
+      kind : kind
+    }
+
+  let create dbg kind = { dbg; kind }
+
+  let compare { dbg = dbg1; kind = kind1 } { dbg = dbg2; kind = kind2 } =
+    (* compare by [dbg] first to print the errors in the order they appear in
+       the source file. *)
+    let c = Debuginfo.compare dbg1 dbg2 in
+    if c <> 0 then c else Stdlib.compare kind1 kind2
+
+  let print_kind ppf kind =
+    let open Format in
+    match kind with
+    | Alloc { bytes; dbginfo = _ } -> fprintf ppf "allocation of %d bytes" bytes
+    | Indirect_call -> fprintf ppf "indirect call"
+    | Indirect_tailcall -> fprintf ppf "indirect tailcall"
+    | Direct_call { callee } -> fprintf ppf "direct call %s" callee
+    | Direct_tailcall { callee : string } ->
+      fprintf ppf "direct tailcall %s" callee
+    | Missing_summary { callee } -> fprintf ppf "missing summary for %s" callee
+    | Forward_call { callee } ->
+      fprintf ppf "foward call or tailcall (conservatively handled) %s" callee
+    | Extcall { callee } -> fprintf ppf "external call to %s" callee
+    | Arch_specific -> fprintf ppf "arch specific operation"
+    | Probe { name; handler_code_sym } ->
+      fprintf ppf "probe %s handler %s" name handler_code_sym
+
+  let get_alloc_dbginfo kind =
+    match kind with
+    | Alloc { bytes = _; dbginfo } -> Some dbginfo
+    | Indirect_call | Indirect_tailcall | Direct_call _ | Direct_tailcall _
+    | Missing_summary _ | Forward_call _ | Extcall _ | Arch_specific | Probe _
+      ->
+      None
+
+  let print ppf { kind; dbg } =
+    Format.fprintf ppf "%a %a" print_kind kind Debuginfo.print_compact dbg
+end
+
+module Witnesses : sig
+  type t
+
+  val empty : t
+
+  val is_empty : t -> bool
+
+  val iter : t -> f:(Witness.t -> unit) -> unit
+
+  val join : t -> t -> t
+
+  val create : Witness.kind -> Debuginfo.t -> t
+
+  val print : Format.formatter -> t -> unit
+
+  val elements : t -> Witness.t list
+
+  type components =
+    { nor : t;
+      exn : t;
+      div : t
+    }
+
+  val simplify : components -> components
+end = struct
+  include Set.Make (Witness)
+
+  (* CR gyorsh: consider using Flambda_backend_flags.checkmach_details_cutoff to
+     limit the size of this set. The downside is that it won't get tested as
+     much. Only keep witnesses for functions that need checking. *)
+  let join = union
+
+  let create kind dbg = singleton (Witness.create dbg kind)
+
+  let iter t ~f = iter f t
+
+  let print ppf t = Format.pp_print_seq Witness.print ppf (to_seq t)
+
+  type components =
+    { nor : t;
+      exn : t;
+      div : t
+    }
+
+  let simplify { nor; exn; div } =
+    { div =
+        (* don't print diverge witnesses unless they are the only ones. *)
+        (if is_empty nor && is_empty exn then div else empty);
+      nor;
+      (* only print the exn witnesses that are not also nor witnesses. *)
+      exn = diff exn nor
+    }
+end
+
+type iter_witnesses = (string -> Witnesses.components -> unit) -> unit

--- a/backend/checkmach_types.mli
+++ b/backend/checkmach_types.mli
@@ -25,31 +25,64 @@
  **********************************************************************************)
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-(** Maintains shared state per compilation unit *)
+(** When the check fails, [Witness.t] represents an instruction that does
+    not satisfy the property. *)
+module Witness : sig
+  type kind =
+    | Alloc of
+        { bytes : int;
+          dbginfo : Debuginfo.alloc_dbginfo
+        }
+    | Indirect_call
+    | Indirect_tailcall
+    | Direct_call of { callee : string }
+    | Direct_tailcall of { callee : string }
+    | Missing_summary of { callee : string }
+    | Forward_call of { callee : string }
+    | Extcall of { callee : string }
+    | Arch_specific
+    | Probe of
+        { name : string;
+          handler_code_sym : string
+        }
 
-(** Removes all information *)
-val reset_unit_info : unit -> unit
+  type t =
+    { dbg : Debuginfo.t;
+      kind : kind
+    }
 
-(** Records the result in [Compilenv] to be saved to [cmx]. *)
-val record_unit_info : Format.formatter -> unit
+  val get_alloc_dbginfo : kind -> Debuginfo.alloc_dbginfo option
 
-(** Analyzes the function, performs all checks that are enabled, and accumulates
-    the results. *)
-val fundecl :
-  Format.formatter ->
-  future_funcnames:Misc.Stdlib.String.Set.t ->
-  Mach.fundecl ->
-  Mach.fundecl
+  val print_kind : Format.formatter -> kind -> unit
+end
 
-(**   Iterate over all function symbols with their witnesses. This function can be called
-      at any time, but the complete information is only available after a call to
-      [record_unit_info].  To get all witnesses for all functions, and not only for
-      functions annotated with [@zero_alloc], set
-      [Flambda_backend_flags.checkmach_details_cutoff] to a negative value before calls to
-      [fundecl].  Used by compiler_hooks. *)
-type iter_witnesses =
-  (string -> Checkmach_types.Witnesses.components -> unit) -> unit
+module Witnesses : sig
+  type t
 
-val iter_witnesses : iter_witnesses
+  val create : Witness.kind -> Debuginfo.t -> t
 
-val is_check_enabled : Cmm.codegen_option list -> string -> Debuginfo.t -> bool
+  val is_empty : t -> bool
+
+  val join : t -> t -> t
+
+  val empty : t
+
+  val print : Format.formatter -> t -> unit
+
+  val iter : t -> f:(Witness.t -> unit) -> unit
+
+  (** The witnesses are classified into which path they may appear on. If a witness
+          appears on both a path to a normal and an excpetional return, it will only appear in
+          [nor] component. *)
+  type components =
+    { nor : t;  (** on a path from function entry to a normal return  *)
+      exn : t;  (** on a path from function entry to an exceptionall return  *)
+      div : t  (** on a path from function entry that may diverge *)
+    }
+
+  val simplify : components -> components
+
+  val elements : t -> Witness.t list
+end
+
+type iter_witnesses = (string -> Witnesses.components -> unit) -> unit

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -46,7 +46,9 @@ type _ pass =
   | Cmm : Cmm.phrase list pass
 
   | Inlining_tree : Flambda2_simplify_shared.Inlining_report.Inlining_tree.t pass
-  | Check_allocations : Checkmach.iter_witnesses pass
+  | Check_allocations : Checkmach_types.iter_witnesses pass
+
+  | Imported_compilation_unit : (Compilation_unit.t * string) pass
 
 (* Register a new hook for [pass]. *)
 val register : 'a pass -> ('a -> unit) -> unit

--- a/dune
+++ b/dune
@@ -116,6 +116,7 @@
   printlinear
   printmach
   checkmach
+  checkmach_types
   proc
   simd
   simd_selection

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -56,7 +56,8 @@ type unit_infos =
     mutable ui_generic_fns: generic_fns;  (* Generic functions needed *)
     mutable ui_export_info: Flambda2_cmx.Flambda_cmx_format.t option;
     mutable ui_checks: Checks.t;
-    mutable ui_force_link: bool }         (* Always linked *)
+    mutable ui_force_link: bool;         (* Always linked *)
+    mutable ui_impl_filename : string; }
 
 type unit_infos_raw =
   { uir_unit: Compilation_unit.t;
@@ -71,6 +72,7 @@ type unit_infos_raw =
                                       relative to byte immediately after
                                       this record *)
     uir_sections_length: int;      (* Byte length of all sections *)
+    uir_impl_filename : string;
   }
 
 (* Each .a library has a matching .cmxa file that provides the following

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -59,6 +59,10 @@ type unit_infos =
     mutable ui_force_link: bool;         (* Always linked *)
     mutable ui_impl_filename : string; }
 
+type unit_infos_associated_source = {
+  filename : string
+}
+
 type unit_infos_raw =
   { uir_unit: Compilation_unit.t;
     uir_defines: Compilation_unit.t list;
@@ -72,7 +76,6 @@ type unit_infos_raw =
                                       relative to byte immediately after
                                       this record *)
     uir_sections_length: int;      (* Byte length of all sections *)
-    uir_impl_filename : string;
   }
 
 (* Each .a library has a matching .cmxa file that provides the following

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -91,6 +91,7 @@ let read_unit_info filename =
     let first_section_offset = pos_in ic in
     seek_in ic (first_section_offset + uir.uir_sections_length);
     let crc = Digest.input ic in
+    let associated_source = (input_value ic : unit_infos_associated_source) in
     (* This consumes the channel *)
     let sections = File_sections.create uir.uir_section_toc filename ic ~first_section_offset in
     let export_info =
@@ -106,7 +107,7 @@ let read_unit_info filename =
       ui_export_info = export_info;
       ui_checks = Checks.of_raw uir.uir_checks;
       ui_force_link = uir.uir_force_link;
-      ui_impl_filename = uir.uir_impl_filename;
+      ui_impl_filename = associated_source.filename;
     }
     in
     (ui, crc)
@@ -255,7 +256,6 @@ let write_unit_info info filename =
     uir_force_link = info.ui_force_link;
     uir_section_toc = toc;
     uir_sections_length = total_length;
-    uir_impl_filename = info.ui_impl_filename;
   } in
   let oc = open_out_bin filename in
   output_string oc cmx_magic_number;
@@ -264,6 +264,7 @@ let write_unit_info info filename =
   flush oc;
   let crc = Digest.file filename in
   Digest.output oc crc;
+  output_value oc { filename = info.ui_impl_filename };
   close_out oc
 
 let save_unit_info filename =

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -341,6 +341,7 @@ let dump_obj_by_kind filename ic obj_kind =
     let first_section_offset = pos_in ic in
     seek_in ic (first_section_offset + uir.uir_sections_length);
     let crc = Digest.input ic in
+    let _filename = (input_value ic : unit_infos_associated_source) in
     (* This consumes ic *)
     let sections = Flambda_backend_utils.File_sections.create
         uir.uir_section_toc filename ic ~first_section_offset in


### PR DESCRIPTION
When writing tools connecting to the compiler it is often useful to know which external compilation units are needed, and from which source file they were generated from.
This PR adds a new compiler hook to retrieve that information. Most of the code is straightforward but the two following needed to happen to have it working:
- `Checkmach` depends on `Compilenv` so to avoid a cyclic dependency I moved types definitions out from `Checkmach`
- The `cmx` format is now slightly altered. The absolute path to the filename (after taking into account any build prefix) is now stored after the `crc` as the last field. It is stored away from the unit info to avoid being part of the crc computation