### PR TITLE
Reclassify 'CR ocaml 5 runtime' comments

### DIFF
--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -118,7 +118,7 @@ let run_mdflx_file filename : Outcome.t =
     Error
 
 let _ =
-  (* CR ocaml 5 runtime: remove this once we are on the 5 runtime *)
+  (* CR ocaml 5 all-runtime5: remove this once we are on the 5 runtime *)
   Symbol0.force_runtime4_symbols ();
   if not Config.stack_allocation
   then (

--- a/ocaml/otherlibs/str/str.ml
+++ b/ocaml/otherlibs/str/str.ml
@@ -610,7 +610,7 @@ external re_search_backward: regexp -> string -> int -> int array
 module Domain = struct
   module DLS = struct
 
-    (* CR ocaml 5 runtime: Remove this proxy and use the real Domain.DLS *)
+    (* CR ocaml 5 domains: Remove this proxy and use the real Domain.DLS *)
     let[@inline always] new_key f = ref (f ())
     let[@inline always] set k s = k := s
     let[@inline always] get k = !k

--- a/ocaml/otherlibs/systhreads4/st_stubs.c
+++ b/ocaml/otherlibs/systhreads4/st_stubs.c
@@ -13,10 +13,6 @@
 /*                                                                        */
 /**************************************************************************/
 
-// CR ocaml 5 runtime: We will need to pull in changes from the same file in
-// [tip-5] tag in ocaml-jst. We're considering this file to be part of the
-// runtime.
-
 #define CAML_INTERNALS
 
 #define CAML_NAME_SPACE

--- a/ocaml/otherlibs/unix/signals.c
+++ b/ocaml/otherlibs/unix/signals.c
@@ -13,9 +13,10 @@
 /*                                                                        */
 /**************************************************************************/
 
-/* CR ocaml 5 runtime: This file is the 4.x version together with
+/* CR ocaml 5 domains: This file is the 4.x version together with
    adjustments to the names of exported functions ("unix_" -> "caml_unix").
-   (mshinwell/xclerc)
+   (mshinwell/xclerc).
+   For multi-domain support we'll need to revisit this.
 */
 
 #define CAML_INTERNALS

--- a/ocaml/runtime/caml/stack.h
+++ b/ocaml/runtime/caml/stack.h
@@ -59,7 +59,7 @@
 #ifdef TARGET_arm64
 /* Size of the gc_regs structure, in words.
    See arm64.S and arm64/proc.ml for the indices */
-/* CR ocaml 5 runtime (mshinwell): this has not been updated for SIMD */
+/* CR-someday mshinwell: update for SIMD */
 #define Wosize_gc_regs (2 + 24 /* int regs */ + 24 /* float regs */)
 #define Saved_return_address(sp) *((intnat *)((sp) - 8))
 #define Pop_frame_pointer(sp) sp += sizeof(value)

--- a/ocaml/runtime/dynlink.c
+++ b/ocaml/runtime/dynlink.c
@@ -236,7 +236,7 @@ void caml_free_shared_libs(void)
 #define Handle_val(v) (*((void **) (v)))
 
 /* The mode argument is here for compatibility with runtime4. */
-/* CR ocaml 5 runtime: Remove [mode] when all-runtime5. */
+/* CR ocaml 5 all-runtime5: Remove [mode] when all-runtime5. */
 CAMLprim value caml_dynlink_open_lib(value mode, value filename)
 {
   void * handle;

--- a/ocaml/runtime/extern.c
+++ b/ocaml/runtime/extern.c
@@ -1380,7 +1380,7 @@ enum reachable_words_node_state {
    * root that we reached it from */
 };
 
-/* CR ocaml 5 runtime (mshinwell): think about what to do here */
+/* CR ocaml 5 domains (mshinwell): think about what to do here */
 /* Not multicore-safe (the [volatile] just lets us use this with the [Field] macro) */
 static void add_to_long_value(volatile value *v, intnat x) {
   *v = Val_long(Long_val(*v) + x);

--- a/ocaml/runtime4/caml/camlatomic.h
+++ b/ocaml/runtime4/caml/camlatomic.h
@@ -43,7 +43,7 @@ using std::memory_order_seq_cst;
 #include <stdatomic.h>
 #define ATOMIC_UINTNAT_INIT(x) (x)
 
-// CR ocaml 5 runtime: provide these typedefs (requires C11)
+// CR ocaml 5 domains: provide these typedefs (requires C11)
 // typedef _Atomic uintnat atomic_uintnat;
 // typedef _Atomic intnat atomic_intnat;
 

--- a/ocaml/stdlib/domain.ml
+++ b/ocaml/stdlib/domain.ml
@@ -21,8 +21,10 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
-(* CR ocaml 5 runtime: domain-local-storage assumes single-domain,
-   i.e. calling split will never be necessary. *)
+(* CR ocaml 5 domains: domain-local-storage assumes single-domain,
+   i.e. calling split will never be necessary.
+   For multi-domain support we'll need the upstream 5.x implementation.
+*)
 
 module DLS = struct
 
@@ -107,7 +109,7 @@ let do_at_exit () =
 
 let _ = Stdlib.do_domain_local_at_exit := do_at_exit
 
-(* CR ocaml 5 runtime: domains not supported on 4.x
+(* CR ocaml 5 domains: use this code
 
 module Raw = struct
   (* Low-level primitives provided by the runtime *)

--- a/ocaml/stdlib/domain.mli
+++ b/ocaml/stdlib/domain.mli
@@ -17,7 +17,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* CR ocaml 5 runtime: domains not supported on 4.x
+(* CR ocaml 5 domains: domains not supported on 4.x
 
 [@@@alert unstable
     "The Domain interface may change in incompatible ways in the future."

--- a/ocaml/stdlib/gc.ml
+++ b/ocaml/stdlib/gc.ml
@@ -67,9 +67,9 @@ external full_major : unit -> unit = "caml_gc_full_major"
 external compact : unit -> unit = "caml_gc_compaction"
 external get_minor_free : unit -> int = "caml_get_minor_free"
 
-(* CR ocaml 5 runtime: These functions are no-ops upstream. We should make them
-   no-ops internally when we delete the corresponding C functions from the
-   runtime -- they're already marked as deprecated in the mli.
+(* CR ocaml 5 all-runtime5: These functions are no-ops upstream. We should
+   make them no-ops internally when we delete the corresponding C functions
+   from the runtime -- they're already marked as deprecated in the mli.
 *)
 
 external eventlog_pause : unit -> unit = "caml_eventlog_pause"

--- a/ocaml/stdlib/gc.mli
+++ b/ocaml/stdlib/gc.mli
@@ -100,7 +100,7 @@ type stat =
         value will always be [0].
 
         @since 3.12 *)
-    (* CR ocaml 5 runtime: Update the above comment to what it is upstream:
+    (* CR ocaml 5 all-runtime5: Update the above comment to what it is upstream:
 
        This metrics is currently not available in OCaml 5: the field value is
        always [0].

--- a/ocaml/stdlib/mutex.mli
+++ b/ocaml/stdlib/mutex.mli
@@ -70,4 +70,5 @@ val protect : t -> (unit -> 'a) -> 'a
 
     @since 5.1 *)
 (* CR ocaml 5 runtime (mshinwell): looks like [protect] needs to use
-   Sys.with_async_exns? *)
+   Sys.with_async_exns?
+   (PR2007 fixes this) *)

--- a/ocaml/stdlib/stdlib.ml
+++ b/ocaml/stdlib/stdlib.ml
@@ -608,7 +608,7 @@ module Complex        = Complex
 module Condition      = Condition
 module Digest         = Digest
 module Domain         = Domain
-(* CR ocaml 5 runtime:
+(* CR ocaml 5 effects:
    BACKPORT
 module Effect         = Effect
 *)

--- a/ocaml/stdlib/stdlib.mli
+++ b/ocaml/stdlib/stdlib.mli
@@ -1410,7 +1410,7 @@ module Domain         = Domain
 [@@alert unstable
     "The Domain interface may change in incompatible ways in the future."
 ]
-(* CR ocaml 5 runtime:
+(* CR ocaml 5 effects:
 BACKPORT
 module Effect         = Effect
 [@@alert "-unstable"]

--- a/ocaml/testsuite/tests/misc/pr7168.ml
+++ b/ocaml/testsuite/tests/misc/pr7168.ml
@@ -76,7 +76,7 @@ let _ =
    * to simplify this test along the same
    * lines as upstream, as stack overflow
    * detection is always supported in
-* ocaml 5. *)
+  * ocaml 5. *)
   if (Gc.get ()).Gc.stack_limit = 0 then begin
     (* We are in native code. Skip the test because some platforms cannot
        reliably detect stack overflow. *)

--- a/ocaml/testsuite/tests/statmemprof/thread_exit_in_callback.ml
+++ b/ocaml/testsuite/tests/statmemprof/thread_exit_in_callback.ml
@@ -6,7 +6,7 @@ include systhreads
 *** native
 *)
 
-(* CR ocaml 5 runtime: Once statmemprof is ported, remove "runtime4" stanzas
+(* CR ocaml 5 statmemprof: Once statmemprof is ported, remove "runtime4" stanzas
    for the tests/statmemprof/ tests. *)
 
 let _ =

--- a/ocaml/utils/symbol.ml
+++ b/ocaml/utils/symbol.ml
@@ -47,7 +47,7 @@ end)
 
 let caml_symbol_prefix = "caml"
 
-(* CR ocaml 5 runtime: Remove this_is_ocamlc and force_runtime4_symbols once
+(* CR ocaml 5 all-runtime5: Remove this_is_ocamlc and force_runtime4_symbols once
    fully on runtime5 *)
 let this_is_ocamlc = ref false
 let force_runtime4_symbols = ref false

--- a/tests/backend/checkmach/filter.sh
+++ b/tests/backend/checkmach/filter.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# CR ocaml 5 runtime: remove __ mangling once we're always using the 5 runtime
+# CR ocaml 5 all-runtime5: remove __ mangling once we're always using the 5 runtime
 sed -r 's/Error: Annotation check for zero_alloc( strict | )failed on function ([^ ]*) \(caml(.*)_[0-9]+(_[0-9]+_code)?\)$/Error: Annotation check for zero_alloc\1failed on function \2 \(caml\3_HIDE_STAMP\)/' | \
     sed -r 's/  direct (tail)?call caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/  direct \1call caml\2_HIDE_STAMP\4/' | sed -r 's/  probe (test)? handler caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/  probe \1 handler caml\2_HIDE_STAMP\4/' | \
     sed 's/__/./'


### PR DESCRIPTION
The remaining `CR ocaml 5 runtime` comments should be addressed soon.

The others have been reclassified as follows:
```
CR ocaml 5 all-runtime5:
CR ocaml 5 domains:
CR ocaml 5 effects:
CR ocaml 5 merge:
CR ocaml 5 runtime:
CR ocaml 5 statmemprof:
```