### PR TITLE
Fix tests/backtrace/backtrace_bounds_exn

### DIFF
--- a/ocaml/testsuite/tests/backtrace/backtrace_bounds_exn.ml
+++ b/ocaml/testsuite/tests/backtrace/backtrace_bounds_exn.ml
@@ -1,13 +1,7 @@
 (* TEST
-   * setup-ocamlc.byte-build-env
-   ** ocamlc.byte
    flags = "-g"
    ocamlrunparam += ",b=1"
 *)
-
-(* CR mshinwell: re-enable for native once Flambda 2 fixed to say
-   "Raised by primitive operation" in backtraces rather than just
-   "Raised" for bounds check failures *)
 
 (* #11436: bad backtrace for out-of-bounds exception *)
 

--- a/ocaml/testsuite/tests/backtrace/backtrace_bounds_exn.reference
+++ b/ocaml/testsuite/tests/backtrace/backtrace_bounds_exn.reference
@@ -1,4 +1,4 @@
 Uncaught exception Invalid_argument("index out of bounds")
-Raised by primitive operation at Backtrace_bounds_exn.bad_bound_fn in file "backtrace_bounds_exn.ml", line 11, characters 7-15
+Raised at Backtrace_bounds_exn.bad_bound_fn in file "backtrace_bounds_exn.ml", line 11, characters 7-15
 Called from Backtrace_bounds_exn in file "backtrace_bounds_exn.ml", line 15, characters 32-54
 OK

--- a/ocaml/testsuite/tests/backtrace/backtrace_bounds_exn.run
+++ b/ocaml/testsuite/tests/backtrace/backtrace_bounds_exn.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+(${program} 2>&1 || true) 2>&1 | \
+  ${test_source_directory}/sanitize-backtrace.sh > ${output}


### PR DESCRIPTION
Fix the test by applying the existing backtrace normalizing script before comparing the backtrace to the reference (and update the reference).
See the comment in the sanitize-backtrace.sh script for more info.