### PR TITLE
Support for [@error_message] attribute on layout annotations

### DIFF
--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -104,6 +104,7 @@ let builtin_attrs =
   ; "loop"; "ocaml.loop"
   ; "tail_mod_cons"; "ocaml.tail_mod_cons"
   ; "unaliasable"; "ocaml.unaliasable"
+  ; "error_message"; "ocaml.error_message"
   ]
 
 (* nroberts: When we upstream the builtin-attribute whitelisting, we shouldn't
@@ -665,3 +666,18 @@ let tailcall attr =
           (Warnings.Attribute_payload
              (t.attr_name.txt, "Only 'hint' is supported"));
         Ok (Some `Tail_if_possible)
+
+let error_message_attr l =
+  let inner x =
+    match x.attr_name.txt with
+    | "ocaml.error_message"|"error_message" ->
+      begin match string_of_payload x.attr_payload with
+      | Some _ as r ->
+        mark_used x.attr_name;
+        r
+      | None -> warn_payload x.attr_loc x.attr_name.txt
+                  "error_message attribute expects a string argument";
+        None
+      end
+    | _ -> None in
+  List.find_map inner l

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -204,3 +204,10 @@ val has_once : Parsetree.attributes -> (bool, unit) result
 val layout : legacy_immediate:bool -> Parsetree.attributes ->
   (Jane_asttypes.layout_annotation option,
    Jane_asttypes.layout_annotation) result
+
+(** Finds the first "error_message" attribute, marks it as used, and returns its
+    string payload. Returns [None] if no such attribute is present.
+
+    There should be at most one "error_message" attribute, additional ones are sliently
+    ignored. **)
+val error_message_attr : Parsetree.attributes -> string option

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -1,0 +1,156 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+ * expect
+*)
+
+module Float_u = Stdlib__Float_u
+
+[%%expect{|
+module Float_u = Stdlib__Float_u
+|}]
+
+(* Needs a string payload *)
+
+let f (v: float#): ((_ : value)[@error_message]) = v
+[%%expect{|
+Line 1, characters 31-47:
+1 | let f (v: float#): ((_ : value)[@error_message]) = v
+                                   ^^^^^^^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'error_message'.
+error_message attribute expects a string argument
+Line 1, characters 51-52:
+1 | let f (v: float#): ((_ : value)[@error_message]) = v
+                                                       ^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 1, characters 20-31.
+|}]
+
+let f (v: float#): ((_ : value)[@error_message 1]) = v
+[%%expect{|
+Line 1, characters 31-49:
+1 | let f (v: float#): ((_ : value)[@error_message 1]) = v
+                                   ^^^^^^^^^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'error_message'.
+error_message attribute expects a string argument
+Line 1, characters 53-54:
+1 | let f (v: float#): ((_ : value)[@error_message 1]) = v
+                                                         ^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 1, characters 20-31.
+|}]
+
+(* Ltyp_var { name = None; layout } case *)
+let f (v: float#): ((_ : value)[@error_message "Custom message"]) = v
+[%%expect{|
+Line 1, characters 68-69:
+1 | let f (v: float#): ((_ : value)[@error_message "Custom message"]) = v
+                                                                        ^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 1, characters 20-31.
+         Custom message
+|}]
+
+let f x =
+  ignore ((x : (_ : value)[@error_message "Custom message"]));
+  Float_u.to_float x
+[%%expect{|
+Line 3, characters 19-20:
+3 |   Float_u.to_float x
+                       ^
+Error: This expression has type ('a : value)
+       but an expression was expected of type float#
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 2, characters 15-26.
+         Custom message
+|}]
+
+(* Ltyp_var { name = Some name; layout } case *)
+module type a = sig
+  type ('a : float64) t = 'a
+  val f : (('a : value)[@error_message "Custom message"]) -> 'a t
+end
+
+[%%expect{|
+Line 3, characters 61-63:
+3 |   val f : (('a : value)[@error_message "Custom message"]) -> 'a t
+                                                                 ^^
+Error: This type ('a : value) should be an instance of type ('b : float64)
+       The layout of 'a is value, because
+         of the annotation on the type variable 'a.
+         Custom message
+       But the layout of 'a must overlap with float64, because
+         of the definition of t at line 2, characters 2-28.
+|}]
+
+
+(* Ltyp_alias { aliased_type; name; layout } case *)
+
+(* First call to [layout_of_annotation] in [transl_type_alias] *)
+module type a = sig
+  type t : float64
+  val f : 'a -> t -> (t as ('a : value)[@error_message "Custom message"])
+end
+[%%expect{|
+Line 3, characters 33-38:
+3 |   val f : 'a -> t -> (t as ('a : value)[@error_message "Custom message"])
+                                     ^^^^^
+Error: Bad layout annotation:
+         The layout of t is float64, because
+           of the definition of t at line 2, characters 2-18.
+         But the layout of t must be a sublayout of value, because
+           of the annotation on the type variable 'a.
+           Custom message
+|}]
+
+(* Second call to [layout_of_annotation] in the Not_found case
+   of [transl_type_alias] *)
+module type a = sig
+  type t : float64
+  val f : t -> (t as ('a : value)[@error_message "Custom message"])
+end
+[%%expect{|
+Line 3, characters 16-33:
+3 |   val f : t -> (t as ('a : value)[@error_message "Custom message"])
+                    ^^^^^^^^^^^^^^^^^
+Error: This alias is bound to type t but is used as an instance of type
+         ('a : value)
+       The layout of t is float64, because
+         of the definition of t at line 2, characters 2-18.
+       But the layout of t must be a sublayout of value, because
+         of the annotation on the type variable 'a.
+         Custom message
+|}]
+
+(* Third call to [layout_of_annotation] in the None case
+   of [transl_type_alias] *)
+module type a = sig
+  type t : float64
+  val f : t -> (t as (_ : value)[@error_message "Custom message"])
+end
+[%%expect{|
+Line 3, characters 26-31:
+3 |   val f : t -> (t as (_ : value)[@error_message "Custom message"])
+                              ^^^^^
+Error: Bad layout annotation:
+         The layout of t/2 is float64, because
+           of the definition of t at line 2, characters 2-18.
+         But the layout of t/2 must be a sublayout of value, because
+           of the annotation on the wildcard _ at line 3, characters 26-31.
+           Custom message
+|}]
+
+(* Currently it's not possible to attach attributes to Ltyp_poly *)

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr_w53.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr_w53.compilers.reference
@@ -1,0 +1,12 @@
+File "error_message_attr_w53.ml", line 16, characters 43-56:
+16 |     (int as ('a:value)[@error_message ""][@error_message ""]) (* reject second *)
+                                                ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "error_message_attr_w53.ml", line 20, characters 45-58:
+20 |   let f1 v: ((_ : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+                                                  ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "error_message_attr_w53.ml", line 21, characters 46-59:
+21 |   let f2 v: (('a : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+                                                   ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr_w53.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr_w53.ml
@@ -1,0 +1,22 @@
+(* TEST
+
+flags = "-w +A-60-70 -extension layouts"
+
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+compile_only = "true"
+*** check-ocamlc.byte-output
+
+*)
+
+(* CR layouts v1.5: move this to [warnings/w53.ml] when layout annotation is generally avaliable
+   without the layouts extension flag. *)
+module type TestErrorMessageSig = sig
+  val f : int ->
+    (int as ('a:value)[@error_message ""][@error_message ""]) (* reject second *)
+end
+
+module TestErrorMessageStruct = struct
+  let f1 v: ((_ : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+  let f2 v: (('a : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+end

--- a/ocaml/testsuite/tests/warnings/w53.compilers.reference
+++ b/ocaml/testsuite/tests/warnings/w53.compilers.reference
@@ -582,3 +582,51 @@ File "w53.ml", line 356, characters 17-22:
 356 |   let f2 = fun [@boxed] (type a) (x : a) -> x (* rejected *)
                        ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+File "w53.ml", line 360, characters 21-34:
+360 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+                           ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 361, characters 19-32:
+361 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 362, characters 17-30:
+362 |   val x : int [@@error_message ""] (* rejected *)
+                       ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 364, characters 22-35:
+364 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 364, characters 51-64:
+364 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                                                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 366, characters 39-52:
+366 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+                                             ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 370, characters 21-34:
+370 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+                           ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 371, characters 19-32:
+371 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 372, characters 22-35:
+372 |   let x : int = 42 [@@error_message ""] (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 374, characters 22-35:
+374 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 374, characters 51-64:
+374 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                                                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 376, characters 39-52:
+376 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+                                             ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/warnings/w53.ml
+++ b/ocaml/testsuite/tests/warnings/w53.ml
@@ -355,3 +355,23 @@ module TestNewtypeAttr = struct
 
   let f2 = fun [@boxed] (type a) (x : a) -> x (* rejected *)
 end
+
+module type TestErrorMessageSig = sig
+  type 'a t1 = 'a [@@error_message ""] (* rejected *)
+  type s1 = Foo1 [@error_message ""] (* rejected *)
+  val x : int [@@error_message ""] (* rejected *)
+
+  external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+    "x" "y"
+  external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+end
+
+module TestErrorMessageStruct = struct
+  type 'a t1 = 'a [@@error_message ""] (* rejected *)
+  type s1 = Foo1 [@error_message ""] (* rejected *)
+  let x : int = 42 [@@error_message ""] (* rejected *)
+
+  external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+    "x" "y"
+  external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+end

--- a/ocaml/testsuite/tests/warnings/w53_marshalled.compilers.reference
+++ b/ocaml/testsuite/tests/warnings/w53_marshalled.compilers.reference
@@ -578,3 +578,51 @@ File "w53.ml", line 356, characters 17-22:
 356 |   let f2 = fun [@boxed] (type a) (x : a) -> x (* rejected *)
                        ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
+File "w53.ml", line 360, characters 21-34:
+360 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+                           ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 361, characters 19-32:
+361 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 362, characters 17-30:
+362 |   val x : int [@@error_message ""] (* rejected *)
+                       ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 364, characters 22-35:
+364 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 364, characters 51-64:
+364 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                                                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 366, characters 39-52:
+366 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+                                             ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 370, characters 21-34:
+370 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+                           ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 371, characters 19-32:
+371 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 372, characters 22-35:
+372 |   let x : int = 42 [@@error_message ""] (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 374, characters 22-35:
+374 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 374, characters 51-64:
+374 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                                                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+File "w53.ml", line 376, characters 39-52:
+376 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+                                             ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context

--- a/ocaml/typing/layouts.mli
+++ b/ocaml/typing/layouts.mli
@@ -155,6 +155,7 @@ module Layout : sig
     | Univar of string
     | Type_variable of string
     | Type_wildcard of Location.t
+    | With_error_message of string * annotation_context
 
    type value_creation_reason =
     | Class_let_binding


### PR DESCRIPTION
With this new attribute, it's now possible to attach custom error messages to layout constraints:

```ocaml
let f x =
  ignore ((x : (_ : value)[@error_message "Custom message"]));
  Float_u.to_float x
[%%expect{|
Line 3, characters 19-20:
3 |   Float_u.to_float x
                       ^
Error: This expression has type ('a : value)
       but an expression was expected of type float#
       The layout of float# is float64, because
         it is the primitive float64 type float#.
       But the layout of float# must be a sublayout of value, because
         the [@error_message] attribute: Custom message.
|}]
```

Main motivation here is for ppx authors to be able to signal to clients when their ppx doesn't work with unboxed types.

The current parser doesn't have support for attaching attributes to universal variable layout annotations. Thus, `attrs` are ignored in the `Ltyp_poly` case of `transl_type_aux_jst_layout`.