### PR TITLE
Restore better printing in `Base` by reverting `ocaml/ocaml#11515`

### DIFF
--- a/ocaml/testsuite/tests/generalized-open/gpr1506.ml
+++ b/ocaml/testsuite/tests/generalized-open/gpr1506.ml
@@ -12,7 +12,7 @@ module M = struct
     type t = B of t * t' | C
 end
 [%%expect{|
-module M : sig type t = B of t * t/2 | C end
+module M : sig type t = B of t/1 * t/2 | C end
 |}]
 
 (* test *)

--- a/ocaml/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
+++ b/ocaml/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
@@ -1,7 +1,7 @@
 File "cannot_shadow_error.ml", line 24, characters 2-36:
 24 |   include Comparable with type t = t
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/2 by t.
+Error: Illegal shadowing of included type t/2 by t/1.
 File "cannot_shadow_error.ml", line 23, characters 2-19:
 23 |   include Printable
        ^^^^^^^^^^^^^^^^^

--- a/ocaml/testsuite/tests/shadow_include/shadow_all.ml
+++ b/ocaml/testsuite/tests/shadow_include/shadow_all.ml
@@ -100,7 +100,7 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type t/2 by t.
+Error: Illegal shadowing of included type t/2 by t/1.
 Line 2, characters 2-11:
 2 |   include S
       ^^^^^^^^^
@@ -144,7 +144,7 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module M/2 by M.
+Error: Illegal shadowing of included module M/2 by M/1.
 Line 2, characters 2-11:
 2 |   include S
       ^^^^^^^^^
@@ -189,7 +189,7 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module type T/2 by T.
+Error: Illegal shadowing of included module type T/2 by T/1.
 Line 2, characters 2-11:
 2 |   include S
       ^^^^^^^^^
@@ -210,7 +210,7 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type ext/2 by ext.
+Error: Illegal shadowing of included type ext/2 by ext/1.
 Line 2, characters 2-11:
 2 |   include S
       ^^^^^^^^^
@@ -506,15 +506,15 @@ end
 Line 8, characters 2-8:
 8 |   type t
       ^^^^^^
-Error: Illegal shadowing of included type t/4 by t.
+Error: Illegal shadowing of included type t/2 by t/1.
 Lines 2-5, characters 2-5:
 2 | ..include struct
 3 |     type t = A
 4 |     let x = A
 5 |   end
-  Type t/4 came from this include.
+  Type t/2 came from this include.
 Line 4, characters 8-9:
 4 |     let x = A
             ^
-  The value x has no valid type if t/4 is shadowed.
+  The value x has no valid type if t/2 is shadowed.
 |}]

--- a/ocaml/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
+++ b/ocaml/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
@@ -54,8 +54,8 @@ type t = X of u | Y of [ f | `B ]  and u = Y of t;;
 [%%expect{|
 type t
 type f = [ `A of t ]
-type t = X of u | Y of [ `A of t/2 | `B ]
-and u = Y of t
+type t = X of u | Y of [ `A of t/1 | `B ]
+and u = Y of t/2
 |}];;
 
 #show t;;

--- a/ocaml/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
+++ b/ocaml/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
@@ -14,7 +14,7 @@ val y : (u * v * (module S)) M.t = M.X (A, B, <module>)
 Line 2, characters 4-5:
 2 | x = y;;
         ^
-Error: This expression has type (u * v * (module S)) M.t
+Error: This expression has type (u/1 * v/1 * (module S/1)) M/1.t
        but an expression was expected of type
          (u/2 * v/2 * (module S/2)) M/2.t
        Hint: The types v and u have been defined multiple times in this
@@ -43,14 +43,16 @@ Error: This expression has type a/2 but an expression was expected of type
 Line 1, characters 4-5:
 1 | a = c;;
         ^
-Error: This expression has type a but an expression was expected of type a/3
+Error: This expression has type a/1 but an expression was expected of type
+         a/2
        Hint: The type a has been defined multiple times in this toplevel
          session. Some toplevel values still refer to old versions of this
          type. Did you try to redefine them?
 Line 1, characters 4-5:
 1 | b = c;;
         ^
-Error: This expression has type a but an expression was expected of type a/2
+Error: This expression has type a/1 but an expression was expected of type
+         a/2
        Hint: The type a has been defined multiple times in this toplevel
          session. Some toplevel values still refer to old versions of this
          type. Did you try to redefine them?

--- a/ocaml/testsuite/tests/typing-extension-constructor/test.ocaml.reference
+++ b/ocaml/testsuite/tests/typing-extension-constructor/test.ocaml.reference
@@ -6,8 +6,6 @@ module M : sig type extension_constructor = int end
 Line 2, characters 1-27:
 2 | ([%extension_constructor A] : extension_constructor);;
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type extension_constructor/2
+Error: This expression has type extension_constructor
        but an expression was expected of type M.extension_constructor = int
-       File "_none_", line 1:
-         Definition of type extension_constructor/2
 

--- a/ocaml/testsuite/tests/typing-misc/pr6416.ml
+++ b/ocaml/testsuite/tests/typing-misc/pr6416.ml
@@ -23,13 +23,13 @@ Error: Signature mismatch:
        is not included in
          sig val f : t -> unit end
        Values do not match:
-         val f : t -> unit
+         val f : t/1 -> unit
        is not included in
          val f : t/2 -> unit
-       The type t -> unit is not compatible with the type t/2 -> unit
-       Type t is not compatible with type t/2
+       The type t/1 -> unit is not compatible with the type t/2 -> unit
+       Type t/1 is not compatible with type t/2
        Line 6, characters 4-14:
-         Definition of type t
+         Definition of type t/1
        Line 2, characters 2-12:
          Definition of type t/2
 |}]
@@ -49,16 +49,16 @@ Error: Signature mismatch:
        is not included in
          sig type u = A of t end
        Type declarations do not match:
-         type u = A of t
+         type u = A of t/1
        is not included in
          type u = A of t/2
        Constructors do not match:
-         A of t
+         A of t/1
        is not the same as:
-         A of t
-       The type t is not equal to the type t/2
+         A of t/2
+       The type t/1 is not equal to the type t/2
        Line 4, characters 9-19:
