### PR TITLE
Propagate never-returning functions, except when annotated with [@opaque]

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1632,6 +1632,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot decl
         (Poll_attribute.from_lambda (Function_decl.poll_attribute decl))
       ~check:(Check_attribute.from_lambda (Function_decl.check_attribute decl))
       ~is_a_functor:(Function_decl.is_a_functor decl)
+      ~is_opaque:(Function_decl.is_opaque decl)
       ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)
       ~dbg ~is_tupled
@@ -1763,6 +1764,7 @@ let close_functions acc external_env ~current_region function_declarations =
             ~stub:(Function_decl.stub decl) ~inline:Never_inline ~check
             ~poll_attribute
             ~is_a_functor:(Function_decl.is_a_functor decl)
+            ~is_opaque:(Function_decl.is_opaque decl)
             ~recursive:(Function_decl.recursive decl)
             ~newer_version_of:None ~cost_metrics
             ~inlining_arguments:(Inlining_arguments.create ~round:0)
@@ -2091,6 +2093,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
         check = Default_check;
         loop = Default_loop;
         is_a_functor = false;
+        is_opaque = false;
         stub = true;
         poll = Default_poll;
         tmc_candidate = false

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -786,6 +786,8 @@ module Function_decls = struct
 
     let is_a_functor t = t.attr.is_a_functor
 
+    let is_opaque t = t.attr.is_opaque
+
     let check_attribute t = t.attr.check
 
     let stub t = t.attr.stub

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -369,6 +369,8 @@ module Function_decls : sig
 
     val is_a_functor : t -> bool
 
+    val is_opaque : t -> bool
+
     val check_attribute : t -> Lambda.check_attribute
 
     val stub : t -> bool

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -905,7 +905,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
             ~contains_no_escaping_local_allocs:false ~stub:false ~inline
             ~check:Default_check
               (* CR gyorsh: should [check] be set properly? *)
