### PR TITLE
Fix C warnings

### DIFF
--- a/ocaml/otherlibs/systhreads4/st_stubs.c
+++ b/ocaml/otherlibs/systhreads4/st_stubs.c
@@ -186,7 +186,7 @@ struct caml_locking_scheme caml_default_locking_scheme =
     default_can_skip_yield,
     (void (*)(void*))&st_thread_yield };
 
-static void acquire_runtime_lock()
+static void acquire_runtime_lock(void)
 {
   struct caml_locking_scheme* s;
 
@@ -205,7 +205,7 @@ static void acquire_runtime_lock()
   }
 }
 
-static void release_runtime_lock()
+static void release_runtime_lock(void)
 {
   /* There is no tricky case here like in acquire, as only the holder
      of the lock can change it. (Here, that's us) */
@@ -616,7 +616,7 @@ CAMLprim value caml_thread_initialize(value unit)   /* ML */
 }
 
 /* Start tick thread, if not already running */
-static st_retcode start_tick_thread()
+static st_retcode start_tick_thread(void)
 {
   st_retcode err;
   if (caml_tick_thread_running) return 0;
@@ -626,7 +626,7 @@ static st_retcode start_tick_thread()
 }
 
 /* Stop tick thread, if currently running */
-static void stop_tick_thread()
+static void stop_tick_thread(void)
 {
   if (!caml_tick_thread_running) return;
   caml_tick_thread_stop = 1;

--- a/ocaml/runtime4/afl.c
+++ b/ocaml/runtime4/afl.c
@@ -66,7 +66,7 @@ static void afl_write(uint32_t msg)
     caml_fatal_error("writing to afl-fuzz");
 }
 
-static uint32_t afl_read()
+static uint32_t afl_read(void)
 {
   uint32_t msg;
   if (read(FORKSRV_FD_READ, &msg, 4) != 4)

--- a/ocaml/runtime4/domain.c
+++ b/ocaml/runtime4/domain.c
@@ -21,7 +21,7 @@
 
 CAMLexport caml_domain_state* Caml_state;
 
-void caml_init_domain ()
+void caml_init_domain (void)
 {
   if (Caml_state != NULL)
     return;

--- a/ocaml/runtime4/eventlog.c
+++ b/ocaml/runtime4/eventlog.c
@@ -120,7 +120,7 @@ static int64_t time_counter(void)
 #endif
 }
 
-static void setup_evbuf()
+static void setup_evbuf(void)
 {
   CAMLassert(!evbuf);
   evbuf = caml_stat_alloc_noexc(sizeof(*evbuf));
@@ -132,7 +132,7 @@ static void setup_evbuf()
 }
 
 #define OUTPUT_FILE_LEN 4096
-static void setup_eventlog_file()
+static void setup_eventlog_file(void)
 {
   char_os output_file[OUTPUT_FILE_LEN];
   char_os *eventlog_filename = NULL;
@@ -239,7 +239,7 @@ static void teardown_eventlog(void)
   }
 }
 
-void caml_eventlog_init()
+void caml_eventlog_init(void)
 {
   char_os *toggle = caml_secure_getenv(T("OCAML_EVENTLOG_ENABLED"));
 
@@ -330,7 +330,7 @@ void caml_ev_alloc(uint64_t sz)
 /*  Note that this function does not trigger an actual disk flush, it just
     pushes events in the event buffer.
 */
-void caml_ev_alloc_flush()
+void caml_ev_alloc_flush(void)
 {
   int i;
 
@@ -345,7 +345,7 @@ void caml_ev_alloc_flush()
   }
 }
 
-void caml_ev_flush()
+void caml_ev_flush(void)
 {
   if (!Caml_state->eventlog_enabled) return;
   if (Caml_state->eventlog_paused) return;
@@ -357,7 +357,7 @@ void caml_ev_flush()
   };
 }
 
-void caml_eventlog_disable()
+void caml_eventlog_disable(void)
 {
   Caml_state->eventlog_enabled = 0;
   teardown_eventlog();

--- a/ocaml/runtime4/extern.c
+++ b/ocaml/runtime4/extern.c
@@ -1301,7 +1301,7 @@ intnat reachable_words_once(value root, intnat identifier, value sizes_by_root_i
   return size;
 }
 
-void reachable_words_init()
+void reachable_words_init(void)
 {
   obj_counter = 0;
   extern_flags = 0;
@@ -1315,7 +1315,7 @@ void reachable_words_mark_root(value v)
   extern_record_location_with_data(v, h, RootUnprocessed);
 }
 
-void reachable_words_cleanup()
+void reachable_words_cleanup(void)
 {
   extern_free_stack();
   extern_free_position_table();

--- a/ocaml/runtime4/finalise.c
+++ b/ocaml/runtime4/finalise.c
@@ -152,11 +152,11 @@ static void generic_final_update (struct finalisable * final, int darken_value)
   }
 }
 
