### PR TITLE
Improve layout history error message: hide layout history reason of various generalized vars

### DIFF
--- a/ocaml/parsing/location.ml
+++ b/ocaml/parsing/location.ml
@@ -221,7 +221,7 @@ let print_filename ppf file =
    Some of the information (filename, line number or characters numbers) in the
    location might be invalid; in which case we do not print it.
  *)
-let print_loc ppf loc =
+let print_loc ~capitalize_first ppf loc =
   setup_colors ();
   let file_valid = function
     | "_none_" ->
@@ -247,7 +247,8 @@ let print_loc ppf loc =
 
   let first = ref true in
   let capitalize s =
-    if !first then (first := false; String.capitalize_ascii s)
+    if !first then (first := false;
+                    if capitalize_first then String.capitalize_ascii s else s)
     else s in
   let comma () =
     if !first then () else Format.fprintf ppf ", " in
@@ -275,6 +276,9 @@ let print_loc ppf loc =
   );
 
   Format.fprintf ppf "@}"
+
+let print_loc_in_lowercase = print_loc ~capitalize_first:false
+let print_loc = print_loc ~capitalize_first:true
 
 (* Print a comma-separated list of locations *)
 let print_locs ppf locs =

--- a/ocaml/parsing/location.mli
+++ b/ocaml/parsing/location.mli
@@ -137,6 +137,7 @@ val show_filename: string -> string
 val print_filename: formatter -> string -> unit
 
 val print_loc: formatter -> t -> unit
+val print_loc_in_lowercase: formatter -> t -> unit
 val print_locs: formatter -> t list -> unit
 
 

--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -147,7 +147,7 @@ Line 2, characters 2-31:
 Error: The layout of type string is value, because
          it is the primitive value type string.
        But the layout of type string must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-31.
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (variant) *)
@@ -161,7 +161,7 @@ Line 2, characters 2-41:
 Error: The layout of type t is value, because
          it's a boxed variant.
        But the layout of type t must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t/2.
+         of the annotation on the declaration of the type t.
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (record) *)
@@ -175,7 +175,7 @@ Line 2, characters 2-38:
 Error: The layout of type t is value, because
          it's a boxed record.
        But the layout of type t must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t/3.
+         of the annotation on the declaration of the type t/2.
 |}];;
 
 (* Not guaranteed that t is immediate, so this is an invalid declaration *)
@@ -188,9 +188,9 @@ Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
-         an abstract type has the value layout by default.
+         of the definition of t at Line 2, characters 2-8.
        But the layout of type t must be a sublayout of immediate, because
-         of the annotation on the declaration of the type s.
+         of the definition of s at Line 3, characters 2-26.
 |}];;
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
@@ -214,7 +214,7 @@ Error: Signature mismatch:
        The layout of the first is value, because
          it is the primitive value type string.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 1, characters 15-35.
 |}];;
 
 (* Same as above but with explicit signature *)
@@ -233,7 +233,7 @@ Error: Signature mismatch:
        The layout of the first is value, because
          it is the primitive value type string.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 1, characters 20-40.
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)
@@ -248,7 +248,7 @@ Line 2, characters 2-26:
 Error: The layout of type s is value, because
          it is the primitive value type string.
        But the layout of type s must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t/2.
+         of the definition of t at Line 2, characters 2-26.
 |}];;
 
 

--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -147,7 +147,7 @@ Line 2, characters 2-31:
 Error: The layout of type string is value, because
          it is the primitive value type string.
        But the layout of type string must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-31.
+         of the definition of t at line 2, characters 2-31.
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (variant) *)
@@ -188,9 +188,9 @@ Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
-         of the definition of t at Line 2, characters 2-8.
+         of the definition of t at line 2, characters 2-8.
        But the layout of type t must be a sublayout of immediate, because
-         of the definition of s at Line 3, characters 2-26.
+         of the definition of s at line 3, characters 2-26.
 |}];;
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
@@ -214,7 +214,7 @@ Error: Signature mismatch:
        The layout of the first is value, because
          it is the primitive value type string.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 1, characters 15-35.
+         of the definition of t at line 1, characters 15-35.
 |}];;
 
 (* Same as above but with explicit signature *)
@@ -233,7 +233,7 @@ Error: Signature mismatch:
        The layout of the first is value, because
          it is the primitive value type string.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 1, characters 20-40.
+         of the definition of t at line 1, characters 20-40.
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)
@@ -248,7 +248,7 @@ Line 2, characters 2-26:
 Error: The layout of type s is value, because
          it is the primitive value type string.
        But the layout of type s must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-26.
+         of the definition of t at line 2, characters 2-26.
 |}];;
 
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
@@ -22,7 +22,7 @@ Error: This expression has type int -> int
        The layout of int -> int is value, because
          it's a function type.
        But the layout of int -> int must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 1, characters 0-22.
 |}]
 
 
@@ -40,7 +40,7 @@ Error: This expression has type [ `A | `B ]
        The layout of [ `A | `B ] is immediate, because
          it's an enumeration variant (all constructors are constant).
        But the layout of [ `A | `B ] must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 1, characters 0-22.
 |}]
 
 
@@ -58,7 +58,7 @@ Error: This expression has type [ `A of int | `B ]
        The layout of [ `A of int | `B ] is value, because
          it's a polymorphic variant.
        But the layout of [ `A of int | `B ] must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 1, characters 0-22.
 |}]
 
 
@@ -78,7 +78,7 @@ Error: This expression has type v but an expression was expected of type
        The layout of v is immediate, because
          it's an enumeration variant (all constructors are constant).
        But the layout of v must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 1, characters 0-22.
 |}]
 
 (* Extensible_variant *)
@@ -97,7 +97,7 @@ Error: This expression has type attr but an expression was expected of type
        The layout of attr is value, because
          it's an extensible variant.
        But the layout of attr must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 1, characters 0-22.
 |}]
 
 (* First_class_module *)
@@ -118,7 +118,7 @@ Error: This expression has type (module X_int)
        The layout of (module X_int) is value, because
          it's a first-class module type.
        But the layout of (module X_int) must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 1, characters 0-22.
 |}]
 
 (* Match *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
@@ -76,7 +76,7 @@ Line 3, characters 21-22:
 Error: This expression has type v but an expression was expected of type
          'a t = ('a : void)
        The layout of v is immediate, because
-         it's an enumeration variant (all constructors are constant).
+         of the definition of v at Line 2, characters 0-10.
        But the layout of v must be a sublayout of void, because
          of the definition of t at Line 1, characters 0-22.
 |}]
@@ -95,7 +95,7 @@ Line 3, characters 24-25:
 Error: This expression has type attr but an expression was expected of type
          'a t = ('a : void)
        The layout of attr is value, because
-         it's an extensible variant.
+         of the definition of attr at Line 2, characters 0-14.
        But the layout of attr must be a sublayout of void, because
          of the definition of t at Line 1, characters 0-22.
 |}]
@@ -133,7 +133,7 @@ Line 2, characters 15-37:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_1)
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 1, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_1, because
          it's matched against a pattern.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
@@ -22,7 +22,7 @@ Error: This expression has type int -> int
        The layout of int -> int is value, because
          it's a function type.
        But the layout of int -> int must be a sublayout of void, because
-         of the definition of t at Line 1, characters 0-22.
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 
@@ -40,7 +40,7 @@ Error: This expression has type [ `A | `B ]
        The layout of [ `A | `B ] is immediate, because
          it's an enumeration variant (all constructors are constant).
        But the layout of [ `A | `B ] must be a sublayout of void, because
-         of the definition of t at Line 1, characters 0-22.
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 
@@ -58,7 +58,7 @@ Error: This expression has type [ `A of int | `B ]
        The layout of [ `A of int | `B ] is value, because
          it's a polymorphic variant.
        But the layout of [ `A of int | `B ] must be a sublayout of void, because
-         of the definition of t at Line 1, characters 0-22.
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 
@@ -76,9 +76,9 @@ Line 3, characters 21-22:
 Error: This expression has type v but an expression was expected of type
          'a t = ('a : void)
        The layout of v is immediate, because
-         of the definition of v at Line 2, characters 0-10.
+         of the definition of v at line 2, characters 0-10.
        But the layout of v must be a sublayout of void, because
-         of the definition of t at Line 1, characters 0-22.
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Extensible_variant *)
@@ -95,7 +95,7 @@ Error:
        The layout of attr is value, because
          it's an extensible variant.
        But the layout of attr must be a sublayout of void, because
-         of the definition of t at Line 1, characters 0-22.
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 (* First_class_module *)
@@ -116,7 +116,7 @@ Error: This expression has type (module X_int)
        The layout of (module X_int) is value, because
          it's a first-class module type.
        But the layout of (module X_int) must be a sublayout of void, because
-         of the definition of t at Line 1, characters 0-22.
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Match *)
@@ -131,7 +131,7 @@ Line 2, characters 15-37:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_1)
        The layout of t_any is any, because
-         of the definition of t_any at Line 1, characters 0-16.
+         of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_1, because
          it's matched against a pattern.
 |}]
@@ -147,5 +147,5 @@ Error: Bad layout annotation:
          The layout of 'a -> int is value, because
            it's a function type.
          But the layout of 'a -> int must be a sublayout of void, because
-           of the annotation on the wildcard _ at Line 1, characters 27-31.
+           of the annotation on the wildcard _ at line 1, characters 27-31.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
@@ -84,18 +84,16 @@ Error: This expression has type v but an expression was expected of type
 (* Extensible_variant *)
 type ('a: void) t = 'a
 type attr = ..
-let f (x: attr): 'a t = x
+and w = attr t
 
 [%%expect{|
 type ('a : void) t = 'a
-type attr = ..
-Line 3, characters 24-25:
-3 | let f (x: attr): 'a t = x
-                            ^
-Error: This expression has type attr but an expression was expected of type
-         'a t = ('a : void)
+Line 2, characters 0-14:
+2 | type attr = ..
+    ^^^^^^^^^^^^^^
+Error:
        The layout of attr is value, because
-         of the definition of attr at Line 2, characters 0-14.
+         it's an extensible variant.
        But the layout of attr must be a sublayout of void, because
          of the definition of t at Line 1, characters 0-22.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/error_messages.ml
@@ -22,7 +22,7 @@ Error: This expression has type int -> int
        The layout of int -> int is value, because
          it's a function type.
        But the layout of int -> int must be a sublayout of void, because
-         of definition of t at Line 1, characters 0-22.
+         of the definition of t at Line 1, characters 0-22.
 |}]
 
 
@@ -40,7 +40,7 @@ Error: This expression has type [ `A | `B ]
        The layout of [ `A | `B ] is immediate, because
          it's an enumeration variant (all constructors are constant).
        But the layout of [ `A | `B ] must be a sublayout of void, because
-         of definition of t at Line 1, characters 0-22.
+         of the definition of t at Line 1, characters 0-22.
 |}]
 
 
@@ -58,7 +58,7 @@ Error: This expression has type [ `A of int | `B ]
        The layout of [ `A of int | `B ] is value, because
          it's a polymorphic variant.
        But the layout of [ `A of int | `B ] must be a sublayout of void, because
-         of definition of t at Line 1, characters 0-22.
+         of the definition of t at Line 1, characters 0-22.
 |}]
 
 
@@ -78,7 +78,7 @@ Error: This expression has type v but an expression was expected of type
        The layout of v is immediate, because
          it's an enumeration variant (all constructors are constant).
        But the layout of v must be a sublayout of void, because
-         of definition of t at Line 1, characters 0-22.
+         of the definition of t at Line 1, characters 0-22.
 |}]
 
 (* Extensible_variant *)
@@ -97,7 +97,7 @@ Error: This expression has type attr but an expression was expected of type
        The layout of attr is value, because
          it's an extensible variant.
        But the layout of attr must be a sublayout of void, because
-         of definition of t at Line 1, characters 0-22.
+         of the definition of t at Line 1, characters 0-22.
 |}]
 
 (* First_class_module *)
@@ -118,7 +118,7 @@ Error: This expression has type (module X_int)
        The layout of (module X_int) is value, because
          it's a first-class module type.
        But the layout of (module X_int) must be a sublayout of void, because
