### PR TITLE
Error message: add hint for unboxed types

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -255,10 +255,11 @@ Error: The type constructor float# expects 0 argument(s),
 (* Hint for #float *)
 type t = #float;;
 [%%expect {|
-Line 1, characters 10-15:
+Line 1, characters 9-15:
 1 | type t = #float;;
-              ^^^^^
-Error: Did you mean float#?
+             ^^^^^^
+Error: float is neither a polymorphic variant nor a class type.
+       Did you mean the unboxed type float#?
 |}]
 
 (* Hint should not show up in this case *)

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -258,7 +258,7 @@ type t = #float;;
 Line 1, characters 10-15:
 1 | type t = #float;;
               ^^^^^
-Error: Unbound class type float
+Error: Did you mean float#?
 |}]
 
 (* Hint should not show up in this case *)

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -259,7 +259,6 @@ Line 1, characters 10-15:
 1 | type t = #float;;
               ^^^^^
 Error: Unbound class type float
-Hint: Did you mean float#?
 |}]
 
 (* Hint should not show up in this case *)
@@ -271,5 +270,5 @@ Line 2, characters 15-20:
 2 | class type c = float
                    ^^^^^
 Error: Unbound class type float
-Hint: Did you mean float#?
+Hint: Did you mean floot?
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -261,3 +261,15 @@ Line 1, characters 10-15:
 Error: Unbound class type float
 Hint: Did you mean float#?
 |}]
+
+(* Hint should not show up in this case *)
+class type floot = object end
+class type c = float
+[%%expect {|
+class type floot = object  end
+Line 2, characters 15-20:
+2 | class type c = float
+                   ^^^^^
+Error: Unbound class type float
+Hint: Did you mean float#?
+|}]

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -3889,8 +3889,8 @@ let report_lookup_error _loc env ppf = function
   | Unbound_cltype lid ->
       fprintf ppf "Unbound class type %a" !print_longident lid;
       begin match lid with
-      | Lident "float" ->
-        Misc.did_you_mean ppf (fun () -> ["float#"])
+      | Lident name when List.exists (String.equal (name^"#")) (extract_types None env) ->
+        Misc.did_you_mean ppf (fun () -> [name^"#"])
       | Lident _ | Ldot _ | Lapply _ ->
         spellcheck ppf extract_cltypes env lid
       end;

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -3888,12 +3888,7 @@ let report_lookup_error _loc env ppf = function
     end
   | Unbound_cltype lid ->
       fprintf ppf "Unbound class type %a" !print_longident lid;
-      begin match lid with
-      | Lident name when List.exists (String.equal (name^"#")) (extract_types None env) ->
-        Misc.did_you_mean ppf (fun () -> [name^"#"])
-      | Lident _ | Ldot _ | Lapply _ ->
-        spellcheck ppf extract_cltypes env lid
-      end;
+      spellcheck ppf extract_cltypes env lid
   | Unbound_instance_variable s ->
       fprintf ppf "Unbound instance variable %s" s;
       spellcheck_name ppf extract_instance_variables env s;

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -725,7 +725,7 @@ and transl_type_aux env policy mode styp =
             | Longident.Lapply(_, _) -> fatal_error "Typetexp.transl_type"
           in
           ignore (Env.find_type_by_name lid3 env : Path.t * Types.type_declaration);
-          raise (Error (lid.loc, env, Did_you_mean_unboxed lid3))
+          raise (Error (styp.ptyp_loc, env, Did_you_mean_unboxed lid.txt))
         with Not_found ->
           ignore (Env.lookup_cltype ~loc:lid.loc lid.txt env); assert false
       in
@@ -1400,7 +1400,8 @@ let report_error env ppf = function
       (Jkind.Violation.report_with_offender
          ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) violation
   | Did_you_mean_unboxed lid ->
-    fprintf ppf "Did you mean %a?" longident lid
+    fprintf ppf "@[%a is neither a polymorphic variant nor a class type.@ \
+                 Did you mean the unboxed type %a#?@]" longident lid longident lid
 
 let () =
   Location.register_error_of_exn

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -77,6 +77,7 @@ type error =
   | Non_sort of
       {vloc : sort_loc; typ : type_expr; err : Jkind.Violation.t}
   | Bad_jkind_annot of type_expr * Jkind.Violation.t
+  | Did_you_mean_unboxed of Longident.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -715,6 +716,16 @@ and transl_type_aux env policy mode styp =
           let path, decl = Env.find_type_by_name lid2 env in
           ignore(Env.lookup_cltype ~loc:lid.loc lid.txt env);
           (path, decl, false)
+        with Not_found -> try
+          (* Raise a different error if it matches the name of an unboxed type *)
+          let lid3 =
+            match lid.txt with
+              Longident.Lident s     -> Longident.Lident (s ^ "#")
+            | Longident.Ldot(r, s)   -> Longident.Ldot (r, s ^ "#")
+            | Longident.Lapply(_, _) -> fatal_error "Typetexp.transl_type"
+          in
+          ignore (Env.find_type_by_name lid3 env : Path.t * Types.type_declaration);
+          raise (Error (lid.loc, env, Did_you_mean_unboxed lid3))
         with Not_found ->
           ignore (Env.lookup_cltype ~loc:lid.loc lid.txt env); assert false
       in
@@ -1388,6 +1399,8 @@ let report_error env ppf = function
     fprintf ppf "@[<b 2>Bad layout annotation:@ %a@]"
       (Jkind.Violation.report_with_offender
          ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) violation
+  | Did_you_mean_unboxed lid ->
+    fprintf ppf "Did you mean %a?" longident lid
 
 let () =
   Location.register_error_of_exn

--- a/ocaml/typing/typetexp.mli
+++ b/ocaml/typing/typetexp.mli
@@ -118,6 +118,7 @@ type error =
   | Non_sort of
       {vloc : sort_loc; typ : type_expr; err : Jkind.Violation.t}
   | Bad_jkind_annot of type_expr * Jkind.Violation.t
+  | Did_you_mean_unboxed of Longident.t
 
 exception Error of Location.t * Env.t * error
 


### PR DESCRIPTION
This PR builds on top of #1864 and adds a hint to the error message whenever `#x` is encountered and `x#` is a valid type in the current environment.

Review: @goldfirere 