### PR TITLE
Fix breaking of tail recursion in classic mode

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -885,6 +885,9 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
           [new_id, value_kind]
           User_visible (Simple new_value) ~body)
       k_exn
+  | Llet ((Strict | Alias | StrictOpt), _layout, id, defining_expr, Lvar id')
+    when Ident.same id id' ->
+    cps acc env ccenv defining_expr k k_exn
   | Llet ((Strict | Alias | StrictOpt), layout, id, defining_expr, body) ->
     let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler:false
       ~params:[id, is_user_visible env id, layout]


### PR DESCRIPTION
Patch from @lthls 

Tail recursion was being broken in cases involving `Psequand` and `Psequor` in classic mode.  For example:
```
let rec f1 x =
  x && f1 x

let rec f2 x y z =
  x && y && z && f2 x y z

let rec f3 x =
  x || f3 x

let rec f4 x y z =
  x || y || z || f4 x y z
```