### PR TITLE
Fix kinds in symbol projections

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -241,10 +241,10 @@ let subst_unary_primitive env (p : Flambda_primitive.unary_primitive) :
     let move_from = subst_function_slot env move_from in
     let move_to = subst_function_slot env move_to in
     Project_function_slot { move_from; move_to }
-  | Project_value_slot { project_from; value_slot; kind } ->
+  | Project_value_slot { project_from; value_slot } ->
     let project_from = subst_function_slot env project_from in
     let value_slot = subst_value_slot env value_slot in
-    Project_value_slot { project_from; value_slot; kind }
+    Project_value_slot { project_from; value_slot }
   | _ -> p
 
 let subst_primitive env (p : Flambda_primitive.t) : Flambda_primitive.t =
@@ -640,26 +640,15 @@ let unary_prim_ops env (prim_op1 : Flambda_primitive.unary_primitive)
            Flambda_primitive.Project_function_slot
              { move_from = move_from1'; move_to = move_to1' })
   | ( Project_value_slot
-        { project_from = function_slot1;
-          value_slot = value_slot1;
-          kind = kind1
-        },
+        { project_from = function_slot1; value_slot = value_slot1 },
       Project_value_slot
-        { project_from = function_slot2;
-          value_slot = value_slot2;
-          kind = kind2
-        } ) ->
-    triples ~f1:function_slots ~f2:value_slots
-      ~f3:(Comparator.of_predicate Flambda_kind.With_subkind.equal)
-      env
-      (function_slot1, value_slot1, kind1)
-      (function_slot2, value_slot2, kind2)
-    |> Comparison.map ~f:(fun (function_slot1', value_slot1', kind1') ->
+        { project_from = function_slot2; value_slot = value_slot2 } ) ->
+    pairs ~f1:function_slots ~f2:value_slots env
+      (function_slot1, value_slot1)
+      (function_slot2, value_slot2)
+    |> Comparison.map ~f:(fun (function_slot1', value_slot1') ->
            Flambda_primitive.Project_value_slot
-             { project_from = function_slot1';
-               value_slot = value_slot1';
-               kind = kind1'
-             })
+             { project_from = function_slot1'; value_slot = value_slot1' })
   | _, _ ->
     if Flambda_primitive.equal_unary_primitive prim_op1 prim_op2
     then Equivalent

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1544,12 +1544,10 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
     Variable.Map.fold
       (fun var value_slot (acc, body) ->
         let var = VB.create var Name_mode.normal in
-        let kind = Value_slot.kind value_slot in
         let named =
           Named.create_prim
             (Unary
-               ( Project_value_slot
-                   { project_from = function_slot; value_slot; kind },
+               ( Project_value_slot { project_from = function_slot; value_slot },
                  my_closure' ))
             Debuginfo.none
         in

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -398,7 +398,7 @@ let unop env (unop : Fexpr.unop) : Flambda_primitive.unary_primitive =
     let kind = Flambda_kind.With_subkind.any_value in
     let value_slot = fresh_or_existing_value_slot env value_slot kind in
     let project_from = fresh_or_existing_function_slot env project_from in
-    Project_value_slot { project_from; value_slot; kind }
+    Project_value_slot { project_from; value_slot }
   | Project_function_slot { move_from; move_to } ->
     let move_from = fresh_or_existing_function_slot env move_from in
     let move_to = fresh_or_existing_function_slot env move_to in

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -533,7 +533,7 @@ let unop env (op : Flambda_primitive.unary_primitive) : Fexpr.unop =
   | Opaque_identity _ -> Opaque_identity
   | Unbox_number bk -> Unbox_number bk
   | Untag_immediate -> Untag_immediate
-  | Project_value_slot { project_from; value_slot; kind = _ } ->
+  | Project_value_slot { project_from; value_slot } ->
     let project_from = Env.translate_function_slot env project_from in
     let value_slot = Env.translate_value_slot env value_slot in
     Project_value_slot { project_from; value_slot }

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -546,8 +546,7 @@ let create_let_symbols uacc lifted_constant ~body =
               in
               Binary (Block_load (block_access_kind, Immutable), symbol, index)
             | Project_value_slot { project_from; value_slot } ->
-              Unary
-                (Project_value_slot { project_from; value_slot; kind }, symbol)
+              Unary (Project_value_slot { project_from; value_slot }, symbol)
           in
           ( Named.create_prim prim Debuginfo.none,
             coercion_from_proj_to_var,

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -562,11 +562,10 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
           | Const _ | Symbol _ -> expr, cost_metrics, free_names
           | In_closure { var; value_slot; value = _ } ->
             let arg = VB.create var Name_mode.normal in
-            let kind = Value_slot.kind value_slot in
             let prim =
               P.Unary
                 ( Project_value_slot
-                    { project_from = wrapper_function_slot; value_slot; kind },
+                    { project_from = wrapper_function_slot; value_slot },
                   Simple.var my_closure )
             in
             let cost_metrics_of_defining_expr =

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -918,10 +918,10 @@ let simplify_immutable_block_load access_kind ~min_name_mode dacc ~original_term
       ~const:(fun const ->
         match Reg_width_const.descr const with
         | Tagged_immediate index ->
+          let kind = P.Block_access_kind.element_subkind_for_load access_kind in
           Simplify_common.add_symbol_projection result.dacc ~projected_from:arg1
             (Symbol_projection.Projection.block_load ~index)
-            ~projection_bound_to:result_var
-            ~kind:Flambda_kind.With_subkind.tagged_immediate
+            ~projection_bound_to:result_var ~kind
         | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
         | Naked_nativeint _ | Naked_vec128 _ ->
           Misc.fatal_errorf "Kind error for [Block_load] of %a at index %a"

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -43,8 +43,9 @@ let simplify_project_function_slot ~move_from ~move_to ~min_name_mode dacc
            ~this_function_slot:move_from closures)
       ~result_var ~result_kind:K.value
 
-let simplify_project_value_slot function_slot value_slot kind ~min_name_mode
-    dacc ~original_term ~arg:closure ~arg_ty:closure_ty ~result_var =
+let simplify_project_value_slot function_slot value_slot ~min_name_mode dacc
+    ~original_term ~arg:closure ~arg_ty:closure_ty ~result_var =
+  let kind = Value_slot.kind value_slot in
   let result =
     (* We try a faster method before falling back to [simplify_projection]. *)
     match
@@ -608,8 +609,8 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
   let original_term = Named.create_prim original_prim dbg in
   let simplifier =
     match prim with
-    | Project_value_slot { project_from; value_slot; kind } ->
-      simplify_project_value_slot project_from value_slot ~min_name_mode kind
+    | Project_value_slot { project_from; value_slot } ->
+      simplify_project_value_slot project_from value_slot ~min_name_mode
     | Project_function_slot { move_from; move_to } ->
       simplify_project_function_slot ~move_from ~move_to ~min_name_mode
     | Unbox_number boxable_number_kind ->

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -158,16 +158,15 @@ module Field = struct
 end
 
 module Closure_field = struct
-  let unboxing_prim function_slot ~closure value_slot kind =
+  let unboxing_prim function_slot ~closure value_slot =
     P.Unary
-      ( Project_value_slot { project_from = function_slot; value_slot; kind },
-        closure )
+      (Project_value_slot { project_from = function_slot; value_slot }, closure)
 
-  let unboxer function_slot value_slot kind =
+  let unboxer function_slot value_slot =
     { var_name = "closure_field_at_use";
       invalid_const = Const.const_zero;
       unboxing_prim =
-        (fun closure -> unboxing_prim function_slot ~closure value_slot kind);
+        (fun closure -> unboxing_prim function_slot ~closure value_slot);
       prove_simple =
         (fun tenv ~min_name_mode t ->
           T.meet_project_value_slot_simple tenv ~min_name_mode t value_slot)

--- a/middle_end/flambda2/simplify/unboxing/unboxers.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.mli
@@ -62,13 +62,7 @@ module Field : sig
 end
 
 module Closure_field : sig
-  val unboxing_prim :
-    Function_slot.t ->
-    closure:Simple.t ->
-    Value_slot.t ->
-    Flambda_kind.With_subkind.t ->
-    P.t
+  val unboxing_prim : Function_slot.t -> closure:Simple.t -> Value_slot.t -> P.t
 
-  val unboxer :
-    Function_slot.t -> Value_slot.t -> Flambda_kind.With_subkind.t -> unboxer
+  val unboxer : Function_slot.t -> Value_slot.t -> unboxer
 end

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -282,7 +282,7 @@ and compute_extra_args_for_closure ~pass rewrite_id ~typing_env_at_use
   let vars_within_closure =
     Value_slot.Map.mapi
       (fun var ({ epa; decision; kind } : U.field_decision) : U.field_decision ->
-        let unboxer = Unboxers.Closure_field.unboxer function_slot var kind in
+        let unboxer = Unboxers.Closure_field.unboxer function_slot var in
         let new_extra_arg, new_arg_being_unboxed =
           unbox_arg unboxer ~typing_env_at_use arg_being_unboxed
         in

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -270,6 +270,12 @@ module Block_access_kind = struct
   let element_kind_for_load t =
     match t with Values _ -> K.value | Naked_floats _ -> K.naked_float
 
+  let element_subkind_for_load t =
+    match t with
+    | Values { field_kind = Any_value; _ } -> K.With_subkind.any_value
+    | Values { field_kind = Immediate; _ } -> K.With_subkind.tagged_immediate
+    | Naked_floats _ -> K.With_subkind.naked_float
+
   let element_kind_for_set = element_kind_for_load
 
   let compare t1 t2 =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -131,6 +131,8 @@ module Block_access_kind : sig
   val compare : t -> t -> int
 
   val element_kind_for_load : t -> Flambda_kind.t
+
+  val element_subkind_for_load : t -> Flambda_kind.With_subkind.t
 end
 
 (* CR-someday mshinwell: We should have unboxed arrays of int32, int64 and

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -311,8 +311,7 @@ type unary_primitive =
           closures. *)
   | Project_value_slot of
       { project_from : Function_slot.t;
-        value_slot : Value_slot.t;
-        kind : Flambda_kind.With_subkind.t
+        value_slot : Value_slot.t
       }
       (** Project a value slot from a set of closures -- in other words, read an
           entry from the closure environment (the captured variables). *)

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -599,7 +599,8 @@ let unary_primitive env res dbg f arg =
       let message = dead_slots_msg dbg [c1; c2] [] in
       let expr, res = C.invalid res ~message in
       None, res, expr)
-  | Project_value_slot { project_from; value_slot; kind } -> (
+  | Project_value_slot { project_from; value_slot } -> (
+    let kind = Value_slot.kind value_slot in
     match
       value_slot_offset env value_slot, function_slot_offset env project_from
     with


### PR DESCRIPTION
A bit of boring refactoring to fix an issue with symbol projections.
The base issue is the patch in `Simplify_binary_primitive`: we were considering that all block loads from a symbol resulted in a value of (sub)kind immediate. It's likely impossible to trigger an issue with it, because we don't lift float records so all block loads are of value kind, and failing to register the variable is unlikely to cause an issue (the value is stored in a symbol so will not be collected; the only problem is if the value gets promoted between the read and the use, but given that all these bindings we generate are short-lived it would be hard to actually observe a bug).

Nevertheless, it is a bug, so I've patched it. The patch is relatively heavy: projections now only take a kind, not a subkind, and for various reasons it was also necessary to remove the kind field from the `Project_value_slot` primitive (the value slot already contains the kind anyway).
