### PR TITLE
Ports custom runtime locking

### DIFF
--- a/ocaml/otherlibs/systhreads/st_pthreads.h
+++ b/ocaml/otherlibs/systhreads/st_pthreads.h
@@ -160,7 +160,7 @@ static void st_masterlock_acquire(st_masterlock *m)
     atomic_fetch_add(&m->waiters, -1);
   }
   m->busy = 1;
-  // single-domain hack: we assume no backup thread
+  // CR ocaml 5 domains: we assume no backup thread
   // st_bt_lock_acquire(m);
   pthread_mutex_unlock(&m->lock);
 
@@ -171,7 +171,7 @@ static void st_masterlock_release(st_masterlock * m)
 {
   pthread_mutex_lock(&m->lock);
   m->busy = 0;
-  // single-domain hack: we assume no backup thread
+  // CR ocaml 5 domains: we assume no backup thread
   // st_bt_lock_release(m);
   custom_condvar_signal(&m->is_free);
   pthread_mutex_unlock(&m->lock);
@@ -210,7 +210,7 @@ Caml_inline void st_thread_yield(st_masterlock * m)
      messaging the bt should not be required because yield assumes
      that a thread will resume execution (be it the yielding thread
      or a waiting thread */
-  // single-domain hack
+  // CR ocaml 5 domains
   // caml_release_domain_lock();
 
   do {
@@ -224,7 +224,7 @@ Caml_inline void st_thread_yield(st_masterlock * m)
   m->busy = 1;
   atomic_fetch_add(&m->waiters, -1);
 
-  // single-domain hack
+  // CR ocaml 5 domains
   // caml_acquire_domain_lock();
 
   pthread_mutex_unlock(&m->lock);

--- a/ocaml/otherlibs/systhreads/st_pthreads.h
+++ b/ocaml/otherlibs/systhreads/st_pthreads.h
@@ -160,7 +160,8 @@ static void st_masterlock_acquire(st_masterlock *m)
     atomic_fetch_add(&m->waiters, -1);
   }
   m->busy = 1;
-  st_bt_lock_acquire(m);
+  // single-domain hack: we assume no backup thread
+  // st_bt_lock_acquire(m);
   pthread_mutex_unlock(&m->lock);
 
   return;
@@ -170,7 +171,8 @@ static void st_masterlock_release(st_masterlock * m)
 {
   pthread_mutex_lock(&m->lock);
   m->busy = 0;
-  st_bt_lock_release(m);
+  // single-domain hack: we assume no backup thread
+  // st_bt_lock_release(m);
   custom_condvar_signal(&m->is_free);
   pthread_mutex_unlock(&m->lock);
 
@@ -208,7 +210,8 @@ Caml_inline void st_thread_yield(st_masterlock * m)
      messaging the bt should not be required because yield assumes
      that a thread will resume execution (be it the yielding thread
      or a waiting thread */
-  caml_release_domain_lock();
+  // single-domain hack
+  // caml_release_domain_lock();
 
   do {
     /* Note: the POSIX spec prevents the above signal from pairing with this
@@ -221,7 +224,8 @@ Caml_inline void st_thread_yield(st_masterlock * m)
   m->busy = 1;
   atomic_fetch_add(&m->waiters, -1);
 
-  caml_acquire_domain_lock();
+  // single-domain hack
+  // caml_acquire_domain_lock();
 
   pthread_mutex_unlock(&m->lock);
 

--- a/ocaml/otherlibs/systhreads/st_stubs.c
+++ b/ocaml/otherlibs/systhreads/st_stubs.c
@@ -48,8 +48,8 @@
 
 #include "../../runtime/sync_posix.h"
 
-/* threads.h is *not* included since it contains the _external_ declarations for
-   the caml_c_thread_register and caml_c_thread_unregister functions. */
+#define CAMLextern_libthreads
+#include "threads.h"
 
 /* Max computation time before rescheduling, in milliseconds */
 #define Thread_timeout 50
@@ -59,6 +59,22 @@
 #include "st_win32.h"
 #else
 #include "st_posix.h"
+#endif
+
+/* Atomics */
+#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ == 8
+  /* GCC 4.8 shipped with a working implementation of atomics, but no
+     stdatomic.h header, so we need to use GCC-specific intrinsics. */
+
+  #define _Atomic /* GCC intrinsics work on normal variables */
+  #define atomic_store(v, x) \
+    __atomic_store_n((v), (x), __ATOMIC_SEQ_CST)
+  #define atomic_load(v) \
+    __atomic_load_n((v), __ATOMIC_SEQ_CST)
+  #define atomic_exchange(v, x) \
+    __atomic_exchange_n((v), (x), __ATOMIC_SEQ_CST)
+#else
+  #include <stdatomic.h>
 #endif
 
 /* The ML value describing a thread (heap-allocated) */
@@ -114,7 +130,9 @@ st_tlskey caml_thread_key;
 /* overall table for threads across domains */
 struct caml_thread_table {
   caml_thread_t active_thread;
-  st_masterlock thread_lock;
+  struct caml_locking_scheme * _Atomic locking_scheme;
+  st_masterlock default_lock;
+  struct caml_locking_scheme default_locking_scheme;
   int tick_thread_running;
   st_thread_id tick_thread_id;
 };
@@ -122,16 +140,36 @@ struct caml_thread_table {
 /* thread_table instance, up to Max_domains */
 static struct caml_thread_table thread_table[Max_domains];
 
-#define Thread_lock(dom_id) &thread_table[dom_id].thread_lock
+#define Locking_scheme(dom_id) (thread_table[dom_id].locking_scheme)
+#define Default_lock(dom_id) (&thread_table[dom_id].default_lock)
+#define Default_locking_scheme(dom_id) (&thread_table[dom_id].default_locking_scheme)
 
 static void thread_lock_acquire(int dom_id)
 {
-  st_masterlock_acquire(Thread_lock(dom_id));
+  struct caml_locking_scheme* s;
+
+  /* The locking scheme may be changed by the thread that currently
+     holds it. This means that it may change while we're waiting to
+     acquire it, so by the time we acquire it it may no longer be the
+     right scheme. */
+
+ retry:
+  s = atomic_load(&Locking_scheme(dom_id));
+  s->lock(s->context);
+  if (atomic_load(&Locking_scheme(dom_id)) != s) {
+    /* This is no longer the right scheme. Unlock and try again */
+    s->unlock(s->context);
+    goto retry;
+  }
 }
 
 static void thread_lock_release(int dom_id)
 {
-  st_masterlock_release(Thread_lock(dom_id));
+  /* There is no tricky case here like in acquire, as only the holder
+     of the lock can change it. (Here, that's us) */
+  struct caml_locking_scheme *s;
+  s = atomic_load(&Locking_scheme(dom_id));
+  s->unlock(s->context);
 }
 
 /* The remaining fields are accessed while holding the domain lock */
@@ -155,6 +193,17 @@ static atomic_uintnat thread_next_id = 0;
 static value caml_threadstatus_new (void);
 static void caml_threadstatus_terminate (value);
 static st_retcode caml_threadstatus_wait (value);
+
+static int default_can_skip_yield(st_masterlock *m)
+{
+  return st_masterlock_waiters(m) == 0;
+}
+
+static void default_reinitialize_after_fork(st_masterlock *m)
+{
+  m->init = 0; /* force initialization */
+  st_masterlock_init(m);
+}
 
 /* Hook for scanning the stacks of the other threads */
 
@@ -192,25 +241,33 @@ static void caml_thread_scan_roots(
 
 static void save_runtime_state(void)
 {
-  CAMLassert(This_thread != NULL);
-  caml_thread_t this_thread = This_thread;
-  this_thread->current_stack = Caml_state->current_stack;
-  this_thread->c_stack = Caml_state->c_stack;
-  this_thread->gc_regs = Caml_state->gc_regs;
-  this_thread->gc_regs_buckets = Caml_state->gc_regs_buckets;
-  this_thread->exn_handler = Caml_state->exn_handler;
-  this_thread->async_exn_handler = Caml_state->async_exn_handler;
-  this_thread->local_roots = Caml_state->local_roots;
-  this_thread->local_arenas = caml_get_local_arenas(Caml_state);
-  this_thread->backtrace_pos = Caml_state->backtrace_pos;
-  this_thread->backtrace_buffer = Caml_state->backtrace_buffer;
-  this_thread->backtrace_last_exn = Caml_state->backtrace_last_exn;
+  /* CR zqian: we save to [active_thread] instead of [this_thread]. I believe
+  they are equivalent here, but I think use [active_thread] is easier to
+  understand, also follows the systhreads4 behavior. */
+  caml_thread_t th = Active_thread;
+  CAMLassert(th != NULL);
+  th->current_stack = Caml_state->current_stack;
+  th->c_stack = Caml_state->c_stack;
+  th->gc_regs = Caml_state->gc_regs;
+  th->gc_regs_buckets = Caml_state->gc_regs_buckets;
+  th->exn_handler = Caml_state->exn_handler;
+  th->async_exn_handler = Caml_state->async_exn_handler;
+  th->local_roots = Caml_state->local_roots;
+  th->local_arenas = caml_get_local_arenas(Caml_state);
+  th->backtrace_pos = Caml_state->backtrace_pos;
+  th->backtrace_buffer = Caml_state->backtrace_buffer;
+  th->backtrace_last_exn = Caml_state->backtrace_last_exn;
 #ifndef NATIVE_CODE
-  this_thread->trap_sp_off = Caml_state->trap_sp_off;
-  this_thread->trap_barrier_off = Caml_state->trap_barrier_off;
-  this_thread->external_raise = Caml_state->external_raise;
-  this_thread->external_raise_async = Caml_state->external_raise_async;
+  th->trap_sp_off = Caml_state->trap_sp_off;
+  th->trap_barrier_off = Caml_state->trap_barrier_off;
+  th->external_raise = Caml_state->external_raise;
+  th->external_raise_async = Caml_state->external_raise_async;
 #endif
+}
+
+CAMLexport void caml_thread_save_runtime_state(void)
+{
+  save_runtime_state();
 }
 
 static void restore_runtime_state(caml_thread_t th)
@@ -234,6 +291,29 @@ static void restore_runtime_state(caml_thread_t th)
   Caml_state->external_raise = th->external_raise;
   Caml_state->external_raise_async = th->external_raise_async;
 #endif
+}
+
+CAMLexport void caml_thread_restore_runtime_state(void)
+{
+  restore_runtime_state(This_thread);
+}
+
+
+CAMLexport void caml_switch_runtime_locking_scheme(struct caml_locking_scheme* new)
+{
+  struct caml_locking_scheme* old;
+  int dom_id = Caml_state->id;
+  save_runtime_state();
+  old = atomic_exchange(&Locking_scheme(dom_id), new);
+  /* We hold 'old', but it is no longer the runtime lock */
+  old->unlock(old->context);
+  thread_lock_acquire(dom_id);
+  restore_runtime_state(This_thread);
+}
+
+CAMLexport struct caml_locking_scheme* caml_get_default_locking_scheme(void)
+{
+  return Default_locking_scheme(Caml_state->id);
 }
 
 CAMLprim value caml_thread_cleanup(value unit);
@@ -392,15 +472,16 @@ static void caml_thread_reinitialize(void)
   Active_thread->next = Active_thread;
   Active_thread->prev = Active_thread;
 
+  // Single-domain hack: systhreads doesn't maintain domain lock
   /* Within the child, the domain_lock needs to be reset and acquired. */
-  caml_reset_domain_lock();
-  caml_acquire_domain_lock();
-  /* The master lock needs to be initialized again. This process will also be
+  // caml_reset_domain_lock();
+  // caml_acquire_domain_lock();
+
+  /* The lock needs to be initialized again. This process will also be
      the effective owner of the lock. So there is no need to run
-     st_masterlock_acquire (busy = 1) */
-  st_masterlock *m = Thread_lock(Caml_state->id);
-  m->init = 0; /* force initialization */
-  st_masterlock_init(m);
+     s->lock (busy = 1) */
+  struct caml_locking_scheme *s = atomic_load(&Locking_scheme(Caml_state->id));
+  s->reinitialize_after_fork(s->context);
 }
 
 CAMLprim value caml_thread_join(value th);
@@ -440,7 +521,19 @@ static void caml_thread_domain_initialize_hook(void)
   /* OS-specific initialization */
   st_initialize();
 
-  st_masterlock_init(Thread_lock(Caml_state->id));
+  st_masterlock *default_lock = Default_lock(Caml_state->id);
+  st_masterlock_init(default_lock);
+  struct caml_locking_scheme *ls = Default_locking_scheme(Caml_state->id);
+  ls->context = default_lock;
+  ls->lock = (void (*)(void*))&st_masterlock_acquire;
+  ls->unlock = (void (*)(void*))&st_masterlock_release;
+  ls->thread_start = NULL;
+  ls->thread_stop = NULL;
+  ls->reinitialize_after_fork = (void (*)(void*))&default_reinitialize_after_fork;
+  ls->can_skip_yield = (int (*)(void*))&default_can_skip_yield;
+  ls->yield = (void (*)(void*))&st_thread_yield;
+
+  Locking_scheme(Caml_state->id) = ls;
 
   new_thread =
     (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
@@ -553,6 +646,9 @@ static void * caml_thread_start(void * v)
   caml_init_domain_self(dom_id);
 
   st_tls_set(caml_thread_key, th);
+  struct caml_locking_scheme *s = atomic_load(&Locking_scheme(dom_id));
+  if (s -> thread_start != NULL)
+    s->thread_start(s->context, Thread_type_caml);
 
   thread_lock_acquire(dom_id);
   restore_runtime_state(th);
@@ -568,6 +664,9 @@ static void * caml_thread_start(void * v)
   caml_modify(&(Start_closure(Active_thread->descr)), Val_unit);
   caml_callback_exn(clos, Val_unit);
   caml_thread_stop();
+  s = atomic_load(&Locking_scheme(dom_id));
+  if (s->thread_stop != NULL)
+    s->thread_stop(s->context, Thread_type_caml);
   caml_free_signal_stack(signal_stack);
   return 0;
 }
@@ -656,6 +755,12 @@ CAMLprim value caml_thread_new(value clos)
 /* the thread lock is not held when entering */
 CAMLexport int caml_c_thread_register(void)
 {
+  /* CR zqian: I would personally delay this after the "already registered"
+  check, but this is to follow the original PR.*/
+  struct caml_locking_scheme *s = atomic_load(&Locking_scheme(Dom_c_threads));
+  if (s->thread_start != NULL)
+    s->thread_start(s->context, Thread_type_c_registered);
+
   /* Already registered? */
   if (This_thread != NULL) return 0;
 
@@ -716,6 +821,13 @@ CAMLexport int caml_c_thread_unregister(void)
   caml_thread_remove_and_free(th);
   /* Release the runtime */
   thread_lock_release(Dom_c_threads);
+  struct caml_locking_scheme *s = atomic_load(&Locking_scheme(Dom_c_threads));
+  if (s->thread_stop != NULL)
+    s->thread_stop(s->context, Thread_type_c_registered);
+  /* CR zqian: This follows the original PR. But some asymetry here: if a thread
+  is already registered, registering again gives callback. If a thread is
+  already unregistered, unregistering again does not give callback. Is that
+  fine? */
   return 1;
 }
 
@@ -750,8 +862,9 @@ CAMLprim value caml_thread_uncaught_exception(value exn)
 
 CAMLprim value caml_thread_yield(value unit)
 {
-  st_masterlock *m = Thread_lock(Caml_state->id);
-  if (st_masterlock_waiters(m) == 0)
+  struct caml_locking_scheme *s;
+  s = atomic_load(&Locking_scheme(Caml_state->id));
+  if (s->can_skip_yield != NULL && s -> can_skip_yield(s->context))
     return Val_unit;
 
   /* Do all the parts of a blocking section enter/leave except lock
@@ -761,8 +874,16 @@ CAMLprim value caml_thread_yield(value unit)
   */
 
   (void) caml_raise_async_if_exception(caml_process_pending_signals_exn (), "");
+
+  // s may have changed in caml_process_pending_signals_exn
+  s = atomic_load(&Locking_scheme(Caml_state->id));
   save_runtime_state();
-  st_thread_yield(m);
+  s->yield(s->context);
+  if (atomic_load(&Locking_scheme(Caml_state->id)) != s) {
+    // The lock we own is no longer the runtime lock
+    s->unlock(s->context);
+    thread_lock_acquire(Caml_state->id);
+  }
   restore_runtime_state(This_thread);
   (void) caml_raise_async_if_exception(caml_process_pending_signals_exn (), "");
 

--- a/ocaml/otherlibs/systhreads/threads.h
+++ b/ocaml/otherlibs/systhreads/threads.h
@@ -50,8 +50,12 @@ CAMLextern void caml_leave_blocking_section (void);
    use the runtime system (typically, a blocking I/O operation).
 */
 
-CAMLextern int caml_c_thread_register(void);
-CAMLextern int caml_c_thread_unregister(void);
+/* These functions are defined in the threads library, not the runtime */
+#ifndef CAMLextern_libthreads
+#define CAMLextern_libthreads CAMLextern
+#endif
+CAMLextern_libthreads int caml_c_thread_register(void);
+CAMLextern_libthreads int caml_c_thread_unregister(void);
 
 /* If a thread is created by C code (instead of by OCaml itself),
    it must be registered with the OCaml runtime system before
@@ -63,6 +67,53 @@ CAMLextern int caml_c_thread_unregister(void);
    Both functions return 1 on success, 0 on error.
    Note that threads registered by C code belong to the domain 0.
 */
+
+enum caml_thread_type { Thread_type_caml, Thread_type_c_registered };
+struct caml_locking_scheme {
+  void* context;
+  void (*lock)(void*);
+  void (*unlock)(void*);
+
+  /* If non-NULL, these functions are called when threads start and stop.
+     For threads created by OCaml, that's at creation and termination.
+     For threads created by C, that's at caml_c_thread_register/unregister.
+     The lock is not held when these functions are called. */
+  void (*thread_start)(void*, enum caml_thread_type);
+  void (*thread_stop)(void*, enum caml_thread_type);
+
+  /* Called after fork().
+     The lock should be held after this function returns. */
+  void (*reinitialize_after_fork)(void*);
+
+  /* can_skip_yield and yield are both called with the lock held,
+     and expect it held on return */
+  int (*can_skip_yield)(void*);
+  void (*yield)(void*);
+};
+
+/* Switch to a new runtime locking scheme.
+
+   The old runtime lock must be held (i.e. not in a blocking section),
+   and the new runtime lock must not be held. After this function
+   returns, the old lock is released and the new one is held.
+
+   There is a period during this function when neither lock is held,
+   so context-switches may occur. */
+CAMLextern_libthreads
+void caml_switch_runtime_locking_scheme(struct caml_locking_scheme*);
+
+/* Returns the default scheme; caller must hold the lock */
+CAMLextern_libthreads
+struct caml_locking_scheme *caml_get_default_locking_scheme(void);
+
+/* Save runtime state of the active thread; caller must hold the lock */
+CAMLextern_libthreads
+void caml_thread_save_runtime_state(void);
+
+/* Restore the runtime state of the current thread; caller must hold the lock */
+CAMLextern_libthreads
+void caml_thread_restore_runtime_state(void);
+
 
 #ifdef __cplusplus
 }

--- a/ocaml/otherlibs/systhreads4/st_stubs.c
+++ b/ocaml/otherlibs/systhreads4/st_stubs.c
@@ -182,6 +182,11 @@ struct caml_locking_scheme caml_default_locking_scheme =
     default_can_skip_yield,
     (void (*)(void*))&st_thread_yield };
 
+CAMLexport struct caml_locking_scheme *caml_get_default_locking_scheme(void)
+{
+  return &caml_default_locking_scheme;
+}
+
 static void acquire_runtime_lock(void)
 {
   struct caml_locking_scheme* s;

--- a/ocaml/otherlibs/systhreads4/threads.h
+++ b/ocaml/otherlibs/systhreads4/threads.h
@@ -88,7 +88,8 @@ struct caml_locking_scheme {
   void (*yield)(void*);
 };
 
-extern struct caml_locking_scheme caml_default_locking_scheme;
+CAMLextern_libthreads
+struct caml_locking_scheme *caml_get_default_locking_scheme(void);
 
 /* Switch to a new runtime locking scheme.
 

--- a/ocaml/runtime/domain.c
+++ b/ocaml/runtime/domain.c
@@ -943,6 +943,8 @@ struct domain_startup_params {
 
 static void* backup_thread_func(void* v)
 {
+  // single-domain hack
+  caml_fatal_error("backup thread not allowed to run");
   dom_internal* di = (dom_internal*)v;
   uintnat msg;
   struct interruptor* s = &di->interruptor;

--- a/ocaml/testsuite/tests/c-api/test_c_thread_has_lock_systhread.ml
+++ b/ocaml/testsuite/tests/c-api/test_c_thread_has_lock_systhread.ml
@@ -13,7 +13,8 @@ external test_without_lock : unit -> bool = "without_lock"
 let passed b = Printf.printf (if b then "passed\n" else "failed\n")
 
 let f () =
-  passed (not (test_without_lock ())) ;
+  (* CR ocaml 5 domains: all systhreads will always have [caml_state != NULL] *)
+  passed (test_without_lock ());
   passed (test_with_lock ())
 
 let _ =

--- a/ocaml/testsuite/tests/lib-systhreads/swapgil.ml
+++ b/ocaml/testsuite/tests/lib-systhreads/swapgil.ml
@@ -1,12 +1,9 @@
 (* TEST
 modules = "swapgil_stubs.c"
-* runtime5
-** skip
-* runtime4
-** hassysthreads
+* hassysthreads
 include systhreads
-*** hasunix
-**** native
+** hasunix
+*** native
 *)
 
 external setup : unit -> unit = "swap_gil_setup"

--- a/ocaml/testsuite/tests/lib-systhreads/swapgil_stubs.c
+++ b/ocaml/testsuite/tests/lib-systhreads/swapgil_stubs.c
@@ -113,8 +113,9 @@ static void runtime_reinitialize(void* m)
 
 value swap_gil_setup(value unused)
 {
-  caml_default_locking_scheme.thread_start = runtime_thread_start;
-  caml_default_locking_scheme.thread_stop = runtime_thread_stop;
+  struct caml_locking_scheme *s = caml_get_default_locking_scheme();
+  s->thread_start = runtime_thread_start;
+  s->thread_stop = runtime_thread_stop;
   started = 1;
   return Val_unit;
 }


### PR DESCRIPTION
This ports a series of PRs related to custom runtime locking: #1365, #1411, #1429 

This does not port #1869 or the follow-up bug fix #1976. Note that #1869 is reverted by #1984.

- A major difficulty in this porting PR is that the default runtime lock `st_masterlock`  tries to acquire the `domain_lock` as well. Our API allows user to replace the `st_masterlock` with their own, which probably won't acquire `domain_lock`. This is only safe if there is no backup-thread in the current domain, which is ensured by inserting an `abort` in `backup_thread_func`. This would prevent mutliple-domain.
- I also removed acquiring `domain_lock` from `st_masterlock` just for consistency. As a result, `domain_lock` is rendered pretty much redundent. I didn't remove it for minimal diff and future reference - let me know if I should. 
- Note that `domain_lock` has a further security check, which is that the domain runtime state pointer `caml_state` is a thread-local variable and only not-null for the current active thread. This check has to be removed. because a thread could acquire the lock in python (and thus not setting `caml_state`), then enter ocaml assuming it has the lock (and thus `caml_state` not null). I believe our current approach should ensure that `caml_state` is always not-null for all systhreads. 
- Diff that will have to change in the future with multi-domain are marked with "single-domain hack", so it's easier to find and fix in the future.
- Comments starting with `CR zqian` are intended to initiate review conversion, and will be removed right before merging.
- Note that in `save_runtime_state` we talk about `Active_thread` instead of `This_thread`. I think it doesn't make much difference for this PR, but will be needed when we want to port #1869.

Request review from @stedolan 