-         of definition of t at Line 1, characters 0-22.
+         of the definition of t at Line 1, characters 0-22.
 |}]
 
 (* Match *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
@@ -6,4 +6,4 @@ Error: This expression has type a but an expression was expected of type
        The layout of a is value, because
          it's an unannotated existential type variable.
        But the layout of a must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of f at File "gadt_existential.ml", line 10, characters 6-17.

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
@@ -6,4 +6,4 @@ Error: This expression has type a but an expression was expected of type
        The layout of a is value, because
          it's an unannotated existential type variable.
        But the layout of a must be a sublayout of void, because
-         of definition of f at File "gadt_existential.ml", line 10, characters 6-17.
+         of the definition of f at File "gadt_existential.ml", line 10, characters 6-17.

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
@@ -6,4 +6,4 @@ Error: This expression has type a but an expression was expected of type
        The layout of a is value, because
          it's an unannotated existential type variable.
        But the layout of a must be a sublayout of void, because
-         of the definition of f at File "gadt_existential.ml", line 10, characters 6-17.
+         of the definition of f at file "gadt_existential.ml", line 10, characters 6-17.

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -178,3 +178,80 @@ Error: This expression has type t_void but an expression was expected of type
        But the layout of t_void must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}]
+
+type ('a : value) t_v = 'a
+type ('a : void) t_vv = 'a
+let f x: 'a t_v = x
+let f2 = f
+let () = ignore (f2 (assert false : 'a t_vv))
+
+[%%expect{|
+type 'a t_v = 'a
+type ('a : void) t_vv = 'a
+val f : 'a t_v -> 'a t_v = <fun>
+val f2 : 'a t_v -> 'a t_v = <fun>
+Line 5, characters 20-44:
+5 | let () = ignore (f2 (assert false : 'a t_vv))
+                        ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type 'a t_vv = ('a : void)
+       but an expression was expected of type 'b t_v = ('b : value)
+       The layout of 'a is value, because
+         of definition of f2 at Line 4, characters 9-10.
+       But the layout of 'a must overlap with void, because
+         of definition of t_vv at Line 2, characters 0-26.
+|}]
+
+type ('a : value) t_v = 'a
+type ('a : void) t_v1 = 'a
+type 'a t_v2 = 'a t_v1
+let f x: 'a t_v = x
+
+let () = ignore (f (assert false : 'a t_v2))
+
+[%%expect{|
+type 'a t_v = 'a
+type ('a : void) t_v1 = 'a
+type ('a : void) t_v2 = 'a t_v1
+val f : 'a t_v -> 'a t_v = <fun>
+Line 6, characters 19-43:
+6 | let () = ignore (f (assert false : 'a t_v2))
+                       ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type 'a t_v2 = ('a : void)
+       but an expression was expected of type 'b t_v = ('b : value)
+       The layout of 'a is value, because
+         of definition of f at Line 4, characters 6-19.
+       But the layout of 'a must overlap with void, because
+         of definition of t_v2 at Line 3, characters 0-22.
+|}]
+
+
+module type S1 = sig
+  type ('a : void) t = 'a
+end
+
+module type S2 = S1
+
+module M : S2 = struct
+  type 'a t = 'a
+end
+
+[%%expect{|
+module type S1 = sig type ('a : void) t = 'a end
+module type S2 = S1
+Lines 7-9, characters 16-3:
+7 | ................struct
+8 |   type 'a t = 'a
+9 | end
+Error: Signature mismatch:
+       Modules do not match: sig type 'a t = 'a end is not included in S2
+       Type declarations do not match:
+         type 'a t = 'a
+       is not included in
+         type ('a : void) t = 'a
+       The type ('a : value) is not equal to the type ('a0 : void)
+       because their layouts are different.
+       The layout of 'a is value, because
+         of definition of t at Line 8, characters 2-16.
+       The layout of 'a is void, because
+         of definition of t at Line 2, characters 2-25.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -196,9 +196,9 @@ Line 5, characters 20-44:
 Error: This expression has type 'a t_vv = ('a : void)
        but an expression was expected of type 'b t_v = ('b : value)
        The layout of 'a is value, because
-         of definition of f2 at Line 4, characters 9-10.
+         of the definition of f2 at Line 4, characters 9-10.
        But the layout of 'a must overlap with void, because
-         of definition of t_vv at Line 2, characters 0-26.
+         of the definition of t_vv at Line 2, characters 0-26.
 |}]
 
 type ('a : value) t_v = 'a
@@ -219,9 +219,9 @@ Line 6, characters 19-43:
 Error: This expression has type 'a t_v2 = ('a : void)
        but an expression was expected of type 'b t_v = ('b : value)
        The layout of 'a is value, because
-         of definition of f at Line 4, characters 6-19.
+         of the definition of f at Line 4, characters 6-19.
        But the layout of 'a must overlap with void, because
-         of definition of t_v2 at Line 3, characters 0-22.
+         of the definition of t_v2 at Line 3, characters 0-22.
 |}]
 
 
@@ -251,7 +251,7 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : void)
        because their layouts are different.
        The layout of 'a is value, because
-         of definition of t at Line 8, characters 2-16.
+         of the definition of t at Line 8, characters 2-16.
        The layout of 'a is void, because
-         of definition of t at Line 2, characters 2-25.
+         of the definition of t at Line 2, characters 2-25.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -29,7 +29,7 @@ Line 1, characters 29-30:
 Error: This expression has type t_void but an expression was expected of type
          'a A.t = ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of A.t has this layout.
 |}]
@@ -42,7 +42,7 @@ Line 1, characters 9-15:
              ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of A.t has this layout.
 |}]
@@ -57,7 +57,7 @@ Line 1, characters 29-30:
 Error: This expression has type t_void but an expression was expected of type
          'a B.t = ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of B.t has this layout.
 |}]
@@ -70,7 +70,7 @@ Line 1, characters 9-15:
              ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of B.t has this layout.
 |}]
@@ -84,7 +84,7 @@ Line 1, characters 36-37:
 Error: This expression has type t_void but an expression was expected of type
          ('a, 'b) A.t2 = ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 1st type argument of A.t2 has this layout.
 |}]
@@ -97,7 +97,7 @@ Line 1, characters 10-16:
               ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 1st type argument of A.t2 has this layout.
 |}]
@@ -110,7 +110,7 @@ Line 1, characters 19-25:
                        ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 2nd type argument of A.t5 has this layout.
 |}]
@@ -123,7 +123,7 @@ Line 1, characters 28-34:
                                 ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 3rd type argument of A.t5 has this layout.
 |}]
@@ -136,7 +136,7 @@ Line 1, characters 37-43:
                                          ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 4th type argument of A.t5 has this layout.
 |}]
@@ -150,7 +150,7 @@ Line 1, characters 46-52:
                                                   ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 5th type argument of A.t5 has this layout.
 |}]
@@ -174,7 +174,7 @@ Line 1, characters 26-27:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 2, characters 0-18.
+         of the definition of t_void at line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}]
@@ -196,9 +196,9 @@ Line 5, characters 20-44:
 Error: This expression has type 'a t_vv = ('a : void)
        but an expression was expected of type 'b t_v = ('b : value)
        The layout of 'a is value, because
-         of the definition of f2 at Line 4, characters 9-10.
+         of the definition of f2 at line 4, characters 9-10.
        But the layout of 'a must overlap with void, because
-         of the definition of t_vv at Line 2, characters 0-26.
+         of the definition of t_vv at line 2, characters 0-26.
 |}]
 
 type ('a : value) t_v = 'a
@@ -219,9 +219,9 @@ Line 6, characters 19-43:
 Error: This expression has type 'a t_v2 = ('a : void)
        but an expression was expected of type 'b t_v = ('b : value)
        The layout of 'a is value, because
-         of the definition of f at Line 4, characters 6-19.
+         of the definition of f at line 4, characters 6-19.
        But the layout of 'a must overlap with void, because
-         of the definition of t_v2 at Line 3, characters 0-22.
+         of the definition of t_v2 at line 3, characters 0-22.
 |}]
 
 
@@ -251,7 +251,7 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : void)
        because their layouts are different.
        The layout of 'a is value, because
-         of the definition of t at Line 8, characters 2-16.
+         of the definition of t at line 8, characters 2-16.
        The layout of 'a is void, because
-         of the definition of t at Line 2, characters 2-25.
+         of the definition of t at line 2, characters 2-25.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -29,7 +29,7 @@ Line 1, characters 29-30:
 Error: This expression has type t_void but an expression was expected of type
          'a A.t = ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of A.t has this layout.
 |}]
@@ -42,7 +42,7 @@ Line 1, characters 9-15:
              ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of A.t has this layout.
 |}]
@@ -57,7 +57,7 @@ Line 1, characters 29-30:
 Error: This expression has type t_void but an expression was expected of type
          'a B.t = ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of B.t has this layout.
 |}]
@@ -70,7 +70,7 @@ Line 1, characters 9-15:
              ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of B.t has this layout.
 |}]
@@ -84,7 +84,7 @@ Line 1, characters 36-37:
 Error: This expression has type t_void but an expression was expected of type
          ('a, 'b) A.t2 = ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 1st type argument of A.t2 has this layout.
 |}]
@@ -97,7 +97,7 @@ Line 1, characters 10-16:
               ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 1st type argument of A.t2 has this layout.
 |}]
@@ -110,7 +110,7 @@ Line 1, characters 19-25:
                        ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 2nd type argument of A.t5 has this layout.
 |}]
@@ -123,7 +123,7 @@ Line 1, characters 28-34:
                                 ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 3rd type argument of A.t5 has this layout.
 |}]
@@ -136,7 +136,7 @@ Line 1, characters 37-43:
                                          ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 4th type argument of A.t5 has this layout.
 |}]
@@ -150,7 +150,7 @@ Line 1, characters 46-52:
                                                   ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the 5th type argument of A.t5 has this layout.
 |}]
@@ -174,7 +174,7 @@ Line 1, characters 26-27:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 2, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -112,7 +112,7 @@ Line 1, characters 27-28:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -150,7 +150,7 @@ Line 1, characters 12-21:
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -284,7 +284,7 @@ Line 1, characters 31-40:
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
        The layout of x is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of x must be a sublayout of value, because
          it's stored in a module structure.
 |}];;
@@ -324,7 +324,7 @@ Line 1, characters 30-31:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -362,7 +362,7 @@ Line 1, characters 20-29:
                         ^^^^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -403,7 +403,7 @@ Line 1, characters 20-39:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          of the definition of id_value at Line 5, characters 13-18.
 |}];;
@@ -585,7 +585,7 @@ Line 1, characters 15-28:
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -610,7 +610,7 @@ Line 1, characters 21-56:
 Error: The method x has type t_float64 but is expected to have type
          ('a : value)
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -637,7 +637,7 @@ Line 1, characters 25-26:
                              ^
 Error: Variables bound in a class must have layout value.
        The layout of x is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of x must be a sublayout of value, because
          it's an class field.
 |}];;
@@ -715,7 +715,7 @@ Line 3, characters 17-19:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's captured in an object.
 |}];;
@@ -732,7 +732,7 @@ Line 3, characters 17-19:
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's captured in an object.
 |}];;
@@ -751,7 +751,7 @@ Line 1, characters 28-29:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}];;
@@ -764,7 +764,7 @@ Line 1, characters 36-37:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}];;
@@ -777,7 +777,7 @@ Line 1, characters 45-46:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}];;
@@ -790,7 +790,7 @@ Line 1, characters 41-42:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -125,7 +125,7 @@ Line 1, characters 33-34:
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
-         of the annotation on 'a in the declaration of the type t_float64_id.
+         of definition of t_float64_id at Line 2, characters 0-37.
        But the layout of 'a t_float64_id must overlap with value, because
          it's a tuple element.
 |}];;
@@ -296,7 +296,7 @@ Line 1, characters 31-46:
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
        The layout of x is float64, because
-         of the annotation on 'a in the declaration of the type t_float64_id.
+         of definition of t_float64_id at Line 2, characters 0-37.
        But the layout of x must overlap with value, because
          it's stored in a module structure.
 |}];;
@@ -337,7 +337,7 @@ Line 1, characters 36-37:
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
-         of the annotation on 'a in the declaration of the type t_float64_id.
+         of definition of t_float64_id at Line 2, characters 0-37.
        But the layout of 'a t_float64_id must overlap with value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -405,7 +405,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         it's used as a function result, defaulted to layout value.
+         of definition of id_value at Line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -416,9 +416,9 @@ Line 1, characters 20-42:
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
-         of the annotation on 'a in the declaration of the type t_float64_id.
+         of definition of make_t_float64_id at Line 2, characters 22-57.
        But the layout of 'a t_float64_id must overlap with value, because
-         it's used as a function result, defaulted to layout value.
+         of definition of id_value at Line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -431,7 +431,7 @@ Error: This expression has type float# but an expression was expected of type
        The layout of float# is float64, because
          it is the primitive float64 type float#.
        But the layout of float# must be a sublayout of value, because
