### PR TITLE
Ports #1247 (suppress caml_print_timestamp warning)

### DIFF
--- a/ocaml/runtime/unix.c
+++ b/ocaml/runtime/unix.c
@@ -483,7 +483,7 @@ void caml_print_timestamp(FILE* channel, int formatted)
     fprintf(channel, "%ld.%06d ", (long)tv.tv_sec, (int)tv.tv_usec);
   } else {
     struct tm tm;
-    char tz[10] = "Z";
+    char tz[64] = "Z";
     localtime_r(&tv.tv_sec, &tm);
     if (tm.tm_gmtoff != 0) {
       long tzhour = tm.tm_gmtoff / 60 / 60;


### PR DESCRIPTION
This PR increases the size of buffer to supress GCC warning that the buffer is too small. Essentially GCC doesn't know that hours and minutes are two digits, and insists they could be as big as `long` allows. 

The code was introduced by #2032 