-            ~is_a_functor:false ~recursive
+            ~is_a_functor:false ~is_opaque:false ~recursive
             ~cost_metrics (* CR poechsel: grab inlining arguments from fexpr. *)
             ~inlining_arguments:(Inlining_arguments.create ~round:0)
             ~poll_attribute:Default ~dbg:Debuginfo.none ~is_tupled

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -627,8 +627,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
             (Code_metadata.contains_no_escaping_local_allocs
                callee's_code_metadata)
           ~stub:true ~inline:Default_inline ~poll_attribute:Default
-          ~check:Check_attribute.Default_check ~is_a_functor:false ~recursive
-          ~cost_metrics:cost_metrics_of_body
+          ~check:Check_attribute.Default_check ~is_a_functor:false
+          ~is_opaque:false ~recursive ~cost_metrics:cost_metrics_of_body
           ~inlining_arguments:(DE.inlining_arguments (DA.denv dacc))
           ~dbg ~is_tupled:false
           ~is_my_closure_used:

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -32,6 +32,7 @@ type t =
     check : Check_attribute.t;
     poll_attribute : Poll_attribute.t;
     is_a_functor : bool;
+    is_opaque : bool;
     recursive : Recursive.t;
     cost_metrics : Cost_metrics.t;
     inlining_arguments : Inlining_arguments.t;
@@ -80,6 +81,8 @@ module Code_metadata_accessors (X : Metadata_view_type) = struct
   let poll_attribute t = (metadata t).poll_attribute
 
   let is_a_functor t = (metadata t).is_a_functor
+
+  let is_opaque t = (metadata t).is_opaque
 
   let recursive t = (metadata t).recursive
 
@@ -138,6 +141,7 @@ type 'a create_type =
   check:Check_attribute.t ->
   poll_attribute:Poll_attribute.t ->
   is_a_functor:bool ->
+  is_opaque:bool ->
   recursive:Recursive.t ->
   cost_metrics:Cost_metrics.t ->
   inlining_arguments:Inlining_arguments.t ->
@@ -153,7 +157,7 @@ type 'a create_type =
 let createk k code_id ~newer_version_of ~params_arity ~param_modes
     ~first_complex_local_param ~result_arity ~result_types ~result_mode
     ~contains_no_escaping_local_allocs ~stub ~(inline : Inline_attribute.t)
-    ~check ~poll_attribute ~is_a_functor ~recursive ~cost_metrics
+    ~check ~poll_attribute ~is_a_functor ~is_opaque ~recursive ~cost_metrics
     ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used ~inlining_decision
     ~absolute_history ~relative_history ~loopify =
   (match stub, inline with
@@ -194,6 +198,7 @@ let createk k code_id ~newer_version_of ~params_arity ~param_modes
       check;
       poll_attribute;
       is_a_functor;
+      is_opaque;
       recursive;
       cost_metrics;
       inlining_arguments;
@@ -234,7 +239,7 @@ let [@ocamlformat "disable"] print_inlining_paths ppf
 
 let [@ocamlformat "disable"] print ppf
        { code_id = _; newer_version_of; stub; inline; check; poll_attribute;
-         is_a_functor; params_arity; param_modes;
+         is_a_functor; is_opaque; params_arity; param_modes;
          first_complex_local_param; result_arity;
          result_types; result_mode; contains_no_escaping_local_allocs;
          recursive; cost_metrics; inlining_arguments;
@@ -248,6 +253,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>%t(%a)%t@]@ \
       @[<hov 1>%t(poll_attribute@ %a)%t@]@ \
       @[<hov 1>%t(is_a_functor@ %b)%t@]@ \
+      @[<hov 1>%t(is_opaque@ %b)%t@]@ \
       @[<hov 1>%t(params_arity@ %t%a%t)%t@]@ \
       @[<hov 1>%t(param_modes@ %t(%a)%t)%t@]@ \
       @[<hov 1>(first_complex_local_param@ %d)@]@ \
@@ -287,6 +293,9 @@ let [@ocamlformat "disable"] print ppf
     Flambda_colours.pop
     (if not is_a_functor then Flambda_colours.elide else C.none)
     is_a_functor
+    Flambda_colours.pop
+    (if not is_opaque then Flambda_colours.elide else C.none)
+    is_opaque
     Flambda_colours.pop
     (if Flambda_arity.is_one_param_of_kind_value params_arity
     then Flambda_colours.elide
@@ -360,6 +369,7 @@ let free_names
       check = _;
       poll_attribute = _;
       is_a_functor = _;
+      is_opaque = _;
       recursive = _;
       cost_metrics = _;
       inlining_arguments = _;
@@ -402,6 +412,7 @@ let apply_renaming
        check = _;
        poll_attribute = _;
        is_a_functor = _;
+       is_opaque = _;
        recursive = _;
        cost_metrics = _;
        inlining_arguments = _;
@@ -455,6 +466,7 @@ let ids_for_export
       check = _;
       poll_attribute = _;
       is_a_functor = _;
+      is_opaque = _;
       recursive = _;
       cost_metrics = _;
       inlining_arguments = _;
@@ -494,6 +506,7 @@ let approx_equal
       check = check1;
       poll_attribute = poll_attribute1;
       is_a_functor = is_a_functor1;
+      is_opaque = is_opaque1;
       recursive = recursive1;
       cost_metrics = cost_metrics1;
       inlining_arguments = inlining_arguments1;
@@ -519,6 +532,7 @@ let approx_equal
       check = check2;
       poll_attribute = poll_attribute2;
       is_a_functor = is_a_functor2;
+      is_opaque = is_opaque2;
       recursive = recursive2;
       cost_metrics = cost_metrics2;
       inlining_arguments = inlining_arguments2;
@@ -544,6 +558,7 @@ let approx_equal
   && Check_attribute.equal check1 check2
   && Poll_attribute.equal poll_attribute1 poll_attribute2
   && Bool.equal is_a_functor1 is_a_functor2
+  && Bool.equal is_opaque1 is_opaque2
   && Recursive.equal recursive1 recursive2
   && Cost_metrics.equal cost_metrics1 cost_metrics2
   && Inlining_arguments.equal inlining_arguments1 inlining_arguments2

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -56,6 +56,8 @@ module type Code_metadata_accessors_result_type = sig
 
   val is_a_functor : 'a t -> bool
 
+  val is_opaque : 'a t -> bool
+
   val recursive : 'a t -> Recursive.t
 
   val cost_metrics : 'a t -> Cost_metrics.t
@@ -99,6 +101,7 @@ type 'a create_type =
   check:Check_attribute.t ->
   poll_attribute:Poll_attribute.t ->
   is_a_functor:bool ->
+  is_opaque:bool ->
   recursive:Recursive.t ->
   cost_metrics:Cost_metrics.t ->
   inlining_arguments:Inlining_arguments.t ->

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -566,6 +566,7 @@ type function_attribute = {
   poll: poll_attribute;
   loop: loop_attribute;
   is_a_functor: bool;
+  is_opaque: bool;
   stub: bool;
   tmc_candidate: bool;
 }
@@ -755,6 +756,7 @@ let default_function_attribute = {
   poll = Default_poll;
   loop = Default_loop;
   is_a_functor = false;
+  is_opaque = false;
   stub = false;
   tmc_candidate = false;
 }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -462,6 +462,7 @@ type function_attribute = {
   poll: poll_attribute;
   loop: loop_attribute;
   is_a_functor: bool;
+  is_opaque: bool;
   stub: bool;
   tmc_candidate: bool;
 }

--- a/ocaml/lambda/translattribute.ml
+++ b/ocaml/lambda/translattribute.ml
@@ -50,6 +50,10 @@ let is_poll_attribute =
 let is_loop_attribute =
   [ ["loop"; "ocaml.loop"], true ]
 
+let is_opaque_attribute =
+  [ ["opaque"; "ocaml.opaque"], true ]
+
+
 let find_attribute p attributes =
   let inline_attribute =
     Builtin_attributes.filter_attributes
@@ -297,6 +301,17 @@ let parse_loop_attribute attr =
         ]
         payload
 
+let parse_opaque_attribute attr =
+  match attr with
+  | None -> false
+  | Some {Parsetree.attr_name = {txt; loc}; attr_payload = payload} ->
+      parse_id_payload txt loc
+        ~default:false
+        ~empty:true
+        []
+        payload
+
+
 let get_inline_attribute l =
   let attr = find_attribute is_inline_attribute l in
   parse_inline_attribute attr
@@ -308,6 +323,11 @@ let get_specialise_attribute l =
 let get_local_attribute l =
   let attr = find_attribute is_local_attribute l in
   parse_local_attribute attr
+
+let get_opaque_attribute l =
+  let attr = find_attribute is_opaque_attribute l in
+  parse_opaque_attribute attr
+
 
 let get_property_attribute l p =
   let attr = find_attribute (is_property_attribute p) l in
@@ -359,6 +379,25 @@ let check_poll_local loc attr =
           "[@poll error] is incompatible with local function optimization")
   | _ ->
       ()
+
+let check_opaque_inline loc attr =
+  match attr.is_opaque, attr.inline with
+  | true, (Always_inline | Available_inline | Unroll _) ->
+      Location.prerr_warning loc
+        (Warnings.Inlining_impossible
+           "[@opaque] is incompatible with inlining")
+  | _ ->
+      ()
+
+let check_opaque_local loc attr =
+  match attr.is_opaque, attr.local with
+  | true, Always_local ->
+      Location.prerr_warning loc
+        (Warnings.Inlining_impossible
+           "[@opaque] is incompatible with local function optimization")
+  | _ ->
+      ()
+
 
 let lfunction_with_attr ~attr
   { kind; params; return; body; attr=_; loc; mode; ret_mode; region } =
@@ -525,6 +564,24 @@ let add_poll_attribute expr loc attributes =
     end
   | expr -> expr
 
+let add_opaque_attribute expr loc attributes =
+  match expr with
+  | Lfunction({ attr } as funct) ->
+      if not (get_opaque_attribute attributes) then
+        expr
+      else begin
+        if attr.is_opaque then
+          Location.prerr_warning loc
+            (Warnings.Duplicated_attribute "opaque");
+        let attr = { attr with is_opaque = true } in
+        check_opaque_inline loc attr;
+        check_opaque_local loc attr;
+        let attr = { attr with inline = Never_inline; local = Never_local } in
+        lfunction_with_attr ~attr funct
+      end
+  | _ -> expr
+
+
 (* Get the [@inlined] attribute payload (or default if not present). *)
 let get_inlined_attribute e =
   let attr = find_attribute is_inlined_attribute e.exp_attributes in
@@ -584,8 +641,11 @@ let add_function_attributes lam loc attr =
   let lam =
     add_tmc_attribute lam loc attr
   in
+  (* last because poll and opaque overrides inline and local *)
   let lam =
-    (* last because poll overrides inline and local *)
     add_poll_attribute lam loc attr
+  in
+  let lam =
+    add_opaque_attribute lam loc attr
   in
   lam

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -967,6 +967,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           check = Default_check;
           loop = Never_loop;
           is_a_functor = false;
+          is_opaque = false;
           stub = false;
           poll = Default_poll;
           tmc_candidate = false;

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -588,6 +588,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
       poll = Default_poll;
       loop = Never_loop;
       is_a_functor = true;
+      is_opaque = false;
       check = Ignore_assert_all Zero_alloc;
       stub = false;
       tmc_candidate = false;

--- a/ocaml/testsuite/tests/backtrace/pr6920_why_at.ml
+++ b/ocaml/testsuite/tests/backtrace/pr6920_why_at.ml
@@ -5,7 +5,7 @@
    exit_status = "2"
 *)
 
