### PR TITLE
Fix builds with --disable-flat-float-array

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -145,7 +145,13 @@ let convert_array_ref_kind (kind : L.array_ref_kind) : converted_array_ref_kind
     =
   match kind with
   | Pgenarray_ref mode ->
-    check_float_array_optimisation_enabled ();
+    (* CR mshinwell: We can't check this because of the translations of
+       primitives for Obj.size, Obj.field and Obj.set_field, which can be used
+       both on arrays and blocks. We should probably propagate the "%obj_..."
+       primitives which these functions use all the way to the middle end. Then
+       this check could be reinstated for all normal cases.
+
+       check_float_array_optimisation_enabled (); *)
     Float_array_opt_dynamic_ref mode
   | Paddrarray_ref -> Array_ref_kind Values
   | Pintarray_ref -> Array_ref_kind Immediates
@@ -159,7 +165,9 @@ let convert_array_set_kind (kind : L.array_set_kind) : converted_array_set_kind
     =
   match kind with
   | Pgenarray_set mode ->
-    check_float_array_optimisation_enabled ();
+    (* CR mshinwell: see CR in [convert_array_ref_kind] above
+
+       check_float_array_optimisation_enabled (); *)
     Float_array_opt_dynamic_set (Alloc_mode.For_assignments.from_lambda mode)
   | Paddrarray_set mode ->
     Array_set_kind

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -448,7 +448,9 @@ let simplify_float_arith_op (op : P.unary_float_arith_op) dacc ~original_term
   | Invalid -> SPR.create_invalid dacc
 
 let simplify_is_boxed_float dacc ~original_term ~arg:_ ~arg_ty ~result_var =
-  assert (Flambda_features.flat_float_array ());
+  (* CR mshinwell: see CRs in lambda_to_flambda_primitives.ml
+
+     assert (Flambda_features.flat_float_array ()); *)
   match T.prove_is_or_is_not_a_boxed_float (DA.typing_env dacc) arg_ty with
   | Proved is_a_boxed_float ->
     let imm = Targetint_31_63.bool is_a_boxed_float in
@@ -460,7 +462,9 @@ let simplify_is_boxed_float dacc ~original_term ~arg:_ ~arg_ty ~result_var =
 
 let simplify_is_flat_float_array dacc ~original_term ~arg:_ ~arg_ty ~result_var
     =
-  assert (Flambda_features.flat_float_array ());
+  (* CR mshinwell: see CRs in lambda_to_flambda_primitives.ml
+
+     assert (Flambda_features.flat_float_array ()); *)
   match T.meet_is_flat_float_array (DA.typing_env dacc) arg_ty with
   | Known_result is_flat_float_array ->
     let imm = Targetint_31_63.bool is_flat_float_array in


### PR DESCRIPTION
As discussed on Slack, some of the tests for `Pgenarray` are too strong at the moment, because even in `--disable-flat-float-array` mode the `Obj.size`, `field` and `set_field` functions can be applied to both arrays and all-float records (the latter of which remain unboxed).

It is not checked by CI but this does fix the existing build failure when flat float arrays are disabled.