### PR TITLE
Wider scope of `in_minor_collection`

### DIFF
--- a/ocaml/otherlibs/systhreads/st_stubs.c
+++ b/ocaml/otherlibs/systhreads/st_stubs.c
@@ -192,8 +192,6 @@ static void caml_thread_scan_roots(
 
 static void save_runtime_state(void)
 {
-  if (Caml_state->in_minor_collection)
-    caml_fatal_error("Thread switch from inside minor GC");
   CAMLassert(This_thread != NULL);
   caml_thread_t this_thread = This_thread;
   this_thread->current_stack = Caml_state->current_stack;

--- a/ocaml/otherlibs/systhreads4/st_stubs.c
+++ b/ocaml/otherlibs/systhreads4/st_stubs.c
@@ -251,8 +251,6 @@ static void memprof_ctx_iter(th_ctx_action f, void* data)
 
 CAMLexport void caml_thread_save_runtime_state(void)
 {
-  if (Caml_state->_in_minor_collection)
-    caml_fatal_error("Thread switch from inside minor GC");
 #ifdef NATIVE_CODE
   curr_thread->top_of_stack = Caml_state->_top_of_stack;
   curr_thread->bottom_of_stack = Caml_state->_bottom_of_stack;

--- a/ocaml/runtime/signals.c
+++ b/ocaml/runtime/signals.c
@@ -147,6 +147,8 @@ CAMLexport void caml_enter_blocking_section(void)
 {
   caml_domain_state * domain = Caml_state;
   while (1){
+    if (Caml_state->in_minor_collection)
+      caml_fatal_error("Thread switch from inside minor GC");
     /* Process all pending signals now */
     caml_process_pending_actions();
     caml_enter_blocking_section_hook ();

--- a/ocaml/runtime/signals.c
+++ b/ocaml/runtime/signals.c
@@ -148,7 +148,7 @@ CAMLexport void caml_enter_blocking_section(void)
   caml_domain_state * domain = Caml_state;
   while (1){
     if (Caml_state->in_minor_collection)
-      caml_fatal_error("Thread switch from inside minor GC");
+      caml_fatal_error("caml_enter_blocking_section from inside minor GC");
     /* Process all pending signals now */
     caml_process_pending_actions();
     caml_enter_blocking_section_hook ();

--- a/ocaml/runtime4/signals.c
+++ b/ocaml/runtime4/signals.c
@@ -153,6 +153,8 @@ CAMLno_tsan /* The read of [caml_something_to_do] is not synchronized. */
 CAMLexport void caml_enter_blocking_section(void)
 {
   while (1){
+    if (Caml_state->in_minor_collection)
+      caml_fatal_error("Thread switch from inside minor GC");
     /* Process all pending signals now */
     caml_raise_async_if_exception(caml_process_pending_signals_exn(),
                                   "signal handler");

--- a/ocaml/runtime4/signals.c
+++ b/ocaml/runtime4/signals.c
@@ -154,7 +154,7 @@ CAMLexport void caml_enter_blocking_section(void)
 {
   while (1){
     if (Caml_state->in_minor_collection)
-      caml_fatal_error("Thread switch from inside minor GC");
+      caml_fatal_error("caml_enter_blocking_section from inside minor GC");
     /* Process all pending signals now */
     caml_raise_async_if_exception(caml_process_pending_signals_exn(),
                                   "signal handler");

--- a/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
+++ b/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
@@ -1,11 +1,9 @@
 (* TEST
-   * skip
-   reason = "flaky tests"
    modules = "stub.c"
-   ** hassysthreads
    include systhreads
-   *** not-windows
-   **** native
+   * hassysthreads
+   ** not-windows
+   *** native
 *)
 
 type t

--- a/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
+++ b/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
@@ -15,4 +15,6 @@ let f () =
   ignore (alloc ());
   ()
 
-let () = f ()
+let () =
+  f ();
+  Gc.minor()

--- a/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
+++ b/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
@@ -1,9 +1,11 @@
 (* TEST
+   * skip
+   reason = "flaky tests"
    modules = "stub.c"
-   * hassysthreads
+   ** hassysthreads
    include systhreads
-   ** not-windows
-   *** native
+   *** not-windows
+   **** native
 *)
 
 type t

--- a/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
+++ b/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
@@ -6,9 +6,7 @@
 
 type t
 external alloc : unit -> t = "caml_test_alloc"
-external init : unit -> unit = "caml_test_init"
 
 let () =
-  init ();
   ignore (alloc());
   Gc.minor()

--- a/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
+++ b/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
@@ -1,20 +1,14 @@
 (* TEST
    modules = "stub.c"
-   include systhreads
-   * hassysthreads
-   ** not-windows
-   *** native
+   * not-windows
+   ** native
 *)
 
 type t
 external alloc : unit -> t = "caml_test_alloc"
 external init : unit -> unit = "caml_test_init"
 
-let f () =
-  init ();
-  ignore (alloc ());
-  ()
-
 let () =
-  f ();
+  init ();
+  ignore (alloc());
   Gc.minor()

--- a/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
+++ b/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.ml
@@ -1,0 +1,18 @@
+(* TEST
+   modules = "stub.c"
+   * hassysthreads
+   include systhreads
+   ** not-windows
+   *** native
+*)
+
+type t
+external alloc : unit -> t = "caml_test_alloc"
+external init : unit -> unit = "caml_test_init"
+
+let f () =
+  init ();
+  ignore (alloc ());
+  ()
+
+let () = f ()

--- a/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.run
+++ b/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.run
@@ -1,4 +1,4 @@
 #!/bin/sh
 ulimit -c 0
-(${program} > ${output}) 2>&1 | grep -q 'Thread switch from inside minor GC'
+(${program} > ${output}) 2>&1 | grep -q 'from inside minor GC'
 exit $?

--- a/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.run
+++ b/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.run
@@ -1,4 +1,4 @@
 #!/bin/sh
-
+ulimit -c 0
 (${program} > ${output}) 2>&1 | grep -q 'Thread switch from inside minor GC'
 exit $?

--- a/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.run
+++ b/ocaml/testsuite/tests/regression/pr2098/in_minor_collection.run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+(${program} > ${output}) 2>&1 | grep -q 'Thread switch from inside minor GC'
+exit $?

--- a/ocaml/testsuite/tests/regression/pr2098/stub.c
+++ b/ocaml/testsuite/tests/regression/pr2098/stub.c
@@ -1,7 +1,6 @@
-#include <caml/mlvalues.h>
+#define CAML_INTERNALS
+
 #include <caml/custom.h>
-#include <caml/alloc.h>
-#include <caml/signals.h>
 
 static void caml_test_finalize(value v)
 {
@@ -9,13 +8,26 @@ static void caml_test_finalize(value v)
     caml_fatal_error("Thread switch from inside minor GC");
 }
 
+static void caml_test_serialize(value v,
+                                uintnat * wsize_32,
+                                uintnat * wsize_64)
+{
+  *wsize_32 = 0;
+  *wsize_64 = 0;
+}
+
+uintnat caml_test_deserialize(void * dst)
+{
+  return 0;
+}
+
 static struct custom_operations caml_test_ops = {
   "_test",
   caml_test_finalize,
   custom_compare_default,
   custom_hash_default,
-  custom_serialize_default,
-  custom_deserialize_default,
+  caml_test_serialize,
+  caml_test_deserialize,
   custom_compare_ext_default,
   custom_fixed_length_default
 };

--- a/ocaml/testsuite/tests/regression/pr2098/stub.c
+++ b/ocaml/testsuite/tests/regression/pr2098/stub.c
@@ -4,21 +4,8 @@
 
 static void caml_test_finalize(value v)
 {
-  if (Caml_state -> in_minor_collection)
+  if (Caml_state -> _in_minor_collection)
     caml_fatal_error("Thread switch from inside minor GC");
-}
-
-static void caml_test_serialize(value v,
-                                uintnat * wsize_32,
-                                uintnat * wsize_64)
-{
-  *wsize_32 = 0;
-  *wsize_64 = 0;
-}
-
-uintnat caml_test_deserialize(void * dst)
-{
-  return 0;
 }
 
 static struct custom_operations caml_test_ops = {
@@ -26,8 +13,8 @@ static struct custom_operations caml_test_ops = {
   caml_test_finalize,
   custom_compare_default,
   custom_hash_default,
-  caml_test_serialize,
-  caml_test_deserialize,
+  custom_serialize_default,
+  custom_deserialize_default,
   custom_compare_ext_default,
   custom_fixed_length_default
 };
@@ -35,10 +22,4 @@ static struct custom_operations caml_test_ops = {
 value caml_test_alloc(value unit)
 {
   return caml_alloc_custom(&caml_test_ops, 0, 0, 1);
-}
-
-CAMLprim value caml_test_init(value unit)
-{
-  caml_register_custom_operations(&caml_test_ops);
-  return Val_unit;
 }

--- a/ocaml/testsuite/tests/regression/pr2098/stub.c
+++ b/ocaml/testsuite/tests/regression/pr2098/stub.c
@@ -5,7 +5,8 @@
 
 static void caml_test_finalize(value v)
 {
-  caml_enter_blocking_section();
+  if (Caml_state -> in_minor_collection)
+    caml_fatal_error("Thread switch from inside minor GC");
 }
 
 static struct custom_operations caml_test_ops = {

--- a/ocaml/testsuite/tests/regression/pr2098/stub.c
+++ b/ocaml/testsuite/tests/regression/pr2098/stub.c
@@ -1,9 +1,10 @@
 #include <caml/custom.h>
+#include <caml/signals.h>
 
 static void caml_test_finalize(value v)
 {
-  if (Caml_state_field(in_minor_collection))
-    caml_fatal_error("Thread switch from inside minor GC");
+  caml_enter_blocking_section();
+  caml_leave_blocking_section();
 }
 
 static struct custom_operations caml_test_ops = {

--- a/ocaml/testsuite/tests/regression/pr2098/stub.c
+++ b/ocaml/testsuite/tests/regression/pr2098/stub.c
@@ -1,10 +1,8 @@
-#define CAML_INTERNALS
-
 #include <caml/custom.h>
 
 static void caml_test_finalize(value v)
 {
-  if (Caml_state -> _in_minor_collection)
+  if (Caml_state_field(in_minor_collection))
     caml_fatal_error("Thread switch from inside minor GC");
 }
 

--- a/ocaml/testsuite/tests/regression/pr2098/stub.c
+++ b/ocaml/testsuite/tests/regression/pr2098/stub.c
@@ -1,0 +1,31 @@
+#include <caml/mlvalues.h>
+#include <caml/custom.h>
+#include <caml/alloc.h>
+#include <caml/signals.h>
+
+static void caml_test_finalize(value v)
+{
+  caml_enter_blocking_section();
+}
+
+static struct custom_operations caml_test_ops = {
+  "_test",
+  caml_test_finalize,
+  custom_compare_default,
+  custom_hash_default,
+  custom_serialize_default,
+  custom_deserialize_default,
+  custom_compare_ext_default,
+  custom_fixed_length_default
+};
+
+value caml_test_alloc(value unit)
+{
+  return caml_alloc_custom(&caml_test_ops, 0, 0, 1);
+}
+
+CAMLprim value caml_test_init(value unit)
+{
+  caml_register_custom_operations(&caml_test_ops);
+  return Val_unit;
+}


### PR DESCRIPTION
This fixes the interaction between #2068 and #2075 by increasing the scope of `in_minor_collection`, so now it covers a wider range, including the custom block finalizer.

Reqeust review from @stedolan 