### PR TITLE
Remove Config.runtime5 check in dll.ml; guard the one in symbol.ml

### DIFF
--- a/ocaml/bytecomp/dll.ml
+++ b/ocaml/bytecomp/dll.ml
@@ -19,13 +19,7 @@ type dll_handle
 type dll_address
 type dll_mode = For_checking | For_execution
 
-external dll_open5: string -> dll_handle = "caml_dynlink_open_lib"
-
-external dll_open4: dll_mode -> string -> dll_handle = "caml_dynlink_open_lib"
-
-let dll_open mode path =
-  if Config.runtime5 then dll_open5 path else dll_open4 mode path
-
+external dll_open: dll_mode -> string -> dll_handle = "caml_dynlink_open_lib"
 external dll_close: dll_handle -> unit = "caml_dynlink_close_lib"
 external dll_sym: dll_handle -> string -> dll_address
                 = "caml_dynlink_lookup_symbol"

--- a/ocaml/runtime/dynlink.c
+++ b/ocaml/runtime/dynlink.c
@@ -235,7 +235,9 @@ void caml_free_shared_libs(void)
 
 #define Handle_val(v) (*((void **) (v)))
 
-CAMLprim value caml_dynlink_open_lib(value filename)
+/* The mode argument is here for compatibility with runtime4. */
+/* CR ocaml 5 runtime: Remove [mode] when all-runtime5. */
+CAMLprim value caml_dynlink_open_lib(value mode, value filename)
 {
   void * handle;
   value result;

--- a/ocaml/utils/symbol.ml
+++ b/ocaml/utils/symbol.ml
@@ -50,6 +50,8 @@ let caml_symbol_prefix = "caml"
 let force_runtime4_symbols = ref false
 
 let separator () =
+  if not !Clflags.native_code then
+    Misc.fatal_error "Didn't expect utils/symbol.ml to be used in bytecode";
   if Config.runtime5 && not !force_runtime4_symbols then "." else "__"
 
 let force_runtime4_symbols () = force_runtime4_symbols := true


### PR DESCRIPTION
Two minor changes working towards the goal of not having any `Config.runtime5` conditionals in the bytecode compiler.

1. Harmonize caml_dynlink_open_lib interface between 4 and 5 runtimes, by adjusting the 5 runtime.
2. Check in `ocaml/utils/symbol.ml` that the `Config.runtime5` check is only executed in the native code compiler.