### PR TITLE
Zero alloc: add payload "opt" and "-zero-alloc-check-opt" flag

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -1162,7 +1162,13 @@ end
 module Spec_zero_alloc : Spec = struct
   let property = Cmm.Zero_alloc
 
-  let enabled () = !Clflags.zero_alloc_check || !Clflags.zero_alloc_check_opt
+  let enabled () =
+    (* Checkmach no longer distinguishes between opt and default checks. *)
+    match !Clflags.zero_alloc_check with
+    | No_check -> false
+    | Check_default -> true
+    | Check_all -> true
+    | Check_opt_only -> true
 
   (* Compact the mapping from function name to Value.t to reduce size of Checks
      in cmx and memory consumption Compilenv. Different components have

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -1162,7 +1162,7 @@ end
 module Spec_zero_alloc : Spec = struct
   let property = Cmm.Zero_alloc
 
-  let enabled () = !Clflags.zero_alloc_check
+  let enabled () = !Clflags.zero_alloc_check || !Clflags.zero_alloc_check_opt
 
   (* Compact the mapping from function name to Value.t to reduce size of Checks
      in cmx and memory consumption Compilenv. Different components have

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4329,8 +4329,10 @@ let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
           never_returns_normally;
           loc
         } ]
-  | Check { property; strict; loc } ->
-    [Check { property = transl_property property; strict; loc }]
+  | Check { property; strict; loc; opt } ->
+    if Lambda.is_check_enabled ~opt property
+    then [Check { property = transl_property property; strict; loc }]
+    else []
 
 let kind_of_layout (layout : Lambda.layout) =
   match layout with

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -92,8 +92,8 @@ let mk_heap_reduction_threshold f =
 let mk_zero_alloc_check f =
   let annotations = Clflags.Annotations.(List.map to_string all) in
   "-zero-alloc-check", Arg.Symbol (annotations, f),
-  " Check that annoted functions do not allocate \
-   and do not have indirect calls"
+  " Check that annotated functions do not allocate \
+   and do not have indirect calls. "^Clflags.Annotations.doc
 
 let mk_dcheckmach f =
   "-dcheckmach", Arg.Unit f, " (undocumented)"

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -90,13 +90,10 @@ let mk_heap_reduction_threshold f =
 ;;
 
 let mk_zero_alloc_check f =
-  "-zero-alloc-check", Arg.Unit f, " Check that annoted functions do not allocate \
-                                    and do not have indirect calls"
-
-let mk_zero_alloc_check_opt f =
-  "-zero-alloc-check-opt", Arg.Unit f,
+  let annotations = Clflags.Annotations.(List.map to_string all) in
+  "-zero-alloc-check", Arg.Symbol (annotations, f),
   " Check that annoted functions do not allocate \
-   and do not have indirect calls in an optimized build."
+   and do not have indirect calls"
 
 let mk_dcheckmach f =
   "-dcheckmach", Arg.Unit f, " (undocumented)"
@@ -591,8 +588,7 @@ module type Flambda_backend_options = sig
   val dno_asm_comments : unit -> unit
 
   val heap_reduction_threshold : int -> unit
-  val zero_alloc_check : unit -> unit
-  val zero_alloc_check_opt : unit -> unit
+  val zero_alloc_check : string -> unit
   val dcheckmach : unit -> unit
   val checkmach_details_cutoff : int -> unit
 
@@ -697,7 +693,6 @@ struct
 
     mk_heap_reduction_threshold F.heap_reduction_threshold;
     mk_zero_alloc_check F.zero_alloc_check;
-    mk_zero_alloc_check_opt F.zero_alloc_check_opt;
     mk_dcheckmach F.dcheckmach;
     mk_checkmach_details_cutoff F.checkmach_details_cutoff;
 
@@ -844,8 +839,12 @@ module Flambda_backend_options_impl = struct
   let heap_reduction_threshold x =
     Flambda_backend_flags.heap_reduction_threshold := x
 
-  let zero_alloc_check = set' Clflags.zero_alloc_check
-  let zero_alloc_check_opt = set' Clflags.zero_alloc_check_opt
+  let zero_alloc_check s =
+    match Clflags.Annotations.of_string s with
+    | None -> () (* this should not occur as we use Arg.Symbol *)
+    | Some a ->
+      Clflags.zero_alloc_check := a
+
   let dcheckmach = set' Flambda_backend_flags.dump_checkmach
   let checkmach_details_cutoff n =
     let c : Flambda_backend_flags.checkmach_details_cutoff =
