### PR TITLE
`--enable-warn-error` by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,12 @@ AC_ARG_ENABLE([legacy-library-layout],
   [legacy_layout=yes],
   [legacy_layout=no])
 
+AC_ARG_ENABLE([warn-error],
+  [AS_HELP_STRING([--enable-warn-error],
+    [treat C compiler warnings as errors])],
+  [warn_error=""], # if the user passed this, it will already be passed through
+  [warn_error=--enable-warn-error])
+
 AC_SUBST([prefix])
 AC_SUBST([middle_end])
 AC_SUBST([dune])
@@ -62,7 +68,7 @@ AC_SUBST([legacy_layout])
 AC_DISABLE_OPTION_CHECKING
 
 AX_SUBDIRS_CONFIGURE([ocaml],
-  [$middle_end_arg,-C,--disable-ocamldoc,--disable-stdlib-manpages,--enable-ocamltest],
+  [$middle_end_arg,$warn_error,-C,--disable-ocamldoc,--disable-stdlib-manpages,--enable-ocamltest],
   [],
   [],
   [])


### PR DESCRIPTION
This is implemented by passing `--enable-warn-error` to the subdirectory configure scripts if the user provided neither `--enable-warn-error` nor `--disable-warn-error`.  If they did provide either of those, it's already passed through.