-         it's used as a function result, defaulted to layout value.
+         of definition of id_value at Line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -626,7 +626,7 @@ Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
-         of the annotation on 'a in the declaration of the type t_float64_id.
+         of definition of t_float64_id at Line 2, characters 0-37.
 |}];;
 (* CR layouts v2.9: Error could be improved *)
 
@@ -678,7 +678,7 @@ Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
-         of the annotation on 'a in the declaration of the type t_float64_id.
+         of definition of t_float64_id at Line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -112,7 +112,7 @@ Line 1, characters 27-28:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -125,7 +125,7 @@ Line 1, characters 33-34:
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
-         of the definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at line 2, characters 0-37.
        But the layout of 'a t_float64_id must overlap with value, because
          it's a tuple element.
 |}];;
@@ -150,7 +150,7 @@ Line 1, characters 12-21:
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -284,7 +284,7 @@ Line 1, characters 31-40:
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
        The layout of x is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of x must be a sublayout of value, because
          it's stored in a module structure.
 |}];;
@@ -296,7 +296,7 @@ Line 1, characters 31-46:
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
        The layout of x is float64, because
-         of the definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at line 2, characters 0-37.
        But the layout of x must overlap with value, because
          it's stored in a module structure.
 |}];;
@@ -324,7 +324,7 @@ Line 1, characters 30-31:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -337,7 +337,7 @@ Line 1, characters 36-37:
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
-         of the definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at line 2, characters 0-37.
        But the layout of 'a t_float64_id must overlap with value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -362,7 +362,7 @@ Line 1, characters 20-29:
                         ^^^^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -403,9 +403,9 @@ Line 1, characters 20-39:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
-         of the definition of id_value at Line 5, characters 13-18.
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -416,9 +416,9 @@ Line 1, characters 20-42:
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
-         of the definition of make_t_float64_id at Line 2, characters 22-57.
+         of the definition of make_t_float64_id at line 2, characters 22-57.
        But the layout of 'a t_float64_id must overlap with value, because
-         of the definition of id_value at Line 5, characters 13-18.
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -431,7 +431,7 @@ Error: This expression has type float# but an expression was expected of type
        The layout of float# is float64, because
          it is the primitive float64 type float#.
        But the layout of float# must be a sublayout of value, because
-         of the definition of id_value at Line 5, characters 13-18.
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -585,7 +585,7 @@ Line 1, characters 15-28:
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -610,7 +610,7 @@ Line 1, characters 21-56:
 Error: The method x has type t_float64 but is expected to have type
          ('a : value)
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -626,7 +626,7 @@ Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
-         of the definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
 (* CR layouts v2.9: Error could be improved *)
 
@@ -637,7 +637,7 @@ Line 1, characters 25-26:
                              ^
 Error: Variables bound in a class must have layout value.
        The layout of x is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of x must be a sublayout of value, because
          it's an class field.
 |}];;
@@ -678,7 +678,7 @@ Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
-         of the definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -715,7 +715,7 @@ Line 3, characters 17-19:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's captured in an object.
 |}];;
@@ -732,7 +732,7 @@ Line 3, characters 17-19:
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          it's captured in an object.
 |}];;
@@ -751,7 +751,7 @@ Line 1, characters 28-29:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}];;
@@ -764,7 +764,7 @@ Line 1, characters 36-37:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}];;
@@ -777,7 +777,7 @@ Line 1, characters 45-46:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}];;
@@ -790,7 +790,7 @@ Line 1, characters 41-42:
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 1, characters 0-26.
+         of the definition of t_float64 at line 1, characters 0-26.
        But the layout of t_float64 must be a sublayout of value, because
          of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha.ml
@@ -125,7 +125,7 @@ Line 1, characters 33-34:
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
-         of definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at Line 2, characters 0-37.
        But the layout of 'a t_float64_id must overlap with value, because
          it's a tuple element.
 |}];;
@@ -296,7 +296,7 @@ Line 1, characters 31-46:
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
        The layout of x is float64, because
-         of definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at Line 2, characters 0-37.
        But the layout of x must overlap with value, because
          it's stored in a module structure.
 |}];;
@@ -337,7 +337,7 @@ Line 1, characters 36-37:
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
-         of definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at Line 2, characters 0-37.
        But the layout of 'a t_float64_id must overlap with value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -405,7 +405,7 @@ Error: This expression has type t_float64
        The layout of t_float64 is float64, because
          of the annotation on the declaration of the type t_float64.
        But the layout of t_float64 must be a sublayout of value, because
-         of definition of id_value at Line 5, characters 13-18.
+         of the definition of id_value at Line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -416,9 +416,9 @@ Line 1, characters 20-42:
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
        The layout of 'a t_float64_id is float64, because
-         of definition of make_t_float64_id at Line 2, characters 22-57.
+         of the definition of make_t_float64_id at Line 2, characters 22-57.
        But the layout of 'a t_float64_id must overlap with value, because
-         of definition of id_value at Line 5, characters 13-18.
+         of the definition of id_value at Line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -431,7 +431,7 @@ Error: This expression has type float# but an expression was expected of type
        The layout of float# is float64, because
          it is the primitive float64 type float#.
        But the layout of float# must be a sublayout of value, because
-         of definition of id_value at Line 5, characters 13-18.
+         of the definition of id_value at Line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -626,7 +626,7 @@ Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
-         of definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at Line 2, characters 0-37.
 |}];;
 (* CR layouts v2.9: Error could be improved *)
 
@@ -678,7 +678,7 @@ Error: This type ('a : float64) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with float64, because
-         of definition of t_float64_id at Line 2, characters 0-37.
+         of the definition of t_float64_id at Line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
@@ -4,6 +4,6 @@ File "insert.ml", line 5, characters 47-48:
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
        The layout of t_void is void, because
-         of the definition of t_void at File "insert.ml", line 1, characters 0-20.
+         of the definition of t_void at file "insert.ml", line 1, characters 0-20.
        But the layout of t_void must be a sublayout of value, because
          of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
@@ -4,6 +4,6 @@ File "insert.ml", line 5, characters 47-48:
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at File "insert.ml", line 1, characters 0-20.
        But the layout of t_void must be a sublayout of value, because
          of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -4,6 +4,6 @@ File "insert_extensible.ml", line 5, characters 58-59:
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at File "insert_extensible.ml", line 1, characters 0-20.
        But the layout of t_void must be a sublayout of value, because
          of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -4,6 +4,6 @@ File "insert_extensible.ml", line 5, characters 58-59:
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
        The layout of t_void is void, because
-         of the definition of t_void at File "insert_extensible.ml", line 1, characters 0-20.
+         of the definition of t_void at file "insert_extensible.ml", line 1, characters 0-20.
        But the layout of t_void must be a sublayout of value, because
          of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -50,7 +50,7 @@ Error: This type B.b_value = A.a_value should be an instance of type
        The layout of B.b_value is value, because
          of layout requirements from an imported definition.
        But the layout of B.b_value must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type imm_arg.
+         of definition of imm_arg at Line 3, characters 0-29.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -50,7 +50,7 @@ Error: This type B.b_value = A.a_value should be an instance of type
        The layout of B.b_value is value, because
          of layout requirements from an imported definition.
        But the layout of B.b_value must be a sublayout of immediate, because
-         of the definition of imm_arg at Line 3, characters 0-29.
+         of the definition of imm_arg at line 3, characters 0-29.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -50,7 +50,7 @@ Error: This type B.b_value = A.a_value should be an instance of type
        The layout of B.b_value is value, because
          of layout requirements from an imported definition.
        But the layout of B.b_value must be a sublayout of immediate, because
-         of definition of imm_arg at Line 3, characters 0-29.
+         of the definition of imm_arg at Line 3, characters 0-29.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -227,7 +227,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on the universal variable a.
+         of the definition of r at Line 1, characters 0-47.
 |}]
 
 let r = { field = fun x -> x }
@@ -261,7 +261,7 @@ Line 2, characters 18-55:
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
        The layout of 'a is value, because
-         it's an unannotated universal variable.
+         of the definition of r_value at Line 1, characters 0-39.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on the abstract type declaration for a.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -105,7 +105,7 @@ Error: This type string should be an instance of type ('a : immediate)
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of t2_imm at Line 1, characters 0-28.
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 let f : 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -227,7 +227,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of r at Line 1, characters 0-47.
+         of the definition of r at line 1, characters 0-47.
 |}]
 
 let r = { field = fun x -> x }
@@ -261,7 +261,7 @@ Line 2, characters 18-55:
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
        The layout of 'a is value, because
-         of the definition of r_value at Line 1, characters 0-39.
+         of the definition of r_value at line 1, characters 0-39.
        But the layout of 'a must be a sublayout of immediate, because
          of the annotation on the abstract type declaration for a.
 |}]
@@ -280,7 +280,7 @@ Line 3, characters 15-39:
 Error: The layout of type 'a is value, because
          of the annotation on the universal variable a.
        But the layout of type 'a must be a sublayout of immediate, because
-         of the definition of t_imm at Line 1, characters 0-27.
+         of the definition of t_imm at line 1, characters 0-27.
 |}]
 (* CR layouts v1.5: the location on that message is wrong. But it's hard
    to improve, because it comes from re-checking typedtree, where we don't

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -105,7 +105,7 @@ Error: This type string should be an instance of type ('a : immediate)
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of t2_imm at Line 1, characters 0-28.
+         of the definition of t2_imm at Line 1, characters 0-28.
 |}]
 
 let f : 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -280,7 +280,7 @@ Line 3, characters 15-39:
 Error: The layout of type 'a is value, because
          of the annotation on the universal variable a.
        But the layout of type 'a must be a sublayout of immediate, because
-         of definition of t_imm at Line 1, characters 0-27.
+         of the definition of t_imm at Line 1, characters 0-27.
 |}]
 (* CR layouts v1.5: the location on that message is wrong. But it's hard
    to improve, because it comes from re-checking typedtree, where we don't

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -105,7 +105,7 @@ Error: This type string should be an instance of type ('a : immediate)
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t2_imm.
+         of definition of t2_imm at Line 1, characters 0-28.
 |}]
 
 let f : 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -280,7 +280,7 @@ Line 3, characters 15-39:
 Error: The layout of type 'a is value, because
          of the annotation on the universal variable a.
        But the layout of type 'a must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t_imm.
+         of definition of t_imm at Line 1, characters 0-27.
 |}]
 (* CR layouts v1.5: the location on that message is wrong. But it's hard
    to improve, because it comes from re-checking typedtree, where we don't

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -238,7 +238,7 @@ Error: This type string should be an instance of type ('a : immediate)
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of imm_id at Line 1, characters 0-33.
+         of the definition of imm_id at Line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -261,7 +261,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of id_for_imms at Line 1, characters 16-35.
+         of the definition of id_for_imms at Line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -378,7 +378,7 @@ Lines 4-5, characters 33-22:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of definition of void5 at Line 1, characters 0-37.
+         of the definition of void5 at Line 1, characters 0-37.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}];;
@@ -393,7 +393,7 @@ Error: This type int should be an instance of type ('a : void)
        The layout of int is immediate, because
          it is the primitive immediate type int.
        But the layout of int must be a sublayout of void, because
-         of definition of void5 at Line 1, characters 0-37.
+         of the definition of void5 at Line 1, characters 0-37.
 |}];;
 
 let h5' (x : int any5) = Void5 x
@@ -406,7 +406,7 @@ Error: This expression has type int any5
        The layout of int any5 is value, because
          it's a boxed variant.
        But the layout of int any5 must be a sublayout of void, because
-         of definition of void5 at Line 1, characters 0-37.
+         of the definition of void5 at Line 1, characters 0-37.
 |}];;
 
 (* disallowed - tries to return void *)
@@ -421,7 +421,7 @@ Lines 1-3, characters 6-16:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of definition of void5 at Line 1, characters 0-37.
+         of the definition of void5 at Line 1, characters 0-37.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -452,7 +452,7 @@ Error: This definition has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of definition of t6_imm at Line 1, characters 0-42.
+         of the definition of t6_imm at Line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -468,7 +468,7 @@ Error: This method has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of definition of t6_imm at Line 1, characters 0-42.
+         of the definition of t6_imm at Line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -490,7 +490,7 @@ Error: This type int * int should be an instance of type ('a : immediate)
        The layout of int * int is value, because
          it's a tuple type.
        But the layout of int * int must be a sublayout of immediate, because
-         of definition of t7 at Line 1, characters 0-37.
+         of the definition of t7 at Line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -542,7 +542,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         of definition of t at Line 2, characters 2-42.
+         of the definition of t at Line 2, characters 2-42.
 |}];;
 
 module M8_4 = struct
