### PR TITLE
Fix `~region` in list comprehensions

### DIFF
--- a/ocaml/lambda/transl_list_comprehension.ml
+++ b/ocaml/lambda/transl_list_comprehension.ml
@@ -259,7 +259,7 @@ let rec translate_bindings
           ~attr:default_function_attribute
           ~loc
           ~mode:alloc_local
-          ~region:true (* One region per iterator, like for loops *)
+          ~region:false
           ~body:(add_bindings body)
       in
       let result =


### PR DESCRIPTION
@Ekdohibs spotted this suspicious code over in #1871, and I agree it looks like a bug.

The list comprehensions code builds up intermediate list results as local lists, and then at the end constructs a global list to return to the user (see long comment at the top of `transl_list_comprehension.ml`).  This code, `translate_bindings` constructs a function that builds such a local list (if you trace it's implementation you'll see that the body of this function is eventually constructed using `rev_list_snoc_local`, which explicitly constructs a local block).  Since it intends to return this locally allocated list to its caller, it should not have a region.  But it does, and this PR fixes that.

This could be a rather bad bug, but I weakly believe it's not actually observable because there's no opportunity for the stack to get smashed after the function constructed by `translate_bindings` is called and before we use its result to build the final global list.  So, I haven't added a new test.

Review: @goldfirere, @riaqn, @lpw25 or @stedolan 