### PR TITLE
Disable zstd to avoid dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ AC_SUBST([legacy_layout])
 AC_DISABLE_OPTION_CHECKING
 
 AX_SUBDIRS_CONFIGURE([ocaml],
-  [$middle_end_arg,$runtime5_arg,-C,--disable-ocamldoc,--disable-stdlib-manpages,--enable-ocamltest],
+  [$middle_end_arg,$runtime5_arg,-C,--disable-ocamldoc,--disable-stdlib-manpages,--enable-ocamltest,--without-zstd],
   [],
   [],
   [])


### PR DESCRIPTION
This was introduced for compressed marshalling, but it produces a dependency on zstd for every OCaml-produced executable, which we don't want at the moment.