### PR TITLE
Add missing iarrayLabels module from stdlib dune file

### DIFF
--- a/ocaml/stdlib/dune
+++ b/ocaml/stdlib/dune
@@ -119,6 +119,8 @@
     hashtbl.mli
     iarray.ml
     iarray.mli
+    iarrayLabels.ml
+    iarrayLabels.mli
     in_channel.ml
     in_channel.mli
     int.ml


### PR DESCRIPTION
@gretay-js pointed out we were missing this, causing these files to not be installed with the distribution, resulting in bad merlin behavior.

Review: @goldfirere 