### PR TITLE
Run CI only on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     name: ${{ matrix.name }}


### PR DESCRIPTION
We've been running CI both upon pushing a commit and refreshing a PR. Now it only runs on push. It should still be running the same set of jobs.