-         Definition of type t
+         Definition of type t/1
        Line 2, characters 2-11:
          Definition of type t/2
 |}]
@@ -85,15 +85,15 @@ Error: Signature mismatch:
          sig module A : functor (X : s) -> sig end end
        In module A:
        Modules do not match:
-         functor (X : s) -> ...
+         functor (X : s/1) -> ...
        is not included in
          functor (X : s/2) -> ...
        Module types do not match:
-         s
+         s/1
        does not include
          s/2
        Line 5, characters 6-19:
-         Definition of module type s
+         Definition of module type s/1
        Line 2, characters 2-15:
          Definition of module type s/2
 |}]
@@ -118,16 +118,16 @@ Error: Signature mismatch:
        is not included in
          sig type t = A of T.t end
        Type declarations do not match:
-         type t = A of T.t
+         type t = A of T/1.t
        is not included in
          type t = A of T/2.t
        Constructors do not match:
-         A of T.t
+         A of T/1.t
        is not the same as:
-         A of T.t
-       The type T.t is not equal to the type T/2.t
+         A of T/2.t
+       The type T/1.t is not equal to the type T/2.t
        Line 5, characters 6-34:
-         Definition of module T
+         Definition of module T/1
        Line 2, characters 2-30:
          Definition of module T/2
 |}]
@@ -145,22 +145,22 @@ Line 5, characters 2-62:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
        Modules do not match:
-         sig module type s type t = B val f : (module s) -> t/2 -> t end
+         sig module type s type t = B val f : (module s) -> t/2 -> t/1 end
        is not included in
          sig val f : (module s) -> t -> t end
        Values do not match:
-         val f : (module s) -> t/2 -> t
+         val f : (module s/1) -> t/2 -> t/1
        is not included in
          val f : (module s/2) -> t/2 -> t/2
-       The type (module s) -> t/2 -> t is not compatible with the type
+       The type (module s/1) -> t/2 -> t/1 is not compatible with the type
          (module s/2) -> t/2 -> t/2
-       Type (module s) is not compatible with type (module s/2)
+       Type (module s/1) is not compatible with type (module s/2)
        Line 5, characters 23-33:
-         Definition of type t
+         Definition of type t/1
        Line 3, characters 2-12:
          Definition of type t/2
        Line 5, characters 9-22:
-         Definition of module type s
+         Definition of module type s/1
        Line 2, characters 2-15:
          Definition of module type s/2
 |}]
@@ -178,18 +178,18 @@ Line 5, characters 5-41:
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
        Modules do not match:
-         sig type a = B val f : a/2 -> 'a -> a end
+         sig type a = B val f : a/2 -> 'a -> a/1 end
        is not included in
          sig val f : a -> (module a) -> a end
        Values do not match:
-         val f : a/2 -> 'a -> a
+         val f : a/2 -> 'a -> a/1
        is not included in
          val f : a/2 -> (module a) -> a/2
-       The type a/2 -> (module a) -> a is not compatible with the type
+       The type a/2 -> (module a) -> a/1 is not compatible with the type
          a/2 -> (module a) -> a/2
-       Type a is not compatible with type a/2
+       Type a/1 is not compatible with type a/2
        Line 5, characters 12-22:
-         Definition of type a
+         Definition of type a/1
        Line 3, characters 2-12:
          Definition of type a/2
 |}]
@@ -222,7 +222,7 @@ Error: Signature mismatch:
        The public method c cannot be hidden
        The first class type has no method m
        Line 5, characters 4-74:
-         Definition of class type a
+         Definition of class type a/1
        Line 2, characters 2-36:
          Definition of class type a/2
 |}]
@@ -248,12 +248,12 @@ Error: Signature mismatch:
        is not included in
          sig class type b = a end
        Class type declarations do not match:
-         class type b = a
+         class type b = a/1
        does not match
          class type b = a/2
        The first class type has no method m
        Line 5, characters 4-29:
-         Definition of class type a
+         Definition of class type a/1
        Line 2, characters 2-42:
          Definition of class type a/2
 |}]
@@ -315,11 +315,11 @@ Error: Signature mismatch:
        Class type declarations do not match:
          class type c = object method m : t/2 end
        does not match
-         class type c = object method m : t end
-       The method m has type t/2 but is expected to have type t
-       Type t/2 is not equal to type t = K.t
+         class type c = object method m : t/1 end
+       The method m has type t/2 but is expected to have type t/1
+       Type t/2 is not equal to type t/1 = K.t
        Line 12, characters 4-10:
-         Definition of type t
+         Definition of type t/1
        Line 9, characters 2-8:
          Definition of type t/2
 |}]
@@ -338,12 +338,12 @@ Error: Signature mismatch:
        is not included in
          sig type t type a = M.t end
        Type declarations do not match:
-         type a = M.t
+         type a = M/1.t
        is not included in
          type a = M/2.t
-       The type M.t = M/2.M.t is not equal to the type M/2.t
+       The type M/1.t = M/2.M.t is not equal to the type M/2.t
        Line 2, characters 14-42:
-         Definition of module M
+         Definition of module M/1
        File "_none_", line 1:
          Definition of module M/2
 |}]
@@ -368,23 +368,23 @@ Lines 5-7, characters 44-3:
 7 | end..
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : t/4 -> t/3 -> t/2 -> t end
+         sig val f : t/2 -> t/3 -> t/4 -> t/1 end
        is not included in
          sig val f : t -> t -> t -> t end
        Values do not match:
-         val f : t/4 -> t/3 -> t/2 -> t
+         val f : t/2 -> t/3 -> t/4 -> t/1
        is not included in
-         val f : t -> t -> t -> t
-       The type t/4 -> t/3 -> t/2 -> t is not compatible with the type
-         t -> t -> t -> t
-       Type t/4 is not compatible with type t
+         val f : t/1 -> t/1 -> t/1 -> t/1
+       The type t/2 -> t/3 -> t/4 -> t/1 is not compatible with the type
+         t/1 -> t/1 -> t/1 -> t/1
+       Type t/2 is not compatible with type t/1
        Line 4, characters 0-10:
