### PR TITLE
Revert Linscan etc. to the previous 4.x version

### DIFF
--- a/backend/interval.ml
+++ b/backend/interval.ml
@@ -38,11 +38,10 @@ type kind =
   | Argument
   | Live
 
-type result =
-  {
-    intervals : t list;
-    fixed_intervals : t list;
-  }
+let interval_list = ref ([] : t list)
+let fixed_interval_list = ref ([] : t list)
+let all_intervals() = !interval_list
+let all_fixed_intervals() = !fixed_interval_list
 
 (* Check if two intervals overlap *)
 
@@ -168,22 +167,19 @@ let build_intervals fd =
     end in
   walk_instruction fd.fun_body;
   (* Generate the interval and fixed interval lists *)
-  let interval_list = ref [] in
-  let fixed_intervals = ref [] in
+  interval_list := [];
+  fixed_interval_list := [];
   Array.iter
     (fun i ->
       if i.iend != 0 then begin
         i.ranges <- List.rev i.ranges;
         begin match i.reg.loc with
           Reg _ ->
-            fixed_intervals := i :: !fixed_intervals
+            fixed_interval_list := i :: !fixed_interval_list
         | _ ->
             interval_list := i :: !interval_list
         end
       end)
     intervals;
-  {
-    fixed_intervals = !fixed_intervals;
-    intervals = List.sort (fun i0 i1 -> i0.ibegin - i1.ibegin) !interval_list;
-    (* Sort the intervals according to their start position *)
-  }
+  (* Sort the intervals according to their start position *)
+  interval_list := List.sort (fun i0 i1 -> i0.ibegin - i1.ibegin) !interval_list

--- a/backend/interval.mli
+++ b/backend/interval.mli
@@ -30,13 +30,9 @@ type t =
     mutable ranges: range list;
   }
 
-type result =
-  {
-    intervals : t list;
-    fixed_intervals : t list;
-  }
-
+val all_intervals: unit -> t list
+val all_fixed_intervals: unit -> t list
 val overlap: t -> t -> bool
 val is_live: t -> int -> bool
 val remove_expired_ranges: t -> int -> unit
-val build_intervals: Mach.fundecl -> result
+val build_intervals: Mach.fundecl -> unit

--- a/backend/linscan.ml
+++ b/backend/linscan.ml
@@ -17,118 +17,66 @@
 (* Linear scan register allocation. *)
 
 open Interval
-
-module IntervalSet = Set.Make (struct
-    type t = Interval.t
-    let compare i j =
-      let c = Int.compare i.iend j.iend in
-      if c = 0 then Int.compare i.reg.stamp j.reg.stamp else c
-  end)
-
-module SlotSet = Set.Make(Int)
+open Reg
 
 (* Live intervals per register class *)
 
-type reg_class_intervals =
+type class_intervals =
   {
-    mutable ci_fixed: IntervalSet.t;
-    mutable ci_active: IntervalSet.t;
-    mutable ci_inactive: IntervalSet.t;
-  }
-
-type stack_class_intervals =
-  {
-    mutable ci_spilled:
-      (* spilled stack slots (reg.loc = Stack (Local n)) still in use *)
-      IntervalSet.t;
-    mutable ci_free_slots:
-      (* expired stack slots available for reuse *)
-      SlotSet.t;
+    mutable ci_fixed: Interval.t list;
+    mutable ci_active: Interval.t list;
+    mutable ci_inactive: Interval.t list;
   }
 
 let active = Array.init Proc.num_register_classes (fun _ -> {
-  ci_fixed = IntervalSet.empty;
-  ci_active = IntervalSet.empty;
-  ci_inactive = IntervalSet.empty;
+  ci_fixed = [];
+  ci_active = [];
+  ci_inactive = []
 })
 
-let stack_active = Array.init Proc.num_stack_slot_classes (fun _ -> {
-  ci_spilled = IntervalSet.empty;
-  ci_free_slots = SlotSet.empty;
-})
+(* Insert interval into list sorted by end position *)
 
-let slot_of_spilled i =
-  match i.reg.loc with
-  | Stack(Local ss) -> ss
-  | _ -> invalid_arg "Linscan.slot_of_spilled"
+let rec insert_interval_sorted i = function
+    [] -> [i]
+  | j :: _ as il when j.iend <= i.iend -> i :: il
+  | j :: il -> j :: insert_interval_sorted i il
 
+let rec release_expired_fixed pos = function
+    i :: il when i.iend >= pos ->
+      Interval.remove_expired_ranges i pos;
+      i :: release_expired_fixed pos il
+  | _ -> []
 