@@ -656,7 +656,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         of definition of t at Line 2, characters 2-24.
+         of the definition of t at Line 2, characters 2-24.
 |}];;
 
 module M9_6 = struct
@@ -747,7 +747,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of x at Line 8, characters 10-26.
+         of the definition of x at Line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -787,7 +787,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of x at Line 8, characters 10-26.
+         of the definition of x at Line 8, characters 10-26.
 |}]
 
 (**************************************************************)
@@ -804,7 +804,7 @@ Line 5, characters 4-7:
         ^^^
 Error: Methods must have layout value.
        The layout of this expression is void, because
-         of definition of t at Line 2, characters 2-42.
+         of the definition of t at Line 2, characters 2-42.
        But the layout of this expression must overlap with value, because
          it's an object.
 |}]
@@ -836,7 +836,7 @@ Line 4, characters 12-33:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of definition of t at Line 2, characters 2-30.
+         of the definition of t at Line 2, characters 2-30.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}];;
@@ -962,7 +962,7 @@ Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
-         of definition of t at Line 2, characters 2-20.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 module M12_5 = struct
@@ -981,7 +981,7 @@ Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
-         of definition of t at Line 2, characters 2-30.
+         of the definition of t at Line 2, characters 2-30.
 |}];;
 
 module type S12_6 = sig
@@ -1001,7 +1001,7 @@ Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
-         of definition of t at Line 2, characters 2-30.
+         of the definition of t at Line 2, characters 2-30.
 |}];;
 
 module type S12_7 = sig
@@ -1336,7 +1336,7 @@ Lines 5-7, characters 6-20:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of definition of r at Line 3, characters 0-40.
+         of the definition of r at Line 3, characters 0-40.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}];;
@@ -1712,7 +1712,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         of definition of eq at Line 2, characters 2-43.
+         of the definition of eq at Line 2, characters 2-43.
 |}]
 
 (**************************************)
@@ -1741,7 +1741,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         of definition of f at Line 3, characters 4-20.
+         of the definition of f at Line 3, characters 4-20.
 |}]
 
 (**************************************************)
@@ -1820,5 +1820,5 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         of definition of t35 at Line 1, characters 0-16.
+         of the definition of t35 at Line 1, characters 0-16.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -238,7 +238,7 @@ Error: This type string should be an instance of type ('a : immediate)
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type imm_id.
+         of definition of imm_id at Line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -261,7 +261,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type imm_id.
+         of definition of id_for_imms at Line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -378,7 +378,7 @@ Lines 4-5, characters 33-22:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of the annotation on 'a in the declaration of the type void5.
+         of definition of void5 at Line 1, characters 0-37.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}];;
@@ -393,7 +393,7 @@ Error: This type int should be an instance of type ('a : void)
        The layout of int is immediate, because
          it is the primitive immediate type int.
        But the layout of int must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type void5.
+         of definition of void5 at Line 1, characters 0-37.
 |}];;
 
 let h5' (x : int any5) = Void5 x
@@ -406,7 +406,7 @@ Error: This expression has type int any5
        The layout of int any5 is value, because
          it's a boxed variant.
        But the layout of int any5 must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type void5.
+         of definition of void5 at Line 1, characters 0-37.
 |}];;
 
 (* disallowed - tries to return void *)
@@ -421,7 +421,7 @@ Lines 1-3, characters 6-16:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of the annotation on 'a in the declaration of the type void5.
+         of definition of void5 at Line 1, characters 0-37.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -452,7 +452,7 @@ Error: This definition has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t6_imm.
+         of definition of t6_imm at Line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -468,7 +468,7 @@ Error: This method has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t6_imm.
+         of definition of t6_imm at Line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -490,7 +490,7 @@ Error: This type int * int should be an instance of type ('a : immediate)
        The layout of int * int is value, because
          it's a tuple type.
        But the layout of int * int must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t7.
+         of definition of t7 at Line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -542,7 +542,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it's a field of a polymorphic variant.
+         of definition of t at Line 2, characters 2-42.
 |}];;
 
 module M8_4 = struct
@@ -656,7 +656,7 @@ Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it's a tuple element.
+         of definition of t at Line 2, characters 2-24.
 |}];;
 
 module M9_6 = struct
@@ -747,7 +747,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of x at Line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -787,7 +787,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of x at Line 8, characters 10-26.
 |}]
 
 (**************************************************************)
@@ -804,7 +804,7 @@ Line 5, characters 4-7:
         ^^^
 Error: Methods must have layout value.
        The layout of this expression is void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-42.
        But the layout of this expression must overlap with value, because
          it's an object.
 |}]
@@ -836,7 +836,7 @@ Line 4, characters 12-33:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-30.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}];;
@@ -962,7 +962,7 @@ Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-20.
 |}];;
 
 module M12_5 = struct
@@ -981,7 +981,7 @@ Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-30.
 |}];;
 
 module type S12_6 = sig
@@ -1001,7 +1001,7 @@ Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-30.
 |}];;
 
 module type S12_7 = sig
@@ -1336,7 +1336,7 @@ Lines 5-7, characters 6-20:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of the annotation on 'a in the declaration of the type r.
+         of definition of r at Line 3, characters 0-40.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}];;
@@ -1712,7 +1712,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it's used as a function argument, defaulted to layout value.
+         of definition of eq at Line 2, characters 2-43.
 |}]
 
 (**************************************)
@@ -1741,7 +1741,7 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it's used as a function argument, defaulted to layout value.
+         of definition of f at Line 3, characters 4-20.
 |}]
 
 (**************************************************)
@@ -1820,5 +1820,5 @@ Error: This expression has type t_void but an expression was expected of type
        The layout of t_void is void, because
          of the annotation on the declaration of the type t_void.
        But the layout of t_void must be a sublayout of value, because
-         it instantiates an unannotated type parameter, defaulted to layout value.
+         of definition of t35 at Line 1, characters 0-16.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -38,7 +38,7 @@ Line 2, characters 17-22:
                      ^^^^^
 Error: Function return types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 1, characters 0-18.
        But the layout of t_any must be a sublayout of '_representable_layout_1, because
          it's used as a function result.
 |}];;
@@ -52,7 +52,7 @@ Line 2, characters 10-15:
               ^^^^^
 Error: Function argument types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 1, characters 0-18.
        But the layout of t_any must be a sublayout of '_representable_layout_2, because
          it's used as a function argument.
 |}];;
@@ -69,7 +69,7 @@ Line 4, characters 35-41:
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_3) is not compatible with type t
        The layout of t is any, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-14.
        But the layout of t must be a sublayout of '_representable_layout_3, because
          it instantiates an unannotated type parameter.
 |}]
@@ -86,7 +86,7 @@ Line 4, characters 35-41:
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_4) is not compatible with type t
        The layout of t is any, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-14.
        But the layout of t must be a sublayout of '_representable_layout_4, because
          it instantiates an unannotated type parameter.
 |}]
@@ -99,7 +99,7 @@ Line 1, characters 20-32:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_5)
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 1, characters 0-18.
        But the layout of t_any must be a sublayout of '_representable_layout_5, because
          it's used as a function result.
 |}];;
@@ -113,7 +113,7 @@ Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_6)
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 1, characters 0-18.
        But the layout of t_any must be a sublayout of '_representable_layout_6, because
          it's used as a function argument.
 |}];;
@@ -194,7 +194,7 @@ Line 1, characters 27-33:
                                ^^^^^^
 Error: This type signature for x is not a value type.
        The layout of x is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of x must be a sublayout of value, because
          it's stored in a module structure.
 |}];;
@@ -404,7 +404,7 @@ Line 1, characters 31-32:
 Error: This expression has type int any5
        but an expression was expected of type ('a : void)
        The layout of int any5 is value, because
-         it's a boxed variant.
+         of the definition of any5 at Line 2, characters 0-33.
        But the layout of int any5 must be a sublayout of void, because
          of the definition of void5 at Line 1, characters 0-37.
 |}];;
@@ -507,7 +507,7 @@ Line 2, characters 40-46:
                                             ^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -540,7 +540,7 @@ Line 4, characters 13-19:
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          of the definition of t at Line 2, characters 2-42.
 |}];;
@@ -555,7 +555,7 @@ Line 2, characters 54-78:
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
        The layout of void_unboxed_record is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -569,7 +569,7 @@ Line 2, characters 17-23:
                      ^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}]
@@ -587,7 +587,7 @@ Line 2, characters 20-26:
                         ^^^^^^
 Error: Tuple element types must have layout value.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -601,7 +601,7 @@ Line 2, characters 31-50:
                                    ^^^^^^^^^^^^^^^^^^^
 Error: Tuple element types must have layout value.
        The layout of void_unboxed_record is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -621,7 +621,7 @@ Line 7, characters 13-14:
 Error: This expression has type void_unboxed_record
        but an expression was expected of type ('a : value)
        The layout of void_unboxed_record is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -638,7 +638,7 @@ Line 4, characters 8-16:
 Error: The record field vur_void belongs to the type void_unboxed_record
        but is mixed here with fields of type ('a : value)
        The layout of void_unboxed_record is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a boxed record.
 |}];;
@@ -654,7 +654,7 @@ Line 4, characters 13-19:
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          of the definition of t at Line 2, characters 2-24.
 |}];;
@@ -669,7 +669,7 @@ Line 2, characters 34-58:
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
        The layout of void_unboxed_record is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -683,7 +683,7 @@ Line 2, characters 16-22:
                     ^^^^^^
 Error: Tuple element types must have layout value.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -702,7 +702,7 @@ Line 5, characters 11-23:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -819,7 +819,7 @@ Line 2, characters 17-30:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -850,7 +850,7 @@ Line 2, characters 12-22:
                 ^^^^^^^^^^
 Error: Object field types must have layout value.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -880,7 +880,7 @@ Line 2, characters 36-47:
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_void
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -923,7 +923,7 @@ Line 4, characters 10-13:
               ^^^
 Error: Variables bound in a class must have layout value.
        The layout of bar is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of bar must be a sublayout of value, because
          it's an class field.
 |}];;
@@ -941,7 +941,7 @@ Line 4, characters 18-21:
                       ^^^
 Error: Variables bound in a class must have layout value.
        The layout of bar is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of bar must be a sublayout of value, because
          it's an class field.
 |}];;
@@ -1016,7 +1016,7 @@ Line 4, characters 6-22:
           ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
        The layout of baz is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of baz must be a sublayout of value, because
          it's an instance variable.
 |}];;
@@ -1032,7 +1032,7 @@ Line 1, characters 11-17:
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of Lazy.t has this layout.
 |}];;
@@ -1045,7 +1045,7 @@ Line 1, characters 22-23:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a lazy expression.
 |}];;
@@ -1060,7 +1060,7 @@ Line 3, characters 17-18:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a lazy expression.
 |}];;
@@ -1074,7 +1074,7 @@ Line 1, characters 11-17:
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of option has layout value.
 |}];;
@@ -1087,7 +1087,7 @@ Line 1, characters 22-23:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of option has layout value.
 |}];;
@@ -1103,7 +1103,7 @@ Line 3, characters 17-18:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of option has layout value.
 |}];;
@@ -1117,7 +1117,7 @@ Line 1, characters 11-17:
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of list has layout value.
 |}];;
@@ -1130,7 +1130,7 @@ Line 1, characters 18-19:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of list has layout value.
 |}];;
@@ -1146,7 +1146,7 @@ Line 3, characters 14-15:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of list has layout value.
 |}];;
@@ -1160,7 +1160,7 @@ Line 1, characters 11-17:
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of array has layout value.
 |}];;
@@ -1173,7 +1173,7 @@ Line 1, characters 20-21:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an array element.
 |}];;
@@ -1189,7 +1189,7 @@ Line 3, characters 18-19:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an array element.
 |}];;
@@ -1211,7 +1211,7 @@ Line 2, characters 0-18:
     ^^^^^^^^^^^^^^^^^^
 Error:
        The layout of foo14 is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 6, characters 0-19.
        But the layout of foo14 must be a sublayout of value, because
          the type argument of list has layout value.
 |}];;
@@ -1370,9 +1370,9 @@ Error: This pattern matches values of type (M.t_void, M.t_void) eq
        but a pattern was expected which matches values of type
          (M.t_void, M.t_imm) eq
        The layout of M.t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 4, characters 2-20.
        But the layout of M.t_void must overlap with immediate, because
-         of the annotation on the declaration of the type t_imm.
+         of the definition of t_imm at Line 5, characters 2-24.
 |}]
 (* CR layouts v2.9: error message is OK, but it could probably be better.
    But a similar case without layouts is already pretty bad, so try
@@ -1409,7 +1409,7 @@ Line 2, characters 15-16:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of option has layout value.
 |}]
