### PR TITLE
zero alloc: new payload supported in [@@@zero_alloc check...] to match flags

### DIFF
--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -592,7 +592,7 @@ let zero_alloc_attribute (attr : Parsetree.attribute)  =
         Clflags.zero_alloc_check_assert_all := true
       | _ ->
         warn_payload attr.attr_loc attr.attr_name.txt
-          "Only 'check' and 'all' are supported")
+          "Only 'all', 'check', 'check_opt', 'check_all', and 'check_none' are supported")
 
 let afl_inst_ratio_attribute attr =
   clflags_attribute_with_int_payload attr

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -585,6 +585,9 @@ let zero_alloc_attribute (attr : Parsetree.attribute)  =
   parse_attribute_with_ident_payload attr
     ~name:"zero_alloc" ~f:(function
       | "check" -> Clflags.zero_alloc_check := Clflags.Annotations.Check_default
+      | "check_opt" -> Clflags.zero_alloc_check := Clflags.Annotations.Check_opt_only
+      | "check_all" -> Clflags.zero_alloc_check := Clflags.Annotations.Check_all
+      | "check_none" -> Clflags.zero_alloc_check := Clflags.Annotations.No_check
       | "all" ->
         Clflags.zero_alloc_check_assert_all := true
       | _ ->

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -654,3 +654,79 @@
  (enabled_if (= %{context_name} "main"))
  (deps test_misplaced_attr.output test_misplaced_attr.output.corrected)
  (action (diff test_misplaced_attr.output test_misplaced_attr.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_attr_check.output.corrected)
+ (deps (:ml test_attr_check.ml) filter.sh)
+ (action
+   (with-outputs-to test_attr_check.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check all -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_attr_check.output test_attr_check.output.corrected)
+ (action (diff test_attr_check.output test_attr_check.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_attr_check_all.output.corrected)
+ (deps (:ml test_attr_check_all.ml) filter.sh)
+ (action
+   (with-outputs-to test_attr_check_all.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_attr_check_all.output test_attr_check_all.output.corrected)
+ (action (diff test_attr_check_all.output test_attr_check_all.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_attr_check_opt.output.corrected)
+ (deps (:ml test_attr_check_opt.ml) filter.sh)
+ (action
+   (with-outputs-to test_attr_check_opt.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_attr_check_opt.output test_attr_check_opt.output.corrected)
+ (action (diff test_attr_check_opt.output test_attr_check_opt.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_attr_check_none.output.corrected)
+ (deps (:ml test_attr_check_none.ml) filter.sh)
+ (action
+   (with-outputs-to test_attr_check_none.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 0
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_attr_check_none.output test_attr_check_none.output.corrected)
+ (action (diff test_attr_check_none.output test_attr_check_none.output.corrected)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -128,5 +128,8 @@ let () =
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_assume_on_call";
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_misplaced_assume";
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:0 "test_misplaced_attr";
-
+  print_test_expected_output ~extra_flags:"-zero-alloc-check all" ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_attr_check";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_attr_check_all";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_attr_check_opt";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:0 "test_attr_check_none";
   ()

--- a/tests/backend/checkmach/test_attr_check.ml
+++ b/tests/backend/checkmach/test_attr_check.ml
@@ -1,0 +1,3 @@
+[@@@zero_alloc check]
+let[@zero_alloc] test x = (x,x)
+let[@zero_alloc opt] test_opt x = (x,x)

--- a/tests/backend/checkmach/test_attr_check.output
+++ b/tests/backend/checkmach/test_attr_check.output
@@ -1,0 +1,5 @@
+File "test_attr_check.ml", line 2, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_attr_check.test (camlTest_attr_check.test_HIDE_STAMP)
+
+File "test_attr_check.ml", line 2, characters 26-31:
+Error: Unexpected allocation of 24 bytes

--- a/tests/backend/checkmach/test_attr_check_all.ml
+++ b/tests/backend/checkmach/test_attr_check_all.ml
@@ -1,0 +1,3 @@
+[@@@zero_alloc check_all]
+let[@zero_alloc] test x = (x,x)
+let[@zero_alloc opt] test_opt x = (x,x)

--- a/tests/backend/checkmach/test_attr_check_all.output
+++ b/tests/backend/checkmach/test_attr_check_all.output
@@ -1,0 +1,11 @@
+File "test_attr_check_all.ml", line 2, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_attr_check_all.test (camlTest_attr_check_all.test_HIDE_STAMP)
+
+File "test_attr_check_all.ml", line 2, characters 26-31:
+Error: Unexpected allocation of 24 bytes
+
+File "test_attr_check_all.ml", line 3, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_attr_check_all.test_opt (camlTest_attr_check_all.test_opt_HIDE_STAMP)
+
+File "test_attr_check_all.ml", line 3, characters 34-39:
+Error: Unexpected allocation of 24 bytes

--- a/tests/backend/checkmach/test_attr_check_none.ml
+++ b/tests/backend/checkmach/test_attr_check_none.ml
@@ -1,0 +1,3 @@
+[@@@zero_alloc check_none]
+let[@zero_alloc] test x = (x,x)
+let[@zero_alloc opt] test_opt x = (x,x)

--- a/tests/backend/checkmach/test_attr_check_opt.ml
+++ b/tests/backend/checkmach/test_attr_check_opt.ml
@@ -1,0 +1,3 @@
+[@@@zero_alloc check_opt]
+let[@zero_alloc] test x = (x,x)
+let[@zero_alloc opt] test_opt x = (x,x)

--- a/tests/backend/checkmach/test_attr_check_opt.output
+++ b/tests/backend/checkmach/test_attr_check_opt.output
@@ -1,0 +1,5 @@
+File "test_attr_check_opt.ml", line 3, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_attr_check_opt.test_opt (camlTest_attr_check_opt.test_opt_HIDE_STAMP)
+
+File "test_attr_check_opt.ml", line 3, characters 34-39:
+Error: Unexpected allocation of 24 bytes

--- a/tests/backend/checkmach/test_misplaced_attr.ml
+++ b/tests/backend/checkmach/test_misplaced_attr.ml
@@ -5,3 +5,5 @@ let[@zero_alloc assume] foo =
 let[@zero_alloc] bar =
   let x = 42 in
   fun z -> z + x
+
+[@@@zero_alloc default]

--- a/tests/backend/checkmach/test_misplaced_attr.output
+++ b/tests/backend/checkmach/test_misplaced_attr.output
@@ -1,3 +1,7 @@
+File "test_misplaced_attr.ml", line 9, characters 0-23:
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+Only 'all', 'check', 'check_opt', 'check_all', and 'check_none' are supported
+
 File "test_misplaced_attr.ml", line 1, characters 5-15:
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 


### PR DESCRIPTION
In #1936 we added "opt" payload and corresponding flags. This PR enables them to be set on individual files using an attribute at the top level. 

It is a bit confusing, as the last setting in the file applies to the entire file.

Maybe we should just remove "check" payload? We added it in #1294 as a workaround for stdlib, but it has since been removed.  However, I found this top-level attribute useful for quick testing/debugging and tracking down stray allocations, because it overwrites all other settings (command line, env vars, build configurations, etc) and is much cheaper because it doesn't require a rebuilding anything else to enable the check (we commute function summaries unconditionally, this attribute enables the checking).