### PR TITLE
Add the "debugger4/" files to .gitignore

### DIFF
--- a/ocaml/.gitignore
+++ b/ocaml/.gitignore
@@ -92,6 +92,12 @@ META
 /debugger/debugger_parser.output
 /debugger/ocamldebug
 
+/debugger4/debugger_lexer.ml
+/debugger4/debugger_parser.ml
+/debugger4/debugger_parser.mli
+/debugger4/debugger_parser.output
+/debugger4/ocamldebug
+
 /emacs/ocamltags
 /emacs/*.elc
 


### PR DESCRIPTION
(As per title, to keep `git status` tidy.)