-         Definition of type t
-       Line 3, characters 0-10:
+         Definition of type t/1
+       Line 1, characters 0-10:
          Definition of type t/2
        Line 2, characters 0-10:
          Definition of type t/3
-       Line 1, characters 0-10:
+       Line 3, characters 0-10:
          Definition of type t/4
 |}]
 

--- a/ocaml/testsuite/tests/typing-misc/pr6634.ml
+++ b/ocaml/testsuite/tests/typing-misc/pr6634.ml
@@ -18,16 +18,16 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t = [ `T of t ] end
        is not included in
-         sig type t = [ `T of t/2 ] end
+         sig type t = [ `T of t ] end
        Type declarations do not match:
-         type t = [ `T of t ]
+         type t = [ `T of t/2 ]
        is not included in
-         type t = [ `T of t/3 ]
-       The type [ `T of t ] is not equal to the type [ `T of t/2 ]
-       Type t = [ `T of t ] is not equal to type t/2 = int
+         type t = [ `T of t/1 ]
+       The type [ `T of t/1 ] is not equal to the type [ `T of t/2 ]
+       Type t/1 = [ `T of t/1 ] is not equal to type t/2 = int
        Types for tag `T are incompatible
        Line 4, characters 2-20:
-         Definition of type t
+         Definition of type t/1
        Line 1, characters 0-12:
          Definition of type t/2
 |}]

--- a/ocaml/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/ocaml/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -14,9 +14,10 @@ val x : t = A
 Line 5, characters 27-28:
 5 |   let f: t -> t = fun B -> x
                                ^
-Error: This expression has type t/2 but an expression was expected of type t
+Error: This expression has type t/2 but an expression was expected of type
+         t/1
        Line 4, characters 2-12:
-         Definition of type t
+         Definition of type t/1
        Line 1, characters 0-10:
          Definition of type t/2
 |}]
@@ -37,9 +38,9 @@ Line 7, characters 34-35:
 7 |   let f : M.t -> M.t = fun M.C -> y
                                       ^
 Error: This expression has type M/2.t but an expression was expected of type
-         M.t
+         M/1.t
        Lines 4-6, characters 2-5:
-         Definition of module M
+         Definition of module M/1
        Line 1, characters 0-32:
          Definition of module M/2
 |}]
@@ -53,9 +54,10 @@ type t = D
 Line 2, characters 25-26:
 2 | let f: t -> t = fun D -> x;;
                              ^
-Error: This expression has type t/2 but an expression was expected of type t
+Error: This expression has type t/2 but an expression was expected of type
+         t/1
        Line 1, characters 0-10:
-         Definition of type t
+         Definition of type t/1
        Line 1, characters 0-10:
          Definition of type t/2
 |}]
@@ -77,9 +79,9 @@ Line 2, characters 32-33:
 2 | let x: ttt = let rec y = A y in y;;
                                     ^
 Error: This expression has type ttt/2 but an expression was expected of type
-         ttt
+         ttt/1
        Line 1, characters 0-26:
-         Definition of type ttt
+         Definition of type ttt/1
        Line 2, characters 0-30:
          Definition of type ttt/2
 |}]

--- a/ocaml/testsuite/tests/typing-modules-bugs/pr10693_bad.compilers.reference
+++ b/ocaml/testsuite/tests/typing-modules-bugs/pr10693_bad.compilers.reference
@@ -35,20 +35,20 @@ Error: Signature mismatch:
        In module M.M:
        Modules do not match:
          sig
-           val x : X.t option
-           module M : functor (Y : Dep) -> sig val x : X.t option end
+           val x : X/2.t option
+           module M : functor (Y : Dep) -> sig val x : X/2.t option end
          end
        is not included in
          sig val x : X.t option end
        In module M.M:
        Values do not match:
-         val x : X.t option
+         val x : X/1.t option
        is not included in
          val x : X/2.t option
-       The type X.t option is not compatible with the type X/2.t option
-       Type X.t is not compatible with type X/2.t
+       The type X/1.t option is not compatible with the type X/2.t option
+       Type X/1.t is not compatible with type X/2.t
        File "_none_", line 1:
-         Definition of module X
+         Definition of module X/1
        File "_none_", line 1:
          Definition of module X/2
        File "pr10693_bad.ml", line 17, characters 6-24: Expected declaration

--- a/ocaml/testsuite/tests/typing-modules/functors.ml
+++ b/ocaml/testsuite/tests/typing-modules/functors.ml
@@ -520,11 +520,11 @@ Error: The functor application is ill-typed.
          functor (X : x) (B : b/2) (Y : y) -> ...
        1. Module $S1 matches the expected module type x
        2. Modules do not match:
-            P.B : b
+            P.B : b/1
           is not included in
             b/2
           Line 5, characters 2-15:
-            Definition of module type b
+            Definition of module type b/1
           Line 2, characters 0-13:
             Definition of module type b/2
        3. Modules do not match: $S3 : sig type w end is not included in y
@@ -543,9 +543,9 @@ module F : functor (X : a) -> sig type t end
 Line 6, characters 13-19:
 6 |     type t = F(X).t
                  ^^^^^^
-Error: Modules do not match: (a with P.X) is not included in a/2
+Error: Modules do not match: (a/1 with P.X) is not included in a/2
      Line 3, characters 2-15:
-       Definition of module type a
+       Definition of module type a/1
      Line 1, characters 0-13:
        Definition of module type a/2
 |}]
@@ -576,16 +576,16 @@ Error: Signature mismatch:
          sig module F : functor (X : a) (Y : a) -> sig end end
        In module F:
        Modules do not match:
-         functor (X : aa) (Y : a) -> ...
+         functor (X : aa) (Y : a/1) -> ...
        is not included in
          functor (X : a/2) (Y : a/2) -> ...
        1. Module types aa and a/2 match
        2. Module types do not match:
-            a
+            a/1
           does not include
             a/2
           Line 4, characters 2-15:
-            Definition of module type a
+            Definition of module type a/1
           Line 1, characters 0-13:
             Definition of module type a/2
 |}]
