### PR TITLE
Port #843 (Make Obj.dup use a new primitive, %obj_dup)

### DIFF
--- a/ocaml/runtime/obj.c
+++ b/ocaml/runtime/obj.c
@@ -168,6 +168,7 @@ CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
 
 CAMLprim value caml_obj_dup(value arg)
 {
+  if (!Is_block(arg)) return arg;
   return caml_obj_with_tag(Val_long(Tag_val(arg)), arg);
 }
 


### PR DESCRIPTION
This PR forward ports the runtime part of https://github.com/ocaml-flambda/flambda-backend/pull/843