### PR TITLE
Fixes for runtest on runtime5

### DIFF
--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -118,6 +118,10 @@ let run_mdflx_file filename : Outcome.t =
     Error
 
 let _ =
+  if not Config.stack_allocation
+  then (
+    Printf.printf "flexpect not supported when stack allocation disabled";
+    exit 0);
   let file = Sys.argv.(1) in
   let ext = Filename.extension file in
   let outcome =

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -118,6 +118,7 @@ let run_mdflx_file filename : Outcome.t =
     Error
 
 let _ =
+  (* CR ocaml 5 runtime: remove this once we are on the 5 runtime *)
   Symbol0.force_runtime4_symbols ();
   if not Config.stack_allocation
   then (

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -118,6 +118,7 @@ let run_mdflx_file filename : Outcome.t =
     Error
 
 let _ =
+  Symbol0.force_runtime4_symbols ();
   if not Config.stack_allocation
   then (
     Printf.printf "flexpect not supported when stack allocation disabled";

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -720,6 +720,7 @@ runtime_COMMON_C_SOURCES = \
   runtime_events \
   shared_heap \
   signals \
+  simd \
   skiplist \
   startup_aux \
   str \

--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -42,6 +42,7 @@
    ../.depend
    ../.depend.menhir
    ../config.status
+   ../stdlib/StdlibModules
    (glob_files caml/*.h)
    (glob_files *.h)
    caml/domain_state.tbl

--- a/ocaml/utils/symbol.ml
+++ b/ocaml/utils/symbol.ml
@@ -46,7 +46,13 @@ include Identifiable.Make (struct
 end)
 
 let caml_symbol_prefix = "caml"
-let separator = if Config.runtime5 then "." else "__"
+
+let force_runtime4_symbols = ref false
+
+let separator () =
+  if Config.runtime5 && not !force_runtime4_symbols then "." else "__"
+
+let force_runtime4_symbols () = force_runtime4_symbols := true
 
 let linkage_name t = t.linkage_name
 
@@ -74,7 +80,7 @@ let linkage_name_for_compilation_unit comp_unit =
       let pack_names =
         CU.Prefix.to_list for_pack_prefix |> List.map CU.Name.to_string
       in
-      String.concat separator (pack_names @ [name])
+      String.concat (separator ()) (pack_names @ [name])
   in
   caml_symbol_prefix ^ suffix
   |> Linkage_name.of_string
@@ -98,7 +104,7 @@ let for_name compilation_unit name =
     linkage_name_for_compilation_unit compilation_unit |> Linkage_name.to_string
   in
   let linkage_name =
-    prefix ^ separator ^ name |> Linkage_name.of_string
+    prefix ^ (separator ()) ^ name |> Linkage_name.of_string
   in
   { compilation_unit;
     linkage_name;

--- a/ocaml/utils/symbol.mli
+++ b/ocaml/utils/symbol.mli
@@ -45,3 +45,7 @@ val linkage_name_for_ocamlobjinfo : t -> string
 include Identifiable.S with type t := t
 
 val is_predef_exn : t -> bool
+
+(* Temporary means by which to force symbol names to use __.  Only for use
+   for flambda2 flexpect tests. *)
+val force_runtime4_symbols : unit -> unit

--- a/tests/backend/checkmach/fail1.output
+++ b/tests/backend/checkmach/fail1.output
@@ -1,2 +1,2 @@
 File "fail1.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail1.test15 (camlFail1__test15_HIDE_STAMP)
+Error: Annotation check for zero_alloc strict failed on function Fail1.test15 (camlFail1.test15_HIDE_STAMP)

--- a/tests/backend/checkmach/fail10.output
+++ b/tests/backend/checkmach/fail10.output
@@ -1,2 +1,2 @@
 File "fail10.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail10.test7 (camlFail10__test7_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail10.test7 (camlFail10.test7_HIDE_STAMP)

--- a/tests/backend/checkmach/fail11.output
+++ b/tests/backend/checkmach/fail11.output
@@ -1,2 +1,2 @@
 File "fail11.ml", line 14, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail11.f (camlFail11__f_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail11.f (camlFail11.f_HIDE_STAMP)

--- a/tests/backend/checkmach/fail12.output
+++ b/tests/backend/checkmach/fail12.output
@@ -1,4 +1,4 @@
 File "fail12.ml", line 5, characters 47-57:
-Error: Annotation check for zero_alloc failed on function Fail12.Inner.bar.(fun) (camlFail12__anon_fn[fail12.ml:5,40--70]_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail12.Inner.bar.(fun) (camlFail12.anon_fn[fail12.ml:5,40--70]_HIDE_STAMP)
 File "fail12.ml", line 5, characters 64-69:
   allocate 24 bytes

--- a/tests/backend/checkmach/fail13.output
+++ b/tests/backend/checkmach/fail13.output
@@ -1,2 +1,2 @@
 File "fail13.ml", line 3, characters 15-29:
-Error: Annotation check for zero_alloc failed on function Fail13.fail_loud2 (camlFail13__fail_loud2_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail13.fail_loud2 (camlFail13.fail_loud2_HIDE_STAMP)

--- a/tests/backend/checkmach/fail14.output
+++ b/tests/backend/checkmach/fail14.output
@@ -1,2 +1,2 @@
 File "fail14.ml", line 6, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail14.foo (camlFail14__foo_HIDE_STAMP)
+Error: Annotation check for zero_alloc strict failed on function Fail14.foo (camlFail14.foo_HIDE_STAMP)

--- a/tests/backend/checkmach/fail15.output
+++ b/tests/backend/checkmach/fail15.output
@@ -2,4 +2,4 @@ File "fail15.ml", line 6, characters 40-50:
 Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than once on this expression
 
 File "fail15.ml", line 8, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail15.call (camlFail15__call_HIDE_STAMP)
+Error: Annotation check for zero_alloc strict failed on function Fail15.call (camlFail15.call_HIDE_STAMP)

--- a/tests/backend/checkmach/fail16.output
+++ b/tests/backend/checkmach/fail16.output
@@ -1,2 +1,2 @@
 File "fail16.ml", lines 13-15, characters 6-6:
-Error: Annotation check for zero_alloc failed on function Fail16.f (camlFail16__f_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail16.f (camlFail16.f_HIDE_STAMP)

--- a/tests/backend/checkmach/fail17.output
+++ b/tests/backend/checkmach/fail17.output
@@ -1,2 +1,2 @@
 File "fail17.ml", line 2, characters 6-40:
-Error: Annotation check for zero_alloc failed on function Fail17.f (camlFail17__f_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail17.f (camlFail17.f_HIDE_STAMP)

--- a/tests/backend/checkmach/fail18.output
+++ b/tests/backend/checkmach/fail18.output
@@ -1,2 +1,2 @@
 File "fail18.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail18.f (camlFail18__f_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail18.f (camlFail18.f_HIDE_STAMP)

--- a/tests/backend/checkmach/fail19.output
+++ b/tests/backend/checkmach/fail19.output
@@ -1,5 +1,5 @@
 File "fail19.ml", line 7, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail19.foo (camlFail19__foo_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail19.foo (camlFail19.foo_HIDE_STAMP)
 File "fail19.ml", line 18, characters 5-26:
   allocate 48 bytes (fail19.ml:18,5--26;dep19.ml:1,38--52)
 File "fail19.ml", line 18, characters 5-26:
@@ -7,11 +7,11 @@ File "fail19.ml", line 18, characters 5-26:
 File "fail19.ml", line 10, characters 12-17:
   allocate 24 bytes
 File "fail19.ml", line 12, characters 10-15:
-  direct call camlFail19__bar_HIDE_STAMP
+  direct call camlFail19.bar_HIDE_STAMP
 File "fail19.ml", line 13, characters 13-16:
   indirect call
 File "fail19.ml", line 14, characters 15-44:
-  probe test handler camlFail19__probe_handler_test_HIDE_STAMP
+  probe test handler camlFail19.probe_handler_test_HIDE_STAMP
 File "fail19.ml", line 14, characters 46-54:
   allocate 24 bytes
 File "fail19.ml", line 15, characters 11-20:

--- a/tests/backend/checkmach/fail2.output
+++ b/tests/backend/checkmach/fail2.output
@@ -1,2 +1,2 @@
 File "fail2.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail2.test (camlFail2__test_HIDE_STAMP)
+Error: Annotation check for zero_alloc strict failed on function Fail2.test (camlFail2.test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail20.output
+++ b/tests/backend/checkmach/fail20.output
@@ -1,6 +1,6 @@
 File "fail20.ml", line 7, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail20.foo (camlFail20__foo_HIDE_STAMP)
+Error: Annotation check for zero_alloc strict failed on function Fail20.foo (camlFail20.foo_HIDE_STAMP)
 File "fail20.ml", line 10, characters 13-24:
-  direct call camlFail20__div_36 (fail20.ml:10,13--24;fail20.ml:4,30--41)
+  direct call camlFail20.div_36 (fail20.ml:10,13--24;fail20.ml:4,30--41)
 File "fail20.ml", line 8, characters 16-25:
   allocate 32 bytes (fail20.ml:8,16--25;fail20.ml:3,18--29) on a path to exceptional return

--- a/tests/backend/checkmach/fail21.output
+++ b/tests/backend/checkmach/fail21.output
@@ -1,4 +1,4 @@
 File "fail21.ml", line 10, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail21.test4 (camlFail21__test4_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail21.test4 (camlFail21.test4_HIDE_STAMP)
 File "fail21.ml", line 12, characters 2-9:
   allocate 24 bytes (fail21.ml:12,2--9;fail21.ml:3,30--35)

--- a/tests/backend/checkmach/fail22.output
+++ b/tests/backend/checkmach/fail22.output
@@ -1,4 +1,4 @@
 File "fail22.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail22.foo (camlFail22__foo_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail22.foo (camlFail22.foo_HIDE_STAMP)
 File "fail22.ml", line 2, characters 29-34:
   allocate 24 bytes

--- a/tests/backend/checkmach/fail23.output
+++ b/tests/backend/checkmach/fail23.output
@@ -1,4 +1,4 @@
 File "fail23.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail23.test1 (camlFail23__test1_HIDE_STAMP)
+Error: Annotation check for zero_alloc strict failed on function Fail23.test1 (camlFail23.test1_HIDE_STAMP)
 File "fail23.ml", line 7, characters 10-40:
   allocate 32 bytes on a path to exceptional return

--- a/tests/backend/checkmach/fail3.output
+++ b/tests/backend/checkmach/fail3.output
@@ -1,2 +1,2 @@
 File "fail3.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail3.test (camlFail3__test_HIDE_STAMP)
+Error: Annotation check for zero_alloc strict failed on function Fail3.test (camlFail3.test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail4.output
+++ b/tests/backend/checkmach/fail4.output
@@ -1,2 +1,2 @@
 File "fail4.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail4.test (camlFail4__test_HIDE_STAMP)
+Error: Annotation check for zero_alloc strict failed on function Fail4.test (camlFail4.test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail5.output
+++ b/tests/backend/checkmach/fail5.output
@@ -1,2 +1,2 @@
 File "fail5.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail5.test (camlFail5__test_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail5.test (camlFail5.test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail6.output
+++ b/tests/backend/checkmach/fail6.output
@@ -1,2 +1,2 @@
 File "fail6.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail6.test3 (camlFail6__test3_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail6.test3 (camlFail6.test3_HIDE_STAMP)

--- a/tests/backend/checkmach/fail7.output
+++ b/tests/backend/checkmach/fail7.output
@@ -1,2 +1,2 @@
 File "fail7.ml", line 7, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail7.test (camlFail7__test_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail7.test (camlFail7.test_HIDE_STAMP)

--- a/tests/backend/checkmach/fail8.output
+++ b/tests/backend/checkmach/fail8.output
@@ -1,2 +1,2 @@
 File "fail8.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail8.f (camlFail8__f_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail8.f (camlFail8.f_HIDE_STAMP)

--- a/tests/backend/checkmach/fail9.output
+++ b/tests/backend/checkmach/fail9.output
@@ -1,2 +1,2 @@
 File "fail9.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail9.g (camlFail9__g_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail9.g (camlFail9.g_HIDE_STAMP)

--- a/tests/backend/checkmach/filter.sh
+++ b/tests/backend/checkmach/filter.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+# CR ocaml 5 runtime: remove __ mangling once we're always using the 5 runtime
 sed -r 's/Error: Annotation check for zero_alloc( strict | )failed on function ([^ ]*) \(caml(.*)_[0-9]+(_[0-9]+_code)?\)$/Error: Annotation check for zero_alloc\1failed on function \2 \(caml\3_HIDE_STAMP\)/' | \
-    sed -r 's/  direct (tail)?call caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/  direct \1call caml\2_HIDE_STAMP\4/' | sed -r 's/  probe (test)? handler caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/  probe \1 handler caml\2_HIDE_STAMP\4/'
+    sed -r 's/  direct (tail)?call caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/  direct \1call caml\2_HIDE_STAMP\4/' | sed -r 's/  probe (test)? handler caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/  probe \1 handler caml\2_HIDE_STAMP\4/' | \
+    sed 's/__/./'

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -44,8 +44,6 @@ let () =
       | "exit_code" -> string_of_int exit_code
       | "cutoff" -> string_of_int cutoff
       | "extra_flags" -> extra_flags
-      (* CR ocaml 5 runtime: remove once we're always using the 5 runtime *)
-      | "__" -> "."  (* symbol separators *)
       | _ -> assert false
     in
     Buffer.clear buf;

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -44,6 +44,8 @@ let () =
       | "exit_code" -> string_of_int exit_code
       | "cutoff" -> string_of_int cutoff
       | "extra_flags" -> extra_flags
+      (* CR ocaml 5 runtime: remove once we're always using the 5 runtime *)
+      | "__" -> "."  (* symbol separators *)
       | _ -> assert false
     in
     Buffer.clear buf;

--- a/tests/backend/checkmach/test_attribute_error_duplicate.output
+++ b/tests/backend/checkmach/test_attribute_error_duplicate.output
@@ -17,4 +17,4 @@ Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 It must be either 'assume', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume strict never_returns_normally', 'ignore' or empty
 
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate__test1_HIDE_STAMP)
+Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate.test1_HIDE_STAMP)

--- a/tests/backend/checkmach/test_never_returns_normally.output
+++ b/tests/backend/checkmach/test_never_returns_normally.output
@@ -1,9 +1,9 @@
 File "test_never_returns_normally.ml", line 9, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.foo (camlTest_never_returns_normally__foo_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.foo (camlTest_never_returns_normally.foo_HIDE_STAMP)
 File "test_never_returns_normally.ml", line 9, characters 25-41:
   indirect tailcall
 
 File "test_never_returns_normally.ml", line 10, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.bar (camlTest_never_returns_normally__bar_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.bar (camlTest_never_returns_normally.bar_HIDE_STAMP)
 File "test_never_returns_normally.ml", line 10, characters 27-50:
   indirect tailcall

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -5,7 +5,7 @@
  (language c)
  (names stubs)
  (flags -msse4.2)
- (include_dirs "../../ocaml/runtime4"))
+ (include_dirs "../../ocaml/%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}"))
 
 ; Tests with external assembler
 


### PR DESCRIPTION
- Fixes to checkmach related to symbol separators
- Likewise for flexpect...
- ...but also flexpect is now disabled when stack allocation is off.  This is only the case whilst locals is being ported to runtime5, and it's complicated to support otherwise.