### PR TITLE
Fix interface differences in Printtyp

### DIFF
--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -2926,9 +2926,9 @@ let tree_of_path = tree_of_path Other
 let tree_of_module ident ?(ellipsis = false) =
   tree_of_module ident ?abbrev:(if ellipsis then Some (Abbrev.ellipsis ()) else None)
 let tree_of_signature sg = tree_of_signature sg
-let tree_of_modtype ~abbrev ty =
+let tree_of_modtype ?(abbrev = false) ty =
   abbreviate ~abbrev tree_of_modtype ty
-let tree_of_modtype_declaration ~abbrev id md =
+let tree_of_modtype_declaration ?(abbrev = false) id md =
   abbreviate ~abbrev tree_of_modtype_declaration id md
 let type_expansion mode ppf ty_exp =
   type_expansion ppf (trees_of_type_expansion mode ty_exp)

--- a/ocaml/typing/printtyp.mli
+++ b/ocaml/typing/printtyp.mli
@@ -160,9 +160,9 @@ val tree_of_module:
     Ident.t -> ?ellipsis:bool -> module_type -> rec_status -> out_sig_item
 val modtype: formatter -> module_type -> unit
 val signature: formatter -> signature -> unit
-val tree_of_modtype: abbrev:bool -> module_type -> out_module_type
+val tree_of_modtype: ?abbrev:bool -> module_type -> out_module_type
 val tree_of_modtype_declaration:
-    abbrev:bool -> Ident.t -> modtype_declaration -> out_sig_item
+    ?abbrev:bool -> Ident.t -> modtype_declaration -> out_sig_item
 
 val expand_module_type: (Env.t -> module_type -> module_type) ref
 (* Forward declaration to be filled in Mtype. We want to be able to print types


### PR DESCRIPTION
PR #1895 introduced an incompatibility in the interface of `Printtyp` which prevented some external libraries from compiling. This hopefully fixes that.