### PR TITLE
Install missing files in stdlib

### DIFF
--- a/ocaml/stdlib/dune
+++ b/ocaml/stdlib/dune
@@ -78,8 +78,6 @@
   atomic.mli
   effect.ml
   effect.mli
-  domain.ml
-  domain.mli
   bigarray.ml
   bigarray.mli
   bool.ml
@@ -220,9 +218,6 @@
   .stdlib.objs/byte/stdlib__Effect.cmi
   .stdlib.objs/byte/stdlib__Effect.cmt
   .stdlib.objs/byte/stdlib__Effect.cmti
-  .stdlib.objs/byte/stdlib__Domain.cmi
-  .stdlib.objs/byte/stdlib__Domain.cmt
-  .stdlib.objs/byte/stdlib__Domain.cmti
   .stdlib.objs/byte/stdlib__Bigarray.cmi
   .stdlib.objs/byte/stdlib__Bigarray.cmt
   .stdlib.objs/byte/stdlib__Bigarray.cmti
@@ -473,7 +468,6 @@
   .stdlib.objs/native/stdlib__Digest.cmx
   .stdlib.objs/native/stdlib__Atomic.cmx
   .stdlib.objs/native/stdlib__Effect.cmx
-  .stdlib.objs/native/stdlib__Domain.cmx
   .stdlib.objs/native/stdlib__Either.cmx
   .stdlib.objs/native/stdlib__In_channel.cmx
   .stdlib.objs/native/stdlib__Out_channel.cmx

--- a/ocaml/stdlib/dune
+++ b/ocaml/stdlib/dune
@@ -76,6 +76,10 @@
   arrayLabels.mli
   atomic.ml
   atomic.mli
+  effect.ml
+  effect.mli
+  domain.ml
+  domain.mli
   bigarray.ml
   bigarray.mli
   bool.ml
@@ -213,6 +217,12 @@
   .stdlib.objs/byte/stdlib__Atomic.cmi
   .stdlib.objs/byte/stdlib__Atomic.cmt
   .stdlib.objs/byte/stdlib__Atomic.cmti
+  .stdlib.objs/byte/stdlib__Effect.cmi
+  .stdlib.objs/byte/stdlib__Effect.cmt
+  .stdlib.objs/byte/stdlib__Effect.cmti
+  .stdlib.objs/byte/stdlib__Domain.cmi
+  .stdlib.objs/byte/stdlib__Domain.cmt
+  .stdlib.objs/byte/stdlib__Domain.cmti
   .stdlib.objs/byte/stdlib__Bigarray.cmi
   .stdlib.objs/byte/stdlib__Bigarray.cmt
   .stdlib.objs/byte/stdlib__Bigarray.cmti
@@ -462,6 +472,8 @@
   .stdlib.objs/native/stdlib__BytesLabels.cmx
   .stdlib.objs/native/stdlib__Digest.cmx
   .stdlib.objs/native/stdlib__Atomic.cmx
+  .stdlib.objs/native/stdlib__Effect.cmx
+  .stdlib.objs/native/stdlib__Domain.cmx
   .stdlib.objs/native/stdlib__Either.cmx
   .stdlib.objs/native/stdlib__In_channel.cmx
   .stdlib.objs/native/stdlib__Out_channel.cmx


### PR DESCRIPTION
Installs `effect.ml{,i}` ~and `domain.ml{,i}`~ and the corresponding artifacts, to fix build failures in client code.