@@ -1662,7 +1662,7 @@ Line 4, characters 9-19:
 Error: This pattern matches values of type t_void
        but a pattern was expected which matches values of type ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it's a tuple element.
 |}]
@@ -1684,7 +1684,7 @@ Line 4, characters 9-22:
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
        The layout of t_float64 is float64, because
-         of the annotation on the declaration of the type t_float64.
+         of the definition of t_float64 at Line 5, characters 0-24.
        But the layout of t_float64 must be a sublayout of value, because
          it's a tuple element.
 |}]
@@ -1710,7 +1710,7 @@ Line 4, characters 16-28:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          of the definition of eq at Line 2, characters 2-43.
 |}]
@@ -1739,7 +1739,7 @@ Line 8, characters 27-28:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          of the definition of f at Line 3, characters 4-20.
 |}]
@@ -1779,7 +1779,7 @@ Line 1, characters 14-37:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}]
@@ -1794,7 +1794,7 @@ Line 1, characters 17-22:
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
        The layout of foo33 is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 1, characters 0-18.
        But the layout of foo33 must be a sublayout of value, because
          it's stored in a module structure.
 |}]
@@ -1818,7 +1818,7 @@ Line 2, characters 30-31:
 Error: This expression has type t_void but an expression was expected of type
          'a t35 = ('a : value)
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          of the definition of t35 at Line 1, characters 0-16.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -38,7 +38,7 @@ Line 2, characters 17-22:
                      ^^^^^
 Error: Function return types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 1, characters 0-18.
+         of the definition of t_any at line 1, characters 0-18.
        But the layout of t_any must be a sublayout of '_representable_layout_1, because
          it's used as a function result.
 |}];;
@@ -52,7 +52,7 @@ Line 2, characters 10-15:
               ^^^^^
 Error: Function argument types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 1, characters 0-18.
+         of the definition of t_any at line 1, characters 0-18.
        But the layout of t_any must be a sublayout of '_representable_layout_2, because
          it's used as a function argument.
 |}];;
@@ -69,7 +69,7 @@ Line 4, characters 35-41:
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_3) is not compatible with type t
        The layout of t is any, because
-         of the definition of t at Line 2, characters 2-14.
+         of the definition of t at line 2, characters 2-14.
        But the layout of t must be a sublayout of '_representable_layout_3, because
          it instantiates an unannotated type parameter.
 |}]
@@ -86,7 +86,7 @@ Line 4, characters 35-41:
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_4) is not compatible with type t
        The layout of t is any, because
-         of the definition of t at Line 2, characters 2-14.
+         of the definition of t at line 2, characters 2-14.
        But the layout of t must be a sublayout of '_representable_layout_4, because
          it instantiates an unannotated type parameter.
 |}]
@@ -99,7 +99,7 @@ Line 1, characters 20-32:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_5)
        The layout of t_any is any, because
-         of the definition of t_any at Line 1, characters 0-18.
+         of the definition of t_any at line 1, characters 0-18.
        But the layout of t_any must be a sublayout of '_representable_layout_5, because
          it's used as a function result.
 |}];;
@@ -113,7 +113,7 @@ Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_6)
        The layout of t_any is any, because
-         of the definition of t_any at Line 1, characters 0-18.
+         of the definition of t_any at line 1, characters 0-18.
        But the layout of t_any must be a sublayout of '_representable_layout_6, because
          it's used as a function argument.
 |}];;
@@ -194,7 +194,7 @@ Line 1, characters 27-33:
                                ^^^^^^
 Error: This type signature for x is not a value type.
        The layout of x is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of x must be a sublayout of value, because
          it's stored in a module structure.
 |}];;
@@ -238,7 +238,7 @@ Error: This type string should be an instance of type ('a : immediate)
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of imm_id at Line 1, characters 0-33.
+         of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -261,7 +261,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of id_for_imms at Line 1, characters 16-35.
+         of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -378,7 +378,7 @@ Lines 4-5, characters 33-22:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of the definition of void5 at Line 1, characters 0-37.
+         of the definition of void5 at line 1, characters 0-37.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}];;
@@ -393,7 +393,7 @@ Error: This type int should be an instance of type ('a : void)
        The layout of int is immediate, because
          it is the primitive immediate type int.
        But the layout of int must be a sublayout of void, because
-         of the definition of void5 at Line 1, characters 0-37.
+         of the definition of void5 at line 1, characters 0-37.
 |}];;
 
 let h5' (x : int any5) = Void5 x
@@ -404,9 +404,9 @@ Line 1, characters 31-32:
 Error: This expression has type int any5
        but an expression was expected of type ('a : void)
        The layout of int any5 is value, because
-         of the definition of any5 at Line 2, characters 0-33.
+         of the definition of any5 at line 2, characters 0-33.
        But the layout of int any5 must be a sublayout of void, because
-         of the definition of void5 at Line 1, characters 0-37.
+         of the definition of void5 at line 1, characters 0-37.
 |}];;
 
 (* disallowed - tries to return void *)
@@ -421,7 +421,7 @@ Lines 1-3, characters 6-16:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of the definition of void5 at Line 1, characters 0-37.
+         of the definition of void5 at line 1, characters 0-37.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -452,7 +452,7 @@ Error: This definition has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of the definition of t6_imm at Line 1, characters 0-42.
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -468,7 +468,7 @@ Error: This method has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of the definition of t6_imm at Line 1, characters 0-42.
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -490,7 +490,7 @@ Error: This type int * int should be an instance of type ('a : immediate)
        The layout of int * int is value, because
          it's a tuple type.
        But the layout of int * int must be a sublayout of immediate, because
-         of the definition of t7 at Line 1, characters 0-37.
+         of the definition of t7 at line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -507,7 +507,7 @@ Line 2, characters 40-46:
                                             ^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -540,9 +540,9 @@ Line 4, characters 13-19:
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
-         of the definition of t at Line 2, characters 2-42.
+         of the definition of t at line 2, characters 2-42.
 |}];;
 
 module M8_4 = struct
@@ -555,7 +555,7 @@ Line 2, characters 54-78:
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
        The layout of void_unboxed_record is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}];;
@@ -569,7 +569,7 @@ Line 2, characters 17-23:
                      ^^^^^^
 Error: Polymorpic variant constructor argument types must have layout value.
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}]
@@ -587,7 +587,7 @@ Line 2, characters 20-26:
                         ^^^^^^
 Error: Tuple element types must have layout value.
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -601,7 +601,7 @@ Line 2, characters 31-50:
                                    ^^^^^^^^^^^^^^^^^^^
 Error: Tuple element types must have layout value.
        The layout of void_unboxed_record is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -621,7 +621,7 @@ Line 7, characters 13-14:
 Error: This expression has type void_unboxed_record
        but an expression was expected of type ('a : value)
        The layout of void_unboxed_record is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -638,7 +638,7 @@ Line 4, characters 8-16:
 Error: The record field vur_void belongs to the type void_unboxed_record
        but is mixed here with fields of type ('a : value)
        The layout of void_unboxed_record is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a boxed record.
 |}];;
@@ -654,9 +654,9 @@ Line 4, characters 13-19:
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
-         of the definition of t at Line 2, characters 2-24.
+         of the definition of t at line 2, characters 2-24.
 |}];;
 
 module M9_6 = struct
@@ -669,7 +669,7 @@ Line 2, characters 34-58:
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
        The layout of void_unboxed_record is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -683,7 +683,7 @@ Line 2, characters 16-22:
                     ^^^^^^
 Error: Tuple element types must have layout value.
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -702,7 +702,7 @@ Line 5, characters 11-23:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a tuple element.
 |}];;
@@ -747,7 +747,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of x at Line 8, characters 10-26.
+         of the definition of x at line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -787,7 +787,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of x at Line 8, characters 10-26.
+         of the definition of x at line 8, characters 10-26.
 |}]
 
 (**************************************************************)
@@ -804,7 +804,7 @@ Line 5, characters 4-7:
         ^^^
 Error: Methods must have layout value.
        The layout of this expression is void, because
-         of the definition of t at Line 2, characters 2-42.
+         of the definition of t at line 2, characters 2-42.
        But the layout of this expression must overlap with value, because
          it's an object.
 |}]
@@ -819,7 +819,7 @@ Line 2, characters 17-30:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -836,7 +836,7 @@ Line 4, characters 12-33:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of the definition of t at Line 2, characters 2-30.
+         of the definition of t at line 2, characters 2-30.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}];;
@@ -850,7 +850,7 @@ Line 2, characters 12-22:
                 ^^^^^^^^^^
 Error: Object field types must have layout value.
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -880,7 +880,7 @@ Line 2, characters 36-47:
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_void
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an object field.
 |}];;
@@ -923,7 +923,7 @@ Line 4, characters 10-13:
               ^^^
 Error: Variables bound in a class must have layout value.
        The layout of bar is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of bar must be a sublayout of value, because
          it's an class field.
 |}];;
@@ -941,7 +941,7 @@ Line 4, characters 18-21:
                       ^^^
 Error: Variables bound in a class must have layout value.
        The layout of bar is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of bar must be a sublayout of value, because
          it's an class field.
 |}];;
@@ -962,7 +962,7 @@ Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module M12_5 = struct
@@ -981,7 +981,7 @@ Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
-         of the definition of t at Line 2, characters 2-30.
+         of the definition of t at line 2, characters 2-30.
 |}];;
 
 module type S12_6 = sig
@@ -1001,7 +1001,7 @@ Error: This type ('a : void) should be an instance of type ('a0 : value)
        The layout of 'a is value, because
          it's a term-level argument to a class constructor.
        But the layout of 'a must overlap with void, because
-         of the definition of t at Line 2, characters 2-30.
+         of the definition of t at line 2, characters 2-30.
 |}];;
 
 module type S12_7 = sig
@@ -1016,7 +1016,7 @@ Line 4, characters 6-22:
           ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
        The layout of baz is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of baz must be a sublayout of value, because
          it's an instance variable.
 |}];;
@@ -1032,7 +1032,7 @@ Line 1, characters 11-17:
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of Lazy.t has this layout.
 |}];;
@@ -1045,7 +1045,7 @@ Line 1, characters 22-23:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a lazy expression.
 |}];;
@@ -1060,7 +1060,7 @@ Line 3, characters 17-18:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's a lazy expression.
 |}];;
@@ -1074,7 +1074,7 @@ Line 1, characters 11-17:
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of option has layout value.
 |}];;
@@ -1087,7 +1087,7 @@ Line 1, characters 22-23:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of option has layout value.
 |}];;
@@ -1103,7 +1103,7 @@ Line 3, characters 17-18:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of option has layout value.
 |}];;
@@ -1117,7 +1117,7 @@ Line 1, characters 11-17:
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of list has layout value.
 |}];;
@@ -1130,7 +1130,7 @@ Line 1, characters 18-19:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of list has layout value.
 |}];;
@@ -1146,7 +1146,7 @@ Line 3, characters 14-15:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of list has layout value.
 |}];;
@@ -1160,7 +1160,7 @@ Line 1, characters 11-17:
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          the type argument of array has layout value.
 |}];;
@@ -1173,7 +1173,7 @@ Line 1, characters 20-21:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an array element.
 |}];;
@@ -1189,7 +1189,7 @@ Line 3, characters 18-19:
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
        The layout of t_void is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's an array element.
 |}];;
@@ -1211,7 +1211,7 @@ Line 2, characters 0-18:
     ^^^^^^^^^^^^^^^^^^
 Error:
        The layout of foo14 is void, because
-         of the definition of t_void at Line 6, characters 0-19.
+         of the definition of t_void at line 6, characters 0-19.
        But the layout of foo14 must be a sublayout of value, because
          the type argument of list has layout value.
 |}];;
@@ -1336,7 +1336,7 @@ Lines 5-7, characters 6-20:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void, because
-         of the definition of r at Line 3, characters 0-40.
+         of the definition of r at line 3, characters 0-40.
        But the layout of 'a must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}];;
@@ -1370,9 +1370,9 @@ Error: This pattern matches values of type (M.t_void, M.t_void) eq
        but a pattern was expected which matches values of type
          (M.t_void, M.t_imm) eq
        The layout of M.t_void is void, because
-         of the definition of t_void at Line 4, characters 2-20.
+         of the definition of t_void at line 4, characters 2-20.
        But the layout of M.t_void must overlap with immediate, because
-         of the definition of t_imm at Line 5, characters 2-24.
+         of the definition of t_imm at line 5, characters 2-24.
 |}]
 (* CR layouts v2.9: error message is OK, but it could probably be better.
    But a similar case without layouts is already pretty bad, so try
@@ -1409,7 +1409,7 @@ Line 2, characters 15-16:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          the type argument of option has layout value.
 |}]
