### PR TITLE
Add OCaml 4 feature macros

### DIFF
--- a/ocaml/runtime4/caml/version.h.in
+++ b/ocaml/runtime4/caml/version.h.in
@@ -22,3 +22,11 @@
 #undef OCAML_VERSION_EXTRA
 #undef OCAML_VERSION
 #undef OCAML_VERSION_STRING
+
+/* Macros defining differences between Jane Street's version of OCaml and
+   stock OCaml 5, which we will not port over to the OCaml 5 runtime.
+ */
+
+#define JANE_STREET_HAS_OCAML_4_GC
+#define JANE_STREET_HAS_OCAML_4_PRNG
+#define JANE_STREET_HAS_NO_DOMAINS


### PR DESCRIPTION
Add feature macros defining which OCaml 4 features our runtime has. We should add to this freely, I'm just adding ones that come to mind.

This is needed because C code often uses conditional compilation to decide which bindings in the runtime to access. Usually that code just inspects `OCAML_VERSION` in `caml/version.h`. We've bumped that version past OCaml 5, but don't yet offer all OCaml 5-related bindings in the runtime, so we need to guard access to the new bindings based on additional preprocessor checks. The new macros in this PR are meant to be used in such checks.