### PR TITLE
port #797 (long frames in frametable)

### DIFF
--- a/ocaml/runtime/backtrace_nat.c
+++ b/ocaml/runtime/backtrace_nat.c
@@ -231,7 +231,7 @@ debuginfo caml_debuginfo_extract(backtrace_slot slot)
     return NULL;
   }
   /* Recover debugging info */
-  infoptr = (unsigned char*)&d->live_ofs[d->num_live];
+  infoptr = frame_end_of_live_ofs(d);
   if (frame_has_allocs(d)) {
     /* skip alloc_lengths */
     infoptr += *infoptr + 1;

--- a/ocaml/runtime/caml/frame_descriptors.h
+++ b/ocaml/runtime/caml/frame_descriptors.h
@@ -79,7 +79,7 @@ typedef struct {
 
 typedef struct {
   int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
-  uint16_t marker;     /* LONG_FRAME_MARKER */
+  uint16_t marker;     /* FRAME_LONG_MARKER */
   uint16_t _pad;       /* Ensure frame_data is 4-byte aligned */
   uint32_t frame_data; /* frame size and various flags */
   uint32_t num_live;
@@ -101,7 +101,7 @@ Caml_inline bool frame_return_to_C(frame_descr *d) {
 }
 
 Caml_inline bool frame_is_long(frame_descr *d) {
-  CAMLassert(d && d -> frame_data != FRAME_RETURN_TO_C);
+  CAMLassert(d && !frame_return_to_C(d));
   return (d -> frame_data == FRAME_LONG_MARKER);
 }
 
@@ -128,7 +128,7 @@ Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
   }
 }
 
-Caml_inline uint16_t frame_size(frame_descr *d) {
+Caml_inline uint32_t frame_size(frame_descr *d) {
   return frame_data(d) &~ FRAME_DESCRIPTOR_FLAGS;
 }
 

--- a/ocaml/runtime/caml/frame_descriptors.h
+++ b/ocaml/runtime/caml/frame_descriptors.h
@@ -58,6 +58,7 @@
 #define FRAME_DESCRIPTOR_ALLOC 2
 #define FRAME_DESCRIPTOR_FLAGS 3
 #define FRAME_RETURN_TO_C 0xFFFF
+#define FRAME_LONG_MARKER 0x7FFF
 
 typedef struct {
   int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
@@ -76,20 +77,67 @@ typedef struct {
     debug_info itself to a debuginfo structure. */
 } frame_descr;
 
+typedef struct {
+  int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
+  uint16_t marker;     /* LONG_FRAME_MARKER */
+  uint16_t _pad;       /* Ensure frame_data is 4-byte aligned */
+  uint32_t frame_data; /* frame size and various flags */
+  uint32_t num_live;
+  uint32_t live_ofs[1 /* num_live */];
+  /*
+    If frame_has_allocs(), alloc lengths follow:
+        uint8_t num_allocs;
+        uint8_t alloc[num_allocs];
+
+    If frame_has_debug(), debug info follows (32-bit aligned):
+        uint32_t debug_info[frame_has_allocs() ? num_allocs : 1];
+
+    Debug info is stored as a relative offset, in bytes, from the
+    debug_info itself to a debuginfo structure. */
+} frame_descr_long;
+
 Caml_inline bool frame_return_to_C(frame_descr *d) {
-  return d->frame_data == 0xFFFF;
+  return d->frame_data == FRAME_RETURN_TO_C;
+}
+
+Caml_inline bool frame_is_long(frame_descr *d) {
+  CAMLassert(d && d -> frame_data != FRAME_RETURN_TO_C);
+  return (d -> frame_data == FRAME_LONG_MARKER);
+}
+
+Caml_inline frame_descr_long *frame_as_long(frame_descr *d) {
+  frame_descr_long *dl = (frame_descr_long *) d;
+  return dl;
+}
+
+Caml_inline uint32_t frame_data(frame_descr *d) {
+  if (frame_is_long(d)) {
+    frame_descr_long *dl = frame_as_long(d);
+    return (dl -> frame_data);
+  } else {
+    return (d -> frame_data);
+  }
+}
+
+Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
+  if (frame_is_long(d)) {
+    frame_descr_long *dl = frame_as_long(d);
+    return ((unsigned char *)&dl->live_ofs[dl->num_live]);
+  } else {
+    return ((unsigned char *)&d->live_ofs[d->num_live]);
+  }
 }
 
 Caml_inline uint16_t frame_size(frame_descr *d) {
-  return d->frame_data &~ FRAME_DESCRIPTOR_FLAGS;
+  return frame_data(d) &~ FRAME_DESCRIPTOR_FLAGS;
 }
 
 Caml_inline bool frame_has_allocs(frame_descr *d) {
-  return (d->frame_data & FRAME_DESCRIPTOR_ALLOC) != 0;
+  return (frame_data(d) & FRAME_DESCRIPTOR_ALLOC) != 0;
 }
 
 Caml_inline bool frame_has_debug(frame_descr *d) {
-  return (d->frame_data & FRAME_DESCRIPTOR_DEBUG) != 0;
+  return (frame_data(d) & FRAME_DESCRIPTOR_DEBUG) != 0;
 }
 
 /* Allocation lengths are encoded reduced by one, so values 0-255 mean

--- a/ocaml/runtime/frame_descriptors.c
+++ b/ocaml/runtime/frame_descriptors.c
@@ -38,7 +38,7 @@ static frame_descr * next_frame_descr(frame_descr * d) {
   CAMLassert(Retaddr_frame(d) >= 4096);
   if (!frame_return_to_C(d)) {
     /* Skip to end of live_ofs */
-    p = (unsigned char*)&d->live_ofs[d->num_live];
+    p = frame_end_of_live_ofs(d);
     /* Skip alloc_lengths if present */
     if (frame_has_allocs(d)) {
       num_allocs = *p;

--- a/ocaml/runtime/signals_nat.c
+++ b/ocaml/runtime/signals_nat.c
@@ -62,7 +62,7 @@ void caml_garbage_collection(void)
 
   { /* Compute the total allocation size at this point,
        including allocations combined by Comballoc */
-    unsigned char* alloc_len = (unsigned char*)(&d->live_ofs[d->num_live]);
+    unsigned char* alloc_len = frame_end_of_live_ofs(d);
     int i, nallocs = *alloc_len++;
     intnat allocsz = 0;
 


### PR DESCRIPTION
This ports #797. 

I checked that all direct access of `->live_ofs` and `->num_live` are safe. Remaining accesses are indirect via the `frame_end_of_live_ofs` which are aware of long format. Similar for `->frame_data`.