-let split_by_pos intervals pos =
-  let divider =
-    (* this interval is strictly above intervals [i] with [i.iend < pos] and
-       strictly below [i] with [i.iend >= pos]. We use a dummy register with a
-       non-existent [stamp] to make sure that it is not "equal" to any of the
-       intervals in the set (according to the equality function of [IntervalSet]
-       above). *)
-    {Interval.reg = {Reg.dummy with stamp = -1};
-     ibegin = pos;
-     iend = pos;
-     ranges = []}
-  in
-  let (before, divider_in_set, after) = IntervalSet.split divider intervals in
-  assert (not divider_in_set);
-  (before, after)
+let rec release_expired_active ci pos = function
+    i :: il when i.iend >= pos ->
+      Interval.remove_expired_ranges i pos;
+      if Interval.is_live i pos then
+        i :: release_expired_active ci pos il
+      else begin
+        ci.ci_inactive <- insert_interval_sorted i ci.ci_inactive;
+        release_expired_active ci pos il
+      end
+  | _ -> []
 
-let remove_expired_ranges intervals pos =
-  IntervalSet.iter (fun i -> Interval.remove_expired_ranges i pos) intervals
-
-let release_expired_spilled ci pos =
-  let (expired, rest) = split_by_pos ci.ci_spilled pos in
-  ci.ci_free_slots <-
-    IntervalSet.fold (fun i free -> SlotSet.add (slot_of_spilled i) free)
-      expired ci.ci_free_slots;
-  ci.ci_spilled <- rest
-
-let release_expired_fixed ci pos =
-  let (_expired, rest) = split_by_pos ci.ci_fixed pos in
-  remove_expired_ranges rest pos;
-  ci.ci_fixed <- rest
-
-let partition_live intervals pos =
-  IntervalSet.partition (fun i -> Interval.is_live i pos) intervals
-
-let release_expired_active ci pos =
-  let (_expired, rest) = split_by_pos ci.ci_active pos in
-  remove_expired_ranges rest pos;
-  let active, inactive = partition_live rest pos in
-  ci.ci_active <- active;
-  ci.ci_inactive <- IntervalSet.union inactive ci.ci_inactive
-
-let release_expired_inactive ci pos =
-  let (_expired, rest) = split_by_pos ci.ci_inactive pos in
-  remove_expired_ranges rest pos;
-  let active, inactive = partition_live rest pos in
-  ci.ci_inactive <- inactive;
-  ci.ci_active <- IntervalSet.union active ci.ci_active
+let rec release_expired_inactive ci pos = function
+    i :: il when i.iend >= pos ->
+      Interval.remove_expired_ranges i pos;
+      if not (Interval.is_live i pos) then
+        i :: release_expired_inactive ci pos il
+      else begin
+        ci.ci_active <- insert_interval_sorted i ci.ci_active;
+        release_expired_inactive ci pos il
+      end
+  | _ -> []
 
 (* Allocate a new stack slot to the interval. *)
 
 let allocate_stack_slot num_stack_slots i =
   let cl = Proc.stack_slot_class i.reg.typ in
-  let ci = stack_active.(cl) in
-  let ss =
-    match SlotSet.min_elt_opt ci.ci_free_slots with
-    | Some ss ->
-      ci.ci_free_slots <- SlotSet.remove ss ci.ci_free_slots;
-      ss
-    | None ->
-      let ss = num_stack_slots.(cl) in
-      num_stack_slots.(cl) <- succ ss;
-      ss
-  in
+  let ss = num_stack_slots.(cl) in
+  num_stack_slots.(cl) <- succ ss;
   i.reg.loc <- Stack(Local ss);
-  i.reg.spill <- true;
-  ci.ci_spilled <- IntervalSet.add i ci.ci_spilled
+  i.reg.spill <- true
 
 (* Find a register for the given interval and assigns this register.
    The interval is added to active. Raises Not_found if no free registers
@@ -156,7 +104,7 @@ let allocate_free_register num_stack_slots i =
                    registers) *)
           let regmask = Array.make rn true in
           (* Remove all assigned registers from the register mask *)
-          IntervalSet.iter
+          List.iter
             (function
               {reg = {loc = Reg r}} ->
                 if r - r0 < rn then regmask.(r - r0) <- false
@@ -169,8 +117,8 @@ let allocate_free_register num_stack_slots i =
                    && Interval.overlap j i then
                 regmask.(r - r0) <- false
             | _ -> () in
-          IntervalSet.iter remove_bound_overlapping ci.ci_inactive;
-          IntervalSet.iter remove_bound_overlapping ci.ci_fixed;
+          List.iter remove_bound_overlapping ci.ci_inactive;
+          List.iter remove_bound_overlapping ci.ci_fixed;
           (* Assign the first free register (if any) *)
           let rec assign r =
             if r = rn then
@@ -180,7 +128,7 @@ let allocate_free_register num_stack_slots i =
                  current interval into the active list *)
               i.reg.loc <- Reg (r0 + r);
               i.reg.spill <- false;
-              ci.ci_active <- IntervalSet.add i ci.ci_active
+              ci.ci_active <- insert_interval_sorted i ci.ci_active
             end else
               assign (succ r) in
           assign 0
@@ -191,22 +139,20 @@ let allocate_free_register num_stack_slots i =
 let allocate_blocked_register num_stack_slots i =
   let cl = Proc.register_class i.reg in
   let ci = active.(cl) in