-let why : unit -> unit = fun () -> raise Exit [@@inline never]
+let why : unit -> unit = fun () -> raise Exit [@@inline never][@@opaque]
 let f () =
   why @@ ();
   ignore (3 + 2);

--- a/ocaml/testsuite/tests/backtrace/pr6920_why_at.ml
+++ b/ocaml/testsuite/tests/backtrace/pr6920_why_at.ml
@@ -5,7 +5,7 @@
    exit_status = "2"
 *)
 
-let why : unit -> unit = fun () -> raise Exit [@@inline never][@@opaque]
+let why : unit -> unit = fun () -> raise Exit [@@opaque]
 let f () =
   why @@ ();
   ignore (3 + 2);

--- a/ocaml/testsuite/tests/backtrace/pr6920_why_swallow.ml
+++ b/ocaml/testsuite/tests/backtrace/pr6920_why_swallow.ml
@@ -5,7 +5,7 @@
    exit_status = "2"
 *)
 
-let why : unit -> unit = fun () -> raise Exit [@@inline never][@@opaque]
+let why : unit -> unit = fun () -> raise Exit [@@opaque]
 let f () =
   for i = 1 to 10 do
     why @@ ();

--- a/ocaml/testsuite/tests/backtrace/pr6920_why_swallow.ml
+++ b/ocaml/testsuite/tests/backtrace/pr6920_why_swallow.ml
@@ -5,7 +5,7 @@
    exit_status = "2"
 *)
 
-let why : unit -> unit = fun () -> raise Exit [@@inline never]
+let why : unit -> unit = fun () -> raise Exit [@@inline never][@@opaque]
 let f () =
   for i = 1 to 10 do
     why @@ ();


### PR DESCRIPTION
When a function never returns, this information is propagated and used, even if the function is not inlined. This behaviour can be disabled by an `[@opaque]` attribute on the function, which automatically implies `[@inline never]` and `[@local never]` as well.