### PR TITLE
Turn on CFG by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,6 @@ jobs:
             use_runtime: d
             ocamlrunparam: "v=0,V=1"
 
-          - name: closure_cfg
-            config: --enable-middle-end=closure --enable-poll-insertion
-            os: ubuntu-latest
-            build_ocamlparam: _,ocamlcfg=1
-
           - name: flambda1
             config: --enable-middle-end=flambda
             os: ubuntu-latest
@@ -35,11 +30,6 @@ jobs:
             config: --enable-middle-end=flambda --enable-frame-pointers --enable-poll-insertion
             os: ubuntu-latest
             build_ocamlparam: ''
-
-          - name: flambda1_cfg
-            config: --enable-middle-end=flambda --enable-poll-insertion
-            os: ubuntu-latest
-            build_ocamlparam: _,ocamlcfg=1
 
           - name: flambda2_runtime5
             config: --enable-middle-end=flambda2 --enable-runtime5
@@ -73,10 +63,10 @@ jobs:
             ocamlparam: '_,Oclassic=1'
             disable_testcases: 'ocaml/testsuite/tests/typing-local/regression_cmm_unboxing.ml ocaml/testsuite/tests/int64-unboxing/test.ml'
 
-          - name: flambda2_cfg
+          - name: flambda2_no_cfg
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
-            build_ocamlparam: _,ocamlcfg=1
+            build_ocamlparam: _,ocamlcfg=0
 
           - name: flambda2_macos
             config: --enable-middle-end=flambda2

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -13,7 +13,7 @@
 (*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
-let use_ocamlcfg = ref false            (* -ocamlcfg *)
+let use_ocamlcfg = ref true             (* -[no-]ocamlcfg *)
 let dump_cfg = ref false                (* -dcfg *)
 let cfg_invariants = ref false          (* -dcfg-invariants *)
 let cfg_equivalence_check = ref false   (* -dcfg-equivalence-check *)


### PR DESCRIPTION
This is just to bypass linearize (as in #1041) by default. We had quite a bit of testing for this configuration and no issues so far.

There is `-no-ocamlcfg` flag to turn this off if needed, and it can be turned off via `OCAMLPARAM` as well. 

Removed CI jobs that were testing `-ocamlcfg` except one that was updated to test `-no-ocamlcfg` with flambda2. This will also be removed soon.
