### PR TITLE
Install simd.h with other runtime headers

### DIFF
--- a/ocaml/runtime/caml/dune
+++ b/ocaml/runtime/caml/dune
@@ -92,6 +92,7 @@
     (startup.h as caml/startup.h)
     (startup_aux.h as caml/startup_aux.h)
     (sys.h as caml/sys.h)
+    (simd.h as caml/simd.h)
     (ui.h as caml/ui.h)
     (version.h as caml/version.h)
     (weak.h as caml/weak.h)


### PR DESCRIPTION
Forgot to add `simd.h` to the runtime installer build rule.