### PR TITLE
add `caml_get_header` to runtime5

### DIFF
--- a/ocaml/runtime/obj.c
+++ b/ocaml/runtime/obj.c
@@ -73,6 +73,13 @@ CAMLprim value caml_obj_make_forward(value blk, value fwd)
   return Val_unit;
 }
 
+CAMLprim value caml_get_header(value blk)
+{
+  // undefined behaviour if blk is not a block
+  intnat r = Hd_val(blk);
+  return caml_copy_nativeint(r);
+}
+
 /* [size] is a value encoding a number of blocks */
 CAMLprim value caml_obj_block(value tag, value size)
 {


### PR DESCRIPTION
Forward port the runtime part of https://github.com/ocaml-flambda/ocaml-jst/commit/5be3cb82b572ff2b72cb8640acef32add8a25de3

Note that as of now, runtime5 doesn't have stack allocation, so `lib-obj/get_header.ml` will fail as some object are on heap (while expected to be on stack)