@@ -1104,8 +1103,13 @@ module Extra_params = struct
        set_int_option' Flambda_backend_flags.reorder_blocks_random
     | "basic-block-sections" -> set' Flambda_backend_flags.basic_block_sections
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
-    | "zero-alloc-check" -> set' Clflags.zero_alloc_check
-    | "zero-alloc-check-opt" -> set' Clflags.zero_alloc_check_opt
+    | "zero-alloc-check" ->
+      (match Clflags.Annotations.of_string v with
+       | Some a -> Clflags.zero_alloc_check := a; true
+       | None ->
+         raise
+           (Arg.Bad
+              (Printf.sprintf "Unexpected value %s for %s" v name)))
     | "dump-checkmach" -> set' Flambda_backend_flags.dump_checkmach
     | "checkmach-details-cutoff" ->
       begin match Compenv.check_int ppf name v with

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -93,6 +93,11 @@ let mk_zero_alloc_check f =
   "-zero-alloc-check", Arg.Unit f, " Check that annoted functions do not allocate \
                                     and do not have indirect calls"
 
+let mk_zero_alloc_check_opt f =
+  "-zero-alloc-check-opt", Arg.Unit f,
+  " Check that annoted functions do not allocate \
+   and do not have indirect calls in an optimized build."
+
 let mk_dcheckmach f =
   "-dcheckmach", Arg.Unit f, " (undocumented)"
 
@@ -587,6 +592,7 @@ module type Flambda_backend_options = sig
 
   val heap_reduction_threshold : int -> unit
   val zero_alloc_check : unit -> unit
+  val zero_alloc_check_opt : unit -> unit
   val dcheckmach : unit -> unit
   val checkmach_details_cutoff : int -> unit
 
@@ -691,6 +697,7 @@ struct
 
     mk_heap_reduction_threshold F.heap_reduction_threshold;
     mk_zero_alloc_check F.zero_alloc_check;
+    mk_zero_alloc_check_opt F.zero_alloc_check_opt;
     mk_dcheckmach F.dcheckmach;
     mk_checkmach_details_cutoff F.checkmach_details_cutoff;
 
@@ -838,6 +845,7 @@ module Flambda_backend_options_impl = struct
     Flambda_backend_flags.heap_reduction_threshold := x
 
   let zero_alloc_check = set' Clflags.zero_alloc_check
+  let zero_alloc_check_opt = set' Clflags.zero_alloc_check_opt
   let dcheckmach = set' Flambda_backend_flags.dump_checkmach
   let checkmach_details_cutoff n =
     let c : Flambda_backend_flags.checkmach_details_cutoff =
@@ -1097,6 +1105,7 @@ module Extra_params = struct
     | "basic-block-sections" -> set' Flambda_backend_flags.basic_block_sections
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
     | "zero-alloc-check" -> set' Clflags.zero_alloc_check
+    | "zero-alloc-check-opt" -> set' Clflags.zero_alloc_check_opt
     | "dump-checkmach" -> set' Flambda_backend_flags.dump_checkmach
     | "checkmach-details-cutoff" ->
       begin match Compenv.check_int ppf name v with

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -44,8 +44,7 @@ module type Flambda_backend_options = sig
   val dno_asm_comments : unit -> unit
 
   val heap_reduction_threshold : int -> unit
-  val zero_alloc_check : unit -> unit
-  val zero_alloc_check_opt : unit -> unit
+  val zero_alloc_check : string -> unit
   val dcheckmach : unit -> unit
   val checkmach_details_cutoff : int -> unit
 

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -45,6 +45,7 @@ module type Flambda_backend_options = sig
 
   val heap_reduction_threshold : int -> unit
   val zero_alloc_check : unit -> unit
+  val zero_alloc_check_opt : unit -> unit
   val dcheckmach : unit -> unit
   val checkmach_details_cutoff : int -> unit
 

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -58,8 +58,10 @@ let from_lambda : Lambda.check_attribute -> t = function
         never_returns_normally;
         loc
       }
-  | Check { property; strict; loc } ->
-    Check { property = Property.from_lambda property; strict; loc }
+  | Check { property; strict; opt; loc } ->
+    if Lambda.is_check_enabled ~opt property
+    then Check { property = Property.from_lambda property; strict; loc }
+    else Default_check
 
 let equal x y =
   match x, y with

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1663,3 +1663,9 @@ let array_set_kind mode = function
   | Paddrarray -> Paddrarray_set mode
   | Pintarray -> Pintarray_set
   | Pfloatarray -> Pfloatarray_set
