### PR TITLE
Refresh optimized compilers before testing

### DIFF
--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -224,6 +224,7 @@ install_for_test: _install
          ln -s . boot; \
 	 for exe in ocamlc ocamlopt ocamllex; do \
 	   rm -f $$exe; ln -s $$exe.byte $$exe; \
+         touch ocamlc.opt ocamlopt.opt; \
 	 done; \
 	 ln -s _install/lib/ocaml stdlib; \
 	 mkdir runtime4; \


### PR DESCRIPTION
I ran this locally, and I no longer got a warning saying that the testsuite was using unoptimized compilers. Authored by @mshinwell actually.