@@ -1445,8 +1445,8 @@ Error: Signature mismatch:
        1. An extra argument is provided of module type
               $S1 = sig type wrong end
        2. Module types $S2 and $T2 match
-       3. Module types X.T and X.T match
-       4. Module types X.T and X.T match
+       3. Module types X/3.T and X/2.T match
+       4. Module types X/3.T and X/2.T match
 |}]
 
 
@@ -1519,9 +1519,9 @@ Error: Signature mismatch:
             sig end
           The type `wrong' is required but not provided
        2. Module types $S2 and $T2 match
-       3. An extra argument is provided of module type X.T
-       4. Module types X.T and X.T match
-       5. Module types X.T and X.T match
+       3. An extra argument is provided of module type X/2.T
+       4. Module types X/2.T and X/2.T match
+       5. Module types X/2.T and X/2.T match
 |}]
 
 
@@ -1554,7 +1554,7 @@ Error: The functor application is ill-typed.
        3. Modules do not match:
             Y : sig type t = Y.t = Y of int end
           is not included in
-            $T3 = sig type t = Y of X.t end
+            $T3 = sig type t = Y of X/2.t end
           Type declarations do not match:
             type t = Y.t = Y of int
           is not included in
@@ -1567,7 +1567,7 @@ Error: The functor application is ill-typed.
        4. Modules do not match:
             Z : sig type t = Z.t = Z of int end
           is not included in
-            $T4 = sig type t = Z of X.t end
+            $T4 = sig type t = Z of X/2.t end
           Type declarations do not match:
             type t = Z.t = Z of int
           is not included in
@@ -1827,10 +1827,12 @@ Error: The functor application is ill-typed.
           is not included in
             type 'a t
           They have different arities.
+          Lines 9-12, characters 0-3:
+            Definition of module A/1
        2. Modules do not match:
             $S2 : sig val f : 'a -> 'a end
           is not included in
-            $T2 = sig type 'a t val f : 'a A.t -> 'a t end
+            $T2 = sig type 'a t val f : 'a A/2.t -> 'a t end
 |}]
 
 
@@ -1918,7 +1920,7 @@ Error: The functor application is ill-typed.
          functor (A : ...) (B : $T2) () () -> ...
        1. Module $S1 matches the expected module type
        2. An argument appears to be missing with module type
-              $T2 = sig module type t = A.t end
+              $T2 = sig module type t = A/2.t end
        3. Module () matches the expected module type
        4. Module () matches the expected module type
 |}]
@@ -1973,10 +1975,12 @@ Error: The functor application is ill-typed.
             $T1 = sig type 'a t type 'a s end
           Type declarations do not match: type t is not included in type 'a t
           They have different arities.
+          Line 5, characters 0-32:
+            Definition of module X/1
        2. Modules do not match:
             $S2 : sig val f : 'a -> 'a end
           is not included in
-            $T2 = sig val f : 'a X.s -> 'a end
+            $T2 = sig val f : 'a X/2.s -> 'a end
           Values do not match:
             val f : 'a -> 'a
           is not included in

--- a/ocaml/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/ocaml/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -552,14 +552,14 @@ Error: Signature mismatch:
        is not included in
          sig val f : (module s) -> unit end
        Values do not match:
-         val f : (module s) -> unit
+         val f : (module s/1) -> unit
        is not included in
          val f : (module s/2) -> unit
-       The type (module s) -> unit is not compatible with the type
+       The type (module s/1) -> unit is not compatible with the type
          (module s/2) -> unit
-       Type (module s) is not compatible with type (module s/2)
+       Type (module s/1) is not compatible with type (module s/2)
        Line 6, characters 4-17:
-         Definition of module type s
+         Definition of module type s/1
        Line 2, characters 2-15:
          Definition of module type s/2
 |}];;

--- a/ocaml/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/ocaml/testsuite/tests/typing-modules/merge_constraint.ml
@@ -58,8 +58,8 @@ module VarianceEnv :
         type 'a user = Foo of 'a abstract
         module M :
           sig
-            type 'a abstract = 'a abstract/2
-            type 'a user = 'a user/2 = Foo of 'a abstract
+            type 'a abstract = 'a abstract
+            type 'a user = 'a user = Foo of 'a abstract
           end
         type 'a foo = 'a M.user
       end
@@ -93,8 +93,8 @@ module UnboxedEnv :
         type t = T : 'e ind -> t [@@unboxed]
         module type ReboundSig =
           sig
-            type 'a ind = 'a ind/2
-            type t = t/2 = T : 'a ind -> t [@@unboxed]
+            type 'a ind = 'a ind
+            type t = t/2 = T : 'a ind -> t/1 [@@unboxed]
           end
       end
   end
@@ -115,7 +115,7 @@ module ParamsUnificationEnv :
       sig type 'a u = 'a list type +'a t constraint 'a = 'b u end
     type +'a t = 'b constraint 'a = 'b list
     module type Sig2 =
-      sig type 'a u = 'a list type +'a t = 'a t/2 constraint 'a = 'b u end
+      sig type 'a u = 'a list type +'a t = 'a t constraint 'a = 'b u end
   end
 |}]
 
@@ -147,7 +147,7 @@ module CorrectEnvConstructionTest :
         and +'a abstract
         module M :
           sig
-            type 'a user = 'a user/2 = Foo of 'a abstract
+            type 'a user = 'a user = Foo of 'a abstract/1
             and 'a abstract = 'a abstract/2
           end
         type 'a foo = 'a M.user

--- a/ocaml/testsuite/tests/typing-ocamlc-i/pervasives_leitmotiv.compilers.reference
+++ b/ocaml/testsuite/tests/typing-ocamlc-i/pervasives_leitmotiv.compilers.reference
@@ -3,11 +3,11 @@ Warning 63 [erroneous-printed-signature]: The printed interface differs from the
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
 File "pervasives_leitmotiv.ml", lines 10-12, characters 0-3:
-  Definition of module Stdlib
+  Definition of module Stdlib/1
 File "_none_", line 1:
   Definition of module Stdlib/2
 Beware that this warning is purely informational and will not catch
 all instances of erroneous printed interface.
 type fpclass = A
 module Stdlib : sig type fpclass = B end
-val f : fpclass -> Stdlib.fpclass -> Stdlib/2.fpclass
+val f : fpclass -> Stdlib/1.fpclass -> Stdlib/2.fpclass

--- a/ocaml/testsuite/tests/typing-ocamlc-i/pr4791.compilers.reference
+++ b/ocaml/testsuite/tests/typing-ocamlc-i/pr4791.compilers.reference
@@ -3,10 +3,10 @@ Warning 63 [erroneous-printed-signature]: The printed interface differs from the
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
 File "pr4791.ml", line 11, characters 2-12:
-  Definition of type t
+  Definition of type t/1
 File "pr4791.ml", line 8, characters 0-10:
   Definition of type t/2
 Beware that this warning is purely informational and will not catch
 all instances of erroneous printed interface.
 type t = A
-module B : sig type t = B val f : t/2 -> t end
+module B : sig type t = B val f : t/2 -> t/1 end

--- a/ocaml/testsuite/tests/typing-ocamlc-i/pr6323.compilers.reference
+++ b/ocaml/testsuite/tests/typing-ocamlc-i/pr6323.compilers.reference
@@ -3,7 +3,7 @@ Warning 63 [erroneous-printed-signature]: The printed interface differs from the
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
 File "pr6323.ml", line 15, characters 2-24:
-  Definition of type t
+  Definition of type t/1
 File "pr6323.ml", line 8, characters 0-26:
   Definition of type t/2
 Beware that this warning is purely informational and will not catch

--- a/ocaml/testsuite/tests/typing-ocamlc-i/pr7402.compilers.reference
+++ b/ocaml/testsuite/tests/typing-ocamlc-i/pr7402.compilers.reference
@@ -3,7 +3,7 @@ Warning 63 [erroneous-printed-signature]: The printed interface differs from the
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
 File "pr7402.ml", lines 14-16, characters 0-5:
-  Definition of module M
+  Definition of module M/1
 File "pr7402.ml", lines 8-11, characters 0-3:
   Definition of module M/2
 Beware that this warning is purely informational and will not catch

--- a/ocaml/testsuite/tests/typing-signatures/els.ocaml.reference
+++ b/ocaml/testsuite/tests/typing-signatures/els.ocaml.reference
@@ -79,16 +79,12 @@ module type WEAPON_LIB =
   sig
     type t = Weapon.t
     module T :
-      sig
-        type t = t/2
-        val eq : t -> t -> bool
-        val to_string : t -> string
-      end
+      sig type t = t val eq : t -> t -> bool val to_string : t -> string end
     module Make :
       functor
         (TV : sig
                 type combined
-                type t = t/2
+                type t = t
                 val map : (combined -> t) * (t -> combined)
               end)
         -> USERCODE(TV).F

--- a/ocaml/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/ocaml/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,7 +24,7 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/2 by t.
+Error: Illegal shadowing of included type t/2 by t/1.
 Line 2, characters 2-19:
 2 |   include Printable
       ^^^^^^^^^^^^^^^^^

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -428,7 +428,7 @@ let ident_name = Naming_context.ident_name
 let reset_naming_context = Naming_context.reset
 
 let ident ppf id = pp_print_string ppf
-    (Out_name.print (Naming_context.ident_name None id))
+    (Out_name.print (Naming_context.ident_name_simple None id))
 
 let namespaced_ident namespace  id =
   Out_name.print (Naming_context.ident_name (Some namespace) id)

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -123,6 +123,7 @@ let () = Env.print_longident := longident
 module Out_name = struct
   let create x = { printed_name = x }
   let print x = x.printed_name
+  let set out_name x = out_name.printed_name <- x
 end
 
 (** Some identifiers may require hiding when printing *)
@@ -135,6 +136,8 @@ let printing_env = ref Env.empty
    current printing environment, without reading any new
    cmi present on the file system *)
 let in_printing_env f = Env.without_cmis f !printing_env
+
+let human_unique n id = Printf.sprintf "%s/%d" (Ident.name id) n
 
  type namespace = Sig_component_kind.t =
     | Value
@@ -209,32 +212,15 @@ module Conflicts = struct
   type explanation =
     { kind: namespace; name:string; root_name:string; location:Location.t}
   let explanations = ref M.empty
-
-  let add namespace name id =
-    match Namespace.location (Some namespace) id with
-    | None -> ()
-    | Some location ->
-        let explanation =
-          { kind = namespace; location; name; root_name=Ident.name id}
-        in
-        explanations := M.add name explanation !explanations
-
-  let collect_explanation namespace id ~name =
+  let collect_explanation namespace n id =
+    let name = human_unique n id in
     let root_name = Ident.name id in
-    (* if [name] is of the form "root_name/%d", we register both
-      [id] and the identifier in scope for [root_name].
-     *)
-    if root_name <> name && not (M.mem name !explanations) then
-      begin
-        add namespace name id;
-        if not (M.mem root_name !explanations) then
-          (* lookup the identifier in scope with name [root_name] and
-             add it too
-           *)
-          match Namespace.lookup (Some namespace) root_name with
-          | Pident root_id -> add namespace root_name root_id
-          | exception Not_found | _ -> ()
-      end
+    if not (M.mem name !explanations) then
+      match Namespace.location (Some namespace) id with
+      | None -> ()
+      | Some location ->
+          let explanation = { kind = namespace; location; name; root_name } in
+          explanations := M.add name explanation !explanations
 
   let pp_explanation ppf r=
     Format.fprintf ppf "@[<v 2>%a:@,Definition of %s %s@]"
@@ -308,30 +294,43 @@ module S = String.Set
 let enabled = ref true
 let enable b = enabled := b
 
-(* Names bound in recursive definitions should be considered as bound
-   in the environment when printing identifiers but not when trying
-   to find shortest path.
-   For instance, if we define
-   [{
-   module Avoid__me = struct
-     type t = A
-   end
-   type t = X
-   type u = [` A of t * t ]
-   module M = struct
-     type t = A of [ u | `B ]
-     type r = Avoid__me.t
-   end
-  }]
-  It is is important that in the definition of [t] that the outer type [t] is
-  printed as [t/2] reserving the name [t] to the type being defined in the
-  current recursive definition.
-     Contrarily, in the definition of [r], one should not shorten the
-  path [Avoid__me.t] to [r] until the end of the definition of [r].
-  The [bound_in_recursion] bridges the gap between those two slightly different
-  notions of printing environment.
-*)
-let bound_in_recursion = ref M.empty
+(** Name mapping *)
+type mapping =
+  | Need_unique_name of int Ident.Map.t
+  (** The same name has already been attributed to multiple types.
+      The [map] argument contains the specific binding time attributed to each
+      types.
+  *)
+  | Uniquely_associated_to of Ident.t * out_name
+  (** For now, the name [Ident.name id] has been attributed to [id],
+      [out_name] is used to expand this name if a conflict arises
+      at a later point
+  *)
+  | Associated_to_pervasives of out_name
+  (** [Associated_to_pervasives out_name] is used when the item
+      [Stdlib.$name] has been associated to the name [$name].
+      Upon a conflict, this name will be expanded to ["Stdlib." ^ name ] *)
+
+let hid_start = 0
+
+let add_hid_id id map =
+  let new_id = 1 + Ident.Map.fold (fun _ -> Int.max) map hid_start in
+  new_id, Ident.Map.add id new_id  map
+
+let find_hid id map =
+  try Ident.Map.find id map, map with
+    Not_found -> add_hid_id id map
+
+let pervasives name = "Stdlib." ^ name
+
+let map = Array.make Namespace.size M.empty
+let get namespace = map.(Namespace.id namespace)
+let set namespace x = map.(Namespace.id namespace) <- x
+
+(* Names used in recursive definitions are not considered when determining
+   if a name is already attributed in the current environment.
+   This is a complementary version of hidden_rec_items used by short-path. *)
+let protected = ref S.empty
 
 (* When dealing with functor arguments, identity becomes fuzzy because the same
    syntactic argument may be represented by different identifiers during the
@@ -343,68 +342,90 @@ let with_arg id f =
 let fuzzy_id namespace id = namespace = Module && S.mem (Ident.name id) !fuzzy
 
 let with_hidden ids f =
-  let update m id = M.add (Ident.name id.ident) id.ident m in
-  let updated = List.fold_left update !bound_in_recursion ids in
-  protect_refs [ R(bound_in_recursion, updated )] f
+  let update m id = S.add (Ident.name id.ident) m in
+  protect_refs [ R(protected, List.fold_left update !protected ids)] f
 
-let human_id id index =
-  (* The identifier with index [k] is the (k+1)-th most recent identifier in
-     the printing environment. We print them as [name/(k+1)] except for [k=0]
-     which is printed as [name] rather than [name/1].
-  *)
-  if index = 0 then
-    Ident.name id
-  else
-    let ordinal = index + 1 in
-    String.concat "/" [Ident.name id; string_of_int ordinal]
+let pervasives_name namespace name =
+  match namespace, !enabled with
+  | None, _ | _, true -> Out_name.create name
+  | Some namespace, false ->
+      match M.find name (get namespace) with
+      | Associated_to_pervasives r -> r
+      | Need_unique_name _ -> Out_name.create (pervasives name)
+      | Uniquely_associated_to (id',r) ->
+          let hid, map = add_hid_id id' Ident.Map.empty in
+          Out_name.set r (human_unique hid id');
+          Conflicts.collect_explanation namespace hid id';
+          set namespace @@ M.add name (Need_unique_name map) (get namespace);
+          Out_name.create (pervasives name)
+      | exception Not_found ->
+          let r = Out_name.create name in
+          set namespace @@ M.add name (Associated_to_pervasives r) (get namespace);
+          r
 
-let indexed_name namespace id =
-  let find namespace id env = match namespace with
-    | Type -> Env.find_type_index id env
-    | Module -> Env.find_module_index id env
-    | Module_type -> Env.find_modtype_index id env
-    | Class -> Env.find_class_index id env
-    | Class_type-> Env.find_cltype_index id env
-    | Value | Extension_constructor -> None
-  in
-  let index =
-    match M.find_opt (Ident.name id) !bound_in_recursion with
-    | Some rec_bound_id ->
-        (* the identifier name appears in the current group of recursive
-           definition *)
-        if Ident.same rec_bound_id id then
-          Some 0
-        else
-          (* the current recursive definition shadows one more time the
-            previously existing identifier with the same name *)
-          Option.map succ (in_printing_env (find namespace id))
-    | None ->
-        in_printing_env (find namespace id)
-  in
-  let index =
-    (* If [index] is [None] at this point, it might indicate that
-       the identifier id is not defined in the environment, while there
-       are other identifiers in scope that share the same name.
-       Currently, this kind of partially incoherent environment happens
-       within functor error messages where the left and right hand side
-       have a different views of the environment at the source level.
-       Printing the source-level by using a default index of `0`
-       seems like a reasonable compromise in this situation however.*)
-    Option.value index ~default:0
-  in
-  human_id id index
+(** Lookup for preexisting named item within the current {!printing_env} *)
+let env_ident namespace name =
+  if S.mem name !protected then None else
+  match Namespace.lookup namespace name with
+  | Pident id -> Some id
+  | _ -> None
+  | exception Not_found -> None
 
-let ident_name namespace id =
+(** Associate a name to the identifier [id] within [namespace] *)
+let ident_name_simple namespace id =
   match namespace, !enabled with
   | None, _ | _, false -> Out_name.create (Ident.name id)
   | Some namespace, true ->
-      if fuzzy_id namespace id then Out_name.create (Ident.name id)
-      else
-        let name = indexed_name namespace id in
-        Conflicts.collect_explanation namespace id ~name;
-        Out_name.create name
+    if fuzzy_id namespace id then Out_name.create (Ident.name id)
+    else
+      let name = Ident.name id in
+      match M.find name (get namespace) with
+      | Uniquely_associated_to (id',r) when Ident.same id id' ->
+          r
+      | Need_unique_name map ->
+          let hid, m = find_hid id map in
+          Conflicts.collect_explanation namespace hid id;
+          set namespace @@ M.add name (Need_unique_name m) (get namespace);
+          Out_name.create (human_unique hid id)
+      | Uniquely_associated_to (id',r) ->
+          let hid', m = find_hid id' Ident.Map.empty in
+          let hid, m = find_hid id m in
+          Out_name.set r (human_unique hid' id');
+          List.iter (fun (id,hid) -> Conflicts.collect_explanation namespace hid id)
+            [id, hid; id', hid' ];
+          set namespace @@ M.add name (Need_unique_name m) (get namespace);
+          Out_name.create (human_unique hid id)
+      | Associated_to_pervasives r ->
+          Out_name.set r ("Stdlib." ^ Out_name.print r);
+          let hid, m = find_hid id Ident.Map.empty in
+          set namespace @@ M.add name (Need_unique_name m) (get namespace);
+          Out_name.create (human_unique hid id)
+      | exception Not_found ->
+          let r = Out_name.create name in
+          set namespace
+          @@ M.add name (Uniquely_associated_to (id,r) ) (get namespace);
+          r
+
+(** Same as {!ident_name_simple} but lookup to existing named identifiers
+    in the current {!printing_env} *)
+let ident_name namespace id =
+  begin match env_ident namespace (Ident.name id) with
+  | Some id' -> ignore (ident_name_simple namespace id')
+  | None -> ()
+  end;
+  ident_name_simple namespace id
+
+let reset () =
+  Array.iteri ( fun i _ -> map.(i) <- M.empty ) map
+
+let with_ctx f =
+  let old = Array.copy map in
+  try_finally f
+    ~always:(fun () -> Array.blit old 0 map 0 (Array.length map))
+
 end
 let ident_name = Naming_context.ident_name
+let reset_naming_context = Naming_context.reset
 
 let ident ppf id = pp_print_string ppf
     (Out_name.print (Naming_context.ident_name None id))
@@ -417,11 +438,11 @@ let namespaced_ident namespace  id =
 
 let ident_stdlib = Ident.create_persistent "Stdlib"
 
-let non_shadowed_stdlib namespace = function
+let non_shadowed_pervasive = function
   | Pdot(Pident id, s) as path ->
       Ident.same id ident_stdlib &&
-      (match Namespace.lookup namespace s with
-       | path' -> Path.same path path'
+      (match in_printing_env (Env.find_type_by_name (Lident s)) with
+       | (path', _) -> Path.same path path'
        | exception Not_found -> true)
   | _ -> false
 
@@ -504,20 +525,15 @@ let rec rewrite_double_underscore_longidents env (l : Longident.t) =
           else
           l
 
-let rec tree_of_path ?(disambiguation=true) namespace p =
-  let tree_of_path namespace p = tree_of_path ~disambiguation namespace p in
-  let namespace = if disambiguation then namespace else None in
-  match p with
+let rec tree_of_path namespace = function
   | Pident id ->
       Oide_ident (ident_name namespace id)
-  | Pdot(_, s) as path when non_shadowed_stdlib namespace path ->
-      Oide_ident (Out_name.create s)
+  | Pdot(_, s) as path when non_shadowed_pervasive path ->
+      Oide_ident (Naming_context.pervasives_name namespace s)
   | Pdot(p, s) ->
       Oide_dot (tree_of_path (Some Module) p, s)
   | Papply(p1, p2) ->
-      let t1 = tree_of_path (Some Module) p1 in
-      let t2 = tree_of_path (Some Module) p2 in
-      Oide_apply (t1, t2)
+      Oide_apply (tree_of_path (Some Module) p1, tree_of_path (Some Module) p2)
   | Pextra_ty (p, extra) -> begin
       (* inline record types are syntactically prevented from escaping their
          binding scope, and are never shown to users. *)
@@ -528,9 +544,8 @@ let rec tree_of_path ?(disambiguation=true) namespace p =
           tree_of_path None p
     end
 
-let tree_of_path ?disambiguation namespace p =
-  tree_of_path ?disambiguation namespace
-    (rewrite_double_underscore_paths !printing_env p)
+let tree_of_path namespace p =
+  tree_of_path namespace (rewrite_double_underscore_paths !printing_env p)
 
 let path ppf p =
   !Oprint.out_ident ppf (tree_of_path None p)
@@ -539,6 +554,7 @@ let string_of_path p =
   Format.asprintf "%a" path p
 
 let strings_of_paths namespace p =
+  reset_naming_context ();
   let trees = List.map (tree_of_path namespace) p in
   List.map (Format.asprintf "%a" !Oprint.out_ident) trees
 
@@ -813,7 +829,7 @@ let set_printing_env env =
   end
 
 let wrap_printing_env env f =
-  set_printing_env env;
+  set_printing_env env; reset_naming_context ();
   try_finally f ~always:(fun () -> set_printing_env Env.empty)
 
 let wrap_printing_env ~error env f =
@@ -877,13 +893,6 @@ let best_type_path p =
     let p'' = try get_path () with Not_found -> p' in
     (* Format.eprintf "%a = %a -> %a@." path p path p' path p''; *)
     (p'', s)
-
-(* When building a tree for a best type path, we should not disambiguate
-   identifiers whenever the short-path algorithm detected a better path than
-   the original one.*)
-let tree_of_best_type_path p p' =
-  if Path.same p p' then tree_of_path (Some Type) p'
-  else tree_of_path ~disambiguation:false None p'
 
 (* Print a type expression *)
 
@@ -1179,7 +1188,7 @@ let reset_except_context () =
   Names.reset_names (); reset_loop_marks ()
 
 let reset () =
-  Conflicts.reset ();
+  reset_naming_context (); Conflicts.reset ();
   reset_except_context ()
 
 let prepare_for_printing tyl =
@@ -1270,9 +1279,7 @@ let rec tree_of_typexp mode ty =
         let tyl' = apply_subst s tyl in
         if is_nth s && not (tyl'=[])
         then tree_of_typexp mode (List.hd tyl')
-        else
-          let tpath = tree_of_best_type_path p p' in
-          Otyp_constr (tpath, tree_of_typlist mode tyl')
+        else Otyp_constr (tree_of_path (Some Type) p', tree_of_typlist mode tyl')
     | Tvariant row ->
         let Row {fields; name; closed; _} = row_repr row in
         let fields =
@@ -1291,7 +1298,7 @@ let rec tree_of_typexp mode ty =
         begin match name with
         | Some(p, tyl) when nameable_row row ->
             let (p', s) = best_type_path p in
-            let id = tree_of_best_type_path p p' in
+            let id = tree_of_path (Some Type) p' in
             let args = tree_of_typlist mode (apply_subst s tyl) in
             let out_variant =
               if is_nth s then List.hd args else Otyp_constr (id, args) in
@@ -1411,7 +1418,7 @@ and tree_of_typobject mode fi nm =
       let args = tree_of_typlist mode tyl in
       let (p', s) = best_type_path p in
       assert (s = Id);
-      Otyp_class (tree_of_best_type_path p p', args)
+      Otyp_class (tree_of_path (Some Type) p', args)
   | _ ->
       fatal_error "Printtyp.tree_of_typobject"
   end
@@ -1463,7 +1470,7 @@ let type_scheme ppf ty =
 let type_path ppf p =
   let (p', s) = best_type_path p in
   let p'' = if (s = Id) then p' else p in
-  let t = tree_of_best_type_path p p'' in
+  let t = tree_of_path (Some Type) p'' in
   !Oprint.out_ident ppf t
 
 let tree_of_type_scheme ty =
@@ -2281,7 +2288,8 @@ and tree_of_signature_rec ?abbrev ?max_items env' sg =
     | Some _ | None ->
         let env = !printing_env in
         let env', group_trees =
-            trees_of_recursive_sigitem_group ?abbrev env group
+          Naming_context.with_ctx
+            (fun () -> trees_of_recursive_sigitem_group ?abbrev env group)
         in
         set_printing_env env';
         let max_items, group_trees = match max_items with
@@ -2374,6 +2382,7 @@ let modtype_declaration id ppf decl =
 
 let print_items showval env x =
   Names.refresh_weak();
+  reset_naming_context ();
   Conflicts.reset ();
   let extend_val env (sigitem,outcome) = outcome, showval env sigitem in
   let post_process (env,l) = List.map (extend_val env) l in
@@ -2391,6 +2400,7 @@ let signature ppf sg =
 let printed_signature sourcefile ppf sg =
   (* we are tracking any collision event for warning 63 *)
   Conflicts.reset ();
+  reset_naming_context ();
   let t = tree_of_signature sg in
   if Warnings.(is_active @@ Erroneous_printed_signature "")
   && Conflicts.exists ()

--- a/ocaml/typing/printtyp.mli
+++ b/ocaml/typing/printtyp.mli
@@ -54,6 +54,9 @@ module Naming_context: sig
   val enable: bool -> unit
   (** When contextual names are enabled, the mapping between identifiers
       and names is ensured to be one-to-one. *)
+
+  val reset: unit -> unit
+  (** Reset the naming context *)
 end
 
 (** The [Conflicts] module keeps track of conflicts arising when attributing

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2711,6 +2711,7 @@ let report_error ppf = function
       let reaching_path = Reaching_path.simplify reaching_path in
       Printtyp.prepare_for_printing [used_as; defined_as];
       Reaching_path.add_to_preparation reaching_path;
+      Printtyp.Naming_context.reset ();
       fprintf ppf
         "@[<hv>This recursive type is not regular.@ \
          The type constructor %s is defined as@;<1 2>type %a@ \
@@ -2816,6 +2817,7 @@ let report_error ppf = function
       (match n with
        | Variance_variable_error { error; variable; context } ->
            Printtyp.prepare_for_printing [ variable ];
+           Printtyp.Naming_context.reset ();
            begin match context with
            | Type_declaration (id, decl) ->
                Printtyp.add_type_declaration_to_preparation id decl;


### PR DESCRIPTION
Revert ocaml/ocaml#11515 internally so that opening Base leads to more understandable type printing. See ocaml/ocaml#12738.

I'll cherry-pick this onto https://github.com/ocaml-flambda/flambda-backend/tree/5.1.1minus-1-microbranch after this PR is reviewed and merged.

Review: @ccasin 

#### Instructions for review

The below instructions help you confirm that the diff to the tests is the reverse diff to the tests in ocaml/ocaml#11515.

First, run these commands to bring in the relevant commits for the diff of 11515:

```bash
git remote add ocaml-upstream git@github.com:ocaml/ocaml
git fetch ocaml-upstream 224ee78620ebdb0c3193b358d0088b9349caf3c8 5b91ab5703ae916802bd8b9dc23d0536bcb17877
```

Next, run this command (from this branch) to take the diff-of-diffs between (i) the reverse diff of 11515's changes to the tests and (ii) this PR's changes to the tests.

```bash
patdiff \
  <(git diff --reverse 224ee78620ebdb0c3193b358d0088b9349caf3c8 5b91ab5703ae916802bd8b9dc23d0536bcb17877 -- testsuite | grep -v ^index) \
  <(git diff 0ef631e24bdbbae2d140dfa4082a6d839438cea4 HEAD -- ocaml/testsuite | sed 's|ocaml/||g' | grep -v ^index) \
| less -R
```

The normalization (grep/sed) makes the file names look more similar and removes commit hashes from the output of `git diff`.

There are a number of things in the diff, but ultimately none of them are material:
  * ocaml/ocaml#11515 also makes a whitespace change that this PR preserves. That's reflected by big blocks of red in the diff-of-diff, in `test_locations.compilers.reference` and `pr3968_bad.compilers.reference` (and a few others).
  * `typing-modules/functors.ml` has since had some new tests added that weren't in the original PR.
  * `shadow_include/shadow_all.ml` and `shadow_include/cannot_shadow_error.compilers.reference` and `typing-sigsubst/sigsubst.ml` were not changed in the original PR because their printing used to go through a different code path. (This printing was changed in another upstream PR which came sometime after the original PR.) So these changes aren't surprising.