+
+let is_check_enabled ~opt property =
+  match property with
+  | Zero_alloc ->
+    (!Clflags.zero_alloc_check && not opt) ||
+    (!Clflags.zero_alloc_check_opt && opt)

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1667,5 +1667,8 @@ let array_set_kind mode = function
 let is_check_enabled ~opt property =
   match property with
   | Zero_alloc ->
-    (!Clflags.zero_alloc_check && not opt) ||
-    (!Clflags.zero_alloc_check_opt && opt)
+    match !Clflags.zero_alloc_check with
+    | No_check -> false
+    | Check_all -> true
+    | Check_default -> not opt
+    | Check_opt_only -> opt

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -509,6 +509,7 @@ type check_attribute =
   | Ignore_assert_all of property
   | Check of { property: property;
                strict: bool;
+               opt: bool;
                loc: Location.t;
              }
   | Assume of { property: property;

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -771,3 +771,4 @@ val array_ref_kind : alloc_mode -> array_kind -> array_ref_kind
 
 (** The mode will be discarded if unnecessary for the given [array_kind] *)
 val array_set_kind : modify_mode -> array_kind -> array_set_kind
+val is_check_enabled : opt:bool -> property -> bool

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -401,6 +401,7 @@ type check_attribute =
                   then the property holds (but property violations on
                   exceptional returns or divering loops are ignored).
                   This definition may not be applicable to new properties. *)