-void caml_final_update_mark_phase (){
+void caml_final_update_mark_phase (void){
   generic_final_update(&finalisable_first, /* darken_value */ 1);
 }
 
-void caml_final_update_clean_phase (){
+void caml_final_update_clean_phase (void){
   generic_final_update(&finalisable_last, /* darken_value */ 0);
 }
 
@@ -227,7 +227,7 @@ void caml_final_do_roots (scanning_action f)
 /* Call caml_invert_root on the values of the finalisable set. This is called
    directly by the compactor.
 */
-void caml_final_invert_finalisable_values ()
+void caml_final_invert_finalisable_values (void)
 {
   uintnat i;
 
@@ -247,7 +247,7 @@ void caml_final_invert_finalisable_values ()
 /* Call [caml_oldify_one] on the closures and values of the recent set.
    This is called by the minor GC through [caml_oldify_local_roots].
 */
-void caml_final_oldify_young_roots ()
+void caml_final_oldify_young_roots (void)
 {
   uintnat i;
 
@@ -337,7 +337,7 @@ static void generic_final_minor_update (struct finalisable * final)
    minor heap when moved to major heap or moved them to the finalising
    set when dead.
 */
-void caml_final_update_minor_roots ()
+void caml_final_update_minor_roots (void)
 {
   generic_final_minor_update(&finalisable_last);
 }

--- a/ocaml/runtime4/fix_code.c
+++ b/ocaml/runtime4/fix_code.c
@@ -158,7 +158,7 @@ void caml_thread_code (code_t code, asize_t len)
 
 #else
 
-int* caml_init_opcode_nargs()
+int* caml_init_opcode_nargs(void)
 {
   return NULL;
 }

--- a/ocaml/runtime4/gc_ctrl.c
+++ b/ocaml/runtime4/gc_ctrl.c
@@ -329,7 +329,7 @@ CAMLprim value caml_gc_quick_stat(value v)
   CAMLreturn (res);
 }
 
-double caml_gc_minor_words_unboxed()
+double caml_gc_minor_words_unboxed(void)
 {
   return (Caml_state->stat_minor_words
           + (double) (Caml_state->young_alloc_end - Caml_state->young_ptr));

--- a/ocaml/runtime4/instrtrace.c
+++ b/ocaml/runtime4/instrtrace.c
@@ -36,7 +36,7 @@ extern code_t caml_start_code;
 
 intnat caml_icount = 0;
 
-void caml_stop_here () {}
+void caml_stop_here (void) {}
 
 void caml_disasm_instr(code_t pc)
 {

--- a/ocaml/runtime4/major_gc.c
+++ b/ocaml/runtime4/major_gc.c
@@ -314,7 +314,7 @@ void caml_darken (value v, value *p)
 /* This function shrinks the mark stack back to the MARK_STACK_INIT_SIZE size
    and is called at the end of a GC compaction to avoid a mark stack greater
    than 1/32th of the heap. */
-void caml_shrink_mark_stack () {
+void caml_shrink_mark_stack (void) {
   struct mark_stack* stk = Caml_state->mark_stack;
   intnat init_stack_bsize = MARK_STACK_INIT_SIZE * sizeof(mark_entry);
   mark_entry* shrunk_stack;

--- a/ocaml/runtime4/memory.c
+++ b/ocaml/runtime4/memory.c
@@ -706,7 +706,7 @@ CAMLexport void caml_modify_local (value obj, intnat i, value val)
   }
 }
 
-CAMLexport intnat caml_local_region_begin()
+CAMLexport intnat caml_local_region_begin(void)
 {
   return Caml_state->local_sp;
 }
@@ -716,7 +716,7 @@ CAMLexport void caml_local_region_end(intnat reg)
   Caml_state->local_sp = reg;
 }
 
-CAMLexport caml_local_arenas* caml_get_local_arenas()
+CAMLexport caml_local_arenas* caml_get_local_arenas(void)
 {
   caml_local_arenas* s = Caml_state->local_arenas;
   if (s != NULL)
@@ -739,7 +739,7 @@ CAMLexport void caml_set_local_arenas(caml_local_arenas* s)
   }
 }
 
-void caml_local_realloc()
+void caml_local_realloc(void)
 {
   caml_local_arenas* s = caml_get_local_arenas();
   intnat i;

--- a/ocaml/runtime4/memprof.c
+++ b/ocaml/runtime4/memprof.c
@@ -340,7 +340,7 @@ static uintnat rand_binom(uintnat len)
    which may call the GC, but prefer using [caml_alloc_shr], which
    gives this guarantee. The return value is either a valid callstack
    or 0 in out-of-memory scenarios. */
-static value capture_callstack_postponed()
+static value capture_callstack_postponed(void)
 {
   value res;
   intnat callstack_len =
@@ -1098,7 +1098,7 @@ static void th_ctx_iter_default(th_ctx_action f, void* data) {
 CAMLexport void (*caml_memprof_th_ctx_iter_hook)(th_ctx_action, void*)
   = th_ctx_iter_default;
 
-CAMLexport struct caml_memprof_th_ctx* caml_memprof_new_th_ctx()
+CAMLexport struct caml_memprof_th_ctx* caml_memprof_new_th_ctx(void)
 {
   struct caml_memprof_th_ctx* ctx =
     caml_stat_alloc(sizeof(struct caml_memprof_th_ctx));

--- a/ocaml/runtime4/minor_gc.c
+++ b/ocaml/runtime4/minor_gc.c
@@ -63,7 +63,7 @@
 
 struct generic_table CAML_TABLE_STRUCT(char);
 
-void caml_alloc_minor_tables ()
+void caml_alloc_minor_tables (void)
 {
   Caml_state->ref_table =
     caml_stat_alloc_noexc(sizeof(struct caml_ref_table));
@@ -359,7 +359,7 @@ void caml_oldify_mopup (void)
 }
 
 #ifdef DEBUG
-static void verify_minor_heap()
+static void verify_minor_heap(void)
 {
   header_t* p;
   struct caml_local_arena* arena = Caml_state->local_arenas ?

--- a/ocaml/runtime4/signals.c
+++ b/ocaml/runtime4/signals.c
@@ -339,7 +339,7 @@ Caml_inline value process_pending_actions_with_root_exn(value extra_root)
 }
 
 CAMLno_tsan /* The access to [caml_something_to_do] is not synchronized. */
-int caml_check_pending_actions()
+int caml_check_pending_actions(void)
 {
   return caml_something_to_do;
 }


### PR DESCRIPTION
This pull request fixes a number of C warnings
by rewriting

```
... f() { ... }
```

to

```... f(void) { ... }```