### PR TITLE
Abbreviate module types when printing error messages

### DIFF
--- a/ocaml/testsuite/tests/typing-modules/abbreviate_in_error_messages.ml
+++ b/ocaml/testsuite/tests/typing-modules/abbreviate_in_error_messages.ml
@@ -1,0 +1,98 @@
+(* TEST
+   * expect
+*)
+
+module Width = struct
+  module type S1 = sig
+    val a : int
+    val b : int
+    val c : int
+    val d : int
+    val e : int
+  end
+
+
+  module type F = functor
+    (X :
+      sig
+        module M1 : sig include S1 end
+        module M2 : sig include S1 end
+        module M3 : sig include S1 end
+        module M4 : sig include S1 end
+        module M5 : sig include S1 end
+        module M6 : sig include S1 end
+        module M7 : sig include S1 end
+      end
+    ) -> S1
+
+  module G(F:F)(X:functor() -> S1) = F(X)
+end
+
+[%%expect{|
+Line 24, characters 37-41:
+24 |   module G(F:F)(X:functor() -> S1) = F(X)
+                                          ^^^^
+Error: Modules do not match: functor () -> S1 is not included in
+       sig
+         module M1 :
+           sig
+             val a : int
+             val b : int
+             val c : int
+             val d : int
+             val e : int
+           end
+         module M2 :
+           sig val a : int val b : int val c : int val d : int ... end
+         module M3 : sig ... end
+         module M4 : sig ... end
+         module M5 : sig ... end
+         module M6 : sig ... end
+         module M7 : sig ... end
+       end
+     Modules do not match:
+       functor () -> ...
+     is not included in
+       functor  -> ...
+       An extra argument is provided of module type ()
+|}]
+
+module Depth = struct
+  module type S = sig
+    module M : sig
+      module N : sig
+        module O : sig
+          module P : sig
+            module Q : sig
+              val x : int
+              val y : int
+            end
+          end
+        end
+      end
+    end
+  end
+
+  module type F = functor(X:S) -> S
+
+  module F(F : F)(X : sig module M : sig end end) = F(X)
+end
+
+[%%expect{|
+Line 19, characters 52-56:
+19 |   module F(F : F)(X : sig module M : sig end end) = F(X)
+                                                         ^^^^
+Error: Modules do not match: sig module M : sig end end is not included in
+       S
+     In module M:
+     Modules do not match:
+       sig end
+     is not included in
+       sig
+         module N :
+           sig
+             module O : sig module P : sig module Q : sig ... end end end
+           end
+       end
+     In module M: The module `N' is required but not provided
+|}]

--- a/ocaml/testsuite/tests/typing-modules/functors.ml
+++ b/ocaml/testsuite/tests/typing-modules/functors.ml
@@ -921,37 +921,14 @@ Error: Signature mismatch:
          sig
            module B :
              sig
-               module C :
-                 sig
-                   module D :
-                     sig
-                       module E :
-                         sig
-                           module F :
-                             functor (X : sig type x end)
-                               (Y : sig type y' end) (W : sig type w end) ->
-                               sig end
-                         end
-                     end
-                 end
+               module C : sig module D : sig module E : sig ... end end end
              end
          end
        is not included in
          sig
            module B :
              sig
-               module C :
-                 sig
-                   module D :
-                     sig
-                       module E :
-                         sig
-                           module F :
-                             sig type x end -> sig type y end ->
-                               sig type z end -> sig type w end -> sig end
-                         end
-                     end
-                 end
+               module C : sig module D : sig module E : sig ... end end end
              end
          end
        In module B:
@@ -966,8 +943,8 @@ Error: Signature mismatch:
                    module E :
                      sig
                        module F :
-                         sig type x end -> sig type y end ->
-                           sig type z end -> sig type w end -> sig end
+                         sig ... end -> sig ... end -> sig ... end ->
+                           sig ... end -> sig end
                      end
                  end
              end

--- a/ocaml/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/ocaml/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -502,22 +502,7 @@ Error: Signature mismatch:
                      sig
                        module C :
                          functor (X : sig end) (Y : sig end)
-                           (Z : sig
-                                  module D :
-                                    sig
-                                      module E :
-                                        sig
-                                          module F :
-                                            functor (X : sig end)
-                                              (Arg : sig
-                                                       val two : int
-                                                       val one : int
-                                                     end)
-                                              -> sig end
-                                        end
-                                    end
-                                end)
-                           -> sig end
+                           (Z : sig ... end) -> sig end
                      end
                  end
              end
@@ -532,22 +517,7 @@ Error: Signature mismatch:
                      sig
                        module C :
                          functor (X : sig end) (Y : sig end)
-                           (Z : sig
-                                  module D :
-                                    sig
-                                      module E :
-                                        sig
-                                          module F :
-                                            functor (X : sig end)
-                                              (Arg : sig
-                                                       val one : int
-                                                       val two : int
-                                                     end)
-                                              -> sig end
-                                        end
-                                    end
-                                end)
-                           -> sig end
+                           (Z : sig ... end) -> sig end
                      end
                  end
              end
@@ -561,22 +531,7 @@ Error: Signature mismatch:
                    sig
                      module C :
                        functor (X : sig end) (Y : sig end)
-                         (Z : sig
-                                module D :
-                                  sig
-                                    module E :
-                                      sig
-                                        module F :
-                                          functor (X : sig end)
-                                            (Arg : sig
-                                                     val two : int
-                                                     val one : int
-                                                   end)
-                                            -> sig end
-                                      end
-                                  end
-                              end)
-                         -> sig end
+                         (Z : sig module D : sig ... end end) -> sig end
                    end
                end
            end
@@ -589,22 +544,7 @@ Error: Signature mismatch:
                    sig
                      module C :
                        functor (X : sig end) (Y : sig end)
-                         (Z : sig
-                                module D :
-                                  sig
-                                    module E :
-                                      sig
-                                        module F :
-                                          functor (X : sig end)
-                                            (Arg : sig
-                                                     val one : int
-                                                     val two : int
-                                                   end)
-                                            -> sig end
-                                      end
-                                  end
-                              end)
-                         -> sig end
+                         (Z : sig module D : sig ... end end) -> sig end
                    end
                end
            end

--- a/ocaml/typing/includemod_errorprinter.ml
+++ b/ocaml/typing/includemod_errorprinter.ml
@@ -203,7 +203,7 @@ let show_locs ppf (loc1, loc2) =
 
 
 let dmodtype mty =
-  let tmty = Printtyp.tree_of_modtype mty in
+  let tmty = Printtyp.tree_of_modtype ~abbrev:true mty in
   Format.dprintf "%a" !Oprint.out_module_type tmty
 
 let space ppf () = Format.fprintf ppf "@ "
@@ -666,22 +666,22 @@ let module_types {Err.got=mty1; expected=mty2} =
   Format.dprintf
     "@[<hv 2>Modules do not match:@ \
      %a@;<1 -2>is not included in@ %a@]"
-    !Oprint.out_module_type (Printtyp.tree_of_modtype mty1)
-    !Oprint.out_module_type (Printtyp.tree_of_modtype mty2)
+    !Oprint.out_module_type (Printtyp.tree_of_modtype ~abbrev:true mty1)
+    !Oprint.out_module_type (Printtyp.tree_of_modtype ~abbrev:true mty2)
 
 let eq_module_types {Err.got=mty1; expected=mty2} =
   Format.dprintf
     "@[<hv 2>Module types do not match:@ \
      %a@;<1 -2>is not equal to@ %a@]"
-    !Oprint.out_module_type (Printtyp.tree_of_modtype mty1)
-    !Oprint.out_module_type (Printtyp.tree_of_modtype mty2)
+    !Oprint.out_module_type (Printtyp.tree_of_modtype ~abbrev:true mty1)
+    !Oprint.out_module_type (Printtyp.tree_of_modtype ~abbrev:true mty2)
 
 let module_type_declarations id {Err.got=d1 ; expected=d2} =
   Format.dprintf
     "@[<hv 2>Module type declarations do not match:@ \
      %a@;<1 -2>does not match@ %a@]"
-    !Oprint.out_sig_item (Printtyp.tree_of_modtype_declaration id d1)
-    !Oprint.out_sig_item (Printtyp.tree_of_modtype_declaration id d2)
+    !Oprint.out_sig_item (Printtyp.tree_of_modtype_declaration ~abbrev:true id d1)
+    !Oprint.out_sig_item (Printtyp.tree_of_modtype_declaration ~abbrev:true id d2)
 
 let interface_mismatch ppf (diff: _ Err.diff) =
   Format.fprintf ppf

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -2161,6 +2161,12 @@ and tree_of_signature ?abbrev = function
   | sg ->
     Abbrev.deeper abbrev (fun () ->
       wrap_env (fun env -> env)(fun sg ->
+        (* Only expand signatures to 'abbrev.depth' depth and print at most 'abbrev.width'
+           items overall. We just keep decreasing 'abbrev.width' during the traversal but
+           make sure that we expand the current signature up to 'abbrev.width' before
+           expanding it's components. Below, 'max_items' is the number of items we should
+           print in the current signature and 'abbrev.width' is then be the remaining
+           number of items. This is simpler to implement than proper breadth-first. *)
         let max_items, trimmed = Abbrev.items abbrev sg in
         let tree_groups = tree_of_signature_rec ?abbrev ?max_items !printing_env sg in
         let items = List.concat_map (fun (_env,l) -> List.map snd l) tree_groups in
@@ -2170,6 +2176,7 @@ and tree_of_signature ?abbrev = function
 
 and tree_of_signature_rec ?abbrev ?max_items env' sg =
   let structured = List.of_seq (Signature_group.seq sg) in
+  (* Don't descent into more than 'max_items' (if set) elements to save time. *)
   let collect_trees_of_rec_group max_items group =
     match max_items with
     | Some n when n <= 0 -> (max_items, (!printing_env, []))

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -2065,17 +2065,68 @@ let expand_module_type =
   ref ((fun _env _mty -> assert false) :
       Env.t -> module_type -> module_type)
 
-let rec tree_of_modtype ?(ellipsis=false) = function
+(** How to abbreviate signatures *)
+module Abbrev = struct
+  (* The code is substantially simpler if [width] is mutable. Strictly speaking, [depth]
+     doesn't have to be mutable here but mixed mutability would be quite confusing. *)
+  type t =
+    { (* To what depth to unfold the module tree *)
+      mutable depth : int
+      (* How many signature items to print in total across all signatures *)
+    ; mutable width : int
+    }
+
+  (** Standard abbreviation heuristic *)
+  let abbrev () =
+    { depth = 4
+    ; width = 16
+    }
+
+  (** Don't print any signature items *)
+  let ellipsis () =
+    { depth = 0
+    ; width =  0
+    }
+
+  (** Should we print anything in this signature *)
+  let exhausted = function
+    | Some {depth; width} -> depth <= 0 || width <= 0
+    | None -> false
+
+  (** Run [f] at one deeper unfolding level *)
+  let deeper t f =
+    match t with
+    | Some t ->
+        let saved = t.depth in
+        t.depth <- t.depth - 1;
+        let x = f () in
+        t.depth <- saved;
+        x
+    | None -> f ()
+
+  (** Reduce the remaining width by the number of items in [sg] and return the number of
+      items to print in [sg] and a flag that inidicates whether [sg] is being trimmed. *)
+  let items t sg =
+    match t with
+    | Some t ->
+        let n = List.length sg in
+        let k = min t.width n in
+        t.width <- t.width - n;
+        Some k, (k < n)
+    | None ->
+        None, false
+end
+
+let rec tree_of_modtype ?abbrev = function
   | Mty_ident p ->
       Omty_ident (tree_of_path Module_type p)
   | Mty_signature sg ->
-      Omty_signature (if ellipsis then [Osig_ellipsis]
-                      else tree_of_signature sg)
+      Omty_signature (tree_of_signature ?abbrev sg)
   | Mty_functor(param, ty_res) ->
       let param, env =
-        tree_of_functor_parameter param
+        tree_of_functor_parameter ?abbrev param
       in
-      let res = wrap_env env (tree_of_modtype ~ellipsis) ty_res in
+      let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
       Omty_functor (param, res)
   | Mty_alias p ->
       Omty_alias (tree_of_path Module p)
@@ -2087,11 +2138,11 @@ let rec tree_of_modtype ?(ellipsis=false) = function
             && not (Env.is_functor_arg p !printing_env)
           in
           Omty_strengthen
-            (tree_of_modtype ~ellipsis mty, tree_of_path Module p, unaliasable)
-      | mty -> tree_of_modtype ~ellipsis mty
+            (tree_of_modtype ?abbrev mty, tree_of_path Module p, unaliasable)
+      | mty -> tree_of_modtype ?abbrev mty
       end
 
-and tree_of_functor_parameter = function
+and tree_of_functor_parameter ?abbrev = function
   | Unit ->
       None, fun k -> k
   | Named (param, ty_arg) ->
@@ -2102,30 +2153,52 @@ and tree_of_functor_parameter = function
             Some (Ident.name id),
             Env.add_module ~arg:true id Mp_present ty_arg
       in
-      Some (name, tree_of_modtype ~ellipsis:false ty_arg), env
+      Some (name, tree_of_modtype ?abbrev ty_arg), env
 
-and tree_of_signature sg =
-  wrap_env (fun env -> env)(fun sg ->
-      let tree_groups = tree_of_signature_rec !printing_env sg in
-      List.concat_map (fun (_env,l) -> List.map snd l) tree_groups
-    ) sg
+and tree_of_signature ?abbrev = function
+  | [] -> []
+  | _ when Abbrev.exhausted abbrev -> [Osig_ellipsis]
+  | sg ->
+    Abbrev.deeper abbrev (fun () ->
+      wrap_env (fun env -> env)(fun sg ->
+        let max_items, trimmed = Abbrev.items abbrev sg in
+        let tree_groups = tree_of_signature_rec ?abbrev ?max_items !printing_env sg in
+        let items = List.concat_map (fun (_env,l) -> List.map snd l) tree_groups in
+        if trimmed then items @ [Osig_ellipsis] else items
+        ) sg
+    )
 
-and tree_of_signature_rec env' sg =
+and tree_of_signature_rec ?abbrev ?max_items env' sg =
   let structured = List.of_seq (Signature_group.seq sg) in
-  let collect_trees_of_rec_group group =
-    let env = !printing_env in
-    let env', group_trees =
-      Naming_context.with_ctx
-        (fun () -> trees_of_recursive_sigitem_group env group)
-    in
-    set_printing_env env';
-    (env, group_trees) in
+  let collect_trees_of_rec_group max_items group =
+    match max_items with
+    | Some n when n <= 0 -> (max_items, (!printing_env, []))
+    | Some _ | None ->
+        let env = !printing_env in
+        let env', group_trees =
+          Naming_context.with_ctx
+            (fun () -> trees_of_recursive_sigitem_group ?abbrev env group)
+        in
+        set_printing_env env';
+        let max_items, group_trees = match max_items with
+          | None -> None, group_trees
+          | Some n ->
+              let rec take n acc xs =
+                match n, xs with
+                | 0, _ | _, [] -> n, List.rev acc
+                | n, x :: xs -> take (n-1) (x :: acc) xs
+              in
+              let n, group_trees = take n [] group_trees in
+              Some n, group_trees
+        in
+        max_items, (env, group_trees)
+  in
   set_printing_env env';
-  List.map collect_trees_of_rec_group structured
+  snd (List.fold_left_map collect_trees_of_rec_group max_items structured)
 
-and trees_of_recursive_sigitem_group env
+and trees_of_recursive_sigitem_group ?abbrev env
     (syntactic_group: Signature_group.rec_group) =
-  let display (x:Signature_group.sig_item) = x.src, tree_of_sigitem x.src in
+  let display (x:Signature_group.sig_item) = x.src, tree_of_sigitem ?abbrev x.src in
   let env = Env.add_signature syntactic_group.pre_ghosts env in
   match syntactic_group.group with
   | Not_rec x -> add_sigitem env x, [display x]
@@ -2134,7 +2207,7 @@ and trees_of_recursive_sigitem_group env
       List.fold_left add_sigitem env items,
       with_hidden_items ids (fun () -> List.map display items)
 
-and tree_of_sigitem = function
+and tree_of_sigitem ?abbrev = function
   | Sig_value(id, decl, _) ->
       tree_of_value_description id decl
   | Sig_type(id, decl, rs, _) ->
@@ -2142,29 +2215,32 @@ and tree_of_sigitem = function
   | Sig_typext(id, ext, es, _) ->
       tree_of_extension_constructor id ext es
   | Sig_module(id, _, md, rs, _) ->
-      let ellipsis =
-        List.exists (function
-          | Parsetree.{attr_name = {txt="..."}; attr_payload = PStr []} -> true
-          | _ -> false)
-          md.md_attributes in
-      tree_of_module id md.md_type rs ~ellipsis
+      let abbrev =
+        if List.exists (function
+            | Parsetree.{attr_name = {txt="..."}; attr_payload = PStr []} -> true
+            | _ -> false)
+            md.md_attributes
+          then Some (Abbrev.ellipsis ())
+          else abbrev
+      in
+      tree_of_module ?abbrev id md.md_type rs
   | Sig_modtype(id, decl, _) ->
-      tree_of_modtype_declaration id decl
+      tree_of_modtype_declaration ?abbrev id decl
   | Sig_class(id, decl, rs, _) ->
       tree_of_class_declaration id decl rs
   | Sig_class_type(id, decl, rs, _) ->
       tree_of_cltype_declaration id decl rs
 
-and tree_of_modtype_declaration id decl =
+and tree_of_modtype_declaration ?abbrev id decl =
   let mty =
     match decl.mtd_type with
     | None -> Omty_abstract
-    | Some mty -> tree_of_modtype mty
+    | Some mty -> tree_of_modtype ?abbrev mty
   in
   Osig_modtype (Ident.name id, mty)
 
-and tree_of_module id ?ellipsis mty rs =
-  Osig_module (Ident.name id, tree_of_modtype ?ellipsis mty, tree_of_rec rs)
+and tree_of_module ?abbrev id mty rs =
+  Osig_module (Ident.name id, tree_of_modtype ?abbrev mty, tree_of_rec rs)
 
 let rec functor_parameters ~sep custom_printer = function
   | [] -> ignore
@@ -2836,8 +2912,17 @@ let report_ambiguous_type_error ppf env tp0 tpl txt1 txt2 txt3 =
           txt3 type_path_expansion tp0)
 
 (* Adapt functions to exposed interface *)
+let abbreviate ~abbrev f =
+  f ?abbrev:(if abbrev then Some (Abbrev.abbrev ()) else None)
+
 let tree_of_path = tree_of_path Other
-let tree_of_modtype = tree_of_modtype ~ellipsis:false
+let tree_of_module ident ?(ellipsis = false) =
+  tree_of_module ident ?abbrev:(if ellipsis then Some (Abbrev.ellipsis ()) else None)
+let tree_of_signature sg = tree_of_signature sg
+let tree_of_modtype ~abbrev ty =
+  abbreviate ~abbrev tree_of_modtype ty
+let tree_of_modtype_declaration ~abbrev id md =
+  abbreviate ~abbrev tree_of_modtype_declaration id md
 let type_expansion mode ppf ty_exp =
   type_expansion ppf (trees_of_type_expansion mode ty_exp)
 let tree_of_type_declaration ident td rs =

--- a/ocaml/typing/printtyp.mli
+++ b/ocaml/typing/printtyp.mli
@@ -160,9 +160,9 @@ val tree_of_module:
     Ident.t -> ?ellipsis:bool -> module_type -> rec_status -> out_sig_item
 val modtype: formatter -> module_type -> unit
 val signature: formatter -> signature -> unit
-val tree_of_modtype: module_type -> out_module_type
+val tree_of_modtype: abbrev:bool -> module_type -> out_module_type
 val tree_of_modtype_declaration:
-    Ident.t -> modtype_declaration -> out_sig_item
+    abbrev:bool -> Ident.t -> modtype_declaration -> out_sig_item
 
 val expand_module_type: (Env.t -> module_type -> module_type) ref
 (* Forward declaration to be filled in Mtype. We want to be able to print types


### PR DESCRIPTION
Module types can become huge and pretty-printing them in error messages seems to be very slow. In one case, we produced a ~400k lines error message which took about 4 minutes to generate.

This PR caps the overall number of signature elements we print and the depth to which we unfold module types. In my somewhat limited testing, this seemed to be the best heuristic I tried, although it is far from perfect. We can adjust later based on user feedback.

For the one file in question, this reduced the compile time to ~13s.