### PR TITLE
Ports #1914 (`is_stack` macro for C-stub authors)

### DIFF
--- a/ocaml/runtime/array.c
+++ b/ocaml/runtime/array.c
@@ -404,7 +404,7 @@ CAMLprim value caml_array_blit(value a1, value ofs1, value a2, value ofs2,
     return caml_floatarray_blit(a1, ofs1, a2, ofs2, n);
 #endif
   CAMLassert (Tag_val(a2) != Double_array_tag);
-  if (Is_young(a2) || caml_is_local(a2)) {
+  if (Is_young(a2) || caml_is_stack(a2)) {
     /* Arrays of values, destination is local or in young generation.
        Here too we can do a direct copy since this cannot create
        old-to-young pointers, nor mess up with the incremental major GC.
@@ -638,7 +638,7 @@ CAMLprim value caml_array_fill(value array,
   }
 #endif
   fp = &Field(array, ofs);
-  if (Is_young(array) || caml_is_local(array)) {
+  if (Is_young(array) || caml_is_stack(array)) {
     for (; len > 0; len--, fp++) *fp = val;
   } else {
     int is_val_young_block = Is_block(val) && Is_young(val);

--- a/ocaml/runtime/caml/memory.h
+++ b/ocaml/runtime/caml/memory.h
@@ -166,7 +166,7 @@ CAMLextern caml_stat_string caml_stat_strconcat(int n, ...);
 CAMLextern wchar_t* caml_stat_wcsconcat(int n, ...);
 #endif
 
-CAMLextern int caml_is_local(value);
+CAMLextern int caml_is_stack(value);
 
 /* void caml_shrink_heap (char *);        Only used in compact.c */
 

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -333,7 +333,7 @@ CAMLexport void caml_set_fields (value obj, value v)
   }
 }
 
-CAMLexport int caml_is_local (value v)
+CAMLexport int caml_is_stack (value v)
 {
   int i;
   struct caml_local_arenas* loc = Caml_state->local_arenas;
@@ -359,7 +359,7 @@ CAMLexport void caml_modify_local (value obj, intnat i, value val)
 {
   if (Color_hd(Hd_val(obj)) == NOT_MARKABLE) {
     /* This function should not be used on external values */
-    CAMLassert(caml_is_local(obj));
+    CAMLassert(caml_is_stack(obj));
     Field(obj, i) = val;
   } else {
     caml_modify(&Field(obj, i), val);

--- a/ocaml/runtime/obj.c
+++ b/ocaml/runtime/obj.c
@@ -260,7 +260,7 @@ CAMLprim value caml_lazy_update_to_forcing (value v)
 
 CAMLprim value caml_obj_is_stack (value v)
 {
-  return Val_int(caml_is_local(v));
+  return Val_int(caml_is_stack(v));
 }
 
 /* For mlvalues.h and camlinternalOO.ml


### PR DESCRIPTION
#1914 does two things:
- rename mentioning of `is_local` to `is_stack` in the runtime
- provides `Is_stack` that returns a C int.

This PR does the first point. For the second point, the local runtime PR already introduced `caml_is_stack` which returns a C int. For best backward compatibility we should rename this function, but I believe the original `Is_stack` was newly introduced and barely used anyway, so I'm not renaming it.