### PR TITLE
Record *old* value of sort during backtracking

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
@@ -263,7 +263,7 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-        'a has layout float64, which does not overlap with value.
+         'a has layout float64, which does not overlap with value.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_alpha_beta.ml
@@ -255,9 +255,17 @@ and 'a t5_11 = {x : 'a t5_10; y : 'a}
 type ('a : float64) t5_12 = {x : 'a; y : float#};;
 [%%expect{|
 type ('a : float64, 'b : float64) t5_9 = { x : 'a; y : 'b; z : 'a; }
-type ('a : float64) t5_10 = 'a t_float64_id
-and ('a : float64) t5_11 = { x : 'a t5_10; y : 'a; }
-type ('a : float64) t5_12 = { x : 'a; y : float#; }
+Line 4, characters 20-28:
+4 | and 'a t5_11 = {x : 'a t5_10; y : 'a}
+                        ^^^^^^^^
+Error: Layout mismatch in final type declaration consistency check.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+        'a has layout float64, which does not overlap with value.
+       The fix will likely be to add a layout annotation on a parameter to
+       the declaration where this error is reported.
 |}];;
 
 type ('a : float64) t5_13 = {x : 'a; y : float#};;

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -297,7 +297,7 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-        'a has layout value, which is not a sublayout of immediate.
+         'a has layout value, which is not a sublayout of immediate.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots_beta.ml
@@ -292,7 +292,14 @@ type ('a : immediate) t_imm
 Line 3, characters 15-39:
 3 | type s = { f : ('a : value). 'a -> 'a u }
                    ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type 'a has layout value, which is not a sublayout of immediate.
+Error: Layout mismatch in final type declaration consistency check.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+        'a has layout value, which is not a sublayout of immediate.
+       The fix will likely be to add a layout annotation on a parameter to
+       the declaration where this error is reported.
 |}]
 (* CR layouts v1.5: the location on that message is wrong. But it's hard
    to improve, because it comes from re-checking typedtree, where we don't

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -1392,7 +1392,7 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-        'a has layout value, which is not a sublayout of immediate.
+         'a has layout value, which is not a sublayout of immediate.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -1387,7 +1387,14 @@ type ('a : immediate) t2_imm
 Line 3, characters 15-40:
 3 | type s = { f : ('a : value) . 'a -> 'a u }
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type 'a has layout value, which is not a sublayout of immediate.
+Error: Layout mismatch in final type declaration consistency check.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+        'a has layout value, which is not a sublayout of immediate.
+       The fix will likely be to add a layout annotation on a parameter to
+       the declaration where this error is reported.
 |}]
 
 (****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -331,8 +331,53 @@ and t2 = Mk1 of t_void t | Mk2
 type 'a t8_5 = { x : 'a t8_6; y : string}
 and 'a t8_6 = 'a void_t;;
 [%%expect {|
-type ('a : void) t8_5 = { x : 'a t8_6; y : string; }
-and ('a : void) t8_6 = 'a void_t
+Line 1, characters 21-28:
+1 | type 'a t8_5 = { x : 'a t8_6; y : string}
+                         ^^^^^^^
+Error: Layout mismatch in final type declaration consistency check.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+        'a has layout void, which does not overlap with value.
+       The fix will likely be to add a layout annotation on a parameter to
+       the declaration where this error is reported.
+|}]
+
+type ('a : immediate) imm_t
+type 'a t10 = { x : 'a t10_2; y : string}
+and 'a t10_2 = 'a imm_t;;
+
+[%%expect{|
+type ('a : immediate) imm_t
+Line 2, characters 20-28:
+2 | type 'a t10 = { x : 'a t10_2; y : string}
+                        ^^^^^^^^
+Error: Layout mismatch in final type declaration consistency check.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+        'a has layout value, which is not a sublayout of immediate.
+       The fix will likely be to add a layout annotation on a parameter to
+       the declaration where this error is reported.
+|}]
+
+type 'a t = { x : ('b : void). 'b t -> 'b t }
+            constraint 'a = float#
+
+[%%expect{|
+Line 1, characters 18-43:
+1 | type 'a t = { x : ('b : void). 'b t -> 'b t }
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Layout mismatch in final type declaration consistency check.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+        float# has layout float64, which is not a sublayout of void.
+       The fix will likely be to add a layout annotation on a parameter to
+       the declaration where this error is reported.
 |}]
 
 (*****************************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -339,7 +339,7 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-        'a has layout void, which does not overlap with value.
+         'a has layout void, which does not overlap with value.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -358,7 +358,7 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-        'a has layout value, which is not a sublayout of immediate.
+         'a has layout value, which is not a sublayout of immediate.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -375,7 +375,7 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-        float# has layout float64, which is not a sublayout of void.
+         float# has layout float64, which is not a sublayout of void.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -69,7 +69,7 @@ module Sort = struct
 
   let set : var -> t option -> unit =
    fun v t_op ->
-    log_change (v, t_op);
+    log_change (v, !v);
     v := t_op
 
   (* Post-condition: If the result is a [Var v], then [!v] is [None]. *)

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -73,6 +73,7 @@ type error =
   | Deep_unbox_or_untag_attribute of native_repr_kind
   | Jkind_mismatch_of_type of type_expr * Jkind.Violation.t
   | Jkind_mismatch_of_path of Path.t * Jkind.Violation.t
+  | Jkind_mismatch_in_check_constraints of type_expr * Jkind.Violation.t
   | Jkind_sort of
       { kloc : jkind_sort_loc
       ; typ : type_expr
@@ -850,7 +851,7 @@ let rec check_constraints_rec env loc visited ty =
         | Unification_failure err ->
           raise (Error(loc, Constraint_failed (env, err)))
         | Jkind_mismatch { original_jkind; inferred_jkind; ty } ->
-          raise (Error(loc, Jkind_mismatch_of_type (ty,
+          raise (Error(loc, Jkind_mismatch_in_check_constraints (ty,
                               (Jkind.Violation.of_ (Not_a_subjkind
                                  (original_jkind, inferred_jkind))))))
         | All_good -> ()
@@ -1744,9 +1745,14 @@ let transl_type_decl env rec_flag sdecl_list =
   (* Check that all type variables are closed; this also defaults any remaining
      sort variables. Defaulting must happen before update_decls_jkind,
      Typedecl_seperability.update_decls, and add_types_to_env, all of which need
-     to check whether parts of the type are void (and currently use
-     Jkind.equate to do this which would set any remaining sort variables
-     to void). *)
+     to check whether parts of the type are void (and currently use Jkind.equate
+     to do this which would set any remaining sort variables to void). It also
+     must happen before check_constraints, so that check_constraints can detect
+     when a jkind is inferred incorrectly.  (The unification that
+     check_constraints does is undone via backtracking, and thus forgetting to
+     do the defaulting first is actually unsound: the unification in
+     check_constraints will succeed via mutation, be backtracked, and then
+     perhaps a sort variable gets defaulted to value. Bad bad.) *)
   List.iter2
     (fun sdecl tdecl ->
       let decl = tdecl.typ_type in
@@ -2625,6 +2631,18 @@ module Reaching_path = struct
     pp path
 end
 
+let report_jkind_mismatch_in_check_constraints ppf ty violation =
+  fprintf ppf
+    "@[<v>Layout mismatch in final type declaration consistency check.@ \
+     This is most often caused by the fact that type inference is not@ \
+     clever enough to propagate layouts through variables in different@ \
+     declarations. It is also not clever enough to produce a good error@ \
+     message, so we'll say this instead:@;<1 2>@[%a@]@ \
+     The fix will likely be to add a layout annotation on a parameter to@ \
+     the declaration where this error is reported.@]"
+    (Jkind.Violation.report_with_offender
+       ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) violation
+
 let report_error ppf = function
   | Repeated_parameter ->
       fprintf ppf "A type parameter occurs several times"
@@ -2664,11 +2682,24 @@ let report_error ppf = function
            "the original" "this" "definition" env)
         err
   | Constraint_failed (env, err) ->
+      let get_jkind_error : _ Errortrace.elt -> _ = function
+      | Bad_jkind (ty, violation) | Bad_jkind_sort (ty, violation) ->
+        Some (ty, violation)
+      | Unequal_var_jkinds _ | Diff _ | Variant _ | Obj _
+      | Escape _ | Incompatible_fields _ | Rec_occur _ -> None
+      in
+      begin match List.find_map get_jkind_error err.trace with
+      | Some (ty, violation) ->
+        report_jkind_mismatch_in_check_constraints ppf ty violation
+      | None ->
       fprintf ppf "@[<v>Constraints are not satisfied in this type.@ ";
       Printtyp.report_unification_error ppf env err
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "should be an instance of");
       fprintf ppf "@]"
+      end
+  | Jkind_mismatch_in_check_constraints (ty, violation) ->
+      report_jkind_mismatch_in_check_constraints ppf ty violation
   | Non_regular { definition; used_as; defined_as; reaching_path } ->
       let reaching_path = Reaching_path.simplify reaching_path in
       Printtyp.prepare_for_printing [used_as; defined_as];

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1741,8 +1741,6 @@ let transl_type_decl env rec_flag sdecl_list =
         raise (Error (loc, Type_clash (new_env, err))))
       checks)
     delayed_jkind_checks;
-  (* Check that constraints are enforced *)
-  List.iter2 (check_constraints new_env) sdecl_list decls;
   (* Check that all type variables are closed; this also defaults any remaining
      sort variables. Defaulting must happen before update_decls_jkind,
      Typedecl_seperability.update_decls, and add_types_to_env, all of which need
@@ -1756,6 +1754,8 @@ let transl_type_decl env rec_flag sdecl_list =
          Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
        | None   -> ())
     sdecl_list tdecls;
+  (* Check that constraints are enforced *)
+  List.iter2 (check_constraints new_env) sdecl_list decls;
   (* Add type properties to declarations *)
   let decls =
     try

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -107,6 +107,7 @@ type error =
   | Deep_unbox_or_untag_attribute of native_repr_kind
   | Jkind_mismatch_of_type of type_expr * Jkind.Violation.t
   | Jkind_mismatch_of_path of Path.t * Jkind.Violation.t
+  | Jkind_mismatch_in_check_constraints of type_expr * Jkind.Violation.t
   | Jkind_sort of
       { kloc : jkind_sort_loc
       ; typ : type_expr


### PR DESCRIPTION
This can't easily be tested, but this bug surfaced in my upcoming modal kinds patch. Thought it would be easier to review separately.

Review suggestion: @alanechang 