+               opt: bool;
                loc: Location.t;
              }
   | Assume of { property: property;

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -687,9 +687,9 @@ let check_attribute ppf check =
       (check_property p)
       (if strict then "_strict" else "")
       (if never_returns_normally then "_never_returns_normally" else "")
-  | Check {property=p; strict; loc = _} ->
-    fprintf ppf "assert_%s%s@ "
-      (check_property p)
+  | Check {property=p; strict; loc = _; opt} ->
+    fprintf ppf "assert_%s%s%s@ "
+      (check_property p) (if opt then "_opt" else "")
       (if strict then "_strict" else "")
 
 let function_attribute ppf t =

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -314,8 +314,8 @@ let get_property_attribute l p =
    | None, (Check _ | Assume _ | Ignore_assert_all _) -> assert false
    | Some _, Ignore_assert_all _ -> ()
    | Some _, Assume _ -> ()
-   | Some attr, Check _ ->
-     if !Clflags.zero_alloc_check && !Clflags.native_code then
+   | Some attr, Check { opt; _ } ->
+     if Lambda.is_check_enabled ~opt p && !Clflags.native_code then
        (* The warning for unchecked functions will not trigger if the check is requested
           through the [@@@zero_alloc all] top-level annotation rather than through the
           function annotation [@zero_alloc]. *)

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -251,11 +251,13 @@ let parse_property_attribute attr property =
   | Some {Parsetree.attr_name = {txt; loc}; attr_payload = payload}->
       parse_ids_payload txt loc
         ~default:Default_check
-        ~empty:(Check { property; strict = false; loc; } )
+        ~empty:(Check { property; strict = false; opt = false; loc; } )
         [
           ["assume"],
           Assume { property; strict = false; never_returns_normally = false; loc; };
-          ["strict"], Check { property; strict = true; loc; };
+          ["strict"], Check { property; strict = true; opt = false; loc; };
+          ["opt"], Check { property; strict = false; opt = true; loc; };
+          ["opt"; "strict"; ], Check { property; strict = true; opt = true; loc; };
           ["assume"; "strict"],
           Assume { property; strict = true; never_returns_normally = false; loc; };
           ["assume"; "never_returns_normally"],

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -586,7 +586,7 @@ let parse_attribute_with_ident_payload attr ~name ~f =
 let zero_alloc_attribute (attr : Parsetree.attribute)  =
   parse_attribute_with_ident_payload attr
     ~name:"zero_alloc" ~f:(function
-      | "check" -> Clflags.zero_alloc_check := true
+      | "check" -> Clflags.zero_alloc_check := Clflags.Annotations.Check_default
       | "all" ->
         Clflags.zero_alloc_check_assert_all := true
       | _ ->

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -659,6 +659,12 @@ module Annotations = struct
       if String.equal (to_string t) v then Some t else None
     in
     List.find_map f all
+
+  let doc =
+    "\n\    The argument specifies which annotations to check: \n\
+     \      \"opt\" means attributes with \"opt\" payload and is intended for debugging;\n\
+     \      \"default\" means attributes without \"opt\" payload; \n\
+     \      \"all\" covers both \"opt\" and \"default\" and is intended for optimized builds."
 end
 
 let zero_alloc_check = ref Annotations.No_check         (* -zero-alloc-check *)

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -636,4 +636,5 @@ let print_arguments program =
   Arg.usage !arg_spec (create_usage_msg program)
 
 let zero_alloc_check = ref false            (* -zero-alloc-check *)
+let zero_alloc_check_opt = ref false        (* -zero-alloc-check-opt *)
 let zero_alloc_check_assert_all = ref false (* -zero-alloc-check-assert-all *)

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -635,6 +635,31 @@ let create_usage_msg program =
 let print_arguments program =
   Arg.usage !arg_spec (create_usage_msg program)
 
-let zero_alloc_check = ref false            (* -zero-alloc-check *)
-let zero_alloc_check_opt = ref false        (* -zero-alloc-check-opt *)
+module Annotations = struct
+  type t = Check_default | Check_all | Check_opt_only | No_check
+
+  let all = [ Check_default; Check_all; Check_opt_only; No_check ]
+
+  let to_string = function
+    | Check_default -> "default"
+    | Check_all -> "all"
+    | Check_opt_only -> "opt"
+    | No_check -> "none"
+
+  let equal t1 t2 =
+    match t1, t2 with
+    | Check_default, Check_default -> true
+    | Check_all, Check_all -> true
+    | No_check, No_check -> true
+    | Check_opt_only, Check_opt_only -> true
+    | (Check_default | Check_all | Check_opt_only | No_check), _ -> false
+
+  let of_string v =
+    let f t =
+      if String.equal (to_string t) v then Some t else None
+    in
+    List.find_map f all
+end
+
+let zero_alloc_check = ref Annotations.No_check         (* -zero-alloc-check *)
 let zero_alloc_check_assert_all = ref false (* -zero-alloc-check-assert-all *)

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -293,6 +293,7 @@ module Annotations : sig
   val to_string : t -> string
   val of_string : string -> t option
   val equal : t -> t -> bool
+  val doc : string
 end
 val zero_alloc_check : Annotations.t ref
 val zero_alloc_check_assert_all : bool ref

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -287,5 +287,6 @@ val print_arguments : string -> unit
 val reset_arguments : unit -> unit
 
 val zero_alloc_check : bool ref
+val zero_alloc_check_opt : bool ref
 val zero_alloc_check_assert_all : bool ref
 

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -286,7 +286,14 @@ val print_arguments : string -> unit
 (* [reset_arguments ()] clear all declared arguments *)
 val reset_arguments : unit -> unit
 
-val zero_alloc_check : bool ref
-val zero_alloc_check_opt : bool ref
+(* [Annotations] specifies which zero_alloc attributes to check. *)
+module Annotations : sig
+  type t = Check_default | Check_all | Check_opt_only | No_check
+  val all : t list
+  val to_string : t -> string
+  val of_string : string -> t option
+  val equal : t -> t -> bool
+end
+val zero_alloc_check : Annotations.t ref
 val zero_alloc_check_assert_all : bool ref
 

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -3,19 +3,19 @@
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps s.ml t.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps t5.ml test_assume.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps test_flambda.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (enabled_if (= %{context_name} "main"))
@@ -26,7 +26,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -45,7 +45,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -64,7 +64,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -83,7 +83,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -102,7 +102,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -121,7 +121,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -140,7 +140,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -159,7 +159,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -178,7 +178,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -197,7 +197,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -216,7 +216,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -235,7 +235,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -254,7 +254,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -273,7 +273,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -292,7 +292,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -311,7 +311,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -330,7 +330,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -349,7 +349,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -368,7 +368,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -387,7 +387,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -406,7 +406,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -425,7 +425,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 0 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 0 -O3))
     (run "./filter.sh")
    ))))
 
@@ -444,7 +444,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 0
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -463,7 +463,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 0
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -477,19 +477,19 @@
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps t7.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps test_stub_dep.ml test_stub.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps t1.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
@@ -500,7 +500,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 0
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -519,7 +519,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -538,7 +538,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check-opt -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check opt -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -557,7 +557,7 @@
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-          -zero-alloc-check-opt -checkmach-details-cutoff 20 -O3))
+          -zero-alloc-check opt -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
    ))))
 
