### PR TITLE
Ignore dynlink mlis

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 name: coverage-linux
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     name: ${{ matrix.name }}

--- a/.github/workflows/jane_syntax.yml
+++ b/.github/workflows/jane_syntax.yml
@@ -1,6 +1,6 @@
 name: jane-syntax-upstream-build
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -1,6 +1,6 @@
 name: ocamlformat
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/ocaml/otherlibs/dynlink/.gitignore
+++ b/ocaml/otherlibs/dynlink/.gitignore
@@ -1,0 +1,2 @@
+byte/dynlink.mli
+native/dynlink.mli


### PR DESCRIPTION
These are generated by the build; this .gitignores them.
Also removes `pull_request` from the other CI workflows.