### PR TITLE
Disable Compmisc.auto_include: do not add the directory, do not alert.

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -146,8 +146,9 @@ let mk_gc_timings f =
 
 let mk_no_auto_include_otherlibs f =
   "-no-auto-include-otherlibs", Arg.Unit f,
-  "Add only stdlib to the list of include directories. Do not add subdirectories of other\
-   libraries distributed with the compiler (such as unix, str, dynlink). Do not alert when \
+  "Add only stdlib to the list of include directories (unless -nostdlib is \
+   specified). Do not add subdirectories of other libraries distributed with \
+   the compiler (such as unix, str, dynlink). Do not alert when \
    they are missing."
 
 module Flambda2 = Flambda_backend_flags.Flambda2

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -144,6 +144,12 @@ let mk_internal_assembler f =
 let mk_gc_timings f =
   "-dgc-timings", Arg.Unit f, "Output information about time spent in the GC"
 
+let mk_no_auto_include_otherlibs f =
+  "-no-auto-include-otherlibs", Arg.Unit f,
+  "Add only stdlib to the list of include directories. Do not add subdirectories of other\
+   libraries distributed with the compiler (such as unix, str, dynlink). Do not alert when \
+   they are missing."
+
 module Flambda2 = Flambda_backend_flags.Flambda2
 
 let mk_flambda2_result_types_functors_only f =
@@ -603,6 +609,7 @@ module type Flambda_backend_options = sig
   val internal_assembler : unit -> unit
 
   val gc_timings : unit -> unit
+  val no_auto_include_otherlibs : unit -> unit
 
   val flambda2_debug : unit -> unit
   val no_flambda2_debug : unit -> unit
@@ -708,6 +715,7 @@ struct
     mk_internal_assembler F.internal_assembler;
 
     mk_gc_timings F.gc_timings;
+    mk_no_auto_include_otherlibs F.no_auto_include_otherlibs;
 
     mk_flambda2_debug F.flambda2_debug;
     mk_no_flambda2_debug F.no_flambda2_debug;
@@ -867,6 +875,7 @@ module Flambda_backend_options_impl = struct
   let internal_assembler = set' Flambda_backend_flags.internal_assembler
 
   let gc_timings = set' Flambda_backend_flags.gc_timings
+  let no_auto_include_otherlibs = set' Clflags.no_auto_include_otherlibs
 
   let flambda2_debug = set' Flambda_backend_flags.Flambda2.debug
   let no_flambda2_debug = clear' Flambda_backend_flags.Flambda2.debug
@@ -1088,6 +1097,7 @@ module Extra_params = struct
     match name with
     | "internal-assembler" -> set' Flambda_backend_flags.internal_assembler
     | "dgc-timings" -> set' Flambda_backend_flags.gc_timings
+    | "auto-include-otherlibs" -> set' Clflags.no_auto_include_otherlibs
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
     | "cfg-invariants" -> set' Flambda_backend_flags.cfg_invariants
     | "cfg-equivalence-check" -> set' Flambda_backend_flags.cfg_equivalence_check

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -1098,7 +1098,7 @@ module Extra_params = struct
     match name with
     | "internal-assembler" -> set' Flambda_backend_flags.internal_assembler
     | "dgc-timings" -> set' Flambda_backend_flags.gc_timings
-    | "auto-include-otherlibs" -> set' Clflags.no_auto_include_otherlibs
+    | "no-auto-include-otherlibs" -> set' Clflags.no_auto_include_otherlibs
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
     | "cfg-invariants" -> set' Flambda_backend_flags.cfg_invariants
     | "cfg-equivalence-check" -> set' Flambda_backend_flags.cfg_equivalence_check

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -59,6 +59,7 @@ module type Flambda_backend_options = sig
   val internal_assembler : unit -> unit
 
   val gc_timings : unit -> unit
+  val no_auto_include_otherlibs : unit -> unit
 
   val flambda2_debug : unit -> unit
   val no_flambda2_debug : unit -> unit

--- a/ocaml/driver/compmisc.ml
+++ b/ocaml/driver/compmisc.ml
@@ -13,12 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let auto_include find_in_dir fn =
-  if !Clflags.no_std_include then
+(* Unlike upstream, we do not add the directory or alert.
+   Instead, the build system requires all direct
+   dependencies to be specified explicitly. *)
+let auto_include _find_in_dir _fn =
     raise Not_found
-  else
-    let alert = Location.auto_include_alert in
-    Load_path.auto_include_otherlibs alert find_in_dir fn
 
 (* Initialize the search path.
    [dir] (default: the current directory)

--- a/ocaml/driver/compmisc.ml
+++ b/ocaml/driver/compmisc.ml
@@ -20,7 +20,6 @@ let auto_include find_in_dir fn =
     let alert = Location.auto_include_alert in
     Load_path.auto_include_otherlibs alert find_in_dir fn
 
-
 (* Initialize the search path.
    [dir] (default: the current directory)
    is always searched first  unless -nocwd is specified,

--- a/ocaml/driver/compmisc.ml
+++ b/ocaml/driver/compmisc.ml
@@ -13,11 +13,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Unlike upstream, we do not add the directory or alert.
-   Instead, the build system requires all direct
-   dependencies to be specified explicitly. *)
-let auto_include _find_in_dir _fn =
+let auto_include find_in_dir fn =
+  if !Clflags.no_auto_include_otherlibs || !Clflags.no_std_include then
     raise Not_found
+  else
+    let alert = Location.auto_include_alert in
+    Load_path.auto_include_otherlibs alert find_in_dir fn
+
 
 (* Initialize the search path.
    [dir] (default: the current directory)

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -1200,12 +1200,8 @@ module PpxContext = struct
       | "load_path" ->
           (* Duplicates Compmisc.auto_include, since we can't reference Compmisc
              from this module. *)
-          let auto_include find_in_dir fn =
-            if !Clflags.no_std_include then
+          let auto_include _find_in_dir _fn =
               raise Not_found
-            else
-              let alert = Location.auto_include_alert in
-              Load_path.auto_include_otherlibs alert find_in_dir fn
           in
           Load_path.init ~auto_include (get_list get_string payload)
       | "open_modules" ->

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -1200,8 +1200,12 @@ module PpxContext = struct
       | "load_path" ->
           (* Duplicates Compmisc.auto_include, since we can't reference Compmisc
              from this module. *)
-          let auto_include _find_in_dir _fn =
+          let auto_include find_in_dir fn =
+            if !Clflags.no_auto_include_otherlibs || !Clflags.no_std_include then
               raise Not_found
+            else
+              let alert = Location.auto_include_alert in
+              Load_path.auto_include_otherlibs alert find_in_dir fn
           in
           Load_path.init ~auto_include (get_list get_string payload)
       | "open_modules" ->

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -673,3 +673,5 @@ end
 
 let zero_alloc_check = ref Annotations.No_check         (* -zero-alloc-check *)
 let zero_alloc_check_assert_all = ref false (* -zero-alloc-check-assert-all *)
+
+let no_auto_include_otherlibs = ref false      (* -no-auto-include-otherlibs *)

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -301,3 +301,4 @@ end
 val zero_alloc_check : Annotations.t ref
 val zero_alloc_check_assert_all : bool ref
 
+val no_auto_include_otherlibs : bool ref


### PR DESCRIPTION
Recover the behavior we had before ocaml-5 merge: do not automatically include directories from compiler distribution in the  load path and do not alert about missing directories. Instead, we will get `Error: Unbound module Unix` for example if `Unix` is not explicitly listed as a dependency of a library that directly depends on it. 

(See also https://github.com/ocaml-flambda/flambda-backend/pull/1094)