### PR TITLE
Fix a couple of build errors

### DIFF
--- a/ocaml/runtime/gc_ctrl.c
+++ b/ocaml/runtime/gc_ctrl.c
@@ -302,7 +302,7 @@ CAMLprim value caml_gc_compaction(value v)
   value exn = gc_major_exn(1);
   ++ Caml_state->stat_forced_major_collections;
   CAML_EV_END(EV_EXPLICIT_GC_COMPACT);
-  return caml_raise_if_exception(exn);
+  return caml_raise_async_if_exception(exn, "");
 }
 
 CAMLprim value caml_gc_stat(value v)

--- a/ocaml/runtime/platform.c
+++ b/ocaml/runtime/platform.c
@@ -34,6 +34,7 @@
 #endif
 
 #include "caml/alloc.h"
+#define CAML_NO_SYNC_CHECK_ERROR
 #include "sync_posix.h"
 
 /* Error reporting */

--- a/ocaml/runtime/platform.c
+++ b/ocaml/runtime/platform.c
@@ -34,7 +34,6 @@
 #endif
 
 #include "caml/alloc.h"
-#define CAML_NO_SYNC_CHECK_ERROR
 #include "sync_posix.h"
 
 /* Error reporting */

--- a/ocaml/runtime/sync_posix.h
+++ b/ocaml/runtime/sync_posix.h
@@ -206,11 +206,7 @@ Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
 
 /* Reporting errors */
 
-/* Silence warnings about the following function when pulled into
-   e.g. platform.c by the flambda-backend custom-condvar fix. */
-#ifndef CAML_NO_SYNC_CHECK_ERROR
-
-static void sync_check_error(int retcode, char * msg)
+Caml_inline void sync_check_error(int retcode, char * msg)
 {
   char * err;
   char buf[1024];
@@ -228,7 +224,5 @@ static void sync_check_error(int retcode, char * msg)
   memcpy (&Byte(str, msglen + 2), err, errlen);
   caml_raise_sys_error(str);
 }
-
-#endif
 
 #endif /* CAML_SYNC_POSIX_H */

--- a/ocaml/runtime/sync_posix.h
+++ b/ocaml/runtime/sync_posix.h
@@ -92,7 +92,7 @@ Caml_inline int sync_mutex_unlock(sync_mutex m)
 
 /* If we're using glibc, use a custom condition variable implementation to
    avoid this bug: https://sourceware.org/bugzilla/show_bug.cgi?id=25847
-   
+
    For now we only have this on linux because it directly uses the linux futex
    syscalls. */
 #if defined(__linux__) && defined(__GNU_LIBRARY__) && defined(__GLIBC__) && defined(__GLIBC_MINOR__)
@@ -206,6 +206,10 @@ Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
 
 /* Reporting errors */
 
+/* Silence warnings about the following function when pulled into
+   e.g. platform.c by the flambda-backend custom-condvar fix. */
+#ifndef CAML_NO_SYNC_CHECK_ERROR
+
 static void sync_check_error(int retcode, char * msg)
 {
   char * err;
@@ -224,5 +228,7 @@ static void sync_check_error(int retcode, char * msg)
   memcpy (&Byte(str, msglen + 2), err, errlen);
   caml_raise_sys_error(str);
 }
+
+#endif
 
 #endif /* CAML_SYNC_POSIX_H */


### PR DESCRIPTION
1. caused by a conflict between the async exns and compactor patches
2. silence a warning about an unused copy of `sync_check_error`