### PR TITLE
Zero alloc: change format of error messages

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -62,7 +62,7 @@ module Witness = struct
   let print_kind ppf kind =
     let open Format in
     match kind with
-    | Alloc { bytes; dbginfo = _ } -> fprintf ppf "allocate %d bytes" bytes
+    | Alloc { bytes; dbginfo = _ } -> fprintf ppf "allocation of %d bytes" bytes
     | Indirect_call -> fprintf ppf "indirect call"
     | Indirect_tailcall -> fprintf ppf "indirect tailcall"
     | Direct_call { callee } -> fprintf ppf "direct call %s" callee
@@ -86,41 +86,6 @@ module Witness = struct
 
   let print ppf { kind; dbg } =
     Format.fprintf ppf "%a %a" print_kind kind Debuginfo.print_compact dbg
-
-  let print_error component t : Location.msg list =
-    let mkloc pp dbg suffix =
-      let loc = Debuginfo.to_location dbg in
-      Location.mkloc
-        (fun ppf ->
-          pp ppf;
-          (* Show inlined locations. If dbg has only one item, it will already
-             be shown as [loc]. *)
-          if Debuginfo.Dbg.length (Debuginfo.get_dbg t.dbg) > 1
-          then Format.fprintf ppf " (%a)" Debuginfo.print_compact dbg;
-          if not (String.equal "" component)
-          then Format.fprintf ppf " on a path to %s" component;
-          Format.fprintf ppf "%s" suffix)
-        loc
-    in
-    let pp_kind ppf = print_kind ppf t.kind in
-    match get_alloc_dbginfo t.kind with
-    | None | Some [] | Some [_] -> [mkloc pp_kind t.dbg ""]
-    | Some alloc_dbginfo ->
-      (* One Ialloc is a result of comballoc, print details of each location. *)
-      let suffix =
-        Printf.sprintf " combining %d allocations below"
-          (List.length alloc_dbginfo)
-      in
-      let details =
-        List.map
-          (fun (item : Debuginfo.alloc_dbginfo_item) ->
-            let pp_alloc ppf =
-              Format.fprintf ppf "allocate %d words" item.alloc_words
-            in
-            mkloc pp_alloc item.alloc_dbg "")
-          alloc_dbginfo
-      in
-      mkloc pp_kind t.dbg suffix :: details
 end
 
 module Witnesses : sig
@@ -466,65 +431,120 @@ end = struct
 
   exception Fail of t list * Cmm.property
 
-  let print_witnesses w : Location.msg list =
-    let { Witnesses.nor; exn; div } = Witnesses.simplify w in
-    let f t component =
-      t |> Witnesses.elements
-      |> List.map (Witness.print_error component)
-      |> List.concat
+  let annotation_error ~property_name t =
+    (* print location of the annotation, print function name as part of the
+       message. *)
+    let loc = Annotation.get_loc t.a in
+    let print_annotated_fun ppf () =
+      let scoped_name =
+        t.fun_dbg |> Debuginfo.get_dbg |> Debuginfo.Dbg.to_list
+        |> List.map (fun dbg ->
+               Debuginfo.(Scoped_location.string_of_scopes dbg.dinfo_scopes))
+        |> String.concat ","
+      in
+      Format.fprintf ppf "Annotation check for %s%s failed on function %s (%s)"
+        property_name
+        (if Annotation.is_strict t.a then " strict" else "")
+        scoped_name t.fun_name
     in
