### PR TITLE
Zero alloc: show all errors in a compilation unit

### DIFF
--- a/tests/backend/checkmach/test_never_returns_normally.output
+++ b/tests/backend/checkmach/test_never_returns_normally.output
@@ -2,3 +2,7 @@ File "test_never_returns_normally.ml", line 9, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.foo (camlTest_never_returns_normally__foo_HIDE_STAMP)
 File "test_never_returns_normally.ml", line 9, characters 25-41:
   indirect tailcall
+File "test_never_returns_normally.ml", line 10, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.bar (camlTest_never_returns_normally__bar_HIDE_STAMP)
+File "test_never_returns_normally.ml", line 10, characters 27-50:
+  indirect tailcall


### PR DESCRIPTION
Print error messages about all functions that failed the check in a compilation unit, not just the first one.