### PR TITLE
Respect the configure setting of no-naked-pointers

### DIFF
--- a/ocaml/utils/config.common.ml
+++ b/ocaml/utils/config.common.ml
@@ -56,7 +56,6 @@ and cfg_magic_number = "Caml2021G520"
 
 let safe_string = true
 let default_safe_string = true
-let naked_pointers = false
 let flambda_backend = true
 
 let interface_suffix = ref ".mli"

--- a/ocaml/utils/config.fixed.ml
+++ b/ocaml/utils/config.fixed.ml
@@ -77,3 +77,5 @@ let ar_supports_response_files = true
 
 (* mshinwell: at present always use runtime4 for bootstrap *)
 let runtime5 = false
+(* This setting is only for bootstrap, does not affect dune-built compilers: *)
+let naked_pointers = false

--- a/ocaml/utils/config.generated.ml.in
+++ b/ocaml/utils/config.generated.ml.in
@@ -116,4 +116,5 @@ let flexdll_dirs = [@flexdll_dir@]
 
 let ar_supports_response_files = @ar_supports_response_files@
 
+let naked_pointers = "@naked_pointers@" = "true"
 let runtime5 = "@enable_runtime5@" = "yes"


### PR DESCRIPTION
Unfortunately during the merge of 5.1.1 to form 5-minus, the no-naked-pointers configuration setting was added back to the autoconf script, but we (possibly I) failed to notice that the `Config` modules in `ocaml/utils` had been refactored in such a way that NNP was always hardcoded to false.  The result was that all compilers were being built in NNP mode.

Testing for this PR:
```
 4644  autoconf && ./configure --prefix=$(pwd)/_install --enable-middle-end=flambda2  && make install
 4645  ./_install/bin/ocamlopt -config 2>&1|grep naked
naked_pointers: true
 4646  autoconf && ./configure --prefix=$(pwd)/_install --enable-middle-end=flambda2 --disable-naked-pointers  && make install
 4647  ./_install/bin/ocamlopt -config 2>&1|grep naked
naked_pointers: false
```