-    let l =
+    Location.error_of_printer ~loc print_annotated_fun ()
+
+  let error_messages ~property_name t : Location.error list =
+    let pp_inlined_dbg ppf dbg =
+      (* Show inlined locations, if dbg has more than one item. The first item
+         will be shown at the start of the error message. *)
+      if Debuginfo.Dbg.length (Debuginfo.get_dbg dbg) > 1
+      then Format.fprintf ppf " (%a)" Debuginfo.print_compact dbg
+    in
+    let print_comballoc (w : Witness.t) =
+      match Witness.get_alloc_dbginfo w.kind with
+      | None | Some [] | Some [_] -> "", []
+      | Some alloc_dbginfo ->
+        (* If one Ialloc is a result of combining multiple allocations, print
+           details of each location. Currently, this cannot happen because
+           checkmach is before comballoc. In the future, this may be done in the
+           middle-end. *)
+        let msg =
+          Printf.sprintf " combining %d allocations below"
+            (List.length alloc_dbginfo)
+        in
+        let details =
+          List.map
+            (fun (item : Debuginfo.alloc_dbginfo_item) ->
+              let pp_alloc ppf =
+                Format.fprintf ppf "allocate %d words%a" item.alloc_words
+                  pp_inlined_dbg item.alloc_dbg
+              in
+              let aloc = Debuginfo.to_location item.alloc_dbg in
+              Location.mkloc pp_alloc aloc)
+            alloc_dbginfo
+        in
+        msg, details
+    in
+    let print_witness (w : Witness.t) ~component =
+      (* print location of the witness, print witness description. *)
+      let loc = Debuginfo.to_location w.dbg in
+      let comballoc_msg, sub = print_comballoc w in
+      let component_msg =
+        if String.equal "" component
+        then component
+        else " on a path to " ^ component
+      in
+      let pp ppf () =
+        Format.fprintf ppf "Unexpected %a%a%s%s" Witness.print_kind w.kind
+          pp_inlined_dbg w.dbg component_msg comballoc_msg
+      in
+      Location.error_of_printer ~loc ~sub pp ()
+    in
+    let print_witnesses ws : Location.error list =
+      let { Witnesses.nor; exn; div } = Witnesses.simplify ws in
+      let f ws component =
+        ws |> Witnesses.elements |> List.map (print_witness ~component)
+      in
       List.concat [f div "diverge"; f nor ""; f exn "exceptional return"]
     in