-  match IntervalSet.max_elt_opt ci.ci_active with
-  | Some ilast when
+  match ci.ci_active with
+  | ilast :: il when
       ilast.iend > i.iend &&
       (* Last interval in active is the last interval, so spill it. *)
       let chk r = r.reg.loc = ilast.reg.loc && Interval.overlap r i in
       (* But only if its physical register is admissible for the current
          interval. *)
-      not (IntervalSet.exists chk ci.ci_fixed ||
-           IntervalSet.exists chk ci.ci_inactive)
+      not (List.exists chk ci.ci_fixed || List.exists chk ci.ci_inactive)
     ->
-      let il = IntervalSet.remove ilast ci.ci_active in
       begin match ilast.reg.loc with Reg _ -> () | _ -> assert false end;
       (* Use register from last interval for current interval *)
       i.reg.loc <- ilast.reg.loc;
       (* Remove the last interval from active and insert the current *)
-      ci.ci_active <- IntervalSet.add i il;
+      ci.ci_active <- insert_interval_sorted i il;
       (* Now get a new stack slot for the spilled register *)
       allocate_stack_slot num_stack_slots ilast
   | _ ->
@@ -220,13 +166,10 @@ let walk_interval num_stack_slots i =
   (* Release all intervals that have been expired at the current position *)
   Array.iter
     (fun ci ->
-       release_expired_fixed ci pos;
-       release_expired_active ci pos;
-       release_expired_inactive ci pos)
+      ci.ci_fixed <- release_expired_fixed pos ci.ci_fixed;
+      ci.ci_active <- release_expired_active ci pos ci.ci_active;
+      ci.ci_inactive <- release_expired_inactive ci pos ci.ci_inactive)
     active;
-  Array.iter
-    (fun ci -> release_expired_spilled ci pos)
-    stack_active;
   try
     (* Allocate free register (if any) *)
     allocate_free_register num_stack_slots i
@@ -235,21 +178,14 @@ let walk_interval num_stack_slots i =
       (* No free register, need to decide which interval to spill *)
       allocate_blocked_register num_stack_slots i
 
-let allocate_registers (intervals : Interval.result) =
+let allocate_registers() =
   (* Initialize the stack slots and interval lists *)
   for cl = 0 to Proc.num_register_classes - 1 do
     (* Start with empty interval lists *)
     active.(cl) <- {
-      ci_fixed = IntervalSet.empty;
-      ci_active = IntervalSet.empty;
-      ci_inactive = IntervalSet.empty;
-    };
-  done;
-  for cl = 0 to Proc.num_stack_slot_classes - 1 do
-    (* Start with empty interval lists *)
-    stack_active.(cl) <- {
-      ci_spilled = IntervalSet.empty;
-      ci_free_slots = SlotSet.empty;
+      ci_fixed = [];
+      ci_active = [];
+      ci_inactive = []
     };
   done;
   (* Reset the stack slot counts *)
@@ -258,8 +194,8 @@ let allocate_registers (intervals : Interval.result) =
   List.iter
     (fun i ->
       let ci = active.(Proc.register_class i.reg) in
-      ci.ci_fixed <- IntervalSet.add i ci.ci_fixed)
-    intervals.fixed_intervals;
+      ci.ci_fixed <- insert_interval_sorted i ci.ci_fixed)
+    (Interval.all_fixed_intervals());
   (* Walk all the intervals within the list *)
-  List.iter (walk_interval num_stack_slots) intervals.intervals;
+  List.iter (walk_interval num_stack_slots) (Interval.all_intervals());
   num_stack_slots

--- a/backend/linscan.mli
+++ b/backend/linscan.mli
@@ -16,4 +16,4 @@
 
 (* Linear scan register allocation. *)
 
-val allocate_registers: Interval.result -> int array
+val allocate_registers: unit -> int array

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -384,10 +384,10 @@ let interval ppf i =
       i.ranges in
   fprintf ppf "@[<2>%a:%t@]@." reg i.reg interv
 
-let intervals ppf (intervals : Interval.result) =
+let intervals ppf () =
   fprintf ppf "*** Intervals@.";
-  List.iter (interval ppf) intervals.fixed_intervals;
-  List.iter (interval ppf) intervals.intervals
+  List.iter (interval ppf) (Interval.all_fixed_intervals());
+  List.iter (interval ppf) (Interval.all_intervals())
 
 let preference ppf r =
   let prefs ppf =

--- a/backend/printmach.mli
+++ b/backend/printmach.mli
@@ -32,5 +32,5 @@ val instr: formatter -> Mach.instruction -> unit
 val fundecl: formatter -> Mach.fundecl -> unit
 val phase: string -> formatter -> Mach.fundecl -> unit
 val interferences: formatter -> unit -> unit
-val intervals: formatter -> Interval.result -> unit
+val intervals: formatter -> unit -> unit
 val preferences: formatter -> unit -> unit


### PR DESCRIPTION
The 5.x backport has some bug or other.  This code is being replaced by Cfg regalloc in not too long, anyway.