### PR TITLE
Improve layout history error message: omit history for signature mismatch

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -249,8 +249,4 @@ Error: Signature mismatch:
          type ('a : void) t = 'a
        The type ('a : value) is not equal to the type ('a0 : void)
        because their layouts are different.
-       The layout of 'a is value, because
-         of the definition of t at line 8, characters 2-16.
-       The layout of 'a is void, because
-         of the definition of t at line 2, characters 2-25.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -94,10 +94,6 @@ Error: Signature mismatch:
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
-       The layout of 'a is value, because
-         of the definition of t at line 2, characters 2-21.
-       The layout of 'a is immediate, because
-         of the definition of t at line 2, characters 2-25.
 |}]
 
 (************************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_beta.ml
@@ -84,10 +84,6 @@ Error: Signature mismatch:
          type ('a : immediate) t = 'a list
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
-       The layout of 'a is value, because
-         of the definition of t at line 2, characters 2-21.
-       The layout of 'a is immediate, because
-         of the definition of t at line 2, characters 2-25.
 |}]
 
 module M1_2''' : S1_2 = struct
@@ -110,10 +106,6 @@ Error: Signature mismatch:
        Their parameters differ:
        The type ('a : value) is not equal to the type ('a0 : immediate)
        because their layouts are different.
-       The layout of 'a is value, because
-         of the definition of t at line 2, characters 2-21.
-       The layout of 'a is immediate, because
-         of the definition of t at line 2, characters 2-25.
 |}]
 
 (************************************************************************)

--- a/ocaml/typing/errortrace.ml
+++ b/ocaml/typing/errortrace.ml
@@ -113,6 +113,7 @@ type ('a, 'variety) elt =
   | Bad_layout_sort : type_expr * Layout.Violation.t -> ('a, _) elt
   | Unequal_var_layouts :
       type_expr * layout * type_expr * layout -> ('a, _) elt
+  | Unequal_var_layouts_with_no_history
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 
@@ -129,6 +130,7 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
   | Bad_layout _ as x -> x
   | Bad_layout_sort _ as x -> x
   | Unequal_var_layouts _ as x -> x
+  | Unequal_var_layouts_with_no_history as x -> x
 
 let map f t = List.map (map_elt f) t
 

--- a/ocaml/typing/errortrace.mli
+++ b/ocaml/typing/errortrace.mli
@@ -98,6 +98,7 @@ type ('a, 'variety) elt =
   | Bad_layout_sort : type_expr * Layout.Violation.t -> ('a, _) elt
   | Unequal_var_layouts :
       type_expr * layout * type_expr * layout -> ('a, _) elt
+  | Unequal_var_layouts_with_no_history
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -2609,6 +2609,8 @@ let explanation (type variety) intro prev env
       in
       Some (dprintf "@ because their layouts are different.@ @[<v>%a@;%a@]"
               (fmt_history t1) l1 (fmt_history t2) l2)
+  | Errortrace.Unequal_var_layouts_with_no_history ->
+      Some (dprintf "@ because their layouts are different.")
 
 let mismatch intro env trace =
   Errortrace.explain trace (fun ~prev h -> explanation intro prev env h)
@@ -2665,7 +2667,8 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
       tr
   in
   let layout_error = match Misc.last tr with
-    | Some (Bad_layout _ | Bad_layout_sort _ | Unequal_var_layouts _) ->
+    | Some (Bad_layout _ | Bad_layout_sort _ | Unequal_var_layouts _
+           | Unequal_var_layouts_with_no_history) ->
         true
     | Some (Diff _ | Escape _ | Variant _ | Obj _ | Incompatible_fields _
            | Rec_occur _)


### PR DESCRIPTION
This PR removes the layout history part for signature mismatch errors like this:

```diff
module type S1 = sig type ('a : void) t = 'a end
module type S2 = S1
Lines 7-9, characters 16-3:
7 | ................struct
8 |   type 'a t = 'a
9 | end
Error: Signature mismatch:
       Modules do not match: sig type 'a t = 'a end is not included in S2
       Type declarations do not match:
         type 'a t = 'a
       is not included in
         type ('a : void) t = 'a
       The type ('a : value) is not equal to the type ('a0 : void)
       because their layouts are different.
-      The layout of 'a is value, because
-        of the definition of t at line 8, characters 2-16.
-      The layout of 'a is void, because
-        of the definition of t at line 2, characters 2-25.
```

Review: @goldfirere 