### PR TITLE
Fix compiler warning in tests/asmgen

### DIFF
--- a/testsuite/tests/asmgen/main.c
+++ b/testsuite/tests/asmgen/main.c
@@ -20,7 +20,7 @@
 
 /* This stub isn't needed for msvc32, since it's already in asmgen_i386nt.asm */
 #if !defined(_MSC_VER) || !defined(_M_IX86)
-void caml_call_gc()
+void caml_call_gc(void)
 {
 
 }

--- a/testsuite/tests/asmgen/mainarith.c
+++ b/testsuite/tests/asmgen/mainarith.c
@@ -22,7 +22,7 @@
 #include <caml/config.h>
 #define FMT ARCH_INTNAT_PRINTF_FORMAT
 
-void caml_call_poll()
+void caml_call_poll(void)
 {
 }
 


### PR DESCRIPTION
Running into some compiler warnings when doing `make test`:

```
> mainarith.c:25:6: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
>  void caml_call_poll()
>       ^~~~~~~~~~~~~~
> mainarith.c: In function ‘caml_call_poll’:
> mainarith.c:25:6: error: old-style function definition [-Werror=old-style-definition]
> cc1: all warnings being treated as errors
```

This PR adds the `void` keyword to fix that.

Review suggestion: @mshinwell 