### PR TITLE
Remove mode from Texp_send

### DIFF
--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -697,10 +697,10 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         for_body = event_before ~scopes for_body
                      (maybe_region_layout layout_unit body);
       }
-  | Texp_send(expr, met, pos, alloc_mode) ->
+  | Texp_send(expr, met, pos) ->
       let lam =
         let pos = transl_apply_position pos in
-        let mode = transl_alloc_mode alloc_mode in
+        let mode = Lambda.alloc_heap in
         let loc = of_location ~scopes e.exp_loc in
         let layout = layout_exp sort e in
         match met with

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -478,17 +478,14 @@ and expression i ppf x =
       expression i ppf for_from;
       expression i ppf for_to;
       expression i ppf for_body
-  | Texp_send (e, Tmeth_name s, _, am) ->
+  | Texp_send (e, Tmeth_name s, _) ->
       line i ppf "Texp_send \"%s\"\n" s;
-      alloc_mode i ppf am;
       expression i ppf e
-  | Texp_send (e, Tmeth_val s, _, am) ->
+  | Texp_send (e, Tmeth_val s, _) ->
       line i ppf "Texp_send \"%a\"\n" fmt_ident s;
-      alloc_mode i ppf am;
       expression i ppf e
-  | Texp_send (e, Tmeth_ancestor(s, _), _, am) ->
+  | Texp_send (e, Tmeth_ancestor(s, _), _) ->
       line i ppf "Texp_send \"%a\"\n" fmt_ident s;
-      alloc_mode i ppf am;
       expression i ppf e
   | Texp_new (li, _, _, _) -> line i ppf "Texp_new %a\n" fmt_path li;
   | Texp_setinstvar (_, s, _, e) ->

--- a/ocaml/typing/rec_check.ml
+++ b/ocaml/typing/rec_check.ml
@@ -709,7 +709,7 @@ let rec expression : Typedtree.expression -> term_judg =
         expression wh_cond << Dereference;
         expression wh_body << Guard;
       ]
-    | Texp_send (e1, _, _, _) ->
+    | Texp_send (e1, _, _) ->
       (*
         G |- e: m[Dereference]
         ---------------------- (plus weird 'eo' option)

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -269,7 +269,7 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
       sub.expr sub for_from;
       sub.expr sub for_to;
       sub.expr sub for_body
-  | Texp_send (exp, _, _, _) ->
+  | Texp_send (exp, _, _) ->
       sub.expr sub exp
   | Texp_new _ -> ()
   | Texp_instvar _ -> ()

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -384,13 +384,12 @@ let expr sub x =
         Texp_for {tf with for_from = sub.expr sub tf.for_from;
                           for_to = sub.expr sub tf.for_to;
                           for_body = sub.expr sub tf.for_body}
-    | Texp_send (exp, meth, ap, am) ->
+    | Texp_send (exp, meth, ap) ->
         Texp_send
           (
             sub.expr sub exp,
             meth,
-            ap,
-            am
+            ap
           )
     | Texp_new _
     | Texp_instvar _ as d -> d

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -5570,9 +5570,7 @@ and type_expect_
             assert false
       in
       rue {
-        exp_desc = Texp_send(obj, meth, pm.apply_position,
-          register_allocation expected_mode
-        );
+        exp_desc = Texp_send(obj, meth, pm.apply_position);
         exp_loc = loc; exp_extra = [];
         exp_type = typ;
         exp_attributes = sexp.pexp_attributes;

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -162,7 +162,7 @@ and expression_desc =
       for_body : expression;
       for_body_sort : Jkind.sort;
     }
-  | Texp_send of expression * meth * apply_position * Mode.Alloc.t
+  | Texp_send of expression * meth * apply_position
   | Texp_new of
       Path.t * Longident.t loc * Types.class_declaration * apply_position
   | Texp_instvar of Path.t * Path.t * string loc

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -339,8 +339,7 @@ and expression_desc =
       for_body : expression;
       for_body_sort : Jkind.sort;
     }
-  | Texp_send of expression * meth * apply_position * Mode.Alloc.t
-    (** [alloc_mode] is the allocation mode of the result *)
+  | Texp_send of expression * meth * apply_position
   | Texp_new of
       Path.t * Longident.t loc * Types.class_declaration * apply_position
   | Texp_instvar of Path.t * Path.t * string loc

--- a/ocaml/typing/uniqueness_analysis.ml
+++ b/ocaml/typing/uniqueness_analysis.ml
@@ -1291,7 +1291,7 @@ let rec check_uniqueness_exp (ienv : Ienv.t) exp : UF.t =
     let uf_to = check_uniqueness_exp ienv for_to in
     let uf_body = check_uniqueness_exp ienv for_body in
     UF.seq (UF.par uf_from uf_to) uf_body
-  | Texp_send (e, _, _, _) -> check_uniqueness_exp ienv e
+  | Texp_send (e, _, _) -> check_uniqueness_exp ienv e
   | Texp_new _ -> UF.unused
   | Texp_instvar _ -> UF.unused
   | Texp_setinstvar (_, _, _, e) -> check_uniqueness_exp ienv e

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -578,7 +578,7 @@ let expression sub exp =
         Pexp_for (for_pat,
           sub.expr sub for_from, sub.expr sub for_to,
           for_dir, sub.expr sub for_body)
-    | Texp_send (exp, meth, _, _) ->
+    | Texp_send (exp, meth, _) ->
         Pexp_send (sub.expr sub exp, match meth with
             Tmeth_name name -> mkloc name loc
           | Tmeth_val id -> mkloc (Ident.name id) loc


### PR DESCRIPTION
`Texp_send` always returns a heap value, so there is no need to store a mode on it. (We do need a mode on `Lsend`, because it can be combined with a following application, but this does not apply to `Texp_send`).

This gets rid of a surprising behaviour noted by @Ekdohibs , in which unary `Texp_send` would have a mode set to `local` where mode-crossing allows it, because the typechecker modelled this as an allocation which could be optimised by making it local.