@@ -1662,7 +1662,7 @@ Line 4, characters 9-19:
 Error: This pattern matches values of type t_void
        but a pattern was expected which matches values of type ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it's a tuple element.
 |}]
@@ -1684,7 +1684,7 @@ Line 4, characters 9-22:
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
        The layout of t_float64 is float64, because
-         of the definition of t_float64 at Line 5, characters 0-24.
+         of the definition of t_float64 at line 5, characters 0-24.
        But the layout of t_float64 must be a sublayout of value, because
          it's a tuple element.
 |}]
@@ -1710,9 +1710,9 @@ Line 4, characters 16-28:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
-         of the definition of eq at Line 2, characters 2-43.
+         of the definition of eq at line 2, characters 2-43.
 |}]
 
 (**************************************)
@@ -1739,9 +1739,9 @@ Line 8, characters 27-28:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
-         of the definition of f at Line 3, characters 4-20.
+         of the definition of f at line 3, characters 4-20.
 |}]
 
 (**************************************************)
@@ -1779,7 +1779,7 @@ Line 1, characters 14-37:
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it's a field of a polymorphic variant.
 |}]
@@ -1794,7 +1794,7 @@ Line 1, characters 17-22:
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
        The layout of foo33 is any, because
-         of the definition of t_any at Line 1, characters 0-18.
+         of the definition of t_any at line 1, characters 0-18.
        But the layout of foo33 must be a sublayout of value, because
          it's stored in a module structure.
 |}]
@@ -1818,7 +1818,7 @@ Line 2, characters 30-31:
 Error: This expression has type t_void but an expression was expected of type
          'a t35 = ('a : value)
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
-         of the definition of t35 at Line 1, characters 0-16.
+         of the definition of t35 at line 1, characters 0-16.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -77,7 +77,7 @@ Error: This type string should be an instance of type ('a : immediate)
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of imm_id at Line 1, characters 0-33.
+         of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -100,7 +100,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of id_for_imms at Line 1, characters 16-35.
+         of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -229,7 +229,7 @@ Error: This definition has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of the definition of t6_imm at Line 1, characters 0-42.
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -245,7 +245,7 @@ Error: This method has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of the definition of t6_imm at Line 1, characters 0-42.
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -266,7 +266,7 @@ Error: This type int * int should be an instance of type ('a : immediate)
        The layout of int * int is value, because
          it's a tuple type.
        But the layout of int * int must be a sublayout of immediate, because
-         of the definition of t7 at Line 1, characters 0-37.
+         of the definition of t7 at line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -324,7 +324,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of x at Line 8, characters 10-26.
+         of the definition of x at line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -364,7 +364,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of x at Line 8, characters 10-26.
+         of the definition of x at line 8, characters 10-26.
 |}]
 
 (**************************************************************)
@@ -577,7 +577,7 @@ Line 3, characters 15-40:
 Error: The layout of type 'a is value, because
          of the annotation on the universal variable a.
        But the layout of type 'a must be a sublayout of immediate, because
-         of the definition of t2_imm at Line 1, characters 0-28.
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 (****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -77,7 +77,7 @@ Error: This type string should be an instance of type ('a : immediate)
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type imm_id.
+         of definition of imm_id at Line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -100,7 +100,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type imm_id.
+         of definition of id_for_imms at Line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -229,7 +229,7 @@ Error: This definition has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t6_imm.
+         of definition of t6_imm at Line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -245,7 +245,7 @@ Error: This method has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t6_imm.
+         of definition of t6_imm at Line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -266,7 +266,7 @@ Error: This type int * int should be an instance of type ('a : immediate)
        The layout of int * int is value, because
          it's a tuple type.
        But the layout of int * int must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t7.
+         of definition of t7 at Line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -324,7 +324,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of x at Line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -364,7 +364,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of x at Line 8, characters 10-26.
 |}]
 
 (**************************************************************)
@@ -577,7 +577,7 @@ Line 3, characters 15-40:
 Error: The layout of type 'a is value, because
          of the annotation on the universal variable a.
        But the layout of type 'a must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t2_imm.
+         of definition of t2_imm at Line 1, characters 0-28.
 |}]
 
 (****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -77,7 +77,7 @@ Error: This type string should be an instance of type ('a : immediate)
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of imm_id at Line 1, characters 0-33.
+         of the definition of imm_id at Line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -100,7 +100,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of id_for_imms at Line 1, characters 16-35.
+         of the definition of id_for_imms at Line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -229,7 +229,7 @@ Error: This definition has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of definition of t6_imm at Line 1, characters 0-42.
+         of the definition of t6_imm at Line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -245,7 +245,7 @@ Error: This method has type 'b -> unit which is less general than
        The layout of 'a is value, because
          it's an unannotated universal variable.
        But the layout of 'a must be a sublayout of immediate, because
-         of definition of t6_imm at Line 1, characters 0-42.
+         of the definition of t6_imm at Line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -266,7 +266,7 @@ Error: This type int * int should be an instance of type ('a : immediate)
        The layout of int * int is value, because
          it's a tuple type.
        But the layout of int * int must be a sublayout of immediate, because
-         of definition of t7 at Line 1, characters 0-37.
+         of the definition of t7 at Line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -324,7 +324,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of x at Line 8, characters 10-26.
+         of the definition of x at Line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -364,7 +364,7 @@ Error: Signature mismatch:
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of x at Line 8, characters 10-26.
+         of the definition of x at Line 8, characters 10-26.
 |}]
 
 (**************************************************************)
@@ -577,7 +577,7 @@ Line 3, characters 15-40:
 Error: The layout of type 'a is value, because
          of the annotation on the universal variable a.
        But the layout of type 'a must be a sublayout of immediate, because
-         of definition of t2_imm at Line 1, characters 0-28.
+         of the definition of t2_imm at Line 1, characters 0-28.
 |}]
 
 (****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -51,7 +51,7 @@ Line 1, characters 15-31:
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_1, because
          it's used as constructor field 0.
 |}];;
@@ -63,7 +63,7 @@ Line 1, characters 15-45:
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_2, because
          it's used as constructor field 1.
 |}];;
@@ -75,7 +75,7 @@ Line 1, characters 15-41:
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_3, because
          it's used as constructor field 0.
 |}];;
@@ -88,7 +88,7 @@ Line 2, characters 0-29:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
        The layout of 'b t1_constraint' is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of 'b t1_constraint' must be a sublayout of '_representable_layout_4, because
          it instantiates an unannotated type parameter.
 |}]
@@ -149,7 +149,7 @@ Line 1, characters 17-26:
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_5, because
          it's used in the declaration of the record field "x/341".
 |}];;
@@ -161,7 +161,7 @@ Line 1, characters 34-43:
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_6, because
          it's used in the declaration of the record field "y/344".
 |}];;
@@ -173,7 +173,7 @@ Line 1, characters 18-28:
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_7, because
          it's used in the declaration of the record field "x/346".
 |}];;
@@ -185,7 +185,7 @@ Line 1, characters 23-32:
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_8, because
          it's used in the declaration of the record field "x/350".
 |}];;
@@ -197,7 +197,7 @@ Line 1, characters 40-49:
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_9, because
          it's used in the declaration of the record field "y/354".
 |}];;
@@ -209,7 +209,7 @@ Line 1, characters 23-33:
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_10, because
          it's used in the declaration of the record field "x/357".
 |}];;
@@ -243,7 +243,7 @@ Line 1, characters 11-24:
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_11, because
          it's used as constructor field 0.
 |}];;
@@ -255,7 +255,7 @@ Line 1, characters 11-38:
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_12, because
          it's used as constructor field 1.
 |}];;
@@ -267,7 +267,7 @@ Line 1, characters 11-34:
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_13, because
          it's used as constructor field 0.
 |}];;
@@ -301,7 +301,7 @@ Line 1, characters 39-48:
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the definition of t_any at Line 2, characters 0-16.
+         of the definition of t_any at line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_14, because
          it's used in the declaration of the record field "y/387".
 |}];;
@@ -329,7 +329,7 @@ Error: This expression has type float but an expression was expected of type
        The layout of float is value, because
          it is the primitive value type float.
        But the layout of float must be a sublayout of immediate, because
-         of the definition of s6 at Line 2, characters 0-35.
+         of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -329,7 +329,7 @@ Error: This expression has type float but an expression was expected of type
        The layout of float is value, because
          it is the primitive value type float.
        But the layout of float must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type s6.
+         of definition of s6 at Line 2, characters 0-35.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -329,7 +329,7 @@ Error: This expression has type float but an expression was expected of type
        The layout of float is value, because
          it is the primitive value type float.
        But the layout of float must be a sublayout of immediate, because
-         of definition of s6 at Line 2, characters 0-35.
+         of the definition of s6 at Line 2, characters 0-35.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -51,7 +51,7 @@ Line 1, characters 15-31:
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_1, because
          it's used as constructor field 0.
 |}];;
@@ -63,7 +63,7 @@ Line 1, characters 15-45:
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_2, because
          it's used as constructor field 1.
 |}];;
@@ -75,7 +75,7 @@ Line 1, characters 15-41:
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_3, because
          it's used as constructor field 0.
 |}];;
@@ -88,7 +88,7 @@ Line 2, characters 0-29:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
        The layout of 'b t1_constraint' is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of 'b t1_constraint' must be a sublayout of '_representable_layout_4, because
          it instantiates an unannotated type parameter.
 |}]
@@ -149,7 +149,7 @@ Line 1, characters 17-26:
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_5, because
          it's used in the declaration of the record field "x/341".
 |}];;
@@ -161,7 +161,7 @@ Line 1, characters 34-43:
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_6, because
          it's used in the declaration of the record field "y/344".
 |}];;
@@ -173,7 +173,7 @@ Line 1, characters 18-28:
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_7, because
          it's used in the declaration of the record field "x/346".
 |}];;
@@ -185,7 +185,7 @@ Line 1, characters 23-32:
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_8, because
          it's used in the declaration of the record field "x/350".
 |}];;
@@ -197,7 +197,7 @@ Line 1, characters 40-49:
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_9, because
          it's used in the declaration of the record field "y/354".
 |}];;
@@ -209,7 +209,7 @@ Line 1, characters 23-33:
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_10, because
          it's used in the declaration of the record field "x/357".
 |}];;
@@ -243,7 +243,7 @@ Line 1, characters 11-24:
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_11, because
          it's used as constructor field 0.
 |}];;
@@ -255,7 +255,7 @@ Line 1, characters 11-38:
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_12, because
          it's used as constructor field 1.
 |}];;
@@ -267,7 +267,7 @@ Line 1, characters 11-34:
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_13, because
          it's used as constructor field 0.
 |}];;
@@ -301,7 +301,7 @@ Line 1, characters 39-48:
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
        The layout of t_any is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 2, characters 0-16.
        But the layout of t_any must be a sublayout of '_representable_layout_14, because
          it's used in the declaration of the record field "y/387".
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_beta.ml
@@ -83,7 +83,7 @@ Error: This expression has type float but an expression was expected of type
        The layout of float is value, because
          it is the primitive value type float.
        But the layout of float must be a sublayout of immediate, because
-         of definition of s6 at Line 2, characters 0-35.
+         of the definition of s6 at Line 2, characters 0-35.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_beta.ml
@@ -83,7 +83,7 @@ Error: This expression has type float but an expression was expected of type
        The layout of float is value, because
          it is the primitive value type float.
        But the layout of float must be a sublayout of immediate, because
-         of the definition of s6 at Line 2, characters 0-35.
+         of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_beta.ml
@@ -83,7 +83,7 @@ Error: This expression has type float but an expression was expected of type
        The layout of float is value, because
          it is the primitive value type float.
        But the layout of float must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type s6.
+         of definition of s6 at Line 2, characters 0-35.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -136,7 +136,7 @@ Line 2, characters 2-29:
 Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
        But the layout of type Bar3.t must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t/2.
+         of the definition of t at Line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -185,7 +185,7 @@ Line 5, characters 30-46:
 Error: The layout of type string is value, because
          it is the primitive value type string.
        But the layout of type string must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -226,7 +226,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -246,7 +246,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 (* CR layouts: this is broken because of the package with-type hack.  It was
@@ -270,7 +270,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -136,7 +136,7 @@ Line 2, characters 2-29:
 Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
        But the layout of type Bar3.t must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-29.
+         of the definition of t at line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -185,7 +185,7 @@ Line 5, characters 30-46:
 Error: The layout of type string is value, because
          it is the primitive value type string.
        But the layout of type string must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -226,7 +226,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -246,7 +246,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (* CR layouts: this is broken because of the package with-type hack.  It was
@@ -270,7 +270,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -39,7 +39,7 @@ Line 1, characters 32-34:
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : void)
        The layout of 'a is void, because
-         of definition of t at Line 10, characters 2-20.
+         of the definition of t at Line 10, characters 2-20.
        But the layout of 'a must overlap with value, because
          the type argument of list has layout value.
 |}];;
