### PR TITLE
Fix error message regression: use manifest jkind less

### DIFF
--- a/ocaml/testsuite/tests/typing-misc/records.ml
+++ b/ocaml/testsuite/tests/typing-misc/records.ml
@@ -300,3 +300,14 @@ Line 6, characters 13-23:
 Error: Unbound module Coq__10
 Hint: Did you mean Coq__11?
 |}]
+
+type a = unit
+type b = a = { a : int }
+[%%expect{|
+type a = unit
+Line 2, characters 0-24:
+2 | type b = a = { a : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type a
+       The original is abstract, but this is a record.
+|}]

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -755,16 +755,15 @@ let transl_declaration env sdecl (id, uid) =
     let jkind =
     (* - If there's an annotation, we use that. It's checked against
          a kind in [update_decl_jkind] and the manifest in [check_coherence].
-       - If there's no annotation but there is a manifest, we estimate the
-         jkind based on the manifest here. This upper bound saves time
+       - If there's no annotation but it's an abstract type and there is a manifest,
+         we estimate the jkind based on the manifest here. This upper bound saves time
          later by avoiding expanding the manifest in jkind checks, but it
          would be sound to leave in `any`. We can't give a perfectly
          accurate jkind here because we don't have access to the
          manifests of mutually defined types (but we could one day consider
          improving it at a later point in transl_type_decl).
-       - If there's no annotation and no manifest, we fill in with the
-         default calculated above here. It will get updated in
-         [update_decl_jkind]. See Note [Default jkinds in transl_declaration].
+       - Otherwise, we fill in with the default calculated above here. It will get
+         updated in [update_decl_jkind]. See Note [Default jkinds in transl_declaration].
     *)
     (* CR layouts: Is the estimation mentioned in the second bullet above
        doing anything for us?  Abstract types are updated by

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -770,10 +770,10 @@ let transl_declaration env sdecl (id, uid) =
        doing anything for us?  Abstract types are updated by
        check_coherence and record/variant types are updated by
        update_decl_jkind.  *)
-      match jkind_annotation, man with
-      | Some annot, _ -> annot
-      | None, Some typ -> Ctype.estimate_type_jkind env typ
-      | None, None -> jkind_default
+      match jkind_annotation, man, tkind with
+      | Some annot, _, _ -> annot
+      | None, Some typ, Ttype_abstract -> Ctype.estimate_type_jkind env typ
+      | None, _, _ -> jkind_default
     in
     let arity = List.length params in
     let decl =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -755,24 +755,18 @@ let transl_declaration env sdecl (id, uid) =
     let jkind =
     (* - If there's an annotation, we use that. It's checked against
          a kind in [update_decl_jkind] and the manifest in [check_coherence].
-       - If there's no annotation but it's an abstract type and there is a manifest,
-         we estimate the jkind based on the manifest here. This upper bound saves time
-         later by avoiding expanding the manifest in jkind checks, but it
-         would be sound to leave in `any`. We can't give a perfectly
-         accurate jkind here because we don't have access to the
-         manifests of mutually defined types (but we could one day consider
-         improving it at a later point in transl_type_decl).
-       - Otherwise, we fill in with the default calculated above here. It will get
-         updated in [update_decl_jkind]. See Note [Default jkinds in transl_declaration].
+         Both of those functions update the [type_jkind] field in the
+         [type_declaration] as appropriate.
+       - If there's no annotation but there is a manifest, just use [any].
+         This will get updated to the manifest's jkind in [check_coherence].
+       - If there's no annotation and no manifest, we fill in with the
+         default calculated above here. It will get updated in
+         [update_decl_jkind]. See Note [Default jkinds in transl_declaration].
     *)
-    (* CR layouts: Is the estimation mentioned in the second bullet above
-       doing anything for us?  Abstract types are updated by
-       check_coherence and record/variant types are updated by
-       update_decl_jkind.  *)
-      match jkind_annotation, man, tkind with
-      | Some annot, _, _ -> annot
-      | None, Some typ, Ttype_abstract -> Ctype.estimate_type_jkind env typ
-      | None, _, _ -> jkind_default
+      match jkind_annotation, man with
+      | Some annot, _ -> annot
+      | None, Some _ -> Jkind.any ~why:Initial_typedecl_env
+      | None, None -> jkind_default
     in
     let arity = List.length params in
     let decl =
@@ -1776,10 +1770,10 @@ let transl_type_decl env rec_flag sdecl_list =
     | Typedecl_separability.Error (loc, err) ->
         raise (Error (loc, Separability err))
   in
+  (* Check re-exportation, updating [type_jkind] from the manifest *)
+  let decls = List.map2 (check_abbrev new_env) sdecl_list decls in
   (* Compute the final environment with variance and immediacy *)
   let final_env = add_types_to_env decls env in
-  (* Check re-exportation *)
-  let decls = List.map2 (check_abbrev final_env) sdecl_list decls in
   (* Keep original declaration *)
   let final_decls =
     List.map2


### PR DESCRIPTION
With this example, we get a confusing error message about layouts:

```
utop # type a = unit ;;
--
type a = unit
utop # type b = a = { a : int };;
Line 1, characters 0-24:
Error: Type b has layout value, which is not a sublayout of immediate.
```

The original error message is more helpful:

```
2 | type b = a = { a : int }
    ^^^^^^^^^^^^^^^^^^^^^^^^
Error: This variant or record definition does not match that of type a
       Their kinds differ. 
```

This PR seeks to have the old error message printed rather than the new one.

To achieve this, it restricts the jkind inference using the type manifest in `transl_declaration` to only when it's a `Ttype_abstract`. There's a call to `check_coherence` later than should help ensure the type jkind does not differ from the manifest jkind.