### PR TITLE
Remove no_flat_float_array from the compiler config

### DIFF
--- a/build_ocaml_compiler.sexp
+++ b/build_ocaml_compiler.sexp
@@ -19,7 +19,9 @@
    naked_pointers_checker
    flambda
    flambda2
-   no_flat_float_array
+   ; CR-someday poechsel: This feature is currently broken - it should be turned back on 
+   ; once it is working again.
+   ; no_flat_float_array
    perf_demangled_symbols
    stack_allocation
    poll_insertion


### PR DESCRIPTION
The compiler can't build when this feature is on.

This should be turned back on once we get it to work again