@@ -95,9 +95,9 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         of definition of t at Line 2, characters 2-21.
+         of the definition of t at Line 2, characters 2-21.
        The layout of 'a is immediate, because
-         of definition of t at Line 2, characters 2-25.
+         of the definition of t at Line 2, characters 2-25.
 |}]
 
 (************************************************************************)
@@ -141,7 +141,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of t at Line 2, characters 2-25.
+         of the definition of t at Line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -268,7 +268,7 @@ Error: This type Foo3.t should be an instance of type ('a : void)
        The layout of Foo3.t is value, because
          an abstract type has the value layout by default.
        But the layout of Foo3.t must be a sublayout of void, because
-         of definition of t at Line 10, characters 2-20.
+         of the definition of t at Line 10, characters 2-20.
 |}];;
 
 (* Previous example works with annotation *)
@@ -321,7 +321,7 @@ Error: This type M4.s should be an instance of type ('a : void)
        The layout of M4.s is value, because
          it's a boxed variant.
        But the layout of M4.s must be a sublayout of void, because
-         of definition of t4_void at Line 8, characters 0-24.
+         of the definition of t4_void at Line 8, characters 0-24.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -351,7 +351,7 @@ Error: This type M4'.s should be an instance of type ('a : void)
        The layout of M4'.s is immediate, because
          of the annotation on the declaration of the type t.
        But the layout of M4'.s must be a sublayout of void, because
-         of definition of t4_void at Line 8, characters 0-24.
+         of the definition of t4_void at Line 8, characters 0-24.
 |}];;
 
 (************************************)
@@ -384,7 +384,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of f at Line 3, characters 2-20.
+         of the definition of f at Line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -39,7 +39,7 @@ Line 1, characters 32-34:
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : void)
        The layout of 'a is void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 10, characters 2-20.
        But the layout of 'a must overlap with value, because
          the type argument of list has layout value.
 |}];;
@@ -95,9 +95,9 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         the type argument of list has layout value.
+         of definition of t at Line 2, characters 2-21.
        The layout of 'a is immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-25.
 |}]
 
 (************************************************************************)
@@ -141,7 +141,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -268,7 +268,7 @@ Error: This type Foo3.t should be an instance of type ('a : void)
        The layout of Foo3.t is value, because
          an abstract type has the value layout by default.
        But the layout of Foo3.t must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 10, characters 2-20.
 |}];;
 
 (* Previous example works with annotation *)
@@ -321,7 +321,7 @@ Error: This type M4.s should be an instance of type ('a : void)
        The layout of M4.s is value, because
          it's a boxed variant.
        But the layout of M4.s must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t4_void.
+         of definition of t4_void at Line 8, characters 0-24.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -351,7 +351,7 @@ Error: This type M4'.s should be an instance of type ('a : void)
        The layout of M4'.s is immediate, because
          of the annotation on the declaration of the type t.
        But the layout of M4'.s must be a sublayout of void, because
-         of the annotation on 'a in the declaration of the type t4_void.
+         of definition of t4_void at Line 8, characters 0-24.
 |}];;
 
 (************************************)
@@ -384,7 +384,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of f at Line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -39,7 +39,7 @@ Line 1, characters 32-34:
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : void)
        The layout of 'a is void, because
-         of the definition of t at Line 10, characters 2-20.
+         of the definition of t at line 10, characters 2-20.
        But the layout of 'a must overlap with value, because
          the type argument of list has layout value.
 |}];;
@@ -51,9 +51,9 @@ Line 1, characters 27-42:
 1 | module type S1'' = S1 with type s = t_void;;
                                ^^^^^^^^^^^^^^^
 Error: The layout of type t_void is void, because
-         of the definition of t_void at Line 5, characters 0-19.
+         of the definition of t_void at line 5, characters 0-19.
        But the layout of type t_void must be a sublayout of value, because
-         of the definition of s at Line 11, characters 2-8.
+         of the definition of s at line 11, characters 2-8.
 |}]
 
 module type S1_2 = sig
@@ -95,9 +95,9 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         of the definition of t at Line 2, characters 2-21.
+         of the definition of t at line 2, characters 2-21.
        The layout of 'a is immediate, because
-         of the definition of t at Line 2, characters 2-25.
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 (************************************************************************)
@@ -141,7 +141,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-25.
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -199,7 +199,7 @@ Line 2, characters 2-29:
 Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
        But the layout of type Bar3.t must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-29.
+         of the definition of t at line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -268,7 +268,7 @@ Error: This type Foo3.t should be an instance of type ('a : void)
        The layout of Foo3.t is value, because
          an abstract type has the value layout by default.
        But the layout of Foo3.t must be a sublayout of void, because
-         of the definition of t at Line 10, characters 2-20.
+         of the definition of t at line 10, characters 2-20.
 |}];;
 
 (* Previous example works with annotation *)
@@ -319,9 +319,9 @@ Line 1, characters 11-15:
                ^^^^
 Error: This type M4.s should be an instance of type ('a : void)
        The layout of M4.s is value, because
-         of the definition of s at Line 2, characters 2-21.
+         of the definition of s at line 2, characters 2-21.
        But the layout of M4.s must be a sublayout of void, because
-         of the definition of t4_void at Line 8, characters 0-24.
+         of the definition of t4_void at line 8, characters 0-24.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -349,9 +349,9 @@ Line 1, characters 10-15:
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : void)
        The layout of M4'.s is immediate, because
-         of the definition of s at Line 2, characters 2-45.
+         of the definition of s at line 2, characters 2-45.
        But the layout of M4'.s must be a sublayout of void, because
-         of the definition of t4_void at Line 8, characters 0-24.
+         of the definition of t4_void at line 8, characters 0-24.
 |}];;
 
 (************************************)
@@ -384,7 +384,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of f at Line 3, characters 2-20.
+         of the definition of f at line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig
@@ -400,7 +400,7 @@ Line 5, characters 30-46:
 Error: The layout of type string is value, because
          it is the primitive value type string.
        But the layout of type string must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -426,7 +426,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of void, because
-         of the definition of t at Line 2, characters 2-15.
+         of the definition of t at line 2, characters 2-15.
 |}];;
 
 module type S6_3 = sig
@@ -443,7 +443,7 @@ Line 6, characters 33-34:
                                      ^
 Error: Signature package constraint types must have layout value.
        The layout of t_void is void, because
-         of the definition of t_void at Line 5, characters 0-19.
+         of the definition of t_void at line 5, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's used as an element in a first-class module.
 |}];;
@@ -469,7 +469,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -489,7 +489,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -510,7 +510,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (*****************************************)
@@ -537,7 +537,7 @@ Line 1, characters 28-33:
                                 ^^^^^
 Error: This type signature for x is not a value type.
        The layout of x is any, because
-         of the definition of t_any at Line 1, characters 0-18.
+         of the definition of t_any at line 1, characters 0-18.
        But the layout of x must be a sublayout of value, because
          it's stored in a module structure.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -51,9 +51,9 @@ Line 1, characters 27-42:
 1 | module type S1'' = S1 with type s = t_void;;
                                ^^^^^^^^^^^^^^^
 Error: The layout of type t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 5, characters 0-19.
        But the layout of type t_void must be a sublayout of value, because
-         an abstract type has the value layout by default.
+         of the definition of s at Line 11, characters 2-8.
 |}]
 
 module type S1_2 = sig
@@ -199,7 +199,7 @@ Line 2, characters 2-29:
 Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
        But the layout of type Bar3.t must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t/2.
+         of the definition of t at Line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -319,7 +319,7 @@ Line 1, characters 11-15:
                ^^^^
 Error: This type M4.s should be an instance of type ('a : void)
        The layout of M4.s is value, because
-         it's a boxed variant.
+         of the definition of s at Line 2, characters 2-21.
        But the layout of M4.s must be a sublayout of void, because
          of the definition of t4_void at Line 8, characters 0-24.
 |}]
@@ -349,7 +349,7 @@ Line 1, characters 10-15:
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : void)
        The layout of M4'.s is immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of s at Line 2, characters 2-45.
        But the layout of M4'.s must be a sublayout of void, because
          of the definition of t4_void at Line 8, characters 0-24.
 |}];;
@@ -400,7 +400,7 @@ Line 5, characters 30-46:
 Error: The layout of type string is value, because
          it is the primitive value type string.
        But the layout of type string must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -426,7 +426,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of void, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-15.
 |}];;
 
 module type S6_3 = sig
@@ -443,7 +443,7 @@ Line 6, characters 33-34:
                                      ^
 Error: Signature package constraint types must have layout value.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 5, characters 0-19.
        But the layout of t_void must be a sublayout of value, because
          it's used as an element in a first-class module.
 |}];;
@@ -469,7 +469,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -489,7 +489,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -510,7 +510,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 (*****************************************)
@@ -537,7 +537,7 @@ Line 1, characters 28-33:
                                 ^^^^^
 Error: This type signature for x is not a value type.
        The layout of x is any, because
-         of the annotation on the declaration of the type t_any.
+         of the definition of t_any at Line 1, characters 0-18.
        But the layout of x must be a sublayout of value, because
          it's stored in a module structure.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -85,9 +85,9 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         of the definition of t at Line 2, characters 2-21.
+         of the definition of t at line 2, characters 2-21.
        The layout of 'a is immediate, because
-         of the definition of t at Line 2, characters 2-25.
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 module M1_2''' : S1_2 = struct
@@ -111,9 +111,9 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         of the definition of t at Line 2, characters 2-21.
+         of the definition of t at line 2, characters 2-21.
        The layout of 'a is immediate, because
-         of the definition of t at Line 2, characters 2-25.
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 (************************************************************************)
@@ -157,7 +157,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-25.
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -216,7 +216,7 @@ Line 2, characters 2-29:
 Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
        But the layout of type Bar3.t must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-29.
+         of the definition of t at line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -330,7 +330,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the definition of f at Line 3, characters 2-20.
+         of the definition of f at line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig
@@ -346,7 +346,7 @@ Line 5, characters 30-46:
 Error: The layout of type string is value, because
          it is the primitive value type string.
        But the layout of type string must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -386,7 +386,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -406,7 +406,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -427,7 +427,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the definition of t at Line 2, characters 2-20.
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -216,7 +216,7 @@ Line 2, characters 2-29:
 Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
        But the layout of type Bar3.t must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t/2.
+         of the definition of t at Line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -346,7 +346,7 @@ Line 5, characters 30-46:
 Error: The layout of type string is value, because
          it is the primitive value type string.
        But the layout of type string must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -386,7 +386,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -406,7 +406,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -427,7 +427,7 @@ Error: In this `with' constraint, the new definition of t
        The layout of the first is value, because
          it's used as an element in a first-class module.
        But the layout of the first must be a sublayout of immediate, because
-         of the annotation on the declaration of the type t.
+         of the definition of t at Line 2, characters 2-20.
 |}];;
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -85,9 +85,9 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         the type argument of list has layout value.
+         of definition of t at Line 2, characters 2-21.
        The layout of 'a is immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-25.
 |}]
 
 module M1_2''' : S1_2 = struct
@@ -111,9 +111,9 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         the type argument of list has layout value.
+         of definition of t at Line 2, characters 2-21.
        The layout of 'a is immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-25.
 |}]
 
 (************************************************************************)
@@ -157,7 +157,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of t at Line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -330,7 +330,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of the annotation on 'a in the declaration of the type t.
+         of definition of f at Line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -85,9 +85,9 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         of definition of t at Line 2, characters 2-21.
+         of the definition of t at Line 2, characters 2-21.
        The layout of 'a is immediate, because
