### PR TITLE
Make `lazy.ml` independent of the runtime version

### DIFF
--- a/ocaml/stdlib/lazy.ml
+++ b/ocaml/stdlib/lazy.ml
@@ -57,8 +57,6 @@ type 'a t = 'a CamlinternalLazy.t
 exception Undefined = CamlinternalLazy.Undefined
 external make_forward : 'a -> 'a lazy_t = "caml_lazy_make_forward"
 external force : 'a t -> 'a = "%lazy_force"
-external runtime5 : unit -> bool = "%runtime5"
-let runtime5 = runtime5 ()
 
 let force_val l = CamlinternalLazy.force_gen ~only_val:true l
 
@@ -67,7 +65,7 @@ let from_fun (f : unit -> 'arg) =
   Obj.set_field x 0 (Obj.repr f);
   (Obj.obj x : 'arg t)
 
-let from_val4 (v : 'arg) =
+let from_val (v : 'arg) =
   let t = Obj.tag (Obj.repr v) in
   if t = Obj.forward_tag || t = Obj.lazy_tag ||
      t = Obj.forcing_tag || t = Obj.double_tag then begin
@@ -75,18 +73,6 @@ let from_val4 (v : 'arg) =
   end else begin
     (Obj.magic v : 'arg t)
   end
-
-let from_val5 (v : 'arg) =
-  let t = Obj.tag (Obj.repr v) in
-  if t = Obj.forward_tag || t = Obj.lazy_tag
-    || t = Obj.forcing_tag
-    || t = Obj.double_tag then begin
-    make_forward v
-  end else begin
-    (Obj.magic v : 'arg t)
-  end
-
-let from_val = if runtime5 then from_val5 else from_val4
 
 let is_val (l : 'arg t) = Obj.tag (Obj.repr l) <> Obj.lazy_tag
 


### PR DESCRIPTION
The rebase of https://github.com/ocaml-flambda/flambda-backend/pull/2038 produced of version
of `lazy.ml` that was still dependent of the
runtime version. This pull requests moves
back to the previous version of the file.