### PR TITLE
Fix result layout of combined applications

### DIFF
--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1110,7 +1110,7 @@ and transl_apply ~scopes
       (Rc_normal | Rc_nontail) ->
         Lapply
           {ap with ap_args = ap.ap_args @ args; ap_loc = loc;
-                   ap_region_close = pos; ap_mode = mode}
+                   ap_region_close = pos; ap_mode = mode; ap_result_layout = result_layout }
     | lexp, _ ->
         Lapply {
           ap_loc=loc;


### PR DESCRIPTION
It was previously failing on:
```ocaml
let f1 x _y = x
let f2 x = x
let f3 (x1 : float#) x2 = f2 ((f1 x1) x2)
```