### PR TITLE
`tast_{iterator,mapper}` were missing locs in jkind annotations

### DIFF
--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -34,7 +34,7 @@ type iterator =
     env: iterator -> Env.t -> unit;
     expr: iterator -> expression -> unit;
     extension_constructor: iterator -> extension_constructor -> unit;
-    jkind_annotation: iterator -> Jkind.const -> unit;
+    jkind_annotation: iterator -> Jkind.annotation -> unit;
     location: iterator -> Location.t -> unit;
     module_binding: iterator -> module_binding -> unit;
     module_coercion: iterator -> module_coercion -> unit;
@@ -578,7 +578,7 @@ let typ sub {ctyp_loc; ctyp_desc; ctyp_env; ctyp_attributes; _} =
   sub.env sub ctyp_env;
   match ctyp_desc with
   | Ttyp_var (_, jkind) ->
-      Option.iter (fun (jkind, _) -> sub.jkind_annotation sub jkind) jkind
+      Option.iter (sub.jkind_annotation sub) jkind
   | Ttyp_arrow (_, ct1, ct2) ->
       sub.typ sub ct1;
       sub.typ sub ct2
@@ -592,10 +592,10 @@ let typ sub {ctyp_loc; ctyp_desc; ctyp_env; ctyp_attributes; _} =
       List.iter (sub.typ sub) list
   | Ttyp_alias (ct, _, jkind) ->
       sub.typ sub ct;
-      Option.iter (fun (jkind, _) -> sub.jkind_annotation sub jkind) jkind
+      Option.iter (sub.jkind_annotation sub) jkind
   | Ttyp_variant (list, _, _) -> List.iter (sub.row_field sub) list
   | Ttyp_poly (vars, ct) ->
-      List.iter (fun (_, l) -> Option.iter (fun (j, _) -> sub.jkind_annotation sub j) l) vars;
+      List.iter (fun (_, l) -> Option.iter (sub.jkind_annotation sub) l) vars;
       sub.typ sub ct
   | Ttyp_package pack -> sub.package_type sub pack
 
@@ -649,7 +649,7 @@ let value_binding sub {vb_loc; vb_pat; vb_expr; vb_attributes; _} =
 
 let env _sub _ = ()
 
-let jkind_annotation _sub _ = ()
+let jkind_annotation sub (_, l) = iter_loc sub l
 
 let default_iterator =
   {

--- a/ocaml/typing/tast_iterator.mli
+++ b/ocaml/typing/tast_iterator.mli
@@ -38,7 +38,7 @@ type iterator =
     env: iterator -> Env.t -> unit;
     expr: iterator -> expression -> unit;
     extension_constructor: iterator -> extension_constructor -> unit;
-    jkind_annotation: iterator -> Jkind.const -> unit;
+    jkind_annotation: iterator -> Jkind.annotation -> unit;
     location: iterator -> Location.t -> unit;
     module_binding: iterator -> module_binding -> unit;
     module_coercion: iterator -> module_coercion -> unit;

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -914,7 +914,7 @@ let value_binding sub x =
 
 let env _sub x = x
 
-let jkind_annotation _sub l = l
+let jkind_annotation sub (c, l) = (c, map_loc sub l)
 
 let default =
   {


### PR DESCRIPTION
This fixes a small bug in the ocaml 5 merge that I noticed while doing the merlin merge.

Review: @ncik-roberts ?