### PR TITLE
Fix arch.mli

### DIFF
--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -20,6 +20,7 @@ val popcnt_support : bool ref
 val prefetchw_support : bool ref
 val prefetchwt1_support : bool ref
 val trap_notes : bool ref
+val clmul_support : bool ref
 val sse3_support : bool ref
 val ssse3_support : bool ref
 val sse41_support : bool ref


### PR DESCRIPTION
The 5 merge added `arch.mli`, so the new `clmul_support` bool needs to be exposed there.