### PR TITLE
Change error message for non-value class lets

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -788,8 +788,8 @@ end
 Line 3, characters 11-12:
 3 |     let VV v = v in
                ^
-Error: Variables bound in a class must have layout value.
-       v has layout void, which is not a sublayout of value.
+Error: The types of variables bound by a 'let' in a class function
+       must have layout value. Instead, v's type has layout void.
 |}];;
 
 (* Hits the Cfk_concrete case of Pcf_val *)

--- a/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_beta.ml
@@ -702,8 +702,8 @@ end
 Line 4, characters 8-9:
 4 |     let d = f u in
             ^
-Error: Variables bound in a class must have layout value.
-       d has layout float64, which is not a sublayout of value.
+Error: The types of variables bound by a 'let' in a class function
+       must have layout value. Instead, d's type has layout float64.
 |}];;
 
 (* Hits the Cfk_concrete case of Pcf_val *)

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -490,8 +490,6 @@ let of_new_sort_var ~why =
 
 let of_new_sort ~why = fst (of_new_sort_var ~why)
 
-let of_sort_for_error ~why s = fresh_jkind (Sort s) ~why:(Concrete_creation why)
-
 let of_const ~why : const -> t = function
   | Any -> fresh_jkind Any ~why
   | Immediate -> fresh_jkind Immediate ~why

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -362,11 +362,6 @@ val of_new_sort_var : why:concrete_jkind_reason -> t * sort
 (** Create a fresh sort variable, packed into a jkind. *)
 val of_new_sort : why:concrete_jkind_reason -> t
 
-(** There should not be a need to convert a sort to a jkind, but this is
-    occasionally useful for formatting error messages. Do not use in actual
-    type-checking. *)
-val of_sort_for_error : why:concrete_jkind_reason -> sort -> t
-
 val of_const : why:creation_reason -> const -> t
 
 (* CR layouts v1.5: remove legacy_immediate when the old attributes mechanism

--- a/ocaml/typing/typeclass.mli
+++ b/ocaml/typing/typeclass.mli
@@ -125,6 +125,7 @@ type error =
   | Closing_self_type of class_signature
   | Polymorphic_class_parameter
   | Non_value_binding of string * Jkind.Violation.t
+  | Non_value_let_binding of string * Jkind.sort
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error


### PR DESCRIPTION
The old way of producing this error required `of_sort_for_error`, which causes trouble in the modal kinds world. This kills off that terrible function.

Review: @ccasin 