### PR TITLE
Stop installing `afl-fuzz` on macOS (CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-x1name: build
+name: build
 on: [push, pull_request]
 jobs:
   build:
@@ -112,8 +112,10 @@ jobs:
       run: sudo apt-get install afl++
 
     - name: Install AFL (for macOS workers)
+      # The "afl-fuzz" package is deprecated (2023-10) and can no longer be installed
       if: matrix.os == 'macos-latest'
       run: true
+      # run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install afl-fuzz
 
     - name: Cache OCaml 4.14 and dune
       uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,10 +111,12 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install afl++
 
-    # The "afl-fuzz" package is deprecated (2023-10) and can no longer be installed
-    #- name: Install AFL (for macOS workers)
-    #  if: matrix.os == 'macos-latest'
-    #  run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install afl-fuzz
+
+    - name: Install AFL (for macOS workers)
+      # The "afl-fuzz" package is deprecated (2023-10) and can no longer be installed
+      if: matrix.os == 'macos-latest'
+      run: true
+      # run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install afl-fuzz
 
     - name: Cache OCaml 4.14 and dune
       uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+x1name: build
 on: [push, pull_request]
 jobs:
   build:
@@ -111,9 +111,10 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install afl++
 
-    - name: Install AFL (for macOS workers)
-      if: matrix.os == 'macos-latest'
-      run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install afl-fuzz
+    # The "afl-fuzz" package is deprecated (2023-10) and can no longer be installed
+    #- name: Install AFL (for macOS workers)
+    #  if: matrix.os == 'macos-latest'
+    #  run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install afl-fuzz
 
     - name: Cache OCaml 4.14 and dune
       uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,12 +111,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install afl++
 
-
     - name: Install AFL (for macOS workers)
-      # The "afl-fuzz" package is deprecated (2023-10) and can no longer be installed
       if: matrix.os == 'macos-latest'
       run: true
-      # run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install afl-fuzz
 
     - name: Cache OCaml 4.14 and dune
       uses: actions/cache@v2


### PR DESCRIPTION
(Cherry-picked from #1949)

The `afl-fuzz` package is deprecated in brew,
so stop installing it. The related test already
runs iff the binary is in the path.