### PR TITLE
Remove Jkind.of_sort

### DIFF
--- a/ocaml/lambda/translmod.mli
+++ b/ocaml/lambda/translmod.mli
@@ -53,7 +53,7 @@ type unsafe_info =
 type error =
   Circular_dependency of (Ident.t * unsafe_info) list
 | Conflicting_inline_attributes
-| Non_value_jkind of Types.type_expr * Jkind.Violation.t
+| Non_value_jkind of Types.type_expr * Jkind.sort
 
 exception Error of Location.t * error
 

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -55,6 +55,10 @@ val create_scope : unit -> int
 val newty: type_desc -> type_expr
 val new_scoped_ty: int -> type_desc -> type_expr
 val newvar: ?name:string -> Jkind.t -> type_expr
+val new_rep_var :
+  ?name:string -> why:Jkind.concrete_jkind_reason -> unit ->
+  type_expr * Jkind.sort
+        (* Return a fresh representable variable, along with its sort *)
 val newvar2: ?name:string -> int -> Jkind.t -> type_expr
         (* Return a fresh variable *)
 val new_global_var: ?name:string -> Jkind.t -> type_expr

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -471,9 +471,12 @@ let get_required_layouts_level (context : annotation_context) (jkind : const) :
 (* construction *)
 
 let of_new_sort_var ~why =
-  fresh_jkind (Sort (Sort.new_var ())) ~why:(Concrete_creation why)
+  let sort = Sort.new_var () in
+  fresh_jkind (Sort sort) ~why:(Concrete_creation why), sort
 
-let of_sort ~why s = fresh_jkind (Sort s) ~why:(Concrete_creation why)
+let of_new_sort ~why = fst (of_new_sort_var ~why)
+
+let of_sort_for_error ~why s = fresh_jkind (Sort s) ~why:(Concrete_creation why)
 
 let of_const ~why : const -> t = function
   | Any -> fresh_jkind Any ~why

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -348,10 +348,17 @@ val float64 : why:float64_creation_reason -> t
 (******************************)
 (* construction *)
 
-(** Create a fresh sort variable, packed into a jkind. *)
-val of_new_sort_var : why:concrete_jkind_reason -> t
+(** Create a fresh sort variable, packed into a jkind, returning both
+    the resulting kind and the sort. *)
+val of_new_sort_var : why:concrete_jkind_reason -> t * sort
 
-val of_sort : why:concrete_jkind_reason -> sort -> t
+(** Create a fresh sort variable, packed into a jkind. *)
+val of_new_sort : why:concrete_jkind_reason -> t
+
+(** There should not be a need to convert a sort to a jkind, but this is
+    occasionally useful for formatting error messages. Do not use in actual
+    type-checking. *)
+val of_sort_for_error : why:concrete_jkind_reason -> sort -> t
 
 val of_const : why:creation_reason -> const -> t
 

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1398,7 +1398,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                   Typecore.escape ~loc ~env:val_env ~reason:Other mode;
                   if not (Jkind.Sort.(equate sort value))
                   then let viol = Jkind.Violation.of_ (Not_a_subjkind(
-                    Jkind.of_sort ~why:Let_binding sort,
+                    Jkind.of_sort_for_error ~why:Let_binding sort,
                     Jkind.value ~why:Class_let_binding))
                     in
                     raise (Error(loc, met_env,

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -464,7 +464,7 @@ let transl_type_param env path styp =
    to ask for it with an annotation.  Some restriction here seems necessary
    for backwards compatibility (e.g., we wouldn't want [type 'a id = 'a] to
    have jkind any).  But it might be possible to infer any in some cases. *)
-  let jkind = Jkind.of_new_sort_var ~why:Unannotated_type_parameter in
+  let jkind = Jkind.of_new_sort ~why:Unannotated_type_parameter in
   let attrs = styp.ptyp_attributes in
   match styp.ptyp_desc with
     Ptyp_any -> transl_type_param_var env loc attrs None jkind None
@@ -480,7 +480,7 @@ let transl_type_param env path styp =
 
 let get_type_param_jkind path styp =
   match Jane_syntax.Core_type.of_ast styp with
-  | None -> Jkind.of_new_sort_var ~why:Unannotated_type_parameter
+  | None -> Jkind.of_new_sort ~why:Unannotated_type_parameter
   | Some (Jtyp_layout (Ltyp_var { name; jkind }), _attrs) ->
     Jkind.of_annotation ~context:(Type_parameter (path, name)) jkind
   | Some _ -> Misc.fatal_error "non-type-variable in get_type_param_jkind"


### PR DESCRIPTION
We shouldn't ever really have to convert a sort back into a layout or kind. And it turns out that almost all uses of `of_sort` worked on a freshly created sort variable. Because converting a sort into a layout/kind is suspect, this refactor makes it harder to do so. Sadly, in one case, the conversion really is the easiest way to construct the right error message, so I kept that one usage of `of_sort`.

This is just a refactoring; no change in functionality, so no testcase changes.