### PR TITLE
Refine type printing heuristics in view of #1962

### DIFF
--- a/ocaml/testsuite/tests/printing-types/multiple_files.ml
+++ b/ocaml/testsuite/tests/printing-types/multiple_files.ml
@@ -1,0 +1,7 @@
+(* See [test_multiple_files.ml]. *)
+
+module B = struct
+  type t = B1 | B2
+end
+
+type _b = B.t = B1 | B2

--- a/ocaml/testsuite/tests/printing-types/test_multiple_files.compilers.reference
+++ b/ocaml/testsuite/tests/printing-types/test_multiple_files.compilers.reference
@@ -1,0 +1,4 @@
+val other_file_b : Multiple_files.B.t
+module A : sig type t = A1 | A2 end
+type _a = A.t = A1 | A2
+val this_file_a : A.t

--- a/ocaml/testsuite/tests/printing-types/test_multiple_files.ml
+++ b/ocaml/testsuite/tests/printing-types/test_multiple_files.ml
@@ -1,0 +1,27 @@
+(* TEST
+
+   readonly_files ="multiple_files.ml"
+   * setup-ocamlopt.opt-build-env
+   ** ocamlopt.opt
+       module = "multiple_files.ml"
+       flags = "-g"
+   *** ocamlopt.opt
+        module = "test_multiple_files.ml"
+        flags = "-short-paths -i"
+   **** check-ocamlopt.opt-output
+*)
+
+(* Ensure that underscore-prefixed type names
+   are avoided by the type printer when
+   a good, underscoreless name is available.
+*)
+
+let other_file_b = Multiple_files.B1
+
+module A = struct
+  type t = A1 | A2
+end
+
+type _a = A.t = A1 | A2
+
+let this_file_a = A1

--- a/ocaml/testsuite/tests/typing-short-paths/errors.ml
+++ b/ocaml/testsuite/tests/typing-short-paths/errors.ml
@@ -86,9 +86,9 @@ Line 1, characters 0-75:
 1 | module rec A : sig type t = B.t -> int end = struct type t = B.t -> int end
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of A.t contains a cycle:
-         B.t -> int contains B.t,
-         B.t = B.t,
-         B.t = B.t -> int,
-         B.t -> int contains B.t,
-         B.t = B.t
+         A.t -> int contains A.t,
+         A.t = A.t,
+         A.t = A.t -> int,
+         A.t -> int contains A.t,
+         A.t = A.t
 |}]

--- a/ocaml/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/ocaml/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -87,7 +87,7 @@ type t1 = A
 module M1 : sig type u = v and v = t1 end
 module N1 : sig type u = v and v = t1 end
 type t1 = B
-module N2 : sig type u = v and v = N1.v end
+module N2 : sig type u = v and v = t1/2 end
 module type PR6566 = sig type t = string end
 module PR6566 : sig type t = int end
 Line 1, characters 26-32:

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -911,7 +911,7 @@ let best_type_path p =
     let get_path () =
       try
         get_best_path (Path.Map.find p' !printing_map) !printing_env
-      with Not_found -> p'
+      with Not_found -> rewrite_double_underscore_paths !printing_env p'
     in
     while !printing_cont <> [] &&
       fst (path_size (get_path ()) !printing_env) > !printing_depth


### PR DESCRIPTION
This refines #1962 to print better paths in some common cases.

#1962 adds a lot more paths to the printing cache. This stresses the type printing heuristics, as we'd still like type printing to produce a good path for many common libraries.

The three refinements:
  * Penalize idents that start with `_` in more circumstances. We were already penalizing them, but inconsistently.
  * Always consider the original path itself as a way of printing a path. (Technically, we rewrite double underscores first so the original path wins many competitions.)
  * Break ties in favor of first-discovered paths rather than most-recently-discovered paths.

Testing: I was able to write a test for the second one (it fails at the base of this PR). The other two changes imply other changes to test but I struggled to write a test specifically for them.

Of the three refinements, I'm least sure about the last one -- it seems to be fairly disruptive -- but handles printing of `Sexp.t` better.