-         of definition of t at Line 2, characters 2-25.
+         of the definition of t at Line 2, characters 2-25.
 |}]
 
 module M1_2''' : S1_2 = struct
@@ -111,9 +111,9 @@ Error: Signature mismatch:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
        The layout of 'a is value, because
-         of definition of t at Line 2, characters 2-21.
+         of the definition of t at Line 2, characters 2-21.
        The layout of 'a is immediate, because
-         of definition of t at Line 2, characters 2-25.
+         of the definition of t at Line 2, characters 2-25.
 |}]
 
 (************************************************************************)
@@ -157,7 +157,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of t at Line 2, characters 2-25.
+         of the definition of t at Line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -330,7 +330,7 @@ Error: This expression has type string but an expression was expected of type
        The layout of string is value, because
          it is the primitive value type string.
        But the layout of string must be a sublayout of immediate, because
-         of definition of f at Line 3, characters 2-20.
+         of the definition of f at Line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -77,7 +77,7 @@ Lines 13-21, characters 8-3:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of void_rec is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of void_rec must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -140,7 +140,7 @@ Lines 3-11, characters 9-3:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of void_rec is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of void_rec must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -229,7 +229,7 @@ Lines 17-35, characters 10-27:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -443,7 +443,7 @@ Line 5, characters 4-6:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -490,7 +490,7 @@ Lines 3-11, characters 26-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -520,7 +520,7 @@ Lines 1-3, characters 26-32:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of void_rec is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of void_rec must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -632,7 +632,7 @@ Lines 1-13, characters 31-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -674,7 +674,7 @@ Lines 1-13, characters 31-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -715,7 +715,7 @@ Lines 1-12, characters 31-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -756,7 +756,7 @@ Lines 1-12, characters 31-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -838,7 +838,7 @@ Lines 8-18, characters 21-29:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -888,7 +888,7 @@ Lines 5-11, characters 10-7:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -957,7 +957,7 @@ Lines 3-11, characters 22-11:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -1002,7 +1002,7 @@ Lines 3-12, characters 22-23:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
+         of the definition of t_void at Line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -77,7 +77,7 @@ Lines 13-21, characters 8-3:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of void_rec is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of void_rec must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -140,7 +140,7 @@ Lines 3-11, characters 9-3:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of void_rec is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of void_rec must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -229,7 +229,7 @@ Lines 17-35, characters 10-27:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -443,7 +443,7 @@ Line 5, characters 4-6:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -490,7 +490,7 @@ Lines 3-11, characters 26-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -520,7 +520,7 @@ Lines 1-3, characters 26-32:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of void_rec is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of void_rec must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -632,7 +632,7 @@ Lines 1-13, characters 31-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -674,7 +674,7 @@ Lines 1-13, characters 31-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -715,7 +715,7 @@ Lines 1-12, characters 31-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -756,7 +756,7 @@ Lines 1-12, characters 31-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -838,7 +838,7 @@ Lines 8-18, characters 21-29:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -888,7 +888,7 @@ Lines 5-11, characters 10-7:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -957,7 +957,7 @@ Lines 3-11, characters 22-11:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]
@@ -1002,7 +1002,7 @@ Lines 3-12, characters 22-23:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void, because
-         of the definition of t_void at Line 1, characters 0-18.
+         of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
 |}]

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2114,6 +2114,25 @@ let unification_layout_check env ty layout =
   | Delay_checks r -> r := (ty,layout) :: !r
   | Skip_checks -> ()
 
+let update_generalized_ty_layout_reason ty reason =
+  let rec inner ty =
+    let level = get_level ty in
+    if level = generic_level && try_mark_node ty then begin
+      begin match get_desc ty with
+      | Tvar ({ layout; _ } as r) ->
+        let new_layout = Layout.(update_reason layout reason) in
+        set_type_desc ty (Tvar {r with layout = new_layout})
+      | Tunivar ({ layout; _ } as r) ->
+        let new_layout = Layout.(update_reason layout reason) in
+        set_type_desc ty (Tunivar {r with layout = new_layout})
+      | _ -> ()
+      end;
+      iter_type_expr inner ty
+    end
+  in
+  inner ty;
+  unmark_type ty
+
 let is_principal ty =
   not !Clflags.principal || get_level ty = generic_level
 

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -520,6 +520,9 @@ val check_type_layout :
 val constrain_type_layout :
   Env.t -> type_expr -> layout -> (unit, Layout.Violation.t) result
 
+(* Update the layout reason of all generalized type vars inside the given [type_expr] *)
+val update_generalized_ty_layout_reason : type_expr -> Layout.creation_reason -> unit
+
 val is_principal : type_expr -> bool
 
 (* True if a type is always global (i.e., it mode crosses for local).  This is

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -335,7 +335,7 @@ module Layout = struct
     | Imported
     | Imported_type_argument of {parent_path: Path.t; position: int; arity: int}
     (* [position] is 1-indexed *)
-
+    | Generalized of Ident.t option * Location.t
 
   type interact_reason =
     | Gadt_equation of Path.t
@@ -830,6 +830,11 @@ module Layout = struct
         fprintf ppf "the %stype argument of %a has this layout"
           (format_position ~arity position)
           !printtyp_path parent_path
+      | Generalized (id, loc) ->
+        let format_id ppf = function
+          | Some id -> fprintf ppf " of %s" (Ident.name id)
+          | None -> () in
+        fprintf ppf "of definition%a at %a" format_id id Location.print_loc loc
 
     let format_interact_reason ppf = function
       | Gadt_equation name ->
@@ -1215,6 +1220,12 @@ module Layout = struct
       | Imported_type_argument {parent_path; position; arity}  ->
            fprintf ppf "Imported_type_argument (pos %d, arity %d) of %a"
            position arity !printtyp_path parent_path
+      | Generalized (id, loc) ->
+        fprintf ppf "Generalized (%s, %a)"
+          (match id with
+           | Some id -> Ident.unique_name id
+           | None -> "")
+           Location.print_loc loc
 
     let interact_reason ppf = function
       | Gadt_equation p ->

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -705,7 +705,7 @@ module Layout = struct
       | Type_variable name ->
           fprintf ppf "the type variable %s" name
       | Type_wildcard loc ->
-          fprintf ppf "the wildcard _ at %a" Location.print_loc loc
+          fprintf ppf "the wildcard _ at %a" Location.print_loc_in_lowercase loc
 
     let format_any_creation_reason ppf : any_creation_reason -> unit = function
       | Missing_cmi p ->
@@ -834,7 +834,8 @@ module Layout = struct
         let format_id ppf = function
           | Some id -> fprintf ppf " of %s" (Ident.name id)
           | None -> () in
-        fprintf ppf "of the definition%a at %a" format_id id Location.print_loc loc
+        fprintf ppf "of the definition%a at %a"
+          format_id id Location.print_loc_in_lowercase loc
 
     let format_interact_reason ppf = function
       | Gadt_equation name ->

--- a/ocaml/typing/layouts.ml
+++ b/ocaml/typing/layouts.ml
@@ -834,7 +834,7 @@ module Layout = struct
         let format_id ppf = function
           | Some id -> fprintf ppf " of %s" (Ident.name id)
           | None -> () in
-        fprintf ppf "of definition%a at %a" format_id id Location.print_loc loc
+        fprintf ppf "of the definition%a at %a" format_id id Location.print_loc loc
 
     let format_interact_reason ppf = function
       | Gadt_equation name ->

--- a/ocaml/typing/layouts.mli
+++ b/ocaml/typing/layouts.mli
@@ -235,6 +235,7 @@ module Layout : sig
     | Imported
     | Imported_type_argument of {parent_path: Path.t; position: int; arity: int}
     (* [position] is 1-indexed *)
+    | Generalized of Ident.t option * Location.t
 
   type interact_reason =
     | Gadt_equation of Path.t

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -7676,23 +7676,8 @@ and type_let
       | Tpat_alias(_, id, _, _) -> Some id
       | _ -> None in
     let reason = Layout.Generalized (pat_name, exp.exp_loc) in
-    let rec inner ty =
-      let level = get_level ty in
-      if level = generic_level && try_mark_node ty then begin
-        begin match get_desc ty with
-        | Tvar ({ layout; _ } as r) ->
-          let new_layout = Layout.(update_reason layout reason) in
-          set_type_desc ty (Tvar {r with layout = new_layout})
-        | Tunivar ({ layout; _ } as r) ->
-          let new_layout = Layout.(update_reason layout reason) in
-          set_type_desc ty (Tunivar {r with layout = new_layout})
-        | _ -> ()
-        end;
-        iter_type_expr inner ty
-      end
-    in
-    inner exp.exp_type;
-    unmark_type exp.exp_type in
+    Ctype.update_generalized_ty_layout_reason exp.exp_type reason
+  in
   List.iter2 update_layout pat_list exp_list;
   let l = List.combine pat_list exp_list in
   let l = List.combine sorts l in

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1170,16 +1170,11 @@ let update_decl_layout env dpath decl =
 let update_decls_layout_reason decls =
   List.map
     (fun (id, decl) ->
-       let reason =  Layout.(Generalized (Some id, decl.type_loc)) in
-       List.iter
-         (fun ty -> Ctype.update_generalized_ty_layout_reason ty reason)
-         decl.type_params;
-       Btype.iter_type_expr_kind
-         (fun ty -> Ctype.update_generalized_ty_layout_reason ty reason) decl.type_kind;
-       begin match decl.type_manifest with
-       | None    -> ()
-       | Some ty -> Ctype.update_generalized_ty_layout_reason ty reason
-       end;
+       let reason = Layout.(Generalized (Some id, decl.type_loc)) in
+       let update_generalized ty = Ctype.update_generalized_ty_layout_reason ty reason in
+       List.iter update_generalized decl.type_params;
+       Btype.iter_type_expr_kind update_generalized decl.type_kind;
+       Option.iter update_generalized decl.type_manifest;
        let new_decl = {decl with type_layout =
                                    Layout.(update_reason decl.type_layout reason)} in
        (id, new_decl)

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2055,6 +2055,8 @@ let transl_value_decl env loc valdecl =
     Env.enter_value valdecl.pval_name.txt v env
       ~check:(fun s -> Warnings.Unused_value_declaration s)
   in
+  let reason = Layout.Generalized (Some id, loc) in
+  Ctype.update_generalized_ty_layout_reason ty reason;
   let desc =
     {
      val_id = id;

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1174,7 +1174,16 @@ let update_decls_layout_reason decls =
        List.iter
          (fun ty -> Ctype.update_generalized_ty_layout_reason ty reason)
          decl.type_params;
-       (id, decl))
+       Btype.iter_type_expr_kind
+         (fun ty -> Ctype.update_generalized_ty_layout_reason ty reason) decl.type_kind;
+       begin match decl.type_manifest with
+       | None    -> ()
+       | Some ty -> Ctype.update_generalized_ty_layout_reason ty reason
+       end;
+       let new_decl = {decl with type_layout =
+                                   Layout.(update_reason decl.type_layout reason)} in
+       (id, new_decl)
+    )
     decls
 
 let update_decls_layout env decls =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1167,6 +1167,16 @@ let update_decl_layout env dpath decl =
     end;
   new_decl
 
+let update_decls_layout_reason decls =
+  List.map
+    (fun (id, decl) ->
+       let reason =  Layout.(Generalized (Some id, decl.type_loc)) in
+       List.iter
+         (fun ty -> Ctype.update_generalized_ty_layout_reason ty reason)
+         decl.type_params;
+       (id, decl))
+    decls
+
 let update_decls_layout env decls =
   List.map
     (fun (id, decl) -> (id, update_decl_layout env (Pident id) decl))
@@ -1522,6 +1532,7 @@ let transl_type_decl env rec_flag sdecl_list =
       |> Typedecl_variance.update_decls env sdecl_list
       |> Typedecl_separability.update_decls env
       |> update_decls_layout new_env
+      |> update_decls_layout_reason
     with
     | Typedecl_variance.Error (loc, err) ->
         raise (Error (loc, Variance err))


### PR DESCRIPTION
This PR erases the layout history reason of certain generalized type variables. Motivation behind this is when explaining the reason of an error, the implementation details of some other value/type defined far away is not particularly interesting nor helpful to the user.

To illustrate, this PR changes the error message of this example:

```ocaml
module _ = struct
  module M : sig
    val f : 'a -> 'a
  end = struct
    let f x = x
  end
  let g (x : t_void) = M.f x
end
```

in such a way:

```diff
Line 8, characters 27-28:
8 |   let g (x : t_void) = M.f x
                               ^
Error: This expression has type t_void but an expression was expected of type
         ('a : value)
       The layout of t_void is void, because
         of the annotation on the declaration of the type t_void.
       But the layout of t_void must be a sublayout of value, because
-        it's used as a function argument, defaulted to layout value.
+        of definition of f at Line 3, characters 4-20.
```

This also puts the error reporting of layouts more in line with what's being done for types.

In terms of implementation details, this layout reason erasing behavior is added at three places:
- for let statements within `type_let`
- for val/external declarations within `transl_value_decl`
- for only the type params of type declarations within `transl_type_decl`