-    let len = List.length l in
-    match !Flambda_backend_flags.checkmach_details_cutoff with
-    | Keep_all -> l
-    | No_details ->
-      (* don't even print the dots *)
-      assert (len = 0);
-      []
-    | At_most cutoff ->
-      let print_with_dots l =
-        let dots = Location.mknoloc (fun ppf -> Format.fprintf ppf "...") in
-        l @ [dots]
-      in
-      if len <= cutoff
-      then l
-      else
-        let details, _ = Misc.Stdlib.List.split_at cutoff l in
-        print_with_dots details
+    let details =
+      match !Flambda_backend_flags.checkmach_details_cutoff with
+      | No_details ->
+        (* do not print witnesses. *)
+        []
+      | Keep_all -> print_witnesses t.witnesses
+      | At_most cutoff ->
+        let all = print_witnesses t.witnesses in
+        if List.compare_length_with all cutoff <= 0
+        then all
+        else
+          let result, _ = Misc.Stdlib.List.split_at cutoff all in
+          result
+    in
+    annotation_error ~property_name t :: details
 
-  let error_message ~property_name t =
-    let { a; fun_name; fun_dbg; witnesses } = t in
-    let sub = print_witnesses witnesses in
-    let loc = Annotation.get_loc a in
-    Location.errorf ~loc ~sub
-      "Annotation check for %s%s failed on function %s (%s)" property_name
-      (if Annotation.is_strict a then " strict" else "")
-      (fun_dbg |> Debuginfo.get_dbg |> Debuginfo.Dbg.to_list
-      |> List.map (fun dbg ->
-             Debuginfo.(Scoped_location.string_of_scopes dbg.dinfo_scopes))
-      |> String.concat ",")
-      fun_name
-
-  let print_one ~property_name t =
-    error_message ~property_name t |> Location.print_report Format.err_formatter
+  let rec print_all msgs =
+    (* Print all errors message in a compilation unit as separate messages to
+       make editor integration easier. *)
+    match msgs with
+    | [] -> assert false
+    | [last_error] ->
+      (* Finally, raise Error with the last function. *)
+      Some last_error
+    | error :: tl ->
+      Location.print_report Format.err_formatter error;
+      print_all tl
 
   let print = function
-    | Fail (reports, property) -> (
-      match reports with
-      | [] -> assert false
-      | last_error :: rev_other_errors ->
-        (* Print all errors in a compilation unit as separate messages to make
-           editor integration easier. *)
-        (* CR-someday gyorsh: adjust Location and editor integration to make it
-           easier to print an error message with nested sub-locations.
-           Location.msg currently allows only one level of nesting, but here we
-           have two levels. *)
-        let property_name = Printcmm.property_to_string property in
-        rev_other_errors |> List.rev |> List.iter (print_one ~property_name);
-        (* Finally, raise Error with the last function. *)
-        Some (error_message ~property_name last_error))
+    | Fail (reports, property) ->
+      let property_name = Printcmm.property_to_string property in
+      (* Sort by function's location. If debuginfo is missing, keep sorted by
+         function name. *)
+      let compare t1 t2 =
+        let c = Debuginfo.compare t1.fun_dbg t2.fun_dbg in
+        if not (Int.equal c 0)
+        then c
+        else String.compare t1.fun_name t2.fun_name
+      in
+      reports |> List.stable_sort compare
+      |> List.concat_map (error_messages ~property_name)
+      |> print_all
     | _ -> None
 end
 

--- a/tests/backend/checkmach/fail12.output
+++ b/tests/backend/checkmach/fail12.output
@@ -1,4 +1,5 @@
 File "fail12.ml", line 5, characters 47-57:
 Error: Annotation check for zero_alloc failed on function Fail12.Inner.bar.(fun) (camlFail12.anon_fn[fail12.ml:5,40--70]_HIDE_STAMP)
+
 File "fail12.ml", line 5, characters 64-69:
-  allocate 24 bytes
+Error: Unexpected allocation of 24 bytes

--- a/tests/backend/checkmach/fail19.output
+++ b/tests/backend/checkmach/fail19.output
@@ -1,22 +1,32 @@
 File "fail19.ml", line 7, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail19.foo (camlFail19.foo_HIDE_STAMP)
+
 File "fail19.ml", line 18, characters 5-26:
-  allocate 48 bytes (fail19.ml:18,5--26;dep19.ml:1,38--52)
+Error: Unexpected allocation of 48 bytes (fail19.ml:18,5--26;dep19.ml:1,38--52)
+
 File "fail19.ml", line 18, characters 5-26:
-  external call to caml_make_array (fail19.ml:18,5--26;dep19.ml:1,38--52)
+Error: Unexpected external call to caml_make_array (fail19.ml:18,5--26;dep19.ml:1,38--52)
+
 File "fail19.ml", line 10, characters 12-17:
-  allocate 24 bytes
+Error: Unexpected allocation of 24 bytes
+
 File "fail19.ml", line 12, characters 10-15:
-  direct call camlFail19.bar_HIDE_STAMP
+Error: Unexpected direct call camlFail19.bar_HIDE_STAMP
+
 File "fail19.ml", line 13, characters 13-16:
-  indirect call
+Error: Unexpected indirect call
+
 File "fail19.ml", line 14, characters 15-44:
-  probe test handler camlFail19.probe_handler_test_HIDE_STAMP
+Error: Unexpected probe test handler camlFail19.probe_handler_test_HIDE_STAMP
+
 File "fail19.ml", line 14, characters 46-54:
-  allocate 24 bytes
+Error: Unexpected allocation of 24 bytes
+
 File "fail19.ml", line 15, characters 11-20:
-  allocate 24 bytes
+Error: Unexpected allocation of 24 bytes
+
 File "fail19.ml", line 17, characters 10-15:
-  allocate 24 bytes
+Error: Unexpected allocation of 24 bytes
+
 File "fail19.ml", line 18, characters 2-27:
-  allocate 24 bytes
+Error: Unexpected allocation of 24 bytes

--- a/tests/backend/checkmach/fail20.output
+++ b/tests/backend/checkmach/fail20.output
@@ -1,6 +1,8 @@
 File "fail20.ml", line 7, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Fail20.foo (camlFail20.foo_HIDE_STAMP)
+
 File "fail20.ml", line 10, characters 13-24:
-  direct call camlFail20.div_36 (fail20.ml:10,13--24;fail20.ml:4,30--41)
+Error: Unexpected direct call camlFail20.div_36 (fail20.ml:10,13--24;fail20.ml:4,30--41)
+
 File "fail20.ml", line 8, characters 16-25:
-  allocate 32 bytes (fail20.ml:8,16--25;fail20.ml:3,18--29) on a path to exceptional return
+Error: Unexpected allocation of 32 bytes (fail20.ml:8,16--25;fail20.ml:3,18--29) on a path to exceptional return

--- a/tests/backend/checkmach/fail21.output
+++ b/tests/backend/checkmach/fail21.output
@@ -1,4 +1,5 @@
 File "fail21.ml", line 10, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail21.test4 (camlFail21.test4_HIDE_STAMP)
+
 File "fail21.ml", line 12, characters 2-9:
-  allocate 24 bytes (fail21.ml:12,2--9;fail21.ml:3,30--35)
+Error: Unexpected allocation of 24 bytes (fail21.ml:12,2--9;fail21.ml:3,30--35)

--- a/tests/backend/checkmach/fail22.output
+++ b/tests/backend/checkmach/fail22.output
@@ -1,4 +1,5 @@
 File "fail22.ml", line 2, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail22.foo (camlFail22.foo_HIDE_STAMP)
+
 File "fail22.ml", line 2, characters 29-34:
-  allocate 24 bytes
+Error: Unexpected allocation of 24 bytes

--- a/tests/backend/checkmach/fail23.output
+++ b/tests/backend/checkmach/fail23.output
@@ -1,4 +1,5 @@
 File "fail23.ml", line 3, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Fail23.test1 (camlFail23.test1_HIDE_STAMP)
+
 File "fail23.ml", line 7, characters 10-40:
-  allocate 32 bytes on a path to exceptional return
+Error: Unexpected allocation of 32 bytes on a path to exceptional return

--- a/tests/backend/checkmach/filter.sh
+++ b/tests/backend/checkmach/filter.sh
@@ -2,5 +2,5 @@
 
 # CR ocaml 5 runtime: remove __ mangling once we're always using the 5 runtime
 sed -r 's/Error: Annotation check for zero_alloc( strict | )failed on function ([^ ]*) \(caml(.*)_[0-9]+(_[0-9]+_code)?\)$/Error: Annotation check for zero_alloc\1failed on function \2 \(caml\3_HIDE_STAMP\)/' | \
-    sed -r 's/  direct (tail)?call caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/  direct \1call caml\2_HIDE_STAMP\4/' | sed -r 's/  probe (test)? handler caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/  probe \1 handler caml\2_HIDE_STAMP\4/' | \
+    sed -r 's/Error: Unexpected direct (tail)?call caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/Error: Unexpected direct \1call caml\2_HIDE_STAMP\4/' | sed -r 's/Error: Unexpected probe (test)? handler caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/Error: Unexpected probe \1 handler caml\2_HIDE_STAMP\4/' | \
     sed 's/__/./'

--- a/tests/backend/checkmach/test_never_returns_normally.output
+++ b/tests/backend/checkmach/test_never_returns_normally.output
@@ -1,9 +1,11 @@
 File "test_never_returns_normally.ml", line 9, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.foo (camlTest_never_returns_normally.foo_HIDE_STAMP)
+
 File "test_never_returns_normally.ml", line 9, characters 25-41:
-  indirect tailcall
+Error: Unexpected indirect tailcall
 
 File "test_never_returns_normally.ml", line 10, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.bar (camlTest_never_returns_normally.bar_HIDE_STAMP)
+
 File "test_never_returns_normally.ml", line 10, characters 27-50:
-  indirect tailcall
+Error: Unexpected indirect tailcall


### PR DESCRIPTION
Do not use "sub-locations". Refactor the way error messages are printed. 

Instead of printing one error message per function with a list of allocation witnesses, print each witness as a separate error message. This makes editor integeration easier, in particular, no adjustments are needed to click on the source location of witnesses.