@@ -571,10 +571,10 @@
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps test_zero_alloc_opt1.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check-opt -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check opt -dcse -dcheckmach -dump-into-file -O3)))
 
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
  (deps test_zero_alloc_opt2.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check-opt -dcse -dcheckmach -dump-into-file -O3)))
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check opt -dcse -dcheckmach -dump-into-file -O3)))

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -528,3 +528,53 @@
  (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
  (deps test_never_returns_normally.output test_never_returns_normally.output.corrected)
  (action (diff test_never_returns_normally.output test_never_returns_normally.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail22.output.corrected)
+ (deps (:ml fail22.ml) filter.sh)
+ (action
+   (with-outputs-to fail22.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check-opt -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail22.output fail22.output.corrected)
+ (action (diff fail22.output fail22.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (targets fail23.output.corrected)
+ (deps (:ml fail23.ml) filter.sh)
+ (action
+   (with-outputs-to fail23.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check-opt -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (deps fail23.output fail23.output.corrected)
+ (action (diff fail23.output fail23.output.corrected)))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_zero_alloc_opt1.ml)
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check-opt -dcse -dcheckmach -dump-into-file -O3)))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_zero_alloc_opt2.ml)
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check-opt -dcse -dcheckmach -dump-into-file -O3)))

--- a/tests/backend/checkmach/fail22.ml
+++ b/tests/backend/checkmach/fail22.ml
@@ -1,0 +1,3 @@
+(* expect to fail with -zero-alloc-check-opt *)
+let[@zero_alloc opt] foo x = (x,x)
+

--- a/tests/backend/checkmach/fail22.output
+++ b/tests/backend/checkmach/fail22.output
@@ -1,0 +1,4 @@
+File "fail22.ml", line 2, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Fail22.foo (camlFail22__foo_HIDE_STAMP)
+File "fail22.ml", line 2, characters 29-34:
+  allocate 24 bytes

--- a/tests/backend/checkmach/fail23.ml
+++ b/tests/backend/checkmach/fail23.ml
@@ -1,7 +1,8 @@
+exception Exn of string * int
 (* expect to fail with -zero-alloc-check-opt *)
 let[@zero_alloc opt strict] test1 x =
   if x > 0
   then x+1
   else
-    failwith ("expected positive, got "^(string_of_int x))
+    raise (Exn ("expected positive", x))
 

--- a/tests/backend/checkmach/fail23.ml
+++ b/tests/backend/checkmach/fail23.ml
@@ -1,0 +1,7 @@
+(* expect to fail with -zero-alloc-check-opt *)
+let[@zero_alloc opt strict] test1 x =
+  if x > 0
+  then x+1
+  else
+    failwith ("expected positive, got "^(string_of_int x))
+

--- a/tests/backend/checkmach/fail23.output
+++ b/tests/backend/checkmach/fail23.output
@@ -1,8 +1,4 @@
-File "fail23.ml", line 2, characters 5-15:
+File "fail23.ml", line 3, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Fail23.test1 (camlFail23__test1_HIDE_STAMP)
-File "fail23.ml", line 6, characters 13-58:
-  direct call camlStdlib__^_HIDE_STAMP on a path to exceptional return
-File "fail23.ml", line 6, characters 4-58:
-  allocate 24 bytes (fail23.ml:6,4--58;stdlib.ml:32,22--33) on a path to exceptional return
-File "fail23.ml", line 6, characters 40-57:
-  external call to caml_format_int (fail23.ml:6,40--57;stdlib.ml:271,2--19) on a path to exceptional return
+File "fail23.ml", line 7, characters 10-40:
+  allocate 32 bytes on a path to exceptional return

--- a/tests/backend/checkmach/fail23.output
+++ b/tests/backend/checkmach/fail23.output
@@ -1,0 +1,8 @@
+File "fail23.ml", line 2, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Fail23.test1 (camlFail23__test1_HIDE_STAMP)
+File "fail23.ml", line 6, characters 13-58:
+  direct call camlStdlib__^_HIDE_STAMP on a path to exceptional return
+File "fail23.ml", line 6, characters 4-58:
+  allocate 24 bytes (fail23.ml:6,4--58;stdlib.ml:32,22--33) on a path to exceptional return
+File "fail23.ml", line 6, characters 40-57:
+  external call to caml_format_int (fail23.ml:6,40--57;stdlib.ml:271,2--19) on a path to exceptional return

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -8,7 +8,7 @@ let () =
       {|(enabled_if (= %{context_name} "main"))|}
   in
   let buf = Buffer.create 1000 in
