### PR TITLE
Move -no-auto-include-otherlibs flag from Flambda_backend_args to Main_args

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -144,13 +144,6 @@ let mk_internal_assembler f =
 let mk_gc_timings f =
   "-dgc-timings", Arg.Unit f, "Output information about time spent in the GC"
 
-let mk_no_auto_include_otherlibs f =
-  "-no-auto-include-otherlibs", Arg.Unit f,
-  "Add only stdlib to the list of include directories (unless -nostdlib is \
-   specified). Do not add subdirectories of other libraries distributed with \
-   the compiler (such as unix, str, dynlink). Do not alert when \
-   they are missing."
-
 module Flambda2 = Flambda_backend_flags.Flambda2
 
 let mk_flambda2_result_types_functors_only f =
@@ -610,7 +603,6 @@ module type Flambda_backend_options = sig
   val internal_assembler : unit -> unit
 
   val gc_timings : unit -> unit
-  val no_auto_include_otherlibs : unit -> unit
 
   val flambda2_debug : unit -> unit
   val no_flambda2_debug : unit -> unit
@@ -716,7 +708,6 @@ struct
     mk_internal_assembler F.internal_assembler;
 
     mk_gc_timings F.gc_timings;
-    mk_no_auto_include_otherlibs F.no_auto_include_otherlibs;
 
     mk_flambda2_debug F.flambda2_debug;
     mk_no_flambda2_debug F.no_flambda2_debug;
@@ -876,7 +867,6 @@ module Flambda_backend_options_impl = struct
   let internal_assembler = set' Flambda_backend_flags.internal_assembler
 
   let gc_timings = set' Flambda_backend_flags.gc_timings
-  let no_auto_include_otherlibs = set' Clflags.no_auto_include_otherlibs
 
   let flambda2_debug = set' Flambda_backend_flags.Flambda2.debug
   let no_flambda2_debug = clear' Flambda_backend_flags.Flambda2.debug
@@ -1098,7 +1088,6 @@ module Extra_params = struct
     match name with
     | "internal-assembler" -> set' Flambda_backend_flags.internal_assembler
     | "dgc-timings" -> set' Flambda_backend_flags.gc_timings
-    | "no-auto-include-otherlibs" -> set' Clflags.no_auto_include_otherlibs
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
     | "cfg-invariants" -> set' Flambda_backend_flags.cfg_invariants
     | "cfg-equivalence-check" -> set' Flambda_backend_flags.cfg_equivalence_check

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -59,7 +59,6 @@ module type Flambda_backend_options = sig
   val internal_assembler : unit -> unit
 
   val gc_timings : unit -> unit
-  val no_auto_include_otherlibs : unit -> unit
 
   val flambda2_debug : unit -> unit
   val no_flambda2_debug : unit -> unit

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -270,6 +270,7 @@ let read_one_param ppf position name v =
   | "noassert" -> set "noassert" [ noassert ] v
   | "noautolink" -> set "noautolink" [ no_auto_link ] v
   | "nostdlib" -> set "nostdlib" [ no_std_include ] v
+  | "no-auto-include-otherlibs" -> set "nostdlib" [ no_auto_include_otherlibs ] v
   | "nocwd" -> set "nocwd" [ no_cwd ] v
   | "linkall" -> set "linkall" [ link_everything ] v
   | "nolabels" -> set "nolabels" [ classic ] v

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -371,6 +371,13 @@ let mk_nostdlib f =
   "-nostdlib", Arg.Unit f,
   " Do not add default directory to the list of include directories"
 
+let mk_no_auto_include_otherlibs f =
+  "-no-auto-include-otherlibs", Arg.Unit f,
+  "Add only stdlib to the list of include directories (unless -nostdlib is \
+   specified). Do not add subdirectories of other libraries distributed with \
+   the compiler (such as unix, str, dynlink). Do not alert when \
+   they are missing."
+
 let mk_nocwd f =
   "-nocwd", Arg.Unit f,
   " Do not implicitly add the current directory to the load path"
@@ -854,6 +861,7 @@ module type Common_options = sig
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit
+  val _no_auto_include_otherlibs : unit -> unit
   val _nocwd : unit -> unit
   val _open : string -> unit
   val _ppx : string -> unit
@@ -1150,6 +1158,7 @@ struct
     mk_noautolink_byt F._noautolink;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
+    mk_no_auto_include_otherlibs F._no_auto_include_otherlibs;
     mk_nocwd F._nocwd;
     mk_nopervasives F._nopervasives;
     mk_o F._o;
@@ -1245,6 +1254,7 @@ struct
     mk_noprompt F._noprompt;
     mk_nopromptcont F._nopromptcont;
     mk_nostdlib F._nostdlib;
+    mk_no_auto_include_otherlibs F._no_auto_include_otherlibs;
     mk_nocwd F._nocwd;
     mk_nopervasives F._nopervasives;
     mk_open F._open;
@@ -1368,6 +1378,7 @@ struct
     mk_no_insn_sched F._no_insn_sched;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
+    mk_no_auto_include_otherlibs F._no_auto_include_otherlibs;
     mk_nocwd F._nocwd;
     mk_nopervasives F._nopervasives;
     mk_no_unbox_free_vars_of_closures F._no_unbox_free_vars_of_closures;
@@ -1509,6 +1520,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_noprompt F._noprompt;
     mk_nopromptcont F._nopromptcont;
     mk_nostdlib F._nostdlib;
+    mk_no_auto_include_otherlibs F._no_auto_include_otherlibs;
     mk_nocwd F._nocwd;
     mk_nopervasives F._nopervasives;
     mk_no_unbox_free_vars_of_closures F._no_unbox_free_vars_of_closures;
@@ -1607,6 +1619,7 @@ struct
     mk_noassert F._noassert;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
+    mk_no_auto_include_otherlibs F._no_auto_include_otherlibs;
     mk_nocwd F._nocwd;
     mk_open F._open;
     mk_pp F._pp;
@@ -1711,6 +1724,7 @@ module Default = struct
     let _noassert = set noassert
     let _nolabels = set classic
     let _nostdlib = set no_std_include
+    let _no_auto_include_otherlibs = set no_auto_include_otherlibs
     let _nocwd = set no_cwd
     let _open s = open_modules := (s :: (!open_modules))
     let _principal = set principal

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -33,6 +33,7 @@ module type Common_options = sig
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit
+  val _no_auto_include_otherlibs : unit -> unit
   val _nocwd : unit -> unit
   val _open : string -> unit
   val _ppx : string -> unit


### PR DESCRIPTION
... so it can be passed to `ocamlc`.
This is a fix for #2012.