-  let print_test ?(extra_flags="-zero-alloc-check") ~flambda_only deps =
+  let print_test ?(extra_flags="-zero-alloc-check default") ~flambda_only deps =
     let enabled_if = enabled_if flambda_only in
     let subst = function
       | "enabled_if" -> enabled_if
@@ -27,7 +27,7 @@ let () =
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
-  let print_test_expected_output ?(extra_flags="-zero-alloc-check") ~cutoff ~flambda_only ~extra_dep ~exit_code name =
+  let print_test_expected_output ?(extra_flags="-zero-alloc-check default") ~cutoff ~flambda_only ~extra_dep ~exit_code name =
     let enabled_if = enabled_if flambda_only in
     let ml_deps =
       let s =
@@ -120,8 +120,8 @@ let () =
   (* closure does not delete dead functions *)
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:(Some "test_warning199.mli") ~exit_code:0 "test_warning199";
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "test_never_returns_normally";
-  print_test_expected_output ~extra_flags:"-zero-alloc-check-opt" ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail22";
-  print_test_expected_output ~extra_flags:"-zero-alloc-check-opt" ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "fail23";
-  print_test ~extra_flags:"-zero-alloc-check-opt" ~flambda_only:false "test_zero_alloc_opt1.ml";
-  print_test ~extra_flags:"-zero-alloc-check-opt" ~flambda_only:false "test_zero_alloc_opt2.ml";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check opt" ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail22";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check opt" ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "fail23";
+  print_test ~extra_flags:"-zero-alloc-check opt" ~flambda_only:false "test_zero_alloc_opt1.ml";
+  print_test ~extra_flags:"-zero-alloc-check opt" ~flambda_only:false "test_zero_alloc_opt2.ml";
   ()

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -251,3 +251,8 @@ module Never_returns_normally = struct
  let[@zero_alloc] foo x = failwithf "%d" x
  let[@zero_alloc] bar x y = invalid_argf "%d" (x+y)
 end
+
+
+module Opt = struct
+  let[@zero_alloc opt] test x = x,x
+end

--- a/tests/backend/checkmach/t.ml
+++ b/tests/backend/checkmach/t.ml
@@ -254,5 +254,7 @@ end
 
 
 module Opt = struct
+  (* passes because -zero-alloc-check-opt is not provided. *)
   let[@zero_alloc opt] test x = x,x
+  let[@zero_alloc opt strict] test x = x,x
 end

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -4,12 +4,12 @@ File "test_attribute_error_duplicate.ml", line 2, characters 66-76:
 Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
 File "test_attribute_error_duplicate.ml", line 3, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
+It must be either 'assume', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 4, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
+It must be either 'assume', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 5, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
+It must be either 'assume', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate__test1_HIDE_STAMP)

--- a/tests/backend/checkmach/test_zero_alloc_opt1.ml
+++ b/tests/backend/checkmach/test_zero_alloc_opt1.ml
@@ -1,0 +1,3 @@
+(* expect to succeed with -zero-alloc-check-opt without -zero-alloc-check *)
+let[@zero_alloc] bar x = (x,x)
+let[@zero_alloc strict] test1 x = if x > 0 then x+1 else failwith "x must be positive"

--- a/tests/backend/checkmach/test_zero_alloc_opt2.ml
+++ b/tests/backend/checkmach/test_zero_alloc_opt2.ml
@@ -1,0 +1,4 @@
+(* expect to succeed with -zero-alloc-check-opt *)
+let[@zero_alloc opt] test1 x = if x > 0 then x+1 else failwith "x must be positive"
+let[@zero_alloc opt strict] test2 x = x + 1
+let[@zero_alloc strict opt] test3 x = x - 1


### PR DESCRIPTION
Support `[@zero_alloc opt]` annotation. The intended use is to annotate functions that are "zero-alloc"  in an optimized build but may allocate in a non-optimized build. This annotation is checked when `-zero-alloc-check-opt` compilation flag is set (off by default).  

Using both `[@zero_alloc][@zero_alloc opt]` on the same function is not allowed. Instead, optimized build should set both `-zero-alloc-check` and `-zero-alloc-check-opt` flags. If a function is expected to be `zero_alloc` in all builds, it should be annotated with `[@zero_alloc]` only, without `opt`.   

Payload `opt` can be combined with `strict` payload but not with `assume`.

The new annotation is resolved on the way out of `Lambda`, so that backend and middle-end do not need to know about `opt`. It is hard to resolve this information earlier because of the way function attributes are handled using two separate calls to `Translattribute.add_function_attributes`.

